### PR TITLE
Improve loading of defaults.vim

### DIFF
--- a/runtime/defaults.vim
+++ b/runtime/defaults.vim
@@ -1,7 +1,7 @@
 " The default vimrc file.
 "
 " Maintainer:	The Vim Project <https://github.com/vim/vim>
-" Last Change:	2025 Apr 10
+" Last Change:	2025 May 09
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 "
 " This is loaded if no vimrc file was found.
@@ -19,6 +19,13 @@ endif
 if exists('skip_defaults_vim')
   finish
 endif
+
+" We cannot bail out if $VIM_NO_SOURCE_DEFAULTS is set, 
+" because this would cause only defaults.vim being sourced (and finished)
+" but not all depending runtime files
+" if exists("$VIM_NO_SOURCE_DEFAULTS")
+"   finish
+" endif
 
 " Use Vim settings, rather than Vi settings (much better!).
 " This must be first, because it changes other options as a side effect.

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -149,6 +149,13 @@ a slash.  Thus "-R" means recovery and "-/R" readonly.
 			-u NORC		     no		yes	  no
 			--noplugin	     yes	no	  yes
 
+							*--load-defaults*
+--load-defaults	Always load |defaults.vim| runtime file very early.
+
+--no-load-defaults					*--no-load-defaults*
+		Skip loading |defaults.vim|.  Alternatively set the
+		environment variable `$VIM_NO_SOURCE_DEFAULTS`.
+
 --startuptime {fname}					*--startuptime*
 		During startup write timing messages to the file {fname}.
 		This can be used to find out where time is spent while loading
@@ -846,8 +853,12 @@ accordingly.  Vim proceeds in this order:
 							*evim.vim*
      a. If Vim was started as |evim| or |eview| or with the |-y| argument, the
 	script $VIMRUNTIME/evim.vim will be loaded.
+
+     b. If Vim was started using the |--load-defaults| argument |defaults.vim|
+	file will be sourced first (and always, even if a personal runtime
+	file exists).
 							*system-vimrc*
-     b. For Unix, MS-Windows, VMS, Macintosh and Amiga the system vimrc file
+     c. For Unix, MS-Windows, VMS, Macintosh and Amiga the system vimrc file
 	is read for initializations.  The path of this file is shown with the
 	":version" command.  Mostly it's "$VIM/vimrc".  Note that this file is
 	ALWAYS read in 'compatible' mode, since the automatic resetting of
@@ -856,7 +867,7 @@ accordingly.  Vim proceeds in this order:
 
 			*VIMINIT* *.vimrc* *_vimrc* *EXINIT* *.exrc* *_exrc*
 			*$MYVIMRC* *$MYVIMDIR*
-     c. Five places are searched for initializations.  The first that exists
+     d. Five places are searched for initializations.  The first that exists
 	is used, the others are ignored.  The `$MYVIMRC` environment variable is
 	set to the file that was first found, unless `$MYVIMRC` was already set
 	when using VIMINIT.  The `$MYVIMDIR` environment variable is
@@ -893,7 +904,7 @@ accordingly.  Vim proceeds in this order:
 	    options values and has "syntax on" and "filetype on" commands,
 	    which is what most new users will want.  See |defaults.vim|.
 
-     d. If the 'exrc' option is on (which is NOT the default), the current
+     e. If the 'exrc' option is on (which is NOT the default), the current
 	directory is searched for three files.  The first that exists is used,
 	the others are ignored.
 	-  The file ".vimrc" (for Unix, Amiga) (*)
@@ -1077,30 +1088,35 @@ giving the mapping.
 
 Defaults without a .vimrc file ~
 							*defaults.vim* *E1187*
-If Vim is started normally and no user vimrc file is found, the
-$VIMRUNTIME/defaults.vim script is loaded.  This will set 'compatible' off,
-switch on syntax highlighting and a few more things.  See the script for
-details.  NOTE: this is done since Vim 8.0, not in Vim 7.4. (it was added in
-patch 7.4.2111 to be exact).
+If Vim is started normally, the $VIMRUNTIME/defaults.vim script is loaded.
+This will set 'compatible' off, switch on syntax highlighting and a few more
+things.  See the script for details.  NOTE: this is done since Vim 8.0, not in
+Vim 7.4. (it was added in patch 7.4.2111 to be exact).
 
-This should work well for new Vim users.  If you create your own .vimrc, it is
-recommended to add these lines somewhere near the top: >
+This should work well for new Vim users.  If you create your own .vimrc,
+defaults.vim will (by default) not be loaded.  If you want to have the
+defaults.vim always be loaded you can use the |--load-defaults| argument or
+you can explicitly source defaults.vim by adding the following lines at the
+top of your personal vimrc file: >
+
 	unlet! skip_defaults_vim
 	source $VIMRUNTIME/defaults.vim
-Then Vim works like before you had a .vimrc.
-Copying $VIMRUNTIME/vimrc_example.vim to your .vimrc is another way to do
-this. Alternatively, you can copy defaults.vim to your .vimrc and modify it
-(but then you won't get updates when it changes).
+<
+See the defaults.vim file for hints on how to revert each item and see
+|:scriptnames| to verify which runtime files have been loaded.
 
-If you don't like some of the defaults, you can still source defaults.vim and
-revert individual settings.  See the defaults.vim file for hints on how to
-revert each item.
+Note: since patch 9.1.XXXX Vim can be configured to force loading the
+|defaults.vim| runtime file as the very first initialization file using the
+|--load-defaults| option.  This is done, so the effects can be undo in the
+system and/or vimrc runtime file.  To prevent loading the |defaults.vim|
+runtime file, use the |--no-load-defaults| argument (or define the environment
+variable `$VIM_NO_SOURCE_DEFAULTS`).
+
 						*skip_defaults_vim*
 If you use a system-wide vimrc and don't want defaults.vim to change settings,
 set the "skip_defaults_vim" variable.  If this was set and you want to load
 defaults.vim from your .vimrc, first unlet skip_defaults_vim, as in the
 example above.
-
 
 					*xdg-base-dir* *$XDG_CONFIG_HOME*
 XDG Base Directory Specification ~

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -1552,7 +1552,9 @@ $quote	eval.txt	/*$quote*
 --gui-dialog-file	starting.txt	/*--gui-dialog-file*
 --help	starting.txt	/*--help*
 --literal	starting.txt	/*--literal*
+--load-defaults	starting.txt	/*--load-defaults*
 --log	starting.txt	/*--log*
+--no-load-defaults	starting.txt	/*--no-load-defaults*
 --nofork	starting.txt	/*--nofork*
 --noplugin	starting.txt	/*--noplugin*
 --not-a-term	starting.txt	/*--not-a-term*

--- a/runtime/doc/vim.1
+++ b/runtime/doc/vim.1
@@ -427,6 +427,13 @@ This can be used to edit a filename that starts with a '\-'.
 Do not use any personal configuration (vimrc, plugins, etc.).  Useful to see if
 a problem reproduces with a clean Vim setup.
 .TP
+\-\-no-load-defaults
+Do not source defaults.vim.
+.TP
+\-\-load-defaults
+Do source defaults.vim (as the very first runtime file), even if a personal
+runtime file exists.
+.TP
 \-\-cmd {command}
 Like using "\-c", but the command is executed just before
 processing any vimrc file.

--- a/runtime/doc/vim.man
+++ b/runtime/doc/vim.man
@@ -311,6 +311,13 @@ OPTIONS
                    etc.).   Useful to see if a problem reproduces with a clean
                    Vim setup.
 
+       --no-load-defaults
+                   Do not source defaults.vim.
+
+       --load-defaults
+                   Do source defaults.vim (as the very  first  runtime  file),
+                   even if a personal runtime file exists.
+
        --cmd {command}
                    Like using "-c", but the command is  executed  just  before
                    processing  any  vimrc file.  You can use up to 10 of these
@@ -329,13 +336,13 @@ OPTIONS
                    Give a bit of help about the command line arguments and op‐
                    tions.  After this Vim exits.
 
-       --literal   Take file name arguments literally,  do  not  expand  wild‐
-                   cards.   This has no effect on Unix where the shell expands
+       --literal   Take  file  name  arguments  literally, do not expand wild‐
+                   cards.  This has no effect on Unix where the shell  expands
                    wildcards.
 
        --log {filename}
-                   If Vim has been compiled with  eval  and  channel  feature,
-                   start  logging  and write entries to {filename}. This works
+                   If  Vim  has  been  compiled with eval and channel feature,
+                   start logging and write entries to {filename}.  This  works
                    like calling ch_logfile({filename}, 'ao') very early during
                    startup.
 
@@ -345,8 +352,8 @@ OPTIONS
        --noplugin  Skip loading plugins.  Implied by -u NONE.
 
        --not-a-term
-                   Tells Vim that the user knows that the input and/or  output
-                   is  not connected to a terminal.  This will avoid the warn‐
+                   Tells  Vim that the user knows that the input and/or output
+                   is not connected to a terminal.  This will avoid the  warn‐
                    ing and the two second delay that would happen.
 
        --remote    Connect to a Vim server and make it edit the files given in
@@ -354,18 +361,18 @@ OPTIONS
                    is given and the files are edited in the current Vim.
 
        --remote-expr {expr}
-                   Connect to a Vim server, evaluate {expr} in  it  and  print
+                   Connect  to  a  Vim server, evaluate {expr} in it and print
                    the result on stdout.
 
        --remote-send {keys}
                    Connect to a Vim server and send {keys} to it.
 
        --remote-silent
-                   As  --remote,  but  without  the  warning when no server is
+                   As --remote, but without the  warning  when  no  server  is
                    found.
 
        --remote-wait
-                   As --remote, but Vim does not exit  until  the  files  have
+                   As  --remote,  but  Vim  does not exit until the files have
                    been edited.
 
        --remote-wait-silent
@@ -381,26 +388,26 @@ OPTIONS
                    the server to connect to.
 
        --socketid {id}
-                   GTK GUI only: Use the GtkPlug mechanism to run gVim in  an‐
+                   GTK  GUI only: Use the GtkPlug mechanism to run gVim in an‐
                    other window.
 
        --startuptime {file}
                    During startup write timing messages to the file {fname}.
 
-       --ttyfail   When  stdin  or  stdout is not a a terminal (tty) then exit
+       --ttyfail   When stdin or stdout is not a a terminal  (tty)  then  exit
                    right away.
 
        --version   Print version information and exit.
 
        --windowid {id}
-                   Win32 GUI only: Make gVim try to use the window {id}  as  a
+                   Win32  GUI  only: Make gVim try to use the window {id} as a
                    parent, so that it runs inside that window.
 
 ON-LINE HELP
-       Type  ":help"  in Vim to get started.  Type ":help subject" to get help
-       on a specific subject.  For example: ":help ZZ" to  get  help  for  the
-       "ZZ"  command.   Use <Tab> and CTRL-D to complete subjects (":help cmd‐
-       line-completion").  Tags are present to jump from one place to  another
+       Type ":help" in Vim to get started.  Type ":help subject" to  get  help
+       on  a  specific  subject.   For example: ":help ZZ" to get help for the
+       "ZZ" command.  Use <Tab> and CTRL-D to complete subjects  (":help  cmd‐
+       line-completion").   Tags are present to jump from one place to another
        (sort of hypertext links, see ":help").  All documentation files can be
        viewed in this way, for example ":help syntax.txt".
 
@@ -464,17 +471,17 @@ SEE ALSO
 AUTHOR
        Most of Vim was made by Bram Moolenaar, with a lot of help from others.
        See ":help credits" in Vim.
-       Vim is based on Stevie, worked on by: Tim Thompson,  Tony  Andrews  and
+       Vim  is  based  on Stevie, worked on by: Tim Thompson, Tony Andrews and
        G.R. (Fred) Walter.  Although hardly any of the original code remains.
 
 BUGS
        Probably.  See ":help todo" for a list of known problems.
 
-       Note  that a number of things that may be regarded as bugs by some, are
-       in fact caused by a too-faithful reproduction of Vi's  behaviour.   And
-       if  you  think  other things are bugs "because Vi does it differently",
-       you should take a closer look at the vi_diff.txt file  (or  type  :help
-       vi_diff.txt  when  in  Vim).   Also have a look at the 'compatible' and
+       Note that a number of things that may be regarded as bugs by some,  are
+       in  fact  caused by a too-faithful reproduction of Vi's behaviour.  And
+       if you think other things are bugs "because Vi  does  it  differently",
+       you  should  take  a closer look at the vi_diff.txt file (or type :help
+       vi_diff.txt when in Vim).  Also have a look  at  the  'compatible'  and
        'cpoptions' options.
 
                                   2025 Jun 27                           VIM(1)

--- a/src/structs.h
+++ b/src/structs.h
@@ -4701,6 +4701,7 @@ typedef struct
 #ifdef FEAT_DIFF
     int		diff_mode;		// start with 'diff' set
 #endif
+    int		load_defaults;		// [no-]load-defaults
 } mparm_T;
 
 /*


### PR DESCRIPTION
Always since the introduction of defaults.vim is has been controversial how Vim loaded those defaults (because they were not loaded when a custom user vimrc file was present).

This is an attempt to solve this, by always sourcing the defaults.vim file. This is unfortunately not fully backwards compatible, since now new settings may be setup before you source your vimrc file. So if you relied on some settings that have been changed in defaults.vim you will now have to undo those changes in your vimrc, or opt-out explicitly from sourcing the defaults.vim. This is possible by setting the `VIM_NO_SOURCE_DEFAULTS` environment variable, which will keep the current load-order.

I have also slightly changed 2 more options in `defaults.vim`, one removing the 'i' flag from the 'complete' setting as requested in #14853 and another is setting the '!' flag for Windows, so that external commands are run in a terminal and not an ugly cmdline window.

Currently marked as draft, please let me know if you think this is beneficial for Vim or your rather would like to keep the existing behaviour and not change it again. 