### PR TITLE
Add Faust filetype

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -1265,6 +1265,56 @@ export def FTtyp()
   setf typst
 enddef
 
+# Detect Microsoft Developer Studio Project files (Makefile) or Faust DSP
+# files.
+export def FTdsp()
+  if exists("g:filetype_dsp")
+    exe "setf " .. g:filetype_dsp
+    return
+  endif
+
+  # Test the filename
+  if expand('%:t') =~ '^[mM]akefile.*$'
+    setf make
+    return
+  endif
+
+  # Test the file contents
+  for line in getline(1, 200)
+    # Chech for comment style
+    if line =~ '^#.*'
+      setf make
+      return
+    endif
+
+    # Check for common lines
+    if line =~ '^.*Microsoft Developer Studio Project File.*$'
+      setf make
+      return
+    endif
+
+    if line =~ '^!MESSAGE This is not a valid makefile\..+$'
+      setf make
+      return
+    endif
+
+    # Check for keywords
+    if line =~ '^!(IF,ELSEIF,ENDIF).*$'
+      setf make
+      return
+    endif
+
+    # Check for common assignments
+    if line =~ '^SOURCE=.*$'
+      setf make
+      return
+    endif
+  endfor
+
+  # Otherwise, assume we have a Faust file
+  setf faust
+enddef
+
 # Set the filetype of a *.v file to Verilog, V or Cog based on the first 200
 # lines.
 export def FTv()

--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -149,6 +149,7 @@ variables can be used to overrule the filetype used for certain extensions:
 	*.csh		g:filetype_csh		|ft-csh-syntax|
 	*.dat		g:filetype_dat
 	*.def		g:filetype_def
+	*.dsp		g:filetype_dsp
 	*.f		g:filetype_f		|ft-forth-syntax|
 	*.frm		g:filetype_frm		|ft-form-syntax|
 	*.fs		g:filetype_fs		|ft-forth-syntax|

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -457,7 +457,7 @@ au BufNewFile,BufRead */.cmus/{autosave,rc,command-history,*.theme} setf cmusrc
 au BufNewFile,BufRead */cmus/{rc,*.theme}			setf cmusrc
 
 " Cobol
-au BufNewFile,BufRead *.cbl,*.cob,*.lib	setf cobol
+au BufNewFile,BufRead *.cbl,*.cob	setf cobol
 "   cobol or zope form controller python script? (heuristic)
 au BufNewFile,BufRead *.cpy
 	\ if getline(1) =~ '^##' |
@@ -531,6 +531,10 @@ au BufNewFile,BufRead s6-*                              setf execline
 
 " Fontconfig config files
 au BufNewFile,BufRead fonts.conf			setf xml
+
+" Faust
+au BufNewFile,BufRead *.lib				setf faust
+au BufNewFile,BufRead *.dsp				call dist#ft#FTdsp()
 
 " Libreoffice config files
 au BufNewFile,BufRead *.xcu,*.xlb,*.xlc,*.xba		setf xml
@@ -1365,8 +1369,8 @@ au BufNewFile,BufRead */etc/mail/aliases,*/etc/aliases	setf mailaliases
 au BufNewFile,BufRead .mailcap,mailcap		setf mailcap
 
 " Makefile
-au BufNewFile,BufRead *[mM]akefile,*.mk,*.mak,*.dsp setf make
-au BufNewFile,BufRead Kbuild setf make
+au BufNewFile,BufRead *[mM]akefile,*.mk,*.mak	setf make
+au BufNewFile,BufRead Kbuild			setf make
 
 " MakeIndex
 au BufNewFile,BufRead *.ist,*.mst		setf ist

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -160,7 +160,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     cmakecache: ['CMakeCache.txt'],
     cmod: ['file.cmod'],
     cmusrc: ['any/.cmus/autosave', 'any/.cmus/rc', 'any/.cmus/command-history', 'any/.cmus/file.theme', 'any/cmus/rc', 'any/cmus/file.theme', '/.cmus/autosave', '/.cmus/command-history', '/.cmus/file.theme', '/.cmus/rc', '/cmus/file.theme', '/cmus/rc'],
-    cobol: ['file.cbl', 'file.cob', 'file.lib'],
+    cobol: ['file.cbl', 'file.cob'],
     coco: ['file.atg'],
     conaryrecipe: ['file.recipe'],
     conf: ['auto.master', 'file.conf', 'texdoc.cnf', '.x11vncrc', '.chktexrc', '.ripgreprc', 'ripgreprc', 'file.ctags', '.mbsyncrc'],
@@ -256,6 +256,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     factor: ['file.factor'],
     falcon: ['file.fal'],
     fan: ['file.fan', 'file.fwt'],
+    faust: ['file.dsp', 'file.lib'],
     fennel: ['file.fnl'],
     fetchmail: ['.fetchmailrc'],
     fgl: ['file.4gl', 'file.4gh', 'file.m4gl'],
@@ -420,7 +421,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     mail: ['snd.123', '.letter', '.letter.123', '.followup', '.article', '.article.123', 'pico.123', 'mutt-xx-xxx', 'muttng-xx-xxx', 'ae123.txt', 'file.eml', 'reportbug-file'],
     mailaliases: ['/etc/mail/aliases', '/etc/aliases', 'any/etc/aliases', 'any/etc/mail/aliases'],
     mailcap: ['.mailcap', 'mailcap'],
-    make: ['file.mk', 'file.mak', 'file.dsp', 'makefile', 'Makefile', 'makefile-file', 'Makefile-file', 'some-makefile', 'some-Makefile', 'Kbuild'],
+    make: ['file.mk', 'file.mak', 'makefile', 'Makefile', 'makefile-file', 'Makefile-file', 'some-makefile', 'some-Makefile', 'Kbuild'],
     mallard: ['file.page'],
     man: ['file.man'],
     manconf: ['/etc/man.conf', 'man.config', 'any/etc/man.conf'],
@@ -2395,6 +2396,32 @@ func Test_typ_file()
   call assert_equal('typst', &filetype)
   bwipe!
   unlet g:filetype_typ
+
+  filetype off
+endfunc
+
+func Test_dsp_file()
+  filetype on
+
+  " Microsoft Developer Studio Project file
+
+  call writefile(['# Microsoft Developer Studio Project File'], 'Xfile.dsp', 'D')
+  split Xfile.dsp
+  call assert_equal('make', &filetype)
+  bwipe!
+
+  let g:filetype_dsp = 'make'
+  split test.dsp
+  call assert_equal('make', &filetype)
+  bwipe!
+  unlet g:filetype_dsp
+
+  " Faust
+
+  call writefile(['this is a fallback'], 'Xfile.dsp')
+  split Xfile.dsp
+  call assert_equal('faust', &filetype)
+  bwipe!
 
   filetype off
 endfunc


### PR DESCRIPTION
This adds the `faust` filetype for [Faust](https://faust.grame.fr/) `.dsp` and `.lib` files.

The `.lib` file extension was marked as being for COBOL files, but I couldn't find any evidence to support `.lib` being an extension that's used by COBOL (see sources below), so I reassigned it to Faust, which does use the `.lib` extension ([example](https://github.com/grame-cncm/faustlibraries/blob/master/basics.lib)). If anyone can find a `.lib` file in COBOL, I'll gladly write a file type detector for it, but I would need to see it in order to know what I'm detecting.

---
Sources proving that COBOL doesn't use `.lib`:

1. [The Wikipedia article on COBOL](https://en.wikipedia.org/wiki/COBOL) does not list `.lib` as an extension
![image](https://github.com/vim/vim/assets/24578572/c5cab256-a74b-4eaf-a3a2-c8bee91564fa)
2. [Visual Studio's _COBOL Language Support_ extension](https://github.com/eclipse-che4z/che-che4z-lsp-for-cobol?tab=readme-ov-file#cobol-language-support) does not list `.lib` as an extension they detect as a COBOL file.
![image](https://github.com/vim/vim/assets/24578572/b7ac6716-7ac7-4d47-b9b4-cc5da4092a37)
3. [The first 100 search results for `.lib` files on github](https://github.com/search?q=path%3A*.lib&type=code) are all in repos that do not contain any COBOL code 
(verified by hand)