### PR TITLE
runtime(deb822sources): add missing Enabled field

### DIFF
--- a/runtime/syntax/deb822sources.vim
+++ b/runtime/syntax/deb822sources.vim
@@ -40,7 +40,7 @@ syn match deb822sourcesUri            '\(https\?://\|ftp://\|[rs]sh://\|debtorre
 syn region deb822sourcesStrictField matchgroup=deb822sourcesEntryField start="^\%(Types\|URIs\|Suites\|Components\): *" end="$" contains=deb822sourcesType,deb822sourcesUri,deb822sourcesSupportedSuites,deb822sourcesUnsupportedSuites,deb822sourcesFreeComponent,deb822sourcesNonFreeComponent oneline
 syn region deb822sourcesField matchgroup=deb822sourcesOptionField start="^\%(Signed-By\|Check-Valid-Until\|Valid-Until-Min\|Valid-Until-Max\|Date-Max-Future\|InRelease-Path\): *" end="$" oneline
 syn region deb822sourcesField matchgroup=deb822sourcesMultiValueOptionField start="^\%(Architectures\|Languages\|Targets\)\%(-Add\|-Remove\)\?: *" end="$" oneline
-syn region deb822sourcesStrictField matchgroup=deb822sourcesBooleanOptionField start="^\%(PDiffs\|Allow-Insecure\|Allow-Weak\|Allow-Downgrade-To-Insecure\|Trusted\|Check-Date\): *" end="$" contains=deb822sourcesYesNo oneline
+syn region deb822sourcesStrictField matchgroup=deb822sourcesBooleanOptionField start="^\%(PDiffs\|Allow-Insecure\|Allow-Weak\|Allow-Downgrade-To-Insecure\|Trusted\|Check-Date\|Enabled\): *" end="$" contains=deb822sourcesYesNo oneline
 syn region deb822sourcesStrictField matchgroup=deb822sourcesForceBooleanOptionField start="^\%(By-Hash\): *" end="$" contains=deb822sourcesForce,deb822sourcesYesNo oneline
 
 hi def link deb822sourcesField                   Default


### PR DESCRIPTION
It lacks the support of Enabled: boolean option field [1]:

e.g.

```
  Types: deb
  Uris: https://paulcarroty.gitlab.io/vscodium-deb-rpm-repo/debs/
  Components: main
  Suites: vscodium
  Architectures: amd64 i386 arm64 armhf
  Enabled: yes
  Signed-By: /var/lib/extrepo/keys/vscodium.asc
```

This patch was also forwarded to upstream. [2]

[1] https://manpages.debian.org/unstable/apt/sources.list.5.en.html#DEB822-STYLE_FORMAT
[2] https://salsa.debian.org/vim-team/vim-debian/-/merge_requests/16