### PR TITLE
Inconsistencies between functions for option flags

### DIFF
--- a/src/bufwrite.c
+++ b/src/bufwrite.c
@@ -690,7 +690,7 @@ buf_write(
     int		    write_undo_file = FALSE;
     context_sha256_T sha_ctx;
 #endif
-    unsigned int    bkc = get_bkc_value(buf);
+    unsigned int    bkc = get_bkc_flags(buf);
     pos_T	    orig_start = buf->b_op_start;
     pos_T	    orig_end = buf->b_op_end;
 

--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -1226,7 +1226,7 @@ ins_compl_build_pum(void)
     int		cur = -1;
     int		lead_len = 0;
     int		max_fuzzy_score = 0;
-    int		cur_cot_flags = get_cot_flags();
+    unsigned int cur_cot_flags = get_cot_flags();
     int		compl_no_select = (cur_cot_flags & COT_NOSELECT) != 0;
     int		compl_fuzzy_match = (cur_cot_flags & COT_FUZZY) != 0;
 
@@ -2925,7 +2925,7 @@ set_completion(colnr_T startcol, list_T *list)
     int save_w_wrow = curwin->w_wrow;
     int save_w_leftcol = curwin->w_leftcol;
     int flags = CP_ORIGINAL_TEXT;
-    int cur_cot_flags = get_cot_flags();
+    unsigned int cur_cot_flags = get_cot_flags();
     int compl_longest = (cur_cot_flags & COT_LONGEST) != 0;
     int compl_no_insert = (cur_cot_flags & COT_NOINSERT) != 0;
     int compl_no_select = (cur_cot_flags & COT_NOSELECT) != 0;
@@ -4126,7 +4126,7 @@ find_next_completion_match(
 {
     int	    found_end = FALSE;
     compl_T *found_compl = NULL;
-    int	    cur_cot_flags = get_cot_flags();
+    unsigned int cur_cot_flags = get_cot_flags();
     int	    compl_no_select = (cur_cot_flags & COT_NOSELECT) != 0;
     int	    compl_fuzzy_match = (cur_cot_flags & COT_FUZZY) != 0;
 
@@ -4246,7 +4246,7 @@ ins_compl_next(
     int	    advance;
     int	    started = compl_started;
     buf_T   *orig_curbuf = curbuf;
-    int	    cur_cot_flags = get_cot_flags();
+    unsigned int cur_cot_flags = get_cot_flags();
     int	    compl_no_insert = (cur_cot_flags & COT_NOINSERT) != 0;
     int	    compl_fuzzy_match = (cur_cot_flags & COT_FUZZY) != 0;
 

--- a/src/option.c
+++ b/src/option.c
@@ -8364,10 +8364,10 @@ get_sidescrolloff_value(void)
 }
 
 /*
- * Get the local or global value of 'backupcopy'.
+ * Get the local or global value of 'backupcopy' flags.
  */
     unsigned int
-get_bkc_value(buf_T *buf)
+get_bkc_flags(buf_T *buf)
 {
     return buf->b_bkc_flags ? buf->b_bkc_flags : bkc_flags;
 }
@@ -8386,7 +8386,7 @@ get_flp_value(buf_T *buf)
 #endif
 
 /*
- * Get the local or global value of the 'virtualedit' flags.
+ * Get the local or global value of 'virtualedit' flags.
  */
     unsigned int
 get_ve_flags(void)

--- a/src/proto/insexpand.pro
+++ b/src/proto/insexpand.pro
@@ -27,7 +27,7 @@ int ins_compl_accept_char(int c);
 int ins_compl_add_infercase(char_u *str_arg, int len, int icase, char_u *fname, int dir, int cont_s_ipos);
 int ins_compl_has_shown_match(void);
 int ins_compl_long_shown_match(void);
-unsigned get_cot_flags(void);
+unsigned int get_cot_flags(void);
 int pum_wanted(void);
 void ins_compl_show_pum(void);
 char_u *find_word_start(char_u *ptr);

--- a/src/proto/option.pro
+++ b/src/proto/option.pro
@@ -139,7 +139,7 @@ int reset_option_was_set(char_u *name);
 int can_bs(int what);
 long get_scrolloff_value(void);
 long get_sidescrolloff_value(void);
-unsigned int get_bkc_value(buf_T *buf);
+unsigned int get_bkc_flags(buf_T *buf);
 char_u *get_flp_value(buf_T *buf);
 unsigned int get_ve_flags(void);
 char_u *get_showbreak_value(win_T *win);


### PR DESCRIPTION
Problem:  Inconsistencies between functions for option flags.
Solution: Consistently use "unsigned int" as return type and rename
          get_bkc_value() to get_bkc_flags().
