### PR TITLE
Make indentexpr evaluate from older vim scripts

### DIFF
--- a/runtime/indent/vim.vim
+++ b/runtime/indent/vim.vim
@@ -14,9 +14,7 @@ endif
 b:did_indent = true
 b:undo_indent = 'setlocal indentkeys< indentexpr<'
 
-import autoload '../autoload/dist/vimindent.vim'
-
-setlocal indentexpr=vimindent.Expr()
+setlocal indentexpr=dist#vimindent#Expr()
 setlocal indentkeys+==endif,=enddef,=endfu,=endfor,=endwh,=endtry,=endclass,=endinterface,=endenum,=},=else,=cat,=finall,=END,0\\
 execute('setlocal indentkeys+=0=\"\\\ ,0=#\\\ ')
 setlocal indentkeys-=0#


### PR DESCRIPTION
Older scripts have a problem with recent changes to indentexpr for vim9, they will see it as undefined variable E121.  Patch avoids the error in vim8 script as mentioned by @monkoose in https://github.com/vim/vim/issues/14111#issuecomment-1986917946

Fixes #14111
