### PR TITLE
Fix several documents

### DIFF
--- a/runtime/doc/mbyte.txt
+++ b/runtime/doc/mbyte.txt
@@ -801,7 +801,7 @@ is suitable for complex input, such as CJK.
   number of Hira-gana characters are 76.  So, first, we pre-input text as
   pronounced in Hira-gana, second, we convert Hira-gana to Kanji or Kata-Kana,
   if needed.  There are some Kana-Kanji conversion server: jserver
-  (distributed with Wnn, see below) and canna.Canna can be found at:
+  (distributed with Wnn, see below) and canna.  Canna can be found at:
   https://osdn.net/projects/canna/
 
 There is a good input system: Wnn4.2.  Wnn 4.2 contains,
@@ -1356,7 +1356,7 @@ You might also want to select the font used for the menus.  Unfortunately this
 doesn't always work.  See the system specific remarks below, and 'langmenu'.
 
 
-USING UTF-8 IN X-Windows				*utf-8-in-xwindows*
+USING UTF-8 IN X-WINDOWS				*utf-8-in-xwindows*
 
 Note: This section does not apply to the GTK+ 2 GUI.
 

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -1335,7 +1335,7 @@ passed to make, say :make html or :make pdf.
 Additional arguments can be passed to pandoc:
 
 - either by appending them to make, say `:make html --self-contained` .
-- or setting them in `b:pandoc_compiler_args` or `g:pandoc_compiler_args`
+- or setting them in `b:pandoc_compiler_args` or `g:pandoc_compiler_args`.
 
 PERL					*quickfix-perl* *compiler-perl*
 

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -935,14 +935,14 @@ ASTRO						*astro.vim* *ft-astro-syntax*
 Configuration
 
 The following variables control certain syntax highlighting features.
-You can add them to your .vimrc: >
+You can add them to your .vimrc.
+
+To enables TypeScript and TSX for ".astro" files (default "disable"): >
 	let g:astro_typescript = "enable"
 <
-Enables TypeScript and TSX for ".astro" files. Default Value: "disable" >
+To enables Stylus for ".astro" files (default "disable"): >
 	let g:astro_stylus = "enable"
 <
-Enables Stylus for ".astro" files. Default Value: "disable"
-
 NOTE: You need to install an external plugin to support stylus in astro files.
 
 
@@ -1909,7 +1909,7 @@ Note: Syntax folding might slow down syntax highlighting significantly,
 especially for large files.
 
 
-HTML/OS (by Aestiva)				*htmlos.vim* *ft-htmlos-syntax*
+HTML/OS (BY AESTIVA)				*htmlos.vim* *ft-htmlos-syntax*
 
 The coloring scheme for HTML/OS works as follows:
 

--- a/runtime/doc/usr_52.txt
+++ b/runtime/doc/usr_52.txt
@@ -341,7 +341,7 @@ will have to make sure to use a unique name for these global items. Example: >
 
 COMMENT PACKAGE
 
-Vim comes with a comment plugin, written in Vim9 script |comment-install|.
+Vim comes with a comment plugin, written in Vim9 script.  |comment-install|
 Have a look at the package located at $VIMRUNTIME/pack/dist/opt/comment/
 
 HIGHLIGHT YANK PLUGIN
@@ -350,27 +350,27 @@ Here is an example for highlighting the yanked region. It makes use of the
 |getregionpos()| function, available since Vim 9.1.0446.
 
 Copy the following example into a new file and place it into your plugin directory
-and it will be active next time you start Vim |add-plugin|: >
+and it will be active next time you start Vim.  |add-plugin|: >
 
 	vim9script
 
 	def HighlightedYank(hlgroup = 'IncSearch', duration = 300, in_visual = true)
 	  if v:event.operator ==? 'y'
-		  if !in_visual && visualmode() != null_string
-			visualmode(1)
-			return
-		  endif
-		  var [beg, end] = [getpos("'["), getpos("']")]
-		  var type = v:event.regtype ?? 'v'
-		  var pos = getregionpos(beg, end, {type: type})
-		  var end_offset = (type == 'V' || v:event.inclusive) ? 1 : 0
-		  var m = matchaddpos(hlgroup, pos->mapnew((_, v) => {
-			var col_beg = v[0][2] + v[0][3]
-			var col_end = v[1][2] + v[1][3] + end_offset
-			return [v[0][1], col_beg, col_end - col_beg]
-		  }))
-		  var winid = win_getid()
-		  timer_start(duration, (_) => m->matchdelete(winid))
+	    if !in_visual && visualmode() != null_string
+	      visualmode(1)
+	      return
+	    endif
+	    var [beg, end] = [getpos("'["), getpos("']")]
+	    var type = v:event.regtype ?? 'v'
+	    var pos = getregionpos(beg, end, {type: type})
+	    var end_offset = (type == 'V' || v:event.inclusive) ? 1 : 0
+	    var m = matchaddpos(hlgroup, pos->mapnew((_, v) => {
+	      var col_beg = v[0][2] + v[0][3]
+	      var col_end = v[1][2] + v[1][3] + end_offset
+	      return [v[0][1], col_beg, col_end - col_beg]
+	    }))
+	    var winid = win_getid()
+	    timer_start(duration, (_) => m->matchdelete(winid))
 	  endif
 	enddef
 


### PR DESCRIPTION
### REMARKS:

- mbyte.txt
L804
Regression at https://github.com/vim/vim/commit/1c5728e0c4a9df930879f9f0ca108092d5902194#diff-b5ce8ea08d78c0baef6b22f54deb0c81f940d56c6d8cf651b29ce950e9367568L803-R804

- syntax.txt
L937 - L946
Vim documentation typically follows the order "Code explanation" ---> "Code".
I have corrected the parts where the order was different.
If you don't like the default value writing style, change it.

--
Best regards,
Hirohito Higashi (h_east)