### PR TITLE
runtime(termdebug): Fix saved_mousemodel check

### DIFF
--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -1208,7 +1208,7 @@ def DeleteCommands()
     win_gotoid(curwinid)
     winbar_winids = []
 
-    if exists('saved_mousemodel')
+    if saved_mousemodel != ''
       &mousemodel = saved_mousemodel
       saved_mousemodel = null_string
       aunmenu PopUp.-SEP3-


### PR DESCRIPTION
Fix issue introduced by 23f29ffc64276dd790581f98b86a0a6435b7eb22 where saved_mousemodel is introduced as a variable, so the exists check will always be true.

Move to check the value of saved_mousemodel instead.