### PR TITLE
runtime: add .vim8 as vim filetype

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -2583,7 +2583,7 @@ au BufNewFile,BufRead *.tape			setf vhs
 au BufNewFile,BufRead *.hdl,*.vhd,*.vhdl,*.vbe,*.vst,*.vho  setf vhdl
 
 " Vim script
-au BufNewFile,BufRead *.vim,.exrc,_exrc,.netrwhist	setf vim
+au BufNewFile,BufRead *.vim,*.vim8,.exrc,_exrc,.netrwhist	setf vim
 
 " Viminfo file
 au BufNewFile,BufRead .viminfo,_viminfo		setf viminfo


### PR DESCRIPTION
Neovim does not support vim9script, and I am not sure they ever will. Because of this, I have started to use the `.vim8` extension on scripts which keep compatibility with old vimscript.

Would perhaps a more generic `*.vim[0-9]*` be better?