### PR TITLE
Fix the mousemodel restoration fix.

### DIFF
--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -109,7 +109,7 @@ var winbar_winids = []
 var plus_map_saved = {}
 var minus_map_saved = {}
 var k_map_saved = {}
-var saved_mousemodel = ''
+var saved_mousemodel = null_string
 
 
 # Need either the +terminal feature or +channel and the prompt buffer.
@@ -1220,7 +1220,7 @@ def DeleteCommands()
     win_gotoid(curwinid)
     winbar_winids = []
 
-    if saved_mousemodel != ''
+    if saved_mousemodel isnot null_string
       &mousemodel = saved_mousemodel
       saved_mousemodel = null_string
       try


### PR DESCRIPTION
Follow on to #14946
@laburnumT @ubaldot @yegappan 
I'm somewhat obsessed with vim's null handling and saw this issue go by... I didn't test it, but the following shows the problem. You can apply the fix in this PR to the test and see that it behaves.

**Note**: One might expect that `if mm != null` would work, but the
string container is an exception and `isnot` is required. 
See `:help null-anomolies`


Run this, which is like the code without this PR, and see the unexpected results
```
vim9script

var mm = ''

def SaveRestoreMM()
    echom printf("save '%s'", &mousemodel)

    mm = &mousemodel
    &mousemodel = 'popup_setpos'

    if mm != ''
        echom printf("restore '%s'", mm)
        &mousemodel = mm
        mm = null_string
    endif
enddef

SaveRestoreMM()

&mousemodel = ''

SaveRestoreMM()

SaveRestoreMM()

&mousemodel = ''

SaveRestoreMM()
```
Output:
```
save 'extend'
restore 'extend'
save ''
save 'popup_setpos'
restore 'popup_setpos'
save ''
```