### PR TITLE
fix(completion): compl_shown_match not update when fuzzy with complete

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -1220,6 +1220,7 @@ ins_compl_build_pum(void)
 {
     compl_T     *compl;
     compl_T     *shown_compl = NULL;
+    compl_T     *after_first_compl = NULL;
     int		did_find_shown_match = FALSE;
     int		shown_match_ok = FALSE;
     int		i;
@@ -1296,6 +1297,8 @@ ins_compl_build_pum(void)
 	    }
 	    else if (compl_fuzzy_match)
 	    {
+		if (i == 0)
+		    after_first_compl = compl;
 		// Update the maximum fuzzy score and the shown match
 		// if the current item's score is higher
 		if (compl->cp_score > max_fuzzy_score)
@@ -1316,6 +1319,8 @@ ins_compl_build_pum(void)
 		{
 		    shown_match_ok = TRUE;
 		    cur = 0;
+		    if (match_at_original_text(compl_shown_match))
+		      compl_shown_match = after_first_compl;
 		}
 	    }
 

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -2559,6 +2559,13 @@ func Test_complete_fuzzy_match()
   call feedkeys("S\<C-x>\<C-o>fb\<C-p>\<C-p>\<C-p>\<C-p>", 'tx')
   call assert_equal('fooBaz', g:word)
 
+  func Comp()
+    call complete(col('.'), ["fooBaz", "foobar", "foobala"])
+    return ''
+  endfunc
+  call feedkeys("i\<C-R>=Comp()\<CR>", 'tx')
+  call assert_equal('fooBaz', g:word)
+
   " respect noselect
   set completeopt+=noselect
   call feedkeys("S\<C-x>\<C-o>fb", 'tx')
@@ -2574,6 +2581,7 @@ func Test_complete_fuzzy_match()
   augroup! AAAAA_Group
   delfunc OnPumChange
   delfunc Omni_test
+  delfunc Comp
   unlet g:item
   unlet g:word
 endfunc


### PR DESCRIPTION
Problem: when use fuzzy option and get completion from complete the compl_shown_match not update .

Solution: when no leader and shown match is first match we should set it to the first compl which is first item in compl_match_array.