### PR TITLE
runtime(doc): restore description of "$" in col() and virtcol()

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -1,4 +1,4 @@
-*builtin.txt*	For Vim version 9.1.  Last change: 2024 Jun 12
+*builtin.txt*	For Vim version 9.1.  Last change: 2024 Jun 13
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -1729,6 +1729,8 @@ col({expr} [, {winid}])					*col()*
 		The result is a Number, which is the byte index of the column
 		position given with {expr}.
 		For accepted positions see |getpos()|.
+		When {expr} is "$", it means the end of the cursor line, so
+		the result is the number of bytes in the cursor line plus one.
 		Additionally {expr} can be [lnum, col]: a |List| with the line
 		and column number. Most useful when the column is "$", to get
 		the last column of a specific line.  When "lnum" or "col" is
@@ -4492,7 +4494,7 @@ getpos({expr})							*getpos()*
 		    .	    The cursor position.
 		    $	    The last line in the current buffer.
 		    'x	    Position of mark x (if the mark is not set, 0 is
-			    returned).
+			    returned for all values).
 		    w0	    First line visible in current window (one if the
 			    display isn't updated, e.g. in silent Ex mode).
 		    w$	    Last line visible in current window (this is one
@@ -4542,8 +4544,8 @@ getpos({expr})							*getpos()*
 			let save_a_mark = getpos("'a")
 			...
 			call setpos("'a", save_a_mark)
-
-<		Also see |getcharpos()|, |getcurpos()| and |setpos()|.
+<
+		Also see |getcharpos()|, |getcurpos()| and |setpos()|.
 
 		Can also be used as a |method|: >
 			GetMark()->getpos()
@@ -11754,6 +11756,8 @@ virtcol({expr} [, {list} [, {winid}]])			*virtcol()*
 		For the byte position use |col()|.
 
 		For the use of {expr} see |getpos()| and |col()|.
+		When {expr} is "$", it means the end of the cursor line, so
+		the result is the number of cells in the cursor line plus one.
 
 		When 'virtualedit' is used {expr} can be [lnum, col, off],
 		where "off" is the offset in screen columns from the start of


### PR DESCRIPTION
These are different from line() and getpos().
