### PR TITLE
If vim9script, return null_job from term_getjob when there is no job.

### DIFF
--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -647,7 +647,8 @@ term_getcursor({buf})					*term_getcursor()*
 term_getjob({buf})					*term_getjob()*
 		Get the Job associated with terminal window {buf}.
 		{buf} is used as with |term_getsize()|.
-		Returns |v:null| when there is no job.
+		Returns |v:null| when there is no job. In Vim9 script, return
+		null_job when there is no job.
 
 		Can also be used as a |method|: >
 			GetBufnr()->term_getjob()

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -6171,8 +6171,16 @@ f_term_getjob(typval_T *argvars, typval_T *rettv)
     buf = term_get_buf(argvars, "term_getjob()");
     if (buf == NULL)
     {
-	rettv->v_type = VAR_SPECIAL;
-	rettv->vval.v_number = VVAL_NULL;
+	if (in_vim9script())
+	{
+	    rettv->v_type = VAR_JOB;
+	    rettv->vval.v_job = NULL;
+	}
+	else
+	{
+	    rettv->v_type = VAR_SPECIAL;
+	    rettv->vval.v_number = VVAL_NULL;
+	}
 	return;
     }
 

--- a/src/testdir/test_vim9_builtin.vim
+++ b/src/testdir/test_vim9_builtin.vim
@@ -4557,6 +4557,7 @@ enddef
 def Test_term_getjob()
   CheckRunVimInTerminal
   v9.CheckSourceDefAndScriptFailure(['term_getjob(0z10)'], ['E1013: Argument 1: type mismatch, expected string but got blob', 'E1220: String or Number required for argument 1'])
+  v9.CheckSourceDefAndScriptSuccess(['assert_true(term_getjob(0) == null_job)'])
 enddef
 
 def Test_term_getline()


### PR DESCRIPTION
This change gets in more in accord with the spec/help. (I think)

It also gets `job_status(term_getjob(0))` to work; returns `'fail'` rather than throwing an exception. This came up around the vim9 termdebug port. @ubaldot 

Note that the return values is adjusted acc'd to if vim9; I'm assuming legacy can not handle a `null_job`. @yegappan 