### PR TITLE
fuzzy_match_str_with_pos() may leak memory on failure

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -5688,7 +5688,6 @@ PmenuThumb	Popup menu: Thumb of the scrollbar.
 PmenuMatch	Popup menu: Matched text in normal item
 							*hl-PmenuMatchSel*
 PmenuMatchSel	Popup menu: Matched text in selected item
-
 							*hl-PopupNotification*
 PopupNotification
 		Popup window created with |popup_notification()|.  If not

--- a/src/search.c
+++ b/src/search.c
@@ -5120,12 +5120,14 @@ fuzzy_match_str_with_pos(char_u *str UNUSED, char_u *pat UNUSED)
     if (str == NULL || pat == NULL)
     {
         ga_clear(match_positions);
+	vim_free(match_positions);
         return NULL;
     }
     l = list_alloc();
     if (l == NULL)
     {
         ga_clear(match_positions);
+	vim_free(match_positions);
         return NULL;
     }
 
@@ -5209,6 +5211,7 @@ cleanup:
     if (l != NULL)
         list_free(l);
     ga_clear(match_positions);
+    vim_free(match_positions);
     return NULL;
 #else
     return NULL;


### PR DESCRIPTION
Problem:  fuzzy_match_str_with_pos() may leak memory on failure.
Solution: Also free match_positions itself.
