### PR TITLE
`README.md`: Fix link to release archives

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ an overview of currently available distributions.
 
 Some popular places to get the latest Vim:
 * Check out the git repository from [GitHub](https://github.com/vim/vim).
-* Get the source code as an [archive](https://github.com/vim/vim/releases).
+* Get the source code as an [archive](https://github.com/vim/vim/tags).
 * Get a Windows executable from the
 [vim-win32-installer](https://github.com/vim/vim-win32-installer/releases) repository.
 

--- a/README.rux.txt
+++ b/README.rux.txt
@@ -48,7 +48,7 @@ MS Windows 95/98/Me/NT/2000/XP/Vista, AmigaDOS, Atari MiNT, BeOS и RISC OS.
 
 Несколько полезных мест, где можно получить последнюю версию редактора Vim:
 * Посмотрите в git-хранилище на GitHub: https://github.com/vim/vim.
-* Получить исходный код в виде архива: https://github.com/vim/vim/releases.
+* Получить исходный код в виде архива: https://github.com/vim/vim/tags.
 * Получить исполняемый файл для ОС Windows из хранилища vim-win32-installer:
 https://github.com/vim/vim-win32-installer/releases.
 

--- a/README.txt
+++ b/README.txt
@@ -37,7 +37,7 @@ an overview of currently available distributions.
 
 Some popular places to get the latest Vim:
 * Check out the git repository from github: https://github.com/vim/vim.
-* Get the source code as an archive: https://github.com/vim/vim/releases.
+* Get the source code as an archive: https://github.com/vim/vim/tags.
 * Get a Windows executable from the vim-win32-installer repository:
   https://github.com/vim/vim-win32-installer/releases.
 


### PR DESCRIPTION
The releases page doesn't have anything listed:

<img width="944" alt="image" src="https://github.com/vim/vim/assets/1735266/485ec37d-2de9-4729-8e26-e961d64e1916">
