### PR TITLE
runtime(termdebug): add no_tty option to prevent creation of TTY window

### DIFF
--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -1661,6 +1661,14 @@ If there is no g:terminal_config yet you can use: >
 After this, breakpoints will be displayed as `>>` in the signcolumn.
 
 
+Program window ~
+							*termdebug_no_tty*
+
+The program I/O window can be hidden by setting the 'no_tty' configuration to
+true.
+	let g:termdebug_config['no_tty'] = 1
+
+
 Window toolbar ~
 							*termdebug_winbar*
 By default the Termdebug plugin creates a window toolbar if the mouse is

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -328,14 +328,14 @@ enddef
 
 # Use when debugger didn't start or ended.
 def CloseBuffers()
-  exe $'bwipe! {ptybufnr}'
-  exe $'bwipe! {commbufnr}'
-  if asmbufnr > 0 && bufexists(asmbufnr)
-    exe $'bwipe! {asmbufnr}'
-  endif
-  if varbufnr > 0 && bufexists(varbufnr)
-    exe $'bwipe! {varbufnr}'
-  endif
+  var bufnames = ['debugged\ program', 'gdb\ communication', asmbufname, varbufname]
+  for bufname in bufnames
+    var buf_nr = bufnr(bufname)
+    if buf_nr > 0 && bufexists(buf_nr)
+      exe $'bwipe! {bufname}'
+    endif
+  endfor
+
   running = 0
   gdbwin = 0
 enddef

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -717,7 +717,7 @@ def ContinueCommand()
 enddef
 
 # This is global so that a user can create their mappings with this.
-def TermDebugSendCommand(cmd: string)
+def g:TermDebugSendCommand(cmd: string)
   if way == 'prompt'
     ch_sendraw(gdb_channel, $"{cmd}\n")
   else


### PR DESCRIPTION
In some circumstances, like debugging an embedded system, the TTY window is useless and there was no way to prevent its creation.

Add a new "no_tty" option to termdebug_config to let user get rid of TTY window if they don't want it.

This is based on development by @GitMensch in #10389, adapted to newer Vim Script.

Unfortunately I could not get the vim9 version to work with my local installation for unknown reasons, so it's untested.