### PR TITLE
runtime(java): Add a config variable for commonly used compiler options

### DIFF
--- a/runtime/compiler/javac.vim
+++ b/runtime/compiler/javac.vim
@@ -1,7 +1,7 @@
 " Vim compiler file
 " Compiler:	Java Development Kit Compiler
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2024 Apr 03
+" Last Change:	2024 Jun 14
 
 if exists("current_compiler")
   finish
@@ -11,7 +11,12 @@ let current_compiler = "javac"
 let s:cpo_save = &cpo
 set cpo&vim
 
-CompilerSet makeprg=javac
+if exists("g:javac_makeprg_params")
+  execute $'CompilerSet makeprg=javac\ {escape(g:javac_makeprg_params, ' \|"')}'
+else
+  CompilerSet makeprg=javac
+endif
+
 CompilerSet errorformat=%E%f:%l:\ error:\ %m,
 		       \%W%f:%l:\ warning:\ %m,
 		       \%-Z%p^,

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -1303,6 +1303,14 @@ g:compiler_gcc_ignore_unmatched_lines
 				positives.
 
 
+JAVAC							*compiler-javac*
+
+Commonly used compiler options can be added to 'makeprg' by setting the
+g:javac_makeprg_params variable.  For example: >
+
+	let g:javac_makeprg_params = "-Xlint:all -encoding utf-8"
+<
+
 MANX AZTEC C				*quickfix-manx* *compiler-manx*
 
 To use Vim with Manx's Aztec C compiler on the Amiga you should do the

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -6532,6 +6532,7 @@ compiler-dotnet	quickfix.txt	/*compiler-dotnet*
 compiler-gcc	quickfix.txt	/*compiler-gcc*
 compiler-gnat	ft_ada.txt	/*compiler-gnat*
 compiler-hpada	ft_ada.txt	/*compiler-hpada*
+compiler-javac	quickfix.txt	/*compiler-javac*
 compiler-manx	quickfix.txt	/*compiler-manx*
 compiler-pandoc	quickfix.txt	/*compiler-pandoc*
 compiler-perl	quickfix.txt	/*compiler-perl*


### PR DESCRIPTION
The value of `g:javac_makeprg_params` is now added to the value of 'makeprg' as an option string.

@Konfekt, does that work for you?
