### PR TITLE
fix(completion): use exist shown_compl instead after_first_compl

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -1222,7 +1222,6 @@ ins_compl_build_pum(void)
 {
     compl_T     *compl;
     compl_T     *shown_compl = NULL;
-    compl_T     *after_first_compl = NULL;
     int		did_find_shown_match = FALSE;
     int		shown_match_ok = FALSE;
     int		i;
@@ -1300,7 +1299,7 @@ ins_compl_build_pum(void)
 	    else if (compl_fuzzy_match)
 	    {
 		if (i == 0)
-		    after_first_compl = compl;
+		    shown_compl = compl;
 		// Update the maximum fuzzy score and the shown match
 		// if the current item's score is higher
 		if (compl->cp_score > max_fuzzy_score)
@@ -1322,7 +1321,7 @@ ins_compl_build_pum(void)
 		    shown_match_ok = TRUE;
 		    cur = 0;
 		    if (match_at_original_text(compl_shown_match))
-		      compl_shown_match = after_first_compl;
+		      compl_shown_match = shown_compl;
 		}
 	    }
 


### PR DESCRIPTION
Sorry I couldn't update the PR in time because of computer problems yesterday. I ignored the existing shown_compl and didn't need anyone to add any new variables.