### PR TITLE
fix(completion): avoid breaking default completion mode

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -4155,8 +4155,8 @@ find_next_completion_match(
     {
 	if (compl_shows_dir_forward() && compl_shown_match->cp_next != NULL)
 	{
-	    compl_shown_match = !compl_fuzzy_match ? compl_shown_match->cp_next
-						: find_comp_when_fuzzy();
+	    compl_shown_match = compl_fuzzy_match && compl_match_array != NULL
+			? find_comp_when_fuzzy() : compl_shown_match->cp_next;
 	    found_end = (compl_first_match != NULL
 		    && (is_first_match(compl_shown_match->cp_next)
 			|| is_first_match(compl_shown_match)));
@@ -4165,8 +4165,8 @@ find_next_completion_match(
 		&& compl_shown_match->cp_prev != NULL)
 	{
 	    found_end = is_first_match(compl_shown_match);
-	    compl_shown_match = !compl_fuzzy_match ? compl_shown_match->cp_prev
-						   : find_comp_when_fuzzy();
+	    compl_shown_match = compl_fuzzy_match && compl_match_array != NULL
+			? find_comp_when_fuzzy() : compl_shown_match->cp_prev;
 	    found_end |= is_first_match(compl_shown_match);
 	}
 	else

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -2573,6 +2573,15 @@ func Test_complete_fuzzy_match()
   call feedkeys("S\<C-x>\<C-o>fb\<C-n>", 'tx')
   call assert_equal('fooBaz', g:word)
 
+  " avoid break default completion behavior
+  set completeopt=fuzzy,menu
+  call setline(1, ['hello help hero h'])
+  exe "normal A\<C-X>\<C-N>"
+  call assert_equal('hello help hero hello', getline('.'))
+  set completeopt+=noinsert
+  exe "normal Shello help hero h\<C-X>\<C-N>"
+  call assert_equal('hello help hero h', getline('.'))
+
   " clean up
   set omnifunc=
   bw!


### PR DESCRIPTION
currently we fuzzy search item in match array. so if array is empty we should still find from list. avoid broken default completion behavior. 

it's part of https://github.com/vim/vim/pull/14976, seems like #14976 need some dicussions so split it to a single pr


Fix #15009
