### PR TITLE
filetype: Vim-script files not detected by shebang line

### DIFF
--- a/runtime/autoload/dist/script.vim
+++ b/runtime/autoload/dist/script.vim
@@ -229,6 +229,10 @@ export def Exe2filetype(name: string, line1: string): string
   elseif name =~ '^execlineb\>'
     return 'execline'
 
+    # Vim
+  elseif name =~ '^vim\>'
+    return 'vim'
+
   endif
 
   return ''

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -994,6 +994,7 @@ def s:GetScriptChecks(): dict<list<list<string>>>
             ['#!/path/regina']],
     janet:  [['#!/path/janet']],
     dart:   [['#!/path/dart']],
+    vim:    [['#!/path/vim']],
   }
 enddef
 


### PR DESCRIPTION
Problem:  Vim-script files may not be recognised
Solution: Add shebang line detection
