### PR TITLE
Implement lstat() for Windows

### DIFF
--- a/src/filepath.c
+++ b/src/filepath.c
@@ -3645,11 +3645,15 @@ dos_expandpath(
 	    }
 	    else
 	    {
+		stat_T  sb;
+
 		// no more wildcards, check if there is a match
 		// remove backslashes for the remaining components only
 		if (*path_end != 0)
 		    backslash_halve(buf + len + 1);
-		if (mch_getperm(buf) >= 0)	// add existing file
+		// add existing file
+		if ((flags & EW_ALLLINKS) ? mch_lstat((char *)buf, &sb) >= 0
+			: mch_getperm(buf) >= 0)
 		    addfile(gap, buf, flags);
 	    }
 	}

--- a/src/macros.h
+++ b/src/macros.h
@@ -194,7 +194,11 @@
 #ifdef HAVE_LSTAT
 # define mch_lstat(n, p)	lstat((n), (p))
 #else
-# define mch_lstat(n, p)	mch_stat((n), (p))
+# ifdef MSWIN
+#  define mch_lstat(n, p)	vim_lstat((n), (p))
+# else
+#  define mch_lstat(n, p)	mch_stat((n), (p))
+# endif
 #endif
 
 #ifdef VMS

--- a/src/os_mswin.c
+++ b/src/os_mswin.c
@@ -520,7 +520,7 @@ wstat_symlink_aware(const WCHAR *name, stat_T *stp)
 mswin_lstat(const WCHAR *name, stat_T *stp)
 {
     int			n;
-    int	    		fd;
+    int			fd;
     BOOL		is_symlink = FALSE;
     HANDLE		hFind, h;
     DWORD		attr = 0;

--- a/src/os_mswin.c
+++ b/src/os_mswin.c
@@ -430,16 +430,6 @@ slash_adjust(char_u *p)
     }
 }
 
-// Use 64-bit stat functions.
-#undef stat
-#undef _stat
-#undef _wstat
-#undef _fstat
-#define stat _stat64
-#define _stat _stat64
-#define _wstat _wstat64
-#define _fstat _fstat64
-
     static int
 read_reparse_point(const WCHAR *name, char_u *buf, DWORD *buf_len)
 {
@@ -459,100 +449,6 @@ read_reparse_point(const WCHAR *name, char_u *buf, DWORD *buf_len)
     CloseHandle(h);
 
     return ok ? OK : FAIL;
-}
-
-    static int
-wstat_symlink_aware(const WCHAR *name, stat_T *stp)
-{
-#if (defined(_MSC_VER) && (_MSC_VER < 1900)) || defined(__MINGW32__)
-    // Work around for VC12 or earlier (and MinGW). _wstat() can't handle
-    // symlinks properly.
-    // VC9 or earlier: _wstat() doesn't support a symlink at all. It retrieves
-    // status of a symlink itself.
-    // VC10: _wstat() supports a symlink to a normal file, but it doesn't
-    // support a symlink to a directory (always returns an error).
-    // VC11 and VC12: _wstat() doesn't return an error for a symlink to a
-    // directory, but it doesn't set S_IFDIR flag.
-    // MinGW: Same as VC9.
-    int			n;
-    BOOL		is_symlink = FALSE;
-    HANDLE		hFind, h;
-    DWORD		attr = 0;
-    WIN32_FIND_DATAW	findDataW;
-
-    hFind = FindFirstFileW(name, &findDataW);
-    if (hFind != INVALID_HANDLE_VALUE)
-    {
-	attr = findDataW.dwFileAttributes;
-	if ((attr & FILE_ATTRIBUTE_REPARSE_POINT)
-		&& (findDataW.dwReserved0 == IO_REPARSE_TAG_SYMLINK))
-	    is_symlink = TRUE;
-	FindClose(hFind);
-    }
-    if (is_symlink)
-    {
-	h = CreateFileW(name, FILE_READ_ATTRIBUTES,
-		FILE_SHARE_READ | FILE_SHARE_WRITE, NULL,
-		OPEN_EXISTING,
-		(attr & FILE_ATTRIBUTE_DIRECTORY)
-					    ? FILE_FLAG_BACKUP_SEMANTICS : 0,
-		NULL);
-	if (h != INVALID_HANDLE_VALUE)
-	{
-	    int	    fd;
-
-	    fd = _open_osfhandle((intptr_t)h, _O_RDONLY);
-	    n = _fstat(fd, (struct _stat *)stp);
-	    if ((n == 0) && (attr & FILE_ATTRIBUTE_DIRECTORY))
-		stp->st_mode = (stp->st_mode & ~S_IFREG) | S_IFDIR;
-	    _close(fd);
-	    return n;
-	}
-    }
-#endif
-    return _wstat(name, (struct _stat *)stp);
-}
-
-/*
- * Implements lstat(), a version of stat() that doesn't resolve symlinks.
- */
-    static int
-mswin_lstat(const WCHAR *name, stat_T *stp)
-{
-    int			n;
-    int			fd;
-    BOOL		is_symlink = FALSE;
-    HANDLE		hFind, h;
-    DWORD		attr = 0;
-    WIN32_FIND_DATAW	findDataW;
-
-    hFind = FindFirstFileW(name, &findDataW);
-    if (hFind == INVALID_HANDLE_VALUE)
-	return -1;
-
-    attr = findDataW.dwFileAttributes;
-    if ((attr & FILE_ATTRIBUTE_REPARSE_POINT)
-	    && (findDataW.dwReserved0 == IO_REPARSE_TAG_SYMLINK))
-	is_symlink = TRUE;
-    FindClose(hFind);
-
-    // Use the plain old stat() whenever it's possible.
-    if (!is_symlink)
-	return _wstat(name, stp);
-
-    h = CreateFileW(name, FILE_READ_ATTRIBUTES, 0, NULL, OPEN_EXISTING,
-	    FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT,
-	    NULL);
-    if (h == INVALID_HANDLE_VALUE)
-	return -1;
-
-    fd = _open_osfhandle((intptr_t)h, _O_RDONLY);
-    n = _fstat(fd, (struct _stat *)stp);
-    if ((n == 0) && (attr & FILE_ATTRIBUTE_DIRECTORY))
-	stp->st_mode = (stp->st_mode & ~S_IFMT) | S_IFDIR;
-    _close(fd);
-
-    return n;
 }
 
     char_u *
@@ -610,6 +506,70 @@ resolve_appexeclink(char_u *fname)
     return utf16_to_enc(p, NULL);
 }
 
+// Use 64-bit stat functions.
+#undef stat
+#undef _stat
+#undef _wstat
+#undef _fstat
+#define stat _stat64
+#define _stat _stat64
+#define _wstat _wstat64
+#define _fstat _fstat64
+
+/*
+ * Implements lstat() and stat() that can handle symlinks properly.
+ */
+    static int
+mswin_stat_impl(const WCHAR *name, stat_T *stp, const int resolve)
+{
+    int			n;
+    int			fd;
+    BOOL		is_symlink = FALSE;
+    HANDLE		hFind, h;
+    DWORD		attr = 0;
+    DWORD		flag = 0;
+    WIN32_FIND_DATAW    findDataW;
+
+#ifdef _UCRT
+    if (resolve)
+	// Universal CRT can handle symlinks properly.
+	return _wstat(name, stp);
+#endif
+
+    hFind = FindFirstFileW(name, &findDataW);
+    if (hFind != INVALID_HANDLE_VALUE)
+    {
+	attr = findDataW.dwFileAttributes;
+	if ((attr & FILE_ATTRIBUTE_REPARSE_POINT)
+		&& (findDataW.dwReserved0 == IO_REPARSE_TAG_SYMLINK))
+	    is_symlink = TRUE;
+	FindClose(hFind);
+    }
+
+    // Use the plain old stat() whenever it's possible.
+    if (!is_symlink)
+	return _wstat(name, stp);
+
+    if (!resolve && is_symlink)
+	flag = FILE_FLAG_OPEN_REPARSE_POINT;
+    if (attr & FILE_ATTRIBUTE_DIRECTORY)
+	flag |= FILE_FLAG_BACKUP_SEMANTICS;
+
+    h = CreateFileW(name, FILE_READ_ATTRIBUTES,
+	    FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING, flag,
+	    NULL);
+    if (h == INVALID_HANDLE_VALUE)
+	return -1;
+
+    fd = _open_osfhandle((intptr_t)h, _O_RDONLY);
+    n = _fstat(fd, (struct _stat *)stp);
+    if ((n == 0) && (attr & FILE_ATTRIBUTE_DIRECTORY))
+	stp->st_mode = (stp->st_mode & ~S_IFMT) | S_IFDIR;
+    _close(fd);
+
+    return n;
+}
+
 /*
  * stat() can't handle a trailing '/' or '\', remove it first.
  * When 'resolve' is true behave as lstat() wrt symlinks.
@@ -650,7 +610,7 @@ stat_impl(const char *name, stat_T *stp, const int resolve)
     if (wp == NULL)
 	return -1;
 
-    n = resolve ? wstat_symlink_aware(wp, stp) : mswin_lstat(wp, stp);
+    n = mswin_stat_impl(wp, stp, resolve);
     vim_free(wp);
     return n;
 }

--- a/src/os_mswin.c
+++ b/src/os_mswin.c
@@ -538,7 +538,7 @@ mswin_lstat(const WCHAR *name, stat_T *stp)
 
     // Use the plain old stat() whenever it's possible.
     if (!is_symlink)
-	return wstat_symlink_aware(name, stp);
+	return _wstat(name, stp);
 
     h = CreateFileW(name, FILE_READ_ATTRIBUTES, 0, NULL, OPEN_EXISTING,
 	    FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT,
@@ -548,6 +548,8 @@ mswin_lstat(const WCHAR *name, stat_T *stp)
 
     fd = _open_osfhandle((intptr_t)h, _O_RDONLY);
     n = _fstat(fd, (struct _stat *)stp);
+    if ((n == 0) && (attr & FILE_ATTRIBUTE_DIRECTORY))
+	stp->st_mode = (stp->st_mode & ~S_IFMT) | S_IFDIR;
     _close(fd);
 
     return n;

--- a/src/proto/os_mswin.pro
+++ b/src/proto/os_mswin.pro
@@ -11,6 +11,7 @@ int mch_isFullName(char_u *fname);
 void slash_adjust(char_u *p);
 char_u *resolve_appexeclink(char_u *fname);
 int vim_stat(const char *name, stat_T *stp);
+int vim_lstat(const char *name, stat_T *stp);
 void mch_settmode(tmode_T tmode);
 int mch_get_shellsize(void);
 void mch_set_shellsize(void);

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -3823,12 +3823,6 @@ func Test_glob2()
 endfunc
 
 func Test_glob_symlinks()
-  " Symlinks on Windows are emulated in a number of ways, including by copying the source
-  " file over. Since we cannot detect that skip the test when running on those platforms.
-  if has('win32') && executable('uname') && system('uname -s') =~ '^MSYS\|MINGW\|CYGWIN'
-    throw 'Skipped: does not work on MinGW/Cygwin/Msys'
-  endif
-
   call writefile([], 'Xglob1')
 
   if has("win32")

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -3823,6 +3823,12 @@ func Test_glob2()
 endfunc
 
 func Test_glob_symlinks()
+  " Symlinks on Windows are emulated in a number of ways, including by copying the source
+  " file over. Since we cannot detect that skip the test when running on those platforms.
+  if has('win32') && executable('uname') && system('uname -s') =~ '^MSYS\|MINGW\|CYGWIN'
+    throw 'Skipped: does not work on MinGW/Cygwin/Msys'
+  endif
+
   call writefile([], 'Xglob1')
 
   if has("win32")

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -3822,6 +3822,29 @@ func Test_glob2()
   endif
 endfunc
 
+func Test_glob_symlinks()
+  call writefile([], 'Xglob1')
+
+  if has("win32")
+    silent !mklink XglobBad DoesNotExist
+    if v:shell_error
+      throw 'Skipped: cannot create symlinks'
+    endif
+    silent !mklink XglobOk Xglob1
+  else
+    silent !ln -s XglobBad DoesNotExist
+    silent !ln -s XglobOk Xglob1
+  endif
+
+  " The broken symlink is excluded when alllinks is false.
+  call assert_equal(['Xglob1', 'XglobBad', 'XglobOk'], sort(glob('Xglob*', 0, 1, 1)))
+  call assert_equal(['Xglob1', 'XglobOk'], sort(glob('Xglob*', 0, 1, 0)))
+
+  call delete('Xglob1')
+  call delete('XglobBad')
+  call delete('XglobOk')
+endfunc
+
 " Test for browse()
 func Test_browse()
   CheckFeature browse

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -3832,8 +3832,8 @@ func Test_glob_symlinks()
     endif
     silent !mklink XglobOk Xglob1
   else
-    silent !ln -s XglobBad DoesNotExist
-    silent !ln -s XglobOk Xglob1
+    silent !ln -s DoesNotExist XglobBad
+    silent !ln -s Xglob1 XglobOk
   endif
 
   " The broken symlink is excluded when alllinks is false.


### PR DESCRIPTION
lstat() differs from stat() in how it handles symbolic links, the former
doesn't resolve the symlink while the latter does so.

Implement a simple yet effective fallback using Win32 APIs.

Fixes https://github.com/vim/vim/issues/14933