### PR TITLE
runtime(html): bump length of character references

### DIFF
--- a/runtime/syntax/html.vim
+++ b/runtime/syntax/html.vim
@@ -191,7 +191,7 @@ syn keyword htmlArg contained step title translate typemustmatch
 syn match   htmlArg contained "\<data-\h\%(\w\|[-.]\)*\%(\_s*=\)\@="
 
 " special characters
-syn match htmlSpecialChar "&#\=[0-9A-Za-z]\{1,8};"
+syn match htmlSpecialChar "&#\=[0-9A-Za-z]\{1,32};"
 
 " Comments (the real ones or the old netscape ones)
 if exists("html_wrong_comments")


### PR DESCRIPTION
This allows handling longer references such as `&CounterClockwiseContourIntegral;`.