### PR TITLE
Fix typo in several documents

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -3591,7 +3591,7 @@ get({dict}, {key} [, {default}])
 		Preferably used as a |method|: >
 			mydict->get(key)
 <
-		Return type: any, depending on {list}
+		Return type: any, depending on {dict}
 
 get({func}, {what})
 		Get item {what} from Funcref {func}.  Possible values for
@@ -3755,7 +3755,7 @@ getcellwidths()						*getcellwidths()*
 		by |setcellwidths()|.  The format is equal to the argument of
 		|setcellwidths()|.  If no character ranges have their cell
 		widths overridden, an empty List is returned.
-<
+
 		Return type: list<any>
 
 
@@ -4567,7 +4567,7 @@ getqflist([{what}])					*getqflist()*
 			vcol	|TRUE|: "col" is visual column
 				|FALSE|: "col" is byte index
 			nr	error number
-			pattern	search list<number>
+			pattern	search pattern used to locate the error
 			text	description of the error
 			type	type of the error, 'E', '1', etc.
 			valid	|TRUE|: recognized error message

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1915,7 +1915,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 			feature}
 	A template for a comment.  The "%s" in the value is replaced with the
 	comment text, and should be padded with a space when possible.
-	Currently used to add markers for folding, see |fold-marker| also
+	Currently used to add markers for folding, see |fold-marker|.  Also
 	commonly used by commenting plugins (e.g. |comment-install|).
 
 			*'compatible'* *'cp'* *'nocompatible'* *'nocp'*

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -5685,9 +5685,9 @@ PmenuSbar	Popup menu: Scrollbar.
 							*hl-PmenuThumb*
 PmenuThumb	Popup menu: Thumb of the scrollbar.
 							*hl-PmenuMatch*
-PmenuMatch	Popup menu: Matched text in normal item
+PmenuMatch	Popup menu: Matched text in normal item.
 							*hl-PmenuMatchSel*
-PmenuMatchSel	Popup menu: Matched text in selected item
+PmenuMatchSel	Popup menu: Matched text in selected item.
 							*hl-PopupNotification*
 PopupNotification
 		Popup window created with |popup_notification()|.  If not

--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -648,7 +648,7 @@ term_getjob({buf})					*term_getjob()*
 		Get the Job associated with terminal window {buf}.
 		{buf} is used as with |term_getsize()|.
 		Returns |v:null| when there is no job. In Vim9 script, return
-		null_job when there is no job.
+		|null_job| when there is no job.
 
 		Can also be used as a |method|: >
 			GetBufnr()->term_getjob()

--- a/runtime/doc/testing.txt
+++ b/runtime/doc/testing.txt
@@ -483,7 +483,7 @@ test_unknown()						*test_unknown()*
 test_void()						*test_void()*
 		Return a value with void type. Only useful for testing.
 
-		Return type: unknown
+		Return type: void
 
 ==============================================================================
 3. Assert functions				*assert-functions-details*
@@ -499,6 +499,7 @@ assert_beeps({cmd})					*assert_beeps()*
 			GetCmd()->assert_beeps()
 <
 		Return type: |Number|
+
 							*assert_equal()*
 assert_equal({expected}, {actual} [, {msg}])
 		When {expected} and {actual} are not equal an error message is
@@ -522,7 +523,7 @@ assert_equal({expected}, {actual} [, {msg}])
 <
 		Return type: |Number|
 
-<							*assert_equalfile()*
+							*assert_equalfile()*
 assert_equalfile({fname-one}, {fname-two} [, {msg}])
 		When the files {fname-one} and {fname-two} do not contain
 		exactly the same text an error message is added to |v:errors|.
@@ -550,6 +551,7 @@ assert_exception({error} [, {msg}])			*assert_exception()*
 			endtry
 <
 		Return type: |Number|
+
 							*assert_fails()*
 assert_fails({cmd} [, {error} [, {msg} [, {lnum} [, {context}]]]])
 		Run {cmd} and add an error message to |v:errors| if it does

--- a/runtime/doc/version9.txt
+++ b/runtime/doc/version9.txt
@@ -31694,7 +31694,7 @@ The release 9.1 is dedicated to Vim's Benevolent dictator for life
 This release has hundreds of bug fixes, there are a few new features and there
 are many minor improvements.
 
-Vim9 classes
+Vim9 classes ~
 ------------
 Support for classes and objects in a Vim9 script are added.  This is described
 in |vim9-class|.  The following features are supported:
@@ -41597,7 +41597,7 @@ Highlighting: ~
 
 |hl-MsgArea|		highlighting of the Command-line and messages area
 |hl-PmenuMatch|		Popup menu: highlighting of matched text
-|hl-PmenuMatchSel|     	Popup menu: highlighting of matched text in selected
+|hl-PmenuMatchSel|	Popup menu: highlighting of matched text in selected
 			line
 
 Commands: ~

--- a/runtime/syntax/generator/vim.vim.base
+++ b/runtime/syntax/generator/vim.vim.base
@@ -874,12 +874,12 @@ endif
 " Allows users to specify the type of embedded script highlighting
 " they want:  (perl/python/ruby/tcl support)
 "   g:vimsyn_embed == 0   : don't embed any scripts
-"   g:vimsyn_embed =~# 'l' : embed lua      (but only if vim supports it)
-"   g:vimsyn_embed =~# 'm' : embed mzscheme (but only if vim supports it)
-"   g:vimsyn_embed =~# 'p' : embed perl     (but only if vim supports it)
-"   g:vimsyn_embed =~# 'P' : embed python   (but only if vim supports it)
-"   g:vimsyn_embed =~# 'r' : embed ruby     (but only if vim supports it)
-"   g:vimsyn_embed =~# 't' : embed tcl      (but only if vim supports it)
+"   g:vimsyn_embed =~# 'l' : embed Lua      (but only if vim supports it)
+"   g:vimsyn_embed =~# 'm' : embed MzScheme (but only if vim supports it)
+"   g:vimsyn_embed =~# 'p' : embed Perl     (but only if vim supports it)
+"   g:vimsyn_embed =~# 'P' : embed Python   (but only if vim supports it)
+"   g:vimsyn_embed =~# 'r' : embed Ruby     (but only if vim supports it)
+"   g:vimsyn_embed =~# 't' : embed Tcl      (but only if vim supports it)
 if !exists("g:vimsyn_embed")
  let g:vimsyn_embed= "lmpPr"
 endif


### PR DESCRIPTION
Also includes this fix.
https://github.com/vim/vim/commit/5674c9a7de503d5e798055a5e1115343ff885221#r143214961