### PR TITLE
getcmdcompltype() interferes with cmdline completion

### DIFF
--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -4176,6 +4176,7 @@ get_cmdline_completion(void)
 {
     cmdline_info_T *p;
     char_u	*buffer;
+    int		xp_context;
 
     if (cmdline_star > 0)
 	return NULL;
@@ -4184,15 +4185,21 @@ get_cmdline_completion(void)
     if (p == NULL || p->xpc == NULL)
 	return NULL;
 
-    set_expand_context(p->xpc);
-    if (p->xpc->xp_context == EXPAND_UNSUCCESSFUL)
+    xp_context = p->xpc->xp_context;
+    if (xp_context == EXPAND_NOTHING)
+    {
+	set_expand_context(p->xpc);
+	xp_context = p->xpc->xp_context;
+	p->xpc->xp_context = EXPAND_NOTHING;
+    }
+    if (xp_context == EXPAND_UNSUCCESSFUL)
 	return NULL;
 
-    char_u *cmd_compl = cmdcomplete_type_to_str(p->xpc->xp_context);
+    char_u *cmd_compl = cmdcomplete_type_to_str(xp_context);
     if (cmd_compl == NULL)
 	return NULL;
 
-    if (p->xpc->xp_context == EXPAND_USER_LIST || p->xpc->xp_context == EXPAND_USER_DEFINED)
+    if (xp_context == EXPAND_USER_LIST || xp_context == EXPAND_USER_DEFINED)
     {
 	buffer = alloc(STRLEN(cmd_compl) + STRLEN(p->xpc->xp_arg) + 2);
 	if (buffer == NULL)

--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -3612,7 +3612,7 @@ func Test_cmdline_complete_bang_cmd_argument()
 endfunc
 
 func Call_cmd_funcs()
-  return string([getcmdpos(), getcmdscreenpos(), getcmdcompltype()])
+  return [getcmdpos(), getcmdscreenpos(), getcmdcompltype()]
 endfunc
 
 func Test_screenpos_and_completion()
@@ -3620,13 +3620,24 @@ func Test_screenpos_and_completion()
   call assert_equal(0, getcmdscreenpos())
   call assert_equal('', getcmdcompltype())
 
-  cnoremap <expr> <F2> string([getcmdpos(), getcmdscreenpos(), getcmdcompltype()])
+  cnoremap <expr> <F2> string(Call_cmd_funcs())
   call feedkeys(":let a\<F2>\<C-B>\"\<CR>", "xt")
   call assert_equal("\"let a[6, 7, 'var']", @:)
   call feedkeys(":quit \<F2>\<C-B>\"\<CR>", "xt")
   call assert_equal("\"quit [6, 7, '']", @:)
   call feedkeys(":nosuchcommand \<F2>\<C-B>\"\<CR>", "xt")
   call assert_equal("\"nosuchcommand [15, 16, '']", @:)
+
+  " Check that getcmdcompltype() doesn't interfere with cmdline completion.
+  let g:results = []
+  cnoremap <F2> <Cmd>let g:results += [[getcmdline()] + Call_cmd_funcs()]<CR>
+  call feedkeys(":sign un\<Tab>\<F2>\<Tab>\<F2>\<Tab>\<F2>\<C-C>", "xt")
+  call assert_equal([
+        \ ['sign undefine', 14, 15, 'sign'],
+        \ ['sign unplace', 13, 14, 'sign'],
+        \ ['sign un', 8, 9, 'sign']], g:results)
+
+  unlet g:results
   cunmap <F2>
 endfunc
 


### PR DESCRIPTION
Problem:  getcmdcompltype() interferes with cmdline completion.
Solution: Don't set expand context when it's already set.
