### PR TITLE
fix(filetype): improve `htmldjango` filetype detection

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -410,7 +410,7 @@ export def FThtml()
       setf xhtml
       return
     endif
-    if getline(n) =~ '{%\s*\(extends\|block\|load\)\>\|{#\s\+'
+    if getline(n) =~ '{%\s*\(autoescape\|block\|comment\|csrf_token\|cycle\|debug\|extends\|filter\|firstof\|for\|if\|ifchanged\|include\|load\|lorem\|now\|query_string\|regroup\|resetcycle\|spaceless\|templatetag\|url\|verbatim\|widthratio\|with\)\>\|{#\s\+'
       setf htmldjango
       return
     endif

--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -405,7 +405,7 @@ enddef
 # Distinguish between HTML, XHTML and Django
 export def FThtml()
   var n = 1
-  while n < 10 && n <= line("$")
+  while n < 40 && n <= line("$")
     if getline(n) =~ '\<DTD\s\+XHTML\s'
       setf xhtml
       return


### PR DESCRIPTION
I found `htmldjango` filetype detection regex is only match small number of Django tags which results in high false negative. This PR adds the rest of the tags based on https://docs.djangoproject.com/en/5.0/ref/templates/builtins/#built-in-tag-reference.

In addition, the supplied lines for matching is too few and might result in high false negative too. Increasing it to 40 lines should reduce the false negative. (I picked 40 as I think it is close to the most common height of terminal in a 1080p screen.)

Let me know if you have any suggestion :D

Related PR on Neovim: https://github.com/neovim/neovim/pull/29377