### PR TITLE
win32: Clean up old codes

### DIFF
--- a/src/Make_mvc.mak
+++ b/src/Make_mvc.mak
@@ -1638,7 +1638,6 @@ $(OUTDIR)/if_tcl.obj: $(OUTDIR) if_tcl.c  $(INCL)
 	$(CC) $(CFLAGS_OUTDIR) $(TCL_INC) if_tcl.c
 
 $(OUTDIR)/iscygpty.obj:	$(OUTDIR) iscygpty.c $(CUI_INCL)
-	$(CC) $(CFLAGS_OUTDIR) iscygpty.c
 
 $(OUTDIR)/job.obj:	$(OUTDIR) job.c $(INCL)
 

--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -274,13 +274,9 @@ gui_mch_set_rendering_options(char_u *s)
 
 // cproto fails on missing include files
 #ifndef PROTO
-
-# ifndef __MINGW32__
-#  include <shellapi.h>
-# endif
+# include <shellapi.h>
 # include <commctrl.h>
 # include <windowsx.h>
-
 #endif // PROTO
 
 #ifdef FEAT_MENU

--- a/src/mbyte.c
+++ b/src/mbyte.c
@@ -102,7 +102,7 @@
 # define WINBYTE BYTE
 #endif
 
-#if (defined(MSWIN) || defined(WIN32UNIX)) && !defined(__MINGW32__)
+#if defined(MSWIN) || defined(WIN32UNIX)
 # include <winnls.h>
 #endif
 

--- a/src/os_mswin.c
+++ b/src/os_mswin.c
@@ -18,20 +18,12 @@
 #include <sys/types.h>
 #include <signal.h>
 #include <limits.h>
+
+// cproto fails on missing include files
 #ifndef PROTO
 # include <process.h>
-#endif
-
-#undef chdir
-#ifdef __GNUC__
-# ifndef __MINGW32__
-#  include <dirent.h>
-# endif
-#else
 # include <direct.h>
-#endif
 
-#ifndef PROTO
 # if !defined(FEAT_GUI_MSWIN)
 #  include <shellapi.h>
 # endif
@@ -41,36 +33,7 @@
 #  include <winspool.h>
 #  include <commdlg.h>
 # endif
-
 #endif // PROTO
-
-#ifdef __MINGW32__
-# ifndef FROM_LEFT_1ST_BUTTON_PRESSED
-#  define FROM_LEFT_1ST_BUTTON_PRESSED    0x0001
-# endif
-# ifndef RIGHTMOST_BUTTON_PRESSED
-#  define RIGHTMOST_BUTTON_PRESSED	  0x0002
-# endif
-# ifndef FROM_LEFT_2ND_BUTTON_PRESSED
-#  define FROM_LEFT_2ND_BUTTON_PRESSED    0x0004
-# endif
-# ifndef FROM_LEFT_3RD_BUTTON_PRESSED
-#  define FROM_LEFT_3RD_BUTTON_PRESSED    0x0008
-# endif
-# ifndef FROM_LEFT_4TH_BUTTON_PRESSED
-#  define FROM_LEFT_4TH_BUTTON_PRESSED    0x0010
-# endif
-
-/*
- * EventFlags
- */
-# ifndef MOUSE_MOVED
-#  define MOUSE_MOVED   0x0001
-# endif
-# ifndef DOUBLE_CLICK
-#  define DOUBLE_CLICK  0x0002
-# endif
-#endif
 
 /*
  * When generating prototypes for Win32 on Unix, these lines make the syntax
@@ -142,37 +105,6 @@ static HWND s_hwnd = 0;	    // console window handle, set by GetConsoleHwnd()
 
 #ifdef FEAT_JOB_CHANNEL
 int WSInitialized = FALSE; // WinSock is initialized
-#endif
-
-// Don't generate prototypes here, because some systems do have these
-// functions.
-#if defined(__GNUC__) && !defined(PROTO)
-# ifndef __MINGW32__
-int _stricoll(char *a, char *b)
-{
-    // the ANSI-ish correct way is to use strxfrm():
-    char a_buff[512], b_buff[512];  // file names, so this is enough on Win32
-    strxfrm(a_buff, a, 512);
-    strxfrm(b_buff, b, 512);
-    return strcoll(a_buff, b_buff);
-}
-
-char * _fullpath(char *buf, char *fname, int len)
-{
-    LPTSTR toss;
-
-    return (char *)GetFullPathName(fname, len, buf, &toss);
-}
-# endif
-
-# if !defined(__MINGW32__) || (__GNUC__ < 4)
-int _chdrive(int drive)
-{
-    char temp [3] = "-:";
-    temp[0] = drive + 'A' - 1;
-    return !SetCurrentDirectory(temp);
-}
-# endif
 #endif
 
 

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -34,52 +34,14 @@
 #ifndef PROTO
 # include <process.h>
 # include <winternl.h>
-#endif
-
-#undef chdir
-#ifdef __GNUC__
-# ifndef __MINGW32__
-#  include <dirent.h>
-# endif
-#else
 # include <direct.h>
-#endif
 
-#ifndef PROTO
 # if !defined(FEAT_GUI_MSWIN)
 #  include <shellapi.h>
 # endif
-#endif
 
-#ifdef FEAT_JOB_CHANNEL
-# include <tlhelp32.h>
-#endif
-
-#ifdef __MINGW32__
-# ifndef FROM_LEFT_1ST_BUTTON_PRESSED
-#  define FROM_LEFT_1ST_BUTTON_PRESSED    0x0001
-# endif
-# ifndef RIGHTMOST_BUTTON_PRESSED
-#  define RIGHTMOST_BUTTON_PRESSED	  0x0002
-# endif
-# ifndef FROM_LEFT_2ND_BUTTON_PRESSED
-#  define FROM_LEFT_2ND_BUTTON_PRESSED    0x0004
-# endif
-# ifndef FROM_LEFT_3RD_BUTTON_PRESSED
-#  define FROM_LEFT_3RD_BUTTON_PRESSED    0x0008
-# endif
-# ifndef FROM_LEFT_4TH_BUTTON_PRESSED
-#  define FROM_LEFT_4TH_BUTTON_PRESSED    0x0010
-# endif
-
-/*
- * EventFlags
- */
-# ifndef MOUSE_MOVED
-#  define MOUSE_MOVED   0x0001
-# endif
-# ifndef DOUBLE_CLICK
-#  define DOUBLE_CLICK  0x0002
+# ifdef FEAT_JOB_CHANNEL
+#  include <tlhelp32.h>
 # endif
 #endif
 
@@ -2761,12 +2723,6 @@ theend:
     return 0;
 #endif // FEAT_GUI_MSWIN
 }
-
-#ifndef PROTO
-# ifndef __MINGW32__
-#  include <shellapi.h>	// required for FindExecutable()
-# endif
-#endif
 
 /*
  * Return TRUE if "name" is an executable file, FALSE if not or it doesn't exist.
@@ -5529,11 +5485,7 @@ mch_call_shell(
      * CTRL-C, Ctrl-Break or illegal instruction  might otherwise kill us.
      */
     mch_signal(SIGINT, SIG_IGN);
-#if defined(__GNUC__) && !defined(__MINGW32__)
-    mch_signal(SIGKILL, SIG_IGN);
-#else
     mch_signal(SIGBREAK, SIG_IGN);
-#endif
     mch_signal(SIGILL, SIG_IGN);
     mch_signal(SIGFPE, SIG_IGN);
     mch_signal(SIGSEGV, SIG_IGN);
@@ -5768,11 +5720,7 @@ mch_call_shell(
     resettitle();
 
     mch_signal(SIGINT, SIG_DFL);
-#if defined(__GNUC__) && !defined(__MINGW32__)
-    mch_signal(SIGKILL, SIG_DFL);
-#else
     mch_signal(SIGBREAK, SIG_DFL);
-#endif
     mch_signal(SIGILL, SIG_DFL);
     mch_signal(SIGFPE, SIG_DFL);
     mch_signal(SIGSEGV, SIG_DFL);


### PR DESCRIPTION
* Remove very old codes for Cygwin version of GCC.  
  Nowadays Cygwin GCC cannot be used for building Win32 Vim. (The `-mno-cygwin` option was removed in Cygwin GCC4.)
* Remove old codes for old versions of MinGW.  
  Remove `__MINGW32__` as much as possible.
* Adjust makefile.