### PR TITLE
:help execute() incorrectly specifies the return type

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -2580,7 +2580,7 @@ execute({command} [, {silent}])					*execute()*
 		Can also be used as a |method|: >
 			GetCommand()->execute()
 <
-		Return type: |Number|
+		Return type: |String|
 
 
 exepath({expr})						*exepath()*


### PR DESCRIPTION
The description clearly explains that this function returns a string.  I think the 'Number' here is a copy/paste error.