### PR TITLE
Reinforced mapping tests & simplified mapping restore logic.  

### DIFF
--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -1224,32 +1224,24 @@ def DeleteCommands()
   delcommand Winbar
 
 
-  if !empty(saved_K_map) && saved_K_map.buffer
-    # pass
-  elseif !empty(saved_K_map) && !saved_K_map.buffer
-    nunmap K
+  if !empty(saved_K_map) && !saved_K_map.buffer
     mapset(saved_K_map)
   elseif empty(saved_K_map)
     silent! nunmap K
   endif
 
-  if !empty(saved_plus_map) && saved_plus_map.buffer
-    # pass
-  elseif !empty(saved_plus_map) && !saved_plus_map.buffer
-    nunmap +
+  if !empty(saved_plus_map) && !saved_plus_map.buffer
     mapset(saved_plus_map)
   elseif empty(saved_plus_map)
     silent! nunmap +
   endif
 
-  if !empty(saved_minus_map) && saved_minus_map.buffer
-    # pass
-  elseif !empty(saved_minus_map) && !saved_minus_map.buffer
-    nunmap -
+  if !empty(saved_minus_map) && !saved_minus_map.buffer
     mapset(saved_minus_map)
   elseif empty(saved_minus_map)
     silent! nunmap -
   endif
+
 
   if has('menu')
     # Remove the WinBar entries from all windows where it was added.

--- a/src/testdir/test_termdebug.vim
+++ b/src/testdir/test_termdebug.vim
@@ -278,9 +278,20 @@ func Test_termdebug_mapping()
   call assert_equal(':echom "K"<cr>', maparg('K', 'n', 0, 1).rhs)
 
   %bw!
+
+  " -- Test that local-buffer mappings are restored in the correct buffers --
+  " local mappings for foo
+  file foo
   nnoremap <buffer> K :echom "bK"<cr>
   nnoremap <buffer> - :echom "b-"<cr>
   nnoremap <buffer> + :echom "b+"<cr>
+
+  " no mappings for 'bar'
+  enew
+  file bar
+
+  " Start termdebug from foo
+  buffer foo
   Termdebug
   call WaitForAssert({-> assert_equal(3, winnr('$'))})
   wincmd b
@@ -288,10 +299,33 @@ func Test_termdebug_mapping()
   call assert_true(maparg('-', 'n', 0, 1).buffer)
   call assert_true(maparg('+', 'n', 0, 1).buffer)
   call assert_equal(maparg('K', 'n', 0, 1).rhs, ':echom "bK"<cr>')
+
+  Source
+  buffer bar
+  call assert_false(maparg('K', 'n', 0, 1)->empty())
+  call assert_false(maparg('-', 'n', 0, 1)->empty())
+  call assert_false(maparg('+', 'n', 0, 1)->empty())
+  call assert_true(maparg('K', 'n', 0, 1).buffer->empty())
+  call assert_true(maparg('-', 'n', 0, 1).buffer->empty())
+  call assert_true(maparg('+', 'n', 0, 1).buffer->empty())
   wincmd t
   quit!
   redraw!
   call WaitForAssert({-> assert_equal(1, winnr('$'))})
+
+  " Termdebug session ended. Buffer 'bar' shall have no mappings
+  call assert_true(bufname() ==# 'bar')
+  call assert_false(maparg('K', 'n', 0, 1)->empty())
+  call assert_false(maparg('-', 'n', 0, 1)->empty())
+  call assert_false(maparg('+', 'n', 0, 1)->empty())
+  call assert_true(maparg('K', 'n', 0, 1).buffer->empty())
+  call assert_true(maparg('-', 'n', 0, 1).buffer->empty())
+  call assert_true(maparg('+', 'n', 0, 1).buffer->empty())
+
+  " Buffer 'foo' shall have the same mapping as before running the termdebug
+  " session
+  buffer foo
+  call assert_true(bufname() ==# 'foo')
   call assert_true(maparg('K', 'n', 0, 1).buffer)
   call assert_true(maparg('-', 'n', 0, 1).buffer)
   call assert_true(maparg('+', 'n', 0, 1).buffer)


### PR DESCRIPTION
* Tests now check that local-buffer mappings are restored in the correct buffers. 
* Mapping restoring at termdebug shutdown logic simplified.

EDIT; I am thinking that an even leaner approach would be to move some logic inside the `Init` function to clean up a bit `InstallCommands()` and `DeleteCommands()` (think for example to the logic to set the variable `map` inside `InstallCommands()`). It needs more thinking.... 