### PR TITLE
Problem: inner-tag textobject confused about > in attribute

### DIFF
--- a/src/testdir/test_textobjects.vim
+++ b/src/testdir/test_textobjects.vim
@@ -201,6 +201,18 @@ func Test_string_html_objects()
     normal! 2k0vaty
     call assert_equal("<div><div\nattr=\"attr\"\n></div></div>", @", e)
 
+    " tag, that includes a > in some attribute
+    let t = "<div attr=\"attr >> foo >> bar \">Hello</div>"
+    $put =t
+    normal! fHyit
+    call assert_equal("Hello", @", e)
+
+    " tag, that includes a > in some attribute
+    let t = "<div attr='attr >> foo >> bar '>Hello 123</div>"
+    $put =t
+    normal! fHyit
+    call assert_equal("Hello 123", @", e)
+
     set quoteescape&
 
     " this was going beyond the end of the line

--- a/src/textobject.c
+++ b/src/textobject.c
@@ -1426,15 +1426,22 @@ again:
 
     if (!do_include)
     {
-	// Exclude the start tag.
+	// Exclude the start tag,
+	// but skip over '>' if it appears in quotes
+	int in_quotes = FALSE;
 	curwin->w_cursor = start_pos;
 	while (inc_cursor() >= 0)
-	    if (*ml_get_cursor() == '>')
+	{
+	    p = ml_get_cursor();
+	    if (*p == '>' && !in_quotes)
 	    {
 		inc_cursor();
 		start_pos = curwin->w_cursor;
 		break;
 	    }
+	    else if (*p == '"' || *p == '\'')
+		in_quotes = !in_quotes;
+	}
 	curwin->w_cursor = end_pos;
 
 	// If we are in Visual mode and now have the same text as before set


### PR DESCRIPTION
Problem:  inner-tag textobject confused about > in attribute
Solution: Skip over quoted '>' when determining the start position

closes: #15043