### PR TITLE
runtime(gomod): add commentstring for go module file

### DIFF
--- a/.github/MAINTAINERS
+++ b/.github/MAINTAINERS
@@ -152,6 +152,7 @@ runtime/ftplugin/gitsendemail.vim	@tpope
 runtime/ftplugin/graphql.vim	@ribru17
 runtime/ftplugin/gyp.vim		@ObserverOfTime
 runtime/ftplugin/go.vim			@dbarnett
+runtime/ftplugin/gomod.vim		@yu-yk
 runtime/ftplugin/gprof.vim		@dpelle
 runtime/ftplugin/haml.vim		@tpope
 runtime/ftplugin/hare.vim		@selenebun

--- a/runtime/ftplugin/gomod.vim
+++ b/runtime/ftplugin/gomod.vim
@@ -1,0 +1,14 @@
+" Vim filetype plugin file
+" Language:    go module file
+" Maintainer:  YU YUK KUEN <yukkuen.yu719@gmail.com>
+" Last Change: 2024-06-21
+
+if exists('b:did_ftplugin')
+  finish
+endif
+let b:did_ftplugin = 1
+
+setlocal formatoptions-=t formatoptions-=c
+setlocal commentstring=//\ %s
+
+let b:undo_ftplugin = 'setl fo< cms<'


### PR DESCRIPTION
add commentstring for go module file according to the go documentation.
`Comments start with // and run to the end of a line. /* */ comments are not allowed.`
ref: https://go.dev/ref/mod