### PR TITLE
CursorMovedC triggered at wrong pos when using setcmdpos()

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -1,4 +1,4 @@
-*autocmd.txt*   For Vim version 9.1.  Last change: 2024 Jun 20
+*autocmd.txt*   For Vim version 9.1.  Last change: 2024 Jun 21
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -751,7 +751,8 @@ CursorMoved			After the cursor was moved in Normal or Visual
 				that is slow.
 							*CursorMovedC*
 CursorMovedC			After the cursor was moved in the command
-				line. Be careful not to mess up the
+				line while the text in the command line hasn't
+				changed.  Be careful not to mess up the
 				command line, it may cause Vim to lock up.
 				<afile> is set to a single character,
 				indicating the type of command-line.

--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -1586,7 +1586,7 @@ getcmdline_int(
     int		res;
     int		save_msg_scroll = msg_scroll;
     int		save_State = State;	// remember State when called
-    int		save_cmdspos = ccline.cmdspos;
+    int		prev_cmdpos = -1;
     int		some_key_typed = FALSE;	// one of the keys was typed
     // mouse drag and release events are ignored, unless they are
     // preceded with a mouse down event
@@ -2474,16 +2474,19 @@ getcmdline_int(
  * (Sorry for the goto's, I know it is ugly).
  */
 cmdline_not_changed:
-	 // Trigger CursorMovedC autocommands.
-	 if (ccline.cmdspos != save_cmdspos)
+	// Trigger CursorMovedC autocommands.
+	if (ccline.cmdpos != prev_cmdpos)
+	{
 	    trigger_cmd_autocmd(cmdline_type, EVENT_CURSORMOVEDC);
-
+	    prev_cmdpos = ccline.cmdpos;
+	}
 #ifdef FEAT_SEARCH_EXTRA
 	if (!is_state.incsearch_postponed)
 	    continue;
 #endif
 
 cmdline_changed:
+	prev_cmdpos = ccline.cmdpos;
 #ifdef FEAT_SEARCH_EXTRA
 	// If the window changed incremental search state is not valid.
 	if (is_state.winid != curwin->w_id)
@@ -4320,9 +4323,6 @@ set_cmdline_pos(
 	new_cmdpos = 0;
     else
 	new_cmdpos = pos;
-
-    // Trigger CursorMovedC autocommands.
-    trigger_cmd_autocmd(get_cmdline_type(), EVENT_CURSORMOVEDC);
 
     return 0;
 }

--- a/src/testdir/test_autocmd.vim
+++ b/src/testdir/test_autocmd.vim
@@ -2097,20 +2097,28 @@ func Test_Cmdline()
   au! CmdlineLeave
   let &shellslash = save_shellslash
 
-  au! CursorMovedC : let g:pos = getcmdpos()
-  let g:pos = 0
-  call feedkeys(":hello\<Left>\<ESC>", 'xt')
-  call assert_equal(5, g:pos)
-  call feedkeys(":12345678\<C-R>=setcmdpos(3)\<CR>\<ESC>", 'xt')
-  call assert_equal(3, g:pos)
+  au! CursorMovedC : let g:pos += [getcmdpos()]
+  let g:pos = []
+  call feedkeys(":hello\<Left>\<C-R>=''\<CR>\<Left>\<Right>\<Esc>", 'xt')
+  call assert_equal([5, 4, 5], g:pos)
+  let g:pos = []
+  call feedkeys(":12345678\<C-R>=setcmdpos(3)??''\<CR>\<Esc>", 'xt')
+  call assert_equal([3], g:pos)
+  let g:pos = []
+  call feedkeys(":12345678\<C-R>=setcmdpos(3)??''\<CR>\<Left>\<Esc>", 'xt')
+  call assert_equal([3, 2], g:pos)
   au! CursorMovedC
 
-  " CursorMovedC changes the cursor position.
-  au! CursorMovedC : let g:pos = getcmdpos() | call setcmdpos(getcmdpos()-1)
-  let g:pos = 0
-  call feedkeys(":hello\<Left>\<ESC>", 'xt')
-  call assert_equal(5, g:pos)
+  " setcmdpos() is no-op inside an autocommand
+  au! CursorMovedC : let g:pos += [getcmdpos()] | call setcmdpos(1)
+  let g:pos = []
+  call feedkeys(":hello\<Left>\<Left>\<Esc>", 'xt')
+  call assert_equal([5, 4], g:pos)
   au! CursorMovedC
+
+  unlet g:entered
+  unlet g:left
+  unlet g:pos
 endfunc
 
 " Test for BufWritePre autocommand that deletes or unloads the buffer.


### PR DESCRIPTION
Problem:  CursorMovedC triggered at wrong pos when using setcmdpos().
Solution: Remove the premature triggering.  Also don't trigger when
          cursor didn't move.
