### PR TITLE
Mode message for spell completion doesn't match allowed keys

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -58,7 +58,7 @@ static char *ctrl_x_msgs[] =
     N_(" Command-line completion (^V^N^P)"),
     N_(" User defined completion (^U^N^P)"),
     N_(" Omni completion (^O^N^P)"),
-    N_(" Spelling suggestion (s^N^P)"),
+    N_(" Spelling suggestion (^S^N^P)"),
     N_(" Keyword Local completion (^N^P)"),
     NULL,   // CTRL_X_EVAL doesn't use msg.
     N_(" Command-line completion (^V^N^P)"),

--- a/src/testdir/test_spell.vim
+++ b/src/testdir/test_spell.vim
@@ -5,6 +5,7 @@ source check.vim
 CheckFeature spell
 
 source screendump.vim
+source view_util.vim
 
 func TearDown()
   set nospell
@@ -298,6 +299,20 @@ func Test_compl_with_CTRL_X_CTRL_K_using_spell()
 
   bwipe!
   set spell& spelllang& dictionary& ignorecase&
+endfunc
+
+func Test_compl_with_CTRL_X_s()
+  new
+  set spell spelllang=en_us showmode
+  inoremap <buffer><F2> <Cmd>let g:msg = Screenline(&lines)<CR>
+
+  call feedkeys("STheatre\<C-X>s\<F2>\<C-Y>\<Esc>", 'tx')
+  call assert_equal(['Theater'], getline(1, '$'))
+  call assert_match('(^S^N^P)', g:msg)
+
+  bwipe!
+  set spell& spelllang& showmode&
+  unlet g:msg
 endfunc
 
 func Test_spellrepall()


### PR DESCRIPTION
Problem:  Mode message for spell completion doesn't match allowed keys.
Solution: Use "^S" instead of "s".

fixes: neovim/neovim#29431

This matches the code in vim_is_ctrl_x_key():

	case CTRL_X_SPELL:
	    return (c == Ctrl_S || c == Ctrl_P || c == Ctrl_N);
