### PR TITLE
Behavior of CursorMovedC is strange

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -1,4 +1,4 @@
-*autocmd.txt*   For Vim version 9.1.  Last change: 2024 Jun 21
+*autocmd.txt*   For Vim version 9.1.  Last change: 2024 Jul 07
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -751,9 +751,8 @@ CursorMoved			After the cursor was moved in Normal or Visual
 				that is slow.
 							*CursorMovedC*
 CursorMovedC			After the cursor was moved in the command
-				line while the text in the command line hasn't
-				changed.  Be careful not to mess up the
-				command line, it may cause Vim to lock up.
+				line.  Be careful not to mess up the command
+				line, it may cause Vim to lock up.
 				<afile> is set to a single character,
 				indicating the type of command-line.
 				|cmdwin-char|

--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -2480,13 +2480,13 @@ cmdline_not_changed:
 	    trigger_cmd_autocmd(cmdline_type, EVENT_CURSORMOVEDC);
 	    prev_cmdpos = ccline.cmdpos;
 	}
+
 #ifdef FEAT_SEARCH_EXTRA
 	if (!is_state.incsearch_postponed)
 	    continue;
 #endif
 
 cmdline_changed:
-	prev_cmdpos = ccline.cmdpos;
 #ifdef FEAT_SEARCH_EXTRA
 	// If the window changed incremental search state is not valid.
 	if (is_state.winid != curwin->w_id)
@@ -2495,6 +2495,13 @@ cmdline_changed:
 	// Trigger CmdlineChanged autocommands.
 	if (trigger_cmdlinechanged)
 	    trigger_cmd_autocmd(cmdline_type, EVENT_CMDLINECHANGED);
+
+	// Trigger CursorMovedC autocommands.
+	if (ccline.cmdpos != prev_cmdpos)
+	{
+	    trigger_cmd_autocmd(cmdline_type, EVENT_CURSORMOVEDC);
+	    prev_cmdpos = ccline.cmdpos;
+	}
 
 #ifdef FEAT_SEARCH_EXTRA
 	if (xpc.xp_context == EXPAND_NOTHING && (KeyTyped || vpeekc() == NUL))

--- a/src/testdir/test_autocmd.vim
+++ b/src/testdir/test_autocmd.vim
@@ -2099,21 +2099,30 @@ func Test_Cmdline()
 
   au! CursorMovedC : let g:pos += [getcmdpos()]
   let g:pos = []
+  call feedkeys(":foo bar baz\<C-W>\<C-W>\<C-W>\<Esc>", 'xt')
+  call assert_equal([2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 9, 5, 1], g:pos)
+  let g:pos = []
+  call feedkeys(":hello\<C-B>\<Esc>", 'xt')
+  call assert_equal([2, 3, 4, 5, 6, 1], g:pos)
+  let g:pos = []
+  call feedkeys(":hello\<C-U>\<Esc>", 'xt')
+  call assert_equal([2, 3, 4, 5, 6, 1], g:pos)
+  let g:pos = []
   call feedkeys(":hello\<Left>\<C-R>=''\<CR>\<Left>\<Right>\<Esc>", 'xt')
-  call assert_equal([5, 4, 5], g:pos)
+  call assert_equal([2, 3, 4, 5, 6, 5, 4, 5], g:pos)
   let g:pos = []
   call feedkeys(":12345678\<C-R>=setcmdpos(3)??''\<CR>\<Esc>", 'xt')
-  call assert_equal([3], g:pos)
+  call assert_equal([2, 3, 4, 5, 6, 7, 8, 9, 3], g:pos)
   let g:pos = []
   call feedkeys(":12345678\<C-R>=setcmdpos(3)??''\<CR>\<Left>\<Esc>", 'xt')
-  call assert_equal([3, 2], g:pos)
+  call assert_equal([2, 3, 4, 5, 6, 7, 8, 9, 3, 2], g:pos)
   au! CursorMovedC
 
   " setcmdpos() is no-op inside an autocommand
   au! CursorMovedC : let g:pos += [getcmdpos()] | call setcmdpos(1)
   let g:pos = []
   call feedkeys(":hello\<Left>\<Left>\<Esc>", 'xt')
-  call assert_equal([5, 4], g:pos)
+  call assert_equal([2, 3, 4, 5, 6, 5, 4], g:pos)
   au! CursorMovedC
 
   unlet g:entered


### PR DESCRIPTION
Problem:  Behavior of CursorMovedC is strange.
Solution: Also trigger when the cmdline has changed.

Fix #15069
