### PR TITLE
Avoid SEGV: for object compare, use recursive_cnt.

### DIFF
--- a/src/testdir/test_vim9_class.vim
+++ b/src/testdir/test_vim9_class.vim
@@ -10486,6 +10486,24 @@ def Test_Ref_Class_Within_Same_Class()
   v9.CheckScriptFailure(lines, 'E1347: Not a valid interface: A', 3)
 enddef
 
+" Test for comparing a class referencing itself
+def Test_Object_Compare_With_Recursive_Class_Ref()
+  var lines =<< trim END
+    vim9script
+
+    class C
+    public var nest: C
+    endclass
+
+    var o1 = C.new()
+    o1.nest = o1
+
+    var result = o1 == o1
+    assert_equal(true, result)
+  END
+  v9.CheckScriptSuccess(lines)
+enddef
+
 " Test for using a compound operator from a lambda function in an object method
 def Test_compound_op_in_objmethod_lambda()
   # Test using the "+=" operator

--- a/src/typval.c
+++ b/src/typval.c
@@ -2114,7 +2114,9 @@ tv_equal(
 	    return tv1->vval.v_class == tv2->vval.v_class;
 
 	case VAR_OBJECT:
+	    ++recursive_cnt;
 	    (void)typval_compare_object(tv1, tv2, EXPR_EQUAL, ic, &r);
+	    --recursive_cnt;
 	    return r;
 
 	case VAR_PARTIAL:


### PR DESCRIPTION
Fix the  SEGV that results from executing the following
```vim
vim9script

class C
public var nest: C
endclass

var o1 = C.new()
o1.nest = o1

var result = o1 == o1
echo result
```