### PR TITLE
Fix class downcasting

### DIFF
--- a/src/structs.h
+++ b/src/structs.h
@@ -4902,7 +4902,8 @@ typedef enum {
     WT_MEMBER,
     WT_METHOD,		// object method
     WT_METHOD_ARG,	// object method argument type
-    WT_METHOD_RETURN	// object method return type
+    WT_METHOD_RETURN,	// object method return type
+    WT_CAST,		// type cast
 } wherekind_T;
 
 // Struct used to pass the location of a type check.  Used in error messages to

--- a/src/testdir/test_vim9_class.vim
+++ b/src/testdir/test_vim9_class.vim
@@ -10762,4 +10762,21 @@ def Test_class_object_index()
   v9.CheckScriptFailure(lines, 'E689: Index not allowed after a object: a[10] = 1', 5)
 enddef
 
+def Test_class_cast()
+  var lines =<< trim END
+    vim9script
+    class A
+    endclass
+    class B extends A
+      var mylen: number
+    endclass
+    def F(o: A): number
+      return (<B>o).mylen
+    enddef
+
+    defcompile F
+  END
+  v9.CheckScriptSuccess(lines)
+enddef
+
 " vim: ts=8 sw=2 sts=2 expandtab tw=80 fdm=marker

--- a/src/testdir/test_vim9_disassemble.vim
+++ b/src/testdir/test_vim9_disassemble.vim
@@ -1761,6 +1761,74 @@ def Test_disassemble_typecast()
         instr)
 enddef
 
+def Test_disassemble_object_cast()
+  # Downcasting.
+  var lines =<< trim END
+      vim9script
+      class A
+      endclass
+      class B extends A
+        var mylen: number
+      endclass
+      def F(o: A): number
+        return (<B>o).mylen
+      enddef
+
+      g:instr = execute('disassemble F')
+  END
+  v9.CheckScriptSuccess(lines)
+  assert_match('\<SNR>\d*_F\_s*' ..
+        'return (<B>o).mylen\_s*' ..
+        '0 LOAD arg\[-1\]\_s*' ..
+        '1 CHECKTYPE object<B> stack\[-1\]\_s*' ..
+        '2 OBJ_MEMBER 0\_s*' ..
+        '3 RETURN\_s*',
+        g:instr)
+
+  # Upcasting.
+  lines =<< trim END
+      vim9script
+      class A
+        var mylen: number
+      endclass
+      class B extends A
+      endclass
+      def F(o: B): number
+        return (<A>o).mylen
+      enddef
+
+      g:instr = execute('disassemble F')
+  END
+  v9.CheckScriptSuccess(lines)
+  assert_match('\<SNR>\d*_F\_s*' ..
+        'return (<A>o).mylen\_s*' ..
+        '0 LOAD arg\[-1\]\_s*' ..
+        '1 OBJ_MEMBER 0\_s*' ..
+        '2 RETURN\_s*',
+        g:instr)
+
+  # Casting, type is not statically known.
+  lines =<< trim END
+      vim9script
+      class A
+      endclass
+      class B extends A
+      endclass
+      def F(o: any): any
+        return <A>o
+      enddef
+
+      g:instr = execute('disassemble F')
+  END
+  v9.CheckScriptSuccess(lines)
+  assert_match('\<SNR>\d*_F\_s*' ..
+        'return <A>o\_s*' ..
+        '0 LOAD arg\[-1\]\_s*' ..
+        '1 CHECKTYPE object<A> stack\[-1\]\_s*' ..
+        '2 RETURN\_s*',
+        g:instr)
+enddef
+
 def s:Computing()
   var nr = 3
   var nrres = nr + 7

--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -522,6 +522,8 @@ use_typecheck(type_T *actual, type_T *expected)
 		    (actual->tt_member == &t_void)
 					 == (expected->tt_member == &t_void))))
 	return TRUE;
+    if (actual->tt_type == VAR_OBJECT && expected->tt_type == VAR_OBJECT)
+	return TRUE;
     if ((actual->tt_type == VAR_LIST || actual->tt_type == VAR_DICT)
 				       && actual->tt_type == expected->tt_type)
 	// This takes care of a nested list or dict.

--- a/src/vim9expr.c
+++ b/src/vim9expr.c
@@ -2836,12 +2836,13 @@ compile_expr8(char_u **arg, cctx_T *cctx, ppconst_T *ppconst)
 	type_T	    *actual;
 	where_T	    where = WHERE_INIT;
 
+	where.wt_kind = WT_CAST;
 	generate_ppconst(cctx, ppconst);
 	actual = get_type_on_stack(cctx, 0);
 	if (check_type_maybe(want_type, actual, FALSE, where) != OK)
 	{
-	    if (need_type(actual, want_type, FALSE,
-					    -1, 0, cctx, FALSE, FALSE) == FAIL)
+	    if (need_type_where(actual, want_type, FALSE, -1, where, cctx, FALSE, FALSE)
+		    == FAIL)
 		return FAIL;
 	}
     }

--- a/src/vim9type.c
+++ b/src/vim9type.c
@@ -934,6 +934,7 @@ type_mismatch_where(type_T *expected, type_T *actual, where_T where)
 		semsg(_(e_argument_nr_type_mismatch_expected_str_but_got_str_in_str),
 			where.wt_index, typename1, typename2, where.wt_func_name);
 	    break;
+	case WT_CAST:
 	case WT_UNKNOWN:
 	    if (where.wt_func_name == NULL)
 		semsg(_(e_type_mismatch_expected_str_but_got_str),
@@ -1090,7 +1091,15 @@ check_type_maybe(
 		    ret = FAIL;
 	    }
 	    else if (!class_instance_of(actual->tt_class, expected->tt_class))
-		ret = FAIL;
+	    {
+		// Check if this is an up-cast, if so we'll have to check the type at
+		// runtime.
+		if (where.wt_kind == WT_CAST &&
+			class_instance_of(expected->tt_class, actual->tt_class))
+		    ret = MAYBE;
+		else
+		    ret = FAIL;
+	    }
 	}
 
 	if (ret == FAIL && give_msg)


### PR DESCRIPTION
When casting an object from one class to another the target type may be a subclass (downcast) or superclass (upcast) of the source one. Upcasts require a runtime type check to be emitted.

Fixes #13244