### PR TITLE
Fix SEGV in `object_equal()`.

### DIFF
--- a/src/testdir/test_vim9_class.vim
+++ b/src/testdir/test_vim9_class.vim
@@ -10502,6 +10502,20 @@ def Test_Object_Compare_With_Recursive_Class_Ref()
     assert_equal(true, result)
   END
   v9.CheckScriptSuccess(lines)
+
+  lines =<< trim END
+    vim9script
+
+    class C
+        public var nest: C
+    endclass
+    var o1 = C.new()
+    var o2 = C.new(C.new())
+
+    var result = o1 == o2
+    assert_equal(false, result)
+  END
+  v9.CheckScriptSuccess(lines)
 enddef
 
 " Test for using a compound operator from a lambda function in an object method

--- a/src/vim9class.c
+++ b/src/vim9class.c
@@ -3855,6 +3855,8 @@ object_equal(
 
     if (o1 == o2)
 	return TRUE;
+    if (o1 == NULL || o2 == NULL)
+	return FALSE;
 
     cl1 = o1->obj_class;
     cl2 = o2->obj_class;


### PR DESCRIPTION
@LemonBoy @yegappan Simple Fix 

@chrisbra This probably conflicts with #15082. Hopefully I'll quickly get to the one you don't check in for rebase/fixup...

(3 crashes in 2 days, got to be a new record :) ) And I've got a couple tests I'm still working on. 

If you feel like crashing vim run
```
vim9script

class C
    public var nest: C
endclass
var o1 = C.new()
var o2 = C.new(C.new())

var result = o1 == o2
```