### PR TITLE
Fix freeze on macos during big text paste

### DIFF
--- a/src/edit.c
+++ b/src/edit.c
@@ -4447,7 +4447,7 @@ bracketed_paste(paste_mode_T mode, int drop, garray_T *gap)
     for (;;)
     {
 	// When the end is not defined read everything there is.
-	if (end == NULL && vpeekc() == NUL)
+	if (vpeekc() == NUL)
 	    break;
 	do
 	    c = vgetc();


### PR DESCRIPTION
Environment
> VIM - Vi IMproved 9.0 (2022 Jun 28, compiled Apr 13 2024 12:28:29)
macOS version - arm64
Included patches: 1-2136, 2142

Problem: When I paste more than 5890 chars text via Cmd+V in insert mode vim freezes indefinitely.

Steps to reproduce:
1. Run vim on new file
2. Copy somewhere >5890 chars text
3. Enter insert mode in vim
4. Paste via Cmd+V
5. Find vim frozen and a console not responsible

P.S. Don't know how to write UT for such situation.