### PR TITLE
Correctly assign the member declared types

### DIFF
--- a/src/testdir/test_vim9_class.vim
+++ b/src/testdir/test_vim9_class.vim
@@ -10776,4 +10776,37 @@ def Test_class_object_index()
   v9.CheckScriptFailure(lines, 'E689: Index not allowed after a object: a[10] = 1', 5)
 enddef
 
+def Test_class_member_init_typecheck()
+  # Ensure the class member is assigned its declared type.
+  var lines =<< trim END
+    vim9script
+    class S
+        static var l: list<string> = []
+    endclass
+    S.l->add(123)
+  END
+  v9.CheckScriptFailure(lines, 'E1012: Type mismatch; expected string but got number', 5)
+
+  # Ensure the initializer value and the declared type match.
+  lines =<< trim END
+    vim9script
+    class S
+        var l: list<string> = [1, 2, 3]
+    endclass
+    var o = S.new()
+  END
+  v9.CheckScriptFailure(lines, 'E1382: Variable "l": type mismatch, expected list<string> but got list<number>')
+
+  # Ensure the class member is assigned its declared type.
+  lines =<< trim END
+    vim9script
+    class S
+        var l: list<string> = []
+    endclass
+    var o = S.new()
+    o.l->add(123)
+  END
+  v9.CheckScriptFailure(lines, 'E1012: Type mismatch; expected string but got number', 6)
+enddef
+
 " vim: ts=8 sw=2 sts=2 expandtab tw=80 fdm=marker

--- a/src/testdir/test_vim9_disassemble.vim
+++ b/src/testdir/test_vim9_disassemble.vim
@@ -3508,7 +3508,7 @@ def Test_disassemble_member_initializer()
   v9.CheckScriptSuccess(lines)
   # Ensure SETTYPE is emitted and that matches the declared type.
   assert_match('new\_s*' ..
-   '0 NEW A size 72\_s*' ..
+   '0 NEW A size \d\+\_s*' ..
    '1 NEWLIST size 0\_s*' ..
    '2 SETTYPE list<string>\_s*' ..
    '3 STORE_THIS 0\_s*' ..

--- a/src/testdir/test_vim9_disassemble.vim
+++ b/src/testdir/test_vim9_disassemble.vim
@@ -3496,4 +3496,26 @@ def Test_disassemble_compound_op_in_closure()
   unlet g:instr
 enddef
 
+def Test_disassemble_member_initializer()
+  var lines =<< trim END
+    vim9script
+    class A
+      var l: list<string> = []
+      var d: dict<string> = {}
+    endclass
+    g:instr = execute('disassemble A.new')
+  END
+  v9.CheckScriptSuccess(lines)
+  # Ensure SETTYPE is emitted and that matches the declared type.
+  assert_match('new\_s*' ..
+   '0 NEW A size 72\_s*' ..
+   '1 NEWLIST size 0\_s*' ..
+   '2 SETTYPE list<string>\_s*' ..
+   '3 STORE_THIS 0\_s*' ..
+   '4 NEWDICT size 0\_s*' ..
+   '5 SETTYPE dict<string>\_s*' ..
+   '6 STORE_THIS 1', g:instr)
+  unlet g:instr
+enddef
+
 " vim: ts=8 sw=2 sts=2 expandtab tw=80 fdm=marker

--- a/src/vim9class.c
+++ b/src/vim9class.c
@@ -1280,6 +1280,7 @@ add_class_members(class_T *cl, exarg_T *eap, garray_T *type_list_gap)
 	    tv->v_type = m->ocm_type->tt_type;
 	    tv->vval.v_string = NULL;
 	}
+	set_tv_type(tv, m->ocm_type);
 	if (m->ocm_flags & OCMFLAG_CONST)
 	    item_lock(tv, DICT_MAXNEST, TRUE, TRUE);
     }

--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -3315,7 +3315,7 @@ obj_constructor_prologue(ufunc_T *ufunc, cctx_T *cctx)
 		// the initialization expression type.
 		m->ocm_type = type;
 	    }
-	    else if (m->ocm_type->tt_type != type->tt_type)
+	    else
 	    {
 		// The type of the member initialization expression is
 		// determined at run time.  Add a runtime type check.
@@ -3329,6 +3329,15 @@ obj_constructor_prologue(ufunc_T *ufunc, cctx_T *cctx)
 	}
 	else
 	    push_default_value(cctx, m->ocm_type->tt_type, FALSE, NULL);
+
+	if ((m->ocm_type->tt_type == VAR_DICT
+		    || m->ocm_type->tt_type == VAR_LIST)
+		&& m->ocm_type->tt_member != NULL
+		&& m->ocm_type->tt_member != &t_any
+		&& m->ocm_type->tt_member != &t_unknown)
+	    // Set the type in the list or dict, so that it can be checked,
+	    // also in legacy script.
+	    generate_SETTYPE(cctx, m->ocm_type);
 
 	generate_STORE_THIS(cctx, i);
     }


### PR DESCRIPTION
Ensure the generated typevals get the declared type and generate typechecks to ensure that's the case.

Closes #15090

@errael Mind giving this a try?