### PR TITLE
Uniform naming in makefiles of macros pointing to a Vim executable file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ VIM_FOR_INDENTTEST = ../../src/vim
 indenttest:
 	cd runtime/indent && \
 		$(MAKE) clean && \
-		$(MAKE) test VIM="$(VIM_FOR_INDENTTEST)"
+		$(MAKE) test VIMPROG="$(VIM_FOR_INDENTTEST)"
 
 # Executable used for running the syntax tests.
 VIM_FOR_SYNTAXTEST = ../../src/vim
@@ -248,9 +248,6 @@ VIMVER	= vim-$(MAJOR).$(MINOR)
 VERSION = $(MAJOR)$(MINOR)
 VDOT	= $(MAJOR).$(MINOR)
 VIMRTDIR = vim$(VERSION)
-
-# Vim used for conversion from "unix" to "dos"
-VIM	= vim
 
 # How to include Filelist depends on the version of "make" you have.
 # If the current choice doesn't work, try the other one.

--- a/runtime/doc/Make_mvc.mak
+++ b/runtime/doc/Make_mvc.mak
@@ -12,7 +12,7 @@
 
 # Correct the following line for the where executeable file vim is installed.
 # Please do not put the path in quotes.
-VIMEXE = D:\Programs\Vim\vim90\vim.exe
+VIMPROG = D:\Programs\Vim\vim90\vim.exe
 
 # Correct the following line for the directory where iconv installed.
 # Please do not put the path in quotes.
@@ -63,7 +63,7 @@ doctags : doctags.c
 # Use Vim to generate the tags file.  Can only be used when Vim has been
 # compiled and installed.  Supports multiple languages.
 vimtags : $(DOCS)
-	@"$(VIMEXE)" --clean -esX -V1 -u doctags.vim
+	@"$(VIMPROG)" --clean -esX -V1 -u doctags.vim
 
 
 uganda.nsis.txt : uganda.???
@@ -105,7 +105,7 @@ perlhtml : tags $(DOCS)
 
 # Check URLs in the help with "curl" or "powershell".
 test_urls :
-	"$(VIMEXE)" --clean -S test_urls.vim
+	"$(VIMPROG)" --clean -S test_urls.vim
 
 clean :
 	$(RM) doctags.exe doctags.obj

--- a/runtime/doc/Makefile
+++ b/runtime/doc/Makefile
@@ -7,7 +7,7 @@
 AWK = awk
 
 # Set to $(VIMTARGET) when executed from src/Makefile.
-VIMEXE = vim
+VIMPROG = vim
 
 # include the config.mk from the source directory.  It's only needed to set
 # AWK, used for "make html".  Comment this out if the include gives problems.
@@ -25,7 +25,7 @@ all: tags vim.man evim.man vimdiff.man vimtutor.man xxd.man $(CONVERTED)
 # Use Vim to generate the tags file.  Can only be used when Vim has been
 # compiled and installed.  Supports multiple languages.
 vimtags: $(DOCS)
-	@$(VIMEXE) --clean -esX -V1 -u doctags.vim
+	@$(VIMPROG) --clean -esX -V1 -u doctags.vim
 
 # Use "doctags" to generate the tags file.  Only works for English!
 tags: doctags $(DOCS)
@@ -57,7 +57,7 @@ uganda.nsis.txt : uganda.???
             $${dpn} | uniq > $${trg%txt}$${dpn##*.}; \
 	done
 # This files needs to be in dos fileformat for NSIS.
-	$(VIMEXE) -e -X -u NONE --cmd "set notitle noicon nocp noml viminfo=" \
+	$(VIMPROG) -e -X -u NONE --cmd "set notitle noicon nocp noml viminfo=" \
 	  -c "argdo write ++ff=dos" -c "qa" uganda.nsis.???
 
 # Awk version of .txt to .html conversion.
@@ -91,7 +91,7 @@ perlhtml: tags $(DOCS)
 
 # Check URLs in the help with "curl".
 test_urls:
-	$(VIMEXE) --clean -S test_urls.vim
+	$(VIMPROG) --clean -S test_urls.vim
 
 clean:
 	-rm -f doctags *.html tags.ref

--- a/runtime/indent/Make_mvc.mak
+++ b/runtime/indent/Make_mvc.mak
@@ -4,7 +4,7 @@
 
 .SUFFIXES:
 
-VIM = vim.exe
+VIMPROG = vim.exe
 VIMRUNTIME = ..
 
 # Run the tests that didn't run yet or failed previously.
@@ -12,7 +12,7 @@ VIMRUNTIME = ..
 # If a test fails a testdir\*.fail file will be written.
 test :
 	@ set "VIMRUNTIME=$(VIMRUNTIME)"
-	$(VIM) --clean --not-a-term -u testdir\runtest.vim
+	$(VIMPROG) --clean --not-a-term -u testdir\runtest.vim
 
 
 clean testclean :

--- a/runtime/indent/Makefile
+++ b/runtime/indent/Makefile
@@ -3,14 +3,14 @@
 .SUFFIXES:
 .PHONY: test clean testclean
 
-VIM = vim
+VIMPROG = vim
 VIMRUNTIME = ..
 
 # Run the tests that didn't run yet or failed previously.
 # If a test succeeds a testdir/*.out file will be written.
 # If a test fails a testdir/*.fail file will be written.
 test:
-	VIMRUNTIME=$(VIMRUNTIME) $(VIM) --clean --not-a-term -u testdir/runtest.vim
+	VIMRUNTIME=$(VIMRUNTIME) $(VIMPROG) --clean --not-a-term -u testdir/runtest.vim
 
 
 clean testclean:

--- a/runtime/syntax/generator/Makefile
+++ b/runtime/syntax/generator/Makefile
@@ -1,5 +1,5 @@
 VIM_SRCDIR = ../../../src
-RUN_VIM = $(VIM_SRCDIR)/vim -N -u NONE -i NONE -n
+RUN_VIMPROG = $(VIM_SRCDIR)/vim -N -u NONE -i NONE -n
 REVISION ?= $(shell date +%Y-%m-%dT%H:%M:%S%:z)
 
 SRC =	$(VIM_SRCDIR)/eval.c $(VIM_SRCDIR)/ex_cmds.h $(VIM_SRCDIR)/ex_docmd.c \
@@ -15,13 +15,13 @@ generate: vim.vim
 vim.vim: vim.vim.rc update_date.vim
 	@echo "Generating vim.vim ..."
 	@cp -f vim.vim.rc ../vim.vim
-	@$(RUN_VIM) -S update_date.vim
+	@$(RUN_VIMPROG) -S update_date.vim
 	@echo "done."
 
 vim.vim.rc: gen_syntax_vim.vim vim.vim.base $(SRC)
 	@echo "Generating vim.vim.rc ..."
 	@rm -f sanity_check.err generator.err
-	@$(RUN_VIM) -S gen_syntax_vim.vim
+	@$(RUN_VIMPROG) -S gen_syntax_vim.vim
 	@if test -f sanity_check.err ; then \
 		echo ; \
 		echo "Sanity errors:" ; \

--- a/src/Make_mvc.mak
+++ b/src/Make_mvc.mak
@@ -1420,7 +1420,7 @@ test:
 
 testgvim testgui:
 	cd testdir
-	$(MAKE) /NOLOGO -f Make_mvc.mak VIMPROG=..\gvim
+	$(MAKE) /NOLOGO -f Make_mvc.mak "VIMPROG=..\gvim.exe"
 	cd ..
 
 testtiny:
@@ -1430,7 +1430,7 @@ testtiny:
 
 testgvimtiny:
 	cd testdir
-	$(MAKE) /NOLOGO -f Make_mvc.mak tiny VIMPROG=..\gvim
+	$(MAKE) /NOLOGO -f Make_mvc.mak "VIMPROG=..\gvim.exe" tiny
 	cd ..
 
 testclean:

--- a/src/Makefile
+++ b/src/Makefile
@@ -2189,7 +2189,7 @@ test check: unittests $(TERM_TEST) scripttests
 scripttests:
 	$(MAKE) -f Makefile $(VIMTARGET)
 	if test -n "$(MAKEMO)" -a -f $(PODIR)/Makefile; then \
-		cd $(PODIR); $(MAKE) -f Makefile check VIM=../$(VIMTARGET); \
+		cd $(PODIR); $(MAKE) -f Makefile check VIMPROG=../$(VIMTARGET); \
 	fi
 	-if test $(VIMTARGET) != vim -a ! -r vim; then \
 		ln -s $(VIMTARGET) vim; \
@@ -2357,7 +2357,7 @@ installrtbase: $(HELPSOURCE)/vim.1 $(DEST_VIM) $(VIMTARGET) $(DEST_RT) \
 	# We can assume Vim was build, but it may not have been installed,
 	# thus use the executable in the current directory.
 	-@BUILD_DIR="`pwd`"; cd $(HELPSOURCE); if test -z "$(CROSS_COMPILING)"; then \
-		$(MAKE) VIMEXE="$$BUILD_DIR/$(VIMTARGET)" vimtags; fi
+		$(MAKE) VIMPROG="$$BUILD_DIR/$(VIMTARGET)" vimtags; fi
 	cd $(HELPSOURCE); \
 		files=`ls *.txt tags`; \
 		files="$$files `ls *.??x tags-?? 2>/dev/null || true`"; \

--- a/src/po/Make_cyg.mak
+++ b/src/po/Make_cyg.mak
@@ -16,7 +16,7 @@ endif
 include Make_all.mak
 
 PACKAGE = vim
-VIM = ../vim
+VIMPROG = ../vim
 
 # Uncomment one of the lines below or modify it to put the path to your
 # gettext binaries
@@ -64,18 +64,18 @@ PO_INPUTLIST = \
 	vim.desktop.in
 
 first_time: $(PO_INPUTLIST) $(PO_VIM_INPUTLIST)
-	$(VIM) -u NONE --not-a-term -S tojavascript.vim $(LANGUAGE).pot $(PO_VIM_INPUTLIST)
+	$(VIMPROG) -u NONE --not-a-term -S tojavascript.vim $(LANGUAGE).pot $(PO_VIM_INPUTLIST)
 	$(XGETTEXT) --default-domain=$(LANGUAGE) \
 		--add-comments $(XGETTEXT_KEYWORDS) $(PO_INPUTLIST) $(PO_VIM_JSLIST)
-	$(VIM) -u NONE --not-a-term -S fixfilenames.vim $(LANGUAGE).pot $(PO_VIM_INPUTLIST)
+	$(VIMPROG) -u NONE --not-a-term -S fixfilenames.vim $(LANGUAGE).pot $(PO_VIM_INPUTLIST)
 	$(RM) *.js
 
 $(PACKAGE).pot: $(PO_INPUTLIST) $(PO_VIM_INPUTLIST)
-	$(VIM) -u NONE --not-a-term -S tojavascript.vim $(PACKAGE).pot $(PO_VIM_INPUTLIST)
+	$(VIMPROG) -u NONE --not-a-term -S tojavascript.vim $(PACKAGE).pot $(PO_VIM_INPUTLIST)
 	$(XGETTEXT) --default-domain=$(PACKAGE) \
 		--add-comments $(XGETTEXT_KEYWORDS) $(PO_INPUTLIST) $(PO_VIM_JSLIST)
 	$(MV) $(PACKAGE).po $(PACKAGE).pot
-	$(VIM) -u NONE --not-a-term -S fixfilenames.vim $(PACKAGE).pot $(PO_VIM_INPUTLIST)
+	$(VIMPROG) -u NONE --not-a-term -S fixfilenames.vim $(PACKAGE).pot $(PO_VIM_INPUTLIST)
 	$(RM) *.js
 
 # Don't add a dependency here, we only want to update the .po files manually

--- a/src/po/Make_ming.mak
+++ b/src/po/Make_ming.mak
@@ -23,9 +23,9 @@ include Make_all.mak
 
 PACKAGE = vim
 ifeq (sh.exe, $(SHELL))
-VIM = ..\vim
+VIMPROG = ..\vim
 else
-VIM = ../vim
+VIMPROG = ../vim
 endif
 
 # Uncomment one of the lines below or modify it to put the path to your
@@ -77,18 +77,18 @@ PO_INPUTLIST = \
 	vim.desktop.in
 
 first_time: $(PO_INPUTLIST) $(PO_VIM_INPUTLIST)
-	$(VIM) -u NONE --not-a-term -S tojavascript.vim $(LANGUAGE).pot $(PO_VIM_INPUTLIST)
+	$(VIMPROG) -u NONE --not-a-term -S tojavascript.vim $(LANGUAGE).pot $(PO_VIM_INPUTLIST)
 	$(XGETTEXT) --default-domain=$(LANGUAGE) \
 		--add-comments $(XGETTEXT_KEYWORDS) $(PO_INPUTLIST) $(PO_VIM_JSLIST)
-	$(VIM) -u NONE --not-a-term -S fixfilenames.vim $(LANGUAGE).pot $(PO_VIM_INPUTLIST)
+	$(VIMPROG) -u NONE --not-a-term -S fixfilenames.vim $(LANGUAGE).pot $(PO_VIM_INPUTLIST)
 	$(RM) *.js
 
 $(PACKAGE).pot: $(PO_INPUTLIST) $(PO_VIM_INPUTLIST)
-	$(VIM) -u NONE --not-a-term -S tojavascript.vim $(PACKAGE).pot $(PO_VIM_INPUTLIST)
+	$(VIMPROG) -u NONE --not-a-term -S tojavascript.vim $(PACKAGE).pot $(PO_VIM_INPUTLIST)
 	$(XGETTEXT) --default-domain=$(PACKAGE) \
 		--add-comments $(XGETTEXT_KEYWORDS) $(PO_INPUTLIST) $(PO_VIM_JSLIST)
 	$(MV) $(PACKAGE).po $(PACKAGE).pot
-	$(VIM) -u NONE --not-a-term -S fixfilenames.vim $(PACKAGE).pot $(PO_VIM_INPUTLIST)
+	$(VIMPROG) -u NONE --not-a-term -S fixfilenames.vim $(PACKAGE).pot $(PO_VIM_INPUTLIST)
 	$(RM) *.js
 
 # Don't add a dependency here, we only want to update the .po files manually

--- a/src/po/Make_mvc.mak
+++ b/src/po/Make_mvc.mak
@@ -40,7 +40,7 @@ VIMRUNTIME = ..\..\runtime
 PACKAGE = vim
 # Correct the following line for the where executeable file vim is
 # installed.  Please do not put the path in quotes.
-VIM = ..\vim.exe
+VIMPROG = ..\vim.exe
 
 # Correct the following line for the directory where gettext et al is
 # installed.  Please do not put the path in quotes.
@@ -102,7 +102,7 @@ originals : $(MOFILES)
 converted: $(MOCONVERTED)
 
 .po.ck:
-	"$(VIM)" -u NONE --noplugins -e -s -X --cmd "set enc=utf-8" -S check.vim \
+	"$(VIMPROG)" -u NONE --noplugins -e -s -X --cmd "set enc=utf-8" -S check.vim \
 		-c "if error == 0 | q | else | num 2 | cq | endif" $<
 	$(TOUCH_TARGET)
 
@@ -496,25 +496,25 @@ files: $(PO_INPUTLIST)
 	$(LS) $(LSFLAGS) $(PO_INPUTLIST) > .\files
 
 first_time: files
-	"$(VIM)" -u NONE --not-a-term -S tojavascript.vim $(LANGUAGE).po \
+	"$(VIMPROG)" -u NONE --not-a-term -S tojavascript.vim $(LANGUAGE).po \
 		$(PO_VIM_INPUTLIST)
 	set OLD_PO_FILE_INPUT=yes
 	set OLD_PO_FILE_OUTPUT=yes
 	$(XGETTEXT) --default-domain=$(LANGUAGE) --add-comments $(XGETTEXT_KEYWORDS) \
 		--files-from=.\files $(PO_VIM_JSLIST)
-	"$(VIM)" -u NONE --not-a-term -S fixfilenames.vim $(LANGUAGE).po \
+	"$(VIMPROG)" -u NONE --not-a-term -S fixfilenames.vim $(LANGUAGE).po \
 		$(PO_VIM_INPUTLIST)
 	$(RM) *.js
 
 $(PACKAGE).pot: files
-	"$(VIM)" -u NONE --not-a-term -S tojavascript.vim $(PACKAGE).pot \
+	"$(VIMPROG)" -u NONE --not-a-term -S tojavascript.vim $(PACKAGE).pot \
 		$(PO_VIM_INPUTLIST)
 	set OLD_PO_FILE_INPUT=yes
 	set OLD_PO_FILE_OUTPUT=yes
 	$(XGETTEXT) --default-domain=$(PACKAGE) --add-comments $(XGETTEXT_KEYWORDS) \
 		--files-from=.\files $(PO_VIM_JSLIST)
 	$(MV) $(PACKAGE).po $(PACKAGE).pot
-	"$(VIM)" -u NONE --not-a-term -S fixfilenames.vim $(PACKAGE).pot \
+	"$(VIMPROG)" -u NONE --not-a-term -S fixfilenames.vim $(PACKAGE).pot \
 		$(PO_VIM_INPUTLIST)
 	$(RM) *.js
 
@@ -541,10 +541,10 @@ install-all: all
 		"$(VIMRUNTIME)\lang\%%l\LC_MESSAGES\$(PACKAGE).mo"
 
 cleanup-po: $(LANGUAGE).po
-	"$(VIM)" -u NONE -e -X -S cleanup.vim -c wq $(LANGUAGE).po
+	"$(VIMPROG)" -u NONE -e -X -S cleanup.vim -c wq $(LANGUAGE).po
 
 cleanup-po-all: $(POFILES)
-	!"$(VIM)" -u NONE -e -X -S cleanup.vim -c wq $**
+	!"$(VIMPROG)" -u NONE -e -X -S cleanup.vim -c wq $**
 
 clean: checkclean
 	$(RM) *.mo

--- a/src/po/Makefile
+++ b/src/po/Makefile
@@ -12,7 +12,7 @@ include $(PO_BASEDIR)/Make_all.mak
 
 PACKAGE = vim
 SHELL = /bin/sh
-VIM = $(PO_BASEDIR)/../vim
+VIMPROG = $(PO_BASEDIR)/../vim
 
 # MacOS sed is locale aware, set $LANG to avoid problems.
 SED = LANG=C sed
@@ -41,7 +41,7 @@ converted: $(MOCONVERTED)
 	$(MSGFMTCMD) -o $@ $<
 
 .po.ck:
-	$(VIM) -u NONE --noplugins -e -s -X --cmd "set enc=utf-8" -S check.vim \
+	$(VIMPROG) -u NONE --noplugins -e -s -X --cmd "set enc=utf-8" -S check.vim \
 		-c "if error == 0 | q | else | num 2 | cq | endif" $<
 	touch $@
 
@@ -262,13 +262,13 @@ PO_INPUTLIST = \
 
 $(PACKAGE).pot: $(PO_INPUTLIST) $(PO_VIM_INPUTLIST)
 	# Convert the Vim scripts to (what looks like) Javascript.
-	$(VIM) -u NONE --not-a-term -S $(PO_BASEDIR)/tojavascript.vim $(PACKAGE).pot $(PO_VIM_INPUTLIST)
+	$(VIMPROG) -u NONE --not-a-term -S $(PO_BASEDIR)/tojavascript.vim $(PACKAGE).pot $(PO_VIM_INPUTLIST)
 	# Create vim.pot.
 	$(XGETTEXT) --default-domain=$(PACKAGE) --add-comments \
 		$(XGETTEXT_KEYWORDS) $(PO_INPUTLIST) $(PO_VIM_JSLIST)
 	mv -f $(PACKAGE).po $(PACKAGE).pot
 	# Fix Vim scripts names, so that "gf" works.
-	$(VIM) -u NONE --not-a-term -S $(PO_BASEDIR)/fixfilenames.vim $(PACKAGE).pot $(PO_VIM_INPUTLIST)
+	$(VIMPROG) -u NONE --not-a-term -S $(PO_BASEDIR)/fixfilenames.vim $(PACKAGE).pot $(PO_VIM_INPUTLIST)
 	# Delete the temporary files.
 	rm *.js
 

--- a/src/testdir/Make_mvc.mak
+++ b/src/testdir/Make_mvc.mak
@@ -5,9 +5,9 @@
 
 # Testing may be done with a debug build 
 !IF EXIST(..\\vimd.exe) && !EXIST(..\\vim.exe)
-VIMPROG = ..\\vimd
+VIMPROG = ..\\vimd.exe
 !ELSE
-VIMPROG = ..\\vim
+VIMPROG = ..\\vim.exe
 !ENDIF
 
 

--- a/src/testdir/Makefile
+++ b/src/testdir/Makefile
@@ -84,7 +84,7 @@ test_vim9:
 
 RM_ON_RUN = test.out X* viminfo
 RM_ON_START = test.ok benchmark.out
-RUN_VIM = VIMRUNTIME=$(SCRIPTSOURCE) $(VALGRIND) $(VIMPROG) -f $(GUI_FLAG) -u unix.vim $(NO_INITS) -s dotest.in
+RUN_VIMPROG = VIMRUNTIME=$(SCRIPTSOURCE) $(VALGRIND) $(VIMPROG) -f $(GUI_FLAG) -u unix.vim $(NO_INITS) -s dotest.in
 
 # Delete files that may interfere with running tests.  This includes some files
 # that may result from working on the tests, not only from running them.
@@ -114,7 +114,7 @@ tinytests: $(SCRIPTS_TINY_OUT)
 	@# 200 msec is sufficient, but only modern sleep supports a fraction of
 	@# a second, fall back to a second if it fails.
 	@-/bin/sh -c "sleep .2 > /dev/null 2>&1 || sleep 1"
-	$(RUN_VIM) $*.in $(REDIR_TEST_TO_NULL)
+	$(RUN_VIMPROG) $*.in $(REDIR_TEST_TO_NULL)
 
 	@# Check if the test.out file matches test.ok.
 	@/bin/sh -c "if test -f test.out; then \


### PR DESCRIPTION
Problem:
All makefiles in use have different names for macros pointing to the
location of the Vim executable. And when you need to specify a different
location of the Vim file via the make program command line, you either have to
remember the name of the macro in the given makefile, or you have to open the
makefile to see the name of the macro.
This, as you may realize, is not very good for productivity and also creates
some confusion in the makefiles themselves.

Solution:
Use a common name for such a macro in the makefiles.
This macro name is "VIMPROG", similar to the `v:progpath` variable.
(in addition, the same name is used in the syntax checker Makefile and testdir).