### PR TITLE
Right release selects immediately when pum is truncated

### DIFF
--- a/src/popupmenu.c
+++ b/src/popupmenu.c
@@ -1332,9 +1332,10 @@ pum_set_event_info(dict_T *dict)
     static void
 pum_position_at_mouse(int min_width)
 {
-    if (Rows - mouse_row > pum_size)
+    if (Rows - mouse_row > pum_size || Rows - mouse_row > mouse_row)
     {
-	// Enough space below the mouse row.
+	// Enough space below the mouse row,
+	// or there is more space below the mouse row than above.
 	pum_row = mouse_row + 1;
 	if (pum_height > Rows - pum_row)
 	    pum_height = Rows - pum_row;
@@ -1633,7 +1634,7 @@ pum_select_mouse_pos(void)
 {
     int idx = mouse_row - pum_row;
 
-    if (idx < 0 || idx >= pum_size)
+    if (idx < 0 || idx >= pum_height)
 	pum_selected = -1;
     else if (*pum_array[idx].pum_text != NUL)
 	pum_selected = idx;

--- a/src/testdir/test_menu.vim
+++ b/src/testdir/test_menu.vim
@@ -481,13 +481,48 @@ func Test_popup_menu()
   unmenu PopUp
 endfunc
 
+func Test_popup_menu_truncated()
+  CheckNotGui
+
+  set mouse=a mousemodel=popup
+  aunmenu PopUp
+  for i in range(2 * &lines)
+    exe $'menu PopUp.{i} <Cmd>let g:res = {i}<CR>'
+  endfor
+
+  func LeftClickExpr(row, col)
+    call test_setmouse(a:row, a:col)
+    return "\<LeftMouse>"
+  endfunc
+
+  " Clicking at the bottom should place popup menu above click position.
+  " <RightRelease> should not select an item immediately.
+  let g:res = -1
+  call test_setmouse(&lines, 1)
+  nnoremap <expr><F2> LeftClickExpr(4, 1)
+  call feedkeys("\<RightMouse>\<RightRelease>\<F2>", 'tx')
+  call assert_equal(3, g:res)
+
+  " Clicking at the top should place popup menu below click position.
+  let g:res = -1
+  call test_setmouse(1, 1)
+  nnoremap <expr><F2> LeftClickExpr(5, 1)
+  call feedkeys("\<RightMouse>\<RightRelease>\<F2>", 'tx')
+  call assert_equal(3, g:res)
+
+  nunmap <F2>
+  delfunc LeftClickExpr
+  unlet g:res
+  aunmenu PopUp
+  set mouse& mousemodel&
+endfunc
+
 " Test for MenuPopup autocommand
 func Test_autocmd_MenuPopup()
   CheckNotGui
 
-  set mouse=a
-  set mousemodel=popup
-  aunmenu *
+  set mouse=a mousemodel=popup
+  aunmenu PopUp
   autocmd MenuPopup * exe printf(
     \ 'anoremenu PopUp.Foo <Cmd>let g:res = ["%s", "%s"]<CR>',
     \ expand('<afile>'), expand('<amatch>'))


### PR DESCRIPTION
Problem:  Right release selects immediately when pum is truncated.
Solution: Use pum_height instead of pum_size when checking click row.
          Don't place it above mouse row when there is more space below.

Fix #15101
