### PR TITLE
Support for the "arity" argument in get()

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -3611,6 +3611,15 @@ get({func}, {what})
 			"func"	The function
 			"dict"	The dictionary
 			"args"	The list with arguments
+			"arity"	A dictionary with information about the number of
+				arguments accepted by the function with the following
+				fields:
+				    required	The number of positional arguments.
+				    optional	The number of optional arguments, in
+						addition to the required ones.
+				    varargs	|TRUE| if the function accepts a variable
+						number of arguments. See |...|.
+
 		Returns zero on error.
 		Preferably used as a |method|: >
 			myfunc->get(what)

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -5134,6 +5134,36 @@ f_get(typval_T *argvars, typval_T *rettv)
 			list_append_tv(rettv->vval.v_list, &pt->pt_argv[i]);
 		}
 	    }
+	    else if (STRCMP(what, "arity") == 0)
+	    {
+		int required = 0, optional = 0, varargs = FALSE;
+		char_u *name = partial_name(pt);
+
+		get_func_arity(name, &required, &optional, &varargs);
+
+		rettv->v_type = VAR_DICT;
+		if (rettv_dict_alloc(rettv) == OK)
+		{
+		    dict_T *dict = rettv->vval.v_dict;
+
+		    // Take into account the arguments of the partial, if any.
+		    // Note that it is possible to supply more arguments than the function
+		    // accepts.
+		    if (pt->pt_argc >= required + optional)
+			required = optional = 0;
+		    else if (pt->pt_argc > required)
+		    {
+			optional -= pt->pt_argc - required;
+			required = 0;
+		    }
+		    else
+			required -= pt->pt_argc;
+
+		    dict_add_number(dict, "required", required);
+		    dict_add_number(dict, "optional", optional);
+		    dict_add_bool(dict, "varargs", varargs);
+		}
+	    }
 	    else
 		semsg(_(e_invalid_argument_str), what);
 

--- a/src/proto/userfunc.pro
+++ b/src/proto/userfunc.pro
@@ -95,4 +95,5 @@ int set_ref_in_call_stack(int copyID);
 int set_ref_in_functions(int copyID);
 int set_ref_in_func_args(int copyID);
 int set_ref_in_func(char_u *name, ufunc_T *fp_in, int copyID);
+int get_func_arity(char_u *name, int *required, int *optional, int *varargs);
 /* vim: set ft=c : */

--- a/src/testdir/test_getvar.vim
+++ b/src/testdir/test_getvar.vim
@@ -142,20 +142,29 @@ func Test_get_func()
   let l:F = function('tr')
   call assert_equal('tr', get(l:F, 'name'))
   call assert_equal(l:F, get(l:F, 'func'))
+  call assert_equal({'required': 3, 'optional': 0, 'varargs': v:false},
+      \ get(l:F, 'arity'))
 
   let Fb_func = function('s:FooBar')
   call assert_match('<SNR>\d\+_FooBar', get(Fb_func, 'name'))
+  call assert_equal({'required': 0, 'optional': 0, 'varargs': v:false},
+      \ get(Fb_func, 'arity'))
   let Fb_ref = funcref('s:FooBar')
   call assert_match('<SNR>\d\+_FooBar', get(Fb_ref, 'name'))
+  call assert_equal({'required': 0, 'optional': 0, 'varargs': v:false},
+      \ get(Fb_ref, 'arity'))
 
   call assert_equal({'func has': 'no dict'}, get(l:F, 'dict', {'func has': 'no dict'}))
   call assert_equal(0, get(l:F, 'dict'))
   call assert_equal([], get(l:F, 'args'))
+  call assert_equal({'required': 3, 'optional': 0, 'varargs': v:false}, get(l:F, 'arity'))
+
   let NF = test_null_function()
   call assert_equal('', get(NF, 'name'))
   call assert_equal(NF, get(NF, 'func'))
   call assert_equal(0, get(NF, 'dict'))
   call assert_equal([], get(NF, 'args'))
+  call assert_equal({'required': 0, 'optional': 0, 'varargs': v:false}, get(NF, 'arity'))
 endfunc
 
 " get({partial}, {what} [, {default}]) - in test_partial.vim

--- a/src/testdir/test_partial.vim
+++ b/src/testdir/test_partial.vim
@@ -310,6 +310,9 @@ func Test_auto_partial_rebind()
   call assert_equal('dict1', dict2['f2']())
 endfunc
 
+func s:Qux(x, y, z=3,...)
+endfunc
+
 func Test_get_partial_items()
   let dict = {'name': 'hello'}
   let args = ["foo", "bar"]
@@ -331,6 +334,17 @@ func Test_get_partial_items()
   let dict = {'partial has': 'no dict'}
   call assert_equal(dict, get(P, 'dict', dict))
   call assert_equal(0, get(l:P, 'dict'))
+
+  call assert_equal({'required': 2, 'optional': 1, 'varargs': v:true},
+      \ get(funcref('s:Qux', []), 'arity'))
+  call assert_equal({'required': 1, 'optional': 1, 'varargs': v:true},
+      \ get(funcref('s:Qux', [1]), 'arity'))
+  call assert_equal({'required': 0, 'optional': 1, 'varargs': v:true},
+      \ get(funcref('s:Qux', [1, 2]), 'arity'))
+  call assert_equal({'required': 0, 'optional': 0, 'varargs': v:true},
+      \ get(funcref('s:Qux', [1, 2, 3]), 'arity'))
+  call assert_equal({'required': 0, 'optional': 0, 'varargs': v:true},
+      \ get(funcref('s:Qux', [1, 2, 3, 4]), 'arity'))
 endfunc
 
 func Test_compare_partials()

--- a/src/testdir/test_partial.vim
+++ b/src/testdir/test_partial.vim
@@ -310,7 +310,7 @@ func Test_auto_partial_rebind()
   call assert_equal('dict1', dict2['f2']())
 endfunc
 
-func s:Qux(x, y, z=3,...)
+func s:Qux(x, y, z=3, w=1,...)
 endfunc
 
 func Test_get_partial_items()
@@ -335,13 +335,13 @@ func Test_get_partial_items()
   call assert_equal(dict, get(P, 'dict', dict))
   call assert_equal(0, get(l:P, 'dict'))
 
-  call assert_equal({'required': 2, 'optional': 1, 'varargs': v:true},
+  call assert_equal({'required': 2, 'optional': 2, 'varargs': v:true},
       \ get(funcref('s:Qux', []), 'arity'))
-  call assert_equal({'required': 1, 'optional': 1, 'varargs': v:true},
+  call assert_equal({'required': 1, 'optional': 2, 'varargs': v:true},
       \ get(funcref('s:Qux', [1]), 'arity'))
-  call assert_equal({'required': 0, 'optional': 1, 'varargs': v:true},
+  call assert_equal({'required': 0, 'optional': 2, 'varargs': v:true},
       \ get(funcref('s:Qux', [1, 2]), 'arity'))
-  call assert_equal({'required': 0, 'optional': 0, 'varargs': v:true},
+  call assert_equal({'required': 0, 'optional': 1, 'varargs': v:true},
       \ get(funcref('s:Qux', [1, 2, 3]), 'arity'))
   call assert_equal({'required': 0, 'optional': 0, 'varargs': v:true},
       \ get(funcref('s:Qux', [1, 2, 3, 4]), 'arity'))


### PR DESCRIPTION
Add a way to extract the number of required and optional arguments for a given function or partial.

Closes #15097