### PR TITLE
Add blank number format for whitespace-aware CTRL_A and CTRL_X

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5918,6 +5918,19 @@ A jump table for the options with a short description can be found at |Q_op|.
 		    (without "unsigned" it would become "9-2019").
 		    Using CTRL-X on "0" or CTRL-A on "18446744073709551615"
 		    (2^64 - 1) has no effect, overflow is prevented.
+	blank	If included, treat numbers as signed or unsigned based on
+		preceding whitespace. If a number with a leading dash has its
+		dash immediately preceded by a non-whitespace character (i.e.,
+		not a tab or a " "), the negative sign won't be considered as
+		part of the number.  For example:
+		    Using CTRL-A on "14" in "Carbon-14" results in "Carbon-15"
+		    (without "blank" it would become "Carbon-13").
+		    Using CTRL-X on "8" in "Carbon -8" results in "Carbon -9"
+		    (because -8 is preceded by whitespace. If "unsigned" was
+		    set, it would result in "Carbon -7").
+		If this format is included, overflow is prevented as if
+		"unsigned" were set. If both this format and "unsigned" are
+		included, "unsigned" will take precedence.
 	Numbers which simply begin with a digit in the range 1-9 are always
 	considered decimal.  This also happens for numbers that are not
 	recognized as octal or hex.

--- a/src/ops.c
+++ b/src/ops.c
@@ -2817,9 +2817,7 @@ do_addsub(
 		&& !do_unsigned)
 	{
 	    if (do_blank && col >= 2 && !VIM_ISWHITE(ptr[col - 2]))
-	    {
 		blank_unsigned = TRUE;
-	    }
 	    else
 	    {
 		negative = TRUE;
@@ -2886,9 +2884,7 @@ do_addsub(
 		&& !do_unsigned)
 	{
 	    if (do_blank && col >= 2 && !VIM_ISWHITE(ptr[col - 2]))
-	    {
 		blank_unsigned = TRUE;
-	    }
 	    else
 	    {
 		// negative number

--- a/src/ops.c
+++ b/src/ops.c
@@ -2673,6 +2673,8 @@ do_addsub(
     int		do_bin;
     int		do_alpha;
     int		do_unsigned;
+    int		do_blank;
+    int		blank_unsigned = FALSE;	// blank: treat as unsigned?
     int		firstdigit;
     int		subtract;
     int		negative = FALSE;
@@ -2690,6 +2692,7 @@ do_addsub(
     do_bin = (vim_strchr(curbuf->b_p_nf, 'b') != NULL);	// "Bin"
     do_alpha = (vim_strchr(curbuf->b_p_nf, 'p') != NULL);	// "alPha"
     do_unsigned = (vim_strchr(curbuf->b_p_nf, 'u') != NULL);	// "Unsigned"
+    do_blank = (vim_strchr(curbuf->b_p_nf, 'k') != NULL);	// "blanK"
 
     if (virtual_active())
     {
@@ -2813,8 +2816,15 @@ do_addsub(
 		&& (!has_mbyte || !(*mb_head_off)(ptr, ptr + col - 1))
 		&& !do_unsigned)
 	{
-	    negative = TRUE;
-	    was_positive = FALSE;
+	    if (do_blank && col >= 2 && !VIM_ISWHITE(ptr[col - 2]))
+	    {
+		blank_unsigned = TRUE;
+	    }
+	    else
+	    {
+		negative = TRUE;
+		was_positive = FALSE;
+	    }
 	}
     }
 
@@ -2875,10 +2885,18 @@ do_addsub(
 		&& !visual
 		&& !do_unsigned)
 	{
-	    // negative number
-	    --col;
-	    negative = TRUE;
+	    if (do_blank && col >= 2 && !VIM_ISWHITE(ptr[col - 2]))
+	    {
+		blank_unsigned = TRUE;
+	    }
+	    else
+	    {
+		// negative number
+		--col;
+		negative = TRUE;
+	    }
 	}
+
 	// get the number value (unsigned)
 	if (visual && VIsual_mode != 'V')
 	    maxlen = (curbuf->b_visual.vi_curswant == MAXCOL
@@ -2938,7 +2956,7 @@ do_addsub(
 		negative = FALSE;
 	}
 
-	if (do_unsigned && negative)
+	if ((do_unsigned || blank_unsigned) && negative)
 	{
 	    if (subtract)
 		// sticking at zero.

--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -33,7 +33,7 @@ static char *(p_briopt_values[]) = {"shift:", "min:", "sbr", "list:", "column:",
 static char *(p_dip_values[]) = {"filler", "context:", "iblank", "icase", "iwhite", "iwhiteall", "iwhiteeol", "horizontal", "vertical", "closeoff", "hiddenoff", "foldcolumn:", "followwrap", "internal", "indent-heuristic", "algorithm:", NULL};
 static char *(p_dip_algorithm_values[]) = {"myers", "minimal", "patience", "histogram", NULL};
 #endif
-static char *(p_nf_values[]) = {"bin", "octal", "hex", "alpha", "unsigned", NULL};
+static char *(p_nf_values[]) = {"bin", "octal", "hex", "alpha", "unsigned", "blank", NULL};
 static char *(p_ff_values[]) = {FF_UNIX, FF_DOS, FF_MAC, NULL};
 #ifdef FEAT_CLIPBOARD
 // Note: Keep this in sync with did_set_clipboard()

--- a/src/testdir/test_increment.vim
+++ b/src/testdir/test_increment.vim
@@ -840,6 +840,44 @@ func Test_increment_unsigned()
   set nrformats-=unsigned
 endfunc
 
+" Try incrementing/decrementing a number when nrformats contains blank
+func Test_increment_blank()
+  set nrformats+=blank
+
+  " Signed
+  call setline(1, '0')
+  exec "norm! gg0\<C-X>"
+  call assert_equal('-1', getline(1))
+
+  call setline(1, '3')
+  exec "norm! gg010\<C-X>"
+  call assert_equal('-7', getline(1))
+
+  call setline(1, '-0')
+  exec "norm! gg0\<C-X>"
+  call assert_equal("-1", getline(1))
+
+  " Unsigned
+  " NOTE: 18446744073709551615 == 2^64 - 1
+  call setline(1, 'a-18446744073709551615')
+  exec "norm! gg0\<C-A>"
+  call assert_equal('a-18446744073709551615', getline(1))
+
+  call setline(1, 'a-18446744073709551615')
+  exec "norm! gg0\<C-A>"
+  call assert_equal('a-18446744073709551615', getline(1))
+
+  call setline(1, 'a-18446744073709551614')
+  exec "norm! gg08\<C-A>"
+  call assert_equal('a-18446744073709551615', getline(1))
+
+  call setline(1, 'a-1')
+  exec "norm! gg0\<C-A>"
+  call assert_equal('a-2', getline(1))
+
+  set nrformats-=blank
+endfunc
+
 func Test_in_decrement_large_number()
   " NOTE: 18446744073709551616 == 2^64
   call setline(1, '18446744073709551616')


### PR DESCRIPTION
Implement context-based incrementing and decrementing as suggested in #15033.  