### PR TITLE
Use correct script ctx when evaluating member init

### DIFF
--- a/src/structs.h
+++ b/src/structs.h
@@ -1551,6 +1551,7 @@ typedef struct {
     type_T	*ocm_type;
     int		ocm_flags;
     char_u	*ocm_init;	// allocated
+    sctx_T	ocm_init_sctx;	// script context of the initializer expression
 } ocmember_T;
 
 // used for the lookup table of a class member index and object method index

--- a/src/testdir/test_vim9_import.vim
+++ b/src/testdir/test_vim9_import.vim
@@ -3330,4 +3330,25 @@ def Test_import_locked_var()
   v9.CheckScriptFailure(lines, 'E741: Value is locked: Foo', 3)
 enddef
 
+def Test_import_member_initializer()
+  var lines =<< trim END
+    vim9script
+    export const DEFAULT = 'default'
+    export class Foo
+      public var x = DEFAULT
+    endclass
+  END
+  writefile(lines, 'Ximportclass.vim', 'D')
+  # The initializer for Foo.x is evaluated in the context of Ximportclass.vim.
+  lines =<< trim END
+    vim9script
+    import './Ximportclass.vim' as X
+    class Bar extends X.Foo
+    endclass
+    var o = Bar.new()
+    assert_equal(X.DEFAULT, o.x)
+  END
+  v9.CheckScriptSuccess(lines)
+enddef
+
 " vim: ts=8 sw=2 sts=2 expandtab tw=80 fdm=marker

--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -3295,9 +3295,13 @@ obj_constructor_prologue(ufunc_T *ufunc, cctx_T *cctx)
 
 	if (m->ocm_init != NULL)
 	{
-	    char_u *expr = m->ocm_init;
+	    char_u	*expr = m->ocm_init;
+	    sctx_T	save_current_sctx = current_sctx;
 
-	    if (compile_expr0(&expr, cctx) == FAIL)
+	    current_sctx = m->ocm_init_sctx;
+	    int r = compile_expr0(&expr, cctx);
+	    current_sctx = save_current_sctx;
+	    if (r == FAIL)
 		return FAIL;
 
 	    if (!ends_excmd2(m->ocm_init, expr))


### PR DESCRIPTION
The initializer expression for class members is evaluated as-needed. Use the script context where the class is defined when evaluating it to avoid missing variable errors.

Closes #14011