### PR TITLE
translation: update spelling suggestion message across all languages

### DIFF
--- a/src/po/ca.po
+++ b/src/po/ca.po
@@ -1326,8 +1326,8 @@ msgstr " Compleció definida per l'usuari (^U^N^P)"
 msgid " Omni completion (^O^N^P)"
 msgstr " Omni-compleció (^O^N^P)"
 
-msgid " Spelling suggestion (s^N^P)"
-msgstr " Suggeriment d'ortografia (s^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
+msgstr " Suggeriment d'ortografia (^S^N^P)"
 
 # i C-x C-p
 msgid " Keyword Local completion (^N^P)"

--- a/src/po/da.po
+++ b/src/po/da.po
@@ -412,8 +412,8 @@ msgstr " Fuldførelse af brugerdefineret (^U^N^P)"
 msgid " Omni completion (^O^N^P)"
 msgstr " Fuldførelse af omni (^O^N^P)"
 
-msgid " Spelling suggestion (s^N^P)"
-msgstr " Staveforslag (s^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
+msgstr " Staveforslag (^S^N^P)"
 
 msgid " Keyword Local completion (^N^P)"
 msgstr " Fuldførelse af nøgleord local (^N^P)"

--- a/src/po/de.po
+++ b/src/po/de.po
@@ -1376,8 +1376,8 @@ msgstr " Benutzerdefinierte Vervollständigung (^U^N^P)"
 msgid " Omni completion (^O^N^P)"
 msgstr " Omni-Vervollständigung (^O^N^P)"
 
-msgid " Spelling suggestion (s^N^P)"
-msgstr " Vorschlag der Rechtschreibprüfung (s^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
+msgstr " Vorschlag der Rechtschreibprüfung (^S^N^P)"
 
 msgid " Keyword Local completion (^N^P)"
 msgstr " Lokale Stichwort-Vervollständigung(^N^P)"

--- a/src/po/eo.po
+++ b/src/po/eo.po
@@ -2616,8 +2616,8 @@ msgstr " Kompletigo difinita de uzanto (^U^N^P)"
 msgid " Omni completion (^O^N^P)"
 msgstr " Kompletigo Omni (^O^N^P)"
 
-msgid " Spelling suggestion (s^N^P)"
-msgstr " Sugesto de literumo (s^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
+msgstr " Sugesto de literumo (^S^N^P)"
 
 msgid " Keyword Local completion (^N^P)"
 msgstr " Kompletigo loka de ŝlosilvorto (^N/^P)"

--- a/src/po/es.po
+++ b/src/po/es.po
@@ -1351,8 +1351,8 @@ msgstr " Completar definido por usuario (^U^N^P)"
 msgid " Omni completion (^O^N^P)"
 msgstr " Completar con método Omni (^O^N^P)"
 
-msgid " Spelling suggestion (s^N^P)"
-msgstr " Sugerencia de ortografía (s^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
+msgstr " Sugerencia de ortografía (^S^N^P)"
 
 # Scroll has its own msgs, in its place there is the msg for local
 # * ctrl_x_mode = 0 (eg continue_status & CONT_LOCAL)  -- Acevedo

--- a/src/po/fi.po
+++ b/src/po/fi.po
@@ -1325,8 +1325,8 @@ msgstr " Käyttäjän määrittelemä täydennys (^U^N^P)"
 msgid " Omni completion (^O^N^P)"
 msgstr " Omnitäydennys (^O^N^P)"
 
-msgid " Spelling suggestion (s^N^P)"
-msgstr " Oikaisulukuehdotus (s^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
+msgstr " Oikaisulukuehdotus (^S^N^P)"
 
 msgid " Keyword Local completion (^N^P)"
 msgstr " Avainsanan paikallinen täydennys (^N^P)"

--- a/src/po/fr.po
+++ b/src/po/fr.po
@@ -2738,8 +2738,8 @@ msgstr " Complètement défini par l'utilisateur (^U^N^P)"
 msgid " Omni completion (^O^N^P)"
 msgstr " Complètement selon le type de fichier (Omni) (^O^N^P)"
 
-msgid " Spelling suggestion (s^N^P)"
-msgstr " Suggestion d'orthographe (s^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
+msgstr " Suggestion d'orthographe (^S^N^P)"
 
 msgid " Keyword Local completion (^N^P)"
 msgstr " Complètement local de mot-clé (^N/^P)"

--- a/src/po/ga.po
+++ b/src/po/ga.po
@@ -1401,8 +1401,8 @@ msgstr " Comhlánú saincheaptha (^U^N^P)"
 msgid " Omni completion (^O^N^P)"
 msgstr " Comhlánú Omni (^O^N^P)"
 
-msgid " Spelling suggestion (s^N^P)"
-msgstr " Moladh litrithe (s^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
+msgstr " Moladh litrithe (^S^N^P)"
 
 msgid " Keyword Local completion (^N^P)"
 msgstr " Comhlánú logánta lorgfhocal (^N^P)"

--- a/src/po/hu.po
+++ b/src/po/hu.po
@@ -264,8 +264,8 @@ msgstr " Felhasználó által definiált kiegészítés (^U^N^P)"
 msgid " Omni completion (^O^N^P)"
 msgstr " Omni kiegészítés (^O^N^P)"
 
-msgid " Spelling suggestion (s^N^P)"
-msgstr " Helyesírási javaslat (s^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
+msgstr " Helyesírási javaslat (^S^N^P)"
 
 msgid " Keyword Local completion (^N^P)"
 msgstr " Kulcsszó helyi kiegészítés (^N^P)"

--- a/src/po/it.po
+++ b/src/po/it.po
@@ -1287,8 +1287,8 @@ msgstr " Completamento definito dall'utente (^U^N^P)"
 msgid " Omni completion (^O^N^P)"
 msgstr " Completamento globale (^O^N^P)"
 
-msgid " Spelling suggestion (s^N^P)"
-msgstr " Suggerimento ortografico (s^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
+msgstr " Suggerimento ortografico (^S^N^P)"
 
 msgid " Keyword Local completion (^N^P)"
 msgstr " Completamento Parola Locale (^N^P)"

--- a/src/po/ja.euc-jp.po
+++ b/src/po/ja.euc-jp.po
@@ -1337,8 +1337,8 @@ msgstr " ユーザー定義補完 (^U^N^P)"
 msgid " Omni completion (^O^N^P)"
 msgstr " オムニ補完 (^O^N^P)"
 
-msgid " Spelling suggestion (s^N^P)"
-msgstr " 綴り修正候補 (s^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
+msgstr " 綴り修正候補 (^S^N^P)"
 
 msgid " Keyword Local completion (^N^P)"
 msgstr " 局所キーワード補完 (^N^P)"

--- a/src/po/ja.po
+++ b/src/po/ja.po
@@ -1337,8 +1337,8 @@ msgstr " ユーザー定義補完 (^U^N^P)"
 msgid " Omni completion (^O^N^P)"
 msgstr " オムニ補完 (^O^N^P)"
 
-msgid " Spelling suggestion (s^N^P)"
-msgstr " 綴り修正候補 (s^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
+msgstr " 綴り修正候補 (^S^N^P)"
 
 msgid " Keyword Local completion (^N^P)"
 msgstr " 局所キーワード補完 (^N^P)"

--- a/src/po/ja.sjis.po
+++ b/src/po/ja.sjis.po
@@ -1337,8 +1337,8 @@ msgstr " ユーザー定義補完 (^U^N^P)"
 msgid " Omni completion (^O^N^P)"
 msgstr " オムニ補完 (^O^N^P)"
 
-msgid " Spelling suggestion (s^N^P)"
-msgstr " 綴り修正候補 (s^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
+msgstr " 綴り修正候補 (^S^N^P)"
 
 msgid " Keyword Local completion (^N^P)"
 msgstr " 局所キーワード補完 (^N^P)"

--- a/src/po/ko.UTF-8.po
+++ b/src/po/ko.UTF-8.po
@@ -411,8 +411,8 @@ msgstr " 사용자 정의 완성 (^U^N^P)"
 msgid " Omni completion (^O^N^P)"
 msgstr " Omni 완성 (^O^N^P)"
 
-msgid " Spelling suggestion (s^N^P)"
-msgstr " 단어 제안 (s^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
+msgstr " 단어 제안 (^S^N^P)"
 
 msgid " Keyword Local completion (^N^P)"
 msgstr " 낱말 로컬 완성 (^N^P)"

--- a/src/po/ko.po
+++ b/src/po/ko.po
@@ -411,8 +411,8 @@ msgstr " 사용자 정의 완성 (^U^N^P)"
 msgid " Omni completion (^O^N^P)"
 msgstr " Omni 완성 (^O^N^P)"
 
-msgid " Spelling suggestion (s^N^P)"
-msgstr " 단어 제안 (s^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
+msgstr " 단어 제안 (^S^N^P)"
 
 msgid " Keyword Local completion (^N^P)"
 msgstr " 낱말 로컬 완성 (^N^P)"

--- a/src/po/nb.po
+++ b/src/po/nb.po
@@ -283,9 +283,8 @@ msgstr " Brukerdefinert fullføring (^U^N^P)"
 msgid " Omni completion (^O^N^P)"
 msgstr " Omni-fullføring (^O^N^P)"
 
-#, fuzzy
-#~ msgid " Spelling suggestion (s^N^P)"
-#~ msgstr " Staveforslag (^S^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
+msgstr " Staveforslag (^S^N^P)"
 
 msgid " Keyword Local completion (^N^P)"
 msgstr " Lokal nøkkelordfullføring (^N^P)"

--- a/src/po/nl.po
+++ b/src/po/nl.po
@@ -287,8 +287,8 @@ msgstr " gebruikergedefinieerde voltooiing (^U^N^P)"
 msgid " Omni completion (^O^N^P)"
 msgstr " omni-voltooiing (^O^N^P)"
 
-msgid " Spelling suggestion (s^N^P)"
-msgstr " spellingsuggestie (s^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
+msgstr " spellingsuggestie (^S^N^P)"
 
 msgid " Keyword Local completion (^N^P)"
 msgstr " lokaal-trefwoordvoltooiing (^N^P)"

--- a/src/po/no.po
+++ b/src/po/no.po
@@ -283,9 +283,8 @@ msgstr " Brukerdefinert fullføring (^U^N^P)"
 msgid " Omni completion (^O^N^P)"
 msgstr " Omni-fullføring (^O^N^P)"
 
-#, fuzzy
-#~ msgid " Spelling suggestion (s^N^P)"
-#~ msgstr " Staveforslag (^S^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
+msgstr " Staveforslag (^S^N^P)"
 
 msgid " Keyword Local completion (^N^P)"
 msgstr " Lokal nøkkelordfullføring (^N^P)"

--- a/src/po/pl.UTF-8.po
+++ b/src/po/pl.UTF-8.po
@@ -298,8 +298,8 @@ msgstr "Dopełnianie zdefiniowane przez użytkownika (^U^N^P)"
 msgid " Omni completion (^O^N^P)"
 msgstr " Omni uzupełnianie (^O^N^P)"
 
-msgid " Spelling suggestion (s^N^P)"
-msgstr "Propozycja pisowni (^L^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
+msgstr "Propozycja pisowni (^S^N^P)"
 
 msgid " Keyword Local completion (^N^P)"
 msgstr " Lokalne dopełnianie słów kluczowych (^N^P)"

--- a/src/po/pl.cp1250.po
+++ b/src/po/pl.cp1250.po
@@ -298,8 +298,8 @@ msgstr "Dope³nianie zdefiniowane przez u¿ytkownika (^U^N^P)"
 msgid " Omni completion (^O^N^P)"
 msgstr " Omni uzupe³nianie (^O^N^P)"
 
-msgid " Spelling suggestion (s^N^P)"
-msgstr "Propozycja pisowni (^L^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
+msgstr "Propozycja pisowni (^S^N^P)"
 
 msgid " Keyword Local completion (^N^P)"
 msgstr " Lokalne dope³nianie s³ów kluczowych (^N^P)"

--- a/src/po/pl.po
+++ b/src/po/pl.po
@@ -298,8 +298,8 @@ msgstr "Dope³nianie zdefiniowane przez u¿ytkownika (^U^N^P)"
 msgid " Omni completion (^O^N^P)"
 msgstr " Omni uzupe³nianie (^O^N^P)"
 
-msgid " Spelling suggestion (s^N^P)"
-msgstr "Propozycja pisowni (^L^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
+msgstr "Propozycja pisowni (^S^N^P)"
 
 msgid " Keyword Local completion (^N^P)"
 msgstr " Lokalne dope³nianie s³ów kluczowych (^N^P)"

--- a/src/po/pt_BR.po
+++ b/src/po/pt_BR.po
@@ -406,8 +406,8 @@ msgstr " Completar definido pelo usuário (^U^N^P)"
 msgid " Omni completion (^O^N^P)"
 msgstr " Completação inteligente (^O^N^P)"
 
-msgid " Spelling suggestion (s^N^P)"
-msgstr " Sugestão de ortografia (s^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
+msgstr " Sugestão de ortografia (^S^N^P)"
 
 msgid " Keyword Local completion (^N^P)"
 msgstr " Completar palavra-chave local (^N^P)"

--- a/src/po/ru.cp1251.po
+++ b/src/po/ru.cp1251.po
@@ -2045,7 +2045,7 @@ msgid " Omni completion (^O^N^P)"
 msgstr " Подстановка по контексту CTRL+O и CTRL+N или CTRL+P"
 
 # :!~ Restorer
-msgid " Spelling suggestion (s^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
 msgstr " Подстановка вариантов написания CTRL+S и CTRL+N или CTRL+P"
 
 # :!~ Restorer

--- a/src/po/ru.po
+++ b/src/po/ru.po
@@ -2039,7 +2039,7 @@ msgid " Omni completion (^O^N^P)"
 msgstr " Подстановка по контексту CTRL+O и CTRL+N или CTRL+P"
 
 # :!~ Restorer
-msgid " Spelling suggestion (s^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
 msgstr " Подстановка вариантов написания CTRL+S и CTRL+N или CTRL+P"
 
 # :!~ Restorer

--- a/src/po/sr.po
+++ b/src/po/sr.po
@@ -1372,8 +1372,8 @@ msgstr " Кориснички дефинисано довршавање (^U^N^P)
 msgid " Omni completion (^O^N^P)"
 msgstr " Omni довршавање (^O^N^P)"
 
-msgid " Spelling suggestion (s^N^P)"
-msgstr " Правописни предлог (s^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
+msgstr " Правописни предлог (^S^N^P)"
 
 msgid " Keyword Local completion (^N^P)"
 msgstr " Довршавање локалне кључне речи (^N^P)"

--- a/src/po/sv.po
+++ b/src/po/sv.po
@@ -261,8 +261,8 @@ msgstr " Användardefinierad komplettering (^U^N^P)"
 msgid " Omni completion (^O^N^P)"
 msgstr " Omnikomplettering (^O^N^P)"
 
-msgid " Spelling suggestion (s^N^P)"
-msgstr " Stavningsförslag (s^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
+msgstr " Stavningsförslag (^S^N^P)"
 
 msgid " Keyword Local completion (^N^P)"
 msgstr " Lokal nyckelordskomplettering (^N^P)"

--- a/src/po/tr.po
+++ b/src/po/tr.po
@@ -1348,8 +1348,8 @@ msgstr " Kullanıcı tanımlı tamamlamalar (^U^N^P)"
 msgid " Omni completion (^O^N^P)"
 msgstr " Omni tamamlaması (^O^N^P)"
 
-msgid " Spelling suggestion (s^N^P)"
-msgstr " Yazım önerisi (s^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
+msgstr " Yazım önerisi (^S^N^P)"
 
 msgid " Keyword Local completion (^N^P)"
 msgstr " Dahili anahtar sözcük tamamlaması (^N^P)"

--- a/src/po/uk.cp1251.po
+++ b/src/po/uk.cp1251.po
@@ -1386,8 +1386,8 @@ msgstr " Користувацьке доповнення (^U^N^P)"
 msgid " Omni completion (^O^N^P)"
 msgstr " Кмітливе доповнення (^O^N^P)"
 
-msgid " Spelling suggestion (s^N^P)"
-msgstr " Орфографічна підказка (s^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
+msgstr " Орфографічна підказка (^S^N^P)"
 
 msgid " Keyword Local completion (^N^P)"
 msgstr " Доповнення місцевих ключових слів (^N^P)"

--- a/src/po/uk.po
+++ b/src/po/uk.po
@@ -1386,8 +1386,8 @@ msgstr " Користувацьке доповнення (^U^N^P)"
 msgid " Omni completion (^O^N^P)"
 msgstr " Кмітливе доповнення (^O^N^P)"
 
-msgid " Spelling suggestion (s^N^P)"
-msgstr " Орфографічна підказка (s^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
+msgstr " Орфографічна підказка (^S^N^P)"
 
 msgid " Keyword Local completion (^N^P)"
 msgstr " Доповнення місцевих ключових слів (^N^P)"

--- a/src/po/zh_CN.UTF-8.po
+++ b/src/po/zh_CN.UTF-8.po
@@ -1291,8 +1291,8 @@ msgstr " 用户自定义补全 (^U^N^P)"
 msgid " Omni completion (^O^N^P)"
 msgstr " 全能补全 (^O^N^P)"
 
-msgid " Spelling suggestion (s^N^P)"
-msgstr " 拼写建议 (s^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
+msgstr " 拼写建议 (^S^N^P)"
 
 msgid " Keyword Local completion (^N^P)"
 msgstr " 关键字局部补全 (^N^P)"

--- a/src/po/zh_CN.cp936.po
+++ b/src/po/zh_CN.cp936.po
@@ -1291,8 +1291,8 @@ msgstr " 用户自定义补全 (^U^N^P)"
 msgid " Omni completion (^O^N^P)"
 msgstr " 全能补全 (^O^N^P)"
 
-msgid " Spelling suggestion (s^N^P)"
-msgstr " 拼写建议 (s^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
+msgstr " 拼写建议 (^S^N^P)"
 
 msgid " Keyword Local completion (^N^P)"
 msgstr " 关键字局部补全 (^N^P)"

--- a/src/po/zh_CN.po
+++ b/src/po/zh_CN.po
@@ -1291,8 +1291,8 @@ msgstr " 用户自定义补全 (^U^N^P)"
 msgid " Omni completion (^O^N^P)"
 msgstr " 全能补全 (^O^N^P)"
 
-msgid " Spelling suggestion (s^N^P)"
-msgstr " 拼写建议 (s^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
+msgstr " 拼写建议 (^S^N^P)"
 
 msgid " Keyword Local completion (^N^P)"
 msgstr " 关键字局部补全 (^N^P)"


### PR DESCRIPTION
I updated the translation files based on the discussion in [this thread](https://github.com/vim/vim/pull/15065#issuecomment-2183187747).

There was debate about whether this should be done or not, but I decided to submit a pull request for it anyway.

It doesn't _exactly_ follow the process in `src/po/README.txt`, but if this update is not made now, then messages will be incorrect until each individual language translation is updated. That could take a long time, and in the meantime the messages will not be up to date.