### PR TITLE
(Try to) gracefully handle out-of-memory in bindtextdomain().

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -68,7 +68,7 @@ balloon_gettext()		String	current text in the balloon
 balloon_show({expr})		none	show {expr} inside the balloon
 balloon_split({msg})		List	split {msg} as used for a balloon
 bindtextdomain({package}, {path})
-				none	bind text domain to specied path
+				Bool	bind text domain to specified path
 blob2list({blob})		List	convert {blob} into a list of numbers
 browse({save}, {title}, {initdir}, {default})
 				String	put up a file requester
@@ -1227,7 +1227,10 @@ bindtextdomain({package}, {path})			*bindtextdomain()*
 		translations for a package.  {path} is the directory name
 		for the translations. See |package-create|.
 
-		Return type: none
+		Returns v:true on success and v:false on failure (out of
+		memory).
+
+		Return type: |vim9-boolean|
 
 blob2list({blob})					*blob2list()*
 		Return a List containing the number value of each byte in Blob

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -1826,7 +1826,7 @@ static funcentry_T global_functions[] =
 #endif
 			},
     {"bindtextdomain",	2, 2, 0,	    arg2_string,
-			ret_void,	    f_bindtextdomain},
+			ret_bool,	    f_bindtextdomain},
     {"blob2list",	1, 1, FEARG_1,	    arg1_blob,
 			ret_list_number,    f_blob2list},
     {"browse",		4, 4, 0,	    arg4_browse,
@@ -3483,8 +3483,11 @@ get_buf_arg(typval_T *arg)
  * "bindtextdomain(package, path)" function
  */
     static void
-f_bindtextdomain(typval_T *argvars UNUSED, typval_T *rettv UNUSED)
+f_bindtextdomain(typval_T *argvars, typval_T *rettv)
 {
+    rettv->v_type = VAR_BOOL;
+    rettv->vval.v_number = VVAL_TRUE;
+
     if (check_for_nonempty_string_arg(argvars, 0) == FAIL
 	    || check_for_nonempty_string_arg(argvars, 1) == FAIL)
 	return;
@@ -3492,7 +3495,13 @@ f_bindtextdomain(typval_T *argvars UNUSED, typval_T *rettv UNUSED)
     if (strcmp((const char *)argvars[0].vval.v_string, VIMPACKAGE) == 0)
 	semsg(_(e_invalid_argument_str), tv_get_string(&argvars[0]));
     else
-	bindtextdomain((const char *)argvars[0].vval.v_string, (const char *)argvars[1].vval.v_string);
+    {
+	if (bindtextdomain((const char *)argvars[0].vval.v_string, (const char *)argvars[1].vval.v_string) == NULL)
+	{
+	    do_outofmem_msg((long)0);
+	    rettv->vval.v_number = VVAL_FALSE;
+	}
+    }
 
     return;
 }

--- a/src/testdir/test_gettext.vim
+++ b/src/testdir/test_gettext.vim
@@ -1,18 +1,18 @@
 source check.vim
 
+CheckFeature gettext
+
 " Test for gettext()
 func Test_gettext()
-  if has("gettext")
-    call assert_fails('call bindtextdomain("test")', 'E119:')
-    call assert_fails('call bindtextdomain("vim", "test")', 'E475:')
+  call assert_fails('call bindtextdomain("test")', 'E119:')
+  call assert_fails('call bindtextdomain("vim", "test")', 'E475:')
 
-    call assert_fails('call gettext(1)', 'E1174:')
-    call assert_equal('xxxTESTxxx', gettext("xxxTESTxxx"))
+  call assert_fails('call gettext(1)', 'E1174:')
+  call assert_equal('xxxTESTxxx', gettext("xxxTESTxxx"))
 
-    call assert_equal('xxxTESTxxx', gettext("xxxTESTxxx", "vim"))
-    call assert_equal('xxxTESTxxx', gettext("xxxTESTxxx", "__PACKAGE__"))
-    call assert_equal('ERROR: ', gettext("ERROR: ", "__PACKAGE__"))
-  endif
+  call assert_equal('xxxTESTxxx', gettext("xxxTESTxxx", "vim"))
+  call assert_equal('xxxTESTxxx', gettext("xxxTESTxxx", "__PACKAGE__"))
+  call assert_equal('ERROR: ', gettext("ERROR: ", "__PACKAGE__"))
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_gettext.vim
+++ b/src/testdir/test_gettext.vim
@@ -2,15 +2,17 @@ source check.vim
 
 " Test for gettext()
 func Test_gettext()
-  call assert_fails('call bindtextdomain("test")', 'E119:')
-  call assert_fails('call bindtextdomain("vim", "test")', 'E475:')
+  if has("gettext")
+    call assert_fails('call bindtextdomain("test")', 'E119:')
+    call assert_fails('call bindtextdomain("vim", "test")', 'E475:')
 
-  call assert_fails('call gettext(1)', 'E1174:')
-  call assert_equal('xxxTESTxxx', gettext("xxxTESTxxx"))
+    call assert_fails('call gettext(1)', 'E1174:')
+    call assert_equal('xxxTESTxxx', gettext("xxxTESTxxx"))
 
-  call assert_equal('xxxTESTxxx', gettext("xxxTESTxxx", "vim"))
-  call assert_equal('xxxTESTxxx', gettext("xxxTESTxxx", "__PACKAGE__"))
-  call assert_equal('ERROR: ', gettext("ERROR: ", "__PACKAGE__"))
+    call assert_equal('xxxTESTxxx', gettext("xxxTESTxxx", "vim"))
+    call assert_equal('xxxTESTxxx', gettext("xxxTESTxxx", "__PACKAGE__"))
+    call assert_equal('ERROR: ', gettext("ERROR: ", "__PACKAGE__"))
+  endif
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_gettext_cp1251.vim
+++ b/src/testdir/test_gettext_cp1251.vim
@@ -6,18 +6,25 @@ CheckNotMSWindows
 " Test for gettext()
 func Test_gettext()
   set encoding=cp1251
-  call bindtextdomain("__PACKAGE__", getcwd())
+  call assert_equal('ERROR: ', gettext("ERROR: ", "__PACKAGE__"))
+
   try
-    language ru_RU
-    call assert_equal('Œÿ»¡ ¿: ', gettext("ERROR: ", "__PACKAGE__"))
-  catch /^Vim\%((\a\+)\)\=:E197:/
-    throw "Skipped: not possible to set locale to ru (missing?)"
-  endtry
-  try
-    language en_GB.UTF-8
-    call assert_equal('ERROR: ', gettext("ERROR: ", "__PACKAGE__"))
-  catch /^Vim\%((\a\+)\)\=:E197:/
-    throw "Skipped: not possible to set locale to en (missing?)"
+    call assert_true(bindtextdomain("__PACKAGE__", getcwd()))
+
+    try
+      language ru_RU
+      call assert_equal('Œÿ»¡ ¿: ', gettext("ERROR: ", "__PACKAGE__"))
+    catch /^Vim\%((\a\+)\)\=:E197:/
+      throw "Skipped: not possible to set locale to ru (missing?)"
+    endtry
+    try
+      language en_GB.UTF-8
+      call assert_equal('ERROR: ', gettext("ERROR: ", "__PACKAGE__"))
+    catch /^Vim\%((\a\+)\)\=:E197:/
+      throw "Skipped: not possible to set locale to en (missing?)"
+    endtry
+  catch /^Vim\%((\a\+)\)\=:E342:/
+    throw "Skipped: out of memory executing bindtextdomain()"
   endtry
   set encoding&
 endfunc

--- a/src/testdir/test_gettext_cp1251.vim
+++ b/src/testdir/test_gettext_cp1251.vim
@@ -3,32 +3,32 @@ source check.vim
 CheckNotMac
 CheckNotMSWindows
 
+CheckFeature gettext
+
 " Test for gettext()
 func Test_gettext()
-  if has("gettext")
-    set encoding=cp1251
-    call assert_equal('ERROR: ', gettext("ERROR: ", "__PACKAGE__"))
+  set encoding=cp1251
+  call assert_equal('ERROR: ', gettext("ERROR: ", "__PACKAGE__"))
+
+  try
+    call assert_true(bindtextdomain("__PACKAGE__", getcwd()))
 
     try
-      call assert_true(bindtextdomain("__PACKAGE__", getcwd()))
-
-      try
-        language ru_RU
-        call assert_equal('Œÿ»¡ ¿: ', gettext("ERROR: ", "__PACKAGE__"))
-      catch /^Vim\%((\a\+)\)\=:E197:/
-        throw "Skipped: not possible to set locale to ru (missing?)"
-      endtry
-      try
-        language en_GB.UTF-8
-        call assert_equal('ERROR: ', gettext("ERROR: ", "__PACKAGE__"))
-      catch /^Vim\%((\a\+)\)\=:E197:/
-        throw "Skipped: not possible to set locale to en (missing?)"
-      endtry
-    catch /^Vim\%((\a\+)\)\=:E342:/
-      throw "Skipped: out of memory executing bindtextdomain()"
+      language ru_RU
+      call assert_equal('Œÿ»¡ ¿: ', gettext("ERROR: ", "__PACKAGE__"))
+    catch /^Vim\%((\a\+)\)\=:E197:/
+      throw "Skipped: not possible to set locale to ru (missing?)"
     endtry
-    set encoding&
-  endif
+    try
+      language en_GB.UTF-8
+      call assert_equal('ERROR: ', gettext("ERROR: ", "__PACKAGE__"))
+    catch /^Vim\%((\a\+)\)\=:E197:/
+      throw "Skipped: not possible to set locale to en (missing?)"
+    endtry
+  catch /^Vim\%((\a\+)\)\=:E342:/
+    throw "Skipped: out of memory executing bindtextdomain()"
+  endtry
+  set encoding&
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_gettext_cp1251.vim
+++ b/src/testdir/test_gettext_cp1251.vim
@@ -5,28 +5,30 @@ CheckNotMSWindows
 
 " Test for gettext()
 func Test_gettext()
-  set encoding=cp1251
-  call assert_equal('ERROR: ', gettext("ERROR: ", "__PACKAGE__"))
-
-  try
-    call assert_true(bindtextdomain("__PACKAGE__", getcwd()))
+  if has("gettext")
+    set encoding=cp1251
+    call assert_equal('ERROR: ', gettext("ERROR: ", "__PACKAGE__"))
 
     try
-      language ru_RU
-      call assert_equal('Œÿ»¡ ¿: ', gettext("ERROR: ", "__PACKAGE__"))
-    catch /^Vim\%((\a\+)\)\=:E197:/
-      throw "Skipped: not possible to set locale to ru (missing?)"
+      call assert_true(bindtextdomain("__PACKAGE__", getcwd()))
+
+      try
+        language ru_RU
+        call assert_equal('Œÿ»¡ ¿: ', gettext("ERROR: ", "__PACKAGE__"))
+      catch /^Vim\%((\a\+)\)\=:E197:/
+        throw "Skipped: not possible to set locale to ru (missing?)"
+      endtry
+      try
+        language en_GB.UTF-8
+        call assert_equal('ERROR: ', gettext("ERROR: ", "__PACKAGE__"))
+      catch /^Vim\%((\a\+)\)\=:E197:/
+        throw "Skipped: not possible to set locale to en (missing?)"
+      endtry
+    catch /^Vim\%((\a\+)\)\=:E342:/
+      throw "Skipped: out of memory executing bindtextdomain()"
     endtry
-    try
-      language en_GB.UTF-8
-      call assert_equal('ERROR: ', gettext("ERROR: ", "__PACKAGE__"))
-    catch /^Vim\%((\a\+)\)\=:E197:/
-      throw "Skipped: not possible to set locale to en (missing?)"
-    endtry
-  catch /^Vim\%((\a\+)\)\=:E342:/
-    throw "Skipped: out of memory executing bindtextdomain()"
-  endtry
-  set encoding&
+    set encoding&
+  endif
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_gettext_utf8.vim
+++ b/src/testdir/test_gettext_utf8.vim
@@ -6,18 +6,25 @@ CheckNotMSWindows
 " Test for gettext()
 func Test_gettext()
   set encoding=utf-8
-  call bindtextdomain("__PACKAGE__", getcwd())
+  call assert_equal('ERROR: ', gettext("ERROR: ", "__PACKAGE__"))
+
   try
-    language ru_RU
-    call assert_equal('ОШИБКА: ', gettext("ERROR: ", "__PACKAGE__"))
-  catch /^Vim\%((\a\+)\)\=:E197:/
-    throw "Skipped: not possible to set locale to ru (missing?)"
-  endtry
-  try
-    language en_GB.UTF-8
-    call assert_equal('ERROR: ', gettext("ERROR: ", "__PACKAGE__"))
-  catch /^Vim\%((\a\+)\)\=:E197:/
-    throw "Skipped: not possible to set locale to en (missing?)"
+    call assert_true(bindtextdomain("__PACKAGE__", getcwd()))
+
+    try
+      language ru_RU
+      call assert_equal('ОШИБКА: ', gettext("ERROR: ", "__PACKAGE__"))
+    catch /^Vim\%((\a\+)\)\=:E197:/
+      throw "Skipped: not possible to set locale to ru (missing?)"
+    endtry
+    try
+      language en_GB.UTF-8
+      call assert_equal('ERROR: ', gettext("ERROR: ", "__PACKAGE__"))
+    catch /^Vim\%((\a\+)\)\=:E197:/
+      throw "Skipped: not possible to set locale to en (missing?)"
+    endtry
+  catch /^Vim\%((\a\+)\)\=:E342:/
+    throw "Skipped: out of memory executing bindtextdomain()"
   endtry
   set encoding&
 endfunc

--- a/src/testdir/test_gettext_utf8.vim
+++ b/src/testdir/test_gettext_utf8.vim
@@ -5,28 +5,30 @@ CheckNotMSWindows
 
 " Test for gettext()
 func Test_gettext()
-  set encoding=utf-8
-  call assert_equal('ERROR: ', gettext("ERROR: ", "__PACKAGE__"))
-
-  try
-    call assert_true(bindtextdomain("__PACKAGE__", getcwd()))
+  if has("gettext")
+    set encoding=utf-8
+    call assert_equal('ERROR: ', gettext("ERROR: ", "__PACKAGE__"))
 
     try
-      language ru_RU
-      call assert_equal('ОШИБКА: ', gettext("ERROR: ", "__PACKAGE__"))
-    catch /^Vim\%((\a\+)\)\=:E197:/
-      throw "Skipped: not possible to set locale to ru (missing?)"
+      call assert_true(bindtextdomain("__PACKAGE__", getcwd()))
+
+      try
+        language ru_RU
+        call assert_equal('ОШИБКА: ', gettext("ERROR: ", "__PACKAGE__"))
+      catch /^Vim\%((\a\+)\)\=:E197:/
+        throw "Skipped: not possible to set locale to ru (missing?)"
+      endtry
+      try
+        language en_GB.UTF-8
+        call assert_equal('ERROR: ', gettext("ERROR: ", "__PACKAGE__"))
+      catch /^Vim\%((\a\+)\)\=:E197:/
+        throw "Skipped: not possible to set locale to en (missing?)"
+      endtry
+    catch /^Vim\%((\a\+)\)\=:E342:/
+      throw "Skipped: out of memory executing bindtextdomain()"
     endtry
-    try
-      language en_GB.UTF-8
-      call assert_equal('ERROR: ', gettext("ERROR: ", "__PACKAGE__"))
-    catch /^Vim\%((\a\+)\)\=:E197:/
-      throw "Skipped: not possible to set locale to en (missing?)"
-    endtry
-  catch /^Vim\%((\a\+)\)\=:E342:/
-    throw "Skipped: out of memory executing bindtextdomain()"
-  endtry
-  set encoding&
+    set encoding&
+  endif
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_gettext_utf8.vim
+++ b/src/testdir/test_gettext_utf8.vim
@@ -3,32 +3,32 @@ source check.vim
 CheckNotMac
 CheckNotMSWindows
 
+CheckFeature gettext
+
 " Test for gettext()
 func Test_gettext()
-  if has("gettext")
-    set encoding=utf-8
-    call assert_equal('ERROR: ', gettext("ERROR: ", "__PACKAGE__"))
+  set encoding=utf-8
+  call assert_equal('ERROR: ', gettext("ERROR: ", "__PACKAGE__"))
+
+  try
+    call assert_true(bindtextdomain("__PACKAGE__", getcwd()))
 
     try
-      call assert_true(bindtextdomain("__PACKAGE__", getcwd()))
-
-      try
-        language ru_RU
-        call assert_equal('ОШИБКА: ', gettext("ERROR: ", "__PACKAGE__"))
-      catch /^Vim\%((\a\+)\)\=:E197:/
-        throw "Skipped: not possible to set locale to ru (missing?)"
-      endtry
-      try
-        language en_GB.UTF-8
-        call assert_equal('ERROR: ', gettext("ERROR: ", "__PACKAGE__"))
-      catch /^Vim\%((\a\+)\)\=:E197:/
-        throw "Skipped: not possible to set locale to en (missing?)"
-      endtry
-    catch /^Vim\%((\a\+)\)\=:E342:/
-      throw "Skipped: out of memory executing bindtextdomain()"
+      language ru_RU
+      call assert_equal('ОШИБКА: ', gettext("ERROR: ", "__PACKAGE__"))
+    catch /^Vim\%((\a\+)\)\=:E197:/
+      throw "Skipped: not possible to set locale to ru (missing?)"
     endtry
-    set encoding&
-  endif
+    try
+      language en_GB.UTF-8
+      call assert_equal('ERROR: ', gettext("ERROR: ", "__PACKAGE__"))
+    catch /^Vim\%((\a\+)\)\=:E197:/
+      throw "Skipped: not possible to set locale to en (missing?)"
+    endtry
+  catch /^Vim\%((\a\+)\)\=:E342:/
+    throw "Skipped: out of memory executing bindtextdomain()"
+  endtry
+  set encoding&
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/vim.h
+++ b/src/vim.h
@@ -598,7 +598,7 @@ extern int (*dyn_libintl_wputenv)(const wchar_t *envstring);
 # ifdef bindtextdomain
 #  undef bindtextdomain
 # endif
-# define bindtextdomain(x, y) (y)
+# define bindtextdomain(x, y) ""
 # ifdef bind_textdomain_codeset
 #  undef bind_textdomain_codeset
 # endif

--- a/src/vim.h
+++ b/src/vim.h
@@ -598,7 +598,7 @@ extern int (*dyn_libintl_wputenv)(const wchar_t *envstring);
 # ifdef bindtextdomain
 #  undef bindtextdomain
 # endif
-# define bindtextdomain(x, y) // empty
+# define bindtextdomain(x, y) (y)
 # ifdef bind_textdomain_codeset
 #  undef bind_textdomain_codeset
 # endif


### PR DESCRIPTION
The error return value of ``bindtextdomain()`` was not propagated to the original calling script. This implements returning ``FALSE`` when the call fails, and ``TRUE`` when it succeeds.
