### PR TITLE
runtime(man): UX fixes

### DIFF
--- a/runtime/autoload/dist/man.vim
+++ b/runtime/autoload/dist/man.vim
@@ -165,7 +165,9 @@ func dist#man#GetPage(cmdmods, ...)
       endwhile
     endif
     if &filetype != "man"
-      if exists("g:ft_man_open_mode")
+      if a:cmdmods =~ '\<\(tab\|vertical\|horizontal\)\>'
+	let open_cmd = a:cmdmods . ' split'
+      elseif exists("g:ft_man_open_mode")
         if g:ft_man_open_mode == 'vert'
 	  let open_cmd = 'vsplit'
         elseif g:ft_man_open_mode == 'tab'
@@ -174,7 +176,7 @@ func dist#man#GetPage(cmdmods, ...)
 	  let open_cmd = 'split'
         endif
       else
-	let open_cmd = a:cmdmods . ' split'
+	let open_cmd = 'split'
       endif
     endif
   endif

--- a/runtime/ftplugin/man.vim
+++ b/runtime/ftplugin/man.vim
@@ -23,9 +23,9 @@ let s:cpo_save = &cpo
 set cpo-=C
 
 if &filetype == "man"
-  " Allow hyphen, plus, colon, dot, and commercial at in manual page name.
-  " Parentheses are not here but in dist#man#PreGetPage()
-  setlocal iskeyword=48-57,_,a-z,A-Z,-,+,:,.,@-@
+  " Allow hyphen, plus, colon, dot, parentheses and commercial at
+  " in manual page names.
+  setlocal iskeyword=48-57,_,a-z,A-Z,-,+,:,.,(,),@-@
   let b:undo_ftplugin = "setlocal iskeyword<"
 
   " Add mappings, unless the user didn't want this.


### PR DESCRIPTION
Two minor improvements to manpage support that _seem_ to do the right thing for me.
Note that I'm fairly new to Vim{,script}, so please do not kick me too hard if any of these changes are bogus.

- Honor placement (vert/hor/tab) cmd modifiers to `:Man`, if any are present, before `g:ft_man_open_mode`.  
  This way, e.g. `:vert Man` does the expected thing even in presence of a contradicting `g:ft_man_open_mode`.

- Actually add parentheses to `iskeyword=` so that `K` on a man page reference considers its section (if present).  
  The comment suggests that the parentheses were added to the iskeyword set elsewhere, but I could not find it in the code (and, indeed, it did not work in practice).