### PR TITLE
xxd,msvc: Specify source-charset

### DIFF
--- a/src/xxd/Make_mvc.mak
+++ b/src/xxd/Make_mvc.mak
@@ -9,7 +9,7 @@ SUBSYSTEM = $(SUBSYSTEM),$(SUBSYSTEM_VER)
 xxd: xxd.exe
 
 xxd.exe: xxd.c
-	cl /nologo -DWIN32 xxd.c -link -subsystem:$(SUBSYSTEM)
+	cl /nologo /source-charset:utf-8 -DWIN32 xxd.c -link -subsystem:$(SUBSYSTEM)
 
 # This was for an older compiler
 #    cl /nologo -DWIN32 xxd.c /link setargv.obj


### PR DESCRIPTION
xxd.c has non-ASCII-character comments. This causes the following warning on MSVC:
```
warning C4819: The file contains a character that cannot be represented
in the current code page (932). Save the file in Unicode format to
prevent data loss.
```

Add the `/source-charset:utf-8` option to avoid this.