### PR TITLE
ex: fix newline escaping

### DIFF
--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -2336,12 +2336,7 @@ do_one_cmd(
     {
 	for (p = ea.arg; *p; ++p)
 	{
-	    // Remove one backslash before a newline, so that it's possible to
-	    // pass a newline to the shell and also a newline that is preceded
-	    // with a backslash.  This makes it impossible to end a shell
-	    // command in a backslash, but that doesn't appear useful.
-	    // Halving the number of backslashes is incompatible with previous
-	    // versions.
+	    // Remove one backslash before a newline
 	    if (*p == '\\' && p[1] == '\n')
 		STRMOVE(p, p + 1);
 	    else if (*p == '\n' && !(ea.argt & EX_EXPR_ARG))

--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -3138,31 +3138,15 @@ redraw:
 	windgoto(msg_row, msg_col);
 	pend = (char_u *)(line_ga.ga_data) + line_ga.ga_len;
 
-	// We are done when a NL is entered, but not when it comes after an
-	// odd number of backslashes, that results in a NUL.
-	if (line_ga.ga_len > 0 && pend[-1] == '\n')
+	// We are done when a NL is entered, but not when it comes after a
+	// backslash in prompt mode.
+	if (line_ga.ga_len > 0 && pend[-1] == '\n'
+		&& (line_ga.ga_len <= 1 || pend[-2] != '\\' || !promptc))
 	{
-	    int bcount = 0;
-
-	    while (line_ga.ga_len - 2 >= bcount && pend[-2 - bcount] == '\\')
-		++bcount;
-
-	    if (bcount > 0)
-	    {
-		// Halve the number of backslashes: "\NL" -> "NUL", "\\NL" ->
-		// "\NL", etc.
-		line_ga.ga_len -= (bcount + 1) / 2;
-		pend -= (bcount + 1) / 2;
-		pend[-1] = '\n';
-	    }
-
-	    if ((bcount & 1) == 0)
-	    {
-		--line_ga.ga_len;
-		--pend;
-		*pend = NUL;
-		break;
-	    }
+	    --line_ga.ga_len;
+	    --pend;
+	    *pend = NUL;
+	    break;
 	}
     }
 

--- a/src/testdir/test_ex_mode.vim
+++ b/src/testdir/test_ex_mode.vim
@@ -165,6 +165,37 @@ func Test_Ex_global()
   call assert_equal('bax', getline(3))
   call assert_equal('bay', getline(5))
   bwipe!
+
+  new
+  call setline(1, ['foo', 'bar'])
+  call feedkeys("Qg/./i\\\na\\\n.\\\na\\\nb\\\n.", "xt")
+  call assert_equal(['a', 'b', 'foo', 'a', 'b', 'bar'], getline(1, '$'))
+  bwipe!
+endfunc
+
+func Test_Ex_shell()
+  CheckUnix
+
+  new
+  call feedkeys("Qr !echo foo\\\necho bar\n", 'xt')
+  call assert_equal(['', 'foo', 'bar'], getline(1, '$'))
+  bwipe!
+
+  new
+  call feedkeys("Qr !echo foo\\\\\nbar\n", 'xt')
+  call assert_equal(['', 'foobar'], getline(1, '$'))
+  bwipe!
+
+  new
+  call feedkeys("Qr !echo foo\\ \\\necho bar\n", 'xt')
+  call assert_equal(['', 'foo ', 'bar'], getline(1, '$'))
+  bwipe!
+
+  new
+  call setline(1, ['bar', 'baz'])
+  call feedkeys("Qg/./!echo \\\ns/b/c/", "xt")
+  call assert_equal(['car', 'caz'], getline(1, '$'))
+  bwipe!
 endfunc
 
 " Test for pressing Ctrl-C in :append inside a loop in Ex mode
@@ -204,18 +235,11 @@ func Test_Ex_append()
   call feedkeys("Qappend!\npqr\nxyz\n.\nvisual\n", 'xt')
   call assert_equal(["\t   abc", "\t   pqr", "\t   xyz"], getline(1, '$'))
   close!
-endfunc
 
-" In Ex-mode, backslashes at the end of a command should be halved.
-func Test_Ex_echo_backslash()
-  " This test works only when the language is English
-  CheckEnglish
-  let bsl = '\\\\'
-  let bsl2 = '\\\'
-  call assert_fails('call feedkeys("Qecho " .. bsl .. "\nvisual\n", "xt")',
-        \ 'E15: Invalid expression: "\\"')
-  call assert_fails('call feedkeys("Qecho " .. bsl2 .. "\nm\nvisual\n", "xt")',
-        \ "E15: Invalid expression: \"\\\nm\"")
+  new
+  call feedkeys("Qappend\na\\\n.", 'xt')
+  call assert_equal(['a\'], getline(1, '$'))
+  close!
 endfunc
 
 func Test_ex_mode_errors()


### PR DESCRIPTION
This fixes newline escaping to allow passing multiple commands to ":global", multiple lines to shell commands, and ending lines in append mode with backslashes. This reverts a previous incorrect attempt to fix append mode which removed half of trailing backslashes which lead to, eg. the following two commands being parsed as having a different number of backslashes:

```
!echo foo\\\
```

```
!echo foo\\ \
```

Fixes #6135
Fixes #7244

@konrad-schwarz