### PR TITLE
Wrong spanish translation. Lost some meaning

### DIFF
--- a/runtime/tutor/tutor.es
+++ b/runtime/tutor/tutor.es
@@ -236,7 +236,7 @@ Ahora continúe con la Lección 2.
 
   Muchos comandos que cambian texto están compuestos por un operador y un
   movimiento.
-  El formato para eliminar un comando con el operador de borrado  d  es el
+  El formato para comando eliminar con el operador de borrado  d  es el
   siguiente:
 
     d   movimiento

--- a/runtime/tutor/tutor.es.utf-8
+++ b/runtime/tutor/tutor.es.utf-8
@@ -236,7 +236,7 @@ Ahora continúe con la Lección 2.
 
   Muchos comandos que cambian texto están compuestos por un operador y un
   movimiento.
-  El formato para eliminar un comando con el operador de borrado  d  es el
+  El formato para comando eliminar con el operador de borrado  d  es el
   siguiente:
 
     d   movimiento


### PR DESCRIPTION
I was followng the vimtutor when spotted this.
The specific line looks to have been initially transliterated word by word from english, then rewrited, but part of the important keywords like command and operators remained in an awkward position.

Just to be sure, I've checked the main english version of the line in the tutor file.

Spanish is my mother language, anyway, but if there is a spanish speaker among the devs who cares to take a look at this to double check my criteria, please do :)