### PR TITLE
Fix exception throwing after silent try

### DIFF
--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -1460,8 +1460,13 @@ handle_did_throw(void)
     current_exception->throw_name = NULL;
 
     discard_current_exception();	// uses IObuff if 'verbose'
-    suppress_errthrow = TRUE;
-    force_abort = TRUE;
+
+    // If "silent!" is active the uncaught exception is not fatal.
+    if (emsg_silent == 0)
+    {
+	suppress_errthrow = TRUE;
+	force_abort = TRUE;
+    }
 
     if (messages != NULL)
     {

--- a/src/testdir/test_vimscript.vim
+++ b/src/testdir/test_vimscript.vim
@@ -7536,6 +7536,31 @@ func Test_deeply_nested_source()
   call system(cmd)
 endfunc
 
+func Test_exception_silent()
+  XpathINIT
+  let lines =<< trim END
+  func Throw()
+    Xpath 'a'
+    throw "Uncaught"
+    " This line is not executed.
+    Xpath 'b'
+  endfunc
+  " The exception is suppressed due to the presence of silent!.
+  silent! call Throw()
+  try
+    call DoesNotExist()
+  catch /E117:/
+    Xpath 'c'
+  endtry
+  Xpath 'd'
+  END
+  let verify =<< trim END
+    call assert_equal('acd', g:Xpath)
+  END
+
+  call RunInNewVim(lines, verify)
+endfunc
+
 "-------------------------------------------------------------------------------
 " Modelines								    {{{1
 " vim: ts=8 sw=2 sts=2 expandtab tw=80 fdm=marker


### PR DESCRIPTION
The silent! flag causes the evaluation not to be aborted in case of uncaught exceptions, adjust handle_did_throw to take this detail into account.

Fixes the long-standing todo.txt item:
```
Problem that a previous silent ":throw" causes a following try/catch not
to work. (ZyX, 2013 Sep 28) With examples: (Malcolm Rowe, 2015 Dec 24)
Also see #8487 for an example.
```

Fixes #538