### PR TITLE
runtime(man): use `nnoremap` to map to Ex commands

### DIFF
--- a/runtime/ftplugin/man.vim
+++ b/runtime/ftplugin/man.vim
@@ -61,8 +61,8 @@ endif
 
 if exists(":Man") != 2
   com -nargs=+ -complete=shellcmd Man call dist#man#GetPage(<q-mods>, <f-args>)
-  nmap <Leader>K :call dist#man#PreGetPage(0)<CR>
-  nmap <Plug>ManPreGetPage :call dist#man#PreGetPage(0)<CR>
+  nnoremap <Leader>K :call dist#man#PreGetPage(0)<CR>
+  nnoremap <Plug>ManPreGetPage :call dist#man#PreGetPage(0)<CR>
 endif
 
 let &cpo = s:cpo_save


### PR DESCRIPTION
(Companion to #15117...)

If the user plays rebinding games such as

    nnoremap : ,
    nnoremap , :

(cf. https://konfekt.github.io/blog/2016/10/03/get-the-leader-right),
then the mappings defined by man.vim will become non-functional.