### PR TITLE
Unwanted cursor movement with pagescroll at start of buffer

### DIFF
--- a/src/move.c
+++ b/src/move.c
@@ -3281,10 +3281,13 @@ pagescroll(int dir, long count, int half)
 				MAX(1, p_window - 2) : get_scroll_overlap(dir));
 	nochange = scroll_with_sms(dir, count, &count);
 
-	// Place cursor at top or bottom of window.
-	validate_botline();
-	curwin->w_cursor.lnum = (dir == FORWARD ? curwin->w_topline
+	if (!nochange)
+	{
+	    // Place cursor at top or bottom of window.
+	    validate_botline();
+	    curwin->w_cursor.lnum = (dir == FORWARD ? curwin->w_topline
 						    : curwin->w_botline - 1);
+	}
     }
 
     if (get_scrolloff_value() > 0)

--- a/src/testdir/test_normal.vim
+++ b/src/testdir/test_normal.vim
@@ -4257,6 +4257,9 @@ func Test_page_cursor_topbot()
   call assert_equal(18, line('.'))
   exe "norm! \<C-B>\<C-F>"
   call assert_equal(9, line('.'))
+  " Not when already at the start of the buffer.
+  exe "norm! ggj\<C-B>"
+  call assert_equal(2, line('.'))
   bwipe!
 endfunc
 


### PR DESCRIPTION
Problem:  Cursor is moved to bottom of window trying to pagescroll when
          already at the start of the buffer.
Solution: Don't move cursor when buffer content did not move.