### PR TITLE
[vim9class] Fix `string()` to handle an object's function ref.

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -5923,6 +5923,37 @@ func_tv2string(typval_T *tv, char_u **tofree, int echo_style)
 }
 
 /*
+ * Return a textual representation of the object method in "tv", a VAR_PARTIAL.
+ * If the memory is allocated "tofree" is set to it, otherwise NULL.
+ * When "echo_style" is FALSE, put quotes around the function name as
+ * "function()", otherwise does not put quotes around function name.
+ * May return NULL.
+ */
+    static char_u *
+method_tv2string(typval_T *tv, char_u **tofree, int echo_style)
+{
+    char_u	buf[MAX_FUNC_NAME_LEN];
+    partial_T	*pt = tv->vval.v_partial;
+
+    size_t len = vim_snprintf((char *)buf, sizeof(buf), "<SNR>%d_%s.%s",
+			   pt->pt_func->uf_script_ctx.sc_sid,
+			   pt->pt_func->uf_class->class_name,
+			   pt->pt_func->uf_name);
+    if (len >= sizeof(buf))
+    {
+	if (echo_style)
+	{
+	    *tofree = NULL;
+	    return (char_u *)"function()";
+	}
+	else
+	    return *tofree = string_quote((char_u*)"", TRUE);
+    }
+
+    return *tofree = echo_style ? vim_strsave(buf) : string_quote(buf, TRUE);
+}
+
+/*
  * Return a textual representation of a partial in "tv".
  * If the memory is allocated "tofree" is set to it, otherwise NULL.
  * "numbuf" is used for a number.  May return NULL.
@@ -6241,7 +6272,11 @@ echo_string_core(
 	    break;
 
 	case VAR_PARTIAL:
-	    r = partial_tv2string(tv, tofree, numbuf, copyID);
+	    if (tv->vval.v_partial == NULL
+		    || tv->vval.v_partial->pt_obj == NULL)
+		r = partial_tv2string(tv, tofree, numbuf, copyID);
+	    else
+		r = method_tv2string(tv, tofree, echo_style);
 	    break;
 
 	case VAR_BLOB:

--- a/src/testdir/test_vim9_class.vim
+++ b/src/testdir/test_vim9_class.vim
@@ -10466,6 +10466,20 @@ func Test_object_string()
   call v9.CheckSourceSuccess(lines)
 endfunc
 
+" Test for using the string() builtin method with an object's method
+def Test_method_string()
+  var lines =<< trim END
+    vim9script
+    class A
+      def F()
+      enddef
+    endclass
+    assert_match('function(''<SNR>\d\+_A\.F'')', string(A.new().F))
+  END
+  v9.CheckScriptSuccess(lines)
+enddef
+
+
 " Test for using a class in the class definition
 def Test_Ref_Class_Within_Same_Class()
   var lines =<< trim END


### PR DESCRIPTION
Fix #15129.