### PR TITLE
Add builtin `id(:any)`, returns a string (the address) of the arg.

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -309,6 +309,7 @@ hlget([{name} [, {resolve}]])	List	get highlight group attributes
 hlset({list})			Number	set highlight group attributes
 hostname()			String	name of the machine Vim is running on
 iconv({expr}, {from}, {to})	String	convert encoding of {expr}
+id({item})			String	get address of item as a string
 indent({lnum})			Number	indent of line {lnum}
 index({object}, {expr} [, {start} [, {ic}]])
 				Number	index in {object} where {expr} appears
@@ -5600,6 +5601,34 @@ iconv({string}, {from}, {to})				*iconv()*
 
 		Can also be used as a |method|: >
 			GetText()->iconv('latin1', 'utf-8')
+<
+		Return type: |String|
+
+
+id({item})							    *id()*
+		The result is a unique String associated with the {item} and
+		not with the {item}'s contents. It is only valid while the
+		{item} exists and is referenced. It is valid only in the
+		instance of vim that produces the result. The whole idea is
+		that `id({item})` does not change if the contents of {item}
+		changes. This is useful as a `key` for creating an identity
+		dictionary, rather than one based on equals.
+
+		This operation does not reference {item} and there is no
+		function to convert the `id` to the {item}. It may be useful to
+		have a map of `id` to {item}. The following >
+		    var referenceMap: dict<any>
+		    var id = item->id()
+		    referenceMap[id] = item
+<		prevents {item} from being garbage collected and provides a
+		way to get the {item} from the `id`.
+
+		{item} may be a List, Dictionary, Object, Job, Channel or
+		Blob. If the item is not a permitted type, or it is a null
+		value, then an empty String is returned.
+
+		Can also be used as a |method|: >
+			GetItem()->id()
 <
 		Return type: |String|
 

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -8297,6 +8297,7 @@ iconise	starting.txt	/*iconise*
 iconize	starting.txt	/*iconize*
 iconv()	builtin.txt	/*iconv()*
 iconv-dynamic	mbyte.txt	/*iconv-dynamic*
+id()	builtin.txt	/*id()*
 ident-search	tips.txt	/*ident-search*
 idl-syntax	syntax.txt	/*idl-syntax*
 idl.vim	syntax.txt	/*idl.vim*

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -1408,6 +1408,8 @@ Various:					*various-functions*
 
 	wordcount()		get byte/word/char count of buffer
 
+	id()			get unique string for item to use as a key
+
 	luaeval()		evaluate |Lua| expression
 	mzeval()		evaluate |MzScheme| expression
 	perleval()		evaluate Perl expression (|+perl|)

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -82,6 +82,7 @@ static void f_haslocaldir(typval_T *argvars, typval_T *rettv);
 static void f_hlID(typval_T *argvars, typval_T *rettv);
 static void f_hlexists(typval_T *argvars, typval_T *rettv);
 static void f_hostname(typval_T *argvars, typval_T *rettv);
+static void f_id(typval_T *argvars, typval_T *rettv);
 static void f_index(typval_T *argvars, typval_T *rettv);
 static void f_indexof(typval_T *argvars, typval_T *rettv);
 static void f_input(typval_T *argvars, typval_T *rettv);
@@ -2207,6 +2208,8 @@ static funcentry_T global_functions[] =
 			ret_string,	    f_hostname},
     {"iconv",		3, 3, FEARG_1,	    arg3_string,
 			ret_string,	    f_iconv},
+    {"id",		1, 1, FEARG_1,	    NULL,
+			ret_string,	    f_id},
     {"indent",		1, 1, FEARG_1,	    arg1_lnum,
 			ret_number,	    f_indent},
     {"index",		2, 4, FEARG_1,	    arg24_index,
@@ -7484,6 +7487,40 @@ f_hostname(typval_T *argvars UNUSED, typval_T *rettv)
     mch_get_host_name(hostname, 256);
     rettv->v_type = VAR_STRING;
     rettv->vval.v_string = vim_strsave(hostname);
+}
+
+/*
+ * "id()" function
+ * Identity. Return address of item as a hex string, %p format.
+ * Currently only valid for object/container types.
+ * Return empty string if not an object.
+ */
+    void
+f_id(typval_T *argvars, typval_T *rettv)
+{
+    char_u	numbuf[NUMBUFLEN];
+
+    switch (argvars[0].v_type)
+    {
+	case VAR_LIST:
+	case VAR_DICT:
+	case VAR_OBJECT:
+	case VAR_JOB:
+	case VAR_CHANNEL:
+	case VAR_BLOB:
+	    // Assume pointer value in typval_T vval union at common location.
+	    if (argvars[0].vval.v_object != NULL)
+		vim_snprintf((char*)numbuf, sizeof(numbuf), "%p",
+					    (void *)argvars[0].vval.v_object);
+	    else
+		numbuf[0] = NUL;
+	    break;
+	default:
+	    numbuf[0] = NUL;
+    }
+
+    rettv->v_type = VAR_STRING;
+    rettv->vval.v_string = vim_strsave(numbuf);
 }
 
 /*

--- a/src/testdir/test_listdict.vim
+++ b/src/testdir/test_listdict.vim
@@ -1619,4 +1619,34 @@ func Test_deep_nested_listdict_compare()
   call v9.CheckLegacyAndVim9Success(lines)
 endfunc
 
+" Test for using id()
+def Test_id_with_dict()
+  # demonstate a way that "id(item)" differs from "string(item)"
+  var d1 = {one: 1}
+  var d2 = {one: 1}
+  var d3 = {one: 1}
+  var idDict: dict<any>
+  idDict[id(d1)] = d1
+  idDict[id(d2)] = d2
+  idDict[id(d3)] = d3
+  assert_equal(3, idDict->len())
+
+  var stringDict: dict<any>
+  stringDict[string(d1)] = d1
+  stringDict[string(d2)] = d2
+  stringDict[string(d3)] = d3
+  assert_equal(1, stringDict->len())
+
+  assert_equal('', id(3))
+
+  assert_equal('', id(null))
+  assert_equal('', id(null_blob))
+  assert_equal('', id(null_dict))
+  assert_equal('', id(null_function))
+  assert_equal('', id(null_list))
+  assert_equal('', id(null_partial))
+  assert_equal('', id(null_string))
+  assert_equal('', id(null_channel))
+  assert_equal('', id(null_job))
+enddef
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
There is a discussion, #14374, about using a `class` or `enum` as a `dict` key.
Consider java's `HashMap` and `IdentityHashMap`.

This PR provides a way to have an identity `dict` using `dict` or `list` or
`object` as the key. See below for an example comparing the difference. Without
something like this, it is impossible to create an efficient, or even close to
efficient, identity map.

I went with a short name, `id`, as is my wont. Maybe `identity` is better.
No help/tests yet, looking for feedback first.

job and channel could be included or anything that has a refcount. LMK.

This should be considered an initial implementation and probably should be
extended, or supplanted, in the future. Some issues are
1. Must manually keep a reference to an item used as a key. The `id()` call
   does not increment the refcount.
2. Could add an option to `id()` to take a reference. But this requires
   considerable consideration. For example need a decref and avoid SEGV.

Returns empty string if not `VAR_OBJECT`/`VAR_DICT`/`VAR_LIST`.

```vim
vim9script

var d1: dict<any>
var d2: dict<any>

d1 = {a: 1}
d2 = {a: 2}

var d: dict<any>
d[string(d1)] = d1
d[string(d2)] = d2

echo d

d->filter((_, _) => false)
d2.a = 1
d[string(d1)] = d1
d[string(d2)] = d2
echo d

# Now the same thing with "id()"

d->filter((_, _) => false)
d1 = {a: 1}
d2 = {a: 2}
d[id(d1)] = d1
d[id(d2)] = d2
echo d

d->filter((_, _) => false)
d2.a = 1
d[id(d1)] = d1
d[id(d2)] = d2
echo d
```

**using `string()`**
Equality is used as the index.
```
{'{''a'': 2}': {'a': 2}, '{''a'': 1}': {'a': 1}}
{'{''a'': 1}': {'a': 1}}
```

**using `id()`**
Identity is used as the index.
```
{'0x5e9614976fc0': {'a': 2}, '0x5e961497ab60': {'a': 1}}
{'0x5e9614976fc0': {'a': 1}, '0x5e961497ab60': {'a': 1}}
```
