### PR TITLE
runtime(docker): spellcheck Dockerfile comments

### DIFF
--- a/runtime/syntax/dockerfile.vim
+++ b/runtime/syntax/dockerfile.vim
@@ -34,7 +34,7 @@ syntax region dockerfileJSON   contained keepend start=/\v\[/ skip=/\v\\\_./ end
 syntax region dockerfileShell  contained keepend start=/\v/ skip=/\v\\\_./ end=/\v$/ contains=@Shell
 syntax region dockerfileValue  contained keepend start=/\v/ skip=/\v\\\_./ end=/\v$/ contains=dockerfileString
 
-syntax region dockerfileComment start=/\v^\s*#/ end=/\v$/
+syntax region dockerfileComment start=/\v^\s*#/ end=/\v$/ contains=@Spell
 set commentstring=#\ %s
 
 hi def link dockerfileString String


### PR DESCRIPTION
The [upstream repo](https://github.com/honza/dockerfile.vim) has been archived and suggests submitting fixes directly to vim.   