### PR TITLE
filetype: cedar files not recognized

### DIFF
--- a/.github/MAINTAINERS
+++ b/.github/MAINTAINERS
@@ -113,6 +113,7 @@ runtime/ftplugin/astro.vim		@romainl
 runtime/ftplugin/awk.vim		@dkearns
 runtime/ftplugin/basic.vim		@dkearns
 runtime/ftplugin/bst.vim		@tpope
+runtime/ftplugin/cedar.vim		@ribru17
 runtime/ftplugin/cfg.vim		@chrisbra
 runtime/ftplugin/chatito.vim		@ObserverOfTime
 runtime/ftplugin/chicken.vim		@evhan

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -321,6 +321,9 @@ au BufNewFile,BufRead *.toc
 " Cdrdao config
 au BufNewFile,BufRead */etc/cdrdao.conf,*/etc/defaults/cdrdao,*/etc/default/cdrdao,.cdrdao	setf cdrdaoconf
 
+" Cedar
+au BufNewFile,BufRead *.cedar			setf cedar
+
 " Cfengine
 au BufNewFile,BufRead cfengine.conf		setf cfengine
 

--- a/runtime/ftplugin/cedar.vim
+++ b/runtime/ftplugin/cedar.vim
@@ -1,0 +1,13 @@
+" Vim filetype plugin
+" Language:	Cedar
+" Maintainer:	Riley Bruins <ribru17@gmail.com>
+" Last Change:	2024 Jul 4
+
+if exists('b:did_ftplugin')
+  finish
+endif
+let b:did_ftplugin = 1
+
+setl comments=:// commentstring=//\ %s
+
+let b:undo_ftplugin = 'setl com< cms<'

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -142,6 +142,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     cdl: ['file.cdl'],
     cdrdaoconf: ['/etc/cdrdao.conf', '/etc/defaults/cdrdao', '/etc/default/cdrdao', '.cdrdao', 'any/etc/cdrdao.conf', 'any/etc/default/cdrdao', 'any/etc/defaults/cdrdao'],
     cdrtoc: ['file.toc'],
+    cedar: ['file.cedar'],
     cf: ['file.cfm', 'file.cfi', 'file.cfc'],
     cfengine: ['cfengine.conf'],
     cfg: ['file.hgrc', 'filehgrc', 'hgrc', 'some-hgrc'],


### PR DESCRIPTION
Recognizes [cedar policy](https://github.com/cedar-policy) files, based on [their VSCode extension](https://github.com/cedar-policy/vscode-cedar/blob/01568c049ff583e77a7424c48b82ab7d00fc8d76/README.md#cedar-policy-language)