### PR TITLE
runtime: ftplugin for cabal files

### DIFF
--- a/.github/MAINTAINERS
+++ b/.github/MAINTAINERS
@@ -113,6 +113,7 @@ runtime/ftplugin/astro.vim		@romainl
 runtime/ftplugin/awk.vim		@dkearns
 runtime/ftplugin/basic.vim		@dkearns
 runtime/ftplugin/bst.vim		@tpope
+runtime/ftplugin/cabal.vim		@ribru17
 runtime/ftplugin/cedar.vim		@ribru17
 runtime/ftplugin/cfg.vim		@chrisbra
 runtime/ftplugin/chatito.vim		@ObserverOfTime

--- a/runtime/ftplugin/cabal.vim
+++ b/runtime/ftplugin/cabal.vim
@@ -1,0 +1,13 @@
+" Vim filetype plugin file
+" Language:	Haskell Cabal Build file
+" Maintainer:	Riley Bruins <ribru17@gmail.com>
+" Last Change:	2024 Jul 06
+
+if exists('b:did_ftplugin')
+  finish
+endif
+let b:did_ftplugin = 1
+
+setl comments=:-- commentstring=--\ %s
+
+let b:undo_ftplugin = 'setl com< cms<'


### PR DESCRIPTION
Filetype plugin for [cabal](https://cabal.readthedocs.io/en/3.4/developing-packages.html#:~:text=Cabal%20files%20use%20%E2%80%9C%20%2D%2D%20%E2%80%9D%20Haskell,be%20confused%20with%20program%20options.) files