### PR TITLE
runtime: update kivy syntax, add ftplugin support

### DIFF
--- a/.github/MAINTAINERS
+++ b/.github/MAINTAINERS
@@ -180,6 +180,7 @@ runtime/ftplugin/julia.vim		@carlobaldassi
 runtime/ftplugin/jq.vim	    	        @vito-c
 runtime/ftplugin/kconfig.vim		@chrisbra
 runtime/ftplugin/kdl.vim		@imsnif @jiangyinzuo
+runtime/ftplugin/kivy.vim		@ribru17
 runtime/ftplugin/kotlin.vim		@udalov
 runtime/ftplugin/less.vim		@genoma
 runtime/ftplugin/liquid.vim		@tpope

--- a/runtime/ftplugin/kivy.vim
+++ b/runtime/ftplugin/kivy.vim
@@ -1,0 +1,13 @@
+" Vim filetype plugin
+" Language:	Kivy
+" Maintainer:	Riley Bruins <ribru17@gmail.com>
+" Last Change:	2024 Jul 06
+
+if exists('b:did_ftplugin')
+  finish
+endif
+let b:did_ftplugin = 1
+
+setl commentstring=#\ %s
+
+let b:undo_ftplugin = 'setl cms<'

--- a/runtime/syntax/kivy.vim
+++ b/runtime/syntax/kivy.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:    Kivy
 " Maintainer:  Corey Prophitt <prophitt.corey@gmail.com>
-" Last Change: May 29th, 2014
+" Last Change: Jul 6th, 2024
 " Version:     1
 " URL:         http://kivy.org/
 
@@ -17,7 +17,7 @@ syn include @pyth $VIMRUNTIME/syntax/python.vim
 
 " Define Kivy syntax
 syn match kivyPreProc   /#:.*/
-syn match kivyComment   /#.*/
+syn match kivyComment   /#[^:].*/
 syn match kivyRule      /<\I\i*\(,\s*\I\i*\)*>:/
 syn match kivyAttribute /\<\I\i*\>/ nextgroup=kivyValue
 


### PR DESCRIPTION
Kivy uses "#:" for preprocessing commands (like "#:import ...") which were overridden by the comment syntax. This has been changed, and a commentstring has been added.