### PR TITLE
runtime: add mysql ftplugin

### DIFF
--- a/runtime/ftplugin/mysql.vim
+++ b/runtime/ftplugin/mysql.vim
@@ -1,0 +1,1 @@
+runtime ftplugin/sql.vim


### PR DESCRIPTION
This one just inherits from the SQL ftplugin. Without this, *.mysql files don't inherit the common SQL settings.