### PR TITLE
runtime: javacc ftplugin file

### DIFF
--- a/.github/MAINTAINERS
+++ b/.github/MAINTAINERS
@@ -170,6 +170,7 @@ runtime/ftplugin/indent.vim		@dkearns
 runtime/ftplugin/ishd.vim		@dkearns
 runtime/ftplugin/j.vim			@glts
 runtime/ftplugin/java.vim		@zzzyxwvut
+runtime/ftplugin/javacc.vim		@ribru17
 runtime/ftplugin/javascript.vim		@dkearns
 runtime/ftplugin/javascriptreact.vim	@dkearns
 runtime/ftplugin/jj.vim			@gpanders

--- a/runtime/ftplugin/javacc.vim
+++ b/runtime/ftplugin/javacc.vim
@@ -1,0 +1,20 @@
+" Vim filetype plugin
+" Language:	JavaCC
+" Maintainer:	Riley Bruins <ribru17@gmail.com>
+" Last Change:	2024 Jul 06
+
+if exists('b:did_ftplugin')
+  finish
+endif
+let b:did_ftplugin = 1
+
+" Set 'formatoptions' to break comment lines but not other lines,
+" and insert the comment leader when hitting <CR> or using "o".
+setlocal formatoptions-=t formatoptions+=croql
+
+" Set 'comments' to format dashed lists in comments. Behaves just like C.
+setlocal comments& comments^=sO:*\ -,mO:*\ \ ,exO:*/
+
+setlocal commentstring=//\ %s
+
+let b:undo_ftplugin = 'setl fo< com< cms<'


### PR DESCRIPTION
Filetype plugin file for [JavaCC](https://javacc.github.io/javacc/documentation/grammar.html)