### PR TITLE
Unused assignment in sign_define_cmd()

### DIFF
--- a/runtime/doc/sign.txt
+++ b/runtime/doc/sign.txt
@@ -1,4 +1,4 @@
-*sign.txt*      For Vim version 9.1.  Last change: 2024 Jul 06
+*sign.txt*      For Vim version 9.1.  Last change: 2024 Jul 07
 
 
 		  VIM REFERENCE MANUAL    by Gordon Prieur
@@ -404,6 +404,7 @@ sign_define({list})
 		   icon		full path to the bitmap file for the sign.
 		   linehl	highlight group used for the whole line the
 				sign is placed in.
+		   priority	default priority value of the sign
 		   numhl	highlight group used for the line number where
 				the sign is placed.
 		   text		text that is displayed when there is no icon

--- a/src/sign.c
+++ b/src/sign.c
@@ -1390,7 +1390,6 @@ sign_define_cmd(char_u *sign_name, char_u *cmdline)
 	{
 	    arg += 9;
 	    prio = atoi((char *)arg);
-	    arg = skiptowhite(arg);
 	}
 	else
 	{


### PR DESCRIPTION
Problem:  Unused assignment in sign_define_cmd().
Solution: Remove the assignment.  Also document the "priority" flag of
          sign_define().
