### PR TITLE
fix: failing test `Test_null_values` when vim configured without channel

### DIFF
--- a/src/testdir/test_vim9_script.vim
+++ b/src/testdir/test_vim9_script.vim
@@ -5085,15 +5085,19 @@ def Test_null_values()
     var nullValues = [
       [null, 1, 'null', 7, 'special'],
       [null_blob, 1, '0z', 10, 'blob'],
-      [null_channel, 1, 'channel fail', 9, 'channel'],
       [null_dict, 1, '{}', 4, 'dict<any>'],
       [null_function, 1, "function('')", 2, 'func(...): unknown'],
-      [null_job, 1, 'no process', 8, 'job'],
       [null_list, 1, '[]', 3, 'list<any>'],
       [null_object, 1, 'object of [unknown]', 13, 'object<Unknown>'],
       [null_partial, 1, "function('')", 2, 'func(...): unknown'],
       [null_string, 1, "''", 1, 'string']
     ]
+    if has('channel')
+      nullValues->add([null_channel, 1, 'channel fail', 9, 'channel'])
+    endif
+    if has('job')
+      nullValues->add([null_job, 1, 'no process', 8, 'job'])
+    endif
 
     for [Val, emptyExp, stringExp, typeExp, typenameExp] in nullValues
       assert_equal(emptyExp, empty(Val))


### PR DESCRIPTION
Test `Test_null_values` was failing when vim is configured without channel because the test uses function `null_channel()` (which requires the `+channel` feature) and using `null_job()` which requires the `+job` feature. But was reproducible when vim is configured with:
```
./configure --with-features=huge --enable-gui=none --disable-channel
```

Only check `null_channel()` when the `+channel` feature is available. Only check `null_job()` when the `+job` feature is available.