### PR TITLE
doc example fix: autocmd accepts list not dict

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -54,12 +54,12 @@ Recommended use:
   without the autocommand being repeated.
 
 Example in Vim9 script: >
-   autocmd_add({replace: true,
+   autocmd_add([{replace: true,
 		group:   'DemoGroup',
 		event:   'BufEnter',
 		pattern: '*.txt',
 		cmd:     'call DemoBufEnter()'
-		})
+		}])
 
 In legacy script: >
    call autocmd_add(#{replace: v:true,


### PR DESCRIPTION
doc example is missing square brackets for autocmd accepts list not dict.