### PR TITLE
Termdebug help add timeout info

### DIFF
--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -1535,6 +1535,14 @@ If there is no g:termdebug_config you can use: >
 <
 However, the latter form will be deprecated in future releases.
 
+Startup timeout ~
+						*termdebug-timeout*
+The termdebug plugin waits debugger to startup for 3 seconds by default,
+however, if the debugger takes longer to launch, e.g. in a slow NFS, consider
+to increase the timeout with: >
+	let g:termdebug_config['timeout'] = 600
+This will set the timeout to 600 x 10 milliseconds = 6 seconds.
+
 Mappings ~
 The termdebug plugin enables a few default mappings.  All those mappings
 are reset to their original values once the termdebug session concludes.

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -517,7 +517,8 @@ def CreateGdbConsole(dict: dict<any>, pty: string, commpty: string): string
   endwhile
 
   if !success
-    return 'Failed to startup the gdb program.'
+    return 'Failed to startup the gdb program within '
+      .. counter_max .. ' x 10ms, may consider to increase timeout'
   endif
 
   # ---- gdb started. Next, let's set the MI interface. ---
@@ -576,7 +577,6 @@ enddef
 
 # Open a terminal window without a job, to run the debugged program in.
 def StartDebug_term(dict: dict<any>)
-
   var programpty = CreateProgramPty()
   if programpty is null_string
     Echoerr('Failed to open the program terminal window')

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -517,7 +517,7 @@ def CreateGdbConsole(dict: dict<any>, pty: string, commpty: string): string
   endwhile
 
   if !success
-    return 'Failed to startup the gdb program within '
+    return $'Failed to startup the gdb program within {counter_max}ms, consider increasing the timeout'
       .. counter_max .. ' x 10ms, may consider to increase timeout'
   endif
 

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -517,8 +517,7 @@ def CreateGdbConsole(dict: dict<any>, pty: string, commpty: string): string
   endwhile
 
   if !success
-    return 'Failed to startup the gdb program within '
-      .counter_max.' x 10ms, may consider to increase timeout'
+    return 'Failed to startup the gdb program.'
   endif
 
   # ---- gdb started. Next, let's set the MI interface. ---
@@ -577,6 +576,7 @@ enddef
 
 # Open a terminal window without a job, to run the debugged program in.
 def StartDebug_term(dict: dict<any>)
+
   var programpty = CreateProgramPty()
   if programpty is null_string
     Echoerr('Failed to open the program terminal window')

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -517,7 +517,8 @@ def CreateGdbConsole(dict: dict<any>, pty: string, commpty: string): string
   endwhile
 
   if !success
-    return 'Failed to startup the gdb program.'
+    return 'Failed to startup the gdb program within '
+      .counter_max.' x 10ms, may consider to increase timeout'
   endif
 
   # ---- gdb started. Next, let's set the MI interface. ---
@@ -576,7 +577,6 @@ enddef
 
 # Open a terminal window without a job, to run the debugged program in.
 def StartDebug_term(dict: dict<any>)
-
   var programpty = CreateProgramPty()
   if programpty is null_string
     Echoerr('Failed to open the program terminal window')


### PR DESCRIPTION
My setup is using a debugger in a NFS which is slow to launch/startup, default 3s timeout if not enough.

Adding info for timeout in help and error message, though error message is not directly visible, but does show up in log file with -V option.