### PR TITLE
Correct shell command to get $VIMRUNTIME in help doc for $VIMRUNTIME.

### DIFF
--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -1257,7 +1257,7 @@ To change it later, use a ":let" command like this: >
 In case you need the value of $VIMRUNTIME in a shell (e.g., for a script that
 greps in the help files) you might be able to use this: >
 
-	VIMRUNTIME=`vim -e -T dumb --cmd 'exe "set t_cm=\<C-M>"|echo $VIMRUNTIME|quit' | tr -d '\015' `
+	VIMRUNTIME=$(vim -es '+put=$VIMRUNTIME|print|quit!')
 
 Don't set $VIMRUNTIME to an empty value, some things may stop working.
 


### PR DESCRIPTION
The original shell command could set the VIMRUNTIME variable to an invalid path.
    - since v9.0.0592 trailing spaces were typically added making the path invalid. (I observed that spaces were added if the length of the path wasn't equal to one less than an integer multiple of the number of display columns.)
    - newline character/s would be added, making the path invalid, if the path was longer than the number of display columns.

The new command is shorter than the original command.