### PR TITLE
Fix MSVC warning. I can't test it, but now it matches the prototypes.

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -6166,10 +6166,10 @@ object_tv2string(
     else if (copyID != 0 && obj->obj_copyID == copyID
             && obj->obj_class->class_obj_member_count != 0)
     {
-	int n = 25 + strlen((char*)obj->obj_class->class_name);
+	size_t n = 25 + strlen((char *)obj->obj_class->class_name);
 	r = alloc(n);
 	if (r != NULL)
-	    (void)vim_snprintf((char*)r, n, "object of %s {...}",
+	    (void)vim_snprintf((char *)r, n, "object of %s {...}",
 						obj->obj_class->class_name);
 	*tofree = r;
     }


### PR DESCRIPTION
Change cast `(char*)` to `(char *)`. Doesn't seem required style, but the space is used over 98% of the time; so...