### PR TITLE
Add '%hidden' highlighting to tmux file type

### DIFF
--- a/runtime/syntax/tmux.vim
+++ b/runtime/syntax/tmux.vim
@@ -28,7 +28,7 @@ syn match tmuxKey               /\(C-\|M-\|\^\)\+\S\+/ display
 syn match tmuxNumber            /\<\d\+\>/             display
 syn match tmuxFlags             /\s-\a\+/              display
 syn match tmuxVariableExpansion /\$\({[A-Za-z_]\w*}\|[A-Za-z_]\w*\)/ display
-syn match tmuxControl           /\(^\|\s\)%\(if\|elif\|else\|endif\)\($\|\s\)/ display
+syn match tmuxControl           /\(^\|\s\)%\(if\|elif\|else\|endif\|hidden\)\($\|\s\)/ display
 syn match tmuxEscape            /\\\(u\x\{4\}\|U\x\{8\}\|\o\{3\}\|[\\ernt$]\)/ display
 
 " Missing closing bracket.


### PR DESCRIPTION
Currently `%hidden` is not highlighted in tmux config files. This PR adds the missing highlighting.