### PR TITLE
revert: patch 9.1.0503

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2151,11 +2151,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 		    difference how completion candidates are reduced from the
 		    list of alternatives, but not how the candidates are
 		    collected (using different completion types).
-	  fuzzycollect
-		    Enable fuzzy collection for default keyword completion.
-		    This allows the collection of matches using fuzzy matching
-		    criteria, providing more comprehensive and flexible
-		    results. Works in combination with other fuzzy options.
 
 					*'completepopup'* *'cpp'*
 'completepopup' 'cpp'	string (default empty)

--- a/runtime/doc/version9.txt
+++ b/runtime/doc/version9.txt
@@ -41642,8 +41642,8 @@ Improved visual highlighting.
 
 Python3 support in OpenVMS.
 
-Support for |fuzzy-matching| during |ins-completion| with the "fuzzy" and
-"fuzzycollect" values of the 'completeopt' setting
+Support for |fuzzy-matching| during |ins-completion| with the "fuzzy"
+values of the 'completeopt' setting
 
 ==============================================================================
 COMPILE TIME CHANGES					*compile-changes-9.2*

--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -4512,11 +4512,6 @@ ins_compl_use_match(int c)
     static int
 get_normal_compl_info(char_u *line, int startcol, colnr_T curs_col)
 {
-    int		i;
-    int		char_len;
-    size_t	fuzzy_len;
-    char_u	*fuzzy_pattern;
-
     if ((compl_cont_status & CONT_SOL) || ctrl_x_mode_path_defines())
     {
 	if (!compl_status_adding())
@@ -4630,39 +4625,6 @@ get_normal_compl_info(char_u *line, int startcol, colnr_T curs_col)
     }
 
     compl_patternlen = STRLEN(compl_pattern);
-
-    if ((get_cot_flags() & COT_FUZZYCOLLECT) != 0)
-    {
-	// Adjust size to avoid buffer overflow
-	fuzzy_len = (size_t)compl_length * 5 + 10;
-	// Allocate enough space
-	fuzzy_pattern = alloc(fuzzy_len);
-	if (fuzzy_pattern == NULL)
-	{
-	    compl_patternlen = 0;
-	    return FAIL;
-	}
-	// Use 'very magic' mode for simpler syntax
-	STRCPY(fuzzy_pattern, "\\v");
-	i = 2; // Start from 2 to skip "\\v"
-	while (i < compl_length + 2)
-	{
-	    // Append "\\k*" before each character
-	    STRNCAT(fuzzy_pattern, "\\k*", fuzzy_len - STRLEN(fuzzy_pattern) - 1);
-	    // Get length of current multi-byte character
-	    char_len = mb_ptr2len(compl_pattern + i);
-	    // Concatenate the character safely
-	    STRNCAT(fuzzy_pattern, compl_pattern + i, char_len);
-	    // Move to the next character
-	    i += char_len;
-	}
-	// Append "\\k*" at the end to match any characters after the pattern
-	STRNCAT(fuzzy_pattern, "\\k*", fuzzy_len - STRLEN(fuzzy_pattern) - 1);
-	vim_free(compl_pattern);
-	compl_pattern = fuzzy_pattern;
-	compl_patternlen = STRLEN(compl_pattern);
-    }
-
     return OK;
 }
 

--- a/src/option.h
+++ b/src/option.h
@@ -527,7 +527,6 @@ EXTERN unsigned	cot_flags;	// flags from 'completeopt'
 #define COT_NOINSERT	    0x040   // FALSE: select & insert, TRUE: noinsert
 #define COT_NOSELECT	    0x080   // FALSE: select & insert, TRUE: noselect
 #define COT_FUZZY	    0x100   // TRUE: fuzzy match enabled
-#define COT_FUZZYCOLLECT    0x200   // TRUE: fuzzy collect enabled
 #ifdef BACKSLASH_IN_FILENAME
 EXTERN char_u	*p_csl;		// 'completeslash'
 #endif

--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -118,7 +118,7 @@ static char *(p_fdm_values[]) = {"manual", "expr", "marker", "indent", "syntax",
 				NULL};
 static char *(p_fcl_values[]) = {"all", NULL};
 #endif
-static char *(p_cot_values[]) = {"menu", "menuone", "longest", "preview", "popup", "popuphidden", "noinsert", "noselect", "fuzzy", "fuzzycollect", NULL};
+static char *(p_cot_values[]) = {"menu", "menuone", "longest", "preview", "popup", "popuphidden", "noinsert", "noselect", "fuzzy", NULL};
 #ifdef BACKSLASH_IN_FILENAME
 static char *(p_csl_values[]) = {"slash", "backslash", NULL};
 #endif

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -2586,37 +2586,6 @@ func Test_complete_fuzzy_match()
   call feedkeys("A\<C-X>\<C-N>\<Esc>0", 'tx!')
   call assert_equal('hello help hero h', getline('.'))
 
-  set completeopt=fuzzycollect
-  call setline(1, ['xyz  yxz  x'])
-  call feedkeys("A\<C-X>\<C-N>\<Esc>0", 'tx!')
-  call assert_equal('xyz  yxz  xyz', getline('.'))
-  " can fuzzy get yxz when use Ctrl-N twice
-  call setline(1, ['xyz  yxz  x'])
-  call feedkeys("A\<C-X>\<C-N>\<C-N>\<Esc>0", 'tx!')
-  call assert_equal('xyz  yxz  yxz', getline('.'))
-
-  call setline(1, ['one two o'])
-  call feedkeys("A\<C-X>\<C-N>\<Esc>0", 'tx!')
-  call assert_equal('one two one', getline('.'))
-
-  call setline(1, ['你好 你'])
-  call feedkeys("A\<C-X>\<C-N>\<Esc>0", 'tx!')
-  call assert_equal('你好 你好', getline('.'))
-  call setline(1, ['你的 我的 的'])
-  call feedkeys("A\<C-X>\<C-N>\<Esc>0", 'tx!')
-  call assert_equal('你的 我的 你的', getline('.'))
-  " can fuzzy get multiple-byte word when use Ctrl-N twice
-  call setline(1, ['你的 我的 的'])
-  call feedkeys("A\<C-X>\<C-N>\<C-N>\<Esc>0", 'tx!')
-  call assert_equal('你的 我的 我的', getline('.'))
-
-  "respect noinsert
-  set completeopt=fuzzycollect,menu,menuone,noinsert
-  call setline(1, ['one two o'])
-  call feedkeys("A\<C-X>\<C-N>", 'tx')
-  call assert_equal('one', g:word)
-  call assert_equal('one two o', getline('.'))
-
   " clean up
   set omnifunc=
   bw!


### PR DESCRIPTION
fuzzy can handle keyword completion as well. so fuzzycollect is no longer needed.