### PR TITLE
ci.yml: python2 for mac x86_64 and m chip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -330,7 +330,7 @@ jobs:
       - name: Install packages
         if: matrix.features == 'huge'
         run: |
-          brew install lua libtool
+          brew install lua libtool kamilturek/python2/python@2
           echo "LUA_PREFIX=$(brew --prefix)" >> $GITHUB_ENV
 
       - name: Install blackhole-2ch for macos-12


### PR DESCRIPTION
ubuntu 24.04 does not provide python2
homebrew might be the only way to provide it for build and tests, if we don't want to drop python2 support.