### PR TITLE
Implement buffer skipping in :bnext/:bprev

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -1358,9 +1358,8 @@ do_buffer_ext(
 	    // Don't count unlisted buffers.
 	    // Avoid non-help buffers if the starting point was a non-help buffer and
 	    // vice-versa.
-	    if (unload || (buf->b_p_bl &&
-			((flags & DOBUF_SKIPHELP) == 0 || (bp != buf &&
-			    buf->b_help == bp->b_help))))
+	    if (unload || (buf->b_p_bl
+			&& ((flags & DOBUF_SKIPHELP) == 0 || buf->b_help == bp->b_help)))
 	    {
 		 --count;
 		 bp = NULL;	// use this buffer as new starting point

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -50,6 +50,7 @@ static void	free_buffer(buf_T *);
 static void	free_buffer_stuff(buf_T *buf, int free_options);
 static int	bt_nofileread(buf_T *buf);
 static void	no_write_message_buf(buf_T *buf);
+static int	do_buffer_ext(int action, int start, int dir, int count, int flags);
 
 #ifdef UNIX
 # define dev_T dev_t
@@ -1100,13 +1101,30 @@ goto_buffer(
 {
     bufref_T	old_curbuf;
     int		save_sea = swap_exists_action;
+    int		skip_help_buf;
+
+    switch (eap->cmdidx)
+    {
+	case CMD_bnext:
+	case CMD_sbnext:
+	case CMD_bNext:
+	case CMD_bprevious:
+	case CMD_sbNext:
+	case CMD_sbprevious:
+	    skip_help_buf = TRUE;
+	    break;
+	default:
+	    skip_help_buf = FALSE;
+	    break;
+    }
 
     set_bufref(&old_curbuf, curbuf);
 
     if (swap_exists_action == SEA_NONE)
 	swap_exists_action = SEA_DIALOG;
-    (void)do_buffer(*eap->cmd == 's' ? DOBUF_SPLIT : DOBUF_GOTO,
-					     start, dir, count, eap->forceit);
+    (void)do_buffer_ext(*eap->cmd == 's' ? DOBUF_SPLIT : DOBUF_GOTO, start, dir, count,
+	    (eap->forceit ? DOBUF_FORCEIT : 0) |
+	    (skip_help_buf ? DOBUF_SKIPHELP : 0));
     if (swap_exists_action == SEA_QUIT && *eap->cmd == 's')
     {
 #if defined(FEAT_EVAL)
@@ -1337,8 +1355,12 @@ do_buffer_ext(
 		if (buf == NULL)
 		    buf = lastbuf;
 	    }
-	    // don't count unlisted buffers
-	    if (unload || buf->b_p_bl)
+	    // Don't count unlisted buffers.
+	    // Avoid non-help buffers if the starting point was a non-help buffer and
+	    // vice-versa.
+	    if (unload || (buf->b_p_bl &&
+			((flags & DOBUF_SKIPHELP) == 0 || (bp != buf &&
+			    buf->b_help == bp->b_help))))
 	    {
 		 --count;
 		 bp = NULL;	// use this buffer as new starting point

--- a/src/testdir/test_buffer.vim
+++ b/src/testdir/test_buffer.vim
@@ -135,13 +135,13 @@ func Test_bnext_bprev_help()
   e Xbuf1
   let b2 = bufnr()
 
-  " There's only one buffer of each type, the commands should fail.
+  " There's only one buffer of each type.
   b XHelp1
-  call assert_fails('bnext', 'E85:')
-  call assert_fails('bprev', 'E85:')
+  bnext | call assert_equal(b1, bufnr())
+  bprev | call assert_equal(b1, bufnr())
   b Xbuf1
-  call assert_fails('bnext', 'E85:')
-  call assert_fails('bprev', 'E85:')
+  bnext | call assert_equal(b2, bufnr())
+  bprev | call assert_equal(b2, bufnr())
 
   " Add one more buffer of each type.
   e XHelp2 | set bt=help

--- a/src/testdir/test_buffer.vim
+++ b/src/testdir/test_buffer.vim
@@ -126,6 +126,52 @@ func Test_buflist_browse()
   %bwipe!
 endfunc
 
+" Test for :bnext and :bprev when called from help and non-help buffers.
+func Test_bnext_bprev_help()
+  %bwipe!
+
+  e XHelp1 | set bt=help
+  let b1 = bufnr()
+  e Xbuf1
+  let b2 = bufnr()
+
+  " There's only one buffer of each type, the commands should fail.
+  b XHelp1
+  call assert_fails('bnext', 'E85:')
+  call assert_fails('bprev', 'E85:')
+  b Xbuf1
+  call assert_fails('bnext', 'E85:')
+  call assert_fails('bprev', 'E85:')
+
+  " Add one more buffer of each type.
+  e XHelp2 | set bt=help
+  let b3 = bufnr()
+  e Xbuf2
+  let b4 = bufnr()
+
+  " Help buffer jumps to help buffer.
+  b XHelp1
+  bnext | call assert_equal(b3, bufnr())
+  bnext | call assert_equal(b1, bufnr())
+  bprev | call assert_equal(b3, bufnr())
+  bprev | call assert_equal(b1, bufnr())
+
+  " Regular buffer jumps to regular buffer.
+  b Xbuf1
+  bnext | call assert_equal(b4, bufnr())
+  bnext | call assert_equal(b2, bufnr())
+  bprev | call assert_equal(b4, bufnr())
+  bprev | call assert_equal(b2, bufnr())
+
+  " :brewind and :blast are not affected by the buffer type.
+  b Xbuf2
+  brewind | call assert_equal(b1, bufnr())
+  b XHelp1
+  blast   | call assert_equal(b4, bufnr())
+
+  %bwipe!
+endfunc
+
 " Test for :bdelete
 func Test_bdelete_cmd()
   %bwipe!

--- a/src/vim.h
+++ b/src/vim.h
@@ -1074,6 +1074,8 @@ extern int (*dyn_libintl_wputenv)(const wchar_t *envstring);
 // Values for flags argument of do_buffer()
 #define DOBUF_FORCEIT	1	// :cmd!
 #define DOBUF_NOPOPUP	2	// skip popup window buffers
+#define DOBUF_SKIPHELP	4	// skip or keep help buffers depending on b_help of the
+				// starting buffer
 
 // Values for sub_cmd and which_pat argument for search_regcomp()
 // Also used for which_pat argument for searchit()


### PR DESCRIPTION
As explained in the help section for :bnext and :bprev the commands should jump from help buffers to help buffers (and from regular ones to regular ones).

Closes #4478