### PR TITLE
Keep track of container types in assignments

### DIFF
--- a/src/dict.c
+++ b/src/dict.c
@@ -1636,6 +1636,24 @@ dict_set_items_ro(dict_T *di)
 }
 
 /*
+ * Replaces the typval_T of dict item "di" to "tv".  "tv" is copied.
+ * Return FAIL when the type is wrong.
+ */
+    int
+dict_set_item_move(dict_T *d, dictitem_T *di, typval_T *tv)
+{
+    if (d->dv_type != NULL
+	    && d->dv_type->tt_member->tt_type != VAR_ANY
+	    && check_typval_arg_type(d->dv_type->tt_member, tv, NULL, 0) == FAIL)
+	return FAIL;
+
+    clear_tv(&di->di_tv);
+    di->di_tv = *tv;
+
+    return OK;
+}
+
+/*
  * "has_key()" function
  */
     void

--- a/src/eval.c
+++ b/src/eval.c
@@ -2313,9 +2313,9 @@ set_var_lval(
 		typ = lp->ll_valtype;
 	    // Use the type infos available at runtime.
 	    else if (lp->ll_dict != NULL)
-		typ = lp->ll_dict->dv_type;
+		typ = lp->ll_dict->dv_type->tt_member;
 	    else if (lp->ll_list != NULL)
-		typ = lp->ll_list->lv_type;
+		typ = lp->ll_list->lv_type->tt_member;
 
 	    if (typ != NULL && typ->tt_type != VAR_ANY
 		    && check_typval_arg_type(typ, rettv, NULL, 0) == FAIL)

--- a/src/eval.c
+++ b/src/eval.c
@@ -2312,9 +2312,9 @@ set_var_lval(
 	    if (lp->ll_valtype != NULL)
 		typ = lp->ll_valtype;
 	    // Use the type infos available at runtime.
-	    else if (lp->ll_dict != NULL)
+	    else if (lp->ll_dict != NULL && lp->ll_dict->dv_type != NULL)
 		typ = lp->ll_dict->dv_type->tt_member;
-	    else if (lp->ll_list != NULL)
+	    else if (lp->ll_list != NULL && lp->ll_list->lv_type != NULL)
 		typ = lp->ll_list->lv_type->tt_member;
 
 	    if (typ != NULL && typ->tt_type != VAR_ANY

--- a/src/eval.c
+++ b/src/eval.c
@@ -2304,10 +2304,23 @@ set_var_lval(
 	    return;
 	}
 
-	if (lp->ll_valtype != NULL
-		    && check_typval_arg_type(lp->ll_valtype, rettv,
-							      NULL, 0) == FAIL)
-	    return;
+	if (in_vim9script())
+	{
+	    type_T	*typ = NULL;
+
+	    // Use the declared type if available.
+	    if (lp->ll_valtype != NULL)
+		typ = lp->ll_valtype;
+	    // Use the type infos available at runtime.
+	    else if (lp->ll_dict != NULL)
+		typ = lp->ll_dict->dv_type;
+	    else if (lp->ll_list != NULL)
+		typ = lp->ll_list->lv_type;
+
+	    if (typ != NULL && typ->tt_type != VAR_ANY
+		    && check_typval_arg_type(typ, rettv, NULL, 0) == FAIL)
+		return;
+	}
 
 	if (lp->ll_newkey != NULL)
 	{

--- a/src/list.c
+++ b/src/list.c
@@ -620,6 +620,24 @@ list_append_tv(list_T *l, typval_T *tv)
 }
 
 /*
+ * Replaces the typval_T of list item "li" to "tv".  "tv" is copied.
+ * Return FAIL when the type is wrong.
+ */
+    int
+list_set_item_move(list_T *l, listitem_T *li, typval_T *tv)
+{
+    if (l->lv_type != NULL
+	    && l->lv_type->tt_member->tt_type != VAR_ANY
+	    && check_typval_arg_type(l->lv_type->tt_member, tv, NULL, 0) == FAIL)
+	return FAIL;
+
+    clear_tv(&li->li_tv);
+    li->li_tv = *tv;
+
+    return OK;
+}
+
+/*
  * As list_append_tv() but move the value instead of copying it.
  * Return FAIL when out of memory.
  */

--- a/src/proto/dict.pro
+++ b/src/proto/dict.pro
@@ -49,5 +49,6 @@ void f_items(typval_T *argvars, typval_T *rettv);
 void f_keys(typval_T *argvars, typval_T *rettv);
 void f_values(typval_T *argvars, typval_T *rettv);
 void dict_set_items_ro(dict_T *di);
+int dict_set_item_move(dict_T *d, dictitem_T *di, typval_T *tv);
 void f_has_key(typval_T *argvars, typval_T *rettv);
 /* vim: set ft=c : */

--- a/src/proto/list.pro
+++ b/src/proto/list.pro
@@ -24,6 +24,7 @@ listitem_T *list_find_index(list_T *l, long *idx);
 long list_idx_of_item(list_T *l, listitem_T *item);
 void list_append(list_T *l, listitem_T *item);
 int list_append_tv(list_T *l, typval_T *tv);
+int list_set_item_move(list_T *l, listitem_T *li, typval_T *tv);
 int list_append_dict(list_T *list, dict_T *dict);
 int list_append_list(list_T *list1, list_T *list2);
 int list_append_string(list_T *l, char_u *str, int len);

--- a/src/testdir/test_vim9_expr.vim
+++ b/src/testdir/test_vim9_expr.vim
@@ -4200,4 +4200,24 @@ func Test_expr_fails()
   call v9.CheckDefAndScriptFailure(["echo doesnotexist()"], 'E117:', 1)
 endfunc
 
+def Test_expr_assign_typecheck()
+  # Ensure types are checked at runtime when assigning to a list or dict.
+
+  var lines =<< trim END
+      var x: list<list<number>> = [[1], [2], [3], [4]]
+      # Erase the type and then modify an item.
+      var proxy: list<any> = x
+      proxy[2][0] = 'abc'
+  END
+  v9.CheckDefExecAndScriptFailure(lines, 'E1012:', 4)
+
+  lines =<< trim END
+      var x: dict<list<number>> = {a: [1], b: [2], c: [3], d: [4]}
+      # Erase the type and then modify an item.
+      var proxy: dict<any> = x
+      proxy['c'][0] = 'abc'
+  END
+  v9.CheckDefExecAndScriptFailure(lines, 'E1012:', 4)
+enddef
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_vim9_expr.vim
+++ b/src/testdir/test_vim9_expr.vim
@@ -4212,10 +4212,10 @@ def Test_expr_assign_typecheck()
   v9.CheckDefExecAndScriptFailure(lines, 'E1012:', 4)
 
   lines =<< trim END
-      var x: dict<list<number>> = {a: [1], b: [2], c: [3], d: [4]}
+      var x: dict<dict<number>> = {a: {a: 1}, b: {b: 2}, c: {c: 3}, d: {d: 4} }
       # Erase the type and then modify an item.
       var proxy: dict<any> = x
-      proxy['c'][0] = 'abc'
+      proxy['c']['c'] = 'abc'
   END
   v9.CheckDefExecAndScriptFailure(lines, 'E1012:', 4)
 enddef

--- a/src/vim9execute.c
+++ b/src/vim9execute.c
@@ -2313,7 +2313,8 @@ execute_storeindex(isn_T *iptr, ectx_T *ectx)
 					     e_cannot_change_locked_list_item))
 		    return FAIL;
 		// overwrite existing list item
-		list_set_item_move(list, li, tv);
+		if (list_set_item_move(list, li, tv) == FAIL)
+		    return FAIL;
 	    }
 	    else
 	    {
@@ -2347,7 +2348,8 @@ execute_storeindex(isn_T *iptr, ectx_T *ectx)
 						    e_cannot_change_dict_item))
 		    return FAIL;
 		// overwrite existing value
-		dict_set_item_move(dict, di, tv);
+		if (dict_set_item_move(dict, di, tv) == FAIL)
+		    return FAIL;
 	    }
 	    else
 	    {

--- a/src/vim9execute.c
+++ b/src/vim9execute.c
@@ -2290,11 +2290,13 @@ execute_storeindex(isn_T *iptr, ectx_T *ectx)
 	{
 	    list_T	    *list = tv_dest->vval.v_list;
 
+	    SOURCING_LNUM = iptr->isn_lnum;
 	    if (list == NULL)
 	    {
 		emsg(_(e_list_not_set));
 		return FAIL;
 	    }
+
 	    if (lidx < 0 && list->lv_len + lidx >= 0)
 		// negative index is relative to the end
 		lidx = list->lv_len + lidx;
@@ -2311,8 +2313,7 @@ execute_storeindex(isn_T *iptr, ectx_T *ectx)
 					     e_cannot_change_locked_list_item))
 		    return FAIL;
 		// overwrite existing list item
-		clear_tv(&li->li_tv);
-		li->li_tv = *tv;
+		list_set_item_move(list, li, tv);
 	    }
 	    else
 	    {
@@ -2336,6 +2337,7 @@ execute_storeindex(isn_T *iptr, ectx_T *ectx)
 		emsg(_(e_dictionary_not_set));
 		return FAIL;
 	    }
+
 	    if (key == NULL)
 		key = (char_u *)"";
 	    di = dict_find(dict, key, -1);
@@ -2345,8 +2347,7 @@ execute_storeindex(isn_T *iptr, ectx_T *ectx)
 						    e_cannot_change_dict_item))
 		    return FAIL;
 		// overwrite existing value
-		clear_tv(&di->di_tv);
-		di->di_tv = *tv;
+		dict_set_item_move(dict, di, tv);
 	    }
 	    else
 	    {


### PR DESCRIPTION
Introduce runtime checks to ensure any assignment to an existing item of a dictionary or list takes into account the member type.

Closes #15208

The `vim9execute.c` part can be reviewed by comparing the new functions with `list_append_tv` and `dict_add_tv` that are used in the else branch. The `eval.c` is sligtly more involved but is essentially the same but for the expression evaluator.