### PR TITLE
Fix Prolog file detection regex

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -465,7 +465,7 @@ export def ProtoCheck(default: string)
     # recognize Prolog by specific text in the first non-empty line
     # require a blank after the '%' because Perl uses "%list" and "%translate"
     var lnum = getline(nextnonblank(1))
-    if lnum =~ '\<prolog\>' || lnum =~ '(^\s*(:-\|%\|\/\*))\|.\s*$'
+    if lnum =~ '\<prolog\>' || lnum =~ '^\(:-\|%\|\/\*\)\|\.$'
       setf prolog
     else
       exe 'setf ' .. default


### PR DESCRIPTION
Problem: filetype: .pro file detection for Prolog is broken
Solution: fixed the regex to only match on the tested cases (igna_martinoli)

Fixes: https://github.com/vim/vim/issues/10835
Closes: https://github.com/vim/vim/pull/15206