### PR TITLE
Mark Test_gui_lowlevel_keyevent as flaky

### DIFF
--- a/src/testdir/test_gui.vim
+++ b/src/testdir/test_gui.vim
@@ -1706,6 +1706,7 @@ endfunc
 func Test_gui_lowlevel_keyevent()
   CheckMSWindows
   new
+  let g:test_is_flaky = 1
 
   " Test for <Ctrl-A> to <Ctrl-Z> keys
   for kc in range(65, 90)


### PR DESCRIPTION
Test_gui_lowlevel_keyevent is failing on vim-win32-installer recently.
Mark it as flaky for now.

(I tried to reproduce this in my local environment, but I couldn't. So, I'm not sure what the root cause is.)