### PR TITLE
Work around Test_gui_lowlevel_keyevent (2nd try)

### DIFF
--- a/src/testdir/test_gui.vim
+++ b/src/testdir/test_gui.vim
@@ -1706,10 +1706,10 @@ endfunc
 func Test_gui_lowlevel_keyevent()
   CheckMSWindows
   new
-  let g:test_is_flaky = 1
 
   " Test for <Ctrl-A> to <Ctrl-Z> keys
-  for kc in range(65, 90)
+  " FIXME: <Ctrl-C> is excluded for now.  It makes the test flaky.
+  for kc in range(65, 66) + range(68, 90)
     call SendKeys([0x11, kc])
     try
       let ch = getcharstr()


### PR DESCRIPTION
I found that v9.1.0571 was not enough.
Even with the 5 times retry, the test still often fails in some environments.

Ctrl-C interruption may occur before the preceding events are processed.
Exclude Ctrl-C to avoid the flakiness.