### PR TITLE
ex: fix inserting text after trailing bar

### DIFF
--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -1992,8 +1992,8 @@ too long when appending characters a line break is automatically inserted.
 			name.
 
 These two commands will keep on asking for lines, until you type a line
-containing only a ".".  Watch out for lines starting with a backslash, see
-|line-continuation|.
+containing only a ".".  Text typed after a "|" command separator is used first.
+Watch out for lines starting with a backslash, see |line-continuation|.
 
 NOTE: These commands cannot be used with |:global| or |:vglobal|.
 ":append" and ":insert" don't work properly in between ":if" and

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -3360,7 +3360,13 @@ ex_append(exarg_T *eap)
 		indent = get_indent_lnum(lnum);
 	}
 	ex_keep_indent = FALSE;
-	if (eap->ea_getline == NULL)
+	if (*eap->arg == '|')
+	{
+	    // Get the text after the trailing bar.
+	    theline = vim_strsave(eap->arg + 1);
+	    *eap->arg = NUL;
+	}
+	else if (eap->ea_getline == NULL)
 	{
 	    // No getline() function, use the lines that follow. This ends
 	    // when there is no more.

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -5401,7 +5401,11 @@ separate_nextcmd(exarg_T *eap, int keep_backslash)
 		    && in_vim9script()
 		    && !(eap->argt & EX_NOTRLCOM)
 		    && p > eap->cmd && VIM_ISWHITE(p[-1]))
-		|| *p == '|' || *p == '\n')
+		|| (*p == '|'
+		    && eap->cmdidx != CMD_append
+		    && eap->cmdidx != CMD_change
+		    && eap->cmdidx != CMD_insert)
+		|| *p == '\n')
 	{
 	    /*
 	     * We remove the '\' before the '|', unless EX_CTRLV is used

--- a/src/testdir/test_ex_mode.vim
+++ b/src/testdir/test_ex_mode.vim
@@ -364,4 +364,12 @@ func Test_implicit_print()
   bw!
 endfunc
 
+" Test inserting text after the trailing bar
+func Test_insert_after_trailing_bar()
+  new
+  call feedkeys("Qi|\nfoo\n.\na|bar\nbar\n.\nc|baz\n.", "xt")
+  call assert_equal(['', 'foo', 'bar', 'baz'], getline(1, '$'))
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
This is the behavior in [traditional ex](https://github.com/n-t-roff/heirloom-ex-vi) and as specified by [POSIX](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/ex.html) (step 12.c):

> If the command was an **append**, **change**, or **insert** command, and the step 12.b. ended at a \<vertical-line> character, any subsequent characters, up to the next non- \<backslash>-escaped \<newline> shall be used as input text to the command.