### PR TITLE
ex: fix implicit print for single address

### DIFF
--- a/runtime/doc/motion.txt
+++ b/runtime/doc/motion.txt
@@ -351,6 +351,7 @@ gg			Goto line [count], default first line, on the first
 
 							*:[range]*
 :[range]		Set the cursor on the last line number in [range].
+			In Ex mode, print the lines in [range].
 			[range] can also be just one line number, e.g., ":1"
 			or ":'m".
 			In contrast with |G| this command does not modify the

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -2730,7 +2730,7 @@ ex_range_without_command(exarg_T *eap)
 {
     char *errormsg = NULL;
 
-    if ((*eap->cmd == '|' || (exmode_active && eap->line1 != eap->line2))
+    if ((*eap->cmd == '|' || exmode_active)
 #ifdef FEAT_EVAL
 	    && !in_vim9script()
 #endif

--- a/src/testdir/test_paste.vim
+++ b/src/testdir/test_paste.vim
@@ -93,7 +93,7 @@ func Test_paste_ex_mode()
   call assert_equal("foo\rbar", foo)
 
   " pasting more than 40 bytes
-  exe "norm Q\<PasteStart>0000000000000000000000000000000000000000000000000000000000000000000000\<C-C>"
+  exe "norm Q\<PasteStart>s/.*/0000000000000000000000000000000000000000000000000000000000000000/\<C-C>"
 endfunc
 
 func Test_paste_onechar()


### PR DESCRIPTION
This makes it more consistent rather than having eg. `1,1` behave differently than `1,2`, or `.` doing nothing. This is also how it works in [traditional ex](https://github.com/n-t-roff/heirloom-ex-vi), and there's no mention of differing addresses in the [POSIX standard](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/ex.html) (step 6.b) for an implied print to take place.