### PR TITLE
Add v:event.typedchar for KeyInputPre autocmd

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -980,10 +980,11 @@ InsertLeavePre			Just before leaving Insert mode.  Also when
 InsertLeave			Just after leaving Insert mode.  Also when
 				using CTRL-O |i_CTRL-O|.  But not for |i_CTRL-C|.
 							*KeyInputPre*
-KeyInputPre			Just before a key is processed. The pattern is
-				matched against a string that indicates the
-				current mode, which is the same as what is
-				returned by `mode(1)`.
+KeyInputPre			Just before a key is processed after mappings
+				have been applied. The pattern is matched
+				against a string that indicates the current
+				mode, which is the same as what is returned by
+				`mode(1)`.
 				The |v:char| variable indicates the key typed
 				and can be changed during the event to process
 				a different key.  When |v:char| is not a
@@ -991,6 +992,7 @@ KeyInputPre			Just before a key is processed. The pattern is
 				character is used.
 				The following values of |v:event| are set:
 				   typed	The key is typed or not.
+				   typedchar	The typed key character.
 				It is not allowed to change the text
 				|textlock| or the current mode.
 				{only with the +eval feature}

--- a/src/getchar.c
+++ b/src/getchar.c
@@ -42,8 +42,10 @@ static buffheader_T recordbuff = {{NULL, {NUL}}, NULL, 0, 0};
 
 static int typeahead_char = 0;		// typeahead char that's not flushed
 
+#ifdef FEAT_EVAL
 static char_u typedchars[MAXMAPLEN + 1] = { NUL };  // typed chars before map
 static int typedchars_pos = 0;
+#endif
 
 /*
  * When block_redo is TRUE the redo buffer will not be changed.
@@ -1377,11 +1379,13 @@ gotchars(char_u *chars, int len)
         {
 	    updatescript(state.buf[i]);
 
+#ifdef FEAT_EVAL
 	    if (typedchars_pos < MAXMAPLEN)
 	    {
 		typedchars[typedchars_pos] = state.buf[i];
 		typedchars_pos++;
 	    }
+#endif
         }
 
 	if (reg_recording != 0)

--- a/src/getchar.c
+++ b/src/getchar.c
@@ -2190,6 +2190,7 @@ do_key_input_pre(int c)
 	buf[(*mb_char2bytes)(c, buf)] = NUL;
 
     typedchars[typedchars_pos] = NUL;
+    vim_unescape_csi(typedchars);
 
     get_mode(curr_mode);
 

--- a/src/getchar.c
+++ b/src/getchar.c
@@ -2150,10 +2150,10 @@ vgetc(void)
 
 #ifdef FEAT_EVAL
     c = do_key_input_pre(c);
-#endif
 
     // Clear the next typedchars_pos
     typedchars_pos = 0;
+#endif
 
     // Need to process the character before we know it's safe to do something
     // else.

--- a/src/getchar.c
+++ b/src/getchar.c
@@ -1376,17 +1376,7 @@ gotchars(char_u *chars, int len)
 
 	// Handle one byte at a time; no translation to be done.
 	for (i = 0; i < state.buflen; ++i)
-        {
 	    updatescript(state.buf[i]);
-
-#ifdef FEAT_EVAL
-	    if (typedchars_pos < MAXMAPLEN)
-	    {
-		typedchars[typedchars_pos] = state.buf[i];
-		typedchars_pos++;
-	    }
-#endif
-        }
 
 	if (reg_recording != 0)
 	{
@@ -1724,6 +1714,13 @@ updatescript(int c)
 	ml_sync_all(c == 0, TRUE);
 	count = 0;
     }
+#ifdef FEAT_EVAL
+    if (typedchars_pos < MAXMAPLEN)
+    {
+	typedchars[typedchars_pos] = c;
+	typedchars_pos++;
+    }
+#endif
 }
 
 /*

--- a/src/testdir/test_autocmd.vim
+++ b/src/testdir/test_autocmd.vim
@@ -4820,6 +4820,15 @@ func Test_KeyInputPre()
   call feedkeys('j', 'nx')
 
   au! KeyInputPre
+
+  " Test for v:event.typedchar
+  nnoremap j   k
+  au KeyInputPre n
+        \   call assert_equal(v:event.typedchar, 'j')
+        \ | call assert_equal(v:char, 'k')
+  call feedkeys('j', 'tx')
+
+  au! KeyInputPre
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Continues of #15182 

I have added `v:event.typedchar` for KeyInputPre autocmd.
Because `v:char` is mapped keys.

It is useful to record user input keys.