### PR TITLE
Fix test_gettext_make (again)

### DIFF
--- a/src/testdir/test_gettext_make.vim
+++ b/src/testdir/test_gettext_make.vim
@@ -6,7 +6,7 @@ CheckFeature gettext
 func Test_gettext_makefile()
   cd ../po
   if has('win32')
-    if getenv('GETTEXT_PATH') == ''
+    if getenv('GETTEXT_PATH') == v:null
       throw 'Skipped: %GETTEXT_PATH% is not set.'
     endif
     call system('nmake.exe -f Make_mvc.mak "VIMPROG=' .. getenv('VIMPROG') ..


### PR DESCRIPTION
There was a mistake in v9.1.0570.
Correct how to check the existence of %GETTEXT_PATH%.