### PR TITLE
link javaConceptKind to javaStorageClass instead of NonText

### DIFF
--- a/runtime/syntax/java.vim
+++ b/runtime/syntax/java.vim
@@ -562,7 +562,7 @@ hi def link javaStorageClass		StorageClass
 hi def link javaMethodDecl		javaStorageClass
 hi def link javaClassDecl		javaStorageClass
 hi def link javaScopeDecl		javaStorageClass
-hi def link javaConceptKind		NonText
+hi def link javaConceptKind		javaStorageClass
 
 hi def link javaBoolean		Boolean
 hi def link javaSpecial		Special


### PR DESCRIPTION
From :help highlight, the NonText highlight group is for "characters that do not really exist in the text (e.g., ">" displayed when a double-wide character doesn't fit at the end of the line).

Because of this, linking the javaConceptKind highlight group (which consists of the keywords `abstract` and `final`) to NonText seems wrong.

This commit changes javaConceptKind to link to javaStorageClass instead. This seems more correct as javaStorageClass is the highlight group to which keywords `public` `static` `synchronized` (and others) are linked.

These keywords often occur together with `abstract` and `final`, e.g. `public abstract class ...` or `static final ...`

fixes #15237