### PR TITLE
Unnecessary checks for v:sizeoflong in test_put.vim

### DIFF
--- a/src/testdir/test_put.vim
+++ b/src/testdir/test_put.vim
@@ -168,10 +168,6 @@ func Test_very_large_count()
 endfunc
 
 func Test_very_large_count_64bit()
-  if v:sizeoflong < 8
-    throw 'Skipped: only works with 64 bit long ints'
-  endif
-
   new
   let @" = repeat('x', 100)
   call assert_fails('norm 999999999p', 'E1240:')
@@ -188,10 +184,6 @@ func Test_very_large_count_block()
 endfunc
 
 func Test_very_large_count_block_64bit()
-  if v:sizeoflong < 8
-    throw 'Skipped: only works with 64 bit long ints'
-  endif
-
   new
   call setline(1, repeat('x', 100))
   exe "norm \<C-V>$y"


### PR DESCRIPTION
Problem:  Unnecessary checks for v:sizeoflong in test_put.vim.  They are
          no longer necessary as patch 8.2.3661 has changed the count to
          be within 32-bit integer limit.
Solution: Remove the checks.
