### PR TITLE
Ex command is still executed after giving E1247

### DIFF
--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -4698,6 +4698,7 @@ get_address(
 		if (n == MAXLNUM)
 		{
 		    emsg(_(e_line_number_out_of_range));
+		    cmd = NULL;
 		    goto error;
 		}
 	    }
@@ -4728,6 +4729,7 @@ get_address(
 		    if (lnum >= 0 && n >= LONG_MAX - lnum)
 		    {
 			emsg(_(e_line_number_out_of_range));
+			cmd = NULL;
 			goto error;
 		    }
 		    lnum += n;

--- a/src/testdir/test_excmd.vim
+++ b/src/testdir/test_excmd.vim
@@ -703,6 +703,8 @@ func Test_address_line_overflow()
   call setline(1, range(100))
   call assert_fails('|.44444444444444444444444', 'E1247:')
   call assert_fails('|.9223372036854775806', 'E1247:')
+  call assert_fails('.44444444444444444444444d', 'E1247:')
+  call assert_equal(range(100)->map('string(v:val)'), getline(1, '$'))
 
   $
   yank 77777777777777777777


### PR DESCRIPTION
Problem:  Ex command is still executed after giving E1247.
Solution: Indicate the error properly.
