### PR TITLE
runtime(macros): fix maze compilation error

### DIFF
--- a/runtime/macros/maze/mazeclean.c
+++ b/runtime/macros/maze/mazeclean.c
@@ -9,6 +9,7 @@
 char *M, A, Z, E = 40, line[80], T[3];
 int
 main (C)
+int C;
 {
   for (M = line + E, *line = A = scanf ("%d", &C); --E; line[E] = M[E] = E)
     printf ("._");


### PR DESCRIPTION
Implicit int is an error in newer versions of clang.