### PR TITLE
Fix for mapping processing when capital letters are represented with terminal codes

### DIFF
--- a/src/getchar.c
+++ b/src/getchar.c
@@ -2726,8 +2726,11 @@ handle_mapping(
 		    }
 		}
 		else
+		{
 		    // No match; may have to check for termcode at next
-		    // character.  If the first character that didn't match is
+		    // character.  
+
+		    // If the first character that didn't match is
 		    // K_SPECIAL then check for a termcode.  This isn't perfect
 		    // but should work in most cases.
 		    if (max_mlen < mlen)
@@ -2737,6 +2740,12 @@ handle_mapping(
 		    }
 		    else if (max_mlen == mlen && mp->m_keys[mlen] == K_SPECIAL)
 			want_termcode = 1;
+
+		    // Check termcode for uppercase character to properly 
+		    // process "ESC[27;2;<ascii code>~" control sequences.
+		    if (ASCII_ISUPPER(mp->m_keys[mlen]))
+			want_termcode = 1;
+		}
 	    }
 	}
 


### PR DESCRIPTION
Problem: there are two mappings and
1) the first mapping is substring of the second,
2) the first non-matching letter is capital,
3) capital letters are represented with termcodes "ESC[27;2;<ascii code>~" on given system 
then first mapping is applied instead of second.

Example:

    :map B b
    :map BBB blimp!

and then

    BBB -> bbb

instead of

    BBB -> blimp!

Solution: force termcodes check if capital letter does not match.