### PR TITLE
runtime(filetype): Update FTpl() regex for Prolog detection

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -465,7 +465,7 @@ export def ProtoCheck(default: string)
     # recognize Prolog by specific text in the first non-empty line
     # require a blank after the '%' because Perl uses "%list" and "%translate"
     var lnum = getline(nextnonblank(1))
-    if lnum =~ '\<prolog\>' || lnum =~ '^\(:-\|%\|\/\*\)\|\.$'
+    if lnum =~ '\<prolog\>' || lnum =~ '^\s*\(:-\|%\+\(\s\|$\)\|\/\*\)\|\.\s*$'
       setf prolog
     else
       exe 'setf ' .. default
@@ -644,7 +644,7 @@ export def FTpl()
     # recognize Prolog by specific text in the first non-empty line
     # require a blank after the '%' because Perl uses "%list" and "%translate"
     var line = getline(nextnonblank(1))
-    if line =~ '\<prolog\>' || line =~ '^\(:-\|%\|\/\*\)\|\.$'
+    if line =~ '\<prolog\>' || line =~ '^\s*\(:-\|%\+\(\s\|$\)\|\/\*\)\|\.\s*$'
       setf prolog
     else
       setf perl

--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -644,7 +644,7 @@ export def FTpl()
     # recognize Prolog by specific text in the first non-empty line
     # require a blank after the '%' because Perl uses "%list" and "%translate"
     var line = getline(nextnonblank(1))
-    if line =~ '\<prolog\>' || line =~ '^\s*\(%\+\(\s\|$\)\|/\*\)' || line =~ ':-'
+    if line =~ '\<prolog\>' || line =~ '^\(:-\|%\|\/\*\)\|\.$'
       setf prolog
     else
       setf perl

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -2614,28 +2614,28 @@ func Test_pl_file()
 
   "Prolog
   call writefile([':-module(test/1,'], 'Xfile.pro', 'D')
-  split Xfile.pro
+  split Xfile.pl
   call assert_equal('prolog', &filetype)
   bwipe!
 
   call writefile(['% comment'], 'Xfile.pro', 'D')
-  split Xfile.pro
+  split Xfile.pl
   call assert_equal('prolog', &filetype)
   bwipe!
 
   call writefile(['/* multiline comment'], 'Xfile.pro', 'D')
-  split Xfile.pro
+  split Xfile.pl
   call assert_equal('prolog', &filetype)
   bwipe!
 
   call writefile(['rule(test, 1.7).'], 'Xfile.pro', 'D')
-  split Xfile.pro
+  split Xfile.pl
   call assert_equal('prolog', &filetype)
   bwipe!
 
   " Perl
   call writefile(['%data = (1, 2, 3);'], 'Xfile.pro', 'D')
-  split Xfile.pro
+  split Xfile.pl
   call assert_notequal('prolog', &filetype)
 
   filetype off

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -2613,28 +2613,28 @@ func Test_pl_file()
   filetype on
 
   "Prolog
-  call writefile([':-module(test/1,'], 'Xfile.pro', 'D')
+  call writefile([':-module(test/1,'], 'Xfile.pl', 'D')
   split Xfile.pl
   call assert_equal('prolog', &filetype)
   bwipe!
 
-  call writefile(['% comment'], 'Xfile.pro', 'D')
+  call writefile(['% comment'], 'Xfile.pl', 'D')
   split Xfile.pl
   call assert_equal('prolog', &filetype)
   bwipe!
 
-  call writefile(['/* multiline comment'], 'Xfile.pro', 'D')
+  call writefile(['/* multiline comment'], 'Xfile.pl', 'D')
   split Xfile.pl
   call assert_equal('prolog', &filetype)
   bwipe!
 
-  call writefile(['rule(test, 1.7).'], 'Xfile.pro', 'D')
+  call writefile(['rule(test, 1.7).'], 'Xfile.pl', 'D')
   split Xfile.pl
   call assert_equal('prolog', &filetype)
   bwipe!
 
   " Perl
-  call writefile(['%data = (1, 2, 3);'], 'Xfile.pro', 'D')
+  call writefile(['%data = (1, 2, 3);'], 'Xfile.pl', 'D')
   split Xfile.pl
   call assert_notequal('prolog', &filetype)
 

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -2603,7 +2603,7 @@ func Test_pro_file()
   " IDL
   call writefile(['x = findgen(100)/10'], 'Xfile.pro', 'D')
   split Xfile.pro
-  call assert_equal('idl', &filetype)
+  call assert_equal('idlang', &filetype)
 
   filetype off
 endfunc

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -2636,7 +2636,7 @@ func Test_pl_file()
   " Perl
   call writefile(['%data = (1, 2, 3);'], 'Xfile.pl', 'D')
   split Xfile.pl
-  call assert_notequal('prolog', &filetype)
+  call assert_equal('perl', &filetype)
 
   filetype off
 endfunc

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -2600,6 +2600,10 @@ func Test_pro_file()
   call assert_equal('prolog', &filetype)
   bwipe!
 
+  call writefile(['%data = (1, 2, 3);'], 'Xfile.pro', 'D')
+  split Xfile.pro
+  call assert_notequal('prolog', &filetype)
+
   filetype off
 endfunc
 

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -2600,6 +2600,40 @@ func Test_pro_file()
   call assert_equal('prolog', &filetype)
   bwipe!
 
+  " IDL
+  call writefile(['x = findgen(100)/10'], 'Xfile.pro', 'D')
+  split Xfile.pro
+  call assert_equal('idl', &filetype)
+
+  filetype off
+endfunc
+
+
+func Test_pl_file()
+  filetype on
+
+  "Prolog
+  call writefile([':-module(test/1,'], 'Xfile.pro', 'D')
+  split Xfile.pro
+  call assert_equal('prolog', &filetype)
+  bwipe!
+
+  call writefile(['% comment'], 'Xfile.pro', 'D')
+  split Xfile.pro
+  call assert_equal('prolog', &filetype)
+  bwipe!
+
+  call writefile(['/* multiline comment'], 'Xfile.pro', 'D')
+  split Xfile.pro
+  call assert_equal('prolog', &filetype)
+  bwipe!
+
+  call writefile(['rule(test, 1.7).'], 'Xfile.pro', 'D')
+  split Xfile.pro
+  call assert_equal('prolog', &filetype)
+  bwipe!
+
+  " Perl
   call writefile(['%data = (1, 2, 3);'], 'Xfile.pro', 'D')
   split Xfile.pro
   call assert_notequal('prolog', &filetype)


### PR DESCRIPTION
Problem: The regex in the FTpl() function was outdated
Solution: Updated the regex as per https://github.com/vim/vim/pull/15220/files

fixes: #10835
closes: #15206