### PR TITLE
Storage class warning

### DIFF
--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -7534,7 +7534,7 @@ f_hostname(typval_T *argvars UNUSED, typval_T *rettv)
  * Currently only valid for object/container types.
  * Return empty string if not an object.
  */
-    void
+    static void
 f_id(typval_T *argvars, typval_T *rettv)
 {
     char    numbuf[NUMBUFLEN];


### PR DESCRIPTION
After patch 9.1.548 HP-UX give this warning:
`    cc -c -I. -Iproto -DHAVE_CONFIG_H     -O2       -D_REENTRANT -o objects/evalfunc.o evalfunc.c
cc: "evalfunc.c", line 7529: warning 562: Redeclaration of "f_id" with a different storage class specifier: "f_id" will have internal linkage.
`