### PR TITLE
Printed line doesn't overwrite colon when pressing Enter in Ex mode

### DIFF
--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -2722,6 +2722,12 @@ ex_errmsg(char *msg, char_u *arg)
 }
 
 /*
+ * The "+" string used in place of an empty command in Ex mode.
+ * This string is used in pointer comparison.
+ */
+static char exmode_plus[] = "+";
+
+/*
  * Handle a range without a command.
  * Returns an error message on failure.
  */
@@ -2730,7 +2736,8 @@ ex_range_without_command(exarg_T *eap)
 {
     char *errormsg = NULL;
 
-    if ((*eap->cmd == '|' || exmode_active)
+    if ((*eap->cmd == '|' ||
+		(exmode_active && eap->cmd != (char_u *)exmode_plus + 1))
 #ifdef FEAT_EVAL
 	    && !in_vim9script()
 #endif
@@ -3213,7 +3220,7 @@ parse_command_modifiers(
 		eap->cmd = orig_cmd;
     }
     else if (use_plus_cmd)
-	eap->cmd = (char_u *)"+";
+	eap->cmd = (char_u *)exmode_plus;
 
     return OK;
 }

--- a/src/testdir/test_ex_mode.vim
+++ b/src/testdir/test_ex_mode.vim
@@ -68,7 +68,7 @@ func Test_Ex_substitute()
   CheckRunVimInTerminal
   let buf = RunVimInTerminal('', {'rows': 6})
 
-  call term_sendkeys(buf, ":call setline(1, ['foo foo', 'foo foo', 'foo foo'])\<CR>")
+  call term_sendkeys(buf, ":call setline(1, repeat(['foo foo'], 4))\<CR>")
   call term_sendkeys(buf, ":set number\<CR>")
   call term_sendkeys(buf, "gQ")
   call WaitForAssert({-> assert_match(':', term_getline(buf, 6))}, 1000)
@@ -90,8 +90,14 @@ func Test_Ex_substitute()
 
   " Pressing enter in ex mode should print the current line
   call term_sendkeys(buf, "\<CR>")
-  call WaitForAssert({-> assert_match('  3 foo foo',
-        \ term_getline(buf, 5))}, 1000)
+  call WaitForAssert({-> assert_match('  3 foo foo', term_getline(buf, 5))}, 1000)
+  call WaitForAssert({-> assert_match(':', term_getline(buf, 6))}, 1000)
+
+  " The printed line should overwrite the colon
+  call term_sendkeys(buf, "\<CR>")
+  call WaitForAssert({-> assert_match('  3 foo foo', term_getline(buf, 4))}, 1000)
+  call WaitForAssert({-> assert_match('  4 foo foo', term_getline(buf, 5))}, 1000)
+  call WaitForAssert({-> assert_match(':', term_getline(buf, 6))}, 1000)
 
   call term_sendkeys(buf, ":vi\<CR>")
   call WaitForAssert({-> assert_match('foo bar', term_getline(buf, 1))}, 1000)


### PR DESCRIPTION
Problem:  Printed line no longer overwrites colon when pressing Enter in
          Ex mode (after 9.1.0573).
Solution: Restore the behavior of pressing Enter in Ex mode.
