### PR TITLE
runtime(filetype): recommended indent options for go and gdscript

### DIFF
--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -623,11 +623,33 @@ any #lang directive overrides, use the following command: >
 	let g:freebasic_lang = "fblite"
 
 
+GDSCRIPT						*ft-gdscript-plugin*
+
+By default the following options are set, based on Godot official docs: >
+
+	setlocal noexpandtab softtabstop=0 shiftwidth=0
+
+To disable this behavior, set the following variable in your vimrc: >
+
+	let g:gdscript_recommended_style = 0
+
+
 GIT COMMIT                                              *ft-gitcommit-plugin*
 
 One command, :DiffGitCached, is provided to show a diff of the current commit
 in the preview window.  It is equivalent to calling "git diff --cached" plus
 any arguments given to the command.
+
+
+GO							*ft-go-plugin*
+
+By default the following options are set, based on Golang official docs: >
+
+	setlocal noexpandtab softtabstop=0 shiftwidth=0
+
+To disable this behavior, set the following variable in your vimrc: >
+
+	let g:go_recommended_style = 0
 
 
 GPROF							*ft-gprof-plugin*

--- a/runtime/ftplugin/gdscript.vim
+++ b/runtime/ftplugin/gdscript.vim
@@ -25,7 +25,7 @@ setlocal foldexpr=GDScriptFoldLevel()
 
 if get(g:, 'gdscript_recommended_style', 1)
     setlocal noexpandtab tabstop=4 softtabstop=0 shiftwidth=0
-    let b:undo_ftplugin ..= ' | setlocal expandtab< tabstop< softtabstop< shiftwidth<'
+    b:undo_ftplugin ..= ' | setlocal expandtab< tabstop< softtabstop< shiftwidth<'
 endif
 
 

--- a/runtime/ftplugin/gdscript.vim
+++ b/runtime/ftplugin/gdscript.vim
@@ -24,8 +24,8 @@ setlocal foldignore=
 setlocal foldexpr=GDScriptFoldLevel()
 
 if get(g:, 'gdscript_recommended_style', 1)
-    setlocal noexpandtab softtabstop=0 shiftwidth=0
-    let b:undo_ftplugin .= ' | setl et< sts< sw<'
+    setlocal noexpandtab tabstop=4 softtabstop=0 shiftwidth=0
+    let b:undo_ftplugin .= ' | setl et< ts< sts< sw<'
 endif
 
 

--- a/runtime/ftplugin/gdscript.vim
+++ b/runtime/ftplugin/gdscript.vim
@@ -25,7 +25,7 @@ setlocal foldexpr=GDScriptFoldLevel()
 
 if get(g:, 'gdscript_recommended_style', 1)
     setlocal noexpandtab tabstop=4 softtabstop=0 shiftwidth=0
-    let b:undo_ftplugin .= ' | setl et< ts< sts< sw<'
+    let b:undo_ftplugin ..= ' | setlocal expandtab< tabstop< softtabstop< shiftwidth<'
 endif
 
 

--- a/runtime/ftplugin/gdscript.vim
+++ b/runtime/ftplugin/gdscript.vim
@@ -4,6 +4,7 @@ vim9script
 # Language: gdscript (Godot game engine scripting language)
 # Maintainer: Maxim Kim <habamax@gmail.com>
 # Website: https://github.com/habamax/vim-gdscript
+# Last Change: 2024 Jul 14
 
 if exists("b:did_ftplugin") | finish | endif
 
@@ -21,6 +22,11 @@ setlocal suffixesadd=.gd
 setlocal commentstring=#\ %s
 setlocal foldignore=
 setlocal foldexpr=GDScriptFoldLevel()
+
+if get(g:, 'gdscript_recommended_style', 1)
+    setlocal noexpandtab softtabstop=0 shiftwidth=0
+    let b:undo_ftplugin .= ' | setl et< sts< sw<'
+endif
 
 
 def GDScriptFoldLevel(): string

--- a/runtime/ftplugin/go.vim
+++ b/runtime/ftplugin/go.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin file
 " Language:	Go
 " Maintainer:	David Barnett (https://github.com/google/vim-ft-go)
-" Last Change:	2014 Aug 16
+" Last Change:	2024 Jul 14
 
 if exists('b:did_ftplugin')
   finish
@@ -14,5 +14,10 @@ setlocal comments=s1:/*,mb:*,ex:*/,://
 setlocal commentstring=//\ %s
 
 let b:undo_ftplugin = 'setl fo< com< cms<'
+
+if get(g:, 'go_recommended_style', 1)
+  setlocal noexpandtab softtabstop=0 shiftwidth=0
+  let b:undo_ftplugin .= ' | setl et< sts< sw<'
+endif
 
 " vim: sw=2 sts=2 et

--- a/runtime/ftplugin/gomod.vim
+++ b/runtime/ftplugin/gomod.vim
@@ -8,7 +8,8 @@ if exists('b:did_ftplugin')
 endif
 let b:did_ftplugin = 1
 
+setlocal noexpandtab
 setlocal formatoptions-=t formatoptions-=c
 setlocal commentstring=//\ %s
 
-let b:undo_ftplugin = 'setl fo< cms<'
+let b:undo_ftplugin = 'setl et< fo< cms<'


### PR DESCRIPTION
Updates the ftplugin files of to use the officially recommended indentation styles for Golang and GDScript.

## go
Go officially recommends using tabs over spaces, and their formatter enforces tabs for indents https://go.dev/doc/effective_go
> We use tabs for indentation and gofmt emits them by default. Use spaces only if you must.

## gdscript
Godot also officially recommended using tabs over spaces https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html#formatting
> Use Tabs instead of spaces for indentation. (editor default)

*EDIT: (ftplugin maintainers have been contacted)*