### PR TITLE
doc: 'cpoptions': Include "z" in the documented default

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2257,7 +2257,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	Also see 'preserveindent'.
 
 						*'cpoptions'* *'cpo'* *cpo*
-'cpoptions' 'cpo'	string	(Vim default: "aABceFs",
+'cpoptions' 'cpo'	string	(Vim default: "aABceFsz",
 				 Vi default:  all flags)
 			global
 	A sequence of single character flags.  When a character is present


### PR DESCRIPTION
A fixup for

commit 22105fd1fe0dcfe993b5c04c6ebe017a626116e3 (tag: v9.1.0589)
Author: Christian Brabandt <cb@256bit.org>
Date:   Mon Jul 15 20:51:11 2024 +0200

    patch 9.1.0589: vi: d{motion} and cw work differently than expected