### PR TITLE
fix(completion): wrong exit condition on search fuzzy

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -3538,7 +3538,8 @@ get_next_filename_completion(void)
     char_u	**sorted_matches;
     int		*fuzzy_indices_data;
 
-    if (in_fuzzy)
+    if (in_fuzzy && (vim_strchr(leader, '/') == NULL
+		&& vim_strchr(leader, '\\') == NULL))
     {
 	vim_free(compl_pattern);
 	compl_pattern = vim_strsave((char_u *)"*");

--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -3537,12 +3537,41 @@ get_next_filename_completion(void)
     int		in_fuzzy = ((get_cot_flags() & COT_FUZZY) != 0 && leader_len > 0);
     char_u	**sorted_matches;
     int		*fuzzy_indices_data;
+    char_u	*last_sep = NULL;
+    size_t	path_with_wildcard_len;
+    char_u	*path_with_wildcard;
 
-    if (in_fuzzy && (vim_strchr(leader, '/') == NULL
-		&& vim_strchr(leader, '\\') == NULL))
+    if (in_fuzzy)
     {
-	vim_free(compl_pattern);
-	compl_pattern = vim_strsave((char_u *)"*");
+	last_sep = vim_strrchr(leader, PATHSEP);
+	if (last_sep == NULL)
+	{
+	    // No path separator or separator is the last character,
+	    // fuzzy match the whole leader
+	    vim_free(compl_pattern);
+	    compl_pattern = vim_strsave((char_u *)"*");
+	    compl_patternlen = STRLEN(compl_pattern);
+	}
+	else if (*(last_sep + 1) == '\0')
+	    in_fuzzy = FALSE;
+	else
+	{
+	    // Split leader into path and file parts
+	    int path_len = last_sep - leader + 1;
+	    path_with_wildcard_len = path_len + 2;
+	    path_with_wildcard = alloc(path_with_wildcard_len);
+	    if (path_with_wildcard != NULL)
+	    {
+		vim_strncpy(path_with_wildcard, leader, path_len);
+		vim_strcat(path_with_wildcard, (char_u *)"*", path_with_wildcard_len);
+		vim_free(compl_pattern);
+		compl_pattern = path_with_wildcard;
+		compl_patternlen = STRLEN(compl_pattern);
+
+		// Move leader to the file part
+		leader = last_sep + 1;
+	    }
+	}
     }
 
     if (expand_wildcards(1, &compl_pattern, &num_matches, &matches,

--- a/src/search.c
+++ b/src/search.c
@@ -5222,15 +5222,16 @@ search_for_fuzzy_match(
     if (whole_line)
 	current_pos.lnum += dir;
 
+    if (buf == curbuf)
+        circly_end = *start_pos;
+    else
+    {
+        circly_end.lnum = buf->b_ml.ml_line_count;
+        circly_end.col = 0;
+        circly_end.coladd = 0;
+    }
+
     do {
-	if (buf == curbuf)
-	    circly_end = *start_pos;
-	else
-	{
-	    circly_end.lnum = buf->b_ml.ml_line_count;
-	    circly_end.col = 0;
-	    circly_end.coladd = 0;
-	}
 
 	// Check if looped around and back to start position
 	if (looped_around && EQUAL_POS(current_pos, circly_end))
@@ -5255,6 +5256,8 @@ search_for_fuzzy_match(
 			*pos = current_pos;
 			break;
 		    }
+		    else if (looped_around && current_pos.lnum == circly_end.lnum)
+			break;
 		}
 		else
 		{

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -2625,6 +2625,8 @@ func Test_complete_fuzzy_match()
   call assert_equal('fobar', getline('.'))
   call feedkeys("Sfob\<C-X>\<C-f>\<C-N>\<Esc>0", 'tx!')
   call assert_equal('foobar', getline('.'))
+  call feedkeys("S../\<C-X>\<C-f>\<Esc>0", 'tx!')
+  call assert_match('../*', getline('.'))
 
   " can get completion from other buffer
   set completeopt=fuzzy,menu,menuone
@@ -2639,6 +2641,8 @@ func Test_complete_fuzzy_match()
   call assert_equal('Omnipotent', getline('.'))
   call feedkeys("Somp\<C-P>\<C-P>\<Esc>0", 'tx!')
   call assert_equal('Composite', getline('.'))
+  call feedkeys("S omp\<C-N>\<Esc>0", 'tx!')
+  call assert_equal(' completeness', getline('.'))
 
   " fuzzy on whole line completion
   call setline(1, ["world is on fire", "no one can save me but you", 'user can execute', ''])

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -2627,6 +2627,8 @@ func Test_complete_fuzzy_match()
   call assert_equal('foobar', getline('.'))
   call feedkeys("S../\<C-X>\<C-f>\<Esc>0", 'tx!')
   call assert_match('../*', getline('.'))
+  call feedkeys("S../td\<C-X>\<C-f>\<Esc>0", 'tx!')
+  call assert_match('../testdir', getline('.'))
 
   " can get completion from other buffer
   set completeopt=fuzzy,menu,menuone


### PR DESCRIPTION
Problem:
1. in file completion leader can have the path separator.
2. Infinite loop when the col of startpos is not 0. Each time the loop reaches a new row, the col of currentpos will be reset to 0, making it impossible to exit the loop.

Solution:
1. when leader include path separator don't fuzzy result.
2. when back to startpos lnum and this line no match break loop avoid infinite loop

Fix #15287