### PR TITLE
Allow popup_filter_yesno to handle "Press ENTER ...".

### DIFF
--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -2651,8 +2651,11 @@ f_popup_filter_yesno(typval_T *argvars, typval_T *rettv)
 	return;
 
     c = *key;
+    if (c == CAR && need_wait_return)
+	return;
     if (c == K_SPECIAL && key[1] != NUL)
 	c = TO_SPECIAL(key[1], key[2]);
+
 
     // consume all keys until done
     rettv->v_type = VAR_BOOL;


### PR DESCRIPTION
Fix #15300

Looking around I came across a simple fix. But key handling is complex. It doesn't seem like this could cause problems since it only kicks in when popup_filter_yesno is active.

I looked around for a solution from script, but it eludes me. For starters I couldn't find a way to tell if `Press ENTER ...` is active.