### PR TITLE
fix(filetype): use correct extension detection for Dracula

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -713,7 +713,7 @@ if has("fname_case")
 endif
 
 " Dracula
-au BufNewFile,BufRead *.drac,*.drc,*lvs,*lpe	setf dracula
+au BufNewFile,BufRead *.drac,*.drc,*.lvs,*.lpe	setf dracula
 
 " Datascript
 au BufNewFile,BufRead *.ds			setf datascript

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -225,7 +225,7 @@ def s:GetFilenameChecks(): dict<list<string>>
              'psprint.conf', 'sofficerc', 'any/.config/lxqt/globalkeyshortcuts.conf', 'any/.config/screengrab/screengrab.conf',
              'any/.local/share/flatpak/repo/config', '.notmuch-config'],
     dot: ['file.dot', 'file.gv'],
-    dracula: ['file.drac', 'file.drc', 'filelvs', 'filelpe', 'drac.file', 'lpe', 'lvs', 'some-lpe', 'some-lvs'],
+    dracula: ['file.drac', 'file.drc', 'file.lvs', 'file.lpe', 'drac.file'],
     dtd: ['file.dtd'],
     dtrace: ['/usr/lib/dtrace/io.d'],
     dts: ['file.dts', 'file.dtsi', 'file.dtso', 'file.its', 'file.keymap'],


### PR DESCRIPTION
Problem: pattern detection for Dracula language uses "\*lvs" and "\*lpe".
  As there is no dot, those are not treated as extensions which they
  should (judging by 'runtime/syntax/dracula.vim' and common sense).

Solution: use "\*.lvs" and "\*.lpe" patterns.