### PR TITLE
Remove old statically-linked executable notice

### DIFF
--- a/src/INSTALL
+++ b/src/INSTALL
@@ -178,12 +178,6 @@ There used to be a KDE version of Vim, using Qt libraries, but since it didn't
 work very well and there was no maintainer it was dropped.
 
 
-Unix: COMPILING ON LINUX
-
-On Linux, when using -g to compile (which is default for gcc), the executable
-will probably be statically linked.  If you don't want this, remove the -g
-option from CFLAGS.
-
 Unix: PUTTING vimrc IN /etc
 
 Some Linux distributions prefer to put the global vimrc file in /etc, and the


### PR DESCRIPTION
The -g compiler flag might have resulted in a statically-linked executable 20 years ago (the date this was added to the documentation,) but nowadays that is no longer true.

Remove incorrect section.