### PR TITLE
Exclude generated files from style checking

### DIFF
--- a/src/testdir/test_codestyle.vim
+++ b/src/testdir/test_codestyle.vim
@@ -28,6 +28,13 @@ def Test_source_files()
     g:ignoreSwapExists = 'e'
     exe 'edit ' .. fname
 
+    # Some files are generated files and may contain space errors.
+    if fname =~ 'dlldata.c'
+        || fname =~ 'if_ole.h'
+        || fname =~ 'iid_ole.c'
+      continue
+    endif
+
     PerformCheck(fname, ' \t', 'space before Tab', '')
 
     PerformCheck(fname, '\s$', 'trailing white space', '')


### PR DESCRIPTION
Some OLE-related auto-generated files may contain space errors:
https://ci.appveyor.com/project/chrisbra/vim-win32-installer/builds/50248542/job/w45ve9yd6qmmws8t#L11475
```
	From test_codestyle.vim:
	Found errors in Test_source_files():
	command line..script C:/projects/vim-win32-installer/vim/src/testdir/runtest.vim[607]..function RunTheTest[57]..Test_source_files[8]..<SNR>8_PerformCheck[11]..<SNR>8_ReportError line 2: ../dlldata.c line 2: trailing white space
	command line..script C:/projects/vim-win32-installer/vim/src/testdir/runtest.vim[607]..function RunTheTest[57]..Test_source_files[8]..<SNR>8_PerformCheck[11]..<SNR>8_ReportError line 2: ../iid_ole.c line 12: trailing white space
	command line..script C:/projects/vim-win32-installer/vim/src/testdir/runtest.vim[607]..function RunTheTest[57]..Test_source_files[6]..<SNR>8_PerformCheck[11]..<SNR>8_ReportError line 2: ../if_ole.h line 60: space before Tab
	command line..script C:/projects/vim-win32-installer/vim/src/testdir/runtest.vim[607]..function RunTheTest[57]..Test_source_files[8]..<SNR>8_PerformCheck[11]..<SNR>8_ReportError line 2: ../if_ole.h line 10: trailing white space
```

Exclude them from style checking.