### PR TITLE
runtime(mysql): update syntax script

### DIFF
--- a/runtime/syntax/mysql.vim
+++ b/runtime/syntax/mysql.vim
@@ -1,9 +1,9 @@
 " Vim syntax file
 " Language:     mysql
 " Maintainer:   Kenneth J. Pronovici <pronovic@ieee.org>
-" Last Change:  $LastChangedDate: 2016-04-11 10:31:04 -0500 (Mon, 11 Apr 2016) $
+" Last Change:  $LastChangedDate: 2024-07-20 14:01:04 +0800 (Sat, 20 July 2024) $
 " Filenames:    *.mysql
-" URL:          ftp://cedar-solutions.com/software/mysql.vim
+" URL:          ftp://cedar-solutions.com/software/mysql.vim (https://github.com/pronovic/vim-syntax/blob/master/mysql.vim)
 " Note:         The definitions below are taken from the mysql user manual as of April 2002, for version 3.23
 
 " quit when a syntax file was already loaded
@@ -92,23 +92,23 @@ syn keyword mysqlType            tinytext mediumtext longtext text
 syn keyword mysqlType            tinyblob mediumblob longblob blob
 syn region mysqlType             start="float\W" end="."me=s-1
 syn region mysqlType             start="float$" end="."me=s-1
-syn region mysqlType             start="float(" end=")" contains=mysqlNumber,mysqlVariable
+syn region mysqlType             start="\<float(" end=")" contains=mysqlNumber,mysqlVariable
 syn region mysqlType             start="double\W" end="."me=s-1
 syn region mysqlType             start="double$" end="."me=s-1
-syn region mysqlType             start="double(" end=")" contains=mysqlNumber,mysqlVariable
+syn region mysqlType             start="\<double(" end=")" contains=mysqlNumber,mysqlVariable
 syn region mysqlType             start="double precision\W" end="."me=s-1
 syn region mysqlType             start="double precision$" end="."me=s-1
 syn region mysqlType             start="double precision(" end=")" contains=mysqlNumber,mysqlVariable
 syn region mysqlType             start="real\W" end="."me=s-1
 syn region mysqlType             start="real$" end="."me=s-1
-syn region mysqlType             start="real(" end=")" contains=mysqlNumber,mysqlVariable
-syn region mysqlType             start="numeric(" end=")" contains=mysqlNumber,mysqlVariable
+syn region mysqlType             start="\<real(" end=")" contains=mysqlNumber,mysqlVariable
+syn region mysqlType             start="\<numeric(" end=")" contains=mysqlNumber,mysqlVariable
 syn region mysqlType             start="dec\W" end="."me=s-1
 syn region mysqlType             start="dec$" end="."me=s-1
-syn region mysqlType             start="dec(" end=")" contains=mysqlNumber,mysqlVariable
+syn region mysqlType             start="\<dec(" end=")" contains=mysqlNumber,mysqlVariable
 syn region mysqlType             start="decimal\W" end="."me=s-1
 syn region mysqlType             start="decimal$" end="."me=s-1
-syn region mysqlType             start="decimal(" end=")" contains=mysqlNumber,mysqlVariable
+syn region mysqlType             start="\<decimal(" end=")" contains=mysqlNumber,mysqlVariable
 syn region mysqlType             start="\Wtimestamp\W" end="."me=s-1
 syn region mysqlType             start="\Wtimestamp$" end="."me=s-1
 syn region mysqlType             start="\Wtimestamp(" end=")" contains=mysqlNumber,mysqlVariable
@@ -117,25 +117,42 @@ syn region mysqlType             start="^timestamp$" end="."me=s-1
 syn region mysqlType             start="^timestamp(" end=")" contains=mysqlNumber,mysqlVariable
 syn region mysqlType             start="\Wyear(" end=")" contains=mysqlNumber,mysqlVariable
 syn region mysqlType             start="^year(" end=")" contains=mysqlNumber,mysqlVariable
-syn region mysqlType             start="char(" end=")" contains=mysqlNumber,mysqlVariable
-syn region mysqlType             start="varchar(" end=")" contains=mysqlNumber,mysqlVariable
-syn region mysqlType             start="enum(" end=")" contains=mysqlString,mysqlVariable
+syn region mysqlType             start="\<char(" end=")" contains=mysqlNumber,mysqlVariable
+syn region mysqlType             start="\<varchar(" end=")" contains=mysqlNumber,mysqlVariable
+syn region mysqlType             start="\<enum(" end=")" contains=mysqlString,mysqlVariable
 syn region mysqlType             start="\Wset(" end=")" contains=mysqlString,mysqlVariable
 syn region mysqlType             start="^set(" end=")" contains=mysqlString,mysqlVariable
 
 " Logical, string and  numeric operators
 syn keyword mysqlOperator        between not and or is in like regexp rlike binary exists
-syn region mysqlOperator         start="isnull(" end=")" contains=ALL
-syn region mysqlOperator         start="coalesce(" end=")" contains=ALL
-syn region mysqlOperator         start="interval(" end=")" contains=ALL
+syn region mysqlOperatorFunction start="\<isnull(" end=")" contains=ALL
+syn region mysqlOperatorFunction start="\<coalesce(" end=")" contains=ALL
+syn region mysqlOperatorFunction start="\<interval(" end=")" contains=ALL
 
-" Control flow functions
-syn keyword mysqlFlow            case when then else end
-syn region mysqlFlow             start="ifnull("   end=")"  contains=ALL
-syn region mysqlFlow             start="nullif("   end=")"  contains=ALL
-syn region mysqlFlow             start="if("       end=")"  contains=ALL
+" Flow control functions
+" https://docs.oracle.com/cd/E17952_01/mysql-8.4-en/flow-control-functions.html
+syn keyword mysqlFlowLabel       case when then else end
+syn region mysqlFlowFunction     start="\<ifnull("   end=")"  contains=ALL
+syn region mysqlFlowFunction     start="\<nullif("   end=")"  contains=ALL
+syn region mysqlFlowFunction     start="\<if("       end=")"  contains=ALL
 
-" General Functions
+" Window functions
+" https://docs.oracle.com/cd/E17952_01/mysql-8.4-en/window-functions-usage.html
+syn keyword mysqlWindowKeyword   over partition window
+" https://docs.oracle.com/cd/E17952_01/mysql-8.4-en/window-function-descriptions.html
+syn region  mysqlWindowFunction  start="\<cume_dist(" end=")" contains=ALL
+syn region  mysqlWindowFunction  start="\<dense_rank(" end=")" contains=ALL
+syn region  mysqlWindowFunction  start="\<first_value(" end=")" contains=ALL
+syn region  mysqlWindowFunction  start="\<lag(" end=")" contains=ALL
+syn region  mysqlWindowFunction  start="\<last_value(" end=")" contains=ALL
+syn region  mysqlWindowFunction  start="\<lead(" end=")" contains=ALL
+syn region  mysqlWindowFunction  start="\<nth_value(" end=")" contains=ALL
+syn region  mysqlWindowFunction  start="\<ntile(" end=")" contains=ALL
+syn region  mysqlWindowFunction  start="\<percent_rank(" end=")" contains=ALL
+syn region  mysqlWindowFunction  start="\<rank(" end=")" contains=ALL
+syn region  mysqlWindowFunction  start="\<row_number(" end=")" contains=ALL
+
+" General functions
 "
 " I'm leery of just defining keywords for functions, since according to the MySQL manual:
 "
@@ -147,140 +164,144 @@ syn region mysqlFlow             start="if("       end=")"  contains=ALL
 " region to define them, not just a keyword.  This will probably cause the syntax file
 " to load more slowly, but at least it will be 'correct'.
 
-syn region mysqlFunction         start="abs(" end=")" contains=ALL
-syn region mysqlFunction         start="acos(" end=")" contains=ALL
-syn region mysqlFunction         start="adddate(" end=")" contains=ALL
-syn region mysqlFunction         start="ascii(" end=")" contains=ALL
-syn region mysqlFunction         start="asin(" end=")" contains=ALL
-syn region mysqlFunction         start="atan(" end=")" contains=ALL
-syn region mysqlFunction         start="atan2(" end=")" contains=ALL
-syn region mysqlFunction         start="avg(" end=")" contains=ALL
-syn region mysqlFunction         start="benchmark(" end=")" contains=ALL
-syn region mysqlFunction         start="bin(" end=")" contains=ALL
-syn region mysqlFunction         start="bit_and(" end=")" contains=ALL
-syn region mysqlFunction         start="bit_count(" end=")" contains=ALL
-syn region mysqlFunction         start="bit_or(" end=")" contains=ALL
-syn region mysqlFunction         start="ceiling(" end=")" contains=ALL
-syn region mysqlFunction         start="character_length(" end=")" contains=ALL
-syn region mysqlFunction         start="char_length(" end=")" contains=ALL
-syn region mysqlFunction         start="concat(" end=")" contains=ALL
-syn region mysqlFunction         start="concat_ws(" end=")" contains=ALL
-syn region mysqlFunction         start="connection_id(" end=")" contains=ALL
-syn region mysqlFunction         start="conv(" end=")" contains=ALL
-syn region mysqlFunction         start="cos(" end=")" contains=ALL
-syn region mysqlFunction         start="cot(" end=")" contains=ALL
-syn region mysqlFunction         start="count(" end=")" contains=ALL
-syn region mysqlFunction         start="curdate(" end=")" contains=ALL
-syn region mysqlFunction         start="curtime(" end=")" contains=ALL
-syn region mysqlFunction         start="date_add(" end=")" contains=ALL
-syn region mysqlFunction         start="date_format(" end=")" contains=ALL
-syn region mysqlFunction         start="date_sub(" end=")" contains=ALL
-syn region mysqlFunction         start="dayname(" end=")" contains=ALL
-syn region mysqlFunction         start="dayofmonth(" end=")" contains=ALL
-syn region mysqlFunction         start="dayofweek(" end=")" contains=ALL
-syn region mysqlFunction         start="dayofyear(" end=")" contains=ALL
-syn region mysqlFunction         start="decode(" end=")" contains=ALL
-syn region mysqlFunction         start="degrees(" end=")" contains=ALL
-syn region mysqlFunction         start="elt(" end=")" contains=ALL
-syn region mysqlFunction         start="encode(" end=")" contains=ALL
-syn region mysqlFunction         start="encrypt(" end=")" contains=ALL
-syn region mysqlFunction         start="exp(" end=")" contains=ALL
-syn region mysqlFunction         start="export_set(" end=")" contains=ALL
-syn region mysqlFunction         start="extract(" end=")" contains=ALL
-syn region mysqlFunction         start="field(" end=")" contains=ALL
-syn region mysqlFunction         start="find_in_set(" end=")" contains=ALL
-syn region mysqlFunction         start="floor(" end=")" contains=ALL
-syn region mysqlFunction         start="format(" end=")" contains=ALL
-syn region mysqlFunction         start="from_days(" end=")" contains=ALL
-syn region mysqlFunction         start="from_unixtime(" end=")" contains=ALL
-syn region mysqlFunction         start="get_lock(" end=")" contains=ALL
-syn region mysqlFunction         start="greatest(" end=")" contains=ALL
-syn region mysqlFunction         start="group_unique_users(" end=")" contains=ALL
-syn region mysqlFunction         start="hex(" end=")" contains=ALL
-syn region mysqlFunction         start="inet_aton(" end=")" contains=ALL
-syn region mysqlFunction         start="inet_ntoa(" end=")" contains=ALL
-syn region mysqlFunction         start="instr(" end=")" contains=ALL
-syn region mysqlFunction         start="lcase(" end=")" contains=ALL
-syn region mysqlFunction         start="least(" end=")" contains=ALL
-syn region mysqlFunction         start="length(" end=")" contains=ALL
-syn region mysqlFunction         start="load_file(" end=")" contains=ALL
-syn region mysqlFunction         start="locate(" end=")" contains=ALL
-syn region mysqlFunction         start="log(" end=")" contains=ALL
-syn region mysqlFunction         start="log10(" end=")" contains=ALL
-syn region mysqlFunction         start="lower(" end=")" contains=ALL
-syn region mysqlFunction         start="lpad(" end=")" contains=ALL
-syn region mysqlFunction         start="ltrim(" end=")" contains=ALL
-syn region mysqlFunction         start="make_set(" end=")" contains=ALL
-syn region mysqlFunction         start="master_pos_wait(" end=")" contains=ALL
-syn region mysqlFunction         start="max(" end=")" contains=ALL
-syn region mysqlFunction         start="md5(" end=")" contains=ALL
-syn region mysqlFunction         start="mid(" end=")" contains=ALL
-syn region mysqlFunction         start="min(" end=")" contains=ALL
-syn region mysqlFunction         start="mod(" end=")" contains=ALL
-syn region mysqlFunction         start="monthname(" end=")" contains=ALL
-syn region mysqlFunction         start="now(" end=")" contains=ALL
-syn region mysqlFunction         start="oct(" end=")" contains=ALL
-syn region mysqlFunction         start="octet_length(" end=")" contains=ALL
-syn region mysqlFunction         start="ord(" end=")" contains=ALL
-syn region mysqlFunction         start="period_add(" end=")" contains=ALL
-syn region mysqlFunction         start="period_diff(" end=")" contains=ALL
-syn region mysqlFunction         start="pi(" end=")" contains=ALL
-syn region mysqlFunction         start="position(" end=")" contains=ALL
-syn region mysqlFunction         start="pow(" end=")" contains=ALL
-syn region mysqlFunction         start="power(" end=")" contains=ALL
-syn region mysqlFunction         start="quarter(" end=")" contains=ALL
-syn region mysqlFunction         start="radians(" end=")" contains=ALL
-syn region mysqlFunction         start="rand(" end=")" contains=ALL
-syn region mysqlFunction         start="release_lock(" end=")" contains=ALL
-syn region mysqlFunction         start="repeat(" end=")" contains=ALL
-syn region mysqlFunction         start="reverse(" end=")" contains=ALL
-syn region mysqlFunction         start="round(" end=")" contains=ALL
-syn region mysqlFunction         start="rpad(" end=")" contains=ALL
-syn region mysqlFunction         start="rtrim(" end=")" contains=ALL
-syn region mysqlFunction         start="sec_to_time(" end=")" contains=ALL
-syn region mysqlFunction         start="session_user(" end=")" contains=ALL
-syn region mysqlFunction         start="sign(" end=")" contains=ALL
-syn region mysqlFunction         start="sin(" end=")" contains=ALL
-syn region mysqlFunction         start="soundex(" end=")" contains=ALL
-syn region mysqlFunction         start="space(" end=")" contains=ALL
-syn region mysqlFunction         start="sqrt(" end=")" contains=ALL
-syn region mysqlFunction         start="std(" end=")" contains=ALL
-syn region mysqlFunction         start="stddev(" end=")" contains=ALL
-syn region mysqlFunction         start="strcmp(" end=")" contains=ALL
-syn region mysqlFunction         start="subdate(" end=")" contains=ALL
-syn region mysqlFunction         start="substring(" end=")" contains=ALL
-syn region mysqlFunction         start="substring_index(" end=")" contains=ALL
-syn region mysqlFunction         start="subtime(" end=")" contains=ALL
-syn region mysqlFunction         start="sum(" end=")" contains=ALL
-syn region mysqlFunction         start="sysdate(" end=")" contains=ALL
-syn region mysqlFunction         start="system_user(" end=")" contains=ALL
-syn region mysqlFunction         start="tan(" end=")" contains=ALL
-syn region mysqlFunction         start="time_format(" end=")" contains=ALL
-syn region mysqlFunction         start="time_to_sec(" end=")" contains=ALL
-syn region mysqlFunction         start="to_days(" end=")" contains=ALL
-syn region mysqlFunction         start="trim(" end=")" contains=ALL
-syn region mysqlFunction         start="ucase(" end=")" contains=ALL
-syn region mysqlFunction         start="unique_users(" end=")" contains=ALL
-syn region mysqlFunction         start="unix_timestamp(" end=")" contains=ALL
-syn region mysqlFunction         start="upper(" end=")" contains=ALL
-syn region mysqlFunction         start="user(" end=")" contains=ALL
-syn region mysqlFunction         start="version(" end=")" contains=ALL
-syn region mysqlFunction         start="week(" end=")" contains=ALL
-syn region mysqlFunction         start="weekday(" end=")" contains=ALL
-syn region mysqlFunction         start="yearweek(" end=")" contains=ALL
+syn region mysqlFunction         start="\<abs(" end=")" contains=ALL
+syn region mysqlFunction         start="\<acos(" end=")" contains=ALL
+syn region mysqlFunction         start="\<adddate(" end=")" contains=ALL
+syn region mysqlFunction         start="\<ascii(" end=")" contains=ALL
+syn region mysqlFunction         start="\<asin(" end=")" contains=ALL
+syn region mysqlFunction         start="\<atan(" end=")" contains=ALL
+syn region mysqlFunction         start="\<atan2(" end=")" contains=ALL
+syn region mysqlFunction         start="\<avg(" end=")" contains=ALL
+syn region mysqlFunction         start="\<benchmark(" end=")" contains=ALL
+syn region mysqlFunction         start="\<bin(" end=")" contains=ALL
+syn region mysqlFunction         start="\<bit_and(" end=")" contains=ALL
+syn region mysqlFunction         start="\<bit_count(" end=")" contains=ALL
+syn region mysqlFunction         start="\<bit_or(" end=")" contains=ALL
+syn region mysqlFunction         start="\<ceiling(" end=")" contains=ALL
+syn region mysqlFunction         start="\<character_length(" end=")" contains=ALL
+syn region mysqlFunction         start="\<char_length(" end=")" contains=ALL
+syn region mysqlFunction         start="\<concat(" end=")" contains=ALL
+syn region mysqlFunction         start="\<concat_ws(" end=")" contains=ALL
+syn region mysqlFunction         start="\<connection_id(" end=")" contains=ALL
+syn region mysqlFunction         start="\<conv(" end=")" contains=ALL
+syn region mysqlFunction         start="\<cos(" end=")" contains=ALL
+syn region mysqlFunction         start="\<cot(" end=")" contains=ALL
+syn region mysqlFunction         start="\<count(" end=")" contains=ALL
+syn region mysqlFunction         start="\<curdate(" end=")" contains=ALL
+syn region mysqlFunction         start="\<curtime(" end=")" contains=ALL
+syn region mysqlFunction         start="\<date_add(" end=")" contains=ALL
+syn region mysqlFunction         start="\<date_format(" end=")" contains=ALL
+syn region mysqlFunction         start="\<date_sub(" end=")" contains=ALL
+syn region mysqlFunction         start="\<dayname(" end=")" contains=ALL
+syn region mysqlFunction         start="\<dayofmonth(" end=")" contains=ALL
+syn region mysqlFunction         start="\<dayofweek(" end=")" contains=ALL
+syn region mysqlFunction         start="\<dayofyear(" end=")" contains=ALL
+syn region mysqlFunction         start="\<decode(" end=")" contains=ALL
+syn region mysqlFunction         start="\<degrees(" end=")" contains=ALL
+syn region mysqlFunction         start="\<elt(" end=")" contains=ALL
+syn region mysqlFunction         start="\<encode(" end=")" contains=ALL
+syn region mysqlFunction         start="\<encrypt(" end=")" contains=ALL
+syn region mysqlFunction         start="\<exp(" end=")" contains=ALL
+syn region mysqlFunction         start="\<export_set(" end=")" contains=ALL
+syn region mysqlFunction         start="\<extract(" end=")" contains=ALL
+syn region mysqlFunction         start="\<field(" end=")" contains=ALL
+syn region mysqlFunction         start="\<find_in_set(" end=")" contains=ALL
+syn region mysqlFunction         start="\<floor(" end=")" contains=ALL
+syn region mysqlFunction         start="\<format(" end=")" contains=ALL
+syn region mysqlFunction         start="\<from_days(" end=")" contains=ALL
+syn region mysqlFunction         start="\<from_unixtime(" end=")" contains=ALL
+syn region mysqlFunction         start="\<get_lock(" end=")" contains=ALL
+syn region mysqlFunction         start="\<greatest(" end=")" contains=ALL
+syn region mysqlFunction         start="\<group_unique_users(" end=")" contains=ALL
+syn region mysqlFunction         start="\<hex(" end=")" contains=ALL
+syn region mysqlFunction         start="\<inet_aton(" end=")" contains=ALL
+syn region mysqlFunction         start="\<inet_ntoa(" end=")" contains=ALL
+syn region mysqlFunction         start="\<instr(" end=")" contains=ALL
+syn region mysqlFunction         start="\<lcase(" end=")" contains=ALL
+syn region mysqlFunction         start="\<least(" end=")" contains=ALL
+syn region mysqlFunction         start="\<length(" end=")" contains=ALL
+syn region mysqlFunction         start="\<load_file(" end=")" contains=ALL
+syn region mysqlFunction         start="\<locate(" end=")" contains=ALL
+syn region mysqlFunction         start="\<log(" end=")" contains=ALL
+syn region mysqlFunction         start="\<log10(" end=")" contains=ALL
+syn region mysqlFunction         start="\<lower(" end=")" contains=ALL
+syn region mysqlFunction         start="\<lpad(" end=")" contains=ALL
+syn region mysqlFunction         start="\<ltrim(" end=")" contains=ALL
+syn region mysqlFunction         start="\<make_set(" end=")" contains=ALL
+syn region mysqlFunction         start="\<master_pos_wait(" end=")" contains=ALL
+syn region mysqlFunction         start="\<max(" end=")" contains=ALL
+syn region mysqlFunction         start="\<md5(" end=")" contains=ALL
+syn region mysqlFunction         start="\<mid(" end=")" contains=ALL
+syn region mysqlFunction         start="\<min(" end=")" contains=ALL
+syn region mysqlFunction         start="\<mod(" end=")" contains=ALL
+syn region mysqlFunction         start="\<monthname(" end=")" contains=ALL
+syn region mysqlFunction         start="\<now(" end=")" contains=ALL
+syn region mysqlFunction         start="\<oct(" end=")" contains=ALL
+syn region mysqlFunction         start="\<octet_length(" end=")" contains=ALL
+syn region mysqlFunction         start="\<ord(" end=")" contains=ALL
+syn region mysqlFunction         start="\<period_add(" end=")" contains=ALL
+syn region mysqlFunction         start="\<period_diff(" end=")" contains=ALL
+syn region mysqlFunction         start="\<pi(" end=")" contains=ALL
+syn region mysqlFunction         start="\<position(" end=")" contains=ALL
+syn region mysqlFunction         start="\<pow(" end=")" contains=ALL
+syn region mysqlFunction         start="\<power(" end=")" contains=ALL
+syn region mysqlFunction         start="\<quarter(" end=")" contains=ALL
+syn region mysqlFunction         start="\<radians(" end=")" contains=ALL
+syn region mysqlFunction         start="\<rand(" end=")" contains=ALL
+syn region mysqlFunction         start="\<release_lock(" end=")" contains=ALL
+syn region mysqlFunction         start="\<repeat(" end=")" contains=ALL
+syn region mysqlFunction         start="\<reverse(" end=")" contains=ALL
+syn region mysqlFunction         start="\<round(" end=")" contains=ALL
+syn region mysqlFunction         start="\<rpad(" end=")" contains=ALL
+syn region mysqlFunction         start="\<rtrim(" end=")" contains=ALL
+syn region mysqlFunction         start="\<sec_to_time(" end=")" contains=ALL
+syn region mysqlFunction         start="\<session_user(" end=")" contains=ALL
+syn region mysqlFunction         start="\<sign(" end=")" contains=ALL
+syn region mysqlFunction         start="\<sin(" end=")" contains=ALL
+syn region mysqlFunction         start="\<soundex(" end=")" contains=ALL
+syn region mysqlFunction         start="\<space(" end=")" contains=ALL
+syn region mysqlFunction         start="\<sqrt(" end=")" contains=ALL
+syn region mysqlFunction         start="\<std(" end=")" contains=ALL
+syn region mysqlFunction         start="\<stddev(" end=")" contains=ALL
+syn region mysqlFunction         start="\<strcmp(" end=")" contains=ALL
+syn region mysqlFunction         start="\<subdate(" end=")" contains=ALL
+syn region mysqlFunction         start="\<substring(" end=")" contains=ALL
+syn region mysqlFunction         start="\<substring_index(" end=")" contains=ALL
+syn region mysqlFunction         start="\<subtime(" end=")" contains=ALL
+syn region mysqlFunction         start="\<sum(" end=")" contains=ALL
+syn region mysqlFunction         start="\<sysdate(" end=")" contains=ALL
+syn region mysqlFunction         start="\<system_user(" end=")" contains=ALL
+syn region mysqlFunction         start="\<tan(" end=")" contains=ALL
+syn region mysqlFunction         start="\<time_format(" end=")" contains=ALL
+syn region mysqlFunction         start="\<time_to_sec(" end=")" contains=ALL
+syn region mysqlFunction         start="\<to_days(" end=")" contains=ALL
+syn region mysqlFunction         start="\<trim(" end=")" contains=ALL
+syn region mysqlFunction         start="\<ucase(" end=")" contains=ALL
+syn region mysqlFunction         start="\<unique_users(" end=")" contains=ALL
+syn region mysqlFunction         start="\<unix_timestamp(" end=")" contains=ALL
+syn region mysqlFunction         start="\<upper(" end=")" contains=ALL
+syn region mysqlFunction         start="\<user(" end=")" contains=ALL
+syn region mysqlFunction         start="\<version(" end=")" contains=ALL
+syn region mysqlFunction         start="\<week(" end=")" contains=ALL
+syn region mysqlFunction         start="\<weekday(" end=")" contains=ALL
+syn region mysqlFunction         start="\<yearweek(" end=")" contains=ALL
 
 " Define the default highlighting.
 " Only when an item doesn't have highlighting yet
 
-hi def link mysqlKeyword            Statement
+hi def link mysqlKeyword            Keyword
 hi def link mysqlSpecial            Special
 hi def link mysqlString             String
 hi def link mysqlNumber             Number
 hi def link mysqlVariable           Identifier
 hi def link mysqlComment            Comment
 hi def link mysqlType               Type
-hi def link mysqlOperator           Statement
-hi def link mysqlFlow               Statement
+hi def link mysqlOperator           Operator
+hi def link mysqlOperatorFunction   Function
+hi def link mysqlFlowFunction       Function
+hi def link mysqlFlowLabel          Label
+hi def link mysqlWindowFunction     Function
+hi def link mysqlWindowKeyword      Keyword
 hi def link mysqlFunction           Function
 
 


### PR DESCRIPTION
Problem:

- `syn region ...`s in syntax/mysql.vim match function names inaccurately.
- no syntax rules for mysql window function.
- coarse highlight definition in syntax/mysql.vim.

Solution:

- add `\<...\>` to match the function name accurately.
- add syntax rules for mysql window function.
- enhance the highlight definition.