### PR TITLE
Update/delete out-of-date comments, etc. in Makefiles.

### DIFF
--- a/runtime/doc/Makefile
+++ b/runtime/doc/Makefile
@@ -6,7 +6,6 @@
 
 AWK = awk
 
-# Set to $(VIMTARGET) when executed from src/Makefile.
 VIMPROG = ../../src/vim
 
 # include the config.mk from the source directory.  It's only needed to set
@@ -23,7 +22,7 @@ include Make_all.mak
 all: tags vim.man evim.man vimdiff.man vimtutor.man xxd.man $(CONVERTED)
 
 # Use Vim to generate the tags file.  Can only be used when Vim has been
-# compiled and installed.  Supports multiple languages.
+# compiled.  Supports multiple languages.
 vimtags: $(DOCS)
 	@$(VIMPROG) --clean -esX -V1 -u doctags.vim
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -2354,10 +2354,8 @@ installrtbase: $(HELPSOURCE)/vim.1 $(DEST_VIM) $(VIMTARGET) $(DEST_RT) \
 	cd $(HELPSOURCE); if test -z "$(CROSS_COMPILING)" -a -f tags; then \
 		mv -f tags tags.dist; fi
 	@echo generating help tags
-	# We can assume Vim was build, but it may not have been installed,
-	# thus use the executable in the current directory.
-	-@BUILD_DIR="`pwd`"; cd $(HELPSOURCE); if test -z "$(CROSS_COMPILING)"; then \
-		$(MAKE) VIMPROG="$$BUILD_DIR/$(VIMTARGET)" vimtags; fi
+	-@cd $(HELPSOURCE); if test -z "$(CROSS_COMPILING)"; then \
+		$(MAKE) vimtags; fi
 	cd $(HELPSOURCE); \
 		files=`ls *.txt tags`; \
 		files="$$files `ls *.??x tags-?? 2>/dev/null || true`"; \


### PR DESCRIPTION
related: commit b81109192f.


Here are the changes and the reasons for them:

### runtime/doc/Makefile

- Delete the comment preceding the assignment to VIMPROG. Since b81109192f there's no need for VIMPROG to be set to something else when this is executed from src/Makefile. (The comment was wrong anyway; VIMPROG was being set to "$$BUILD_DIR/$(VIMTARGET)".)

```
    # Set to $(VIMTARGET) when executed from src/Makefile.
     VIMPROG = ../../src/vim
```

- Delete "`and installed`" in the following comment; The vimtags rule doesn't require that Vim has been installed.

```
    # Use Vim to generate the tags file.  Can only be used when Vim has been
    # compiled and installed.  Supports multiple languages.
    vimtags: $(DOCS)
```

### installrtbase rule (in src/Makefile)

- With commit b81109192f there is no longer a need to set VIMPROG here:

```
       -@BUILD_DIR="`pwd`"; cd $(HELPSOURCE); if test -z "$(CROSS_COMPILING)"; then \
               $(MAKE) VIMPROG="$$BUILD_DIR/$(VIMTARGET)" vimtags; fi
```

The new code below will use the same vim executable as the old code:
```
       -@cd $(HELPSOURCE); if test -z "$(CROSS_COMPILING)"; then \
               $(MAKE) vimtags; fi
```

- Delete the following comment which was related to setting VIMPROG as it no longer has any value:
```
       # We can assume Vim was build, but it may not have been installed,
       # thus use the executable in the current directory.
```
Note: this comment used to be (unnecessarily) echoed to the terminal (because it was indented) when making installrtbase.