### PR TITLE
runtime(make): Fix highlight of Microsoft Makefile

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -532,6 +532,27 @@ export def FTm()
   endif
 enddef
 
+export def FTmake()
+  # Check if it is a Microsoft Makefile
+  if exists("b:make_microsoft")
+    unlet b:make_microsoft
+  endif
+  var n = 1
+  while n < 1000 && n <= line('$')
+    var line = getline(n)
+    if line =~? '^\s*!\s*\(ifn\=\(def\)\=\|include\|message\|error\)\>'
+      b:make_microsoft = 1
+      break
+    elseif line =~ '^ *ifn\=\(eq\|def\)\>' || line =~ '^ *[-s]\=include\s'
+      break
+    elseif line =~ '^ *\w\+\s*[!?:+]='
+      break
+    endif
+    n += 1
+  endwhile
+  setf make
+enddef
+
 export def FTmms()
   var n = 1
   while n < 20

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -2278,7 +2278,7 @@ By default mail.vim synchronises syntax to 100 lines before the first
 displayed line.  If you have a slow machine, and generally deal with emails
 with short headers, you can change this to a smaller value: >
 
-    :let mail_minlines = 30
+	:let mail_minlines = 30
 
 
 MAKE						*make.vim* *ft-make-syntax*
@@ -2288,6 +2288,16 @@ errors.  However, this may be too much coloring for you.  You can turn this
 feature off by using: >
 
 	:let make_no_commands = 1
+
+Comments are also highlighted by default.  You can turn this off by using: >
+
+	:let make_no_comments = 1
+
+Microsoft Makefile handles variable expansion and comments differently
+(backslashes are not used for escape).  If you see any wrong highlights
+because of this, you can try this: >
+
+	:let make_microsoft = 1
 
 
 MAPLE						*maple.vim* *ft-maple-syntax*

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1387,7 +1387,7 @@ au BufNewFile,BufRead */etc/mail/aliases,*/etc/aliases	setf mailaliases
 au BufNewFile,BufRead .mailcap,mailcap		setf mailcap
 
 " Makefile
-au BufNewFile,BufRead *[mM]akefile,*.mk,*.mak	setf make
+au BufNewFile,BufRead *[mM]akefile,*.mk,*.mak	call dist#ft#FTmake()
 au BufNewFile,BufRead Kbuild			setf make
 
 " MakeIndex

--- a/runtime/syntax/make.vim
+++ b/runtime/syntax/make.vim
@@ -28,8 +28,13 @@ syn match makePreCondit "^!\s*\(cmdswitches\|error\|message\|include\|if\|ifdef\
 syn case match
 
 " identifiers
-syn region makeIdent	start="\$(" skip="\\)\|\\\\" end=")" contains=makeStatement,makeIdent
-syn region makeIdent	start="\${" skip="\\}\|\\\\" end="}" contains=makeStatement,makeIdent
+if exists("make_microsoft")
+  syn region makeIdent	start="\$(" end=")" contains=makeStatement,makeIdent
+  syn region makeIdent	start="\${" end="}" contains=makeStatement,makeIdent
+else
+  syn region makeIdent	start="\$(" skip="\\)\|\\\\" end=")" contains=makeStatement,makeIdent
+  syn region makeIdent	start="\${" skip="\\}\|\\\\" end="}" contains=makeStatement,makeIdent
+endif
 syn match makeIdent	"\$\$\w*"
 syn match makeIdent	"\$[^({]"
 syn match makeIdent	"^ *[^:#= \t]*\s*[:+?!*]="me=e-2
@@ -78,11 +83,13 @@ syn match makeOverride	"^ *override\>"
 syn match makeStatement contained "(\(abspath\|addprefix\|addsuffix\|and\|basename\|call\|dir\|error\|eval\|file\|filter-out\|filter\|findstring\|firstword\|flavor\|foreach\|guile\|if\|info\|join\|lastword\|notdir\|or\|origin\|patsubst\|realpath\|shell\|sort\|strip\|subst\|suffix\|value\|warning\|wildcard\|word\|wordlist\|words\)\>"ms=s+1
 
 " Comment
-if exists("make_microsoft")
-   syn match  makeComment "#.*" contains=@Spell,makeTodo
-elseif !exists("make_no_comments")
-   syn region  makeComment	start="#" end="^$" end="[^\\]$" keepend contains=@Spell,makeTodo
-   syn match   makeComment	"#$" contains=@Spell
+if !exists("make_no_comments")
+  if exists("make_microsoft")
+    syn match   makeComment	"#.*" contains=@Spell,makeTodo
+  else
+    syn region  makeComment	start="#" end="^$" end="[^\\]$" keepend contains=@Spell,makeTodo
+    syn match   makeComment	"#$" contains=@Spell
+  endif
 endif
 syn keyword makeTodo TODO FIXME XXX contained
 

--- a/runtime/syntax/make.vim
+++ b/runtime/syntax/make.vim
@@ -28,7 +28,7 @@ syn match makePreCondit "^!\s*\(cmdswitches\|error\|message\|include\|if\|ifdef\
 syn case match
 
 " identifiers
-if exists("make_microsoft")
+if exists("b:make_microsoft") || exists("make_microsoft")
   syn region makeIdent	start="\$(" end=")" contains=makeStatement,makeIdent
   syn region makeIdent	start="\${" end="}" contains=makeStatement,makeIdent
 else
@@ -84,7 +84,7 @@ syn match makeStatement contained "(\(abspath\|addprefix\|addsuffix\|and\|basena
 
 " Comment
 if !exists("make_no_comments")
-  if exists("make_microsoft")
+  if exists("b:make_microsoft") || exists("make_microsoft")
     syn match   makeComment	"#.*" contains=@Spell,makeTodo
   else
     syn region  makeComment	start="#" end="^$" end="[^\\]$" keepend contains=@Spell,makeTodo


### PR DESCRIPTION
Highlighting of variable expansion in Microsoft Makefile can be broken. E.g.:
https://github.com/vim/vim/blob/2979cfc2627d76a9c09cad46a1647dcd4aa73f5f/src/Make_mvc.mak#L1331

Don't use backslash as escape characters if `make_microsoft` is set. Also fix that `make_no_comments` was not considered if `make_microsoft` was set.

Add description for `make_microsoft` and `make_no_comments` in the document.