### PR TITLE
Cursor moves beyond first line of folded end of buffer

### DIFF
--- a/src/edit.c
+++ b/src/edit.c
@@ -2849,7 +2849,6 @@ cursor_down_inner(win_T *wp, long n)
 	// count each sequence of folded lines as one logical line
 	while (n--)
 	{
-	    // Move to last line of fold, will fail if it's the end-of-file.
 	    if (hasFoldingWin(wp, lnum, NULL, &last, TRUE, NULL))
 		lnum = last + 1;
 	    else
@@ -2877,8 +2876,11 @@ cursor_down(
 {
     linenr_T	lnum = curwin->w_cursor.lnum;
     linenr_T	line_count = curwin->w_buffer->b_ml.ml_line_count;
-    // This fails if the cursor is already in the last line or would move
-    // beyond the last line and '-' is in 'cpoptions'
+    // This fails if the cursor is already in the last (folded) line, or would
+    // move beyond the last line and '-' is in 'cpoptions'.
+#ifdef FEAT_FOLDING
+    hasFoldingWin(curwin, lnum, NULL, &lnum, TRUE, NULL);
+#endif
     if (n > 0
 	    && (lnum >= line_count
 		|| (lnum + n > line_count

--- a/src/testdir/test_fold.vim
+++ b/src/testdir/test_fold.vim
@@ -1914,4 +1914,18 @@ func Test_foldexpr_end_fold()
   bwipe!
 endfunc
 
+" Test moving cursor down to or beyond start of folded end of buffer.
+func Test_cursor_down_fold_eob()
+  call setline(1, range(1, 4))
+  norm Gzf2kj
+  call assert_equal(2, line('.'))
+  norm zojzc
+  call assert_equal(3, line('.'))
+  norm j
+  call assert_equal(3, line('.'))
+  norm k2j
+  call assert_equal(4, line('.'))
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  Cursor moves beyond start of a folded range at the end of a buffer. 
Solution: Move cursor to start of fold when going beyond end of buffer.
          Check that cursor moved to detect FAIL in outer cursor function.