### PR TITLE
win32,mingw: Use --gc-sections to reduce the size of executables

### DIFF
--- a/src/GvimExt/Make_ming.mak
+++ b/src/GvimExt/Make_ming.mak
@@ -29,7 +29,7 @@ LDFLAGS += -static-libgcc -static-libstdc++
 endif
 
 ifeq ($(CROSS),yes)
-DEL = rm
+DEL = rm -f
 ifeq ($(MINGWOLD),yes)
 CXXFLAGS := -O2 -fvtable-thunks
 else
@@ -38,7 +38,7 @@ endif
 else
 CXXFLAGS := -O2
 ifneq (sh.exe, $(SHELL))
-DEL = rm
+DEL = rm -f
 else
 DEL = del
 endif

--- a/src/Make_cyg_ming.mak
+++ b/src/Make_cyg_ming.mak
@@ -186,7 +186,7 @@ ifeq ($(CROSS),yes)
  ifndef CROSS_COMPILE
 CROSS_COMPILE = i586-pc-mingw32msvc-
  endif
-DEL = rm
+DEL = rm -f
 MKDIR = mkdir -p
 DIRSLASH = /
 else
@@ -214,7 +214,7 @@ CROSS_COMPILE =
 # In this case, unix-like commands can be used.
 #
  ifneq (sh.exe, $(SHELL))
-DEL = rm
+DEL = rm -f
 MKDIR = mkdir -p
 DIRSLASH = /
  else

--- a/src/Make_cyg_ming.mak
+++ b/src/Make_cyg_ming.mak
@@ -124,12 +124,12 @@ ifndef CTAGS
 CTAGS = ctags -I INIT+,INIT2+,INIT3+,INIT4+,INIT5+ --fields=+S
 endif
 
+
 # Link against the shared version of libstdc++ by default.  Set
 # STATIC_STDCPLUS to "yes" to link against static version instead.
 ifndef STATIC_STDCPLUS
 STATIC_STDCPLUS=no
 endif
-
 
 # Link against the shared version of libwinpthread by default.  Set
 # STATIC_WINPTHREAD to "yes" to link against static version instead.
@@ -139,6 +139,13 @@ endif
 # If you use TDM-GCC(-64), change HAS_GCC_EH to "no".
 # This is used when STATIC_STDCPLUS=yes.
 HAS_GCC_EH=yes
+
+# Reduce the size of the executables by using the --gc-sections linker
+# option.  Set USE_GC_SECTIONS to "no" if you see any issues with this.
+ifndef USE_GC_SECTIONS
+USE_GC_SECTIONS=yes
+endif
+
 
 # If the user doesn't want gettext, undefine it.
 ifeq (no, $(GETTEXT))
@@ -1091,6 +1098,16 @@ ifeq (yes, $(STATIC_WINPTHREAD))
 LIB += -lgcc_eh
  endif
 LIB += -Wl,-Bstatic -lwinpthread -Wl,-Bdynamic
+endif
+
+# To reduce the file size
+ifeq (yes, $(USE_GC_SECTIONS))
+CFLAGS += -ffunction-sections -fno-asynchronous-unwind-tables
+CXXFLAGS += -fasynchronous-unwind-tables
+LFLAGS += -Wl,--gc-sections
+ ifeq (yes, $(VIMDLL))
+EXELFLAGS += -Wl,--gc-sections
+ endif
 endif
 
 ifeq (yes, $(MAP))

--- a/src/xxd/Make_ming.mak
+++ b/src/xxd/Make_ming.mak
@@ -16,7 +16,7 @@ CC = gcc
 CFLAGS = -O2 -Wall -DWIN32 $(DEFINES)
 
 ifneq (sh.exe, $(SHELL))
-DEL = rm
+DEL = rm -f
 else
 DEL = del
 endif


### PR DESCRIPTION
Use the `--gc-sections` linker option and the `-ffunction-sections` compiler option to reduce the size of the executable files.  To make these work, the `-fno-asynchronous-unwind-tables` compiler option is also needed.

This is enabled by default and can be disabled by `USE_GC_SECTIONS=no`.

Note: A similar feature has been already used in MSVC. (The `/OPT` linker option.)