### PR TITLE
win32: Rework win32 startup code

### DIFF
--- a/src/Make_mvc.mak
+++ b/src/Make_mvc.mak
@@ -1302,11 +1302,11 @@ $(NETBEANS_OBJ) $(CHANNEL_OBJ) $(XPM_OBJ) $(OUTDIR)\version.obj $(LINKARGS2)
 
 $(GVIM).exe: $(OUTDIR) $(EXEOBJG) $(VIMDLLBASE).dll
 	$(LINK) $(LINKARGS1) /subsystem:$(SUBSYSTEM) -out:$(GVIM).exe \
-		$(EXEOBJG) $(VIMDLLBASE).lib $(LIBC)
+		$(EXEOBJG) $(VIMDLLBASE).lib
 
 $(VIM).exe: $(OUTDIR) $(EXEOBJC) $(VIMDLLBASE).dll
 	$(LINK) $(LINKARGS1) /subsystem:$(SUBSYSTEM_CON) -out:$(VIM).exe \
-		$(EXEOBJC) $(VIMDLLBASE).lib $(LIBC)
+		$(EXEOBJC) $(VIMDLLBASE).lib
 
 !else
 
@@ -1715,10 +1715,10 @@ $(OUTDIR)/os_w32dll.obj:	$(OUTDIR) os_w32dll.c
 $(OUTDIR)/os_w32exe.obj:	$(OUTDIR) os_w32exe.c  $(INCL)
 
 $(OUTDIR)/os_w32exec.obj:	$(OUTDIR) os_w32exe.c  $(INCL)
-	$(CC) $(CFLAGS:-DFEAT_GUI_MSWIN=) /Fo$@ os_w32exe.c
+	$(CC) $(CFLAGS:-DFEAT_GUI_MSWIN=) /DUSE_OWNSTARTUP /GS- /Fo$@ os_w32exe.c
 
 $(OUTDIR)/os_w32exeg.obj:	$(OUTDIR) os_w32exe.c  $(INCL)
-	$(CC) $(CFLAGS) /Fo$@ os_w32exe.c
+	$(CC) $(CFLAGS) /DUSE_OWNSTARTUP /GS- /Fo$@ os_w32exe.c
 
 $(OUTDIR)/pathdef.obj:	$(OUTDIR) $(PATHDEF_SRC) $(INCL)
 	$(CC) $(CFLAGS_OUTDIR) $(PATHDEF_SRC)

--- a/src/os_w32dll.c
+++ b/src/os_w32dll.c
@@ -7,7 +7,7 @@
  * See README.txt for an overview of the Vim source code.
  */
 /*
- * Windows GUI: main program (DLL) entry point:
+ * Windows GUI/Console: main program (DLL) entry point:
  *
  * Ron Aaron <ronaharon@yahoo.com> wrote this and the DLL support code.
  * Adapted by Ken Takata.

--- a/src/os_w32exe.c
+++ b/src/os_w32exe.c
@@ -8,10 +8,10 @@
  * See README.txt for an overview of the Vim source code.
  */
 /*
- * Windows GUI: main program (EXE) entry point:
+ * Windows GUI/Console: main program (EXE) entry point:
  *
- * Ron Aaron <ronaharon@yahoo.com> wrote this and the (now deleted) DLL support
- * code.
+ * Ron Aaron <ronaharon@yahoo.com> wrote this and the DLL support code.
+ * Adapted by Ken Takata.
  */
 #include "vim.h"
 
@@ -20,32 +20,53 @@
 __declspec(dllimport)
 #endif
 int VimMain(int argc, char **argv);
-#ifndef VIMDLL
+
+#ifdef VIMDLL
+# define SaveInst(hInst)    // Do nothing
+#else
 void SaveInst(HINSTANCE hInst);
 #endif
 
-#ifndef PROTO
-# ifdef FEAT_GUI
+#ifdef FEAT_GUI
     int WINAPI
 wWinMain(
     HINSTANCE	hInstance,
     HINSTANCE	hPrevInst UNUSED,
     LPWSTR	lpszCmdLine UNUSED,
     int		nCmdShow UNUSED)
-# else
+{
+    SaveInst(hInstance);
+    return VimMain(0, NULL);
+}
+#else
     int
 wmain(int argc UNUSED, wchar_t **argv UNUSED)
-# endif
 {
-# ifndef VIMDLL
-#  ifdef FEAT_GUI
-    SaveInst(hInstance);
-#  else
     SaveInst(GetModuleHandleW(NULL));
-#  endif
-# endif
-    VimMain(0, NULL);
-
-    return 0;
+    return VimMain(0, NULL);
 }
 #endif
+
+#ifdef USE_OWNSTARTUP
+// Use our own entry point and don't use the default CRT startup code to
+// reduce the size of (g)vim.exe.  This works only when VIMDLL is defined.
+//
+// For MSVC, the /GS- compiler option is needed to avoid the undefined symbol
+// error.  (It disables the security check. However, it affects only this
+// function and doesn't have any effect on Vim itself.)
+// For MinGW, the -nostdlib compiler option and the --entry linker option are
+// needed.
+# ifdef FEAT_GUI
+    void WINAPI
+wWinMainCRTStartup(void)
+{
+    VimMain(0, NULL);
+}
+# else
+    void
+wmainCRTStartup(void)
+{
+    VimMain(0, NULL);
+}
+# endif
+#endif	// USE_OWNSTARTUP


### PR DESCRIPTION
* Revise the code and reduce #ifdefs.
* For VIMDLL, stop using the default CRT startup code to reduce the file size.
  The file size becomes ~130 KB -> ~34 KB on MSVC.
* Update comments. Make them consistent between os_w32dll.c and os_w32exe.c.