### PR TITLE
win32,if_mzsch: Fix if_mzsch with VIMDLL

### DIFF
--- a/src/Make_cyg_ming.mak
+++ b/src/Make_cyg_ming.mak
@@ -1000,12 +1000,15 @@ VIMDLLBASE := vim32$(DEBUG_SUFFIX)
  endif
 TARGET = $(VIMDLLBASE).dll
 LFLAGS += -shared
-EXELFLAGS += -municode -nostdlib
+EXELFLAGS += -municode
  ifneq ($(DEBUG),yes)
 EXELFLAGS += -s
  endif
  ifeq ($(COVERAGE),yes)
 EXELFLAGS += --coverage
+ else
+EXELFLAGS += -nostdlib
+EXECFLAGS = -DUSE_OWNSTARTUP
  endif
 DEFINES += $(DEF_GUI) -DVIMDLL
 OBJ += $(GUIOBJ) $(CUIOBJ)
@@ -1137,12 +1140,14 @@ $(EXEOBJG): | $(OUTDIR)
 $(EXEOBJC): | $(OUTDIR)
 
 ifeq ($(VIMDLL),yes)
- ifeq ($(ARCH),x86-64)
+ ifneq ($(COVERAGE),yes)
+  ifeq ($(ARCH),x86-64)
 EXEENTRYC = -Wl,--entry=wmainCRTStartup
 EXEENTRYG = -Wl,--entry=wWinMainCRTStartup
- else ifeq ($(ARCH),i686)
+  else ifeq ($(ARCH),i686)
 EXEENTRYC = -Wl,--entry=_wmainCRTStartup
 EXEENTRYG = -Wl,--entry=_wWinMainCRTStartup@0
+  endif
  endif
 
 $(TARGET): $(OBJ)
@@ -1320,6 +1325,9 @@ $(OUTDIR)/gui_w32.o:	gui_w32.c $(INCL) $(GUI_INCL) version.h
 $(OUTDIR)/if_cscope.o:	if_cscope.c $(INCL)
 	$(CC) -c $(CFLAGS) if_cscope.c -o $@
 
+$(OUTDIR)/if_lua.o:	if_lua.c $(INCL)
+	$(CC) -c $(CFLAGS:-fno-asynchronous-unwind-tables=) if_lua.c -o $@
+
 $(OUTDIR)/if_mzsch.o:	if_mzsch.c $(INCL) $(MZSCHEME_INCL) $(MZ_EXTRA_DEP)
 	$(CC) -c $(CFLAGS) if_mzsch.c -o $@
 
@@ -1353,10 +1361,10 @@ $(OUTDIR)/netbeans.o:	netbeans.c $(INCL) $(NBDEBUG_INCL) $(NBDEBUG_SRC)
 	$(CC) -c $(CFLAGS) netbeans.c -o $@
 
 $(OUTDIR)/os_w32exec.o:	os_w32exe.c $(INCL)
-	$(CC) -c $(CFLAGS) -UFEAT_GUI_MSWIN -DUSE_OWNSTARTUP os_w32exe.c -o $@
+	$(CC) -c $(CFLAGS) -UFEAT_GUI_MSWIN $(EXECFLAGS) os_w32exe.c -o $@
 
 $(OUTDIR)/os_w32exeg.o:	os_w32exe.c $(INCL)
-	$(CC) -c $(CFLAGS) -DUSE_OWNSTARTUP os_w32exe.c -o $@
+	$(CC) -c $(CFLAGS) $(EXECFLAGS) os_w32exe.c -o $@
 
 $(OUTDIR)/os_win32.o:	os_win32.c $(INCL) $(MZSCHEME_INCL)
 	$(CC) -c $(CFLAGS) os_win32.c -o $@

--- a/src/Make_cyg_ming.mak
+++ b/src/Make_cyg_ming.mak
@@ -1188,10 +1188,13 @@ notags:
 
 clean:
 	-$(DEL) $(OUTDIR)$(DIRSLASH)*.o
+	-$(DEL) $(OUTDIR)$(DIRSLASH)*.gcno
+	-$(DEL) $(OUTDIR)$(DIRSLASH)*.gcda
 	-$(DEL) $(OUTDIR)$(DIRSLASH)*.res
 	-$(DEL) $(OUTDIR)$(DIRSLASH)pathdef.c
 	-rmdir $(OUTDIR)
 	-$(DEL) $(MAIN_TARGET) vimrun.exe install.exe uninstall.exe
+	-$(DEL) *.gcno *.gcda
 	-$(DEL) *.map
 ifdef PERL
 	-$(DEL) if_perl.c

--- a/src/Make_cyg_ming.mak
+++ b/src/Make_cyg_ming.mak
@@ -1006,7 +1006,7 @@ EXELFLAGS += -s
  endif
  ifeq ($(COVERAGE),yes)
 EXELFLAGS += --coverage
- else
+ else ifndef MZSCHEME
 EXELFLAGS += -nostdlib
 EXECFLAGS = -DUSE_OWNSTARTUP
  endif
@@ -1141,12 +1141,14 @@ $(EXEOBJC): | $(OUTDIR)
 
 ifeq ($(VIMDLL),yes)
  ifneq ($(COVERAGE),yes)
-  ifeq ($(ARCH),x86-64)
+  ifndef MZSCHEME
+   ifeq ($(ARCH),x86-64)
 EXEENTRYC = -Wl,--entry=wmainCRTStartup
 EXEENTRYG = -Wl,--entry=wWinMainCRTStartup
-  else ifeq ($(ARCH),i686)
+   else ifeq ($(ARCH),i686)
 EXEENTRYC = -Wl,--entry=_wmainCRTStartup
 EXEENTRYG = -Wl,--entry=_wWinMainCRTStartup@0
+   endif
   endif
  endif
 

--- a/src/Make_mvc.mak
+++ b/src/Make_mvc.mak
@@ -801,6 +801,13 @@ OBJ = $(OBJ) $(OUTDIR)\os_w32dll.obj $(OUTDIR)\vimd.res
 EXEOBJC = $(OUTDIR)\os_w32exec.obj $(OUTDIR)\vimc.res
 EXEOBJG = $(OUTDIR)\os_w32exeg.obj $(OUTDIR)\vimg.res
 CFLAGS = $(CFLAGS) -DVIMDLL
+! ifdef MZSCHEME
+EXECFLAGS =
+EXELIBC = $(LIBC)
+! else
+EXECFLAGS = -DUSE_OWNSTARTUP /GS-
+EXELIBC =
+! endif
 !else
 OBJ = $(OBJ) $(OUTDIR)\os_w32exe.obj $(OUTDIR)\vim.res
 !endif
@@ -1302,11 +1309,11 @@ $(NETBEANS_OBJ) $(CHANNEL_OBJ) $(XPM_OBJ) $(OUTDIR)\version.obj $(LINKARGS2)
 
 $(GVIM).exe: $(OUTDIR) $(EXEOBJG) $(VIMDLLBASE).dll
 	$(LINK) $(LINKARGS1) /subsystem:$(SUBSYSTEM) -out:$(GVIM).exe \
-		$(EXEOBJG) $(VIMDLLBASE).lib
+		$(EXEOBJG) $(VIMDLLBASE).lib $(EXELIBC)
 
 $(VIM).exe: $(OUTDIR) $(EXEOBJC) $(VIMDLLBASE).dll
 	$(LINK) $(LINKARGS1) /subsystem:$(SUBSYSTEM_CON) -out:$(VIM).exe \
-		$(EXEOBJC) $(VIMDLLBASE).lib
+		$(EXEOBJC) $(VIMDLLBASE).lib $(EXELIBC)
 
 !else
 
@@ -1380,12 +1387,16 @@ clean: testclean
 	- if exist $(OUTDIR)/nul $(DEL_TREE) $(OUTDIR)
 	- if exist *.obj del *.obj
 	- if exist $(VIM).exe del $(VIM).exe
+	- if exist $(VIM).exp del $(VIM).exp
+	- if exist $(VIM).lib del $(VIM).lib
 	- if exist $(VIM).ilk del $(VIM).ilk
 	- if exist $(VIM).pdb del $(VIM).pdb
 	- if exist $(VIM).map del $(VIM).map
 	- if exist $(VIM).ncb del $(VIM).ncb
 !if "$(VIMDLL)" == "yes"
 	- if exist $(GVIM).exe del $(GVIM).exe
+	- if exist $(GVIM).exp del $(GVIM).exp
+	- if exist $(GVIM).lib del $(GVIM).lib
 	- if exist $(GVIM).map del $(GVIM).map
 	- if exist $(VIMDLLBASE).dll del $(VIMDLLBASE).dll
 	- if exist $(VIMDLLBASE).ilk del $(VIMDLLBASE).ilk
@@ -1715,10 +1726,10 @@ $(OUTDIR)/os_w32dll.obj:	$(OUTDIR) os_w32dll.c
 $(OUTDIR)/os_w32exe.obj:	$(OUTDIR) os_w32exe.c  $(INCL)
 
 $(OUTDIR)/os_w32exec.obj:	$(OUTDIR) os_w32exe.c  $(INCL)
-	$(CC) $(CFLAGS:-DFEAT_GUI_MSWIN=) /DUSE_OWNSTARTUP /GS- /Fo$@ os_w32exe.c
+	$(CC) $(CFLAGS:-DFEAT_GUI_MSWIN=) $(EXECFLAGS) /Fo$@ os_w32exe.c
 
 $(OUTDIR)/os_w32exeg.obj:	$(OUTDIR) os_w32exe.c  $(INCL)
-	$(CC) $(CFLAGS) /DUSE_OWNSTARTUP /GS- /Fo$@ os_w32exe.c
+	$(CC) $(CFLAGS) $(EXECFLAGS) /Fo$@ os_w32exe.c
 
 $(OUTDIR)/pathdef.obj:	$(OUTDIR) $(PATHDEF_SRC) $(INCL)
 	$(CC) $(CFLAGS_OUTDIR) $(PATHDEF_SRC)

--- a/src/os_w32exe.c
+++ b/src/os_w32exe.c
@@ -70,3 +70,24 @@ wmainCRTStartup(void)
 }
 # endif
 #endif	// USE_OWNSTARTUP
+
+
+#if defined(VIMDLL) && defined(FEAT_MZSCHEME)
+
+# if defined(_MSC_VER)
+static __declspec(thread) void *tls_space;
+extern intptr_t _tls_index;
+# elif defined(__MINGW32__)
+static __thread void *tls_space;
+extern intptr_t _tls_index;
+# endif
+
+// Get TLS information that is needed for if_mzsch.
+    __declspec(dllexport) void
+get_tls_info(void ***ptls_space, intptr_t *ptls_index)
+{
+    *ptls_space = &tls_space;
+    *ptls_index = _tls_index;
+    return;
+}
+#endif


### PR DESCRIPTION
`scheme_register_tls_space()` doesn't support a thread-local variable in a DLL:
https://docs.racket-lang.org/inside/im_memoryalloc.html#%28cpp._scheme_register_tls_space%29

Define it inside (g)vim.exe and refer to it from the DLL.

This should be applied after #15361.