### PR TITLE
Add filetype support for SuperHTML and Ziggy

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -421,7 +421,6 @@ export def FThtml()
       setf htmlangular
       return
     endif
-
     # Check for XHTML
     if getline(n) =~ '\<DTD\s\+XHTML\s'
       setf xhtml
@@ -431,6 +430,11 @@ export def FThtml()
     if getline(n) =~ '{%\s*\(autoescape\|block\|comment\|csrf_token\|cycle\|debug\|extends\|filter\|firstof\|for\|if\|ifchanged\|include\|load\|lorem\|now\|query_string\|regroup\|resetcycle\|spaceless\|templatetag\|url\|verbatim\|widthratio\|with\)\>\|{#\s\+'
       setf htmldjango
       return
+    endif
+    # Check for SuperHTML
+    if getline(n) =~ '\<extend\|\<super\>'
+        setf superhtml
+        return
     endif
     n += 1
   endwhile

--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -432,7 +432,7 @@ export def FThtml()
       return
     endif
     # Check for SuperHTML
-    if getline(n) =~ '\<extend\|\<super\>'
+    if getline(n) =~ '<extend\|<super>'
         setf superhtml
         return
     endif

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1039,7 +1039,7 @@ au BufNewFile,BufRead *.t.html			setf tilde
 " Translate shell
 au BufNewFile,BufRead init.trans,*/etc/translate-shell,.trans	setf clojure
 
-" HTML (.shtml and .stm for server side)
+" HTML (.shtml and .stm for server side, .shtml is also for superhtml)
 au BufNewFile,BufRead *.html,*.htm,*.shtml,*.stm  call dist#ft#FThtml()
 au BufNewFile,BufRead *.cshtml			setf html
 

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -2196,6 +2196,10 @@ au BufNewFile,BufRead .login,.cshrc,csh.cshrc,csh.login,csh.logout,*.csh,.alias 
 " Zig and Zig Object Notation (ZON)
 au BufNewFile,BufRead *.zig,*.zon		setf zig
 
+" Ziggy and Ziggy Schema
+au BufNewFile,BufRead *.ziggy                   setf ziggy
+au BufNewFile,BufRead *.ziggy-schema            setf ziggy_schema
+
 " Zserio
 au BufNewFile,BufRead *.zs			setf zserio
 

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -864,6 +864,8 @@ def s:GetFilenameChecks(): dict<list<string>>
     z8a: ['file.z8a'],
     zathurarc: ['zathurarc'],
     zig: ['file.zig', 'build.zig.zon'],
+    ziggy: ['file.ziggy'],
+    ziggy_schema: ['file.ziggy-schema'],
     zimbu: ['file.zu'],
     zimbutempl: ['file.zut'],
     zserio: ['file.zs'],

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -1612,7 +1612,7 @@ func Test_html_file()
         \ '   <div id="content">',
         \ '   </div>']
   call writefile(content, 'Xfile.shtml', 'D')
-  split Xfile.html
+  split Xfile.shtml
   call assert_equal('superhtml', &filetype)
   bwipe!
 
@@ -1632,7 +1632,7 @@ func Test_html_file()
         \ '    </div>',
         \ '  </body>']
   call writefile(content, 'Xfile.shtml', 'D')
-  split Xfile.html
+  split Xfile.shtml
   call assert_equal('superhtml', &filetype)
   bwipe!
 

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -1603,6 +1603,37 @@ func Test_html_file()
   call assert_equal('htmldjango', &filetype)
   bwipe!
 
+  " Super html layout
+  let content = ['<extend template="base.shtml>',
+        \ '   <title id="title" var="$page.title"></title>',
+        \ '   <head id="head"></head>',
+        \ '   <div id="content">',
+        \ '   </div>']
+  call writefile(content, 'Xfile.shtml', 'D')
+  split Xfile.html
+  call assert_equal('superhtml', &filetype)
+  bwipe!
+
+  " Super html template
+  let content = ['<!DOCTYPE html>',
+        \ '<html>',
+        \ '  <head id="head">',
+        \ '    <title id="title">',
+        \ '      <super>',
+        \ '      suffix',
+        \ '    </title>',
+        \ '    <super>',
+        \ '  </head>',
+        \ '  <body>',
+        \ '    <div id="content">',
+        \ '      <super>',
+        \ '    </div>',
+        \ '  </body>']
+  call writefile(content, 'Xfile.shtml', 'D')
+  split Xfile.html
+  call assert_equal('superhtml', &filetype)
+  bwipe!
+
   " regular HTML
   let content = ['<!DOCTYPE html>', '<html>', '    <head>Foobar</head>', '    <body>Content', '    </body>', '</html>']
   call writefile(content, 'Xfile.html', 'D')

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -1606,11 +1606,11 @@ func Test_html_file()
   bwipe!
 
   " Super html layout
-  let content = ['<extend template="base.shtml>',
-        \ '   <title id="title" var="$page.title"></title>',
-        \ '   <head id="head"></head>',
-        \ '   <div id="content">',
-        \ '   </div>']
+  let content = ['<extend template="base.shtml">',
+        \ '<title id="title" var="$page.title"></title>',
+        \ '<head id="head"></head>',
+        \ '<div id="content">',
+        \ '</div>']
   call writefile(content, 'Xfile.shtml', 'D')
   split Xfile.shtml
   call assert_equal('superhtml', &filetype)
@@ -1630,7 +1630,8 @@ func Test_html_file()
         \ '    <div id="content">',
         \ '      <super>',
         \ '    </div>',
-        \ '  </body>']
+        \ '  </body>',
+        \ '</html>']
   call writefile(content, 'Xfile.shtml', 'D')
   split Xfile.shtml
   call assert_equal('superhtml', &filetype)


### PR DESCRIPTION
This is a PR to address https://github.com/vim/vim/issues/15355 to add SuperHTML and Ziggy filetype support into vim.

Some things to note which may require further discussion.
1. SuperHTML is an overload of the .shtml file extension. As such I updated the FThtml() function as mentioned in https://github.com/vim/vim/issues/15355. I also added tests for both of the tags that indicate something is a SuperHTML file.
2. ziggy-schema's filetype is currently set to `ziggy_schema` to match with the language id that the lsp and tree-sitter setups rely on.