### PR TITLE
fix: compilation warnings with `-Wunused-parameter`

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -6119,10 +6119,10 @@ dict_tv2string(
  */
     static char_u *
 jobchan_tv2string(
-    typval_T	*tv,
-    char_u	**tofree,
-    char_u	*numbuf,
-    int		composite_val)
+    typval_T	*tv UNUSED,
+    char_u	**tofree UNUSED,
+    char_u	*numbuf UNUSED,
+    int		composite_val UNUSED)
 {
     char_u	*r = NULL;
 

--- a/src/misc2.c
+++ b/src/misc2.c
@@ -72,7 +72,7 @@ coladvance_force(colnr_T wcol)
  * Get the screen position of character col with a coladd in the cursor line.
  */
     int
-getviscol2(colnr_T col, colnr_T coladd UNUSED)
+getviscol2(colnr_T col, colnr_T coladd)
 {
     colnr_T	x;
     pos_T	pos;

--- a/src/strings.c
+++ b/src/strings.c
@@ -1037,7 +1037,7 @@ string_reduce(
  * Implementation of "byteidx()" and "byteidxcomp()" functions
  */
     static void
-byteidx_common(typval_T *argvars, typval_T *rettv, int comp UNUSED)
+byteidx_common(typval_T *argvars, typval_T *rettv, int comp)
 {
     rettv->vval.v_number = -1;
 

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -6299,7 +6299,7 @@ f_term_getsize(typval_T *argvars, typval_T *rettv)
  * "term_setsize(buf, rows, cols)" function
  */
     void
-f_term_setsize(typval_T *argvars UNUSED, typval_T *rettv UNUSED)
+f_term_setsize(typval_T *argvars, typval_T *rettv UNUSED)
 {
     buf_T	*buf;
     term_T	*term;

--- a/src/textprop.c
+++ b/src/textprop.c
@@ -2060,7 +2060,7 @@ list_types(hashtab_T *ht, list_T *l)
  * prop_type_list([{bufnr}])
  */
     void
-f_prop_type_list(typval_T *argvars, typval_T *rettv UNUSED)
+f_prop_type_list(typval_T *argvars, typval_T *rettv)
 {
     buf_T *buf = NULL;
 

--- a/src/typval.c
+++ b/src/typval.c
@@ -2214,7 +2214,7 @@ eval_number(
 	char_u	    **arg,
 	typval_T    *rettv,
 	int	    evaluate,
-	int	    want_string UNUSED)
+	int	    want_string)
 {
     int		len;
     int		skip_quotes = !in_old_script(4);

--- a/src/undo.c
+++ b/src/undo.c
@@ -3683,7 +3683,7 @@ u_eval_tree(buf_T *buf, u_header_T *first_uhp, list_T *list)
  * "undofile(name)" function
  */
     void
-f_undofile(typval_T *argvars UNUSED, typval_T *rettv)
+f_undofile(typval_T *argvars, typval_T *rettv)
 {
     if (in_vim9script() && check_for_string_arg(argvars, 0) == FAIL)
 	return;
@@ -3738,7 +3738,7 @@ u_undofile_reset_and_delete(buf_T *buf)
  * "undotree(expr)" function
  */
     void
-f_undotree(typval_T *argvars UNUSED, typval_T *rettv)
+f_undotree(typval_T *argvars, typval_T *rettv)
 {
     if (in_vim9script() && check_for_opt_buffer_arg(argvars, 0) == FAIL)
 	return;

--- a/src/vim9class.c
+++ b/src/vim9class.c
@@ -2665,7 +2665,7 @@ typealias_unref(typealias_T *ta)
  * Handle ":type".  Create an alias for a type specification.
  */
     void
-ex_type(exarg_T *eap UNUSED)
+ex_type(exarg_T *eap)
 {
     char_u	*arg = eap->arg;
 

--- a/src/vim9cmds.c
+++ b/src/vim9cmds.c
@@ -1639,7 +1639,7 @@ compile_try(char_u *arg, cctx_T *cctx)
  * Compile "catch {expr}".
  */
     char_u *
-compile_catch(char_u *arg, cctx_T *cctx UNUSED)
+compile_catch(char_u *arg, cctx_T *cctx)
 {
     scope_T	*scope = cctx->ctx_scope;
     garray_T	*instr = &cctx->ctx_instr;
@@ -1923,7 +1923,7 @@ compile_endtry(char_u *arg, cctx_T *cctx)
  * compile "throw {expr}"
  */
     char_u *
-compile_throw(char_u *arg, cctx_T *cctx UNUSED)
+compile_throw(char_u *arg, cctx_T *cctx)
 {
     char_u *p = skipwhite(arg);
 

--- a/src/viminfo.c
+++ b/src/viminfo.c
@@ -251,7 +251,7 @@ barline_writestring(FILE *fd, char_u *s, int remaining_start)
 viminfo_readstring(
     vir_T	*virp,
     int		off,		    // offset for virp->vir_line
-    int		convert UNUSED)	    // convert the string
+    int		convert)	    // convert the string
 {
     char_u	*retval = NULL;
     char_u	*s, *d;

--- a/src/window.c
+++ b/src/window.c
@@ -1708,7 +1708,7 @@ win_count(void)
     int
 make_windows(
     int		count,
-    int		vertical UNUSED)  // split windows vertically if TRUE
+    int		vertical)  // split windows vertically if TRUE
 {
     int		maxcount;
     int		todo;
@@ -3486,7 +3486,7 @@ win_free_all(void)
     win_T *
 winframe_remove(
     win_T	*win,
-    int		*dirp UNUSED,	// set to 'v' or 'h' for direction if 'ea'
+    int		*dirp,		// set to 'v' or 'h' for direction if 'ea'
     tabpage_T	*tp,		// tab page "win" is in, NULL for current
     frame_T	**unflat_altfr)	// if not NULL, set to pointer of frame that got
 				// the space, and it is not flattened
@@ -4855,8 +4855,8 @@ tabpage_index(tabpage_T *ftp)
  */
     static int
 leave_tabpage(
-    buf_T	*new_curbuf UNUSED,    // what is going to be the new curbuf,
-				       // NULL if unknown
+    buf_T	*new_curbuf,		// what is going to be the new curbuf,
+					// NULL if unknown
     int		trigger_leave_autocmds)
 {
     tabpage_T	*tp = curtab;
@@ -4908,7 +4908,7 @@ leave_tabpage(
     static void
 enter_tabpage(
     tabpage_T	*tp,
-    buf_T	*old_curbuf UNUSED,
+    buf_T	*old_curbuf,
     int		trigger_enter_autocmds,
     int		trigger_leave_autocmds)
 {
@@ -7855,7 +7855,7 @@ get_win_number(win_T *wp, win_T *first_win)
 }
 
     int
-get_tab_number(tabpage_T *tp UNUSED)
+get_tab_number(tabpage_T *tp)
 {
     int		i = 1;
     tabpage_T	*t;


### PR DESCRIPTION
Problem:  Compilation warnings with `-Wunused-parameter`
Solution: Add the `UNUSED` macro where needed, and remove some superfluous ones

Change fixes this kind of warnings when building without the channel feature:

```
eval.c:6122:15: warning: unused parameter ‘tv’ [-Wunused-parameter]
     typval_T *tv,
               ^
eval.c:6123:14: warning: unused parameter ‘tofree’ [-Wunused-parameter]
     char_u **tofree,
              ^
eval.c:6124:13: warning: unused parameter ‘numbuf’ [-Wunused-parameter]
     char_u *numbuf,
             ^
eval.c:6125:10: warning: unused parameter ‘composite_val’ [-Wunused-parameter]
     int  composite_val)