### PR TITLE
Problem:  Ctrl-P not working by default

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -4012,11 +4012,8 @@ ins_compl_get_exp(pos_T *ini)
 	st.ins_buf = curbuf;  // In case the buffer was wiped out.
 
     compl_old_match = compl_curr_match;	// remember the last current match
-    if (in_fuzzy)
-	st.cur_match_pos = (compl_dir_forward())
+    st.cur_match_pos = (compl_dir_forward())
 				    ? &st.last_match_pos : &st.first_match_pos;
-    else
-	st.cur_match_pos = &st.last_match_pos;
 
     // For ^N/^P loop over all the flags/windows/buffers in 'complete'.
     for (;;)

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -2688,4 +2688,14 @@ func Test_complete_fuzzy_match_tie()
   set completeopt&
 endfunc
 
+func Test_complete_backwards_default()
+  new
+  call append(1, ['foobar', 'foobaz'])
+  new
+  call feedkeys("i\<c-p>", 'tx')
+  call assert_equal('foobaz', getline('.'))
+  bw!
+  bw!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab nofoldenable


### PR DESCRIPTION
Problem:  Ctrl-P not working by default
Solution: Revert part of v9.1.0598 and set cur_match_pos
          correctly according to compl_dir_forward()

fixes: #15370