### PR TITLE
Check that mapping rhs starts with lhs fails if not simplified

### DIFF
--- a/src/structs.h
+++ b/src/structs.h
@@ -1309,6 +1309,9 @@ typedef struct mapblock mapblock_T;
 struct mapblock
 {
     mapblock_T	*m_next;	// next mapblock in list
+    mapblock_T	*m_alt;		// pointer to mapblock of the same mapping
+				// with an alternative form of m_keys, or NULL
+				// if there is no such mapblock
     char_u	*m_keys;	// mapped from, lhs
     char_u	*m_str;		// mapped to, rhs
     char_u	*m_orig_str;	// rhs as entered by the user

--- a/src/testdir/test_mapping.vim
+++ b/src/testdir/test_mapping.vim
@@ -1767,6 +1767,49 @@ func Test_unmap_simplifiable()
   unmap <C-I>
 endfunc
 
+" Test that the first byte of rhs is not remapped if rhs starts with lhs.
+func Test_map_rhs_starts_with_lhs()
+  new
+  func MapExpr()
+    return "\<C-R>\<C-P>"
+  endfunc
+
+  for expr in [v:false, v:true]
+    if expr
+      imap <buffer><expr> <C-R> MapExpr()
+    else
+      imap <buffer> <C-R> <C-R><C-P>
+    endif
+
+    for restore in [v:false, v:true]
+      if restore
+        let saved = maparg('<C-R>', 'i', v:false, v:true)
+        iunmap <buffer> <C-R>
+        call mapset(saved)
+      endif
+
+      let @a = 'foo'
+      call feedkeys("S\<C-R>a", 'tx')
+      call assert_equal('foo', getline('.'))
+
+      let @a = 'bar'
+      call feedkeys("S\<*C-R>a", 'tx')
+      call assert_equal('bar', getline('.'))
+    endfor
+  endfor
+
+  " When two mappings are used for <C-I> and <Tab>, remapping should work.
+  imap <buffer> <C-I> <Tab>bar
+  imap <buffer> <Tab> foo
+  call feedkeys("S\<Tab>", 'xt')
+  call assert_equal('foo', getline('.'))
+  call feedkeys("S\<*C-I>", 'xt')
+  call assert_equal('foobar', getline('.'))
+
+  delfunc MapExpr
+  bwipe!
+endfunc
+
 func Test_expr_map_escape_special()
   nnoremap … <Cmd>let g:got_ellipsis += 1<CR>
   func Func()


### PR DESCRIPTION
Problem:  Check that mapping rhs starts with lhs doesn't work if lhs is
          not simplified.
Solution: Keep track of the mapblock containing the alternative lhs and
          also compare with it.

related: #15376
