### PR TITLE
win32: Don't enable OLE on console

### DIFF
--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -5522,6 +5522,9 @@ gui_mch_prepare(int *argc, char **argv)
     }
 
 #ifdef FEAT_OLE
+# ifdef VIMDLL
+    if (mch_is_gui_executable())
+# endif
     {
 	int	bDoRestart = FALSE;
 


### PR DESCRIPTION
If VIMDLL was enabled, a message box for registering OLE might be shown even if Vim was executed in a console. (See #15372)

Enabling OLE in a console is not so useful.  Disable it.