### PR TITLE
ci.yml: improve macos package installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -330,6 +330,10 @@ jobs:
       - name: Install packages
         if: matrix.features == 'huge'
         run: |
+          # Install lua required for features huge.
+          # Apple diff is broken. Use GNU diff instead. See #14032.
+          brew install lua diffutils
+          echo "LUA_PREFIX=$(brew --prefix)" >> $GITHUB_ENV
           if [ $(uname -r | grep ^21 | cut -c1-2) == 21 ]; then
           # Install audio device (blackhole-2ch) for playing sound since some of macos-12 machines have no audio device installed.
             brew install blackhole-2ch
@@ -338,10 +342,6 @@ jobs:
           # Install libtool required for features huge.
             brew install libtool
           fi
-          # Install lua required for features huge.
-          # Apple diff is broken. Use GNU diff instead. See #14032.
-          brew install lua diffutils
-          echo "LUA_PREFIX=$(brew --prefix)" >> $GITHUB_ENV
 
       - name: Grant microphone access for macos-14
         if: matrix.features == 'huge' && matrix.runner == 'macos-14'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -330,15 +330,12 @@ jobs:
       - name: Install packages
         if: matrix.features == 'huge'
         run: |
-          brew install lua libtool
-          echo "LUA_PREFIX=$(brew --prefix)" >> $GITHUB_ENV
-
-      - name: Install blackhole-2ch for macos-12
-        if: matrix.features == 'huge' && matrix.runner == 'macos-12'
-        run: |
-          # Install audio device for playing sound since some of macos-12 machines have no audio device installed.
-          if system_profiler -json SPAudioDataType | jq -er '.SPAudioDataType[]._items == []'; then
-            brew install blackhole-2ch
+          if [ $(uname -r | grep ^21 | cut -c1-2) ]; then
+            brew install lua blackhole-2ch
+            echo "LUA_PREFIX=$(brew --prefix)" >> $GITHUB_ENV
+          else
+            brew install lua libtool diffutils
+            echo "LUA_PREFIX=$(brew --prefix)" >> $GITHUB_ENV
           fi
 
       - name: Grant microphone access for macos-14
@@ -388,11 +385,6 @@ jobs:
           "${SRCDIR}"/vim --version
           "${SRCDIR}"/vim -u NONE -i NONE --not-a-term -esNX -V1 -S ci/if_ver-1.vim -c quit
           "${SRCDIR}"/vim -u NONE -i NONE --not-a-term -esNX -V1 -S ci/if_ver-2.vim -c quit
-
-      - name: Install packages for testing
-        run: |
-          # Apple diff is broken. Use GNU diff instead. See #14032.
-          brew install diffutils
 
       - name: Test
         timeout-minutes: 20

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,13 +334,12 @@ jobs:
           # Install lua required for features huge.
           # Install audio device (blackhole-2ch) for playing sound since some of macos-12 machines have no audio device installed.
             brew install lua blackhole-2ch
-            echo "LUA_PREFIX=$(brew --prefix)" >> $GITHUB_ENV
           else
           # Install lua and libtool required for features huge.
           # Apple diff is broken. Use GNU diff instead. See #14032.
             brew install lua libtool diffutils
-            echo "LUA_PREFIX=$(brew --prefix)" >> $GITHUB_ENV
           fi
+          echo "LUA_PREFIX=$(brew --prefix)" >> $GITHUB_ENV
 
       - name: Grant microphone access for macos-14
         if: matrix.features == 'huge' && matrix.runner == 'macos-14'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -330,10 +330,14 @@ jobs:
       - name: Install packages
         if: matrix.features == 'huge'
         run: |
-          if [ $(uname -r | grep ^21 | cut -c1-2) ]; then
+          if [ $(uname -r | grep ^21 | cut -c1-2) == 21 ]; then
+          # Install lua required for features huge.
+          # Install audio device (blackhole-2ch) for playing sound since some of macos-12 machines have no audio device installed.
             brew install lua blackhole-2ch
             echo "LUA_PREFIX=$(brew --prefix)" >> $GITHUB_ENV
           else
+          # Install lua and libtool required for features huge.
+          # Apple diff is broken. Use GNU diff instead. See #14032.
             brew install lua libtool diffutils
             echo "LUA_PREFIX=$(brew --prefix)" >> $GITHUB_ENV
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -331,14 +331,16 @@ jobs:
         if: matrix.features == 'huge'
         run: |
           if [ $(uname -r | grep ^21 | cut -c1-2) == 21 ]; then
-          # Install lua required for features huge.
           # Install audio device (blackhole-2ch) for playing sound since some of macos-12 machines have no audio device installed.
-            brew install lua blackhole-2ch
-          else
-          # Install lua and libtool required for features huge.
-          # Apple diff is broken. Use GNU diff instead. See #14032.
-            brew install lua libtool diffutils
+            brew install blackhole-2ch
           fi
+          if [ $(uname -r | grep ^23 | cut -c1-2) == 23 ]; then
+          # Install libtool required for features huge.
+            brew install libtool
+          fi
+          # Install lua required for features huge.
+          # Apple diff is broken. Use GNU diff instead. See #14032.
+          brew install lua diffutils
           echo "LUA_PREFIX=$(brew --prefix)" >> $GITHUB_ENV
 
       - name: Grant microphone access for macos-14


### PR DESCRIPTION
All brew install steps moved into one.

Install audio device for playing sound since some of macos-12 machines have no audio device installed. Is returning false, shouldn't be the case anymore.

libtool is skipped on macos-12 due already installed.

diffutils installed for macos-14