### PR TITLE
win32: Fix channel timeout

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -2277,7 +2277,7 @@ channel_parse_json(channel_T *channel, ch_part_T part)
 	{
 	    int timeout;
 #ifdef MSWIN
-	    timeout = GetTickCount() > chanpart->ch_deadline;
+	    timeout = (int)(GetTickCount() - chanpart->ch_deadline) > 0;
 #else
 	    {
 		struct timeval now_tv;


### PR DESCRIPTION
Timeout calculation may be wrong when GetTickCount() wrapping around.