### PR TITLE
Unnecessary STRLEN() when applying mapping

### DIFF
--- a/src/testdir/test_mapping.vim
+++ b/src/testdir/test_mapping.vim
@@ -1789,11 +1789,11 @@ func Test_map_rhs_starts_with_lhs()
       endif
 
       let @a = 'foo'
-      call feedkeys("S\<C-R>a", 'tx')
+      call assert_nobeep('call feedkeys("S\<C-R>a", "tx")')
       call assert_equal('foo', getline('.'))
 
       let @a = 'bar'
-      call feedkeys("S\<*C-R>a", 'tx')
+      call assert_nobeep('call feedkeys("S\<*C-R>a", "tx")')
       call assert_equal('bar', getline('.'))
     endfor
   endfor


### PR DESCRIPTION
Problem:  Unnecessary STRLEN() when applying mapping.
Solution: Use m_keylen and vim_strnsave().
