### PR TITLE
ex: fix global insert of a newline

### DIFF
--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -3370,7 +3370,7 @@ ex_append(exarg_T *eap)
 	{
 	    // No getline() function, use the lines that follow. This ends
 	    // when there is no more.
-	    if (eap->nextcmd == NULL || *eap->nextcmd == NUL)
+	    if (eap->nextcmd == NULL)
 		break;
 	    p = vim_strchr(eap->nextcmd, NL);
 	    if (p == NULL)
@@ -3378,6 +3378,8 @@ ex_append(exarg_T *eap)
 	    theline = vim_strnsave(eap->nextcmd, p - eap->nextcmd);
 	    if (*p != NUL)
 		++p;
+	    else
+		p = NULL;
 	    eap->nextcmd = p;
 	}
 	else

--- a/src/testdir/test_ex_mode.vim
+++ b/src/testdir/test_ex_mode.vim
@@ -378,4 +378,13 @@ func Test_insert_after_trailing_bar()
   bwipe!
 endfunc
 
+" Test global insert of a newline without terminating period
+func Test_global_insert_newline()
+  new
+  call setline(1, ['foo'])
+  call feedkeys("Qg/foo/i\\\n", "xt")
+  call assert_equal(['', 'foo'], getline(1, '$'))
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
This fixes a corner case where the last command in a global command list is insert/append/change and the last line of that is an empty line, and the terminating period is not used (it is optional if the insert/append/change is the last command in a global command list since the end is unambiguous). The example is:

```
g/foo/i\
<newline>
```