### PR TITLE
Coverity warning in cstrncmp()

### DIFF
--- a/src/regexp.c
+++ b/src/regexp.c
@@ -1743,7 +1743,7 @@ cstrncmp(char_u *s1, char_u *s2, int *n)
     else if (enc_utf8)
     {
 	char_u *p = s1;
-	size_t n2 = 0;
+	int n2 = 0;
 	int n1 = *n;
 	// count the number of characters for byte-length of s1
 	while (n1 > 0 && *p != NUL)
@@ -1760,7 +1760,7 @@ cstrncmp(char_u *s1, char_u *s2, int *n)
 	n2 = p - s2;
 
 	result = MB_STRNICMP2(s1, s2, *n, n2);
-	if (result == 0 && (int)n2 < *n)
+	if (result == 0 && n2 < *n)
 	    *n = n2;
     }
     else


### PR DESCRIPTION
Problem:  Coverity warning in cstrncmp().
Solution: Change the type of n2 to int.

________________________________________________________________________________________________________
*** CID 1615684:  Integer handling issues  (INTEGER_OVERFLOW)
/src/regexp.c: 1757 in cstrncmp()
1751                 n1 -= mb_ptr2len(s1);
1752                 MB_PTR_ADV(p);
1753                 n2++;
1754             }
1755             // count the number of bytes to advance the same number of chars for s2
1756             p = s2;
>>>     CID 1615684:  Integer handling issues  (INTEGER_OVERFLOW)
>>>     Expression "n2--", which is equal to 18446744073709551615, where "n2" is known to be equal to 0, underflows the type that receives it, an unsigned integer 64 bits wide.
1757             while (n2-- > 0 && *p != NUL)
1758                 MB_PTR_ADV(p);
1759
1760             n2 = p - s2;
1761
1762             result = MB_STRNICMP2(s1, s2, *n, n2);
