### PR TITLE
Wrong comment for "len" argument of call_simple_func()

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -3259,7 +3259,7 @@ may_call_simple_func(
 	char_u *p = STRNCMP(arg, "<SNR>", 5) == 0 ? skipdigits(arg + 5) : arg;
 
 	if (to_name_end(p, TRUE) == parens)
-	    r = call_simple_func(arg, (int)(parens - arg), rettv);
+	    r = call_simple_func(arg, (size_t)(parens - arg), rettv);
     }
     return r;
 }

--- a/src/proto/userfunc.pro
+++ b/src/proto/userfunc.pro
@@ -39,7 +39,7 @@ int call_callback(callback_T *callback, int len, typval_T *rettv, int argcount, 
 varnumber_T call_callback_retnr(callback_T *callback, int argcount, typval_T *argvars);
 void user_func_error(funcerror_T error, char_u *name, int found_var);
 int call_func(char_u *funcname, int len, typval_T *rettv, int argcount_in, typval_T *argvars_in, funcexe_T *funcexe);
-int call_simple_func(char_u *funcname, int len, typval_T *rettv);
+int call_simple_func(char_u *funcname, size_t len, typval_T *rettv);
 char_u *printable_func_name(ufunc_T *fp);
 char_u *trans_function_name(char_u **pp, int *is_global, int skip, int flags);
 char_u *trans_function_name_ext(char_u **pp, int *is_global, int skip, int flags, funcdict_T *fdp, partial_T **partial, type_T **type, ufunc_T **ufunc);

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -4058,7 +4058,7 @@ theend:
     int
 call_simple_func(
     char_u	*funcname,	// name of the function
-    int		len,		// length of "name" or -1 to use strlen()
+    size_t	len,		// length of "name"
     typval_T	*rettv)		// return value goes here
 {
     int		ret = FAIL;


### PR DESCRIPTION
Problem:  Wrong comment for "len" argument of call_simple_func().
Solution: Remove the "or -1 to use strlen()".  Also change its type to
          size_t to remove one cast.
