### PR TITLE
runtime(goaccess): add syntax

### DIFF
--- a/.github/MAINTAINERS
+++ b/.github/MAINTAINERS
@@ -446,6 +446,7 @@ runtime/syntax/gitolite.vim		@sitaramc
 runtime/syntax/gitrebase.vim		@tpope
 runtime/syntax/glsl.vim		@gpanders
 runtime/syntax/go.vim			@bhcleek
+runtime/syntax/goaccess.vim		@meonkeys
 runtime/syntax/godoc.vim		@dbarnett
 runtime/syntax/gp.vim			@KBelabas
 runtime/syntax/gprof.vim		@dpelle

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -953,6 +953,9 @@ au BufNewFile,BufRead *.go			setf go
 au BufNewFile,BufRead Gopkg.lock		setf toml
 au BufRead,BufNewFile go.work			setf gowork
 
+" GoAccess configuration
+au BufNewFile,BufRead goaccess.conf		setf goaccess
+
 " GrADS scripts
 au BufNewFile,BufRead *.gs			setf grads
 

--- a/runtime/ftplugin/goaccess.vim
+++ b/runtime/ftplugin/goaccess.vim
@@ -1,0 +1,14 @@
+" Vim filetype plugin
+" Language: GoAccess configuration
+" Maintainer: Adam Monsen <haircut@gmail.com>
+" Last Change: August 1, 2024
+
+if exists('b:did_ftplugin')
+  finish
+endif
+
+let b:did_ftplugin = 1
+
+setl comments=:# commentstring=#\ %s
+
+let b:undo_ftplugin = 'setl com< cms<'

--- a/runtime/syntax/goaccess.vim
+++ b/runtime/syntax/goaccess.vim
@@ -1,0 +1,34 @@
+" Vim syntax file
+" Language: GoAccess configuration
+" Maintainer: Adam Monsen <haircut@gmail.com>
+" Last Change: August 1, 2024
+" Remark: see https://goaccess.io/man#configuration
+"
+" The GoAccess configuration file syntax is line-separated settings. Settings
+" are space-separated key value pairs. Comments are any line starting with a
+" hash mark.
+" Example: https://github.com/allinurl/goaccess/blob/master/config/goaccess.conf
+"
+" This syntax definition supports todo/fixme highlighting in comments, and
+" special (Keyword) highlighting if a setting's value is 'true' or 'false'.
+"
+" TODO: a value is required, so use extreme highlighting (e.g. bright red
+" background) if a setting is missing a value.
+
+if exists("b:current_syntax")
+  finish
+endif
+
+syn match goaccessSettingName '^[a-z-]\+' nextgroup=goaccessSettingValue
+syn match goaccessSettingValue '\s\+.\+$' contains=goaccessKeyword
+syn match goaccessComment "^#.*$" contains=goaccessTodo,@Spell
+syn keyword goaccessTodo TODO FIXME contained
+syn keyword goaccessKeyword true false contained
+
+hi def link goaccessSettingName Type
+hi def link goaccessSettingValue String
+hi def link goaccessComment Comment
+hi def link goaccessTodo Todo
+hi def link goaccessKeyword Keyword
+
+let b:current_syntax = "goaccess"

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -300,6 +300,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     gnash: ['gnashrc', '.gnashrc', 'gnashpluginrc', '.gnashpluginrc'],
     gnuplot: ['file.gpi', '.gnuplot', 'file.gnuplot', '.gnuplot_history'],
     go: ['file.go'],
+    goaccess: ['goaccess.conf'],
     gomod: ['go.mod'],
     gosum: ['go.sum', 'go.work.sum'],
     gowork: ['go.work'],


### PR DESCRIPTION
Add syntax highlighting for GoAccess configuration file.

GoAccess is a real-time web log analyzer and interactive viewer that runs in a terminal in *nix systems or through your browser.

GoAccess home page: https://goaccess.io