### PR TITLE
fix(completion): file completion respect completeslash when fuzzy

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -3552,9 +3552,34 @@ get_next_filename_completion(void)
     size_t	path_with_wildcard_len;
     char_u	*path_with_wildcard;
 
+#ifdef BACKSLASH_IN_FILENAME
+    char pathsep = (curbuf->b_p_csl[0] == 's') ?
+	'/' : (curbuf->b_p_csl[0] == 'b') ? '\\' : PATHSEP;
+#else
+    char pathsep = PATHSEP;
+#endif
+
     if (in_fuzzy)
     {
-	last_sep = vim_strrchr(leader, PATHSEP);
+#ifdef BACKSLASH_IN_FILENAME
+	if (curbuf->b_p_csl[0] == 's')
+	{
+	    for (i = 0; i < leader_len; i++)
+	    {
+		if (leader[i] == '\\')
+		    leader[i] = '/';
+	    }
+	}
+	else if (curbuf->b_p_csl[0] == 'b')
+	{
+	    for (i = 0; i < leader_len; i++)
+	    {
+		if (leader[i] == '/')
+		    leader[i] = '\\';
+	    }
+	}
+#endif
+	last_sep = vim_strrchr(leader, pathsep);
 	if (last_sep == NULL)
 	{
 	    // No path separator or separator is the last character,

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -2668,6 +2668,38 @@ func Test_complete_fuzzy_match()
   unlet g:word
 endfunc
 
+func Test_complete_fuzzy_with_completeslash()
+  CheckMSWindows
+
+  call writefile([''], 'fobar', 'D')
+  let orig_shellslash = &shellslash
+  set cpt&
+  new
+  set completeopt+=fuzzy
+  set noshellslash
+
+  " Test with completeslash unset
+  set completeslash=
+  call setline(1, ['.\fob'])
+  call feedkeys("A\<C-X>\<C-F>\<Esc>0", 'tx!')
+  call assert_equal('.\fobar', getline('.'))
+
+  " Test with completeslash=backslash
+  set completeslash=backslash
+  call feedkeys("S.\\fob\<C-X>\<C-F>\<Esc>0", 'tx!')
+  call assert_equal('.\fobar', getline('.'))
+
+  " Test with completeslash=slash
+  set completeslash=slash
+  call feedkeys("S.\\fob\<C-X>\<C-F>\<Esc>0", 'tx!')
+  call assert_equal('./fobar', getline('.'))
+
+  " Reset and clean up
+  let &shellslash = orig_shellslash
+  set completeslash=
+  %bw!
+endfunc
+
 " Check that tie breaking is stable for completeopt+=fuzzy (which should
 " behave the same on different platforms).
 func Test_complete_fuzzy_match_tie()


### PR DESCRIPTION
Problem: fuzzy not respect completeslash in windows

Solution: replace  the path separator in leader according the value of completeslash

Fix #15392 