### PR TITLE
Coverity warns about dereferencing NULL pointer

### DIFF
--- a/src/help.c
+++ b/src/help.c
@@ -813,6 +813,8 @@ fix_help_buffer(void)
 			    f1 = fnames[i1];
 			    t1 = gettail(f1);
 			    e1 = vim_strrchr(t1, '.');
+			    if (e1 == NULL)
+				continue;
 			    if (fnamecmp(e1, ".txt") != 0
 					       && fnamecmp(e1, fname + 4) != 0)
 			    {
@@ -828,6 +830,8 @@ fix_help_buffer(void)
 				    continue;
 				t2 = gettail(f2);
 				e2 = vim_strrchr(t2, '.');
+				if (e2 == NULL)
+				    continue;
 				if (e1 - f1 != e2 - f2
 					    || fnamencmp(f1, f2, e1 - f1) != 0)
 				    continue;


### PR DESCRIPTION
Problem:  Coverity warns about dereferencing NULL pointer.
Solution: Bail out if vim_strrchr() returns NULL.

________________________________________________________________________________________________________
*** CID 1616019:    (NULL_RETURNS)
/src/help.c: 834 in fix_help_buffer()
828                                  continue;
829                              t2 = gettail(f2);
830                              e2 = vim_strrchr(t2, '.');
831                              if (e1 - f1 != e2 - f2
832                                          || fnamencmp(f1, f2, e1 - f1) != 0)
833                                  continue;
>>>     CID 1616019:    (NULL_RETURNS)
>>>     Dereferencing a pointer that might be "NULL" "(char_u *)e2" when calling "vim_fnamecmp".
834                              if (fnamecmp(e1, ".txt") == 0
835                                             && fnamecmp(e2, fname + 4) == 0)
836                                  // use .abx instead of .txt
837                                  VIM_CLEAR(fnames[i1]);
838                          }
839                      }
/src/help.c: 816 in fix_help_buffer()
810                      // the same directory.
811                      for (i1 = 0; i1 < fcount; ++i1)
812                      {
813                          f1 = fnames[i1];
814                          t1 = gettail(f1);
815                          e1 = vim_strrchr(t1, '.');
>>>     CID 1616019:    (NULL_RETURNS)
>>>     Dereferencing a pointer that might be "NULL" "(char_u *)e1" when calling "vim_fnamecmp".
816                          if (fnamecmp(e1, ".txt") != 0
817                                             && fnamecmp(e1, fname + 4) != 0)
818                          {
819                              // Not .txt and not .abx, remove it.
820                              VIM_CLEAR(fnames[i1]);
821                              continue;
