### PR TITLE
fix(completion): completion next word when fuzzy enable

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -5197,6 +5197,7 @@ ins_compl_start(void)
     if (line_invalid)
 	line = ml_get(curwin->w_cursor.lnum);
 
+    int in_fuzzy = get_cot_flags() & COT_FUZZY;
     if (compl_status_adding())
     {
 	edit_submode_pre = (char_u *)_(" Adding");
@@ -5212,6 +5213,11 @@ ins_compl_start(void)
 	    curbuf->b_p_com = old;
 	    compl_length = 0;
 	    compl_col = curwin->w_cursor.col;
+	}
+	else if (ctrl_x_mode_normal() && in_fuzzy)
+	{
+	    compl_startpos = curwin->w_cursor;
+	    compl_cont_status &= CONT_S_IPOS;
 	}
     }
     else

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -2654,10 +2654,38 @@ func Test_complete_fuzzy_match()
   call feedkeys("Su\<C-X>\<C-L>\<C-P>\<Esc>0", 'tx!')
   call assert_equal('no one can save me but you', getline('.'))
 
+  " issue #15412
+  call setline(1, ['alpha bravio charlie'])
+  call feedkeys("Salpha\<C-X>\<C-N>\<Esc>0", 'tx!')
+  call assert_equal('alpha bravio', getline('.'))
+  call feedkeys("Salp\<C-X>\<C-N>\<Esc>0", 'tx!')
+  call assert_equal('alpha', getline('.'))
+  call feedkeys("A\<C-X>\<C-N>\<Esc>0", 'tx!')
+  call assert_equal('alpha bravio', getline('.'))
+  call feedkeys("A\<C-X>\<C-N>\<Esc>0", 'tx!')
+  call assert_equal('alpha bravio charlie', getline('.'))
+
+  set complete-=i
+  call feedkeys("Salp\<C-X>\<C-N>\<Esc>0", 'tx!')
+  call assert_equal('alpha', getline('.'))
+  call feedkeys("A\<C-X>\<C-N>\<Esc>0", 'tx!')
+  call assert_equal('alpha bravio', getline('.'))
+  call feedkeys("A\<C-X>\<C-N>\<Esc>0", 'tx!')
+  call assert_equal('alpha bravio charlie', getline('.'))
+
+  call setline(1, ['alpha bravio charlie', 'alpha another'])
+  call feedkeys("Salpha\<C-X>\<C-N>\<C-N>\<Esc>0", 'tx!')
+  call assert_equal('alpha another', getline('.'))
+  call setline(1, ['你好 我好', '你好 他好'])
+  call feedkeys("S你好\<C-X>\<C-N>\<Esc>0", 'tx!')
+  call assert_equal('你好 我好', getline('.'))
+  call feedkeys("S你好\<C-X>\<C-N>\<C-N>\<Esc>0", 'tx!')
+  call assert_equal('你好 他好', getline('.'))
+
   " issue #15526
   set completeopt=fuzzy,menuone,menu,noselect
   call setline(1, ['Text', 'ToText', ''])
-  call cursor(2, 1)
+  call cursor(3, 1)
   call feedkeys("STe\<C-X>\<C-N>x\<CR>\<Esc>0", 'tx!')
   call assert_equal('Tex', getline('.'))
 


### PR DESCRIPTION
Problem: when cursor after a word which already in buffer no completion is given or shown.

Solution: if word before cursor is matched return next word as completion result.


Fix #15412