### PR TITLE
filecopy() may return wrong value when readlink() fails

### DIFF
--- a/src/fileio.c
+++ b/src/fileio.c
@@ -3912,7 +3912,7 @@ vim_rename(char_u *from, char_u *to)
 
 /*
  * Create the new file with same permissions as the original.
- * Return -1 for failure, 0 for success.
+ * Return FAIL for failure, OK for success.
  */
     int
 vim_copyfile(char_u *from, char_u *to)
@@ -3936,7 +3936,7 @@ vim_copyfile(char_u *from, char_u *to)
     ret = mch_lstat((char *)from, &st);
     if (ret >= 0 && S_ISLNK(st.st_mode))
     {
-	ret = FAIL;
+	ret = -1;
 
 	len = readlink((char *)from, linkbuf, MAXPATHL);
 	if (len > 0)


### PR DESCRIPTION
Problem:  filecopy() may return wrong value when readlink() fails.
Solution: Set ret to -1 so that 0 is returned when readlink() fails.

I don't think it's possible to add a test for this, as I can't think of
a case where lstat() succeeds while readlink() fails.
