### PR TITLE
[vim9class] During compilation, don't look for a return statement for an `abstract` method.

### DIFF
--- a/src/testdir/test_vim9_class.vim
+++ b/src/testdir/test_vim9_class.vim
@@ -6129,6 +6129,27 @@ def Test_abstract_method()
     assert_equal('foo', A.Foo())
   END
   v9.CheckSourceSuccess(lines)
+
+  # Invoke method returning a value through the abstract class. See #15432.
+  lines =<< trim END
+    vim9script
+
+    abstract class A
+        abstract def String(): string
+    endclass
+
+    class B extends A
+        def String(): string
+            return 'B'
+        enddef
+    endclass
+
+    def F(o: A)
+        assert_equal('B', o.String())
+    enddef
+    F(B.new())
+  END
+  v9.CheckSourceSuccess(lines)
 enddef
 
 " Test for calling a class method from a subclass

--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -4120,8 +4120,9 @@ compile_def_function(
     ufunc->uf_args_visible = ufunc->uf_args.ga_len;
 
     // Compiling a function in an interface is done to get the function type.
-    // No code is actually compiled.
-    if (ufunc->uf_class != NULL && IS_INTERFACE(ufunc->uf_class))
+    // No code is actually compiled. Same goes for an abstract method.
+    if ((ufunc->uf_class != NULL && IS_INTERFACE(ufunc->uf_class))
+	|| IS_ABSTRACT_METHOD(ufunc))
     {
 	ufunc->uf_def_status = UF_NOT_COMPILED;
 	ret = OK;


### PR DESCRIPTION
This fixes part of #15432. In particular
```
vim9script

abstract class A
    abstract def String(): string
endclass

class B extends A
    def String(): string
        return 'B'
    enddef
endclass
def F(o: A)
    assert_equal('B', o.String())
enddef
F(B.new())
```
generates
```
Error detected while compiling /tmp/d.vim[15]..function <SNR>46_F[1]..<SNR>46_A.String:
line    1:
E1027: Missing return statement
```
The error arises because the compiler tries to compile
```
abstract def String(): string
```
Since this is an abstract method declaration it has no body; there is no return statement. This PR treats the compilation of an abstract method the same as compiling an interface function; it exits `compile_def_function()` early. So for an abstract method, just like an interface method, the compiler never tries to compile the non-existent body (it never looks for a return statement).

**Note:** this fails the same in the `vim-9.1` release.

@dkearns Notice that this showcases the similarity between interface and abstract class, which has been the topic of much discussion.

@chrisbra @yegappan @LemonBoy @zzzyxwvut 
UPDATE: the updated PR, treating it like a interface function, seems to fit much better.


