### PR TITLE
win32: Restore main screen buffer

### DIFF
--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -3561,6 +3561,10 @@ mch_exit_c(int r)
     vtp_exit();
 
     stoptermcap();
+    // Switch back to main screen buffer.
+    if (use_alternate_screen_buffer)
+	vtp_printf("\033[?1049l");
+
     if (g_fWindInitCalled)
 	settmode(TMODE_COOK);
 
@@ -6333,10 +6337,6 @@ termcap_mode_end(void)
 # endif
     RestoreConsoleBuffer(cb, p_rs);
     restore_console_color_rgb();
-
-    // Switch back to main screen buffer.
-    if (exiting && use_alternate_screen_buffer)
-	vtp_printf("\033[?1049l");
 
     if (!USE_WT && (p_rs || exiting))
     {


### PR DESCRIPTION
`vim.exe --cmd quit` quitted without switching back to the main screen buffer and the alternate screen buffer was kept shown.

Restore the main screen buffer even when termcap mode has not been started.