### PR TITLE
runtime: Add indent for Protobuf

### DIFF
--- a/.github/MAINTAINERS
+++ b/.github/MAINTAINERS
@@ -341,6 +341,7 @@ runtime/indent/perl.vim			@petdance
 runtime/indent/php.vim			@2072
 runtime/indent/postscr.vim		@mrdubya
 runtime/indent/prolog.vim		@dkearns
+runtime/indent/proto.vim		@Limero
 runtime/indent/ps1.vim			@heaths
 runtime/indent/qb64.vim			@dkearns
 runtime/indent/qml.vim			@ChaseKnowlden

--- a/runtime/indent/proto.vim
+++ b/runtime/indent/proto.vim
@@ -1,6 +1,6 @@
 " Vim indent file
 " Language:	Protobuf
-" Maintainer:	Johannes Zellner <johannes@zellner.org>
+" Maintainer:	David Pedersen <limero@me.com>
 " Last Change:	2024 Aug 07
 
 " Only load this indent file when no other was loaded.

--- a/runtime/indent/proto.vim
+++ b/runtime/indent/proto.vim
@@ -1,0 +1,19 @@
+" Vim indent file
+" Language:	Protobuf
+" Maintainer:	Johannes Zellner <johannes@zellner.org>
+" Last Change:	2002 Mar 15
+
+" Only load this indent file when no other was loaded.
+if exists("b:did_indent")
+  finish
+endif
+let b:did_indent = 1
+
+" Protobuf is like indenting C
+setlocal cindent
+setlocal expandtab
+setlocal shiftwidth=2
+
+let b:undo_indent = "setl cin<"
+
+" vim: sw=2 sts=2 et

--- a/runtime/indent/proto.vim
+++ b/runtime/indent/proto.vim
@@ -1,7 +1,7 @@
 " Vim indent file
 " Language:	Protobuf
 " Maintainer:	Johannes Zellner <johannes@zellner.org>
-" Last Change:	2002 Mar 15
+" Last Change:	2024 Aug 07
 
 " Only load this indent file when no other was loaded.
 if exists("b:did_indent")
@@ -14,6 +14,6 @@ setlocal cindent
 setlocal expandtab
 setlocal shiftwidth=2
 
-let b:undo_indent = "setl cin<"
+let b:undo_indent = "setlocal cindent< expandtab< shiftwidth<"
 
 " vim: sw=2 sts=2 et


### PR DESCRIPTION
This adds the indent file for Protobuf from https://github.com/uarun/vim-protobuf/blob/master/indent/proto.vim

I've contacted the original author (Johannes Zellner) and he is ok with it being upstreamed.

Protobuf will fail to build unless the files are indented with 2 spaces, so it makes sense to have this be the default for any vim user editing proto files. Indenting in another way will throw an error like: `Found an incorrect indentation style "	". "  " is correct.`