### PR TITLE
runtime(doc): clarify directory of Vim's executable vs CWD

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -1,4 +1,4 @@
-*builtin.txt*	For Vim version 9.1.  Last change: 2024 Jul 28
+*builtin.txt*	For Vim version 9.1.  Last change: 2024 Aug 08
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -2532,6 +2532,7 @@ executable({expr})					*executable()*
 		This function checks if an executable with the name {expr}
 		exists.  {expr} must be the name of the program without any
 		arguments.
+
 		executable() uses the value of $PATH and/or the normal
 		searchpath for programs.		*PATHEXT*
 		On MS-Windows the ".exe", ".bat", etc. can optionally be
@@ -2543,11 +2544,14 @@ executable({expr})					*executable()*
 		then the name is also tried without adding an extension.
 		On MS-Windows it only checks if the file exists and is not a
 		directory, not if it's really executable.
-		On MS-Windows an executable in the same directory as Vim is
-		normally found.  Since this directory is added to $PATH it
-		should also work to execute it |win32-PATH|.  This can be
-		disabled by setting the $NoDefaultCurrentDirectoryInExePath
-		environment variable.  *NoDefaultCurrentDirectoryInExePath*
+		On MS-Windows an executable in the same directory as the Vim
+		executable is always found.  Since this directory is added to
+		$PATH it should also work to execute it |win32-PATH|.
+					*NoDefaultCurrentDirectoryInExePath*
+		On MS-Windows an executable in Vim's current working directory
+		is also normally found, but this can be disabled by setting
+		the $NoDefaultCurrentDirectoryInExePath environment variable.
+
 		The result is a Number:
 			1	exists
 			0	does not exist

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -2534,7 +2534,8 @@ executable({expr})					*executable()*
 		arguments.
 
 		executable() uses the value of $PATH and/or the normal
-		searchpath for programs.		*PATHEXT*
+		searchpath for programs.
+							*PATHEXT*
 		On MS-Windows the ".exe", ".bat", etc. can optionally be
 		included.  Then the extensions in $PATHEXT are tried.  Thus if
 		"foo.exe" does not exist, "foo.exe.bat" can be found.  If


### PR DESCRIPTION
According to :h win32-PATH, "the same directory as Vim" means the same
directory as the Vim executable, not Vim's current directory.  In patch
8.2.4860 these two concepts were mixed up.
