### PR TITLE
runtime(dosbatch): Add syn-sync

### DIFF
--- a/runtime/syntax/dosbatch.vim
+++ b/runtime/syntax/dosbatch.vim
@@ -74,7 +74,7 @@ syn match dosbatchSet		"\s\h\w*[+-]\==\{-1}" contains=dosbatchIdentifier,dosbatc
 
 " Args to bat files and for loops, etc
 syn match dosbatchArgument	"%\(\d\|\*\)"
-syn match dosbatchArgument	"%[a-z]\>"
+syn match dosbatchArgument	"%%[a-z]\>"
 if dosbatch_cmdextversion == 1
   syn match dosbatchArgument	"%\~[fdpnxs]\+\(\($PATH:\)\=[a-z]\|\d\)\>"
 else

--- a/runtime/syntax/dosbatch.vim
+++ b/runtime/syntax/dosbatch.vim
@@ -105,7 +105,7 @@ syn match dosbatchColonCommentErr contained "\s*:\s*:[^)]*\(\(\n\s*\)\?)\)\@="
 syn region dosbatchCodeBlock	transparent start=+(+ end=+)+ contains=dosbatchString,dosbatchVariable,dosBatchArgument,@dosbatchNumber,dosbatchImplicit,dosbatchStatement,dosbatchConditional,dosbatchRepeat,dosbatchOperator,dosbatchIfOperator,@dosbatchCodeBlockComment,dosbatchColonCommentErr,dosbatchCodeBlock
 syn match dosbatchCodeBlockErr	")"
 
-syn sync match dosbatchSyncCodeBlock grouphere NONE "^\s*)\s*$"
+syn sync match dosbatchSyncCodeBlock grouphere NONE "^)\s*$"
 
 syn keyword dosbatchImplicit    append assoc at attrib break cacls cd chcp chdir
 syn keyword dosbatchImplicit    chkdsk chkntfs cls cmd color comp compact convert copy

--- a/runtime/syntax/dosbatch.vim
+++ b/runtime/syntax/dosbatch.vim
@@ -2,7 +2,7 @@
 " Language:	MS-DOS/Windows batch file (with NT command extensions)
 " Maintainer:	Mike Williams <mrmrdubya@gmail.com>
 " Filenames:    *.bat
-" Last Change:	3rd February 2024
+" Last Change:	8th August 2024
 "
 " Options Flags:
 " dosbatch_cmdextversion	- 1 = Windows NT, 2 = Windows 2000 [default]
@@ -45,7 +45,7 @@ syn match dosbatchString	"\<echo\([^)>|]\|\^\@<=[)>|]\)*"lc=4 contains=dosbatchV
 syn match dosbatchEchoOperator  "\<echo\s\+\(on\|off\)\s*$"lc=4
 
 " For embedded commands
-syn match dosbatchCmd		"(\s*'[^']*'"lc=1 contains=dosbatchString,dosbatchVariable,dosBatchArgument,@dosbatchNumber,dosbatchImplicit,dosbatchStatement,dosbatchConditional,dosbatchRepeat,dosbatchOperator
+syn match dosbatchCmd		"(\s*'[^']*'"lc=1 contains=dosbatchString,dosbatchVariable,dosBatchArgument,@dosbatchNumber,dosbatchImplicit,dosbatchStatement,dosbatchConditional,dosbatchRepeat,dosbatchOperator,dosbatchIfOperator
 
 " Numbers - surround with ws to not include in dir and filenames
 syn match dosbatchInteger       "[[:space:]=(/:,!~-]\d\+"lc=1
@@ -102,8 +102,10 @@ else
   syn match dosbatchColonCommentErr contained "\s*:\s*:.*$"
 endif
 syn match dosbatchColonCommentErr contained "\s*:\s*:[^)]*\(\(\n\s*\)\?)\)\@="
-syn region dosbatchCodeBlock	transparent start=+(+ end=+)+ contains=dosbatchString,dosbatchVariable,dosBatchArgument,@dosbatchNumber,dosbatchImplicit,dosbatchStatement,dosbatchConditional,dosbatchRepeat,dosbatchOperator,@dosbatchCodeBlockComment,dosbatchColonCommentErr,dosbatchCodeBlock
+syn region dosbatchCodeBlock	transparent start=+(+ end=+)+ contains=dosbatchString,dosbatchVariable,dosBatchArgument,@dosbatchNumber,dosbatchImplicit,dosbatchStatement,dosbatchConditional,dosbatchRepeat,dosbatchOperator,dosbatchIfOperator,@dosbatchCodeBlockComment,dosbatchColonCommentErr,dosbatchCodeBlock
 syn match dosbatchCodeBlockErr	")"
+
+syn sync match dosbatchSyncCodeBlock grouphere NONE "^\s*)\s*$"
 
 syn keyword dosbatchImplicit    append assoc at attrib break cacls cd chcp chdir
 syn keyword dosbatchImplicit    chkdsk chkntfs cls cmd color comp compact convert copy


### PR DESCRIPTION
Closing parentheses were often highlighted as errors. Add a syntax sync command to reduce the error.

Also fix that `defined` was not highlighted as an operator inside parentheses.  E.g.:
```
if defined foo (
    if defined bar (
        ...
    )
)
```
The first `defined` was highlighted but the second one was not.

Also fix that `%%i` was not shown as a variable. Inside batch files, `%%i` must be used instead of `%i`.