### PR TITLE
Locked variable can be changed in a :for loop

### DIFF
--- a/src/evalvars.c
+++ b/src/evalvars.c
@@ -4100,7 +4100,7 @@ set_var_const(
 
 	    // Modifying a final variable with a List value using the "+="
 	    // operator is allowed.  For other types, it is not allowed.
-	    if (((flags & ASSIGN_FOR_LOOP) == 0
+	    if ((((flags & ASSIGN_FOR_LOOP) == 0 || (flags & ASSIGN_DECL) == 0)
 			&& ((flags & ASSIGN_COMPOUND_OP) == 0
 			    || !type_inplace_modifiable))
 				 ? var_check_permission(di, name) == FAIL


### PR DESCRIPTION
Problem:  Locked variable can be changed in a :for loop.
Solution: Always do a full permission check on the first loop iteration
          where ASSIGN_DECL is not set.

related: #12470
fixex: #15450
