### PR TITLE
assert_equal() doesn't show multibyte string correctly

### DIFF
--- a/src/testdir/test_assert.vim
+++ b/src/testdir/test_assert.vim
@@ -48,8 +48,17 @@ func Test_assert_equal()
   call assert_match("Expected 'bar' but got 'foo'", v:errors[0])
   call remove(v:errors, 0)
 
+  let s = 'αβγ'
+  call assert_equal(1, assert_equal('δεζ', s))
+  call assert_match("Expected 'δεζ' but got 'αβγ'", v:errors[0])
+  call remove(v:errors, 0)
+
   call assert_equal('XxxxxxxxxxxxxxxxxxxxxxX', 'XyyyyyyyyyyyyyyyyyyyyyyyyyX')
   call assert_match("Expected 'X\\\\\\[x occurs 21 times]X' but got 'X\\\\\\[y occurs 25 times]X'", v:errors[0])
+  call remove(v:errors, 0)
+
+  call assert_equal('ΩωωωωωωωωωωωωωωωωωωωωωΩ', 'ΩψψψψψψψψψψψψψψψψψψψψψψψψψΩ')
+  call assert_match("Expected 'Ω\\\\\\[ω occurs 21 times]Ω' but got 'Ω\\\\\\[ψ occurs 25 times]Ω'", v:errors[0])
   call remove(v:errors, 0)
 
   " special characters are escaped

--- a/src/testing.c
+++ b/src/testing.c
@@ -99,7 +99,7 @@ ga_concat_shorten_esc(garray_T *gap, char_u *str)
 	return;
     }
 
-    for (p = str; *p != NUL; ++p)
+    for (p = str; *p != NUL; )
     {
 	same_len = 1;
 	s = p;
@@ -118,10 +118,13 @@ ga_concat_shorten_esc(garray_T *gap, char_u *str)
 	    vim_snprintf((char *)buf, NUMBUFLEN, "%d", same_len);
 	    ga_concat(gap, buf);
 	    ga_concat(gap, (char_u *)" times]");
-	    p = s - 1;
+	    p = s;
 	}
 	else
+	{
 	    ga_concat_esc(gap, p, clen);
+	    p += clen;
+	}
     }
 }
 


### PR DESCRIPTION
Problem:  assert_equal() doesn't show multibyte string correctly.
Solution: Properly advance over a multibyte char.
