### PR TITLE
[vim9class] Only allow child class override method signatures that require no runtime checks.

### DIFF
--- a/runtime/doc/vim9class.txt
+++ b/runtime/doc/vim9class.txt
@@ -654,10 +654,11 @@ is not possible to override them (unlike some other languages).
 
 						*E1356* *E1357* *E1358*
 Object methods of the base class can be overruled.  The signature (arguments,
-argument types and return type) must be exactly the same.  If the return type
-of a method is a class, then that class or one of its subclasses can be used
-in the extended method.  The method of the base class can be called by
-prefixing "super.".
+argument types and return type) must be compile time compatible with the base
+class signature; no runtime checks are required.  If the return type of a
+method is a class, then that class or one of its subclasses can be used in the
+extended method.  The method of the base class can be called by prefixing
+"super.".
 
 						*E1377*
 The access level of a method (public or protected) in a child class should be

--- a/src/testdir/test_vim9_class.vim
+++ b/src/testdir/test_vim9_class.vim
@@ -7554,6 +7554,24 @@ def Test_extended_obj_method_type_check()
     endclass
   END
   v9.CheckSourceFailure(lines, 'E1383: Method "F": type mismatch, expected func(...list<any>) but got func(list<any>)', 10)
+
+  lines =<< trim END
+    vim9script
+
+    class A
+        def String(): string
+            return 'S'
+        enddef
+    endclass
+    class B extends A
+        def String(): any
+            return '?'
+        enddef
+    endclass
+
+    var o = B.new().String()
+  END
+  v9.CheckSourceFailure(lines, 'E1383: Method "String": type mismatch, expected func(): string but got func(): any', 12)
 enddef
 
 " Test type checking for class variable in assignments

--- a/src/vim9class.c
+++ b/src/vim9class.c
@@ -1427,8 +1427,14 @@ add_classfuncs_objmethods(
 			where_T where = WHERE_INIT;
 			where.wt_func_name = (char *)pname;
 			where.wt_kind = WT_METHOD;
-			(void)check_type(pf->uf_func_type, cf->uf_func_type,
-								TRUE, where);
+			int ret = check_type_maybe(pf->uf_func_type,
+						   cf->uf_func_type,
+						   TRUE, where);
+			// Signature must be such that no runtime checks
+			// are required. Only this compile time check.
+			if (ret == MAYBE)
+			    type_mismatch_where(pf->uf_func_type,
+						cf->uf_func_type, where);
 		    }
 		}
 	    }


### PR DESCRIPTION
Fix #15442; the issue has considerable discussion.

Enforce the spec, 4th paragraph after `:help extends`
```
*vim9class.txt*	For Vim version 9.1.  Last change: 2024 Apr 13
...
Object methods of the base class can be overruled.  The signature (arguments,
argument types and return type) must be exactly the same.
```

Note this is not related to recent issues around method dispatch, but it may be that enforcing the same signature simplifies some solutions to those issues.