### PR TITLE
Problem:  marker folds may get corrupted on undo

### DIFF
--- a/src/fold.c
+++ b/src/fold.c
@@ -1492,6 +1492,9 @@ deleteFoldRecurse(garray_T *gap)
 // foldMarkAdjust() {{{2
 /*
  * Update line numbers of folds for inserted/deleted lines.
+ *
+ * We are adjusting the folds in the range from line1 til line2,
+ * make sure that line2 does not get smaller than line1
  */
     void
 foldMarkAdjust(
@@ -1505,6 +1508,8 @@ foldMarkAdjust(
     // lines, set line2 so that only deleted lines have their folds removed.
     if (amount == MAXLNUM && line2 >= line1 && line2 - line1 >= -amount_after)
 	line2 = line1 - amount_after - 1;
+    if (line2 < line1)
+	line2 = line1;
     // If appending a line in Insert mode, it should be included in the fold
     // just above the line.
     if ((State & MODE_INSERT) && amount == (linenr_T)1 && line2 == MAXLNUM)

--- a/src/testdir/test_fold.vim
+++ b/src/testdir/test_fold.vim
@@ -1928,4 +1928,25 @@ func Test_cursor_down_fold_eob()
   bwipe!
 endfunc
 
+" issue: #15455
+func Test_cursor_fold_marker_undo()
+  new
+  call setline(1, ['{{{', '', 'This is a Line', '', 'This is a Line', '', '}}}'])
+  let &ul=&ul
+  setl foldmethod=marker
+  call cursor(2, 1)
+  norm! zo1vjdu
+  call assert_equal(1, foldlevel('.'))
+  bwipe!
+  new
+  call setline(1, ['', '{{{', '', 'This is a Line', '', 'This is a Line', '', '}}}'])
+  let &ul=&ul
+  setl foldmethod=marker
+  call cursor(3, 1)
+  norm! zo
+  norm! vjdu
+  call assert_equal(1, foldlevel('.'))
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  marker folds may get corrupted on undo
Solution: make sure, lnum2 does dot not get lower than 1