### PR TITLE
Some other options reset curswant unnecessarily when set

### DIFF
--- a/src/optiondefs.h
+++ b/src/optiondefs.h
@@ -621,13 +621,12 @@ static struct vimoption options[] =
     {"columns",	    "co",   P_NUM|P_NODEFAULT|P_NO_MKRC|P_VI_DEF|P_RCLR,
 			    (char_u *)&Columns, PV_NONE, NULL, NULL,
 			    {(char_u *)80L, (char_u *)0L} SCTX_INIT},
-    {"comments",    "com",  P_STRING|P_ALLOCED|P_VI_DEF|P_ONECOMMA
-							  |P_NODUP|P_CURSWANT,
+    {"comments",    "com",  P_STRING|P_ALLOCED|P_VI_DEF|P_ONECOMMA|P_NODUP,
 			    (char_u *)&p_com, PV_COM, did_set_comments, NULL,
 			    {(char_u *)"s1:/*,mb:*,ex:*/,://,b:#,:%,:XCOMM,n:>,fb:-",
 				(char_u *)0L}
 			    SCTX_INIT},
-    {"commentstring", "cms", P_STRING|P_ALLOCED|P_VI_DEF|P_CURSWANT,
+    {"commentstring", "cms", P_STRING|P_ALLOCED|P_VI_DEF,
 #ifdef FEAT_FOLDING
 			    (char_u *)&p_cms, PV_CMS, did_set_commentstring, NULL,
 			    {(char_u *)"/* %s */", (char_u *)0L}
@@ -801,7 +800,7 @@ static struct vimoption options[] =
     {"debug",	    NULL,   P_STRING|P_VI_DEF,
 			    (char_u *)&p_debug, PV_NONE, did_set_debug, expand_set_debug,
 			    {(char_u *)"", (char_u *)0L} SCTX_INIT},
-    {"define",	    "def",  P_STRING|P_ALLOCED|P_VI_DEF|P_CURSWANT,
+    {"define",	    "def",  P_STRING|P_ALLOCED|P_VI_DEF,
 #ifdef FEAT_FIND_ID
 			    (char_u *)&p_def, PV_DEF, NULL, NULL,
 			    {(char_u *)"^\\s*#\\s*define", (char_u *)0L}

--- a/src/testdir/test_goto.vim
+++ b/src/testdir/test_goto.vim
@@ -322,6 +322,7 @@ func Test_set_options_keep_col()
   normal j
   set invhlsearch spell spelllang=en,cjk spelloptions=camel textwidth=80
   set cursorline cursorcolumn cursorlineopt=line colorcolumn=+1 winfixbuf
+  set comments=:# commentstring=#%s define=function
   set background=dark
   set background=light
   normal k
@@ -329,6 +330,7 @@ func Test_set_options_keep_col()
   bwipe!
   set hlsearch& spell& spelllang& spelloptions& textwidth&
   set cursorline& cursorcolumn& cursorlineopt& colorcolumn& winfixbuf&
+  set comments& commentstring& define&
   set background&
 endfunc
 


### PR DESCRIPTION
Problem:  Some other options reset curswant unnecessarily when set.
Solution: Don't reset curswant when setting 'comments', 'commentstring'
          or 'define'.

fixes: #15462