### PR TITLE
python3: Defaults to Stable ABI 3.8

### DIFF
--- a/src/Make_cyg_ming.mak
+++ b/src/Make_cyg_ming.mak
@@ -391,14 +391,19 @@ endif
 #	Python3 interface:
 #	  PYTHON3=[Path to Python3 directory] (Set inside Make_cyg.mak or Make_ming.mak)
 #	  DYNAMIC_PYTHON3=yes (to load the Python3 DLL dynamically)
-#	  PYTHON3_VER=[Python3 version, eg 31, 32] (default is 36)
+#	  PYTHON3_VER=[Python3 version, eg 31, 32] (default is 38)
 ifdef PYTHON3
  ifndef DYNAMIC_PYTHON3
 DYNAMIC_PYTHON3=yes
  endif
+ ifndef DYNAMIC_PYTHON3_STABLE_ABI
+  ifeq (yes,$(DYNAMIC_PYTHON3))
+DYNAMIC_PYTHON3_STABLE_ABI=yes
+  endif
+ endif
 
  ifndef PYTHON3_VER
-PYTHON3_VER=36
+PYTHON3_VER=38
  endif
  ifeq ($(DYNAMIC_PYTHON3_STABLE_ABI),yes)
 PYTHON3_NAME=python3

--- a/src/Make_mvc.mak
+++ b/src/Make_mvc.mak
@@ -80,7 +80,7 @@
 #	Python3 interface:
 #	  PYTHON3=[Path to Python3 directory]
 #	  DYNAMIC_PYTHON3=yes (to load the Python3 DLL dynamically)
-#	  PYTHON3_VER=[Python3 version, eg 30, 31]  (default is 36)
+#	  PYTHON3_VER=[Python3 version, eg 30, 31]  (default is 38)
 #
 #	Ruby interface:
 #	  RUBY=[Path to Ruby directory]
@@ -994,8 +994,13 @@ PYTHON_LIB = "$(PYTHON)\libs\python$(PYTHON_VER).lib"
 
 # PYTHON3 interface
 !ifdef PYTHON3
+! ifndef DYNAMIC_PYTHON3_STABLE_ABI
+!  if "$(DYNAMIC_PYTHON3)" == "yes"
+DYNAMIC_PYTHON3_STABLE_ABI = yes
+!  endif
+! endif
 ! ifndef PYTHON3_VER
-PYTHON3_VER = 36
+PYTHON3_VER = 38
 ! endif
 ! if "$(DYNAMIC_PYTHON3_STABLE_ABI)" == "yes"
 PYTHON3_NAME = python3

--- a/src/auto/configure
+++ b/src/auto/configure
@@ -1575,7 +1575,7 @@ Optional Packages:
   --with-python-command=NAME  name of the Python 2 command (default: python2 or python)
   --with-python-config-dir=PATH  Python's config directory (deprecated)
   --with-python3-command=NAME  name of the Python 3 command (default: python3 or python)
-  --with-python3-stable-abi=VERSION  stable ABI version to target (e.g. 3.8)
+  --with-python3-stable-abi=VERSION  stable ABI version to target (default: 3.8)
   --with-python3-config-dir=PATH  Python's config directory (deprecated)
   --with-tclsh=PATH       which tclsh to use (default: tclsh8.0)
   --with-ruby-command=RUBY  name of the Ruby command (default: ruby)
@@ -7083,21 +7083,30 @@ printf %s "checking Python is 3.0 or better... " >&6; }
       { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yep" >&5
 printf "%s\n" "yep" >&6; }
 
-            { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking --with-python3-stable-abi argument" >&5
+            python3_stable_abi_default=3.8
+      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking --with-python3-stable-abi argument" >&5
 printf %s "checking --with-python3-stable-abi argument... " >&6; }
 
 
 # Check whether --with-python3-stable-abi was given.
 if test ${with_python3_stable_abi+y}
 then :
-  withval=$with_python3_stable_abi; vi_cv_var_python3_stable_abi="$withval"; { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $vi_cv_var_python3_stable_abi" >&5
+  withval=$with_python3_stable_abi;
+	 if test "X$withval" = "Xyes"; then
+	   vi_cv_var_python3_stable_abi=$python3_stable_abi_default
+	 else
+	   vi_cv_var_python3_stable_abi="$withval"
+	 fi
+	 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $vi_cv_var_python3_stable_abi" >&5
 printf "%s\n" "$vi_cv_var_python3_stable_abi" >&6; }
 else $as_nop
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+
+	 vi_cv_var_python3_stable_abi=$python3_stable_abi_default
+	 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no. defaults to $python3_stable_abi_default." >&5
+printf "%s\n" "no. defaults to $python3_stable_abi_default." >&6; }
 fi
 
-      if test "X$vi_cv_var_python3_stable_abi" != "X"; then
+      if test "X$vi_cv_var_python3_stable_abi" != "Xno"; then
         if test ${vi_cv_var_python3_stable_abi_hex+y}
 then :
   printf %s "(cached) " >&6

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -1539,12 +1539,21 @@ if test "$enable_python3interp" = "yes" -o "$enable_python3interp" = "dynamic"; 
       AC_MSG_RESULT(yep)
 
       dnl -- get the stable ABI version if passed in
+      python3_stable_abi_default=3.8
       AC_MSG_CHECKING(--with-python3-stable-abi argument)
       AC_SUBST(vi_cv_var_python3_stable_abi)
-      AC_ARG_WITH(python3-stable-abi, [  --with-python3-stable-abi=VERSION  stable ABI version to target (e.g. 3.8)],
-        vi_cv_var_python3_stable_abi="$withval"; AC_MSG_RESULT($vi_cv_var_python3_stable_abi),
-        AC_MSG_RESULT(no))
-      if test "X$vi_cv_var_python3_stable_abi" != "X"; then
+      AC_ARG_WITH(python3-stable-abi, [  --with-python3-stable-abi=VERSION  stable ABI version to target (default: 3.8)],
+        [
+	 if test "X$withval" = "Xyes"; then
+	   vi_cv_var_python3_stable_abi=$python3_stable_abi_default
+	 else
+	   vi_cv_var_python3_stable_abi="$withval"
+	 fi
+	 AC_MSG_RESULT($vi_cv_var_python3_stable_abi)],
+        [
+	 vi_cv_var_python3_stable_abi=$python3_stable_abi_default
+	 AC_MSG_RESULT(no. defaults to $python3_stable_abi_default.)])
+      if test "X$vi_cv_var_python3_stable_abi" != "Xno"; then
         AC_CACHE_VAL(vi_cv_var_python3_stable_abi_hex,
         [
          vi_cv_var_python3_stable_abi_hex=`


### PR DESCRIPTION
Enable Stable ABI 3.8 by default (when python3/dyn).
Also, change the default version from 3.6 to 3.8 on Windows.

See #15457