### PR TITLE
PO file conversion does not work on FreeBSD

### DIFF
--- a/src/po/Makefile
+++ b/src/po/Makefile
@@ -107,55 +107,55 @@ nb.po: no.po
 ja.sjis.po: ja.po
 	@$(MAKE) sjiscorr
 	rm -f $@
-	iconv -f UTF-8 -t CP932 $< | ./sjiscorr > $@
+	iconv -f UTF-8 -t CP932 $? | ./sjiscorr > $@
 
 sjiscorr: sjiscorr.c
 	$(CC) -o sjiscorr sjiscorr.c
 
 ja.euc-jp.po: ja.po
-	iconv -f UTF-8 -t EUC-JP $< | \
+	iconv -f UTF-8 -t EUC-JP $? | \
 		$(SED) -e 's/charset=[uU][tT][fF]-8/charset=EUC-JP/' \
-			-e 's/# Original translations/# Generated from $<, DO NOT EDIT/' \
+			-e 's/# Original translations/# Generated from $?, DO NOT EDIT/' \
 			> $@
 
 # Convert cs.po to create cs.cp1250.po.
 cs.cp1250.po: cs.po
 	rm -f $@
-	iconv -f ISO-8859-2 -t CP1250 $< | \
+	iconv -f ISO-8859-2 -t CP1250 $? | \
 		$(SED) -e 's/charset=[iI][sS][oO]-8859-2/charset=CP1250/' \
-			-e 's/# Original translations/# Generated from $<, DO NOT EDIT/' \
+			-e 's/# Original translations/# Generated from $?, DO NOT EDIT/' \
 			> $@
 
 # Convert pl.po to create pl.cp1250.po.
 pl.cp1250.po: pl.po
 	rm -f $@
-	iconv -f ISO-8859-2 -t CP1250 $< | \
+	iconv -f ISO-8859-2 -t CP1250 $? | \
 		$(SED) -e 's/charset=[iI][sS][oO]-8859-2/charset=CP1250/' \
-			-e 's/# Original translations/# Generated from $<, DO NOT EDIT/' \
+			-e 's/# Original translations/# Generated from $?, DO NOT EDIT/' \
 			> $@
 
 # Convert pl.po to create pl.UTF-8.po.
 pl.UTF-8.po: pl.po
 	rm -f $@
-	iconv -f ISO-8859-2 -t UTF-8 $< | \
+	iconv -f ISO-8859-2 -t UTF-8 $? | \
 		$(SED) -e 's/charset=[iI][sS][oO]-8859-2/charset=UTF-8/' \
-			-e 's/# Original translations/# Generated from $<, DO NOT EDIT/' \
+			-e 's/# Original translations/# Generated from $?, DO NOT EDIT/' \
 			> $@
 
 # Convert sk.po to create sk.cp1250.po.
 sk.cp1250.po: sk.po
 	rm -f $@
-	iconv -f ISO-8859-2 -t CP1250 $< | \
+	iconv -f ISO-8859-2 -t CP1250 $? | \
 		$(SED) -e 's/charset=[iI][sS][oO]-8859-2/charset=CP1250/' \
-			-e 's/# Original translations/# Generated from $<, DO NOT EDIT/' \
+			-e 's/# Original translations/# Generated from $?, DO NOT EDIT/' \
 			> $@
 
 # Convert zh_CN.UTF-8.po to create zh_CN.po.
 zh_CN.po: zh_CN.UTF-8.po
 	rm -f $@
-	iconv -f UTF-8 -t GB2312 $< | \
+	iconv -f UTF-8 -t GB2312 $? | \
 		$(SED) -e 's/charset=[uU][tT][fF]-8/charset=GB2312/' \
-			-e 's/# Original translations/# Generated from $<, DO NOT EDIT/' \
+			-e 's/# Original translations/# Generated from $?, DO NOT EDIT/' \
 			> $@
 
 # Convert zh_CN.UTF-8.po to create zh_CN.cp936.po.
@@ -163,17 +163,17 @@ zh_CN.po: zh_CN.UTF-8.po
 # This used to convert from zh_CN.po, but that results in a conversion error.
 zh_CN.cp936.po: zh_CN.UTF-8.po
 	rm -f $@
-	iconv -f UTF-8 -t CP936 $< | \
+	iconv -f UTF-8 -t CP936 $? | \
 		$(SED) -e 's/charset=[uU][tT][fF]-8/charset=GBK/' \
-			-e 's/# Original translations/# Generated from $<, DO NOT EDIT/' \
+			-e 's/# Original translations/# Generated from $?, DO NOT EDIT/' \
 			> $@
 
 # Convert zh_TW.UTF-8.po to create zh_TW.po.
 zh_TW.po: zh_TW.UTF-8.po
 	rm -f $@
-	iconv -f UTF-8 -t BIG5 $< | \
+	iconv -f UTF-8 -t BIG5 $? | \
 		$(SED) -e 's/charset=[uU][tT][fF]-8/charset=BIG5/' \
-			-e 's/# Original translations/# Generated from $<, DO NOT EDIT/' \
+			-e 's/# Original translations/# Generated from $?, DO NOT EDIT/' \
 			> $@
 
 
@@ -197,7 +197,7 @@ zh_TW.po: zh_TW.UTF-8.po
 #zh_TW.po: zh_TW.UTF-8.po
 #	@$(MAKE) big5corr
 #	rm -f $@
-#	iconv -f UTF-8 -t BIG5 $< | ./big5corr > $@
+#	iconv -f UTF-8 -t BIG5 $? | ./big5corr > $@
 
 
 # 06.11.23, added by Restorer
@@ -209,25 +209,25 @@ zh_TW.po: zh_TW.UTF-8.po
 # Convert ko.UTF-8.po to create ko.po.
 ko.po: ko.UTF-8.po
 	rm -f $@
-	iconv -f UTF-8 -t EUC-KR $< | \
+	iconv -f UTF-8 -t EUC-KR $? | \
 		$(SED) -e 's/charset=[uU][tT][fF]-8/charset=EUC-KR/' \
-			-e 's/# Original translations/# Generated from $<, DO NOT EDIT/' \
+			-e 's/# Original translations/# Generated from $?, DO NOT EDIT/' \
 			> $@
 
 # Convert ru.po to create ru.cp1251.po.
 ru.cp1251.po: ru.po
 	rm -f $@
-	iconv -f UTF-8 -t CP1251 $< | \
+	iconv -f UTF-8 -t CP1251 $? | \
 		$(SED) -e 's/charset=[uU][tT][fF]-8/charset=CP1251/' \
-			-e 's/# Original translations/# Generated from $<, DO NOT EDIT/' \
+			-e 's/# Original translations/# Generated from $?, DO NOT EDIT/' \
 			> $@
 
 # Convert uk.po to create uk.cp1251.po.
 uk.cp1251.po: uk.po
 	rm -f $@
-	iconv -f UTF-8 -t CP1251 $< | \
+	iconv -f UTF-8 -t CP1251 $? | \
 		$(SED) -e 's/charset=[uU][tT][fF]-8/charset=CP1251/' \
-			-e 's/# Original translations/# Generated from $<, DO NOT EDIT/' \
+			-e 's/# Original translations/# Generated from $?, DO NOT EDIT/' \
 			> $@
 
 prefixcheck:
@@ -329,6 +329,6 @@ $(PLUGPACKAGE).pot: $(PO_PLUG_INPUTLIST)
 # Converting the PO file of the plug-in package to the binary format of the MO
 MO_PLUGPACKAGE_PATH = $(PWD)
 $(PLUGPACKAGE).mo: $(PO_PLUGPACKAGE)
-	$(MSGFMTCMD) -o $(MO_PLUGPACKAGE_PATH)/$@ $<
+	$(MSGFMTCMD) -o $(MO_PLUGPACKAGE_PATH)/$@ $?
 
 # vim: set noet sw=8 ts=8 sts=0 wm=0 tw=0 ft=make:


### PR DESCRIPTION
Problem: PO file conversion does not work on FreeBSD.
Solution: In the file conversion rules, change the `$<` variable to `$?`.
This is a portable variable, unrecognizable by both GNU make and BSD make.

FreeBSD:
>.OODATE   The  list  of  sources for this target that were deemed out-of-date; also known as `?'.

GNU:
> $? The names of all the prerequisites that are newer than the target, with spaces between them. If the target does not exist, all prerequisites will be included.