### PR TITLE
runtime(sql, mysql): fix E169: Command too recursive when `let g:sql_type_default = "mysql"`

### DIFF
--- a/runtime/ftplugin/mysql.vim
+++ b/runtime/ftplugin/mysql.vim
@@ -1,1 +1,9 @@
+" Vim filetype plugin
+" Language:	MySQL
+" Maintainer:	Riley Bruins <ribru17@gmail.com>
+" Last Change:	2024 Aug 12
+if exists("b:did_ftplugin")
+  finish
+endif
+
 runtime ftplugin/sql.vim

--- a/runtime/ftplugin/sql.vim
+++ b/runtime/ftplugin/sql.vim
@@ -92,12 +92,18 @@
 " Only do this when not done yet for this buffer
 " This ftplugin can be used with other ftplugins.  So ensure loading
 " happens if all elements of this plugin have not yet loaded.
-if exists("b:did_ftplugin") && exists("b:current_ftplugin") && b:current_ftplugin == 'sql'
+if exists("b:did_ftplugin")
     finish
 endif
 
+" Don't load another plugin for this buffer
+let b:did_ftplugin = 1
+
 let s:save_cpo = &cpo
 set cpo&vim
+
+let b:undo_ftplugin = "setl comments< commentstring< formatoptions< define< omnifunc<" .
+            \ " | unlet! b:browsefilter b:match_words"
 
 " Disable autowrapping for code, but enable for comments
 " t     Auto-wrap text using textwidth
@@ -262,19 +268,6 @@ elseif exists("g:sql_type_default")
         "     echomsg 'ftplugin/'.g:sql_type_default.'.vim not exist, using default'
     endif
 endif
-
-" If the above runtime command succeeded, do not load the default settings
-" as they should have already been loaded from a previous run.
-if exists("b:did_ftplugin") && exists("b:current_ftplugin") && b:current_ftplugin == 'sql'
-    finish
-endif
-
-let b:undo_ftplugin = "setl comments< commentstring< formatoptions< define< omnifunc<" .
-            \ " | unlet! b:browsefilter b:match_words"
-
-" Don't load another plugin for this buffer
-let b:did_ftplugin     = 1
-let b:current_ftplugin = 'sql'
 
 " Win32 and GTK can filter files in the browse dialog
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")


### PR DESCRIPTION
Problem: When setting `let g:sql_type_default = "mysql", editing .sql
file reports `E169: Command too recursive` error

Solution:

- Add `let b:did_ftplugin = 1` at the top of ftplugin/sql.vim
- Add  `if exists("b:did_ftplugin") | finish | endif` in ftplugin/mysql.vim
- Remove redundant code in ftplugin/sql.vim

fixes: #15474