### PR TITLE
runtime(syntax-tests): Facilitate the viewing of rendered screendumps

### DIFF
--- a/Filelist
+++ b/Filelist
@@ -836,6 +836,7 @@ RT_SCRIPTS =	\
 		runtime/syntax/Makefile \
 		runtime/syntax/testdir/README.txt \
 		runtime/syntax/testdir/runtest.vim \
+		runtime/syntax/testdir/viewdumps.vim \
 		runtime/syntax/testdir/ftplugin/*.* \
 		runtime/syntax/testdir/input/*.* \
 		runtime/syntax/testdir/input/selftestdir/* \

--- a/runtime/syntax/testdir/README.txt
+++ b/runtime/syntax/testdir/README.txt
@@ -124,6 +124,31 @@ verify that the tests fail.  Then you know your changes are covered by the
 test.
 
 
+Viewing generated screendumps
+-----------------------------
+
+You may also wish to look at the whole batch of failed screendumps after
+running "make test".  Source the "viewdumps.vim" script for this task:
+
+	[VIMRUNTIME=../..] \
+	../../src/vim --clean -S testdir/viewdumps.vim \
+				[testdir/dumps/java_*.dump ...]
+
+By default, all screendumps found in the "failed" directory will be added to
+the argument list and then the first one will be loaded.  Loaded screendumps
+that bear filenames of screendumps found in the "dumps" directory will be
+rendering the contents of any such pair of files and the difference between
+them (:help term_dumpdiff()); otherwise, they will be rendering own contents
+(:help term_dumpload()).  Remember to execute :edit when occasionally you see
+raw file contents instead of rendered.
+
+At any time, you can add, list, and abandon other screendumps:
+
+	:$argedit testdir/dumps/java_*.dump
+	:args
+	:qall
+
+The listing of argument commands can be found under :help buffer-list.
 
 
 TODO: run test for one specific filetype

--- a/runtime/syntax/testdir/runtest.vim
+++ b/runtime/syntax/testdir/runtest.vim
@@ -409,6 +409,12 @@ func RunTest()
   call Message('OK: ' .. ok_count)
   call Message('FAILED: ' .. len(failed_tests) .. ': ' .. string(failed_tests))
   call Message('skipped: ' .. skipped_count)
+
+  if !empty(failed_tests)
+    call Message('')
+    call Message('View generated screendumps with "../../src/vim --clean -S testdir/viewdumps.vim"')
+  endif
+
   call AppendMessages('== SUMMARY ==')
 
   if len(failed_tests) > 0

--- a/runtime/syntax/testdir/runtest.vim
+++ b/runtime/syntax/testdir/runtest.vim
@@ -118,7 +118,7 @@ func RunTest()
 
   if exists("$VIM_SYNTAX_SELF_TESTING")
     let dirpath = 'input/selftestdir/'
-    let fnames = readdir(dirpath, {fname -> fname !~ '^README.txt$'})
+    let fnames = readdir(dirpath, {fname -> fname !~ '^README\.txt$'})
   else
     let dirpath = 'input/'
     let fnames = readdir(dirpath, {fname -> fname !~ '\~$' && fname =~ '^.\+\..\+$'})

--- a/runtime/syntax/testdir/viewdumps.vim
+++ b/runtime/syntax/testdir/viewdumps.vim
@@ -1,0 +1,77 @@
+vim9script
+
+# Support sourcing this script from this directory or any other directory in
+# the direct path that leads to the project's root directory.
+const failed_path: string = finddir('failed', getcwd() .. '/**', -1)
+  ->filter(((cwdpath: string) => (_: number, dirpath: string) =>
+	cwdpath =~ '\<syntax\>' || dirpath =~ '\<syntax\>')(getcwd()))
+  ->get(-1, '') .. '/'
+var error: string = null_string
+
+if failed_path == '/'
+  error = 'No such directory: "failed"'
+else
+  const failed_fnames: string = failed_path .. readdir(failed_path,
+	  (fname: string) => fname =~ '^.\+\.dump$')
+    ->join(' ' .. failed_path)
+
+  if failed_fnames =~ 'failed/$'
+    error = 'No such file: "*.dump"'
+  else
+    exec ':0argedit ' .. failed_fnames
+    buffers
+  endif
+endif
+
+def Render()
+  const failed_fname: string = bufname()
+  try
+    setlocal suffixesadd=.dump
+    const dumps_fname: string = findfile(
+			fnamemodify(failed_fname, ':p:t'),
+			fnamemodify(failed_fname, ':p:h:h') .. '/dumps')
+    if filereadable(dumps_fname)
+      term_dumpdiff(failed_fname, dumps_fname)
+    else
+      term_dumpload(failed_fname)
+    endif
+  finally
+    exec 'bwipeout ' .. failed_fname
+  endtry
+enddef
+
+# THE FOLLOWING SETTINGS PERTAIN TO "input/" FILES THAT ARE LIKELY TO BE
+# LOADED SIDE BY SIDE WHENEVER BATCHES OF NEW SCREENDUMPS ARE GENERATED.
+
+# Match "LC_ALL=C" of Makefile.
+language C
+
+# Match the settings from term_util.vim#RunVimInTerminal().
+set t_Co=256 background=light
+hi Normal ctermfg=NONE ctermbg=NONE
+
+# Match the settings from runtest.vim#Xtestscript#SetUpVim().
+set display=lastline ruler scrolloff=5 t_ZH= t_ZR=
+
+# Anticipate non-Latin-1 characters in "input/" files.
+set encoding=utf-8 termencoding=utf-8
+
+autocmd_add([{
+  replace:	true,
+  group:	'viewdumps',
+  event:	'BufRead',
+  pattern:	'*.dump',
+  cmd:		'Render()',
+}])
+
+# Unconditionally help, in case a list of filenames is passed to the command,
+# the first terminal window with its BufRead event.
+silent doautocmd viewdumps BufRead
+
+if error != null_string
+  # Instead of sleeping, fill half a window with blanks and prompt hit-enter.
+  echom error .. repeat("\x20", (winwidth(0) * (winheight(0) / 2) - strlen(error)))
+  error = null_string
+endif
+
+# vim:fdm=syntax:sw=2:ts=8:noet:nolist:nosta:


### PR DESCRIPTION
With the submitted `viewdumps.vim` script, a few manual  
steps in typical workflows (see below) can be automated.  
The updated `README.txt` contains additional information.


------------------------------------------------------------

Reviewing LOCAL failed syntax tests can be arranged as  
follows:

1) Run tests and generate screendumps:

```shell
cd /path/to/fork/runtime/syntax
make clean test
```

2) Examine the screendumps from the `failed` directory:

```shell
../../src/vim --clean -S testdir/viewdumps.vim
```


------------------------------------------------------------

Reviewing UPLOADED failed syntax tests can be arranged as  
follows (it can be further locally scripted):

1) Fetch an artifact with failed screendumps from
`github.com/vim/vim/actions/runs/A_ID/artifacts/B_ID`.

2) Extract the archived files:

```shell
unzip /tmp/failed-tests.zip -d /tmp
```

3) Set up the `dumps` directory.  Create a symlink to  
`/path/to/fork/dirs/dumps` in the extracted directories so  
that `term_dumpdiff()` can be used.  (The lookup algorithm  
resolves `dumps` for every loaded filename.  So, with  
`/tmp/runtime/syntax/testdir/failed/*.dump` files passed  
as script arguments, the algorithm will make the files in  
`/tmp/runtime/syntax/testdir/dumps` queried.)

```shell
cd /path/to/fork
ln -s $(pwd)/runtime/syntax/testdir/dumps \
  /tmp/runtime/syntax/testdir/dumps
```

4) Examine the extracted screendumps:

```shell
./src/vim --clean -S runtime/syntax/testdir/viewdumps.vim \
  /tmp/runtime/syntax/testdir/failed/*.dump
```

5) Clean up:

```shell
unlink /tmp/runtime/syntax/testdir/dumps
rm -rf /tmp/runtime
```


------------------------------------------------------------

Reviewing SUBMITTED FOR PULL REQUEST syntax tests can be  
arranged as follows (it can be further locally scripted):

1) List the fetched changeset and write the changed `dumps`  
filenames to `/tmp/filelist`:

```shell
cd /path/to/fork
git switch prs/1234
git diff-index --relative=runtime/syntax/testdir/dumps/ \
  --name-only prs/1234~1 > /tmp/filelist
```

2) Reconcile relative filepaths, and copy next-to-be-updated  
`dumps` files in the `failed` directory (note the missing  
new screendumps, if any):

```shell
git switch master
cd runtime/syntax/testdir/dumps
cp -t ../failed $(cat /tmp/filelist)
```

3) Remember about the introduced INVERTED relation between  
`dumps` and `failed`, i.e. the files to be committed are in  
`dumps` already and their previous versions are in `failed`;  
therefore, copy the missing new screendumps from `dumps` to  
`failed` (otherwise these won't be shown):

```shell
git switch prs/1234
cp -t ../failed foo_10.dump foo_11.dump foo_12.dump
```

4) Examine the screendumps from the `failed` directory (new  
screendumps will be shown with no difference between their  
versions):

```shell
cd ..
../../../src/vim --clean -S viewdumps.vim
```
