### PR TITLE
Function dispatch problems when using super.

### DIFF
--- a/src/proto/vim9instr.pro
+++ b/src/proto/vim9instr.pro
@@ -58,7 +58,7 @@ int check_internal_func_args(cctx_T *cctx, int func_idx, int argcount, int metho
 int generate_BCALL(cctx_T *cctx, int func_idx, int argcount, int method_call);
 int generate_LISTAPPEND(cctx_T *cctx);
 int generate_BLOBAPPEND(cctx_T *cctx);
-int generate_CALL(cctx_T *cctx, ufunc_T *ufunc, class_T *cl, int mi, int pushed_argcount);
+int generate_CALL(cctx_T *cctx, ufunc_T *ufunc, class_T *cl, int mi, int pushed_argcount, int is_super);
 int generate_UCALL(cctx_T *cctx, char_u *name, int argcount);
 int check_func_args_from_type(cctx_T *cctx, type_T *type, int argcount, int at_top, char_u *name);
 int generate_PCALL(cctx_T *cctx, int argcount, char_u *name, type_T *type, int at_top);

--- a/src/vim9.h
+++ b/src/vim9.h
@@ -238,8 +238,9 @@ typedef struct {
 // arguments to ISN_METHODCALL
 typedef struct {
     class_T *cmf_itf;	    // interface used
-    int	    cmf_idx;	    // index in "def_functions" for ISN_DCALL
+    int	    cmf_idx;	    // index in "def_functions" for ISN_METHODCALL
     int	    cmf_argcount;   // number of arguments on top of stack
+    int	    cmf_is_super;   // doing "super.Func", use cmf_itf, not cmf_idx
 } cmfunc_T;
 
 // arguments to ISN_PCALL

--- a/src/vim9execute.c
+++ b/src/vim9execute.c
@@ -4400,14 +4400,23 @@ exec_instructions(ectx_T *ectx)
 			goto on_error;
 		    }
 
-		    class_T *cl = obj->obj_class;
+		    ufunc_T *ufunc;
+		    if (mfunc->cmf_is_super)
+			// Doing "super.Func", use the specific ufunc.
+			ufunc = mfunc->cmf_itf->class_obj_methods[
+							    mfunc->cmf_idx];
+		    else
+		    {
+			class_T *cl = obj->obj_class;
 
-		    // convert the interface index to the object index
-		    int idx = object_index_from_itf_index(mfunc->cmf_itf,
-						    TRUE, mfunc->cmf_idx, cl);
+			// convert the interface index to the object index
+			int idx = object_index_from_itf_index(mfunc->cmf_itf,
+						     TRUE, mfunc->cmf_idx, cl);
+			ufunc = cl->class_obj_methods[idx];
+		    }
 
-		    if (call_ufunc(cl->class_obj_methods[idx], NULL,
-				mfunc->cmf_argcount, ectx, NULL, NULL) == FAIL)
+		    if (call_ufunc(ufunc, NULL, mfunc->cmf_argcount, ectx,
+							   NULL, NULL) == FAIL)
 			goto on_error;
 		}
 		break;

--- a/src/vim9instr.c
+++ b/src/vim9instr.c
@@ -1805,6 +1805,8 @@ generate_BLOBAPPEND(cctx_T *cctx)
  * Generate an ISN_DCALL, ISN_UCALL or ISN_METHODCALL instruction.
  * When calling a method on an object, of which we know the interface only,
  * then "cl" is the interface and "mi" the method index on the interface.
+ * save is_super in the "isn->isn_arg"; it flags execution to use mfunc
+ * directly to determine ufunc.
  * Return FAIL if the number of arguments is wrong.
  */
     int
@@ -1813,7 +1815,8 @@ generate_CALL(
 	ufunc_T	    *ufunc,
 	class_T	    *cl,
 	int	    mi,
-	int	    pushed_argcount)
+	int	    pushed_argcount,
+	int	    is_super)
 {
     isn_T	*isn;
     int		regular_args = ufunc->uf_args.ga_len;
@@ -1898,6 +1901,7 @@ generate_CALL(
 	++cl->class_refcount;
 	isn->isn_arg.mfunc->cmf_idx = mi;
 	isn->isn_arg.mfunc->cmf_argcount = argcount;
+	isn->isn_arg.mfunc->cmf_is_super = is_super;
     }
     else if (isn->isn_type == ISN_DCALL)
     {


### PR DESCRIPTION
Fix #15448 and #15463: (2) super.method may not execute in context of defining class

When compiling "super.Func()" force class context to class that defines function that is doing "super.Func()".
ISN_METHODCALL arg "cmf_is_super" for specific ufunc.