### PR TITLE
runtime(mediawiki): fix typos

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -2374,7 +2374,7 @@ have the following in your .vimrc: >
 
 MEDIAWIKI					*ft-mediawiki-syntax*
 
-Be default, syntax highlighting includes basic HTML tags like style and
+By default, syntax highlighting includes basic HTML tags like style and
 headers |html.vim|. For strict Mediawiki syntax highlighting: >
 
 	let g:html_no_rendering = 1

--- a/runtime/ftplugin/mediawiki.vim
+++ b/runtime/ftplugin/mediawiki.vim
@@ -8,7 +8,7 @@
 if exists("b:did_ftplugin")
   finish
 endif
-let g:did_ftplugin = 1
+let b:did_ftplugin = 1
 
 " Many MediaWiki wikis prefer line breaks only at the end of paragraphs
 " (like in a text processor), which results in long, wrapping lines.


### PR DESCRIPTION
Fixed `did_ftplugin` variable from global to buffer.

Also I think the meaning of `g:html_style_rendering` variable is reversed. I think it was meant `if exists("html_style_rendering")`.

Also maybe variables should be named with mediawiki perfix like `g:mediawiki_no_html_rendering` and `g:mediawiki_style_rendering` (no html here because it affects `''italic''` too).

@avidseeker