### PR TITLE
runtime(javascript): Fix syntax highlighting issues

### DIFF
--- a/runtime/syntax/javascript.vim
+++ b/runtime/syntax/javascript.vim
@@ -110,7 +110,7 @@ hi def link javaScriptBranch		Conditional
 hi def link javaScriptOperator		Operator
 hi def link javaScriptType			Type
 hi def link javaScriptStatement		Statement
-hi def link javaScriptFunction		Function
+hi def link javaScriptFunction		Keyword
 hi def link javaScriptBraces		Function
 hi def link javaScriptError		Error
 hi def link javaScrParenError		javaScriptError

--- a/runtime/syntax/javascript.vim
+++ b/runtime/syntax/javascript.vim
@@ -66,7 +66,8 @@ syn keyword javaScriptMessage		alert confirm prompt status
 syn keyword javaScriptGlobal		self window top parent
 syn keyword javaScriptMember		document event location 
 syn keyword javaScriptDeprecated	escape unescape
-syn keyword javaScriptReserved		abstract boolean byte char class const debugger double enum export extends final float from goto implements import int interface let long native package private protected public short static super synchronized throws transient var volatile async
+syn keyword javaScriptReserved		abstract boolean byte char class const debugger double enum export extends final float from goto implements import int interface let long native package private protected public short super synchronized throws transient var volatile async
+syn keyword javaScriptModifier  static
 
 syn cluster  javaScriptEmbededExpr	contains=javaScriptBoolean,javaScriptNull,javaScriptIdentifier,javaScriptStringD,javaScriptStringS,javaScriptStringT
 
@@ -126,6 +127,7 @@ hi def link javaScriptGlobal		Keyword
 hi def link javaScriptMember		Keyword
 hi def link javaScriptDeprecated		Exception 
 hi def link javaScriptReserved		Keyword
+hi def link javaScriptModifier		StorageClass
 hi def link javaScriptDebug		Debug
 hi def link javaScriptConstant		Label
 hi def link javaScriptEmbed		Special

--- a/runtime/syntax/javascript.vim
+++ b/runtime/syntax/javascript.vim
@@ -66,7 +66,7 @@ syn keyword javaScriptMessage		alert confirm prompt status
 syn keyword javaScriptGlobal		self window top parent
 syn keyword javaScriptMember		document event location 
 syn keyword javaScriptDeprecated	escape unescape
-syn keyword javaScriptReserved		abstract boolean byte char class const debugger double enum export extends final float goto implements import int interface let long native package private protected public short static super synchronized throws transient var volatile async
+syn keyword javaScriptReserved		abstract boolean byte char class const debugger double enum export extends final float from goto implements import int interface let long native package private protected public short static super synchronized throws transient var volatile async
 
 syn cluster  javaScriptEmbededExpr	contains=javaScriptBoolean,javaScriptNull,javaScriptIdentifier,javaScriptStringD,javaScriptStringS,javaScriptStringT
 

--- a/runtime/syntax/javascript.vim
+++ b/runtime/syntax/javascript.vim
@@ -59,14 +59,14 @@ syn keyword javaScriptType		Array Boolean Date Function Number Object String Reg
 syn keyword javaScriptStatement		return with await yield
 syn keyword javaScriptBoolean		true false
 syn keyword javaScriptNull		null undefined
-syn keyword javaScriptIdentifier	arguments this var let
+syn keyword javaScriptIdentifier	arguments this
 syn keyword javaScriptLabel		case default
 syn keyword javaScriptException		try catch finally throw
 syn keyword javaScriptMessage		alert confirm prompt status
 syn keyword javaScriptGlobal		self window top parent
 syn keyword javaScriptMember		document event location 
 syn keyword javaScriptDeprecated	escape unescape
-syn keyword javaScriptReserved		abstract boolean byte char class const debugger double enum export extends final float goto implements import int interface long native package private protected public short static super synchronized throws transient volatile async
+syn keyword javaScriptReserved		abstract boolean byte char class const debugger double enum export extends final float goto implements import int interface let long native package private protected public short static super synchronized throws transient var volatile async
 
 syn cluster  javaScriptEmbededExpr	contains=javaScriptBoolean,javaScriptNull,javaScriptIdentifier,javaScriptStringD,javaScriptStringS,javaScriptStringT
 


### PR DESCRIPTION
This provides more consistent highlighting of certain Javascript keywords in line with the docs about default capture groups.

See: https://vimdoc.sourceforge.net/htmldoc/syntax.html