### PR TITLE
runtime(doc): Updated man pages

### DIFF
--- a/runtime/doc/evim.1
+++ b/runtime/doc/evim.1
@@ -1,4 +1,4 @@
-.TH EVIM 1 "2002 February 16"
+.TH EVIM 1 "2024 August 12"
 .SH NAME
 evim \- easy Vim, edit a file with Vim and setup for modeless editing
 .SH SYNOPSIS
@@ -34,8 +34,12 @@ Use CTRL-Q to obtain the original meaning of CTRL-V.
 See vim(1).
 .SH FILES
 .TP 15
-/usr/local/lib/vim/evim.vim
+/usr/local/share/vim/vim??/evim.vim
 The script loaded to initialize eVim.
+.br
+.I vim??
+is short version number, like vim91 for
+.B Vim 9.1
 .SH AKA
 Also Known As "Vim for gumbies".
 When using evim you are expected to take a handkerchief,

--- a/runtime/doc/evim.man
+++ b/runtime/doc/evim.man
@@ -1,4 +1,4 @@
-EVIM(1)                                                                EVIM(1)
+EVIM(1)                     General Commands Manual                    EVIM(1)
 
 
 
@@ -10,7 +10,7 @@ SYNOPSIS
        eview
 
 DESCRIPTION
-       eVim starts Vim and sets options to make it behave like a modeless edi-
+       eVim starts Vim and sets options to make it behave like a modeless edi‐
        tor.  This is still Vim but used as  a  point-and-click  editor.   This
        feels  a lot like using Notepad on MS-Windows.  eVim will always run in
        the GUI, to enable the use of menus and toolbar.
@@ -32,8 +32,9 @@ OPTIONS
        See vim(1).
 
 FILES
-       /usr/local/lib/vim/evim.vim
+       /usr/local/share/vim/vim??/evim.vim
                       The script loaded to initialize eVim.
+                      vim??  is short version number, like vim91 for Vim 9.1
 
 AKA
        Also Known As "Vim for gumbies".  When using evim you are  expected  to
@@ -49,4 +50,4 @@ AUTHOR
 
 
 
-                               2002 February 16                        EVIM(1)
+                                2024 August 12                         EVIM(1)

--- a/runtime/doc/vim.1
+++ b/runtime/doc/vim.1
@@ -1,4 +1,4 @@
-.TH VIM 1 "2024 Aug 03"
+.TH VIM 1 "2024 Aug 12"
 .SH NAME
 vim \- Vi IMproved, a programmer's text editor
 .SH SYNOPSIS
@@ -150,18 +150,6 @@ Example: vim "+set si" main.c
 .br
 Note: You can use up to 10 "+" or "\-c" commands.
 .TP
-\-S {file}
-{file} will be sourced after the first file has been read.
-This is equivalent to \-c "source {file}".
-{file} cannot start with '\-'.
-If {file} is omitted "Session.vim" is used (only works when \-S is the last
-argument).
-.TP
-\-\-cmd {command}
-Like using "\-c", but the command is executed just before
-processing any vimrc file.
-You can use up to 10 of these commands, independently from "\-c" commands.
-.TP
 \-A
 If
 .B Vim
@@ -224,11 +212,6 @@ is executed by a program that will wait for the edit
 session to finish (e.g. mail).
 On the Amiga the ":sh" and ":!" commands will not work.
 .TP
-\-\-nofork
-Foreground.  For the GUI version,
-.B Vim
-will not fork and detach from the shell it was started in.
-.TP
 \-F
 If
 .B Vim
@@ -239,6 +222,8 @@ in Farsi mode, i.e. 'fkmap' and 'rightleft' are set.
 Otherwise an error message is given and
 .B Vim
 aborts.
+.br
+Note: Farsi support has been removed in patch 8.1.0932.
 .TP
 \-g
 If
@@ -247,18 +232,6 @@ has been compiled with GUI support, this option enables the GUI.
 If no GUI support was compiled in, an error message is given and
 .B Vim
 aborts.
-.TP
-\-\-gui-dialog-file {name}
-When using the GUI, instead of showing a dialog, write the title and message of
-the dialog to file {name}.  The file is created or appended to.  Only useful
-for testing, to avoid that the test gets stuck on a dialog that can't be seen.
-Without the GUI the argument is ignored.
-.TP
-\-\-help, \-h, \-?
-Give a bit of help about the command line arguments and options.
-After this
-.B Vim
-exits.
 .TP
 \-H
 If
@@ -277,12 +250,12 @@ instead of the default "~/.viminfo".
 This can also be used to skip the use of the .viminfo file, by giving the name
 "NONE".
 .TP
-\-L
-Same as \-r.
-.TP
 \-l
 Lisp mode.
 Sets the 'lisp' and 'showmatch' options on.
+.TP
+\-L
+Same as \-r.
 .TP
 \-m
 Modifying files is disabled.
@@ -294,19 +267,19 @@ Modifications not allowed.  The 'modifiable' and 'write' options will be unset,
 so that changes are not allowed and files can not be written.  Note that these
 options can be set to enable making modifications.
 .TP
-\-N
-No-compatible mode.  Resets the 'compatible' option.
-This will make
-.B Vim
-behave a bit better, but less Vi compatible, even though a .vimrc file does
-not exist.
-.TP
 \-n
 No swap file will be used.
 Recovery after a crash will be impossible.
 Handy if you want to edit a file on a very slow medium (e.g. floppy).
 Can also be done with ":set uc=0".
 Can be undone with ":set uc=200".
+.TP
+\-N
+No-compatible mode.  Resets the 'compatible' option.
+This will make
+.B Vim
+behave a bit better, but less Vi compatible, even though a .vimrc file does
+not exist.
 .TP
 \-nb
 Become an editor server for NetBeans.  See the docs for details.
@@ -330,6 +303,16 @@ the window title of the parent application.  Make sure that it is specific
 enough. Note that the implementation is still primitive.  It won't work with
 all applications and the menu doesn't work.
 .TP
+\-r
+List swap files, with information about using them for recovery.
+.TP
+\-r {file}
+Recovery mode.
+The swap file is used to recover a crashed editing session.
+The swap file is a file with the same filename as the text file with ".swp"
+appended.
+See ":help recovery".
+.TP
 \-R
 Read-only mode.
 The 'readonly' option will be set.
@@ -340,16 +323,6 @@ as in ":w!".
 The \-R option also implies the \-n option (see above).
 The 'readonly' option can be reset with ":set noro".
 See ":help 'readonly'".
-.TP
-\-r
-List swap files, with information about using them for recovery.
-.TP
-\-r {file}
-Recovery mode.
-The swap file is used to recover a crashed editing session.
-The swap file is a file with the same filename as the text file with ".swp"
-appended.
-See ":help recovery".
 .TP
 \-s
 Silent mode.  Only when started as "Ex" or when the "\-e" option was given
@@ -362,6 +335,13 @@ The same can be done with the command ":source! {scriptin}".
 If the end of the file is reached before the editor exits, further characters
 are read from the keyboard.
 .TP
+\-S {file}
+{file} will be sourced after the first file has been read.
+This is equivalent to \-c "source {file}".
+{file} cannot start with '\-'.
+If {file} is omitted "Session.vim" is used (only works when \-S is the last
+argument).
+.TP
 \-T {terminal}
 Tells
 .B Vim
@@ -370,16 +350,6 @@ Only required when the automatic way doesn't work.
 Should be a terminal known to
 .B Vim
 (builtin) or defined in the termcap or terminfo file.
-.TP
-\-\-not-a-term
-Tells
-.B Vim
-that the user knows that the input and/or output is not connected to a
-terminal.  This will avoid the warning and the two second delay that would
-happen.
-.TP
-\-\-ttyfail
-When stdin or stdout is not a a terminal (tty) then exit right away.
 .TP
 \-u {vimrc}
 Use the commands in the file {vimrc} for initializations.
@@ -394,6 +364,12 @@ All the other GUI initializations are skipped.
 It can also be used to skip all GUI initializations by giving the name "NONE".
 See ":help gui\-init" within vim for more details.
 .TP
+\-v
+Start
+.B Vim
+in Vi mode, just like the executable was called "vi".  This only has effect
+when the executable is called "ex".
+.TP
 \-V[N]
 Verbose.  Give messages about which files are sourced and for reading and
 writing a viminfo file.  The optional number N is the value for 'verbose'.
@@ -403,20 +379,6 @@ Default is 10.
 Like \-V and set 'verbosefile' to {filename}.  The result is that messages are
 not displayed but written to the file {filename}.  {filename} must not start
 with a digit.
-.TP
-\-\-log {filename}
-If
-.B Vim
-has been compiled with eval and channel feature, start logging and write
-entries to {filename}. This works like calling
-.I ch_logfile({filename}, 'ao')
-very early during startup.
-.TP
-\-v
-Start
-.B Vim
-in Vi mode, just like the executable was called "vi".  This only has effect
-when the executable is called "ex".
 .TP
 \-w{number}
 Set the 'window' option to {number}.
@@ -462,15 +424,52 @@ This can be used to edit a filename that starts with a '\-'.
 Do not use any personal configuration (vimrc, plugins, etc.).  Useful to see if
 a problem reproduces with a clean Vim setup.
 .TP
+\-\-cmd {command}
+Like using "\-c", but the command is executed just before
+processing any vimrc file.
+You can use up to 10 of these commands, independently from "\-c" commands.
+.TP
 \-\-echo\-wid
 GTK GUI only: Echo the Window ID on stdout.
+.TP
+\-\-gui\-dialog\-file {name}
+When using the GUI, instead of showing a dialog, write the title and message of
+the dialog to file {name}.  The file is created or appended to.  Only useful
+for testing, to avoid that the test gets stuck on a dialog that can't be seen.
+Without the GUI the argument is ignored.
+.TP
+\-\-help, \-h, \-?
+Give a bit of help about the command line arguments and options.
+After this
+.B Vim
+exits.
 .TP
 \-\-literal
 Take file name arguments literally, do not expand wildcards.  This has no
 effect on Unix where the shell expands wildcards.
 .TP
+\-\-log {filename}
+If
+.B Vim
+has been compiled with eval and channel feature, start logging and write
+entries to {filename}. This works like calling
+.I ch_logfile({filename}, 'ao')
+very early during startup.
+.TP
+\-\-nofork
+Foreground.  For the GUI version,
+.B Vim
+will not fork and detach from the shell it was started in.
+.TP
 \-\-noplugin
 Skip loading plugins.  Implied by \-u NONE.
+.TP
+\-\-not\-a\-term
+Tells
+.B Vim
+that the user knows that the input and/or output is not connected to a
+terminal.  This will avoid the warning and the two second delay that would
+happen.
 .TP
 \-\-remote
 Connect to a Vim server and make it edit the files given in the rest of the
@@ -500,16 +499,19 @@ Use {name} as the server name.  Used for the current Vim, unless used with a
 \-\-remote argument, then it's the name of the server to connect to.
 .TP
 \-\-socketid {id}
-GTK GUI only: Use the GtkPlug mechanism to run gvim in another window.
+GTK GUI only: Use the GtkPlug mechanism to run gVim in another window.
 .TP
 \-\-startuptime {file}
 During startup write timing messages to the file {fname}.
+.TP
+\-\-ttyfail
+When stdin or stdout is not a a terminal (tty) then exit right away.
 .TP
 \-\-version
 Print version information and exit.
 .TP
 \-\-windowid {id}
-Win32 GUI only: Make gvim try to use the window {id} as a parent, so that it
+Win32 GUI only: Make gVim try to use the window {id} as a parent, so that it
 runs inside that window.
 .SH ON-LINE HELP
 Type ":help" in
@@ -557,13 +559,16 @@ initializations (first one found is used).
 System wide gvim initializations.
 .TP
 ~/.gvimrc, ~/.vim/gvimrc, $XDG_CONFIG_HOME/vim/gvimrc
-Your personal gvim initializations (first one found is used).
+Your personal 
+.B gVim
+initializations (first one found is used).
 .TP
 /usr/local/share/vim/vim??/optwin.vim
 Script used for the ":options" command, a nice way to view and set options.
 .TP
 /usr/local/share/vim/vim??/menu.vim
-System wide menu initializations for gvim.
+System wide menu initializations for 
+.B gVim.
 .TP
 /usr/local/share/vim/vim??/bugreport.vim
 Script to generate a bug report.  See ":help bugs".

--- a/runtime/doc/vim.man
+++ b/runtime/doc/vim.man
@@ -36,11 +36,11 @@ DESCRIPTION
             vim [options] [filelist]
 
        If the filelist is missing, the editor will start with an empty buffer.
-       Otherwise  exactly  one out of the following four may be used to choose
+       Otherwise exactly one out of the following four may be used  to  choose
        one or more files to be edited.
 
-       file ..     A list of filenames.  The first one  will  be  the  current
-                   file  and  read  into the buffer.  The cursor will be posi‐
+       file ..     A  list  of  filenames.   The first one will be the current
+                   file and read into the buffer.  The cursor  will  be  posi‐
                    tioned on the first line of the buffer.  You can get to the
                    other files with the ":next" command.  To edit a file  that
                    starts with a dash, precede the filelist with "--".
@@ -49,18 +49,18 @@ DESCRIPTION
                    from stderr, which should be a tty.
 
        -t {tag}    The file to edit and the initial cursor position depends on
-                   a "tag", a sort of goto label.  {tag} is looked up  in  the
+                   a  "tag",  a sort of goto label.  {tag} is looked up in the
                    tags file, the associated file becomes the current file and
                    the  associated  command  is executed.  Mostly this is used
                    for C programs, in which case {tag}  could  be  a  function
                    name.  The effect is that the file containing that function
-                   becomes  the  current  file and the cursor is positioned on
+                   becomes the current file and the cursor  is  positioned  on
                    the start of the function.  See ":help tag-commands".
 
        -q [errorfile]
-                   Start in quickFix mode.  The file [errorfile] is  read  and
-                   the  first  error is displayed.  If [errorfile] is omitted,
-                   the filename is obtained from the 'errorfile'  option  (de‐
+                   Start  in  quickFix mode.  The file [errorfile] is read and
+                   the first error is displayed.  If [errorfile]  is  omitted,
+                   the  filename  is obtained from the 'errorfile' option (de‐
                    faults to "AztecC.Err" for the Amiga, "errors.err" on other
                    systems).   Further  errors can be jumped to with the ":cn"
                    command.  See ":help quickfix".
@@ -70,10 +70,10 @@ DESCRIPTION
 
        vim       The "normal" way, everything is default.
 
-       ex        Start in Ex mode.  Go to Normal mode with the ":vi"  command.
+       ex        Start  in Ex mode.  Go to Normal mode with the ":vi" command.
                  Can also be done with the "-e" argument.
 
-       view      Start  in read-only mode.  You will be protected from writing
+       view      Start in read-only mode.  You will be protected from  writing
                  the files.  Can also be done with the "-R" argument.
 
        gvim gview
@@ -111,16 +111,6 @@ OPTIONS
                    vim "+set si" main.c
                    Note: You can use up to 10 "+" or "-c" commands.
 
-       -S {file}   {file} will be sourced after the first file has been  read.
-                   This  is  equivalent  to -c "source {file}".  {file} cannot
-                   start with '-'.  If {file} is omitted "Session.vim" is used
-                   (only works when -S is the last argument).
-
-       --cmd {command}
-                   Like using "-c", but the command is  executed  just  before
-                   processing  any  vimrc file.  You can use up to 10 of these
-                   commands, independently from "-c" commands.
-
        -A          If Vim has been compiled with ARABIC  support  for  editing
                    right-to-left  oriented  files and Arabic keyboard mapping,
                    this option starts Vim in Arabic  mode,  i.e.  'arabic'  is
@@ -134,86 +124,73 @@ OPTIONS
                    ists.
 
        -d          Start in diff mode.  There should between two to eight file
-                   name arguments.  Vim will open all the files and show  dif‐
+                   name  arguments.  Vim will open all the files and show dif‐
                    ferences between them.  Works like vimdiff(1).
 
        -d {device}, -dev {device}
-                   Open  {device}  for  use as a terminal.  Only on the Amiga.
+                   Open {device} for use as a terminal.  Only  on  the  Amiga.
                    Example: "-d con:20/30/600/150".
 
-       -D          Debugging.  Go to debugging mode when executing  the  first
+       -D          Debugging.   Go  to debugging mode when executing the first
                    command from a script.
 
-       -e          Start  Vim  in Ex mode, just like the executable was called
+       -e          Start Vim in Ex mode, just like the executable  was  called
                    "ex".
 
        -E          Start Vim in improved Ex mode, just like the executable was
                    called "exim".
 
        -f          Foreground.  For the GUI version, Vim will not fork and de‐
-                   tach from the shell it was started in.  On the  Amiga,  Vim
-                   is  not restarted to open a new window.  This option should
-                   be used when Vim is executed by a program  that  will  wait
-                   for  the  edit session to finish (e.g. mail).  On the Amiga
+                   tach  from  the shell it was started in.  On the Amiga, Vim
+                   is not restarted to open a new window.  This option  should
+                   be  used  when  Vim is executed by a program that will wait
+                   for the edit session to finish (e.g. mail).  On  the  Amiga
                    the ":sh" and ":!" commands will not work.
 
-       --nofork    Foreground.  For the GUI version, Vim will not fork and de‐
-                   tach from the shell it was started in.
-
-       -F          If Vim has been compiled with  FKMAP  support  for  editing
-                   right-to-left  oriented  files  and Farsi keyboard mapping,
-                   this option starts Vim in  Farsi  mode,  i.e.  'fkmap'  and
-                   'rightleft'  are  set.  Otherwise an error message is given
+       -F          If  Vim  has  been  compiled with FKMAP support for editing
+                   right-to-left oriented files and  Farsi  keyboard  mapping,
+                   this  option  starts  Vim  in  Farsi mode, i.e. 'fkmap' and
+                   'rightleft' are set.  Otherwise an error message  is  given
                    and Vim aborts.
+                   Note: Farsi support has been removed in patch 8.1.0932.
 
-       -g          If Vim has been compiled with GUI support, this option  en‐
+       -g          If  Vim has been compiled with GUI support, this option en‐
                    ables the GUI.  If no GUI support was compiled in, an error
                    message is given and Vim aborts.
 
-       --gui-dialog-file {name}
-                   When  using the GUI, instead of showing a dialog, write the
-                   title and message of the dialog to file {name}.   The  file
-                   is  created  or  appended  to.  Only useful for testing, to
-                   avoid that the test gets stuck on a dialog  that  can't  be
-                   seen.  Without the GUI the argument is ignored.
-
-       --help, -h, -?
-                   Give a bit of help about the command line arguments and op‐
-                   tions.  After this Vim exits.
-
        -H          If Vim has been compiled with RIGHTLEFT support for editing
-                   right-to-left  oriented  files and Hebrew keyboard mapping,
-                   this option starts Vim in Hebrew  mode,  i.e.  'hkmap'  and
-                   'rightleft'  are  set.  Otherwise an error message is given
+                   right-to-left oriented files and Hebrew  keyboard  mapping,
+                   this  option  starts  Vim  in Hebrew mode, i.e. 'hkmap' and
+                   'rightleft' are set.  Otherwise an error message  is  given
                    and Vim aborts.
 
        -i {viminfo}
-                   Specifies the filename to use when reading or  writing  the
-                   viminfo  file,  instead  of the default "~/.viminfo".  This
-                   can also be used to skip the use of the .viminfo  file,  by
+                   Specifies  the  filename to use when reading or writing the
+                   viminfo file, instead of the  default  "~/.viminfo".   This
+                   can  also  be used to skip the use of the .viminfo file, by
                    giving the name "NONE".
-
-       -L          Same as -r.
 
        -l          Lisp mode.  Sets the 'lisp' and 'showmatch' options on.
 
-       -m          Modifying  files  is  disabled.  Resets the 'write' option.
-                   You can still modify the buffer, but writing a file is  not
+       -L          Same as -r.
+
+       -m          Modifying files is disabled.  Resets  the  'write'  option.
+                   You  can still modify the buffer, but writing a file is not
                    possible.
 
-       -M          Modifications  not  allowed.   The 'modifiable' and 'write'
-                   options will be unset, so that changes are not allowed  and
-                   files  can  not be written.  Note that these options can be
+       -M          Modifications not allowed.  The  'modifiable'  and  'write'
+                   options  will be unset, so that changes are not allowed and
+                   files can not be written.  Note that these options  can  be
                    set to enable making modifications.
+
+       -n          No  swap file will be used.  Recovery after a crash will be
+                   impossible.  Handy if you want to edit a  file  on  a  very
+                   slow  medium  (e.g.  floppy).   Can also be done with ":set
+                   uc=0".  Can be undone with ":set uc=200".
 
        -N          No-compatible mode.  Resets the 'compatible' option.   This
                    will  make Vim behave a bit better, but less Vi compatible,
                    even though a .vimrc file does not exist.
-
-       -n          No swap file will be used.  Recovery after a crash will  be
-                   impossible.   Handy  if  you  want to edit a file on a very
-                   slow medium (e.g. floppy).  Can also  be  done  with  ":set
-                   uc=0".  Can be undone with ":set uc=200".
 
        -nb         Become an editor server for NetBeans.  See the docs for de‐
                    tails.
@@ -221,7 +198,7 @@ OPTIONS
        -o[N]       Open N windows stacked.  When N is omitted, open one window
                    for each file.
 
-       -O[N]       Open  N  windows side by side.  When N is omitted, open one
+       -O[N]       Open N windows side by side.  When N is omitted,  open  one
                    window for each file.
 
        -p[N]       Open N tab pages.  When N is omitted, open one tab page for
@@ -232,25 +209,25 @@ OPTIONS
                    tion.   When possible, Vim will run in an MDI window inside
                    the application. {parent-title} must appear in  the  window
                    title of the parent application.  Make sure that it is spe‐
-                   cific  enough. Note that the implementation is still primi‐
-                   tive.  It won't work with all  applications  and  the  menu
+                   cific enough. Note that the implementation is still  primi‐
+                   tive.   It  won't  work  with all applications and the menu
                    doesn't work.
 
-       -R          Read-only  mode.   The  'readonly' option will be set.  You
-                   can still edit the buffer, but will be prevented from acci‐
-                   dentally overwriting a file.  If you do want to overwrite a
-                   file, add an exclamation mark to  the  Ex  command,  as  in
-                   ":w!".   The  -R  option  also  implies  the -n option (see
-                   above).  The 'readonly' option  can  be  reset  with  ":set
-                   noro".  See ":help 'readonly'".
-
-       -r          List  swap files, with information about using them for re‐
+       -r          List swap files, with information about using them for  re‐
                    covery.
 
-       -r {file}   Recovery mode.  The swap file is used to recover a  crashed
-                   editing  session.   The  swap  file is a file with the same
+       -r {file}   Recovery  mode.  The swap file is used to recover a crashed
+                   editing session.  The swap file is a  file  with  the  same
                    filename as the text file with ".swp" appended.  See ":help
                    recovery".
+
+       -R          Read-only mode.  The 'readonly' option will  be  set.   You
+                   can still edit the buffer, but will be prevented from acci‐
+                   dentally overwriting a file.  If you do want to overwrite a
+                   file,  add  an  exclamation  mark  to the Ex command, as in
+                   ":w!".  The -R option  also  implies  the  -n  option  (see
+                   above).   The  'readonly'  option  can  be reset with ":set
+                   noro".  See ":help 'readonly'".
 
        -s          Silent mode.  Only when started as "Ex" or  when  the  "-e"
                    option was given before the "-s" option.
@@ -262,50 +239,41 @@ OPTIONS
                    end of the file is reached before the editor exits, further
                    characters are read from the keyboard.
 
+       -S {file}   {file}  will be sourced after the first file has been read.
+                   This is equivalent to -c "source  {file}".   {file}  cannot
+                   start with '-'.  If {file} is omitted "Session.vim" is used
+                   (only works when -S is the last argument).
+
        -T {terminal}
                    Tells Vim the name of the terminal you are using.  Only re‐
                    quired  when  the  automatic way doesn't work.  Should be a
                    terminal known to Vim (builtin) or defined in  the  termcap
                    or terminfo file.
 
-       --not-a-term
-                   Tells  Vim that the user knows that the input and/or output
-                   is not connected to a terminal.  This will avoid the  warn‐
-                   ing and the two second delay that would happen.
-
-       --ttyfail   When  stdin  or  stdout is not a a terminal (tty) then exit
-                   right away.
-
-       -u {vimrc}  Use the commands in the file {vimrc}  for  initializations.
-                   All  the  other  initializations  are skipped.  Use this to
-                   edit a special kind of files.  It can also be used to  skip
-                   all  initializations by giving the name "NONE".  See ":help
+       -u {vimrc}  Use  the  commands in the file {vimrc} for initializations.
+                   All the other initializations are  skipped.   Use  this  to
+                   edit  a special kind of files.  It can also be used to skip
+                   all initializations by giving the name "NONE".  See  ":help
                    initialization" within vim for more details.
 
-       -U {gvimrc} Use the commands in the file {gvimrc} for  GUI  initializa‐
-                   tions.   All the other GUI initializations are skipped.  It
-                   can also be used to skip all GUI initializations by  giving
-                   the  name "NONE".  See ":help gui-init" within vim for more
+       -U {gvimrc} Use  the  commands in the file {gvimrc} for GUI initializa‐
+                   tions.  All the other GUI initializations are skipped.   It
+                   can  also be used to skip all GUI initializations by giving
+                   the name "NONE".  See ":help gui-init" within vim for  more
                    details.
 
-       -V[N]       Verbose.  Give messages about which files are  sourced  and
-                   for  reading and writing a viminfo file.  The optional num‐
+       -v          Start  Vim  in Vi mode, just like the executable was called
+                   "vi".  This only has effect when the executable  is  called
+                   "ex".
+
+       -V[N]       Verbose.   Give  messages about which files are sourced and
+                   for reading and writing a viminfo file.  The optional  num‐
                    ber N is the value for 'verbose'.  Default is 10.
 
        -V[N]{filename}
                    Like -V and set 'verbosefile' to {filename}.  The result is
                    that messages are not displayed but  written  to  the  file
                    {filename}.  {filename} must not start with a digit.
-
-       --log {filename}
-                   If  Vim  has  been  compiled with eval and channel feature,
-                   start logging and write entries to {filename}.  This  works
-                   like calling ch_logfile({filename}, 'ao') very early during
-                   startup.
-
-       -v          Start  Vim  in Vi mode, just like the executable was called
-                   "vi".  This only has effect when the executable  is  called
-                   "ex".
 
        -w{number}  Set the 'window' option to {number}.
 
@@ -319,11 +287,11 @@ OPTIONS
        -W {scriptout}
                    Like -w, but an existing file is overwritten.
 
-       -x          If Vim has been compiled with encryption support,  use  en‐
+       -x          If  Vim  has been compiled with encryption support, use en‐
                    cryption when writing files.  Will prompt for a crypt key.
 
-       -X          Don't  connect to the X server.  Shortens startup time in a
-                   terminal, but the window title and clipboard  will  not  be
+       -X          Don't connect to the X server.  Shortens startup time in  a
+                   terminal,  but  the  window title and clipboard will not be
                    used.
 
        -y          Start Vim in easy mode, just like the executable was called
@@ -341,31 +309,61 @@ OPTIONS
                    etc.).  Useful to see if a problem reproduces with a  clean
                    Vim setup.
 
+       --cmd {command}
+                   Like  using  "-c",  but the command is executed just before
+                   processing any vimrc file.  You can use up to 10  of  these
+                   commands, independently from "-c" commands.
+
        --echo-wid  GTK GUI only: Echo the Window ID on stdout.
 
-       --literal   Take  file  name  arguments  literally, do not expand wild‐
-                   cards.  This has no effect on Unix where the shell  expands
+       --gui-dialog-file {name}
+                   When  using the GUI, instead of showing a dialog, write the
+                   title and message of the dialog to file {name}.   The  file
+                   is  created  or  appended  to.  Only useful for testing, to
+                   avoid that the test gets stuck on a dialog  that  can't  be
+                   seen.  Without the GUI the argument is ignored.
+
+       --help, -h, -?
+                   Give a bit of help about the command line arguments and op‐
+                   tions.  After this Vim exits.
+
+       --literal   Take file name arguments literally,  do  not  expand  wild‐
+                   cards.   This has no effect on Unix where the shell expands
                    wildcards.
 
+       --log {filename}
+                   If Vim has been compiled with  eval  and  channel  feature,
+                   start  logging  and write entries to {filename}. This works
+                   like calling ch_logfile({filename}, 'ao') very early during
+                   startup.
+
+       --nofork    Foreground.  For the GUI version, Vim will not fork and de‐
+                   tach from the shell it was started in.
+
        --noplugin  Skip loading plugins.  Implied by -u NONE.
+
+       --not-a-term
+                   Tells Vim that the user knows that the input and/or  output
+                   is  not connected to a terminal.  This will avoid the warn‐
+                   ing and the two second delay that would happen.
 
        --remote    Connect to a Vim server and make it edit the files given in
                    the rest of the arguments.  If no server is found a warning
                    is given and the files are edited in the current Vim.
 
        --remote-expr {expr}
-                   Connect  to  a  Vim server, evaluate {expr} in it and print
+                   Connect to a Vim server, evaluate {expr} in  it  and  print
                    the result on stdout.
 
        --remote-send {keys}
                    Connect to a Vim server and send {keys} to it.
 
        --remote-silent
-                   As --remote, but without the  warning  when  no  server  is
+                   As  --remote,  but  without  the  warning when no server is
                    found.
 
        --remote-wait
-                   As  --remote,  but  Vim  does not exit until the files have
+                   As --remote, but Vim does not exit  until  the  files  have
                    been edited.
 
        --remote-wait-silent
@@ -381,16 +379,19 @@ OPTIONS
                    the server to connect to.
 
        --socketid {id}
-                   GTK  GUI only: Use the GtkPlug mechanism to run gvim in an‐
+                   GTK GUI only: Use the GtkPlug mechanism to run gVim in  an‐
                    other window.
 
        --startuptime {file}
                    During startup write timing messages to the file {fname}.
 
+       --ttyfail   When  stdin  or  stdout is not a a terminal (tty) then exit
+                   right away.
+
        --version   Print version information and exit.
 
        --windowid {id}
-                   Win32 GUI only: Make gvim try to use the window {id}  as  a
+                   Win32 GUI only: Make gVim try to use the window {id}  as  a
                    parent, so that it runs inside that window.
 
 ON-LINE HELP
@@ -403,12 +404,12 @@ ON-LINE HELP
 
 FILES
        /usr/local/share/vim/vim??/doc/*.txt
-                      The  Vim documentation files.  Use ":help doc-file-list"
+                      The Vim documentation files.  Use ":help  doc-file-list"
                       to get the complete list.
                       vim??  is short version number, like vim91 for Vim 9.1
 
        /usr/local/share/vim/vim??/doc/tags
-                      The tags file used for finding information in the  docu‐
+                      The  tags file used for finding information in the docu‐
                       mentation files.
 
        /usr/local/share/vim/vim??/syntax/syntax.vim
@@ -421,32 +422,32 @@ FILES
                       System wide Vim initializations.
 
        ~/.vimrc, ~/.vim/vimrc, $XDG_CONFIG_HOME/vim/vimrc
-                      Your  personal  Vim  initializations (first one found is
+                      Your personal Vim initializations (first  one  found  is
                       used).
 
        /usr/local/share/vim/gvimrc
                       System wide gvim initializations.
 
        ~/.gvimrc, ~/.vim/gvimrc, $XDG_CONFIG_HOME/vim/gvimrc
-                      Your personal gvim initializations (first one  found  is
+                      Your  personal  gVim initializations (first one found is
                       used).
 
        /usr/local/share/vim/vim??/optwin.vim
-                      Script  used  for  the ":options" command, a nice way to
+                      Script used for the ":options" command, a  nice  way  to
                       view and set options.
 
        /usr/local/share/vim/vim??/menu.vim
-                      System wide menu initializations for gvim.
+                      System wide menu initializations for gVim.
 
        /usr/local/share/vim/vim??/bugreport.vim
                       Script to generate a bug report.  See ":help bugs".
 
        /usr/local/share/vim/vim??/filetype.vim
-                      Script to detect the type of a file by  its  name.   See
+                      Script  to  detect  the type of a file by its name.  See
                       ":help 'filetype'".
 
        /usr/local/share/vim/vim??/scripts.vim
-                      Script  to  detect  the  type of a file by its contents.
+                      Script to detect the type of a  file  by  its  contents.
                       See ":help 'filetype'".
 
        /usr/local/share/vim/vim??/print/*.ps
@@ -474,4 +475,4 @@ BUGS
        vi_diff.txt  when  in  Vim).   Also have a look at the 'compatible' and
        'cpoptions' options.
 
-                                  2024 Aug 03                           VIM(1)
+                                  2024 Aug 12                           VIM(1)

--- a/runtime/doc/vimdiff.1
+++ b/runtime/doc/vimdiff.1
@@ -1,4 +1,4 @@
-.TH VIMDIFF 1 "2001 March 30"
+.TH VIMDIFF 1 "2021 June 13"
 .SH NAME
 vimdiff \- edit between two and eight versions of a file with Vim and show differences
 .SH SYNOPSIS

--- a/runtime/doc/vimdiff.man
+++ b/runtime/doc/vimdiff.man
@@ -44,4 +44,4 @@ AUTHOR
 
 
 
-                                 2001 March 30                      VIMDIFF(1)
+                                 2021 June 13                       VIMDIFF(1)

--- a/runtime/doc/vimtutor.1
+++ b/runtime/doc/vimtutor.1
@@ -1,4 +1,4 @@
-.TH VIMTUTOR 1 "2001 April 2"
+.TH VIMTUTOR 1 "2024 August 12"
 .SH NAME
 vimtutor \- the Vim tutor
 .SH SYNOPSIS
@@ -19,7 +19,7 @@ is useful for people that want to learn their first
 commands.
 .PP
 The optional argument \-g starts vimtutor with gvim rather than vim, if the
-GUI version of vim is available, or falls back to Vim if gvim is not found.
+GUI version of Vim is available, or falls back to vim if gvim is not found.
 .PP
 The optional [language] argument is the two-letter name of a language, like
 "it" or "es".
@@ -32,12 +32,16 @@ Otherwise the English version will be used.
 is always started in Vi compatible mode.
 .SH FILES
 .TP 15
-/usr/local/lib/vim/tutor/tutor[.language]
+/usr/local/share/vim/vim??/tutor/tutor[.language]
 The
 .B Vimtutor
 text file(s).
+.br
+.I vim??
+is short version number, like vim91 for
+.B Vim 9.1
 .TP 15
-/usr/local/lib/vim/tutor/tutor.vim
+/usr/local/share/vim/vim??/tutor/tutor.vim
 The Vim script used to copy the
 .B Vimtutor
 text file.

--- a/runtime/doc/vimtutor.man
+++ b/runtime/doc/vimtutor.man
@@ -16,7 +16,7 @@ DESCRIPTION
        commands.
 
        The  optional argument -g starts vimtutor with gvim rather than vim, if
-       the GUI version of vim is available, or falls back to Vim  if  gvim  is
+       the GUI version of Vim is available, or falls back to vim  if  gvim  is
        not found.
 
        The  optional [language] argument is the two-letter name of a language,
@@ -28,10 +28,11 @@ DESCRIPTION
        Vim is always started in Vi compatible mode.
 
 FILES
-       /usr/local/lib/vim/tutor/tutor[.language]
+       /usr/local/share/vim/vim??/tutor/tutor[.language]
                       The Vimtutor text file(s).
+                      vim??  is short version number, like vim91 for Vim 9.1
 
-       /usr/local/lib/vim/tutor/tutor.vim
+       /usr/local/share/vim/vim??/tutor/tutor.vim
                       The Vim script used to copy the Vimtutor text file.
 
 AUTHOR
@@ -47,4 +48,4 @@ SEE ALSO
 
 
 
-                                 2001 April 2                      VIMTUTOR(1)
+                                2024 August 12                     VIMTUTOR(1)

--- a/runtime/doc/xxd.1
+++ b/runtime/doc/xxd.1
@@ -1,4 +1,4 @@
-.TH XXD 1 "August 1996" "Manual page for xxd"
+.TH XXD 1 "May 2024" "Manual page for xxd"
 .\"
 .\" 21st May 1996
 .\" Man page author:
@@ -190,7 +190,8 @@ When editing hex dumps, please note that
 skips everything on the input line after reading enough columns of hexadecimal
 data (see option \-c). This also means that changes to the printable ASCII (or
 EBCDIC) columns are always ignored. Reverting a plain (or PostScript) style
-hex dump with xxd \-r \-p does not depend on the correct number of columns. Here, anything that looks like a pair of hex digits is interpreted.
+hex dump with xxd \-r \-p does not depend on the correct number of columns.
+Here, anything that looks like a pair of hex digits is interpreted.
 .PP
 Note the difference between
 .br
@@ -224,7 +225,8 @@ Hex dump from file position 0x100 (=1024\-768) onwards.
 \fI% sh \-c "dd of=plain_snippet bs=1k count=1; xxd \-s +\-768 > hex_snippet" < file\fR
 .PP
 However, this is a rare situation and the use of `+' is rarely needed.
-The author prefers to monitor the effect of xxd with strace(1) or truss(1), whenever \-s is used.
+The author prefers to monitor the effect of xxd with strace(1) or truss(1),
+whenever \-s is used.
 .SH EXAMPLES
 .PP
 .br
@@ -239,22 +241,25 @@ Print 3 lines (hex 0x30 bytes) from the end of
 .br
 \fI% xxd \-s \-0x30 file\fR
 .PP
+Note: The results of the examples below are relevant to the xxd.1 man page as of
+May 2024
+.PP
 .br
 Print 120 bytes as a continuous hex dump with 20 octets per line.
 .br
 \fI% xxd \-l 120 \-ps \-c 20 xxd.1\fR
 .br
-2e54482058584420312022417567757374203139
+2e544820585844203120224d6179203230323422
 .br
-39362220224d616e75616c207061676520666f72
+20224d616e75616c207061676520666f72207878
 .br
-20787864220a2e5c220a2e5c222032317374204d
+64220a2e5c220a2e5c222032317374204d617920
 .br
-617920313939360a2e5c22204d616e2070616765
+313939360a2e5c22204d616e2070616765206175
 .br
-20617574686f723a0a2e5c2220202020546f6e79
+74686f723a0a2e5c2220202020546f6e79204e75
 .br
-204e7567656e74203c746f6e79407363746e7567
+67656e74203c746f6e79407363746e7567656e2e
 .br
 
 .br
@@ -262,32 +267,32 @@ Hex dump the first 120 bytes of this man page with 12 octets per line.
 .br
 \fI% xxd \-l 120 \-c 12 xxd.1\fR
 .br
-0000000: 2e54 4820 5858 4420 3120 2241  .TH XXD 1 "A
+00000000: 2e54 4820 5858 4420 3120 224d  .TH XXD 1 "M
 .br
-000000c: 7567 7573 7420 3139 3936 2220  ugust 1996" 
+0000000c: 6179 2032 3032 3422 2022 4d61  ay 2024" "Ma
 .br
-0000018: 224d 616e 7561 6c20 7061 6765  "Manual page
+00000018: 6e75 616c 2070 6167 6520 666f  nual page fo
 .br
-0000024: 2066 6f72 2078 7864 220a 2e5c   for xxd"..\\
+00000024: 7220 7878 6422 0a2e 5c22 0a2e  r xxd"..\\"..
 .br
-0000030: 220a 2e5c 2220 3231 7374 204d  "..\\" 21st M
+00000030: 5c22 2032 3173 7420 4d61 7920  \\" 21st May 
 .br
-000003c: 6179 2031 3939 360a 2e5c 2220  ay 1996..\\" 
+0000003c: 3139 3936 0a2e 5c22 204d 616e  1996..\\" Man
 .br
-0000048: 4d61 6e20 7061 6765 2061 7574  Man page aut
+00000048: 2070 6167 6520 6175 7468 6f72   page author
 .br
-0000054: 686f 723a 0a2e 5c22 2020 2020  hor:..\\"    
+00000054: 3a0a 2e5c 2220 2020 2054 6f6e  :..\\"    Ton
 .br
-0000060: 546f 6e79 204e 7567 656e 7420  Tony Nugent 
+00000060: 7920 4e75 6765 6e74 203c 746f  y Nugent <to
 .br
-000006c: 3c74 6f6e 7940 7363 746e 7567  <tony@sctnug
+0000006c: 6e79 4073 6374 6e75 6765 6e2e  ny@sctnugen.
 .PP
 .br
 Display just the date from the file xxd.1
 .br
-\fI% xxd \-s 0x36 \-l 13 \-c 13 xxd.1\fR
+\fI% xxd \-s 0x33 \-l 13 \-c 13 xxd.1\fR
 .br
-0000036: 3231 7374 204d 6179 2031 3939 36  21st May 1996
+00000033: 3231 7374 204d 6179 2031 3939 36  21st May 1996
 .PP
 .br
 Copy
@@ -302,11 +307,11 @@ and prepend 100 bytes of value 0x00.
 .br
 Patch the date in the file xxd.1
 .br
-\fI% echo "0000037: 3574 68" | xxd \-r \- xxd.1\fR
+\fI% echo "0000034: 3574 68" | xxd \-r \- xxd.1\fR
 .br
-\fI% xxd \-s 0x36 \-l 13 \-c 13 xxd.1\fR
+\fI% xxd \-s 0x33 \-l 13 \-c 13 xxd.1\fR
 .br
-0000036: 3235 7468 204d 6179 2031 3939 36  25th May 1996
+0000033: 3235 7468 204d 6179 2031 3939 36  25th May 1996
 .PP
 .br
 Create a 65537 byte file with all bytes 0x00,
@@ -323,7 +328,7 @@ Hex dump this file with autoskip.
 .br
 *
 .br
-000fffc: 0000 0000 40                   ....A
+000fffc: 0000 0000 41                   ....A
 .PP
 Create a 1 byte file containing a single 'A' character.
 The number after '\-r \-s' adds to the line numbers found in the file;
@@ -388,7 +393,7 @@ The tool's weirdness matches its creator's brain.
 Use entirely at your own risk. Copy files. Trace it. Become a wizard.
 .br
 .SH VERSION
-This manual page documents xxd version 1.7
+This manual page documents xxd version 1.7 from 2024-05.
 .SH AUTHOR
 .br
 (c) 1990-1997 by Juergen Weigert

--- a/runtime/doc/xxd.man
+++ b/runtime/doc/xxd.man
@@ -179,39 +179,42 @@ EXAMPLES
        Print 3 lines (hex 0x30 bytes) from the end of file.
        % xxd -s -0x30 file
 
+       Note: The results of the examples below are relevant to the xxd.1 man
+       page as of May 2024
+
        Print 120 bytes as a continuous hex dump with 20 octets per line.
        % xxd -l 120 -ps -c 20 xxd.1
-       2e54482058584420312022417567757374203139
-       39362220224d616e75616c207061676520666f72
-       20787864220a2e5c220a2e5c222032317374204d
-       617920313939360a2e5c22204d616e2070616765
-       20617574686f723a0a2e5c2220202020546f6e79
-       204e7567656e74203c746f6e79407363746e7567
+       2e544820585844203120224d6179203230323422
+       20224d616e75616c207061676520666f72207878
+       64220a2e5c220a2e5c222032317374204d617920
+       313939360a2e5c22204d616e2070616765206175
+       74686f723a0a2e5c2220202020546f6e79204e75
+       67656e74203c746f6e79407363746e7567656e2e
 
        Hex dump the first 120 bytes of this man page with 12 octets per line.
        % xxd -l 120 -c 12 xxd.1
-       0000000: 2e54 4820 5858 4420 3120 2241  .TH XXD 1 "A
-       000000c: 7567 7573 7420 3139 3936 2220  ugust 1996"
-       0000018: 224d 616e 7561 6c20 7061 6765  "Manual page
-       0000024: 2066 6f72 2078 7864 220a 2e5c   for xxd"..\
-       0000030: 220a 2e5c 2220 3231 7374 204d  "..\" 21st M
-       000003c: 6179 2031 3939 360a 2e5c 2220  ay 1996..\"
-       0000048: 4d61 6e20 7061 6765 2061 7574  Man page aut
-       0000054: 686f 723a 0a2e 5c22 2020 2020  hor:..\"
-       0000060: 546f 6e79 204e 7567 656e 7420  Tony Nugent
-       000006c: 3c74 6f6e 7940 7363 746e 7567  <tony@sctnug
+       00000000: 2e54 4820 5858 4420 3120 224d  .TH XXD 1 "M
+       0000000c: 6179 2032 3032 3422 2022 4d61  ay 2024" "Ma
+       00000018: 6e75 616c 2070 6167 6520 666f  nual page fo
+       00000024: 7220 7878 6422 0a2e 5c22 0a2e  r xxd"..\"..
+       00000030: 5c22 2032 3173 7420 4d61 7920  \" 21st May
+       0000003c: 3139 3936 0a2e 5c22 204d 616e  1996..\" Man
+       00000048: 2070 6167 6520 6175 7468 6f72   page author
+       00000054: 3a0a 2e5c 2220 2020 2054 6f6e  :..\"    Ton
+       00000060: 7920 4e75 6765 6e74 203c 746f  y Nugent <to
+       0000006c: 6e79 4073 6374 6e75 6765 6e2e  ny@sctnugen.
 
        Display just the date from the file xxd.1
-       % xxd -s 0x36 -l 13 -c 13 xxd.1
-       0000036: 3231 7374 204d 6179 2031 3939 36  21st May 1996
+       % xxd -s 0x33 -l 13 -c 13 xxd.1
+       0000033: 3231 7374 204d 6179 2031 3939 36  21st May 1996
 
        Copy input_file to output_file and prepend 100 bytes of value 0x00.
        % xxd input_file | xxd -r -s 100 > output_file
 
        Patch the date in the file xxd.1
-       % echo "0000037: 3574 68" | xxd -r - xxd.1
-       % xxd -s 0x36 -l 13 -c 13 xxd.1
-       0000036: 3235 7468 204d 6179 2031 3939 36  25th May 1996
+       % echo "0000034: 3574 68" | xxd -r - xxd.1
+       % xxd -s 0x33 -l 13 -c 13 xxd.1
+       0000033: 3235 7468 204d 6179 2031 3939 36  25th May 1996
 
        Create  a  65537 byte file with all bytes 0x00, except for the last one
        which is 'A' (hex 0x41).
@@ -221,7 +224,7 @@ EXAMPLES
        % xxd -a -c 12 file
        0000000: 0000 0000 0000 0000 0000 0000  ............
        *
-       000fffc: 0000 0000 40                   ....A
+       000fffc: 0000 0000 41                   ....A
 
        Create a 1 byte file containing a single 'A' character.  The number af‐
        ter  '-r -s' adds to the line numbers found in the file; in effect, the
@@ -268,7 +271,7 @@ WARNINGS
        own risk. Copy files. Trace it. Become a wizard.
 
 VERSION
-       This manual page documents xxd version 1.7
+       This manual page documents xxd version 1.7 from 2024-05.
 
 AUTHOR
        (c) 1990-1997 by Juergen Weigert
@@ -282,4 +285,4 @@ AUTHOR
        <tony@sctnugen.ppp.gu.edu.au> <T.Nugent@sct.gu.edu.au>
        Small changes by Bram Moolenaar.  Edited by Juergen Weigert.
 
-Manual page for xxd               August 1996                           XXD(1)
+Manual page for xxd                May 2024                             XXD(1)

--- a/src/testdir/test_xxd.vim
+++ b/src/testdir/test_xxd.vim
@@ -73,21 +73,21 @@ func Test_xxd()
   exe '0r! ' . s:xxd_cmd . ' -l 120 -ps -c20 ' . man_copy
   $d
   let expected = [
-      \ '2e54482058584420312022417567757374203139',
-      \ '39362220224d616e75616c207061676520666f72',
-      \ '20787864220a2e5c220a2e5c222032317374204d',
-      \ '617920313939360a2e5c22204d616e2070616765',
-      \ '20617574686f723a0a2e5c2220202020546f6e79',
-      \ '204e7567656e74203c746f6e79407363746e7567']
+      \ '2e544820585844203120224d6179203230323422',
+      \ '20224d616e75616c207061676520666f72207878',
+      \ '64220a2e5c220a2e5c222032317374204d617920',
+      \ '313939360a2e5c22204d616e2070616765206175',
+      \ '74686f723a0a2e5c2220202020546f6e79204e75',
+      \ '67656e74203c746f6e79407363746e7567656e2e']
   call assert_equal(expected, getline(1,'$'), s:Mess(s:test))
 
   " Test 6: Print the date from xxd.1
   let s:test += 1
   for arg in ['-l 13', '-l13', '-len 13']
     %d
-    exe '0r! ' . s:xxd_cmd . ' -s 0x36 ' . arg . ' -cols 13 ' . man_copy
+    exe '0r! ' . s:xxd_cmd . ' -s 0x33 ' . arg . ' -cols 13 ' . man_copy
     $d
-    call assert_equal('00000036: 3231 7374 204d 6179 2031 3939 36  21st May 1996', getline(1), s:Mess(s:test))
+    call assert_equal('00000033: 3231 7374 204d 6179 2031 3939 36  21st May 1996', getline(1), s:Mess(s:test))
   endfor
 
   " Cleanup after tests 5 and 6


### PR DESCRIPTION
"evim.1"
`/usr/local/lib/vim/evim.vim`
changed to
`/usr/local/share/vim/vim??/evim.vim`
Added description of "vim???".
Typographical corrections.

"vim.1"
Arranged command line arguments.
Added a note for the `-F` argument.
Typographical corrections.

"vimdiff.1"
Corrected the date of the last modification.

"vimtutor.1"
`/usr/local/lib/vim/tutor/tutor[.language]`
`/usr/local/lib/vim/tutor/tutor.vim`
changed to
`/usr/local/share/vim/vim???/tutor/tutor/tutor[.language]`
`/usr/local/share/vim/vim??/tutor/tutor.vim`
Added description of "vim???".

"xxd.1"
Corrected the date of the last modification.
Corrected examples, fixed a mistake.
Added date of last change to version number.

"test_xxd.vim"
Updated test data for the new values in xxd.1
