### PR TITLE
[vim9class] DRAFT-DO-NOT-MERGE Incorportate interfaces from extended class

### DIFF
--- a/src/logfile.c
+++ b/src/logfile.c
@@ -106,13 +106,20 @@ ch_log(channel_T *ch, const char *fmt, ...)
 {
     if (log_fd == NULL)
 	return;
-
     va_list ap;
+    va_start(ap, fmt);
+    vch_log(ch, fmt, ap);
+    va_end(ap);
+}
+
+    void
+vch_log(channel_T *ch, const char *fmt, va_list ap)
+{
+    if (log_fd == NULL)
+	return;
 
     ch_log_lead("", ch, PART_COUNT);
-    va_start(ap, fmt);
     vfprintf(log_fd, fmt, ap);
-    va_end(ap);
     fputc('\n', log_fd);
     fflush(log_fd);
     did_repeated_msg = 0;
@@ -123,13 +130,20 @@ ch_error(channel_T *ch, const char *fmt, ...)
 {
     if (log_fd == NULL)
 	return;
-
     va_list ap;
+    va_start(ap, fmt);
+    vch_error(ch, fmt, ap);
+    va_end(ap);
+}
+
+    void
+vch_error(channel_T *ch, const char *fmt, va_list ap)
+{
+    if (log_fd == NULL)
+	return;
 
     ch_log_lead("ERR ", ch, PART_COUNT);
-    va_start(ap, fmt);
     vfprintf(log_fd, fmt, ap);
-    va_end(ap);
     fputc('\n', log_fd);
     fflush(log_fd);
     did_repeated_msg = 0;

--- a/src/proto.h
+++ b/src/proto.h
@@ -271,6 +271,8 @@ void mbyte_im_set_active(int active_arg);
 // Not generated automatically so that we can add an extra attribute.
 void ch_log(channel_T *ch, const char *fmt, ...) ATTRIBUTE_FORMAT_PRINTF(2, 3);
 void ch_error(channel_T *ch, const char *fmt, ...) ATTRIBUTE_FORMAT_PRINTF(2, 3);
+void vch_log(channel_T *ch, const char *fmt, va_list ap);
+void vch_error(channel_T *ch, const char *fmt, va_list ap);
 # endif
 
 # if defined(FEAT_GUI) || defined(FEAT_JOB_CHANNEL)

--- a/src/testdir/test_vim9_class.vim
+++ b/src/testdir/test_vim9_class.vim
@@ -2929,6 +2929,35 @@ def Test_call_interface_method()
   v9.CheckSourceSuccess(lines)
 enddef
 
+def Test_class_inherits_interface()
+  # Check dynamic dispatching. See https://github.com/vim/vim/issues/15484.
+  var lines =<< trim END
+    vim9script
+
+    interface I
+      def F(): string
+    endinterface
+
+    class A implements I
+      def F(): string
+        return 'A'
+      enddef
+    endclass
+
+    class C extends A
+      def F(): string
+        return 'C'
+      enddef
+    endclass
+
+    def TestI(i: I): string
+      return i.F()
+    enddef
+    assert_equal('C', TestI(C.new()))
+  END
+  v9.CheckSourceSuccess(lines)
+enddef
+
 def Test_class_used_as_type()
   var lines =<< trim END
     vim9script


### PR DESCRIPTION
Experimental fix for #15484

This PR is essentially an additional step to `vim9class.c::validate_implements_classes()`. It looks at the class which is being extended and adds any interfaces from the extended class to the new class. Then they can be found when the new class is used/typed as the interface. See #15484 for details and discussion.

If nothing more, this patch points to the data structures and runtime involved in the problem.