### PR TITLE
Preserve substitute pattern with :keeppatterns

### DIFF
--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -379,7 +379,7 @@ terminals)
 
 :keepp[atterns] {command}			*:keepp* *:keeppatterns*
 		Execute {command}, without adding anything to the search
-		history
+		history or modifying the last substitute pattern.
 
 ==============================================================================
 2. Command-line completion				*cmdline-completion*

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -3777,6 +3777,7 @@ ex_substitute(exarg_T *eap)
     int		endcolumn = FALSE;	// cursor in last column when done
     pos_T	old_cursor = curwin->w_cursor;
     int		start_nsubs;
+    int		keeppatterns = cmdmod.cmod_flags & CMOD_KEEPPATTERNS;
 #ifdef FEAT_EVAL
     int		save_ma = 0;
     int		save_sandbox = 0;
@@ -3876,7 +3877,7 @@ ex_substitute(exarg_T *eap)
 		    // out of memory
 		    return;
 	    }
-	    else
+	    else if (!keeppatterns)
 	    {
 		vim_free(old_sub);
 		old_sub = vim_strsave(sub);
@@ -3940,7 +3941,7 @@ ex_substitute(exarg_T *eap)
 	    ex_may_print(eap);
 	}
 
-	if ((cmdmod.cmod_flags & CMOD_KEEPPATTERNS) == 0)
+	if (!keeppatterns)
 	    save_re_pat(RE_SUBST, pat, patlen, magic_isset());
 	// put pattern in history
 	add_to_history(HIST_SEARCH, pat, patlen, TRUE, NUL);

--- a/src/testdir/test_substitute.vim
+++ b/src/testdir/test_substitute.vim
@@ -806,7 +806,7 @@ func Test_replace_keeppatterns()
   a
 foobar
 
-substitute foo asdf
+substitute foo asdf foo
 
 one two
 .
@@ -815,21 +815,26 @@ one two
   /^substitute
   s/foo/bar/
   call assert_equal('foo', @/)
-  call assert_equal('substitute bar asdf', getline('.'))
+  call assert_equal('substitute bar asdf foo', getline('.'))
 
   /^substitute
   keeppatterns s/asdf/xyz/
   call assert_equal('^substitute', @/)
-  call assert_equal('substitute bar xyz', getline('.'))
+  call assert_equal('substitute bar xyz foo', getline('.'))
+
+  /^substitute
+  &
+  call assert_equal('^substitute', @/)
+  call assert_equal('substitute bar xyz bar', getline('.'))
 
   exe "normal /bar /e\<CR>"
   call assert_equal(15, col('.'))
   normal -
   keeppatterns /xyz
   call assert_equal('bar ', @/)
-  call assert_equal('substitute bar xyz', getline('.'))
+  call assert_equal('substitute bar xyz bar', getline('.'))
   exe "normal 0dn"
-  call assert_equal('xyz', getline('.'))
+  call assert_equal('xyz bar', getline('.'))
 
   close!
 endfunc


### PR DESCRIPTION
**Problem**: The `:keeppatterns` modifier does not preserve the last substitute pattern, so `:s/foo/bar`, `:keeppatterns s/asdf/xyz` followed by `:&` will replace `foo` with `xyz` (not `bar`). This makes it impossible for plugins to use a substitute command without modifying the user's own substitute pattern history.

**Solution**: Make `:keeppatterns` also preserve the substitute pattern.
