### PR TITLE
Changed pattern for comments '#.' in cleanup.vim script.

### DIFF
--- a/src/po/cleanup.vim
+++ b/src/po/cleanup.vim
@@ -9,24 +9,24 @@ let s:was_diff = &diff
 setl nodiff
 
 " untranslated message preceded by c-format or comment
-silent g/^#, c-format\n#/.d
-silent g/^#\..*\n#/.d
+silent g/^#, c-format\n#/.d _
+silent g/^#\..*\n#/.d _
 
 " c-format comments have no effect, the check.vim scripts checks it.
 " But they might still be useful?
-" silent g/^#, c-format$/d
+" silent g/^#, c-format$/d _
 
-silent g/^#[:~] /d
+silent g/^#[:~] /d _
 silent g/^#, fuzzy\(, .*\)\=\nmsgid ""\@!/.+1,/^$/-1s/^/#\~ /
 silent g/^msgstr"/s//msgstr "/
 silent g/^msgid"/s//msgid "/
 silent g/^msgstr ""\(\n"\)\@!/?^msgid?,.s/^/#\~ /
 
 " Comments only useful for the translator
-silent g/^#\. /d
+silent g/^#\./d _
 
 " clean up empty lines
-silent g/^\n\n\n/.d
+silent g/^\n\n\n/.d _
 silent! %s/\n\+\%$//
 
 if s:was_diff


### PR DESCRIPTION
Problem: Comments like '#.' are not deleted if they are followed by an
end-of-line character.
Solution: Removed the space in the `global` command search pattern `#\. `.

Other. Added a register "black hole" for the `d` operator.
