### PR TITLE
Rename from w_closing to w_locked is incomplete

### DIFF
--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -2838,7 +2838,7 @@ do_ecmd(
 		int	    did_decrement;
 		buf_T	    *was_curbuf = curbuf;
 
-		// Set the w_closing flag to avoid that autocommands close the
+		// Set the w_locked flag to avoid that autocommands close the
 		// window.  And set b_locked for the same reason.
 		the_curwin->w_locked = TRUE;
 		++buf->b_locked;

--- a/src/structs.h
+++ b/src/structs.h
@@ -3785,8 +3785,7 @@ struct window_S
     synblock_T	*w_s;		    // for :ownsyntax
 #endif
 
-    int		w_locked;	    // window is being closed, don't let
-				    // autocommands close it too.
+    int		w_locked;	    // don't let autocommands close the window
 
     frame_T	*w_frame;	    // frame containing this window
 

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -3647,7 +3647,7 @@ term_after_channel_closed(term_T *term)
 	if (term->tl_finish == TL_FINISH_CLOSE)
 	{
 	    aco_save_T	aco;
-	    int		do_set_w_closing = term->tl_buffer->b_nwindows == 0;
+	    int		do_set_w_locked = term->tl_buffer->b_nwindows == 0;
 #ifdef FEAT_PROP_POPUP
 	    win_T	*pwin = NULL;
 
@@ -3678,11 +3678,11 @@ term_after_channel_closed(term_T *term)
 	    {
 		// Avoid closing the window if we temporarily use it.
 		if (is_aucmd_win(curwin))
-		    do_set_w_closing = TRUE;
-		if (do_set_w_closing)
+		    do_set_w_locked = TRUE;
+		if (do_set_w_locked)
 		    curwin->w_locked = TRUE;
 		do_bufdel(DOBUF_WIPE, (char_u *)"", 1, fnum, fnum, FALSE);
-		if (do_set_w_closing)
+		if (do_set_w_locked)
 		    curwin->w_locked = FALSE;
 		aucmd_restbuf(&aco);
 	    }


### PR DESCRIPTION
Problem:  Rename from w_closing to w_locked is incomplete
          (after 9.1.0678).
Solution: Rename remaining occurrences of w_closing to w_locked and
          update comments.
