### PR TITLE
VMS does not have defined uintptr_t

### DIFF
--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -7541,6 +7541,14 @@ f_hostname(typval_T *argvars UNUSED, typval_T *rettv)
  * Currently only valid for object/container types.
  * Return empty string if not an object.
  */
+#ifdef VMS // VMS does not have defined uintptr_t
+# if defined(HAVE_NO_LONG_LONG)
+typedef unsigned int uintptr_t;
+# else
+typedef unsigned long long uintptr_t;
+# endif
+#endif // VMS
+
     static void
 f_id(typval_T *argvars, typval_T *rettv)
 {


### PR DESCRIPTION
There are systems where the uintptr_t is not defined.
This pull request fixes the issue on VMS systems, but I guess there will be added some other exotic architectures that has the very same problem.

Thanks.