### PR TITLE
runtime(doc): fix grammar in :h :keeppatterns

### DIFF
--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -1,4 +1,4 @@
-*cmdline.txt*   For Vim version 9.1.  Last change: 2024 Aug 19
+*cmdline.txt*   For Vim version 9.1.  Last change: 2024 Aug 20
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -379,8 +379,8 @@ terminals)
 
 :keepp[atterns] {command}			*:keepp* *:keeppatterns*
 		Execute {command}, without adding anything to the search
-		history and, in case of the the |:s| and |:&| command, without
-		modifying the last substitute pattern and substitute string.
+		history and, in case of |:s| or |:&|, without modifying the
+		last substitute pattern or substitute string.
 
 ==============================================================================
 2. Command-line completion				*cmdline-completion*


### PR DESCRIPTION
- It's clear that :s and :& are Ex commands, so remove "command" along
  with the duplicate "the".
- Use "or" instead of "and" following "without".
