### PR TITLE
refine pandoc compiler settings

### DIFF
--- a/runtime/compiler/pandoc.vim
+++ b/runtime/compiler/pandoc.vim
@@ -25,30 +25,32 @@ let s:supported_filetypes =
 
 silent! function s:PandocFiletype(filetype) abort
   let ft = a:filetype
-  if ft ==# 'pandoc'
-    return 'markdown'
-  elseif ft ==# 'tex'
-    return 'latex'
-  elseif ft ==# 'xml'
-    " Pandoc does not support XML as a generic input format, but it does support
-    " EndNote XML and Jats XML out of which the latter seems more universal.
-    return 'jats'
-  elseif ft ==# 'text' || empty(ft)
-    return 'markdown'
-  elseif index(s:supported_filetypes, &ft) >= 0
-      return ft
+
+  if     ft ==# 'pandoc' | return 'markdown'
+  elseif ft ==# 'tex'    | return 'latex'
+  " Pandoc does not support XML as a generic input format, but it does support
+  " EndNote XML and Jats XML out of which the latter seems more universal.
+  elseif ft ==# 'xml'    | return 'jats'
+  elseif ft ==# 'text' || empty(ft)             | return 'markdown'
+  elseif index(s:supported_filetypes, &ft) >= 0 | return ft
   else
-    echomsg 'Unsupported filetype: ' . ft . ', falling back to Markdown as input format!'
+    echomsg 'Unsupported filetype: '..ft..', falling back to Markdown as input format!'
     return 'markdown'
   endif
 endfunction
-execute 'CompilerSet makeprg=pandoc\ --standalone' .
-      \ '\ --metadata\ title=%:t:r:S' .
-      \ '\ --metadata\ lang=' . matchstr(&spelllang, '^\a\a') .
-      \ '\ --from=' . s:PandocFiletype(&filetype) .
-      \ '\ ' . escape(get(b:, 'pandoc_compiler_args', get(g:, 'pandoc_compiler_args', '')), ' ') .
-      \ '\ --output\ %:r:S.$*\ %:S'
 
+let b:pandoc_compiler_from = get(b:, 'pandoc_compiler_from', s:PandocFiletype(&filetype))
+let b:pandoc_compiler_lang = get(b:, 'pandoc_compiler_lang', &spell ? matchstr(&spelllang, '^\a\a') : '')
+
+execute 'CompilerSet makeprg=pandoc'..escape(
+      \ ' --standalone' .
+      \ (b:pandoc_compiler_from ==# 'markdown' && (getline(1) =~# '^%\s\+\S\+' || (search('^title:\s+\S+', 'cnw') > 0)) ?
+      \ '' : ' --metadata title=%:t:r:S') .
+      \ empty(b:pandoc_compiler_lang) ?
+      \ '' : ' --metadata lang='..b:pandoc_compiler_lang .
+      \ ' --from='..b:pandoc_compiler_from .
+      \ ' '..get(b:, 'pandoc_compiler_args', get(g:, 'pandoc_compiler_args', '')) .
+      \ ' --output %:r:S.$* -- %:S', ' ')
 CompilerSet errorformat="%f",\ line\ %l:\ %m
 
 let &cpo = s:keepcpo

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -1345,6 +1345,13 @@ Additional arguments can be passed to pandoc:
 - either by appending them to make, say `:make html --self-contained` .
 - or setting them in `b:pandoc_compiler_args` or `g:pandoc_compiler_args`.
 
+The `--from` argument is an educated guess using the buffer file type;
+it can be overridden by setting `b:pandoc_compiler_from`.
+Likewise the `--metadata lang` argument is set using `&spelllang`;
+it can be overridden by setting `b:pandoc_compiler_lang`.
+If `--from=markdown` is assumed and no title set in a title header or
+YAML block, then the filename (without extension) is used as the title.
+
 PERL					*quickfix-perl* *compiler-perl*
 
 The Perl compiler plugin doesn't actually compile, but invokes Perl's internal


### PR DESCRIPTION
Make some settings configurable, just in case, and be less aggressive setting output document title, in particular if provided in source buffer