### PR TITLE
fix(completion): do not update the shown match when noselect set

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -1311,7 +1311,8 @@ ins_compl_build_pum(void)
 		{
 		    did_find_shown_match = TRUE;
 		    max_fuzzy_score = compl->cp_score;
-		    compl_shown_match = compl;
+		    if (!compl_no_select)
+			compl_shown_match = compl;
 		}
 
 		if (!shown_match_ok && compl == compl_shown_match && !compl_no_select)

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -2654,6 +2654,13 @@ func Test_complete_fuzzy_match()
   call feedkeys("Su\<C-X>\<C-L>\<C-P>\<Esc>0", 'tx!')
   call assert_equal('no one can save me but you', getline('.'))
 
+  " issue #15526
+  set completeopt=fuzzy,menuone,menu,noselect
+  call setline(1, ['Text', 'ToText', ''])
+  call cursor(2, 1)
+  call feedkeys("STe\<C-X>\<C-N>x\<CR>\<Esc>0", 'tx!')
+  call assert_equal('Tex', getline('.'))
+
   " clean up
   set omnifunc=
   bw!


### PR DESCRIPTION
Problem: when noselect is set the compl_shown_match still update.

Solution: check noselect before update compl_shown_match.

Fix #15526