### PR TITLE
Fix `mode()` returns wrong value at cmdline in visual mode

### DIFF
--- a/src/misc1.c
+++ b/src/misc1.c
@@ -678,17 +678,6 @@ get_mode(char_u *buf)
 	buf[i++] = 't';
     }
 #endif
-    else if (VIsual_active)
-    {
-	if (VIsual_select)
-	    buf[i++] = VIsual_mode + 's' - 'v';
-	else
-	{
-	    buf[i++] = VIsual_mode;
-	    if (restart_VIsual_select)
-		buf[i++] = 's';
-	}
-    }
     else if (State == MODE_HITRETURN || State == MODE_ASKMORE
 						      || State == MODE_SETWSIZE
 		|| State == MODE_CONFIRM)
@@ -730,6 +719,17 @@ get_mode(char_u *buf)
 	    buf[i++] = 'e';
 	if ((State & MODE_CMDLINE) && cmdline_overstrike())
 	    buf[i++] = 'r';
+    }
+    else if (VIsual_active)
+    {
+	if (VIsual_select)
+	    buf[i++] = VIsual_mode + 's' - 'v';
+	else
+	{
+	    buf[i++] = VIsual_mode;
+	    if (restart_VIsual_select)
+		buf[i++] = 's';
+	}
     }
     else
     {

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -923,6 +923,10 @@ func Test_mode()
   call feedkeys("gQ\<Insert>\<F2>vi\<CR>", 'xt')
   call assert_equal("c-cvr", g:current_modes)
 
+  " Commandline mode in Visual mode should return "c-c", never "v-v".
+  call feedkeys("v\<Cmd>call input('')\<CR>\<F2>\<CR>\<Esc>", 'xt')
+  call assert_equal("c-c", g:current_modes)
+
   " Executing commands in Vim Ex mode should return "cv", never "cvr",
   " as Cmdline editing has already ended.
   call feedkeys("gQcall Save_mode()\<CR>vi\<CR>", 'xt')


### PR DESCRIPTION
Problem: `mode()` returns wrong value at directly called commandline mode in visual mode
Solution: Change decision priority of `VIsual_active`