### PR TITLE
Problem:  Vim9: dereferences NULL pointer in check_type_is_value()

### DIFF
--- a/src/testdir/test_vim9_cmd.vim
+++ b/src/testdir/test_vim9_cmd.vim
@@ -2036,6 +2036,14 @@ def Test_no_space_after_command()
   v9.CheckDefExecAndScriptFailure(lines, 'E486:', 1)
 enddef
 
+def Test_lambda_crash()
+  # This used to crash Vim
+  var lines =<< trim END
+    vim9 () => super      => {
+  END
+  v9.CheckSourceFailure(lines, 'E1356: "super" must be followed by a dot', 1)
+enddef
+
 " Test for the 'previewpopup' option
 def Test_previewpopup()
   set previewpopup=height:10,width:60

--- a/src/vim9type.c
+++ b/src/vim9type.c
@@ -2138,12 +2138,13 @@ check_type_is_value(type_T *type)
     switch (type->tt_type)
     {
 	case VAR_CLASS:
-	    if (IS_ENUM(type->tt_class))
+	    if (type->tt_class != NULL && IS_ENUM(type->tt_class))
 		semsg(_(e_using_enum_as_value_str),
 			type->tt_class->class_name);
 	    else
 		semsg(_(e_using_class_as_value_str),
-			type->tt_class->class_name);
+			type->tt_class == NULL ? (char_u *)""
+			: type->tt_class->class_name);
 	    return FAIL;
 
 	case VAR_TYPEALIAS:


### PR DESCRIPTION
Problem:  Vim9: dereferences NULL pointer in check_type_is_value()
Solution: Verify that the pointer is not Null

closes: #15540