### PR TITLE
runtime(java): Make optional the use of the bundled `&foldtext` function

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1,4 +1,4 @@
-*syntax.txt*	For Vim version 9.1.  Last change: 2024 Aug 13
+*syntax.txt*	For Vim version 9.1.  Last change: 2024 Aug 22
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -2134,6 +2134,14 @@ Note that these three variables are maintained in the HTML syntax file.
 
 Numbers and strings can be recognized in non-Javadoc comments with >
 	:let g:java_comment_strings = 1
+
+When 'foldmethod' is set to "syntax", blocks of code and multi-line comments
+will be folded.  No text is usually written in the first line of a multi-line
+comment, making folded contents of Javadoc comments less informative with the
+default 'foldtext' value; you may opt for showing the contents of a second
+line for any comments written in this way, and showing the contents of a first
+line otherwise, with >
+	:let g:java_foldtext_show_first_or_second_line = 1
 
 Trailing whitespace characters or a run of space characters before a tab
 character can be marked as an error with >

--- a/runtime/syntax/testdir/dumps/java_enfoldment_00.dump
+++ b/runtime/syntax/testdir/dumps/java_enfoldment_00.dump
@@ -1,5 +1,5 @@
 | +0#0000e05#a8a8a8255@1>/+0&#ffffff0@1| |V|I|M|_|T|E|S|T|_|S|E|T|U|P| |s|e|t|l|o|c|a|l| |f|o|l|d|e|n|a|b|l|e| |f|o|l|d|c|o|l|u|m|n|=|2| |f|o|l|d|m|e|t|h|o|d|=|s|y|n|t|a|x| +0#0000000&@4
-| +0#0000e05#a8a8a8255@1| +0#0000000#ffffff0@72
+| +0#0000e05#a8a8a8255@1|/+0&#ffffff0@1| |V|I|M|_|T|E|S|T|_|S|E|T|U|P| |l|e|t| |g|:|j|a|v|a|_|f|o|l|d|t|e|x|t|_|s|h|o|w|_|f|i|r|s|t|_|o|r|_|s|e|c|o|n|d|_|l|i|n|e| |=| |1| +0#0000000&@5
 | +0#0000e05#a8a8a8255@1| +0#0000000#ffffff0@72
 |++0#0000e05#a8a8a8255| |+|-@1| |1|6| |l|i|n|e|s|:| |@|S|u|p@1|r|e|s@1|W|a|r|n|i|n|g|s|(|{|-@39
 | @1|c+0#00e0003#ffffff0|l|a|s@1| +0#0000000&|F|o|l|d|i|n|g|T|e|s|t|s| |{| @52

--- a/runtime/syntax/testdir/input/java_enfoldment.java
+++ b/runtime/syntax/testdir/input/java_enfoldment.java
@@ -1,5 +1,5 @@
 // VIM_TEST_SETUP setlocal foldenable foldcolumn=2 foldmethod=syntax
-
+// VIM_TEST_SETUP let g:java_foldtext_show_first_or_second_line = 1
 
 	@SuppressWarnings({
 	"""


### PR DESCRIPTION
- Obtain and pass through translated messages with this
  function.
- If `g:java_foldtext_show_first_or_second_line` is defined,
  assign this function to `&foldtext`.
