### PR TITLE
runtime(netrw): Change line on `mx` if command output exists

### DIFF
--- a/runtime/autoload/netrw.vim
+++ b/runtime/autoload/netrw.vim
@@ -7500,6 +7500,9 @@ fun! s:NetrwMarkFileExe(islocal,enbloc)
        NetrwKeepj call netrw#ErrorMsg(s:ERROR,"command<".xcmd."> failed, aborting",54)
        break
       else
+       if ret !=# ''
+        echo "\n"
+       endif
        echo ret
       endif
      endfor


### PR DESCRIPTION
On external command execution by `mx` shortcut,
the command output is printed right after user input.

![netrw_mx_20240822_161912](https://github.com/user-attachments/assets/834d4b92-1b6c-461b-9234-c3324d72f1e8)

Shouldn't it change line?

#### How to Repro

```vim
" Open NetRW
:e ./

" Select some file in NetRW
mf

" Execute a command for the selected files
mx
file
" Then, the output of external command `file` follows this user input without line change.
```
