### PR TITLE
runtime(netrw): Fix `mf`-selected entry highlighting

### DIFF
--- a/runtime/autoload/netrw.vim
+++ b/runtime/autoload/netrw.vim
@@ -6887,11 +6887,7 @@ fun! s:NetrwMarkFile(islocal,fname)
 
   let ykeep   = @@
   let curbufnr= bufnr("%")
-  if a:fname =~ '^\a'
-   let leader= '\<'
-  else
-   let leader= ''
-  endif
+  let leader= '\(^\|\s\)\zs'
   if a:fname =~ '\a$'
    let trailer = '\>[@=|\/\*]\=\ze\%(  \|\t\|$\)'
   else


### PR DESCRIPTION
On file select (`mf`), NetRW highlights selected files.

However, it's highlighting pattern being bad,
it can highlights some parts of other files.

![netrw_mf_20240822_162235](https://github.com/user-attachments/assets/5a731115-1f59-4357-b6a1-29223bf5dbaa)

#### How to Repro

```vim
" Open NetRW
:e ./

" Create the target files
:!touch tmp .tmp a.tmp

" Select the file `tmp` in NetRW
mf

" Now, it should highlight the file `tmp` only,
" but the `tmp` parts of other file names are also highlighted.
```

Since the target pattern is now `\<TARGET_FILE_NAME\>[@=|\/\*]\=\ze\%(  \|\t\|$\)`,
the `\<` or word-beginning matches the alphabet after `.` unexpectedly.
