### PR TITLE
runtime(syntax): fix missing syntax highlighting for html in htmlangular

### DIFF
--- a/runtime/syntax/htmlangular.vim
+++ b/runtime/syntax/htmlangular.vim
@@ -1,0 +1,18 @@
+" Vim syntax file
+" Language: Angular HTML template
+" Maintainer: Dennis van den Berg <dennis@vdberg.dev>
+" Last Change: 2024 Aug 22
+
+" quit when a syntax file was already loaded
+if exists("b:current_syntax")
+  finish
+endif
+
+if !exists("main_syntax")
+  let main_syntax = 'html'
+endif
+
+runtime! syntax/html.vim
+unlet b:current_syntax
+
+let b:current_syntax = "htmlangular"


### PR DESCRIPTION
Fixes #15459 

I did not have time to figure out how to do the Angular specific syntax highlighting. Is there any documentation on that part? Any help is appreciated.

At least the HTML highlighting should be fixed with this.