### PR TITLE
Problem:  python3: stable-abi by default may cause segfault on Unix

### DIFF
--- a/src/auto/configure
+++ b/src/auto/configure
@@ -7092,21 +7092,16 @@ printf %s "checking --with-python3-stable-abi argument... " >&6; }
 if test ${with_python3_stable_abi+y}
 then :
   withval=$with_python3_stable_abi;
-	 if test "X$withval" = "Xyes"; then
-	   vi_cv_var_python3_stable_abi=$python3_stable_abi_default
-	 else
-	   vi_cv_var_python3_stable_abi="$withval"
-	 fi
-	 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $vi_cv_var_python3_stable_abi" >&5
+     if test "X$withval" = "Xyes"; then
+       vi_cv_var_python3_stable_abi=$python3_stable_abi_default
+     else
+       vi_cv_var_python3_stable_abi="$withval"
+     fi
+     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $vi_cv_var_python3_stable_abi" >&5
 printf "%s\n" "$vi_cv_var_python3_stable_abi" >&6; }
-else $as_nop
-
-	 vi_cv_var_python3_stable_abi=$python3_stable_abi_default
-	 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no. defaults to $python3_stable_abi_default." >&5
-printf "%s\n" "no. defaults to $python3_stable_abi_default." >&6; }
 fi
 
-      if test "X$vi_cv_var_python3_stable_abi" != "Xno"; then
+      if test "X$vi_cv_var_python3_stable_abi" != "X"; then
         if test ${vi_cv_var_python3_stable_abi_hex+y}
 then :
   printf %s "(cached) " >&6

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -1544,16 +1544,13 @@ if test "$enable_python3interp" = "yes" -o "$enable_python3interp" = "dynamic"; 
       AC_SUBST(vi_cv_var_python3_stable_abi)
       AC_ARG_WITH(python3-stable-abi, [  --with-python3-stable-abi=VERSION  stable ABI version to target (default: 3.8)],
         [
-	 if test "X$withval" = "Xyes"; then
-	   vi_cv_var_python3_stable_abi=$python3_stable_abi_default
-	 else
-	   vi_cv_var_python3_stable_abi="$withval"
-	 fi
-	 AC_MSG_RESULT($vi_cv_var_python3_stable_abi)],
-        [
-	 vi_cv_var_python3_stable_abi=$python3_stable_abi_default
-	 AC_MSG_RESULT(no. defaults to $python3_stable_abi_default.)])
-      if test "X$vi_cv_var_python3_stable_abi" != "Xno"; then
+     if test "X$withval" = "Xyes"; then
+       vi_cv_var_python3_stable_abi=$python3_stable_abi_default
+     else
+       vi_cv_var_python3_stable_abi="$withval"
+     fi
+     AC_MSG_RESULT($vi_cv_var_python3_stable_abi)])
+      if test "X$vi_cv_var_python3_stable_abi" != "X"; then
         AC_CACHE_VAL(vi_cv_var_python3_stable_abi_hex,
         [
          vi_cv_var_python3_stable_abi_hex=`


### PR DESCRIPTION
Problem:  python3: stable-abi by default may cause segfault on Unix
Solution: do not enable the stable Python ABI by default, only when used
          with --with-python3-stable-abi argument is given

related: #15543

cc @k-takata 