### PR TITLE
Wrong patlen value in ex_substitute()

### DIFF
--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -3841,11 +3841,11 @@ ex_substitute(exarg_T *eap)
 	    which_pat = RE_LAST;	    // use last used regexp
 	    delimiter = *cmd++;		    // remember delimiter character
 	    pat = cmd;			    // remember start of search pat
-	    patlen = STRLEN(pat);
 	    cmd = skip_regexp_ex(cmd, delimiter, magic_isset(),
 							&eap->arg, NULL, NULL);
 	    if (cmd[0] == delimiter)	    // end delimiter found
 		*cmd++ = NUL;		    // replace it with a NUL
+	    patlen = STRLEN(pat);
 	}
 
 	/*

--- a/src/testdir/test_search.vim
+++ b/src/testdir/test_search.vim
@@ -1747,6 +1747,37 @@ func Test_search_with_no_last_pat()
   call delete('Xresult')
 endfunc
 
+" Test for using the last substitute pattern without last search pattern.
+func Test_search_with_last_substitute_pat()
+  let lines =<< trim [SCRIPT]
+    new
+    set shortmess+=S
+    call setline(1, repeat(['foofoo'], 3))
+    %s/foo/bar/
+    call assert_equal(repeat(['barfoo'], 3), getline(1, '$'))
+
+    call cursor(1, 1)
+    call assert_equal("/foo", execute('call feedkeys("/\r", "tx")', '')->trim())
+    call assert_equal([0, 1, 4, 0], getpos('.'))
+
+    if has('rightleft')
+      set rightleft rightleftcmd=search
+      call cursor(1, 1)
+      call assert_equal("oof/", execute('call feedkeys("/\r", "tx")', '')->trim())
+      call assert_equal([0, 1, 4, 0], getpos('.'))
+    endif
+
+    call writefile(v:errors, 'Xresult')
+    qall!
+  [SCRIPT]
+  call writefile(lines, 'Xscript', 'D')
+
+  if RunVim([], [], '--clean -S Xscript')
+    call assert_equal([], readfile('Xresult'))
+  endif
+  call delete('Xresult')
+endfunc
+
 " Test for using tilde (~) atom in search. This should use the last used
 " substitute pattern
 func Test_search_tilde_pat()


### PR DESCRIPTION
Problem:  Wrong patlen value in ex_substitute() (after 9.1.0426).
Solution: Compute patlen after finding end separator.

Add a more explicit test.  The test already passes as the only case
where a overlarge patlen value matters was fixed by patch 9.1.0689.
