### PR TITLE
"Untitled" file not removed when running Test_crash1_3 alone

### DIFF
--- a/src/testdir/test_crash.vim
+++ b/src/testdir/test_crash.vim
@@ -237,9 +237,9 @@ func Test_crash2()
   exe buf .. "bw!"
 endfunc
 
-func Test_zz_cleanup()
-  " That file is created at Test_crash1_2() by dialog_changed_uaf
-  " but cleanup in that Test, doesn't remove it. Let's try again at
+func TearDown()
+  " That file is created at Test_crash1_3() by dialog_changed_uaf
+  " but cleaning up in that test doesn't remove it. Let's try again at
   " the end of this test script
   call delete('Untitled')
 endfunc


### PR DESCRIPTION
Problem:  "Untitled" file not removed when running Test_crash1_3 alone
          with TEST_FILTER.
Solution: Use a TearDown function instead of another test.
