### PR TITLE
dvgo is not always an inclusive motion

### DIFF
--- a/runtime/doc/motion.txt
+++ b/runtime/doc/motion.txt
@@ -1,4 +1,4 @@
-*motion.txt*    For Vim version 9.1.  Last change: 2024 Jul 14
+*motion.txt*    For Vim version 9.1.  Last change: 2024 Aug 28
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -364,11 +364,11 @@ gg			Goto line [count], default first line, on the first
 			See also 'startofline' option.
 
 :[range]go[to] [count]					*:go* *:goto* *go*
-[count]go		Go to [count] byte in the buffer.  Default [count] is
-			one, start of the file.  When giving [range], the
-			last number in it used as the byte count.  End-of-line
-			characters are counted depending on the current
-			'fileformat' setting.
+[count]go		Go to [count] byte in the buffer.  |exclusive| motion.
+			Default [count] is one, start of the file.  When
+			giving [range], the last number in it used as the byte
+			count.  End-of-line characters are counted depending
+			on the current 'fileformat' setting.
 			Also see the |line2byte()| function, and the 'o'
 			option in 'statusline'.
 			{not available when compiled without the

--- a/src/normal.c
+++ b/src/normal.c
@@ -6227,6 +6227,7 @@ nv_g_cmd(cmdarg_T *cap)
 #ifdef FEAT_BYTEOFF
     // "go": goto byte count from start of buffer
     case 'o':
+	oap->inclusive = FALSE;
 	goto_byte(cap->count0);
 	break;
 #endif

--- a/src/testdir/test_normal.vim
+++ b/src/testdir/test_normal.vim
@@ -4281,4 +4281,17 @@ func Test_scroll_longline_no_loop()
   exe "normal! \<C-E>"
   bwipe!
 endfunc
+
+" Test for go command
+func Test_normal_go()
+  new
+  call setline(1, ['one two three four'])
+  call cursor(1, 5)
+  norm! dvgo
+  call assert_equal('wo three four', getline(1))
+  norm! ...
+  call assert_equal('three four', getline(1))
+
+  bwipe!
+endfunc
 " vim: shiftwidth=2 sts=2 expandtab nofoldenable


### PR DESCRIPTION
Problem:  "dvgo" is not always an inclusive motion
Solution: initialize oap->inclusive to FALSE always

fixes: #15580