### PR TITLE
Optimize insertion (`:normal 10000ix`)

### DIFF
--- a/src/edit.c
+++ b/src/edit.c
@@ -512,6 +512,7 @@ edit(
 #ifdef FEAT_DIFF
 		&& curwin->w_topfill == old_topfill
 #endif
+		&& count <= 1
 		)
 	{
 	    mincol = curwin->w_wcol;
@@ -568,7 +569,8 @@ edit(
 
 	if (curwin->w_p_crb)
 	    do_check_cursorbind();
-	update_curswant();
+	if (count <= 1)
+	    update_curswant();
 	old_topline = curwin->w_topline;
 #ifdef FEAT_DIFF
 	old_topfill = curwin->w_topfill;

--- a/src/edit.c
+++ b/src/edit.c
@@ -549,11 +549,13 @@ edit(
 	}
 
 	// May need to adjust w_topline to show the cursor.
-	update_topline();
+	if (!char_avail())
+	    update_topline();
 
 	did_backspace = FALSE;
 
-	validate_cursor();		// may set must_redraw
+	if (!char_avail())
+	    validate_cursor();		// may set must_redraw
 
 	/*
 	 * Redraw the display when no characters are waiting.

--- a/src/edit.c
+++ b/src/edit.c
@@ -549,12 +549,12 @@ edit(
 	}
 
 	// May need to adjust w_topline to show the cursor.
-	if (!char_avail())
+	if (count <= 1)
 	    update_topline();
 
 	did_backspace = FALSE;
 
-	if (!char_avail())
+	if (count <= 1)
 	    validate_cursor();		// may set must_redraw
 
 	/*


### PR DESCRIPTION
Editing a very long line in Vim is slow.
This patch optimizes the insertion with a large count (e.g. `:normal 10000ix`).

It seems that calculation of the cursor position for a long line is slow and it takes O(n^2).
Disable the calculation if not needed.

Before:
```
$ time ./vim --clean -c 'normal 10000ix' -cq!
real    0m1.879s
user    0m1.328s
sys     0m0.139s

$ time ./vim --clean -c 'normal 20000ix' -cq!
real    0m5.574s
user    0m5.421s
sys     0m0.093s

$ time ./vim --clean -c 'normal 40000ix' -cq!
real    0m23.588s
user    0m23.187s
sys     0m0.140s
```

After:
```
$ time ./vim --clean -c 'normal 10000ix' -cq!
real    0m0.715s
user    0m0.156s
sys     0m0.155s

$ time ./vim --clean -c 'normal 20000ix' -cq!
real    0m0.678s
user    0m0.515s
sys     0m0.109s

$ time ./vim --clean -c 'normal 40000ix' -cq!
real    0m2.475s
user    0m2.311s
sys     0m0.124s
```