### PR TITLE
Fix test_gettext tests when run in a shadowdir

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,7 @@ jobs:
             libtool-bin \
             libncurses-dev:${{ matrix.architecture }} \
             libxt-dev:${{ matrix.architecture }} \
+            locales-all \
           )
           if ${{ matrix.features == 'huge' }}; then
             LUA_VER=${{ matrix.lua_ver || '5.4' }}

--- a/src/Makefile
+++ b/src/Makefile
@@ -2939,6 +2939,7 @@ shadow:	runtime pixmaps
 				 ../../testdir/*.py \
 				 ../../testdir/python* \
 				 ../../testdir/pyxfile \
+				 ../../testdir/ru_RU \
 				 ../../testdir/sautest \
 				 ../../testdir/samples \
 				 ../../testdir/dumps \


### PR DESCRIPTION
Install locales-all package so the tests actually run in CI (which then exposes the issue in the shadowdir-enabled job).

Symlink the ru_RU directory into the shadowdir so the translations are available when testing inside a shadowdir.