### PR TITLE
Optimize memory allocation for insertion

### DIFF
--- a/src/change.c
+++ b/src/change.c
@@ -1181,6 +1181,7 @@ ins_char_bytes(char_u *buf, int charlen)
     void
 ins_str(char_u *s)
 {
+    static char_u	*prevp = NULL;
     char_u	*oldp, *newp;
     int		newlen = (int)STRLEN(s);
     int		oldlen;
@@ -1198,7 +1199,7 @@ ins_str(char_u *s)
 
     newtotlen = oldlen + newlen;
     new_size = newtotlen + 1;
-    if ((curbuf->b_ml.ml_line_size < new_size)
+    if ((curbuf->b_ml.ml_line_size < new_size) || (prevp != oldp)
 #ifdef FEAT_PROP_POPUP
 	    || curbuf->b_has_textprop
 #endif
@@ -1215,6 +1216,7 @@ ins_str(char_u *s)
     }
     else
 	newp = oldp;
+    prevp = newp;
 
     if (col > 0 && newp != oldp)
 	mch_memmove(newp, oldp, (size_t)col);

--- a/src/change.c
+++ b/src/change.c
@@ -1212,19 +1212,17 @@ ins_str(char_u *s)
 	newp = alloc(new_size);
 	if (newp == NULL)
 	    return;
+	curbuf->b_ml.ml_line_size = new_size;
     }
     else
-    {
 	newp = oldp;
-	new_size = curbuf->b_ml.ml_line_size;
-    }
     prevp = newp;
 
     if (col > 0 && newp != oldp)
 	mch_memmove(newp, oldp, (size_t)col);
     mch_memmove(newp + col + newlen, oldp + col, (size_t)(oldlen - col + 1));
     mch_memmove(newp + col, s, (size_t)newlen);
-    ml_replace_len_size(lnum, newp, newtotlen, FALSE, FALSE, new_size);
+    ml_replace_len(lnum, newp, newtotlen, FALSE, FALSE);
     inserted_bytes(lnum, col, newlen);
     curwin->w_cursor.col += newlen;
 }

--- a/src/change.c
+++ b/src/change.c
@@ -1212,17 +1212,19 @@ ins_str(char_u *s)
 	newp = alloc(new_size);
 	if (newp == NULL)
 	    return;
-	curbuf->b_ml.ml_line_size = new_size;
     }
     else
+    {
 	newp = oldp;
+	new_size = curbuf->b_ml.ml_line_size;
+    }
     prevp = newp;
 
     if (col > 0 && newp != oldp)
 	mch_memmove(newp, oldp, (size_t)col);
     mch_memmove(newp + col + newlen, oldp + col, (size_t)(oldlen - col + 1));
     mch_memmove(newp + col, s, (size_t)newlen);
-    ml_replace_len(lnum, newp, newtotlen, FALSE, FALSE);
+    ml_replace_len_size(lnum, newp, newtotlen, FALSE, FALSE, new_size);
     inserted_bytes(lnum, col, newlen);
     curwin->w_cursor.col += newlen;
 }

--- a/src/change.c
+++ b/src/change.c
@@ -1181,6 +1181,7 @@ ins_char_bytes(char_u *buf, int charlen)
     void
 ins_str(char_u *s)
 {
+    static char_u	*prevp = NULL;
     char_u	*oldp, *newp;
     int		newlen = (int)STRLEN(s);
     int		oldlen;
@@ -1198,7 +1199,7 @@ ins_str(char_u *s)
 
     newtotlen = oldlen + newlen;
     new_size = newtotlen + 1;
-    if ((curbuf->b_ml.ml_line_size < new_size)
+    if ((curbuf->b_ml.ml_line_size < new_size) || (prevp != oldp)
 #ifdef FEAT_PROP_POPUP
 	    || curbuf->b_has_textprop
 #endif
@@ -1217,6 +1218,7 @@ ins_str(char_u *s)
 	newp = oldp;
 	new_size = curbuf->b_ml.ml_line_size;
     }
+    prevp = newp;
 
     if (col > 0 && newp != oldp)
 	mch_memmove(newp, oldp, (size_t)col);

--- a/src/change.c
+++ b/src/change.c
@@ -1181,7 +1181,6 @@ ins_char_bytes(char_u *buf, int charlen)
     void
 ins_str(char_u *s)
 {
-    static char_u	*prevp = NULL;
     char_u	*oldp, *newp;
     int		newlen = (int)STRLEN(s);
     int		oldlen;
@@ -1199,7 +1198,7 @@ ins_str(char_u *s)
 
     newtotlen = oldlen + newlen;
     new_size = newtotlen + 1;
-    if ((curbuf->b_ml.ml_line_size < new_size) || (prevp != oldp)
+    if ((curbuf->b_ml.ml_line_size < new_size)
 #ifdef FEAT_PROP_POPUP
 	    || curbuf->b_has_textprop
 #endif
@@ -1218,7 +1217,6 @@ ins_str(char_u *s)
 	newp = oldp;
 	new_size = curbuf->b_ml.ml_line_size;
     }
-    prevp = newp;
 
     if (col > 0 && newp != oldp)
 	mch_memmove(newp, oldp, (size_t)col);

--- a/src/change.c
+++ b/src/change.c
@@ -1181,7 +1181,6 @@ ins_char_bytes(char_u *buf, int charlen)
     void
 ins_str(char_u *s)
 {
-    static char_u	*prevp = NULL;
     char_u	*oldp, *newp;
     int		newlen = (int)STRLEN(s);
     int		oldlen;
@@ -1199,7 +1198,7 @@ ins_str(char_u *s)
 
     newtotlen = oldlen + newlen;
     new_size = newtotlen + 1;
-    if ((curbuf->b_ml.ml_line_size < new_size) || (prevp != oldp)
+    if ((curbuf->b_ml.ml_line_size < new_size)
 #ifdef FEAT_PROP_POPUP
 	    || curbuf->b_has_textprop
 #endif
@@ -1216,7 +1215,6 @@ ins_str(char_u *s)
     }
     else
 	newp = oldp;
-    prevp = newp;
 
     if (col > 0 && newp != oldp)
 	mch_memmove(newp, oldp, (size_t)col);

--- a/src/edit.c
+++ b/src/edit.c
@@ -4125,7 +4125,10 @@ ins_bs(
 
 			    if (curbuf->b_ml.ml_flags
 					      & (ML_LINE_DIRTY | ML_ALLOCATED))
+			    {
 				vim_free(curbuf->b_ml.ml_line_ptr);
+				curbuf->b_ml.ml_line_size = 0;
+			    }
 			    curbuf->b_ml.ml_line_ptr = newp;
 			    curbuf->b_ml.ml_line_len--;
 			    curbuf->b_ml.ml_line_textlen--;
@@ -5111,7 +5114,10 @@ ins_tab(void)
 					   curbuf->b_ml.ml_line_len - col - i);
 
 		    if (curbuf->b_ml.ml_flags & (ML_LINE_DIRTY | ML_ALLOCATED))
+		    {
 			vim_free(curbuf->b_ml.ml_line_ptr);
+			curbuf->b_ml.ml_line_size = 0;
+		    }
 		    curbuf->b_ml.ml_line_ptr = newp;
 		    curbuf->b_ml.ml_line_len -= i;
 		    curbuf->b_ml.ml_line_textlen = 0;

--- a/src/memline.c
+++ b/src/memline.c
@@ -4246,7 +4246,10 @@ ml_flush_line(buf_T *buf)
 	entered = FALSE;
     }
     else if (buf->b_ml.ml_flags & ML_ALLOCATED)
+    {
 	vim_free(buf->b_ml.ml_line_ptr);
+	buf->b_ml.ml_line_size = 0;
+    }
 
     buf->b_ml.ml_flags &= ~(ML_LINE_DIRTY | ML_ALLOCATED);
     buf->b_ml.ml_line_lnum = 0;

--- a/src/memline.c
+++ b/src/memline.c
@@ -883,10 +883,7 @@ ml_close(buf_T *buf, int del_file)
     mf_close(buf->b_ml.ml_mfp, del_file);	// close the .swp file
     if (buf->b_ml.ml_line_lnum != 0
 		      && (buf->b_ml.ml_flags & (ML_LINE_DIRTY | ML_ALLOCATED)))
-    {
 	vim_free(buf->b_ml.ml_line_ptr);
-	buf->b_ml.ml_line_size = 0;
-    }
     vim_free(buf->b_ml.ml_stack);
 #ifdef FEAT_BYTEOFF
     VIM_CLEAR(buf->b_ml.ml_chunksize);
@@ -3582,7 +3579,7 @@ ml_replace(linenr_T lnum, char_u *line, int copy)
 
     if (line != NULL)
 	len = (colnr_T)STRLEN(line);
-    return ml_replace_len_size(lnum, line, len, FALSE, copy, 0);
+    return ml_replace_len(lnum, line, len, FALSE, copy);
 }
 
 /*
@@ -3601,27 +3598,8 @@ ml_replace_len(
 	int	    has_props,
 	int	    copy)
 {
-    return ml_replace_len_size(lnum, line_arg, len_arg, has_props, copy, 0);
-}
-
-/*
- * Replace a line for the current buffer.  Like ml_replace_len() with:
- * "size_arg" is the size of the buffer.
- * If this is called from ins_str(), "size_arg" is set to non-zero and
- * "line_arg" can be same with curbuf->b_ml.ml_line_ptr.
- */
-    int
-ml_replace_len_size(
-	linenr_T    lnum,
-	char_u	    *line_arg,
-	colnr_T	    len_arg,
-	int	    has_props,
-	int	    copy,
-	int	    size_arg)
-{
     char_u *line = line_arg;
     colnr_T len = len_arg;
-    int	    size = size_arg;
 
     if (line == NULL)		// just checking...
 	return FAIL;
@@ -3682,7 +3660,6 @@ ml_replace_len_size(
 		mch_memmove(newline + len, curbuf->b_ml.ml_line_ptr
 						    + oldtextlen, textproplen);
 		vim_free(line);
-		size = 0;
 		line = newline;
 		len += (colnr_T)textproplen;
 	    }
@@ -3696,7 +3673,6 @@ ml_replace_len_size(
 
     curbuf->b_ml.ml_line_ptr = line;
     curbuf->b_ml.ml_line_len = len;
-    curbuf->b_ml.ml_line_size = size;
     curbuf->b_ml.ml_line_textlen = !has_props ? len_arg + 1 : 0;
     curbuf->b_ml.ml_line_lnum = lnum;
     curbuf->b_ml.ml_flags = (curbuf->b_ml.ml_flags | ML_LINE_DIRTY) & ~ML_EMPTY;
@@ -4270,10 +4246,7 @@ ml_flush_line(buf_T *buf)
 	entered = FALSE;
     }
     else if (buf->b_ml.ml_flags & ML_ALLOCATED)
-    {
 	vim_free(buf->b_ml.ml_line_ptr);
-	buf->b_ml.ml_line_size = 0;
-    }
 
     buf->b_ml.ml_flags &= ~(ML_LINE_DIRTY | ML_ALLOCATED);
     buf->b_ml.ml_line_lnum = 0;

--- a/src/memline.c
+++ b/src/memline.c
@@ -2812,6 +2812,7 @@ errorret:
 
 	buf->b_ml.ml_line_ptr = (char_u *)dp + start;
 	buf->b_ml.ml_line_len = end - start;
+	buf->b_ml.ml_line_size = 0;
 #if defined(FEAT_BYTEOFF) && defined(FEAT_PROP_POPUP)
 	// Text properties come after a NUL byte, so ml_line_len should be
 	// larger than the size of textprop_T if there is any.
@@ -2845,6 +2846,7 @@ errorret:
 	{
 	    memmove(p, buf->b_ml.ml_line_ptr, buf->b_ml.ml_line_len);
 	    buf->b_ml.ml_line_ptr = p;
+	    buf->b_ml.ml_line_size = 0;
 	    buf->b_ml.ml_flags |= ML_ALLOCATED;
 	    if (will_change)
 		// can't make the change in the data block

--- a/src/memline.c
+++ b/src/memline.c
@@ -3663,7 +3663,8 @@ ml_replace_len(
     }
 #endif
 
-    if (curbuf->b_ml.ml_flags & (ML_LINE_DIRTY | ML_ALLOCATED))
+    if ((curbuf->b_ml.ml_flags & (ML_LINE_DIRTY | ML_ALLOCATED))
+	    && (curbuf->b_ml.ml_line_ptr != line))
 	vim_free(curbuf->b_ml.ml_line_ptr);	// free allocated line
 
     curbuf->b_ml.ml_line_ptr = line;
@@ -4236,6 +4237,7 @@ ml_flush_line(buf_T *buf)
 	    }
 	}
 	vim_free(new_line);
+	buf->b_ml.ml_line_size = 0;
 
 	entered = FALSE;
     }

--- a/src/memline.c
+++ b/src/memline.c
@@ -2751,6 +2751,7 @@ ml_get_buf(
 errorret:
 	STRCPY(questions, "???");
 	buf->b_ml.ml_line_len = 4;
+	buf->b_ml.ml_line_size = 0;
 	buf->b_ml.ml_line_textlen = buf->b_ml.ml_line_len;
 	buf->b_ml.ml_line_lnum = lnum;
 	return questions;
@@ -2761,6 +2762,7 @@ errorret:
     if (buf->b_ml.ml_mfp == NULL)	// there are no lines
     {
 	buf->b_ml.ml_line_len = 1;
+	buf->b_ml.ml_line_size = 0;
 	buf->b_ml.ml_line_textlen = buf->b_ml.ml_line_len;
 	return (char_u *)"";
     }

--- a/src/memline.c
+++ b/src/memline.c
@@ -883,7 +883,10 @@ ml_close(buf_T *buf, int del_file)
     mf_close(buf->b_ml.ml_mfp, del_file);	// close the .swp file
     if (buf->b_ml.ml_line_lnum != 0
 		      && (buf->b_ml.ml_flags & (ML_LINE_DIRTY | ML_ALLOCATED)))
+    {
 	vim_free(buf->b_ml.ml_line_ptr);
+	buf->b_ml.ml_line_size = 0;
+    }
     vim_free(buf->b_ml.ml_stack);
 #ifdef FEAT_BYTEOFF
     VIM_CLEAR(buf->b_ml.ml_chunksize);

--- a/src/proto/memline.pro
+++ b/src/proto/memline.pro
@@ -31,6 +31,7 @@ int ml_append_flags(linenr_T lnum, char_u *line, colnr_T len, int flags);
 int ml_append_buf(buf_T *buf, linenr_T lnum, char_u *line, colnr_T len, int newfile);
 int ml_replace(linenr_T lnum, char_u *line, int copy);
 int ml_replace_len(linenr_T lnum, char_u *line_arg, colnr_T len_arg, int has_props, int copy);
+int ml_replace_len_size(linenr_T lnum, char_u *line_arg, colnr_T len_arg, int has_props, int copy, int size_arg);
 int ml_delete(linenr_T lnum);
 int ml_delete_flags(linenr_T lnum, int flags);
 void ml_setmarked(linenr_T lnum);

--- a/src/proto/memline.pro
+++ b/src/proto/memline.pro
@@ -31,7 +31,6 @@ int ml_append_flags(linenr_T lnum, char_u *line, colnr_T len, int flags);
 int ml_append_buf(buf_T *buf, linenr_T lnum, char_u *line, colnr_T len, int newfile);
 int ml_replace(linenr_T lnum, char_u *line, int copy);
 int ml_replace_len(linenr_T lnum, char_u *line_arg, colnr_T len_arg, int has_props, int copy);
-int ml_replace_len_size(linenr_T lnum, char_u *line_arg, colnr_T len_arg, int has_props, int copy, int size_arg);
 int ml_delete(linenr_T lnum);
 int ml_delete_flags(linenr_T lnum, int flags);
 void ml_setmarked(linenr_T lnum);

--- a/src/structs.h
+++ b/src/structs.h
@@ -802,6 +802,7 @@ typedef struct memline
 #define ML_ALLOCATED	0x10	// ml_line_ptr is an allocated copy
     int		ml_flags;
 
+    colnr_T	ml_line_size;	// allocated size of ml_line_ptr (Used by ins_str())
     colnr_T	ml_line_len;	// length of the cached line + NUL + text properties
     colnr_T	ml_line_textlen;// length of the cached line + NUL, 0 if not known yet
     linenr_T	ml_line_lnum;	// line number of cached line, 0 if not valid

--- a/src/textprop.c
+++ b/src/textprop.c
@@ -318,7 +318,10 @@ prop_add_one(
 					    sizeof(textprop_T) * (proplen - i));
 
 	if (buf->b_ml.ml_flags & (ML_LINE_DIRTY | ML_ALLOCATED))
+	{
 	    vim_free(buf->b_ml.ml_line_ptr);
+	    buf->b_ml.ml_line_size = 0;
+	}
 	buf->b_ml.ml_line_ptr = newtext;
 	buf->b_ml.ml_line_len += sizeof(textprop_T);
 	buf->b_ml.ml_flags |= ML_LINE_DIRTY;
@@ -866,7 +869,10 @@ set_text_props(linenr_T lnum, char_u *props, int len)
     if (len > 0)
 	mch_memmove(newtext + textlen, props, len);
     if (curbuf->b_ml.ml_flags & (ML_LINE_DIRTY | ML_ALLOCATED))
+    {
 	vim_free(curbuf->b_ml.ml_line_ptr);
+	curbuf->b_ml.ml_line_size = 0;
+    }
     curbuf->b_ml.ml_line_ptr = newtext;
     curbuf->b_ml.ml_line_len = textlen + len;
     curbuf->b_ml.ml_flags |= ML_LINE_DIRTY;
@@ -889,7 +895,10 @@ add_text_props(linenr_T lnum, textprop_T *text_props, int text_prop_count)
     mch_memmove(newtext, text, curbuf->b_ml.ml_line_len);
     mch_memmove(newtext + curbuf->b_ml.ml_line_len, text_props, proplen);
     if (curbuf->b_ml.ml_flags & (ML_LINE_DIRTY | ML_ALLOCATED))
+    {
 	vim_free(curbuf->b_ml.ml_line_ptr);
+	curbuf->b_ml.ml_line_size = 0;
+    }
     curbuf->b_ml.ml_line_ptr = newtext;
     curbuf->b_ml.ml_line_len += proplen;
     curbuf->b_ml.ml_flags |= ML_LINE_DIRTY;
@@ -1097,7 +1106,10 @@ f_prop_clear(typval_T *argvars, typval_T *rettv UNUSED)
 		if (newtext == NULL)
 		    return;
 		if (buf->b_ml.ml_flags & ML_ALLOCATED)
+		{
 		    vim_free(buf->b_ml.ml_line_ptr);
+		    buf->b_ml.ml_line_size = 0;
+		}
 		buf->b_ml.ml_line_ptr = newtext;
 		buf->b_ml.ml_flags |= ML_LINE_DIRTY;
 	    }
@@ -1716,7 +1728,10 @@ f_prop_remove(typval_T *argvars, typval_T *rettv)
 			mch_memmove(newptr, buf->b_ml.ml_line_ptr,
 							buf->b_ml.ml_line_len);
 			if (buf->b_ml.ml_flags & ML_ALLOCATED)
+			{
 			    vim_free(buf->b_ml.ml_line_ptr);
+			    buf->b_ml.ml_line_size = 0;
+			}
 			buf->b_ml.ml_line_ptr = newptr;
 			buf->b_ml.ml_flags |= ML_LINE_DIRTY;
 
@@ -2291,7 +2306,10 @@ adjust_prop_columns(
 	    char_u *p = vim_memsave(curbuf->b_ml.ml_line_ptr, newlen);
 
 	    if (curbuf->b_ml.ml_flags & ML_ALLOCATED)
+	    {
 		vim_free(curbuf->b_ml.ml_line_ptr);
+		curbuf->b_ml.ml_line_size = 0;
+	    }
 	    curbuf->b_ml.ml_line_ptr = p;
 	}
 	curbuf->b_ml.ml_flags |= ML_LINE_DIRTY;


### PR DESCRIPTION
This is an additional optimization for #15588.
Reduce the memory allocation in ins_str().

If this PR is combined with #15588, `:normal 10000ix` becomes O(n):
```
$ time ./vim --clean -c 'normal 160000ix' -cq!
real    0m0.684s
user    0m0.109s
sys     0m0.108s

$ time ./vim --clean -c 'normal 1280000ix' -cq!
real    0m0.969s
user    0m0.827s
sys     0m0.077s
```