### PR TITLE
GUIEnter event not found in Turkish locale

### DIFF
--- a/src/highlight.c
+++ b/src/highlight.c
@@ -1215,8 +1215,8 @@ highlight_set_cterm_color(
 
 	target.key = 0;
 	target.value = (char *)arg;
-	target.length = 0;	// not used, see cmp_keyvalue_value_i()
-	entry = (keyvalue_T *)bsearch(&target, &color_name_tab, ARRAY_LENGTH(color_name_tab), sizeof(color_name_tab[0]), cmp_keyvalue_value_i);
+	target.length = 0;	// not used, see cmp_keyvalue_value_ni()
+	entry = (keyvalue_T *)bsearch(&target, &color_name_tab, ARRAY_LENGTH(color_name_tab), sizeof(color_name_tab[0]), cmp_keyvalue_value_ni);
 	if (entry == NULL)
 	{
 	    semsg(_(e_color_name_or_number_not_recognized_str), key_start);
@@ -2542,8 +2542,8 @@ gui_get_color_cmn(char_u *name)
 
     target.key = 0;
     target.value = (char *)name;
-    target.length = 0;		// not used, see cmp_keyvalue_value_i()
-    entry = (keyvalue_T *)bsearch(&target, &rgb_tab, ARRAY_LENGTH(rgb_tab), sizeof(rgb_tab[0]), cmp_keyvalue_value_i);
+    target.length = 0;		// not used, see cmp_keyvalue_value_ni()
+    entry = (keyvalue_T *)bsearch(&target, &rgb_tab, ARRAY_LENGTH(rgb_tab), sizeof(rgb_tab[0]), cmp_keyvalue_value_ni);
     if (entry != NULL)
 	return gui_adjust_rgb((guicolor_T)entry->key);
 

--- a/src/misc2.c
+++ b/src/misc2.c
@@ -3090,16 +3090,6 @@ cmp_keyvalue_value_n(const void *a, const void *b)
     return STRNCMP(kv1->value, kv2->value, MAX(kv1->length, kv2->length));
 }
 
-// compare two keyvalue_T structs by case insensitive value
-    int
-cmp_keyvalue_value_i(const void *a, const void *b)
-{
-    keyvalue_T *kv1 = (keyvalue_T *)a;
-    keyvalue_T *kv2 = (keyvalue_T *)b;
-
-    return STRICMP(kv1->value, kv2->value);
-}
-
 // compare two keyvalue_T structs by case insensitive ASCII value
 // with length
     int

--- a/src/misc2.c
+++ b/src/misc2.c
@@ -3100,7 +3100,7 @@ cmp_keyvalue_value_i(const void *a, const void *b)
     return STRICMP(kv1->value, kv2->value);
 }
 
-// compare two keyvalue_T structs by case insensitive value
+// compare two keyvalue_T structs by case insensitive ASCII value
 // with length
     int
 cmp_keyvalue_value_ni(const void *a, const void *b)
@@ -3108,6 +3108,6 @@ cmp_keyvalue_value_ni(const void *a, const void *b)
     keyvalue_T *kv1 = (keyvalue_T *)a;
     keyvalue_T *kv2 = (keyvalue_T *)b;
 
-    return STRNICMP(kv1->value, kv2->value, MAX(kv1->length, kv2->length));
+    return vim_strnicmp_asc(kv1->value, kv2->value, MAX(kv1->length, kv2->length));
 }
 

--- a/src/proto/misc2.pro
+++ b/src/proto/misc2.pro
@@ -63,6 +63,5 @@ int build_argv_from_list(list_T *l, char ***argv, int *argc);
 int get_special_pty_type(void);
 int cmp_keyvalue_value(const void *a, const void *b);
 int cmp_keyvalue_value_n(const void *a, const void *b);
-int cmp_keyvalue_value_i(const void *a, const void *b);
 int cmp_keyvalue_value_ni(const void *a, const void *b);
 /* vim: set ft=c : */

--- a/src/proto/strings.pro
+++ b/src/proto/strings.pro
@@ -15,6 +15,7 @@ void vim_strcat(char_u *to, char_u *from, size_t tosize);
 size_t vim_strlen_maxlen(char *s, size_t maxlen);
 int vim_stricmp(char *s1, char *s2);
 int vim_strnicmp(char *s1, char *s2, size_t len);
+int vim_strnicmp_asc(char *s1, char *s2, size_t len);
 char_u *vim_strchr(char_u *string, int c);
 char_u *vim_strbyte(char_u *string, int c);
 char_u *vim_strrchr(char_u *string, int c);

--- a/src/strings.c
+++ b/src/strings.c
@@ -590,6 +590,33 @@ vim_strnicmp(char *s1, char *s2, size_t len)
 #endif
 
 /*
+ * Compare two ASCII strings, for length "len", ignoring case, ignoring locale
+ * (mostly matters for turkish locale where i I might be different).
+ * return 0 for match, < 0 for smaller, > 0 for bigger
+ */
+    int
+vim_strnicmp_asc(char *s1, char *s2, size_t len)
+{
+    int                i;
+    int                save_cmp_flags = cmp_flags;
+
+    cmp_flags |= CMP_KEEPASCII;		// compare by ASCII value, ignoring locale
+    while (len > 0)
+    {
+       i = vim_tolower(*s1) - vim_tolower(*s2);
+       if (i != 0)
+           break;			// this character is different
+       if (*s1 == NUL)
+           break;			// strings match until NUL
+       ++s1;
+       ++s2;
+       --len;
+    }
+    cmp_flags = save_cmp_flags;
+    return i;
+}
+
+/*
  * Search for first occurrence of "c" in "string".
  * Version of strchr() that handles unsigned char strings with characters from
  * 128 to 255 correctly.  It also doesn't return a pointer to the NUL at the

--- a/src/testdir/test_autocmd.vim
+++ b/src/testdir/test_autocmd.vim
@@ -4863,5 +4863,24 @@ func Test_WinNewPre_crash()
   let &cmdheight=_cmdheight
 endfunc
 
+" The specifics of the turkish locale may
+" cause that Vim will not treat the GuiEnter autocommand
+" as case insensitive and instead issues an error
+func Test_GuiEnter_Turkish_locale()
+  try
+    let lng = v:lang
+    lang tr_TR.UTF-8
+    let result = execute(':au GuiEnter')
+    call assert_equal("\n--- Autocommands ---", result)
+    let result = execute(':au GUIENTER')
+    call assert_equal("\n--- Autocommands ---", result)
+    let result = execute(':au guienter')
+    call assert_equal("\n--- Autocommands ---", result)
+    exe ":lang" lng
+  catch /E197:/
+    " can't use Turkish locale
+    throw 'Skipped: Turkish locale not available'
+  endtry
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:   GUIEnter not found in Turkish locale
           (James McCoy, after v9.1.0256, the issue was there before,
            but v9.1.0256 made it more apparent)
Solution:  explicitly compare autocommand events by ASCII value and
           ignoring locale, because according to the documentation,
           events are case insensitive (:h autocommand-events)

fixes: #15574