### PR TITLE
Recursive window update does not account for reset skipcol

### DIFF
--- a/src/drawscreen.c
+++ b/src/drawscreen.c
@@ -2774,7 +2774,7 @@ win_update(win_T *wp)
 		    redrawWinline(wp, wp->w_cursor.lnum);
 	    }
 #endif
-	    // New redraw either due to updated topline or due to wcol fix.
+	    // New redraw either due to updated topline, wcol fix or reset skipcol.
 	    if (wp->w_redr_type != 0)
 	    {
 		// Don't update for changes in buffer again.
@@ -2782,6 +2782,7 @@ win_update(win_T *wp)
 		curbuf->b_mod_set = FALSE;
 		j = curbuf->b_mod_xlines;
 		curbuf->b_mod_xlines = 0;
+		curs_columns(TRUE);
 		win_update(curwin);
 		curbuf->b_mod_set = i;
 		curbuf->b_mod_xlines = j;

--- a/src/testdir/dumps/Test_smooth_long_scrolloff_1.dump
+++ b/src/testdir/dumps/Test_smooth_long_scrolloff_1.dump
@@ -1,8 +1,8 @@
-| +0&#ffffff0@39
-@40
-@40
-> @39
-@40
-@40
-@40
-@40
+|<+0#4040ff13#ffffff0@2|t+0#0000000&|w|o| |l|o|n|g| |t|w|o| |l|o|n|g| |t|w|o| |l|o|n|g| |t|w|o| |l|o|n|g| |t
+|w|o| |l|o|n|g| |t|w|o| |l|o|n|g| |t|w|o| |l|o|n|g| |t|w|o| |l|o|n|g| |t|w|o| |l
+|o|n|g| |t|w|o| |l|o|n|g| |t|w|o| |l|o|n|g| |t|w|o| |l|o|n|g| |t|w|o| |l|o|n|g| 
+>t|w|o| |l|o|n|g| |t|w|o| |l|o|n|g| |t|w|o| |l|o|n|g| |t|w|o| |l|o|n|g| |t|w|o| 
+|l|o|n|g| |t|w|o| |l|o|n|g| |t|w|o| |l|o|n|g| |t|w|o| |l|o|n|g| |t|w|o| |l|o|n|g
+| |t|w|o| |l|o|n|g| |t|w|o| |l|o|n|g| |t|w|o| |l|o|n|g| |t|w|o| |l|o|n|g| |t|w|o
+| |l|o|n|g| |t|w|o| |l|o|n|g| |t|w|o| |l|o|n|g| |t|w|o| |l|o|n|g| |t|w|o| |l|o|n
+| @39

--- a/src/testdir/dumps/Test_smooth_long_scrolloff_7.dump
+++ b/src/testdir/dumps/Test_smooth_long_scrolloff_7.dump
@@ -1,8 +1,8 @@
-| +0&#ffffff0@39
-@40
-@40
-@40
-@40
-@40
-> @39
+|<+0#4040ff13#ffffff0@2|l+0#0000000&|o|n|g| |t|w|o| |l|o|n|g| |t|w|o| |l|o|n|g| |t|w|o| |l|o|n|g| |t|w|o| |l
+|o|n|g| |t|w|o| |l|o|n|g| |t|w|o| |l|o|n|g| |t|w|o| |l|o|n|g| |t|w|o| |l|o|n|g| 
+|t|w|o| |l|o|n|g| |t|w|o| |l|o|n|g| |t|w|o| |l|o|n|g| |t|w|o| |l|o|n|g| |t|w|o| 
+|l|o|n|g| |t|w|o| |l|o|n|g| |t|w|o| |l|o|n|g| |t|w|o| |l|o|n|g| |t|w|o| |l|o|n|g
+| |t|w|o| |l|o|n|g| |t|w|o| |l|o|n|g| |t|w|o| |l|o|n|g| |t|w|o| |l|o|n|g| |t|w|o
+| |l|o|n|g| |t|w|o| |l|o|n|g| |t|w|o| |l|o|n|g| |t|w|o| |l|o|n|g| |t|w|o| |l|o|n
+>g| |t|w|o| |l|o|n|g| |t|w|o| |l|o|n|g| @20
 @40

--- a/src/testdir/test_scroll_opt.vim
+++ b/src/testdir/test_scroll_opt.vim
@@ -1162,7 +1162,6 @@ func Test_smooth_long_scrolloff()
   END
   call writefile(lines, 'XSmoothLongScrolloff', 'D')
   let buf = RunVimInTerminal('-u NONE -S XSmoothLongScrolloff', #{rows: 8, cols: 40})
-  "FIXME: empty screen due to reset_skipcol()/curs_columns() shenanigans
   call term_sendkeys(buf, ":norm j721|\<CR>")
   call VerifyScreenDump(buf, 'Test_smooth_long_scrolloff_1', {})
 
@@ -1182,7 +1181,6 @@ func Test_smooth_long_scrolloff()
   call VerifyScreenDump(buf, 'Test_smooth_long_scrolloff_6', {})
 
   call term_sendkeys(buf, "gk")
-  "FIXME: empty screen due to reset_skipcol()/curs_columns() shenanigans
   call VerifyScreenDump(buf, 'Test_smooth_long_scrolloff_7', {})
 
   call StopVimInTerminal(buf)


### PR DESCRIPTION
Problem:  Window is updated with potentially invalid skipcol in recursive
          window update path. I.e. cursor outside of visible range in
          large line that does not fit.
Solution: Make sure it is valid.