### PR TITLE
Newline causes E749 in Ex mode

### DIFF
--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -2916,6 +2916,11 @@ parse_command_modifiers(
 	    }
 	    return FAIL;
 	}
+	if (eap->nextcmd == NULL && *eap->cmd == '\n')
+	{
+	    eap->nextcmd = eap->cmd + 1;
+	    return FAIL;
+	}
 	if (*eap->cmd == NUL)
 	{
 	    if (!skip_only)

--- a/src/testdir/test_ex_mode.vim
+++ b/src/testdir/test_ex_mode.vim
@@ -387,4 +387,20 @@ func Test_global_insert_newline()
   bwipe!
 endfunc
 
+" An empty command followed by a newline shouldn't cause E749 in Ex mode.
+func Test_ex_empty_command_newline()
+  let g:var = 0
+  call feedkeys("gQexecute \"\\nlet g:var = 1\"\r", 'xt')
+  call assert_equal(1, g:var)
+  call feedkeys("gQexecute \"  \\nlet g:var = 2\"\r", 'xt')
+  call assert_equal(2, g:var)
+  call feedkeys("gQexecute \"\\t \\nlet g:var = 3\"\r", 'xt')
+  call assert_equal(3, g:var)
+  call feedkeys("gQexecute \"\\\"?!\\nlet g:var = 4\"\r", 'xt')
+  call assert_equal(4, g:var)
+  call feedkeys("gQexecute \"  \\\"?!\\nlet g:var = 5\"\r", 'xt')
+  call assert_equal(5, g:var)
+  unlet g:var
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  Newline causes E749 in Ex mode (after 9.1.0573).
Solution: Don't execute empty command followed by a newline.

Fix #15613