### PR TITLE
Not correctly parsing color names (after v9.1.0709)

### DIFF
--- a/src/highlight.c
+++ b/src/highlight.c
@@ -1215,8 +1215,8 @@ highlight_set_cterm_color(
 
 	target.key = 0;
 	target.value = (char *)arg;
-	target.length = 0;	// not used, see cmp_keyvalue_value_ni()
-	entry = (keyvalue_T *)bsearch(&target, &color_name_tab, ARRAY_LENGTH(color_name_tab), sizeof(color_name_tab[0]), cmp_keyvalue_value_ni);
+	target.length = 0;	// not used, see cmp_keyvalue_value_i()
+	entry = (keyvalue_T *)bsearch(&target, &color_name_tab, ARRAY_LENGTH(color_name_tab), sizeof(color_name_tab[0]), cmp_keyvalue_value_i);
 	if (entry == NULL)
 	{
 	    semsg(_(e_color_name_or_number_not_recognized_str), key_start);
@@ -2542,8 +2542,8 @@ gui_get_color_cmn(char_u *name)
 
     target.key = 0;
     target.value = (char *)name;
-    target.length = 0;		// not used, see cmp_keyvalue_value_ni()
-    entry = (keyvalue_T *)bsearch(&target, &rgb_tab, ARRAY_LENGTH(rgb_tab), sizeof(rgb_tab[0]), cmp_keyvalue_value_ni);
+    target.length = 0;		// not used, see cmp_keyvalue_value_i()
+    entry = (keyvalue_T *)bsearch(&target, &rgb_tab, ARRAY_LENGTH(rgb_tab), sizeof(rgb_tab[0]), cmp_keyvalue_value_i);
     if (entry != NULL)
 	return gui_adjust_rgb((guicolor_T)entry->key);
 

--- a/src/misc2.c
+++ b/src/misc2.c
@@ -3090,6 +3090,16 @@ cmp_keyvalue_value_n(const void *a, const void *b)
     return STRNCMP(kv1->value, kv2->value, MAX(kv1->length, kv2->length));
 }
 
+// compare two keyvalue_T structs by case insensitive value
+    int
+cmp_keyvalue_value_i(const void *a, const void *b)
+{
+    keyvalue_T *kv1 = (keyvalue_T *)a;
+    keyvalue_T *kv2 = (keyvalue_T *)b;
+
+    return STRICMP(kv1->value, kv2->value);
+}
+
 // compare two keyvalue_T structs by case insensitive ASCII value
 // with length
     int

--- a/src/proto/misc2.pro
+++ b/src/proto/misc2.pro
@@ -63,5 +63,6 @@ int build_argv_from_list(list_T *l, char ***argv, int *argc);
 int get_special_pty_type(void);
 int cmp_keyvalue_value(const void *a, const void *b);
 int cmp_keyvalue_value_n(const void *a, const void *b);
+int cmp_keyvalue_value_i(const void *a, const void *b);
 int cmp_keyvalue_value_ni(const void *a, const void *b);
 /* vim: set ft=c : */


### PR DESCRIPTION
Problem:  Not correctly parsing color names (chdiza, after v9.1.0709)
Solution: Revert part of the patch that compares the color names

fixes: #15617