### PR TITLE
Optimize cursor computation

### DIFF
--- a/src/charset.c
+++ b/src/charset.c
@@ -900,7 +900,11 @@ win_linetabsize_cts(chartabsize_T *cts, colnr_T len)
 	    && (old_line != NULL)
 	    && (old_line == cts->cts_line)
 	    && (saved_ptr >= cts->cts_line)
-	    && (saved_ptr < cts->cts_line + slen))
+	    && (saved_ptr < cts->cts_line + slen)
+#ifdef FEAT_PROP_POPUP
+	    && !cts->cts_has_prop_with_text
+#endif
+       )
     {
 	cts->cts_ptr = saved_ptr;
 	cts->cts_vcol = vcol = saved_vcol;
@@ -913,7 +917,11 @@ win_linetabsize_cts(chartabsize_T *cts, colnr_T len)
 		&& (cts->cts_ptr > cts->cts_line)
 		&& (cts->cts_ptr - cts->cts_line <= col_save)
 		&& (cts->cts_ptr + (*mb_ptr2len)(cts->cts_ptr) - cts->cts_line
-			>= col_save))
+			>= col_save)
+#ifdef FEAT_PROP_POPUP
+		&& !cts->cts_has_prop_with_text
+#endif
+	   )
 	{
 	    saved_ptr = cts->cts_ptr;
 	    saved_vcol = vcol;
@@ -1744,7 +1752,11 @@ getvcol(
 		&& (old_line == line)
 		&& (saved_ptr >= line)
 		&& (saved_ptr < line + pos->col)
-		&& (old_cond == 2))
+		&& (old_cond == 2)
+#ifdef FEAT_PROP_POPUP
+		&& !cts.cts_has_prop_with_text
+#endif
+	   )
 	{
 	    cts.cts_ptr = saved_ptr;
 	    cts.cts_vcol = saved_vcol;
@@ -1779,7 +1791,11 @@ getvcol(
 	    if (s_use_vcol_cache
 		    && (cts.cts_ptr > line)
 		    && (cts.cts_ptr - line <= col_save)
-		    && (next_ptr - line >= col_save))
+		    && (next_ptr - line >= col_save)
+#ifdef FEAT_PROP_POPUP
+		    && !cts.cts_has_prop_with_text
+#endif
+	       )
 	    {
 		saved_ptr = next_ptr;
 		saved_vcol = cts.cts_vcol + incr;

--- a/src/charset.c
+++ b/src/charset.c
@@ -875,6 +875,7 @@ invalidate_vcol_cache(void)
     void
 win_linetabsize_cts(chartabsize_T *cts, colnr_T len)
 {
+    static win_T    *old_win = NULL;
     static char_u   *old_line = NULL;
     static char_u   *saved_ptr = NULL;
     static colnr_T  saved_vcol = 0;
@@ -897,8 +898,8 @@ win_linetabsize_cts(chartabsize_T *cts, colnr_T len)
     else
 	s_vcol_cache_valid1 = FALSE;
     if (s_vcol_cache_valid1
-	    && (old_line != NULL)
-	    && (old_line == cts->cts_line)
+	    && (old_win != NULL) && (old_win != cts->cts_win)
+	    && (old_line != NULL) && (old_line == cts->cts_line)
 	    && (saved_ptr >= cts->cts_line)
 	    && (saved_ptr < cts->cts_line + slen)
 #ifdef FEAT_PROP_POPUP
@@ -925,6 +926,7 @@ win_linetabsize_cts(chartabsize_T *cts, colnr_T len)
 	{
 	    saved_ptr = cts->cts_ptr;
 	    saved_vcol = vcol;
+	    old_win = cts->cts_win;
 	    old_line = cts->cts_line;
 	    s_vcol_cache_valid1 = TRUE;
 	}
@@ -1639,6 +1641,7 @@ getvcol(
     int		on_NUL = FALSE;
 #endif
     colnr_T	col_save = 0;
+    static win_T    *old_win = NULL;
     static char_u   *old_line = NULL;
     static char_u   *saved_ptr = NULL;
     static colnr_T  saved_vcol = 0;
@@ -1675,8 +1678,8 @@ getvcol(
        )
     {
 	if (s_vcol_cache_valid2
-		&& (old_line != NULL)
-		&& (old_line == line)
+		&& (old_win != NULL) && (old_win == wp)
+		&& (old_line != NULL) && (old_line == line)
 		&& (saved_ptr >= line)
 		&& (saved_ptr < line + pos->col)
 		&& (old_cond == 1))
@@ -1737,6 +1740,7 @@ getvcol(
 	    {
 		saved_ptr = next_ptr;
 		saved_vcol = vcol + incr;
+		old_win = wp;
 		old_line = line;
 		old_cond = 1;
 		s_vcol_cache_valid2 = TRUE;
@@ -1748,8 +1752,8 @@ getvcol(
     else
     {
 	if (s_vcol_cache_valid2
-		&& (old_line != NULL)
-		&& (old_line == line)
+		&& (old_win != NULL) && (old_win == wp)
+		&& (old_line != NULL) && (old_line == line)
 		&& (saved_ptr >= line)
 		&& (saved_ptr < line + pos->col)
 		&& (old_cond == 2)
@@ -1799,6 +1803,7 @@ getvcol(
 	    {
 		saved_ptr = next_ptr;
 		saved_vcol = cts.cts_vcol + incr;
+		old_win = wp;
 		old_line = line;
 		old_cond = 2;
 		s_vcol_cache_valid2 = TRUE;

--- a/src/charset.c
+++ b/src/charset.c
@@ -862,7 +862,7 @@ enable_vcol_cache(void)
     void
 disable_vcol_cache(void)
 {
-    s_use_vcol_cache = TRUE;
+    s_use_vcol_cache = FALSE;
 }
 
     void

--- a/src/charset.c
+++ b/src/charset.c
@@ -898,7 +898,7 @@ win_linetabsize_cts(chartabsize_T *cts, colnr_T len)
     else
 	s_vcol_cache_valid1 = FALSE;
     if (s_vcol_cache_valid1
-	    && (old_win != NULL) && (old_win != cts->cts_win)
+	    && (old_win != NULL) && (old_win == cts->cts_win)
 	    && (old_line != NULL) && (old_line == cts->cts_line)
 	    && (saved_ptr >= cts->cts_line)
 	    && (saved_ptr < cts->cts_line + slen)

--- a/src/charset.c
+++ b/src/charset.c
@@ -849,8 +849,21 @@ linetabsize_no_outer(win_T *wp, linenr_T lnum)
 #endif
 }
 
+static int s_use_vcol_cache = FALSE;
 static int s_vcol_cache_valid1 = FALSE;
 static int s_vcol_cache_valid2 = FALSE;
+
+    void
+enable_vcol_cache(void)
+{
+    s_use_vcol_cache = TRUE;
+}
+
+    void
+disable_vcol_cache(void)
+{
+    s_use_vcol_cache = TRUE;
+}
 
     void
 invalidate_vcol_cache(void)
@@ -866,17 +879,23 @@ win_linetabsize_cts(chartabsize_T *cts, colnr_T len)
     static char_u   *saved_ptr = NULL;
     static colnr_T  saved_vcol = 0;
     colnr_T slen = len;
-    colnr_T col_save;
+    colnr_T col_save = 0;
     vimlong_T vcol = cts->cts_vcol;
 
 #ifdef FEAT_PROP_POPUP
     cts->cts_with_trailing = len == MAXCOL;
 #endif
-    if (slen == MAXCOL)
-	slen = STRLEN(cts->cts_line);
-    col_save = (colnr_T)((varnumber_T)slen * 4 / 5);
-    if (slen - col_save > 4096)
-	col_save = slen - 4096;
+
+    if (s_use_vcol_cache)
+    {
+	if (slen == MAXCOL)
+	    slen = STRLEN(cts->cts_line);
+	col_save = (colnr_T)((varnumber_T)slen * 4 / 5);
+	if (slen - col_save > 4096)
+	    col_save = slen - 4096;
+    }
+    else
+	s_vcol_cache_valid1 = FALSE;
     if (s_vcol_cache_valid1
 	    && (old_line != NULL)
 	    && (old_line == cts->cts_line)
@@ -886,10 +905,12 @@ win_linetabsize_cts(chartabsize_T *cts, colnr_T len)
 	cts->cts_ptr = saved_ptr;
 	cts->cts_vcol = vcol = saved_vcol;
     }
+
     for ( ; *cts->cts_ptr != NUL && (len == MAXCOL || cts->cts_ptr < cts->cts_line + len);
 						      MB_PTR_ADV(cts->cts_ptr))
     {
-	if ((cts->cts_ptr > cts->cts_line)
+	if (s_use_vcol_cache
+		&& (cts->cts_ptr > cts->cts_line)
 		&& (cts->cts_ptr - cts->cts_line <= col_save)
 		&& (cts->cts_ptr + (*mb_ptr2len)(cts->cts_ptr) - cts->cts_line
 			>= col_save))
@@ -1609,7 +1630,7 @@ getvcol(
 #ifdef FEAT_PROP_POPUP
     int		on_NUL = FALSE;
 #endif
-    colnr_T	col_save;
+    colnr_T	col_save = 0;
     static char_u   *old_line = NULL;
     static char_u   *saved_ptr = NULL;
     static colnr_T  saved_vcol = 0;
@@ -1621,9 +1642,15 @@ getvcol(
     init_chartabsize_arg(&cts, wp, pos->lnum, 0, line, line);
     cts.cts_max_head_vcol = -1;
 
-    col_save = (colnr_T)((varnumber_T)pos->col * 4 / 5);
-    if (pos->col - col_save > 4096)
-	col_save = pos->col - 4096;
+    if (s_use_vcol_cache)
+    {
+	col_save = (colnr_T)((varnumber_T)pos->col * 4 / 5);
+	if (pos->col - col_save > 4096)
+	    col_save = pos->col - 4096;
+    }
+    else
+	s_vcol_cache_valid2 = FALSE;
+
     /*
      * This function is used very often, do some speed optimizations.
      * When 'list', 'linebreak', 'showbreak' and 'breakindent' are not set
@@ -1695,7 +1722,8 @@ getvcol(
 	    if (next_ptr - line > pos->col) // character at pos->col
 		break;
 
-	    if ((ptr > line)
+	    if (s_use_vcol_cache
+		    && (ptr > line)
 		    && (ptr - line <= col_save)
 		    && (next_ptr - line >= col_save))
 	    {
@@ -1748,7 +1776,8 @@ getvcol(
 	    if (next_ptr - line > pos->col) // character at pos->col
 		break;
 
-	    if ((cts.cts_ptr > line)
+	    if (s_use_vcol_cache
+		    && (cts.cts_ptr > line)
 		    && (cts.cts_ptr - line <= col_save)
 		    && (next_ptr - line >= col_save))
 	    {

--- a/src/charset.c
+++ b/src/charset.c
@@ -890,7 +890,12 @@ win_linetabsize_cts(chartabsize_T *cts, colnr_T len)
     if (s_use_vcol_cache)
     {
 	if (slen == MAXCOL)
-	    slen = STRLEN(cts->cts_line);
+	{
+	    if (cts->cts_len != -1)
+		slen = cts->cts_len;
+	    else
+		slen = STRLEN(cts->cts_line);
+	}
 	col_save = (colnr_T)((varnumber_T)slen * 4 / 5);
 	if (slen - col_save > 4096)
 	    col_save = slen - 4096;
@@ -1099,11 +1104,25 @@ init_chartabsize_arg(
 	char_u		*line,
 	char_u		*ptr)
 {
+    init_chartabsize_arg_len(cts, wp, lnum, col, line, ptr, -1);
+}
+
+    void
+init_chartabsize_arg_len(
+	chartabsize_T	*cts,
+	win_T		*wp,
+	linenr_T	lnum UNUSED,
+	colnr_T		col,
+	char_u		*line,
+	char_u		*ptr,
+	colnr_T		len)
+{
     CLEAR_POINTER(cts);
     cts->cts_win = wp;
     cts->cts_vcol = col;
     cts->cts_line = line;
     cts->cts_ptr = ptr;
+    cts->cts_len = len;
 #ifdef FEAT_LINEBREAK
     cts->cts_bri_size = -1;
 #endif

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -11942,6 +11942,7 @@ f_virtcol(typval_T *argvars, typval_T *rettv)
 	    if (fp->col > len)
 		fp->col = len;
 	}
+	invalidate_vcol_cache();
 	getvvcol(curwin, fp, &vcol_start, NULL, &vcol_end);
 	++vcol_start;
 	++vcol_end;

--- a/src/memline.c
+++ b/src/memline.c
@@ -883,7 +883,10 @@ ml_close(buf_T *buf, int del_file)
     mf_close(buf->b_ml.ml_mfp, del_file);	// close the .swp file
     if (buf->b_ml.ml_line_lnum != 0
 		      && (buf->b_ml.ml_flags & (ML_LINE_DIRTY | ML_ALLOCATED)))
+    {
 	vim_free(buf->b_ml.ml_line_ptr);
+	invalidate_vcol_cache();
+    }
     vim_free(buf->b_ml.ml_stack);
 #ifdef FEAT_BYTEOFF
     VIM_CLEAR(buf->b_ml.ml_chunksize);
@@ -3671,6 +3674,7 @@ ml_replace_len(
     curbuf->b_ml.ml_line_textlen = !has_props ? len_arg + 1 : 0;
     curbuf->b_ml.ml_line_lnum = lnum;
     curbuf->b_ml.ml_flags = (curbuf->b_ml.ml_flags | ML_LINE_DIRTY) & ~ML_EMPTY;
+    invalidate_vcol_cache();
 
     return OK;
 }
@@ -4236,11 +4240,15 @@ ml_flush_line(buf_T *buf)
 	    }
 	}
 	vim_free(new_line);
+	invalidate_vcol_cache();
 
 	entered = FALSE;
     }
     else if (buf->b_ml.ml_flags & ML_ALLOCATED)
+    {
 	vim_free(buf->b_ml.ml_line_ptr);
+	invalidate_vcol_cache();
+    }
 
     buf->b_ml.ml_flags &= ~(ML_LINE_DIRTY | ML_ALLOCATED);
     buf->b_ml.ml_line_lnum = 0;

--- a/src/misc1.c
+++ b/src/misc1.c
@@ -405,10 +405,12 @@ plines_win_nofold(win_T *wp, linenr_T lnum)
     char_u	*s;
     long	col;
     int		width;
+    colnr_T	len;
     chartabsize_T cts;
 
     s = ml_get_buf(wp->w_buffer, lnum, FALSE);
-    init_chartabsize_arg(&cts, wp, lnum, 0, s, s);
+    len = ml_get_buf_len(wp->w_buffer, lnum);
+    init_chartabsize_arg_len(&cts, wp, lnum, 0, s, s, len);
     if (*s == NUL
 #ifdef FEAT_PROP_POPUP
 	    && !cts.cts_has_prop_with_text

--- a/src/move.c
+++ b/src/move.c
@@ -1144,6 +1144,7 @@ curs_columns(
     long	siso = get_sidescrolloff_value();
     int		did_sub_skipcol = FALSE;
 
+    enable_vcol_cache();
     /*
      * First make sure that w_topline is valid (after moving the cursor).
      */
@@ -1427,6 +1428,8 @@ curs_columns(
     curwin->w_valid_skipcol = curwin->w_skipcol;
 
     curwin->w_valid |= VALID_WCOL|VALID_WROW|VALID_VIRTCOL;
+
+    disable_vcol_cache();
 }
 
 #if (defined(FEAT_EVAL) || defined(FEAT_PROP_POPUP)) || defined(PROTO)

--- a/src/move.c
+++ b/src/move.c
@@ -656,6 +656,7 @@ changed_window_setting(void)
     void
 changed_window_setting_win(win_T *wp)
 {
+    invalidate_vcol_cache();
     wp->w_lines_valid = 0;
     changed_line_abv_curs_win(wp);
     wp->w_valid &= ~(VALID_BOTLINE|VALID_BOTLINE_AP|VALID_TOPLINE);

--- a/src/move.c
+++ b/src/move.c
@@ -1144,7 +1144,6 @@ curs_columns(
     long	siso = get_sidescrolloff_value();
     int		did_sub_skipcol = FALSE;
 
-    enable_vcol_cache();
     /*
      * First make sure that w_topline is valid (after moving the cursor).
      */
@@ -1428,8 +1427,6 @@ curs_columns(
     curwin->w_valid_skipcol = curwin->w_skipcol;
 
     curwin->w_valid |= VALID_WCOL|VALID_WROW|VALID_VIRTCOL;
-
-    disable_vcol_cache();
 }
 
 #if (defined(FEAT_EVAL) || defined(FEAT_PROP_POPUP)) || defined(PROTO)

--- a/src/ops.c
+++ b/src/ops.c
@@ -3958,6 +3958,7 @@ do_pending_operator(cmdarg_T *cap, int old_col, int gui_yank)
 
 	if (VIsual_active || redo_VIsual_busy)
 	{
+	    invalidate_vcol_cache();
 	    get_op_vcol(oap, redo_VIsual.rv_vcol, TRUE);
 
 	    if (!redo_VIsual_busy && !gui_yank)

--- a/src/option.c
+++ b/src/option.c
@@ -2747,7 +2747,6 @@ did_set_option(
 	*p = *p | P_INSECURE;
     else if (new_value)
 	*p = *p & ~P_INSECURE;
-    invalidate_vcol_cache();
 }
 
 /*

--- a/src/option.c
+++ b/src/option.c
@@ -2747,6 +2747,7 @@ did_set_option(
 	*p = *p | P_INSECURE;
     else if (new_value)
 	*p = *p & ~P_INSECURE;
+    invalidate_vcol_cache();
 }
 
 /*

--- a/src/proto/charset.pro
+++ b/src/proto/charset.pro
@@ -37,6 +37,7 @@ int vim_isfilec_or_wc(int c);
 int vim_isprintc(int c);
 int vim_isprintc_strict(int c);
 void init_chartabsize_arg(chartabsize_T *cts, win_T *wp, linenr_T lnum, colnr_T col, char_u *line, char_u *ptr);
+void init_chartabsize_arg_len(chartabsize_T *cts, win_T *wp, linenr_T lnum, colnr_T col, char_u *line, char_u *ptr, colnr_T len);
 void clear_chartabsize_arg(chartabsize_T *cts);
 int lbr_chartabsize(chartabsize_T *cts);
 int lbr_chartabsize_adv(chartabsize_T *cts);

--- a/src/proto/charset.pro
+++ b/src/proto/charset.pro
@@ -21,6 +21,7 @@ int linetabsize_col(int startcol, char_u *s);
 int win_linetabsize(win_T *wp, linenr_T lnum, char_u *line, colnr_T len);
 int linetabsize(win_T *wp, linenr_T lnum);
 int linetabsize_no_outer(win_T *wp, linenr_T lnum);
+void invalidate_vcol_cache(void);
 void win_linetabsize_cts(chartabsize_T *cts, colnr_T len);
 int vim_isIDc(int c);
 int vim_isNormalIDc(int c);

--- a/src/proto/charset.pro
+++ b/src/proto/charset.pro
@@ -21,8 +21,6 @@ int linetabsize_col(int startcol, char_u *s);
 int win_linetabsize(win_T *wp, linenr_T lnum, char_u *line, colnr_T len);
 int linetabsize(win_T *wp, linenr_T lnum);
 int linetabsize_no_outer(win_T *wp, linenr_T lnum);
-void enable_vcol_cache(void);
-void disable_vcol_cache(void);
 void invalidate_vcol_cache(void);
 void win_linetabsize_cts(chartabsize_T *cts, colnr_T len);
 int vim_isIDc(int c);

--- a/src/proto/charset.pro
+++ b/src/proto/charset.pro
@@ -21,6 +21,8 @@ int linetabsize_col(int startcol, char_u *s);
 int win_linetabsize(win_T *wp, linenr_T lnum, char_u *line, colnr_T len);
 int linetabsize(win_T *wp, linenr_T lnum);
 int linetabsize_no_outer(win_T *wp, linenr_T lnum);
+void enable_vcol_cache(void);
+void disable_vcol_cache(void);
 void invalidate_vcol_cache(void);
 void win_linetabsize_cts(chartabsize_T *cts, colnr_T len);
 int vim_isIDc(int c);

--- a/src/structs.h
+++ b/src/structs.h
@@ -4975,6 +4975,7 @@ typedef struct {
 #endif
     int		cts_vcol;		// virtual column at current position
     int		cts_max_head_vcol;	// see win_lbr_chartabsize()
+    colnr_T	cts_len;		// length of cts_line, or -1
 } chartabsize_T;
 
 /*


### PR DESCRIPTION
Fixes #15606

Cache the result of `getvcol()` and `win_linetabsize_cts()`.
Cache the vcol value at 80% position or at the last 4KB position.
Invalidate the cache when the content of the line is changed or the window options are changed.

To check the performance, e.g. create a line with 2 million characters:
```
:call setline(1, repeat("x", 2 * 1000 * 1000))
```
then move the cursor around.