### PR TITLE
Fix setcellwidths([])

### DIFF
--- a/src/mbyte.c
+++ b/src/mbyte.c
@@ -5644,7 +5644,7 @@ f_setcellwidths(typval_T *argvars, typval_T *rettv UNUSED)
 	// Clearing the table.
 	VIM_CLEAR(cw_table);
 	cw_table_size = 0;
-	return;
+	goto done;
     }
 
     ptrs = ALLOC_MULT(listitem_T *, l->lv_len);
@@ -5756,6 +5756,7 @@ f_setcellwidths(typval_T *argvars, typval_T *rettv UNUSED)
     }
 
     vim_free(cw_table_save);
+done:
     changed_window_setting_all();
     redraw_all_later(UPD_CLEAR);
 }

--- a/src/testdir/test_utf8.vim
+++ b/src/testdir/test_utf8.vim
@@ -228,6 +228,9 @@ func Test_setcellwidths()
     call setcellwidths([[0x2103, 0x2103, 2]])
     redraw
     call assert_equal(19, wincol())
+    call setcellwidths([])
+    redraw
+    call assert_equal((aw == 'single') ? 10 : 19, wincol())
   endfor
   set ambiwidth& isprint&
 


### PR DESCRIPTION
Fix that `setcellwidths([])` didn't update the display.
Redraw after clearing the cellwidth table.