### PR TITLE
Wrong breakindentopt=list:-1 with multibyte or TABs

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1,4 +1,4 @@
-*options.txt*	For Vim version 9.1.  Last change: 2024 Aug 12
+*options.txt*	For Vim version 9.1.  Last change: 2024 Sep 07
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -1491,9 +1491,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 		list:{n}    Adds an additional indent for lines that match a
 			    numbered or bulleted list (using the
 			    'formatlistpat' setting).
-		list:-1	    Uses the length of a match with 'formatlistpat'
-			    for indentation.
 			    (default: 0)
+		list:-1	    Uses the width of a match with 'formatlistpat' for
+			    indentation.
 		column:{n}  Indent at column {n}. Will overrule the other
 			    sub-options. Note: an additional indent may be
 			    added for the 'showbreak' setting.

--- a/src/charset.c
+++ b/src/charset.c
@@ -739,8 +739,8 @@ chartabsize(char_u *p, colnr_T col)
     RET_WIN_BUF_CHARTABSIZE(curwin, curbuf, p, col)
 }
 
-#ifdef FEAT_LINEBREAK
-    static int
+#if defined(FEAT_LINEBREAK) || defined(PROTO)
+    int
 win_chartabsize(win_T *wp, char_u *p, colnr_T col)
 {
     RET_WIN_BUF_CHARTABSIZE(wp, wp->w_buffer, p, col)

--- a/src/indent.c
+++ b/src/indent.c
@@ -1021,7 +1021,21 @@ get_breakindent_win(
 		    if (wp->w_briopt_list > 0)
 			prev_list = wp->w_briopt_list;
 		    else
-			prev_indent = (*regmatch.endp - *regmatch.startp);
+		    {
+			char_u	*ptr = *regmatch.startp;
+			char_u	*end_ptr = *regmatch.endp;
+			int	indent = 0;
+
+			// Compute the width of the matched text.
+			// Use win_chartabsize() so that TAB size is correct,
+			// while wrapping is ignored.
+			while (ptr < end_ptr)
+			{
+			    indent += win_chartabsize(wp, ptr, indent);
+			    MB_PTR_ADV(ptr);
+			}
+			prev_indent = indent;
+		    }
 		}
 		vim_regfree(regmatch.regprog);
 	    }

--- a/src/proto/charset.pro
+++ b/src/proto/charset.pro
@@ -16,6 +16,7 @@ int ptr2cells(char_u *p);
 int vim_strsize(char_u *s);
 int vim_strnsize(char_u *s, int len);
 int chartabsize(char_u *p, colnr_T col);
+int win_chartabsize(win_T *wp, char_u *p, colnr_T col);
 int linetabsize_str(char_u *s);
 int linetabsize_col(int startcol, char_u *s);
 int win_linetabsize(win_T *wp, linenr_T lnum, char_u *line, colnr_T len);

--- a/src/testdir/test_breakindent.vim
+++ b/src/testdir/test_breakindent.vim
@@ -797,18 +797,73 @@ func Test_breakindent20_list()
 	\ ]
   let lines = s:screen_lines2(1, 9, 20)
   call s:compare_lines(expect, lines)
+
+  " check with TABs
+  call setline(1, ["\t1.\tCongress shall make no law",
+        \ "\t2.) Congress shall make no law",
+        \ "\t3.] Congress shall make no law"])
+  setl tabstop=4 list listchars=tab:<->
+  norm! 1gg
+  redraw!
+  let expect = [
+	\ "<-->1.<>Congress    ",
+	\ "        shall make  ",
+	\ "        no law      ",
+	\ "<-->2.) Congress    ",
+	\ "        shall make  ",
+	\ "        no law      ",
+	\ "<-->3.] Congress    ",
+	\ "        shall make  ",
+	\ "        no law      ",
+	\ ]
+  let lines = s:screen_lines2(1, 9, 20)
+  call s:compare_lines(expect, lines)
+
+  setl tabstop=2 nolist
+  redraw!
+  let expect = [
+	\ "  1.  Congress      ",
+	\ "      shall make no ",
+	\ "      law           ",
+	\ "  2.) Congress      ",
+	\ "      shall make no ",
+	\ "      law           ",
+	\ "  3.] Congress      ",
+	\ "      shall make no ",
+	\ "      law           ",
+	\ ]
+  let lines = s:screen_lines2(1, 9, 20)
+  call s:compare_lines(expect, lines)
+
+  setl tabstop& list listchars=space:_
+  redraw!
+  let expect = [
+	\ "^I1.^ICongress_     ",
+	\ "      shall_make_no_",
+	\ "      law           ",
+	\ "^I2.)_Congress_     ",
+	\ "      shall_make_no_",
+	\ "      law           ",
+	\ "^I3.]_Congress_     ",
+	\ "      shall_make_no_",
+	\ "      law           ",
+	\ ]
+  let lines = s:screen_lines2(1, 9, 20)
+  call s:compare_lines(expect, lines)
+
   " check formatlistpat indent with different list levels
-  let &l:flp = '^\s*\*\+\s\+'
+  let &l:flp = '^\s*\(\*\|•\)\+\s\+'
+  setl list&vim listchars&vim
   %delete _
   call setline(1, ['* Congress shall make no law',
-        \ '*** Congress shall make no law',
+        \ '••• Congress shall make no law',
         \ '**** Congress shall make no law'])
   norm! 1gg
   redraw!
   let expect = [
 	\ "* Congress shall    ",
 	\ "  make no law       ",
-	\ "*** Congress shall  ",
+	\ "••• Congress shall  ",
 	\ "    make no law     ",
 	\ "**** Congress shall ",
 	\ "     make no law    ",
@@ -824,7 +879,7 @@ func Test_breakindent20_list()
   let expect = [
 	\ "* Congress shall    ",
 	\ "> make no law       ",
-	\ "*** Congress shall  ",
+	\ "••• Congress shall  ",
 	\ ">   make no law     ",
 	\ "**** Congress shall ",
 	\ ">    make no law    ",
@@ -840,7 +895,7 @@ func Test_breakindent20_list()
   let expect = [
 	\ "* Congress shall    ",
 	\ ">   make no law     ",
-	\ "*** Congress shall  ",
+	\ "••• Congress shall  ",
 	\ ">     make no law   ",
 	\ "**** Congress shall ",
 	\ ">      make no law  ",


### PR DESCRIPTION
Problem:  Wrong breakindentopt=list:-1 with multibyte chars or TABs in
          text matched by 'formatlistpat'.
Solution: Use the width of the match text.

fixes: #15634
