### PR TITLE
Crash when id > INT_MAX in text_prop_add()

### DIFF
--- a/runtime/doc/textprop.txt
+++ b/runtime/doc/textprop.txt
@@ -1,4 +1,4 @@
-*textprop.txt*  For Vim version 9.1.  Last change: 2024 Sep 07
+*textprop.txt*  For Vim version 9.1.  Last change: 2024 Sep 08
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -271,7 +271,7 @@ prop_add_list({props}, [{item}, ...])			*prop_add_list()*
 			call prop_add_list(#{type: 'MyProp', id: 2},
 					\ [[1, 4, 1, 7],
 					\  [1, 15, 1, 20],
-					\  [2, 30, 3, 30]]
+					\  [2, 30, 3, 30]])
 <
 		Can also be used as a |method|: >
 			GetProp()->prop_add_list([[1, 1, 1, 2], [1, 4, 1, 8]])

--- a/runtime/doc/textprop.txt
+++ b/runtime/doc/textprop.txt
@@ -1,4 +1,4 @@
-*textprop.txt*  For Vim version 9.1.  Last change: 2024 Jun 08
+*textprop.txt*  For Vim version 9.1.  Last change: 2024 Sep 07
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -140,10 +140,10 @@ prop_add({lnum}, {col}, {props})
 		   bufnr	buffer to add the property to; when omitted
 				the current buffer is used
 		   id		user defined ID for the property; must be a
-				number, should be positive; when using "text"
-				then "id" must not be present and will be set
-				automatically to a negative number; otherwise
-				zero is used
+				number, should be positive |E1510|;
+				when using "text" then "id" must not be
+				present and will be set automatically to a
+				negative number; otherwise zero is used
 							*E1305*
 		   text		text to be displayed before {col}, or
 				above/below the line if {col} is zero; prepend

--- a/src/testdir/test_textprop.vim
+++ b/src/testdir/test_textprop.vim
@@ -1780,6 +1780,7 @@ func Test_prop_func_invalid_args()
   call assert_fails("call prop_add(2, 3, {'type': 'xxx', 'length':-1})", 'E475:')
   call assert_fails("call prop_add(2, 3, {'type': 'xxx', 'end_col':0})", 'E475:')
   call assert_fails("call prop_add(2, 3, {'length':1})", 'E965:')
+  call assert_fails("call prop_add(2, 3, {'type': 'xxx', 'id': 2147483648})", 'E1510:')
 
   call prop_type_delete('xxx')
   bwipe!

--- a/src/testdir/test_textprop.vim
+++ b/src/testdir/test_textprop.vim
@@ -393,6 +393,8 @@ func Test_prop_add_list()
   call assert_fails('call prop_add_list(test_null_dict(), [[2, 2, 2]])', 'E965:')
   call assert_fails('call prop_add_list(#{type: "one"}, test_null_list())', 'E1298:')
   call assert_fails('call prop_add_list(#{type: "one"}, [test_null_list()])', 'E714:')
+  call assert_fails('call prop_add_list(#{type: "one", id: 2147483648}, [[2, 2, 2, 2], [3, 20, 3, 22]])', 'E1510:')
+  call assert_fails('call prop_add_list(#{type: "one", id: -2147483648}, [[2, 2, 2, 2], [3, 20, 3, 22]])', 'E1510:')
 
   " only one error for multiple wrong values
   call assert_fails('call prop_add_list(#{type: "one"}, [[{}, [], 0z00, 0.3]])', ['E728:', 'E728:'])
@@ -1781,6 +1783,7 @@ func Test_prop_func_invalid_args()
   call assert_fails("call prop_add(2, 3, {'type': 'xxx', 'end_col':0})", 'E475:')
   call assert_fails("call prop_add(2, 3, {'length':1})", 'E965:')
   call assert_fails("call prop_add(2, 3, {'type': 'xxx', 'id': 2147483648})", 'E1510:')
+  call assert_fails("call prop_add(2, 3, {'type': 'xxx', 'id': -2147483648})", 'E1510:')
 
   call prop_type_delete('xxx')
   bwipe!

--- a/src/textprop.c
+++ b/src/textprop.c
@@ -372,7 +372,16 @@ f_prop_add_list(typval_T *argvars, typval_T *rettv UNUSED)
     type_name = dict_get_string(dict, "type", FALSE);
 
     if (dict_has_key(dict, "id"))
-	id = dict_get_number(dict, "id");
+    {
+	vimlong_T x;
+	x = dict_get_number(dict, "id");
+	if (x > INT_MAX || x  <= INT_MIN)
+	{
+	    semsg(_(e_val_too_large), dict_get_string(dict, "id", FALSE));
+	    return;
+	}
+	id = (int)x;
+    }
 
     if (get_bufnr_from_arg(&argvars[0], &buf) == FAIL)
 	return;
@@ -500,7 +509,7 @@ prop_add_common(
     {
 	vimlong_T x;
 	x = dict_get_number(dict, "id");
-	if (x > INT_MAX)
+	if (x > INT_MAX || x  <= INT_MIN)
 	{
 	    semsg(_(e_val_too_large), dict_get_string(dict, "id", FALSE));
 	    goto theend;

--- a/src/textprop.c
+++ b/src/textprop.c
@@ -497,7 +497,16 @@ prop_add_common(
 	end_col = 1;
 
     if (dict_has_key(dict, "id"))
-	id = dict_get_number(dict, "id");
+    {
+	vimlong_T x;
+	x = dict_get_number(dict, "id");
+	if (x > INT_MAX)
+	{
+	    semsg(_(e_val_too_large), dict_get_string(dict, "id", FALSE));
+	    goto theend;
+	}
+	id = (int)x;
+    }
 
     if (dict_has_key(dict, "text"))
     {


### PR DESCRIPTION
Problem:  Crash when id > INT_MAX in text_prop_add()
Solution: Error out if the id is > INT_MAX

fixes: #15637