### PR TITLE
Several fixes for GetLatestVimScripts

### DIFF
--- a/runtime/autoload/getscript.vim
+++ b/runtime/autoload/getscript.vim
@@ -212,9 +212,10 @@ fun! getscript#GetLatestVimScripts()
 "  call Decho("searching plugins for GetLatestVimScripts dependencies")
   let lastline    = line("$")
 "  call Decho("lastline#".lastline)
-  let firstdir    = substitute(&rtp,',.*$','','')
+  let firstdir    = substitute(&rtp,',.{-}$','','')
   let plugins     = split(globpath(firstdir,"plugin/**/*.vim"),'\n')
-  let plugins     = plugins + split(globpath(firstdir,"AsNeeded/**/*.vim"),'\n')
+  let plugins     += split(globpath(firstdir,"ftplugin/**/*.vim"),'\n')
+  let plugins     += split(globpath(firstdir,"AsNeeded/**/*.vim"),'\n')
   let foundscript = 0
 
   " this loop updates the GetLatestVimScripts.dat file

--- a/runtime/autoload/getscript.vim
+++ b/runtime/autoload/getscript.vim
@@ -64,7 +64,7 @@ if !exists("g:GetLatestVimScripts_options")
  if g:GetLatestVimScripts_wget == "wget"
   let g:GetLatestVimScripts_options= "-q -O"
  elseif g:GetLatestVimScripts_wget == "curl"
-  let g:GetLatestVimScripts_options= "-s -O"
+  let g:GetLatestVimScripts_options= "-s -o"
  else
   let g:GetLatestVimScripts_options= ""
  endif
@@ -77,7 +77,11 @@ endif
 
 " set up default scriptaddr address
 if !exists("g:GetLatestVimScripts_scriptaddr")
- let g:GetLatestVimScripts_scriptaddr = 'http://vim.sourceforge.net/script.php?script_id='
+ let g:GetLatestVimScripts_scriptaddr = 'https://www.vim.org/scripts/script.php?script_id='
+endif
+
+if !exists("g:GetLatestVimScripts_downloadaddr")
+  let g:GetLatestVimScripts_downloadaddr = 'https://www.vim.org/scripts/download_script.php?src_id='
 endif
 
 "" For debugging:
@@ -89,11 +93,11 @@ endif
 let s:autoinstall= ""
 if g:GetLatestVimScripts_allowautoinstall
 
- if (has("win32") || has("gui_win32") || has("gui_win32s") || has("win16") || has("win64") || has("win32unix") || has("win95")) && &shell != "bash"
+ if (has("win32") || has("gui_win32") || has("gui_win32s") || has("win16") || has("win64") || has("win32unix") || has("win95")) && &shell !~ '\cbash\|pwsh\|powershell'
   " windows (but not cygwin/bash)
   let s:dotvim= "vimfiles"
   if !exists("g:GetLatestVimScripts_mv")
-   let g:GetLatestVimScripts_mv= "ren"
+   let g:GetLatestVimScripts_mv= "move"
   endif
 
  else
@@ -515,11 +519,11 @@ fun! s:GetOneScript(...)
 "   call Decho(".downloading new <".sname.">")
    echomsg ".downloading new <".sname.">"
    if has("win32") || has("win16") || has("win95")
-"    call Decho(".new|exe silent r!".g:GetLatestVimScripts_wget." ".g:GetLatestVimScripts_options." ".shellescape(sname)." ".shellescape('http://vim.sourceforge.net/scripts/download_script.php?src_id='.latestsrcid)."|q")
-    new|exe "silent r!".g:GetLatestVimScripts_wget." ".g:GetLatestVimScripts_options." ".shellescape(sname)." ".shellescape('http://vim.sourceforge.net/scripts/download_script.php?src_id='.latestsrcid)|q
+"    call Decho(".new|exe silent r!".g:GetLatestVimScripts_wget." ".g:GetLatestVimScripts_options." ".shellescape(sname)." ".shellescape(g:GetLatestVimScripts_downloadaddr.latestsrcid)."|q")
+    new|exe "silent r!".g:GetLatestVimScripts_wget." ".g:GetLatestVimScripts_options." ".shellescape(sname)." ".shellescape(g:GetLatestVimScripts_downloadaddr.latestsrcid)|q
    else
-"    call Decho(".exe silent !".g:GetLatestVimScripts_wget." ".g:GetLatestVimScripts_options." ".shellescape(sname)." ".shellescape('http://vim.sourceforge.net/scripts/download_script.php?src_id='))
-    exe "silent !".g:GetLatestVimScripts_wget." ".g:GetLatestVimScripts_options." ".shellescape(sname)." ".shellescape('http://vim.sourceforge.net/scripts/download_script.php?src_id=').latestsrcid
+"    call Decho(".exe silent !".g:GetLatestVimScripts_wget." ".g:GetLatestVimScripts_options." ".shellescape(sname)." ".shellescape(g:GetLatestVimScripts_downloadaddr).latestsrcid
+    exe "silent !".g:GetLatestVimScripts_wget." ".g:GetLatestVimScripts_options." ".shellescape(sname)." ".shellescape(g:GetLatestVimScripts_downloadaddr).latestsrcid
    endif
 
    " --------------------------------------------------------------------------
@@ -573,7 +577,7 @@ fun! s:GetOneScript(...)
 "      call Decho("no decompression needed")
      endif
      
-     " distribute archive(.zip, .tar, .vba, ...) contents
+     " distribute archive(.zip, .tar, .vba, .vmb, ...) contents
      if sname =~ '\.zip$'
 "      call Decho("dearchive: attempt to unzip ".sname)
       exe "silent !unzip -o ".shellescape(sname)
@@ -592,7 +596,7 @@ fun! s:GetOneScript(...)
      elseif sname =~ '\.txz$'
 "      call Decho("dearchive: attempt to untar+xz ".sname)
       exe "silent !tar -Jxvf ".shellescape(sname)
-     elseif sname =~ '\.vba$'
+     elseif sname =~ '\.vba$\|\.vmb$'
 "      call Decho("dearchive: attempt to handle a vimball: ".sname)
       silent 1split
       if exists("g:vimball_home")

--- a/runtime/doc/pi_getscript.txt
+++ b/runtime/doc/pi_getscript.txt
@@ -59,9 +59,9 @@ the "important" part of it is the first two lines.
 
 Your computer needs to have wget or curl for GetLatestVimScripts to do its work.
 
-	1. if compressed:  gunzip getscript.vba.gz
+	1. if compressed:  gunzip getscript.vmb.gz
 	2. Unix:
-		vim getscript.vba
+		vim getscript.vmb
 		:so %
 		:q
 		cd ~/.vim/GetLatest
@@ -70,7 +70,7 @@ Your computer needs to have wget or curl for GetLatestVimScripts to do its work.
 		list of desired plugins -- see |GetLatestVimScripts_dat|)
 
 	3. Windows:
-		vim getscript.vba
+		vim getscript.vmb
 		:so %
 		:q
 		cd **path-to-vimfiles**/GetLatest
@@ -281,11 +281,14 @@ With :AutoInstall: enabled, as it is by default, files which end with
 
 	---.tar.bz2  : decompressed & untarred in .vim/ directory
 	---.vba.bz2  : decompressed in .vim/ directory, then vimball handles it
+	---.vmb.bz2  : decompressed in .vim/ directory, then vimball handles it
 	---.vim.bz2  : decompressed & moved into .vim/plugin directory
 	---.tar.gz   : decompressed & untarred in .vim/ directory
 	---.vba.gz   : decompressed in .vim/ directory, then vimball handles it
+	---.vmb.gz   : decompressed in .vim/ directory, then vimball handles it
 	---.vim.gz   : decompressed & moved into .vim/plugin directory
-	---.vba      : unzipped in .vim/ directory
+	---.vba      : moved to .vim/ directory, then vimball handles it
+	---.vmb      : moved to .vim/ directory, then vimball handles it
 	---.vim      : moved to .vim/plugin directory
 	---.zip      : unzipped in .vim/ directory
 
@@ -300,7 +303,7 @@ When is a script not auto-installable?  Let me give an example:
 The <blockhl.vim> script provides block highlighting for C/C++ programs; it is
 available at:
 
-	http://vim.sourceforge.net/scripts/script.php?script_id=104
+	https://www.vim.org/scripts/script.php?script_id=104
 
 Currently, vim's after/syntax only supports by-filetype scripts (in
 blockhl.vim's case, that's after/syntax/c.vim).  Hence, auto-install would
@@ -309,7 +312,7 @@ possibly overwrite the current user's after/syntax/c.vim file.
 In my own case, I use <aftersyntax.vim> (renamed to after/syntax/c.vim) to
 allow a after/syntax/c/ directory:
 
-	http://vim.sourceforge.net/scripts/script.php?script_id=1023
+	https://www.vim.org/scripts/script.php?script_id=1023
 
 The script allows multiple syntax files to exist separately in the
 after/syntax/c subdirectory.  I can't bundle aftersyntax.vim in and build an
@@ -345,17 +348,22 @@ after/syntax/c.vim contained in it to overwrite a user's c.vim.
 		Doesn't override vimball installation.
 >
 	g:GetLatestVimScripts_scriptaddr
-<       default='http://vim.sourceforge.net/script.php?script_id='
+<        default='https://www.vim.org/scripts/script.php?script_id='
 		Override this if your system needs
-	  ...  ='http://vim.sourceforge.net/script/script.php?script_id='
-
+	  ...  ='http://vim.sourceforge.net/script.php?script_id='
+>
+	g:GetLatestVimScripts_downloadaddr
+<        default='https://www.vim.org/scripts/download_script.php?src_id='
+		Override this if your system needs
+	  ...  ='http://vim.sourceforge.net/scripts/download_script.php?src_id='
+>
 ==============================================================================
 8. GetLatestVimScripts Algorithm		*glvs-algorithm* *glvs-alg*
 
 The Vim sourceforge page dynamically creates a page by keying off of the
 so-called script-id.  Within the webpage of
 
-	http://vim.sourceforge.net/scripts/script.php?script_id=40
+	https://www.vim.org/scripts/script.php?script_id=40
 
 is a line specifying the latest source-id (src_id).  The source identifier
 numbers are always increasing, hence if the src_id is greater than the one


### PR DESCRIPTION
GetLatestVimScripts builtin plugin required several fixes:
+ Support for the new vimbal `.vmb` extension introduced in [patch 9.0.1797: Vimball/Visual Basic filetype detection conflict](https://github.com/vim/vim/commit/f97f6bbf56408c0c97b4ddbe81fba858d7455b0d).
+ Update the urls from the old `sourceforge.net` to `vim.org`. The download url was hardcoded and a new variable is introduced.
+ Fix `curl` command line option to set a filename (`-O` uses the remote filename and `-o` specifies a filename).
+ Replace windows' command to move files. `REN` can only rename files and the script actually moves them. My educated guess was that originally only renaming was necessary. When the script was modified to move files no change was required on linux because `mv` does both.
+ Fix Autoinstall support to check `ftplugins` and `pack-plugins` too (`pack-plugins` did not exist when the plugin was created).