### PR TITLE
runtime(doc): Fix typo in :help :hide text

### DIFF
--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -394,7 +394,7 @@ CTRL-W CTRL-C						*CTRL-W_CTRL-C*
 		to the buffer are not written and won't get lost, so this is a
 		"safe" command.
 
-:hid[e] {cmd}	Execute {cmd} with 'hidden' is set.  The previous value of
+:hid[e] {cmd}	Execute {cmd} with 'hidden' set.  The previous value of
 		'hidden' is restored after {cmd} has been executed.
 		Example: >
 		    :hide edit Makefile


### PR DESCRIPTION
Fix typo in :help :hide text.