### PR TITLE
add compiler/make.vim to reset compiler to default GNU make

### DIFF
--- a/runtime/compiler/make.vim
+++ b/runtime/compiler/make.vim
@@ -1,4 +1,4 @@
-if exists("current_compiler") | finish | endif
+if exists("g:current_compiler") | unlet b:current_compiler | endif
 if exists("b:current_compiler") | unlet b:current_compiler | endif
 
 let s:cpo_save = &cpo

--- a/runtime/compiler/make.vim
+++ b/runtime/compiler/make.vim
@@ -1,4 +1,4 @@
-if exists("g:current_compiler") | unlet b:current_compiler | endif
+if exists("g:current_compiler") | unlet g:current_compiler | endif
 if exists("b:current_compiler") | unlet b:current_compiler | endif
 
 let s:cpo_save = &cpo

--- a/runtime/compiler/make.vim
+++ b/runtime/compiler/make.vim
@@ -1,0 +1,11 @@
+if exists("current_compiler") | finish | endif
+if exists("b:current_compiler") | unlet b:current_compiler | endif
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+CompilerSet makeprg&
+CompilerSet errorformat&
+
+let &cpo = s:cpo_save
+unlet s:cpo_save

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -1280,7 +1280,7 @@ GNU MAKE						*compiler-make*
 
 Since the default make program is "make", the compiler plugin for make,
 :compiler make, will reset the 'makeprg' and 'errorformat' option to
-the default values and unlet any variables that may have been set by a 
+the default values and unlet any variables that may have been set by a
 previous compiler plugin.
 
 DOTNET							*compiler-dotnet*

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -1276,6 +1276,12 @@ not "b:current_compiler".  What the command actually does is the following:
 
 For writing a compiler plugin, see |write-compiler-plugin|.
 
+GNU MAKE						*compiler-make*
+
+Since the default make program is "make", the compiler plugin for make,
+:compiler make, will reset the 'makeprg' and 'errorformat' option to
+the default values and unlet any variables that may have been set by a 
+previous compiler plugin.
 
 DOTNET							*compiler-dotnet*
 


### PR DESCRIPTION
I am sorry for this stupid PR but I wonder how to conveniently reset the compiler to the default GNU make, other than manually unletting `b/g:compiler` amd unsetting `&makeprg/errorformat`.