### PR TITLE
Update dosini syntax file: Only spellcheck comments

### DIFF
--- a/runtime/syntax/dosini.vim
+++ b/runtime/syntax/dosini.vim
@@ -1,12 +1,12 @@
 " Vim syntax file
 " Language:               Configuration File (ini file) for MSDOS/MS Windows
-" Version:                2.3
+" Version:                2.4
 " Original Author:        Sean M. McKee <mckee@misslink.net>
 " Previous Maintainer:    Nima Talebi <nima@it.net.au>
 " Current Maintainer:     Hong Xu <hong@topbug.net>
 " Homepage:               http://www.vim.org/scripts/script.php?script_id=3747
 " Repository:             https://github.com/xuhdev/syntax-dosini.vim
-" Last Change:            2023 Aug 20
+" Last Change:            2024 Sept 08
 
 
 " quit when a syntax file was already loaded
@@ -27,7 +27,7 @@ syn match  dosiniNumber   "=\zs\s*\d\+\s*$"
 syn match  dosiniNumber   "=\zs\s*\d*\.\d\+\s*$"
 syn match  dosiniNumber   "=\zs\s*\d\+e[+-]\=\d\+\s*$"
 syn region dosiniHeader   start="^\s*\[" end="\]"
-syn match  dosiniComment  "^[#;].*$"
+syn match  dosiniComment  "^[#;].*$" contains=@Spell
 syn region dosiniSection  start="\s*\[.*\]" end="\ze\s*\[.*\]" fold
       \ contains=dosiniLabel,dosiniValue,dosiniNumber,dosiniHeader,dosiniComment
 


### PR DESCRIPTION
By default spell checking is enabled for all text, but adding `contains=@Spell` to syntax rules restricts spell checking to those syntax rules.  See `:help spell-syntax` for full details.

Variable names and headers are far more likely than comments to contain spelling errors, so only enable spell checking in comments.

Introduced in https://github.com/xuhdev/syntax-dosini.vim/pull/8

cc @tobinjt

(The author of this commit is set to @tobinjt, please use rebase merge if possible)