### PR TITLE
Revert outdated comment in completeopt's fuzzy documentation

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2148,10 +2148,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	   fuzzy    Enable |fuzzy-matching| for completion candidates. This
 		    allows for more flexible and intuitive matching, where
 		    characters can be skipped and matches can be found even
-		    if the exact sequence is not typed.  Only makes a
-		    difference how completion candidates are reduced from the
-		    list of alternatives, but not how the candidates are
-		    collected (using different completion types).
+		    if the exact sequence is not typed.
 
 					*'completepopup'* *'cpp'*
 'completepopup' 'cpp'	string (default empty)


### PR DESCRIPTION
Originally, `:set completeopt+=fuzzy` did not affect how the candidate list is collected in default keyword completion. A comment was added to documentation as part of #14912 to clarify it. #15193 later changed the fuzzy behavior to now change the candidate collection behavior as well so the clarification in docs is now wrong. Remove them here.