### PR TITLE
fix(runtime): add .swiftinterface to recognized filetypes

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -2371,7 +2371,7 @@ au BufNewFile,BufRead *.sml			setf sml
 au BufNewFile,BufRead *.cm			setf voscm
 
 " Swift
-au BufNewFile,BufRead *.swift			setf swift
+au BufNewFile,BufRead *.swift,*.swiftinterface	setf swift
 au BufNewFile,BufRead *.swift.gyb		setf swiftgyb
 
 " Swift Intermediate Language or SILE

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -712,7 +712,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     svg: ['file.svg'],
     svn: ['svn-commitfile.tmp', 'svn-commit-file.tmp', 'svn-commit.tmp'],
     swayconfig: ['/home/user/.sway/config', '/home/user/.config/sway/config', '/etc/sway/config', '/etc/xdg/sway/config'],
-    swift: ['file.swift'],
+    swift: ['file.swift', 'file.swiftinterface'],
     swiftgyb: ['file.swift.gyb'],
     swig: ['file.swg', 'file.swig'],
     sysctl: ['/etc/sysctl.conf', '/etc/sysctl.d/file.conf', 'any/etc/sysctl.conf', 'any/etc/sysctl.d/file.conf'],


### PR DESCRIPTION
.swiftinterface files are distributed inside of binary Swift modules and include type/method definitions, similar to header files in C/C++/etc.
While you are never expected to write such a file yourself, things like the Swift LSP will open them when looking at declarations of symbols in a source-closed library (e.g. Apples UI frameworks).