### PR TITLE
Support xxd -b and -i options at the same time

### DIFF
--- a/runtime/doc/xxd.1
+++ b/runtime/doc/xxd.1
@@ -63,8 +63,8 @@ Toggle autoskip: A single '*' replaces NUL-lines.  Default off.
 Switch to bits (binary digits) dump, rather than hex dump.
 This option writes octets as eight digits "1"s and "0"s instead of a normal
 hexadecimal dump. Each line is preceded by a line number in hexadecimal and
-followed by an ASCII (or EBCDIC) representation. The command line switches
-\-p, \-i do not work with this mode.
+followed by an ASCII (or EBCDIC) representation. The command line switch
+\-p does not work with this mode. Can be combined with \-i.
 .TP
 .IR "\-c cols " | " \-cols cols"
 Format
@@ -109,7 +109,8 @@ Print a summary of available commands and exit.  No hex dumping is performed.
 .TP
 .IR \-i " | " \-include
 Output in C include file style. A complete static array definition is written
-(named after the input file), unless xxd reads from stdin.
+(named after the input file), unless xxd reads from stdin. Can be combined
+with \-b.
 .TP
 .IR "\-l len " | " \-len len"
 Stop after writing

--- a/src/testdir/test_xxd.vim
+++ b/src/testdir/test_xxd.vim
@@ -269,6 +269,23 @@ func Test_xxd()
   endfor
 
 
+  " Test 19: Print C include in binary format
+  let s:test += 1
+  call writefile(['TESTabcd09'], 'XXDfile')
+  %d
+  exe '0r! ' . s:xxd_cmd . ' -i -b XXDfile'
+  $d
+  let expected =<< trim [CODE]
+    unsigned char XXDfile[] = {
+      0b01010100, 0b01000101, 0b01010011, 0b01010100, 0b01100001, 0b01100010,
+      0b01100011, 0b01100100, 0b00110000, 0b00111001, 0b00001010
+    };
+    unsigned int XXDfile_len = 11;
+  [CODE]
+
+  call assert_equal(expected, getline(1,'$'), s:Mess(s:test))
+
+
   %d
   bwipe!
   call delete('XXDfile')

--- a/src/xxd/xxd.c
+++ b/src/xxd/xxd.c
@@ -220,7 +220,7 @@ char osver[] = "";
 char hexxa[] = "0123456789abcdef0123456789ABCDEF", *hexx = hexxa;
 
 /* the different hextypes known by this program: */
-#define HEX_NORMAL         0x00  /* No flags set */
+#define HEX_NORMAL         0x00 /* no flags set */
 #define HEX_POSTSCRIPT     0x01
 #define HEX_CINCLUDE       0x02
 #define HEX_BITS           0x04 /* not hex a dump, but bits: 01111001 */

--- a/src/xxd/xxd.c
+++ b/src/xxd/xxd.c
@@ -63,6 +63,7 @@
  * 25.01.2024  revert the previous patch (size_t instead of unsigned int)
  * 10.02.2024  fix buffer-overflow when writing color output to buffer, #14003
  * 10.05.2024  fix another buffer-overflow when writing colored output to buffer, #14738
+ * 10.09.2024  Support -b and -i together, #15661
  *
  * (c) 1990-1998 by Juergen Weigert (jnweiger@gmail.com)
  *

--- a/src/xxd/xxd.c
+++ b/src/xxd/xxd.c
@@ -1002,8 +1002,8 @@ main(int argc, char *argv[])
                 fputs_or_die(", ", fpo);
 
               FPRINTF_OR_DIE((fpo, "0b"));
-              for (int i = 7; i >= 0; i--)
-                putc_or_die((c & (1 << i)) ? '1' : '0', fpo);
+              for (int j = 7; j >= 0; j--)
+                putc_or_die((c & (1 << j)) ? '1' : '0', fpo);
               p++;
 	    }
           else

--- a/src/xxd/xxd.c
+++ b/src/xxd/xxd.c
@@ -256,7 +256,7 @@ exit_with_usage(void)
   fprintf(stderr, "    or\n       %s -r [-s [-]offset] [-c cols] [-ps] [infile [outfile]]\n", pname);
   fprintf(stderr, "Options:\n");
   fprintf(stderr, "    -a          toggle autoskip: A single '*' replaces nul-lines. Default off.\n");
-  fprintf(stderr, "    -b          binary digit dump (incompatible with -ps,-i). Default hex.\n");
+  fprintf(stderr, "    -b          binary digit dump (incompatible with -ps). Default hex.\n");
   fprintf(stderr, "    -C          capitalize variable names in C include file style (-i).\n");
   fprintf(stderr, "    -c cols     format <cols> octets per line. Default 16 (-i: 12, -ps: 30).\n");
   fprintf(stderr, "    -E          show characters in EBCDIC. Default ASCII.\n");


### PR DESCRIPTION
Addressing issue #15362.

Taking the least invasive change here, supporting exactly the combination of -b and -i without adding any other combinations that might make make sense.

Disclosure - this PR was generated by AI from augmentcode.com