### PR TITLE
runtime(syntax-tests): Support running a subset of syntax tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,9 @@ indenttest:
 # Executable used for running the syntax tests.
 VIM_FOR_SYNTAXTEST = ../../src/vim
 
+# (For local testing only with GNU Make.)
+VIM_SYNTAX_TEST_FILTER =
+
 syntaxtest:
 	cd runtime/syntax && \
 		$(MAKE) clean && \

--- a/runtime/syntax/Makefile
+++ b/runtime/syntax/Makefile
@@ -31,10 +31,38 @@ test:
 	@echo "../$(VIMPROG)" > testdir/vimcmd
 	@echo "$(RUN_VIMTEST)" >> testdir/vimcmd
 	VIMRUNTIME=$(VIMRUNTIME) $(ENVVARS) $(VIMPROG) --clean --not-a-term $(DEBUGLOG) -u testdir/runtest.vim
+	@rm -f testdir/Xfilter
 	@# FIXME: Temporarily show the whole file to find out what goes wrong
 	@#if [ -f testdir/messages ]; then tail -n 6 testdir/messages; fi
 	@if [ -f testdir/messages ]; then cat testdir/messages; fi
 
 
 clean testclean:
-	rm -f testdir/failed/* testdir/done/* testdir/vimcmd testdir/messages testdir/Xtestscript
+	rm -f testdir/failed/* testdir/done/* testdir/vimcmd testdir/messages testdir/Xtestscript testdir/Xfilter
+
+# All initial phony targets; these names may clash with file extensions.
+phonies = clean test testclean
+
+# Collect all input filenames and their file extensions.
+testnames != set +f; \
+awk 'BEGIN { \
+    for (i = 1; i < ARGC; i++) { \
+        split(ARGV[i], names, /\//); \
+        split(names[3], parts, /\./); \
+        exts[parts[2]]; \
+        print names[3]; \
+    } \
+    split("$(phonies)", scratch); \
+    for (phony in scratch) \
+        phonies[scratch[phony]]; \
+    for (ext in exts) \
+        print ext ((ext in phonies) ? "_" : ""); \
+}' testdir/input/*.*
+
+.PHONY: self-testing $(testnames)
+
+$(testnames)::
+	@echo $@ >> testdir/Xfilter
+
+self-testing:: $(testnames)
+	@echo self-testing > testdir/Xfilter

--- a/runtime/syntax/testdir/README.txt
+++ b/runtime/syntax/testdir/README.txt
@@ -63,12 +63,40 @@ script file will be sourced before any VIM_TEST_SETUP commands are executed.
 
 Every line of a source file must not be longer than 1425 (19 x 75) characters.
 
-If there is no further setup required, you can now run the tests:
+If there is no further setup required, you can now run all tests:
 
 	make test
 
-The first time this will fail with an error for a missing screendump.  The
-newly created screendumps will be "failed/java_00.dump",
+Or you can run the tests for a filetype only by passing its file extension as
+another target, e.g. "java", before "test":
+
+	make java test
+
+Or you can run a test or two by passing their filenames as extra targets, e.g.
+"java_string.java" and "java_numbers.java", before "test", after listing all
+available syntax tests for Java:
+
+	ls testdir/input/java*
+	make java_string.java java_numbers.java test
+
+(Some interactive shells may attempt to perform word completion on arbitrary
+command arguments when you press certain keys, e.g. Tab or Ctrl-i.)
+
+As an alternative, you can specify a subset of test filenames for running as
+a regular expression and assign it to a VIM_SYNTAX_TEST_FILTER environment
+variable; e.g. to run all tests whose base names contain "fold", use any of:
+
+	make test -e 'VIM_SYNTAX_TEST_FILTER = fold.*\..\+'
+	make test VIM_SYNTAX_TEST_FILTER='fold.*\..\+'
+	VIM_SYNTAX_TEST_FILTER='fold.*\..\+' make test
+
+Consider quoting the variable value to avoid any interpretation by the shell.
+
+Both Make targets and the variable may be used at the same time, the target
+names will be tried for matching before the variable value.
+
+The first time testing "input/java.java" will fail with an error for a missing
+screendump.  The newly created screendumps will be "failed/java_00.dump",
 "failed/java_01.dump", etc.  You can inspect each with:
 
 	call term_dumpload('failed/java_00.dump')
@@ -206,5 +234,4 @@ screendumps will be shown with no difference between their versions):
 	../../../src/vim --clean -S viewdumps.vim
 
 
-TODO: run test for one specific filetype
 TODO: test syncing by jumping around

--- a/runtime/syntax/testdir/input/selftestdir/README.txt
+++ b/runtime/syntax/testdir/input/selftestdir/README.txt
@@ -6,5 +6,5 @@ This is mainly used for debugging and testing the syntax test suite.
 
 Please test any changes as follows:
 	cd runtime/syntax/
-	VIM_SYNTAX_SELF_TESTING=1 make clean test
+	make clean self-testing test
 

--- a/runtime/syntax/testdir/runtest.vim
+++ b/runtime/syntax/testdir/runtest.vim
@@ -115,13 +115,26 @@ func RunTest()
   " Create a map of setup configuration filenames with their basenames as keys.
   let setup = glob('input/setup/*.vim', 1, 1)
     \ ->reduce({d, f -> extend(d, {fnamemodify(f, ':t:r'): f})}, {})
+  " Turn a subset of filenames etc. requested for testing into a pattern.
+  let filter = filereadable('../testdir/Xfilter')
+    \ ? readfile('../testdir/Xfilter')
+	\ ->map({_, v -> (v =~ '\.' ? '^' : '\.') .. v .. '$'})
+	\ ->join('\|')
+    \ : ''
 
-  if exists("$VIM_SYNTAX_SELF_TESTING")
+  " Treat "\.self-testing$" as a string NOT as a regexp.
+  if filter ==# '\.self-testing$'
     let dirpath = 'input/selftestdir/'
     let fnames = readdir(dirpath, {fname -> fname !~ '^README\.txt$'})
   else
     let dirpath = 'input/'
-    let fnames = readdir(dirpath, {fname -> fname !~ '\~$' && fname =~ '^.\+\..\+$'})
+    let filter ..= exists("$VIM_SYNTAX_TEST_FILTER") &&
+		\ !empty($VIM_SYNTAX_TEST_FILTER)
+      \ ? (empty(filter) ? '' : '\|') .. $VIM_SYNTAX_TEST_FILTER
+      \ : ''
+    let fnames = readdir(dirpath,
+	\ {subset -> {fname -> fname !~ '\~$' && fname =~# subset}}(
+		\ empty(filter) ? '^.\+\..\+$' : filter))
   endif
 
   for fname in fnames


### PR DESCRIPTION
Two methods of assembling a subset of test filenames for  
selection are provided:

- Filename and filetype Make targets will be generated, and  
  multiple such targets can be passed before the mandated  
  trailing `test` target, e.g. `make html markdown test`.

- Filenames and their parts can be specified as a regular  
  expression that is assigned to a `VIM_SYNTAX_TEST_FILTER`  
  environment variable, and used with the `test` Make target,  
  e.g. `VIM_SYNTAX_TEST_FILTER=html\\\|markdown make test`.
  (This variable will be ignored and the whole suite will be  
  run when Make is GNU Make and a parent Makefile is used.)

Methods can be used alone or together, with the Make targets  
having the higher precedence.  Neither method will influence  
the order of test execution.
