### PR TITLE
runtime(filetype)!: unify case sensitive extension matching

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -237,7 +237,10 @@ au BufNewFile,BufRead *.bat			setf dosbatch
 au BufNewFile,BufRead *.cmd
 	\ if getline(1) =~ '^/\*' | setf rexx | else | setf dosbatch | endif
 " ABB RAPID or Batch file for MSDOS.
-au BufNewFile,BufRead *.sys\c			call dist#ft#FTsys()
+au BufNewFile,BufRead *.sys			call dist#ft#FTsys()
+if has("fname_case")
+  au BufNewFile,BufRead *.Sys,*.SYS			call dist#ft#FTsys()
+endif
 
 " Batch file for 4DOS
 au BufNewFile,BufRead *.btm			call dist#ft#FTbtm()
@@ -455,7 +458,10 @@ au BufNewFile,BufRead *.ent			call dist#ft#FTent()
 au BufNewFile,BufRead .cling_history		setf cpp
 
 " Clipper, FoxPro, ABB RAPID or eviews
-au BufNewFile,BufRead *.prg\c			call dist#ft#FTprg()
+au BufNewFile,BufRead *.prg			call dist#ft#FTprg()
+if has("fname_case")
+  au BufNewFile,BufRead *.Prg,*.PRG			call dist#ft#FTprg()
+endif
 
 " Clojure
 au BufNewFile,BufRead *.clj,*.cljs,*.cljx,*.cljc		setf clojure
@@ -602,7 +608,10 @@ au BufNewFile,BufRead */tex/latex/**.cfg		setf tex
 au BufNewFile,BufRead .wakatime.cfg		setf dosini
 
 " Configure files
-au BufNewFile,BufRead *.cfg\c			call dist#ft#FTcfg()
+au BufNewFile,BufRead *.cfg			call dist#ft#FTcfg()
+if has("fname_case")
+  au BufNewFile,BufRead *.Cfg,*.CFG			call dist#ft#FTcfg()
+endif
 
 " Cucumber
 au BufNewFile,BufRead *.feature			setf cucumber
@@ -1227,9 +1236,14 @@ au BufNewFile,BufRead *.kdl			setf kdl
 au BufNewFile,BufRead *.kix			setf kix
 
 " Kuka Robot Language
-au BufNewFile,BufRead *.src\c			call dist#ft#FTsrc()
-au BufNewFile,BufRead *.dat\c			call dist#ft#FTdat()
-au BufNewFile,BufRead *.sub\c			setf krl
+au BufNewFile,BufRead *.src			call dist#ft#FTsrc()
+au BufNewFile,BufRead *.dat			call dist#ft#FTdat()
+au BufNewFile,BufRead *.sub			setf krl
+if has("fname_case")
+   au BufNewFile,BufRead *.Src,*.SRC			call dist#ft#FTsrc()
+   au BufNewFile,BufRead *.Dat,*.DAT			call dist#ft#FTdat()
+   au BufNewFile,BufRead *.Sub,*.SUB			setf krl
+endif
 
 " Kimwitu[++]
 au BufNewFile,BufRead *.k			setf kwt
@@ -1479,7 +1493,10 @@ au BufNewFile,BufRead .msmtprc			setf msmtp
 au BufNewFile,BufRead *.mmp			setf mmp
 
 " ABB Rapid, Modula-2, Modsim III or LambdaProlog
-au BufNewFile,BufRead *.mod\c			call dist#ft#FTmod()
+au BufNewFile,BufRead *.mod			call dist#ft#FTmod()
+if has("fname_case")
+   au BufNewFile,BufRead *.Mod,*.MOD			call dist#ft#FTmod()
+endif
 
 " Modula-3 (.m3, .i3, .mg, .ig)
 au BufNewFile,BufRead *.[mi][3g]		setf modula3

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -1155,15 +1155,14 @@ func Test_cfg_file()
   unlet g:filetype_cfg
 
   " RAPID cfg
-  let ext = 'cfg'
   for i in ['EIO', 'MMC', 'MOC', 'PROC', 'SIO', 'SYS']
-    call writefile([i .. ':CFG'], 'cfgfile.' .. ext)
-    execute "split cfgfile." .. ext
-    call assert_equal('rapid', &filetype)
-    bwipe!
-    call delete('cfgfile.' .. ext)
-    " check different case of file extension
-    let ext = substitute(ext, '\(\l\)', '\u\1', '')
+    for ext in ['cfg', 'Cfg', 'CFG']
+      call writefile([i .. ':CFG'], 'cfgfile.' .. ext)
+      execute "split cfgfile." .. ext
+      call assert_equal('rapid', &filetype)
+      bwipe!
+      call delete('cfgfile.' .. ext)
+    endfor
   endfor
 
   " clean up


### PR DESCRIPTION
Problem: there are different approaches of how extensions are matched
  with respect to case sensitivity. In particular, '\c' flag is used in
  pattern whereas in most places case sensitive matching is guarded
  behind `has("fname_case")` condition.
Solution: replace all instances of '\c' with an explicit case sensitive
  pattern variants guarded by `has("fname_case")`.
  Strictly speaking, this is a breaking change because only two (most
  common and prevailingly tested) variants are now matched: upper first
  letter and upper all letters.

------

Notes:
- All seven case insensitive extension matches were added in first half of April 2022: https://github.com/vim/vim/commit/3ad2090316edc85e93094bba7af64f9991cc7f85 and https://github.com/vim/vim/commit/0bbf09ca41382302493e5db51b01d2fbdc778586. I didn't find any mention of why all 8 variants for extensions should be recognized, so opted for what is (mostly) tested: `xxx`, `Xxx`, and `XXX`.