### PR TITLE
Crash with culopt=screenline and narrow window

### DIFF
--- a/src/drawline.c
+++ b/src/drawline.c
@@ -61,7 +61,7 @@ margin_columns_win(win_T *wp, int *left_col, int *right_col)
     *left_col = 0;
     *right_col = width1;
 
-    if (wp->w_virtcol >= (colnr_T)width1)
+    if (wp->w_virtcol >= (colnr_T)width1 && width2 > 0)
 	*right_col = width1 + ((wp->w_virtcol - width1) / width2 + 1) * width2;
     if (wp->w_virtcol >= (colnr_T)width1 && width2 > 0)
 	*left_col = (wp->w_virtcol - width1) / width2 * width2 + width1;

--- a/src/testdir/test_cursorline.vim
+++ b/src/testdir/test_cursorline.vim
@@ -288,6 +288,17 @@ func Test_cursorline_screenline_update()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_cursorline_screenline_zero_width()
+  CheckOption foldcolumn
+
+  set cursorline culopt=screenline winminwidth=1 foldcolumn=1
+  " This used to crash Vim
+  1vnew | redraw
+
+  bwipe!
+  set cursorline& culopt& winminwidth& foldcolumn&
+endfunc
+
 func Test_cursorline_cursorbind_horizontal_scroll()
   CheckScreendump
 


### PR DESCRIPTION
Problem:  Crash with culopt=screenline and narrow window.
Solution: Don't set right_col when width2 is 0.

fixes: #15677