### PR TITLE
heap-use-after-free in garbage collection with location list user data

### DIFF
--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -8011,6 +8011,10 @@ set_ref_in_quickfix(int copyID)
 	    abort = mark_quickfix_ctx(win->w_llist_ref, copyID);
 	    if (abort)
 		return abort;
+
+	    abort = mark_quickfix_user_data(win->w_llist_ref, copyID);
+	    if (abort)
+		return abort;
 	}
     }
 

--- a/src/testdir/test_quickfix.vim
+++ b/src/testdir/test_quickfix.vim
@@ -4208,6 +4208,18 @@ func Test_ll_window_ctx()
   enew | only
 endfunc
 
+" Similar to the problem above, but for user data.
+func Test_ll_window_user_data()
+  call setloclist(0, [#{bufnr: bufnr(), user_data: {}}])
+  lopen
+  wincmd t
+  close
+  call test_garbagecollect_now()
+  call feedkeys("\<CR>", 'tx')
+  call test_garbagecollect_now()
+  %bwipe!
+endfunc
+
 " The following test used to crash vim
 func Test_lfile_crash()
   sp Xtest


### PR DESCRIPTION
Problem:  heap-use-after-free in garbage collection with location list
          user data.
Solution: Mark user data as in use when no other window is referencing
          the location list.

fixes: neovim/neovim#30371
