### PR TITLE
Add runtime files for Jinja and Salt

### DIFF
--- a/.github/MAINTAINERS
+++ b/.github/MAINTAINERS
@@ -480,6 +480,7 @@ runtime/syntax/j.vim			@glts
 runtime/syntax/jargon.vim		@h3xx
 runtime/syntax/java.vim			@zzzyxwvut
 runtime/syntax/javascript.vim		@fleiner
+runtime/syntax/jinja.vim		@gpanders
 runtime/syntax/jj.vim			@gpanders
 runtime/syntax/json.vim		        @vito-c
 runtime/syntax/jsonc.vim		@izhakjakov

--- a/.github/MAINTAINERS
+++ b/.github/MAINTAINERS
@@ -551,6 +551,7 @@ runtime/syntax/rng.vim			@jhradilek
 runtime/syntax/routeros.vim		@zainin
 runtime/syntax/rst.vim			@marshallward
 runtime/syntax/ruby.vim			@dkearns
+runtime/syntax/salt.vim			@gpanders
 runtime/syntax/sass.vim			@tpope
 runtime/syntax/scala.vim		@derekwyatt
 runtime/syntax/scheme.vim		@evhan

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -2231,6 +2231,9 @@ au BufNewFile,BufRead .zprofile,*/etc/zprofile,.zfbfmarks  setf zsh
 au BufNewFile,BufRead .zshrc,.zshenv,.zlogin,.zlogout,.zcompdump,.zsh_history setf zsh
 au BufNewFile,BufRead *.zsh,*.zsh-theme,*.zunit		setf zsh
 
+" Salt state files
+au BufNewFile,BufRead *.sls			setf salt
+
 " Scheme ("racket" patterns are now separate, see above)
 au BufNewFile,BufRead *.scm,*.ss,*.sld		setf scheme
 

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1183,6 +1183,9 @@ au BufNewFile,BufRead *.clp			setf jess
 " Jgraph
 au BufNewFile,BufRead *.jgr			setf jgraph
 
+" Jinja
+au BufNewFile,BufRead *.jinja			setf jinja
+
 " Jujutsu
 au BufNewFile,BufRead *.jjdescription		setf jj
 

--- a/runtime/syntax/jinja.vim
+++ b/runtime/syntax/jinja.vim
@@ -1,0 +1,86 @@
+" Vim syntax file
+" Language: Jinja
+" Maintainer: Gregory Anders
+" Upstream: https://gitlab.com/HiPhish/jinja.vim
+
+if exists('b:current_syntax')
+    finish
+endif
+
+syntax case match
+syntax sync fromstart
+
+" Jinja template built-in tags and parameters (without filter, macro, is and raw, they
+" have special threatment)
+syn keyword jinjaStatement containedin=jinjaVarBlock,jinjaTagBlock,jinjaNested contained and if else in not or recursive as import
+
+syn keyword jinjaStatement containedin=jinjaVarBlock,jinjaTagBlock,jinjaNested contained is filter skipwhite nextgroup=jinjaFilter
+syn keyword jinjaStatement containedin=jinjaTagBlock contained macro skipwhite nextgroup=jinjaFunction
+syn keyword jinjaStatement containedin=jinjaTagBlock contained block skipwhite nextgroup=jinjaBlockName
+
+" Variable Names
+syn match jinjaVariable containedin=jinjaVarBlock,jinjaTagBlock,jinjaNested contained /[a-zA-Z_][a-zA-Z0-9_]*/
+syn keyword jinjaSpecial containedin=jinjaVarBlock,jinjaTagBlock,jinjaNested contained false true none False True None loop super caller varargs kwargs
+
+" Filters
+syn match jinjaOperator "|" containedin=jinjaVarBlock,jinjaTagBlock,jinjaNested contained skipwhite nextgroup=jinjaFilter
+syn match jinjaFilter contained /[a-zA-Z_][a-zA-Z0-9_]*/
+syn match jinjaFunction contained /[a-zA-Z_][a-zA-Z0-9_]*/
+syn match jinjaBlockName contained /[a-zA-Z_][a-zA-Z0-9_]*/
+
+" Jinja template constants
+syn region jinjaString containedin=jinjaVarBlock,jinjaTagBlock,jinjaNested contained start=/"/ skip=/\(\\\)\@<!\(\(\\\\\)\@>\)*\\"/ end=/"/
+syn region jinjaString containedin=jinjaVarBlock,jinjaTagBlock,jinjaNested contained start=/'/ skip=/\(\\\)\@<!\(\(\\\\\)\@>\)*\\'/ end=/'/
+syn match jinjaNumber containedin=jinjaVarBlock,jinjaTagBlock,jinjaNested contained /[0-9]\+\(\.[0-9]\+\)\?/
+
+" Operators
+syn match jinjaOperator containedin=jinjaVarBlock,jinjaTagBlock,jinjaNested contained /[+\-*\/<>=!,:]/
+syn match jinjaPunctuation containedin=jinjaVarBlock,jinjaTagBlock,jinjaNested contained /[()\[\]]/
+syn match jinjaOperator containedin=jinjaVarBlock,jinjaTagBlock,jinjaNested contained /\./ nextgroup=jinjaAttribute
+syn match jinjaAttribute contained /[a-zA-Z_][a-zA-Z0-9_]*/
+
+" Jinja template tag and variable blocks
+syn region jinjaNested matchgroup=jinjaOperator start="(" end=")" transparent display containedin=jinjaVarBlock,jinjaTagBlock,jinjaNested contained
+syn region jinjaNested matchgroup=jinjaOperator start="\[" end="\]" transparent display containedin=jinjaVarBlock,jinjaTagBlock,jinjaNested contained
+syn region jinjaNested matchgroup=jinjaOperator start="{" end="}" transparent display containedin=jinjaVarBlock,jinjaTagBlock,jinjaNested contained
+syn region jinjaTagBlock matchgroup=jinjaTagDelim start=/{%-\?/ end=/-\?%}/ containedin=ALLBUT,jinjaTagBlock,jinjaVarBlock,jinjaRaw,jinjaString,jinjaNested,jinjaComment
+
+syn region jinjaVarBlock matchgroup=jinjaVarDelim start=/{{-\?/ end=/-\?}}/ containedin=ALLBUT,jinjaTagBlock,jinjaVarBlock,jinjaRaw,jinjaString,jinjaNested,jinjaComment
+
+" Jinja template 'raw' tag
+syn region jinjaRaw matchgroup=jinjaRawDelim start="{%\s*raw\s*%}" end="{%\s*endraw\s*%}" containedin=ALLBUT,jinjaTagBlock,jinjaVarBlock,jinjaString,jinjaComment
+
+" Jinja comments
+syn region jinjaComment matchgroup=jinjaCommentDelim start="{#" end="#}" containedin=ALLBUT,jinjaTagBlock,jinjaVarBlock,jinjaString
+
+" Block start keywords.  A bit tricker.  We only highlight at the start of a
+" tag block and only if the name is not followed by a comma or equals sign
+" which usually means that we have to deal with an assignment.
+syn match jinjaStatement containedin=jinjaTagBlock contained /\({%-\?\s*\)\@<=\<[a-zA-Z_][a-zA-Z0-9_]*\>\(\s*[,=]\)\@!/
+
+" and context modifiers
+syn match jinjaStatement containedin=jinjaTagBlock contained /\<with\(out\)\?\s\+context\>/
+
+hi def link jinjaPunctuation jinjaOperator
+hi def link jinjaAttribute jinjaVariable
+hi def link jinjaFunction jinjaFilter
+
+hi def link jinjaTagDelim jinjaTagBlock
+hi def link jinjaVarDelim jinjaVarBlock
+hi def link jinjaCommentDelim jinjaComment
+hi def link jinjaRawDelim jinja
+
+hi def link jinjaSpecial Special
+hi def link jinjaOperator Normal
+hi def link jinjaRaw Normal
+hi def link jinjaTagBlock PreProc
+hi def link jinjaVarBlock PreProc
+hi def link jinjaStatement Statement
+hi def link jinjaFilter Function
+hi def link jinjaBlockName Function
+hi def link jinjaVariable Identifier
+hi def link jinjaString Constant
+hi def link jinjaNumber Constant
+hi def link jinjaComment Comment
+
+let b:current_syntax = 'jinja'

--- a/runtime/syntax/salt.vim
+++ b/runtime/syntax/salt.vim
@@ -1,0 +1,16 @@
+" Vim syntax file
+" Maintainer: Gregory Anders
+" Last Changed: 2024-09-16
+
+if exists('b:current_syntax')
+  finish
+endif
+
+" Salt state files are just YAML with embedded Jinja
+runtime! syntax/yaml.vim
+unlet! b:current_syntax
+
+runtime! syntax/jinja.vim
+unlet! b:current_syntax
+
+let b:current_syntax = 'salt'

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -635,6 +635,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     rtf: ['file.rtf'],
     ruby: ['.irbrc', 'irbrc', '.irb_history', 'irb_history', 'file.rb', 'file.rbw', 'file.gemspec', 'file.ru', 'Gemfile', 'file.builder', 'file.rxml', 'file.rjs', 'file.rant', 'file.rake', 'rakefile', 'Rakefile', 'rantfile', 'Rantfile', 'rakefile-file', 'Rakefile-file', 'Puppetfile', 'Vagrantfile'],
     rust: ['file.rs'],
+    salt: ['file.sls'],
     samba: ['smb.conf'],
     sas: ['file.sas'],
     sass: ['file.sass'],

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -366,6 +366,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     javascriptreact: ['file.jsx'],
     jess: ['file.clp'],
     jgraph: ['file.jgr'],
+    jinja: ['file.jinja'],
     jj: ['file.jjdescription'],
     jq: ['file.jq'],
     jovial: ['file.jov', 'file.j73', 'file.jovial'],


### PR DESCRIPTION
[Salt](https://docs.saltproject.io/en/master/topics/tutorials/walkthrough.html#salt-in-10-minutes/) is an infrastructure management tool. "Salt state" files are YAML with embedded [Jinja](https://jinja.palletsprojects.com/en/3.1.x/) for templating.

The Jinja syntax is taken from https://gitlab.com/HiPhish/jinja.vim. This only upstreams the syntax file, which hasn't been modified in 7 years (it's stable).