### PR TITLE
screendump.vim: Bump up the sleep value

### DIFF
--- a/src/testdir/screendump.vim
+++ b/src/testdir/screendump.vim
@@ -80,7 +80,7 @@ func VerifyScreenDump(buf, filename, options, ...)
   let i = 0
   while 1
     " leave some time for updating the original window
-    sleep 10m
+    sleep 50m
     call delete(testfile)
     call term_dumpwrite(a:buf, testfile, a:options)
     let testdump = ReadAndFilter(testfile, filter)


### PR DESCRIPTION
Asynchronous terminal jobs occasionally require more time to  
complete their tasks and update the window.