### PR TITLE
runtime(netrw): Fix E872 too much '(' in highlight pattern for `mf` selection (fixup for #15551)

### DIFF
--- a/runtime/autoload/netrw.vim
+++ b/runtime/autoload/netrw.vim
@@ -6890,7 +6890,7 @@ fun! s:NetrwMarkFile(islocal,fname)
 
   let ykeep   = @@
   let curbufnr= bufnr("%")
-  let leader= '\(^\|\s\)\zs'
+  let leader= '\%(^\|\s\)\zs'
   if a:fname =~ '\a$'
    let trailer = '\>[@=|\/\*]\=\ze\%(  \|\t\|$\)'
   else


### PR DESCRIPTION
I introduced #15551, but it causes E872 error for many file selection by `mf`:
since that makes a highlight patten with too much `\(`.

To avoid E872, it should've been `\%(`, that is without submatch reference.

### How to Repro

* Select 10? or more files by `mf` in a netrw window.
