### PR TITLE
runtime(lyrics): support multiple timestamps

### DIFF
--- a/runtime/syntax/lyrics.vim
+++ b/runtime/syntax/lyrics.vim
@@ -2,7 +2,7 @@
 " Language:     LyRiCs
 " Maintainer:   ObserverOfTime <chronobserver@disroot.org>
 " Filenames:    *.lrc
-" Last Change:  2022 Sep 18
+" Last Change:  2024 Sep 20
 
 if exists('b:current_syntax')
     finish
@@ -23,7 +23,7 @@ syn match lrcTagName contained nextgroup=lrcTagValue
 syn match lrcTagValue /:\zs.\+\ze\]/ contained
 
 " Lyrics
-syn match lrcLyricTime /^\s*\[\d\d:\d\d\.\d\d\]/
+syn match lrcLyricTime /^\s*\(\[\d\d:\d\d\.\d\d\]\)\+/
             \ contains=lrcNumber nextgroup=lrcLyricLine
 syn match lrcLyricLine /.*$/ contained contains=lrcWordTime,@Spell
 syn match lrcWordTime /<\d\d:\d\d\.\d\d>/ contained contains=lrcNumber,@NoSpell


### PR DESCRIPTION
Problem:  Multiple timestamps in the same line were not highlighted
Solution: Adapt the syntax to support multiple timestamps

Closes #15703