### PR TITLE
if_py_both.h: Reset severity for empty messages

### DIFF
--- a/src/if_py_both.h
+++ b/src/if_py_both.h
@@ -678,6 +678,14 @@ writer(writefn fn, char_u *str, PyInt n)
 	mch_memmove(((char *)io_ga.ga_data) + io_ga.ga_len, str, (size_t)n);
 	io_ga.ga_len += (int)n;
     }
+
+    // Reset emsg_sever if we got empty output from Python interpreter.
+    // Usually emsg_severe is set to FALSE in emsg(), but the function is not called
+    // for empty strings and the var stays TRUE, causing side effects further down,
+    // f.e. returning a different error message than expected, because not severe message
+    // gets severity from previous call write_output() which had the severity.
+    if (fn == (writefn)emsg && emsg_severe == TRUE)
+	emsg_severe = FALSE;
 }
 
     static int


### PR DESCRIPTION
Python 3 interpreter sometimes sends error which is not parsable by `PyArg_Parse()` in `write_output()`, which ends up with empty string being sent to `writer()` with `emsg_severe` being set, but `emsg()`, which resets the severity flag, is not called for empty strings.

It can result in certain cases into putting severity on not severe messages, because severity stays set after processing an empty string - it was one of the causes of test suite errors when compiled with Python 3.13 and using stable ABI.

The patch resets the severity flag in `writer()` in case the flag is set and we would have called `emsg()` if the string was not empty.

Partially resolves #15534