### PR TITLE
feat(complete): add cpstr in complete-item of complete

### DIFF
--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -1180,6 +1180,8 @@ items:
 			item with the same word is already present.
 	empty		when non-zero this match will be added even when it is
 			an empty string
+	cpstr		optional field that replaces word for matching against
+			input during completion.
 	user_data	custom data which is associated with the item and
 			available in |v:completed_item|; it can be any type;
 			defaults to an empty string


### PR DESCRIPTION
Problem:
Currently, LSP supports triggering completion after entering a dot (.) following a pointer variable. The textEdit.newText returned by the LSP will contain the pointer symbol ->. Typically, textEdit.newText is used as the complete-item word, except in the case of snippets.

For example, if wp is a pointer variable and you enter wp., it triggers LSP completion. The LSP will return a result such as ->w_handle. At this point, the LSP plugin should call the complete function to display the popup menu. Note that the internal data compl_orig_text at this moment is just the dot (.). You then continue typing w to filter the results, but the popup menu disappears. The internal data compl->cp_str will now all start with the pointer symbol, for instance, ->w_handle. This leads to a failure when trying to match the completion word with the leader using either strncmp or a fuzzy matching algorithm, causing the popup menu to disappear.

One possible solution is to clean the word using a keyword `\k` pattern. However, if you are working in an HTML file, the LSP completion might return results with tag symbols, such as /li>. These would also be cleaned and removed, leading to another issue. Adding special-case checks for different file types is not an ideal solution.

```
      filterText = 'w_handle',
      insertText = '->w_handle',
      label = ' w_handle',
      textEdit = {
         newText = '->w_handle',
```

Solution:
    So for improve this add a new `cpstr` field in complete function which
    used to instead of `cp_str` for leader match compare. Usually can use lsp result
    item `filterText` in there.

Reproduce step:

Use these code in vscode compare how vscode works on this situation.
```C
#include <stdlib.h>

typedef struct {
    int handle;
    int w_handle;
} Window;

int main(void) {
    Window *wp = malloc(sizeof(*wp));
    wp.|
}
```


Ref https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#completionItem