### PR TITLE
runtime(python): support multi-line case

### DIFF
--- a/runtime/syntax/python.vim
+++ b/runtime/syntax/python.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:	Python
 " Maintainer:	Zvezdan Petkovic <zpetkovic@acm.org>
-" Last Change:	2023 Feb 28
+" Last Change:	2024 Sep 21
 " Credits:	Neil Schemenauer <nas@python.ca>
 "		Dmitry Vasiliev
 "
@@ -108,7 +108,7 @@ syn keyword pythonAsync		async await
 " These keywords do not mean anything unless used in the right context.
 " See https://docs.python.org/3/reference/lexical_analysis.html#soft-keywords
 " for more on this.
-syn match   pythonConditional   "^\s*\zscase\%(\s\+.*:.*$\)\@="
+syn match   pythonConditional   "^\s*\zscase\%(\s\+.*[:(].*$\)\@="
 syn match   pythonConditional   "^\s*\zsmatch\%(\s\+.*:\s*\%(#.*\)\=$\)\@="
 
 " Decorators


### PR DESCRIPTION
Updates runtime(python) so that it can handle multi-line case statements.

Before:

<img width="262" alt="Screenshot 2024-09-21 at 10 09 07 PM" src="https://github.com/user-attachments/assets/14d2bdad-6af0-4d46-9197-d4a09ad9efa7">

After:

<img width="262" alt="Screenshot 2024-09-21 at 10 10 19 PM" src="https://github.com/user-attachments/assets/e3a559d1-1d19-42a5-99ee-2f028f8661c0">

Useful for matching against Enums with long names, where you want one line per "or" condition. Also, [black](https://github.com/psf/black) will automatically split long case statements using parenthesis in this way.

Fixes #15631 
