### PR TITLE
More fixes for GetLatestVimScripts

### DIFF
--- a/runtime/autoload/getscript.vim
+++ b/runtime/autoload/getscript.vim
@@ -10,6 +10,7 @@
 "   2024 Sep 08 by Vim Project: several small fixes (#15640)
 "   2024 Sep 23 by Vim Project: runtimedir selection fix (#15722)
 "                               autoloading search path fix
+"                               substitution of hardcoded commands with global variables
 "  }}}
 "
 " GetLatestVimScripts: 642 1 :AutoInstall: getscript.vim
@@ -21,7 +22,7 @@
 if exists("g:loaded_getscript")
  finish
 endif
-let g:loaded_getscript= "v36"
+let g:loaded_getscript= "v37"
 if &cp
  echoerr "GetLatestVimScripts is not vi-compatible; not loaded (you need to set nocp)"
  finish
@@ -87,6 +88,24 @@ endif
 
 if !exists("g:GetLatestVimScripts_downloadaddr")
   let g:GetLatestVimScripts_downloadaddr = 'https://www.vim.org/scripts/download_script.php?src_id='
+endif
+
+" define decompression tools (on windows this allows redirection to wsl or git tools).
+" Note tar is available as builtin since Windows 11.
+if !exists("g:GetLatestVimScripts_bunzip2")
+ let g:GetLatestVimScripts_bunzip2= "bunzip2"
+endif
+
+if !exists("g:GetLatestVimScripts_gunzip")
+ let g:GetLatestVimScripts_gunzip= "gunzip"
+endif
+
+if !exists("g:GetLatestVimScripts_unxz")
+ let g:GetLatestVimScripts_unxz= "unxz"
+endif
+
+if !exists("g:GetLatestVimScripts_unzip")
+ let g:GetLatestVimScripts_unzip= "unzip"
 endif
 
 "" For debugging:
@@ -569,17 +588,17 @@ fun! s:GetOneScript(...)
      " decompress
      if sname =~ '\.bz2$'
 "      call Decho("decompress: attempt to bunzip2 ".sname)
-      exe "sil !bunzip2 ".shellescape(sname)
+      exe "sil !".g:GetLatestVimScripts_bunzip2." ".shellescape(sname)
       let sname= substitute(sname,'\.bz2$','','')
 "      call Decho("decompress: new sname<".sname."> after bunzip2")
      elseif sname =~ '\.gz$'
 "      call Decho("decompress: attempt to gunzip ".sname)
-      exe "sil !gunzip ".shellescape(sname)
+      exe "sil !".g:GetLatestVimScripts_gunzip." ".shellescape(sname)
       let sname= substitute(sname,'\.gz$','','')
 "      call Decho("decompress: new sname<".sname."> after gunzip")
      elseif sname =~ '\.xz$'
 "      call Decho("decompress: attempt to unxz ".sname)
-      exe "sil !unxz ".shellescape(sname)
+      exe "sil !".g:GetLatestVimScripts_unxz." ".shellescape(sname)
       let sname= substitute(sname,'\.xz$','','')
 "      call Decho("decompress: new sname<".sname."> after unxz")
      else
@@ -589,7 +608,7 @@ fun! s:GetOneScript(...)
      " distribute archive(.zip, .tar, .vba, .vmb, ...) contents
      if sname =~ '\.zip$'
 "      call Decho("dearchive: attempt to unzip ".sname)
-      exe "silent !unzip -o ".shellescape(sname)
+      exe "silent !".g:GetLatestVimScripts_unzip." -o ".shellescape(sname)
      elseif sname =~ '\.tar$'
 "      call Decho("dearchive: attempt to untar ".sname)
       exe "silent !tar -xvf ".shellescape(sname)

--- a/runtime/doc/pi_getscript.txt
+++ b/runtime/doc/pi_getscript.txt
@@ -357,6 +357,35 @@ after/syntax/c.vim contained in it to overwrite a user's c.vim.
 		Override this if your system needs
 	  ...  ='http://vim.sourceforge.net/scripts/download_script.php?src_id='
 >
+	g:GetLatestVimScripts_bunzip2
+<        default= bunzip2
+		This variable holds the name of the command to decompress .bz2
+		files
+>
+	g:GetLatestVimScripts_gunzip
+<        default= gunzip
+		This variable holds the name of the command to decompress .gz
+		files
+>
+	g:GetLatestVimScripts_unxz
+<        default= unxz
+		This variable holds the name of the command to decompress .xz
+		files
+>
+	g:GetLatestVimScripts_unzip
+<        default= unzip
+		This variable holds the name of the command to decompress .zip
+		files
+
+Note: The variables associated with decompression commands help workaround
+      crossplatform issues. For example, on Windows is possible to delegate this
+      calls into `wsl` by doing: >
+
+	let g:GetLatestVimScripts_bunzip2= "wsl -e bunzip2"
+	let g:GetLatestVimScripts_gunzip= "wsl -e gunzip"
+	let g:GetLatestVimScripts_unxz= "wsl -e unxz"
+	let g:GetLatestVimScripts_unzip= "wsl -e unzip"
+<
 ==============================================================================
 8. GetLatestVimScripts Algorithm		*glvs-algorithm* *glvs-alg*
 
@@ -393,6 +422,11 @@ The AutoInstall process will:
 ==============================================================================
 9. GetLatestVimScripts History		*getscript-history* *glvs-hist* {{{1
 
+v37 Sep 23, 2024 : * Support for the new vimball's .vmb extension (old .vba
+		     extension conflicted with visual basic).
+		   * Support for |glvs-autoinstal| in ftplugins and packages.
+		   * Allow platform driven customization of decompressing
+		     commands.
 v36 Apr 22, 2013 : * (glts) suggested use of plugin/**/*.vim instead of
 		     plugin/*.vim in globpath() call.
 		   * (Andy Wokula) got warning message when setting

--- a/runtime/plugin/getscriptPlugin.vim
+++ b/runtime/plugin/getscriptPlugin.vim
@@ -23,7 +23,7 @@ if &cp
  endif
  finish
 endif
-let g:loaded_getscriptPlugin = "v36"
+let g:loaded_getscriptPlugin = "v37"
 let s:keepcpo                = &cpo
 set cpo&vim
 


### PR DESCRIPTION
- A fix for two errors introduced in #15640:
  -  The wrong vim runtime directory name was selected if using powershell or bash on windows. The runtime directory is independent from the shell (only depends on OS windows: _vimfiles_ linux: ._vim_)
  - A faulty pattern for the search of autoload plugins. It has been fixed and the logic updated to contemplate the *package feature* (script predates the feature).
- Allow the user to customize the commands used to decompress the scripts downloaded from `www.vim.org`. This way windows users can delegate into wsl. For example:
```vim
    let g:GetLatestVimScripts_bunzip2= "wsl -e bunzip2"
    let g:GetLatestVimScripts_gunzip= "wsl -e gunzip"
    let g:GetLatestVimScripts_unxz= "wsl -e unxz"
    let g:GetLatestVimScripts_unzip= "wsl -e unzip"
```
will allow the downloaded scripts to be decompress using wsl tools (no need for those tools to be available on windows).