### PR TITLE
getcmdprompt() may return the previous prompt

### DIFF
--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -3780,8 +3780,6 @@ f_confirm(typval_T *argvars UNUSED, typval_T *rettv UNUSED)
     message = tv_get_string_chk(&argvars[0]);
     if (message == NULL)
 	error = TRUE;
-    else
-	set_prompt(message);
     if (argvars[1].v_type != VAR_UNKNOWN)
     {
 	buttons = tv_get_string_buf_chk(&argvars[1], buf);
@@ -3814,8 +3812,12 @@ f_confirm(typval_T *argvars UNUSED, typval_T *rettv UNUSED)
 	buttons = (char_u *)_("&Ok");
 
     if (!error)
+    {
+	set_prompt(message);
 	rettv->vval.v_number = do_dialog(type, NULL, message, buttons,
 							    def, NULL, FALSE);
+	set_prompt((char_u *)"");
+    }
 #endif
 }
 

--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -4975,5 +4975,6 @@ get_user_input(
 	msg_didout = FALSE;
     }
     cmd_silent = cmd_silent_save;
+    set_prompt((char_u *)"");
 }
 #endif

--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -1650,7 +1650,11 @@ func Test_getcmdtype_getcmdprompt()
   call feedkeys(":call input('Answer?')\<CR>a\<CR>\<ESC>", "xt")
   call assert_equal('Answer?', g:cmdprompt)
   call assert_equal('', getcmdprompt())
+  call feedkeys(":\<CR>\<ESC>", "xt")
+  call assert_equal('', g:cmdprompt)
+  call assert_equal('', getcmdprompt())
 
+  unlet g:cmdprompt
   augroup test_CmdlineEnter
     au!
   augroup END


### PR DESCRIPTION
Problem:  getcmdprompt() may return the previous prompt.
Solution: Clear the prompt text when a prompt has ended.
