### PR TITLE
runtime:comment: add gC mapping to (un)comment rest of line

### DIFF
--- a/runtime/pack/dist/opt/comment/doc/comment.txt
+++ b/runtime/pack/dist/opt/comment/doc/comment.txt
@@ -12,17 +12,23 @@ See |comment-install| on how to activate this package.
 The comment.vim package, allows to toggle comments for a single line, a range
 of lines or a selected text object.  It defines the following mappings:
 
-							*gcc*
-gcc		to comment/uncomment current line
 							*o_gc*
 gc{motion}	to toggle comments for the selected motion
-							*gcip*
-gcip		to comment/uncomment current paragraph
-							*gcG*
-gcG		to comment/uncomment from current line till the end of a buffer
 							*v_gc*
 {Visual}gc	to comment/uncomment the highlighted lines.
 
+Since gc operates on a motion, it can be used with any motion, for example _
+to comment the current line, or ip to comment the current paragraph.
+A default mapping `gcc` to `gc_` is defined:
+							*gcc*
+gcc		to comment/uncomment current line
+
+To comment the rest of the line by  `gC`  whenever the syntax supports it
+(that is, whenever the comment marker precedes the code) and fall back
+to `gcc` otherwise, add the following mapping to your vimrc:
+
+  nnoremap <silent> <expr> gC comment.Toggle() .. '$'
+<
 This plugin uses the buffer-local 'commentstring' option value to add or remove
 comment markers to the selected lines.  Whether it will comment or un-comment
 depends on the first line of the range of lines to act upon.  When it matches


### PR DESCRIPTION
As discussed in https://github.com/vim/vim/issues/15727#issuecomment-2371636002 only works differently from `gcc` whenever the comment marker precedes code as happens for many languages such as Python, Lua, Vim, Sh, ...
To illustrate for C: `set cms =//\ %s` lets `gC` operate on the end of the line, whereas with `set cms=/*\ %s\ */` it behaves like `gcc`.