### PR TITLE
Fix getcmdprompt()

### DIFF
--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -3780,8 +3780,6 @@ f_confirm(typval_T *argvars UNUSED, typval_T *rettv UNUSED)
     message = tv_get_string_chk(&argvars[0]);
     if (message == NULL)
 	error = TRUE;
-    else
-	set_prompt(message);
     if (argvars[1].v_type != VAR_UNKNOWN)
     {
 	buttons = tv_get_string_buf_chk(&argvars[1], buf);

--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -30,7 +30,6 @@ static cmdline_info_T ccline;
 
 #ifdef FEAT_EVAL
 static int	new_cmdpos;	// position set by set_cmdline_pos()
-static char_u	*current_prompt;
 #endif
 
 static int	extra_char = NUL;  // extra character to display when redrawing
@@ -50,9 +49,6 @@ static void	alloc_cmdbuff(int len);
 static void	draw_cmdline(int start, int len);
 static void	save_cmdline(cmdline_info_T *ccp);
 static void	restore_cmdline(cmdline_info_T *ccp);
-#ifdef FEAT_EVAL
-static char_u	*get_prompt(void);
-#endif
 static int	cmdline_paste(int regname, int literally, int remcr);
 static void	redrawcmdprompt(void);
 static int	ccheck_abbr(int);
@@ -4236,24 +4232,6 @@ f_getcmdline(typval_T *argvars UNUSED, typval_T *rettv)
 }
 
 /*
- * Get current command line prompt.
- */
-    static char_u *
-get_prompt(void)
-{
-    return current_prompt;
-}
-
-/*
- * Set current command line prompt.
- */
-    void
-set_prompt(char_u* str)
-{
-    current_prompt = str;
-}
-
-/*
  * "getcmdpos()" function
  */
     void
@@ -4272,7 +4250,8 @@ f_getcmdprompt(typval_T *argvars UNUSED, typval_T *rettv)
 {
     cmdline_info_T *p = get_ccline_ptr();
     rettv->v_type = VAR_STRING;
-    rettv->vval.v_string = p != NULL ? vim_strsave(get_prompt()) : NULL;
+    rettv->vval.v_string = p != NULL && p->cmdprompt != NULL ?
+					    vim_strsave(p->cmdprompt) : NULL;
 }
 
 /*
@@ -4898,8 +4877,6 @@ get_user_input(
     cmd_silent = FALSE;		// Want to see the prompt.
     if (prompt != NULL)
     {
-	set_prompt(prompt);
-
 	// Only the part of the message after the last NL is considered as
 	// prompt for the command line
 	p = vim_strrchr(prompt, '\n');

--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -30,7 +30,7 @@ static cmdline_info_T ccline;
 
 #ifdef FEAT_EVAL
 static int	new_cmdpos;	// position set by set_cmdline_pos()
-static char_u	current_prompt[CMDBUFFSIZE + 1] = "";
+static char_u	*current_prompt;
 #endif
 
 static int	extra_char = NUL;  // extra character to display when redrawing
@@ -4250,7 +4250,7 @@ get_prompt(void)
     void
 set_prompt(char_u* str)
 {
-    vim_strncpy(current_prompt, str, sizeof(current_prompt) - 1);
+    current_prompt = str;
 }
 
 /*

--- a/src/proto/ex_getln.pro
+++ b/src/proto/ex_getln.pro
@@ -40,7 +40,6 @@ void f_setcmdline(typval_T *argvars, typval_T *rettv);
 void f_setcmdpos(typval_T *argvars, typval_T *rettv);
 int get_cmdline_firstc(void);
 int get_list_range(char_u **str, int *num1, int *num2);
-void set_prompt(char_u* str);
 char *did_set_cedit(optset_T *args);
 int is_in_cmdwin(void);
 char_u *script_get(exarg_T *eap, char_u *cmd);

--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -1651,6 +1651,10 @@ func Test_getcmdtype_getcmdprompt()
   call assert_equal('Answer?', g:cmdprompt)
   call assert_equal('', getcmdprompt())
 
+  let str = "C" .. repeat("c", 1023) .. "xyz"
+  call feedkeys(":call input('" .. str .. "')\<CR>\<CR>\<ESC>", "xt")
+  call assert_equal(str, g:cmdprompt)
+
   augroup test_CmdlineEnter
     au!
   augroup END

--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -1650,10 +1650,17 @@ func Test_getcmdtype_getcmdprompt()
   call feedkeys(":call input('Answer?')\<CR>a\<CR>\<ESC>", "xt")
   call assert_equal('Answer?', g:cmdprompt)
   call assert_equal('', getcmdprompt())
+  call feedkeys(":\<CR>\<ESC>", "xt")
+  call assert_equal('', g:cmdprompt)
+  call assert_equal('', getcmdprompt())
 
   let str = "C" .. repeat("c", 1023) .. "xyz"
   call feedkeys(":call input('" .. str .. "')\<CR>\<CR>\<ESC>", "xt")
   call assert_equal(str, g:cmdprompt)
+
+  call feedkeys(':call input("Msg1\nMessage2\nAns?")' .. "\<CR>b\<CR>\<ESC>", "xt")
+  call assert_equal('Ans?', g:cmdprompt)
+  call assert_equal('', getcmdprompt())
 
   augroup test_CmdlineEnter
     au!


### PR DESCRIPTION
The size limit on the string retrieved by `getcmdprompt()` has been removed.
Since there is no size limit on the {msg} of `confirm()` and the {prompt} of `input()`, it makes sense that there should also be no size limit on `getcmdprompt()`.