### PR TITLE
docs(options.txt): improve `:set` command behavior table

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -396,13 +396,14 @@ between string and number-based options.
 			options which are different from the default.
 
 For buffer-local and window-local options:
-	Command		 global value	    local value ~
-      :set option=value	     set		set
- :setlocal option=value	      -			set
-:setglobal option=value	     set		 -
-      :set option?	      -		       display
- :setlocal option?	      -		       display
-:setglobal option?	    display		 -
+	Command		 global value	  local value	       condition ~
+      :set option=value	     set	      set
+ :setlocal option=value	      -		      set
+:setglobal option=value	     set	       -
+      :set option?	      -		     display	 local value is set
+      :set option?	    display	       -	 local value is not set
+ :setlocal option?	      -		     display
+:setglobal option?	    display	       -
 
 
 Global options with a local value			*global-local*


### PR DESCRIPTION
`:set` command behavior table is inaccurate.

`:set option?` behaves differently depending on whether the local option is set or not-set.