### PR TITLE
tests: Test_halfpage_longline() fails on large terminals

### DIFF
--- a/src/testdir/test_normal.vim
+++ b/src/testdir/test_normal.vim
@@ -4266,6 +4266,7 @@ endfunc
 " Test for Ctrl-D with long line
 func Test_halfpage_longline()
   10new
+  40vsplit
   call setline(1, ['long'->repeat(1000), 'short'])
   exe "norm! \<C-D>"
   call assert_equal(2, line('.'))


### PR DESCRIPTION
Problem:  Test_halfpage_longline() fails on large terminals.
Solution: Use a window with known width.

fixes: #15755
