### PR TITLE
filetype: bun and deno history files are not recognized

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -301,6 +301,9 @@ endif
 " Busted (Lua unit testing framework - configuration files)
 au BufNewFile,BufRead .busted			setf lua
 
+" Bun history
+au BufNewFile,BufRead .bun_repl_history		setf javascript
+
 " Bundle config
 au BufNewFile,BufRead */.bundle/config			setf yaml
 
@@ -651,6 +654,9 @@ au BufNewFile,BufRead copyright
 au BufNewFile,BufRead */etc/apt/sources.list		setf debsources
 au BufNewFile,BufRead */etc/apt/sources.list.d/*.list	setf debsources
 au BufNewFile,BufRead */etc/apt/sources.list.d/*.sources	setf deb822sources
+
+" Deno history
+au BufNewFile,BufRead deno_history.txt		setf javascript
 
 " Deny hosts
 au BufNewFile,BufRead denyhosts.conf		setf denyhosts

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -362,7 +362,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     janet: ['file.janet'],
     java: ['file.java', 'file.jav'],
     javacc: ['file.jj', 'file.jjt'],
-    javascript: ['file.js', 'file.jsm', 'file.javascript', 'file.es', 'file.mjs', 'file.cjs', '.node_repl_history'],
+    javascript: ['file.js', 'file.jsm', 'file.javascript', 'file.es', 'file.mjs', 'file.cjs', '.node_repl_history', '.bun_repl_history', 'deno_history.txt'],
     'javascript.glimmer': ['file.gjs'],
     javascriptreact: ['file.jsx'],
     jess: ['file.clp'],


### PR DESCRIPTION
Problem: Bun and deno history files are not recognized
Solution: Recognize bun and deno history files as javascript filetype
