### PR TITLE
Wrong display when typing in diff mode with 'smoothscroll'

### DIFF
--- a/src/drawscreen.c
+++ b/src/drawscreen.c
@@ -1906,9 +1906,13 @@ win_update(win_T *wp)
 		    // Correct the first entry for filler lines at the top
 		    // when it won't get updated below.
 		    if (wp->w_p_diff && bot_start > 0)
-			wp->w_lines[0].wl_size =
-			    plines_win_nofill(wp, wp->w_topline, TRUE)
-							      + wp->w_topfill;
+		    {
+			int n = plines_win_nofill(wp, wp->w_topline, FALSE)
+			      + wp->w_topfill - adjust_plines_for_skipcol(wp);
+			if (n > wp->w_height)
+			    n = wp->w_height;
+			wp->w_lines[0].wl_size = n;
+		    }
 #endif
 		}
 	    }

--- a/src/testdir/dumps/Test_smooth_diff_change_line_1.dump
+++ b/src/testdir/dumps/Test_smooth_diff_change_line_1.dump
@@ -1,0 +1,20 @@
+|<+0#4040ff13#ffffff0@2| +0#0000000&|a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a||+1&&|<+0#4040ff13&@2| +0#0000000&|a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a
+| +0#0000e05#a8a8a8255@1|b+0#0000000#ffffff0|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| ||+1&&| +0#0000e05#a8a8a8255@1|b+0#0000000#ffffff0|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| 
+| +0#0000e05#a8a8a8255@1|a+0#0000000#ffffff0|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c||+1&&| +0#0000e05#a8a8a8255@1|a+0#0000000#ffffff0|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c
+| +0#0000e05#a8a8a8255@1| +0#0000000#ffffff0|a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| @14||+1&&| +0#0000e05#a8a8a8255@1| +0#0000000#ffffff0|a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| @14
+| +0#0000e05#a8a8a8255@1|f+0#0000000#5fd7ff255|o@1| @31||+1&#ffffff0| +0#0000e05#a8a8a8255@1|-+0#4040ff13#afffff255@34
+| +0#0000e05#a8a8a8255@1|b+0#0000000#ffffff0|a|r| @31||+1&&| +0#0000e05#a8a8a8255@1>b+0#0000000#ffffff0|a|r| @31
+| +0#0000e05#a8a8a8255@1| +0#0000000#ffffff0|a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b||+1&&| +0#0000e05#a8a8a8255@1| +0#0000000#ffffff0|a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b
+| +0#0000e05#a8a8a8255@1|c+0#0000000#ffffff0| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a||+1&&| +0#0000e05#a8a8a8255@1|c+0#0000000#ffffff0| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a
+| +0#0000e05#a8a8a8255@1|b+0#0000000#ffffff0|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| ||+1&&| +0#0000e05#a8a8a8255@1|b+0#0000000#ffffff0|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| 
+| +0#0000e05#a8a8a8255@1|a+0#0000000#ffffff0|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c||+1&&| +0#0000e05#a8a8a8255@1|a+0#0000000#ffffff0|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c
+| +0#0000e05#a8a8a8255@1| +0#0000000#ffffff0|a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b||+1&&| +0#0000e05#a8a8a8255@1| +0#0000000#ffffff0|a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b
+| +0#0000e05#a8a8a8255@1|c+0#0000000#ffffff0| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a||+1&&| +0#0000e05#a8a8a8255@1|c+0#0000000#ffffff0| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a
+| +0#0000e05#a8a8a8255@1|b+0#0000000#ffffff0|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| ||+1&&| +0#0000e05#a8a8a8255@1|b+0#0000000#ffffff0|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| 
+| +0#0000e05#a8a8a8255@1|a+0#0000000#ffffff0|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c||+1&&| +0#0000e05#a8a8a8255@1|a+0#0000000#ffffff0|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c
+| +0#0000e05#a8a8a8255@1| +0#0000000#ffffff0|a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| @14||+1&&| +0#0000e05#a8a8a8255@1| +0#0000000#ffffff0|a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| @14
+|~+0#4040ff13&| @35||+1#0000000&|~+0#4040ff13&| @35
+|~| @35||+1#0000000&|~+0#4040ff13&| @35
+|~| @35||+1#0000000&|~+0#4040ff13&| @35
+|[+1#0000000&|N|o| |N|a|m|e|]| |[|+|]| @5|2|,|1| @11|A|l@1| |[+3&&|N|o| |N|a|m|e|]| |[|+|]| @5|2|,|1| @11|A|l@1
+| +0&&@74

--- a/src/testdir/dumps/Test_smooth_diff_change_line_2.dump
+++ b/src/testdir/dumps/Test_smooth_diff_change_line_2.dump
@@ -1,0 +1,20 @@
+|<+0#4040ff13#ffffff0@2| +0#0000000&|a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a||+1&&|<+0#4040ff13&@2| +0#0000000&|a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a
+| +0#0000e05#a8a8a8255@1|b+0#0000000#ffffff0|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| ||+1&&| +0#0000e05#a8a8a8255@1|b+0#0000000#ffffff0|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| 
+| +0#0000e05#a8a8a8255@1|a+0#0000000#ffffff0|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c||+1&&| +0#0000e05#a8a8a8255@1|a+0#0000000#ffffff0|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c
+| +0#0000e05#a8a8a8255@1| +0#0000000#ffffff0|a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| @14||+1&&| +0#0000e05#a8a8a8255@1| +0#0000000#ffffff0|a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| @14
+| +0#0000e05#a8a8a8255@1|f+0#0000000#5fd7ff255|o@1| @31||+1&#ffffff0| +0#0000e05#a8a8a8255@1|-+0#4040ff13#afffff255@34
+| +0#0000e05#a8a8a8255@1|b+0#0000000#ffffff0|a|r| @31||+1&&| +0#0000e05#a8a8a8255@1|b+0#0000000#ffffff0|a|r|b|a|r> @28
+| +0#0000e05#a8a8a8255@1| +0#0000000#ffffff0|a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b||+1&&| +0#0000e05#a8a8a8255@1| +0#0000000#ffffff0|a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b
+| +0#0000e05#a8a8a8255@1|c+0#0000000#ffffff0| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a||+1&&| +0#0000e05#a8a8a8255@1|c+0#0000000#ffffff0| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a
+| +0#0000e05#a8a8a8255@1|b+0#0000000#ffffff0|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| ||+1&&| +0#0000e05#a8a8a8255@1|b+0#0000000#ffffff0|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| 
+| +0#0000e05#a8a8a8255@1|a+0#0000000#ffffff0|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c||+1&&| +0#0000e05#a8a8a8255@1|a+0#0000000#ffffff0|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c
+| +0#0000e05#a8a8a8255@1| +0#0000000#ffffff0|a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b||+1&&| +0#0000e05#a8a8a8255@1| +0#0000000#ffffff0|a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b
+| +0#0000e05#a8a8a8255@1|c+0#0000000#ffffff0| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a||+1&&| +0#0000e05#a8a8a8255@1|c+0#0000000#ffffff0| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a
+| +0#0000e05#a8a8a8255@1|b+0#0000000#ffffff0|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| ||+1&&| +0#0000e05#a8a8a8255@1|b+0#0000000#ffffff0|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| 
+| +0#0000e05#a8a8a8255@1|a+0#0000000#ffffff0|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c||+1&&| +0#0000e05#a8a8a8255@1|a+0#0000000#ffffff0|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c
+| +0#0000e05#a8a8a8255@1| +0#0000000#ffffff0|a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| @14||+1&&| +0#0000e05#a8a8a8255@1| +0#0000000#ffffff0|a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| @14
+|~+0#4040ff13&| @35||+1#0000000&|~+0#4040ff13&| @35
+|~| @35||+1#0000000&|~+0#4040ff13&| @35
+|~| @35||+1#0000000&|~+0#4040ff13&| @35
+|[+1#0000000&|N|o| |N|a|m|e|]| |[|+|]| @5|2|,|4| @11|A|l@1| |[+3&&|N|o| |N|a|m|e|]| |[|+|]| @5|2|,|7| @11|A|l@1
+|-+2&&@1| |I|N|S|E|R|T| |-@1| +0&&@62

--- a/src/testdir/dumps/Test_smooth_diff_change_line_3.dump
+++ b/src/testdir/dumps/Test_smooth_diff_change_line_3.dump
@@ -1,0 +1,20 @@
+|<+0#4040ff13#ffffff0@2| +0#0000000&|a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a||+1&&|<+0#4040ff13&@2| +0#0000000&|a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a
+| +0#0000e05#a8a8a8255@1|b+0#0000000#ffffff0|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| ||+1&&| +0#0000e05#a8a8a8255@1|b+0#0000000#ffffff0|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| 
+| +0#0000e05#a8a8a8255@1|a+0#0000000#ffffff0|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c||+1&&| +0#0000e05#a8a8a8255@1|a+0#0000000#ffffff0|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c
+| +0#0000e05#a8a8a8255@1| +0#0000000#ffffff0|a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| @14||+1&&| +0#0000e05#a8a8a8255@1| +0#0000000#ffffff0|a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| @14
+| +0#0000e05#a8a8a8255@1|f+2#0000000#ff404010|o@1| +0&#ffd7ff255@31||+1&#ffffff0| +0#0000e05#a8a8a8255@1|b+2#0000000#ff404010|a|r|b|a>r| +0&#ffd7ff255@28
+| +0#0000e05#a8a8a8255@1|b+0#0000000#5fd7ff255|a|r| @31||+1&#ffffff0| +0#0000e05#a8a8a8255@1|-+0#4040ff13#afffff255@34
+| +0#0000e05#a8a8a8255@1| +0#0000000#ffffff0|a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b||+1&&| +0#0000e05#a8a8a8255@1| +0#0000000#ffffff0|a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b
+| +0#0000e05#a8a8a8255@1|c+0#0000000#ffffff0| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a||+1&&| +0#0000e05#a8a8a8255@1|c+0#0000000#ffffff0| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a
+| +0#0000e05#a8a8a8255@1|b+0#0000000#ffffff0|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| ||+1&&| +0#0000e05#a8a8a8255@1|b+0#0000000#ffffff0|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| 
+| +0#0000e05#a8a8a8255@1|a+0#0000000#ffffff0|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c||+1&&| +0#0000e05#a8a8a8255@1|a+0#0000000#ffffff0|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c
+| +0#0000e05#a8a8a8255@1| +0#0000000#ffffff0|a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b||+1&&| +0#0000e05#a8a8a8255@1| +0#0000000#ffffff0|a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b
+| +0#0000e05#a8a8a8255@1|c+0#0000000#ffffff0| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a||+1&&| +0#0000e05#a8a8a8255@1|c+0#0000000#ffffff0| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a
+| +0#0000e05#a8a8a8255@1|b+0#0000000#ffffff0|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| ||+1&&| +0#0000e05#a8a8a8255@1|b+0#0000000#ffffff0|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| 
+| +0#0000e05#a8a8a8255@1|a+0#0000000#ffffff0|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c||+1&&| +0#0000e05#a8a8a8255@1|a+0#0000000#ffffff0|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c
+| +0#0000e05#a8a8a8255@1| +0#0000000#ffffff0|a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| @14||+1&&| +0#0000e05#a8a8a8255@1| +0#0000000#ffffff0|a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| @14
+|~+0#4040ff13&| @35||+1#0000000&|~+0#4040ff13&| @35
+|~| @35||+1#0000000&|~+0#4040ff13&| @35
+|~| @35||+1#0000000&|~+0#4040ff13&| @35
+|[+1#0000000&|N|o| |N|a|m|e|]| |[|+|]| @5|2|,|4| @11|A|l@1| |[+3&&|N|o| |N|a|m|e|]| |[|+|]| @5|2|,|6| @11|A|l@1
+| +0&&@74

--- a/src/testdir/dumps/Test_smooth_diff_change_line_4.dump
+++ b/src/testdir/dumps/Test_smooth_diff_change_line_4.dump
@@ -1,0 +1,20 @@
+|<+0#4040ff13#ffffff0@2| +0#0000000&|a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a||+1&&|<+0#4040ff13&@2| +0#0000000&|a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a
+| +0#0000e05#a8a8a8255@1|b+0#0000000#ffffff0|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| ||+1&&| +0#0000e05#a8a8a8255@1|b+0#0000000#ffffff0|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| 
+| +0#0000e05#a8a8a8255@1|a+0#0000000#ffffff0|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c||+1&&| +0#0000e05#a8a8a8255@1|a+0#0000000#ffffff0|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c
+| +0#0000e05#a8a8a8255@1| +0#0000000#ffffff0|a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| @14||+1&&| +0#0000e05#a8a8a8255@1| +0#0000000#ffffff0|a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| @14
+| +0#0000e05#a8a8a8255@1|f+2#0000000#ff404010|o@1| +0&#ffd7ff255@31||+1&#ffffff0| +0#0000e05#a8a8a8255@1|b+2#0000000#ff404010|a|r|b|a|r| +0&#ffd7ff255@28
+| +0#0000e05#a8a8a8255@1|b+0#0000000#ffd7ff255|a|r| @31||+1&#ffffff0| +0#0000e05#a8a8a8255@1>b+0#0000000#ffd7ff255|a|r|b+2&#ff404010|a|r| +0&#ffd7ff255@28
+| +0#0000e05#a8a8a8255@1| +0#0000000#ffffff0|a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b||+1&&| +0#0000e05#a8a8a8255@1| +0#0000000#ffffff0|a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b
+| +0#0000e05#a8a8a8255@1|c+0#0000000#ffffff0| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a||+1&&| +0#0000e05#a8a8a8255@1|c+0#0000000#ffffff0| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a
+| +0#0000e05#a8a8a8255@1|b+0#0000000#ffffff0|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| ||+1&&| +0#0000e05#a8a8a8255@1|b+0#0000000#ffffff0|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| 
+| +0#0000e05#a8a8a8255@1|a+0#0000000#ffffff0|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c||+1&&| +0#0000e05#a8a8a8255@1|a+0#0000000#ffffff0|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c
+| +0#0000e05#a8a8a8255@1| +0#0000000#ffffff0|a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b||+1&&| +0#0000e05#a8a8a8255@1| +0#0000000#ffffff0|a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b
+| +0#0000e05#a8a8a8255@1|c+0#0000000#ffffff0| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a||+1&&| +0#0000e05#a8a8a8255@1|c+0#0000000#ffffff0| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a
+| +0#0000e05#a8a8a8255@1|b+0#0000000#ffffff0|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| ||+1&&| +0#0000e05#a8a8a8255@1|b+0#0000000#ffffff0|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| 
+| +0#0000e05#a8a8a8255@1|a+0#0000000#ffffff0|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c||+1&&| +0#0000e05#a8a8a8255@1|a+0#0000000#ffffff0|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c
+| +0#0000e05#a8a8a8255@1| +0#0000000#ffffff0|a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| @14||+1&&| +0#0000e05#a8a8a8255@1| +0#0000000#ffffff0|a|b|c| |a|b|c| |a|b|c| |a|b|c| |a|b|c| @14
+|~+0#4040ff13&| @35||+1#0000000&|~+0#4040ff13&| @35
+|~| @35||+1#0000000&|~+0#4040ff13&| @35
+|~| @35||+1#0000000&|~+0#4040ff13&| @35
+|[+1#0000000&|N|o| |N|a|m|e|]| |[|+|]| @5|3|,|1| @11|A|l@1| |[+3&&|N|o| |N|a|m|e|]| |[|+|]| @5|3|,|1| @11|A|l@1
+| +0&&@74

--- a/src/testdir/test_scroll_opt.vim
+++ b/src/testdir/test_scroll_opt.vim
@@ -302,6 +302,36 @@ func Test_smoothscroll_diff_mode()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_smoothscroll_diff_change_line()
+  CheckScreendump
+
+  let lines =<< trim END
+    set diffopt+=followwrap smoothscroll
+    call setline(1, repeat(' abc', &columns))
+    call setline(2, 'bar')
+    call setline(3, repeat(' abc', &columns))
+    vnew
+    call setline(1, repeat(' abc', &columns))
+    call setline(2, 'foo')
+    call setline(3, 'bar')
+    call setline(4, repeat(' abc', &columns))
+    windo exe "normal! 2gg5\<C-E>"
+    windo diffthis
+  END
+  call writefile(lines, 'XSmoothDiffChangeLine', 'D')
+  let buf = RunVimInTerminal('-S XSmoothDiffChangeLine', #{rows: 20, columns: 55})
+
+  call VerifyScreenDump(buf, 'Test_smooth_diff_change_line_1', {})
+  call term_sendkeys(buf, "Abar")
+  call VerifyScreenDump(buf, 'Test_smooth_diff_change_line_2', {})
+  call term_sendkeys(buf, "\<Esc>")
+  call VerifyScreenDump(buf, 'Test_smooth_diff_change_line_3', {})
+  call term_sendkeys(buf, "yyp")
+  call VerifyScreenDump(buf, 'Test_smooth_diff_change_line_4', {})
+
+  call StopVimInTerminal(buf)
+endfunc
+
 func Test_smoothscroll_wrap_scrolloff_zero()
   CheckScreendump
 


### PR DESCRIPTION
Problem:  Wrong display when typing in diff mode with 'smoothscroll'.
Solution: Use adjust_plines_for_skipcol().
