### PR TITLE
`cedit` raises error for invalid `<xxx>` notation and fix docs

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1651,9 +1651,10 @@ A jump table for the options with a short description can be found at |Q_op|.
 	The default is CTRL-F when 'compatible' is off.
 	Only non-printable keys are allowed.
 	The key can be specified as a single character, but it is difficult to
-	type.  The preferred way is to use the <> notation.  Examples: >
-		:exe "set cedit=\<C-Y>"
-		:exe "set cedit=\<Esc>"
+	type.  The preferred way is to use |key-notation| (e.g. <Up>, <C-F>) or
+	a letter preceded with a caret (e.g. `^F` is CTRL-F).  Examples: >
+		:set cedit=^Y
+		:set cedit=<Esc>
 <	|Nvi| also has this option, but it only uses the first character.
 	See |cmdwin|.
 	NOTE: This option is set to the Vim default value when 'compatible'

--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -4445,7 +4445,7 @@ did_set_cedit(optset_T *args UNUSED)
     else
     {
 	n = string_to_key(p_cedit, FALSE);
-	if (vim_isprintc(n))
+	if (n == 0 || vim_isprintc(n))
 	    return e_invalid_argument;
 	cedit_key = n;
     }

--- a/src/testdir/gen_opt_test.vim
+++ b/src/testdir/gen_opt_test.vim
@@ -72,7 +72,7 @@ let test_values = {
       \ 'bufhidden': [['', 'hide', 'wipe'], ['xxx', 'hide,wipe']],
       \ 'buftype': [['', 'help', 'nofile'], ['xxx', 'help,nofile']],
       \ 'casemap': [['', 'internal'], ['xxx']],
-      \ 'cedit': [['', '\<Esc>'], ['xxx', 'f']],
+      \ 'cedit': [['', '^Y', '<Esc>'], ['xxx', 'f', '<xxx>']],
       \ 'clipboard': [['', 'unnamed', 'autoselect,unnamed', 'html', 'exclude:vimdisplay'], ['xxx', '\ze*', 'exclude:\\%(']],
       \ 'colorcolumn': [['', '8', '+2'], ['xxx']],
       \ 'comments': [['', 'b:#'], ['xxx']],


### PR DESCRIPTION
## Problem

- `:set cedit=<xxx>` does not raise a error.
- The help for `cedit` is inaccurate.
  - `:set cedit=<Esc>` works, but the example says to use `:exe "set cedit=\<Esc>"`.
  - `:set cedit=^F` works, but the help does not mention that.

## Expected behaviour

When executing `:set cedit=<xxx>`, the error `E474: Invalid argument` occurs.

