### PR TITLE
docs: add `usr` tag to usr_toc.txt

### DIFF
--- a/runtime/doc/usr_toc.txt
+++ b/runtime/doc/usr_toc.txt
@@ -2,7 +2,7 @@
 
 		     VIM USER MANUAL - by Bram Moolenaar
 
-			      Table Of Contents			*user-manual*
+			      Table Of Contents		       *user-manual* *usr*
 
 ==============================================================================
 Overview ~


### PR DESCRIPTION
When typing `:h usr` it redirects to usr_01.txt, but I'd argue
usr_toc.txt is more useful as you can see an overview of all manuals.
When I usr `:h usr` I personally always intend to go to `usr_toc`.
