### PR TITLE
'filetype', 'syntax' and 'keymap' only allows alphanumeric or some characters

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3510,7 +3510,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	one dot may appear.
 	This option is not copied to another buffer, independent of the 's' or
 	'S' flag in 'cpoptions'.
-	Only normal file name characters can be used, "/\*?[|<>" are illegal.
+	Only alphanumeric characters, '.', '-' and '_' can be used.
 
 						*'fillchars'* *'fcs'*
 'fillchars' 'fcs'	string	(default "vert:|,fold:-,eob:~")
@@ -4992,7 +4992,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	Setting this option to a valid keymap name has the side effect of
 	setting 'iminsert' to one, so that the keymap becomes effective.
 	'imsearch' is also set to one, unless it was -1
-	Only normal file name characters can be used, "/\*?[|<>" are illegal.
+	Only alphanumeric characters, '.', '-' and '_' can be used.
 
 					*'keymodel'* *'km'*
 'keymodel' 'km'		string	(default "")
@@ -8112,7 +8112,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	Syntax autocommand event is triggered with the value as argument.
 	This option is not copied to another buffer, independent of the 's' or
 	'S' flag in 'cpoptions'.
-	Only normal file name characters can be used, "/\*?[|<>" are illegal.
+	Only alphanumeric characters, '.', '-' and '_' can be used.
 
 						*'tabclose'* *'tcl'*
 'tabclose' 'tcl'	string	(default "")


### PR DESCRIPTION
## Problem

Help says:
https://github.com/vim/vim/blob/6a89c94a9eeee53481ced1a1260a177bffde4c0f/runtime/doc/options.txt#L3513

But `'filetype'`, `'syntax'` and `'keymap'` only allows alphanumeric, `.`, `-` or `_`.

## Detail

This help entry is common to all options that have `P_NFNAME`.
`'filetype'`, `'syntax'` and `'keymap'` also have them, but implement additional constraints:
https://github.com/vim/vim/blob/6a89c94a9eeee53481ced1a1260a177bffde4c0f/src/optionstr.c#L606-L614
https://github.com/vim/vim/blob/6a89c94a9eeee53481ced1a1260a177bffde4c0f/src/option.c#L3103-L3108