### PR TITLE
runtime:ftplugin:systemd: small fixes to &keywordprg

### DIFF
--- a/runtime/ftplugin/systemd.vim
+++ b/runtime/ftplugin/systemd.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin file
 " Language:			systemd.unit(5)
 " Keyword Lookup Support:	Enno Nagel <enno.nagel+vim@gmail.com>
-" Latest Revision:		2024-09-19 (simplify keywordprg #15696)
+" Latest Revision:		2024-10-02 (small fixes to &keywordprg)
 
 if exists("b:did_ftplugin")
   finish
@@ -10,20 +10,20 @@ endif
 runtime! ftplugin/dosini.vim
 
 if has('unix') && executable('less') && exists(':terminal') == 2
-  command -buffer -nargs=1 SystemdKeywordPrg silent exe 'term ' . KeywordLookup_systemd(<q-args>)
+  command! -buffer -nargs=1 SystemdKeywordPrg silent exe 'term' KeywordLookup_systemd(<q-args>)
   silent! function KeywordLookup_systemd(keyword) abort
     let matches = matchlist(getline(search('\v^\s*\[\s*.+\s*\]\s*$', 'nbWz')), '\v^\s*\[\s*(\k+).*\]\s*$')
     if len(matches) > 1
       let section = matches[1]
-      return 'LESS= MANPAGER="less --pattern=''(^|,)\s+' . a:keyword . '=$'' --hilite-search" man ' . 'systemd.' . section
+      return 'env LESS= MANPAGER="less --pattern=''(^|,)\\s+' . a:keyword . '=$'' --hilite-search" man ' . 'systemd.' . section
     else
-      return 'LESS= MANPAGER="less --pattern=''(^|,)\s+' . a:keyword . '=$'' --hilite-search" man ' . 'systemd'
+      return 'env LESS= MANPAGER="less --pattern=''(^|,)\\s+' . a:keyword . '=$'' --hilite-search" man ' . 'systemd'
     endif
   endfunction
   setlocal iskeyword+=-
   setlocal keywordprg=:SystemdKeywordPrg
   if !exists('b:undo_ftplugin') || empty(b:undo_ftplugin)
-    let b:undo_ftplugin = 'setlocal keywordprg< iskeyword<'
+    let b:undo_ftplugin = 'setlocal keywordprg< iskeyword< | sil! delc -buffer SystemdKeywordPrg'
   else
     let b:undo_ftplugin .= '| setlocal keywordprg< iskeyword< | sil! delc -buffer SystemdKeywordPrg'
   endif


### PR DESCRIPTION
Vim's  `:term` does not understand initial env. var's and slashes need to be escaped.
Question: Isn't `:term ++close` preferable?