### PR TITLE
set invalid key to 'wildcharm' will result in 0 without error

### DIFF
--- a/src/option.c
+++ b/src/option.c
@@ -2251,10 +2251,11 @@ do_set_option_numeric(
      * Different ways to set a number option:
      * &	    set to default value
      * <	    set to global value
-     * <xx>	    accept special key codes for 'wildchar'
-     * c	    accept any non-digit for 'wildchar'
-     * [-]0-9   set number
-     * other    error
+     * <xx>	    accept special key codes for 'wildchar' or 'wildcharm'
+     * ^x	    accept ctrl key codes for 'wildchar' or 'wildcharm'
+     * c	    accept any non-digit for 'wildchar' or 'wildcharm'
+     * [-]0-9	    set number
+     * other	    error
      */
     ++arg;
     if (nextchar == '&')
@@ -2281,7 +2282,7 @@ do_set_option_numeric(
 		    && !VIM_ISDIGIT(*arg))))
     {
 	value = string_to_key(arg, FALSE);
-	if (value == 0 && (long *)varp != &p_wcm)
+	if (value == 0)
 	{
 	    errmsg = e_invalid_argument;
 	    goto skip;

--- a/src/testdir/gen_opt_test.vim
+++ b/src/testdir/gen_opt_test.vim
@@ -7,6 +7,8 @@ if 1
 
 set nomore
 
+const K_KENTER = -16715
+
 " The terminal size is restored at the end.
 " Clear out t_WS, we don't want to resize the actual terminal.
 let script = [
@@ -55,7 +57,10 @@ let test_values = {
       \ 'updatecount': [[0, 1, 8, 9999], [-1]],
       \ 'updatetime': [[0, 1, 8, 9999], [-1]],
       \ 'verbose': [[-1, 0, 1, 8, 9999], []],
-      \ 'wildcharm': [[-1, 0, 100], []],
+      \ 'wildchar': [[-1, 0, 100, 'x', '^Y', '<Esc>', '<t_xx>'],
+      \		['', 'xxx', '<xxx>', '<Esc', '<C-C>', '<NL>', '<CR>', K_KENTER]],
+      \ 'wildcharm': [[-1, 0, 100, 'x', '^Y', '<Esc>'],
+      \		['', 'xxx', '<xxx>', '<Esc', '<C-C>', '<NL>', '<CR>', K_KENTER]],
       \ 'winheight': [[1, 10, 999], [-1, 0]],
       \ 'winminheight': [[0, 1], [-1]],
       \ 'winminwidth': [[0, 1, 10], [-1]],


### PR DESCRIPTION
## Problem

`:set wildcharm=<xxx>` does not throw an error, and set to `0`.
There are not enough test patterns for `wildchar` or `wildcharm`.

## Detail

`:set wildcharm=0` initializes it, I think it should not ignore errors.
This removed condition was implemented around Vim 7.0. I don't know the details.