### PR TITLE
Problem:  tests: messages file contains ansi escape sequences

### DIFF
--- a/src/testdir/Makefile
+++ b/src/testdir/Makefile
@@ -12,7 +12,7 @@ SCRIPTSOURCE = ../../runtime
 # Comment out this line to see the verbose output of tests.
 #
 # Catches SwapExists to avoid hanging at the ATTENTION prompt.
-REDIR_TEST_TO_NULL = --cmd 'au SwapExists * let v:swapchoice = "e"' | LC_ALL=C LANG=C LANGUAGE=C awk '/Executing Test_/{match($$0, "([0-9][0-9]:[0-9][0-9] *)?Executing Test_[^\\)]*\\)"); print substr($$0, RSTART, RLENGTH) "\r"; fflush()}'
+REDIR_TEST_TO_NULL = --cmd 'au SwapExists * let v:swapchoice = "e"' | LC_ALL=C awk '/Executing Test_/{match($$0, "([0-9][0-9]:[0-9][0-9] *)?Executing Test_[^\\)]*\\)"); print substr($$0, RSTART, RLENGTH) "\r"; fflush()}'
 
 # Uncomment this line to use valgrind for memory leaks and extra warnings.
 #   The output goes into a file "valgrind.testN"

--- a/src/testdir/runtest.vim
+++ b/src/testdir/runtest.vim
@@ -522,11 +522,11 @@ func FinishTesting()
   " Add SKIPPED messages
   call extend(s:messages, s:skipped)
 
-  " Append messages to the file "messages"
+  " Append messages to the file "messages", but remove ANSI Escape sequences
   split messages
   call append(line('$'), '')
   call append(line('$'), 'From ' . g:testname . ':')
-  call append(line('$'), s:messages)
+  call append(line('$'), s:messages->map({_, val -> substitute(val, '\%x1b\[\d\?m', '', 'g')}))
   write
 
   qall!


### PR DESCRIPTION
Problem:  tests: messages file contains ansi escape sequences
Solution: filter out those special sequences

Also, since we are setting $LC_ALL, we don't need to set $LANG and $LANGUAGE since those are overridden by $LC_ALL anyhow.