### PR TITLE
Constrain gitcommitHash length to 40 or 64

### DIFF
--- a/runtime/syntax/gitcommit.vim
+++ b/runtime/syntax/gitcommit.vim
@@ -51,7 +51,7 @@ unlet s:l s:comment s:scissors
 
 syn match   gitcommitTrailerToken "^[[:alnum:]-]\+\s*:" contained containedin=gitcommitTrailers
 
-syn match   gitcommitHash	"\<\x\{40,}\>" contains=@NoSpell display
+syn match   gitcommitHash	"\<\x\{40}\>\|\<\x\{64}\>" contains=@NoSpell display
 syn match   gitcommitOnBranch	"\%(^. \)\@<=On branch" contained containedin=gitcommitComment nextgroup=gitcommitBranch skipwhite
 syn match   gitcommitOnBranch	"\%(^. \)\@<=Your branch .\{-\} '" contained containedin=gitcommitComment nextgroup=gitcommitBranch skipwhite
 syn match   gitcommitBranch	"[^ ']\+" contained


### PR DESCRIPTION
Git commit hashes are either 40 or 64 characters long (for SHA-1 or SHA-256 respectively). The previous implementation matches all hexadecimal strings of 40 or more characters, which is too eager.