### PR TITLE
tests: no error is occurs if gen_opt_test.vim fails

### DIFF
--- a/src/testdir/Make_ming.mak
+++ b/src/testdir/Make_ming.mak
@@ -158,7 +158,7 @@ test_gui_init.res: test_gui_init.vim
 	@$(DEL) vimcmd
 
 opt_test.vim: ../optiondefs.h gen_opt_test.vim
-	$(VIMPROG) -u NONE -S gen_opt_test.vim --noplugin --not-a-term ../optiondefs.h
+	$(VIMPROG) -e -s -u NONE $(COMMON_ARGS) --nofork -S gen_opt_test.vim ../optiondefs.h
 
 test_bench_regexp.res: test_bench_regexp.vim
 	-$(DEL) benchmark.out

--- a/src/testdir/Make_mvc.mak
+++ b/src/testdir/Make_mvc.mak
@@ -152,7 +152,7 @@ test_gui_init.res: test_gui_init.vim
 	@del vimcmd
 
 opt_test.vim: ../optiondefs.h gen_opt_test.vim
-	$(VIMPROG) -u NONE -S gen_opt_test.vim --noplugin --not-a-term ../optiondefs.h
+	$(VIMPROG) -e -s -u NONE $(COMMON_ARGS) --nofork -S gen_opt_test.vim ../optiondefs.h
 
 test_bench_regexp.res: test_bench_regexp.vim
 	-if exist benchmark.out del benchmark.out

--- a/src/testdir/Makefile
+++ b/src/testdir/Makefile
@@ -161,7 +161,7 @@ test_gui_init.res: test_gui_init.vim
 	@rm vimcmd
 
 opt_test.vim: ../optiondefs.h gen_opt_test.vim
-	$(VIMPROG) -u NONE -S gen_opt_test.vim --noplugin --not-a-term ../optiondefs.h
+	$(VIMPROG) -e -s -u NONE $(NO_INITS) --nofork --gui-dialog-file guidialog -S gen_opt_test.vim ../optiondefs.h
 
 test_xxd.res:
 	XXD=$(XXDPROG); export XXD; $(RUN_VIMTEST) $(NO_INITS) -S runtest.vim test_xxd.vim

--- a/src/testdir/gen_opt_test.vim
+++ b/src/testdir/gen_opt_test.vim
@@ -1,9 +1,11 @@
-" Script to generate testdir/opt_test.vim from option.c
+" Script to generate testdir/opt_test.vim from optiondefs.h
 
 set cpo=&vim
 
 " Only do this when build with the +eval feature.
 if 1
+
+try
 
 set nomore
 
@@ -243,6 +245,13 @@ call add(script, 'let &columns = save_columns')
 call add(script, 'let &lines = save_lines')
 
 call writefile(script, 'opt_test.vim')
+
+" Exit with error-code if error occurs.
+catch
+  set verbose=1
+  echoc 'Error:' v:exception 'in' v:throwpoint
+  cq! 1
+endtry
 
 endif
 


### PR DESCRIPTION
If gen_opt_test.vim fails then make should fail.
Script errors should be displayed.