### PR TITLE
runtime(doc,syntax): help formatting and add syntax

### DIFF
--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -481,13 +481,13 @@ The 'wildignorecase' option can be set to ignore case in filenames.  For
 completing other texts (e.g. command names), the 'ignorecase' option is used
 instead (fuzzy matching always ignores case, however).
 
-If you like tcsh's autolist completion, you can use this mapping:
+If you like tcsh's autolist completion, you can use this mapping: >
 	:cnoremap X <C-L><C-D>
 (Where X is the command key to use, <C-L> is CTRL-L and <C-D> is CTRL-D)
 This will find the longest match and then list all matching files.
 
 If you like tcsh's autolist completion, you can use the 'wildmode' option to
-emulate it.  For example, this mimics autolist=ambiguous:
+emulate it.  For example, this mimics autolist=ambiguous: >
 	:set wildmode=longest,list
 This will find the longest match with the first 'wildchar', then list all
 matching files with the next.

--- a/runtime/doc/if_tcl.txt
+++ b/runtime/doc/if_tcl.txt
@@ -461,14 +461,14 @@ Input from stdin is currently not supported.
 Here are a few small (and maybe useful) Tcl scripts.
 
 This script sorts the lines of the entire buffer (assume it contains a list
-of names or something similar):
+of names or something similar): >
 	set buf $::vim::current(buffer)
 	set lines [$buf get top bottom]
 	set lines [lsort -dictionary $lines]
 	$buf set top bottom $lines
 
 This script reverses the lines in the buffer.  Note the use of "::vim::lbase"
-and "$buf last" to work with any line number setting.
+and "$buf last" to work with any line number setting: >
 	set buf $::vim::current(buffer)
 	set t $::vim::lbase
 	set b [$buf last]
@@ -481,7 +481,7 @@ and "$buf last" to work with any line number setting.
 		incr b -1
 	}
 
-This script adds a consecutive number to each line in the current range:
+This script adds a consecutive number to each line in the current range: >
 	set buf $::vim::current(buffer)
 	set i $::vim::range(start)
 	set n 1
@@ -491,17 +491,17 @@ This script adds a consecutive number to each line in the current range:
 		incr i ; incr n
 	}
 
-The same can also be done quickly with two Ex commands, using ":tcldo":
+The same can also be done quickly with two Ex commands, using ":tcldo": >
 	:tcl set n 1
 	:[range]tcldo set line "$n\t$line" ; incr n
 
-This procedure runs an Ex command on each buffer (idea stolen from Ron Aaron):
+This procedure runs an Ex command on each buffer (idea stolen from Ron Aaron): >
 	proc eachbuf { cmd } {
 		foreach b [::vim::buffer list] {
 			$b command $cmd
 		}
 	}
-Use it like this:
+Use it like this: >
 	:tcl eachbuf %s/foo/bar/g
 Be careful with Tcl's string and backslash substitution, tough.  If in doubt,
 surround the Ex command with curly braces.
@@ -509,7 +509,7 @@ surround the Ex command with curly braces.
 
 If you want to add some Tcl procedures permanently to vim, just place them in
 a file (e.g. "~/.vimrc.tcl" on Unix machines), and add these lines to your
-startup file (usually "~/.vimrc" on Unix):
+startup file (usually "~/.vimrc" on Unix): >
 	if has("tcl")
 		tclfile ~/.vimrc.tcl
 	endif

--- a/runtime/doc/indent.txt
+++ b/runtime/doc/indent.txt
@@ -117,7 +117,7 @@ If you really want to reindent when you type 'o', 'O', 'e', '0', '<', '>',
 "<!>", respectively, for those keys.
 
 For an emacs-style indent mode where lines aren't indented every time you
-press <Enter> but only if you press <Tab>, I suggest:
+press <Enter> but only if you press <Tab>, I suggest: >
 	:set cinkeys=0{,0},:,0#,!<Tab>,!^F
 You might also want to switch off 'autoindent' then.
 

--- a/runtime/doc/intro.txt
+++ b/runtime/doc/intro.txt
@@ -825,7 +825,7 @@ The current mode is "-- INSERT --" or "-- REPLACE --", see |'showmode'|.  The
 command characters are those that you typed but were not used yet.
 
 If you have a slow terminal you can switch off the status messages to speed
-up editing:
+up editing: >
 	:set nosc noru nosm
 
 If there is an error, an error message will be shown for at least one second

--- a/runtime/doc/motion.txt
+++ b/runtime/doc/motion.txt
@@ -169,9 +169,9 @@ h		or					*h*
 CTRL-H		or					*CTRL-H* *<BS>*
 <BS>			[count] characters to the left.  |exclusive| motion.
 			Note: If you prefer <BS> to delete a character, use
-			the mapping:
+			the mapping: >
 				:map CTRL-V<BS>		X
-			(to enter "CTRL-V<BS>" type the CTRL-V key, followed
+<			(to enter "CTRL-V<BS>" type the CTRL-V key, followed
 			by the <BS> key)
 			See |:fixdel| if the <BS> key does not do what you
 			want.

--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -105,9 +105,9 @@ where the cursor was before the global command).
 
 The global command sets both the last used search pattern and the last used
 substitute pattern (this is vi compatible).  This makes it easy to globally
-replace a string:
+replace a string: >
 	:g/pat/s//PAT/g
-This replaces all occurrences of "pat" with "PAT".  The same can be done with:
+This replaces all occurrences of "pat" with "PAT".  The same can be done with: >
 	:%s/pat/PAT/g
 Which is two characters shorter!
 
@@ -526,7 +526,7 @@ Example: the lines >
 		     \:%,
 		     \n:>,
 		     \fb:-
-are interpreted as if they were given in one line:
+are interpreted as if they were given in one line: >
 	:set comments=sr:/*,mb:*,el:*/,://,b:#,:%,n:>,fb:-
 
 All leading whitespace characters in the line before a backslash are ignored.
@@ -611,7 +611,7 @@ advantages over normal plugins:
 Using a package and loading automatically ~
 
 Let's assume your Vim files are in the "~/.vim" directory and you want to add a
-package from a zip archive "/tmp/foopack.zip":
+package from a zip archive "/tmp/foopack.zip": >
 	% mkdir -p ~/.vim/pack/foo
 	% cd ~/.vim/pack/foo
 	% unzip /tmp/foopack.zip
@@ -661,7 +661,7 @@ If the package has an "after" directory, that directory is added to the end of
 Using a single plugin and loading it automatically ~
 
 If you don't have a package but a single plugin, you need to create the extra
-directory level:
+directory level: >
 	% mkdir -p ~/.vim/pack/foo/start/foobar
 	% cd ~/.vim/pack/foo/start/foobar
 	% unzip /tmp/someplugin.zip
@@ -978,13 +978,13 @@ will put the MO files in the "lang/" directory of the Vim editor.
 Type the following commands:
 >
 	cd /d f:\forkvim\src\po
- (the following command must be entered in one line, here it is separated for example)
- For Russian:
+< (the following command must be entered in one line, here it is separated for example)
+ For Russian: >
 	nmake.exe -f Make_mvc.mak "PLUGPACKAGE=aap"
 	"PO_PLUGPACKAGE=e:\project\translate\plugins\ru.po"
 	"MO_PLUGPACKAGE_PATH=d:\Programs\vim\vim91\lang\ru\LC_MESSAGES"
 	aap.mo
- For German:
+< For German: >
 	nmake.exe -f Make_mvc.mak "PLUGPACKAGE=aap"
 	"PO_PLUGPACKAGE=e:\project\translate\plugins\de.po"
 	"MO_PLUGPACKAGE_PATH=d:\Programs\vim\vim91\lang\de\LC_MESSAGES"

--- a/runtime/doc/spell.txt
+++ b/runtime/doc/spell.txt
@@ -792,7 +792,7 @@ them before the Vim word list is made.  The tools for this can be found in the
 The format for the affix and word list files is based on what Myspell uses
 (the spell checker of Mozilla and OpenOffice.org).  A description can be found
 here:
-	http://lingucomponent.openoffice.org/affix.readme ~
+	http://lingucomponent.openoffice.org/affix.readme
 Note that affixes are case sensitive, this isn't obvious from the description.
 
 Vim supports quite a few extras.  They are described below |spell-affix-vim|.

--- a/runtime/doc/term.txt
+++ b/runtime/doc/term.txt
@@ -292,11 +292,11 @@ entry in /etc/termcap and everything should work.
 On some systems (at least on FreeBSD with XFree86 3.1.2) the codes that the
 <End> and <Home> keys send contain a <Nul> character.  To make these keys send
 the proper key code, add these lines to your ~/.Xdefaults file:
-
-*VT100.Translations:		#override \n\
-		<Key>Home: string("0x1b") string("[7~") \n\
-		<Key>End: string("0x1b") string("[8~")
-
+>
+	*VT100.Translations:		#override \n\
+			<Key>Home: string("0x1b") string("[7~") \n\
+			<Key>End: string("0x1b") string("[8~")
+<
 						*xterm-8bit* *xterm-8-bit*
 Xterm can be run in a mode where it uses 8-bit escape sequences.  The CSI code
 is used instead of <Esc>[.  The advantage is that an <Esc> can quickly be
@@ -719,9 +719,9 @@ If this feature is enabled by the 't_fe' sequence, special key sequences are
 sent from the terminal to Vim every time the terminal gains or loses focus.
 Vim fires focus events (|FocusGained|/|FocusLost|) by handling them accordingly.
 Focus event tracking is disabled by a 't_fd' sequence when exiting "raw" mode.
-If you would like to disable this feature, add the following to your .vimrc:
-	`set t_fd=`
-	`set t_fe=`
+If you would like to disable this feature, add the following to your .vimrc: >
+	set t_fd=
+	set t_fe=
 If your terminal does support this but Vim does not recognize the terminal,
 you may have to set the options yourself: >
 	let &t_fe = "\<Esc>[?1004h"
@@ -810,13 +810,13 @@ region.  It should be set to an empty string otherwise.
 Note for xterm users: The shifted cursor keys normally don't work.  You can
 	make them work with the xmodmap command and some mappings in Vim.
 
-	Give these commands in the xterm:
+	Give these commands in the xterm: >
 		xmodmap -e "keysym Up = Up F13"
 		xmodmap -e "keysym Down = Down F16"
 		xmodmap -e "keysym Left = Left F18"
 		xmodmap -e "keysym Right = Right F19"
-
-	And use these mappings in Vim:
+<
+	And use these mappings in Vim: >
 		:map <t_F3> <S-Up>
 		:map! <t_F3> <S-Up>
 		:map <t_F6> <S-Down>

--- a/runtime/doc/usr_29.txt
+++ b/runtime/doc/usr_29.txt
@@ -34,8 +34,8 @@ following command: >
 
 "ctags" is a separate program.  Most Unix systems already have it installed.
 If you do not have it yet, you can find Universal/Exuberant ctags at:
-	http://ctags.io ~
-	http://ctags.sf.net ~
+	http://ctags.io
+	http://ctags.sf.net
 
 Universal ctags is preferred, Exuberant ctags is no longer being developed.
 

--- a/runtime/doc/usr_45.txt
+++ b/runtime/doc/usr_45.txt
@@ -177,7 +177,7 @@ example is for the X Window System.  This font is in a package that is used to
 enhance xterm with Unicode support.  If you don't have this font, you might
 find it here:
 
-	http://www.cl.cam.ac.uk/~mgk25/download/ucs-fonts.tar.gz ~
+	http://www.cl.cam.ac.uk/~mgk25/download/ucs-fonts.tar.gz
 
 For MS-Windows, some fonts have a limited number of Unicode characters.  Try
 using the "Courier New" font.  You can use the Edit/Select Font... menu to
@@ -189,7 +189,7 @@ though.  Example: >
 If it doesn't work well, try getting a fontpack.  If Microsoft didn't move it,
 you can find it here:
 
-	http://www.microsoft.com/typography/fonts/default.aspx ~
+	http://www.microsoft.com/typography/fonts/default.aspx
 
 Now you have told Vim to use Unicode internally and display text with a
 Unicode font.  Typed characters still arrive in the encoding of your original

--- a/runtime/doc/usr_90.txt
+++ b/runtime/doc/usr_90.txt
@@ -36,7 +36,7 @@ FROM A PACKAGE
 You can get precompiled binaries for many different UNIX systems.  There is a
 long list with links on this page:
 
-	http://www.vim.org/binaries.html ~
+	http://www.vim.org/binaries.html
 
 Volunteers maintain the binaries, so they are often out of date.  It is a
 good idea to compile your own UNIX version from the source.  Also, creating
@@ -59,7 +59,7 @@ To compile and install Vim, you will need the following:
 To get the Vim archives, look in this file for a mirror near you, this should
 provide the fastest download:
 
-	ftp://ftp.vim.org/pub/vim/MIRRORS ~
+	ftp://ftp.vim.org/pub/vim/MIRRORS
 
 Or use the home site ftp.vim.org, if you think it's fast enough.  Go to the
 "unix" directory and you'll find a list of files there.  The version number is
@@ -213,7 +213,7 @@ one, you will need:
 To get the Vim archives, look in this file for a mirror near you, this should
 provide the fastest download:
 
-	ftp://ftp.vim.org/pub/vim/MIRRORS ~
+	ftp://ftp.vim.org/pub/vim/MIRRORS
 
 Or use the home site ftp.vim.org, if you think it's fast enough.  Go to the
 "pc" directory and you'll find a list of files there.  The version number is

--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -71,7 +71,7 @@ ga			Print the ascii value of the character under the
 			If the character can be inserted as a digraph, also
 			output the two characters that can be used to create
 			the character:
-			    <ö> 246, Hex 00f6, Oct 366, Digr o: ~
+				<ö> 246, Hex 00f6, Oct 366, Digr o: ~
 			This shows you can type CTRL-K o : to insert ö.
 
 							*g8*

--- a/runtime/doc/vi_diff.txt
+++ b/runtime/doc/vi_diff.txt
@@ -119,11 +119,11 @@ Vi compatibility.					|'compatible'|
 	considered to be a bug, or at least need improvement.  But still, Vim
 	starts in a mode which behaves like the "real" Vi as much as possible.
 	To make Vim behave a little bit better, try resetting the 'compatible'
-	option:
+	option: >
 		:set nocompatible
-	Or start Vim with the "-N" argument:
+<	Or start Vim with the "-N" argument: >
 		vim -N
-	Vim starts with 'nocompatible' automatically if you have a .vimrc
+<	Vim starts with 'nocompatible' automatically if you have a .vimrc
 	file.  See |startup|.
 	The 'cpoptions' option can be used to set Vi compatibility on/off for
 	a number of specific items.

--- a/runtime/syntax/help.vim
+++ b/runtime/syntax/help.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:	Vim help file
 " Maintainer:	The Vim Project <https://github.com/vim/vim>
-" Last Change:	2023 Aug 10
+" Last Change:	05 Oct 2024
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Quit when a (custom) syntax file was already loaded
@@ -64,14 +64,14 @@ syn match helpSpecial		"\<N\.\s"me=e-2
 syn match helpSpecial		"(N\>"ms=s+1
 
 syn match helpSpecial		"\[N]"
-" avoid highlighting N  N in help.txt
+" avoid highlighting N  N in quickref.txt
 syn match helpSpecial		"N  N"he=s+1
 syn match helpSpecial		"Nth"me=e-2
 syn match helpSpecial		"N-1"me=e-2
 " highlighting N of cinoptions-values in indent.txt
-syn match helpSpecial		"\<Ns\>"me=e-1
+syn match helpSpecial		"^\t-\?\zsNs\?\s"me=s+1
 " highlighting N of cinoptions-values in indent.txt
-syn match helpSpecial		"^\t[enfLlbghNEpticCuUwWkmMjJP]N "ms=s+2,me=e-1
+syn match helpSpecial		"^\t[>enf{}^L:=lbghNEpti+cC/(uUwWkmMjJ)*#P]N\s"ms=s+2,me=e-1
 syn match helpSpecial		"{[-a-zA-Z0-9'"*+/:%#=[\]<>.,]\+}"
 syn match helpSpecial		"\s\[[-a-z^A-Z0-9_]\{2,}]"ms=s+1
 syn match helpSpecial		"<[-a-zA-Z0-9_]\+>"

--- a/runtime/syntax/help.vim
+++ b/runtime/syntax/help.vim
@@ -68,6 +68,10 @@ syn match helpSpecial		"\[N]"
 syn match helpSpecial		"N  N"he=s+1
 syn match helpSpecial		"Nth"me=e-2
 syn match helpSpecial		"N-1"me=e-2
+" highlighting N of cinoptions-values in indent.txt
+syn match helpSpecial		"\<Ns\>"me=e-1
+" highlighting N of cinoptions-values in indent.txt
+syn match helpSpecial		"^\t[enfLlbghNEpticCuUwWkmMjJP]N "ms=s+2,me=e-1
 syn match helpSpecial		"{[-a-zA-Z0-9'"*+/:%#=[\]<>.,]\+}"
 syn match helpSpecial		"\s\[[-a-z^A-Z0-9_]\{2,}]"ms=s+1
 syn match helpSpecial		"<[-a-zA-Z0-9_]\+>"


### PR DESCRIPTION
- Apply `helpExample`.
- Remove `helpHeader` from URL, because `helpURL` takes priority.
- Fix indentation.
- Add `N` emphasis to `helpSpecial`.