### PR TITLE
runtime:comment: consider &tabstop in lines after whitespace indent

### DIFF
--- a/runtime/pack/dist/opt/comment/autoload/comment.vim
+++ b/runtime/pack/dist/opt/comment/autoload/comment.vim
@@ -58,9 +58,11 @@ export def Toggle(...args: list<string>): string
                 # handle % with substitute
                 line = printf(substitute(cms, '%s\@!', '%%', 'g'), getline(lnum))
             else
+                line = getline(lnum)
+                var indent_start_len = strlen(indent_start)
                 # handle % with substitute
                 line = printf(indent_start .. substitute(cms, '%s\@!', '%%', 'g'),
-                        strpart(getline(lnum), strlen(indent_start)))
+                    strpart(line, (line[0 : strlen(indent_start_len) - 1] =~ '\t' ? indent_start_len / &tabstop : indent_start_len)))
             endif
         else
             line = substitute(getline(lnum), $'^\s*\zs{cms_l[0]} \?\| \?{cms_l[1]}$', '', 'g')


### PR DESCRIPTION
The count `strlen()` in

```vim
line = printf(indent_start .. substitute(cms, '%s\@!', '%%', 'g'),
                       strpart(getline(lnum), strlen(indent_start)))
```

is too high here as for`2gcc` on line 2  we've `strlen(indent_start) = 4` for an initial indent of 4 spaces, but in the following line there is only a single tab character if they happen to be tabs with &tabstop = 8.

The check is still too simple because it assumes that as soon as there's a tab the whole indent is made of tabs; it's a start of entering the mixed tab and whitespace indent rabbit hole.

Addresses [0]

Links:

[0]: https://github.com/vim/vim/issues/15797