### PR TITLE
Problem:  :cd completion fails on Windows with backslash in path

### DIFF
--- a/src/fileio.c
+++ b/src/fileio.c
@@ -5570,6 +5570,8 @@ match_file_list(char_u *list, char_u *sfname, char_u *ffname)
  * allow_dirs, otherwise FALSE is put there -- webb.
  * Handle backslashes before special characters, like "\*" and "\ ".
  *
+ * no_bslash only makes a difference, when BACKSLASH_IN_FILENAME is defined
+ *
  * Returns NULL when out of memory.
  */
     char_u *

--- a/src/findfile.c
+++ b/src/findfile.c
@@ -2362,7 +2362,7 @@ uniquefy_paths(
     file_pattern[0] = '*';
     file_pattern[1] = NUL;
     STRCAT(file_pattern, pattern);
-    pat = file_pat_to_reg_pat(file_pattern, NULL, NULL, TRUE);
+    pat = file_pat_to_reg_pat(file_pattern, NULL, NULL, FALSE);
     vim_free(file_pattern);
     if (pat == NULL)
 	return;

--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -3920,4 +3920,15 @@ func Test_ex_command_completion()
   set cpo-=*
 endfunc
 
+func Test_cd_bslsh_completion_windows()
+  CheckMSWindows
+  let save_shellslash = &shellslash
+  set noshellslash
+  call system('mkdir XXXa\_b')
+  defer delete('XXXa', 'rf')
+  call feedkeys(":cd XXXa\\_b\<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"cd XXXa\_b\', @:)
+  let &shellslash = save_shellslash
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  :cd completion fails on Windows with backslash in path
Solution: switch no_bslash argument to FALSE in file_pat_to_reg_pat()

Note: only fixes the problem on Windows. For Unix, we still need to escape \ since those are taken as regex atoms.

fixes: #15643