### PR TITLE
No test for patches 6.2.418 and 7.3.489

### DIFF
--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -1,4 +1,4 @@
-*map.txt*       For Vim version 9.1.  Last change: 2024 Sep 26
+*map.txt*       For Vim version 9.1.  Last change: 2024 Oct 07
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -84,6 +84,8 @@ modes.
 			where the map command applies.  Disallow mapping of
 			{rhs}, to avoid nested and recursive mappings.  Often
 			used to redefine a command.
+			Note: Keys in {rhs} also won't trigger abbreviation,
+			with the exception of |i_CTRL-]| and |c_CTRL-]|.
 			Note: When <Plug> appears in the {rhs} this part is
 			always applied even if remapping is disallowed.
 

--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -3920,7 +3920,7 @@ func Test_ex_command_completion()
   set cpo-=*
 endfunc
 
-func Test_cd_bslsh_completion_windows()
+func Test_cd_bslash_completion_windows()
   CheckMSWindows
   let save_shellslash = &shellslash
   set noshellslash

--- a/src/testdir/test_mapping.vim
+++ b/src/testdir/test_mapping.vim
@@ -7,40 +7,62 @@ source term_util.vim
 import './vim9.vim' as v9
 
 func Test_abbreviation()
+  new
   " abbreviation with 0x80 should work
   inoreab чкпр   vim
   call feedkeys("Goчкпр \<Esc>", "xt")
   call assert_equal('vim ', getline('$'))
   iunab чкпр
-  set nomodified
+  bwipe!
+endfunc
+
+func Test_abbreviation_with_noremap()
+  nnoremap <F2> :echo "cheese"
+  cabbr cheese xxx
+  call feedkeys(":echo \"cheese\"\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"echo "xxx"', @:)
+  call feedkeys("\<F2>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"echo "cheese"', @:)
+  nnoremap <F2> :echo "cheese<C-]>"
+  call feedkeys("\<F2>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"echo "xxx"', @:)
+  nunmap <F2>
+  cunabbr cheese
+
+  new
+  inoremap <buffer> ( <C-]>()
+  iabbr <buffer> fnu fun
+  call feedkeys("ifnu(", 'tx')
+  call assert_equal('fun()', getline(1))
+  bwipe!
 endfunc
 
 func Test_abclear()
-   abbrev foo foobar
-   iabbrev fooi foobari
-   cabbrev fooc foobarc
-   call assert_equal("\n\n"
-         \        .. "c  fooc          foobarc\n"
-         \        .. "i  fooi          foobari\n"
-         \        .. "!  foo           foobar", execute('abbrev'))
+  abbrev foo foobar
+  iabbrev fooi foobari
+  cabbrev fooc foobarc
+  call assert_equal("\n\n"
+        \        .. "c  fooc          foobarc\n"
+        \        .. "i  fooi          foobari\n"
+        \        .. "!  foo           foobar", execute('abbrev'))
 
-   iabclear
-   call assert_equal("\n\n"
-         \        .. "c  fooc          foobarc\n"
-         \        .. "c  foo           foobar", execute('abbrev'))
-   abbrev foo foobar
-   iabbrev fooi foobari
+  iabclear
+  call assert_equal("\n\n"
+        \        .. "c  fooc          foobarc\n"
+        \        .. "c  foo           foobar", execute('abbrev'))
+  abbrev foo foobar
+  iabbrev fooi foobari
 
-   cabclear
-   call assert_equal("\n\n"
-         \        .. "i  fooi          foobari\n"
-         \        .. "i  foo           foobar", execute('abbrev'))
-   abbrev foo foobar
-   cabbrev fooc foobarc
+  cabclear
+  call assert_equal("\n\n"
+        \        .. "i  fooi          foobari\n"
+        \        .. "i  foo           foobar", execute('abbrev'))
+  abbrev foo foobar
+  cabbrev fooc foobarc
 
-   abclear
-   call assert_equal("\n\nNo abbreviation found", execute('abbrev'))
-   call assert_fails('%abclear', 'E481:')
+  abclear
+  call assert_equal("\n\nNo abbreviation found", execute('abbrev'))
+  call assert_fails('%abclear', 'E481:')
 endfunc
 
 func Test_abclear_buffer()
@@ -161,7 +183,7 @@ func Test_map_langmap()
   imap a c
   call feedkeys("Go\<C-R>a\<Esc>", "xt")
   call assert_equal('bbbb', getline('$'))
- 
+
   " langmap should not apply in Command-line mode
   set langmap=+{ nolangremap
   call feedkeys(":call append(line('$'), '+')\<CR>", "xt")

--- a/src/testdir/test_quickfix.vim
+++ b/src/testdir/test_quickfix.vim
@@ -6581,8 +6581,8 @@ func Test_cbuffer_range()
   call XbufferTests_range('l')
 endfunc
 
-" Test for displaying fname pass from setqflist when the name
-" are hard links to prevent seemly duplicate entries.
+" Test for displaying fname passed from setqflist() when the names include
+" hard links to prevent seemingly duplicate entries.
 func Xtest_hardlink_fname(cchar)
   call s:setup_commands(a:cchar)
   %bwipe


### PR DESCRIPTION
Problem:  No test for patches 6.2.418 and 7.3.489.
Solution: Add a test.  Fix some whitespace problems in test_mapping.vim.
          Document the behavior.
