### PR TITLE
Issue 15775 - Fix incorrect cursor position when restoring main scree…

### DIFF
--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -3556,13 +3556,15 @@ mch_init_c(void)
     static void
 mch_exit_c(int r)
 {
+    int fTermcapMode = g_fTermcapMode;  // Copy flag since stoptermcap() will clear the flag.
+
     exiting = TRUE;
 
     vtp_exit();
 
     stoptermcap();
-    // Switch back to main screen buffer.
-    if (use_alternate_screen_buffer)
+    // Switch back to main screen buffer if TermcapMode was not active.
+    if (!fTermcapMode &&  use_alternate_screen_buffer)
 	vtp_printf("\033[?1049l");
 
     if (g_fWindInitCalled)
@@ -6337,6 +6339,10 @@ termcap_mode_end(void)
 # endif
     RestoreConsoleBuffer(cb, p_rs);
     restore_console_color_rgb();
+
+    // Switch back to main screen buffer.
+    if (exiting && use_alternate_screen_buffer)
+        vtp_printf("\033[?1049l");
 
     if (!USE_WT && (p_rs || exiting))
     {


### PR DESCRIPTION
Issue #15775 - Fix incorrect cursor position when restoring main screen buffer.

Patch 9.1.0664 moved the VTP command for switching back to the main screen buffer from termcap_mode_end() to mch_exit_c().  However, the saved cursor position from the main screen continued to be restored in termcap_mode_end().  This failed if the cursor position was beyond the console window height, since the alternate screen buffer is always the same size as the console window.

This patch restores the VTP command for switching back to the main screen buffer to termcap_mode_end().  In order to preserve the effect of patch 9.1.0664, the VTP command for switching back to the main screen buffer in mch_exit_c() is issued only if termcap mode was not active while exiting Vim.

See issue 15775 for a fuller description, with screen shots of the problem.