### PR TITLE
"shellcmdline" doesn't work with getcompletion()

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -1,4 +1,4 @@
-*builtin.txt*	For Vim version 9.1.  Last change: 2024 Oct 08
+*builtin.txt*	For Vim version 9.1.  Last change: 2024 Oct 09
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -4091,7 +4091,7 @@ getcompletion({pat}, {type} [, {filtered}])		*getcompletion()*
 		cscope		|:cscope| suboptions
 		custom,{func}	custom completion, defined via {func}
 		customlist,{func} custom completion, defined via {func}
-		diff_buffer     |:diffget| and |:diffput| completion
+		diff_buffer	|:diffget| and |:diffput| completion
 		dir		directory names
 		dir_in_path	directory names in |'cdpath'|
 		environment	environment variable names
@@ -4115,6 +4115,7 @@ getcompletion({pat}, {type} [, {filtered}])		*getcompletion()*
 		runtime		|:runtime| completion
 		scriptnames	sourced script names |:scriptnames|
 		shellcmd	Shell command
+		shellcmdline	Shell command line with filename arguments
 		sign		|:sign| suboptions
 		syntax		syntax file names |'syntax'|
 		syntime		|:syntime| suboptions

--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -1084,6 +1084,8 @@ func Test_cmdline_complete_shellcmdline()
 
   call feedkeys(":MyCmd whoam\<C-A>\<C-B>\"\<CR>", 'tx')
   call assert_match('^".*\<whoami\>', @:)
+  let l = getcompletion('whoam', 'shellcmdline')
+  call assert_match('\<whoami\>', join(l, ' '))
 
   delcommand MyCmd
 endfunc
@@ -3649,9 +3651,13 @@ func Test_cmdline_complete_shellcmdline_argument()
 
   call feedkeys(":MyCmd vim test_cmdline.\<Tab>\<C-B>\"\<CR>", 'xt')
   call assert_equal('"MyCmd vim test_cmdline.vim', @:)
+  call assert_equal(['test_cmdline.vim'],
+        \ getcompletion('vim test_cmdline.', 'shellcmdline'))
 
   call feedkeys(":MyCmd vim nonexistentfile\<Tab>\<C-B>\"\<CR>", 'xt')
   call assert_equal('"MyCmd vim nonexistentfile', @:)
+  call assert_equal([],
+        \ getcompletion('vim nonexistentfile', 'shellcmdline'))
 
   let compl1 = getcompletion('', 'file')[0]
   let compl2 = getcompletion('', 'file')[1]
@@ -3668,9 +3674,13 @@ func Test_cmdline_complete_shellcmdline_argument()
   set wildoptions&
   call feedkeys(":MyCmd vim test_cmdline.\<Tab>\<C-B>\"\<CR>", 'xt')
   call assert_equal('"MyCmd vim test_cmdline.vim', @:)
+  call assert_equal(['test_cmdline.vim'],
+        \ getcompletion('vim test_cmdline.', 'shellcmdline'))
 
   call feedkeys(":MyCmd vim nonexistentfile\<Tab>\<C-B>\"\<CR>", 'xt')
   call assert_equal('"MyCmd vim nonexistentfile', @:)
+  call assert_equal([],
+        \ getcompletion('vim nonexistentfile', 'shellcmdline'))
 
   let compl1 = getcompletion('', 'file')[0]
   let compl2 = getcompletion('', 'file')[1]


### PR DESCRIPTION
Problem:  "shellcmdline" doesn't work with getcompletion().
Solution: Use set_context_for_wildcard_arg().
