### PR TITLE
Tests for set and option are not comprehensive

### DIFF
--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -4,7 +4,1101 @@ source shared.vim
 source check.vim
 source view_util.vim
 
-func Test_whichwrap()
+func CheckWasSet(name)
+  let verb_cm = execute('verbose set ' .. a:name .. '?')
+  call assert_match('Last set from.*test_options.vim', verb_cm)
+endfunc
+func CheckWasNotSet(name)
+  let verb_cm = execute('verbose set ' .. a:name .. '?')
+  call assert_notmatch('Last set from', verb_cm)
+endfunc
+
+" Test each options
+
+func Test_opt_ambiwidth()
+  " Conflict with value of 'listchars'
+  setlocal listchars=trail:·
+  call assert_fails('set ambiwidth=double', 'E834:')
+  setlocal listchars=trail:-
+  setglobal listchars=trail:·
+  call assert_fails('set ambiwidth=double', 'E834:')
+  set listchars&
+
+  " Conflict with value of 'fillchars'
+  setlocal fillchars=stl:·
+  call assert_fails('set ambiwidth=double', 'E835:')
+  setlocal fillchars=stl:-
+  setglobal fillchars=stl:·
+  call assert_fails('set ambiwidth=double', 'E835:')
+  set fillchars&
+endfunc
+
+func Test_opt_backupcopy()
+  call assert_fails('set backupcopy=', 'E474:')
+endfunc
+
+func Test_opt_backupdir()
+  call assert_fails('sandbox set backupdir?', 'E48:')
+  call assert_fails('sandbox set backupdir&', 'E48:')
+  call assert_fails('sandbox set backupdir<', 'E48:')
+  call assert_fails('sandbox set backupdir=', 'E48:')
+  call assert_fails('sandbox set backupdir=.', 'E48:')
+  call assert_fails('sandbox let &backupdir = "."', 'E48:')
+endfunc
+
+func Test_opt_backupext_and_patchmode_are_equal_error()
+  " Test for 'backupext' and 'patchmode' set to the same value
+  set backupext=.bak
+  set patchmode=.patch
+  call assert_fails('set patchmode=.bak', 'E589:')
+  call assert_equal('.patch', &patchmode)
+  call assert_fails('set backupext=.patch', 'E589:')
+  call assert_equal('.bak', &backupext)
+  set backupext& patchmode&
+endfunc
+
+func Test_opt_backupskip()
+  " Option 'backupskip' may contain several comma-separated path
+  " specifications if one or more of the environment variables TMPDIR, TMP,
+  " or TEMP is defined.  To simplify testing, convert the string value into a
+  " list.
+  let bsklist = split(&bsk, ',')
+
+  if has("mac")
+    let found = (index(bsklist, '/private/tmp/*') >= 0)
+    call assert_true(found, '/private/tmp not in option bsk: ' . &bsk)
+  elseif has("unix")
+    let found = (index(bsklist, '/tmp/*') >= 0)
+    call assert_true(found, '/tmp not in option bsk: ' . &bsk)
+  endif
+
+  " If our test platform is Windows, the path(s) in option bsk will use
+  " backslash for the path separator and the components could be in short
+  " (8.3) format.  As such, we need to replace the backslashes with forward
+  " slashes and convert the path components to long format.  The expand()
+  " function will do this but it cannot handle comma-separated paths.  This is
+  " why bsk was converted from a string into a list of strings above.
+  "
+  " One final complication is that the wildcard "/*" is at the end of each
+  " path and so expand() might return a list of matching files.  To prevent
+  " this, we need to remove the wildcard before calling expand() and then
+  " append it afterwards.
+  if has('win32')
+    let item_nbr = 0
+    while item_nbr < len(bsklist)
+      let path_spec = bsklist[item_nbr]
+      let path_spec = strcharpart(path_spec, 0, strlen(path_spec)-2)
+      let path_spec = substitute(expand(path_spec), '\\', '/', 'g')
+      let bsklist[item_nbr] = path_spec . '/*'
+      let item_nbr += 1
+    endwhile
+  endif
+
+  " Option bsk will also include these environment variables if defined.
+  " If they're defined, verify they appear in the option value.
+  for var in  ['$TMPDIR', '$TMP', '$TEMP']
+    if exists(var)
+      let varvalue = substitute(expand(var), '\\', '/', 'g')
+      let varvalue = substitute(varvalue, '/$', '', '')
+      let varvalue .= '/*'
+      let found = (index(bsklist, varvalue) >= 0)
+      call assert_true(found, var . ' (' . varvalue . ') not in option bsk: ' . &bsk)
+    endif
+  endfor
+
+  " Duplicates from environment variables should be filtered out (option has
+  " P_NODUP).  Run this in a separate instance and write v:errors in a file,
+  " so that we see what happens on startup.
+  let after =<< trim [CODE]
+      let bsklist = split(&backupskip, ',')
+      call assert_equal(uniq(copy(bsklist)), bsklist)
+      call writefile(['errors:'] + v:errors, 'Xtestout')
+      qall
+  [CODE]
+  call writefile(after, 'Xafter', 'D')
+  let cmd = GetVimProg() . ' --not-a-term -S Xafter --cmd "set enc=utf8"'
+
+  let saveenv = {}
+  for var in ['TMPDIR', 'TMP', 'TEMP']
+    let saveenv[var] = getenv(var)
+    call setenv(var, '/duplicate/path')
+  endfor
+
+  exe 'silent !' . cmd
+  call assert_equal(['errors:'], readfile('Xtestout'))
+
+  " restore environment variables
+  for var in ['TMPDIR', 'TMP', 'TEMP']
+    call setenv(var, saveenv[var])
+  endfor
+
+  call delete('Xtestout')
+
+  " Duplicates should be filtered out (option has P_NODUP)
+  let backupskip = &backupskip
+  set backupskip=
+  set backupskip+=/test/dir
+  set backupskip+=/other/dir
+  set backupskip+=/test/dir
+  call assert_equal('/test/dir,/other/dir', &backupskip)
+  let &backupskip = backupskip
+endfunc
+
+func Test_opt_binary_resets_depending_options()
+  " setting the binary option, resets all dependent options
+  " and will be reported correctly using :verbose set <option>?
+  let lines =<< trim [CODE]
+    " set binary test
+    set expandtab
+
+    source Xvimrc_bin2
+
+    redir > Xoutput_bin
+    verbose set expandtab?
+    verbose setg expandtab?
+    verbose setl expandtab?
+    redir END
+
+    qall!
+  [CODE]
+
+  call writefile(lines, 'Xvimrc_bin', 'D')
+  call writefile(['set binary'], 'Xvimrc_bin2', 'D')
+  if !RunVim([], lines, '--clean')
+    return
+  endif
+
+  let result = readfile('Xoutput_bin')->filter('!empty(v:val)')
+  call assert_equal('noexpandtab', result[0])
+  call assert_match("^\tLast set from .*Xvimrc_bin2 line 1$", result[1])
+  call assert_equal('noexpandtab', result[2])
+  call assert_match("^\tLast set from .*Xvimrc_bin2 line 1$", result[3])
+  call assert_equal('noexpandtab', result[4])
+  call assert_match("^\tLast set from .*Xvimrc_bin2 line 1$", result[5])
+
+  call delete('Xoutput_bin')
+endfunc
+
+func Test_opt_buftype()
+  new
+  call setline(1, ['L1'])
+  set buftype=nowrite
+  call assert_fails('write', 'E382:')
+
+  for val in ['', 'nofile', 'nowrite', 'acwrite', 'quickfix', 'help', 'terminal', 'prompt', 'popup']
+    exe 'set buftype=' .. val
+    call writefile(['something'], 'XBuftype', 'D')
+    call assert_fails('write XBuftype', 'E13:', 'with buftype=' .. val)
+  endfor
+
+  bwipe!
+endfunc
+
+func Test_opt_cdhome()
+  if has('unix') || has('vms')
+    throw 'Skipped: only works on non-Unix'
+  endif
+
+  set cdhome&
+  call assert_equal(0, &cdhome)
+  set cdhome
+
+  " This paragraph is copied from Test_cd_no_arg().
+  let path = getcwd()
+  cd
+  call assert_equal($HOME, getcwd())
+  call assert_notequal(path, getcwd())
+  exe 'cd ' .. fnameescape(path)
+  call assert_equal(path, getcwd())
+
+  set cdhome&
+endfunc
+
+func Test_opt_cdpath()
+  call assert_fails('sandbox set cdpath?', 'E48:')
+  call assert_fails('sandbox set cdpath&', 'E48:')
+  call assert_fails('sandbox set cdpath<', 'E48:')
+  call assert_fails('sandbox set cdpath=', 'E48:')
+  call assert_fails('sandbox set cdpath=.', 'E48:')
+  call assert_fails('sandbox let &cdpath = "."', 'E48:')
+endfunc
+
+func Test_opt_cdpath_default()
+  let after =<< trim [CODE]
+    call assert_equal(',/path/to/dir1,/path/to/dir2', &cdpath)
+    call writefile(v:errors, 'Xtestout')
+    qall
+  [CODE]
+  if has('unix')
+    let $CDPATH='/path/to/dir1:/path/to/dir2'
+  else
+    let $CDPATH='/path/to/dir1;/path/to/dir2'
+  endif
+  if RunVim([], after, '')
+    call assert_equal([], readfile('Xtestout'))
+    call delete('Xtestout')
+  endif
+endfunc
+
+func Test_opt_cinkeys()
+  " This used to cause invalid memory access
+  set cindent cinkeys=0
+  norm a
+  set cindent& cinkeys&
+endfunc
+
+func Test_opt_cmdheight()
+  %bw!
+  let ht = &lines
+  set cmdheight=9999
+  call assert_equal(1, winheight(0))
+  call assert_equal(ht - 1, &cmdheight)
+
+  call assert_fails('set cmdheight=-1', 'E487:')
+
+  set cmdheight&
+endfunc
+
+func Test_opt_cmdwinheight()
+  call assert_fails('set cmdwinheight=-1', 'E487:')
+endfunc
+
+func Test_opt_colorcolumn()
+  CheckFeature syntax
+  call assert_fails('set colorcolumn=-a', 'E474:')
+  call assert_fails('set colorcolumn=a', 'E474:')
+  call assert_fails('set colorcolumn=1,', 'E474:')
+  call assert_fails('set colorcolumn=1;', 'E474:')
+endfunc
+
+func Test_opt_columns_and_lines_set_to_minimum_value()
+  let after =<< trim END
+    set nomore
+    let msg = []
+    let v:errmsg = ''
+    silent! let &columns=0
+    call add(msg, v:errmsg)
+    silent! set columns=0
+    call add(msg, v:errmsg)
+    silent! call setbufvar('', '&columns', 0)
+    call add(msg, v:errmsg)
+    "call writefile(msg, 'XResultsetminlines')
+    silent! let &lines=0
+    call add(msg, v:errmsg)
+    silent! set lines=0
+    call add(msg, v:errmsg)
+    silent! call setbufvar('', '&lines', 0)
+    call add(msg, v:errmsg)
+    call writefile(msg, 'XResultsetminlines')
+    qall!
+  END
+  if RunVim([], after, '')
+    call assert_equal(['E594: Need at least 12 columns',
+          \ 'E594: Need at least 12 columns: columns=0',
+          \ 'E594: Need at least 12 columns',
+          \ 'E593: Need at least 2 lines',
+          \ 'E593: Need at least 2 lines: lines=0',
+          \ 'E593: Need at least 2 lines',], readfile('XResultsetminlines'))
+  endif
+
+  call delete('XResultsetminlines')
+endfunc
+
+func Test_opt_comments()
+  call assert_fails('set comments=-', 'E524:')
+  call assert_fails('set comments=a', 'E525:')
+endfunc
+
+func Test_opt_commentstring()
+  CheckFeature folding
+  call assert_fails('set commentstring=x', 'E537:')
+  call assert_fails('let &commentstring = "x"', 'E537:')
+  call assert_fails('let &g:commentstring = "x"', 'E537:')
+  call assert_fails('let &l:commentstring = "x"', 'E537:')
+endfunc
+
+func Test_opt_complete()
+  " Trailing single backslash used to cause invalid memory access.
+  set complete=s\
+  new
+  call feedkeys("i\<C-N>\<Esc>", 'xt')
+  bwipe!
+
+  " Illegal character after <i>
+  call assert_fails('set complete=ix', 'E535:')
+
+  " Illegal character after <x>
+  call assert_fails('set complete=x', 'E539:')
+
+  set complete&
+endfunc
+
+func Test_opt_conceallevel()
+  CheckFeature conceal
+  call assert_fails('set conceallevel=-1', 'E487:')
+  call assert_fails('set conceallevel=4', 'E474:')
+endfunc
+
+func Test_opt_debug()
+  " redraw to avoid matching previous messages
+  redraw
+  set debug=beep
+  exe "normal \<C-c>"
+  call assert_equal('Beep!', Screenline(&lines))
+  call assert_equal('line    4:', Screenline(&lines - 1))
+  " also check a line above, with a certain window width the colon is there
+  call assert_match('Test_opt_debug:$',
+        \ Screenline(&lines - 3) .. Screenline(&lines - 2))
+  set debug&
+endfunc
+
+func Test_opt_delcombine()
+  new
+  set backspace=indent,eol,start
+
+  set delcombine
+  call setline(1, 'β̳̈:β̳̈')
+  normal! 0x
+  call assert_equal('β̈:β̳̈', getline(1))
+  exe "normal! A\<BS>"
+  call assert_equal('β̈:β̈', getline(1))
+  normal! 0x
+  call assert_equal('β:β̈', getline(1))
+  exe "normal! A\<BS>"
+  call assert_equal('β:β', getline(1))
+  normal! 0x
+  call assert_equal(':β', getline(1))
+  exe "normal! A\<BS>"
+  call assert_equal(':', getline(1))
+
+  set nodelcombine
+  call setline(1, 'β̳̈:β̳̈')
+  normal! 0x
+  call assert_equal(':β̳̈', getline(1))
+  exe "normal! A\<BS>"
+  call assert_equal(':', getline(1))
+
+  set backspace& delcombine&
+  bwipe!
+endfunc
+
+func Test_opt_dictionary()
+  " Check that it's possible to set the option.
+  set dictionary=/usr/share/dict/words
+  call assert_equal('/usr/share/dict/words', &dictionary)
+  set dictionary=/usr/share/dict/words,/and/there
+  call assert_equal('/usr/share/dict/words,/and/there', &dictionary)
+  set dictionary=/usr/share/dict\ words
+  call assert_equal('/usr/share/dict words', &dictionary)
+
+  " Check rejecting weird characters.
+  call assert_fails('set dictionary=/not&there', 'E474:')
+  call assert_fails('set dictionary=/not>there', 'E474:')
+  call assert_fails('set dictionary=/not.*there', 'E474:')
+endfunc
+
+func Test_opt_encoding()
+  let save_encoding = &encoding
+
+  set enc=iso8859-1
+  call assert_equal('latin1', &enc)
+  set enc=iso8859_1
+  call assert_equal('latin1', &enc)
+  set enc=iso-8859-1
+  call assert_equal('latin1', &enc)
+  set enc=iso_8859_1
+  call assert_equal('latin1', &enc)
+  set enc=iso88591
+  call assert_equal('latin1', &enc)
+  set enc=iso8859
+  call assert_equal('latin1', &enc)
+  set enc=iso-8859
+  call assert_equal('latin1', &enc)
+  set enc=iso_8859
+  call assert_equal('latin1', &enc)
+  call assert_fails('set enc=iso8858', 'E474:')
+  call assert_equal('latin1', &enc)
+
+  let &encoding = save_encoding
+endfunc
+
+" check that the very first buffer created does not have 'endoffile' set
+func Test_opt_endoffile_default()
+  let after =<< trim [CODE]
+    call writefile([execute('set eof?')], 'Xtestout')
+    qall!
+  [CODE]
+  if RunVim([], after, '')
+    call assert_equal(["\nnoendoffile"], readfile('Xtestout'))
+  endif
+  call delete('Xtestout')
+endfunc
+
+func Test_opt_errorbells()
+  set errorbells
+  call assert_beeps('s/a1b2/x1y2/')
+  set noerrorbells
+endfunc
+
+func Test_opt_exrc()
+  call assert_fails('sandbox set exrc?', 'E48:')
+  call assert_fails('sandbox set exrc&', 'E48:')
+  call assert_fails('sandbox set exrc<', 'E48:')
+  call assert_fails('sandbox set exrc', 'E48:')
+  call assert_fails('sandbox set noexrc', 'E48:')
+  call assert_fails('sandbox set invexrc', 'E48:')
+  call assert_fails('sandbox let &exrc = 1', 'E48:')
+endfunc
+
+func Test_opt_fileencoding()
+  call assert_fails('set fileencoding=latin1,utf-8', 'E474:')
+  set nomodifiable
+  call assert_fails('set fileencoding=latin1', 'E21:')
+  set modifiable&
+endfunc
+
+func Test_opt_filetype()
+  set ft=valid_name
+  call assert_equal("valid_name", &filetype)
+  set ft=valid-name
+  call assert_equal("valid-name", &filetype)
+
+  call assert_fails(":set ft=wrong;name", "E474:")
+  call assert_fails(":set ft=wrong\\\\name", "E474:")
+  call assert_fails(":set ft=wrong\\|name", "E474:")
+  call assert_fails(":set ft=wrong/name", "E474:")
+  call assert_fails(":set ft=wrong\\\nname", "E474:")
+  call assert_equal("valid-name", &filetype)
+
+  exe "set ft=trunc\x00name"
+  call assert_equal("trunc", &filetype)
+endfunc
+
+func Test_opt_foldmarker()
+  call assert_fails('set foldmarker=', 'E536:')
+  call assert_fails('set foldmarker=x', 'E536:')
+endfunc
+
+func Test_opt_formatoptions()
+  " Setting 'formatoptions' with :let should check errors.
+  call assert_fails('let &formatoptions = "?"', 'E539:')
+  call assert_fails('call setbufvar("", "&formatoptions", "?")', 'E539:')
+endfunc
+
+func Test_opt_guicursor()
+  CheckFeature cursorshape
+  " This invalid value for 'guicursor' used to cause Vim to crash.
+  call assert_fails('set guicursor=i-ci,r-cr:h', 'E545:')
+  call assert_fails('set guicursor=i-ci', 'E545:')
+  call assert_fails('set guicursor=x', 'E545:')
+  call assert_fails('set guicursor=x:', 'E546:')
+  call assert_fails('set guicursor=r-cr:horx', 'E548:')
+  call assert_fails('set guicursor=r-cr:hor0', 'E549:')
+endfunc
+
+func Test_opt_helpheight()
+  call assert_fails('set helpheight=-1', 'E487:')
+endfunc
+
+func Test_opt_history()
+  call assert_fails('set history=-1', 'E487:')
+  call assert_fails('set history=10001', 'E474:')
+endfunc
+
+func Test_opt_indentexpr()
+  " this was causing usage of freed memory
+  func ResetIndentexpr()
+    set indentexpr=
+  endfunc
+  set indentexpr=ResetIndentexpr()
+  new
+  call feedkeys("i\<c-f>", 'x')
+  call assert_equal('', &indentexpr)
+  bwipe!
+endfunc
+
+func Test_opt_isfname()
+  " This used to cause Vim to access uninitialized memory.
+  set isfname=
+  call assert_equal("~X", expand("~X"))
+  set isfname&
+  " Test for setting 'isfname' to an unsupported character
+  let save_isfname = &isfname
+  call assert_fails('exe $"set isfname+={"\u1234"}"', 'E474:')
+  call assert_equal(save_isfname, &isfname)
+endfunc
+
+" Test for setting option value containing spaces with isfname+=32 (8.2.1386)
+func Test_opt_isfname_contain_space()
+  set isfname+=32
+  setlocal keywordprg=:term\ help.exe
+  call assert_equal(':term help.exe', &keywordprg)
+  set isfname&
+  setlocal keywordprg&
+endfunc
+
+func Test_opt_keymap()
+  CheckFeature keymap
+  call assert_fails(":set kmp=valid_name", "E544:")
+  call assert_fails(":set kmp=valid_name", "valid_name")
+  call assert_fails(":set kmp=valid-name", "E544:")
+  call assert_fails(":set kmp=valid-name", "valid-name")
+
+  call assert_fails(":set kmp=wrong;name", "E474:")
+  call assert_fails(":set kmp=wrong\\\\name", "E474:")
+  call assert_fails(":set kmp=wrong\\|name", "E474:")
+  call assert_fails(":set kmp=wrong/name", "E474:")
+  call assert_fails(":set kmp=wrong\\\nname", "E474:")
+
+  call assert_fails(":set kmp=trunc\x00name", "E544:")
+  call assert_fails(":set kmp=trunc\x00name", "trunc")
+endfunc
+
+func Test_opt_keyprotocol()
+  CheckNotGui
+
+  let term = &term
+  set term=ansi
+  call assert_equal('', &t_TI)
+
+  " Setting 'keyprotocol' should affect terminal codes without needing to
+  " reset 'term'
+  set keyprotocol+=ansi:kitty
+  call assert_equal("\<Esc>[=1;1u", &t_TI)
+  let &term = term
+endfunc
+
+func Test_opt_keywordprg()
+  " :set empty string for global 'keywordprg' falls back to ":help"
+  let k = &keywordprg
+  set keywordprg=man
+  call assert_equal('man', &keywordprg)
+  set keywordprg=
+  call assert_equal(':help', &keywordprg)
+  set keywordprg=man
+  call assert_equal('man', &keywordprg)
+  call assert_equal("\n  keywordprg=:help", execute('set kp= kp?'))
+  let &keywordprg = k
+endfunc
+
+" Test that resetting laststatus does change scroll option
+func Test_opt_laststatus_changes_scroll()
+  CheckRunVimInTerminal
+  let vimrc =<< trim [CODE]
+    set scroll=2
+    set laststatus=2
+  [CODE]
+  call writefile(vimrc, 'Xscroll', 'D')
+  let buf = RunVimInTerminal('-S Xscroll', {'rows': 16, 'cols': 45})
+  call term_sendkeys(buf, ":verbose set scroll?\n")
+  call WaitForAssert({-> assert_match('Last set.*window size', term_getline(buf, 15))})
+  call assert_match('^\s*scroll=7$', term_getline(buf, 14))
+
+  " clean up
+  call StopVimInTerminal(buf)
+endfunc
+
+func Test_opt_modelineexpr()
+  call assert_fails('sandbox set modelineexpr?', 'E48:')
+  call assert_fails('sandbox set modelineexpr&', 'E48:')
+  call assert_fails('sandbox set modelineexpr<', 'E48:')
+  call assert_fails('sandbox set modelineexpr', 'E48:')
+  call assert_fails('sandbox set nomodelineexpr', 'E48:')
+  call assert_fails('sandbox set invmodelineexpr', 'E48:')
+  call assert_fails('sandbox let &modelineexpr = 1', 'E48:')
+endfunc
+
+func Test_opt_mouseshape()
+  CheckFeature mouseshape
+  call assert_fails('set mouseshape=i-r:x', 'E547:')
+endfunc
+
+func Test_opt_numberwidth()
+  CheckFeature linebreak
+  call assert_fails('set numberwidth=0', 'E487:')
+  call assert_fails('set numberwidth=21', 'E474:')
+endfunc
+
+func Test_opt_paste_resets_depending_options()
+  " setting the paste option, resets all dependent options
+  " and will be reported correctly using :verbose set <option>?
+  let lines =<< trim [CODE]
+    " set paste test
+    set autoindent
+    set expandtab
+    " disabled, because depends on compiled feature set
+    " set hkmap
+    " set revins
+    " set varsofttabstop=8,32,8
+    set ruler
+    set showmatch
+    set smarttab
+    set softtabstop=4
+    set textwidth=80
+    set wrapmargin=10
+
+    source Xvimrc_paste2
+
+    redir > Xoutput_paste
+    verbose set expandtab?
+    verbose setg expandtab?
+    verbose setl expandtab?
+    redir END
+
+    qall!
+  [CODE]
+
+  call writefile(lines, 'Xvimrc_paste', 'D')
+  call writefile(['set paste'], 'Xvimrc_paste2', 'D')
+  if !RunVim([], lines, '--clean')
+    return
+  endif
+
+  let result = readfile('Xoutput_paste')->filter('!empty(v:val)')
+  call assert_equal('noexpandtab', result[0])
+  call assert_match("^\tLast set from .*Xvimrc_paste2 line 1$", result[1])
+  call assert_equal('noexpandtab', result[2])
+  call assert_match("^\tLast set from .*Xvimrc_paste2 line 1$", result[3])
+  call assert_equal('noexpandtab', result[4])
+  call assert_match("^\tLast set from .*Xvimrc_paste2 line 1$", result[5])
+
+  call delete('Xoutput_paste')
+endfunc
+
+func Test_opt_pastetoggle()
+  " character with K_SPECIAL byte
+  let &pastetoggle = '…'
+  call assert_equal('…', &pastetoggle)
+  call assert_equal("\n  pastetoggle=…", execute('set pastetoggle?'))
+
+  " modified character with K_SPECIAL byte
+  let &pastetoggle = '<M-…>'
+  call assert_equal('<M-…>', &pastetoggle)
+  call assert_equal("\n  pastetoggle=<M-…>", execute('set pastetoggle?'))
+
+  " illegal bytes
+  let str = ":\x7f:\x80:\x90:\xd0:"
+  let &pastetoggle = str
+  call assert_equal(str, &pastetoggle)
+  call assert_equal("\n  pastetoggle=" .. strtrans(str), execute('set pastetoggle?'))
+
+  unlet str
+  set pastetoggle&
+endfunc
+
+func Test_opt_path()
+  " Test that changing 'path' keeps two commas.
+  set path=foo,,bar
+  set path-=bar
+  set path+=bar
+  call assert_equal('foo,,bar', &path)
+
+  " Test path too long.
+  exe 'set path=' .. repeat('x', 10000)
+  call assert_fails('find x', 'E854:')
+
+  set path&
+endfunc
+
+func Test_opt_pyxversion()
+  if !(has('python') || has('python3'))
+    MissingFeature 'python or python3'
+  endif
+
+  set pyxversion=0
+  set pyxversion=2
+  set pyxversion=3
+
+  call assert_fails('set pyxversion=-1', 'E474:')
+  call assert_fails('set pyxversion=1', 'E474:')
+  call assert_fails('set pyxversion=4', 'E474:')
+  call assert_fails('set pyxversion=999', 'E474:')
+endfunc
+
+func Test_opt_regexpengine()
+  call assert_fails('set regexpengine=-1', 'E474:')
+  call assert_fails('set regexpengine=3', 'E474:')
+endfunc
+
+func Test_opt_renderoptions()
+  " Only do this for Windows Vista and later, fails on Windows XP and earlier.
+  " Doesn't hurt to do this on a non-Windows system.
+  if windowsversion() !~ '^[345]\.'
+    throw 'Skipped: fails on Windows XP and earlier'
+  endif
+
+  set renderoptions=type:directx
+  set rop=type:directx
+endfunc
+
+func Test_opt_report()
+  call assert_fails('set report=-1', 'E487:')
+endfunc
+
+func Test_opt_rightleftcmd()
+  CheckFeature rightleft
+  set rightleft
+
+  let g:l = []
+  func AddPos()
+    call add(g:l, screencol())
+    return ''
+  endfunc
+  cmap <expr> <F2> AddPos()
+
+  set rightleftcmd=
+  call feedkeys("/\<F2>abc\<Right>\<F2>\<Left>\<Left>\<F2>" ..
+        \ "\<Right>\<F2>\<Esc>", 'xt')
+  call assert_equal([2, 5, 3, 4], g:l)
+
+  let g:l = []
+  set rightleftcmd=search
+  call feedkeys("/\<F2>abc\<Left>\<F2>\<Right>\<Right>\<F2>" ..
+        \ "\<Left>\<F2>\<Esc>", 'xt')
+  call assert_equal([&co - 1, &co - 4, &co - 2, &co - 3], g:l)
+
+  cunmap <F2>
+  unlet g:l
+  set rightleftcmd&
+  set rightleft&
+endfunc
+
+func Test_opt_rulerformat()
+  call assert_fails('set rulerformat=%-', 'E539:')
+  call assert_fails('set rulerformat=%(', 'E542:')
+  call assert_fails('set rulerformat=%15(%%', 'E542:')
+endfunc
+
+func Test_opt_scroll()
+  call assert_fails('set scroll=-1', 'E49:')
+endfunc
+
+func Test_opt_scrolljump()
+  help
+  resize 10
+
+  " Test with positive 'scrolljump'.
+  set scrolljump=2
+  norm! Lj
+  call assert_equal({'lnum':11, 'leftcol':0, 'col':0, 'topfill':0,
+        \            'topline':3, 'coladd':0, 'skipcol':0, 'curswant':0},
+        \           winsaveview())
+
+  " Test with negative 'scrolljump' (percentage of window height).
+  set scrolljump=-40
+  norm! ggLj
+  call assert_equal({'lnum':11, 'leftcol':0, 'col':0, 'topfill':0,
+         \            'topline':5, 'coladd':0, 'skipcol':0, 'curswant':0},
+         \           winsaveview())
+
+  set scrolljump&
+  bw
+endfunc
+
+func Test_opt_scrolloff()
+  set scrolloff=5
+  split
+  call assert_equal(5, &so)
+  setlocal scrolloff=3
+  call assert_equal(3, &so)
+  wincmd w
+  call assert_equal(5, &so)
+  wincmd w
+  call assert_equal(3, &so)
+  setlocal scrolloff<
+  call assert_equal(5, &so)
+  setglobal scrolloff=8
+  call assert_equal(8, &so)
+  call assert_equal(-1, &l:so)
+  setlocal scrolloff=0
+  call assert_equal(0, &so)
+  setlocal scrolloff=-1
+  call assert_equal(8, &so)
+"  setglobal scrolloff=3
+"  setlocal scrolloff=5
+  close
+  set scrolloff&
+endfunc
+
+func Test_opt_shiftwidth()
+  call assert_fails('set shiftwidth=-1', 'E487:')
+endfunc
+
+func Test_opt_shortmess_F()
+  new
+  call assert_match('\[No Name\]', execute('file'))
+  set shortmess+=F
+  call assert_match('\[No Name\]', execute('file'))
+  call assert_match('^\s*$', execute('file foo'))
+  call assert_match('foo', execute('file'))
+  set shortmess-=F
+  call assert_match('bar', execute('file bar'))
+  call assert_match('bar', execute('file'))
+  set shortmess&
+  bwipe
+endfunc
+
+func Test_opt_shortmess_F2()
+  e file1
+  e file2
+  call assert_match('file1', execute('bn', ''))
+  call assert_match('file2', execute('bn', ''))
+  set shortmess+=F
+  call assert_true(empty(execute('bn', '')))
+  call assert_false(test_getvalue('need_fileinfo'))
+  call assert_true(empty(execute('bn', '')))
+  call assert_false('need_fileinfo'->test_getvalue())
+  set hidden
+  call assert_true(empty(execute('bn', '')))
+  call assert_false(test_getvalue('need_fileinfo'))
+  call assert_true(empty(execute('bn', '')))
+  call assert_false(test_getvalue('need_fileinfo'))
+  set nohidden
+  call assert_true(empty(execute('bn', '')))
+  call assert_false(test_getvalue('need_fileinfo'))
+  call assert_true(empty(execute('bn', '')))
+  call assert_false(test_getvalue('need_fileinfo'))
+  set shortmess&
+  call assert_match('file1', execute('bn', ''))
+  call assert_match('file2', execute('bn', ''))
+  bwipe
+  bwipe
+  call assert_fails('call test_getvalue("abc")', 'E475:')
+endfunc
+
+func Test_opt_shortmess_F3()
+  call writefile(['foo'], 'X_dummy', 'D')
+
+  set hidden
+  set autoread
+  e X_dummy
+  e Xotherfile
+  call assert_equal(['foo'], getbufline('X_dummy', 1, '$'))
+  set shortmess+=F
+  echo ''
+
+  if has('nanotime')
+    sleep 10m
+  else
+    sleep 2
+  endif
+  call writefile(['bar'], 'X_dummy')
+  bprev
+  call assert_equal('', Screenline(&lines))
+  call assert_equal(['bar'], getbufline('X_dummy', 1, '$'))
+
+  if has('nanotime')
+    sleep 10m
+  else
+    sleep 2
+  endif
+  call writefile(['baz'], 'X_dummy')
+  checktime
+  call assert_equal('', Screenline(&lines))
+  call assert_equal(['baz'], getbufline('X_dummy', 1, '$'))
+
+  set shortmess&
+  set autoread&
+  set hidden&
+  bwipe X_dummy
+  bwipe Xotherfile
+endfunc
+
+func Test_opt_showbreak()
+  CheckFeature linebreak
+  let save_encoding = &encoding
+  set encoding=utf8
+
+  " Unprintable
+  call assert_fails("set showbreak=\x01", 'E595:')
+
+  " Wide character
+  call assert_fails("set showbreak=\u3042", 'E595:')
+
+  let &encoding = save_encoding
+endfunc
+
+func Test_opt_sidescroll()
+  call assert_fails('set sidescroll=-1', 'E487:')
+endfunc
+
+func Test_opt_sidescrolloff()
+  set sidescrolloff=7
+  split
+  call assert_equal(7, &siso)
+  setlocal sidescrolloff=3
+  call assert_equal(3, &siso)
+  wincmd w
+  call assert_equal(7, &siso)
+  wincmd w
+  call assert_equal(3, &siso)
+  setlocal sidescrolloff<
+  call assert_equal(7, &siso)
+  setglobal sidescrolloff=4
+  call assert_equal(4, &siso)
+  call assert_equal(-1, &l:siso)
+  setlocal sidescrolloff=0
+  call assert_equal(0, &siso)
+  setlocal sidescrolloff=-1
+  call assert_equal(4, &siso)
+"  setglobal sidescrolloff=5
+"  setlocal sidescrolloff=7
+  close
+  set sidescrolloff&
+endfunc
+
+func Test_opt_signcolumn()
+  CheckFeature signs
+  call assert_equal("auto", &signcolumn)
+  set signcolumn=yes
+  set signcolumn=no
+  call assert_fails('set signcolumn=nope')
+endfunc
+
+func Test_opt_spellcapcheck()
+  call assert_fails('set spellcapcheck=%\\(', 'E54:')
+endfunc
+
+func Test_opt_statusline()
+  call assert_fails('set statusline=%$', 'E539:')
+  call assert_fails('set statusline=%{', 'E540:')
+  call assert_fails('set statusline=%{%', 'E540:')
+  call assert_fails('set statusline=%{%}', 'E539:')
+  call assert_fails('set statusline=%(', 'E542:')
+  call assert_fails('set statusline=%)', 'E542:')
+endfunc
+
+func Test_opt_switchbuf_reset()
+  set switchbuf=useopen
+  sblast
+  call assert_equal(1, winnr('$'))
+  set all&
+  call assert_equal('', &switchbuf)
+  sblast
+  call assert_equal(2, winnr('$'))
+  only!
+endfunc
+
+func Test_opt_syntax()
+  CheckFeature syntax
+  set syn=valid_name
+  call assert_equal("valid_name", &syntax)
+  set syn=valid-name
+  call assert_equal("valid-name", &syntax)
+
+  call assert_fails(":set syn=wrong;name", "E474:")
+  call assert_fails(":set syn=wrong\\\\name", "E474:")
+  call assert_fails(":set syn=wrong\\|name", "E474:")
+  call assert_fails(":set syn=wrong/name", "E474:")
+  call assert_fails(":set syn=wrong\\\nname", "E474:")
+  call assert_equal("valid-name", &syntax)
+
+  exe "set syn=trunc\x00name"
+  call assert_equal("trunc", &syntax)
+endfunc
+
+func Test_opt_tabline()
+  call assert_fails('set tabline=%$', 'E539:')
+  call assert_fails('set tabline=%{', 'E540:')
+  call assert_fails('set tabline=%{%', 'E540:')
+  call assert_fails('set tabline=%{%}', 'E539:')
+  call assert_fails('set tabline=%(', 'E542:')
+  call assert_fails('set tabline=%)', 'E542:')
+endfunc
+
+func Test_opt_tabstop()
+  call assert_fails('set tabstop=-1', 'E487:')
+  call assert_fails('set tabstop=10000', 'E474:')
+  call assert_fails('set tabstop=5500000000', 'E474:')
+endfunc
+
+" Must be executed before other tests that set 'term'.
+func Test_000_opt_term_option_verbose()
+  CheckNotGui
+
+  call CheckWasNotSet('t_cm')
+
+  let term_save = &term
+  set term=ansi
+  call CheckWasSet('t_cm')
+  let &term = term_save
+endfunc
+
+func Test_opt_textwidth()
+  call assert_fails('set textwidth=-1', 'E487:')
+endfunc
+
+func Test_opt_thesaurus()
+  " Check that it's possible to set the option.
+  set thesaurus=/usr/share/dict/words
+  call assert_equal('/usr/share/dict/words', &thesaurus)
+  set thesaurus=/usr/share/dict/words,/and/there
+  call assert_equal('/usr/share/dict/words,/and/there', &thesaurus)
+  set thesaurus=/usr/share/dict\ words
+  call assert_equal('/usr/share/dict words', &thesaurus)
+
+  " Check rejecting weird characters.
+  call assert_fails('set thesaurus=/not&there', 'E474:')
+  call assert_fails('set thesaurus=/not>there', 'E474:')
+  call assert_fails('set thesaurus=/not.*there', 'E474:')
+endfunc
+
+func Test_opt_timeoutlen()
+  call assert_fails('set timeoutlen=-1', 'E487:')
+endfunc
+
+func Test_opt_ttytype()
+  CheckUnix
+  CheckNotGui
+
+  " Setting 'ttytype' used to cause a double-free when exiting vim and
+  " when vim is compiled with -DEXITFREE.
+  set ttytype=ansi
+  call assert_equal('ansi', &ttytype)
+  call assert_equal(&ttytype, &term)
+  set ttytype=xterm
+  call assert_equal('xterm', &ttytype)
+  call assert_equal(&ttytype, &term)
+  try
+    set ttytype=
+    call assert_report('set ttytype= did not fail')
+  catch /E529/
+  endtry
+
+  " Some systems accept any terminal name and return dumb settings,
+  " check for failure of finding the entry and for missing 'cm' entry.
+  try
+    set ttytype=xxx
+    call assert_report('set ttytype=xxx did not fail')
+  catch /E522\|E437/
+  endtry
+
+  set ttytype&
+  call assert_equal(&ttytype, &term)
+
+  if has('gui') && !has('gui_running')
+    call assert_fails('set term=gui', 'E531:')
+  endif
+endfunc
+
+func Test_opt_updatecount()
+  call assert_fails('set updatecount=-1', 'E487:')
+endfunc
+
+func Test_opt_updatetime()
+  call assert_fails('set updatetime=-1', 'E487:')
+endfunc
+
+func Test_opt_visualbell()
+  let save_belloff = &belloff
+  set belloff=
+  set visualbell
+  call assert_beeps('normal 0h')
+  set novisualbell
+  let &belloff = save_belloff
+endfunc
+
+func Test_opt_whichwrap()
   set whichwrap=b,s
   call assert_equal('b,s', &whichwrap)
 
@@ -41,40 +1135,7 @@ func Test_whichwrap()
   set whichwrap&
 endfunc
 
-func Test_isfname()
-  " This used to cause Vim to access uninitialized memory.
-  set isfname=
-  call assert_equal("~X", expand("~X"))
-  set isfname&
-  " Test for setting 'isfname' to an unsupported character
-  let save_isfname = &isfname
-  call assert_fails('exe $"set isfname+={"\u1234"}"', 'E474:')
-  call assert_equal(save_isfname, &isfname)
-endfunc
-
-" Test for getting the value of 'pastetoggle'
-func Test_pastetoggle()
-  " character with K_SPECIAL byte
-  let &pastetoggle = '…'
-  call assert_equal('…', &pastetoggle)
-  call assert_equal("\n  pastetoggle=…", execute('set pastetoggle?'))
-
-  " modified character with K_SPECIAL byte
-  let &pastetoggle = '<M-…>'
-  call assert_equal('<M-…>', &pastetoggle)
-  call assert_equal("\n  pastetoggle=<M-…>", execute('set pastetoggle?'))
-
-  " illegal bytes
-  let str = ":\x7f:\x80:\x90:\xd0:"
-  let &pastetoggle = str
-  call assert_equal(str, &pastetoggle)
-  call assert_equal("\n  pastetoggle=" .. strtrans(str), execute('set pastetoggle?'))
-
-  unlet str
-  set pastetoggle&
-endfunc
-
-func Test_wildchar()
+func Test_opt_wildchar()
   " Empty 'wildchar' used to access invalid memory.
   call assert_fails('set wildchar=', 'E521:')
   call assert_fails('set wildchar=abc', 'E521:')
@@ -84,16 +1145,241 @@ func Test_wildchar()
   set wildchar=27
   let a=execute('set wildchar?')
   call assert_equal("\n  wildchar=<Esc>", a)
+
+  " To specify a control character as an option value, '^' can be used
+  set wildchar=^v
+  call assert_equal("\<C-V>", nr2char(&wildchar))
+
   set wildchar&
 endfunc
 
-func Test_wildoptions()
+func Test_opt_wildcharm()
+  " To specify a control character as an option value, '^' can be used
+  set wildcharm=^r
+  call assert_equal("\<C-R>", nr2char(&wildcharm))
+
+  set wildcharm&
+endfunc
+
+func Test_opt_wildoptions()
   set wildoptions=
   set wildoptions+=tagfile
   set wildoptions+=tagfile
   call assert_equal('tagfile', &wildoptions)
 endfunc
 
+func Test_opt_window()
+  " Needs only one open widow
+  %bw!
+  call setline(1, range(1, 8))
+  set window=5
+  exe "normal \<C-F>"
+  call assert_equal(4, line('w0'))
+  exe "normal \<C-F>"
+  call assert_equal(7, line('w0'))
+  exe "normal \<C-F>"
+  call assert_equal(8, line('w0'))
+  exe "normal \<C-B>"
+  call assert_equal(5, line('w0'))
+  exe "normal \<C-B>"
+  call assert_equal(2, line('w0'))
+  exe "normal \<C-B>"
+  call assert_equal(1, line('w0'))
+  set window=1
+  exe "normal gg\<C-F>"
+  call assert_equal(2, line('w0'))
+  exe "normal \<C-F>"
+  call assert_equal(3, line('w0'))
+  exe "normal \<C-B>"
+  call assert_equal(2, line('w0'))
+  exe "normal \<C-B>"
+  call assert_equal(1, line('w0'))
+  enew!
+  set window&
+endfunc
+
+func Test_opt_winheight()
+  " 'winheight' cannot be smaller than 'winminheight'
+  set winminheight& winheight&
+  set winheight=11 winminheight=10
+  set winheight=10
+  call assert_fails('set winheight=9', 'E591:')
+
+  set winminheight& winheight&
+endfunc
+
+func Test_opt_winminheight()
+  " 'winheight' cannot be smaller than 'winminheight'
+  set winminheight& winheight&
+  set winheight=10 winminheight=9
+  set winminheight=10
+  call assert_fails('set winminheight=11', 'E591:')
+  call assert_equal(10, &winminheight, 'set to value of winheight')
+  set winminheight=5
+  call assert_fails('set winminheight=11', 'E591:')
+  call assert_equal(10, &winminheight, 'set to value of winheight')
+
+  " Not enough room
+  set winminheight& winheight&
+  only!
+  let &winheight = &lines + 4
+  call assert_fails('set winminheight=' .. (&lines + 2), 'E36:')
+  call assert_true(&winminheight <= &lines)
+
+  set winminheight& winheight&
+endfunc
+
+func Test_opt_winminheight_in_terminal()
+  CheckRunVimInTerminal
+
+  " The tabline should be taken into account.
+  let lines =<< trim END
+    set wmh=0 stal=2
+    below sp | wincmd _
+    below sp | wincmd _
+    below sp | wincmd _
+    below sp
+  END
+  call writefile(lines, 'Xwinminheight', 'D')
+  let buf = RunVimInTerminal('-S Xwinminheight', #{rows: 11})
+  call term_sendkeys(buf, ":set wmh=1\n")
+  call WaitForAssert({-> assert_match('E36: Not enough room', term_getline(buf, 11))})
+
+  call StopVimInTerminal(buf)
+endfunc
+
+func Test_opt_winminheight_in_terminal_tabs()
+  CheckRunVimInTerminal
+
+  " The tabline should be taken into account.
+  let lines =<< trim END
+    set wmh=0 stal=2
+    split
+    split
+    split
+    split
+    tabnew
+  END
+  call writefile(lines, 'Xwinminheight', 'D')
+  let buf = RunVimInTerminal('-S Xwinminheight', #{rows: 11})
+  call term_sendkeys(buf, ":set wmh=1\n")
+  call WaitForAssert({-> assert_match('E36: Not enough room', term_getline(buf, 11))})
+
+  call StopVimInTerminal(buf)
+endfunc
+
+func Test_opt_winminwidth()
+  " 'winwidth' cannot be smaller than 'winminwidth'
+  set winminwidth& winwidth&
+  set winwidth=10 winminwidth=9
+  set winminwidth=10
+  call assert_fails('set winminwidth=11', 'E592:')
+  call assert_equal(10, &winminwidth, 'set to value of winwidth')
+  set winminwidth=5
+  call assert_fails('set winminwidth=11', 'E592:')
+  call assert_equal(10, &winminwidth, 'set to value of winwidth')
+
+  " Not enough room
+  set winminwidth& winwidth&
+  only!
+  let &winwidth = &columns + 4
+  call assert_fails('let &winminwidth = &columns + 2', 'E36:')
+  call assert_true(&winminwidth <= &columns)
+
+  set winminwidth& winwidth&
+endfunc
+
+func Test_opt_winwidth()
+  " 'winwidth' cannot be smaller than 'winminwidth'
+  set winminwidth& winwidth&
+  set winwidth=11 winminwidth=10
+  set winwidth=10
+  call assert_fails('set winwidth=9', 'E592:')
+
+  set winwidth& winminwidth&
+endfunc
+
+func Test_opt_wrap()
+  " Unsetting 'wrap' when 'smoothscroll' is set does not result in incorrect
+  " cursor position.
+  set wrap smoothscroll scrolloff=5
+
+  call setline(1, ['', 'aaaa'->repeat(500)])
+  20 split
+  20 vsplit
+  norm 2G$
+  redraw
+  set nowrap
+  call assert_equal(2, winline())
+
+  set wrap& smoothscroll& scrolloff&
+endfunc
+
+func Test_opt_write()
+  new
+  call setline(1, ['L1'])
+  set nowrite
+  call assert_fails('write Xwrfile', 'E142:')
+  set write
+  " close swapfile
+  bw!
+endfunc
+
+func Test_opt_writedelay()
+  CheckFunction reltimefloat
+
+  new
+  call setline(1, 'empty')
+  redraw
+  set writedelay=10
+  let start = reltime()
+  call setline(1, repeat('x', 70))
+  redraw
+  let elapsed = reltimefloat(reltime(start))
+  set writedelay=0
+  " With 'writedelay' set should take at least 30 * 10 msec
+  call assert_inrange(30 * 0.01, 999.0, elapsed)
+
+  bwipe!
+endfunc
+
+" end of Test each options
+
+" Can set missing-options, but cannot be printed.
+func Test_set_missing_options()
+  set autoprint
+  call assert_fails('set autoprint?', 'E519:')
+  set beautify
+  call assert_fails('set beautify?', 'E519:')
+  set flash
+  call assert_fails('set flash?', 'E519:')
+  set graphic
+  call assert_fails('set graphic?', 'E519:')
+  set hardtabs=8
+  call assert_fails('set hardtabs?', 'E519:')
+  set mesg
+  call assert_fails('set mesg?', 'E519:')
+  set novice
+  call assert_fails('set novice?', 'E519:')
+  set open
+  call assert_fails('set open?', 'E519:')
+  set optimize
+  call assert_fails('set optimize?', 'E519:')
+  set redraw
+  call assert_fails('set redraw?', 'E519:')
+  set slowopen
+  call assert_fails('set slowopen?', 'E519:')
+  set sourceany
+  call assert_fails('set sourceany?', 'E519:')
+  set w300=23
+  call assert_fails('set w300?', 'E519:')
+  set w1200=23
+  call assert_fails('set w1200?', 'E519:')
+  set w9600=23
+  call assert_fails('set w9600?', 'E519:')
+endfunc
+
+" Test for :options
 func Test_options_command()
   let caught = 'ok'
   try
@@ -151,127 +1437,6 @@ func Test_options_command()
     close
   endif
 endfunc
-
-func Test_path_keep_commas()
-  " Test that changing 'path' keeps two commas.
-  set path=foo,,bar
-  set path-=bar
-  set path+=bar
-  call assert_equal('foo,,bar', &path)
-
-  set path&
-endfunc
-
-func Test_path_too_long()
-  exe 'set path=' .. repeat('x', 10000)
-  call assert_fails('find x', 'E854:')
-  set path&
-endfunc
-
-func Test_signcolumn()
-  CheckFeature signs
-  call assert_equal("auto", &signcolumn)
-  set signcolumn=yes
-  set signcolumn=no
-  call assert_fails('set signcolumn=nope')
-endfunc
-
-func Test_filetype_valid()
-  set ft=valid_name
-  call assert_equal("valid_name", &filetype)
-  set ft=valid-name
-  call assert_equal("valid-name", &filetype)
-
-  call assert_fails(":set ft=wrong;name", "E474:")
-  call assert_fails(":set ft=wrong\\\\name", "E474:")
-  call assert_fails(":set ft=wrong\\|name", "E474:")
-  call assert_fails(":set ft=wrong/name", "E474:")
-  call assert_fails(":set ft=wrong\\\nname", "E474:")
-  call assert_equal("valid-name", &filetype)
-
-  exe "set ft=trunc\x00name"
-  call assert_equal("trunc", &filetype)
-endfunc
-
-func Test_syntax_valid()
-  CheckFeature syntax
-  set syn=valid_name
-  call assert_equal("valid_name", &syntax)
-  set syn=valid-name
-  call assert_equal("valid-name", &syntax)
-
-  call assert_fails(":set syn=wrong;name", "E474:")
-  call assert_fails(":set syn=wrong\\\\name", "E474:")
-  call assert_fails(":set syn=wrong\\|name", "E474:")
-  call assert_fails(":set syn=wrong/name", "E474:")
-  call assert_fails(":set syn=wrong\\\nname", "E474:")
-  call assert_equal("valid-name", &syntax)
-
-  exe "set syn=trunc\x00name"
-  call assert_equal("trunc", &syntax)
-endfunc
-
-func Test_keymap_valid()
-  CheckFeature keymap
-  call assert_fails(":set kmp=valid_name", "E544:")
-  call assert_fails(":set kmp=valid_name", "valid_name")
-  call assert_fails(":set kmp=valid-name", "E544:")
-  call assert_fails(":set kmp=valid-name", "valid-name")
-
-  call assert_fails(":set kmp=wrong;name", "E474:")
-  call assert_fails(":set kmp=wrong\\\\name", "E474:")
-  call assert_fails(":set kmp=wrong\\|name", "E474:")
-  call assert_fails(":set kmp=wrong/name", "E474:")
-  call assert_fails(":set kmp=wrong\\\nname", "E474:")
-
-  call assert_fails(":set kmp=trunc\x00name", "E544:")
-  call assert_fails(":set kmp=trunc\x00name", "trunc")
-endfunc
-
-func Test_wildchar_valid()
-  call assert_fails("set wildchar=<CR>", "E474:")
-  call assert_fails("set wildcharm=<C-C>", "E474:")
-endfunc
-
-func Check_dir_option(name)
-  " Check that it's possible to set the option.
-  exe 'set ' . a:name . '=/usr/share/dict/words'
-  call assert_equal('/usr/share/dict/words', eval('&' . a:name))
-  exe 'set ' . a:name . '=/usr/share/dict/words,/and/there'
-  call assert_equal('/usr/share/dict/words,/and/there', eval('&' . a:name))
-  exe 'set ' . a:name . '=/usr/share/dict\ words'
-  call assert_equal('/usr/share/dict words', eval('&' . a:name))
-
-  " Check rejecting weird characters.
-  call assert_fails("set " . a:name . "=/not&there", "E474:")
-  call assert_fails("set " . a:name . "=/not>there", "E474:")
-  call assert_fails("set " . a:name . "=/not.*there", "E474:")
-endfunc
-
-func Test_cinkeys()
-  " This used to cause invalid memory access
-  set cindent cinkeys=0
-  norm a
-  set cindent& cinkeys&
-endfunc
-
-func Test_dictionary()
-  call Check_dir_option('dictionary')
-endfunc
-
-func Test_thesaurus()
-  call Check_dir_option('thesaurus')
-endfun
-
-func Test_complete()
-  " Trailing single backslash used to cause invalid memory access.
-  set complete=s\
-  new
-  call feedkeys("i\<C-N>\<Esc>", 'xt')
-  bwipe!
-  call assert_fails('set complete=ix', 'E535:')
-  set complete&
-endfun
 
 func Test_set_completion()
   call feedkeys(":set di\<C-A>\<C-B>\"\<CR>", 'tx')
@@ -725,184 +1890,14 @@ func Test_set_completion_string_values()
   set ww&
 endfunc
 
-func Test_set_option_errors()
-  call assert_fails('set scroll=-1', 'E49:')
-  call assert_fails('set backupcopy=', 'E474:')
-  call assert_fails('set regexpengine=3', 'E474:')
-  call assert_fails('set history=10001', 'E474:')
-  call assert_fails('set numberwidth=21', 'E474:')
-  call assert_fails('set colorcolumn=-a', 'E474:')
-  call assert_fails('set colorcolumn=a', 'E474:')
-  call assert_fails('set colorcolumn=1,', 'E474:')
-  call assert_fails('set colorcolumn=1;', 'E474:')
-  call assert_fails('set cmdheight=-1', 'E487:')
-  call assert_fails('set cmdwinheight=-1', 'E487:')
-  if has('conceal')
-    call assert_fails('set conceallevel=-1', 'E487:')
-    call assert_fails('set conceallevel=4', 'E474:')
-  endif
-  call assert_fails('set helpheight=-1', 'E487:')
-  call assert_fails('set history=-1', 'E487:')
-  call assert_fails('set report=-1', 'E487:')
-  call assert_fails('set shiftwidth=-1', 'E487:')
-  call assert_fails('set sidescroll=-1', 'E487:')
-  call assert_fails('set tabstop=-1', 'E487:')
-  call assert_fails('set tabstop=10000', 'E474:')
-  call assert_fails('let &tabstop = 10000', 'E474:')
-  call assert_fails('set tabstop=5500000000', 'E474:')
-  call assert_fails('set textwidth=-1', 'E487:')
-  call assert_fails('set timeoutlen=-1', 'E487:')
-  call assert_fails('set updatecount=-1', 'E487:')
-  call assert_fails('set updatetime=-1', 'E487:')
-  call assert_fails('set winheight=-1', 'E487:')
-  call assert_fails('set tabstop!', 'E488:')
-  call assert_fails('set xxx', 'E518:')
-  call assert_fails('set beautify?', 'E519:')
-  call assert_fails('set undolevels=x', 'E521:')
-  call assert_fails('set tabstop=', 'E521:')
-  call assert_fails('set comments=-', 'E524:')
-  call assert_fails('set comments=a', 'E525:')
-  call assert_fails('set foldmarker=x', 'E536:')
-  call assert_fails('set commentstring=x', 'E537:')
-  call assert_fails('let &commentstring = "x"', 'E537:')
-  call assert_fails('set complete=x', 'E539:')
-  call assert_fails('set rulerformat=%-', 'E539:')
-  call assert_fails('set rulerformat=%(', 'E542:')
-  call assert_fails('set rulerformat=%15(%%', 'E542:')
-  call assert_fails('set statusline=%$', 'E539:')
-  call assert_fails('set statusline=%{', 'E540:')
-  call assert_fails('set statusline=%{%', 'E540:')
-  call assert_fails('set statusline=%{%}', 'E539:')
-  call assert_fails('set statusline=%(', 'E542:')
-  call assert_fails('set statusline=%)', 'E542:')
-  call assert_fails('set tabline=%$', 'E539:')
-  call assert_fails('set tabline=%{', 'E540:')
-  call assert_fails('set tabline=%{%', 'E540:')
-  call assert_fails('set tabline=%{%}', 'E539:')
-  call assert_fails('set tabline=%(', 'E542:')
-  call assert_fails('set tabline=%)', 'E542:')
-
-  if has('cursorshape')
-    " This invalid value for 'guicursor' used to cause Vim to crash.
-    call assert_fails('set guicursor=i-ci,r-cr:h', 'E545:')
-    call assert_fails('set guicursor=i-ci', 'E545:')
-    call assert_fails('set guicursor=x', 'E545:')
-    call assert_fails('set guicursor=x:', 'E546:')
-    call assert_fails('set guicursor=r-cr:horx', 'E548:')
-    call assert_fails('set guicursor=r-cr:hor0', 'E549:')
-  endif
-  if has('mouseshape')
-    call assert_fails('se mouseshape=i-r:x', 'E547:')
-  endif
-
-  " Test for 'backupext' and 'patchmode' set to the same value
-  set backupext=.bak
-  set patchmode=.patch
-  call assert_fails('set patchmode=.bak', 'E589:')
-  call assert_equal('.patch', &patchmode)
-  call assert_fails('set backupext=.patch', 'E589:')
-  call assert_equal('.bak', &backupext)
-  set backupext& patchmode&
-
-  call assert_fails('set winminheight=10 winheight=9', 'E591:')
-  set winminheight& winheight&
-  set winheight=10 winminheight=10
-  call assert_fails('set winheight=9', 'E591:')
-  set winminheight& winheight&
-  call assert_fails('set winminwidth=10 winwidth=9', 'E592:')
-  set winminwidth& winwidth&
-  call assert_fails('set winwidth=9 winminwidth=10', 'E592:')
-  set winwidth& winminwidth&
-  call assert_fails("set showbreak=\x01", 'E595:')
-  call assert_fails('set t_foo=', 'E846:')
-  call assert_fails('set tabstop??', 'E488:')
-  call assert_fails('set wrapscan!!', 'E488:')
-  call assert_fails('set tabstop&&', 'E488:')
-  call assert_fails('set wrapscan<<', 'E488:')
-  call assert_fails('set wrapscan=1', 'E474:')
-  call assert_fails('set autoindent@', 'E488:')
-  call assert_fails('set wildchar=<abc>', 'E474:')
-  call assert_fails('set cmdheight=1a', 'E521:')
-  call assert_fails('set invcmdheight', 'E474:')
-  if has('python') || has('python3')
-    call assert_fails('set pyxversion=6', 'E474:')
-  endif
-  call assert_fails("let &tabstop='ab'", ['E521:', 'E521:'])
-  call assert_fails('set spellcapcheck=%\\(', 'E54:')
-  call assert_fails('set sessionoptions=curdir,sesdir', 'E474:')
-  call assert_fails('set foldmarker={{{,', 'E474:')
-  call assert_fails('set sessionoptions=sesdir,curdir', 'E474:')
-  setlocal listchars=trail:·
-  call assert_fails('set ambiwidth=double', 'E834:')
-  setlocal listchars=trail:-
-  setglobal listchars=trail:·
-  call assert_fails('set ambiwidth=double', 'E834:')
-  set listchars&
-  setlocal fillchars=stl:·
-  call assert_fails('set ambiwidth=double', 'E835:')
-  setlocal fillchars=stl:-
-  setglobal fillchars=stl:·
-  call assert_fails('set ambiwidth=double', 'E835:')
-  set fillchars&
-  call assert_fails('set fileencoding=latin1,utf-8', 'E474:')
-  set nomodifiable
-  call assert_fails('set fileencoding=latin1', 'E21:')
-  set modifiable&
-  call assert_fails('set t_#-&', 'E522:')
-  call assert_fails('let &formatoptions = "?"', 'E539:')
-  call assert_fails('call setbufvar("", "&formatoptions", "?")', 'E539:')
+" Should raises only one error if passing a wrong variable type. (9.0.1631)
+func Test_set_raises_only_one_error()
   call assert_fails('call setwinvar(0, "&scrolloff", [])', ['E745:', 'E745:'])
   call assert_fails('call setwinvar(0, "&list", [])', ['E745:', 'E745:'])
   call assert_fails('call setwinvar(0, "&listchars", [])', ['E730:', 'E730:'])
   call assert_fails('call setwinvar(0, "&nosuchoption", 0)', ['E355:', 'E355:'])
   call assert_fails('call setwinvar(0, "&nosuchoption", "")', ['E355:', 'E355:'])
   call assert_fails('call setwinvar(0, "&nosuchoption", [])', ['E355:', 'E355:'])
-endfunc
-
-func Test_set_encoding()
-  let save_encoding = &encoding
-
-  set enc=iso8859-1
-  call assert_equal('latin1', &enc)
-  set enc=iso8859_1
-  call assert_equal('latin1', &enc)
-  set enc=iso-8859-1
-  call assert_equal('latin1', &enc)
-  set enc=iso_8859_1
-  call assert_equal('latin1', &enc)
-  set enc=iso88591
-  call assert_equal('latin1', &enc)
-  set enc=iso8859
-  call assert_equal('latin1', &enc)
-  set enc=iso-8859
-  call assert_equal('latin1', &enc)
-  set enc=iso_8859
-  call assert_equal('latin1', &enc)
-  call assert_fails('set enc=iso8858', 'E474:')
-  call assert_equal('latin1', &enc)
-
-  let &encoding = save_encoding
-endfunc
-
-func CheckWasSet(name)
-  let verb_cm = execute('verbose set ' .. a:name .. '?')
-  call assert_match('Last set from.*test_options.vim', verb_cm)
-endfunc
-func CheckWasNotSet(name)
-  let verb_cm = execute('verbose set ' .. a:name .. '?')
-  call assert_notmatch('Last set from', verb_cm)
-endfunc
-
-" Must be executed before other tests that set 'term'.
-func Test_000_term_option_verbose()
-  CheckNotGui
-
-  call CheckWasNotSet('t_cm')
-
-  let term_save = &term
-  set term=ansi
-  call CheckWasSet('t_cm')
-  let &term = term_save
 endfunc
 
 func Test_copy_context()
@@ -926,176 +1921,14 @@ func Test_copy_context()
   call CheckWasSet('fo')
 endfunc
 
-func Test_set_ttytype()
-  CheckUnix
-  CheckNotGui
-
-  " Setting 'ttytype' used to cause a double-free when exiting vim and
-  " when vim is compiled with -DEXITFREE.
-  set ttytype=ansi
-  call assert_equal('ansi', &ttytype)
-  call assert_equal(&ttytype, &term)
-  set ttytype=xterm
-  call assert_equal('xterm', &ttytype)
-  call assert_equal(&ttytype, &term)
-  try
-    set ttytype=
-    call assert_report('set ttytype= did not fail')
-  catch /E529/
-  endtry
-
-  " Some systems accept any terminal name and return dumb settings,
-  " check for failure of finding the entry and for missing 'cm' entry.
-  try
-    set ttytype=xxx
-    call assert_report('set ttytype=xxx did not fail')
-  catch /E522\|E437/
-  endtry
-
-  set ttytype&
-  call assert_equal(&ttytype, &term)
-
-  if has('gui') && !has('gui_running')
-    call assert_fails('set term=gui', 'E531:')
-  endif
-endfunc
-
-func Test_set_all()
-  set tw=75
-  set iskeyword=a-z,A-Z
-  set nosplitbelow
-  let out = execute('set all')
-  call assert_match('textwidth=75', out)
-  call assert_match('iskeyword=a-z,A-Z', out)
-  call assert_match('nosplitbelow', out)
-  set tw& iskeyword& splitbelow&
-endfunc
-
-func Test_set_one_column()
-  let out_mult = execute('set all')->split("\n")
-  let out_one = execute('set! all')->split("\n")
-  call assert_true(len(out_mult) < len(out_one))
-  call assert_equal(out_one[0], '--- Options ---')
-  let options = out_one[1:]->mapnew({_, line -> line[2:]})
-  call assert_equal(sort(copy(options)), options)
-endfunc
-
 func Test_set_values()
-  " opt_test.vim is generated from ../optiondefs.h using gen_opt_test.vim
+  " src/testdir/opt_test.vim is generated from src/optiondefs.h and
+  " runtime/doc/options.txt using src/testdir/gen_opt_test.vim
   if filereadable('opt_test.vim')
     source opt_test.vim
   else
     throw 'Skipped: opt_test.vim does not exist'
   endif
-endfunc
-
-func Test_renderoptions()
-  " Only do this for Windows Vista and later, fails on Windows XP and earlier.
-  " Doesn't hurt to do this on a non-Windows system.
-  if windowsversion() !~ '^[345]\.'
-    set renderoptions=type:directx
-    set rop=type:directx
-  endif
-endfunc
-
-func ResetIndentexpr()
-  set indentexpr=
-endfunc
-
-func Test_set_indentexpr()
-  " this was causing usage of freed memory
-  set indentexpr=ResetIndentexpr()
-  new
-  call feedkeys("i\<c-f>", 'x')
-  call assert_equal('', &indentexpr)
-  bwipe!
-endfunc
-
-func Test_backupskip()
-  " Option 'backupskip' may contain several comma-separated path
-  " specifications if one or more of the environment variables TMPDIR, TMP,
-  " or TEMP is defined.  To simplify testing, convert the string value into a
-  " list.
-  let bsklist = split(&bsk, ',')
-
-  if has("mac")
-    let found = (index(bsklist, '/private/tmp/*') >= 0)
-    call assert_true(found, '/private/tmp not in option bsk: ' . &bsk)
-  elseif has("unix")
-    let found = (index(bsklist, '/tmp/*') >= 0)
-    call assert_true(found, '/tmp not in option bsk: ' . &bsk)
-  endif
-
-  " If our test platform is Windows, the path(s) in option bsk will use
-  " backslash for the path separator and the components could be in short
-  " (8.3) format.  As such, we need to replace the backslashes with forward
-  " slashes and convert the path components to long format.  The expand()
-  " function will do this but it cannot handle comma-separated paths.  This is
-  " why bsk was converted from a string into a list of strings above.
-  "
-  " One final complication is that the wildcard "/*" is at the end of each
-  " path and so expand() might return a list of matching files.  To prevent
-  " this, we need to remove the wildcard before calling expand() and then
-  " append it afterwards.
-  if has('win32')
-    let item_nbr = 0
-    while item_nbr < len(bsklist)
-      let path_spec = bsklist[item_nbr]
-      let path_spec = strcharpart(path_spec, 0, strlen(path_spec)-2)
-      let path_spec = substitute(expand(path_spec), '\\', '/', 'g')
-      let bsklist[item_nbr] = path_spec . '/*'
-      let item_nbr += 1
-    endwhile
-  endif
-
-  " Option bsk will also include these environment variables if defined.
-  " If they're defined, verify they appear in the option value.
-  for var in  ['$TMPDIR', '$TMP', '$TEMP']
-    if exists(var)
-      let varvalue = substitute(expand(var), '\\', '/', 'g')
-      let varvalue = substitute(varvalue, '/$', '', '')
-      let varvalue .= '/*'
-      let found = (index(bsklist, varvalue) >= 0)
-      call assert_true(found, var . ' (' . varvalue . ') not in option bsk: ' . &bsk)
-    endif
-  endfor
-
-  " Duplicates from environment variables should be filtered out (option has
-  " P_NODUP).  Run this in a separate instance and write v:errors in a file,
-  " so that we see what happens on startup.
-  let after =<< trim [CODE]
-      let bsklist = split(&backupskip, ',')
-      call assert_equal(uniq(copy(bsklist)), bsklist)
-      call writefile(['errors:'] + v:errors, 'Xtestout')
-      qall
-  [CODE]
-  call writefile(after, 'Xafter', 'D')
-  let cmd = GetVimProg() . ' --not-a-term -S Xafter --cmd "set enc=utf8"'
-
-  let saveenv = {}
-  for var in ['TMPDIR', 'TMP', 'TEMP']
-    let saveenv[var] = getenv(var)
-    call setenv(var, '/duplicate/path')
-  endfor
-
-  exe 'silent !' . cmd
-  call assert_equal(['errors:'], readfile('Xtestout'))
-
-  " restore environment variables
-  for var in ['TMPDIR', 'TMP', 'TEMP']
-    call setenv(var, saveenv[var])
-  endfor
-
-  call delete('Xtestout')
-
-  " Duplicates should be filtered out (option has P_NODUP)
-  let backupskip = &backupskip
-  set backupskip=
-  set backupskip+=/test/dir
-  set backupskip+=/other/dir
-  set backupskip+=/test/dir
-  call assert_equal('/test/dir,/other/dir', &backupskip)
-  let &backupskip = backupskip
 endfunc
 
 func Test_buf_copy_winopt()
@@ -1254,278 +2087,8 @@ def Test_split_copy_options()
   endfor
 enddef
 
-func Test_shortmess_F()
-  new
-  call assert_match('\[No Name\]', execute('file'))
-  set shortmess+=F
-  call assert_match('\[No Name\]', execute('file'))
-  call assert_match('^\s*$', execute('file foo'))
-  call assert_match('foo', execute('file'))
-  set shortmess-=F
-  call assert_match('bar', execute('file bar'))
-  call assert_match('bar', execute('file'))
-  set shortmess&
-  bwipe
-endfunc
-
-func Test_shortmess_F2()
-  e file1
-  e file2
-  call assert_match('file1', execute('bn', ''))
-  call assert_match('file2', execute('bn', ''))
-  set shortmess+=F
-  call assert_true(empty(execute('bn', '')))
-  call assert_false(test_getvalue('need_fileinfo'))
-  call assert_true(empty(execute('bn', '')))
-  call assert_false('need_fileinfo'->test_getvalue())
-  set hidden
-  call assert_true(empty(execute('bn', '')))
-  call assert_false(test_getvalue('need_fileinfo'))
-  call assert_true(empty(execute('bn', '')))
-  call assert_false(test_getvalue('need_fileinfo'))
-  set nohidden
-  call assert_true(empty(execute('bn', '')))
-  call assert_false(test_getvalue('need_fileinfo'))
-  call assert_true(empty(execute('bn', '')))
-  call assert_false(test_getvalue('need_fileinfo'))
-  set shortmess&
-  call assert_match('file1', execute('bn', ''))
-  call assert_match('file2', execute('bn', ''))
-  bwipe
-  bwipe
-  call assert_fails('call test_getvalue("abc")', 'E475:')
-endfunc
-
-func Test_shortmess_F3()
-  call writefile(['foo'], 'X_dummy', 'D')
-
-  set hidden
-  set autoread
-  e X_dummy
-  e Xotherfile
-  call assert_equal(['foo'], getbufline('X_dummy', 1, '$'))
-  set shortmess+=F
-  echo ''
-
-  if has('nanotime')
-    sleep 10m
-  else
-    sleep 2
-  endif
-  call writefile(['bar'], 'X_dummy')
-  bprev
-  call assert_equal('', Screenline(&lines))
-  call assert_equal(['bar'], getbufline('X_dummy', 1, '$'))
-
-  if has('nanotime')
-    sleep 10m
-  else
-    sleep 2
-  endif
-  call writefile(['baz'], 'X_dummy')
-  checktime
-  call assert_equal('', Screenline(&lines))
-  call assert_equal(['baz'], getbufline('X_dummy', 1, '$'))
-
-  set shortmess&
-  set autoread&
-  set hidden&
-  bwipe X_dummy
-  bwipe Xotherfile
-endfunc
-
-func Test_local_scrolloff()
-  set so=5
-  set siso=7
-  split
-  call assert_equal(5, &so)
-  setlocal so=3
-  call assert_equal(3, &so)
-  wincmd w
-  call assert_equal(5, &so)
-  wincmd w
-  call assert_equal(3, &so)
-  setlocal so<
-  call assert_equal(5, &so)
-  setglob so=8
-  call assert_equal(8, &so)
-  call assert_equal(-1, &l:so)
-  setlocal so=0
-  call assert_equal(0, &so)
-  setlocal so=-1
-  call assert_equal(8, &so)
-
-  call assert_equal(7, &siso)
-  setlocal siso=3
-  call assert_equal(3, &siso)
-  wincmd w
-  call assert_equal(7, &siso)
-  wincmd w
-  call assert_equal(3, &siso)
-  setlocal siso<
-  call assert_equal(7, &siso)
-  setglob siso=4
-  call assert_equal(4, &siso)
-  call assert_equal(-1, &l:siso)
-  setlocal siso=0
-  call assert_equal(0, &siso)
-  setlocal siso=-1
-  call assert_equal(4, &siso)
-
-  close
-  set so&
-  set siso&
-endfunc
-
-func Test_writedelay()
-  CheckFunction reltimefloat
-
-  new
-  call setline(1, 'empty')
-  redraw
-  set writedelay=10
-  let start = reltime()
-  call setline(1, repeat('x', 70))
-  redraw
-  let elapsed = reltimefloat(reltime(start))
-  set writedelay=0
-  " With 'writedelay' set should take at least 30 * 10 msec
-  call assert_inrange(30 * 0.01, 999.0, elapsed)
-
-  bwipe!
-endfunc
-
-func Test_visualbell()
-  set belloff=
-  set visualbell
-  call assert_beeps('normal 0h')
-  set novisualbell
-  set belloff=all
-endfunc
-
-" Test for the 'write' option
-func Test_write()
-  new
-  call setline(1, ['L1'])
-  set nowrite
-  call assert_fails('write Xwrfile', 'E142:')
-  set write
-  " close swapfile
-  bw!
-endfunc
-
-" Test for 'buftype' option
-func Test_buftype()
-  new
-  call setline(1, ['L1'])
-  set buftype=nowrite
-  call assert_fails('write', 'E382:')
-
-  for val in ['', 'nofile', 'nowrite', 'acwrite', 'quickfix', 'help', 'terminal', 'prompt', 'popup']
-    exe 'set buftype=' .. val
-    call writefile(['something'], 'XBuftype', 'D')
-    call assert_fails('write XBuftype', 'E13:', 'with buftype=' .. val)
-  endfor
-
-  bwipe!
-endfunc
-
-" Test for the 'rightleftcmd' option
-func Test_rightleftcmd()
-  CheckFeature rightleft
-  set rightleft
-
-  let g:l = []
-  func AddPos()
-    call add(g:l, screencol())
-    return ''
-  endfunc
-  cmap <expr> <F2> AddPos()
-
-  set rightleftcmd=
-  call feedkeys("/\<F2>abc\<Right>\<F2>\<Left>\<Left>\<F2>" ..
-        \ "\<Right>\<F2>\<Esc>", 'xt')
-  call assert_equal([2, 5, 3, 4], g:l)
-
-  let g:l = []
-  set rightleftcmd=search
-  call feedkeys("/\<F2>abc\<Left>\<F2>\<Right>\<Right>\<F2>" ..
-        \ "\<Left>\<F2>\<Esc>", 'xt')
-  call assert_equal([&co - 1, &co - 4, &co - 2, &co - 3], g:l)
-
-  cunmap <F2>
-  unlet g:l
-  set rightleftcmd&
-  set rightleft&
-endfunc
-
-" Test for the 'debug' option
-func Test_debug_option()
-  " redraw to avoid matching previous messages
-  redraw
-  set debug=beep
-  exe "normal \<C-c>"
-  call assert_equal('Beep!', Screenline(&lines))
-  call assert_equal('line    4:', Screenline(&lines - 1))
-  " also check a line above, with a certain window width the colon is there
-  call assert_match('Test_debug_option:$',
-        \ Screenline(&lines - 3) .. Screenline(&lines - 2))
-  set debug&
-endfunc
-
-" Test for the default CDPATH option
-func Test_opt_default_cdpath()
-  let after =<< trim [CODE]
-    call assert_equal(',/path/to/dir1,/path/to/dir2', &cdpath)
-    call writefile(v:errors, 'Xtestout')
-    qall
-  [CODE]
-  if has('unix')
-    let $CDPATH='/path/to/dir1:/path/to/dir2'
-  else
-    let $CDPATH='/path/to/dir1;/path/to/dir2'
-  endif
-  if RunVim([], after, '')
-    call assert_equal([], readfile('Xtestout'))
-    call delete('Xtestout')
-  endif
-endfunc
-
-" Test for setting keycodes using set
-func Test_opt_set_keycode()
-  call assert_fails('set <t_k1=l', 'E474:')
-  call assert_fails('set <Home=l', 'E474:')
-  set <t_k9>=abcd
-  call assert_equal('abcd', &t_k9)
-  set <t_k9>&
-  set <F9>=xyz
-  call assert_equal('xyz', &t_k9)
-  set <t_k9>&
-
-  " should we test all of them?
-  set t_Ce=testCe
-  set t_Cs=testCs
-  set t_Us=testUs
-  set t_ds=testds
-  set t_Ds=testDs
-  call assert_equal('testCe', &t_Ce)
-  call assert_equal('testCs', &t_Cs)
-  call assert_equal('testUs', &t_Us)
-  call assert_equal('testds', &t_ds)
-  call assert_equal('testDs', &t_Ds)
-endfunc
-
-" Test for changing options in a sandbox
-func Test_opt_sandbox()
-  for opt in ['backupdir', 'cdpath', 'exrc']
-    call assert_fails('sandbox set ' .. opt .. '?', 'E48:')
-    call assert_fails('sandbox let &' .. opt .. ' = 1', 'E48:')
-  endfor
-  call assert_fails('sandbox let &modelineexpr = 1', 'E48:')
-endfunc
-
 " Test for setting an option with local value to global value
-func Test_opt_local_to_global()
+func Test_set_option_local_to_global()
   setglobal equalprg=gprg
   setlocal equalprg=lprg
   call assert_equal('gprg', &g:equalprg)
@@ -1554,172 +2117,8 @@ func Test_opt_local_to_global()
   set autoread&
 endfunc
 
-func Test_set_in_sandbox()
-  " Some boolean options cannot be set in sandbox, some can.
-  call assert_fails('sandbox set modelineexpr', 'E48:')
-  sandbox set number
-  call assert_true(&number)
-  set number&
-
-  " Some boolean options cannot be set in sandbox, some can.
-  if has('python') || has('python3')
-    call assert_fails('sandbox set pyxversion=3', 'E48:')
-  endif
-  sandbox set tabstop=4
-  call assert_equal(4, &tabstop)
-  set tabstop&
-
-  " Some string options cannot be set in sandbox, some can.
-  call assert_fails('sandbox set backupdir=/tmp', 'E48:')
-  sandbox set filetype=perl
-  call assert_equal('perl', &filetype)
-  set filetype&
-endfunc
-
-" Test for incrementing, decrementing and multiplying a number option value
-func Test_opt_num_op()
-  set shiftwidth=4
-  set sw+=2
-  call assert_equal(6, &sw)
-  set sw-=2
-  call assert_equal(4, &sw)
-  set sw^=2
-  call assert_equal(8, &sw)
-  set shiftwidth&
-endfunc
-
-" Test for setting option values using v:false and v:true
-func Test_opt_boolean()
-  set number&
-  set number
-  call assert_equal(1, &nu)
-  set nonu
-  call assert_equal(0, &nu)
-  let &nu = v:true
-  call assert_equal(1, &nu)
-  let &nu = v:false
-  call assert_equal(0, &nu)
-  set number&
-endfunc
-
-" Test for the 'window' option
-func Test_window_opt()
-  " Needs only one open widow
-  %bw!
-  call setline(1, range(1, 8))
-  set window=5
-  exe "normal \<C-F>"
-  call assert_equal(4, line('w0'))
-  exe "normal \<C-F>"
-  call assert_equal(7, line('w0'))
-  exe "normal \<C-F>"
-  call assert_equal(8, line('w0'))
-  exe "normal \<C-B>"
-  call assert_equal(5, line('w0'))
-  exe "normal \<C-B>"
-  call assert_equal(2, line('w0'))
-  exe "normal \<C-B>"
-  call assert_equal(1, line('w0'))
-  set window=1
-  exe "normal gg\<C-F>"
-  call assert_equal(2, line('w0'))
-  exe "normal \<C-F>"
-  call assert_equal(3, line('w0'))
-  exe "normal \<C-B>"
-  call assert_equal(2, line('w0'))
-  exe "normal \<C-B>"
-  call assert_equal(1, line('w0'))
-  enew!
-  set window&
-endfunc
-
-" Test for the 'winminheight' option
-func Test_opt_winminheight()
-  only!
-  let &winheight = &lines + 4
-  call assert_fails('let &winminheight = &lines + 2', 'E36:')
-  call assert_true(&winminheight <= &lines)
-  set winminheight&
-  set winheight&
-endfunc
-
-func Test_opt_winminheight_term()
-  CheckRunVimInTerminal
-
-  " The tabline should be taken into account.
-  let lines =<< trim END
-    set wmh=0 stal=2
-    below sp | wincmd _
-    below sp | wincmd _
-    below sp | wincmd _
-    below sp
-  END
-  call writefile(lines, 'Xwinminheight', 'D')
-  let buf = RunVimInTerminal('-S Xwinminheight', #{rows: 11})
-  call term_sendkeys(buf, ":set wmh=1\n")
-  call WaitForAssert({-> assert_match('E36: Not enough room', term_getline(buf, 11))})
-
-  call StopVimInTerminal(buf)
-endfunc
-
-func Test_opt_winminheight_term_tabs()
-  CheckRunVimInTerminal
-
-  " The tabline should be taken into account.
-  let lines =<< trim END
-    set wmh=0 stal=2
-    split
-    split
-    split
-    split
-    tabnew
-  END
-  call writefile(lines, 'Xwinminheight', 'D')
-  let buf = RunVimInTerminal('-S Xwinminheight', #{rows: 11})
-  call term_sendkeys(buf, ":set wmh=1\n")
-  call WaitForAssert({-> assert_match('E36: Not enough room', term_getline(buf, 11))})
-
-  call StopVimInTerminal(buf)
-endfunc
-
-" Test for the 'winminwidth' option
-func Test_opt_winminwidth()
-  only!
-  let &winwidth = &columns + 4
-  call assert_fails('let &winminwidth = &columns + 2', 'E36:')
-  call assert_true(&winminwidth <= &columns)
-  set winminwidth&
-  set winwidth&
-endfunc
-
-" Test for setting option value containing spaces with isfname+=32
-func Test_isfname_with_options()
-  set isfname+=32
-  setlocal keywordprg=:term\ help.exe
-  call assert_equal(':term help.exe', &keywordprg)
-  set isfname&
-  setlocal keywordprg&
-endfunc
-
-" Test that resetting laststatus does change scroll option
-func Test_opt_reset_scroll()
-  CheckRunVimInTerminal
-  let vimrc =<< trim [CODE]
-    set scroll=2
-    set laststatus=2
-  [CODE]
-  call writefile(vimrc, 'Xscroll', 'D')
-  let buf = RunVimInTerminal('-S Xscroll', {'rows': 16, 'cols': 45})
-  call term_sendkeys(buf, ":verbose set scroll?\n")
-  call WaitForAssert({-> assert_match('Last set.*window size', term_getline(buf, 15))})
-  call assert_match('^\s*scroll=7$', term_getline(buf, 14))
-
-  " clean up
-  call StopVimInTerminal(buf)
-endfunc
-
 " Check that VIM_POSIX env variable influences default value of 'cpo' and 'shm'
-func Test_VIM_POSIX()
+func Test_env_VIM_POSIX()
   let saved_VIM_POSIX = getenv("VIM_POSIX")
 
   call setenv('VIM_POSIX', "1")
@@ -1746,92 +2145,6 @@ func Test_VIM_POSIX()
   call setenv('VIM_POSIX', saved_VIM_POSIX)
 endfunc
 
-" Test for setting an option to a Vi or Vim default
-func Test_opt_default()
-  set formatoptions&vi
-  call assert_equal('vt', &formatoptions)
-  set formatoptions&vim
-  call assert_equal('tcq', &formatoptions)
-
-  call assert_equal('ucs-bom,utf-8,default,latin1', &fencs)
-  set fencs=latin1
-  set fencs&
-  call assert_equal('ucs-bom,utf-8,default,latin1', &fencs)
-  set fencs=latin1
-  set all&
-  call assert_equal('ucs-bom,utf-8,default,latin1', &fencs)
-endfunc
-
-" Test for the 'cmdheight' option
-func Test_cmdheight()
-  %bw!
-  let ht = &lines
-  set cmdheight=9999
-  call assert_equal(1, winheight(0))
-  call assert_equal(ht - 1, &cmdheight)
-  set cmdheight&
-endfunc
-
-" To specify a control character as an option value, '^' can be used
-func Test_opt_control_char()
-  set wildchar=^v
-  call assert_equal("\<C-V>", nr2char(&wildchar))
-  set wildcharm=^r
-  call assert_equal("\<C-R>", nr2char(&wildcharm))
-  " Bug: This doesn't work for the 'cedit' and 'termwinkey' options
-  set wildchar& wildcharm&
-endfunc
-
-" Test for the 'errorbells' option
-func Test_opt_errorbells()
-  set errorbells
-  call assert_beeps('s/a1b2/x1y2/')
-  set noerrorbells
-endfunc
-
-func Test_opt_scrolljump()
-  help
-  resize 10
-
-  " Test with positive 'scrolljump'.
-  set scrolljump=2
-  norm! Lj
-  call assert_equal({'lnum':11, 'leftcol':0, 'col':0, 'topfill':0,
-        \            'topline':3, 'coladd':0, 'skipcol':0, 'curswant':0},
-        \           winsaveview())
-
-  " Test with negative 'scrolljump' (percentage of window height).
-  set scrolljump=-40
-  norm! ggLj
-  call assert_equal({'lnum':11, 'leftcol':0, 'col':0, 'topfill':0,
-         \            'topline':5, 'coladd':0, 'skipcol':0, 'curswant':0},
-         \           winsaveview())
-
-  set scrolljump&
-  bw
-endfunc
-
-" Test for the 'cdhome' option
-func Test_opt_cdhome()
-  if has('unix') || has('vms')
-    throw 'Skipped: only works on non-Unix'
-  endif
-
-  set cdhome&
-  call assert_equal(0, &cdhome)
-  set cdhome
-
-  " This paragraph is copied from Test_cd_no_arg().
-  let path = getcwd()
-  cd
-  call assert_equal($HOME, getcwd())
-  call assert_notequal(path, getcwd())
-  exe 'cd ' .. fnameescape(path)
-  call assert_equal(path, getcwd())
-
-  set cdhome&
-endfunc
-
 func Test_set_completion_fuzzy()
   CheckOption termguicolors
 
@@ -1852,81 +2165,6 @@ func Test_set_completion_fuzzy()
   call assert_equal('"set notermguicolors', @:)
 
   set wildoptions=
-endfunc
-
-func Test_switchbuf_reset()
-  set switchbuf=useopen
-  sblast
-  call assert_equal(1, winnr('$'))
-  set all&
-  call assert_equal('', &switchbuf)
-  sblast
-  call assert_equal(2, winnr('$'))
-  only!
-endfunc
-
-" :set empty string for global 'keywordprg' falls back to ":help"
-func Test_keywordprg_empty()
-  let k = &keywordprg
-  set keywordprg=man
-  call assert_equal('man', &keywordprg)
-  set keywordprg=
-  call assert_equal(':help', &keywordprg)
-  set keywordprg=man
-  call assert_equal('man', &keywordprg)
-  call assert_equal("\n  keywordprg=:help", execute('set kp= kp?'))
-  let &keywordprg = k
-endfunc
-
-" check that the very first buffer created does not have 'endoffile' set
-func Test_endoffile_default()
-  let after =<< trim [CODE]
-    call writefile([execute('set eof?')], 'Xtestout')
-    qall!
-  [CODE]
-  if RunVim([], after, '')
-    call assert_equal(["\nnoendoffile"], readfile('Xtestout'))
-  endif
-  call delete('Xtestout')
-endfunc
-
-" Test for setting the 'lines' and 'columns' options to a minimum value
-func Test_set_min_lines_columns()
-  let save_lines = &lines
-  let save_columns = &columns
-
-  let after =<< trim END
-    set nomore
-    let msg = []
-    let v:errmsg = ''
-    silent! let &columns=0
-    call add(msg, v:errmsg)
-    silent! set columns=0
-    call add(msg, v:errmsg)
-    silent! call setbufvar('', '&columns', 0)
-    call add(msg, v:errmsg)
-    "call writefile(msg, 'XResultsetminlines')
-    silent! let &lines=0
-    call add(msg, v:errmsg)
-    silent! set lines=0
-    call add(msg, v:errmsg)
-    silent! call setbufvar('', '&lines', 0)
-    call add(msg, v:errmsg)
-    call writefile(msg, 'XResultsetminlines')
-    qall!
-  END
-  if RunVim([], after, '')
-    call assert_equal(['E594: Need at least 12 columns',
-          \ 'E594: Need at least 12 columns: columns=0',
-          \ 'E594: Need at least 12 columns',
-          \ 'E593: Need at least 2 lines',
-          \ 'E593: Need at least 2 lines: lines=0',
-          \ 'E593: Need at least 2 lines',], readfile('XResultsetminlines'))
-  endif
-
-  call delete('XResultsetminlines')
-  let &lines = save_lines
-  let &columns = save_columns
 endfunc
 
 " Test for reverting a string option value if the new value is invalid.
@@ -2163,147 +2401,6 @@ func Test_set_option_window_global_local_all()
     exe 'let &g:' .. opt .. '=' .. default
   endfor
   bw!
-endfunc
-
-func Test_paste_depending_options()
-  " setting the paste option, resets all dependent options
-  " and will be reported correctly using :verbose set <option>?
-  let lines =<< trim [CODE]
-    " set paste test
-    set autoindent
-    set expandtab
-    " disabled, because depends on compiled feature set
-    " set hkmap
-    " set revins
-    " set varsofttabstop=8,32,8
-    set ruler
-    set showmatch
-    set smarttab
-    set softtabstop=4
-    set textwidth=80
-    set wrapmargin=10
-
-    source Xvimrc_paste2
-
-    redir > Xoutput_paste
-    verbose set expandtab?
-    verbose setg expandtab?
-    verbose setl expandtab?
-    redir END
-
-    qall!
-  [CODE]
-
-  call writefile(lines, 'Xvimrc_paste', 'D')
-  call writefile(['set paste'], 'Xvimrc_paste2', 'D')
-  if !RunVim([], lines, '--clean')
-    return
-  endif
-
-  let result = readfile('Xoutput_paste')->filter('!empty(v:val)')
-  call assert_equal('noexpandtab', result[0])
-  call assert_match("^\tLast set from .*Xvimrc_paste2 line 1$", result[1])
-  call assert_equal('noexpandtab', result[2])
-  call assert_match("^\tLast set from .*Xvimrc_paste2 line 1$", result[3])
-  call assert_equal('noexpandtab', result[4])
-  call assert_match("^\tLast set from .*Xvimrc_paste2 line 1$", result[5])
-
-  call delete('Xoutput_paste')
-endfunc
-
-func Test_binary_depending_options()
-  " setting the paste option, resets all dependent options
-  " and will be reported correctly using :verbose set <option>?
-  let lines =<< trim [CODE]
-    " set binary test
-    set expandtab
-
-    source Xvimrc_bin2
-
-    redir > Xoutput_bin
-    verbose set expandtab?
-    verbose setg expandtab?
-    verbose setl expandtab?
-    redir END
-
-    qall!
-  [CODE]
-
-  call writefile(lines, 'Xvimrc_bin', 'D')
-  call writefile(['set binary'], 'Xvimrc_bin2', 'D')
-  if !RunVim([], lines, '--clean')
-    return
-  endif
-
-  let result = readfile('Xoutput_bin')->filter('!empty(v:val)')
-  call assert_equal('noexpandtab', result[0])
-  call assert_match("^\tLast set from .*Xvimrc_bin2 line 1$", result[1])
-  call assert_equal('noexpandtab', result[2])
-  call assert_match("^\tLast set from .*Xvimrc_bin2 line 1$", result[3])
-  call assert_equal('noexpandtab', result[4])
-  call assert_match("^\tLast set from .*Xvimrc_bin2 line 1$", result[5])
-
-  call delete('Xoutput_bin')
-endfunc
-
-func Test_set_keyprotocol()
-  CheckNotGui
-
-  let term = &term
-  set term=ansi
-  call assert_equal('', &t_TI)
-
-  " Setting 'keyprotocol' should affect terminal codes without needing to
-  " reset 'term'
-  set keyprotocol+=ansi:kitty
-  call assert_equal("\<Esc>[=1;1u", &t_TI)
-  let &term = term
-endfunc
-
-func Test_set_wrap()
-  " Unsetting 'wrap' when 'smoothscroll' is set does not result in incorrect
-  " cursor position.
-  set wrap smoothscroll scrolloff=5
-
-  call setline(1, ['', 'aaaa'->repeat(500)])
-  20 split
-  20 vsplit
-  norm 2G$
-  redraw
-  set nowrap
-  call assert_equal(2, winline())
-
-  set wrap& smoothscroll& scrolloff&
-endfunc
-
-func Test_delcombine()
-  new
-  set backspace=indent,eol,start
-
-  set delcombine
-  call setline(1, 'β̳̈:β̳̈')
-  normal! 0x
-  call assert_equal('β̈:β̳̈', getline(1))
-  exe "normal! A\<BS>"
-  call assert_equal('β̈:β̈', getline(1))
-  normal! 0x
-  call assert_equal('β:β̈', getline(1))
-  exe "normal! A\<BS>"
-  call assert_equal('β:β', getline(1))
-  normal! 0x
-  call assert_equal(':β', getline(1))
-  exe "normal! A\<BS>"
-  call assert_equal(':', getline(1))
-
-  set nodelcombine
-  call setline(1, 'β̳̈:β̳̈')
-  normal! 0x
-  call assert_equal(':β̳̈', getline(1))
-  exe "normal! A\<BS>"
-  call assert_equal(':', getline(1))
-
-  set backspace& delcombine&
-  bwipe!
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_set.vim
+++ b/src/testdir/test_set.vim
@@ -18,17 +18,6 @@ function Test_set_backslash()
   let &isk = isk_save
 endfunction
 
-function Test_set_add()
-  let wig_save = &wig
-
-  set wildignore=*.png,
-  set wildignore+=*.jpg
-  call assert_equal('*.png,*.jpg', &wig)
-
-  let &wig = wig_save
-endfunction
-
-
 " :set, :setlocal, :setglobal without arguments show values of options.
 func Test_set_no_arg()
   set textwidth=79
@@ -47,6 +36,29 @@ func Test_set_no_arg()
   setglobal textwidth&
 endfunc
 
+" Test for :set all
+func Test_set_all()
+  set tw=75
+  set iskeyword=a-z,A-Z
+  set nosplitbelow
+  let out = execute('set all')
+  call assert_match('textwidth=75', out)
+  call assert_match('iskeyword=a-z,A-Z', out)
+  call assert_match('nosplitbelow', out)
+  set tw& iskeyword& splitbelow&
+endfunc
+
+" Test for :set! all
+func Test_set_all_one_column()
+  let out_mult = execute('set all')->split("\n")
+  let out_one = execute('set! all')->split("\n")
+  call assert_true(len(out_mult) < len(out_one))
+  call assert_equal(out_one[0], '--- Options ---')
+  let options = out_one[1:]->mapnew({_, line -> line[2:]})
+  call assert_equal(sort(copy(options)), options)
+endfunc
+
+" Test for :set termcap
 func Test_set_termcap()
   CheckNotGui
 
@@ -73,6 +85,522 @@ func Test_set_termcap()
   call assert_true(i < len(more_lines))
   call assert_true(i > keys_idx)
   call assert_true(len(more_lines) - i > len(lines) - keys_idx)
+endfunc
+
+" Test for setting string option value
+func Test_set_string_option()
+  " :set {option}=
+  set makeprg=
+  call assert_equal('', &mp)
+  set makeprg=abc
+  call assert_equal('abc', &mp)
+
+  " :set {option}:
+  set makeprg:
+  call assert_equal('', &mp)
+  set makeprg:abc
+  call assert_equal('abc', &mp)
+
+  " Let string
+  let &makeprg = ''
+  call assert_equal('', &mp)
+  let &makeprg = 'abc'
+  call assert_equal('abc', &mp)
+
+  " Let number
+  let &makeprg = 42
+  call assert_equal('42', &mp)
+
+  " Appending
+  set makeprg=abc
+  set makeprg+=def
+  call assert_equal('abcdef', &mp)
+  set makeprg+=def
+  call assert_equal('abcdefdef', &mp, ':set+= appends a value even if it already contained')
+  let &makeprg .= 'gh'
+  call assert_equal('abcdefdefgh', &mp)
+  let &makeprg ..= 'ij'
+  call assert_equal('abcdefdefghij', &mp)
+
+  " Removing
+  set makeprg=abcdefghi
+  set makeprg-=def
+  call assert_equal('abcghi', &mp)
+  set makeprg-=def
+  call assert_equal('abcghi', &mp, ':set-= does not remove a value if it is not contained')
+
+  " Prepending
+  set makeprg=abc
+  set makeprg^=def
+  call assert_equal('defabc', &mp)
+  set makeprg^=def
+  call assert_equal('defdefabc', &mp, ':set+= prepends a value even if it already contained')
+
+  set makeprg&
+endfunc
+
+" Test for setting comma-separated list option value
+func Test_set_list_option()
+  " :set {option}=
+  set tags=
+  call assert_equal('', &tags)
+  set tags=abc
+  call assert_equal('abc', &tags)
+
+  " :set {option}:
+  set tags:
+  call assert_equal('', &tags)
+  set tags:abc
+  call assert_equal('abc', &tags)
+
+  " Let string
+  let &tags = ''
+  call assert_equal('', &tags)
+  let &tags = 'abc'
+  call assert_equal('abc', &tags)
+
+  " Let number
+  let &tags = 42
+  call assert_equal('42', &tags)
+
+  " Appending
+  set tags=abc
+  set tags+=def
+  call assert_equal('abc,def', &tags, ':set+= prepends a comma to append a value')
+  set tags+=def
+  call assert_equal('abc,def', &tags, ':set+= does not append a value if it already contained')
+  set tags+=ef
+  call assert_equal('abc,def,ef', &tags, ':set+= prepends a comma to append a value if it is not exactly match to item')
+  let &tags .= 'gh'
+  call assert_equal('abc,def,efgh', &tags, ':let-& .= appends a value without a comma')
+  let &tags ..= 'ij'
+  call assert_equal('abc,def,efghij', &tags, ':let-& ..= appends a value without a comma')
+
+  " Removing
+  set tags=abc,def,ghi
+  set tags-=def
+  call assert_equal('abc,ghi', &tags)
+  set tags-=def
+  call assert_equal('abc,ghi', &tags, ':set-= does not remove a value if it is not contained')
+  set tags-=bc
+  call assert_equal('abc,ghi', &tags, ':set-= does not remove a value if it is not exactly match to item')
+
+  " Prepending
+  set tags=abc
+  set tags^=def
+  call assert_equal('def,abc', &tags)
+  set tags^=def
+  call assert_equal('def,abc', &tags, ':set+= does not prepend a value if it already contained')
+  set tags^=ef
+  call assert_equal('ef,def,abc', &tags, ':set+= prepend a value if it is not exactly match to item')
+
+  set tags&
+endfunc
+
+" Test for setting flags option value
+func Test_set_flags_option()
+  " :set {option}=
+  set formatoptions=
+  call assert_equal('', &fo)
+  set formatoptions=abc
+  call assert_equal('abc', &fo)
+
+  " :set {option}:
+  set formatoptions:
+  call assert_equal('', &fo)
+  set formatoptions:abc
+  call assert_equal('abc', &fo)
+
+  " Let string
+  let &formatoptions = ''
+  call assert_equal('', &fo)
+  let &formatoptions = 'abc'
+  call assert_equal('abc', &fo)
+
+  " Let number
+  let &formatoptions = 12
+  call assert_equal('12', &fo)
+
+  " Appending
+  set formatoptions=abc
+  set formatoptions+=pqr
+  call assert_equal('abcpqr', &fo)
+  set formatoptions+=pqr
+  call assert_equal('abcpqr', &fo, ':set+= does not append a value if it already contained')
+  let &formatoptions .= 'r'
+  call assert_equal('abcpqrr', &fo, ':let-& .= appends a value even if it already contained')
+  let &formatoptions ..= 'r'
+  call assert_equal('abcpqrrr', &fo, ':let-& ..= appends a value even if it already contained')
+
+  " Removing
+  set formatoptions=abcpqr
+  set formatoptions-=cp
+  call assert_equal('abqr', &fo)
+  set formatoptions-=cp
+  call assert_equal('abqr', &fo, ':set-= does not remove a value if it is not contained')
+  set formatoptions-=ar
+  call assert_equal('abqr', &fo, ':set-= does not remove a value if it is not exactly match')
+
+  " Prepending
+  set formatoptions=abc
+  set formatoptions^=pqr
+  call assert_equal('pqrabc', &fo)
+  set formatoptions^=qr
+  call assert_equal('pqrabc', &fo, ':set+= does not prepend a value if it already contained')
+
+  set formatoptions&
+endfunc
+
+" Test for setting number option value
+func Test_set_number_option()
+  " :set {option}=
+  set scrolljump=5
+  call assert_equal(5, &sj)
+  set scrolljump=-3
+  call assert_equal(-3, &sj)
+
+  " :set {option}:
+  set scrolljump:7
+  call assert_equal(7, &sj)
+  set scrolljump:-5
+  call assert_equal(-5, &sj)
+
+  " Set hex
+  set scrolljump=0x10
+  call assert_equal(16, &sj)
+  set scrolljump=-0x10
+  call assert_equal(-16, &sj)
+  set scrolljump=0X12
+  call assert_equal(18, &sj)
+  set scrolljump=-0X12
+  call assert_equal(-18, &sj)
+
+  " Set octal
+  set scrolljump=010
+  call assert_equal(8, &sj)
+  set scrolljump=-010
+  call assert_equal(-8, &sj)
+  set scrolljump=0o12
+  call assert_equal(10, &sj)
+  set scrolljump=-0o12
+  call assert_equal(-10, &sj)
+  set scrolljump=0O15
+  call assert_equal(13, &sj)
+  set scrolljump=-0O15
+  call assert_equal(-13, &sj)
+
+  " Let number
+  let &scrolljump = 4
+  call assert_equal(4, &sj)
+  let &scrolljump = -6
+  call assert_equal(-6, &sj)
+
+  " Let string
+  let &scrolljump = '7'
+  call assert_equal(7, &sj)
+  let &scrolljump = '-9'
+  call assert_equal(-9, &sj)
+
+  " Incrementing
+  set shiftwidth=4
+  set shiftwidth+=2
+  call assert_equal(6, &sw)
+  let &shiftwidth += 2
+  call assert_equal(8, &sw)
+
+  " Decrementing
+  set shiftwidth=6
+  set shiftwidth-=2
+  call assert_equal(4, &sw)
+  let &shiftwidth -= 2
+  call assert_equal(2, &sw)
+
+  " Multiplying
+  set shiftwidth=4
+  set shiftwidth^=2
+  call assert_equal(8, &sw)
+  let &shiftwidth *= 2
+  call assert_equal(16, &sw)
+
+  set scrolljump&
+  set shiftwidth&
+endfunc
+
+" Test for setting boolean option value
+func Test_set_boolean_option()
+  set number&
+
+  " :set {option}
+  set number
+  call assert_equal(1, &nu)
+
+  " :set no{option}
+  set nonu
+  call assert_equal(0, &nu)
+
+  " :set {option}!
+  set number!
+  call assert_equal(1, &nu)
+  set number!
+  call assert_equal(0, &nu)
+
+  " :set inv{option}
+  set invnumber
+  call assert_equal(1, &nu)
+  set invnumber
+  call assert_equal(0, &nu)
+
+  " Let number
+  let &number = 1
+  call assert_equal(1, &nu)
+  let &number = 0
+  call assert_equal(0, &nu)
+
+  " Let string
+  let &number = '1'
+  call assert_equal(1, &nu)
+  let &number = '0'
+  call assert_equal(0, &nu)
+
+  " Let v:true and v:false
+  let &number = v:true
+  call assert_equal(1, &nu)
+  let &number = v:false
+  call assert_equal(0, &nu)
+
+  set number&
+endfunc
+
+" Test for setting string option errors
+func Test_set_string_option_errors()
+  " :set no{option}
+  call assert_fails('set notabstop', 'E474:')
+  call assert_fails('setlocal notabstop', 'E474:')
+  call assert_fails('setglobal notabstop', 'E474:')
+
+  " :set inv{option}
+  call assert_fails('set invtabstop', 'E474:')
+  call assert_fails('setlocal invtabstop', 'E474:')
+  call assert_fails('setglobal invtabstop', 'E474:')
+
+  " :set {option}!
+  call assert_fails('set makeprg!', 'E488:')
+  call assert_fails('setlocal makeprg!', 'E488:')
+  call assert_fails('setglobal makeprg!', 'E488:')
+
+  " Invalid trailing chars
+  call assert_fails('set makeprg??', 'E488:')
+  call assert_fails('setlocal makeprg??', 'E488:')
+  call assert_fails('setglobal makeprg??', 'E488:')
+  call assert_fails('set makeprg&&', 'E488:')
+  call assert_fails('setlocal makeprg&&', 'E488:')
+  call assert_fails('setglobal makeprg&&', 'E488:')
+  call assert_fails('set makeprg<<', 'E488:')
+  call assert_fails('setlocal makeprg<<', 'E488:')
+  call assert_fails('setglobal makeprg<<', 'E488:')
+  call assert_fails('set makeprg@', 'E488:')
+  call assert_fails('setlocal makeprg@', 'E488:')
+  call assert_fails('setglobal makeprg@', 'E488:')
+endfunc
+
+" Test for setting number option errors
+func Test_set_number_option_errors()
+  " :set no{option}
+  call assert_fails('set notabstop', 'E474:')
+  call assert_fails('setlocal notabstop', 'E474:')
+  call assert_fails('setglobal notabstop', 'E474:')
+
+  " :set inv{option}
+  call assert_fails('set invtabstop', 'E474:')
+  call assert_fails('setlocal invtabstop', 'E474:')
+  call assert_fails('setglobal invtabstop', 'E474:')
+
+  " :set {option}!
+  call assert_fails('set tabstop!', 'E488:')
+  call assert_fails('setlocal tabstop!', 'E488:')
+  call assert_fails('setglobal tabstop!', 'E488:')
+
+  " Invalid trailing chars
+  call assert_fails('set tabstop??', 'E488:')
+  call assert_fails('setlocal tabstop??', 'E488:')
+  call assert_fails('setglobal tabstop??', 'E488:')
+  call assert_fails('set tabstop&&', 'E488:')
+  call assert_fails('setlocal tabstop&&', 'E488:')
+  call assert_fails('setglobal tabstop&&', 'E488:')
+  call assert_fails('set tabstop<<', 'E488:')
+  call assert_fails('setlocal tabstop<<', 'E488:')
+  call assert_fails('setglobal tabstop<<', 'E488:')
+  call assert_fails('set tabstop@', 'E488:')
+  call assert_fails('setlocal tabstop@', 'E488:')
+  call assert_fails('setglobal tabstop@', 'E488:')
+
+  " Not a number
+  call assert_fails('set tabstop=', 'E521:')
+  call assert_fails('setlocal tabstop=', 'E521:')
+  call assert_fails('setglobal tabstop=', 'E521:')
+  call assert_fails('set tabstop=x', 'E521:')
+  call assert_fails('setlocal tabstop=x', 'E521:')
+  call assert_fails('setglobal tabstop=x', 'E521:')
+  call assert_fails('set tabstop=1x', 'E521:')
+  call assert_fails('setlocal tabstop=1x', 'E521:')
+  call assert_fails('setglobal tabstop=1x', 'E521:')
+  call assert_fails('set tabstop=-x', 'E521:')
+  call assert_fails('setlocal tabstop=-x', 'E521:')
+  call assert_fails('setglobal tabstop=-x', 'E521:')
+  call assert_fails('set tabstop=0x', 'E521:')
+  call assert_fails('setlocal tabstop=0x', 'E521:')
+  call assert_fails('setglobal tabstop=0x', 'E521:')
+  call assert_fails('set tabstop=0o', 'E521:')
+  call assert_fails('setlocal tabstop=0o', 'E521:')
+  call assert_fails('setglobal tabstop=0o', 'E521:')
+  call assert_fails("let &tabstop = 'x'", 'E521:')
+  call assert_fails("let &g:tabstop = 'x'", 'E521:')
+  call assert_fails("let &l:tabstop = 'x'", 'E521:')
+endfunc
+
+" Test for setting boolean option errors
+func Test_set_boolean_option_errors()
+  " :set {option}=
+  call assert_fails('set number=', 'E474:')
+  call assert_fails('setlocal number=', 'E474:')
+  call assert_fails('setglobal number=', 'E474:')
+  call assert_fails('set number=1', 'E474:')
+  call assert_fails('setlocal number=1', 'E474:')
+  call assert_fails('setglobal number=1', 'E474:')
+
+  " :set {option}:
+  call assert_fails('set number:', 'E474:')
+  call assert_fails('setlocal number:', 'E474:')
+  call assert_fails('setglobal number:', 'E474:')
+  call assert_fails('set number:1', 'E474:')
+  call assert_fails('setlocal number:1', 'E474:')
+  call assert_fails('setglobal number:1', 'E474:')
+
+  " :set {option}+=
+  call assert_fails('set number+=1', 'E474:')
+  call assert_fails('setlocal number+=1', 'E474:')
+  call assert_fails('setglobal number+=1', 'E474:')
+
+  " :set {option}^=
+  call assert_fails('set number^=1', 'E474:')
+  call assert_fails('setlocal number^=1', 'E474:')
+  call assert_fails('setglobal number^=1', 'E474:')
+
+  " :set {option}-=
+  call assert_fails('set number-=1', 'E474:')
+  call assert_fails('setlocal number-=1', 'E474:')
+  call assert_fails('setglobal number-=1', 'E474:')
+
+  " Invalid trailing chars
+  call assert_fails('set number!!', 'E488:')
+  call assert_fails('setlocal number!!', 'E488:')
+  call assert_fails('setglobal number!!', 'E488:')
+  call assert_fails('set number??', 'E488:')
+  call assert_fails('setlocal number??', 'E488:')
+  call assert_fails('setglobal number??', 'E488:')
+  call assert_fails('set number&&', 'E488:')
+  call assert_fails('setlocal number&&', 'E488:')
+  call assert_fails('setglobal number&&', 'E488:')
+  call assert_fails('set number<<', 'E488:')
+  call assert_fails('setlocal number<<', 'E488:')
+  call assert_fails('setglobal number<<', 'E488:')
+  call assert_fails('set number@', 'E488:')
+  call assert_fails('setlocal number@', 'E488:')
+  call assert_fails('setglobal number@', 'E488:')
+endfunc
+
+" Test for setting unknown option errors
+func Test_set_unknown_option_error()
+  call assert_fails('set xxx', 'E518:')
+  call assert_fails('setlocal xxx', 'E518:')
+  call assert_fails('setglobal xxx', 'E518:')
+  call assert_fails('set xxx=', 'E518:')
+  call assert_fails('setlocal xxx=', 'E518:')
+  call assert_fails('setglobal xxx=', 'E518:')
+  call assert_fails('set xxx:', 'E518:')
+  call assert_fails('setlocal xxx:', 'E518:')
+  call assert_fails('setglobal xxx:', 'E518:')
+  call assert_fails('set xxx!', 'E518:')
+  call assert_fails('setlocal xxx!', 'E518:')
+  call assert_fails('setglobal xxx!', 'E518:')
+  call assert_fails('set xxx?', 'E518:')
+  call assert_fails('setlocal xxx?', 'E518:')
+  call assert_fails('setglobal xxx?', 'E518:')
+  call assert_fails('set xxx&', 'E518:')
+  call assert_fails('setlocal xxx&', 'E518:')
+  call assert_fails('setglobal xxx&', 'E518:')
+  call assert_fails('set xxx<', 'E518:')
+  call assert_fails('setlocal xxx<', 'E518:')
+  call assert_fails('setglobal xxx<', 'E518:')
+endfunc
+
+" Test for setting an option to a Vi or Vim default
+func Test_set_default()
+  set formatoptions&vi
+  call assert_equal('vt', &formatoptions)
+  set formatoptions&vim
+  call assert_equal('tcq', &formatoptions)
+
+  call assert_equal('ucs-bom,utf-8,default,latin1', &fencs)
+  set fencs=latin1
+  set fencs&
+  call assert_equal('ucs-bom,utf-8,default,latin1', &fencs)
+  set fencs=latin1
+  set all&
+  call assert_equal('ucs-bom,utf-8,default,latin1', &fencs)
+endfunc
+
+" Test for setting options in sandbox
+func Test_set_in_sandbox()
+  " Some boolean options cannot be set in sandbox, some can.
+  call assert_fails('sandbox set modelineexpr', 'E48:')
+  sandbox set number
+  call assert_true(&number)
+  set number&
+
+  " Some number options cannot be set in sandbox, some can.
+  if has('python') || has('python3')
+    call assert_fails('sandbox set pyxversion=3', 'E48:')
+  endif
+  sandbox set tabstop=4
+  call assert_equal(4, &tabstop)
+  set tabstop&
+
+  " Some string options cannot be set in sandbox, some can.
+  call assert_fails('sandbox set backupdir=/tmp', 'E48:')
+  sandbox set filetype=perl
+  call assert_equal('perl', &filetype)
+  set filetype&
+endfunc
+
+" Test for setting keycodes using set
+func Test_set_keycode()
+  call assert_fails('set <t_k1=l', 'E474:')
+  call assert_fails('set <Home=l', 'E474:')
+  set <t_k9>=abcd
+  call assert_equal('abcd', &t_k9)
+  set <t_k9>&
+  set <F9>=xyz
+  call assert_equal('xyz', &t_k9)
+  set <t_k9>&
+
+  " Not found in termcap
+  call assert_fails('set t_#-&', 'E522:')
+
+  " Keycode not set
+  call assert_fails('set t_foo=', 'E846:')
+
+  " should we test all of them?
+  set t_Ce=testCe
+  set t_Cs=testCs
+  set t_Us=testUs
+  set t_ds=testds
+  set t_Ds=testDs
+  call assert_equal('testCe', &t_Ce)
+  call assert_equal('testCs', &t_Cs)
+  call assert_equal('testUs', &t_Us)
+  call assert_equal('testds', &t_ds)
+  call assert_equal('testDs', &t_Ds)
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
- Moved tests for `:set` to test_set.vim.
- Added comprehensive test patterns.
- Split up long errors test into separate tests for each options.
- Reordering option tests alphabetically.