### PR TITLE
Add missing filetype for PHP config files 

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1800,7 +1800,7 @@ au BufNewFile,BufRead *.pod			setf pod
 au BufNewFile,BufRead *.php,*.php\d,*.phtml,*.ctp,*.phpt,*.theme	setf php
 
 " PHP config
-au BufNewFile,BufRead php.ini-*, php-fpm.conf*, www.conf*	setf dosini
+au BufNewFile,BufRead php.ini-*,php-fpm.conf*,www.conf*		setf dosini
 
 " Pike and Cmod
 au BufNewFile,BufRead *.pike,*.pmod		setf pike

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1800,7 +1800,7 @@ au BufNewFile,BufRead *.pod			setf pod
 au BufNewFile,BufRead *.php,*.php\d,*.phtml,*.ctp,*.phpt,*.theme	setf php
 
 " PHP config
-au BufNewFile,BufRead php.ini-*			setf dosini
+au BufNewFile,BufRead php.ini-*, php-fpm.conf*, www.conf*	setf dosini
 
 " Pike and Cmod
 au BufNewFile,BufRead *.pike,*.pmod		setf pike

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -217,7 +217,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     dockerfile: ['Containerfile', 'Dockerfile', 'dockerfile', 'file.Dockerfile', 'file.dockerfile', 'Dockerfile.debian', 'Containerfile.something'],
     dosbatch: ['file.bat'],
     dosini: ['/etc/yum.conf', '/etc/nfs.conf', '/etc/nfsmount.conf', 'file.ini',
-             'npmrc', '.npmrc', 'php.ini', 'php.ini-5', 'php.ini-file',
+             'npmrc', '.npmrc', 'php.ini', 'php.ini-5', 'php.ini-file', 'php-fpm.conf', 'php-fpm.conf.default', 'www.conf', 'www.conf.default',
              '/etc/yum.repos.d/file', 'any/etc/yum.conf', 'any/etc/yum.repos.d/file', 'file.wrap',
              'file.vbp', 'ja2.ini', 'JA2.INI', 'mimeapps.list', 'pip.conf', 'setup.cfg', 'pudb.cfg',
              '.coveragerc', '.pypirc', '.gitlint', '.oelint.cfg', 'pylintrc', '.pylintrc',


### PR DESCRIPTION
This PR covers the following files distributed in the upstream tarball
```bash
/usr/local/php/etc/
├── php-fpm.conf
├── php-fpm.conf.default
└── php-fpm.d
    ├── www.conf
    └── www.conf.default
```
They are written in dosini, but currently don’t get parsed as such because they don’t use the `.ini` extension.