### PR TITLE
fix: do not close pum on <BS> using `complete()`

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -1916,7 +1916,6 @@ ins_compl_bs(void)
     // Respect the 'backspace' option.
     if ((int)(p - line) - (int)compl_col < 0
 	    || ((int)(p - line) - (int)compl_col == 0 && !ctrl_x_mode_omni())
-	    || ctrl_x_mode_eval()
 	    || (!can_bs(BS_START) && (int)(p - line) - (int)compl_col
 							- compl_length < 0))
 	return K_BS;

--- a/src/testdir/test_popup.vim
+++ b/src/testdir/test_popup.vim
@@ -51,16 +51,15 @@ func Test_popup_complete()
   call assert_equal(["August"], getline(1,2))
   %d
 
-  " <BS> - Delete one character from the inserted text (state: 1)
-  " TODO: This should not end the completion, but it does.
-  " This should according to the documentation:
-  " January
-  " but instead, this does
-  " Januar
-  " (idea is, C-L inserts the match from the popup menu
-  " but if the menu is closed, it will insert the character <c-l>
+  " C-L inserts the match from the popup menu
   call feedkeys("aJ\<f5>\<bs>\<c-l>\<esc>", 'tx')
-  call assert_equal(["Januar"], getline(1,2))
+  call assert_equal(["January"], getline(1,2))
+  %d
+
+  " C-L and a <bs> back to `J`, and then select next item from completion
+  " menu which should still be open
+  call feedkeys("aJ\<f5>\<bs>\<bs>\<bs>\<bs>\<bs>\<bs>\<c-n>\<c-y>\<esc>", 'tx')
+  call assert_equal(["June"], getline(1,2))
   %d
 
   " any-non special character: Stop completion without changing the match


### PR DESCRIPTION
Closes #15833 