### PR TITLE
`writefile`: optionally update the corresponding buffer's `mtime`

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -12417,6 +12417,10 @@ writefile({object}, {fname} [, {flags}])			*writefile()*
 		     When {flags} does not contain "S" or "s" then fsync() is
 		     called if the 'fsync' option is set.
 
+		't'  if the {fname} corresponds to a buffer, update that buffer's
+		     modified time so future writes to the buffer don't think there's
+		     changes outside of Vim.
+
 		An existing file is overwritten, if possible.
 
 		When the write fails -1 is returned, otherwise 0.  There is an

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -38,7 +38,6 @@ static void	buflist_getfpos(void);
 static char_u	*buflist_match(regmatch_T *rmp, buf_T *buf, int ignore_case);
 static char_u	*fname_match(regmatch_T *rmp, char_u *name, int ignore_case);
 #ifdef UNIX
-static buf_T	*buflist_findname_stat(char_u *ffname, stat_T *st);
 static int	otherfile_buf(buf_T *buf, char_u *ffname, stat_T *stp);
 static int	buf_same_ino(buf_T *buf, stat_T *stp);
 #else
@@ -2656,7 +2655,7 @@ buflist_findname(char_u *ffname)
  * twice for the same file.
  * Returns NULL if not found.
  */
-    static buf_T *
+    buf_T *
 buflist_findname_stat(
     char_u	*ffname,
     stat_T	*stp)

--- a/src/bufwrite.c
+++ b/src/bufwrite.c
@@ -2580,9 +2580,7 @@ nofail:
 	    // prompt when writing again.
 	    if (mch_stat((char *)fname, &st_old) >= 0)
 	    {
-		buf_store_time(buf, &st_old, fname);
-		buf->b_mtime_read = buf->b_mtime;
-		buf->b_mtime_read_ns = buf->b_mtime_ns;
+		buf_store_time(buf, &st_old, fname, TRUE);
 	    }
 	}
     }

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -422,9 +422,7 @@ readfile(
 	// Remember time of file.
 	if (mch_stat((char *)fname, &st) >= 0)
 	{
-	    buf_store_time(curbuf, &st, fname);
-	    curbuf->b_mtime_read = curbuf->b_mtime;
-	    curbuf->b_mtime_read_ns = curbuf->b_mtime_ns;
+	    buf_store_time(curbuf, &st, fname, TRUE);
 #ifdef FEAT_CRYPT
 	    filesize_disk = st.st_size;
 #endif
@@ -2632,9 +2630,7 @@ failed:
 	if (newfile && !read_stdin && !read_buffer
 					 && mch_stat((char *)fname, &st) >= 0)
 	{
-	    buf_store_time(curbuf, &st, fname);
-	    curbuf->b_mtime_read = curbuf->b_mtime;
-	    curbuf->b_mtime_read_ns = curbuf->b_mtime_ns;
+	    buf_store_time(curbuf, &st, fname, TRUE);
 	}
 #endif
     }
@@ -4225,7 +4221,7 @@ buf_check_timestamp(
 	    buf->b_orig_mode = 0;
 	}
 	else
-	    buf_store_time(buf, &st, buf->b_ffname);
+	    buf_store_time(buf, &st, buf->b_ffname, FALSE);
 
 	// Don't do anything for a directory.  Might contain the file
 	// explorer.
@@ -4625,7 +4621,7 @@ buf_reload(buf_T *buf, int orig_mode, int reload_options)
 }
 
     void
-buf_store_time(buf_T *buf, stat_T *st, char_u *fname UNUSED)
+buf_store_time(buf_T *buf, stat_T *st, char_u *fname UNUSED, int update_mtime_read)
 {
     buf->b_mtime = (long)st->st_mtime;
 #ifdef ST_MTIM_NSEC
@@ -4639,6 +4635,12 @@ buf_store_time(buf_T *buf, stat_T *st, char_u *fname UNUSED)
 #else
     buf->b_orig_mode = mch_getperm(fname);
 #endif
+
+    if (update_mtime_read)
+    {
+	buf->b_mtime_read = buf->b_mtime;
+	buf->b_mtime_read_ns = buf->b_mtime_ns;
+    }
 }
 
 /*

--- a/src/memline.c
+++ b/src/memline.c
@@ -1056,9 +1056,7 @@ set_b0_fname(ZERO_BL *b0p, buf_T *buf)
 #ifdef CHECK_INODE
 	    long_to_char((long)st.st_ino, b0p->b0_ino);
 #endif
-	    buf_store_time(buf, &st, buf->b_ffname);
-	    buf->b_mtime_read = buf->b_mtime;
-	    buf->b_mtime_read_ns = buf->b_mtime_ns;
+	    buf_store_time(buf, &st, buf->b_ffname, TRUE);
 	}
 	else
 	{

--- a/src/netbeans.c
+++ b/src/netbeans.c
@@ -1739,7 +1739,7 @@ nb_do_cmd(
 		// avoid "file changed" warnings.
 		if (buf->bufp->b_ffname != NULL
 			&& mch_stat((char *)buf->bufp->b_ffname, &st) >= 0)
-		    buf_store_time(buf->bufp, &st, buf->bufp->b_ffname);
+		    buf_store_time(buf->bufp, &st, buf->bufp->b_ffname, FALSE);
 		buf->bufp->b_changed = FALSE;
 	    }
 	    buf->modified = buf->bufp->b_changed;

--- a/src/proto/buffer.pro
+++ b/src/proto/buffer.pro
@@ -23,6 +23,9 @@ void free_buf_options(buf_T *buf, int free_p_ff);
 int buflist_getfile(int n, linenr_T lnum, int options, int forceit);
 buf_T *buflist_findname_exp(char_u *fname);
 buf_T *buflist_findname(char_u *ffname);
+#ifdef UNIX
+buf_T *buflist_findname_stat(char_u *ffname, stat_T *stp);
+#endif
 int buflist_findpat(char_u *pattern, char_u *pattern_end, int unlisted, int diffmode, int curtab_only);
 int ExpandBufnames(char_u *pat, int *num_file, char_u ***file, int options);
 buf_T *buflist_findnr(int nr);

--- a/src/proto/fileio.pro
+++ b/src/proto/fileio.pro
@@ -30,7 +30,7 @@ int vim_copyfile(char_u *from, char_u *to);
 int check_timestamps(int focus);
 int buf_check_timestamp(buf_T *buf, int focus);
 void buf_reload(buf_T *buf, int orig_mode, int reload_options);
-void buf_store_time(buf_T *buf, stat_T *st, char_u *fname);
+void buf_store_time(buf_T *buf, stat_T *st, char_u *fname, int update_mtime_read);
 void write_lnum_adjust(linenr_T offset);
 int readdir_core(garray_T *gap, char_u *path, int withattr, void *context, int (*checkitem)(void *context, void *item), int sort);
 int delete_recursive(char_u *name);


### PR DESCRIPTION
This permits plugins which use `writefile()` to write to a buffer, to also update the buffer's `mtime`, so future `:write`s won't then think there's been a change to the file outside of vim