### PR TITLE
runtime(comment): fix commment toggle with mixed tab&spaces

### DIFF
--- a/runtime/pack/dist/opt/comment/autoload/comment.vim
+++ b/runtime/pack/dist/opt/comment/autoload/comment.vim
@@ -35,19 +35,25 @@ export def Toggle(...args: list<string>): string
 
     if len(cms_l) == 0 | return '' | endif
     if len(cms_l) == 1 | call add(cms_l, '') | endif
-    var comment = 0
+    var comment = false
+    var indent_spaces = false
+    var indent_tabs = false
     var indent_min = indent(lnum1)
     var indent_start = matchstr(getline(lnum1), '^\s*')
     for lnum in range(lnum1, lnum2)
         if getline(lnum) =~ '^\s*$' | continue | endif
+        var indent_str = matchstr(getline(lnum), '^\s*')
         if indent_min > indent(lnum)
             indent_min = indent(lnum)
-            indent_start = matchstr(getline(lnum), '^\s*')
+            indent_start = indent_str
         endif
+        indent_spaces = indent_spaces || (stridx(indent_str, ' ') != -1)
+        indent_tabs = indent_tabs || (stridx(indent_str, "\t") != -1)
         if getline(lnum) !~ $'^\s*{cms_l[0]}.*{cms_l[1]}$'
-            comment = 1
+            comment = true
         endif
     endfor
+    var mixed_indent = indent_spaces && indent_tabs
     var lines = []
     var line = ''
     for lnum in range(lnum1, lnum2)
@@ -58,10 +64,7 @@ export def Toggle(...args: list<string>): string
                 line = printf(substitute(cms, '%s\@!', '%%', 'g'), getline(lnum))
             else
                 # consider different whitespace indenting
-                var indent_current = matchstr(getline(lnum), '^\s*')
-                if strlen(indent_start) < strlen(indent_current)
-                    indent_current = indent_start
-                endif
+                var indent_current = mixed_indent ? matchstr(getline(lnum), '^\s*') : indent_start
                 line = printf(indent_current .. substitute(cms, '%s\@!', '%%', 'g'),
                     strpart(getline(lnum), strlen(indent_current)))
             endif

--- a/runtime/pack/dist/opt/comment/autoload/comment.vim
+++ b/runtime/pack/dist/opt/comment/autoload/comment.vim
@@ -55,16 +55,15 @@ export def Toggle(...args: list<string>): string
             line = getline(lnum)
         elseif comment
             if exists("g:comment_first_col") || exists("b:comment_first_col")
-                # handle % with substitute
                 line = printf(substitute(cms, '%s\@!', '%%', 'g'), getline(lnum))
             else
-                line = getline(lnum)
-                var indent_start_len = strlen(indent_start)
-                # handle % with substitute,
                 # consider different whitespace indenting
-                line = printf(indent_start .. substitute(cms, '%s\@!', '%%', 'g'),
-                    strpart(line, (line[0 : strlen(indent_start_len) - 1] =~ '\t' ?
-                    indent_start_len / &tabstop : indent_start_len)))
+                var indent_current = matchstr(getline(lnum), '^\s*')
+                if strlen(indent_start) < strlen(indent_current)
+                    indent_current = indent_start
+                endif
+                line = printf(indent_current .. substitute(cms, '%s\@!', '%%', 'g'),
+                    strpart(getline(lnum), strlen(indent_current)))
             endif
         else
             line = substitute(getline(lnum), $'^\s*\zs{cms_l[0]} \?\| \?{cms_l[1]}$', '', 'g')


### PR DESCRIPTION
- fix regression where toggling doesn't properly remove comment chars in files with tabs indents only.
- refactor toggling comments for mixed tab&spaces files.

Relates https://github.com/vim/vim/issues/15797#issuecomment-2408822379

PS, I wanted to come up with tests but figured out there is regression so I had to fix it first.

I will introduce tests later, spent time on fixing regression.