### PR TITLE
Fix correct name to "Vim script"

### DIFF
--- a/runtime/autoload/getscript.vim
+++ b/runtime/autoload/getscript.vim
@@ -365,7 +365,7 @@ fun! getscript#GetLatestVimScripts()
 endfun
 
 " ---------------------------------------------------------------------
-"  GetOneScript: (Get Latest Vim Script) this function operates {{{1
+"  GetOneScript: (Get Latest Vim script) this function operates {{{1
 "    on the current line, interpreting two numbers and text as
 "    ScriptID, SourceID, and Filename.
 "    It downloads any scripts that have newer versions from vim.sourceforge.net.

--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -1325,7 +1325,7 @@ used (Motif only offers one pattern, but you can edit it).
 For example, to have only Vim files in the dialog, you could use the following
 command: >
 
-     let g:browsefilter = "Vim Scripts\t*.vim\nVim Startup Files\t*vimrc\n"
+     let g:browsefilter = "Vim scripts\t*.vim\nVim Startup Files\t*vimrc\n"
 
 You can override the filter setting on a per-buffer basis by setting the
 b:browsefilter variable.  You would most likely set b:browsefilter in a

--- a/runtime/menu.vim
+++ b/runtime/menu.vim
@@ -1137,7 +1137,7 @@ else
   endif
   tmenu ToolBar.LoadSesn	Choose a session to load
   tmenu ToolBar.SaveSesn	Save current session
-  tmenu ToolBar.RunScript	Choose a Vim Script to run
+  tmenu ToolBar.RunScript	Choose a Vim script to run
   tmenu ToolBar.Make		Make current project (:make)
   tmenu ToolBar.RunCtags	Build tags in current directory tree (!ctags -R .)
   tmenu ToolBar.TagJump		Jump to tag under cursor

--- a/runtime/pack/dist/opt/comment/doc/comment.txt
+++ b/runtime/pack/dist/opt/comment/doc/comment.txt
@@ -57,7 +57,7 @@ Vim script): >
 
 	autocmd Filetype vim :setlocal commentstring="%s
 
-This example sets the " as start of a comment for legacy Vim Script.  For Vim9
+This example sets the " as start of a comment for legacy Vim script.  For Vim9
 script, you would instead use the "#" char: >
 
 	autocmd Filetype vim :setlocal commentstring=#\ %s

--- a/runtime/pack/dist/opt/editorconfig/autoload/editorconfig.vim
+++ b/runtime/pack/dist/opt/editorconfig/autoload/editorconfig.vim
@@ -1,4 +1,4 @@
-" autoload/editorconfig.vim: EditorConfig native Vimscript plugin
+" autoload/editorconfig.vim: EditorConfig native Vim script plugin
 " Copyright (c) 2011-2019 EditorConfig Team
 " All rights reserved.
 "

--- a/runtime/pack/dist/opt/editorconfig/doc/editorconfig.txt
+++ b/runtime/pack/dist/opt/editorconfig/doc/editorconfig.txt
@@ -47,7 +47,7 @@ Specify the mode of EditorConfig core. Generally it is OK to leave this option
 empty. Currently, the supported modes are "vim_core" (default) and
 "external_command".
 
-    vim_core:           Use the included VimScript EditorConfig Core.
+    vim_core:           Use the included Vim script EditorConfig Core.
     external_command:   Run external EditorConfig Core.
 
 If "g:EditorConfig_core_mode" is not specified, this plugin will automatically

--- a/runtime/pack/dist/opt/editorconfig/plugin/editorconfig.vim
+++ b/runtime/pack/dist/opt/editorconfig/plugin/editorconfig.vim
@@ -1,4 +1,4 @@
-" plugin/editorconfig.vim: EditorConfig native Vimscript plugin file
+" plugin/editorconfig.vim: EditorConfig native Vim script plugin file
 " Copyright (c) 2011-2019 EditorConfig Team
 " All rights reserved.
 "

--- a/runtime/syntax/modula2/opt/r10.vim
+++ b/runtime/syntax/modula2/opt/r10.vim
@@ -157,7 +157,7 @@ syn match modula2Base16Num "0[ux][0-9A-F]\+\('[0-9A-F]\+\)*"
 "| which greatly diminishes readability and thereby increases the opportunity
 "| for error during maintenance. Ideally, regular expressions should be split
 "| into small human readable pieces with interleaved comments that explain
-"| precisely what each piece is doing.  Vimscript imposes poor design. :-(
+"| precisely what each piece is doing.  Vim script imposes poor design. :-(
 
 syn match modula2Base10Num
   \ "\(\(0[bux]\@!\|[1-9]\)[0-9]*\('[0-9]\+\)*\)\(\.[0-9]\+\('[0-9]\+\)*\(e[+-]\?[0-9]\+\('[0-9]\+\)*\)\?\)\?"

--- a/src/testdir/script_util.vim
+++ b/src/testdir/script_util.vim
@@ -1,4 +1,4 @@
-" Functions shared by the tests for Vim Script
+" Functions shared by the tests for Vim script
 
 " Commands to track the execution path of a script
 com!		   XpathINIT  let g:Xpath = ''

--- a/src/testdir/test_expr.vim
+++ b/src/testdir/test_expr.vim
@@ -929,7 +929,7 @@ func Test_string_interp()
     #" String conversion.
     call assert_equal('hello from ' .. v:version, $"hello from {v:version}")
     call assert_equal('hello from ' .. v:version, $'hello from {v:version}')
-    #" Paper over a small difference between VimScript behaviour.
+    #" Paper over a small difference between Vim script behaviour.
     call assert_equal(string(v:true), $"{v:true}")
     call assert_equal('(1+1=2)', $"(1+1={1 + 1})")
     #" Hex-escaped opening brace: char2nr('{') == 0x7b


### PR DESCRIPTION
The late Mr. Bram stated this clearly:
https://groups.google.com/g/vim_dev/c/3Z5yM8KER2w/m/wAqws0QSEAAJ

> "Vim script" is the short form.

The language label on GitHub is also wrong, so I created a new discussion about it.
https://github.com/orgs/community/discussions/141314

P.S.
I'll make a pull request for EditorConfig later.