### PR TITLE
Disambiguate `ctermfg=Brown` to show same colour across terminals

### DIFF
--- a/runtime/syntax/syncolor.vim
+++ b/runtime/syntax/syncolor.vim
@@ -50,7 +50,7 @@ else
   " #6a5acd is SlateBlue
   SynColor Special	term=bold cterm=NONE ctermfg=DarkMagenta ctermbg=NONE gui=NONE guifg=#6a5acd guibg=NONE
   SynColor Identifier	term=underline cterm=NONE ctermfg=DarkCyan ctermbg=NONE gui=NONE guifg=DarkCyan guibg=NONE
-  SynColor Statement	term=bold cterm=NONE ctermfg=Brown ctermbg=NONE gui=bold guifg=Brown guibg=NONE
+  SynColor Statement	term=bold cterm=NONE ctermfg=DarkYellow ctermbg=NONE gui=bold guifg=DarkYellow guibg=NONE
   " #6a0dad is Purple
   SynColor PreProc	term=underline cterm=NONE ctermfg=DarkMagenta ctermbg=NONE gui=NONE guifg=#6a0dad guibg=NONE
   SynColor Type		term=underline cterm=NONE ctermfg=DarkGreen ctermbg=NONE gui=bold guifg=SeaGreen guibg=NONE


### PR DESCRIPTION
As per in-line comment

> " Many terminals can only use six different colors (plus black and white).
" Therefore the number of colors used is kept low.

All colours not expressed as hex strings are from the [16 cterm-colors](https://vimhelp.org/syntax.txt.html#cterm-colors). Brown here means colour No. 3 (Brown, DarkYellow) and is shown as yellow on 8-colour and 16-colour terminals 

![IMG_2035](https://github.com/user-attachments/assets/ce2d822c-a1e2-4b4b-87ba-368e3cbf4041)

but as brown on 256-colour terminals

![IMG_2036](https://github.com/user-attachments/assets/978460af-b7e2-48d5-96e2-74f79b1d761f)

This PR uses the alternative, unambiguous term ‘DarkYellow’ so Statement can exhibit the same colour in all terminals.

Pro: cross-terminal consistency 

Con: users on 256-colour terminals will see a slight colour change in the default palette 

I’m not entirely sure whether this is worthwhile to do.