### PR TITLE
Add info on default colorscheme in syntax.txt

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -5309,10 +5309,10 @@ of colors by using the `:colorscheme` command, for example: >
 			This is basically the same as >
 				:echo g:colors_name
 <			In case g:colors_name has not been defined :colo will
-			output "default", which is defined in the file
-			"syntax/syncolor.vim" and based on the palette of
-			legacy versions of peachpuff and desert. When compiled
-			without the |+eval| feature it will output "unknown".
+			output "default". Its palette is defined in the file
+			"syntax/syncolor.vim" and is based on legacy versions
+			of peachpuff and desert. When compiled without the
+			|+eval| feature it will output "unknown".
 
 :colo[rscheme] {name}	Load color scheme {name}.  This searches 'runtimepath'
 			for the file "colors/{name}.vim".  The first one that

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -5309,8 +5309,10 @@ of colors by using the `:colorscheme` command, for example: >
 			This is basically the same as >
 				:echo g:colors_name
 <			In case g:colors_name has not been defined :colo will
-			output "default".  When compiled without the |+eval|
-			feature it will output "unknown".
+			output "default", which is defined in the file
+			"syntax/syncolor.vim" and based on the palette of
+			legacy versions of peachpuff and desert. When compiled
+			without the |+eval| feature it will output "unknown".
 
 :colo[rscheme] {name}	Load color scheme {name}.  This searches 'runtimepath'
 			for the file "colors/{name}.vim".  The first one that


### PR DESCRIPTION
One often reads on support forums that Vim’s `:colo default` is peachpuff. It’s less widely known that this is a slightly altered version of legacy peachpuff (and desert for dark background) and is loaded from "syntax/syncolor.vim", giving rise to confusion when users try to run `:colo peachpuff` after reading such advice and get a different look.

This PR documents the colorscheme of `:colo default`.