### PR TITLE
Fix Kitty protocol decoding of the Escape key

### DIFF
--- a/src/edit.c
+++ b/src/edit.c
@@ -1625,7 +1625,8 @@ decodeModifyOtherKeys(int c)
     if (typebuf.tb_len >= 4 && (c == CSI || (c == ESC && *p == '[')))
     {
 	idx = (*p == '[');
-	if (p[idx] == '2' && p[idx + 1] == '7' && p[idx + 2] == ';')
+	if (p[idx] == '2' && p[idx + 1] == '7' && p[idx + 2] == ';' &&
+		kitty_protocol_state != KKPS_ENABLED)
 	{
 	    form = 1;
 	    idx += 3;
@@ -1640,9 +1641,10 @@ decodeModifyOtherKeys(int c)
 		break;
 	    ++idx;
 	}
+	int kitty_no_mods = argidx == 0 && kitty_protocol_state == KKPS_ENABLED;
 	if (idx < typebuf.tb_len
 		&& p[idx] == (form == 1 ? '~' : 'u')
-		&& argidx == 1)
+		&& (argidx == 1 || kitty_no_mods))
 	{
 	    // Match, consume the code.
 	    typebuf.tb_off += idx + 1;
@@ -1652,7 +1654,7 @@ decodeModifyOtherKeys(int c)
 		typebuf_was_filled = FALSE;
 #endif
 
-	    mod_mask = decode_modifiers(arg[!form]);
+	    mod_mask = kitty_no_mods ? 0 : decode_modifiers(arg[!form]);
 	    c = merge_modifyOtherKeys(arg[form], &mod_mask);
 	}
     }

--- a/src/testdir/test_termcodes.vim
+++ b/src/testdir/test_termcodes.vim
@@ -2001,6 +2001,12 @@ func Test_xx08_kitty_response()
         \ kitty: 'y',
         \ }, terminalprops())
 
+  call feedkeys("\<Esc>[?1u") " simulate the kitty keyboard protocol is enabled
+  call feedkeys(':' .. GetEscCodeCSIu('V', '5') .. GetEscCodeCSIuWithoutModifier("\<Esc>") .. "\<C-B>\"\<CR>", 'Lx!')
+  call assert_equal("\"\<Esc>", @:)
+  call feedkeys(':' .. GetEscCodeCSIu('V', '5') .. GetEscCodeCSIu("\<Esc>", '129') .. "\<C-B>\"\<CR>", 'Lx!')
+  call assert_equal("\"\<Esc>", @:)
+
   set t_RV=
   call test_override('term_props', 0)
 endfunc


### PR DESCRIPTION
Problem:  `<CSI>27[;<mod>]u` is not decoded to a literal Escape character in kitty and foot
Solution: disable XTerm modifyOtherKeys form 1 (`<CSI>27;<mod>;<key>~`) when the kitty protocol is enabled

XTerm's modifyOtherKeys uses 27 (Escape) to denote a special alternate form (as per the author: "noticing that 27 was unused"). The kitty keyboard protocol doesn't special-case 27. Escape is sent just like other printable keys. Some keys are sent with a different terminator than `u` however in these cases the key number isn't an Unicode codepoint and cannot be simply used as a printable character in vim's Ctrl+V, so not handling them in this function seems OK (on par with other terminals).

References:
- https://invisible-island.net/xterm/modified-keys.html
- https://sw.kovidgoyal.net/kitty/keyboard-protocol/
- https://codeberg.org/dnkl/foot/src/commit/e891abdd6a6652bd46b28c1988700a7f30931210/kitty-keymap.h
- https://github.com/kovidgoyal/kitty/blob/d31459b0926f2afddc317d76314e4afd0d07d473/kitty/key_encoding.c#L193

fixes: #15868