### PR TITLE
tests: does not display errors in gen_opt_test.vim in windows gVim

### DIFF
--- a/src/testdir/Make_ming.mak
+++ b/src/testdir/Make_ming.mak
@@ -157,8 +157,12 @@ test_gui_init.res: test_gui_init.vim
 	$(VIMPROG) -u gui_preinit.vim -U gui_init.vim $(NO_PLUGINS) -S runtest.vim $<
 	@$(DEL) vimcmd
 
-opt_test.vim: ../optiondefs.h gen_opt_test.vim
-	$(VIMPROG) -e -s -u NONE $(COMMON_ARGS) --nofork -S gen_opt_test.vim ../optiondefs.h
+opt_test.vim: gen_opt_test.vim ../optiondefs.h
+	$(VIMPROG) -e -s -u NONE $(COMMON_ARGS) --nofork -S $^
+	@if test -f test.log; then \
+		cat test.log; \
+		exit 1; \
+	fi
 
 test_bench_regexp.res: test_bench_regexp.vim
 	-$(DEL) benchmark.out

--- a/src/testdir/Make_mvc.mak
+++ b/src/testdir/Make_mvc.mak
@@ -151,8 +151,9 @@ test_gui_init.res: test_gui_init.vim
 	$(VIMPROG) -u gui_preinit.vim -U gui_init.vim $(NO_PLUGINS) -S runtest.vim $*.vim
 	@del vimcmd
 
-opt_test.vim: ../optiondefs.h gen_opt_test.vim
-	$(VIMPROG) -e -s -u NONE $(COMMON_ARGS) --nofork -S gen_opt_test.vim ../optiondefs.h
+opt_test.vim: gen_opt_test.vim ../optiondefs.h
+	$(VIMPROG) -e -s -u NONE $(COMMON_ARGS) --nofork -S $**
+	@if exist test.log ( type test.log & exit /b 1 )
 
 test_bench_regexp.res: test_bench_regexp.vim
 	-if exist benchmark.out del benchmark.out

--- a/src/testdir/Makefile
+++ b/src/testdir/Makefile
@@ -160,8 +160,10 @@ test_gui_init.res: test_gui_init.vim
 	$(RUN_VIMTEST) -u gui_preinit.vim -U gui_init.vim $(NO_PLUGINS) -S runtest.vim $<
 	@rm vimcmd
 
-opt_test.vim: gen_opt_test.vim ../optiondefs.h
-	$(VIMPROG) -e -s -u NONE $(NO_INITS) --nofork --gui-dialog-file guidialog -S $^
+GEN_OPT_DEPS = gen_opt_test.vim ../optiondefs.h
+
+opt_test.vim: $(GEN_OPT_DEPS)
+	$(VIMPROG) -e -s -u NONE $(NO_INITS) --nofork --gui-dialog-file guidialog -S $(GEN_OPT_DEPS)
 	@if test -f test.log; then \
 		cat test.log; \
 		exit 1; \

--- a/src/testdir/Makefile
+++ b/src/testdir/Makefile
@@ -160,8 +160,12 @@ test_gui_init.res: test_gui_init.vim
 	$(RUN_VIMTEST) -u gui_preinit.vim -U gui_init.vim $(NO_PLUGINS) -S runtest.vim $<
 	@rm vimcmd
 
-opt_test.vim: ../optiondefs.h gen_opt_test.vim
-	$(VIMPROG) -e -s -u NONE $(NO_INITS) --nofork --gui-dialog-file guidialog -S gen_opt_test.vim ../optiondefs.h
+opt_test.vim: gen_opt_test.vim ../optiondefs.h
+	$(VIMPROG) -e -s -u NONE $(NO_INITS) --nofork --gui-dialog-file guidialog -S $^
+	@if test -f test.log; then \
+		cat test.log; \
+		exit 1; \
+	fi
 
 test_xxd.res:
 	XXD=$(XXDPROG); export XXD; $(RUN_VIMTEST) $(NO_INITS) -S runtest.vim test_xxd.vim

--- a/src/testdir/gen_opt_test.vim
+++ b/src/testdir/gen_opt_test.vim
@@ -192,6 +192,12 @@ let test_values = {
       \ 'otherstring': [['', 'xxx'], []],
       \}
 
+const invalid_options = test_values->keys()
+      \->filter({-> v:val !~# '^other' && !exists($"&{v:val}")})
+if !empty(invalid_options)
+  throw $"Invalid option name in test_values: '{invalid_options->join("', '")}'"
+endif
+
 1
 /struct vimoption options
 while 1
@@ -253,11 +259,14 @@ call add(script, 'let &lines = save_lines')
 
 call writefile(script, 'opt_test.vim')
 
-" Exit with error-code if error occurs.
+" Write error messages if error occurs.
 catch
-  set verbose=1
-  echoc 'Error:' v:exception 'in' v:throwpoint
-  cq! 1
+  " Append errors to test.log
+  let error = $'Error: {v:exception} in {v:throwpoint}'
+  echoc error
+  split test.log
+  call append('$', error)
+  write
 endtry
 
 endif


### PR DESCRIPTION
This allows we to see in the CI log if the test implementation is incorrect.