### PR TITLE
runtime:compiler:cppcheck: check for compile_commands in build subdirs

### DIFF
--- a/runtime/compiler/cppcheck.vim
+++ b/runtime/compiler/cppcheck.vim
@@ -1,7 +1,7 @@
 " vim compiler file
 " Compiler:	cppcheck (C++ static checker)
 " Maintainer:   Vincent B. (twinside@free.fr)
-" Last Change:  2024 Oct 4 by @Konfekt
+" Last Change:  2024 oct 17 by @Konfekt
 
 if exists("cppcheck")
   finish
@@ -10,6 +10,8 @@ let current_compiler = "cppcheck"
 
 let s:cpo_save = &cpo
 set cpo-=C
+
+let s:slash = has('win32')? '\' : '/'
 
 if !exists('g:c_cppcheck_params')
   let g:c_cppcheck_params = '--verbose --force --inline-suppr'
@@ -20,11 +22,11 @@ endif
 
 let &l:makeprg = 'cppcheck --quiet'
       \ ..' --template="{file}:{line}:{column}: {severity}: [{id}] {message} {callstack}"'
-      \ ..' '..get(b:, 'c_cppcheck_params',
-      \            g:c_cppcheck_params..' '..(&filetype ==# 'cpp' ? ' --language=c++' : ''))
+      \ ..' '..get(b:, 'c_cppcheck_params', get(g:, 'c_cppcheck_params', (&filetype ==# 'cpp' ? ' --language=c++' : '')))
       \ ..' '..get(b:, 'c_cppcheck_includes', get(g:, 'c_cppcheck_includes',
       \	          (filereadable('compile_commands.json') ? '--project=compile_commands.json' :
-      \	          (empty(&path) ? '' : '-I')..join(map(filter(split(&path, ','), 'isdirectory(v:val)'),'shellescape(v:val)'), ' -I'))))
+      \           (!empty(glob('*'..s:slash..'compile_commands.json', 1, 1)) ? '--project='..glob('*'..s:slash..'compile_commands.json', 1, 1)[0] :
+      \	          (empty(&path) ? '' : '-I')..join(map(filter(split(&path, ','), 'isdirectory(v:val)'),'shellescape(v:val)'), ' -I')))))
 silent CompilerSet makeprg
 
 CompilerSet errorformat=


### PR DESCRIPTION
As it is usually not in root dir