### PR TITLE
Problem: AmigaOS4 build should use default runtime (newlib)

### DIFF
--- a/src/Make_ami.mak
+++ b/src/Make_ami.mak
@@ -53,8 +53,8 @@ endif
 
 # OS specific compiler flags
 ifeq ($(UNM),AmigaOS)
-LDFLAGS = -mcrt=clib2 -lauto -lm -lnet
-CFLAGS += -DHAVE_FSYNC -D__USE_INLINE__ -mcrt=clib2
+LDFLAGS = -lauto
+CFLAGS += -DHAVE_FSYNC -D__USE_INLINE__
 else
 ifeq ($(UNM),AROS)
 LDFLAGS = -DHAVE_FSYNC -ldebug


### PR DESCRIPTION
Solution: Remove clib2 from compiler / linker flags