### PR TITLE
syntax(swayconfig): add flag for bindsym/bindcode

### DIFF
--- a/runtime/syntax/swayconfig.vim
+++ b/runtime/syntax/swayconfig.vim
@@ -29,7 +29,7 @@ syn keyword i3ConfigConditionProp app_id pid shell contained
 
 syn keyword i3ConfigWorkspaceDir prev_on_output next_on_output contained
 
-syn match i3ConfigBindArgument /--\(locked\|to-code\|no-repeat\|input-device=[^ '"]*\|no-warn\) / contained contains=i3ConfigShOper,@i3ConfigStrVar nextgroup=i3ConfigBindArgument,i3ConfigBindCombo
+syn match i3ConfigBindArgument /--\(locked\|to-code\|no-repeat\|input-device=[^ '"]*\|no-warn\|inhibited\) / contained contains=i3ConfigShOper,@i3ConfigStrVar nextgroup=i3ConfigBindArgument,i3ConfigBindCombo
 syn region i3ConfigBindArgument start=/--input-device=['"]/ end=/\s/ contained contains=@i3ConfigIdent,i3ConfigShOper,i3ConfigString nextgroup=i3ConfigBindArgument,i3ConfigBindCombo
 
 syn region i3ConfigBindCombo matchgroup=i3ConfigParen start=/{$/ end=/^\s*}$/ contained contains=i3ConfigBindArgument,i3ConfigBindCombo,i3ConfigComment fold keepend extend


### PR DESCRIPTION
Add the `--inhibited` flag for the bindsym/bindcode commands.

Relevant commits in sway: [#eeac0aa170](https://github.com/swaywm/sway/commit/eeac0aa170d4ee19111df072ea361b56c802cf34), [#6a1c176d14](https://github.com/swaywm/sway/commit/6a1c176d14232a235ec30ce67ce87f3e549a6121)

@jamespeapen Could you please review this patch?