### PR TITLE
runtime(typst): add folding to typst ftplugin

### DIFF
--- a/runtime/autoload/typst.vim
+++ b/runtime/autoload/typst.vim
@@ -31,6 +31,31 @@ function! typst#indentexpr() abort
     return l:ind
 endfunction
 
+function typst#foldexpr()
+    let line = getline(v:lnum)
+
+    " Whenever the user wants to fold nested headers under the parent
+    let nested = get(g:, "typst_foldnested", 1)
+
+    " Regular headers
+    let depth = match(line, '\(^=\+\)\@<=\( .*$\)\@=')
+
+    " Do not fold nested regular headers
+    if depth > 1 && !nested
+        let depth = 1
+    endif
+
+    if depth > 0
+        " check syntax, it should be typstMarkupHeading
+        let syncode = synstack(v:lnum, 1)
+        if len(syncode) > 0 && synIDattr(syncode[0], 'name') ==# 'typstMarkupHeading'
+            return ">" . depth
+        endif
+    endif
+
+    return "="
+endfunction
+
 " Gets the previous non-blank line that is not a comment.
 function! s:get_prev_nonblank(lnum) abort
     let l:lnum = prevnonblank(a:lnum)

--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -939,6 +939,19 @@ TYPST							*ft-typst-plugin*
 							*g:typst_conceal*
 When |TRUE| the Typst filetype plugin will set the 'conceallevel' option to 2.
 
+							*g:typst_folding*
+When |TRUE| the Typst filetype plugin will fold headings. (default: |FALSE|)
+
+To enable: >
+	let g:typst_folding = 1
+<
+							*g:typst_foldnested*
+When |TRUE| the Typst filetype plugin will fold nested heading under their parents
+(default: |TRUE|)
+
+To disable: >
+	let g:typst_foldnested = 0
+<
 VIM							*ft-vim-plugin*
 
 The Vim filetype plugin defines mappings to move to the start and end of

--- a/runtime/ftplugin/typst.vim
+++ b/runtime/ftplugin/typst.vim
@@ -21,6 +21,12 @@ if get(g:, 'typst_conceal', 0)
   let b:undo_ftplugin .= ' cole<'
 endif
 
+if has("folding") && get(g:, 'typst_folding', 0)
+    setlocal foldexpr=typst#foldexpr()
+    setlocal foldmethod=expr
+    let b:undo_ftplugin .= "|setl foldexpr< foldmethod<"
+endif
+
 if !exists('current_compiler')
   compiler typst
   let b:undo_ftplugin ..= "| compiler make"


### PR DESCRIPTION
ping mantainer: @gpanders 

Adding folding to typst ftplugin.

This PR does:

1. Creates a function for folding
2. declare user the following user variables:
- `g:typst_folding` (default: 0): whenever to enable folding of headers 
- `g:typst_foldnested` (default: 1): whenever to fold nested headers (e.g. headers 2 are folded under headers 1)
3. makes folding undoable
