### PR TITLE
tests: tests fails depending on Windows environment.

### DIFF
--- a/src/testdir/dos.vim
+++ b/src/testdir/dos.vim
@@ -3,7 +3,7 @@
 set shell=c:\COMMAND.COM shellquote= shellxquote= shellcmdflag=/c shellredir=>
 " This is used only when the +eval feature is available.
 if executable("cmd.exe")
-   set shell=cmd.exe
+   set shell=cmd.exe shellcmdflag=/D\ /c
 endif
 
 source setup.vim

--- a/src/testdir/shared.vim
+++ b/src/testdir/shared.vim
@@ -59,7 +59,7 @@ func RunCommand(cmd)
     let job = job_start(a:cmd, {"stoponexit": "hup"})
     call job_setoptions(job, {"stoponexit": "kill"})
   elseif has('win32')
-    exe 'silent !start cmd /c start "test_channel" ' . a:cmd
+    exe 'silent !start cmd /D /c start "test_channel" ' . a:cmd
   else
     exe 'silent !' . a:cmd . '&'
   endif

--- a/src/testdir/term_util.vim
+++ b/src/testdir/term_util.vim
@@ -174,7 +174,7 @@ endfunc
 " number.
 func Run_shell_in_terminal(options)
   if has('win32')
-    let buf = term_start([&shell, '/k'], a:options)
+    let buf = term_start([&shell, '/D', '/k'], a:options)
   else
     let buf = term_start(&shell, a:options)
   endif

--- a/src/testdir/test_autocmd.vim
+++ b/src/testdir/test_autocmd.vim
@@ -89,7 +89,7 @@ if has('timers')
     let g:triggered = 0
     au CursorHoldI * let g:triggered += 1
     set updatetime=100
-    call job_start(has('win32') ? 'cmd /c echo:' : 'echo',
+    call job_start(has('win32') ? 'cmd /D /c echo:' : 'echo',
           \ {'exit_cb': {-> timer_start(200, 'ExitInsertMode')}})
     call feedkeys('a', 'x!')
     call assert_equal(1, g:triggered)

--- a/src/testdir/test_channel.vim
+++ b/src/testdir/test_channel.vim
@@ -1429,7 +1429,7 @@ func Test_exit_cb_wipes_buf()
   new
   let g:wipe_buf = bufnr('')
 
-  let job = job_start(has('win32') ? 'cmd /c echo:' : ['true'],
+  let job = job_start(has('win32') ? 'cmd /D /c echo:' : ['true'],
 	\ {'exit_cb': 'ExitCbWipe'})
   let timer = timer_start(300, {-> feedkeys("\<Esc>", 'nt')}, {'repeat': 5})
   call feedkeys(repeat('g', 1000) . 'o', 'ntx!')
@@ -1770,7 +1770,7 @@ func Test_job_start_fails()
   call assert_fails("call job_start('ls',
         \ {'err_io' : 'buffer', 'err_buf' : -1})", 'E475:')
 
-  let cmd = has('win32') ? "cmd /c dir" : "ls"
+  let cmd = has('win32') ? "cmd /D /c dir" : "ls"
 
   set nomodifiable
   call assert_fails("call job_start(cmd,
@@ -2308,7 +2308,7 @@ endfunc
 
 func Test_issue_5150()
   if has('win32')
-    let cmd = 'cmd /c pause'
+    let cmd = 'cmd /D /c pause'
   else
     let cmd = 'grep foo'
   endif
@@ -2438,7 +2438,7 @@ func Test_cb_with_input()
   let g:wait_exit_cb = 1
 
   if has('win32')
-    let cmd = 'cmd /c echo "Vim''s test"'
+    let cmd = 'cmd /D /c echo "Vim''s test"'
   else
     let cmd = 'echo "Vim''s test"'
   endif

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -3416,7 +3416,7 @@ func Test_range()
     call assert_fails('call term_start(range(3, 4))', 'E474:')
     let g:terminal_ansi_colors = range(16)
     if has('win32')
-      let cmd = "cmd /c dir"
+      let cmd = "cmd /D /c dir"
     else
       let cmd = "ls"
     endif

--- a/src/testdir/test_swap.vim
+++ b/src/testdir/test_swap.vim
@@ -420,7 +420,7 @@ func s:get_unused_pid(base)
   if has('job')
     " Execute 'echo' as a temporary job, and return its pid as an unused pid.
     if has('win32')
-      let cmd = 'cmd /c echo'
+      let cmd = 'cmd /D /c echo'
     else
       let cmd = 'echo'
     endif

--- a/src/testdir/test_terminal.vim
+++ b/src/testdir/test_terminal.vim
@@ -320,10 +320,10 @@ endfunc
 func Get_cat_123_cmd()
   if has('win32')
     if !has('conpty')
-      return 'cmd /c "cls && color 2 && echo 123"'
+      return 'cmd /D /c "cls && color 2 && echo 123"'
     else
       " When clearing twice, extra sequence is not output.
-      return 'cmd /c "cls && cls && color 2 && echo 123"'
+      return 'cmd /D /c "cls && cls && color 2 && echo 123"'
     endif
   else
     call writefile(["\<Esc>[32m123"], 'Xtext')
@@ -410,7 +410,7 @@ func Test_terminal_scrape_multibyte()
   if has('win32')
     " Run cmd with UTF-8 codepage to make the type command print the expected
     " multibyte characters.
-    let buf = term_start("cmd /K chcp 65001")
+    let buf = term_start("cmd /D /K chcp 65001")
     call term_sendkeys(buf, "type Xtext\<CR>")
     eval buf->term_sendkeys("exit\<CR>")
     let line = 4
@@ -457,7 +457,7 @@ endfunc
 func Test_terminal_scroll()
   call writefile(range(1, 200), 'Xtext', 'D')
   if has('win32')
-    let cmd = 'cmd /c "type Xtext"'
+    let cmd = 'cmd /D /c "type Xtext"'
   else
     let cmd = "cat Xtext"
   endif
@@ -765,7 +765,7 @@ endfunc
 
 func Test_terminal_cwd()
   if has('win32')
-    let cmd = 'cmd /c cd'
+    let cmd = 'cmd /D /c cd'
   else
     CheckExecutable pwd
     let cmd = 'pwd'
@@ -1111,7 +1111,7 @@ func Test_terminal_composing_unicode()
   set encoding=utf-8
 
   if has('win32')
-    let cmd = "cmd /K chcp 65001"
+    let cmd = "cmd /D /K chcp 65001"
     let lnum = [3, 6, 9]
   else
     let cmd = &shell

--- a/src/testdir/test_terminal2.vim
+++ b/src/testdir/test_terminal2.vim
@@ -450,7 +450,7 @@ func Test_terminal_does_not_truncate_last_newlines()
   for c in contents
     call writefile(c, 'Xdntfile', 'D')
     if has('win32')
-      term cmd /c type Xdntfile
+      term cmd /D /c type Xdntfile
     else
       term cat Xdntfile
     endif
@@ -465,7 +465,7 @@ endfunc
 
 func GetDummyCmd()
   if has('win32')
-    return 'cmd /c ""'
+    return 'cmd /D /c ""'
   else
     CheckExecutable false
     return 'false'

--- a/src/testdir/test_windows_home.vim
+++ b/src/testdir/test_windows_home.vim
@@ -105,7 +105,7 @@ func Test_WindowsHome()
       RestoreEnv
       let $HOME = save_home
       let env = ''
-      let job = job_start('cmd /c set', {'out_cb': {ch,x->[env,execute('let env=x')]}})
+      let job = job_start('cmd /D /c set', {'out_cb': {ch,x->[env,execute('let env=x')]}})
       sleep 1
       let env = filter(split(env, "\n"), 'v:val=="HOME"')
       let home = len(env) == 0 ? "" : env[0]


### PR DESCRIPTION
Tests failure on some windows environment.
This doesn't apply to GitHub CI, but it might help in some user environments.

```
> cmd /?
Starts a new instance of the Windows command interpreter

CMD [/A | /U] [/Q] [/D] [/E:ON | /E:OFF] [/F:ON | /F:OFF] [/V:ON | /V:OFF]
    [[/S] [/C | /K] string]

/C      Carries out the command specified by string and then terminates
/K      Carries out the command specified by string but remains
...
/D      Disable execution of AutoRun commands from registry (see below)
```