### PR TITLE
Add support for the 'findprg' option

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3556,13 +3556,16 @@ A jump table for the options with a short description can be found at |Q_op|.
 'findprg' 'fprg'	string	(default "")
 			global or local to buffer |global-local|
 	External program to use for the |:find| command.  When this option is
-	empty the internal file finding mechanism is used.  When executing the
-	external command, "$*" in 'findprg' is replaced with the argument
-	passed to the |:find| command.
-	If a matching file is found, the command should return one or more
-	file names separated by the newline character.  Example:
+	empty, the internal |file-searching| mechanism is used.
+	The external command is executed for each directory in 'path' until a
+	match is found.
+	When executing the external command, "$*" in 'findprg' is replaced
+	with the argument passed to the |:find| command.   The placeholder
+	"$@" in 'findprg' is replaced with a directory name from |'path'|.
+	If a match is found, the command should return one or more file names
+	separated by a newline character.  Example:
 >
-	    :set findprg=find\ .\ -name\ '$*'
+	    :set findprg=find\ $@\ -name\ '$*'
 <
 		*'fixendofline'* *'fixeol'* *'nofixendofline'* *'nofixeol'*
 'fixendofline' 'fixeol'	boolean	(default on)

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3552,6 +3552,18 @@ A jump table for the options with a short description can be found at |Q_op|.
 	  eob		EndOfBuffer		|hl-EndOfBuffer|
 	  lastline	NonText			|hl-NonText|
 
+						*'findprg'* *'fprg'*
+'findprg' 'fprg'	string	(default "")
+			global or local to buffer |global-local|
+	External program to use for the |:find| command.  When this option is
+	empty the internal file finding mechanism is used.  When executing the
+	external command, "$*" in 'findprg' is replaced with the argument
+	passed to the |:find| command.
+	If a matching file is found, the command should return one or more
+	file names separated by the newline character.  Example:
+>
+	    :set findprg=find\ .\ -name\ '$*'
+<
 		*'fixendofline'* *'fixeol'* *'nofixendofline'* *'nofixeol'*
 'fixendofline' 'fixeol'	boolean	(default on)
 			local to buffer

--- a/runtime/doc/quickref.txt
+++ b/runtime/doc/quickref.txt
@@ -707,6 +707,7 @@ Short explanation of each option:		*option-list*
 'fileignorecase'  'fic'     ignore case when using file names
 'filetype'	  'ft'	    type of file, used for autocommands
 'fillchars'	  'fcs'     characters to use for displaying special items
+'findprg'	  'fprg'    external command to use for |:find|
 'fixendofline'	  'fixeol'  make sure last line in file has <EOL>
 'fkmap'		  'fk'	    obsolete option for Farsi
 'foldclose'	  'fcl'     close a fold when the cursor leaves it

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -277,6 +277,7 @@ $quote	eval.txt	/*$quote*
 'fileignorecase'	options.txt	/*'fileignorecase'*
 'filetype'	options.txt	/*'filetype'*
 'fillchars'	options.txt	/*'fillchars'*
+'findprg'	options.txt	/*'findprg'*
 'fixendofline'	options.txt	/*'fixendofline'*
 'fixeol'	options.txt	/*'fixeol'*
 'fk'	options.txt	/*'fk'*
@@ -305,6 +306,7 @@ $quote	eval.txt	/*$quote*
 'formatoptions'	options.txt	/*'formatoptions'*
 'formatprg'	options.txt	/*'formatprg'*
 'fp'	options.txt	/*'fp'*
+'fprg'	options.txt	/*'fprg'*
 'fs'	options.txt	/*'fs'*
 'fsync'	options.txt	/*'fsync'*
 'ft'	options.txt	/*'ft'*

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -2478,6 +2478,7 @@ free_buf_options(
     clear_string_option(&buf->b_p_efm);
 #endif
     clear_string_option(&buf->b_p_ep);
+    clear_string_option(&buf->b_p_fprg);
     clear_string_option(&buf->b_p_path);
     clear_string_option(&buf->b_p_tags);
     clear_string_option(&buf->b_p_tc);

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -7006,6 +7006,7 @@ findprg_find_file(char_u *findarg, int findarg_len, int count)
     mch_dirname(curdir, MAXPATHL);
     ga_init2(&path_ga, sizeof(char_u *), 1);
     expand_path_option(curdir, path_opt, &path_ga);
+    vim_free(curdir);
 
     cc = findarg[findarg_len];
     findarg[findarg_len] = NUL;

--- a/src/findfile.c
+++ b/src/findfile.c
@@ -2210,7 +2210,7 @@ is_unique(char_u *maybe_unique, garray_T *gap, int i)
  * TODO: handle upward search (;) and path limiter (**N) notations by
  * expanding each into their equivalent path(s).
  */
-    static void
+    void
 expand_path_option(
 	char_u		*curdir,
 	char_u		*path_option,	// p_path or p_cdpath

--- a/src/option.c
+++ b/src/option.c
@@ -6293,6 +6293,9 @@ unset_global_local_option(char_u *name, void *from)
 	case PV_FP:
 	    clear_string_option(&buf->b_p_fp);
 	    break;
+	case PV_FPRG:
+	    clear_string_option(&buf->b_p_fprg);
+	    break;
 # ifdef FEAT_QUICKFIX
 	case PV_EFM:
 	    clear_string_option(&buf->b_p_efm);
@@ -6371,6 +6374,7 @@ get_varp_scope(struct vimoption *p, int scope)
 	switch ((int)p->indir)
 	{
 	    case PV_FP:   return (char_u *)&(curbuf->b_p_fp);
+	    case PV_FPRG:   return (char_u *)&(curbuf->b_p_fprg);
 #ifdef FEAT_QUICKFIX
 	    case PV_EFM:  return (char_u *)&(curbuf->b_p_efm);
 	    case PV_GP:   return (char_u *)&(curbuf->b_p_gp);
@@ -6481,6 +6485,8 @@ get_varp(struct vimoption *p)
 #endif
 	case PV_FP:	return *curbuf->b_p_fp != NUL
 				    ? (char_u *)&(curbuf->b_p_fp) : p->var;
+	case PV_FPRG:	return *curbuf->b_p_fprg != NUL
+				    ? (char_u *)&curbuf->b_p_fprg : p->var;
 #ifdef FEAT_QUICKFIX
 	case PV_EFM:	return *curbuf->b_p_efm != NUL
 				    ? (char_u *)&(curbuf->b_p_efm) : p->var;
@@ -6725,6 +6731,17 @@ get_equalprg(void)
     if (*curbuf->b_p_ep == NUL)
 	return p_ep;
     return curbuf->b_p_ep;
+}
+
+/*
+ * Get the value of 'findprg', either the buffer-local one or the global one.
+ */
+    char_u *
+get_findprg(void)
+{
+    if (*curbuf->b_p_fprg == NUL)
+	return p_fprg;
+    return curbuf->b_p_fprg;
 }
 
 /*
@@ -7255,6 +7272,7 @@ buf_copy_options(buf_T *buf, int flags)
 	    buf->b_p_efm = empty_option;
 #endif
 	    buf->b_p_ep = empty_option;
+	    buf->b_p_fprg = empty_option;
 	    buf->b_p_kp = empty_option;
 	    buf->b_p_path = empty_option;
 	    buf->b_p_tags = empty_option;

--- a/src/option.h
+++ b/src/option.h
@@ -596,6 +596,7 @@ EXTERN char_u	*p_ffs;		// 'fileformats'
 EXTERN int	p_fic;		// 'fileignorecase'
 EXTERN char_u	*p_ft;		// 'filetype'
 EXTERN char_u	*p_fcs;		// 'fillchar'
+EXTERN char_u	*p_fprg;	// 'findprg'
 EXTERN int	p_fixeol;	// 'fixendofline'
 #ifdef FEAT_FOLDING
 EXTERN char_u	*p_fcl;		// 'foldclose'
@@ -1169,6 +1170,7 @@ enum
     , BV_ET
     , BV_FENC
     , BV_FP
+    , BV_FPRG
 #ifdef FEAT_EVAL
     , BV_BEXPR
     , BV_FEX

--- a/src/optiondefs.h
+++ b/src/optiondefs.h
@@ -72,6 +72,7 @@
 # define PV_BEXPR	OPT_BOTH(OPT_BUF(BV_BEXPR))
 #endif
 #define PV_FP		OPT_BOTH(OPT_BUF(BV_FP))
+#define PV_FPRG		OPT_BOTH(OPT_BUF(BV_FPRG))
 #ifdef FEAT_EVAL
 # define PV_FEX		OPT_BUF(BV_FEX)
 #endif
@@ -958,6 +959,9 @@ static struct vimoption options[] =
 			    {(char_u *)"vert:|,fold:-,eob:~,lastline:@",
 								  (char_u *)0L}
 			    SCTX_INIT},
+    {"findprg",   "fprg",   P_STRING|P_EXPAND|P_VI_DEF|P_SECURE,
+			    (char_u *)&p_fprg, PV_NONE, NULL, NULL,
+			    {(char_u *)"", (char_u *)0L} SCTX_INIT},
     {"fixendofline",  "fixeol", P_BOOL|P_VI_DEF|P_RSTAT,
 			    (char_u *)&p_fixeol, PV_FIXEOL,
 			    did_set_eof_eol_fixeol_bomb, NULL,

--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -324,6 +324,7 @@ check_buf_options(buf_T *buf)
     check_string_option(&buf->b_p_efm);
 #endif
     check_string_option(&buf->b_p_ep);
+    check_string_option(&buf->b_p_fprg);
     check_string_option(&buf->b_p_path);
     check_string_option(&buf->b_p_tags);
     check_string_option(&buf->b_p_tc);

--- a/src/proto/findfile.pro
+++ b/src/proto/findfile.pro
@@ -12,6 +12,7 @@ char_u *file_name_at_cursor(int options, long count, linenr_T *file_lnum);
 char_u *file_name_in_line(char_u *line, int col, int options, long count, char_u *rel_fname, linenr_T *file_lnum);
 char_u *find_file_name_in_path(char_u *ptr, int len, int options, long count, char_u *rel_fname);
 int vim_ispathlistsep(int c);
+void expand_path_option(char_u *curdir, char_u *path_option, garray_T *gap);
 void uniquefy_paths(garray_T *gap, char_u *pattern, char_u *path_option);
 int expand_in_path(garray_T *gap, char_u *pattern, int flags);
 void simplify_filename(char_u *filename);

--- a/src/proto/option.pro
+++ b/src/proto/option.pro
@@ -119,6 +119,7 @@ char_u *get_option_var(int opt_idx);
 char_u *get_option_fullname(int opt_idx);
 opt_did_set_cb_T get_option_did_set_cb(int opt_idx);
 char_u *get_equalprg(void);
+char_u *get_findprg(void);
 void win_copy_options(win_T *wp_from, win_T *wp_to);
 void after_copy_winopt(win_T *wp);
 void copy_winopt(winopt_T *from, winopt_T *to);

--- a/src/structs.h
+++ b/src/structs.h
@@ -3326,6 +3326,7 @@ struct file_buffer
     char_u	*b_p_efm;	// 'errorformat' local value
 #endif
     char_u	*b_p_ep;	// 'equalprg' local value
+    char_u	*b_p_fprg;	// 'findprg' local value
     char_u	*b_p_path;	// 'path' local value
     int		b_p_ar;		// 'autoread' local value
     char_u	*b_p_tags;	// 'tags' local value

--- a/src/testdir/test_findfile.vim
+++ b/src/testdir/test_findfile.vim
@@ -294,24 +294,24 @@ func Test_findprg()
   call writefile(['bFile'], 'Xdir/dirB/foobar.c', 'D')
 
   call chdir('Xdir')
-  setlocal findprg=find\ .\ -name\ '$*'\|sort
+  setlocal findprg=find\ $@\ -name\ '$*'\|sort
   find foobar.c
-  call assert_equal('./dirA/foobar.c', @%)
+  call assert_match('/dirA/foobar.c$', @%)
   bw!
   2find foobar.c
-  call assert_equal('./dirB/foobar.c', @%)
+  call assert_match('/dirB/foobar.c$', @%)
   bw!
   call assert_fails('3find foobar.c', 'E347: No more file "foobar.c" found in path')
   call assert_fails('find foobar', 'E345: Can''t find file "foobar" in path')
 
   sfind foobar.c
-  call assert_equal('./dirA/foobar.c', @%)
+  call assert_match('/dirA/foobar.c$', @%)
   call assert_equal(2, winnr('$'))
   %bw!
   call assert_fails('sfind foobar', 'E345: Can''t find file "foobar" in path')
 
   tabfind foobar.c
-  call assert_equal('./dirA/foobar.c', @%)
+  call assert_match('/dirA/foobar.c$', @%)
   call assert_equal(2, tabpagenr())
   %bw!
   call assert_fails('tabfind foobar', 'E345: Can''t find file "foobar" in path')

--- a/src/testdir/test_findfile.vim
+++ b/src/testdir/test_findfile.vim
@@ -292,8 +292,11 @@ func Test_findprg()
   call mkdir('Xdir/dirB', 'pR')
   call writefile(['aFile'], 'Xdir/dirA/foobar.c', 'D')
   call writefile(['bFile'], 'Xdir/dirB/foobar.c', 'D')
-
   call chdir('Xdir')
+
+  setlocal path=.,,
+
+  " Test both the "$@" and the "$*" placeholders
   setlocal findprg=find\ $@\ -name\ '$*'\|sort
   find foobar.c
   call assert_match('/dirA/foobar.c$', @%)
@@ -316,8 +319,15 @@ func Test_findprg()
   %bw!
   call assert_fails('tabfind foobar', 'E345: Can''t find file "foobar" in path')
 
+  " Test without the "$@" placeholder
+  setlocal findprg=find\ .\ -name\ '$*'\|sort
+  find foobar.c
+  call assert_match('/dirA/foobar.c$', @%)
+  bw!
+
   call chdir(save_dir)
   set findprg&
+  set path&
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_findfile.vim
+++ b/src/testdir/test_findfile.vim
@@ -294,7 +294,7 @@ func Test_findprg()
   call writefile(['bFile'], 'Xdir/dirB/foobar.c', 'D')
   call chdir('Xdir')
 
-  setlocal path=.,,
+  set path=.,,
 
   " Test both the "$@" and the "$*" placeholders
   setlocal findprg=find\ $@\ -name\ '$*'\|sort

--- a/src/testdir/test_findfile.vim
+++ b/src/testdir/test_findfile.vim
@@ -1,5 +1,7 @@
 " Test findfile() and finddir()
 
+source check.vim
+
 let s:files = [ 'Xfinddir1/foo',
       \         'Xfinddir1/bar',
       \         'Xfinddir1/Xdir2/foo',
@@ -279,6 +281,45 @@ func Test_find_non_existing_path()
   call chdir(save_dir)
   bw!
   let &path = save_path
+endfunc
+
+" Test for 'findprg'
+func Test_findprg()
+  CheckUnix
+  call assert_equal('', &findprg)
+  let save_dir = getcwd()
+  call mkdir('Xdir/dirA/dir1', 'pR')
+  call writefile(['aFile'], 'Xdir/dirA/dir1/1File.c', 'D')
+  call writefile(['bFile'], 'Xdir/dirA/dir1/2File.c', 'D')
+
+  call chdir('Xdir')
+  setlocal findprg=find\ .\ -name\ '$*'\|sort
+  find 1File.c
+  call assert_equal('./dirA/dir1/1File.c', @%)
+  bw!
+  find *.c
+  call assert_equal('./dirA/dir1/1File.c', @%)
+  bw!
+  2find *.c
+  call assert_equal('./dirA/dir1/2File.c', @%)
+  bw!
+  call assert_fails('3find *.c', 'E347: No more file "*.c" found in path')
+  call assert_fails('find foobar', 'E345: Can''t find file "foobar" in path')
+
+  sfind 2File.c
+  call assert_equal('./dirA/dir1/2File.c', @%)
+  call assert_equal(2, winnr('$'))
+  %bw!
+  call assert_fails('sfind foobar', 'E345: Can''t find file "foobar" in path')
+
+  tabfind 1File.c
+  call assert_equal('./dirA/dir1/1File.c', @%)
+  call assert_equal(2, tabpagenr())
+  %bw!
+  call assert_fails('tabfind foobar', 'E345: Can''t find file "foobar" in path')
+
+  call chdir(save_dir)
+  set findprg&
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_findfile.vim
+++ b/src/testdir/test_findfile.vim
@@ -288,32 +288,30 @@ func Test_findprg()
   CheckUnix
   call assert_equal('', &findprg)
   let save_dir = getcwd()
-  call mkdir('Xdir/dirA/dir1', 'pR')
-  call writefile(['aFile'], 'Xdir/dirA/dir1/1File.c', 'D')
-  call writefile(['bFile'], 'Xdir/dirA/dir1/2File.c', 'D')
+  call mkdir('Xdir/dirA', 'pR')
+  call mkdir('Xdir/dirB', 'pR')
+  call writefile(['aFile'], 'Xdir/dirA/foobar.c', 'D')
+  call writefile(['bFile'], 'Xdir/dirB/foobar.c', 'D')
 
   call chdir('Xdir')
   setlocal findprg=find\ .\ -name\ '$*'\|sort
-  find 1File.c
-  call assert_equal('./dirA/dir1/1File.c', @%)
+  find foobar.c
+  call assert_equal('./dirA/foobar.c', @%)
   bw!
-  find *.c
-  call assert_equal('./dirA/dir1/1File.c', @%)
+  2find foobar.c
+  call assert_equal('./dirB/foobar.c', @%)
   bw!
-  2find *.c
-  call assert_equal('./dirA/dir1/2File.c', @%)
-  bw!
-  call assert_fails('3find *.c', 'E347: No more file "*.c" found in path')
+  call assert_fails('3find foobar.c', 'E347: No more file "foobar.c" found in path')
   call assert_fails('find foobar', 'E345: Can''t find file "foobar" in path')
 
-  sfind 2File.c
-  call assert_equal('./dirA/dir1/2File.c', @%)
+  sfind foobar.c
+  call assert_equal('./dirA/foobar.c', @%)
   call assert_equal(2, winnr('$'))
   %bw!
   call assert_fails('sfind foobar', 'E345: Can''t find file "foobar" in path')
 
-  tabfind 1File.c
-  call assert_equal('./dirA/dir1/1File.c', @%)
+  tabfind foobar.c
+  call assert_equal('./dirA/foobar.c', @%)
   call assert_equal(2, tabpagenr())
   %bw!
   call assert_fails('tabfind foobar', 'E345: Can''t find file "foobar" in path')


### PR DESCRIPTION
Add a new 'findprg' option to specify the external command to use for the `:find` command.