### PR TITLE
WIP: `json_encode`, and `vim_snprintf`, loses floating point precision when using `%g`

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -4089,8 +4089,13 @@ eval_concat_str(typval_T *tv1, typval_T *tv2)
 		vartype_name(tv2->v_type));
     else if (vim9script && tv2->v_type == VAR_FLOAT)
     {
-	vim_snprintf((char *)buf2, NUMBUFLEN, "%g",
+#if defined(__LP64__)
+	vim_snprintf((char *)buf2, NUMBUFLEN, "%.*Lg", FLOAT_PRECISION,
 		tv2->vval.v_float);
+#else
+	vim_snprintf((char *)buf2, NUMBUFLEN, "%.*g", FLOAT_PRECISION,
+		tv2->vval.v_float);
+#endif
 	s2 = buf2;
     }
     else
@@ -6320,7 +6325,13 @@ echo_string_core(
 
 	case VAR_FLOAT:
 	    *tofree = NULL;
-	    vim_snprintf((char *)numbuf, NUMBUFLEN, "%g", tv->vval.v_float);
+#if defined(__LP64__)
+	    vim_snprintf((char *)numbuf, NUMBUFLEN, "%.*Lg", FLOAT_PRECISION,
+		    tv->vval.v_float);
+#else
+	    vim_snprintf((char *)numbuf, NUMBUFLEN, "%.*g", FLOAT_PRECISION,
+		    tv->vval.v_float);
+#endif
 	    r = numbuf;
 	    break;
 

--- a/src/globals.h
+++ b/src/globals.h
@@ -1710,6 +1710,7 @@ EXTERN char typename_percent[]	INIT(= N_("percent"));
 EXTERN char typename_char[] INIT(= N_("char"));
 EXTERN char typename_string[]	INIT(= N_("string"));
 EXTERN char typename_float[]	INIT(= N_("float"));
+EXTERN char typename_longfloat[]	INIT(= N_("long float"));
 
 /*
  * When ":global" is used to number of substitutions and changed lines is

--- a/src/json.c
+++ b/src/json.c
@@ -425,8 +425,13 @@ json_encode_item(garray_T *gap, typval_T *val, int copyID, int options)
 	    else
 #endif
 	    {
-		vim_snprintf((char *)numbuf, NUMBUFLEN, "%g",
-							   val->vval.v_float);
+#if defined(__LP64__)
+		vim_snprintf((char *)numbuf, NUMBUFLEN, "%.*Lg",
+			FLOAT_PRECISION, val->vval.v_float);
+#else
+		vim_snprintf((char *)numbuf, NUMBUFLEN, "%.*g",
+			FLOAT_PRECISION, val->vval.v_float);
+#endif
 		ga_concat(gap, numbuf);
 	    }
 	    break;

--- a/src/strings.c
+++ b/src/strings.c
@@ -2273,7 +2273,8 @@ enum
     TYPE_PERCENT,
     TYPE_CHAR,
     TYPE_STRING,
-    TYPE_FLOAT
+    TYPE_FLOAT,
+    TYPE_LONGFLOAT
 };
 
 /* Types that can be used in a format string
@@ -2429,6 +2430,9 @@ format_typename(
 
 	case TYPE_FLOAT:
 	    return _(typename_float);
+
+	case TYPE_LONGFLOAT:
+	    return _(typename_longfloat);
     }
 
     return _(typename_unknown);
@@ -2942,6 +2946,10 @@ skip_to_arg(
 
 	case TYPE_FLOAT:
 	    va_arg(*ap, double);
+	    break;
+
+	case TYPE_LONGFLOAT:
+	    va_arg(*ap, long double);
 	    break;
 	}
     }

--- a/src/strings.c
+++ b/src/strings.c
@@ -2289,8 +2289,8 @@ format_typeof(
     // current conversion specifier character
     char    fmt_spec = '\0';
 
-    // parse 'h', 'l' and 'll' length modifiers
-    if (*type == 'h' || *type == 'l')
+    // parse 'h', 'l', 'll' and 'L' length modifiers
+    if (*type == 'h' || *type == 'l' || *type == 'L')
     {
 	length_modifier = *type;
 	type++;
@@ -2386,7 +2386,14 @@ format_typeof(
     case 'E':
     case 'g':
     case 'G':
-	return TYPE_FLOAT;
+	if (length_modifier == 'L')
+	{
+	    return TYPE_LONGFLOAT;
+	}
+	else
+	{
+	    return TYPE_FLOAT;
+	}
     }
 
     return TYPE_UNKNOWN;
@@ -2768,8 +2775,8 @@ parse_fmt_types(
 		ptype = p;
 	    }
 
-	    // parse 'h', 'l' and 'll' length modifiers
-	    if (*p == 'h' || *p == 'l')
+	    // parse 'h', 'l', 'll' and 'L' length modifiers
+	    if (*p == 'h' || *p == 'l' || *p == 'L')
 	    {
 		length_modifier = *p;
 		p++;
@@ -3223,8 +3230,8 @@ vim_vsnprintf_typval(
 		}
 	    }
 
-	    // parse 'h', 'l' and 'll' length modifiers
-	    if (*p == 'h' || *p == 'l')
+	    // parse 'h', 'l', 'll' and 'L' length modifiers
+	    if (*p == 'h' || *p == 'l' || *p == 'L')
 	    {
 		length_modifier = *p;
 		p++;

--- a/src/structs.h
+++ b/src/structs.h
@@ -1439,7 +1439,16 @@ typedef long_u hash_T;		// Type for hi_hash
 // value.
 typedef signed char int8_T;
 
-typedef double	float_T;
+// Allow longer floats if system supports it, otherwise fallback to behavior we
+// know worked in the past for most use-cases
+//
+// Attributions;
+// - https://gcc.gnu.org/onlinedocs/cpp/Common-Predefined-Macros.html -> __LP64__
+#if defined(__LP64__)
+  typedef long double	float_T;
+#else
+  typedef double	float_T;
+#endif
 
 typedef struct typval_S typval_T;
 typedef struct listvar_S list_T;

--- a/src/typval.c
+++ b/src/typval.c
@@ -1132,7 +1132,13 @@ tv_get_string_buf_chk_strict(typval_T *varp, char_u *buf, int strict)
 		emsg(_(e_using_float_as_string));
 		break;
 	    }
-	    vim_snprintf((char *)buf, NUMBUFLEN, "%g", varp->vval.v_float);
+#if defined(__LP64__)
+	    vim_snprintf((char *)buf, NUMBUFLEN, "%.*Lg", FLOAT_PRECISION,
+		    varp->vval.v_float);
+#else
+	    vim_snprintf((char *)buf, NUMBUFLEN, "%.*g", FLOAT_PRECISION,
+		    varp->vval.v_float);
+#endif
 	    return buf;
 	case VAR_STRING:
 	    if (varp->vval.v_string != NULL)

--- a/src/vim.h
+++ b/src/vim.h
@@ -3003,3 +3003,10 @@ long elapsed(DWORD start_tick);
 #define CF_ABSTRACT_METHOD	4	// inside an abstract class
 
 #endif // VIM__H
+
+#if defined(__LP64__)
+# define FLOAT_PRECISION 20
+#else
+# define FLOAT_PRECISION 5
+#endif
+

--- a/src/vim9execute.c
+++ b/src/vim9execute.c
@@ -6891,7 +6891,16 @@ list_instructions(char *pfx, isn_T *instr, int instr_count, ufunc_T *ufunc)
 				   get_var_special_name(iptr->isn_arg.number));
 		break;
 	    case ISN_PUSHF:
-		smsg("%s%4d PUSHF %g", pfx, current, iptr->isn_arg.fnumber);
+#if defined(__LP64__)
+		smsg("%s%4d PUSHF %.*Lg", FLOAT_PRECISION, pfx, current,
+			iptr->isn_arg.fnumber);
+		/* smsg("%s%4d PUSHF %.20Lg", pfx, current, iptr->isn_arg.fnumber); */
+#else
+		/* smsg("%s%4d PUSHF %g", pfx, current, iptr->isn_arg.fnumber); */
+		smsg("%s%4d PUSHF %.*g", FLOAT_PRECISION, pfx, current,
+			iptr->isn_arg.fnumber);
+
+#endif
 		break;
 	    case ISN_PUSHS:
 		smsg("%s%4d PUSHS \"%s\"", pfx, current, iptr->isn_arg.string);


### PR DESCRIPTION
:warning: This breaks `echo` and messes with other Vim Ex mode commands, ex;

```vim
echo json_encode({'value':0.5670403838157654})
```
> Results could be;
>
> - `{"value":5.068898e-310}`
> - `{"value":1.237282e-313}`
> - `{"value":0.0}`

```vim
:echo json_decode('{"value":0.5670403838157654}')
```
> Results, regardless of float size, always be;
>
> - `{'value': 0.0}`

... Side note; `printf` within Vim Ex mode also has inconsistent behaviors.

## Questions

- Is this worth pursuing?  And if so;
  - What causes the inconsistencies?
  - Where else do I need to apply updates?
  - Is there a convenient way to avoid/expand `e` notation?
  - Any pointers on adding some unit tests?

## Story time

I'm writing a plugin, aimed at Vim8 compatibility, that makes calls to an API that I do not control outputs of.  And the API returns JSON that contains large floats, example;

```json
{
  "embedding": [
    0.5670403838157654,
    0.009260174818336964,
    0.23178744316101074,
    -0.2916173040866852,
    -0.8924556970596313,
    0.8785552978515625,
    -0.34576427936553955,
    0.5742510557174683,
    -0.04222835972905159,
    -0.137906014919281
  ]
}
```

... As of Vim version `9.1.1-785` packaged by Arch, I use Arch (BTW™), these values are truncated to about five digits past the decimal point, eg.

```vim
:echo json_decode('{"embedding":[0.5670403838157654]}')
```
> Result: `{'embedding': [0.56704]}`

Oddly it looks like this might be a `echo` bug, because wrapping with `printf` and using a large limit mostly preserves precision of input floats... _mostly_

```vim
:echo printf('%.25g', json_decode('{"embedding":[0.5670403838157654]}').embedding[0])
```
> Result: `0.5670403838157653808593750`
>
> Notice, we lost the last `4` and picked-up a bunch of extra `3808593750` :shrug:
