### PR TITLE
tests: having 'nolist' in modelines isn't always desired

### DIFF
--- a/runtime/syntax/testdir/viewdumps.vim
+++ b/runtime/syntax/testdir/viewdumps.vim
@@ -21,4 +21,4 @@ set display=lastline ruler scrolloff=5 t_ZH= t_ZR=
 # Anticipate non-Latin-1 characters in "input/" files.
 set encoding=utf-8 termencoding=utf-8
 
-# vim:fdm=syntax:sw=2:ts=8:noet:nolist:nosta:
+# vim:fdm=syntax:sw=2:ts=8:noet:nosta:

--- a/src/testdir/commondumps.vim
+++ b/src/testdir/commondumps.vim
@@ -73,4 +73,4 @@ def g:Init(subtreedirname: string, count: number)
   endif
 enddef
 
-# vim:fdm=syntax:sw=2:ts=8:noet:nolist:nosta:
+# vim:fdm=syntax:sw=2:ts=8:noet:nosta:

--- a/src/testdir/gen_opt_test.vim
+++ b/src/testdir/gen_opt_test.vim
@@ -485,4 +485,4 @@ endif
 
 qa!
 
-" vim:sw=2:ts=8:noet:nolist:nosta:
+" vim:sw=2:ts=8:noet:nosta:

--- a/src/testdir/viewdumps.vim
+++ b/src/testdir/viewdumps.vim
@@ -8,4 +8,4 @@ g:Init('\<src\>', 0)
 # Match ":language" of runtest.vim.
 language messages C
 
-# vim:fdm=syntax:sw=2:ts=8:noet:nolist:nosta:
+# vim:fdm=syntax:sw=2:ts=8:noet:nosta:


### PR DESCRIPTION
Problem:  tests: having 'nolist' in modelines isn't always desired.
Solution: Remove 'nolist' from modelines.

There is no reason to force 'nolist' on anyone that edits these files.
