### PR TITLE
'breakindentopt' does not check in setglobal

### DIFF
--- a/src/indent.c
+++ b/src/indent.c
@@ -869,11 +869,15 @@ get_number_indent(linenr_T lnum)
 
 #if defined(FEAT_LINEBREAK) || defined(PROTO)
 /*
+ * Check "briopt" as 'breakindentopt' and update the members of "wp".
  * This is called when 'breakindentopt' is changed and when a window is
  * initialized.
+ * Returns FAIL for failure, OK otherwise.
  */
     int
-briopt_check(win_T *wp)
+briopt_check(
+    char_u	*briopt,	// when NULL: use "wp->w_p_briopt"
+    win_T	*wp)		// when NULL: only check "briopt"
 {
     char_u	*p;
     int		bri_shift = 0;
@@ -882,7 +886,11 @@ briopt_check(win_T *wp)
     int		bri_list = 0;
     int		bri_vcol = 0;
 
-    p = wp->w_p_briopt;
+    if (briopt != NULL)
+	p = briopt;
+    else
+	p = wp->w_p_briopt;
+
     while (*p != NUL)
     {
 	// Note: Keep this in sync with p_briopt_values
@@ -917,6 +925,9 @@ briopt_check(win_T *wp)
 	if (*p == ',')
 	    ++p;
     }
+
+    if (wp == NULL)
+	return OK;
 
     wp->w_briopt_shift = bri_shift;
     wp->w_briopt_min   = bri_min;

--- a/src/option.c
+++ b/src/option.c
@@ -6751,7 +6751,7 @@ after_copy_winopt(win_T *wp)
     else
 	wp->w_skipcol = 0;
 #ifdef FEAT_LINEBREAK
-    briopt_check(wp);
+    briopt_check(NULL, wp);
 #endif
 #ifdef FEAT_SYN_HL
     fill_culopt_flags(NULL, wp);

--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -1235,17 +1235,19 @@ did_set_breakat(optset_T *args UNUSED)
  * The 'breakindentopt' option is changed.
  */
     char *
-did_set_breakindentopt(optset_T *args UNUSED)
+did_set_breakindentopt(optset_T *args)
 {
-    char *errmsg = NULL;
+    char_u	**varp = (char_u **)args->os_varp;
 
-    if (briopt_check(curwin) == FAIL)
-	errmsg = e_invalid_argument;
+    if (briopt_check(*varp, varp == &curwin->w_p_briopt ? curwin : NULL)
+								      == FAIL)
+	return e_invalid_argument;
+
     // list setting requires a redraw
-    if (curwin->w_briopt_list)
+    if (varp == &curwin->w_p_briopt && curwin->w_briopt_list)
 	redraw_all_later(UPD_NOT_VALID);
 
-    return errmsg;
+    return NULL;
 }
 
     int

--- a/src/proto/indent.pro
+++ b/src/proto/indent.pro
@@ -18,7 +18,7 @@ int get_indent_str(char_u *ptr, int ts, int no_ts);
 int get_indent_str_vtab(char_u *ptr, int ts, int *vts, int no_ts);
 int set_indent(int size, int flags);
 int get_number_indent(linenr_T lnum);
-int briopt_check(win_T *wp);
+int briopt_check(char_u *briopt, win_T *wp);
 int get_breakindent_win(win_T *wp, char_u *line);
 int inindent(int extra);
 void op_reindent(oparg_T *oap, int (*how)(void));

--- a/src/testdir/gen_opt_test.vim
+++ b/src/testdir/gen_opt_test.vim
@@ -45,7 +45,6 @@ endwhile
 let skip_setglobal_reasons = #{
       \ iminsert: 'The global value is always overwritten by the local value',
       \ imsearch: 'The global value is always overwritten by the local value',
-      \ breakindentopt:	'TODO: fix missing error handling for setglobal',
       \ colorcolumn:	'TODO: fix missing error handling for setglobal',
       \ conceallevel:	'TODO: fix missing error handling for setglobal',
       \ foldcolumn:	'TODO: fix missing error handling for setglobal',


### PR DESCRIPTION
### Problem

`setglobal breakindentopt=xxx` does not generate an error, so we can set invalid values:
```vim
setglobal briopt=xxx
set briopt?
" =>   breakindentopt=
new
set briopt?
" =>   breakindentopt=xxx
```