### PR TITLE
tests: add equality test for global-local options on switchback

### DIFF
--- a/src/testdir/gen_opt_test.vim
+++ b/src/testdir/gen_opt_test.vim
@@ -423,8 +423,8 @@ while 1
       endfor
       " Testing to clear the local value and switch back to the global value.
       if global_locals->has_key(fullname)
-	let swichback_val = global_locals[fullname]
-	call add(script, $'setlocal {opt}={swichback_val}')
+	let switchback_val = global_locals[fullname]
+	call add(script, $'setlocal {opt}={switchback_val}')
 	call add(script, $'call assert_equal(&g:{fullname}, &{fullname})')
       endif
     endfor

--- a/src/testdir/gen_opt_test.vim
+++ b/src/testdir/gen_opt_test.vim
@@ -25,7 +25,7 @@ endwhile
 call extend(global_locals, #{
       \ scrolloff: -1,
       \ sidescrolloff: -1,
-      \ undolevels: -12345,
+      \ undolevels: -123456,
       \})
 
 " Get local-noglobal options.
@@ -61,7 +61,8 @@ let skip_setglobal_reasons = #{
       \ textwidth:	'TODO: fix missing error handling for setglobal',
       \}
 
-" The terminal size is restored at the end.
+" Script header.
+" The test values contains multibyte characters.
 let script = [
       \ '" DO NOT EDIT: Generated with gen_opt_test.vim',
       \ '" Used by test_options_all.vim.',
@@ -424,6 +425,7 @@ while 1
       if global_locals->has_key(fullname)
 	let swichback_val = global_locals[fullname]
 	call add(script, $'setlocal {opt}={swichback_val}')
+	call add(script, $'call assert_equal(&g:{fullname}, &{fullname})')
       endif
     endfor
 

--- a/src/testdir/gen_opt_test.vim
+++ b/src/testdir/gen_opt_test.vim
@@ -1,7 +1,7 @@
 " Script to generate src/testdir/opt_test.vim from src/optiondefs.h and
 " runtime/doc/options.txt
 
-set cpo=&vim
+set cpo&vim
 
 " Only do this when build with the +eval feature.
 if 1


### PR DESCRIPTION
### Problem

> Why is this -12345 instead of -123456?
https://github.com/vim/vim/pull/15894#pullrequestreview-2383502146

> It seems that this line should be removed as well.
https://github.com/vim/vim/pull/15894#pullrequestreview-2383504112

### Solution

- Fix restore value for `undolevels`.
- Fix comments.
- Add equality test for global-local options on switchback.