### PR TITLE
'colorcolumn' does not check in setglobal

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -214,7 +214,7 @@ open_buffer(
 	enter_buffer(curbuf);
 #ifdef FEAT_SYN_HL
 	if (old_tw != curbuf->b_p_tw)
-	    check_colorcolumn(curwin);
+	    check_colorcolumn(NULL, curwin);
 #endif
 	return FAIL;
     }
@@ -1213,7 +1213,7 @@ handle_swap_exists(bufref_T *old_curbuf)
 
 #ifdef FEAT_SYN_HL
 	    if (old_tw != curbuf->b_p_tw)
-		check_colorcolumn(curwin);
+		check_colorcolumn(NULL, curwin);
 #endif
 	}
 	// If "old_curbuf" is NULL we are in big trouble here...
@@ -1911,7 +1911,7 @@ set_curbuf(buf_T *buf, int action)
 	    enter_buffer(buf);
 #ifdef FEAT_SYN_HL
 	if (old_tw != curbuf->b_p_tw)
-	    check_colorcolumn(curwin);
+	    check_colorcolumn(NULL, curwin);
 #endif
     }
 }

--- a/src/option.c
+++ b/src/option.c
@@ -4328,7 +4328,7 @@ did_set_textwidth(optset_T *args UNUSED)
 	tabpage_T	*tp;
 
 	FOR_ALL_TAB_WINDOWS(tp, wp)
-	    check_colorcolumn(wp);
+	    check_colorcolumn(NULL, wp);
     }
 #endif
 
@@ -6755,7 +6755,7 @@ after_copy_winopt(win_T *wp)
 #endif
 #ifdef FEAT_SYN_HL
     fill_culopt_flags(NULL, wp);
-    check_colorcolumn(wp);
+    check_colorcolumn(NULL, wp);
 #endif
     set_listchars_option(wp, wp->w_p_lcs, TRUE, NULL, 0);
     set_fillchars_option(wp, wp->w_p_fcs, TRUE, NULL, 0);

--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -1478,9 +1478,11 @@ did_set_cinoptions(optset_T *args UNUSED)
  * The 'colorcolumn' option is changed.
  */
     char *
-did_set_colorcolumn(optset_T *args UNUSED)
+did_set_colorcolumn(optset_T *args)
 {
-    return check_colorcolumn(curwin);
+    char_u	**varp = (char_u **)args->os_varp;
+
+    return check_colorcolumn(*varp, varp == &curwin->w_p_cc ? curwin : NULL);
 }
 #endif
 

--- a/src/proto/window.pro
+++ b/src/proto/window.pro
@@ -98,7 +98,7 @@ void restore_snapshot(int idx, int close_curwin);
 int win_hasvertsplit(void);
 int get_win_number(win_T *wp, win_T *first_win);
 int get_tab_number(tabpage_T *tp);
-char *check_colorcolumn(win_T *wp);
+char *check_colorcolumn(char_u *cc, win_T *wp);
 int get_last_winid(void);
 int win_locked(win_T *wp);
 /* vim: set ft=c : */

--- a/src/testdir/gen_opt_test.vim
+++ b/src/testdir/gen_opt_test.vim
@@ -46,7 +46,6 @@ let skip_setglobal_reasons = #{
       \ iminsert: 'The global value is always overwritten by the local value',
       \ imsearch: 'The global value is always overwritten by the local value',
       \ breakindentopt:	'TODO: fix missing error handling for setglobal',
-      \ colorcolumn:	'TODO: fix missing error handling for setglobal',
       \ conceallevel:	'TODO: fix missing error handling for setglobal',
       \ foldcolumn:	'TODO: fix missing error handling for setglobal',
       \ foldmethod:	'TODO: fix `setglobal fdm=` not given an error',


### PR DESCRIPTION
### Problem

`setglobal colorcolumn=xxx` does not generate an error, so we can set invalid values:
```vim
setglobal cc=xxx
set cc?
" =>   colorcolumn=
new
set cc?
" =>   colorcolumn=xxx
```