### PR TITLE
'foldmethod' does not check correctly in setglobal

### DIFF
--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -2336,8 +2336,7 @@ did_set_foldmethod(optset_T *args)
 {
     char_u	**varp = (char_u **)args->os_varp;
 
-    if (check_opt_strings(*varp, p_fdm_values, FALSE) != OK
-	    || *curwin->w_p_fdm == NUL)
+    if (check_opt_strings(*varp, p_fdm_values, FALSE) != OK || **varp == NUL)
 	return e_invalid_argument;
 
     foldUpdateAll(curwin);

--- a/src/testdir/gen_opt_test.vim
+++ b/src/testdir/gen_opt_test.vim
@@ -49,7 +49,6 @@ let skip_setglobal_reasons = #{
       \ colorcolumn:	'TODO: fix missing error handling for setglobal',
       \ conceallevel:	'TODO: fix missing error handling for setglobal',
       \ foldcolumn:	'TODO: fix missing error handling for setglobal',
-      \ foldmethod:	'TODO: fix `setglobal fdm=` not given an error',
       \ iskeyword:	'TODO: fix missing error handling for setglobal',
       \ numberwidth:	'TODO: fix missing error handling for setglobal',
       \ scrolloff:	'TODO: fix missing error handling for setglobal',


### PR DESCRIPTION
### Problem

`setglobal foldmethod=` does not generate an error, so we can set empty value:
```vim
setglobal fdm=
set fdm?
" =>   foldmethod=manual
new
set fdm?
" =>   foldmethod=
```