### PR TITLE
'termwinkey' does not check in setglobal

### DIFF
--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -3892,9 +3892,11 @@ did_set_term_option(optset_T *args)
  * The 'termwinkey' option is changed.
  */
     char *
-did_set_termwinkey(optset_T *args UNUSED)
+did_set_termwinkey(optset_T *args)
 {
-    if (*curwin->w_p_twk != NUL && string_to_key(curwin->w_p_twk, TRUE) == 0)
+    char_u	**varp = (char_u **)args->os_varp;
+
+    if ((*varp)[0] != NUL && string_to_key(*varp, TRUE) == 0)
 	return e_invalid_argument;
 
     return NULL;

--- a/src/testdir/gen_opt_test.vim
+++ b/src/testdir/gen_opt_test.vim
@@ -56,7 +56,6 @@ let skip_setglobal_reasons = #{
       \ shiftwidth:	'TODO: fix missing error handling for setglobal',
       \ sidescrolloff:	'TODO: fix missing error handling for setglobal',
       \ tabstop:	'TODO: fix missing error handling for setglobal',
-      \ termwinkey:	'TODO: fix missing error handling for setglobal',
       \ termwinsize:	'TODO: fix missing error handling for setglobal',
       \ textwidth:	'TODO: fix missing error handling for setglobal',
       \}


### PR DESCRIPTION
### Problem

`setglobal termwinkey=<xxx>` does not generate an error, so we can set invalid values:
```vim
setglobal twk=<xxx>
set twk?
" =>   termwinkey=
new
set twk?
" =>   termwinkey=<xxx>
```