### PR TITLE
Support expanding :find command argument using 'findexpr'

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3552,7 +3552,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	  eob		EndOfBuffer		|hl-EndOfBuffer|
 	  lastline	NonText			|hl-NonText|
 
-						*'findexpr'* *'fexpr'*
+						*'findexpr'* *'fexpr'* *E1514*
 'findexpr' 'fexpr'	string	(default "")
 			global or local to buffer |global-local|
 			{not available when compiled without the |+eval|

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -4574,6 +4574,7 @@ E1510	change.txt	/*E1510*
 E1511	options.txt	/*E1511*
 E1512	options.txt	/*E1512*
 E1513	message.txt	/*E1513*
+E1514	options.txt	/*E1514*
 E152	helphelp.txt	/*E152*
 E153	helphelp.txt	/*E153*
 E154	helphelp.txt	/*E154*

--- a/src/errors.h
+++ b/src/errors.h
@@ -3652,3 +3652,5 @@ EXTERN char e_wrong_character_width_for_field_str[]
 	INIT(= N_("E1512: Wrong character width for field \"%s\""));
 EXTERN char e_winfixbuf_cannot_go_to_buffer[]
 	INIT(= N_("E1513: Cannot switch buffer. 'winfixbuf' is enabled"));
+EXTERN char e_invalid_return_type_from_findexpr[]
+	INIT(= N_("E1514: findexpr did not return a List type"));

--- a/src/proto/ex_docmd.pro
+++ b/src/proto/ex_docmd.pro
@@ -46,6 +46,7 @@ void tabpage_close_other(tabpage_T *tp, int forceit);
 void ex_stop(exarg_T *eap);
 void handle_drop(int filec, char_u **filev, int split, void (*callback)(void *), void *cookie);
 void handle_any_postponed_drop(void);
+int expand_findexpr(char_u *pat, char_u ***files, int *numMatches);
 void ex_splitview(exarg_T *eap);
 void tabpage_new(void);
 void do_exedit(exarg_T *eap, win_T *old_curwin);

--- a/src/testdir/test_findfile.vim
+++ b/src/testdir/test_findfile.vim
@@ -294,7 +294,6 @@ func Test_findexpr()
   " basic tests
   func FindExpr1()
     let fnames = ['Xfindexpr1.c', 'Xfindexpr2.c', 'Xfindexpr3.c']
-    "return fnames->copy()->filter('v:val =~? v:fname')->join("\n")
     return fnames->copy()->filter('v:val =~? v:fname')
   endfunc
 
@@ -353,8 +352,8 @@ func Test_findexpr()
   set findexpr=FindExpr2()
   call assert_fails('find Xfindexpr1.c', 'find error')
 
-  " Try using a null string as the expression
-  set findexpr=test_null_string()
+  " Try using a null List as the expression
+  set findexpr=test_null_list()
   call assert_fails('find Xfindexpr1.c', 'E345: Can''t find file "Xfindexpr1.c" in path')
 
   " Try to create a new window from the find expression
@@ -372,6 +371,10 @@ func Test_findexpr()
   endfunc
   set findexpr=FindExpr4()
   call assert_fails('find Xfindexpr1.c', 'E565: Not allowed to change text or change window')
+
+  " Expression returning a string
+  set findexpr='abc'
+  call assert_fails('find Xfindexpr1.c', 'E1514: findexpr did not return a List type')
 
   set findexpr&
   delfunc! FindExpr1
@@ -447,6 +450,33 @@ func Test_findexpr_scriptlocal_func()
 
   set findexpr=
   delfunc s:FindExprScript
+endfunc
+
+" Test for expanding the argument to the :find command using 'findexpr'
+func Test_findexpr_expand_arg()
+  func FindExpr1()
+    let fnames = ['Xfindexpr1.c', 'Xfindexpr2.c', 'Xfindexpr3.c']
+    return fnames->copy()->filter('v:val =~? v:fname')
+  endfunc
+  set findexpr=FindExpr1()
+
+  call feedkeys(":find \<Tab>\<C-B>\"\<CR>", "xt")
+  call assert_equal('"find Xfindexpr1.c', @:)
+
+  call feedkeys(":find Xfind\<Tab>\<Tab>\<C-B>\"\<CR>", "xt")
+  call assert_equal('"find Xfindexpr2.c', @:)
+
+  call feedkeys(":find *3*\<Tab>\<C-B>\"\<CR>", "xt")
+  call assert_equal('"find Xfindexpr3.c', @:)
+
+  call feedkeys(":find Xfind\<C-A>\<C-B>\"\<CR>", "xt")
+  call assert_equal('"find Xfindexpr1.c Xfindexpr2.c Xfindexpr3.c', @:)
+
+  call feedkeys(":find abc\<Tab>\<C-B>\"\<CR>", "xt")
+  call assert_equal('"find abc', @:)
+
+  set findexpr&
+  delfunc! FindExpr1
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
When the 'findexpr' option is set, use that to expand the argument to the ':find' command.