### PR TITLE
defaults: make putty background by default dark

### DIFF
--- a/runtime/defaults.vim
+++ b/runtime/defaults.vim
@@ -115,6 +115,10 @@ if 1
       \ |   execute "normal! g`\""
       \ | endif
 
+    " Set the default background for putty to dark. Putty usually sets the 
+    " $TERM to xterm and by default it starts with a dark background which
+    " makes syntax highlighting often hard to read with bg=light
+    autocmd TermResponse * if v:termresponse == "\e[>0;136;0c" | set bg=dark | endif
   augroup END
 
   " Quite a few people accidentally type "q:" instead of ":q" and get confused

--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -1701,6 +1701,8 @@ func Test_verbose_option()
   CheckScreendump
 
   let lines =<< trim [SCRIPT]
+    " clear the TermResponse autocommand from defaults.vim
+    au! vimStartup TermResponse
     command DoSomething echo 'hello' |set ts=4 |let v = '123' |echo v
     call feedkeys("\r", 't') " for the hit-enter prompt
     set verbose=20


### PR DESCRIPTION
Vim tries to determine the default background and checks for $TERM and even checks for the "putty" value. But unfortunately, putty by default uses "xterm" as $TERM and as such Vim uses a "light" background

So use a TermResponse autocommand to set the background for putty back to dark.