### PR TITLE
mapset() may remove unrelated mapping

### DIFF
--- a/src/testdir/test_map_functions.vim
+++ b/src/testdir/test_map_functions.vim
@@ -540,6 +540,25 @@ func Test_map_restore_negative_sid()
   call delete('Xresult')
 endfunc
 
+" Check that restoring a mapping doesn't remove a mapping whose {rhs} matches
+" the restored mapping's {lhs}.
+func Test_map_restore_with_rhs_match_lhs()
+  nnoremap <F2> <F3>
+  nnoremap <F3> <F4>
+  call assert_equal('<F3>', maparg('<F2>', 'n'))
+  call assert_equal('<F4>', maparg('<F3>', 'n'))
+  let d = maparg('<F3>', 'n', v:false, v:true)
+  nunmap <F3>
+  call assert_equal('<F3>', maparg('<F2>', 'n'))
+  call assert_equal('', maparg('<F3>', 'n'))
+  call mapset(d)
+  call assert_equal('<F3>', maparg('<F2>', 'n'))
+  call assert_equal('<F4>', maparg('<F3>', 'n'))
+
+  nunmap <F2>
+  nunmap <F3>
+endfunc
+
 def Test_maplist()
   new
   def ClearMappingsAbbreviations()

--- a/src/vim.h
+++ b/src/vim.h
@@ -1013,9 +1013,10 @@ extern int (*dyn_libintl_wputenv)(const wchar_t *envstring);
 #define KEY_COMPLETE	0x103	// end of completion
 
 // Used for the first argument of do_map()
-#define MAPTYPE_MAP	0
-#define MAPTYPE_UNMAP	1
-#define MAPTYPE_NOREMAP	2
+#define MAPTYPE_MAP		0
+#define MAPTYPE_UNMAP		1
+#define MAPTYPE_NOREMAP		2
+#define MAPTYPE_UNMAP_LHS	3
 
 // Values for "noremap" argument of ins_typebuf().  Also used for
 // map->m_noremap and menu->noremap[].


### PR DESCRIPTION
Problem:  mapset() may remove unrelated mapping whose {rhs} matches the
          restored mapping's {lhs}.
Solution: Only match by {lhs} when unmapping for mapset().
