### PR TITLE
netrw: fix typo of missing let

### DIFF
--- a/runtime/plugin/netrwPlugin.vim
+++ b/runtime/plugin/netrwPlugin.vim
@@ -96,7 +96,7 @@ if exists(':Launch') == 2
   elseif executable('open')
       let s:cmd = 'open'
   else
-    s:cmd = ''
+      let s:cmd = ''
   endif
   function s:Open(cmd, file)
     if empty(a:cmd) && !exists('g:netrw_browsex_viewer')


### PR DESCRIPTION
As kindly pointed out by @zzzyxwvut in https://github.com/vim/vim/commit/3d7e567ea7392e43a90a6ffb3cd49b71a7b59d1a#diff-04bdb3e603079bce69af82dde6018a473e9ec1da595229d3f7bfc777885a169aR39