### PR TITLE
runtime(netrw): fix E874 when browsing remote directory which contains `~` character

### DIFF
--- a/runtime/autoload/netrw.vim
+++ b/runtime/autoload/netrw.vim
@@ -9588,7 +9588,7 @@ fun! s:NetrwTreeListing(dirname)
     let w:netrw_treetop= a:dirname
     let s:netrw_treetop= w:netrw_treetop
 "    call Decho("w:netrw_treetop<".w:netrw_treetop."> (reusing)",'~'.expand("<slnum>"))
-   elseif (w:netrw_treetop =~ ('^'.a:dirname) && s:Strlen(a:dirname) < s:Strlen(w:netrw_treetop)) || a:dirname !~ ('^'.w:netrw_treetop)
+   elseif (w:netrw_treetop =~ ('^'.'\M'.a:dirname) && s:Strlen(a:dirname) < s:Strlen(w:netrw_treetop)) || a:dirname !~ ('^'.'\M'.w:netrw_treetop)
 "    call Decho("update the treetop  (override w:netrw_treetop with a:dirname<".a:dirname.">)",'~'.expand("<slnum>"))
     let w:netrw_treetop= a:dirname
     let s:netrw_treetop= w:netrw_treetop

--- a/runtime/autoload/netrw.vim
+++ b/runtime/autoload/netrw.vim
@@ -9588,7 +9588,7 @@ fun! s:NetrwTreeListing(dirname)
     let w:netrw_treetop= a:dirname
     let s:netrw_treetop= w:netrw_treetop
 "    call Decho("w:netrw_treetop<".w:netrw_treetop."> (reusing)",'~'.expand("<slnum>"))
-   elseif (w:netrw_treetop =~ ('^'.'\M'.a:dirname) && s:Strlen(a:dirname) < s:Strlen(w:netrw_treetop)) || a:dirname !~ ('^'.'\M'.w:netrw_treetop)
+   elseif (w:netrw_treetop =~ ('^'.'\V'.a:dirname) && s:Strlen(a:dirname) < s:Strlen(w:netrw_treetop)) || a:dirname !~ ('^'.'\V'.w:netrw_treetop)
 "    call Decho("update the treetop  (override w:netrw_treetop with a:dirname<".a:dirname.">)",'~'.expand("<slnum>"))
     let w:netrw_treetop= a:dirname
     let s:netrw_treetop= w:netrw_treetop


### PR DESCRIPTION
Fixes https://github.com/neovim/neovim/issues/30991

The regexp was matching against the `~` character in the directory name, which causes the regexp engine to pop the latest substitute string which didn't exist.

`\M` disables the `~` special character (and others) for the rest of the string, which is the directory name that may contain `~` in our case.