### PR TITLE
Adding an .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+root = true
+
+[*]
+indent_style = tab
+tab_width = 8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{c,h,proto}]
+indent_size = 4
+
+[*.{md,yml,sh,bat}]
+# This will become the default after we migrate the codebase
+indent_style = space
+indent_size = 2
+
+[*.md]
+# Markdown uses trailing whitespaces to do an hard line break
+# https://spec.commonmark.org/0.31.2/#hard-line-breaks
+trim_trailing_whitespace = false

--- a/Filelist
+++ b/Filelist
@@ -17,6 +17,7 @@ SRC_ALL =	\
 		.hgignore \
 		.appveyor.yml \
 		.codecov.yml \
+		.editorconfig \
 		ci/appveyor.bat \
 		ci/config.mk*.sed \
 		ci/if_ver*.vim \


### PR DESCRIPTION
This commit tries to use an editorconfig file to ensure the same settings across editors while contributing to the vim repository.

The rules are based of the guidelines defined in `runtime/doc/develop.txt`.