### PR TITLE
CI: Raise the timeout value for search*() when testing

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -22,9 +22,10 @@ freebsd_task:
     - chown -R cirrus:cirrus .
     - sudo -u cirrus make test
   on_failure:
-    screendump_artifacts:
+    test_artifacts:
       name: "Cirrus-CI-freebsd-failed-tests"
       path: |
+        runtime/indent/testdir/*.fail
         runtime/syntax/testdir/failed/*
         src/testdir/failed/*
       type: application/octet-stream

--- a/.github/actions/test_artifacts/action.yml
+++ b/.github/actions/test_artifacts/action.yml
@@ -1,5 +1,5 @@
-name: 'screendump'
-description: "Upload failed screendump tests"
+name: 'test_artifacts'
+description: "Upload failed test artifacts"
 runs:
   using: "composite"
   steps:
@@ -12,6 +12,7 @@ runs:
         # A file, directory or wildcard pattern that describes what
         # to upload.
         path: |
+         ${{ github.workspace }}/runtime/indent/testdir/*.fail
          ${{ github.workspace }}/runtime/syntax/testdir/failed/*
          ${{ github.workspace }}/src/testdir/failed/*
         # The desired behavior if no files are found using the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,7 +272,7 @@ jobs:
           do_test make ${SHADOWOPT} ${TEST}
 
       - if: ${{ !cancelled() }}
-        uses: ./.github/actions/screendump
+        uses: ./.github/actions/test_artifacts
 
       - name: Vim tags
         if: contains(matrix.extra, 'vimtags')
@@ -394,7 +394,7 @@ jobs:
           make ${TEST}
 
       - if: ${{ !cancelled() }}
-        uses: ./.github/actions/screendump
+        uses: ./.github/actions/test_artifacts
 
   windows:
     runs-on: windows-2022
@@ -704,7 +704,7 @@ jobs:
           )
 
       - if: ${{ !cancelled() }}
-        uses: ./.github/actions/screendump
+        uses: ./.github/actions/test_artifacts
 
       - name: Generate gcov files
         if: matrix.coverage

--- a/Filelist
+++ b/Filelist
@@ -10,8 +10,8 @@ SRC_ALL =	\
 		.github/ISSUE_TEMPLATE/feature_request.md \
 		.github/workflows/ci.yml \
 		.github/workflows/codeql-analysis.yml \
-		.github/actions/screendump/action.yml \
 		.github/workflows/coverity.yml \
+		.github/actions/test_artifacts/action.yml \
 		.github/dependabot.yml \
 		.gitignore \
 		.hgignore \

--- a/src/testdir/runtest.vim
+++ b/src/testdir/runtest.vim
@@ -247,6 +247,11 @@ func RunTheTest(test)
     let g:timeout_start = localtime()
   endif
 
+  if ValgrindOrAsan()
+    let g:vim_indent = {"searchpair_timeout": 1024}
+    let g:python_indent = {"searchpair_timeout": 1024}
+  endif
+
   " Avoid stopping at the "hit enter" prompt
   set nomore
 

--- a/src/testdir/shared.vim
+++ b/src/testdir/shared.vim
@@ -318,6 +318,14 @@ func RunningWithValgrind()
   return GetVimCommand() =~ '\<valgrind\>'
 endfunc
 
+func RunningAsan()
+  return exists("$ASAN_OPTIONS")
+endfunc
+
+func ValgrindOrAsan()
+  return RunningWithValgrind() || RunningAsan()
+endfun
+
 " Get the command to run Vim, with --clean instead of "-u NONE".
 func GetVimCommandClean()
   let cmd = GetVimCommand()


### PR DESCRIPTION
There are intermittent failures with [ASan](https://github.com/google/sanitizers/wiki/AddressSanitizer) Vim builds that  
run indent tests.  Typical logs report varying byte counts  
for the expected and the obtained results.  [For example](https://github.com/vim/vim/actions/runs/11587133292/job/32258841875),  
a two-byte excess can be spotted for `testdir/vim.fail`  
(`testdir/vim.fail`: 12579B; `testdir/vim.out`: 12577B).

I did some local indent testing with an old ASan Vim build  
(`v9.1.0380`) and a variable number of `yes(1)` instances to  
load the CPUs; it turns out that raising the timeout for  
`searchpair()` (and `search()`) improves the odds for passing  
a test:

```
let g:vim_indent = {"searchpair_timeout": 1024}
let g:python_indent = {"searchpair_timeout": 1024}
```

[failures.tar.gz](https://github.com/user-attachments/files/17604034/failures.tar.gz) is a small archive with locally failed test  
files.

Curiously, the byte tally for `*.out` and `*.fail` can be  
equal (and a different byte distribution), less, or greater.


