### PR TITLE
Utilise string_T structure to store strings

### DIFF
--- a/src/autocmd.c
+++ b/src/autocmd.c
@@ -707,8 +707,8 @@ event_name2nr(char_u *start, char_u **end)
 	;
 
     target.key = 0;
-    target.value = (char *)start;
-    target.length = (size_t)(p - start);
+    target.value.string = start;
+    target.value.length = (size_t)(p - start);
 
     // special cases:
     // BufNewFile and BufRead are searched for ALOT (especially at startup)
@@ -752,7 +752,7 @@ event_nr2name(event_T event)
     for (i = cache_last_index; cache_tab[i] >= 0; )
     {
 	if ((event_T)event_tab[cache_tab[i]].key == event)
-	    return (char_u *)event_tab[cache_tab[i]].value;
+	    return event_tab[cache_tab[i]].value.string;
 
 	if (i == 0)
 	    i = ARRAY_LENGTH(cache_tab) - 1;
@@ -780,7 +780,7 @@ event_nr2name(event_T event)
 	}
     }
 
-    return (i == (int)ARRAY_LENGTH(event_tab)) ? (char_u *)"Unknown" : (char_u *)event_tab[i].value;
+    return (i == (int)ARRAY_LENGTH(event_tab)) ? (char_u *)"Unknown" : event_tab[i].value.string;
 }
 
 /*
@@ -2880,7 +2880,7 @@ get_event_name(expand_T *xp UNUSED, int idx)
     if (i < 0 || i >= (int)ARRAY_LENGTH(event_tab))
 	return NULL;
 
-    return (char_u *)event_tab[i].value;
+    return event_tab[i].value.string;
 }
 
 /*
@@ -2893,7 +2893,7 @@ get_event_name_no_group(expand_T *xp UNUSED, int idx)
     if (idx < 0 || idx >= (int)ARRAY_LENGTH(event_tab))
 	return NULL;
 
-    return (char_u *)event_tab[idx].value;
+    return event_tab[idx].value.string;
 }
 
 
@@ -3365,8 +3365,8 @@ f_autocmd_get(typval_T *argvars, typval_T *rettv)
 		keyvalue_T *entry;
 
 		target.key = 0;
-		target.value = (char *)name;
-		target.length = (int)STRLEN(target.value);
+		target.value.string = name;
+		target.value.length = STRLEN(target.value.string);
 		entry = (keyvalue_T *)bsearch(&target, &event_tab, ARRAY_LENGTH(event_tab), sizeof(event_tab[0]), cmp_keyvalue_value_ni);
 		if (entry == NULL)
 		{

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -9530,14 +9530,14 @@ find_cmdline_var(char_u *src, size_t *usedlen)
 
     case '<':
 	target.key = 0;
-	target.value = (char *)src + 1;	    // skip over '<'
-	target.length = 0;		    // not used, see cmp_keyvalue_value_n()
+	target.value.string = src + 1;	    // skip over '<'
+	target.value.length = 0;	    // not used, see cmp_keyvalue_value_n()
 
 	entry = (keyvalue_T *)bsearch(&target, &spec_str_tab, ARRAY_LENGTH(spec_str_tab), sizeof(spec_str_tab[0]), cmp_keyvalue_value_n);
 	if (entry == NULL)
 	    return -1;
 
-	*usedlen = entry->length + 1;
+	*usedlen = entry->value.length + 1;
 	return entry->key;
 
     default:

--- a/src/highlight.c
+++ b/src/highlight.c
@@ -869,10 +869,10 @@ highlight_set_termgui_attr(int idx, char_u *key, char_u *arg, int init)
     attr = 0;
     off = 0;
     target.key = 0;
-    target.length = 0;	// not used, see cmp_keyvalue_value_ni()
+    target.value.length = 0;	// not used, see cmp_keyvalue_value_ni()
     while (arg[off] != NUL)
     {
-	target.value = (char *)arg + off;
+	target.value.string = (char *)arg + off;
 	entry = (keyvalue_T *)bsearch(&target, &highlight_tab, ARRAY_LENGTH(highlight_tab), sizeof(highlight_tab[0]), cmp_keyvalue_value_ni);
 	if (entry == NULL)
 	{
@@ -881,7 +881,7 @@ highlight_set_termgui_attr(int idx, char_u *key, char_u *arg, int init)
 	}
 
 	attr |= entry->key;
-	off += entry->length;
+	off += entry->value.length;
 	if (arg[off] == ',')		// another one follows
 	    ++off;
     }
@@ -1214,8 +1214,8 @@ highlight_set_cterm_color(
 	keyvalue_T *entry;
 
 	target.key = 0;
-	target.value = (char *)arg;
-	target.length = 0;	// not used, see cmp_keyvalue_value_i()
+	target.value.string = arg;
+	target.value.length = 0;	// not used, see cmp_keyvalue_value_i()
 	entry = (keyvalue_T *)bsearch(&target, &color_name_tab, ARRAY_LENGTH(color_name_tab), sizeof(color_name_tab[0]), cmp_keyvalue_value_i);
 	if (entry == NULL)
 	{
@@ -2541,8 +2541,8 @@ gui_get_color_cmn(char_u *name)
 	return color;
 
     target.key = 0;
-    target.value = (char *)name;
-    target.length = 0;		// not used, see cmp_keyvalue_value_i()
+    target.value.string = name;
+    target.value.length = 0;		// not used, see cmp_keyvalue_value_i()
     entry = (keyvalue_T *)bsearch(&target, &rgb_tab, ARRAY_LENGTH(rgb_tab), sizeof(rgb_tab[0]), cmp_keyvalue_value_i);
     if (entry != NULL)
 	return gui_adjust_rgb((guicolor_T)entry->key);
@@ -3139,8 +3139,8 @@ highlight_list_arg(
 		    STRCPY(buf + buflen, (char_u *)",");
 		    ++buflen;
 		}
-		STRCPY(buf + buflen, (char_u *)highlight_index_tab[i]->value);
-		buflen += highlight_index_tab[i]->length;
+		STRCPY(buf + buflen, highlight_index_tab[i]->value.string);
+		buflen += highlight_index_tab[i]->value.length;
 		iarg &= ~highlight_index_tab[i]->key;	    // don't want "inverse"/"reverse"
 	    }
 	}
@@ -4236,7 +4236,7 @@ highlight_get_attr_dict(int hlattr)
     {
 	if (hlattr & highlight_index_tab[i]->key)
 	{
-	    dict_add_bool(dict, highlight_index_tab[i]->value, VVAL_TRUE);
+	    dict_add_bool(dict, highlight_index_tab[i]->value.string, VVAL_TRUE);
 	    hlattr &= ~highlight_index_tab[i]->key;	// don't want "inverse"/"reverse"
 	}
     }
@@ -4478,14 +4478,14 @@ hldict_attr_to_str(
     p = attr_str;
     for (i = 0; i < (int)ARRAY_LENGTH(highlight_tab); ++i)
     {
-	if (dict_get_bool(attrdict, highlight_tab[i].value, VVAL_FALSE) == VVAL_TRUE)
+	if (dict_get_bool(attrdict, highlight_tab[i].value.string, VVAL_FALSE) == VVAL_TRUE)
 	{
 	    if (p != attr_str && (size_t)(p - attr_str + 2) < len)
 		STRCPY(p, (char_u *)",");
-	    if (p - attr_str + highlight_tab[i].length + 1 < len)
+	    if (p - attr_str + highlight_tab[i].value.length + 1 < len)
 	    {
-		STRCPY(p, highlight_tab[i].value);
-		p += highlight_tab[i].length;
+		STRCPY(p, highlight_tab[i].value.string);
+		p += highlight_tab[i].value.length;
 	    }
 	}
     }

--- a/src/highlight.c
+++ b/src/highlight.c
@@ -872,7 +872,7 @@ highlight_set_termgui_attr(int idx, char_u *key, char_u *arg, int init)
     target.value.length = 0;	// not used, see cmp_keyvalue_value_ni()
     while (arg[off] != NUL)
     {
-	target.value.string = (char *)arg + off;
+	target.value.string = arg + off;
 	entry = (keyvalue_T *)bsearch(&target, &highlight_tab, ARRAY_LENGTH(highlight_tab), sizeof(highlight_tab[0]), cmp_keyvalue_value_ni);
 	if (entry == NULL)
 	{
@@ -4236,7 +4236,7 @@ highlight_get_attr_dict(int hlattr)
     {
 	if (hlattr & highlight_index_tab[i]->key)
 	{
-	    dict_add_bool(dict, highlight_index_tab[i]->value.string, VVAL_TRUE);
+	    dict_add_bool(dict, (char *)highlight_index_tab[i]->value.string, VVAL_TRUE);
 	    hlattr &= ~highlight_index_tab[i]->key;	// don't want "inverse"/"reverse"
 	}
     }
@@ -4478,7 +4478,7 @@ hldict_attr_to_str(
     p = attr_str;
     for (i = 0; i < (int)ARRAY_LENGTH(highlight_tab); ++i)
     {
-	if (dict_get_bool(attrdict, highlight_tab[i].value.string, VVAL_FALSE) == VVAL_TRUE)
+	if (dict_get_bool(attrdict, (char *)highlight_tab[i].value.string, VVAL_FALSE) == VVAL_TRUE)
 	{
 	    if (p != attr_str && (size_t)(p - attr_str + 2) < len)
 		STRCPY(p, (char_u *)",");

--- a/src/misc2.c
+++ b/src/misc2.c
@@ -3108,6 +3108,6 @@ cmp_keyvalue_value_ni(const void *a, const void *b)
     keyvalue_T *kv1 = (keyvalue_T *)a;
     keyvalue_T *kv2 = (keyvalue_T *)b;
 
-    return vim_strnicmp_asc(kv1->value.string, kv2->value.string, MAX(kv1->value.length, kv2->value.length));
+    return vim_strnicmp_asc((char *)kv1->value.string, (char *)kv2->value.string, MAX(kv1->value.length, kv2->value.length));
 }
 

--- a/src/misc2.c
+++ b/src/misc2.c
@@ -3077,7 +3077,7 @@ cmp_keyvalue_value(const void *a, const void *b)
     keyvalue_T *kv1 = (keyvalue_T *)a;
     keyvalue_T *kv2 = (keyvalue_T *)b;
 
-    return STRCMP(kv1->value, kv2->value);
+    return STRCMP(kv1->value.string, kv2->value.string);
 }
 
 // compare two keyvalue_T structs by value with length
@@ -3087,7 +3087,7 @@ cmp_keyvalue_value_n(const void *a, const void *b)
     keyvalue_T *kv1 = (keyvalue_T *)a;
     keyvalue_T *kv2 = (keyvalue_T *)b;
 
-    return STRNCMP(kv1->value, kv2->value, MAX(kv1->length, kv2->length));
+    return STRNCMP(kv1->value.string, kv2->value.string, MAX(kv1->value.length, kv2->value.length));
 }
 
 // compare two keyvalue_T structs by case insensitive value
@@ -3097,17 +3097,17 @@ cmp_keyvalue_value_i(const void *a, const void *b)
     keyvalue_T *kv1 = (keyvalue_T *)a;
     keyvalue_T *kv2 = (keyvalue_T *)b;
 
-    return STRICMP(kv1->value, kv2->value);
+    return STRICMP(kv1->value.string, kv2->value.string);
 }
 
 // compare two keyvalue_T structs by case insensitive ASCII value
-// with length
+// with value.length
     int
 cmp_keyvalue_value_ni(const void *a, const void *b)
 {
     keyvalue_T *kv1 = (keyvalue_T *)a;
     keyvalue_T *kv2 = (keyvalue_T *)b;
 
-    return vim_strnicmp_asc(kv1->value, kv2->value, MAX(kv1->length, kv2->length));
+    return vim_strnicmp_asc(kv1->value.string, kv2->value.string, MAX(kv1->value.length, kv2->value.length));
 }
 

--- a/src/regexp.c
+++ b/src/regexp.c
@@ -265,8 +265,8 @@ get_char_class(char_u **pp)
 	static keyvalue_T *last_entry = NULL;
 
 	target.key = 0;
-	target.value = (char *)*pp + 2;
-	target.length = 0;		    // not used, see cmp_keyvalue_value_n()
+	target.value.string = *pp + 2;
+	target.value.length = 0;		    // not used, see cmp_keyvalue_value_n()
 
 	if (last_entry != NULL && cmp_keyvalue_value_n(&target, last_entry) == 0)
 	    entry = last_entry;
@@ -277,7 +277,7 @@ get_char_class(char_u **pp)
 	if (entry != NULL)
 	{
 	    last_entry = entry;
-	    *pp += entry->length + 2;
+	    *pp += entry->value.length + 2;
 	    return entry->key;
 	}
     }

--- a/src/structs.h
+++ b/src/structs.h
@@ -5087,13 +5087,12 @@ typedef struct {
 // Return the length of a string literal
 #define STRLEN_LITERAL(s) (sizeof(s) - 1)
 
-// Store a key/value pair
+// Store a key/value (string) pair
 typedef struct
 {
     int	    key;        // the key
-    char    *value;     // the value string
-    size_t  length;     // length of the value string
+    string_T value;	// the value
 } keyvalue_T;
 
 #define KEYVALUE_ENTRY(k, v) \
-    {(k), (v), STRLEN_LITERAL(v)}
+    {(k), {((char_u *)v), STRLEN_LITERAL(v)}}

--- a/src/syntax.c
+++ b/src/syntax.c
@@ -4066,7 +4066,7 @@ syn_list_flags(keyvalue_T *nlist, int nr_entries, int flags, int attr)
     for (i = 0; i < nr_entries; ++i)
 	if (flags & nlist[i].key)
 	{
-	    msg_puts_attr(nlist[i].value, attr);
+	    msg_puts_attr((char *)nlist[i].value.string, attr);
 	    msg_putchar(' ');
 	}
 }

--- a/src/usercmd.c
+++ b/src/usercmd.c
@@ -465,7 +465,7 @@ get_user_cmd_complete(expand_T *xp UNUSED, int idx)
 {
     if (idx < 0 || idx >= (int)ARRAY_LENGTH(command_complete_tab))
 	return NULL;
-    return (char_u *)command_complete_tab[idx].value;
+    return command_complete_tab[idx].value.string;
 }
 
 /*
@@ -494,7 +494,7 @@ cmdcomplete_type_to_str(int expand)
 
     kv = get_commandtype(expand);
 
-    return (kv == NULL) ? NULL : (char_u *)kv->value;
+    return (kv == NULL) ? NULL : kv->value.string;
 }
 
 /*
@@ -514,8 +514,8 @@ cmdcomplete_str_to_type(char_u *complete_str)
 	return EXPAND_USER_LIST;
 
     target.key = 0;
-    target.value = (char *)complete_str;
-    target.length = 0;				// not used, see cmp_keyvalue_value()
+    target.value.string = complete_str;
+    target.value.length = 0;			// not used, see cmp_keyvalue_value()
 
     if (last_entry != NULL && cmp_keyvalue_value(&target, last_entry) == 0)
 	entry = last_entry;
@@ -670,8 +670,8 @@ uc_list(char_u *name, size_t name_len)
 	    entry = get_commandtype(cmd->uc_compl);
 	    if (entry != NULL)
 	    {
-		STRCPY(IObuff + len, entry->value);
-		len += entry->length;
+		STRCPY(IObuff + len, entry->value.string);
+		len += entry->value.length;
 #ifdef FEAT_EVAL
 		if (p_verbose > 0 && cmd->uc_compl_arg != NULL)
 		{
@@ -826,8 +826,8 @@ parse_compl_arg(
     }
 
     target.key = 0;
-    target.value = (char *)value;
-    target.length = valend;
+    target.value.string = value;
+    target.value.length = valend;
 
     if (last_entry != NULL && cmp_keyvalue_value_n(&target, last_entry) == 0)
 	entry = last_entry;
@@ -1637,7 +1637,7 @@ produce_cmdmods(char_u *buf, cmdmod_T *cmod, int quote)
     // the modifiers that are simple flags
     for (i = 0; i < (int)ARRAY_LENGTH(mod_entry_tab); ++i)
 	if (cmod->cmod_flags & mod_entry_tab[i].key)
-	    buflen += add_cmd_modifier(buf, buflen, mod_entry_tab[i].value, mod_entry_tab[i].length, &multi_mods);
+	    buflen += add_cmd_modifier(buf, buflen, (char *)mod_entry_tab[i].value.string, mod_entry_tab[i].value.length, &multi_mods);
 
     // :silent
     if (cmod->cmod_flags & CMOD_SILENT)


### PR DESCRIPTION
Change the keyvalue_T structure to use string_T instead of separate fields for the value and value's length. Adjust macro KEYVALUE_ENTRY() and use sites accordingly.