### PR TITLE
:setglobal doesn't work properly for 'ffu' and 'tsrfu'

### DIFF
--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -6934,6 +6934,9 @@ get_findfunc_callback(void)
     return *curbuf->b_p_ffu != NUL ? &curbuf->b_ffu_cb : &ffu_cb;
 }
 
+/*
+ * Call 'findfunc' to obtain a list of file names.
+ */
     static list_T *
 call_findfunc(char_u *pat, int cmdcomplete)
 {
@@ -6944,7 +6947,6 @@ call_findfunc(char_u *pat, int cmdcomplete)
     sctx_T	saved_sctx = current_sctx;
     sctx_T	*ctx;
 
-    // Call 'findfunc' to obtain the list of file names.
     args[0].v_type = VAR_STRING;
     args[0].vval.v_string = pat;
     args[1].v_type = VAR_BOOL;
@@ -7076,15 +7078,16 @@ did_set_findfunc(optset_T *args UNUSED)
 {
     int	retval;
 
-    if (*curbuf->b_p_ffu != NUL)
-    {
+    if (args->os_flags & OPT_LOCAL)
 	// buffer-local option set
 	retval = option_set_callback_func(curbuf->b_p_ffu, &curbuf->b_ffu_cb);
-    }
     else
     {
 	// global option set
 	retval = option_set_callback_func(p_ffu, &ffu_cb);
+	// when using :set, free the local callback
+	if (!(args->os_flags & OPT_GLOBAL))
+	    free_callback(&curbuf->b_ffu_cb);
     }
 
     if (retval == FAIL)

--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -2687,16 +2687,17 @@ did_set_thesaurusfunc(optset_T *args UNUSED)
 {
     int	retval;
 
-    if (*curbuf->b_p_tsrfu != NUL)
-    {
+    if (args->os_flags & OPT_LOCAL)
 	// buffer-local option set
 	retval = option_set_callback_func(curbuf->b_p_tsrfu,
 							&curbuf->b_tsrfu_cb);
-    }
     else
     {
 	// global option set
 	retval = option_set_callback_func(p_tsrfu, &tsrfu_cb);
+	// when using :set, free the local callback
+	if (!(args->os_flags & OPT_GLOBAL))
+	    free_callback(&curbuf->b_tsrfu_cb);
     }
 
     return retval == FAIL ? e_invalid_argument : NULL;

--- a/src/testdir/test_findfile.vim
+++ b/src/testdir/test_findfile.vim
@@ -359,7 +359,7 @@ func Test_findfunc()
 
   " Error cases
 
-  " Function that doesn't any argument
+  " Function that doesn't take any arguments
   func FindFuncNoArg()
   endfunc
   set findfunc=FindFuncNoArg
@@ -474,6 +474,41 @@ func Test_findfunc_scriptlocal_func()
   call assert_equal(expand('<SID>') .. 'FindFuncScript', &findfunc)
   call assert_equal(expand('<SID>') .. 'FindFuncScript', &l:findfunc)
   call assert_equal('', &g:findfunc)
+  let g:FindFuncArg = ''
+  find abc
+  call assert_equal('abc', g:FindFuncArg)
+  bw!
+
+  new | only
+  set findfunc=
+  setlocal findfunc=NoSuchFunc
+  setglobal findfunc=s:FindFuncScript
+  call assert_equal('NoSuchFunc', &findfunc)
+  call assert_equal('NoSuchFunc', &l:findfunc)
+  call assert_equal(expand('<SID>') .. 'FindFuncScript', &g:findfunc)
+  new | only
+  call assert_equal(expand('<SID>') .. 'FindFuncScript', &findfunc)
+  call assert_equal(expand('<SID>') .. 'FindFuncScript', &g:findfunc)
+  call assert_equal('', &l:findfunc)
+  let g:FindFuncArg = ''
+  find abc
+  call assert_equal('abc', g:FindFuncArg)
+  bw!
+
+  new | only
+  set findfunc=
+  setlocal findfunc=NoSuchFunc
+  set findfunc=s:FindFuncScript
+  call assert_equal(expand('<SID>') .. 'FindFuncScript', &findfunc)
+  call assert_equal(expand('<SID>') .. 'FindFuncScript', &g:findfunc)
+  call assert_equal('', &l:findfunc)
+  let g:FindFuncArg = ''
+  find abc
+  call assert_equal('abc', g:FindFuncArg)
+  new | only
+  call assert_equal(expand('<SID>') .. 'FindFuncScript', &findfunc)
+  call assert_equal(expand('<SID>') .. 'FindFuncScript', &g:findfunc)
+  call assert_equal('', &l:findfunc)
   let g:FindFuncArg = ''
   find abc
   call assert_equal('abc', g:FindFuncArg)

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -2150,6 +2150,7 @@ func Test_thesaurusfunc_callback()
     call add(g:TsrFunc3Args, [a:findstart, a:base])
     return a:findstart ? 0 : []
   endfunc
+
   set tsrfu=s:TsrFunc3
   new
   call setline(1, 'script1')
@@ -2165,6 +2166,46 @@ func Test_thesaurusfunc_callback()
   call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
   call assert_equal([[1, ''], [0, 'script2']], g:TsrFunc3Args)
   bw!
+
+  new | only
+  set thesaurusfunc=
+  setlocal thesaurusfunc=NoSuchFunc
+  setglobal thesaurusfunc=s:TsrFunc3
+  call assert_equal('NoSuchFunc', &thesaurusfunc)
+  call assert_equal('NoSuchFunc', &l:thesaurusfunc)
+  call assert_equal('s:TsrFunc3', &g:thesaurusfunc)
+  new | only
+  call assert_equal('s:TsrFunc3', &thesaurusfunc)
+  call assert_equal('s:TsrFunc3', &g:thesaurusfunc)
+  call assert_equal('', &l:thesaurusfunc)
+  call setline(1, 'script1')
+  let g:TsrFunc3Args = []
+  call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
+  call assert_equal([[1, ''], [0, 'script1']], g:TsrFunc3Args)
+  bw!
+
+  new | only
+  set thesaurusfunc=
+  setlocal thesaurusfunc=NoSuchFunc
+  set thesaurusfunc=s:TsrFunc3
+  call assert_equal('s:TsrFunc3', &thesaurusfunc)
+  call assert_equal('s:TsrFunc3', &g:thesaurusfunc)
+  call assert_equal('', &l:thesaurusfunc)
+  call setline(1, 'script1')
+  let g:TsrFunc3Args = []
+  call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
+  call assert_equal([[1, ''], [0, 'script1']], g:TsrFunc3Args)
+  setlocal bufhidden=wipe
+  new | only!
+  call assert_equal('s:TsrFunc3', &thesaurusfunc)
+  call assert_equal('s:TsrFunc3', &g:thesaurusfunc)
+  call assert_equal('', &l:thesaurusfunc)
+  call setline(1, 'script1')
+  let g:TsrFunc3Args = []
+  call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
+  call assert_equal([[1, ''], [0, 'script1']], g:TsrFunc3Args)
+  bw!
+
   delfunc s:TsrFunc3
 
   " invalid return value


### PR DESCRIPTION
Problem:  :setglobal doesn't work properly for 'ffu' and 'tsrfu' when
          the local value is set.
Solution: Check os_flags instead of buffer option variable.