### PR TITLE
Assume features work when cross-compiling.

### DIFF
--- a/src/auto/configure
+++ b/src/auto/configure
@@ -11328,7 +11328,9 @@ else $as_nop
     if test "$cross_compiling" = yes
 then :
 
-    as_fn_error $? "cross-compiling: please set 'vim_cv_toupper_broken'" "$LINENO" 5
+    vim_cv_toupper_broken=no
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: cross-compiling: consider setting 'vim_cv_toupper_broken'" >&5
+printf "%s\n" "$as_me: WARNING: cross-compiling: consider setting 'vim_cv_toupper_broken'" >&2;}
 
 else $as_nop
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -12746,7 +12748,7 @@ fi
     if test "x$olibs" != "x$LIBS"; then
                         if test "$cross_compiling" = yes
 then :
-  res="FAIL"
+  res="OK"
 else $as_nop
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -12822,7 +12824,9 @@ else $as_nop
     if test "$cross_compiling" = yes
 then :
 
-      as_fn_error $? "cross-compiling: please set 'vim_cv_terminfo'" "$LINENO" 5
+      vim_cv_terminfo=yes
+      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: cross-compiling: consider setting 'vim_cv_terminfo'" >&5
+printf "%s\n" "$as_me: WARNING: cross-compiling: consider setting 'vim_cv_terminfo'" >&2;}
 
 else $as_nop
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -12840,17 +12844,17 @@ else $as_nop
 # include <stddef.h>
 #endif
 int main()
-{char *s; s=(char *)tgoto("%p1%d", 0, 1); exit(!strcmp(s==0 ? "" : s, "1")); }
+{char *s; s=(char *)tgoto("%p1%d", 0, 1); exit(!!strcmp(s==0 ? "" : s, "1")); }
 
 _ACEOF
 if ac_fn_c_try_run "$LINENO"
 then :
 
-      vim_cv_terminfo=no
+      vim_cv_terminfo=yes
 
 else $as_nop
 
-      vim_cv_terminfo=yes
+      vim_cv_terminfo=no
 
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
@@ -12877,7 +12881,9 @@ else $as_nop
     if test "$cross_compiling" = yes
 then :
 
-      as_fn_error $? "failed to compile test program." "$LINENO" 5
+      vim_cv_tgetent=zero
+      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: cross-compiling: consider setting 'vim_cv_tgetent'" >&5
+printf "%s\n" "$as_me: WARNING: cross-compiling: consider setting 'vim_cv_tgetent'" >&2;}
 
 else $as_nop
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -13253,7 +13259,9 @@ else $as_nop
     if test "$cross_compiling" = yes
 then :
 
-      as_fn_error $? "cross-compiling: please set 'vim_cv_getcwd_broken'" "$LINENO" 5
+      vim_cv_getcwd_broken=no
+      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: cross-compiling: consider setting 'vim_cv_getcwd_broken'" >&5
+printf "%s\n" "$as_me: WARNING: cross-compiling: consider setting 'vim_cv_getcwd_broken'" >&2;}
 
 else $as_nop
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -14149,50 +14157,29 @@ then :
   printf %s "(cached) " >&6
 else $as_nop
 
-if test "$cross_compiling" = yes
-then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: failed to build test program; if cross-compiling please set 'vim_cv_timer_create'" >&5
-printf "%s\n" "$as_me: WARNING: failed to build test program; if cross-compiling please set 'vim_cv_timer_create'" >&2;}
-
-else $as_nop
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
-#if STDC_HEADERS
-# include <stdlib.h>
-# include <stddef.h>
-#endif
-#include <signal.h>
-#include <time.h>
-static void set_flag(union sigval sv) {}
+  #include <time.h>
 
 int
 main (void)
 {
 
-  struct timespec ts;
-  struct sigevent action = {0};
-  timer_t timer_id;
-
-  action.sigev_notify = SIGEV_THREAD;
-  action.sigev_notify_function = set_flag;
-  if (timer_create(CLOCK_MONOTONIC, &action, &timer_id) < 0)
-    exit(1);  // cannot create a monotonic timer
+    timer_create(CLOCK_MONOTONIC, NULL, NULL);
 
   ;
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_run "$LINENO"
+if ac_fn_c_try_compile "$LINENO"
 then :
   vim_cv_timer_create=yes
 else $as_nop
   vim_cv_timer_create=no
-fi
-rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
-  conftest.$ac_objext conftest.beam conftest.$ac_ext
-fi
 
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
 fi
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $vim_cv_timer_create" >&5
 printf "%s\n" "$vim_cv_timer_create" >&6; }
@@ -14207,10 +14194,56 @@ then :
   printf %s "(cached) " >&6
 else $as_nop
 
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+    #include <time.h>
+
+int
+main (void)
+{
+
+      timer_create(CLOCK_MONOTONIC, NULL, NULL);
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+  vim_cv_timer_create_with_lrt=yes
+else $as_nop
+  vim_cv_timer_create_with_lrt=no
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $vim_cv_timer_create_with_lrt" >&5
+printf "%s\n" "$vim_cv_timer_create_with_lrt" >&6; }
+  LIBS="$save_LIBS"
+else
+  vim_cv_timer_create_with_lrt=no
+fi
+
+if test "x$vim_cv_timer_create" = "xyes" ||
+   test "x$vim_cv_timer_create_with_lrt" = "xyes"; then
+  save_LIBS="$LIBS"
+  if test "x$vim_cv_timer_create_works" = "xyes" ; then
+    LIBS="$LIBS -lrt"
+  fi
+
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if timer_create works" >&5
+printf %s "checking if timer_create works... " >&6; }
+if test ${vim_cv_timer_create_works+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+
     if test "$cross_compiling" = yes
 then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: failed to build test program; if cross-compiling please set 'vim_cv_timer_create_with_lrt'" >&5
-printf "%s\n" "$as_me: WARNING: failed to build test program; if cross-compiling please set 'vim_cv_timer_create_with_lrt'" >&2;}
+  vim_cv_timer_create_works=yes
+      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: cross-compiling: consider setting 'vim_cv_timer_create_works'" >&5
+printf "%s\n" "$as_me: WARNING: cross-compiling: consider setting 'vim_cv_timer_create_works'" >&2;}
 
 else $as_nop
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -14235,7 +14268,7 @@ main (void)
       action.sigev_notify = SIGEV_THREAD;
       action.sigev_notify_function = set_flag;
       if (timer_create(CLOCK_MONOTONIC, &action, &timer_id) < 0)
-	exit(1);  // cannot create a monotonic timer
+        exit(1);  // cannot create a monotonic timer
 
   ;
   return 0;
@@ -14243,30 +14276,25 @@ main (void)
 _ACEOF
 if ac_fn_c_try_run "$LINENO"
 then :
-  vim_cv_timer_create_with_lrt=yes
+  vim_cv_timer_create_works=yes
 else $as_nop
-  vim_cv_timer_create_with_lrt=no
+  vim_cv_timer_create_works=no
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
   conftest.$ac_objext conftest.beam conftest.$ac_ext
 fi
 
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $vim_cv_timer_create_with_lrt" >&5
-printf "%s\n" "$vim_cv_timer_create_with_lrt" >&6; }
-  LIBS="$save_LIBS"
-else
-  vim_cv_timer_create_with_lrt=no
-fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $vim_cv_timer_create_works" >&5
+printf "%s\n" "$vim_cv_timer_create_works" >&6; }
 
-if test "x$vim_cv_timer_create" = "xyes" ; then
-  printf "%s\n" "#define HAVE_TIMER_CREATE 1" >>confdefs.h
+  if test "x$vim_cv_timer_create_works" = "xyes" ; then
+    printf "%s\n" "#define HAVE_TIMER_CREATE 1" >>confdefs.h
 
-fi
-if test "x$vim_cv_timer_create_with_lrt" = "xyes" ; then
-  printf "%s\n" "#define HAVE_TIMER_CREATE 1" >>confdefs.h
-
-  LIBS="$LIBS -lrt"
+    LIBS="$LIBS -lrt"
+  else
+    LIBS="$save_LIBS"
+  fi
 fi
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether stat() ignores a trailing slash" >&5
@@ -14279,7 +14307,9 @@ else $as_nop
     if test "$cross_compiling" = yes
 then :
 
-      as_fn_error $? "cross-compiling: please set 'vim_cv_stat_ignores_slash'" "$LINENO" 5
+      vim_cv_stat_ignores_slash=yes
+      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: cross-compiling: consider setting 'vim_cv_stat_ignores_slash'" >&5
+printf "%s\n" "$as_me: WARNING: cross-compiling: consider setting 'vim_cv_stat_ignores_slash'" >&2;}
 
 else $as_nop
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -15414,8 +15444,8 @@ printf "%s\n" "#define VIM_SIZEOF_LONG $ac_cv_sizeof_long" >>confdefs.h
 printf %s "checking uint32_t is 32 bits... " >&6; }
 if test "$cross_compiling" = yes
 then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: cannot check uint32_t when cross-compiling." >&5
-printf "%s\n" "$as_me: WARNING: cannot check uint32_t when cross-compiling." >&2;}
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: assuming uint32_t is correct when cross-compiling" >&5
+printf "%s\n" "$as_me: WARNING: assuming uint32_t is correct when cross-compiling" >&2;}
 else $as_nop
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -15478,7 +15508,9 @@ else $as_nop
     if test "$cross_compiling" = yes
 then :
 
-	as_fn_error $? "cross-compiling: please set 'vim_cv_memmove_handles_overlap'" "$LINENO" 5
+	vim_cv_memmove_handles_overlap=yes
+	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: cross-compiling: consider setting 'vim_cv_memmove_handles_overlap'" >&5
+printf "%s\n" "$as_me: WARNING: cross-compiling: consider setting 'vim_cv_memmove_handles_overlap'" >&2;}
 
 else $as_nop
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -15518,7 +15550,9 @@ else $as_nop
       if test "$cross_compiling" = yes
 then :
 
-	as_fn_error $? "cross-compiling: please set 'vim_cv_bcopy_handles_overlap'" "$LINENO" 5
+	vim_cv_bcopy_handles_overlap=yes
+	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: cross-compiling: consider setting 'vim_cv_bcopy_handles_overlap'" >&5
+printf "%s\n" "$as_me: WARNING: cross-compiling: consider setting 'vim_cv_bcopy_handles_overlap'" >&2;}
 
 else $as_nop
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -15558,7 +15592,9 @@ else $as_nop
 	if test "$cross_compiling" = yes
 then :
 
-	    as_fn_error $? "cross-compiling: please set 'vim_cv_memcpy_handles_overlap'" "$LINENO" 5
+	    vim_cv_memcpy_handles_overlap=yes
+	    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: cross-compiling: consider setting 'vim_cv_memcpy_handles_overlap'" >&5
+printf "%s\n" "$as_me: WARNING: cross-compiling: consider setting 'vim_cv_memcpy_handles_overlap'" >&2;}
 
 else $as_nop
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -3297,7 +3297,8 @@ int main() { exit(toupper('A') == 'A' && tolower('z') == 'z'); }
   ],[
     vim_cv_toupper_broken=no
   ],[
-    AC_MSG_ERROR(cross-compiling: please set 'vim_cv_toupper_broken')
+    vim_cv_toupper_broken=no
+    AC_MSG_WARN(cross-compiling: consider setting 'vim_cv_toupper_broken')
   ])])
 
 if test "x$vim_cv_toupper_broken" = "xyes" ; then
@@ -3510,7 +3511,7 @@ else
 # include <stddef.h>
 #endif
 int main() {char *s; s=(char *)tgoto("%p1%d", 0, 1); exit(0); }])],
-			  res="OK", res="FAIL", res="FAIL")
+			  res="OK", res="FAIL", res="OK")
       if test "$res" = "OK"; then
 	break
       fi
@@ -3549,13 +3550,14 @@ AC_CACHE_CHECK([whether we talk terminfo], [vim_cv_terminfo],
 # include <stddef.h>
 #endif
 int main()
-{char *s; s=(char *)tgoto("%p1%d", 0, 1); exit(!strcmp(s==0 ? "" : s, "1")); }
+{char *s; s=(char *)tgoto("%p1%d", 0, 1); exit(!!strcmp(s==0 ? "" : s, "1")); }
     ]])],[
+      vim_cv_terminfo=yes
+    ],[
       vim_cv_terminfo=no
     ],[
       vim_cv_terminfo=yes
-    ],[
-      AC_MSG_ERROR(cross-compiling: please set 'vim_cv_terminfo')
+      AC_MSG_WARN(cross-compiling: consider setting 'vim_cv_terminfo')
     ])
   ])
 
@@ -3581,7 +3583,8 @@ int main()
     ],[
       vim_cv_tgetent=non-zero
     ],[
-      AC_MSG_ERROR(failed to compile test program.)
+      vim_cv_tgetent=zero
+      AC_MSG_WARN(cross-compiling: consider setting 'vim_cv_tgetent')
     ])
   ])
 
@@ -3747,7 +3750,8 @@ int main()
     ],[
       vim_cv_getcwd_broken=yes
     ],[
-      AC_MSG_ERROR(cross-compiling: please set 'vim_cv_getcwd_broken')
+      vim_cv_getcwd_broken=no
+      AC_MSG_WARN(cross-compiling: consider setting 'vim_cv_getcwd_broken')
     ])
   ])
 
@@ -3871,30 +3875,14 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
 	AC_MSG_RESULT(no))
 
 dnl Check for timer_create. It probably requires the 'rt' library.
-dnl Run the program to find out if timer_create(CLOCK_MONOTONIC) actually
-dnl works, on Solaris timer_create() exists but fails at runtime.
 AC_CACHE_CHECK([for timer_create without -lrt], [vim_cv_timer_create], [
-AC_RUN_IFELSE([AC_LANG_PROGRAM([
-#if STDC_HEADERS
-# include <stdlib.h>
-# include <stddef.h>
-#endif
-#include <signal.h>
-#include <time.h>
-static void set_flag(union sigval sv) {}
-], [
-  struct timespec ts;
-  struct sigevent action = {0};
-  timer_t timer_id;
-
-  action.sigev_notify = SIGEV_THREAD;
-  action.sigev_notify_function = set_flag;
-  if (timer_create(CLOCK_MONOTONIC, &action, &timer_id) < 0)
-    exit(1);  // cannot create a monotonic timer
-  ])],
-  vim_cv_timer_create=yes,
-  vim_cv_timer_create=no,
-  AC_MSG_WARN([failed to build test program; if cross-compiling please set 'vim_cv_timer_create'])
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
+  #include <time.h>
+  ], [
+    timer_create(CLOCK_MONOTONIC, NULL, NULL);
+     ])],
+    vim_cv_timer_create=yes,
+    vim_cv_timer_create=no
   )])
 
 dnl If the previous failed, check for timer_create() and linking with -lrt.
@@ -3902,6 +3890,29 @@ if test "x$vim_cv_timer_create" = "xno" ; then
   save_LIBS="$LIBS"
   LIBS="$LIBS -lrt"
   AC_CACHE_CHECK([for timer_create with -lrt], [vim_cv_timer_create_with_lrt], [
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
+    #include <time.h>
+    ], [
+      timer_create(CLOCK_MONOTONIC, NULL, NULL);
+       ])],
+      vim_cv_timer_create_with_lrt=yes,
+      vim_cv_timer_create_with_lrt=no
+    )])
+  LIBS="$save_LIBS"
+else
+  vim_cv_timer_create_with_lrt=no
+fi
+
+dnl Run the program to find out if timer_create(CLOCK_MONOTONIC) actually
+dnl works, on Solaris timer_create() exists but fails at runtime.
+if test "x$vim_cv_timer_create" = "xyes" ||
+   test "x$vim_cv_timer_create_with_lrt" = "xyes"; then
+  save_LIBS="$LIBS"
+  if test "x$vim_cv_timer_create_works" = "xyes" ; then
+    LIBS="$LIBS -lrt"
+  fi
+
+  AC_CACHE_CHECK([if timer_create works], [vim_cv_timer_create_works], [
     AC_RUN_IFELSE([AC_LANG_PROGRAM([
     #if STDC_HEADERS
     # include <stdlib.h>
@@ -3918,23 +3929,20 @@ if test "x$vim_cv_timer_create" = "xno" ; then
       action.sigev_notify = SIGEV_THREAD;
       action.sigev_notify_function = set_flag;
       if (timer_create(CLOCK_MONOTONIC, &action, &timer_id) < 0)
-	exit(1);  // cannot create a monotonic timer
+        exit(1);  // cannot create a monotonic timer
       ])],
-      vim_cv_timer_create_with_lrt=yes,
-      vim_cv_timer_create_with_lrt=no,
-      AC_MSG_WARN([failed to build test program; if cross-compiling please set 'vim_cv_timer_create_with_lrt'])
+      vim_cv_timer_create_works=yes,
+      vim_cv_timer_create_works=no,
+      vim_cv_timer_create_works=yes
+      AC_MSG_WARN([cross-compiling: consider setting 'vim_cv_timer_create_works'])
     )])
-  LIBS="$save_LIBS"
-else
-  vim_cv_timer_create_with_lrt=no
-fi
 
-if test "x$vim_cv_timer_create" = "xyes" ; then
-  AC_DEFINE(HAVE_TIMER_CREATE)
-fi
-if test "x$vim_cv_timer_create_with_lrt" = "xyes" ; then
-  AC_DEFINE(HAVE_TIMER_CREATE)
-  LIBS="$LIBS -lrt"
+  if test "x$vim_cv_timer_create_works" = "xyes" ; then
+    AC_DEFINE(HAVE_TIMER_CREATE)
+    LIBS="$LIBS -lrt"
+  else
+    LIBS="$save_LIBS"
+  fi
 fi
 
 AC_CACHE_CHECK([whether stat() ignores a trailing slash], [vim_cv_stat_ignores_slash],
@@ -3953,7 +3961,8 @@ int main() {struct stat st;  exit(stat("configure/", &st) != 0); }
     ],[
       vim_cv_stat_ignores_slash=no
     ],[
-      AC_MSG_ERROR(cross-compiling: please set 'vim_cv_stat_ignores_slash')
+      vim_cv_stat_ignores_slash=yes
+      AC_MSG_WARN(cross-compiling: consider setting 'vim_cv_stat_ignores_slash')
     ])
   ])
 
@@ -4320,7 +4329,7 @@ int main() {
 }])],
 AC_MSG_RESULT(ok),
 AC_MSG_ERROR([WRONG!  uint32_t not defined correctly.]),
-AC_MSG_WARN([cannot check uint32_t when cross-compiling.]))
+AC_MSG_WARN([assuming uint32_t is correct when cross-compiling]))
 
 dnl Check for memmove() before bcopy(), makes memmove() be used when both are
 dnl present, fixes problem with incompatibility between Solaris 2.4 and 2.5.
@@ -4355,7 +4364,8 @@ AC_CACHE_CHECK([whether memmove handles overlaps],[vim_cv_memmove_handles_overla
       ],[
 	vim_cv_memmove_handles_overlap=no
       ],[
-	AC_MSG_ERROR(cross-compiling: please set 'vim_cv_memmove_handles_overlap')
+	vim_cv_memmove_handles_overlap=yes
+	AC_MSG_WARN(cross-compiling: consider setting 'vim_cv_memmove_handles_overlap')
       ])
   ])
 
@@ -4370,7 +4380,8 @@ else
       ],[
 	vim_cv_bcopy_handles_overlap=no
       ],[
-	AC_MSG_ERROR(cross-compiling: please set 'vim_cv_bcopy_handles_overlap')
+	vim_cv_bcopy_handles_overlap=yes
+	AC_MSG_WARN(cross-compiling: consider setting 'vim_cv_bcopy_handles_overlap')
       ])
     ])
 
@@ -4385,7 +4396,8 @@ else
 	  ],[
 	    vim_cv_memcpy_handles_overlap=no
 	  ],[
-	    AC_MSG_ERROR(cross-compiling: please set 'vim_cv_memcpy_handles_overlap')
+	    vim_cv_memcpy_handles_overlap=yes
+	    AC_MSG_WARN(cross-compiling: consider setting 'vim_cv_memcpy_handles_overlap')
 	  ])
       ])
 


### PR DESCRIPTION
Problem:  Cross-compiling to good modern operating systems is difficult as
          configure assumes obscure bugs are present by default. However,
          most core autoconf-based packages today assume features work
          when in doubt, making cross-compilation easier.
Solution: Assume features work by default and continue to issue a warning
          with the appropriate cache variable. This solution shifts the
          burden onto the users of rare buggy operating systems and
          makes cross-compilation work out of the box for everyone else.

The vim_cv_terminfo test was accidentally negated, where the yes case was in the error handler, leading to false positives if the test program failed to compile.

Split the timer_create detection into two phases: First locating the the library containing timer_create, and then another check to check if timer_create works to properly support cross-compilation.