### PR TITLE
Setting to prevent matchparen from overriding the cursor highlighting

### DIFF
--- a/runtime/doc/pi_paren.txt
+++ b/runtime/doc/pi_paren.txt
@@ -29,6 +29,17 @@ the ":highlight" command.  Example: >
 
 	:hi MatchParen ctermbg=blue guibg=lightblue
 
+By default the plugin will highlight both the paren under the cursor and the
+matching one using MatchParen colors; depending on the selected highlighting,
+the colorscheme, or even the terminal emulator, this might result in the cursor
+briefly disappearing from the screen as the MatchParen colors take over the
+cursor style. To prevent this from happening and have the plugin only highlight
+the matching paren and not the one under the cursor (effectively leaving the
+cursor style unchanged), you can use the "matchparen_disable_cursor_hl"
+variable: >
+
+	:let matchparen_disable_cursor_hl = 1
+
 The characters to be matched come from the 'matchpairs' option.  You can
 change the value to highlight different matches.  Note that not everything is
 possible.  For example, you can't highlight single or double quotes, because

--- a/runtime/plugin/matchparen.vim
+++ b/runtime/plugin/matchparen.vim
@@ -17,6 +17,9 @@ endif
 if !exists("g:matchparen_insert_timeout")
   let g:matchparen_insert_timeout = 60
 endif
+if !exists("g:matchparen_disable_cursor_hl")
+  let g:matchparen_disable_cursor_hl = 0
+endif
 
 let s:has_matchaddpos = exists('*matchaddpos')
 
@@ -189,10 +192,18 @@ func s:Highlight_Matching_Pair()
   " If a match is found setup match highlighting.
   if m_lnum > 0 && m_lnum >= stoplinetop && m_lnum <= stoplinebottom 
     if s:has_matchaddpos
-      call add(w:matchparen_ids, matchaddpos('MatchParen', [[c_lnum, c_col - before], [m_lnum, m_col]], 10))
+      if !g:matchparen_disable_cursor_hl
+        call add(w:matchparen_ids, matchaddpos('MatchParen', [[c_lnum, c_col - before], [m_lnum, m_col]], 10))
+      else
+        call add(w:matchparen_ids, matchaddpos('MatchParen', [[m_lnum, m_col]], 10))
+      endif
     else
-      exe '3match MatchParen /\(\%' . c_lnum . 'l\%' . (c_col - before) .
-	    \ 'c\)\|\(\%' . m_lnum . 'l\%' . m_col . 'c\)/'
+      if !g:matchparen_disable_cursor_hl
+        exe '3match MatchParen /\(\%' . c_lnum . 'l\%' . (c_col - before) .
+              \ 'c\)\|\(\%' . m_lnum . 'l\%' . m_col . 'c\)/'
+      else
+        exe '3match MatchParen /\(\%' . m_lnum . 'l\%' . m_col . 'c\)/'
+      endif
       call add(w:matchparen_ids, 3)
     endif
     let w:paren_hl_on = 1


### PR DESCRIPTION
As explained in the doc update:

> By default the plugin will hilight also the paren under the cursor using
> the same MatchParen colors, and depending on the selected highlighting colors and
> the colorscheme, this might result in the cursor disappearing from the screen.

Let me know if you think there might be better ways of fixing this, and I will be happy to experiment with it.  Same goes for changing the name of the new variable `matchparen_disable_cursor_hl`.