### PR TITLE
Check for the sync function in configure

### DIFF
--- a/src/auto/configure
+++ b/src/auto/configure
@@ -13642,6 +13642,12 @@ then :
   printf "%s\n" "#define HAVE_CLOCK_GETTIME 1" >>confdefs.h
 
 fi
+ac_fn_c_check_func "$LINENO" "sync" "ac_cv_func_sync"
+if test "x$ac_cv_func_sync" = xyes
+then :
+  printf "%s\n" "#define HAVE_SYNC 1" >>confdefs.h
+
+fi
 
 
 

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -209,6 +209,7 @@
 #undef HAVE_CANBERRA
 #undef HAVE_SODIUM
 #undef HAVE_ST_BLKSIZE
+#undef HAVE_SYNC
 #undef HAVE_SYSCONF
 #undef HAVE_SYSCTL
 #undef HAVE_SYSINFO

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -3769,7 +3769,7 @@ AC_CHECK_FUNCS(fchdir fchown fchmod fsync getcwd getpseudotty \
 	sigprocmask sigvec strcasecmp strcoll strerror strftime stricmp strncasecmp \
 	strnicmp strpbrk strptime strtol tgetent towlower towupper iswupper \
 	tzset usleep utime utimes mblen ftruncate unsetenv posix_openpt \
-	clock_gettime)
+	clock_gettime sync)
 AC_FUNC_SELECT_ARGTYPES
 AC_FUNC_FSEEKO
 

--- a/src/memfile.c
+++ b/src/memfile.c
@@ -597,10 +597,10 @@ mf_sync(memfile_T *mfp, int flags)
 	    // OpenNT is strictly POSIX (Benzinger)
 	    // Tandem/Himalaya NSK-OSS doesn't have sync()
 	    // No sync() on Stratus VOS
-# if defined(__OPENNT) || defined(__TANDEM) || defined(__VOS__)
-	    fflush(NULL);
-# else
+# ifdef HAVE_SYNC
 	    sync();
+# else
+	    fflush(NULL);
 # endif
 #endif
 #ifdef VMS


### PR DESCRIPTION
It's better to check for features directly rather than maintaining a denylist of operating systems without them.