### PR TITLE
tests: Prefer Python 3 when picking a Python program in Vim tests

### DIFF
--- a/src/testdir/shared.vim
+++ b/src/testdir/shared.vim
@@ -25,10 +25,10 @@ func PythonProg()
     if !(has('job') || executable('pkill'))
       return ''
     endif
-    if executable('python')
-      let s:python = 'python'
-    elseif executable('python3')
+    if executable('python3')
       let s:python = 'python3'
+    elseif executable('python')
+      let s:python = 'python'
     else
       return ''
     end


### PR DESCRIPTION
Most OSes have Python 3 mapped to `python3` instead of `python`. Vim tests should prioritize using that instead of Python 2 in case that is still installed on the host system.