### PR TITLE
Refactor undo.c to remove calls to STRLEN()

### DIFF
--- a/src/structs.h
+++ b/src/structs.h
@@ -397,6 +397,7 @@ typedef struct {
     char_u	*ul_line;	// text of the line
     long	ul_len;		// length of the line including NUL, plus text
 				// properties
+    colnr_T	ul_textlen;	// length of the line excluding NUL
 } undoline_T;
 
 typedef struct u_entry u_entry_T;

--- a/src/structs.h
+++ b/src/structs.h
@@ -397,7 +397,8 @@ typedef struct {
     char_u	*ul_line;	// text of the line
     long	ul_len;		// length of the line including NUL, plus text
 				// properties
-    colnr_T	ul_textlen;	// length of the line excluding NUL
+    colnr_T	ul_textlen;	// length of the line excluding NUL and any text
+				// properties
 } undoline_T;
 
 typedef struct u_entry u_entry_T;

--- a/src/undo.c
+++ b/src/undo.c
@@ -3121,7 +3121,10 @@ ex_undolist(exarg_T *eap UNUSED)
 	    len = vim_snprintf((char *)IObuff, IOSIZE, "%6ld %7d  ",
 							uhp->uh_seq, changes);
 	    add_time(IObuff + len, IOSIZE - len, uhp->uh_time);
-	    len = STRLEN(IObuff);
+
+	    // we have to call STRLEN() here because add_time() does not report
+	    // the number of characters added.
+	    len += STRLEN(IObuff + len);
 	    if (uhp->uh_save_nr > 0)
 	    {
 		int n = (len >= 33) ? 0 : 33 - len;

--- a/src/undo.c
+++ b/src/undo.c
@@ -3099,7 +3099,6 @@ ex_undolist(exarg_T *eap UNUSED)
     int		mark;
     int		nomark;
     int		changes = 1;
-    int		i;
     int		len;
 
     /*
@@ -3122,15 +3121,12 @@ ex_undolist(exarg_T *eap UNUSED)
 	    len = vim_snprintf((char *)IObuff, IOSIZE, "%6ld %7d  ",
 							uhp->uh_seq, changes);
 	    add_time(IObuff + len, IOSIZE - len, uhp->uh_time);
+	    len = STRLEN(IObuff);
 	    if (uhp->uh_save_nr > 0)
 	    {
-		while (len < 33)
-		{
-		    STRNCPY(IObuff + len, " ", IOSIZE - len);
-		    ++len;
-		}
-		len = vim_snprintf((char *)IObuff + len, IOSIZE - len,
-						   "  %3ld", uhp->uh_save_nr);
+		int n = (len >= 33) ? 0 : 33 - len;
+
+		len += vim_snprintf((char *)IObuff + len, IOSIZE - len, "%*.*s  %3ld", n, n, " ", uhp->uh_save_nr);
 	    }
 	    ((char_u **)(ga.ga_data))[ga.ga_len++] = vim_strnsave(IObuff, len);
 	}
@@ -3179,6 +3175,8 @@ ex_undolist(exarg_T *eap UNUSED)
 	msg(_("Nothing to undo"));
     else
     {
+	int		i;
+
 	sort_strings((char_u **)ga.ga_data, ga.ga_len);
 
 	msg_start();


### PR DESCRIPTION
Is it worth using string_T in the undoline_T struct? Or in other places as well? I haven't done so because I wanted to get some feedback first.

Also, when using the comment `:undolist` the saved value doesn't line up with the heading. See here:
![Screenshot 2024-11-05 140600](https://github.com/user-attachments/assets/2a764433-4bd8-42bf-9a94-d631f1c4f0ef)

Should this be changed so the saved value is right-justified under it's heading?

