### PR TITLE
runtime(netrw): fixed several bugs in tree listing

### DIFF
--- a/runtime/autoload/netrw.vim
+++ b/runtime/autoload/netrw.vim
@@ -4765,6 +4765,9 @@ endfun
 "                       directory and a new directory name.  Also, if the
 "                       "new directory name" is actually a file,
 "                       NetrwBrowseChgDir() edits the file.
+"    cursor=0: newdir is relative to b:netrw_curdir
+"          =1: newdir is relative to the path to the word under the cursor in
+"              tree view
 fun! s:NetrwBrowseChgDir(islocal,newdir,cursor,...)
 "  call Dfunc("s:NetrwBrowseChgDir(islocal=".a:islocal."> newdir<".a:newdir.">) a:0=".a:0." win#".winnr()." curpos<".string(getpos("."))."> b:netrw_curdir<".(exists("b:netrw_curdir")? b:netrw_curdir : "").">")
 "  call Decho("tab#".tabpagenr()." win#".winnr()." buf#".bufnr("%")."<".bufname("%")."> line#".line(".")." col#".col(".")." winline#".winline()." wincol#".wincol(),'~'.expand("<slnum>"))

--- a/runtime/autoload/netrw.vim
+++ b/runtime/autoload/netrw.vim
@@ -12551,7 +12551,7 @@ fun! s:ShowLink()
    else
     let basedir = b:netrw_curdir.'/'
    endif
-   let fname = basedir .. s:NetrwGetWord()
+   let fname = basedir.s:NetrwGetWord()
    let resname = resolve(fname)
 " "   call Decho("fname         <".fname.">",'~'.expand("<slnum>"))
 " "   call Decho("resname       <".resname.">",'~'.expand("<slnum>"))


### PR DESCRIPTION
Bugs fixed when using tree listing style :

- Hitting Ctrl-L causes directories to appear as files, fixes #9807 
- Cursor would jump to the top when opening a directory. Fixed one case of this issue, it can still happen under certain circumstances
- When opening a symlink, netrw would use b:netrw_curdir as the base directory for the symlink but the symlink might not be under b:netrw_curdir because of the tree view. Should fix #14623. Might also fix #5630 
- Symlink resolve didn't work after refresh sometimes in `s:ShowLink`.

Added an argument to `s:NetrwBrowseChgDir` : `cursor` forces the `dirname` value to be retrieved from the word under the cursor. If `cursor` is 1 and tree view, `dirname` is computed with `s:NetrwTreePath`. Wherever there is `s:NetrwBrowseChgDir(.., s:NetrwGetWord(),..)`, `cursor` was set to 1

Known remaining issue :
- Hitting Ctrl-L no longer causes directories to appear as files but sorting is incorrect for the files that are one level deep in the tree listing