### PR TITLE
add support for focusing in popup

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -12231,7 +12231,7 @@ win_gettype([{nr}])					*win_gettype()*
 
 win_gotoid({expr})					*win_gotoid()*
 		Go to window with ID {expr}.  This may also change the current
-		tabpage.
+		tabpage.  This can also be used to focus on a focusable popup.
 		Return TRUE if successful, FALSE if the window cannot be found.
 
 		Can also be used as a |method|: >

--- a/runtime/doc/popup.txt
+++ b/runtime/doc/popup.txt
@@ -683,6 +683,9 @@ The second argument of |popup_create()| is a dictionary with options:
 			horizontally centered.  The first column is 1.
 			When using "textprop" the number is relative to the
 			text property and can be negative.
+	focusable	When FALSE (the default) the popup is not focusable.
+			When TRUE the popup is focusable. Popup can be focused
+			using |win_gotoid| function.
 	pos		"topleft", "topright", "botleft" or "botright":
 			defines what corner of the popup "line" and "col" are
 			used for.  When not set "topleft" is used.

--- a/runtime/doc/popup.txt
+++ b/runtime/doc/popup.txt
@@ -833,6 +833,7 @@ The second argument of |popup_create()| is a dictionary with options:
 			Default is zero, except for |popup_menu()|.
 	filter		A callback that can filter typed characters, see
 			|popup-filter|.
+			It is ignored when focusable popup.
 	mapping		Allow for key mapping.  When FALSE and the popup is
 			visible and has a filter callback key mapping is
 			disabled.  Default value is TRUE.

--- a/src/evalwindow.c
+++ b/src/evalwindow.c
@@ -851,6 +851,10 @@ f_win_gotoid(typval_T *argvars, typval_T *rettv)
 	    rettv->vval.v_number = 1;
 	    return;
 	}
+
+    wp = win_id2wp(id);
+    if (wp != NULL && WIN_IS_POPUP(wp))
+	win_enter(wp, TRUE);
 }
 
 /*

--- a/src/evalwindow.c
+++ b/src/evalwindow.c
@@ -855,7 +855,11 @@ f_win_gotoid(typval_T *argvars, typval_T *rettv)
 #if defined(FEAT_PROP_POPUP) || defined(PROTO)
     wp = win_id2wp(id);
     if (wp != NULL && WIN_IS_POPUP(wp) && wp->w_popup_flags & POPF_FOCUSABLE)
+    {
 	win_enter(wp, TRUE);
+	rettv->vval.v_number = 1;
+	return;
+    }
 #endif
 }
 

--- a/src/evalwindow.c
+++ b/src/evalwindow.c
@@ -852,9 +852,11 @@ f_win_gotoid(typval_T *argvars, typval_T *rettv)
 	    return;
 	}
 
+#if defined(FEAT_PROP_POPUP) || defined(PROTO)
     wp = win_id2wp(id);
-    if (wp != NULL && WIN_IS_POPUP(wp))
+    if (wp != NULL && WIN_IS_POPUP(wp) && wp->w_popup_flags & POPF_FOCUSABLE)
 	win_enter(wp, TRUE);
+#endif
 }
 
 /*

--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -764,6 +764,15 @@ apply_general_options(win_T *wp, dict_T *dict)
 	    wp->w_popup_flags &= ~POPF_DRAGALL;
     }
 
+    nr = dict_get_bool(dict, (char_u *)"focusable", -1);
+    if (nr != -1)
+    {
+	if (nr)
+	    wp->w_popup_flags |= POPF_FOCUSABLE;
+	else
+	    wp->w_popup_flags &= ~POPF_FOCUSABLE;
+    }
+
     nr = dict_get_bool(dict, "posinvert", -1);
     if (nr != -1)
     {
@@ -3332,6 +3341,8 @@ f_popup_getoptions(typval_T *argvars, typval_T *rettv)
     dict_add_number(dict, "resize", (wp->w_popup_flags & POPF_RESIZE) != 0);
     dict_add_number(dict, "posinvert",
 	    (wp->w_popup_flags & POPF_POSINVERT) != 0);
+    dict_add_number(dict, "focusable",
+	    (wp->w_popup_flags & POPF_FOCUSABLE) != 0);
     dict_add_number(dict, "cursorline",
 	    (wp->w_popup_flags & POPF_CURSORLINE) != 0);
     dict_add_string(dict, "highlight", wp->w_p_wcr);

--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -764,7 +764,7 @@ apply_general_options(win_T *wp, dict_T *dict)
 	    wp->w_popup_flags &= ~POPF_DRAGALL;
     }
 
-    nr = dict_get_bool(dict, (char_u *)"focusable", -1);
+    nr = dict_get_bool(dict, "focusable", -1);
     if (nr != -1)
     {
 	if (nr)

--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -2741,13 +2741,6 @@ f_popup_close(typval_T *argvars, typval_T *rettv UNUSED)
 	return;
 
     id = (int)tv_get_number(argvars);
-    if (
-# ifdef FEAT_TERMINAL
-	// if the popup contains a terminal it will become hidden
-	curbuf->b_term == NULL &&
-# endif
-	    ERROR_IF_ANY_POPUP_WINDOW)
-	return;
 
     wp = find_popup_win(id);
     if (wp != NULL)

--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -719,7 +719,7 @@ popup_highlight_curline(win_T *wp)
 apply_general_options(win_T *wp, dict_T *dict)
 {
     dictitem_T	*di;
-    int		nr;
+    int		nr, focusable;
     char_u	*str;
 
     // TODO: flip
@@ -982,7 +982,7 @@ apply_general_options(win_T *wp, dict_T *dict)
     }
 
     di = dict_find(dict, (char_u *)"filter", -1);
-    if (di != NULL)
+    if (di != NULL && (wp->w_popup_flags & POPF_FOCUSABLE) == 0)
     {
 	callback_T	callback = get_callback(&di->di_tv);
 

--- a/src/testdir/test_popupwin.vim
+++ b/src/testdir/test_popupwin.vim
@@ -4148,6 +4148,8 @@ func Test_popupwin_focus()
   call win_gotoid(popup_winid)
   call assert_equal(popup_winid, win_getid())
 
+  " TODO: we shouldn't be needing this.
+  " popup_close should automatically go to the correct last winid.
   call win_gotoid(winid)
   call popup_close(popup_winid)
 endfunc

--- a/src/testdir/test_popupwin.vim
+++ b/src/testdir/test_popupwin.vim
@@ -4131,12 +4131,23 @@ func Test_popupwin_latin1_encoding()
   call StopVimInTerminal(buf)
 endfunc
 
-func Test_popupwin_focus()
+func Test_popupwin_non_focusable()
   let winid = win_getid()
   let popup_winid = popup_create(['hello', 'world'], #{line: 1, col: 2})
+  call assert_equal(0, popup_getoptions(popup_winid)['focusable'])
+  call assert_equal(winid, win_getid())
+  call win_gotoid(popup_winid)
+  call assert_equal(winid, win_getid())
+  call popup_close(popup_winid)
+endfunc
+
+func Test_popupwin_focus()
+  let winid = win_getid()
+  let popup_winid = popup_create(['hello', 'world'], #{line: 1, col: 2, focusable: 1})
+  call assert_equal(1, popup_getoptions(popup_winid)['focusable'])
   call assert_equal(winid, win_getid())
 
-  " first focus to popup
+  " first focus to popup window
   call win_gotoid(popup_winid)
   call assert_equal(popup_winid, win_getid())
 

--- a/src/testdir/test_popupwin.vim
+++ b/src/testdir/test_popupwin.vim
@@ -4131,6 +4131,27 @@ func Test_popupwin_latin1_encoding()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_popupwin_focus()
+  let winid = win_getid()
+  let popup_winid = popup_create(['hello', 'world'], #{line: 1, col: 2})
+  call assert_equal(winid, win_getid())
+
+  " first focus to popup
+  call win_gotoid(popup_winid)
+  call assert_equal(popup_winid, win_getid())
+
+  " focus back to main window
+  call win_gotoid(winid)
+  call assert_equal(winid, win_getid())
+
+  " second focus to popup window
+  call win_gotoid(popup_winid)
+  call assert_equal(popup_winid, win_getid())
+
+  call win_gotoid(winid)
+  call popup_close(popup_winid)
+endfunc
+
 func Test_popupwin_atcursor_far_right()
   new
 

--- a/src/testdir/test_popupwin.vim
+++ b/src/testdir/test_popupwin.vim
@@ -4148,15 +4148,18 @@ func Test_popupwin_focus()
   call assert_equal(winid, win_getid())
 
   " first focus to popup window
-  call win_gotoid(popup_winid)
+  let win_gotoid_result = win_gotoid(popup_winid)
+  call assert_equal(1, win_gotoid_result)
   call assert_equal(popup_winid, win_getid())
 
   " focus back to main window
-  call win_gotoid(winid)
+  let win_gotoid_result = win_gotoid(winid)
+  call assert_equal(1, win_gotoid_result)
   call assert_equal(winid, win_getid())
 
   " second focus to popup window
-  call win_gotoid(popup_winid)
+  let win_gotoid_result = win_gotoid(popup_winid)
+  call assert_equal(1, win_gotoid_result)
   call assert_equal(popup_winid, win_getid())
 
   " TODO: we shouldn't be needing this.

--- a/src/vim.h
+++ b/src/vim.h
@@ -673,6 +673,7 @@ extern int (*dyn_libintl_wputenv)(const wchar_t *envstring);
 #define POPF_INFO	0x200	// used for info of popup menu
 #define POPF_INFO_MENU	0x400	// align info popup with popup menu
 #define POPF_POSINVERT	0x800	// vertical position can be inverted
+#define POPF_FOCUSABLE	0x1000	// popup can be focused
 
 // flags used in w_popup_handled
 #define POPUP_HANDLED_1	    0x01    // used by mouse_find_win()


### PR DESCRIPTION
Continues of #7555

Known issues:

- [ ] When you trigger manual buffer completion in popup window, Vim freezes. https://github.com/vim/vim/pull/16000#issuecomment-2460055573
- [ ] Internal error https://github.com/vim/vim/pull/16000#issuecomment-2462212605
- [ ] The border feature does not work well in focusable windows https://github.com/vim/vim/pull/16000#issuecomment-2461815345 https://github.com/vim/vim/pull/16000#issuecomment-2525170801
- [ ] call popup_clear() gives the same error E994
- [ ] Popup filter is not ignored
- [ ] There are also a few other normal-mode mappings that don't work while in the popup. For example, ZZ or ZQ. What should they do when a popup is focused?