### PR TITLE
Add getcellpixels()

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -3790,6 +3790,8 @@ getbufvar({buf}, {varname} [, {def}])				*getbufvar()*
 getcellpixels()						*getcellpixels()*
 		Returns a |List| of cell pixel size.
 		List format is [xpixels, ypixels].
+		Depending on the terminal and environment used,
+		unreliable values may be returned.
 		Only on UNIX.
 
 		Return type: list<any>

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -222,6 +222,7 @@ getbufline({buf}, {lnum} [, {end}])
 getbufoneline({buf}, {lnum})	String	line {lnum} of buffer {buf}
 getbufvar({buf}, {varname} [, {def}])
 				any	variable {varname} in buffer {buf}
+getcellpixels()			List	get character cell pixel size
 getcellwidths()			List	get character cell width overrides
 getchangelist([{buf}])		List	list of change list items
 getchar([{expr}])		Number or String
@@ -3786,6 +3787,14 @@ getbufvar({buf}, {varname} [, {def}])				*getbufvar()*
 		Return type: any, depending on {varname}
 
 
+getcellpixels()						*getcellpixels()*
+		Returns a |List| of cell pixel size.
+		List format is [xpixels, ypixels].
+		Only on UNIX.
+
+		Return type: list<any>
+
+
 getcellwidths()						*getcellwidths()*
 		Returns a |List| of cell widths of character ranges overridden
 		by |setcellwidths()|.  The format is equal to the argument of
@@ -5071,8 +5080,6 @@ getwininfo([{winid}])					*getwininfo()*
 			botline		last complete displayed buffer line
 			bufnr		number of buffer in the window
 			height		window height (excluding winbar)
-			hpixel		window height of pixel-level
-					{only with UNIX build}
 			loclist		1 if showing a location list
 					{only with the +quickfix feature}
 			quickfix	1 if quickfix or location list window
@@ -5084,8 +5091,6 @@ getwininfo([{winid}])					*getwininfo()*
 			variables	a reference to the dictionary with
 					window-local variables
 			width		window width
-			wpixel		window width of pixel-level
-					{only with UNIX build}
 			winbar		1 if the window has a toolbar, 0
 					otherwise
 			wincol		leftmost screen column of the window;

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -3792,7 +3792,8 @@ getcellpixels()						*getcellpixels()*
 		List format is [xpixels, ypixels].
 		Depending on the terminal and environment used,
 		unreliable values may be returned.
-		Only on UNIX.
+		Only works on Unix. For gVim, returns [5, 10], on other systems,
+		returns [-1, -1].
 
 		Return type: list<any>
 

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -5071,6 +5071,8 @@ getwininfo([{winid}])					*getwininfo()*
 			botline		last complete displayed buffer line
 			bufnr		number of buffer in the window
 			height		window height (excluding winbar)
+			hpixel		window height of pixel-level
+					{only with UNIX build}
 			loclist		1 if showing a location list
 					{only with the +quickfix feature}
 			quickfix	1 if quickfix or location list window
@@ -5082,6 +5084,8 @@ getwininfo([{winid}])					*getwininfo()*
 			variables	a reference to the dictionary with
 					window-local variables
 			width		window width
+			wpixel		window width of pixel-level
+					{only with UNIX build}
 			winbar		1 if the window has a toolbar, 0
 					otherwise
 			wincol		leftmost screen column of the window;

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -3792,7 +3792,7 @@ getcellpixels()						*getcellpixels()*
 		List format is [xpixels, ypixels].
 		Depending on the terminal and environment used,
 		unreliable values may be returned.
-		Only works on Unix. For gVim, returns [5, 10], on other systems,
+		Only works on Unix. For gVim and on other systems,
 		returns [-1, -1].
 
 		Return type: list<any>

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -7834,6 +7834,7 @@ getbufinfo()	builtin.txt	/*getbufinfo()*
 getbufline()	builtin.txt	/*getbufline()*
 getbufoneline()	builtin.txt	/*getbufoneline()*
 getbufvar()	builtin.txt	/*getbufvar()*
+getcellpixels()	builtin.txt	/*getcellpixels()*
 getcellwidths()	builtin.txt	/*getcellwidths()*
 getchangelist()	builtin.txt	/*getchangelist()*
 getchar()	builtin.txt	/*getchar()*

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -778,6 +778,7 @@ String manipulation:					*string-functions*
 	strdisplaywidth()	size of string when displayed, deals with tabs
 	setcellwidths()		set character cell width overrides
 	getcellwidths()		get character cell width overrides
+	getcellpixels()		get character cell pixel size
 	reverse()		reverse the order of characters in a string
 	substitute()		substitute a pattern match with a string
 	submatch()		get a specific match in ":s" and substitute()

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -2077,6 +2077,14 @@ static funcentry_T global_functions[] =
 			ret_string,	    f_getbufoneline},
     {"getbufvar",	2, 3, FEARG_1,	    arg3_buffer_string_any,
 			ret_any,	    f_getbufvar},
+    {"getcellpixels",	0, 0, 0,	    NULL,
+			ret_list_any,
+#if defined(UNIX) || defined(VMS)
+	    f_getcellpixels
+#else
+	    NULL
+#endif
+			},
     {"getcellwidths",	0, 0, 0,	    NULL,
 			ret_list_any,	    f_getcellwidths},
     {"getchangelist",	0, 1, FEARG_1,	    arg1_buffer,

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -2079,7 +2079,7 @@ static funcentry_T global_functions[] =
 			ret_any,	    f_getbufvar},
     {"getcellpixels",	0, 0, 0,	    NULL,
 			ret_list_any,
-#if defined(UNIX) || defined(VMS)
+#if (defined(UNIX) || defined(VMS)) && (defined(FEAT_EVAL) || defined(PROTO))
 	    f_getcellpixels
 #else
 	    NULL

--- a/src/evalwindow.c
+++ b/src/evalwindow.c
@@ -409,6 +409,18 @@ get_win_info(win_T *wp, short tpnr, short winnr)
     if (dict == NULL)
 	return NULL;
 
+# if defined(UNIX) || defined(VMS)
+    struct cellsize cs;
+#ifdef FEAT_GUI
+    if (!gui.in_use)
+    {
+#endif
+        calc_cell_size(&cs);
+#ifdef FEAT_GUI
+    }
+#endif
+#endif
+
     // make sure w_botline is valid
     validate_botline_win(wp);
 
@@ -416,6 +428,16 @@ get_win_info(win_T *wp, short tpnr, short winnr)
     dict_add_number(dict, "winnr", winnr);
     dict_add_number(dict, "winid", wp->w_id);
     dict_add_number(dict, "height", wp->w_height);
+# if defined(UNIX) || defined(VMS)
+#ifdef FEAT_GUI
+    if (!gui.in_use)
+    {
+#endif
+        dict_add_number(dict, "hpixel", cs.cs_ypixel * wp->w_height);
+#ifdef FEAT_GUI
+    }
+#endif
+#endif
     dict_add_number(dict, "winrow", wp->w_winrow + 1);
     dict_add_number(dict, "topline", wp->w_topline);
     dict_add_number(dict, "botline", wp->w_botline - 1);
@@ -423,6 +445,16 @@ get_win_info(win_T *wp, short tpnr, short winnr)
     dict_add_number(dict, "winbar", wp->w_winbar_height);
 #endif
     dict_add_number(dict, "width", wp->w_width);
+# if defined(UNIX) || defined(VMS)
+#ifdef FEAT_GUI
+    if (!gui.in_use)
+    {
+#endif
+        dict_add_number(dict, "wpixel", cs.cs_xpixel * wp->w_width);
+#ifdef FEAT_GUI
+    }
+#endif
+#endif
     dict_add_number(dict, "wincol", wp->w_wincol + 1);
     dict_add_number(dict, "textoff", win_col_off(wp));
     dict_add_number(dict, "bufnr", wp->w_buffer->b_fnum);

--- a/src/evalwindow.c
+++ b/src/evalwindow.c
@@ -409,18 +409,6 @@ get_win_info(win_T *wp, short tpnr, short winnr)
     if (dict == NULL)
 	return NULL;
 
-# if defined(UNIX) || defined(VMS)
-    struct cellsize cs;
-#ifdef FEAT_GUI
-    if (!gui.in_use)
-    {
-#endif
-        calc_cell_size(&cs);
-#ifdef FEAT_GUI
-    }
-#endif
-#endif
-
     // make sure w_botline is valid
     validate_botline_win(wp);
 
@@ -428,16 +416,6 @@ get_win_info(win_T *wp, short tpnr, short winnr)
     dict_add_number(dict, "winnr", winnr);
     dict_add_number(dict, "winid", wp->w_id);
     dict_add_number(dict, "height", wp->w_height);
-# if defined(UNIX) || defined(VMS)
-#ifdef FEAT_GUI
-    if (!gui.in_use)
-    {
-#endif
-        dict_add_number(dict, "hpixel", cs.cs_ypixel * wp->w_height);
-#ifdef FEAT_GUI
-    }
-#endif
-#endif
     dict_add_number(dict, "winrow", wp->w_winrow + 1);
     dict_add_number(dict, "topline", wp->w_topline);
     dict_add_number(dict, "botline", wp->w_botline - 1);
@@ -445,16 +423,6 @@ get_win_info(win_T *wp, short tpnr, short winnr)
     dict_add_number(dict, "winbar", wp->w_winbar_height);
 #endif
     dict_add_number(dict, "width", wp->w_width);
-# if defined(UNIX) || defined(VMS)
-#ifdef FEAT_GUI
-    if (!gui.in_use)
-    {
-#endif
-        dict_add_number(dict, "wpixel", cs.cs_xpixel * wp->w_width);
-#ifdef FEAT_GUI
-    }
-#endif
-#endif
     dict_add_number(dict, "wincol", wp->w_wincol + 1);
     dict_add_number(dict, "textoff", win_col_off(wp));
     dict_add_number(dict, "bufnr", wp->w_buffer->b_fnum);

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -4404,8 +4404,8 @@ mch_calc_cell_size(struct cellsize *cs_out)
     }
     else
     {
-        cs_out->cs_xpixel = 5;
-        cs_out->cs_ypixel = 10;
+        cs_out->cs_xpixel = -1;
+        cs_out->cs_ypixel = -1;
     }
 #endif
 }

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -4391,7 +4391,7 @@ mch_calc_cell_size(struct cellsize *cs_out)
 
         // calculate parent tty's pixel per cell.
         int x_cell_size = ws.ws_xpixel / ws.ws_col;
-        int y_cell_size = ws.ws_xpixel / ws.ws_row;
+        int y_cell_size = ws.ws_ypixel / ws.ws_row;
 
         // calculate current tty's pixel
         cs_out->cs_xpixel = x_cell_size;

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -4348,6 +4348,19 @@ mch_get_shellsize(void)
     return OK;
 }
 
+    void
+f_getcellpixels(typval_T *argvars UNUSED, typval_T *rettv)
+{
+    struct cellsize cs;
+    calc_cell_size(&cs);
+
+    if (rettv_list_alloc(rettv) == FAIL)
+        return;
+
+    list_append_number(rettv->vval.v_list, (varnumber_T)cs.cs_xpixel);
+    list_append_number(rettv->vval.v_list, (varnumber_T)cs.cs_ypixel);
+}
+
 /*
  * Try to get the current terminal cell size.
  * If faile get cell size, fallback 5x10 pixel.
@@ -4364,20 +4377,15 @@ calc_cell_size(struct cellsize *cs_out)
         char* tty_path = ttyname(STDIN_FILENO);
 
         // open parent process's tty.
+        // It opens Vim's own tty, so it doesn't fail
         int tty_fd = open(tty_path, O_RDWR);
-        if (tty_fd == -1)
-        {
-            cs_out->cs_xpixel = 5;
-            cs_out->cs_ypixel = 10;
-            return;
-        }
 
-              // get parent tty size.
+        // get parent tty size.
         struct winsize ws;
         if (ioctl(tty_fd, TIOCGWINSZ, &ws) == -1)
         {
-            cs_out->cs_xpixel = 5;
-            cs_out->cs_ypixel = 10;
+            cs_out->cs_xpixel = -1;
+            cs_out->cs_ypixel = -1;
             close(tty_fd);
             return;
         }

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -4396,7 +4396,7 @@ mch_calc_cell_size(struct cellsize *cs_out)
         cs_out->cs_ypixel = y_cell_size;
 
 #  ifdef FEAT_EVAL
-        ch_log(NULL, "Got cell pixel size with TIOCGWINSZ: %ld x %ld", x_cell_size, y_cell_size);
+        ch_log(NULL, "Got cell pixel size with TIOCGWINSZ: %d x %d", x_cell_size, y_cell_size);
 #  endif
 #if defined(FEAT_GUI)
     }

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -4360,22 +4360,8 @@ calc_cell_size(struct cellsize *cs_out)
     {
 #endif
 
-        // get parent process pid.
-        pid_t ppid = getppid();
-
         // get parent process's tty path.
-        char tty_path[256];
-        snprintf(tty_path, sizeof(tty_path), "/proc/%d/fd/0", ppid);
-
-        char actual_tty[256];
-        ssize_t len = readlink(tty_path, actual_tty, sizeof(actual_tty) - 1);
-        if (len == -1)
-        {
-            cs_out->cs_xpixel = 5;
-            cs_out->cs_ypixel = 10;
-            return;
-        }
-        actual_tty[len] = '\0';
+        char* tty_path = ttyname(STDIN_FILENO);
 
         // open parent process's tty.
         int tty_fd = open(tty_path, O_RDWR);

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -4348,6 +4348,7 @@ mch_get_shellsize(void)
     return OK;
 }
 
+#if defined(FEAT_EVAL) || defined(PROTO)
     void
 f_getcellpixels(typval_T *argvars UNUSED, typval_T *rettv)
 {
@@ -4360,6 +4361,7 @@ f_getcellpixels(typval_T *argvars UNUSED, typval_T *rettv)
     list_append_number(rettv->vval.v_list, (varnumber_T)cs.cs_xpixel);
     list_append_number(rettv->vval.v_list, (varnumber_T)cs.cs_ypixel);
 }
+#endif
 
 /*
  * Try to get the current terminal cell size.

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -4353,7 +4353,8 @@ mch_get_shellsize(void)
  * If faile get cell size, fallback 5x10 pixel.
  */
     void
-calc_cell_size(struct cellsize *cs_out) {
+calc_cell_size(struct cellsize *cs_out)
+{
 #if defined(FEAT_GUI)
     if (!gui.in_use)
     {
@@ -4368,7 +4369,8 @@ calc_cell_size(struct cellsize *cs_out) {
 
         char actual_tty[256];
         ssize_t len = readlink(tty_path, actual_tty, sizeof(actual_tty) - 1);
-        if (len == -1) {
+        if (len == -1)
+        {
             cs_out->cs_xpixel = 5;
             cs_out->cs_ypixel = 10;
             return;
@@ -4377,7 +4379,8 @@ calc_cell_size(struct cellsize *cs_out) {
 
         // open parent process's tty.
         int tty_fd = open(tty_path, O_RDWR);
-        if (tty_fd == -1) {
+        if (tty_fd == -1)
+        {
             cs_out->cs_xpixel = 5;
             cs_out->cs_ypixel = 10;
             return;
@@ -4385,7 +4388,8 @@ calc_cell_size(struct cellsize *cs_out) {
 
               // get parent tty size.
         struct winsize ws;
-        if (ioctl(tty_fd, TIOCGWINSZ, &ws) == -1) {
+        if (ioctl(tty_fd, TIOCGWINSZ, &ws) == -1)
+        {
             cs_out->cs_xpixel = 5;
             cs_out->cs_ypixel = 10;
             close(tty_fd);

--- a/src/os_unix.h
+++ b/src/os_unix.h
@@ -488,3 +488,11 @@ int mch_rename(const char *src, const char *dest);
 
 // We have three kinds of ACL support.
 #define HAVE_ACL (HAVE_POSIX_ACL || HAVE_SOLARIS_ACL || HAVE_AIX_ACL)
+
+struct cellsize {
+    unsigned int cs_xpixel;
+    unsigned int cs_ypixel;
+};
+
+void calc_cell_size(struct cellsize *cs_out);
+

--- a/src/os_unix.h
+++ b/src/os_unix.h
@@ -494,5 +494,3 @@ struct cellsize {
     unsigned int cs_ypixel;
 };
 
-void calc_cell_size(struct cellsize *cs_out);
-

--- a/src/proto/os_unix.pro
+++ b/src/proto/os_unix.pro
@@ -92,4 +92,5 @@ void stop_timeout(void);
 volatile sig_atomic_t *start_timeout(long msec);
 void delete_timer(void);
 void f_getcellpixels(typval_T *argvars UNUSED, typval_T *rettv);
+void mch_calc_cell_size(struct cellsize *cs_out);
 /* vim: set ft=c : */

--- a/src/proto/os_unix.pro
+++ b/src/proto/os_unix.pro
@@ -1,4 +1,4 @@
-/* os_unix.c */
+/* os_;.c */
 sighandler_T mch_signal(int sig, sighandler_T func);
 int mch_chdir(char *path);
 void mch_write(char_u *s, int len);
@@ -91,4 +91,5 @@ void xsmp_close(void);
 void stop_timeout(void);
 volatile sig_atomic_t *start_timeout(long msec);
 void delete_timer(void);
+void f_getcellpixels(typval_T *argvars UNUSED, typval_T *rettv);
 /* vim: set ft=c : */

--- a/src/proto/os_unix.pro
+++ b/src/proto/os_unix.pro
@@ -1,4 +1,4 @@
-/* os_;.c */
+/* os_unix.c */
 sighandler_T mch_signal(int sig, sighandler_T func);
 int mch_chdir(char *path);
 void mch_write(char_u *s, int len);

--- a/src/testdir/test_utf8.vim
+++ b/src/testdir/test_utf8.vim
@@ -273,6 +273,12 @@ func Test_setcellwidths()
   bwipe!
 endfunc
 
+" Pixel size of a cell is terminal-dependent, so in the test, only the list and size 2 are checked.
+func Test_getcellpixels()
+  let cellpixels = getcellpixels()
+  call assert_equal(2, len(cellpixels))
+endfunc
+
 func Test_getcellwidths()
   call setcellwidths([])
   call assert_equal([], getcellwidths())

--- a/src/testdir/test_utf8.vim
+++ b/src/testdir/test_utf8.vim
@@ -275,6 +275,8 @@ endfunc
 
 " Pixel size of a cell is terminal-dependent, so in the test, only the list and size 2 are checked.
 func Test_getcellpixels()
+  " Not yet Windows-compatible
+  CheckNotMSWindows
   let cellpixels = getcellpixels()
   call assert_equal(2, len(cellpixels))
 endfunc


### PR DESCRIPTION
### What I want to do?
I want to get the pixel size of the window in the CUI version of Vim.

### Motivation:
The ability to output Sixel in echoraw has opened up possibilities such as image display plugins
If the pixel size of the window can be known, the possibilities for functions such as fitting the image to the window will be expanded.

### Pros:
The ability to obtain precise pixel size opens up possibilities for image output plugins.

### Cons:
Even in cases where the matrix level is sufficient, processing time to obtain pixel level values is added.

### Implementation:

* Issue TIOCSWINSZ to the parent process's tty to get the size, and calculate the cell size from it.
* Calculate the window pixel size using the cell width and height and the window row, col.
* Add wpixel and hpixel entries to the getwininfo() dictionary and store the pixel size there.

### Others:

The initial implementation used CSI escape sequences, but it was changed to the `TIOCSWINSZ` implementation because of a problem where processing would not continue unless `<Enter>` was pressed after `getwinsize()`.
(See: https://github.com/vim/vim/compare/master...mikoto2000:vim:add-pixel-size-in-getwininfo2)