### PR TITLE
runtime(vim): Fix indent after :silent! function

### DIFF
--- a/runtime/autoload/dist/vimindent.vim
+++ b/runtime/autoload/dist/vimindent.vim
@@ -2,10 +2,11 @@ vim9script
 
 # Language:     Vim script
 # Maintainer:   github user lacygoill
-# Last Change:  2023 Jun 29
+# Last Change:  2024 Nov 08
 #
-# Includes Changes from Vim:
+# Includes changes from The Vim Project:
 #  - 2024 Feb 09: Fix indent after literal Dict (A. Radev via #13966)
+#  - 2024 Nov 08: Fix indent after :silent! function (D. Kearns via #16009)
 
 # NOTE: Whenever you change the code, make sure the tests are still passing:
 #
@@ -295,7 +296,7 @@ patterns = []
     endfor
 }
 
-const STARTS_NAMED_BLOCK: string = $'^\s*\%(sil\%[ent]\s\+\)\=\%({patterns->join('\|')}\)\>\%(\s\|$\|!\)\@='
+const STARTS_NAMED_BLOCK: string = $'^\s*\%(sil\%[ent]!\=\s\+\)\=\%({patterns->join('\|')}\)\>\%(\s\|$\|!\)\@='
 
 # STARTS_CURLY_BLOCK {{{3
 

--- a/runtime/indent/testdir/vim.in
+++ b/runtime/indent/testdir/vim.in
@@ -951,3 +951,12 @@ endenum
 call prop_type_add('indent_after_literal_dict', #{ foo: 'bar' })
 call prop_type_delete('indent_after_literal_dict')
 " END_INDENT
+
+" START_INDENT
+silent function Foo()
+return 42
+endfunction
+silent! function Bar()
+return 42
+endfunction
+" END_INDENT

--- a/runtime/indent/testdir/vim.ok
+++ b/runtime/indent/testdir/vim.ok
@@ -951,3 +951,12 @@ endenum
 call prop_type_add('indent_after_literal_dict', #{ foo: 'bar' })
 call prop_type_delete('indent_after_literal_dict')
 " END_INDENT
+
+" START_INDENT
+silent function Foo()
+    return 42
+endfunction
+silent! function Bar()
+    return 42
+endfunction
+" END_INDENT


### PR DESCRIPTION
See https://github.com/vim/vim/commit/35699f17497dcdcfdd747fedaef28f208ac6eb5f#commitcomment-148816912

@Konfekt, does that work for your cases?

Ping @lacygoill
