### PR TITLE
runtime: add option for decimal breakpoint signs in termdebug

### DIFF
--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -1692,7 +1692,7 @@ If you would like to use decimal (base 10) breakpoint signs: >
 	let g:termdebug_config['sign_decimal'] = 1
 If there is no g:terminal_config yet you can use: >
 	let g:termdebug_config = {'sign': '>>'}
-Or, for decimal signs: >
+Likewise, to enable decimal signs: >
 	let g:termdebug_config = {'sign_decimal': 1}
 
 

--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -1692,8 +1692,8 @@ If you would like to use decimal (base 10) breakpoint signs: >
 	let g:termdebug_config['sign_decimal'] = 1
 If there is no g:terminal_config yet you can use: >
 	let g:termdebug_config = {'sign': '>>'}
-Or: >
-	let g:termdebug_config = {'sign_decimal': '>>'}
+Or, for decimal signs: >
+	let g:termdebug_config = {'sign_decimal': 1}
 
 
 Window toolbar ~

--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -1683,13 +1683,17 @@ Change default signs ~
 Termdebug uses the hex number of the breakpoint ID in the signcolumn to
 represent breakpoints. If it is greater than "0xFF", then it will be displayed
 as "F+", due to we really only have two screen cells for the sign.
+You may also use decimal breakpoint signs instead, in which case IDs greater
+than 99 will be displayed as "9+".
 
-If you want to customize the breakpoint signs: >
+If you want to customize the breakpoint signs to show `>>` in the signcolumn: >
 	let g:termdebug_config['sign'] = '>>'
+If you would like to use decimal (base 10) breakpoint signs: >
+	let g:termdebug_config['sign_decimal'] = 1
 If there is no g:terminal_config yet you can use: >
 	let g:termdebug_config = {'sign': '>>'}
-
-After this, breakpoints will be displayed as `>>` in the signcolumn.
+Or: >
+	let g:termdebug_config = {'sign_decimal': '>>'}
 
 
 Window toolbar ~

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -1912,6 +1912,11 @@ def CreateBreakpoint(id: number, subid: number, enabled: string)
     var label = ''
     if exists('g:termdebug_config') && has_key(g:termdebug_config, 'sign')
       label = g:termdebug_config['sign']
+    elseif exists('g:termdebug_config') && has_key(g:termdebug_config, 'sign_decimal')
+      label = printf('%02d', id)
+      if id > 99
+        label = '9+'
+      endif
     else
       label = printf('%02X', id)
       if id > 255


### PR DESCRIPTION
I see there's been some back-and-forth about how to display breakpoint ID signs in the source window (see #13525 ).

The current hex implementation allows for more breakpoints, but is confusing for me when I need to refer to that breakpoint in the GDB window:
```
(gdb) disab 0E
Bad breakpoint number '0E'
(gdb) disab 0x0e
Bad breakpoint number '0x0e'
```

For this reason, I have added a configuration flag to `g:termdebug_config` (`sign_decimal`) to allow the user to display breakpoint signs in decimal instead. Following the convention of showing >255 as "F+", breakpoints over 99 will display as "9+". 

I'm new to Vimscript but it is working for me, I also added documentation. I did not open an issue for this change but am happy to do so if it would facilitate further discussion.

@ubaldot - does this seem in line with Vim/termdebug's vision?