### PR TITLE
No warning when IPC registers are not available

### DIFF
--- a/runtime/doc/gui.txt
+++ b/runtime/doc/gui.txt
@@ -1,4 +1,4 @@
-*gui.txt*       For Vim version 9.1.  Last change: 2024 Jul 17
+*gui.txt*       For Vim version 9.1.  Last change: 2024 Nov 07
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -473,6 +473,8 @@ transferred via the |x11-cut-buffer|, the selection type is ALWAYS lost.
 When the "unnamed" string is included in the 'clipboard' option, the unnamed
 register is the same as the "* register.  Thus you can yank to and paste the
 selection without prepending "* to commands.
+
+See also |W23|.
 
 ==============================================================================
 5. Menus						*menus*

--- a/runtime/doc/gui_x11.txt
+++ b/runtime/doc/gui_x11.txt
@@ -1,4 +1,4 @@
-*gui_x11.txt*   For Vim version 9.1.  Last change: 2024 Apr 22
+*gui_x11.txt*   For Vim version 9.1.  Last change: 2024 Nov 07
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -708,6 +708,13 @@ Examples: (assuming the default option values)
 Note that the text in the "+ register remains available when making a Visual
 selection, which makes other text available in the "* register.  That allows
 overwriting selected text.
+
+								*W23*
+When you are yanking into the "* or "+ register and Vim cannot establish a
+connection to the X11 selection, it will use register 0 and output a warning:
+
+  Warning: Clipboard register not available, using register 0 ~
+
 							*x11-cut-buffer*
 There are, by default, 8 cut-buffers: CUT_BUFFER0 to CUT_BUFFER7.  Vim only
 uses CUT_BUFFER0, which is the one that xterm uses by default.

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -5818,6 +5818,7 @@ W19	autocmd.txt	/*W19*
 W20	if_pyth.txt	/*W20*
 W21	if_pyth.txt	/*W21*
 W22	userfunc.txt	/*W22*
+W23	gui_x11.txt	/*W23*
 WORD	motion.txt	/*WORD*
 WSL	os_win32.txt	/*WSL*
 WWW	intro.txt	/*WWW*

--- a/src/clipboard.c
+++ b/src/clipboard.c
@@ -2220,10 +2220,12 @@ adjust_clip_reg(int *rp)
 	    *rp = ((clip_unnamed_saved & CLIP_UNNAMED_PLUS)
 					   && clip_plus.available) ? '+' : '*';
     }
-    if (!clip_star.available && *rp == '*')
+    if ((!clip_star.available && *rp == '*') ||
+           (!clip_plus.available && *rp == '+'))
+    {
+	msg_warn_missing_clipboard();
 	*rp = 0;
-    if (!clip_plus.available && *rp == '+')
-	*rp = 0;
+    }
 }
 
 #endif // FEAT_CLIPBOARD

--- a/src/message.c
+++ b/src/message.c
@@ -55,6 +55,9 @@ static int msg_hist_len = 0;
 static FILE *verbose_fd = NULL;
 static int  verbose_did_open = FALSE;
 
+static int  did_warn_clipboard = FALSE;
+static char *warn_clipboard = "W23: Clipboard register not available, using register 0";
+
 /*
  * When writing messages to the screen, there are many different situations.
  * A number of variables is used to remember the current state:
@@ -4058,6 +4061,19 @@ msg_advance(int col)
 #endif
 	while (msg_col < col)
 	    msg_putchar(' ');
+}
+
+/*
+ * Warn about missing Clipboard Support
+ */
+    void
+msg_warn_missing_clipboard(void)
+{
+    if (!global_busy && !did_warn_clipboard)
+    {
+       msg(_(warn_clipboard));
+       did_warn_clipboard = TRUE;
+    }
 }
 
 #if defined(FEAT_CON_DIALOG) || defined(PROTO)

--- a/src/proto/message.pro
+++ b/src/proto/message.pro
@@ -73,6 +73,7 @@ void give_warning(char_u *message, int hl);
 void give_warning_with_source(char_u *message, int hl, int with_source);
 void give_warning2(char_u *message, char_u *a1, int hl);
 void msg_advance(int col);
+void msg_warn_missing_clipboard(void);
 int do_dialog(int type, char_u *title, char_u *message, char_u *buttons, int dfltbutton, char_u *textfield, int ex_cmd);
 int vim_dialog_yesno(int type, char_u *title, char_u *message, int dflt);
 int vim_dialog_yesnocancel(int type, char_u *title, char_u *message, int dflt);

--- a/src/register.c
+++ b/src/register.c
@@ -198,6 +198,12 @@ valid_yank_reg(
 #endif
 							)
 	return TRUE;
+    // Warn about missing clipboard support once
+    else if (regname == '*' || regname == '+')
+    {
+	msg_warn_missing_clipboard();
+	return FALSE;
+    }
     return FALSE;
 }
 
@@ -1173,10 +1179,12 @@ op_yank(oparg_T *oap, int deleting, int mess)
 	return OK;
 
 #ifdef FEAT_CLIPBOARD
-    if (!clip_star.available && oap->regname == '*')
+    if ((!clip_star.available && oap->regname == '*') || (!clip_plus.available
+               && oap->regname == '+'))
+    {
 	oap->regname = 0;
-    else if (!clip_plus.available && oap->regname == '+')
-	oap->regname = 0;
+	msg_warn_missing_clipboard();
+    }
 #endif
 
     if (!deleting)		    // op_delete() already set y_current

--- a/src/testdir/test_registers.vim
+++ b/src/testdir/test_registers.vim
@@ -1045,4 +1045,16 @@ func Test_insert_small_delete_replace_mode()
   bwipe!
 endfunc
 
+" Test for W23 when clipboard is not available
+func Test_clipboard_regs_not_working()
+  CheckNotGui
+  if !has("clipboard")
+    new
+    call append(0, "text for clipboard test")
+    let mess = execute(':norm "*yiw')
+    call assert_match('W23', mess)
+    bw!
+  endif
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Vim silently uses the 0 register, when clipboard/register * or + is not available. This might be a bit unexpected for the user.

So let's just warn when we silently (re-)use register 0.

related: #14768