### PR TITLE
if_lua: v:false/v:true are not evaluated to boolean

### DIFF
--- a/src/if_lua.c
+++ b/src/if_lua.c
@@ -595,7 +595,7 @@ luaV_pushtypval(lua_State *L, typval_T *tv)
 	case VAR_BOOL:
 	case VAR_SPECIAL:
 	    if (tv->vval.v_number <= VVAL_TRUE)
-		lua_pushinteger(L, (int) tv->vval.v_number);
+		lua_pushboolean(L, (int) tv->vval.v_number);
 	    else
 		lua_pushnil(L);
 	    break;

--- a/src/testdir/test_lua.vim
+++ b/src/testdir/test_lua.vim
@@ -117,11 +117,11 @@ func Test_lua_eval()
 
   " lua.eval with a bool
   lua v = vim.eval('v:true')
-  call assert_equal('number', luaeval('vim.type(v)'))
-  call assert_equal(1, luaeval('v'))
+  call assert_equal('boolean', luaeval('vim.type(v)'))
+  call assert_equal(v:true, luaeval('v'))
   lua v = vim.eval('v:false')
-  call assert_equal('number', luaeval('vim.type(v)'))
-  call assert_equal(0, luaeval('v'))
+  call assert_equal('boolean', luaeval('vim.type(v)'))
+  call assert_equal(v:false, luaeval('v'))
 
   " lua.eval with a null
   lua v = vim.eval('v:null')

--- a/src/testdir/test_python3.vim
+++ b/src/testdir/test_python3.vim
@@ -299,7 +299,7 @@ func Test_unicode()
 endfunc
 
 " Test vim.eval() with various types.
-func Test_python3_vim_val()
+func Test_python3_vim_eval()
   call assert_equal("\n8",             execute('py3 print(vim.eval("3+5"))'))
   call assert_equal("\n3.140000",    execute('py3 print(vim.eval("1.01+2.13"))'))
   call assert_equal("\n0.000000",    execute('py3 print(vim.eval("0.0/(1.0/0.0)"))'))


### PR DESCRIPTION
Problem:  if_lua: v:false/v:true are not evaluated to boolean.
Solution: Use lua_pushboolean() instead of lua_pushinteger().

Fix #15994
