### PR TITLE
runtime(lua): make recognice user functions

### DIFF
--- a/runtime/syntax/lua.vim
+++ b/runtime/syntax/lua.vim
@@ -62,8 +62,12 @@ syn match  luaParenError ")"
 syn match  luaError "}"
 syn match  luaError "\<\%(end\|else\|elseif\|then\|until\|in\)\>"
 
+" methods and user functions
+syn match luaFunc "[^ :.]\@=\k\+(\@="
+
 " Function declaration
 syn region luaFunctionBlock transparent matchgroup=luaFunction start="\<function\>" end="\<end\>" contains=TOP
+syn region luaFunctionBlock transparent matchgroup=luaLambda start="\<function\>\ze(" end="\<end\>" contains=TOP
 
 " else
 syn keyword luaCondElse matchgroup=luaCond contained containedin=luaCondEnd else
@@ -165,9 +169,6 @@ endif
 
 " tables
 syn region luaTableBlock transparent matchgroup=luaTable start="{" end="}" contains=TOP,luaStatement
-
-" methods
-syntax match luaFunc ":\@<=\k\+"
 
 " built-in functions
 syn keyword luaFunc assert collectgarbage dofile error next
@@ -422,7 +423,8 @@ hi def link luaSymbolOperator   luaOperator
 hi def link luaConstant         Constant
 hi def link luaCond             Conditional
 hi def link luaCondElse         Conditional
-hi def link luaFunction         Function
+hi def link luaFunction         Keyword
+hi def link luaLambda           Function
 hi def link luaMetaMethod       Function
 hi def link luaComment          Comment
 hi def link luaCommentDelimiter luaComment


### PR DESCRIPTION
ping to maintainer: @marcuscf

Hi,
This PR tries to make recognize user defined function in lua files. First I believe that `function` and the `end` are keywords and they should be highlighted correctly unless it a lambda. In that case I consider them more of a callable function.  

## Before

![image](https://github.com/user-attachments/assets/428c5cd5-bd79-4c69-8a47-7662e80df459)

## After

![image](https://github.com/user-attachments/assets/8dfeef33-2ac0-4b01-82f0-bbdc8fcdb463)