### PR TITLE
runtime(racket): update Racket runtime files

### DIFF
--- a/runtime/autoload/racket.vim
+++ b/runtime/autoload/racket.vim
@@ -1,6 +1,6 @@
 " Maintainer: D. Ben Knoble <ben.knoble+github@gmail.com>
 " URL: https://github.com/benknoble/vim-racket
-" Last Change: 2023 Sep 22
+" Last Change: 2024 Nov 12
 vim9script
 
 def MakePatternFromLiterals(xs: list<string>): string
@@ -170,7 +170,7 @@ def PosLT(left: dict<any>, right: dict<any>): bool
 enddef
 
 def IsForFold(word: string): bool
-  return ['for/fold', 'for/foldr', 'for*/fold', 'for*/foldr']->index(word) >= 0
+  return ['for/fold', 'for/foldr', 'for/lists', 'for*/fold', 'for*/foldr', 'for*/lists']->index(word) >= 0
 enddef
 
 def IsSecondForm(blnum: number, bcol: number, vlnum: number): bool
@@ -209,5 +209,5 @@ def IsSecondForm(blnum: number, bcol: number, vlnum: number): bool
   endwhile
 
   # assert_report(printf('forms seen pre-return: %d', forms_seen))
-  return forms_seen == 2 || (forms_seen == 1 && !empty(stack))
+  return (forms_seen == 2 && empty(stack)) || (forms_seen == 1 && !empty(stack))
 enddef

--- a/runtime/ftplugin/racket.vim
+++ b/runtime/ftplugin/racket.vim
@@ -3,7 +3,7 @@
 " Maintainer:           D. Ben Knoble <ben.knoble+github@gmail.com>
 " Previous Maintainer:  Will Langstroth <will@langstroth.com>
 " URL:                  https://github.com/benknoble/vim-racket
-" Last Change:          2024 May 28
+" Last Change:          2024 Jun 01
 
 if exists("b:did_ftplugin")
   finish
@@ -16,19 +16,20 @@ set cpo&vim
 " quick hack to allow adding values
 setlocal iskeyword=@,!,#-',*-:,<-Z,a-z,~,_,94
 
+setlocal shiftwidth=2 softtabstop=2
+
 " Enable auto begin new comment line when continuing from an old comment line
 setlocal comments=:;;;;,:;;;,:;;,:;
 setlocal formatoptions+=r
 
-"setlocal commentstring=;;\ %s
-setlocal commentstring=#\|\ %s\ \|#
+setlocal commentstring=;;\ %s
 
 setlocal formatprg=raco\ fmt
 
 " Undo our settings when the filetype changes away from Racket
 " (this should be amended if settings/mappings are added above!)
 let b:undo_ftplugin =
-      \  "setlocal iskeyword< lispwords< lisp< comments< formatoptions< formatprg<"
+      \  "setlocal iskeyword< shiftwidth< softtabstop< comments< formatoptions< formatprg<"
       \. " | setlocal commentstring<"
 
 if !exists("no_plugin_maps") && !exists("no_racket_maps")

--- a/runtime/indent/racket.vim
+++ b/runtime/indent/racket.vim
@@ -3,7 +3,7 @@
 " Maintainer:           D. Ben Knoble <ben.knoble+github@gmail.com>
 " Previous Maintainer:  Will Langstroth <will@langstroth.com>
 " URL:                  https://github.com/benknoble/vim-racket
-" Last Change:          2024 Jan 31
+" Last Change:          2024 Nov 12
 
 if exists("b:did_indent")
    finish
@@ -21,6 +21,7 @@ setlocal lispwords+=λ
 setlocal lispwords+=with-handlers
 setlocal lispwords+=define-values,opt-lambda,case-lambda,syntax-rules,with-syntax,syntax-case,syntax-parse
 setlocal lispwords+=define-for-syntax,define-syntax-parser,define-syntax-parse-rule,define-syntax-class,define-splicing-syntax-class
+setlocal lispwords+=syntax/loc,quasisyntax/loc
 setlocal lispwords+=define-syntax-parameter,syntax-parameterize
 setlocal lispwords+=define-signature,unit,unit/sig,compund-unit/sig,define-values/invoke-unit/sig
 setlocal lispwords+=define-opt/c,define-syntax-rule
@@ -30,6 +31,11 @@ setlocal lispwords+=with-input-from-file,with-output-to-file
 setlocal lispwords+=begin,begin0
 setlocal lispwords+=place
 setlocal lispwords+=cond
+" Racket style indents if like a function application:
+" (if test
+"     then
+"     else)
+setlocal lispwords-=if
 
 " Racket OOP
 " TODO missing a lot of define-like forms here (e.g., define/augment, etc.)
@@ -50,6 +56,7 @@ setlocal lispwords+=for/set,for*/set
 setlocal lispwords+=for/first,for*/first
 setlocal lispwords+=for/last,for*/last
 setlocal lispwords+=for/stream,for*/stream
+setlocal lispwords+=for/lists,for*/lists
 
 setlocal lispwords+=match,match*,match/values,define/match,match-lambda,match-lambda*,match-lambda**
 setlocal lispwords+=match-let,match-let*,match-let-values,match-let*-values
@@ -65,5 +72,8 @@ setlocal lispwords+=define-qi-syntax,define-qi-syntax-parser,define-qi-syntax-ru
 setlocal lispwords+=if-view,case-view,cond-view,list-view,dyn-view
 setlocal lispwords+=case/dep
 setlocal lispwords+=define/obs
+
+" rackunit
+setlocal lispwords+=define-simple-check,define-binary-check,define-check,with-check-info
 
 let b:undo_indent = "setlocal lisp< ai< si< lw<" .. (has('vim9script') ? ' indentexpr< lispoptions<' : '')

--- a/runtime/syntax/racket.vim
+++ b/runtime/syntax/racket.vim
@@ -4,7 +4,7 @@
 " Previous Maintainer:  Will Langstroth <will@langstroth.com>
 " URL:                  https://github.com/benknoble/vim-racket
 " Description:          Contains all of the keywords in #lang racket
-" Last Change:          2023 Sep 22
+" Last Change:          2024 Apr 14
 
 " Initializing:
 if exists("b:current_syntax")
@@ -30,7 +30,7 @@ endif
 " http://docs.racket-lang.org/reference/index.html
 "
 syntax keyword racketSyntax module module* module+ require provide quote
-syntax keyword racketSyntax #%datum #%expression #%top #%variable-reference #%app
+syntax keyword racketSyntax #%module-begin #%datum #%expression #%top #%variable-reference #%app
 syntax keyword racketSyntax lambda case-lambda let let* letrec
 syntax keyword racketSyntax let-values let*-values let-syntax letrec-syntax
 syntax keyword racketSyntax let-syntaxes letrec-syntaxes letrec-syntaxes+values


### PR DESCRIPTION
This brings the included Racket runtime files to commit c41bc5a (indent for[*]/lists with accumulator clause correctly, 2024-11-12) of https://github.com/benknoble/vim-racket. Note that not all files from that repository are included.