### PR TITLE
runtime(bash): support for dash in func keywords

### DIFF
--- a/runtime/indent/sh.vim
+++ b/runtime/indent/sh.vim
@@ -7,6 +7,8 @@
 " License:             Vim (see :h license)
 " Repository:          https://github.com/chrisbra/vim-sh-indent
 " Changelog:
+"          20241411  - Detect dash character in function keyword for
+"                      bash mode (issue #16049)
 "          20190726  - Correctly skip if keywords in syntax comments
 "                      (issue #17)
 "          20190603  - Do not indent in zsh filetypes with an `if` in comments
@@ -195,7 +197,9 @@ endfunction
 function! s:is_function_definition(line)
   return a:line =~ '^\s*\<\k\+\>\s*()\s*{' ||
        \ a:line =~ '^\s*{' ||
-       \ a:line =~ '^\s*function\s*\k\+\s*\%(()\)\?\s*{'
+       \ a:line =~ '^\s*function\s*\k\+\s*\%(()\)\?\s*{' ||
+       \ (get(b:, 'is_bash', 0) &&
+       \  a:line =~ '^\s*function\s*\S\+\s*\%(()\)\?\s*{' )
 endfunction
 
 function! s:is_array(line)

--- a/runtime/indent/testdir/bash.in
+++ b/runtime/indent/testdir/bash.in
@@ -1,0 +1,22 @@
+#!/bin/bash
+# vim: set ft=bash sw=2 noet:
+
+# START_INDENT
+a = 10
+b = 20
+
+function add() {
+c = $((a + b))
+}
+
+function print {
+# do nothing
+}
+
+if [[ $c -ge 15 ]];
+then
+print("ok")
+else
+print("not ok")
+fi
+# END_INDENT

--- a/runtime/indent/testdir/bash.ok
+++ b/runtime/indent/testdir/bash.ok
@@ -1,0 +1,22 @@
+#!/bin/bash
+# vim: set ft=bash sw=2 noet:
+
+# START_INDENT
+a = 10
+b = 20
+
+function add() {
+  c = $((a + b))
+}
+
+function print {
+  # do nothing
+}
+
+if [[ $c -ge 15 ]];
+then
+  print("ok")
+else
+  print("not ok")
+fi
+# END_INDENT


### PR DESCRIPTION
This adds support for dash character in function keywords. Bash does support it, POSIX shell does not:

```
sh-5.2$ function test-it() {
> echo "test"
> }
sh: „test-it“: not valid identifier

lzap@nuc:~$ function test-it() {
> echo "test"
> }
```

It also introduces a simple test.