### PR TITLE
runtime(org): add basic support for org files

### DIFF
--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -830,6 +830,12 @@ To enable folding use this: >
 	let g:markdown_recommended_style = 0
 
 
+ORG							*ft-org-plugin*
+
+To enable folding use this: >
+	let g:org_folding = 1
+<
+
 PDF							*ft-pdf-plugin*
 
 Two maps, <C-]> and <C-T>, are provided to simulate a tag stack for navigating

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1472,6 +1472,9 @@ au BufNewFile,BufRead *.markdown,*.mdown,*.mkd,*.mkdn,*.mdwn,*.md
 	\   setf markdown |
 	\ endif
 
+" Org (Emacs' org-mode)
+au BufNewFile,BufRead *.org			setf org
+
 " Mason (it used to include *.comp, are those Mason files?)
 au BufNewFile,BufRead *.mason,*.mhtml	setf mason
 

--- a/runtime/ftplugin/org.vim
+++ b/runtime/ftplugin/org.vim
@@ -1,0 +1,37 @@
+" Vim filetype plugin file
+" Language:	Org
+" Maintainer:	Luca Saccarola <github.e41mv@aleeas.com>
+" Last Change:	2024 Nov 14
+
+if exists("b:did_ftplugin")
+    finish
+endif
+let b:did_ftplugin = 1
+
+if exists('b:undo_ftplugin')
+    let b:undo_ftplugin .= "|setl cms< com< fo< flp<"
+else
+    let b:undo_ftplugin = "setl cms< com< fo< flp<"
+endif
+
+setl commentstring=#\ %s
+setl comments=fb:*,fb:-,fb:+,b:#,b:\:
+
+setl formatoptions+=nql
+setl formatlistpat=^\\s*\\(\\(\\d\\|\\a\\)\\+[.)]\\|[+-]\\)\\s\\+
+
+function OrgFoldExpr()
+    let l:depth = match(getline(v:lnum), '\(^\*\+\)\@<=\( .*$\)\@=')
+    if l:depth > 0 && synIDattr(synID(v:lnum, 1, 1), 'name') =~# '\m^orgHeadline'
+        return ">" . l:depth
+    endif
+    return "="
+endfunction
+
+if has("folding") && get(g:, 'org_folding', 0)
+    setl foldexpr=OrgFoldExpr()
+    setl foldmethod=expr
+    let b:undo_ftplugin .= "|setl foldexpr< foldmethod<"
+endif
+
+" vim: ts=8 sts=2 sw=2 et

--- a/runtime/syntax/org.vim
+++ b/runtime/syntax/org.vim
@@ -1,0 +1,71 @@
+" Vim syntax file
+" Language:	Org
+" Maintainer:	Luca Saccarola <github.e41mv@aleeas.com>
+" Last Change:	2024 Nov 14
+"
+" Reference Specification: Org mode manual
+"   GNU Info: `$ info Org`
+"   Web: <https://orgmode.org/manual/index.html>
+
+" Quit when a (custom) syntax file was already loaded
+if exists("b:current_syntax")
+  finish
+endif
+let b:current_syntax = 'org'
+
+syn case ignore
+
+" Bold
+syn region orgBold matchgroup=orgBoldDelimiter start="\(^\|[- '"({\]]\)\@<=\*\ze[^ ]" end="^\@!\*\([^\k\*]\|$\)\@=" keepend
+hi def link orgBold markdownBold
+hi def link orgBoldDelimiter orgBold
+
+" Italic
+syn region orgItalic matchgroup=orgItalicDelimiter start="\(^\|[- '"({\]]\)\@<=\/\ze[^ ]" end="^\@!\/\([^\k\/]\|$\)\@=" keepend
+hi def link orgItalic markdownItalic
+hi def link orgItalicDelimiter orgItalic
+
+" Strikethrogh
+syn region orgStrikethrough matchgroup=orgStrikethroughDelimiter start="\(^\|[ '"({\]]\)\@<=+\ze[^ ]" end="^\@!+\([^\k+]\|$\)\@=" keepend
+hi def link orgStrikethrough markdownStrike
+hi def link orgStrikethroughDelimiter orgStrikethrough
+
+" Underline
+syn region orgUnderline matchgroup=orgUnderlineDelimiter start="\(^\|[- '"({\]]\)\@<=_\ze[^ ]" end="^\@!_\([^\k_]\|$\)\@=" keepend
+
+" Headlines
+syn match orgHeadline "^\*\+\s\+.*$" keepend
+hi def link orgHeadline Title
+
+" Line Comment
+syn match  orgLineComment /^\s*#\s\+.*$/ keepend
+hi def link orgLineComment Comment
+
+" Block Comment
+syn region orgBlockComment matchgroup=orgBlockCommentDelimiter start="\c^\s*#+BEGIN_COMMENT" end="\c^\s*#+END_COMMENT" keepend
+hi def link orgBlockComment Comment
+hi def link orgBlockCommentDelimiter Comment
+
+" Lists
+syn match orgUnorderedListMarker "^\s*[-+]\s\+" keepend
+hi def link orgUnorderedListMarker markdownOrderedListMarker
+syn match orgOrderedListMarker "^\s*\(\d\|\a\)\+[.)]\s\+" keepend
+hi def link orgOrderedListMarker markdownOrderedListMarker
+"
+" Verbatim
+syn region orgVerbatimInline matchgroup=orgVerbatimInlineDelimiter start="\(^\|[- '"({\]]\)\@<==\ze[^ ]" end="^\@!=\([^\k=]\|$\)\@=" keepend
+hi def link orgVerbatimInline markdownCodeBlock
+hi def link orgVerbatimInlineDelimiter orgVerbatimInline
+syn region orgVerbatimBlock matchgroup=orgVerbatimBlockDelimiter start="\c^\s*#+BEGIN_.*" end="\c^\s*#+END_.*" keepend
+hi def link orgVerbatimBlock orgCode
+hi def link orgVerbatimBlockDelimiter orgVerbatimBlock
+
+" Code
+syn region orgCodeInline matchgroup=orgCodeInlineDelimiter start="\(^\|[- '"({\]]\)\@<=\~\ze[^ ]" end="^\@!\~\([^\k\~]\|$\)\@=" keepend
+highlight def link orgCodeInline markdownCodeBlock
+highlight def link orgCodeInlineDelimiter orgCodeInline
+syn region orgCodeBlock matchgroup=orgCodeBlockDelimiter start="\c^\s*#+BEGIN_SRC.*" end="\c^\s*#+END_SRC" keepend
+highlight def link orgCodeBlock markdownCodeBlock
+highlight def link orgCodeBlockDelimiter orgCodeBlock
+
+" vim: ts=8 sts=2 sw=2 et

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -2724,4 +2724,14 @@ func Test_make_file()
   filetype off
 endfunc
 
+func Test_org_file()
+  filetype on
+
+  call writefile(['* org Headline', '*some bold text*', '/some italic text/'], 'Xfile.org', 'D')
+  split Xfile.org
+  call assert_equal('org', &filetype)
+
+  filetype off
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Hi,
This PR adds basic support for Emacs' org mode files. Things like:
- Folding
- Syntax highlighting for primitives
- Basic ftplugin 