### PR TITLE
defaults: enable by default wildmenu even without defaults.vim

### DIFF
--- a/runtime/defaults.vim
+++ b/runtime/defaults.vim
@@ -39,7 +39,6 @@ set backspace=indent,eol,start
 set history=200		" keep 200 lines of command line history
 set ruler		" show the cursor position all the time
 set showcmd		" display incomplete commands
-set wildmenu		" display completion matches in a status line
 
 set ttimeout		" time out for key codes
 set ttimeoutlen=100	" wait up to 100ms after Esc for special key

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5325,7 +5325,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	The cursor is displayed at the start of the space a Tab character
 	occupies, not at the end as usual in Normal mode.  To get this cursor
 	position while displaying Tabs with spaces, use: >
-		:set list lcs=tab:\ \ 
+		:set list lcs=tab:\ \
 <
 	Note that list mode will also affect formatting (set with 'textwidth'
 	or 'wrapmargin') when 'cpoptions' includes 'L'.  See 'listchars' for
@@ -7385,7 +7385,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 			feature}
 	String to put at the start of lines that have been wrapped.  Useful
 	values are "> " or "+++ ": >
-		:set showbreak=>\ 
+		:set showbreak=>\
 <	Note the backslash to escape the trailing space.  It's easier like
 	this: >
 		:let &showbreak = '+++ '
@@ -9430,7 +9430,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	happens when there are special characters.
 
 				*'wildmenu'* *'wmnu'* *'nowildmenu'* *'nowmnu'*
-'wildmenu' 'wmnu'	boolean	(default off, set in |defaults.vim|)
+'wildmenu' 'wmnu'	boolean	(default on)
 			global
 	When 'wildmenu' is on, command-line completion operates in an enhanced
 	mode.  On pressing 'wildchar' (usually <Tab>) to invoke completion,

--- a/src/optiondefs.h
+++ b/src/optiondefs.h
@@ -2845,7 +2845,7 @@ static struct vimoption options[] =
 			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"wildmenu",    "wmnu", P_BOOL|P_VI_DEF,
 			    (char_u *)&p_wmnu, PV_NONE, NULL, NULL,
-			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
+			    {(char_u *)TRUE, (char_u *)0L} SCTX_INIT},
     {"wildmode",    "wim",  P_STRING|P_VI_DEF|P_ONECOMMA|P_NODUP|P_COLON,
 			    (char_u *)&p_wim, PV_NONE, did_set_wildmode, expand_set_wildmode,
 			    {(char_u *)"full", (char_u *)0L} SCTX_INIT},


### PR DESCRIPTION
Hi,
I believe that `wildmenu` should be enabled even without `defaults.vim`. It is such a useful feature and the majority of user will want that. There isn't really a gain in disabling it by default and relegate it to `defaults.vim`.

Most novice users want this enabled in every situation and a lot of them don't know that if you create a .vimrc `defaults.vim` won't be loaded anymore. I've just have a chat with a friend yestarday about this (and it isn't the first time). The only people I can see bothering is people that, for some reason, don't like completion. I think this days they are a very small group.

I don't know if I need to check if wildmenu is enabled or if I'm doing this correctly feedback will really be appreciated :).

Do I need to wrap it in a `#ifdef FEAT_WILDMENU` or something like that?