### PR TITLE
defaults: increase history to 200

### DIFF
--- a/runtime/defaults.vim
+++ b/runtime/defaults.vim
@@ -36,7 +36,6 @@ silent! endwhile
 " Allow backspacing over everything in insert mode.
 set backspace=indent,eol,start
 
-set history=200		" keep 200 lines of command line history
 set ruler		" show the cursor position all the time
 set showcmd		" display incomplete commands
 set wildmenu		" display completion matches in a status line

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4435,8 +4435,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	See |highlight-default| for the default highlight groups.
 
 						*'history'* *'hi'*
-'history' 'hi'		number	(Vim default: 50, Vi default: 0,
-						 set to 200 in |defaults.vim|)
+'history' 'hi'		number	(Vim default: 200, Vi default: 0)
 			global
 	A history of ":" commands, and a history of previous search patterns
 	is remembered.  This option decides how many entries may be stored in

--- a/src/optiondefs.h
+++ b/src/optiondefs.h
@@ -1305,7 +1305,7 @@ static struct vimoption options[] =
 			    SCTX_INIT},
     {"history",	    "hi",   P_NUM|P_VIM,
 			    (char_u *)&p_hi, PV_NONE, NULL, NULL,
-			    {(char_u *)0L, (char_u *)50L} SCTX_INIT},
+			    {(char_u *)0L, (char_u *)200L} SCTX_INIT},
     {"hkmap",	    "hk",   P_BOOL|P_VI_DEF|P_VIM,
 #ifdef FEAT_RIGHTLEFT
 			    (char_u *)&p_hkmap, PV_NONE, NULL, NULL,


### PR DESCRIPTION
This PR moves the increase in history from `defaults.vim` the C source code.

This I don't think has a reason to be only in `defaults.vim`.