### PR TITLE
Editorconfig changes: don't trim trailing whitespaces in runtime/doc

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -19,3 +19,7 @@ indent_size = 2
 # Markdown uses trailing whitespaces to do an hard line break
 # https://spec.commonmark.org/0.31.2/#hard-line-breaks
 trim_trailing_whitespace = false
+
+[runtime/doc/**.txt]
+# It can mess up some documentation by trying to strip trailing whitespaces
+trim_trailing_whitespace = false


### PR DESCRIPTION
Having editorconfig remove trailing whitespaces in did cause problems in some of my recent PRs when editing documentation files (#16057 #16055).

Solution:
- Don't remove automatically trailing whitespaces for `*.txt` files under `runtime/doc`