### PR TITLE
Improve the Warnings about missing clipboard registers

### DIFF
--- a/runtime/doc/gui.txt
+++ b/runtime/doc/gui.txt
@@ -1,4 +1,4 @@
-*gui.txt*       For Vim version 9.1.  Last change: 2024 Nov 07
+*gui.txt*       For Vim version 9.1.  Last change: 2024 Nov 16
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -474,7 +474,7 @@ When the "unnamed" string is included in the 'clipboard' option, the unnamed
 register is the same as the "* register.  Thus you can yank to and paste the
 selection without prepending "* to commands.
 
-See also |W23|.
+See also |W23| and |W24|.
 
 ==============================================================================
 5. Menus						*menus*

--- a/runtime/doc/gui_x11.txt
+++ b/runtime/doc/gui_x11.txt
@@ -1,4 +1,4 @@
-*gui_x11.txt*   For Vim version 9.1.  Last change: 2024 Nov 11
+*gui_x11.txt*   For Vim version 9.1.  Last change: 2024 Nov 16
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -715,6 +715,25 @@ connection to the X11 selection (or clipboard), it will use register 0 and
 output a warning:
 
   Warning: Clipboard register not available, using register 0 ~
+
+								*W24*
+Vim comes in different flavors, from a tiny build, that just tries to be
+compatible to original Vi, to enhanced builds which include many improvements
+(like a GUI).  However, on servers and embedded systems, Vim is typically
+compiled without clipboard support, since this feature requires X11 libraries
+to be present.  Check the ":version" output for the flag |+clipboard| or
+-clipboard.  The former means clipboard support is present while the latter
+means your Vim does not contain clipboard support.
+
+In the case when you are trying to access the "* or "+ register and Vim has
+no clipboard support, you will see this warning:
+
+  Warning: Clipboard register not available. See :h W24~
+
+If you have a vim with no clipboard support but would like to use the
+clipboard, try to install a more enhanced Vim package like vim-enhanced or
+vim-gtk3 (the gui packages usually also come with a terminal Vim that has
+clipboard support included).
 
 							*x11-cut-buffer*
 There are, by default, 8 cut-buffers: CUT_BUFFER0 to CUT_BUFFER7.  Vim only

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -5821,6 +5821,7 @@ W20	if_pyth.txt	/*W20*
 W21	if_pyth.txt	/*W21*
 W22	userfunc.txt	/*W22*
 W23	gui_x11.txt	/*W23*
+W24	gui_x11.txt	/*W24*
 WORD	motion.txt	/*WORD*
 WSL	os_win32.txt	/*WSL*
 WWW	intro.txt	/*WWW*

--- a/src/message.c
+++ b/src/message.c
@@ -56,7 +56,6 @@ static FILE *verbose_fd = NULL;
 static int  verbose_did_open = FALSE;
 
 static int  did_warn_clipboard = FALSE;
-static char *warn_clipboard = "W23: Clipboard register not available, using register 0";
 
 /*
  * When writing messages to the screen, there are many different situations.
@@ -4071,7 +4070,11 @@ msg_warn_missing_clipboard(void)
 {
     if (!global_busy && !did_warn_clipboard)
     {
-       msg(_(warn_clipboard));
+#ifdef FEAT_CLIPBOARD
+       msg(_("W23: Clipboard register not available, using register 0"));
+#else
+       msg(_("W24: Clipboard register not available. See :h W24"));
+#endif
        did_warn_clipboard = TRUE;
     }
 }

--- a/src/testdir/test_registers.vim
+++ b/src/testdir/test_registers.vim
@@ -1052,7 +1052,7 @@ func Test_clipboard_regs_not_working()
     new
     call append(0, "text for clipboard test")
     let mess = execute(':norm "*yiw')
-    call assert_match('W23', mess)
+    call assert_match('W24', mess)
     bw!
   endif
 endfunc


### PR DESCRIPTION
- Make it translatable
- Use a different warning, when clipboard support was not compiled in