### PR TITLE
tests: Test_terminal_qall_exit() is flaky

### DIFF
--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -4391,7 +4391,7 @@ mch_calc_cell_size(struct cellsize *cs_out)
    ch_log(NULL, "ioctl(TIOCGWINSZ) %s", retval == 0 ? "success" : "failed");
 #endif
 
-   if (retval == -1)
+   if (retval == -1 || ws.ws_xpixel == 0)
    {
        cs_out->cs_xpixel = -1;
        cs_out->cs_ypixel = -1;

--- a/src/testdir/test_terminal.vim
+++ b/src/testdir/test_terminal.vim
@@ -1334,7 +1334,7 @@ func Run_terminal_qall_kill(line1, line2)
   if !RunVim([], after, '')
     return
   endif
-  call assert_equal("done", readfile("Xdone")[0])
+  call WaitForAssert({-> assert_equal('done', readfile('Xdone')[0])})
   call delete("Xdone")
 endfunc
 
@@ -1369,7 +1369,7 @@ func Test_terminal_qall_exit()
   if !RunVim([], after, '')
     return
   endif
-  call assert_equal("done", readfile("Xdone")[0])
+  call WaitForAssert({-> assert_equal('done', readfile('Xdone')[0])})
   call delete("Xdone")
 endfunc
 


### PR DESCRIPTION
Problem:  tests: Test_terminal_qall_exit() is flaky
Solution: Use WaitForAssert()