### PR TITLE
Added DEBUG flag

### DIFF
--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -1737,4 +1737,23 @@ This can also be used in a "one-shot" manner: >
 	  let g:termdebug_config['evaluate_in_popup'] = v:false
 	endfunc
 <
+
+Contributing ~
+						*termdebug_contributing*
+Contributions for termdebug improvements are welcome.
+However, it is fairly common that during the development process you need some
+mechanisms like `echo` statements (or similar) to help you in your job.
+For this reason, you can set: >
+    let g:termdebug_config['debug'] = true
+<
+This sets the `DEBUG` variable to `true` in the source code that you can use
+within the source code. An example of its usage follows: >
+    if exists('g:termdebug_loaded')
+      if DEBUG
+	Echoerr('Termdebug already loaded.')
+      endif
+      finish
+    endif
+<
+
  vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -39,6 +39,9 @@ vim9script
 # https://sourceware.org/gdb/current/onlinedocs/gdb/GDB_002fMI.html
 
 var DEBUG = false
+if exists('g:termdebug_config')
+  DEBUG = get(g:termdebug_config, 'debug', false)
+endif
 
 def Echoerr(msg: string)
   echohl ErrorMsg | echom $'[termdebug] {msg}' | echohl None

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -38,6 +38,8 @@ vim9script
 # The communication with gdb uses GDB/MI.  See:
 # https://sourceware.org/gdb/current/onlinedocs/gdb/GDB_002fMI.html
 
+var DEBUG = false
+
 def Echoerr(msg: string)
   echohl ErrorMsg | echom $'[termdebug] {msg}' | echohl None
 enddef
@@ -49,7 +51,9 @@ enddef
 # Variables to keep their status among multiple instances of Termdebug
 # Avoid to source the script twice.
 if exists('g:termdebug_loaded')
-  Echoerr('Termdebug already loaded.')
+  if DEBUG
+    Echoerr('Termdebug already loaded.')
+  endif
   finish
 endif
 g:termdebug_loaded = true

--- a/src/testdir/test_termdebug.vim
+++ b/src/testdir/test_termdebug.vim
@@ -564,4 +564,19 @@ function Test_termdebug_config_types()
   unlet g:termdebug_config
 endfunction
 
+function Test_termdebug_config_debug()
+  let s:error_message = 'Termdebug already loaded'
+
+  " USER mode: No error message shall be displayed
+  packadd termdebug
+  call WaitForAssert({-> assert_true(execute('messages') !~ s:error_message)})
+
+  " DEBUG mode: Error message shall be now displayed
+  let g:termdebug_config = {}
+  let g:termdebug_config['debug'] = 1
+  packadd termdebug
+  call WaitForAssert({-> assert_true(execute('messages') =~ s:error_message)})
+
+  unlet g:termdebug_config
+endfunction
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem: during development/plugin update you may need some additional output message to aid the plugin updates, but some messaged may be annoying for users and could be silenced, see e.g. https://github.com/vim/vim/discussions/16035
Solution: Added a DEBUG flag.   