### PR TITLE
CI: Fix codecov flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,7 +297,7 @@ jobs:
         if: matrix.coverage
         uses: codecov/codecov-action@v5
         with:
-          flags: linux,${{ matrix.features }}-${{ matrix.compiler }}-${{ matrix.extra }}
+          flags: linux,${{ matrix.features }}-${{ matrix.compiler }}-${{ join(matrix.extra, '-') }}
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: ASan logs


### PR DESCRIPTION
## Problem

Some flags for codecov are not correct because it directly embeds an array with `${{ }}` (e.g. `huge-gcc-Array`).

https://app.codecov.io/gh/vim/vim/flags

## Solution

This PR fixes the flags by joining an array into a string with `-` separator.