### PR TITLE
runtime(netrw): Fixing powershell issues on windows due to mismatch in escaping

### DIFF
--- a/runtime/autoload/netrw.vim
+++ b/runtime/autoload/netrw.vim
@@ -11297,7 +11297,7 @@ endfun
 " s:NetrwExe: executes a string using "!" {{{2
 fun! s:NetrwExe(cmd)
 "  call Dfunc("s:NetrwExe(a:cmd<".a:cmd.">)")
-  if has("win32") && &shell !~? 'cmd\|pwsh\|powershell' && !g:netrw_cygwin
+  if has("win32") && &shell !~? '\v(cmd|pwsh|powershell)(\.exe)?$' && !g:netrw_cygwin
 "    call Decho("using win32:",expand("<slnum>"))
     let savedShell=[&shell,&shellcmdflag,&shellxquote,&shellxescape,&shellquote,&shellpipe,&shellredir,&shellslash]
     set shell& shellcmdflag& shellxquote& shellxescape&

--- a/runtime/autoload/netrw.vim
+++ b/runtime/autoload/netrw.vim
@@ -11297,7 +11297,7 @@ endfun
 " s:NetrwExe: executes a string using "!" {{{2
 fun! s:NetrwExe(cmd)
 "  call Dfunc("s:NetrwExe(a:cmd<".a:cmd.">)")
-  if has("win32") && &shell !~? '\v(cmd|pwsh|powershell)(\.exe)?$' && !g:netrw_cygwin
+  if has("win32") && exepath(&shell) !~? '\v[\/]?(cmd|pwsh|powershell)(\.exe)?$' && !g:netrw_cygwin
 "    call Decho("using win32:",expand("<slnum>"))
     let savedShell=[&shell,&shellcmdflag,&shellxquote,&shellxescape,&shellquote,&shellpipe,&shellredir,&shellslash]
     set shell& shellcmdflag& shellxquote& shellxescape&

--- a/runtime/autoload/netrw.vim
+++ b/runtime/autoload/netrw.vim
@@ -11297,7 +11297,7 @@ endfun
 " s:NetrwExe: executes a string using "!" {{{2
 fun! s:NetrwExe(cmd)
 "  call Dfunc("s:NetrwExe(a:cmd<".a:cmd.">)")
-  if has("win32")
+  if has("win32") && &shell !~? 'cmd\|pwsh\|powershell' && !g:netrw_cygwin
 "    call Decho("using win32:",expand("<slnum>"))
     let savedShell=[&shell,&shellcmdflag,&shellxquote,&shellxescape,&shellquote,&shellpipe,&shellredir,&shellslash]
     set shell& shellcmdflag& shellxquote& shellxescape&


### PR DESCRIPTION
All *shell* calls in the `netrw` plugin go through the `s:NetrwExe()` function.
All of them received arguments escaped via builtin `shellEscape()`.
The `shellEscape()` function was updated to use '' marks for escaping if shell is powershell.

The PR #15721 forced the use of the default shell (*cmd*) for windows which cannot recognized the powershell escaping.

Another issue of restricting all windows *shell* calls to *cmd* is that powershell scripts can no longer be used as commands, `g:netrw_ssh_cmd` for example, because *cmd* do not acknowledge them as scripts and passes them to the explorer file association (notepad for powershell scripts is the default).