### PR TITLE
Refactor insexpand.c to remove calls to STRLEN()

### DIFF
--- a/src/proto/insexpand.pro
+++ b/src/proto/insexpand.pro
@@ -31,6 +31,7 @@ unsigned int get_cot_flags(void);
 int pum_wanted(void);
 void ins_compl_show_pum(void);
 char_u *ins_compl_leader(void);
+size_t ins_compl_leader_len(void);
 char_u *find_word_start(char_u *ptr);
 char_u *find_word_end(char_u *ptr);
 void ins_compl_clear(void);


### PR DESCRIPTION
Use string_T to store strings.
Fix a warning in get_next_file_completion():
```
clang -c -I. -Iproto -DWIN32 -DWINVER=0x0A00 -D_WIN32_WINNT=0x0A00 -DHAVE_PATHDEF -DFEAT_NORMAL -DHAVE_STDINT_H -D__USE_MINGW_ANSI_STDIO -pipe -D_REENTRANT -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1 -Wall -Wextra -Wshadow -Wstrict-prototypes -Wmissing-prototypes -Werror -Wno-deprecated-declarations -Wno-error=missing-field-initializers -Werror=uninitialized -DEXITFREE -DFEAT_GUI_MSWIN -DFEAT_CLIPBOARD insexpand.c -o gobjx86-64/insexpand.o
insexpand.c:3576:20: warning: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long long') [-Wsign-compare]
 3576 |             for (i = 0; i < leader_len; i++)
      |                         ~ ^ ~~~~~~~~~~
insexpand.c:3584:20: warning: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long long') [-Wsign-compare]
 3584 |             for (i = 0; i < leader_len; i++)
      |                         ~ ^ ~~~~~~~~~~

```
Add function ins_complete_leader_len() for use elsewhere in the code.
