### PR TITLE
[RFC] runtime/helptoc: uncache g:helptoc.shell_prompt

### DIFF
--- a/runtime/pack/dist/opt/helptoc/autoload/helptoc.vim
+++ b/runtime/pack/dist/opt/helptoc/autoload/helptoc.vim
@@ -2,9 +2,15 @@ vim9script noclear
 
 # Config {{{1
 
-const SHELL_PROMPT: string = g:
-    ->get('helptoc', {})
-    ->get('shell_prompt', '^\w\+@\w\+:\f\+\$\s')
+var SHELL_PROMPT: string = ''
+
+def UpdateUserSettings() #{{{2
+    SHELL_PROMPT = g:
+        ->get('helptoc', {})
+        ->get('shell_prompt', '^\w\+@\w\+:\f\+\$\s')
+enddef
+
+UpdateUserSettings()
 
 # Init {{{1
 
@@ -200,6 +206,7 @@ enddef
 #}}}1
 # Core {{{1
 def SetToc() #{{{2
+    UpdateUserSettings()
     var toc: dict<any> = {entries: []}
     var type: string = GetType()
     toc.changedtick = b:changedtick

--- a/runtime/pack/dist/opt/helptoc/autoload/helptoc.vim
+++ b/runtime/pack/dist/opt/helptoc/autoload/helptoc.vim
@@ -5,9 +5,14 @@ vim9script noclear
 var SHELL_PROMPT: string = ''
 
 def UpdateUserSettings() #{{{2
-    SHELL_PROMPT = g:
+    var new_prompt: string = g:
         ->get('helptoc', {})
         ->get('shell_prompt', '^\w\+@\w\+:\f\+\$\s')
+    if new_prompt != SHELL_PROMPT
+        SHELL_PROMPT = new_prompt
+        # invalidate cache: user config has changed
+        unlet! b:toc
+    endif
 enddef
 
 UpdateUserSettings()
@@ -147,6 +152,8 @@ export def Open() #{{{2
         return
     endif
 
+    UpdateUserSettings()
+
     # invalidate the cache if the buffer's contents has changed
     if exists('b:toc') && &filetype != 'man'
         if b:toc.changedtick != b:changedtick
@@ -206,7 +213,6 @@ enddef
 #}}}1
 # Core {{{1
 def SetToc() #{{{2
-    UpdateUserSettings()
     var toc: dict<any> = {entries: []}
     var type: string = GetType()
     toc.changedtick = b:changedtick


### PR DESCRIPTION
Follow up on PR 10446 [1] so that changes at run-time (or after loading a vimrc) are reflected at next use.

[1]: https://github.com/vim/vim/pull/10446#issuecomment-2485169333

---

As the original comment points out, this may have been done for performance. Please try it out and comment if there are issues.

I'm not sure if the `SHELL_PROMPT` definition is formatted in a "standard" way under vim9script; feel free to suggest better versions.