### PR TITLE
gui_gtk: Open message dialogs should be focused when main window activates

### DIFF
--- a/src/gui_gtk.c
+++ b/src/gui_gtk.c
@@ -1790,6 +1790,8 @@ gui_mch_dialog(int	type,	    // type of dialog
     dialog = create_message_dialog(type, title, message);
     dialoginfo.dialog = GTK_DIALOG(dialog);
     dialog_add_buttons(GTK_DIALOG(dialog), buttons);
+    gtk_window_set_type_hint(GTK_WINDOW(dialog),
+			     GDK_WINDOW_TYPE_HINT_POPUP_MENU);
 
     if (textfield != NULL)
     {


### PR DESCRIPTION
Tell the window manager that message dialogs should be given focus when the user switches from another application back to Vim.  This can happen, e.g., when the user has a file open in Vim and then edits it in another program:

![image](https://github.com/user-attachments/assets/37969705-3aff-4112-addf-b3f8b988b8ed)


Fixes #172.

Tested locally on Ubuntu 22.04.5 LTS amd64 with GNOME 42.9.

