### PR TITLE
Fix Hyphen-minus keyword in apache.vim

### DIFF
--- a/runtime/syntax/apache.vim
+++ b/runtime/syntax/apache.vim
@@ -14,6 +14,7 @@ if exists("b:current_syntax")
 	finish
 endif
 
+syn iskeyword @,48-57,_,192-255,-
 syn case ignore
 
 " Base constructs


### PR DESCRIPTION
Multiple currently defined keywords in this file contain `-` (hyphen-minus). Because this character isn’t among Vim’s default keyword characters, however, these keywords don’t actually get recognised.

This PR merely adds `-` to the default set so all such keywords can work properly.

I hope to do a follow-on later to bring this file up to date with the latest version of Apache.