### PR TITLE
Fix gcc compile warning in vim_strnicmp_asc()

### DIFF
--- a/src/strings.c
+++ b/src/strings.c
@@ -597,7 +597,7 @@ vim_strnicmp(char *s1, char *s2, size_t len)
     int
 vim_strnicmp_asc(char *s1, char *s2, size_t len)
 {
-    int                i;
+    int                i = 0;
     int                save_cmp_flags = cmp_flags;
 
     cmp_flags |= CMP_KEEPASCII;		// compare by ASCII value, ignoring locale


### PR DESCRIPTION
Fix this gcc (v14.2.1 20240910) warning:
`gcc -Iproto -DHAVE_CONFIG_H -I/usr/include/gtk-2.0 -I/usr/lib/x86_64-linux-gnu/gtk-2.0/include -I/usr/include/pango-1.0 -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -I/usr/include/harfbuzz -I/usr/include/freetype2 -I/usr/include/libpng16 -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/fribidi -I/usr/include/uuid -I/usr/include/cairo -I/usr/include/pixman-1 -I/usr/include/gdk-pixbuf-2.0 -I/usr/include/x86_64-linux-gnu -I/usr/include/atk-1.0 -pthread -c -I. -Iproto -DHAVE_CONFIG_H     -O -Wall -Wextra -Wshadow -Werror -Wstrict-prototypes -Wmissing-prototypes -Wno-deprecated-declarations -Wno-error=missing-field-initializers -Wno-error=maybe-uninitialized       -D_REENTRANT -o objects/strings.o strings.c
strings.c: In function 'vim_strnicmp_asc':
strings.c:616:12: warning: 'i' may be used uninitialized [-Wmaybe-uninitialized]
  616 |     return i;
         |               ^
strings.c:600:24: note: 'i' was declared here
  600 |     int                i;
         |                        ^
`

[gcc_string_warning.txt](https://github.com/user-attachments/files/17882704/gcc_string_warning.txt)
