### PR TITLE
Changing of the makefiles for tutor1 and tutor2 files

### DIFF
--- a/runtime/tutor/Make_all.mak
+++ b/runtime/tutor/Make_all.mak
@@ -2,32 +2,47 @@
 # Makefile with common components
 #
 
-CONVERTED = \
-		tutor.utf-8 \
-		tutor.bar \
-		tutor.ca.utf-8 \
-		tutor.de.utf-8 \
-		tutor.el \
-		tutor.el.cp737 \
-		tutor.eo \
-		tutor.es \
-		tutor.fr.utf-8 \
-		tutor.hr \
-		tutor.hr.cp1250 \
-		tutor.hu \
-		tutor.hu.cp1250 \
-		tutor.it.utf-8 \
-		tutor.ja.sjis \
-		tutor.ja.euc \
-		tutor.ko.euc \
-		tutor.nl \
-		tutor.no.utf-8 \
-		tutor.nb \
-		tutor.nb.utf-8 \
-		tutor.ru \
-		tutor.ru.cp1251 \
-		tutor.sv.utf-8 \
-		tutor.tr.iso9 \
-		tutor.zh.utf-8
+CHAPTER1 = \
+		tutor1.utf-8 \
+		tutor1.bar \
+		tutor1.ca.utf-8 \
+		tutor1.cs \
+		tutor1.cs.cp1250 \
+		tutor1.da \
+		tutor1.de.utf-8 \
+		tutor1.el \
+		tutor1.el.cp737 \
+		tutor1.eo \
+		tutor1.es \
+		tutor1.fr.utf-8 \
+		tutor1.hr \
+		tutor1.hr.cp1250 \
+		tutor1.hu \
+		tutor1.hu.cp1250 \
+		tutor1.it.utf-8 \
+		tutor1.ja.sjis \
+		tutor1.ja.euc \
+		tutor1.ko \
+		tutor1.ko.euc \
+		tutor1.nl \
+		tutor1.no.utf-8 \
+		tutor1.nb \
+		tutor1.nb.utf-8 \
+		tutor1.pl \
+		tutor1.pl.cp1250 \
+		tutor1.pt \
+		tutor1.ru \
+		tutor1.ru.cp1251 \
+		tutor1.sk \
+		tutor1.sk.cp1250 \
+		tutor1.sr.cp1250 \
+		tutor1.sv.utf-8 \
+		tutor1.tr.iso9 \
+		tutor1.zh.utf-8
+
+CHAPTER2 = \
+		tutor2
+
+CONVERTED = $(CHAPTER1) $(CHAPTER2)
 
 # vim: set noet sw=8 ts=8 sts=0 wm=0 tw=0 ft=make:

--- a/runtime/tutor/Make_mvc.mak
+++ b/runtime/tutor/Make_mvc.mak
@@ -1,7 +1,11 @@
 #
 # Makefile for converting the Vim tutorial on Windows.
 #
-# 21.11.23, Restorer, restorer@mail2k.ru
+# 21.11.24, Restorer, restorer@mail2k.ru
+#
+# Use the UTF-8 version as the original and create the others with conversion.
+# For some translation files of chapter one, conversion from traditional
+# encodings to UTF-8 encoding is performed.
 
 
 !IF [powershell -nologo -noprofile "exit $$psversiontable.psversion.major"] == 2
@@ -27,22 +31,25 @@ ICONV = "$(ICONV_PATH)\iconv.exe"
 
 RM = del /q
 CP = copy /y
+HDLNK = mklink /h
 PS = PowerShell.exe
 
 PSFLAGS = -NoLogo -NoProfile -Command
 
+.SUFFIXES :
+
 all : $(CONVERTED)
 
-tutor.utf-8 : tutor
+tutor1.utf-8 : tutor1
 !IF DEFINED (ICONV)
 	$(ICONV) -f ISO-8859-1 -t UTF-8 $? >$@
 !ELSE
 	$(PS) $(PSFLAGS) [System.IO.File]::ReadAllText(\"$?\", \
 		[System.Text.Encoding]::GetEncoding(28591)) ^| \
-		1>nul New-Item -Force -ItemType file -Path . -Name $@
+		1>nul New-Item -Path . -Name $@ -ItemType file -Force
 !ENDIF
 
-tutor.bar : tutor.bar.utf-8
+tutor2 : tutor2.utf-8
 !IF DEFINED (ICONV)
 	$(ICONV) -f UTF-8 -t ISO-8859-1 $? >$@
 !ELSE
@@ -52,55 +59,134 @@ tutor.bar : tutor.bar.utf-8
 		[System.Text.Encoding]::GetEncoding(28591))
 !ENDIF
 
-tutor.ca.utf-8 : tutor.ca
+tutor1.bar tutor2.bar :
+!IF DEFINED (ICONV)
+	$(ICONV) -f UTF-8 -t ISO-8859-1 $@.utf-8 >$@
+!ELSE
+	$(PS) $(PSFLAGS) [System.IO.File]::WriteAllText(\"$@\", \
+		[System.IO.File]::ReadAllText(\"$@.utf-8\", \
+		[System.Text.Encoding]::GetEncoding(65001)), \
+		[System.Text.Encoding]::GetEncoding(28591))
+!ENDIF
+
+tutor1.ca.utf-8 : tutor1.ca
 !IF DEFINED (ICONV)
 	$(ICONV) -f ISO-8859-1 -t UTF-8 $? >$@
 !ELSE
 	$(PS) $(PSFLAGS) [System.IO.File]::ReadAllText(\"$?\", \
 		[System.Text.Encoding]::GetEncoding(28591)) ^| \
-		1>nul New-Item -Force -ItemType file -Path . -Name $@
+		1>nul New-Item -Path . -Name $@ -ItemType file -Force
 !ENDIF
 
-tutor.de.utf-8 : tutor.de
+tutor2.ca : tutor2.ca.utf-8
 !IF DEFINED (ICONV)
-	$(ICONV) -f ISO-8859-1 -t UTF-8 $? >$@
-!ELSE
-	$(PS) $(PSFLAGS) [System.IO.File]::ReadAllText(\"$?\", \
-		[System.Text.Encoding]::GetEncoding(28591)) ^| \
-		1>nul New-Item -Force -ItemType file -Path . -Name $@
-!ENDIF
-
-tutor.el : tutor.el.utf-8
-!IF DEFINED (ICONV)
-	$(ICONV) -f UTF-8 -t ISO-8859-7 $? >$@
+	$(ICONV) -f UTF-8 -t ISO-8859-1 $? >$@
 !ELSE
 	$(PS) $(PSFLAGS) [System.IO.File]::WriteAllText(\"$@\", \
 		[System.IO.File]::ReadAllText(\"$?\", \
+		[System.Text.Encoding]::GetEncoding(65001)), \
+		[System.Text.Encoding]::GetEncoding(28591))
+!ENDIF
+
+tutor1.cs tutor2.cs :
+!IF DEFINED (ICONV)
+	$(ICONV) -f UTF-8 -t ISO-8859-2 $@.utf-8 >$@
+!ELSE
+	$(PS) $(PSFLAGS) [System.IO.File]::WriteAllText(\"$@\", \
+		[System.IO.File]::ReadAllText(\"$@.utf-8\", \
+		[System.Text.Encoding]::GetEncoding(65001)), \
+		[System.Text.Encoding]::GetEncoding(28592))
+!ENDIF
+
+tutor1.cs.cp1250 tutor2.cs.cp1250 :
+!IF DEFINED (ICONV)
+	$(ICONV) -f UTF-8 -t CP1250 $(@R).utf-8 >$@
+!ELSE
+	$(PS) $(PSFLAGS) [System.IO.File]::WriteAllText(\"$@\", \
+		[System.IO.File]::ReadAllText(\"$(@R).utf-8\", \
+		[System.Text.Encoding]::GetEncoding(65001)), \
+		[System.Text.Encoding]::GetEncoding(1250))
+!ENDIF
+
+tutor1.da tutor2.da :
+!IF DEFINED (ICONV)
+	$(ICONV) -f UTF-8 -t ISO-8859-4 $@.utf-8 >$@
+!ELSE
+	$(PS) $(PSFLAGS) [System.IO.File]::WriteAllText(\"$@\", \
+		[System.IO.File]::ReadAllText(\"$@.utf-8\", \
+		[System.Text.Encoding]::GetEncoding(65001)), \
+		[System.Text.Encoding]::GetEncoding(28594))
+!ENDIF
+
+tutor1.de.utf-8 : tutor1.de
+!IF DEFINED (ICONV)
+	$(ICONV) -f ISO-8859-1 -t UTF-8 $? >$@
+!ELSE
+	$(PS) $(PSFLAGS) [System.IO.File]::ReadAllText(\"$?\", \
+		[System.Text.Encoding]::GetEncoding(28591)) ^| \
+		1>nul New-Item -Path . -Name $@ -ItemType file -Force
+!ENDIF
+
+tutor2.de : tutor2.de.utf-8
+!IF DEFINED (ICONV)
+	$(ICONV) -f UTF-8 -t ISO-8859-1 $? >$@
+!ELSE
+	$(PS) $(PSFLAGS) [System.IO.File]::WriteAllText(\"$@\", \
+		[System.IO.File]::ReadAllText(\"$?\", \
+		[System.Text.Encoding]::GetEncoding(65001)), \
+		[System.Text.Encoding]::GetEncoding(28591))
+!ENDIF
+
+tutor1.el tutor2.el :
+!IF DEFINED (ICONV)
+	$(ICONV) -f UTF-8 -t ISO-8859-7 $@.utf-8 >$@
+!ELSE
+	$(PS) $(PSFLAGS) [System.IO.File]::WriteAllText(\"$@\", \
+		[System.IO.File]::ReadAllText(\"$@.utf-8\", \
 		[System.Text.Encoding]::GetEncoding(65001)), \
 		[System.Text.Encoding]::GetEncoding(28597))
 !ENDIF
 
-tutor.el.cp737 : tutor.el.utf-8
+tutor1.el.cp737 tutor2.el.cp737 :
 !IF DEFINED (ICONV)
-	$(ICONV) -f UTF-8 -t CP737 $? >$@
+	$(ICONV) -f UTF-8 -t CP737 $(@R).utf-8 >$@
 !ELSE
 	$(PS) $(PSFLAGS) [System.IO.File]::WriteAllText(\"$@\", \
-		[System.IO.File]::ReadAllText(\"$?\", \
+		[System.IO.File]::ReadAllText(\"$(@R).utf-8\", \
 		[System.Text.Encoding]::GetEncoding(65001)), \
 		[System.Text.Encoding]::GetEncoding(737))
 !ENDIF
 
-tutor.eo : tutor.eo.utf-8
+tutor1.eo tutor2.eo :
 !IF DEFINED (ICONV)
-	$(ICONV) -f UTF-8 -t ISO-8859-3 $? >$@
+	$(ICONV) -f UTF-8 -t ISO-8859-3 $@.utf-8 >$@
 !ELSE
 	$(PS) $(PSFLAGS) [System.IO.File]::WriteAllText(\"$@\", \
-		[System.IO.File]::ReadAllText(\"$?\", \
+		[System.IO.File]::ReadAllText(\"$@.utf-8\", \
 		[System.Text.Encoding]::GetEncoding(65001)), \
 		[System.Text.Encoding]::GetEncoding(28593))
 !ENDIF
 
-tutor.es : tutor.es.utf-8
+tutor1.es tutor2.es :
+!IF DEFINED (ICONV)
+	$(ICONV) -f UTF-8 -t ISO-8859-1 $@.utf-8 >$@
+!ELSE
+	$(PS) $(PSFLAGS) [System.IO.File]::WriteAllText(\"$@\", \
+		[System.IO.File]::ReadAllText(\"$@.utf-8\", \
+		[System.Text.Encoding]::GetEncoding(65001)), \
+		[System.Text.Encoding]::GetEncoding(28591))
+!ENDIF
+
+tutor1.fr.utf-8 : tutor1.fr
+!IF DEFINED (ICONV)
+	$(ICONV) -f ISO-8859-1 -t UTF-8 $? >$@
+!ELSE
+	$(PS) $(PSFLAGS) [System.IO.File]::ReadAllText(\"$?\", \
+		[System.Text.Encoding]::GetEncoding(28591)) ^| \
+		1>nul New-Item -Path . -Name $@ -ItemType file -Force
+!ENDIF
+
+tutor2.fr : tutor2.fr.utf-8
 !IF DEFINED (ICONV)
 	$(ICONV) -f UTF-8 -t ISO-8859-1 $? >$@
 !ELSE
@@ -110,95 +196,118 @@ tutor.es : tutor.es.utf-8
 		[System.Text.Encoding]::GetEncoding(28591))
 !ENDIF
 
-tutor.fr.utf-8 : tutor.fr
+tutor1.hr tutor2.hr :
+!IF DEFINED (ICONV)
+	$(ICONV) -f UTF-8 -t ISO-8859-2 $@.utf-8 >$@
+!ELSE
+	$(PS) $(PSFLAGS) [System.IO.File]::WriteAllText(\"$@\", \
+		[System.IO.File]::ReadAllText(\"$@.utf-8\", \
+		[System.Text.Encoding]::GetEncoding(65001)), \
+		[System.Text.Encoding]::GetEncoding(28592))
+!ENDIF
+
+tutor1.hr.cp1250 tutor2.hr.cp1250 :
+!IF DEFINED (ICONV)
+	$(ICONV) -f UTF-8 -t CP1250 $(@R).utf-8 >$@
+!ELSE
+	$(PS) $(PSFLAGS) [System.IO.File]::WriteAllText(\"$@\", \
+		[System.IO.File]::ReadAllText(\"$(@R).utf-8\", \
+		[System.Text.Encoding]::GetEncoding(65001)), \
+		[System.Text.Encoding]::GetEncoding(1250))
+!ENDIF
+
+tutor1.hu tutor2.hu :
+!IF DEFINED (ICONV)
+	$(ICONV) -f UTF-8 -t ISO-8859-2 $@.utf-8 >$@
+!ELSE
+	$(PS) $(PSFLAGS) [System.IO.File]::WriteAllText(\"$@\", \
+		[System.IO.File]::ReadAllText(\"$@.utf-8\", \
+		[System.Text.Encoding]::GetEncoding(65001)), \
+		[System.Text.Encoding]::GetEncoding(28592))
+!ENDIF
+
+tutor1.hu.cp1250 tutor2.hu.cp1250 :
+!IF DEFINED (ICONV)
+	$(ICONV) -f UTF-8 -t CP1250 $(@R).utf-8 >$@
+!ELSE
+	$(PS) $(PSFLAGS) [System.IO.File]::WriteAllText(\"$@\", \
+		[System.IO.File]::ReadAllText(\"$(@R).utf-8\", \
+		[System.Text.Encoding]::GetEncoding(65001)), \
+		[System.Text.Encoding]::GetEncoding(1250))
+!ENDIF
+
+tutor1.it.utf-8 : tutor1.it
 !IF DEFINED (ICONV)
 	$(ICONV) -f ISO-8859-1 -t UTF-8 $? >$@
 !ELSE
 	$(PS) $(PSFLAGS) [System.IO.File]::ReadAllText(\"$?\", \
 		[System.Text.Encoding]::GetEncoding(28591)) ^| \
-		1>nul New-Item -Force -ItemType file -Path . -Name $@
+		1>nul New-Item -Path . -Name $@ -ItemType file -Force
 !ENDIF
 
-tutor.hr : tutor.hr.utf-8
+tutor2.it : tutor2.it.utf-8
 !IF DEFINED (ICONV)
-	$(ICONV) -f UTF-8 -t ISO-8859-2 $? >$@
+	$(ICONV) -f UTF-8 -t ISO-8859-1 $? >$@
 !ELSE
 	$(PS) $(PSFLAGS) [System.IO.File]::WriteAllText(\"$@\", \
 		[System.IO.File]::ReadAllText(\"$?\", \
 		[System.Text.Encoding]::GetEncoding(65001)), \
-		[System.Text.Encoding]::GetEncoding(28592))
+		[System.Text.Encoding]::GetEncoding(28591))
 !ENDIF
 
-tutor.hr.cp1250 : tutor.hr.utf-8
+tutor1.ja.sjis tutor2.ja.sjis :
 !IF DEFINED (ICONV)
-	$(ICONV) -f UTF-8 -t CP1250 $? >$@
+	$(ICONV) -f UTF-8 -t CP932 $(@R).utf-8 >$@
 !ELSE
 	$(PS) $(PSFLAGS) [System.IO.File]::WriteAllText(\"$@\", \
-		[System.IO.File]::ReadAllText(\"$?\", \
-		[System.Text.Encoding]::GetEncoding(65001)), \
-		[System.Text.Encoding]::GetEncoding(1250))
-!ENDIF
-
-tutor.hu : tutor.hu.utf-8
-!IF DEFINED (ICONV)
-	$(ICONV) -f UTF-8 -t ISO-8859-2 $? >$@
-!ELSE
-	$(PS) $(PSFLAGS) [System.IO.File]::WriteAllText(\"$@\", \
-		[System.IO.File]::ReadAllText(\"$?\", \
-		[System.Text.Encoding]::GetEncoding(65001)), \
-		[System.Text.Encoding]::GetEncoding(28592))
-!ENDIF
-
-tutor.hu.cp1250 : tutor.hu.utf-8
-!IF DEFINED (ICONV)
-	$(ICONV) -f UTF-8 -t CP1250 $? >$@
-!ELSE
-	$(PS) $(PSFLAGS) [System.IO.File]::WriteAllText(\"$@\", \
-		[System.IO.File]::ReadAllText(\"$?\", \
-		[System.Text.Encoding]::GetEncoding(65001)), \
-		[System.Text.Encoding]::GetEncoding(1250))
-!ENDIF
-
-tutor.it.utf-8 : tutor.it
-!IF DEFINED (ICONV)
-	$(ICONV) -f ISO-8859-1 -t UTF-8 $? >$@
-!ELSE
-	$(PS) $(PSFLAGS) [System.IO.File]::ReadAllText(\"$?\", \
-		[System.Text.Encoding]::GetEncoding(28591)) ^| \
-		1>nul New-Item -Force -ItemType file -Path . -Name $@
-!ENDIF
-
-tutor.ja.sjis : tutor.ja.utf-8
-!IF DEFINED (ICONV)
-	$(ICONV) -f UTF-8 -t CP932 $? >$@
-!ELSE
-	$(PS) $(PSFLAGS) [System.IO.File]::WriteAllText(\"$@\", \
-		[System.IO.File]::ReadAllText(\"$?\", \
+		[System.IO.File]::ReadAllText(\"$(@R).utf-8\", \
 		[System.Text.Encoding]::GetEncoding(65001)), \
 		[System.Text.Encoding]::GetEncoding(932))
 !ENDIF
 
-tutor.ja.euc : tutor.ja.utf-8
+tutor1.ja.euc tutor2.ja.euc :
 !IF DEFINED (ICONV)
-	$(ICONV) -f UTF-8 -t EUC-JP $? >$@
+	$(ICONV) -f UTF-8 -t EUC-JP $(@R).utf-8 >$@
 !ELSE
 	$(PS) $(PSFLAGS) [System.IO.File]::WriteAllText(\"$@\", \
-		[System.IO.File]::ReadAllText(\"$?\", \
+		[System.IO.File]::ReadAllText(\"$(@R).utf-8\", \
 		[System.Text.Encoding]::GetEncoding(65001)), \
 		[System.Text.Encoding]::GetEncoding(51932))
 !ENDIF
 
-tutor.ko.euc : tutor.ko.utf-8
+tutor1.ko tutor2.ko :
+	$(HDLNK) $@ $@.utf-8
+
+tutor1.ko.euc tutor2.ko.euc :
 !IF DEFINED (ICONV)
-	$(ICONV) -f UTF-8 -t EUC-KR $? >$@
+	$(ICONV) -f UTF-8 -t EUC-KR $(@R).utf-8 >$@
 !ELSE
 	$(PS) $(PSFLAGS) [System.IO.File]::WriteAllText(\"$@\", \
-		[System.IO.File]::ReadAllText(\"$?\", \
+		[System.IO.File]::ReadAllText(\"$(@R).utf-8\", \
 		[System.Text.Encoding]::GetEncoding(65001)), \
 		[System.Text.Encoding]::GetEncoding(51949))
 !ENDIF
 
-tutor.nl : tutor.nl.utf-8
+tutor1.nl tutor2.nl :
+!IF DEFINED (ICONV)
+	$(ICONV) -f UTF-8 -t ISO-8859-1 $@.utf-8 >$@
+!ELSE
+	$(PS) $(PSFLAGS) [System.IO.File]::WriteAllText(\"$@\", \
+		[System.IO.File]::ReadAllText(\"$@.utf-8\", \
+		[System.Text.Encoding]::GetEncoding(65001)), \
+		[System.Text.Encoding]::GetEncoding(28591))
+!ENDIF
+
+tutor1.no.utf-8 : tutor1.no
+!IF DEFINED (ICONV)
+	$(ICONV) -f ISO-8859-1 -t UTF-8 $? >$@
+!ELSE
+	$(PS) $(PSFLAGS) [System.IO.File]::ReadAllText(\"$?\", \
+		[System.Text.Encoding]::GetEncoding(28591)) ^| \
+		1>nul New-Item -Path . -Name $@ -ItemType file -Force
+!ENDIF
+
+tutor2.no : tutor2.no.utf-8
 !IF DEFINED (ICONV)
 	$(ICONV) -f UTF-8 -t ISO-8859-1 $? >$@
 !ELSE
@@ -208,67 +317,134 @@ tutor.nl : tutor.nl.utf-8
 		[System.Text.Encoding]::GetEncoding(28591))
 !ENDIF
 
-tutor.no.utf-8 : tutor.no
-!IF DEFINED (ICONV)
-	$(ICONV) -f ISO-8859-1 -t UTF-8 $? >$@
-!ELSE
-	$(PS) $(PSFLAGS) [System.IO.File]::ReadAllText(\"$?\", \
-		[System.Text.Encoding]::GetEncoding(28591)) ^| \
-		1>nul New-Item -Force -ItemType file -Path . -Name $@
-!ENDIF
-
 # nb is an alias for no
-tutor.nb : tutor.no
-	$(CP) tutor.no tutor.nb
+tutor1.nb tutor2.nb : $$(@R).no
+	$(HDLNK) $@ $?
 
-tutor.nb.utf-8 : tutor.no.utf-8
-	$(CP) tutor.no.utf-8 tutor.nb.utf-8
+tutor1.nb.utf-8 tutor2.nb.utf-8 : $$(@R)
+	$(HDLNK) $@ %|dpfF.no.utf-8
 
-tutor.ru : tutor.ru.utf-8
+tutor1.pl tutor2.pl :
 !IF DEFINED (ICONV)
-	$(ICONV) -f UTF-8 -t KOI8-R $? >$@
+	$(ICONV) -f UTF-8 -t ISO-8859-2 $@.utf-8 >$@
 !ELSE
 	$(PS) $(PSFLAGS) [System.IO.File]::WriteAllText(\"$@\", \
-		[System.IO.File]::ReadAllText(\"$?\", \
+		[System.IO.File]::ReadAllText(\"$@.utf-8\", \
+		[System.Text.Encoding]::GetEncoding(65001)), \
+		[System.Text.Encoding]::GetEncoding(28592))
+!ENDIF
+
+tutor1.pl.cp1250 tutor2.pl.cp1250 :
+!IF DEFINED (ICONV)
+	$(ICONV) -f UTF-8 -t CP1250 $(@R).utf-8 >$@
+!ELSE
+	$(PS) $(PSFLAGS) [System.IO.File]::WriteAllText(\"$@\", \
+		[System.IO.File]::ReadAllText(\"$(@R).utf-8\", \
+		[System.Text.Encoding]::GetEncoding(65001)), \
+		[System.Text.Encoding]::GetEncoding(1252))
+!ENDIF
+
+tutor1.pt tutor2.pt :
+!IF DEFINED (ICONV)
+	$(ICONV) -f UTF-8 -t ISO-8859-15 $@.utf-8 >$@
+!ELSE
+	$(PS) $(PSFLAGS) [System.IO.File]::WriteAllText(\"$@\", \
+		[System.IO.File]::ReadAllText(\"$@.utf-8\", \
+		[System.Text.Encoding]::GetEncoding(65001)), \
+		[System.Text.Encoding]::GetEncoding(28605))
+!ENDIF
+
+tutor1.ru tutor2.ru :
+!IF DEFINED (ICONV)
+	$(ICONV) -f UTF-8 -t KOI8-R $@.utf-8 >$@
+!ELSE
+	$(PS) $(PSFLAGS) [System.IO.File]::WriteAllText(\"$@\", \
+		[System.IO.File]::ReadAllText(\"$@.utf-8\", \
 		[System.Text.Encoding]::GetEncoding(65001)), \
 		[System.Text.Encoding]::GetEncoding(20866))
 !ENDIF
 
-tutor.ru.cp1251 : tutor.ru.utf-8
+tutor1.ru.cp1251 tutor2.ru.cp1251 :
 !IF DEFINED (ICONV)
-	$(ICONV) -f UTF-8 -t CP1251 $? >$@
+	$(ICONV) -f UTF-8 -t CP1251 $(@R).utf-8 >$@
 !ELSE
 	$(PS) $(PSFLAGS) [System.IO.File]::WriteAllText(\"$@\", \
-		[System.IO.File]::ReadAllText(\"$?\", \
+		[System.IO.File]::ReadAllText(\"$(@R).utf-8\", \
 		[System.Text.Encoding]::GetEncoding(65001)), \
 		[System.Text.Encoding]::GetEncoding(1251))
 !ENDIF
 
-tutor.sv.utf-8 : tutor.sv
+tutor1.sk tutor2.sk :
 !IF DEFINED (ICONV)
-	$(ICONV) -f ISO-8859-1 -t UTF-8 $? >$@
+	$(ICONV) -f UTF-8 -t ISO-8859-2 $@.utf-8 >$@
 !ELSE
-	$(PS) $(PSFLAGS) [System.IO.File]::ReadAllText(\"$?\", \
-		[System.Text.Encoding]::GetEncoding(28591)) ^| \
-		1>nul New-Item -Force -ItemType file -Path . -Name $@
+	$(PS) $(PSFLAGS) [System.IO.File]::WriteAllText(\"$@\", \
+		[System.IO.File]::ReadAllText(\"$@.utf-8\", \
+		[System.Text.Encoding]::GetEncoding(65001)), \
+		[System.Text.Encoding]::GetEncoding(28592))
 !ENDIF
 
-tutor.tr.iso9 : tutor.tr.utf-8
+tutor1.sk.cp1250 tutor2.sk.cp1250 :
 !IF DEFINED (ICONV)
-	$(ICONV) -f UTF-8 -t ISO-8859-9 $? >$@
+	$(ICONV) -f UTF-8 -t CP1250 $(@R).utf-8 >$@
+!ELSE
+	$(PS) $(PSFLAGS) [System.IO.File]::WriteAllText(\"$@\", \
+		[System.IO.File]::ReadAllText(\"$(@R).utf-8\", \
+		[System.Text.Encoding]::GetEncoding(65001)), \
+		[System.Text.Encoding]::GetEncoding(1252))
+!ENDIF
+
+tutor1.sr.cp1250 tutor2.sr.cp1250 :
+!IF DEFINED (ICONV)
+	$(ICONV) -f UTF-8 -t CP1250 $(@R).utf-8 >$@
+!ELSE
+	$(PS) $(PSFLAGS) [System.IO.File]::WriteAllText(\"$@\", \
+		[System.IO.File]::ReadAllText(\"$(@R).utf-8\", \
+		[System.Text.Encoding]::GetEncoding(65001)), \
+		[System.Text.Encoding]::GetEncoding(1252))
+!ENDIF
+
+tutor1.sv.utf-8 : tutor1.sv
+!IF DEFINED (ICONV)
+	$(ICONV) -f ISO-8859-15 -t UTF-8 $? >$@
+!ELSE
+	$(PS) $(PSFLAGS) [System.IO.File]::ReadAllText(\"$?\", \
+		[System.Text.Encoding]::GetEncoding(28605)) ^| \
+		1>nul New-Item -Path . -Name $@ -ItemType file -Force
+!ENDIF
+
+tutor2.sv : tutor2.sv.utf-8
+!IF DEFINED (ICONV)
+	$(ICONV) -f UTF-8 -t ISO-8859-15 $? >$@
 !ELSE
 	$(PS) $(PSFLAGS) [System.IO.File]::WriteAllText(\"$@\", \
 		[System.IO.File]::ReadAllText(\"$?\", \
 		[System.Text.Encoding]::GetEncoding(65001)), \
+		[System.Text.Encoding]::GetEncoding(28605))
+!ENDIF
+
+tutor1.tr.iso9 tutor2.tr.iso9 :
+!IF DEFINED (ICONV)
+	$(ICONV) -f UTF-8 -t ISO-8859-9 $*.utf-8 >$@
+!ELSE
+	$(PS) $(PSFLAGS) [System.IO.File]::WriteAllText(\"$@\", \
+		[System.IO.File]::ReadAllText(\"$*.utf-8\", \
+		[System.Text.Encoding]::GetEncoding(65001)), \
 		[System.Text.Encoding]::GetEncoding(28599))
 !ENDIF
 
-tutor.zh.utf-8 : tutor.zh.big5
+tutor1.zh.utf-8 : tutor1.zh.big5
 	$(PS) $(PSFLAGS) [System.IO.File]::ReadAllText(\"$?\", \
 		[System.Text.Encoding]::GetEncoding(950)) ^| \
-		1>nul New-Item -Force -ItemType file -Path . -Name $@
+		1>nul New-Item -Path . -Name $@ -ItemType file -Force
+
+tutor2.zh.big5 : tutor2.zh.utf-8
+	$(PS) $(PSFLAGS) [System.IO.File]::WriteAllText(\"$@\", \
+		[System.IO.File]::ReadAllText(\"$?\", \
+		[System.Text.Encoding]::GetEncoding(65001)), \
+		[System.Text.Encoding]::GetEncoding(950))
 
 clean :
-	@for %%G in ($(CONVERTED)) do (if exist .\%%G ($(RM) %%G))
+	@for %%G in ($(CONVERTED)) do (if exist .\%%G $(RM) .\%%G)
 
 # vim: set noet sw=8 ts=8 sts=0 wm=0 tw=0 ft=make:

--- a/runtime/tutor/Makefile
+++ b/runtime/tutor/Makefile
@@ -1,95 +1,150 @@
 # Makefile for the Vim tutor.
 #
-# The Japanese tutor exists in three encodings.  Use the UTF-8 version as the
-# original and create the others with conversion.
-#
-# Similarly for Russian and Korean
+# Use the UTF-8 version as the original and create the others with conversion.
+# For some translation files of chapter one, conversion from traditional
+# encodings to UTF-8 encoding is performed.
 
 # Common components
 include Make_all.mak
 
 .PHONY: all clean
 
+.SUFFIXES:
+
 all: $(CONVERTED)
 
-tutor.utf-8: tutor
+tutor1.utf-8: tutor1
 	iconv -f ISO-8859-1 -t UTF-8 $? >$@
 
-tutor.bar: tutor.bar.utf-8
+tutor2: tutor2.utf-8
 	iconv -f UTF-8 -t ISO-8859-1 $? >$@
 
-tutor.ca.utf-8: tutor.ca
+tutor1.bar tutor2.bar:
+	iconv -f UTF-8 -t ISO-8859-1 $@.utf-8 >$@
+
+tutor1.ca.utf-8: tutor1.ca
 	iconv -f ISO-8859-1 -t UTF-8 $? >$@
 
-tutor.eo: tutor.eo.utf-8
-	iconv -f UTF-8 -t ISO-8859-3 $? >$@
-
-tutor.de.utf-8: tutor.de
-	iconv -f ISO-8859-1 -t UTF-8 $? >$@
-
-tutor.el: tutor.el.utf-8
-	iconv -f UTF-8 -t ISO-8859-7 $? >$@
-
-tutor.el.cp737: tutor.el.utf-8
-	iconv -f UTF-8 -t CP737 $? >$@
-
-tutor.es: tutor.es.utf-8
+tutor2.ca: tutor2.ca.utf-8
 	iconv -f UTF-8 -t ISO-8859-1 $? >$@
 
-tutor.fr.utf-8: tutor.fr
+tutor1.cs tutor2.cs :
+	iconv -f UTF-8 -t ISO-8859-2 $@.utf-8 >$@
+
+tutor1.cs.cp1250 tutor2.cs.cp1250 :
+	iconv -f UTF-8 -t CP1250 $(@:.cp1250=).utf-8 >$@
+
+tutor1.da tutor2.da :
+	iconv -f UTF-8 -t ISO-8859-4 $@.utf-8 >$@
+
+tutor1.de.utf-8: tutor1.de
 	iconv -f ISO-8859-1 -t UTF-8 $? >$@
 
-tutor.hu: tutor.hu.utf-8
-	iconv -f UTF-8 -t ISO-8859-2 $? >$@
-
-tutor.hu.cp1250: tutor.hu.utf-8
-	iconv -f UTF-8 -t CP1250 $? >$@
-
-tutor.it.utf-8: tutor.it
-	iconv -f ISO-8859-1 -t UTF-8 $? >$@
-
-tutor.hr: tutor.hr.utf-8
-	iconv -f UTF-8 -t ISO-8859-2 $? >$@
-
-tutor.hr.cp1250: tutor.hr.utf-8
-	iconv -f UTF-8 -t CP1250 $? >$@
-
-tutor.ja.sjis: tutor.ja.utf-8
-	iconv -f UTF-8 -t CP932 $? >$@
-
-tutor.ja.euc: tutor.ja.utf-8
-	iconv -f UTF-8 -t EUC-JP $? >$@
-
-tutor.ko.euc: tutor.ko.utf-8
-	iconv -f UTF-8 -t EUC-KR $? >$@
-
-tutor.nl: tutor.nl.utf-8
+tutor2.de: tutor2.de.utf-8
 	iconv -f UTF-8 -t ISO-8859-1 $? >$@
 
-tutor.no.utf-8: tutor.no
+tutor1.el tutor2.el:
+	iconv -f UTF-8 -t ISO-8859-7 $@.utf-8 >$@
+
+tutor1.el.cp737 tutor2.el.cp737:
+	iconv -f UTF-8 -t CP737 $(@:.cp737=.utf-8) >$@
+
+tutor1.eo tutor2.eo:
+	iconv -f UTF-8 -t ISO-8859-3 $@.utf-8 >$@
+
+tutor1.es tutor2.es:
+	iconv -f UTF-8 -t ISO-8859-1 $@.utf-8 >$@
+
+tutor1.fr.utf-8: tutor1.fr
 	iconv -f ISO-8859-1 -t UTF-8 $? >$@
+
+tutor2.fr: tutor2.fr.utf-8
+	iconv -f UTF-8 -t ISO-8859-1 $? >$@
+
+tutor1.hr tutor2.hr:
+	iconv -f UTF-8 -t ISO-8859-2 $@.utf-8 >$@
+
+tutor1.hr.cp1250 tutor2.hr.cp1250:
+	iconv -f UTF-8 -t CP1250 $(@:.cp1250=.utf-8) >$@
+
+tutor1.hu tutor2.hu:
+	iconv -f UTF-8 -t ISO-8859-2 $@.utf-8 >$@
+
+tutor1.hu.cp1250 tutor2.hu.cp1250:
+	iconv -f UTF-8 -t CP1250 $(@:.cp1250=.utf-8) >$@
+
+tutor1.it.utf-8: tutor1.it
+	iconv -f ISO-8859-1 -t UTF-8 $? >$@
+
+tutor2.it: tutor2.it.utf-8
+	iconv -f UTF-8 -t ISO-8859-1 $? >$@
+
+tutor1.ja.sjis tutor2.ja.sjis:
+	iconv -f UTF-8 -t CP932 $(@:.sjis=.utf-8) >$@
+
+tutor1.ja.euc tutor2.ja.euc:
+	iconv -f UTF-8 -t EUC-JP $(@:.euc=.utf-8) >$@
+
+tutor1.ko tutor2.ko:
+	ln $@.utf-8 $@
+
+tutor1.ko.euc tutor2.ko.euc:
+	iconv -f UTF-8 -t EUC-KR $(@:.euc=.utf-8) >$@
+
+tutor1.nl tutor2.nl:
+	iconv -f UTF-8 -t ISO-8859-1 $@.utf-8 >$@
+
+tutor1.no.utf-8: tutor1.no
+	iconv -f ISO-8859-1 -t UTF-8 $? >$@
+
+tutor2.no: tutor2.no.utf-8
+	iconv -f UTF-8 -t ISO-8859-1 $? >$@
 
 # nb is an alias for no
-tutor.nb: tutor.no
-	cp $? $@
+tutor1.nb tutor2.nb:
+	ln $(@:.nb=.no) $@
 
-tutor.nb.utf-8: tutor.no.utf-8
-	cp $? $@
+tutor1.nb.utf-8 tutor2.nb.utf-8:
+	ln $(@:.nb.utf-8=.no.utf-8) $@
 
-tutor.ru: tutor.ru.utf-8
-	iconv -f UTF-8 -t KOI8-R $? >$@
+tutor1.pl tutor2.pl :
+	iconv -f UTF-8 -t ISO-8859-2 $@.utf-8 >$@
 
-tutor.ru.cp1251: tutor.ru.utf-8
-	iconv -f UTF-8 -t CP1251 $? >$@
+tutor1.pl.cp1250 tutor2.pl.cp1250 :
+	iconv -f UTF-8 -t CP1250 $(@:.cp1250=).utf-8 >$@
 
-tutor.tr.iso9: tutor.tr.utf-8
-	iconv -f UTF-8 -t ISO-8859-9 $? >$@
+tutor1.pt tutor2.pt :
+	iconv -f UTF-8 -t ISO-8859-15 $@.utf-8 >$@
 
-tutor.sv.utf-8: tutor.sv
-	iconv -f ISO-8859-1 -t UTF-8 $? >$@
+tutor1.ru tutor2.ru:
+	iconv -f UTF-8 -t KOI8-R $@.utf-8 >$@
 
-tutor.zh.utf-8: tutor.zh.big5
-	iconv -f BIG-5 -t UTF-8 $? >$@
+tutor1.ru.cp1251 tutor2.ru.cp1251:
+	iconv -f UTF-8 -t CP1251 $(@:.cp1251=.utf-8) >$@
+
+tutor1.sk tutor2.sk :
+	iconv -f UTF-8 -t ISO-8859-2 $@.utf-8 >$@
+
+tutor1.sk.cp1250 tutor2.sk.cp1250 :
+	iconv -f UTF-8 -t CP1250 $(@:.cp1250=).utf-8 >$@
+
+tutor1.sr.cp1250 tutor2.sr.cp1250 :
+	iconv -f UTF-8 -t CP1250 $(@:.cp1250=).utf-8 >$@
+
+tutor1.sv.utf-8: tutor1.sv
+	iconv -f ISO-8859-15 -t UTF-8 $? >$@
+
+tutor2.sv: tutor2.sv.utf-8
+	iconv -f UTF-8 -t ISO-8859-15 $? >$@
+
+tutor1.tr.iso9 tutor2.tr.iso9:
+	iconv -f UTF-8 -t ISO-8859-9 $(@:.iso9=.utf-8) >$@
+
+tutor1.zh.utf-8: tutor1.zh.big5
+	iconv -f BIG-5 -t UTF-8 -c $? >$@
+
+tutor2.zh.big5: tutor2.zh.utf-8
+	iconv -f UTF-8 -t BIG-5 -c $? >$@
 
 clean:
-	for G in $(CONVERTED); do if [ -f $$G ]; then rm -f $$G; fi; done
+	for G in $(CONVERTED); do if [ -f ./$$G ]; then rm -f ./$$G; fi; done;


### PR DESCRIPTION
The following is done to convert the text encoding of the text of the tutorial files:
- CHAPTER1 and CHAPTER2 variables were added to the file Make_all.mak;
- Mekefile and Make_mvc.mak files were changed to handle tutor1 and tutor2 files.

related to https://github.com/vim/vim/pull/16110