### PR TITLE
fix(eval): add leftcol in getwininfo

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -5086,6 +5086,8 @@ getwininfo([{winid}])					*getwininfo()*
 			botline		last complete displayed buffer line
 			bufnr		number of buffer in the window
 			height		window height (excluding winbar)
+			leftcol		first column displayed; only used when
+					'wrap' is off
 			loclist		1 if showing a location list
 					{only with the +quickfix feature}
 			quickfix	1 if quickfix or location list window

--- a/src/evalwindow.c
+++ b/src/evalwindow.c
@@ -426,6 +426,7 @@ get_win_info(win_T *wp, short tpnr, short winnr)
     dict_add_number(dict, "wincol", wp->w_wincol + 1);
     dict_add_number(dict, "textoff", win_col_off(wp));
     dict_add_number(dict, "bufnr", wp->w_buffer->b_fnum);
+    dict_add_number(dict, "leftcol", wp->w_leftcol);
 
 #ifdef FEAT_TERMINAL
     dict_add_number(dict, "terminal", bt_terminal(wp->w_buffer));

--- a/src/testdir/test_bufwintabinfo.vim
+++ b/src/testdir/test_bufwintabinfo.vim
@@ -115,6 +115,18 @@ func Test_getbufwintabinfo()
   wincmd t | only
 endfunc
 
+function Test_get_wininfo_leftcol()
+  set nowrap
+  set winwidth=10
+  vsp
+  call setline(1, ['abcdefghijklmnopqrstuvwxyz'])
+  norm! 5zl
+  call assert_equal(5, getwininfo()[0].leftcol)
+  bwipe!
+  set wrap&
+  set winwidth&
+endfunc
+
 function Test_get_buf_options()
   let opts = bufnr()->getbufvar('&')
   call assert_equal(v:t_dict, type(opts))


### PR DESCRIPTION
Problem: currently no way get leftcol of a special window

Solution: add leftcol in getwininfo eval function