### PR TITLE
The maximum value of 'cmdheight' is limited by other tabpages.

### DIFF
--- a/src/option.c
+++ b/src/option.c
@@ -4859,15 +4859,15 @@ check_num_option_bounds(
     size_t	errbuflen,
     char	*errmsg)
 {
-    if (Rows < min_rows() && full_screen)
+    if (Rows < min_rows_for_all_tabpages() && full_screen)
     {
 	if (errbuf != NULL)
 	{
 	    vim_snprintf(errbuf, errbuflen,
-		    _(e_need_at_least_nr_lines), min_rows());
+		    _(e_need_at_least_nr_lines), min_rows_for_all_tabpages());
 	    errmsg = errbuf;
 	}
-	Rows = min_rows();
+	Rows = min_rows_for_all_tabpages();
     }
     if (Columns < MIN_COLUMNS && full_screen)
     {

--- a/src/option.c
+++ b/src/option.c
@@ -3417,13 +3417,13 @@ did_set_cmdheight(optset_T *args)
     char *errmsg = NULL;
 
     // if p_ch changed value, change the command line height
-    if (p_ch < 1)
+    if (p_ch < MIN_CMDHEIGHT)
     {
 	errmsg = e_argument_must_be_positive;
-	p_ch = 1;
+	p_ch = MIN_CMDHEIGHT;
     }
-    if (p_ch > Rows - min_rows() + 1)
-	p_ch = Rows - min_rows() + 1;
+    if (p_ch > Rows - min_rows() + MIN_CMDHEIGHT)
+	p_ch = Rows - min_rows() + MIN_CMDHEIGHT;
 
     // Only compute the new window layout when startup has been
     // completed. Otherwise the frame sizes may be wrong.

--- a/src/proto/window.pro
+++ b/src/proto/window.pro
@@ -89,6 +89,7 @@ void last_status(int morewin);
 int tabline_height(void);
 int last_stl_height(int morewin);
 int min_rows(void);
+int min_rows_for_all_tabpages(void);
 int only_one_window(void);
 void check_lnums(int do_curwin);
 void check_lnums_nested(int do_curwin);

--- a/src/term.c
+++ b/src/term.c
@@ -3564,8 +3564,9 @@ get_bytes_from_buf(char_u *buf, char_u *bytes, int num_bytes)
     void
 check_shellsize(void)
 {
-    if (Rows < min_rows())	// need room for one window and command line
-	Rows = min_rows();
+    // need room for one window and command line
+    if (Rows < min_rows_for_all_tabpages())
+	Rows = min_rows_for_all_tabpages();
     limit_screen_size();
 
     // make sure these values are not invalid

--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -2294,12 +2294,12 @@ func Test_opt_cmdheight()
   %bw!
   set cmdheight& winminheight& winheight&
 
-  " The 'winminheight' in oher tabpages should be taken into account.
+  " Only the windows in the current tabpage are taken into account.
   set winheight=3 winminheight=3 showtabline=0
   split
   tabnew
   set cmdheight=9999
-  call assert_equal(ht - 8, &cmdheight)
+  call assert_equal(ht - 3, &cmdheight)
   %bw!
   set cmdheight& winminheight& winheight& showtabline&
 endfunc

--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -2262,13 +2262,46 @@ func Test_opt_default()
 endfunc
 
 " Test for the 'cmdheight' option
-func Test_cmdheight()
+func Test_opt_cmdheight()
   %bw!
   let ht = &lines
   set cmdheight=9999
   call assert_equal(1, winheight(0))
   call assert_equal(ht - 1, &cmdheight)
   set cmdheight&
+
+  " The status line should be taken into account.
+  set laststatus=2
+  set cmdheight=9999
+  call assert_equal(ht - 2, &cmdheight)
+  set cmdheight& laststatus&
+
+  " The tabline should be taken into account only non-GUI.
+  set showtabline=2
+  set cmdheight=9999
+  if has('gui_running')
+    call assert_equal(ht - 1, &cmdheight)
+  else
+    call assert_equal(ht - 2, &cmdheight)
+  endif
+  set cmdheight& showtabline&
+
+  " The 'winminheight' should be taken into account.
+  set winheight=3 winminheight=3
+  split
+  set cmdheight=9999
+  call assert_equal(ht - 8, &cmdheight)
+  %bw!
+  set cmdheight& winminheight& winheight&
+
+  " The 'winminheight' in oher tabpages should be taken into account.
+  set winheight=3 winminheight=3 showtabline=0
+  split
+  tabnew
+  set cmdheight=9999
+  call assert_equal(ht - 8, &cmdheight)
+  %bw!
+  set cmdheight& winminheight& winheight& showtabline&
 endfunc
 
 " To specify a control character as an option value, '^' can be used

--- a/src/testdir/test_window_cmd.vim
+++ b/src/testdir/test_window_cmd.vim
@@ -68,7 +68,7 @@ func Test_cmdheight_not_changed()
 
   tabonly!
   only
-  set winminwidth& cmdheight&
+  set winminheight& cmdheight&
   augroup Maximize
     au!
   augroup END

--- a/src/vim.h
+++ b/src/vim.h
@@ -1625,6 +1625,7 @@ typedef UINT32_TYPEDEF UINT32_T;
  */
 #define MIN_COLUMNS	12	// minimal columns for screen
 #define MIN_LINES	2	// minimal lines for screen
+#define MIN_CMDHEIGHT	1	// minimal height for command line
 #define STATUS_HEIGHT	1	// height of a status line under a window
 #ifdef FEAT_MENU		// height of a status line under a window
 # define WINBAR_HEIGHT(wp)	(wp)->w_winbar_height

--- a/src/window.c
+++ b/src/window.c
@@ -6826,7 +6826,7 @@ win_drag_status_line(win_T *dragwin, int offset)
     row = win_comp_pos();
     screen_fill(row, cmdline_row, 0, (int)Columns, ' ', ' ', 0);
     cmdline_row = row;
-    p_ch = MAX(Rows - cmdline_row, 1);
+    p_ch = MAX(Rows - cmdline_row, MIN_CMDHEIGHT);
     curtab->tp_ch_used = p_ch;
 
     win_fix_scroll(TRUE);
@@ -7501,7 +7501,7 @@ min_rows(void)
 	return MIN_LINES;
 
     return frame_minheight(curtab->tp_topframe, NULL) + tabline_height()
-	+ 1;		// count the room for the command line
+	+ MIN_CMDHEIGHT;
 }
 
 /*
@@ -7526,7 +7526,7 @@ min_rows_for_all_tabpages(void)
 	    total = n;
     }
     total += tabline_height();
-    total += 1;		// count the room for the command line
+    total += MIN_CMDHEIGHT;
     return total;
 }
 

--- a/src/window.c
+++ b/src/window.c
@@ -6667,7 +6667,7 @@ win_setminheight(void)
     while (p_wmh > 0)
     {
 	room = Rows - p_ch;
-	needed = min_rows() - 1;  // 1 was added for the cmdline
+	needed = min_rows_for_all_tabpages() - 1;  // 1 was added for the cmdline
 	if (room >= needed)
 	    break;
 	--p_wmh;
@@ -7496,6 +7496,20 @@ last_stl_height(
  */
     int
 min_rows(void)
+{
+    if (firstwin == NULL)	// not initialized yet
+	return MIN_LINES;
+
+    return frame_minheight(curtab->tp_topframe, NULL) + tabline_height()
+	+ 1;		// count the room for the command line
+}
+
+/*
+ * Return the minimal number of rows that is needed on the screen to display
+ * the current number of windows for all tab pages.
+ */
+    int
+min_rows_for_all_tabpages(void)
 {
     int		total;
     tabpage_T	*tp;


### PR DESCRIPTION
Problem: The maximum value of 'cmdheight' is limited by other tabpages.
Solution: Limit the maximum value of 'cmdheight' to the current tabpage only.

The Help says that `cmdheight` is local to the tab page, but says nothing about the maximum value depending on the state of all tab pages. Users may wonder why they can't increase `cmdheight` when there are still rows available on the current tab page.
This PR changes the behavior of `cmdheight` so that its maximum value depends only on the state of the current tab page.

Also, since magic numbers were embedded in various places with the minimum value of `cmdheight` being `1`, we defined a constant to make it easier to understand.