### PR TITLE
runtime(typst): provide a formatlistpat

### DIFF
--- a/runtime/ftplugin/typst.vim
+++ b/runtime/ftplugin/typst.vim
@@ -11,10 +11,12 @@ let b:did_ftplugin = 1
 
 setlocal commentstring=//\ %s
 setlocal comments=s1:/*,mb:*,ex:*/,://
-setlocal formatoptions+=croq
+setlocal formatoptions+=croqn
+setlocal formatlistpat=^\\s*\\d\\+[\\]:.)}\\t\ ]\\s*
+setlocal formatlistpat+=\\\|^\\s*[-+\]\\s\\+
 setlocal suffixesadd=.typ
 
-let b:undo_ftplugin = 'setl cms< com< fo< sua<'
+let b:undo_ftplugin = 'setl cms< com< fo< flp< sua<'
 
 if get(g:, 'typst_conceal', 0)
   setlocal conceallevel=2


### PR DESCRIPTION
ping maintainer: @gpanders 

Hi,
this PR does the following changes:
- adds the `n` to `formatoptions` so it handles correctly lists when formatting with `gq`
- make recognize `-`, `+` and numbered lists

After this is merged I will make a PR at https://github.com/kaarmu/typst.vim