### PR TITLE
Detect .pxi,.pyx+ extension as pyrex

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1982,8 +1982,8 @@ au BufNewFile,BufRead MANIFEST.in		setf pymanifest
 " Pyret
 au BufNewFile,BufRead *.arr			setf pyret
 
-" Pyrex
-au BufNewFile,BufRead *.pyx,*.pxd		setf pyrex
+" Pyrex/Cython
+au BufNewFile,BufRead *.pyx,*.pyx+,*.pxd,*.pxi	setf pyrex
 
 " Python, Python Shell Startup and Python Stub Files
 " Quixote (Python-based web framework)

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -613,7 +613,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     purescript: ['file.purs'],
     pymanifest: ['MANIFEST.in'],
     pyret: ['file.arr'],
-    pyrex: ['file.pyx', 'file.pxd'],
+    pyrex: ['file.pyx', 'file.pxd', 'file.pxi', 'file.pyx+'],
     python: ['file.py', 'file.pyw', '.pythonstartup', '.pythonrc', '.python_history', '.jline-jython.history', 'file.ptl', 'file.pyi', 'SConstruct'],
     ql: ['file.ql', 'file.qll'],
     qml: ['file.qml', 'file.qbs'],


### PR DESCRIPTION
as in the title.

see https://cython.readthedocs.io/en/latest/src/userguide/language_basics.html#cython-file-types

cython is a successor of pyrex. https://cython.readthedocs.io/en/latest/src/quickstart/overview.html#pyrex

side note: pyrex also has a mention for `.pxi` file extension https://www.csse.canterbury.ac.nz/greg.ewing/python/Pyrex/version/Doc/Manual/basics.html#mozTocId494354 , and also `.pyx+` https://www.csse.canterbury.ac.nz/greg.ewing/python/Pyrex/version/Doc/Manual/using_with_c++.html (not sure if `.pyx+` appears in cython but I see no harm including either)