### PR TITLE
Issue #16126: 'compact' formatter is no longer distributed with eslint

### DIFF
--- a/runtime/compiler/eslint.vim
+++ b/runtime/compiler/eslint.vim
@@ -3,11 +3,12 @@
 " Maintainer:  Romain Lafourcade <romainlafourcade@gmail.com>
 " Last Change: 2020 August 20
 "	       2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
+"	       2024 Nov 29 by romainl (changed errorformat and makeprg)
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "eslint"
 
-CompilerSet makeprg=npx\ eslint\ --format\ compact
-CompilerSet errorformat=%f:\ line\ %l\\,\ col\ %c\\,\ %m,%-G%.%#
+CompilerSet makeprg=npx\ eslint\ --format\ stylish
+CompilerSet errorformat=%-P%f,\%\\s%#%l:%c\ %#\ %trror\ \ %m,\%\\s%#%l:%c\ %#\ %tarning\ \ %m,\%-Q,\%-G%.%#,


### PR DESCRIPTION
- switch to '--format stylish' in makeprg
- update errorformat with @sparkcanon's efm