### PR TITLE
runtime(compiler): Improve defaults and error handling for SpotBugs

### DIFF
--- a/Filelist
+++ b/Filelist
@@ -769,6 +769,8 @@ RT_ALL =	\
 		runtime/tutor/tutor1 \
 		runtime/tutor/en/vim-01-beginner.tutor \
 		runtime/tutor/en/vim-01-beginner.tutor.json \
+		runtime/tutor/it/vim-01-beginner.tutor \
+		runtime/tutor/it/vim-01-beginner.tutor.json \
 		runtime/tutor/tutor.tutor \
 		runtime/tutor/tutor.tutor.json \
 		runtime/tutor/tutor.vim \

--- a/runtime/autoload/spotbugs.vim
+++ b/runtime/autoload/spotbugs.vim
@@ -1,6 +1,6 @@
 " Default pre- and post-compiler actions for SpotBugs
 " Maintainers:  @konfekt and @zzzyxwvut
-" Last Change:  2024 Dec 02
+" Last Change:  2024 Dec 03
 
 let s:save_cpo = &cpo
 set cpo&vim
@@ -130,8 +130,8 @@ function! spotbugs#DefaultPostCompilerAction() abort
   make %:S
 endfunction
 
-" Look for "spotbugs#compiler" in "ftplugin/java.vim".
-let s:compiler = exists('spotbugs#compiler') ? spotbugs#compiler : ''
+" Look for "g:spotbugs#compiler" in "ftplugin/java.vim".
+let s:compiler = exists('g:spotbugs#compiler') ? g:spotbugs#compiler : ''
 let s:readable = filereadable($VIMRUNTIME . '/compiler/' . s:compiler . '.vim')
 
 if s:readable && s:compiler ==# 'maven' && executable('mvn')
@@ -158,10 +158,10 @@ if s:readable && s:compiler ==# 'maven' && executable('mvn')
             \ function('spotbugs#DefaultPreCompilerTestAction'),
         \ 'PostCompilerAction':
             \ function('spotbugs#DefaultPostCompilerAction'),
-        \ 'sourceDirPath':      'src/main/java',
-        \ 'classDirPath':       'target/classes',
-        \ 'testSourceDirPath':  'src/test/java',
-        \ 'testClassDirPath':   'target/test-classes',
+        \ 'sourceDirPath':      ['src/main/java'],
+        \ 'classDirPath':       ['target/classes'],
+        \ 'testSourceDirPath':  ['src/test/java'],
+        \ 'testClassDirPath':   ['target/test-classes'],
         \ }
   endfunction
 
@@ -190,10 +190,10 @@ elseif s:readable && s:compiler ==# 'ant' && executable('ant')
             \ function('spotbugs#DefaultPreCompilerTestAction'),
         \ 'PostCompilerAction':
             \ function('spotbugs#DefaultPostCompilerAction'),
-        \ 'sourceDirPath':      'src',
-        \ 'classDirPath':       'build/classes',
-        \ 'testSourceDirPath':  'test',
-        \ 'testClassDirPath':   'build/test/classes',
+        \ 'sourceDirPath':      ['src'],
+        \ 'classDirPath':       ['build/classes'],
+        \ 'testSourceDirPath':  ['test'],
+        \ 'testClassDirPath':   ['build/test/classes'],
         \ }
   endfunction
 

--- a/runtime/autoload/spotbugs.vim
+++ b/runtime/autoload/spotbugs.vim
@@ -1,6 +1,6 @@
 " Default pre- and post-compiler actions for SpotBugs
 " Maintainers:  @konfekt and @zzzyxwvut
-" Last Change:  2024 Dec 03
+" Last Change:  2024 Dec 07
 
 let s:save_cpo = &cpo
 set cpo&vim
@@ -275,6 +275,41 @@ else
   " XXX: Keep "s:compiler" around for "spotbugs#DefaultPreCompilerAction()".
   unlet s:readable
 endif
+
+function! s:DefineBufferAutocmd(event, ...) abort
+  if !exists('#java_spotbugs#User')
+    return 1
+  endif
+
+  for l:event in insert(copy(a:000), a:event)
+    if l:event != 'User'
+      execute printf('silent! autocmd! java_spotbugs %s <buffer>', l:event)
+      execute printf('autocmd java_spotbugs %s <buffer> doautocmd User', l:event)
+    endif
+  endfor
+
+  return 0
+endfunction
+
+function! s:RemoveBufferAutocmd(event, ...) abort
+  if !exists('#java_spotbugs')
+    return 1
+  endif
+
+  for l:event in insert(copy(a:000), a:event)
+    if l:event != 'User'
+      execute printf('silent! autocmd! java_spotbugs %s <buffer>', l:event)
+    endif
+  endfor
+
+  return 0
+endfunction
+
+" Documented in ":help compiler-spotbugs".
+command! -bar -nargs=+ -complete=event SpotBugsDefineBufferAutocmd
+    \ call s:DefineBufferAutocmd(<f-args>)
+command! -bar -nargs=+ -complete=event SpotBugsRemoveBufferAutocmd
+    \ call s:RemoveBufferAutocmd(<f-args>)
 
 let &cpo = s:save_cpo
 unlet s:save_cpo

--- a/runtime/compiler/spotbugs.vim
+++ b/runtime/compiler/spotbugs.vim
@@ -1,7 +1,7 @@
 " Vim compiler file
 " Compiler:     Spotbugs (Java static checker; needs javac compiled classes)
 " Maintainer:   @konfekt and @zzzyxwvut
-" Last Change:  2024 Nov 27
+" Last Change:  2024 Dec 01
 
 if exists('g:current_compiler') || bufname() !~# '\.java\=$' || wordcount().chars < 9
   finish
@@ -24,8 +24,9 @@ let s:type_names = '\C\<\%(\.\@1<!class\|@\=interface\|enum\|record\)\s*\(\K\k*\
 let s:package_names = '\C\<package\s*\(\K\%(\k*\.\=\)\+;\)'
 let s:package = ''
 
-if has('syntax') && exists('g:syntax_on') && exists('b:current_syntax') &&
-    \ b:current_syntax == 'java' && hlexists('javaClassDecl')
+if has('syntax') && exists('g:syntax_on') &&
+    \ exists('b:current_syntax') && b:current_syntax == 'java' &&
+    \ hlexists('javaClassDecl') && hlexists('javaExternal')
 
   function! s:GetDeclaredTypeNames() abort
     if bufname() =~# '\<\%(module\|package\)-info\.java\=$'
@@ -106,10 +107,10 @@ else
 endif
 
 if exists('g:spotbugs_properties') &&
-    \ (has_key(g:spotbugs_properties, 'sourceDirPath') &&
+    \ ((has_key(g:spotbugs_properties, 'sourceDirPath') &&
     \ has_key(g:spotbugs_properties, 'classDirPath')) ||
     \ (has_key(g:spotbugs_properties, 'testSourceDirPath') &&
-    \ has_key(g:spotbugs_properties, 'testClassDirPath'))
+    \ has_key(g:spotbugs_properties, 'testClassDirPath')))
 
 function! s:FindClassFiles(src_type_name) abort
   let class_files = []

--- a/runtime/compiler/spotbugs.vim
+++ b/runtime/compiler/spotbugs.vim
@@ -1,7 +1,7 @@
 " Vim compiler file
 " Compiler:     Spotbugs (Java static checker; needs javac compiled classes)
 " Maintainer:   @konfekt and @zzzyxwvut
-" Last Change:  2024 Dec 03
+" Last Change:  2024 Dec 06
 
 if exists('g:current_compiler') || bufname() !~# '\.java\=$' || wordcount().chars < 9
   finish
@@ -112,59 +112,59 @@ if exists('g:spotbugs_properties') &&
     \ (!empty(get(g:spotbugs_properties, 'testSourceDirPath', [])) &&
         \ !empty(get(g:spotbugs_properties, 'testClassDirPath', []))))
 
-function! s:CommonIdxsAndDirs() abort
-  let src_dir_path = get(g:spotbugs_properties, 'sourceDirPath', [])
-  let bin_dir_path = get(g:spotbugs_properties, 'classDirPath', [])
-  let test_src_dir_path = get(g:spotbugs_properties, 'testSourceDirPath', [])
-  let test_bin_dir_path = get(g:spotbugs_properties, 'testClassDirPath', [])
-  let dir_cnt = min([len(src_dir_path), len(bin_dir_path)])
-  let test_dir_cnt = min([len(test_src_dir_path), len(test_bin_dir_path)])
-  " Do not break up path pairs with filtering!
-  return [[range(dir_cnt),
-          \ src_dir_path[0 : dir_cnt - 1],
-          \ bin_dir_path[0 : dir_cnt - 1]],
-      \ [range(test_dir_cnt),
-          \ test_src_dir_path[0 : test_dir_cnt - 1],
-          \ test_bin_dir_path[0 : test_dir_cnt - 1]]]
-endfunction
+  function! s:CommonIdxsAndDirs() abort
+    let src_dir_path = get(g:spotbugs_properties, 'sourceDirPath', [])
+    let bin_dir_path = get(g:spotbugs_properties, 'classDirPath', [])
+    let test_src_dir_path = get(g:spotbugs_properties, 'testSourceDirPath', [])
+    let test_bin_dir_path = get(g:spotbugs_properties, 'testClassDirPath', [])
+    let dir_cnt = min([len(src_dir_path), len(bin_dir_path)])
+    let test_dir_cnt = min([len(test_src_dir_path), len(test_bin_dir_path)])
+    " Do not break up path pairs with filtering!
+    return [[range(dir_cnt),
+            \ src_dir_path[0 : dir_cnt - 1],
+            \ bin_dir_path[0 : dir_cnt - 1]],
+        \ [range(test_dir_cnt),
+            \ test_src_dir_path[0 : test_dir_cnt - 1],
+            \ test_bin_dir_path[0 : test_dir_cnt - 1]]]
+  endfunction
 
-let s:common_idxs_and_dirs = s:CommonIdxsAndDirs()
-delfunction s:CommonIdxsAndDirs
+  let s:common_idxs_and_dirs = s:CommonIdxsAndDirs()
+  delfunction s:CommonIdxsAndDirs
 
-function! s:FindClassFiles(src_type_name) abort
-  let class_files = []
-  " Match pairwise the components of source and class pathnames
-  for [idxs, src_dirs, bin_dirs] in s:common_idxs_and_dirs
-    " Do not use "fnamemodify(a:src_type_name, ':p:s?src?bin?')" because only
-    " the rightmost "src" is looked for
-    for idx in idxs
-      let tail_idx = strridx(a:src_type_name, src_dirs[idx])
-      " No such directory or no such inner type (i.e. without "$")
-      if tail_idx < 0 | continue | endif
-      " Substitute "bin_dirs[idx]" for the rightmost "src_dirs[idx]"
-      let candidate_type_name = strpart(a:src_type_name, 0, tail_idx)..
-          \ bin_dirs[idx]..
-          \ strpart(a:src_type_name, (tail_idx + strlen(src_dirs[idx])))
-      for candidate in insert(s:GlobClassFiles(candidate_type_name),
-            \ candidate_type_name..'.class')
-        if filereadable(candidate) | call add(class_files, shellescape(candidate)) | endif
+  function! s:FindClassFiles(src_type_name) abort
+    let class_files = []
+    " Match pairwise the components of source and class pathnames
+    for [idxs, src_dirs, bin_dirs] in s:common_idxs_and_dirs
+      " Do not use "fnamemodify(a:src_type_name, ':p:s?src?bin?')" because
+      " only the rightmost "src" is looked for
+      for idx in idxs
+        let tail_idx = strridx(a:src_type_name, src_dirs[idx])
+        " No such directory or no such inner type (i.e. without "$")
+        if tail_idx < 0 | continue | endif
+        " Substitute "bin_dirs[idx]" for the rightmost "src_dirs[idx]"
+        let candidate_type_name = strpart(a:src_type_name, 0, tail_idx)..
+            \ bin_dirs[idx]..
+            \ strpart(a:src_type_name, (tail_idx + strlen(src_dirs[idx])))
+        for candidate in insert(s:GlobClassFiles(candidate_type_name),
+              \ candidate_type_name..'.class')
+          if filereadable(candidate) | call add(class_files, shellescape(candidate)) | endif
+        endfor
+        if !empty(class_files) | break | endif
       endfor
       if !empty(class_files) | break | endif
     endfor
-    if !empty(class_files) | break | endif
-  endfor
-  return class_files
-endfunction
+    return class_files
+  endfunction
 
 else
-function! s:FindClassFiles(src_type_name) abort
-  let class_files = []
-  for candidate in insert(s:GlobClassFiles(a:src_type_name),
-        \ a:src_type_name..'.class')
-    if filereadable(candidate) | call add(class_files, shellescape(candidate)) | endif
-  endfor
-  return class_files
-endfunction
+  function! s:FindClassFiles(src_type_name) abort
+    let class_files = []
+    for candidate in insert(s:GlobClassFiles(a:src_type_name),
+          \ a:src_type_name..'.class')
+      if filereadable(candidate) | call add(class_files, shellescape(candidate)) | endif
+    endfor
+    return class_files
+  endfunction
 endif
 
 function! s:CollectClassFiles() abort

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -1,4 +1,4 @@
-*quickfix.txt*  For Vim version 9.1.  Last change: 2024 Dec 08
+*quickfix.txt*  For Vim version 9.1.  Last change: 2024 Dec 14
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -1481,8 +1481,20 @@ Both "g:spotbugs_properties" and "b:spotbugs_properties" are recognized and
 must be modifiable (|:unlockvar|).  The "*Command" entries are always treated
 as global functions to be shared among all Java buffers.
 
+The SpotBugs Java library and, by extension, its distributed shell scripts do
+not support in the `-textui` mode listed pathnames with directory filenames
+that contain blank characters [2].  To work around this limitation, consider
+making a symbolic link to such a directory from a directory that does not have
+blank characters in its name and passing this information to SpotBugs: >
+
+	let g:spotbugs_alternative_path = {
+		\ 'fromPath':	'path/to/dir_without_blanks',
+		\ 'toPath':	'path/to/dir with blanks',
+	\ }
+
 [0] https://github.com/Konfekt/vim-compilers
 [1] https://github.com/MarcWeber/vim-addon-local-vimrc
+[2] https://github.com/spotbugs/spotbugs/issues/909
 
 GNU MAKE						*compiler-make*
 

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -1,4 +1,4 @@
-*quickfix.txt*  For Vim version 9.1.  Last change: 2024 Dec 02
+*quickfix.txt*  For Vim version 9.1.  Last change: 2024 Dec 03
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -1362,10 +1362,10 @@ their paths (distinct and relative to their common root directory) to the
 following properties (using the example of a common Maven project): >
 
 	let g:spotbugs_properties = {
-		\ 'sourceDirPath':	'src/main/java',
-		\ 'classDirPath':	'target/classes',
-		\ 'testSourceDirPath':	'src/test/java',
-		\ 'testClassDirPath':	'target/test-classes',
+		\ 'sourceDirPath':	['src/main/java'],
+		\ 'classDirPath':	['target/classes'],
+		\ 'testSourceDirPath':	['src/test/java'],
+		\ 'testClassDirPath':	['target/test-classes'],
 	\ }
 
 Note that source and class path entries are expected to come in pairs: define
@@ -1396,10 +1396,10 @@ available. >
 			\ function('spotbugs#DefaultPreCompilerTestAction'),
 		\ 'PostCompilerAction':
 			\ function('spotbugs#DefaultPostCompilerAction'),
-		\ 'sourceDirPath':	'src/main/java',
-		\ 'classDirPath':	'target/classes',
-		\ 'testSourceDirPath':	'src/test/java',
-		\ 'testClassDirPath':	'target/test-classes',
+		\ 'sourceDirPath':	['src/main/java'],
+		\ 'classDirPath':	['target/classes'],
+		\ 'testSourceDirPath':	['src/test/java'],
+		\ 'testClassDirPath':	['target/test-classes'],
 	\ }
 
 With default actions, the compiler of choice will attempt to rebuild the class

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -1,4 +1,4 @@
-*quickfix.txt*  For Vim version 9.1.  Last change: 2024 Nov 28
+*quickfix.txt*  For Vim version 9.1.  Last change: 2024 Dec 02
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -1368,13 +1368,16 @@ following properties (using the example of a common Maven project): >
 		\ 'testClassDirPath':	'target/test-classes',
 	\ }
 
+Note that source and class path entries are expected to come in pairs: define
+both "sourceDirPath" and "classDirPath" when you are considering at least one,
+and apply the same logic to "testSourceDirPath" and "testClassDirPath".
 Note that values for the path keys describe only for SpotBugs where to look
 for files; refer to the documentation for particular compiler plugins for more
 information.
 
 The default pre- and post-compiler actions are provided for Ant, Maven, and
 Javac compiler plugins and can be selected by assigning the name of a compiler
-plugin to the "compiler" key: >
+plugin (`ant`, `maven`, or `javac`) to the "compiler" key: >
 
 	let g:spotbugs_properties = {
 		\ 'compiler':		'maven',
@@ -1415,12 +1418,14 @@ project and requests other default Maven settings with the "compiler" entry: >
 		call spotbugs#DeleteClassFiles()
 		compiler maven
 		make compile
+		cc
 	endfunction
 
 	function! MavenPreCompilerTestAction() abort
 		call spotbugs#DeleteClassFiles()
 		compiler maven
 		make test-compile
+		cc
 	endfunction
 
 	let g:spotbugs_properties = {
@@ -1433,6 +1438,10 @@ project and requests other default Maven settings with the "compiler" entry: >
 
 Note that all entered custom settings will take precedence over the matching
 default settings in "g:spotbugs_properties".
+Note that it is necessary to notify the plugin of the result of a pre-compiler
+action before further work can be undertaken.  Using |:cc| after |:make| (or
+|:ll| after |:lmake|) as the last command of an action is the supported means
+of such communication.
 
 The "g:spotbugs_properties" variable is consulted by the Java filetype plugin
 (|ft-java-plugin|) to arrange for the described automation, and, therefore, it

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -1,4 +1,4 @@
-*quickfix.txt*  For Vim version 9.1.  Last change: 2024 Dec 14
+*quickfix.txt*  For Vim version 9.1.  Last change: 2024 Dec 16
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -1349,7 +1349,7 @@ It scans the Java bytecode of all classes in the currently open buffer.
 (Therefore, `:compiler! spotbugs` is not supported.)
 
 Commonly used compiler options can be added to 'makeprg' by setting the
-"b:" or "g:spotbugs_makeprg_params" variable.  For example: >
+"b:" or "g:spotbugs_makeprg_params" variable.  For example: >vim
 
 	let b:spotbugs_makeprg_params = "-longBugCodes -effort:max -low"
 
@@ -1359,7 +1359,7 @@ By default, the class files are searched in the directory where the source
 files are placed.  However, typical Java projects use distinct directories
 for source files and class files.  To make both known to SpotBugs, assign
 their paths (distinct and relative to their common root directory) to the
-following properties (using the example of a common Maven project): >
+following properties (using the example of a common Maven project): >vim
 
 	let g:spotbugs_properties = {
 		\ 'sourceDirPath':	['src/main/java'],
@@ -1377,7 +1377,7 @@ information.
 
 The default pre- and post-compiler actions are provided for Ant, Maven, and
 Javac compiler plugins and can be selected by assigning the name of a compiler
-plugin (`ant`, `maven`, or `javac`) to the "compiler" key: >
+plugin (`ant`, `maven`, or `javac`) to the "compiler" key: >vim
 
 	let g:spotbugs_properties = {
 		\ 'compiler':		'maven',
@@ -1387,7 +1387,7 @@ This single setting is essentially equivalent to all the settings below, with
 the exception made for the "PreCompilerAction" and "PreCompilerTestAction"
 values: their listed |Funcref|s will obtain no-op implementations whereas the
 implicit Funcrefs of the "compiler" key will obtain the requested defaults if
-available. >
+available. >vim
 
 	let g:spotbugs_properties = {
 		\ 'PreCompilerAction':
@@ -1413,8 +1413,8 @@ Begin by considering which of the supported keys, "DefaultPreCompilerCommand",
 write an implementation for, observing that each of these keys corresponds to
 a particular "*Action" key.  Follow it by defining a new function that always
 declares an only parameter of type string and puts to use a command equivalent
-of |:make|, and assigning its |Funcref| to the selected key.  For example: >
-
+of |:make|, and assigning its |Funcref| to the selected key.  For example:
+>vim
 	function! GenericPostCompilerCommand(arguments) abort
 		execute 'make ' . a:arguments
 	endfunction
@@ -1429,8 +1429,8 @@ arbitrary functions yourself and matching their Funcrefs to the supported
 keys: "PreCompilerAction", "PreCompilerTestAction", and "PostCompilerAction".
 
 The next example re-implements the default pre-compiler actions for a Maven
-project and requests other default Maven settings with the "compiler" entry: >
-
+project and requests other default Maven settings with the "compiler" entry:
+>vim
 	function! MavenPreCompilerAction() abort
 		call spotbugs#DeleteClassFiles()
 		compiler maven
@@ -1463,7 +1463,7 @@ of such communication.
 Two commands, "SpotBugsRemoveBufferAutocmd" and "SpotBugsDefineBufferAutocmd",
 are provided to toggle actions for buffer-local autocommands.  For example, to
 also run actions on any |BufWritePost| and |SigUSR1| event, add these lines to
-`~/.vim/after/ftplugin/java.vim`:  >
+`~/.vim/after/ftplugin/java.vim`: >vim
 
 	if exists(':SpotBugsDefineBufferAutocmd') == 2
 		SpotBugsDefineBufferAutocmd BufWritePost SigUSR1
@@ -1485,7 +1485,7 @@ The SpotBugs Java library and, by extension, its distributed shell scripts do
 not support in the `-textui` mode listed pathnames with directory filenames
 that contain blank characters [2].  To work around this limitation, consider
 making a symbolic link to such a directory from a directory that does not have
-blank characters in its name and passing this information to SpotBugs: >
+blank characters in its name and passing this information to SpotBugs: >vim
 
 	let g:spotbugs_alternative_path = {
 		\ 'fromPath':	'path/to/dir_without_blanks',

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -1443,6 +1443,17 @@ action before further work can be undertaken.  Using |:cc| after |:make| (or
 |:ll| after |:lmake|) as the last command of an action is the supported means
 of such communication.
 
+Two commands, "SpotBugsRemoveBufferAutocmd" and "SpotBugsDefineBufferAutocmd",
+are provided to toggle actions for buffer-local autocommands.  For example, to
+also run actions on any |BufWritePost| and |SigUSR1| event, add these lines to
+`~/.vim/after/ftplugin/java.vim`:  >
+
+	if exists(':SpotBugsDefineBufferAutocmd') == 2
+		SpotBugsDefineBufferAutocmd BufWritePost SigUSR1
+	endif
+
+Otherwise, you can turn to `:doautocmd java_spotbugs User` at any time.
+
 The "g:spotbugs_properties" variable is consulted by the Java filetype plugin
 (|ft-java-plugin|) to arrange for the described automation, and, therefore, it
 must be defined before |FileType| events can take place for the buffers loaded

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -1,4 +1,4 @@
-*quickfix.txt*  For Vim version 9.1.  Last change: 2024 Dec 07
+*quickfix.txt*  For Vim version 9.1.  Last change: 2024 Dec 08
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -1407,8 +1407,25 @@ files for the buffer (and possibly for the whole project) as soon as a Java
 syntax file is loaded; then, `spotbugs` will attempt to analyze the quality of
 the compilation unit of the buffer.
 
-When default actions are not suited to a desired workflow, consider writing
-arbitrary functions yourself and matching their |Funcref|s to the supported
+Vim commands proficient in 'makeprg' [0] can be composed with default actions.
+Begin by considering which of the supported keys, "DefaultPreCompilerCommand",
+"DefaultPreCompilerTestCommand", or "DefaultPostCompilerCommand", you need to
+write an implementation for, observing that each of these keys corresponds to
+a particular "*Action" key.  Follow it by defining a new function that always
+declares an only parameter of type string and puts to use a command equivalent
+of |:make|, and assigning its |Funcref| to the selected key.  For example: >
+
+	function! GenericPostCompilerCommand(arguments) abort
+		execute 'make ' . a:arguments
+	endfunction
+
+	let g:spotbugs_properties = {
+		\ 'DefaultPostCompilerCommand':
+			\ function('GenericPostCompilerCommand'),
+	\ }
+
+When default actions are not suited to a desired workflow, proceed by writing
+arbitrary functions yourself and matching their Funcrefs to the supported
 keys: "PreCompilerAction", "PreCompilerTestAction", and "PostCompilerAction".
 
 The next example re-implements the default pre-compiler actions for a Maven
@@ -1458,12 +1475,14 @@ The "g:spotbugs_properties" variable is consulted by the Java filetype plugin
 (|ft-java-plugin|) to arrange for the described automation, and, therefore, it
 must be defined before |FileType| events can take place for the buffers loaded
 with Java source files.  It could, for example, be set in a project-local
-|vimrc| loaded by [0].
+|vimrc| loaded by [1].
 
 Both "g:spotbugs_properties" and "b:spotbugs_properties" are recognized and
-must be modifiable (|:unlockvar|).
+must be modifiable (|:unlockvar|).  The "*Command" entries are always treated
+as global functions to be shared among all Java buffers.
 
-[0] https://github.com/MarcWeber/vim-addon-local-vimrc/
+[0] https://github.com/Konfekt/vim-compilers
+[1] https://github.com/MarcWeber/vim-addon-local-vimrc
 
 GNU MAKE						*compiler-make*
 

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -1,4 +1,4 @@
-*quickfix.txt*  For Vim version 9.1.  Last change: 2024 Dec 03
+*quickfix.txt*  For Vim version 9.1.  Last change: 2024 Dec 07
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -1448,6 +1448,9 @@ The "g:spotbugs_properties" variable is consulted by the Java filetype plugin
 must be defined before |FileType| events can take place for the buffers loaded
 with Java source files.  It could, for example, be set in a project-local
 |vimrc| loaded by [0].
+
+Both "g:spotbugs_properties" and "b:spotbugs_properties" are recognized and
+must be modifiable (|:unlockvar|).
 
 [0] https://github.com/MarcWeber/vim-addon-local-vimrc/
 

--- a/runtime/ftplugin/java.vim
+++ b/runtime/ftplugin/java.vim
@@ -123,12 +123,14 @@ if exists("g:spotbugs_properties") &&
     endif
 
     if has_key(g:spotbugs_properties, 'PreCompilerTestAction')
-	let s:dispatcher = 'call g:spotbugs_properties.PreCompilerTestAction()'
+	let s:dispatcher = printf('call call(%s, [])',
+	    \ string(g:spotbugs_properties.PreCompilerTestAction))
 	let s:request += 2
     endif
 
     if has_key(g:spotbugs_properties, 'PreCompilerAction')
-	let s:dispatcher = 'call g:spotbugs_properties.PreCompilerAction()'
+	let s:dispatcher = printf('call call(%s, [])',
+	    \ string(g:spotbugs_properties.PreCompilerAction))
 	let s:request += 1
     endif
 
@@ -168,7 +170,7 @@ if exists("g:spotbugs_properties") &&
     endif
 
     if exists("s:dispatcher")
-	function! s:ExecuteAction(pre_action, post_action) abort
+	function! s:ExecuteActions(pre_action, post_action) abort
 """"	    let status = v:shell_error
 """"	    let success = 0
 
@@ -184,10 +186,6 @@ if exists("g:spotbugs_properties") &&
 """"	    if success || !v:shell_error || status
 """"		execute a:post_action
 """"	    endif
-	endfunction
-    else
-	function! s:ExecuteAction(action) abort
-	    execute a:action
 	endfunction
     endif
 
@@ -211,16 +209,16 @@ if exists("g:spotbugs_properties") &&
 
 	for s:idx in range(len(s:actions))
 	    if s:request == 7 || s:request == 6 || s:request == 5
-		let s:actions[s:idx].cmd = printf('call s:ExecuteAction(%s, %s)',
+		let s:actions[s:idx].cmd = printf('call s:ExecuteActions(%s, %s)',
 		    \ string(s:dispatcher),
-		    \ string('compiler spotbugs | ' .
-			\ 'call g:spotbugs_properties.PostCompilerAction()'))
+		    \ string(printf('compiler spotbugs | call call(%s, [])',
+			\ string(g:spotbugs_properties.PostCompilerAction))))
 	    elseif s:request == 4
-		let s:actions[s:idx].cmd = printf('call s:ExecuteAction(%s)',
-		    \ string('compiler spotbugs | ' .
-			\ 'call g:spotbugs_properties.PostCompilerAction()'))
+		let s:actions[s:idx].cmd = printf(
+		    \ 'compiler spotbugs | call call(%s, [])',
+		    \ string(g:spotbugs_properties.PostCompilerAction))
 	    elseif s:request == 3 || s:request == 2 || s:request == 1
-		let s:actions[s:idx].cmd = printf('call s:ExecuteAction(%s, %s)',
+		let s:actions[s:idx].cmd = printf('call s:ExecuteActions(%s, %s)',
 		    \ string(s:dispatcher),
 		    \ string('compiler spotbugs'))
 	    else

--- a/runtime/ftplugin/java.vim
+++ b/runtime/ftplugin/java.vim
@@ -3,7 +3,7 @@
 " Maintainer:		Aliaksei Budavei <0x000c70 AT gmail DOT com>
 " Former Maintainer:	Dan Sharp
 " Repository:		https://github.com/zzzyxwvut/java-vim.git
-" Last Change:		2024 Dec 08
+" Last Change:		2024 Dec 16
 "			2024 Jan 14 by Vim Project (browsefilter)
 "			2024 May 23 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 
@@ -113,11 +113,11 @@ if (!empty(get(g:, 'spotbugs_properties', {})) ||
     endfunction
 
     " Work around ":bar"s and ":autocmd"s.
-    function! s:ExecuteActionOnce(action_cmd, cleanup_cmd) abort
+    function! s:ExecuteActionOnce(cleanup_cmd, action_cmd) abort
 	try
-	    execute a:action_cmd
-	finally
 	    execute a:cleanup_cmd
+	finally
+	    execute a:action_cmd
 	endtry
     endfunction
 
@@ -297,9 +297,9 @@ if (!empty(get(g:, 'spotbugs_properties', {})) ||
 		execute printf('autocmd java_spotbugs %s <buffer> ' .
 			\ 'call s:ExecuteActionOnce(%s, %s)',
 		    \ s:action.event,
-		    \ string(s:action.cmd),
 		    \ string(printf('autocmd! java_spotbugs %s <buffer>',
-			\ s:action.event)))
+			\ s:action.event)),
+		    \ string(s:action.cmd))
 	    else
 		execute printf('autocmd java_spotbugs %s <buffer> %s',
 		    \ s:action.event,

--- a/runtime/ftplugin/java.vim
+++ b/runtime/ftplugin/java.vim
@@ -3,7 +3,7 @@
 " Maintainer:		Aliaksei Budavei <0x000c70 AT gmail DOT com>
 " Former Maintainer:	Dan Sharp
 " Repository:		https://github.com/zzzyxwvut/java-vim.git
-" Last Change:		2024 Dec 03
+" Last Change:		2024 Dec 05
 "			2024 Jan 14 by Vim Project (browsefilter)
 "			2024 May 23 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 
@@ -192,7 +192,7 @@ if exists("g:spotbugs_properties") &&
     endif
 
     if s:request
-	if exists("b:spotbugs_syntax_once")
+	if exists("b:spotbugs_syntax_once") || empty(join(getline(1, 8), ''))
 	    let s:actions = [{'event': 'BufWritePost'}]
 	else
 	    " XXX: Handle multiple FileType events when vimrc contains more

--- a/runtime/ftplugin/java.vim
+++ b/runtime/ftplugin/java.vim
@@ -220,7 +220,7 @@ if (!empty(get(g:, 'spotbugs_properties', {})) ||
 
     if s:request
 	if exists("b:spotbugs_syntax_once") || empty(join(getline(1, 8), ''))
-	    let s:actions = [{'event': 'BufWritePost'}]
+	    let s:actions = [{'event': 'User'}]
 	else
 	    " XXX: Handle multiple FileType events when vimrc contains more
 	    " than one filetype setting for the language, e.g.:
@@ -232,7 +232,7 @@ if (!empty(get(g:, 'spotbugs_properties', {})) ||
 		    \ 'event': 'Syntax',
 		    \ 'once': 1,
 		\ }, {
-		    \ 'event': 'BufWritePost',
+		    \ 'event': 'User',
 		\ }]
 	endif
 
@@ -261,7 +261,7 @@ if (!empty(get(g:, 'spotbugs_properties', {})) ||
 	endif
 
 	" The events are defined in s:actions.
-	silent! autocmd! java_spotbugs BufWritePost <buffer>
+	silent! autocmd! java_spotbugs User <buffer>
 	silent! autocmd! java_spotbugs Syntax <buffer>
 
 	for s:action in s:actions
@@ -292,8 +292,8 @@ function! JavaFileTypeCleanUp() abort
     setlocal suffixes< suffixesadd< formatoptions< comments< commentstring< path< includeexpr<
     unlet! b:browsefilter
 
-    " The concatenated removals may be misparsed as a BufWritePost autocmd.
-    silent! autocmd! java_spotbugs BufWritePost <buffer>
+    " The concatenated removals may be misparsed as a User autocmd.
+    silent! autocmd! java_spotbugs User <buffer>
     silent! autocmd! java_spotbugs Syntax <buffer>
 endfunction
 

--- a/runtime/ftplugin/java.vim
+++ b/runtime/ftplugin/java.vim
@@ -228,21 +228,11 @@ if (!empty(get(g:, 'spotbugs_properties', {})) ||
 
     if exists("s:dispatcher")
 	function! s:ExecuteActions(pre_action, post_action) abort
-""""	    let status = v:shell_error
-""""	    let success = 0
-
 	    try
-		" FIXME: Why ":make" does not update "v:shell_error"?
 		execute a:pre_action
 	    catch /\<E42:/
 		execute a:post_action
-		return
-""""		let success = !v:shell_error || status
 	    endtry
-
-""""	    if success || !v:shell_error || status
-""""		execute a:post_action
-""""	    endif
 	endfunction
     endif
 

--- a/src/testdir/test_compiler.vim
+++ b/src/testdir/test_compiler.vim
@@ -99,6 +99,7 @@ func s:SpotBugsParseFilterMakePrg(dirname, makeprg)
   endif
   let offset += 1 + strlen('-sourcepath')
   let result.sourcepath = matchstr(strpart(a:makeprg, offset), '.\{-}\ze[ \t]')
+  let offset += 1 + strlen(result.sourcepath)
 
   " Get the class file arguments, dropping the pathname prefix.
   let offset = stridx(a:makeprg, a:dirname, offset)
@@ -148,7 +149,8 @@ func Test_compiler_spotbugs_makeprg()
   " THE EXPECTED RESULTS.
   let results = {}
   let results['Xspotbugs/src/tests/𐌂1.java'] = {
-      \ 'sourcepath': '%:p:h:S',
+      \ 'Sourcepath': {-> fnamemodify('Xspotbugs/src/tests/𐌂1.java',
+          \ ':p:h:S')},
       \ 'classfiles': sort([
           \ 'Xspotbugs/tests/𐌂1$1.class',
           \ 'Xspotbugs/tests/𐌂1$1𐌉𐌉1.class',
@@ -161,11 +163,12 @@ func Test_compiler_spotbugs_makeprg()
       \ }
   " No class file for an empty source file even with "-Xpkginfo:always".
   let results['Xspotbugs/src/tests/package-info.java'] = {
-      \ 'sourcepath': '',
+      \ 'Sourcepath': {-> ''},
       \ 'classfiles': [],
       \ }
   let results['Xspotbugs/src/tests/α/𐌂1.java'] = {
-      \ 'sourcepath': '%:p:h:h:S',
+      \ 'Sourcepath': {-> fnamemodify('Xspotbugs/src/tests/α/𐌂1.java',
+          \ ':p:h:h:S')},
       \ 'classfiles': sort([
           \ 'Xspotbugs/tests/α/𐌂1$1.class',
           \ 'Xspotbugs/tests/α/𐌂1$1𐌉𐌉1.class',
@@ -177,11 +180,13 @@ func Test_compiler_spotbugs_makeprg()
           \ 'Xspotbugs/tests/α/𐌂2.class']),
       \ }
   let results['Xspotbugs/src/tests/α/package-info.java'] = {
-      \ 'sourcepath': '%:p:h:S',
+      \ 'Sourcepath': {-> fnamemodify('Xspotbugs/src/tests/α/package-info.java',
+          \ ':p:h:S')},
       \ 'classfiles': ['Xspotbugs/tests/α/package-info.class'],
       \ }
   let results['Xspotbugs/src/tests/α/β/𐌂1.java'] = {
-      \ 'sourcepath': '%:p:h:h:h:S',
+      \ 'Sourcepath': {-> fnamemodify('Xspotbugs/src/tests/α/β/𐌂1.java',
+          \ ':p:h:h:h:S')},
       \ 'classfiles': sort([
           \ 'Xspotbugs/tests/α/β/𐌂1$1.class',
           \ 'Xspotbugs/tests/α/β/𐌂1$1𐌉𐌉1.class',
@@ -193,11 +198,13 @@ func Test_compiler_spotbugs_makeprg()
           \ 'Xspotbugs/tests/α/β/𐌂2.class']),
       \ }
   let results['Xspotbugs/src/tests/α/β/package-info.java'] = {
-      \ 'sourcepath': '%:p:h:S',
+      \ 'Sourcepath': {-> fnamemodify('Xspotbugs/src/tests/α/β/package-info.java',
+          \ ':p:h:S')},
       \ 'classfiles': ['Xspotbugs/tests/α/β/package-info.class'],
       \ }
   let results['Xspotbugs/src/tests/α/β/γ/𐌂1.java'] = {
-      \ 'sourcepath': '%:p:h:h:h:h:S',
+      \ 'Sourcepath': {-> fnamemodify('Xspotbugs/src/tests/α/β/γ/𐌂1.java',
+          \ ':p:h:h:h:h:S')},
       \ 'classfiles': sort([
           \ 'Xspotbugs/tests/α/β/γ/𐌂1$1.class',
           \ 'Xspotbugs/tests/α/β/γ/𐌂1$1𐌉𐌉1.class',
@@ -209,11 +216,13 @@ func Test_compiler_spotbugs_makeprg()
           \ 'Xspotbugs/tests/α/β/γ/𐌂2.class']),
       \ }
   let results['Xspotbugs/src/tests/α/β/γ/package-info.java'] = {
-      \ 'sourcepath': '%:p:h:S',
+      \ 'Sourcepath': {-> fnamemodify('Xspotbugs/src/tests/α/β/γ/package-info.java',
+          \ ':p:h:S')},
       \ 'classfiles': ['Xspotbugs/tests/α/β/γ/package-info.class'],
       \ }
   let results['Xspotbugs/src/tests/α/β/γ/δ/𐌂1.java'] = {
-      \ 'sourcepath': '%:p:h:h:h:h:h:S',
+      \ 'Sourcepath': {-> fnamemodify('Xspotbugs/src/tests/α/β/γ/δ/𐌂1.java',
+          \ ':p:h:h:h:h:h:S')},
       \ 'classfiles': sort([
           \ 'Xspotbugs/tests/α/β/γ/δ/𐌂1$1.class',
           \ 'Xspotbugs/tests/α/β/γ/δ/𐌂1$1𐌉𐌉1.class',
@@ -225,7 +234,8 @@ func Test_compiler_spotbugs_makeprg()
           \ 'Xspotbugs/tests/α/β/γ/δ/𐌂2.class']),
       \ }
   let results['Xspotbugs/src/tests/α/β/γ/δ/package-info.java'] = {
-      \ 'sourcepath': '%:p:h:S',
+      \ 'Sourcepath': {-> fnamemodify('Xspotbugs/src/tests/α/β/γ/δ/package-info.java',
+          \ ':p:h:S')},
       \ 'classfiles': ['Xspotbugs/tests/α/β/γ/δ/package-info.class'],
       \ }
 
@@ -265,14 +275,14 @@ func Test_compiler_spotbugs_makeprg()
       execute 'edit ' .. type_file
       compiler spotbugs
       let result = s:SpotBugsParseFilterMakePrg('Xspotbugs', &l:makeprg)
-      call assert_equal(results[type_file].sourcepath, result.sourcepath)
+      call assert_equal(results[type_file].Sourcepath(), result.sourcepath)
       call assert_equal(results[type_file].classfiles, result.classfiles)
       bwipeout
 
       execute 'edit ' .. package_file
       compiler spotbugs
       let result = s:SpotBugsParseFilterMakePrg('Xspotbugs', &l:makeprg)
-      call assert_equal(results[package_file].sourcepath, result.sourcepath)
+      call assert_equal(results[package_file].Sourcepath(), result.sourcepath)
       call assert_equal(results[package_file].classfiles, result.classfiles)
       bwipeout
     endfor

--- a/src/testdir/test_compiler.vim
+++ b/src/testdir/test_compiler.vim
@@ -410,7 +410,17 @@ func Test_compiler_spotbugs_properties()
     " Some ":autocmd"s with one of "PreCompiler*Action", "PostCompilerAction".
     call assert_true(exists('#java_spotbugs'))
     call assert_true(exists('#java_spotbugs#Syntax'))
-    call assert_true(exists('#java_spotbugs#BufWritePost'))
+    call assert_true(exists('#java_spotbugs#User'))
+    call assert_equal(2, exists(':SpotBugsDefineBufferAutocmd'))
+    SpotBugsDefineBufferAutocmd SigUSR1 User SigUSR1 User
+    call assert_true(exists('#java_spotbugs#SigUSR1'))
+    call assert_true(exists('#java_spotbugs#Syntax'))
+    call assert_true(exists('#java_spotbugs#User'))
+    call assert_equal(2, exists(':SpotBugsRemoveBufferAutocmd'))
+    SpotBugsRemoveBufferAutocmd SigUSR1 User SigUSR1 User
+    call assert_false(exists('#java_spotbugs#SigUSR1'))
+    call assert_true(exists('#java_spotbugs#Syntax'))
+    call assert_true(exists('#java_spotbugs#User'))
 
     let s:spotbugs_results.preActionDone = 0
     let s:spotbugs_results.preTestActionDone = 0
@@ -441,7 +451,7 @@ func Test_compiler_spotbugs_properties()
     let g:spotbugs_properties.testSourceDirPath = ['tests']
     let g:spotbugs_properties.testClassDirPath = ['tests']
 
-    doautocmd java_spotbugs BufWritePost
+    doautocmd java_spotbugs User
     " No match: "type_file !~# 'src/main/java'" (with old "*DirPath" values
     " cached).
     call assert_false(s:spotbugs_results.preActionDone)
@@ -461,7 +471,7 @@ func Test_compiler_spotbugs_properties()
     doautocmd FileType
 
     call assert_true(exists('b:spotbugs_syntax_once'))
-    doautocmd java_spotbugs BufWritePost
+    doautocmd java_spotbugs User
     " A match: "type_file =~# 'Xspotbugs/src'" (with new "*DirPath" values
     " cached).
     call assert_true(s:spotbugs_results.preActionDone)
@@ -494,7 +504,7 @@ func Test_compiler_spotbugs_properties()
     call assert_equal('java', &l:filetype)
     call assert_true(exists('#java_spotbugs'))
     call assert_true(exists('#java_spotbugs#Syntax'))
-    call assert_true(exists('#java_spotbugs#BufWritePost'))
+    call assert_true(exists('#java_spotbugs#User'))
     call assert_fails('doautocmd java_spotbugs Syntax', 'Oops')
     call assert_false(exists('#java_spotbugs#Syntax'))
     " No match: "test_file !~# 'Xspotbugs/src'".
@@ -516,7 +526,7 @@ func Test_compiler_spotbugs_properties()
     doautocmd FileType
 
     call assert_true(exists('b:spotbugs_syntax_once'))
-    doautocmd java_spotbugs BufWritePost
+    doautocmd java_spotbugs User
     " No match: "test_file !~# 'Xspotbugs/src'".
     call assert_false(s:spotbugs_results.preActionDone)
     " A match: "test_file =~# 'tests'".

--- a/src/testdir/test_compiler.vim
+++ b/src/testdir/test_compiler.vim
@@ -229,8 +229,8 @@ func Test_compiler_spotbugs_makeprg()
 
   " MAKE CLASS FILES DISCOVERABLE!
   let g:spotbugs_properties = {
-    \ 'sourceDirPath': 'src/tests',
-    \ 'classDirPath': 'tests',
+      \ 'sourceDirPath': ['src/tests'],
+      \ 'classDirPath': ['tests'],
   \ }
 
   call assert_true(has_key(s:SpotBugsParseFilterMakePrg('Xspotbugs', ''), 'sourcepath'))


### PR DESCRIPTION

[BREAKING CHANGES]

* Support multiple source- and class-file search paths.  The  
  type for `*DirPath` values of `g:spotbugs_properties` is  
  now `list of strings` NOT `string`.

* Keep `spotbugs#DefaultPreCompilerTestAction()` defined but  
  do not assign its Funcref to the `PreCompilerTestAction`  
  key of `g:spotbugs_properties`: there are no default and  
  there can only be introduced arbitrary `*sourceDirPath`  
  entries; therefore, this assignment is confusing at best,  
  given that the function's implementation delegates to  
  whatever `PreCompilerAction` is.

* Replace `BufWritePost` with `User` `:autocmd`s.

* Do not define a `Syntax` `:autocmd` for empty buffers.


[FIXES AND IMPROVEMENTS]

* Test event-driving properties of SpotBugs.

* Only attempt to run a post-compiler action in the absence  
  of failures for a pre-compiler action.  Note that warnings  
  and failures are treated alike (?!) by the Javac compiler,  
  so when previews are tried out with `--enable-preview`,  
  remember about passing `-Xlint:-preview` too to also let  
  SpotBugs have a go.

* Strive to not leave behind a fire-once `Syntax` `:autocmd`    
  for a Java buffer whenever an arbitrary pre-compiler  
  action errors out.

* Properly group conditional operators when testing for key  
  entries in a user-defined variable.

* Also test whether `javaExternal` is defined when choosing  
  an implementation for source-file parsing.

* Immediately resolve function names for defined actions.

* Allow for the possibility of relative source pathnames  
  passed as arguments to Vim for the Javac default actions,  
  and the necessity to have them properly reconciled when  
  the current working directory is changed.

* Do not expect users to remember or know that new source  
  files ‘must be’ `:argadd`'d to be then known to the Javac  
  default actions; so collect the names of Java-file buffers  
  and Java-file Vim arguments; and let users providing the  
  `@sources` file-lists in the `g:javac_makeprg_params`  
  variable update these file-lists themselves.

* Support `b:` and `g:spotbugs_properties` variables.

* Support Vim commands proficient in `&makeprg`.

* Recognise alternative paths for unsupported directory  
  names.

* Introduce API commands.

  Two user commands are provided to toggle actions for  
  buffer-local autocommands:
  - `SpotBugsRemoveBufferAutocmd`;
  - `SpotBugsDefineBufferAutocmd`.

  For example, try in `~/.vim/after/ftplugin/java.vim`:

  ```vim
  if exists(':SpotBugsDefineBufferAutocmd') == 2
          SpotBugsDefineBufferAutocmd BufWritePost SigUSR1
  endif
  ```

  And `:doautocmd java_spotbugs User` can be manually used  
  at will.
