### PR TITLE
Create vietnamese.txt and update Vietnamese localization messages

### DIFF
--- a/runtime/doc/Make_all.mak
+++ b/runtime/doc/Make_all.mak
@@ -152,6 +152,7 @@ DOCS = \
 	vim9.txt \
 	vim9class.txt \
 	visual.txt \
+	vietnamese.txt \
 	windows.txt \
 	workshop.txt
 
@@ -303,6 +304,7 @@ HTMLS = \
 	version8.html \
 	version9.html \
 	vi_diff.html \
+	vietnamese.html \
 	vimindex.html \
 	vim9.html \
 	vim9class.html \

--- a/runtime/doc/Makefile
+++ b/runtime/doc/Makefile
@@ -10,7 +10,7 @@ VIMPROG = ../../src/vim
 
 # include the config.mk from the source directory.  It's only needed to set
 # AWK, used for "make html".  Comment this out if the include gives problems.
-include ../../src/auto/config.mk
+# include ../../src/auto/config.mk
 
 # Common components
 include Make_all.mak
@@ -149,6 +149,9 @@ os_risc.txt:
 	touch $@
 
 os_win32.txt:
+	touch $@
+
+vietnamese.txt:
 	touch $@
 
 # In *BSD, the variable '$<' is used in suffix-transformation rules (in GNU this

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -2043,7 +2043,17 @@ $quote	eval.txt	/*$quote*
 :&	change.txt	/*:&*
 :&&	change.txt	/*:&&*
 :'	cmdline.txt	/*:'*
-:++	vim9.txt	/*:++*
+:++	vim9.txt	/*:++
+vietnamese     vietnamese.txt  /*vietnamese*
+vietnamese-ime_diff    vietnamese.txt  /*vietnamese-ime_diff*
+vietnamese-intro       vietnamese.txt  /*vietnamese-intro*
+vietnamese-keymap      vietnamese.txt  /*vietnamese-keymap*
+vietnamese-l18n        vietnamese.txt  /*vietnamese-l18n*
+vietnamese-telex_utf-8 vietnamese.txt  /*vietnamese-telex_utf-8*
+vietnamese-viqr_utf-8  vietnamese.txt  /*vietnamese-viqr_utf-8*
+vietnamese-vni_utf-8   vietnamese.txt  /*vietnamese-vni_utf-8*
+vietnamese.txt vietnamese.txt  /*vietnamese.txt*
+*
 :,	cmdline.txt	/*:,*
 :--	vim9.txt	/*:--*
 :.	cmdline.txt	/*:.*
@@ -5786,6 +5796,7 @@ V	visual.txt	/*V*
 VIMINIT	starting.txt	/*VIMINIT*
 VMS	os_vms.txt	/*VMS*
 Vi	intro.txt	/*Vi*
+Vietnamese     vietnamese.txt  /*Vietnamese*
 View	starting.txt	/*View*
 Vim9	vim9.txt	/*Vim9*
 Vim9-abstract-class	vim9class.txt	/*Vim9-abstract-class*
@@ -11241,6 +11252,15 @@ vi-features	vi_diff.txt	/*vi-features*
 vi:	options.txt	/*vi:*
 vi_diff.txt	vi_diff.txt	/*vi_diff.txt*
 vib	motion.txt	/*vib*
+vietnamese     vietnamese.txt  /*vietnamese*
+vietnamese-ime_diff    vietnamese.txt  /*vietnamese-ime_diff*
+vietnamese-intro       vietnamese.txt  /*vietnamese-intro*
+vietnamese-keymap      vietnamese.txt  /*vietnamese-keymap*
+vietnamese-l18n        vietnamese.txt  /*vietnamese-l18n*
+vietnamese-telex_utf-8 vietnamese.txt  /*vietnamese-telex_utf-8*
+vietnamese-viqr_utf-8  vietnamese.txt  /*vietnamese-viqr_utf-8*
+vietnamese-vni_utf-8   vietnamese.txt  /*vietnamese-vni_utf-8*
+vietnamese.txt vietnamese.txt  /*vietnamese.txt*
 view	starting.txt	/*view*
 view-diffs	diff.txt	/*view-diffs*
 view-file	starting.txt	/*view-file*

--- a/runtime/doc/vietnamese.txt
+++ b/runtime/doc/vietnamese.txt
@@ -1,0 +1,86 @@
+*vietnamese.txt*   For Vim version 9.1.  Last change: 2024 Dec 02
+
+
+		  VIM REFERENCE MANUAL    by Phạm Bình An
+
+
+Vietnamese language support in Vim		*vietnamese* *Vietnamese*
+
+1. Introduction				  |vietnamese-intro|
+2. Vietnamese keymaps			  |vietnamese-keymap|
+3. Localization				  |vietnamese-l18n|
+
+===============================================================================
+1. Introduction
+							*vietnamese-intro*
+
+Vim supports Vietnamese language in the following ways:
+
+- Built-in |vietnamese-keymap|, which allows you to type Vietnamese characters
+  in |Insert-mode| and |search-commands| using US keyboard layout.
+- Localization in Vietnamese. See |vietnamese-l18n|
+
+===============================================================================
+2. Vietnamese keymaps
+							*vietnamese-keymap*
+
+To switch between languages you can use your system native keyboard switcher,
+or use one of the Vietnamese keymaps included in the Vim distribution, like
+below >
+    :set keymap=vietnamese-telex_utf-8
+<
+See |'keymap'| for more information.
+
+In the latter case, you can type Vietnamese even if you do not have a
+Vietnamese input method engine (IME) or you want Vim to be independent from a
+system-wide keyboard settings (when |'imdisable'| is set). You can also |:map|
+a key to switch between keyboards.
+
+Vim comes with the following Vietnamese keymaps:
+- *vietnamese-telex_utf-8*	Telex input method, |UTF-8| encoding.
+- *vietnamese-viqr_utf-8*	VIQR input method, |UTF-8| encoding.
+- *vietnamese-vni_utf-8*	VNI input method, |UTF-8| encoding.
+
+                                                   *vietnamese-ime_diff*
+
+Since these keymaps were designed to be minimalistic, they do not support all
+features of the corresponding input methods. The differences are described
+below:
+
+- You can only type each character individually, entering the base letter first
+  and then the diacritics later.  For example, to type the word `nến` using
+  |vietnamese-vni_utf-8|, you must type `ne61n`, not `nen61` or `ne6n1`
+- For characters with more than 1 diacritic, you need to type vowel mark before
+  tone mark. For example, to type `ồ` using |vietnamese-telex_utf-8|, you need
+  to type `oof`, not `ofo`.
+- With |vietnamese-telex_utf-8|, you need to type all uppercase letters to
+  produce uppercase characters with diacritics. For example, `Ừ` must be typed
+  as `UWF`.
+- With |vietnamese-telex_utf-8|, the escape character `\` from VNI is added,
+  hence the confusing `ooo` input to type `oo` is removed, which could lead to
+  ambiguities.  For example, to type the word `Đoòng`, you would type
+  `DDo\ofng`.
+- Simple Telex (both v1 and v2), including the `w[]{}` style, is not
+  supported.
+- Removing diacritics using `z` in Telex or `0` in VNI and VIQR is not supported.
+
+===============================================================================
+3. Localization
+							*vietnamese-l18n*
+
+Vim |messages| are also available in Vietnamese.  If you wish to see messages in
+Vietnamese, you can run the command |:language| with an argument being the name
+of the Vietnamese locale.  For example, >
+	:language vi_VN
+< or >
+	:language vi_VN.utf-8
+<
+Note that the name of the Vietnamese locale may vary depending on your system.
+See |mbyte-first| for details.
+
+|vimtutor| is also available in Vietnamese. To start Vimtutor in Vietnamese,
+run the following command in terminal: >sh
+	vimtutor vi
+<
+===============================================================================
+vim:tw=78:ts=8:noet:ft=help:norl:

--- a/src/po/vi.po
+++ b/src/po/vi.po
@@ -195,8 +195,7 @@ msgid "E100: No other buffer in diff mode"
 msgstr "E100: Không còn bộ đệm trong chế độ khác biệt (diff) nào nữa"
 
 msgid "E101: More than two buffers in diff mode, don't know which one to use"
-msgstr ""
-"E101: Có nhiều hơn hai bộ đệm trong chế độ khác biệt (diff), không biết chọn"
+msgstr "E101: Có nhiều hơn hai bộ đệm trong chế độ khác biệt (diff), không biết nên chọn cái nào"
 
 #, c-format
 msgid "E102: Can't find buffer \"%s\""
@@ -5230,3 +5229,9 @@ msgstr "E449: Nhận được một biểu thức không cho phép"
 
 msgid "E463: Region is guarded, cannot modify"
 msgstr "E463: Không thể thay đổi vùng đã được bảo vệ"
+
+msgid "No tutorial with that name found"
+msgstr "Không tìm thấy hướng dẫn (tutorial) có tên đó"
+
+msgid "Only one argument accepted (check spaces)"
+msgstr "Chỉ chấp nhận một tham số (vui lòng kiểm tra dấu cách)"


### PR DESCRIPTION
## 1. Create vietnamese.txt

### Why?
The Vietnamese keymaps in Vim is quite different from corresponding input methods that Vietnamese people use, so I think there should be a help document that tell users these differences

## 2. Add Vietnamese translation for 2 messages:
 ```
No tutorial with that name found
```
```
Only one argument accepted (check spaces)
```
## Other questions
Vim provides Vimtutor for many languages, but there doesn't seem to be a way to open any localized Vimtutor in Vim. The only way I know is using `vimtutor` command in terminal, but it doesn't open the tutor in Vim. So I would like to know if there is a way to open `vimtutor` in Vim actually?