### PR TITLE
defaults: set showcmd by default

### DIFF
--- a/runtime/defaults.vim
+++ b/runtime/defaults.vim
@@ -34,7 +34,6 @@ silent! while 0
 silent! endwhile
 
 set ruler		" show the cursor position all the time
-set showcmd		" display incomplete commands
 
 set ttimeout		" time out for key codes
 set ttimeoutlen=100	" wait up to 100ms after Esc for special key

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -7409,8 +7409,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 		:setlocal showbreak=NONE
 <
 				     *'showcmd'* *'sc'* *'noshowcmd'* *'nosc'*
-'showcmd' 'sc'		boolean	(Vim default: on, off for Unix,
-				       Vi default: off, set in |defaults.vim|)
+'showcmd' 'sc'		boolean	(Vim default: on, Vi default: off)
 			global
 	Show (partial) command in the last line of the screen.  Set this
 	option off if your terminal is slow.

--- a/src/optiondefs.h
+++ b/src/optiondefs.h
@@ -2311,13 +2311,7 @@ static struct vimoption options[] =
 			    {(char_u *)"", (char_u *)0L} SCTX_INIT},
     {"showcmd",	    "sc",   P_BOOL|P_VIM,
 			    (char_u *)&p_sc, PV_NONE, NULL, NULL,
-			    {(char_u *)FALSE,
-#ifdef UNIX
-				(char_u *)FALSE
-#else
-				(char_u *)TRUE
-#endif
-				} SCTX_INIT},
+			    {(char_u *)FALSE, (char_u *)TRUE} SCTX_INIT},
     {"showcmdloc",  "sloc", P_STRING|P_RSTAT,
 			    (char_u *)&p_sloc, PV_NONE, did_set_showcmdloc, expand_set_showcmdloc,
 			    {(char_u *)"last", (char_u *)"last"} SCTX_INIT},


### PR DESCRIPTION
This PR make `showcmd` on by default when using vim.