### PR TITLE
remove completeopt buffer-local in todo

### DIFF
--- a/runtime/doc/todo.txt
+++ b/runtime/doc/todo.txt
@@ -4749,7 +4749,6 @@ Insert mode completion/expansion:
     (Prabir Shrestha, 2017 May 19, #1713)
 -   When 'completeopt' has "noselect" does not insert a newline.
     (Lifepillar, 2017 Apr 23, #1653)
--   Can 'completeopt' be made buffer-local? (#5487)
 -   When complete() first argument is before where insert started and
     'backspace' is Vi compatible, the completion fails.
     (Hirohito Higashi, 2015 Feb 19)


### PR DESCRIPTION
has already implemented by @zeertzjq  on https://github.com/vim/vim/pull/14922