### PR TITLE
defaults: make grepprg more performant on UNIX systems

### DIFF
--- a/src/optiondefs.h
+++ b/src/optiondefs.h
@@ -1147,12 +1147,12 @@ static struct vimoption options[] =
 			    (char_u *)&p_gp, PV_GP, NULL, NULL,
 			    {
 # if defined(MSWIN)
-			    // may be changed to "grep -n" in os_win32.c
+			    // may be changed to "grep -In" in os_win32.c
 			    (char_u *)"findstr /n",
 # elif defined(UNIX)
 			    // Add an extra file name so that grep will always
 			    // insert a file name in the match line.
-			    (char_u *)"grep -n $* /dev/null",
+			    (char_u *)"grep -In $* /dev/null",
 # elif defined(VMS)
 			    (char_u *)"SEARCH/NUMBERS ",
 # else


### PR DESCRIPTION
Looking at neovim defaults I've notice they made some minor changes to the grepprg that can be benefitial for better performance while grepping.

Add `-I` on UNIX to prevent grep to search through binary files.

> `-I`: Process a binary file as if it did not contain matching data; this is equivalent to the --binary-files=without-match option.
> -- Grep Man Page

They also include `-H` to making sure grep will always print the filename of the searched files. But I don't know if it is a good idea include this one also because we cannot assume GNU grep on every UNIX system.

> `-H`, `--with-filename`: Print the file name for each match.  This is the default when there is more than one file to search.  This is a GNU extension.
