### PR TITLE
Support passing boolean argument to digraph_getlist() in a vim9script

### DIFF
--- a/src/digraph.c
+++ b/src/digraph.c
@@ -2115,18 +2115,15 @@ f_digraph_getlist(typval_T *argvars, typval_T *rettv)
 # ifdef FEAT_DIGRAPHS
     int     flag_list_all;
 
-    if (in_vim9script() && check_for_opt_bool_arg(argvars, 0) == FAIL)
+    if (check_for_opt_bool_arg(argvars, 0) == FAIL)
 	return;
 
     if (argvars[0].v_type == VAR_UNKNOWN)
 	flag_list_all = FALSE;
     else
     {
-	int	    error = FALSE;
-	varnumber_T flag = tv_get_number_chk(&argvars[0], &error);
+	varnumber_T flag = tv_get_bool(&argvars[0]);
 
-	if (error)
-	    return;
 	flag_list_all = flag ? TRUE : FALSE;
     }
 

--- a/src/testdir/test_digraph.vim
+++ b/src/testdir/test_digraph.vim
@@ -605,8 +605,10 @@ func Test_digraph_getlist_function()
   " of digraphs returned.
   call assert_equal(digraph_getlist()->len(), digraph_getlist(0)->len())
   call assert_notequal(digraph_getlist()->len(), digraph_getlist(1)->len())
+  call assert_equal(digraph_getlist()->len(), digraph_getlist(v:false)->len())
+  call assert_notequal(digraph_getlist()->len(), digraph_getlist(v:true)->len())
 
-  call assert_fails('call digraph_getlist(0z12)', 'E974: Using a Blob as a Number')
+  call assert_fails('call digraph_getlist(0z12)', 'E1212: Bool required for argument 1')
 endfunc
 
 

--- a/src/testdir/test_vim9_builtin.vim
+++ b/src/testdir/test_vim9_builtin.vim
@@ -963,6 +963,18 @@ enddef
 def Test_digraph_getlist()
   v9.CheckSourceDefAndScriptFailure(['digraph_getlist(10)'], ['E1013: Argument 1: type mismatch, expected bool but got number', 'E1212: Bool required for argument 1'])
   v9.CheckSourceDefAndScriptFailure(['digraph_getlist("")'], ['E1013: Argument 1: type mismatch, expected bool but got string', 'E1212: Bool required for argument 1'])
+
+  var lines =<< trim END
+    var l = digraph_getlist(true)
+    assert_notequal([], l)
+    l = digraph_getlist(false)
+    assert_equal([], l)
+    l = digraph_getlist(1)
+    assert_notequal([], l)
+    l = digraph_getlist(0)
+    assert_equal([], l)
+  END
+  v9.CheckSourceDefAndScriptSuccess(lines)
 enddef
 
 def Test_digraph_set()


### PR DESCRIPTION

Fixes the issue reported in #16154.