### PR TITLE
Proposed fixes for issues found by OpenScanHub

### DIFF
--- a/src/spell.c
+++ b/src/spell.c
@@ -3829,7 +3829,7 @@ spell_soundfold_wsal(slang_T *slang, char_u *inword, char_u *res)
 			    c = *ws;
 			if (strstr((char *)s, "^^") != NULL)
 			{
-			    if (c != NUL)
+			    if (c != NUL && reslen < MAXWLEN)
 				wres[reslen++] = c;
 			    mch_memmove(word, word + i + 1,
 				       sizeof(int) * (wordlen - (i + 1) + 1));

--- a/src/vim9class.c
+++ b/src/vim9class.c
@@ -3313,7 +3313,7 @@ class_defining_member(class_T *cl, char_u *name, size_t len, ocmember_T **p_m)
 	    if (( m = class_member_lookup(super, name, len, NULL)) != NULL)
 	    {
 		cl_tmp = super;
-		vartype = VAR_OBJECT;
+		vartype = VAR_CLASS;
 	    }
 	}
 	if (cl_tmp == NULL)


### PR DESCRIPTION
Hi,

we in Fedora and CentOS Stream run static and dynamic analyzer tool called [OpenScanHub](https://github.com/openscanhub/openscanhub) which scans our components in the OS.

I went through its results for Vim and selected 4 possible issues which might be real issues (I was not able to find a reason why it can't happen, but some circumstances were wild...) - the PR is split into several commits based on which found issues it fixes.

[src/spell.c: Protect wres from possible buffer overflow](https://github.com/vim/vim/commit/d5e68641a8aed5b5ef8a425af496c153582bb8b1) - here is probably some hidden meaning why the execution can't reach the buffer overflow, but it was not clear from the code, so a simple check should do the trick.

[src/json.c: Protect nr from integer overflow](https://github.com/vim/vim/commit/95d4167c0aa788a7684b785cd2581765f48d5cef) - IMHO might happen if Vim reads invalid JSON, which includes too large number which would cause the integer overflow.

[src/vim9class.c: Fix typo](https://github.com/vim/vim/commit/ca9ab72da763d782de71826fc380ab65b582642b) - this looked like a typo - the code tries to find the class where the member is defined, and IMO the second if is for class variables, so the vartype should be VAR_CLASS.

Does it make sense to fix these issues or they are false positives? If it makes sense to fix them, it would be great if the PR was merged into the project.

Thank you in advance!

Zdenek