### PR TITLE
Problem: printoptions:portrait does not change postscript Orientation

### DIFF
--- a/src/hardcopy.c
+++ b/src/hardcopy.c
@@ -2742,7 +2742,7 @@ mch_print_begin(prt_settings_T *psettings)
 
     prt_dsc_textline("CreationDate", get_ctime(time(NULL), FALSE));
     prt_dsc_textline("DocumentData", "Clean8Bit");
-    prt_dsc_textline("Orientation", "Portrait");
+    prt_dsc_textline("Orientation", prt_portrait ? "Portrait" : "Landscape");
     prt_dsc_atend("Pages");
     prt_dsc_textline("PageOrder", "Ascend");
     // The bbox does not change with orientation - it is always in the default

--- a/src/testdir/test_hardcopy.vim
+++ b/src/testdir/test_hardcopy.vim
@@ -209,4 +209,31 @@ func Test_illegal_byte()
   call delete('Xpstest')
 endfunc
 
+func Test_printoptions_portrait()
+  CheckFeature postscript
+  edit test_hardcopy.vim
+  syn on
+
+  set printoptions=portrait:y
+  1,50hardcopy > Xhardcopy_printoptions_portrait
+  let lines = readfile('Xhardcopy_printoptions_portrait')
+  call assert_match('Orientation: Portrait', lines[6])
+  call assert_match('BoundingBox: 59 49 564 800', lines[9])
+  call assert_match('DocumentMedia: A4', lines[10])
+  call assert_match('PageMedia: A4', lines[24])
+  call delete('Xhardcopy_printoptions')
+
+  set printoptions=portrait:n
+  1,50hardcopy > Xhardcopy_printoptions_portrait
+  let lines = readfile('Xhardcopy_printoptions_portrait')
+  call assert_match('Orientation: Landscape', lines[6])
+  call assert_match('BoundingBox: 59 42 590 756', lines[9])
+  call assert_match('DocumentMedia: A4', lines[10])
+  call assert_match('PageMedia: A4', lines[24])
+  call delete('Xhardcopy_printoptions')
+
+  set printoptions&
+  bwipe
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  printoptions:portrait does not change postscript Orientation
Solution: Set Orientation depending on portrait suboption.

fixes: #16156