### PR TITLE
Fix integer overflow bug in `xxd -autoskip`

### DIFF
--- a/src/xxd/xxd.c
+++ b/src/xxd/xxd.c
@@ -530,7 +530,7 @@ huntype(
 xxdline(FILE *fp, char *l, int nz)
 {
   static char z[LLEN+1];
-  static int zero_seen = 0;
+  static signed char zero_seen = 0;
 
   if (!nz && zero_seen == 1)
     strcpy(z, l);
@@ -551,6 +551,11 @@ xxdline(FILE *fp, char *l, int nz)
       if (nz)
 	zero_seen = 0;
     }
+
+  /* If zero_seen > 3, then its exact value doesn't matter, so long as it
+   * remains >3 and incrementing it will not cause overflow. */
+  if (zero_seen >= 0x7F)
+    zero_seen = 4;
 }
 
 /* This is an EBCDIC to ASCII conversion table */


### PR DESCRIPTION
When encountering INT_MAX lines of zeros in the input, xxd overflows an `int` counter, resulting in undefined behaviour.  Usually, this results in a spurious line of zeros being output every 2**32 lines, while the "*" line is lost, as is the final line of zeros that delineate the file size if at end of file.

Since xxd doesn't need to know exactly how many lines are being skipped when it's > 3, the exact value of the line counter `zero_seen` doesn't matter and it can simply be reduced in value before the overflow occurs.

Changing the type of `zero_seen` to `signed char` is not important, and done only to make the bug triggerable with more modest file sizes, and therefore more convenient to test the fix.

Fixes https://github.com/vim/vim/issues/16170