### PR TITLE
Set default guifont to 12pt

### DIFF
--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -160,7 +160,7 @@ static const GtkTargetEntry dnd_targets[] =
  * "Monospace" is a standard font alias that should be present
  * on all proper Pango/fontconfig installations.
  */
-# define DEFAULT_FONT	"Monospace 10"
+# define DEFAULT_FONT	"Monospace 12"
 
 #if defined(FEAT_GUI_GNOME) && defined(FEAT_SESSION)
 # define USE_GNOME_SESSION

--- a/src/os_mswin.c
+++ b/src/os_mswin.c
@@ -2729,8 +2729,8 @@ quality_id2name(DWORD id)
 }
 
 // The default font height in 100% scaling (96dpi).
-// (-12 in 96dpi equates to roughly 9pt)
-#define DEFAULT_FONT_HEIGHT	(-12)
+// (-16 in 96dpi equates to roughly 12pt)
+#define DEFAULT_FONT_HEIGHT	(-16)
 
 static const LOGFONTW s_lfDefault =
 {

--- a/src/testdir/runtest.vim
+++ b/src/testdir/runtest.vim
@@ -56,6 +56,10 @@ silent! endwhile
 " In the GUI we can always change the screen size.
 if has('gui_running')
   set columns=80 lines=25
+  if has('gui_gtk')
+    " to keep screendump size unchanged
+    set guifont=Monospace\ 10
+  endif
 endif
 
 " Check that the screen size is at least 24 x 80 characters.

--- a/src/testdir/runtest.vim
+++ b/src/testdir/runtest.vim
@@ -55,11 +55,11 @@ silent! endwhile
 
 " In the GUI we can always change the screen size.
 if has('gui_running')
-  set columns=80 lines=25
   if has('gui_gtk')
     " to keep screendump size unchanged
     set guifont=Monospace\ 10
   endif
+  set columns=80 lines=25
 endif
 
 " Check that the screen size is at least 24 x 80 characters.

--- a/src/testdir/test_gui.vim
+++ b/src/testdir/test_gui.vim
@@ -105,8 +105,8 @@ func Test_getfontname_without_arg()
     let pat = '\(7x13\)\|\(\c-Misc-Fixed-Medium-R-Normal--13-120-75-75-C-70-ISO8859-1\)'
     call assert_match(pat, fname)
   elseif has('gui_gtk2') || has('gui_gnome') || has('gui_gtk3')
-    " 'expected' is DEFAULT_FONT of gui_gtk_x11.c.
-    call assert_equal('Monospace 12', fname)
+    " 'expected' is DEFAULT_FONT of gui_gtk_x11.c (any size)
+    call assert_match('Monospace', fname)
   endif
 endfunc
 
@@ -426,7 +426,7 @@ func Test_set_guifont()
 
     " Empty list. Should fallback to the built-in default.
     set guifont=
-    call assert_equal('Monospace 12', getfontname())
+    call assert_match('Monospace', getfontname())
   endif
 
   if has('xfontset')

--- a/src/testdir/test_gui.vim
+++ b/src/testdir/test_gui.vim
@@ -106,7 +106,7 @@ func Test_getfontname_without_arg()
     call assert_match(pat, fname)
   elseif has('gui_gtk2') || has('gui_gnome') || has('gui_gtk3')
     " 'expected' is DEFAULT_FONT of gui_gtk_x11.c.
-    call assert_equal('Monospace 10', fname)
+    call assert_equal('Monospace 12', fname)
   endif
 endfunc
 
@@ -426,7 +426,7 @@ func Test_set_guifont()
 
     " Empty list. Should fallback to the built-in default.
     set guifont=
-    call assert_equal('Monospace 10', getfontname())
+    call assert_equal('Monospace 12', getfontname())
   endif
 
   if has('xfontset')
@@ -613,7 +613,7 @@ func Test_expand_guifont()
 
     " Test recalling default and existing option
     set guifont=
-    call assert_equal('Monospace\ 10', getcompletion('set guifont=', 'cmdline')[0])
+    call assert_equal('Monospace\ 12', getcompletion('set guifont=', 'cmdline')[0])
     set guifont=Monospace\ 9
     call assert_equal('Monospace\ 9', getcompletion('set guifont=', 'cmdline')[0])
 

--- a/src/testdir/test_gui.vim
+++ b/src/testdir/test_gui.vim
@@ -106,7 +106,7 @@ func Test_getfontname_without_arg()
     call assert_match(pat, fname)
   elseif has('gui_gtk2') || has('gui_gnome') || has('gui_gtk3')
     " 'expected' is DEFAULT_FONT of gui_gtk_x11.c (any size)
-    call assert_match('Monospace', fname)
+    call assert_match('^Monospace\>', fname)
   endif
 endfunc
 
@@ -426,7 +426,7 @@ func Test_set_guifont()
 
     " Empty list. Should fallback to the built-in default.
     set guifont=
-    call assert_match('Monospace', getfontname())
+    call assert_match('^Monospace\>', getfontname())
   endif
 
   if has('xfontset')
@@ -613,7 +613,7 @@ func Test_expand_guifont()
 
     " Test recalling default and existing option
     set guifont=
-    call assert_equal('Monospace\ 12', getcompletion('set guifont=', 'cmdline')[0])
+    call assert_match('^Monospace\>', getcompletion('set guifont=', 'cmdline')[0])
     set guifont=Monospace\ 9
     call assert_equal('Monospace\ 9', getcompletion('set guifont=', 'cmdline')[0])
 

--- a/src/testdir/test_highlight.vim
+++ b/src/testdir/test_highlight.vim
@@ -782,7 +782,7 @@ func Test_1_highlight_Normalgroup_exists()
     call assert_match('hi Normal\s*clear', hlNormal)
   elseif has('gui_gtk2') || has('gui_gnome') || has('gui_gtk3')
     " expect is DEFAULT_FONT of gui_gtk_x11.c
-    call assert_match('hi Normal\s*font=Monospace 10', hlNormal)
+    call assert_match('hi Normal\s*font=Monospace 12', hlNormal)
   elseif has('gui_motif')
     " expect is DEFAULT_FONT of gui_x11.c
     call assert_match('hi Normal\s*font=7x13', hlNormal)

--- a/src/testdir/test_highlight.vim
+++ b/src/testdir/test_highlight.vim
@@ -781,8 +781,8 @@ func Test_1_highlight_Normalgroup_exists()
   if !has('gui_running')
     call assert_match('hi Normal\s*clear', hlNormal)
   elseif has('gui_gtk2') || has('gui_gnome') || has('gui_gtk3')
-    " expect is DEFAULT_FONT of gui_gtk_x11.c
-    call assert_match('hi Normal\s*font=Monospace 12', hlNormal)
+    " expect is DEFAULT_FONT of gui_gtk_x11.c (any size)
+    call assert_match('hi Normal\s*font=Monospace', hlNormal)
   elseif has('gui_motif')
     " expect is DEFAULT_FONT of gui_x11.c
     call assert_match('hi Normal\s*font=7x13', hlNormal)

--- a/src/testdir/test_highlight.vim
+++ b/src/testdir/test_highlight.vim
@@ -782,7 +782,7 @@ func Test_1_highlight_Normalgroup_exists()
     call assert_match('hi Normal\s*clear', hlNormal)
   elseif has('gui_gtk2') || has('gui_gnome') || has('gui_gtk3')
     " expect is DEFAULT_FONT of gui_gtk_x11.c (any size)
-    call assert_match('hi Normal\s*font=Monospace', hlNormal)
+    call assert_match('hi Normal\s*font=Monospace\>', hlNormal)
   elseif has('gui_motif')
     " expect is DEFAULT_FONT of gui_x11.c
     call assert_match('hi Normal\s*font=7x13', hlNormal)


### PR DESCRIPTION
Make default gui font size in Gtk and Windows GVim larger for better user experience

Closes #16172 