### PR TITLE
runtime(typst): add definion lists to formatlistpat

### DIFF
--- a/.github/MAINTAINERS
+++ b/.github/MAINTAINERS
@@ -19,7 +19,7 @@ runtime/autoload/modula2.vim		@dkearns
 runtime/autoload/php.vim		@david-szabo97
 runtime/autoload/rubycomplete.vim	@segfault @dkearns
 runtime/autoload/rust.vim		@lilyball
-runtime/autoload/typst.vim		@gpanders
+runtime/autoload/typst.vim		@saccarosium
 runtime/autoload/xmlformat.vim		@chrisbra
 runtime/autoload/dist/json.vim		@habamax
 runtime/colors/blue.vim			@habamax @romainl @neutaaaaan
@@ -104,7 +104,7 @@ runtime/compiler/tidy.vim		@dkearns
 runtime/compiler/ts-node.vim		@dkearns
 runtime/compiler/tsc.vim		@dkearns
 runtime/compiler/typedoc.vim		@dkearns
-runtime/compiler/typst.vim		@gpanders
+runtime/compiler/typst.vim		@saccarosium
 runtime/compiler/xmllint.vim		@dkearns
 runtime/compiler/xo.vim			@dkearns
 runtime/compiler/yamllint.vim		@romainl
@@ -294,7 +294,7 @@ runtime/ftplugin/toml.vim		@averms
 runtime/ftplugin/tt2html.vim		@petdance
 runtime/ftplugin/typescript.vim		@dkearns
 runtime/ftplugin/typescriptreact.vim	@dkearns
-runtime/ftplugin/typst.vim		@gpanders
+runtime/ftplugin/typst.vim		@saccarosium
 runtime/ftplugin/unison.vim		@chuwy
 runtime/ftplugin/v.vim			@ribru17
 runtime/ftplugin/vdf.vim		@ObserverOfTime
@@ -334,7 +334,7 @@ runtime/indent/freebasic.vim		@dkearns
 runtime/indent/gdscript.vim		@habamax
 runtime/indent/gitconfig.vim		@tpope
 runtime/indent/gitolite.vim		@sitaramc
-runtime/indent/glsl.vim		@gpanders
+runtime/indent/glsl.vim			@gpanders
 runtime/indent/go.vim			@dbarnett
 runtime/indent/gyp.vim			@ObserverOfTime
 runtime/indent/haml.vim			@tpope
@@ -387,7 +387,7 @@ runtime/indent/teraterm.vim		@k-takata
 runtime/indent/terraform.vim		@gpanders
 runtime/indent/thrift.vim		@jiangyinzuo
 runtime/indent/typescript.vim		@HerringtonDarkholme
-runtime/indent/typst.vim		@gpanders
+runtime/indent/typst.vim		@saccarosium
 runtime/indent/vroom.vim		@dbarnett
 runtime/indent/wast.vim			@rhysd
 runtime/indent/xml.vim			@chrisbra

--- a/runtime/autoload/typst.vim
+++ b/runtime/autoload/typst.vim
@@ -1,6 +1,6 @@
 " Language:    Typst
-" Maintainer:  Gregory Anders
-" Last Change: 2024 Nov 02
+" Maintainer:  Luca Saccarola <github.e41mv@aleeas.com>
+" Last Change: 2024 Dec 09
 " Based on:    https://github.com/kaarmu/typst.vim
 
 function! typst#indentexpr() abort

--- a/runtime/compiler/typst.vim
+++ b/runtime/compiler/typst.vim
@@ -1,7 +1,7 @@
 " Vim compiler file
 " Language:    Typst
-" Maintainer:  Gregory Anders
-" Last Change: 2024-07-14
+" Maintainer:  Luca Saccarola <github.e41mv@aleeas.com>
+" Last Change: 2024 Dec 09
 " Based on:    https://github.com/kaarmu/typst.vim
 
 if exists('current_compiler')

--- a/runtime/ftplugin/typst.vim
+++ b/runtime/ftplugin/typst.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin file
 " Language:    Typst
-" Maintainer:  Gregory Anders
-" Last Change: 2024 Dev 01
+" Maintainer:  Luca Saccarola <github.e41mv@aleeas.com>
+" Last Change: 2024 Dec 09
 " Based on:    https://github.com/kaarmu/typst.vim
 
 if exists('b:did_ftplugin')

--- a/runtime/ftplugin/typst.vim
+++ b/runtime/ftplugin/typst.vim
@@ -12,8 +12,10 @@ let b:did_ftplugin = 1
 setlocal commentstring=//\ %s
 setlocal comments=s1:/*,mb:*,ex:*/,://
 setlocal formatoptions+=croqn
+" Numbered Lists
 setlocal formatlistpat=^\\s*\\d\\+[\\]:.)}\\t\ ]\\s*
-setlocal formatlistpat+=\\\|^\\s*[-+\]\\s\\+
+" Unordered (-), Ordered (+) and definiotion (/) Lists
+setlocal formatlistpat+=\\\|^\\s*[-+/\]\\s\\+
 setlocal suffixesadd=.typ
 
 let b:undo_ftplugin = 'setl cms< com< fo< flp< sua<'

--- a/runtime/indent/typst.vim
+++ b/runtime/indent/typst.vim
@@ -1,7 +1,7 @@
 " Vim indent file
 " Language:    Typst
-" Maintainer:  Gregory Anders <greg@gpanders.com>
-" Last Change: 2024-07-14
+" Maintainer:  Luca Saccarola <github.e41mv@aleeas.com>
+" Last Change: 2024 Dec 09
 " Based on:    https://github.com/kaarmu/typst.vim
 
 if exists('b:did_indent')

--- a/runtime/syntax/typst.vim
+++ b/runtime/syntax/typst.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:    Typst
-" Maintainer:  Gregory Anders <greg@gpanders.com>
-" Last Change: 2024 Nov 02
+" Maintainer:  Luca Saccarola <github.e41mv@aleeas.com>
+" Last Change: 2024 Dec 09
 " Based on:    https://github.com/kaarmu/typst.vim
 
 if exists('b:current_syntax')


### PR DESCRIPTION
ping maintainer: @gpanders

Hi,
this PR does the following changes:

- Adds to `formatlistpat` [definitions](https://typst.app/docs/reference/model/terms/) list

```typst
/ definition: hello I'm a definition
```

After this is merged I will make a PR at https://github.com/kaarmu/typst.vim