### PR TITLE
runtime(proto): Add ftplugin script for protobuf filetype

### DIFF
--- a/.github/MAINTAINERS
+++ b/.github/MAINTAINERS
@@ -247,6 +247,7 @@ runtime/ftplugin/pod.vim		@petdance @dkearns
 runtime/ftplugin/poefilter.vim		@ObserverOfTime
 runtime/ftplugin/postscr.vim		@mrdubya
 runtime/ftplugin/prisma.vim		@ribru17
+runtime/ftplugin/proto.vim		@Limero
 runtime/ftplugin/ps1.vim		@heaths
 runtime/ftplugin/ps1xml.vim		@heaths
 runtime/ftplugin/ptx.vim		@jiangyinzuo

--- a/runtime/ftplugin/proto.vim
+++ b/runtime/ftplugin/proto.vim
@@ -1,0 +1,18 @@
+" Vim filetype plugin
+" Language:	Protobuf
+" Maintainer:	David Pedersen <limero@me.com>
+" Last Change:	2024 Dec 09
+
+if exists('b:did_ftplugin')
+  finish
+endif
+let b:did_ftplugin = 1
+
+setlocal formatoptions-=t formatoptions+=croql
+
+setlocal comments=s1:/*,mb:*,ex:*/,://
+setlocal commentstring=//\ %s
+
+let b:undo_ftplugin = "setlocal formatoptions< comments< commentstring<"
+
+" vim: sw=2 sts=2 et


### PR DESCRIPTION
This adds a ftplugin file for handling comments/commenting in protobuf files.

It's mostly the same as the ftplugin for [Go](https://github.com/vim/vim/blob/master/runtime/ftplugin/go.vim), with the expection of adding the extra `formatoptions` from [C](https://github.com/vim/vim/blob/ad3b6a3340a4ab02c1e5bc4a6d6a5fb858b671d3/runtime/ftplugin/c.vim#L24)/[Java](https://github.com/vim/vim/blob/ad3b6a3340a4ab02c1e5bc4a6d6a5fb858b671d3/runtime/ftplugin/java.vim#L73).

From my testing, it should follow the formatting from the official protobuf docs at https://protobuf.dev/programming-guides/proto3/#adding-comments