### PR TITLE
Tiny Vim crashes with buffer completion when 'wildoptions' is "fuzzy"

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -2985,9 +2985,9 @@ ExpandBufnames(
 	    vim_free(patc);
     }
 
-#ifdef FEAT_VIMINFO
     if (!fuzzy)
     {
+#ifdef FEAT_VIMINFO
 	if (matches != NULL)
 	{
 	    int i;
@@ -3007,13 +3007,13 @@ ExpandBufnames(
 	    }
 	    vim_free(matches);
 	}
+#endif
     }
     else
     {
 	if (fuzzymatches_to_strmatches(fuzmatch, file, count, FALSE) == FAIL)
 	    return FAIL;
     }
-#endif
 
     *num_file = count;
     return (count == 0 ? FAIL : OK);


### PR DESCRIPTION
### Preparation
Build **tiny** feature Vim.
```bash
$ cd /path-to-your/vim
$ ./configure --with-features=tiny
$ make -j
```

### Steps to reproduce

1. Start tiny Vim
```bash
$ src/vim --clean a.txt
```
2. Set 'wildoptions' option to `fuzzy`
```vim
set wildoptions=fuzzy
```
3. Do buffer complation. (After typing `:b `, hit the tab key twice)
```vim
:b <Tab><Tab>
```

### Result
Vim crashes.
```
Vim: Caught deadly signal SEGV
Vim: Finished.

Segmentation fault (core dumped)
```

### Cause
- The `file` argument is not updated in the ExpandBufnames() function.
  (The range from `#ifdef FEAT_VIMINFO` to `#endif` is incorrect)

### Expected behavior
Vim doesn't crash.