### PR TITLE
refactor(popupmenu): repalce simply if by MAX/MIN

### DIFF
--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -13,10 +13,6 @@
 
 #include "vim.h"
 
-#ifndef MAX
-# define MAX(x,y) ((x) > (y) ? (x) : (y))
-#endif
-
 // Return value when handling keys in command-line mode.
 #define CMDLINE_NOT_CHANGED	1
 #define CMDLINE_CHANGED		2


### PR DESCRIPTION
Define the MAX/MIN macros. Since we support some older platforms which C compilers may not be smart moder c compiler. This helps reduce unnecessary if statements and redundant ternary expressions. Pre-calculate some expressions by defining variables. Remove unnecessary parentheses. Adjust certain lines to avoid exceeding 80 columns.