### PR TITLE
Fix terminal window issue related scrollback (fix: #16024)

### DIFF
--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -6621,7 +6621,9 @@ gui_mch_draw_part_cursor(int w, int h, guicolor_T color)
     void
 gui_mch_update(void)
 {
-    while (g_main_context_pending(NULL) && !vim_is_input_buf_full())
+    int cnt = 0;	// prevent endless loop
+    while (g_main_context_pending(NULL) && !vim_is_input_buf_full()
+								&& ++cnt < 100)
 	g_main_context_iteration(NULL, TRUE);
 }
 

--- a/src/window.c
+++ b/src/window.c
@@ -5578,6 +5578,10 @@ win_enter_ext(win_T *wp, int flags)
 	did_decrement = TRUE;
     }
 #endif
+#ifdef FEAT_TERMINAL
+    if (bt_terminal(curwin->w_buffer))
+	update_topline();
+#endif
 
     win_fix_current_dir();
 


### PR DESCRIPTION
Fix: #16024

When switching the current window with mouse operations, `update_topline()` is not called, resulting in multiple occurrences of E340 and E315.