### PR TITLE
filetype: Pixi lock files are not recognized

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1873,6 +1873,9 @@ au BufNewFile,BufRead requires/*.txt		setf requirements
 au BufNewFile,BufRead Pipfile			setf toml
 au BufNewFile,BufRead Pipfile.lock		setf json
 
+" Pixi lock
+au BufNewFile,BufRead pixi.lock			setf yaml
+
 " PL/1, PL/I
 au BufNewFile,BufRead *.pli,*.pl1		setf pli
 

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -893,7 +893,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     xslt: ['file.xsl', 'file.xslt'],
     yacc: ['file.yy', 'file.yxx', 'file.y++'],
     yaml: ['file.yaml', 'file.yml', 'file.eyaml', 'any/.bundle/config', '.clangd', '.clang-format', '.clang-tidy', 'file.mplstyle', 'matplotlibrc', 'yarn.lock',
-           '/home/user/.kube/config', '.condarc', 'condarc'],
+           '/home/user/.kube/config', '.condarc', 'condarc', 'pixi.lock'],
     yang: ['file.yang'],
     yuck: ['file.yuck'],
     z8a: ['file.z8a'],


### PR DESCRIPTION
Problem:  filetype: Pixi lock files are not recognized
Solution: Recognized pixi.lock file as yaml filetype

Ref https://pixi.sh/latest/features/lockfile/