### PR TITLE
Fix Test_shortmess_F3() sometimes fails

### DIFF
--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -1365,21 +1365,13 @@ func Test_shortmess_F3()
   echo ''
 
   call writefile(['bar'], 'X_dummy')
-  if has('nanotime')
-    sleep 10m
-  else
-    sleep 2
-  endif
+  call WaitFor("readfile('X_dummy')[0] == 'bar'")
   bprev
   call assert_equal('', Screenline(&lines))
   call assert_equal(['bar'], getbufline('X_dummy', 1, '$'))
 
   call writefile(['baz'], 'X_dummy')
-  if has('nanotime')
-    sleep 10m
-  else
-    sleep 2
-  endif
+  call WaitFor("readfile('X_dummy')[0] == 'baz'")
   checktime
   call assert_equal('', Screenline(&lines))
   call assert_equal(['baz'], getbufline('X_dummy', 1, '$'))

--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -1364,22 +1364,22 @@ func Test_shortmess_F3()
   set shortmess+=F
   echo ''
 
+  call writefile(['bar'], 'X_dummy')
   if has('nanotime')
     sleep 10m
   else
     sleep 2
   endif
-  call writefile(['bar'], 'X_dummy')
   bprev
   call assert_equal('', Screenline(&lines))
   call assert_equal(['bar'], getbufline('X_dummy', 1, '$'))
 
+  call writefile(['baz'], 'X_dummy')
   if has('nanotime')
     sleep 10m
   else
     sleep 2
   endif
-  call writefile(['baz'], 'X_dummy')
   checktime
   call assert_equal('', Screenline(&lines))
   call assert_equal(['baz'], getbufline('X_dummy', 1, '$'))


### PR DESCRIPTION
```
From test_options.vim:
Found errors in Test_shortmess_F3():
command line..script D:/a/vim/vim/src/testdir/runtest.vim[617]..function RunTheTest[57]..Test_shortmess_F3 line 29: Expected ['baz'] but got ['bar']
NMAKE : fatal error U1077: 'if exist test.log ( type test.log & exit /b 1 )' : return code '0x1'
Stop.
Error: Process completed with exit code 1.
```

I think it can be resolved by using WaitFor() instead of waiting.