### PR TITLE
(help) Add support language annotation in codeblocks

### DIFF
--- a/runtime/doc/helphelp.txt
+++ b/runtime/doc/helphelp.txt
@@ -438,6 +438,13 @@ also implicitly stops the block of ex-commands before it.  E.g. >
     endfunction
 <
 
+To add annotation in the block, place the annotation(ex: vim) after a greater
+than (>) character. E.g. >vim
+    function Example_Func()
+	echo "Example"
+    endfunction
+<
+
 The following are highlighted differently in a Vim help file:
   - a special key name expressed either in <> notation as in <PageDown>, or
     as a Ctrl character as in CTRL-X

--- a/runtime/doc/helphelp.txt
+++ b/runtime/doc/helphelp.txt
@@ -438,7 +438,7 @@ also implicitly stops the block of ex-commands before it.  E.g. >
     endfunction
 <
 
-To add annotation in the block, place the annotation(ex: vim) after a greater
+To add annotation in the block, place the annotation (ex: vim) after a greater
 than (>) character. E.g. >vim
     function Example_Func()
 	echo "Example"

--- a/runtime/doc/helphelp.txt
+++ b/runtime/doc/helphelp.txt
@@ -438,12 +438,13 @@ also implicitly stops the block of ex-commands before it.  E.g. >
     endfunction
 <
 
-To add annotation in the block, place the annotation (ex: vim) after a greater
-than (>) character. E.g. >vim
+To add annotation in the block, place the annotation (ex: "vim") after a
+greater than (>) character. E.g. >vim
     function Example_Func()
 	echo "Example"
     endfunction
 <
+NOTE: Currently, only "vim" annotations are syntax highlighted.
 
 The following are highlighted differently in a Vim help file:
   - a special key name expressed either in <> notation as in <PageDown>, or

--- a/runtime/syntax/help.vim
+++ b/runtime/syntax/help.vim
@@ -16,9 +16,18 @@ syn match helpHeadline		"^[A-Z.][-A-Z0-9 .,()_']*?\=\ze\(\s\+\*\|$\)"
 syn match helpSectionDelim	"^===.*===$"
 syn match helpSectionDelim	"^---.*--$"
 if has("conceal")
-  syn region helpExample	matchgroup=helpIgnore start=" >$" start="^>$" end="^[^ \t]"me=e-1 end="^<" concealends
+  syn region helpExample	matchgroup=helpIgnore start=" >[a-z0-9]*$" start="^>[a-z0-9]*$" end="^[^ \t]"me=e-1 end="^<" concealends
+
+  unlet! b:current_syntax
+  silent! syntax include @helpExampleVimScript syntax/vim.vim
+  syntax region helpExampleVimScript
+        \ start=/^>vim$/
+        \ start=/ >vim$/
+        \ end=/^</
+        \ end=/^[^ \t]/me=e-1  concealends
+        \ contains=@helpExampleVimScript keepend
 else
-  syn region helpExample	matchgroup=helpIgnore start=" >$" start="^>$" end="^[^ \t]"me=e-1 end="^<"
+  syn region helpExample	matchgroup=helpIgnore start=" >[a-z0-9]*$" start="^>[a-z0-9]*$" end="^[^ \t]"me=e-1 end="^<"
 endif
 if has("ebcdic")
   syn match helpHyperTextJump	"\\\@<!|[^"*|]\+|" contains=helpBar

--- a/runtime/syntax/help.vim
+++ b/runtime/syntax/help.vim
@@ -15,20 +15,23 @@ set cpo&vim
 syn match helpHeadline		"^[A-Z.][-A-Z0-9 .,()_']*?\=\ze\(\s\+\*\|$\)"
 syn match helpSectionDelim	"^===.*===$"
 syn match helpSectionDelim	"^---.*--$"
+
+unlet! b:current_syntax
+silent! syntax include @helpExampleVimScript syntax/vim.vim
 if has("conceal")
   syn region helpExample	matchgroup=helpIgnore start=" >[a-z0-9]*$" start="^>[a-z0-9]*$" end="^[^ \t]"me=e-1 end="^<" concealends
-
-  unlet! b:current_syntax
-  silent! syntax include @helpExampleVimScript syntax/vim.vim
-  syntax region helpExampleVimScript
-        \ start=/^>vim$/
-        \ start=/ >vim$/
-        \ end=/^</
-        \ end=/^[^ \t]/me=e-1  concealends
+  syn region helpExampleVimScript
+        \ start=/^>vim$/ start=/ >vim$/
+        \ end=/^</ end=/^[^ \t]/me=e-1  concealends
         \ contains=@helpExampleVimScript keepend
 else
   syn region helpExample	matchgroup=helpIgnore start=" >[a-z0-9]*$" start="^>[a-z0-9]*$" end="^[^ \t]"me=e-1 end="^<"
+  syn region helpExampleVimScript
+        \ start=/^>vim$/ start=/ >vim$/
+        \ end=/^</ end=/^[^ \t]/me=e-1
+        \ contains=@helpExampleVimScript keepend
 endif
+
 if has("ebcdic")
   syn match helpHyperTextJump	"\\\@<!|[^"*|]\+|" contains=helpBar
   syn match helpHyperTextEntry	"\*[^"*|]\+\*\s"he=e-1 contains=helpStar


### PR DESCRIPTION
Neovim supports language annotation in help codeblocks.
I think it is useful.

So I have added the support it also in Vim.

And I have added Vim script highlight in help.

![2024-12-15_13-56](https://github.com/user-attachments/assets/4c86eebd-6e86-494a-a3c5-aaa756c4cf0f)