### PR TITLE
Add g:help_example_languages to support language annotation highlighting

### DIFF
--- a/runtime/doc/helphelp.txt
+++ b/runtime/doc/helphelp.txt
@@ -443,7 +443,7 @@ greater than (>) character.  E.g: >lua
 	print("hello")
 <
 Note: uses lua syntax highlighting, if "lua" is in |g:help_example_languages|.
-In default, it's possible to add Vim syntax highlighting support to code
+It's possible to add Vim syntax highlighting support to code
 examples.  E.g: >vim
 	function Example_Func()
 	  echo "Example"

--- a/runtime/doc/helphelp.txt
+++ b/runtime/doc/helphelp.txt
@@ -442,6 +442,7 @@ To add annotation in the block, place the annotation (ex: "lua") after a
 greater than (>) character.  E.g: >lua
 	print("hello")
 <
+Note: uses lua syntax highlighting, if "lua" is in |g:help_example_languages|.
 In default, it's possible to add Vim syntax highlighting support to code
 examples.  E.g: >vim
 	function Example_Func()

--- a/runtime/doc/helphelp.txt
+++ b/runtime/doc/helphelp.txt
@@ -453,8 +453,10 @@ examples.  E.g: >vim
 If you want to change the syntax highlighting in the block, you can
 change it like this: >
 	:let g:help_example_languages = #{ vim: 'vim', sh: 'bash' }
-The key is the annotation marker and the value is the 'syntax' name.
+The key is the annotation marker name and the value is the 'syntax' name.
 When not configured, help files support Vim script highlighting only.
+Note: When setting "g:help_example_languages", if you do not add "vim", Vim
+script syntax highlighting will not be available.
 
 The following are highlighted differently in a Vim help file:
   - a special key name expressed either in <> notation as in <PageDown>, or

--- a/runtime/doc/helphelp.txt
+++ b/runtime/doc/helphelp.txt
@@ -454,6 +454,7 @@ If you want to change the syntax highlighting in the block, you can
 change it like this: >
 	:let g:help_example_languages = #{ vim: 'vim', sh: 'bash' }
 The key is the annotation marker and the value is the 'syntax' name.
+When not configured, help files support Vim script highlighting only.
 
 The following are highlighted differently in a Vim help file:
   - a special key name expressed either in <> notation as in <PageDown>, or

--- a/runtime/doc/helphelp.txt
+++ b/runtime/doc/helphelp.txt
@@ -433,17 +433,27 @@ To quote a block of ex-commands verbatim, place a greater than (>) character
 at the end of the line before the block and a less than (<) character as the
 first non-blank on a line following the block.  Any line starting in column 1
 also implicitly stops the block of ex-commands before it.  E.g. >
-    function Example_Func()
-	echo "Example"
-    endfunction
+	function Example_Func()
+	  echo "Example"
+	endfunction
 <
-It's possible to add Vim syntax highlighting support to code examples.  This
-can be done by adding "vim" after the greater than (>) character (">vim").
-E.g: >vim
-    function Example_Func()
-	echo "Example"
-    endfunction
+
+To add annotation in the block, place the annotation (ex: "lua") after a
+greater than (>) character.  E.g: >lua
+	print("hello")
 <
+In default, it's possible to add Vim syntax highlighting support to code
+examples.  E.g: >vim
+	function Example_Func()
+	  echo "Example"
+	endfunction
+<
+						 *g:help_example_languages*
+If you want to change the syntax highlighting in the block, you can
+change it like this: >
+	:let g:help_example_languages = #{ vim: 'vim', sh: 'bash' }
+The key is language annotation and the value is syntax name.
+
 The following are highlighted differently in a Vim help file:
   - a special key name expressed either in <> notation as in <PageDown>, or
     as a Ctrl character as in CTRL-X

--- a/runtime/doc/helphelp.txt
+++ b/runtime/doc/helphelp.txt
@@ -442,9 +442,11 @@ To add annotation in the block, place the annotation (ex: "lua") after a
 greater than (>) character.  E.g: >lua
 	print("hello")
 <
-Note: uses lua syntax highlighting, if "lua" is in |g:help_example_languages|.
-It's possible to add Vim syntax highlighting support to code
-examples.  E.g: >vim
+Note: uses lua syntax highlighting, if "lua" key is in
+|g:help_example_languages|.
+
+It's possible to add Vim syntax highlighting support to code examples.
+E.g: >vim
 	function Example_Func()
 	  echo "Example"
 	endfunction
@@ -453,10 +455,12 @@ examples.  E.g: >vim
 If you want to change the syntax highlighting in the block, you can
 change it like this: >
 	:let g:help_example_languages = #{ vim: 'vim', sh: 'bash' }
-The key is the annotation marker name and the value is the 'syntax' name.
-When not configured, help files support Vim script highlighting only.
-Note: When setting "g:help_example_languages", if you do not add "vim", Vim
-When setting "g:help_example_languages" to an empty value, syntax highlighting for embedded languages will be disabled.
+The key represents the annotation marker name, and the value is the 'syntax'
+name.  By default, help files support only Vim script highlighting.
+Note: When setting "g:help_example_languages", if you do not include "vim"
+key, the Vim syntax highlighting will not be enabled. If you set
+"g:help_example_languages" to an empty value, syntax highlighting for embedded
+languages will be disabled.
 
 The following are highlighted differently in a Vim help file:
   - a special key name expressed either in <> notation as in <PageDown>, or

--- a/runtime/doc/helphelp.txt
+++ b/runtime/doc/helphelp.txt
@@ -456,7 +456,7 @@ change it like this: >
 The key is the annotation marker name and the value is the 'syntax' name.
 When not configured, help files support Vim script highlighting only.
 Note: When setting "g:help_example_languages", if you do not add "vim", Vim
-script syntax highlighting will not be available.
+When setting "g:help_example_languages" to an empty value, syntax highlighting for embedded languages will be disabled.
 
 The following are highlighted differently in a Vim help file:
   - a special key name expressed either in <> notation as in <PageDown>, or

--- a/runtime/doc/helphelp.txt
+++ b/runtime/doc/helphelp.txt
@@ -453,7 +453,7 @@ examples.  E.g: >vim
 If you want to change the syntax highlighting in the block, you can
 change it like this: >
 	:let g:help_example_languages = #{ vim: 'vim', sh: 'bash' }
-The key is language annotation and the value is syntax name.
+The key is the annotation marker and the value is the 'syntax' name.
 
 The following are highlighted differently in a Vim help file:
   - a special key name expressed either in <> notation as in <PageDown>, or

--- a/runtime/doc/os_dos.txt
+++ b/runtime/doc/os_dos.txt
@@ -292,9 +292,9 @@ should be:
 'shellquote'	   "
 'shellxquote'						 "
 
-For Dos 16 bit this starts the shell as:
+For Dos 16 bit this starts the shell as: >
 	<shell> -c "command name" >file
-For Win32 as:
+For Win32 as: >
 	<shell> -c "command name >file"
 For DOS 32 bit, DJGPP does this internally somehow.
 

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -7583,6 +7583,7 @@ g:gzip_exec	pi_gzip.txt	/*g:gzip_exec*
 g:hare_recommended_style	ft_hare.txt	/*g:hare_recommended_style*
 g:hare_space_error	ft_hare.txt	/*g:hare_space_error*
 g:haredoc_search_depth	ft_hare.txt	/*g:haredoc_search_depth*
+g:help_example_languages	helphelp.txt	/*g:help_example_languages*
 g:html_charset_override	syntax.txt	/*g:html_charset_override*
 g:html_diff_one_file	syntax.txt	/*g:html_diff_one_file*
 g:html_dynamic_folds	syntax.txt	/*g:html_dynamic_folds*

--- a/runtime/syntax/help.vim
+++ b/runtime/syntax/help.vim
@@ -37,6 +37,8 @@ for [s:lang, s:syntax] in g:help_example_languages->items()
         \ (has("conceal") ? 'concealends' : '')
         \ $'contains=@Example{s:lang} keepend'
 endfor
+unlet s:lang
+unlet s:syntax
 
 if has("ebcdic")
   syn match helpHyperTextJump	"\\\@<!|[^"*|]\+|" contains=helpBar

--- a/runtime/syntax/help.vim
+++ b/runtime/syntax/help.vim
@@ -35,7 +35,7 @@ for [s:lang, s:syntax] in g:help_example_languages->items()
         \ $'syntax/{s:syntax}.vim'
 
   execute $'syn region helpExampleHighlight_{s:lang} matchgroup=helpIgnore'
-        \ $'start=/^>{s:lang}$/ start=/ >{s:lang}$/'
+        \ $'start=/\%(^\| \)>{s:lang}$/'
         \ 'end=/^[^ \t]/me=e-1 end=/^</'
         \ (has("conceal") ? 'concealends' : '')
         \ $'contains=@helpExampleHighlight_{s:lang} keepend'

--- a/runtime/syntax/help.vim
+++ b/runtime/syntax/help.vim
@@ -21,21 +21,24 @@ syn match helpSectionDelim	"^===.*===$"
 syn match helpSectionDelim	"^---.*--$"
 
 if has("conceal")
-  syn region helpExample	matchgroup=helpIgnore start=" >[a-z0-9]*$" start="^>[a-z0-9]*$" end="^[^ \t]"me=e-1 end="^<" concealends
+  syn region helpExample	matchgroup=helpIgnore
+        \ start="\%(^\| \)>[a-z0-9]*$" end="^[^ \t]"me=e-1 end="^<" concealends
  else
-   syn region helpExample	matchgroup=helpIgnore start=" >[a-z0-9]*$" start="^>[a-z0-9]*$" end="^[^ \t]"me=e-1 end="^<"
+   syn region helpExample	matchgroup=helpIgnore
+         \ start="\%(^\| \)>[a-z0-9]*$" end="^[^ \t]"me=e-1 end="^<"
 endif
 
 for [s:lang, s:syntax] in g:help_example_languages->items()
   unlet! b:current_syntax
   " silent! to prevent E403
-  execute 'silent! syntax include' $'@Example{s:lang}' $'syntax/{s:syntax}.vim'
+  execute 'silent! syn include' $'@helpExampleHighlight_{s:lang}'
+        \ $'syntax/{s:syntax}.vim'
 
-  execute $'syn region helpExample{s:lang} matchgroup=helpIgnore'
+  execute $'syn region helpExampleHighlight_{s:lang} matchgroup=helpIgnore'
         \ $'start=/^>{s:lang}$/ start=/ >{s:lang}$/'
         \ 'end=/^[^ \t]/me=e-1 end=/^</'
         \ (has("conceal") ? 'concealends' : '')
-        \ $'contains=@Example{s:lang} keepend'
+        \ $'contains=@helpExampleHighlight_{s:lang} keepend'
 endfor
 unlet s:lang
 unlet s:syntax

--- a/runtime/syntax/help.vim
+++ b/runtime/syntax/help.vim
@@ -12,26 +12,32 @@ endif
 let s:cpo_save = &cpo
 set cpo&vim
 
+if !exists('g:help_example_languages')
+  let g:help_example_languages = #{ vim: 'vim' }
+endif
+
 syn match helpHeadline		"^[A-Z.][-A-Z0-9 .,()_']*?\=\ze\(\s\+\*\|$\)"
 syn match helpSectionDelim	"^===.*===$"
 syn match helpSectionDelim	"^---.*--$"
 
-unlet! b:current_syntax
-" sil! to prevent E403
-silent! syntax include @VimScript syntax/vim.vim
 if has("conceal")
-  syn region helpExample	matchgroup=helpIgnore start=" >$" start="^>$" end="^[^ \t]"me=e-1 end="^<" concealends
-  syn region helpExampleVimScript matchgroup=helpIgnore
-        \ start=/^>vim$/ start=/ >vim$/
-        \ end=/^[^ \t]/me=e-1 end=/^</ concealends
-        \ contains=@VimScript keepend
+  syn region helpExample	matchgroup=helpIgnore start=" >[a-z0-9]*$" start="^>[a-z0-9]*$" end="^[^ \t]"me=e-1 end="^<" concealends
  else
-   syn region helpExample	matchgroup=helpIgnore start=" >$" start="^>$" end="^[^ \t]"me=e-1 end="^<"
-   syn region helpExampleVimScript matchgroup=helpIgnore
-         \ start=/^>vim$/ start=/ >vim$/
-         \ end=/^[^ \t]/me=e-1 end=/^</
-         \ contains=@VimScript keepend
+   syn region helpExample	matchgroup=helpIgnore start=" >[a-z0-9]*$" start="^>[a-z0-9]*$" end="^[^ \t]"me=e-1 end="^<"
 endif
+
+for [s:lang, s:syntax] in g:help_example_languages->items()
+  unlet! b:current_syntax
+  " silent! to prevent E403
+  execute 'silent! syntax include' $'@Example{s:lang}' $'syntax/{s:syntax}.vim'
+
+  execute $'syn region helpExample{s:lang} matchgroup=helpIgnore'
+        \ $'start=/^>{s:lang}$/ start=/ >{s:lang}$/'
+        \ 'end=/^[^ \t]/me=e-1 end=/^</'
+        \ (has("conceal") ? 'concealends' : '')
+        \ $'contains=@Example{s:lang} keepend'
+endfor
+
 if has("ebcdic")
   syn match helpHyperTextJump	"\\\@<!|[^"*|]\+|" contains=helpBar
   syn match helpHyperTextEntry	"\*[^"*|]\+\*\s"he=e-1 contains=helpStar


### PR DESCRIPTION
Continues of https://github.com/vim/vim/pull/16215

I have added `g:help_example_languages` variable to support language annotation highlighting.
Because markdown has similar feature by `g:markdown_fenced_languages`.

Before:

![2024-12-17_17-52](https://github.com/user-attachments/assets/09a65139-a926-49d8-acbc-055231749906)

After:

![2024-12-17_17-55](https://github.com/user-attachments/assets/4b1a5fa8-facc-4f7e-9e76-2dfd7eca4f61)