### PR TITLE
ci: Update macOS from macos-14 to macos-15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,7 +323,7 @@ jobs:
       fail-fast: false
       matrix:
         features: [tiny, normal, huge]
-        runner: [macos-13, macos-14]
+        runner: [macos-13, macos-15]
 
     steps:
       - name: Checkout repository from github
@@ -335,11 +335,11 @@ jobs:
           brew install lua libtool
           echo "LUA_PREFIX=$(brew --prefix)" >> $GITHUB_ENV
 
-      - name: Grant microphone access for macos-14
-        if: matrix.features == 'huge' && matrix.runner == 'macos-14'
+      - name: Set up Xcode
+        if: matrix.runner == 'macos-15'
         run: |
-          # Temporary fix to fix microphone permission issues for macos-14 when playing sound.
-          sqlite3 $HOME/Library/Application\ Support/com.apple.TCC/TCC.db "INSERT OR IGNORE INTO access VALUES ('kTCCServiceMicrophone','/usr/local/opt/runner/provisioner/provisioner',1,2,4,1,NULL,NULL,0,'UNUSED',NULL,0,1687786159,NULL,NULL,'UNUSED',1687786159);"
+          # Xcode 16 has compiler bugs which are fixed in 16.2+
+          sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
 
       - name: Set up environment
         run: |


### PR DESCRIPTION
Make sure to use the latest Xcode (16.2) which contains fixes in the compiler, as GitHub Actions defaults to using 16.0 still. See #15764.