### PR TITLE
kind file not as opposed to unkind, but two separate columns

### DIFF
--- a/src/po/sv.po
+++ b/src/po/sv.po
@@ -1434,7 +1434,7 @@ msgid "tagname"
 msgstr "taggnamn"
 
 msgid " kind file\n"
-msgstr " snäll fil\n"
+msgstr "  typ fil\n"
 
 msgid "'history' option is zero"
 msgstr "'history'-flagga är noll"


### PR DESCRIPTION
(see #16237)
I see some white space (and original English messages) have been changed without rerunning the full pot machinery since 2007, so is this good enough?