### PR TITLE
Wrong cursor shape when using "gq" and 'indentexpr' executes :normal

### DIFF
--- a/src/testdir/test_indent.vim
+++ b/src/testdir/test_indent.vim
@@ -1,5 +1,8 @@
 " Test for various indent options
 
+source shared.vim
+source check.vim
+
 func Test_preserveindent()
   new
   " Test for autoindent copying indent from the previous line
@@ -298,6 +301,52 @@ func Test_indent_overflow_count2()
   norm! <<
   call assert_equal(0, indent(1))
   close!
+endfunc
+
+" Test that mouse shape is restored to Normal mode after using "gq" when
+" 'indentexpr' executes :normal.
+func Test_indent_norm_with_gq()
+  CheckFeature mouseshape
+  CheckCanRunGui
+
+  let lines =<< trim END
+    func Indent()
+      exe "normal! \<Ignore>"
+      return 0
+    endfunc
+
+    setlocal indentexpr=Indent()
+  END
+  call writefile(lines, 'Xindentexpr.vim', 'D')
+
+  let lines =<< trim END
+    vim9script
+    var mouse_shapes = []
+
+    setline(1, [repeat('a', 80), repeat('b', 80)])
+
+    feedkeys('ggVG')
+    timer_start(50, (_) => {
+      mouse_shapes += [getmouseshape()]
+      timer_start(50, (_) => {
+        feedkeys('gq')
+        timer_start(50, (_) => {
+          mouse_shapes += [getmouseshape()]
+          timer_start(50, (_) => {
+            writefile(mouse_shapes, 'Xmouseshapes')
+            quit!
+          })
+        })
+      })
+    })
+  END
+  call writefile(lines, 'Xmouseshape.vim', 'D')
+
+  call RunVim([], [], "-g -S Xindentexpr.vim -S Xmouseshape.vim")
+  call WaitForAssert({-> assert_equal(['rightup-arrow', 'arrow'],
+        \ readfile('Xmouseshapes'))}, 300)
+
+  call delete('Xmouseshapes')
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/textformat.c
+++ b/src/textformat.c
@@ -1163,13 +1163,24 @@ format_lines(
 		State = MODE_INSERT;	// for open_line()
 		smd_save = p_smd;
 		p_smd = FALSE;
+
 		insertchar(NUL, INSCHAR_FORMAT
 			+ (do_comments ? INSCHAR_DO_COM : 0)
 			+ (do_comments && do_comments_list
 						       ? INSCHAR_COM_LIST : 0)
 			+ (avoid_fex ? INSCHAR_NO_FEX : 0), second_indent);
+
 		State = old_State;
 		p_smd = smd_save;
+		// Cursor and mouse shape shapes may have been updated (e.g. by
+		// :normal) in insertchar(), so they need to be updated here.
+#ifdef CURSOR_SHAPE
+		ui_cursor_shape();
+#endif
+#ifdef FEAT_MOUSESHAPE
+		update_mouseshape(-1);
+#endif
+
 		second_indent = -1;
 		// at end of par.: need to set indent of next par.
 		need_set_indent = is_end_par;


### PR DESCRIPTION
Problem:  Wrong cursor shape when using "gq" and 'indentexpr' executes
          :normal.
Solution: Update cursor and mouse shape after restoring old_State.
