### PR TITLE
fix cross-compile to osx-arm64

### DIFF
--- a/src/auto/configure
+++ b/src/auto/configure
@@ -14234,7 +14234,7 @@ fi
 if test "x$vim_cv_timer_create" = "xyes" ||
    test "x$vim_cv_timer_create_with_lrt" = "xyes"; then
   save_LIBS="$LIBS"
-  if test "x$vim_cv_timer_create_works" = "xyes" ; then
+  if test "x$vim_cv_timer_create_with_lrt" = "xyes" ; then
     LIBS="$LIBS -lrt"
   fi
 
@@ -14297,7 +14297,6 @@ printf "%s\n" "$vim_cv_timer_create_works" >&6; }
   if test "x$vim_cv_timer_create_works" = "xyes" ; then
     printf "%s\n" "#define HAVE_TIMER_CREATE 1" >>confdefs.h
 
-    LIBS="$LIBS -lrt"
   else
     LIBS="$save_LIBS"
   fi

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -3908,7 +3908,7 @@ dnl works, on Solaris timer_create() exists but fails at runtime.
 if test "x$vim_cv_timer_create" = "xyes" ||
    test "x$vim_cv_timer_create_with_lrt" = "xyes"; then
   save_LIBS="$LIBS"
-  if test "x$vim_cv_timer_create_works" = "xyes" ; then
+  if test "x$vim_cv_timer_create_with_lrt" = "xyes" ; then
     LIBS="$LIBS -lrt"
   fi
 
@@ -3939,7 +3939,6 @@ if test "x$vim_cv_timer_create" = "xyes" ||
 
   if test "x$vim_cv_timer_create_works" = "xyes" ; then
     AC_DEFINE(HAVE_TIMER_CREATE)
-    LIBS="$LIBS -lrt"
   else
     LIBS="$save_LIBS"
   fi


### PR DESCRIPTION
Cross-compiling to osx-arm64 fails with the following

```
  In file included from json.c:17:
  In file included from ./vim.h:457:
  ./macros.h:304:24: error: expected identifier or '('
    304 |      static inline int isnan(double x)
        |                        ^
  .../MacOSX11.0.sdk/usr/include/math.h:165:7: note: expanded from macro 'isnan'
    165 |     ( sizeof(x) == sizeof(float)  ? __inline_isnanf((float)(x))
        |       ^

```
This can be traced back to ./configure incorrectly detecting the compiler support for `isnan()`, from the config.log:

```
  configure:14567: checking for isnan()
  configure:14588: arm64-apple-darwin20.0.0-clang <...> -L$PREFIX/lib conftest.c  -lncurses -ltinfo -lrt >&5
  ld: library not found for -lrt
  arm64-apple-darwin20.0: error: linker command failed with exit code 1 (use -v to see invocation)
```

The `-lrt` linking is added by ./configure script when it detects compiler support for `timer_create()`. On the osx-arm64 platform `timer_create()` works but does not link with `-lrt`. This results in the following settings from config.log:

```
  vim_cv_timer_create=yes
  vim_cv_timer_create_with_lrt=no
  vim_cv_timer_create_works=yes
```

But the configure.ac incorrectly uses `timer_create_works` to add `-lrt`, instead of using `timer_create_with_lrt`.

Fixes: https://github.com/conda-forge/vim-feedstock/pull/1664