### PR TITLE
fix: don't highlight input leader

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -923,7 +923,13 @@ ins_compl_insert_bytes(char_u *p, int len)
     int
 ins_compl_col_range_attr(int col)
 {
-    if (col >= compl_col && col < compl_ins_end_col)
+    int	    scol = compl_col;
+    int	    leader_len = ins_compl_leader_len();
+
+    if (leader_len > 0)
+	scol += leader_len;
+
+    if (col >= scol && col < compl_ins_end_col)
 	return syn_name2attr((char_u *)"ComplMatchIns");
 
     return -1;


### PR DESCRIPTION
Problem: ComplMatchIns should only highlighted the text which does not include input leader.

Solution: check col start after compl_leader

need rebase after https://github.com/vim/vim/pull/16244