### PR TITLE
Missing cmdline completion for :pbuffer

### DIFF
--- a/src/cmdexpand.c
+++ b/src/cmdexpand.c
@@ -2332,6 +2332,7 @@ set_context_by_cmdname(
 	    // FALLTHROUGH
 	case CMD_buffer:
 	case CMD_sbuffer:
+	case CMD_pbuffer:
 	case CMD_checktime:
 	    xp->xp_context = EXPAND_BUFFERS;
 	    xp->xp_pattern = arg;

--- a/src/testdir/test_preview.vim
+++ b/src/testdir/test_preview.vim
@@ -47,8 +47,19 @@ func Test_window_preview_from_pbuffer()
   edit Xpreview.c
   const buf_num = bufnr('%')
   enew
+
+  call feedkeys(":pbuffer Xpre\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal("\"pbuffer Xpreview.c", @:)
+
   call assert_equal(1, winnr('$'))
   exe 'pbuffer ' .  buf_num
+  call assert_equal(2, winnr('$'))
+  call assert_equal(0, &previewwindow)
+
+  call s:goto_preview_and_close()
+
+  call assert_equal(1, winnr('$'))
+  pbuffer Xpreview.c
   call assert_equal(2, winnr('$'))
   call assert_equal(0, &previewwindow)
 


### PR DESCRIPTION
Problem:  Missing cmdline completion for :pbuffer.
Solution: Add cmdline completion for :pbuffer like :buffer.

fixes: #16250