### PR TITLE
Add a note about handling symbolic links in starting.txt

### DIFF
--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -976,6 +976,7 @@ accordingly.  Vim proceeds in this order:
 The $MYVIMRC or $MYGVIMRC environment variable will be set to the first found
 vimrc and/or gvimrc file while $MYVIMDIR is set to the users personal runtime
 directory 'rtp' (typically the first entry in 'runtimepath').
+Note: These environment variables resolve symbolic links, but 'rtp' does not.
 
 
 Some hints on using initializations ~


### PR DESCRIPTION
```vim
:help $MYVIMDIR
/MYVIMDIR is
```

Found article:
```
$MYVIMDIR is set to the users personal runtime directory 'rtp' (typically the first entry in 'runtimepath').
```

The above article is not strictly correct because $MYVIMDIR and 'rtp' handle symbolic links differently.
So I added a note. What do you think?