### PR TITLE
runtime: fennelrc files cannot be recognized

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -844,7 +844,7 @@ au BufNewFile,BufRead *.fan,*.fwt		setf fan
 au BufNewFile,BufRead *.factor			setf factor
 
 " Fennel
-autocmd BufRead,BufNewFile *.fnl		setf fennel
+autocmd BufRead,BufNewFile *.fnl,{,.}fennelrc	setf fennel
 
 " Fetchmail RC file
 au BufNewFile,BufRead .fetchmailrc		setf fetchmail

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -273,7 +273,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     falcon: ['file.fal'],
     fan: ['file.fan', 'file.fwt'],
     faust: ['file.dsp', 'file.lib'],
-    fennel: ['file.fnl'],
+    fennel: ['file.fnl', '.fennelrc', 'fennelrc'],
     fetchmail: ['.fetchmailrc'],
     fgl: ['file.4gl', 'file.4gh', 'file.m4gl'],
     firrtl: ['file.fir'],


### PR DESCRIPTION
Problem: fennelrc files cannot be recognized
Solution: fennelrc files are recognized as fennel filetype

Refer https://github.com/bakpakin/Fennel/issues/193
