### PR TITLE
do not double escape Vim special characters

### DIFF
--- a/runtime/autoload/netrw.vim
+++ b/runtime/autoload/netrw.vim
@@ -5199,8 +5199,7 @@ fun! netrw#Open(file) abort
       endif
     endif
 
-    " although shellescape(..., 1) is used in netrw#Open(), it's insufficient
-    call netrw#Open(escape(fname, '#%'))
+    call netrw#Open(fname)
 
     " cleanup: remove temporary file,
     "          delete current buffer if success with handler,


### PR DESCRIPTION
This double escaping was likely introduced because it was the only way to make :Open work with hashes/percent signs despite shellescape(..., 1) supposedly taking care of it, but then breaks the gx mapping on MSYS2 as reported at [0]

Since special characters in the URL following :Open can be escaped, whereas gx simply breaks and is more common, no longer double escape

[0]: https://github.com/vim/vim/issues/16252