### PR TITLE
When assigning to a list item, if the type of the LHS item is any, then use the list item type.

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -1489,8 +1489,17 @@ get_lval_list(
 	return FAIL;
 
     if (lp->ll_valtype != NULL && !lp->ll_range)
+    {
 	// use the type of the member
-	lp->ll_valtype = lp->ll_valtype->tt_member;
+	if (lp->ll_valtype->tt_member != NULL)
+	    lp->ll_valtype = lp->ll_valtype->tt_member;
+	else
+	    // If the LHS member type is not known (VAR_ANY), then get it from
+	    // the list item (after indexing)
+	    lp->ll_valtype = typval2type(&lp->ll_li->li_tv, get_copyID(),
+					 &lp->ll_type_list, TVTT_DO_MEMBER);
+
+    }
 
     /*
      * May need to find the item or absolute index for the second
@@ -1994,6 +2003,7 @@ get_lval(
 
     // Clear everything in "lp".
     CLEAR_POINTER(lp);
+    ga_init2(&lp->ll_type_list, sizeof(type_T *), 10);
 
     if (skip || (flags & GLV_COMPILING))
     {
@@ -2178,6 +2188,7 @@ clear_lval(lval_T *lp)
 {
     vim_free(lp->ll_exp_name);
     vim_free(lp->ll_newkey);
+    clear_type_list(&lp->ll_type_list);
 }
 
 /*

--- a/src/structs.h
+++ b/src/structs.h
@@ -4692,6 +4692,7 @@ typedef struct lval_S
     int		ll_oi;		// The object/class member index
     int		ll_is_root;	// TRUE if ll_tv is the lval_root, like a
 				// plain object/class. ll_tv is variable.
+    garray_T	ll_type_list;   // list of pointers to allocated types
 } lval_T;
 
 /**


### PR DESCRIPTION
Fixes the issue reported in #15208.