### PR TITLE
Fix help tag E1182 place

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -797,7 +797,7 @@ length minus one is used: >
 
 
 Blob modification ~
-					*blob-modification* *E1182* *E1184*
+						*blob-modification* *E1184*
 To change a specific byte of a blob use |:let| this way: >
 	:let blob[4] = 0x44
 

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -4292,7 +4292,7 @@ E1179	options.txt	/*E1179*
 E118	eval.txt	/*E118*
 E1180	vim9.txt	/*E1180*
 E1181	vim9.txt	/*E1181*
-E1182	eval.txt	/*E1182*
+E1182	vim9.txt	/*E1182*
 E1183	eval.txt	/*E1183*
 E1184	eval.txt	/*E1184*
 E1185	various.txt	/*E1185*

--- a/runtime/doc/vim9.txt
+++ b/runtime/doc/vim9.txt
@@ -193,7 +193,7 @@ created yet.  In this case you can call `execute()` to invoke it at runtime. >
 "closure".  A `:def` function always aborts on an error (unless `:silent!` was
 used for the command or the error was caught a `:try` block), does not get a
 range passed, cannot be a "dict" function, and can always be a closure.
-						*vim9-no-dict-function*
+						*vim9-no-dict-function* *E1182*
 You can use a Vim9 Class (|Vim9-class|) instead of a "dict function".
 You can also pass the dictionary explicitly: >
 	def DictFunc(self: dict<any>, arg: string)


### PR DESCRIPTION
`:h E1182` jumps to the following location in eval.txt:

```
Blob modification ~
					*blob-modification* *E1182* *E1184*
To change a specific byte of a blob use |:let| this way: >
	:let blob[4] = 0x44
```

But, the message E1182 is not related to the blob.
```
"E1182: Cannot define a dict function in Vim9 script: %s"
```

Perhaps it would be appropriate to place near the `vim9-no-dict-function`.