### PR TITLE
Fix loss of data due to conversion build warnings in MS-Windows

### DIFF
--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -628,7 +628,7 @@ may_adjust_incsearch_highlighting(
 	    return FAIL;
 	}
 	skiplen = 0;
-	patlen = last_search_pattern_len();
+	patlen = (int)last_search_pattern_len();
     }
     else
 	pat = ccline.cmdbuff + skiplen;
@@ -1472,7 +1472,7 @@ cmdline_browse_history(
 		}
 		if (i == 0)
 		{
-		    alloc_cmdbuff(len);
+		    alloc_cmdbuff((int)len);
 		    if (ccline.cmdbuff == NULL)
 		    {
 			res = GOTO_NORMAL_MODE;
@@ -1481,18 +1481,18 @@ cmdline_browse_history(
 		}
 	    }
 	    ccline.cmdbuff[len] = NUL;
-	    ccline.cmdpos = ccline.cmdlen = len;
+	    ccline.cmdpos = ccline.cmdlen = (int)len;
 	}
 	else
 	{
-	    alloc_cmdbuff(plen);
+	    alloc_cmdbuff((int)plen);
 	    if (ccline.cmdbuff == NULL)
 	    {
 		res = GOTO_NORMAL_MODE;
 		goto done;
 	    }
 	    STRCPY(ccline.cmdbuff, p);
-	    ccline.cmdpos = ccline.cmdlen = plen;
+	    ccline.cmdpos = ccline.cmdlen = (int)plen;
 	}
 
 	redrawcmd();
@@ -4778,8 +4778,8 @@ open_cmdwin(void)
 	    {
 		// Execute the command directly.
 		ccline.cmdbuff = vim_strnsave(p, plen);
-		ccline.cmdlen = plen;
-		ccline.cmdbufflen = plen + 1;
+		ccline.cmdlen = (int)plen;
+		ccline.cmdbufflen = (int)(plen + 1);
 		cmdwin_result = CAR;
 	    }
 	    else

--- a/src/filepath.c
+++ b/src/filepath.c
@@ -675,7 +675,7 @@ repeat:
 			    if (s != NULL)
 			    {
 				*fnamep = s;
-				*fnamelen = slen;
+				*fnamelen = (int)slen;
 				vim_free(*bufp);
 				*bufp = s;
 				didit = TRUE;

--- a/src/option.c
+++ b/src/option.c
@@ -193,7 +193,7 @@ set_init_default_backupskip(void)
 		itemlen = vim_snprintf((char *)item, itemsize, "%s%s*", p, (has_trailing_path_sep) ? "" : PATHSEPSTR);
 
 		if (find_dup_item(ga.ga_data, item, itemlen, options[opt_idx].flags) == NULL
-			&& ga_grow(&ga, itemseplen + itemlen + 1) == OK)
+			&& ga_grow(&ga, (int)(itemseplen + itemlen + 1)) == OK)
 		{
 		    ga.ga_len += vim_snprintf((char *)ga.ga_data + ga.ga_len,
 				    itemseplen + itemlen + 1,
@@ -8415,7 +8415,7 @@ vimrc_found(char_u *fname, char_u *envname)
 		if (vim_getenv((char_u *)"MYVIMDIR", &dofree) == NULL)
 		{
 		    size_t  usedlen = 0;
-		    int     len = 0;
+		    size_t  len = 0;
 		    char_u  *fbuf = NULL;
 
 		    if (STRNCMP(gettail(fname), ".vimrc", 6) == 0)
@@ -8452,7 +8452,7 @@ vimrc_found(char_u *fname, char_u *envname)
 		    }
 #endif
 		    else
-			(void)modify_fname((char_u *)":h", FALSE, &usedlen, &p, &fbuf, &len);
+			(void)modify_fname((char_u *)":h", FALSE, &usedlen, &p, &fbuf, (int *)&len);
 
 		    if (p != NULL)
 		    {

--- a/src/undo.c
+++ b/src/undo.c
@@ -3124,7 +3124,7 @@ ex_undolist(exarg_T *eap UNUSED)
 
 	    // we have to call STRLEN() here because add_time() does not report
 	    // the number of characters added.
-	    len += STRLEN(IObuff + len);
+	    len += (int)STRLEN(IObuff + len);
 	    if (uhp->uh_save_nr > 0)
 	    {
 		int n = (len >= 33) ? 0 : 33 - len;

--- a/src/usercmd.c
+++ b/src/usercmd.c
@@ -671,7 +671,7 @@ uc_list(char_u *name, size_t name_len)
 	    if (entry != NULL)
 	    {
 		STRCPY(IObuff + len, entry->value.string);
-		len += entry->value.length;
+		len += (int)entry->value.length;
 #ifdef FEAT_EVAL
 		if (p_verbose > 0 && cmd->uc_compl_arg != NULL)
 		{
@@ -681,7 +681,7 @@ uc_list(char_u *name, size_t name_len)
 		    {
 			IObuff[len++] = ',';
 			STRCPY(IObuff + len, cmd->uc_compl_arg);
-			len += uc_compl_arglen;
+			len += (int)uc_compl_arglen;
 		    }
 		}
 #endif

--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -1838,7 +1838,7 @@ compile_lhs_script_var(
     int		script_var = FALSE;
     imported_T	*import;
     char_u	*var_name;
-    int		var_name_len;
+    size_t	var_name_len;
 
     if (lhs->lhs_varlen > 1 && STRNCMP(var_start, "s:", 2) == 0)
 	script_namespace = TRUE;

--- a/src/vim9execute.c
+++ b/src/vim9execute.c
@@ -3184,7 +3184,7 @@ any_var_get_obj_member(class_T *current_class, isn_T *iptr, typval_T *tv)
     copy_tv(tv, &mtv);
 
     // 'name' can either be a object variable or a object method
-    int		namelen = STRLEN(iptr->isn_arg.string);
+    int		namelen = (int)STRLEN(iptr->isn_arg.string);
     int		save_did_emsg = did_emsg;
 
     if (get_member_tv(obj->obj_class, TRUE, iptr->isn_arg.string, namelen,

--- a/src/viminfo.c
+++ b/src/viminfo.c
@@ -1142,7 +1142,7 @@ barline_parse(vir_T *virp, char_u *text, garray_T *values)
 			// freed later, also need to free "buf" later
 			value->bv_tofree = buf;
 		    s = sconv;
-		    len = STRLEN(s);
+		    len = (int)STRLEN(s);
 		    converted = TRUE;
 		}
 	    }


### PR DESCRIPTION
In the Appveyor CI Windows builds, there are several warnings similar to the one below:

warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data

This PR fixes these warnings.