### PR TITLE
fix: boost score for fully match in matchfuzzy

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -4385,6 +4385,7 @@ fuzzy_match_compute_score(
     int		i;
     char_u	*p = str;
     int_u	sidx = 0;
+    int		is_exact_match = TRUE;
 
     // Initialize score
     score = 100;
@@ -4452,7 +4453,14 @@ fuzzy_match_compute_score(
 	    // First letter
 	    score += FIRST_LETTER_BONUS;
 	}
+	// Check exact match condition
+        if (currIdx != (int_u)i)
+	    is_exact_match = FALSE;
     }
+    // Boost score for exact matches
+    if (is_exact_match && numMatches == strSz)
+        score += 100;
+
     return score;
 }
 

--- a/src/testdir/test_matchfuzzy.vim
+++ b/src/testdir/test_matchfuzzy.vim
@@ -23,6 +23,8 @@ func Test_matchfuzzy()
   call assert_equal(['aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'], matchfuzzy(['aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'], 'aa'))
   call assert_equal(256, matchfuzzy([repeat('a', 256)], repeat('a', 256))[0]->len())
   call assert_equal([], matchfuzzy([repeat('a', 300)], repeat('a', 257)))
+  " full match has highest score
+  call assert_equal(['Cursor', 'lCursor'], matchfuzzy(["hello", "lCursor", "Cursor"], "Cursor"))
   " matches with same score should not be reordered
   let l = ['abc1', 'abc2', 'abc3']
   call assert_equal(l, l->matchfuzzy('abc'))
@@ -97,7 +99,7 @@ func Test_matchfuzzypos()
   call assert_equal([['curl', 'world'], [[2,3], [2,3]], [128, 127]], matchfuzzypos(['world', 'curl'], 'rl'))
   call assert_equal([['curl', 'world'], [[2,3], [2,3]], [128, 127]], matchfuzzypos(['world', 'one', 'curl'], 'rl'))
   call assert_equal([['hello', 'hello world hello world'],
-        \ [[0, 1, 2, 3, 4], [0, 1, 2, 3, 4]], [275, 257]],
+        \ [[0, 1, 2, 3, 4], [0, 1, 2, 3, 4]], [375, 257]],
         \ matchfuzzypos(['hello world hello world', 'hello', 'world'], 'hello'))
   call assert_equal([['aaaaaaa'], [[0, 1, 2]], [191]], matchfuzzypos(['aaaaaaa'], 'aaa'))
   call assert_equal([['a  b'], [[0, 3]], [219]], matchfuzzypos(['a  b'], 'a  b'))
@@ -132,7 +134,7 @@ func Test_matchfuzzypos()
   call assert_equal([['foo bar baz'], [[0, 1, 2, 3, 4, 5, 10]], [326]], ['foo bar baz', 'foo', 'foo bar', 'baz bar']->matchfuzzypos('foo baz', {'matchseq': 1}))
   call assert_equal([[], [], []], ['foo bar baz', 'foo', 'foo bar', 'baz bar']->matchfuzzypos('one two'))
   call assert_equal([[], [], []], ['foo bar']->matchfuzzypos(" \t "))
-  call assert_equal([['grace'], [[1, 2, 3, 4, 2, 3, 4, 0, 1, 2, 3, 4]], [657]], ['grace']->matchfuzzypos('race ace grace'))
+  call assert_equal([['grace'], [[1, 2, 3, 4, 2, 3, 4, 0, 1, 2, 3, 4]], [757]], ['grace']->matchfuzzypos('race ace grace'))
 
   let l = [{'id' : 5, 'val' : 'crayon'}, {'id' : 6, 'val' : 'camera'}]
   call assert_equal([[{'id' : 6, 'val' : 'camera'}], [[0, 1, 2]], [192]],


### PR DESCRIPTION
Problem: Fuzzy matching did not prioritize exact matches and had insufficient handling of multi-byte characters, leading to incorrect scoring.

Solution: Added exact match prioritization with a bonus and improved multi-byte character handling to ensure accurate scoring and ranking.


Fix https://github.com/vim/vim/issues/15654


cc @yegappan 
