### PR TITLE
runtime(filetype): support bun.lock files

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1263,7 +1263,7 @@ au BufNewFile,BufRead *.sublime-project,*.sublime-settings,*.sublime-workspace	s
 au BufNewFile,BufRead .prettierrc,.firebaserc,.stylelintrc,.lintstagedrc,flake.lock,deno.lock	setf json
 
 " JSONC (JSON with comments)
-au BufNewFile,BufRead *.jsonc,.babelrc,.eslintrc,.jsfmtrc	setf jsonc
+au BufNewFile,BufRead *.jsonc,.babelrc,.eslintrc,.jsfmtrc,bun.lock	setf jsonc
 au BufNewFile,BufRead .jshintrc,.jscsrc,.vsconfig,.hintrc,.swrc,[jt]sconfig*.json	setf jsonc
 
 " JSON

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -394,7 +394,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     '.prettierrc', '.firebaserc', '.stylelintrc', '.lintstagedrc', 'file.slnf', 'file.sublime-project', 'file.sublime-settings', 'file.sublime-workspace',
     'file.bd', 'file.bda', 'file.xci', 'flake.lock', 'pack.mcmeta', 'deno.lock'],
     json5: ['file.json5'],
-    jsonc: ['file.jsonc', '.babelrc', '.eslintrc', '.jsfmtrc', '.jshintrc', '.jscsrc', '.vsconfig', '.hintrc', '.swrc', 'jsconfig.json', 'tsconfig.json', 'tsconfig.test.json', 'tsconfig-test.json', '.luaurc'],
+    jsonc: ['file.jsonc', '.babelrc', '.eslintrc', '.jsfmtrc', '.jshintrc', '.jscsrc', '.vsconfig', '.hintrc', '.swrc', 'jsconfig.json', 'tsconfig.json', 'tsconfig.test.json', 'tsconfig-test.json', '.luaurc', 'bun.lock'],
     jsonl: ['file.jsonl'],
     jsonnet: ['file.jsonnet', 'file.libsonnet'],
     jsp: ['file.jsp'],


### PR DESCRIPTION
Bun javascript runtime recently introduced a new jsonc text based lock file. It would be nice to have built in support for detecting its filetype.

> The bun.lock file is JSONC (like tsconfig.json)

source https://bun.sh/blog/bun-lock-text-lockfile#tooling-compatibility