### PR TITLE
runtime(sh): set shellcheck as the compiler for supported shells

### DIFF
--- a/runtime/ftplugin/sh.vim
+++ b/runtime/ftplugin/sh.vim
@@ -44,7 +44,11 @@ if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
   let b:undo_ftplugin ..= " | unlet! b:browsefilter"
 endif
 
-if get(b:, "is_bash", 0)
+let s:is_sh = get(b:, "is_sh", get(g:, "is_sh", 0))
+let s:is_bash = get(b:, "is_bash", get(g:, "is_bash", 0))
+let s:is_kornshell = get(b:, "is_kornshell", get(g:, "is_kornshell", 0))
+
+if s:is_bash
   if exists(':terminal') == 2
     command! -buffer -nargs=1 ShKeywordPrg silent exe ':term bash -c "help "<args>" 2>/dev/null || man "<args>""'
   else
@@ -52,14 +56,21 @@ if get(b:, "is_bash", 0)
   endif
   setlocal keywordprg=:ShKeywordPrg
   let b:undo_ftplugin ..= " | setl kp< | sil! delc -buffer ShKeywordPrg"
+endif
 
+if (s:is_sh || s:is_bash || s:is_kornshell) && executable('shellcheck')
   if !exists('current_compiler')
     compiler shellcheck
+    let b:undo_ftplugin ..= ' | compiler make'
   endif
-  let b:undo_ftplugin .= ' | compiler make'
+elseif s:is_bash
+  if !exists('current_compiler')
+    compiler bash
+    let b:undo_ftplugin ..= ' | compiler make'
+  endif
 endif
 
 let &cpo = s:save_cpo
-unlet s:save_cpo
+unlet s:save_cpo s:is_sh s:is_bash s:is_kornshell
 
 " vim: nowrap sw=2 sts=2 ts=8 noet:


### PR DESCRIPTION
Hi,
I think we should be setting shellcheck has the compiler for every shellcheck supported shell.
https://www.shellcheck.net/wiki/SC1071.