### PR TITLE
ensures the code adheres to the C89 standard

### DIFF
--- a/src/structs.h
+++ b/src/structs.h
@@ -5101,7 +5101,7 @@ typedef struct
 #define KEYVALUE_ENTRY(k, v) \
     {(k), {((char_u *)v), STRLEN_LITERAL(v)}}
 
-#if defined(UNIX) || defined(MSWIN)
+#if defined(UNIX) || defined(MSWIN) || defined(VMS)
 // Defined as signed, to return -1 on error
 struct cellsize {
     int cs_xpixel;

--- a/src/vim9execute.c
+++ b/src/vim9execute.c
@@ -4425,9 +4425,10 @@ exec_instructions(ectx_T *ectx)
 		    // Stack has the local variable, argument the whole :lock
 		    // or :unlock command, like ISN_EXEC.
 		    --ectx->ec_stack.ga_len;
-		    lval_root_T root = { .lr_tv = STACK_TV_BOT(0),
-			    .lr_cl_exec = iptr->isn_arg.lockunlock.lu_cl_exec,
-			    .lr_is_arg  = iptr->isn_arg.lockunlock.lu_is_arg };
+		    lval_root_T root;
+            root.lr_tv      = STACK_TV_BOT(0);
+            root.lr_cl_exec = iptr->isn_arg.lockunlock.lu_cl_exec;
+            root.lr_is_arg  = iptr->isn_arg.lockunlock.lu_is_arg;
 		    lval_root = &root;
 		    int res = exec_command(iptr,
 					iptr->isn_arg.lockunlock.lu_string);


### PR DESCRIPTION
While building on OpenVMS systems there have been observed two issues:


1) 
cc /def=("FEAT_HUGE","HAVE_CONFIG_H"    )  /opt/prefix=all/name=(upper,short)  /include=([.proto]  ,[.xdiff]) EVALFUNC.C

void mch_calc_cell_size(struct cellsize *cs_out);
........................^
%CC-I-PROTOSCOPE, The type "struct cellsize" has been declared within and is limited to a function prototype scope.  It will not be compatible with an identical type declared in another scope.  This might not be what you intended.
at line number 94 in file DKA100:[WORK.VIM91-889.SRC.PROTO]OS_UNIX.PRO;1

        struct cellsize cs;
........................^
%CC-E-INCOMPNOLINK, In this declaration, "cs" has no linkage and is of an incomplete type.
at line number 5233 in file DKA100:[WORK.VIM91-889.SRC]EVALFUNC.C;1
%MMS-F-ABORT, For target EVALFUNC.OBJ, CLI returned abort status: %X10B91262.

Solution: 
Define the struct cellsize for VMS too.

2) 
cc /def=("FEAT_HUGE","HAVE_CONFIG_H"    )  /noopt/prefix=all/name=(upper,short)  /include=([.proto]  ,[.xdiff]) VIM9EXECUTE.C
                            lval_root_T root = { .lr_tv = STACK_TV_BOT(0),
        .........................................^
%CC-I-DESIGNATORUSE, The use of a designation in an initializer list is a new
 feature in the C99 standard.
                At line number 4401 in DUA3:[WORK.VIM91-889.SRC]VIM9EXECUTE.C;1.

Solution: 
Ensure the code adheres to the C89 standard - like everywhere else:
- The structure root is declared first.
- Each member of the structure is then assigned a value individually.

On OpenVMS systems the code worked well.

Please review, comment and commit the changes.

Happy New Year :)
....and Happy Vimming as Bram used to say.


