### PR TITLE
Fix document typo

### DIFF
--- a/runtime/doc/version9.txt
+++ b/runtime/doc/version9.txt
@@ -41617,7 +41617,7 @@ Changed~
   |CompleteDone| autocommand in the |v:event| dictionary
 - the default fontsize for the GTK builds of Vim (Windows and Unix) has been
   increased to 12pt to accomodate modern high-dpi monitors
-- filetype detection now detects bash scripts as a separate "bash filetype
+- filetype detection now detects bash scripts as a separate "bash" filetype
   instead of the "sh" filetype
 - the default value of the 'keyprotocol' option has been updated by support
   for the ghostty terminal emulator (using kitty protocol)

--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -1011,8 +1011,9 @@ CTRL-W g }						*CTRL-W_g}*
 		If [N] is not given, the current buffer remains being edited.
 		See |:buffer-!| for [!].  This will also edit a buffer that is
 		not in the buffer list, without setting the 'buflisted' flag.
-		The notation with single quotes does not work here, `:pbuffer
-		12'345'` uses 12'345 as a buffer name.  Also see |+cmd|.
+		The notation with single quotes does not work here,
+		`:pbuffer 12'345'` uses 12'345' as a buffer name.
+		Also see |+cmd|.
 
 							*:ped* *:pedit*
 :ped[it][!] [++opt] [+cmd] {file}
@@ -1280,7 +1281,7 @@ list of buffers. |unlisted-buffer|
 		[!].  This will also edit a buffer that is not in the buffer
 		list, without setting the 'buflisted' flag.
 		The notation with single quotes does not work here,
-		`:buf 12'345'` uses 12'345 as a buffer name.
+		`:buf 12'345'` uses 12'345' as a buffer name.
 		Also see |+cmd|.
 
 :[N]b[uffer][!] [+cmd] {bufname}				*{bufname}*


### PR DESCRIPTION
NOTE: I think 12'345 in windows.txt is a mistake and should be 12'345'.