### PR TITLE
feat: filetype detect slnx

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -2414,6 +2414,7 @@ au BufNewFile,BufRead *.ice			setf slice
 " Microsoft Visual Studio Solution
 au BufNewFile,BufRead *.sln			setf solution
 au BufNewFile,BufRead *.slnf			setf json
+au BufNewFile,BufRead *.slnx			setf xml
 
 " Spice
 au BufNewFile,BufRead *.sp,*.spice		setf spice

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -892,7 +892,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     xml: ['/etc/blkid.tab', '/etc/blkid.tab.old', 'file.xmi', 'file.csproj', 'file.csproj.user', 'file.fsproj', 'file.fsproj.user', 'file.vbproj', 'file.vbproj.user', 'file.ui',
           'file.tpm', '/etc/xdg/menus/file.menu', 'fglrxrc', 'file.xlf', 'file.xliff', 'file.xul', 'file.wsdl', 'file.wpl', 'any/etc/blkid.tab', 'any/etc/blkid.tab.old',
           'any/etc/xdg/menus/file.menu', 'file.atom', 'file.rss', 'file.cdxml', 'file.psc1', 'file.mpd', 'fonts.conf', 'file.xcu', 'file.xlb', 'file.xlc', 'file.xba', 'file.xpr',
-          'file.xpfm', 'file.spfm', 'file.bxml', 'file.mmi'],
+          'file.xpfm', 'file.spfm', 'file.bxml', 'file.mmi', 'file.slnx'],
     xmodmap: ['anyXmodmap', 'Xmodmap', 'some-Xmodmap', 'some-xmodmap', 'some-xmodmap-file', 'xmodmap', 'xmodmap-file'],
     xpm: ['file.xpm'],
     xpm2: ['file.xpm2'],


### PR DESCRIPTION
Problem:  filetype: slnx file is not recognized
Solution: detect 'slnx' file as xml filetype

Context: https://blog.jetbrains.com/dotnet/2024/10/04/support-for-slnx-solution-files/

I have never contributed to vim before so feel free to point me in the right direction if I did anything wrong. I did read the contributing.md before making this PR.

I based my PR on a similiar previous [PR](https://github.com/vim/vim/commit/f07ae5b3bdb7331ee0e65adcb74402eef74f0a2b)