### PR TITLE
runtime(doc): Fix enum example syntax

### DIFF
--- a/runtime/doc/vim9class.txt
+++ b/runtime/doc/vim9class.txt
@@ -951,11 +951,11 @@ aliased: >
 						*enum* *E1418* *E1419* *E1420*
 An enum is a type that can have one of a list of values.  Example: >
 
-    :enum Color
+    enum Color
 	White,
 	Red,
 	Green, Blue, Black
-    :endenum
+    endenum
 <
 						*enumvalue* *E1422*
 The enum values are separated by commas.  More than one enum value can be


### PR DESCRIPTION
An ex-colon is not allowed before endenum.  As no other examples in the
file use an ex-colon remove them both.
