### PR TITLE
Fix typo after 9.1.0973

### DIFF
--- a/src/fileio.c
+++ b/src/fileio.c
@@ -2531,7 +2531,7 @@ failed:
 	    if (ff_error == EOL_DOS)
 	    {
 		buflen += vim_snprintf((char *)IObuff + buflen, IOSIZE - buflen,
-			_("CR missing"));
+			_("[CR missing]"));
 		c = TRUE;
 	    }
 	    if (split)


### PR DESCRIPTION
Add missing square brackets.