### PR TITLE
runtime(lnkmap): treat DESCT as TI linker map file's keyword

### DIFF
--- a/runtime/syntax/lnkmap.vim
+++ b/runtime/syntax/lnkmap.vim
@@ -19,7 +19,7 @@ syn match lnkmapFile			'[^ =]\+\%(\.\S\+\)\+\>'
 syn match lnkmapLibFile			'[^ =]\+\.lib\>'
 syn match lnkmapAttrib			'\<[RWIX]\+\>'
 syn match lnkmapAttrib			'\s\zs--HOLE--\ze\%\(\s\|$\)'
-syn keyword lnkmapAttrib		UNINITIALIZED
+syn keyword lnkmapAttrib		UNINITIALIZED DESCT
 
 
 hi def link lnkmapTime			Comment

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -2782,7 +2782,7 @@ func Test_map_file()
   call assert_equal('lnkmap', &filetype)
   bwipe!
 
-  " TI linker map file
+  " UMN mapserver config file
   call writefile(['MAP', 'NAME "local-demo"', 'END'], 'Xfile.map', 'D')
   split Xfile.map
   call assert_equal('map', &filetype)


### PR DESCRIPTION
Problem: DESCT is an attribute of output section
Solution: treat DESCT as TI linker map file's keyword
