### PR TITLE
docs: use standard SGR format in xterm-true-color

### DIFF
--- a/runtime/doc/term.txt
+++ b/runtime/doc/term.txt
@@ -688,10 +688,11 @@ The default values are set like this: >
 	 let &t_8f = "\<Esc>[38;2;%lu;%lu;%lum"
 	 let &t_8b = "\<Esc>[48;2;%lu;%lu;%lum"
 
-Some terminals accept the same sequences, but with all semicolons replaced by
-colons (this is actually more compatible, but less widely supported): >
-	 let &t_8f = "\<Esc>[38:2:%lu:%lu:%lum"
-	 let &t_8b = "\<Esc>[48:2:%lu:%lu:%lum"
+Some terminals accept similar sequences, with semicolons replaced by colons
+and an extra colon after the number 2 (this is conformant to the ISO 8613-6
+standard, but less widely supported): >
+	 let &t_8f = "\<Esc>[38:2::%lu:%lu:%lum"
+	 let &t_8b = "\<Esc>[48:2::%lu:%lu:%lum"
 
 These options contain printf strings, with |printf()| (actually, its C
 equivalent hence `l` modifier) invoked with the t_ option value and three

--- a/src/libvterm/t/30state_pen.test
+++ b/src/libvterm/t/30state_pen.test
@@ -82,7 +82,7 @@ PUSH "\e[34m"
   ?pen foreground = idx(4)
 PUSH "\e[91m"
   ?pen foreground = idx(9)
-PUSH "\e[38:2:10:20:30m"
+PUSH "\e[38:2::10:20:30m"
   ?pen foreground = rgb(10,20,30)
 PUSH "\e[38:5:1m"
   ?pen foreground = idx(1)
@@ -98,7 +98,7 @@ PUSH "\e[44m"
   ?pen background = idx(4)
 PUSH "\e[101m"
   ?pen background = idx(9)
-PUSH "\e[48:2:10:20:30m"
+PUSH "\e[48::2:10:20:30m"
   ?pen background = rgb(10,20,30)
 PUSH "\e[48:5:1m"
   ?pen background = idx(1)


### PR DESCRIPTION
By default, Vim uses the non-standard, but widely supported, legacy xterm/Konsole format for setting "direct colors" with set setaf and setbf escape codes, which use semicolons as separators.

The documentation for xterm-true-color mentions that, as an alternative, users can set alternative sequences that use colons instead of semicolons. This format, though, isn't standard and it is unclear how widely supported it is; it was added by xterm patch 282 due to a misinterpretation of the ISO 8613-6 (ITU T.416) standard, and was later changed to the format suggested by this patch, which is the one specified in the standard.

Today, looking at ncurses' [terminfo], it seems that all terminal emulators use either the standard format (named "xterm+direct" in the terminfo source) or the legacy format (named "xterm+indirect" in the terminfo source).

Hence, I believe it makes sense to align the docs with reality.

If you're interested in the story of this escape sequence, I'd recommend reading
<https://invisible-island.net/ncurses/ncurses.faq.html#xterm_16MegaColors>.

[terminfo]: https://invisible-island.net/ncurses/terminfo.ti.html

I tried sending this patch via email to vim-dev@ as message-id `<20241229215653.81401-1-andrea@pappacoda.it>`, but it seems that it was discarded.