### PR TITLE
Tweak documentation about Base64 APIs

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -67,8 +67,8 @@ autocmd_get([{opts}])		List	return a list of autocmds
 balloon_gettext()		String	current text in the balloon
 balloon_show({expr})		none	show {expr} inside the balloon
 balloon_split({msg})		List	split {msg} as used for a balloon
-base64_decode({string})		Blob	base-64 decode {string} characters
-base64_encode({blob})		String	base-64 encode the bytes in {blob}
+base64_decode({string})		Blob	Base64 decode {string} characters
+base64_encode({blob})		String	Base64 encode the bytes in {blob}
 bindtextdomain({package}, {path})
 				Bool	bind text domain to specified path
 blob2list({blob})		List	convert {blob} into a list of numbers
@@ -1171,43 +1171,6 @@ autocmd_get([{opts}])					*autocmd_get()*
 		Return type: list<dict<any>>
 
 
-base64_decode({string})					*base64_decode()*
-		Return a Blob containing the bytes decoded from the base64
-		characters in {string}.
-
-		The {string} argument should contain only base64-encoded
-		characters and should have a length that is a multiple of 4.
-
-		Returns an empty blob on error.
-
-		Examples: >
-		    " Write the decoded contents to a binary file
-		    call writefile(base64_decode(s), 'tools.bmp')
-		    " Decode a base64-encoded string
-		    echo list2str(blob2list(base64_decode(encodedstr)))
-<
-		Can also be used as a |method|: >
-			GetEncodedString()->base64_decode()
-<
-		Return type: |Blob|
-
-
-base64_encode({blob})					*base64_encode()*
-		Return a base64-encoded String representing the bytes in
-		{blob}.  The base64 alphabet defined in RFC 4648 is used.
-
-		Examples: >
-		    " Encode the contents of a binary file
-		    echo base64_encode(readblob('somefile.bin'))
-		    " Encode a string
-		    echo base64_encode(list2blob(str2list(somestr)))
-<
-		Can also be used as a |method|: >
-			GetBinaryData()->base64_encode()
-<
-		Return type: |String|
-
-
 balloon_gettext()					*balloon_gettext()*
 		Return the current text in the balloon.  Only for the string,
 		not used for the List.  Returns an empty string if balloon
@@ -1263,6 +1226,43 @@ balloon_split({msg})					*balloon_split()*
 		feature}
 
 		Return type: list<any> or list<string>
+
+base64_decode({string})					*base64_decode()*
+		Return a Blob containing the bytes decoded from the Base64
+		characters in {string}.
+
+		The {string} argument should contain only Base64-encoded
+		characters and should have a length that is a multiple of 4.
+
+		Returns an empty blob on error.
+
+		Examples: >
+		    " Write the decoded contents to a binary file
+		    call writefile(base64_decode(s), 'tools.bmp')
+		    " Decode a Base64-encoded string
+		    echo list2str(blob2list(base64_decode(encodedstr)))
+<
+		Can also be used as a |method|: >
+			GetEncodedString()->base64_decode()
+<
+		Return type: |Blob|
+
+
+base64_encode({blob})					*base64_encode()*
+		Return a Base64-encoded String representing the bytes in
+		{blob}.  The Base64 alphabet defined in RFC 4648 is used.
+
+		Examples: >
+		    " Encode the contents of a binary file
+		    echo base64_encode(readblob('somefile.bin'))
+		    " Encode a string
+		    echo base64_encode(list2blob(str2list(somestr)))
+<
+		Can also be used as a |method|: >
+			GetBinaryData()->base64_encode()
+<
+		Return type: |String|
+
 
 bindtextdomain({package}, {path})			*bindtextdomain()*
 		Bind a specific {package} to a {path} so that the


### PR DESCRIPTION
Related: https://github.com/vim/vim/commit/810785c6890ef0a1cd2428410c8488cacfbac77b
(@yegappan )
- Moved the documentation for `base64_decode()` and `base64_encode()` to the correct alphabetical position.
- The notation for Base64 is "Base64".