### PR TITLE
Add `getstacktrace()` and `v:stacktrace`

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -279,6 +279,7 @@ getregionpos({pos1}, {pos2} [, {opts}])
 				List	get a list of positions for a region
 getregtype([{regname}])		String	type of a register
 getscriptinfo([{opts}])		List	list of sourced scripts
+getstacktrace()			List	get current stack trace of Vim scripts
 gettabinfo([{expr}])		List	list of tab pages
 gettabvar({nr}, {varname} [, {def}])
 				any	variable {varname} in tab {nr} or {def}
@@ -4994,6 +4995,21 @@ getscriptinfo([{opts}])					*getscriptinfo()*
 			:echo getscriptinfo({'name': 'myscript'})
 			:echo getscriptinfo({'sid': 15})[0].variables
 <
+		Return type: list<dict<any>>
+
+
+getstacktrace()						*getstacktrace()*
+		Returns the current stack trace of Vim scripts.
+		Stack trace is a |List|, of which each item is a |Dictionary|
+		with the following items:
+		    funcref	The funcref if the stack is at the function,
+				otherwise this item is not exist.
+		    event	The string of the event description if the
+				stack is at autocmd event, otherwise this item
+				is not exist.
+		    lnum	The line number of the script on the stack.
+		    filepath	The file path of the script on the stack.
+
 		Return type: list<dict<any>>
 
 

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2551,6 +2551,15 @@ v:sizeofpointer	Number of bytes in a pointer.  Depends on how Vim was compiled.
 					*v:statusmsg* *statusmsg-variable*
 v:statusmsg	Last given status message.  It's allowed to set this variable.
 
+					*v:stacktrace* *stacktrace-variable*
+v:stacktrace	Contains the stack trace whitch is a list of dictionaries.
+		This dictionary has following member:
+			'funcref'	The funcref of current function.
+			'lnum'		If this function was defined in a script,
+					contains the current line number.
+			'filepath'	If this function was defined in a script,
+					contains the current filepath.
+
 					*v:swapname* *swapname-variable*
 v:swapname	Only valid when executing |SwapExists| autocommands: Name of
 		the swap file found.  Read-only.

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2172,7 +2172,8 @@ v:event		Dictionary containing information about the current
 <
 					*v:exception* *exception-variable*
 v:exception	The value of the exception most recently caught and not
-		finished.  See also |v:throwpoint| and |throw-variables|.
+		finished.  See also |v:stacktrace|, |v:throwpoint|, and
+		|throw-variables|.
 		Example: >
 	:try
 	:  throw "oops"
@@ -2548,17 +2549,14 @@ v:sizeofpointer	Number of bytes in a pointer.  Depends on how Vim was compiled.
 		This is only useful for deciding whether a test will give the
 		expected result.
 
+					*v:stacktrace* *stacktrace-variable*
+v:stacktrace	The stack trace where the exception most recently caught and
+		not finished.  Refer to |getstacktrace()| for the structure of
+		stack trace.  See also |v:exception|, |v:throwpoint|, and
+		|throw-variables|.
+
 					*v:statusmsg* *statusmsg-variable*
 v:statusmsg	Last given status message.  It's allowed to set this variable.
-
-					*v:stacktrace* *stacktrace-variable*
-v:stacktrace	Contains the stack trace whitch is a list of dictionaries.
-		This dictionary has following member:
-			'funcref'	The funcref of current function.
-			'lnum'		If this function was defined in a script,
-					contains the current line number.
-			'filepath'	If this function was defined in a script,
-					contains the current filepath.
 
 					*v:swapname* *swapname-variable*
 v:swapname	Only valid when executing |SwapExists| autocommands: Name of
@@ -2685,7 +2683,7 @@ v:this_session	Full filename of the last loaded or saved session file.  See
 					*v:throwpoint* *throwpoint-variable*
 v:throwpoint	The point where the exception most recently caught and not
 		finished was thrown.  Not set when commands are typed.  See
-		also |v:exception| and |throw-variables|.
+		also |v:exception|, |v:stacktrace|, and |throw-variables|.
 		Example: >
 	:try
 	:  throw "oops"
@@ -3865,7 +3863,8 @@ in the variable |v:exception|: >
 	:    echo "Number thrown.  Value is" v:exception
 
 You may also be interested where an exception was thrown.  This is stored in
-|v:throwpoint|.  Note that "v:exception" and "v:throwpoint" are valid for the
+|v:throwpoint|.  And you can obtain the stack trace from |v:stacktrace|.
+Note that "v:exception", "v:stacktrace" and "v:throwpoint" are valid for the
 exception most recently caught as long it is not finished.
    Example: >
 

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -7908,6 +7908,7 @@ getscript-history	pi_getscript.txt	/*getscript-history*
 getscript-plugins	pi_getscript.txt	/*getscript-plugins*
 getscript-start	pi_getscript.txt	/*getscript-start*
 getscriptinfo()	builtin.txt	/*getscriptinfo()*
+getstacktrace()	builtin.txt	/*getstacktrace()*
 gettabinfo()	builtin.txt	/*gettabinfo()*
 gettabvar()	builtin.txt	/*gettabvar()*
 gettabwinvar()	builtin.txt	/*gettabwinvar()*
@@ -10218,6 +10219,7 @@ sqrt()	builtin.txt	/*sqrt()*
 squirrel.vim	syntax.txt	/*squirrel.vim*
 srand()	builtin.txt	/*srand()*
 sscanf	eval.txt	/*sscanf*
+stacktrace-variable	eval.txt	/*stacktrace-variable*
 standard-plugin	usr_05.txt	/*standard-plugin*
 standard-plugin-list	help.txt	/*standard-plugin-list*
 standout	syntax.txt	/*standout*
@@ -11038,6 +11040,7 @@ v:shell_error	eval.txt	/*v:shell_error*
 v:sizeofint	eval.txt	/*v:sizeofint*
 v:sizeoflong	eval.txt	/*v:sizeoflong*
 v:sizeofpointer	eval.txt	/*v:sizeofpointer*
+v:stacktrace	eval.txt	/*v:stacktrace*
 v:statusmsg	eval.txt	/*v:statusmsg*
 v:swapchoice	eval.txt	/*v:swapchoice*
 v:swapcommand	eval.txt	/*v:swapcommand*

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -1399,7 +1399,8 @@ Various:					*various-functions*
 	eventhandler()		check if invoked by an event handler
 	getcellpixels()		get List of cell pixel size
 	getpid()		get process ID of Vim
-	getscriptinfo()		get list of sourced vim scripts
+	getscriptinfo()		get list of sourced Vim scripts
+	getstacktrace()		get current stack trace of Vim scripts
 	getimstatus()		check if IME status is active
 	interrupt()		interrupt script execution
 	windowsversion()	get MS-Windows version

--- a/src/dict.c
+++ b/src/dict.c
@@ -532,6 +532,29 @@ dict_add_callback(dict_T *d, char *key, callback_T *cb)
 }
 
 /*
+ * Add a function entry to dictionary "d".
+ * Returns FAIL when out of memory and when key already exists.
+ */
+    int
+dict_add_func(dict_T *d, char *key, ufunc_T *fp)
+{
+    dictitem_T	*item;
+
+    item = dictitem_alloc((char_u *)key);
+    if (item == NULL)
+	return FAIL;
+    item->di_tv.v_type = VAR_FUNC;
+    item->di_tv.vval.v_string = vim_strsave(fp->uf_name);
+    if (dict_add(d, item) == FAIL)
+    {
+	dictitem_free(item);
+	return FAIL;
+    }
+    func_ref(item->di_tv.vval.v_string);
+    return OK;
+}
+
+/*
  * Initializes "iter" for iterating over dictionary items with
  * dict_iterate_next().
  * If "var" is not a Dict or an empty Dict then there will be nothing to

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -2170,6 +2170,8 @@ static funcentry_T global_functions[] =
 			ret_string,	    f_getregtype},
     {"getscriptinfo",	0, 1, 0,	    arg1_dict_any,
 			ret_list_dict_any,  f_getscriptinfo},
+    {"getstacktrace",	0, 0, 0,	    NULL,
+			ret_list_dict_any,  f_getstacktrace},
     {"gettabinfo",	0, 1, FEARG_1,	    arg1_number,
 			ret_list_dict_any,  f_gettabinfo},
     {"gettabvar",	2, 3, FEARG_1,	    arg3_number_string_any,

--- a/src/evalvars.c
+++ b/src/evalvars.c
@@ -160,7 +160,8 @@ static struct vimvar
     {VV_NAME("python3_version",	 VAR_NUMBER), NULL, VV_RO},
     {VV_NAME("t_typealias",	 VAR_NUMBER), NULL, VV_RO},
     {VV_NAME("t_enum",		 VAR_NUMBER), NULL, VV_RO},
-    {VV_NAME("t_enumvalue",	 VAR_NUMBER), NULL, VV_RO}
+    {VV_NAME("t_enumvalue",	 VAR_NUMBER), NULL, VV_RO},
+    {VV_NAME("stacktrace",	 VAR_LIST), &t_list_string, VV_RO},
 };
 
 // shorthand
@@ -249,6 +250,7 @@ evalvars_init(void)
     set_vim_var_nr(VV_SIZEOFLONG, sizeof(long));
     set_vim_var_nr(VV_SIZEOFPOINTER, sizeof(char *));
     set_vim_var_nr(VV_MAXCOL, MAXCOL);
+    set_vim_var_list(VV_STACKTRACE, list_alloc());
 
     set_vim_var_nr(VV_TYPE_NUMBER,  VAR_TYPE_NUMBER);
     set_vim_var_nr(VV_TYPE_STRING,  VAR_TYPE_STRING);

--- a/src/evalvars.c
+++ b/src/evalvars.c
@@ -250,7 +250,6 @@ evalvars_init(void)
     set_vim_var_nr(VV_SIZEOFLONG, sizeof(long));
     set_vim_var_nr(VV_SIZEOFPOINTER, sizeof(char *));
     set_vim_var_nr(VV_MAXCOL, MAXCOL);
-    set_vim_var_list(VV_STACKTRACE, list_alloc());
 
     set_vim_var_nr(VV_TYPE_NUMBER,  VAR_TYPE_NUMBER);
     set_vim_var_nr(VV_TYPE_STRING,  VAR_TYPE_STRING);

--- a/src/proto/dict.pro
+++ b/src/proto/dict.pro
@@ -22,6 +22,7 @@ int dict_add_string_len(dict_T *d, char *key, char_u *str, int len);
 int dict_add_list(dict_T *d, char *key, list_T *list);
 int dict_add_tv(dict_T *d, char *key, typval_T *tv);
 int dict_add_callback(dict_T *d, char *key, callback_T *cb);
+int dict_add_func(dict_T *d, char *key, ufunc_T *fp);
 void dict_iterate_start(typval_T *var, dict_iterator_T *iter);
 char_u *dict_iterate_next(dict_iterator_T *iter, typval_T **tv_result);
 int dict_add_dict(dict_T *d, char *key, dict_T *dict);

--- a/src/proto/scriptfile.pro
+++ b/src/proto/scriptfile.pro
@@ -5,6 +5,8 @@ estack_T *estack_push_ufunc(ufunc_T *ufunc, long lnum);
 int estack_top_is_ufunc(ufunc_T *ufunc, long lnum);
 estack_T *estack_pop(void);
 char_u *estack_sfile(estack_arg_T which);
+list_T *stacktrace_create(void);
+void f_getstacktrace(typval_T *argvars, typval_T *rettv);
 void ex_runtime(exarg_T *eap);
 void set_context_in_runtime_cmd(expand_T *xp, char_u *arg);
 int find_script_by_name(char_u *name);

--- a/src/structs.h
+++ b/src/structs.h
@@ -63,6 +63,17 @@ typedef struct growarray
 
 #define GA_EMPTY    {0, 0, 0, 0, NULL}
 
+// On rare systems "char" is unsigned, sometimes we really want a signed 8-bit
+// value.
+typedef signed char	int8_T;
+typedef double		float_T;
+
+typedef struct typval_S		typval_T;
+typedef struct listvar_S	list_T;
+typedef struct dictvar_S	dict_T;
+typedef struct partial_S	partial_T;
+typedef struct blobvar_S	blob_T;
+
 typedef struct window_S		win_T;
 typedef struct wininfo_S	wininfo_T;
 typedef struct frame_S		frame_T;
@@ -1087,6 +1098,7 @@ struct vim_exception
     struct msglist	*messages;	// message(s) causing error exception
     char_u		*throw_name;	// name of the throw point
     linenr_T		throw_lnum;	// line number of the throw point
+    list_T		*stacktrace;	// stacktrace
     except_T		*caught;	// next exception on the caught stack
 };
 
@@ -1446,18 +1458,6 @@ typedef long_u hash_T;		// Type for hi_hash
 #  define UVARNUM_MAX		ULONG_LONG_MAX
 # endif
 #endif
-
-// On rare systems "char" is unsigned, sometimes we really want a signed 8-bit
-// value.
-typedef signed char int8_T;
-
-typedef double	float_T;
-
-typedef struct typval_S typval_T;
-typedef struct listvar_S list_T;
-typedef struct dictvar_S dict_T;
-typedef struct partial_S partial_T;
-typedef struct blobvar_S blob_T;
 
 // Struct that holds both a normal function name and a partial_T, as used for a
 // callback argument.

--- a/src/testdir/Make_all.mak
+++ b/src/testdir/Make_all.mak
@@ -292,6 +292,7 @@ NEW_TESTS = \
 	test_spell_utf8 \
 	test_spellfile \
 	test_spellrare \
+	test_stacktrace \
 	test_startup \
 	test_startup_utf8 \
 	test_stat \
@@ -545,6 +546,7 @@ NEW_TESTS_RES = \
 	test_spell_utf8.res \
 	test_spellfile.res \
 	test_spellrare.res \
+	test_stacktrace.res \
 	test_startup.res \
 	test_stat.res \
 	test_statusline.res \

--- a/src/testdir/test_stacktrace.vim
+++ b/src/testdir/test_stacktrace.vim
@@ -1,0 +1,107 @@
+" Test for getstacktrace() and v:stacktrace
+
+let s:thisfile = expand('%:p')
+let s:testdir = s:thisfile->fnamemodify(':h')
+
+func Filepath(name)
+  return s:testdir .. '/' .. a:name
+endfunc
+
+func AssertStacktrace(expect, actual)
+  call assert_equal(#{lnum: 617, filepath: Filepath('runtest.vim')}, a:actual[0])
+  call assert_equal(a:expect, a:actual[-len(a:expect):])
+endfunc
+
+func Test_getstacktrace()
+  let g:stacktrace = []
+  let lines1 =<< trim [SCRIPT]
+  " Xscript1
+  source Xscript2
+  func Xfunc1()
+    " Xfunc1
+    call Xfunc2()
+  endfunc
+  [SCRIPT]
+  let lines2 =<< trim [SCRIPT]
+  " Xscript2
+  func Xfunc2()
+    " Xfunc2
+    let g:stacktrace = getstacktrace()
+  endfunc
+  [SCRIPT]
+  call writefile(lines1, 'Xscript1', 'D')
+  call writefile(lines2, 'Xscript2', 'D')
+  source Xscript1
+  call Xfunc1()
+  call AssertStacktrace([
+        \ #{funcref: funcref('Test_getstacktrace'), lnum: 35, filepath: s:thisfile},
+        \ #{funcref: funcref('Xfunc1'), lnum: 5, filepath: Filepath('Xscript1')},
+        \ #{funcref: funcref('Xfunc2'), lnum: 4, filepath: Filepath('Xscript2')},
+        \ ], g:stacktrace)
+  unlet g:stacktrace
+endfunc
+
+func Test_getstacktrace_event()
+  let g:stacktrace = []
+  let lines1 =<< trim [SCRIPT]
+  " Xscript1
+  func Xfunc()
+    " Xfunc
+    let g:stacktrace = getstacktrace()
+  endfunc
+  augroup test_stacktrace
+    autocmd SourcePre * call Xfunc()
+  augroup END
+  [SCRIPT]
+  let lines2 =<< trim [SCRIPT]
+  " Xscript2
+  [SCRIPT]
+  call writefile(lines1, 'Xscript1', 'D')
+  call writefile(lines2, 'Xscript2', 'D')
+  source Xscript1
+  source Xscript2
+  call AssertStacktrace([
+       \ #{funcref: funcref('Test_getstacktrace_event'), lnum: 62, filepath: s:thisfile},
+       \ #{event: 'SourcePre Autocommands for "*"', lnum: 7, filepath: Filepath('Xscript1')},
+       \ #{funcref: funcref('Xfunc'), lnum: 4, filepath: Filepath('Xscript1')},
+       \ ], g:stacktrace)
+  augroup test_stacktrace
+    autocmd!
+  augroup END
+  unlet g:stacktrace
+endfunc
+
+func Test_vstacktrace()
+  let lines1 =<< trim [SCRIPT]
+  " Xscript1
+  source Xscript2
+  func Xfunc1()
+    " Xfunc1
+    call Xfunc2()
+  endfunc
+  [SCRIPT]
+  let lines2 =<< trim [SCRIPT]
+  " Xscript2
+  func Xfunc2()
+    " Xfunc2
+    throw 'Exception from Xfunc2'
+  endfunc
+  [SCRIPT]
+  call writefile(lines1, 'Xscript1', 'D')
+  call writefile(lines2, 'Xscript2', 'D')
+  source Xscript1
+  call assert_equal([], v:stacktrace)
+  try
+    call Xfunc1()
+  catch
+    let stacktrace = v:stacktrace
+  endtry
+  call assert_equal([], v:stacktrace)
+  call AssertStacktrace([
+       \ #{funcref: funcref('Test_vstacktrace'), lnum: 95, filepath: s:thisfile},
+       \ #{funcref: funcref('Xfunc1'), lnum: 5, filepath: Filepath('Xscript1')},
+       \ #{funcref: funcref('Xfunc2'), lnum: 4, filepath: Filepath('Xscript2')},
+       \ ], stacktrace)
+endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -3322,45 +3322,6 @@ check_user_func_argcount(ufunc_T *fp, int argcount)
     return FCERR_UNKNOWN;
 }
 
-    static void
-push_stacktrace(ufunc_T *fp, linenr_T lnum)
-{
-    list_T	*l = NULL;
-    dict_T	*d = NULL;
-    typval_T	tv;
-
-    l = get_vim_var_list(VV_STACKTRACE);
-    if (l == NULL)
-	return;
-
-    d = dict_alloc();
-    if (d == NULL)
-	return;
-
-    tv.v_type = VAR_DICT;
-    tv.v_lock = VAR_LOCKED;
-    tv.vval.v_dict = d;
-
-    dict_add_func(d, "funcref", fp);
-    dict_add_number(d, "lnum", current_sctx.sc_lnum + lnum);
-    dict_add_string(d, "filepath", current_sctx.sc_sid > 0 ?
-			   get_scriptname(current_sctx.sc_sid) : (char_u *)"");
-
-    list_append_tv(l, &tv);
-}
-
-    static void
-pop_stacktrace()
-{
-    list_T	*l = get_vim_var_list(VV_STACKTRACE);
-
-    if (l == NULL)
-	return;
-
-    if (0 < l->lv_len && l->lv_u.mat.lv_last != NULL)
-	listitem_remove(l, l->lv_u.mat.lv_last);
-}
-
 /*
  * Call a user function after checking the arguments.
  */
@@ -3411,10 +3372,8 @@ call_user_func_check(
 	    did_save_redo = TRUE;
 	}
 	++fp->uf_calls;
-	push_stacktrace(fp, SOURCING_LNUM);
 	error = call_user_func(fp, argcount, argvars, rettv, funcexe,
 				   (fp->uf_flags & FC_DICT) ? selfdict : NULL);
-	pop_stacktrace();
 	if (--fp->uf_calls <= 0 && fp->uf_refcount <= 0)
 	    // Function was unreferenced while being used, free it now.
 	    func_clear_free(fp, FALSE);

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -3322,6 +3322,45 @@ check_user_func_argcount(ufunc_T *fp, int argcount)
     return FCERR_UNKNOWN;
 }
 
+    static void
+push_stacktrace(ufunc_T *fp, linenr_T lnum)
+{
+    list_T	*l = NULL;
+    dict_T	*d = NULL;
+    typval_T	tv;
+
+    l = get_vim_var_list(VV_STACKTRACE);
+    if (l == NULL)
+	return;
+
+    d = dict_alloc();
+    if (d == NULL)
+	return;
+
+    tv.v_type = VAR_DICT;
+    tv.v_lock = VAR_LOCKED;
+    tv.vval.v_dict = d;
+
+    dict_add_func(d, "funcref", fp);
+    dict_add_number(d, "lnum", current_sctx.sc_lnum + lnum);
+    dict_add_string(d, "filepath", current_sctx.sc_sid > 0 ?
+			   get_scriptname(current_sctx.sc_sid) : (char_u *)"");
+
+    list_append_tv(l, &tv);
+}
+
+    static void
+pop_stacktrace()
+{
+    list_T	*l = get_vim_var_list(VV_STACKTRACE);
+
+    if (l == NULL)
+	return;
+
+    if (0 < l->lv_len && l->lv_u.mat.lv_last != NULL)
+	listitem_remove(l, l->lv_u.mat.lv_last);
+}
+
 /*
  * Call a user function after checking the arguments.
  */
@@ -3372,8 +3411,10 @@ call_user_func_check(
 	    did_save_redo = TRUE;
 	}
 	++fp->uf_calls;
+	push_stacktrace(fp, SOURCING_LNUM);
 	error = call_user_func(fp, argcount, argvars, rettv, funcexe,
 				   (fp->uf_flags & FC_DICT) ? selfdict : NULL);
+	pop_stacktrace();
 	if (--fp->uf_calls <= 0 && fp->uf_refcount <= 0)
 	    // Function was unreferenced while being used, free it now.
 	    func_clear_free(fp, FALSE);

--- a/src/vim.h
+++ b/src/vim.h
@@ -2190,7 +2190,8 @@ typedef int sock_T;
 #define VV_TYPE_TYPEALIAS 107
 #define VV_TYPE_ENUM	  108
 #define VV_TYPE_ENUMVALUE 109
-#define VV_LEN		110	// number of v: vars
+#define VV_STACKTRACE	110
+#define VV_LEN		111	// number of v: vars
 
 // used for v_number in VAR_BOOL and VAR_SPECIAL
 #define VVAL_FALSE	0L	// VAR_BOOL


### PR DESCRIPTION
Original patch is written by @rbtnn 

Add `getstacktrace()` and `v:stacktrace` as the tools for investigation of Vim script.

### `getstacktrace()`

Returns the current stack trace of Vim scripts, a list of dict.
Dict items are:
* `funcref`
  * funcref (e.g. `funcref('MyFunc')`); if the stack is on function, otherwise this item is not exist
* `event`
  * string of event description (e.g. `BufNew Autocommands for "*"`); if the stack is on event, otherwise this item is not exist
* `lnum`
  * line number of the script
* `filepath`
  * file path of the script

### `v:stacktrace`

The stack trace where the exception most recently caught and not finished.
The structure is the same as `getstacktrace()`.
