### PR TITLE
Revert the documentation for :horizontal

### DIFF
--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -1386,7 +1386,7 @@ tag		command		action ~
 |:highlight|	:hi[ghlight]	specify highlighting methods
 |:hide|		:hid[e]		hide current buffer for a command
 |:history|	:his[tory]	print a history list
-|:horizontal|	:ho[rizontal]	following window command work horizontally
+|:horizontal|	:hor[izontal]	following window command work horizontally
 |:insert|	:i[nsert]	insert text
 |:iabbrev|	:ia[bbrev]	like ":abbrev" but for Insert mode
 |:iabclear|	:iabc[lear]	like ":abclear" but for Insert mode

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -2670,7 +2670,7 @@ $quote	eval.txt	/*$quote*
 :his	cmdline.txt	/*:his*
 :history	cmdline.txt	/*:history*
 :history-indexing	cmdline.txt	/*:history-indexing*
-:ho	windows.txt	/*:ho*
+:hor	windows.txt	/*:hor*
 :horizontal	windows.txt	/*:horizontal*
 :i	insert.txt	/*:i*
 :ia	map.txt	/*:ia*

--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -263,8 +263,8 @@ and 'winminwidth' are relevant.
 		will be equalized only vertically.
 		Doesn't work for |:execute| and |:normal|.
 
-						*:ho* *:horizontal*
-:ho[rizontal] {cmd}
+						*:hor* *:horizontal*
+:hor[izontal] {cmd}
 		Execute {cmd}.  Currently only makes a difference for
 		`horizontal wincmd =`, which will equalize windows only
 		horizontally.


### PR DESCRIPTION
(It is correct that :ho is not recognized as :horizontal)

After: https://github.com/vim/vim/commit/0c3e57b403e0e3a1fefca7bbd5ad4cb950eea616

PS.
`runtime/syntax/generator/gen_syntax_vim.vim` will be fixed later.