### PR TITLE
runtime(vim): Update matchit pattern, no Vim9 short names

### DIFF
--- a/runtime/ftplugin/vim.vim
+++ b/runtime/ftplugin/vim.vim
@@ -1,9 +1,9 @@
 " Vim filetype plugin
 " Language:		Vim
 " Maintainer:		Doug Kearns <dougkearns@gmail.com>
-" Last Change:		2024 Apr 13
-" 			2024 May 23 by Riley Bruins <ribru17@gmail.com> ('commentstring')
+" Last Change:		2025 Jan 3
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
+" Contributors:		Riley Bruins <ribru17@gmail.com> ('commentstring')
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin")
@@ -108,8 +108,8 @@ if exists("loaded_matchit")
 	\ '\<try\>:\%(\%(^\||\)\s*\)\@<=\<cat\%[ch]\>:\%(\%(^\||\)\s*\)\@<=\<fina\%[lly]\>:\%(\%(^\||\)\s*\)\@<=\<endt\%[ry]\>,' ..
 	\ '\<aug\%[roup]\s\+\%(END\>\)\@!\S:\<aug\%[roup]\s\+END\>,' ..
 	\ '\<class\>:\<endclass\>,' ..
-	\ '\<inte\%[rface]\>:\<endinterface\>,' ..
-	\ '\<enu\%[m]\>:\<endenum\>,'
+	\ '\<interface\>:\<endinterface\>,' ..
+	\ '\<enum\>:\<endenum\>,'
 
   " Ignore syntax region commands and settings, any 'en*' would clobber
   " if-endif.


### PR DESCRIPTION
Abbreviated :enum and :interface commands are no longer supported.
