### PR TITLE
filetype: add cake filetype

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -342,7 +342,7 @@ au BufNewFile,BufRead *.capnp			setf capnp
 au BufNewFile,BufRead cgdbrc			setf cgdbrc
 
 " C#
-au BufNewFile,BufRead *.cs,*.csx		setf cs
+au BufNewFile,BufRead *.cs,*.csx,*.cake		setf cs
 
 " CSDL
 au BufNewFile,BufRead *.csdl			setf csdl

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -196,7 +196,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     crm: ['file.crm'],
     crontab: ['crontab', 'crontab.file', '/etc/cron.d/file', 'any/etc/cron.d/file'],
     crystal: ['file.cr'],
-    cs: ['file.cs', 'file.csx'],
+    cs: ['file.cs', 'file.csx', 'file.cake'],
     csc: ['file.csc'],
     csdl: ['file.csdl'],
     csp: ['file.csp', 'file.fdr'],


### PR DESCRIPTION
Problem: filetype: cake filetype is not recognized
Solution: detect cake files as cs

This is a rather uncommon c# format used as a makefile replacement. See https://cakebuild.net/ for more info.