### PR TITLE
Vim9: Not able to use a comment after the opening curly brace of an inner-block

### DIFF
--- a/src/testdir/test_vim9_func.vim
+++ b/src/testdir/test_vim9_func.vim
@@ -4697,6 +4697,23 @@ def Test_test_override_defcompile()
   test_override('defcompile', 0)
 enddef
 
+" Test for using a comment after the opening curly brace of an inner block.
+def Test_comment_after_inner_block()
+  var lines =<< trim END
+    vim9script
+
+    def F(G: func)
+    enddef
+
+    F(() => {       # comment1
+      F(() => {     # comment2
+        echo 'ok'   # comment3
+      })            # comment4
+    })              # comment5
+  END
+  v9.CheckScriptSuccess(lines)
+enddef
+
 " The following messes up syntax highlight, keep near the end.
 if has('python3')
   def Test_python3_command()

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -1123,7 +1123,20 @@ get_function_body(
 	    if (nesting_def[nesting] ? *p != '#' : *p != '"')
 	    {
 		// Not a comment line: check for nested inline function.
-		end = p + STRLEN(p) - 1;
+
+		if (in_vim9script())
+		{
+		    // A comment can be present after the opening curly brace
+		    // of a block statement.  Need to ignore the comment and
+		    // look for the opening curly brace before that.
+		    char_u	*t = p;
+		    while (*t && !vim9_comment_start(t))
+			t++;
+		    end = t -1;
+		}
+		else
+		    end = p + STRLEN(p) - 1;
+
 		while (end > p && VIM_ISWHITE(*end))
 		    --end;
 		if (end > p + 1 && *end == '{' && VIM_ISWHITE(end[-1]))


### PR DESCRIPTION

Fixes #16363.