### PR TITLE
Vim9: Whitespace after the final enum value can produce a syntax error

### DIFF
--- a/src/testdir/test_codestyle.vim
+++ b/src/testdir/test_codestyle.vim
@@ -85,6 +85,7 @@ def Test_test_files()
             && fname !~ 'test_let.vim'
             && fname !~ 'test_tagjump.vim'
             && fname !~ 'test_vim9_cmd.vim'
+            && fname !~ 'test_vim9_enum.vim'
       cursor(1, 1)
       var lnum = search(
           fname =~ 'test_vim9_assign.vim' ? '[^=]\s$'

--- a/src/testdir/test_vim9_enum.vim
+++ b/src/testdir/test_vim9_enum.vim
@@ -908,6 +908,18 @@ def Test_enum_comments()
   END
   v9.CheckSourceSuccess(lines)
 
+  lines =<< trim END
+    vim9script
+    enum Car   # cars
+      # before enum
+      Honda(), # honda
+      # before enum
+      Ford()   # ford
+    endenum
+    assert_equal(1, Car.Ford.ordinal)
+  END
+  v9.CheckSourceSuccess(lines)
+
   # Test for using an unsupported comment
   lines =<< trim END
     vim9script
@@ -919,6 +931,29 @@ def Test_enum_comments()
     defcompile
   END
   v9.CheckSourceFailure(lines, 'E1170: Cannot use #{ to start a comment', 4)
+enddef
+
+" Test trailing whitespace after enum values
+def Test_enum_whitespace()
+  var lines =<< trim END
+    vim9script
+    enum Car
+      Honda, 
+      Ford   
+    endenum
+    defcompile
+  END
+  v9.CheckSourceSuccess(lines)
+
+  lines =<< trim END
+    vim9script
+    enum Car
+      Honda(), 
+      Ford()   
+    endenum
+    defcompile
+  END
+  v9.CheckSourceSuccess(lines)
 enddef
 
 " Test string() with enums

--- a/src/vim9class.c
+++ b/src/vim9class.c
@@ -1623,6 +1623,8 @@ enum_parse_values(
 	}
     }
 
+    p = skipwhite(p);
+
     if (*p != NUL && *p != '#')
     {
 	if (did_emsg == did_emsg_before)


### PR DESCRIPTION
Problem:  Vim9: Whitespace after the final enum value produces a syntax error (E1123: Missing comma before argument) if constructor args are specified.
Solution: Fix parsing to allow whitespace after the final enum value.
