### PR TITLE
v:stacktrace has wrong type in Vim9 script

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -1,4 +1,4 @@
-*builtin.txt*	For Vim version 9.1.  Last change: 2025 Jan 05
+*builtin.txt*	For Vim version 9.1.  Last change: 2025 Jan 06
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -5002,12 +5002,12 @@ getstacktrace()						*getstacktrace()*
 		Returns the current stack trace of Vim scripts.
 		Stack trace is a |List|, of which each item is a |Dictionary|
 		with the following items:
-		    funcref	The funcref if the stack is at the function,
-				otherwise this item is not exist.
+		    funcref	The funcref if the stack is at a function,
+				otherwise this item is omitted.
 		    event	The string of the event description if the
-				stack is at autocmd event, otherwise this item
-				is not exist.
-		    lnum	The line number of the script on the stack.
+				stack is at an autocmd event, otherwise this
+				item is omitted.
+		    lnum	The line number in the script on the stack.
 		    filepath	The file path of the script on the stack.
 
 		Return type: list<dict<any>>

--- a/src/evalvars.c
+++ b/src/evalvars.c
@@ -161,7 +161,7 @@ static struct vimvar
     {VV_NAME("t_typealias",	 VAR_NUMBER), NULL, VV_RO},
     {VV_NAME("t_enum",		 VAR_NUMBER), NULL, VV_RO},
     {VV_NAME("t_enumvalue",	 VAR_NUMBER), NULL, VV_RO},
-    {VV_NAME("stacktrace",	 VAR_LIST), &t_list_string, VV_RO},
+    {VV_NAME("stacktrace",	 VAR_LIST), &t_list_dict_any, VV_RO},
 };
 
 // shorthand

--- a/src/testdir/test_stacktrace.vim
+++ b/src/testdir/test_stacktrace.vim
@@ -1,5 +1,7 @@
 " Test for getstacktrace() and v:stacktrace
 
+import './vim9.vim' as v9
+
 let s:thisfile = expand('%:p')
 let s:testdir = s:thisfile->fnamemodify(':h')
 
@@ -34,7 +36,7 @@ func Test_getstacktrace()
   source Xscript1
   call Xfunc1()
   call AssertStacktrace([
-        \ #{funcref: funcref('Test_getstacktrace'), lnum: 35, filepath: s:thisfile},
+        \ #{funcref: funcref('Test_getstacktrace'), lnum: 37, filepath: s:thisfile},
         \ #{funcref: funcref('Xfunc1'), lnum: 5, filepath: Filepath('Xscript1')},
         \ #{funcref: funcref('Xfunc2'), lnum: 4, filepath: Filepath('Xscript2')},
         \ ], g:stacktrace)
@@ -61,7 +63,7 @@ func Test_getstacktrace_event()
   source Xscript1
   source Xscript2
   call AssertStacktrace([
-       \ #{funcref: funcref('Test_getstacktrace_event'), lnum: 62, filepath: s:thisfile},
+       \ #{funcref: funcref('Test_getstacktrace_event'), lnum: 64, filepath: s:thisfile},
        \ #{event: 'SourcePre Autocommands for "*"', lnum: 7, filepath: Filepath('Xscript1')},
        \ #{funcref: funcref('Xfunc'), lnum: 4, filepath: Filepath('Xscript1')},
        \ ], g:stacktrace)
@@ -98,10 +100,33 @@ func Test_vstacktrace()
   endtry
   call assert_equal([], v:stacktrace)
   call AssertStacktrace([
-       \ #{funcref: funcref('Test_vstacktrace'), lnum: 95, filepath: s:thisfile},
+       \ #{funcref: funcref('Test_vstacktrace'), lnum: 97, filepath: s:thisfile},
        \ #{funcref: funcref('Xfunc1'), lnum: 5, filepath: Filepath('Xscript1')},
        \ #{funcref: funcref('Xfunc2'), lnum: 4, filepath: Filepath('Xscript2')},
        \ ], stacktrace)
+endfunc
+
+func Test_zzz_stacktrace_vim9()
+  let lines =<< trim [SCRIPT]
+  var stacktrace = getstacktrace()
+  assert_notequal([], stacktrace)
+  for d in stacktrace
+    assert_true(has_key(d, 'lnum'))
+  endfor
+  try
+    throw 'Exception from s:Func'
+  catch
+    assert_notequal([], v:stacktrace)
+    assert_equal(len(stacktrace), len(v:stacktrace))
+    for d in v:stacktrace
+      assert_true(has_key(d, 'lnum'))
+    endfor
+  endtry
+  [SCRIPT]
+  call v9.CheckDefSuccess(lines)
+  " FIXME: v:stacktrace is not cleared after the exception handling, and this
+  " test has to be run as the last one because of this.
+  " call assert_equal([], v:stacktrace)
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  v:stacktrace has wrong type in Vim9 script.
Solution: Change the type to t_list_dict_any.  Fix grammar in docs.