### PR TITLE
detect Visual Studio Code Json settings as JsonC

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1274,7 +1274,7 @@ au BufNewFile,BufRead .prettierrc,.firebaserc,.stylelintrc,.lintstagedrc,flake.l
 au BufNewFile,BufRead *.jsonc,.babelrc,.eslintrc,.jsfmtrc,bun.lock	setf jsonc
 au BufNewFile,BufRead .jshintrc,.jscsrc,.vsconfig,.hintrc,.swrc,[jt]sconfig*.json	setf jsonc
 " Visual Studio Code settings
-au BufRead,BufNewFile ~/*/{Code,VSCodium}/User/*.json setf jsconc
+au BufRead,BufNewFile ~/*/{Code,VSCodium}/User/*.json setf jsonc
 
 " JSON
 au BufNewFile,BufRead *.json,*.jsonp,*.webmanifest	setf json

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1273,7 +1273,7 @@ au BufNewFile,BufRead .prettierrc,.firebaserc,.stylelintrc,.lintstagedrc,flake.l
 " JSONC (JSON with comments)
 au BufNewFile,BufRead *.jsonc,.babelrc,.eslintrc,.jsfmtrc,bun.lock	setf jsonc
 au BufNewFile,BufRead .jshintrc,.jscsrc,.vsconfig,.hintrc,.swrc,[jt]sconfig*.json	setf jsonc
-" Visual Code settings
+" Visual Studio Code settings
 au BufRead,BufNewFile ~/*/{Code,VSCodium}/User/*.json setf jsconc
 
 " JSON

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1274,20 +1274,7 @@ au BufNewFile,BufRead .prettierrc,.firebaserc,.stylelintrc,.lintstagedrc,flake.l
 au BufNewFile,BufRead *.jsonc,.babelrc,.eslintrc,.jsfmtrc,bun.lock	setf jsonc
 au BufNewFile,BufRead .jshintrc,.jscsrc,.vsconfig,.hintrc,.swrc,[jt]sconfig*.json	setf jsonc
 " Visual Code settings
-if has('win32')
-  au BufRead,BufNewFile,BufFilePost $APPDATA/{Code,VSCodium}/User/*.json setlocal filetype=jsconc
-elseif has('unix')
-  " Mac: $HOME/Library/Application Support/Code/User/settings.json
-  if isdirectory($HOME..'/Library/Application Support')
-    au BufRead,BufNewFile,BufFilePost ~/Library/Application Support/{Code,VSCodium}/User/*.json setlocal filetype=jsonc
-  " Linux: $XDG_CONFIG_HOME/Code/User/settings.json
-  " with $XDG_CONFIG_HOME being $HOME/.config by default
-  elseif !empty($XDG_CONFIG_HOME)
-    au BufRead,BufNewFile,BufFilePost $XDG_CONFIG_HOME/{Code,VSCodium}/User/*.json setlocal filetype=jsonc
-  elseif isdirectory($HOME..'/.config')
-    au BufRead,BufNewFile,BufFilePost ~/.config/{Code,VSCodium}/User/*.json setlocal filetype=jsonc
-  endif
-endif
+au BufRead,BufNewFile ~/{Code,VSCodium}/User/*.json setf jsconc
 
 " JSON
 au BufNewFile,BufRead *.json,*.jsonp,*.webmanifest	setf json

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1274,7 +1274,7 @@ au BufNewFile,BufRead .prettierrc,.firebaserc,.stylelintrc,.lintstagedrc,flake.l
 au BufNewFile,BufRead *.jsonc,.babelrc,.eslintrc,.jsfmtrc,bun.lock	setf jsonc
 au BufNewFile,BufRead .jshintrc,.jscsrc,.vsconfig,.hintrc,.swrc,[jt]sconfig*.json	setf jsonc
 " Visual Code settings
-au BufRead,BufNewFile ~/{Code,VSCodium}/User/*.json setf jsconc
+au BufRead,BufNewFile ~/*/{Code,VSCodium}/User/*.json setf jsconc
 
 " JSON
 au BufNewFile,BufRead *.json,*.jsonp,*.webmanifest	setf json

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1273,6 +1273,21 @@ au BufNewFile,BufRead .prettierrc,.firebaserc,.stylelintrc,.lintstagedrc,flake.l
 " JSONC (JSON with comments)
 au BufNewFile,BufRead *.jsonc,.babelrc,.eslintrc,.jsfmtrc,bun.lock	setf jsonc
 au BufNewFile,BufRead .jshintrc,.jscsrc,.vsconfig,.hintrc,.swrc,[jt]sconfig*.json	setf jsonc
+" Visual Code settings
+if has('win32')
+  au BufRead,BufNewFile,BufFilePost $APPDATA/{Code,VSCodium}/User/*.json setlocal filetype=jsconc
+elseif has('unix')
+  " Mac: $HOME/Library/Application Support/Code/User/settings.json
+  if isdirectory($HOME..'/Library/Application Support')
+    au BufRead,BufNewFile,BufFilePost ~/Library/Application Support/{Code,VSCodium}/User/*.json setlocal filetype=jsonc
+  " Linux: $XDG_CONFIG_HOME/Code/User/settings.json
+  " with $XDG_CONFIG_HOME being $HOME/.config by default
+  elseif !empty($XDG_CONFIG_HOME)
+    au BufRead,BufNewFile,BufFilePost $XDG_CONFIG_HOME/{Code,VSCodium}/User/*.json setlocal filetype=jsonc
+  elseif isdirectory($HOME..'/.config')
+    au BufRead,BufNewFile,BufFilePost ~/.config/{Code,VSCodium}/User/*.json setlocal filetype=jsonc
+  endif
+endif
 
 " JSON
 au BufNewFile,BufRead *.json,*.jsonp,*.webmanifest	setf json

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -399,7 +399,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     '.prettierrc', '.firebaserc', '.stylelintrc', '.lintstagedrc', 'file.slnf', 'file.sublime-project', 'file.sublime-settings', 'file.sublime-workspace',
     'file.bd', 'file.bda', 'file.xci', 'flake.lock', 'pack.mcmeta', 'deno.lock'],
     json5: ['file.json5'],
-    jsonc: ['file.jsonc', '.babelrc', '.eslintrc', '.jsfmtrc', '.jshintrc', '.jscsrc', '.vsconfig', '.hintrc', '.swrc', 'jsconfig.json', 'tsconfig.json', 'tsconfig.test.json', 'tsconfig-test.json', '.luaurc', 'bun.lock', /home/linus/.config/VSCodium/User/settings.json'],
+    jsonc: ['file.jsonc', '.babelrc', '.eslintrc', '.jsfmtrc', '.jshintrc', '.jscsrc', '.vsconfig', '.hintrc', '.swrc', 'jsconfig.json', 'tsconfig.json', 'tsconfig.test.json', 'tsconfig-test.json', '.luaurc', 'bun.lock', '/home/linus/.config/VSCodium/User/settings.json'],
     jsonl: ['file.jsonl'],
     jsonnet: ['file.jsonnet', 'file.libsonnet'],
     jsp: ['file.jsp'],

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -399,7 +399,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     '.prettierrc', '.firebaserc', '.stylelintrc', '.lintstagedrc', 'file.slnf', 'file.sublime-project', 'file.sublime-settings', 'file.sublime-workspace',
     'file.bd', 'file.bda', 'file.xci', 'flake.lock', 'pack.mcmeta', 'deno.lock'],
     json5: ['file.json5'],
-    jsonc: ['file.jsonc', '.babelrc', '.eslintrc', '.jsfmtrc', '.jshintrc', '.jscsrc', '.vsconfig', '.hintrc', '.swrc', 'jsconfig.json', 'tsconfig.json', 'tsconfig.test.json', 'tsconfig-test.json', '.luaurc', 'bun.lock', '/home/linus/.config/VSCodium/User/settings.json'],
+    jsonc: ['file.jsonc', '.babelrc', '.eslintrc', '.jsfmtrc', '.jshintrc', '.jscsrc', '.vsconfig', '.hintrc', '.swrc', 'jsconfig.json', 'tsconfig.json', 'tsconfig.test.json', 'tsconfig-test.json', '.luaurc', 'bun.lock', expand("$HOME/.config/VSCodium/User/settings.json")],
     jsonl: ['file.jsonl'],
     jsonnet: ['file.jsonnet', 'file.libsonnet'],
     jsp: ['file.jsp'],

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -399,7 +399,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     '.prettierrc', '.firebaserc', '.stylelintrc', '.lintstagedrc', 'file.slnf', 'file.sublime-project', 'file.sublime-settings', 'file.sublime-workspace',
     'file.bd', 'file.bda', 'file.xci', 'flake.lock', 'pack.mcmeta', 'deno.lock'],
     json5: ['file.json5'],
-    jsonc: ['file.jsonc', '.babelrc', '.eslintrc', '.jsfmtrc', '.jshintrc', '.jscsrc', '.vsconfig', '.hintrc', '.swrc', 'jsconfig.json', 'tsconfig.json', 'tsconfig.test.json', 'tsconfig-test.json', '.luaurc', 'bun.lock'],
+    jsonc: ['file.jsonc', '.babelrc', '.eslintrc', '.jsfmtrc', '.jshintrc', '.jscsrc', '.vsconfig', '.hintrc', '.swrc', 'jsconfig.json', 'tsconfig.json', 'tsconfig.test.json', 'tsconfig-test.json', '.luaurc', 'bun.lock', /home/linus/.config/VSCodium/User/settings.json'],
     jsonl: ['file.jsonl'],
     jsonnet: ['file.jsonnet', 'file.libsonnet'],
     jsp: ['file.jsp'],


### PR DESCRIPTION
Visual Code is a popular IDE, in particular having a Vim extension and another one to embed Neovim, a fork of Vim, inside it.

I'm under the impression that fine-grained detection using specific paths is rather uncommon at this spot, but let's see what's recommended (other than the user putting this snippet into .vim/ftdetect/*.vim)