### PR TITLE
Fix Ruby tests to pass with Ruby 3.4

### DIFF
--- a/src/testdir/test_ruby.vim
+++ b/src/testdir/test_ruby.vim
@@ -290,7 +290,7 @@ func Test_ruby_Vim_buffer_get()
   call assert_match('Xfoo1$', rubyeval('Vim::Buffer[1].name'))
   call assert_match('Xfoo2$', rubyeval('Vim::Buffer[2].name'))
   call assert_fails('ruby print Vim::Buffer[3].name',
-        \           "NoMethodError: undefined method `name' for nil")
+        \           "NoMethodError")
   %bwipe
 endfunc
 
@@ -372,7 +372,7 @@ func Test_ruby_Vim_evaluate_dict()
   redir => l:out
   ruby d = Vim.evaluate("d"); print d
   redir END
-  call assert_equal(['{"a"=>"foo", "b"=>123}'], split(l:out, "\n"))
+  call assert_equal(['{"a"=>"foo","b"=>123}'], split(substitute(l:out, '\s', '', 'g'), "\n"))
 endfunc
 
 " Test Vim::message({msg}) (display message {msg})
@@ -391,7 +391,7 @@ func Test_ruby_print()
   call assert_equal('1.23', RubyPrint('1.23'))
   call assert_equal('Hello World!', RubyPrint('"Hello World!"'))
   call assert_equal('[1, 2]', RubyPrint('[1, 2]'))
-  call assert_equal('{"k1"=>"v1", "k2"=>"v2"}', RubyPrint('({"k1" => "v1", "k2" => "v2"})'))
+  call assert_equal('{"k1"=>"v1","k2"=>"v2"}', substitute(RubyPrint('({"k1" => "v1", "k2" => "v2"})'), '\s', '', 'g'))
   call assert_equal('true', RubyPrint('true'))
   call assert_equal('false', RubyPrint('false'))
   call assert_equal('', RubyPrint('nil'))


### PR DESCRIPTION
Vim's Ruby tests relied on explicit matching of output texts which are fragile in design. Ruby 3.4 has changed the output slightly (using 'name' instead of `name', and also using more spaces in dictionary printouts). Modify the Vim tests to be less fragile to such changes.