### PR TITLE
runtime: Fix typo of tiasm's b:current_syntax

### DIFF
--- a/runtime/syntax/tiasm.vim
+++ b/runtime/syntax/tiasm.vim
@@ -99,4 +99,4 @@ hi def link tiasmIdentifier	Identifier
 hi def link tiasmType		Type
 hi def link tiasmFunction	Function
 
-let b:current_syntax = "lineartiasm"
+let b:current_syntax = "tiasm"


### PR DESCRIPTION
Problem: Typo of tiasm's b:current_syntax
Solution: Fix it
