### PR TITLE
runtime(editorconfig): set omnifunc to syntax

### DIFF
--- a/runtime/ftplugin/editorconfig.vim
+++ b/runtime/ftplugin/editorconfig.vim
@@ -10,4 +10,6 @@ let b:did_ftplugin = 1
 
 setl comments=:#,:; commentstring=#\ %s
 
-let b:undo_ftplugin = 'setl com< cms<'
+setl omnifunc=syntaxcomplete#Complete
+
+let b:undo_ftplugin = 'setl com< cms< ofu<'


### PR DESCRIPTION
I always forget the supported properties of editorconfig. This helps with that.
