### PR TITLE
docs: add justify help tags

### DIFF
--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -2129,6 +2129,7 @@ $quote	eval.txt	/*$quote*
 :GnatTags	ft_ada.txt	/*:GnatTags*
 :HelpToc	helphelp.txt	/*:HelpToc*
 :Hexplore	pi_netrw.txt	/*:Hexplore*
+:Justify	usr_25.txt	/*:Justify*
 :LP	pi_logipat.txt	/*:LP*
 :LPE	pi_logipat.txt	/*:LPE*
 :LPF	pi_logipat.txt	/*:LPF*
@@ -5567,6 +5568,7 @@ J	change.txt	/*J*
 Japanese	mbyte.txt	/*Japanese*
 Job	eval.txt	/*Job*
 Jobs	eval.txt	/*Jobs*
+Justify()	usr_25.txt	/*Justify()*
 K	various.txt	/*K*
 KDE	gui_x11.txt	/*KDE*
 KVim	gui_x11.txt	/*KVim*
@@ -8538,6 +8540,7 @@ jump-motions	motion.txt	/*jump-motions*
 jumplist	motion.txt	/*jumplist*
 jumplist-stack	motion.txt	/*jumplist-stack*
 jumpto-diffs	diff.txt	/*jumpto-diffs*
+justify	usr_25.txt	/*justify*
 k	motion.txt	/*k*
 kcc	uganda.txt	/*kcc*
 kde	gui_x11.txt	/*kde*

--- a/runtime/doc/usr_25.txt
+++ b/runtime/doc/usr_25.txt
@@ -190,7 +190,7 @@ This results in the following:
 	story. ~
 
 
-JUSTIFYING TEXT
+JUSTIFYING TEXT				*justify* *:Justify*
 
 Vim has no built-in way of justifying text.  However, there is a neat macro
 package that does the job.  To use this package, execute the following

--- a/runtime/doc/usr_25.txt
+++ b/runtime/doc/usr_25.txt
@@ -190,7 +190,7 @@ This results in the following:
 	story. ~
 
 
-JUSTIFYING TEXT				*justify* *:Justify*
+JUSTIFYING TEXT				*justify* *:Justify* *Justify()*
 
 Vim has no built-in way of justifying text.  However, there is a neat macro
 package that does the job.  To use this package, execute the following


### PR DESCRIPTION
I accidentally discovered `packadd justify` (through `packadd <tab>` & looking through the pmenu) and wanted to learn more about this plugin, but there were no help tags.

I ran `:grep 'packadd.*justify'` on vim source files to find it.