### PR TITLE
Use the correct instruction for getting the interface member variable

### DIFF
--- a/src/testdir/test_vim9_class.vim
+++ b/src/testdir/test_vim9_class.vim
@@ -7257,6 +7257,31 @@ def Test_interface_extends_with_dup_members()
   v9.CheckSourceSuccess(lines)
 enddef
 
+" Test for implementing an interface with different ordering for the interface
+" member variables.
+def Test_implement_interface_with_different_variable_order()
+  var lines =<< trim END
+    vim9script
+
+    interface IX
+      var F: func(): string
+    endinterface
+
+    class X implements IX
+      var x: number
+      var F: func(): string = () => 'ok'
+    endclass
+
+    def Foo(ix: IX): string
+      return ix.F()
+    enddef
+
+    var x0 = X.new(0)
+    assert_equal('ok', Foo(x0))
+  END
+  v9.CheckSourceSuccess(lines)
+enddef
+
 " Test for using "any" type for a variable in a sub-class while it has a
 " concrete type in the interface
 def Test_implements_using_var_type_any()

--- a/src/testdir/test_vim9_disassemble.vim
+++ b/src/testdir/test_vim9_disassemble.vim
@@ -3586,4 +3586,29 @@ def Test_disassemble_member_initializer()
   unlet g:instr
 enddef
 
+" Disassemble the code generated for accessing a interface member variable
+def Test_disassemble_interface_variable_access()
+  var lines =<< trim END
+    vim9script
+    interface IX
+      var F: func(): string
+    endinterface
+
+    def Foo(ix: IX): string
+      return ix.F()
+    enddef
+
+    g:instr = execute('disassemble Foo')
+  END
+  v9.CheckScriptSuccess(lines)
+  assert_match('<SNR>\d\+_Foo\_s*' ..
+    'return ix.F()\_s*' ..
+    '0 LOAD arg\[-1\]\_s*' ..
+    '1 ITF_MEMBER 0 on IX\_s*' ..
+    '2 PCALL top (argc 0)\_s*' ..
+    '3 PCALL end\_s*' ..
+    '4 RETURN', g:instr)
+  unlet g:instr
+enddef
+
 " vim: ts=8 sw=2 sts=2 expandtab tw=80 fdm=marker

--- a/src/vim9expr.c
+++ b/src/vim9expr.c
@@ -392,8 +392,15 @@ compile_class_object_index(cctx_T *cctx, char_u **arg, type_T *type)
 	    }
 	    else
 	    {
-		if (generate_GET_OBJ_MEMBER(cctx, m_idx, ocm->ocm_type) ==
-									FAIL)
+		int status;
+
+		if (IS_INTERFACE(cl))
+		    status = generate_GET_ITF_MEMBER(cctx, cl, m_idx,
+							ocm->ocm_type);
+		else
+		    status = generate_GET_OBJ_MEMBER(cctx, m_idx,
+							ocm->ocm_type);
+		if (status == FAIL)
 		    return FAIL;
 	    }
 	}


### PR DESCRIPTION
Fix the issue reported in #16345.