### PR TITLE
Translate the function name before invoking it in call()

### DIFF
--- a/src/testdir/test_vim9_disassemble.vim
+++ b/src/testdir/test_vim9_disassemble.vim
@@ -3611,4 +3611,26 @@ def Test_disassemble_interface_variable_access()
   unlet g:instr
 enddef
 
+" Disassemble the code generated for accessing a script-local funcref
+def Test_disassemble_using_script_local_funcref()
+  var lines =<< trim END
+    vim9script
+    def Noop()
+    enddef
+    export var Setup = Noop
+    export def Run()
+      Setup()
+    enddef
+    g:instr = execute('disassemble Run')
+  END
+  v9.CheckScriptSuccess(lines)
+  assert_match('<SNR>\d\+_Run\_s*' ..
+    'Setup()\_s*' ..
+    '0 LOADSCRIPT Setup-0 from .*\_s*' ..
+    '1 PCALL (argc 0)\_s*' ..
+    '2 DROP\_s*' ..
+    '3 RETURN void\_s*', g:instr)
+  unlet g:instr
+enddef
+
 " vim: ts=8 sw=2 sts=2 expandtab tw=80 fdm=marker

--- a/src/testdir/test_vim9_func.vim
+++ b/src/testdir/test_vim9_func.vim
@@ -4714,6 +4714,47 @@ def Test_comment_after_inner_block()
   v9.CheckScriptSuccess(lines)
 enddef
 
+" Test for calling an imported funcref which is modified in the current script
+def Test_call_modified_import_func()
+  var lines =<< trim END
+    vim9script
+
+    export var done = 0
+
+    def Noop()
+    enddef
+
+    export var Setup = Noop
+
+    export def Run()
+      done = 0
+      Setup()
+      done += 1
+    enddef
+  END
+  writefile(lines, 'XcallModifiedImportFunc.vim', 'D')
+
+  lines =<< trim END
+    vim9script
+
+    import './XcallModifiedImportFunc.vim' as imp
+
+    var setup = 0
+
+    imp.Run()
+
+    imp.Setup = () => {
+      ++setup
+    }
+
+    imp.Run()
+
+    assert_equal(1, setup)
+    assert_equal(1, imp.done)
+  END
+  v9.CheckScriptSuccess(lines)
+enddef
+
 " The following messes up syntax highlight, keep near the end.
 if has('python3')
   def Test_python3_command()

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -2309,49 +2309,6 @@ find_func_with_prefix(char_u *name, int sid)
 }
 
 /*
- * Find a function by name, return pointer to it.
- * The name may be a local script variable, VAR_FUNC. or it may be a fully
- * qualified import name such as 'i_imp.FuncName'.
- *
- * When VAR_FUNC, the import might either direct or autoload.
- * When 'i_imp.FuncName' it is direct, autoload is rewritten as i_imp#FuncName
- * in f_call and subsequently found.
- */
-    static ufunc_T *
-find_func_imported(char_u *name, int flags)
-{
-    ufunc_T	*func = NULL;
-    char_u	*dot = name; // Find a dot, '.', in the name
-
-    // Either run into '.' or the end of the string
-    while (eval_isnamec(*dot))
-	++dot;
-
-    if (*dot == '.')
-    {
-	imported_T *import = find_imported(name, dot - name, FALSE);
-	if (import != NULL)
-	    func = find_func_with_sid(dot + 1, import->imp_sid);
-    }
-    else if (*dot == NUL) // looking at the entire string
-    {
-	hashtab_T *ht = get_script_local_ht();
-	if (ht != NULL)
-	{
-	    hashitem_T *hi = hash_find(ht, name);
-	    if (!HASHITEM_EMPTY(hi))
-	    {
-		dictitem_T *di = HI2DI(hi);
-		if (di->di_tv.v_type == VAR_FUNC
-			&& di->di_tv.vval.v_string != NULL)
-		    func = find_func_even_dead(di->di_tv.vval.v_string, flags);
-	    }
-	}
-    }
-    return func;
-}
-
-/*
  * Find a function by name, return pointer to it in ufuncs.
  * When "flags" has FFED_IS_GLOBAL don't find script-local or imported
  * functions.
@@ -2405,9 +2362,6 @@ find_func_even_dead(char_u *name, int flags)
     if (func != NULL)
 	return func;
 
-    // Find a script-local "VAR_FUNC" or i_"imp.Func", so vim9script).
-    if (in_vim9script())
-	func = find_func_imported(name, flags);
     return func;
 }
 


### PR DESCRIPTION
Fix the issue reported in #16430.  Revert the changes made in  9.1.0646 and fix the original issue by translating
the function name before using it in call().