### PR TITLE
Use ubuntu24 test runner.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   linux:
-    runs-on: ${{ matrix.architecture == 'arm64' && 'ubuntu-22.04-arm' || 'ubuntu-22.04' }}
+    runs-on: ${{ matrix.architecture == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
 
     env:
       CC: ${{ matrix.compiler }}
@@ -115,6 +115,7 @@ jobs:
             libncurses-dev:${{ matrix.architecture }} \
             libxt-dev:${{ matrix.architecture }} \
             locales-all \
+            software-properties-common \
           )
           if ${{ matrix.features == 'huge' }}; then
             LUA_VER=${{ matrix.lua_ver || '5.4' }}
@@ -124,7 +125,6 @@ jobs:
               lcov \
               libcanberra-dev \
               libperl-dev \
-              python2-dev \
               python3-dev \
               liblua${LUA_VER}-dev \
               lua${LUA_VER} \
@@ -136,7 +136,7 @@ jobs:
               libattr1-dev
             )
           fi
-          sudo apt-get update && sudo apt-get upgrade && sudo apt-get install -y "${PKGS[@]}"
+          sudo apt-get update && sudo apt-get upgrade -y && sudo apt-get install -y "${PKGS[@]}"
 
       - name: Install gcc-${{ env.GCC_VER }}
         if:  matrix.compiler == 'gcc'
@@ -168,7 +168,7 @@ jobs:
           (
           echo "LINUX_VERSION=$(uname -r)"
           echo "NPROC=$(getconf _NPROCESSORS_ONLN)"
-          echo "TMPDIR=${{ runner.temp }}"
+          echo "TMPDIR=$(mktemp -d -p /tmp)"
 
           case "${{ matrix.features }}" in
           tiny)
@@ -185,7 +185,8 @@ jobs:
             if ${{ matrix.python3 == 'stable-abi' }}; then
               PYTHON3_CONFOPT="--with-python3-stable-abi=3.8"
             fi
-            echo "CONFOPT=--enable-perlinterp=${INTERFACE} --enable-pythoninterp=${INTERFACE} --enable-python3interp=${INTERFACE} --enable-rubyinterp=${INTERFACE} --enable-luainterp=${INTERFACE} --enable-tclinterp=${INTERFACE} ${PYTHON3_CONFOPT}"
+            # The ubuntu-24.04 CI runner does not provide a python2 package.
+            echo "CONFOPT=--enable-perlinterp=${INTERFACE} --enable-pythoninterp=no --enable-python3interp=${INTERFACE} --enable-rubyinterp=${INTERFACE} --enable-luainterp=${INTERFACE} --enable-tclinterp=${INTERFACE} ${PYTHON3_CONFOPT}"
             ;;
           esac
 
@@ -263,8 +264,8 @@ jobs:
         if: matrix.architecture != 'arm64'
         timeout-minutes: 25
         run: |
-          do_test() { echo "$*"; sg audio "sg $(id -gn) '$*'"; }
-          do_test make ${SHADOWOPT} ${TEST}
+          make ${SHADOWOPT} ${TEST}
+
 
       # `sg audio` does not work on arm64 runner due to permission ('Incorrect password' error).
       - name: Test on arm64

--- a/src/if_perl.xs
+++ b/src/if_perl.xs
@@ -52,6 +52,11 @@
 # include <perliol.h>
 #endif
 
+#if defined(DYNAMIC_PERL) && ((PERL_REVISION == 5) && (PERL_VERSION >= 38))
+// Copy/pasted from perl.h
+const char PL_memory_wrap[] = "panic: memory wrap";
+#endif
+
 /* Workaround for perl < 5.8.7 */
 #ifndef PERLIO_FUNCS_DECL
 # ifdef PERLIO_FUNCS_CONST
@@ -312,9 +317,6 @@ typedef int perl_key;
 # ifdef PERL_USE_THREAD_LOCAL
 #  define PL_current_context *dll_PL_current_context
 # endif
-# if defined(DYNAMIC_PERL) && ((PERL_REVISION == 5) && (PERL_VERSION >= 38))
-#  define PL_memory_wrap *dll_PL_memory_wrap
-# endif
 # define Perl_hv_iternext_flags dll_Perl_hv_iternext_flags
 # define Perl_hv_iterinit dll_Perl_hv_iterinit
 # define Perl_hv_iterkey dll_Perl_hv_iterkey
@@ -487,9 +489,6 @@ static perl_key* (*Perl_Gthr_key_ptr)_((pTHX));
 # ifdef PERL_USE_THREAD_LOCAL
 static void** dll_PL_current_context;
 # endif
-# if defined(DYNAMIC_PERL) && ((PERL_REVISION == 5) && (PERL_VERSION >= 38))
-static const char **dll_PL_memory_wrap;
-# endif
 static void (*boot_DynaLoader)_((pTHX_ CV*));
 static HE * (*Perl_hv_iternext_flags)(pTHX_ HV *, I32);
 static I32 (*Perl_hv_iterinit)(pTHX_ HV *);
@@ -641,9 +640,6 @@ static struct {
 #  endif
 #  ifdef PERL_USE_THREAD_LOCAL
     {"PL_current_context", (PERL_PROC*)&dll_PL_current_context},
-#  endif
-#  if defined(DYNAMIC_PERL) && ((PERL_REVISION == 5) && (PERL_VERSION >= 38))
-    {"PL_memory_wrap", (PERL_PROC*)&dll_PL_memory_wrap},
 #  endif
 # else
     {"Perl_Idefgv_ptr", (PERL_PROC*)&Perl_Idefgv_ptr},

--- a/src/testdir/dumps/Test_verbose_system_1.vim
+++ b/src/testdir/dumps/Test_verbose_system_1.vim
@@ -2,4 +2,4 @@
 " that shows the system() command executed.
 " This should be on the first line, but if it isn't there ignore the error,
 " the screendump will then show the problem.
-1s+|t|m|p|/|.|.|.*| |+|t|m|p|/|x|x|x|x|x|x|x|/|1| |+e
+1,2s+|>|/|.*|2|>|&|1|".*+|>|.|.|.|2|>|\&|1|"+e

--- a/src/testdir/dumps/Test_verbose_system_2.vim
+++ b/src/testdir/dumps/Test_verbose_system_2.vim
@@ -2,4 +2,4 @@
 " that shows the system() command executed.
 " This should be on the first line, but if it isn't there ignore the error,
 " the screendump will then show the problem.
-1s+|t|m|p|/|.|.|.*| |+|t|m|p|/|x|x|x|x|x|x|x|/|1| |+e
+1,2s+|>|/|.*|2|>|&|1|".*+|>|.|.|.|2|>|\&|1|"+e

--- a/src/testdir/test_messages.vim
+++ b/src/testdir/test_messages.vim
@@ -386,7 +386,7 @@ endfunc
 func Test_echo_verbose_system()
   CheckRunVimInTerminal
   CheckUnix    " needs the "seq" command
-  CheckNotMac  " doesn't use /tmp
+  CheckNotMac  " the macos TMPDIR is too long for snapshot testing
 
   let buf = RunVimInTerminal('', {'rows': 10})
   call term_sendkeys(buf, ":4 verbose echo system('seq 20')\<CR>")


### PR DESCRIPTION
Problem: ubuntu22 test runner lacks frame pointers.
Solution: Use ubuntu24 test runner.

The frame pointers in the ubuntu24 test runner will facilitate ASAN fast unwinding for dynamically loaded shared libraries (e.g. #16315).

These changes also include some perl compatibility changes since ubuntu24 ships perl 5.38. Big thanks to @ychin for help with those!