### PR TITLE
add sanity check before running linematch, similar to diff_find_change

### DIFF
--- a/src/diff.c
+++ b/src/diff.c
@@ -2338,7 +2338,8 @@ diff_check_with_linestatus(win_T *wp, linenr_T lnum, int *linestatus)
     // Don't run linematch when lnum is offscreen.  Useful for scrollbind
     // calculations which need to count all the filler lines above the screen.
     if (lnum >= wp->w_topline && lnum < wp->w_botline
-				&& !dp->is_linematched && diff_linematch(dp))
+				&& !dp->is_linematched && diff_linematch(dp)
+				&& diff_check_sanity(curtab, dp))
       run_linematch_algorithm(dp);
 
     if (dp->is_linematched)


### PR DESCRIPTION
in this test case:
```
#!/bin/bash
echo -e "abc\ndef\nhij" > file1.txt
echo -e "defq\nhijk\nnopq" > file2.txt
echo -e "hijklm\nnopqr\nstuv" > file3.txt

echo -e "" > test.vim
echo -e ":set diffopt+=linematch:60" > test.vim
echo -e 'call feedkeys("Aq\\<esc>")' >> test.vim
echo -e 'call feedkeys("GAklm\\<esc>")' >> test.vim
# this next line will cause an error
echo -e 'call feedkeys("o")' >> test.vim
./src/vim -n -d -S test.vim -u NONE file1.txt file2.txt file3.txt
```
the resulting diff blocks contained in curtab->tp_diffbuf are invalid. the diff block count / line refers to a line in the file which is longer than the file contains. This test case above produces the incorrect results after the commit:  06fe70c183a53ea97cd42ace490d4fb9fd14f042 because the logic in diff.c:diff_read is still not perfect. We can at least fix the internal error by adding a `diff.c:diff_check_sanity`, similar to `diff.c:diff_find_change`.
```
    int
diff_find_change(
    win_T	*wp,
    linenr_T	lnum,
    int		*startp,	// first char of the change
    int		*endp)		// last char of the change
{
...
    if (dp == NULL || diff_check_sanity(curtab, dp) == FAIL)
    {
	vim_free(line_org);
	return FALSE;
    }
```