### PR TITLE
ci: add CI jobs for arm64 Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   linux:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.architecture == 'arm64' && 'ubuntu-22.04-arm' || 'ubuntu-22.04' }}
 
     env:
       CC: ${{ matrix.compiler }}
@@ -48,6 +48,10 @@ jobs:
           - features: tiny
             compiler: gcc
             extra: [nogui]
+          - features: tiny
+            compiler: gcc
+            architecture: arm64
+            extra: [nogui]
           - features: normal
             shadow: ./src/shadow
             compiler: gcc
@@ -73,6 +77,11 @@ jobs:
             compiler: gcc
             coverage: true
             extra: [unittests]
+          - features: huge
+            compiler: gcc
+            coverage: true
+            extra: [unittests]
+            architecture: arm64
           - features: normal
             compiler: gcc
             extra: [vimtags]
@@ -251,10 +260,18 @@ jobs:
           "${SRCDIR}"/vim -u NONE -i NONE --not-a-term -esNX -V1 -S ci/if_ver-2.vim -c quit
 
       - name: Test
+        if: matrix.architecture != 'arm64'
         timeout-minutes: 25
         run: |
           do_test() { echo "$*"; sg audio "sg $(id -gn) '$*'"; }
           do_test make ${SHADOWOPT} ${TEST}
+
+      # `sg audio` does not work on arm64 runner due to permission ('Incorrect password' error).
+      - name: Test on arm64
+        if: matrix.architecture == 'arm64'
+        timeout-minutes: 25
+        run: |
+          make ${SHADOWOPT} ${TEST}
 
       - if: ${{ !cancelled() }}
         uses: ./.github/actions/test_artifacts


### PR DESCRIPTION
GitHub recently [announced](https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/) hosted runners for Linux arm64 as public preview. Since Vim is largely distributed for arm64 Linux (e.g. RasPi), running tests on the platform in CI is highly valuable.

This patch adds the new job matrix to run tests on arm64 GitHub Actions hosted runner for the both `tiny` and `huge` features.

Notes:

- I needed to add a workaround for `Test` step because `sg audio` didn't work.
- Only unit tests are run for `huge` feature because I saw many flaky test cases failed.
- I tested this change on my fork and all jobs [passed](https://github.com/rhysd/vim/actions/runs/12845187647).

