### PR TITLE
Display an error when an abstract method is invoked using super

### DIFF
--- a/src/errors.h
+++ b/src/errors.h
@@ -3619,8 +3619,10 @@ EXTERN char e_class_can_only_be_used_in_script[]
 	INIT(= N_("E1429: Class can only be used in a script"));
 EXTERN char e_uninitialized_object_var_reference[]
 	INIT(= N_("E1430: Uninitialized object variable '%s' referenced"));
+EXTERN char e_abstract_method_str_direct[]
+	INIT(= N_("E1431: Abstract method \"%s\" in class \"%s\" cannot be accessed directly"));
 #endif
-// E1431 - E1499 unused (reserved for Vim9 class support)
+// E1432 - E1499 unused (reserved for Vim9 class support)
 EXTERN char e_cannot_mix_positional_and_non_positional_str[]
 	INIT(= N_("E1500: Cannot mix positional and non-positional arguments: %s"));
 EXTERN char e_fmt_arg_nr_unused_str[]

--- a/src/vim9expr.c
+++ b/src/vim9expr.c
@@ -373,6 +373,7 @@ compile_class_object_index(cctx_T *cctx, char_u **arg, type_T *type)
 		break;
 	    }
 	}
+
 	ocmember_T  *ocm = NULL;
 	if (ufunc == NULL)
 	{
@@ -403,6 +404,15 @@ compile_class_object_index(cctx_T *cctx, char_u **arg, type_T *type)
 		if (status == FAIL)
 		    return FAIL;
 	    }
+	}
+
+	if (is_super && IS_ABSTRACT_METHOD(ufunc))
+	{
+	    // Trying to invoke an abstract method in a super class is not
+	    // allowed.
+	    semsg(_(e_abstract_method_str_direct), ufunc->uf_name,
+		    ufunc->uf_defclass->class_name);
+	    return FAIL;
 	}
 
 	// A private object method can be used only inside the class where it


### PR DESCRIPTION

Merge the changes proposed in https://github.com/vim/vim/issues/15514.  Also include the tests from that issue.

Credit: @errael, @zzzyxwvut 