### PR TITLE
detect termguicolor support in a terminal

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -8501,6 +8501,11 @@ A jump table for the options with a short description can be found at |Q_op|.
 	When on, uses |highlight-guifg| and |highlight-guibg| attributes in
 	the terminal (thus using 24-bit color).
 
+	Will automatically be enabled, if Vim detects that it runs in a
+	capable terminal (when the terminal supports the RGB terminfo
+	capability or when the number of colors |t_Co| supported by the
+	terminal is 0x1000000, e.g. with $TERM=xterm-direct).
+
 	Requires a ISO-8613-3 compatible terminal.  If setting this option
 	does not work (produces a colorless UI) reading |xterm-true-color|
 	might help.

--- a/runtime/doc/version9.txt
+++ b/runtime/doc/version9.txt
@@ -41628,6 +41628,8 @@ Changed~
 - New option value "nosort" for 'completeopt'
 - add |dist#vim9#Launch()| and |dist#vim9#Open()| to the |vim-script-library|
   and decouple it from |netrw|
+- 'termguicolors' is automatically enabled if the terminal supports the RGB
+  terminfo capability or supports 0x1000000 colors
 
 							*added-9.2*
 Added ~

--- a/src/term.c
+++ b/src/term.c
@@ -1661,6 +1661,11 @@ set_color_count(int nr)
 	sprintf((char *)nr_colors, "%d", t_colors);
     else
 	*nr_colors = NUL;
+#ifdef FEAT_TERMGUICOLORS
+    // xterm-direct, enable termguicolors
+    if (t_colors == 0x1000000 && !p_tgc)
+	set_option_value((char_u *)"termguicolors", 1L, NULL, 0);
+#endif
     set_string_option_direct((char_u *)"t_Co", -1, nr_colors, OPT_FREE, 0);
 }
 
@@ -1694,8 +1699,9 @@ may_adjust_color_count(int val)
 static char *(key_names[]) =
 {
 # ifdef FEAT_TERMRESPONSE
-    // Do this one first, it may cause a screen redraw.
+    // Do those ones first, both may cause a screen redraw.
     "Co",
+    "RGB",
 # endif
     "ku", "kd", "kr", "kl",
     "#2", "#4", "%i", "*7",
@@ -5854,6 +5860,7 @@ handle_dcs(char_u *tp, char_u *argp, int len, char_u *key_name, int *slen)
 {
     int i, j;
 
+    LOG_TR(("Received DCS response: %s", (char*)tp));
     j = 1 + (tp[0] == ESC);
     if (len < j + 3)
 	i = len; // need more chars
@@ -7100,7 +7107,7 @@ req_codes_from_term(void)
     static void
 req_more_codes_from_term(void)
 {
-    char	buf[23];  // extra size to shut up LGTM
+    char	buf[32];  // extra size to shut up LGTM
     int		old_idx = xt_index_out;
 
     // Don't do anything when going to exit.
@@ -7115,7 +7122,10 @@ req_more_codes_from_term(void)
 
 	MAY_WANT_TO_LOG_THIS;
 	LOG_TR(("Requesting XT %d: %s", xt_index_out, key_name));
-	sprintf(buf, "\033P+q%02x%02x\033\\", key_name[0], key_name[1]);
+	if (key_name[2] != NUL)
+	    sprintf(buf, "\033P+q%02x%02x%02x\033\\", key_name[0], key_name[1], key_name[2]);
+	else
+	    sprintf(buf, "\033P+q%02x%02x\033\\", key_name[0], key_name[1]);
 	out_str_nf((char_u *)buf);
 	++xt_index_out;
     }
@@ -7135,7 +7145,7 @@ req_more_codes_from_term(void)
 got_code_from_term(char_u *code, int len)
 {
 #define XT_LEN 100
-    char_u	name[3];
+    char_u	name[4];
     char_u	str[XT_LEN];
     int		i;
     int		j = 0;
@@ -7143,13 +7153,16 @@ got_code_from_term(char_u *code, int len)
 
     // A '1' means the code is supported, a '0' means it isn't.
     // When half the length is > XT_LEN we can't use it.
-    // Our names are currently all 2 characters.
-    if (code[0] == '1' && code[7] == '=' && len / 2 < XT_LEN)
+    if (code[0] == '1' && (code[7] || code[9] == '=') && len / 2 < XT_LEN)
     {
 	// Get the name from the response and find it in the table.
 	name[0] = hexhex2nr(code + 3);
 	name[1] = hexhex2nr(code + 5);
-	name[2] = NUL;
+	if (code[9] == '=')
+	    name[2] = hexhex2nr(code + 7);
+	else
+	    name[2] = NUL;
+	name[3] = NUL;
 	for (i = 0; key_names[i] != NULL; ++i)
 	{
 	    if (STRCMP(key_names[i], name) == 0)
@@ -7163,7 +7176,8 @@ got_code_from_term(char_u *code, int len)
 
 	if (key_names[i] != NULL)
 	{
-	    for (i = 8; (c = hexhex2nr(code + i)) >= 0; i += 2)
+	    i = (code[7] == '=') ? 8 : 10;
+	    for (; (c = hexhex2nr(code + i)) >= 0; i += 2)
 		str[j++] = c;
 	    str[j] = NUL;
 	    if (name[0] == 'C' && name[1] == 'o')
@@ -7180,6 +7194,22 @@ got_code_from_term(char_u *code, int len)
 #endif
 		may_adjust_color_count(val);
 	    }
+#ifdef FEAT_TERMGUICOLORS
+	    // when RGB result comes back, it is supported when the result contains an '='
+	    else if (name[0] == 'R' && name[1] == 'G' && name[2] == 'B' && code[9] == '=')
+	    {
+		int val = atoi((char *)str);
+		// 8 bits per color channel
+		if (val == 8)
+		{
+#ifdef FEAT_EVAL
+		    ch_log(NULL, "got_code_from_term(RGB): xterm-direct colors detected");
+#endif
+		    // RGB capability set, enable termguicolors
+		    set_option_value((char_u *)"termguicolors", 1L, NULL, 0);
+		}
+	    }
+#endif
 	    else
 	    {
 		i = find_term_bykeys(str);


### PR DESCRIPTION
The terminfo database for xterm-direct contains both the (non-standard) termcap RGB capability and a number of colors == 0x1000000 so it seems either of those two options can be used to detect a terminal capable of displaying true colors.

So set the termguicolor option automatically, when either of the two options is detected. (for some reasons, my debian xterm (v393) does not respond to XTGETTCAP query attempts, so falling back to the number of colors seems like a good compromize)