### PR TITLE
When checking for abstract methods in an extended class, only check for the immediate super class methods

### DIFF
--- a/src/errors.h
+++ b/src/errors.h
@@ -3508,7 +3508,7 @@ EXTERN char e_abstract_must_be_followed_by_def[]
 	INIT(= N_("E1371: Abstract must be followed by \"def\""));
 EXTERN char e_abstract_method_in_concrete_class[]
 	INIT(= N_("E1372: Abstract method \"%s\" cannot be defined in a concrete class"));
-EXTERN char e_abstract_method_str_not_found[]
+EXTERN char e_abstract_method_str_not_implemented[]
 	INIT(= N_("E1373: Abstract method \"%s\" is not implemented"));
 EXTERN char e_class_variable_str_accessible_only_inside_class_str[]
 	INIT(= N_("E1374: Class variable \"%s\" accessible only inside class \"%s\""));

--- a/src/vim9class.c
+++ b/src/vim9class.c
@@ -561,20 +561,34 @@ validate_abstract_class_methods(
 	    if (!IS_ABSTRACT_METHOD(uf))
 		continue;
 
-	    int method_found = FALSE;
+	    int	concrete_method_found = FALSE;
+	    int	j = 0;
 
-	    for (int j = 0; j < method_count; j++)
+	    // Check if the abstract method is already implemented in one of
+	    // the parent classes.
+	    for (j = 0; !concrete_method_found && j < i; j++)
+	    {
+		ufunc_T *uf2 = extends_methods[j];
+		if (!IS_ABSTRACT_METHOD(uf2) &&
+			STRCMP(uf->uf_name, uf2->uf_name) == 0)
+		    concrete_method_found = TRUE;
+	    }
+
+	    if (concrete_method_found)
+		continue;
+
+	    for (j = 0; j < method_count; j++)
 	    {
 		if (STRCMP(uf->uf_name, cl_fp[j]->uf_name) == 0)
 		{
-		    method_found = TRUE;
+		    concrete_method_found = TRUE;
 		    break;
 		}
 	    }
 
-	    if (!method_found)
+	    if (!concrete_method_found)
 	    {
-		semsg(_(e_abstract_method_str_not_found), uf->uf_name);
+		semsg(_(e_abstract_method_str_not_implemented), uf->uf_name);
 		return FALSE;
 	    }
 	}


### PR DESCRIPTION
Fixes the issue described in #16495.