### PR TITLE
Update .gitignore for shadowdir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,6 +111,8 @@ src/shadow
 src/shadow-*
 src/runtime
 src/pixmaps
+src/LICENSE
+src/README.txt
 
 # other files possibly created by tools
 src/cscope.out


### PR DESCRIPTION
[v9.1.1036](https://github.com/vim/vim/releases/tag/v9.1.1036) added link files for LICENSE and README.txt, so should add them to .gitignore.