### PR TITLE
feat: add nosort in completeopt

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2164,6 +2164,10 @@ A jump table for the options with a short description can be found at |Q_op|.
 		    characters can be skipped and matches can be found even
 		    if the exact sequence is not typed.
 
+	   nosort   Disable sorting of completion candidates based on fuzzy
+		    scores when "fuzzy" is enabled. candidates will appear
+		    in their original order.
+
 					*'completepopup'* *'cpp'*
 'completepopup' 'cpp'	string (default empty)
 			global

--- a/src/option.h
+++ b/src/option.h
@@ -530,6 +530,7 @@ EXTERN unsigned	cot_flags;	// flags from 'completeopt'
 #define COT_NOINSERT	    0x040   // FALSE: select & insert, TRUE: noinsert
 #define COT_NOSELECT	    0x080   // FALSE: select & insert, TRUE: noselect
 #define COT_FUZZY	    0x100   // TRUE: fuzzy match enabled
+#define COT_NOSORT	    0x200   // TRUE: fuzzy match without qsort score
 #ifdef BACKSLASH_IN_FILENAME
 EXTERN char_u	*p_csl;		// 'completeslash'
 #endif

--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -120,7 +120,7 @@ static char *(p_fdm_values[]) = {"manual", "expr", "marker", "indent", "syntax",
 				NULL};
 static char *(p_fcl_values[]) = {"all", NULL};
 #endif
-static char *(p_cot_values[]) = {"menu", "menuone", "longest", "preview", "popup", "popuphidden", "noinsert", "noselect", "fuzzy", NULL};
+static char *(p_cot_values[]) = {"menu", "menuone", "longest", "preview", "popup", "popuphidden", "noinsert", "noselect", "fuzzy", "nosort", NULL};
 #ifdef BACKSLASH_IN_FILENAME
 static char *(p_csl_values[]) = {"slash", "backslash", NULL};
 #endif

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -2700,7 +2700,7 @@ func Test_complete_fuzzy_match()
     if a:findstart
       return col(".")
     endif
-    return [#{word: "foo"}, #{word: "foobar"}, #{word: "fooBaz"}, #{word: "foobala"}]
+    return [#{word: "foo"}, #{word: "foobar"}, #{word: "fooBaz"}, #{word: "foobala"}, #{word: "你好吗"}, #{word: "我好"}]
   endfunc
 
   new
@@ -2854,6 +2854,21 @@ func Test_complete_fuzzy_match()
   call cursor(3, 1)
   call feedkeys("STe\<C-X>\<C-N>x\<CR>\<Esc>0", 'tx!')
   call assert_equal('Tex', getline('.'))
+
+  " test case for nosort option
+  set cot=menuone,menu,noinsert,fuzzy,nosort
+  " fooBaz" should have a higher score when the leader is "fb".
+  " With `nosort`, "foobar" should still be shown first in the popup menu.
+  call feedkeys("S\<C-x>\<C-o>fb", 'tx')
+  call assert_equal('foobar', g:word)
+  call feedkeys("S\<C-x>\<C-o>好", 'tx')
+  call assert_equal("你好吗", g:word)
+
+  set cot+=noselect
+  call feedkeys("S\<C-x>\<C-o>好", 'tx')
+  call assert_equal(v:null, g:word)
+  call feedkeys("S\<C-x>\<C-o>好\<C-N>", 'tx')
+  call assert_equal('你好吗', g:word)
 
   " clean up
   set omnifunc=


### PR DESCRIPTION
Problem: The lsp spec standard defines sortText in the returned completionitem list. This means that the editor can sorted the results with it. When fuzzy exists, this will break the results order which already sorted by `sortText`

Solution: disable sorting of candidates when nosort is set in completeopt

Ref: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#completionItem