### PR TITLE
crash after scrolling and pasting in silent Ex mode

### DIFF
--- a/src/move.c
+++ b/src/move.c
@@ -3285,8 +3285,11 @@ pagescroll(int dir, long count, int half)
 	{
 	    // Place cursor at top or bottom of window.
 	    validate_botline();
-	    curwin->w_cursor.lnum = (dir == FORWARD ? curwin->w_topline
+	    linenr_T lnum = (dir == FORWARD ? curwin->w_topline
 						    : curwin->w_botline - 1);
+	    // In silent Ex mode the value of w_botline - 1 may be 0,
+	    // but cursor lnum needs to be at least 1.
+	    curwin->w_cursor.lnum = MAX(lnum, 1);
 	}
     }
 

--- a/src/testdir/test_normal.vim
+++ b/src/testdir/test_normal.vim
@@ -1342,6 +1342,22 @@ func Test_scroll_in_ex_mode()
   call delete('Xdone')
 endfunc
 
+func Test_scroll_and_paste_in_ex_mode()
+  " This used to crash because of moving cursor to line 0.
+  let lines =<< trim END
+      v/foo/vi|YY9PYQ
+      v/bar/vi|YY9PYQ
+      v/bar/exe line('.') == 1 ? "vi|Y\<C-B>9PYQ" : "vi|YQ"
+      call writefile(['done'], 'Xdone')
+      qa!
+  END
+  call writefile(lines, 'Xscript', 'D')
+  call assert_equal(1, RunVim([], [], '-u NONE -i NONE -n -X -Z -e -s -S Xscript'))
+  call assert_equal(['done'], readfile('Xdone'))
+
+  call delete('Xdone')
+endfunc
+
 " Test for the 'sidescroll' option
 func Test_sidescroll_opt()
   new
@@ -4293,4 +4309,5 @@ func Test_normal_go()
 
   bwipe!
 endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab nofoldenable


### PR DESCRIPTION
Problem:  Crash after scrolling and pasting in silent Ex mode.
          (fizz-is-on-the-way)
Solution: Don't move cursor to line 0 when scrolling.