### PR TITLE
fix(ftplugin): `'commentstring'` in filetype PHP

### DIFF
--- a/runtime/ftplugin/php.vim
+++ b/runtime/ftplugin/php.vim
@@ -2,8 +2,8 @@
 " Language:		PHP
 " Maintainer:		Doug Kearns <dougkearns@gmail.com>
 " Previous Maintainer:	Dan Sharp
-" Last Change:		2024 Jan 14
-" Last Change:		2024 May 23 by Riley Bruins <ribru17@gmail.com> ('commentstring')
+" Last Change:		2025 Jan 22
+" Last Change:		2025 Jan 22 by Phạm Bình An <phambinhanctb@gmail.com> ('commentstring')
 
 if exists("b:did_ftplugin")
   finish
@@ -45,13 +45,13 @@ if exists("b:match_skip")
 endif
 
 setlocal comments=s1:/*,mb:*,ex:*/,://,:#
-setlocal commentstring=/*\ %s\ */
+setlocal commentstring=//\ %s
 setlocal formatoptions+=l formatoptions-=t
 
 if get(g:, "php_autocomment", 1)
   setlocal formatoptions+=croq
   " NOTE: set g:PHP_autoformatcomment = 0 to prevent the indent plugin from
-  "       overriding this 'comments' value 
+  "       overriding this 'comments' value
   setlocal comments-=:#
   " space after # comments to exclude attributes
   setlocal comments+=b:#


### PR DESCRIPTION
Problem:
Currently, `'commentstring'` of PHP is set to `/* %s */`. However, this doesn't play nice with Vim's builtin comment plugin because the plugin is based on line commenting instead of block commenting. And when writing PHP, people often use `// %s` for line commenting instead of `/* %s */`

Solution:
Change `'commentstring'` to `// %s`