### PR TITLE
"nosort" enables fuzzy filtering even if "fuzzy" isn't in 'completeopt'

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -1264,8 +1264,8 @@ ins_compl_build_pum(void)
     int		max_fuzzy_score = 0;
     unsigned int cur_cot_flags = get_cot_flags();
     int		compl_no_select = (cur_cot_flags & COT_NOSELECT) != 0;
-    int		fuzzy_nosort = (cur_cot_flags & COT_NOSORT) != 0;
-    int		fuzzy_filter = fuzzy_nosort || (cur_cot_flags & COT_FUZZY) != 0;
+    int		fuzzy_filter = (cur_cot_flags & COT_FUZZY) != 0;
+    int		fuzzy_sort = fuzzy_filter && !(cur_cot_flags & COT_NOSORT);
     compl_T	*match_head = NULL;
     compl_T	*match_tail = NULL;
     compl_T	*match_next = NULL;
@@ -1328,14 +1328,14 @@ ins_compl_build_pum(void)
 		    shown_compl = compl;
 		// Update the maximum fuzzy score and the shown match
 		// if the current item's score is higher
-		if (!fuzzy_nosort && compl->cp_score > max_fuzzy_score)
+		if (fuzzy_sort && compl->cp_score > max_fuzzy_score)
 		{
 		    did_find_shown_match = TRUE;
 		    max_fuzzy_score = compl->cp_score;
 		    if (!compl_no_select)
 			compl_shown_match = compl;
 		}
-		else if (fuzzy_nosort && i == 0 && !compl_no_select)
+		else if (!fuzzy_sort && i == 0 && !compl_no_select)
 		    compl_shown_match = shown_compl;
 
 		if (!shown_match_ok && compl == compl_shown_match && !compl_no_select)
@@ -1392,7 +1392,7 @@ ins_compl_build_pum(void)
 	compl = match_next;
     }
 
-    if (fuzzy_filter && !fuzzy_nosort && compl_leader.string != NULL && compl_leader.length > 0)
+    if (fuzzy_sort && compl_leader.string != NULL && compl_leader.length > 0)
     {
 	for (i = 0; i < compl_match_arraysize; i++)
 	    compl_match_array[i].pum_idx = i;

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -2857,8 +2857,8 @@ func Test_complete_fuzzy_match()
 
   " test case for nosort option
   set cot=menuone,menu,noinsert,fuzzy,nosort
-  " fooBaz" should have a higher score when the leader is "fb".
-  " With `nosort`, "foobar" should still be shown first in the popup menu.
+  " "fooBaz" should have a higher score when the leader is "fb".
+  " With "nosort", "foobar" should still be shown first in the popup menu.
   call feedkeys("S\<C-x>\<C-o>fb", 'tx')
   call assert_equal('foobar', g:word)
   call feedkeys("S\<C-x>\<C-o>好", 'tx')
@@ -2869,6 +2869,11 @@ func Test_complete_fuzzy_match()
   call assert_equal(v:null, g:word)
   call feedkeys("S\<C-x>\<C-o>好\<C-N>", 'tx')
   call assert_equal('你好吗', g:word)
+
+  " "nosort" shouldn't enable fuzzy filtering when "fuzzy" isn't present.
+  set cot=menuone,noinsert,nosort
+  call feedkeys("S\<C-x>\<C-o>fooB\<C-Y>", 'tx')
+  call assert_equal('fooBaz', getline('.'))
 
   " clean up
   set omnifunc=


### PR DESCRIPTION
Problem:  "nosort" enables fuzzy filtering even if "fuzzy" isn't in
          'completeopt'.
Solution: Only enable fuzzy filtering when "fuzzy" is in 'completeopt'.
