### PR TITLE
tests: Fix off-by-one in CheckCWD leading to local tests failure

### DIFF
--- a/src/testdir/test_debugger.vim
+++ b/src/testdir/test_debugger.vim
@@ -8,10 +8,11 @@ CheckRunVimInTerminal
 
 func CheckCWD()
   " Check that the longer lines don't wrap due to the length of the script name
-  " in cwd
+  " in cwd. Need to subtract by 1 since Vim will still wrap the message if it
+  " just fits.
   let script_len = len( getcwd() .. '/Xtest1.vim' )
   let longest_line = len( 'Breakpoint in "" line 1' )
-  if script_len > ( 75 - longest_line )
+  if script_len > ( 75 - longest_line - 1 )
     throw 'Skipped: Your CWD has too many characters'
   endif
 endfunc


### PR DESCRIPTION
Vim's test_debugger's Test_debug_backtrace_level test will fail if you happen to run it in a Vim repository with full path of directory being exactly 29 characters (e.g. `/Users/bob/developing/src/vim`). The test does term dump comparison and the printout will overflow if the CWD is too long. It does have a function to skip to test if it detects that but it's off by one leading to this one situation where it will fail.

The reason why the logic didn't account for this is that Vim's message printing will overflow the text if it prints a message at exactly the width of the terminal. This could be considered a bug / quirk but that will be another issue.