### PR TITLE
Fix multi level imports

### DIFF
--- a/src/testdir/test_vim9_import.vim
+++ b/src/testdir/test_vim9_import.vim
@@ -3420,4 +3420,51 @@ def Test_imported_class_as_def_func_rettype()
   v9.CheckScriptSuccess(lines)
 enddef
 
+" Test for multi level import
+def Test_import_multi_level()
+  var lines =<< trim END
+    vim9script
+    export var a0 = "A0"
+  END
+  writefile(lines, 'aa0.vim', 'D')
+
+  lines =<< trim END
+    vim9script
+    import './bb.vim'
+    import './bb1.vim' as acme
+    export var a = "A"
+  END
+  writefile(lines, 'aa.vim', 'D')
+
+  lines =<< trim END
+    vim9script
+    export var b = "B"
+  END
+  writefile(lines, 'bb.vim', 'D')
+
+  lines =<< trim END
+    vim9script
+    import './cc.vim'
+    export var b1 = "B1"
+  END
+  writefile(lines, 'bb1.vim', 'D')
+
+  lines =<< trim END
+    vim9script
+    export var c = "C"
+  END
+  writefile(lines, 'cc.vim', 'D')
+
+  lines =<< trim END
+    vim9script
+    import './aa0.vim' as acme
+    import './aa.vim'
+    assert_equal("A0", acme.a0)
+    assert_equal("A", aa.a)
+    assert_equal("B1", aa.acme.b1)
+    assert_equal("C", aa.acme.cc.c)
+  END
+  v9.CheckScriptSuccess(lines)
+enddef
+
 " vim: ts=8 sw=2 sts=2 expandtab tw=80 fdm=marker


### PR DESCRIPTION
Retrying #16440.
The logic of multi-level imports has been revised.
(But #16379 is not fixed. #16379 has another cause.)
However, this PR should be able to do normal multi-level imports.


NOTE:
- A stack overflow due to circular references does not logically occur, so I do not check for it.
- The E1048 error message may need to be reconsidered.


