### PR TITLE
runtime(syntax): add missing byte directives to asm syntax

### DIFF
--- a/runtime/syntax/asm.vim
+++ b/runtime/syntax/asm.vim
@@ -32,6 +32,9 @@ syn match asmType "\.single"
 syn match asmType "\.space"
 syn match asmType "\.string"
 syn match asmType "\.word"
+syn match asmType "\.2byte"
+syn match asmType "\.4byte"
+syn match asmType "\.8byte"
 
 syn match asmIdentifier		"[a-z_][a-z0-9_]*"
 syn match asmLabel		"[a-z_][a-z0-9_]*:"he=e-1


### PR DESCRIPTION
Problem: When opening GNU assembler source code with Vim, the syntax highlighting does not detect the ```.2byte```, ```.4byte``` and ```.8byte``` directives, even though they are supported: https://sourceware.org/binutils/docs/as/2byte.html

Solution: Add support for those directives into the syntax file