### PR TITLE
src/Makefile: fix tutor race condition at install time

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -2482,7 +2482,7 @@ installgtutorbin: $(DEST_BIN)
 	$(INSTALL_DATA) gvimtutor $(DEST_BIN)/$(GVIMNAME)tutor
 	chmod $(SCRIPTMOD) $(DEST_BIN)/$(GVIMNAME)tutor
 
-installtutor: $(DEST_RT) $(DEST_TUTOR)
+installtutor: $(DEST_RT) $(DEST_TUTOR)/en $(DEST_TUTOR)/it
 	-$(INSTALL_DATA) $(TUTORSOURCE)/README* $(TUTORSOURCE)/tutor* $(DEST_TUTOR)
 	-$(INSTALL_DATA) $(TUTORSOURCE)/en/* $(DEST_TUTOR)/en/
 	-$(INSTALL_DATA) $(TUTORSOURCE)/it/* $(DEST_TUTOR)/it/


### PR DESCRIPTION
Without the change `make install -j16` fails
sometimes due to race condition to create a directory.

It's best reproducible with `make --shuffle`:

    $ make install --shuffle
    ...
    bash install-sh -c -d /vim-9.1.0990/share/vim/vim91/tutor
    chmod 755 /vim-9.1.0990/share/vim/vim91/tutor
    cp ../runtime/tutor/README* ../runtime/tutor/tutor* /vim-9.1.0990/share/vim/vim91/tutor
    cp ../runtime/tutor/en/* /vim-9.1.0990/share/vim/vim91/tutor/en/
    cp: target '/vim-9.1.0990/share/vim/vim91/tutor/en/': No such file or directory
    make[1]: [Makefile:2487: installtutor] Error 1 (ignored) shuffle=2340321974
    cp ../runtime/tutor/it/* /vim-9.1.0990/share/vim/vim91/tutor/it/
    cp: target '/vim-9.1.0990/share/vim/vim91/tutor/it/': No such file or directory
    make[1]: [Makefile:2488: installtutor] Error 1 (ignored) shuffle=2340321974

The fix adds a dependency on targetd directories used to install tutor.

Before the change it too 2-3 attempts to reproduce the install failure. After the change `vim` survives 150 install attempts without failures.