### PR TITLE
runtime(dist/vim9): fix regressions in dist#vim9#Open

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1,4 +1,4 @@
-*eval.txt*	For Vim version 9.1.  Last change: 2025 Jan 25
+*eval.txt*	For Vim version 9.1.  Last change: 2025 Jan 29
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -4908,12 +4908,24 @@ executable.  It takes the following arguments:
 	executable	string
 
 						      *dist#vim9#Open()* *:Open*
-						      *g:Openprg*
+						      *g:Openprg* *gx*
 dist#vim9#Open(file: string) ~
 
 Opens `path` with the system default handler (macOS `open`, Windows
 `explorer.exe`, Linux `xdg-open`, …). If the variable |g:Openprg| exists the
 string specified in the variable is used instead.
+
+This function is by default called using the gx mapping.  In visual mode
+tries to open the visually selected text.
+
+Associated setting variables:
+`g:gx_word`: control how gx picks up the text under the cursor. Uses
+	     `g:netrw_gx` as a fallback for backward compatibility.
+	     (default: `<cfile>`)
+
+`g:nogx`: disables the gx mapping. Uses `g:netrw_nogx` as a fallback for
+	  backward compatibility. (default: `unset`)
+
 
 NOTE: Escaping of the path is automatically applied.
 

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -8053,6 +8053,7 @@ gvimrc	gui.txt	/*gvimrc*
 gw	change.txt	/*gw*
 gwgw	change.txt	/*gwgw*
 gww	change.txt	/*gww*
+gx	eval.txt	/*gx*
 gzip	pi_gzip.txt	/*gzip*
 gzip-autocmd	pi_gzip.txt	/*gzip-autocmd*
 gzip-example	autocmd.txt	/*gzip-example*

--- a/runtime/plugin/openPlugin.vim
+++ b/runtime/plugin/openPlugin.vim
@@ -12,9 +12,18 @@ command -complete=file -nargs=1 Open vim9.Open(trim(<q-args>))
 
 const no_gx = get(g:, "nogx", get(g:, "netrw_nogx", false))
 if !no_gx
+  def GetWordUnderCursor(): string
+    const url = matchstr(expand("<cWORD>"), '\%(\%(http\|ftp\|irc\)s\?\|file\)://\S\{-}\ze[^A-Za-z0-9/]*$')
+    if !empty(url)
+      return url
+    endif
+
+    const user_var = get(g:, 'gx_word', get(g:, 'netrw_gx', '<cfile>')
+    return expand(user_var)
+  enddef
+
   if maparg('gx', 'n') == ""
-    const file = get(g:, 'netrw_gx', '<cfile>')
-    nnoremap <unique> gx <scriptcmd>vim9.Open(expand(file))<CR>
+    nnoremap <unique> gx <scriptcmd>vim9.Open(GetWordUnderCursor())<CR>
   endif
   if maparg('gx', 'x') == ""
     xnoremap <unique> gx <scriptcmd>vim9.Open(getregion(getpos('v'), getpos('.'), { type: mode() })->join())<CR>


### PR DESCRIPTION
fixes: #16533, #16532

Hi,
This PR addresses some regressions introduced with #16494.

@habamax can you test if this patch fixes things.

@Konfekt I'll respond to your issue here.

> Just wondering why these were removed

I've decided to remove the customization per filetype because it isn't needed since you can remap `gx` per filetype with a custom function to pass to `dist#vim9#Open`.

```vim
function! getMarkdownUrl()
  " get url
endfunction

au! FileType markdown nnoremap gx call dist#vim9#Open(getMarkdownUrl())
```

This is much more flexible and doesn't introduce configuration that needs the user to know the inner workings of the `gx` mapping. 