### PR TITLE
Superfluous cleanup steps in test_ins_complete.vim

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -4374,16 +4374,17 @@ ins_compl_insert(int in_compl_func, int move_cursor)
 {
     int	    compl_len = get_compl_len();
     int	    preinsert = ins_compl_has_preinsert();
-    char_u  *str = compl_shown_match->cp_str.string;
-    int	    leader_len = ins_compl_leader_len();
+    char_u  *cp_str = compl_shown_match->cp_str.string;
+    size_t  cp_str_len = compl_shown_match->cp_str.length;
+    size_t  leader_len = ins_compl_leader_len();
 
     // Make sure we don't go over the end of the string, this can happen with
     // illegal bytes.
-    if (compl_len < (int)compl_shown_match->cp_str.length)
+    if (compl_len < (int)cp_str_len)
     {
-	ins_compl_insert_bytes(str + compl_len, -1);
+	ins_compl_insert_bytes(cp_str + compl_len, -1);
 	if (preinsert && move_cursor)
-	    curwin->w_cursor.col -= ((size_t)STRLEN(str) - leader_len);
+	    curwin->w_cursor.col -= (colnr_T)(cp_str_len - leader_len);
     }
     if (match_at_original_text(compl_shown_match) || preinsert)
 	compl_used_match = FALSE;

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -2989,7 +2989,6 @@ func Test_complete_info_matches()
   call assert_false(has_key(g:compl_info, 'matches'))
 
   bw!
-  bw!
   unlet g:what
   delfunc ShownInfo
   set cot&
@@ -3019,7 +3018,6 @@ func Test_complete_info_completed()
   call feedkeys("Go\<C-X>\<C-N>\<F5>\<Esc>dd", 'tx')
   call assert_equal({}, g:compl_info)
 
-  bw!
   bw!
   delfunc ShownInfo
   set cot&
@@ -3082,7 +3080,7 @@ function Test_completeopt_preinsert()
   call assert_equal("hello  fobar wo", getline('.'))
   call feedkeys("\<C-E>\<ESC>", 'tx')
 
-  " confrim
+  " confirm
   call feedkeys("S\<C-X>\<C-O>f\<C-Y>", 'tx')
   call assert_equal("fobar", getline('.'))
   call assert_equal(5, col('.'))
@@ -3135,11 +3133,9 @@ function Test_completeopt_preinsert()
   call assert_equal(5, col('.'))
 
   bw!
-  bw!
   set cot&
   set omnifunc&
   delfunc Omni_test
-  autocmd! CompleteChanged
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab nofoldenable


### PR DESCRIPTION
Problem:  Superfluous cleanup steps in test_ins_complete.vim.
Solution: Remove unnecessary :bw! and :autocmd! commands.
          Also remove unnecessary STRLEN().