### PR TITLE
fix: avoid delete the input text when preinsert

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -4094,7 +4094,7 @@ get_next_default_completion(ins_compl_next_state_T *st, pos_T *start_pos)
 	if (!in_fuzzy)
 	    ptr = ins_compl_get_next_word_or_line(st->ins_buf, st->cur_match_pos,
 							       &len, &cont_s_ipos);
-	if (ptr == NULL)
+	if (ptr == NULL || (ins_compl_has_preinsert() && STRCMP(ptr, compl_pattern.string) == 0))
 	    continue;
 
 	if (ins_compl_add_infercase(ptr, len, p_ic,
@@ -4342,7 +4342,7 @@ ins_compl_delete(void)
     int	has_preinsert = ins_compl_preinsert_effect();
     if (has_preinsert)
     {
-	col = compl_col + ins_compl_leader_len() - compl_length;
+	col += ins_compl_leader_len();
 	curwin->w_cursor.col = compl_ins_end_col;
     }
 

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -3112,6 +3112,10 @@ function Test_completeopt_preinsert()
   call assert_equal("hello hero", getline('.'))
   call assert_equal(2, col('.'))
 
+  call feedkeys("Shello hero\<CR>h\<C-X>\<C-N>er", 'tx')
+  call assert_equal("hero", getline('.'))
+  call assert_equal(3, col('.'))
+
   " can not work with fuzzy
   set cot+=fuzzy
   call feedkeys("S\<C-X>\<C-O>", 'tx')


### PR DESCRIPTION
Problem: when new leadder add and preinsert will delete already input text.
Solution: remove compl_length reduce and check the ptr eqaul to pattern when preinsert