### PR TITLE
runtime(vim): fix unclosed parenthesis in GetWordUnderCursor()

### DIFF
--- a/runtime/plugin/openPlugin.vim
+++ b/runtime/plugin/openPlugin.vim
@@ -18,7 +18,7 @@ if !no_gx
       return url
     endif
 
-    const user_var = get(g:, 'gx_word', get(g:, 'netrw_gx', '<cfile>')
+    const user_var = get(g:, 'gx_word', get(g:, 'netrw_gx', '<cfile>'))
     return expand(user_var)
   enddef
 


### PR DESCRIPTION
Problem:

Saw the following error when invoking gx mapping with cursor on a URL:

    Error detected while compiling function <SNR>95_GetWordUnderCursor:
    line    7:
    E1123: Missing comma before argument: return expand(user_var)
    E116: Invalid arguments for function dist#vim9#Open

Solution:

The line before "return expand(...)" has two open parentheses but only one close parenthesis. Add another close parenthesis.