### PR TITLE
Cannot map Ctrl-I in terminal mode when using modifyOtherKeys

### DIFF
--- a/src/misc2.c
+++ b/src/misc2.c
@@ -1535,8 +1535,7 @@ find_special_key(
  * CTRL-2 is CTRL-@
  * CTRL-6 is CTRL-^
  * CTRL-- is CTRL-_
- * Also, unless no_reduce_keys is set then <C-H> and <C-h> mean the same thing,
- * use "H".
+ * Also, <C-H> and <C-h> mean the same thing, always use "H".
  * Returns the possibly adjusted key.
  */
     int
@@ -1546,12 +1545,7 @@ may_adjust_key_for_ctrl(int modifiers, int key)
 	return key;
 
     if (ASCII_ISALPHA(key))
-    {
-#ifdef FEAT_TERMINAL
-	check_no_reduce_keys();  // may update the no_reduce_keys flag
-#endif
-	return no_reduce_keys == 0 ? TOUPPER_ASC(key) : key;
-    }
+	return TOUPPER_ASC(key);
     if (key == '2')
 	return '@';
     if (key == '6')

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -1722,9 +1722,12 @@ term_convert_key(term_T *term, int c, int modmask, char *buf)
 
     // Ctrl-Shift-i may have the key "I" instead of "i", but for the kitty
     // keyboard protocol should use "i".  Applies to all ascii letters.
+    // Without the Shift modifier, use lower-case for ascii letters when the
+    // Ctrl modifier is present.
     if (ASCII_ISUPPER(c)
-	    && vterm_is_kitty_keyboard(vterm)
-	    && mod == (VTERM_MOD_CTRL | VTERM_MOD_SHIFT))
+	    && ((vterm_is_kitty_keyboard(vterm)
+		    && mod == (VTERM_MOD_CTRL | VTERM_MOD_SHIFT))
+		|| ((mod & VTERM_MOD_CTRL) && !(mod & VTERM_MOD_SHIFT))))
 	c = TOLOWER_ASC(c);
 
     /*


### PR DESCRIPTION
Problem:  Cannot map Ctrl-I in terminal mode when using modifyOtherKeys
          (after 9.0.0912).
Solution: Convert letters with Ctrl modifier to upper-case in input
          buffer, and convert them back to lower-case in terminal.c.