### PR TITLE
heap-use-after-free and stack-use-after-scope with :14verbose

### DIFF
--- a/src/testdir/test_user_func.vim
+++ b/src/testdir/test_user_func.vim
@@ -987,4 +987,36 @@ func Test_func_curly_brace_invalid_name()
   delfunc Fail
 endfunc
 
+func Test_func_return_in_try_verbose()
+  func TryReturnList()
+    try
+      return [1, 2, 3]
+    endtry
+  endfunc
+  func TryReturnNumber()
+    try
+      return 123
+    endtry
+  endfunc
+  func TryReturnOverlongString()
+    try
+      return repeat('a', 9999)
+    endtry
+  endfunc
+
+  " This should not cause heap-use-after-free
+  call assert_match('\n:return \[1, 2, 3\] made pending\n',
+                  \ execute('14verbose call TryReturnList()'))
+  " This should not cause stack-use-after-scope
+  call assert_match('\n:return 123 made pending\n',
+                  \ execute('14verbose call TryReturnNumber()'))
+  " An overlong string is truncated
+  call assert_match('\n:return a\{100,}\.\.\.',
+                  \ execute('14verbose call TryReturnOverlongString()'))
+
+  delfunc TryReturnList
+  delfunc TryReturnNumber
+  delfunc TryReturnOverlongString
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -682,12 +682,12 @@ make_ufunc_name_readable(char_u *name, char_u *buf, size_t bufsize)
     return buf;
 }
 
-/*
- * Get a name for a lambda.  Returned in static memory.
- */
 static char_u	lambda_name[8 + NUMBUFLEN];
 static size_t	lambda_namelen = 0;
 
+/*
+ * Get a name for a lambda.  Returned in static memory.
+ */
     char_u *
 get_lambda_name(void)
 {
@@ -6820,17 +6820,13 @@ discard_pending_return(void *rettv)
 get_return_cmd(void *rettv)
 {
     char_u	*s = NULL;
+    char_u	*tofree = NULL;
+    char_u	numbuf[NUMBUFLEN];
     size_t	slen = 0;
     size_t	IObufflen;
 
     if (rettv != NULL)
-    {
-	char_u	*tofree = NULL;
-	char_u	numbuf[NUMBUFLEN];
-
 	s = echo_string((typval_T *)rettv, &tofree, numbuf, 0);
-	vim_free(tofree);
-    }
     if (s == NULL)
 	s = (char_u *)"";
     else
@@ -6839,11 +6835,12 @@ get_return_cmd(void *rettv)
     STRCPY(IObuff, ":return ");
     STRNCPY(IObuff + 8, s, IOSIZE - 8);
     IObufflen = 8 + slen;
-    if (slen + 8 >= IOSIZE)
+    if (IObufflen >= IOSIZE)
     {
 	STRCPY(IObuff + IOSIZE - 4, "...");
-	IObufflen += 3;
+	IObufflen = IOSIZE - 1;
     }
+    vim_free(tofree);
     return vim_strnsave(IObuff, IObufflen);
 }
 


### PR DESCRIPTION
Problem:  heap-use-after-free and stack-use-after-scope with :14verbose
          when using :return and :try (after 9.1.1063).
Solution: Move back the vim_free(tofree) and the scope of numbuf[].
