### PR TITLE
fix: delete operation also need remove text from preinsert

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -2498,6 +2498,9 @@ ins_compl_stop(int c, int prev_mode, int retval)
 	retval = TRUE;
     }
 
+    if ((c == Ctrl_W || c == Ctrl_U) && ins_compl_preinsert_effect())
+	ins_compl_delete();
+
     auto_format(FALSE, TRUE);
 
     // Trigger the CompleteDonePre event to give scripts a chance to

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -3103,6 +3103,14 @@ function Test_completeopt_preinsert()
   call assert_equal("fo ", getline('.'))
   call assert_equal(3, col('.'))
 
+  call feedkeys("She\<C-X>\<C-N>\<C-U>", 'tx')
+  call assert_equal("", getline('.'))
+  call assert_equal(1, col('.'))
+
+  call feedkeys("She\<C-X>\<C-N>\<C-W>", 'tx')
+  call assert_equal("", getline('.'))
+  call assert_equal(1, col('.'))
+
   " whole line
   call feedkeys("Shello hero\<CR>\<C-X>\<C-L>", 'tx')
   call assert_equal("hello hero", getline('.'))


### PR DESCRIPTION
Problem: insert mode delete text operation does not clean text
         which insert by using preinsert

Solution: clean text when key is C-w or C-U

Fix #16557