### PR TITLE
syntax.c does not understand contains=TOP in included files

### DIFF
--- a/src/testdir/test_syntax.vim
+++ b/src/testdir/test_syntax.vim
@@ -949,7 +949,7 @@ func Test_syn_contained_transparent()
 endfunc
 
 func Test_syn_include_contains_TOP()
-  let l:case = "TOP in included syntax means its group list name"
+  let l:case = "TOP in included syntax refers to top level of that included syntax"
   new
   syntax include @INCLUDED syntax/c.vim
   syntax region FencedCodeBlockC start=/```c/ end=/```/ contains=@INCLUDED
@@ -960,6 +960,18 @@ func Test_syn_include_contains_TOP()
   " cCppOutElse has contains=TOP
   let l:expected = ["cType"]
   eval AssertHighlightGroups(5, 1, l:expected, 1, l:case)
+  syntax clear
+  bw!
+endfunc
+
+func Test_syn_include_contains_TOP_excluding()
+  new
+  syntax include @INCLUDED syntax/c.vim
+  syntax region FencedCodeBlockC start=/```c/ end=/```/ contains=@INCLUDED
+
+  call setline(1,  ['```c', '#if 0', 'int', '#else', 'int', '#if', '#endif', '```' ])
+  let l:expected = ["cCppOutElse", "cConditional"]
+  eval AssertHighlightGroups(6, 1, l:expected, 1)
   syntax clear
   bw!
 endfunc

--- a/src/vim.h
+++ b/src/vim.h
@@ -953,6 +953,7 @@ extern int (*dyn_libintl_wputenv)(const wchar_t *envstring);
 # define HL_TRANS_CONT	0x10000 // transparent item without contains arg
 # define HL_CONCEAL	0x20000 // can be concealed
 # define HL_CONCEALENDS	0x40000 // can be concealed
+# define HL_INCLUDED_TOPLEVEL 0x80000 // toplevel item in included syntax, allowed by contains=TOP
 #endif
 
 // Values for 'options' argument in do_search() and searchit()


### PR DESCRIPTION
Problem: Syntax engine interpreted contains=TOP as matching nothing inside included files, since :syn-include forces HL_CONTAINED on for every included item. After 8.2.2761, interprets contains=TOP as contains=@INCLUDED, which is also not correct since it doesn't respect exclusions, and doesn't work if there is no @INCLUDED cluster.

Solution: revert patch 8.2.2761, instead track groups that have had HL_CONTAINED forced, and interpret contains=TOP and contains=CONTAINED using this.

fixes #11277