### PR TITLE
tests: test_compiler fails on Windows without Maven

### DIFF
--- a/src/testdir/test_compiler.vim
+++ b/src/testdir/test_compiler.vim
@@ -417,8 +417,10 @@ func Test_compiler_spotbugs_properties()
 
   " TEST INTEGRATION WITH A SUPPORTED COMPILER PLUGIN.
   if filereadable($VIMRUNTIME .. '/compiler/maven.vim')
+    let save_PATH = $PATH
     if !executable('mvn')
       if has('win32')
+        let $PATH = 'Xspotbugs;' .. $PATH
         " This is what ":help executable()" suggests.
         call writefile([], 'Xspotbugs/mvn.cmd')
       else
@@ -702,6 +704,7 @@ func Test_compiler_spotbugs_properties()
 
     bwipeout
     setlocal makeprg=
+    let $PATH = save_PATH
   endif
 
   filetype plugin off


### PR DESCRIPTION
Problem:  tests: test_compiler fails on Windows without Maven.
Solution: Add Xspotbugs directory to $PATH when mvn is not available.
