### PR TITLE
vim_strnchr() is strange and unnecessary

### DIFF
--- a/src/linematch.c
+++ b/src/linematch.c
@@ -34,14 +34,10 @@ static size_t test_charmatch_paths(diffcmppath_T *node, int lastdecision);
 line_len(const mmfile_t *m)
 {
     char	*s = m->ptr;
-    size_t	n = (size_t)m->size;
     char	*end;
 
-    end = vim_strnchr(s, &n, '\n');
-    if (end)
-	return (size_t)(end - s);
-
-    return (size_t)m->size;
+    end = memchr(s, '\n', (size_t)m->size);
+    return end ? (size_t)(end - s) : (size_t)m->size;
 }
 
 #define MATCH_CHAR_MAX_LEN 800
@@ -171,10 +167,11 @@ fastforward_buf_to_lnum(mmfile_t s, linenr_T lnum)
 {
     for (int i = 0; i < lnum - 1; i++)
     {
-	size_t n = (size_t)s.size;
+	char *line_end;
 
-	s.ptr = vim_strnchr(s.ptr, &n, '\n');
-	s.size = (int)n;
+	line_end = memchr(s.ptr, '\n', (size_t)s.size);
+	s.size = line_end ? (int)(s.size - (line_end - s.ptr)) : 0;
+	s.ptr = line_end;
 	if (!s.ptr)
 	    break;
 	s.ptr++;

--- a/src/strings.c
+++ b/src/strings.c
@@ -674,22 +674,6 @@ vim_strchr(char_u *string, int c)
     return NULL;
 }
 
-// Sized version of strchr that can handle embedded NULs.
-// Adjusts n to the new size.
-    char *
-vim_strnchr(const char *p, size_t *n, int c)
-{
-    while (*n > 0)
-    {
-	if (*p == c)
-	    return (char *)p;
-	p++;
-	(*n)--;
-    }
-
-    return NULL;
-}
-
 /*
  * Version of strchr() that only works for bytes and handles unsigned char
  * strings with characters above 128 correctly. It also doesn't return a
@@ -3558,8 +3542,6 @@ vim_vsnprintf_typval(
 			str_arg_l = 0;
 		    else
 		    {
-			// Don't put the #if inside memchr(), it can be a
-			// macro.
 			// memchr on HP does not like n > 2^31  !!!
 			char *q = memchr(str_arg, '\0',
 				  precision <= (size_t)0x7fffffffL ? precision


### PR DESCRIPTION
Problem:  vim_strnchr() is strange and unnecessary.
Solution: Remove vim_strnchr() and use memchr() instead.  Also remove a
          comment referencing an #if that is no longer present.

vim_strnchr() is strange in several ways:
- It's named like vim_strchr(), but unlike vim_strchr() it doesn't
  support finding a multibyte char.
- Its logic is similar to vim_strbyte(), but unlike vim_strbyte() it
  uses char instead of char_u.
- It takes a pointer as its size argument, which isn't convenient for
  all its callers.
- It allows embedded NULs, unlike other "strn*" functions which stop
  when encountering a NUL byte.

In comparison, memchr() also allows embedded NULs, and it converts bytes
in the string to (unsigned char).
