### PR TITLE
Add support for Hurd

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -12750,6 +12750,7 @@ gui_win32s		idem, and Win32s system being used (Windows 3.1)
 haiku			Haiku version of Vim.
 hangul_input		Compiled with Hangul input support. |hangul|
 hpux			HP-UX version of Vim.
+hurd			Hurd version of Vim
 iconv			Can use iconv() for conversion.
 insert_expand		Compiled with support for CTRL-X expansion commands in
 			Insert mode. (always true)

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -6425,7 +6425,7 @@ f_has(typval_T *argvars, typval_T *rettv)
 #endif
 		},
 	{"bsd",
-#if defined(BSD) && !defined(MACOS_X)
+#if defined(BSD) && !defined(MACOS_X) && !defined(__GNU__)
 		1
 #else
 		0

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -6438,6 +6438,13 @@ f_has(typval_T *argvars, typval_T *rettv)
 		0
 #endif
 		},
+	{"hurd",
+#ifdef __GNU__
+		1
+#else
+		0
+#endif
+		},
 	{"linux",
 #ifdef __linux__
 		1

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -2888,6 +2888,7 @@ func Test_platform_name()
   " Is Unix?
   call assert_equal(has('bsd'), has('bsd') && has('unix'))
   call assert_equal(has('hpux'), has('hpux') && has('unix'))
+  call assert_equal(has('hurd'), has('hurd') && has('unix'))
   call assert_equal(has('linux'), has('linux') && has('unix'))
   call assert_equal(has('mac'), has('mac') && has('unix'))
   call assert_equal(has('qnx'), has('qnx') && has('unix'))
@@ -2905,6 +2906,7 @@ func Test_platform_name()
     call assert_equal(uname =~? 'QNX', has('qnx'))
     call assert_equal(uname =~? 'SunOS', has('sun'))
     call assert_equal(uname =~? 'CYGWIN\|MSYS', has('win32unix'))
+    call assert_equal(uname =~? 'GNU', has('hurd'))
   endif
 endfunc
 


### PR DESCRIPTION
GNU/Hurd, like Mac OS X, is a BSD-based system. It should exclude has('bsd') feature just like what Mac OS X does. The __GNU__ pre-defined macro indicates it's compiled for GNU/Hurd.