### PR TITLE
feat: detect mill files as Scala

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -2212,7 +2212,7 @@ au BufNewFile,BufRead *.sass			setf sass
 au BufNewFile,BufRead *.sa			call dist#ft#FTsa()
 
 " Scala
-au BufNewFile,BufRead *.scala			setf scala
+au BufNewFile,BufRead *.scala,*.mill		setf scala
 
 " SBT - Scala Build Tool
 au BufNewFile,BufRead *.sbt			setf sbt

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -674,7 +674,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     sas: ['file.sas'],
     sass: ['file.sass'],
     sbt: ['file.sbt'],
-    scala: ['file.scala'],
+    scala: ['file.scala', 'file.mill'],
     scheme: ['file.scm', 'file.ss', 'file.sld', 'file.stsg', 'any/local/share/supertux2/config', '.lips_repl_history'],
     scilab: ['file.sci', 'file.sce'],
     screen: ['.screenrc', 'screenrc'],


### PR DESCRIPTION
In the past [Mill](https://mill-build.org/mill/index.html) build files
were always `build.sc` and treated as Scala files. However as the 0.12.x
series of mill you can create a `build.mill` file. You can see a lot of
examples of this if you search
[GitHub](https://github.com/search?q=build.mill&type=code). This small
change just ensures that if you have a `*.mill` file it treats it as a
Scala file.
