### PR TITLE
Fix GUI late startup leading to uninitialized scrollbars

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -488,6 +488,7 @@ gui_init_check(void)
 gui_init(void)
 {
     win_T	*wp;
+    tabpage_T	*tp;
     static int	recursive = 0;
 
     /*
@@ -695,7 +696,7 @@ gui_init(void)
     gui_reset_scroll_region();
 
     // Create initial scrollbars
-    FOR_ALL_WINDOWS(wp)
+    FOR_ALL_TAB_WINDOWS(tp, wp)
     {
 	gui_create_scrollbar(&wp->w_scrollbars[SBAR_LEFT], SBAR_LEFT, wp);
 	gui_create_scrollbar(&wp->w_scrollbars[SBAR_RIGHT], SBAR_RIGHT, wp);


### PR DESCRIPTION
GUI startup was erroneously only initializing scrollbars for all windows in current tab, instead of all tabs. This breaks if the user has created tab pages before using `:gui` command to enter GUI mode, or sourced a session file in vimrc (instead of waiting for `VimEnter` or `GUIEnter` autocmds).