### PR TITLE
Fix setreg() blockwise width calculations with mbyte chars

### DIFF
--- a/src/register.c
+++ b/src/register.c
@@ -3019,12 +3019,17 @@ str_to_reg(
 	{
 	    int charlen = 0;
 
-	    for (i = start; i < len; ++i)	// find the end of the line
+	    for (i = start; i < len;)	// find the end of the line
 	    {
 		if (str[i] == '\n')
 		    break;
 		if (type == MBLOCK)
 		    charlen += mb_ptr2cells_len(str + i, len - i);
+
+		if (str[i] == NUL)
+		    i++; // registers can have NUL chars
+		else
+		    i += mb_ptr2len_len(str + i, len - i);
 	    }
 	    i -= start;			// i is now length of line
 	    if (charlen > maxlen)

--- a/src/testdir/test_registers.vim
+++ b/src/testdir/test_registers.vim
@@ -431,6 +431,23 @@ func Test_set_register()
   enew!
 endfunc
 
+" Test for blockwise register width calculations
+func Test_set_register_blockwise_width()
+  " Test for regular calculations and overriding the width
+  call setreg('a', "12\n1234\n123", 'b')
+  call assert_equal("\<c-v>4", getreginfo('a').regtype)
+  call setreg('a', "12\n1234\n123", 'b1')
+  call assert_equal("\<c-v>1", getreginfo('a').regtype)
+  call setreg('a', "12\n1234\n123", 'b6')
+  call assert_equal("\<c-v>6", getreginfo('a').regtype)
+
+  " Test for Unicode parsing
+  call setreg('a', "z😅😅z\n12345", 'b')
+  call assert_equal("\<c-v>6", getreginfo('a').regtype)
+  call setreg('a', ["z😅😅z", "12345"], 'b')
+  call assert_equal("\<c-v>6", getreginfo('a').regtype)
+endfunc
+
 " Test for clipboard registers (* and +)
 func Test_clipboard_regs()
   CheckNotGui


### PR DESCRIPTION
setreg() will automatically calculate the width when a blockwise mode is specified, but it does not properly calculate the line widths of mbyte characters when value is passed as newline-terminated string. It does work when value is passed as a list of lines though.

Fix this by properly using the mbyte utiilty to increment the loop counter.

~~Update: Seems like it's failing some terminal tests in test_terminal2. Looking.~ Update 2: Nevermind the test failures are unrelated to my change.