### PR TITLE
Add missing file extension for filetype "trace32"

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -2646,7 +2646,7 @@ au BufNewFile,BufRead *.toml			setf toml
 au BufNewFile,BufRead *.tpp			setf tpp
 
 " TRACE32 Script Language
-au BufNewFile,BufRead *.cmm,*.t32		setf trace32
+au BufNewFile,BufRead *.cmm,*.cmmt,*.t32	setf trace32
 
 " Treetop
 au BufRead,BufNewFile *.treetop			setf treetop

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -816,7 +816,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     tmux: ['tmuxfile.conf', '.tmuxfile.conf', '.tmux-file.conf', '.tmux.conf', 'tmux-file.conf', 'tmux.conf', 'tmux.conf.local'],
     toml: ['file.toml', 'Gopkg.lock', 'Pipfile', '/home/user/.cargo/config', '.black'],
     tpp: ['file.tpp'],
-    trace32: ['file.cmm', 'file.t32'],
+    trace32: ['file.cmm', 'file.cmmt', 'file.t32'],
     treetop: ['file.treetop'],
     trig: ['file.trig'],
     trustees: ['trustees.conf'],


### PR DESCRIPTION
"cmmt" files are regular TRACE32 scripts intended to be used as templates.