### PR TITLE
Vim9: fix clash :import with extends

### DIFF
--- a/src/testdir/test_vim9_import.vim
+++ b/src/testdir/test_vim9_import.vim
@@ -3420,4 +3420,42 @@ def Test_imported_class_as_def_func_rettype()
   v9.CheckScriptSuccess(lines)
 enddef
 
+" Test for don't crash when using a combination of import and class extends
+def Test_vim9_import_and_class_extends()
+  var lines =<< trim END
+    vim9script
+    import './cccc.vim'
+    export class Property extends cccc.Run
+      public var value: string
+      def new(this.value)
+      cccc.Run.value2 = this.value
+    enddef
+    endclass
+  END
+  writefile(lines, './aaaa.vim', 'D')
+
+  lines =<< trim END
+    vim9script
+    export class Run
+      public var value2: string
+      def new(this.value)
+      enddef
+    endclass
+  END
+  writefile(lines, './cccc.vim', 'D')
+
+  lines =<< trim END
+    vim9script
+    import './aaaa.vim'
+    class View
+      var content = aaaa.Property.new('')
+    endclass
+
+    var myView = View.new('This should be ok')
+    assert_equal('This should be ok', myView.content.value)
+  END
+  # TODO: The root cause will be identified later.
+  v9.CheckScriptFailure(lines, 'E1099: Unknown error while executing new', 7)
+enddef
+
 " vim: ts=8 sw=2 sts=2 expandtab tw=80 fdm=marker

--- a/src/vim9execute.c
+++ b/src/vim9execute.c
@@ -2461,8 +2461,14 @@ execute_storeindex(isn_T *iptr, ectx_T *ectx)
 		otv = class->class_members_tv;
 	    }
 
-	    clear_tv(&otv[lidx]);
-	    otv[lidx] = *tv;
+	    if (otv != NULL)
+	    {
+		clear_tv(&otv[lidx]);
+		otv[lidx] = *tv;
+	    }
+	    else
+		status = FAIL;
+
 	}
 	else
 	{


### PR DESCRIPTION
### Step to reproduce
#### Prepare some script files
aaaa.vim
```vim
vim9script
import './cccc.vim'
export class Property extends cccc.Run
  public var value: string
  def new(this.value)
      cccc.Run.value2 = this.value
  enddef
endclass
```

cccc.vim
```vim
vim9script
export class Run
  public var value2: string
  def new(this.value)
  enddef
endclass
```

test.vim
```vim
vim9script
import './aaaa.vim'
class View
  var content = aaaa.Property.new('')
endclass
var myView = View.new('This should be ok')
```

#### Run Vim some args.
```bash
$ vim --clean -S test.vim
```

### Actual behavior
```
Vim: Caught deadly signal SEGV
Vim: Finished.
Segmentation fault (core dumped)
```

### Expected behavior
Do not crash

### Note
This patch just avoids the SEGV for now.
I'll investigate the root cause and fix it later.