### PR TITLE
Vim9: Fix import and class extends E1001 issue (Try again)

### DIFF
--- a/src/proto/vim9compile.pro
+++ b/src/proto/vim9compile.pro
@@ -12,6 +12,7 @@ int need_type(type_T *actual, type_T *expected, int number_ok, int offset, int a
 lvar_T *reserve_local(cctx_T *cctx, char_u *name, size_t len, int assign, type_T *type);
 int get_script_item_idx(int sid, char_u *name, int check_writable, cctx_T *cctx, cstack_T *cstack);
 imported_T *find_imported(char_u *name, size_t len, int load);
+imported_T *find_imported_from_extends(cctx_T *cctx, char_u *name, size_t len, int load);
 char_u *may_peek_next_line(cctx_T *cctx, char_u *arg, char_u **nextp);
 char_u *peek_next_line_from_context(cctx_T *cctx);
 char_u *next_line_from_context(cctx_T *cctx, int skip_comment);

--- a/src/proto/vim9expr.pro
+++ b/src/proto/vim9expr.pro
@@ -2,7 +2,7 @@
 int generate_ppconst(cctx_T *cctx, ppconst_T *ppconst);
 void clear_ppconst(ppconst_T *ppconst);
 int compile_member(int is_slice, int *keeping_dict, cctx_T *cctx);
-int compile_load_scriptvar(cctx_T *cctx, char_u *name, char_u *start, char_u **end);
+int compile_load_scriptvar(cctx_T *cctx, char_u *name, char_u *start, char_u **end, imported_T *import);
 int compile_load(char_u **arg, char_u *end_arg, cctx_T *cctx, int is_expr, int error);
 int compile_arguments(char_u **arg, cctx_T *cctx, int *argcount, ca_special_T special_fn);
 char_u *to_name_end(char_u *arg, int use_namespace);

--- a/src/testdir/test_vim9_import.vim
+++ b/src/testdir/test_vim9_import.vim
@@ -3457,4 +3457,41 @@ def Test_vim9_import_and_class_extends()
   v9.CheckScriptFailure(lines, 'E1376: Object variable "value2" accessible only using class "Run" object', 2)
 enddef
 
+" Test for import and class extends
+def Test_vim9_import_and_class_extends_2()
+  mkdir('import', 'R')
+  var save_rtp = &rtp
+  &rtp = getcwd()
+
+  var lines =<< trim END
+    vim9script
+    export class Property
+      public var value: string
+    endclass
+  END
+  writefile(lines, './import/libproperty.vim')
+
+  lines =<< trim END
+    vim9script
+    import 'libproperty.vim'
+    export class View
+      var _content = libproperty.Property.new('')
+    endclass
+  END
+  writefile(lines, './import/libview.vim')
+
+  lines =<< trim END
+    vim9script
+    import 'libview.vim'
+    class MyView extends libview.View
+      def new(value: string)
+        this._content.value = value
+      enddef
+    endclass
+    var myView = MyView.new('This should be ok')
+  END
+  v9.CheckScriptSuccess(lines)
+  &rtp = save_rtp
+enddef
+
 " vim: ts=8 sw=2 sts=2 expandtab tw=80 fdm=marker

--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -844,11 +844,13 @@ find_imported(char_u *name, size_t len, int load)
 find_imported_from_extends(cctx_T *cctx, char_u *name, size_t len, int load)
 {
     imported_T	*ret = NULL;
-    class_T	*cl_extends = NULL;
+    class_T	*cl_extends;
 
-    if (cctx != NULL && cctx->ctx_ufunc != NULL
-					&& cctx->ctx_ufunc->uf_class != NULL)
-	cl_extends = cctx->ctx_ufunc->uf_class->class_extends;
+    if (cctx == NULL || cctx->ctx_ufunc == NULL
+					|| cctx->ctx_ufunc->uf_class == NULL)
+	return NULL;
+
+    cl_extends = cctx->ctx_ufunc->uf_class->class_extends;
 
     if (cl_extends != NULL && cl_extends->class_class_function_count_child > 0)
     {

--- a/src/vim9expr.c
+++ b/src/vim9expr.c
@@ -538,11 +538,12 @@ compile_load_scriptvar(
 	cctx_T *cctx,
 	char_u *name,	    // variable NUL terminated
 	char_u *start,	    // start of variable
-	char_u **end)	    // end of variable, may be NULL
+	char_u **end,	    // end of variable, may be NULL
+	imported_T *import) // found imported item, can be NULL
 {
     scriptitem_T    *si;
     int		    idx;
-    imported_T	    *import;
+    imported_T	    *imp;
 
     if (!SCRIPT_ID_VALID(current_sctx.sc_sid))
 	return FAIL;
@@ -557,8 +558,18 @@ compile_load_scriptvar(
 	return OK;
     }
 
-    import = end == NULL ? NULL : find_imported(name, 0, FALSE);
-    if (import != NULL)
+    if (end == NULL)
+	imp = NULL;
+    else if (import == NULL)
+    {
+	imp = find_imported(name, 0, FALSE);
+	if (imp == NULL)
+	    imp = find_imported_from_extends(cctx, name, 0, FALSE);
+    }
+    else
+	imp = import;
+
+    if (imp != NULL)
     {
 	char_u	*p = skipwhite(*end);
 	char_u	*exp_name;
@@ -568,8 +579,8 @@ compile_load_scriptvar(
 	int	done = FALSE;
 	int	res = OK;
 
-	check_script_symlink(import->imp_sid);
-	import_check_sourced_sid(&import->imp_sid);
+	check_script_symlink(imp->imp_sid);
+	import_check_sourced_sid(&imp->imp_sid);
 
 	// Need to lookup the member.
 	if (*p != '.')
@@ -591,11 +602,11 @@ compile_load_scriptvar(
 	cc = *p;
 	*p = NUL;
 
-	si = SCRIPT_ITEM(import->imp_sid);
+	si = SCRIPT_ITEM(imp->imp_sid);
 	if (si->sn_import_autoload && si->sn_state == SN_STATE_NOT_LOADED)
 	    // "import autoload './dir/script.vim'" or
 	    // "import autoload './autoload/script.vim'" - load script first
-	    res = generate_SOURCE(cctx, import->imp_sid);
+	    res = generate_SOURCE(cctx, imp->imp_sid);
 
 	if (res == OK)
 	{
@@ -624,17 +635,17 @@ compile_load_scriptvar(
 		{
 		    char_u sid_name[MAX_FUNC_NAME_LEN];
 
-		    func_name_with_sid(exp_name, import->imp_sid, sid_name);
+		    func_name_with_sid(exp_name, imp->imp_sid, sid_name);
 		    res = generate_PUSHFUNC(cctx, sid_name, &t_func_any, TRUE);
 		}
 		else
 		    res = generate_OLDSCRIPT(cctx, ISN_LOADEXPORT, exp_name,
-						      import->imp_sid, &t_any);
+						      imp->imp_sid, &t_any);
 		done = TRUE;
 	    }
 	    else
 	    {
-		idx = find_exported(import->imp_sid, exp_name, &ufunc, &type,
+		idx = find_exported(imp->imp_sid, exp_name, &ufunc, &type,
 							     cctx, NULL, TRUE);
 	    }
 	}
@@ -656,7 +667,7 @@ compile_load_scriptvar(
 	}
 
 	generate_VIM9SCRIPT(cctx, ISN_LOADSCRIPT,
-		import->imp_sid,
+		imp->imp_sid,
 		idx,
 		type);
 	return OK;
@@ -751,7 +762,7 @@ compile_load(
 			      res = generate_funcref(cctx, name, FALSE);
 			  else
 			      res = compile_load_scriptvar(cctx, name,
-								   NULL, &end);
+							    NULL, &end, NULL);
 			  break;
 		case 'g': if (vim_strchr(name, AUTOLOAD_CHAR) == NULL)
 			  {
@@ -869,11 +880,15 @@ compile_load(
 	    }
 	    else
 	    {
+		imported_T *imp = NULL;
+
 		// "var" can be script-local even without using "s:" if it
 		// already exists in a Vim9 script or when it's imported.
 		if (script_var_exists(*arg, len, cctx, NULL) == OK
-				      || find_imported(name, 0, FALSE) != NULL)
-		   res = compile_load_scriptvar(cctx, name, *arg, &end);
+		    || (imp = find_imported(name, 0, FALSE)) != NULL
+		    || (imp = find_imported_from_extends(cctx, name, 0, FALSE))
+								    != NULL)
+		   res = compile_load_scriptvar(cctx, name, *arg, &end, imp);
 
 		// When evaluating an expression and the name starts with an
 		// uppercase letter it can be a user defined function.

--- a/src/vim9expr.c
+++ b/src/vim9expr.c
@@ -561,11 +561,7 @@ compile_load_scriptvar(
     if (end == NULL)
 	imp = NULL;
     else if (import == NULL)
-    {
 	imp = find_imported(name, 0, FALSE);
-	if (imp == NULL)
-	    imp = find_imported_from_extends(cctx, name, 0, FALSE);
-    }
     else
 	imp = import;
 


### PR DESCRIPTION
Fix: #16379
Related: #16440