### PR TITLE
When using an imported class, check for a valid class member variable at compile time

### DIFF
--- a/src/testdir/Makefile
+++ b/src/testdir/Makefile
@@ -96,7 +96,7 @@ clean:
 	-rm -f opt_test.vim test_result.log $(CLEANUP_FILES)
 	-rm -rf $(RM_ON_RUN) $(RM_ON_START)
 	-rm -f valgrind.*
-	-rm -f asan.*
+	-rm -f asan.* asan_test_*
 	-rm -f guidialog guidialogfile
 
 # Delete the files produced by benchmarking, so they can run again.

--- a/src/testdir/test_vim9_import.vim
+++ b/src/testdir/test_vim9_import.vim
@@ -3454,8 +3454,7 @@ def Test_vim9_import_and_class_extends()
     var myView = View.new('This should be ok')
     assert_equal('This should be ok', myView.content.value)
   END
-  # TODO: The root cause will be identified later.
-  v9.CheckScriptFailure(lines, 'E1099: Unknown error while executing new', 7)
+  v9.CheckScriptFailure(lines, 'E1376: Object variable "value2" accessible only using class "Run" object', 2)
 enddef
 
 " vim: ts=8 sw=2 sts=2 expandtab tw=80 fdm=marker

--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -2496,9 +2496,10 @@ compile_load_lhs(
 	lhs->lhs_type = cctx->ctx_type_stack.ga_len == 0 ? &t_void
 						  : get_type_on_stack(cctx, 0);
 
-	if (lhs->lhs_type->tt_type == VAR_OBJECT)
+	if (lhs->lhs_type->tt_type == VAR_CLASS
+		|| lhs->lhs_type->tt_type == VAR_OBJECT)
 	{
-	    // Check whether the object variable is modifiable
+	    // Check whether the class or object variable is modifiable
 	    if (!lhs_class_member_modifiable(lhs, var_start, cctx))
 		return FAIL;
 	}

--- a/src/vim9execute.c
+++ b/src/vim9execute.c
@@ -2461,14 +2461,8 @@ execute_storeindex(isn_T *iptr, ectx_T *ectx)
 		otv = class->class_members_tv;
 	    }
 
-	    if (otv != NULL)
-	    {
-		clear_tv(&otv[lidx]);
-		otv[lidx] = *tv;
-	    }
-	    else
-		status = FAIL;
-
+	    clear_tv(&otv[lidx]);
+	    otv[lidx] = *tv;
 	}
 	else
 	{


### PR DESCRIPTION
Properly fix the issue reported in the PR #16601.