### PR TITLE
runtime: add b:match_words for nroff

### DIFF
--- a/runtime/ftplugin/nroff.vim
+++ b/runtime/ftplugin/nroff.vim
@@ -2,6 +2,7 @@
 " Language:	roff(7)
 " Maintainer:	Aman Verma
 " Homepage:	https://github.com/a-vrma/vim-nroff-ftplugin
+" Document:     https://www.gnu.org/software/groff/manual/groff.html
 " Previous Maintainer: Chris Spiegel <cspiegel@gmail.com>
 "		2024 May 24 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 
@@ -13,5 +14,17 @@ let b:did_ftplugin = 1
 setlocal commentstring=.\\\"\ %s
 setlocal comments=:.\\\"
 setlocal sections+=Sh
+setlocal define=.\s*de
 
-let b:undo_ftplugin = 'setlocal commentstring< comments< sections<'
+let b:undo_ftplugin = 'setlocal commentstring< comments< sections< define<'
+
+if exists('loaded_matchit')
+  let b:match_words = '^\.\s*ie\>:^\.\s*el\>'
+        \ . ',^\.\s*LB\>:^\.\s*LI\>:^\.\s*LE\>'
+        \ . ',^\.\s*TS\>:^\.\s*TE\>'
+        \ . ',^\.\s*PS\>:^\.\s*P[EF]\>'
+        \ . ',^\.\s*EQ\>:^\.\s*EN\>'
+        \ . ',^\.\s*[\>:^\.\s*]\>'
+        \ . ',^\.\s*FS\>:^\.\s*FE\>'
+  let b:undo_ftplugin .= "| unlet b:match_words"
+endif


### PR DESCRIPTION
Problem: nroff filetype miss b:match_words
Solution: add b:match_words for nroff

@averms Sorry, I forget your https://github.com/averms/vim-nroff-ftplugin/