### PR TITLE
'smoothscroll' gets stuck with 'listchars' "eol"

### DIFF
--- a/src/change.c
+++ b/src/change.c
@@ -572,8 +572,7 @@ changed_common(
 		    && (last < wp->w_topline
 			|| (wp->w_topline >= lnum
 			    && wp->w_topline < lnume
-			    && win_linetabsize(wp, wp->w_topline,
-					ml_get(wp->w_topline), (colnr_T)MAXCOL)
+			    && linetabsize_eol(wp, wp->w_topline)
 				    <= wp->w_skipcol + sms_marker_overlap(wp, -1))))
 		wp->w_skipcol = 0;
 

--- a/src/charset.c
+++ b/src/charset.c
@@ -821,6 +821,7 @@ linetabsize_col(int startcol, char_u *s)
 
 /*
  * Like linetabsize_str(), but for a given window instead of the current one.
+ * Doesn't count the size of 'listchars' "eol".
  */
     int
 win_linetabsize(win_T *wp, linenr_T lnum, char_u *line, colnr_T len)
@@ -836,12 +837,23 @@ win_linetabsize(win_T *wp, linenr_T lnum, char_u *line, colnr_T len)
 /*
  * Return the number of cells line "lnum" of window "wp" will take on the
  * screen, taking into account the size of a tab and text properties.
+ * Doesn't count the size of 'listchars' "eol".
  */
-  int
+    int
 linetabsize(win_T *wp, linenr_T lnum)
 {
     return win_linetabsize(wp, lnum,
 		       ml_get_buf(wp->w_buffer, lnum, FALSE), (colnr_T)MAXCOL);
+}
+
+/*
+ * Like linetabsize(), but counts the size of 'listchars' "eol".
+ */
+    int
+linetabsize_eol(win_T *wp, linenr_T lnum)
+{
+    return linetabsize(wp, lnum)
+	+ ((wp->w_p_list && wp->w_lcs_chars.eol != NUL) ? 1 : 0);
 }
 
 /*

--- a/src/misc2.c
+++ b/src/misc2.c
@@ -168,7 +168,7 @@ coladvance2(
 		&& wcol >= (colnr_T)width
 		&& width > 0)
 	{
-	    csize = linetabsize(curwin, pos->lnum);
+	    csize = linetabsize_eol(curwin, pos->lnum);
 	    if (csize > 0)
 		csize--;
 

--- a/src/normal.c
+++ b/src/normal.c
@@ -5764,7 +5764,7 @@ nv_g_home_m_cmd(cmdarg_T *cap)
 	// that skipcol is not adjusted later.
 	if (curwin->w_skipcol > 0 && curwin->w_cursor.lnum == curwin->w_topline)
 	{
-	    int overlap = sms_marker_overlap(curwin, -1);
+	    int overlap = sms_marker_overlap(curwin, curwin->w_width - width2);
 	    if (overlap > 0 && i == curwin->w_skipcol)
 		i += overlap;
 	}

--- a/src/proto/charset.pro
+++ b/src/proto/charset.pro
@@ -22,6 +22,7 @@ int linetabsize_str(char_u *s);
 int linetabsize_col(int startcol, char_u *s);
 int win_linetabsize(win_T *wp, linenr_T lnum, char_u *line, colnr_T len);
 int linetabsize(win_T *wp, linenr_T lnum);
+int linetabsize_eol(win_T *wp, linenr_T lnum);
 int linetabsize_no_outer(win_T *wp, linenr_T lnum);
 void win_linetabsize_cts(chartabsize_T *cts, colnr_T len);
 int vim_isIDc(int c);

--- a/src/testdir/test_scroll_opt.vim
+++ b/src/testdir/test_scroll_opt.vim
@@ -1216,4 +1216,59 @@ func Test_smooth_long_scrolloff()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_smoothscroll_listchars_eol()
+  call NewWindow(10, 40)
+  setlocal list listchars=eol:$ scrolloff=0 smoothscroll
+  call setline(1, repeat('-', 40))
+  call append(1, repeat(['foobar'], 10))
+
+  normal! G
+  call assert_equal(2, line('w0'))
+  call assert_equal(0, winsaveview().skipcol)
+
+  exe "normal! \<C-Y>"
+  call assert_equal(1, line('w0'))
+  call assert_equal(40, winsaveview().skipcol)
+
+  exe "normal! \<C-Y>"
+  call assert_equal(1, line('w0'))
+  call assert_equal(0, winsaveview().skipcol)
+
+  exe "normal! \<C-Y>"
+  call assert_equal(1, line('w0'))
+  call assert_equal(0, winsaveview().skipcol)
+
+  exe "normal! \<C-E>"
+  call assert_equal(1, line('w0'))
+  call assert_equal(40, winsaveview().skipcol)
+
+  exe "normal! \<C-E>"
+  call assert_equal(2, line('w0'))
+  call assert_equal(0, winsaveview().skipcol)
+
+  for ve in ['', 'all', 'onemore']
+    let &virtualedit = ve
+    normal! gg
+    call assert_equal(1, line('w0'))
+    call assert_equal(0, winsaveview().skipcol)
+
+    exe "normal! \<C-E>"
+    redraw  " redrawing should not cause another scroll
+    call assert_equal(1, line('w0'))
+    call assert_equal(40, winsaveview().skipcol)
+
+    exe "normal! \<C-E>"
+    redraw
+    call assert_equal(2, line('w0'))
+    call assert_equal(0, winsaveview().skipcol)
+
+    if ve != 'all'
+      call assert_equal([0, 2, 1, 0], getpos('.'))
+    endif
+  endfor
+
+  set virtualedit&
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  'smoothscroll' gets stuck with 'listchars' "eol".
Solution: Count size of 'listchars' "eol" in line size when scrolling.

fixes: neovim/neovim#32405
