### PR TITLE
fix: wrong selected index when enable nsort in completeopt

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -1372,8 +1372,6 @@ ins_compl_build_pum(void)
 		    if (!compl_no_select)
 			compl_shown_match = compl;
 		}
-		else if (!fuzzy_sort && i == 0 && !compl_no_select)
-		    compl_shown_match = shown_compl;
 
 		if (!shown_match_ok && compl == compl_shown_match && !compl_no_select)
 		{
@@ -1406,6 +1404,13 @@ ins_compl_build_pum(void)
 
     if (compl_match_arraysize == 0)
 	return -1;
+
+    if (fuzzy_filter && !fuzzy_sort && !compl_no_select && !shown_match_ok)
+    {
+	compl_shown_match = shown_compl;
+	shown_match_ok = TRUE;
+	cur = 0;
+    }
 
     compl_match_array = ALLOC_CLEAR_MULT(pumitem_T, compl_match_arraysize);
     if (compl_match_array == NULL)

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -2689,6 +2689,8 @@ func Test_complete_fuzzy_match()
   func OnPumChange()
     let g:item = get(v:event, 'completed_item', {})
     let g:word = get(g:item, 'word', v:null)
+    let g:abbr = get(g:item, 'abbr', v:null)
+    let g:selected = get(complete_info(['selected']), 'selected')
   endfunction
 
   augroup AAAAA_Group
@@ -2875,6 +2877,20 @@ func Test_complete_fuzzy_match()
   call feedkeys("S\<C-x>\<C-o>fooB\<C-Y>", 'tx')
   call assert_equal('fooBaz', getline('.'))
 
+  set cot=menuone,fuzzy,nosort
+  func CompAnother()
+    call complete(col('.'), [#{word: "do" }, #{word: "echo"}, #{word: "for (${1:expr1}, ${2:expr2}, ${3:expr3}) {\n\t$0\n}", abbr: "for" }, #{word: "foo"}])
+    return ''
+  endfunc
+  call feedkeys("i\<C-R>=CompAnother()\<CR>\<C-N>\<C-N>", 'tx')
+  call assert_equal("for", g:abbr)
+  call assert_equal(2, g:selected)
+
+  set cot+=noinsert
+  call feedkeys("i\<C-R>=CompAnother()\<CR>f", 'tx')
+  call assert_equal("for", g:abbr)
+  call assert_equal(2, g:selected)
+
   " clean up
   set omnifunc=
   bw!
@@ -2885,8 +2901,11 @@ func Test_complete_fuzzy_match()
   delfunc OnPumChange
   delfunc Omni_test
   delfunc Comp
+  delfunc CompAnother
   unlet g:item
   unlet g:word
+  unlet g:selected
+  unlet g:abbr
 endfunc
 
 func Test_complete_fuzzy_with_completeslash()


### PR DESCRIPTION
Problem: Can not range all completion candidates when set nosort and fuzzy in completeopt.

Solution: Set cur to zero and update compl_shown_match when nosort without noselect in completopt

Fix #16624