### PR TITLE
runtime(syntax-tests): Apply stronger synchronisation between buffers

### DIFF
--- a/Filelist
+++ b/Filelist
@@ -878,6 +878,7 @@ RT_SCRIPTS =	\
 		runtime/syntax/testdir/input/setup/*.* \
 		runtime/syntax/testdir/dumps/*.dump \
 		runtime/syntax/testdir/dumps/*.vim \
+		runtime/syntax/testdir/tools/* \
 		runtime/syntax/generator/Makefile \
 		runtime/syntax/generator/README.md \
 		runtime/syntax/generator/gen_syntax_vim.vim \

--- a/runtime/syntax/Makefile
+++ b/runtime/syntax/Makefile
@@ -3,7 +3,7 @@
 # To run the test manually:
 # ../../src/vim -u 'testdir/runtest.vim' --cmd 'breakadd func RunTest'
 
-# Override this if needed, the default assumes Vim was build in the src dir.
+# Override this if needed, the default assumes Vim was built in the src dir.
 #VIMPROG = vim
 VIMPROG = ../../src/vim
 
@@ -13,6 +13,10 @@ VIMRUNTIME = ../..
 # Uncomment this line to use valgrind for memory leaks and extra warnings.
 # VALGRIND = valgrind --tool=memcheck --leak-check=yes --num-callers=45 --log-file=valgrind.$*
 
+# Trace ruler liveness on demand.
+# VIM_SYNTAX_TEST_LOG = `pwd`/testdir/failed/00-TRACE_LOG
+
+# ENVVARS = LC_ALL=C VIM_SYNTAX_TEST_LOG="$(VIM_SYNTAX_TEST_LOG)"
 # ENVVARS = LC_ALL=C LANG=C LANGUAGE=C
 # Run the syntax tests with a C locale
 ENVVARS = LC_ALL=C
@@ -31,6 +35,9 @@ test:
 	@# the "vimcmd" file is used by the screendump utils
 	@echo "../$(VIMPROG)" > testdir/vimcmd
 	@echo "$(RUN_VIMTEST)" >> testdir/vimcmd
+	@# Trace ruler liveness on demand.
+	@#mkdir -p testdir/failed
+	@#touch "$(VIM_SYNTAX_TEST_LOG)"
 	VIMRUNTIME=$(VIMRUNTIME) $(ENVVARS) $(VIMPROG) --clean --not-a-term $(DEBUGLOG) -u testdir/runtest.vim > /dev/null 
 	@rm -f testdir/Xfilter
 	@# FIXME: Temporarily show the whole file to find out what goes wrong

--- a/runtime/syntax/testdir/runtest.vim
+++ b/runtime/syntax/testdir/runtest.vim
@@ -15,6 +15,17 @@ let s:messagesFname = fnameescape(syntaxDir .. '/testdir/messages')
 
 let s:messages = []
 
+" Erase the cursor line and do not advance the cursor.
+def EraseLineAndReturnCarriage(rname: string)
+  const full_width: number = winwidth(0)
+  const half_width: number = full_width - (full_width + 1) / 2
+  if (strlen(rname) + strlen('Test' .. "\x20\x20" .. 'FAILED')) > half_width
+    echon "\r" .. repeat("\x20", full_width) .. "\r"
+  else
+    echon repeat("\x20", half_width) .. "\r"
+  endif
+enddef
+
 " Add one message to the list of messages
 func Message(msg)
   echomsg a:msg
@@ -30,22 +41,23 @@ endfunc
 
 " Append s:messages to the messages file and make it empty.
 func AppendMessages(header)
-  exe 'split ' .. s:messagesFname
+  silent exe 'split ' .. s:messagesFname
   call append(line('$'), '')
   call append(line('$'), a:header)
   call append(line('$'), s:messages)
   let s:messages = []
-  wq
+  silent wq
 endfunc
 
 " Relevant messages are written to the "messages" file.
 " If the file already exists it is appended to.
-exe 'split ' .. s:messagesFname
+silent exe 'split ' .. s:messagesFname
 call append(line('$'), repeat('=-', 70))
 call append(line('$'), '')
 let s:test_run_message = 'Test run on ' .. strftime("%Y %b %d %H:%M:%S")
 call append(line('$'), s:test_run_message)
-wq
+silent wq
+echo "\n"
 
 if syntaxDir !~ '[/\\]runtime[/\\]syntax\>'
   call Fatal('Current directory must be "runtime/syntax"')
@@ -517,6 +529,8 @@ func RunTest()
       let skipped_count += 1
     endif
 
+    call EraseLineAndReturnCarriage(root)
+
     " Append messages to the file "testdir/messages"
     call AppendMessages('Input file ' .. fname .. ':')
 
@@ -525,6 +539,7 @@ func RunTest()
     endif
   endfor
 
+  call EraseLineAndReturnCarriage('')
   call Message(s:test_run_message)
   call Message('OK: ' .. ok_count)
   call Message('FAILED: ' .. len(failed_tests) .. ': ' .. string(failed_tests))
@@ -550,4 +565,4 @@ endif
 
 qall!
 
-" vim:ts=8
+" vim:sw=2:ts=8:noet:

--- a/runtime/syntax/testdir/tools/regenerate_screendumps.sh
+++ b/runtime/syntax/testdir/tools/regenerate_screendumps.sh
@@ -1,0 +1,126 @@
+#!/bin/sh -e
+#
+# The following steps are to be taken by this script:
+# 1) Remove all files from the "dumps" directory.
+# 2) Generate screendumps for each syntax test and each self-test.
+# 3) Unconditionally move each batch of screendumps to "dumps"; if generated
+#	files differ on repeated runs, always remove these files from "dumps".
+# 4) Repeat steps 2) and 3) once or as many times as requested with the "$1"
+#	argument.
+# 5) Summarise any differences.
+#
+# Provided that "git difftool" is set up (see src/testdir/commondumps.vim),
+# run "git difftool HEAD -- '**/*.dump'" to collate tracked and generated
+# screendumps.
+
+case "$1" in
+-h | --help)
+	printf >&2 "Usage: [time VIM_SYNTAX_TEST_LOG=/tmp/log] $0 [1 | 2 | ...]\n"
+	exit 0
+	;;
+esac
+
+tries="${1:-1}"
+shift $#
+
+case "$tries" in
+0* | *[!0-9]*)
+	exit 80
+	;;
+esac
+
+test -x "$(command -v make)"	|| exit 81
+test -x "$(command -v git)"	|| exit 82
+
+case "$(git status --porcelain=v1)" in
+'')	;;
+*)	printf >&2 'Resolve ALL changes before proceeding.\n'
+	exit 83
+	;;
+esac
+
+templet=$(printf "\t\t\t\t$(tput rev)%%s$(tput sgr0)") || exit 84
+cd "$(dirname "$0")/../../../syntax" || exit 85
+set +f
+rm testdir/dumps/*.dump || exit 86
+spuriosities=''
+
+# Because the clean target of Make will be executed before each syntax test,
+# this environment variable needs to be pointed to an existing file that is
+# created in a directory not affectable by the target.
+if test -w "$VIM_SYNTAX_TEST_LOG"
+then
+	log=-e VIM_SYNTAX_TEST_LOG="$VIM_SYNTAX_TEST_LOG"
+else
+	log=
+fi
+
+for f in testdir/input/*.*
+do
+	test ! -d "$f" || continue
+	b=$(basename "$f")
+	i=0
+	printf "$templet\n\n" "$b"
+
+	while test "$i" -le "$tries"
+	do
+		make $log clean "$b" test || :
+
+		case "$i" in
+		0)	mv testdir/failed/*.dump testdir/dumps/
+			;;
+		*)	case "$(printf '%s' testdir/failed/*.dump)" in
+			testdir/failed/\*.dump)
+				# (Repeatable) success.
+				;;
+			*)	spuriosities="${spuriosities}${b} "
+				p=${b%.*}
+				rm -f testdir/dumps/"$p"_[0-9][0-9].dump \
+					testdir/dumps/"$p"_[0-9][0-9][0-9].dump \
+					testdir/dumps/"$p"_[0-9][0-9][0-9][0-9].dump
+				;;
+			esac
+			;;
+		esac
+
+		i=$(($i + 1))
+		sleep 1
+	done
+done
+
+# For a 20-file set, initially fail for a series of: 1-6, 7-12, 13-18, 19-20.
+tries=$(($tries + 3))
+i=0
+
+while test "$i" -le "$tries"
+do
+	make $log clean self-testing test || :
+
+	case "$i" in
+	[0-3])	mv testdir/failed/dots_*.dump testdir/dumps/
+		;;
+	*)	case "$(printf '%s' testdir/failed/*.dump)" in
+		testdir/failed/\*.dump)
+			# (Repeatable) success.
+			;;
+		*)	spuriosities="${spuriosities}dots_xy "
+			rm -f testdir/dumps/dots_*.dump
+			;;
+		esac
+		;;
+	esac
+
+	sleep 1
+	i=$(($i + 1))
+done
+
+make clean
+git diff --compact-summary
+
+if test -n "$spuriosities"
+then
+	printf '\n%s\n' "$spuriosities"
+	exit 87
+fi
+
+# vim:sw=8:ts=8:noet:nosta:


### PR DESCRIPTION
The current lightweight synchronisation with `:redraw` needs  
further reinforcement in the light of [v9.1.1110](https://github.com/vim/vim/commit/e70587dbdbb1aba2c3f92490b8f870361d4a4177).  And, with  
[v9.1.0820](https://github.com/vim/vim/commit/baab7c08653a4e1b7227d6426d96cab030ccf9e8), make another synchronisation point _before_ the  
first (or only) screenful is dumped.
