### PR TITLE
Inconsistencies in get_next_or_prev_match()

### DIFF
--- a/src/cmdexpand.c
+++ b/src/cmdexpand.c
@@ -737,21 +737,22 @@ get_next_or_prev_match(int mode, expand_T *xp)
     int	    findex = xp->xp_selected;
     int	    ht;
 
-    // When no files found, return NULL
+    // When no matches found, return NULL
     if (xp->xp_numfiles <= 0)
 	return NULL;
 
     if (mode == WILD_PREV)
     {
-	// Select last file if at start
+	// Select the last entry if at original text
 	if (findex == -1)
 	    findex = xp->xp_numfiles;
+	// Otherwise select the previous entry
 	--findex;
     }
     else if (mode == WILD_NEXT)
     {
-	// Select next file
-	findex = findex + 1;
+	// Select the next entry
+	++findex;
     }
     else   // WILD_PAGEDOWN or WILD_PAGEUP
     {
@@ -765,7 +766,7 @@ get_next_or_prev_match(int mode, expand_T *xp)
 	    if (findex == 0)
 		// at the first entry, don't select any entries
 		findex = -1;
-	    else if (findex == -1)
+	    else if (findex < 0)
 		// no entry is selected. select the last entry
 		findex = xp->xp_numfiles - 1;
 	    else
@@ -774,12 +775,12 @@ get_next_or_prev_match(int mode, expand_T *xp)
 	}
 	else    // mode == WILD_PAGEDOWN
 	{
-	    if (findex < 0)
-		// no entry is selected, select the first entry
-		findex = 0;
-	    else if (findex >= xp->xp_numfiles - 1)
+	    if (findex >= xp->xp_numfiles - 1)
 		// at the last entry, don't select any entries
 		findex = -1;
+	    else if (findex < 0)
+		// no entry is selected, select the first entry
+		findex = 0;
 	    else
 		// go down by the pum height
 		findex = MIN(findex + ht, xp->xp_numfiles - 1);
@@ -789,7 +790,7 @@ get_next_or_prev_match(int mode, expand_T *xp)
     // Handle wrapping around
     if (findex < 0 || findex >= xp->xp_numfiles)
     {
-	// If original string exists, return to it when wrapping around
+	// If original text exists, return to it when wrapping around
 	if (xp->xp_orig != NULL)
 	    findex = -1;
 	else
@@ -808,7 +809,7 @@ get_next_or_prev_match(int mode, expand_T *xp)
 		cmd_showtail);
 
     xp->xp_selected = findex;
-    // Return the original string or the selected match
+    // Return the original text or the selected match
     return vim_strsave(findex == -1 ? xp->xp_orig : xp->xp_files[findex]);
 }
 


### PR DESCRIPTION
Problem:  Inconsistencies in get_next_or_prev_match() (after 9.1.1109).
Solution: Change "file" to "entry" or "match" in comments.  Use the same
          order of branches for PAGEUP and PAGEDOWN.
