### PR TITLE
Make Test_terminal_builtin_without_gui run faster

### DIFF
--- a/src/testdir/test_termcodes.vim
+++ b/src/testdir/test_termcodes.vim
@@ -2750,7 +2750,7 @@ func Test_terminal_builtin_without_gui()
   CheckNotMSWindows
 
   " builtin_gui should not be output by :set term=xxx
-  let output = systemlist("TERM=dumb " .. v:progpath .. " --clean -c ':set t_ti= t_te=' -c 'set term=xxx' -c ':q!'")
+  let output = systemlist("TERM=dumb " .. v:progpath .. " --not-a-term --clean -c ':set t_ti= t_te=' -c 'set term=xxx' -c ':q!'")
   redraw!
   call map(output, {_, val -> trim(val)})
   call assert_equal(-1, index(output, 'builtin_gui'))


### PR DESCRIPTION
Using --not-a-term removes the annoying 2s delay in error message when Vim detects that stdio are not from a terminal.

---

Found this straggler from the recent Vim test performance PR. This saves only 2 seconds, but there's no harm / change in results by using `--not-a-term` to prevent Vim from complaining.