### PR TITLE
runtime(netrw): upstream snapshot of v178

### DIFF
--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -7527,7 +7527,6 @@ g0	motion.txt	/*g0*
 g8	various.txt	/*g8*
 g:	eval.txt	/*g:*
 g:NetrwTopLvlMenu	pi_netrw.txt	/*g:NetrwTopLvlMenu*
-g:Netrw_UserMaps	pi_netrw.txt	/*g:Netrw_UserMaps*
 g:Netrw_corehandler	pi_netrw.txt	/*g:Netrw_corehandler*
 g:Netrw_funcref	pi_netrw.txt	/*g:Netrw_funcref*
 g:Openprg	eval.txt	/*g:Openprg*
@@ -8988,7 +8987,6 @@ netrw-browsing	pi_netrw.txt	/*netrw-browsing*
 netrw-c-tab	pi_netrw.txt	/*netrw-c-tab*
 netrw-cB	pi_netrw.txt	/*netrw-cB*
 netrw-cadaver	pi_netrw.txt	/*netrw-cadaver*
-netrw-call	pi_netrw.txt	/*netrw-call*
 netrw-cb	pi_netrw.txt	/*netrw-cb*
 netrw-cd	pi_netrw.txt	/*netrw-cd*
 netrw-chgup	pi_netrw.txt	/*netrw-chgup*
@@ -9013,7 +9011,6 @@ netrw-enter	pi_netrw.txt	/*netrw-enter*
 netrw-ex	pi_netrw.txt	/*netrw-ex*
 netrw-explore	pi_netrw.txt	/*netrw-explore*
 netrw-explore-cmds	pi_netrw.txt	/*netrw-explore-cmds*
-netrw-expose	pi_netrw.txt	/*netrw-expose*
 netrw-externapp	pi_netrw.txt	/*netrw-externapp*
 netrw-file	pi_netrw.txt	/*netrw-file*
 netrw-filigree	pi_netrw.txt	/*netrw-filigree*
@@ -9060,7 +9057,6 @@ netrw-mh	pi_netrw.txt	/*netrw-mh*
 netrw-middlemouse	pi_netrw.txt	/*netrw-middlemouse*
 netrw-ml_get	pi_netrw.txt	/*netrw-ml_get*
 netrw-mm	pi_netrw.txt	/*netrw-mm*
-netrw-modify	pi_netrw.txt	/*netrw-modify*
 netrw-mouse	pi_netrw.txt	/*netrw-mouse*
 netrw-move	pi_netrw.txt	/*netrw-move*
 netrw-mp	pi_netrw.txt	/*netrw-mp*
@@ -9148,7 +9144,6 @@ netrw-transparent	pi_netrw.txt	/*netrw-transparent*
 netrw-u	pi_netrw.txt	/*netrw-u*
 netrw-updir	pi_netrw.txt	/*netrw-updir*
 netrw-urls	pi_netrw.txt	/*netrw-urls*
-netrw-usermaps	pi_netrw.txt	/*netrw-usermaps*
 netrw-userpass	pi_netrw.txt	/*netrw-userpass*
 netrw-v	pi_netrw.txt	/*netrw-v*
 netrw-var	pi_netrw.txt	/*netrw-var*

--- a/runtime/pack/dist/opt/netrw/doc/netrw.txt
+++ b/runtime/pack/dist/opt/netrw/doc/netrw.txt
@@ -367,10 +367,6 @@ settings are described below, in |netrw-browser-options|, and in
 			    let g:Netrw_funcref= function("MyFuncRef")
 
 <
- *g:Netrw_UserMaps*	specifies a function or |List| of functions which can
-			be used to set up user-specified maps and functionality.
-			See |netrw-usermaps|
-
  *g:netrw_ftp*		   if it doesn't exist, use default ftp
 			=0 use default ftp		       (uid password)
 			=1 use alternate ftp method	  (user uid password)
@@ -3213,60 +3209,6 @@ than a <c-tab>, too: (but you'll still need to have had |g:netrw_usetab| set). >
 Related topics:			|:Lexplore|
 Associated setting variable:	|g:netrw_usetab|
 
-
-USER SPECIFIED MAPS					*netrw-usermaps* {{{1
-
-One may make customized user maps.  Specify a variable, |g:Netrw_UserMaps|,
-to hold a |List| of lists of keymap strings and function names: >
-
-	[["keymap-sequence","ExampleUserMapFunc"],...]
-<
-When netrw is setting up maps for a netrw buffer, if |g:Netrw_UserMaps|
-exists, then the internal function netrw#UserMaps(islocal) is called.
-This function goes through all the entries in the |g:Netrw_UserMaps| list:
-
-	* sets up maps: >
-		nno <buffer> <silent> KEYMAP-SEQUENCE
-		:call s:UserMaps(islocal,"ExampleUserMapFunc")
-<	* refreshes if result from that function call is the string
-	  "refresh"
-	* if the result string is not "", then that string will be
-	  executed (:exe result)
-	* if the result is a List, then the above two actions on results
-	  will be taken for every string in the result List
-
-The user function is passed one argument; it resembles >
-
-	fun! ExampleUserMapFunc(islocal)
-<
-where a:islocal is 1 if its a local-directory system call or 0 when
-remote-directory system call.
-
-			        *netrw-call*  *netrw-expose*  *netrw-modify*
-Use netrw#Expose("varname")          to access netrw-internal (script-local)
-				     variables.
-Use netrw#Modify("varname",newvalue) to change netrw-internal variables.
-Use netrw#Call("funcname"[,args])    to call a netrw-internal function with
-				     specified arguments.
-
-Example: Get a copy of netrw's marked file list: >
-
-	let netrwmarkfilelist= netrw#Expose("netrwmarkfilelist")
-<
-Example: Modify the value of netrw's marked file list: >
-
-	call netrw#Modify("netrwmarkfilelist",[])
-<
-Example: Clear netrw's marked file list via a mapping on gu >
-    " ExampleUserMap: {{{2
-    fun! ExampleUserMap(islocal)
-      call netrw#Modify("netrwmarkfilelist",[])
-      call netrw#Modify('netrwmarkfilemtch_{bufnr("%")}',"")
-      let retval= ["refresh"]
-      return retval
-    endfun
-    let g:Netrw_UserMaps= [["gu","ExampleUserMap"]]
-<
 
 10. Problems and Fixes					*netrw-problems* {{{1
 


### PR DESCRIPTION
Hi, This PR remove a really problematic configuration option. `netrw#UserMaps` uses some functions like `netrw#Expose` and `netrw#Modify` to mutate local or private varibles inside netrw. This can leads the users to do stupid or dangerous things and I don't want to support this in any capacity. It was a bad decision and needs to be deleted.

Note that netrw stores connection passwords in a netrw local variable witch can be read by `netrw#Expose`.