### PR TITLE
fix: insert newline when pum visible

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -1889,6 +1889,7 @@ ins_compl_clear(void)
     compl_cont_status = 0;
     compl_started = FALSE;
     compl_matches = 0;
+    compl_selected_item = -1;
     compl_ins_end_col = 0;
     VIM_CLEAR_STRING(compl_pattern);
     VIM_CLEAR_STRING(compl_leader);
@@ -2579,6 +2580,10 @@ ins_compl_prep(int c)
 {
     int		retval = FALSE;
     int		prev_mode = ctrl_x_mode;
+    int		handle_enter = FALSE;
+
+    if ((c == CAR || c == NL || c == K_KENTER) && compl_selected_item == -1)
+	handle_enter = TRUE;
 
     // Forget any previous 'special' messages if this is actually
     // a ^X mode key - bar ^R, in which case we wait to see what it gives us.
@@ -2676,7 +2681,14 @@ ins_compl_prep(int c)
 	if ((ctrl_x_mode_normal() && c != Ctrl_N && c != Ctrl_P
 				       && c != Ctrl_R && !ins_compl_pum_key(c))
 		|| ctrl_x_mode == CTRL_X_FINISHED)
+	{
 	    retval = ins_compl_stop(c, prev_mode, retval);
+	    // When it is the Enter key and no selected item, return false, and
+	    // continue processing the Enter key to insert a new line in the
+	    // edit function.
+	    if (retval && handle_enter)
+		retval = FALSE;
+	}
     }
     else if (ctrl_x_mode == CTRL_X_LOCAL_MSG)
 	// Trigger the CompleteDone event to give scripts a chance to act

--- a/src/testdir/test_edit.vim
+++ b/src/testdir/test_edit.vim
@@ -198,7 +198,7 @@ func Test_edit_07()
     endif
   endfu
   au InsertCharPre <buffer> :call DoIt()
-  call feedkeys("A\<f5>\<c-p>u\<cr>\<c-l>\<cr>", 'tx')
+  call feedkeys("A\<f5>\<c-p>u\<C-Y>\<c-l>\<cr>", 'tx')
   call assert_equal(["Jan\<c-l>",''], 1->getline('$'))
   %d
   call setline(1, 'J')
@@ -594,7 +594,7 @@ func Test_edit_CTRL_I()
   call assert_equal([include, 'two', ''], getline(1, '$'))
   call feedkeys("2ggC\<c-x>\<tab>\<down>\<down>\<cr>\<esc>", 'tnix')
   call assert_equal([include, 'three', ''], getline(1, '$'))
-  call feedkeys("2ggC\<c-x>\<tab>\<down>\<down>\<down>\<cr>\<esc>", 'tnix')
+  call feedkeys("2ggC\<c-x>\<tab>\<down>\<down>\<down>\<C-y>\<esc>", 'tnix')
   call assert_equal([include, '', ''], getline(1, '$'))
   bw!
 endfunc
@@ -622,7 +622,7 @@ func Test_edit_CTRL_K()
   %d
   call setline(1, 'A')
   call cursor(1, 1)
-  call feedkeys("A\<c-x>\<c-k>\<down>\<down>\<down>\<cr>\<esc>", 'tnix')
+  call feedkeys("A\<c-x>\<c-k>\<down>\<down>\<down>\<C-Y>\<esc>", 'tnix')
   call assert_equal(['A'], getline(1, '$'))
   %d
   call setline(1, 'A')
@@ -2291,6 +2291,17 @@ func Test_edit_backspace_smarttab_virtual_text()
   call CloseWindow()
   call prop_type_delete('theprop')
   set smarttab&
+endfunc
+
+func Test_edit_CAR()
+  set cot=menu,menuone,noselect
+  new
+
+  call feedkeys("Shello hero\<CR>h\<C-x>\<C-N>e\<CR>", 'tx')
+  call assert_equal(['hello hero', 'he', ''], getline(1, '$'))
+
+  bw!
+  set cot&
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -2855,7 +2855,7 @@ func Test_complete_fuzzy_match()
   call setline(1, ['Text', 'ToText', ''])
   call cursor(3, 1)
   call feedkeys("STe\<C-X>\<C-N>x\<CR>\<Esc>0", 'tx!')
-  call assert_equal('Tex', getline('.'))
+  call assert_equal('Tex', getline(line('.') - 1))
 
   " test case for nosort option
   set cot=menuone,menu,noinsert,fuzzy,nosort

--- a/src/testdir/test_popup.vim
+++ b/src/testdir/test_popup.vim
@@ -987,7 +987,7 @@ func Test_popup_complete_backwards()
   call setline(1, ['Post', 'Port', 'Po'])
   let expected=['Post', 'Port', 'Port']
   call cursor(3,2)
-  call feedkeys("A\<C-X>". repeat("\<C-P>", 3). "rt\<cr>", 'tx')
+  call feedkeys("A\<C-X>". repeat("\<C-P>", 3). "rt\<C-Y>", 'tx')
   call assert_equal(expected, getline(1,'$'))
   bwipe!
 endfunc
@@ -997,7 +997,7 @@ func Test_popup_complete_backwards_ctrl_p()
   call setline(1, ['Post', 'Port', 'Po'])
   let expected=['Post', 'Port', 'Port']
   call cursor(3,2)
-  call feedkeys("A\<C-P>\<C-N>rt\<cr>", 'tx')
+  call feedkeys("A\<C-P>\<C-N>rt\<C-Y>", 'tx')
   call assert_equal(expected, getline(1,'$'))
   bwipe!
 endfunc


### PR DESCRIPTION
Problem: When the PUM is visible and there is no selected complete-item, pressing Enter does not insert a new line.
Solution: When Enter is pressed and no complete-item is selected, ins_compl_prep returns false, and the edit function continues processing Enter to insert a new line.

cc @lifepillar 

Fix #1653