### PR TITLE
feat: Lua ftplugin

### DIFF
--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -746,9 +746,21 @@ Add following lines to $HOME/.vim/ftplugin/json.vim: >
 
 LUA							*ft-lua-plugin*
 
-You can enable folding of Lua functions using |fold-expr| by: >
+							*g:lua_folding*
+You can enable folding of Lua functions using |fold-expr| by: >vim
 
 	let g:lua_folding = 1
+<
+					*g:lua_version* *g:lua_subversion*
+Lua filetype's |includeexpr| and |ft-lua-syntax| highlighting use the global
+variables "g:lua_version" and "g:lua_subversion" to determine the version of
+Lua to use (5.3 is the default)
+
+For example, to use Lua 5.1, set the variables like this: >vim
+
+	let g:lua_version = 5
+	let g:lua_subversion = 1
+<
 
 MAIL							*ft-mail-plugin*
 

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -2343,13 +2343,9 @@ instead, and the name of your source file should be *.pike
 
 LUA						*lua.vim* *ft-lua-syntax*
 
-The Lua syntax file can be used for versions 4.0, 5.0, 5.1 and 5.2 (5.2 is
-the default). You can select one of these versions using the global variables
-lua_version and lua_subversion. For example, to activate Lua
-5.1 syntax highlighting, set the variables like this: >
-
-	:let lua_version = 5
-	:let lua_subversion = 1
+The Lua syntax file can be used for versions 4.0, 5.0+. You can select one of
+these versions using the global variables |g:lua_version| and
+|g:lua_subversion|.
 
 
 MAIL						*mail.vim* *ft-mail.vim*

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -7625,6 +7625,9 @@ g:html_use_input_for_pc	syntax.txt	/*g:html_use_input_for_pc*
 g:html_use_xhtml	syntax.txt	/*g:html_use_xhtml*
 g:html_whole_filler	syntax.txt	/*g:html_whole_filler*
 g:lf_shell_syntax	syntax.txt	/*g:lf_shell_syntax*
+g:lua_folding	filetype.txt	/*g:lua_folding*
+g:lua_subversion	filetype.txt	/*g:lua_subversion*
+g:lua_version	filetype.txt	/*g:lua_version*
 g:markdown_fenced_languages	syntax.txt	/*g:markdown_fenced_languages*
 g:markdown_minlines	syntax.txt	/*g:markdown_minlines*
 g:markdown_syntax_conceal	syntax.txt	/*g:markdown_syntax_conceal*
@@ -8099,7 +8102,6 @@ help-context	help.txt	/*help-context*
 help-curwin	tips.txt	/*help-curwin*
 help-notation	helphelp.txt	/*help-notation*
 help-summary	usr_02.txt	/*help-summary*
-help-tags	tags	1
 help-toc-install	helphelp.txt	/*help-toc-install*
 help-translated	helphelp.txt	/*help-translated*
 help-writing	helphelp.txt	/*help-writing*

--- a/runtime/ftplugin/lua.vim
+++ b/runtime/ftplugin/lua.vim
@@ -32,7 +32,7 @@ let &l:include = '\v<((do|load)file|require)[^''"]*[''"]\zs[^''"]+'
 setlocal includeexpr=LuaInclude(v:fname)
 setlocal suffixesadd=.lua
 
-let b:undo_ftplugin = "setlocal cms< com< def< fo< inex< sua<"
+let b:undo_ftplugin = "setlocal cms< com< def< fo< inc< inex< sua<"
 
 if exists("loaded_matchit") && !exists("b:match_words")
   let b:match_ignorecase = 0

--- a/runtime/ftplugin/lua.vim
+++ b/runtime/ftplugin/lua.vim
@@ -5,7 +5,7 @@
 " Contributor:		Dorai Sitaram <ds26@gte.com>
 "			C.D. MacEachern <craig.daniel.maceachern@gmail.com>
 "			Tyler Miller <tmillr@proton.me>
-" Last Change:		18 Feb 2025
+" Last Change:		2025 Feb 18
 
 if exists("b:did_ftplugin")
   finish


### PR DESCRIPTION
Problem:
- `:h ft-lua-syntax` says the default `g:lua_subversion` is 2, but in fact it is 3 (see `runtime/syntax/lua.vim`)
- `gf` doesn't work in ft Lua

Solution:
- Fix doc
- Assign value to option `l:&include`
- Add function `LuaInclude()` and assign it to `l:&includeexpr`