### PR TITLE
Add a way to convert a blob to a list of strings without encoding

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -1311,8 +1311,11 @@ blob2str({blob} [, {options}])				*blob2str()*
 				encoding.  The value is a |String|.  See
 				|encoding-names| for the supported values.
 							*E1515*
-		An error is given and an empty List is returned if
-		an invalid byte sequence is encountered in {blob},
+		When current 'encoding' is "utf-8", an error is given and an
+		empty List is returned if an invalid byte sequence is
+		encountered in {blob}.  To suppress this validation and get
+		potentially invalid string, set "encoding" in {options} to
+		"none".
 
 		Returns an empty List if blob is empty.
 
@@ -10640,12 +10643,10 @@ str2blob({list} [, {options}])					*str2blob()*
 		newline character in the string is translated into a <NUL>
 		byte in the blob.
 
-		If {options} is not supplied, the current 'encoding' value is
-		used to convert the characters into bytes.
-
 		The argument {options} is a |Dict| and supports the following
 		items:
-		    encoding	Encode the characters using this encoding.
+		    encoding	Convert the characters using this encoding
+				before making the Blob.
 				The value is a |String|.  See |encoding-names|
 				for the supported values.
 

--- a/src/strings.c
+++ b/src/strings.c
@@ -1289,7 +1289,7 @@ f_blob2str(typval_T *argvars, typval_T *rettv)
     blob_T	*blob;
     int		blen;
     long	idx;
-    int		utf8_inuse = FALSE;
+    int		validate_utf8 = FALSE;
 
     if (check_for_blob_arg(argvars, 0) == FAIL
 	    || check_for_opt_dict_arg(argvars, 1) == FAIL)
@@ -1316,7 +1316,14 @@ f_blob2str(typval_T *argvars, typval_T *rettv)
     }
 
     if (STRCMP(p_enc, "utf-8") == 0 || STRCMP(p_enc, "utf8") == 0)
-	utf8_inuse = TRUE;
+	validate_utf8 = TRUE;
+
+    if (from_encoding != NULL && STRCMP(from_encoding, "none") == 0)
+    {
+	validate_utf8 = FALSE;
+	vim_free(from_encoding);
+	from_encoding = NULL;
+    }
 
     idx = 0;
     while (idx < blen)
@@ -1340,7 +1347,7 @@ f_blob2str(typval_T *argvars, typval_T *rettv)
 	    }
 	}
 
-	if (utf8_inuse)
+	if (validate_utf8)
 	{
 	    if (!utf_valid_string(converted_str, NULL))
 	    {

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -4446,6 +4446,9 @@ func Test_blob2str()
     call assert_equal(['a'], blob2str(0z61, test_null_dict()))
     call assert_equal(['a'], blob2str(0z61, {'encoding': test_null_string()}))
 
+    call assert_equal(["\x80"], blob2str(0z80, {'encoding': 'none'}))
+    call assert_equal(['a', "\x80"], blob2str(0z610A80, {'encoding': 'none'}))
+
     #" Invalid encoding
     call assert_fails("call blob2str(0z80)", "E1515: Unable to convert from 'utf-8' encoding")
     call assert_fails("call blob2str(0z610A80)", "E1515: Unable to convert from 'utf-8' encoding")


### PR DESCRIPTION
`blob2str()` can't convert a blob that is not valid as UTF-8, so I enabled that with `blob2str(blob, #{encoding: 'none'})`.
It is useful to make a binary buffer from a blob.

Also, the documentation for `blob2str()` / `str2blob()` was misleading for some use cases, so I made it more clear.

note:
`str2blob()` without options does not "encode" characters before making a blob. It simply doesn't care about encoding.
```
echo str2blob(["\xff"])
" => 0zFF
```