### PR TITLE
feat: add commentstring '> %s' for ftplugin mail

### DIFF
--- a/runtime/ftplugin/mail.vim
+++ b/runtime/ftplugin/mail.vim
@@ -24,6 +24,9 @@ endif
 " Set 'formatoptions' to break text lines and keep the comment leader ">".
 setlocal fo+=tcql
 
+" Set commentstring to quoting sign ">" so comment shortcuts can be used to
+" edit quoted parts of mail
+setlocal commentstring=>\ %s
 " Add n:> to 'comments, in case it was removed elsewhere
 setlocal comments+=n:>
 


### PR DESCRIPTION
Problem: The new native commenting functionality is currently not used when editing mail. One could reasonably expect it to change the "quote" state of any given line in the mail (i.e. the preceding ">"), which would be very handy and feel natural when editing mail. Especially since the current file already uses "setlocal comments+=n:>".

Solution: Add commentstring to `> %s` to be used in files of type mail.


This is similar to the feature at the end of the file, but I think would feel very intuitive for most users by providing an experience more consistent with the usual behavior of comments.

(I am very new to this, I tried to adhere to the contribution guidelines as best as I could, sorry if I overlooked something)