### PR TITLE
fix: update compl_enter_selects when have selected item

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -2109,7 +2109,7 @@ ins_compl_new_leader(void)
 	compl_restarting = FALSE;
     }
 
-    compl_enter_selects = !compl_used_match;
+    compl_enter_selects = !compl_used_match && compl_selected_item != -1;
 
     // Show the popup menu with a different set of matches.
     ins_compl_show_pum();
@@ -2580,10 +2580,6 @@ ins_compl_prep(int c)
 {
     int		retval = FALSE;
     int		prev_mode = ctrl_x_mode;
-    int		handle_enter = FALSE;
-
-    if ((c == CAR || c == NL || c == K_KENTER) && compl_selected_item == -1)
-	handle_enter = TRUE;
 
     // Forget any previous 'special' messages if this is actually
     // a ^X mode key - bar ^R, in which case we wait to see what it gives us.
@@ -2681,14 +2677,7 @@ ins_compl_prep(int c)
 	if ((ctrl_x_mode_normal() && c != Ctrl_N && c != Ctrl_P
 				       && c != Ctrl_R && !ins_compl_pum_key(c))
 		|| ctrl_x_mode == CTRL_X_FINISHED)
-	{
 	    retval = ins_compl_stop(c, prev_mode, retval);
-	    // When it is the Enter key and no selected item, return false, and
-	    // continue processing the Enter key to insert a new line in the
-	    // edit function.
-	    if (retval && handle_enter)
-		retval = FALSE;
-	}
     }
     else if (ctrl_x_mode == CTRL_X_LOCAL_MSG)
 	// Trigger the CompleteDone event to give scripts a chance to act

--- a/src/testdir/test_edit.vim
+++ b/src/testdir/test_edit.vim
@@ -594,7 +594,7 @@ func Test_edit_CTRL_I()
   call assert_equal([include, 'two', ''], getline(1, '$'))
   call feedkeys("2ggC\<c-x>\<tab>\<down>\<down>\<cr>\<esc>", 'tnix')
   call assert_equal([include, 'three', ''], getline(1, '$'))
-  call feedkeys("2ggC\<c-x>\<tab>\<down>\<down>\<down>\<C-y>\<esc>", 'tnix')
+  call feedkeys("2ggC\<c-x>\<tab>\<down>\<down>\<down>\<cr>\<esc>", 'tnix')
   call assert_equal([include, '', ''], getline(1, '$'))
   bw!
 endfunc
@@ -622,7 +622,7 @@ func Test_edit_CTRL_K()
   %d
   call setline(1, 'A')
   call cursor(1, 1)
-  call feedkeys("A\<c-x>\<c-k>\<down>\<down>\<down>\<C-Y>\<esc>", 'tnix')
+  call feedkeys("A\<c-x>\<c-k>\<down>\<down>\<down>\<cr>\<esc>", 'tnix')
   call assert_equal(['A'], getline(1, '$'))
   %d
   call setline(1, 'A')


### PR DESCRIPTION
Problem: patch 9.1.1121 used a wrong way to handle enter

Solution: comple_enter_selects also need consider selected item in ins_compl_new_leader