### PR TITLE
fix: wrong cur update whe noselect and fuzzy set in cot

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -1368,7 +1368,7 @@ ins_compl_build_pum(void)
 			compl_shown_match = compl;
 		}
 
-		if (!shown_match_ok && compl == compl_shown_match && !compl_no_select)
+		if (!shown_match_ok && compl == compl_shown_match)
 		{
 		    cur = i;
 		    shown_match_ok = TRUE;

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -2891,6 +2891,14 @@ func Test_complete_fuzzy_match()
   call assert_equal("for", g:abbr)
   call assert_equal(2, g:selected)
 
+  set cot=menu,menuone,noselect,fuzzy
+  call feedkeys("i\<C-R>=CompAnother()\<CR>\<C-N>\<C-N>\<C-N>\<C-N>", 'tx')
+  call assert_equal("foo", g:word)
+  call feedkeys("i\<C-R>=CompAnother()\<CR>\<C-P>", 'tx')
+  call assert_equal("foo", g:word)
+  call feedkeys("i\<C-R>=CompAnother()\<CR>\<C-P>\<C-P>", 'tx')
+  call assert_equal("for", g:abbr)
+
   " clean up
   set omnifunc=
   bw!


### PR DESCRIPTION
Problem: when fuzzy and noselect both set in completeopt can not update item correctly when repeatedly move

Solution: remove unnecessary compl_no_select check

Fix #16641