### PR TITLE
No test for 'listchars' "precedes" with double-width char

### DIFF
--- a/src/drawline.c
+++ b/src/drawline.c
@@ -3718,7 +3718,7 @@ win_line(
 #endif
 	// Handle the case where we are in column 0 but not on the first
 	// character of the line and the user wants us to show us a
-	// special character (via 'listchars' option "precedes:<char>".
+	// special character (via 'listchars' option "precedes:<char>").
 	if (lcs_prec_todo != NUL
 		&& wp->w_p_list
 		&& (wp->w_p_wrap ? (wp->w_skipcol > 0 && wlv.row == 0)

--- a/src/testdir/test_listchars.vim
+++ b/src/testdir/test_listchars.vim
@@ -671,5 +671,34 @@ func Test_listchars_foldcolumn()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_listchars_precedes_with_wide_char()
+  new
+  setlocal nowrap list listchars=eol:$,precedes:!
+  call setline(1, '123口456')
+  call assert_equal(['123口456$ '], ScreenLines(1, 10))
+  let attr = screenattr(1, 9)
+  normal! zl
+  call assert_equal(['!3口456$  '], ScreenLines(1, 10))
+  call assert_equal(attr, screenattr(1, 1))
+  normal! zl
+  call assert_equal(['!口456$   '], ScreenLines(1, 10))
+  call assert_equal(attr, screenattr(1, 1))
+  normal! zl
+  call assert_equal(['!<456$    '], ScreenLines(1, 10))
+  call assert_equal(attr, screenattr(1, 1))
+  call assert_equal(attr, screenattr(1, 2))
+  normal! zl
+  " TODO: should it be '!' instead of '<' here?
+  call assert_equal(['<456$     '], ScreenLines(1, 10))
+  call assert_equal(attr, screenattr(1, 1))
+  normal! zl
+  call assert_equal(['!56$      '], ScreenLines(1, 10))
+  call assert_equal(attr, screenattr(1, 1))
+  normal! zl
+  call assert_equal(['!6$       '], ScreenLines(1, 10))
+  call assert_equal(attr, screenattr(1, 1))
+
+  bw!
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  No test for 'listchars' "precedes" with double-width char.
Solution: Add a test and fix a typo in code.
