### PR TITLE
runtime:vim: make K / &keywordprg smarter

### DIFF
--- a/runtime/ftplugin/vim.vim
+++ b/runtime/ftplugin/vim.vim
@@ -49,19 +49,26 @@ setlocal isk+=#
 
 " Use :help to lookup the keyword under the cursor with K.
 " Distinguish between commands, options and functions.
-function! s:Help(args)
-  silent! let syn_name = synIDattr(synID(line('.'), col('.'), 1), 'name')
+if !exists("*" .. expand("<SID>") .. "Help")
+  function! s:Help(args) abort
+    if !g:syntax_on
+      execute 'help' a:args
+      return
+    endif
 
-  if syn_name =~# 'vimCommand'
-    execute 'help' a:args..':'
-  elseif syn_name =~# 'vimOption'
-    execute 'help' "'"..a:args.."'"
-  elseif syn_name =~# 'vimFunc'
-    execute 'help' a:args..'()'
-  else
-    execute 'help' a:args
-  endif
-endfunction
+    silent! let syn_name = synIDattr(synID(line('.'), col('.'), 1), 'name')
+
+    if syn_name =~# 'vimCommand'
+      execute "help :"..a:args
+    elseif syn_name =~# 'vimOption'
+      execute "help '"..a:args.."'"
+    elseif syn_name =~# 'vimFunc'
+      execute "help "..a:args.."()"
+    else
+      execute "help" a:args
+    endif
+  endfunction
+endif
 command! -buffer -nargs=1 VimKeywordPrg :call s:Help(<q-args>)
 setlocal keywordprg=:VimKeywordPrg
 

--- a/runtime/ftplugin/vim.vim
+++ b/runtime/ftplugin/vim.vim
@@ -18,7 +18,7 @@ set cpo&vim
 
 if !exists('*VimFtpluginUndo')
   func VimFtpluginUndo()
-    setl fo< isk< com< tw< commentstring< include< define<
+    setl fo< isk< com< tw< commentstring< include< define< keywordprg<
     if exists('b:did_add_maps')
       silent! nunmap <buffer> [[
       silent! vunmap <buffer> [[
@@ -48,7 +48,22 @@ setlocal fo-=t fo+=croql
 setlocal isk+=#
 
 " Use :help to lookup the keyword under the cursor with K.
-setlocal keywordprg=:help
+" Distinguish between commands, options and functions.
+function! s:Help(args)
+  silent! let syn_name = synIDattr(synID(line('.'), col('.'), 1), 'name')
+
+  if syn_name =~# 'vimCommand'
+    execute 'help' a:args..':'
+  elseif syn_name =~# 'vimOption'
+    execute 'help' "'"..a:args.."'"
+  elseif syn_name =~# 'vimFunc'
+    execute 'help' a:args..'()'
+  else
+    execute 'help' a:args
+  endif
+endfunction
+command! -buffer -nargs=1 VimKeywordPrg :call s:Help(<q-args>)
+setlocal keywordprg=:VimKeywordPrg
 
 " Comments starts with # in Vim9 script.  We have to guess which one to use.
 if "\n" .. getline(1, 32)->join("\n") =~# '\n\s*vim9\%[script]\>'

--- a/runtime/ftplugin/vim.vim
+++ b/runtime/ftplugin/vim.vim
@@ -51,7 +51,7 @@ setlocal isk+=#
 " Use :help to lookup the keyword under the cursor with K.
 " Distinguish between commands, options and functions.
 if !exists("*" .. expand("<SID>") .. "Help")
-  function s:HelpTopic(topic) abort
+  function s:Help(topic) abort
     let topic = a:topic
 
     if get(g:, 'syntax_on', 0)
@@ -62,7 +62,7 @@ if !exists("*" .. expand("<SID>") .. "Help")
         return "'".topic."'"
       elseif syn ==# 'vimUserAttrbKey'
         return ':command-'.topic
-      elseif syn_name =~# 'vimCommand'
+      elseif syn =~# 'vimCommand'
         return ':'.topic
       endif
     endif
@@ -89,12 +89,8 @@ if !exists("*" .. expand("<SID>") .. "Help")
       return topic
     endif
   endfunction
-
-  function s:Help(args)
-    execute 'help' s:HelpTopic(a:args)
-  endfunction
 endif
-command! -buffer -nargs=1 VimKeywordPrg :call s:Help(<q-args>)
+command! -buffer -nargs=1 VimKeywordPrg :exe 'help' s:Help(<q-args>)
 setlocal keywordprg=:VimKeywordPrg
 
 " Comments starts with # in Vim9 script.  We have to guess which one to use.

--- a/runtime/ftplugin/vim.vim
+++ b/runtime/ftplugin/vim.vim
@@ -50,11 +50,8 @@ setlocal isk+=#
 " Use :help to lookup the keyword under the cursor with K.
 " Distinguish between commands, options and functions.
 if !exists("*" .. expand("<SID>") .. "Help")
-  function! s:Help(args) abort
-    if !g:syntax_on
-      execute 'help' a:args
-      return
-    endif
+  function s:Help(args) abort
+    if !g:syntax_on | execute "help" a:args | return | endif
 
     silent! let syn_name = synIDattr(synID(line('.'), col('.'), 1), 'name')
 

--- a/runtime/ftplugin/vim.vim
+++ b/runtime/ftplugin/vim.vim
@@ -144,15 +144,15 @@ if exists("loaded_matchit")
   "   func name
   " require a parenthesis following, then there can be an "endfunc".
   let b:match_words =
-        \ '\<\%(fu\%[nction]\|def\)!\=\s\+\S\+\s*(:\%(\%(^\||\)\s*\)\@<=\<retu\%[rn]\>:\%(\%(^\||\)\s*\)\@<=\<\%(endf\%[unction]\|enddef\)\>,' ..
-        \ '\<\%(wh\%[ile]\|for\)\>:\%(\%(^\||\)\s*\)\@<=\<brea\%[k]\>:\%(\%(^\||\)\s*\)\@<=\<con\%[tinue]\>:\%(\%(^\||\)\s*\)\@<=\<end\%(w\%[hile]\|fo\%[r]\)\>,' ..
-        \ '\<if\>:\%(\%(^\||\)\s*\)\@<=\<el\%[seif]\>:\%(\%(^\||\)\s*\)\@<=\<en\%[dif]\>,' ..
-        \ '{:},' ..
-        \ '\<try\>:\%(\%(^\||\)\s*\)\@<=\<cat\%[ch]\>:\%(\%(^\||\)\s*\)\@<=\<fina\%[lly]\>:\%(\%(^\||\)\s*\)\@<=\<endt\%[ry]\>,' ..
-        \ '\<aug\%[roup]\s\+\%(END\>\)\@!\S:\<aug\%[roup]\s\+END\>,' ..
-        \ '\<class\>:\<endclass\>,' ..
-        \ '\<interface\>:\<endinterface\>,' ..
-        \ '\<enum\>:\<endenum\>'
+	\ '\<\%(fu\%[nction]\|def\)!\=\s\+\S\+\s*(:\%(\%(^\||\)\s*\)\@<=\<retu\%[rn]\>:\%(\%(^\||\)\s*\)\@<=\<\%(endf\%[unction]\|enddef\)\>,' ..
+	\ '\<\%(wh\%[ile]\|for\)\>:\%(\%(^\||\)\s*\)\@<=\<brea\%[k]\>:\%(\%(^\||\)\s*\)\@<=\<con\%[tinue]\>:\%(\%(^\||\)\s*\)\@<=\<end\%(w\%[hile]\|fo\%[r]\)\>,' ..
+	\ '\<if\>:\%(\%(^\||\)\s*\)\@<=\<el\%[seif]\>:\%(\%(^\||\)\s*\)\@<=\<en\%[dif]\>,' ..
+	\ '{:},' ..
+	\ '\<try\>:\%(\%(^\||\)\s*\)\@<=\<cat\%[ch]\>:\%(\%(^\||\)\s*\)\@<=\<fina\%[lly]\>:\%(\%(^\||\)\s*\)\@<=\<endt\%[ry]\>,' ..
+	\ '\<aug\%[roup]\s\+\%(END\>\)\@!\S:\<aug\%[roup]\s\+END\>,' ..
+	\ '\<class\>:\<endclass\>,' ..
+	\ '\<interface\>:\<endinterface\>,' ..
+	\ '\<enum\>:\<endenum\>'
 
   " Ignore syntax region commands and settings, any 'en*' would clobber
   " if-endif.
@@ -160,11 +160,11 @@ if exists("loaded_matchit")
   " - au! FileType javascript syntax region foldBraces start=/{/ end=/}/ …
   " Also ignore here-doc and dictionary keys (vimVar).
   let b:match_skip = 'synIDattr(synID(line("."), col("."), 1), "name")
-        \ =~? "comment\\|string\\|vimSynReg\\|vimSet\\|vimLetHereDoc\\|vimVar"'
+	                  \ =~? "comment\\|string\\|vimSynReg\\|vimSet\\|vimLetHereDoc\\|vimVar"'
 endif
 
 let &cpo = s:cpo_save
 unlet s:cpo_save
 
 " removed this, because 'cpoptions' is a global option.
-" setlocal cpo+=M               " makes \%( match \)
+" setlocal cpo+=M		" makes \%( match \)

--- a/runtime/ftplugin/vim.vim
+++ b/runtime/ftplugin/vim.vim
@@ -21,17 +21,17 @@ if !exists('*VimFtpluginUndo')
     setl fo< isk< com< tw< commentstring< include< define< keywordprg<
     if exists('b:did_add_maps')
       silent! nunmap <buffer> [[
-      silent! vunmap <buffer> [[
+      silent! xunmap <buffer> [[
       silent! nunmap <buffer> ]]
-      silent! vunmap <buffer> ]]
+      silent! xunmap <buffer> ]]
       silent! nunmap <buffer> []
-      silent! vunmap <buffer> []
+      silent! xunmap <buffer> []
       silent! nunmap <buffer> ][
-      silent! vunmap <buffer> ][
+      silent! xunmap <buffer> ][
       silent! nunmap <buffer> ]"
-      silent! vunmap <buffer> ]"
+      silent! xunmap <buffer> ]"
       silent! nunmap <buffer> ["
-      silent! vunmap <buffer> ["
+      silent! xunmap <buffer> ["
     endif
     unlet! b:match_ignorecase b:match_words b:match_skip b:did_add_maps
   endfunc
@@ -99,19 +99,19 @@ if !exists("no_plugin_maps") && !exists("no_vim_maps")
 
   " Move around functions.
   nnoremap <silent><buffer> [[ m':call search('^\s*\(fu\%[nction]\\|\(export\s\+\)\?def\)\>', "bW")<CR>
-  vnoremap <silent><buffer> [[ m':<C-U>exe "normal! gv"<Bar>call search('^\s*\(fu\%[nction]\\|\(export\s\+\)\?def\)\>', "bW")<CR>
+  xnoremap <silent><buffer> [[ m':<C-U>exe "normal! gv"<Bar>call search('^\s*\(fu\%[nction]\\|\(export\s\+\)\?def\)\>', "bW")<CR>
   nnoremap <silent><buffer> ]] m':call search('^\s*\(fu\%[nction]\\|\(export\s\+\)\?def\)\>', "W")<CR>
-  vnoremap <silent><buffer> ]] m':<C-U>exe "normal! gv"<Bar>call search('^\s*\(fu\%[nction]\\|\(export\s\+\)\?def\)\>', "W")<CR>
+  xnoremap <silent><buffer> ]] m':<C-U>exe "normal! gv"<Bar>call search('^\s*\(fu\%[nction]\\|\(export\s\+\)\?def\)\>', "W")<CR>
   nnoremap <silent><buffer> [] m':call search('^\s*end\(f\%[unction]\\|\(export\s\+\)\?def\)\>', "bW")<CR>
-  vnoremap <silent><buffer> [] m':<C-U>exe "normal! gv"<Bar>call search('^\s*end\(f\%[unction]\\|\(export\s\+\)\?def\)\>', "bW")<CR>
+  xnoremap <silent><buffer> [] m':<C-U>exe "normal! gv"<Bar>call search('^\s*end\(f\%[unction]\\|\(export\s\+\)\?def\)\>', "bW")<CR>
   nnoremap <silent><buffer> ][ m':call search('^\s*end\(f\%[unction]\\|\(export\s\+\)\?def\)\>', "W")<CR>
-  vnoremap <silent><buffer> ][ m':<C-U>exe "normal! gv"<Bar>call search('^\s*end\(f\%[unction]\\|\(export\s\+\)\?def\)\>', "W")<CR>
+  xnoremap <silent><buffer> ][ m':<C-U>exe "normal! gv"<Bar>call search('^\s*end\(f\%[unction]\\|\(export\s\+\)\?def\)\>', "W")<CR>
 
   " Move around comments
   nnoremap <silent><buffer> ]" :call search('\%(^\s*".*\n\)\@<!\%(^\s*"\)', "W")<CR>
-  vnoremap <silent><buffer> ]" :<C-U>exe "normal! gv"<Bar>call search('\%(^\s*".*\n\)\@<!\%(^\s*"\)', "W")<CR>
+  xnoremap <silent><buffer> ]" :<C-U>exe "normal! gv"<Bar>call search('\%(^\s*".*\n\)\@<!\%(^\s*"\)', "W")<CR>
   nnoremap <silent><buffer> [" :call search('\%(^\s*".*\n\)\%(^\s*"\)\@!', "bW")<CR>
-  vnoremap <silent><buffer> [" :<C-U>exe "normal! gv"<Bar>call search('\%(^\s*".*\n\)\%(^\s*"\)\@!', "bW")<CR>
+  xnoremap <silent><buffer> [" :<C-U>exe "normal! gv"<Bar>call search('\%(^\s*".*\n\)\%(^\s*"\)\@!', "bW")<CR>
 endif
 
 " Let the matchit plugin know what items can be matched.

--- a/runtime/ftplugin/vim.vim
+++ b/runtime/ftplugin/vim.vim
@@ -3,7 +3,8 @@
 " Maintainer:           Doug Kearns <dougkearns@gmail.com>
 " Last Change:          2025 Jan 06
 " Former Maintainer:    Bram Moolenaar <Bram@vim.org>
-" Contributors:         Riley Bruins <ribru17@gmail.com> ('commentstring')
+" Contributors:         Riley Bruins <ribru17@gmail.com> ('commentstring'),
+"                       @Konfekt, @tpope ('keywordprg')
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin")
@@ -55,7 +56,7 @@ if !exists("*" .. expand("<SID>") .. "Help")
     let topic = a:topic
 
     if get(g:, 'syntax_on', 0)
-      silent! let syn = synIDattr(synID(line('.'), col('.'), 1), 'name')
+      let syn = synIDattr(synID(line('.'), col('.'), 1), 'name')
       if syn ==# 'vimFuncName'
         return topic.'()'
       elseif syn ==# 'vimOption'

--- a/runtime/ftplugin/vim.vim
+++ b/runtime/ftplugin/vim.vim
@@ -1,9 +1,9 @@
 " Vim filetype plugin
-" Language:		Vim
-" Maintainer:		Doug Kearns <dougkearns@gmail.com>
-" Last Change:		2025 Jan 06
-" Former Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Contributors:		Riley Bruins <ribru17@gmail.com> ('commentstring')
+" Language:             Vim
+" Maintainer:           Doug Kearns <dougkearns@gmail.com>
+" Last Change:          2025 Jan 06
+" Former Maintainer:    Bram Moolenaar <Bram@vim.org>
+" Contributors:         Riley Bruins <ribru17@gmail.com> ('commentstring')
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin")
@@ -62,6 +62,8 @@ if !exists("*" .. expand("<SID>") .. "Help")
         return "'".topic."'"
       elseif syn ==# 'vimUserAttrbKey'
         return ':command-'.topic
+      elseif syn_name =~# 'vimCommand'
+        return ':'.topic
       endif
     endif
 
@@ -146,15 +148,15 @@ if exists("loaded_matchit")
   "   func name
   " require a parenthesis following, then there can be an "endfunc".
   let b:match_words =
-	\ '\<\%(fu\%[nction]\|def\)!\=\s\+\S\+\s*(:\%(\%(^\||\)\s*\)\@<=\<retu\%[rn]\>:\%(\%(^\||\)\s*\)\@<=\<\%(endf\%[unction]\|enddef\)\>,' ..
-	\ '\<\%(wh\%[ile]\|for\)\>:\%(\%(^\||\)\s*\)\@<=\<brea\%[k]\>:\%(\%(^\||\)\s*\)\@<=\<con\%[tinue]\>:\%(\%(^\||\)\s*\)\@<=\<end\%(w\%[hile]\|fo\%[r]\)\>,' ..
-	\ '\<if\>:\%(\%(^\||\)\s*\)\@<=\<el\%[seif]\>:\%(\%(^\||\)\s*\)\@<=\<en\%[dif]\>,' ..
-	\ '{:},' ..
-	\ '\<try\>:\%(\%(^\||\)\s*\)\@<=\<cat\%[ch]\>:\%(\%(^\||\)\s*\)\@<=\<fina\%[lly]\>:\%(\%(^\||\)\s*\)\@<=\<endt\%[ry]\>,' ..
-	\ '\<aug\%[roup]\s\+\%(END\>\)\@!\S:\<aug\%[roup]\s\+END\>,' ..
-	\ '\<class\>:\<endclass\>,' ..
-	\ '\<interface\>:\<endinterface\>,' ..
-	\ '\<enum\>:\<endenum\>'
+        \ '\<\%(fu\%[nction]\|def\)!\=\s\+\S\+\s*(:\%(\%(^\||\)\s*\)\@<=\<retu\%[rn]\>:\%(\%(^\||\)\s*\)\@<=\<\%(endf\%[unction]\|enddef\)\>,' ..
+        \ '\<\%(wh\%[ile]\|for\)\>:\%(\%(^\||\)\s*\)\@<=\<brea\%[k]\>:\%(\%(^\||\)\s*\)\@<=\<con\%[tinue]\>:\%(\%(^\||\)\s*\)\@<=\<end\%(w\%[hile]\|fo\%[r]\)\>,' ..
+        \ '\<if\>:\%(\%(^\||\)\s*\)\@<=\<el\%[seif]\>:\%(\%(^\||\)\s*\)\@<=\<en\%[dif]\>,' ..
+        \ '{:},' ..
+        \ '\<try\>:\%(\%(^\||\)\s*\)\@<=\<cat\%[ch]\>:\%(\%(^\||\)\s*\)\@<=\<fina\%[lly]\>:\%(\%(^\||\)\s*\)\@<=\<endt\%[ry]\>,' ..
+        \ '\<aug\%[roup]\s\+\%(END\>\)\@!\S:\<aug\%[roup]\s\+END\>,' ..
+        \ '\<class\>:\<endclass\>,' ..
+        \ '\<interface\>:\<endinterface\>,' ..
+        \ '\<enum\>:\<endenum\>'
 
   " Ignore syntax region commands and settings, any 'en*' would clobber
   " if-endif.
@@ -162,11 +164,11 @@ if exists("loaded_matchit")
   " - au! FileType javascript syntax region foldBraces start=/{/ end=/}/ …
   " Also ignore here-doc and dictionary keys (vimVar).
   let b:match_skip = 'synIDattr(synID(line("."), col("."), 1), "name")
-	\ =~? "comment\\|string\\|vimSynReg\\|vimSet\\|vimLetHereDoc\\|vimVar"'
+        \ =~? "comment\\|string\\|vimSynReg\\|vimSet\\|vimLetHereDoc\\|vimVar"'
 endif
 
 let &cpo = s:cpo_save
 unlet s:cpo_save
 
 " removed this, because 'cpoptions' is a global option.
-" setlocal cpo+=M		" makes \%( match \)
+" setlocal cpo+=M               " makes \%( match \)

--- a/runtime/ftplugin/vim.vim
+++ b/runtime/ftplugin/vim.vim
@@ -19,6 +19,7 @@ set cpo&vim
 if !exists('*VimFtpluginUndo')
   func VimFtpluginUndo()
     setl fo< isk< com< tw< commentstring< include< define< keywordprg<
+    sil! delc -buffer VimKeywordPrg
     if exists('b:did_add_maps')
       silent! nunmap <buffer> [[
       silent! xunmap <buffer> [[
@@ -51,7 +52,7 @@ setlocal isk+=#
 " Distinguish between commands, options and functions.
 if !exists("*" .. expand("<SID>") .. "Help")
   function s:Help(args) abort
-    if !g:syntax_on | execute "help" a:args | return | endif
+    if !get(g:, 'syntax_on', 0) | execute "help" a:args | return | endif
 
     silent! let syn_name = synIDattr(synID(line('.'), col('.'), 1), 'name')
 


### PR DESCRIPTION
Let keywordprg in vim.vim to handle context-sensitive help calls. Detect the syntax group of the word under the cursor.

See https://github.com/vim/vim/issues/16677
