### PR TITLE
runtime(dosini): Add support for # comments

### DIFF
--- a/runtime/ftplugin/dosini.vim
+++ b/runtime/ftplugin/dosini.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin file
 " Language:             Configuration File (ini file) for MS-DOS/MS Windows
 " Previous Maintainer:  Nikolai Weibull <now@bitwi.se>
-" Latest Revision:      2008-07-09
+" Latest Revision:      2025-02-20
 
 if exists("b:did_ftplugin")
   finish
@@ -13,7 +13,7 @@ set cpo&vim
 
 let b:undo_ftplugin = "setl com< cms< fo<"
 
-setlocal comments=:; commentstring=;\ %s formatoptions-=t formatoptions+=croql
+setlocal comments=:;,:# commentstring=;\ %s formatoptions-=t formatoptions+=croql
 
 let &cpo = s:cpo_save
 unlet s:cpo_save


### PR DESCRIPTION
runtime/syntax/dosini.vim supports both ; and # as comments, and I think a bunch of the files detected as dosini do too, so add support for # to the ftplugin.