### PR TITLE
filetype: Detect Guile's init file as scheme

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -2347,8 +2347,8 @@ au BufNewFile,BufRead *.zsh,*.zsh-theme,*.zunit		setf zsh
 " Salt state files
 au BufNewFile,BufRead *.sls			setf salt
 
-" Scheme, Supertux configuration, Lips.js history ("racket" patterns are now separate, see above)
-au BufNewFile,BufRead *.scm,*.ss,*.sld,*.stsg,*/supertux2/config,.lips_repl_history	setf scheme
+" Scheme, Supertux configuration, Lips.js history, Guile init file ("racket" patterns are now separate, see above)
+au BufNewFile,BufRead *.scm,*.ss,*.sld,*.stsg,*/supertux2/config,.lips_repl_history,.guile	setf scheme
 
 " Screen RC
 au BufNewFile,BufRead .screenrc,screenrc	setf screen

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -675,7 +675,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     sass: ['file.sass'],
     sbt: ['file.sbt'],
     scala: ['file.scala', 'file.mill'],
-    scheme: ['file.scm', 'file.ss', 'file.sld', 'file.stsg', 'any/local/share/supertux2/config', '.lips_repl_history'],
+    scheme: ['file.scm', 'file.ss', 'file.sld', 'file.stsg', 'any/local/share/supertux2/config', '.lips_repl_history', '.guile'],
     scilab: ['file.sci', 'file.sce'],
     screen: ['.screenrc', 'screenrc'],
     scss: ['file.scss'],


### PR DESCRIPTION
https://www.gnu.org/software/guile/manual/html_node/Init-File.html
> When run interactively, Guile will load a local initialization file
> from ~/.guile. This file should contain Scheme expressions for
> evaluation.