### PR TITLE
Some fixes/updates in search.c

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -5335,7 +5335,7 @@ search_for_fuzzy_match(
 		    {
 			if (ctrl_x_mode_normal())
 			{
-			    if (STRNCMP(*ptr, pattern, *len) == 0)
+			    if (STRNCMP(*ptr, pattern, *len) == 0 && pattern[*len] == NUL)
 			    {
 				char_u	*next_word_end = find_word_start(*ptr + *len);
 				if (*next_word_end != NUL && *next_word_end != NL)


### PR DESCRIPTION
In function update_search_stat():
add a check for a theoretical null pointer reference,
set and remember the length of lastpat,
remove the three calls to STRLEN() and use the various string's associated lengths instead,
add a check for an out-of-memory condition.

In function search_for_fuzz_match():
remove need to call strnsave() and thus avoid having to add a check for an out-of-memory condition,
replace the call to STRLEN() with ml_get_buf_len().
