### PR TITLE
perf: do not mark buffer text as changed for match highlight

### DIFF
--- a/src/drawscreen.c
+++ b/src/drawscreen.c
@@ -3365,9 +3365,21 @@ redrawWinline(
     win_T	*wp,
     linenr_T	lnum)
 {
-    if (wp->w_redraw_top == 0 || wp->w_redraw_top > lnum)
-	wp->w_redraw_top = lnum;
-    if (wp->w_redraw_bot == 0 || wp->w_redraw_bot < lnum)
-	wp->w_redraw_bot = lnum;
-    redraw_win_later(wp, UPD_VALID);
+    redraw_win_range_later(wp, lnum, lnum);
+}
+
+    void
+redraw_win_range_later(
+    win_T	*wp,
+    linenr_T	first,
+    linenr_T	last)
+{
+    if (last >= wp->w_topline && first < wp->w_botline)
+    {
+	if (wp->w_redraw_top == 0 || wp->w_redraw_top > first)
+	    wp->w_redraw_top = first;
+	if (wp->w_redraw_bot == 0 || wp->w_redraw_bot < last)
+	    wp->w_redraw_bot = last;
+	redraw_win_later(wp, UPD_VALID);
+    }
 }

--- a/src/fold.c
+++ b/src/fold.c
@@ -2384,12 +2384,7 @@ foldUpdateIEMS(win_T *wp, linenr_T top, linenr_T bot)
     // this in other situations, the changed lines will be redrawn anyway and
     // this method can cause the whole window to be updated.
     if (end != bot)
-    {
-	if (wp->w_redraw_top == 0 || wp->w_redraw_top > top)
-	    wp->w_redraw_top = top;
-	if (wp->w_redraw_bot < end)
-	    wp->w_redraw_bot = end;
-    }
+	redraw_win_range_later(wp, top, end);
 
     invalid_top = (linenr_T)0;
 }

--- a/src/match.c
+++ b/src/match.c
@@ -187,20 +187,7 @@ match_add(
 	// Calculate top and bottom lines for redrawing area
 	if (toplnum != 0)
 	{
-	    if (wp->w_buffer->b_mod_set)
-	    {
-		if (wp->w_buffer->b_mod_top > toplnum)
-		    wp->w_buffer->b_mod_top = toplnum;
-		if (wp->w_buffer->b_mod_bot < botlnum)
-		    wp->w_buffer->b_mod_bot = botlnum;
-	    }
-	    else
-	    {
-		wp->w_buffer->b_mod_set = TRUE;
-		wp->w_buffer->b_mod_top = toplnum;
-		wp->w_buffer->b_mod_bot = botlnum;
-		wp->w_buffer->b_mod_xlines = 0;
-	    }
+	    redraw_win_range_later(wp, toplnum, botlnum);
 	    m->mit_toplnum = toplnum;
 	    m->mit_botlnum = botlnum;
 	    rtype = UPD_VALID;
@@ -269,20 +256,7 @@ match_delete(win_T *wp, int id, int perr)
     vim_free(cur->mit_pattern);
     if (cur->mit_toplnum != 0)
     {
-	if (wp->w_buffer->b_mod_set)
-	{
-	    if (wp->w_buffer->b_mod_top > cur->mit_toplnum)
-		wp->w_buffer->b_mod_top = cur->mit_toplnum;
-	    if (wp->w_buffer->b_mod_bot < cur->mit_botlnum)
-		wp->w_buffer->b_mod_bot = cur->mit_botlnum;
-	}
-	else
-	{
-	    wp->w_buffer->b_mod_set = TRUE;
-	    wp->w_buffer->b_mod_top = cur->mit_toplnum;
-	    wp->w_buffer->b_mod_bot = cur->mit_botlnum;
-	    wp->w_buffer->b_mod_xlines = 0;
-	}
+	redraw_win_range_later(wp, cur->mit_toplnum, cur->mit_botlnum);
 	rtype = UPD_VALID;
     }
     vim_free(cur->mit_pos_array);

--- a/src/proto/drawscreen.pro
+++ b/src/proto/drawscreen.pro
@@ -24,4 +24,5 @@ void status_redraw_curbuf(void);
 void redraw_statuslines(void);
 void win_redraw_last_status(frame_T *frp);
 void redrawWinline(win_T *wp, linenr_T lnum);
+void redraw_win_range_later(win_T *wp, linenr_T first, linenr_T last);
 /* vim: set ft=c : */


### PR DESCRIPTION
Problem:  Match highlighting marks a region to be redrawn as if its
          buffer text was changed, unnecessarily invoking syntax code.
Solution: Set the `w_redraw_top/bot` variables instead.