### PR TITLE
'suffixesadd' doesn't work with multiple items

### DIFF
--- a/src/findfile.c
+++ b/src/findfile.c
@@ -1082,6 +1082,7 @@ vim_findfile(void *search_ctx_arg)
 			 * Try without extra suffix and then with suffixes
 			 * from 'suffixesadd'.
 			 */
+			len = file_path.length;
 			if (search_ctx->ffsc_tagfile)
 			    suf = (char_u *)"";
 			else
@@ -1164,8 +1165,8 @@ vim_findfile(void *search_ctx_arg)
 			    // Not found or found already, try next suffix.
 			    if (*suf == NUL)
 				break;
-			    file_path.length += copy_option_part(&suf, file_path.string + file_path.length,
-							 MAXPATHL - file_path.length, ",");
+			    file_path.length = len + copy_option_part(&suf,
+				  file_path.string + len, MAXPATHL - len, ",");
 			}
 		    }
 		}
@@ -1872,6 +1873,7 @@ find_file_in_path_option(
 	if (first == TRUE)
 	{
 	    int		l;
+	    int		NameBufflen;
 	    int		run;
 	    size_t	rel_fnamelen = 0;
 	    char_u	*suffix;
@@ -1912,6 +1914,7 @@ find_file_in_path_option(
 
 		// When the file doesn't exist, try adding parts of
 		// 'suffixesadd'.
+		NameBufflen = l;
 		suffix = suffixes;
 		for (;;)
 		{
@@ -1920,12 +1923,13 @@ find_file_in_path_option(
 				 || ((find_what == FINDFILE_DIR)
 						    == mch_isdir(NameBuff))))
 		    {
-			file_name = vim_strnsave(NameBuff, l);
+			file_name = vim_strnsave(NameBuff, NameBufflen);
 			goto theend;
 		    }
 		    if (*suffix == NUL)
 			break;
-		    l += copy_option_part(&suffix, NameBuff + l, MAXPATHL - l, ",");
+		    NameBufflen = l + copy_option_part(&suffix, NameBuff + l,
+							    MAXPATHL - l, ",");
 		}
 	    }
 	}

--- a/src/testdir/test_findfile.vim
+++ b/src/testdir/test_findfile.vim
@@ -222,6 +222,36 @@ func Test_finddir_error()
   call assert_fails('call finddir("x", repeat("x", 5000))', 'E854:')
 endfunc
 
+func Test_findfile_with_suffixesadd()
+  let save_path = &path
+  let save_dir = getcwd()
+  set path=,,
+  call mkdir('Xfinddir1', 'pR')
+  cd Xfinddir1
+
+  call writefile([], 'foo.c', 'D')
+  call writefile([], 'bar.cpp', 'D')
+  call writefile([], 'baz.cc', 'D')
+  call writefile([], 'foo.o', 'D')
+  call writefile([], 'bar.o', 'D')
+  call writefile([], 'baz.o', 'D')
+
+  set suffixesadd=.c,.cpp
+  call assert_equal('foo.c', findfile('foo'))
+  call assert_equal('./foo.c', findfile('./foo'))
+  call assert_equal('bar.cpp', findfile('bar'))
+  call assert_equal('./bar.cpp', findfile('./bar'))
+  call assert_equal('', findfile('baz'))
+  call assert_equal('', findfile('./baz'))
+  set suffixesadd+=.cc
+  call assert_equal('baz.cc', findfile('baz'))
+  call assert_equal('./baz.cc', findfile('./baz'))
+
+  set suffixesadd&
+  call chdir(save_dir)
+  let &path = save_path
+endfunc
+
 " Test for the :find, :sfind and :tabfind commands
 func Test_find_cmd()
   new

--- a/src/testdir/test_gf.vim
+++ b/src/testdir/test_gf.vim
@@ -353,4 +353,36 @@ func Test_gf_switchbuf()
   %bw!
 endfunc
 
+func Test_gf_with_suffixesadd()
+  let cwd = getcwd()
+  let dir = 'Xtestgf_sua_dir'
+  call mkdir(dir, 'R')
+  call chdir(dir)
+
+  call writefile([], 'foo.c', 'D')
+  call writefile([], 'bar.cpp', 'D')
+  call writefile([], 'baz.cc', 'D')
+  call writefile([], 'foo.o', 'D')
+  call writefile([], 'bar.o', 'D')
+  call writefile([], 'baz.o', 'D')
+
+  new
+  setlocal path=,, suffixesadd=.c,.cpp
+  call setline(1, ['./foo', './bar', './baz'])
+  exe "normal! gg\<C-W>f"
+  call assert_equal('foo.c', expand('%:t'))
+  close
+  exe "normal! 2gg\<C-W>f"
+  call assert_equal('bar.cpp', expand('%:t'))
+  close
+  call assert_fails('exe "normal! 3gg\<C-W>f"', 'E447:')
+  setlocal suffixesadd+=.cc
+  exe "normal! 3gg\<C-W>f"
+  call assert_equal('baz.cc', expand('%:t'))
+  close
+
+  %bwipe!
+  call chdir(cwd)
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  'suffixesadd' doesn't work with multiple items
          (after 9.1.1122).
Solution: Don't concat multiple suffixes together.

fixes: #16694
