### PR TITLE
Bugfix: Ensure 'info' window scrolls correctly during ins-completion

### DIFF
--- a/src/popupmenu.c
+++ b/src/popupmenu.c
@@ -1097,7 +1097,7 @@ pum_set_selected(int n, int repeat UNUSED)
 		    if (pum_selected != prev_selected)
 		    {
 # ifdef FEAT_PROP_POPUP
-			curwin->w_firstline = 1;
+			curwin->w_firstline = 0;
 # endif
 			curwin->w_topline = 1;
 		    }

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -497,6 +497,52 @@ func Test_completefunc_info()
   set completefunc&
 endfunc
 
+func ScrollInfoWindowUserDefinedFn(findstart, query)
+  " User defined function (i_CTRL-X_CTRL-U)
+  if a:findstart
+    return col('.')
+  endif
+  let infostr = range(20)->mapnew({_, v -> string(v)})->join("\n")
+  return [{'word': 'foo', 'info': infostr}, {'word': 'bar'}]
+endfunc
+
+func ScrollInfoWindowPageDown()
+  call win_execute(popup_findinfo(), "normal! \<PageDown>")
+  return ''
+endfunc
+
+func ScrollInfoWindowPageUp()
+  call win_execute(popup_findinfo(), "normal! \<PageUp>")
+  return ''
+endfunc
+
+func ScrollInfoWindowTest(mvmt, count, fline)
+  new
+  set completeopt=menuone,popup,noinsert,noselect
+  set completepopup=height:5
+  set completefunc=ScrollInfoWindowUserDefinedFn
+  let keyseq = "i\<C-X>\<C-U>\<C-N>"
+  for _ in range(a:count)
+    let keyseq .= (a:mvmt == "pageup" ? "\<C-R>\<C-R>=ScrollInfoWindowPageUp()\<CR>" :
+          \ "\<C-R>\<C-R>=ScrollInfoWindowPageDown()\<CR>")
+  endfor
+  let keyseq .= "\<C-R>\<C-R>=string(popup_getpos(popup_findinfo()))\<CR>\<ESC>"
+  call feedkeys(keyseq, "tx")
+  call assert_match('''firstline'': ' . a:fline, getline(1))
+  bwipe!
+  set completeopt&
+  set completepopup&
+  set completefunc&
+endfunc
+
+func Test_scroll_info_window()
+  call ScrollInfoWindowTest("", 0, 1)
+  call ScrollInfoWindowTest("pagedown", 1, 4)
+  call ScrollInfoWindowTest("pagedown", 2, 7)
+  call ScrollInfoWindowTest("pagedown", 3, 11)
+  call ScrollInfoWindowTest("pageup", 3, 1)
+endfunc
+
 func CompleteInfoUserDefinedFn(findstart, query)
   " User defined function (i_CTRL-X_CTRL-U)
   if a:findstart


### PR DESCRIPTION
The 'info' window, which appears during insert-mode completion to display additional information, was not scrolling properly when using commands like: `win_execute(popup_findinfo(), "normal! \<PageDown>")`. This issue made it impossible to navigate through info window contents using keyboard-based scrolling.

The fix correctly updates the w_firstline value of the popup window, ensuring proper scrolling behavior. Mouse scrolling was already working as expected and remains unaffected.

M  src/popupmenu.c
M  src/testdir/test_ins_complete.vim