### PR TITLE
runtime:compiler: add svelte-check

### DIFF
--- a/runtime/compiler/svelte-check.vim
+++ b/runtime/compiler/svelte-check.vim
@@ -4,10 +4,15 @@ let current_compiler = "svelte-check"
 let s:cpo_save = &cpo
 set cpo&vim
 
-CompilerSet makeprg=npx\ svelte-check
-CompilerSet errorformat=%E%f:%l:%c,
-CompilerSet errorformat+=%+ZError\:\ %m,
+CompilerSet makeprg=npx\ svelte-check\ --output\ machine
+CompilerSet errorformat=%*\\d\ %t%*\\a\ \"%f\"\ %l:%c\ %m
 CompilerSet errorformat+=%-G%.%#
+
+" " Fall-back for versions of svelte-check that don't support --output machine
+" CompilerSet makeprg=npx\ svelte-check
+" CompilerSet errorformat=%E%f:%l:%c,
+" CompilerSet errorformat+=%+ZError\:\ %m,
+" CompilerSet errorformat+=%-G%.%#
 
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/runtime/compiler/svelte-check.vim
+++ b/runtime/compiler/svelte-check.vim
@@ -1,0 +1,13 @@
+if exists("current_compiler") | finish | endif
+let current_compiler = "svelte-check"
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+CompilerSet makeprg=npx\ svelte-check
+CompilerSet errorformat=%E%f:%l:%c,
+CompilerSet errorformat+=%+ZError\:\ %m,
+CompilerSet errorformat+=%-G%.%#
+
+let &cpo = s:cpo_save
+unlet s:cpo_save

--- a/runtime/compiler/svelte-check.vim
+++ b/runtime/compiler/svelte-check.vim
@@ -1,18 +1,19 @@
+" Vim compiler file
+" Compiler:	svelte-check
+" Maintainer:	@Konfekt
+" Last Change:	2025 Feb 22
+
 if exists("current_compiler") | finish | endif
 let current_compiler = "svelte-check"
-
-let s:cpo_save = &cpo
-set cpo&vim
 
 CompilerSet makeprg=npx\ svelte-check\ --output\ machine
 CompilerSet errorformat=%*\\d\ %t%*\\a\ \"%f\"\ %l:%c\ %m
 CompilerSet errorformat+=%-G%.%#
 
 " " Fall-back for versions of svelte-check that don't support --output machine
+" " before  May 2020 https://github.com/sveltejs/language-tools/commit/9f7a90379d287a41621a5e78af5b010a8ab810c3
+" " which is before the first production release 1.1.31 of Svelte-Check
 " CompilerSet makeprg=npx\ svelte-check
 " CompilerSet errorformat=%E%f:%l:%c,
 " CompilerSet errorformat+=%+ZError\:\ %m,
 " CompilerSet errorformat+=%-G%.%#
-
-let &cpo = s:cpo_save
-unlet s:cpo_save


### PR DESCRIPTION
Just picks up the errors, but useful enough