### PR TITLE
[fifo] not displayed (after v7.4.2189)

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -275,6 +275,7 @@ open_buffer(
 	{
 	    curbuf->b_p_bin = save_bin;
 	    if (retval == OK)
+		// do not add READ_FIFO here, otherweise we won't be able to detect the encoding
 		retval = read_buffer(FALSE, eap, flags);
 	}
 #endif

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -366,15 +366,18 @@ readfile(
 	    goto theend;
 	}
     }
-
-    if (!read_stdin && !read_buffer && !read_fifo)
-    {
 #if defined(UNIX) || defined(VMS)
+    if (!read_stdin && fname != NULL)
 	/*
 	 * On Unix it is possible to read a directory, so we have to
 	 * check for it before the mch_open().
 	 */
 	perm = mch_getperm(fname);
+#endif
+
+    if (!read_stdin && !read_buffer && !read_fifo)
+    {
+#if defined(UNIX) || defined(VMS)
 	if (perm >= 0 && !S_ISREG(perm)		    // not a regular file ...
 		      && !S_ISFIFO(perm)	    // ... or fifo
 		      && !S_ISSOCK(perm)	    // ... or socket

--- a/src/testdir/test_startup_utf8.vim
+++ b/src/testdir/test_startup_utf8.vim
@@ -60,6 +60,33 @@ func Test_read_fifo_utf8()
   call delete('Xtestout')
 endfunc
 
+func Test_detect_fifo()
+  CheckUnix
+  " Using bash/zsh's process substitution.
+  if executable('bash')
+    set shell=bash
+  elseif executable('zsh')
+    set shell=zsh
+  else
+    throw 'Skipped: bash or zsh is required'
+  endif
+  let linesin = ['one', 'two']
+  call writefile(linesin, 'Xtestin_fifo', 'D')
+  let after = [
+	\ 'call writefile(split(execute(":mess"), "\\n"), "Xtestout")',
+	\ 'quit!',
+	\ ]
+  if RunVim([], after, '<(cat Xtestin_fifo)')
+    let lines = readfile('Xtestout')
+    call assert_match('\[fifo\]', lines[0])
+    call assert_match('\[fifo\]', lines[1])
+  else
+    call assert_equal('', 'RunVim failed.')
+  endif
+
+  call delete('Xtestout')
+endfunc
+
 func Test_detect_ambiwidth()
   CheckRunVimInTerminal
 


### PR DESCRIPTION
Problem:  [fifo] not displayed (after v7.4.2189)
Solution: stat the filename and detect the file type correctly

related: #16702