### PR TITLE
CI: Install netbeans on windows for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -678,6 +678,17 @@ jobs:
       #    name: vim${{ matrix.bits }}-${{ matrix.toolchain }}
       #    path: ./artifacts
 
+      - name: Install packages for testing
+        shell: bash
+        run: |
+          if ${{ matrix.features != 'TINY' }}; then
+            if ${{ matrix.arch == 'x86' }}; then
+              choco install netbeans --version=8.2.20171030 --no-progress --forcex86
+            else
+              choco install netbeans --no-progress
+            fi
+          fi
+
       - name: Test and show the result of testing gVim
         if: matrix.GUI == 'yes' || matrix.VIMDLL == 'yes'
         shell: cmd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -682,10 +682,10 @@ jobs:
         shell: bash
         run: |
           if ${{ matrix.features != 'TINY' }}; then
-            if ${{ matrix.arch == 'x86' }}; then
-              choco install netbeans --version=8.2.20171030 --no-progress --forcex86
-            else
+            if ${{ matrix.arch == 'x64' }}; then
               choco install netbeans --no-progress
+            else
+              exit 0
             fi
           fi
 


### PR DESCRIPTION
`src/testdir/test_netbeans.vim` needs this package to perform the test.
Netbeans is no longer available for x86, so it is only for x64.