### PR TITLE
Refactor ins_str() to remove call STRLEN()

### DIFF
--- a/src/change.c
+++ b/src/change.c
@@ -1178,10 +1178,9 @@ ins_char_bytes(char_u *buf, int charlen)
  * Caller must have prepared for undo.
  */
     void
-ins_str(char_u *s)
+ins_str(char_u *s, size_t slen)
 {
     char_u	*oldp, *newp;
-    int		newlen = (int)STRLEN(s);
     int		oldlen;
     colnr_T	col;
     linenr_T	lnum = curwin->w_cursor.lnum;
@@ -1193,16 +1192,16 @@ ins_str(char_u *s)
     oldp = ml_get(lnum);
     oldlen = (int)ml_get_len(lnum);
 
-    newp = alloc(oldlen + newlen + 1);
+    newp = alloc(oldlen + slen + 1);
     if (newp == NULL)
 	return;
     if (col > 0)
 	mch_memmove(newp, oldp, (size_t)col);
-    mch_memmove(newp + col, s, (size_t)newlen);
-    mch_memmove(newp + col + newlen, oldp + col, (size_t)(oldlen - col + 1));
+    mch_memmove(newp + col, s, slen);
+    mch_memmove(newp + col + slen, oldp + col, (size_t)(oldlen - col + 1));
     ml_replace(lnum, newp, FALSE);
-    inserted_bytes(lnum, col, newlen);
-    curwin->w_cursor.col += newlen;
+    inserted_bytes(lnum, col, slen);
+    curwin->w_cursor.col += slen;
 }
 
 /*

--- a/src/edit.c
+++ b/src/edit.c
@@ -2058,7 +2058,7 @@ insert_special(
 	    if (stop_arrow() == FAIL)
 		return;
 	    p[len - 1] = NUL;
-	    ins_str(p);
+	    ins_str(p, len - 1);
 	    AppendToRedobuffLit(p, -1);
 	    ctrlv = FALSE;
 	}
@@ -2275,7 +2275,7 @@ insertchar(
 	do_digraph(buf[i-1]);		// may be the start of a digraph
 #endif
 	buf[i] = NUL;
-	ins_str(buf);
+	ins_str(buf, i);
 	if (flags & INSCHAR_CTRLV)
 	{
 	    redo_literal(*buf);
@@ -4300,7 +4300,7 @@ ins_bs(
 		    ins_char(' ');
 		else
 		{
-		    ins_str((char_u *)" ");
+		    ins_str((char_u *)" ", 1);
 		    if ((State & REPLACE_FLAG))
 			replace_push(NUL);
 		}
@@ -4976,7 +4976,7 @@ ins_tab(void)
 	    ins_char(' ');
 	else
 	{
-	    ins_str((char_u *)" ");
+	    ins_str((char_u *)" ", 1);
 	    if (State & REPLACE_FLAG)	    // no char replaced
 		replace_push(NUL);
 	}

--- a/src/gui.c
+++ b/src/gui.c
@@ -5289,7 +5289,7 @@ gui_do_findrepl(
 
 		    del_bytes((long)(regmatch.endp[0] - regmatch.startp[0]),
 								FALSE, FALSE);
-		    ins_str(repl_text);
+		    ins_str(repl_text, STRLEN(repl_text));
 		}
 	    }
 	    else

--- a/src/indent.c
+++ b/src/indent.c
@@ -1429,11 +1429,13 @@ change_indent(
 	    ptr = alloc(i + 1);
 	    if (ptr != NULL)
 	    {
+		size_t ptrlen;
 		new_cursor_col += i;
 		ptr[i] = NUL;
+		ptrlen = i;
 		while (--i >= 0)
 		    ptr[i] = ' ';
-		ins_str(ptr);
+		ins_str(ptr, ptrlen);
 		vim_free(ptr);
 	    }
 	}

--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -4402,7 +4402,7 @@ ins_compl_delete(void)
     // In insert mode: Delete the typed part.
     // In replace mode: Put the old characters back, if any.
     int col = compl_col + (compl_status_adding() ? compl_length : 0);
-    char_u  *remaining = NULL;
+    string_T	remaining = {NULL, 0};
     int	    orig_col;
     int	has_preinsert = ins_compl_preinsert_effect();
     if (has_preinsert)
@@ -4415,18 +4415,18 @@ ins_compl_delete(void)
     {
 	if (curwin->w_cursor.col < ml_get_curline_len())
 	{
-	    char_u *line = ml_get_curline();
-	    remaining = vim_strnsave(line + curwin->w_cursor.col,
-				(size_t)STRLEN(line + curwin->w_cursor.col));
-	    if (remaining == NULL)
+	    char_u *line = ml_get_cursor();
+	    remaining.length = ml_get_cursor_len();
+	    remaining.string = vim_strnsave(line, remaining.length);
+	    if (remaining.string == NULL)
 		return;
 	}
 	while (curwin->w_cursor.lnum > compl_lnum)
 	{
 	    if (ml_delete(curwin->w_cursor.lnum) == FAIL)
 	    {
-		if (remaining)
-		    VIM_CLEAR(remaining);
+		if (remaining.string)
+		    vim_free(remaining.string);
 		return;
 	    }
 	    deleted_lines_mark(curwin->w_cursor.lnum, 1L);
@@ -4440,20 +4440,20 @@ ins_compl_delete(void)
     {
 	if (stop_arrow() == FAIL)
 	{
-	    if (remaining)
-		VIM_CLEAR(remaining);
+	    if (remaining.string)
+		vim_free(remaining.string);
 	    return;
 	}
 	backspace_until_column(col);
 	compl_ins_end_col = curwin->w_cursor.col;
     }
 
-    if (remaining != NULL)
+    if (remaining.string != NULL)
     {
 	orig_col = curwin->w_cursor.col;
-	ins_str(remaining);
+	ins_str(remaining.string, remaining.length);
 	curwin->w_cursor.col = orig_col;
-	vim_free(remaining);
+	vim_free(remaining.string);
     }
     // TODO: is this sufficient for redrawing?  Redrawing everything causes
     // flicker, thus we can't do that.

--- a/src/ops.c
+++ b/src/ops.c
@@ -3011,9 +3011,9 @@ do_addsub(
     else
     {
 	char_u	*buf1;
-	size_t	buf1len;
+	int	buf1len;
 	char_u	buf2[NUMBUFLEN];
-	size_t	buf2len;
+	int	buf2len;
 	pos_T	save_pos;
 	int	i;
 
@@ -3189,7 +3189,7 @@ do_addsub(
 	    buf2len = vim_snprintf((char *)buf2, NUMBUFLEN, "%llX", n);
 	else
 	    buf2len = vim_snprintf((char *)buf2, NUMBUFLEN, "%llx", n);
-	length -= (int)buf2len;
+	length -= buf2len;
 
 	/*
 	 * Adjust number of zeros to the new number of digits, so the
@@ -3201,7 +3201,7 @@ do_addsub(
 	    while (length-- > 0)
 		*ptr++ = '0';
 	*ptr = NUL;
-	buf1len = (size_t)(ptr - buf1);
+	buf1len = (int)(ptr - buf1);
 
 	STRCPY(buf1 + buf1len, buf2);
 	buf1len += buf2len;
@@ -3212,7 +3212,7 @@ do_addsub(
 	save_pos = curwin->w_cursor;
 	if (todel > 0)
 	    inc_cursor();
-	ins_str(buf1, buf1len);		// insert the new number
+	ins_str(buf1, (size_t)buf1len);		// insert the new number
 	vim_free(buf1);
 
 	// del_char() will also mark line needing displaying

--- a/src/ops.c
+++ b/src/ops.c
@@ -2796,8 +2796,6 @@ do_addsub(
     linenr_T	Prenum1)
 {
     int		col;
-    char_u	*buf1;
-    char_u	buf2[NUMBUFLEN];
     int		pre;		// 'X'/'x': hex; '0': octal; 'B'/'b': bin
     static int	hexupper = FALSE;	// 0xABC
     uvarnumber_T	n;
@@ -3012,6 +3010,10 @@ do_addsub(
     }
     else
     {
+	char_u	*buf1;
+	size_t	buf1len;
+	char_u	buf2[NUMBUFLEN];
+	size_t	buf2len;
 	pos_T	save_pos;
 	int	i;
 
@@ -3174,20 +3176,20 @@ do_addsub(
 	    for (bit = bits; bit > 0; bit--)
 		if ((n >> (bit - 1)) & 0x1) break;
 
-	    for (i = 0; bit > 0 && i < (NUMBUFLEN - 1); bit--)
-		buf2[i++] = ((n >> (bit - 1)) & 0x1) ? '1' : '0';
+	    for (buf2len = 0; bit > 0 && buf2len < (NUMBUFLEN - 1); bit--)
+		buf2[buf2len++] = ((n >> (bit - 1)) & 0x1) ? '1' : '0';
 
-	    buf2[i] = '\0';
+	    buf2[buf2len] = NUL;
 	}
 	else if (pre == 0)
-	    vim_snprintf((char *)buf2, NUMBUFLEN, "%llu", n);
+	    buf2len = vim_snprintf((char *)buf2, NUMBUFLEN, "%llu", n);
 	else if (pre == '0')
-	    vim_snprintf((char *)buf2, NUMBUFLEN, "%llo", n);
+	    buf2len = vim_snprintf((char *)buf2, NUMBUFLEN, "%llo", n);
 	else if (pre && hexupper)
-	    vim_snprintf((char *)buf2, NUMBUFLEN, "%llX", n);
+	    buf2len = vim_snprintf((char *)buf2, NUMBUFLEN, "%llX", n);
 	else
-	    vim_snprintf((char *)buf2, NUMBUFLEN, "%llx", n);
-	length -= (int)STRLEN(buf2);
+	    buf2len = vim_snprintf((char *)buf2, NUMBUFLEN, "%llx", n);
+	length -= (int)buf2len;
 
 	/*
 	 * Adjust number of zeros to the new number of digits, so the
@@ -3199,8 +3201,10 @@ do_addsub(
 	    while (length-- > 0)
 		*ptr++ = '0';
 	*ptr = NUL;
+	buf1len = (size_t)(ptr - buf1);
 
-	STRCAT(buf1, buf2);
+	STRCPY(buf1 + buf1len, buf2);
+	buf1len += buf2len;
 
 	// Insert just after the first character to be removed, so that any
 	// text properties will be adjusted.  Then delete the old number
@@ -3208,7 +3212,7 @@ do_addsub(
 	save_pos = curwin->w_cursor;
 	if (todel > 0)
 	    inc_cursor();
-	ins_str(buf1);		// insert the new number
+	ins_str(buf1, buf1len);		// insert the new number
 	vim_free(buf1);
 
 	// del_char() will also mark line needing displaying

--- a/src/proto/change.pro
+++ b/src/proto/change.pro
@@ -23,7 +23,7 @@ void ins_bytes(char_u *p);
 void ins_bytes_len(char_u *p, int len);
 void ins_char(int c);
 void ins_char_bytes(char_u *buf, int charlen);
-void ins_str(char_u *s);
+void ins_str(char_u *s, size_t slen);
 int del_char(int fixpos);
 int del_chars(long count, int fixpos);
 int del_bytes(long count, int fixpos_arg, int use_delcombine);

--- a/src/textformat.c
+++ b/src/textformat.c
@@ -434,7 +434,7 @@ internal_format(
 			// add the additional whitespace needed after the
 			// comment leader for the numbered list.
 			for (i = 0; i < padding; i++)
-			    ins_str((char_u *)" ");
+			    ins_str((char_u *)" ", 1);
 		    }
 		    else
 		    {


### PR DESCRIPTION
Change ins_str() to pass the length of the string to be inserted. Adjust all the call sites.

In my measurements running the test suite on a huge non-gui build on linux, ins_str() was called 6582 times. Given that ins_str() begins with a single call to STRLEN() to determine the length of it's string argument, we can say that STRLEN() was called 6582 times.

Refactoring each call site to pass the length of the string argument (where available) reduces the number of calls to STRLEN() to 0 for the same test suite.

Cheers
John