### PR TITLE
Add functions to retrieve inserted and recorded string lengths

### DIFF
--- a/src/edit.c
+++ b/src/edit.c
@@ -421,7 +421,7 @@ edit(
 	new_insert_skip = 0;
     else
     {
-	new_insert_skip = (int)STRLEN(ptr);
+	new_insert_skip = (int)get_inserted_len();
 	vim_free(ptr);
     }
 
@@ -2462,7 +2462,7 @@ stop_insert(
      * otherwise CTRL-O w and then <Left> will clear "last_insert".
      */
     ptr = get_inserted();
-    int added = ptr == NULL ? 0 : (int)STRLEN(ptr) - new_insert_skip;
+    int added = ptr == NULL ? 0 : (int)get_inserted_len() - new_insert_skip;
     if (did_restart_edit == 0 || added > 0)
     {
 	vim_free(last_insert);
@@ -2993,11 +2993,11 @@ get_last_insert_save(void)
 
     if (last_insert == NULL)
 	return NULL;
-    s = vim_strsave(last_insert + last_insert_skip);
+    len = (int)STRLEN(last_insert + last_insert_skip);
+    s = vim_strnsave(last_insert + last_insert_skip, len);
     if (s == NULL)
 	return NULL;
 
-    len = (int)STRLEN(s);
     if (len > 0 && s[len - 1] == ESC)	// remove trailing ESC
 	s[len - 1] = NUL;
     return s;

--- a/src/getchar.c
+++ b/src/getchar.c
@@ -194,7 +194,8 @@ get_recorded(void)
      * When stopping recording from Insert mode with CTRL-O q, also remove the
      * CTRL-O.
      */
-    if (last_get_recorded_len > 0 && restart_edit != 0 && p[last_get_recorded_len - 1] == Ctrl_O)
+    if (last_get_recorded_len > 0 && restart_edit != 0
+				    && p[last_get_recorded_len - 1] == Ctrl_O)
     {
 	--last_get_recorded_len;
 	p[last_get_recorded_len] = NUL;

--- a/src/getchar.c
+++ b/src/getchar.c
@@ -88,6 +88,11 @@ static char_u	noremapbuf_init[TYPELEN_INIT];	// initial typebuf.tb_noremap
 
 static size_t	last_recorded_len = 0;	// number of last recorded chars
 
+static size_t	last_get_recorded_len = 0;	// length of the string returned from the
+						// last call to get_recorded()
+static size_t	last_get_inserted_len = 0;	// length of the string returned from the
+						// last call to get_inserted()
+
 #ifdef FEAT_EVAL
 mapblock_T	*last_used_map = NULL;
 int		last_used_sid = -1;
@@ -168,29 +173,43 @@ get_buffcont(
 get_recorded(void)
 {
     char_u	*p;
-    size_t	len;
 
-    p = get_buffcont(&recordbuff, TRUE, &len);
+    p = get_buffcont(&recordbuff, TRUE, &last_get_recorded_len);
+    if (p == NULL)
+	return NULL;
+
     free_buff(&recordbuff);
 
     /*
      * Remove the characters that were added the last time, these must be the
      * (possibly mapped) characters that stopped the recording.
      */
-    if (len >= last_recorded_len)
+    if (last_get_recorded_len >= last_recorded_len)
     {
-	len -= last_recorded_len;
-	p[len] = NUL;
+	last_get_recorded_len -= last_recorded_len;
+	p[last_get_recorded_len] = NUL;
     }
 
     /*
      * When stopping recording from Insert mode with CTRL-O q, also remove the
      * CTRL-O.
      */
-    if (len > 0 && restart_edit != 0 && p[len - 1] == Ctrl_O)
-	p[len - 1] = NUL;
+    if (last_get_recorded_len > 0 && restart_edit != 0 && p[last_get_recorded_len - 1] == Ctrl_O)
+    {
+	--last_get_recorded_len;
+	p[last_get_recorded_len] = NUL;
+    }
 
     return (p);
+}
+
+/*
+ * Return the length of string returned from the last call of get_recorded().
+ */
+    size_t
+get_recorded_len(void)
+{
+    return last_get_recorded_len;
 }
 
 /*
@@ -200,7 +219,16 @@ get_recorded(void)
     char_u *
 get_inserted(void)
 {
-    return get_buffcont(&redobuff, FALSE, NULL);
+    return get_buffcont(&redobuff, FALSE, &last_get_inserted_len);
+}
+
+/*
+ * Return the length of string returned from the last call of get_inserted().
+ */
+    size_t
+get_inserted_len(void)
+{
+    return last_get_inserted_len;
 }
 
 /*

--- a/src/proto/getchar.pro
+++ b/src/proto/getchar.pro
@@ -1,6 +1,8 @@
 /* getchar.c */
 char_u *get_recorded(void);
+size_t get_recorded_len(void);
 char_u *get_inserted(void);
+size_t get_inserted_len(void);
 int stuff_empty(void);
 int readbuf1_empty(void);
 void typeahead_noflush(int c);

--- a/src/register.c
+++ b/src/register.c
@@ -28,7 +28,7 @@ static yankreg_T	*y_current;	    // ptr to current yankreg
 static int		y_append;	    // TRUE when appending
 static yankreg_T	*y_previous = NULL; // ptr to last written yankreg
 
-static int	stuff_yank(int, char_u *);
+static int	stuff_yank(int, char_u *, size_t);
 static void	put_reedit_in_typebuf(int silent);
 static int	put_in_typebuf(char_u *s, int esc, int colon, int silent);
 static int	yank_copy_line(struct block_def *bd, long y_idx, int exclude_trailing_space);
@@ -419,7 +419,7 @@ do_record(int c)
 	    old_y_previous = y_previous;
 	    old_y_current = y_current;
 
-	    retval = stuff_yank(regname, p);
+	    retval = stuff_yank(regname, p, get_recorded_len());
 
 	    y_previous = old_y_previous;
 	    y_current = old_y_current;
@@ -435,10 +435,8 @@ do_record(int c)
  * return FAIL for failure, OK otherwise
  */
     static int
-stuff_yank(int regname, char_u *p)
+stuff_yank(int regname, char_u *p, size_t plen)
 {
-    size_t	plen;
-
     // check for read-only register
     if (regname != 0 && !valid_yank_reg(regname, TRUE))
     {
@@ -451,7 +449,6 @@ stuff_yank(int regname, char_u *p)
 	return OK;
     }
 
-    plen = STRLEN(p);
     get_yank_register(regname, TRUE);
     if (y_append && y_current->y_array != NULL)
     {


### PR DESCRIPTION
Add new functions get_inserted_len() and get_recorded_len().

These return the length of the string returned from the most recent calls to get_inserted() and get_recorded() respectively.

In my measurements running the test suite on a huge non-gui build on linux, get_inserted() was called 7423 times. Given that each call to get_inserted() is followed with a call to STRLEN() on it's result, we can say that STRLEN() was called 7432 times. Using get_inserted_len() reduces the number of calls to 0.

The results for get_recorded() (and therefore get_recorded_len()) are similar but the numbers are smaller at 107 calls, but every bit helps.

Also, add a check for an out-of-memory condition in get_recorded().

Cheers
John