### PR TITLE
NSIS: added support for pt-BR and clarifications in README.txt

### DIFF
--- a/nsis/gvim.nsi
+++ b/nsis/gvim.nsi
@@ -1,6 +1,6 @@
 # NSIS file to create a self-installing exe for Vim.
 # It requires NSIS version 3.0 or later.
-# Last Change:	2025 Jan 05
+# Last Change:	2025 Feb 24
 
 Unicode true
 
@@ -806,7 +806,8 @@ Function .onInit
   ClearErrors
   System::Call 'kernel32::GetUserDefaultLocaleName(t.r19, *i${NSIS_MAX_STRLEN})'
   StrCmp $R9 "zh-cn" coincide 0
-  StrCmp $R9 "zh-tw" 0 part
+  StrCmp $R9 "zh-tw" coincide 0
+  StrCmp $R9 "pt-br" 0 part
   coincide:
   System::Call 'User32::CharLower(t r19 r19)*i${NSIS_MAX_STRLEN}'
   ${StrRep} $lng_usr "$R9" "-" "_"

--- a/nsis/lang/README.txt
+++ b/nsis/lang/README.txt
@@ -18,6 +18,13 @@ allowable length of strings.  For example:
  drop-down lists on the .vimrc page - 55 characters.
 Characters in this case mean characters of the English alphabet.
 
+Once the message translation file is ready, it must be included in the
+"gvim.nsi" file.
+Find the line "# Include support for other languages:" in the file "gvim.nsi"
+and specify the name of the file with your translation below the line
+!if ${HAVE_MULTI_LANG}, similar to the entries already there. File names are
+specified in alphabetical order.
+
 If you do not yet have a translated "LICENSE" file and/or a main "README.txt"
 file, set the following values:
 
@@ -32,3 +39,25 @@ variables similarly to what is done in the other translation files.
 Translation files should be located in the "lang" subdirectory of the root
 directory. The name of the files is as follows: "README.xx.txt", where xx is the
 language code according to ISO639.
+
+
+There are two ways to test the installer in different languages:
+
+1. Find and uncomment the "!define MUI_LANGDLL_ALWAYSSHOW" line in the
+   "gvim.nsi" file and rebuild the installer.
+   Now every time you run it, you will see a dialog box with the possibility to
+   select the language of the installer.
+
+2. If the Vim editor is already installed in your system, delete the
+   "Installer Language" parameter in the Windows registry under
+   "HKEY_CURRENT_USER\Software\Vim".
+   Or you can create a file "NoLangInstallerVim.reg" with the following content:
+
+	Windows Registry Editor Version 5.00
+
+	[HKEY_CURRENT_USER\Software\Vim]
+	"Installer Language"=-
+
+   and apply it by double-clicking on it.
+   After these steps, when you start the installer, a window with the installer
+   language selection will also be displayed. 


### PR DESCRIPTION
Added support for copying the README and LICENSE files for the pt-BR language to the Vim editor installation directory.

Clarifications in nsis\lang\README.txt for translators.

Related https://github.com/vim/vim/pull/16692