### PR TITLE
Fix :highlight auto-completing cterm colors to -1 when it's unset

### DIFF
--- a/src/highlight.c
+++ b/src/highlight.c
@@ -4531,14 +4531,17 @@ expand_highlight_group(
 
 	char_u	    buf[MAX_ATTR_LEN];
 
-	if (expand_hi_synid != 0 && type != 0 && expand_hi_include_orig)
+	expand_hi_curvalue = NULL;
+	if (expand_hi_include_orig)
 	{
-	    // Retrieve the current value to go first in completion
-	    expand_hi_curvalue = highlight_arg_to_string(
-		    type, iarg, sarg, buf);
+	    if (((type == LIST_ATTR || type == LIST_INT) && iarg != 0) ||
+		(type == LIST_STRING && sarg != NULL))
+	    {
+		// Retrieve the current value to go first in completion
+		expand_hi_curvalue = highlight_arg_to_string(
+			type, iarg, sarg, buf);
+	    }
 	}
-	else
-	    expand_hi_curvalue = NULL;
 
 	if (expandfunc != NULL)
 	{

--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -488,14 +488,22 @@ func Test_highlight_group_completion()
 
   " Test completing the current value
   hi FooBar term=bold,underline cterm=undercurl ctermfg=lightgray ctermbg=12 ctermul=34
+  hi AlmostEmpty term=bold
   call assert_equal('bold,underline', getcompletion('hi FooBar term=', 'cmdline')[0])
   call assert_equal('undercurl', getcompletion('hi FooBar cterm=', 'cmdline')[0])
   call assert_equal('7', getcompletion('hi FooBar ctermfg=', 'cmdline')[0])
   call assert_equal('12', getcompletion('hi FooBar ctermbg=', 'cmdline')[0])
   call assert_equal('34', getcompletion('hi FooBar ctermul=', 'cmdline')[0])
 
-  " "bold,underline" is unique and creates an extra item. "undercurl" and
-  " should be de-duplicated
+  " highlight group exists, but no value was set. Should not complete to
+  " existing value
+  call assert_equal('fg', getcompletion('hi AlmostEmpty ctermfg=', 'cmdline')[0])
+  call assert_equal('fg', getcompletion('hi AlmostEmpty ctermbg=', 'cmdline')[0])
+  call assert_equal('fg', getcompletion('hi AlmostEmpty ctermul=', 'cmdline')[0])
+  call assert_equal('bold', getcompletion('hi AlmostEmpty cterm=', 'cmdline')[0])
+
+  " "bold,underline" is unique and creates an extra item. "undercurl" isn't
+  " and should be de-duplicated.
   call assert_equal(len(getcompletion('hi FooBar term=', 'cmdline')),
         \ 1 + len(getcompletion('hi FooBar cterm=', 'cmdline')))
 
@@ -519,6 +527,13 @@ func Test_highlight_group_completion()
 
     " Check that existing value is de-duplicated and doesn't show up later
     call assert_equal(1, count(getcompletion('hi FooBar guibg=', 'cmdline'), 'brown1'))
+
+    " highlight group exists, but no value was set. Should not complete to
+    " existing value
+    call assert_equal('fg', getcompletion('hi AlmostEmpty guifg=', 'cmdline')[0])
+    call assert_equal('fg', getcompletion('hi AlmostEmpty guibg=', 'cmdline')[0])
+    call assert_equal('fg', getcompletion('hi AlmostEmpty guisp=', 'cmdline')[0])
+    call assert_equal('bold', getcompletion('hi AlmostEmpty gui=', 'cmdline')[0])
   endif
 
   " Test completing attributes


### PR DESCRIPTION
Problem: :highlight auto-complete has a minor bug where an existing highlight group with a cterm color being unset would result in it being auto-completed to -1 in cmdline which is invalid.

Solution: Correctly check for whether an int value is set to non-zero before retrieving the existing value for auto-complete. Also do this for attr/string values as they previously worked only by accident.

Related: #16712