### PR TITLE
make VimKeywordPrg even smarter for regexes

### DIFF
--- a/runtime/ftplugin/vim.vim
+++ b/runtime/ftplugin/vim.vim
@@ -86,7 +86,7 @@ if !exists("*" .. expand("<SID>") .. "Help")
     elseif pre =~# '\<v:$'
       return 'v:'.topic
     elseif pre =~# '\\$'
-      return '\'.topic
+      return '/\'.topic
     elseif topic ==# 'v' && post =~# ':\w\+'
       return 'v'.matchstr(post, ':\w\+')
     else

--- a/runtime/ftplugin/vim.vim
+++ b/runtime/ftplugin/vim.vim
@@ -85,6 +85,8 @@ if !exists("*" .. expand("<SID>") .. "Help")
       return ':'.topic
     elseif pre =~# '\<v:$'
       return 'v:'.topic
+    elseif pre =~# '\\$'
+      return '\'.topic
     elseif topic ==# 'v' && post =~# ':\w\+'
       return 'v'.matchstr(post, ':\w\+')
     else


### PR DESCRIPTION
Now with the cursor on`\V` it jumps to `:help \V` instead of `:help V`; it is a best guess as of course, like the other checks, it could for example be part of normal mode command sequence; pinging @dkearns