### PR TITLE
Fix: command expansion not displaying for input() function

### DIFF
--- a/src/cmdexpand.c
+++ b/src/cmdexpand.c
@@ -2723,6 +2723,8 @@ set_cmd_context(
 	xp->xp_context = ccline->xp_context;
 	xp->xp_pattern = ccline->cmdbuff;
 	xp->xp_arg = ccline->xp_arg;
+	while (nextcomm != NULL)
+		nextcomm = set_one_cmd_context(xp, nextcomm);
     }
     else
 #endif

--- a/src/cmdexpand.c
+++ b/src/cmdexpand.c
@@ -2731,8 +2731,8 @@ set_cmd_context(
 	xp->xp_context = ccline->xp_context;
 	xp->xp_pattern = ccline->cmdbuff;
 	xp->xp_arg = ccline->xp_arg;
-	}
-	else
+    }
+    else
 #endif
 	while (nextcomm != NULL)
 	    nextcomm = set_one_cmd_context(xp, nextcomm);

--- a/src/cmdexpand.c
+++ b/src/cmdexpand.c
@@ -232,15 +232,15 @@ nextwild(
 #ifdef FEAT_EVAL
     if (ccline->input_fn && ccline->xp_context == EXPAND_COMMANDS)
     {
-    // Expand commands in input() function
+    // Expand commands typed in input() function
     set_cmd_context(xp, ccline->cmdbuff, ccline->cmdlen, ccline->cmdpos, FALSE);
     }
     else
 #endif
     {
     set_expand_context(xp);
-    cmd_showtail = expand_showtail(xp);
     }
+    cmd_showtail = expand_showtail(xp);
     }
 
     if (xp->xp_context == EXPAND_UNSUCCESSFUL)

--- a/src/cmdexpand.c
+++ b/src/cmdexpand.c
@@ -230,17 +230,17 @@ nextwild(
     if (xp->xp_numfiles == -1)
     {
 #ifdef FEAT_EVAL
-    if (ccline->input_fn && ccline->xp_context == EXPAND_COMMANDS)
-    {
-    // Expand commands typed in input() function
-    set_cmd_context(xp, ccline->cmdbuff, ccline->cmdlen, ccline->cmdpos, FALSE);
-    }
-    else
+        if (ccline->input_fn && ccline->xp_context == EXPAND_COMMANDS)
+        {
+        // Expand commands typed in input() function
+        set_cmd_context(xp, ccline->cmdbuff, ccline->cmdlen, ccline->cmdpos, FALSE);
+        }
+        else
 #endif
-    {
-    set_expand_context(xp);
-    }
-    cmd_showtail = expand_showtail(xp);
+        {
+        set_expand_context(xp);
+        }
+        cmd_showtail = expand_showtail(xp);
     }
 
     if (xp->xp_context == EXPAND_UNSUCCESSFUL)

--- a/src/cmdexpand.c
+++ b/src/cmdexpand.c
@@ -229,12 +229,14 @@ nextwild(
 
     if (xp->xp_numfiles == -1)
     {
+#ifdef FEAT_EVAL
     if (ccline->input_fn && ccline->xp_context == EXPAND_COMMANDS)
     {
     // Expand commands in input() function
     set_cmd_context(xp, ccline->cmdbuff, ccline->cmdlen, ccline->cmdpos, FALSE);
     }
     else
+#endif
     {
     set_expand_context(xp);
     cmd_showtail = expand_showtail(xp);

--- a/src/cmdexpand.c
+++ b/src/cmdexpand.c
@@ -231,14 +231,14 @@ nextwild(
     {
 #ifdef FEAT_EVAL
         if (ccline->input_fn && ccline->xp_context == EXPAND_COMMANDS)
-        {
-        // Expand commands typed in input() function
-        set_cmd_context(xp, ccline->cmdbuff, ccline->cmdlen, ccline->cmdpos, FALSE);
+	{
+	    // Expand commands typed in input() function
+	    set_cmd_context(xp, ccline->cmdbuff, ccline->cmdlen, ccline->cmdpos, FALSE);
         }
         else
 #endif
         {
-        set_expand_context(xp);
+	    set_expand_context(xp);
         }
         cmd_showtail = expand_showtail(xp);
     }

--- a/src/cmdexpand.c
+++ b/src/cmdexpand.c
@@ -229,8 +229,16 @@ nextwild(
 
     if (xp->xp_numfiles == -1)
     {
-	set_expand_context(xp);
-	cmd_showtail = expand_showtail(xp);
+    if (ccline->input_fn && ccline->xp_context == EXPAND_COMMANDS)
+    {
+    // Expand commands in input() function
+    set_cmd_context(xp, ccline->cmdbuff, ccline->cmdlen, ccline->cmdpos, FALSE);
+    }
+    else
+    {
+    set_expand_context(xp);
+    cmd_showtail = expand_showtail(xp);
+    }
     }
 
     if (xp->xp_context == EXPAND_UNSUCCESSFUL)
@@ -2723,10 +2731,8 @@ set_cmd_context(
 	xp->xp_context = ccline->xp_context;
 	xp->xp_pattern = ccline->cmdbuff;
 	xp->xp_arg = ccline->xp_arg;
-	while (nextcomm != NULL)
-		nextcomm = set_one_cmd_context(xp, nextcomm);
-    }
-    else
+	}
+	else
 #endif
 	while (nextcomm != NULL)
 	    nextcomm = set_one_cmd_context(xp, nextcomm);

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -2245,6 +2245,7 @@ func Test_input_func()
   call assert_fails("call input('F:', '', 'invalid')", 'E180:')
   call assert_fails("call input('F:', '', [])", 'E730:')
 
+  " Test for using 'command' as the completion function
   call feedkeys(":let c = input('Command? ', '', 'command')\<CR>"
         \ .. "echo bufnam\<C-A>\<CR>", 'xt')
   call assert_equal('echo bufname(', c)

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -2244,6 +2244,10 @@ func Test_input_func()
 
   call assert_fails("call input('F:', '', 'invalid')", 'E180:')
   call assert_fails("call input('F:', '', [])", 'E730:')
+
+  call feedkeys(":let c = input('Command? ', '', 'command')\<CR>"
+        \ .. "echo bufnam\<C-A>\<CR>", 'xt')
+  call assert_equal('echo bufname(', c)
 endfunc
 
 " Test for the inputdialog() function


### PR DESCRIPTION
Handle the case specially, to correctly set context for a command line that is inside `input('', '', 'command')`.

Related issue: #16723.