### PR TITLE
Not able to use autoloaded class across scripts

### DIFF
--- a/src/evalvars.c
+++ b/src/evalvars.c
@@ -3087,6 +3087,9 @@ eval_variable(
 			dictitem_T *v = find_var_in_ht(ht, 0, name,
 						  flags & EVAL_VAR_NOAUTOLOAD);
 
+			if (v == NULL)
+			    v = find_var_autoload_prefix(name, sid, NULL, NULL);
+
 			if (v != NULL)
 			{
 			    tv = &v->di_tv;

--- a/src/testdir/test_vim9_import.vim
+++ b/src/testdir/test_vim9_import.vim
@@ -3523,77 +3523,111 @@ def Test_use_imported_class_as_type()
   source Xdir/import/a.vim
 enddef
 
-" FIXME: The following test currently fails.
-" " Test for using an autoloaded class from another autoloaded script
-" def Test_class_from_auloaded_script()
-"   mkdir('Xdir', 'R')
-"   var save_rtp = &rtp
-"   &rtp = getcwd()
-"   exe 'set rtp^=' .. getcwd() .. '/Xdir'
-"
-"   mkdir('Xdir/autoload/SomeClass/bar', 'p')
-"
-"   var lines =<< trim END
-"     vim9script
-"
-"     export class Baz
-"       static var v1: string = "v1"
-"       var v2: string = "v2"
-"       def GetName(): string
-"         return "baz"
-"       enddef
-"     endclass
-"   END
-"   writefile(lines, 'Xdir/autoload/SomeClass/bar/baz.vim', 'D')
-"
-"   lines =<< trim END
-"     vim9script
-"
-"     import autoload './bar/baz.vim'
-"
-"     export def MyTestFoo(): string
-"       assert_fails('var x = baz.Baz.NonExisting()', 'E1325: Method "NonExisting" not found in class "Baz"')
-"       assert_fails('var x = baz.Baz.foobar', 'E1337: Class variable "foobar" not found in class "Baz"')
-"
-"       const instance = baz.Baz.new()
-"       return $'{instance.GetName()} {baz.Baz.v1} {instance.v2}'
-"     enddef
-"   END
-"   writefile(lines, 'Xdir/autoload/SomeClass/foo.vim', 'D')
-"
-"   lines =<< trim END
-"     vim9script
-"
-"     import autoload 'SomeClass/foo.vim'
-"     import autoload 'SomeClass/bar/baz.vim'
-"
-"     def NotInAutoload()
-"       # Use non-existing class method and variable
-"       assert_fails('var x = baz.Baz.NonExisting()', 'E1325: Method "NonExisting" not found in class "Baz"')
-"
-"       var caught_exception = false
-"       try
-"         var x = baz.Baz.foobar
-"       catch /E1337: Class variable "foobar" not found in class "Baz"/
-"         caught_exception = true
-"       endtry
-"       assert_true(caught_exception)
-"
-"       const instance = baz.Baz.new()
-"       assert_equal("baz v1 v2", $'{instance.GetName()} {baz.Baz.v1} {instance.v2}')
-"     enddef
-"
-"     def InAutoload()
-"       assert_equal("baz v1 v2", foo.MyTestFoo())
-"     enddef
-"
-"     NotInAutoload()
-"     InAutoload()
-"   END
-"   v9.CheckScriptSuccess(lines)
-"
-"   &rtp = save_rtp
-" enddef
+" Test for using an autoloaded class from another autoloaded script
+def Test_class_from_auloaded_script()
+  mkdir('Xdir', 'R')
+  var save_rtp = &rtp
+  &rtp = getcwd()
+  exe 'set rtp^=' .. getcwd() .. '/Xdir'
+
+  mkdir('Xdir/autoload/SomeClass/bar', 'p')
+
+  var lines =<< trim END
+    vim9script
+
+    export class Baz
+      static var v1: string = "v1"
+      var v2: string = "v2"
+      def GetName(): string
+        return "baz"
+      enddef
+    endclass
+  END
+  writefile(lines, 'Xdir/autoload/SomeClass/bar/baz.vim', 'D')
+
+  lines =<< trim END
+    vim9script
+
+    import autoload './bar/baz.vim'
+
+    export def MyTestFoo(): string
+      assert_fails('var x = baz.Baz.NonExisting()', 'E1325: Method "NonExisting" not found in class "Baz"')
+      assert_fails('var x = baz.Baz.foobar', 'E1337: Class variable "foobar" not found in class "Baz"')
+
+      const instance = baz.Baz.new()
+      return $'{instance.GetName()} {baz.Baz.v1} {instance.v2}'
+    enddef
+  END
+  writefile(lines, 'Xdir/autoload/SomeClass/foo.vim', 'D')
+
+  lines =<< trim END
+    vim9script
+
+    import autoload 'SomeClass/foo.vim'
+    import autoload 'SomeClass/bar/baz.vim'
+
+    def NotInAutoload()
+      # Use non-existing class method and variable
+      assert_fails('var x = baz.Baz.NonExisting()', 'E1325: Method "NonExisting" not found in class "Baz"')
+
+      var caught_exception = false
+      try
+        var x = baz.Baz.foobar
+      catch /E1337: Class variable "foobar" not found in class "Baz"/
+        caught_exception = true
+      endtry
+      assert_true(caught_exception)
+
+      const instance = baz.Baz.new()
+      assert_equal("baz v1 v2", $'{instance.GetName()} {baz.Baz.v1} {instance.v2}')
+    enddef
+
+    def InAutoload()
+      assert_equal("baz v1 v2", foo.MyTestFoo())
+    enddef
+
+    NotInAutoload()
+    InAutoload()
+  END
+  v9.CheckScriptSuccess(lines)
+
+  &rtp = save_rtp
+enddef
+
+" Test for using an autoloaded enum from another script
+def Test_enum_from_auloaded_script()
+  mkdir('Xdir', 'R')
+  var save_rtp = &rtp
+  &rtp = getcwd()
+  exe 'set rtp^=' .. getcwd() .. '/Xdir'
+
+  mkdir('Xdir/autoload/', 'p')
+
+  var lines =<< trim END
+    vim9script
+    export enum Color
+      Red,
+      Green,
+      Blue
+    endenum
+  END
+  writefile(lines, 'Xdir/autoload/color.vim', 'D')
+
+  lines =<< trim END
+    vim9script
+
+    import autoload 'color.vim'
+
+    def CheckColor()
+      var c = color.Color.Green
+      assert_equal('Green', c.name)
+    enddef
+    CheckColor()
+  END
+  v9.CheckScriptSuccess(lines)
+
+  &rtp = save_rtp
+enddef
 
 " Test for using a non-exported constant as an instance variable initiazer in an
 " imported class

--- a/src/vim9class.c
+++ b/src/vim9class.c
@@ -2063,7 +2063,7 @@ early_ret:
     tv.v_type = VAR_CLASS;
     tv.vval.v_class = cl;
     SOURCING_LNUM = start_lnum;
-    int rc = set_var_const(cl->class_name, current_sctx.sc_sid, NULL, &tv, FALSE, 0, 0);
+    int rc = set_var_const(cl->class_name, 0, NULL, &tv, FALSE, 0, 0);
     if (rc == FAIL)
 	goto cleanup;
 


### PR DESCRIPTION

Fix the issue reported in #15031.  This was originally fixed by 9.1.1119.  But caused a regression. So this was reverted
in 9.1.1128.  This PR properly fixes this issue and re-enables the test.