### PR TITLE
fix: require 'menu' and 'menuone' for 'preinsert' option in 'complete…

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2172,7 +2172,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 		    Preinsert the portion of the first candidate word that is
 		    not part of the current completion leader and using the
 		    |hl-ComplMatchIns| highlight group. Does not work when
-		    "fuzzy" is also included.
+		    "fuzzy" is also included. Requires both "menu" and
+		    "menuone" to be set.
 
 					*'completepopup'* *'cpp'*
 'completepopup' 'cpp'	string (default empty)

--- a/src/edit.c
+++ b/src/edit.c
@@ -146,7 +146,6 @@ edit(
 #ifdef FEAT_CONCEAL
     int		cursor_line_was_concealed;
 #endif
-    int		ins_completion = FALSE;
 
     // Remember whether editing was restarted after CTRL-O.
     did_restart_edit = restart_edit;
@@ -637,11 +636,8 @@ edit(
 	 * and the cursor is still in the completed word.  Only when there is
 	 * a match, skip this when no matches were found.
 	 */
-	ins_completion = ins_compl_active()
-	    && curwin->w_cursor.col >= ins_compl_col()
-	    && ins_compl_has_shown_match();
-
-	if (ins_completion && pum_wanted())
+	if (ins_compl_active() && curwin->w_cursor.col >= ins_compl_col()
+		&& ins_compl_has_shown_match() && pum_wanted())
 	{
 	    // BS: Delete one character from "compl_leader".
 	    if ((c == K_BS || c == Ctrl_H)
@@ -699,8 +695,6 @@ edit(
 		    ins_compl_delete();
 	    }
 	}
-	else if (ins_completion && !pum_wanted() && ins_compl_preinsert_effect())
-	    ins_compl_delete();
 
 	// Prepare for or stop CTRL-X mode.  This doesn't do completion, but
 	// it does fix up the text when finishing completion.

--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -1985,12 +1985,15 @@ ins_compl_len(void)
 }
 
 /*
- * Return TRUE when preinsert is set otherwise FALSE.
+ * Return TRUE when preinsert is set AND both 'menu' and 'menuone' flags
+ * are also set, otherwise return FALSE.
  */
     static int
 ins_compl_has_preinsert(void)
 {
-    return (get_cot_flags() & (COT_PREINSERT | COT_FUZZY)) == COT_PREINSERT;
+    int cur_cot_flags = get_cot_flags();
+    return (cur_cot_flags & (COT_PREINSERT | COT_FUZZY | COT_MENU | COT_MENUONE))
+	== (COT_PREINSERT | COT_MENU | COT_MENUONE);
 }
 
 /*

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -3217,10 +3217,11 @@ function Test_completeopt_preinsert()
   call assert_equal("fobar", getline('.'))
   call assert_equal(5, col('.'))
 
+  " When the pum is not visible, the preinsert has no effect
   set cot=preinsert
   call feedkeys("Sfoo1 foo2\<CR>f\<C-X>\<C-N>bar", 'tx')
-  call assert_equal("fbar", getline('.'))
-  call assert_equal(4, col('.'))
+  call assert_equal("foo1bar", getline('.'))
+  call assert_equal(7, col('.'))
 
   bw!
   set cot&


### PR DESCRIPTION
…opt'

Problem: The 'preinsert' feature requires Ctrl-Y to confirm insertion, but Ctrl-Y only works when the popup menu (pum) is displayed. Without enforcing this dependency, it could lead to confusing behavior or non-functional features.

Solution: Modify ins_compl_has_preinsert() to check for both 'menu' and 'menuone' flags when 'preinsert' is set. Update documentation to clarify this requirement. This avoids adding complex conditional behaviors.

Fix #16728