### PR TITLE
fix: preinsert only requires menuone to be set

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2168,8 +2168,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 		    Preinsert the portion of the first candidate word that is
 		    not part of the current completion leader and using the
 		    |hl-ComplMatchIns| highlight group. Does not work when
-		    "fuzzy" is set. Requires both "menu" and "menuone" to be
-		    set.
+		    "fuzzy" is set. Requires "menuone" to be set.
 
 	   preview  Show extra information about the currently selected
 		    completion in the preview window.  Only works in

--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -1985,15 +1985,15 @@ ins_compl_len(void)
 }
 
 /*
- * Return TRUE when preinsert is set AND both 'menu' and 'menuone' flags
- * are also set, otherwise return FALSE.
+ * Return TRUE when the 'completeopt' "preinsert" flag is in effect,
+ * otherwise return FALSE.
  */
     static int
 ins_compl_has_preinsert(void)
 {
     int cur_cot_flags = get_cot_flags();
-    return (cur_cot_flags & (COT_PREINSERT | COT_FUZZY | COT_MENU | COT_MENUONE))
-	== (COT_PREINSERT | COT_MENU | COT_MENUONE);
+    return (cur_cot_flags & (COT_PREINSERT | COT_FUZZY | COT_MENUONE))
+	== (COT_PREINSERT | COT_MENUONE);
 }
 
 /*

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -3223,6 +3223,11 @@ function Test_completeopt_preinsert()
   call assert_equal("foo1bar", getline('.'))
   call assert_equal(7, col('.'))
 
+  set cot=preinsert,menuone
+  call feedkeys("Sfoo1 foo2\<CR>f\<C-X>\<C-N>", 'tx')
+  call assert_equal("foo1", getline('.'))
+  call assert_equal(1, col('.'))
+
   bw!
   set cot&
   set omnifunc&


### PR DESCRIPTION
Problem: patch-9.1.1160 require menu and menuone both set.but the menu is redundant condition.

Solution: preinsert only requires menuone