### PR TITLE
MYVIMDIR set too late

### DIFF
--- a/src/option.c
+++ b/src/option.c
@@ -8420,6 +8420,8 @@ vimrc_found(char_u *fname, char_u *envname)
 		vim_setenv(envname, p);
 		vim_free(p);
 	    }
+	    // Set $MYVIMDIR
+	    export_myvimdir();
 	}
 	else if (dofree)
 	    vim_free(p);

--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -135,7 +135,6 @@ static char *(p_sws_values[]) = {"fsync", "sync", NULL};
 
 static int check_opt_strings(char_u *val, char **values, int list);
 static int opt_strings_flags(char_u *val, char **values, unsigned *flagp, int list);
-static void export_myvimdir(void);
 
 /*
  * After setting various option values: recompute variables that depend on
@@ -4817,7 +4816,7 @@ restore_shm_value(void)
 /*
  * Export the environment variable $MYVIMDIR to the first item in runtimepath
  */
-    static void
+    void
 export_myvimdir()
 {
     int		dofree = FALSE;

--- a/src/proto/optionstr.pro
+++ b/src/proto/optionstr.pro
@@ -198,4 +198,5 @@ char *did_set_string_option(int opt_idx, char_u **varp, char_u *oldval, char_u *
 int check_ff_value(char_u *p);
 void save_clear_shm_value(void);
 void restore_shm_value(void);
+void export_myvimdir(void);
 /* vim: set ft=c : */

--- a/src/testdir/test_xdg.vim
+++ b/src/testdir/test_xdg.vim
@@ -21,7 +21,7 @@ func Test_xdg_rc_detection()
   let rc = s:get_rcs()
   let before =<< trim CODE
     call writefile([expand('$MYVIMRC')], "XMY_VIMRC")
-    call writefile([expand('$MYVIMRCDIR')], "XMY_VIMDIR")
+    call writefile([expand('$MYVIMDIR')], "XMY_VIMDIR")
     quit!
   CODE
   call RunVim(before, [], "")
@@ -58,21 +58,30 @@ func Test_xdg_runtime_files()
   " g:rc_one|two|three|four is to verify, that the other
   " init files are not sourced
   " g:rc is to verify which rc file has been loaded.
+  " g:rc_vimdir is to verify $MYVIMDIR is set and valid
   let file1 =<< trim CODE
     let g:rc_one = 'one'
     let g:rc = '.vimrc'
+    let g:rc_vimdir = expand('~/.vim/')
+    call assert_equal(g:rc_vimdir, $MYVIMDIR)
   CODE
   let file2 =<< trim CODE
     let g:rc_two = 'two'
     let g:rc = '.vim/vimrc'
+    let g:rc_vimdir = expand('~/.vim/')
+    call assert_equal(g:rc_vimdir, $MYVIMDIR)
   CODE
   let file3 =<< trim CODE
     let g:rc_three = 'three'
     let g:rc = '.config/vim/vimrc'
+    let g:rc_vimdir = expand('~/.config/vim/')
+    call assert_equal(g:rc_vimdir, $MYVIMDIR)
   CODE
   let file4 =<< trim CODE
     let g:rc_four = 'four'
     let g:rc = 'xdg/vim/vimrc'
+    let g:rc_vimdir = expand('~/xdg/vim/')
+    call assert_equal(g:rc_vimdir, $MYVIMDIR)
   CODE
   call writefile(file1, rc1)
   call writefile(file2, rc2)
@@ -87,7 +96,7 @@ func Test_xdg_runtime_files()
     call assert_match('XfakeHOME/\.vimrc', $MYVIMRC)
     call assert_match('XfakeHOME/.vim/', $MYVIMDIR)
     call filter(g:, {idx, _ -> idx =~ '^rc'})
-    call assert_equal(#{rc_one: 'one', rc: '.vimrc'}, g:)
+    call assert_equal(#{rc_one: 'one', rc: '.vimrc', rc_vimdir: $MYVIMDIR}, g:)
     call assert_match('XfakeHOME/\.vim/view', &viewdir)
     call writefile(v:errors, 'Xresult')
     quit
@@ -103,7 +112,7 @@ func Test_xdg_runtime_files()
     call assert_match('XfakeHOME/\.vim/vimrc', $MYVIMRC)
     call assert_match('XfakeHOME/\.vim/', $MYVIMDIR)
     call filter(g:, {idx, _ -> idx =~ '^rc'})
-    call assert_equal(#{rc_two: 'two', rc: '.vim/vimrc'}, g:)
+    call assert_equal(#{rc_two: 'two', rc: '.vim/vimrc', rc_vimdir: $MYVIMDIR}, g:)
     call assert_match('XfakeHOME/\.vim/view', &viewdir)
     call writefile(v:errors, 'Xresult')
     quit
@@ -123,7 +132,7 @@ func Test_xdg_runtime_files()
     call assert_match('XfakeHOME/\.config/vim/vimrc', $MYVIMRC, msg)
     call assert_match('XfakeHOME/\.config/vim/', $MYVIMDIR, msg)
     call filter(g:, {idx, _ -> idx =~ '^rc'})
-    call assert_equal(#{rc_three: 'three', rc: '.config/vim/vimrc'}, g:)
+    call assert_equal(#{rc_three: 'three', rc: '.config/vim/vimrc', rc_vimdir: $MYVIMDIR}, g:)
     call assert_match('XfakeHOME/\.config/vim/view', &viewdir)
     call writefile(v:errors, 'Xresult')
     quit
@@ -141,7 +150,7 @@ func Test_xdg_runtime_files()
     call assert_match('XfakeHOME/xdg/vim/vimrc', $MYVIMRC, msg)
     call assert_match('XfakeHOME/xdg/vim/', $MYVIMDIR, msg)
     call filter(g:, {idx, _ -> idx =~ '^rc'})
-    call assert_equal(#{rc_four: 'four', rc: 'xdg/vim/vimrc'}, g:)
+    call assert_equal(#{rc_four: 'four', rc: 'xdg/vim/vimrc', rc_vimdir: $MYVIMDIR}, g:)
     call assert_match('XfakeHOME/xdg/vim/view, &viewdir)
     call writefile(v:errors, 'Xresult')
     quit


### PR DESCRIPTION
Problem:  $MYVIMDIR not available when sourcing runtime files
Solution: export $MYVIMDIR earlier

fixes: #16764