### PR TITLE
Use file header to distinguish between .tbz files when `file` is not available

### DIFF
--- a/runtime/autoload/tar.vim
+++ b/runtime/autoload/tar.vim
@@ -190,10 +190,10 @@ fun! tar#Browse(tarfile)
    " Determine the compression type by inspecting the file header:
    " - 'BZh' indicates bzip2 compression
    " - 'BZ3' indicates bzip3 compression
-   let header = strpart(readfile(tarfile, 0, 1)[0], 0, 3)
-   if header == 'BZh'
+   let header = readblob(tarfile, 0, 3)
+   if header == 0z425A68
     exe "sil! r! bzip2 -d -c -- ".shellescape(tarfile,1)." | ".g:tar_cmd." -".g:tar_browseoptions." - "
-   elseif header == 'BZ3'
+   elseif header == 0z425A33
     exe "sil! r! bzip3 -d -c -- ".shellescape(tarfile,1)." | ".g:tar_cmd." -".g:tar_browseoptions." - "
    endif
   elseif tarfile =~# '\.\(lzma\|tlz\)$'

--- a/runtime/autoload/tar.vim
+++ b/runtime/autoload/tar.vim
@@ -182,8 +182,17 @@ fun! tar#Browse(tarfile)
 
   elseif tarfile =~# '\.lrp'
    exe "sil! r! cat -- ".shellescape(tarfile,1)."|gzip -d -c -|".g:tar_cmd." -".g:tar_browseoptions." - "
-  elseif tarfile =~# '\.\(bz2\|tbz\|tb2\)$'
+  elseif tarfile =~# '\.\(bz2\|tb2\)$'
    exe "sil! r! bzip2 -d -c -- ".shellescape(tarfile,1)." | ".g:tar_cmd." -".g:tar_browseoptions." - "
+  elseif tarfile =~# '\.tbz'
+   " Read the first three characters of the file to determine whether it is 
+   " compressed by bzip2 or by bzip3.
+   " bzip2 files has header 'BZh', bzip3 files has header 'BZ3'
+   let header = strpart(readfile(a:filename, 0, 1), 0, 3)
+   if header == 'BZh'
+    exe "sil! r! bzip2 -d -c -- ".shellescape(tarfile,1)." | ".g:tar_cmd." -".g:tar_browseoptions." - "
+   elseif header == 'BZ3'
+    exe "sil! r! bzip3 -d -c -- ".shellescape(tarfile,1)." | ".g:tar_cmd." -".g:tar_browseoptions." - "
   elseif tarfile =~# '\.\(bz3\|tb3\)$'
    exe "sil! r! bzip3 -d -c -- ".shellescape(tarfile,1)." | ".g:tar_cmd." -".g:tar_browseoptions." - "
   elseif tarfile =~# '\.\(lzma\|tlz\)$'

--- a/runtime/autoload/tar.vim
+++ b/runtime/autoload/tar.vim
@@ -187,9 +187,9 @@ fun! tar#Browse(tarfile)
   elseif tarfile =~# '\.\(bz3\|tb3\)$'
    exe "sil! r! bzip3 -d -c -- ".shellescape(tarfile,1)." | ".g:tar_cmd." -".g:tar_browseoptions." - "
   elseif tarfile =~# '\.tbz'
-   " Read the first three characters of the file to determine whether it is 
-   " compressed by bzip2 or by bzip3.
-   " bzip2 files has header 'BZh', bzip3 files has header 'BZ3'
+   " Determine the compression type by inspecting the file header:
+   " - 'BZh' indicates bzip2 compression
+   " - 'BZ3' indicates bzip3 compression
    let header = strpart(readfile(tarfile, 0, 1)[0], 0, 3)
    if header == 'BZh'
     exe "sil! r! bzip2 -d -c -- ".shellescape(tarfile,1)." | ".g:tar_cmd." -".g:tar_browseoptions." - "

--- a/runtime/autoload/tar.vim
+++ b/runtime/autoload/tar.vim
@@ -188,8 +188,8 @@ fun! tar#Browse(tarfile)
    exe "sil! r! bzip3 -d -c -- ".shellescape(tarfile,1)." | ".g:tar_cmd." -".g:tar_browseoptions." - "
   elseif tarfile =~# '\.tbz'
    " Determine the compression type by inspecting the file header:
-   " - 'BZh' indicates bzip2 compression
-   " - 'BZ3' indicates bzip3 compression
+   " - 'BZh(0z425A68)' indicates bzip2 compression
+   " - 'BZ3(0z425A33)' indicates bzip3 compression
    let header = readblob(tarfile, 0, 3)
    if header == 0z425A68
     exe "sil! r! bzip2 -d -c -- ".shellescape(tarfile,1)." | ".g:tar_cmd." -".g:tar_browseoptions." - "

--- a/runtime/autoload/tar.vim
+++ b/runtime/autoload/tar.vim
@@ -188,7 +188,7 @@ fun! tar#Browse(tarfile)
    " Read the first three characters of the file to determine whether it is 
    " compressed by bzip2 or by bzip3.
    " bzip2 files has header 'BZh', bzip3 files has header 'BZ3'
-   let header = strpart(readfile(a:filename, 0, 1), 0, 3)
+   let header = strpart(readfile(a:filename, 0, 1)[0], 0, 3)
    if header == 'BZh'
     exe "sil! r! bzip2 -d -c -- ".shellescape(tarfile,1)." | ".g:tar_cmd." -".g:tar_browseoptions." - "
    elseif header == 'BZ3'

--- a/runtime/autoload/tar.vim
+++ b/runtime/autoload/tar.vim
@@ -184,6 +184,8 @@ fun! tar#Browse(tarfile)
    exe "sil! r! cat -- ".shellescape(tarfile,1)."|gzip -d -c -|".g:tar_cmd." -".g:tar_browseoptions." - "
   elseif tarfile =~# '\.\(bz2\|tb2\)$'
    exe "sil! r! bzip2 -d -c -- ".shellescape(tarfile,1)." | ".g:tar_cmd." -".g:tar_browseoptions." - "
+  elseif tarfile =~# '\.\(bz3\|tb3\)$'
+   exe "sil! r! bzip3 -d -c -- ".shellescape(tarfile,1)." | ".g:tar_cmd." -".g:tar_browseoptions." - "
   elseif tarfile =~# '\.tbz'
    " Read the first three characters of the file to determine whether it is 
    " compressed by bzip2 or by bzip3.
@@ -194,8 +196,6 @@ fun! tar#Browse(tarfile)
    elseif header == 'BZ3'
     exe "sil! r! bzip3 -d -c -- ".shellescape(tarfile,1)." | ".g:tar_cmd." -".g:tar_browseoptions." - "
    endif
-  elseif tarfile =~# '\.\(bz3\|tb3\)$'
-   exe "sil! r! bzip3 -d -c -- ".shellescape(tarfile,1)." | ".g:tar_cmd." -".g:tar_browseoptions." - "
   elseif tarfile =~# '\.\(lzma\|tlz\)$'
    exe "sil! r! lzma -d -c -- ".shellescape(tarfile,1)." | ".g:tar_cmd." -".g:tar_browseoptions." - "
   elseif tarfile =~# '\.\(xz\|txz\)$'

--- a/runtime/autoload/tar.vim
+++ b/runtime/autoload/tar.vim
@@ -193,6 +193,7 @@ fun! tar#Browse(tarfile)
     exe "sil! r! bzip2 -d -c -- ".shellescape(tarfile,1)." | ".g:tar_cmd." -".g:tar_browseoptions." - "
    elseif header == 'BZ3'
     exe "sil! r! bzip3 -d -c -- ".shellescape(tarfile,1)." | ".g:tar_cmd." -".g:tar_browseoptions." - "
+   endif
   elseif tarfile =~# '\.\(bz3\|tb3\)$'
    exe "sil! r! bzip3 -d -c -- ".shellescape(tarfile,1)." | ".g:tar_cmd." -".g:tar_browseoptions." - "
   elseif tarfile =~# '\.\(lzma\|tlz\)$'

--- a/runtime/autoload/tar.vim
+++ b/runtime/autoload/tar.vim
@@ -188,7 +188,7 @@ fun! tar#Browse(tarfile)
    " Read the first three characters of the file to determine whether it is 
    " compressed by bzip2 or by bzip3.
    " bzip2 files has header 'BZh', bzip3 files has header 'BZ3'
-   let header = strpart(readfile(a:filename, 0, 1)[0], 0, 3)
+   let header = strpart(readfile(tarfile, 0, 1)[0], 0, 3)
    if header == 'BZh'
     exe "sil! r! bzip2 -d -c -- ".shellescape(tarfile,1)." | ".g:tar_cmd." -".g:tar_browseoptions." - "
    elseif header == 'BZ3'


### PR DESCRIPTION
Related issue: #16761