### PR TITLE
Fix: indent cUserLabels with UTF-8 characters correctly

### DIFF
--- a/src/cindent.c
+++ b/src/cindent.c
@@ -369,7 +369,8 @@ find_line_comment(void) // XXX
  * "s" is a UTF-8 continuation byte, if first bit is 1.
  */
     static int
-cin_isIDc(char_u s) {
+cin_isIDc(char_u s)
+{
     return s>>7 || vim_isIDc(s);
 }
 

--- a/src/cindent.c
+++ b/src/cindent.c
@@ -366,6 +366,14 @@ find_line_comment(void) // XXX
 }
 
 /*
+ * "s" is a UTF-8 continuation byte, if first bit is 1.
+ */
+    static int
+cin_isIDc(char_u s) {
+    return s>>7 || vim_isIDc(s);
+}
+
+/*
  * Return TRUE if "text" starts with "key:".
  */
     static int
@@ -380,10 +388,10 @@ cin_has_js_key(char_u *text)
 	quote = *s;
 	++s;
     }
-    if (!vim_isIDc(*s))	    // need at least one ID character
+    if (!cin_isIDc(*s))	    // need at least one ID character
 	return FALSE;
 
-    while (vim_isIDc(*s))
+    while (cin_isIDc(*s))
 	++s;
     if (*s == quote)
 	++s;
@@ -401,10 +409,10 @@ cin_has_js_key(char_u *text)
     static int
 cin_islabel_skip(char_u **s)
 {
-    if (!vim_isIDc(**s))	    // need at least one ID character
+    if (!cin_isIDc(**s))	    // need at least one ID character
 	return FALSE;
 
-    while (vim_isIDc(**s))
+    while (cin_isIDc(**s))
 	(*s)++;
 
     *s = cin_skipcomment(*s);
@@ -506,7 +514,7 @@ cin_iselse(
 {
     if (*p == '}')	    // accept "} else"
 	p = cin_skipcomment(p + 1);
-    return (STRNCMP(p, "else", 4) == 0 && !vim_isIDc(p[4]));
+    return (STRNCMP(p, "else", 4) == 0 && !cin_isIDc(p[4]));
 }
 
 /*
@@ -568,7 +576,7 @@ cin_starts_with(char_u *s, char *word)
 {
     int l = (int)STRLEN(word);
 
-    return (STRNCMP(s, word, l) == 0 && !vim_isIDc(s[l]));
+    return (STRNCMP(s, word, l) == 0 && !cin_isIDc(s[l]));
 }
 
 /*
@@ -984,7 +992,7 @@ cin_first_id_amount(void)
 		|| (STRNCMP(s, "char", 4) == 0 && VIM_ISWHITE(s[4])))
 	    p = s;
     }
-    for (len = 0; vim_isIDc(p[len]); ++len)
+    for (len = 0; cin_isIDc(p[len]); ++len)
 	;
     if (len == 0 || !VIM_ISWHITE(p[len]) || cin_nocode(p))
 	return 0;
@@ -1291,13 +1299,13 @@ done:
     static int
 cin_isif(char_u *p)
 {
- return (STRNCMP(p, "if", 2) == 0 && !vim_isIDc(p[2]));
+ return (STRNCMP(p, "if", 2) == 0 && !cin_isIDc(p[2]));
 }
 
     static int
 cin_isdo(char_u *p)
 {
-    return (STRNCMP(p, "do", 2) == 0 && !vim_isIDc(p[2]));
+    return (STRNCMP(p, "do", 2) == 0 && !cin_isIDc(p[2]));
 }
 
 /*
@@ -1371,7 +1379,7 @@ cin_is_if_for_while_before_offset(char_u *line, int *poffset)
     return 0;
 
 probablyFound:
-    if (!offset || !vim_isIDc(line[offset - 1]))
+    if (!offset || !cin_isIDc(line[offset - 1]))
     {
 	*poffset = offset;
 	return 1;
@@ -1439,7 +1447,7 @@ cin_iswhileofdo_end(int terminated)
     static int
 cin_isbreak(char_u *p)
 {
-    return (STRNCMP(p, "break", 5) == 0 && !vim_isIDc(p[5]));
+    return (STRNCMP(p, "break", 5) == 0 && !cin_isIDc(p[5]));
 }
 
 /*
@@ -1557,8 +1565,8 @@ cin_is_cpp_baseclass(
 	    else
 		s = cin_skipcomment(s + 1);
 	}
-	else if ((STRNCMP(s, "class", 5) == 0 && !vim_isIDc(s[5]))
-		|| (STRNCMP(s, "struct", 6) == 0 && !vim_isIDc(s[6])))
+	else if ((STRNCMP(s, "class", 5) == 0 && !cin_isIDc(s[5]))
+		|| (STRNCMP(s, "struct", 6) == 0 && !cin_isIDc(s[6])))
 	{
 	    class_or_struct = TRUE;
 	    lookfor_ctor_init = FALSE;
@@ -1586,7 +1594,7 @@ cin_is_cpp_baseclass(
 		// Avoid seeing '() :' after '?' as constructor init.
 		return FALSE;
 	    }
-	    else if (!vim_isIDc(s[0]))
+	    else if (!cin_isIDc(s[0]))
 	    {
 		// if it is not an identifier, we are wrong
 		class_or_struct = FALSE;

--- a/src/testdir/test_indent.vim
+++ b/src/testdir/test_indent.vim
@@ -109,6 +109,20 @@ func Test_preproc_indent()
   close!
 endfunc
 
+func Test_userlabel_indent()
+  new
+  set sw=4
+  call setline(1, ['{', 'label:'])
+  normal GV=
+  call assert_equal('label:', getline(2))
+
+  call setline(2, 'läbél:')
+  normal GV=
+  call assert_equal('läbél:', getline(2))
+
+  close!
+endfunc
+
 " Test for 'copyindent'
 func Test_copyindent()
   new

--- a/src/testdir/test_indent.vim
+++ b/src/testdir/test_indent.vim
@@ -111,7 +111,6 @@ endfunc
 
 func Test_userlabel_indent()
   new
-  set sw=4
   call setline(1, ['{', 'label:'])
   normal GV=
   call assert_equal('label:', getline(2))


### PR DESCRIPTION
Problem: cUserLabels containing non-ascii characters are not recognized
         as cUserLabels in indentation, because vim_isIDc returns FALSE
	 for UTF-8 continuation bytes

Solution: in cindent.c, substitute vim_isIDc with a function that checks if the
          character is a UTF-8 continuation byte before calling vim_isIDc