### PR TITLE
Don't use global variable for get_insert()

### DIFF
--- a/src/edit.c
+++ b/src/edit.c
@@ -415,14 +415,10 @@ edit(
      * Get the current length of the redo buffer, those characters have to be
      * skipped if we want to get to the inserted characters.
      */
-    ptr = get_inserted();
-    if (ptr == NULL)
-	new_insert_skip = 0;
-    else
-    {
-	new_insert_skip = (int)get_inserted_len();
-	vim_free(ptr);
-    }
+    string_T inserted = get_inserted();
+    new_insert_skip = (int)inserted.length;
+    if (inserted.string != NULL)
+	vim_free(inserted.string);
 
     old_indent = 0;
 
@@ -2445,7 +2441,7 @@ stop_insert(
     int		nomove)			// <c-\><c-o>, don't move cursor
 {
     int		cc;
-    char_u	*ptr;
+    string_T	inserted;
 
     stop_redo_ins();
     replace_flush();		// abandon replace stack
@@ -2455,16 +2451,16 @@ stop_insert(
      * Don't do it when "restart_edit" was set and nothing was inserted,
      * otherwise CTRL-O w and then <Left> will clear "last_insert".
      */
-    ptr = get_inserted();
-    int added = ptr == NULL ? 0 : (int)get_inserted_len() - new_insert_skip;
+    inserted = get_inserted();
+    int added = inserted.string == NULL ? 0 : (int)inserted.length - new_insert_skip;
     if (did_restart_edit == 0 || added > 0)
     {
 	vim_free(last_insert);
-	last_insert = ptr;
+	last_insert = inserted.string;
 	last_insert_skip = added < 0 ? 0 : new_insert_skip;
     }
     else
-	vim_free(ptr);
+	vim_free(inserted.string);
 
     if (!arrow_used && end_insert_pos != NULL)
     {

--- a/src/getchar.c
+++ b/src/getchar.c
@@ -88,9 +88,6 @@ static char_u	noremapbuf_init[TYPELEN_INIT];	// initial typebuf.tb_noremap
 
 static size_t	last_recorded_len = 0;	// number of last recorded chars
 
-static size_t	last_get_inserted_len = 0;	// length of the string returned from the
-						// last call to get_inserted()
-
 #ifdef FEAT_EVAL
 mapblock_T	*last_used_map = NULL;
 int		last_used_sid = -1;
@@ -203,19 +200,13 @@ get_recorded(void)
  * Return the contents of the redo buffer as a single string.
  * K_SPECIAL and CSI in the returned string are escaped.
  */
-    char_u *
+    string_T
 get_inserted(void)
 {
-    return get_buffcont(&redobuff, FALSE, &last_get_inserted_len);
-}
-
-/*
- * Return the length of string returned from the last call of get_inserted().
- */
-    size_t
-get_inserted_len(void)
-{
-    return last_get_inserted_len;
+    size_t len = 0;
+    char_u* str = get_buffcont(&redobuff, FALSE, &len);
+    string_T ret = { str, len };
+    return ret;
 }
 
 /*

--- a/src/proto/getchar.pro
+++ b/src/proto/getchar.pro
@@ -1,7 +1,6 @@
 /* getchar.c */
 char_u *get_recorded(void);
-char_u *get_inserted(void);
-size_t get_inserted_len(void);
+string_T get_inserted(void);
 int stuff_empty(void);
 int readbuf1_empty(void);
 void typeahead_noflush(int c);

--- a/src/proto/userfunc.pro
+++ b/src/proto/userfunc.pro
@@ -2,8 +2,7 @@
 void func_init(void);
 hashtab_T *func_tbl_get(void);
 char_u *make_ufunc_name_readable(char_u *name, char_u *buf, size_t bufsize);
-char_u *get_lambda_name(void);
-size_t get_lambda_name_len(void);
+string_T get_lambda_name(void);
 char_u *register_cfunc(cfunc_T cb, cfunc_free_T cb_free, void *state);
 int get_lambda_tv(char_u **arg, typval_T *rettv, int types_optional, evalarg_T *evalarg);
 char_u *deref_func_name(char_u *name, int *lenp, partial_T **partialp, type_T **type, int no_autoload, int new_function, int *found_var);

--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -1033,8 +1033,7 @@ compile_nested_function(exarg_T *eap, cctx_T *cctx, garray_T *lines_to_free)
     char_u	*name_end = to_name_end(eap->arg, TRUE);
     int		off;
     char_u	*func_name;
-    char_u	*lambda_name;
-    size_t	lambda_namelen;
+    string_T	lambda_name;
     ufunc_T	*ufunc;
     int		r = FAIL;
     compiletype_T   compile_type;
@@ -1094,9 +1093,8 @@ compile_nested_function(exarg_T *eap, cctx_T *cctx, garray_T *lines_to_free)
     eap->forceit = FALSE;
     // We use the special <Lamba>99 name, but it's not really a lambda.
     lambda_name = get_lambda_name();
-    lambda_namelen = get_lambda_name_len();
-    lambda_name = vim_strnsave(lambda_name, lambda_namelen);
-    if (lambda_name == NULL)
+    lambda_name.string = vim_strnsave(lambda_name.string, lambda_name.length);
+    if (lambda_name.string == NULL)
 	return NULL;
 
     // This may free the current line, make a copy of the name.
@@ -1112,7 +1110,7 @@ compile_nested_function(exarg_T *eap, cctx_T *cctx, garray_T *lines_to_free)
     int save_KeyTyped = KeyTyped;
     KeyTyped = FALSE;
 
-    ufunc = define_function(eap, lambda_name, lines_to_free, 0, NULL, 0);
+    ufunc = define_function(eap, lambda_name.string, lines_to_free, 0, NULL, 0);
 
     KeyTyped = save_KeyTyped;
 
@@ -1148,9 +1146,10 @@ compile_nested_function(exarg_T *eap, cctx_T *cctx, garray_T *lines_to_free)
     // recursive call.
     if (is_global)
     {
-	r = generate_NEWFUNC(cctx, lambda_name, func_name);
+	r = generate_NEWFUNC(cctx, lambda_name.string, func_name);
 	func_name = NULL;
-	lambda_name = NULL;
+	lambda_name.string = NULL;
+	lambda_name.length = 0;
     }
     else
     {
@@ -1197,7 +1196,7 @@ compile_nested_function(exarg_T *eap, cctx_T *cctx, garray_T *lines_to_free)
     }
 
 theend:
-    vim_free(lambda_name);
+    vim_free(lambda_name.string);
     vim_free(func_name);
     return r == FAIL ? NULL : (char_u *)"";
 }


### PR DESCRIPTION
In #16720, `get_insert()` was modified to store a string length in a global variable to be queried immediately by another `get_insert_len()` function, which is somewhat fragile. Instead, just have the function itself return the length.