### PR TITLE
editorconfig: set indent config for *.vim files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -20,6 +20,10 @@ indent_size = 2
 # https://spec.commonmark.org/0.31.2/#hard-line-breaks
 trim_trailing_whitespace = false
 
+[*.vim]
+indent_style = space
+indent_size = 2
+
 [runtime/doc/**.txt]
 # It can mess up some documentation by trying to strip trailing whitespaces
 trim_trailing_whitespace = false


### PR DESCRIPTION
I tried to figure out what was the most common using modelines. Note that there are 2401 vim files, and the numbers in the other command outputs below add up to significantly less than that, so it's possible that my estimate of what's most common is way off.

```
$ find . -name \*.vim | wc -l
2401
```

It looks like 2 is the most common value by far for shiftwidth and softtabstop, so I used that for indent_size.

```
$ git grep -hE '(^|\s)((vi|vim|ex):|(vi|[vV]im|ex):\s*set? .*:)' -- '*.vim' |
> grep -Eo '\<(sw|shiftwidth)=[0-9]+' | cut -d = -f 2 |
> sort | uniq -c | sort -n
      2 0
     14 3
     18 8
     75 4
    610 2

$ git grep -hE '(^|\s)((vi|vim|ex):|(vi|[vV]im|ex):\s*set? .*:)' -- '*.vim' |
> grep -Eo '\<(sts|softtabstop)=[^ :]+' | cut -d = -f 2 |
> sort | uniq -c | sort -n
      2 -1
      7 8
      9 0
      9 3
     43 4
    469 2
```

Similarly, 8 is by far the most common tabstop, so I didn't adjust that.

```
$ git grep -hE '(^|\s)((vi|vim|ex):|(vi|[vV]im|ex):\s*set? .*:)' -- '*.vim' |
> grep -Eo '\<(ts|tabstop)=[0-9]+' | cut -d = -f 2 |
> sort | uniq -c | sort -n
      1 20
      1 6
      1 9
      2 10
      2 16
      2 17
      3 15
      4 3
      5 18
      9 2
     40 4
    497 8
```

And expandtab is significantly more common than noexpandtab. Taking that in combination with the common shiftwidth and softtabstop of 2 but tabstop of 8, I set indent_style to space.

```
$ git grep -hE '(^|\s)((vi|vim|ex):|(vi|[vV]im|ex):\s*set? .*:)' -- '*.vim' |
> grep -Eo '\<(no)?(et|expandtab)\>' | sort | uniq -c | sort -n
     15 noexpandtab
     86 noet
    115 et
    309 expandtab
```

I did try to look at a few of the less common values for those options to see if there was any obvious pattern, like all *.vim files in one directory having a different setting. The only real pattern I noticed was in runtime/pack/dist/opt/netrw, but that looks like it's imported from a separate repository? So I think it might make more sense for them to create their own .editorconfig file rather than putting settings for that directory in this one.