### PR TITLE
Remove unneeded logic

### DIFF
--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -977,7 +977,7 @@ cmdline_wildchar_complete(
 		    p_wmnu = 0;
 
 		    // remove match
-		    nextwild(xp, WILD_PREV, 0 | (options & ~WIM_NOSELECT), escape);
+		    nextwild(xp, WILD_PREV, options, escape);
 		    p_wmnu = p_wmnu_save;
 		}
 		(void)showmatches(xp, p_wmnu


### PR DESCRIPTION
`options` needs to be passed into nextwild() since it may contain WILD_KEEP_SOLE_ITEM which prevents the menu items list from getting freed if there is only 1 item left (if `noselect` is set).

https://github.com/vim/vim/pull/16759#discussion_r1977190105

M  src/ex_getln.c