### PR TITLE
tests: wrong arguments passed to assert_equal()

### DIFF
--- a/src/testdir/test_registers.vim
+++ b/src/testdir/test_registers.vim
@@ -1162,7 +1162,7 @@ func Test_mark_from_yank()
   normal! yi"
   call assert_equal([0, 1, 10, 0], getpos("']"))
   normal! ya"
-  call assert_equal(getpos("']"), [0, 1, 13, 0], getpos("']"))
+  call assert_equal([0, 1, 13, 0], getpos("']"))
   " single quote object
   call setline(1, 'test ''yank''  mark')
   normal! yi'


### PR DESCRIPTION
Problem:  tests: wrong arguments passed to assert_equal().
Solution: Remove the first getpos() argument.
