### PR TITLE
safer check for vim9script

### DIFF
--- a/runtime/doc/vim9.txt
+++ b/runtime/doc/vim9.txt
@@ -1920,7 +1920,7 @@ There is one way to use both legacy and Vim9 syntax in one script file: >
 	# Vim9 script commands go here
 This allows for writing a script that takes advantage of the Vim9 script
 syntax if possible, but will also work on a Vim version without it.
-Note that Vim9 syntax changed before Vim 9 so that scripts using the current 
+Note that Vim9 syntax changed before Vim 9 so that scripts using the current
 syntax (such as import from instead of import) might throw errors.
 To prevent these, a safer check could be for v:version >= 900 instead.
 

--- a/runtime/doc/vim9.txt
+++ b/runtime/doc/vim9.txt
@@ -1912,7 +1912,7 @@ In the |vimrc| file sourced on startup this does not happen.
 							*vim9-mix*
 There is one way to use both legacy and Vim9 syntax in one script file: >
 	" comments may go here
-	if !has('vim9script')
+	if v:version < 900
 	   " legacy script commands go here
 	   finish
 	endif

--- a/runtime/doc/vim9.txt
+++ b/runtime/doc/vim9.txt
@@ -1912,7 +1912,7 @@ In the |vimrc| file sourced on startup this does not happen.
 							*vim9-mix*
 There is one way to use both legacy and Vim9 syntax in one script file: >
 	" comments may go here
-	if v:version < 900
+	if !has('vim9script')
 	   " legacy script commands go here
 	   finish
 	endif
@@ -1920,6 +1920,9 @@ There is one way to use both legacy and Vim9 syntax in one script file: >
 	# Vim9 script commands go here
 This allows for writing a script that takes advantage of the Vim9 script
 syntax if possible, but will also work on a Vim version without it.
+Note that Vim9 syntax changed before Vim 9 so that scripts using the current 
+syntax (such as import from instead of import) might throw errors.
+To prevent these, a safer check could be for v:version >= 900 instead.
 
 This can only work in two ways:
 1. The "if" statement evaluates to false, the commands up to `endif` are


### PR DESCRIPTION
Vim9 syntax changed before Vim 9 leading to errors thrown if checked for availability of Vim9script in Vim Version 8.2 such as [0]. This check seems to work as well and throws less errors on Vim 8.2 such as on Ubuntu 22.04

[0]: https://github.com/bfrg/vim-qf-diagnostics/issues/2