### PR TITLE
runtime(man): don't add jumps when loading a manpage

### DIFF
--- a/runtime/autoload/dist/man.vim
+++ b/runtime/autoload/dist/man.vim
@@ -188,7 +188,7 @@ func dist#man#GetPage(cmdmods, ...)
   setl buftype=nofile noswapfile
 
   setl fdc=0 ma nofen nonu nornu
-  %delete _
+  keepjumps %delete _
   let unsetwidth = 0
   if empty($MANWIDTH)
     let $MANWIDTH = winwidth(0)
@@ -218,10 +218,10 @@ func dist#man#GetPage(cmdmods, ...)
   endif
   " Remove blank lines from top and bottom.
   while line('$') > 1 && getline(1) =~ '^\s*$'
-    1delete _
+    keepjumps 1delete _
   endwhile
   while line('$') > 1 && getline('$') =~ '^\s*$'
-    $delete _
+    keepjumps $delete _
   endwhile
   1
   setl ft=man nomod


### PR DESCRIPTION
Without this change, pressing K while in one manpage to load another one, then pressing CTRL-O to go back, results in going to the bottom of the current (second) manpage. With this change, it goes back to the previous manpage.

I reached out to the maintainers first (though it was about a different change to runtime/ftplugin/man.vim), and one of them asked me to make a PR.