### PR TITLE
test: override existing file in Test_complete_cmdline()

### DIFF
--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -1179,8 +1179,8 @@ func Test_complete_cmdline()
   call assert_equal('abcxyz(', getline(3))
   com! -buffer TestCommand1 echo 'TestCommand1'
   com! -buffer TestCommand2 echo 'TestCommand2'
-  write TestCommand1Test
-  write TestCommand2Test
+  write! TestCommand1Test
+  write! TestCommand2Test
   " Test repeating <CTRL-X> <CTRL-V> and switching to another CTRL-X mode
   exe "normal oT\<C-X>\<C-V>\<C-X>\<C-V>\<C-X>\<C-F>\<Esc>"
   call assert_equal('TestCommand2Test', getline(4))


### PR DESCRIPTION
Problem: when 'TestCommand1Test' or 'TestCommand2Test' file exists, `Test_complete_cmdline()` will fail because cannot write the file. And there's no related cleaning operation for this file before the test run.

Solution: modify `write` to `write!` to override.