### PR TITLE
runtime(filetype): add tera filetype

### DIFF
--- a/.github/MAINTAINERS
+++ b/.github/MAINTAINERS
@@ -296,6 +296,7 @@ runtime/ftplugin/swig.vim		@jmarrec
 runtime/ftplugin/tap.vim		@petdance
 runtime/ftplugin/tcsh.vim		@dkearns
 runtime/ftplugin/terraform.vim		@JannoTjarks
+runtime/ftplugin/tera.vim		@MuntasirSZN
 runtime/ftplugin/tf.vim			@ribru17
 runtime/ftplugin/thrift.vim		@jiangyinzuo
 runtime/ftplugin/tiasm.vim		@Freed-Wu

--- a/.github/MAINTAINERS
+++ b/.github/MAINTAINERS
@@ -295,8 +295,8 @@ runtime/ftplugin/systemverilog.vim	@Kocha
 runtime/ftplugin/swig.vim		@jmarrec
 runtime/ftplugin/tap.vim		@petdance
 runtime/ftplugin/tcsh.vim		@dkearns
-runtime/ftplugin/terraform.vim		@JannoTjarks
 runtime/ftplugin/tera.vim		@MuntasirSZN
+runtime/ftplugin/terraform.vim		@JannoTjarks
 runtime/ftplugin/tf.vim			@ribru17
 runtime/ftplugin/thrift.vim		@jiangyinzuo
 runtime/ftplugin/tiasm.vim		@Freed-Wu

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -2607,6 +2607,9 @@ au BufNewFile,BufRead *.ti			setf terminfo
 " Terraform variables
 au BufRead,BufNewFile *.tfvars			setf terraform-vars
 
+" Tera
+au BufRead,BufNewFile *.tera			setf tera
+
 " TeX
 au BufNewFile,BufRead *.latex,*.sty,*.dtx,*.ltx,*.bbl	setf tex
 au BufNewFile,BufRead *.tex			call dist#ft#FTtex()

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -2604,11 +2604,11 @@ au BufRead,BufNewFile *.ttl
 " Terminfo
 au BufNewFile,BufRead *.ti			setf terminfo
 
-" Terraform variables
-au BufRead,BufNewFile *.tfvars			setf terraform-vars
-
 " Tera
 au BufRead,BufNewFile *.tera			setf tera
+
+" Terraform variables
+au BufRead,BufNewFile *.tfvars			setf terraform-vars
 
 " TeX
 au BufNewFile,BufRead *.latex,*.sty,*.dtx,*.ltx,*.bbl	setf tex

--- a/runtime/ftplugin/tera.vim
+++ b/runtime/ftplugin/tera.vim
@@ -1,0 +1,13 @@
+" Vim filetype plugin file
+" Language:             tera
+" Previous Maintainer:  Muntasir Mahmud <muntasir.joypurhat@gmail.com>
+" Latest Revision:      2025-03-06
+
+if exists("b:did_ftplugin")
+  finish
+endif
+let b:did_ftplugin = 1
+
+setlocal commentstring={#\ %s\ #}
+
+let b:undo_ftplugin = "setlocal commentstring<"

--- a/runtime/ftplugin/tera.vim
+++ b/runtime/ftplugin/tera.vim
@@ -1,6 +1,6 @@
 " Vim filetype plugin file
 " Language:             tera
-" Previous Maintainer:  Muntasir Mahmud <muntasir.joypurhat@gmail.com>
+" Maintainer:           Muntasir Mahmud <muntasir.joypurhat@gmail.com>
 " Latest Revision:      2025-03-06
 
 if exists("b:did_ftplugin")

--- a/runtime/ftplugin/tera.vim
+++ b/runtime/ftplugin/tera.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin file
-" Language:             tera
+" Language:             Tera
 " Maintainer:           Muntasir Mahmud <muntasir.joypurhat@gmail.com>
-" Latest Revision:      2025-03-06
+" Last Change:          2025 Mar 06
 
 if exists("b:did_ftplugin")
   finish

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -804,6 +804,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     teal: ['file.tl'],
     templ: ['file.templ'],
     template: ['file.tmpl'],
+    tera: ['file.tera'],
     teraterm: ['file.ttl'],
     terminfo: ['file.ti'],
     'terraform-vars': ['file.tfvars'],


### PR DESCRIPTION
Tera is a templating language. For more info, see:

https://keats.github.io/tera/

## Checklist
 
* [x]  to add a new [filetype test](https://github.com/vim/vim/blob/master/src/testdir/test_filetype.vim) (keep it similar to the other filetype tests).
* [x]  all configuration switches should be documented (check [filetype.txt](https://github.com/vim/vim/blob/master/runtime/doc/filetype.txt) and/or [syntax.txt](https://github.com/vim/vim/blob/master/runtime/doc/syntax.txt) for filetype and syntax plugins)
* [x]  add yourself as Maintainer to the top of file (again, keep the header similar to other runtime files)
* [x]  add yourself to the [MAINTAINERS](https://github.com/vim/vim/blob/master/.github/MAINTAINERS) file.