### PR TITLE
No cmdline completion for 'completefuzzycollect'

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2135,10 +2135,10 @@ A jump table for the options with a short description can be found at |Q_op|.
 	   fuzzy    Enable |fuzzy-matching| for completion candidates. This
 		    allows for more flexible and intuitive matching, where
 		    characters can be skipped and matches can be found even
-		    if the exact sequence is not typed. Note: This option
+		    if the exact sequence is not typed.  Note: This option
 		    does not affect the collection of candidate list, it only
 		    controls how completion candidates are reduced from the
-		    list of alternatives. If you want to use |fuzzy-matching|
+		    list of alternatives.  If you want to use |fuzzy-matching|
 		    to gather more alternatives for your candidate list,
 		    see |'completefuzzycollect'|.
 

--- a/runtime/optwin.vim
+++ b/runtime/optwin.vim
@@ -1,7 +1,7 @@
 " These commands create the option window.
 "
 " Maintainer:	The Vim Project <https://github.com/vim/vim>
-" Last Change:	2025 Feb 08
+" Last Change:	2025 Mar 07
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " If there already is an option window, jump to that one.
@@ -849,7 +849,7 @@ if has("insert_expand")
   call <SID>AddOption("complete", gettext("specifies how Insert mode completion works for CTRL-N and CTRL-P"))
   call append("$", "\t" .. s:local_to_buffer)
   call <SID>OptionL("cfc")
-  call <SID>AddOption("completefuzzycollect", gettext("using fuzzy collect for defaule completion mode"))
+  call <SID>AddOption("completefuzzycollect", gettext("use fuzzy collection for specific completion modes"))
   call <SID>OptionL("cpt")
   call <SID>AddOption("completeopt", gettext("whether to use a popup menu for Insert mode completion"))
   call <SID>OptionL("cot")

--- a/src/optiondefs.h
+++ b/src/optiondefs.h
@@ -656,7 +656,7 @@ static struct vimoption options[] =
 #endif
 			    SCTX_INIT},
     {"completefuzzycollect", "cfc", P_STRING|P_VI_DEF|P_ONECOMMA|P_NODUP,
-			    (char_u *)&p_cfc, PV_NONE, did_set_completefuzzycollect, NULL,
+			    (char_u *)&p_cfc, PV_NONE, did_set_completefuzzycollect, expand_set_completefuzzycollect,
 			    {(char_u *)"", (char_u *)0L}
 			    SCTX_INIT},
     {"completeitemalign", "cia", P_STRING|P_VI_DEF|P_ONECOMMA|P_NODUP,

--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -1659,6 +1659,20 @@ did_set_completefuzzycollect(optset_T *args UNUSED)
     return NULL;
 }
 
+    int
+expand_set_completefuzzycollect(
+	optexpand_T *args,
+	int *numMatches,
+	char_u ***matches)
+{
+    return expand_set_opt_string(
+	    args,
+	    p_cfc_values,
+	    ARRAY_LENGTH(p_cfc_values) - 1,
+	    numMatches,
+	    matches);
+}
+
 /*
  * The 'completeitemalign' option is changed.
  */

--- a/src/proto/optionstr.pro
+++ b/src/proto/optionstr.pro
@@ -44,6 +44,7 @@ char *did_set_completeopt(optset_T *args);
 int expand_set_completeopt(optexpand_T *args, int *numMatches, char_u ***matches);
 char *did_set_completeitemalign(optset_T *args);
 char *did_set_completefuzzycollect(optset_T *args);
+int expand_set_completefuzzycollect(optexpand_T *args, int *numMatches, char_u ***matches);
 char *did_set_completepopup(optset_T *args);
 char *did_set_completeslash(optset_T *args);
 int expand_set_completeslash(optexpand_T *args, int *numMatches, char_u ***matches);

--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -501,6 +501,7 @@ func Test_set_completion_string_values()
   endif
   call assert_equal('.', getcompletion('set complete=', 'cmdline')[1])
   call assert_equal('menu', getcompletion('set completeopt=', 'cmdline')[1])
+  call assert_equal('keyword', getcompletion('set completefuzzycollect=', 'cmdline')[0])
   if exists('+completeslash')
     call assert_equal('backslash', getcompletion('set completeslash=', 'cmdline')[1])
   endif


### PR DESCRIPTION
Problem:  No cmdline completion for the 'completefuzzycollect' option.
Solution: Add cmdline completion for the 'completefuzzycollect' option.
          Improve its description in optwin.vim.