### PR TITLE
IDX_KEYNAME_TAB is not needed

### DIFF
--- a/src/misc2.c
+++ b/src/misc2.c
@@ -930,7 +930,6 @@ static char_u modifier_keys_table[] =
 #define IDX_KEYNAME_NL 101
 #define IDX_KEYNAME_SWD 115
 #define IDX_KEYNAME_SWU 118
-#define IDX_KEYNAME_TAB 124
 
 #define STRING_INIT(s) \
     {(char_u *)(s), STRLEN_LITERAL(s)}
@@ -1065,7 +1064,7 @@ static struct key_name_entry
     {TRUE, K_MIDDLERELEASE, STRING_INIT("MiddleRelease"), NULL},
     {TRUE, K_MOUSE, STRING_INIT("Mouse"), NULL},
     {TRUE, K_MOUSEDOWN, STRING_INIT("MouseDown"),
-	&key_names_table[IDX_KEYNAME_SWU].name},		    // OBSOLETE: Use ScrollWheelUP instead
+	&key_names_table[IDX_KEYNAME_SWU].name},		    // OBSOLETE: Use ScrollWheelUp instead
     {TRUE, K_MOUSEMOVE, STRING_INIT("MouseMove"), NULL},
     {TRUE, K_MOUSEUP, STRING_INIT("MouseUp"),
 	&key_names_table[IDX_KEYNAME_SWD].name},		    // OBSELETE: Use ScrollWheelDown instead
@@ -1114,8 +1113,7 @@ static struct key_name_entry
 	K_SNR, STRING_INIT("SNR"), NULL},
     {TRUE, ' ', STRING_INIT("Space"), NULL},
     {TRUE, TAB, STRING_INIT("Tab"), NULL},
-    {TRUE, K_TAB, STRING_INIT("Tab"),
-	&key_names_table[IDX_KEYNAME_TAB].name},
+    {TRUE, K_TAB, STRING_INIT("Tab"), NULL},
     {TRUE, K_UNDO, STRING_INIT("Undo"), NULL},
     {TRUE, K_UP, STRING_INIT("Up"), NULL},
     {


### PR DESCRIPTION
Problem:  IDX_KEYNAME_TAB is not needed as TAB and K_TAB have the same
          name.
Solution: Remove IDX_KEYNAME_TAB.
