### PR TITLE
filetype: help files in git repos are not detected

### DIFF
--- a/runtime/doc/todo.txt
+++ b/runtime/doc/todo.txt
@@ -6276,5 +6276,4 @@ Far future and "big" extensions:
     are reflected in each Vim immediately.  Could work with local files but
     also over the internet.  See http://www.codingmonkeys.de/subethaedit/.
 
-vim:tw=78:sw=4:sts=4:ts=8:noet:ft=help:norl:
-vim: set fo+=n :
+vim:tw=78:sw=4:sts=4:ts=8:noet:ft=help:norl:fo+=n:

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -52,7 +52,10 @@ func s:StarSetf(ft)
 endfunc
 
 " Vim help file
-au BufNewFile,BufRead $VIMRUNTIME/doc/*.txt	setf help
+au BufNewFile,BufRead */doc/*.txt
+	\  if getline('$') =~ 'vim:.*\<\(ft\|filetype\)=help\>'
+	\|   setf help
+	\| endif
 
 " Abaqus or Trasys
 au BufNewFile,BufRead *.inp			call dist#ft#Check_inp()

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -919,8 +919,6 @@ def s:GetFilenameChecks(): dict<list<string>>
           '.zcompdump', '.zlogin', '.zlogout', '.zshenv', '.zshrc', '.zsh_history',
           '.zcompdump-file', '.zlog', '.zlog-file', '.zsh', '.zsh-file',
           'any/etc/zprofile', 'zlog', 'zlog-file', 'zsh', 'zsh-file'],
-
-    help: [$VIMRUNTIME .. '/doc/help.txt'],
     }
 enddef
 
@@ -1622,6 +1620,23 @@ func Test_haredoc_file()
   bwipe!
   unlet g:filetype_haredoc
   unlet g:haredoc_search_depth
+
+  filetype off
+endfunc
+
+func Test_help_file()
+  filetype on
+  call assert_true(mkdir('doc', 'pR'))
+
+  call writefile(['some text', 'vim:ft=help:'], 'doc/help.txt', 'D')
+  split doc/help.txt
+  call assert_equal('help', &filetype)
+  bwipe!
+
+  call writefile(['some text'], 'doc/nothelp.txt', 'D')
+  split doc/nothelp.txt
+  call assert_notequal('help', &filetype)
+  bwipe!
 
   filetype off
 endfunc


### PR DESCRIPTION
Problem:  filetype: help files in git repos are not detected

Solution: detect `*/doc/*.txt` files as help if they end with a help modeline, even if 'modeline' is off

Here's how I checked that this would still detect vim's own help files
correctly:

```
$ find . -type f -path '*/doc/*.txt' \
> -exec awk '{ } ENDFILE { print FILENAME ":" $0; }' '{}' + |
> grep -v 'vim:.*\<\(ft\|filetype\)=help\>'
./src/libvterm/doc/seqs.txt: 23    DECSM 42         = DECNRCM, national/multinational character
```