### PR TITLE
runtime(nohlsearch): fix CursorHold loop

### DIFF
--- a/runtime/pack/dist/opt/nohlsearch/plugin/nohlsearch.vim
+++ b/runtime/pack/dist/opt/nohlsearch/plugin/nohlsearch.vim
@@ -1,5 +1,5 @@
 " nohlsearch.vim: Auto turn off hlsearch
-" Last Change: 2024-07-31
+" Last Change: 2025-03-08
 " Maintainer: Maxim Kim <habamax@gmail.com>
 "
 " turn off hlsearch after:
@@ -11,10 +11,14 @@ if exists('g:loaded_nohlsearch')
 endif
 let g:loaded_nohlsearch = 1
 
+func! s:Nohlsearch()
+    if v:hlsearch
+        call feedkeys("\<cmd>nohlsearch\<cr>", 'm')
+    endif
+endfunc
+
 augroup nohlsearch
     au!
-    noremap <Plug>(nohlsearch) <cmd>nohlsearch<cr>
-    noremap! <Plug>(nohlsearch) <cmd>nohlsearch<cr>
-    au CursorHold * call feedkeys("\<Plug>(nohlsearch)", 'm')
-    au InsertEnter * call feedkeys("\<Plug>(nohlsearch)", 'm')
+    au CursorHold * call s:Nohlsearch()
+    au InsertEnter * call s:Nohlsearch()
 augroup END


### PR DESCRIPTION
```
au CursorHold * call feedkeys("\<Plug>(nohlsearch)", 'm')
```

`feedkeys` would trigger the CursorHold event, thus coming into a loop. It causes other plugins with this event to take up a lot of CPU.

This PR adds a CursorMoved check to avoid the loop.