### PR TITLE
Problem: Vim script default argument expression error handling postponed

### DIFF
--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -3275,7 +3275,7 @@ call_user_func(
     save_did_emsg = did_emsg;
     did_emsg = FALSE;
 
-    if (default_arg_err && (fp->uf_flags & FC_ABORT))
+    if (default_arg_err)
     {
 	did_emsg = TRUE;
 	retval = FCERR_FAILED;


### PR DESCRIPTION
Solution: Do not begin execution of function body after an error in evaluating an expression for a default argument value.

Unexpected behaviour prior to this commit:
- An error would sometimes not be caught by the first :catch, but could be caught by a second :catch.
- Vim would begin to execute the body of the function called after an error due to a default argument expression. (The number of commands in the function body that Vim would attempt to execute would depend on the cause of the default argument expression error - sometimes only the first command of the function would be executed, and other times Vim would execute the whole function.)