### PR TITLE
fix: move ptr to line_end when pattern not found

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -217,7 +217,6 @@ static int ins_compl_add(char_u *str, int len, char_u *fname, char_u **cptext, t
 static void ins_compl_longest_match(compl_T *match);
 static void ins_compl_del_pum(void);
 static void ins_compl_files(int count, char_u **files, int thesaurus, int flags, regmatch_T *regmatch, char_u *buf, int *dir);
-static char_u *find_line_end(char_u *ptr);
 static void ins_compl_free(void);
 static int  ins_compl_need_restart(void);
 static void ins_compl_new_leader(void);
@@ -1870,8 +1869,6 @@ ins_compl_files(
 				&& score == compl_first_match->cp_next->cp_score)
 			    compl_num_bests++;
 		    }
-		    else if (find_word_end(ptr) == line_end)
-			break;
 		}
 	    }
 	    line_breakcheck();
@@ -1927,7 +1924,7 @@ find_word_end(char_u *ptr)
  * Find the end of the line, omitting CR and NL at the end.
  * Returns a pointer to just after the line.
  */
-    static char_u *
+    char_u *
 find_line_end(char_u *ptr)
 {
     char_u	*s;

--- a/src/proto/insexpand.pro
+++ b/src/proto/insexpand.pro
@@ -65,4 +65,6 @@ int ins_compl_col_range_attr(linenr_T lnum, int col);
 void free_insexpand_stuff(void);
 int ins_compl_preinsert_effect(void);
 int ins_compl_lnum_in_range(linenr_T lnum);
+char_u *find_line_end(char_u *ptr);
+
 /* vim: set ft=c : */

--- a/src/search.c
+++ b/src/search.c
@@ -5229,8 +5229,7 @@ fuzzy_match_str_with_pos(char_u *str UNUSED, char_u *pat UNUSED)
  * - `*len` is set to the length of the matched word.
  * - `*score` contains the match score.
  *
- * If no match is found, `*ptr` is updated to point beyond the last word
- * or to the end of the line.
+ * If no match is found, `*ptr` is updated to to the end of the line.
  */
     int
 fuzzy_match_str_in_line(
@@ -5246,11 +5245,13 @@ fuzzy_match_str_in_line(
     char_u	*start = NULL;
     int		found = FALSE;
     char	save_end;
+    char_u	*line_end = NULL;
 
     if (str == NULL || pat == NULL)
         return found;
+    line_end = find_line_end(str);
 
-    while (*str != NUL)
+    while (str < line_end)
     {
 	// Skip non-word characters
 	start = find_word_start(str);
@@ -5282,6 +5283,9 @@ fuzzy_match_str_in_line(
 	while (*str != NUL && !vim_iswordp(str))
 	    MB_PTR_ADV(str);
     }
+
+    if (!found)
+	*ptr = line_end;
 
     return found;
 }

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -3005,6 +3005,11 @@ func Test_cfc_with_longest()
   call writefile(['  auto int   enum register', 'why'], 'test_case4.txt', 'D')
   exe "normal ggdGSe\<C-N>\<C-N>\<ESC>"
   call assert_equal("enum", getline('.'))
+
+  set complete=ktest_case5.txt
+  call writefile(['hello friends', 'go', 'hero'], 'test_case5.txt', 'D')
+  exe "normal ggdGSh\<C-N>\<C-N>\<ESC>"
+  call assert_equal("hero", getline('.'))
   set complete&
 
   " file


### PR DESCRIPTION
Problem: when pattern not fuzzy match in line the ptr does not moved.

Solution: when nothing found move it to end of line