### PR TITLE
if_python: fix incompatible pointer types in RangeDestructor

### DIFF
--- a/src/if_py_both.h
+++ b/src/if_py_both.h
@@ -5397,7 +5397,7 @@ RangeDestructor(PyObject *self_obj)
 {
     RangeObject *self = (RangeObject*)self_obj;
     PyObject_GC_UnTrack((void *)(self));
-    Py_XDECREF(self->buf);
+    Py_XDECREF(((PyObject *)(self->buf)));
     PyObject_GC_Del((void *)(self));
 }
 


### PR DESCRIPTION
Avoid build failure due to -Wincompatible-pointer-types becoming an error in gcc 14.
When Py_LIMITED_API is < 0x030b0000, then the for Py_XDECREF must be PyObject*.
Vim targets Py_LIMITED_API = 0x03080000 (python 3.8).