### PR TITLE
runtime(doc): use GNOME instead of Gnome

### DIFF
--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -88,9 +88,9 @@ CTRL-SHIFT-V				*c_CTRL-SHIFT-V* *c_CTRL-SHIFT-Q*
 CTRL-SHIFT-Q	Works just like CTRL-V, unless |modifyOtherKeys| is active,
 		then it inserts the Escape sequence for a key with modifiers.
 		In the GUI the |key-notation| is inserted without simplifying.
-		Note: When CTRL-SHIFT-V is intercepted by your system
-		(e.g., to paste text) you can often use CTRL-SHIFT-Q instead.
-		However, in some terminals (e.g. Gnome Terminal), CTRL-SHIFT-Q
+		Note: When CTRL-SHIFT-V is intercepted by your system (e.g.,
+		to paste text) you can often use CTRL-SHIFT-Q instead.
+		However, in some terminals (e.g. GNOME Terminal), CTRL-SHIFT-Q
 		quits the terminal without confirmation.
 
 							*c_<Left>* *c_Left*

--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -224,7 +224,7 @@ CTRL-SHIFT-Q	Works just like CTRL-V, unless |modifyOtherKeys| is active,
 		then it inserts the Escape sequence for a key with modifiers.
 		Note: When CTRL-SHIFT-V is intercepted by your system (e.g.,
 		to paste text) you can often use CTRL-SHIFT-Q instead.
-		However, in some terminals (e.g. Gnome Terminal), CTRL-SHIFT-Q
+		However, in some terminals (e.g. GNOME Terminal), CTRL-SHIFT-Q
 		quits the terminal without confirmation.
 
 CTRL-X		Enter CTRL-X mode.  This is a sub-mode where commands can


### PR DESCRIPTION
It's called "GNOME Terminal" in https://gitlab.gnome.org/GNOME/gnome-terminal
It's also called GNOME Terminal in English Wikipedia https://en.wikipedia.org/wiki/GNOME_Terminal
and the Wikipedia pages of 8 other languages.

Also, make line wrapping the same in insert.txt and cmdline.txt.
