### PR TITLE
tests: test for patch 9.1.1186 doesn't fail without the patch

### DIFF
--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -663,8 +663,8 @@ Also see the 'infercase' option if you want to adjust the case of the match.
 
 When inserting a selected candidate word from the |popup-menu|, the part of
 the candidate word that does not match the query is highlighted using
-|hl-ComplMatchIns|. If fuzzy is enabled in 'completopt', highlighting will not
-be applied.
+|hl-ComplMatchIns|.  If fuzzy is enabled in 'completeopt', highlighting will
+not be applied.
 
 							*complete_CTRL-E*
 When completion is active you can use CTRL-E to stop it and go back to the

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -1625,6 +1625,7 @@ func Test_haredoc_file()
 endfunc
 
 func Test_help_file()
+  set nomodeline
   filetype on
   call assert_true(mkdir('doc', 'pR'))
 
@@ -1639,6 +1640,7 @@ func Test_help_file()
   bwipe!
 
   filetype off
+  set modeline&
 endfunc
 
 func Test_hook_file()


### PR DESCRIPTION
Problem:  Test for patch 9.1.1186 doesn't fail without the patch.
Solution: Set 'nomodeline' in the test.
