### PR TITLE
syntax config for plsql moves fold option settings from syntax to ftplugin

### DIFF
--- a/runtime/ftplugin/plsql.vim
+++ b/runtime/ftplugin/plsql.vim
@@ -1,0 +1,23 @@
+" Vim ftplugin file
+" Language: Oracle Procedural SQL (PL/SQL)
+" Maintainer: Lee Lindley (lee dot lindley at gmail dot com)
+" Previous Maintainer: Jeff Lanzarotta (jefflanzarotta at yahoo dot com)
+" Previous Maintainer: C. Laurence Gonsalves (clgonsal@kami.com)
+" URL: https://github.com/lee-lindley/vim_plsql_syntax
+" Last Change: Feb 19, 2025
+" History:  Enno Konfekt move handling of optional syntax folding from syntax
+"               file to ftplugin
+
+if exists("b:did_ftplugin") | finish | endif
+let b:did_ftplugin = 1
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+if get(g:,"plsql_fold",0) == 1
+    setlocal foldmethod=syntax
+    let b:undo_ftplugin = "setl fdm< "
+endif
+
+let &cpo = s:cpo_save
+unlet s:cpo_save

--- a/runtime/syntax/plsql.vim
+++ b/runtime/syntax/plsql.vim
@@ -694,7 +694,6 @@ syn region plsqlSqlPlusCommand  start="^\(SET\|DEFINE\|PROMPT\|ACCEPT\|EXEC\|HOS
 syn region plsqlSqlPlusRunFile  start="^\(@\|@@\)" skip="\\$" end="$" keepend extend
 
 if get(g:,"plsql_fold",0) == 1
-    setlocal foldmethod=syntax
     syn sync fromstart
 
     syn cluster plsqlProcedureGroup contains=plsqlProcedure


### PR DESCRIPTION
As the maintainer of syntax files for "plsql", I incorporated an optimization contributed by Enno Konfekt to move fold option settings from syntax file to ftplugin. The syntax files and documentation are maintained in https://github.com/lee-lindley/vim_plsql_syntax as noted in the file header comments.
Regression testing shows no change to the observed functionality from the prior release.