### PR TITLE
runtime(man): improve :Man completion for man-db

### DIFF
--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -776,7 +776,7 @@ Local mappings:
 	to the end of the file in Normal mode.  This means "> " is inserted in
 	each line.
 
-MAN					*ft-man-plugin* *:Man* *man.vim*
+MAN					*ft-man-plugin* *:Man* *:ManReload* *man.vim*
 
 This plugin displays a manual page in a nice way.  See |find-manpage| in the
 user manual for more information.
@@ -793,6 +793,8 @@ Commands:
 Man {name}	Display the manual page for {name} in a window.
 Man {number} {name}
 		Display the manual page for {name} in a section {number}.
+ManReload	Reload the cache of available man pages used for |:Man| argument
+		completion.
 
 Global mapping:
 <Leader>K	Displays the manual page for the word under the cursor.
@@ -823,6 +825,14 @@ desired folding style instead.  For example: >
 If you would like :Man {number} {name} to behave like man {number} {name} by
 not running man {name} if no page is found, then use this: >
 	let g:ft_man_no_sect_fallback = 1
+<
+						*g:ft_man_implementation*
+The completion for the :Man command tries to guess which implementation of man
+the system has. If it guesses wrong, you can set g:ft_man_implementation to
+one of these values:
+	'man-db'	https://man-db.nongnu.org/
+	''		Unknown, fall back to completing shell commands
+			instead of man pages.
 
 You may also want to set 'keywordprg' to make the |K| command open a manual
 page in a Vim window: >

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -2142,6 +2142,7 @@ $quote	eval.txt	/*$quote*
 :Lfilter	quickfix.txt	/*:Lfilter*
 :LogiPat	pi_logipat.txt	/*:LogiPat*
 :Man	filetype.txt	/*:Man*
+:ManReload	filetype.txt	/*:ManReload*
 :MkVimball	pi_vimball.txt	/*:MkVimball*
 :N	editing.txt	/*:N*
 :Nexplore	pi_netrw.txt	/*:Nexplore*
@@ -7581,6 +7582,7 @@ g:filetype_csh	syntax.txt	/*g:filetype_csh*
 g:filetype_haredoc	ft_hare.txt	/*g:filetype_haredoc*
 g:filetype_md	syntax.txt	/*g:filetype_md*
 g:filetype_r	syntax.txt	/*g:filetype_r*
+g:ft_man_implementation	filetype.txt	/*g:ft_man_implementation*
 g:ftplugin_rust_source_path	ft_rust.txt	/*g:ftplugin_rust_source_path*
 g:gnat	ft_ada.txt	/*g:gnat*
 g:gnat.Error_Format	ft_ada.txt	/*g:gnat.Error_Format*


### PR DESCRIPTION
On man-db systems, complete with actual man sections and pages, instead of shell commands.

I tried to come up with a portable solution for multiple man implementations in https://github.com/vim/vim/discussions/16794 but I think the differences between implementations were too large to do that without overly complicated code. So instead, I implemented it for man-db (which I think is common on Linux) and hopefully left it easier for other people to implement it on other systems in the future if they want to.