### PR TITLE
Unnecessary use of STRCAT() in au_event_disable()

### DIFF
--- a/src/autocmd.c
+++ b/src/autocmd.c
@@ -870,7 +870,7 @@ au_event_disable(char *what)
     if (*what == ',' && *p_ei == NUL)
 	STRCPY(new_ei, what + 1);
     else
-	STRCAT(new_ei, what);
+	STRCPY(new_ei + p_ei_len, what);
     set_string_option_direct((char_u *)"ei", -1, new_ei,
 	    OPT_FREE, SID_NONE);
     vim_free(new_ei);

--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -4716,7 +4716,7 @@ open_cmdwin(void)
     State = MODE_NORMAL;
     setmouse();
 
-    // Reset here so it can be set by a CmdWinEnter autocommand.
+    // Reset here so it can be set by a CmdwinEnter autocommand.
     cmdwin_result = 0;
 
     // Trigger CmdwinEnter autocommands.

--- a/src/testdir/test_arglist.vim
+++ b/src/testdir/test_arglist.vim
@@ -554,9 +554,34 @@ endfunc
 func Test_argdo()
   next! Xa.c Xb.c Xc.c
   new
+
+  let g:bufenter = 0
+  let g:bufleave = 0
+  autocmd BufEnter * let g:bufenter += 1
+  autocmd BufLeave * let g:bufleave += 1
+
   let l = []
   argdo call add(l, expand('%'))
   call assert_equal(['Xa.c', 'Xb.c', 'Xc.c'], l)
+  call assert_equal(3, g:bufenter)
+  call assert_equal(3, g:bufleave)
+
+  let g:bufenter = 0
+  let g:bufleave = 0
+
+  set eventignore=BufEnter,BufLeave
+  let l = []
+  argdo call add(l, expand('%'))
+  call assert_equal(['Xa.c', 'Xb.c', 'Xc.c'], l)
+  call assert_equal(0, g:bufenter)
+  call assert_equal(0, g:bufleave)
+  call assert_equal('BufEnter,BufLeave', &eventignore)
+  set eventignore&
+
+  autocmd! BufEnter
+  autocmd! BufLeave
+  unlet g:bufenter
+  unlet g:bufleave
   bwipe Xa.c Xb.c Xc.c
 endfunc
 


### PR DESCRIPTION
Problem:  Unnecessary use of STRCAT() in au_event_disable().  STRCAT()
          seeks to the end of new_ei, but here the end is already known.
Solution: Use STRCPY() and add p_ei_len to new_ei.  Also fix a typo in a
          comment.  Add a test that 'eventignore' works in :argdo.
