### PR TITLE
filetype: help filetype detection may have false positives

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -53,7 +53,7 @@ endfunc
 
 " Vim help file, set ft explicitly, because 'modeline' might be off
 au BufNewFile,BufRead */doc/*.txt
-	\  if getline('$') =~ 'vim:.*\<\(ft\|filetype\)=help\>'
+	\  if getline('$') =~ '\(^\|\s\)vim:.*\<\(ft\|filetype\)=help\>'
 	\|   setf help
 	\| endif
 

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -1634,8 +1634,19 @@ func Test_help_file()
   call assert_equal('help', &filetype)
   bwipe!
 
+  call writefile(['some text', 'Copyright: |manual-copyright| vim:ft=help:'],
+        \ 'doc/help1.txt', 'D')
+  split doc/help1.txt
+  call assert_equal('help', &filetype)
+  bwipe!
+
   call writefile(['some text'], 'doc/nothelp.txt', 'D')
   split doc/nothelp.txt
+  call assert_notequal('help', &filetype)
+  bwipe!
+
+  call writefile(['some text', '`vim:ft=help`'], 'doc/nothelp1.txt', 'D')
+  split doc/nothelp1.txt
   call assert_notequal('help', &filetype)
   bwipe!
 


### PR DESCRIPTION
Problem:  filetype: help filetype detection may have false positives.
Solution: Only detect a file as help if modeline appears either at start
          of line or is preceded by whitespace.
