### PR TITLE
runtime(syntax-tests): Support "wait-free" test failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,7 @@ VIM_FOR_SYNTAXTEST = ../../src/vim
 
 # (For local testing only with GNU Make.)
 VIM_SYNTAX_TEST_FILTER =
+VIM_SYNTAX_TEST_WAIT_TIME =
 
 syntaxtest:
 	cd runtime/syntax && \

--- a/runtime/syntax/testdir/README.txt
+++ b/runtime/syntax/testdir/README.txt
@@ -117,7 +117,7 @@ Adjusting a syntax plugin test
 
 If you make changes to the syntax plugin, you should add code to the input
 file to see the effect of these changes.  So that the effect of the changes
-are covered by the test.  You can follow these steps:
+is covered by the test.  You can follow these steps:
 
 1. Edit the syntax plugin somewhere in your personal setup.  Use a file
    somewhere to try out the changes.
@@ -133,19 +133,19 @@ are covered by the test.  You can follow these steps:
    Fix the syntax plugin until the result is good.
 2. Edit the input file for your language to add the items you have improved.
    (TODO: how to add another screendump?).
-   Run the tests and you should get failures.  Like with the previous step,
-   carefully check that the new screendumps in the "failed" directory are
-   good.  Update the syntax plugin and the input file until the highlighting
-   is good and you can see the effect of the syntax plugin improvements.  Then
-   move the screendumps from the "failed" to the "dumps" directory.  Now "make
-   test" should succeed.
+   Run the tests and you should get failures.  (You may opt for faster failure
+   by assigning a small number, e.g. "1", to a VIM_SYNTAX_TEST_WAIT_TIME
+   environment variable and gambling away an "uncertain" possibility of
+   success.)  Like with the previous step, carefully check that the new
+   screendumps in the "failed" directory are good.  Update the syntax plugin
+   and the input file until the highlighting is good and you can see the
+   effect of the syntax plugin improvements.  Then move the screendumps from
+   the "failed" to the "dumps" directory.  Now "make test" should succeed.
 3. Prepare a pull request with the modified files:
 	- syntax plugin:    syntax/{name}.vim
 	- Vim setup file:   syntax/testdir/input/setup/{name}.vim (if any)
 	- test input file:  syntax/testdir/input/{name}.{ext}
-	- test dump files:  syntax/testdir/dumps/{name}_00.dump
-			    syntax/testdir/dumps/{name}_01.dump (if any)
-			    ...
+	- test dump files:  syntax/testdir/dumps/{name}_*.dump
 
 As an extra check you can temporarily put back the old syntax plugin and
 verify that the tests fail.  Then you know your changes are covered by the

--- a/runtime/syntax/testdir/runtest.vim
+++ b/runtime/syntax/testdir/runtest.vim
@@ -383,7 +383,11 @@ func RunTest()
     enddef
   END
   let MAX_FAILED_COUNT = 5
-  lockvar MAX_FAILED_COUNT XTESTSCRIPT
+  let DUMP_OPTS = exists("$VIM_SYNTAX_TEST_WAIT_TIME") &&
+	  \ !empty($VIM_SYNTAX_TEST_WAIT_TIME)
+      \ ? {'wait': max([1, str2nr($VIM_SYNTAX_TEST_WAIT_TIME)])}
+      \ : {}
+  lockvar DUMP_OPTS MAX_FAILED_COUNT XTESTSCRIPT
   let ok_count = 0
   let failed_tests = []
   let skipped_count = 0
@@ -398,8 +402,8 @@ func RunTest()
 	\ ->join('\|')
     \ : ''
 
-  " Treat "\.self-testing$" as a string NOT as a regexp.
-  if filter ==# '\.self-testing$'
+  " Treat "^self-testing" as a string NOT as a regexp.
+  if filter ==# '^self-testing'
     let dirpath = 'input/selftestdir/'
     let fnames = readdir(dirpath, {fname -> fname !~ '^README\.txt$'})
   else
@@ -472,7 +476,7 @@ func RunTest()
       let ruler = s:TermWaitAndPollRuler(buf, in_name_and_out_name)
       call ch_log('First screendump for ' .. in_name_and_out_name)
       " Make a screendump at the start of the file: failed/root_00.dump
-      let fail = VerifyScreenDump(buf, root_00, {})
+      let fail = VerifyScreenDump(buf, root_00, DUMP_OPTS)
 
       " Accommodate the next code block to "buf"'s contingency for self
       " wipe-out.
@@ -492,7 +496,7 @@ func RunTest()
 	      \ in_name_and_out_name)
 	  call ch_log('Next screendump for ' .. in_name_and_out_name)
 	  " Make a screendump of every 18 lines of the file: failed/root_NN.dump
-	  let fail += VerifyScreenDump(buf, root_next, {})
+	  let fail += VerifyScreenDump(buf, root_next, DUMP_OPTS)
 	endwhile
 	call StopVimInTerminal(buf)
       finally


### PR DESCRIPTION
When certain changes guarantee failure for old syntax tests,  
opt for faster failure by reducing the number of screendumps  
made for each file ‘page’ to be no greater than the assigned  
value of a `VIM_SYNTAX_TEST_WAIT_TIME` environment variable.  
(This variable will be ignored and more screendumps may be  
made when Make is GNU Make and a parent Makefile is used.)

Barring regressions, and assuming that `v9.1.1163~1` succeeds  
in providing a correct synchronisation mechanism outside of  
`VerifyScreenDump()`, and assuming that `readfile()` always  
obtains the latest contents written by `term_dumpwrite()` in  
`VerifyScreenDump()`; making a single screendump of a file  
‘page’ and following it with a single reading of the written  
screendump file should be enough to decide whether to pass  
or fail a syntax test.

In addition, re-enable self testing after `v9.1.1183~2`.
