### PR TITLE
runtime(doc): remove unnecessary "an"

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -7588,7 +7588,7 @@ mkdir({name} [, {flags} [, {prot}]])			*mkdir()* *E739*
 		the new directory.  The default is 0o755 (rwxr-xr-x: r/w for
 		the user, readable for others).  Use 0o700 to make it
 		unreadable for others.  This is used for the newly created
-		directories.  Note an umask is applied to {prot} (on Unix).
+		directories.  Note: umask is applied to {prot} (on Unix).
 		Example: >
 			:call mkdir($HOME .. "/tmp/foo/bar", "p", 0o700)
 


### PR DESCRIPTION
"umask" is pronounce like "youmask", so having an "an" before it is a
bit strange.  In other places in the help, "umask" is not preceded by
either "a" or "an", and sometimes preceded by "the".

Also, "Note" is usually followed either by ":" or "that" in builtin.txt,
so add a ":" after "Note".
