### PR TITLE
doc: update the highlight-yank plugin exmaple in 52.6

### DIFF
--- a/runtime/doc/usr_52.txt
+++ b/runtime/doc/usr_52.txt
@@ -1,4 +1,4 @@
-*usr_52.txt*	For Vim version 9.1.  Last change: 2024 Oct 07
+*usr_52.txt*	For Vim version 9.1.  Last change: 2025 Mar 12
 
 		     VIM USER MANUAL - by Bram Moolenaar
 
@@ -362,11 +362,10 @@ and it will be active next time you start Vim.  |add-plugin|: >
 	    endif
 	    var [beg, end] = [getpos("'["), getpos("']")]
 	    var type = v:event.regtype ?? 'v'
-	    var pos = getregionpos(beg, end, {type: type})
-	    var end_offset = (type == 'V' || v:event.inclusive) ? 1 : 0
+	    var pos = getregionpos(beg, end, {type: type, exclusive: false})
 	    var m = matchaddpos(hlgroup, pos->mapnew((_, v) => {
 	      var col_beg = v[0][2] + v[0][3]
-	      var col_end = v[1][2] + v[1][3] + end_offset
+	      var col_end = v[1][2] + v[1][3] + 1
 	      return [v[0][1], col_beg, col_end - col_beg]
 	    }))
 	    var winid = win_getid()


### PR DESCRIPTION
Problem: 
the highlight-yank plugin exmaple provided in the doc behaves incorrectly when selection is set to exclusive.

Solution: 
use a unified offset of 1 and pass 'exclusive: false' to getregionpos()

Related: #15276 #16772