### PR TITLE
GitHub Actions doesn't show why indent tests failed

### DIFF
--- a/runtime/indent/Makefile
+++ b/runtime/indent/Makefile
@@ -10,7 +10,16 @@ VIMRUNTIME = ..
 # If a test succeeds a testdir/*.out file will be written.
 # If a test fails a testdir/*.fail file will be written.
 test:
-	VIMRUNTIME=$(VIMRUNTIME) $(VIMPROG) --clean --not-a-term -u testdir/runtest.vim
+	VIMRUNTIME=$(VIMRUNTIME) $(VIMPROG) --clean --not-a-term -u testdir/runtest.vim || \
+		{ \
+			retval=$$?; \
+			for fail in testdir/*.fail; do \
+				[ -f "$$fail" ] || continue; \
+				echo "$$fail:"; \
+				cat "$$fail"; \
+			done; \
+			exit $$retval; \
+		}
 	@echo "INDENT TESTS: DONE"
 
 


### PR DESCRIPTION
Problem:  GitHub Actions doesn't show why indent tests failed
Solution: Send the .fail files to stdout

References:
https://github.com/vim/vim/pull/16852#issuecomment-2719041781