### PR TITLE
runtime(doc): make :h 'completefuzzycollect' a bit clearer

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2107,11 +2107,11 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'completefuzzycollect'* *'cfc'*
 'completefuzzycollect' 'cfc'	string	(default: empty)
 				global
-	A comma-separated list of option enables fuzzy collection for specific
-	|ins-completion| modes, affecting how items are gathered during
-	completion. When set, fuzzy matching is used to find completion
-	candidates instead of the standard prefix-based matching. This option
-	can contain the following values are:
+	A comma-separated list of strings to enable fuzzy collection for
+	specific |ins-completion| modes, affecting how matches are gathered
+	during completion.  For specified modes, fuzzy matching is used to
+	find completion candidates instead of the standard prefix-based
+	matching.  This option can contain the following values:
 
 	keyword		keywords in the current file |i_CTRL-X_CTRL-N|
 			keywords with the ".", "w", "b", "u", "U" and


### PR DESCRIPTION
- Fix grammar
- Use "matches" instead of "items" ("completion candidates" is used in
  some other places, but it's a bit verbose)
- "When set" is a bit vague, instead use "For specified modes"
