### PR TITLE
runtime(pacmanlog): detect logrotate’d pacmanlog

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1814,7 +1814,7 @@ au BufNewFile,BufRead *.hook
 au BufNewFile,BufRead {.,}makepkg.conf			setf sh
 
 " Pacman log
-au BufNewFile,BufRead pacman.log			setf pacmanlog
+au BufRead pacman.log*					call s:StarSetf('pacmanlog')
 
 " Pam conf
 au BufNewFile,BufRead */etc/pam.conf			setf pamconf

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -574,7 +574,6 @@ def s:GetFilenameChecks(): dict<list<string>>
     opl: ['file.OPL', 'file.OPl', 'file.OpL', 'file.Opl', 'file.oPL', 'file.oPl', 'file.opL', 'file.opl'],
     ora: ['file.ora'],
     org: ['file.org', 'file.org_archive'],
-    pacmanlog: ['pacman.log'],
     pamconf: ['/etc/pam.conf', '/etc/pam.d/file', 'any/etc/pam.conf', 'any/etc/pam.d/file'],
     pamenv: ['/etc/security/pam_env.conf', '/home/user/.pam_environment', '.pam_environment', 'pam_env.conf'],
     pandoc: ['file.pandoc', 'file.pdk', 'file.pd', 'file.pdc'],
@@ -2871,6 +2870,18 @@ func Test_org_file()
   split Xfile.org
   call assert_equal('org', &filetype)
 
+  filetype off
+endfunc
+
+" Filetypes detected from names of existing files
+func Test_pacmanlog()
+  filetype on
+  for fname in ['pacman.log', 'pacman.log.1', 'pacman.log-20250123']
+    call writefile(["[2025-01-23T01:23:45+0000] [PACMAN] Running 'pacman -S -y --config /etc/pacman.conf --'"], fname, 'D')
+    exe 'split ' .. fname
+    call assert_equal('pacmanlog', &filetype, 'for text: ' .. string(fname))
+    bwipe!
+  endfor
   filetype off
 endfunc
 


### PR DESCRIPTION
At the moment logrotate’d pacman.log files—`pacman.log.1`, `pacman.log-20250101`, etc—are not detected as pacmanlog.
