### PR TITLE
fix: cmdline pum does not close when completion in input

### DIFF
--- a/src/cmdexpand.c
+++ b/src/cmdexpand.c
@@ -423,9 +423,22 @@ cmdline_pum_remove(void)
 {
     int save_p_lz = p_lz;
     int	save_KeyTyped = KeyTyped;
+    cmdline_info_T *ccline = get_cmdline_info();
+    int save_RedrawingDisabled = RedrawingDisabled;
 
     pum_undisplay();
     VIM_CLEAR(compl_match_array);
+
+#ifdef FEAT_EVAL
+    if (RedrawingDisabled && ccline->input_fn)
+    {
+        RedrawingDisabled = 0;
+        update_screen(0);
+        RedrawingDisabled = save_RedrawingDisabled;
+    }
+    else
+#endif
+        update_screen(0);
     p_lz = FALSE;  // avoid the popup menu hanging around
     update_screen(0);
     p_lz = save_p_lz;

--- a/src/testdir/test_menu.vim
+++ b/src/testdir/test_menu.vim
@@ -650,4 +650,21 @@ func Test_popupmenu_cmdline()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_popupmenu_cmdline_input()
+  CheckRunVimInTerminal
+  let lines =<< trim END
+    set wildmenu
+    set wildoptions=pum
+  END
+  call writefile(lines, 'Xpopupcmdline_input', 'D')
+  let buf = RunVimInTerminal('-S Xpopupcmdline_input', {})
+
+  call term_sendkeys(buf, ":call input('', '', 'command')\<CR>")
+  call TermWait(buf, 50)
+  call term_sendkeys(buf, "ech\<TAB> ")
+  call VerifyScreenDump(buf, 'Test_popupmenu_cmdline_2', {})
+
+  call StopVimInTerminal(buf)
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem: when expand completion for command, input does not close pum

Soution: temporary disable RedrawingDisabled when have pum for input