### PR TITLE
Update C# runtime files

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1286,6 +1286,19 @@ doesn't work for you, or you don't edit Progress at all, use this in your
 startup vimrc: >
    :let filetype_w = "cweb"
 
+CSHARP							 *cs.vim* *ft-cs-syntax*
+
+C# raw string literals may use any number of quote marks to encapsulate the
+block, and raw interpolated string literals may use any number of braces to
+encapsulate the interpolation, e.g. >
+    $$$""""Hello {{{name}}}""""
+By default, Vim highlights 3-8 quote marks, and 1-8 interpolation braces.
+The maximum numbers of quotes and braces recognized can configured using the
+following variables:
+
+Variable					Default ~
+*g:cs_raw_string_quote_count*			8
+*g:cs_raw_string_interpolation_brace_count*	8
 
 DART						*dart.vim* *ft-dart-syntax*
 

--- a/runtime/ftplugin/cs.vim
+++ b/runtime/ftplugin/cs.vim
@@ -2,8 +2,7 @@
 " Language:            C#
 " Maintainer:          Nick Jensen <nickspoon@gmail.com>
 " Former Maintainer:   Johannes Zellner <johannes@zellner.org>
-" Last Change:         2022-11-16
-"                      2024 Jan 14 by Vim Project (browsefilter)
+" Last Change:         2025-03-14
 " License:             Vim (see :h license)
 " Repository:          https://github.com/nickspoons/vim-cs
 
@@ -21,8 +20,11 @@ setlocal formatoptions-=t formatoptions+=croql
 
 " Set 'comments' to format dashed lists in comments.
 setlocal comments=sO:*\ -,mO:*\ \ ,exO:*/,s1:/*,mb:*,ex:*/,:///,://
+setlocal commentstring=//\ %s
 
-let b:undo_ftplugin = 'setl com< fo<'
+setlocal cinoptions=J1
+
+let b:undo_ftplugin = 'setl com< fo< cino<'
 
 if exists('loaded_matchit') && !exists('b:match_words')
   " #if/#endif support included by default


### PR DESCRIPTION
These runtime file changes include:

- Highlighting support for C#11 "raw" string literals
- Adding the standard `setlocal commentstring=//\ %s` to support the new built-in comment plugin
- `setlocal cinoptions=J1`, which is a more common C# indentation default