### PR TITLE
runtime(doc): fix a typo in gitrebase filetype

### DIFF
--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -652,7 +652,7 @@ with interactive `git rebase`: >
 	:Reword " to pick this commit, but change the commit message
 	:Squash " to squash this commit into the previous one
 
-In addition, the following comamnd can be used to cycle between the different
+In addition, the following command can be used to cycle between the different
 possibilities: >
 
 	:Cycle  " to cycle between the previous commands


### PR DESCRIPTION
Noticed while reading the docs.

Introduced in 4d2c4b90f.