### PR TITLE
MS-Windows: crash when passing long string to expand()

### DIFF
--- a/src/proto/filepath.pro
+++ b/src/proto/filepath.pro
@@ -55,7 +55,7 @@ int vim_fexists(char_u *fname);
 int expand_wildcards_eval(char_u **pat, int *num_file, char_u ***file, int flags);
 int expand_wildcards(int num_pat, char_u **pat, int *num_files, char_u ***files, int flags);
 int match_suffix(char_u *fname);
-int unix_expandpath(garray_T *gap, char_u *path, int wildoff, int flags, int didstar);
+int unix_expandpath(garray_T *gap, char_u *path, size_t wildoff, int flags, int didstar);
 int gen_expand_wildcards(int num_pat, char_u **pat, int *num_file, char_u ***file, int flags);
 void addfile(garray_T *gap, char_u *f, int flags);
 void FreeWild(int count, char_u **files);

--- a/src/testdir/test_expand_func.vim
+++ b/src/testdir/test_expand_func.vim
@@ -141,4 +141,11 @@ func Test_expand_wildignore()
   set wildignore&
 endfunc
 
+" Passing a long string to expand with 'wildignorecase' should not crash Vim.
+func Test_expand_long_str()
+  set wildignorecase
+  call expand('a'->repeat(99999))
+  set wildignorecase&
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  MS-Windows: crash when passing long string to expand() with
          'wildignorecase'.
Solution: Use the same buflen as unix_expandpath() in dos_expandpath().
          Remove an unnecessary STRLEN() while at it.
