### PR TITLE
fix(ft-go): uses terminal for keywordprg in Gvim, and mimic behavior of Vim `:terminal` in Nvim

### DIFF
--- a/runtime/ftplugin/go.vim
+++ b/runtime/ftplugin/go.vim
@@ -33,10 +33,8 @@ if !exists('*' .. expand('<SID>') .. 'GoKeywordPrg')
     setl iskeyword+=.
     try
       let cmd = 'go doc -C ' . shellescape(expand('%:h')) . ' ' . shellescape(expand('<cword>'))
-      if has('nvim')
-        exe 'split | term' cmd
-      elseif has('gui_running')
-        exe 'term' cmd
+      if ('gui_running') || has('nvim')
+        exe 'hor term' cmd
       else
         exe '!' . cmd
       endif

--- a/runtime/ftplugin/go.vim
+++ b/runtime/ftplugin/go.vim
@@ -33,7 +33,7 @@ if !exists('*' .. expand('<SID>') .. 'GoKeywordPrg')
     setl iskeyword+=.
     try
       let cmd = 'go doc -C ' . shellescape(expand('%:h')) . ' ' . shellescape(expand('<cword>'))
-      if ('gui_running') || has('nvim')
+      if has('gui_running') || has('nvim')
         exe 'hor term' cmd
       else
         exe '!' . cmd

--- a/runtime/ftplugin/go.vim
+++ b/runtime/ftplugin/go.vim
@@ -34,9 +34,9 @@ if !exists('*' .. expand('<SID>') .. 'GoKeywordPrg')
     try
       let cmd = 'go doc -C ' . shellescape(expand('%:h')) . ' ' . shellescape(expand('<cword>'))
       if has('nvim')
-        exe "term" cmd
-        startinsert
-        tmap <buffer> <Esc> <Cmd>call jobstop(&channel) <Bar> bdelete<CR>
+        exe 'split | term' cmd
+      elseif has('gui_running')
+        exe 'term' cmd
       else
         exe '!' . cmd
       endif


### PR DESCRIPTION
Problem:
- The document from `go doc` can be very long, and you can scroll if using `!` to run shell command in Gvim.
- I realize that I didn't fully mimic behavior of default keywordprg in Nvim in the previous PR

Solution:
- Use builtin terminal for keywordprg in Gvim
- In Nvim (both TUI and GUI), it should mimic the behavior of Vim `:term`, `:Man`, and `:help`

I would like to opinion from @gpanders in Nvim case, since he is the author of https://github.com/neovim/neovim/pull/15398