### PR TITLE
runtime(syntax-tests): Do not ignore failed screendumps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,9 +96,7 @@ src/json_test
 src/message_test
 src/kword_test
 
-runtime/syntax/testdir/Xfilter
 runtime/syntax/testdir/done/
-runtime/syntax/testdir/failed/
 runtime/syntax/testdir/messages
 runtime/syntax/testdir/testdeps.mk
 runtime/syntax/testdir/vimcmd

--- a/.hgignore
+++ b/.hgignore
@@ -98,9 +98,7 @@ src/json_test
 src/message_test
 src/kword_test
 
-runtime/syntax/testdir/Xfilter
 runtime/syntax/testdir/done/
-runtime/syntax/testdir/failed/
 runtime/syntax/testdir/messages
 runtime/syntax/testdir/testdeps.mk
 runtime/syntax/testdir/vimcmd

--- a/runtime/syntax/Makefile
+++ b/runtime/syntax/Makefile
@@ -43,7 +43,6 @@ test:
 	@#mkdir -p testdir/failed
 	@#touch "$(VIM_SYNTAX_TEST_LOG)"
 	VIMRUNTIME=$(VIMRUNTIME) $(ENVVARS) $(VIMPROG) --clean --not-a-term $(DEBUGLOG) -u testdir/runtest.vim > /dev/null
-	@rm -f testdir/Xfilter
 	@# FIXME: Temporarily show the whole file to find out what goes wrong
 	@#if [ -f testdir/messages ]; then tail -n 6 testdir/messages; fi
 	@if [ -f testdir/messages ]; then cat testdir/messages; fi


### PR DESCRIPTION
The process of preparing and submitting syntax tests is  
fraught with challenges that can turn away many aspiring  
contributors from ever attempting it.  (Out of 69 languages  
introduced since `v9.0.1627`, there are only syntax tests for  
Tera.)

After `v9.1.1176~1`, one visual cue for admitting syntax test  
failures previously available with e.g. `git status` is gone  
after all files under `failed/` have been made ignored for  
Git and Mercurial.  There isn't a single way to go about it:  
some people may move files from `failed/` to `dumps/` after  
each iteration; some people may only move ‘good’ iteration  
files; when a test file is refactored to a great extent,  
some people may prefer deleting all test-related files under  
`dumps/` before moving files from `failed/`.  The usability  
of reporting, at any time, that there are some _untracked_  
files under `failed/` cannot be overstated.  Without it, the  
chances are greater for pushing mismatched changesets.  And  
when tests fail then everyone but the author will be kept in  
the dark about the cause: were some updated screendumps not  
committed _or_ was a wrong version of the syntax plugin  
committed?

Another file, `testdir/Xfilter` (`v9.1.0763`), that will be  
created to establish communication from Make to Vim about  
what subset of syntax tests is requested for running, should  
also be not ignored but rather deleted once its contents are  
read.  Unless it is explicitly deleted _after test failure_,  
the file may contain new *and* old test names when another  
testing attempt is under way.  And by virtue of it being  
ignored, the reason for also running not requested tests  
will be as ever puzzling.

Both Git and Mercurial support per-user configuration; such  
wide-reaching settings hardly belong to clonable defaults.

Also, match literal dots in testname filters.

Also, discover and report _some_ disused screendump files  
tracked under `dumps/`.

References:
https://git-scm.com/docs/gitignore
https://www.mercurial-scm.org/help/topics/config#ui
