### PR TITLE
Problem: wrong translation for encoding failures

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -1311,7 +1311,7 @@ blob2str({blob} [, {options}])				*blob2str()*
 				encoding.  The value is a |String|.  See
 				|encoding-names| for the supported values
 				(plus the special value "none").
-							*E1515*
+							*E1515* *E1516*
 		When current 'encoding' is "utf-8", an error is given and an
 		empty List is returned if an invalid byte sequence is
 		encountered in {blob}.  To suppress this validation and get

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -4589,6 +4589,7 @@ E1512	options.txt	/*E1512*
 E1513	message.txt	/*E1513*
 E1514	options.txt	/*E1514*
 E1515	builtin.txt	/*E1515*
+E1516	builtin.txt	/*E1516*
 E152	helphelp.txt	/*E152*
 E153	helphelp.txt	/*E153*
 E154	helphelp.txt	/*E154*

--- a/src/errors.h
+++ b/src/errors.h
@@ -3660,5 +3660,7 @@ EXTERN char e_winfixbuf_cannot_go_to_buffer[]
 	INIT(= N_("E1513: Cannot switch buffer. 'winfixbuf' is enabled"));
 EXTERN char e_invalid_return_type_from_findfunc[]
 	INIT(= N_("E1514: 'findfunc' did not return a List type"));
-EXTERN char e_str_encoding_failed[]
-	INIT(= N_("E1515: Unable to convert %s '%s' encoding"));
+EXTERN char e_str_encoding_from_failed[]
+	INIT(= N_("E1515: Unable to convert from '%s' encoding"));
+EXTERN char e_str_encoding_to_failed[]
+	INIT(= N_("E1516: Unable to convert to '%s' encoding"));

--- a/src/strings.c
+++ b/src/strings.c
@@ -1339,7 +1339,7 @@ f_blob2str(typval_T *argvars, typval_T *rettv)
 	    vim_free(str);
 	    if (converted_str == NULL)
 	    {
-		semsg(_(e_str_encoding_failed), "from", from_encoding);
+		semsg(_(e_str_encoding_from_failed), from_encoding);
 		goto done;
 	    }
 	}
@@ -1348,7 +1348,7 @@ f_blob2str(typval_T *argvars, typval_T *rettv)
 	{
 	    if (!utf_valid_string(converted_str, NULL))
 	    {
-		semsg(_(e_str_encoding_failed), "from", p_enc);
+		semsg(_(e_str_encoding_from_failed), p_enc);
 		vim_free(converted_str);
 		goto done;
 	    }
@@ -1414,7 +1414,7 @@ f_str2blob(typval_T *argvars, typval_T *rettv)
 	    str = convert_string(str, p_enc, to_encoding);
 	    if (str == NULL)
 	    {
-		semsg(_(e_str_encoding_failed), "to", to_encoding);
+		semsg(_(e_str_encoding_to_failed), to_encoding);
 		goto done;
 	    }
 	}

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -4422,10 +4422,10 @@ func Test_str2blob()
 
     call assert_fails("call str2blob(['abc'], [])", 'E1206: Dictionary required for argument 2')
     call assert_fails("call str2blob(['abc'], {'encoding': []})", 'E730: Using a List as a String')
-    call assert_fails("call str2blob(['abc'], {'encoding': 'ab12xy'})", 'E1515: Unable to convert to ''ab12xy'' encoding')
-    call assert_fails("call str2blob(['ŝş'], {'encoding': 'latin1'})", 'E1515: Unable to convert to ''latin1'' encoding')
-    call assert_fails("call str2blob(['அஇ'], {'encoding': 'latin1'})", 'E1515: Unable to convert to ''latin1'' encoding')
-    call assert_fails("call str2blob(['🁰🁳'], {'encoding': 'latin1'})", 'E1515: Unable to convert to ''latin1'' encoding')
+    call assert_fails("call str2blob(['abc'], {'encoding': 'ab12xy'})", 'E1516: Unable to convert to ''ab12xy'' encoding')
+    call assert_fails("call str2blob(['ŝş'], {'encoding': 'latin1'})", 'E1516: Unable to convert to ''latin1'' encoding')
+    call assert_fails("call str2blob(['அஇ'], {'encoding': 'latin1'})", 'E1516: Unable to convert to ''latin1'' encoding')
+    call assert_fails("call str2blob(['🁰🁳'], {'encoding': 'latin1'})", 'E1516: Unable to convert to ''latin1'' encoding')
   END
   call v9.CheckLegacyAndVim9Success(lines)
 endfunc


### PR DESCRIPTION
Problem:  wrong translation for encoding failures because of using
          literal "from" and "to" in the resulting error message
Solution: use separate error messages for encoding errors "from" and
          "to" encoding.

fixes: #16898