### PR TITLE
Fix string length (after 9.1.1212)

### DIFF
--- a/src/edit.c
+++ b/src/edit.c
@@ -2915,11 +2915,11 @@ stuff_inserted(
     long    count,	// Repeat this many times
     int	    no_esc)	// Don't add an ESC at the end
 {
-    string_T	*insert;				// text to be inserted
+    string_T	insert;				// text to be inserted
     char_u	last = ' ';
 
     insert = get_last_insert();
-    if (insert->string == NULL)
+    if (insert.string == NULL)
     {
 	emsg(_(e_no_inserted_text_yet));
 	return FAIL;
@@ -2929,39 +2929,39 @@ stuff_inserted(
     if (c != NUL)
 	stuffcharReadbuff(c);
 
-    if (insert->length > 0)
+    if (insert.length > 0)
     {
 	char_u	*p;
 
 	// look for the last ESC in 'insert'
-	for (p = insert->string + insert->length - 1; p >= insert->string; --p)
+	for (p = insert.string + insert.length - 1; p >= insert.string; --p)
 	{
 	    if (*p == ESC)
 	    {
-		insert->length = (size_t)(p - insert->string);
+		insert.length = (size_t)(p - insert.string);
 		break;
 	    }
 	}
     }
 
-    if (insert->length > 0)
+    if (insert.length > 0)
     {
-	char_u	*p = insert->string + insert->length - 1;
+	char_u	*p = insert.string + insert.length - 1;
 
 	// when the last char is either "0" or "^" it will be quoted if no ESC
 	// comes after it OR if it will insert more than once and "ptr"
 	// starts with ^D.	-- Acevedo
 	if ((*p == '0' || *p == '^')
-		&& (no_esc || (*insert->string == Ctrl_D && count > 1)))
+		&& (no_esc || (*insert.string == Ctrl_D && count > 1)))
 	{
 	    last = *p;
-	    --insert->length;
+	    --insert.length;
 	}
     }
 
     do
     {
-	stuffReadbuffLen(insert->string, insert->length);
+	stuffReadbuffLen(insert.string, insert.length);
 	// a trailing "0" is inserted as "<C-V>048", "^" as "<C-V>^"
 	switch (last)
 	{
@@ -2990,23 +2990,18 @@ stuff_inserted(
     return OK;
 }
 
-    string_T *
+    string_T
 get_last_insert(void)
 {
-    static string_T insert = {NULL, 0};
+    string_T insert = {NULL, 0};
 
-    if (last_insert.string == NULL)
-    {
-	insert.string = NULL;
-	insert.length = 0;
-    }
-    else
+    if (last_insert.string != NULL)
     {
 	insert.string = last_insert.string + last_insert_skip;
 	insert.length = (size_t)(last_insert.length - last_insert_skip);
     }
 
-    return &insert;
+    return insert;
 }
 
 /*
@@ -3016,17 +3011,17 @@ get_last_insert(void)
     char_u *
 get_last_insert_save(void)
 {
-    string_T	*insert = get_last_insert();
+    string_T	insert = get_last_insert();
     char_u	*s;
 
-    if (insert->string == NULL)
+    if (insert.string == NULL)
 	return NULL;
-    s = vim_strnsave(insert->string, insert->length);
+    s = vim_strnsave(insert.string, insert.length);
     if (s == NULL)
 	return NULL;
 
-    if (insert->length > 0 && s[insert->length - 1] == ESC)	// remove trailing ESC
-	s[insert->length - 1] = NUL;
+    if (insert.length > 0 && s[insert.length - 1] == ESC)	// remove trailing ESC
+	s[insert.length - 1] = NUL;
     return s;
 }
 

--- a/src/edit.c
+++ b/src/edit.c
@@ -3025,12 +3025,11 @@ get_last_insert_save(void)
     if (s == NULL)
 	return NULL;
 
-    if (insert->length > 0)
+    // remove trailing ESC
+    if (insert->length > 0 && s[insert->length - 1] == ESC)
     {
-	// remove trailing ESC
 	--insert->length;
-	if (s[insert->length] == ESC)
-	    s[insert->length] = NUL;
+	s[insert->length] = NUL;
     }
     return s;
 }

--- a/src/edit.c
+++ b/src/edit.c
@@ -3025,12 +3025,8 @@ get_last_insert_save(void)
     if (s == NULL)
 	return NULL;
 
-    // remove trailing ESC
-    if (insert->length > 0 && s[insert->length - 1] == ESC)
-    {
-	--insert->length;
-	s[insert->length] = NUL;
-    }
+    if (insert->length > 0 && s[insert->length - 1] == ESC)	// remove trailing ESC
+	s[insert->length - 1] = NUL;
     return s;
 }
 

--- a/src/proto/edit.pro
+++ b/src/proto/edit.pro
@@ -24,7 +24,7 @@ int cursor_up(long n, int upd_topline);
 void cursor_down_inner(win_T *wp, long n);
 int cursor_down(long n, int upd_topline);
 int stuff_inserted(int c, long count, int no_esc);
-string_T *get_last_insert(void);
+string_T get_last_insert(void);
 char_u *get_last_insert_save(void);
 void replace_push(int c);
 int replace_push_mb(char_u *p);

--- a/src/register.c
+++ b/src/register.c
@@ -2379,6 +2379,7 @@ ex_display(exarg_T *eap)
     char_u	*arg = eap->arg;
     int		clen;
     int		type;
+    string_T	insert;
 
     if (arg != NULL && *arg == NUL)
 	arg = NULL;
@@ -2471,7 +2472,8 @@ ex_display(exarg_T *eap)
     }
 
     // display last inserted text
-    if ((p = get_last_insert()->string) != NULL
+    insert = get_last_insert();
+    if ((p = insert.string) != NULL
 		  && (arg == NULL || vim_strchr(arg, '.') != NULL) && !got_int
 						      && !message_filtered(p))
     {


### PR DESCRIPTION
Fixes an unfortunate regression.

Thanks to Christ van Willegen.

Edit: while we are here change `get_last_insert()` to return a `string_T` structure and not a pointer to a static structure. Thanks to zeertzjq.