### PR TITLE
runtime(filetype): detect uv.lock as toml filetype

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -2660,7 +2660,7 @@ au BufNewFile,BufRead *.tla			setf tla
 au BufNewFile,BufRead {.,}tmux*.conf		setf tmux
 
 " TOML
-au BufNewFile,BufRead *.toml			setf toml
+au BufNewFile,BufRead *.toml,uv.lock		setf toml
 
 " TPP - Text Presentation Program
 au BufNewFile,BufRead *.tpp			setf tpp

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -818,7 +818,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     tla: ['file.tla'],
     tli: ['file.tli'],
     tmux: ['tmuxfile.conf', '.tmuxfile.conf', '.tmux-file.conf', '.tmux.conf', 'tmux-file.conf', 'tmux.conf', 'tmux.conf.local'],
-    toml: ['file.toml', 'Gopkg.lock', 'Pipfile', '/home/user/.cargo/config', '.black',
+    toml: ['file.toml', 'uv.lock', 'Gopkg.lock', 'Pipfile', '/home/user/.cargo/config', '.black',
            'any/containers/containers.conf', 'any/containers/containers.conf.d/file.conf',
            'any/containers/containers.conf.modules/file.conf', 'any/containers/containers.conf.modules/any/file.conf',
            'any/containers/registries.conf', 'any/containers/registries.conf.d/file.conf',


### PR DESCRIPTION
Problem: filetype: uv.lock file is not recognized
Solution: detect 'uv.lock' file as toml filetype