### PR TITLE
Strange error with wrong type for matchfuzzy() "camelcase"

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -1,4 +1,4 @@
-*builtin.txt*	For Vim version 9.1.  Last change: 2025 Mar 16
+*builtin.txt*	For Vim version 9.1.  Last change: 2025 Mar 18
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -7277,7 +7277,7 @@ matchfuzzy({list}, {str} [, {dict}])			*matchfuzzy()*
 				returned.  Zero means no limit.
 		    camelcase	Use enhanced camel case scoring making results
 				better suited for completion related to
-				programming languages. Default is v:true
+				programming languages.  Defaults to v:true.
 
 		If {list} is a list of dictionaries, then the optional {dict}
 		argument supports the following additional items:

--- a/src/search.c
+++ b/src/search.c
@@ -4979,7 +4979,7 @@ do_fuzzymatch(typval_T *argvars, typval_T *rettv, int retmatchpos)
     if (argvars[1].v_type != VAR_STRING
 	    || argvars[1].vval.v_string == NULL)
     {
-	semsg(_(e_invalid_argument_str), tv_get_string(&argvars[1]));
+	semsg(_(e_invalid_argument_str), typval_tostring(&argvars[1], TRUE));
 	return;
     }
 
@@ -5000,7 +5000,8 @@ do_fuzzymatch(typval_T *argvars, typval_T *rettv, int retmatchpos)
 		    || di->di_tv.vval.v_string == NULL
 		    || *di->di_tv.vval.v_string == NUL)
 	    {
-		semsg(_(e_invalid_argument_str), tv_get_string(&di->di_tv));
+		semsg(_(e_invalid_value_for_argument_str_str), "key",
+					    typval_tostring(&di->di_tv, TRUE));
 		return;
 	    }
 	    key = tv_get_string(&di->di_tv);
@@ -5019,21 +5020,23 @@ do_fuzzymatch(typval_T *argvars, typval_T *rettv, int retmatchpos)
 	{
 	    if (di->di_tv.v_type != VAR_NUMBER)
 	    {
-		semsg(_(e_invalid_argument_str), tv_get_string(&di->di_tv));
+		semsg(_(e_invalid_value_for_argument_str_str), "limit",
+					    typval_tostring(&di->di_tv, TRUE));
 		return;
 	    }
 	    max_matches = (long)tv_get_number_chk(&di->di_tv, NULL);
 	}
 
 	if ((di = dict_find(d, (char_u *)"camelcase", -1)) != NULL)
-        {
+	{
 	    if (di->di_tv.v_type != VAR_BOOL)
 	    {
-		semsg(_(e_invalid_argument_str), "camelcase");
+		semsg(_(e_invalid_value_for_argument_str_str), "camelcase",
+					    typval_tostring(&di->di_tv, TRUE));
 		return;
 	    }
 	    camelcase = tv_get_bool_chk(&di->di_tv, NULL);
-        }
+	}
 
 	if (dict_has_key(d, "matchseq"))
 	    matchseq = TRUE;

--- a/src/testdir/test_matchfuzzy.vim
+++ b/src/testdir/test_matchfuzzy.vim
@@ -7,7 +7,7 @@ source term_util.vim
 " Test for matchfuzzy()
 func Test_matchfuzzy()
   call assert_fails('call matchfuzzy(10, "abc")', 'E686:')
-  call assert_fails('call matchfuzzy(["abc"], [])', 'E730:')
+  call assert_fails('call matchfuzzy(["abc"], [])', 'E475: Invalid argument: []')
   call assert_fails("let x = matchfuzzy(test_null_list(), 'foo')", 'E686:')
   call assert_fails('call matchfuzzy(["abc"], test_null_string())', 'E475:')
   call assert_equal([], matchfuzzy([], 'abc'))
@@ -76,7 +76,7 @@ func Test_matchfuzzy()
   call assert_fails("let x = matchfuzzy(l, 'day', {'text_cb' : {a, b -> 1}})", 'E119:')
   call assert_equal([], matchfuzzy(l, 'cam'))
   call assert_fails("let x = matchfuzzy(l, 'cam', {'text_cb' : []})", 'E921:')
-  call assert_fails("let x = matchfuzzy(l, 'foo', {'key' : []})", 'E730:')
+  call assert_fails("let x = matchfuzzy(l, 'foo', {'key' : []})", 'E475: Invalid value for argument key: []')
   call assert_fails("let x = matchfuzzy(l, 'cam', test_null_dict())", 'E1297:')
   call assert_fails("let x = matchfuzzy(l, 'foo', {'key' : test_null_string()})", 'E475:')
   call assert_fails("let x = matchfuzzy(l, 'foo', {'text_cb' : test_null_function()})", 'E475:')
@@ -88,10 +88,15 @@ func Test_matchfuzzy()
   call assert_fails("let x = matchfuzzy(l, 'foo', {'key' : 'name'})", 'E730:')
 
   " camelcase
-  call assert_equal(['Cursor', 'CurSearch', 'CursorLine', 'lCursor', 'shCurlyIn', 'shCurlyError', 'TracesCursor'],
-        \ matchfuzzy(['Cursor', 'lCursor', 'shCurlyIn', 'shCurlyError', 'TracesCursor', 'CurSearch', 'CursorLine'], 'Cur', {"camelcase": v:false}))
   call assert_equal(['lCursor', 'shCurlyIn', 'shCurlyError', 'TracesCursor', 'Cursor', 'CurSearch', 'CursorLine'],
         \ matchfuzzy(['Cursor', 'lCursor', 'shCurlyIn', 'shCurlyError', 'TracesCursor', 'CurSearch', 'CursorLine'], 'Cur'))
+  call assert_equal(['lCursor', 'shCurlyIn', 'shCurlyError', 'TracesCursor', 'Cursor', 'CurSearch', 'CursorLine'],
+        \ matchfuzzy(['Cursor', 'lCursor', 'shCurlyIn', 'shCurlyError', 'TracesCursor', 'CurSearch', 'CursorLine'], 'Cur', {"camelcase": v:true}))
+  call assert_equal(['Cursor', 'CurSearch', 'CursorLine', 'lCursor', 'shCurlyIn', 'shCurlyError', 'TracesCursor'],
+        \ matchfuzzy(['Cursor', 'lCursor', 'shCurlyIn', 'shCurlyError', 'TracesCursor', 'CurSearch', 'CursorLine'], 'Cur', {"camelcase": v:false}))
+  call assert_equal(['things', 'sThings', 'thisThings'],
+        \ matchfuzzy(['things','sThings', 'thisThings'], 'thin', {'camelcase': v:false}))
+  call assert_fails("let x = matchfuzzy([], 'foo', {'camelcase': []})", 'E475: Invalid value for argument camelcase: []')
 
   " Test in latin1 encoding
   let save_enc = &encoding
@@ -155,7 +160,7 @@ func Test_matchfuzzypos()
   call assert_fails("let x = matchfuzzypos(l, 'day', {'text_cb' : {a, b -> 1}})", 'E119:')
   call assert_equal([[], [], []], matchfuzzypos(l, 'cam'))
   call assert_fails("let x = matchfuzzypos(l, 'cam', {'text_cb' : []})", 'E921:')
-  call assert_fails("let x = matchfuzzypos(l, 'foo', {'key' : []})", 'E730:')
+  call assert_fails("let x = matchfuzzypos(l, 'foo', {'key' : []})", 'E475: Invalid value for argument key: []')
   call assert_fails("let x = matchfuzzypos(l, 'cam', test_null_dict())", 'E1297:')
   call assert_fails("let x = matchfuzzypos(l, 'foo', {'key' : test_null_string()})", 'E475:')
   call assert_fails("let x = matchfuzzypos(l, 'foo', {'text_cb' : test_null_function()})", 'E475:')
@@ -178,11 +183,13 @@ func Test_matchfuzzypos()
   " camelcase
   call assert_equal([['lCursor', 'shCurlyIn', 'shCurlyError', 'TracesCursor', 'Cursor', 'CurSearch', 'CursorLine'], [[1, 2, 3], [2, 3, 4], [2, 3, 4], [6, 7, 8], [0, 1, 2], [0, 1, 2], [0, 1, 2]], [318, 311, 308, 303, 267, 264, 263]],
         \ matchfuzzypos(['Cursor', 'lCursor', 'shCurlyIn', 'shCurlyError', 'TracesCursor', 'CurSearch', 'CursorLine'], 'Cur'))
-
+  call assert_equal([['lCursor', 'shCurlyIn', 'shCurlyError', 'TracesCursor', 'Cursor', 'CurSearch', 'CursorLine'], [[1, 2, 3], [2, 3, 4], [2, 3, 4], [6, 7, 8], [0, 1, 2], [0, 1, 2], [0, 1, 2]], [318, 311, 308, 303, 267, 264, 263]],
+        \ matchfuzzypos(['Cursor', 'lCursor', 'shCurlyIn', 'shCurlyError', 'TracesCursor', 'CurSearch', 'CursorLine'], 'Cur', {"camelcase": v:true}))
   call assert_equal([['Cursor', 'CurSearch', 'CursorLine', 'lCursor', 'shCurlyIn', 'shCurlyError', 'TracesCursor'], [[0, 1, 2], [0, 1, 2], [0, 1, 2], [1, 2, 3], [2, 3, 4], [2, 3, 4], [6, 7, 8]], [267, 264, 263, 246, 239, 236, 231]],
         \ matchfuzzypos(['Cursor', 'lCursor', 'shCurlyIn', 'shCurlyError', 'TracesCursor', 'CurSearch', 'CursorLine'], 'Cur', {"camelcase": v:false}))
   call assert_equal([['things', 'sThings', 'thisThings'], [[0, 1, 2, 3], [1, 2, 3, 4], [0, 1, 2, 7]], [333, 287, 279]],
         \ matchfuzzypos(['things','sThings', 'thisThings'], 'thin', {'camelcase': v:false}))
+  call assert_fails("let x = matchfuzzypos([], 'foo', {'camelcase': []})", 'E475: Invalid value for argument camelcase: []')
 endfunc
 
 " Test for matchfuzzy() with multibyte characters
@@ -272,7 +279,8 @@ func Test_matchfuzzy_limit()
   call assert_equal(['2'], x->matchfuzzy('2', #{limit: 1}))
   call assert_equal(['2', '2'], x->matchfuzzy('2', #{limit: 2}))
   call assert_equal(['2', '2'], x->matchfuzzy('2', #{limit: 3}))
-  call assert_fails("call matchfuzzy(x, '2', #{limit: '2'})", 'E475:')
+  call assert_fails("call matchfuzzy(x, '2', #{limit: '2'})", "E475: Invalid value for argument limit: '2'")
+  call assert_fails("call matchfuzzy(x, '2', #{limit: []})", 'E475: Invalid value for argument limit: []')
 
   let l = [{'id': 5, 'val': 'crayon'}, {'id': 6, 'val': 'camera'}]
   call assert_equal([{'id': 5, 'val': 'crayon'}, {'id': 6, 'val': 'camera'}], l->matchfuzzy('c', #{text_cb: {v -> v.val}}))


### PR DESCRIPTION
Problem:  Strange error with type for matchfuzzy() "camelcase".
Solution: Show the error "Invalid value for argument camelcase" instead
          of "Invalid argument: camelcase".  Use typval_tostring() to
          prevent tv_get_string() giving another error.
