### PR TITLE
fix: allow Ctrl-C to close popups without filter callback 

### DIFF
--- a/runtime/doc/pattern.txt
+++ b/runtime/doc/pattern.txt
@@ -141,6 +141,7 @@ CTRL-C			Interrupt current (search) command.  Use CTRL-Break on
 			help users who use "vim file | grep word" and don't
 			know how to get out (blindly typing :qa<CR> would
 			work).
+			If a popup is open, the active popup will be closed.
 
 							*:noh* *:nohlsearch*
 :noh[lsearch]		Stop the highlighting for the 'hlsearch' option.  It

--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -3586,6 +3586,20 @@ popup_do_filter(int c)
 		&& (wp->w_filter_mode & state) != 0)
 	    res = invoke_popup_filter(wp, c);
 
+    // when Ctrl-C and no popup has been processed (res is still FALSE)
+    // Try to find and close a popup that has no filter callback
+    if (c == Ctrl_C && res == FALSE)
+    {
+	popup_reset_handled(POPUP_HANDLED_2);
+	wp = find_next_popup(FALSE, POPUP_HANDLED_2);
+        if (wp != NULL)
+        {
+	    popup_close_with_retval(wp, -1);
+	    res = TRUE;
+	}
+    }
+
+
     if (must_redraw > was_must_redraw)
     {
 	int save_got_int = got_int;

--- a/src/testdir/test_popupwin.vim
+++ b/src/testdir/test_popupwin.vim
@@ -3898,6 +3898,24 @@ func Test_popupwin_cancel()
   call assert_equal({}, popup_getpos(win3))
 endfunc
 
+func Test_popupwin_cancel_with_without_filter()
+  let win1 = popup_create('with filter', #{line: 5, filter: {... -> 0}})
+  let win2 = popup_create('no filter', #{line: 10})
+
+  call assert_equal(5, popup_getpos(win1).line)
+  call assert_equal(10, popup_getpos(win2).line)
+
+  call feedkeys("\<C-C>", 'xt')
+  call assert_equal({}, popup_getpos(win1))
+  call assert_equal(10, popup_getpos(win2).line)
+
+  call feedkeys("\<C-C>", 'xt')
+  call assert_equal({}, popup_getpos(win1))
+  call assert_equal({}, popup_getpos(win2))
+
+  call popup_clear()
+endfunc
+
 func Test_popupwin_filter_redraw()
   " Create two popups with a filter that closes the popup when typing "0".
   " Both popups should close, even though the redraw also calls


### PR DESCRIPTION
Problem: Ctrl-C only closes popup windows that have a filter callback,
         but does not close popups without a filter callback.
Solution: Modified popup_do_filter() to also close popups without
          filter callback when Ctrl-C is pressed.

Fix #16839