### PR TITLE
fix bash indentation for local arrays in functions

### DIFF
--- a/runtime/indent/sh.vim
+++ b/runtime/indent/sh.vim
@@ -7,6 +7,7 @@
 " License:             Vim (see :h license)
 " Repository:          https://github.com/chrisbra/vim-sh-indent
 " Changelog:
+"          20250318  - Detect local arrays in functions
 "          20241411  - Detect dash character in function keyword for
 "                      bash mode (issue #16049)
 "          20190726  - Correctly skip if keywords in syntax comments
@@ -203,7 +204,7 @@ function! s:is_function_definition(line)
 endfunction
 
 function! s:is_array(line)
-  return a:line =~ '^\s*\<\k\+\>=('
+  return a:line =~ '^\s*\(local\s\+\)\?\<\k\+\>=('
 endfunction
 
 function! s:is_case_label(line, pnum)

--- a/runtime/indent/testdir/bash.in
+++ b/runtime/indent/testdir/bash.in
@@ -5,6 +5,16 @@
 a = 10
 b = 20
 
+function variables(){
+local test1="test1"
+test2=(
+"test" "test2"
+)
+local test3=(
+"test" "test3"
+)
+}
+
 function add() {
 c = $((a + b))
 }

--- a/runtime/indent/testdir/bash.ok
+++ b/runtime/indent/testdir/bash.ok
@@ -5,6 +5,16 @@
 a = 10
 b = 20
 
+function variables(){
+  local test1="test1"
+  test2=(
+    "test" "test2"
+  )
+  local test3=(
+    "test" "test3"
+  )
+}
+
 function add() {
   c = $((a + b))
 }


### PR DESCRIPTION
Currently, multiline local arrays are not properly indented, and the closing parenthesis within a function breaks the indentation.

This commit shows the issue and restores the expected behavior:
https://github.com/exgade/linux-gaming/commit/9b2e0a1f07ca2c11adf6f7af1ede556d80e5ad4c

Fix:
- Updated the regular expression in the is_array function to optionally match the local keyword.
- Added test cases to cover functions containing local strings, global arrays, and local arrays.
