### PR TITLE
"shellcmdline" completion doesn't work with input()

### DIFF
--- a/src/cmdexpand.c
+++ b/src/cmdexpand.c
@@ -15,6 +15,7 @@
 
 static int	cmd_showtail;	// Only show path tail in lists ?
 
+static void	set_context_for_wildcard_arg(exarg_T *eap, char_u *arg, int usefilter, expand_T *xp, int *complp);
 static int	ExpandFromContext(expand_T *xp, char_u *, char_u ***, int *, int);
 static char_u	*showmatches_gettail(char_u *s);
 static int	expand_showtail(expand_T *xp);
@@ -230,17 +231,17 @@ nextwild(
     if (xp->xp_numfiles == -1)
     {
 #ifdef FEAT_EVAL
-        if (ccline->input_fn && ccline->xp_context == EXPAND_COMMANDS)
+	if (ccline->input_fn && ccline->xp_context == EXPAND_COMMANDS)
 	{
 	    // Expand commands typed in input() function
 	    set_cmd_context(xp, ccline->cmdbuff, ccline->cmdlen, ccline->cmdpos, FALSE);
-        }
-        else
+	}
+	else
 #endif
-        {
+	{
 	    set_expand_context(xp);
-        }
-        cmd_showtail = expand_showtail(xp);
+	}
+	cmd_showtail = expand_showtail(xp);
     }
 
     if (xp->xp_context == EXPAND_UNSUCCESSFUL)
@@ -2723,6 +2724,7 @@ set_cmd_context(
 {
 #ifdef FEAT_EVAL
     cmdline_info_T	*ccline = get_cmdline_info();
+    int			context;
 #endif
     int		old_char = NUL;
     char_u	*nextcomm;
@@ -2745,6 +2747,12 @@ set_cmd_context(
 	xp->xp_context = ccline->xp_context;
 	xp->xp_pattern = ccline->cmdbuff;
 	xp->xp_arg = ccline->xp_arg;
+	if (xp->xp_context == EXPAND_SHELLCMDLINE)
+	{
+	    context = xp->xp_context;
+	    set_context_for_wildcard_arg(NULL, xp->xp_pattern, FALSE, xp,
+								     &context);
+	}
     }
     else
 #endif

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -2245,10 +2245,20 @@ func Test_input_func()
   call assert_fails("call input('F:', '', 'invalid')", 'E180:')
   call assert_fails("call input('F:', '', [])", 'E730:')
 
-  " Test for using 'command' as the completion function
+  " Test for using "command" as the completion function
   call feedkeys(":let c = input('Command? ', '', 'command')\<CR>"
         \ .. "echo bufnam\<C-A>\<CR>", 'xt')
   call assert_equal('echo bufname(', c)
+
+  " Test for using "shellcmdline" as the completion function
+  call feedkeys(":let c = input('Shell? ', '', 'shellcmdline')\<CR>"
+        \ .. "vim test_functions.\<C-A>\<CR>", 'xt')
+  call assert_equal('vim test_functions.vim', c)
+  if executable('whoami')
+    call feedkeys(":let c = input('Shell? ', '', 'shellcmdline')\<CR>"
+          \ .. "whoam\<C-A>\<CR>", 'xt')
+    call assert_match('\<whoami\>', c)
+  endif
 endfunc
 
 " Test for the inputdialog() function


### PR DESCRIPTION
Problem:  "shellcmdline" completion doesn't work with input().
Solution: Use set_context_for_wildcard_arg().  Fix indent in nextwild().

There are some other inconsistencies for input() completion (ref #948),
but since "shellcmdline" currently doesn't work at all, it makes sense
to at least make it work.

fixes: #16932
