### PR TITLE
remove extra NULL check in VIM_CLEAR()

### DIFF
--- a/src/macros.h
+++ b/src/macros.h
@@ -360,11 +360,8 @@
  */
 #define VIM_CLEAR(p) \
     do { \
-	if ((p) != NULL) \
-	{ \
-	    vim_free(p); \
-	    (p) = NULL; \
-	} \
+	vim_free(p); \
+	(p) = NULL; \
     } while (0)
 
 /*


### PR DESCRIPTION
The NULL check in this part is unnecessary because vim_free() called by the VIM_CLEAR() macro performs the NULL check.
Also, I don't think the variables passed to VIM_CLEAR() will often be NULL, so I don't think it will be a problem to always assign NULL to them.

FYI, I added `VIM_CLEAR()` in [8.0.1496](https://github.com/vim/vim/commit/d23a823669d93fb2a570a039173eefe4856ac806).