### PR TITLE
Comment text object

### DIFF
--- a/runtime/pack/dist/opt/comment/autoload/comment.vim
+++ b/runtime/pack/dist/opt/comment/autoload/comment.vim
@@ -95,6 +95,11 @@ export def ObjComment(inner: bool)
         endif
     enddef
 
+    # requires syntax support
+    if !exists("g:syntax_on")
+      return
+    endif
+
     var pos_init = getcurpos()
 
     # If not in comment, search next one,

--- a/runtime/pack/dist/opt/comment/autoload/comment.vim
+++ b/runtime/pack/dist/opt/comment/autoload/comment.vim
@@ -88,11 +88,7 @@ enddef
 export def ObjComment(inner: bool)
     def IsComment(): bool
         var stx = map(synstack(line('.'), col('.')), 'synIDattr(v:val, "name")')->join()
-        if stx =~? 'Comment'
-            return true
-        else
-            return false
-        endif
+        return stx =~? 'Comment'
     enddef
 
     # requires syntax support

--- a/runtime/pack/dist/opt/comment/autoload/comment.vim
+++ b/runtime/pack/dist/opt/comment/autoload/comment.vim
@@ -104,18 +104,18 @@ export def ObjComment(inner: bool)
 
     # If not in comment, search next one,
     if !IsComment()
-        if search('\S\+', 'W', line(".") + 100, 100, () => !IsComment()) <= 0
+        if search('\v\S+', 'W', line(".") + 100, 100, () => !IsComment()) <= 0
             return
         endif
     endif
 
     # Search for the beginning of the comment block
     if IsComment()
-        if search('\v(\S+)|$', 'bW', 0, 200, IsComment) > 0
-            search('\v(\S+)|$', 'W', 0, 200, () => !IsComment())
+        if search('\v%(\S+)|$', 'bW', 0, 200, IsComment) > 0
+            search('\v%(\S+)|$', 'W', 0, 200, () => !IsComment())
         else
             cursor(1, 1)
-            search('\S\+', 'cW', 0, 200)
+            search('\v\S+', 'cW', 0, 200)
         endif
     endif
 
@@ -131,7 +131,7 @@ export def ObjComment(inner: bool)
     if pos_init[1] > pos_start[1]
         cursor(pos_init[1], pos_init[2])
     endif
-    if search('\v(\S+)|$', 'W', 0, 200, IsComment) > 0
+    if search('\v%(\S+)|$', 'W', 0, 200, IsComment) > 0
         search('\S', 'beW', 0, 200, () => !IsComment())
     else
         if search('\%$', 'W', 0, 200) > 0

--- a/runtime/pack/dist/opt/comment/autoload/comment.vim
+++ b/runtime/pack/dist/opt/comment/autoload/comment.vim
@@ -111,8 +111,8 @@ export def ObjComment(inner: bool)
 
     # Search for the beginning of the comment block
     if IsComment()
-        if search('\v%(\S+)|$', 'bW', 0, 200, IsComment) > 0
-            search('\v%(\S+)|$', 'W', 0, 200, () => !IsComment())
+        if search('\v%(\S+)|^', 'bW', 0, 200, IsComment) > 0
+            search('\v%(\S)|$', 'W', 0, 200, () => !IsComment())
         else
             cursor(1, 1)
             search('\v\S+', 'cW', 0, 200)
@@ -122,9 +122,12 @@ export def ObjComment(inner: bool)
     var pos_start = getcurpos()
 
     if !inner
-        if search('\v\s+', 'bW', line('.'), 200) > 0
-            pos_start = getcurpos()
-        endif
+        var col = pos_start[2]
+        var prefix = getline(pos_start[1])[ : col - 2]
+        while col > 0 && prefix[col - 2] =~ '\s'
+            col -= 1
+        endwhile
+        pos_start[2] = col
     endif
 
     # Search for the comment end.

--- a/runtime/pack/dist/opt/comment/autoload/comment.vim
+++ b/runtime/pack/dist/opt/comment/autoload/comment.vim
@@ -104,7 +104,7 @@ export def ObjComment(inner: bool)
 
     # If not in comment, search next one,
     if !IsComment()
-        if search('\v\S+', 'W', line(".") + 100, 100, () => !IsComment()) <= 0
+        if search('\v\k+', 'W', line(".") + 100, 100, () => !IsComment()) <= 0
             return
         endif
     endif

--- a/runtime/pack/dist/opt/comment/autoload/comment.vim
+++ b/runtime/pack/dist/opt/comment/autoload/comment.vim
@@ -122,7 +122,7 @@ export def ObjComment(inner: bool)
     var pos_start = getcurpos()
 
     if !inner
-        if search('\s*', 'bW', line('.'), 200) > 0
+        if search('\v\s+', 'bW', line('.'), 200) > 0
             pos_start = getcurpos()
         endif
     endif

--- a/runtime/pack/dist/opt/comment/autoload/comment.vim
+++ b/runtime/pack/dist/opt/comment/autoload/comment.vim
@@ -111,7 +111,7 @@ export def ObjComment(inner: bool)
 
     # Search for the beginning of the comment block
     if IsComment()
-        if search('\v%(\S+)|^', 'bW', 0, 200, IsComment) > 0
+        if search('\v%(\S+)|$', 'bW', 0, 200, IsComment) > 0
             search('\v%(\S)|$', 'W', 0, 200, () => !IsComment())
         else
             cursor(1, 1)

--- a/runtime/pack/dist/opt/comment/autoload/comment.vim
+++ b/runtime/pack/dist/opt/comment/autoload/comment.vim
@@ -1,7 +1,7 @@
 vim9script
 
 # Maintainer: Maxim Kim <habamax@gmail.com>
-# Last Update: 2024 Oct 05
+# Last Update: 2025-03-21
 #
 # Toggle comments
 # Usage:

--- a/runtime/pack/dist/opt/comment/autoload/comment.vim
+++ b/runtime/pack/dist/opt/comment/autoload/comment.vim
@@ -88,7 +88,7 @@ enddef
 export def ObjComment(inner: bool)
     def IsComment(): bool
         var stx = map(synstack(line('.'), col('.')), 'synIDattr(v:val, "name")')->join()
-        if stx =~ 'Comment'
+        if stx =~? 'Comment'
             return true
         else
             return false

--- a/runtime/pack/dist/opt/comment/doc/comment.txt
+++ b/runtime/pack/dist/opt/comment/doc/comment.txt
@@ -43,8 +43,8 @@ ic		"inner comment", select current or next comment.
 
 This plugin uses the buffer-local 'commentstring' option value to add or remove
 comment markers to the selected lines.  Whether it will comment or un-comment
-depends on the first line of the range of lines to act upon.  When it matches
-a comment marker, the line will be un-commented, if it doesn't, the line will
+depends on the range of lines to act upon.  When all of the lines in range
+have comment markers, all lines will be un-commented, if it doesn't, the lines will
 be commented out.  Blank and empty lines are ignored.
 
 The value of 'commentstring' is the same for the entire buffer and determined

--- a/runtime/pack/dist/opt/comment/doc/comment.txt
+++ b/runtime/pack/dist/opt/comment/doc/comment.txt
@@ -32,8 +32,8 @@ back to `gcc` otherwise, add the following mapping to your vimrc: >
 Note: using `gC` may not always result in valid comment markers depending on
 the language used.
 
-Additionally, the plugin defines comment text-object which has effect when
-syntax is enabled:
+Additionally, the plugin defines a comment text-object which requires syntax
+highlighting to be enabled.
 						     *v_ac* *ac*
 ac		"a comment", select current or next comment.
 		Leading and trailing white space is included.

--- a/runtime/pack/dist/opt/comment/doc/comment.txt
+++ b/runtime/pack/dist/opt/comment/doc/comment.txt
@@ -44,8 +44,8 @@ ic		"inner comment", select current or next comment.
 This plugin uses the buffer-local 'commentstring' option value to add or remove
 comment markers to the selected lines.  Whether it will comment or un-comment
 depends on the range of lines to act upon.  When all of the lines in range
-have comment markers, all lines will be un-commented, if it doesn't, the lines will
-be commented out.  Blank and empty lines are ignored.
+have comment markers, all lines will be un-commented, if it doesn't, the lines
+will be commented out.  Blank and empty lines are ignored.
 
 The value of 'commentstring' is the same for the entire buffer and determined
 by its filetype (|filetypes|). To adapt it within the buffer for embedded

--- a/runtime/pack/dist/opt/comment/doc/comment.txt
+++ b/runtime/pack/dist/opt/comment/doc/comment.txt
@@ -32,6 +32,15 @@ back to `gcc` otherwise, add the following mapping to your vimrc: >
 Note: using `gC` may not always result in valid comment markers depending on
 the language used.
 
+Additionally, the plugin defines comment text-object which has effect when
+syntax is enabled:
+						     *v_ac* *ac*
+ac		"a comment", select current or next comment.
+		Leading and trailing white space is included.
+		Trailing newlines are included too.
+						     *v_ic* *ic*
+ic		"inner comment", select current or next comment.
+
 This plugin uses the buffer-local 'commentstring' option value to add or remove
 comment markers to the selected lines.  Whether it will comment or un-comment
 depends on the first line of the range of lines to act upon.  When it matches

--- a/runtime/pack/dist/opt/comment/plugin/comment.vim
+++ b/runtime/pack/dist/opt/comment/plugin/comment.vim
@@ -1,7 +1,7 @@
 vim9script
 
 # Maintainer: Maxim Kim <habamax@gmail.com>
-# Last Update: 2025-03-20
+# Last Update: 2025-03-21
 
 import autoload 'comment.vim'
 

--- a/runtime/pack/dist/opt/comment/plugin/comment.vim
+++ b/runtime/pack/dist/opt/comment/plugin/comment.vim
@@ -1,9 +1,15 @@
 vim9script
 
 # Maintainer: Maxim Kim <habamax@gmail.com>
-# Last Update: 2024-04-26
+# Last Update: 2025-03-20
 
 import autoload 'comment.vim'
+
 nnoremap <silent> <expr> gc comment.Toggle()
 xnoremap <silent> <expr> gc comment.Toggle()
 nnoremap <silent> <expr> gcc comment.Toggle() .. '_'
+
+onoremap <silent>ic <scriptcmd>comment.ObjComment(v:true)<CR>
+onoremap <silent>ac <scriptcmd>comment.ObjComment(v:false)<CR>
+xnoremap <silent>ic <esc><scriptcmd>comment.ObjComment(v:true)<CR>
+xnoremap <silent>ac <esc><scriptcmd>comment.ObjComment(v:false)<CR>

--- a/src/testdir/test_plugin_comment.vim
+++ b/src/testdir/test_plugin_comment.vim
@@ -29,7 +29,6 @@ func Test_basic_comment()
   call assert_equal(["# vim9script", "", "# def Hello()", '#   echo "Hello"', "# enddef"], result)
 endfunc
 
-
 func Test_basic_uncomment()
   CheckScreendump
   let lines =<< trim END
@@ -459,4 +458,59 @@ func Test_textobj_cursor_on_leading_space_comment()
   let result = readfile(output_file)
 
   call assert_equal(["int main() {", "", "}"], result)
+endfunc
+
+func Test_textobj_conseq_comment()
+  CheckScreendump
+  let lines =<< trim END
+    int main() {
+        printf("hello"); // hello
+        // world
+        printf("world");
+    }
+  END
+
+  let input_file = "test_textobj_conseq_comment_input.c"
+  call writefile(lines, input_file, "D")
+
+  let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
+
+  call term_sendkeys(buf, "dac")
+  let output_file = "comment_textobj_conseq_comment.c"
+  call term_sendkeys(buf, $":w {output_file}\<CR>")
+  defer delete(output_file)
+
+  call StopVimInTerminal(buf)
+
+  let result = readfile(output_file)
+
+  call assert_equal(["int main() {", "    printf(\"hello\");", "    printf(\"world\");", "}"], result)
+endfunc
+
+func Test_textobj_conseq_comment2()
+  CheckScreendump
+  let lines =<< trim END
+    int main() {
+        printf("hello"); // hello
+
+        // world
+        printf("world");
+    }
+  END
+
+  let input_file = "test_textobj_conseq_comment_input2.c"
+  call writefile(lines, input_file, "D")
+
+  let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
+
+  call term_sendkeys(buf, "dac")
+  let output_file = "comment_textobj_conseq_comment2.c"
+  call term_sendkeys(buf, $":w {output_file}\<CR>")
+  defer delete(output_file)
+
+  call StopVimInTerminal(buf)
+
+  let result = readfile(output_file)
+
+  call assert_equal(["int main() {", "    printf(\"hello\");", "", "    // world", "    printf(\"world\");", "}"], result)
 endfunc

--- a/src/testdir/test_plugin_comment.vim
+++ b/src/testdir/test_plugin_comment.vim
@@ -378,3 +378,30 @@ func Test_textobj_noleading_space_comment2()
 
   call assert_equal(["int main() {", "}"], result)
 endfunc
+
+func Test_textobj_cursor_on_leading_space_comment()
+  CheckScreendump
+  let lines =<< trim END
+    int main() {
+        // multilple comments
+        // cursor is between them
+    }
+  END
+
+  let input_file = "test_textobj_cursor_on_leading_space_comment_input.c"
+  call writefile(lines, input_file, "D")
+
+  let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
+
+  call term_sendkeys(buf, "jjdac")
+  let output_file = "comment_textobj_cursor_on_leading_space_comment.c"
+  call term_sendkeys(buf, $":w {output_file}\<CR>")
+  defer delete(output_file)
+
+  call StopVimInTerminal(buf)
+
+  let result = readfile(output_file)
+
+  call assert_equal(["int main() {", "", "}"], result)
+endfunc
+

--- a/src/testdir/test_plugin_comment.vim
+++ b/src/testdir/test_plugin_comment.vim
@@ -331,7 +331,6 @@ func Test_textobj_firstline_comment()
   call assert_equal(["int main() {}"], result)
 endfunc
 
-
 func Test_textobj_noleading_space_comment()
   CheckScreendump
   let lines =<< trim END
@@ -346,6 +345,30 @@ func Test_textobj_noleading_space_comment()
 
   call term_sendkeys(buf, "dacdic")
   let output_file = "comment_textobj_noleading_space_comment.c"
+  call term_sendkeys(buf, $":w {output_file}\<CR>")
+  defer delete(output_file)
+
+  call StopVimInTerminal(buf)
+
+  let result = readfile(output_file)
+
+  call assert_equal(["int main() {", "}"], result)
+endfunc
+
+func Test_textobj_noleading_space_comment2()
+  CheckScreendump
+  let lines =<< trim END
+    int main() {// main start
+    }    /* main end */
+  END
+
+  let input_file = "test_textobj_noleading_space_input2.c"
+  call writefile(lines, input_file, "D")
+
+  let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
+
+  call term_sendkeys(buf, "dac.")
+  let output_file = "comment_textobj_noleading_space_comment2.c"
   call term_sendkeys(buf, $":w {output_file}\<CR>")
   defer delete(output_file)
 

--- a/src/testdir/test_plugin_comment.vim
+++ b/src/testdir/test_plugin_comment.vim
@@ -55,7 +55,7 @@ func Test_basic_uncomment()
 
   let result = readfile(output_file)
 
- call assert_equal(["# vim9script", "", "def Hello()", '  echo "Hello"', "enddef"], result)
+  call assert_equal(["# vim9script", "", "def Hello()", '  echo "Hello"', "enddef"], result)
 endfunc
 
 func Test_bothends_comment()
@@ -239,7 +239,35 @@ func Test_textobj_icomment2()
 
   let result = readfile(output_file)
 
-   call assert_equal(["#include <stdio.h>", "", "int main() {", "    printf(\"hello\");  printf(\" world\\n\");", "    ", "", "    return 0;", "}"], result)
+  call assert_equal(["#include <stdio.h>", "", "int main() {", "    printf(\"hello\");  printf(\" world\\n\");", "    ", "", "    return 0;", "}"], result)
+endfunc
+
+func Test_textobj_icomment3()
+  CheckScreendump
+  let lines =<< trim END
+    #include <stdio.h>
+
+    int main() {
+        printf("hello");/*hello world*/printf(" world\n");
+        return 0;
+    }
+  END
+
+  let input_file = "test_textobj_icomment3_input.c"
+  call writefile(lines, input_file, "D")
+
+  let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
+
+  call term_sendkeys(buf, "jjjdic")
+  let output_file = "comment_textobj_icomment3.c"
+  call term_sendkeys(buf, $":w {output_file}\<CR>")
+  defer delete(output_file)
+
+  call StopVimInTerminal(buf)
+
+  let result = readfile(output_file)
+
+  call assert_equal(["#include <stdio.h>", "", "int main() {", "    printf(\"hello\");printf(\" world\\n\");",  "    return 0;", "}"], result)
 endfunc
 
 func Test_textobj_acomment()
@@ -303,7 +331,35 @@ func Test_textobj_acomment2()
 
   let result = readfile(output_file)
 
-   call assert_equal(["#include <stdio.h>", "", "int main() {", "    printf(\"hello\");printf(\" world\\n\");", "    return 0;", "}"], result)
+  call assert_equal(["#include <stdio.h>", "", "int main() {", "    printf(\"hello\");printf(\" world\\n\");", "    return 0;", "}"], result)
+endfunc
+
+func Test_textobj_acomment3()
+  CheckScreendump
+  let lines =<< trim END
+    #include <stdio.h>
+
+    int main() {
+        printf("hello");/*hello world*/printf(" world\n");
+        return 0;
+    }
+  END
+
+  let input_file = "test_textobj_acomment3_input.c"
+  call writefile(lines, input_file, "D")
+
+  let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
+
+  call term_sendkeys(buf, "jjjdac")
+  let output_file = "comment_textobj_acomment3.c"
+  call term_sendkeys(buf, $":w {output_file}\<CR>")
+  defer delete(output_file)
+
+  call StopVimInTerminal(buf)
+
+  let result = readfile(output_file)
+
+  call assert_equal(["#include <stdio.h>", "", "int main() {", "    printf(\"hello\");printf(\" world\\n\");",  "    return 0;", "}"], result)
 endfunc
 
 func Test_textobj_firstline_comment()
@@ -404,4 +460,3 @@ func Test_textobj_cursor_on_leading_space_comment()
 
   call assert_equal(["int main() {", "", "}"], result)
 endfunc
-

--- a/src/testdir/test_plugin_comment.vim
+++ b/src/testdir/test_plugin_comment.vim
@@ -330,3 +330,28 @@ func Test_textobj_firstline_comment()
 
   call assert_equal(["int main() {}"], result)
 endfunc
+
+
+func Test_textobj_noleading_space_comment()
+  CheckScreendump
+  let lines =<< trim END
+    int main() {// main start
+    }/* main end */
+  END
+
+  let input_file = "test_textobj_noleading_space_input.c"
+  call writefile(lines, input_file, "D")
+
+  let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
+
+  call term_sendkeys(buf, "dacdic")
+  let output_file = "comment_textobj_noleading_space_comment.c"
+  call term_sendkeys(buf, $":w {output_file}\<CR>")
+  defer delete(output_file)
+
+  call StopVimInTerminal(buf)
+
+  let result = readfile(output_file)
+
+  call assert_equal(["int main() {", "}"], result)
+endfunc

--- a/src/testdir/test_plugin_comment.vim
+++ b/src/testdir/test_plugin_comment.vim
@@ -305,3 +305,28 @@ func Test_textobj_acomment2()
 
    call assert_equal(["#include <stdio.h>", "", "int main() {", "    printf(\"hello\");printf(\" world\\n\");", "    return 0;", "}"], result)
 endfunc
+
+func Test_textobj_firstline_comment()
+  CheckScreendump
+  let lines =<< trim END
+    /*#include <stdio.h>*/
+
+    int main() {}
+  END
+
+  let input_file = "test_textobj_firstlinecomment_input.c"
+  call writefile(lines, input_file, "D")
+
+  let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
+
+  call term_sendkeys(buf, "dac")
+  let output_file = "comment_textobj_firstline_comment.c"
+  call term_sendkeys(buf, $":w {output_file}\<CR>")
+  defer delete(output_file)
+
+  call StopVimInTerminal(buf)
+
+  let result = readfile(output_file)
+
+  call assert_equal(["int main() {}"], result)
+endfunc

--- a/src/testdir/test_plugin_comment.vim
+++ b/src/testdir/test_plugin_comment.vim
@@ -177,3 +177,131 @@ func Test_mixed_indent_comment()
 
   call assert_equal(["/* int main() { */", "\t/* if 1 { */", "\t  /* return 0; */",  "\t/* } */", "    /* return 1; */", "/* } */"], result)
 endfunc
+
+func Test_textobj_icomment()
+  CheckScreendump
+  let lines =<< trim END
+    for x in range(10):
+      print(x) # printing stuff
+      # print(x*x)
+      #print(x*x*x)
+      print(x*x*x*x) # printing stuff
+      print(x*x*x*x*x) # printing stuff
+      # print(x*x)
+      #print(x*x*x)
+
+      print(x*x*x*x*x)
+  END
+
+  let input_file = "test_textobj_icomment_input.py"
+  call writefile(lines, input_file, "D")
+
+  let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
+
+  call term_sendkeys(buf, "dic..")
+  let output_file = "comment_textobj_icomment.py"
+  call term_sendkeys(buf, $":w {output_file}\<CR>")
+  defer delete(output_file)
+
+  call StopVimInTerminal(buf)
+
+  let result = readfile(output_file)
+
+  call assert_equal(["for x in range(10):", "  print(x) ", "  print(x*x*x*x) ", "  print(x*x*x*x*x) ", "", "  print(x*x*x*x*x)"], result)
+endfunc
+
+func Test_textobj_icomment2()
+  CheckScreendump
+  let lines =<< trim END
+    #include <stdio.h>
+
+    int main() {
+        printf("hello"); /* hello world */ printf(" world\n");
+        /* if 1 {
+            return 1;
+        }*/
+
+        return 0;
+    }
+  END
+
+  let input_file = "test_textobj_icomment2_input.c"
+  call writefile(lines, input_file, "D")
+
+  let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
+
+  call term_sendkeys(buf, "dic..")
+  let output_file = "comment_textobj_icomment2.c"
+  call term_sendkeys(buf, $":w {output_file}\<CR>")
+  defer delete(output_file)
+
+  call StopVimInTerminal(buf)
+
+  let result = readfile(output_file)
+
+   call assert_equal(["#include <stdio.h>", "", "int main() {", "    printf(\"hello\");  printf(\" world\\n\");", "    ", "", "    return 0;", "}"], result)
+endfunc
+
+func Test_textobj_acomment()
+  CheckScreendump
+  let lines =<< trim END
+    for x in range(10):
+      print(x) # printing stuff
+      # print(x*x)
+      #print(x*x*x)
+      print(x*x*x*x) # printing stuff
+      print(x*x*x*x*x) # printing stuff
+      # print(x*x)
+      #print(x*x*x)
+
+      print(x*x*x*x*x)
+  END
+
+  let input_file = "test_textobj_acomment_input.py"
+  call writefile(lines, input_file, "D")
+
+  let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
+
+  call term_sendkeys(buf, "dac..")
+  let output_file = "comment_textobj_acomment.py"
+  call term_sendkeys(buf, $":w {output_file}\<CR>")
+  defer delete(output_file)
+
+  call StopVimInTerminal(buf)
+
+  let result = readfile(output_file)
+
+  call assert_equal(["for x in range(10):", "  print(x)", "  print(x*x*x*x)", "  print(x*x*x*x*x)", "", "  print(x*x*x*x*x)"], result)
+endfunc
+
+func Test_textobj_acomment2()
+  CheckScreendump
+  let lines =<< trim END
+    #include <stdio.h>
+
+    int main() {
+        printf("hello"); /* hello world */ printf(" world\n");
+        /* if 1 {
+            return 1;
+        }*/
+
+        return 0;
+    }
+  END
+
+  let input_file = "test_textobj_acomment2_input.c"
+  call writefile(lines, input_file, "D")
+
+  let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
+
+  call term_sendkeys(buf, "dac.")
+  let output_file = "comment_textobj_acomment2.c"
+  call term_sendkeys(buf, $":w {output_file}\<CR>")
+  defer delete(output_file)
+
+  call StopVimInTerminal(buf)
+
+  let result = readfile(output_file)
+
+   call assert_equal(["#include <stdio.h>", "", "int main() {", "    printf(\"hello\");printf(\" world\\n\");", "    return 0;", "}"], result)
+endfunc


### PR DESCRIPTION
Add comment text object `ic` and `ac`:

[![asciicast](https://asciinema.org/a/akUDDNUUVf44rlX7QVptv3EOA.svg)](https://asciinema.org/a/akUDDNUUVf44rlX7QVptv3EOA)

Works when syntax is enabled, useful to do something with a comment (including uncommenting a comment with `gcic` or `gcac`)