### PR TITLE
runtime(sh): consider sh as POSIX shell by default

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -3512,25 +3512,25 @@ cases pertain, then the first line of the file is examined (ex. looking for
 /bin/sh  /bin/ksh  /bin/bash).  If the first line specifies a shelltype, then
 that shelltype is used.  However some files (ex. .profile) are known to be
 shell files but the type is not apparent.  Furthermore, on many systems sh is
-symbolically linked to "bash" (Linux, Windows+cygwin) or "ksh" (Posix).
+symbolically linked to "bash" (Linux, Windows+cygwin) or "ksh" (POSIX).
 
 One may specify a global default by instantiating one of the following
 variables in your <.vimrc>:
 
    ksh: >
 	let g:is_kornshell = 1
-<   posix:  (using this is nearly the same as setting g:is_kornshell to 1) >
+<   posix: (default) >
 	let g:is_posix     = 1
 <   bash: >
 	let g:is_bash	   = 1
-<   sh: (default) Bourne shell >
+<   dash: >
+	let g:is_dash	   = 1
+<   sh: Bourne shell >
 	let g:is_sh	   = 1
-
-<   (dash users should use posix)
 
 If there's no "#! ..." line, and the user hasn't availed himself/herself of a
 default sh.vim syntax setting as just shown, then syntax/sh.vim will assume
-the Bourne shell syntax.  No need to quote RFCs or market penetration
+the POSIX shell syntax.  No need to quote RFCs or market penetration
 statistics in error reports, please -- just select the default version of the
 sh your system uses and install the associated "let..." in your <.vimrc>.
 

--- a/runtime/syntax/sh.vim
+++ b/runtime/syntax/sh.vim
@@ -17,6 +17,9 @@ if exists("b:current_syntax")
   finish
 endif
 
+" Ensure this is set unless we find another shell
+let b:is_sh = 1
+
 " If the shell script itself specifies which shell to use, use it
 if getline(1) =~ '\<ksh\>'
  let b:is_kornshell = 1
@@ -24,60 +27,56 @@ elseif getline(1) =~ '\<bash\>'
  let b:is_bash      = 1
 elseif getline(1) =~ '\<dash\>'
  let b:is_dash      = 1
-elseif !exists("g:is_kornshell") && !exists("g:is_bash") && !exists("g:is_posix") && !exists("g:is_sh") && !exists("g:is_dash")
- " user did not specify which shell to use, and
- " the script itself does not specify which shell to use. FYI: /bin/sh is ambiguous.
- " Assuming /bin/sh is executable, and if its a link, find out what it links to.
- let s:shell = ""
- if executable("/bin/sh")
-  let s:shell = resolve("/bin/sh")
- elseif executable("/usr/bin/sh")
-  let s:shell = resolve("/usr/bin/sh")
- endif
- if     s:shell =~ '\<ksh\>'
-  let b:is_kornshell= 1
- elseif s:shell =~ '\<bash\>'
-  let b:is_bash = 1
- elseif s:shell =~ '\<dash\>'
-  let b:is_dash = 1
- endif
- unlet s:shell
-endif
-
 " handling /bin/sh with is_kornshell/is_sh {{{1
 " b:is_sh will be set when "#! /bin/sh" is found;
 " However, it often is just a masquerade by bash (typically Linux)
 " or kornshell (typically workstations with Posix "sh").
-" So, when the user sets "g:is_bash", "g:is_kornshell",
-" or "g:is_posix", a b:is_sh is converted into b:is_bash/b:is_kornshell,
-" respectively.
-if !exists("b:is_kornshell") && !exists("b:is_bash") && !exists("b:is_dash")
-  if exists("g:is_posix") && !exists("g:is_kornshell")
-   let g:is_kornshell= g:is_posix
+" So, when the user sets "g:is_kornshell", "g:is_bash",
+" "g:is_posix" or "g:is_dash", a b:is_sh is converted into
+" b:is_kornshell/b:is_bash/b:is_posix/b:is_dash, respectively.
+elseif !exists("b:is_kornshell") && !exists("b:is_bash") && !exists("b:is_posix") && !exists("b:is_dash")
+ if exists("g:is_kornshell")
+  let b:is_kornshell= 1
+ elseif exists("g:is_bash")
+  let b:is_bash= 1
+ elseif exists("g:is_dash")
+  let b:is_dash= 1
+ elseif exists("g:is_posix")
+  let b:is_posix= 1
+ elseif exists("g:is_sh")
+  let b:is_sh= 1
+ else
+  " user did not specify which shell to use, and
+  " the script itself does not specify which shell to use. FYI: /bin/sh is ambiguous.
+  " Assuming /bin/sh is executable, and if its a link, find out what it links to.
+  let s:shell = ""
+  if executable("/bin/sh")
+   let s:shell = resolve("/bin/sh")
+  elseif executable("/usr/bin/sh")
+   let s:shell = resolve("/usr/bin/sh")
   endif
-  if exists("g:is_kornshell")
-    let b:is_kornshell= 1
-    if exists("b:is_sh")
-      unlet b:is_sh
-    endif
-  elseif exists("g:is_bash")
-    let b:is_bash= 1
-    if exists("b:is_sh")
-      unlet b:is_sh
-    endif
-  elseif exists("g:is_dash")
-    let b:is_dash= 1
-    if exists("b:is_sh")
-      unlet b:is_sh
-    endif
+  if     s:shell =~ '\<ksh\>'
+   let b:is_kornshell= 1
+  elseif s:shell =~ '\<bash\>'
+   let b:is_bash = 1
+  elseif s:shell =~ '\<dash\>'
+   let b:is_dash = 1
   else
-    let b:is_sh= 1
+   let b:is_posix = 1
   endif
+  unlet s:shell
+ endif
 endif
 
 " if b:is_dash, set b:is_posix too
 if exists("b:is_dash")
  let b:is_posix= 1
+endif
+
+if exists("b:is_kornshell") || exists("b:is_bash")
+ if exists("b:is_sh")
+  unlet b:is_sh
+ endif
 endif
 
 " set up default g:sh_fold_enabled {{{1


### PR DESCRIPTION
Also, do not set g:is_kornshell when g:is_posix is set.

This resolves standard constructs such as command substitution (eg. `$(echo hello)`) being flagged as errors by default on BSDs (including macOS) where the shell is not a symlink to anything. It should be safe to assume that `/bin/sh` in 2025 supports POSIX. On legacy systems, the user can override this with `g:is_sh`.

This also fixes a bug where it attempts to resolve a `/bin/sh` symlink despite the shell already being specified (eg. via the name of the file such as `.bash_profile`).