### PR TITLE
Fix compile failure if FEAT_QUICKFIX is not defined.

### DIFF
--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -40,10 +40,10 @@ static int  message_win_time = 3000;
 // hit-enter prompt.
 static int    start_message_win_timer = FALSE;
 
-static int popup_on_cmdline = FALSE;
-
 static void may_start_message_win_timer(win_T *wp);
 #endif
+
+static int popup_on_cmdline = FALSE;
 
 static void popup_adjust_position(win_T *wp);
 

--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -4573,15 +4573,6 @@ popup_hide_info(void)
 }
 
 /*
- * Returns TRUE if a popup extends into the cmdline area.
- */
-    int
-popup_overlaps_cmdline(void)
-{
-    return popup_on_cmdline;
-}
-
-/*
  * Close any info popup.
  */
     void
@@ -4593,6 +4584,15 @@ popup_close_info(void)
 	popup_close_with_retval(wp, -1);
 }
 #endif
+
+/*
+ * Returns TRUE if a popup extends into the cmdline area.
+ */
+    int
+popup_overlaps_cmdline(void)
+{
+    return popup_on_cmdline;
+}
 
 #if defined(HAS_MESSAGE_WINDOW) || defined(PROTO)
 

--- a/src/screen.c
+++ b/src/screen.c
@@ -2328,7 +2328,7 @@ screen_fill(
 	    redraw_cmdline = TRUE;
 	    if (start_col == 0 && end_col == Columns
 		    && c1 == ' ' && c2 == ' ' && attr == 0
-#ifdef FEAT_PROP_POPUP
+#if defined(FEAT_PROP_POPUP) && defined(FEAT_QUICKFIX)
 		    && !popup_overlaps_cmdline()
 #endif
 		    )

--- a/src/screen.c
+++ b/src/screen.c
@@ -2328,7 +2328,7 @@ screen_fill(
 	    redraw_cmdline = TRUE;
 	    if (start_col == 0 && end_col == Columns
 		    && c1 == ' ' && c2 == ' ' && attr == 0
-#if defined(FEAT_PROP_POPUP) && defined(FEAT_QUICKFIX)
+#ifdef FEAT_PROP_POPUP
 		    && !popup_overlaps_cmdline()
 #endif
 		    )


### PR DESCRIPTION
My windows x64 GUI build (clang 20.1.0 on msys2) fails to compile with his linker error if FEAT_QUICKFIX is not defined:
`make --directory=/e/Users/John/Documents/Software/Utility/Vim/git/vim/src CC=clang CXX=clang++ FEATURES=NORMAL OPTIMIZE=MAXSPEED DIRECTX=no ICONV= GETTEXT= IME=no DYNAMIC_IME=no POSTSCRIPT=no OLE=no WINVER=0x0A00 CSCOPE=no NETBEANS=no CHANNEL=no TERMINAL=no SOUND=no XPM=no STATIC_STDCPLUS=yes GUI=yes CFLAGS=-I. -Iproto -DWIN32 -DWINVER=0x0A00 -D_WIN32_WINNT=0x0A00 -DHAVE_PATHDEF -DFEAT_NORMAL -DHAVE_STDINT_H -D__USE_MINGW_ANSI_STDIO -pipe -Wall -O3 -fomit-frame-pointer -fpie -fPIE -Db_lto=true -Db_lto_mode=thin -DFEAT_GUI_MSWIN -DFEAT_CLIPBOARD LFLAGS=-Wl,-nxcompat,-dynamicbase -Wl,--high-entropy-va -Wl,--as-needed -Wl,--pic-executable -municode -s -mwindows --environment-overrides --jobs=33 --keep-going --output-sync --no-print-directory --makefile=Make_ming.mak gvim.exe
clang -c -I. -Iproto -DWIN32 -DWINVER=0x0A00 -D_WIN32_WINNT=0x0A00 -DHAVE_PATHDEF -DFEAT_NORMAL -DHAVE_STDINT_H -D__USE_MINGW_ANSI_STDIO -pipe -Wall -O3 -fomit-frame-pointer -fpie -fPIE -Db_lto=true -Db_lto_mode=thin -DFEAT_GUI_MSWIN -DFEAT_CLIPBOARD screen.c -o gobjx86-64/screen.o
clang -I. -Iproto -DWIN32 -DWINVER=0x0A00 -D_WIN32_WINNT=0x0A00 -DHAVE_PATHDEF -DFEAT_NORMAL -DHAVE_STDINT_H -D__USE_MINGW_ANSI_STDIO -pipe -Wall -O3 -fomit-frame-pointer -fpie -fPIE -Db_lto=true -Db_lto_mode=thin -DFEAT_GUI_MSWIN -DFEAT_CLIPBOARD -Wl,-nxcompat,-dynamicbase -Wl,--high-entropy-va -Wl,--as-needed -Wl,--pic-executable -municode -s -mwindows -o gvim.exe gobjx86-64/alloc.o gobjx86-64/arabic.o gobjx86-64/arglist.o gobjx86-64/autocmd.o gobjx86-64/beval.o gobjx86-64/blob.o gobjx86-64/blowfish.o gobjx86-64/buffer.o gobjx86-64/bufwrite.o gobjx86-64/change.o gobjx86-64/charset.o gobjx86-64/cindent.o gobjx86-64/clientserver.o gobjx86-64/clipboard.o gobjx86-64/cmdexpand.o gobjx86-64/cmdhist.o gobjx86-64/crypt.o gobjx86-64/crypt_zip.o gobjx86-64/debugger.o gobjx86-64/dict.o gobjx86-64/diff.o gobjx86-64/digraph.o gobjx86-64/drawline.o gobjx86-64/drawscreen.o gobjx86-64/edit.o gobjx86-64/eval.o gobjx86-64/evalbuffer.o gobjx86-64/evalfunc.o gobjx86-64/evalvars.o gobjx86-64/evalwindow.o gobjx86-64/ex_cmds.o gobjx86-64/ex_cmds2.o gobjx86-64/ex_docmd.o gobjx86-64/ex_eval.o gobjx86-64/ex_getln.o gobjx86-64/fileio.o gobjx86-64/filepath.o gobjx86-64/findfile.o gobjx86-64/float.o gobjx86-64/fold.o gobjx86-64/getchar.o gobjx86-64/gc.o gobjx86-64/gui_xim.o gobjx86-64/hardcopy.o gobjx86-64/hashtab.o gobjx86-64/help.o gobjx86-64/highlight.o gobjx86-64/if_cscope.o gobjx86-64/indent.o gobjx86-64/insexpand.o gobjx86-64/json.o gobjx86-64/linematch.o gobjx86-64/list.o gobjx86-64/locale.o gobjx86-64/logfile.o gobjx86-64/main.o gobjx86-64/map.o gobjx86-64/mark.o gobjx86-64/match.o gobjx86-64/memfile.o gobjx86-64/memline.o gobjx86-64/menu.o gobjx86-64/message.o gobjx86-64/misc1.o gobjx86-64/misc2.o gobjx86-64/mouse.o gobjx86-64/move.o gobjx86-64/mbyte.o gobjx86-64/normal.o gobjx86-64/ops.o gobjx86-64/option.o gobjx86-64/optionstr.o gobjx86-64/os_mswin.o gobjx86-64/os_win32.o gobjx86-64/pathdef.o gobjx86-64/popupmenu.o gobjx86-64/popupwin.o gobjx86-64/profiler.o gobjx86-64/quickfix.o gobjx86-64/regexp.o gobjx86-64/register.o gobjx86-64/scriptfile.o gobjx86-64/screen.o gobjx86-64/search.o gobjx86-64/session.o gobjx86-64/sha256.o gobjx86-64/sign.o gobjx86-64/spell.o gobjx86-64/spellfile.o gobjx86-64/spellsuggest.o gobjx86-64/strings.o gobjx86-64/syntax.o gobjx86-64/tag.o gobjx86-64/term.o gobjx86-64/testing.o gobjx86-64/textformat.o gobjx86-64/textobject.o gobjx86-64/textprop.o gobjx86-64/time.o gobjx86-64/typval.o gobjx86-64/ui.o gobjx86-64/undo.o gobjx86-64/usercmd.o gobjx86-64/userfunc.o gobjx86-64/version.o gobjx86-64/vim9class.o gobjx86-64/vim9cmds.o gobjx86-64/vim9compile.o gobjx86-64/vim9execute.o gobjx86-64/vim9expr.o gobjx86-64/vim9instr.o gobjx86-64/vim9script.o gobjx86-64/vim9type.o gobjx86-64/viminfo.o gobjx86-64/winclip.o gobjx86-64/window.o gobjx86-64/os_w32exe.o gobjx86-64/vimres.o gobjx86-64/xdiffi.o gobjx86-64/xemit.o gobjx86-64/xprepare.o gobjx86-64/xutils.o gobjx86-64/xhistogram.o gobjx86-64/xpatience.o gobjx86-64/gui.o gobjx86-64/gui_w32.o gobjx86-64/gui_beval.o -lkernel32 -luser32 -lgdi32 -ladvapi32 -lcomdlg32 -lcomctl32 -lnetapi32 -lversion -lgcc_eh -Wl,-Bstatic -lwinpthread -Wl,-Bdynamic -lole32 -luuid
E:/msys64/ucrt64/bin/ld: gobjx86-64/screen.o:screen.c:(.text+0xcc9): undefined reference to 'popup_overlaps_cmdline'
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [Make_cyg_ming.mak:1170: gvim.exe] Error 1`

Non-GUI build fails with the same error.

The inclusion of the call to `popup_overlaps_cmdline()` in `screen.c` (line 2332) is conditional on the definition of `FEAT_PROP_POPUP`. However, `popup_overlaps_cmdline()` is only defined in `popupwin.c` if `FEAT_QUICKFIX` is defined (lines 4514 to 4595).

Cheers
John