### PR TITLE
fix: col of current pos update wrong after got a match

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -5375,7 +5375,6 @@ search_for_fuzzy_match(
 				}
 
 				*len = next_word_end - *ptr;
-				current_pos.col = *len;
 			    }
 			}
 			*pos = current_pos;

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -2963,6 +2963,10 @@ func Test_complete_fuzzy_collect()
   call feedkeys("Sh\<C-X>\<C-K>\<C-N>\<C-N>\<CR>\<Esc>0", 'tx!')
   call assert_equal('think', getline(line('.') - 1))
 
+  call setline(1, ['foo bar fuzzy', 'completefuzzycollect'])
+  call feedkeys("Gofuzzy\<C-X>\<C-N>\<C-N>\<C-N>\<C-Y>\<Esc>0", 'tx!')
+  call assert_equal('completefuzzycollect', getline('.'))
+
   bw!
   bw!
   set dict&


### PR DESCRIPTION
Problem: The current_pos.col was incorrectly updated to the length of the matching text. This will cause the next search to start from the wrong position.

Solution: current_pos has already been updated in search_str_in_line and does not need to be changed.