### PR TITLE
Limiting highlighting duration for package-hlyank

### DIFF
--- a/runtime/doc/usr_05.txt
+++ b/runtime/doc/usr_05.txt
@@ -470,8 +470,8 @@ Load the plugin with this command: >
 	packadd hlyank
 <
 This package briefly highlights the affected region of the last |yank|
-command. See |52.6| for a simplified implementation using the |getregionpos()|
-function.
+command.  See |52.6| for a simplified implementation using the
+|getregionpos()| function.
 
 The plugin understands the following configuration variables (the settings
 show the default values).
@@ -481,7 +481,9 @@ To specify a different highlighting group, use: >
 <
 To use a different highlighting duration, use: >
 	:let g:hlyank_duration = 300
-<
+The unit is milliseconds, and the upper limit is 3000 ms.  If you set a value
+higher than this, the highlighting duration will be 3000 ms.
+
 To highlight in visual mode, use: >
 	:let g:hlyank_invisual = v:true
 

--- a/runtime/pack/dist/opt/hlyank/plugin/hlyank.vim
+++ b/runtime/pack/dist/opt/hlyank/plugin/hlyank.vim
@@ -6,10 +6,7 @@ vim9script
 def HighlightedYank()
 
   var hlgroup = get(g:, "hlyank_hlgroup", "IncSearch")
-  var duration = get(g:, "hlyank_duration", 300)
-  if duration > 3000
-    duration = 3000
-  endif
+  var duration = min([get(g:, "hlyank_duration", 300), 3000])
   var in_visual = get(g:, "hlyank_invisual", true)
 
   if v:event.operator ==? 'y'

--- a/runtime/pack/dist/opt/hlyank/plugin/hlyank.vim
+++ b/runtime/pack/dist/opt/hlyank/plugin/hlyank.vim
@@ -7,6 +7,9 @@ def HighlightedYank()
 
   var hlgroup = get(g:, "hlyank_hlgroup", "IncSearch")
   var duration = get(g:, "hlyank_duration", 300)
+  if duration > 3000
+    duration = 3000
+  endif
   var in_visual = get(g:, "hlyank_invisual", true)
 
   if v:event.operator ==? 'y'
@@ -14,8 +17,8 @@ def HighlightedYank()
       visualmode(1)
       return
     endif
-    # if clipboard has autoselect (default on linux) exiting from Visual with ESC
-    # generates bogus event and this highlights previous yank
+    # if clipboard has autoselect (default on linux) exiting from Visual with
+    # ESC generates bogus event and this highlights previous yank
     if &clipboard =~ 'autoselect' && v:event.regname == "*" && v:event.visual
       return
     endif
@@ -36,3 +39,4 @@ augroup hlyank
   autocmd!
   autocmd TextYankPost * HighlightedYank()
 augroup END
+# vim:sts=2:sw=2:et:


### PR DESCRIPTION
I feel that if the highlighting duration is too long it can be confusing, so I set an upper limit (3000 ms).
Even if set `g:hlyank_duration` to a value higher than the upper limit, the highlighting duration will always be 3000 ms.
What do you think?

Other changes:
- Add the modeline to the last line of hlyank.vim.
- Fix over 80 columns in hlyank.vim:20
- Change "two spaces after a comma" in runtime/doc/usr_06.txt:473