### PR TITLE
filetype: SPA JSON files are not detected

### DIFF
--- a/.github/MAINTAINERS
+++ b/.github/MAINTAINERS
@@ -285,6 +285,7 @@ runtime/ftplugin/slint.vim		@ribru17
 runtime/ftplugin/snakemake.vim		@ribru17
 runtime/ftplugin/solidity.vim		@cothi
 runtime/ftplugin/solution.vim		@dkearns
+runtime/ftplugin/spajson.vim		@dseomn
 runtime/ftplugin/spec.vim		@ignatenkobrain
 runtime/ftplugin/squirrel.vim		@ribru17
 runtime/ftplugin/ssa.vim		@ObserverOfTime
@@ -396,6 +397,7 @@ runtime/indent/scheme.vim		@evhan
 runtime/indent/scss.vim			@tpope
 runtime/indent/sh.vim			@chrisbra
 runtime/indent/solidity.vim		@cothi
+runtime/indent/spajson.vim		@dseomn
 runtime/indent/systemverilog.vim	@Kocha
 runtime/indent/tcl.vim			@dkearns
 runtime/indent/tcsh.vim			@dkearns
@@ -609,6 +611,7 @@ runtime/syntax/sed.vim			@dkearns
 runtime/syntax/shared/debversions.vim	@jamessan
 runtime/syntax/shaderslang.vim          @mTvare6
 runtime/syntax/solidity.vim		@cothi
+runtime/syntax/spajson.vim		@dseomn
 runtime/syntax/spec.vim			@ignatenkobrain
 runtime/syntax/sqloracle.vim		@chrisbra
 runtime/syntax/squirrel.vim		@zenmatic

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -2515,6 +2515,10 @@ au BufNewFile,BufRead *.class
 " SMCL
 au BufNewFile,BufRead *.hlp,*.ihlp,*.smcl	setf smcl
 
+" SPA JSON
+au BufNewFile,BufRead */pipewire/*.conf		setf spajson
+au BufNewFile,BufRead */wireplumber/*.conf	setf spajson
+
 " Stored Procedures
 au BufNewFile,BufRead *.stp			setf stp
 

--- a/runtime/ftplugin/spajson.vim
+++ b/runtime/ftplugin/spajson.vim
@@ -1,0 +1,14 @@
+" Vim filetype plugin
+" Language:	SPA JSON
+" Maintainer:	David Mandelberg <david@mandelberg.org>
+" Last Change:	2025 Mar 22
+
+if exists('b:did_ftplugin')
+  finish
+endif
+let b:did_ftplugin = 1
+
+setlocal comments=:###,:##,:#
+setlocal commentstring=#\ %s
+
+let b:undo_ftplugin = "setlocal comments< commentstring<"

--- a/runtime/indent/spajson.vim
+++ b/runtime/indent/spajson.vim
@@ -1,0 +1,6 @@
+" Vim indent file
+" Language:	SPA JSON
+" Maintainer:	David Mandelberg <david@mandelberg.org>
+" Last Change:	2025 Mar 22
+
+runtime! indent/json.vim

--- a/runtime/syntax/spajson.vim
+++ b/runtime/syntax/spajson.vim
@@ -1,0 +1,50 @@
+" Vim syntax file
+" Language:	SPA JSON
+" Maintainer:	David Mandelberg <david@mandelberg.org>
+" Last Change:	2025 Mar 22
+"
+" Based on parser code:
+" https://gitlab.freedesktop.org/pipewire/pipewire/-/blob/master/spa/include/spa/utils/json-core.h
+
+if exists("b:current_syntax")
+ finish
+endif
+let b:current_syntax = "spajson"
+
+syn sync minlines=500
+
+" Treat the __BARE parser state as a keyword, to make it easier to match
+" keywords and numbers only when they're not part of a larger __BARE section.
+" E.g., v4l2 and pipewire-0 probably shouldn't highlight anything as
+" spajsonInt.
+syn iskeyword 32-126,^ ,^",^#,^:,^,,^=,^],^},^\
+
+syn match spajsonEscape "\\["\\/bfnrt]" contained
+syn match spajsonEscape "\\u[0-9A-Fa-f]\{4}" contained
+
+syn match spajsonError "."
+syn match spajsonBare "\k\+"
+syn match spajsonComment "#.*$" contains=@Spell
+syn region spajsonString start=/"/ skip=/\\\\\|\\"/ end=/"/ contains=spajsonEscape
+syn match spajsonKeyDelimiter "[:=]"
+syn region spajsonArray matchgroup=spajsonBracket start="\[" end="]" contains=ALLBUT,spajsonKeyDelimiter fold
+syn region spajsonObject matchgroup=spajsonBrace start="{" end="}" contains=ALL fold
+syn match spajsonFloat "\<[+-]\?[0-9]\+\(\.[0-9]*\)\?\([Ee][+-]\?[0-9]\+\)\?\>"
+syn match spajsonFloat "\<[+-]\?\.[0-9]\+\([Ee][+-]\?[0-9]\+\)\?\>"
+syn match spajsonInt "\<[+-]\?0[Xx][0-9A-Fa-f]\+\>"
+syn match spajsonInt "\<[+-]\?[1-9][0-9]*\>"
+syn match spajsonInt "\<[+-]\?0[0-7]*\>"
+syn keyword spajsonBoolean true false
+syn keyword spajsonNull null
+syn match spajsonWhitespace "[\x00\t \r\n,]"
+
+hi def link spajsonBoolean Boolean
+hi def link spajsonBrace Delimiter
+hi def link spajsonBracket Delimiter
+hi def link spajsonComment Comment
+hi def link spajsonError Error
+hi def link spajsonEscape SpecialChar
+hi def link spajsonFloat Float
+hi def link spajsonInt Number
+hi def link spajsonNull Constant
+hi def link spajsonString String

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -721,6 +721,8 @@ def s:GetFilenameChecks(): dict<list<string>>
     snobol4: ['file.sno', 'file.spt'],
     solidity: ['file.sol'],
     solution: ['file.sln'],
+    spajson: ['any/pipewire/file.conf', 'any/pipewire/file.conf.d/other.conf',
+              'any/wireplumber/file.conf', 'any/wireplumber/file.conf.d/other.conf'],
     sparql: ['file.rq', 'file.sparql'],
     spec: ['file.spec'],
     spice: ['file.sp', 'file.spice'],


### PR DESCRIPTION
Problem:  filetype: SPA JSON files are not detected
Solution: detect pipewire and wireplumber config files as spajson
          filetype and include filetype, indent, and syntax files for
          the new filetype (David Mandelberg)

I looked at all the files found by this command to see if the syntax highlighting looked reasonable:

```
find {~/.config,/etc,/usr/share}/{pipewire,wireplumber} -type f -name \*.conf
```

References:
*   pipewire config files: https://docs.pipewire.org/page_config.html
*   wireplumber config files:
    https://pipewire.pages.freedesktop.org/wireplumber/daemon/configuration/conf_file.html
    and
    https://pipewire.pages.freedesktop.org/wireplumber/daemon/locations.html