### PR TITLE
str2blob() example is incorrect.

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -1323,9 +1323,10 @@ blob2str({blob} [, {options}])				*blob2str()*
 		See also |str2blob()|
 
 		Examples: >
-			blob2str(0z6162)	returns ["ab"]
-			blob2str(0zC2ABC2BB)	returns ["«»"]
-			blob2str(0zABBB, {'encoding': 'latin1'}) returns ["«»"]
+			blob2str(0z6162)	returns ['ab']
+			blob2str(0zC2ABC2BB)	returns ['«»']
+			blob2str(0z610A62)	returns ['a', 'b']
+			blob2str(0zABBB, {'encoding': 'latin1'}) returns ['«»']
 <
 		Can also be used as a |method|: >
 			GetBlob()->blob2str()
@@ -10666,11 +10667,12 @@ str2blob({list} [, {options}])					*str2blob()*
 		See also |blob2str()|
 
 		Examples: >
-		    str2blob(["ab"])	returns 0z6162
-		    str2blob(["«»"])	returns 0zC2ABC2BB
-		    str2blob(["a\nb"])	returns 0z610A62
-		    str2blob(readfile('myfile.txt'))
+		    str2blob(["ab"])		returns 0z6162
+		    str2blob(["«»"])		returns 0zC2ABC2BB
+		    str2blob(["a\nb"])		returns 0z610062
+		    str2blob(["a","b"])		returns 0z610A62
 		    str2blob(["«»"], {'encoding': 'latin1'}) returns 0zABBB
+		    str2blob(readfile('myfile.txt'))
 <
 		Can also be used as a |method|: >
 			GetListOfStrings()->str2blob()


### PR DESCRIPTION
```vim
:h str2blob()
/0z610A62
```

```
		    str2blob(["a\nb"])	returns 0z610A62
```

---

Expected:
```vim
:echo str2blob(["a\nb"])
0z610062
```

So I adjusted the `str2blob()` and `blob2str()` examples.

I received a report from @gcrtnst.
