### PR TITLE
Fix an omission in the documentation.

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -5896,8 +5896,8 @@ indexof({object}, {expr} [, {opts}])			*indexof()*
 		v:true.  {object} must be a |List|, a |Tuple| or a |Blob|.
 
 		If {object} is a |List| or a |Tuple|, evaluate {expr} for each
-		item in the List until the expression is v:true and return the
-		index of this item.
+		item in the List or Tuple until the expression is v:true
+		and return the index of this item.
 
 		If {object} is a |Blob| evaluate {expr} for each byte in the
 		Blob until the expression is v:true and return the index of


### PR DESCRIPTION
In the documentation for the ``indexof()`` function, one of the sentences in the documentation only mentions a ``List`` and not a ``Tuple`` as well.