### PR TITLE
When removing the ESC, also decrease string length.

### DIFF
--- a/src/edit.c
+++ b/src/edit.c
@@ -3022,7 +3022,7 @@ get_last_insert_save(void)
 	return NULL;
 
     if (insert.length > 0 && s[insert.length - 1] == ESC)	// remove trailing ESC
-	s[insert.length - 1] = NUL;
+	s[--insert.length] = NUL;
     return s;
 }
 


### PR DESCRIPTION
This fixes an off-by-one error in the string length when an ``ESC`` was removed at the end of the inserted string in the ``get_last_insert_save()`` function. In that case, the length also needs to be updated.