### PR TITLE
fix: cursor column didn't restore correctly when `splitkeep=screen`

### DIFF
--- a/src/testdir/test_window_cmd.vim
+++ b/src/testdir/test_window_cmd.vim
@@ -1979,6 +1979,18 @@ func Test_splitkeep_misc()
   set splitkeep&
 endfunc
 
+func Test_splitkeep_screen_cursor_pos()
+  new
+  set splitkeep=screen
+  call setline(1, ["longer than the last", "shorter"])
+  norm! $
+  wincmd s
+  close
+  call assert_equal([0, 1, 20, 0], getpos('.'))
+  %bwipeout!
+  set splitkeep&
+endfunc
+
 func Test_splitkeep_cursor()
   CheckScreendump
   let lines =<< trim END

--- a/src/window.c
+++ b/src/window.c
@@ -7038,7 +7038,7 @@ win_fix_scroll(int resize)
 	    {
 		int diff = (wp->w_winrow - wp->w_prev_winrow)
 					  + (wp->w_height - wp->w_prev_height);
-		linenr_T lnum = wp->w_cursor.lnum;
+		pos_T cursor = wp->w_cursor;
 		wp->w_cursor.lnum = wp->w_botline - 1;
 
 		//  Add difference in height and row to botline.
@@ -7052,7 +7052,8 @@ win_fix_scroll(int resize)
 		wp->w_fraction = FRACTION_MULT;
 		scroll_to_fraction(wp, wp->w_prev_height);
 
-		wp->w_cursor.lnum = lnum;
+		wp->w_cursor = cursor;
+		wp->w_valid &= ~VALID_WCOL;
 	    }
 	    else if (wp == curwin)
 		wp->w_valid &= ~VALID_CROW;


### PR DESCRIPTION
Problem: When `set splitkeep=screen`, cursor did't restore column
correctly when split a window on a line longer than the last line in
screen.
```
echo longlonglongling\nshort | vim - -u NONE --cmd 'set splitkeep=screen' +'norm $' +new +q
```

Solution: Restore cursor column in `win_fix_scroll` since it may be
changed in `getvcol` after
https://github.com/vim/vim/commit/396fd1ec2956307755392a1c61f55d5c1847f308.

Fix https://github.com/vim/vim/issues/16968.
