### PR TITLE
runtime(hyprlang): save and restore cpo setting in syntax script

### DIFF
--- a/runtime/syntax/hyprlang.vim
+++ b/runtime/syntax/hyprlang.vim
@@ -6,6 +6,9 @@
 if exists("b:current_syntax")
   finish
 endif
+let s:cpo= &cpo
+set cpo&vim
+
 let b:current_syntax = "hyprlang"
 
 syn case ignore
@@ -56,4 +59,6 @@ hi def link hyprString    String
 hi def link hyprColor     Structure
 hi def link hyprCommand   Keyword
 
+let &cpo = s:cpo
+unlet s:cpo
 " vim: ts=8 sts=2 sw=2 et


### PR DESCRIPTION
fixes: #16970