### PR TITLE
Update Solidity syntax

### DIFF
--- a/runtime/syntax/solidity.vim
+++ b/runtime/syntax/solidity.vim
@@ -158,6 +158,15 @@ hi def link solEvent             Type
 hi def link solEventName         Function
 hi def link solEventArgSpecial   Label
 
+" Error
+syn match   solError             /\<error\>/ nextgroup=solErrorName,solErrorArgs skipwhite
+syn match   solErrorName         contained /\<[a-zA-Z_$][0-9a-zA-Z_$]*/ nextgroup=solErrorArgs skipwhite
+syn region  solErrorArgs         contained matchgroup=solFuncParens start='(' end=')' contains=solErrorArgCommas,solBuiltinType skipwhite skipempty
+syn match   solErrorArgCommas    contained ','
+
+hi def link solError             Type
+hi def link solErrorName         Function
+
 " Comment
 syn keyword solCommentTodo       TODO FIXME XXX TBD contained
 syn match solNatSpec             contained /@title\|@author\|@notice\|@dev\|@param\|@inheritdoc\|@return/

--- a/runtime/syntax/solidity.vim
+++ b/runtime/syntax/solidity.vim
@@ -15,7 +15,7 @@ endif
 syn keyword solKeyword           abstract anonymous as break calldata case catch constant constructor continue default switch revert require
 syn keyword solKeyword           ecrecover addmod mulmod keccak256
 syn keyword solKeyword           delete do else emit enum external final for function if immutable import in indexed inline
-syn keyword solKeyword           interface internal is let match memory modifier new of payable pragma private public pure override virtual
+syn keyword solKeyword           interface internal is let match memory modifier new of payable pragma private public pure override virtual transient
 syn keyword solKeyword           relocatable return returns static storage struct throw try type typeof using
 syn keyword solKeyword           var view while
 

--- a/runtime/syntax/solidity.vim
+++ b/runtime/syntax/solidity.vim
@@ -2,10 +2,11 @@
 " Language:		Solidity
 " Maintainer:		Cothi (jiungdev@gmail.com)
 " Original Author:	tomlion (https://github.com/tomlion/vim-solidity/blob/master/syntax/solidity.vim)
-" Last Change:		2022 Sep 27
+" Last Change:		2025 Mar 25
 "
 " Contributors:
 "       Modified by thesis (https://github.com/thesis/vim-solidity/blob/main/indent/solidity.vim)
+"       Modified by S0AndS0 (https://github.com/S0AndS0/vim/blob/syntax-solidity-updates/runtime/syntax/solidity.vim)
 
 if exists("b:current_syntax")
   finish


### PR DESCRIPTION
**TLDR**

- `error` definitions are, other than lacking `indexed`, nearly identical to `event`
- `transient` is a key/value storage option scoped to a specific transaction
   > Note; spec says its incompatible with `constant` and `immutable` storage modifiers

**Relevant docs**

- https://soliditylang.org/blog/2021/04/21/custom-errors/
- https://docs.soliditylang.org/en/latest/contracts.html#transient-storage

**Example**

```solidity

abstract contract ExampleLock {
    bool transient locked;

    error ReentryBlockedFor(address caller);

    modifier nonReentrant {
        if (locked) revert ReentryBlockedFor(msg.sender);
        locked = true;
        _;
        locked = false;
    }
}
```
