### PR TITLE
Plugin comment update 20250326

### DIFF
--- a/runtime/pack/dist/opt/comment/autoload/comment.vim
+++ b/runtime/pack/dist/opt/comment/autoload/comment.vim
@@ -151,7 +151,7 @@ export def ObjComment(inner: bool)
         endif
     endif
 
-    if (pos_end[2] == (getline(pos_end[1])->len() ?? 1)) && pos_start[2] == 1
+    if (pos_end[2] == (getline(pos_end[1])->len() ?? 1)) && pos_start[2] <= 1
         cursor(pos_end[1], 1)
         normal! V
         cursor(pos_start[1], 1)

--- a/src/testdir/test_plugin_comment.vim
+++ b/src/testdir/test_plugin_comment.vim
@@ -457,7 +457,7 @@ func Test_textobj_cursor_on_leading_space_comment()
 
   let result = readfile(output_file)
 
-  call assert_equal(["int main() {", "", "}"], result)
+  call assert_equal(["int main() {", "}"], result)
 endfunc
 
 func Test_textobj_conseq_comment()

--- a/src/testdir/test_plugin_comment.vim
+++ b/src/testdir/test_plugin_comment.vim
@@ -514,3 +514,49 @@ func Test_textobj_conseq_comment2()
 
   call assert_equal(["int main() {", "    printf(\"hello\");", "", "    // world", "    printf(\"world\");", "}"], result)
 endfunc
+
+func Test_inline_comment()
+  CheckScreendump
+  let lines =<< trim END
+    echo "Hello" This should be a comment
+  END
+
+  let input_file = "test_inline_comment_input.vim"
+  call writefile(lines, input_file, "D")
+
+  let buf = RunVimInTerminal('-c "packadd comment" -c "nnoremap <expr> gC comment#Toggle()..''$''" ' .. input_file, {})
+
+  call term_sendkeys(buf, "fTgC")
+
+  let output_file = "comment_inline_test.vim"
+  call term_sendkeys(buf, $":w {output_file}\<CR>")
+  defer delete(output_file)
+
+  call StopVimInTerminal(buf)
+
+  let result = readfile(output_file)
+  call assert_equal(['echo "Hello" " This should be a comment'], result)
+endfunc
+
+func Test_inline_uncomment()
+  CheckScreendump
+  let lines =<< trim END
+    echo "Hello" " This should be a comment
+  END
+
+  let input_file = "test_inline_uncomment_input.vim"
+  call writefile(lines, input_file, "D")
+
+  let buf = RunVimInTerminal('-c "packadd comment" -c "nnoremap <expr> gC comment#Toggle()..''$''" ' .. input_file, {})
+
+  call term_sendkeys(buf, '$F"gC')
+
+  let output_file = "uncomment_inline_test.vim"
+  call term_sendkeys(buf, $":w {output_file}\<CR>")
+  defer delete(output_file)
+
+  call StopVimInTerminal(buf)
+
+  let result = readfile(output_file)
+  call assert_equal(['echo "Hello" This should be a comment'], result)
+endfunc


### PR DESCRIPTION
Fix regression where sometimes `ac/ic` should be line-wise:

[![asciicast](https://asciinema.org/a/yYpV8MnBYNA11ValTUp9UFjtj.svg)](https://asciinema.org/a/yYpV8MnBYNA11ValTUp9UFjtj)