### PR TITLE
fix internal error abort when closing window

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -545,8 +545,6 @@ close_buffer(
     int		wipe_buf = (action == DOBUF_WIPE || action == DOBUF_WIPE_REUSE);
     int		del_buf = (action == DOBUF_DEL || wipe_buf);
 
-    CHECK_CURBUF;
-
     // Force unloading or deleting when 'bufhidden' says so.
     // The caller must take care of NOT deleting/freeing when 'bufhidden' is
     // "hide" (otherwise we could never free or delete a buffer).


### PR DESCRIPTION
Should fix the error that was found coincidentally by a test found in #16920: [backtrace](https://github.com/vim/vim/pull/16920#issuecomment-2745384212).

A way to reproduce this:
1. compile with `ABORT_ON_INTERNAL_ERROR` defined
2. `:new`
3. `lexpr 'test' | lopen`
4. `wincmd k`
5. `lclose`
6. `wincmd q`

Not really sure what the CHECK_CURBUF macro is for though? Current fix just removes it because it doesn't seem to have any side effects.