### PR TITLE
No test that 'listchars' "eol" doesn't affect "gM"

### DIFF
--- a/src/testdir/test_normal.vim
+++ b/src/testdir/test_normal.vim
@@ -2698,6 +2698,22 @@ func Test_normal33_g_cmd2()
   call assert_equal(87, col('.'))
   call assert_equal('E', getreg(0))
 
+  " Have an odd number of chars in the line
+  norm! A.
+  call assert_equal(145, col('.'))
+  norm! gMyl
+  call assert_equal(73, col('.'))
+  call assert_equal('0', getreg(0))
+
+  " 'listchars' "eol" should not affect gM behavior
+  setlocal list listchars=eol:$
+  norm! $
+  call assert_equal(145, col('.'))
+  norm! gMyl
+  call assert_equal(73, col('.'))
+  call assert_equal('0', getreg(0))
+  setlocal nolist
+
   " Test for gM with Tab characters
   call setline('.', "\ta\tb\tc\td\te\tf")
   norm! gMyl


### PR DESCRIPTION
Problem:  No test that 'listchars' "eol" doesn't affect "gM".
Solution: Add a test.
