### PR TITLE
abort when closing window with attached quickfix data

### DIFF
--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -2035,10 +2035,24 @@ wipe_qf_buffer(qf_info_T *qi)
     qfbuf = buflist_findnr(qi->qf_bufnr);
     if (qfbuf != NULL && qfbuf->b_nwindows == 0)
     {
+	int buf_was_null = FALSE;
+	// can happen when curwin is going to be closed e.g. curwin->w_buffer
+	// was already closed in win_close(), and we are now closing the
+	// window related location list buffer from win_free_mem()
+	// but close_buffer() calls CHECK_CURBUF() macro and requires
+	// curwin->w_buffer == curbuf
+	if (curwin->w_buffer == NULL)
+	{
+	    curwin->w_buffer = curbuf;
+	    buf_was_null = TRUE;
+	}
+
 	// If the quickfix buffer is not loaded in any window, then
 	// wipe the buffer.
 	close_buffer(NULL, qfbuf, DOBUF_WIPE, FALSE, FALSE);
 	qi->qf_bufnr = INVALID_QFBUFNR;
+	if (buf_was_null)
+	    curwin->w_buffer = NULL;
     }
 }
 

--- a/src/testdir/test_quickfix.vim
+++ b/src/testdir/test_quickfix.vim
@@ -6718,4 +6718,12 @@ func Test_hardlink_fname()
   call Xtest_hardlink_fname('l')
 endfunc
 
+func Test_quickfix_close_buffer_crash()
+  new
+  lexpr 'test' | lopen
+  wincmd k
+  lclose
+  wincmd q
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  If win_close() is called with a window that has quickfix stack
          attached to it, the corresponding quickfix buffer will be
          closed and freed after the buffer was already closed. At that
          time curwin->w_buffer points to NULL, which the CHECK_CURBUF
          will catch and abort if ABORT_ON_ERROR is defined
Solution: in wipe_qf_buffer temporarily point curwin->w_buffer back to
          curbuf, the window will be closed anyhow, so it shouldn't
          matter that curbuf->b_nwindows isn't incremented.

closes: #16985