### PR TITLE
Fix pi_netrw.txt build to be cross-platform portable

### DIFF
--- a/runtime/doc/Makefile
+++ b/runtime/doc/Makefile
@@ -143,7 +143,7 @@ os_win32.txt:
 
 pi_netrw.txt: ../pack/dist/opt/netrw/doc/netrw.txt
 	cp ../pack/dist/opt/netrw/doc/netrw.txt $@.tmp
-	sed -e '1s/\(.*\)/\0	*pi_netrw.txt*/' $@.tmp > $@ && \
+	sed -e '1s/\(.*\)/\1	*pi_netrw.txt*/' $@.tmp > $@ && \
 	rm -f $@.tmp
 
 vietnamese.txt:

--- a/runtime/doc/Makefile
+++ b/runtime/doc/Makefile
@@ -143,7 +143,7 @@ os_win32.txt:
 
 pi_netrw.txt: ../pack/dist/opt/netrw/doc/netrw.txt
 	cp ../pack/dist/opt/netrw/doc/netrw.txt $@.tmp
-	sed -e '1s/\(.*\)/\1	*pi_netrw.txt*/' $@.tmp > $@ && \
+	sed -e '1s/$$/	*pi_netrw.txt*/' $@.tmp > $@ && \
 	rm -f $@.tmp
 
 vietnamese.txt:


### PR DESCRIPTION
Previously it was using '\0' in sed which is non-portable and does not work in macOS. Fix it to use the already captured group using '\1' instead. An alternative is to use '&' which is the more portable version of '\0'.