### PR TITLE
typos in code and docs related to 'diffopt' "inline"

### DIFF
--- a/runtime/doc/diff.txt
+++ b/runtime/doc/diff.txt
@@ -243,12 +243,11 @@ The diffs are highlighted with these groups:
 				highlight the exact difference between the
 				two.  Will respect any 'diffopt' flag that
 				affects internal diff.
-				Not used when `inline:` set to "none".
-|hl-DiffTextAdd|  DiffTextAdd	Added text inside a Changed line. Similar to
+				Not used when `inline:` is set to "none".
+|hl-DiffTextAdd|  DiffTextAdd	Added text inside a Changed line.  Similar to
 				DiffText, but used when there is no
-				corresponding text in other buffers.  Will not
-				be used when `inline:` is set to "simple" or
-				"none".
+				corresponding text in other buffers.  Not used
+				when `inline:` is set to "simple" or "none".
 |hl-DiffDelete|	DiffDelete	Deleted lines.  Also called filler lines,
 				because they don't really exist in this
 				buffer.

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2982,8 +2982,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 				none    Do not perform inline highlighting.
 				simple  Highlight from first different
 					character to the last one in each
-					line. This is the default if nothing
-					is set.
+					line.  This is the default if no
+					`inline:` value is set.
 				char    Use internal diff to perform a
 					character-wise diff and highlight the
 					difference.

--- a/src/structs.h
+++ b/src/structs.h
@@ -3606,7 +3606,7 @@ typedef struct diffline_change_S diffline_change_T;
 struct diffline_change_S
 {
     colnr_T	dc_start[DB_COUNT];	// byte offset of start of range in the line
-    colnr_T	dc_end[DB_COUNT];	// 1 paste byte offset of end of range in line
+    colnr_T	dc_end[DB_COUNT];	// 1 past byte offset of end of range in line
     int		dc_start_lnum_off[DB_COUNT];	// starting line offset
     int		dc_end_lnum_off[DB_COUNT];	// end line offset
 };

--- a/src/testdir/test_diffmode.vim
+++ b/src/testdir/test_diffmode.vim
@@ -2463,8 +2463,8 @@ func Test_diff_inline()
         \  "abcdefghijklmno", "anchor2",
         \  "abcdefghijklmno", "anchor3",
         \  "test", "multiline"],
-        \ ["a?c?e?g?i?k???o",  "anchor1",
-        \  "a??de?????klmno",  "anchor2",
+        \ ["a?c?e?g?i?k???o", "anchor1",
+        \  "a??de?????klmno", "anchor2",
         \  "a??de??????lmno", "anchor3",
         \  "t?s?", "??????i?e"])
   call VerifyInternal(buf, "Test_diff_inline_char_02", " diffopt+=inline:char")
@@ -2505,7 +2505,7 @@ func Test_diff_inline_multibuffer()
         \ ["This is buffer3. Last.", "anchor", "Some more", "text here.", "anchor", "only in buffer2/3", "not in buffer1"])
   call VerifyInternal(buf, "Test_diff_inline_multibuffer_01", " diffopt+=inline:char")
 
-  " Close one of the buffer and make sure it updates correctly
+  " Close one of the buffers and make sure it updates correctly
   call term_sendkeys(buf, ":diffoff\<CR>")
   call VerifyInternal(buf, "Test_diff_inline_multibuffer_02", " diffopt+=inline:char")
 


### PR DESCRIPTION
Problem:  Typos in code and docs related to 'diffopt' "inline:".
Solution: Fix typos and slightly improve the docs.
