### PR TITLE
Mixing vim_strsize() with mb_ptr2cells() in pum_redraw()

### DIFF
--- a/src/popupmenu.c
+++ b/src/popupmenu.c
@@ -731,7 +731,7 @@ pum_redraw(void)
 				char_u		*old_rt = NULL;
 				char_u		*orig_rt = NULL;
 
-				cells = vim_strsize(rt);
+				cells = mb_string2cells(rt, -1);
 				need_ellipsis = p_pmw > ellipsis_width
 						    && pum_width == p_pmw
 						    && cells > pum_width;


### PR DESCRIPTION
Problem:  Mixing vim_strsize() with mb_ptr2cells() in pum_redraw().
Solution: Change vim_strsize() to mb_string2cells().

Since vim_strsize() uses ptr2cells() for the cell width of each char, it
is strange to mix it with mb_ptr2cells(), which is used both just below
and in pum_screen_puts_with_attr(), and screen_puts_len() also uses
something similar.  Meanwhile mb_string2cells() uses mb_ptr2cells() for
the cell width of each char.

Note that the vim_strsize() and mb_string2cells() actually return the
same value here, as the transstr() above makes sure the string only
contains printable chars, and ptr2cells() and mb_ptr2cells() only return
different values for unprintable chars.
