### PR TITLE
Hang when filtering buffer with NUL bytes

### DIFF
--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -5260,14 +5260,13 @@ mch_call_shell_fork(
 		    else if (wpid == 0) // child
 		    {
 			linenr_T    lnum = curbuf->b_op_start.lnum;
-			int	    written = 0;
+			size_t	    written = 0;
 			char_u	    *lp = ml_get(lnum);
 			size_t	    lplen = (size_t)ml_get_len(lnum);
 
 			close(fromshell_fd);
 			for (;;)
 			{
-			    lplen -= written;
 			    if (lplen == 0)
 				len = 0;
 			    else if (lp[written] == NL)
@@ -5278,10 +5277,10 @@ mch_call_shell_fork(
 				char_u	*s = vim_strchr(lp + written, NL);
 
 				len = write(toshell_fd, (char *)lp + written,
-					   s == NULL ? lplen
+					   s == NULL ? lplen - written
 					      : (size_t)(s - (lp + written)));
 			    }
-			    if (len == (int)lplen)
+			    if (len == (int)(lplen - written))
 			    {
 				// Finished a line, add a NL, unless this line
 				// should not have one.
@@ -5305,7 +5304,7 @@ mch_call_shell_fork(
 				written = 0;
 			    }
 			    else if (len > 0)
-				written += len;
+				written += (size_t)len;
 			}
 			_exit(0);
 		    }

--- a/src/testdir/test_shell.vim
+++ b/src/testdir/test_shell.vim
@@ -299,4 +299,18 @@ func Test_shell_no_prevcmd()
   call delete('Xtestdone')
 endfunc
 
+func Test_shell_filter_buffer_with_nul_bytes()
+  CheckUnix
+  new
+  set noshelltemp
+  " \n is a NUL byte
+  let lines = ["aaa\nbbb\nccc\nddd\neee", "fff\nggg\nhhh\niii\njjj"]
+  call setline(1, lines)
+  %!cat
+  call assert_equal(lines, getline(1, '$'))
+
+  set shelltemp&
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  Hang when filtering buffer with NUL bytes (after 9.1.1050).
Solution: Don't subtract "written" from "lplen" repeatedly.

related: neovim/neovim#33173
