### PR TITLE
runtime(comment): fix ic/ac for comments with trailing spaces

### DIFF
--- a/runtime/pack/dist/opt/comment/autoload/comment.vim
+++ b/runtime/pack/dist/opt/comment/autoload/comment.vim
@@ -144,7 +144,7 @@ export def ObjComment(inner: bool)
         var spaces = matchstr(getline(pos_end[1]), '\%>.c\s*')
         pos_end[2] += spaces->len()
         if getline(pos_end[1])[pos_end[2] : ] =~ '^\s*$'
-            && (pos_start[2] == 1 || getline(pos_start[1])[ : pos_start[2]] =~ '^\s*$')
+            && (pos_start[2] <= 1 || getline(pos_start[1])[ : pos_start[2]] =~ '^\s*$')
             if search('\v\s*\_$(\s*\n)+', 'eW', 0, 200) > 0
                 pos_end = getcurpos()
             endif

--- a/runtime/pack/dist/opt/comment/autoload/comment.vim
+++ b/runtime/pack/dist/opt/comment/autoload/comment.vim
@@ -1,7 +1,7 @@
 vim9script
 
 # Maintainer: Maxim Kim <habamax@gmail.com>
-# Last Update: 2025 Mar 21
+# Last Update: 2025-03-30
 #
 # Toggle comments
 # Usage:

--- a/runtime/pack/dist/opt/comment/autoload/comment.vim
+++ b/runtime/pack/dist/opt/comment/autoload/comment.vim
@@ -107,8 +107,8 @@ export def ObjComment(inner: bool)
 
     # Search for the beginning of the comment block
     if IsComment()
-        if search('\v%(\S+)|$', 'bW', 0, 200, IsComment) > 0
-            search('\v%(\S)|$', 'W', 0, 200, () => !IsComment())
+        if search('\v%(\S+)|%(^\s*$)', 'bW', 0, 200, IsComment) > 0
+            search('\v%(\S)|%(^\s*$)', 'W', 0, 200, () => !IsComment())
         else
             cursor(1, 1)
             search('\v\S+', 'cW', 0, 200)
@@ -130,7 +130,7 @@ export def ObjComment(inner: bool)
     if pos_init[1] > pos_start[1]
         cursor(pos_init[1], pos_init[2])
     endif
-    if search('\v%(\S+)|$', 'W', 0, 200, IsComment) > 0
+    if search('\v%(\S+)|%(^\s*$)', 'W', 0, 200, IsComment) > 0
         search('\S', 'beW', 0, 200, () => !IsComment())
     else
         if search('\%$', 'W', 0, 200) > 0

--- a/runtime/pack/dist/opt/comment/autoload/comment.vim
+++ b/runtime/pack/dist/opt/comment/autoload/comment.vim
@@ -134,7 +134,7 @@ export def ObjComment(inner: bool)
         search('\S', 'beW', 0, 200, () => !IsComment())
     else
         if search('\%$', 'W', 0, 200) > 0
-            search('\ze\S', 'beW', 0, 200, () => !IsComment())
+            search('\ze\S', 'beW', line('.'), 200, () => !IsComment())
         endif
     endif
 

--- a/src/testdir/test_plugin_comment.vim
+++ b/src/testdir/test_plugin_comment.vim
@@ -487,12 +487,7 @@ endfunc
 
 func Test_textobj_trailing_spaces_comment()
   CheckScreendump
-  let lines =<< trim END
-    # print("hello")   
-    # print("world")   
-    #
-    print("!")
-  END
+  let lines = ['# print("hello")   ', '# print("world")   ', "#", 'print("!")']
 
   let input_file = "test_textobj_trailing_spaces_input.py"
   call writefile(lines, input_file, "D")
@@ -513,13 +508,7 @@ endfunc
 
 func Test_textobj_trailing_spaces_last_comment()
   CheckScreendump
-  let lines =<< trim END
-    # print("hello")   
-    # print("world")   
-    #
-
-
-  END
+  let lines = ['# print("hello")   ', '# print("world")   ', "#", '', '']
 
   let input_file = "test_textobj_trailing_spaces_last_input.py"
   call writefile(lines, input_file, "D")

--- a/src/testdir/test_plugin_comment.vim
+++ b/src/testdir/test_plugin_comment.vim
@@ -538,6 +538,30 @@ func Test_textobj_trailing_spaces_last_comment()
   call assert_equal([], result)
 endfunc
 
+func Test_textobj_last_line_empty_comment()
+  CheckScreendump
+  let lines =<< trim END
+    # print("hello")
+    #
+    #
+  END
+
+  let input_file = "test_textobj_last_line_empty_input.py"
+  call writefile(lines, input_file, "D")
+
+  let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
+
+  call term_sendkeys(buf, "dac")
+  let output_file = "comment_textobj_last_line_empty_comment.py"
+  call term_sendkeys(buf, $":w {output_file}\<CR>")
+  defer delete(output_file)
+
+  call StopVimInTerminal(buf)
+
+  let result = readfile(output_file)
+
+  call assert_equal([], result)
+endfunc
 func Test_textobj_cursor_on_leading_space_comment()
   CheckScreendump
   let lines =<< trim END

--- a/src/testdir/test_plugin_comment.vim
+++ b/src/testdir/test_plugin_comment.vim
@@ -485,6 +485,59 @@ func Test_textobj_noleading_space_comment2()
   call assert_equal(["int main() {", "}"], result)
 endfunc
 
+func Test_textobj_trailing_spaces_comment()
+  CheckScreendump
+  let lines =<< trim END
+    # print("hello")   
+    # print("world")   
+    #
+    print("!")
+  END
+
+  let input_file = "test_textobj_trailing_spaces_input.py"
+  call writefile(lines, input_file, "D")
+
+  let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
+
+  call term_sendkeys(buf, "jdac")
+  let output_file = "comment_textobj_trailing_spaces_comment.py"
+  call term_sendkeys(buf, $":w {output_file}\<CR>")
+  defer delete(output_file)
+
+  call StopVimInTerminal(buf)
+
+  let result = readfile(output_file)
+
+  call assert_equal(['print("!")'], result)
+endfunc
+
+func Test_textobj_trailing_spaces_last_comment()
+  CheckScreendump
+  let lines =<< trim END
+    # print("hello")   
+    # print("world")   
+    #
+
+
+  END
+
+  let input_file = "test_textobj_trailing_spaces_last_input.py"
+  call writefile(lines, input_file, "D")
+
+  let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
+
+  call term_sendkeys(buf, "jdac")
+  let output_file = "comment_textobj_trailing_spaces_last_comment.py"
+  call term_sendkeys(buf, $":w {output_file}\<CR>")
+  defer delete(output_file)
+
+  call StopVimInTerminal(buf)
+
+  let result = readfile(output_file)
+
+  call assert_equal([], result)
+endfunc
+
 func Test_textobj_cursor_on_leading_space_comment()
   CheckScreendump
   let lines =<< trim END


### PR DESCRIPTION
Having comments like

```C
// hello (here are some trailing spaces)    
//
```

`vac` should select whole comment

Having last comment with empty comment lines till the end of the buffer

```C
# hello
# world
#
#
```

`vac` should select whole comment including the last empty comment line.
