### PR TITLE
Fix: Ensure menu updates when modifying inserted match

### DIFF
--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -1370,8 +1370,7 @@ In the first state these keys have a special meaning:
 		  the cursor.  This reduces the list of matches, often to one
 		  entry, and switches to the second state.
 Any non-special character:
-		  Stop completion without changing the match and insert the
-		  typed character.
+		  Add this character and reduce the number of matches.
 
 In the second and third state these keys have a special meaning:
 <BS> and CTRL-H   Delete one character, find the matches for the shorter word

--- a/src/edit.c
+++ b/src/edit.c
@@ -637,59 +637,55 @@ edit(
 	{
 	    // BS: Delete one character from "compl_leader".
 	    if ((c == K_BS || c == Ctrl_H)
-			&& curwin->w_cursor.col > ins_compl_col()
-			&& (c = ins_compl_bs()) == NUL)
+		    && curwin->w_cursor.col > ins_compl_col()
+		    && (c = ins_compl_bs()) == NUL)
 		continue;
 
-	    // When no match was selected or it was edited.
-	    if (!ins_compl_used_match())
+	    // CTRL-L: Add one character from the current match to
+	    // "compl_leader".  Except when at the original match and
+	    // there is nothing to add, CTRL-L works like CTRL-P then.
+	    if (c == Ctrl_L
+		    && (!ctrl_x_mode_line_or_eval()
+			|| ins_compl_long_shown_match()))
 	    {
-		// CTRL-L: Add one character from the current match to
-		// "compl_leader".  Except when at the original match and
-		// there is nothing to add, CTRL-L works like CTRL-P then.
-		if (c == Ctrl_L
-			&& (!ctrl_x_mode_line_or_eval()
-			    || ins_compl_long_shown_match()))
-		{
-		    ins_compl_addfrommatch();
-		    continue;
-		}
-
-		// A non-white character that fits in with the current
-		// completion: Add to "compl_leader".
-		if (ins_compl_accept_char(c))
-		{
-#if defined(FEAT_EVAL)
-		    // Trigger InsertCharPre.
-		    char_u *str = do_insert_char_pre(c);
-		    char_u *p;
-
-		    if (str != NULL)
-		    {
-			for (p = str; *p != NUL; MB_PTR_ADV(p))
-			    ins_compl_addleader(PTR2CHAR(p));
-			vim_free(str);
-		    }
-		    else
-#endif
-			ins_compl_addleader(c);
-		    continue;
-		}
-
-		// Pressing CTRL-Y selects the current match.  When
-		// ins_compl_enter_selects() is set the Enter key does the
-		// same.
-		if ((c == Ctrl_Y || (ins_compl_enter_selects()
-				    && (c == CAR || c == K_KENTER || c == NL)))
-			&& stop_arrow() == OK)
-		{
-		    ins_compl_delete();
-		    ins_compl_insert(FALSE, FALSE);
-		}
-		// Delete preinserted text when typing special chars
-		else if (IS_WHITE_NL_OR_NUL(c) && ins_compl_preinsert_effect())
-		    ins_compl_delete();
+		ins_compl_addfrommatch();
+		continue;
 	    }
+
+	    // A non-white character that fits in with the current
+	    // completion: Add to "compl_leader".
+	    if (ins_compl_accept_char(c))
+	    {
+#if defined(FEAT_EVAL)
+		// Trigger InsertCharPre.
+		char_u *str = do_insert_char_pre(c);
+		char_u *p;
+
+		if (str != NULL)
+		{
+		    for (p = str; *p != NUL; MB_PTR_ADV(p))
+			ins_compl_addleader(PTR2CHAR(p));
+		    vim_free(str);
+		}
+		else
+#endif
+		    ins_compl_addleader(c);
+		continue;
+	    }
+
+	    // Pressing CTRL-Y selects the current match.  When
+	    // ins_compl_enter_selects() is set the Enter key does the
+	    // same.
+	    if ((c == Ctrl_Y || (ins_compl_enter_selects()
+			    && (c == CAR || c == K_KENTER || c == NL)))
+		    && stop_arrow() == OK)
+	    {
+		ins_compl_delete();
+		ins_compl_insert(FALSE, FALSE);
+	    }
+	    // Delete preinserted text when typing special chars
+	    else if (IS_WHITE_NL_OR_NUL(c) && ins_compl_preinsert_effect())
+		ins_compl_delete();
 	}
 
 	// Prepare for or stop CTRL-X mode.  This doesn't do completion, but

--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -2021,16 +2021,6 @@ ins_compl_win_active(win_T *wp UNUSED)
 }
 
 /*
- * Selected one of the matches.  When FALSE the match was edited or using the
- * longest common string.
- */
-    int
-ins_compl_used_match(void)
-{
-    return compl_used_match;
-}
-
-/*
  * Initialize get longest common string.
  */
     void

--- a/src/proto/insexpand.pro
+++ b/src/proto/insexpand.pro
@@ -40,7 +40,6 @@ char_u *find_line_end(char_u *ptr);
 void ins_compl_clear(void);
 int ins_compl_active(void);
 int ins_compl_win_active(win_T *wp);
-int ins_compl_used_match(void);
 void ins_compl_init_get_longest(void);
 int ins_compl_interrupted(void);
 int ins_compl_enter_selects(void);

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -3387,4 +3387,32 @@ func Test_complete_multiline_marks()
   delfunc Omni_test
 endfunc
 
+" When a match is inserted and a new character is added, the menu should update
+" to display items matching the new prefix.
+func Test_complete_append_selected_match()
+  func PrintMenuWords()
+    let info = complete_info(["selected", "matches"])
+    call map(info.matches, {_, v -> v.word})
+    return info
+  endfunc
+
+  new
+  call setline(1, ["fo", "foo", "foobar", "fobarbaz"])
+  exe "normal! Gof\<c-n>\<c-r>=PrintMenuWords()\<cr>"
+  call assert_equal('fo{''matches'': [''fo'', ''foo'', ''foobar'', ''fobarbaz''], ''selected'': 0}', getline(5))
+  %d
+  call setline(1, ["fo", "foo", "foobar", "fobarbaz"])
+  exe "normal! Gof\<c-n>o\<c-r>=PrintMenuWords()\<cr>"
+  call assert_equal('foo{''matches'': [''foo'', ''foobar''], ''selected'': 1}', getline(5))
+  %d
+  set completeopt=menu,noselect
+  call setline(1, ["fo", "foo", "foobar", "fobarbaz"])
+  exe "normal! Gof\<c-n>\<c-n>o\<c-r>=PrintMenuWords()\<cr>"
+  call assert_equal('foo{''matches'': [''foo'', ''foobar''], ''selected'': 1}', getline(5))
+  bw!
+
+  set completeopt&
+  delfunc PrintMenuWords
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab nofoldenable


### PR DESCRIPTION
In insert mode completion (`ctrl_x_normal_mode`), when a match is inserted using `<C-N>` or `<C-P>`, appending a new character causes the menu to disappear instead of updating. However, when removing a character with `<BS>`, the menu updates correctly. This fix ensures the menu remains visible and updates dynamically when modifying the inserted match.