### PR TITLE
Prevent line wrapping in fstab.

### DIFF
--- a/runtime/ftplugin/fstab.vim
+++ b/runtime/ftplugin/fstab.vim
@@ -19,6 +19,7 @@ let b:did_ftplugin = 1
 
 setlocal commentstring=#\ %s
 setlocal formatoptions-=t
-let b:undo_ftplugin = "setlocal commentstring<"
+
+let b:undo_ftplugin = "setlocal commentstring< | setlocal formatoptions<"
 
 " vim: ts=8 ft=vim

--- a/runtime/ftplugin/fstab.vim
+++ b/runtime/ftplugin/fstab.vim
@@ -20,6 +20,6 @@ let b:did_ftplugin = 1
 setlocal commentstring=#\ %s
 setlocal formatoptions-=t
 
-let b:undo_ftplugin = "setlocal commentstring< | setlocal formatoptions<"
+let b:undo_ftplugin = "setlocal commentstring< formatoptions<"
 
 " vim: ts=8 ft=vim

--- a/runtime/ftplugin/fstab.vim
+++ b/runtime/ftplugin/fstab.vim
@@ -2,9 +2,12 @@
 " Language: fstab file
 " Maintainer: Radu Dineiu <radu.dineiu@gmail.com>
 " URL: https://raw.github.com/rid9/vim-fstab/master/ftplugin/fstab.vim
-" Last Change: 2021 Jan 02
-"              2024 May 23 by Riley Bruins <ribru17@gmail.com> ('commentstring')
-" Version: 1.0
+" Last Change: 2025 Mar 31
+" Version: 1.0.1
+"
+" Changelog:
+" - 2024 May 23 by Riley Bruins <ribru17@gmail.com> ('commentstring')
+" - 2025 Mar 31 added setlocal formatoptions-=t
 "
 " Credits:
 "   Subhaditya Nath <sn03.general@gmail.com>
@@ -15,6 +18,7 @@ endif
 let b:did_ftplugin = 1
 
 setlocal commentstring=#\ %s
+setlocal formatoptions-=t
 let b:undo_ftplugin = "setlocal commentstring<"
 
 " vim: ts=8 ft=vim


### PR DESCRIPTION
Added `setlocal formatoptions-=t` to fstab ftplugin to prevent line wrapping which would break the fstab syntax.