### PR TITLE
clientserver: does not handle :stopinsert correctly

### DIFF
--- a/src/edit.c
+++ b/src/edit.c
@@ -608,7 +608,16 @@ edit(
 		    if (c != K_IGNORE && c != K_NOP)
 			vungetc(c);
 		    count = 0;
-		    nomove = TRUE;
+
+		    if (!bt_prompt(curwin->w_buffer)
+#ifdef FEAT_TERMINAL
+			    && !bt_terminal(curwin->w_buffer)
+#endif
+			    && stop_insert_mode)
+			// :stopinsert command via callback or via server command
+			nomove = FALSE;
+		    else
+			nomove = TRUE;
 		    ins_compl_prep(ESC);
 		    goto doESCkey;
 		}

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -9326,6 +9326,12 @@ ex_stopinsert(exarg_T *eap UNUSED)
 {
     restart_edit = 0;
     stop_insert_mode = TRUE;
+#if defined(FEAT_CLIENTSERVER) || defined(FEAT_EVAL)
+    // when called from remote_expr in insert mode, make sure insert mode is
+    // ended by adding K_NOP to the typeahead buffer
+    if (vgetc_busy)
+       ins_char_typebuf(K_NOP, 0);
+#endif
     clearmode();
 }
 

--- a/src/testdir/test_clientserver.vim
+++ b/src/testdir/test_clientserver.vim
@@ -191,6 +191,47 @@ func Test_client_server()
         \ has('unix') ? ['E573:.*abc'] : 'E258:')
 endfunc
 
+func Test_client_server_stopinsert()
+  " test does not work on MS-Windows
+  CheckNotMSWindows
+  let g:test_is_flaky = 1
+  let cmd = GetVimCommand()
+  if cmd == ''
+    throw 'GetVimCommand() failed'
+  endif
+  call Check_X11_Connection()
+  let fname = 'Xclientserver_stop.txt'
+  let name = 'XVIMTEST2'
+  call writefile(['one two three'], fname, 'D')
+
+  let cmd .= ' -c "set virtualedit=onemore"'
+  let cmd .= ' -c "call cursor(1, 14)"'
+  let cmd .= ' -c "startinsert"'
+  let cmd .= ' --servername ' . name
+  let cmd .= ' ' .. fname
+  let job = job_start(cmd, {'stoponexit': 'kill', 'out_io': 'null'})
+  call WaitForAssert({-> assert_equal("run", job_status(job))})
+
+  " Takes a short while for the server to be active.
+  " When using valgrind it takes much longer.
+  call WaitForAssert({-> assert_match(name, serverlist())})
+
+  call remote_expr(name, 'execute("stopinsert")')
+
+  call assert_equal('n', name->remote_expr("mode(1)"))
+  call assert_equal('13', name->remote_expr("col('.')"))
+
+  eval name->remote_send(":qa!\<CR>")
+  try
+    call WaitForAssert({-> assert_equal("dead", job_status(job))})
+  finally
+    if job_status(job) != 'dead'
+      call assert_report('Server did not exit')
+      call job_stop(job, 'kill')
+    endif
+  endtry
+endfunc
+
 " Uncomment this line to get a debugging log
 " call ch_logfile('channellog', 'w')
 


### PR DESCRIPTION
Problem:  clientserver: When in insert mode, a :stopinsert command
                is not correctly processed
Solution: If the :stopinsert command is received while waiting for
          input, stuff a dummy key into the type-ahead buffer and
          decrement the cursor position.

fixes: #17016