### PR TITLE
fix: Keep shown match when starting keyword completion

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -1352,10 +1352,10 @@ ins_compl_build_pum(void)
     int		compl_no_select = (cur_cot_flags & COT_NOSELECT) != 0;
     int		fuzzy_filter = (cur_cot_flags & COT_FUZZY) != 0;
     int		fuzzy_sort = fuzzy_filter && !(cur_cot_flags & COT_NOSORT);
-
     compl_T	*match_head = NULL;
     compl_T	*match_tail = NULL;
     compl_T	*match_next = NULL;
+    int		update_shown_match = fuzzy_filter;
 
     // Need to build the popup menu list.
     compl_match_arraysize = 0;
@@ -1365,6 +1365,10 @@ ins_compl_build_pum(void)
     // match after it, don't highlight anything.
     if (match_at_original_text(compl_shown_match))
 	shown_match_ok = TRUE;
+
+    if (fuzzy_filter && ctrl_x_mode_normal() && compl_leader.string == NULL
+	    && compl_shown_match->cp_score > 0)
+	update_shown_match = FALSE;
 
     if (compl_leader.string != NULL
 	    && STRCMP(compl_leader.string, compl_orig_text.string) == 0
@@ -1415,7 +1419,8 @@ ins_compl_build_pum(void)
 		    shown_compl = compl;
 		// Update the maximum fuzzy score and the shown match
 		// if the current item's score is higher
-		if (fuzzy_sort && compl->cp_score > max_fuzzy_score)
+		if (fuzzy_sort && compl->cp_score > max_fuzzy_score
+			&& update_shown_match)
 		{
 		    did_find_shown_match = TRUE;
 		    max_fuzzy_score = compl->cp_score;

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -2829,6 +2829,12 @@ func Test_complete_opt_fuzzy()
   call feedkeys("i\<C-R>=CompAnother()\<CR>\<C-P>\<C-P>", 'tx')
   call assert_equal("for", g:abbr)
 
+  set cot=menu,fuzzy
+  call feedkeys("Sblue\<CR>bar\<CR>b\<C-X>\<C-P>\<C-Y>\<ESC>", 'tx')
+  call assert_equal('bar', getline('.'))
+  call feedkeys("Sb\<C-X>\<C-N>\<C-Y>\<ESC>", 'tx')
+  call assert_equal('blue', getline('.'))
+
   " clean up
   set omnifunc=
   bw!


### PR DESCRIPTION
Problem: compl_shown_match is updated when starting keyword completion and does not include fuzzy matching.

Solution: Do not update compl_shown_match when starting keyword completion, since it is the one already selected by the keyword completion direction.