### PR TITLE
Coverity warns about using uninitialized value

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -4037,6 +4037,8 @@ maketitle(void)
 		    vim_strncpy(buf, p, SPACE_FOR_FNAME);
 		    vim_free(p);
 		}
+		else
+		    STRCPY(buf, "");
 	    }
 
 #ifdef FEAT_TERMINAL


### PR DESCRIPTION
Problem:  Coverity warns about using uninitialized value
          (after 9.1.1270).
Solution: Put an empty string in "buf" when allocation fails.
