### PR TITLE
fix: ctrl_p can not go back original when cot has fuzzy

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -4831,7 +4831,8 @@ find_comp_when_fuzzy(void)
 
     if ((is_forward && compl_selected_item == compl_match_arraysize - 1)
 	    || (is_backward && compl_selected_item == 0))
-	return compl_first_match != compl_shown_match ? compl_first_match :
+	return compl_first_match != compl_shown_match ?
+	    (is_forward ? compl_shown_match->cp_next : compl_first_match) :
 	    (compl_first_match->cp_prev ? compl_first_match->cp_prev : NULL);
 
     if (is_forward)

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -2834,6 +2834,8 @@ func Test_complete_opt_fuzzy()
   call assert_equal('bar', getline('.'))
   call feedkeys("Sb\<C-X>\<C-N>\<C-Y>\<ESC>", 'tx')
   call assert_equal('blue', getline('.'))
+  call feedkeys("Sb\<C-X>\<C-P>\<C-N>\<C-Y>\<ESC>", 'tx')
+  call assert_equal('b', getline('.'))
 
   " clean up
   set omnifunc=


### PR DESCRIPTION
Problem: keyword completion of CTRL_P can not goback when press Ctrl_N

Solution: find_compl_when_fuzzy always return first match of array, there should return shown_match->cp_next in this situation