### PR TITLE
runtime:lua: further speed up folding by precompiled vim9

### DIFF
--- a/runtime/ftplugin/lua.vim
+++ b/runtime/ftplugin/lua.vim
@@ -110,11 +110,13 @@ if !has('vim9script')
     let buf = getline(1, "$")
     for line in buf
       for t in s:patterns
+      	let open = 0
       	let end = 0
       	let tagopen  = '\v^\s*' .. t[0] ..'\s*$'
       	let tagclose = '\v^\s*' .. t[1] ..'\s*$'
       	if line =~# tagopen
 	  call add(foldlist, t)
+      	  let open = 1
 	  break
       	elseif line =~# tagclose
 	  if len(foldlist) > 0 && line =~# foldlist[-1][1]
@@ -126,7 +128,10 @@ if !has('vim9script')
 	  break
       	endif
       endfor
-      call add(b:lua_foldlists, len(foldlist) + end)
+      let prefix = ''
+      if open | let prefix = '>' | endif
+      if end | let prefix = '<' | endif
+      call add(b:lua_foldlists, prefix..len(foldlist) + end)
     endfor
 
     return b:lua_foldlists[v:lnum - 1]
@@ -137,7 +142,7 @@ if !has('vim9script')
 
   finish
 else
-  def s:LuaFold(): number
+  def s:LuaFold(): string
     if b:lua_lasttick == b:changedtick
       return b:lua_foldlists[v:lnum - 1]
     endif
@@ -147,12 +152,14 @@ else
     var foldlist = []
     var buf = getline(1, "$")
     for line in buf
+      var open = 0
       var end = 0
       for t in patterns
       	var tagopen  = '\v^\s*' .. t[0] .. '\s*$'
       	var tagclose = '\v^\s*' .. t[1] .. '\s*$'
       	if line =~# tagopen
 	  add(foldlist, t)
+      	  open = 1
 	  break
       	elseif line =~# tagclose
 	  if len(foldlist) > 0 && line =~# foldlist[-1][1]
@@ -164,7 +171,10 @@ else
 	  break
       	endif
       endfor
-      add(b:lua_foldlists, len(foldlist) + end)
+      var prefix = ''
+      if open | prefix = '>' | endif
+      if end | prefix = '<' | endif
+      add(b:lua_foldlists, prefix..len(foldlist) + end)
     endfor
 
     return b:lua_foldlists[v:lnum - 1]

--- a/runtime/ftplugin/lua.vim
+++ b/runtime/ftplugin/lua.vim
@@ -110,6 +110,7 @@ if !has('vim9script')
     let buf = getline(1, "$")
     for line in buf
       for t in s:patterns
+      	let end = 0
       	let tagopen  = '\v^\s*' .. t[0] ..'\s*$'
       	let tagclose = '\v^\s*' .. t[1] ..'\s*$'
       	if line =~# tagopen
@@ -118,13 +119,14 @@ if !has('vim9script')
       	elseif line =~# tagclose
 	  if len(foldlist) > 0 && line =~# foldlist[-1][1]
 	    call remove(foldlist, -1)
+      	    let end = 1
 	  else
 	    let foldlist = []
 	  endif
 	  break
       	endif
       endfor
-      call add(b:lua_foldlists, len(foldlist))
+      call add(b:lua_foldlists, len(foldlist) + end)
     endfor
 
     return b:lua_foldlists[v:lnum - 1]
@@ -156,6 +158,7 @@ else
     var foldlist = []
     var buf = getline(1, "$")
     for line in buf
+      var end = 0
       for t in patterns
       	var tagopen  = '\v^\s*' .. t[0] .. '\s*$'
       	var tagclose = '\v^\s*' .. t[1] .. '\s*$'
@@ -164,6 +167,7 @@ else
 	  break
       	elseif line =~# tagclose
 	  if len(foldlist) > 0 && line =~# foldlist[-1][1]
+	    end = 1
 	    remove(foldlist, -1)
 	  else
 	    foldlist = []
@@ -171,7 +175,7 @@ else
 	  break
       	endif
       endfor
-      add(b:lua_foldlists, len(foldlist))
+      add(b:lua_foldlists, len(foldlist) + end)
     endfor
 
     return b:lua_foldlists[v:lnum - 1]

--- a/runtime/ftplugin/lua.vim
+++ b/runtime/ftplugin/lua.vim
@@ -1,13 +1,13 @@
 " Vim filetype plugin file.
-" Language:		Lua
-" Maintainer:		Doug Kearns <dougkearns@gmail.com>
-" Previous Maintainer:	Max Ischenko <mfi@ukr.net>
-" Contributor:		Dorai Sitaram <ds26@gte.com>
-"			C.D. MacEachern <craig.daniel.maceachern@gmail.com>
-"			Tyler Miller <tmillr@proton.me>
-"			Phạm Bình An <phambinhanctb2004@gmail.com>
-"			@konfekt
-" Last Change:		2025 Apr 04
+" Language:             Lua
+" Maintainer:           Doug Kearns <dougkearns@gmail.com>
+" Previous Maintainer:  Max Ischenko <mfi@ukr.net>
+" Contributor:          Dorai Sitaram <ds26@gte.com>
+"                       C.D. MacEachern <craig.daniel.maceachern@gmail.com>
+"                       Tyler Miller <tmillr@proton.me>
+"                       Phạm Bình An <phambinhanctb2004@gmail.com>
+"                       @konfekt
+" Last Change:          2025 Apr 04
 
 if exists("b:did_ftplugin")
   finish
@@ -42,11 +42,11 @@ let b:undo_ftplugin = "setl cms< com< def< fo< inc< inex< sua<"
 if exists("loaded_matchit") && !exists("b:match_words")
   let b:match_ignorecase = 0
   let b:match_words =
-	\ '\<\%(do\|function\|if\)\>:' ..
-	\ '\<\%(return\|else\|elseif\)\>:' ..
-	\ '\<end\>,' ..
-	\ '\<repeat\>:\<until\>,' ..
-	\ '\%(--\)\=\[\(=*\)\[:]\1]'
+        \ '\<\%(do\|function\|if\)\>:' ..
+        \ '\<\%(return\|else\|elseif\)\>:' ..
+        \ '\<end\>,' ..
+        \ '\<repeat\>:\<until\>,' ..
+        \ '\%(--\)\=\[\(=*\)\[:]\1]'
   let b:undo_ftplugin ..= " | unlet! b:match_words b:match_ignorecase"
 endif
 
@@ -88,100 +88,99 @@ function s:LuaInclude(fname) abort
 endfunction
 
 let s:patterns = [
-      \ ['do', 'end'],
-      \ ['if\s+.+\s+then', 'end'],
-      \ ['repeat', 'until\s+.+'],
-      \ ['for\s+.+\s+do', 'end'],
-      \ ['while\s+.+\s+do', 'end'],
-      \ ['function.+', 'end'],
-      \ ['return\s+function.+', 'end'],
-      \ ['local\s+function\s+.+', 'end'],
-      \ ]
+    \ ['do', 'end'],
+    \ ['if\s+.+\s+then', 'end'],
+    \ ['repeat', 'until\s+.+'],
+    \ ['for\s+.+\s+do', 'end'],
+    \ ['while\s+.+\s+do', 'end'],
+    \ ['function.+', 'end'],
+    \ ['return\s+function.+', 'end'],
+    \ ['local\s+function\s+.+', 'end'],
+    \ ]
+
+function s:LuaFold() abort
+  if b:lua_lasttick == b:changedtick
+    return b:lua_foldlists[v:lnum - 1]
+  endif
+  let b:lua_lasttick = b:changedtick
+
+  let b:lua_foldlists = []
+  let foldlist = []
+  let buf = getline(1, "$")
+  for line in buf
+    for t in s:patterns
+      let open = 0
+      let end = 0
+      let tagopen  = '\v^\s*' .. t[0] ..'\s*$'
+      let tagclose = '\v^\s*' .. t[1] ..'\s*$'
+      if line =~# tagopen
+        call add(foldlist, t)
+        let open = 1
+        break
+      elseif line =~# tagclose
+        if len(foldlist) > 0 && line =~# foldlist[-1][1]
+          call remove(foldlist, -1)
+          let end = 1
+        else
+          let foldlist = []
+        endif
+        break
+      endif
+    endfor
+    let prefix = ''
+    if open | let prefix = '>' | endif
+    if end | let prefix = '<' | endif
+    call add(b:lua_foldlists, prefix..len(foldlist) + end)
+  endfor
+
+  return b:lua_foldlists[v:lnum - 1]
+endfunction
 
 if !has('vim9script')
-  function s:LuaFold() abort
-    if b:lua_lasttick == b:changedtick
-      return b:lua_foldlists[v:lnum - 1]
-    endif
-    let b:lua_lasttick = b:changedtick
-
-    let b:lua_foldlists = []
-    let foldlist = []
-    let buf = getline(1, "$")
-    for line in buf
-      for t in s:patterns
-      	let open = 0
-      	let end = 0
-      	let tagopen  = '\v^\s*' .. t[0] ..'\s*$'
-      	let tagclose = '\v^\s*' .. t[1] ..'\s*$'
-      	if line =~# tagopen
-	  call add(foldlist, t)
-      	  let open = 1
-	  break
-      	elseif line =~# tagclose
-	  if len(foldlist) > 0 && line =~# foldlist[-1][1]
-	    call remove(foldlist, -1)
-      	    let end = 1
-	  else
-	    let foldlist = []
-	  endif
-	  break
-      	endif
-      endfor
-      let prefix = ''
-      if open | let prefix = '>' | endif
-      if end | let prefix = '<' | endif
-      call add(b:lua_foldlists, prefix..len(foldlist) + end)
-    endfor
-
-    return b:lua_foldlists[v:lnum - 1]
-  endfunction
-
   let &cpo = s:cpo_save
   unlet s:cpo_save
 
   finish
-else
-  def s:LuaFold(): string
-    if b:lua_lasttick == b:changedtick
-      return b:lua_foldlists[v:lnum - 1]
-    endif
-    b:lua_lasttick = b:changedtick
-
-    b:lua_foldlists = []
-    var foldlist = []
-    var buf = getline(1, "$")
-    for line in buf
-      var open = 0
-      var end = 0
-      for t in patterns
-      	var tagopen  = '\v^\s*' .. t[0] .. '\s*$'
-      	var tagclose = '\v^\s*' .. t[1] .. '\s*$'
-      	if line =~# tagopen
-	  add(foldlist, t)
-      	  open = 1
-	  break
-      	elseif line =~# tagclose
-	  if len(foldlist) > 0 && line =~# foldlist[-1][1]
-	    end = 1
-	    remove(foldlist, -1)
-	  else
-	    foldlist = []
-	  endif
-	  break
-      	endif
-      endfor
-      var prefix = ''
-      if open | prefix = '>' | endif
-      if end | prefix = '<' | endif
-      add(b:lua_foldlists, prefix..len(foldlist) + end)
-    endfor
-
-    return b:lua_foldlists[v:lnum - 1]
-  enddef
-
-  let &cpo = s:cpo_save
-  unlet s:cpo_save
 endif
 
+delfunction! s:LuaFold
+def s:LuaFold(): string
+  if b:lua_lasttick == b:changedtick
+    return b:lua_foldlists[v:lnum - 1]
+  endif
+  b:lua_lasttick = b:changedtick
+
+  b:lua_foldlists = []
+  var foldlist = []
+  var buf = getline(1, "$")
+  for line in buf
+    var open = 0
+    var end = 0
+    for t in patterns
+      var tagopen  = '\v^\s*' .. t[0] .. '\s*$'
+      var tagclose = '\v^\s*' .. t[1] .. '\s*$'
+      if line =~# tagopen
+        add(foldlist, t)
+        open = 1
+        break
+      elseif line =~# tagclose
+        if len(foldlist) > 0 && line =~# foldlist[-1][1]
+          end = 1
+          remove(foldlist, -1)
+        else
+          foldlist = []
+        endif
+        break
+      endif
+    endfor
+    var prefix = ""
+    if open | prefix = ">" | endif
+    if end | prefix = "<" | endif
+    add(b:lua_foldlists, prefix..(len(foldlist) + end))
+  endfor
+  return b:lua_foldlists[v:lnum - 1]
+enddef
+
+let &cpo = s:cpo_save
+unlet s:cpo_save
 " vim: nowrap sw=2 sts=2 ts=8 noet:

--- a/runtime/ftplugin/lua.vim
+++ b/runtime/ftplugin/lua.vim
@@ -112,12 +112,12 @@ function s:LuaFold() abort
       let open = 0
       let end = 0
       let tagopen  = '\v^\s*' .. t[0] ..'\s*$'
-      let tagclose = '\v^\s*' .. t[1] ..'\s*$'
+      let tagend = '\v^\s*' .. t[1] ..'\s*$'
       if line =~# tagopen
         call add(foldlist, t)
         let open = 1
         break
-      elseif line =~# tagclose
+      elseif line =~# tagend
         if len(foldlist) > 0 && line =~# foldlist[-1][1]
           call remove(foldlist, -1)
           let end = 1
@@ -127,10 +127,10 @@ function s:LuaFold() abort
         break
       endif
     endfor
-    let prefix = ''
-    if open | let prefix = '>' | endif
-    if end | let prefix = '<' | endif
-    call add(b:lua_foldlists, prefix..len(foldlist) + end)
+    let prefix = ""
+    if open == 1 | let prefix = ">" | endif
+    if end == 1 | let prefix = "<" | endif
+    let b:lua_foldlists += [prefix..(len(foldlist) + end)]
   endfor
 
   return b:lua_foldlists[v:lnum - 1]
@@ -158,12 +158,12 @@ def s:LuaFold(): string
     var end = 0
     for t in patterns
       var tagopen  = '\v^\s*' .. t[0] .. '\s*$'
-      var tagclose = '\v^\s*' .. t[1] .. '\s*$'
+      var tagend = '\v^\s*' .. t[1] .. '\s*$'
       if line =~# tagopen
         add(foldlist, t)
         open = 1
         break
-      elseif line =~# tagclose
+      elseif line =~# tagend
         if len(foldlist) > 0 && line =~# foldlist[-1][1]
           end = 1
           remove(foldlist, -1)
@@ -174,9 +174,9 @@ def s:LuaFold(): string
       endif
     endfor
     var prefix = ""
-    if open | prefix = ">" | endif
-    if end | prefix = "<" | endif
-    add(b:lua_foldlists, prefix..(len(foldlist) + end))
+    if open == 1 | prefix = ">" | endif
+    if end == 1 | prefix = "<" | endif
+    b:lua_foldlists += [prefix .. (len(foldlist) + end)]
   endfor
   return b:lua_foldlists[v:lnum - 1]
 enddef

--- a/runtime/ftplugin/lua.vim
+++ b/runtime/ftplugin/lua.vim
@@ -6,7 +6,8 @@
 "			C.D. MacEachern <craig.daniel.maceachern@gmail.com>
 "			Tyler Miller <tmillr@proton.me>
 "			Phạm Bình An <phambinhanctb2004@gmail.com>
-" Last Change:		2025 Feb 27
+"			@konfekt
+" Last Change:		2025 Apr 04
 
 if exists("b:did_ftplugin")
   finish

--- a/runtime/ftplugin/lua.vim
+++ b/runtime/ftplugin/lua.vim
@@ -87,18 +87,18 @@ function s:LuaInclude(fname) abort
   return fname
 endfunction
 
-if !has('vim9script')
-  let s:patterns = [
-      	\ ['do', 'end'],
-      	\ ['if\s+.+\s+then', 'end'],
-      	\ ['repeat', 'until\s+.+'],
-      	\ ['for\s+.+\s+do', 'end'],
-      	\ ['while\s+.+\s+do', 'end'],
-      	\ ['function.+', 'end'],
-      	\ ['return\s+function.+', 'end'],
-      	\ ['local\s+function\s+.+', 'end'],
-      	\ ]
+let s:patterns = [
+      \ ['do', 'end'],
+      \ ['if\s+.+\s+then', 'end'],
+      \ ['repeat', 'until\s+.+'],
+      \ ['for\s+.+\s+do', 'end'],
+      \ ['while\s+.+\s+do', 'end'],
+      \ ['function.+', 'end'],
+      \ ['return\s+function.+', 'end'],
+      \ ['local\s+function\s+.+', 'end'],
+      \ ]
 
+if !has('vim9script')
   function s:LuaFold() abort
     if b:lua_lasttick == b:changedtick
       return b:lua_foldlists[v:lnum - 1]
@@ -138,17 +138,6 @@ if !has('vim9script')
   finish
 else
   def s:LuaFold(): number
-    var patterns = [
-      	  \ ['do', 'end'],
-      	  \ ['if\s+.+\s+then', 'end'],
-      	  \ ['repeat', 'until\s+.+'],
-      	  \ ['for\s+.+\s+do', 'end'],
-      	  \ ['while\s+.+\s+do', 'end'],
-      	  \ ['function.+', 'end'],
-      	  \ ['return\s+function.+', 'end'],
-      	  \ ['local\s+function\s+.+', 'end'],
-      	  \ ]
-
     if b:lua_lasttick == b:changedtick
       return b:lua_foldlists[v:lnum - 1]
     endif


### PR DESCRIPTION
Discovering @zzzyxwvut 's 

```vim
" /usr/local/share/vim/vim91/ftplugin/java.vim (lines 357-374)
" See ":help vim9-mix".
if !has("vim9script")
    let &cpo = s:save_cpo
    unlet s:save_cpo
    finish
endif

if exists("s:zip_func_upgradable")
    delfunction! JavaFileTypeZipFile

    def! s:JavaFileTypeZipFile(): string
	@/ = substitute(v:fname, '\.', '\\/', 'g') .. '.java'
	return get(zip_files, bufnr('%'), zip_files[0])
    enddef

    setlocal includeexpr=s:JavaFileTypeZipFile()
    setlocal suffixesadd<
endif
```

prompted me to try something similar to `lua.vim` using @ubaldot 's https://github.com/ubaldot/vim9-conversion-aid/
to achieve

```
#  /usr/local/share/vim/vim91/doc/fold.txt (lines 180-182)
In above example further speedup was gained by using a precompiled Vim9 script
function without arguments (that must still use v:lnum).  See
|expr-option-function|.
```