### PR TITLE
fix: remove redundant semicolon in `get_matches_in_str()`

### DIFF
--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -9164,7 +9164,7 @@ get_matches_in_str(
 	if (d == NULL)
 	    return FAIL;
 	if (list_append_dict(mlist, d) == FAIL)
-	    return FAIL;;
+	    return FAIL;
 
 	if (dict_add_number(d, matchbuf ? "lnum" : "idx", idx) == FAIL)
 	    return FAIL;


### PR DESCRIPTION
Removed the extra semicolon after `return FAIL`.

Thanks to @h-east's [tweet](https://x.com/h_east/status/1908735614436205005?s=46&t=MrwsNBTjqgLt39jDW0QKqA)