### PR TITLE
filetype: help files not detected when 'iskeyword' includes ':'

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -53,7 +53,7 @@ endfunc
 
 " Vim help file, set ft explicitly, because 'modeline' might be off
 au BufNewFile,BufRead */doc/*.txt
-	\  if getline('$') =~ '\(^\|\s\)vim:.*\<\(ft\|filetype\)=help\>'
+	\  if getline('$') =~ '\%(^\|\s\)vim:\%(.*\%(:\|\s\)\)\?\%(ft\|filetype\)=help\%(:\|\s\|$\)'
 	\|   setf help
 	\| endif
 

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -1635,20 +1635,36 @@ func Test_haredoc_file()
 endfunc
 
 func Test_help_file()
+  func! s:Check_help_with_iskeyword(fname)
+    exe 'split' a:fname
+    call assert_equal('help', &filetype)
+    bwipe!
+    set iskeyword+=:
+    exe 'split' a:fname
+    call assert_equal('help', &filetype)
+    bwipe!
+    set iskeyword&
+  endfunc
+
   set nomodeline
   filetype on
   call assert_true(mkdir('doc', 'pR'))
 
   call writefile(['some text', 'vim:ft=help:'], 'doc/help.txt', 'D')
-  split doc/help.txt
-  call assert_equal('help', &filetype)
-  bwipe!
+  call s:Check_help_with_iskeyword('doc/help.txt')
 
   call writefile(['some text', 'Copyright: |manual-copyright| vim:ft=help:'],
         \ 'doc/help1.txt', 'D')
-  split doc/help1.txt
-  call assert_equal('help', &filetype)
-  bwipe!
+  call s:Check_help_with_iskeyword('doc/help1.txt')
+
+  call writefile(['some text', 'vim:noet:ft=help:'], 'doc/help2.txt', 'D')
+  call s:Check_help_with_iskeyword('doc/help2.txt')
+
+  call writefile(['some text', 'vim: noet ft=help'], 'doc/help3.txt', 'D')
+  call s:Check_help_with_iskeyword('doc/help3.txt')
+
+  call writefile(['some text', 'vim: ft=help noet'], 'doc/help4.txt', 'D')
+  call s:Check_help_with_iskeyword('doc/help4.txt')
 
   call writefile(['some text'], 'doc/nothelp.txt', 'D')
   split doc/nothelp.txt


### PR DESCRIPTION
Problem:  Help files not detected when 'iskeyword' includes ':'.
Solution: Do not use \\< and \\> in the pattern.

fixes: #17069
