### PR TITLE
feat(ftplugin): add omni completion and set 'iskeyword' for ft-help

### DIFF
--- a/runtime/doc/helphelp.txt
+++ b/runtime/doc/helphelp.txt
@@ -471,6 +471,11 @@ highlighting.  So do these:
 You can find the details in $VIMRUNTIME/syntax/help.vim
 
 
+COMPLETION
+
+See |ft-help-omni|
+
+
 GENDER NEUTRAL LANGUAGE
 
 						*gender-neutral* *inclusion*

--- a/runtime/doc/helphelp.txt
+++ b/runtime/doc/helphelp.txt
@@ -471,10 +471,10 @@ highlighting.  So do these:
 You can find the details in $VIMRUNTIME/syntax/help.vim
 
 
-COMPLETION
+COMPLETION						*ft-help-omni*
 
-See |ft-help-omni|
-
+To get completion for help tags when writing a tag reference, you can use the
+|i_CTRL-X_CTRL-O| command.
 
 GENDER NEUTRAL LANGUAGE
 

--- a/runtime/doc/helphelp.txt
+++ b/runtime/doc/helphelp.txt
@@ -476,8 +476,8 @@ COMPLETION						*ft-help-omni*
 To get completion for help tags when writing a tag reference, you can use the
 |i_CTRL-X_CTRL-O| command.
 
-GENDER NEUTRAL LANGUAGE
 
+GENDER NEUTRAL LANGUAGE
 						*gender-neutral* *inclusion*
 Vim is for everybody, no matter race, gender or anything.  For new or updated
 help text, gender neutral language is recommended.  Some of the help text is

--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -1481,6 +1481,11 @@ Complete properties and their appropriate values according to CSS 2.1
 specification.
 
 
+HELP							*ft-help-omni*
+
+|i_CTRL-X_CTRL-O| provides completion of Vim help tags
+
+
 HTML							*ft-html-omni*
 XHTML							*ft-xhtml-omni*
 

--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -1481,11 +1481,6 @@ Complete properties and their appropriate values according to CSS 2.1
 specification.
 
 
-HELP							*ft-help-omni*
-
-|i_CTRL-X_CTRL-O| provides completion of Vim help tags
-
-
 HTML							*ft-html-omni*
 XHTML							*ft-xhtml-omni*
 

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -7394,6 +7394,7 @@ ft-groff-syntax	syntax.txt	/*ft-groff-syntax*
 ft-gsp-syntax	syntax.txt	/*ft-gsp-syntax*
 ft-hare	filetype.txt	/*ft-hare*
 ft-haskell-syntax	syntax.txt	/*ft-haskell-syntax*
+ft-help-omni	insert.txt	/*ft-help-omni*
 ft-html-indent	indent.txt	/*ft-html-indent*
 ft-html-omni	insert.txt	/*ft-html-omni*
 ft-html-syntax	syntax.txt	/*ft-html-syntax*

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -7394,7 +7394,7 @@ ft-groff-syntax	syntax.txt	/*ft-groff-syntax*
 ft-gsp-syntax	syntax.txt	/*ft-gsp-syntax*
 ft-hare	filetype.txt	/*ft-hare*
 ft-haskell-syntax	syntax.txt	/*ft-haskell-syntax*
-ft-help-omni	insert.txt	/*ft-help-omni*
+ft-help-omni	helphelp.txt	/*ft-help-omni*
 ft-html-indent	indent.txt	/*ft-html-indent*
 ft-html-omni	insert.txt	/*ft-html-omni*
 ft-html-syntax	syntax.txt	/*ft-html-syntax*

--- a/runtime/ftplugin/help.vim
+++ b/runtime/ftplugin/help.vim
@@ -35,7 +35,7 @@ if !exists('*s:Complete')
           return i " Include the `'` in base
         endif
       endfor
-    elseif type(a:base) == v:t_string
+    else
       return taglist('^' .. a:base)
             \ ->map({_, item -> #{word: item->get('name'), kind: item->get('kind')}})
             \ ->extend(getcompletion(a:base, 'help'))

--- a/runtime/ftplugin/help.vim
+++ b/runtime/ftplugin/help.vim
@@ -11,12 +11,34 @@ let b:did_ftplugin = 1
 let s:cpo_save = &cpo
 set cpo&vim
 
-let b:undo_ftplugin = "setl fo< tw< cole< cocu< keywordprg<"
+let b:undo_ftplugin = "setl isk< fo< tw< cole< cocu< keywordprg< omnifunc<"
 
 setlocal formatoptions+=tcroql textwidth=78 keywordprg=:help
+let &l:iskeyword='!-~,^*,^|,^",192-255'
+setlocal omnifunc=s:Complete
 if has("conceal")
   setlocal cole=2 cocu=nc
 endif
 
 let &cpo = s:cpo_save
 unlet s:cpo_save
+
+if !exists('*s:Complete')
+  func s:Complete(findstart, base)
+    if a:findstart
+      let colnr = col('.') - 1 " Get the column number before the cursor
+      let line = getline('.')
+      for i in range(colnr - 1, 0, -1)
+        if line[i] ==# '|'
+          return i + 1 " Don't include the `|` in base
+        elseif line[i] ==# "'"
+          return i " Include the `'` in base
+        endif
+      endfor
+    elseif type(a:base) == v:t_string
+      return taglist('^' .. a:base)
+            \ ->map({_, item -> #{word: item->get('name'), kind: item->get('kind')}})
+            \ ->extend(getcompletion(a:base, 'help'))
+    endif
+  endfunc
+endif


### PR DESCRIPTION
Problem:

- Help tags provide a good way to navigate the Vim documentation, but
  many help documents don't use them effectively. I think one of the
  reasons is that help writers have to look up help tags manually with
  `:help` command, which is not very convenient.
- 'iskeyword' is only set for help buffers opened by `:help` command.
  That means if I'm editing a help file, I cannot jump to tag in same
  file using `Ctrl-]` unless I manually set it, which is annoying.

Solution:

- Add omni completion for Vim help tags.
- Set 'iskeyword' for `ft-help`