### PR TITLE
Add remind.vim ftplugin

### DIFF
--- a/runtime/ftplugin/remind.vim
+++ b/runtime/ftplugin/remind.vim
@@ -1,0 +1,13 @@
+" Vim filetype plugin file
+" Language:             Remind - a sophisticated calendar and alarm
+" Maintainer:           Joe Reynolds <joereynolds952@gmail.com>
+" Previous Maintainer:  None
+" Latest Revision:      2025 April 08
+" License:              Vim (see :h license)
+
+if exists("b:did_ftplugin")
+  finish
+endif
+let b:did_ftplugin = 1
+
+setlocal comments=:# commentstring=#\ %s


### PR DESCRIPTION
Adds the `commentstring` for [remind](https://dianne.skoll.ca/projects/remind/) filetypes.

Probably doesn't look like much but a lot of plugins will use `commentstring` so you can comment things with motions.
I noticed it was missing while I was trying to comment out a line in my remind file.

Thanks :) 