### PR TITLE
runtime(gleam): update ftplugin

### DIFF
--- a/.github/MAINTAINERS
+++ b/.github/MAINTAINERS
@@ -180,7 +180,7 @@ runtime/ftplugin/gitconfig.vim		@tpope
 runtime/ftplugin/gitignore.vim		@ObserverOfTime
 runtime/ftplugin/gitrebase.vim		@tpope
 runtime/ftplugin/gitsendemail.vim	@tpope
-runtime/ftplugin/gleam.vim		@trilowy
+runtime/ftplugin/gleam.vim		@kirillmorozov
 runtime/ftplugin/go.vim			@dbarnett
 runtime/ftplugin/goaccess.vim		@meonkeys
 runtime/ftplugin/gomod.vim		@yu-yk

--- a/runtime/ftplugin/gleam.vim
+++ b/runtime/ftplugin/gleam.vim
@@ -10,7 +10,8 @@ let b:did_ftplugin = 1
 
 setlocal comments=://,:///,:////
 setlocal commentstring=//\ %s
+setlocal formatprg=gleam\ format\ --stdin
 
-let b:undo_ftplugin = "setlocal comments< commentstring<"
+let b:undo_ftplugin = "setlocal comments< commentstring< formatprg<"
 
 " vim: sw=2 sts=2 et

--- a/runtime/ftplugin/gleam.vim
+++ b/runtime/ftplugin/gleam.vim
@@ -11,8 +11,11 @@ let b:did_ftplugin = 1
 
 setlocal comments=://,:///,:////
 setlocal commentstring=//\ %s
+setlocal expandtab
 setlocal formatprg=gleam\ format\ --stdin
+setlocal shiftwidth=2
+setlocal softtabstop=2
 
-let b:undo_ftplugin = "setlocal comments< commentstring< formatprg<"
+let b:undo_ftplugin = "setlocal com< cms< fp< et< sw< sts<"
 
 " vim: sw=2 sts=2 et

--- a/runtime/ftplugin/gleam.vim
+++ b/runtime/ftplugin/gleam.vim
@@ -1,7 +1,8 @@
 " Vim filetype plugin file
-" Language:    Gleam
-" Maintainer:  Trilowy (https://github.com/trilowy)
-" Last Change: 2024 Oct 13
+" Language:            Gleam
+" Maintainer:          Kirill Morozov <kirill@robotix.pro>
+" Previous Maintainer: Trilowy (https://github.com/trilowy)
+" Last Change:         2025-04-12
 
 if exists('b:did_ftplugin')
   finish


### PR DESCRIPTION
Set `formatprg` to use compiler's built-in formatter and use spaces instead of tabs to match the default formatter behaviour.