### PR TITLE
tests: missing cleanup in test_filetype.vim

### DIFF
--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -2814,6 +2814,7 @@ func Test_pro_file()
   call writefile(['x = findgen(100)/10'], 'Xfile.pro', 'D')
   split Xfile.pro
   call assert_equal('idlang', &filetype)
+  bwipe!
 
   filetype off
 endfunc
@@ -2847,6 +2848,7 @@ func Test_pl_file()
   call writefile(['%data = (1, 2, 3);'], 'Xfile.pl', 'D')
   split Xfile.pl
   call assert_equal('perl', &filetype)
+  bwipe!
 
   filetype off
 endfunc
@@ -2892,6 +2894,7 @@ func Test_org_file()
   call writefile(['* org Headline', '*some bold text*', '/some italic text/'], 'Xfile.org', 'D')
   split Xfile.org
   call assert_equal('org', &filetype)
+  bwipe!
 
   filetype off
 endfunc


### PR DESCRIPTION
Problem:  tests: missing cleanup in test_filetype.vim.
Solution: Add :bwipe corresponding to :split.
