### PR TITLE
runtime(make): highlight dependently on an implementation

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -558,37 +558,46 @@ enddef
 
 export def FTmake()
   # Check if it is a BSD, GNU, or Microsoft Makefile
-  # - 2: detected according to file name
-  # - 1: detected according to file content
-  unlet! b:make_bsd
-  unlet! b:make_gnu
-  unlet! b:make_microsoft
+  unlet! b:make_flavor
 
+  # 1. filename
   if expand('%:t') == 'BSDmakefile'
-    b:make_bsd = 2
+    b:make_flavor = 'bsd'
     setf make
     return
   elseif expand('%:t') == 'GNUmakefile'
-    b:make_gnu = 2
+    b:make_flavor = 'gnu'
     setf make
     return
   endif
 
-  # Makefile, foo.mk, etc
+  # 2. user's setting
+  if exists('g:make_flavor')
+    b:make_flavor = g:make_flavor
+    setf make
+    return
+  elseif get(g:, 'make_microsoft')
+    echom "make_microsoft is deprecated; try g:make_flavor = 'microsoft' instead"
+    b:make_flavor = 'microsoft'
+    setf make
+    return
+  endif
+
+  # 3. try to detect a flavor from file content
   var n = 1
   while n < 1000 && n <= line('$')
     var line = getline(n)
     if line =~? '^\s*!\s*\(ifn\=\(def\)\=\|include\|message\|error\)\>'
-      b:make_microsoft = 1
+      b:make_flavor = 'microsoft'
       break
     elseif line =~ '^\.\%(export\|error\|for\|if\%(n\=\%(def\|make\)\)\=\|info\|warning\)\>'
-      b:make_bsd = 1
+      b:make_flavor = 'bsd'
       break
     elseif line =~ '^ *\%(ifn\=\%(eq\|def\)\|define\|override\)\>'
-      b:make_gnu = 1
+      b:make_flavor = 'gnu'
       break
     elseif line =~ '\$[({][a-z-]\+\s\+\S\+'  # a function call, e.g. $(shell pwd)
-      b:make_gnu = 1
+      b:make_flavor = 'gnu'
       break
     endif
     n += 1

--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -158,6 +158,8 @@ variables can be used to overrule the filetype used for certain extensions:
 	*.inc		g:filetype_inc
 	*.lsl		g:filetype_lsl
 	*.m		g:filetype_m		|ft-mathematica-syntax|
+	*[mM]makefile,*.mk,*.mak,[mM]akefile*
+			g:make_flavor		|ft-make-syntax|
 	*.markdown,*.mdown,*.mkd,*.mkdn,*.mdwn,*.md
 			g:filetype_md		|ft-pandoc-syntax|
 	*.mod		g:filetype_mod

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -2393,10 +2393,15 @@ Comments are also highlighted by default.  You can turn this off by using: >
 
 	:let make_no_comments = 1
 
-Microsoft Makefile handles variable expansion and comments differently
-(backslashes are not used for escape).  If you see any wrong highlights
-because of this, you can try this: >
+There are various Make implementations, which add extensions other than the
+POSIX specification and thus are mutually incompatible.  If the filename is
+BSDmakefile or GNUmakefile, the corresponding implementation is automatically
+detected; otherwise it is determined by the file contents.  If you see any
+wrong highlights because of this, you can enforce flavor by setting one of the
+following: >
 
+	:let make_bsd = 1  " or
+	:let make_gnu = 1  " or
 	:let make_microsoft = 1
 
 

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -2397,7 +2397,7 @@ There are various Make implementations, which add extensions other than the
 POSIX specification and thus are mutually incompatible.  If the filename is
 BSDmakefile or GNUmakefile, the corresponding implementation is automatically
 detected; otherwise it is determined by the file contents.  If you see any
-wrong highlights because of this, you can enforce flavor by setting one of the
+wrong highlights because of this, you can enforce a flavor by setting one of the
 following: >
 
 	:let make_bsd = 1  " or

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -2396,13 +2396,13 @@ Comments are also highlighted by default.  You can turn this off by using: >
 There are various Make implementations, which add extensions other than the
 POSIX specification and thus are mutually incompatible.  If the filename is
 BSDmakefile or GNUmakefile, the corresponding implementation is automatically
-detected; otherwise it is determined by the file contents.  If you see any
-wrong highlights because of this, you can enforce a flavor by setting one of the
-following: >
+determined; otherwise vim tries to detect it by the file contents.  If you see
+any wrong highlights because of this, you can enforce a flavor by setting one
+of the following: >
 
-	:let make_bsd = 1  " or
-	:let make_gnu = 1  " or
-	:let make_microsoft = 1
+	:let g:make_flavor = 'bsd'  " or
+	:let g:make_flavor = 'gnu'  " or
+	:let g:make_flavor = 'microsoft'
 
 
 MAPLE						*maple.vim* *ft-maple-syntax*

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -3186,7 +3186,7 @@ au BufNewFile,BufRead */etc/sensors.d/[^.]*	call s:StarSetf('sensors')
 au BufNewFile,BufRead */etc/logcheck/*.d*/*	call s:StarSetf('logcheck')
 
 " Makefile
-au BufNewFile,BufRead [mM]akefile*		call s:StarSetf('make')
+au BufNewFile,BufRead [mM]akefile*		if expand('<afile>:t') !~ g:ft_ignore_pat | call dist#ft#FTmake() | endif
 
 " Ruby Makefile
 au BufNewFile,BufRead [rR]akefile*		call s:StarSetf('ruby')

--- a/runtime/syntax/make.vim
+++ b/runtime/syntax/make.vim
@@ -104,7 +104,7 @@ if get(b:, 'make_flavor', s:make_flavor) == 'gnu'
   syn match makePreCondit	"^ *\(ifn\=\(eq\|def\)\>\|else\(\s\+ifn\=\(eq\|def\)\)\=\>\|endif\>\)"
   syn match makeStatement	"^ *vpath\>"
   syn match makeOverride	"^ *override\>"
-  syn match makeStatement contained "[({]\(abspath\|addprefix\|addsuffix\|and\|basename\|call\|dir\|error\|eval\|file\|filter-out\|filter\|findstring\|firstword\|flavor\|foreach\|guile\|if\|info\|join\|lastword\|notdir\|or\|origin\|patsubst\|realpath\|shell\|sort\|strip\|subst\|suffix\|value\|warning\|wildcard\|word\|wordlist\|words\)\>"ms=s+1
+  syn match makeStatement contained "[({]\(abspath\|addprefix\|addsuffix\|and\|basename\|call\|dir\|error\|eval\|file\|filter-out\|filter\|findstring\|firstword\|flavor\|foreach\|guile\|if\|info\|intcmp\|join\|lastword\|let\|notdir\|or\|origin\|patsubst\|realpath\|shell\|sort\|strip\|subst\|suffix\|value\|warning\|wildcard\|word\|wordlist\|words\)\>"ms=s+1
 endif
 
 " Comment

--- a/runtime/syntax/make.vim
+++ b/runtime/syntax/make.vim
@@ -76,11 +76,11 @@ syn match makeCmdNextLine	"\\\n."he=e-1 contained
 " some directives
 syn match makePreCondit	"^ *\(ifn\=\(eq\|def\)\>\|else\(\s\+ifn\=\(eq\|def\)\)\=\>\|endif\>\)"
 syn match makeInclude	"^ *[-s]\=include\s.*$"
-syn match makeStatement	"^ *vpath"
+syn match makeStatement	"^ *vpath\>"
 syn match makeExport    "^ *\(export\|unexport\)\>"
 syn match makeOverride	"^ *override\>"
 " Statements / Functions (GNU make)
-syn match makeStatement contained "(\(abspath\|addprefix\|addsuffix\|and\|basename\|call\|dir\|error\|eval\|file\|filter-out\|filter\|findstring\|firstword\|flavor\|foreach\|guile\|if\|info\|join\|lastword\|notdir\|or\|origin\|patsubst\|realpath\|shell\|sort\|strip\|subst\|suffix\|value\|warning\|wildcard\|word\|wordlist\|words\)\>"ms=s+1
+syn match makeStatement contained "[({]\(abspath\|addprefix\|addsuffix\|and\|basename\|call\|dir\|error\|eval\|file\|filter-out\|filter\|findstring\|firstword\|flavor\|foreach\|guile\|if\|info\|join\|lastword\|notdir\|or\|origin\|patsubst\|realpath\|shell\|sort\|strip\|subst\|suffix\|value\|warning\|wildcard\|word\|wordlist\|words\)\>"ms=s+1
 
 " Comment
 if !exists("make_no_comments")

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -2860,45 +2860,45 @@ func Test_make_file()
   " BSD Makefile
   call writefile([''], 'BSDmakefile', 'D')
   split BSDmakefile
-  call assert_equal(2, get(b:, 'make_bsd', 0))
+  call assert_equal('bsd', get(b:, 'make_flavor', ''))
   bwipe!
 
   call writefile(['.ifmake all', '.endif'], 'XMakefile.mak', 'D')
   split XMakefile.mak
-  call assert_equal(1, get(b:, 'make_bsd', 0))
+  call assert_equal('bsd', get(b:, 'make_flavor', ''))
   bwipe!
 
   " GNU Makefile
   call writefile([''], 'GNUmakefile', 'D')
   split GNUmakefile
-  call assert_equal(2, get(b:, 'make_gnu', 0))
+  call assert_equal('gnu', get(b:, 'make_flavor', ''))
   bwipe!
 
   call writefile(['ifeq ($(foo),foo)', 'endif'], 'XMakefile.mak', 'D')
   split XMakefile.mak
-  call assert_equal(1, get(b:, 'make_gnu', 0))
+  call assert_equal('gnu', get(b:, 'make_flavor', ''))
   bwipe!
 
   call writefile(['define foo', 'endef'], 'XMakefile.mak', 'D')
   split XMakefile.mak
-  call assert_equal(1, get(b:, 'make_gnu', 0))
+  call assert_equal('gnu', get(b:, 'make_flavor', ''))
   bwipe!
 
   call writefile(['vim := $(wildcard *.vim)'], 'XMakefile.mak', 'D')
   split XMakefile.mak
-  call assert_equal(1, get(b:, 'make_gnu', 0))
+  call assert_equal('gnu', get(b:, 'make_flavor', ''))
   bwipe!
 
   " Microsoft Makefile
   call writefile(['# Makefile for Windows', '!if "$(VIMDLL)" == "yes"'], 'XMakefile.mak', 'D')
   split XMakefile.mak
-  call assert_equal(1, get(b:, 'make_microsoft', 0))
+  call assert_equal('microsoft', get(b:, 'make_flavor', ''))
   bwipe!
 
   " BSD or GNU
   call writefile(['# get the list of tests', 'include testdir/Make_all.mak'], 'XMakefile.mak', 'D')
   split XMakefile.mak
-  call assert_equal(0, get(b:, 'make_microsoft', 0))
+  call assert_notequal('microsoft', get(b:, 'make_flavor', ''))
   bwipe!
 
   filetype off

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -2857,12 +2857,45 @@ endfunc
 func Test_make_file()
   filetype on
 
+  " BSD Makefile
+  call writefile([''], 'BSDmakefile', 'D')
+  split BSDmakefile
+  call assert_equal(2, get(b:, 'make_bsd', 0))
+  bwipe!
+
+  call writefile(['.ifmake all', '.endif'], 'XMakefile.mak', 'D')
+  split XMakefile.mak
+  call assert_equal(1, get(b:, 'make_bsd', 0))
+  bwipe!
+
+  " GNU Makefile
+  call writefile([''], 'GNUmakefile', 'D')
+  split GNUmakefile
+  call assert_equal(2, get(b:, 'make_gnu', 0))
+  bwipe!
+
+  call writefile(['ifeq ($(foo),foo)', 'endif'], 'XMakefile.mak', 'D')
+  split XMakefile.mak
+  call assert_equal(1, get(b:, 'make_gnu', 0))
+  bwipe!
+
+  call writefile(['define foo', 'endef'], 'XMakefile.mak', 'D')
+  split XMakefile.mak
+  call assert_equal(1, get(b:, 'make_gnu', 0))
+  bwipe!
+
+  call writefile(['vim := $(wildcard *.vim)'], 'XMakefile.mak', 'D')
+  split XMakefile.mak
+  call assert_equal(1, get(b:, 'make_gnu', 0))
+  bwipe!
+
   " Microsoft Makefile
   call writefile(['# Makefile for Windows', '!if "$(VIMDLL)" == "yes"'], 'XMakefile.mak', 'D')
   split XMakefile.mak
   call assert_equal(1, get(b:, 'make_microsoft', 0))
   bwipe!
 
+  " BSD or GNU
   call writefile(['# get the list of tests', 'include testdir/Make_all.mak'], 'XMakefile.mak', 'D')
   split XMakefile.mak
   call assert_equal(0, get(b:, 'make_microsoft', 0))


### PR DESCRIPTION
Problem:  GNU extensions, such as `ifeq` and `wildcard` function, are highlighted in BSDmakefile
Solution: detect BSD, GNU, or Microsoft implementation according to filename, user-defined global variables, or file contents