### PR TITLE
runtime(doc): disable last-position-jump in diff mode

### DIFF
--- a/runtime/defaults.vim
+++ b/runtime/defaults.vim
@@ -107,6 +107,7 @@ if 1
       \ let line = line("'\"")
       \ | if line >= 1 && line <= line("$") && &filetype !~# 'commit'
       \      && index(['xxd', 'gitrebase', 'tutor'], &filetype) == -1
+      \      && !&diff
       \ |   execute "normal! g`\""
       \ | endif
 

--- a/runtime/doc/usr_05.txt
+++ b/runtime/doc/usr_05.txt
@@ -1,4 +1,4 @@
-*usr_05.txt*	For Vim version 9.1.  Last change: 2025 Mar 22
+*usr_05.txt*	For Vim version 9.1.  Last change: 2025 Apr 10
 
 		     VIM USER MANUAL - by Bram Moolenaar
 
@@ -307,23 +307,27 @@ This switches on three very clever mechanisms:
    filetypes.  See |:filetype-indent-on| and 'indentexpr'.
 
 
-				*restore-cursor* *last-position-jump*  >
+				*restore-cursor* *last-position-jump*  >vim
     augroup RestoreCursor
       autocmd!
       autocmd BufReadPost *
         \ let line = line("'\"")
         \ | if line >= 1 && line <= line("$") && &filetype !~# 'commit'
         \      && index(['xxd', 'gitrebase'], &filetype) == -1
+        \      && !&diff
         \ |   execute "normal! g`\""
         \ | endif
     augroup END
 
 Another autocommand.  This time it is used after reading any file.  The
 complicated stuff after it checks if the '" mark is defined, and jumps to it
-if so.  It doesn't do that for a commit or rebase message, which are likely
-a different one than last time, and when using xxd(1) to filter and edit
-binary files, which transforms input files back and forth, causing them to
-have dual nature, so to speak.  See also |using-xxd|.
+if so.  It doesn't do that when:
+ - editing a commit or rebase message, which are likely a different one than
+   last time,
+ - using xxd(1) to filter and edit binary files, which transforms input files
+   back and forth, causing them to have dual nature, so to speak (see also
+   |using-xxd|) and
+ - Vim is in diff mode
 
 The backslash at the start of a line is used to continue the command from the
 previous line.  That avoids a line getting very long.  See |line-continuation|.


### PR DESCRIPTION
This has been bothering me quite for some time and I never knew why it happened. Just today it occurred to me this might have been because of the last-position-jump.

So I figured, let's fix it for everybody, not just me.