### PR TITLE
Use confirmation dialog when closing a tab from the tab menu

### DIFF
--- a/src/normal.c
+++ b/src/normal.c
@@ -3074,10 +3074,10 @@ handle_tabmenu(void)
     {
 	case TABLINE_MENU_CLOSE:
 	    if (current_tab == 0)
-		do_cmdline_cmd((char_u *)"tabclose");
+		do_cmdline_cmd((char_u *)"confirm tabclose");
 	    else
 	    {
-		vim_snprintf((char *)IObuff, IOSIZE, "tabclose %d",
+		vim_snprintf((char *)IObuff, IOSIZE, "confirm tabclose %d",
 								 current_tab);
 		do_cmdline_cmd(IObuff);
 	    }


### PR DESCRIPTION
In gvim, the `Close` option on the main menu uses `confirm` which brings up the gui confirmation dialog before closing the file. This change brings up the same dialog when using the `Close tab` option on the gui tabmenu.