### PR TITLE
runtime(mbsync): add syntax and ftplugin files

### DIFF
--- a/.github/MAINTAINERS
+++ b/.github/MAINTAINERS
@@ -231,6 +231,7 @@ runtime/ftplugin/m17ndb.vim		@dseomn
 runtime/ftplugin/m3build.vim		@dkearns
 runtime/ftplugin/m3quake.vim		@dkearns
 runtime/ftplugin/markdown.vim		@tpope
+runtime/ftplugin/mbsync.vim		@fymyte
 runtime/ftplugin/mediawiki.vim		@avidseeker
 runtime/ftplugin/meson.vim		@Liambeguin
 runtime/ftplugin/modula2.vim		@dkearns
@@ -554,6 +555,7 @@ runtime/syntax/mailcap.vim		@dkearns
 runtime/syntax/make.vim			@rohieb
 runtime/syntax/mallard.vim		@jhradilek
 runtime/syntax/markdown.vim		@tpope
+runtime/syntax/mbsync.vim		@fymyte
 runtime/syntax/mason.vim		@petdance
 runtime/syntax/mediawiki.vim		@avidseeker
 runtime/syntax/meson.vim		@Liambeguin

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1,4 +1,4 @@
-*syntax.txt*	For Vim version 9.1.  Last change: 2025 Mar 27
+*syntax.txt*	For Vim version 9.1.  Last change: 2025 Apr 13
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -2450,6 +2450,12 @@ Empty *.m files will automatically be presumed to be Matlab files unless you
 have the following in your .vimrc: >
 
 	let filetype_m = "mma"
+
+MBSYNC					*mbsync.vim* *ft-mbsync-syntax*
+
+The mbsync application uses a configuration file to setup mailboxes names,
+user and password. All files ending with `.mbsyncrc` or `isyncrc`
+will be recognized as mbsync configuration files.
 
 MEDIAWIKI					*ft-mediawiki-syntax*
 

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -7430,6 +7430,7 @@ ft-markdown-syntax	syntax.txt	/*ft-markdown-syntax*
 ft-masm-syntax	syntax.txt	/*ft-masm-syntax*
 ft-mathematica-syntax	syntax.txt	/*ft-mathematica-syntax*
 ft-matlab-indent	indent.txt	/*ft-matlab-indent*
+ft-mbsync-syntax	syntax.txt	/*ft-mbsync-syntax*
 ft-mediawiki-syntax	syntax.txt	/*ft-mediawiki-syntax*
 ft-metafont	ft_mp.txt	/*ft-metafont*
 ft-metafont-intro	ft_mp.txt	/*ft-metafont-intro*
@@ -8854,6 +8855,7 @@ matlab-indent	indent.txt	/*matlab-indent*
 matlab-indenting	indent.txt	/*matlab-indenting*
 max()	builtin.txt	/*max()*
 maxcol-variable	eval.txt	/*maxcol-variable*
+mbsync.vim	syntax.txt	/*mbsync.vim*
 mbyte-IME	mbyte.txt	/*mbyte-IME*
 mbyte-XIM	mbyte.txt	/*mbyte-XIM*
 mbyte-combining	mbyte.txt	/*mbyte-combining*

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1,7 +1,7 @@
 " Vim support file to detect file types
 "
 " Maintainer:	The Vim Project <https://github.com/vim/vim>
-" Last Change:	2025 Mar 18
+" Last Change:	2025 Apr 13
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Listen very carefully, I will say this only once
@@ -3348,6 +3348,8 @@ au BufNewFile,BufRead *.blp			setf blueprint
 
 " Blueprint build system file
 au BufNewFile,BufRead *.bp			setf bp
+
+au BufNewFile,BufRead *.mbsyncrc,*isyncrc	setf mbsync
 
 " Use the filetype detect plugins.  They may overrule any of the previously
 " detected filetypes.

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1554,7 +1554,7 @@ au BufNewFile,BufRead *.nb,*.wl			setf mma
 au BufNewFile,BufRead *.mel			setf mel
 
 " mbsync
-au BufNewFile,BufRead .mbsyncrc			setf conf
+au BufNewFile,BufRead *.mbsyncrc,isyncrc	setf mbsync
 
 " mcmeta
 au BufNewFile,BufRead *.mcmeta			setf json
@@ -3348,8 +3348,6 @@ au BufNewFile,BufRead *.blp			setf blueprint
 
 " Blueprint build system file
 au BufNewFile,BufRead *.bp			setf bp
-
-au BufNewFile,BufRead .mbsyncrc,*.mbsyncrc,isyncrc	setf mbsync
 
 " Use the filetype detect plugins.  They may overrule any of the previously
 " detected filetypes.

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -3349,7 +3349,7 @@ au BufNewFile,BufRead *.blp			setf blueprint
 " Blueprint build system file
 au BufNewFile,BufRead *.bp			setf bp
 
-au BufNewFile,BufRead *.mbsyncrc,*isyncrc	setf mbsync
+au BufNewFile,BufRead .mbsyncrc,*.mbsyncrc,isyncrc	setf mbsync
 
 " Use the filetype detect plugins.  They may overrule any of the previously
 " detected filetypes.

--- a/runtime/ftplugin/mbsync.vim
+++ b/runtime/ftplugin/mbsync.vim
@@ -1,0 +1,13 @@
+" Vim filetype plugin file
+" Language:		mbsync configuration file
+" Maintainer:		Pierrick Guillaume <pguillaume@fymyte.com>
+" Last Change:		2025 Apr 13
+
+if (exists('b:did_ftplugin'))
+  finish
+endif
+let b:did_ftplugin = 1
+
+let b:undo_ftplugin = "setlocal commentstring<"
+
+setlocal commentstring=#\ %s

--- a/runtime/syntax/mbsync.vim
+++ b/runtime/syntax/mbsync.vim
@@ -1,0 +1,218 @@
+" Vim syntax file
+" Language:	mbsyncrc
+" Maintainer:	Pierrick Guillaume  <pguillaume@fymyte.com>
+" Last Change:	2025 Apr 13
+"
+" Syntax support for mbsync config file
+
+" This file is based on the mbsync manual (isync v1.4.4)
+" https://isync.sourceforge.io/mbsync.html
+
+if exists('b:current_syntax')
+  finish
+endif
+
+let b:current_syntax = 'mbsync'
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+syn match mbsError    '.*'
+
+syn match mbsCommentL '^#.*$'
+
+" Properties {{{
+
+syn match   mbsNumber   '[0-9]\+' display contained
+syn match   mbsPath     '\%([A-Za-z0-9/._+#$%~=\\{}\[\]:@!-]\|\\.\)\+' display contained
+syn match   mbsPath     '"\%([A-Za-z0-9/._+#$%~=\\{}\[\]:@! -]\|\\.\)\+"' display contained
+syn match   mbsName     '\%([A-Za-z0-9/._+#$%~=\\{}\[\]:@!-]\|\\.\)\+' display contained
+syn match   mbsName     '"\%([A-Za-z0-9/._+#$%~=\\{}\[\]:@! -]\|\\.\)\+"' display contained
+syn match   mbsCommand  '+\?.*$' display contained contains=mbsCommandPrompt
+syn match   mbsCommandPrompt '+' display contained
+syn region  mbsString   start=+"+ skip=+\\"+ end=+"+ display contained
+syn match   mbsSizeUnit '[kKmMbB]' display contained
+syn match   mbsSize     '[0-9]\+' display contained contains=mbsNumber nextgroup=mbsSizeUnit
+syn keyword mbsBool     yes no contained
+
+" }}}
+
+
+" Stores {{{
+" Global Store Config Items
+syn match mbsGlobConfPath     '^Path\s\+\ze.*$'      contains=mbsGlobConfItemK contained nextgroup=mbsPath transparent
+syn match mbsGlobConfMaxSize  '^MaxSize\s\+\ze.*$'   contains=mbsGlobConfItemK contained nextgroup=mbsSize transparent
+syn match mbsGlobConfMapInbox '^MapInbox\s\+\ze.*$'  contains=mbsGlobConfItemK contained nextgroup=mbsPath transparent
+syn match mbsGlobConfFlatten  '^Flatten\s\+\ze.*$'   contains=mbsGlobConfItemK contained nextgroup=mbsPath transparent
+syn match mbsGlobConfTrash    '^Trash\s\+\ze.*$'     contains=mbsGlobConfItemK contained nextgroup=mbsPath transparent
+syn match mbsGlobConfTrashNO  '^TrashNewOnly\s\+\ze.*$'   contains=mbsGlobConfItemK contained nextgroup=mbsBool transparent
+syn match mbsGlobConfTrashRN  '^TrashRemoteNew\s\+\ze.*$' contains=mbsGlobConfItemK contained nextgroup=mbsBool transparent
+syn keyword mbsGlobConfItemK  Path MaxSize MapInbox Flatten Trash TrashNewOnly TrashRemoteNew contained
+
+syn cluster mbsGlobConfItem contains=mbsGlobConfPath,mbsGlobConfMaxSize,mbsGlobConfMapInbox,mbsGlobConfFlatten,mbsCommentL,mbsGlobConfTrash.*
+
+
+"   MaildirStore
+syn match mbsMdSConfStMaildirStore  '^MaildirStore\s\+\ze.*$'   contains=mbsMdSConfItemK contained nextgroup=mbsName transparent
+syn match mbsMdSConfStAltMap        '^AltMap\s\+\ze.*$'         contains=mbsMdSConfItemK contained nextgroup=mbsBool transparent
+syn match mbsMdsConfStInbox         '^Inbox\s\+\ze.*$'          contains=mbsMdSConfItemK contained nextgroup=mbsPath transparent
+syn match mbsMdsConfStInfoDelimiter '^InfoDelimiter\s\+\ze.*$'  contains=mbsMdSConfItemK contained nextgroup=mbsPath transparent
+syn keyword mbsMdSConfSubFoldersOpt  Verbatim Legacy contained
+syn match mbsMdSConfSubFoldersOpt   'Maildir++' display contained
+syn match mbsMdsConfStSubFolders    '^SubFolders\s\+\ze.*$'     contains=mbsMdSConfItemK contained nextgroup=mbsMdSConfSubFoldersOpt transparent
+
+syn cluster mbsMdSConfItem contains=mbsMdSConfSt.*
+
+syn keyword mbsMdSConfItemK   MaildirStore AltMap Inbox InfoDelimiter SubFolders contained
+
+syn region mbsMaildirStore start="^MaildirStore" end="^$" end='\%$' contains=@mbsGlobConfItem,mbsCommentL,@mbsMdSConfItem,mbsError transparent
+
+
+"   IMAP4Accounts
+syn match mbsIAConfStIMAPAccount  '^IMAPAccount\s\+\ze.*$'    contains=mbsIAConfItemK contained nextgroup=mbsName transparent
+syn match mbsIAConfStHost         '^Host\s\+\ze.*$'           contains=mbsIAConfItemK contained nextgroup=mbsPath transparent
+syn match mbsIAConfStPort         '^Port\s\+\ze.*$'           contains=mbsIAConfItemK contained nextgroup=mbsNumber transparent
+syn match mbsIAConfStTimeout      '^Timeout\s\+\ze.*$'        contains=mbsIAConfItemK contained nextgroup=mbsNumber transparent
+syn match mbsIAConfStUser         '^User\s\+\ze.*$'           contains=mbsIAConfItemK contained nextgroup=mbsPath transparent
+syn match mbsIAConfStUserCmd      '^UserCmd\s\+\ze.*$'        contains=mbsIAConfItemK contained nextgroup=mbsCommand transparent
+syn match mbsIAConfStPass         '^Pass\s\+\ze.*$'           contains=mbsIAConfItemK contained nextgroup=mbsPath transparent
+syn match mbsIAConfStPassCmd      '^PassCmd\s\+\ze.*$'        contains=mbsIAConfItemK contained nextgroup=mbsCommand transparent
+syn match mbsIAConfStUseKeychain  '^UseKeychain\s\+\ze.*$'    contains=mbsIAConfItemK contained nextgroup=mbsBool transparent
+syn match mbsIAConfStTunnel       '^Tunnel\s\+\ze.*$'         contains=mbsIAConfItemK contained nextgroup=mbsCommand transparent
+syn match mbsIAConfStAuthMechs    '^AuthMechs\s\+\ze.*$'      contains=mbsIAConfItemK contained nextgroup=mbsPath transparent
+syn keyword mbsIAConfSSLTypeOpt None STARTTLS IMAPS contained
+syn match mbsIAConfStSSLType      '^SSLType\s\+\ze.*$'        contains=mbsIAConfItemK contained nextgroup=mbsIAConfSSLTypeOpt transparent
+syn match mbsIAConfSSLVersionsOpt '\%(SSLv3\|TLSv1\%(.[123]\)\?\)\%(\s\+\%(SSLv3\|TLSv1\%(.[123]\)\?\)\)*' contained
+syn match mbsIAConfStSSLVersions  '^SSLVersions\s\+\ze.*$'    contains=mbsIAConfItemK contained nextgroup=mbsIAConfSSLVersionsOpt transparent
+syn match mbsIAConfStSystemCertificates  '^SystemCertificates\s\+\ze.*$'    contains=mbsIAConfItemK contained nextgroup=mbsBool transparent
+syn match mbsIAConfStCertificateFile  '^CertificateFile\s\+\ze.*$'    contains=mbsIAConfItemK contained nextgroup=mbsPath transparent
+syn match mbsIAConfStClientCertificate  '^ClientCertificate\s\+\ze.*$'    contains=mbsIAConfItemK contained nextgroup=mbsPath transparent
+syn match mbsIAConfStClientKey    '^ClientKey\s\+\ze.*$'       contains=mbsIAConfItemK contained nextgroup=mbsPath transparent
+syn match mbsIAConfStCipherString '^CipherString\s\+\ze.*$'    contains=mbsIAConfItemK contained nextgroup=mbsString transparent
+syn match mbsIAConfStPipelineDepth '^PipelineDepth\s\+\ze.*$'  contains=mbsIAConfItemK contained nextgroup=mbsNumber transparent
+syn match mbsIAConfStDisableExtensions '^DisableExtensions\?\s\+\ze.*$'  contains=mbsIAConfItemK contained nextgroup=mbsPath transparent
+
+syn cluster mbsIAConfItem contains=mbsIAConfSt.*
+
+syn keyword mbsIAConfItemK
+  \ IMAPAccount Host Port Timeout User UserCmd Pass PassCmd UseKeychain Tunnel
+  \ AuthMechs SSLType SSLVersions SystemCertificates CertificateFile ClientCertificate
+  \ ClientKey CipherString PipelineDepth DisableExtension[s] contained
+
+syn region mbsIMAP4AccontsStore start="^IMAPAccount" end="^$" end="\%$" contains=@mbsGlobConfItem,mbsCommentL,@mbsIAConfItem,mbsError transparent
+
+
+"   IMAPStores
+syn match mbsISConfStIMAPStore    '^IMAPStore\s\+\ze.*$'      contains=mbsISConfItemK contained nextgroup=mbsName transparent
+syn match mbsISConfStAccount      '^Account\s\+\ze.*$'        contains=mbsISConfItemK contained nextgroup=mbsName transparent
+syn match mbsISConfStUseNamespace '^UseNamespace\s\+\ze.*$'   contains=mbsISConfItemK contained nextgroup=mbsBool transparent
+syn match mbsISConfStPathDelimiter '^PathDelimiter\s\+\ze.*$'   contains=mbsISConfItemK contained nextgroup=mbsPath transparent
+syn match mbsISConfStSubscribedOnly '^SubscribedOnly\s\+\ze.*$'   contains=mbsISConfItemK contained nextgroup=mbsBool transparent
+
+syn cluster mbsISConfItem contains=mbsISConfSt.*
+
+syn keyword mbsISConfItemK  IMAPStore Account UseNamespace PathDelimiter SubscribedOnly contained
+
+syn region mbsIMAPStore start="^IMAPStore" end="^$" end="\%$" contains=@mbsGlobConfItem,mbsCommentL,@mbsISConfItem,mbsError transparent
+
+" }}}
+
+" Channels {{{
+
+syn match mbsCConfStChannel       '^Channel\s\+\ze.*$'        contains=mbsCConfItemK contained nextgroup=mbsName transparent
+syn region mbsCConfProxOpt matchgroup=mbsCConfProxOptOp start=':' matchgroup=mbsCConfProxOptOp end=':' contained contains=mbsName nextgroup=mbsPath keepend
+syn match mbsCConfStFar           '^Far\s\+\ze.*$'            contains=mbsCConfItemK contained nextgroup=mbsCConfProxOpt transparent
+syn match mbsCConfStNear          '^Near\s\+\ze.*$'           contains=mbsCConfItemK contained nextgroup=mbsCConfProxOpt transparent
+syn match mbsCConfPatternOptOp '[*%!]' display contained
+syn match mbsCConfPatternOpt  '.*$' display contained contains=mbsCConfPatternOptOp
+syn match mbsCConfStPattern       '^Patterns\?\s\+\ze.*$'     contains=mbsCConfItemK contained nextgroup=mbsCConfPatternOpt transparent
+syn match mbsCConfStMaxSize       '^MaxSize\s\+\ze.*$'        contains=mbsCConfItemK contained nextgroup=mbsSize transparent
+syn match mbsCConfStMaxMessages   '^MaxMessages\s\+\ze.*$'    contains=mbsCConfItemK contained nextgroup=mbsNumber transparent
+syn match mbsCConfStExpireUnread  '^ExpireUnread\s\+\ze.*$'   contains=mbsCConfItemK contained nextgroup=mbsBool transparent
+syn match mbsCConfSyncOpt 'None\|All\|\%(\s\+\%(Pull\|Push\|New\|ReNew\|Delete\|Flags\)\)\+' display contained
+syn match mbsCConfStSync          '^Sync\s\+\ze.*$'           contains=mbsCConfItemK contained nextgroup=mbsCConfSyncOpt transparent
+syn keyword mbsCConfManipOpt  None Far Near Both contained
+syn match mbsCConfStCreate        '^Create\s\+\ze.*$'         contains=mbsCConfItemK contained nextgroup=mbsCConfManipOpt transparent
+syn match mbsCConfStRemove        '^Remove\s\+\ze.*$'         contains=mbsCConfItemK contained nextgroup=mbsCConfManipOpt transparent
+syn match mbsCConfStExpunge       '^Expunge\s\+\ze.*$'        contains=mbsCConfItemK contained nextgroup=mbsCConfManipOpt transparent
+syn match mbsCConfStCopyArrivalDate '^CopyArrivalDate\s\+\ze.*$' contains=mbsCConfItemK contained nextgroup=mbsBool transparent
+syn match mbsCConfSyncStateOpt  '\*\|.*$' display contained contains=mbsCConfSyncStateOptOp,mbsPath transparent
+syn match mbsCConfSyncStateOptOp  '\*' display contained
+syn match mbsCConfStSyncState     '^SyncState\s\+\ze.*$'      contains=mbsCConfItemK contained nextgroup=mbsCConfSyncStateOpt transparent
+
+syn cluster mbsCConfItem contains=mbsCConfSt.*
+
+syn keyword mbsCConfItemK
+  \ Channel Far Near Pattern[s] MaxSize MaxMessages ExpireUnread Sync Create
+  \ Remove Expunge CopyArrivalDate SyncState contained
+
+syn region mbsChannel start="^Channel" end="^$" end="\%$" contains=@mbsCConfItem,mbsCommentL,mbsError transparent
+
+" }}}
+
+" Groups {{{
+
+syn match mbsGConfGroupOpt  '\%([A-Za-z0-9/._+#$%~=\\{}\[\]:@!-]\|\\.\)\+' display contained contains=mbsName nextgroup=mbsGConfChannelOpt
+syn match mbsGConfStGroup         '^Group\s\+\ze.*$'          contains=mbsGConfItemK contained nextgroup=mbsGConfGroupOpt transparent
+syn match mbsGConfChannelOpt '.*$' display contained
+syn match mbsGConfStChannel       '^Channels\?\s\+\ze.*$'     contains=mbsGConfItemK contained nextgroup=mbsGConfChannelOpt transparent
+
+syn cluster mbsGConfItem contains=mbsGConfSt.*
+
+syn keyword mbsGConfItemK  Group Channel[s] contained
+
+syn region mbsGroup start="^Group" end="^$" end="\%$" contains=@mbsGConfItem,mbsError transparent
+
+" }}}
+
+" Global Options {{{
+
+syn match mbsFSync                '^FSync\s\+\ze.*$'          contains=mbsGlobOptItemK nextgroup=mbsBool transparent
+syn match mbsFieldDelimiter       '^FieldDelimiter\s\+\ze.*$' contains=mbsGlobOptItemK nextgroup=mbsPath transparent
+syn match mbsBufferLimit          '^BufferLimit\s\+\ze.*$'    contains=mbsGlobOptItemK nextgroup=mbsSize transparent
+
+syn keyword mbsGlobOptItemK FSync FieldDelimiter BufferLimit contained
+" }}}
+
+" Highlights {{{
+
+hi def link mbsError      Error
+
+hi def link mbsCommentL   Comment
+
+hi def link mbsNumber     Number
+hi def link mbsSizeUnit   Type
+hi def link mbsPath       String
+hi def link mbsString     String
+hi def link mbsCommand    String
+hi def link mbsCommandPrompt Operator
+hi def link mbsName       Constant
+hi def link mbsBool       Boolean
+
+hi def link mbsGlobConfItemK  Statement
+
+hi def link mbsMdSConfItemK   Statement
+hi def link mbsMdSConfSubFoldersOpt Keyword
+
+hi def link mbsIAConfItemK    Statement
+hi def link mbsIAConfSSLTypeOpt Keyword
+hi def link mbsIAConfSSLVersionsOpt Keyword
+
+hi def link mbsISConfItemK    Statement
+
+hi def link mbsCConfItemK     Statement
+hi def link mbsCConfProxOptOp Operator
+hi def link mbsCConfPatternOpt String
+hi def link mbsCConfPatternOptOp Operator
+hi def link mbsCConfSyncOpt   Keyword
+hi def link mbsCConfManipOpt  Keyword
+hi def link mbsCConfSyncStateOptOp Operator
+
+hi def link mbsGConfItemK     Statement
+hi def link mbsGConfChannelOpt  String
+
+hi def link mbsGlobOptItemK   Statement
+" }}}
+
+let &cpo = s:cpo_save
+unlet s:cpo_save

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -2914,10 +2914,12 @@ endfunc
 func Test_mbsync_file()
   filetype on
 
-  call writefile(['IMAPAccount account-name', 'Host 10.0.0.1', 'Port 993', 'User user', 'PassCmd "echo 123"'], 'test.mbsyncrc', 'D')
-  split test.mbsyncrc
-  call assert_equal('mbsync', &filetype)
-  bwipe!
+  for fname in ['.mbsyncrc', 'isyncrc']
+    call writefile(['IMAPAccount account-name', 'Host 10.0.0.1', 'Port 993', 'User user', 'PassCmd "echo 123"'], fname, 'D')
+    exe 'split ' .. fname
+    call assert_equal('mbsync', &filetype, 'for text: ' .. string(fname))
+    bwipe!
+  endfor
 
   filetype off
 endfunc

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -181,7 +181,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     cobol: ['file.cbl', 'file.cob'],
     coco: ['file.atg'],
     conaryrecipe: ['file.recipe'],
-    conf: ['auto.master', 'file.conf', 'texdoc.cnf', '.x11vncrc', '.chktexrc', '.ripgreprc', 'ripgreprc', 'file.ctags', '.mbsyncrc'],
+    conf: ['auto.master', 'file.conf', 'texdoc.cnf', '.x11vncrc', '.chktexrc', '.ripgreprc', 'ripgreprc', 'file.ctags'],
     config: ['configure.in', 'configure.ac', '/etc/hostname.file', 'any/etc/hostname.file'],
     confini: ['pacman.conf', 'paru.conf', 'mpv.conf', 'any/.aws/config', 'any/.aws/credentials', 'file.nmconnection'],
     context: ['tex/context/any/file.tex', 'file.mkii', 'file.mkiv', 'file.mkvi', 'file.mkxl', 'file.mklx'],

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -472,6 +472,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     matlab: ['file.m'],
     maxima: ['file.demo', 'file.dmt', 'file.dm1', 'file.dm2', 'file.dm3',
                 'file.wxm', 'maxima-init.mac'],
+    mbsync: ['.mbsyncrc', 'file.mbsyncrc', 'isyncrc'],
     mediawiki: ['file.mw',  'file.wiki'],
     mel: ['file.mel'],
     mermaid: ['file.mmd', 'file.mmdc', 'file.mermaid'],
@@ -2908,19 +2909,6 @@ func Test_pacmanlog()
     call assert_equal('pacmanlog', &filetype, 'for text: ' .. string(fname))
     bwipe!
   endfor
-  filetype off
-endfunc
-
-func Test_mbsync_file()
-  filetype on
-
-  for fname in ['.mbsyncrc', 'isyncrc']
-    call writefile(['IMAPAccount account-name', 'Host 10.0.0.1', 'Port 993', 'User user', 'PassCmd "echo 123"'], fname, 'D')
-    exe 'split ' .. fname
-    call assert_equal('mbsync', &filetype, 'for text: ' .. string(fname))
-    bwipe!
-  endfor
-
   filetype off
 endfunc
 

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -2911,4 +2911,15 @@ func Test_pacmanlog()
   filetype off
 endfunc
 
+func Test_mbsync_file()
+  filetype on
+
+  call writefile(['IMAPAccount account-name', 'Host 10.0.0.1', 'Port 993', 'User user', 'PassCmd "echo 123"'], 'test.mbsyncrc', 'D')
+  split test.mbsyncrc
+  call assert_equal('mbsync', &filetype)
+  bwipe!
+
+  filetype off
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Upstream support for the mbsync filetype.
Original plugin: https://github.com/Fymyte/mbsync.vim

mbsync is a command line application which synchronizes mailboxes; currently Maildir and IMAP4 mailboxes are supported. New messages, message deletions and flag changes can be propagated both ways; the operation set can be selected in a fine-grained manner.

mbsync syntax overview: mbsync manual (isync v1.4.4) https://isync.sourceforge.io/mbsync.html

NOTE: I am the author of the plugin