### PR TITLE
Fix detection of -inf

### DIFF
--- a/src/float.c
+++ b/src/float.c
@@ -55,7 +55,6 @@ string2float(
     {
 	char_u	    buf[100];
 	char_u	    *p;
-	char_u	    *p_end = NULL;
 	int	    quotes = 0;
 
 	vim_strncpy(buf, (char_u *)s, 99);
@@ -65,10 +64,7 @@ string2float(
 	    if (*p == '\'')
 	    {
 		++quotes;
-		if (p_end == NULL)
-		    p_end = p + STRLEN(p);
-		mch_memmove(p, p + 1, (size_t)(p_end - (p + 1)) + 1);	    // +1 for NUL
-		--p_end;
+		mch_memmove(p, p + 1, STRLEN(p));
 	    }
 	    if (!vim_isdigit(*p))
 		break;

--- a/src/float.c
+++ b/src/float.c
@@ -41,7 +41,7 @@ string2float(
 	*value = INFINITY;
 	return 3;
     }
-    if (STRNICMP(text, "-inf", 3) == 0)
+    if (STRNICMP(text, "-inf", 4) == 0)
     {
 	*value = -INFINITY;
 	return 4;
@@ -55,6 +55,7 @@ string2float(
     {
 	char_u	    buf[100];
 	char_u	    *p;
+	char_u	    *p_end = NULL;
 	int	    quotes = 0;
 
 	vim_strncpy(buf, (char_u *)s, 99);
@@ -64,7 +65,10 @@ string2float(
 	    if (*p == '\'')
 	    {
 		++quotes;
-		mch_memmove(p, p + 1, STRLEN(p));
+		if (p_end == NULL)
+		    p_end = p + STRLEN(p);
+		mch_memmove(p, p + 1, (size_t)(p_end - (p + 1)) + 1);	    // +1 for NUL
+		--p_end;
 	    }
 	    if (!vim_isdigit(*p))
 		break;

--- a/src/testdir/test_viminfo.vim
+++ b/src/testdir/test_viminfo.vim
@@ -1329,4 +1329,30 @@ func Test_viminfo_oldfiles_filter()
   let &viminfofile = _viminfofile
 endfunc
 
+func Test_viminfo_gobal_var()
+  let _viminfofile = &viminfofile
+  let _viminfo = &viminfo
+  let &viminfofile=''
+  set viminfo+=!
+  let lines = [
+    \ '# comment line',
+    \ "",
+    \ '# Viminfo version',
+    \ '|1,4',
+    \ "",
+    \ '*encoding=utf-8',
+    \ "",
+    \ '# global variables:',
+    \ "!VAL\tFLO\t-in",
+    \ "!VAR\tFLO\t-inf",
+    \ "",
+    \ ]
+  call writefile(lines, 'Xviminfo2', 'D')
+  rviminfo! Xviminfo2
+  call assert_equal(0.0, g:VAL)
+  call assert_equal(str2float("-inf"), g:VAR)
+  let &viminfofile = _viminfofile
+  let &viminfo = _viminfo
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_viminfo.vim
+++ b/src/testdir/test_viminfo.vim
@@ -1329,7 +1329,7 @@ func Test_viminfo_oldfiles_filter()
   let &viminfofile = _viminfofile
 endfunc
 
-func Test_viminfo_gobal_var()
+func Test_viminfo_global_var()
   let _viminfofile = &viminfofile
   let _viminfo = &viminfo
   let &viminfofile=''


### PR DESCRIPTION
Compare `text` against the full string `"-inf"` instead of only the first 3 characters.