### PR TITLE
fix(move): ensure computed cursor position is actually valid

### DIFF
--- a/src/move.c
+++ b/src/move.c
@@ -3120,6 +3120,7 @@ cursor_correct(void)
 			    ~(VALID_WROW|VALID_WCOL|VALID_CHEIGHT|VALID_CROW);
 	}
     }
+    check_cursor_moved(curwin);
     curwin->w_valid |= VALID_TOPLINE;
 }
 

--- a/src/testdir/test_normal.vim
+++ b/src/testdir/test_normal.vim
@@ -4326,4 +4326,23 @@ func Test_normal_go()
   bwipe!
 endfunc
 
+" Test for Ctrl-D with 'scrolloff' and narrow window does not get stuck.
+func Test_scroll_longline_scrolloff()
+  11new
+  36vsplit
+  set scrolloff=5
+
+  call setline(1, ['']->repeat(5))
+  call setline(6, ['foo'->repeat(20)]->repeat(2))
+  call setline(8, ['bar'->repeat(30)])
+  call setline(9, ['']->repeat(5))
+  exe "normal! \<C-D>"
+  call assert_equal(6, line('w0'))
+  exe "normal! \<C-D>"
+  call assert_equal(7, line('w0'))
+
+  set scrolloff&
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab nofoldenable


### PR DESCRIPTION
Problem:  cursor_correct() calculates a valid cursor position which
	  is later changed by update_topline().
Solution: Update the valid cursor position before validating topline.

Fix #17106