### PR TITLE
filetype: fix nroff detection

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -595,11 +595,15 @@ enddef
 # This function checks if one of the first five lines start with a dot.  In
 # that case it is probably an nroff file: 'filetype' is set and 1 is returned.
 export def FTnroff(): number
-  if getline(1)[0] .. getline(2)[0] .. getline(3)[0]
-    			.. getline(4)[0] .. getline(5)[0] =~ '\.'
-    setf nroff
-    return 1
-  endif
+  var n = 1
+  while n < 5
+    var line = getline(n)
+    if line =~ '^\.\S\S\?'
+      setf nroff
+      return 1
+    endif
+    n += 1
+  endwhile
   return 0
 enddef
 

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1726,7 +1726,7 @@ au BufNewFile,BufRead *.me
 	\   setf nroff |
 	\ endif
 au BufNewFile,BufRead *.tr,*.nr,*.roff,*.tmac,*.mom	setf nroff
-au BufNewFile,BufRead *.[1-9]			call dist#ft#FTnroff()
+au BufNewFile,BufRead *.[0-9],*.[013]p,*.[1-8]x,*.3{am,perl,pm,posix,type},*.[nlop]	call dist#ft#FTnroff()
 
 " Nroff or Objective C++
 au BufNewFile,BufRead *.mm			call dist#ft#FTmm()

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -2889,6 +2889,20 @@ func Test_map_file()
   filetype off
 endfunc
 
+func Test_nroff_file()
+  filetype on
+
+  call writefile(['.TH vim 1 "YYYY Mth DD"'], 'Xfile.1', 'D')
+  split Xfile.1
+  call assert_equal('nroff', &filetype)
+  bwipe!
+
+  call writefile(['. /etc/profile'], 'Xfile.1', 'D')
+  split Xfile.1
+  call assert_notequal('nroff', &filetype)
+  bwipe!
+endfunc
+
 func Test_org_file()
   filetype on
 


### PR DESCRIPTION
Problem: some man files are not recognized as nroff, e.g. 1p (POSIX commands)
Solution: detect man files as nroff

- sections are revised referring to
    - debian-12:/etc/manpath.config
    - fedora-41:/etc/man_db.conf
- detection logic is improved
- detection test is implemented