### PR TITLE
Have vifmrc use vim syntax highlighting

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -2793,7 +2793,7 @@ au BufNewFile,BufRead *.tape			setf vhs
 au BufNewFile,BufRead *.hdl,*.vhd,*.vhdl,*.vbe,*.vst,*.vho  setf vhdl
 
 " Vim script
-au BufNewFile,BufRead *.vim,.exrc,_exrc,.netrwhist	setf vim
+au BufNewFile,BufRead *.vim,.exrc,_exrc,.netrwhist,vifmrc	setf vim
 
 " Viminfo file
 au BufNewFile,BufRead .viminfo,_viminfo		setf viminfo

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -872,7 +872,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     vgrindefs: ['vgrindefs'],
     vhdl: ['file.hdl', 'file.vhd', 'file.vhdl', 'file.vbe', 'file.vst', 'file.vhdl_123', 'file.vho', 'some.vhdl_1', 'some.vhdl_1-file'],
     vhs: ['file.tape'],
-    vim: ['file.vim', '.exrc', '_exrc', 'some-vimrc', 'some-vimrc-file', 'vimrc', 'vimrc-file', '.netrwhist'],
+    vim: ['file.vim', '.exrc', '_exrc', 'some-vimrc', 'some-vimrc-file', 'vimrc', 'vimrc-file', '.netrwhist', 'vifmrc'],
     viminfo: ['.viminfo', '_viminfo'],
     vmasm: ['file.mar'],
     voscm: ['file.cm'],


### PR DESCRIPTION
The configuration file for [vifm] uses the same syntax as vim.

[vifm]:https://github.com/vifm/vifm/