### PR TITLE
runtime(gleam): Update ftplugin, use recommended_style config variable

### DIFF
--- a/runtime/ftplugin/gleam.vim
+++ b/runtime/ftplugin/gleam.vim
@@ -2,7 +2,7 @@
 " Language:            Gleam
 " Maintainer:          Kirill Morozov <kirill@robotix.pro>
 " Previous Maintainer: Trilowy (https://github.com/trilowy)
-" Last Change:         2025-04-12
+" Last Change:         2025 April 16
 
 if exists('b:did_ftplugin')
   finish
@@ -11,11 +11,15 @@ let b:did_ftplugin = 1
 
 setlocal comments=://,:///,:////
 setlocal commentstring=//\ %s
-setlocal expandtab
 setlocal formatprg=gleam\ format\ --stdin
-setlocal shiftwidth=2
-setlocal softtabstop=2
 
-let b:undo_ftplugin = "setlocal com< cms< fp< et< sw< sts<"
+let b:undo_ftplugin = "setlocal com< cms< fp<"
+
+if get(g:, "gleam_recommended_style", 1)
+  setlocal expandtab
+  setlocal shiftwidth=2
+  setlocal softtabstop=2
+  let b:undo_ftplugin ..= " | setlocal et< sw< sts<"
+endif
 
 " vim: sw=2 sts=2 et


### PR DESCRIPTION
Wrap the setting of basic whitespace formatting options in a conditional
block, following the de facto standard.

Setting 'et', 'sts' and 'sw' can be disabled by setting
"gleam_recommended_style" to false.

Follow up to PR #17086.

@kirillmorozov
