### PR TITLE
fix: remove duplicate check when preinsert

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -2757,9 +2757,6 @@ ins_compl_stop(int c, int prev_mode, int retval)
 	retval = TRUE;
     }
 
-    if ((c == Ctrl_W || c == Ctrl_U) && ins_compl_preinsert_effect())
-	ins_compl_delete();
-
     auto_format(FALSE, TRUE);
 
     // Trigger the CompleteDonePre event to give scripts a chance to


### PR DESCRIPTION
Problem: Duplicate check for preinsert effect, particularly for Ctrl_w and Ctrl_U.
Solution: Remove the specific check for Ctrl_w and Ctrl_U to eliminate redundancy.
