### PR TITLE
runtime(jjdescription): Don't require space to start comments

### DIFF
--- a/runtime/syntax/jjdescription.vim
+++ b/runtime/syntax/jjdescription.vim
@@ -11,7 +11,7 @@ syn match jjAdded "A .*" contained
 syn match jjRemoved "D .*" contained
 syn match jjChanged "M .*" contained
 
-syn region jjComment start="^JJ: " end="$" contains=jjAdded,jjRemoved,jjChanged
+syn region jjComment start="^JJ:" end="$" contains=jjAdded,jjRemoved,jjChanged
 
 syn include @jjCommitDiff syntax/diff.vim
 syn region jjCommitDiff start=/\%(^diff --\%(git\|cc\|combined\) \)\@=/ end=/^\%(diff --\|$\|@@\@!\|[^[:alnum:]\ +-]\S\@!\)\@=/ fold contains=@jjCommitDiff


### PR DESCRIPTION
Since jj v0.24.0 (December 2024), `JJ:` comments are recognised even when not followed by a space.