### PR TITLE
Problem:  b:undo_ftplugin not called when re-using buffers

### DIFF
--- a/src/proto/window.pro
+++ b/src/proto/window.pro
@@ -1,4 +1,6 @@
 /* window.c */
+void window_layout_lock(void);
+void window_layout_unlock(void);
 int window_layout_locked(enum CMD_index cmd);
 int check_can_set_curbuf_disabled(void);
 int check_can_set_curbuf_forceit(int forceit);

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -2959,4 +2959,32 @@ func Test_pacmanlog()
   filetype off
 endfunc
 
+func Test_undo_ftplugin_on_buffer_reuse()
+  filetype on
+
+  new
+  let b:undo_ftplugin = ":let g:var='exists'"
+  let g:bufnr = bufnr('%')
+  " no changes done to the buffer, so the buffer will be re-used
+  e $VIMRUNTIME/defaults.vim
+  call assert_equal(g:bufnr, bufnr('%'))
+  call assert_equal('exists', get(g:, 'var', 'fail'))
+  unlet! g:bufnr g:var
+
+  " try to wipe the buffer
+  enew
+  bw defaults.vim
+  let b:undo_ftplugin = ':bw'
+  call assert_fails(':e $VIMRUNTIME/defaults.vim', 'E937')
+
+  " try to split the window
+  enew
+  bw defaults.vim
+  let b:undo_ftplugin = ':sp $VIMRUNTIME/defaults.vim'
+  call assert_fails(':e $VIMRUNTIME/defaults.vim', 'E242')
+
+  bwipe!
+  filetype off
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/window.c
+++ b/src/window.c
@@ -97,14 +97,14 @@ static int close_disallowed = 0;
  * make sure the previously selected window is still there.
  * Must be matched with exactly one call to window_layout_unlock()!
  */
-    static void
+    void
 window_layout_lock(void)
 {
     ++split_disallowed;
     ++close_disallowed;
 }
 
-    static void
+    void
 window_layout_unlock(void)
 {
     --split_disallowed;


### PR DESCRIPTION
Problem:  b:undo_ftplugin not called when re-using buffers Solution: explicitly call b:undo_ftplugin in buflist_new() when re-using
          the current buffer

fixes: #17113