### PR TITLE
Add out-of-memory check to os_mswin.c

### DIFF
--- a/src/os_mswin.c
+++ b/src/os_mswin.c
@@ -2307,16 +2307,20 @@ findServer(char_u *name)
     void
 serverSetName(char_u *name)
 {
+    size_t	namelen;
     char_u	*ok_name;
     HWND	hwnd = 0;
     int		i = 0;
     char_u	*p;
 
     // Leave enough space for a 9-digit suffix to ensure uniqueness!
-    ok_name = alloc(STRLEN(name) + 10);
+    namelen = STRLEN(name);
+    ok_name = alloc(namelen + 10);
+    if (ok_name == NULL)
+	return;
 
     STRCPY(ok_name, name);
-    p = ok_name + STRLEN(name);
+    p = ok_name + namelen;
 
     for (;;)
     {

--- a/src/proto/os_mswin.pro
+++ b/src/proto/os_mswin.pro
@@ -1,4 +1,5 @@
 /* os_mswin.c */
+void SaveInst(HINSTANCE hInst);
 void mch_exit_g(int r);
 void mch_early_init(void);
 int mch_input_isatty(void);


### PR DESCRIPTION
Also in `serverSetName()` measure the length of `name` once.

In addition fix this compiler warning (clang 20.1.2) by adding `void SaveInst(HINSTANCE hInst);` to `os_mswin.pro`:
> clang -c -I. -Iproto -DWIN32 -DWINVER=0x0601 -D_WIN32_WINNT=0x0601 -DHAVE_PATHDEF -DFEAT_HUGE -DHAVE_STDINT_H -D__USE_MINGW_ANSI_STDIO -pipe -Wall -Wno-deprecated-declarations -D_REENTRANT -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1 -Wall -Wextra -Wshadow -Wstrict-prototypes -Wmissing-prototypes -Wno-deprecated-declarations -Wno-error=missing-field-initializers -Werror=uninitialized -Wunused-but-set-variable -DEXITFREE -DFEAT_GUI_MSWIN -DFEAT_CLIPBOARD os_mswin.c -o gobjx86-64/os_mswin.o
> os_mswin.c:116:1: warning: no previous prototype for function 'SaveInst' [-Wmissing-prototypes]
>   116 | SaveInst(HINSTANCE hInst)
>       | ^
> os_mswin.c:115:5: note: declare 'static' if the function is not intended to be used outside of this translation unit
>   115 |     void
>       |     ^
>       |     static`

Note that clang also gives these warnings, but I am not sure how to correct them:
> os_mswin.c:898:16: warning: cast from 'FARPROC' (aka 'long long (*)()') to 'MYSTRPROCSTR' (aka 'char *(*)(char *)') converts to incompatible function type [-Wcast-function-type-mismatch]
>   898 |             ProcAdd = (MYSTRPROCSTR)GetProcAddress(hinstLib, (LPCSTR)funcname);
>       |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
> os_mswin.c:902:21: warning: cast from 'MYSTRPROCSTR' (aka 'char *(*)(char *)') to 'MYSTRPROCINT' (aka 'int (*)(char *)') converts to incompatible function type [-Wcast-function-type-mismatch]
>   902 |                     retval_int = ((MYSTRPROCINT)ProcAdd)((LPSTR)argstring);
>       |                                   ^~~~~~~~~~~~~~~~~~~~~
> os_mswin.c:910:17: warning: cast from 'FARPROC' (aka 'long long (*)()') to 'MYINTPROCSTR' (aka 'char *(*)(int)') converts to incompatible function type [-Wcast-function-type-mismatch]
>   910 |             ProcAddI = (MYINTPROCSTR) GetProcAddress(hinstLib, (LPCSTR)funcname);
>       |                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
> os_mswin.c:914:21: warning: cast from 'MYINTPROCSTR' (aka 'char *(*)(int)') to 'MYINTPROCINT' (aka 'int (*)(int)') converts to incompatible function type [-Wcast-function-type-mismatch]
>   914 |                     retval_int = ((MYINTPROCINT)ProcAddI)(argint);
>       |                                   ^~~~~~~~~~~~~~~~~~~~~~`
