### PR TITLE
runtime(filetype): improve *.h filetype detection

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -3,7 +3,7 @@ vim9script
 # Vim functions for file type detection
 #
 # Maintainer:		The Vim Project <https://github.com/vim/vim>
-# Last Change:		2025 Apr 15
+# Last Change:		2025 Apr 18
 # Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 # These functions are moved here from runtime/filetype.vim to make startup
@@ -203,19 +203,36 @@ export def FTlpc()
   setf c
 enddef
 
-export def FTheader()
-  if match(getline(1, min([line("$"), 200])), '^@\(interface\|end\|class\)') > -1
-    if exists("g:c_syntax_for_h")
-      setf objc
-    else
-      setf objcpp
+# Searches within the first `maxlines` lines of the file for distinctive
+# Objective-C or C++ syntax and returns the appropriate filetype. Returns a
+# null_string if the search was inconclusive.
+def CheckObjCOrCpp(maxlines = 100): string
+  var n = 1
+  while n < maxlines && n <= line('$')
+    const line = getline(n)
+    if line =~ '\v^\s*\@%(class|interface|end)>'
+      return 'objcpp'
+    elseif line =~ '\v^\s*%(class|namespace|template|using)>'
+      return 'cpp'
     endif
-  elseif exists("g:c_syntax_for_h")
+    ++n
+  endwhile
+  return null_string
+enddef
+
+# Determines whether a *.h file is C, C++, Ch, or Objective-C/Objective-C++.
+export def FTheader()
+  if exists('g:filetype_h')
+    execute $'setf {g:filetype_h}'
+  elseif exists('g:c_syntax_for_h')
     setf c
-  elseif exists("g:ch_syntax_for_h")
+  elseif exists('g:ch_syntax_for_h')
     setf ch
   else
-    setf cpp
+    # Search the first 100 lines of the file for distinctive Objective-C or C++
+    # syntax and set the filetype accordingly. Otherwise, use C as the default
+    # filetype.
+    execute $'setf {CheckObjCOrCpp() ?? 'c'}'
   endif
 enddef
 

--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -153,7 +153,11 @@ variables can be used to overrule the filetype used for certain extensions:
 	*.f		g:filetype_f		|ft-forth-syntax|
 	*.frm		g:filetype_frm		|ft-form-syntax|
 	*.fs		g:filetype_fs		|ft-forth-syntax|
-	*.h		g:c_syntax_for_h	|ft-c-syntax|
+	*.h		g:c_syntax_for_h	|ft-c-syntax|	(deprecated)
+	*.h		g:ch_syntax_for_h	|ft-ch-syntax|	(deprecated)
+	*.h		g:filetype_h		|ft-c-syntax|
+						|ft-ch-syntax|
+						|ft-cpp-syntax|
 	*.i		g:filetype_i		|ft-progress-syntax|
 	*.inc		g:filetype_inc
 	*.lsl		g:filetype_lsl

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1056,8 +1056,12 @@ Variable		Highlight ~
 *c_ansi_typedefs*	 ... but do standard ANSI types
 *c_ansi_constants*	 ... but do standard ANSI constants
 *c_no_utf*		don't highlight \u and \U in strings
-*c_syntax_for_h*	for *.h files use C syntax instead of C++ and use objc
-			syntax instead of objcpp
+*c_syntax_for_h*	use C syntax for *.h files instead of C++/ObjC/ObjC++
+			(NOTE: This variable is deprecated and no longer
+			 necessary, as *.h files now default to C, unless the
+			 file contains C++ or Objective-C syntax. If the
+			 automated detection fails, the default filetype can
+			 be adjusted using `g:filetype_h`.)
 *c_no_if0*		don't highlight "#if 0" blocks as comments
 *c_no_cformat*		don't highlight %-formats in strings
 *c_no_c99*		don't highlight C99 standard items
@@ -1116,8 +1120,11 @@ the C syntax file.  See |c.vim| for all the settings that are available for C.
 
 By setting a variable you can tell Vim to use Ch syntax for *.h files, instead
 of C or C++: >
-	:let ch_syntax_for_h = 1
+	:let g:filetype_h = 'ch'
 
+NOTE: In previous versions of Vim, the following (now-deprecated) variable was
+used, but is no longer the preferred approach: >
+	:let ch_syntax_for_h = 1
 
 CHILL						*chill.vim* *ft-chill-syntax*
 

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -6410,7 +6410,6 @@ c_no_tab_space_error	syntax.txt	/*c_no_tab_space_error*
 c_no_trail_space_error	syntax.txt	/*c_no_trail_space_error*
 c_no_utf	syntax.txt	/*c_no_utf*
 c_space_errors	syntax.txt	/*c_space_errors*
-c_syntax_for_h	syntax.txt	/*c_syntax_for_h*
 c_wildchar	cmdline.txt	/*c_wildchar*
 call()	builtin.txt	/*call()*
 carriage-return	intro.txt	/*carriage-return*

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -436,9 +436,7 @@ au BufNewFile,BufRead *.ixx,*.mpp setf cpp
 " https://clang.llvm.org/docs/StandardCPlusPlusModules.html#file-name-requirement
 au BufNewFile,BufRead *.cppm,*.ccm,*.cxxm,*.c++m setf cpp
 
-" .h files can be C, Ch C++, ObjC or ObjC++.
-" Set c_syntax_for_h if you want C, ch_syntax_for_h if you want Ch. ObjC is
-" detected automatically.
+" .h files can be C, C++, Ch, Objective-C, or Objective-C++.
 au BufNewFile,BufRead *.h			call dist#ft#FTheader()
 
 " Ch (CHscript)


### PR DESCRIPTION
This commit changes header files to default to the C filetype, instead of C++, and replaces the existing variables `g:c_syntax_for_h` and `g:ch_syntax_for_h` with a unified `g:filetype_h`, like is used for other ambiguous file extensions.

I preserved[^1] the existing detection of Objective-C files based on the file contents, and also added similar keyword-based detection for C++, which should handle most common situations. I'm sure it could be made more rigorous, but I'm not really much of a C++ programmer.

[^1]: I *did* reduce the number of lines searched to 100 instead of 200, matching most of the other filetypes, but the behavior should otherwise be identical.