### PR TITLE
fix: cannot chain complete when cot contains fuzzy

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -6010,7 +6010,6 @@ ins_compl_start(void)
     if (line_invalid)
 	line = ml_get(curwin->w_cursor.lnum);
 
-    int in_fuzzy = get_cot_flags() & COT_FUZZY;
     if (compl_status_adding())
     {
 	edit_submode_pre = (char_u *)_(" Adding");
@@ -6028,7 +6027,7 @@ ins_compl_start(void)
 	    compl_col = curwin->w_cursor.col;
 	    compl_lnum = curwin->w_cursor.lnum;
 	}
-	else if (ctrl_x_mode_normal() && in_fuzzy)
+	else if (ctrl_x_mode_normal() && cfc_has_mode())
 	{
 	    compl_startpos = curwin->w_cursor;
 	    compl_cont_status &= CONT_S_IPOS;

--- a/src/search.c
+++ b/src/search.c
@@ -5370,30 +5370,6 @@ search_for_fuzzy_match(
 						    len, &current_pos, score);
 		    if (found_new_match)
 		    {
-			if (ctrl_x_mode_normal())
-			{
-			    if (STRNCMP(*ptr, pattern, *len) == 0 && pattern[*len] == NUL)
-			    {
-				char_u	*next_word_end = find_word_start(*ptr + *len);
-				if (*next_word_end != NUL && *next_word_end != NL)
-				{
-				    // Find end of the word.
-				    if (has_mbyte)
-					while (*next_word_end != NUL)
-					{
-					    int l = (*mb_ptr2len)(next_word_end);
-
-					    if (l < 2 && !vim_iswordc(*next_word_end))
-						break;
-					    next_word_end += l;
-					}
-				    else
-				       next_word_end = find_word_end(next_word_end);
-				}
-
-				*len = next_word_end - *ptr;
-			    }
-			}
 			*pos = current_pos;
 			break;
 		    }

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -3480,6 +3480,14 @@ func Test_complete_opt_fuzzy()
   call feedkeys("Sb\<C-X>\<C-P>\<C-N>\<C-Y>\<ESC>", 'tx')
   call assert_equal('b', getline('.'))
 
+  " chain completion
+  call feedkeys("Slore spum\<CR>lor\<C-X>\<C-P>\<C-X>\<C-P>\<ESC>", 'tx')
+  call assert_equal('lore spum', getline('.'))
+
+  " issue #15412
+  call feedkeys("Salpha bravio charlie\<CR>alpha\<C-X>\<C-N>\<C-X>\<C-N>\<C-X>\<C-N>\<ESC>", 'tx')
+  call assert_equal('alpha bravio charlie', getline('.'))
+
   " clean up
   set omnifunc=
   bw!
@@ -3565,34 +3573,6 @@ func Test_complete_fuzzy_collect()
   call feedkeys("Su\<C-X>\<C-L>\<C-P>\<Esc>0", 'tx!')
   call assert_equal('no one can save me but you', getline('.'))
 
-  " issue #15412
-  call setline(1, ['alpha bravio charlie'])
-  call feedkeys("Salpha\<C-X>\<C-N>\<Esc>0", 'tx!')
-  call assert_equal('alpha bravio', getline('.'))
-  call feedkeys("Salp\<C-X>\<C-N>\<Esc>0", 'tx!')
-  call assert_equal('alpha', getline('.'))
-  call feedkeys("A\<C-X>\<C-N>\<Esc>0", 'tx!')
-  call assert_equal('alpha bravio', getline('.'))
-  call feedkeys("A\<C-X>\<C-N>\<Esc>0", 'tx!')
-  call assert_equal('alpha bravio charlie', getline('.'))
-
-  set complete-=i
-  call feedkeys("Salp\<C-X>\<C-N>\<Esc>0", 'tx!')
-  call assert_equal('alpha', getline('.'))
-  call feedkeys("A\<C-X>\<C-N>\<Esc>0", 'tx!')
-  call assert_equal('alpha bravio', getline('.'))
-  call feedkeys("A\<C-X>\<C-N>\<Esc>0", 'tx!')
-  call assert_equal('alpha bravio charlie', getline('.'))
-
-  call setline(1, ['alpha bravio charlie', 'alpha another'])
-  call feedkeys("Salpha\<C-X>\<C-N>\<C-N>\<Esc>0", 'tx!')
-  call assert_equal('alpha another', getline('.'))
-  call setline(1, ['你好 我好', '你好 他好'])
-  call feedkeys("S你好\<C-X>\<C-N>\<Esc>0", 'tx!')
-  call assert_equal('你好 我好', getline('.'))
-  call feedkeys("S你好\<C-X>\<C-N>\<C-N>\<Esc>0", 'tx!')
-  call assert_equal('你好 他好', getline('.'))
-
   " issue #15526
   set completeopt=menuone,menu,noselect
   call setline(1, ['Text', 'ToText', ''])
@@ -3617,6 +3597,11 @@ func Test_complete_fuzzy_collect()
   call setline(1, ['foo bar fuzzy', 'completefuzzycollect'])
   call feedkeys("Gofuzzy\<C-X>\<C-N>\<C-N>\<C-N>\<C-Y>\<Esc>0", 'tx!')
   call assert_equal('completefuzzycollect', getline('.'))
+
+  execute('%d _')
+  call setline(1, ['fuzzy', 'fuzzy foo', "fuzzy bar", 'fuzzycollect'])
+  call feedkeys("Gofuzzy\<C-X>\<C-N>\<C-N>\<C-N>\<C-Y>\<Esc>0", 'tx!')
+  call assert_equal('fuzzycollect', getline('.'))
 
   bw!
   bw!


### PR DESCRIPTION
Problem: chain complete cannot work when cot include fuzzy and completefuzzycollect will collect word with next word.

Solution: compl_startpos set not correct. remove next word check in search_for_fuzzy_match.

Fix #17131
Fix #16942