### PR TITLE
tests: redundant and strange use of :execute in test_ins_complete.vim

### DIFF
--- a/runtime/doc/develop.txt
+++ b/runtime/doc/develop.txt
@@ -192,7 +192,7 @@ For any non-trivial change, please always create a pull request on github,
 since this triggers the test suite.
 
 							*style-clang-format*
-sound.c and sign.c can be (semi-) automatically formated using the
+sound.c and sign.c can be (semi-) automatically formatted using the
 `clang-format` formatter according to the distributed .clang-format file.
 Other source files do not yet correspond to the .clang-format file.  This may
 change in the future and they may be reformatted as well.

--- a/runtime/doc/version9.txt
+++ b/runtime/doc/version9.txt
@@ -41594,7 +41594,7 @@ Default values: ~
 - the default 'backspace' option for Vim has been set to "indent,eol,start"
   and removed from |defaults.vim|
 - the default fontsize for the GTK builds of Vim (Windows and Unix) has been
-  increased to 12pt to accomodate modern high-dpi monitors
+  increased to 12pt to accommodate modern high-dpi monitors
 - the default value of the 'keyprotocol' option has been updated and support
   for the ghostty terminal emulator (using kitty protocol) has been added
 
@@ -41739,7 +41739,7 @@ Ex-Commands: ~
 Options: ~
 
 'chistory'		Size of the quickfix stack |quickfix-stack|.
-'completefuzzycollect'	Enable fuzzy collection of candiates for (some)
+'completefuzzycollect'	Enable fuzzy collection of candidates for (some)
 			|ins-completion| modes
 'completeitemalign'	Order of |complete-items| in Insert mode completion
 			popup

--- a/src/diff.c
+++ b/src/diff.c
@@ -3229,7 +3229,7 @@ diff_refine_inline_char_highlight(diff_T *dp_orig, garray_T *linemap, int idx1)
 }
 
 /*
- * Find the inline difference within a diff block among differnt buffers.  Do
+ * Find the inline difference within a diff block among different buffers.  Do
  * this by splitting each block's content into characters or words, and then
  * use internal xdiff to calculate the per-character/word diff.  The result is
  * stored in dp instead of returned by the function.
@@ -4548,7 +4548,7 @@ f_diff_hlID(typval_T *argvars UNUSED, typval_T *rettv UNUSED)
     {
 	// Remember the results if using simple since it's recalculated per
 	// call. Otherwise just call diff_find_change() every time since
-	// internally the result is cached interally.
+	// internally the result is cached internally.
 	cache_results = FALSE;
     }
 

--- a/src/normal.c
+++ b/src/normal.c
@@ -2786,7 +2786,7 @@ nv_zet(cmdarg_T *cap)
 		}
 		break;
 
-		// "zp", "zP" in block mode put without addind trailing spaces
+		// "zp", "zP" in block mode put without adding trailing spaces
     case 'P':
     case 'p':  nv_put(cap);
 	       break;

--- a/src/ops.c
+++ b/src/ops.c
@@ -248,11 +248,11 @@ get_vts_sum(int *vts_array, int index)
     int	sum = 0;
     int	i;
 
-    // Perform the summation for indeces within the actual array.
+    // Perform the summation for indices within the actual array.
     for (i = 1; i <= index && i <= vts_array[0]; i++)
 	sum += vts_array[i];
 
-    // Add topstops whose indeces exceed the actual array.
+    // Add topstops whose indices exceed the actual array.
     if (i <= index)
 	sum += vts_array[vts_array[0]] * (index - vts_array[0]);
 

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -4434,7 +4434,7 @@ mch_report_winsize(int fd, int rows, int cols)
     ws.ws_col = cols;
     ws.ws_row = rows;
 
-    // calcurate and set tty pixel size
+    // calculate and set tty pixel size
     struct cellsize cs;
     mch_calc_cell_size(&cs);
 

--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -119,7 +119,7 @@ struct qf_info_S
 };
 
 static qf_info_T ql_info_actual; // global quickfix list
-static qf_info_T *ql_info;	// points to ql_info_actual if memory allocation is sucessful.
+static qf_info_T *ql_info;	// points to ql_info_actual if memory allocation is successful.
 static int_u last_qf_id = 0;	// Last used quickfix list id
 
 #define FMT_PATTERNS 14		// maximum number of % recognized

--- a/src/term.c
+++ b/src/term.c
@@ -1710,7 +1710,7 @@ static char *(key_names[]) =
     // Do those ones first, both may cause a screen redraw.
     "Co",
     // disabled, because it switches termguicolors, but that
-    // is noticable and confuses users
+    // is noticeable and confuses users
     // "RGB",
 # endif
     "ku", "kd", "kr", "kl",

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -3598,7 +3598,7 @@ func Test_complete_fuzzy_collect()
   call feedkeys("Gofuzzy\<C-X>\<C-N>\<C-N>\<C-N>\<C-Y>\<Esc>0", 'tx!')
   call assert_equal('completefuzzycollect', getline('.'))
 
-  execute('%d _')
+  %d _
   call setline(1, ['fuzzy', 'fuzzy foo', "fuzzy bar", 'fuzzycollect'])
   call feedkeys("Gofuzzy\<C-X>\<C-N>\<C-N>\<C-N>\<C-Y>\<Esc>0", 'tx!')
   call assert_equal('fuzzycollect', getline('.'))


### PR DESCRIPTION
Problem:  Redundant and strange use of :execute in test_ins_complete.vim
          (after 9.1.1315).
Solution: Use the executed command directly.  Fix various typos in code.
