### PR TITLE
tests: test_format fails

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -8158,7 +8158,8 @@ printf({fmt}, {expr1} ...)				*printf()*
 <		      1.41
 
 		You will get an overflow error |E1510|, when the field-width
-		or precision will result in a string longer than 6400 chars.
+		or precision will result in a string longer than 1048576
+		chars.
 
 							*E1500*
 		You cannot mix positional and non-positional arguments: >

--- a/src/testdir/Make_all.mak
+++ b/src/testdir/Make_all.mak
@@ -434,6 +434,7 @@ NEW_TESTS_RES = \
 	test_float_func.res \
 	test_fnameescape.res \
 	test_fold.res \
+	test_format.res \
 	test_functions.res \
 	test_function_lists.res \
 	test_getcwd.res \

--- a/src/testdir/test_format.vim
+++ b/src/testdir/test_format.vim
@@ -334,13 +334,13 @@ func Test_printf_pos_errors()
   call v9.CheckLegacyAndVim9Failure(["call printf('%1$*123456789$.*987654321$d', 5)"], "E1510:")
   call v9.CheckLegacyAndVim9Failure(["call printf('%123456789$*1$.*987654321$d', 5)"], "E1510:")
 
-  call v9.CheckLegacyAndVim9Failure(["call printf('%1$*2$.*1$d', 5, 9999)"], "E1510:")
-  call v9.CheckLegacyAndVim9Failure(["call printf('%1$*1$.*2$d', 5, 9999)"], "E1510:")
-  call v9.CheckLegacyAndVim9Failure(["call printf('%2$*3$.*1$d', 5, 9123, 9321)"], "E1510:")
-  call v9.CheckLegacyAndVim9Failure(["call printf('%1$*2$.*3$d', 5, 9123, 9321)"], "E1510:")
-  call v9.CheckLegacyAndVim9Failure(["call printf('%2$*1$.*3$d', 5, 9123, 9312)"], "E1510:")
+  call v9.CheckLegacyAndVim9Failure(["call printf('%1$*2$.*1$d', 5, 9999999)"], "E1510:")
+  call v9.CheckLegacyAndVim9Failure(["call printf('%1$*1$.*2$d', 5, 9999999)"], "E1510:")
+  call v9.CheckLegacyAndVim9Failure(["call printf('%2$*3$.*1$d', 5, 9999123, 9999321)"], "E1510:")
+  call v9.CheckLegacyAndVim9Failure(["call printf('%1$*2$.*3$d', 5, 9999123, 9999321)"], "E1510:")
+  call v9.CheckLegacyAndVim9Failure(["call printf('%2$*1$.*3$d', 5, 9999123, 9999312)"], "E1510:")
 
-  call v9.CheckLegacyAndVim9Failure(["call printf('%1$*2$d', 5, 9999)"], "E1510:")
+  call v9.CheckLegacyAndVim9Failure(["call printf('%1$*2$d', 5, 9999999)"], "E1510:")
 endfunc
 
 func Test_printf_pos_64bit()


### PR DESCRIPTION
Problem:  tests: test_format fails (after 9.1.1314).
Solution: Increase the string size.  Add missing test_format.res in
          NEW_TESTS_RES.
