### PR TITLE
Runtime: Clarify documentation for `'cot'` option's `"nearest"` value

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2208,8 +2208,10 @@ A jump table for the options with a short description can be found at |Q_op|.
 		    Useful when there is additional information about the
 		    match, e.g., what file it comes from.
 
-	   nearest  Matches are presented in order of proximity to the cursor
-		    position.  This applies only to matches from the current
+	   nearest  Matches are listed based on their proximity to the cursor
+		    position, unlike the default behavior, which only
+		    considers proximity for matches appearing below the
+		    cursor.  This applies only to matches from the current
 		    buffer.  No effect if "fuzzy" is present.
 
 	   noinsert Do not insert any text for a match until the user selects


### PR DESCRIPTION


**Problem:**  
The purpose and behavior of the `"nearest"` value for the `'completeopt'` option were unclear in the existing documentation.

**Solution:**  
Updated the documentation to clearly explain how `"nearest"` differs from the default behavior, emphasizing that it considers proximity both above and below the cursor, unlike the default which only considers matches below.
