### PR TITLE
fix: paste multi-line from small delete register

### DIFF
--- a/src/register.c
+++ b/src/register.c
@@ -846,7 +846,7 @@ insert_reg(
 	{
 	    for (i = 0; i < y_current->y_size; ++i)
 	    {
-		if (regname == '-')
+		if (regname == '-' && y_current->y_type == MCHAR)
 		{
 		    int dir = BACKWARD;
 		    if ((State & REPLACE_FLAG) != 0)
@@ -867,11 +867,13 @@ insert_reg(
 		    do_put(regname, NULL, dir, 1L, PUT_CURSEND);
 		}
 		else
+		{
 		    stuffescaped(y_current->y_array[i].string, literally);
-		// Insert a newline between lines and after last line if
-		// y_type is MLINE.
-		if (y_current->y_type == MLINE || i < y_current->y_size - 1)
-		    stuffcharReadbuff('\n');
+		    // Insert a newline between lines and after last line if
+		    // y_type is MLINE.
+		    if (y_current->y_type == MLINE || i < y_current->y_size - 1)
+			stuffcharReadbuff('\n');
+		}
 	    }
 	}
     }

--- a/src/testdir/test_registers.vim
+++ b/src/testdir/test_registers.vim
@@ -1204,4 +1204,13 @@ func Test_mark_from_yank()
   bw!
 endfunc
 
+func Test_insert_small_delete_linewise()
+  new
+  call setline(1, ['foo'])
+  call cursor(1, 1)
+  exe ":norm! \"-cc\<C-R>-"
+  call assert_equal(['foo', ''], getline(1, '$'))
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem: small delete register cannot paste multi-line correctly

Solution: caused by 032a2d050b82b146d70d6ff714838ee62c07d8ad, so make
this logic handle charwise only
