### PR TITLE
tests: not checking error numbers properly

### DIFF
--- a/src/testdir/test_arglist.vim
+++ b/src/testdir/test_arglist.vim
@@ -640,7 +640,7 @@ endfunc
 func Test_clear_arglist_in_all()
   n 0 00 000 0000 00000 000000
   au WinNew 0 n 0
-  call assert_fails("all", "E1156")
+  call assert_fails("all", "E1156:")
   au! *
 endfunc
 

--- a/src/testdir/test_autocmd.vim
+++ b/src/testdir/test_autocmd.vim
@@ -3661,9 +3661,9 @@ func Test_autocmd_normal_mess()
   augroup aucmd_normal_test
     au BufLeave,BufWinLeave,BufHidden,BufUnload,BufDelete,BufWipeout * norm 7q/qc
   augroup END
-  call assert_fails('o4', 'E1159')
+  call assert_fails('o4', 'E1159:')
   silent! H
-  call assert_fails('e xx', 'E1159')
+  call assert_fails('e xx', 'E1159:')
   normal G
 
   augroup aucmd_normal_test
@@ -5078,32 +5078,32 @@ func Test_autocmd_tabclosedpre()
   " Close tab in TabClosedPre autocmd
   call ClearAutomcdAndCreateTabs()
   au TabClosedPre * tabclose
-  call assert_fails('tabclose', 'E1312')
+  call assert_fails('tabclose', 'E1312:')
   call ClearAutomcdAndCreateTabs()
   au TabClosedPre * tabclose
-  call assert_fails('tabclose 2', 'E1312')
+  call assert_fails('tabclose 2', 'E1312:')
   call ClearAutomcdAndCreateTabs()
   au TabClosedPre * tabclose 1
-  call assert_fails('tabclose', 'E1312')
+  call assert_fails('tabclose', 'E1312:')
 
   " Close other (all) tabs in TabClosedPre autocmd
   call ClearAutomcdAndCreateTabs()
   au TabClosedPre * tabonly
-  call assert_fails('tabclose', 'E1312')
+  call assert_fails('tabclose', 'E1312:')
   call ClearAutomcdAndCreateTabs()
   au TabClosedPre * tabonly
-  call assert_fails('tabclose 2', 'E1312')
+  call assert_fails('tabclose 2', 'E1312:')
   call ClearAutomcdAndCreateTabs()
   au TabClosedPre * tabclose 4
-  call assert_fails('tabclose 2', 'E1312')
+  call assert_fails('tabclose 2', 'E1312:')
 
   " Open new tabs in TabClosedPre autocmd
   call ClearAutomcdAndCreateTabs()
   au TabClosedPre * tabnew D
-  call assert_fails('tabclose', 'E1312')
+  call assert_fails('tabclose', 'E1312:')
   call ClearAutomcdAndCreateTabs()
   au TabClosedPre * tabnew D
-  call assert_fails('tabclose 1', 'E1312')
+  call assert_fails('tabclose 1', 'E1312:')
 
   " Moving the tab page in TabClosedPre autocmd
   call ClearAutomcdAndCreateTabs()
@@ -5132,10 +5132,10 @@ func Test_autocmd_tabclosedpre()
   " Create new windows in TabClosedPre autocmd
   call ClearAutomcdAndCreateTabs()
   au TabClosedPre * split | e X| vsplit | e Y | split | e Z
-  call assert_fails('tabclose', 'E242')
+  call assert_fails('tabclose', 'E242:')
   call ClearAutomcdAndCreateTabs()
   au TabClosedPre * new X | new Y | new Z
-  call assert_fails('tabclose 1', 'E242')
+  call assert_fails('tabclose 1', 'E242:')
 
   " Test directly closing the tab page with ':tabclose'
   au!

--- a/src/testdir/test_blob.vim
+++ b/src/testdir/test_blob.vim
@@ -240,13 +240,13 @@ func Test_blob_compare()
       VAR b1 = 0z0011
       echo b1 == 9
   END
-  call v9.CheckLegacyAndVim9Failure(lines, ['E977:', 'E1072', 'E1072'])
+  call v9.CheckLegacyAndVim9Failure(lines, ['E977:', 'E1072:', 'E1072:'])
 
   let lines =<< trim END
       VAR b1 = 0z0011
       echo b1 != 9
   END
-  call v9.CheckLegacyAndVim9Failure(lines, ['E977:', 'E1072', 'E1072'])
+  call v9.CheckLegacyAndVim9Failure(lines, ['E977:', 'E1072:', 'E1072:'])
 
   let lines =<< trim END
       VAR b1 = 0z0011

--- a/src/testdir/test_crypt.vim
+++ b/src/testdir/test_crypt.vim
@@ -344,7 +344,7 @@ func Test_uncrypt_xchacha20_3_persistent_undo()
     " should fail
     norm! u
     call assert_match('Already at oldest change', execute(':1mess'))
-    call assert_fails('verbose rundo ' .. fnameescape(ufile), 'E822')
+    call assert_fails('verbose rundo ' .. fnameescape(ufile), 'E822:')
     bw!
     set undolevels& cryptmethod& undofile&
     call delete('Xcrypt_sodium_undo.txt')
@@ -357,8 +357,8 @@ func Test_encrypt_xchacha20_missing()
     return
   endif
   sp Xcrypt_sodium_undo.txt
-  call assert_fails(':set cryptmethod=xchacha20', 'E474')
-  call assert_fails(':set cryptmethod=xchacha20v2', 'E474')
+  call assert_fails(':set cryptmethod=xchacha20', 'E474:')
+  call assert_fails(':set cryptmethod=xchacha20v2', 'E474:')
   bw!
   set cm&
 endfunc

--- a/src/testdir/test_edit.vim
+++ b/src/testdir/test_edit.vim
@@ -2083,7 +2083,7 @@ endfunc
 func Test_read_invalid()
   set encoding=latin1
   " This was not properly checking for going past the end.
-  call assert_fails('r`=', 'E484')
+  call assert_fails('r`=', 'E484:')
   set encoding=utf-8
 endfunc
 

--- a/src/testdir/test_expr.vim
+++ b/src/testdir/test_expr.vim
@@ -257,10 +257,10 @@ func Test_method_with_prefix()
   call v9.CheckLegacyAndVim9Success(lines)
 
   call assert_equal([0, 1, 2], --3->range())
-  call v9.CheckDefAndScriptFailure(['eval --3->range()'], 'E15')
+  call v9.CheckDefAndScriptFailure(['eval --3->range()'], 'E15:')
 
   call assert_equal(1, !+-+0)
-  call v9.CheckDefAndScriptFailure(['eval !+-+0'], 'E15')
+  call v9.CheckDefAndScriptFailure(['eval !+-+0'], 'E15:')
 endfunc
 
 func Test_option_value()
@@ -874,7 +874,7 @@ endfunc
 " Test for errors in expression evaluation
 func Test_expr_eval_error()
   call v9.CheckLegacyAndVim9Failure(["VAR i = 'abc' .. []"], ['E730:', 'E1105:', 'E730:'])
-  call v9.CheckLegacyAndVim9Failure(["VAR l = [] + 10"], ['E745:', 'E1051:', 'E745'])
+  call v9.CheckLegacyAndVim9Failure(["VAR l = [] + 10"], ['E745:', 'E1051:', 'E745:'])
   call v9.CheckLegacyAndVim9Failure(["VAR v = 10 + []"], ['E745:', 'E1051:', 'E745:'])
   call v9.CheckLegacyAndVim9Failure(["VAR v = 10 / []"], ['E745:', 'E1036:', 'E745:'])
   call v9.CheckLegacyAndVim9Failure(["VAR v = -{}"], ['E728:', 'E1012:', 'E728:'])

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -1147,13 +1147,13 @@ func Test_undo_ftplugin_on_buffer_reuse()
   enew
   bw defaults.vim
   let b:undo_ftplugin = ':bw'
-  call assert_fails(':e $VIMRUNTIME/defaults.vim', 'E937')
+  call assert_fails(':e $VIMRUNTIME/defaults.vim', 'E937:')
 
   " try to split the window
   enew
   bw defaults.vim
   let b:undo_ftplugin = ':sp $VIMRUNTIME/defaults.vim'
-  call assert_fails(':e $VIMRUNTIME/defaults.vim', 'E242')
+  call assert_fails(':e $VIMRUNTIME/defaults.vim', 'E242:')
 
   bwipe!
   filetype off

--- a/src/testdir/test_listdict.vim
+++ b/src/testdir/test_listdict.vim
@@ -1412,7 +1412,7 @@ func Test_listdict_index()
   call v9.CheckLegacyAndVim9Failure(['VAR d = {"k": 10}', 'echo d[1 : 2]'], 'E719:')
 
   call assert_fails("let v = [4, 6][{-> 1}]", 'E729:')
-  call v9.CheckDefAndScriptFailure(['var v = [4, 6][() => 1]'], ['E1012', 'E703:'])
+  call v9.CheckDefAndScriptFailure(['var v = [4, 6][() => 1]'], ['E1012:', 'E703:'])
 
   call v9.CheckLegacyAndVim9Failure(['VAR v = range(5)[2 : []]'], ['E730:', 'E1012:', 'E730:'])
 

--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -277,11 +277,11 @@ func Test_complete()
   set complete=.,w,b,u,k,\ s,i,d,],t,U,f,o
   call assert_fails('set complete=i^-10', 'E535:')
   call assert_fails('set complete=i^x', 'E535:')
-  call assert_fails('set complete=k^2,t^-1,s^', 'E535')
-  call assert_fails('set complete=t^-1', 'E535')
-  call assert_fails('set complete=kfoo^foo2', 'E535')
-  call assert_fails('set complete=kfoo^', 'E535')
-  call assert_fails('set complete=.^', 'E535')
+  call assert_fails('set complete=k^2,t^-1,s^', 'E535:')
+  call assert_fails('set complete=t^-1', 'E535:')
+  call assert_fails('set complete=kfoo^foo2', 'E535:')
+  call assert_fails('set complete=kfoo^', 'E535:')
+  call assert_fails('set complete=.^', 'E535:')
   set complete=.,w,b,u,k,s,i,d,],t,U,f,o
   set complete=.
   set complete=.^10,t^0

--- a/src/testdir/test_startup.vim
+++ b/src/testdir/test_startup.vim
@@ -1441,7 +1441,7 @@ func Test_cq_zero_exmode()
   let logfile = 'Xcq_log.txt'
   let out = system(GetVimCommand() .. ' --clean --log ' .. logfile .. ' -es -X -c "argdelete foobar" -c"7cq"')
   call assert_equal(8, v:shell_error)
-  let log = filter(readfile(logfile), {idx, val -> val =~ "E480"})
+  let log = filter(readfile(logfile), {idx, val -> val =~ "E480:"})
   call assert_match('E480: No match: foobar', log[0])
   call delete(logfile)
 
@@ -1452,7 +1452,7 @@ func Test_cq_zero_exmode()
   else
     call assert_equal(256, v:shell_error)
   endif
-  let log = filter(readfile(logfile), {idx, val -> val =~ "E480"})
+  let log = filter(readfile(logfile), {idx, val -> val =~ "E480:"})
   call assert_match('E480: No match: foobar', log[0])
   call delete('Xcq_log.txt')
 endfunc

--- a/src/testdir/test_trycatch.vim
+++ b/src/testdir/test_trycatch.vim
@@ -1850,7 +1850,7 @@ func T75_R()
       Xpath 'f'
     finally
       Xpath 'g'
-      if caught || $VIMNOERRTHROW && v:errmsg =~ 'E21'
+      if caught || $VIMNOERRTHROW && v:errmsg =~ 'E21:'
         Xpath 'h'
       endif
       break		" discard error for $VIMNOERRTHROW
@@ -1877,7 +1877,7 @@ func Test_builtin_func_error()
         Xpath 'k'
       finally
         Xpath 'l'
-        if caught || $VIMNOERRTHROW && v:errmsg =~ 'E21'
+        if caught || $VIMNOERRTHROW && v:errmsg =~ 'E21:'
           Xpath 'm'
         endif
         break		" discard error for $VIMNOERRTHROW
@@ -1896,7 +1896,7 @@ func Test_builtin_func_error()
         Xpath 'o'
       finally
         Xpath 'p'
-        if caught || $VIMNOERRTHROW && v:errmsg =~ 'E21'
+        if caught || $VIMNOERRTHROW && v:errmsg =~ 'E21:'
           Xpath 'q'
         endif
         break		" discard error for $VIMNOERRTHROW
@@ -1915,7 +1915,7 @@ func Test_builtin_func_error()
         Xpath 's'
       finally
         Xpath 't'
-        if caught || $VIMNOERRTHROW && v:errmsg =~ 'E21'
+        if caught || $VIMNOERRTHROW && v:errmsg =~ 'E21:'
           Xpath 'u'
         endif
         break		" discard error for $VIMNOERRTHROW
@@ -1938,7 +1938,7 @@ func Test_builtin_func_error()
         Xpath 'x'
       finally
         Xpath 'y'
-        if caught || $VIMNOERRTHROW && v:errmsg =~ 'E21'
+        if caught || $VIMNOERRTHROW && v:errmsg =~ 'E21:'
           Xpath 'z'
         endif
         break		" discard error for $VIMNOERRTHROW
@@ -1958,7 +1958,7 @@ func Test_builtin_func_error()
         Xpath 'B'
       finally
         Xpath 'C'
-        if caught || $VIMNOERRTHROW && v:errmsg =~ 'E21'
+        if caught || $VIMNOERRTHROW && v:errmsg =~ 'E21:'
           Xpath 'D'
         endif
         call assert_equal('a', x)

--- a/src/testdir/test_usercommands.vim
+++ b/src/testdir/test_usercommands.vim
@@ -326,13 +326,13 @@ func Test_CmdErrors()
       vim9script
       com! -complete=file DoCmd :
   END
-  call v9.CheckScriptFailure(lines, 'E1208', 2)
+  call v9.CheckScriptFailure(lines, 'E1208:', 2)
 
   let lines =<< trim END
       vim9script
       com! -nargs=0 -complete=file DoCmd :
   END
-  call v9.CheckScriptFailure(lines, 'E1208', 2)
+  call v9.CheckScriptFailure(lines, 'E1208:', 2)
 
   com! -nargs=0 DoCmd :
   call assert_fails('DoCmd x', 'E488:')

--- a/src/testdir/test_vim9_assign.vim
+++ b/src/testdir/test_vim9_assign.vim
@@ -383,7 +383,7 @@ def Test_type_with_extra_white()
   var lines =<< trim END
       const x : number = 3
   END
-  v9.CheckDefExecAndScriptFailure(lines, 'E1059')
+  v9.CheckDefExecAndScriptFailure(lines, 'E1059:')
 enddef
 
 def Test_keep_type_after_assigning_null()
@@ -532,8 +532,8 @@ def Test_assign_unpack()
   lines =<< trim END
       [v1, v2] = [1, 2]
   END
-  v9.CheckDefFailure(lines, 'E1089', 1)
-  v9.CheckScriptFailure(['vim9script'] + lines, 'E1089', 2)
+  v9.CheckDefFailure(lines, 'E1089:', 1)
+  v9.CheckScriptFailure(['vim9script'] + lines, 'E1089:', 2)
 
   lines =<< trim END
       var v1: number

--- a/src/testdir/test_vim9_builtin.vim
+++ b/src/testdir/test_vim9_builtin.vim
@@ -1037,7 +1037,7 @@ def Test_execute()
 
   v9.CheckSourceDefAndScriptFailure(['execute(123)'], ['E1013: Argument 1: type mismatch, expected string but got number', 'E1222: String or List required for argument 1'])
   v9.CheckSourceDefFailure(['execute([123])'], 'E1013: Argument 1: type mismatch, expected list<string> but got list<number>')
-  v9.CheckSourceDefExecFailure(['echo execute(["xx", 123])'], 'E492')
+  v9.CheckSourceDefExecFailure(['echo execute(["xx", 123])'], 'E492:')
   v9.CheckSourceDefAndScriptFailure(['execute("xx", 123)'], ['E1013: Argument 2: type mismatch, expected string but got number', 'E1174: String required for argument 2'])
 enddef
 

--- a/src/testdir/test_vim9_cmd.vim
+++ b/src/testdir/test_vim9_cmd.vim
@@ -1705,7 +1705,7 @@ def Test_lockvar()
       enddef
       SetList()
   END
-  v9.CheckScriptFailure(lines, 'E1119', 4)
+  v9.CheckScriptFailure(lines, 'E1119:', 4)
 
   lines =<< trim END
       vim9script
@@ -1716,7 +1716,7 @@ def Test_lockvar()
       enddef
       AddToList()
   END
-  v9.CheckScriptFailure(lines, 'E741', 2)
+  v9.CheckScriptFailure(lines, 'E741:', 2)
 
   lines =<< trim END
       vim9script
@@ -1727,7 +1727,7 @@ def Test_lockvar()
       enddef
       AddToList()
   END
-  v9.CheckScriptFailure(lines, 'E741', 2)
+  v9.CheckScriptFailure(lines, 'E741:', 2)
 
   # can unlet a locked list item but not change it
   lines =<< trim END
@@ -1742,7 +1742,7 @@ def Test_lockvar()
     lockvar ll[1]
     ll[1] = 9
   END
-  v9.CheckDefExecAndScriptFailure(lines, ['E1119:', 'E741'], 3)
+  v9.CheckDefExecAndScriptFailure(lines, ['E1119:', 'E741:'], 3)
 
   # can unlet a locked dict item but not change it
   lines =<< trim END
@@ -1757,26 +1757,26 @@ def Test_lockvar()
     lockvar dd.a
     dd.a = 3
   END
-  v9.CheckDefExecAndScriptFailure(lines, ['E1121:', 'E741'], 3)
+  v9.CheckDefExecAndScriptFailure(lines, ['E1121:', 'E741:'], 3)
 
   lines =<< trim END
       var theList = [1, 2, 3]
       lockvar theList
   END
-  v9.CheckDefFailure(lines, 'E1178', 2)
+  v9.CheckDefFailure(lines, 'E1178:', 2)
 
   lines =<< trim END
       var theList = [1, 2, 3]
       unlockvar theList
   END
-  v9.CheckDefFailure(lines, 'E1178', 2)
+  v9.CheckDefFailure(lines, 'E1178:', 2)
 
   lines =<< trim END
       vim9script
       var name = 'john'
       lockvar nameX
   END
-  v9.CheckScriptFailure(lines, 'E1246', 3)
+  v9.CheckScriptFailure(lines, 'E1246:', 3)
 
   lines =<< trim END
       vim9script
@@ -1786,14 +1786,14 @@ def Test_lockvar()
       enddef
       LockIt()
   END
-  v9.CheckScriptFailure(lines, 'E1246', 1)
+  v9.CheckScriptFailure(lines, 'E1246:', 1)
 
   lines =<< trim END
       vim9script
       const name = 'john'
       unlockvar name
   END
-  v9.CheckScriptFailure(lines, 'E46', 3)
+  v9.CheckScriptFailure(lines, 'E46:', 3)
 
   lines =<< trim END
       vim9script
@@ -1803,7 +1803,7 @@ def Test_lockvar()
       enddef
       UnLockIt()
   END
-  v9.CheckScriptFailure(lines, 'E46', 1)
+  v9.CheckScriptFailure(lines, 'E46:', 1)
 
   lines =<< trim END
       def _()
@@ -1811,7 +1811,7 @@ def Test_lockvar()
       enddef
       defcomp
   END
-  v9.CheckScriptFailure(lines, 'E179', 1)
+  v9.CheckScriptFailure(lines, 'E179:', 1)
 
   lines =<< trim END
       def T()
@@ -1819,7 +1819,7 @@ def Test_lockvar()
       enddef
       defcomp
   END
-  v9.CheckScriptFailure(lines, 'E179', 1)
+  v9.CheckScriptFailure(lines, 'E179:', 1)
 enddef
 
 def Test_substitute_expr()

--- a/src/testdir/test_vim9_expr.vim
+++ b/src/testdir/test_vim9_expr.vim
@@ -712,7 +712,7 @@ def Test_expr4_equal()
 
   v9.CheckDefExecAndScriptFailure(['var x: any = "a"', 'echo x == true'], 'E1072: Cannot compare string with bool', 2)
   v9.CheckDefExecAndScriptFailure(["var x: any = true", 'echo x == ""'], 'E1072: Cannot compare bool with string', 2)
-  v9.CheckDefExecAndScriptFailure(["var x: any = 99", 'echo x == true'], ['E1138', 'E1072:'], 2)
+  v9.CheckDefExecAndScriptFailure(["var x: any = 99", 'echo x == true'], ['E1138:', 'E1072:'], 2)
   v9.CheckDefExecAndScriptFailure(["var x: any = 'a'", 'echo x == 99'], ['E1030:', 'E1072:'], 2)
 
   lines =<< trim END
@@ -1610,7 +1610,7 @@ def Test_expr6_vim9script()
   lines =<< trim END
       echo 0z1234 - 44
   END
-  v9.CheckDefAndScriptFailure(lines, ['E1036', 'E974:'], 1)
+  v9.CheckDefAndScriptFailure(lines, ['E1036:', 'E974:'], 1)
 
   lines =<< trim END
       echo 'abc' is? 'abc'
@@ -1865,8 +1865,8 @@ def Test_expr7()
   v9.CheckDefFailure(["var d = 6 * "], 'E1097:', 3)
   v9.CheckScriptFailure(['vim9script', "var d = 6 * "], 'E15:', 2)
 
-  v9.CheckDefAndScriptFailure(['echo 1 / 0'], 'E1154', 1)
-  v9.CheckDefAndScriptFailure(['echo 1 % 0'], 'E1154', 1)
+  v9.CheckDefAndScriptFailure(['echo 1 / 0'], 'E1154:', 1)
+  v9.CheckDefAndScriptFailure(['echo 1 % 0'], 'E1154:', 1)
 
   g:zero = 0
   v9.CheckDefExecFailure(['echo 123 / g:zero'], 'E1154: Divide by zero')
@@ -1876,19 +1876,19 @@ def Test_expr7()
         'g:one = 1.0',
         'g:two = 2.0',
         'echo g:one % g:two',
-        ], 'E804', 3)
+        ], 'E804:', 3)
 
   lines =<< trim END
     var n = 0
     eval 1 / n
   END
-  v9.CheckDefExecAndScriptFailure(lines, 'E1154', 2)
+  v9.CheckDefExecAndScriptFailure(lines, 'E1154:', 2)
 
   lines =<< trim END
     var n = 0
     eval 1 % n
   END
-  v9.CheckDefExecAndScriptFailure(lines, 'E1154', 2)
+  v9.CheckDefExecAndScriptFailure(lines, 'E1154:', 2)
 enddef
 
 def Test_expr7_vim9script()
@@ -2185,7 +2185,7 @@ def Test_expr9_string()
 
   v9.CheckDefAndScriptFailure(['var x = "abc'], 'E114:', 1)
   v9.CheckDefAndScriptFailure(["var x = 'abc"], 'E115:', 1)
-  v9.CheckDefFailure(["if 0", "echo 'xx", "endif"], 'E115', 2)
+  v9.CheckDefFailure(["if 0", "echo 'xx", "endif"], 'E115:', 2)
 
   # interpolated string
   var val = 'val'
@@ -2556,28 +2556,28 @@ def Test_expr9_lambda_block()
   lines =<< trim END
       map([1, 2], (k, v) => { redrawt })
   END
-  v9.CheckDefAndScriptFailure(lines, 'E488')
+  v9.CheckDefAndScriptFailure(lines, 'E488:')
 
   lines =<< trim END
       var Func = (nr: int) => {
               echo nr
             }
   END
-  v9.CheckDefAndScriptFailure(lines, 'E1010', 1)
+  v9.CheckDefAndScriptFailure(lines, 'E1010:', 1)
 
   lines =<< trim END
       var Func = (nr: number): int => {
               return nr
             }
   END
-  v9.CheckDefAndScriptFailure(lines, 'E1010', 1)
+  v9.CheckDefAndScriptFailure(lines, 'E1010:', 1)
 
   lines =<< trim END
       var Func = (nr: number): int => {
               return nr
   END
-  v9.CheckDefFailure(lines, 'E1171', 0)  # line nr is function start
-  v9.CheckScriptFailure(['vim9script'] + lines, 'E1171', 2)
+  v9.CheckDefFailure(lines, 'E1171:', 0)  # line nr is function start
+  v9.CheckScriptFailure(['vim9script'] + lines, 'E1171:', 2)
 
   lines =<< trim END
       var Func = (nr: number): int => {


### PR DESCRIPTION
Problem:  tests: not checking error numbers properly.
Solution: Add a trailing comma to avoid matching a different error
          number with the same prefix.
