### PR TITLE
runtime: improve nroff detection pattern

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -639,13 +639,14 @@ export def FTmms()
   setf mmix
 enddef
 
-# This function checks if one of the first five lines start with a dot.  In
-# that case it is probably an nroff file: 'filetype' is set and 1 is returned.
+# This function checks if one of the first five lines start with a typical
+# nroff pattern in man files.  In that case it is probably an nroff file:
+# 'filetype' is set and 1 is returned.
 export def FTnroff(): number
   var n = 1
-  while n < 5
+  while n <= 5
     var line = getline(n)
-    if line =~ '^\.\S\S\?'
+    if line =~ '^\%([.'']\s*\%(TH\|D[dt]\|S[Hh]\|d[es]1\?\|so\)\s\+\S\|[.'']\s*ig\>\|\%([.'']\s*\)\?\\"\)'
       setf nroff
       return 1
     endif

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1728,7 +1728,7 @@ au BufNewFile,BufRead *.me
 	\   setf nroff |
 	\ endif
 au BufNewFile,BufRead *.tr,*.nr,*.roff,*.tmac,*.mom	setf nroff
-au BufNewFile,BufRead *.[0-9],*.[013]p,*.[1-8]x,*.3{am,perl,pm,posix,type},*.[nlop]	call dist#ft#FTnroff()
+au BufNewFile,BufRead *.[0-9],*.[013]p,*.[1-8]x,*.3{am,perl,pm,posix,type},*.n	call dist#ft#FTnroff()
 
 " Nroff or Objective C++
 au BufNewFile,BufRead *.mm			call dist#ft#FTmm()

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -2955,8 +2955,18 @@ endfunc
 func Test_nroff_file()
   filetype on
 
-  call writefile(['.TH vim 1 "YYYY Mth DD"'], 'Xfile.1', 'D')
+  call writefile(['.TH VIM 1 "YYYY Mth DD"'], 'Xfile.1', 'D')
   split Xfile.1
+  call assert_equal('nroff', &filetype)
+  bwipe!
+
+  call writefile(['.Dd $Mdocdate$', '.Dt "DETECTION TEST" "7"', '.Os'], 'Xfile.7', 'D')
+  split Xfile.7
+  call assert_equal('nroff', &filetype)
+  bwipe!
+
+  call writefile(['''\" t'], 'Xfile.3p', 'D')
+  split Xfile.3p
   call assert_equal('nroff', &filetype)
   bwipe!
 


### PR DESCRIPTION
- explicitly check roff comments and macros typically found in manpages
- do not try to detect alphabetically-sectioned files, except for n, as nroff
    - l: > 'l' happens to be a section for historical reasons
         <https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=391977>
    - n: e.g. /usr/share/man/mann/Tcl.n.gz
    - o: unsure (perhaps fedora-specific)
    - p: unsure (perhaps fedora-specific)

#17117