### PR TITLE
runtime(ftplugin): make ft-typescript use javascript.vim

### DIFF
--- a/runtime/ftplugin/javascript.vim
+++ b/runtime/ftplugin/javascript.vim
@@ -27,23 +27,8 @@ setlocal comments=sO:*\ -,mO:*\ \ ,exO:*/,s1:/*,mb:*,ex:*/,://
 
 setlocal commentstring=//\ %s
 
-" Change the :browse e filter to primarily show JavaScript-related files.
-if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
-    let b:browsefilter =
-                \ "JavaScript Files (*.js)\t*.js\n"
-                \ .. "JSX Files (*.jsx)\t*.jsx\n"
-                \ .. "JavaScript Modules (*.es, *.es6, *.cjs, *.mjs, *.jsm)\t*.es;*.es6;*.cjs;*.mjs;*.jsm\n"
-                \ .. "Vue Templates (*.vue)\t*.vue\n"
-                \ .. "JSON Files (*.json)\t*.json\n"
-    if has("win32")
-        let b:browsefilter ..= "All Files (*.*)\t*\n"
-    else
-        let b:browsefilter ..= "All Files (*)\t*\n"
-    endif
-endif
-
 " The following suffixes should be implied when resolving filenames
-setlocal suffixesadd+=.js,.jsx,.es,.es6,.cjs,.mjs,.jsm,.vue,.json
+setlocal suffixesadd+=.tsx,.jsx,.ts,.d.ts,.vue,.mjs,.js,.cjs,.json
 
 " The following suffixes should have low priority
 "   .snap    jest snapshot

--- a/runtime/ftplugin/javascript.vim
+++ b/runtime/ftplugin/javascript.vim
@@ -28,7 +28,7 @@ setlocal comments=sO:*\ -,mO:*\ \ ,exO:*/,s1:/*,mb:*,ex:*/,://
 setlocal commentstring=//\ %s
 
 " The following suffixes should be implied when resolving filenames
-setlocal suffixesadd+=.tsx,.jsx,.ts,.d.ts,.vue,.mjs,.js,.cjs,.json
+setlocal suffixesadd+=.tsx,.jsx,.ts,.d.ts,.vue,.mjs,.js,.cjs,.json,.jsm,.es6,.es
 
 " The following suffixes should have low priority
 "   .snap    jest snapshot

--- a/runtime/ftplugin/javascript_extra.vim
+++ b/runtime/ftplugin/javascript_extra.vim
@@ -1,0 +1,14 @@
+" Change the :browse e filter to primarily show JavaScript-related files.
+if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
+    let b:browsefilter =
+                \ "JavaScript Files (*.js)\t*.js\n"
+                \ .. "JSX Files (*.jsx)\t*.jsx\n"
+                \ .. "JavaScript Modules (*.es, *.es6, *.cjs, *.mjs, *.jsm)\t*.es;*.es6;*.cjs;*.mjs;*.jsm\n"
+                \ .. "Vue Templates (*.vue)\t*.vue\n"
+                \ .. "JSON Files (*.json)\t*.json\n"
+    if has("win32")
+        let b:browsefilter ..= "All Files (*.*)\t*\n"
+    else
+        let b:browsefilter ..= "All Files (*)\t*\n"
+    endif
+endif

--- a/runtime/ftplugin/javascriptreact.vim
+++ b/runtime/ftplugin/javascriptreact.vim
@@ -4,4 +4,4 @@
 " Last Change:	2020 Aug 19
 
 " Placeholder for backwards compatilibity: .jsx used to stand for JavaScript.
-runtime! ftplugin/javascript.vim
+runtime! ftplugin/javascript.vim ftplugin/javascript_*.vim

--- a/runtime/ftplugin/typescript.vim
+++ b/runtime/ftplugin/typescript.vim
@@ -4,26 +4,7 @@
 " Last Change:	2024 Jan 14
 " 		2024 May 23 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 
-if exists("b:did_ftplugin")
-  finish
-endif
-let b:did_ftplugin = 1
-
-let s:cpo_save = &cpo
-set cpo-=C
-
-" Set 'formatoptions' to break comment lines but not other lines,
-" and insert the comment leader when hitting <CR> or using "o".
-setlocal formatoptions-=t formatoptions+=croql
-
-" Set 'comments' to format dashed lists in comments.
-setlocal comments=sO:*\ -,mO:*\ \ ,exO:*/,s1:/*,mb:*,ex:*/,://
-
-setlocal commentstring=//\ %s
-
-setlocal suffixesadd+=.ts,.d.ts,.tsx,.js,.jsx,.cjs,.mjs
-
-let b:undo_ftplugin = "setl fo< com< cms< sua<"
+runtime! ftplugin/javascript.vim
 
 " Change the :browse e filter to primarily show TypeScript-related files.
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
@@ -40,6 +21,3 @@ if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
     endif
     let b:undo_ftplugin .= " | unlet! b:browsefilter"
 endif
-       
-let &cpo = s:cpo_save
-unlet s:cpo_save


### PR DESCRIPTION
Typescript (and JavascriptReact, TypescriptReact) are just super-sets of Javascript. So to avoid duplication, I think we should make them source ft-javascript.

I would like some reviews from @dkearns @chrisbra 