### PR TITLE
Fix :terminal with 'termwinscroll' E315 issue

### DIFF
--- a/src/mouse.c
+++ b/src/mouse.c
@@ -1902,16 +1902,6 @@ retnomove:
 	    // Drag the status line
 	    count = row - W_WINROW(dragwin) - dragwin->w_height + 1
 							     - on_status_line;
-#ifdef FEAT_TERMINAL
-	    if (bt_terminal(dragwin->w_buffer))
-	    {
-		win_T *curwin_save = curwin;
-		curwin = dragwin;
-		update_topline();
-		validate_cursor();
-		curwin = curwin_save;
-	    }
-#endif
 	    win_drag_status_line(dragwin, count);
 	    did_drag |= count;
 	}

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -3454,7 +3454,22 @@ limit_scrollback(term_T *term, garray_T *gap, int update_buffer)
 	    (sb_line_T *)gap->ga_data + todo,
 	    sizeof(sb_line_T) * gap->ga_len);
     if (update_buffer)
+    {
+	win_T	    *curwin_save = curwin;
+	win_T	    *wp = NULL;
+
 	term->tl_scrollback_scrolled -= todo;
+
+	FOR_ALL_WINDOWS(wp)
+	{
+	    if (wp->w_buffer == term->tl_buffer)
+	    {
+		curwin = wp;
+		check_cursor();
+	    }
+	}
+	curwin = curwin_save;
+    }
 
     // make sure cursor is on a valid line
     if (curbuf == term->tl_buffer)

--- a/src/window.c
+++ b/src/window.c
@@ -5643,10 +5643,6 @@ win_enter_ext(win_T *wp, int flags)
 	did_decrement = TRUE;
     }
 #endif
-#ifdef FEAT_TERMINAL
-    if (bt_terminal(curwin->w_buffer))
-	update_topline();
-#endif
 
     win_fix_current_dir();
 


### PR DESCRIPTION
Fix: #17099 #16024 #16211

The issue was fixed by calling `check_cursor()` after the buffer line deletion process when 'termwinscroll' is exceeded.
Accordingly, I have reverted the previous fix code. (Test is successful.)

If there are no problems, I'll add a test for #17099 later.