### PR TITLE
doc: cross-link :| meaning :p and explain E749

### DIFF
--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -98,7 +98,9 @@ g8			Print the hex values of the bytes used in the
 
 						*:p* *:pr* *:print* *E749*
 :[range]p[rint] [flags]
-			Print [range] lines (default current line).
+			Print [range] lines (default current line). Can also
+			be spelled `:[range]|` due to Vi compatibility (see
+			|:bar|). Gives an error in an empty buffer.
 			Note: If you are looking for a way to print your text
 			on paper see |:hardcopy|.  In the GUI you can use the
 			File.Print menu entry.


### PR DESCRIPTION
E749 is given when :print (with any range) is issued on an empty buffer, like the one you get with :new or :enew. Furthermore, due to Vi compatibility :| is a synonym.

As a result, mappings intended to include a <bar> separator (esp. in the case of boolean or "||") between commands can generate E749 on startup when placed in a vimrc if the bars are not properly encoded or escaped. [1]. Document this failure mode and synonym near the generated error, and cross link with :help :bar. Note that one must read or scroll quite a bit to find the mention of :| behaving like :print!

[1]: https://vi.stackexchange.com/q/46625/10604