### PR TITLE
runtime(doc): fix error in macro example

### DIFF
--- a/runtime/doc/usr_10.txt
+++ b/runtime/doc/usr_10.txt
@@ -63,7 +63,7 @@ execute the following commands:
 	$			Move to the end of the line.
 	a"<Esc>			Append the character double quotation mark (")
 				to the end of the line.
-	j			Go to the next line.
+	0j			Go to the start of the next line.
 	q			Stop recording the macro.
 
 Now that you have done the work once, you can repeat the change by typing the


### PR DESCRIPTION
Problem: Macro example does not work

Solution: make sure to return to start of line

Testing: manual