### PR TITLE
runtime(pov): deprecate `#render` and `#statistics` directives

### DIFF
--- a/runtime/syntax/pov.vim
+++ b/runtime/syntax/pov.vim
@@ -86,7 +86,8 @@ syn keyword povDeclareOption deprecated once contained nextgroup=povDeclareOptio
 syn match povIncludeDir "#\s*include\>"
 syn match povFileDir "#\s*\(fclose\|fopen\|read\|write\)\>"
 syn keyword povFileDataType uint8 sint8 unit16be uint16le sint16be sint16le sint32le sint32be
-syn match povMessageDir "#\s*\(debug\|error\|render\|statistics\|warning\)\>"
+syn match povMessageDir "#\s*\(debug\|error\|warning\)\>"
+syn match povMessageDirDeprecated "#\s*\%(render\|statistics\)\>"
 syn region povFileOpen start="#\s*fopen\>" skip=+"[^"]*"+ matchgroup=povOpenType end="\<\(read\|write\|append\)\>" contains=ALLBUT,PovParenError,PovBraceError,@PovPRIVATE transparent keepend
 
 " Literal strings
@@ -126,6 +127,7 @@ hi def link povIncludeDir Include
 hi def link povFileDir PreProc
 hi def link povFileDataType Special
 hi def link povMessageDir Debug
+hi def link povMessageDirDeprecated povError
 hi def link povAppearance povDescriptors
 hi def link povObjects povDescriptors
 hi def link povGlobalSettings povDescriptors


### PR DESCRIPTION
I don’t know when the directives bacame deprecated, but it is 3.5 at latest.

- 3.1g: active https://www.povray.org/ftp/pub/povray/Old-Versions/Official-3.1g/Docs/povuser.pdf#page=172
- 3.5 or later: deprecated https://www.povray.org/ftp/pub/povray/Old-Versions/Official-3.5/Linux/povlinux.tgz 
 └── povray-3.50c/html/povdoc_172.html 
  https://www.povray.org/documentation/3.7.0/r3_3.html#r3_3_2_7_1