### PR TITLE
fix(ftplugin/yaml.vim): wrong append order of undo_ftplugin when editing RIME custom yaml file

### DIFF
--- a/runtime/ftplugin/yaml.vim
+++ b/runtime/ftplugin/yaml.vim
@@ -17,7 +17,7 @@ setlocal comments=:# commentstring=#\ %s expandtab
 setlocal formatoptions-=t formatoptions+=croql
 
 " rime input method engine uses `*.custom.yaml` as its config files
-if !exists("g:yaml_recommended_style") || g:yaml_recommended_style != 0
+if get(g:, "yaml_recommended_style",1)
   let b:undo_ftplugin ..= " sw< sts<"
   setlocal shiftwidth=2 softtabstop=2
 endif

--- a/runtime/ftplugin/yaml.vim
+++ b/runtime/ftplugin/yaml.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin file
 " Language:             YAML (YAML Ain't Markup Language)
 " Previous Maintainer:  Nikolai Weibull <now@bitwi.se> (inactive)
-" Last Change:  2024 Oct 04
+" Last Change:          2025-04-22
 
 if exists("b:did_ftplugin")
   finish
@@ -16,15 +16,19 @@ let b:undo_ftplugin = "setl com< cms< et< fo<"
 setlocal comments=:# commentstring=#\ %s expandtab
 setlocal formatoptions-=t formatoptions+=croql
 
-" rime input method engine uses `*.custom.yaml` as its config files
 if get(g:, "yaml_recommended_style",1)
   let b:undo_ftplugin ..= " sw< sts<"
   setlocal shiftwidth=2 softtabstop=2
 endif
 
+" rime input method engine(https://rime.im/)
+" uses `*.custom.yaml` as its config files
 if expand('%:r:e') ==# 'custom'
+  " `__include` command in `*.custom.yaml`
+  " see: https://github.com/rime/home/wiki/Configuration#%E5%8C%85%E5%90%AB
   setlocal include=__include:\\s*
   let b:undo_ftplugin ..= " inc<"
+
   if !exists('current_compiler')
     compiler rime_deployer
     let b:undo_ftplugin ..= " | compiler make"

--- a/runtime/ftplugin/yaml.vim
+++ b/runtime/ftplugin/yaml.vim
@@ -17,19 +17,20 @@ setlocal comments=:# commentstring=#\ %s expandtab
 setlocal formatoptions-=t formatoptions+=croql
 
 " rime input method engine uses `*.custom.yaml` as its config files
-if expand('%:r:e') ==# 'custom'
-  if !exists('current_compiler')
-    compiler rime_deployer
-    let b:undo_ftplugin ..= "| compiler make"
-  endif
-  setlocal include=__include:\\s*
-  let b:undo_ftplugin ..= " inc<"
-endif
-
 if !exists("g:yaml_recommended_style") || g:yaml_recommended_style != 0
   let b:undo_ftplugin ..= " sw< sts<"
   setlocal shiftwidth=2 softtabstop=2
 endif
+
+if expand('%:r:e') ==# 'custom'
+  setlocal include=__include:\\s*
+  let b:undo_ftplugin ..= " inc<"
+  if !exists('current_compiler')
+    compiler rime_deployer
+    let b:undo_ftplugin ..= " | compiler make"
+  endif
+endif
+
 
 let &cpo = s:cpo_save
 unlet s:cpo_save


### PR DESCRIPTION
when editing a `squirrel.custom.yaml`, run `:set ft=yaml` manually,
get the following error message:

```vim
Compiler not supported: make inc< sw< sts<
```

The `undo_ftplugin` append order is incorrect，moving `| compiler make` to the end.

correct value should be: `setl com< cms< et< fo< inc< sw< sts< | compiler make`.

related files are:

1. `runtime/compiler/rime_deployer.vim`

