### PR TITLE
runtime(groff)!: update groff compiler

### DIFF
--- a/runtime/compiler/groff.vim
+++ b/runtime/compiler/groff.vim
@@ -25,12 +25,16 @@ silent! function s:groff_compiler_lang()
   return empty(lang) ? '' : '-m'..lang
 endfunction
 
-" Requires output format (= device) to be set by user after :make.
+" man, mdoc, mom, etc
+let s:groff_macro_pkg = get(b:, 'groff_macro_pkg', get(g:, 'groff_macro_pkg', 'mom'))
+" html, latin1, pdf, utf8, etc
+let s:groff_output_dev = get(b:, 'groff_output_dev', get(g:, 'groff_output_dev', 'utf8'))
+
 execute 'CompilerSet makeprg=groff'..escape(
     \ ' '..s:groff_compiler_lang()..
     \ ' -K'..get(b:, 'groff_compiler_encoding', get(g:, 'groff_compiler_encoding', 'utf8'))..
     \ ' '..get(b:, 'groff_compiler_args', get(g:, 'groff_compiler_args', ''))..
-    \ ' -mom -T$* -- %:S > %:r:S.$*', ' \|"')
+    \ ' "-'..s:groff_macro_pkg..'" "-T'..s:groff_output_dev..'" -- %:S > %:r:S."'..s:groff_output_dev..'"', ' \|"')
 " From Gavin Freeborn's https://github.com/Gavinok/vim-troff under Vim License
 " https://github.com/Gavinok/vim-troff/blob/91017b1423caa80aba541c997909a4f810edd275/compiler/troff.vim#L39
 CompilerSet errorformat=%o:<standard\ input>\ (%f):%l:%m,

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -1595,15 +1595,17 @@ stdin (standard input) will not be interactive.
 
 GROFF					*quickfix-groff* *compiler-groff*
 
-The GROFF compiler plugin uses the mom macro set (documented in the groff_mom
-manpage) as input and expects that the output file type extension is passed to
-make, say :make html or :make pdf.
-
+The GROFF compiler plugin runs groff on the buffer.  Groff output device can
+be specified by `b:groff_output_dev` or `g:groff_output_dev`, which defaults
+to `utf8`, i.e. plain text in UTF-8.  Groff macro package can be specified by
+`b:groff_macro_pkg` or `g:groff_macro_pkg`, which defaults to `mom`.
 Additional arguments can be passed to groff by setting them in
-`b:groff_compiler_args` or `g:groff_compiler_args`. The `language` argument
+`b:groff_compiler_args` or `g:groff_compiler_args`.  The `language` argument
 passed to groff is set using 'spelllang'; it can be overridden by setting
-`b:groff_compiler_lang`. The default encoding is `UTF-8` and can be changed
-by setting `b:groff_compiler_encoding` or `g:groff_compiler_encoding`.
+`b:groff_compiler_lang`.  The default encoding is `UTF-8` and can be changed
+by setting `b:groff_compiler_encoding` or `g:groff_compiler_encoding`.  See
+man groff(1) for valid options.  Eventually :make runs something like: >
+	!groff -Kutf8 -mom -Tutf8 <buffer>
 
 PANDOC					*quickfix-pandoc* *compiler-pandoc*
 


### PR DESCRIPTION
Problem: groff compiler assumes a single argument, i.e. output device like html, but the requirement is not checked properly.  Also, macro packages is hardcoded to mom.
Solution: Control output device and macro package by variable.  Arguments for :make are now ignored.

#17181