### PR TITLE
Support using the super keyword from a lambda function in the new method

### DIFF
--- a/src/testdir/test_vim9_class.vim
+++ b/src/testdir/test_vim9_class.vim
@@ -12544,6 +12544,35 @@ def Test_super_keyword()
     assert_equal('A.Foo B.Foo', b.Bar())
   END
   v9.CheckSourceSuccess(lines)
+
+  # Test for using super in a lambda function to invoke a base class method from
+  # the new() method.
+  lines =<< trim END
+    vim9script
+
+    def G(F: func): string
+      return F()
+    enddef
+
+    class Base
+      def F(): string
+        return 'Base.F()'
+      enddef
+    endclass
+
+    class Foo extends Base
+      var s: string = 'x'
+      def new()
+        this.s = G((): string => {
+          return super.F()
+        })
+      enddef
+    endclass
+
+    var f = Foo.new()
+    assert_equal('Base.F()', f.s)
+  END
+  v9.CheckSourceSuccess(lines)
 enddef
 
 " Test for using a list of objects

--- a/src/vim9expr.c
+++ b/src/vim9expr.c
@@ -1647,6 +1647,11 @@ compile_lambda(char_u **arg, cctx_T *cctx)
     ++ufunc->uf_refcount;
     clear_tv(&rettv);
 
+    if (cctx->ctx_ufunc != NULL)
+	// This lambda might be defined in a class method.  Inherit the class
+	// from the current function.
+	ufunc->uf_defclass = cctx->ctx_ufunc->uf_defclass;
+
     // Compile it here to get the return type.  The return type is optional,
     // when it's missing use t_unknown.  This is recognized in
     // compile_return().


### PR DESCRIPTION
Fixes the issue reported in #17166.