### PR TITLE
Add out-of-memory checks for call sites of enc_to_utf16() and utf16_to_enc()

### DIFF
--- a/src/fileio.c
+++ b/src/fileio.c
@@ -5476,6 +5476,8 @@ vim_tempname(
     // "sh".  NOTE: This also checks 'shellcmdflag' to help those people who
     // didn't set 'shellslash' but only if not using PowerShell.
     retval = utf16_to_enc(itmp, NULL);
+    if (retval == NULL)
+	return NULL;
     shname = gettail(p_sh);
     if ((*p_shcf == '-' && !(strstr((char *)shname, "powershell") != NULL
 			     || strstr((char *)shname, "pwsh") != NULL ))

--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -3673,7 +3673,7 @@ gui_mch_exit(int rc UNUSED)
     static char_u *
 logfont2name(LOGFONTW lf)
 {
-    size_t	res_size;
+    char	*p;
     char	*res;
     char	*charset_name;
     char	*quality_name;
@@ -3686,46 +3686,43 @@ logfont2name(LOGFONTW lf)
     charset_name = charset_id2name((int)lf.lfCharSet);
     quality_name = quality_id2name((int)lf.lfQuality);
 
-    res_size = STRLEN(font_name) + 30
-		    + (charset_name == NULL ? 0 : STRLEN(charset_name) + 2)
-		    + (quality_name == NULL ? 0 : STRLEN(quality_name) + 2);
-    res = alloc(res_size);
+    res = alloc(strlen(font_name) + 30
+		    + (charset_name == NULL ? 0 : strlen(charset_name) + 2)
+		    + (quality_name == NULL ? 0 : strlen(quality_name) + 2));
     if (res != NULL)
     {
-	char	*p;
-	size_t	plen;
-
 	p = res;
 	// make a normal font string out of the lf thing:
 	points = pixels_to_points(
 			 lf.lfHeight < 0 ? -lf.lfHeight : lf.lfHeight, TRUE);
 	if (lf.lfWeight == FW_NORMAL || lf.lfWeight == FW_BOLD)
-	    plen = vim_snprintf_safelen(
-		(char *)p, res_size, "%s:h%d", font_name, points);
+	    sprintf((char *)p, "%s:h%d", font_name, points);
 	else
-	    plen = vim_snprintf_safelen(
-		(char *)p, res_size, "%s:h%d:W%ld", font_name, points, lf.lfWeight);
-
-	// replace spaces with underscores.
+	    sprintf((char *)p, "%s:h%d:W%ld", font_name, points, lf.lfWeight);
 	while (*p)
 	{
 	    if (*p == ' ')
 		*p = '_';
 	    ++p;
 	}
-
-	plen += vim_snprintf_safelen(
-	    (char *)p + plen,
-	    res_size,
-	    "%s%s%s%s",
-	    lf.lfItalic ? ":i" : "",
-	    lf.lfWeight ? ":b" : "",
-	    lf.lfUnderline ? ":u" : "",
-	    lf.lfStrikeOut ? ":s" : "");
+	if (lf.lfItalic)
+	    STRCAT(p, ":i");
+	if (lf.lfWeight == FW_BOLD)
+	    STRCAT(p, ":b");
+	if (lf.lfUnderline)
+	    STRCAT(p, ":u");
+	if (lf.lfStrikeOut)
+	    STRCAT(p, ":s");
 	if (charset_name != NULL)
-	    plen += vim_snprintf_safelen((char *)p + plen, res_size - plen, ":c%s", charset_name);
+	{
+	    STRCAT(p, ":c");
+	    STRCAT(p, charset_name);
+	}
 	if (quality_name != NULL)
-	    vim_snprintf((char *)p + plen, res_size - plen, ":q%s", quality_name);
+	{
+	    STRCAT(p, ":q");
+	    STRCAT(p, quality_name);
+	}
     }
 
     vim_free(font_name);
@@ -5054,7 +5051,7 @@ _OnMenuSelect(HWND hwnd, WPARAM wParam, LPARAM lParam)
 #endif
 
     static BOOL
-_OnGetDpiScaledSize(HWND hwnd UNUSED, UINT dpi, SIZE *size)
+_OnGetDpiScaledSize(HWND hwnd, UINT dpi, SIZE *size)
 {
     int		old_width, old_height;
     int		new_width, new_height;

--- a/src/message.c
+++ b/src/message.c
@@ -3508,7 +3508,6 @@ do_more_prompt(int typed_char)
     static void
 mch_errmsg_c(char *str)
 {
-    int	    len = (int)STRLEN(str);
     DWORD   nwrite = 0;
     DWORD   mode = 0;
     HANDLE  h = GetStdHandle(STD_ERROR_HANDLE);
@@ -3516,10 +3515,14 @@ mch_errmsg_c(char *str)
     if (GetConsoleMode(h, &mode) && enc_codepage >= 0
 	    && (int)GetConsoleCP() != enc_codepage)
     {
+	int	len = (int)STRLEN(str);
 	WCHAR	*w = enc_to_utf16((char_u *)str, &len);
 
-	WriteConsoleW(h, w, len, &nwrite, NULL);
-	vim_free(w);
+	if (w != NULL)
+	{
+	    WriteConsoleW(h, w, len, &nwrite, NULL);
+	    vim_free(w);
+	}
     }
     else
     {
@@ -3614,19 +3617,21 @@ mch_errmsg(char *str)
     static void
 mch_msg_c(char *str)
 {
-    int	    len = (int)STRLEN(str);
     DWORD   nwrite = 0;
     DWORD   mode;
     HANDLE  h = GetStdHandle(STD_OUTPUT_HANDLE);
 
-
     if (GetConsoleMode(h, &mode) && enc_codepage >= 0
 	    && (int)GetConsoleCP() != enc_codepage)
     {
+	int	len = (int)STRLEN(str);
 	WCHAR	*w = enc_to_utf16((char_u *)str, &len);
 
-	WriteConsoleW(h, w, len, &nwrite, NULL);
-	vim_free(w);
+	if (w != NULL)
+	{
+	    WriteConsoleW(h, w, len, &nwrite, NULL);
+	    vim_free(w);
+	}
     }
     else
     {

--- a/src/os_mswin.c
+++ b/src/os_mswin.c
@@ -3180,10 +3180,12 @@ get_logfont(
 		    if (cp->name == NULL && verbose)
 		    {
 			char_u *s = utf16_to_enc(p, NULL);
-
-			semsg(_(e_illegal_str_name_str_in_font_name_str),
-							   "charset", s, name);
-			vim_free(s);
+			if (s != NULL)
+			{
+			    semsg(_(e_illegal_str_name_str_in_font_name_str),
+							       "charset", s, name);
+			    vim_free(s);
+			}
 			break;
 		    }
 		    break;
@@ -3202,9 +3204,12 @@ get_logfont(
 		    if (qp->name == NULL && verbose)
 		    {
 			char_u *s = utf16_to_enc(p, NULL);
-			semsg(_(e_illegal_str_name_str_in_font_name_str),
-							   "quality", s, name);
-			vim_free(s);
+			if (s != NULL)
+			{
+			    semsg(_(e_illegal_str_name_str_in_font_name_str),
+							       "quality", s, name);
+			    vim_free(s);
+			}
 			break;
 		    }
 		    break;

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -3810,10 +3810,13 @@ mch_dirname(
     if (GetLongPathNameW(wbuf, wcbuf, _MAX_PATH) != 0)
     {
 	p = utf16_to_enc(wcbuf, NULL);
-	if (STRLEN(p) >= (size_t)len)
+	if (p != NULL)
 	{
-	    // long path name is too long, fall back to short one
-	    VIM_CLEAR(p);
+	    if (STRLEN(p) >= (size_t)len)
+	    {
+		// long path name is too long, fall back to short one
+		VIM_CLEAR(p);
+	    }
 	}
     }
     if (p == NULL)

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -7083,7 +7083,11 @@ conpty_term_and_job_init(
     if (cmd_wchar == NULL)
 	goto failed;
     if (opt->jo_cwd != NULL)
+    {
 	cwd_wchar = enc_to_utf16(opt->jo_cwd, NULL);
+	if (cwd_wchar == NULL)
+	    goto failed;
+    }
 
     win32_build_env(opt->jo_env, &ga_env, TRUE);
     env_wchar = ga_env.ga_data;
@@ -7425,7 +7429,11 @@ winpty_term_and_job_init(
     if (cmd_wchar == NULL)
 	goto failed;
     if (opt->jo_cwd != NULL)
+    {
 	cwd_wchar = enc_to_utf16(opt->jo_cwd, NULL);
+	if (cwd_wchar == NULL)
+	    goto failed;
+    }
 
     win32_build_env(opt->jo_env, &ga_env, TRUE);
     env_wchar = ga_env.ga_data;
@@ -7585,8 +7593,11 @@ failed:
 	char *msg = (char *)utf16_to_enc(
 				(short_u *)winpty_error_msg(winpty_err), NULL);
 
-	emsg(msg);
-	winpty_error_free(winpty_err);
+	if (msg != NULL)
+	{
+	    emsg(msg);
+	    winpty_error_free(winpty_err);
+	}
     }
     return FAIL;
 }

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -7596,8 +7596,9 @@ failed:
 	if (msg != NULL)
 	{
 	    emsg(msg);
-	    winpty_error_free(winpty_err);
+	    vim_free(msg);
 	}
+	winpty_error_free(winpty_err);
     }
     return FAIL;
 }


### PR DESCRIPTION
Also:
a) add a small optimisation in `mch_errmsg_c()` and `mch_msg_c()` (in `message.c`) to only call `STRLEN()` if needed.
b) fix a memory leak in `winpty_term_and_job_init()` (in `terminal.c`).