### PR TITLE
Calling expand() interferes with cmdcomplete_info()

### DIFF
--- a/src/cmdexpand.c
+++ b/src/cmdexpand.c
@@ -1115,7 +1115,6 @@ ExpandInit(expand_T *xp)
     xp->xp_backslash = XP_BS_NONE;
     xp->xp_prefix = XP_PREFIX_NONE;
     xp->xp_numfiles = -1;
-    VIM_CLEAR(cmdline_orig);
 }
 
 /*
@@ -1130,6 +1129,12 @@ ExpandCleanup(expand_T *xp)
 	xp->xp_numfiles = -1;
     }
     VIM_CLEAR(xp->xp_orig);
+}
+
+    void
+clear_cmdline_orig(void)
+{
+    VIM_CLEAR(cmdline_orig);
 }
 
 /*

--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -1663,6 +1663,7 @@ getcmdline_int(
 
     ExpandInit(&xpc);
     ccline.xpc = &xpc;
+    clear_cmdline_orig();
 
 #ifdef FEAT_RIGHTLEFT
     if (curwin->w_p_rl && *curwin->w_p_rlc == 's'
@@ -2567,6 +2568,7 @@ returncmd:
 
     ExpandCleanup(&xpc);
     ccline.xpc = NULL;
+    clear_cmdline_orig();
 
 #ifdef FEAT_SEARCH_EXTRA
     finish_incsearch_highlighting(gotesc, &is_state, FALSE);

--- a/src/proto/cmdexpand.pro
+++ b/src/proto/cmdexpand.pro
@@ -11,6 +11,7 @@ int cmdline_compl_is_fuzzy(void);
 char_u *ExpandOne(expand_T *xp, char_u *str, char_u *orig, int options, int mode);
 void ExpandInit(expand_T *xp);
 void ExpandCleanup(expand_T *xp);
+void clear_cmdline_orig(void);
 int showmatches(expand_T *xp, int wildmenu);
 char_u *addstar(char_u *fname, int len, int context);
 void set_expand_context(expand_T *xp);

--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -4268,10 +4268,12 @@ func Test_cd_bslash_completion_windows()
   let &shellslash = save_shellslash
 endfunc
 
-" Testg cmdcomplete_info() with CmdlineLeavePre autocmd
+" Test cmdcomplete_info() with CmdlineLeavePre autocmd
 func Test_cmdcomplete_info()
   augroup test_CmdlineLeavePre
     autocmd!
+    " Calling expand() should not interfere with cmdcomplete_info().
+    autocmd CmdlineLeavePre * call expand('test_cmdline.*')
     autocmd CmdlineLeavePre * let g:cmdcomplete_info = string(cmdcomplete_info())
   augroup END
   new


### PR DESCRIPTION
Problem:  Calling expand() interferes with cmdcomplete_info()
          (after 9.1.1329).
Solution: Only clear cmdline_orig when starting/ending cmdline mode.
