### PR TITLE
Undo corrupted with 'completeopt' "preinsert" when switching buffer

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -2699,7 +2699,7 @@ ins_compl_stop(int c, int prev_mode, int retval)
     char_u	*word = NULL;
 
     // Remove pre-inserted text when present.
-    if (ins_compl_preinsert_effect())
+    if (ins_compl_preinsert_effect() && ins_compl_win_active(curwin))
 	ins_compl_delete();
 
     // Get here when we have finished typing a sequence of ^N and

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -3833,7 +3833,7 @@ func Test_complete_info_completed()
   set cot&
 endfunc
 
-function Test_completeopt_preinsert()
+func Test_completeopt_preinsert()
   func Omni_test(findstart, base)
     if a:findstart
       return col(".")
@@ -3972,6 +3972,47 @@ function Test_completeopt_preinsert()
   call assert_equal("wp.fobar", g:line)
   call assert_equal(4, g:col)
   call assert_equal("wp.", getline('.'))
+
+  %delete _
+  let &l:undolevels = &l:undolevels
+  normal! ifoo
+  let &l:undolevels = &l:undolevels
+  normal! obar
+  let &l:undolevels = &l:undolevels
+  normal! obaz
+  let &l:undolevels = &l:undolevels
+
+  func CheckUndo()
+    let g:errmsg = ''
+    call assert_equal(['foo', 'bar', 'baz'], getline(1, '$'))
+    undo
+    call assert_equal(['foo', 'bar'], getline(1, '$'))
+    undo
+    call assert_equal(['foo'], getline(1, '$'))
+    undo
+    call assert_equal([''], getline(1, '$'))
+    later 3
+    call assert_equal(['foo', 'bar', 'baz'], getline(1, '$'))
+    call assert_equal('', v:errmsg)
+  endfunc
+
+  " Check that switching buffer with "preinsert" doesn't corrupt undo.
+  new
+  setlocal bufhidden=wipe
+  inoremap <buffer> <F2> <Cmd>enew!<CR>
+  call feedkeys("i\<C-X>\<C-O>\<F2>\<Esc>", 'tx')
+  bwipe!
+  call CheckUndo()
+
+  " Check that closing window with "preinsert" doesn't corrupt undo.
+  new
+  setlocal bufhidden=wipe
+  inoremap <buffer> <F2> <Cmd>close!<CR>
+  call feedkeys("i\<C-X>\<C-O>\<F2>\<Esc>", 'tx')
+  call CheckUndo()
+
+  %delete _
+  delfunc CheckUndo
 
   bw!
   set cot&


### PR DESCRIPTION
Problem:  Undo corrupted with 'completeopt' "preinsert" when switching
          buffer or window.
Solution: Do not delete preinsert text when switching buffer or window.

related: neovim/neovim#33581
