### PR TITLE
Fix :terminal E315 issue (again^3)

### DIFF
--- a/src/terminal.c
+++ b/src/terminal.c
@@ -3455,8 +3455,8 @@ limit_scrollback(term_T *term, garray_T *gap, int update_buffer)
 	    sizeof(sb_line_T) * gap->ga_len);
     if (update_buffer)
     {
-	win_T	    *curwin_save = curwin;
-	win_T	    *wp = NULL;
+	win_T *curwin_save = curwin;
+	win_T *wp = NULL;
 
 	term->tl_scrollback_scrolled -= todo;
 
@@ -3466,14 +3466,11 @@ limit_scrollback(term_T *term, garray_T *gap, int update_buffer)
 	    {
 		curwin = wp;
 		check_cursor();
+		update_topline();
 	    }
 	}
 	curwin = curwin_save;
     }
-
-    // make sure cursor is on a valid line
-    if (curbuf == term->tl_buffer)
-	check_cursor();
 }
 
 /*

--- a/src/testdir/test_terminal2.vim
+++ b/src/testdir/test_terminal2.vim
@@ -245,6 +245,8 @@ func Test_termwinscroll()
 endfunc
 
 func Test_termwinscroll_topline()
+  CheckNotMSWindows
+
   set termwinscroll=1000 mouse=a
   terminal
   call assert_equal(2, winnr('$'))


### PR DESCRIPTION
Fix: #17195
Related: #16211 #17170

~~The fix from #16211 has been reinstated.~~

Add a call to `update_topline()` after the call to `check_cursor()` in `limit_scrollback()`.