### PR TITLE
runtime: fix filetype detection from shebang

### DIFF
--- a/runtime/autoload/dist/script.vim
+++ b/runtime/autoload/dist/script.vim
@@ -26,8 +26,9 @@ def DetectFromHashBang(firstline: string)
   # "#!/usr/bin/bash" to make matching easier.
   # Recognize only a few {options} that are commonly used.
   if line1 =~ '^#!\s*\S*\<env\s'
-    line1 = substitute(line1, '\S\+=\S\+', '', 'g')
-    line1 = substitute(line1, '\(-[iS]\|--ignore-environment\|--split-string\)', '', '')
+    line1 = substitute(line1, '\s\zs--split-string[ \t=]', '', '')
+    line1 = substitute(line1, '\s\zs[A-Za-z0-9_]\+=\S*\ze\s', '', 'g')
+    line1 = substitute(line1, '\s\zs\%(-[iS]\+\|--ignore-environment\)\ze\s', '', 'g')
     line1 = substitute(line1, '\<env\s\+', '', '')
   endif
 

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -1073,10 +1073,10 @@ def s:GetScriptEnvChecks(): dict<list<list<string>>>
   return {
     perl: [['#!/usr/bin/env VAR=val perl']],
     scala: [['#!/usr/bin/env VAR=val VVAR=vval scala']],
-    awk: [['#!/usr/bin/env VAR=val -i awk']],
+    awk: [['#!/usr/bin/env --split-string=VAR= awk -vFS="," -f']],
     execline: [['#!/usr/bin/env execlineb']],
     scheme: [['#!/usr/bin/env VAR=val --ignore-environment scheme']],
-    python: [['#!/usr/bin/env VAR=val -S python -w -T']],
+    python: [['#!/usr/bin/env -S -i VAR=val python -B -u']],
     wml: [['#!/usr/bin/env VAR=val --split-string wml']],
     nix: [['#!/usr/bin/env nix-shell']],
   }


### PR DESCRIPTION
Problem: vim does not correctly detect filetype from
- `#!/usr/bin/env --split-string=awk -f`
- `#!/usr/bin/env -S -i awk -f`
- `#!/usr/bin/env -S VAR= awk -f`

Solution: fix detection logic

also, outdated python options are replaced