### PR TITLE
Add out-of-memory check to textformat.c

### DIFF
--- a/src/textformat.c
+++ b/src/textformat.c
@@ -369,7 +369,7 @@ internal_format(
 	{
 	    // In MODE_VREPLACE state, we will backspace over the text to be
 	    // wrapped, so save a copy now to put on the next line.
-	    saved_text = vim_strsave(ml_get_cursor());
+	    saved_text = vim_strnsave(ml_get_cursor(), ml_get_cursor_len());
 	    curwin->w_cursor.col = orig_col;
 	    if (saved_text == NULL)
 		break;	// Can't do it, out of memory
@@ -552,9 +552,7 @@ same_leader(
     char_u  *leader2_flags)
 {
     int	    idx1 = 0, idx2 = 0;
-    char_u  *p;
     char_u  *line1;
-    char_u  *line2;
 
     if (leader1_len == 0)
 	return (leader2_len == 0);
@@ -566,6 +564,8 @@ same_leader(
     // some text after it and the second line has the 'm' flag.
     if (leader1_flags != NULL)
     {
+	char_u	*p;
+
 	for (p = leader1_flags; *p && *p != ':'; ++p)
 	{
 	    if (*p == COM_FIRST)
@@ -589,9 +589,11 @@ same_leader(
 
     // Get current line and next line, compare the leaders.
     // The first line has to be saved, only one line can be locked at a time.
-    line1 = vim_strsave(ml_get(lnum));
+    line1 = vim_strnsave(ml_get(lnum), ml_get_len(lnum));
     if (line1 != NULL)
     {
+	char_u  *line2;
+
 	for (idx1 = 0; VIM_ISWHITE(line1[idx1]); ++idx1)
 	    ;
 	line2 = ml_get(lnum + 1);

--- a/src/textformat.c
+++ b/src/textformat.c
@@ -665,11 +665,8 @@ auto_format(
     int		prev_line)	// may start in previous line
 {
     pos_T	pos;
-    colnr_T	len;
     char_u	*old;
-    char_u	*new, *pnew;
     int		wasatend;
-    int		cc;
 
     if (!has_format_option(FO_AUTO))
 	return;
@@ -688,6 +685,8 @@ auto_format(
     wasatend = (pos.col == ml_get_curline_len());
     if (*old != NUL && !trailblank && wasatend)
     {
+	int cc;
+
 	dec_cursor();
 	cc = gchar_cursor();
 	if (!WHITECHAR(cc) && curwin->w_cursor.col > 0
@@ -740,11 +739,13 @@ auto_format(
     // formatted.
     if (!wasatend && has_format_option(FO_WHITE_PAR))
     {
-	new = ml_get_curline();
-	len = ml_get_curline_len();
+	char_u	*new = ml_get_curline();
+	colnr_T	len = ml_get_curline_len();
 	if (curwin->w_cursor.col == len)
 	{
-	    pnew = vim_strnsave(new, len + 2);
+	    char_u *pnew = vim_strnsave(new, len + 2);
+	    if (pnew == NULL)
+		return;
 	    pnew[len] = ' ';
 	    pnew[len + 1] = NUL;
 	    ml_replace(curwin->w_cursor.lnum, pnew, FALSE);


### PR DESCRIPTION
Add the check to `auto_format()`.
While we are here make small optimisations in `internal_format()` and `same_leader()`.
Also, move the declaration of some variables closer to where they are used in `auto_format()` and `same_leader()`.