### PR TITLE
runtime(doc): clarify complete_match() and isexpand

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -2034,8 +2034,11 @@ complete_info([{what}])				*complete_info()*
 		Return type: dict<any>
 
 complete_match([{lnum}, {col}])			*complete_match()*
-		Returns a List of matches found according to the 'isexpand'
-		option. Each match is represented as a List containing
+		Searches backward from the given position and returns a List
+		of matches according to the 'isexpand' option. When no
+		arguments are provided, uses the current cursor position.
+
+		Each match is represented as a List containing
 		[startcol, trigger_text] where:
 		- startcol: column position where completion should start,
 		  or -1 if no trigger position is found. For multi-character
@@ -2046,9 +2049,6 @@ complete_match([{lnum}, {col}])			*complete_match()*
 
 		When 'isexpand' is empty, uses the 'iskeyword' pattern
 		"\k\+$" to find the start of the current keyword.
-
-		When no arguments are provided, uses the current cursor
-		position.
 
 		Examples: >
 	set isexpand=.,->,/,/*,abc

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4996,6 +4996,10 @@ A jump table for the options with a short description can be found at |Q_op|.
 	Note: Use "\\," to add a literal comma as trigger character, see
 	|option-backslash|.
 
+	Examples: >
+		set isexpand=.,->,/*,\\,
+<
+
 			*'insertmode'* *'im'* *'noinsertmode'* *'noim'*
 'insertmode' 'im'	boolean	(default off)
 			global


### PR DESCRIPTION
clarify complete_match() documentation to better explain its backward search behavior, argument handling, and return value format and add an example of isexpand