### PR TITLE
Fix notation of "Vim script" and "Vim9 script"

### DIFF
--- a/runtime/autoload/dist/vim.vim
+++ b/runtime/autoload/dist/vim.vim
@@ -1,5 +1,5 @@
 " Vim runtime support library,
-" runs the vim9 script version or legacy script version
+" runs the Vim9 script version or legacy script version
 " on demand (mostly for Neovim compatability)
 "
 " Maintainer:	The Vim Project <https://github.com/vim/vim>

--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -269,7 +269,7 @@ D. If your filetype can only be detected by inspecting the contents of the
       item of the 'runtimepath' option.  Example for Unix: >
 	:!mkdir ~/.vim
 <
-   2. Create a vim script file for doing this.  Example: >
+   2. Create a Vim script file for doing this.  Example: >
 	if did_filetype()	" filetype already set..
 	  finish		" ..don't do these checks
 	endif

--- a/runtime/doc/if_perl.txt
+++ b/runtime/doc/if_perl.txt
@@ -74,7 +74,7 @@ The ActiveState one should work, Strawberry Perl is a good alternative.
 			|script-here|.
 
 
-Example vim script: >
+Example Vim script: >
 
 	function! WhitePearl()
 	perl << EOF

--- a/runtime/doc/pi_getscript.txt
+++ b/runtime/doc/pi_getscript.txt
@@ -156,7 +156,7 @@ may have.  As an example, consider: >
 
 	" GetLatestVimScripts: 884  1 :AutoInstall: AutoAlign.vim
 
-This comment line tells getscript.vim to check vimscript #884 and that the
+This comment line tells getscript.vim to check Vim script #884 and that the
 script is automatically installable.  Getscript will also use this line to
 help build the GetLatestVimScripts.dat file, by including a line such as: >
 

--- a/runtime/doc/pi_netrw.txt
+++ b/runtime/doc/pi_netrw.txt
@@ -460,7 +460,7 @@ file using root-relative paths, use the full path:
 ==============================================================================
 4. Network-Oriented File Transfer			*netrw-xfer* {{{1
 
-Network-oriented file transfer under Vim is implemented by a vim script
+Network-oriented file transfer under Vim is implemented by a Vim script
 (<netrw.vim>) using plugin techniques.  It currently supports both reading and
 writing across networks using rcp, scp, ftp or ftp+<.netrc>, scp, fetch,
 dav/cadaver, rsync, or sftp.

--- a/runtime/doc/vim9.txt
+++ b/runtime/doc/vim9.txt
@@ -2043,7 +2043,7 @@ The script name after `import` can be:
 
 If the name does not end in ".vim" then the use of "as name" is required.
 
-Once a vim9 script file has been imported, the result is cached and used the
+Once a Vim9 script file has been imported, the result is cached and used the
 next time the same script is imported.  It will not be read again.
 
 It is not allowed to import the same script twice, also when using two
@@ -2056,7 +2056,7 @@ line, there can be no line break: >
 	echo that
 		.name  # Error!
 <						*import-map*
-When you've imported a function from one script into a vim9 script you can
+When you've imported a function from one script into a Vim9 script you can
 refer to the imported function in a mapping by prefixing it with |<SID>|: >
 	noremap <silent> ,a :call <SID>name.Function()<CR>
 

--- a/runtime/pack/dist/opt/editorconfig/plugin/editorconfig.vim
+++ b/runtime/pack/dist/opt/editorconfig/plugin/editorconfig.vim
@@ -325,7 +325,7 @@ call s:EditorConfigEnable(1)
 " UseConfigFiles function for different modes {{{1
 
 function! s:UseConfigFiles_VimCore(bufnr, target)
-" Use the vimscript EditorConfig core
+" Use the Vim script EditorConfig core
     try
         let l:config = editorconfig_core#handler#get_configurations(
             \ { 'target': a:target } )

--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -2540,7 +2540,7 @@ fun! netrw#NetWrite(...) range
 endfun
 
 " ---------------------------------------------------------------------
-" netrw#NetSource: source a remotely hosted vim script {{{2
+" netrw#NetSource: source a remotely hosted Vim script {{{2
 " uses NetRead to get a copy of the file into a temporarily file,
 "              then sources that file,
 "              then removes that file.

--- a/runtime/pack/dist/opt/netrw/doc/netrw.txt
+++ b/runtime/pack/dist/opt/netrw/doc/netrw.txt
@@ -460,7 +460,7 @@ file using root-relative paths, use the full path:
 ==============================================================================
 4. Network-Oriented File Transfer			*netrw-xfer* {{{1
 
-Network-oriented file transfer under Vim is implemented by a vim script
+Network-oriented file transfer under Vim is implemented by a Vim script
 (<netrw.vim>) using plugin techniques.  It currently supports both reading and
 writing across networks using rcp, scp, ftp or ftp+<.netrc>, scp, fetch,
 dav/cadaver, rsync, or sftp.

--- a/runtime/syntax/generator/vim.vim.base
+++ b/runtime/syntax/generator/vim.vim.base
@@ -1486,7 +1486,7 @@ syn match	vim9SearchDelim	'^\s*\zs:[/?]\|[/?]$'	contained contains=vimCmdSep
 syn region	vimGlobal	matchgroup=Statement start='\<g\%[lobal]!\=/'  skip='\\.' end='/'	skipwhite nextgroup=vimSubst1
 syn region	vimGlobal	matchgroup=Statement start='\<v\%[global]!\=/' skip='\\.' end='/'	skipwhite nextgroup=vimSubst1
 
-" Vim9 Script Regions: {{{2
+" Vim9 script Regions: {{{2
 " ==================
 
 if s:vim9script

--- a/runtime/syntax/groovy.vim
+++ b/runtime/syntax/groovy.vim
@@ -8,7 +8,7 @@
 
 " THE ORIGINAL AUTHOR'S NOTES:
 "
-" This is my very first vim script, I hope to have
+" This is my very first Vim script, I hope to have
 " done it the right way.
 "
 " I must directly or indirectly thank the author of java.vim and ruby.vim:

--- a/runtime/syntax/testdir/input/vim9_expr.vim
+++ b/runtime/syntax/testdir/input/vim9_expr.vim
@@ -149,7 +149,7 @@ def Foo()
 enddef
 
 
-# Issue #16227 (Vimscript ternary expression highlighting)
+# Issue #16227 (Vim script ternary expression highlighting)
 
 var foo = 'foo'                         # comment
 var bar = foo == 'foo' ? 'bar' : 'baz'

--- a/runtime/syntax/testdir/input/vim9_function_calls.vim
+++ b/runtime/syntax/testdir/input/vim9_function_calls.vim
@@ -7,7 +7,7 @@ clearmatches()
 echo "Foo" | clearmatches()
 
 
-# Issue 16721 (vimscript highlight of builtin function after |)
+# Issue 16721 (Vim script highlight of builtin function after |)
 
 &directory = $'{$MYVIMDIR}/.data/swap/'
 &backupdir = $'{$MYVIMDIR}/.data/backup//'

--- a/runtime/syntax/testdir/input/vim_ex_def.vim
+++ b/runtime/syntax/testdir/input/vim_ex_def.vim
@@ -99,7 +99,7 @@ def Foo(
     z: string = "zed")
 enddef
 
-" Issue #16243 (vimscript def parameters syntax highlight is wrong)
+" Issue #16243 (Vim script def parameters syntax highlight is wrong)
 
 def Test(lines: list<number> = [line('.'), line('.')]): void
 enddef

--- a/runtime/syntax/testdir/input/vim_ex_function.vim
+++ b/runtime/syntax/testdir/input/vim_ex_function.vim
@@ -177,7 +177,7 @@ function Foo(...)
 endfunction
 
 
-" Issue #16243 (vimscript def parameters syntax highlight is wrong)
+" Issue #16243 (Vim script def parameters syntax highlight is wrong)
 
 function Test(lines = [line('.'), line('.')])
 endfunction

--- a/runtime/syntax/vim.vim
+++ b/runtime/syntax/vim.vim
@@ -1546,7 +1546,7 @@ syn match	vim9SearchDelim	'^\s*\zs:[/?]\|[/?]$'	contained contains=vimCmdSep
 syn region	vimGlobal	matchgroup=Statement start='\<g\%[lobal]!\=/'  skip='\\.' end='/'	skipwhite nextgroup=vimSubst1
 syn region	vimGlobal	matchgroup=Statement start='\<v\%[global]!\=/' skip='\\.' end='/'	skipwhite nextgroup=vimSubst1
 
-" Vim9 Script Regions: {{{2
+" Vim9 script Regions: {{{2
 " ==================
 
 if s:vim9script

--- a/src/Make_cyg_ming.mak
+++ b/src/Make_cyg_ming.mak
@@ -1215,14 +1215,14 @@ endif
 	$(MAKE) -C xxd -f Make_ming.mak clean
 	$(MAKE) -C tee -f Make_ming.mak clean
 
-# Run vim script to generate the Ex command lookup table.
+# Run Vim script to generate the Ex command lookup table.
 # This only needs to be run when a command name has been added or changed.
 # If this fails because you don't have Vim yet, first build and install Vim
 # without changes.
 cmdidxs: ex_cmds.h
 	vim --clean -N -X --not-a-term -u create_cmdidxs.vim -c quit
 
-# Run vim script to generate the normal/visual mode command lookup table.
+# Run Vim script to generate the normal/visual mode command lookup table.
 # This only needs to be run when a new normal/visual mode command has been
 # added.  If this fails because you don't have Vim yet:
 #   - change nv_cmds[] in nv_cmds.h to add the new normal/visual mode command.

--- a/src/Make_mvc.mak
+++ b/src/Make_mvc.mak
@@ -1430,14 +1430,14 @@ clean: testclean
 	$(MAKE) /NOLOGO -f Make_mvc.mak clean
 	cd ..
 
-# Run vim script to generate the Ex command lookup table.
+# Run Vim script to generate the Ex command lookup table.
 # This only needs to be run when a command name has been added or changed.
 # If this fails because you don't have Vim yet, first build and install Vim
 # without changes.
 cmdidxs: ex_cmds.h
 	vim --clean -N -X --not-a-term -u create_cmdidxs.vim -c quit
 
-# Run vim script to generate the normal/visual mode command lookup table.
+# Run Vim script to generate the normal/visual mode command lookup table.
 # This only needs to be run when a new normal/visual mode command has been
 # added.  If this fails because you don't have Vim yet:
 #   - change nv_cmds[] in nv_cmds.h to add the new normal/visual mode command.

--- a/src/Makefile
+++ b/src/Makefile
@@ -2037,7 +2037,7 @@ autoconf:
 	-rm -rf autom4te.cache
 	-rm -f auto/config.status auto/config.cache
 
-# Run vim script to generate the Ex command lookup table.
+# Run Vim script to generate the Ex command lookup table.
 # This only needs to be run when a command name has been added or changed.
 # If this fails because you don't have Vim yet, first build and install Vim
 # without changes.
@@ -2045,7 +2045,7 @@ autoconf:
 cmdidxs: ex_cmds.h
 	vim --clean -X --not-a-term -S create_cmdidxs.vim -c quit
 
-# Run vim script to generate the normal/visual mode command lookup table.
+# Run Vim script to generate the normal/visual mode command lookup table.
 # This only needs to be run when a new normal/visual mode command has been
 # added.
 # This requires a "vim" executable with the +eval feature.

--- a/src/README.md
+++ b/src/README.md
@@ -35,7 +35,7 @@ clientserver.c	| client server functionality
 clipboard.c	| handling the clipboard
 cmdexpand.c	| command-line completion
 cmdhist.c	| command-line history
-debugger.c	| vim script debugger
+debugger.c	| Vim script debugger
 diff.c		| diff mode (vimdiff)
 drawline.c	| drawing a window line
 drawscreen.c	| drawing the windows
@@ -70,7 +70,7 @@ option.c	| options
 optionstr.c	| handling string options
 popupmenu.c	| popup menu
 popupwin.c	| popup window
-profiler.c	| vim script profiler
+profiler.c	| Vim script profiler
 quickfix.c	| quickfix commands (":make", ":cn")
 regexp.c	| pattern matching
 register.c	| handling registers
@@ -91,7 +91,7 @@ textformat.c	| text formatting
 textobject.c	| text objects
 textprop.c	| text properties
 time.c		| time and timer functions
-typval.c	| vim script type/value functions
+typval.c	| Vim script type/value functions
 undo.c		| undo and redo
 usercmd.c	| user defined commands
 userfunc.c	| user defined functions

--- a/src/eval.c
+++ b/src/eval.c
@@ -2284,7 +2284,7 @@ get_lval(
     {
 	where_T	    where = WHERE_INIT;
 
-	// In a vim9 script, do type check and make sure the variable is
+	// In a Vim9 script, do type check and make sure the variable is
 	// writable.
 	if (check_typval_type(lp->ll_valtype, rettv, where) == FAIL)
 	    return NULL;

--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -9060,7 +9060,7 @@ test_gui_w32_sendevent_mouse(dict_T *args)
 	if (dict_get_bool(args, "cell", FALSE))
 	{
 	    // calculate the middle of the character cell
-	    // Note: Cell coordinates are 1-based from vimscript
+	    // Note: Cell coordinates are 1-based from Vim script
 	    int pY = (row - 1) * gui.char_height + gui.char_height / 2;
 	    int pX = (col - 1) * gui.char_width + gui.char_width / 2;
 	    gui_mouse_moved(pX, pY);

--- a/src/message_test.c
+++ b/src/message_test.c
@@ -34,7 +34,7 @@
 // - warning: format ‘%S’ expects argument of type ‘wchar_t *’, but argument 4 has type ‘char *’
 // - warning: unknown conversion type character ‘b’ in format
 //
-// These formats are in practise only used from vim script printf()
+// These formats are in practise only used from Vim script printf()
 // function and never as literals in C code.
 char *fmt_012p = "%012p";
 char *fmt_5S   = "%5S";
@@ -158,12 +158,12 @@ test_trunc_string_mbyte(void)
 /*
  * Test vim_snprintf() with a focus on checking that truncation is
  * correct when buffer is small, since it cannot be tested from
- * vim script tests. Check that:
+ * Vim script tests. Check that:
  * - no buffer overflows happens (with valgrind or asan)
  * - output string is always NUL terminated.
  *
  * Not all formats of vim_snprintf() are checked here. They are
- * checked more exhaustively in Test_printf*() vim script tests.
+ * checked more exhaustively in Test_printf*() Vim script tests.
  */
     static void
 test_vim_snprintf(void)
@@ -290,7 +290,7 @@ test_vim_snprintf(void)
 	assert(bsize == 0 || STRNCMP(buf, "\x01\x02", bsize_int) == 0);
 	assert(bsize == 0 || buf[MIN(n, bsize_int)] == '\0');
 
-	// %p format is not tested in vim script tests Test_printf*()
+	// %p format is not tested in Vim script tests Test_printf*()
 	// as it only makes sense in C code.
 	// NOTE: SunOS libc doesn't use the prefix "0x" on %p.
 #ifdef SUN_SYSTEM

--- a/src/profiler.c
+++ b/src/profiler.c
@@ -8,7 +8,7 @@
  */
 
 /*
- * profiler.c: vim script profiler
+ * profiler.c: Vim script profiler
  */
 
 #include "vim.h"

--- a/src/structs.h
+++ b/src/structs.h
@@ -1976,7 +1976,7 @@ struct ufunc_S
 #define FC_DEAD	    0x80	// function kept only for reference to dfunc
 #define FC_EXPORT   0x100	// "export def Func()"
 #define FC_NOARGS   0x200	// no a: variables in lambda
-#define FC_VIM9	    0x400	// defined in vim9 script file
+#define FC_VIM9	    0x400	// defined in Vim9 script file
 #define FC_CFUNC    0x800	// defined as Lua C func
 #define FC_COPY	    0x1000	// copy of another function by
 				// copy_lambda_to_global_func()

--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -4267,7 +4267,7 @@ func Test_ex_command_completion()
   " required for :*
   set cpo+=*
   let list = filter(getcompletion('', 'command'), 'exists(":" . v:val) == 0')
-  " :++ and :-- are only valid in Vim9 Script context, so they can be ignored
+  " :++ and :-- are only valid in Vim9 script context, so they can be ignored
   call assert_equal(['++', '--'], sort(list))
   call assert_equal(2, exists(':k'))
   call assert_equal(0, exists(':ke'))

--- a/src/testdir/test_source.vim
+++ b/src/testdir/test_source.vim
@@ -57,7 +57,7 @@ func Test_different_script()
   call assert_fails('source XtwoScript', 'E121:')
 endfunc
 
-" When sourcing a vim script, shebang should be ignored.
+" When sourcing a Vim script, shebang should be ignored.
 func Test_source_ignore_shebang()
   call writefile(['#!./xyzabc', 'let g:val=369'], 'Xsisfile.vim', 'D')
   source Xsisfile.vim
@@ -408,7 +408,7 @@ func Test_source_buffer_vim9()
   source
   call assert_equal(10, Xtestfunc())
 
-  " test for sourcing a vim9 script with line continuation
+  " test for sourcing a Vim9 script with line continuation
   %d _
   let lines =<< trim END
      vim9script

--- a/src/testdir/test_vim9_cmd.vim
+++ b/src/testdir/test_vim9_cmd.vim
@@ -159,7 +159,7 @@ def Test_cmdmod_execute()
   v9.CheckScriptSuccess(lines)
   delfunc g:TheFunc
 
-  # vim9cmd execute(cmd) executes code in vim9 script context
+  # vim9cmd execute(cmd) executes code in Vim9 script context
   lines =<< trim END
     vim9cmd execute("g:vim9executetest = 'bar'")
     call assert_equal('bar', g:vim9executetest)
@@ -176,7 +176,7 @@ def Test_cmdmod_execute()
   unlet g:vim9executetest1
   unlet g:vim9executetest2
 
-  # legacy call execute(cmd) executes code in vim script context
+  # legacy call execute(cmd) executes code in Vim script context
   lines =<< trim END
     vim9script
     legacy call execute("let g:vim9executetest = 'bar'")

--- a/src/testdir/vim9.vim
+++ b/src/testdir/vim9.vim
@@ -1,6 +1,6 @@
 vim9script
 
-# Utility functions for testing vim9 script
+# Utility functions for testing Vim9 script
 
 # Use a different file name for each run.
 var sequence = 1

--- a/src/testing.c
+++ b/src/testing.c
@@ -1411,7 +1411,7 @@ test_gui_mouse_event(dict_T *args)
 	if (dict_get_bool(args, "cell", FALSE))
 	{
 	    // calculate the middle of the character cell
-	    // Note: Cell coordinates are 1-based from vimscript
+	    // Note: Cell coordinates are 1-based from Vim script
 	    pY = (row - 1) * gui.char_height + gui.char_height / 2;
 	    pX = (col - 1) * gui.char_width + gui.char_width / 2;
 	}


### PR DESCRIPTION
Normalize spelling of "Vim script" throughout the source and documentation.

Description:
There are multiple inconsistent spellings of "Vim script" across the source code and documentation, such as "Vimscript," "vim script," and "VimScript" etc...
According to Bram Moolenaar, the original author of Vim, the correct spelling is "Vim script" (two words, capitalized "Vim" only).

Reference:
- https://groups.google.com/forum/#!msg/vim_dev/3Z5yM8KER2w/wAqws0QSEAAJ
  > "Vim script" is the short form.
- [patch 8.0.0360: sometimes VimL is used instead of "Vim script"](https://github.com/vim/vim/commit/b544f3c81f1e6a50322855681ac266ffaa8e313c)
- [patch 8.2.3474: some places use "Vimscript" instead of "Vim script"](https://github.com/vim/vim/commit/965d2edbce1a8ccba96925be5ac4575981f68949)

This pull request corrects the inconsistencies by normalizing all occurrences to "Vim script."

OK:
Vim script
Vim9 script

NG:
vim script
Vim Script
vimscript
Vimscript
VimScript
vim9 script
Vim9 Script
vim9script   (Except Ex-Cmd :vim9script)
Vim9script
Vim9Script

CC: @yegappan @dkearns 