### PR TITLE
Fix: CmdlineLeavePre may trigger twice

### DIFF
--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -1919,7 +1919,10 @@ getcmdline_int(
 
 	// Trigger CmdlineLeavePre autocommand
 	if (KeyTyped && (c == '\n' || c == '\r' || c == K_KENTER || c == ESC
-		    || c == Ctrl_C || c == intr_char))
+#ifdef UNIX
+		    || c == intr_char
+#endif
+		    || c == Ctrl_C))
 	{
 	    trigger_cmd_autocmd(cmdline_type, EVENT_CMDLINELEAVEPRE);
 	    event_cmdlineleavepre_triggered = TRUE;

--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -1620,6 +1620,7 @@ getcmdline_int(
     int		did_save_ccline = FALSE;
     int		cmdline_type;
     int		wild_type = 0;
+    int		event_cmdlineleavepre_triggered = FALSE;
 
     // one recursion level deeper
     ++depth;
@@ -1917,8 +1918,12 @@ getcmdline_int(
 	}
 
 	// Trigger CmdlineLeavePre autocommand
-	if (c == '\n' || c == '\r' || c == K_KENTER || c == ESC || c == Ctrl_C)
+	if (KeyTyped && (c == '\n' || c == '\r' || c == K_KENTER || c == ESC
+		    || c == Ctrl_C || c == intr_char))
+	{
 	    trigger_cmd_autocmd(cmdline_type, EVENT_CMDLINELEAVEPRE);
+	    event_cmdlineleavepre_triggered = TRUE;
+	}
 
 	// The wildmenu is cleared if the pressed key is not used for
 	// navigating the wild menu (i.e. the key is not 'wildchar' or
@@ -2607,6 +2612,10 @@ returncmd:
     // When the command line was typed, no need for a wait-return prompt.
     if (some_key_typed)
 	need_wait_return = FALSE;
+
+    // Trigger CmdlineLeavePre autocommands if not already triggered.
+    if (!event_cmdlineleavepre_triggered)
+	trigger_cmd_autocmd(cmdline_type, EVENT_CMDLINELEAVEPRE);
 
     // Trigger CmdlineLeave autocommands.
     trigger_cmd_autocmd(cmdline_type, EVENT_CMDLINELEAVE);

--- a/src/testdir/test_autocmd.vim
+++ b/src/testdir/test_autocmd.vim
@@ -2002,49 +2002,99 @@ endfunc
 
 func Test_Cmdline_Trigger()
   autocmd CmdlineLeavePre : let g:log = "CmdlineLeavePre"
+  autocmd CmdlineLeavePre : let g:log2 = "CmdlineLeave"
   new
   let g:log = ''
+  let g:log2 = ''
   nnoremap <F1> <Cmd>echo "hello"<CR>
   call feedkeys("\<F1>", 'x')
   call assert_equal('', g:log)
+  call assert_equal('', g:log2)
   nunmap <F1>
+
   let g:log = ''
+  let g:log2 = ''
   nnoremap <F1> :echo "hello"<CR>
   call feedkeys("\<F1>", 'x')
   call assert_equal('CmdlineLeavePre', g:log)
+  call assert_equal('CmdlineLeave', g:log2)
   nunmap <F1>
+
   let g:log = ''
+  let g:log2 = ''
+  call feedkeys(":\<bs>", "tx")
+  call assert_equal('CmdlineLeavePre', g:log)
+  call assert_equal('CmdlineLeave', g:log2)
+
+  let g:log = ''
+  let g:log2 = ''
   split
   call assert_equal('', g:log)
   call feedkeys(":echo hello", "tx")
   call assert_equal('CmdlineLeavePre', g:log)
+  call assert_equal('CmdlineLeave', g:log2)
+
   let g:log = ''
+  let g:log2 = ''
   close
   call assert_equal('', g:log)
   call feedkeys(":echo hello", "tx")
   call assert_equal('CmdlineLeavePre', g:log)
+  call assert_equal('CmdlineLeave', g:log2)
+
   let g:log = ''
+  let g:log2 = ''
   tabnew
   call assert_equal('', g:log)
   call feedkeys(":echo hello", "tx")
   call assert_equal('CmdlineLeavePre', g:log)
+  call assert_equal('CmdlineLeave', g:log2)
+
   let g:log = ''
+  let g:log2 = ''
   split
   call assert_equal('', g:log)
   call feedkeys(":echo hello", "tx")
   call assert_equal('CmdlineLeavePre', g:log)
+  call assert_equal('CmdlineLeave', g:log2)
+
   let g:log = ''
+  let g:log2 = ''
   tabclose
   call assert_equal('', g:log)
   call feedkeys(":echo hello", "tx")
   call assert_equal('CmdlineLeavePre', g:log)
+  call assert_equal('CmdlineLeave', g:log2)
+
   let g:count = 0
   autocmd CmdlineLeavePre * let g:count += 1
   call feedkeys(":let c = input('? ')\<cr>B\<cr>", "tx")
   call assert_equal(2, g:count)
   unlet! g:count
   unlet! g:log
+  unlet! g:log2
   bw!
+endfunc
+
+" Ensure :cabbr does not cause a spurious CmdlineLeavePre.
+func Test_CmdlineLeavePre_cabbr()
+  CheckFeature terminal
+  let buf = term_start([GetVimProg(), '--clean', '-c', 'set noswapfile'], {'term_rows': 3})
+  call assert_equal('running', term_getstatus(buf))
+  call term_sendkeys(buf, ":let g:a=0\<cr>")
+  call term_wait(buf, 50)
+  call term_sendkeys(buf, ":cabbr v v\<cr>")
+  call term_wait(buf, 50)
+  call term_sendkeys(buf, ":command! -nargs=* Foo echo\<cr>")
+  call term_wait(buf, 50)
+  call term_sendkeys(buf, ":au! CmdlineLeavePre * :let g:a+=1\<cr>")
+  call term_wait(buf, 50)
+  call term_sendkeys(buf, ":Foo v\<cr>")
+  call term_wait(buf, 50)
+  call term_sendkeys(buf, ":echo g:a\<cr>")
+  call term_wait(buf, 50)
+  call WaitForAssert({-> assert_match('^2.*$', term_getline(buf, 3))})
+  bwipe!
 endfunc
 
 func Test_Cmdline()


### PR DESCRIPTION
Problem:

There are two problems:
- `CmdlineLeavePre` may be triggered twice when a `:cabbr` is present.
- `CmdlineLeavePre` fails to trigger when exiting the command-line via `<Backspace>`.

Solution:

Check if the Carriage Return (Enter) key was actually typed.
Trigger the event when the command-line is exited using Backspace and other keys.