### PR TITLE
Return value of getcmdline() inconsistent in CmdlineLeavePre

### DIFF
--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -2560,6 +2560,9 @@ cmdline_changed:
     }
 
 returncmd:
+    // Trigger CmdlineLeavePre autocommands if not already triggered.
+    if (!event_cmdlineleavepre_triggered)
+	trigger_cmd_autocmd(cmdline_type, EVENT_CMDLINELEAVEPRE);
 
 #ifdef FEAT_RIGHTLEFT
     cmdmsg_rl = FALSE;
@@ -2615,10 +2618,6 @@ returncmd:
     // When the command line was typed, no need for a wait-return prompt.
     if (some_key_typed)
 	need_wait_return = FALSE;
-
-    // Trigger CmdlineLeavePre autocommands if not already triggered.
-    if (!event_cmdlineleavepre_triggered)
-	trigger_cmd_autocmd(cmdline_type, EVENT_CMDLINELEAVEPRE);
 
     // Trigger CmdlineLeave autocommands.
     trigger_cmd_autocmd(cmdline_type, EVENT_CMDLINELEAVE);

--- a/src/testdir/test_autocmd.vim
+++ b/src/testdir/test_autocmd.vim
@@ -2066,11 +2066,28 @@ func Test_Cmdline_Trigger()
   call assert_equal('CmdlineLeavePre', g:log)
   call assert_equal('CmdlineLeave', g:log2)
 
-  let g:count = 0
-  autocmd CmdlineLeavePre * let g:count += 1
-  call feedkeys(":let c = input('? ')\<cr>B\<cr>", "tx")
-  call assert_equal(2, g:count)
-  unlet! g:count
+  autocmd CmdlineLeavePre * let g:cmdline += [getcmdline()]
+
+  for end_keys in ["\<CR>", "\<NL>", "\<kEnter>", "\<C-C>", "\<Esc>",
+                 \ "\<C-\>\<C-N>", "\<C-\>\<C-G>"]
+    let g:cmdline = []
+    let g:log = ''
+    let g:log2 = ''
+    call assert_equal('', g:log)
+    let keys = $':echo "hello"{end_keys}'
+    let msg = keytrans(keys)
+    call feedkeys(keys, "tx")
+    call assert_equal(['echo "hello"'], g:cmdline, msg)
+    call assert_equal('CmdlineLeavePre', g:log, msg)
+    call assert_equal('CmdlineLeave', g:log2, msg)
+  endfor
+
+  let g:cmdline = []
+  call feedkeys(":let c = input('? ')\<cr>ABCDE\<cr>", "tx")
+  call assert_equal(["let c = input('? ')", 'ABCDE'], g:cmdline)
+
+  au! CmdlineLeavePre
+  unlet! g:cmdline
   unlet! g:log
   unlet! g:log2
   bw!


### PR DESCRIPTION
Problem:  Return value of getcmdline() inconsistent in CmdlineLeavePre
          when leaving cmdline in different ways.
Solution: Trigger CmdlineLeavePre before calling abandon_cmdline() so
          that getcmdline() can return the command line.
