### PR TITLE
Fix ":vim9cmd unlet s" crashes Vim

### DIFF
--- a/src/proto/vim9compile.pro
+++ b/src/proto/vim9compile.pro
@@ -2,7 +2,6 @@
 int lookup_local(char_u *name, size_t len, lvar_T *lvar, cctx_T *cctx);
 int arg_exists(char_u *name, size_t len, int *idxp, type_T **type, int *gen_load_outer, cctx_T *cctx);
 void update_script_var_block_id(char_u *name, int block_id);
-int script_is_vim9(void);
 int script_var_exists(char_u *name, size_t len, cctx_T *cctx, cstack_T *cstack);
 int cctx_class_method_idx(cctx_T *cctx, char_u *name, size_t len, class_T **cl_ret);
 int cctx_class_member_idx(cctx_T *cctx, char_u *name, size_t len, class_T **cl_ret);

--- a/src/testdir/test_vim9_assign.vim
+++ b/src/testdir/test_vim9_assign.vim
@@ -2499,12 +2499,11 @@ def Test_unlet()
   assert_false(exists('g:somevar'))
   unlet! g:somevar
 
-  # also works for script-local variable in legacy Vim script
-  s:somevar = 'legacy'
+  # script-local variable cannot be removed in Vim9 script
+  s:somevar = 'local'
   assert_true(exists('s:somevar'))
-  unlet s:somevar
-  assert_false(exists('s:somevar'))
-  unlet! s:somevar
+  v9.CheckDefExecFailure(['unlet s:somevar'], 'E1081:', 1)
+  v9.CheckDefExecFailure(['unlet! s:somevar'], 'E1081:', 1)
 
   if 0
     unlet g:does_not_exist
@@ -2677,14 +2676,14 @@ def Test_unlet()
    'enddef',
    'defcompile',
    ], 'E1081:')
-  v9.CheckScriptFailure([
+  v9.CheckScriptSuccess([
    'vim9script',
    'var svar = 123',
    'func Func()',
    '  unlet s:svar',
    'endfunc',
    'Func()',
-   ], 'E1081:')
+   ])
   v9.CheckScriptFailure([
    'vim9script',
    'var svar = 123',

--- a/src/testdir/test_vim9_assign.vim
+++ b/src/testdir/test_vim9_assign.vim
@@ -2688,6 +2688,14 @@ def Test_unlet()
    'vim9script',
    'var svar = 123',
    'def Func()',
+   '  vim9cmd unlet s:svar',
+   'enddef',
+   'defcompile',
+   ], 'E1081:')
+  v9.CheckScriptFailure([
+   'vim9script',
+   'var svar = 123',
+   'def Func()',
    '  unlet s:svar',
    'enddef',
    'defcompile',

--- a/src/vim9cmds.c
+++ b/src/vim9cmds.c
@@ -99,7 +99,7 @@ check_vim9_unlet(char_u *name)
     if (name[1] != ':' || vim_strchr((char_u *)"gwtb", *name) == NULL)
     {
 	// "unlet s:var" is allowed in legacy script.
-	if (*name == 's' && !script_is_vim9())
+	if (*name == 's' && !in_vim9script())
 	    return OK;
 	semsg(_(e_cannot_unlet_str), name);
 	return FAIL;

--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -288,15 +288,6 @@ update_script_var_block_id(char_u *name, int block_id)
 }
 
 /*
- * Return TRUE if the script context is Vim9 script.
- */
-    int
-script_is_vim9(void)
-{
-    return SCRIPT_ITEM(current_sctx.sc_sid)->sn_version == SCRIPT_VERSION_VIM9;
-}
-
-/*
  * Lookup a variable (without s: prefix) in the current script.
  * "cctx" is NULL at the script level, "cstack" is NULL in a function.
  * Returns OK or FAIL.
@@ -306,7 +297,7 @@ script_var_exists(char_u *name, size_t len, cctx_T *cctx, cstack_T *cstack)
 {
     if (current_sctx.sc_sid <= 0)
 	return FAIL;
-    if (script_is_vim9())
+    if (current_script_is_vim9())
     {
 	// Check script variables that were visible where the function was
 	// defined.


### PR DESCRIPTION
### Step to reproduce:
- run Vim
```bash
vim --clean
```
- Input following command.
```
:vim9cmd unlet s
```

### Result:
- Vim crashes
```
Vim: Caught deadly signal SEGV
Vim: Finished.
Segmentation fault (core dumped)
```

### GDB Backtrace
```
Thread 1 "vim" received signal SIGSEGV, Segmentation fault.
script_is_vim9 () at vim9compile.c:296
296         return SCRIPT_ITEM(current_sctx.sc_sid)->sn_version == SCRIPT_VERSIO
N_VIM9;
(gdb) bt
#0  script_is_vim9 () at vim9compile.c:296
#1  0x00005cf87fbd082b in check_vim9_unlet (name=0x5cf88e78369e "s") at vim9cmds.c:102
#2  0x00005cf87f99e52f in do_unlet (name=0x5cf88e78369e "s", forceit=0) at evalvars.c:2192
#3  0x00005cf87f99e344 in do_unlet_var (lp=0x7fff4e7a90c0, name_end=0x5cf88e78369f "", eap=0x7fff4e7a9270, deep=0, cookie=0x0) at evalvars.c:2129
#4  0x00005cf87f99e224 in ex_unletlock (eap=0x7fff4e7a9270, argstart=0x5cf88e78369e "s", deep=0, glv_flags=0, callback=0x5cf87f99e2bc <do_unlet_var>, cookie=0x0) at evalvars.c:2096
#5  0x00005cf87f99deaa in ex_unlet (eap=0x7fff4e7a9270) at evalvars.c:2016      
#6  0x00005cf87f9b8550 in do_one_cmd (cmdlinep=0x7fff4e7a94a0, flags=0, cstack=0x7fff4e7a9580, fgetline=0x5cf87f9d19a3 <getexline>, cookie=0x0) at ex_docmd.c:2621
#7  0x00005cf87f9b53ba in do_cmdline (cmdline=0x0, fgetline=0x5cf87f9d19a3 <getexline>, cookie=0x0, flags=0) at ex_docmd.c:1033
#8  0x00005cf87fa74d0e in nv_colon (cap=0x7fff4e7a9c70) at normal.c:3170
#9  0x00005cf87fa70bf0 in normal_cmd (oap=0x7fff4e7a9d00, toplevel=1) at normal.c:952
#10 0x00005cf87fc7a66a in main_loop (cmdwin=0, noexmode=0) at main.c:1610
#11 0x00005cf87fc79961 in vim_main2 () at main.c:948
#12 0x00005cf87fc78f13 in main (argc=1, argv=0x7fff4e7a9f38) at main.c:446
```

### Reason:
- Out of range access. `script_items.ga_data[-1]`.

### Investigation result:
- `script_is_vim9()` does not check `:legacy` or `:vim9cmd`. Existing functions `in_old_script()` or `in_vim9script()` should be used.
- There is a function `current_script_is_vim9()` equivalent to `script_is_vim9()`, so we should use that.
- `:h :unlet` has the following description, but some of the existing tests are incorrect.

                        In Vim9 script variables declared in a function or
                        script cannot be removed.

### Solution:
- Replaced `script_is_vim9()` call in `check_vim9_unlet()` with existing `in_vim9script()`.
- Replaced `script_is_vim9()` call in `script_var_exists()` with `current_script_is_vim9()`.
- Removed `script_is_vim9()`.
- ~~Added test30 (to check if it will crash or not).~~
- Fixed incorrect test for `:unlet` in test_vim9_assign.vim.