### PR TITLE
fix: shouldn't escape help tag in normal (`&buftype=''`) ft-help buffer

### DIFF
--- a/runtime/doc/tagsrch.txt
+++ b/runtime/doc/tagsrch.txt
@@ -542,6 +542,7 @@ exuberant ctags		This is a very good one.  It works for C, C++, Java,
 			many items.  See http://ctags.sourceforge.net.
 			No new version since 2009.
 etags			Connected to Emacs.  Supports many languages.
+|:helptags|		For Vim's |help| files.
 JTags			For Java, in Java.  It can be found at
 			http://www.fleiner.com/jtags/.
 ptags.py		For Python, in Python.  Found in your Python source

--- a/runtime/doc/tagsrch.txt
+++ b/runtime/doc/tagsrch.txt
@@ -542,7 +542,6 @@ exuberant ctags		This is a very good one.  It works for C, C++, Java,
 			many items.  See http://ctags.sourceforge.net.
 			No new version since 2009.
 etags			Connected to Emacs.  Supports many languages.
-|:helptags|		For Vim's |help| files.
 JTags			For Java, in Java.  It can be found at
 			http://www.fleiner.com/jtags/.
 ptags.py		For Python, in Python.  Found in your Python source

--- a/src/normal.c
+++ b/src/normal.c
@@ -3579,7 +3579,7 @@ nv_ident(cmdarg_T *cap)
 	    aux_ptr = (char_u *)(magic_isset() ? "/?.*~[^$\\" : "/?^$\\");
 	else if (tag_cmd)
 	{
-	    if (curbuf->b_help)
+	    if (strcmp((char *)(curbuf->b_p_ft), "help") == 0)
 		// ":help" handles unescaped argument
 		aux_ptr = (char_u *)"";
 	    else

--- a/src/normal.c
+++ b/src/normal.c
@@ -3579,7 +3579,7 @@ nv_ident(cmdarg_T *cap)
 	    aux_ptr = (char_u *)(magic_isset() ? "/?.*~[^$\\" : "/?^$\\");
 	else if (tag_cmd)
 	{
-	    if (strcmp((char *)(curbuf->b_p_ft), "help") == 0)
+	    if (STRCMP(curbuf->b_p_ft, "help") == 0)
 		// ":help" handles unescaped argument
 		aux_ptr = (char_u *)"";
 	    else

--- a/src/testdir/test_help.vim
+++ b/src/testdir/test_help.vim
@@ -206,15 +206,16 @@ func Test_help_using_visual_match()
 endfunc
 
 func Test_helptag_navigation()
-  source $VIMRUNTIME/defaults.vim
   let helpdir = tempname()
   let tempfile = helpdir . '/test.txt'
   call mkdir(helpdir, 'p')
   call writefile(['', '*[tag*', '', '|[tag|'], tempfile)
   exe 'helptags' helpdir
   exe 'sp' tempfile
-  exe 'lcd' helpdir 'call cursor(4, 2)'
+  exe 'lcd' helpdir
   setl ft=help
+  let &l:iskeyword='!-~,^*,^|,^",192-255'
+  call cursor(4, 2)
   exe "normal! \<C-]>"
   call assert_equal(2, line('.'))
   bw

--- a/src/testdir/test_help.vim
+++ b/src/testdir/test_help.vim
@@ -206,7 +206,6 @@ func Test_help_using_visual_match()
 endfunc
 
 func Test_helptag_navigation()
-  filetype plugin on
   let helpdir = tempname()
   let tempfile = helpdir . '/test.txt'
   call mkdir(helpdir, 'p')

--- a/src/testdir/test_help.vim
+++ b/src/testdir/test_help.vim
@@ -205,5 +205,18 @@ func Test_help_using_visual_match()
   call v9.CheckScriptFailure(lines, 'E149:')
 endfunc
 
+func Test_helptag_navigation()
+  let tempdir = tempname()
+  let tempfile = tempdir . '/test.txt'
+  call mkdir(tempdir, 'p')
+  call writefile(['', '*[tag*', '', '|[tag|'], tempfile)
+  exe 'helptags' tempdir
+  exe 'edit' tempfile
+  set ft=help
+  call cursor(4, 2)
+  exe "normal! \<C-]>"
+  call assert_equal(2, line('.'))
+endfunc
+
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_help.vim
+++ b/src/testdir/test_help.vim
@@ -208,7 +208,7 @@ endfunc
 func Test_helptag_navigation()
   let helpdir = tempname()
   let tempfile = helpdir . '/test.txt'
-  call mkdir(helpdir, 'p')
+  call mkdir(helpdir, 'pR')
   " Vim must not escape `[` in tag
   call writefile(['', '*[tag*', '', '|[tag|'], tempfile)
   exe 'helptags' helpdir

--- a/src/testdir/test_help.vim
+++ b/src/testdir/test_help.vim
@@ -206,16 +206,18 @@ func Test_help_using_visual_match()
 endfunc
 
 func Test_helptag_navigation()
-  let tempdir = tempname()
-  let tempfile = tempdir . '/test.txt'
-  call mkdir(tempdir, 'p')
+  filetype plugin on
+  let helpdir = tempname()
+  let tempfile = helpdir . '/test.txt'
+  call mkdir(helpdir, 'p')
   call writefile(['', '*[tag*', '', '|[tag|'], tempfile)
-  exe 'helptags' tempdir
-  exe 'edit' tempfile
-  set ft=help
-  call cursor(4, 2)
+  exe 'helptags' helpdir
+  exe 'sp' tempfile
+  exe 'lcd' helpdircall cursor(4, 2)
+  let &l:iskeyword='!-~,^*,^|,^",192-255'
   exe "normal! \<C-]>"
   call assert_equal(2, line('.'))
+  bw
 endfunc
 
 

--- a/src/testdir/test_help.vim
+++ b/src/testdir/test_help.vim
@@ -206,14 +206,15 @@ func Test_help_using_visual_match()
 endfunc
 
 func Test_helptag_navigation()
+  source $VIMRUNTIME/defaults.vim
   let helpdir = tempname()
   let tempfile = helpdir . '/test.txt'
   call mkdir(helpdir, 'p')
   call writefile(['', '*[tag*', '', '|[tag|'], tempfile)
   exe 'helptags' helpdir
   exe 'sp' tempfile
-  exe 'lcd' helpdircall cursor(4, 2)
-  let &l:iskeyword='!-~,^*,^|,^",192-255'
+  exe 'lcd' helpdir 'call cursor(4, 2)'
+  setl ft=help
   exe "normal! \<C-]>"
   call assert_equal(2, line('.'))
   bw

--- a/src/testdir/test_help.vim
+++ b/src/testdir/test_help.vim
@@ -209,6 +209,7 @@ func Test_helptag_navigation()
   let helpdir = tempname()
   let tempfile = helpdir . '/test.txt'
   call mkdir(helpdir, 'p')
+  " Vim must not escape `[` in tag
   call writefile(['', '*[tag*', '', '|[tag|'], tempfile)
   exe 'helptags' helpdir
   exe 'sp' tempfile


### PR DESCRIPTION
Closes #17224

cc @zeertzjq 