### PR TITLE
runtime: update example ctags program

### DIFF
--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -8595,7 +8595,6 @@ jsbterm-mouse	options.txt	/*jsbterm-mouse*
 json.vim	syntax.txt	/*json.vim*
 json_decode()	builtin.txt	/*json_decode()*
 json_encode()	builtin.txt	/*json_encode()*
-jtags	tagsrch.txt	/*jtags*
 jump-motions	motion.txt	/*jump-motions*
 jumplist	motion.txt	/*jumplist*
 jumplist-stack	motion.txt	/*jumplist-stack*

--- a/runtime/doc/tagsrch.txt
+++ b/runtime/doc/tagsrch.txt
@@ -526,7 +526,7 @@ directory where the tag file is.
 ==============================================================================
 5. Tags file format				*tags-file-format* *E431*
 
-						*ctags* *jtags*
+						*ctags*
 A tags file can be created with an external command, for example "ctags".  It
 will contain a tag for each function.  Some versions of "ctags" will also make
 a tag for each "#defined" macro, typedefs, enums, etc.
@@ -542,13 +542,11 @@ exuberant ctags		This is a very good one.  It works for C, C++, Java,
 			many items.  See http://ctags.sourceforge.net.
 			No new version since 2009.
 etags			Connected to Emacs.  Supports many languages.
-JTags			For Java, in Java.  It can be found at
-			http://www.fleiner.com/jtags/.
+|:helptags|		For Vim's |help| files
 ptags.py		For Python, in Python.  Found in your Python source
 			directory at Tools/scripts/ptags.py.
-ptags			For Perl, in Perl.  It can be found at (link seems
-			dead):
-			http://www.eleves.ens.fr:8080/home/nthiery/Tags/.
+ptags			For Perl, in Perl.  It can be found at
+			https://metacpan.org/pod/Vim::Tag
 gnatxref		For Ada.  See http://www.gnuada.org/.  gnatxref is
 			part of the gnat package.
 


### PR DESCRIPTION
- `:helptags` is also a tags generating program, it deserves mentioning there
- JTags is too dead: its website has been sold, the source, binary can't be found anywhere. Seems like a die-young hobby project to me. So I remove it
- Update link of ptags

I would also like to remove reference to all other tags programs than (Universal) Ctags and `:helptags`, but that needs discussion