### PR TITLE
filetype: GNU Radio companion files are not recognized

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1,7 +1,7 @@
 " Vim support file to detect file types
 "
 " Maintainer:	The Vim Project <https://github.com/vim/vim>
-" Last Change:	2025 Apr 24
+" Last Change:	2025 May 02
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Listen very carefully, I will say this only once
@@ -1022,6 +1022,14 @@ au BufNewFile,BufRead *.gjs			setf javascript.glimmer
 
 " Gnuplot scripts
 au BufNewFile,BufRead *.gpi,*.gnuplot,.gnuplot_history	setf gnuplot
+
+" GNU Radio Companion files
+au BufNewFile,BufRead *.grc
+	\ if getline(1) =~# '<?xml' |
+	\   setf xml |
+	\ else |
+	\   setf yaml |
+	\ endif
 
 " Go (Google)
 au BufNewFile,BufRead *.go			setf go

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -1630,6 +1630,22 @@ func Test_git_file()
   filetype off
 endfunc
 
+func Test_grc_file()
+  filetype on
+
+  call writefile(['<?xml version="1.0"?>', '<block>', '</block>'], 'Xfile.grc')
+  split Xfile.grc
+  call assert_equal('xml', &filetype)
+  bwipe!
+
+  call writefile(['metadata:', '  file_format: 1'], 'Xfile.grc')
+  split Xfile.grc
+  call assert_equal('yaml', &filetype)
+  bwipe!
+
+  filetype off
+endfunc
+
 func Test_haredoc_file()
   filetype on
   call assert_true(mkdir('foo/bar', 'pR'))


### PR DESCRIPTION
Problem:  filetype: GNU Radio companion files are not recognized.
Solution: Recongize .grc files as xml or yaml filetype depending on the
          first line.

Ref:
- https://wiki.gnuradio.org/index.php/XML_GRC
- https://wiki.gnuradio.org/index.php/YAML_GRC
