### PR TITLE
Fix UAF when switching to a closing buffer

### DIFF
--- a/src/errors.h
+++ b/src/errors.h
@@ -3728,3 +3728,5 @@ EXTERN char e_failed_resizing_quickfix_stack[]
 EXTERN char e_no_quickfix_stack[]
 	INIT(= N_("E1545: Quickfix list stack unavailable"));
 #endif
+EXTERN char e_cannot_switch_to_a_closing_buffer[]
+	INIT(= N_("E1546: Cannot switch to a closing buffer"));

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -2743,9 +2743,9 @@ do_ecmd(
 	}
 	if (buf == NULL)
 	    goto theend;
-	// autocommands try to edit a file that is going to be removed,
-	// abort
-	if (buf_locked(buf))
+	// autocommands try to edit a closing buffer, which like splitting, can
+	// result in more windows displaying it; abort
+	if (buf->b_locked_split)
 	{
 	    // window was split, but not editing the new buffer,
 	    // reset b_nwindows again
@@ -2753,6 +2753,7 @@ do_ecmd(
 		    && curwin->w_buffer != NULL
 		    && curwin->w_buffer->b_nwindows > 1)
 		--curwin->w_buffer->b_nwindows;
+	    emsg(_(e_cannot_switch_to_a_closing_buffer));
 	    goto theend;
 	}
 	if (curwin->w_alt_fnum == buf->b_fnum && prev_alt_fnum != 0)

--- a/src/proto/buffer.pro
+++ b/src/proto/buffer.pro
@@ -5,7 +5,6 @@ int open_buffer(int read_stdin, exarg_T *eap, int flags_arg);
 void set_bufref(bufref_T *bufref, buf_T *buf);
 int bufref_valid(bufref_T *bufref);
 int buf_valid(buf_T *buf);
-int buf_locked(buf_T *buf);
 int close_buffer(win_T *win, buf_T *buf, int action, int abort_if_last, int ignore_abort);
 void buf_clear_file(buf_T *buf);
 void buf_freeall(buf_T *buf, int flags);

--- a/src/structs.h
+++ b/src/structs.h
@@ -3072,7 +3072,7 @@ struct file_buffer
     int		b_locked;	// Buffer is being closed or referenced, don't
 				// let autocommands wipe it out.
     int		b_locked_split;	// Buffer is being closed, don't allow opening
-				// a new window with it.
+				// it in more windows.
 
     /*
      * b_ffname has the full path of the file (NULL for no name).

--- a/src/testdir/test_autocmd.vim
+++ b/src/testdir/test_autocmd.vim
@@ -5035,7 +5035,8 @@ func Test_autocmd_BufWinLeave_with_vsp()
   exe "e " fname
   vsp
   augroup testing
-    exe "au BufWinLeave " .. fname .. " :e " dummy .. "| vsp " .. fname
+    exe 'au BufWinLeave' fname 'e' dummy
+          \ '| call assert_fails(''vsp' fname ''', ''E1546:'')'
   augroup END
   bw
   call CleanUpTestAuGroup()

--- a/src/testdir/test_buffer.vim
+++ b/src/testdir/test_buffer.vim
@@ -569,4 +569,39 @@ func Test_buflist_alloc_failure()
   call assert_fails('cexpr "XallocFail6:10:Line10"', 'E342:')
 endfunc
 
+func Test_closed_buffer_still_in_window()
+  %bw!
+
+  let s:w = win_getid()
+  new
+  let s:b = bufnr()
+  setl bufhidden=wipe
+
+  augroup ViewClosedBuffer
+    autocmd!
+    autocmd BufUnload * ++once call assert_fails(
+          \ 'call win_execute(s:w, "' .. s:b .. 'b")', 'E1546:')
+  augroup END
+  quit!
+  " Previously resulted in s:b being curbuf while unloaded (no memfile).
+  call assert_equal(1, bufloaded(bufnr()))
+  call assert_equal(0, bufexists(s:b))
+
+  let s:w = win_getid()
+  split
+  new
+  let s:b = bufnr()
+
+  augroup ViewClosedBuffer
+    autocmd!
+    autocmd BufWipeout * ++once call win_gotoid(s:w)
+          \| call assert_fails(s:b .. 'b', 'E1546:') | wincmd p
+  augroup END
+  bw! " Close only this buffer first; used to be a heap UAF.
+
+  unlet! s:w s:b
+  autocmd! ViewClosedBuffer
+  %bw!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem: Possible to open more windows into a closing buffer without splitting, bypassing existing "b_locked_split" checks and triggering UAF.

Solution: Disallow switching to a closing buffer. Editing a closing buffer (via ":edit", etc.) was fixed in v9.1.0764, but add an error message and check just "b_locked_split", as "b_locked" is necessary only when the buffer shouldn't be wiped, and may be set for buffers that are in-use but not actually closing.