### PR TITLE
Tweak documentation in develop.txt

### DIFF
--- a/runtime/doc/develop.txt
+++ b/runtime/doc/develop.txt
@@ -215,7 +215,7 @@ them:
 - flexible array members: Not supported by HP-UX C compiler (John Marriott)
 
 
-COMMENTS					       *style-comments*
+COMMENTS						*style-comments*
 
 Try to avoid putting multiline comments inside a function body: if the
 function is so complex that you need to separately comment parts of it, you
@@ -231,7 +231,7 @@ For everything else use: >
 <
 
 
-INDENTATION					      *style-indentation*
+INDENTATION						*style-indentation*
 
 We use 4 space to indent the code. If you are using Vim to edit the source,
 you don't need to do anything due to the |modeline|.
@@ -239,7 +239,7 @@ you don't need to do anything due to the |modeline|.
 For other editors an `.editorconfig` is provided at the root of the repo.
 
 
-DECLARATIONS	                                     *style-declarations*
+DECLARATIONS						*style-declarations*
 
 Declare, when possible, `for` loop variables in the guard:
 OK: >
@@ -260,55 +260,72 @@ Wrong: >
 <
 
 
-BRACES							   *style-braces*
+BRACES							*style-braces*
 
 All curly braces must be returned onto a new line:
 OK: >
     if (cond)
     {
-       cmd;
-       cmd;
+	cmd;
+	cmd;
     }
     else
     {
-       cmd;
-       cmd;
+	cmd;
+	cmd;
     }
 <
 Wrong: >
     if (cond) {
-       cmd;
-       cmd;
+	cmd;
+	cmd;
     } else {
-       cmd;
-       cmd;
+	cmd;
+	cmd;
     }
 <
 OK: >
     while (cond)
     {
 	cmd;
+	cmd;
     }
 <
 Wrong: >
     while (cond) {
 	cmd;
+	cmd;
     }
+<
+OK: >
+    do
+    {
+	cmd;
+	cmd;
+    }
+    while (cond);
+<
+Wrong: >
+    do {
+	cmd;
+	cmd;
+    } while (cond);
 <
 When a block has one line, including comments, the braces can be left out.
 OK: >
     if (cond)
+    {
+	/*
+	 * comment
+	 */
 	cmd;
-    else
-	cmd;
+    }
 <
 Wrong: >
     if (cond)
 	/*
 	 * comment
 	 */
-	cmd;
-    else
 	cmd;
 <
 When an `if`/`else` has braces on one block, the other should have it too.

--- a/runtime/doc/develop.txt
+++ b/runtime/doc/develop.txt
@@ -230,7 +230,6 @@ For everything else use: >
     // comment
 <
 
-
 INDENTATION						*style-indentation*
 
 We use 4 space to indent the code. If you are using Vim to edit the source,
@@ -258,7 +257,6 @@ Wrong: >
     int n;
     int *ptr;
 <
-
 
 BRACES							*style-braces*
 
@@ -302,6 +300,13 @@ OK: >
     {
 	cmd;
 	cmd;
+    } while (cond);
+<
+or >
+    do
+    {
+	cmd;
+	cmd;
     }
     while (cond);
 <
@@ -311,78 +316,17 @@ Wrong: >
 	cmd;
     } while (cond);
 <
-When a block has one line, including comments, the braces can be left out.
-OK: >
-    if (cond)
-    {
-	/*
-	 * comment
-	 */
-	cmd;
-    }
-<
-Wrong: >
-    if (cond)
-	/*
-	 * comment
-	 */
-	cmd;
-<
-When an `if`/`else` has braces on one block, the other should have it too.
-OK: >
-    if (cond)
-    {
-	cmd;
-    }
-    else
-    {
-	cmd;
-	cmd;
-    }
-<
-Wrong: >
-    if (cond)
-	cmd;
-    else
-    {
-	cmd;
-	cmd;
-    }
-
-    if (cond)
-    {
-	cmd;
-	cmd;
-    }
-    else
-	cmd;
-<
-OK: >
-    while (cond)
-	cmd;
-<
-Wrong:
->
-    while (cond)
-	if (cond)
-	    cmd;
-<
-
 
 TYPES							    *style-types*
 
-Use descriptive types. You can find a list of them in the src/structs.h file
-and probably in a typedef in the file you are working on.
-
+Use descriptive types. These are defined in src/vim.h, src/structs.h etc.
 Note that all custom types are postfixed with "_T"
 
-OK: >
-    int is_valid_line_number(linenr_T lnum);
+Example: >
+    linenr_T
+    buf_T
+    pos_T
 <
-Wrong: >
-    int is_valid_line_number(unsigned long lnum);
-<
-
 
 SPACES AND PUNCTUATION					   *style-spaces*
 
@@ -403,8 +347,8 @@ Wrong:  func(arg1,arg2);	for (i = 0;i < 2;++i)
 
 Use a space before and after '=', '+', '/', etc.
 
-Wrong:	var=a*5;
 OK:	var = a * 5;
+Wrong:	var=a*5;
 
 Use empty lines to group similar actions together.
 
@@ -428,7 +372,6 @@ Wrong: >
 	buf = rbuf;
     while (buf != NULL && !got_int)
 <
-
 
 FUNCTIONS						*style-functions*
 


### PR DESCRIPTION
- Adjust indentation.
- Add `do { ~ } while (cond);` example.