### PR TITLE
Use GTK3 instead of GTK2 in the CI workflow.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,22 +111,50 @@ jobs:
         run: |
           sudo bash ci/remove_snap.sh
 
+      - name: Enable debug packages
+        run: |
+          # Some of the ASAN suppressions are in libraries linked with dlopen
+          # and symbolization of them requires these debug packages.
+          sudo apt install ubuntu-dbgsym-keyring
+          sudo cp ci/ddebs.list /etc/apt/sources.list.d/ddebs.list
+          sudo cp ci/pinned-pkgs /etc/apt/preferences.d/pinned-pkgs
+
       - name: Install packages
         run: |
           # This is added by default, and it is often broken, but we don't need anything from it
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
-
           PKGS=( \
             gettext \
-            libgtk2.0-dev:${{ matrix.architecture }} \
+            libgtk-3-dev:${{ matrix.architecture }} \
+            libgtk-3-bin:${{ matrix.architecture }} \
             desktop-file-utils \
+            libc6-dbgsym:${{ matrix.architecture }} \
             libtool-bin \
             libncurses-dev:${{ matrix.architecture }} \
             libxt-dev:${{ matrix.architecture }} \
+            libegl-mesa0:${{ matrix.architecture }} \
+            libegl1:${{ matrix.architecture }} \
+            libegl1-mesa-dev:${{ matrix.architecture }} \
+            libepoxy-dev:${{ matrix.architecture }} \
+            libwayland-egl1:${{ matrix.architecture }} \
+            libwayland-client0:${{ matrix.architecture }} \
+            libwayland-cursor0:${{ matrix.architecture }} \
             locales-all \
             software-properties-common \
             sway \
           )
+          if ${{ contains(matrix.extra, 'asan') }} && ${{ contains(matrix.architecture, 'native') }}; then
+          PKGS+=( \
+            libepoxy0-dbgsym:${{ matrix.architecture }} \
+            libxdamage1-dbgsym:${{ matrix.architecture }} \
+            libxcb1-dbgsym:${{ matrix.architecture }} \
+            libgtk-3-bin-dbgsym:${{ matrix.architecture }} \
+            libgtk-3-0t64-dbgsym:${{ matrix.architecture }} \
+            libglib2.0-0t64-dbgsym:${{ matrix.architecture }} \
+            libglib2.0-bin-dbgsym:${{ matrix.architecture }} \
+            libglib2.0-dev-bin-dbgsym:${{ matrix.architecture }} \
+          )
+          fi
           if ${{ matrix.features == 'huge' }}; then
             LUA_VER=${{ matrix.lua_ver || '5.4' }}
             PKGS+=( \
@@ -146,8 +174,7 @@ jobs:
               libattr1-dev
             )
           fi
-
-          sudo apt-get update && sudo apt-get upgrade -y && sudo apt-get install -y "${PKGS[@]}"
+          sudo apt-get update && sudo apt-get upgrade -y --allow-downgrades && sudo apt-get install -y --allow-downgrades "${PKGS[@]}"
 
       - name: Install gcc-${{ env.GCC_VER }}
         if:  matrix.compiler == 'gcc'
@@ -225,6 +252,8 @@ jobs:
             echo "TEST=-C runtime/doc vimtags VIMEXE=../../${SRCDIR}/vim"
           fi
           echo "CFLAGS=${CFLAGS}"
+          # Disables GTK attempt to integrate with the accessibility service that does run in CI.
+          echo "NO_AT_BRIDGE=1"
           ) >> $GITHUB_ENV
 
       - name: Set up system
@@ -281,15 +310,6 @@ jobs:
           fi
 
       - name: Test
-        if: matrix.architecture != 'arm64'
-        timeout-minutes: 25
-        run: |
-          make ${SHADOWOPT} ${TEST}
-
-
-      # `sg audio` does not work on arm64 runner due to permission ('Incorrect password' error).
-      - name: Test on arm64
-        if: matrix.architecture == 'arm64'
         timeout-minutes: 25
         run: |
           make ${SHADOWOPT} ${TEST}

--- a/Filelist
+++ b/Filelist
@@ -27,6 +27,8 @@ SRC_ALL =	\
 		ci/setup-xvfb.sh \
 		ci/setup-sway.sh \
 		ci/remove_snap.sh \
+		ci/ddebs.list \
+		ci/pinned-pkgs \
 		src/Make_all.mak \
 		src/README.md \
 		src/alloc.c \

--- a/ci/ddebs.list
+++ b/ci/ddebs.list
@@ -1,0 +1,3 @@
+deb http://ddebs.ubuntu.com noble main restricted universe multiverse
+deb http://ddebs.ubuntu.com noble-updates main restricted universe multiverse
+deb http://ddebs.ubuntu.com noble-proposed main restricted universe multiverse

--- a/ci/pinned-pkgs
+++ b/ci/pinned-pkgs
@@ -1,0 +1,69 @@
+# Unfortunately ubtunu does not keep the debug packages strictly up-to-date
+# with the main packages. So this file needs to pin the main packages back to
+# the version for which debug packages are available.
+
+Package: libwayland-client0
+Pin: version 1.20.0-1
+Pin-Priority: 1000
+
+Package: libwayland-client0
+Pin: version 1.20.0-1ubuntu0.1
+Pin-Priority: 100
+
+Package: libwayland-cursor0
+Pin: version 1.20.0-1
+Pin-Priority: 1000
+
+Package: libwayland-cursor0
+Pin: version 1.20.0-1ubuntu0.1
+Pin-Priority: 100
+
+Package: libwayland-egl1
+Pin: version 1.20.0-1
+Pin-Priority: 1000
+
+Package: libwayland-egl1
+Pin: version 1.20.0-1ubuntu0.1
+Pin-Priority: 100
+
+Package: libwayland-dev
+Pin: version 1.20.0-1
+Pin-Priority: 1000
+
+Package: libwayland-dev
+Pin: version 1.20.0-1ubuntu0.1
+Pin-Priority: 100
+
+Package: libwayland-server0
+Pin: version 1.20.0-1
+Pin-Priority: 1000
+
+Package: libwayland-server0
+Pin: version 1.20.0-1ubuntu0.1
+Pin-Priority: 100
+
+Package: libwayland-bin
+Pin: version 1.20.0-1
+Pin-Priority: 1000
+
+Package: libwayland-bin
+Pin: version 1.20.0-1ubuntu0.1
+Pin-Priority: 100
+
+# As of 2025-04-27 the base library package libgtk-3-0t64 is still at 3.24.41-4ubuntu1.2
+Package: libgtk-3-0t64-dbgsym
+Pin: version 3.24.41-4ubuntu1.2
+Pin-Priority: 1000
+
+Package: libgtk-3-0t64-dbgsym
+Pin: version 3.24.41-4ubuntu1.3
+Pin-Priority: 100
+
+# As of 2025-04-27 the base binary package libgtk-3-bin is still at 3.24.41-4ubuntu1.2
+Package: libgtk-3-bin-dbgsym
+Pin: version 3.24.41-4ubuntu1.2
+Pin-Priority: 1000
+
+Package: libgtk-3-bin-dbgsym
+Pin: version 3.24.41-4ubuntu1.3
+Pin-Priority: 100

--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -4569,11 +4569,14 @@ gui_mch_open(void)
 
     pixel_width = (guint)(gui_get_base_width() + Columns * gui.char_width);
     pixel_height = (guint)(gui_get_base_height() + Rows * gui.char_height);
+
+# if !GTK_CHECK_VERSION(3,0,0)
     // For GTK2 changing the size of the form widget doesn't cause window
     // resizing.
     if (gtk_socket_id == 0)
 	gtk_window_resize(GTK_WINDOW(gui.mainwin), pixel_width, pixel_height);
     update_window_manager_hints(0, 0);
+# endif
 
     if (foreground_argument != NULL)
 	fg_pixel = gui_get_color((char_u *)foreground_argument);

--- a/src/testdir/check.vim
+++ b/src/testdir/check.vim
@@ -127,12 +127,38 @@ func CheckNotMacM1()
   endif
 endfunc
 
+func SetupWindowSizeToForVisualDumps()
+  " The dumps used as reference in these tests were created with a terminal
+  " width of 75 columns. The vim window that uses the remainder of the GUI
+  " window width must be at least 3 columns. In theory this means we need the
+  " GUI shell to provide 78+ columns. However the GTK3 resize logic is flaky,
+  " sometimes resulting in X11 Configure events that are narrower than
+  " expected by a number of pixels equal to 2 column widths. Therefore
+  " setting 80 columns ensures that the GUI shell can still provide 78+
+  " columns. This is very likely papering over a GTK3 resize bug but one that
+  " has existed for a very long time. Establishing this workaround is meant to
+  " get the GTK3 code working under CI so that we can focus on removing this
+  " over the long term.
+  if &columns != 80
+    set columns=80
+  endif
+  " Without resetting lines, some GTK3 resize events can carry over between
+  " tests, which invalidate assumptions in the scrollbar offset calculations.
+  if &lines != 25
+    set lines=25
+  endif
+endfunc
+
 " Command to check that making screendumps is supported.
 " Caller must source screendump.vim
 command CheckScreendump call CheckScreendump()
 func CheckScreendump()
+  let g:check_screendump_called = v:true
   if !CanRunVimInTerminal()
     throw 'Skipped: cannot make screendumps'
+  endif
+  if has('gui_running')
+    call SetupWindowSizeToForVisualDumps()
   endif
 endfunc
 

--- a/src/testdir/lsan-suppress.txt
+++ b/src/testdir/lsan-suppress.txt
@@ -11,3 +11,6 @@ leak:libperl.so.*
 leak:libpython*.so.*
 leak:libruby*.so.*
 leak:libxcb*.so.*
+# The renderer leaks 128 bytes of metadata when run under CI. Seems to only
+# happen with software rendering.
+leak:gdk_x11_screen_init_gl

--- a/src/testdir/runtest.vim
+++ b/src/testdir/runtest.vim
@@ -606,6 +606,8 @@ for g:testfunc in sort(s:tests)
   " A test can set g:test_is_flaky to retry running the test.
   let g:test_is_flaky = 0
 
+  let g:check_screendump_called = v:false
+
   " A test can set g:max_run_nr to change the max retry count.
   let g:max_run_nr = 5
   if has('mac')

--- a/src/testdir/screendump.vim
+++ b/src/testdir/screendump.vim
@@ -48,6 +48,10 @@ enddef
 " message.  Use this when using the same dump file with different options.
 " Returns non-zero when verification fails.
 func VerifyScreenDump(buf, filename, options, ...)
+  if has('gui_running') && exists("g:check_screendump_called") && g:check_screendump_called == v:false
+      echoerr "VerifyScreenDump() called from a test that lacks a CheckScreendump guard."
+      return 1
+  endif
   let reference = 'dumps/' . a:filename . '.dump'
   let filter = 'dumps/' . a:filename . '.vim'
   let testfile = 'failed/' . a:filename . '.dump'

--- a/src/testdir/test_autocmd.vim
+++ b/src/testdir/test_autocmd.vim
@@ -580,6 +580,7 @@ func Test_WinScrolled_close_curwin()
 endfunc
 
 func Test_WinScrolled_once_only()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -609,6 +610,7 @@ endfunc
 " Check that WinScrolled is not triggered immediately when defined and there
 " are split windows.
 func Test_WinScrolled_not_when_defined()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -3024,6 +3026,7 @@ endfunc
 func Test_autocmd_nested_switch_window()
   " run this in a separate Vim so that SafeState works
   CheckRunVimInTerminal
+  CheckScreendump
 
   let lines =<< trim END
       vim9script

--- a/src/testdir/test_balloon.vim
+++ b/src/testdir/test_balloon.vim
@@ -6,7 +6,6 @@ CheckNotGui
 CheckFeature balloon_eval_term
 
 source screendump.vim
-CheckScreendump
 
 let s:common_script =<< trim [CODE]
   call setline(1, ["one one one", "two tXo two", "three three three"])
@@ -19,6 +18,7 @@ let s:common_script =<< trim [CODE]
 [CODE]
 
 func Test_balloon_eval_term()
+  CheckScreendump
   " Use <Ignore> after <MouseMove> to return from vgetc() without removing
   " the balloon.
   let xtra_lines =<< trim [CODE]
@@ -49,6 +49,7 @@ func Test_balloon_eval_term()
 endfunc
 
 func Test_balloon_eval_term_visual()
+  CheckScreendump
   " Use <Ignore> after <MouseMove> to return from vgetc() without removing
   " the balloon.
   call writefile(s:common_script + [
@@ -66,6 +67,7 @@ func Test_balloon_eval_term_visual()
 endfunc
 
 func Test_balloon_eval_term_rightleft()
+  CheckScreendump
   CheckFeature rightleft
 
   " Use <Ignore> after <MouseMove> to return from vgetc() without removing

--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -2637,6 +2637,7 @@ endfunc
 " Test for using a popup menu for the command line completion matches
 " (wildoptions=pum)
 func Test_wildmenu_pum()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let commands =<< trim [CODE]
@@ -2929,6 +2930,7 @@ func Test_wildmenumode_with_pum()
 endfunc
 
 func Test_wildmenu_with_pum_foldexpr()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -2954,6 +2956,7 @@ endfunc
 " The popup menu should be positioned correctly over the status line of the
 " bottom-most window.
 func Test_wildmenu_pum_from_terminal()
+  CheckScreendump
   CheckRunVimInTerminal
   let python = PythonProg()
   call CheckPython(python)
@@ -2974,6 +2977,7 @@ func Test_wildmenu_pum_from_terminal()
 endfunc
 
 func Test_wildmenu_pum_odd_wildchar()
+  CheckScreendump
   CheckRunVimInTerminal
 
   " Test odd wildchar interactions with pum. Make sure they behave properly

--- a/src/testdir/test_conceal.vim
+++ b/src/testdir/test_conceal.vim
@@ -559,6 +559,8 @@ endfunc
 " Test that cursor is drawn at the correct column when it is after end of the
 " line with 'virtualedit' and concealing.
 func Run_test_conceal_virtualedit_after_eol(wrap)
+  CheckScreendump
+
   let code =<< trim eval [CODE]
     let &wrap = {a:wrap}
     call setline(1, 'abcdefgh|hidden|ijklmnpop')
@@ -591,6 +593,8 @@ endfunc
 
 " Same as Run_test_conceal_virtualedit_after_eol(), but with 'rightleft'.
 func Run_test_conceal_virtualedit_after_eol_rightleft(wrap)
+  CheckScreendump
+
   let code =<< trim eval [CODE]
     let &wrap = {a:wrap}
     call setline(1, 'abcdefgh|hidden|ijklmnpop')
@@ -624,6 +628,8 @@ endfunc
 
 " Test that cursor position is correct when double-width chars are concealed.
 func Run_test_conceal_double_width(wrap)
+  CheckScreendump
+
   let code =<< trim eval [CODE]
     let &wrap = {a:wrap}
     call setline(1, ['aaaaa口=口bbbbb口=口ccccc', 'foobar'])

--- a/src/testdir/test_crash.vim
+++ b/src/testdir/test_crash.vim
@@ -218,6 +218,7 @@ func Test_crash1_3()
 endfunc
 
 func Test_crash2()
+  CheckScreendump
   " The following used to crash Vim
   let opts = #{wait_for_ruler: 0, rows: 20}
   let args = ' -u NONE -i NONE -n -e -s -S '

--- a/src/testdir/test_cursor_func.vim
+++ b/src/testdir/test_cursor_func.vim
@@ -92,6 +92,10 @@ func Test_curswant_with_cursorline()
 endfunc
 
 func Test_screenpos()
+  if has('gui_running')
+    set lines=25
+    set columns=78
+  endif
   rightbelow new
   rightbelow 20vsplit
   call setline(1, ["\tsome text", "long wrapping line here", "next line"])

--- a/src/testdir/test_delete.vim
+++ b/src/testdir/test_delete.vim
@@ -111,6 +111,7 @@ endfunc
 
 " This should no longer trigger ml_get errors
 func Test_delete_ml_get_errors()
+  CheckScreendump
   CheckRunVimInTerminal
   let lines =<< trim END
     set noshowcmd noruler scrolloff=0

--- a/src/testdir/test_diffmode.vim
+++ b/src/testdir/test_diffmode.vim
@@ -879,6 +879,8 @@ endfunc
 
 " Verify a screendump with both the internal and external diff.
 func VerifyBoth(buf, dumpfile, extra)
+  CheckScreendump
+
   " trailing : for leaving the cursor on the command line
   for cmd in [":set diffopt=filler" . a:extra . "\<CR>:", ":set diffopt+=internal\<CR>:"]
     call term_sendkeys(a:buf, cmd)
@@ -897,6 +899,8 @@ endfunc
 
 " Verify a screendump with the internal diff only.
 func VerifyInternal(buf, dumpfile, extra)
+  CheckScreendump
+
   call term_sendkeys(a:buf, ":diffupdate!\<CR>")
   " trailing : for leaving the cursor on the command line
   call term_sendkeys(a:buf, ":set diffopt=internal,filler" . a:extra . "\<CR>:")

--- a/src/testdir/test_display.vim
+++ b/src/testdir/test_display.vim
@@ -377,6 +377,8 @@ func Test_display_linebreak_breakat()
 endfunc
 
 func Run_Test_display_lastline(euro)
+  CheckScreendump
+
   let lines =<< trim END
       call setline(1, ['aaa', 'b'->repeat(200)])
       set display=truncate

--- a/src/testdir/test_edit.vim
+++ b/src/testdir/test_edit.vim
@@ -2021,6 +2021,7 @@ endfunc
 
 " Test for positioning cursor after CTRL-R expression failed
 func Test_edit_ctrl_r_failed()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let buf = RunVimInTerminal('', #{rows: 6, cols: 60})

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -749,6 +749,7 @@ endfunc
 
 " Test for the mode() function
 func Test_mode()
+  CheckScreendump
   new
   call append(0, ["Blue Ball Black", "Brown Band Bowl", ""])
 
@@ -953,6 +954,7 @@ func Test_mode()
 
   " Test statusline updates for overstrike mode
   if CanRunVimInTerminal()
+    CheckScreendump
     let buf = RunVimInTerminal('', {'rows': 12})
     call term_sendkeys(buf, ":set laststatus=2 statusline=%!mode(1)\<CR>")
     call term_sendkeys(buf, ":")

--- a/src/testdir/test_gui.vim
+++ b/src/testdir/test_gui.vim
@@ -770,13 +770,10 @@ func Test_set_guioptions()
 endfunc
 
 func Test_scrollbars()
-  " this test sometimes fails on CI
-  let g:test_is_flaky = 1
-
   " buffer with 200 lines
-  new
   call setline(1, repeat(['one', 'two'], 100))
-  set guioptions+=rlb
+  set scrolloff=0
+  set guioptions=rlbk
 
   " scroll to move line 11 at top, moves the cursor there
   let args = #{which: 'left', value: 10, dragging: 0}
@@ -826,6 +823,7 @@ func Test_scrollbars()
   call assert_fails("call test_gui_event('scrollbar', #{which: 'a', value: 1, dragging: 0})", 'E475:')
 
   set guioptions&
+  set scrolloff&
   set wrap&
   bwipe!
 endfunc

--- a/src/testdir/test_hlsearch.vim
+++ b/src/testdir/test_hlsearch.vim
@@ -74,6 +74,7 @@ func Test_hlsearch_eol_highlight()
 endfunc
 
 func Test_hlsearch_Ctrl_R()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -92,6 +93,7 @@ func Test_hlsearch_Ctrl_R()
 endfunc
 
 func Test_hlsearch_clipboard()
+  CheckScreendump
   CheckRunVimInTerminal
   CheckFeature clipboard_working
 

--- a/src/testdir/test_match.vim
+++ b/src/testdir/test_match.vim
@@ -345,6 +345,7 @@ func Test_matchdelete_error()
 endfunc
 
 func Test_matchclear_other_window()
+  CheckScreendump
   CheckRunVimInTerminal
   let buf = OtherWindowCommon()
   call term_sendkeys(buf, ":call clearmatches(winid)\<CR>")
@@ -355,6 +356,7 @@ func Test_matchclear_other_window()
 endfunc
 
 func Test_matchadd_other_window()
+  CheckScreendump
   CheckRunVimInTerminal
   let buf = OtherWindowCommon()
   call term_sendkeys(buf, ":call matchadd('Search', 'Hello', 1, -1, #{window: winid})\<CR>")
@@ -366,6 +368,7 @@ func Test_matchadd_other_window()
 endfunc
 
 func Test_match_in_linebreak()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -381,6 +384,7 @@ func Test_match_in_linebreak()
 endfunc
 
 func Test_match_with_incsearch()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -420,6 +424,7 @@ func Test_matchdelete_redraw()
 endfunc
 
 func Test_match_tab_with_linebreak()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END

--- a/src/testdir/test_menu.vim
+++ b/src/testdir/test_menu.vim
@@ -631,6 +631,7 @@ endfunc
 
 " Test for opening a menu drawn in the cmdline area
 func Test_popupmenu_cmdline()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END

--- a/src/testdir/test_messages.vim
+++ b/src/testdir/test_messages.vim
@@ -324,6 +324,7 @@ endfunc
 
 " Test more-prompt scrollback
 func Test_message_more_scrollback()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -348,6 +349,7 @@ func Test_message_more_scrollback()
 endfunc
 
 func Test_message_not_cleared_after_mode()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -383,6 +385,7 @@ func Test_message_not_cleared_after_mode()
 endfunc
 
 func Test_mode_cleared_after_silent_message()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -407,6 +410,7 @@ endfunc
 
 " Test verbose message before echo command
 func Test_echo_verbose_system()
+  CheckScreendump
   CheckRunVimInTerminal
   CheckUnix    " needs the "seq" command
   CheckNotMac  " the macos TMPDIR is too long for snapshot testing

--- a/src/testdir/test_move.vim
+++ b/src/testdir/test_move.vim
@@ -47,6 +47,7 @@ func Test_move()
 endfunc
 
 func Test_move_undo()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END

--- a/src/testdir/test_popupwin_textprop.vim
+++ b/src/testdir/test_popupwin_textprop.vim
@@ -5,9 +5,9 @@ CheckFeature popupwin
 CheckFeature textprop
 
 source screendump.vim
-CheckScreendump
 
 func Test_textprop_popup()
+  CheckScreendump
   let lines =<< trim END
 	call setline(1, range(1, 100))
 	call setline(50, 'some text to work with')
@@ -55,6 +55,7 @@ func Test_textprop_popup()
 endfunc
 
 func Test_textprop_popup_corners()
+  CheckScreendump
   let lines =<< trim END
 	call setline(1, range(1, 100))
 	call setline(50, 'now working with some longer text here')
@@ -115,6 +116,7 @@ func Test_textprop_popup_corners()
 endfunc
 
 func Test_textprop_popup_offsets()
+  CheckScreendump
   let lines =<< trim END
 	call setline(1, range(1, 100))
 	call setline(50, 'now working with some longer text here')

--- a/src/testdir/test_put.vim
+++ b/src/testdir/test_put.vim
@@ -248,6 +248,7 @@ func Test_put_visual_block_mode()
 endfunc
 
 func Test_put_other_window()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -267,6 +268,7 @@ func Test_put_other_window()
 endfunc
 
 func Test_put_in_last_displayed_line()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END

--- a/src/testdir/test_search.vim
+++ b/src/testdir/test_search.vim
@@ -945,6 +945,7 @@ func Test_incsearch_cmdline_modifier()
 endfunc
 
 func Test_incsearch_scrolling()
+  CheckScreendump
   CheckRunVimInTerminal
   call assert_equal(0, &scrolloff)
   call writefile([

--- a/src/testdir/test_signs.vim
+++ b/src/testdir/test_signs.vim
@@ -1813,6 +1813,7 @@ endfunc
 
 " Test for correct cursor position after the sign column appears or disappears.
 func Test_sign_cursor_position()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END

--- a/src/testdir/test_startup.vim
+++ b/src/testdir/test_startup.vim
@@ -900,6 +900,7 @@ func Test_issue_3969()
 endfunc
 
 func Test_start_with_tabs()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let buf = RunVimInTerminal('-p a b c', {})

--- a/src/testdir/test_statusline.vim
+++ b/src/testdir/test_statusline.vim
@@ -16,6 +16,10 @@ func TearDown()
 endfunc
 
 func s:get_statusline()
+  if has('gui_running')
+    redraw!
+    sleep 1m
+  endif
   return ScreenLines(&lines - 1, &columns)[0]
 endfunc
 

--- a/src/testdir/test_substitute.vim
+++ b/src/testdir/test_substitute.vim
@@ -728,6 +728,7 @@ func Test_sub_cmd_9()
 endfunc
 
 func Test_sub_highlight_zero_match()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END

--- a/src/testdir/test_syntax.vim
+++ b/src/testdir/test_syntax.vim
@@ -631,6 +631,7 @@ endfunc
 
 " Check highlighting for a small piece of C code with a screen dump.
 func Test_syntax_c()
+  CheckScreendump
   CheckRunVimInTerminal
   call writefile([
 	\ '/* comment line at the top */',

--- a/src/testdir/test_tabpage.vim
+++ b/src/testdir/test_tabpage.vim
@@ -688,6 +688,7 @@ func Test_tabs()
 endfunc
 
 func Test_tabpage_cmdheight()
+  CheckScreendump
   CheckRunVimInTerminal
   call writefile([
         \ 'set laststatus=2',

--- a/src/testdir/test_termencoding.vim
+++ b/src/testdir/test_termencoding.vim
@@ -15,6 +15,7 @@ endif
 " running with 'encoding' "euc-jp".  We need to make sure the text is in the
 " right encoding, this is a bit tricky.
 func Test_termencoding_euc_jp()
+  CheckScreendump
   new
   call setline(1, 'E89: バッファ %ld の変更は保存されていません (! で変更を破棄)')
   write ++enc=euc-jp Xeuc_jp.txt

--- a/src/testdir/test_terminal.vim
+++ b/src/testdir/test_terminal.vim
@@ -522,6 +522,7 @@ func Test_terminal_scrollback()
 endfunc
 
 func Test_terminal_postponed_scrollback()
+  CheckScreendump
   " tail -f only works on Unix
   CheckUnix
 
@@ -1298,6 +1299,7 @@ endfunc
 
 " Run this first, it fails when run after other tests.
 func Test_aa_terminal_focus_events()
+  CheckScreendump
   CheckNotGui
   CheckUnix
   CheckRunVimInTerminal
@@ -1475,6 +1477,7 @@ func Test_terminal_open_autocmd()
 endfunc
 
 func Test_open_term_from_cmd()
+  CheckScreendump
   CheckUnix
   CheckRunVimInTerminal
 
@@ -1497,6 +1500,7 @@ func Test_open_term_from_cmd()
 endfunc
 
 func Test_combining_double_width()
+  CheckScreendump
   CheckUnix
   CheckRunVimInTerminal
 
@@ -1666,6 +1670,7 @@ func Test_terminal_dumpload()
 endfunc
 
 func Test_terminal_dumpload_dump()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -2168,6 +2173,7 @@ func Test_terminal_ansicolors_default()
 endfunc
 
 func Test_terminal_ansicolors_default_reset_tgc()
+  CheckScreendump
   CheckFeature termguicolors
   CheckRunVimInTerminal
 
@@ -2261,6 +2267,7 @@ func Test_terminal_ansicolors_func()
 endfunc
 
 func Test_terminal_all_ansi_colors()
+  CheckScreendump
   CheckRunVimInTerminal
 
   " Use all the ANSI colors.

--- a/src/testdir/test_terminal2.vim
+++ b/src/testdir/test_terminal2.vim
@@ -499,6 +499,7 @@ func Test_terminal_switch_mode()
 endfunc
 
 func Test_terminal_normal_mode()
+  CheckScreendump
   CheckRunVimInTerminal
 
   " Run Vim in a terminal and open a terminal window to run Vim in.

--- a/src/testdir/test_terminal3.vim
+++ b/src/testdir/test_terminal3.vim
@@ -70,6 +70,7 @@ endfunc
 
 " Check a terminal with different colors
 func Terminal_color(group_name, highlight_cmds, highlight_opt, open_cmds)
+  CheckScreendump
   CheckRunVimInTerminal
   CheckUnix
 
@@ -139,6 +140,7 @@ func Test_terminal_color_wincolor_over_group()
 endfunc
 
 func Test_terminal_color_wincolor_split()
+  CheckScreendump
   CheckRunVimInTerminal
   CheckUnix
 
@@ -246,6 +248,7 @@ func Test_terminal_color_gui_transp_wincolor()
 endfunc
 
 func Test_terminal_in_popup()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let text =<< trim END
@@ -324,6 +327,7 @@ endfunc
 
 " Check a terminal in popup window uses the default minimum size.
 func Test_terminal_in_popup_min_size()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let text =<< trim END
@@ -356,6 +360,7 @@ endfunc
 
 " Check a terminal in popup window with different colors
 func Terminal_in_popup_color(group_name, highlight_cmds, highlight_opt, popup_cmds, popup_opt)
+  CheckScreendump
   CheckRunVimInTerminal
   CheckUnix
 

--- a/src/testdir/test_textprop.vim
+++ b/src/testdir/test_textprop.vim
@@ -1256,6 +1256,7 @@ endfunc
 
 func Test_textprop_hl_override()
   CheckScreendump
+  CheckRunVimInTerminal
 
   let lines =<< trim END
       call setline(1, ['One one one one one', 'Two two two two two', 'Three three three three'])
@@ -1286,6 +1287,7 @@ func Test_textprop_hl_override()
 endfunc
 
 func RunTestVisualBlock(width, dump)
+  CheckScreendump
   call writefile([
 	\ "call setline(1, ["
 	\	.. "'xxxxxxxxx 123 x',"
@@ -1992,6 +1994,7 @@ def Test_delete_line_within_multiline_prop()
 enddef
 
 func Test_prop_in_linebreak()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -2017,6 +2020,7 @@ func Test_prop_in_linebreak()
 endfunc
 
 func Test_prop_with_linebreak()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -2036,6 +2040,7 @@ func Test_prop_with_linebreak()
 endfunc
 
 func Test_prop_with_wrap()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -2054,6 +2059,7 @@ func Test_prop_with_wrap()
 endfunc
 
 func Test_prop_after_tab()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -2070,6 +2076,7 @@ func Test_prop_after_tab()
 endfunc
 
 func Test_prop_before_tab()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -2109,6 +2116,7 @@ func Test_prop_before_tab()
 endfunc
 
 func Test_prop_after_linebreak()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -2558,6 +2566,7 @@ func Test_props_do_not_affect_byte_offsets_editline()
 endfunc
 
 func Test_prop_inserts_text()
+  CheckScreendump
   CheckRunVimInTerminal
 
   " Just a basic check for now
@@ -2609,6 +2618,7 @@ func Test_prop_inserts_text()
 endfunc
 
 func Test_prop_inserts_text_highlight()
+  CheckScreendump
   CheckRunVimInTerminal
 
   " Just a basic check for now
@@ -2644,6 +2654,7 @@ func Test_prop_inserts_text_highlight()
 endfunc
 
 func Test_prop_inserts_text_normal_gM()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -2661,6 +2672,7 @@ func Test_prop_inserts_text_normal_gM()
 endfunc
 
 func Run_test_prop_inserts_text_normal_gj_gk(cmd)
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -2695,6 +2707,7 @@ func Test_prop_inserts_text_normal_gj_gk()
 endfunc
 
 func Test_prop_normal_gj_gk_gM_with_outer_virtual_text()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -2737,6 +2750,7 @@ func Test_prop_normal_gj_gk_gM_with_outer_virtual_text()
 endfunc
 
 func Test_prop_inserts_text_visual_block()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -2765,6 +2779,7 @@ func Test_prop_inserts_text_visual_block()
 endfunc
 
 func Run_test_prop_inserts_text_showbreak(cmd)
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -2838,6 +2853,7 @@ func Test_prop_inserts_text_showbreak()
 endfunc
 
 func Test_prop_before_tab_skipcol()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -2875,6 +2891,7 @@ func Test_prop_before_tab_skipcol()
 endfunc
 
 func Test_prop_inserts_text_before_linebreak()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -2894,6 +2911,7 @@ func Test_prop_inserts_text_before_linebreak()
 endfunc
 
 func Test_prop_inserts_text_before_double_width_wrap()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -2914,6 +2932,7 @@ func Test_prop_inserts_text_before_double_width_wrap()
 endfunc
 
 func Test_prop_inserts_text_lcs_extends()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -2948,6 +2967,7 @@ func Test_prop_add_with_text_fails()
 endfunc
 
 func Test_props_with_text_right_align_twice()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -2973,6 +2993,7 @@ func Test_props_with_text_right_align_twice()
 endfunc
 
 func Test_props_with_text_after()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -3004,6 +3025,7 @@ func Test_props_with_text_after()
 endfunc
 
 func Test_props_with_text_after_and_list()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -3041,6 +3063,7 @@ func Test_props_with_text_after_and_list()
 endfunc
 
 func Test_props_with_text_after_below_trunc()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -3077,6 +3100,7 @@ func Test_props_with_text_after_below_trunc()
 endfunc
 
 func Test_props_with_text_truncated_just_before_after()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -3114,6 +3138,7 @@ func Test_props_with_text_truncated_just_before_after()
 endfunc
 
 func Test_prop_with_text_below_after_empty()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -3153,6 +3178,7 @@ func Test_prop_with_text_below_after_empty()
 endfunc
 
 func Test_prop_with_text_above_below_empty()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -3204,6 +3230,7 @@ func Test_prop_with_text_above_below_empty()
 endfunc
 
 func Test_prop_multiple_lines_above()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -3226,6 +3253,7 @@ func Test_prop_multiple_lines_above()
 endfunc
 
 func Test_prop_with_multibyte_above()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -3247,6 +3275,7 @@ func Test_prop_with_multibyte_above()
 endfunc
 
 func Test_prop_with_multibyte_below()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -3268,6 +3297,7 @@ func Test_prop_with_multibyte_below()
 endfunc
 
 func Test_prop_with_text_below_rightleft()
+  CheckScreendump
   CheckRunVimInTerminal
   CheckFeature rightleft
 
@@ -3285,6 +3315,7 @@ func Test_prop_with_text_below_rightleft()
 endfunc
 
 func Test_prop_with_text_above_empty()
+  CheckScreendump
   CheckRunVimInTerminal
 
   " check the cursor is in the correct line
@@ -3310,6 +3341,7 @@ func Test_prop_with_text_above_empty()
 endfunc
 
 func Test_prop_with_text_below_after_match()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -3333,6 +3365,7 @@ func Test_prop_with_text_below_after_match()
 endfunc
 
 func Test_props_with_text_after_joined()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -3358,6 +3391,7 @@ func Test_props_with_text_after_joined()
 endfunc
 
 func Test_props_with_text_after_truncated()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -3396,6 +3430,7 @@ func Test_props_with_text_after_truncated()
 endfunc
 
 func Test_props_with_text_after_truncated_and_ambiwidth_is_double()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -3422,6 +3457,7 @@ endfunc
 
 
 func Test_props_with_text_after_truncated_not_utf8()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -3447,6 +3483,7 @@ func Test_props_with_text_after_truncated_not_utf8()
 endfunc
 
 func Test_props_with_text_empty_line()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -3480,6 +3517,7 @@ func Test_props_with_text_empty_line()
 endfunc
 
 func Test_props_with_text_after_wraps()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -3504,6 +3542,7 @@ func Test_props_with_text_after_wraps()
 endfunc
 
 func Test_props_with_text_after_nowrap()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -3537,6 +3576,7 @@ func Test_props_with_text_after_nowrap()
 endfunc
 
 func Test_prop_with_text_below_cul()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -3560,6 +3600,7 @@ func Test_prop_with_text_below_cul()
 endfunc
 
 func Test_props_with_text_below_nowrap()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -3592,6 +3633,7 @@ func Test_props_with_text_below_nowrap()
 endfunc
 
 func Test_props_with_text_above()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -3654,6 +3696,7 @@ func Test_props_with_text_above()
 endfunc
 
 func Test_prop_with_text_above_padding()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -3690,6 +3733,7 @@ func Test_prop_above_with_indent()
 endfunc
 
 func Test_prop_above_with_number()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -3725,6 +3769,7 @@ func Test_prop_above_with_number()
 endfunc
 
 func Test_prop_above_with_linebreak()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -3744,6 +3789,7 @@ func Test_prop_above_with_linebreak()
 endfunc
 
 func Test_prop_above_and_before()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -3770,6 +3816,7 @@ func Test_prop_above_and_before()
 endfunc
 
 func Test_prop_below_split_line()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -3798,6 +3845,7 @@ func Test_prop_below_split_line()
 endfunc
 
 func Test_prop_above_below_smoothscroll()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -3826,6 +3874,7 @@ func Test_prop_above_below_smoothscroll()
 endfunc
 
 func Test_props_with_text_override()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -3849,6 +3898,7 @@ func Test_props_with_text_override()
 endfunc
 
 func Test_props_with_text_CursorMoved()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -3887,6 +3937,7 @@ func Test_props_with_text_CursorMoved()
 endfunc
 
 func Test_props_with_text_after_split_join()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -3956,6 +4007,7 @@ def Test_insert_text_before_virtual_text()
 enddef
 
 func Test_insert_text_start_incl()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -3997,6 +4049,7 @@ func Test_insert_text_start_incl()
 endfunc
 
 func Test_insert_text_list_mode()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -4026,6 +4079,7 @@ func Test_insert_text_list_mode()
 endfunc
 
 func Test_insert_text_with_padding()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -4078,6 +4132,7 @@ func Test_insert_text_with_padding()
 endfunc
 
 func Test_long_text_below_with_padding()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -4109,6 +4164,7 @@ func Test_long_text_below_with_padding()
 endfunc
 
 func Test_text_after_nowrap()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -4173,6 +4229,7 @@ func Test_text_after_nowrap()
 endfunc
 
 func Test_text_after_nowrap_list()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -4209,6 +4266,7 @@ func Test_text_after_nowrap_list()
 endfunc
 
 func Test_text_below_nowrap()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -4238,6 +4296,7 @@ func Test_text_below_nowrap()
 endfunc
 
 func Test_virtual_text_overlap_with_highlight()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -4278,6 +4337,7 @@ func Test_virtual_text_overlap_with_highlight()
 endfunc
 
 func Test_virtual_text_in_popup_highlight()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -4322,6 +4382,7 @@ func Test_virtual_text_in_popup_highlight()
 endfunc
 
 func Test_insert_text_change_arg()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -4383,6 +4444,7 @@ def Test_textprop_in_quickfix_window()
 enddef
 
 func Test_text_prop_delete_updates()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -4421,6 +4483,7 @@ func Test_text_prop_delete_updates()
 endfunc
 
 func Test_text_prop_diff_mode()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -4459,6 +4522,7 @@ func Test_error_when_using_negative_id()
 endfunc
 
 func Test_error_after_using_negative_id()
+  CheckScreendump
   " This needs to run a separate Vim instance because the
   " "did_use_negative_pop_id" will be set.
   CheckRunVimInTerminal
@@ -4495,6 +4559,7 @@ func Test_error_after_using_negative_id()
 endfunc
 
 func Test_modify_text_before_prop()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -4517,6 +4582,7 @@ func Test_modify_text_before_prop()
 endfunc
 
 func Test_overlong_textprop_above_crash()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -4538,6 +4604,7 @@ func Test_overlong_textprop_above_crash()
 endfunc
 
 func Test_text_prop_list_hl_and_sign_highlight()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -4632,6 +4699,7 @@ func Test_textprop_backspace_fo_aw()
 endfunc
 
 func Test_textprop_with_wincolor()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END

--- a/src/testdir/test_undo.vim
+++ b/src/testdir/test_undo.vim
@@ -849,6 +849,7 @@ func Test_undo_mark()
 endfunc
 
 func Test_undo_after_write()
+  CheckScreendump
   " use a terminal to make undo work like when text is typed
   CheckRunVimInTerminal
 

--- a/src/testdir/test_utf8.vim
+++ b/src/testdir/test_utf8.vim
@@ -294,6 +294,7 @@ func Test_getcellwidths()
 endfunc
 
 func Test_setcellwidths_dump()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -311,6 +312,7 @@ endfunc
 
 " Test setcellwidths() on characters that are not targets of 'ambiwidth'.
 func Test_setcellwidths_with_non_ambiwidth_character_dump()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END
@@ -333,6 +335,7 @@ endfunc
 " For some reason this test causes Test_customlist_completion() to fail on CI,
 " so run it as the last test.
 func Test_zz_ambiwidth_hl_dump()
+  CheckScreendump
   CheckRunVimInTerminal
 
   let lines =<< trim END

--- a/src/testdir/test_vim9_func.vim
+++ b/src/testdir/test_vim9_func.vim
@@ -3204,6 +3204,7 @@ def Test_nested_closure_fails()
 enddef
 
 def Run_Test_closure_in_for_loop_fails()
+  CheckScreendump
   var lines =<< trim END
     vim9script
     redraw
@@ -3600,6 +3601,7 @@ func Test_silent_echo()
 endfunc
 
 def Run_Test_silent_echo()
+  CheckScreendump
   var lines =<< trim END
     vim9script
     def EchoNothing()
@@ -4645,6 +4647,7 @@ def Test_invalid_redir()
 enddef
 
 func Test_keytyped_in_nested_function()
+  CheckScreendump
   CheckRunVimInTerminal
 
   call Run_Test_keytyped_in_nested_function()

--- a/src/testdir/test_vim9_script.vim
+++ b/src/testdir/test_vim9_script.vim
@@ -4174,6 +4174,7 @@ func Test_no_redraw_when_restoring_cpo()
 endfunc
 
 def Run_test_no_redraw_when_restoring_cpo()
+  CheckScreendump
   var lines =<< trim END
     vim9script
     export def Func()
@@ -4205,6 +4206,7 @@ func Test_reject_declaration()
 endfunc
 
 def Run_test_reject_declaration()
+  CheckScreendump
   var buf = g:RunVimInTerminal('', {'rows': 6})
   term_sendkeys(buf, ":vim9cmd var x: number\<CR>")
   g:VerifyScreenDump(buf, 'Test_vim9_reject_declaration_1', {})
@@ -4831,11 +4833,13 @@ def Test_profile_with_lambda()
 enddef
 
 func Test_misplaced_type()
+  CheckScreendump
   CheckRunVimInTerminal
   call Run_Test_misplaced_type()
 endfunc
 
 def Run_Test_misplaced_type()
+  CheckScreendump
   writefile(['let g:somevar = "asdf"'], 'XTest_misplaced_type', 'D')
   var buf = g:RunVimInTerminal('-S XTest_misplaced_type', {'rows': 6})
   term_sendkeys(buf, ":vim9cmd echo islocked('somevar: string')\<CR>")

--- a/src/testdir/test_xxd.vim
+++ b/src/testdir/test_xxd.vim
@@ -667,6 +667,7 @@ func Test_xxd_color2()
   let buf = RunVimInTerminal('', #{rows: 20, cmd: 'sh'})
   call term_sendkeys(buf,  s:xxd_cmd .. " -R never  < XXDfile_colors\<cr>")
   call TermWait(buf)
+  redraw
   call VerifyScreenDump(buf, 'Test_xxd_color_0', {})
 
   call TermWait(buf)


### PR DESCRIPTION
Problem: GTK2 testing was favored over GTK3.
Solution: Install GTK3 in the CI workflow.

Since the configure script favors GTK3 when it is available, distros have built vim with GTK3 for many years now. However we've stuck with GTK2 when running the GUI tests. This PR changes that by installing GTK3 and it's dependencies in the CI workflow.

Since this is long overdue, there are some long-standing, minor bugs in the GTK3 interface that this also works around:

* The core issue is that the GTK3 GUI shell size can sometimes be miscalculated. I believe this is due to the order in which GUI events are processed. See #13575 for some debugging notes. I'm narrowing in on a fix for at least one of those issues but they are going to take a while to fix.
* Some tests have an implicit dependency on a minimum GUI shell size. These are mostly the screendump tests. To make that dependency explicit I've added code to the `CheckScreendump` and `VerifyScreenDump` so that each test, when in GUI mode, must opt into the standard GUI shell at the beginning of each test.
* There is a tiny memory leak in the graphics libraries used by GTK3 that needs to be squelched by ASAN. In order to achieve that, the debug libraries need to be installed. The package pinning required to get the debug packages to install consistently is disappointing to me. I'm hopeful someone reviewing may have a less onerous way to achieve the same stability.

I have mixed feelings about `SetupWindowSizeToForVisualDumps`. It is currently papering over some minor bugs. That isn't great. However, I think getting GTK3 running under CI is the easiest way to invite broader bug fixing participation. Furthermore, even if those bugs didn't exist, I think making this shell size dependency explicit would be good. It ensures that tests fail only for the failures they are meant to protect against.
