### PR TITLE
Add an indent test and fix invalid indents

### DIFF
--- a/src/cindent.c
+++ b/src/cindent.c
@@ -406,10 +406,10 @@ cin_islabel_skip(char_u **s)
 
     while (vim_isIDc(**s))
     {
-        if (has_mbyte)
-            (*s) += (*mb_ptr2len)(*s);
-        else
-            (*s)++;
+	if (has_mbyte)
+	    (*s) += (*mb_ptr2len)(*s);
+	else
+	    (*s)++;
     }
 
     *s = cin_skipcomment(*s);

--- a/src/clipboard.c
+++ b/src/clipboard.c
@@ -2221,7 +2221,7 @@ adjust_clip_reg(int *rp)
 					   && clip_plus.available) ? '+' : '*';
     }
     if ((!clip_star.available && *rp == '*') ||
-           (!clip_plus.available && *rp == '+'))
+	   (!clip_plus.available && *rp == '+'))
     {
 	msg_warn_missing_clipboard();
 	*rp = 0;

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -5582,34 +5582,34 @@ f_get(typval_T *argvars, typval_T *rettv)
 f_getcellpixels(typval_T *argvars UNUSED, typval_T *rettv)
 {
     if (rettv_list_alloc(rettv) == FAIL)
-        return;
+	return;
 
 #if defined(FEAT_GUI)
     if (gui.in_use)
     {
-        // success pixel size and no gui.
-        list_append_number(rettv->vval.v_list, (varnumber_T)gui.char_width);
-        list_append_number(rettv->vval.v_list, (varnumber_T)gui.char_height);
+	// success pixel size and no gui.
+	list_append_number(rettv->vval.v_list, (varnumber_T)gui.char_width);
+	list_append_number(rettv->vval.v_list, (varnumber_T)gui.char_height);
     }
     else
 #endif
     {
-        struct cellsize cs;
+	struct cellsize cs;
 #if defined(UNIX)
-        mch_calc_cell_size(&cs);
+	mch_calc_cell_size(&cs);
 #else
-        // Non-Unix CUIs are not supported, so set this to -1x-1.
-        cs.cs_xpixel = -1;
-        cs.cs_ypixel = -1;
+	// Non-Unix CUIs are not supported, so set this to -1x-1.
+	cs.cs_xpixel = -1;
+	cs.cs_ypixel = -1;
 #endif
 
-        // failed get pixel size.
-        if (cs.cs_xpixel == -1)
-            return;
+	// failed get pixel size.
+	if (cs.cs_xpixel == -1)
+	    return;
 
-        // success pixel size and no gui.
-        list_append_number(rettv->vval.v_list, (varnumber_T)cs.cs_xpixel);
-        list_append_number(rettv->vval.v_list, (varnumber_T)cs.cs_ypixel);
+	// success pixel size and no gui.
+	list_append_number(rettv->vval.v_list, (varnumber_T)cs.cs_xpixel);
+	list_append_number(rettv->vval.v_list, (varnumber_T)cs.cs_ypixel);
     }
 
 }

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -5975,7 +5975,7 @@ get_command_name(expand_T *xp UNUSED, int idx)
 	return expand_user_command_name(idx);
     // the following are no real commands
     if (STRNCMP(cmdnames[idx].cmd_name, "{", 1) == 0 ||
-        STRNCMP(cmdnames[idx].cmd_name, "}", 1) == 0)
+	STRNCMP(cmdnames[idx].cmd_name, "}", 1) == 0)
 	return (char_u *)"";
     return cmdnames[idx].cmd_name;
 }

--- a/src/message.c
+++ b/src/message.c
@@ -1127,17 +1127,17 @@ messagesopt_changed(void)
 
     // Either "wait" or "hit-enter" is required
     if (!(messages_flags_new & (MESSAGES_HIT_ENTER | MESSAGES_WAIT)))
-        return FAIL;
+	return FAIL;
 
     // "history" must be set
     if (!(messages_flags_new & MESSAGES_HISTORY))
-        return FAIL;
+	return FAIL;
 
     if (messages_history_new < 0 || messages_history_new > 10000)
-        return FAIL;
+	return FAIL;
 
     if (messages_wait_new < 0 || messages_wait_new > 10000)
-        return FAIL;
+	return FAIL;
 
     msg_flags = messages_flags_new;
     msg_wait = messages_wait_new;

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -4440,14 +4440,14 @@ mch_report_winsize(int fd, int rows, int cols)
 
     if (cs.cs_xpixel == -1)
     {
-        // failed get pixel size.
-        ws.ws_xpixel = 0;
-        ws.ws_ypixel = 0;
+	// failed get pixel size.
+	ws.ws_xpixel = 0;
+	ws.ws_ypixel = 0;
     }
     else
     {
-        ws.ws_xpixel = cols * cs.cs_xpixel;
-        ws.ws_ypixel = rows * cs.cs_ypixel;
+	ws.ws_xpixel = cols * cs.cs_xpixel;
+	ws.ws_ypixel = rows * cs.cs_ypixel;
     }
 
     retval = ioctl(tty_fd, TIOCSWINSZ, &ws);

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -971,7 +971,7 @@ PlatformId(void)
 
     ovi.dwOSVersionInfoSize = sizeof(ovi);
     if (!GetVersionEx(&ovi))
-        return;
+	return;
 
 #ifdef FEAT_EVAL
     vim_snprintf(windowsVersion, sizeof(windowsVersion), "%d.%d",
@@ -988,7 +988,7 @@ PlatformId(void)
 #ifdef HAVE_ACL
     // Enable privilege for getting or setting SACLs.
     if (!win32_enable_privilege(SE_SECURITY_NAME))
-        return;
+	return;
 #endif
 }
 #ifdef _MSC_VER
@@ -6349,7 +6349,7 @@ termcap_mode_end(void)
 
     // Switch back to main screen buffer.
     if (exiting && use_alternate_screen_buffer)
-        vtp_printf("\033[?1049l");
+	vtp_printf("\033[?1049l");
 
     if (!USE_WT && (p_rs || exiting))
     {

--- a/src/popupmenu.c
+++ b/src/popupmenu.c
@@ -228,7 +228,7 @@ pum_display(
 	pum_size = size;
 	pum_compute_size();
 	max_width = pum_base_width;
-        if (p_pmw > 0 && max_width > p_pmw)
+	if (p_pmw > 0 && max_width > p_pmw)
 	    max_width = p_pmw;
 
 	// Calculate column
@@ -785,61 +785,61 @@ pum_process_item(
 
     for ( ; ; MB_PTR_ADV(p))
     {
-        if (s == NULL)
-            s = p;
-        w = ptr2cells(p);
-        if (*p != NUL && *p != TAB && *totwidth_ptr + w <= pum_width)
-        {
-            width += w;
-            continue;
-        }
+	if (s == NULL)
+	    s = p;
+	w = ptr2cells(p);
+	if (*p != NUL && *p != TAB && *totwidth_ptr + w <= pum_width)
+	{
+	    width += w;
+	    continue;
+	}
 
-        // Display the text that fits or comes before a Tab.
-        // First convert it to printable characters.
-        char_u  *st;
-        int     *attrs = NULL;
-        int     saved = *p;
+	// Display the text that fits or comes before a Tab.
+	// First convert it to printable characters.
+	char_u  *st;
+	int     *attrs = NULL;
+	int     saved = *p;
 
-        if (saved != NUL)
-            *p = NUL;
-        st = transstr(s);
-        if (saved != NUL)
-            *p = saved;
+	if (saved != NUL)
+	    *p = NUL;
+	st = transstr(s);
+	if (saved != NUL)
+	    *p = saved;
 
-        if (item_type == CPT_ABBR)
-            attrs = pum_compute_text_attrs(st, hlf,
-                      pum_array[idx].pum_user_abbr_hlattr);
+	if (item_type == CPT_ABBR)
+	    attrs = pum_compute_text_attrs(st, hlf,
+		      pum_array[idx].pum_user_abbr_hlattr);
 #ifdef FEAT_RIGHTLEFT
-        if (pum_rl)
-            col = pum_display_rtl_text(row, col, st, attr, attrs,
-                    width, pum_width, *totwidth_ptr, next_isempty);
-        else
+	if (pum_rl)
+	    col = pum_display_rtl_text(row, col, st, attr, attrs,
+		    width, pum_width, *totwidth_ptr, next_isempty);
+	else
 #endif
-            col = pum_display_ltr_text(row, col, st, attr, attrs,
-                    width, pum_width, *totwidth_ptr, next_isempty);
+	    col = pum_display_ltr_text(row, col, st, attr, attrs,
+		    width, pum_width, *totwidth_ptr, next_isempty);
 
-        if (attrs != NULL)
-            VIM_CLEAR(attrs);
+	if (attrs != NULL)
+	    VIM_CLEAR(attrs);
 
-        if (*p != TAB)
-            break;
+	if (*p != TAB)
+	    break;
 
-        // Display two spaces for a Tab.
+	// Display two spaces for a Tab.
 #ifdef FEAT_RIGHTLEFT
-        if (pum_rl)
-        {
-            screen_puts_len((char_u *)"  ", 2, row, col - 1, attr);
-            col -= 2;
-        }
-        else
+	if (pum_rl)
+	{
+	    screen_puts_len((char_u *)"  ", 2, row, col - 1, attr);
+	    col -= 2;
+	}
+	else
 #endif
-        {
-            screen_puts_len((char_u *)"  ", 2, row, col, attr);
-            col += 2;
-        }
-        *totwidth_ptr += 2;
-        s = NULL;  // start text at next char
-        width = 0;
+	{
+	    screen_puts_len((char_u *)"  ", 2, row, col, attr);
+	    col += 2;
+	}
+	*totwidth_ptr += 2;
+	s = NULL;  // start text at next char
+	width = 0;
     }
 
     return col;
@@ -856,7 +856,7 @@ pum_draw_scrollbar(
 	int	thumb_height)
 {
     if (pum_scrollbar <= 0)
-        return;
+	return;
 
     int attr = (i >= thumb_pos && i < thumb_pos + thumb_height) ?
 			highlight_attr[HLF_PST] : highlight_attr[HLF_PSB];

--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -3592,8 +3592,8 @@ popup_do_filter(int c)
     {
 	popup_reset_handled(POPUP_HANDLED_2);
 	wp = find_next_popup(FALSE, POPUP_HANDLED_2);
-        if (wp != NULL)
-        {
+	if (wp != NULL)
+	{
 	    popup_close_with_retval(wp, -1);
 	    res = TRUE;
 	}

--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -2268,12 +2268,12 @@ qf_add_entry(
     if (buf != NULL &&
 	buf->b_ffname != NULL && fullname != NULL)
     {
-        if (fnamecmp(fullname, buf->b_ffname) != 0)
-        {
-            p = shorten_fname1(fullname);
-            if (p != NULL)
+	if (fnamecmp(fullname, buf->b_ffname) != 0)
+	{
+	    p = shorten_fname1(fullname);
+	    if (p != NULL)
 		qfp->qf_fname = vim_strsave(p);
-        }
+	}
     }
     vim_free(fullname);
     if ((qfp->qf_text = vim_strsave(mesg)) == NULL)
@@ -7893,7 +7893,7 @@ qf_add_entries(
 	{
 	    entry_to_select = entry;
 	    entry_to_select_index = qfl->qf_count;
-        }
+	}
     }
 
     // Check if any valid error entries are added to the list.

--- a/src/search.c
+++ b/src/search.c
@@ -4518,13 +4518,13 @@ fuzzy_match_compute_score(
 	}
 
 	// Check exact match condition
-        if (currIdx != (int_u)i)
+	if (currIdx != (int_u)i)
 	    is_exact_match = FALSE;
     }
 
     // Boost score for exact matches
     if (is_exact_match && numMatches == strSz)
-        score += EXACT_MATCH_BONUS;
+	score += EXACT_MATCH_BONUS;
 
     return score;
 }
@@ -5265,7 +5265,7 @@ fuzzy_match_str_in_line(
     char_u	*line_end = NULL;
 
     if (str == NULL || pat == NULL)
-        return found;
+	return found;
     line_end = find_line_end(str);
 
     while (str < line_end)
@@ -5333,12 +5333,12 @@ search_for_fuzzy_match(
     int		whole_line = ctrl_x_mode_whole_line();
 
     if (buf == curbuf)
-        circly_end = *start_pos;
+	circly_end = *start_pos;
     else
     {
-        circly_end.lnum = buf->b_ml.ml_line_count;
-        circly_end.col = 0;
-        circly_end.coladd = 0;
+	circly_end.lnum = buf->b_ml.ml_line_count;
+	circly_end.col = 0;
+	circly_end.coladd = 0;
     }
 
     if (whole_line && start_pos->lnum != pos->lnum)

--- a/src/sign.c
+++ b/src/sign.c
@@ -45,17 +45,17 @@ static void sign_undefine(sign_T *sp, sign_T *sp_prev);
 
 static char *cmds[] = { "define",
 # define SIGNCMD_DEFINE 0
-                        "undefine",
+			"undefine",
 # define SIGNCMD_UNDEFINE 1
-                        "list",
+			"list",
 # define SIGNCMD_LIST 2
-                        "place",
+			"place",
 # define SIGNCMD_PLACE 3
-                        "unplace",
+			"unplace",
 # define SIGNCMD_UNPLACE 4
-                        "jump",
+			"jump",
 # define SIGNCMD_JUMP 5
-                        NULL
+			NULL
 # define SIGNCMD_LAST 6
 };
 
@@ -87,21 +87,21 @@ sign_group_ref(char_u *groupname)
 
     if (HASHITEM_EMPTY(hi))
     {
-        // new group
-        group = alloc(offsetof(signgroup_T, sg_name) + STRLEN(groupname) + 1);
-        if (group == NULL)
-            return NULL;
+	// new group
+	group = alloc(offsetof(signgroup_T, sg_name) + STRLEN(groupname) + 1);
+	if (group == NULL)
+	    return NULL;
 
-        STRCPY(group->sg_name, groupname);
-        group->sg_refcount = 1;
-        group->sg_next_sign_id = 1;
-        hash_add_item(&sg_table, hi, group->sg_name, hash);
+	STRCPY(group->sg_name, groupname);
+	group->sg_refcount = 1;
+	group->sg_next_sign_id = 1;
+	hash_add_item(&sg_table, hi, group->sg_name, hash);
     }
     else
     {
-        // existing group
-        group = HI2SG(hi);
-        group->sg_refcount++;
+	// existing group
+	group = HI2SG(hi);
+	group->sg_refcount++;
     }
 
     return group;
@@ -116,15 +116,15 @@ sign_group_unref(char_u *groupname)
 {
     hashitem_T *hi = hash_find(&sg_table, groupname);
     if (HASHITEM_EMPTY(hi))
-        return;
+	return;
 
     signgroup_T *group = HI2SG(hi);
     group->sg_refcount--;
     if (group->sg_refcount == 0)
     {
-        // All the signs in this group are removed
-        hash_remove(&sg_table, hi, "sign remove");
-        vim_free(group);
+	// All the signs in this group are removed
+	hash_remove(&sg_table, hi, "sign remove");
+	vim_free(group);
     }
 }
 
@@ -137,9 +137,9 @@ static int
 sign_in_group(sign_entry_T *sign, char_u *group)
 {
     return ((group != NULL && STRCMP(group, "*") == 0) ||
-            (group == NULL && sign->se_group == NULL) ||
-            (group != NULL && sign->se_group != NULL &&
-             STRCMP(group, sign->se_group->sg_name) == 0));
+	    (group == NULL && sign->se_group == NULL) ||
+	    (group != NULL && sign->se_group != NULL &&
+	     STRCMP(group, sign->se_group->sg_name) == 0));
 }
 
 /*
@@ -150,7 +150,7 @@ static int
 sign_group_for_window(sign_entry_T *sign, win_T *wp)
 {
     int for_popup = sign->se_group != NULL &&
-                    STRNCMP("PopUp", sign->se_group->sg_name, 5) == 0;
+		    STRNCMP("PopUp", sign->se_group->sg_name, 5) == 0;
 
     return WIN_IS_POPUP(wp) ? for_popup : !for_popup;
 }
@@ -167,31 +167,31 @@ sign_group_get_next_signid(buf_T *buf, char_u *groupname)
 
     if (groupname != NULL)
     {
-        hashitem_T *hi = hash_find(&sg_table, groupname);
-        if (HASHITEM_EMPTY(hi))
-            return id;
-        group = HI2SG(hi);
+	hashitem_T *hi = hash_find(&sg_table, groupname);
+	if (HASHITEM_EMPTY(hi))
+	    return id;
+	group = HI2SG(hi);
     }
 
     // Search for the next usable sign identifier
     int found = FALSE;
     while (!found)
     {
-        if (group == NULL)
-            id = next_sign_id++; // global group
-        else
-            id = group->sg_next_sign_id++;
+	if (group == NULL)
+	    id = next_sign_id++; // global group
+	else
+	    id = group->sg_next_sign_id++;
 
-        // Check whether this sign is already placed in the buffer
-        found = TRUE;
-        FOR_ALL_SIGNS_IN_BUF(buf, sign)
-        {
-            if (id == sign->se_id && sign_in_group(sign, groupname))
-            {
-                found = FALSE; // sign identifier is in use
-                break;
-            }
-        }
+	// Check whether this sign is already placed in the buffer
+	found = TRUE;
+	FOR_ALL_SIGNS_IN_BUF(buf, sign)
+	{
+	    if (id == sign->se_id && sign_in_group(sign, groupname))
+	    {
+		found = FALSE; // sign identifier is in use
+		break;
+	    }
+	}
     }
 
     return id;
@@ -203,18 +203,18 @@ sign_group_get_next_signid(buf_T *buf, char_u *groupname)
  */
 static void
 insert_sign(buf_T *buf, // buffer to store sign in
-            sign_entry_T *prev, // previous sign entry
-            sign_entry_T *next, // next sign entry
-            int id, // sign ID
-            char_u *group, // sign group; NULL for global group
-            int prio, // sign priority
-            linenr_T lnum, // line number which gets the mark
-            int typenr) // typenr of sign we are adding
+	    sign_entry_T *prev, // previous sign entry
+	    sign_entry_T *next, // next sign entry
+	    int id, // sign ID
+	    char_u *group, // sign group; NULL for global group
+	    int prio, // sign priority
+	    linenr_T lnum, // line number which gets the mark
+	    int typenr) // typenr of sign we are adding
 {
     sign_entry_T *newsign =
-        lalloc_id(sizeof(sign_entry_T), FALSE, aid_insert_sign);
+	lalloc_id(sizeof(sign_entry_T), FALSE, aid_insert_sign);
     if (newsign == NULL)
-        return;
+	return;
 
     newsign->se_id = id;
     newsign->se_lnum = lnum;
@@ -222,44 +222,44 @@ insert_sign(buf_T *buf, // buffer to store sign in
 
     if (group != NULL)
     {
-        newsign->se_group = sign_group_ref(group);
-        if (newsign->se_group == NULL)
-        {
-            vim_free(newsign);
-            return;
-        }
+	newsign->se_group = sign_group_ref(group);
+	if (newsign->se_group == NULL)
+	{
+	    vim_free(newsign);
+	    return;
+	}
     }
     else
     {
-        newsign->se_group = NULL;
+	newsign->se_group = NULL;
     }
 
     newsign->se_priority = prio;
     newsign->se_next = next;
     newsign->se_prev = prev;
     if (next != NULL)
-        next->se_prev = newsign;
+	next->se_prev = newsign;
 
     if (prev == NULL)
     {
-        // When adding first sign need to redraw the windows to create the
-        // column for signs.
-        if (buf->b_signlist == NULL)
-        {
-            redraw_buf_later(buf, UPD_NOT_VALID);
-            changed_line_abv_curs();
-        }
+	// When adding first sign need to redraw the windows to create the
+	// column for signs.
+	if (buf->b_signlist == NULL)
+	{
+	    redraw_buf_later(buf, UPD_NOT_VALID);
+	    changed_line_abv_curs();
+	}
 
-        // first sign in signlist
-        buf->b_signlist = newsign;
+	// first sign in signlist
+	buf->b_signlist = newsign;
 # ifdef FEAT_NETBEANS_INTG
-        if (netbeans_active())
-            buf->b_has_sign_column = TRUE;
+	if (netbeans_active())
+	    buf->b_has_sign_column = TRUE;
 # endif
     }
     else
     {
-        prev->se_next = newsign;
+	prev->se_next = newsign;
     }
 }
 
@@ -268,17 +268,17 @@ insert_sign(buf_T *buf, // buffer to store sign in
  */
 static void
 insert_sign_by_lnum_prio(buf_T *buf, // buffer to store sign in
-                         sign_entry_T *prev, // previous sign entry
-                         int id, // sign ID
-                         char_u *group, // sign group; NULL for global group
-                         int prio, // sign priority
-                         linenr_T lnum, // line number which gets the mark
-                         int typenr) // typenr of sign we are adding
+			 sign_entry_T *prev, // previous sign entry
+			 int id, // sign ID
+			 char_u *group, // sign group; NULL for global group
+			 int prio, // sign priority
+			 linenr_T lnum, // line number which gets the mark
+			 int typenr) // typenr of sign we are adding
 {
     // keep signs sorted by lnum and by priority: insert new sign at
     // the proper position in the list for this lnum.
     while (prev != NULL && prev->se_lnum == lnum && prev->se_priority <= prio)
-        prev = prev->se_prev;
+	prev = prev->se_prev;
 
     sign_entry_T *sign = (prev == NULL) ? buf->b_signlist : prev->se_next;
 
@@ -293,8 +293,8 @@ find_sign_by_typenr(int typenr)
 {
     sign_T *sp = NULL;
     FOR_ALL_SIGNS(sp)
-        if (sp->sn_typenr == typenr)
-            return sp;
+	if (sp->sn_typenr == typenr)
+	    return sp;
     return NULL;
 }
 
@@ -306,8 +306,8 @@ sign_typenr2name(int typenr)
 {
     sign_T *sp = NULL;
     FOR_ALL_SIGNS(sp)
-        if (sp->sn_typenr == typenr)
-            return sp->sn_name;
+	if (sp->sn_typenr == typenr)
+	    return sp->sn_name;
     return (char_u *)_("[Deleted]");
 }
 
@@ -319,12 +319,12 @@ sign_get_info(sign_entry_T *sign)
 {
     dict_T *d = dict_alloc_id(aid_sign_getinfo);
     if (d == NULL)
-        return NULL;
+	return NULL;
 
     dict_add_number(d, "id", sign->se_id);
     dict_add_string(d, "group",
-                    (sign->se_group == NULL) ? (char_u *)""
-                                             : sign->se_group->sg_name);
+		    (sign->se_group == NULL) ? (char_u *)""
+					     : sign->se_group->sg_name);
     dict_add_number(d, "lnum", sign->se_lnum);
     dict_add_string(d, "name", sign_typenr2name(sign->se_typenr));
     dict_add_number(d, "priority", sign->se_priority);
@@ -343,10 +343,10 @@ sign_sort_by_prio_on_line(buf_T *buf, sign_entry_T *sign)
     // If there is only one sign in the buffer or only one sign on the line or
     // the sign is already sorted by priority, then return.
     if ((sign->se_prev == NULL || sign->se_prev->se_lnum != sign->se_lnum ||
-         sign->se_prev->se_priority > sign->se_priority) &&
-        (sign->se_next == NULL || sign->se_next->se_lnum != sign->se_lnum ||
-         sign->se_next->se_priority < sign->se_priority))
-        return;
+	 sign->se_prev->se_priority > sign->se_priority) &&
+	(sign->se_next == NULL || sign->se_next->se_lnum != sign->se_lnum ||
+	 sign->se_next->se_priority < sign->se_priority))
+	return;
 
     // One or more signs on the same line as 'sign'
     // Find a sign after which 'sign' should be inserted
@@ -354,28 +354,28 @@ sign_sort_by_prio_on_line(buf_T *buf, sign_entry_T *sign)
     // First search backward for a sign with higher priority on the same line
     sign_entry_T *p = sign;
     while (p->se_prev != NULL && p->se_prev->se_lnum == sign->se_lnum &&
-           p->se_prev->se_priority <= sign->se_priority)
-        p = p->se_prev;
+	   p->se_prev->se_priority <= sign->se_priority)
+	p = p->se_prev;
 
     if (p == sign)
     {
-        // Sign not found. Search forward for a sign with priority just before
-        // 'sign'.
-        p = sign->se_next;
-        while (p->se_next != NULL && p->se_next->se_lnum == sign->se_lnum &&
-               p->se_next->se_priority > sign->se_priority)
-            p = p->se_next;
+	// Sign not found. Search forward for a sign with priority just before
+	// 'sign'.
+	p = sign->se_next;
+	while (p->se_next != NULL && p->se_next->se_lnum == sign->se_lnum &&
+	       p->se_next->se_priority > sign->se_priority)
+	    p = p->se_next;
     }
 
     // Remove 'sign' from the list
     if (buf->b_signlist == sign)
-        buf->b_signlist = sign->se_next;
+	buf->b_signlist = sign->se_next;
 
     if (sign->se_prev != NULL)
-        sign->se_prev->se_next = sign->se_next;
+	sign->se_prev->se_next = sign->se_next;
 
     if (sign->se_next != NULL)
-        sign->se_next->se_prev = sign->se_prev;
+	sign->se_next->se_prev = sign->se_prev;
 
     sign->se_prev = NULL;
     sign->se_next = NULL;
@@ -383,24 +383,24 @@ sign_sort_by_prio_on_line(buf_T *buf, sign_entry_T *sign)
     // Re-insert 'sign' at the right place
     if (p->se_priority <= sign->se_priority)
     {
-        // 'sign' has a higher priority and should be inserted before 'p'
-        sign->se_prev = p->se_prev;
-        sign->se_next = p;
-        p->se_prev = sign;
-        if (sign->se_prev != NULL)
-            sign->se_prev->se_next = sign;
+	// 'sign' has a higher priority and should be inserted before 'p'
+	sign->se_prev = p->se_prev;
+	sign->se_next = p;
+	p->se_prev = sign;
+	if (sign->se_prev != NULL)
+	    sign->se_prev->se_next = sign;
 
-        if (buf->b_signlist == p)
-            buf->b_signlist = sign;
+	if (buf->b_signlist == p)
+	    buf->b_signlist = sign;
     }
     else
     {
-        // 'sign' has a lower priority and should be inserted after 'p'
-        sign->se_prev = p;
-        sign->se_next = p->se_next;
-        p->se_next = sign;
-        if (sign->se_next != NULL)
-            sign->se_next->se_prev = sign;
+	// 'sign' has a lower priority and should be inserted after 'p'
+	sign->se_prev = p;
+	sign->se_next = p->se_next;
+	p->se_next = sign;
+	if (sign->se_next != NULL)
+	    sign->se_next->se_prev = sign;
     }
 }
 
@@ -409,32 +409,32 @@ sign_sort_by_prio_on_line(buf_T *buf, sign_entry_T *sign)
  */
 static void
 buf_addsign(buf_T *buf, // buffer to store sign in
-            int id, // sign ID
-            char_u *groupname, // sign group
-            int prio, // sign priority
-            linenr_T lnum, // line number which gets the mark
-            int typenr) // typenr of sign we are adding
+	    int id, // sign ID
+	    char_u *groupname, // sign group
+	    int prio, // sign priority
+	    linenr_T lnum, // line number which gets the mark
+	    int typenr) // typenr of sign we are adding
 {
     sign_entry_T *sign = NULL; // a sign in the signlist
     sign_entry_T *prev = NULL; // the previous sign
     FOR_ALL_SIGNS_IN_BUF(buf, sign)
     {
-        if (lnum == sign->se_lnum && id == sign->se_id &&
-            sign_in_group(sign, groupname))
-        {
-            // Update an existing sign
-            sign->se_typenr = typenr;
-            sign->se_priority = prio;
-            sign_sort_by_prio_on_line(buf, sign);
-            return;
-        }
-        else if (lnum < sign->se_lnum)
-        {
-            insert_sign_by_lnum_prio(buf, prev, id, groupname, prio, lnum,
-                                     typenr);
-            return;
-        }
-        prev = sign;
+	if (lnum == sign->se_lnum && id == sign->se_id &&
+	    sign_in_group(sign, groupname))
+	{
+	    // Update an existing sign
+	    sign->se_typenr = typenr;
+	    sign->se_priority = prio;
+	    sign_sort_by_prio_on_line(buf, sign);
+	    return;
+	}
+	else if (lnum < sign->se_lnum)
+	{
+	    insert_sign_by_lnum_prio(buf, prev, id, groupname, prio, lnum,
+				     typenr);
+	    return;
+	}
+	prev = sign;
     }
 
     insert_sign_by_lnum_prio(buf, prev, id, groupname, prio, lnum, typenr);
@@ -446,21 +446,21 @@ buf_addsign(buf_T *buf, // buffer to store sign in
  */
 static linenr_T
 buf_change_sign_type(buf_T *buf, // buffer to store sign in
-                     int markId, // sign ID
-                     char_u *group, // sign group
-                     int typenr, // typenr of sign we are adding
-                     int prio) // sign priority
+		     int markId, // sign ID
+		     char_u *group, // sign group
+		     int typenr, // typenr of sign we are adding
+		     int prio) // sign priority
 {
     sign_entry_T *sign = NULL; // a sign in the signlist
     FOR_ALL_SIGNS_IN_BUF(buf, sign)
     {
-        if (sign->se_id == markId && sign_in_group(sign, group))
-        {
-            sign->se_typenr = typenr;
-            sign->se_priority = prio;
-            sign_sort_by_prio_on_line(buf, sign);
-            return sign->se_lnum;
-        }
+	if (sign->se_id == markId && sign_in_group(sign, group))
+	{
+	    sign->se_typenr = typenr;
+	    sign->se_priority = prio;
+	    sign_sort_by_prio_on_line(buf, sign);
+	    return sign->se_lnum;
+	}
     }
 
     return (linenr_T)0;
@@ -480,73 +480,73 @@ buf_get_signattrs(win_T *wp, linenr_T lnum, sign_attrs_T *sattr)
     sign_entry_T *sign = NULL;
     FOR_ALL_SIGNS_IN_BUF(buf, sign)
     {
-        // Signs are sorted by line number in the buffer. No need to check
-        // for signs after the specified line number 'lnum'.
-        if (sign->se_lnum > lnum)
-            break;
+	// Signs are sorted by line number in the buffer. No need to check
+	// for signs after the specified line number 'lnum'.
+	if (sign->se_lnum > lnum)
+	    break;
 
-        if (sign->se_lnum == lnum
+	if (sign->se_lnum == lnum
 # ifdef FEAT_PROP_POPUP
-            && sign_group_for_window(sign, wp)
+	    && sign_group_for_window(sign, wp)
 # endif
-        )
-        {
-            sattr->sat_typenr = sign->se_typenr;
-            sign_T *sp = find_sign_by_typenr(sign->se_typenr);
-            if (sp == NULL)
-                return FALSE;
+	)
+	{
+	    sattr->sat_typenr = sign->se_typenr;
+	    sign_T *sp = find_sign_by_typenr(sign->se_typenr);
+	    if (sp == NULL)
+		return FALSE;
 
 # ifdef FEAT_SIGN_ICONS
-            sattr->sat_icon = sp->sn_image;
+	    sattr->sat_icon = sp->sn_image;
 # endif
-            sattr->sat_text = sp->sn_text;
+	    sattr->sat_text = sp->sn_text;
 
-            if (sattr->sat_text != NULL && sp->sn_text_hl > 0)
-                sattr->sat_texthl = syn_id2attr(sp->sn_text_hl);
+	    if (sattr->sat_text != NULL && sp->sn_text_hl > 0)
+		sattr->sat_texthl = syn_id2attr(sp->sn_text_hl);
 
-            if (sp->sn_line_hl > 0)
-                sattr->sat_linehl = syn_id2attr(sp->sn_line_hl);
+	    if (sp->sn_line_hl > 0)
+		sattr->sat_linehl = syn_id2attr(sp->sn_line_hl);
 
-            if (sp->sn_cul_hl > 0)
-                sattr->sat_culhl = syn_id2attr(sp->sn_cul_hl);
+	    if (sp->sn_cul_hl > 0)
+		sattr->sat_culhl = syn_id2attr(sp->sn_cul_hl);
 
-            if (sp->sn_num_hl > 0)
-                sattr->sat_numhl = syn_id2attr(sp->sn_num_hl);
+	    if (sp->sn_num_hl > 0)
+		sattr->sat_numhl = syn_id2attr(sp->sn_num_hl);
 
-            sattr->sat_priority = sign->se_priority;
+	    sattr->sat_priority = sign->se_priority;
 
-            // If there is another sign next with the same priority, may
-            // combine the text and the line highlighting.
-            if (sign->se_next != NULL &&
-                sign->se_next->se_priority == sign->se_priority &&
-                sign->se_next->se_lnum == sign->se_lnum)
-            {
-                sign_T *next_sp = find_sign_by_typenr(sign->se_next->se_typenr);
-                if (next_sp == NULL)
-                    return FALSE;
+	    // If there is another sign next with the same priority, may
+	    // combine the text and the line highlighting.
+	    if (sign->se_next != NULL &&
+		sign->se_next->se_priority == sign->se_priority &&
+		sign->se_next->se_lnum == sign->se_lnum)
+	    {
+		sign_T *next_sp = find_sign_by_typenr(sign->se_next->se_typenr);
+		if (next_sp == NULL)
+		    return FALSE;
 
-                if (sattr->sat_icon == NULL && sattr->sat_text == NULL)
-                {
+		if (sattr->sat_icon == NULL && sattr->sat_text == NULL)
+		{
 # ifdef FEAT_SIGN_ICONS
-                    sattr->sat_icon = next_sp->sn_image;
+		    sattr->sat_icon = next_sp->sn_image;
 # endif
-                    sattr->sat_text = next_sp->sn_text;
-                }
+		    sattr->sat_text = next_sp->sn_text;
+		}
 
-                if (sp->sn_text_hl <= 0 && next_sp->sn_text_hl > 0)
-                    sattr->sat_texthl = syn_id2attr(next_sp->sn_text_hl);
+		if (sp->sn_text_hl <= 0 && next_sp->sn_text_hl > 0)
+		    sattr->sat_texthl = syn_id2attr(next_sp->sn_text_hl);
 
-                if (sp->sn_line_hl <= 0 && next_sp->sn_line_hl > 0)
-                    sattr->sat_linehl = syn_id2attr(next_sp->sn_line_hl);
+		if (sp->sn_line_hl <= 0 && next_sp->sn_line_hl > 0)
+		    sattr->sat_linehl = syn_id2attr(next_sp->sn_line_hl);
 
-                if (sp->sn_cul_hl <= 0 && next_sp->sn_cul_hl > 0)
-                    sattr->sat_culhl = syn_id2attr(next_sp->sn_cul_hl);
+		if (sp->sn_cul_hl <= 0 && next_sp->sn_cul_hl > 0)
+		    sattr->sat_culhl = syn_id2attr(next_sp->sn_cul_hl);
 
-                if (sp->sn_num_hl <= 0 && next_sp->sn_num_hl > 0)
-                    sattr->sat_numhl = syn_id2attr(next_sp->sn_num_hl);
-            }
-            return TRUE;
-        }
+		if (sp->sn_num_hl <= 0 && next_sp->sn_num_hl > 0)
+		    sattr->sat_numhl = syn_id2attr(next_sp->sn_num_hl);
+	    }
+	    return TRUE;
+	}
     }
     return FALSE;
 }
@@ -563,9 +563,9 @@ buf_get_signattrs(win_T *wp, linenr_T lnum, sign_attrs_T *sattr)
  */
 linenr_T
 buf_delsign(buf_T *buf, // buffer sign is stored in
-            linenr_T atlnum, // sign at this line, 0 - at any line
-            int id, // sign id
-            char_u *group) // sign group
+	    linenr_T atlnum, // sign at this line, 0 - at any line
+	    int id, // sign id
+	    char_u *group) // sign group
 {
     // pointer to pointer to current sign
     sign_entry_T **lastp = &buf->b_signlist;
@@ -574,44 +574,44 @@ buf_delsign(buf_T *buf, // buffer sign is stored in
 
     for (sign_entry_T *sign = buf->b_signlist; sign != NULL; sign = next)
     {
-        next = sign->se_next;
+	next = sign->se_next;
 
-        if ((id == 0 || sign->se_id == id) &&
-            (atlnum == 0 || sign->se_lnum == atlnum) &&
-            sign_in_group(sign, group))
-        {
-            *lastp = next;
-            if (next != NULL)
-                next->se_prev = sign->se_prev;
+	if ((id == 0 || sign->se_id == id) &&
+	    (atlnum == 0 || sign->se_lnum == atlnum) &&
+	    sign_in_group(sign, group))
+	{
+	    *lastp = next;
+	    if (next != NULL)
+		next->se_prev = sign->se_prev;
 
-            lnum = sign->se_lnum;
+	    lnum = sign->se_lnum;
 
-            if (sign->se_group != NULL)
-                sign_group_unref(sign->se_group->sg_name);
+	    if (sign->se_group != NULL)
+		sign_group_unref(sign->se_group->sg_name);
 
-            vim_free(sign);
-            redraw_buf_line_later(buf, lnum);
+	    vim_free(sign);
+	    redraw_buf_line_later(buf, lnum);
 
-            // Check whether only one sign needs to be deleted
-            // If deleting a sign with a specific identifier in a particular
-            // group or deleting any sign at a particular line number, delete
-            // only one sign.
-            if (group == NULL || (*group != '*' && id != 0) ||
-                (*group == '*' && atlnum != 0))
-                break;
-        }
-        else
-        {
-            lastp = &sign->se_next;
-        }
+	    // Check whether only one sign needs to be deleted
+	    // If deleting a sign with a specific identifier in a particular
+	    // group or deleting any sign at a particular line number, delete
+	    // only one sign.
+	    if (group == NULL || (*group != '*' && id != 0) ||
+		(*group == '*' && atlnum != 0))
+		break;
+	}
+	else
+	{
+	    lastp = &sign->se_next;
+	}
     }
 
     // When deleting the last sign the cursor position may change, because the
     // sign columns no longer shows.  And the 'signcolumn' may be hidden.
     if (buf->b_signlist == NULL)
     {
-        redraw_buf_later(buf, UPD_NOT_VALID);
-        changed_line_abv_curs();
+	redraw_buf_later(buf, UPD_NOT_VALID);
+	changed_line_abv_curs();
     }
 
     return lnum;
@@ -624,13 +624,13 @@ buf_delsign(buf_T *buf, // buffer sign is stored in
  */
 int
 buf_findsign(buf_T *buf, // buffer to store sign in
-             int id, // sign ID
-             char_u *group) // sign group
+	     int id, // sign ID
+	     char_u *group) // sign group
 {
     sign_entry_T *sign = NULL; // a sign in the signlist
     FOR_ALL_SIGNS_IN_BUF(buf, sign)
-        if (sign->se_id == id && sign_in_group(sign, group))
-            return sign->se_lnum;
+	if (sign->se_id == id && sign_in_group(sign, group))
+	    return sign->se_lnum;
 
     return 0;
 }
@@ -641,19 +641,19 @@ buf_findsign(buf_T *buf, // buffer to store sign in
  */
 static sign_entry_T *
 buf_getsign_at_line(buf_T *buf, // buffer whose sign we are searching for
-                    linenr_T lnum, // line number of sign
-                    char_u *groupname) // sign group name
+		    linenr_T lnum, // line number of sign
+		    char_u *groupname) // sign group name
 {
     sign_entry_T *sign = NULL; // a sign in the signlist
     FOR_ALL_SIGNS_IN_BUF(buf, sign)
     {
-        // Signs are sorted by line number in the buffer. No need to check
-        // for signs after the specified line number 'lnum'.
-        if (sign->se_lnum > lnum)
-            break;
+	// Signs are sorted by line number in the buffer. No need to check
+	// for signs after the specified line number 'lnum'.
+	if (sign->se_lnum > lnum)
+	    break;
 
-        if (sign->se_lnum == lnum && sign_in_group(sign, groupname))
-            return sign;
+	if (sign->se_lnum == lnum && sign_in_group(sign, groupname))
+	    return sign;
     }
 
     return NULL;
@@ -664,13 +664,13 @@ buf_getsign_at_line(buf_T *buf, // buffer whose sign we are searching for
  */
 int
 buf_findsign_id(buf_T *buf, // buffer whose sign we are searching for
-                linenr_T lnum, // line number of sign
-                char_u *groupname) // sign group name
+		linenr_T lnum, // line number of sign
+		char_u *groupname) // sign group name
 {
     // a sign in the signlist
     sign_entry_T *sign = buf_getsign_at_line(buf, lnum, groupname);
     if (sign != NULL)
-        return sign->se_id;
+	return sign->se_id;
 
     return 0;
 }
@@ -681,19 +681,19 @@ buf_findsign_id(buf_T *buf, // buffer whose sign we are searching for
  */
 int
 buf_findsigntype_id(buf_T *buf, // buffer whose sign we are searching for
-                    linenr_T lnum, // line number of sign
-                    int typenr) // sign type number
+		    linenr_T lnum, // line number of sign
+		    int typenr) // sign type number
 {
     sign_entry_T *sign = NULL; // a sign in the signlist
     FOR_ALL_SIGNS_IN_BUF(buf, sign)
     {
-        // Signs are sorted by line number in the buffer. No need to check
-        // for signs after the specified line number 'lnum'.
-        if (sign->se_lnum > lnum)
-            break;
+	// Signs are sorted by line number in the buffer. No need to check
+	// for signs after the specified line number 'lnum'.
+	if (sign->se_lnum > lnum)
+	    break;
 
-        if (sign->se_lnum == lnum && sign->se_typenr == typenr)
-            return sign->se_id;
+	if (sign->se_lnum == lnum && sign->se_typenr == typenr)
+	    return sign->se_id;
     }
 
     return 0;
@@ -710,13 +710,13 @@ buf_signcount(buf_T *buf, linenr_T lnum)
     sign_entry_T *sign = NULL; // a sign in the signlist
     FOR_ALL_SIGNS_IN_BUF(buf, sign)
     {
-        // Signs are sorted by line number in the buffer. No need to check
-        // for signs after the specified line number 'lnum'.
-        if (sign->se_lnum > lnum)
-            break;
+	// Signs are sorted by line number in the buffer. No need to check
+	// for signs after the specified line number 'lnum'.
+	if (sign->se_lnum > lnum)
+	    break;
 
-        if (sign->se_lnum == lnum && sign_get_image(sign->se_typenr) != NULL)
-            count++;
+	if (sign->se_lnum == lnum && sign_get_image(sign->se_typenr) != NULL)
+	    count++;
     }
 
     return count;
@@ -735,8 +735,8 @@ buf_delete_signs(buf_T *buf, char_u *group)
     // sign column. Not when curwin is NULL (this means we're exiting).
     if (buf->b_signlist != NULL && curwin != NULL)
     {
-        redraw_buf_later(buf, UPD_NOT_VALID);
-        changed_line_abv_curs();
+	redraw_buf_later(buf, UPD_NOT_VALID);
+	changed_line_abv_curs();
     }
 
     // pointer to pointer to current sign
@@ -745,23 +745,23 @@ buf_delete_signs(buf_T *buf, char_u *group)
 
     for (sign_entry_T *sign = buf->b_signlist; sign != NULL; sign = next)
     {
-        next = sign->se_next;
-        if (sign_in_group(sign, group))
-        {
-            *lastp = next;
+	next = sign->se_next;
+	if (sign_in_group(sign, group))
+	{
+	    *lastp = next;
 
-            if (next != NULL)
-                next->se_prev = sign->se_prev;
+	    if (next != NULL)
+		next->se_prev = sign->se_prev;
 
-            if (sign->se_group != NULL)
-                sign_group_unref(sign->se_group->sg_name);
+	    if (sign->se_group != NULL)
+		sign_group_unref(sign->se_group->sg_name);
 
-            vim_free(sign);
-        }
-        else
-        {
-            lastp = &sign->se_next;
-        }
+	    vim_free(sign);
+	}
+	else
+	{
+	    lastp = &sign->se_next;
+	}
     }
 }
 
@@ -780,41 +780,41 @@ sign_list_placed(buf_T *rbuf, char_u *sign_group)
     buf_T *buf = (rbuf == NULL) ? firstbuf : rbuf;
     while (buf != NULL && !got_int)
     {
-        if (buf->b_signlist != NULL)
-        {
-            vim_snprintf(lbuf, MSG_BUF_LEN, _("Signs for %s:"), buf->b_fname);
-            msg_puts_attr(lbuf, HL_ATTR(HLF_D));
-            msg_putchar('\n');
-        }
+	if (buf->b_signlist != NULL)
+	{
+	    vim_snprintf(lbuf, MSG_BUF_LEN, _("Signs for %s:"), buf->b_fname);
+	    msg_puts_attr(lbuf, HL_ATTR(HLF_D));
+	    msg_putchar('\n');
+	}
 
-        sign_entry_T *sign = NULL;
-        FOR_ALL_SIGNS_IN_BUF(buf, sign)
-        {
-            if (got_int)
-                break;
+	sign_entry_T *sign = NULL;
+	FOR_ALL_SIGNS_IN_BUF(buf, sign)
+	{
+	    if (got_int)
+		break;
 
-            if (!sign_in_group(sign, sign_group))
-                continue;
+	    if (!sign_in_group(sign, sign_group))
+		continue;
 
-            if (sign->se_group != NULL)
-                vim_snprintf(group, MSG_BUF_LEN, _("  group=%s"),
-                             sign->se_group->sg_name);
-            else
-                group[0] = '\0';
+	    if (sign->se_group != NULL)
+		vim_snprintf(group, MSG_BUF_LEN, _("  group=%s"),
+			     sign->se_group->sg_name);
+	    else
+		group[0] = '\0';
 
-            vim_snprintf(lbuf, MSG_BUF_LEN,
-                         _("    line=%ld  id=%d%s  name=%s  priority=%d"),
-                         (long)sign->se_lnum, sign->se_id, group,
-                         sign_typenr2name(sign->se_typenr), sign->se_priority);
+	    vim_snprintf(lbuf, MSG_BUF_LEN,
+			 _("    line=%ld  id=%d%s  name=%s  priority=%d"),
+			 (long)sign->se_lnum, sign->se_id, group,
+			 sign_typenr2name(sign->se_typenr), sign->se_priority);
 
-            msg_puts(lbuf);
-            msg_putchar('\n');
-        }
+	    msg_puts(lbuf);
+	    msg_putchar('\n');
+	}
 
-        if (rbuf != NULL)
-            break;
+	if (rbuf != NULL)
+	    break;
 
-        buf = buf->b_next;
+	buf = buf->b_next;
     }
 }
 
@@ -827,28 +827,28 @@ sign_mark_adjust(linenr_T line1, linenr_T line2, long amount, long amount_after)
     sign_entry_T *sign = NULL; // a sign in a b_signlist
     FOR_ALL_SIGNS_IN_BUF(curbuf, sign)
     {
-        // Ignore changes to lines after the sign
-        if (sign->se_lnum < line1)
-            continue;
+	// Ignore changes to lines after the sign
+	if (sign->se_lnum < line1)
+	    continue;
 
-        linenr_T new_lnum = sign->se_lnum;
+	linenr_T new_lnum = sign->se_lnum;
 
-        if (sign->se_lnum <= line2)
-        {
-            if (amount != MAXLNUM)
-                new_lnum += amount;
-        }
-        else if (sign->se_lnum > line2)
-        {
-            // Lines inserted or deleted before the sign
-            new_lnum += amount_after;
-        }
+	if (sign->se_lnum <= line2)
+	{
+	    if (amount != MAXLNUM)
+		new_lnum += amount;
+	}
+	else if (sign->se_lnum > line2)
+	{
+	    // Lines inserted or deleted before the sign
+	    new_lnum += amount_after;
+	}
 
-        // If the new sign line number is past the last line in the buffer,
-        // then don't adjust the line number. Otherwise, it will always be past
-        // the last line and will not be visible.
-        if (new_lnum <= curbuf->b_ml.ml_line_count)
-            sign->se_lnum = new_lnum;
+	// If the new sign line number is past the last line in the buffer,
+	// then don't adjust the line number. Otherwise, it will always be past
+	// the last line and will not be visible.
+	if (new_lnum <= curbuf->b_ml.ml_line_count)
+	    sign->se_lnum = new_lnum;
     }
 }
 
@@ -858,14 +858,14 @@ sign_mark_adjust(linenr_T line1, linenr_T line2, long amount, long amount_after)
  */
 static int
 sign_cmd_idx(char_u *begin_cmd, // begin of sign subcmd
-             char_u *end_cmd) // just after sign subcmd
+	     char_u *end_cmd) // just after sign subcmd
 {
     int idx = 0;
     char save = *end_cmd;
     *end_cmd = NUL;
 
     while (cmds[idx] != NULL && STRCMP(begin_cmd, cmds[idx]) != 0)
-        ++idx;
+	++idx;
 
     *end_cmd = save;
     return idx;
@@ -878,16 +878,16 @@ static sign_T *
 sign_find(char_u *name, sign_T **sp_prev)
 {
     if (sp_prev != NULL)
-        *sp_prev = NULL;
+	*sp_prev = NULL;
 
     sign_T *sp = NULL;
     FOR_ALL_SIGNS(sp)
     {
-        if (STRCMP(sp->sn_name, name) == 0)
-            break;
+	if (STRCMP(sp->sn_name, name) == 0)
+	    break;
 
-        if (sp_prev != NULL)
-            *sp_prev = sp;
+	if (sp_prev != NULL)
+	    *sp_prev = sp;
     }
 
     return sp;
@@ -904,7 +904,7 @@ alloc_new_sign(char_u *name)
     // Allocate a new sign.
     sign_T *sp = alloc_clear_id(sizeof(sign_T), aid_sign_define_by_name);
     if (sp == NULL)
-        return NULL;
+	return NULL;
 
     // Check that next_sign_typenr is not already being used.
     // This only happens after wrapping around.  Hopefully
@@ -912,36 +912,36 @@ alloc_new_sign(char_u *name)
     sign_T *lp = first_sign;
     while (lp != NULL)
     {
-        if (lp->sn_typenr == next_sign_typenr)
-        {
-            ++next_sign_typenr;
+	if (lp->sn_typenr == next_sign_typenr)
+	{
+	    ++next_sign_typenr;
 
-            if (next_sign_typenr == MAX_TYPENR)
-                next_sign_typenr = 1;
+	    if (next_sign_typenr == MAX_TYPENR)
+		next_sign_typenr = 1;
 
-            if (next_sign_typenr == start)
-            {
-                vim_free(sp);
-                emsg(_(e_too_many_signs_defined));
-                return NULL;
-            }
+	    if (next_sign_typenr == start)
+	    {
+		vim_free(sp);
+		emsg(_(e_too_many_signs_defined));
+		return NULL;
+	    }
 
-            lp = first_sign; // start all over
-            continue;
-        }
-        lp = lp->sn_next;
+	    lp = first_sign; // start all over
+	    continue;
+	}
+	lp = lp->sn_next;
     }
 
     sp->sn_typenr = next_sign_typenr;
 
     if (++next_sign_typenr == MAX_TYPENR)
-        next_sign_typenr = 1; // wrap around
+	next_sign_typenr = 1; // wrap around
 
     sp->sn_name = vim_strsave(name);
     if (sp->sn_name == NULL) // out of memory
     {
-        vim_free(sp);
-        return NULL;
+	vim_free(sp);
+	return NULL;
     }
 
     return sp;
@@ -959,10 +959,10 @@ sign_define_init_icon(sign_T *sp, char_u *icon)
 # ifdef FEAT_SIGN_ICONS
     if (gui.in_use)
     {
-        out_flush();
-        if (sp->sn_image != NULL)
-            gui_mch_destroy_sign(sp->sn_image);
-        sp->sn_image = gui_mch_register_sign(sp->sn_icon);
+	out_flush();
+	if (sp->sn_image != NULL)
+	    gui_mch_destroy_sign(sp->sn_image);
+	sp->sn_image = gui_mch_register_sign(sp->sn_icon);
     }
 # endif
 }
@@ -980,39 +980,39 @@ sign_define_init_text(sign_T *sp, char_u *text)
     // Remove backslashes so that it is possible to use a space.
     for (s = text; s + 1 < endp; ++s)
     {
-        if (*s == '\\')
-        {
-            STRMOVE(s, s + 1);
-            --endp;
-        }
+	if (*s == '\\')
+	{
+	    STRMOVE(s, s + 1);
+	    --endp;
+	}
     }
 
     // Count cells and check for non-printable chars
     if (has_mbyte)
     {
-        for (s = text; s < endp; s += (*mb_ptr2len)(s))
-        {
-            if (!vim_isprintc((*mb_ptr2char)(s)))
-                break;
+	for (s = text; s < endp; s += (*mb_ptr2len)(s))
+	{
+	    if (!vim_isprintc((*mb_ptr2char)(s)))
+		break;
 
-            cells += (*mb_ptr2cells)(s);
-        }
+	    cells += (*mb_ptr2cells)(s);
+	}
     }
     else
     {
-        for (s = text; s < endp; ++s)
-        {
-            if (!vim_isprintc(*s))
-                break;
-        }
-        cells = (int)(s - text);
+	for (s = text; s < endp; ++s)
+	{
+	    if (!vim_isprintc(*s))
+		break;
+	}
+	cells = (int)(s - text);
     }
 
     // Currently sign text must be one or two display cells
     if (s != endp || cells < 1 || cells > 2)
     {
-        semsg(_(e_invalid_sign_text_str), text);
-        return FAIL;
+	semsg(_(e_invalid_sign_text_str), text);
+	return FAIL;
     }
 
     vim_free(sp->sn_text);
@@ -1023,7 +1023,7 @@ sign_define_init_text(sign_T *sp, char_u *text)
 
     // For single character sign text, pad with a space.
     if (sp->sn_text != NULL && cells == 1)
-        STRCPY(sp->sn_text + len - 1, " ");
+	STRCPY(sp->sn_text + len - 1, " ");
 
     return OK;
 }
@@ -1033,79 +1033,79 @@ sign_define_init_text(sign_T *sp, char_u *text)
  */
 int
 sign_define_by_name(char_u *name,
-                    char_u *icon,
-                    char_u *linehl,
-                    char_u *text,
-                    char_u *texthl,
-                    char_u *culhl,
-                    char_u *numhl,
-                    int prio)
+		    char_u *icon,
+		    char_u *linehl,
+		    char_u *text,
+		    char_u *texthl,
+		    char_u *culhl,
+		    char_u *numhl,
+		    int prio)
 {
     sign_T *sp_prev = NULL;
     sign_T *sp = sign_find(name, &sp_prev);
     if (sp == NULL)
     {
-        sp = alloc_new_sign(name);
-        if (sp == NULL)
-            return FAIL;
+	sp = alloc_new_sign(name);
+	if (sp == NULL)
+	    return FAIL;
 
-        // add the new sign to the list of signs
-        if (sp_prev == NULL)
-            first_sign = sp;
-        else
-            sp_prev->sn_next = sp;
+	// add the new sign to the list of signs
+	if (sp_prev == NULL)
+	    first_sign = sp;
+	else
+	    sp_prev->sn_next = sp;
     }
     else
     {
-        win_T *wp = NULL;
-        // Signs may already exist, a redraw is needed in windows with a
-        // non-empty sign list.
-        FOR_ALL_WINDOWS(wp)
-        {
-            if (wp->w_buffer->b_signlist != NULL)
-                redraw_buf_later(wp->w_buffer, UPD_NOT_VALID);
-        }
+	win_T *wp = NULL;
+	// Signs may already exist, a redraw is needed in windows with a
+	// non-empty sign list.
+	FOR_ALL_WINDOWS(wp)
+	{
+	    if (wp->w_buffer->b_signlist != NULL)
+		redraw_buf_later(wp->w_buffer, UPD_NOT_VALID);
+	}
     }
 
     // set values for a defined sign.
     if (icon != NULL)
-        sign_define_init_icon(sp, icon);
+	sign_define_init_icon(sp, icon);
 
     if (text != NULL && (sign_define_init_text(sp, text) == FAIL))
-        return FAIL;
+	return FAIL;
 
     sp->sn_priority = prio;
 
     if (linehl != NULL)
     {
-        if (*linehl == NUL)
-            sp->sn_line_hl = 0;
-        else
-            sp->sn_line_hl = syn_check_group(linehl, (int)STRLEN(linehl));
+	if (*linehl == NUL)
+	    sp->sn_line_hl = 0;
+	else
+	    sp->sn_line_hl = syn_check_group(linehl, (int)STRLEN(linehl));
     }
 
     if (texthl != NULL)
     {
-        if (*texthl == NUL)
-            sp->sn_text_hl = 0;
-        else
-            sp->sn_text_hl = syn_check_group(texthl, (int)STRLEN(texthl));
+	if (*texthl == NUL)
+	    sp->sn_text_hl = 0;
+	else
+	    sp->sn_text_hl = syn_check_group(texthl, (int)STRLEN(texthl));
     }
 
     if (culhl != NULL)
     {
-        if (*culhl == NUL)
-            sp->sn_cul_hl = 0;
-        else
-            sp->sn_cul_hl = syn_check_group(culhl, (int)STRLEN(culhl));
+	if (*culhl == NUL)
+	    sp->sn_cul_hl = 0;
+	else
+	    sp->sn_cul_hl = syn_check_group(culhl, (int)STRLEN(culhl));
     }
 
     if (numhl != NULL)
     {
-        if (*numhl == NUL)
-            sp->sn_num_hl = 0;
-        else
-            sp->sn_num_hl = syn_check_group(numhl, (int)STRLEN(numhl));
+	if (*numhl == NUL)
+	    sp->sn_num_hl = 0;
+	else
+	    sp->sn_num_hl = syn_check_group(numhl, (int)STRLEN(numhl));
     }
 
     return OK;
@@ -1130,9 +1130,9 @@ sign_undefine_by_name(char_u *name, int give_error)
     sign_T *sp = sign_find(name, &sp_prev);
     if (sp == NULL)
     {
-        if (give_error)
-            semsg(_(e_unknown_sign_str), name);
-        return FAIL;
+	if (give_error)
+	    semsg(_(e_unknown_sign_str), name);
+	return FAIL;
     }
     sign_undefine(sp, sp_prev);
 
@@ -1147,9 +1147,9 @@ sign_list_by_name(char_u *name)
 {
     sign_T *sp = sign_find(name, NULL);
     if (sp != NULL)
-        sign_list_defined(sp);
+	sign_list_defined(sp);
     else
-        semsg(_(e_unknown_sign_str), name);
+	semsg(_(e_unknown_sign_str), name);
 }
 
 static void
@@ -1160,10 +1160,10 @@ may_force_numberwidth_recompute(buf_T *buf, int unplace)
 
     FOR_ALL_TAB_WINDOWS(tp, wp)
     {
-        if (wp->w_buffer == buf && (wp->w_p_nu || wp->w_p_rnu) &&
-            (unplace || wp->w_nrwidth_width < 2) &&
-            (*wp->w_p_scl == 'n' && *(wp->w_p_scl + 1) == 'u'))
-            wp->w_nrwidth_line_count = 0;
+	if (wp->w_buffer == buf && (wp->w_p_nu || wp->w_p_rnu) &&
+	    (unplace || wp->w_nrwidth_width < 2) &&
+	    (*wp->w_p_scl == 'n' && *(wp->w_p_scl + 1) == 'u'))
+	    wp->w_nrwidth_line_count = 0;
     }
 }
 
@@ -1172,61 +1172,61 @@ may_force_numberwidth_recompute(buf_T *buf, int unplace)
  */
 int
 sign_place(int *sign_id,
-           char_u *sign_group,
-           char_u *sign_name,
-           buf_T *buf,
-           linenr_T lnum,
-           int prio)
+	   char_u *sign_group,
+	   char_u *sign_name,
+	   buf_T *buf,
+	   linenr_T lnum,
+	   int prio)
 {
     // Check for reserved character '*' in group name
     if (sign_group != NULL && (*sign_group == '*' || *sign_group == '\0'))
-        return FAIL;
+	return FAIL;
 
     sign_T *sp = NULL;
     FOR_ALL_SIGNS(sp)
     {
-        if (STRCMP(sp->sn_name, sign_name) == 0)
-            break;
+	if (STRCMP(sp->sn_name, sign_name) == 0)
+	    break;
     }
 
     if (sp == NULL)
     {
-        semsg(_(e_unknown_sign_str), sign_name);
-        return FAIL;
+	semsg(_(e_unknown_sign_str), sign_name);
+	return FAIL;
     }
 
     if (*sign_id == 0)
-        *sign_id = sign_group_get_next_signid(buf, sign_group);
+	*sign_id = sign_group_get_next_signid(buf, sign_group);
 
     // Use the default priority value for this sign.
     if (prio == -1)
-        prio = (sp->sn_priority != -1) ? sp->sn_priority : SIGN_DEF_PRIO;
+	prio = (sp->sn_priority != -1) ? sp->sn_priority : SIGN_DEF_PRIO;
 
     if (lnum > 0)
     {
-        // ":sign place {id} line={lnum} name={name} file={fname}":
-        // place a sign
-        buf_addsign(buf, *sign_id, sign_group, prio, lnum, sp->sn_typenr);
+	// ":sign place {id} line={lnum} name={name} file={fname}":
+	// place a sign
+	buf_addsign(buf, *sign_id, sign_group, prio, lnum, sp->sn_typenr);
     }
     else
     {
-        // ":sign place {id} file={fname}": change sign type and/or priority
-        lnum = buf_change_sign_type(buf, *sign_id, sign_group, sp->sn_typenr,
-                                    prio);
+	// ":sign place {id} file={fname}": change sign type and/or priority
+	lnum = buf_change_sign_type(buf, *sign_id, sign_group, sp->sn_typenr,
+				    prio);
     }
 
     if (lnum > 0)
     {
-        redraw_buf_line_later(buf, lnum);
+	redraw_buf_line_later(buf, lnum);
 
-        // When displaying signs in the 'number' column, if the width of the
-        // number column is less than 2, then force recomputing the width.
-        may_force_numberwidth_recompute(buf, FALSE);
+	// When displaying signs in the 'number' column, if the width of the
+	// number column is less than 2, then force recomputing the width.
+	may_force_numberwidth_recompute(buf, FALSE);
     }
     else
     {
-        semsg(_(e_not_possible_to_change_sign_str), sign_name);
-        return FAIL;
+	semsg(_(e_not_possible_to_change_sign_str), sign_name);
+	return FAIL;
     }
 
     return OK;
@@ -1239,27 +1239,27 @@ static int
 sign_unplace(int sign_id, char_u *sign_group, buf_T *buf, linenr_T atlnum)
 {
     if (buf->b_signlist == NULL) // No signs in the buffer
-        return OK;
+	return OK;
 
     if (sign_id == 0)
     {
-        // Delete all the signs in the specified buffer
-        redraw_buf_later(buf, UPD_NOT_VALID);
-        buf_delete_signs(buf, sign_group);
+	// Delete all the signs in the specified buffer
+	redraw_buf_later(buf, UPD_NOT_VALID);
+	buf_delete_signs(buf, sign_group);
     }
     else
     {
-        // Delete only the specified signs
-        linenr_T lnum = buf_delsign(buf, atlnum, sign_id, sign_group);
-        if (lnum == 0)
-            return FAIL;
+	// Delete only the specified signs
+	linenr_T lnum = buf_delsign(buf, atlnum, sign_id, sign_group);
+	if (lnum == 0)
+	    return FAIL;
     }
 
     // When all the signs in a buffer are removed, force recomputing the
     // number column width (if enabled) in all the windows displaying the
     // buffer if 'signcolumn' is set to 'number' in that window.
     if (buf->b_signlist == NULL)
-        may_force_numberwidth_recompute(buf, TRUE);
+	may_force_numberwidth_recompute(buf, TRUE);
 
     return OK;
 }
@@ -1271,12 +1271,12 @@ static void
 sign_unplace_at_cursor(char_u *groupname)
 {
     int id =
-        buf_findsign_id(curwin->w_buffer, curwin->w_cursor.lnum, groupname);
+	buf_findsign_id(curwin->w_buffer, curwin->w_cursor.lnum, groupname);
 
     if (id > 0)
-        sign_unplace(id, groupname, curwin->w_buffer, curwin->w_cursor.lnum);
+	sign_unplace(id, groupname, curwin->w_buffer, curwin->w_cursor.lnum);
     else
-        emsg(_(e_missing_sign_number));
+	emsg(_(e_missing_sign_number));
 }
 
 /*
@@ -1288,31 +1288,31 @@ sign_jump(int sign_id, char_u *sign_group, buf_T *buf)
     linenr_T lnum = buf_findsign(buf, sign_id, sign_group);
     if (lnum <= 0)
     {
-        semsg(_(e_invalid_sign_id_nr), sign_id);
-        return -1;
+	semsg(_(e_invalid_sign_id_nr), sign_id);
+	return -1;
     }
 
     // goto a sign ...
     if (buf_jump_open_win(buf) != NULL)
     { // ... in a current window
-        curwin->w_cursor.lnum = lnum;
-        check_cursor_lnum();
-        beginline(BL_WHITE);
+	curwin->w_cursor.lnum = lnum;
+	check_cursor_lnum();
+	beginline(BL_WHITE);
     }
     else
     { // ... not currently in a window
-        if (buf->b_fname == NULL)
-        {
-            emsg(_(e_cannot_jump_to_buffer_that_does_not_have_name));
-            return -1;
-        }
-        char_u *cmd = alloc(STRLEN(buf->b_fname) + 25);
-        if (cmd == NULL)
-            return -1;
+	if (buf->b_fname == NULL)
+	{
+	    emsg(_(e_cannot_jump_to_buffer_that_does_not_have_name));
+	    return -1;
+	}
+	char_u *cmd = alloc(STRLEN(buf->b_fname) + 25);
+	if (cmd == NULL)
+	    return -1;
 
-        sprintf((char *)cmd, "e +%ld %s", (long)lnum, buf->b_fname);
-        do_cmdline_cmd(cmd);
-        vim_free(cmd);
+	sprintf((char *)cmd, "e +%ld %s", (long)lnum, buf->b_fname);
+	do_cmdline_cmd(cmd);
+	vim_free(cmd);
     }
 # ifdef FEAT_FOLDING
     foldOpenCursor();
@@ -1341,57 +1341,57 @@ sign_define_cmd(char_u *sign_name, char_u *cmdline)
     // set values for a defined sign.
     while (TRUE)
     {
-        arg = skipwhite(p);
-        if (*arg == NUL)
-            break;
+	arg = skipwhite(p);
+	if (*arg == NUL)
+	    break;
 
-        p = skiptowhite_esc(arg);
-        if (STRNCMP(arg, "icon=", 5) == 0)
-        {
-            arg += 5;
-            icon = vim_strnsave(arg, p - arg);
-        }
-        else if (STRNCMP(arg, "text=", 5) == 0)
-        {
-            arg += 5;
-            text = vim_strnsave(arg, p - arg);
-        }
-        else if (STRNCMP(arg, "linehl=", 7) == 0)
-        {
-            arg += 7;
-            linehl = vim_strnsave(arg, p - arg);
-        }
-        else if (STRNCMP(arg, "texthl=", 7) == 0)
-        {
-            arg += 7;
-            texthl = vim_strnsave(arg, p - arg);
-        }
-        else if (STRNCMP(arg, "culhl=", 6) == 0)
-        {
-            arg += 6;
-            culhl = vim_strnsave(arg, p - arg);
-        }
-        else if (STRNCMP(arg, "numhl=", 6) == 0)
-        {
-            arg += 6;
-            numhl = vim_strnsave(arg, p - arg);
-        }
-        else if (STRNCMP(arg, "priority=", 9) == 0)
-        {
-            arg += 9;
-            prio = atoi((char *)arg);
-        }
-        else
-        {
-            semsg(_(e_invalid_argument_str), arg);
-            failed = TRUE;
-            break;
-        }
+	p = skiptowhite_esc(arg);
+	if (STRNCMP(arg, "icon=", 5) == 0)
+	{
+	    arg += 5;
+	    icon = vim_strnsave(arg, p - arg);
+	}
+	else if (STRNCMP(arg, "text=", 5) == 0)
+	{
+	    arg += 5;
+	    text = vim_strnsave(arg, p - arg);
+	}
+	else if (STRNCMP(arg, "linehl=", 7) == 0)
+	{
+	    arg += 7;
+	    linehl = vim_strnsave(arg, p - arg);
+	}
+	else if (STRNCMP(arg, "texthl=", 7) == 0)
+	{
+	    arg += 7;
+	    texthl = vim_strnsave(arg, p - arg);
+	}
+	else if (STRNCMP(arg, "culhl=", 6) == 0)
+	{
+	    arg += 6;
+	    culhl = vim_strnsave(arg, p - arg);
+	}
+	else if (STRNCMP(arg, "numhl=", 6) == 0)
+	{
+	    arg += 6;
+	    numhl = vim_strnsave(arg, p - arg);
+	}
+	else if (STRNCMP(arg, "priority=", 9) == 0)
+	{
+	    arg += 9;
+	    prio = atoi((char *)arg);
+	}
+	else
+	{
+	    semsg(_(e_invalid_argument_str), arg);
+	    failed = TRUE;
+	    break;
+	}
     }
 
     if (!failed)
-        sign_define_by_name(sign_name, icon, linehl, text, texthl, culhl, numhl,
-                            prio);
+	sign_define_by_name(sign_name, icon, linehl, text, texthl, culhl, numhl,
+			    prio);
 
     vim_free(icon);
     vim_free(text);
@@ -1406,40 +1406,40 @@ sign_define_cmd(char_u *sign_name, char_u *cmdline)
  */
 static void
 sign_place_cmd(buf_T *buf,
-               linenr_T lnum,
-               char_u *sign_name,
-               int id,
-               char_u *group,
-               int prio)
+	       linenr_T lnum,
+	       char_u *sign_name,
+	       int id,
+	       char_u *group,
+	       int prio)
 {
     if (id <= 0)
     {
-        // List signs placed in a file/buffer
-        //   :sign place file={fname}
-        //   :sign place group={group} file={fname}
-        //   :sign place group=* file={fname}
-        //   :sign place buffer={nr}
-        //   :sign place group={group} buffer={nr}
-        //   :sign place group=* buffer={nr}
-        //   :sign place
-        //   :sign place group={group}
-        //   :sign place group=*
-        if (lnum >= 0 || sign_name != NULL || (group != NULL && *group == '\0'))
-            emsg(_(e_invalid_argument));
-        else
-            sign_list_placed(buf, group);
+	// List signs placed in a file/buffer
+	//   :sign place file={fname}
+	//   :sign place group={group} file={fname}
+	//   :sign place group=* file={fname}
+	//   :sign place buffer={nr}
+	//   :sign place group={group} buffer={nr}
+	//   :sign place group=* buffer={nr}
+	//   :sign place
+	//   :sign place group={group}
+	//   :sign place group=*
+	if (lnum >= 0 || sign_name != NULL || (group != NULL && *group == '\0'))
+	    emsg(_(e_invalid_argument));
+	else
+	    sign_list_placed(buf, group);
     }
     else
     {
-        // Place a new sign
-        if (sign_name == NULL || buf == NULL ||
-            (group != NULL && *group == '\0'))
-        {
-            emsg(_(e_invalid_argument));
-            return;
-        }
+	// Place a new sign
+	if (sign_name == NULL || buf == NULL ||
+	    (group != NULL && *group == '\0'))
+	{
+	    emsg(_(e_invalid_argument));
+	    return;
+	}
 
-        sign_place(&id, group, sign_name, buf, lnum, prio);
+	sign_place(&id, group, sign_name, buf, lnum, prio);
     }
 }
 
@@ -1448,70 +1448,70 @@ sign_place_cmd(buf_T *buf,
  */
 static void
 sign_unplace_cmd(buf_T *buf,
-                 linenr_T lnum,
-                 char_u *sign_name,
-                 int id,
-                 char_u *group)
+		 linenr_T lnum,
+		 char_u *sign_name,
+		 int id,
+		 char_u *group)
 {
     if (lnum >= 0 || sign_name != NULL || (group != NULL && *group == '\0'))
     {
-        emsg(_(e_invalid_argument));
-        return;
+	emsg(_(e_invalid_argument));
+	return;
     }
 
     if (id == -2)
     {
-        if (buf != NULL)
-        {
-            // :sign unplace * file={fname}
-            // :sign unplace * group={group} file={fname}
-            // :sign unplace * group=* file={fname}
-            // :sign unplace * buffer={nr}
-            // :sign unplace * group={group} buffer={nr}
-            // :sign unplace * group=* buffer={nr}
-            sign_unplace(0, group, buf, 0);
-        }
-        else
-        {
-            // :sign unplace *
-            // :sign unplace * group={group}
-            // :sign unplace * group=*
-            FOR_ALL_BUFFERS(buf)
-            {
-                if (buf->b_signlist != NULL)
-                    buf_delete_signs(buf, group);
-            }
-        }
+	if (buf != NULL)
+	{
+	    // :sign unplace * file={fname}
+	    // :sign unplace * group={group} file={fname}
+	    // :sign unplace * group=* file={fname}
+	    // :sign unplace * buffer={nr}
+	    // :sign unplace * group={group} buffer={nr}
+	    // :sign unplace * group=* buffer={nr}
+	    sign_unplace(0, group, buf, 0);
+	}
+	else
+	{
+	    // :sign unplace *
+	    // :sign unplace * group={group}
+	    // :sign unplace * group=*
+	    FOR_ALL_BUFFERS(buf)
+	    {
+		if (buf->b_signlist != NULL)
+		    buf_delete_signs(buf, group);
+	    }
+	}
     }
     else
     {
-        if (buf != NULL)
-        {
-            // :sign unplace {id} file={fname}
-            // :sign unplace {id} group={group} file={fname}
-            // :sign unplace {id} group=* file={fname}
-            // :sign unplace {id} buffer={nr}
-            // :sign unplace {id} group={group} buffer={nr}
-            // :sign unplace {id} group=* buffer={nr}
-            sign_unplace(id, group, buf, 0);
-        }
-        else
-        {
-            if (id == -1)
-            {
-                // :sign unplace group={group}
-                // :sign unplace group=*
-                sign_unplace_at_cursor(group);
-            }
-            else
-            {
-                // :sign unplace {id}
-                // :sign unplace {id} group={group}
-                // :sign unplace {id} group=*
-                FOR_ALL_BUFFERS(buf)
-                    sign_unplace(id, group, buf, 0);
-            }
-        }
+	if (buf != NULL)
+	{
+	    // :sign unplace {id} file={fname}
+	    // :sign unplace {id} group={group} file={fname}
+	    // :sign unplace {id} group=* file={fname}
+	    // :sign unplace {id} buffer={nr}
+	    // :sign unplace {id} group={group} buffer={nr}
+	    // :sign unplace {id} group=* buffer={nr}
+	    sign_unplace(id, group, buf, 0);
+	}
+	else
+	{
+	    if (id == -1)
+	    {
+		// :sign unplace group={group}
+		// :sign unplace group=*
+		sign_unplace_at_cursor(group);
+	    }
+	    else
+	    {
+		// :sign unplace {id}
+		// :sign unplace {id} group={group}
+		// :sign unplace {id} group=*
+		FOR_ALL_BUFFERS(buf)
+		    sign_unplace(id, group, buf, 0);
+	    }
+	}
     }
 }
 
@@ -1524,24 +1524,24 @@ sign_unplace_cmd(buf_T *buf,
  */
 static void
 sign_jump_cmd(buf_T *buf,
-              linenr_T lnum,
-              char_u *sign_name,
-              int id,
-              char_u *group)
+	      linenr_T lnum,
+	      char_u *sign_name,
+	      int id,
+	      char_u *group)
 {
     if (sign_name == NULL && group == NULL && id == -1)
     {
-        emsg(_(e_argument_required));
-        return;
+	emsg(_(e_argument_required));
+	return;
     }
 
     if (buf == NULL || (group != NULL && *group == '\0') || lnum >= 0 ||
-        sign_name != NULL)
+	sign_name != NULL)
     {
-        // File or buffer is not specified or an empty group is used
-        // or a line number or a sign name is specified.
-        emsg(_(e_invalid_argument));
-        return;
+	// File or buffer is not specified or an empty group is used
+	// or a line number or a sign name is specified.
+	emsg(_(e_invalid_argument));
+	return;
     }
 
     (void)sign_jump(id, group, buf);
@@ -1555,13 +1555,13 @@ sign_jump_cmd(buf_T *buf,
  */
 static int
 parse_sign_cmd_args(int cmd,
-                    char_u *arg,
-                    char_u **sign_name,
-                    int *signid,
-                    char_u **group,
-                    int *prio,
-                    buf_T **buf,
-                    linenr_T *lnum)
+		    char_u *arg,
+		    char_u **sign_name,
+		    int *signid,
+		    char_u **group,
+		    int *prio,
+		    buf_T **buf,
+		    linenr_T *lnum)
 {
     char_u *arg1 = arg;
     char_u *filename = NULL;
@@ -1570,102 +1570,102 @@ parse_sign_cmd_args(int cmd,
     // first arg could be placed sign id
     if (VIM_ISDIGIT(*arg))
     {
-        *signid = getdigits(&arg);
-        if (!VIM_ISWHITE(*arg) && *arg != NUL)
-        {
-            *signid = -1;
-            arg = arg1;
-        }
-        else
-        {
-            arg = skipwhite(arg);
-        }
+	*signid = getdigits(&arg);
+	if (!VIM_ISWHITE(*arg) && *arg != NUL)
+	{
+	    *signid = -1;
+	    arg = arg1;
+	}
+	else
+	{
+	    arg = skipwhite(arg);
+	}
     }
 
     while (*arg != NUL)
     {
-        if (STRNCMP(arg, "line=", 5) == 0)
-        {
-            arg += 5;
-            *lnum = atoi((char *)arg);
-            arg = skiptowhite(arg);
-            lnum_arg = TRUE;
-        }
-        else if (STRNCMP(arg, "*", 1) == 0 && cmd == SIGNCMD_UNPLACE)
-        {
-            if (*signid != -1)
-            {
-                emsg(_(e_invalid_argument));
-                return FAIL;
-            }
-            *signid = -2;
-            arg = skiptowhite(arg + 1);
-        }
-        else if (STRNCMP(arg, "name=", 5) == 0)
-        {
-            arg += 5;
-            char_u *name = arg;
-            arg = skiptowhite(arg);
-            if (*arg != NUL)
-                *arg++ = NUL;
+	if (STRNCMP(arg, "line=", 5) == 0)
+	{
+	    arg += 5;
+	    *lnum = atoi((char *)arg);
+	    arg = skiptowhite(arg);
+	    lnum_arg = TRUE;
+	}
+	else if (STRNCMP(arg, "*", 1) == 0 && cmd == SIGNCMD_UNPLACE)
+	{
+	    if (*signid != -1)
+	    {
+		emsg(_(e_invalid_argument));
+		return FAIL;
+	    }
+	    *signid = -2;
+	    arg = skiptowhite(arg + 1);
+	}
+	else if (STRNCMP(arg, "name=", 5) == 0)
+	{
+	    arg += 5;
+	    char_u *name = arg;
+	    arg = skiptowhite(arg);
+	    if (*arg != NUL)
+		*arg++ = NUL;
 
-            while (name[0] == '0' && name[1] != NUL)
-                ++name;
+	    while (name[0] == '0' && name[1] != NUL)
+		++name;
 
-            *sign_name = name;
-        }
-        else if (STRNCMP(arg, "group=", 6) == 0)
-        {
-            arg += 6;
-            *group = arg;
-            arg = skiptowhite(arg);
-            if (*arg != NUL)
-                *arg++ = NUL;
-        }
-        else if (STRNCMP(arg, "priority=", 9) == 0)
-        {
-            arg += 9;
-            *prio = atoi((char *)arg);
-            arg = skiptowhite(arg);
-        }
-        else if (STRNCMP(arg, "file=", 5) == 0)
-        {
-            arg += 5;
-            filename = arg;
-            *buf = buflist_findname_exp(arg);
-            break;
-        }
-        else if (STRNCMP(arg, "buffer=", 7) == 0)
-        {
-            arg += 7;
-            filename = arg;
-            *buf = buflist_findnr((int)getdigits(&arg));
+	    *sign_name = name;
+	}
+	else if (STRNCMP(arg, "group=", 6) == 0)
+	{
+	    arg += 6;
+	    *group = arg;
+	    arg = skiptowhite(arg);
+	    if (*arg != NUL)
+		*arg++ = NUL;
+	}
+	else if (STRNCMP(arg, "priority=", 9) == 0)
+	{
+	    arg += 9;
+	    *prio = atoi((char *)arg);
+	    arg = skiptowhite(arg);
+	}
+	else if (STRNCMP(arg, "file=", 5) == 0)
+	{
+	    arg += 5;
+	    filename = arg;
+	    *buf = buflist_findname_exp(arg);
+	    break;
+	}
+	else if (STRNCMP(arg, "buffer=", 7) == 0)
+	{
+	    arg += 7;
+	    filename = arg;
+	    *buf = buflist_findnr((int)getdigits(&arg));
 
-            if (*skipwhite(arg) != NUL)
-                semsg(_(e_trailing_characters_str), arg);
+	    if (*skipwhite(arg) != NUL)
+		semsg(_(e_trailing_characters_str), arg);
 
-            break;
-        }
-        else
-        {
-            emsg(_(e_invalid_argument));
-            return FAIL;
-        }
+	    break;
+	}
+	else
+	{
+	    emsg(_(e_invalid_argument));
+	    return FAIL;
+	}
 
-        arg = skipwhite(arg);
+	arg = skipwhite(arg);
     }
 
     if (filename != NULL && *buf == NULL)
     {
-        semsg(_(e_invalid_buffer_name_str), filename);
-        return FAIL;
+	semsg(_(e_invalid_buffer_name_str), filename);
+	return FAIL;
     }
 
     // If the filename is not supplied for the sign place or the sign jump
     // command, then use the current buffer.
     if (filename == NULL &&
-        ((cmd == SIGNCMD_PLACE && lnum_arg) || cmd == SIGNCMD_JUMP))
-        *buf = curwin->w_buffer;
+	((cmd == SIGNCMD_PLACE && lnum_arg) || cmd == SIGNCMD_JUMP))
+	*buf = curwin->w_buffer;
 
     return OK;
 }
@@ -1683,70 +1683,70 @@ ex_sign(exarg_T *eap)
     int idx = sign_cmd_idx(arg, p);
     if (idx == SIGNCMD_LAST)
     {
-        semsg(_(e_unknown_sign_command_str), arg);
-        return;
+	semsg(_(e_unknown_sign_command_str), arg);
+	return;
     }
     arg = skipwhite(p);
 
     if (idx > SIGNCMD_LIST)
     {
-        char_u *sign_name = NULL;
-        int id = -1;
-        char_u *group = NULL;
-        int prio = -1;
-        buf_T *buf = NULL;
-        linenr_T lnum = -1;
+	char_u *sign_name = NULL;
+	int id = -1;
+	char_u *group = NULL;
+	int prio = -1;
+	buf_T *buf = NULL;
+	linenr_T lnum = -1;
 
-        // Parse command line arguments
-        if (parse_sign_cmd_args(idx, arg, &sign_name, &id, &group, &prio, &buf,
-                                &lnum) == FAIL)
-            return;
+	// Parse command line arguments
+	if (parse_sign_cmd_args(idx, arg, &sign_name, &id, &group, &prio, &buf,
+				&lnum) == FAIL)
+	    return;
 
-        if (idx == SIGNCMD_PLACE)
-            sign_place_cmd(buf, lnum, sign_name, id, group, prio);
-        else if (idx == SIGNCMD_UNPLACE)
-            sign_unplace_cmd(buf, lnum, sign_name, id, group);
-        else if (idx == SIGNCMD_JUMP)
-            sign_jump_cmd(buf, lnum, sign_name, id, group);
+	if (idx == SIGNCMD_PLACE)
+	    sign_place_cmd(buf, lnum, sign_name, id, group, prio);
+	else if (idx == SIGNCMD_UNPLACE)
+	    sign_unplace_cmd(buf, lnum, sign_name, id, group);
+	else if (idx == SIGNCMD_JUMP)
+	    sign_jump_cmd(buf, lnum, sign_name, id, group);
 
-        return;
+	return;
     }
 
     // Define, undefine or list signs.
     if (idx == SIGNCMD_LIST && *arg == NUL)
     {
-        // ":sign list": list all defined signs
-        for (sign_T *sp = first_sign; sp != NULL && !got_int; sp = sp->sn_next)
-            sign_list_defined(sp);
+	// ":sign list": list all defined signs
+	for (sign_T *sp = first_sign; sp != NULL && !got_int; sp = sp->sn_next)
+	    sign_list_defined(sp);
     }
     else if (*arg == NUL)
     {
-        emsg(_(e_missing_sign_name));
+	emsg(_(e_missing_sign_name));
     }
     else
     {
 
-        // Isolate the sign name.  If it's a number skip leading zeroes,
-        // so that "099" and "99" are the same sign.  But keep "0".
-        p = skiptowhite(arg);
-        if (*p != NUL)
-            *p++ = NUL;
+	// Isolate the sign name.  If it's a number skip leading zeroes,
+	// so that "099" and "99" are the same sign.  But keep "0".
+	p = skiptowhite(arg);
+	if (*p != NUL)
+	    *p++ = NUL;
 
-        while (arg[0] == '0' && arg[1] != NUL)
-            ++arg;
+	while (arg[0] == '0' && arg[1] != NUL)
+	    ++arg;
 
-        char_u *name = vim_strsave(arg);
+	char_u *name = vim_strsave(arg);
 
-        if (idx == SIGNCMD_DEFINE)
-            sign_define_cmd(name, p);
-        else if (idx == SIGNCMD_LIST)
-            // ":sign list {name}"
-            sign_list_by_name(name);
-        else
-            // ":sign undefine {name}"
-            sign_undefine_by_name(name, TRUE);
+	if (idx == SIGNCMD_DEFINE)
+	    sign_define_cmd(name, p);
+	else if (idx == SIGNCMD_LIST)
+	    // ":sign list {name}"
+	    sign_list_by_name(name);
+	else
+	    // ":sign undefine {name}"
+	    sign_undefine_by_name(name, TRUE);
 
-        vim_free(name);
+	vim_free(name);
     }
 }
 
@@ -1759,44 +1759,44 @@ sign_getinfo(sign_T *sp, dict_T *retdict)
     dict_add_string(retdict, "name", sp->sn_name);
 
     if (sp->sn_icon != NULL)
-        dict_add_string(retdict, "icon", sp->sn_icon);
+	dict_add_string(retdict, "icon", sp->sn_icon);
 
     if (sp->sn_text != NULL)
-        dict_add_string(retdict, "text", sp->sn_text);
+	dict_add_string(retdict, "text", sp->sn_text);
 
     if (sp->sn_priority > 0)
-        dict_add_number(retdict, "priority", sp->sn_priority);
+	dict_add_number(retdict, "priority", sp->sn_priority);
 
     if (sp->sn_line_hl > 0)
     {
-        char_u *p = get_highlight_name_ext(NULL, sp->sn_line_hl - 1, FALSE);
-        if (p == NULL)
-            p = (char_u *)"NONE";
-        dict_add_string(retdict, "linehl", p);
+	char_u *p = get_highlight_name_ext(NULL, sp->sn_line_hl - 1, FALSE);
+	if (p == NULL)
+	    p = (char_u *)"NONE";
+	dict_add_string(retdict, "linehl", p);
     }
 
     if (sp->sn_text_hl > 0)
     {
-        char_u *p = get_highlight_name_ext(NULL, sp->sn_text_hl - 1, FALSE);
-        if (p == NULL)
-            p = (char_u *)"NONE";
-        dict_add_string(retdict, "texthl", p);
+	char_u *p = get_highlight_name_ext(NULL, sp->sn_text_hl - 1, FALSE);
+	if (p == NULL)
+	    p = (char_u *)"NONE";
+	dict_add_string(retdict, "texthl", p);
     }
 
     if (sp->sn_cul_hl > 0)
     {
-        char_u *p = get_highlight_name_ext(NULL, sp->sn_cul_hl - 1, FALSE);
-        if (p == NULL)
-            p = (char_u *)"NONE";
-        dict_add_string(retdict, "culhl", p);
+	char_u *p = get_highlight_name_ext(NULL, sp->sn_cul_hl - 1, FALSE);
+	if (p == NULL)
+	    p = (char_u *)"NONE";
+	dict_add_string(retdict, "culhl", p);
     }
 
     if (sp->sn_num_hl > 0)
     {
-        char_u *p = get_highlight_name_ext(NULL, sp->sn_num_hl - 1, FALSE);
-        if (p == NULL)
-            p = (char_u *)"NONE";
-        dict_add_string(retdict, "numhl", p);
+	char_u *p = get_highlight_name_ext(NULL, sp->sn_num_hl - 1, FALSE);
+	if (p == NULL)
+	    p = (char_u *)"NONE";
+	dict_add_string(retdict, "numhl", p);
     }
 }
 
@@ -1811,24 +1811,24 @@ sign_getlist(char_u *name, list_T *retlist)
 
     if (name != NULL)
     {
-        sp = sign_find(name, NULL);
-        if (sp == NULL)
-            return;
+	sp = sign_find(name, NULL);
+	if (sp == NULL)
+	    return;
     }
 
     for (; sp != NULL && !got_int; sp = sp->sn_next)
     {
-        dict_T *dict = dict_alloc_id(aid_sign_getlist);
-        if (dict == NULL)
-            return;
+	dict_T *dict = dict_alloc_id(aid_sign_getlist);
+	if (dict == NULL)
+	    return;
 
-        if (list_append_dict(retlist, dict) == FAIL)
-            return;
+	if (list_append_dict(retlist, dict) == FAIL)
+	    return;
 
-        sign_getinfo(sp, dict);
+	sign_getinfo(sp, dict);
 
-        if (name != NULL) // handle only the specified sign
-            break;
+	if (name != NULL) // handle only the specified sign
+	    break;
     }
 }
 
@@ -1841,9 +1841,9 @@ get_buffer_signs(buf_T *buf, list_T *l)
     sign_entry_T *sign = NULL;
     FOR_ALL_SIGNS_IN_BUF(buf, sign)
     {
-        dict_T *d = sign_get_info(sign);
-        if (d != NULL)
-            list_append_dict(l, d);
+	dict_T *d = sign_get_info(sign);
+	if (d != NULL)
+	    list_append_dict(l, d);
     }
 }
 
@@ -1852,14 +1852,14 @@ get_buffer_signs(buf_T *buf, list_T *l)
  */
 static void
 sign_get_placed_in_buf(buf_T *buf,
-                       linenr_T lnum,
-                       int sign_id,
-                       char_u *sign_group,
-                       list_T *retlist)
+		       linenr_T lnum,
+		       int sign_id,
+		       char_u *sign_group,
+		       list_T *retlist)
 {
     dict_T *d = dict_alloc_id(aid_sign_getplaced_dict);
     if (d == NULL)
-        return;
+	return;
 
     list_append_dict(retlist, d);
 
@@ -1867,25 +1867,25 @@ sign_get_placed_in_buf(buf_T *buf,
 
     list_T *l = list_alloc_id(aid_sign_getplaced_list);
     if (l == NULL)
-        return;
+	return;
 
     dict_add_list(d, "signs", l);
 
     sign_entry_T *sign = NULL;
     FOR_ALL_SIGNS_IN_BUF(buf, sign)
     {
-        if (!sign_in_group(sign, sign_group))
-            continue;
+	if (!sign_in_group(sign, sign_group))
+	    continue;
 
-        if ((lnum == 0 && sign_id == 0) ||
-            (sign_id == 0 && lnum == sign->se_lnum) ||
-            (lnum == 0 && sign_id == sign->se_id) ||
-            (lnum == sign->se_lnum && sign_id == sign->se_id))
-        {
-            dict_T *sdict = sign_get_info(sign);
-            if (sdict != NULL)
-                list_append_dict(l, sdict);
-        }
+	if ((lnum == 0 && sign_id == 0) ||
+	    (sign_id == 0 && lnum == sign->se_lnum) ||
+	    (lnum == 0 && sign_id == sign->se_id) ||
+	    (lnum == sign->se_lnum && sign_id == sign->se_id))
+	{
+	    dict_T *sdict = sign_get_info(sign);
+	    if (sdict != NULL)
+		list_append_dict(l, sdict);
+	}
     }
 }
 
@@ -1896,22 +1896,22 @@ sign_get_placed_in_buf(buf_T *buf,
  */
 static void
 sign_get_placed(buf_T *buf,
-                linenr_T lnum,
-                int sign_id,
-                char_u *sign_group,
-                list_T *retlist)
+		linenr_T lnum,
+		int sign_id,
+		char_u *sign_group,
+		list_T *retlist)
 {
     if (buf != NULL)
     {
-        sign_get_placed_in_buf(buf, lnum, sign_id, sign_group, retlist);
+	sign_get_placed_in_buf(buf, lnum, sign_id, sign_group, retlist);
     }
     else
     {
-        FOR_ALL_BUFFERS(buf)
-        {
-            if (buf->b_signlist != NULL)
-                sign_get_placed_in_buf(buf, 0, sign_id, sign_group, retlist);
-        }
+	FOR_ALL_BUFFERS(buf)
+	{
+	    if (buf->b_signlist != NULL)
+		sign_get_placed_in_buf(buf, 0, sign_id, sign_group, retlist);
+	}
     }
 }
 
@@ -1926,8 +1926,8 @@ sign_gui_started(void)
     sign_T *sp = NULL;
     FOR_ALL_SIGNS(sp)
     {
-        if (sp->sn_icon != NULL)
-            sp->sn_image = gui_mch_register_sign(sp->sn_icon);
+	if (sp->sn_icon != NULL)
+	    sp->sn_image = gui_mch_register_sign(sp->sn_icon);
     }
 }
 # endif
@@ -1944,70 +1944,70 @@ sign_list_defined(sign_T *sp)
 
     if (sp->sn_icon != NULL)
     {
-        msg_puts(" icon=");
-        msg_outtrans(sp->sn_icon);
+	msg_puts(" icon=");
+	msg_outtrans(sp->sn_icon);
 # ifdef FEAT_SIGN_ICONS
-        if (sp->sn_image == NULL)
-            msg_puts(_(" (NOT FOUND)"));
+	if (sp->sn_image == NULL)
+	    msg_puts(_(" (NOT FOUND)"));
 # else
-        msg_puts(_(" (not supported)"));
+	msg_puts(_(" (not supported)"));
 # endif
     }
 
     if (sp->sn_text != NULL)
     {
-        msg_puts(" text=");
-        msg_outtrans(sp->sn_text);
+	msg_puts(" text=");
+	msg_outtrans(sp->sn_text);
     }
 
     if (sp->sn_priority > 0)
     {
-        vim_snprintf(lbuf, MSG_BUF_LEN, " priority=%d", sp->sn_priority);
-        msg_puts(lbuf);
+	vim_snprintf(lbuf, MSG_BUF_LEN, " priority=%d", sp->sn_priority);
+	msg_puts(lbuf);
     }
 
     if (sp->sn_line_hl > 0)
     {
-        msg_puts(" linehl=");
+	msg_puts(" linehl=");
 
-        char_u *p = get_highlight_name_ext(NULL, sp->sn_line_hl - 1, FALSE);
-        if (p == NULL)
-            msg_puts("NONE");
-        else
-            msg_puts((char *)p);
+	char_u *p = get_highlight_name_ext(NULL, sp->sn_line_hl - 1, FALSE);
+	if (p == NULL)
+	    msg_puts("NONE");
+	else
+	    msg_puts((char *)p);
     }
 
     if (sp->sn_text_hl > 0)
     {
-        msg_puts(" texthl=");
+	msg_puts(" texthl=");
 
-        char_u *p = get_highlight_name_ext(NULL, sp->sn_text_hl - 1, FALSE);
-        if (p == NULL)
-            msg_puts("NONE");
-        else
-            msg_puts((char *)p);
+	char_u *p = get_highlight_name_ext(NULL, sp->sn_text_hl - 1, FALSE);
+	if (p == NULL)
+	    msg_puts("NONE");
+	else
+	    msg_puts((char *)p);
     }
 
     if (sp->sn_cul_hl > 0)
     {
-        msg_puts(" culhl=");
+	msg_puts(" culhl=");
 
-        char_u *p = get_highlight_name_ext(NULL, sp->sn_cul_hl - 1, FALSE);
-        if (p == NULL)
-            msg_puts("NONE");
-        else
-            msg_puts((char *)p);
+	char_u *p = get_highlight_name_ext(NULL, sp->sn_cul_hl - 1, FALSE);
+	if (p == NULL)
+	    msg_puts("NONE");
+	else
+	    msg_puts((char *)p);
     }
 
     if (sp->sn_num_hl > 0)
     {
-        msg_puts(" numhl=");
+	msg_puts(" numhl=");
 
-        char_u *p = get_highlight_name_ext(NULL, sp->sn_num_hl - 1, FALSE);
-        if (p == NULL)
-            msg_puts("NONE");
-        else
-            msg_puts((char *)p);
+	char_u *p = get_highlight_name_ext(NULL, sp->sn_num_hl - 1, FALSE);
+	if (p == NULL)
+	    msg_puts("NONE");
+	else
+	    msg_puts((char *)p);
     }
 }
 
@@ -2022,16 +2022,16 @@ sign_undefine(sign_T *sp, sign_T *sp_prev)
 # ifdef FEAT_SIGN_ICONS
     if (sp->sn_image != NULL)
     {
-        out_flush();
-        gui_mch_destroy_sign(sp->sn_image);
+	out_flush();
+	gui_mch_destroy_sign(sp->sn_image);
     }
 # endif
     vim_free(sp->sn_text);
 
     if (sp_prev == NULL)
-        first_sign = sp->sn_next;
+	first_sign = sp->sn_next;
     else
-        sp_prev->sn_next = sp->sn_next;
+	sp_prev->sn_next = sp->sn_next;
 
     vim_free(sp);
 }
@@ -2043,8 +2043,8 @@ sign_get_image(int typenr) // the attribute which may have a sign
     sign_T *sp = NULL;
     FOR_ALL_SIGNS(sp)
     {
-        if (sp->sn_typenr == typenr)
-            return sp->sn_image;
+	if (sp->sn_typenr == typenr)
+	    return sp->sn_image;
     }
     return NULL;
 }
@@ -2057,7 +2057,7 @@ void
 free_signs(void)
 {
     while (first_sign != NULL)
-        sign_undefine(first_sign, NULL);
+	sign_undefine(first_sign, NULL);
 }
 
 static enum
@@ -2083,8 +2083,8 @@ get_nth_sign_name(int idx)
     // Complete with name of signs already defined
     FOR_ALL_SIGNS(sp)
     {
-        if (current_idx++ == idx)
-            return sp->sn_name;
+	if (current_idx++ == idx)
+	    return sp->sn_name;
     }
     return NULL;
 }
@@ -2102,15 +2102,15 @@ get_nth_sign_group_name(int idx)
     // Complete with name of sign groups already defined
     FOR_ALL_HASHTAB_ITEMS(&sg_table, hi, todo)
     {
-        if (!HASHITEM_EMPTY(hi))
-        {
-            --todo;
-            if (current_idx++ == idx)
-            {
-                signgroup_T *group = HI2SG(hi);
-                return group->sg_name;
-            }
-        }
+	if (!HASHITEM_EMPTY(hi))
+	{
+	    --todo;
+	    if (current_idx++ == idx)
+	    {
+		signgroup_T *group = HI2SG(hi);
+		return group->sg_name;
+	    }
+	}
     }
     return NULL;
 }
@@ -2124,36 +2124,36 @@ get_sign_name(expand_T *xp UNUSED, int idx)
 {
     switch (expand_what)
     {
-        case EXP_SUBCMD:
-            return (char_u *)cmds[idx];
-        case EXP_DEFINE:
-        {
-            char *define_arg[] = { "culhl=", "icon=",   "linehl=",   "numhl=",
-                                   "text=",  "texthl=", "priority=", NULL };
-            return (char_u *)define_arg[idx];
-        }
-        case EXP_PLACE:
-        {
-            char *place_arg[] = { "line=", "name=",   "group=", "priority=",
-                                  "file=", "buffer=", NULL };
-            return (char_u *)place_arg[idx];
-        }
-        case EXP_LIST:
-        {
-            char *list_arg[] = { "group=", "file=", "buffer=", NULL };
-            return (char_u *)list_arg[idx];
-        }
-        case EXP_UNPLACE:
-        {
-            char *unplace_arg[] = { "group=", "file=", "buffer=", NULL };
-            return (char_u *)unplace_arg[idx];
-        }
-        case EXP_SIGN_NAMES:
-            return get_nth_sign_name(idx);
-        case EXP_SIGN_GROUPS:
-            return get_nth_sign_group_name(idx);
-        default:
-            return NULL;
+	case EXP_SUBCMD:
+	    return (char_u *)cmds[idx];
+	case EXP_DEFINE:
+	{
+	    char *define_arg[] = { "culhl=", "icon=",   "linehl=",   "numhl=",
+				   "text=",  "texthl=", "priority=", NULL };
+	    return (char_u *)define_arg[idx];
+	}
+	case EXP_PLACE:
+	{
+	    char *place_arg[] = { "line=", "name=",   "group=", "priority=",
+				  "file=", "buffer=", NULL };
+	    return (char_u *)place_arg[idx];
+	}
+	case EXP_LIST:
+	{
+	    char *list_arg[] = { "group=", "file=", "buffer=", NULL };
+	    return (char_u *)list_arg[idx];
+	}
+	case EXP_UNPLACE:
+	{
+	    char *unplace_arg[] = { "group=", "file=", "buffer=", NULL };
+	    return (char_u *)unplace_arg[idx];
+	}
+	case EXP_SIGN_NAMES:
+	    return get_nth_sign_name(idx);
+	case EXP_SIGN_GROUPS:
+	    return get_nth_sign_group_name(idx);
+	default:
+	    return NULL;
     }
 }
 
@@ -2178,7 +2178,7 @@ set_context_in_sign_cmd(expand_T *xp, char_u *arg)
     // expand subcmd name
     // :sign {subcmd}<CTRL-D>
     if (*end_subcmd == NUL)
-        return;
+	return;
 
     cmd_idx = sign_cmd_idx(arg, end_subcmd);
 
@@ -2197,9 +2197,9 @@ set_context_in_sign_cmd(expand_T *xp, char_u *arg)
     p = begin_subcmd_args;
     do
     {
-        p = skipwhite(p);
-        last = p;
-        p = skiptowhite(p);
+	p = skipwhite(p);
+	last = p;
+	p = skiptowhite(p);
     }
     while (*p != NUL);
 
@@ -2210,75 +2210,75 @@ set_context_in_sign_cmd(expand_T *xp, char_u *arg)
     //                            last     p
     if (p == NULL)
     {
-        // Expand last argument name (before equal sign).
-        xp->xp_pattern = last;
-        switch (cmd_idx)
-        {
-            case SIGNCMD_DEFINE:
-                expand_what = EXP_DEFINE;
-                break;
-            case SIGNCMD_PLACE:
-                // List placed signs
-                if (VIM_ISDIGIT(*begin_subcmd_args))
-                    //   :sign place {id} {args}...
-                    expand_what = EXP_PLACE;
-                else
-                    //   :sign place {args}...
-                    expand_what = EXP_LIST;
-                break;
-            case SIGNCMD_LIST:
-            case SIGNCMD_UNDEFINE:
-                // :sign list <CTRL-D>
-                // :sign undefine <CTRL-D>
-                expand_what = EXP_SIGN_NAMES;
-                break;
-            case SIGNCMD_JUMP:
-            case SIGNCMD_UNPLACE:
-                expand_what = EXP_UNPLACE;
-                break;
-            default:
-                xp->xp_context = EXPAND_NOTHING;
-        }
+	// Expand last argument name (before equal sign).
+	xp->xp_pattern = last;
+	switch (cmd_idx)
+	{
+	    case SIGNCMD_DEFINE:
+		expand_what = EXP_DEFINE;
+		break;
+	    case SIGNCMD_PLACE:
+		// List placed signs
+		if (VIM_ISDIGIT(*begin_subcmd_args))
+		    //   :sign place {id} {args}...
+		    expand_what = EXP_PLACE;
+		else
+		    //   :sign place {args}...
+		    expand_what = EXP_LIST;
+		break;
+	    case SIGNCMD_LIST:
+	    case SIGNCMD_UNDEFINE:
+		// :sign list <CTRL-D>
+		// :sign undefine <CTRL-D>
+		expand_what = EXP_SIGN_NAMES;
+		break;
+	    case SIGNCMD_JUMP:
+	    case SIGNCMD_UNPLACE:
+		expand_what = EXP_UNPLACE;
+		break;
+	    default:
+		xp->xp_context = EXPAND_NOTHING;
+	}
     }
     else
     {
-        // Expand last argument value (after equal sign).
-        xp->xp_pattern = p + 1;
-        switch (cmd_idx)
-        {
-            case SIGNCMD_DEFINE:
-                if (STRNCMP(last, "texthl", 6) == 0 ||
-                    STRNCMP(last, "linehl", 6) == 0 ||
-                    STRNCMP(last, "culhl", 5) == 0 ||
-                    STRNCMP(last, "numhl", 5) == 0)
-                    xp->xp_context = EXPAND_HIGHLIGHT;
-                else if (STRNCMP(last, "icon", 4) == 0)
-                    xp->xp_context = EXPAND_FILES;
-                else
-                    xp->xp_context = EXPAND_NOTHING;
-                break;
-            case SIGNCMD_PLACE:
-                if (STRNCMP(last, "name", 4) == 0)
-                    expand_what = EXP_SIGN_NAMES;
-                else if (STRNCMP(last, "group", 5) == 0)
-                    expand_what = EXP_SIGN_GROUPS;
-                else if (STRNCMP(last, "file", 4) == 0)
-                    xp->xp_context = EXPAND_BUFFERS;
-                else
-                    xp->xp_context = EXPAND_NOTHING;
-                break;
-            case SIGNCMD_UNPLACE:
-            case SIGNCMD_JUMP:
-                if (STRNCMP(last, "group", 5) == 0)
-                    expand_what = EXP_SIGN_GROUPS;
-                else if (STRNCMP(last, "file", 4) == 0)
-                    xp->xp_context = EXPAND_BUFFERS;
-                else
-                    xp->xp_context = EXPAND_NOTHING;
-                break;
-            default:
-                xp->xp_context = EXPAND_NOTHING;
-        }
+	// Expand last argument value (after equal sign).
+	xp->xp_pattern = p + 1;
+	switch (cmd_idx)
+	{
+	    case SIGNCMD_DEFINE:
+		if (STRNCMP(last, "texthl", 6) == 0 ||
+		    STRNCMP(last, "linehl", 6) == 0 ||
+		    STRNCMP(last, "culhl", 5) == 0 ||
+		    STRNCMP(last, "numhl", 5) == 0)
+		    xp->xp_context = EXPAND_HIGHLIGHT;
+		else if (STRNCMP(last, "icon", 4) == 0)
+		    xp->xp_context = EXPAND_FILES;
+		else
+		    xp->xp_context = EXPAND_NOTHING;
+		break;
+	    case SIGNCMD_PLACE:
+		if (STRNCMP(last, "name", 4) == 0)
+		    expand_what = EXP_SIGN_NAMES;
+		else if (STRNCMP(last, "group", 5) == 0)
+		    expand_what = EXP_SIGN_GROUPS;
+		else if (STRNCMP(last, "file", 4) == 0)
+		    xp->xp_context = EXPAND_BUFFERS;
+		else
+		    xp->xp_context = EXPAND_NOTHING;
+		break;
+	    case SIGNCMD_UNPLACE:
+	    case SIGNCMD_JUMP:
+		if (STRNCMP(last, "group", 5) == 0)
+		    expand_what = EXP_SIGN_GROUPS;
+		else if (STRNCMP(last, "file", 4) == 0)
+		    xp->xp_context = EXPAND_BUFFERS;
+		else
+		    xp->xp_context = EXPAND_NOTHING;
+		break;
+	    default:
+		xp->xp_context = EXPAND_NOTHING;
+	}
     }
 }
 
@@ -2300,30 +2300,30 @@ sign_define_from_dict(char_u *name_arg, dict_T *dict)
     int retval = -1;
 
     if (name_arg == NULL && dict == NULL)
-        return retval;
+	return retval;
 
     if (name_arg == NULL)
-        name = dict_get_string(dict, "name", TRUE);
+	name = dict_get_string(dict, "name", TRUE);
     else
-        name = vim_strsave(name_arg);
+	name = vim_strsave(name_arg);
 
     if (name == NULL || name[0] == NUL)
-        goto cleanup;
+	goto cleanup;
 
     if (dict != NULL)
     {
-        icon = dict_get_string(dict, "icon", TRUE);
-        linehl = dict_get_string(dict, "linehl", TRUE);
-        text = dict_get_string(dict, "text", TRUE);
-        texthl = dict_get_string(dict, "texthl", TRUE);
-        culhl = dict_get_string(dict, "culhl", TRUE);
-        numhl = dict_get_string(dict, "numhl", TRUE);
-        prio = dict_get_number_def(dict, "priority", -1);
+	icon = dict_get_string(dict, "icon", TRUE);
+	linehl = dict_get_string(dict, "linehl", TRUE);
+	text = dict_get_string(dict, "text", TRUE);
+	texthl = dict_get_string(dict, "texthl", TRUE);
+	culhl = dict_get_string(dict, "culhl", TRUE);
+	numhl = dict_get_string(dict, "numhl", TRUE);
+	prio = dict_get_number_def(dict, "priority", -1);
     }
 
     if (sign_define_by_name(name, icon, linehl, text, texthl, culhl, numhl,
-                            prio) == OK)
-        retval = 0;
+			    prio) == OK)
+	retval = 0;
 
 cleanup:
     vim_free(name);
@@ -2347,14 +2347,14 @@ sign_define_multiple(list_T *l, list_T *retlist)
     listitem_T *li = NULL;
     FOR_ALL_LIST_ITEMS(l, li)
     {
-        int retval = -1;
+	int retval = -1;
 
-        if (li->li_tv.v_type == VAR_DICT)
-            retval = sign_define_from_dict(NULL, li->li_tv.vval.v_dict);
-        else
-            emsg(_(e_dictionary_required));
+	if (li->li_tv.v_type == VAR_DICT)
+	    retval = sign_define_from_dict(NULL, li->li_tv.vval.v_dict);
+	else
+	    emsg(_(e_dictionary_required));
 
-        list_append_number(retlist, retval);
+	list_append_number(retlist, retval);
     }
 }
 
@@ -2365,17 +2365,17 @@ void
 f_sign_define(typval_T *argvars, typval_T *rettv)
 {
     if (in_vim9script() && (check_for_string_or_list_arg(argvars, 0) == FAIL ||
-                            check_for_opt_dict_arg(argvars, 1) == FAIL))
-        return;
+			    check_for_opt_dict_arg(argvars, 1) == FAIL))
+	return;
 
     if (argvars[0].v_type == VAR_LIST && argvars[1].v_type == VAR_UNKNOWN)
     {
-        // Define multiple signs
-        if (rettv_list_alloc(rettv) == FAIL)
-            return;
+	// Define multiple signs
+	if (rettv_list_alloc(rettv) == FAIL)
+	    return;
 
-        sign_define_multiple(argvars[0].vval.v_list, rettv->vval.v_list);
-        return;
+	sign_define_multiple(argvars[0].vval.v_list, rettv->vval.v_list);
+	return;
     }
 
     // Define a single sign
@@ -2383,13 +2383,13 @@ f_sign_define(typval_T *argvars, typval_T *rettv)
 
     char_u *name = tv_get_string_chk(&argvars[0]);
     if (name == NULL)
-        return;
+	return;
 
     if (check_for_opt_dict_arg(argvars, 1) == FAIL)
-        return;
+	return;
 
     rettv->vval.v_number = sign_define_from_dict(
-        name, argvars[1].v_type == VAR_DICT ? argvars[1].vval.v_dict : NULL);
+	name, argvars[1].v_type == VAR_DICT ? argvars[1].vval.v_dict : NULL);
 }
 
 /*
@@ -2399,14 +2399,14 @@ void
 f_sign_getdefined(typval_T *argvars, typval_T *rettv)
 {
     if (rettv_list_alloc_id(rettv, aid_sign_getdefined) == FAIL)
-        return;
+	return;
 
     if (in_vim9script() && check_for_opt_string_arg(argvars, 0) == FAIL)
-        return;
+	return;
 
     char_u *name = NULL;
     if (argvars[0].v_type != VAR_UNKNOWN)
-        name = tv_get_string(&argvars[0]);
+	name = tv_get_string(&argvars[0]);
 
     sign_getlist(name, rettv->vval.v_list);
 }
@@ -2423,58 +2423,58 @@ f_sign_getplaced(typval_T *argvars, typval_T *rettv)
     char_u *group = NULL;
 
     if (rettv_list_alloc_id(rettv, aid_sign_getplaced) == FAIL)
-        return;
+	return;
 
     if (in_vim9script() && (check_for_opt_buffer_arg(argvars, 0) == FAIL ||
-                            (argvars[0].v_type != VAR_UNKNOWN &&
-                             check_for_opt_dict_arg(argvars, 1) == FAIL)))
-        return;
+			    (argvars[0].v_type != VAR_UNKNOWN &&
+			     check_for_opt_dict_arg(argvars, 1) == FAIL)))
+	return;
 
     if (argvars[0].v_type != VAR_UNKNOWN)
     {
-        // get signs placed in the specified buffer
-        buf = get_buf_arg(&argvars[0]);
-        if (buf == NULL)
-            return;
+	// get signs placed in the specified buffer
+	buf = get_buf_arg(&argvars[0]);
+	if (buf == NULL)
+	    return;
 
-        if (argvars[1].v_type != VAR_UNKNOWN)
-        {
-            if (check_for_nonnull_dict_arg(argvars, 1) == FAIL)
-                return;
+	if (argvars[1].v_type != VAR_UNKNOWN)
+	{
+	    if (check_for_nonnull_dict_arg(argvars, 1) == FAIL)
+		return;
 
-            dictitem_T *di = NULL;
-            dict_T *dict = argvars[1].vval.v_dict;
+	    dictitem_T *di = NULL;
+	    dict_T *dict = argvars[1].vval.v_dict;
 
-            if ((di = dict_find(dict, (char_u *)"lnum", -1)) != NULL)
-            {
-                // get signs placed at this line
-                int notanum = FALSE;
-                tv_get_number_chk(&di->di_tv, &notanum);
-                if (notanum)
-                    return;
+	    if ((di = dict_find(dict, (char_u *)"lnum", -1)) != NULL)
+	    {
+		// get signs placed at this line
+		int notanum = FALSE;
+		tv_get_number_chk(&di->di_tv, &notanum);
+		if (notanum)
+		    return;
 
-                lnum = tv_get_lnum(&di->di_tv);
-            }
+		lnum = tv_get_lnum(&di->di_tv);
+	    }
 
-            if ((di = dict_find(dict, (char_u *)"id", -1)) != NULL)
-            {
-                // get sign placed with this identifier
-                int notanum = FALSE;
-                sign_id = (int)tv_get_number_chk(&di->di_tv, &notanum);
-                if (notanum)
-                    return;
-            }
+	    if ((di = dict_find(dict, (char_u *)"id", -1)) != NULL)
+	    {
+		// get sign placed with this identifier
+		int notanum = FALSE;
+		sign_id = (int)tv_get_number_chk(&di->di_tv, &notanum);
+		if (notanum)
+		    return;
+	    }
 
-            if ((di = dict_find(dict, (char_u *)"group", -1)) != NULL)
-            {
-                group = tv_get_string_chk(&di->di_tv);
-                if (group == NULL)
-                    return;
+	    if ((di = dict_find(dict, (char_u *)"group", -1)) != NULL)
+	    {
+		group = tv_get_string_chk(&di->di_tv);
+		if (group == NULL)
+		    return;
 
-                if (*group == '\0') // empty string means global group
-                    group = NULL;
-            }
-        }
+		if (*group == '\0') // empty string means global group
+		    group = NULL;
+	    }
+	}
     }
 
     sign_get_placed(buf, lnum, sign_id, group, rettv->vval.v_list);
@@ -2490,42 +2490,42 @@ f_sign_jump(typval_T *argvars, typval_T *rettv)
     rettv->vval.v_number = -1;
 
     if (in_vim9script() && (check_for_number_arg(argvars, 0) == FAIL ||
-                            check_for_string_arg(argvars, 1) == FAIL ||
-                            check_for_buffer_arg(argvars, 2) == FAIL))
-        return;
+			    check_for_string_arg(argvars, 1) == FAIL ||
+			    check_for_buffer_arg(argvars, 2) == FAIL))
+	return;
 
     int notanum = FALSE;
     // Sign identifier
     int sign_id = (int)tv_get_number_chk(&argvars[0], &notanum);
     if (notanum)
-        return;
+	return;
 
     if (sign_id <= 0)
     {
-        emsg(_(e_invalid_argument));
-        return;
+	emsg(_(e_invalid_argument));
+	return;
     }
 
     // Sign group
     sign_group = tv_get_string_chk(&argvars[1]);
     if (sign_group == NULL)
-        return;
+	return;
 
     if (sign_group[0] == '\0')
     {
-        sign_group = NULL; // global sign group
+	sign_group = NULL; // global sign group
     }
     else
     {
-        sign_group = vim_strsave(sign_group);
-        if (sign_group == NULL)
-            return;
+	sign_group = vim_strsave(sign_group);
+	if (sign_group == NULL)
+	    return;
     }
 
     // Buffer to place the sign
     buf_T *buf = get_buf_arg(&argvars[2]);
     if (buf == NULL)
-        goto cleanup;
+	goto cleanup;
 
     rettv->vval.v_number = sign_jump(sign_id, sign_group, buf);
 
@@ -2539,10 +2539,10 @@ cleanup:
  */
 static int
 sign_place_from_dict(typval_T *id_tv,
-                     typval_T *group_tv,
-                     typval_T *name_tv,
-                     typval_T *buf_tv,
-                     dict_T *dict)
+		     typval_T *group_tv,
+		     typval_T *name_tv,
+		     typval_T *buf_tv,
+		     dict_T *dict)
 {
     int sign_id = 0;
     char_u *group = NULL;
@@ -2556,114 +2556,114 @@ sign_place_from_dict(typval_T *id_tv,
     // sign identifier
     if (id_tv == NULL)
     {
-        di = dict_find(dict, (char_u *)"id", -1);
-        if (di != NULL)
-            id_tv = &di->di_tv;
+	di = dict_find(dict, (char_u *)"id", -1);
+	if (di != NULL)
+	    id_tv = &di->di_tv;
     }
 
     if (id_tv == NULL)
     {
-        sign_id = 0;
+	sign_id = 0;
     }
     else
     {
-        int notanum = FALSE;
-        sign_id = tv_get_number_chk(id_tv, &notanum);
+	int notanum = FALSE;
+	sign_id = tv_get_number_chk(id_tv, &notanum);
 
-        if (notanum)
-            return -1;
+	if (notanum)
+	    return -1;
 
-        if (sign_id < 0)
-        {
-            emsg(_(e_invalid_argument));
-            return -1;
-        }
+	if (sign_id < 0)
+	{
+	    emsg(_(e_invalid_argument));
+	    return -1;
+	}
     }
 
     // sign group
     if (group_tv == NULL)
     {
-        di = dict_find(dict, (char_u *)"group", -1);
-        if (di != NULL)
-            group_tv = &di->di_tv;
+	di = dict_find(dict, (char_u *)"group", -1);
+	if (di != NULL)
+	    group_tv = &di->di_tv;
     }
 
     if (group_tv == NULL)
     {
-        group = NULL; // global group
+	group = NULL; // global group
     }
     else
     {
-        group = tv_get_string_chk(group_tv);
-        if (group == NULL)
-            goto cleanup;
+	group = tv_get_string_chk(group_tv);
+	if (group == NULL)
+	    goto cleanup;
 
-        if (group[0] == '\0') // global sign group
-        {
-            group = NULL;
-        }
-        else
-        {
-            group = vim_strsave(group);
-            if (group == NULL)
-                return -1;
-        }
+	if (group[0] == '\0') // global sign group
+	{
+	    group = NULL;
+	}
+	else
+	{
+	    group = vim_strsave(group);
+	    if (group == NULL)
+		return -1;
+	}
     }
 
     // sign name
     if (name_tv == NULL)
     {
-        di = dict_find(dict, (char_u *)"name", -1);
-        if (di != NULL)
-            name_tv = &di->di_tv;
+	di = dict_find(dict, (char_u *)"name", -1);
+	if (di != NULL)
+	    name_tv = &di->di_tv;
     }
 
     if (name_tv == NULL)
-        goto cleanup;
+	goto cleanup;
 
     sign_name = tv_get_string_chk(name_tv);
     if (sign_name == NULL)
-        goto cleanup;
+	goto cleanup;
 
     // buffer to place the sign
     if (buf_tv == NULL)
     {
-        di = dict_find(dict, (char_u *)"buffer", -1);
-        if (di != NULL)
-            buf_tv = &di->di_tv;
+	di = dict_find(dict, (char_u *)"buffer", -1);
+	if (di != NULL)
+	    buf_tv = &di->di_tv;
     }
 
     if (buf_tv == NULL)
-        goto cleanup;
+	goto cleanup;
 
     buf = get_buf_arg(buf_tv);
     if (buf == NULL)
-        goto cleanup;
+	goto cleanup;
 
     // line number of the sign
     di = dict_find(dict, (char_u *)"lnum", -1);
     if (di != NULL)
     {
-        lnum = tv_get_lnum(&di->di_tv);
-        if (lnum <= 0)
-        {
-            emsg(_(e_invalid_argument));
-            goto cleanup;
-        }
+	lnum = tv_get_lnum(&di->di_tv);
+	if (lnum <= 0)
+	{
+	    emsg(_(e_invalid_argument));
+	    goto cleanup;
+	}
     }
 
     // sign priority
     di = dict_find(dict, (char_u *)"priority", -1);
     if (di != NULL)
     {
-        int notanum = FALSE;
-        prio = (int)tv_get_number_chk(&di->di_tv, &notanum);
-        if (notanum)
-            goto cleanup;
+	int notanum = FALSE;
+	prio = (int)tv_get_number_chk(&di->di_tv, &notanum);
+	if (notanum)
+	    goto cleanup;
     }
 
     if (sign_place(&sign_id, group, sign_name, buf, lnum, prio) == OK)
-        ret_sign_id = sign_id;
+	ret_sign_id = sign_id;
 
 cleanup:
     vim_free(group);
@@ -2681,21 +2681,21 @@ f_sign_place(typval_T *argvars, typval_T *rettv)
     rettv->vval.v_number = -1;
 
     if (in_vim9script() && (check_for_number_arg(argvars, 0) == FAIL ||
-                            check_for_string_arg(argvars, 1) == FAIL ||
-                            check_for_string_arg(argvars, 2) == FAIL ||
-                            check_for_buffer_arg(argvars, 3) == FAIL ||
-                            check_for_opt_dict_arg(argvars, 4) == FAIL))
-        return;
+			    check_for_string_arg(argvars, 1) == FAIL ||
+			    check_for_string_arg(argvars, 2) == FAIL ||
+			    check_for_buffer_arg(argvars, 3) == FAIL ||
+			    check_for_opt_dict_arg(argvars, 4) == FAIL))
+	return;
 
     if (argvars[4].v_type != VAR_UNKNOWN)
     {
-        if (check_for_nonnull_dict_arg(argvars, 4) == FAIL)
-            return;
-        dict = argvars[4].vval.v_dict;
+	if (check_for_nonnull_dict_arg(argvars, 4) == FAIL)
+	    return;
+	dict = argvars[4].vval.v_dict;
     }
 
     rettv->vval.v_number = sign_place_from_dict(&argvars[0], &argvars[1],
-                                                &argvars[2], &argvars[3], dict);
+						&argvars[2], &argvars[3], dict);
 }
 
 /*
@@ -2705,27 +2705,27 @@ void
 f_sign_placelist(typval_T *argvars, typval_T *rettv)
 {
     if (rettv_list_alloc(rettv) == FAIL)
-        return;
+	return;
 
     if (in_vim9script() && check_for_list_arg(argvars, 0) == FAIL)
-        return;
+	return;
 
     if (check_for_list_arg(argvars, 0) == FAIL)
-        return;
+	return;
 
     // Process the List of sign attributes
     listitem_T *li = NULL;
     FOR_ALL_LIST_ITEMS(argvars[0].vval.v_list, li)
     {
-        int sign_id = -1;
+	int sign_id = -1;
 
-        if (li->li_tv.v_type == VAR_DICT)
-            sign_id = sign_place_from_dict(NULL, NULL, NULL, NULL,
-                                           li->li_tv.vval.v_dict);
-        else
-            emsg(_(e_dictionary_required));
+	if (li->li_tv.v_type == VAR_DICT)
+	    sign_id = sign_place_from_dict(NULL, NULL, NULL, NULL,
+					   li->li_tv.vval.v_dict);
+	else
+	    emsg(_(e_dictionary_required));
 
-        list_append_number(rettv->vval.v_list, sign_id);
+	list_append_number(rettv->vval.v_list, sign_id);
     }
 }
 
@@ -2738,12 +2738,12 @@ sign_undefine_multiple(list_T *l, list_T *retlist)
     listitem_T *li = NULL;
     FOR_ALL_LIST_ITEMS(l, li)
     {
-        int retval = -1;
-        char_u *name = tv_get_string_chk(&li->li_tv);
-        if (name != NULL && (sign_undefine_by_name(name, TRUE) == OK))
-            retval = 0;
+	int retval = -1;
+	char_u *name = tv_get_string_chk(&li->li_tv);
+	if (name != NULL && (sign_undefine_by_name(name, TRUE) == OK))
+	    retval = 0;
 
-        list_append_number(retlist, retval);
+	list_append_number(retlist, retval);
     }
 }
 
@@ -2755,35 +2755,35 @@ f_sign_undefine(typval_T *argvars, typval_T *rettv)
 {
 
     if (in_vim9script() && check_for_opt_string_or_list_arg(argvars, 0) == FAIL)
-        return;
+	return;
 
     if (argvars[0].v_type == VAR_LIST && argvars[1].v_type == VAR_UNKNOWN)
     {
-        // Undefine multiple signs
-        if (rettv_list_alloc(rettv) == FAIL)
-            return;
+	// Undefine multiple signs
+	if (rettv_list_alloc(rettv) == FAIL)
+	    return;
 
-        sign_undefine_multiple(argvars[0].vval.v_list, rettv->vval.v_list);
-        return;
+	sign_undefine_multiple(argvars[0].vval.v_list, rettv->vval.v_list);
+	return;
     }
 
     rettv->vval.v_number = -1;
 
     if (argvars[0].v_type == VAR_UNKNOWN)
     {
-        // Free all the signs
-        free_signs();
-        rettv->vval.v_number = 0;
+	// Free all the signs
+	free_signs();
+	rettv->vval.v_number = 0;
     }
     else
     {
-        // Free only the specified sign
-        char_u *name = tv_get_string_chk(&argvars[0]);
-        if (name == NULL)
-            return;
+	// Free only the specified sign
+	char_u *name = tv_get_string_chk(&argvars[0]);
+	if (name == NULL)
+	    return;
 
-        if (sign_undefine_by_name(name, TRUE) == OK)
-            rettv->vval.v_number = 0;
+	if (sign_undefine_by_name(name, TRUE) == OK)
+	    rettv->vval.v_number = 0;
     }
 }
 
@@ -2801,53 +2801,53 @@ sign_unplace_from_dict(typval_T *group_tv, dict_T *dict)
 
     // sign group
     group = (group_tv != NULL) ? tv_get_string(group_tv)
-                               : dict_get_string(dict, "group", FALSE);
+			       : dict_get_string(dict, "group", FALSE);
 
     if (group != NULL)
     {
-        if (group[0] == '\0') // global sign group
-        {
-            group = NULL;
-        }
-        else
-        {
-            group = vim_strsave(group);
-            if (group == NULL)
-                return retval;
-        }
+	if (group[0] == '\0') // global sign group
+	{
+	    group = NULL;
+	}
+	else
+	{
+	    group = vim_strsave(group);
+	    if (group == NULL)
+		return retval;
+	}
     }
 
     if (dict != NULL)
     {
-        dictitem_T *di = dict_find(dict, (char_u *)"buffer", -1);
-        if (di != NULL)
-        {
-            buf = get_buf_arg(&di->di_tv);
-            if (buf == NULL)
-                goto cleanup;
-        }
+	dictitem_T *di = dict_find(dict, (char_u *)"buffer", -1);
+	if (di != NULL)
+	{
+	    buf = get_buf_arg(&di->di_tv);
+	    if (buf == NULL)
+		goto cleanup;
+	}
 
-        if (dict_has_key(dict, "id"))
-        {
-            sign_id = dict_get_number(dict, "id");
-            if (sign_id <= 0)
-            {
-                emsg(_(e_invalid_argument));
-                goto cleanup;
-            }
-        }
+	if (dict_has_key(dict, "id"))
+	{
+	    sign_id = dict_get_number(dict, "id");
+	    if (sign_id <= 0)
+	    {
+		emsg(_(e_invalid_argument));
+		goto cleanup;
+	    }
+	}
     }
 
     if (buf == NULL)
     {
-        // Delete the sign in all the buffers
-        retval = 0;
-        FOR_ALL_BUFFERS(buf)
-            if (sign_unplace(sign_id, group, buf, 0) != OK)
-                retval = -1;
+	// Delete the sign in all the buffers
+	retval = 0;
+	FOR_ALL_BUFFERS(buf)
+	    if (sign_unplace(sign_id, group, buf, 0) != OK)
+		retval = -1;
     }
     else if (sign_unplace(sign_id, group, buf, 0) == OK)
-        retval = 0;
+	retval = 0;
 
 cleanup:
     vim_free(group);
@@ -2862,7 +2862,7 @@ get_first_valid_sign(win_T *wp)
 
 # ifdef FEAT_PROP_POPUP
     while (sign != NULL && !sign_group_for_window(sign, wp))
-        sign = sign->se_next;
+	sign = sign->se_next;
 # endif
     return sign;
 }
@@ -2877,17 +2877,17 @@ signcolumn_on(win_T *wp)
     // column (if present). Otherwise signs are to be displayed in the sign
     // column.
     if (*wp->w_p_scl == 'n' && *(wp->w_p_scl + 1) == 'u')
-        return get_first_valid_sign(wp) != NULL && !wp->w_p_nu && !wp->w_p_rnu;
+	return get_first_valid_sign(wp) != NULL && !wp->w_p_nu && !wp->w_p_rnu;
 
     if (*wp->w_p_scl == 'n')
-        return FALSE;
+	return FALSE;
 
     if (*wp->w_p_scl == 'y')
-        return TRUE;
+	return TRUE;
 
     return (get_first_valid_sign(wp) != NULL
 # ifdef FEAT_NETBEANS_INTG
-            || wp->w_buffer->b_has_sign_column
+	    || wp->w_buffer->b_has_sign_column
 # endif
     );
 }
@@ -2902,11 +2902,11 @@ f_sign_unplace(typval_T *argvars, typval_T *rettv)
     rettv->vval.v_number = -1;
 
     if ((check_for_string_arg(argvars, 0) == FAIL ||
-         check_for_opt_dict_arg(argvars, 1) == FAIL))
-        return;
+	 check_for_opt_dict_arg(argvars, 1) == FAIL))
+	return;
 
     if (argvars[1].v_type != VAR_UNKNOWN)
-        dict = argvars[1].vval.v_dict;
+	dict = argvars[1].vval.v_dict;
 
     rettv->vval.v_number = sign_unplace_from_dict(&argvars[0], dict);
 }
@@ -2918,25 +2918,25 @@ void
 f_sign_unplacelist(typval_T *argvars, typval_T *rettv)
 {
     if (rettv_list_alloc(rettv) == FAIL)
-        return;
+	return;
 
     if (in_vim9script() && check_for_list_arg(argvars, 0) == FAIL)
-        return;
+	return;
 
     if (check_for_list_arg(argvars, 0) == FAIL)
-        return;
+	return;
 
     listitem_T *li = NULL;
     FOR_ALL_LIST_ITEMS(argvars[0].vval.v_list, li)
     {
-        int retval = -1;
+	int retval = -1;
 
-        if (li->li_tv.v_type == VAR_DICT)
-            retval = sign_unplace_from_dict(NULL, li->li_tv.vval.v_dict);
-        else
-            emsg(_(e_dictionary_required));
+	if (li->li_tv.v_type == VAR_DICT)
+	    retval = sign_unplace_from_dict(NULL, li->li_tv.vval.v_dict);
+	else
+	    emsg(_(e_dictionary_required));
 
-        list_append_number(rettv->vval.v_list, retval);
+	list_append_number(rettv->vval.v_list, retval);
     }
 }
 

--- a/src/sound.c
+++ b/src/sound.c
@@ -48,23 +48,23 @@ get_sound_callback(typval_T *arg)
     soundcb_T *soundcb;
 
     if (arg->v_type == VAR_UNKNOWN)
-        return NULL;
+	return NULL;
     callback = get_callback(arg);
     if (callback.cb_name == NULL)
-        return NULL;
+	return NULL;
 
     soundcb = ALLOC_ONE(soundcb_T);
     if (soundcb == NULL)
     {
-        free_callback(&callback);
-        return NULL;
+	free_callback(&callback);
+	return NULL;
     }
 
     soundcb->snd_next = first_callback;
     first_callback = soundcb;
     set_callback(&soundcb->snd_callback, &callback);
     if (callback.cb_free_name)
-        vim_free(callback.cb_name);
+	vim_free(callback.cb_name);
     return soundcb;
 }
 
@@ -97,16 +97,16 @@ delete_sound_callback(soundcb_T *soundcb)
     soundcb_T *prev = NULL;
 
     for (p = first_callback; p != NULL; prev = p, p = p->snd_next)
-        if (p == soundcb)
-        {
-            if (prev == NULL)
-                first_callback = p->snd_next;
-            else
-                prev->snd_next = p->snd_next;
-            free_callback(&p->snd_callback);
-            vim_free(p);
-            break;
-        }
+	if (p == soundcb)
+	{
+	    if (prev == NULL)
+		first_callback = p->snd_next;
+	    else
+		prev->snd_next = p->snd_next;
+	    free_callback(&p->snd_callback);
+	    vim_free(p);
+	    break;
+	}
 }
 
 # if defined(HAVE_CANBERRA) || defined(PROTO)
@@ -139,24 +139,24 @@ static soundcb_queue_T *callback_queue = NULL;
  */
 static void
 sound_callback(ca_context *c UNUSED,
-               uint32_t id,
-               int error_code,
-               void *userdata)
+	       uint32_t id,
+	       int error_code,
+	       void *userdata)
 {
     soundcb_T *soundcb = (soundcb_T *)userdata;
     soundcb_queue_T *scb;
 
     scb = ALLOC_ONE(soundcb_queue_T);
     if (scb == NULL)
-        return;
+	return;
     scb->scb_next = callback_queue;
     callback_queue = scb;
     scb->scb_id = id;
     scb->scb_result = error_code == CA_SUCCESS ? 0
-                      : error_code == CA_ERROR_CANCELED ||
-                              error_code == CA_ERROR_DESTROYED
-                          ? 1
-                          : 2;
+		      : error_code == CA_ERROR_CANCELED ||
+			      error_code == CA_ERROR_DESTROYED
+			  ? 1
+			  : 2;
     scb->scb_callback = soundcb;
 }
 
@@ -179,13 +179,13 @@ invoke_sound_callback(void)
 
     while (callback_queue != NULL)
     {
-        scb = callback_queue;
-        callback_queue = scb->scb_next;
+	scb = callback_queue;
+	callback_queue = scb->scb_next;
 
-        call_sound_callback(scb->scb_callback, scb->scb_id, scb->scb_result);
+	call_sound_callback(scb->scb_callback, scb->scb_id, scb->scb_result);
 
-        delete_sound_callback(scb->scb_callback);
-        vim_free(scb);
+	delete_sound_callback(scb->scb_callback);
+	vim_free(scb);
     }
     redraw_after_callback(TRUE, FALSE);
 }
@@ -194,12 +194,12 @@ static void
 sound_play_common(typval_T *argvars, typval_T *rettv, int playfile)
 {
     if (in_vim9script() && check_for_string_arg(argvars, 0) == FAIL)
-        return;
+	return;
 
     if (context == NULL)
-        ca_context_create(&context);
+	ca_context_create(&context);
     if (context == NULL)
-        return;
+	return;
 
     soundcb_T *soundcb = get_sound_callback(&argvars[1]);
     int res = CA_ERROR_INVALID;
@@ -207,34 +207,34 @@ sound_play_common(typval_T *argvars, typval_T *rettv, int playfile)
     ++sound_id;
     if (soundcb == NULL)
     {
-        res = ca_context_play(context, sound_id,
-                              playfile ? CA_PROP_MEDIA_FILENAME
-                                       : CA_PROP_EVENT_ID,
-                              tv_get_string(&argvars[0]),
-                              CA_PROP_CANBERRA_CACHE_CONTROL, "volatile", NULL);
+	res = ca_context_play(context, sound_id,
+			      playfile ? CA_PROP_MEDIA_FILENAME
+				       : CA_PROP_EVENT_ID,
+			      tv_get_string(&argvars[0]),
+			      CA_PROP_CANBERRA_CACHE_CONTROL, "volatile", NULL);
     }
     else
     {
-        static ca_proplist *proplist = NULL;
+	static ca_proplist *proplist = NULL;
 
-        ca_proplist_create(&proplist);
-        if (proplist != NULL)
-        {
-            if (playfile)
-                ca_proplist_sets(proplist, CA_PROP_MEDIA_FILENAME,
-                                 (char *)tv_get_string(&argvars[0]));
-            else
-                ca_proplist_sets(proplist, CA_PROP_EVENT_ID,
-                                 (char *)tv_get_string(&argvars[0]));
-            ca_proplist_sets(proplist, CA_PROP_CANBERRA_CACHE_CONTROL,
-                             "volatile");
-            res = ca_context_play_full(context, sound_id, proplist,
-                                       sound_callback, soundcb);
-            if (res != CA_SUCCESS)
-                delete_sound_callback(soundcb);
+	ca_proplist_create(&proplist);
+	if (proplist != NULL)
+	{
+	    if (playfile)
+		ca_proplist_sets(proplist, CA_PROP_MEDIA_FILENAME,
+				 (char *)tv_get_string(&argvars[0]));
+	    else
+		ca_proplist_sets(proplist, CA_PROP_EVENT_ID,
+				 (char *)tv_get_string(&argvars[0]));
+	    ca_proplist_sets(proplist, CA_PROP_CANBERRA_CACHE_CONTROL,
+			     "volatile");
+	    res = ca_context_play_full(context, sound_id, proplist,
+				       sound_callback, soundcb);
+	    if (res != CA_SUCCESS)
+		delete_sound_callback(soundcb);
 
-            ca_proplist_destroy(proplist);
-        }
+	    ca_proplist_destroy(proplist);
+	}
     }
     rettv->vval.v_number = res == CA_SUCCESS ? sound_id : 0;
 }
@@ -261,10 +261,10 @@ void
 f_sound_stop(typval_T *argvars, typval_T *rettv UNUSED)
 {
     if (in_vim9script() && check_for_number_arg(argvars, 0) == FAIL)
-        return;
+	return;
 
     if (context != NULL)
-        ca_context_cancel(context, tv_get_number(&argvars[0]));
+	ca_context_cancel(context, tv_get_number(&argvars[0]));
 }
 
 /*
@@ -274,7 +274,7 @@ void
 f_sound_clear(typval_T *argvars UNUSED, typval_T *rettv UNUSED)
 {
     if (context == NULL)
-        return;
+	return;
     ca_context_destroy(context);
     context = NULL;
 }
@@ -286,17 +286,17 @@ sound_free(void)
     soundcb_queue_T *scb;
 
     if (context != NULL)
-        ca_context_destroy(context);
+	ca_context_destroy(context);
 
     while (first_callback != NULL)
-        delete_sound_callback(first_callback);
+	delete_sound_callback(first_callback);
 
     while (callback_queue != NULL)
     {
-        scb = callback_queue;
-        callback_queue = scb->scb_next;
-        delete_sound_callback(scb->scb_callback);
-        vim_free(scb);
+	scb = callback_queue;
+	callback_queue = scb->scb_next;
+	delete_sound_callback(scb->scb_callback);
+	vim_free(scb);
     }
 }
 #  endif
@@ -316,25 +316,25 @@ sound_wndproc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
 
     switch (message)
     {
-        case MM_MCINOTIFY:
-            for (p = first_callback; p != NULL; p = p->snd_next)
-                if (p->snd_device_id == (MCIDEVICEID)lParam)
-                {
-                    char buf[32];
+	case MM_MCINOTIFY:
+	    for (p = first_callback; p != NULL; p = p->snd_next)
+		if (p->snd_device_id == (MCIDEVICEID)lParam)
+		{
+		    char buf[32];
 
-                    vim_snprintf(buf, sizeof(buf), "close sound%06ld",
-                                 p->snd_id);
-                    mciSendStringA(buf, NULL, 0, 0);
+		    vim_snprintf(buf, sizeof(buf), "close sound%06ld",
+				 p->snd_id);
+		    mciSendStringA(buf, NULL, 0, 0);
 
-                    long result = wParam == MCI_NOTIFY_SUCCESSFUL ? 0
-                                  : wParam == MCI_NOTIFY_ABORTED  ? 1
-                                                                  : 2;
-                    call_sound_callback(p, p->snd_id, result);
+		    long result = wParam == MCI_NOTIFY_SUCCESSFUL ? 0
+				  : wParam == MCI_NOTIFY_ABORTED  ? 1
+								  : 2;
+		    call_sound_callback(p, p->snd_id, result);
 
-                    delete_sound_callback(p);
-                    redraw_after_callback(TRUE, FALSE);
-                }
-            break;
+		    delete_sound_callback(p);
+		    redraw_after_callback(TRUE, FALSE);
+		}
+	    break;
     }
 
     return DefWindowProc(hwnd, message, wParam, lParam);
@@ -345,12 +345,12 @@ sound_window(void)
 {
     if (g_hWndSound == NULL)
     {
-        LPCSTR clazz = "VimSound";
-        WNDCLASS wndclass = { 0, sound_wndproc, 0,    0, g_hinst, NULL, 0,
-                              0, NULL,          clazz };
-        RegisterClass(&wndclass);
-        g_hWndSound = CreateWindow(clazz, NULL, 0, 0, 0, 0, 0, HWND_MESSAGE,
-                                   NULL, g_hinst, NULL);
+	LPCSTR clazz = "VimSound";
+	WNDCLASS wndclass = { 0, sound_wndproc, 0,    0, g_hinst, NULL, 0,
+			      0, NULL,          clazz };
+	RegisterClass(&wndclass);
+	g_hWndSound = CreateWindow(clazz, NULL, 0, 0, 0, 0, 0, HWND_MESSAGE,
+				   NULL, g_hinst, NULL);
     }
 
     return g_hWndSound;
@@ -362,14 +362,14 @@ f_sound_playevent(typval_T *argvars, typval_T *rettv)
     WCHAR *wp;
 
     if (in_vim9script() && check_for_string_arg(argvars, 0) == FAIL)
-        return;
+	return;
 
     wp = enc_to_utf16(tv_get_string(&argvars[0]), NULL);
     if (wp == NULL)
-        return;
+	return;
 
     if (PlaySoundW(wp, NULL, SND_ASYNC | SND_ALIAS))
-        rettv->vval.v_number = ++sound_id;
+	rettv->vval.v_number = ++sound_id;
     free(wp);
 }
 
@@ -385,7 +385,7 @@ f_sound_playfile(typval_T *argvars, typval_T *rettv)
     MCIERROR err;
 
     if (in_vim9script() && check_for_string_arg(argvars, 0) == FAIL)
-        return;
+	return;
 
     filename = tv_get_string(&argvars[0]);
 
@@ -393,25 +393,25 @@ f_sound_playfile(typval_T *argvars, typval_T *rettv)
     p = alloc(len);
     if (p == NULL)
     {
-        return;
+	return;
     }
     vim_snprintf((char *)p, len, "open \"%s\" alias sound%06ld", filename,
-                 newid);
+		 newid);
 
     wp = enc_to_utf16((char_u *)p, NULL);
     free(p);
     if (wp == NULL)
-        return;
+	return;
 
     err = mciSendStringW(wp, NULL, 0, sound_window());
     free(wp);
     if (err != 0)
-        return;
+	return;
 
     vim_snprintf(buf, sizeof(buf), "play sound%06ld notify", newid);
     err = mciSendStringA(buf, NULL, 0, sound_window());
     if (err != 0)
-        goto failure;
+	goto failure;
 
     sound_id = newid;
     rettv->vval.v_number = sound_id;
@@ -419,9 +419,9 @@ f_sound_playfile(typval_T *argvars, typval_T *rettv)
     soundcb = get_sound_callback(&argvars[1]);
     if (soundcb != NULL)
     {
-        vim_snprintf(buf, sizeof(buf), "sound%06ld", newid);
-        soundcb->snd_id = newid;
-        soundcb->snd_device_id = mciGetDeviceID(buf);
+	vim_snprintf(buf, sizeof(buf), "sound%06ld", newid);
+	soundcb->snd_id = newid;
+	soundcb->snd_device_id = mciGetDeviceID(buf);
     }
     return;
 
@@ -437,7 +437,7 @@ f_sound_stop(typval_T *argvars, typval_T *rettv UNUSED)
     char buf[32];
 
     if (in_vim9script() && check_for_number_arg(argvars, 0) == FAIL)
-        return;
+	return;
 
     id = tv_get_number(&argvars[0]);
     vim_snprintf(buf, sizeof(buf), "stop sound%06ld", id);
@@ -458,7 +458,7 @@ sound_free(void)
     CloseWindow(g_hWndSound);
 
     while (first_callback != NULL)
-        delete_sound_callback(first_callback);
+	delete_sound_callback(first_callback);
 }
 #  endif
 
@@ -469,7 +469,7 @@ static void
 sound_play_common(typval_T *argvars, typval_T *rettv, bool playfile)
 {
     if (in_vim9script() && check_for_string_arg(argvars, 0) == FAIL)
-        return;
+	return;
 
     char_u *sound_name = tv_get_string(&argvars[0]);
     soundcb_T *soundcb = get_sound_callback(&argvars[1]);
@@ -479,7 +479,7 @@ sound_play_common(typval_T *argvars, typval_T *rettv, bool playfile)
     bool play_success = sound_mch_play(sound_name, sound_id, soundcb, playfile);
     if (!play_success && soundcb)
     {
-        delete_sound_callback(soundcb);
+	delete_sound_callback(soundcb);
     }
     rettv->vval.v_number = play_success ? sound_id : 0;
 }
@@ -500,7 +500,7 @@ void
 f_sound_stop(typval_T *argvars, typval_T *rettv UNUSED)
 {
     if (in_vim9script() && check_for_number_arg(argvars, 0) == FAIL)
-        return;
+	return;
     sound_mch_stop(tv_get_number(&argvars[0]));
 }
 
@@ -516,7 +516,7 @@ sound_free(void)
 {
     sound_mch_free();
     while (first_callback != NULL)
-        delete_sound_callback(first_callback);
+	delete_sound_callback(first_callback);
 }
 #  endif
 

--- a/src/strings.c
+++ b/src/strings.c
@@ -603,9 +603,9 @@ vim_strnicmp_asc(char *s1, char *s2, size_t len)
     {
        i = TOLOWER_ASC(*s1) - TOLOWER_ASC(*s2);
        if (i != 0)
-           break;			// this character is different
+	   break;			// this character is different
        if (*s1 == NUL)
-           break;			// strings match until NUL
+	   break;			// strings match until NUL
        ++s1;
        ++s2;
        --len;

--- a/src/testdir/test_codestyle.vim
+++ b/src/testdir/test_codestyle.vim
@@ -163,5 +163,27 @@ def Test_help_files()
   bwipe!
 enddef
 
+def Test_indent_of_source_files()
+  for fname in glob('../*.[ch]', 0, 1) + ['../xxd/xxd.c']
+    execute 'tabnew ' .. fname
+    for lnum in range(1, line('$'))
+      var name: string = synIDattr(synID(lnum, 1, 0), 'name')
+      if -1 == index(['cComment', 'cCommentStart'], name)
+        var line: string = getline(lnum)
+        var indent: string = matchstr(line, '^\s*')
+        var tailing: string = matchstr(line, '\s*$')
+        if !empty(indent)
+          if indent !~# '^\t* \{0,7\}$'
+            ReportError('testdir/' .. fname, lnum, 'invalid indent')
+          endif
+        endif
+        if !empty(tailing)
+          ReportError('testdir/' .. fname, lnum, 'tailing spaces')
+        endif
+      endif
+    endfor
+    close
+  endfor
+enddef
 
 " vim: shiftwidth=2 sts=2 expandtab nofoldenable

--- a/src/xxd/xxd.c
+++ b/src/xxd/xxd.c
@@ -357,7 +357,7 @@ parse_hex_digit(int c)
 parse_bin_digit(int c)
 {
   return (c >= '0' && c <= '1') ? c - '0'
-        : -1;
+	: -1;
 }
 
 /*
@@ -405,53 +405,53 @@ huntype(
 	continue;
 
       if (hextype == HEX_NORMAL || hextype == HEX_POSTSCRIPT)
-        {
+	{
 	  n3 = n2;
 	  n2 = n1;
 
 	  n1 = parse_hex_digit(c);
 	  if (n1 == -1 && ign_garb)
 	    continue;
-        }
+	}
       else /* HEX_BITS */
-        {
+	{
 	  n1 = parse_hex_digit(c);
 	  if (n1 == -1 && ign_garb)
 	    continue;
 
-          bt = parse_bin_digit(c);
-          if (bt != -1)
-            {
-              b = ((b << 1) | bt);
-              ++bcnt;
-            }
-        }
+	  bt = parse_bin_digit(c);
+	  if (bt != -1)
+	    {
+	      b = ((b << 1) | bt);
+	      ++bcnt;
+	    }
+	}
 
       ign_garb = 0;
 
       if ((hextype != HEX_POSTSCRIPT) && (p >= cols))
 	{
-          if (hextype == HEX_NORMAL)
-            {
+	  if (hextype == HEX_NORMAL)
+	    {
 	      if (n1 < 0)
-	        {
-	          p = 0;
-	          continue;
-	        }
+		{
+		  p = 0;
+		  continue;
+		}
 	      want_off = (want_off << 4) | n1;
-            }
-          else /* HEX_BITS */
-            {
+	    }
+	  else /* HEX_BITS */
+	    {
 	      if (n1 < 0)
-	        {
-	          p = 0;
-                  bcnt = 0;
-	          continue;
-	        }
+		{
+		  p = 0;
+		  bcnt = 0;
+		  continue;
+		}
 	      want_off = (want_off << 4) | n1;
-            }
-          continue;
-        }
+	    }
+	  continue;
+	}
 
       if (base_off + want_off != have_off)
 	{
@@ -468,35 +468,35 @@ huntype(
 	}
 
       if (hextype == HEX_NORMAL || hextype == HEX_POSTSCRIPT)
-        {
-          if (n2 >= 0 && n1 >= 0)
-            {
-              putc_or_die((n2 << 4) | n1, fpo);
-              have_off++;
-              want_off++;
-              n1 = -1;
-              if (!hextype && (++p >= cols))
-              /* skip the rest of the line as garbage */
-              c = skip_to_eol(fpi, c);
-            }
-          else if (n1 < 0 && n2 < 0 && n3 < 0)
-            /* already stumbled into garbage, skip line, wait and see */
-            c = skip_to_eol(fpi, c);
-        }
+	{
+	  if (n2 >= 0 && n1 >= 0)
+	    {
+	      putc_or_die((n2 << 4) | n1, fpo);
+	      have_off++;
+	      want_off++;
+	      n1 = -1;
+	      if (!hextype && (++p >= cols))
+	      /* skip the rest of the line as garbage */
+	      c = skip_to_eol(fpi, c);
+	    }
+	  else if (n1 < 0 && n2 < 0 && n3 < 0)
+	    /* already stumbled into garbage, skip line, wait and see */
+	    c = skip_to_eol(fpi, c);
+	}
       else /* HEX_BITS */
-        {
-          if (bcnt == 8)
-            {
-              putc_or_die(b, fpo);
-              have_off++;
-              want_off++;
-              b = 0;
-              bcnt = 0;
-              if (++p >= cols)
-                /* skip the rest of the line as garbage */
-                 c = skip_to_eol(fpi, c);
-            }
-        }
+	{
+	  if (bcnt == 8)
+	    {
+	      putc_or_die(b, fpo);
+	      have_off++;
+	      want_off++;
+	      b = 0;
+	      bcnt = 0;
+	      if (++p >= cols)
+		/* skip the rest of the line as garbage */
+		 c = skip_to_eol(fpi, c);
+	    }
+	}
 
       if (c == '\n')
 	{
@@ -595,41 +595,41 @@ begin_coloring_char (char *l, int *c, int e, int ebcdic)
   if (ebcdic)
     {
       if ((e >= 75 && e <= 80) || (e >= 90 && e <= 97) ||
-          (e >= 107 && e <= 111) || (e >= 121 && e <= 127) ||
-          (e >= 129 && e <= 137) || (e >= 145 && e <= 154) ||
-          (e >= 162 && e <= 169) || (e >= 192 && e <= 201) ||
-          (e >= 208 && e <= 217) || (e >= 226 && e <= 233) ||
-          (e >= 240 && e <= 249) || (e == 189) || (e == 64) ||
-          (e == 173) || (e == 224) )
-        l[(*c)++] = COLOR_GREEN;
+	  (e >= 107 && e <= 111) || (e >= 121 && e <= 127) ||
+	  (e >= 129 && e <= 137) || (e >= 145 && e <= 154) ||
+	  (e >= 162 && e <= 169) || (e >= 192 && e <= 201) ||
+	  (e >= 208 && e <= 217) || (e >= 226 && e <= 233) ||
+	  (e >= 240 && e <= 249) || (e == 189) || (e == 64) ||
+	  (e == 173) || (e == 224) )
+	l[(*c)++] = COLOR_GREEN;
 
       else if (e == 37 || e == 13 || e == 5)
-        l[(*c)++] = COLOR_YELLOW;
+	l[(*c)++] = COLOR_YELLOW;
       else if (e == 0)
-        l[(*c)++] = COLOR_WHITE;
+	l[(*c)++] = COLOR_WHITE;
       else if (e == 255)
-        l[(*c)++] = COLOR_BLUE;
+	l[(*c)++] = COLOR_BLUE;
       else
-        l[(*c)++] = COLOR_RED;
+	l[(*c)++] = COLOR_RED;
     }
   else  /* ASCII */
     {
       #if defined(__MVS__) && __CHARSET_LIB == 0
       if (e >= 64)
-        l[(*c)++] = COLOR_GREEN;
+	l[(*c)++] = COLOR_GREEN;
       #else
       if (e > 31 && e < 127)
-        l[(*c)++] = COLOR_GREEN;
+	l[(*c)++] = COLOR_GREEN;
       #endif
 
       else if (e == 9 || e == 10 || e == 13)
-        l[(*c)++] = COLOR_YELLOW;
+	l[(*c)++] = COLOR_YELLOW;
       else if (e == 0)
-        l[(*c)++] = COLOR_WHITE;
+	l[(*c)++] = COLOR_WHITE;
       else if (e == 255)
-        l[(*c)++] = COLOR_BLUE;
+	l[(*c)++] = COLOR_BLUE;
       else
-        l[(*c)++] = COLOR_RED;
+	l[(*c)++] = COLOR_RED;
     }
   l[(*c)++] = 'm';
 }
@@ -815,20 +815,20 @@ main(int argc, char *argv[])
 	    }
 	}
       else if (!STRNCMP(pp, "-n", 2))
-        {
-          if (pp[2] && STRNCMP("ame", pp + 2, 3))
-            varname = pp + 2;
-          else
-            {
-              if (!argv[2])
-                exit_with_usage();
-              varname = argv[2];
-              argv++;
-              argc--;
-            }
-        }
+	{
+	  if (pp[2] && STRNCMP("ame", pp + 2, 3))
+	    varname = pp + 2;
+	  else
+	    {
+	      if (!argv[2])
+		exit_with_usage();
+	      varname = argv[2];
+	      argv++;
+	      argc--;
+	    }
+	}
       else if (!STRNCMP(pp, "-R", 2))
-        {
+	{
 	  char *pw = pp + 2;
 	  if (!pw[0])
 	    {
@@ -849,7 +849,7 @@ main(int argc, char *argv[])
 	    color = enable_color();
 	  else
 	    exit_with_usage();
-        }
+	}
       else if (!strcmp(argv[1], "--"))	/* end of options */
 	{
 	  argv++;
@@ -867,9 +867,9 @@ main(int argc, char *argv[])
 
   if (hextype != (HEX_CINCLUDE | HEX_BITS))
     {
-        /* Allow at most one bit to be set in hextype */
-        if (hextype & (hextype - 1))
-            error_exit(1, "only one of -b, -e, -u, -p, -i can be used");
+	/* Allow at most one bit to be set in hextype */
+	if (hextype & (hextype - 1))
+	    error_exit(1, "only one of -b, -e, -u, -p, -i can be used");
     }
 
   if (!colsgiven || (!cols && hextype != HEX_POSTSCRIPT))
@@ -952,11 +952,11 @@ main(int argc, char *argv[])
       case HEX_NORMAL:
       case HEX_POSTSCRIPT:
       case HEX_BITS:
-        return huntype(fp, fpo, cols, hextype,
-          negseek ? -seekoff : seekoff);
-        break;
+	return huntype(fp, fpo, cols, hextype,
+	  negseek ? -seekoff : seekoff);
+	break;
       default:
-        error_exit(-1, "Sorry, cannot revert this type of hexdump");
+	error_exit(-1, "Sorry, cannot revert this type of hexdump");
       }
 
   if (seekoff || negseek || !relseek)
@@ -988,7 +988,7 @@ main(int argc, char *argv[])
     {
       /* A user-set variable name overrides fp == stdin */
       if (varname == NULL && fp != stdin)
-        varname = argv[1];
+	varname = argv[1];
 
       if (varname != NULL)
 	{
@@ -1000,28 +1000,28 @@ main(int argc, char *argv[])
 
       p = 0;
       while ((length < 0 || p < length) && (c = getc_or_die(fp)) != EOF)
-        {
-          if (hextype & HEX_BITS)
+	{
+	  if (hextype & HEX_BITS)
 	    {
-              if (p == 0)
-                fputs_or_die("  ", fpo);
-              else if (p % cols == 0)
-                fputs_or_die(",\n  ", fpo);
-              else
-                fputs_or_die(", ", fpo);
+	      if (p == 0)
+		fputs_or_die("  ", fpo);
+	      else if (p % cols == 0)
+		fputs_or_die(",\n  ", fpo);
+	      else
+		fputs_or_die(", ", fpo);
 
-              FPRINTF_OR_DIE((fpo, "0b"));
-              for (int j = 7; j >= 0; j--)
-                putc_or_die((c & (1 << j)) ? '1' : '0', fpo);
-              p++;
+	      FPRINTF_OR_DIE((fpo, "0b"));
+	      for (int j = 7; j >= 0; j--)
+		putc_or_die((c & (1 << j)) ? '1' : '0', fpo);
+	      p++;
 	    }
-          else
+	  else
 	    {
 	      FPRINTF_OR_DIE((fpo, (hexx == hexxa) ? "%s0x%02x" : "%s0X%02X",
 		(p % cols) ? ", " : (!p ? "  " : ",\n  "), c));
 	      p++;
 	    }
-        }
+	}
 
       if (p)
 	fputs_or_die("\n", fpo);
@@ -1065,7 +1065,7 @@ main(int argc, char *argv[])
     {
       grplen = octspergrp + octspergrp + 1;	/* chars per octet group */
       if (color)
-        grplen += 11 * octspergrp;  /* color-code needs 11 extra characters */
+	grplen += 11 * octspergrp;  /* color-code needs 11 extra characters */
     }
   else	/* hextype == HEX_BITS */
     grplen = 8 * octspergrp + 1;
@@ -1083,15 +1083,15 @@ main(int argc, char *argv[])
       c = addrlen + 1 + (grplen * x) / octspergrp;
       if (hextype == HEX_NORMAL || hextype == HEX_LITTLEENDIAN)
 	{
-          if (color)
-            {
+	  if (color)
+	    {
 	      COLOR_PROLOGUE
 	      begin_coloring_char(l,&c,e,ebcdic);
 	      l[c++] = hexx[(e >> 4) & 0xf];
 	      l[c++] = hexx[e & 0xf];
 	      COLOR_EPILOGUE
 	    }
-          else /*No colors*/
+	  else /*No colors*/
 	    {
 	      l[c]   = hexx[(e >> 4) & 0xf];
 	      l[++c] = hexx[e & 0xf];
@@ -1112,95 +1112,95 @@ main(int argc, char *argv[])
 	c = (grplen * cols - 1) / octspergrp;
 
       if (color)
-        {
-          if (hextype == HEX_BITS)
-            c += addrlen + 3 + p*12;
-          else
-            c = addrlen + 3 + (grplen * cols - 1)/octspergrp + p*12;
+	{
+	  if (hextype == HEX_BITS)
+	    c += addrlen + 3 + p*12;
+	  else
+	    c = addrlen + 3 + (grplen * cols - 1)/octspergrp + p*12;
 
-          COLOR_PROLOGUE
-          begin_coloring_char(l,&c,e,ebcdic);
+	  COLOR_PROLOGUE
+	  begin_coloring_char(l,&c,e,ebcdic);
 #if defined(__MVS__) && __CHARSET_LIB == 0
-          if (e >= 64)
-            l[c++] = e;
-          else
-            l[c++] = '.';
+	  if (e >= 64)
+	    l[c++] = e;
+	  else
+	    l[c++] = '.';
 #else
-          if (ebcdic)
-            e = (e < 64) ? '.' : etoa64[e-64];
-          l[c++] = (e > 31 && e < 127) ? e : '.';
+	  if (ebcdic)
+	    e = (e < 64) ? '.' : etoa64[e-64];
+	  l[c++] = (e > 31 && e < 127) ? e : '.';
 #endif
-          COLOR_EPILOGUE
-        }
+	  COLOR_EPILOGUE
+	}
       else /*no colors*/
-        {
-          if (ebcdic)
-            e = (e < 64) ? '.' : etoa64[e-64];
+	{
+	  if (ebcdic)
+	    e = (e < 64) ? '.' : etoa64[e-64];
 
-          if (hextype == HEX_LITTLEENDIAN)
-            c -= 1;
+	  if (hextype == HEX_LITTLEENDIAN)
+	    c -= 1;
 
-          c += addrlen + 3 + p;
-          l[c++] =
+	  c += addrlen + 3 + p;
+	  l[c++] =
 #if defined(__MVS__) && __CHARSET_LIB == 0
-              (e >= 64)
+	      (e >= 64)
 #else
-              (e > 31 && e < 127)
+	      (e > 31 && e < 127)
 #endif
-              ? e : '.';
-        }
-        n++;
-        if (++p == cols)
-          {
-            l[c++] = '\n';
-            l[c] = '\0';
-            xxdline(fpo, l, autoskip ? nonzero : 1);
-            nonzero = 0;
-            p = 0;
-          }
+	      ? e : '.';
+	}
+	n++;
+	if (++p == cols)
+	  {
+	    l[c++] = '\n';
+	    l[c] = '\0';
+	    xxdline(fpo, l, autoskip ? nonzero : 1);
+	    nonzero = 0;
+	    p = 0;
+	  }
     }
   if (p)
     {
       l[c++] = '\n';
       l[c] = '\0';
       if (color)
-        {
-          x = p;
-          if (hextype == HEX_LITTLEENDIAN)
-            {
-              int fill = octspergrp - (p % octspergrp);
-              if (fill == octspergrp) fill = 0;
+	{
+	  x = p;
+	  if (hextype == HEX_LITTLEENDIAN)
+	    {
+	      int fill = octspergrp - (p % octspergrp);
+	      if (fill == octspergrp) fill = 0;
 
-              c = addrlen + 1 + (grplen * (x - (octspergrp-fill))) / octspergrp;
+	      c = addrlen + 1 + (grplen * (x - (octspergrp-fill))) / octspergrp;
 
-              for (i = 0; i < fill;i++)
-                {
-                  COLOR_PROLOGUE
-                  l[c++] = COLOR_RED;
-                  l[c++] = 'm';
-                  l[c++] = ' '; /* empty space */
-                  COLOR_EPILOGUE
-                  x++;
-                  p++;
-                }
-            }
+	      for (i = 0; i < fill;i++)
+		{
+		  COLOR_PROLOGUE
+		  l[c++] = COLOR_RED;
+		  l[c++] = 'm';
+		  l[c++] = ' '; /* empty space */
+		  COLOR_EPILOGUE
+		  x++;
+		  p++;
+		}
+	    }
 
-          if (hextype != HEX_BITS)
-            {
-              c = addrlen + 1 + (grplen * x) / octspergrp;
-              c += cols - p;
-              c += (cols - p) / octspergrp;
+	  if (hextype != HEX_BITS)
+	    {
+	      c = addrlen + 1 + (grplen * x) / octspergrp;
+	      c += cols - p;
+	      c += (cols - p) / octspergrp;
 
-              for (i = cols - p; i > 0;i--)
-                {
-                  COLOR_PROLOGUE
-                  l[c++] = COLOR_RED;
-                  l[c++] = 'm';
-                  l[c++] = ' '; /* empty space */
-                  COLOR_EPILOGUE
-                }
-            }
-        }
+	      for (i = cols - p; i > 0;i--)
+		{
+		  COLOR_PROLOGUE
+		  l[c++] = COLOR_RED;
+		  l[c++] = 'm';
+		  l[c++] = ' '; /* empty space */
+		  COLOR_EPILOGUE
+		}
+	    }
+	}
       xxdline(fpo, l, 1);
     }
   else if (autoskip)


### PR DESCRIPTION
I noticed that each line of Vim's source code is supposed to follow the indentation pattern `^\t* \{0,7\}`, but some lines still don't conform to it. So I added an indentation test and fixed the lines with incorrect indentation.