### PR TITLE
runtime/pack/dist/opt/helptoc improved

### DIFF
--- a/.github/MAINTAINERS
+++ b/.github/MAINTAINERS
@@ -124,6 +124,7 @@ runtime/doc/vimtutor-ru.UTF-8.1		@RestorerZ
 runtime/doc/xxd-ru.1			@RestorerZ
 runtime/doc/xxd-ru.UTF-8.1		@RestorerZ
 runtime/ftplugin/abaqus.vim		@costerwi
+runtime/ftplugin/abnf.vim		@A4-Tacks
 runtime/ftplugin/antlr4.vim		@jiangyinzuo
 runtime/ftplugin/apache.vim		@dubgeiser
 runtime/ftplugin/arduino.vim		@k-takata

--- a/.github/MAINTAINERS
+++ b/.github/MAINTAINERS
@@ -124,7 +124,6 @@ runtime/doc/vimtutor-ru.UTF-8.1		@RestorerZ
 runtime/doc/xxd-ru.1			@RestorerZ
 runtime/doc/xxd-ru.UTF-8.1		@RestorerZ
 runtime/ftplugin/abaqus.vim		@costerwi
-runtime/ftplugin/abnf.vim		@A4-Tacks
 runtime/ftplugin/antlr4.vim		@jiangyinzuo
 runtime/ftplugin/apache.vim		@dubgeiser
 runtime/ftplugin/arduino.vim		@k-takata
@@ -431,6 +430,7 @@ runtime/lang/menu_ru_ru.koi8-r.vim	@RestorerZ
 runtime/lang/menu_ru_ru.utf-8.vim	@RestorerZ
 runtime/pack/dist/opt/cfilter/plugin/cfilter.vim	@yegappan
 runtime/pack/dist/opt/comment/	@habamax
+runtime/pack/dist/opt/helptoc/	@kennypete
 runtime/pack/dist/opt/matchit/		@chrisbra
 runtime/pack/dist/opt/nohlsearch/		@habamax
 runtime/plugin/manpager.vim		@Konfekt

--- a/Filelist
+++ b/Filelist
@@ -808,6 +808,8 @@ RT_ALL =	\
 		runtime/pack/dist/opt/editorconfig/ftdetect/editorconfig.vim \
 		runtime/pack/dist/opt/editorconfig/plugin/editorconfig.vim \
 		runtime/pack/dist/opt/helptoc/autoload/helptoc.vim \
+		runtime/pack/dist/opt/helptoc/doc/helptoc.txt \
+		runtime/pack/dist/opt/helptoc/doc/tags \
 		runtime/pack/dist/opt/helptoc/plugin/helptoc.vim \
 		runtime/pack/dist/opt/hlyank/plugin/hlyank.vim \
 		runtime/pack/dist/opt/justify/plugin/justify.vim \

--- a/runtime/doc/helphelp.txt
+++ b/runtime/doc/helphelp.txt
@@ -1,4 +1,4 @@
-*helphelp.txt*	For Vim version 9.1.  Last change: 2025 Apr 21
+*helphelp.txt*	For Vim version 9.1.  Last change: 2025 May 04
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -287,9 +287,11 @@ The latter supports the following normal commands: >
 	<Home>     | select first entry
 	<End>      | select last entry
 
-The plugin can also provide a table of contents in man pages, markdown files,
-and terminal buffers.  In the latter, the entries will be the past executed
-shell commands.  To find those, the following pattern is used: >
+The plugin can also provide a table of contents in buffers of the following
+filetypes: asciidoc, html, man, markdown, tex, vim, and xhtml.  The plugin can
+also provide a table of contents for a terminal buffer, which produces entries
+that are the past executed shell commands.  To find those, by default, the
+following pattern is used: >
 
 	^\w\+@\w\+:\f\+\$\s
 
@@ -297,11 +299,14 @@ This is meant to match a default bash prompt.  If it doesn't match your prompt,
 you can change the regex with the `shell_prompt` key from the `g:helptoc`
 dictionary variable: >
 
-	let g:helptoc = {'shell_prompt': 'regex matching your shell prompt'}
+	vim9 g:helptoc = {'shell_prompt': 'regex matching your shell prompt'}
 
 Tip: After inserting a pattern to look for with the `/` command, if you press
 <Esc> instead of <CR>, you can then get more context for each remaining entry
 by pressing `J` or `K`.
+
+Refer |helptoc.vim| for more details about helptoc, particularly about using
+it with filetypes other than help, and configuring its options.
 
 ==============================================================================
 2. Translated help files				*help-translated*

--- a/runtime/doc/helphelp.txt
+++ b/runtime/doc/helphelp.txt
@@ -288,10 +288,10 @@ The latter supports the following normal commands: >
 	<End>      | select last entry
 
 The plugin can also provide a table of contents in buffers of the following
-filetypes: asciidoc, html, man, markdown, tex, vim, and xhtml.  The plugin can
-also provide a table of contents for a terminal buffer, which produces entries
-that are the past executed shell commands.  To find those, by default, the
-following pattern is used: >
+filetypes: asciidoc, html, man, markdown, tex, vim, and xhtml.  In addition
+it also provide a table of contents for a terminal buffer, which produces
+entries that are the past executed shell commands.  To find those, by default,
+the following pattern is used: >
 
 	^\w\+@\w\+:\f\+\$\s
 
@@ -299,7 +299,7 @@ This is meant to match a default bash prompt.  If it doesn't match your prompt,
 you can change the regex with the `shell_prompt` key from the `g:helptoc`
 dictionary variable: >
 
-	vim9 g:helptoc = {'shell_prompt': 'regex matching your shell prompt'}
+	let g:helptoc = {'shell_prompt': 'regex matching your shell prompt'}
 
 Tip: After inserting a pattern to look for with the `/` command, if you press
 <Esc> instead of <CR>, you can then get more context for each remaining entry

--- a/runtime/pack/dist/opt/helptoc/doc/helptoc.txt
+++ b/runtime/pack/dist/opt/helptoc/doc/helptoc.txt
@@ -1,0 +1,349 @@
+*helptoc.txt*   For Vim version 9.1.  Last change:  2025 May 04
+
+
+			  VIM REFERENCE MANUAL
+
+Interactive table of contents for help buffers and several other filetypes
+
+==============================================================================
+
+
+1. OVERVIEW						*HelpToc-overview*
+
+The helptoc.vim plugin provides one command, :HelpToc, which generates a
+hierarchical table of contents in a popup window, which is based on the
+structure of a Vim buffer.  It was designed initially for help buffers,
+but it also works with buffers of the following types:
+	- asciidoc
+	- html
+	- man
+	- markdown
+	- terminal
+	- tex
+	- vim		Note: only with numbered fold markers, e.g. {{{1
+	- xhtml
+
+1.1 The :HelpToc command				*HelpToc-:HelpToc*
+
+The :HelpToc command takes no arguments and it cannot be executed from an
+unsupported filetype.  Also, it cannot be used to generate a table of contents
+for an inactive buffer.
+
+For most buffers of the supported types, :HelpToc may be entered directly
+in Vim's |Command-line-mode|.  How to use it from Vim's |Terminal-Job| mode is
+explained in |HelpToc-terminal-buftype|.
+
+You may choose to map :HelpToc to keys making it easier to use.  These are
+examples of what could be used: >
+
+	nnoremap <Leader>ht <Cmd>HelpToc<CR>
+	tnoremap <C-t><C-t> <Cmd>HelpToc<CR>
+<
+
+2. DETAILS						*HelpToc-details*
+
+When the :HelpToc command is executed from an active buffer of a supported
+type, a popup window is produced.  The window contains a hierarchical and
+interactive table of contents.  The entries are based on the "headings" in
+the buffer.
+
+Jumping to an entry's position in the buffer can be achieved by pressing
+enter on the applicable entry.  Navigation, and other commands applicable to
+the popup window, such as expanding and contracting levels, fuzzy searching,
+and jumping to the previous or next entry (leaving the table of contents
+itself displayed, using J and K), is provided at |help-TOC|, so that is not
+reproduced in this help file.
+
+
+3. TYPES						*HelpToc-types*
+
+Some filetypes have more predictable structures than others.  For example,
+markdown and asciidoc make the identification of headings (aside from edge
+cases, such as when in quotes) straightforward.  Some filetypes do not have
+such obvious or reliable headings/levels (particularly help buffers).
+Further, in some instances, how to enter the :HelpToc command is not
+necessarily obvious, e.g., when in a Vim |terminal-window|.  So, the following
+headings address specific details regarding the in-scope types.
+
+3.1 asciidoc					*HelpToc-asciidoc-filetype*
+
+The heading levels in asciidoc are typically identified by lines starting
+with a "=" (up to six, one per level), one or more blank characters, and the
+heading text.  :HelpToc will generate a table of contents based on either
+that form of heading type or, because asciidoc also allows for ATX heading
+level syntax (i.e., using the "#" character), headings using that format too.
+
+As asciidoc is very structured, its table of contents entries are presented
+in a standardized form - see |HelpToc-standardized-toc|.  So, the initial
+"=" or "#" characters and the following space from the related heading are
+not included in the table of contents' entries.
+
+3.2 html					*HelpToc-html-filetype*
+
+HTML provides for six levels of headings, <h1> to <h6>, which may be either
+upper or lower case and preceded by all sorts of content like <!--comments-->.
+:HelpToc will produce a table of contents based on the six heading levels.
+
+As HTML is very structured, its table of contents entries are presented
+in a standardized form - see |HelpToc-standardized-toc|.  So, the <h1> to <h6>
+tags, any preceding content, and any trailing content after the heading text,
+is not included in the table of contents' entries.
+
+3.3 man pages					*HelpToc-man-filetype*
+
+Retrieving man pages is typically performed in the terminal.  To use :HelpToc
+to generate a table of contents, the |man.vim| filetype plugin is a
+prerequisite.  It is provided with Vim, and may be sourced with: >
+
+	:runtime ftplugin/man.vim
+<
+Once sourced, the |:Man| command will open the applicable man page in a new
+buffer (of "man" filetype).  For example: >
+
+	:Man pwd
+<
+Once in the man buffer, entering :HelpToc opens the table of contents popup,
+with level 1 containing section names like NAME, SYNOPSIS, etc.  Levels
+below 1 include subsections and options, with the level depending on the
+number of spaces preceding the content.
+
+The table of contents for a man buffer's popup window has the same syntax
+highlighting as man pages.  This reflects that its content is reproduced
+as-is, i.e., no preceding tags, level-indicating data, etc., need be omitted
+for optimal presentation.
+
+3.4 markdown					*HelpToc-markdown-filetype*
+
+The headings and levels in markdown typically are ATX formatted headings
+(lines starting with up to three spaces, one to six "#", then (optionally)
+one or blank characters and the heading text).  The alternate form,
+setext, uses up to three spaces, the heading 1 text, followed by a
+line of one or more "=".  The setext heading 2 is similar, but for one or
+more "-" instead of "=".  There is no heading 3+ in setext.  ATX and setext
+headings are supported.
+
+As markdown is very structured, its table of contents entries are presented
+in a standardized form - see |HelpToc-standardized-toc|.  So, they do not
+include any leading spaces, any initial "#" characters and the following blank
+character(s) in the table of contents' entries.
+
+3.5 terminal					*HelpToc-terminal-buftype*
+
+There are no explicit "headings" for a terminal buffer.  However, :HelpToc
+displays the history of executed shell commands.  Those may be specified
+by changing the pattern used to match the Vim terminal's prompt.
+See |HelpToc-configuration| for examples.
+
+To access the terminal's table of contents, from the Vim's |Terminal-Job| mode
+enter CTRL-W N to go to |Terminal-Normal| mode.  From there, enter :HelpToc to
+generate the table of contents.  If you use the terminal's table of contents
+a lot, an appropriate mapping may make it easier than using CTRL-W N - e.g.: >
+
+          tnoremap <C-t><C-t> <Cmd>HelpToc<CR>
+<
+As the terminal has only "level 1", the table of contents is presented in a
+standardized form - see |HelpToc-standardized-toc| - including only the history
+list of commands.  The prompt itself is also omitted since it adds no value
+repeating it for every entry.
+
+3.6 tex						*HelpToc-tex-filetype*
+
+In LaTeX, a document may be structured hierarchically using part, chapter,
+and sectioning commands.  Document structure levels are:
+	\part{}
+	\chapter{}
+	\section{}
+	\subsection{}
+	\subsubsection{}
+
+To keep things simpler, \part{} is supported, though treated as being at
+the same level as chapter.  Consequently, there are four levels displayed
+for a tex filetype's table of contents, regardless of the \documentclass{},
+i.e., part and chapter (at level 1), section (level 2), subsection (level 3),
+and subsubsection (level 4).
+
+Also supported are:
+	- The "*" used to produce unnumbered headings, which are not intended
+	  for reproduction in a table of contents: >
+		\section*{Unnumbered section heading not produced in the TOC}
+<	- Manual toc entries using \addcontentsline, for example: >
+		\addcontentsline{toc}{section}{entry in the TOC only!}
+<
+The table of contents for a tex filetype is in a standardized form -
+see |HelpToc-standardized-toc|.  Omitted are: the "\", the part, chapter,
+*section, or addcontentsline, and the left and right curly
+brackets preceding and following each heading's text.
+
+3.7 vim						*HelpToc-vim-filetype*
+
+Vimscript and Vim9 script do not have headings or levels inherently like
+markup languages.  However, Vim provides for |folds| defined by markers (|{{{|),
+which themselves may be succeeded by a number explicitly indicating the fold
+level.  This is the structure recognized and supported by helptoc.vim.
+So, for example, the following would produce three table of contents entries: >
+
+	vim9script
+	# Variables {{{1
+	var b: bool = true
+	var s: string = $"Fold markers are great?  {b}!"
+	# Functions {{{1
+	def MyFunction(): void #{{{2
+	  echo s
+	enddef
+	MyFunction()
+<
+The table of contents for that script would appear like this:
+	Variables
+	Functions
+	| MyFunction(): void
+
+Note: The numbered |{{{| marker structure is the only one supported by
+      helptoc.vim for the vim filetype.
+
+As the {{{1 to {{{6 markers make the "headings" explicit, the table of
+contents is in a standardized form - see |HelpToc-standardized-toc|.
+It does not include any leading comment markers (i.e., either # or ") and
+omits the markers themselves.
+
+3.8 xhtml					*HelpToc-xhtml-filetype*
+
+Although XHTML, being XML, is more strictly structured than HTML/HTML5,
+there is no practical difference in treatment required for the xhtml filetype
+because, at the heading level, the tags that matter are very similar.
+See |HelpToc-html-filetype| for how an xhtml filetype's table of contents is
+supported.
+
+
+4. STANDARDIZED TOC				*HelpToc-standardized-toc*
+
+The table of contents for a help buffer, terminal, or man page, make sense
+being presented in the form they appear, minus trailing content (such as tags).
+
+The table of contents for a markdown, asciidoc, [x]html, terminal, or tex
+buffer have superfluous content if the entire line was to be returned.
+For example:
+- Markdown has "#" characters before headings when using ATX heading notation.
+- Asciidoc will have either those or, more often, "=" characters before its
+  headings.
+- HTML, aside from the "<h" headings, may have additional tags, comments,
+  and whitespace before its headings.
+- The Vim terminal has the shell prompt, which adds nothing if repeated for
+  every heading (and may be very long).
+- LaTeX has "\" level indicators like "\section{" and a trailing "}".
+Consequently, standardising these filetypes' tables of contents, removing
+the "noise", and indicating the contents level of each entry, makes sense.
+
+HelpToc standardizes the markdown, asciidoc, [x]html, terminal and tex tables
+of contents by removing extraneous characters, markup indicators, and tags.
+It also applies simple, unobtrusive syntax highlighting to the text and level
+indicators.  By default, it will appear like the following example (though
+any level indicators will be less prominent, using |NonText| highlight group).
+
+	Level 1
+	| Level 2
+	| | Level 3
+	| | | Level 4
+	| | | | Level 5
+	| | | | | Level 6
+
+Note: The "| " level indicator may be changed - see |HelpToc-configuration|.
+
+
+5. CONFIGURATION				*HelpToc-configuration*
+
+All configuration is achieved utilizing the g:helptoc dictionary.  Any of the
+following may be adjusted to meet your needs or preferences:
+
+g:helptoc key	 what it controls
+-------------	 ----------------
+shell_prompt	 The terminal prompt, used for creating a table of contents
+		 for the terminal (history list).  The default is,
+		 '^\w\+@\w\+:\f\+\$\s', which should match many users' bash
+		 prompt.  To change it, either interactively or in your .vimrc,
+		 use (for example for a bare Bourne shell "$ " prompt): >
+			vim9 g:helptoc.shell_prompt = '^\$\s'
+
+<level_indicator  This key's value controls the level indicator used in
+		 standardized tables of contents.  The default is '| '
+		 (i.e., a vertical bar and a space), but may be changed to
+		 whatever you want.  For example, for a broken bar and space: >
+			vim9 g:helptoc.level_indicator = '¦ '
+<
+popup_border	 By default, the table of contents border will appear above,
+		 right, below, and left of the popup window.  If you prefer
+		 not to have the border on the right and left (for example
+		 only), you can achieve that with: >
+			vim9 g:helptoc.popup_border = [1, 0, 1, 0]
+<popup_borderchars
+		 The default border characters for the table of contents popup
+		 window is the list ['─', '│', '─', '│', '┌', '┐', '┘', '└'].
+		 There's nothing wrong with those box drawing characters,
+		 though, for example, if you wanted a border that only uses
+		 ASCII characters, you could make the border spaces only: >
+			vim9 g:helptoc.popup_borderchars = [' ']
+<popup_borderhighlight
+		 The default border highlight group is Normal.  You can change
+		 that, perhaps in combination with popup_borderchars, above,
+		 to create a very clearly prominent border.  For example, if
+		 the popup_borderchars are made [' '], like above, the border
+		 could be made a solid colour different to the background
+		 with: >
+			vim9 g:helptoc.popup_borderhighlight = ['Cursor']
+
+<			  Note: Choosing a highlight group that persists when
+				colorschemes change may be a good idea if you
+				do choose to customize this.
+
+popup_drag	By default, table of contents popup windows may be dragged
+		with a mouse.  If you want to prevent that from happening,
+		for whatever reason, you may deactivate it with: >
+			vim9 g:helptoc.popup_drag = false
+<
+popup_close	Table of contents popups have "none" as the default setting
+		for this option.  If you use a mouse, you may want either
+		to have the option to close popup windows by clicking on them
+		or to have a clickable "X" in the top right corner.  For the
+		former, use "click", and for the latter, use "button", e.g.: >
+			vim9 g:helptoc.popup_close = "button"
+<popup_scrollbar
+		No scrollbar is provided on helptoc popups by default.  If you
+		do want scrollbars (which may be useful as an indicator of how
+		far through the table of contents you are, not just for using
+		with a mouse) you may choose to have them with: >
+			vim9 g:helptoc.popup_scrollbar = true
+<
+NOTE: Information about the "popup_*" options, above, relate to popup options,
+which are explained at the 'second argument' part of |popup_create-arguments|.
+
+
+6. LIMITATIONS					*HelpToc-limitations*
+
+- The help filetype may have edge case formatting patterns.  Those may result
+  in some "headings" not being identified and/or may impact the heading levels
+  of entries in the table of contents itself.
+- Terminal window table of contents may not be active (insofar as jumping to
+  entries going to the Vim terminal's related command line).  For example, if
+  Vim's terminal is set to Windows PowerShell Core, the table of contents will
+  display successfully, though the entries go nowhere when Enter, J, or K are
+  entered on them.
+- The tex filetype may have variable sectioning commands depending on the
+  document class.  Consequently, some compromises are made, though they should
+  have minimal impact.  Specifically:
+  * In instances where \part{} and \chapter{} appear in the same buffer, they
+    will both present at the top level in the table of contents.  This should
+    be a minor matter because, in many instances, chapters will be in a
+    separate document using \include{}.
+  * An article or beamer \documentclass without a \part{} (or any document
+    with neither any \part{} nor any \chapter{} command) will have no content
+    at level 1.  Consequently, its table of contents entries will all appear
+    preceded by at least one "| " (by default) because its headings start at
+    level 2 (presuming \section{} is present).
+- The vim filetype is only supported where numbered fold markers are applied.
+  This is intentional (including not handling unnumbered markers, which, when
+  used in combination with numbered ones, may be used for folding comments).
+  helptoc.vim itself provides an exemplar of how to use numbered fold markers,
+  not only for folds, but to support generating a useful table of contents
+  using :HelpToc.
+
+==============================================================================
+vim:tw=78:ts=8:fo=tcq2:ft=help:

--- a/runtime/pack/dist/opt/helptoc/doc/tags
+++ b/runtime/pack/dist/opt/helptoc/doc/tags
@@ -1,0 +1,16 @@
+HelpToc-:HelpToc	helptoc.txt	/*HelpToc-:HelpToc*
+HelpToc-asciidoc-filetype	helptoc.txt	/*HelpToc-asciidoc-filetype*
+HelpToc-configuration	helptoc.txt	/*HelpToc-configuration*
+HelpToc-details	helptoc.txt	/*HelpToc-details*
+HelpToc-html-filetype	helptoc.txt	/*HelpToc-html-filetype*
+HelpToc-limitations	helptoc.txt	/*HelpToc-limitations*
+HelpToc-man-filetype	helptoc.txt	/*HelpToc-man-filetype*
+HelpToc-markdown-filetype	helptoc.txt	/*HelpToc-markdown-filetype*
+HelpToc-overview	helptoc.txt	/*HelpToc-overview*
+HelpToc-standardized-toc	helptoc.txt	/*HelpToc-standardized-toc*
+HelpToc-terminal-buftype	helptoc.txt	/*HelpToc-terminal-buftype*
+HelpToc-tex-filetype	helptoc.txt	/*HelpToc-tex-filetype*
+HelpToc-types	helptoc.txt	/*HelpToc-types*
+HelpToc-vim-filetype	helptoc.txt	/*HelpToc-vim-filetype*
+HelpToc-xhtml-filetype	helptoc.txt	/*HelpToc-xhtml-filetype*
+helptoc.txt	helptoc.txt	/*helptoc.txt*


### PR DESCRIPTION
# HelpToc Improved

The `helptoc` dist/opt plugin is a [little known?] gem.  It's very good already, though with some improvements, which this PR delivers, it can be great.

This is a summary of fixes, changes, and lots of improvement to the helptoc plugin.

## Files Changed and Why

- `runtime/pack/dist/opt/helptoc/autoload/helptoc.vim`.  This is the main updated Vim9 script.  Changes are explained under the headings, below.
- `runtime/pack/dist/opt/helptoc/doc/helptoc.txt`.  A new help file provides details about the plugin not included already in `helphelp.vim`, which has some information.  `helptoc.txt` explains specifics related to the supported filetypes, configuration options, and more.
- `runtime/pack/dist/opt/helptoc/doc/tags`.  A tags file for the new help file, `helptoc.txt`.
- `runtime/doc/helphelp.txt`.  Incidental changes address the improved helptoc, though most of the content remains as-is because it is focused, logically, mostly on help buffers rather than other filetypes.
- `.github/MAINTAINERS`.  There was no maintainer for `runtime/pack/dist/opt/helptoc/`.  I have added myself, though should
the original author/others be included too? (_I also noticed that there's a line flagged for deletion - that was not intentional - not sure how that came to be, so probably needs to be ignored_).

## Filetype Support

### Support for Additional Filetypes

New table of contents generation support - `MATCH_ENTRY` has additions, matching:

- **asciidoc** (with either native `=` or `#` headings handled, following, https://docs.asciidoctor.org/asciidoc/latest/sections/titles-and-levels/ [Lines 131-140]
- **html** and **xhtml** (`<h1>` to `<h6>`) [Lines 142-149 and lines 206-213]
- **tex** (`\part{...}` to `\subsection{...}` and also `addcontentsline{toc}{part/.../subsection}`) [Lines 177-195]
- **vim** (using numbered `{{{` markers only) [Lines 197-204]

In all instances, except tex, the patterns use very magic.  This makes them easier to read - previously some had loads of backslashes.  There is also a constant, `HTML_H`, for the pattern that may precede the `1` of `<h1>`, `2` of `<h2>`, etc. [Line 124]

### Improved Support for Markdown

**markdown**:

- Did not allow for headings in languages using non-ASCII characters. This is a simple fix, using `\S` for the heading text instead of `\w`. This change would close <https://github.com/vim/vim/issues/16945>.  [Lines 161-165]
- Headings in ATX format now are handled to the extent allowed by <https://spec.commonmark.org/0.31.2/#atx-headings>, which allows for up to three spaces (not tabs) before the first "#" instance.  It also handles empty headings, which were not supported.  [Lines 166-179 and 442]
- Headings in setext format are now handled to the extent allowed by <https://spec.commonmark.org/0.31.2/#setext-headings>. Two TYPE checks and `skip_next` are added to deliver this improvement.  [Lines 161-169, 538-542
and 546-570]

### Sanitised Tables of Contents and Popup Presentation

The added filetypes have lots of extraneous content.  Even the current markdown handling was not optimal because it included `#`s and following spaces in the table of contents' entries.  To make the tables of contents clearer, all filetypes (except help and man pages) have sanitised entries.  [Lines 322-334, 353-473, and 546-558]  Level one has nothing except the heading's text.  From levels 2 onwards, a `| ` is included for each additional level.  The `| ` may be determined by the user by changing `g:helptoc.level_indicator`.

Specific "noise" related to particular filetypes is also handled (e.g., HTML comments [Line 398], processing instructions  [Line 392], TeX escaped characters [Line 462], and Markdown hyperlinks with or without images [Lines 422-425]).  These things make for a more user-friendly and easy-to-read table of contents.

Simple syntax highlighting has been created for the sanitised tables of contents.  [Lines 54-64]  It applies `Normal` to the entries' text and `NonText` to any level indicators, so that they are not as prominent as the text.  The filetypes this applied to are determined by the `SanitizedTocSyntaxTypes` list and a conditional.  [Lines 350-358]

Filetype-specific processing lambdas are included for the types asciidoc, [x]html, markdown, terminal, tex, and vim.  These remove extraneous content such as `#` and following spaces in markdown, `=` in asciidoc, tags in [x]html, etc.  [Lines 353-473, 546-558]

## Configuration Improvements and Additions

### Shell Prompt

How the shell prompt pattern is stored and updated has been simplified to use `g:helptoc` (adding the key, `prior_shell_prompt`).  [Lines 8-12, 16-20]

### Popup Presentation Options

Added user-configurable options for popup appearance [Lines 40-49], through `g:helptoc`, though current defaults are maintained, for:
- `popup_border` - Determines border presence
- `popup_borderchars` - Configures border characters
- `popup_borderhighlight` - Sets highlight group for borders
- `popup_close` - Controls `close` option (to allow, e.g., `'button'`, which also means handling for the `close: 'button'` event in the Callback function, `-2`, is added [Lines 1153-1154])
- `popup_drag` - Allows the user to disable `'drag'`
- `popup_scrollbar` - Toggles scrollbar visibility (but it has been made always on for the help popup).

There is a new `level_indicator` added.  It allows the user to customise the level indicator used in the sanitised TOCs. [Line 49]  (The default is `| `.)

## Help Window: Minor Adjustments

- The width has a revised formula; from testing, it works better [Line 1182]
- The help window is centered because, if the user opens it, they probably want to be focused on it. [Line 1186]  In a similar vein, `line:` and `col:` are omitted, making the help window vertically and horizontally centred.
- The `scrollbar:` has been made "always on" (true) because, although it may not be used for scrolling by non-mouse users, it provides a useful indicator regarding how far through the popup you are (noting it is very long)  [Line 1197]
- `border:`, `borderchars:`, `borderhighlight:`, and `close:` are enabled for users to determine using `g:helptoc.popup_*` configuration. [Lines 1193-1196]

## Code Organisation

- Improved folding markers: `helptoc.vim` itself now renders a nice ToC with `:HelpToc`, illustrating a benefit of using numbered fold markers in a Vim9 script/vimscript  [{{{1, {{{2, and {{{3, throughout]  There is a demo of this in _Animated .gif demonstrations_, below.
- More comments (though mostly to the new code).  [Throughout]
- Many instances of double spaces removed from existing comments.  [Throughout]
- No lines >=80 characters.  [Throughout]
- Added an appropriate modeline consistent with the pre-existing structure (particularly `fdm=marker`, given `helptoc.vim` itself can now produce a nice table of contents of itself).

## Incidental / Miscellaneous

- The `const AUGROUP: string = 'HelpToc'` added little because it was only used in a few places, so the string, 'HelpToc' has been
used as-is instead. [Lines 986, 992, and 1228]
- In `MATCH_ENTRY`, `line` is replaced with `l`, which arguably makes it easier to read and certainly facilitates <80 character lines.

## Animated .gif demonstrations

### Types

These demonstrations show various aspects of the improvements, including the sanitized ToCs, all the new types, including edge cases (such as empty headings in XHTML, AsciiDoc using `=` and `#` headings, Markdown using setext headings, XML named and numeric character references - e.g., `&#x1F47D;` to 👽 in the entries for AsciiDoc, Markdown, and [X]HTML) and much more.

- **asciidoc**: [20250503-asciidoc.gif](https://postimg.cc/N9gdXzBG)
- **help** using `helptoc.txt`: [20250503-help.gif](https://postimg.cc/7fNjQ0tW)
- **html**: [20250503-html5.gif](https://postimg.cc/G82SN5N7)
- **man**: [20250503-man.gif](https://postimg.cc/K10rBZc1)
- **markdown**: [20250503-markdown.gif](https://postimg.cc/MfGjWBRt)
- **terminal**: [20250503-sh.gif](https://postimg.cc/bdn7T5ty)
- **tex**: [20250503-latex.gif](https://postimg.cc/v1RqcY05)
- **vim** using `helptoc.vim`: [20250503-vim.gif](https://postimg.cc/wy4DRF9n)
- **xhtml**: [20250503-xhtml.gif](https://postimg.cc/pyYpSsNv)

### Configuration

Using Windows gvim, [20250503-config.gif](https://postimg.cc/Jt4SZhQL), this is an annotated example, changing `popup_borderchars`, `popup_borderhighlight`, `popup_close`, and using ` ¦ ` (space, U+00A6, space) instead of `| ` (U+007C, space) for the `level_indicator`.