### PR TITLE
runtime(toml): update syntax and ftplugin.

### DIFF
--- a/runtime/ftplugin/toml.vim
+++ b/runtime/ftplugin/toml.vim
@@ -3,7 +3,7 @@
 " Homepage:    https://github.com/cespare/vim-toml
 " Maintainer:  Aman Verma
 " Author:      Lily Ballard <lily@ballards.net>
-" Last Change: Sep 21, 2021
+" Last Change: May 5, 2025
 
 if exists('b:did_ftplugin')
   finish
@@ -12,10 +12,11 @@ let b:did_ftplugin = 1
 
 let s:save_cpo = &cpo
 set cpo&vim
-let b:undo_ftplugin = 'setlocal commentstring< comments<'
+let b:undo_ftplugin = 'setlocal commentstring< comments< iskeyword<'
 
 setlocal commentstring=#\ %s
 setlocal comments=:#
+setlocal iskeyword+=-
 
 let &cpo = s:save_cpo
 unlet s:save_cpo

--- a/runtime/syntax/toml.vim
+++ b/runtime/syntax/toml.vim
@@ -3,7 +3,7 @@
 " Homepage:            https://github.com/cespare/vim-toml
 " Maintainer:          Aman Verma
 " Previous Maintainer: Caleb Spare <cespare@gmail.com>
-" Last Change:         Oct 8, 2021
+" Last Change:         May 5, 2025
 
 if exists('b:current_syntax')
   finish
@@ -23,15 +23,15 @@ syn region tomlString oneline start=/'/ end=/'/
 " Multi-line literal strings
 syn region tomlString start=/'''/ end=/'''/
 
-syn match tomlInteger /[+-]\=\<[1-9]\(_\=\d\)*\>/ display
-syn match tomlInteger /[+-]\=\<0\>/ display
-syn match tomlInteger /[+-]\=\<0x[[:xdigit:]]\(_\=[[:xdigit:]]\)*\>/ display
-syn match tomlInteger /[+-]\=\<0o[0-7]\(_\=[0-7]\)*\>/ display
-syn match tomlInteger /[+-]\=\<0b[01]\(_\=[01]\)*\>/ display
-syn match tomlInteger /[+-]\=\<\(inf\|nan\)\>/ display
+syn match tomlInteger /[+-]\=[1-9]\(_\=\d\)*/ display
+syn match tomlInteger /[+-]\=0/ display
+syn match tomlInteger /[+-]\=0x[[:xdigit:]]\(_\=[[:xdigit:]]\)*/ display
+syn match tomlInteger /[+-]\=0o[0-7]\(_\=[0-7]\)*/ display
+syn match tomlInteger /[+-]\=0b[01]\(_\=[01]\)*/ display
+syn match tomlInteger /[+-]\=\(inf\|nan\)/ display
 
-syn match tomlFloat /[+-]\=\<\d\(_\=\d\)*\.\d\+\>/ display
-syn match tomlFloat /[+-]\=\<\d\(_\=\d\)*\(\.\d\(_\=\d\)*\)\=[eE][+-]\=\d\(_\=\d\)*\>/ display
+syn match tomlFloat /[+-]\=\d\(_\=\d\)*\.\d\+/ display
+syn match tomlFloat /[+-]\=\d\(_\=\d\)*\(\.\d\(_\=\d\)*\)\=[eE][+-]\=\d\(_\=\d\)*/ display
 
 syn match tomlBoolean /\<\%(true\|false\)\>/ display
 


### PR DESCRIPTION
Add "-" to iskeyword. This required a change to the syntax files too because they were using the word begin and end atoms.