### PR TITLE
runtime(ft-lua): update `'path'` option

### DIFF
--- a/runtime/ftplugin/lua.vim
+++ b/runtime/ftplugin/lua.vim
@@ -31,6 +31,7 @@ set cpo&vim
 setlocal comments=:---,:--
 setlocal commentstring=--\ %s
 setlocal formatoptions-=t formatoptions+=croql
+setlocal path-=. " Lua doesn't support importing module in path related to current file like JS
 
 let &l:define = '\<function\|\<local\%(\s\+function\)\='
 
@@ -38,7 +39,7 @@ let &l:include = '\<\%(\%(do\|load\)file\|require\)\s*('
 setlocal includeexpr=s:LuaInclude(v:fname)
 setlocal suffixesadd=.lua
 
-let b:undo_ftplugin = "setl cms< com< def< fo< inc< inex< sua<"
+let b:undo_ftplugin = "setl cms< com< def< fo< inc< inex< sua< pa<"
 
 if exists("loaded_matchit") && !exists("b:match_words")
   let b:match_ignorecase = 0


### PR DESCRIPTION
Problem: Lua doesn't support importing module in path related to current file like JS does (https://www.reddit.com/r/lua/comments/wi0bau/whats_the_correct_way_to_run_a_lua_file_that_uses/)

Solution: Remove `.` from Lua buffer-local option `'path'`