### PR TITLE
runtime: improve tutor.vim

### DIFF
--- a/runtime/plugin/tutor.vim
+++ b/runtime/plugin/tutor.vim
@@ -3,4 +3,9 @@ if exists('g:loaded_tutor_mode_plugin') || &compatible
 endif
 let g:loaded_tutor_mode_plugin = 1
 
+" Define this variable so that users get cmdline completion.
+if !exists('g:tutor_debug')
+  let g:tutor_debug = 0
+endif
+
 command! -nargs=? -complete=custom,tutor#TutorCmdComplete Tutor call tutor#TutorCmd(<q-args>)


### PR DESCRIPTION
@chrisbra I find it annoying that "Tutor" mode is always on (or debug mode is off)
even when I open a file with `:edit` command. I think it makes more
sense to make Tutor mode:
- Always on when it is opened with `:Tutor` command
- Off otherwise

For more references, see `:help`, it is a much better model than `:Tutor`. I don't have to run `let g:tutor_debug = 1` just to be able to edit and save a help file

> [!NOTE]  
> This PR is not meant to be merged now. I will make more change to this plugin later. But I need your opinion 