### PR TITLE
runtime(java): Search type and method declarations with "&inc" and "&def"

### DIFF
--- a/runtime/ftplugin/java.vim
+++ b/runtime/ftplugin/java.vim
@@ -3,7 +3,7 @@
 " Maintainer:		Aliaksei Budavei <0x000c70 AT gmail DOT com>
 " Former Maintainer:	Dan Sharp
 " Repository:		https://github.com/zzzyxwvut/java-vim.git
-" Last Change:		2024 Dec 25
+" Last Change:		2025 May 08
 "			2024 Jan 14 by Vim Project (browsefilter)
 "			2024 May 23 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 
@@ -29,6 +29,32 @@ let b:did_ftplugin = 1
 " For filename completion, prefer the .java extension over the .class
 " extension.
 set suffixes+=.class
+
+" Set up "&define" and "&include".
+let s:peek = ''
+
+try
+    " Since v7.3.1037.
+    if 'ab' !~ 'a\@1<!b'
+	let s:peek = string(strlen('instanceof') + 8)
+    endif
+catch /\<E59:/
+endtry
+
+" Treat "s:common" as a non-backtracking unit to avoid matching constructor
+" declarations whose package-private headers are indistinguishable from method
+" invocation.  Note that "[@-]" must not and "$" may not be in "&l:iskeyword".
+let s:common = '\%(\%(\%(@\%(interface\)\@!\%(\K\k*\.\)*\K\k*\)\s\+\)*' .
+	\ '\%(p\%(rivate\|rotected\|ublic\)\s\+\)\=\)\@>'
+let s:types = '\%(\%(abstract\|final\|non-sealed\|s\%(ealed\|tatic\|trictfp\)\)\s\+\)*' .
+	\ '\%(class\|enum\|@\=interface\|record\)\s\+\ze\K\k*\>'
+let s:methods = '\%(\%(abstract\|default\|final\|native\|s\%(tatic\|trictfp\|ynchronized\)\)\s\+\)*' .
+	\ '\%(<.\{-1,}>\s\+\)\=\%(\K\k*\.\)*\K\k*\s*\%(<.\{-1,}>\%(\s\|\[\)\@=\)\=\s*\%(\[\]\s*\)*' .
+	\ '\s\+\ze\%(\<\%(assert\|case\|instanceof\|new\|return\|throw\|when\)\s\+\)\@' .
+	\ s:peek . '<!\K\k*\s*('
+let &l:define = printf('\C\m^\s*%s\%%(%s\|%s\)', s:common, s:types, s:methods)
+let &l:include = '\C\m^\s*import\s\+\ze\%(\K\k*\.\)\+\K\k*;'
+unlet s:methods s:types s:common s:peek
 
 " Enable gf on import statements.  Convert . in the package
 " name to / and append .java to the name, then search the path.
@@ -341,7 +367,7 @@ if (!empty(get(g:, 'spotbugs_properties', {})) ||
 endif
 
 function! JavaFileTypeCleanUp() abort
-    setlocal suffixes< suffixesadd< formatoptions< comments< commentstring< path< includeexpr<
+    setlocal suffixes< suffixesadd< formatoptions< comments< commentstring< path< includeexpr< include< define<
     unlet! b:browsefilter
 
     " The concatenated ":autocmd" removals may be misparsed as an ":autocmd".


### PR DESCRIPTION
###### =============== LIMITATIONS AND OBSERVATIONS ===============

* Remember that external-type names can only be found when  
  they match filenames resolvable in `&path` with `import`  
  declarations; load the source file of an external type to  
  look up its nested types and sibling top types, if any.

* Strive to narrow the search by assigning only relevant  
  pathnames for directories *or* an archive to `&path`, e.g.  
  `:set path-=/usr/include`.

* Use `{Visual}gf` on fully-qualified names.

* Accept the fact that `&define` cannot contain end-of-line  
  characters (`:help definition-search`).  A declaration  
  whose matchable header is not contained within a line can  
  be found iff all of its non-optional components belong to  
  the same line; for types, such components are a keyword,  
  e.g. `class`, followed by a run of blank characters and  
  an identifier, e.g. `Test`; for methods: a return type,  
  e.g. `String`, or a keyword `void`, followed by a run of  
  blank characters and an identifier, e.g. `toString`, that  
  is followed by `(`.

* The members of the `java.lang` package are usually not  
  associated with `import` declarations; to look up their  
  declarations, load a source file for a member of that  
  package, and then use, on a simple name of interest for  
  a member, either `[-Ctrl-d` etc. for local declarations  
  or `gf` for external declarations, assuming that `.` *or*  
  the appropriate pathname for a JDK archive is assigned to  
  `&path`.

* Follow the above instruction made for the `java.lang`  
  members for any type whose simple name is not associated  
  with an `import` declaration, i.e. a member type of the  
  same package that is declared in another compilation unit.

* Append the `$` character to `&iskeyword` when looking up  
  declarations of generated code.

See zzzyxwvut/java-vim#4.