### PR TITLE
Fix quickfix dummy buffer issues

### DIFF
--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -7078,7 +7078,7 @@ wipe_dummy_buffer(buf_T *buf, char_u *dirname_start)
 		    break;
 		}
 	if (!did_one)
-	    return;
+	    goto fail;
     }
 
     if (curbuf != buf && buf->b_nwindows == 0)	// safety check
@@ -7102,7 +7102,13 @@ wipe_dummy_buffer(buf_T *buf, char_u *dirname_start)
 	if (dirname_start != NULL)
 	    // When autocommands/'autochdir' option changed directory: go back.
 	    restore_start_dir(dirname_start);
+
+	return;
     }
+
+fail:
+    // Keeping the buffer, remove the dummy flag.
+    buf->b_flags &= ~BF_DUMMY;
 }
 
 /*

--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -7026,7 +7026,11 @@ load_dummy_buffer(
 	    aucmd_restbuf(&aco);
 
 	    if (newbuf_to_wipe.br_buf != NULL && bufref_valid(&newbuf_to_wipe))
-		wipe_buffer(newbuf_to_wipe.br_buf, FALSE);
+	    {
+		block_autocmds();
+		wipe_dummy_buffer(newbuf_to_wipe.br_buf, NULL);
+		unblock_autocmds();
+	    }
 	}
 
 	// Add back the "dummy" flag, otherwise buflist_findname_stat() won't
@@ -7052,8 +7056,8 @@ load_dummy_buffer(
 
 /*
  * Wipe out the dummy buffer that load_dummy_buffer() created. Restores
- * directory to "dirname_start" prior to returning, if autocmds or the
- * 'autochdir' option have changed it.
+ * directory to "dirname_start" if not NULL prior to returning, if autocmds or
+ * the 'autochdir' option have changed it.
  */
     static void
 wipe_dummy_buffer(buf_T *buf, char_u *dirname_start)
@@ -7095,8 +7099,9 @@ wipe_dummy_buffer(buf_T *buf, char_u *dirname_start)
 	// new aborting error, interrupt, or uncaught exception.
 	leave_cleanup(&cs);
 #endif
-	// When autocommands/'autochdir' option changed directory: go back.
-	restore_start_dir(dirname_start);
+	if (dirname_start != NULL)
+	    // When autocommands/'autochdir' option changed directory: go back.
+	    restore_start_dir(dirname_start);
     }
 }
 

--- a/src/testdir/test_quickfix.vim
+++ b/src/testdir/test_quickfix.vim
@@ -6921,4 +6921,23 @@ func Test_vimgrep_dummy_buffer_crash()
   %bw!
 endfunc
 
+func Test_vimgrep_dummy_buffer_keep()
+  augroup DummyKeep
+    autocmd!
+    " Trigger a wipe of the dummy buffer by aborting script processing. Prevent
+    " wiping it by splitting it from the autocmd window into an only window.
+    autocmd BufReadCmd * ++once let s:dummy_buf = bufnr()
+          \| tab split | call interrupt()
+  augroup END
+
+  call assert_fails('vimgrep /./ .')
+  call assert_equal(1, bufexists(s:dummy_buf))
+  " Ensure it's no longer considered a dummy; should be able to switch to it.
+  execute s:dummy_buf 'sbuffer'
+
+  unlet! s:dummy_buf
+  autocmd! DummyKeep
+  %bw!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_quickfix.vim
+++ b/src/testdir/test_quickfix.vim
@@ -6899,4 +6899,26 @@ func Test_quickfix_close_buffer_crash()
   wincmd q
 endfunc
 
+func Test_vimgrep_dummy_buffer_crash()
+  augroup DummyCrash
+    autocmd!
+    " Make the dummy buffer non-current, but still open in a window.
+    autocmd BufReadCmd * ++once let s:dummy_buf = bufnr()
+          \| split | wincmd p | enew
+
+    " Autocmds from cleaning up the dummy buffer in this case should be blocked.
+    autocmd BufWipeout *
+          \ call assert_notequal(s:dummy_buf, str2nr(expand('<abuf>')))
+  augroup END
+
+  silent! vimgrep /./ .
+  redraw! " Window to freed dummy buffer used to remain; heap UAF.
+  call assert_equal([], win_findbuf(s:dummy_buf))
+  call assert_equal(0, bufexists(s:dummy_buf))
+
+  unlet! s:dummy_buf
+  autocmd! DummyCrash
+  %bw!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Fixes a heap UAF and the potential for a buffer to remain as a dummy despite being kept.