### PR TITLE
Fix documentation of 'fillchars'

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3663,7 +3663,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	Example: >
 	    :set fillchars=stl:\ ,stlnc:\ ,vert:\|,fold:-,diff:-
 <
-	All items single-byte and multibyte characters are supported.  But
+	All items support single-byte and multibyte characters.  But
 	double-width characters are not supported. |E1512|
 
 	The highlighting used for these items:

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3663,9 +3663,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	Example: >
 	    :set fillchars=stl:\ ,stlnc:\ ,vert:\|,fold:-,diff:-
 <
-	For the "stl", "stlnc", "foldopen", "foldclose" and "foldsep" items
-	single-byte and multibyte characters are supported.  But double-width
-	characters are not supported. |E1512|
+	All items single-byte and multibyte characters are supported.  But
+	double-width characters are not supported. |E1512|
 
 	The highlighting used for these items:
 	  item name	highlight group ~


### PR DESCRIPTION
The description covers only some items, but in fact, it applies to all of them.