### PR TITLE
runtime(lf): fix highlighting for keywords right after `:`

### DIFF
--- a/runtime/syntax/lf.vim
+++ b/runtime/syntax/lf.vim
@@ -3,7 +3,7 @@
 " Maintainer: Andis Sprinkis <andis@sprinkis.com>
 " Former Maintainer: Cameron Wright
 " URL: https://github.com/andis-sprinkis/lf-vim
-" Last Change: 5 Apr 2025
+" Last Change: 10 May 2025
 "
 " The shell syntax highlighting is configurable. See $VIMRUNTIME/doc/syntax.txt
 " lf version: 34
@@ -215,6 +215,7 @@ let s:shell_syntax = get(b:, 'lf_shell_syntax', s:shell_syntax)
 
 unlet b:current_syntax
 exe 'syn include @Shell '.s:shell_syntax
+syn iskeyword @,-
 let b:current_syntax = "lf"
 
 syn region lfCommand matchgroup=lfCommandMarker start=' \zs:\ze' end='$' keepend transparent


### PR DESCRIPTION
Sets `syn iskeyword` in syntax/lf.vim to fix the missing lf keyword highlighting in lines like `map e :open; open` (first `open` not highlighted).

Applies PR andis-sprinkis/lf-vim#21 by @joelim-work

Closes issue andis-sprinkis/lf-vim#14