### PR TITLE
Win32: fix launching `evim` when vim binaries path includes whitespaces

### DIFF
--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -5384,13 +5384,11 @@ gui_mch_do_spawn(char_u *arg)
 	{
 	    if (*p == L'"')
 	    {
-		while (*p && *p != L'"')
-		    ++p;
-		if (*p)
-		    ++p;
+		// Skip quoted strings
+		while (*++p && *p != L'"');
 	    }
-	    else
-		++p;
+
+	    ++p;
 	}
 	cmd = p;
     }


### PR DESCRIPTION
## Error Description
When vim is installed in a path with whitespaces (like ` C:\Program Files (x86)\Vim\vim91\vim.exe`).
Launching `evim` or `vim -d` will try to open the file ` (x86)\Vim\vim91\vim.exe`.

## Behavior Analisys
Modern versions of vim simplify shell operation by parsing its own command line.
For example on linux all vim flavours like `evim`, `rvim`, ... are symlinks to vim.
Then vim uses the `parse_command_name()` function to identify which version of vim it should launch.
For `evim` if GUI is available `gvim` is launched for better user experience.
In order to launch `gvim` the original command line is parsed to be passed *verbatim* to the new instance.
This parsing did not properly handle quoted command lines with whitespaces as
```
"C:\Program Files (x86)\Vim\vim91\vim.exe" -y myfile.txt
```
