### PR TITLE
Runtime(tutor.vim): remove g:tutor_debug

### DIFF
--- a/runtime/autoload/tutor.vim
+++ b/runtime/autoload/tutor.vim
@@ -210,10 +210,32 @@ function! tutor#TutorCmd(tutor_name)
 
     call tutor#SetupVim()
     exe "edit ".l:to_open
+    call tutor#EnableInteractive(v:true)
 endfunction
 
 function! tutor#TutorCmdComplete(lead,line,pos)
     let l:tutors = s:GlobTutorials('*')
     let l:names = uniq(sort(map(l:tutors, 'fnamemodify(v:val, ":t:r")'), 's:Sort'))
     return join(l:names, "\n")
+endfunction
+
+" Enables/disables interactive mode.
+function! tutor#EnableInteractive(enable)
+    let enable = a:enable
+    if enable
+        setlocal buftype=nofile
+        setlocal concealcursor+=inv
+        setlocal conceallevel=2
+        call tutor#ApplyMarks()
+        augroup tutor_interactive
+            autocmd! TextChanged,TextChangedI <buffer> call tutor#ApplyMarksOnChanged()
+        augroup END
+    else
+        setlocal buftype<
+        setlocal concealcursor<
+        setlocal conceallevel<
+        if exists('#tutor_interactive')
+            autocmd! tutor_interactive * <buffer>
+        endif
+    endif
 endfunction

--- a/runtime/ftplugin/tutor.vim
+++ b/runtime/ftplugin/tutor.vim
@@ -12,15 +12,6 @@ call tutor#SetupVim()
 
 " Buffer Settings: {{{1
 setlocal noreadonly
-if !exists('g:tutor_debug') || g:tutor_debug == 0
-    setlocal buftype=nofile
-    setlocal concealcursor+=inv
-    setlocal conceallevel=2
-else
-    setlocal buftype=
-    setlocal concealcursor&
-    setlocal conceallevel=0
-endif
 setlocal noundofile
 
 setlocal keywordprg=:help
@@ -46,14 +37,7 @@ call tutor#SetNormalMappings()
 sign define tutorok text=✓ texthl=tutorOK
 sign define tutorbad text=✗ texthl=tutorX
 
-if !exists('g:tutor_debug') || g:tutor_debug == 0
-    call tutor#ApplyMarks()
-    autocmd! TextChanged,TextChangedI <buffer> call tutor#ApplyMarksOnChanged()
-endif
-
-let b:undo_ftplugin = 'unlet! g:tutor_debug |'
-let b:undo_ftplugin ..= 'setl concealcursor< conceallevel< |'
-let b:undo_ftplugin ..= 'setl foldmethod< foldexpr< foldlevel< |'
-let b:undo_ftplugin ..= 'setl buftype< undofile< keywordprg< iskeyword< |'
+let b:undo_ftplugin = "setl foldmethod< foldexpr< foldlevel< undofile< keywordprg< iskeyword< |"
+    \ . "call tutor#EnableInteractive(v:false) |"
 
 " vim: fdm=marker

--- a/runtime/plugin/tutor.vim
+++ b/runtime/plugin/tutor.vim
@@ -9,9 +9,4 @@ if exists('g:loaded_tutor_mode_plugin') || &compatible
 endif
 let g:loaded_tutor_mode_plugin = 1
 
-" Define this variable so that users get cmdline completion.
-if !exists('g:tutor_debug')
-  let g:tutor_debug = 0
-endif
-
 command! -nargs=? -complete=custom,tutor#TutorCmdComplete Tutor call tutor#TutorCmd(<q-args>)

--- a/runtime/tutor/tutor.tutor
+++ b/runtime/tutor/tutor.tutor
@@ -17,15 +17,8 @@ Table of contents:
 
 ## SETTING UP *setting-up*
 
-First, you'll need to enable "debug" mode
-~~~ cmd
-    :let g:tutor_debug = 1
-~~~
-This will allow saving changes to the tutor files and will disable conceals, so
-you can more easily check your changes.
-
-After this, create a new .tutor file (we will be practicing on this very file, so you
-don't need to do this now):
+Create a new .tutor file (we will be practicing on this very file, so you don't
+need to do this now):
 ~~~ cmd
     :e new-tutorial.tutor
 ~~~

--- a/src/testdir/Make_all.mak
+++ b/src/testdir/Make_all.mak
@@ -328,6 +328,7 @@ NEW_TESTS = \
 	test_true_false \
 	test_trycatch \
 	test_tuple \
+	test_plugin_tutor \
 	test_undo \
 	test_unlet \
 	test_user_func \
@@ -581,6 +582,7 @@ NEW_TESTS_RES = \
 	test_true_false.res \
 	test_trycatch.res \
 	test_tuple.res \
+	test_plugin_tutor.res \
 	test_undo.res \
 	test_user_func.res \
 	test_usercommands.res \

--- a/src/testdir/test_plugin_tutor.vim
+++ b/src/testdir/test_plugin_tutor.vim
@@ -1,0 +1,14 @@
+func SetUp()
+  set nocompatible
+  runtime plugin/tutor.vim
+endfunc
+
+func Test_auto_enable_interactive()
+  Tutor
+  call assert_equal('nofile', &buftype)
+  call assert_match('tutor#EnableInteractive', b:undo_ftplugin)
+
+  edit Xtutor/Xtest.tutor
+  call assert_equal('', &buftype)
+  call assert_match('tutor#EnableInteractive', b:undo_ftplugin)
+endfunc


### PR DESCRIPTION
This is actually what I was trying to say in
https://github.com/vim/vim/pull/17274

I find it annoying that Tutor's interactive mode is always on (or debug mode is off) even when I open a file with :edit command. I think it makes more sense to make this interactive mode:

- Always on when it is opened with :Tutor command
- Off otherwise

For more references, see `:help` feature, it is a much better model than :Tutor. I don't have to run `:let g:help_debug = 1` just to be able to edit and save a help file