### PR TITLE
fix: cycling to original text after last item

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -5236,9 +5236,8 @@ find_comp_when_fuzzy(void)
 
     if ((is_forward && compl_selected_item == compl_match_arraysize - 1)
 	    || (is_backward && compl_selected_item == 0))
-	return compl_first_match != compl_shown_match ?
-	    (is_forward ? compl_shown_match->cp_next : compl_first_match) :
-	    (compl_first_match->cp_prev ? compl_first_match->cp_prev : NULL);
+	return match_at_original_text(compl_first_match)
+			    ? compl_first_match : compl_first_match->cp_prev;
 
     if (is_forward)
 	target_idx = compl_selected_item + 1;

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -3387,11 +3387,15 @@ func Test_complete_opt_fuzzy()
     autocmd CompleteChanged * :call OnPumChange()
   augroup END
 
+  let g:change = 0
   func Omni_test(findstart, base)
     if a:findstart
       return col(".")
     endif
-    return [#{word: "foo"}, #{word: "foobar"}, #{word: "fooBaz"}, #{word: "foobala"}, #{word: "你好吗"}, #{word: "我好"}]
+    if g:change == 0
+      return [#{word: "foo"}, #{word: "foobar"}, #{word: "fooBaz"}, #{word: "foobala"}, #{word: "你好吗"}, #{word: "我好"}]
+    endif
+    return [#{word: "for i = .."}, #{word: "bar"}, #{word: "foo"}, #{word: "for .. ipairs"}, #{word: "for .. pairs"}]
   endfunc
 
   new
@@ -3487,6 +3491,15 @@ func Test_complete_opt_fuzzy()
   " issue #15412
   call feedkeys("Salpha bravio charlie\<CR>alpha\<C-X>\<C-N>\<C-X>\<C-N>\<C-X>\<C-N>\<ESC>", 'tx')
   call assert_equal('alpha bravio charlie', getline('.'))
+
+  set cot=fuzzy,menu,noinsert
+  call feedkeys(":let g:change=1\<CR>")
+  call feedkeys("S\<C-X>\<C-O>for\<C-N>\<C-N>\<C-N>", 'tx')
+  call assert_equal('for', getline('.'))
+  call feedkeys("S\<C-X>\<C-O>for\<C-P>", 'tx')
+  call assert_equal('for', getline('.'))
+  call feedkeys("S\<C-X>\<C-O>for\<C-P>\<C-P>", 'tx')
+  call assert_equal('for .. ipairs', getline('.'))
 
   " clean up
   set omnifunc=


### PR DESCRIPTION
Problem: Cannot return to the original text after selecting the next item when the currently selected item is the last one.

Solution: When continuing to move down past the last item, locate the original completion at the head/tail nodes of the compl linked list