### PR TITLE
fix: avoid skip space pattern of isexpand in complete_match

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -3665,7 +3665,15 @@ f_complete_match(typval_T *argvars, typval_T *rettv)
 
 	while (*p != NUL)
 	{
-	    int len = copy_option_part(&p, part, MAXPATHL, ",");
+	    int	    len = 0;
+	    if (*p == ',' && *(p+1) == ' ' && (*(p+2) == ',' || *(p+2) == NUL))
+	    {
+		part[0] = ' ';
+		len = 1;
+		p++;
+	    }
+	    else
+		len = copy_option_part(&p, part, MAXPATHL, ",");
 
 	    if (len > 0 && len <= col)
 	    {

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -4504,6 +4504,10 @@ func Test_complete_match()
   call feedkeys("Sabc, \<ESC>:let g:result=complete_match()\<CR>", 'tx')
   call assert_equal([[4, ',']], g:result)
 
+  set ise=\ ,=
+  call feedkeys("Sif true  \<ESC>:let g:result=complete_match()\<CR>", 'tx')
+  call assert_equal([[8, ' ']], g:result)
+
   bw!
   unlet g:result
   set isexpand&


### PR DESCRIPTION
problem: When space character is used as a trigger in 'isexpand' option it doesn't get recognized because skip_to_option_part() skips spaces after a comma, treating them as option separators rather than  option content.

solution: manually setting the part to a space character.