### PR TITLE
Inefficient loop for 'nosmoothscroll' scrolling

### DIFF
--- a/src/move.c
+++ b/src/move.c
@@ -3212,12 +3212,15 @@ static int scroll_with_sms(int dir, long count, long *curscount)
 	// extra for scrolling backward so that consuming skipcol is symmetric.
 	if (labs(curwin->w_topline - prev_topline) > (dir == BACKWARD))
 	    fixdir = dir * -1;
-	while (curwin->w_skipcol > 0
-	    && curwin->w_topline < curbuf->b_ml.ml_line_count)
-	{
-	    scroll_redraw(fixdir == FORWARD, 1);
-	    *curscount += (fixdir == dir ? 1 : -1);
-	}
+
+	int width1 = curwin->w_width - curwin_col_off();
+	int width2 = width1 + curwin_col_off2();
+	count = 1 + (curwin->w_skipcol - width1) / width2;
+	if (fixdir == FORWARD)
+	    count = 2 + (linetabsize_eol(curwin, curwin->w_topline)
+					- curwin->w_skipcol - width1) / width2;
+	scroll_redraw(fixdir == FORWARD, count);
+	*curscount += count * (fixdir == dir ? 1 : -1);
     }
     curwin->w_p_sms = prev_sms;
 

--- a/src/testdir/test_normal.vim
+++ b/src/testdir/test_normal.vim
@@ -4345,4 +4345,13 @@ func Test_scroll_longline_scrolloff()
   bwipe!
 endfunc
 
+" Benchmark test for Ctrl-F with 'nosmoothscroll'
+func Test_scroll_longline_benchmark()
+  call setline(1, ['foo'->repeat(20000)] + [''])
+  let start = reltime()
+  exe "normal! \<C-F>"
+  call assert_inrange(0, 0.1, reltimefloat(reltime(start)))
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab nofoldenable


### PR DESCRIPTION
Problem:  Loop that ensures "w_skipcol" is zero with 'nosmoothscroll'
	  for (half)-page scrolling is inefficient.
Solution: Calculate the required "count" instead of looping until
	  "w_skipcol" is zero.

Fix #17301