### PR TITLE
fix: space still not handled correctly

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -3660,20 +3660,28 @@ f_complete_match(typval_T *argvars, typval_T *rettv)
     }
     else
     {
-	char_u	*p = ise;
+	char_u	    *p = ise;
+	char_u	    *p_space = NULL;
+
 	cur_end = before_cursor + (int)STRLEN(before_cursor);
 
 	while (*p != NUL)
 	{
 	    int	    len = 0;
-	    if (*p == ',' && *(p+1) == ' ' && (*(p+2) == ',' || *(p+2) == NUL))
+	    if (p_space)
 	    {
-		part[0] = ' ';
-		len = 1;
-		p++;
+		len = p - p_space - 1;
+		memcpy(part, p_space + 1, len);
+		p_space = NULL;
 	    }
 	    else
+	    {
+		char_u *next_comma = vim_strchr((*p == ',') ? p + 1 : p, ',');
+		if (next_comma && *(next_comma + 1) == ' ')
+		    p_space = next_comma;
+
 		len = copy_option_part(&p, part, MAXPATHL, ",");
+	    }
 
 	    if (len > 0 && len <= col)
 	    {

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -4507,6 +4507,13 @@ func Test_complete_match()
   set ise=\ ,=
   call feedkeys("Sif true  \<ESC>:let g:result=complete_match()\<CR>", 'tx')
   call assert_equal([[8, ' ']], g:result)
+  call feedkeys("Slet a = \<ESC>:let g:result=complete_match()\<CR>", 'tx')
+  call assert_equal([[7, '=']], g:result)
+  set ise={,\ ,=
+  call feedkeys("Sif true  \<ESC>:let g:result=complete_match()\<CR>", 'tx')
+  call assert_equal([[8, ' ']], g:result)
+  call feedkeys("S{ \<ESC>:let g:result=complete_match()\<CR>", 'tx')
+  call assert_equal([[1, '{']], g:result)
 
   bw!
   unlet g:result


### PR DESCRIPTION
Problem: Cannot get completion startcol when space is not the first trigger character

Solution: Detecting the next comma followed by a space in the option string and use in next compare loop