### PR TITLE
Problem:  search_stat not reset when pattern differs in case

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -3291,12 +3291,9 @@ update_search_stat(
 	       || (dirc == '/' && LT_POS(p, lastpos)));
 
     // If anything relevant changed the count has to be recomputed.
-    // MB_STRNICMP ignores case, but we should not ignore case.
-    // Unfortunately, there is no MB_STRNICMP function.
-    // XXX: above comment should be "no MB_STRCMP function" ?
     if (!(chgtick == CHANGEDTICK(curbuf)
 	&& (lastpat != NULL
-	    && MB_STRNICMP(lastpat, spats[last_idx].pat, lastpatlen) == 0
+	    && STRNCMP(lastpat, spats[last_idx].pat, lastpatlen) == 0
 	    && lastpatlen == spats[last_idx].patlen
 	)
 	&& EQUAL_POS(lastpos, *cursor_pos)

--- a/src/testdir/test_search_stat.vim
+++ b/src/testdir/test_search_stat.vim
@@ -459,4 +459,23 @@ func Test_search_stat_backwards()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_search_stat_smartcase_ignorecase()
+  CheckRunVimInTerminal
+
+  let lines =<< trim END
+    set shm-=S ignorecase smartcase
+    call setline(1, [' MainmainmainmmmainmAin', ''])
+  END
+  call writefile(lines, 'Xsearchstat_ignorecase', '5')
+
+  let buf = RunVimInTerminal('-S Xsearchstat_ignorecase', #{rows: 10})
+  call term_sendkeys(buf, "/main\<cr>nnnn")
+  call WaitForAssert({-> assert_match('\[5\/5\]', term_getline(buf, 10))}, 1000)
+
+  call term_sendkeys(buf, "/mAin\<cr>")
+  call WaitForAssert({-> assert_match('\[1\/1\]', term_getline(buf, 10))}, 1000)
+
+  call StopVimInTerminal(buf)
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  search_stat not reset when pattern differs in case
Solution: use STRNCMP instead of MB_STRNICMP macro

There was a long standing todo comment, that using MB_STRNICMP is wrong. So let's change it to STRNCMP() instead. Even if it not handle multi-byte characters correctly, then Vim will rather recompute the search stat, instead of re-using the old (and possibly wrong) value.

fixes: #17312