### PR TITLE
Scrolling one line too far with 'nosmoothscroll' page scrolling

### DIFF
--- a/src/move.c
+++ b/src/move.c
@@ -3215,10 +3215,10 @@ static int scroll_with_sms(int dir, long count, long *curscount)
 
 	int width1 = curwin->w_width - curwin_col_off();
 	int width2 = width1 + curwin_col_off2();
-	count = 1 + (curwin->w_skipcol - width1) / width2;
+	count = 1 + (curwin->w_skipcol - width1 - 1) / width2;
 	if (fixdir == FORWARD)
-	    count = 2 + (linetabsize_eol(curwin, curwin->w_topline)
-					- curwin->w_skipcol - width1) / width2;
+	    count = 1 + (linetabsize_eol(curwin, curwin->w_topline)
+			    - curwin->w_skipcol - width1 + width2 - 1) / width2;
 	scroll_redraw(fixdir == FORWARD, count);
 	*curscount += count * (fixdir == dir ? 1 : -1);
     }

--- a/src/testdir/test_normal.vim
+++ b/src/testdir/test_normal.vim
@@ -4354,4 +4354,21 @@ func Test_scroll_longline_benchmark()
   bwipe!
 endfunc
 
+" Test Ctrl-B with 'nosmoothscroll' not stuck with line exactly window width.
+func Test_scroll_longline_winwidth()
+  10new
+  call setline(1, ['']->repeat(20) + ['A'->repeat(20 * winwidth(0))] + ['']->repeat(20))
+  exe "normal! G3\<C-B>"
+  call assert_equal(22, line('w0'))
+  exe "normal! \<C-B>"
+  call assert_equal(21, line('w0'))
+  exe "normal! \<C-B>"
+  call assert_equal(11, line('w0'))
+  exe "normal! \<C-B>"
+  call assert_equal(3, line('w0'))
+  exe "normal! \<C-B>"
+  call assert_equal(1, line('w0'))
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab nofoldenable


### PR DESCRIPTION
Problem:  One-off error in "count" to make "w_skipcol" zero with
          'nosmoothscroll' page scrolling when last virtual line
          in a buffer line is exactly the entire window width.
Solution: Properly compute the smallest integer value necessary
          to make "w_skipcol" zero.

Fix #17317