### PR TITLE
runtime(pandoc): fix YAML metadata block parsing

### DIFF
--- a/runtime/compiler/pandoc.vim
+++ b/runtime/compiler/pandoc.vim
@@ -51,7 +51,7 @@ endfunction
 
 execute 'CompilerSet makeprg=pandoc'..escape(
     \ ' --standalone'..
-    \ (s:PandocFiletype(&filetype) ==# 'markdown' && (getline(1) =~# '^%\s\+\S\+' || (search('^title:\s+\S+', 'cnw') > 0)) ?
+    \ (s:PandocFiletype(&filetype) ==# 'markdown' && (getline(1) =~# '^%\s\+\S\+' || (search('^title:\s\+\S\+', 'cnw') > 0)) ?
     \ '' : ' --metadata title=%:t:r:S')..
     \ ' '..s:PandocLang()..
     \ ' --from='..s:PandocFiletype(&filetype)..


### PR DESCRIPTION
Previously the incorrect regexp forced title to be a single letter between + characters.