### PR TITLE
Correct spell checking in Gleam files

### DIFF
--- a/runtime/syntax/gleam.vim
+++ b/runtime/syntax/gleam.vim
@@ -2,7 +2,7 @@
 " Language:    Gleam
 " Maintainer:  Kirill Morozov <kirill@robotix.pro>
 " Based On:    https://github.com/gleam-lang/gleam.vim
-" Last Change: 2025 Apr 20
+" Last Change: 2025 May 15
 
 if exists("b:current_syntax")
   finish
@@ -38,7 +38,7 @@ syntax match gleamNumber "\<-\=0[xX]_\?\%(\x\|\x_\x\)\+\>"
 syntax match gleamFloat "\(0*[1-9][0-9_]*\|0\)\.\(0*[1-9][0-9_]*\|0\)\(e-\=0*[1-9][0-9_]*\)\="
 
 " String
-syntax region gleamString start=/"/ end=/"/ contains=gleamSpecial
+syntax region gleamString start=/"/ end=/"/ contains=gleamSpecial,@Spell
 syntax match gleamSpecial '\\.' contained
 
 " Operators
@@ -58,19 +58,19 @@ syntax match gleamOperator "[<>]=\=\.\=\|[=!]="
 syntax match gleamOperator "\.\.\|<>\||"
 
 " Type
-syntax match gleamIdentifier "\<[A-Z][a-zA-Z0-9]*\>"
+syntax match gleamIdentifier "\<[A-Z][a-zA-Z0-9]*\>" contains=@NoSpell
 
 " Attribute
-syntax match gleamPreProc "@[a-z][a-z_]*"
+syntax match gleamPreProc "@[a-z][a-z_]*" contains=@NoSpell
 
 " Function definition
 syntax keyword gleamKeyword fn nextgroup=gleamFunction skipwhite skipempty
-syntax match gleamFunction "[a-z][a-z0-9_]*\ze\s*(" skipwhite skipnl
+syntax match gleamFunction "[a-z][a-z0-9_]*\ze\s*(" skipwhite skipnl contains=@NoSpell
 
 " Comments
-syntax region gleamComment start="//" end="$" contains=gleamTodo
-syntax region gleamSpecialComment start="///" end="$"
-syntax region gleamSpecialComment start="////" end="$"
+syntax region gleamComment start="//" end="$" contains=gleamTodo,@Spell
+syntax region gleamSpecialComment start="///" end="$" contains=@Spell
+syntax region gleamSpecialComment start="////" end="$" contains=@Spell
 syntax keyword gleamTodo contained TODO FIXME XXX NB NOTE
 
 " Highlight groups


### PR DESCRIPTION
Cc @kirillmorozov (maintainer).

I apologise if direct Pull Requests/patches to runtime files aren't allowed (this runtime file doesn't seem to have an upstream repository that I can send patches to); I read [this section of the `CONTRIBUTING.md`], but that seems like it is only talking about reporting issues, and [the section about patches] doesn't mention runtime files.

Before:
![A screenshot of an annotated hello world program where keywords like `fn` and `import`, as well as functions like `println`, are highlighted as a spelling error.](https://github.com/user-attachments/assets/f000338b-3ed7-40ed-9a5e-1a0c996f1319)

After:
![The same code as above, but with spell checking only effective in comments and strings.](https://github.com/user-attachments/assets/93d3013a-6c20-48f8-a650-b5a23f1ee2c0)

There is no change if the `spell` option isn't enabled.

[this section of the `CONTRIBUTING.md`]: https://github.com/vim/vim/blob/master/CONTRIBUTING.md#syntax-indent-and-other-runtime-files
[the section about patches]: https://github.com/vim/vim/blob/master/CONTRIBUTING.md#contributing-to-vim