### PR TITLE
fix(complete): setfiletype should not complete values with underscores

### DIFF
--- a/src/cmdexpand.c
+++ b/src/cmdexpand.c
@@ -3299,7 +3299,17 @@ ExpandFromContext(
     if (xp->xp_context == EXPAND_FILETYPE)
     {
 	char *directories[] = {"syntax", "indent", "ftplugin", NULL};
-	return ExpandRTDir(pat, 0, numMatches, matches, directories);
+	int ret = ExpandRTDir(pat, 0, numMatches, matches, directories);
+	if (ret == OK)
+	{
+	    int i, j = 0;
+	    for (i = 0; i < *numMatches; ++i)
+		// exclude items containing underscore
+		if (strchr((*matches)[i], '_') == NULL)
+		    (*matches)[j++] = (*matches)[i];
+	    *numMatches = j;
+	}
+	return ret;
     }
 #ifdef FEAT_KEYMAP
     if (xp->xp_context == EXPAND_KEYMAP)


### PR DESCRIPTION
for example, in item `stuff_foo`, the filetype name is just `stuff`, not `stuff_foo`.

fix failing test https://github.com/vim/vim/actions/runs/15059404115/job/42331584350?pr=17168