### PR TITLE
docs(pi_tutor): remove outdated Contribution section

### DIFF
--- a/runtime/doc/pi_tutor.txt
+++ b/runtime/doc/pi_tutor.txt
@@ -5,6 +5,8 @@ INTERACTIVE TUTORIALS FOR VIM			 *vim-tutor-mode*
 vim-tutor-mode provides a system to follow and create interactive tutorials
 for vim and third party plugins.  It replaces the venerable `vimtutor` system.
 
+Original Author: Felipe Morales <https://github.com/fmoralesc>
+
 =============================================================================
 1. Usage                                                      *vim-tutor-usage*
 
@@ -46,14 +48,6 @@ to be detected by the :Tutor command.
 
 It is recommended to use a less formal style when writing tutorials than in
 regular documentation (unless the content requires it).
-
-=============================================================================
-3. Contributing
-
-Development of the plugin is done over at github [1].  Feel free to report
-issues and make suggestions.
-
-[1]: https://github.com/fmoralesc/vim-tutor-mode
 
 =============================================================================
  vim:tw=78:ts=8:noet:ft=help:norl:


### PR DESCRIPTION
The Github repo link in the Contribution section was archived 5 years ago. So people who want to contribute to the Tutor plugin should just send PR to Vim repo, similar to most other Vim features, hence there is no need for a Contribution section in this plugin doc.