### PR TITLE
fix(session): saving mappings properly when 'encoding' is multibyte.

### DIFF
--- a/src/map.c
+++ b/src/map.c
@@ -2185,7 +2185,6 @@ put_escstr(FILE *fd, char_u *strstart, int what)
 
 		if (p == NULL)
 		{
-		    // manually advance str if mb_unescape() fails
 		    c = *str;
 		}
 		else

--- a/src/map.c
+++ b/src/map.c
@@ -2186,14 +2186,16 @@ put_escstr(FILE *fd, char_u *strstart, int what)
 		if (p == NULL)
 		{
 		    // manually advance str if mb_unescape() fails
-		    p = str;
-		    str += (*mb_ptr2len)(str);
+		    c = *str;
 		}
-
-		c = (*mb_ptr2char)(p);
-		--str;
+		else
+		{
+		    // retrieve codepoint (character number) from unescaped string
+		    c = (*mb_ptr2char)(p);
+		    --str;
+		}
 	    }
-	    else if (c == K_SPECIAL)
+	    if (c == K_SPECIAL)
 	    {
 		c = TO_SPECIAL(str[1], str[2]);
 		str += 2;

--- a/src/misc2.c
+++ b/src/misc2.c
@@ -1213,7 +1213,7 @@ handle_x_keys(int key)
 get_special_key_name(int c, int modifiers)
 {
     static char_u string[MAX_KEY_NAME_LEN + 1];
-    int	    i, idx;
+    int	    i, idx, len;
     int	    table_idx;
 
     string[0] = '<';
@@ -1286,10 +1286,11 @@ get_special_key_name(int c, int modifiers)
 	// Not a special key, only modifiers, output directly
 	else
 	{
-	    if (has_mbyte && (*mb_char2len)(c) > 1)
-		idx += (*mb_char2bytes)(c, string + idx);
-	    else if (vim_isprintc(c))
+	    len = (*mb_char2len)(c);
+	    if (len == 1 && vim_isprintc(c))
 		string[idx++] = c;
+	    else if (has_mbyte && len > 1)
+		idx += (*mb_char2bytes)(c, string + idx);
 	    else
 	    {
 		char_u	*s = transchar(c);

--- a/src/testdir/test_mksession_utf8.vim
+++ b/src/testdir/test_mksession_utf8.vim
@@ -102,4 +102,35 @@ func Test_mksession_utf8()
   set sessionoptions& splitbelow& fileencoding&
 endfunc
 
+func Test_session_mappings()
+
+  " some characters readily available on european keyboards
+  let entries = [
+        \ ['n', '<M-ç>', '<M-ç>'],
+        \ ['n', '<M-º>', '<M-º>'],
+        \ ['n', '<M-¡>', '<M-¡>'],
+        \ ]
+  for entry in entries
+    exe entry[0] .. 'map ' .. entry[1] .. ' ' .. entry[2]
+  endfor
+
+  mkvimrc Xtestvimrc
+
+  nmapclear
+
+  for entry in entries
+    call assert_equal('', maparg(entry[1], entry[0]))
+  endfor
+
+  source Xtestvimrc
+
+  for entry in entries
+    call assert_equal(entry[2], maparg(entry[1], entry[0]))
+  endfor
+
+  nmapclear
+
+  call delete('Xtestvimrc')
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
## Motivation

I detected an issue on `:mksession`. Basically the mapping:
```vim
imap <M-ç> <Cmd>call copilot#Previous()<CR>
```
turns into the session file as:
```vim
imap <M-Ã>^V§ <Cmd>call copilot#Previous()^V^M
```
and after sourcing and saving the session several times I got:
```vim
imap <M-Ã>^V^V^V^V^V^V^V^V§ <Cmd>call copilot#Previous()^V^M
imap <M-Ã>^V^V^V^V^V^V§ <Cmd>call copilot#Previous()^V^M
imap <M-Ã>^V^V^V^V^V§ <Cmd>call copilot#Previous()^V^M
imap <M-Ã>^V^V^V^V§ <Cmd>call copilot#Previous()^V^M
imap <M-Ã>^V^V^V§ <Cmd>call copilot#Previous()^V^M
imap <M-Ã>^V^V§ <Cmd>call copilot#Previous()^V^M
imap <M-Ã>^V§ <Cmd>call copilot#Previous()^V^M
```
Note that `ç` is a character available on `latin1` encoding (`cp1252` alias) that has a key associated in spanish
keyboards. On `latin1` is 0xE7 which matches its unicode code point. On utf-8 is a multibyte character `C3 A7`,
literally `Ã§`, thus I suspected and encoding issue.

## Review

Basically vim keeps the mappings internally in the encoding specified in `encoding` and translates this encoding to the
file encoding.  Vim uses some codes as markers to associate key metadata (`ALT`, `CTRL`, `SHIFT` modifiers, …). But those
modifiers like `K_SPECIAL` are valid utf-8 code units. To avoid ambiguity, vim *escapes* those codes in its internal
state.

I zeroed the problem in:

+ `put_escstr` (write escape string to file). This function handles *escaped* characters by keeping then temporally in
  an `int` (4 bytes are enough to keep any unicode character for now) and translating them later. The problem is that
  retrieval of multibyte characters was not properly made: requires *unescaping* and the use of a decoding function
  associated to the current 'encoding'.
+ `get_special_key_name` (return a string which contains the name of the given key when the given modifiers are down).
  If a character is available in a single byte and a multibyte encoding, as `ç`, favor the sort one. This way some
  session files can be read in both encodings.

A regression test was introduced too.
