### PR TITLE
fix(typo): fix link to chapter 2 in vim-01-beginner.tutor

### DIFF
--- a/runtime/autoload/tutor.vim
+++ b/runtime/autoload/tutor.vim
@@ -157,12 +157,14 @@ function! s:Sort(a, b)
     return retval
 endfunction
 
-function! s:GlobTutorials(name)
+" returns a list of all tutor files matching the given name
+function! tutor#GlobTutorials(name, locale)
+    let locale = a:locale
     " search for tutorials:
     " 1. non-localized
     let l:tutors = s:GlobPath(&rtp, 'tutor/'.a:name.'.tutor')
     " 2. localized for current locale
-    let l:locale_tutors = s:GlobPath(&rtp, 'tutor/'.s:Locale()[0].'/'.a:name.'.tutor')
+    let l:locale_tutors = s:GlobPath(&rtp, 'tutor/'.locale.'/'.a:name.'.tutor')
     " 3. fallback to 'en'
     if len(l:locale_tutors) == 0
         let l:locale_tutors = s:GlobPath(&rtp, 'tutor/en/'.a:name.'.tutor')
@@ -187,7 +189,7 @@ function! tutor#TutorCmd(tutor_name)
         let l:tutor_name = fnamemodify(l:tutor_name, ':r')
     endif
 
-    let l:tutors = s:GlobTutorials(l:tutor_name)
+    let l:tutors = tutor#GlobTutorials(l:tutor_name, s:Locale()[0])
 
     if len(l:tutors) == 0
         echom "No tutorial with that name found"
@@ -214,7 +216,7 @@ function! tutor#TutorCmd(tutor_name)
 endfunction
 
 function! tutor#TutorCmdComplete(lead,line,pos)
-    let l:tutors = s:GlobTutorials('*')
+    let l:tutors = tutor#GlobTutorials('*', s:Locale()[0])
     let l:names = uniq(sort(map(l:tutors, 'fnamemodify(v:val, ":t:r")'), 's:Sort'))
     return join(l:names, "\n")
 endfunction

--- a/runtime/tutor/en/vim-01-beginner.tutor
+++ b/runtime/tutor/en/vim-01-beginner.tutor
@@ -970,7 +970,7 @@ NOTE: Completion works for many commands. It is especially useful for
 # CONCLUSION
 
 This concludes Chapter 1 of the Vim Tutor.  Consider continuing with
-[Chapter 2](@tutor:tutor:vim-02-beginner).
+[Chapter 2](@tutor:vim-02-beginner).
 
 This was intended to give a brief overview of the Vim editor, just enough to
 allow you to use the editor fairly easily. It is far from complete as Vim has

--- a/src/testdir/test_plugin_tutor.vim
+++ b/src/testdir/test_plugin_tutor.vim
@@ -14,3 +14,21 @@ func Test_auto_enable_interactive()
   call assert_true(empty(&buftype))
   call assert_match('tutor#EnableInteractive', b:undo_ftplugin)
 endfunc
+
+func Test_tutor_link()
+  let tutor_files = globpath($VIMRUNTIME, 'tutor/**/*.tutor', 0, 1)
+  let pattern = '\[.\{-}@tutor:\zs[^)\]]*\ze[)\]]'
+
+  for tutor_file in tutor_files
+    let lang = fnamemodify(tutor_file, ':h:t')
+    if lang == 'tutor'
+      let lang = 'en'
+    endif
+
+    let text = readfile(tutor_file)
+    let links = matchstrlist(text, pattern)->map({_, v -> v.text})
+    for link in links
+      call assert_true(tutor#GlobTutorials(link, lang)->len() > 0)
+    endfor
+  endfor
+endfunc


### PR DESCRIPTION
Problem: that link does not work because of typo

Solution: fix it and add a test

In order to write the test, I expose the function `s:GlobTutorials` as `tutor#GlobTutorials` and make it also accept a `locale` argument.
