### PR TITLE
runtime(vim): Update base-syntax, fix missing luaParenError error

### DIFF
--- a/runtime/syntax/generator/vim.vim.base
+++ b/runtime/syntax/generator/vim.vim.base
@@ -2,7 +2,7 @@
 " Language:	   Vim script
 " Maintainer:	   Hirohito Higashi <h.east.727 ATMARK gmail.com>
 "	   Doug Kearns <dougkearns@gmail.com>
-" Last Change:	   2025 May 17
+" Last Change:	   2025 May 22
 " Former Maintainer: Charles E. Campbell
 
 " DO NOT CHANGE DIRECTLY.
@@ -1551,7 +1551,6 @@ let s:interfaces = get(g:, "vimsyn_embed", "lP")
 if s:interfaces =~# 'l'
   syn include @vimLuaScript syntax/lua.vim
   unlet b:current_syntax
-  syn clear luaParenError " See issue #11277
 endif
 
 syn keyword	vimLua	lua	skipwhite nextgroup=vimLuaHeredoc,vimLuaStatement

--- a/runtime/syntax/vim.vim
+++ b/runtime/syntax/vim.vim
@@ -2,7 +2,7 @@
 " Language:	   Vim script
 " Maintainer:	   Hirohito Higashi <h.east.727 ATMARK gmail.com>
 "	   Doug Kearns <dougkearns@gmail.com>
-" Last Change:	   2025 May 17
+" Last Change:	   2025 May 22
 " Former Maintainer: Charles E. Campbell
 
 " DO NOT CHANGE DIRECTLY.
@@ -1612,7 +1612,6 @@ let s:interfaces = get(g:, "vimsyn_embed", "lP")
 if s:interfaces =~# 'l'
   syn include @vimLuaScript syntax/lua.vim
   unlet b:current_syntax
-  syn clear luaParenError " See issue #11277
 endif
 
 syn keyword	vimLua	lua	skipwhite nextgroup=vimLuaHeredoc,vimLuaStatement


### PR DESCRIPTION
We shouldn't assume that the luaParenError syntax group is present in the, possibly custom, included file or that it hasn't already been removed.  However, issue #11277 has been fixed so it no longer needs to be cleared.

Fixes comment https://github.com/vim/vim/pull/15375#issuecomment-2899791944
