### PR TITLE
Fix compile warnings in os_win32.c

### DIFF
--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -6430,7 +6430,7 @@ termcap_mode_end(void)
 
     // Switch back to main screen buffer.
     if (exiting && use_alternate_screen_buffer)
-        vtp_printf("\033[?1049l");
+	vtp_printf("\033[?1049l");
 
     if (!USE_WT && (p_rs || exiting))
     {

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -164,7 +164,8 @@ static int write_input_record_buffer(INPUT_RECORD* irEvents, int nLength);
 #ifdef FEAT_GUI_MSWIN
 static int s_dont_use_vimrun = TRUE;
 static int need_vimrun_warning = FALSE;
-static char *vimrun_path = "vimrun ";
+static string_T vimrun_path = {(char_u *)"vimrun ", 7};
+static int vimrun_path_allocated = FALSE;
 #endif
 
 static int win32_getattrs(char_u *name);
@@ -175,12 +176,12 @@ static int conpty_working = 0;
 static int conpty_type = 0;
 static int conpty_stable = 0;
 static int conpty_fix_type = 0;
-static void vtp_flag_init();
+static void vtp_flag_init(void);
 
 #if !defined(FEAT_GUI_MSWIN) || defined(VIMDLL)
 static int vtp_working = 0;
-static void vtp_init();
-static void vtp_exit();
+static void vtp_init(void);
+static void vtp_exit(void);
 static void vtp_sgr_bulk(int arg);
 static void vtp_sgr_bulks(int argc, int *argv);
 
@@ -430,17 +431,15 @@ wait_for_single_object(
     void
 mch_get_exe_name(void)
 {
-    // Maximum length of $PATH is more than MAXPATHL.  8191 is often mentioned
-    // as the maximum length that works.  Add 1 for a NUL byte and 5 for
-    // "PATH=".
-#define MAX_ENV_PATH_LEN (8191 + 1 + 5)
-    WCHAR	temp[MAX_ENV_PATH_LEN];
-    WCHAR	buf[MAX_PATH];
     int		updated = FALSE;
     static int	enc_prev = -1;
+    WCHAR	*p;
+    size_t	plen;
 
     if (exe_name == NULL || exe_pathw == NULL || enc_prev != enc_codepage)
     {
+	WCHAR	buf[MAX_PATH];
+
 	// store the name of the executable, may be used for $VIM
 	GetModuleFileNameW(NULL, buf, MAX_PATH);
 	if (*buf != NUL)
@@ -466,33 +465,48 @@ mch_get_exe_name(void)
     // Append our starting directory to $PATH, so that when doing
     // "!xxd" it's found in our starting directory.  Needed because
     // SearchPath() also looks there.
-    WCHAR *p = _wgetenv(L"PATH");
-    if (p == NULL || wcslen(p) + wcslen(exe_pathw) + 2 + 5 < MAX_ENV_PATH_LEN)
-    {
-	wcscpy(temp, L"PATH=");
+    p = _wgetenv(L"PATH");
+    plen = 0;
 
-	if (p == NULL || *p == NUL)
-	    wcscat(temp, exe_pathw);
+    // Maximum length of $PATH is more than MAXPATHL. 8191 is often mentioned
+    // as the maximum length that works. Add 1 for a potential ';', 1 for the
+    // NUL byte and 5 for "PATH=".
+#define MAX_ENV_PATH_LEN (8191 + 2 + 5)
+
+    if (p == NULL
+	|| (plen = wcslen(p)) + wcslen(exe_pathw) + 2 + 5 < MAX_ENV_PATH_LEN)
+    {
+	WCHAR	temp[MAX_ENV_PATH_LEN] = L"PATH=";
+	size_t	templen = 5;
+
+	if (plen == 0)
+	    wcscpy(temp + templen, exe_pathw);
 	else
 	{
-	    wcscat(temp, p);
+	    wcscpy(temp + templen, p);
+	    templen += plen;
 
 	    // Check if exe_path is already included in $PATH.
 	    if (wcsstr(temp, exe_pathw) == NULL)
 	    {
 		// Append ';' if $PATH doesn't end with it.
-		size_t len = wcslen(temp);
-		if (temp[len - 1] != L';')
-		    wcscat(temp, L";");
+		if (temp[templen - 1] != L';')
+		{
+		    wcscpy(temp + templen, L";");
+		    ++templen;
+		}
 
-		wcscat(temp, exe_pathw);
+		wcscpy(temp + templen, exe_pathw);
 	    }
 	}
+
 	_wputenv(temp);
 #ifdef libintl_wputenv
 	libintl_wputenv(temp);
 #endif
     }
+
+#undef MAX_ENV_PATH_LEN
 }
 
 /*
@@ -733,7 +747,7 @@ get_forwarded_dll(HINSTANCE hInst)
     if (p - name + 1 > sizeof(buf))
 	return NULL;
     strncpy(buf, name, p - name);
-    buf[p - name] = '\0';
+    buf[p - name] = NUL;
     return GetModuleHandleA(buf);
 }
 #endif
@@ -776,8 +790,7 @@ dyn_libintl_init(void)
 	{"gettext", (FARPROC*)&dyn_libintl_gettext},
 	{"ngettext", (FARPROC*)&dyn_libintl_ngettext},
 	{"textdomain", (FARPROC*)&dyn_libintl_textdomain},
-	{"bindtextdomain", (FARPROC*)&dyn_libintl_bindtextdomain},
-	{NULL, NULL}
+	{"bindtextdomain", (FARPROC*)&dyn_libintl_bindtextdomain}
     };
     HINSTANCE hmsvcrt;
 
@@ -804,7 +817,7 @@ dyn_libintl_init(void)
 	}
 	return 0;
     }
-    for (i = 0; libintl_entry[i].name != NULL
+    for (i = 0; i < (int)ARRAY_LENGTH(libintl_entry)
 					 && libintl_entry[i].ptr != NULL; ++i)
     {
 	if ((*libintl_entry[i].ptr = GetProcAddress(hLibintlDLL,
@@ -1173,7 +1186,7 @@ decode_key_event(
 	return TRUE;
     }
 
-    for (i = ARRAY_LENGTH(VirtKeyMap);  --i >= 0;  )
+    for (i = ARRAY_LENGTH(VirtKeyMap); --i >= 0; )
     {
 	if (VirtKeyMap[i].wVirtKey == pker->wVirtualKeyCode)
 	{
@@ -2781,17 +2794,18 @@ executable_exists(char *name, char_u **path, int use_path, int use_pathext)
     // means that the maximum pathname is _MAX_PATH * 3 bytes when 'enc' is
     // UTF-8.
     char_u	buf[_MAX_PATH * 3];
-    size_t	len = STRLEN(name);
-    size_t	tmplen;
-    char_u	*p, *e, *e2;
-    char_u	*pathbuf = NULL;
-    char_u	*pathext = NULL;
-    char_u	*pathextbuf = NULL;
+    size_t	buflen;
+    size_t	namelen = STRLEN(name);
+    char_u	*p;
+    string_T	pathbuf = {NULL, 0};
+    int		pathbuf_allocated = FALSE;
+    string_T	pathext = {NULL, 0};
+    int		pathext_allocated = FALSE;
     char_u	*shname = NULL;
     int		noext = FALSE;
     int		retval = FALSE;
 
-    if (len >= sizeof(buf))	// safety check
+    if (namelen >= sizeof(buf))		// safety check
 	return FALSE;
 
     // Using the name directly when a Unix-shell like 'shell'.
@@ -2803,9 +2817,14 @@ executable_exists(char *name, char_u **path, int use_path, int use_pathext)
 
     if (use_pathext)
     {
-	pathext = mch_getenv("PATHEXT");
-	if (pathext == NULL)
-	    pathext = (char_u *)".com;.exe;.bat;.cmd";
+	pathext.string = mch_getenv("PATHEXT");
+	if (pathext.string == NULL)
+	{
+	    pathext.string = (char_u *)".com;.exe;.bat;.cmd";
+	    pathext.length = 19;
+	}
+	else
+	    pathext.length = STRLEN(pathext.string);
 
 	if (noext == FALSE)
 	{
@@ -2813,9 +2832,12 @@ executable_exists(char *name, char_u **path, int use_path, int use_pathext)
 	     * Loop over all extensions in $PATHEXT.
 	     * Check "name" ends with extension.
 	     */
-	    p = pathext;
+	    p = pathext.string;
 	    while (*p)
 	    {
+		char_u  *e;
+		size_t	len;
+
 		if (p[0] == ';'
 			    || (p[0] == '.' && (p[1] == NUL || p[1] == ';')))
 		{
@@ -2825,10 +2847,10 @@ executable_exists(char *name, char_u **path, int use_path, int use_pathext)
 		}
 		e = vim_strchr(p, ';');
 		if (e == NULL)
-		    e = p + STRLEN(p);
-		tmplen = e - p;
+		    e = pathext.string + pathext.length;
+		len = (size_t)(e - p);
 
-		if (_strnicoll(name + len - tmplen, (char *)p, tmplen) == 0)
+		if (_strnicoll(name + namelen - len, (char *)p, len) == 0)
 		{
 		    noext = TRUE;
 		    break;
@@ -2840,20 +2862,27 @@ executable_exists(char *name, char_u **path, int use_path, int use_pathext)
     }
 
     // Prepend single "." to pathext, it means no extension added.
-    if (pathext == NULL)
-	pathext = (char_u *)".";
+    if (pathext.string == NULL)
+    {
+	pathext.string = (char_u *)".";
+	pathext.length = 1;
+    }
     else if (noext == TRUE)
     {
-	if (pathextbuf == NULL)
-	    pathextbuf = alloc(STRLEN(pathext) + 3);
-	if (pathextbuf == NULL)
+	char_u	*tmp;
+
+	tmp = alloc(pathext.length + 3);
+	if (tmp == NULL)
 	{
 	    retval = FALSE;
 	    goto theend;
 	}
-	STRCPY(pathextbuf, ".;");
-	STRCAT(pathextbuf, pathext);
-	pathext = pathextbuf;
+
+	STRCPY(tmp, ".;");
+	STRCPY(tmp + 2, pathext.string);
+	pathext.string = tmp;
+	pathext.length += 2;
+	pathext_allocated = TRUE;
     }
 
     // Use $PATH when "use_path" is TRUE and "name" is basename.
@@ -2862,18 +2891,24 @@ executable_exists(char *name, char_u **path, int use_path, int use_pathext)
 	p = mch_getenv("PATH");
 	if (p != NULL)
 	{
-	    pathbuf = alloc(STRLEN(p) + 3);
-	    if (pathbuf == NULL)
+	    size_t  len = 0;
+
+	    pathbuf.length = STRLEN(p);
+	    pathbuf.string = alloc(pathbuf.length + 3);
+	    if (pathbuf.string == NULL)
 	    {
 		retval = FALSE;
 		goto theend;
 	    }
 
 	    if (mch_getenv("NoDefaultCurrentDirectoryInExePath") == NULL)
-		STRCPY(pathbuf, ".;");
-	    else
-		*pathbuf = NUL;
-	    STRCAT(pathbuf, p);
+	    {
+		STRCPY(pathbuf.string, ".;");
+		len = 2;
+	    }
+	    STRCPY(pathbuf.string + len, p);
+	    pathbuf.length += len;
+	    pathbuf_allocated = TRUE;
 	}
     }
 
@@ -2881,9 +2916,16 @@ executable_exists(char *name, char_u **path, int use_path, int use_pathext)
      * Walk through all entries in $PATH to check if "name" exists there and
      * is an executable file.
      */
-    p = (pathbuf != NULL) ? pathbuf : (char_u *)".";
+    if (pathbuf.string == NULL)
+    {
+	pathbuf.string = (char_u *)".";
+	pathbuf.length = 1;
+    }
+    p = pathbuf.string;
     while (*p)
     {
+	char_u	*e;
+
 	if (*p == ';') // Skip empty entry
 	{
 	    ++p;
@@ -2891,50 +2933,57 @@ executable_exists(char *name, char_u **path, int use_path, int use_pathext)
 	}
 	e = vim_strchr(p, ';');
 	if (e == NULL)
-	    e = p + STRLEN(p);
+	    e = pathbuf.string + pathbuf.length;
 
-	if (e - p + len + 2 > sizeof(buf))
+	if (e - p + namelen + 2 > sizeof(buf))
 	{
 	    retval = FALSE;
 	    goto theend;
 	}
 	// A single "." that means current dir.
 	if (e - p == 1 && *p == '.')
+	{
 	    STRCPY(buf, name);
+	    buflen = namelen;
+	}
 	else
 	{
-	    vim_strncpy(buf, p, e - p);
-	    add_pathsep(buf);
-	    STRCAT(buf, name);
+	    buflen = vim_snprintf_safelen(
+		(char *)buf,
+		sizeof(buf),
+		"%.*s%s%s", (int)(e - p), p,
+		!after_pathsep(p, e - 1) ? PATHSEPSTR : "",
+		name);
 	}
-	tmplen = STRLEN(buf);
 
 	/*
 	 * Loop over all extensions in $PATHEXT.
 	 * Check "name" with extension added.
 	 */
-	p = pathext;
+	p = pathext.string;
 	while (*p)
 	{
+	    char_u  *e2;
+
 	    if (*p == ';')
 	    {
 		// Skip empty entry
 		++p;
 		continue;
 	    }
-	    e2 = vim_strchr(p, (int)';');
+	    e2 = vim_strchr(p, ';');
 	    if (e2 == NULL)
-		e2 = p + STRLEN(p);
+		e2 = pathext.string + pathext.length;
 
 	    if (!(p[0] == '.' && (p[1] == NUL || p[1] == ';')))
 	    {
 		// Not a single "." that means no extension is added.
-		if (e2 - p + tmplen + 1 > sizeof(buf))
+		if (e2 - p + buflen + 1 > sizeof(buf))
 		{
 		    retval = FALSE;
 		    goto theend;
 		}
-		vim_strncpy(buf + tmplen, p, e2 - p);
+		vim_strncpy(buf + buflen, p, e2 - p);
 	    }
 	    if (executable_file((char *)buf, path))
 	    {
@@ -2949,8 +2998,10 @@ executable_exists(char *name, char_u **path, int use_path, int use_pathext)
     }
 
 theend:
-    free(pathextbuf);
-    free(pathbuf);
+    if (pathbuf_allocated)
+	free(pathbuf.string);
+    if (pathext_allocated)
+	free(pathext.string);
     return retval;
 }
 
@@ -3010,25 +3061,47 @@ mch_init_g(void)
 
     // Look for 'vimrun'
     {
-	char_u vimrun_location[_MAX_PATH + 4];
+	char_u	vimrun_location[_MAX_PATH + 4];
+	size_t	vimrun_locationlen;
+	size_t	path_len;
 
 	// First try in same directory as gvim.exe
-	STRCPY(vimrun_location, exe_name);
-	STRCPY(gettail(vimrun_location), "vimrun.exe");
+	path_len = (size_t)(gettail(exe_name) - exe_name);
+
+	vimrun_locationlen = vim_snprintf_safelen(
+	    (char *)vimrun_location,
+	    sizeof(vimrun_location),
+	    "%.*svimrun.exe",
+	    (int)path_len, exe_name);
+
 	if (mch_getperm(vimrun_location) >= 0)
 	{
+	    char_u    *tmp;
+
 	    if (*skiptowhite(vimrun_location) != NUL)
 	    {
 		// Enclose path with white space in double quotes.
 		mch_memmove(vimrun_location + 1, vimrun_location,
-						 STRLEN(vimrun_location) + 1);
+						 vimrun_locationlen + 1);
+		++path_len;
 		*vimrun_location = '"';
-		STRCPY(gettail(vimrun_location), "vimrun\" ");
+		STRCPY(vimrun_location + path_len, "vimrun\" ");
+		vimrun_locationlen = path_len + 8;
 	    }
 	    else
-		STRCPY(gettail(vimrun_location), "vimrun ");
+	    {
+		STRCPY(vimrun_location + path_len, "vimrun ");
+		vimrun_locationlen = path_len + 7;
+	    }
 
-	    vimrun_path = (char *)vim_strsave(vimrun_location);
+	    tmp = vim_strnsave(vimrun_location, vimrun_locationlen);
+	    if (tmp != NULL)
+	    {
+		vimrun_path.string = tmp;
+		vimrun_path.length = vimrun_locationlen;
+		vimrun_path_allocated = TRUE;
+	    }
+
 	    s_dont_use_vimrun = FALSE;
 	}
 	else if (executable_exists("vimrun.exe", NULL, TRUE, FALSE))
@@ -3640,6 +3713,8 @@ mch_exit(int r)
     else
 	mch_exit_c(r);
 #elif defined(FEAT_GUI_MSWIN)
+    if (vimrun_path_allocated)
+	vim_free(vimrun_path.string);
     mch_exit_g(r);
 #else
     mch_exit_c(r);
@@ -3678,12 +3753,10 @@ fname_case(
     char_u	*name,
     int		len)
 {
-    int	    flen;
     WCHAR   *p;
     WCHAR   buf[_MAX_PATH + 1];
 
-    flen = (int)STRLEN(name);
-    if (flen == 0)
+    if (*name == NUL)
 	return;
 
     slash_adjust(name);
@@ -3698,6 +3771,8 @@ fname_case(
 
 	if (q != NULL)
 	{
+	    int	flen = (int)STRLEN(name);
+
 	    if (len > 0 || flen >= (int)STRLEN(q))
 		vim_strncpy(name, q, (len > 0) ? len - 1 : flen);
 	    vim_free(q);
@@ -3778,7 +3853,7 @@ mch_process_running(long pid)
 
     if (hProcess == NULL)
 	return FALSE;  // might not have access
-    if (GetExitCodeProcess(hProcess, &status) )
+    if (GetExitCodeProcess(hProcess, &status))
 	ret = status == STILL_ACTIVE;
     CloseHandle(hProcess);
     return ret;
@@ -3838,10 +3913,8 @@ mch_dirname(
 mch_getperm(char_u *name)
 {
     stat_T	st;
-    int		n;
 
-    n = mch_stat((char *)name, &st);
-    return n == 0 ? (long)(unsigned short)st.st_mode : -1L;
+    return (mch_stat((char *)name, &st) == 0) ? (long)(unsigned short)st.st_mode : -1L;
 }
 
 
@@ -5438,25 +5511,30 @@ mch_call_shell(
     int		x = 0;
     int		tmode = cur_tmode;
     WCHAR	szShellTitle[512];
+    size_t	szShellTitlelen;
 
 #ifdef FEAT_EVAL
     ch_log(NULL, "executing shell command: %s", cmd);
 #endif
     // Change the title to reflect that we are in a subshell.
-    if (GetConsoleTitleW(szShellTitle, ARRAY_LENGTH(szShellTitle) - 4) > 0)
+    szShellTitlelen = (size_t)GetConsoleTitleW(szShellTitle, sizeof(szShellTitle) - 4);
+    if (szShellTitlelen > 0)
     {
 	if (cmd == NULL)
-	    wcscat(szShellTitle, L" :sh");
+	{
+	    wcscpy(szShellTitle + szShellTitlelen, L" :sh");
+	    SetConsoleTitleW(szShellTitle);
+	}
 	else
 	{
 	    WCHAR *wn = enc_to_utf16((char_u *)cmd, NULL);
 
 	    if (wn != NULL)
 	    {
-		wcscat(szShellTitle, L" - !");
-		if ((wcslen(szShellTitle) + wcslen(wn) <
-			    ARRAY_LENGTH(szShellTitle)))
-		    wcscat(szShellTitle, wn);
+		wcscpy(szShellTitle + szShellTitlelen, L" - !");
+		szShellTitlelen += wcslen(szShellTitle + szShellTitlelen);
+		if ((szShellTitlelen + wcslen(wn) < sizeof(szShellTitle)))
+		    wcscpy(szShellTitle + szShellTitlelen, wn);
 		SetConsoleTitleW(szShellTitle);
 		vim_free(wn);
 	    }
@@ -5657,14 +5735,17 @@ mch_call_shell(
 	}
 	else
 	{
+	    size_t  p_sh_len = STRLEN(p_sh);
+	    size_t  p_shcf_len = STRLEN(p_shcf);
+
 	    cmdlen =
 #ifdef FEAT_GUI_MSWIN
 		((gui.in_use || gui.starting) ?
 		    (!s_dont_use_vimrun && p_stmp ?
-			STRLEN(vimrun_path) : STRLEN(p_sh) + STRLEN(p_shcf))
+			vimrun_path.length : p_sh_len + p_shcf_len)
 		    : 0) +
 #endif
-		STRLEN(p_sh) + STRLEN(p_shcf) + STRLEN(cmd) + 10;
+		p_sh_len + p_shcf_len + STRLEN(cmd) + 10;
 
 	    newcmd = alloc(cmdlen);
 	    if (newcmd != NULL)
@@ -5697,7 +5778,7 @@ mch_call_shell(
 		    // Use vimrun to execute the command.  It opens a console
 		    // window, which can be closed without killing Vim.
 		    vim_snprintf((char *)newcmd, cmdlen, "%s%s%s %s %s",
-			    vimrun_path,
+			    vimrun_path.string,
 			    (msg_silent != 0 || (options & SHELL_DOOUT))
 								 ? "-s " : "",
 			    p_sh, p_shcf, cmd);
@@ -6349,7 +6430,7 @@ termcap_mode_end(void)
 
     // Switch back to main screen buffer.
     if (exiting && use_alternate_screen_buffer)
-	vtp_printf("\033[?1049l");
+        vtp_printf("\033[?1049l");
 
     if (!USE_WT && (p_rs || exiting))
     {
@@ -8091,9 +8172,9 @@ copy_extattr(char_u *from, char_u *to)
     if (fromf == NULL || tof == NULL)
 	goto theend;
     STRCPY(fromf, "\\??\\");
-    STRCAT(fromf, from);
+    STRCPY(fromf + STRLEN_LITERAL("\\??\\"), from);
     STRCPY(tof, "\\??\\");
-    STRCAT(tof, to);
+    STRCPY(tof + STRLEN_LITERAL("\\??\\"), to);
 
     // Convert the names to wide characters.
     fromw = enc_to_utf16(fromf, NULL);
@@ -8969,7 +9050,7 @@ GetWin32Error(void)
     // remove trailing \r\n
     char *pcrlf = strstr(msg, "\r\n");
     if (pcrlf != NULL)
-	*pcrlf = '\0';
+	*pcrlf = NUL;
     oldmsg = msg;
     return msg;
 }
@@ -8992,10 +9073,8 @@ static sig_atomic_t *timeout_flag = &timeout_flags[0];
 
 
     static void CALLBACK
-set_flag(void *param, BOOLEAN unused2 UNUSED)
+set_flag(void *param UNUSED, BOOLEAN unused2 UNUSED)
 {
-    int *timeout_flag = (int *)param;
-
     *timeout_flag = TRUE;
 }
 


### PR DESCRIPTION
Fix compiler warnings:
`clang -c -I. -Iproto -DWIN32 -DWINVER=0x0601 -D_WIN32_WINNT=0x0601 -DHAVE_PATHDEF -DFEAT_HUGE -DHAVE_STDINT_H -D__USE_MINGW_ANSI_STDIO -pipe -Wall -Wno-deprecated-declarations -D_REENTRANT -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1 -Wall -Wextra -Wshadow -Wstrict-prototypes -Wmissing-prototypes -Wno-deprecated-declarations -Wno-error=missing-field-initializers -Werror=uninitialized -Wunused-but-set-variable -DEXITFREE  os_win32.c -o objx86-64/os_win32.o`
`os_win32.c:178:26: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]`
`  178 | static void vtp_flag_init();`
`      |                          ^`
`      |                           void`
`os_win32.c:182:21: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]`
`  182 | static void vtp_init();`
`      |                     ^`
`      |                      void`
`os_win32.c:183:21: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]`
`  183 | static void vtp_exit();`
`      |                     ^`
`      |                      void`
`os_win32.c:8997:10: warning: declaration shadows a variable in the global scope [-Wshadow]`
` 8997 |     int *timeout_flag = (int *)param;`
`      |          ^`
`os_win32.c:8991:22: note: previous declaration is here`
` 8991 | static sig_atomic_t *timeout_flag = &timeout_flags[0];`
`      |                      ^`
`4 warnings generated.`

In other news...
In `mch_init_g()`:
-> refactor to remove calls to `STRLEN()`.
-> use `vim_strnsave()` instead of `vim_strave()` and add a out-of-memory check to its call.
-> set a flag if `vimrun_path` is stored in allocated memory so it can be freed at exit.
In `mch_exit()` free `vimrun_path` if it was stored in allocated memory.
In `executable_exists()`:
-> use `string_T` to store some strings.
-> refactor to remove calls to `STRLEN()` (via `STRCAT()`).
In `copy_extattr()` make a small optimisation by replacing call to `STRCAT()` with `STRCPY()`.
In `fname_case()` make a small optimisation by measuring the length of `name` only if needed.
In `dyn_libintl_init()` use `ARRAY_LENGTH` macro to iterate over the `libintl_entry` array.
In `mch_get_exe_name()`:
-> refactor to replace calls to `wcscat()` with `wscspy()`.
-> move variables closer to where they are used.
In `mch_call_shell()`:
-> refactor to replace calls to `wcscat()` with `wcscpy()`.
-> always call `SetConsoleTitleW()` if `GetConsoleTitleW()` succeeds (even if `cmd == NULL`) which seems like the original intent.
-> cache the lengths of `p_sh` and `pshcf`.
In `mch_getperm()` move call to `mch_stat()` into the return statement.
Some cosmetic code styling changes (removing extraneous spaces, etc).