### PR TITLE
Fix compile warnings in os_win32.c

### DIFF
--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -8992,9 +8992,9 @@ static sig_atomic_t *timeout_flag = &timeout_flags[0];
 
 
     static void CALLBACK
-set_flag(void *param UNUSED, BOOLEAN unused2 UNUSED)
+set_flag(void *param, BOOLEAN unused2 UNUSED)
 {
-    *timeout_flag = TRUE;
+    *(sig_atomic_t *)param = TRUE;
 }
 
 /*

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -175,12 +175,12 @@ static int conpty_working = 0;
 static int conpty_type = 0;
 static int conpty_stable = 0;
 static int conpty_fix_type = 0;
-static void vtp_flag_init();
+static void vtp_flag_init(void);
 
 #if !defined(FEAT_GUI_MSWIN) || defined(VIMDLL)
 static int vtp_working = 0;
-static void vtp_init();
-static void vtp_exit();
+static void vtp_init(void);
+static void vtp_exit(void);
 static void vtp_sgr_bulk(int arg);
 static void vtp_sgr_bulks(int argc, int *argv);
 
@@ -8992,10 +8992,8 @@ static sig_atomic_t *timeout_flag = &timeout_flags[0];
 
 
     static void CALLBACK
-set_flag(void *param, BOOLEAN unused2 UNUSED)
+set_flag(void *param UNUSED, BOOLEAN unused2 UNUSED)
 {
-    int *timeout_flag = (int *)param;
-
     *timeout_flag = TRUE;
 }
 


### PR DESCRIPTION
Fix compiler warnings:
`clang -c -I. -Iproto -DWIN32 -DWINVER=0x0601 -D_WIN32_WINNT=0x0601 -DHAVE_PATHDEF -DFEAT_HUGE -DHAVE_STDINT_H -D__USE_MINGW_ANSI_STDIO -pipe -Wall -Wno-deprecated-declarations -D_REENTRANT -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1 -Wall -Wextra -Wshadow -Wstrict-prototypes -Wmissing-prototypes -Wno-deprecated-declarations -Wno-error=missing-field-initializers -Werror=uninitialized -Wunused-but-set-variable -DEXITFREE  os_win32.c -o objx86-64/os_win32.o`
`os_win32.c:178:26: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]`
`  178 | static void vtp_flag_init();`
`      |                          ^`
`      |                           void`
`os_win32.c:182:21: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]`
`  182 | static void vtp_init();`
`      |                     ^`
`      |                      void`
`os_win32.c:183:21: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]`
`  183 | static void vtp_exit();`
`      |                     ^`
`      |                      void`
`os_win32.c:8997:10: warning: declaration shadows a variable in the global scope [-Wshadow]`
` 8997 |     int *timeout_flag = (int *)param;`
`      |          ^`
`os_win32.c:8991:22: note: previous declaration is here`
` 8991 | static sig_atomic_t *timeout_flag = &timeout_flags[0];`
`      |                      ^`
`4 warnings generated.`