### PR TITLE
Make GUI auto detection favor GTK3.

### DIFF
--- a/src/auto/configure
+++ b/src/auto/configure
@@ -10415,7 +10415,7 @@ fi
 
 
 
-if test "X$PKG_CONFIG" = "X"; then
+if test -z "$PKG_CONFIG"; then
   if test -n "$ac_tool_prefix"; then
   # Extract the first word of "${ac_tool_prefix}pkg-config", so it can be a program name with args.
 set dummy ${ac_tool_prefix}pkg-config; ac_word=$2
@@ -10528,9 +10528,7 @@ fi
 
 fi
 
-
-if test -z "$SKIP_GTK2"; then
-
+if test -z "$SKIP_GTK3"; then
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking --disable-gtktest argument" >&5
 printf %s "checking --disable-gtktest argument... " >&6; }
   # Check whether --enable-gtktest was given.
@@ -10551,60 +10549,69 @@ printf "%s\n" "gtk test disabled" >&6; }
   fi
 
   if test "x$PKG_CONFIG" != "xno"; then
-                    save_skip_gtk3=$SKIP_GTK3
-    SKIP_GTK3=YES
 
-  if test "X$GTK_CONFIG" != "Xno" -o "X$PKG_CONFIG" != "Xno"; then
+      min_gtk_version="3.0.0"
+
+    if test "$PKG_CONFIG" != "no"; then
+    case $min_gtk_version in #(
+  2.*) :
+    gtk_pkg_name="gtk+-2.0" ;; #(
+  3.*) :
+    gtk_pkg_name="gtk+-3.0" ;; #(
+  *) :
+    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in '$ac_pwd':" >&5
+printf "%s\n" "$as_me: error: in '$ac_pwd':" >&2;}
+as_fn_error $? "The configure script does not know which pkg-config name to use for GTK $min_gtk_version\"
+See 'config.log' for more details" "$LINENO" 5; } ;;
+esac
+
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for pkg-config $gtk_pkg_name" >&5
+printf %s "checking for pkg-config $gtk_pkg_name... " >&6; }
+    if "$PKG_CONFIG" --exists "$gtk_pkg_name"
+then :
+
+	     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: found" >&5
+printf "%s\n" "found" >&6; }
+	     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for GTK - version >= $min_gtk_version" >&5
+printf %s "checking for GTK - version >= $min_gtk_version... " >&6; }
+	     	     	     	     GTK_CFLAGS=`$PKG_CONFIG --cflags $gtk_pkg_name`
+	     GTK_LIBDIR=`$PKG_CONFIG --libs-only-L $gtk_pkg_name`
+	     GTK_LIBS=`$PKG_CONFIG --libs $gtk_pkg_name`
+	     gtk_major_version=`$PKG_CONFIG --modversion $gtk_pkg_name | \
+	       sed 's/\([0-9]*\)\.\([0-9]*\)\.\([0-9]*\)/\1/'`
+	     gtk_minor_version=`$PKG_CONFIG --modversion $gtk_pkg_name | \
+	       sed 's/\([0-9]*\)\.\([0-9]*\)\.\([0-9]*\)/\2/'`
+	     gtk_micro_version=`$PKG_CONFIG --modversion $gtk_pkg_name | \
+	       sed 's/\([0-9]*\)\.\([0-9]*\)\.\([0-9]*\)/\3/'`
+	     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes; found version $gtk_major_version.$gtk_minor_version.$gtk_micro_version" >&5
+printf "%s\n" "yes; found version $gtk_major_version.$gtk_minor_version.$gtk_micro_version" >&6; }
+
+else case e in #(
+  e)
+	      GTK_CFLAGS=""
+	      GTK_LIBDIR=""
+	      GTK_LIBS=""
+	      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no; consider installing your distro GTK -dev package" >&5
+printf "%s\n" "no; consider installing your distro GTK -dev package" >&6; }
+	      if test "$fail_if_missing" = "yes" -a "$gui_auto" != "yes"; then
+		as_fn_error $? "pkg-config could not find $gtk_pkg_name" "$LINENO" 5
+	      fi
+	     ;;
+esac
+fi
+  fi
+
+              gtktest_success="yes"
+  if test "$enable_gtktest" = "yes"; then
   {
-    no_gtk=""
-    if (test "X$SKIP_GTK2" != "XYES" -a "X$PKG_CONFIG" != "Xno") \
-	  && $PKG_CONFIG --exists gtk+-2.0; then
-    {
-      min_gtk_version=2.2.0
-      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for GTK - version >= $min_gtk_version" >&5
-printf %s "checking for GTK - version >= $min_gtk_version... " >&6; }
-                        GTK_CFLAGS=`$PKG_CONFIG --cflags gtk+-2.0`
-      GTK_LIBDIR=`$PKG_CONFIG --libs-only-L gtk+-2.0`
-      GTK_LIBS=`$PKG_CONFIG --libs gtk+-2.0`
-      gtk_major_version=`$PKG_CONFIG --modversion gtk+-2.0 | \
-	     sed 's/\([0-9]*\)\.\([0-9]*\)\.\([0-9]*\)/\1/'`
-      gtk_minor_version=`$PKG_CONFIG --modversion gtk+-2.0 | \
-	     sed 's/\([0-9]*\)\.\([0-9]*\)\.\([0-9]*\)/\2/'`
-      gtk_micro_version=`$PKG_CONFIG --modversion gtk+-2.0 | \
-	     sed 's/\([0-9]*\)\.\([0-9]*\)\.\([0-9]*\)/\3/'`
-    }
-    elif (test "X$SKIP_GTK3" != "XYES" -a "X$PKG_CONFIG" != "Xno") \
-	  && $PKG_CONFIG --exists gtk+-3.0; then
-    {
-      min_gtk_version=2.2.0
-      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for GTK - version >= $min_gtk_version" >&5
-printf %s "checking for GTK - version >= $min_gtk_version... " >&6; }
+    ac_save_CFLAGS="$CFLAGS"
+    ac_save_LIBS="$LIBS"
+    CFLAGS="$CFLAGS $GTK_CFLAGS"
+    LIBS="$LIBS $GTK_LIBS"
 
-      GTK_CFLAGS=`$PKG_CONFIG --cflags gtk+-3.0`
-      GTK_LIBDIR=`$PKG_CONFIG --libs-only-L gtk+-3.0`
-      GTK_LIBS=`$PKG_CONFIG --libs gtk+-3.0`
-      gtk_major_version=`$PKG_CONFIG --modversion gtk+-3.0 | \
-	     sed 's/\([0-9]*\)\.\([0-9]*\)\.\([0-9]*\)/\1/'`
-      gtk_minor_version=`$PKG_CONFIG --modversion gtk+-3.0 | \
-	     sed 's/\([0-9]*\)\.\([0-9]*\)\.\([0-9]*\)/\2/'`
-      gtk_micro_version=`$PKG_CONFIG --modversion gtk+-3.0 | \
-	     sed 's/\([0-9]*\)\.\([0-9]*\)\.\([0-9]*\)/\3/'`
-    }
-    else
-                  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for GTK -dev package" >&5
-printf %s "checking for GTK -dev package... " >&6; }
-      no_gtk=yes
-    fi
-
-    if test "x$enable_gtktest" = "xyes" -a "x$no_gtk" = "x"; then
-    {
-      ac_save_CFLAGS="$CFLAGS"
-      ac_save_LIBS="$LIBS"
-      CFLAGS="$CFLAGS $GTK_CFLAGS"
-      LIBS="$LIBS $GTK_LIBS"
-
-                        rm -f conf.gtktest
-      if test "$cross_compiling" = yes
+                { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking ability to compile GTK test program" >&5
+printf %s "checking ability to compile GTK test program... " >&6; }
+    if test "$cross_compiling" = yes
 then :
   echo $ac_n "cross compiling; assumed OK... $ac_c"
 else case e in #(
@@ -10621,37 +10628,39 @@ else case e in #(
 int
 main ()
 {
-int major, minor, micro;
-char *tmp_version;
+	int ex_major = $gtk_major_version;
+	int ex_minor = $gtk_minor_version;
+	int ex_micro = $gtk_micro_version;
 
-system ("touch conf.gtktest");
+	#if $gtk_major_version == 2
+	guint ob_major = gtk_major_version;
+	guint ob_minor = gtk_minor_version;
+	guint ob_micro = gtk_micro_version;
+	#else
+	guint ob_major = gtk_get_major_version();
+	guint ob_minor = gtk_get_minor_version();
+	guint ob_micro = gtk_get_micro_version();
+	#endif
 
-/* HP/UX 9 (%@#!) writes to sscanf strings */
-tmp_version = g_strdup("$min_gtk_version");
-if (sscanf(tmp_version, "%d.%d.%d", &major, &minor, &micro) != 3) {
-   printf("%s, bad version string\n", "$min_gtk_version");
-   g_free(tmp_version);
-   exit(1);
- }
-
-g_free(tmp_version);
-
-if ((gtk_major_version > major) ||
-    ((gtk_major_version == major) && (gtk_minor_version > minor)) ||
-    ((gtk_major_version == major) && (gtk_minor_version == minor) &&
-				     (gtk_micro_version >= micro)))
-{
-    return 0;
-}
-return 1;
+	if ((ob_major > ex_major) ||
+		((ob_major == ex_major)
+			&& (ob_minor > ex_minor)) ||
+		((ob_major == ex_major)
+			&& (ob_minor == ex_minor)
+			&& (ob_micro >= ex_micro)))
+		return 0;
+	else
+		return 1;
 }
 
 _ACEOF
 if ac_fn_c_try_run "$LINENO"
 then :
-
+  gtktest_success="yes"; { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; }
 else case e in #(
-  e) no_gtk=yes ;;
+  e) gtktest_success="no"; { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; } ;;
 esac
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
@@ -10659,50 +10668,204 @@ rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
 esac
 fi
 
-      CFLAGS="$ac_save_CFLAGS"
-      LIBS="$ac_save_LIBS"
-    }
-    fi
-    if test "x$no_gtk" = x ; then
-      if test "x$enable_gtktest" = "xyes"; then
-	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes; found version $gtk_major_version.$gtk_minor_version.$gtk_micro_version" >&5
-printf "%s\n" "yes; found version $gtk_major_version.$gtk_minor_version.$gtk_micro_version" >&6; }
-      else
-	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: found version $gtk_major_version.$gtk_minor_version.$gtk_micro_version" >&5
-printf "%s\n" "found version $gtk_major_version.$gtk_minor_version.$gtk_micro_version" >&6; }
-      fi
-      GUI_LIB_LOC="$GTK_LIBDIR"
-		 GTK_LIBNAME="$GTK_LIBS"
-		GUI_INC_LOC="$GTK_CFLAGS"
-    else
-    {
-      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
-      GTK_CFLAGS=""
-      GTK_LIBS=""
-      :
-      if test "$fail_if_missing" = "yes" -a "X$gui_auto" != "Xyes"; then
-	as_fn_error $? "could not configure GTK" "$LINENO" 5
-      fi
-    }
-    fi
+    CFLAGS="$ac_save_CFLAGS"
+    LIBS="$ac_save_LIBS"
   }
+  fi
+
+  if test "$gtktest_success" = "yes"; then
+    GUI_LIB_LOC="$GTK_LIBDIR"
+		 GTK_LIBNAME="$GTK_LIBS"
+		 GUI_INC_LOC="$GTK_CFLAGS"
   else
-    GTK_CFLAGS=""
+        GTK_CFLAGS=""
+    GTK_LIBDIR=""
     GTK_LIBS=""
-    :
+    if test "$fail_if_missing" = "yes" -a "$gui_auto" != "yes"; then
+      as_fn_error $? "Failed to compile GTK test program." "$LINENO" 5
+    fi
   fi
 
 
-  rm -f conf.gtktest
 
-    if test "x$GTK_CFLAGS" != "x"; then
-      SKIP_GTK3=YES
+
+    if test -n "$GTK_CFLAGS"; then
+      SKIP_GTK2=YES
+      SKIP_GNOME=YES
       SKIP_MOTIF=YES
       GUITYPE=GTK
 
-    else
-      SKIP_GTK3=$save_skip_gtk3
+      printf "%s\n" "#define USE_GTK3 1" >>confdefs.h
+
+    fi
+  fi
+fi
+
+if test -z "$SKIP_GTK2"; then
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking --disable-gtktest argument" >&5
+printf %s "checking --disable-gtktest argument... " >&6; }
+  # Check whether --enable-gtktest was given.
+if test ${enable_gtktest+y}
+then :
+  enableval=$enable_gtktest;
+else case e in #(
+  e) enable_gtktest=yes ;;
+esac
+fi
+
+  if test "x$enable_gtktest" = "xyes" ; then
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: gtk test enabled" >&5
+printf "%s\n" "gtk test enabled" >&6; }
+  else
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: gtk test disabled" >&5
+printf "%s\n" "gtk test disabled" >&6; }
+  fi
+
+  if test "x$PKG_CONFIG" != "xno"; then
+
+      min_gtk_version="2.2.0"
+
+    if test "$PKG_CONFIG" != "no"; then
+    case $min_gtk_version in #(
+  2.*) :
+    gtk_pkg_name="gtk+-2.0" ;; #(
+  3.*) :
+    gtk_pkg_name="gtk+-3.0" ;; #(
+  *) :
+    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in '$ac_pwd':" >&5
+printf "%s\n" "$as_me: error: in '$ac_pwd':" >&2;}
+as_fn_error $? "The configure script does not know which pkg-config name to use for GTK $min_gtk_version\"
+See 'config.log' for more details" "$LINENO" 5; } ;;
+esac
+
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for pkg-config $gtk_pkg_name" >&5
+printf %s "checking for pkg-config $gtk_pkg_name... " >&6; }
+    if "$PKG_CONFIG" --exists "$gtk_pkg_name"
+then :
+
+	     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: found" >&5
+printf "%s\n" "found" >&6; }
+	     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for GTK - version >= $min_gtk_version" >&5
+printf %s "checking for GTK - version >= $min_gtk_version... " >&6; }
+	     	     	     	     GTK_CFLAGS=`$PKG_CONFIG --cflags $gtk_pkg_name`
+	     GTK_LIBDIR=`$PKG_CONFIG --libs-only-L $gtk_pkg_name`
+	     GTK_LIBS=`$PKG_CONFIG --libs $gtk_pkg_name`
+	     gtk_major_version=`$PKG_CONFIG --modversion $gtk_pkg_name | \
+	       sed 's/\([0-9]*\)\.\([0-9]*\)\.\([0-9]*\)/\1/'`
+	     gtk_minor_version=`$PKG_CONFIG --modversion $gtk_pkg_name | \
+	       sed 's/\([0-9]*\)\.\([0-9]*\)\.\([0-9]*\)/\2/'`
+	     gtk_micro_version=`$PKG_CONFIG --modversion $gtk_pkg_name | \
+	       sed 's/\([0-9]*\)\.\([0-9]*\)\.\([0-9]*\)/\3/'`
+	     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes; found version $gtk_major_version.$gtk_minor_version.$gtk_micro_version" >&5
+printf "%s\n" "yes; found version $gtk_major_version.$gtk_minor_version.$gtk_micro_version" >&6; }
+
+else case e in #(
+  e)
+	      GTK_CFLAGS=""
+	      GTK_LIBDIR=""
+	      GTK_LIBS=""
+	      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no; consider installing your distro GTK -dev package" >&5
+printf "%s\n" "no; consider installing your distro GTK -dev package" >&6; }
+	      if test "$fail_if_missing" = "yes" -a "$gui_auto" != "yes"; then
+		as_fn_error $? "pkg-config could not find $gtk_pkg_name" "$LINENO" 5
+	      fi
+	     ;;
+esac
+fi
+  fi
+
+              gtktest_success="yes"
+  if test "$enable_gtktest" = "yes"; then
+  {
+    ac_save_CFLAGS="$CFLAGS"
+    ac_save_LIBS="$LIBS"
+    CFLAGS="$CFLAGS $GTK_CFLAGS"
+    LIBS="$LIBS $GTK_LIBS"
+
+                { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking ability to compile GTK test program" >&5
+printf %s "checking ability to compile GTK test program... " >&6; }
+    if test "$cross_compiling" = yes
+then :
+  echo $ac_n "cross compiling; assumed OK... $ac_c"
+else case e in #(
+  e) cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+#include <gtk/gtk.h>
+#include <stdio.h>
+#if STDC_HEADERS
+# include <stdlib.h>
+# include <stddef.h>
+#endif
+
+int
+main ()
+{
+	int ex_major = $gtk_major_version;
+	int ex_minor = $gtk_minor_version;
+	int ex_micro = $gtk_micro_version;
+
+	#if $gtk_major_version == 2
+	guint ob_major = gtk_major_version;
+	guint ob_minor = gtk_minor_version;
+	guint ob_micro = gtk_micro_version;
+	#else
+	guint ob_major = gtk_get_major_version();
+	guint ob_minor = gtk_get_minor_version();
+	guint ob_micro = gtk_get_micro_version();
+	#endif
+
+	if ((ob_major > ex_major) ||
+		((ob_major == ex_major)
+			&& (ob_minor > ex_minor)) ||
+		((ob_major == ex_major)
+			&& (ob_minor == ex_minor)
+			&& (ob_micro >= ex_micro)))
+		return 0;
+	else
+		return 1;
+}
+
+_ACEOF
+if ac_fn_c_try_run "$LINENO"
+then :
+  gtktest_success="yes"; { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; }
+else case e in #(
+  e) gtktest_success="no"; { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; } ;;
+esac
+fi
+rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
+  conftest.$ac_objext conftest.beam conftest.$ac_ext ;;
+esac
+fi
+
+    CFLAGS="$ac_save_CFLAGS"
+    LIBS="$ac_save_LIBS"
+  }
+  fi
+
+  if test "$gtktest_success" = "yes"; then
+    GUI_LIB_LOC="$GTK_LIBDIR"
+		 GTK_LIBNAME="$GTK_LIBS"
+		 GUI_INC_LOC="$GTK_CFLAGS"
+  else
+        GTK_CFLAGS=""
+    GTK_LIBDIR=""
+    GTK_LIBS=""
+    if test "$fail_if_missing" = "yes" -a "$gui_auto" != "yes"; then
+      as_fn_error $? "Failed to compile GTK test program." "$LINENO" 5
+    fi
+  fi
+
+
+
+
+    if test -n "$GTK_CFLAGS"; then
+      SKIP_MOTIF=YES
+      GUITYPE=GTK
+
     fi
   fi
   if test "x$GUITYPE" = "xGTK"; then
@@ -10794,188 +10957,6 @@ printf "%s\n" "not found" >&6; }
 	GTK_LIBNAME="$GTK_LIBNAME $GNOME_LIBDIR $GNOME_LIBS"
       fi
     }
-    fi
-  fi
-fi
-
-
-if test -z "$SKIP_GTK3"; then
-
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking --disable-gtktest argument" >&5
-printf %s "checking --disable-gtktest argument... " >&6; }
-  # Check whether --enable-gtktest was given.
-if test ${enable_gtktest+y}
-then :
-  enableval=$enable_gtktest;
-else case e in #(
-  e) enable_gtktest=yes ;;
-esac
-fi
-
-  if test "x$enable_gtktest" = "xyes" ; then
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: gtk test enabled" >&5
-printf "%s\n" "gtk test enabled" >&6; }
-  else
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: gtk test disabled" >&5
-printf "%s\n" "gtk test disabled" >&6; }
-  fi
-
-  if test "x$PKG_CONFIG" != "xno"; then
-    save_skip_gtk2=$SKIP_GTK2
-    SKIP_GTK2=YES
-
-  if test "X$GTK_CONFIG" != "Xno" -o "X$PKG_CONFIG" != "Xno"; then
-  {
-    no_gtk=""
-    if (test "X$SKIP_GTK2" != "XYES" -a "X$PKG_CONFIG" != "Xno") \
-	  && $PKG_CONFIG --exists gtk+-2.0; then
-    {
-      min_gtk_version=3.0.0
-      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for GTK - version >= $min_gtk_version" >&5
-printf %s "checking for GTK - version >= $min_gtk_version... " >&6; }
-                        GTK_CFLAGS=`$PKG_CONFIG --cflags gtk+-2.0`
-      GTK_LIBDIR=`$PKG_CONFIG --libs-only-L gtk+-2.0`
-      GTK_LIBS=`$PKG_CONFIG --libs gtk+-2.0`
-      gtk_major_version=`$PKG_CONFIG --modversion gtk+-2.0 | \
-	     sed 's/\([0-9]*\)\.\([0-9]*\)\.\([0-9]*\)/\1/'`
-      gtk_minor_version=`$PKG_CONFIG --modversion gtk+-2.0 | \
-	     sed 's/\([0-9]*\)\.\([0-9]*\)\.\([0-9]*\)/\2/'`
-      gtk_micro_version=`$PKG_CONFIG --modversion gtk+-2.0 | \
-	     sed 's/\([0-9]*\)\.\([0-9]*\)\.\([0-9]*\)/\3/'`
-    }
-    elif (test "X$SKIP_GTK3" != "XYES" -a "X$PKG_CONFIG" != "Xno") \
-	  && $PKG_CONFIG --exists gtk+-3.0; then
-    {
-      min_gtk_version=3.0.0
-      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for GTK - version >= $min_gtk_version" >&5
-printf %s "checking for GTK - version >= $min_gtk_version... " >&6; }
-
-      GTK_CFLAGS=`$PKG_CONFIG --cflags gtk+-3.0`
-      GTK_LIBDIR=`$PKG_CONFIG --libs-only-L gtk+-3.0`
-      GTK_LIBS=`$PKG_CONFIG --libs gtk+-3.0`
-      gtk_major_version=`$PKG_CONFIG --modversion gtk+-3.0 | \
-	     sed 's/\([0-9]*\)\.\([0-9]*\)\.\([0-9]*\)/\1/'`
-      gtk_minor_version=`$PKG_CONFIG --modversion gtk+-3.0 | \
-	     sed 's/\([0-9]*\)\.\([0-9]*\)\.\([0-9]*\)/\2/'`
-      gtk_micro_version=`$PKG_CONFIG --modversion gtk+-3.0 | \
-	     sed 's/\([0-9]*\)\.\([0-9]*\)\.\([0-9]*\)/\3/'`
-    }
-    else
-                  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for GTK -dev package" >&5
-printf %s "checking for GTK -dev package... " >&6; }
-      no_gtk=yes
-    fi
-
-    if test "x$enable_gtktest" = "xyes" -a "x$no_gtk" = "x"; then
-    {
-      ac_save_CFLAGS="$CFLAGS"
-      ac_save_LIBS="$LIBS"
-      CFLAGS="$CFLAGS $GTK_CFLAGS"
-      LIBS="$LIBS $GTK_LIBS"
-
-                        rm -f conf.gtktest
-      if test "$cross_compiling" = yes
-then :
-  echo $ac_n "cross compiling; assumed OK... $ac_c"
-else case e in #(
-  e) cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-#include <gtk/gtk.h>
-#include <stdio.h>
-#if STDC_HEADERS
-# include <stdlib.h>
-# include <stddef.h>
-#endif
-
-int
-main ()
-{
-int major, minor, micro;
-char *tmp_version;
-
-system ("touch conf.gtktest");
-
-/* HP/UX 9 (%@#!) writes to sscanf strings */
-tmp_version = g_strdup("$min_gtk_version");
-if (sscanf(tmp_version, "%d.%d.%d", &major, &minor, &micro) != 3) {
-   printf("%s, bad version string\n", "$min_gtk_version");
-   g_free(tmp_version);
-   exit(1);
- }
-
-g_free(tmp_version);
-
-if ((gtk_major_version > major) ||
-    ((gtk_major_version == major) && (gtk_minor_version > minor)) ||
-    ((gtk_major_version == major) && (gtk_minor_version == minor) &&
-				     (gtk_micro_version >= micro)))
-{
-    return 0;
-}
-return 1;
-}
-
-_ACEOF
-if ac_fn_c_try_run "$LINENO"
-then :
-
-else case e in #(
-  e) no_gtk=yes ;;
-esac
-fi
-rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
-  conftest.$ac_objext conftest.beam conftest.$ac_ext ;;
-esac
-fi
-
-      CFLAGS="$ac_save_CFLAGS"
-      LIBS="$ac_save_LIBS"
-    }
-    fi
-    if test "x$no_gtk" = x ; then
-      if test "x$enable_gtktest" = "xyes"; then
-	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes; found version $gtk_major_version.$gtk_minor_version.$gtk_micro_version" >&5
-printf "%s\n" "yes; found version $gtk_major_version.$gtk_minor_version.$gtk_micro_version" >&6; }
-      else
-	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: found version $gtk_major_version.$gtk_minor_version.$gtk_micro_version" >&5
-printf "%s\n" "found version $gtk_major_version.$gtk_minor_version.$gtk_micro_version" >&6; }
-      fi
-      GUI_LIB_LOC="$GTK_LIBDIR"
-		 GTK_LIBNAME="$GTK_LIBS"
-		GUI_INC_LOC="$GTK_CFLAGS"
-    else
-    {
-      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
-      GTK_CFLAGS=""
-      GTK_LIBS=""
-      :
-      if test "$fail_if_missing" = "yes" -a "X$gui_auto" != "Xyes"; then
-	as_fn_error $? "could not configure GTK" "$LINENO" 5
-      fi
-    }
-    fi
-  }
-  else
-    GTK_CFLAGS=""
-    GTK_LIBS=""
-    :
-  fi
-
-
-  rm -f conf.gtktest
-
-    if test "x$GTK_CFLAGS" != "x"; then
-      SKIP_GTK2=YES
-      SKIP_GNOME=YES
-      SKIP_MOTIF=YES
-      GUITYPE=GTK
-
-      printf "%s\n" "#define USE_GTK3 1" >>confdefs.h
-
-    else
-      SKIP_GTK2=$save_skip_gtk2
     fi
   fi
 fi

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -2638,62 +2638,66 @@ dnl Test for GTK, and define GTK_CFLAGS, GTK_LIBDIR and GTK_LIBS
 dnl
 AC_DEFUN(AM_PATH_GTK,
 [
-  if test "X$GTK_CONFIG" != "Xno" -o "X$PKG_CONFIG" != "Xno"; then
+  dnl Even if we don't end up using the pkg-config name, the min_gtk_version
+  dnl will be used when compiling the gtktest program below.
+  min_gtk_version="$1"
+
+  dnl Attempt to source flags from pkg-config if it is installed.
+  if test "$PKG_CONFIG" != "no"; then
+    AS_CASE([$min_gtk_version],
+	    [2.*], [gtk_pkg_name="gtk+-2.0"],
+	    [3.*], [gtk_pkg_name="gtk+-3.0"],
+		   [AC_MSG_FAILURE([The configure script does not know which pkg-config name to use for GTK $min_gtk_version"])])
+
+    AC_MSG_CHECKING([for pkg-config $gtk_pkg_name])
+    AS_IF(["$PKG_CONFIG" --exists "$gtk_pkg_name"],
+	  [
+	     AC_MSG_RESULT(found)
+	     AC_MSG_CHECKING([for GTK - version >= $min_gtk_version])
+	     dnl We should be using PKG_CHECK_MODULES() instead of this hack.
+	     dnl But I guess the dependency on pkgconfig.m4 is not wanted or
+	     dnl something like that.
+	     GTK_CFLAGS=`$PKG_CONFIG --cflags $gtk_pkg_name`
+	     GTK_LIBDIR=`$PKG_CONFIG --libs-only-L $gtk_pkg_name`
+	     GTK_LIBS=`$PKG_CONFIG --libs $gtk_pkg_name`
+	     gtk_major_version=`$PKG_CONFIG --modversion $gtk_pkg_name | \
+	       sed 's/\([[0-9]]*\)\.\([[0-9]]*\)\.\([[0-9]]*\)/\1/'`
+	     gtk_minor_version=`$PKG_CONFIG --modversion $gtk_pkg_name | \
+	       sed 's/\([[0-9]]*\)\.\([[0-9]]*\)\.\([[0-9]]*\)/\2/'`
+	     gtk_micro_version=`$PKG_CONFIG --modversion $gtk_pkg_name | \
+	       sed 's/\([[0-9]]*\)\.\([[0-9]]*\)\.\([[0-9]]*\)/\3/'`
+	     AC_MSG_RESULT([yes; found version $gtk_major_version.$gtk_minor_version.$gtk_micro_version])
+	   ],
+	   [
+	      GTK_CFLAGS=""
+	      GTK_LIBDIR=""
+	      GTK_LIBS=""
+	      AC_MSG_RESULT([no; consider installing your distro GTK -dev package])
+	      if test "$fail_if_missing" = "yes" -a "$gui_auto" != "yes"; then
+		AC_MSG_ERROR([pkg-config could not find $gtk_pkg_name])
+	      fi
+	    ])
+  fi
+
+  dnl Regardless of whether we sources the GTK compilation flags from
+  dnl pkg-config above versus the user specifying them in CFLAGS and LIBS, try
+  dnl to compile the test program.
+  dnl
+  dnl Default to outcome flag to "yes" because disabling the check should be
+  dnl considered the same as assuming it would succeed.
+  gtktest_success="yes"
+  if test "$enable_gtktest" = "yes"; then
   {
-    no_gtk=""
-    if (test "X$SKIP_GTK2" != "XYES" -a "X$PKG_CONFIG" != "Xno") \
-	  && $PKG_CONFIG --exists gtk+-2.0; then
-    {
-      min_gtk_version=ifelse([$1], ,2.2.0,$1)
-      AC_MSG_CHECKING(for GTK - version >= $min_gtk_version)
-      dnl We should be using PKG_CHECK_MODULES() instead of this hack.
-      dnl But I guess the dependency on pkgconfig.m4 is not wanted or
-      dnl something like that.
-      GTK_CFLAGS=`$PKG_CONFIG --cflags gtk+-2.0`
-      GTK_LIBDIR=`$PKG_CONFIG --libs-only-L gtk+-2.0`
-      GTK_LIBS=`$PKG_CONFIG --libs gtk+-2.0`
-      gtk_major_version=`$PKG_CONFIG --modversion gtk+-2.0 | \
-	     sed 's/\([[0-9]]*\)\.\([[0-9]]*\)\.\([[0-9]]*\)/\1/'`
-      gtk_minor_version=`$PKG_CONFIG --modversion gtk+-2.0 | \
-	     sed 's/\([[0-9]]*\)\.\([[0-9]]*\)\.\([[0-9]]*\)/\2/'`
-      gtk_micro_version=`$PKG_CONFIG --modversion gtk+-2.0 | \
-	     sed 's/\([[0-9]]*\)\.\([[0-9]]*\)\.\([[0-9]]*\)/\3/'`
-    }
-    elif (test "X$SKIP_GTK3" != "XYES" -a "X$PKG_CONFIG" != "Xno") \
-	  && $PKG_CONFIG --exists gtk+-3.0; then
-    {
-      min_gtk_version=ifelse([$1], ,3.0.0,$1)
-      AC_MSG_CHECKING(for GTK - version >= $min_gtk_version)
+    ac_save_CFLAGS="$CFLAGS"
+    ac_save_LIBS="$LIBS"
+    CFLAGS="$CFLAGS $GTK_CFLAGS"
+    LIBS="$LIBS $GTK_LIBS"
 
-      GTK_CFLAGS=`$PKG_CONFIG --cflags gtk+-3.0`
-      GTK_LIBDIR=`$PKG_CONFIG --libs-only-L gtk+-3.0`
-      GTK_LIBS=`$PKG_CONFIG --libs gtk+-3.0`
-      gtk_major_version=`$PKG_CONFIG --modversion gtk+-3.0 | \
-	     sed 's/\([[0-9]]*\)\.\([[0-9]]*\)\.\([[0-9]]*\)/\1/'`
-      gtk_minor_version=`$PKG_CONFIG --modversion gtk+-3.0 | \
-	     sed 's/\([[0-9]]*\)\.\([[0-9]]*\)\.\([[0-9]]*\)/\2/'`
-      gtk_micro_version=`$PKG_CONFIG --modversion gtk+-3.0 | \
-	     sed 's/\([[0-9]]*\)\.\([[0-9]]*\)\.\([[0-9]]*\)/\3/'`
-    }
-    else
-      dnl Put some text before the "no" to hint at installing the gtk-dev
-      dnl packages.
-      AC_MSG_CHECKING(for GTK -dev package)
-      no_gtk=yes
-    fi
-
-    if test "x$enable_gtktest" = "xyes" -a "x$no_gtk" = "x"; then
-    {
-      ac_save_CFLAGS="$CFLAGS"
-      ac_save_LIBS="$LIBS"
-      CFLAGS="$CFLAGS $GTK_CFLAGS"
-      LIBS="$LIBS $GTK_LIBS"
-
-      dnl
-      dnl Now check if the installed GTK is sufficiently new.
-      dnl
-      rm -f conf.gtktest
-      AC_RUN_IFELSE([AC_LANG_SOURCE([
+    dnl
+    dnl Now check if the installed GTK is sufficiently new.
+    dnl
+    AC_MSG_CHECKING([ability to compile GTK test program])
+    AC_RUN_IFELSE([AC_LANG_SOURCE([
 #include <gtk/gtk.h>
 #include <stdio.h>
 #if STDC_HEADERS
@@ -2704,62 +2708,53 @@ AC_DEFUN(AM_PATH_GTK,
 int
 main ()
 {
-int major, minor, micro;
-char *tmp_version;
+	int ex_major = $gtk_major_version;
+	int ex_minor = $gtk_minor_version;
+	int ex_micro = $gtk_micro_version;
 
-system ("touch conf.gtktest");
+	#if $gtk_major_version == 2
+	guint ob_major = gtk_major_version;
+	guint ob_minor = gtk_minor_version;
+	guint ob_micro = gtk_micro_version;
+	#else
+	guint ob_major = gtk_get_major_version();
+	guint ob_minor = gtk_get_minor_version();
+	guint ob_micro = gtk_get_micro_version();
+	#endif
 
-/* HP/UX 9 (%@#!) writes to sscanf strings */
-tmp_version = g_strdup("$min_gtk_version");
-if (sscanf(tmp_version, "%d.%d.%d", &major, &minor, &micro) != 3) {
-   printf("%s, bad version string\n", "$min_gtk_version");
-   g_free(tmp_version);
-   exit(1);
- }
-
-g_free(tmp_version);
-
-if ((gtk_major_version > major) ||
-    ((gtk_major_version == major) && (gtk_minor_version > minor)) ||
-    ((gtk_major_version == major) && (gtk_minor_version == minor) &&
-				     (gtk_micro_version >= micro)))
-{
-    return 0;
+	if ((ob_major > ex_major) ||
+		((ob_major == ex_major)
+			&& (ob_minor > ex_minor)) ||
+		((ob_major == ex_major)
+			&& (ob_minor == ex_minor)
+			&& (ob_micro >= ex_micro)))
+		return 0;
+	else
+		return 1;
 }
-return 1;
-}
-])],, no_gtk=yes,[echo $ac_n "cross compiling; assumed OK... $ac_c"])
-      CFLAGS="$ac_save_CFLAGS"
-      LIBS="$ac_save_LIBS"
-    }
-    fi
-    if test "x$no_gtk" = x ; then
-      if test "x$enable_gtktest" = "xyes"; then
-	AC_MSG_RESULT(yes; found version $gtk_major_version.$gtk_minor_version.$gtk_micro_version)
-      else
-	AC_MSG_RESULT(found version $gtk_major_version.$gtk_minor_version.$gtk_micro_version)
-      fi
-      ifelse([$2], , :, [$2])
-    else
-    {
-      AC_MSG_RESULT(no)
-      GTK_CFLAGS=""
-      GTK_LIBS=""
-      ifelse([$3], , :, [$3])
-      if test "$fail_if_missing" = "yes" -a "X$gui_auto" != "Xyes"; then
-	AC_MSG_ERROR([could not configure GTK])
-      fi
-    }
-    fi
+])],
+    [gtktest_success="yes"; AC_MSG_RESULT(yes)],
+    [gtktest_success="no"; AC_MSG_RESULT(no)],
+    [echo $ac_n "cross compiling; assumed OK... $ac_c"])
+    CFLAGS="$ac_save_CFLAGS"
+    LIBS="$ac_save_LIBS"
   }
-  else
-    GTK_CFLAGS=""
-    GTK_LIBS=""
-    ifelse([$3], , :, [$3])
   fi
+
+  if test "$gtktest_success" = "yes"; then
+    ifelse([$2], , :, [$2])
+  else
+    dnl Reset flags sourced from pkg-config if the compilation test failed.
+    GTK_CFLAGS=""
+    GTK_LIBDIR=""
+    GTK_LIBS=""
+    if test "$fail_if_missing" = "yes" -a "$gui_auto" != "yes"; then
+      AC_MSG_ERROR([Failed to compile GTK test program.])
+    fi
+  fi
+
   AC_SUBST(GTK_CFLAGS)
   AC_SUBST(GTK_LIBS)
-  rm -f conf.gtktest
 ])
 
 dnl ---------------------------------------------------------------------------
@@ -2832,16 +2827,43 @@ AC_DEFUN([GNOME_INIT],[
 	GNOME_INIT_HOOK([],fail)
 ])
 
-if test "X$PKG_CONFIG" = "X"; then
+if test -z "$PKG_CONFIG"; then
   AC_PATH_TOOL(PKG_CONFIG, pkg-config, no)
 fi
 
+dnl ---------------------------------------------------------------------------
+dnl Check for GTK3. If it succeeds, skip the check for GTK2.
+dnl ---------------------------------------------------------------------------
+if test -z "$SKIP_GTK3"; then
+  AC_MSG_CHECKING(--disable-gtktest argument)
+  AC_ARG_ENABLE(gtktest, [  --disable-gtktest       Do not try to compile and run a test GTK program],
+	, enable_gtktest=yes)
+  if test "x$enable_gtktest" = "xyes" ; then
+    AC_MSG_RESULT(gtk test enabled)
+  else
+    AC_MSG_RESULT(gtk test disabled)
+  fi
+
+  if test "x$PKG_CONFIG" != "xno"; then
+    AM_PATH_GTK(3.0.0,
+		[GUI_LIB_LOC="$GTK_LIBDIR"
+		 GTK_LIBNAME="$GTK_LIBS"
+		 GUI_INC_LOC="$GTK_CFLAGS"])
+    if test -n "$GTK_CFLAGS"; then
+      SKIP_GTK2=YES
+      SKIP_GNOME=YES
+      SKIP_MOTIF=YES
+      GUITYPE=GTK
+      AC_SUBST(GTK_LIBNAME)
+      AC_DEFINE(USE_GTK3)
+    fi
+  fi
+fi
 
 dnl ---------------------------------------------------------------------------
 dnl Check for GTK2.  If it fails, then continue on for Motif as before...
 dnl ---------------------------------------------------------------------------
 if test -z "$SKIP_GTK2"; then
-
   AC_MSG_CHECKING(--disable-gtktest argument)
   AC_ARG_ENABLE(gtktest, [  --disable-gtktest       Do not try to compile and run a test GTK program],
 	, enable_gtktest=yes)
@@ -2854,21 +2876,14 @@ if test -z "$SKIP_GTK2"; then
   if test "x$PKG_CONFIG" != "xno"; then
     dnl First try finding version 2.2.0 or later.  The 2.0.x series has
     dnl problems (bold fonts, --remote doesn't work).
-    dnl Disable checking for GTK3 here, otherwise it's found when GTK2 is not
-    dnl found.
-    save_skip_gtk3=$SKIP_GTK3
-    SKIP_GTK3=YES
     AM_PATH_GTK(2.2.0,
 		[GUI_LIB_LOC="$GTK_LIBDIR"
 		 GTK_LIBNAME="$GTK_LIBS"
-		GUI_INC_LOC="$GTK_CFLAGS"], )
-    if test "x$GTK_CFLAGS" != "x"; then
-      SKIP_GTK3=YES
+		 GUI_INC_LOC="$GTK_CFLAGS"])
+    if test -n "$GTK_CFLAGS"; then
       SKIP_MOTIF=YES
       GUITYPE=GTK
       AC_SUBST(GTK_LIBNAME)
-    else
-      SKIP_GTK3=$save_skip_gtk3
     fi
   fi
   if test "x$GUITYPE" = "xGTK"; then
@@ -2884,41 +2899,6 @@ if test -z "$SKIP_GTK2"; then
 	GTK_LIBNAME="$GTK_LIBNAME $GNOME_LIBDIR $GNOME_LIBS"
       fi
     }
-    fi
-  fi
-fi
-
-
-dnl ---------------------------------------------------------------------------
-dnl Check for GTK3.
-dnl ---------------------------------------------------------------------------
-if test -z "$SKIP_GTK3"; then
-
-  AC_MSG_CHECKING(--disable-gtktest argument)
-  AC_ARG_ENABLE(gtktest, [  --disable-gtktest       Do not try to compile and run a test GTK program],
-	, enable_gtktest=yes)
-  if test "x$enable_gtktest" = "xyes" ; then
-    AC_MSG_RESULT(gtk test enabled)
-  else
-    AC_MSG_RESULT(gtk test disabled)
-  fi
-
-  if test "x$PKG_CONFIG" != "xno"; then
-    save_skip_gtk2=$SKIP_GTK2
-    SKIP_GTK2=YES
-    AM_PATH_GTK(3.0.0,
-		[GUI_LIB_LOC="$GTK_LIBDIR"
-		 GTK_LIBNAME="$GTK_LIBS"
-		GUI_INC_LOC="$GTK_CFLAGS"], )
-    if test "x$GTK_CFLAGS" != "x"; then
-      SKIP_GTK2=YES
-      SKIP_GNOME=YES
-      SKIP_MOTIF=YES
-      GUITYPE=GTK
-      AC_SUBST(GTK_LIBNAME)
-      AC_DEFINE(USE_GTK3)
-    else
-      SKIP_GTK2=$save_skip_gtk2
     fi
   fi
 fi
@@ -4743,4 +4723,4 @@ dnl write output files
 AC_CONFIG_FILES(auto/config.mk:config.mk.in)
 AC_OUTPUT
 
-dnl vim: set sw=2 tw=78 fo+=l:
+dnl vim: set sw=2 sts=2 tw=78 fo+=l:


### PR DESCRIPTION
Problem: GUI auto detection favored GTK2.
Solution: Make GUI auto detection favor GTK3.

Prior to these changes if the dev pacakges for both GTK2 and GTK3 were installed, the `--enable-gui=auto` would used GTK. After these changes it will use GTK3. Users can still use `--enable-gui=gtk2` to specifically select GTK2.

In addition to the prioritization change, this also brings some cleanups to the GTK autoconf code:

* The `AM_PATH_GTK` macro had an unused third argument that has been removed.
* The `AM_PATH_GTK` macro checked the `SKIP_GTK2` & `SKIP_GTK3` variables but the code that decided whether to call it also checked those. Now just the calling code does so.
* The `AM_PATH_GTK` macro set a default minimum version based on `SKIP_GTK2` and `SKIP_GTK3` but the calling code was also expected to pass a version. Now the calling code _must_ pass a version.
* The GTK test program previous used `gtk_(major|minor|micro)_version` as all of: a C variable name, a C macro provided only by GTK2, and an autoconf variable name. It also needlessly parsed a `x.y.z` version string when the same string was already parsed by autoconf + sed. Now the parsed values are used directly in the test program.
* The GTK test program previous created a test program `conf.gtktest` which was cleaned up by the autoconf script. This appeared to be a crude way to debug whether an erroring configure run had actually run the test program. Instead the autoconf script now outputs more messaging and the user can check `config.log` to determine the status of the configure script.

I'm not an autoconf expert and I don't have access to some of the older systems we try to support with gvim. So I would very much appreciate if anyone could run this on their systems to ensure it doesn't misbehave.

While my motivation here is mainly to further establish GTK3 as the primary GUI mode, this should at least partially address the concern described in #15437.


Here are a few test runs with both GTK 2 and GTK 3 installed:

```
    --with-features=huge \
    --enable-gui \
    --enable-gtk3-check=no \
    --enable-gtktest \
```

```
checking --enable-gui argument... yes/auto - automatic GUI support
checking whether or not to look for GTK+ 2... yes
checking whether or not to look for GNOME... no
checking whether or not to look for GTK+ 3... no
checking whether or not to look for Motif... yes
checking for pkg-config... /usr/bin/pkg-config
checking --disable-gtktest argument... gtk test enabled
checking for pkg-config gtk+-2.0... found
checking for GTK - version >= 2.2.0... yes; found version 2.24.33
checking ability to compile GTK test program... yes
```

```
    --with-features=huge \
    --enable-gui \
    --enable-gtk2-check=no \
    --enable-gtktest \
```

```
checking --enable-gui argument... yes/auto - automatic GUI support
checking whether or not to look for GTK+ 2... no
checking whether or not to look for GTK+ 3... yes
checking whether or not to look for Motif... yes
checking for pkg-config... /usr/bin/pkg-config
checking --disable-gtktest argument... gtk test enabled
checking for pkg-config gtk+-3.0... found
checking for GTK - version >= 3.0.0... yes; found version 3.24.49
checking ability to compile GTK test program... yes
```


```
    --with-features=huge \
```

```
checking --enable-gui argument... yes/auto - automatic GUI support
checking whether or not to look for GTK+ 2... yes
checking whether or not to look for GNOME... no
checking whether or not to look for GTK+ 3... yes
checking whether or not to look for Motif... yes
checking for pkg-config... /usr/bin/pkg-config
checking --disable-gtktest argument... gtk test enabled
checking for pkg-config gtk+-3.0... found
checking for GTK - version >= 3.0.0... yes; found version 3.24.49
checking ability to compile GTK test program... yes
```


```
    --with-features=huge \
    --disable-gtktest \
```

```
checking --enable-gui argument... yes/auto - automatic GUI support
checking whether or not to look for GTK+ 2... yes
checking whether or not to look for GNOME... no
checking whether or not to look for GTK+ 3... yes
checking whether or not to look for Motif... yes
checking for pkg-config... /usr/bin/pkg-config
checking --disable-gtktest argument... gtk test disabled
checking for pkg-config gtk+-3.0... found
checking for GTK - version >= 3.0.0... yes; found version 3.24.49
```

```
    --with-features=huge \
    --enable-gui=gtk2 \
```

```
checking --enable-gui argument... GTK+ 2.x GUI support
checking for pkg-config... /usr/bin/pkg-config
checking --disable-gtktest argument... gtk test enabled
checking for pkg-config gtk+-2.0... found
checking for GTK - version >= 2.2.0... yes; found version 2.24.33
checking ability to compile GTK test program... yes
```

```
    --with-features=huge \
    --enable-gui=gtk3 \
```

```
checking --enable-gui argument... GTK+ 3.x GUI support
checking for pkg-config... /usr/bin/pkg-config
checking --disable-gtktest argument... gtk test enabled
checking for pkg-config gtk+-3.0... found
checking for GTK - version >= 3.0.0... yes; found version 3.24.49
checking ability to compile GTK test program... yes
```

And here is a similar run with the GTK 3 dev package removed:

```
    --with-features=huge \
    --enable-gui=gtk3 \
    --enable-fail-if-missing \
```

```
checking --disable-gtktest argument... gtk test enabled
checking for pkg-config gtk+-3.0... no; consider installing your distro GTK -dev package
configure: error: pkg-config could not find gtk+-3.0
```
