### PR TITLE
crash when calling non-existing function for tabpanel

### DIFF
--- a/src/tabpanel.c
+++ b/src/tabpanel.c
@@ -496,6 +496,7 @@ starts_with_percent_and_bang(tabpanel_T *pargs)
 {
     int		len = 0;
     char_u	*usefmt = p_tpl;
+    int		did_emsg_before = did_emsg;
 
     if (usefmt == NULL)
 	return NULL;
@@ -525,6 +526,13 @@ starts_with_percent_and_bang(tabpanel_T *pargs)
 	    usefmt = p;
 
 	do_unlet((char_u *)"g:tabpanel_winid", TRUE);
+
+	if (did_emsg > did_emsg_before)
+	{
+	    usefmt = NULL;
+	    set_string_option_direct((char_u *)"tabpanel", -1, (char_u *)"",
+		    OPT_FREE | OPT_GLOBAL, SID_ERROR);
+	}
     }
 #endif
 

--- a/src/testdir/test_tabpanel.vim
+++ b/src/testdir/test_tabpanel.vim
@@ -521,4 +521,16 @@ function Test_tabpanel_equalalways()
   call StopVimInTerminal(buf)
 endfunc
 
+function Test_tabpanel_error()
+  set tabpanel=%!NonExistingFunc()
+  try
+    set showtabpanel=2
+    redraw!
+  catch /^Vim\%((\a\+)\)\=:E117:/
+  endtry
+  call assert_true(empty(&tabpanel))
+  set tabpanel&vim
+  set showtabpanel&vim
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  crash when calling non-existing function for tabpanel Solution: check if there was an error and if there was, set tabpanel
          option to empty to prevent showing errors on every redraw

fixes: #17364