### PR TITLE
Can't use getpos('v') in OptionSet when using setbufvar()

### DIFF
--- a/src/autocmd.c
+++ b/src/autocmd.c
@@ -1585,9 +1585,10 @@ aucmd_prepbuf(
 #ifdef FEAT_AUTOCHDIR
     int		save_acd;
 #endif
+    int		same_buffer = buf == curbuf;
 
     // Find a window that is for the new buffer
-    if (buf == curbuf)		// be quick when buf is curbuf
+    if (same_buffer)		// be quick when buf is curbuf
 	win = curwin;
     else
 	FOR_ALL_WINDOWS(win)
@@ -1677,9 +1678,10 @@ aucmd_prepbuf(
     aco->new_curwin_id = curwin->w_id;
     set_bufref(&aco->new_curbuf, curbuf);
 
-    // disable the Visual area, the position may be invalid in another buffer
     aco->save_VIsual_active = VIsual_active;
-    VIsual_active = FALSE;
+    if (!same_buffer)
+	// disable the Visual area, position may be invalid in another buffer
+	VIsual_active = FALSE;
 }
 
 /*

--- a/src/testdir/test_autocmd.vim
+++ b/src/testdir/test_autocmd.vim
@@ -3761,6 +3761,27 @@ func Test_Visual_doautoall_redraw()
   %bwipe!
 endfunc
 
+func Test_get_Visual_selection_in_curbuf_autocmd()
+  call test_override('starting', 1)
+  new
+  autocmd OptionSet list let b:text = getregion(getpos('.'), getpos('v'))
+  call setline(1, 'foo bar baz')
+
+  normal! gg0fbvtb
+  setlocal list
+  call assert_equal(['bar '], b:text)
+  exe "normal! \<Esc>"
+
+  normal! v0
+  call setbufvar('%', '&list', v:false)
+  call assert_equal(['foo bar '], b:text)
+  exe "normal! \<Esc>"
+
+  autocmd! OptionSet list
+  bwipe!
+  call test_override('starting', 0)
+endfunc
+
 " This was using freed memory.
 func Test_BufNew_arglocal()
   arglocal


### PR DESCRIPTION
Problem:  Can't use getpos('v') in OptionSet when using setbufvar().
Solution: Don't reset Visual selection when switching to the same
          buffer.
