### PR TITLE
Fix crash reported in issue #17363

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -4905,7 +4905,7 @@ strip_caret_numbers_in_place(char_u *str)
  * Safely advance the cpt_sources_index by one.
  */
     static void
-advance_cpt_sources_index_safe()
+advance_cpt_sources_index_safe(void)
 {
     cpt_sources_index++;
     if (cpt_sources_index >= cpt_sources_count)

--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -4910,7 +4910,9 @@ advance_cpt_sources_index_safe(void)
     cpt_sources_index++;
     if (cpt_sources_index >= cpt_sources_count)
     {
+#ifdef FEAT_EVAL
 	semsg(_(e_list_index_out_of_range_nr), cpt_sources_index);
+#endif
 	getout(4);
     }
 }

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -4530,7 +4530,7 @@ endfunc
 func Test_complete_safe()
   set complete=b,u,t,i,f^9
   set completefunc=ComplFunc
-  func Completefunc(findstart, base)
+  func Complfunc(findstart, base)
     if findstart == 1
       return 1
     else

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -4526,4 +4526,29 @@ func Test_complete_match()
   delfunc TestComplete
 endfunc
 
+" Issue #17363
+func Test_complete_safe()
+  set complete=b,u,t,i,f^9
+  set completefunc=ComplFunc
+  func Completefunc(findstart, base)
+    if findstart == 1
+      return 1
+    else
+      return {words: ['word'], refresh: 'always'}
+    endif
+  endfunc
+
+  enew
+  file foo1
+  enew
+  file foo2
+  " Following caused Vim to crash in linux
+  exe "normal! Gof\<c-n>\<esc>R"
+  bw!
+  bw!
+  set completefunc&
+  set complete&
+  delfunc ComplFunc
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab nofoldenable

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -4126,6 +4126,11 @@ func Test_complete_match_count()
   exe "normal! Gof\<c-n>\<c-r>=PrintMenuWords()\<cr>"
   call assert_equal('fo{''matches'': [''fo'', ''foo1'', ''foo2''], ''selected'': 0}', getline(5))
   5d
+  set cpt=.^1,,,f^2,,,
+  call setline(1, ["fo", "foo", "foobar", "fobarbaz"])
+  exe "normal! Gof\<c-n>\<c-r>=PrintMenuWords()\<cr>"
+  call assert_equal('fo{''matches'': [''fo'', ''foo1'', ''foo2''], ''selected'': 0}', getline(5))
+  5d
   exe "normal! Gof\<c-n>\<c-n>\<c-r>=PrintMenuWords()\<cr>"
   call assert_equal('foo1{''matches'': [''fo'', ''foo1'', ''foo2''], ''selected'': 1}', getline(5))
   5d


### PR DESCRIPTION
Fixes an out-of-bounds write that could cause a crash.
Ensured safe array access to prevent undefined behavior.

https://github.com/vim/vim/issues/17363

Co-author: https://github.com/csetc