### PR TITLE
Rename f flag to F in 'complete'

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2085,7 +2085,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 		|i_CTRL-X_CTRL-D|
 	]	tag completion
 	t	same as "]"
-	f{func}	call the function {func}.  Multiple "f" flags may be specified.
+	F{func}	call the function {func}.  Multiple "F" flags may be specified.
 		Refer to |complete-functions| for details on how the function
 		is invoked and what it should return.  The value can be the
 		name of a function or a |Funcref|.  For |Funcref| values,
@@ -2103,9 +2103,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 		If generating matches is potentially slow, |complete_check()|
 		should be used to avoid blocking and preserve editor
 		responsiveness.
-	f	equivalent to using "f{func}", where the function is taken from
+	F	equivalent to using "F{func}", where the function is taken from
 		the 'completefunc' option.
-	o	equivalent to using "f{func}", where the function is taken from
+	o	equivalent to using "F{func}", where the function is taken from
 		the 'omnifunc' option.
 
 	Unloaded buffers are not loaded, thus their autocmds |:autocmd| are
@@ -5487,7 +5487,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	The cursor is displayed at the start of the space a Tab character
 	occupies, not at the end as usual in Normal mode.  To get this cursor
 	position while displaying Tabs with spaces, use: >
-		:set list lcs=tab:\ \ 
+		:set list lcs=tab:\ \
 <
 	Note that list mode will also affect formatting (set with 'textwidth'
 	or 'wrapmargin') when 'cpoptions' includes 'L'.  See 'listchars' for
@@ -7584,7 +7584,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 			feature}
 	String to put at the start of lines that have been wrapped.  Useful
 	values are "> " or "+++ ": >
-		:set showbreak=>\ 
+		:set showbreak=>\
 <	Note the backslash to escape the trailing space.  It's easier like
 	this: >
 		:let &showbreak = '+++ '

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5487,7 +5487,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	The cursor is displayed at the start of the space a Tab character
 	occupies, not at the end as usual in Normal mode.  To get this cursor
 	position while displaying Tabs with spaces, use: >
-		:set list lcs=tab:\ \
+		:set list lcs=tab:\ \ 
 <
 	Note that list mode will also affect formatting (set with 'textwidth'
 	or 'wrapmargin') when 'cpoptions' includes 'L'.  See 'listchars' for
@@ -7584,7 +7584,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 			feature}
 	String to put at the start of lines that have been wrapped.  Useful
 	values are "> " or "+++ ": >
-		:set showbreak=>\
+		:set showbreak=>\ 
 <	Note the backslash to escape the trailing space.  It's easier like
 	this: >
 		:let &showbreak = '+++ '

--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -4081,7 +4081,7 @@ process_next_cpt_value(
 	    }
 	}
 #ifdef FEAT_COMPL_FUNC
-	else if (*st->e_cpt == 'f' || *st->e_cpt == 'o')
+	else if (*st->e_cpt == 'F' || *st->e_cpt == 'o')
 	{
 	    compl_type = CTRL_X_FUNCTION;
 	    if (*st->e_cpt == 'o')
@@ -6821,7 +6821,7 @@ cpt_compl_refresh(void)
 	{
 	    if (*p == 'o')
 		cb = &curbuf->b_ofu_cb;
-	    else if (*p == 'f')
+	    else if (*p == 'F')
 		cb = (*(p + 1) != ',' && *(p + 1) != NUL)
 		    ? get_cpt_func_callback(p + 1) : &curbuf->b_cfu_cb;
 	    if (cb)

--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -1594,10 +1594,10 @@ did_set_complete(optset_T *args)
 	}
 	*buf_ptr = NUL;
 
-	if (vim_strchr((char_u *)".wbuksid]tUfo", *buffer) == NULL)
+	if (vim_strchr((char_u *)".wbuksid]tUFo", *buffer) == NULL)
 	    return illegal_char(args->os_errbuf, args->os_errbuflen, *buffer);
 
-	if (vim_strchr((char_u *)"ksf", *buffer) == NULL && *(buffer + 1) != NUL
+	if (vim_strchr((char_u *)"ksF", *buffer) == NULL && *(buffer + 1) != NUL
 		&& *(buffer + 1) != '^')
 	    char_before = *buffer;
 	else
@@ -1642,7 +1642,7 @@ did_set_complete(optset_T *args)
 expand_set_complete(optexpand_T *args, int *numMatches, char_u ***matches)
 {
     static char *(p_cpt_values[]) = {
-	".", "w", "b", "u", "k", "kspell", "s", "i", "d", "]", "t", "U", "f", "o",
+	".", "w", "b", "u", "k", "kspell", "s", "i", "d", "]", "t", "U", "F", "o",
 	NULL};
     return expand_set_opt_string(
 	    args,

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -225,7 +225,7 @@ func Test_completefunc_args()
   call assert_equal(0, s:args[1][0])
   set omnifunc=
 
-  set complete=fCompleteFunc
+  set complete=FCompleteFunc
   call feedkeys("i\<C-N>\<Esc>", 'x')
   call assert_equal([1, 1], s:args[0])
   call assert_equal(0, s:args[1][0])
@@ -299,7 +299,7 @@ func Test_CompleteDoneNone()
   call assert_equal(oldline, newline)
   let s:called_completedone = 0
 
-  set complete=f<SID>CompleteDone_CompleteFuncNone
+  set complete=F<SID>CompleteDone_CompleteFuncNone
   execute "normal a\<C-N>\<C-Y>"
   set complete&
   let newline = join(map(range(&columns), 'nr2char(screenchar(&lines-1, v:val+1))'), '')
@@ -326,7 +326,7 @@ func Test_CompleteDone_vevent_keys()
   endfunc
   set omnifunc=CompleteFunc
   set completefunc=CompleteFunc
-  set complete=.,fCompleteFunc
+  set complete=.,FCompleteFunc
   set completeopt+=menuone
 
   new
@@ -418,7 +418,7 @@ func Test_CompleteDoneDict()
   au CompleteDonePre * :call <SID>CompleteDone_CheckCompletedItemDict(2)
   au CompleteDone * :call <SID>CompleteDone_CheckCompletedItemDict(0)
 
-  set complete=.,f<SID>CompleteDone_CompleteFuncDict
+  set complete=.,F<SID>CompleteDone_CompleteFuncDict
   execute "normal a\<C-N>\<C-Y>"
   set complete&
 
@@ -471,7 +471,7 @@ func Test_CompleteDoneDictNoUserData()
 
   let s:called_completedone = 0
 
-  set complete=.,f<SID>CompleteDone_CompleteFuncDictNoUserData
+  set complete=.,F<SID>CompleteDone_CompleteFuncDictNoUserData
   execute "normal a\<C-N>\<C-Y>"
   set complete&
 
@@ -513,7 +513,7 @@ func Test_CompleteDoneList()
 
   let s:called_completedone = 0
 
-  set complete=.,f<SID>CompleteDone_CompleteFuncList
+  set complete=.,F<SID>CompleteDone_CompleteFuncList
   execute "normal a\<C-N>\<C-Y>"
   set complete&
 
@@ -522,7 +522,7 @@ func Test_CompleteDoneList()
 
   let s:called_completedone = 0
 
-  set complete=.,f
+  set complete=.,F
   execute "normal a\<C-N>\<C-Y>"
   set complete&
 
@@ -573,11 +573,11 @@ func Test_completefunc_info()
   call feedkeys("i\<C-X>\<C-U>\<C-R>\<C-R>=string(complete_info())\<CR>\<ESC>", "tx")
   call assert_equal("matched{'pum_visible': 1, 'mode': 'function', 'selected': 0, 'items': [{'word': 'matched', 'menu': '', 'user_data': '', 'info': '', 'kind': '', 'abbr': ''}]}", getline(1))
   %d
-  set complete=.,fCompleteTest
+  set complete=.,FCompleteTest
   call feedkeys("i\<C-N>\<C-R>\<C-R>=string(complete_info())\<CR>\<ESC>", "tx")
   call assert_equal("matched{'pum_visible': 1, 'mode': 'keyword', 'selected': 0, 'items': [{'word': 'matched', 'menu': '', 'user_data': '', 'info': '', 'kind': '', 'abbr': ''}]}", getline(1))
   %d
-  set complete=.,f
+  set complete=.,F
   call feedkeys("i\<C-N>\<C-R>\<C-R>=string(complete_info())\<CR>\<ESC>", "tx")
   call assert_equal("matched{'pum_visible': 1, 'mode': 'keyword', 'selected': 0, 'items': [{'word': 'matched', 'menu': '', 'user_data': '', 'info': '', 'kind': '', 'abbr': ''}]}", getline(1))
   set completeopt&
@@ -597,7 +597,7 @@ func Test_cpt_func_cursorcol()
     return v:none
   endfunc
 
-  set complete=fCptColTest
+  set complete=FCptColTest
   new
   call feedkeys("ifoo bar\<C-N>", "tx")
   bwipe!
@@ -689,12 +689,12 @@ func CompleteInfoTestUserDefinedFn(mvmt, idx, noselect)
   let completed = a:idx != -1 ? ['foo', 'bar', 'baz', 'qux']->get(a:idx) : ''
   call assert_equal(completed. "{'pum_visible': 1, 'mode': 'function', 'selected': " . a:idx . ", 'items': " . items . "}", getline(1))
   %d
-  set complete=.,fCompleteInfoUserDefinedFn
+  set complete=.,FCompleteInfoUserDefinedFn
   call feedkeys("i\<C-N>" . a:mvmt . "\<C-R>\<C-R>=string(complete_info())\<CR>\<ESC>", "tx")
   let completed = a:idx != -1 ? ['foo', 'bar', 'baz', 'qux']->get(a:idx) : ''
   call assert_equal(completed. "{'pum_visible': 1, 'mode': 'keyword', 'selected': " . a:idx . ", 'items': " . items . "}", getline(1))
   %d
-  set complete=.,f
+  set complete=.,F
   call feedkeys("i\<C-N>" . a:mvmt . "\<C-R>\<C-R>=string(complete_info())\<CR>\<ESC>", "tx")
   let completed = a:idx != -1 ? ['foo', 'bar', 'baz', 'qux']->get(a:idx) : ''
   call assert_equal(completed. "{'pum_visible': 1, 'mode': 'keyword', 'selected': " . a:idx . ", 'items': " . items . "}", getline(1))
@@ -969,9 +969,9 @@ func Test_completefunc_error()
   set completefunc=CompleteFunc
   call setline(1, ['', 'abcd', ''])
   call assert_fails('exe "normal 2G$a\<C-X>\<C-U>"', 'E565:')
-  set complete=fCompleteFunc
+  set complete=FCompleteFunc
   call assert_fails('exe "normal 2G$a\<C-N>"', 'E565:')
-  set complete=f
+  set complete=F
   call assert_fails('exe "normal 2G$a\<C-N>"', 'E565:')
 
   " delete text when called for the second time
@@ -985,9 +985,9 @@ func Test_completefunc_error()
   set completefunc=CompleteFunc2
   call setline(1, ['', 'abcd', ''])
   call assert_fails('exe "normal 2G$a\<C-X>\<C-U>"', 'E565:')
-  set complete=fCompleteFunc2
+  set complete=FCompleteFunc2
   call assert_fails('exe "normal 2G$a\<C-N>"', 'E565:')
-  set complete=f
+  set complete=F
   call assert_fails('exe "normal 2G$a\<C-N>"', 'E565:')
 
   " Jump to a different window from the complete function
@@ -1002,10 +1002,10 @@ func Test_completefunc_error()
   new
   call assert_fails('exe "normal a\<C-X>\<C-U>"', 'E565:')
   %d
-  set complete=fCompleteFunc3
+  set complete=FCompleteFunc3
   call assert_fails('exe "normal a\<C-N>"', 'E565:')
   %d
-  set complete=f
+  set complete=F
   call assert_fails('exe "normal a\<C-N>"', 'E565:')
   close!
 
@@ -1029,11 +1029,11 @@ func Test_completefunc_invalid_data()
   exe "normal i\<C-X>\<C-U>"
   call assert_equal('moon', getline(1))
   %d
-  set complete=fCompleteFunc
+  set complete=FCompleteFunc
   exe "normal i\<C-N>"
   call assert_equal('moon', getline(1))
   %d
-  set complete=f
+  set complete=F
   exe "normal i\<C-N>"
   call assert_equal('moon', getline(1))
   set completefunc& complete&
@@ -1717,13 +1717,13 @@ func Test_complete_item_refresh_always()
   call assert_equal(6, g:CallCount)
   %d
   let g:CallCount = 0
-  set complete=fTcomplete
+  set complete=FTcomplete
   exe "normal! iup\<C-N>\<BS>\<BS>\<BS>\<BS>\<BS>"
   call assert_equal('up', getline(1))
   call assert_equal(6, g:CallCount)
   %d
   let g:CallCount = 0
-  set complete=f
+  set complete=F
   exe "normal! iup\<C-N>\<BS>\<BS>\<BS>\<BS>\<BS>"
   call assert_equal('up', getline(1))
   call assert_equal(6, g:CallCount)
@@ -1750,10 +1750,10 @@ func Test_cpt_func_refresh_always_fail()
     call assert_equal(-999, a:findstart) " Should not reach here
   endfunc
   new
-  set complete=ffunction('CompleteFail'\\,\ [-2])
+  set complete=Ffunction('CompleteFail'\\,\ [-2])
   exe "normal! ia\<C-N>"
   %d
-  set complete=ffunction('CompleteFail'\\,\ [-3])
+  set complete=Ffunction('CompleteFail'\\,\ [-3])
   exe "normal! ia\<C-N>"
   bw!
 
@@ -1771,7 +1771,7 @@ func Test_cpt_func_refresh_always_fail()
   endfunc
   new
   set completeopt=menuone,noselect
-  set complete=ffunction('CompleteFailIntermittent'\\,\ [-2])
+  set complete=Ffunction('CompleteFailIntermittent'\\,\ [-2])
   let g:CallCount = 0
   exe "normal! if\<C-N>\<c-r>=complete_info([\"items\"])\<cr>"
   call assert_match('''word'': ''foo''.*''word'': ''fbar''', getline(1))
@@ -1782,13 +1782,13 @@ func Test_cpt_func_refresh_always_fail()
   call assert_match('''selected'': -1.*''word'': ''foo1''.*''word'': ''foo2''', getline(1))
   call assert_equal(2, g:CallCount)
   %d
-  set complete=ffunction('CompleteFailIntermittent'\\,\ [-3])
+  set complete=Ffunction('CompleteFailIntermittent'\\,\ [-3])
   let g:CallCount = 0
   exe "normal! if\<C-N>o\<c-r>=complete_info([\"items\", \"selected\"])\<cr>"
   call assert_match('''selected'': -1.*''word'': ''foo1''.*''word'': ''foo2''', getline(1))
   call assert_equal(2, g:CallCount)
   %d
-  set complete=ffunction('CompleteFailIntermittent'\\,\ [-2])
+  set complete=Ffunction('CompleteFailIntermittent'\\,\ [-2])
   " completion mode is dismissed when there are no matches in list
   let g:CallCount = 0
   exe "normal! if\<C-N>oo\<c-r>=complete_info([\"items\"])\<cr>"
@@ -1801,7 +1801,7 @@ func Test_cpt_func_refresh_always_fail()
   call assert_equal(3, g:CallCount)
   %d
   " completion mode continues when matches from other sources present
-  set complete=.,ffunction('CompleteFailIntermittent'\\,\ [-2])
+  set complete=.,Ffunction('CompleteFailIntermittent'\\,\ [-2])
   call setline(1, 'fooo1')
   let g:CallCount = 0
   exe "normal! Gof\<C-N>oo\<c-r>=complete_info([\"items\", \"selected\"])\<cr>"
@@ -1817,7 +1817,7 @@ func Test_cpt_func_refresh_always_fail()
   call assert_equal(4, g:CallCount)
   %d
   " refresh will stop when -3 is returned
-  set complete=.,,\ ffunction('CompleteFailIntermittent'\\,\ [-3])
+  set complete=.,,\ Ffunction('CompleteFailIntermittent'\\,\ [-3])
   call setline(1, 'fooo1')
   let g:CallCount = 0
   exe "normal! Gof\<C-N>o\<bs>\<c-r>=complete_info([\"items\", \"selected\"])\<cr>"
@@ -1862,7 +1862,7 @@ func Test_cpt_select_item_refresh_always()
   endfunc
 
   new
-  set complete=.,ffunction('CompleteItemsSelect'\\,\ [[]])
+  set complete=.,Ffunction('CompleteItemsSelect'\\,\ [[]])
   call setline(1, "foobarbar")
   let g:CallCount = 0
   exe "normal! Gof\<c-n>\<c-n>\<c-r>=CompleteMenuWords()\<cr>"
@@ -1894,7 +1894,7 @@ func Test_cpt_select_item_refresh_always()
   call assert_equal(2, g:CallCount)
 
   %d
-  set complete=.,ffunction('CompleteItemsSelect'\\,\ [['foonext']])
+  set complete=.,Ffunction('CompleteItemsSelect'\\,\ [['foonext']])
   call setline(1, "foobarbar")
   let g:CallCount = 0
   exe "normal! Gof\<c-n>\<c-n>\<bs>\<c-r>=CompleteMenuWords()\<cr>"
@@ -1934,7 +1934,7 @@ func Test_cpt_select_item_refresh_always()
   call assert_equal(3, g:CallCount)
 
   %d
-  set complete=.,ffunction('CompleteItemsSelect'\\,\ [['fo'\\,\ 'foonext']])
+  set complete=.,Ffunction('CompleteItemsSelect'\\,\ [['fo'\\,\ 'foonext']])
   call setline(1, "foobarbar")
   let g:CallCount = 0
   exe "normal! Gof\<c-n>\<c-n>\<bs>\<c-r>=CompleteMenuWords()\<cr>"
@@ -1986,7 +1986,7 @@ func Test_cpt_multi_func_refresh_always()
   call assert_equal("f\x0e" . '{''matches'': [], ''selected'': -1}', getline(1))
 
   set completeopt=menuone,noselect
-  set complete=fCompleteItems1,fCompleteItems2
+  set complete=FCompleteItems1,FCompleteItems2
 
   new
   let g:CallCount1 = 0
@@ -2118,7 +2118,7 @@ func Test_cpt_func_callback()
 
   let lines =<< trim END
     #" Test for using a global function name
-    set complete=fg:CompleteFunc2
+    set complete=Fg:CompleteFunc2
     new
     call setline(1, 'global')
     LET g:CompleteFunc2Args = []
@@ -2128,7 +2128,7 @@ func Test_cpt_func_callback()
     bw!
 
     #" Test for using a function()
-    set complete=ffunction('g:CompleteFunc1'\\,\ [10])
+    set complete=Ffunction('g:CompleteFunc1'\\,\ [10])
     new
     call setline(1, 'one')
     LET g:CompleteFunc1Args = []
@@ -2138,7 +2138,7 @@ func Test_cpt_func_callback()
     bw!
 
     #" Using a funcref variable
-    set complete=ffuncref('g:CompleteFunc1'\\,\ [11])
+    set complete=Ffuncref('g:CompleteFunc1'\\,\ [11])
     new
     call setline(1, 'two')
     LET g:CompleteFunc1Args = []
@@ -2155,7 +2155,7 @@ func Test_cpt_func_callback()
     call add(g:CompleteFunc3Args, [a:findstart, a:base])
     return a:findstart ? 0 : []
   endfunc
-  set complete=fs:CompleteFunc3
+  set complete=Fs:CompleteFunc3
   new
   call setline(1, 'script1')
   let g:CompleteFunc3Args = []
@@ -2164,7 +2164,7 @@ func Test_cpt_func_callback()
   set complete&
   bw!
 
-  let &complete = 'fs:CompleteFunc3'
+  let &complete = 'Fs:CompleteFunc3'
   new
   call setline(1, 'script2')
   let g:CompleteFunc3Args = []
@@ -2182,7 +2182,7 @@ func Test_cpt_func_callback()
         add(CompleteFunc4Args, [findstart, base])
         return findstart ? 0 : []
       enddef
-      set complete=fCompleteFunc4
+      set complete=FCompleteFunc4
       new
       setline(1, 'script1')
       feedkeys("A\<C-N>\<Esc>", 'x')
@@ -2202,7 +2202,7 @@ func Test_cpt_func_callback()
     enddef
 
     # Test for using a def function with completefunc
-    set complete=ffunction('Vim9CompleteFunc'\\,\ [60])
+    set complete=Ffunction('Vim9CompleteFunc'\\,\ [60])
     new | only
     setline(1, 'one')
     g:Vim9completeFuncArgs = []
@@ -2211,7 +2211,7 @@ func Test_cpt_func_callback()
     bw!
 
     # Test for using a global function name
-    &complete = 'fg:CompleteFunc2'
+    &complete = 'Fg:CompleteFunc2'
     new | only
     setline(1, 'two')
     g:CompleteFunc2Args = []
@@ -2224,7 +2224,7 @@ func Test_cpt_func_callback()
       add(g:LocalCompleteFuncArgs, [findstart, base])
       return findstart ? 0 : []
     enddef
-    &complete = 'fLocalCompleteFunc'
+    &complete = 'FLocalCompleteFunc'
     new | only
     setline(1, 'three')
     g:LocalCompleteFuncArgs = []
@@ -3122,12 +3122,12 @@ func Test_complete_smartindent()
   let result = getline(1,'$')
   call assert_equal(['', '{','}',''], result)
   %d
-  setlocal complete=fFooBarComplete
+  setlocal complete=FFooBarComplete
   exe "norm! o{\<cr>\<c-n>\<c-p>}\<cr>\<esc>"
   let result = getline(1,'$')
   call assert_equal(['', '{','}',''], result)
   %d
-  setlocal complete=f
+  setlocal complete=F
   exe "norm! o{\<cr>\<c-n>\<c-p>}\<cr>\<esc>"
   let result = getline(1,'$')
   call assert_equal(['', '{','}',''], result)
@@ -4121,7 +4121,7 @@ func Test_complete_match_count()
 
   %d
   set completefunc=ComplFunc
-  set cpt=.^1,f^2
+  set cpt=.^1,F^2
   call setline(1, ["fo", "foo", "foobar", "fobarbaz"])
   exe "normal! Gof\<c-n>\<c-r>=PrintMenuWords()\<cr>"
   call assert_equal('fo{''matches'': [''fo'', ''foo1'', ''foo2''], ''selected'': 0}', getline(5))
@@ -4156,7 +4156,7 @@ func Test_complete_match_count()
 
   %d
   call setline(1, ["foo"])
-  set cpt=fComplFunc^2,.
+  set cpt=FComplFunc^2,.
   exe "normal! Gof\<c-n>\<c-r>=PrintMenuWords()\<cr>"
   call assert_equal('foo1{''matches'': [''foo1'', ''foo2'', ''foo''], ''selected'': 0}', getline(2))
   bw!
@@ -4173,7 +4173,7 @@ func Test_complete_match_count()
   endfunc
 
   new
-  set complete=.,ffunction('CompleteItemsSelect')^2
+  set complete=.,Ffunction('CompleteItemsSelect')^2
   call setline(1, "foobarbar")
   let g:CallCount = 0
   exe "normal! Gof\<c-n>\<c-n>\<c-r>=PrintMenuWords()\<cr>"

--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -274,7 +274,7 @@ func Test_complete()
   call assert_fails('set complete=ix', 'E535:')
   call assert_fails('set complete=x', 'E539:')
   call assert_fails('set complete=..', 'E535:')
-  set complete=.,w,b,u,k,\ s,i,d,],t,U,f,o
+  set complete=.,w,b,u,k,\ s,i,d,],t,U,F,o
   call assert_fails('set complete=i^-10', 'E535:')
   call assert_fails('set complete=i^x', 'E535:')
   call assert_fails('set complete=k^2,t^-1,s^', 'E535:')
@@ -282,13 +282,13 @@ func Test_complete()
   call assert_fails('set complete=kfoo^foo2', 'E535:')
   call assert_fails('set complete=kfoo^', 'E535:')
   call assert_fails('set complete=.^', 'E535:')
-  set complete=.,w,b,u,k,s,i,d,],t,U,f,o
+  set complete=.,w,b,u,k,s,i,d,],t,U,F,o
   set complete=.
   set complete=.^10,t^0
-  set complete+=ffuncref('foo'\\,\ [10])
-  set complete=ffuncref('foo'\\,\ [10])^10
+  set complete+=Ffuncref('foo'\\,\ [10])
+  set complete=Ffuncref('foo'\\,\ [10])^10
   set complete&
-  set complete+=ffunction('g:foo'\\,\ [10\\,\ 20])
+  set complete+=Ffunction('g:foo'\\,\ [10\\,\ 20])
   set complete&
 endfun
 


### PR DESCRIPTION
The "f" flag has been renamed to "F" to maintain compatibility with Neovim.