### PR TITLE
Doc tabstop clarify

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -590,46 +590,6 @@ the system, mostly it is something like 256 or 1024 characters.
 <			You need to restart for this to take effect.
 
 
-						*using-tabs* *tabs-usage*
-There are five main ways to use tabs in Vim:
-
-1. Keep 'tabstop' at 8, set 'softtabstop' and 'shiftwidth' to whatever
-   you prefer and use 'noexpandtab'.  Then Vim will display
-   Horizontal Tabulation characters (ASCII 9, caret notation: ^I)
-   using the traditional 8 columns spacing between tab stops.
-   But when typing <Tab> and <BS>, it will use a mix of spaces and ^I
-   so that the two keys behave as if they were following 'softtabstop'.
-   This is the recommended way, the file will look the same in other
-   tools and when listing it in a terminal.
-
-2. Set 'softtabstop' and 'shiftwidth' to whatever you prefer and use
-   'expandtab'.  This way you will always insert spaces.
-   The formatting will never be messed up when 'tabstop' is changed (leave
-   it at 8 just in case).  The file will be a bit larger.
-   You can get rid of any ^I already present in the file
-   by first setting 'expandtab' and using |:retab!|, making sure
-   the value of 'tabstop' is set correctly.
-
-3. Set 'tabstop' and 'shiftwidth' to whatever you prefer and use 'expandtab'.
-   This way you will always insert spaces, never ^I.
-   The formatting will never be messed up when 'tabstop' is changed,
-   unless ^I were already present in the file.
-
-4. Set 'tabstop' and 'shiftwidth' to whatever you prefer using a
-   |modeline| to set these values when editing the file again.
-
-5. Set 'tabstop' and 'shiftwidth' to the same value, and 'noexpandtab'.
-   This should then work (for initial indents only) for any tabstop setting
-   that people use.  It might be nice to have tabs after the first non-blank
-   inserted as spaces if you do this though.
-   Otherwise aligned comments will be wrong when 'tabstop' is changed.
-
-NOTE: for options 3. 4. and 5. keep in mind that traditionally other tools
-such as `cat` or `git` have their (virtual) horizontal tab stops
-separated by 8 columns, and will display the tab characters ^I
-present in a file accordingly.
-
-
 ==============================================================================
 2. Automatically setting options			*auto-setting*
 
@@ -8532,34 +8492,13 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'tabstop'* *'ts'*
 'tabstop' 'ts'		number	(default 8)
 			local to buffer
-	Number of columns between two (virtual) horizontal tab stops.
+	Defines the column multiple used to display the Horizontal Tab
+	character (ASCII 9); a Horizontal Tab always advances to the next
+	tab stop.
 	The value must be at least 1 and at most 9999.
-
-	In insert mode, this is one of the settings that influence
-	what characters Vim writes in a file when <Tab> is used
-	and what characters get deleted when <BS> is used.
-	See also the 'expandtab', 'softtabstop' and 'smarttab' options.
-
-	It is also used to visually represent the Horizontal Tabulation
-	characters (ASCII 9, caret notation: ^I) already present in a file.
-	Example: with `:set tabstop=8` the following two lines
->
-		1234^I9
-		1234    9
-<
-	will display identically on screen. See also the 'list' option.
-
-	This setting does not influence how Vim represents the Vertical
-	Tabulation characters (ASCII 11) already present in a file; they will
-	always be represented by their caret notation `^K`.
-
-	If Vim is compiled with the |+vartabs| feature then the value of
-	'tabstop' will be ignored if |'vartabstop'| is set to anything other
-	than an empty string.
-
-	Note: Setting 'tabstop' to any other value than 8 can make your file
-	appear wrong in many places, e.g., when printing it.
-	See also |using-tabs| for recommendations.
+	If Vim was compiled with |+vartabs| and |'vartabstop'| is set, this option
+	is ignored.
+	Leave it at 8 unless you have a strong reason (see usr |30.5|).
 
 
 			*'tagbsearch'* *'tbs'* *'notagbsearch'* *'notbs'*

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -8558,7 +8558,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 	See also |using-tabs| for recommendations.
 
 
-
 			*'tagbsearch'* *'tbs'* *'notagbsearch'* *'notbs'*
 'tagbsearch' 'tbs'	boolean	(default on)
 			global

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -593,38 +593,42 @@ the system, mostly it is something like 256 or 1024 characters.
 					 	*using-tabs* *tabs-usage*
 There are five main ways to use tabs in Vim:
 
-1. Always keep 'tabstop' at 8, set 'softtabstop' and 'shiftwidth' to 4
-   and use 'noexpandtab'.  Then Vim
-   will use a mix of tabs and spaces, but typing <Tab> and <BS> will
-   behave like a tab appears every 4 characters.
-   This is the recommended way, the file will look the same with other
+1. Keep 'tabstop' at 8, set 'softtabstop' and 'shiftwidth' to whatever
+   you prefer and use 'noexpandtab'.  Then Vim will display
+   Horizontal Tabulation characters (ASCII 9, caret notation: ^I)
+   using the traditional 8 columns spacing between tab stops.
+   But when typing <Tab> and <BS>, it will use a mix of spaces and ^I
+   so that the two keys behave as if they were following 'softtabstop'.
+   This is the recommended way, the file will look the same in other
    tools and when listing it in a terminal.
 
 2. Set 'softtabstop' and 'shiftwidth' to whatever you prefer and use
-   'expandtab'.  This way you will always insert spaces.  The
-   formatting will never be messed up when 'tabstop' is changed (leave
+   'expandtab'.  This way you will always insert spaces.
+   The formatting will never be messed up when 'tabstop' is changed (leave
    it at 8 just in case).  The file will be a bit larger.
-   You do need to check if no Tabs exist in the file.  You can get rid
-   of them by first setting 'expandtab' and using |:retab!|, making
-   sure the value of 'tabstop' is set correctly.
+   You can get rid of any ^I already present in the file
+   by first setting 'expandtab' and using |:retab!|, making sure
+   the value of 'tabstop' is set correctly.
 
-3. Set 'tabstop' and 'shiftwidth' to whatever you prefer and use
-   'expandtab'.  This way you will always insert spaces.  The
-   formatting will never be messed up when 'tabstop' is changed.
-   You do need to check if no Tabs exist in the file, just like in the
-   item just above.
+3. Set 'tabstop' and 'shiftwidth' to whatever you prefer and use 'expandtab'.
+   This way you will always insert spaces, never ^I.
+   The formatting will never be messed up when 'tabstop' is changed,
+   unless ^I were already present in the file.
 
-4. Set 'tabstop' and 'shiftwidth' to whatever you prefer via a 
-   |modeline| to set these values when editing the file again.  Only
-   works when using Vim to edit the file, other tools assume a tabstop
-   is worth 8 spaces.
+4. Set 'tabstop' and 'shiftwidth' to whatever you prefer using a
+   |modeline| to set these values when editing the file again.
 
-5. Always set 'tabstop' and 'shiftwidth' to the same value, and
-   'noexpandtab'.  This should then work (for initial indents only)
-   for any tabstop setting that people use.  It might be nice to have
-   tabs after the first non-blank inserted as spaces if you do this
-   though.  Otherwise aligned comments will be wrong when 'tabstop' is
-   changed.
+5. Set 'tabstop' and 'shiftwidth' to the same value, and 'noexpandtab'.
+   This should then work (for initial indents only) for any tabstop setting
+   that people use.  It might be nice to have tabs after the first non-blank
+   inserted as spaces if you do this though.
+   Otherwise aligned comments will be wrong when 'tabstop' is changed.
+
+NOTE: for options 3. 4. and 5. keep in mind that traditionally other tools
+such as `cat` or `git` have their (virtual) horizontal tab stops
+separated by 8 columns, and will display the tab characters ^I
+present in a file accordingly.
+
 
 ==============================================================================
 2. Automatically setting options			*auto-setting*

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -8529,7 +8529,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 'tabstop' 'ts'		number	(default 8)
 			local to buffer
 	Number of columns between two (virtual) horizontal tab stops.
-	The value must be between 1 and 10000.
+	The value must be at least 1 and at most 9999.
 
 	In insert mode, this is one of the settings that influence
 	what characters Vim writes in a file when <Tab> is used

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -590,7 +590,7 @@ the system, mostly it is something like 256 or 1024 characters.
 <			You need to restart for this to take effect.
 
 
-					 	*using-tabs* *tabs-usage*
+						*using-tabs* *tabs-usage*
 There are five main ways to use tabs in Vim:
 
 1. Keep 'tabstop' at 8, set 'softtabstop' and 'shiftwidth' to whatever

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -589,6 +589,43 @@ the system, mostly it is something like 256 or 1024 characters.
 				keysym 22 = BackSpace
 <			You need to restart for this to take effect.
 
+
+					 	*using-tabs* *tabs-usage*
+There are five main ways to use tabs in Vim:
+
+1. Always keep 'tabstop' at 8, set 'softtabstop' and 'shiftwidth' to 4
+   (or 3 or whatever you prefer) and use 'noexpandtab'.  Then Vim
+   will use a mix of tabs and spaces, but typing <Tab> and <BS> will
+   behave like a tab appears every 4 (or 3) characters.
+   This is the recommended way, the file will look the same with other
+   tools and when listing it in a terminal.
+
+2. Set 'softtabstop' and 'shiftwidth' to whatever you prefer and use
+   'expandtab'.  This way you will always insert spaces.  The
+   formatting will never be messed up when 'tabstop' is changed (leave
+   it at 8 just in case).  The file will be a bit larger.
+   You do need to check if no Tabs exist in the file.  You can get rid
+   of them by first setting 'expandtab' and using `%retab!`, making
+   sure the value of 'tabstop' is set correctly.
+
+3. Set 'tabstop' and 'shiftwidth' to whatever you prefer and use
+   'expandtab'.  This way you will always insert spaces.  The
+   formatting will never be messed up when 'tabstop' is changed.
+   You do need to check if no Tabs exist in the file, just like in the
+   item just above.
+
+4. Set 'tabstop' and 'shiftwidth' to whatever you prefer and use a
+   |modeline| to set these values when editing the file again.  Only
+   works when using Vim to edit the file, other tools assume a tabstop
+   is worth 8 spaces.
+
+5. Always set 'tabstop' and 'shiftwidth' to the same value, and
+   'noexpandtab'.  This should then work (for initial indents only)
+   for any tabstop setting that people use.  It might be nice to have
+   tabs after the first non-blank inserted as spaces if you do this
+   though.  Otherwise aligned comments will be wrong when 'tabstop' is
+   changed.
+
 ==============================================================================
 2. Automatically setting options			*auto-setting*
 
@@ -8491,46 +8528,36 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'tabstop'* *'ts'*
 'tabstop' 'ts'		number	(default 8)
 			local to buffer
-	Number of spaces that a <Tab> in the file counts for.  Also see
-	the |:retab| command, and the 'softtabstop' option.
+	Number of columns between two (virtual) horizontal tab stops.
+	The value must be between 1 and 10000.
 
-	Note: Setting 'tabstop' to any other value than 8 can make your file
-	appear wrong in many places, e.g., when printing it.
-	The value must be more than 0 and less than 10000.
+	In insert mode, this is one of the settings that influence
+	what characters Vim writes in a file when <Tab> is used
+	and what characters get deleted when <BS> is used.
+	See also the 'expandtab', 'softtabstop' and 'smarttab' options.
 
-	There are five main ways to use tabs in Vim:
-	1. Always keep 'tabstop' at 8, set 'softtabstop' and 'shiftwidth' to 4
-	   (or 3 or whatever you prefer) and use 'noexpandtab'.  Then Vim
-	   will use a mix of tabs and spaces, but typing <Tab> and <BS> will
-	   behave like a tab appears every 4 (or 3) characters.
-	   This is the recommended way, the file will look the same with other
-	   tools and when listing it in a terminal.
-	2. Set 'softtabstop' and 'shiftwidth' to whatever you prefer and use
-	   'expandtab'.  This way you will always insert spaces.  The
-	   formatting will never be messed up when 'tabstop' is changed (leave
-	   it at 8 just in case).  The file will be a bit larger.
-	   You do need to check if no Tabs exist in the file.  You can get rid
-	   of them by first setting 'expandtab' and using `%retab!`, making
-	   sure the value of 'tabstop' is set correctly.
-	3. Set 'tabstop' and 'shiftwidth' to whatever you prefer and use
-	   'expandtab'.  This way you will always insert spaces.  The
-	   formatting will never be messed up when 'tabstop' is changed.
-	   You do need to check if no Tabs exist in the file, just like in the
-	   item just above.
-	4. Set 'tabstop' and 'shiftwidth' to whatever you prefer and use a
-	   |modeline| to set these values when editing the file again.  Only
-	   works when using Vim to edit the file, other tools assume a tabstop
-	   is worth 8 spaces.
-	5. Always set 'tabstop' and 'shiftwidth' to the same value, and
-	   'noexpandtab'.  This should then work (for initial indents only)
-	   for any tabstop setting that people use.  It might be nice to have
-	   tabs after the first non-blank inserted as spaces if you do this
-	   though.  Otherwise aligned comments will be wrong when 'tabstop' is
-	   changed.
+	It is also used to visually represent the Horizontal Tabulation
+	characters (ASCII 9, caret notation: ^I) already present in a file.
+	Example: with `ts=8` the following two lines
+>
+		1234^I9
+		1234    9
+<
+	will display identically on screen. See also the 'list' option.
+
+	This setting does not influence how Vim represents the Vertical
+	Tabulation characters (ASCII 11) already present in a file; they will
+	always be represented by their caret notation `^K`.
 
 	If Vim is compiled with the |+vartabs| feature then the value of
 	'tabstop' will be ignored if |'vartabstop'| is set to anything other
 	than an empty string.
+
+	Note: Setting 'tabstop' to any other value than 8 can make your file
+	appear wrong in many places, e.g., when printing it.
+	See also |using-tabs| for recommendations.
+
+
 
 			*'tagbsearch'* *'tbs'* *'notagbsearch'* *'notbs'*
 'tagbsearch' 'tbs'	boolean	(default on)

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -594,9 +594,9 @@ the system, mostly it is something like 256 or 1024 characters.
 There are five main ways to use tabs in Vim:
 
 1. Always keep 'tabstop' at 8, set 'softtabstop' and 'shiftwidth' to 4
-   (or 3 or whatever you prefer) and use 'noexpandtab'.  Then Vim
+   and use 'noexpandtab'.  Then Vim
    will use a mix of tabs and spaces, but typing <Tab> and <BS> will
-   behave like a tab appears every 4 (or 3) characters.
+   behave like a tab appears every 4 characters.
    This is the recommended way, the file will look the same with other
    tools and when listing it in a terminal.
 
@@ -605,7 +605,7 @@ There are five main ways to use tabs in Vim:
    formatting will never be messed up when 'tabstop' is changed (leave
    it at 8 just in case).  The file will be a bit larger.
    You do need to check if no Tabs exist in the file.  You can get rid
-   of them by first setting 'expandtab' and using `%retab!`, making
+   of them by first setting 'expandtab' and using |:retab!|, making
    sure the value of 'tabstop' is set correctly.
 
 3. Set 'tabstop' and 'shiftwidth' to whatever you prefer and use
@@ -614,7 +614,7 @@ There are five main ways to use tabs in Vim:
    You do need to check if no Tabs exist in the file, just like in the
    item just above.
 
-4. Set 'tabstop' and 'shiftwidth' to whatever you prefer and use a
+4. Set 'tabstop' and 'shiftwidth' to whatever you prefer via a 
    |modeline| to set these values when editing the file again.  Only
    works when using Vim to edit the file, other tools assume a tabstop
    is worth 8 spaces.
@@ -8538,7 +8538,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 	It is also used to visually represent the Horizontal Tabulation
 	characters (ASCII 9, caret notation: ^I) already present in a file.
-	Example: with `ts=8` the following two lines
+	Example: with `:set tabstop=8` the following two lines
 >
 		1234^I9
 		1234    9

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -10669,7 +10669,6 @@ tabpagebuflist()	builtin.txt	/*tabpagebuflist()*
 tabpagenr()	builtin.txt	/*tabpagenr()*
 tabpagewinnr()	builtin.txt	/*tabpagewinnr()*
 tabpanel	tabpage.txt	/*tabpanel*
-tabs-usage	options.txt	/*tabs-usage*
 tag	tagsrch.txt	/*tag*
 tag-!	tagsrch.txt	/*tag-!*
 tag-binary-search	tagsrch.txt	/*tag-binary-search*
@@ -11029,7 +11028,6 @@ userfunc.txt	userfunc.txt	/*userfunc.txt*
 using-<Plug>	usr_51.txt	/*using-<Plug>*
 using-menus	gui.txt	/*using-menus*
 using-scripts	repeat.txt	/*using-scripts*
-using-tabs	options.txt	/*using-tabs*
 using-xxd	tips.txt	/*using-xxd*
 using_CTRL-V	map.txt	/*using_CTRL-V*
 usr	usr_toc.txt	/*usr*

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -10669,6 +10669,7 @@ tabpagebuflist()	builtin.txt	/*tabpagebuflist()*
 tabpagenr()	builtin.txt	/*tabpagenr()*
 tabpagewinnr()	builtin.txt	/*tabpagewinnr()*
 tabpanel	tabpage.txt	/*tabpanel*
+tabs-usage	options.txt	/*tabs-usage*
 tag	tagsrch.txt	/*tag*
 tag-!	tagsrch.txt	/*tag-!*
 tag-binary-search	tagsrch.txt	/*tag-binary-search*
@@ -11028,6 +11029,7 @@ userfunc.txt	userfunc.txt	/*userfunc.txt*
 using-<Plug>	usr_51.txt	/*using-<Plug>*
 using-menus	gui.txt	/*using-menus*
 using-scripts	repeat.txt	/*using-scripts*
+using-tabs	options.txt	/*using-tabs*
 using-xxd	tips.txt	/*using-xxd*
 using_CTRL-V	map.txt	/*using_CTRL-V*
 usr	usr_toc.txt	/*usr*

--- a/runtime/doc/usr_30.txt
+++ b/runtime/doc/usr_30.txt
@@ -431,7 +431,7 @@ same was true for <BS>.
 THE ISSUE WITH TABS AND INDENTATION
 
 In Vim, the number of columns between two (virtual) horizontal tab stops
-is controled by 'tabstop' and is set to eight by default.  Although you can
+is controlled by 'tabstop' and is set to eight by default.  Although you can
 change it, you quickly run into trouble later.  Other programs won't know what
 tabstop value you used.  They probably use the default value of eight, and
 your text suddenly looks very different.  Also, most printers use a fixed
@@ -448,7 +448,7 @@ tab character to make your indent.
   To remedy this, `vi` had the 'shiftwidth' option.  When set to 4, on a new
 line, pressing <C-t> would indent the line by 4 spaces, a result impossible
 to get with the <Tab> key and 'tabstop' set to 8.  To optimize space, `vi`
-would also silently remove packs of spaces and replace then with tab
+would also silently remove packs of spaces and replace them with tab
 characters.  The following shows what happens pressing <C-t> a few times.
 A "." stands for a space character and "------->" for a tab character.
 
@@ -482,7 +482,7 @@ this was not the default everywhere.  Everytime text was displayed with the
 wrong 'tabstop' value, it would ruin the alignment of the text.
   In the meantime, computers got much better and the few octets saved by using
 tabs was no longer making any real difference.  It became possible to use only
-spaces and thus garantee the same resulting text everywhere.  But using only
+spaces and thus guarantee the same resulting text everywhere.  But using only
 spaces was impossible in `vi` without sacrificing features.  Remember that
 'autoindent' would systematically try to input a tab character when it could.
   So in Vim 4.0 introduced the 'expantab' option.  When set, Vim will replace
@@ -498,7 +498,7 @@ to remove only one character at a time.
 CHANGING TABS IN SPACES (AND BACK)
 
 Setting 'expandtab' does not immediately affect existing tab characters.
-Vim will occasionnally convert a tab character to spaces while rewriting
+Vim will occasionally convert a tab character to spaces while rewriting
 the indent of a line.
   In order to purge a file from all its horizontal tab characters, Vim 5.3
 introduced the |:retab| command.  Use these commands: >
@@ -532,7 +532,7 @@ When using only spaces, or a mix of spaces and horizontal tabs, one gets the
 unpleasant feeling that the two keys <Tab> and <BS> do not act in mirror, as
 they do when using only tab characters.
   Vim 5.4 introduced the 'softtabstop' option.  On top of the (hard) tab stops
-using to display the horizontal tab characters in the text, Vim adds extra
+used to display the horizontal tab characters in the text, Vim adds extra
 soft tab stops dedicated only to the cursor.  When 'softtabstop' is set to a
 positive value, and the <Tab> key will push the cursor to the next soft tab
 stop.  Vim will insert the correct combination of tab characters and spaces to
@@ -562,7 +562,7 @@ As we said before, the ASCII table was designed to remotely control
 teleprinters.  A given teleprinter could be configured to have their physical
 tab stops have variable spacing.  After all, the ^I control character was
 only stipulating: go to the next tab stop wherever it is.
-  Vim 7.3 introduced 'vartabstop' to emulate the same functionnality.  For
+  Vim 7.3 introduced 'vartabstop' to emulate the same functionality.  For
 example if Vim was compiled with `+vartabs` and `:set vartabstop=2,4` one gets
 
 	actual character	result ~
@@ -584,7 +584,7 @@ EXAMPLES OF CONFIGURATION
 If you want only tabs, then you have nothing to configure, this is
 the default in Vim.
 
-  If you want to write C code like it were Python (only spaces, with indents
+  If you want to write C code as if it were Python (only spaces, with indents
 of 4 spaces), here is what you can use: >
 
 	:set shiftwidth=4

--- a/runtime/doc/usr_30.txt
+++ b/runtime/doc/usr_30.txt
@@ -409,86 +409,99 @@ the cursor is on "printf":
 ==============================================================================
 *30.5*	Tabs and spaces
 
-'tabstop' is set to eight by default.  Although you can change it, you quickly
-run into trouble later.  Other programs won't know what tabstop value you
-used.  They probably use the default value of eight, and your text suddenly
-looks very different.  Also, most printers use a fixed tabstop value of eight.
-Thus it's best to keep 'tabstop' alone.  (If you edit a file which was written
-with a different tabstop setting, see |25.3| for how to fix that.)
-   For indenting lines in a program, using a multiple of eight spaces makes
+A QUICK HISTORY OF THE RATIONALE BEHIND TABS
+
+`vi` (the ancestor of Vim) was created by Bill Joy.  At the time, he was using
+a PDP-11 with limited memory and I/O operation capabilities.  Back then, it
+was common to optimize the size of source code with the following trick.
+  The ASCII table was first designed to remotely control teleprinters.  When
+control character 9 (the Horizontal Tab, caret notation: ^I) was sent to a
+teleprinter, it would move the carriage to the next tab stop.  Assuming tab
+stops were separated by 8 columns (the typical standard), this means that a
+single control character could produce the same visual effect as up to 8 space
+characters.  For example, the following two lines will display identically >
+
+	1234^I9
+	1234    9
+
+Using the <Tab> key was also faster than typing <Space> several times; the
+same was true for <BS>.
+
+
+THE ISSUE WITH TABS AND INDENTATION
+
+In Vim, the number of columns between two (virtual) horizontal tab stops
+is controled by 'tabstop' and is set to eight by default.  Although you can
+change it, you quickly run into trouble later.  Other programs won't know what
+tabstop value you used.  They probably use the default value of eight, and
+your text suddenly looks very different.  Also, most printers use a fixed
+tabstop value of eight.  Thus it's best to keep 'tabstop' alone; if you edit a
+file which was written with a different tabstop setting, see |25.3| for how
+to fix that.
+   For indenting lines in a program, using a multiple of eight columns makes
 you quickly run into the right border of the window.  Using a single space
 doesn't provide enough visual difference.  Many people prefer to use four
 spaces, a good compromise.
-   Since a <Tab> is eight spaces and you want to use an indent of four spaces,
-you can't use a <Tab> character to make your indent.  There are two ways to
-handle this:
+   Since a tab character at the beginning of a line is visually represented
+as eight spaces and you want to use an indent of four spaces, you can't use a
+tab character to make your indent.
+  To remedy this, `vi` had the 'shiftwidth' option.  When set to 4, on a new
+line, pressing <C-t> would indent the line by 4 spaces, a result impossible
+to get with the <Tab> key and 'tabstop' set to 8.  To optimize space, `vi`
+would also silently remove packs of spaces and replace then with tab
+characters.  The following shows what happens pressing <C-t> a few times.
+A "." stands for a space character and "------->" for a tab character.
 
-1.  Use a mix of <Tab> and space characters.  Since a <Tab> takes the place of
-    eight spaces, you have fewer characters in your file.  Inserting a <Tab>
-    is quicker than eight spaces.  Backspacing works faster as well.
+	type				result ~
+	<C-t>				....
+	<C-t><C-t>			------->
+	<C-t><C-t><C-t>			------->....
 
-2.  Use spaces only.  This avoids the trouble with programs that use a
-    different tabstop value.
+Similarly with `set tabstop=8 shiftwidth=2` one has
 
-Fortunately, Vim supports both methods quite well.
+	type				result ~
+	<C-t><Tab><C-t>			..----->..
+	<C-t><Tab><C-t><C-d>		------->
 
+A third option that one could set in `vi` was 'autoindent'.  It copies the
+indent level of the previous lines, 
 
-SPACES AND TABS
+	type				result ~
+	<Space><Tab>hello		.------>hello
+	<Space><Tab>hello<Enter>	.------>hello
+					------->
 
-If you are using a combination of tabs and spaces, you just edit normally.
-The Vim defaults do a fine job of handling things.
-   You can make life a little easier by setting the 'softtabstop' option.
-This option tells Vim to make the <Tab> key look and feel as if tabs were set
-at the value of 'softtabstop', but actually use a combination of tabs and
-spaces.
-   After you execute the following command, every time you press the <Tab> key
-the cursor moves to the next 4-column boundary: >
-
-	:set softtabstop=4
-
-When you start in the first column and press <Tab>, you get 4 spaces inserted
-in your text.  The second time, Vim takes out the 4 spaces and puts in a <Tab>
-(thus taking you to column 8).  Thus Vim uses as many <Tab>s as possible, and
-then fills up with spaces.
-   When backspacing it works the other way around.  A <BS> will always delete
-the amount specified with 'softtabstop'.  Then <Tab>s are used as many as
-possible and spaces to fill the gap.
-   The following shows what happens pressing <Tab> a few times, and then using
-<BS>.  A "." stands for a space and "------->" for a <Tab>.
-
-	type			  result ~
-	<Tab>			  ....
-	<Tab><Tab>		  ------->
-	<Tab><Tab><Tab>		  ------->....
-	<Tab><Tab><Tab><BS>	  ------->
-	<Tab><Tab><Tab><BS><BS>   ....
-
-An alternative is to use the 'smarttab' option.  When it's set, Vim uses
-'shiftwidth' for a <Tab> typed in the indent of a line, and a real <Tab> when
-typed after the first non-blank character.  However, <BS> doesn't work like
-with 'softtabstop'.
+but the new line is produced by optimizing the number of characters used.
 
 
 JUST SPACES
 
-If you want absolutely no tabs in your file, you can set the 'expandtab'
-option: >
+But using the Horizontal Tab control character to save up space came with
+a drawback.  Although tab stops were supposed to be separated by 8 columns,
+this was not the default everywhere.  Everytime text was displayed with the
+wrong 'tabstop' value, it would ruin the alignment of the text.
+  In the meantime, computers got much better and the few octets saved by using
+tabs was no longer making any real difference.  It became possible to use only
+spaces and thus garantee the same resulting text everywhere.  But using only
+spaces was impossible in `vi` without sacrificing features.  Remember that
+'autoindent' would systematically try to input a tab character when it could.
+  So in Vim 4.0 introduced the 'expantab' option.  When set, Vim will replace
+any horizontal tab character that it would normally insert with an equivalent
+number of spaces, to end up with the same visual effect. <BS> would continue
+to remove only one character at a time.
 
-	:set expandtab
-
-When this option is set, the <Tab> key inserts a series of spaces.  Thus you
-get the same amount of white space as if a <Tab> character was inserted, but
-there isn't a real <Tab> character in your file.
-   The backspace key will delete each space by itself.  Thus after typing one
-<Tab> you have to press the <BS> key up to eight times to undo it.  If you are
-in the indent, pressing CTRL-D will be a lot quicker.
+	type				result ~
+	<Tab>				........
+	<Tab><BS>			.......
 
 
 CHANGING TABS IN SPACES (AND BACK)
 
-Setting 'expandtab' does not affect any existing tabs.  In other words, any
-tabs in the document remain tabs.  If you want to convert tabs to spaces, use
-the ":retab" command.  Use these commands: >
+Setting 'expandtab' does not immediately affect existing tab characters.
+Vim will occasionnally convert a tab character to spaces while rewriting
+the indent of a line.
+  In order to purge a file from all its horizontal tab characters, Vim 5.3
+introduced the |:retab| command.  Use these commands: >
 
 	:set expandtab
 	:%retab
@@ -504,13 +517,94 @@ string.  To check if these exist, you could use this: >
 
 	/"[^"\t]*\t[^"]*"
 
-It's recommended not to use hard tabs inside a string.  Replace them with
-"\t" to avoid trouble.
+It's recommended not to actual ^I characters inside a string.  Replace them
+with "\t" to avoid trouble.
 
 The other way around works just as well: >
 
 	:set noexpandtab
 	:%retab!
+
+
+SOFT TAB STOPS
+
+When using only spaces, or a mix of spaces and horizontal tabs, one gets the
+unpleasant feeling that the two keys <Tab> and <BS> do not act in mirror, as
+they do when using only tab characters.
+  Vim 5.4 introduced the 'softtabstop' option.  On top of the (hard) tab stops
+using to display the horizontal tab characters in the text, Vim adds extra
+soft tab stops dedicated only to the cursor.  When 'softtabstop' is set to a
+positive value, and the <Tab> key will push the cursor to the next soft tab
+stop.  Vim will insert the correct combination of tab characters and spaces to
+make the effect visually.  Likewise pressing <BS> will have the cursor try to
+reach the nearest soft tab stop.  The following example uses
+`:set softtabstop=4`
+
+	type			result ~
+	<Tab>			....
+	<Tab><Tab>a		------->a
+	<Tab><Tab>a<Tab>	------->a...
+	<Tab><Tab><Tab><BS>	------->a
+
+  To maintain global coherence, one can `:set softtabstop=-1` so that
+the value of 'shiftwidth' is use for the number of columns between two soft
+tab stops.
+
+  If you prefer to have different values for 'shiftwidth' and 'softtabstop',
+you can still do so and use <C-t> to indent with 'shiftwidth'.  Or you can
+use the 'smarttab' option introduced in Vim 5.6, allowing for a unified
+<Tab> key that knows what to do in the different situations.
+
+
+VARIABLE TAB STOPS
+
+As we said before, the ASCII table was designed to remotely control
+teleprinters.  A given teleprinter could be configured to have their physical
+tab stops have variable spacing.  After all, the ^I control character was
+only stipulating: go to the next tab stop wherever it is.
+  Vim 7.3 introduced 'vartabstop' to emulate the same functionnality.  For
+example if Vim was compiled with `+vartabs` and `:set vartabstop=2,4` one gets
+
+	actual character	result ~
+	^I			->
+	^I^I			->--->
+	^I^I^I			->--->--->
+
+  Similarly, 'varsofttabstop' was also introduced, to have variably spaced
+soft tab stops.  With `:set varsofttabstop=2,4` one gets
+
+	type			  result ~
+	<Tab>			  ..
+	<Tab><Tab>		  ......
+	<Tab><Tab><Tab>		  ------->....
+
+
+EXAMPLES OF CONFIGURATION
+
+If you want only tabs, then you have nothing to configure, this is
+the default in Vim.
+
+  If you want to write C code like it were Python (only spaces, with indents
+of 4 spaces), here is what you can use: >
+
+	:set shiftwidth=4
+	:set softtabstop=-1
+	:set expandtab
+<
+  You want the same behaviour as above, but on top of that you want the
+ability to finely align code.  You can use: >
+
+	:set shiftwidth=4
+	:set softtabstop=2
+	:set expandtab
+	:set smarttab
+<
+  If instead, you would like to write C code like Bram Moolenaar would have
+(using a mix of tabs and spaces), you can use >
+
+	:set shiftwidth=4
+	:set softtabstop=-1
+<
 
 ==============================================================================
 *30.6*	Formatting comments

--- a/runtime/doc/usr_30.txt
+++ b/runtime/doc/usr_30.txt
@@ -546,7 +546,7 @@ reach the nearest soft tab stop.  The following example uses
 	<Tab>			....
 	<Tab><Tab>a		------->a
 	<Tab><Tab>a<Tab>	------->a...
-	<Tab><Tab><Tab><BS>	------->a
+	<Tab><Tab>a<Tab><BS>	------->a
 
   To maintain global coherence, one can `:set softtabstop=-1` so that
 the value of 'shiftwidth' is use for the number of columns between two soft

--- a/runtime/doc/usr_30.txt
+++ b/runtime/doc/usr_30.txt
@@ -590,8 +590,8 @@ of 4 spaces), here is what you can use: >
 	:set softtabstop=-1
 	:set expandtab
 <
-  You would like the same behaviour as above, but on top of that you would
-also like the ability to finely align code?  You can use: >
+  If you want the same behavior but with better control over alignment
+(e.g.  lining up parameters or comments in multiples of 2 spaces), use: >
 
 	:set shiftwidth=4
 	:set softtabstop=2

--- a/runtime/doc/usr_30.txt
+++ b/runtime/doc/usr_30.txt
@@ -446,11 +446,12 @@ spaces, a good compromise.
 as eight spaces and you want to use an indent of four spaces, you can't use a
 tab character to make your indent.
   To remedy this, `vi` had the 'shiftwidth' option.  When set to 4, on a new
-line, pressing <C-t> in Insert mode would indent the line by 4 spaces, a result impossible
-to get with the <Tab> key and 'tabstop' set to 8.  To optimize space, `vi`
-would also silently remove packs of spaces and replace them with tab
-characters.  The following shows what happens pressing <C-t> a few times.
-A "." stands for a space character and "------->" for a tab character.
+line, pressing <C-t> in Insert mode would indent the line by 4 spaces,
+a result impossible to get with the <Tab> key and 'tabstop' set to 8.
+ To optimize space, `vi` would also silently remove packs of spaces and replace
+them with tab characters.  The following shows what happens pressing <C-t>
+a few times. 
+  A "." stands for a space character and "------->" for a tab character.
 
 	type				result ~
 	<C-t>				....

--- a/runtime/doc/usr_30.txt
+++ b/runtime/doc/usr_30.txt
@@ -487,7 +487,7 @@ tabs was no longer making any real difference.  It became possible to use only
 spaces and thus guarantee the same resulting text everywhere.  But using only
 spaces was impossible in `vi` without sacrificing features.  Remember that
 'autoindent' would systematically try to input a tab character when it could.
-  So in Vim 4.0 introduced the 'expantab' option.  When set, Vim will replace
+  So Vim 4.0 introduced the 'expantab' option.  When set, Vim will replace
 any horizontal tab character that it would normally insert with an equivalent
 number of spaces, to end up with the same visual effect. <BS> would continue
 to remove only one character at a time.

--- a/runtime/doc/usr_30.txt
+++ b/runtime/doc/usr_30.txt
@@ -458,13 +458,14 @@ a few times.
 	<C-t><C-t>			------->
 	<C-t><C-t><C-t>			------->....
 
-Similarly with `set tabstop=8 shiftwidth=2` one has
+  Similarly pressing <C-d> in Insert mode would decrease the indent.  Hence
+with `set tabstop=8 shiftwidth=2` one has
 
 	type				result ~
 	<C-t><Tab><C-t>			..----->..
 	<C-t><Tab><C-t><C-d>		------->
 
-A third option that one could set in `vi` was 'autoindent'.  It copies the
+  A third option that one could set in `vi` was 'autoindent'.  It copies the
 indent level of the previous lines, 
 
 	type				result ~

--- a/runtime/doc/usr_30.txt
+++ b/runtime/doc/usr_30.txt
@@ -417,7 +417,7 @@ was common to optimize the size of source code with the following trick.
   The ASCII table was first designed to remotely control teleprinters.  When
 control character 9 (the Horizontal Tab, caret notation: ^I) was sent to a
 teleprinter, it would move the carriage to the next tab stop.  Assuming tab
-stops were separated by 8 columns (the typical standard), this means that a
+stops were separated by 8 columns (a typical standard), this means that a
 single control character could produce the same visual effect as up to 8 space
 characters.  For example, the following two lines will display identically >
 
@@ -478,19 +478,20 @@ but the new line is produced by optimizing the number of characters used.
 
 JUST SPACES
 
-But using the Horizontal Tab control character to save up space came with
-a drawback.  Although tab stops were supposed to be separated by 8 columns,
-this was not the default everywhere.  Everytime text was displayed with the
-wrong 'tabstop' value, it would ruin the alignment of the text.
+But separating tab stops with 8 columns was not universal: IBM had a standard
+at 10 columns, and today some Go developers write code with `tabstop=4`.  Every
+time text is displayed with a different 'tabstop' value, it risks misaligning
+the text, especially once the file is shared and opened on another machine.
   In the meantime, computers got much better and the few octets saved by using
-tabs was no longer making any real difference.  It became possible to use only
-spaces and thus guarantee the same resulting text everywhere.  But using only
-spaces was impossible in `vi` without sacrificing features.  Remember that
+tabs were no longer making any real difference.  It became possible to use
+only spaces and thus guarantee the same resulting text everywhere.  But using
+only spaces was impossible in `vi` without sacrificing features.  Remember that
 'autoindent' would systematically try to input a tab character when it could.
-  So Vim 4.0 introduced the 'expantab' option.  When set, Vim will replace
-any horizontal tab character that it would normally insert with an equivalent
-number of spaces, to end up with the same visual effect. <BS> would continue
-to remove only one character at a time.
+  Vim 4.0 made working with only spaces as convenient as working only with
+tabs (or a mix of tabs and spaces), by introducing the 'expandtab' option.
+When set, Vim will replace any horizontal tab character it would normally
+insert with an equivalent number of spaces, to end up with the same visual
+effect. <BS> would continue to remove only one character at a time.
 
 	type				result ~
 	<Tab>				........

--- a/runtime/doc/usr_30.txt
+++ b/runtime/doc/usr_30.txt
@@ -499,33 +499,25 @@ to remove only one character at a time.
 
 CHANGING TABS IN SPACES (AND BACK)
 
-Setting 'expandtab' does not immediately affect existing tab characters.
-Vim will occasionally convert a tab character to spaces while rewriting
-the indent of a line.
-  In order to purge a file from all its horizontal tab characters, Vim 5.3
+Setting 'expandtab' does not immediately affect existing tab characters.  In
+order to purge a file from all its horizontal tab characters, Vim 5.3
 introduced the |:retab| command.  Use these commands: >
 
 	:set expandtab
-	:%retab
-
-Now Vim will have changed all indents to use spaces instead of tabs.  However,
-all tabs that come after a non-blank character are kept.  If you want these to
-be converted as well, add a !: >
-
-	:%retab!
+	:retab
 
 This is a little bit dangerous, because it can also change tabs inside a
 string.  To check if these exist, you could use this: >
 
 	/"[^"\t]*\t[^"]*"
 
-It's recommended not to use actual tab characters inside a string.  Replace them
-with "\t" to avoid trouble.
+It's recommended not to use actual tab characters inside a string.  Replace
+them with "\t" to avoid trouble.
 
-The other way around works just as well: >
+  The other way around works just as well: >
 
 	:set noexpandtab
-	:%retab!
+	:retab!
 
 
 SOFT TAB STOPS

--- a/runtime/doc/usr_30.txt
+++ b/runtime/doc/usr_30.txt
@@ -446,7 +446,7 @@ spaces, a good compromise.
 as eight spaces and you want to use an indent of four spaces, you can't use a
 tab character to make your indent.
   To remedy this, `vi` had the 'shiftwidth' option.  When set to 4, on a new
-line, pressing <C-t> would indent the line by 4 spaces, a result impossible
+line, pressing <C-t> in Insert mode would indent the line by 4 spaces, a result impossible
 to get with the <Tab> key and 'tabstop' set to 8.  To optimize space, `vi`
 would also silently remove packs of spaces and replace them with tab
 characters.  The following shows what happens pressing <C-t> a few times.
@@ -517,7 +517,7 @@ string.  To check if these exist, you could use this: >
 
 	/"[^"\t]*\t[^"]*"
 
-It's recommended not to actual ^I characters inside a string.  Replace them
+It's recommended not to use actual tab characters inside a string.  Replace them
 with "\t" to avoid trouble.
 
 The other way around works just as well: >

--- a/runtime/doc/usr_30.txt
+++ b/runtime/doc/usr_30.txt
@@ -583,9 +583,14 @@ soft tab stops.  With `:set varsofttabstop=2,4` one gets
 
 EXAMPLES OF CONFIGURATION
 
-If you want only tabs, then you have nothing to configure, this is
-the default in Vim.
+By default, Vim is configured to use only tabs: >
 
+	:set tabstop=8
+	:set shiftwidth=8
+	:set noexpandtab
+	:set softtabstop=0
+	:set nosmarttab
+<
   If you want to write C code as if it were Python (only spaces, with indents
 of 4 spaces), here is what you can use: >
 
@@ -593,8 +598,8 @@ of 4 spaces), here is what you can use: >
 	:set softtabstop=-1
 	:set expandtab
 <
-  You want the same behaviour as above, but on top of that you want the
-ability to finely align code.  You can use: >
+  You would like the same behaviour as above, but on top of that you would
+also like the ability to finely align code?  You can use: >
 
 	:set shiftwidth=4
 	:set softtabstop=2


### PR DESCRIPTION
# Clarifying the docs on tabstop

## Issue
Understanding how tabs work in Vim is a typical challenge for new users ; there are many blogs / videos dedicated to the subject. The wording of the docs on `tabstop` was confusing to me also at first, since it was written that a `<Tab>` should be equal to `tabstop` spaces.

## Proposed clarification

### `tabstop`
The effect of `tabstop` is separated into
- how Vim displays the char `^I` (controlled only by `tabstop`)
- and how Vim acts on the `<Tab>` action (controlled by several settings at the same time).

A contextual explanation of how Vim displays the char `^K` is added.
A visual example is added to make it clear that a `<Tab>` is not equal to `tabstop` spaces.
The reference to `:retab` is removed ; it is kept in the `using-tabs` section.
A mention to `<BS>` is added, since it is about ‘tab stops’ and not only `<Tab>`.
A reference to `'list'` is added.
The range of allowed values for `tabstop` is made unambiguous.

### `using-tabs` `tabs-usage`
In addition, the five recommended settings to use tabs in Vim are given their own tags `using-tabs` and `tabs-usage` to have a separation between functionalities and recommendations.
I did not change the original wording of these suggestions.