### PR TITLE
Fix spurious CursorHold trigger at GUI startup

### DIFF
--- a/src/globals.h
+++ b/src/globals.h
@@ -1614,7 +1614,7 @@ EXTERN int	autocmd_bufnr INIT(= 0);     // fnum for <abuf> on cmdline
 EXTERN char_u	*autocmd_match INIT(= NULL); // name for <amatch> on cmdline
 EXTERN int	aucmd_cmdline_changed_count INIT(= 0);
 
-EXTERN int	did_cursorhold INIT(= FALSE); // set when CursorHold t'gerd
+EXTERN int	did_cursorhold INIT(= TRUE);  // set when CursorHold t'gerd
 EXTERN pos_T	last_cursormoved	      // for CursorMoved event
 # ifdef DO_INIT
 		    = {0, 0, 0}

--- a/src/testdir/Make_all.mak
+++ b/src/testdir/Make_all.mak
@@ -119,6 +119,7 @@ NEW_TESTS = \
 	test_crypt \
 	test_cscope \
 	test_cursor_func \
+	test_cursorhold_gui_startup.vim \
 	test_cursorline \
 	test_curswant \
 	test_debugger \
@@ -403,6 +404,7 @@ NEW_TESTS_RES = \
 	test_crypt.res \
 	test_cscope.res \
 	test_cursor_func.res \
+	test_cursorhold_gui_startup.res \
 	test_cursorline.res \
 	test_curswant.res \
 	test_debugger.res \

--- a/src/testdir/test_cursorhold_gui_startup.vim
+++ b/src/testdir/test_cursorhold_gui_startup.vim
@@ -1,0 +1,28 @@
+" Test that CursorHold is NOT triggered at startup before a keypress
+
+source check.vim
+CheckCanRunGui
+
+func Test_CursorHold_not_triggered_at_startup()
+  call delete('Xcursorhold.log')
+  call writefile([
+        \ 'set updatetime=300',
+        \ 'let g:cursorhold_triggered = 0',
+        \ 'autocmd CursorHold * let g:cursorhold_triggered += 1 | call writefile(["CursorHold triggered"], "Xcursorhold.log", "a")',
+        \ 'call timer_start(400, {-> execute(''call writefile(["g:cursorhold_triggered=" . g:cursorhold_triggered], "Xcursorhold.log", "a") | qa!'')})',
+        \ ], 'Xcursorhold_test.vim')
+
+  let vimcmd = v:progpath . ' -g -f -N -u NONE -i NONE -S Xcursorhold_test.vim'
+  call system(vimcmd)
+
+  let lines = filereadable('Xcursorhold.log') ? readfile('Xcursorhold.log') : []
+  call delete('Xcursorhold.log')
+  call delete('Xcursorhold_test.vim')
+
+  " Assert that CursorHold did NOT trigger at startup
+  call assert_false(index(lines, 'CursorHold triggered') != -1)
+  let found = filter(copy(lines), 'v:val =~ "^g:cursorhold_triggered="')
+  call assert_equal(['g:cursorhold_triggered=0'], found)
+endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
When Vim is started in GUI mode, the CursorHold autocommand event is triggered 'updatetime' milliseconds later, even when the user has not pressed a key.  This is different from the behavior of Vim in terminal mode, which does not trigger a CursorHold autocommand event at startup, and contradicts the description of the CursorHold event in ":help CursorHold", which states that the event is "[n]ot triggered until the user has pressed a key".

The fix is to change the initial value of did_cursorhold from FALSE to TRUE.  While it is true that the CursorDone event has not been done yet at startup, it should appear to have been done until the user presses a key.

This fixes issue #17350.