### PR TITLE
fix use-after free when there is an error in 'tabpanel' option

### DIFF
--- a/src/tabpanel.c
+++ b/src/tabpanel.c
@@ -530,8 +530,8 @@ starts_with_percent_and_bang(tabpanel_T *pargs)
 	if (did_emsg > did_emsg_before)
 	{
 	    usefmt = NULL;
-	    set_string_option_direct((char_u *)"tabpanel", -1, (char_u *)"",
-		    OPT_FREE | OPT_GLOBAL, SID_ERROR);
+	    set_string_option_direct(opt_name, -1, (char_u *)"",
+		    OPT_FREE | opt_scope, SID_ERROR);
 	}
     }
 #endif
@@ -641,6 +641,12 @@ do_by_tplmode(
 		args.prow = &row;
 		args.pcol = &col;
 		draw_tabpanel_userdefined(tplmode, &args);
+		// p_tpl could have been freed in build_stl_str_hl()
+		if (p_tpl == NULL || *p_tpl == NUL)
+		{
+		    usefmt = NULL;
+		    break;
+		}
 
 		p += i;
 		i = 0;

--- a/src/testdir/test_tabpanel.vim
+++ b/src/testdir/test_tabpanel.vim
@@ -529,6 +529,14 @@ function Test_tabpanel_error()
   catch /^Vim\%((\a\+)\)\=:E117:/
   endtry
   call assert_true(empty(&tabpanel))
+
+  try
+    set tabpanel=%{my#util#TabPanelHighlight}%t
+    redraw!
+  catch /^Vim\%((\a\+)\)\=:E121:/
+  endtry
+  call assert_true(empty(&tabpanel))
+
   set tabpanel&vim
   set showtabpanel&vim
 endfunc


### PR DESCRIPTION
Problem:  fix use-after free when there is an error in 'tabpanel' option
Solution: check if p_tpl has been set to null before accessing it again.

related: #17364

While at it slightly change starts_with_percent_and_bang() and use the existing opt_name and opt_scope variables.