### PR TITLE
Fix typos and language in documentation for tabpanel.

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -8429,7 +8429,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 'tabpanel' 'tpl'			string	(default empty)
 			global
 			{not in Vi}
-	When non empty, this option determines the content of the |tabpanel|.
+	When non-empty, this option determines the content of the |tabpanel|.
 	The option consists of printf style '%' items interspersed with
 	normal text, similar to the 'statusline' or 'tabline'.
 
@@ -8465,7 +8465,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	Optional settings for the |tabpanel|,  It can consist of the following
 	items.  Items must be separated by a comma.
 
-		align:{text}	Specified the position of tabpanel.
+		align:{text}	Specifies the position of the tabpanel.
 				Currently supported positions are:
 
 				left	left-aligned
@@ -8473,13 +8473,13 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 				(default "left")
 
-		columns:{n}	Use the size (in char) of tabpanel.
+		columns:{n}	Use the size (in characters) of the tabpanel.
 				The tabpanel is never shown when using zero
 				or less than the size of Vim window.
 				(default 20)
 
 		vert		Use a vertical separator for tabpanel.
-				This vertical separator is used "tpl_vert" of
+				This vertical separator used is "tpl_vert" of
 				'fillchars'.
 				(default off)
 

--- a/runtime/doc/tabpage.txt
+++ b/runtime/doc/tabpage.txt
@@ -436,9 +436,9 @@ side of the window.  It looks like this:
 	|           |text text text text text text text
 	|           |text text text text text text text
 <
-To configure the tabpanel, use following options: 'tabpanel',
-'showtabpanel', 'tabpanelopt'.
-The 'tabpanel' and 'showtabpanel' options are function similar to the
+To configure the tabpanel, use the following options: 'tabpanel',
+'showtabpanel' and 'tabpanelopt'.
+The 'tabpanel' and 'showtabpanel' options function similar to
 'statusline' or 'tabline'.
 
 The "columns:" of 'tabpanelopt' option specifies the width of the tabpanel:
@@ -480,7 +480,7 @@ displayed between the tabpanel and the main window:
 	|  ~/aaa.txt|text text text text text text text
 	|(2)        |text text text text text text text
 <
-The vertical separator is used "tpl_vert" of 'fillchars'.
+The vertical separator used is "tpl_vert" of 'fillchars'.
 
 You can customize the appearance of the tab page labels using the highlight
 groups: |hl-TabPanel| |hl-TabPanelSel| |hl-TabPanelFill|


### PR DESCRIPTION
In the documentation for the ``tabpanel`` option are some typos and unclear language usage. Fix these.