### PR TITLE
runtime(doc): make sw more precise

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -7496,11 +7496,10 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'shiftwidth'* *'sw'*
 'shiftwidth' 'sw'	number	(default 8)
 			local to buffer
-	Width, in columns, of an indentation level.
-
-	Used by 'autoident', |<<|, |>>|, 'cindent', etc.
-	A value of 0 makes Vim use the current 'tabstop' instead.
-	Use |shiftwidth()| to obtain the effective value in scripts.
+	Number of columns that make up one level of (auto)indentation.  Used
+	by |'cindent'|, |<<|, |>>|, etc.
+	If set to 0, Vim uses the current 'tabstop' value.  Use |shiftwidth()|
+	to obtain the effective value in scripts.
 
 						*'shortmess'* *'shm'*
 'shortmess' 'shm'	string	(Vim default "filnxtToOS", Vi default: "S",

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -7496,10 +7496,11 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'shiftwidth'* *'sw'*
 'shiftwidth' 'sw'	number	(default 8)
 			local to buffer
-	Number of spaces to use for each step of (auto)indent.  Used for
-	|'cindent'|, |>>|, |<<|, etc.
-	When zero the 'tabstop' value will be used.  Use the |shiftwidth()|
-	function to get the effective shiftwidth value.
+	Width, in columns, of an indentation level.
+
+	Used by 'autoident', |<<|, |>>|, 'cindent', etc.
+	A value of 0 makes Vim use the current 'tabstop' instead.
+	Use |shiftwidth()| to obtain the effective value in scripts.
 
 						*'shortmess'* *'shm'*
 'shortmess' 'shm'	string	(Vim default "filnxtToOS", Vi default: "S",


### PR DESCRIPTION
The main goal of this edit is to remove the word ‘space’ which might be mistaken with ‘space character’.

 Here is [what POSIX says](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/ex.html) on `shiftwidth`

> shiftwidth, sw
>
> [Default 8]
>
> The value of this option shall give the width in columns of an indentation level used during autoindentation and by the shift  commands (< and >).