### PR TITLE
runtime(doc): clarify smarttab

### DIFF
--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -556,10 +556,10 @@ extra spaces to get where you want to be.
 
 							*ins-smarttab*
 When the 'smarttab' option is on, and the cursor is in Insert mode within an
-indent (i.e. when all the characters before the cursor are either tabs or
-spaces), Vim will behave as if 'softtabstop' were set with the value of
-'shiftwidth'.  This option allows the user to set 'softtabstop' to a
-value other than 'shiftwidth' and still use the <Tab> key for indentation.
+indent (i.e. when there are only blanks in front of the cursor), Vim will
+behave as if 'softtabstop' were set with the value of 'shiftwidth'.  This
+option allows the user to set 'softtabstop' to a value other than 'shiftwidth'
+and still use the <Tab> key for indentation.
 
 ==============================================================================
 5. Replace mode				*Replace* *Replace-mode* *mode-replace*

--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -555,11 +555,11 @@ cursor.  You will have to delete 'softtabstop' characters first, and then type
 extra spaces to get where you want to be.
 
 							*ins-smarttab*
-When the 'smarttab' option is on, and the cursor is in Insert mode within an
-indent (i.e. when there are only blanks in front of the cursor), Vim will
-behave as if 'softtabstop' were set with the value of 'shiftwidth'.  This
-option allows the user to set 'softtabstop' to a value other than 'shiftwidth'
-and still use the <Tab> key for indentation.
+When the 'smarttab' option is on, the <Tab> key will indent by 'shiftwidth'
+if the cursor is in leading whitespace.  The <BS> key will have the opposite
+effect.  All as if 'softtabstop' were set with the value of 'shiftwidth'.
+This option allows the user to set 'softtabstop' to a value other than
+'shiftwidth' and still use the <Tab> key for indentation.
 
 ==============================================================================
 5. Replace mode				*Replace* *Replace-mode* *mode-replace*

--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -529,7 +529,7 @@ paragraph, no matter where the cursor currently is.  Or you can use Visual
 mode: hit "v", move to the end of the block, and type "gq".  See also |gq|.
 
 ==============================================================================
-4. 'expandtab', 'smarttab' and 'softtabstop' options	*ins-expandtab*
+4. 'expandtab', 'softtabstop' and 'smarttab' options	*ins-expandtab*
 
 If the 'expandtab' option is on, spaces will be used to fill the amount of
 whitespace of the tab.  If you want to enter a real <Tab>, type CTRL-V first
@@ -539,13 +539,6 @@ character is replaced with several spaces.  The result of this is that the
 number of characters in the line increases.  Backspacing will delete one
 space at a time.  The original character will be put back for only one space
 that you backspace over (the last one).
-
-							*ins-smarttab*
-When the 'smarttab' option is on, a <Tab> inserts 'shiftwidth' positions at
-the beginning of a line and 'tabstop' positions in other places.  This means
-that often spaces instead of a <Tab> character are inserted.  When 'smarttab'
-is off, a <Tab> always inserts 'tabstop' positions, and 'shiftwidth' is only
-used for ">>" and the like.
 
 							*ins-softtabstop*
 When the 'softtabstop' option is non-zero, a <Tab> inserts 'softtabstop'
@@ -560,6 +553,13 @@ inserted character is a space, then it will only delete the character before
 the cursor.  Otherwise you cannot always delete a single character before the
 cursor.  You will have to delete 'softtabstop' characters first, and then type
 extra spaces to get where you want to be.
+
+							*ins-smarttab*
+When the 'smarttab' option is on, and the cursor is in Insert mode within an
+indent (i.e. when all the characters before the cursor are either tabs or
+spaces), Vim will behave as if 'softtabstop' were set with the value of
+'shiftwidth'.  This option allows the user to set 'softtabstop' to a
+value other than 'shiftwidth' and still use the <Tab> key for indentation.
 
 ==============================================================================
 5. Replace mode				*Replace* *Replace-mode* *mode-replace*

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -7795,10 +7795,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 				 *'smarttab'* *'sta'* *'nosmarttab'* *'nosta'*
 'smarttab' 'sta'	boolean	(default off)
 			global
-	When enabled, and the cursor is in Insert mode within an indent level
-	(i.e. when there is only whitespace before the cursor), Vim will
-	behave as if 'softtabstop' were set with the value of 'shiftwidth'.
-	Outside of an indent, this option has no effect.
+	When enabled, the <Tab> key will indent by 'shiftwidth' if the cursor
+	is in leading whitespace.  The <BS> key will have the opposite effect.
+	All as if 'softtabstop' were set with the value of 'shiftwidth'.
 	This option is reset when 'compatible' is set; it is temporarily
 	disabled when 'paste' is enabled, and restored when 'paste' is turned
 	off.

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -7795,19 +7795,15 @@ A jump table for the options with a short description can be found at |Q_op|.
 				 *'smarttab'* *'sta'* *'nosmarttab'* *'nosta'*
 'smarttab' 'sta'	boolean	(default off)
 			global
-	When on, a <Tab> in front of a line inserts blanks according to
-	'shiftwidth'.  'tabstop' or 'softtabstop' is used in other places.  A
-	<BS> will delete a 'shiftwidth' worth of space at the start of the
-	line.
-	When off, a <Tab> always inserts blanks according to 'tabstop' or
-	'softtabstop'.  'shiftwidth' is only used for shifting text left or
-	right |shift-left-right|.
-	What gets inserted (a <Tab> or spaces) depends on the 'expandtab'
-	option.  Also see |ins-expandtab|.  When 'expandtab' is not set, the
-	number of spaces is minimized by using <Tab>s.
-	This option is reset when 'paste' is set and restored when 'paste' is
-	reset.
-	NOTE: This option is reset when 'compatible' is set.
+	When enabled, and the cursor is in Insert mode within an indent level
+	(i.e. when all the characters before the cursor are tabs or spaces),
+	Vim will behave as if 'softtabstop' were set with the value of
+	'shiftwidth'.  Outside of an indent, this option has no effect.
+	  This option is reset when 'compatible' is set; it is temporarily
+	disabled when 'paste' is enabled, and restored when 'paste' is turned
+	off.
+	Have a look at section |30.5| of the user guide for detailed
+	explanations on how Vim works with tabs and spaces.
 
 			*'smoothscroll'* *'sms'* *'nosmoothscroll'* *'nosms'*
 'smoothscroll' 'sms'	boolean  (default off)

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -7796,9 +7796,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 'smarttab' 'sta'	boolean	(default off)
 			global
 	When enabled, and the cursor is in Insert mode within an indent level
-	(i.e. when all the characters before the cursor are tabs or spaces),
-	Vim will behave as if 'softtabstop' were set with the value of
-	'shiftwidth'.  Outside of an indent, this option has no effect.
+	(i.e. when there is only whitespace before the cursor), Vim will
+	behave as if 'softtabstop' were set with the value of 'shiftwidth'.
+	Outside of an indent, this option has no effect.
 	  This option is reset when 'compatible' is set; it is temporarily
 	disabled when 'paste' is enabled, and restored when 'paste' is turned
 	off.

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -7799,7 +7799,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	(i.e. when there is only whitespace before the cursor), Vim will
 	behave as if 'softtabstop' were set with the value of 'shiftwidth'.
 	Outside of an indent, this option has no effect.
-	  This option is reset when 'compatible' is set; it is temporarily
+	This option is reset when 'compatible' is set; it is temporarily
 	disabled when 'paste' is enabled, and restored when 'paste' is turned
 	off.
 	Have a look at section |30.5| of the user guide for detailed

--- a/runtime/doc/quickref.txt
+++ b/runtime/doc/quickref.txt
@@ -918,7 +918,7 @@ Short explanation of each option:		*option-list*
 'signcolumn'	  'scl'	    when to display the sign column
 'smartcase'	  'scs'     no ignore case when pattern has uppercase
 'smartindent'	  'si'	    smart autoindenting for C programs
-'smarttab'	  'sta'     in indent, behave as if 'sts' = 'sw'
+'smarttab'	  'sta'     <Tab> in leading whitespace indents by 'shiftwidth'
 'smoothscroll'	  'sms'     scroll by screen lines when 'wrap' is set
 'softtabstop'	  'sts'     number of spaces that <Tab> uses while editing
 'spell'			    enable spell checking

--- a/runtime/doc/quickref.txt
+++ b/runtime/doc/quickref.txt
@@ -918,7 +918,7 @@ Short explanation of each option:		*option-list*
 'signcolumn'	  'scl'	    when to display the sign column
 'smartcase'	  'scs'     no ignore case when pattern has uppercase
 'smartindent'	  'si'	    smart autoindenting for C programs
-'smarttab'	  'sta'     use 'shiftwidth' when inserting <Tab>
+'smarttab'	  'sta'     in indent, behave as if 'sts' = 'sw'
 'smoothscroll'	  'sms'     scroll by screen lines when 'wrap' is set
 'softtabstop'	  'sts'     number of spaces that <Tab> uses while editing
 'spell'			    enable spell checking


### PR DESCRIPTION
With these changes the behaviour of `smarttab` is clear and explicit: it just does as if `sts = sw` while inside an indent. All the relationships with `expandtab`, `tabstop`, `<Tab>` and `<BS>` etc are still not trivial, but now the user understands that they only have to grok how `softtabstop` works.

I also reordered `smarttab` to be after `softtabstop` in `insert.txt`.