### PR TITLE
runtime(doc): make examples verbatim to prevent conceal/tag parsing

### DIFF
--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -1342,9 +1342,15 @@ b:browsefilter variable.  You would most likely set b:browsefilter in a
 filetype plugin, so that the browse dialog would contain entries related to
 the type of file you are currently editing.  Disadvantage: This makes it
 difficult to start editing a file of a different type.  To overcome this, you
-may want to add "All Files (*.*)\t*\n" as the final filter on Windows or "All
-Files (*)\t*\n" on other platforms, so that the user can still access any
-desired file.
+may want to add >
+
+	All Files\t(*.*)\t*\n
+<
+as the final filter on Windows or >
+
+	All Files\t(*)\t*\n"
+<
+on other platforms, so that the user can still access any desired file.
 
 To avoid setting browsefilter when Vim does not actually support it, you can
 use has("browsefilter"): >

--- a/runtime/doc/helphelp.txt
+++ b/runtime/doc/helphelp.txt
@@ -412,7 +412,7 @@ in such a modeline, that can have undesired consequences.
 
 TAGS
 
-To define a help tag, place the name between asterisks (*tag-name*).  The
+To define a help tag, place the name between asterisks ("*tag-name*").  The
 tag-name should be different from all the Vim help tag names and ideally
 should begin with the name of the Vim plugin.  The tag name is usually right
 aligned on a line.

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -3102,7 +3102,7 @@ PRINTCAP + TERMCAP	*ft-ptcap-syntax* *ft-termcap-syntax*
 This syntax file applies to the printcap and termcap databases.
 
 In order for Vim to recognize printcap/termcap files that do not match
-the patterns *printcap*, or *termcap*, you must put additional patterns
+the patterns "*printcap*", or "*termcap*", you must put additional patterns
 appropriate to your system in your |myfiletypefile| file.  For these
 patterns, you must set the variable "b:ptcap_type" to either "print" or
 "term", and then the 'filetype' option to ptcap.

--- a/runtime/doc/usr_02.txt
+++ b/runtime/doc/usr_02.txt
@@ -438,9 +438,9 @@ of the tag given by the word under the cursor.)
    After a few jumps, you might want to go back.  CTRL-T (pop tag) takes you
 back to the preceding position.  CTRL-O (jump to older position) also works
 nicely here.
-   At the top of the help screen, there is the notation *help.txt*.  This name
-between "*" characters is used by the help system to define a tag (hyperlink
-destination).
+   At the top of the help screen, there is the notation "*help.txt*".  This
+name between "*" characters is used by the help system to define a tag
+(hyperlink destination).
    See |29.1| for details about using tags.
 
 To get help on a given subject, use the following command: >

--- a/runtime/doc/usr_11.txt
+++ b/runtime/doc/usr_11.txt
@@ -127,7 +127,7 @@ Example: >
 	vim -r .help.txt.swo
 
 This is also handy when the swap file is in another directory than expected.
-Vim recognizes files with the pattern *.s[uvw][a-z] as swap files.
+Vim recognizes files with the pattern "*.s[uvw][a-z]" as swap files.
 
 If this still does not work, see what file names Vim reports and rename the
 files accordingly.  Check the 'directory' option to see where Vim may have

--- a/runtime/doc/usr_22.txt
+++ b/runtime/doc/usr_22.txt
@@ -27,23 +27,24 @@ Vim has a plugin that makes it possible to edit a directory.  Try this: >
 	:edit .
 
 Through the magic of autocommands and Vim scripts, the window will be filled
-with the contents of the directory.  It looks like this:
+with the contents of the directory.  It looks like this: >
 
-" ============================================================================ ~
-" Netrw Directory Listing                                        (netrw v109) ~
-"   Sorted by      name ~
-"   Sort sequence: [\/]$,\.h$,\.c$,\.cpp$,*,\.info$,\.swp$,\.o$\.obj$,\.bak$ ~
-"   Quick Help: <F1>:help  -:go up dir  D:delete  R:rename  s:sort-by  x:exec ~
-" ============================================================================ ~
-../ ~
-./ ~
-check/ ~
-Makefile ~
-autocmd.txt ~
-change.txt ~
-eval.txt ~
-filetype.txt ~
-help.txt.info ~
+	" ============================================================================ ~
+	" Netrw Directory Listing                                        (netrw v109) ~
+	"   Sorted by      name ~
+	"   Sort sequence: [\/]$,\.h$,\.c$,\.cpp$,*,\.info$,\.swp$,\.o$\.obj$,\.bak$ ~
+	"   Quick Help: <F1>:help  -:go up dir  D:delete  R:rename  s:sort-by  x:exec ~
+	" ============================================================================ ~
+	../ ~
+	./ ~
+	check/ ~
+	Makefile ~
+	autocmd.txt ~
+	change.txt ~
+	eval.txt ~
+	filetype.txt ~
+	help.txt.info ~
+<
 
 You can see these items:
 


### PR DESCRIPTION
Originally described in https://github.com/neovim/tree-sitter-vimdoc/issues/149, there are some lines in the help docs that where the vimdoc TS parser mistakenly parses text as a tag node due to the asterisks. Most of the errors happen in unquoted verbatim examples, i.e.:

- `place the name between asterisks (*tag-name*)`: tag-name is wrongly assumed
  to be a tag itself.
- `Vim recognizes files with the pattern *.s[uvw][a-z] as swap files.`: quote
  the pattern to prevent the asterisk from doing any damage.

(not an exhaustive list of fixes in this PR)

This PR either double-quotes the text that contains the asterisk, or otherwise creates a verbatim code block for it.

The problem not only arises with the TS vimdoc parser, but also some of the asterisks get concealed in Vim.