### PR TITLE
runtime(mbsync): Add TLSType configuration variable

### DIFF
--- a/runtime/syntax/mbsync.vim
+++ b/runtime/syntax/mbsync.vim
@@ -80,9 +80,9 @@ syn match mbsIAConfStPassCmd      '^PassCmd\s\+\ze.*$'        contains=mbsIAConf
 syn match mbsIAConfStUseKeychain  '^UseKeychain\s\+\ze.*$'    contains=mbsIAConfItemK contained nextgroup=mbsBool transparent
 syn match mbsIAConfStTunnel       '^Tunnel\s\+\ze.*$'         contains=mbsIAConfItemK contained nextgroup=mbsCommand transparent
 syn match mbsIAConfStAuthMechs    '^AuthMechs\s\+\ze.*$'      contains=mbsIAConfItemK contained nextgroup=mbsPath transparent
-syn keyword mbsIAConfSSLTypeOpt None STARTTLS IMAPS contained
-syn match mbsIAConfStSSLType      '^SSLType\s\+\ze.*$'        contains=mbsIAConfItemK contained nextgroup=mbsIAConfSSLTypeOpt transparent
-syn match mbsIAConfStTLSType      '^TLSType\s\+\ze.*$'        contains=mbsIAConfItemK contained nextgroup=mbsIAConfSSLTypeOpt transparent
+syn keyword mbsIAConfTLSTypeOpt None STARTTLS IMAPS contained
+syn match mbsIAConfStSSLType      '^SSLType\s\+\ze.*$'        contains=mbsIAConfItemK contained nextgroup=mbsIAConfTLSTypeOpt transparent
+syn match mbsIAConfStTLSType      '^TLSType\s\+\ze.*$'        contains=mbsIAConfItemK contained nextgroup=mbsIAConfTLSTypeOpt transparent
 syn match mbsIAConfSSLVersionsOpt '\%(SSLv3\|TLSv1\%(.[123]\)\?\)\%(\s\+\%(SSLv3\|TLSv1\%(.[123]\)\?\)\)*' contained
 syn match mbsIAConfStSSLVersions  '^SSLVersions\s\+\ze.*$'    contains=mbsIAConfItemK contained nextgroup=mbsIAConfSSLVersionsOpt transparent
 syn match mbsIAConfStSystemCertificates  '^SystemCertificates\s\+\ze.*$'    contains=mbsIAConfItemK contained nextgroup=mbsBool transparent
@@ -196,7 +196,7 @@ hi def link mbsMdSConfItemK   Statement
 hi def link mbsMdSConfSubFoldersOpt Keyword
 
 hi def link mbsIAConfItemK    Statement
-hi def link mbsIAConfSSLTypeOpt Keyword
+hi def link mbsIAConfTLSTypeOpt Keyword
 hi def link mbsIAConfSSLVersionsOpt Keyword
 
 hi def link mbsISConfItemK    Statement

--- a/runtime/syntax/mbsync.vim
+++ b/runtime/syntax/mbsync.vim
@@ -82,6 +82,7 @@ syn match mbsIAConfStTunnel       '^Tunnel\s\+\ze.*$'         contains=mbsIAConf
 syn match mbsIAConfStAuthMechs    '^AuthMechs\s\+\ze.*$'      contains=mbsIAConfItemK contained nextgroup=mbsPath transparent
 syn keyword mbsIAConfSSLTypeOpt None STARTTLS IMAPS contained
 syn match mbsIAConfStSSLType      '^SSLType\s\+\ze.*$'        contains=mbsIAConfItemK contained nextgroup=mbsIAConfSSLTypeOpt transparent
+syn match mbsIAConfStTLSType      '^TLSType\s\+\ze.*$'        contains=mbsIAConfItemK contained nextgroup=mbsIAConfSSLTypeOpt transparent
 syn match mbsIAConfSSLVersionsOpt '\%(SSLv3\|TLSv1\%(.[123]\)\?\)\%(\s\+\%(SSLv3\|TLSv1\%(.[123]\)\?\)\)*' contained
 syn match mbsIAConfStSSLVersions  '^SSLVersions\s\+\ze.*$'    contains=mbsIAConfItemK contained nextgroup=mbsIAConfSSLVersionsOpt transparent
 syn match mbsIAConfStSystemCertificates  '^SystemCertificates\s\+\ze.*$'    contains=mbsIAConfItemK contained nextgroup=mbsBool transparent
@@ -96,7 +97,7 @@ syn cluster mbsIAConfItem contains=mbsIAConfSt.*
 
 syn keyword mbsIAConfItemK
   \ IMAPAccount Host Port Timeout User UserCmd Pass PassCmd UseKeychain Tunnel
-  \ AuthMechs SSLType SSLVersions SystemCertificates CertificateFile ClientCertificate
+  \ AuthMechs SSLType TLSType SSLVersions SystemCertificates CertificateFile ClientCertificate
   \ ClientKey CipherString PipelineDepth DisableExtension[s] contained
 
 syn region mbsIMAP4AccontsStore start="^IMAPAccount" end="^$" end="\%$" contains=@mbsGlobConfItem,mbsCommentL,@mbsIAConfItem,mbsError transparent


### PR DESCRIPTION
isync 1.5.0 renamed the SSLType configuration variable to TLSType. SSLType is still supported, but deprecated.

Upstream isync commit: faec30abf47b583af841b37c9dede1ae826cc582