### PR TITLE
Add out-of-memory checks to os_win32.c

### DIFF
--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -3028,6 +3028,8 @@ mch_init_g(void)
 	STRCPY(gettail(vimrun_location), "vimrun.exe");
 	if (mch_getperm(vimrun_location) >= 0)
 	{
+	    char  *p;
+
 	    if (*skiptowhite(vimrun_location) != NUL)
 	    {
 		// Enclose path with white space in double quotes.
@@ -3039,7 +3041,9 @@ mch_init_g(void)
 	    else
 		STRCPY(gettail(vimrun_location), "vimrun ");
 
-	    vimrun_path = (char *)vim_strsave(vimrun_location);
+	    p = (char *)vim_strsave(vimrun_location);
+	    if (p != NULL)
+		vimrun_path = p;
 	    s_dont_use_vimrun = FALSE;
 	}
 	else if (executable_exists("vimrun.exe", NULL, TRUE, FALSE))

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -3043,8 +3043,10 @@ mch_init_g(void)
 
 	    p = (char *)vim_strsave(vimrun_location);
 	    if (p != NULL)
+	    {
 		vimrun_path = p;
-	    s_dont_use_vimrun = FALSE;
+		s_dont_use_vimrun = FALSE;
+	    }
 	}
 	else if (executable_exists("vimrun.exe", NULL, TRUE, FALSE))
 	    s_dont_use_vimrun = FALSE;

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -1962,14 +1962,19 @@ encode_mouse_event(dict_T *args, INPUT_RECORD *ir)
     static int
 write_input_record_buffer(INPUT_RECORD* irEvents, int nLength)
 {
-    int nCount = 0;
+    int				nCount = 0;
+    input_record_buffer_node_T	*event_node;
+
     while (nCount < nLength)
     {
-	input_record_buffer.length++;
-	input_record_buffer_node_T *event_node =
-				    malloc(sizeof(input_record_buffer_node_T));
+	event_node = alloc(sizeof(input_record_buffer_node_T));
+	if (event_node == NULL)
+	    return -1;
+
 	event_node->ir = irEvents[nCount++];
 	event_node->next = NULL;
+
+	input_record_buffer.length++;
 	if (input_record_buffer.tail == NULL)
 	{
 	    input_record_buffer.head = event_node;
@@ -2065,7 +2070,13 @@ test_mswin_event(char_u *event, dict_T *args)
     // events.  But, this doesn't work well in the CI test environment.  So
     // implementing an input_record_buffer instead.
     if (input_encoded)
-	lpEventsWritten = write_input_record_buffer(&ir, 1);
+    {
+	if ((lpEventsWritten = write_input_record_buffer(&ir, 1)) < 0)
+	{
+	    semsg(_(e_out_of_memory), "event");
+	    return FALSE;
+	}
+    }
 
     // Set flags to execute the event, ie. like feedkeys mode X.
     if (execute)
@@ -7849,7 +7860,10 @@ copy_substream(HANDLE sh, void *context, WCHAR *to, WCHAR *substream, long len)
     HANDLE  hTo;
     WCHAR   *to_name;
 
-    to_name = malloc((wcslen(to) + wcslen(substream) + 1) * sizeof(WCHAR));
+    to_name = alloc((wcslen(to) + wcslen(substream) + 1) * sizeof(WCHAR));
+    if (to_name == NULL)
+	return;
+
     wcscpy(to_name, to);
     wcscat(to_name, substream);
 
@@ -8194,7 +8208,7 @@ get_cmd_argsW(char ***argvp)
     ArglistW = CommandLineToArgvW(GetCommandLineW(), &nArgsW);
     if (ArglistW != NULL)
     {
-	argv = malloc((nArgsW + 1) * sizeof(char *));
+	argv = alloc((nArgsW + 1) * sizeof(char *));
 	if (argv != NULL)
 	{
 	    argc = nArgsW;
@@ -8226,7 +8240,7 @@ get_cmd_argsW(char ***argvp)
     {
 	if (used_file_indexes != NULL)
 	    free(used_file_indexes);
-	used_file_indexes = malloc(argc * sizeof(int));
+	used_file_indexes = alloc(argc * sizeof(int));
     }
 
     if (argvp != NULL)


### PR DESCRIPTION
In `write_input_record_buffer()` add out-of-memory check, and abort if failure occurs.
In `test_mswin_event()` add check for `write_input_record_buffer()` failure.
In `copy_substream()` add out-of-memory check.
In `mch_init_g()` add out-of-memory check.
Change calls to `malloc()` to `alloc()`.

Cheers
John