### PR TITLE
fix: tabpanel flickers when scrolling the window (on gVim)

### DIFF
--- a/src/term.c
+++ b/src/term.c
@@ -4478,7 +4478,9 @@ scroll_region_reset(void)
 {
     OUT_STR(tgoto((char *)T_CS, (int)Rows - 1, 0));
     if (*T_CSV != NUL)
-	OUT_STR(tgoto((char *)T_CSV, Columns - 1, 0));
+	OUT_STR(tgoto((char *)T_CSV,
+		    firstwin->w_wincol + topframe->fr_width - 1,
+		    firstwin->w_wincol));
     screen_start();		    // don't know where cursor is now
 }
 

--- a/src/window.c
+++ b/src/window.c
@@ -6226,7 +6226,14 @@ shell_new_columns(void)
 
     if (!skip_win_fix_scroll)
 	win_fix_scroll(TRUE);
-
+#ifdef FEAT_GUI
+    if (gui.in_use)
+    {
+	if (scroll_region)
+	    scroll_region_reset();
+	scroll_start();	// may scroll the screen to the right position
+    }
+#endif
     redraw_tabline = TRUE;
 #if defined(FEAT_TABPANEL)
     redraw_tabpanel = TRUE;


### PR DESCRIPTION
close #17440

NOTE: This issue seems to occur in CLI Vim as well, but this PR only addresses gVim.