### PR TITLE
fix: 'shortmess' option not properly handled on session files

### DIFF
--- a/src/session.c
+++ b/src/session.c
@@ -687,9 +687,9 @@ makeopens(
 
     // set 'shortmess' for the following.  Add the 'A' flag if it was there
     if (put_line(fd, "if &shortmess =~ 'A'") == FAIL
-	    || put_line(fd, "  set shortmess=aoOA") == FAIL
+	    || put_line(fd, "  set shortmess+=aoOA") == FAIL
 	    || put_line(fd, "else") == FAIL
-	    || put_line(fd, "  set shortmess=aoO") == FAIL
+	    || put_line(fd, "  set shortmess+=aoO") == FAIL
 	    || put_line(fd, "endif") == FAIL)
 	goto fail;
 


### PR DESCRIPTION
I noticed that loading some session files hanged in *hit prompt* messages trying to load files with long paths.

This behavior doesn't happen in ordinary vim usage. I traced the issue to the value of ' shortmess'  option during session load.
```vim
" session file
" default values are loaded
set shortmess=filnxtToOSI
"...
" special flags are temporary added to avoid hit-prompts restoring buffers and windows
if &shortmess =~ 'A'
  set shortmess=aoOA
else
  set shortmess=aoO
endif
"...
" restore original values
set shortmess=filnxtToOSI
```
Using `=` instead of `+=` to add the extra options that prevent *hit prompts* is an error because missing flags like `t` will actually trigger prompts.
