### PR TITLE
CI: Always reset `&columns` and `&lines` for GUI builds

### DIFF
--- a/src/testdir/runtest.vim
+++ b/src/testdir/runtest.vim
@@ -56,10 +56,17 @@ silent! endwhile
 " In the GUI we can always change the screen size.
 if has('gui_running')
   if has('gui_gtk')
-    " to keep screendump size unchanged
+    " Use e.g. SetUp() and TearDown() to change "&guifont" when needed;
+    " otherwise, keep the following value to match current screendumps.
     set guifont=Monospace\ 10
   endif
-  set columns=80 lines=25
+
+  func s:SetDefaultOptionsForGUIBuilds()
+    set columns=80 lines=25
+  endfunc
+else
+  func s:SetDefaultOptionsForGUIBuilds()
+  endfunc
 endif
 
 " Check that the screen size is at least 24 x 80 characters.
@@ -271,6 +278,9 @@ func RunTheTest(test)
   " The test may change the current directory. Save and restore the
   " directory after executing the test.
   let save_cwd = getcwd()
+
+  " Permit "SetUp()" implementations to override default settings.
+  call s:SetDefaultOptionsForGUIBuilds()
 
   if exists("*SetUp")
     try

--- a/src/testdir/test_highlight.vim
+++ b/src/testdir/test_highlight.vim
@@ -1144,6 +1144,17 @@ endfunc
 
 " Test for the hlset() function
 func Test_hlset()
+  " FIXME: With GVim, _current_ test cases that are run before this one may
+  "	influence the result of calling "hlset(hlget())", depending on what
+  "	"&guifont" is set to.  For example, introduce SetUp() as follows:
+  "
+  " if CanRunVimInTerminal() && has('gui_running') && has('gui_gtk')
+  "   def SetUp()
+  "     set guifont=Monospace\ 10
+  "   enddef
+  " endif
+  "
+  "	and see "E416: Missing equal sign: ... line 4" for this test case.
   let lines =<< trim END
     call assert_equal(0, hlset(test_null_list()))
     call assert_equal(0, hlset([]))


### PR DESCRIPTION
Ensure that `&columns` and `&lines` are always set to their  
default values before calling `SetUp()`, if any, for EACH  
test run by a GUI build to avoid yet-to-be-run tests from  
inheriting possibly changed values (after window resizing)  
and leading to broken assumptions about available estate and
occasional test failures.
