### PR TITLE
fix: (after 9.1.1430) When gVim starts, the GUI control code is displayed on the console

### DIFF
--- a/src/window.c
+++ b/src/window.c
@@ -6227,7 +6227,7 @@ shell_new_columns(void)
     if (!skip_win_fix_scroll)
 	win_fix_scroll(TRUE);
 #ifdef FEAT_GUI
-    if (gui.in_use)
+    if (gui.in_use && !gui.starting)
     {
 	if (scroll_region)
 	    scroll_region_reset();


### PR DESCRIPTION
https://github.com/vim/vim/pull/17442#issuecomment-2945554703