### PR TITLE
Add NGINX directive for background cache updates

### DIFF
--- a/runtime/syntax/nginx.vim
+++ b/runtime/syntax/nginx.vim
@@ -389,6 +389,7 @@ syn keyword ngxDirective proxy_buffering
 syn keyword ngxDirective proxy_buffers
 syn keyword ngxDirective proxy_busy_buffers_size
 syn keyword ngxDirective proxy_cache
+syn keyword ngxDirective proxy_cache_background_update
 syn keyword ngxDirective proxy_cache_bypass
 syn keyword ngxDirective proxy_cache_convert_head
 syn keyword ngxDirective proxy_cache_key


### PR DESCRIPTION
Docs: https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_cache_background_update

> Note; I also did a quick spot check for other possible proxy related feature additions around version `1.11.10`, but `proxy_cache_background_update` seems the to be only one