### PR TITLE
avoid redundant sort of already sorted compl list

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -1494,11 +1494,6 @@ ins_compl_build_pum(void)
     int		is_cpt_completion = (cpt_sources_array != NULL);
     int		need_sort = FALSE;
     int		has_scores = FALSE;
-    int		update_shown_match = fuzzy_filter;
-
-    if (fuzzy_filter && ctrl_x_mode_normal()
-      && compl_leader.string == NULL && compl_shown_match->cp_score > 0)
-	update_shown_match = FALSE;
 
     // Need to build the popup menu list.
     compl_match_arraysize = 0;

--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -1492,8 +1492,6 @@ ins_compl_build_pum(void)
     int		*match_count = NULL;
     int		is_forward = compl_shows_dir_forward();
     int		is_cpt_completion = (cpt_sources_array != NULL);
-    int		need_sort = FALSE;
-    int		has_scores = FALSE;
 
     // Need to build the popup menu list.
     compl_match_arraysize = 0;


### PR DESCRIPTION
Problem: fuzzy completion always sorts even when list is already ordered
Solution: detect if scores are in descending order to skip unnecessary sorting