### PR TITLE
Refactor os_win32.c to remove calls to STRLEN()

### DIFF
--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -3674,12 +3674,11 @@ mch_exit(int r)
 #endif
 
 #ifdef VIMDLL
+    if (vimrun_path_allocated)
+	vim_free(vimrun_path.string);
+
     if (gui.in_use || gui.starting)
-    {
-	if (vimrun_path_allocated)
-	    vim_free(vimrun_path.string);
 	mch_exit_g(r);
-    }
     else
 	mch_exit_c(r);
 #elif defined(FEAT_GUI_MSWIN)
@@ -3741,10 +3740,15 @@ fname_case(
 
 	if (q != NULL)
 	{
-	    size_t  namelen = STRLEN(name);
+	    if (len > 0)
+		vim_strncpy(name, q, len - 1);
+	    else
+	    {
+		size_t  namelen = STRLEN(name);
+		if (namelen >= STRLEN(q))
+		    vim_strncpy(name, q, namelen);
+	    }
 
-	    if (len > 0 || namelen >= STRLEN(q))
-		vim_strncpy(name, q, (len > 0) ? len - 1 : namelen);
 	    vim_free(q);
 	}
     }

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -164,7 +164,8 @@ static int write_input_record_buffer(INPUT_RECORD* irEvents, int nLength);
 #ifdef FEAT_GUI_MSWIN
 static int s_dont_use_vimrun = TRUE;
 static int need_vimrun_warning = FALSE;
-static char *vimrun_path = "vimrun ";
+static string_T vimrun_path = {(char_u *)"vimrun ", 7};
+static int vimrun_path_allocated = FALSE;
 #endif
 
 static int win32_getattrs(char_u *name);
@@ -3019,37 +3020,58 @@ mch_init_g(void)
     Rows = 25;
     Columns = 80;
 
-    // Look for 'vimrun'
+    // Look for 'vimrun'.
     {
-	char_u vimrun_location[_MAX_PATH + 4];
+	char_u	vimrun_location[_MAX_PATH + 4];
+	size_t	exe_pathlen = (size_t)(gettail(exe_name) - exe_name);
 
-	// First try in same directory as gvim.exe
-	STRCPY(vimrun_location, exe_name);
-	STRCPY(gettail(vimrun_location), "vimrun.exe");
-	if (mch_getperm(vimrun_location) >= 0)
+	// Note: 10 is length of 'vimrun.exe'.
+	if (exe_pathlen + 10 >= sizeof(vimrun_location))
 	{
-	    char  *p;
-
-	    if (*skiptowhite(vimrun_location) != NUL)
-	    {
-		// Enclose path with white space in double quotes.
-		mch_memmove(vimrun_location + 1, vimrun_location,
-						 STRLEN(vimrun_location) + 1);
-		*vimrun_location = '"';
-		STRCPY(gettail(vimrun_location), "vimrun\" ");
-	    }
-	    else
-		STRCPY(gettail(vimrun_location), "vimrun ");
-
-	    p = (char *)vim_strsave(vimrun_location);
-	    if (p != NULL)
-	    {
-		vimrun_path = p;
+	    if (executable_exists("vimrun.exe", NULL, TRUE, FALSE))
 		s_dont_use_vimrun = FALSE;
-	    }
 	}
-	else if (executable_exists("vimrun.exe", NULL, TRUE, FALSE))
-	    s_dont_use_vimrun = FALSE;
+	else
+	{
+	    // First try in same directory as gvim.exe.
+	    if (exe_pathlen > 0)
+		vim_strncpy(vimrun_location, exe_name, exe_pathlen);
+	    STRCPY(vimrun_location + exe_pathlen, "vimrun.exe");
+
+	    if (mch_getperm(vimrun_location) >= 0)
+	    {
+		char_u  *p;
+		size_t  plen;
+
+		if (exe_pathlen > 0 && *skiptowhite(vimrun_location) != NUL)
+		{
+		    // Enclose path with white space in double quotes.
+		    plen = vim_snprintf_safelen(
+			(char *)vimrun_location,
+			sizeof(vimrun_location),
+			"\"%.*svimrun\" ",
+			(int)exe_pathlen, exe_name);
+		}
+		else
+		{
+		    // Remove the suffix ('.exe').
+		    vimrun_location[exe_pathlen + 6] = ' ';
+		    vimrun_location[exe_pathlen + 7] = NUL;
+		    plen = exe_pathlen + 7;
+		}
+
+		p = vim_strnsave(vimrun_location, plen);
+		if (p != NULL)
+		{
+		    vimrun_path.string = p;
+		    vimrun_path.length = plen;
+		    vimrun_path_allocated = TRUE;
+		    s_dont_use_vimrun = FALSE;
+		}
+	    }
+	    else if (executable_exists("vimrun.exe", NULL, TRUE, FALSE))
+		s_dont_use_vimrun = FALSE;
+	}
 
 	// Don't give the warning for a missing vimrun.exe right now, but only
 	// when vimrun was supposed to be used.  Don't bother people that do
@@ -3059,7 +3081,7 @@ mch_init_g(void)
     }
 
     /*
-     * If "finstr.exe" doesn't exist, use "grep -n" for 'grepprg'.
+     * If "findstr.exe" doesn't exist, use "grep -n" for 'grepprg'.
      * Otherwise the default "findstr /n" is used.
      */
     if (!executable_exists("findstr.exe", NULL, TRUE, FALSE))
@@ -3653,10 +3675,16 @@ mch_exit(int r)
 
 #ifdef VIMDLL
     if (gui.in_use || gui.starting)
+    {
+	if (vimrun_path_allocated)
+	    vim_free(vimrun_path.string);
 	mch_exit_g(r);
+    }
     else
 	mch_exit_c(r);
 #elif defined(FEAT_GUI_MSWIN)
+    if (vimrun_path_allocated)
+	vim_free(vimrun_path.string);
     mch_exit_g(r);
 #else
     mch_exit_c(r);
@@ -3695,12 +3723,10 @@ fname_case(
     char_u	*name,
     int		len)
 {
-    int	    flen;
     WCHAR   *p;
     WCHAR   buf[_MAX_PATH + 1];
 
-    flen = (int)STRLEN(name);
-    if (flen == 0)
+    if (*name == NUL)
 	return;
 
     slash_adjust(name);
@@ -3715,8 +3741,10 @@ fname_case(
 
 	if (q != NULL)
 	{
-	    if (len > 0 || flen >= (int)STRLEN(q))
-		vim_strncpy(name, q, (len > 0) ? len - 1 : flen);
+	    size_t  namelen = STRLEN(name);
+
+	    if (len > 0 || namelen >= STRLEN(q))
+		vim_strncpy(name, q, (len > 0) ? len - 1 : namelen);
 	    vim_free(q);
 	}
     }
@@ -5678,7 +5706,7 @@ mch_call_shell(
 #ifdef FEAT_GUI_MSWIN
 		((gui.in_use || gui.starting) ?
 		    (!s_dont_use_vimrun && p_stmp ?
-			STRLEN(vimrun_path) : STRLEN(p_sh) + STRLEN(p_shcf))
+			vimrun_path.length : STRLEN(p_sh) + STRLEN(p_shcf))
 		    : 0) +
 #endif
 		STRLEN(p_sh) + STRLEN(p_shcf) + STRLEN(cmd) + 10;
@@ -5714,7 +5742,7 @@ mch_call_shell(
 		    // Use vimrun to execute the command.  It opens a console
 		    // window, which can be closed without killing Vim.
 		    vim_snprintf((char *)newcmd, cmdlen, "%s%s%s %s %s",
-			    vimrun_path,
+			    vimrun_path.string,
 			    (msg_silent != 0 || (options & SHELL_DOOUT))
 								 ? "-s " : "",
 			    p_sh, p_shcf, cmd);
@@ -8111,9 +8139,9 @@ copy_extattr(char_u *from, char_u *to)
     if (fromf == NULL || tof == NULL)
 	goto theend;
     STRCPY(fromf, "\\??\\");
-    STRCAT(fromf, from);
+    STRCPY(fromf + STRLEN_LITERAL("\\??\\"), from);
     STRCPY(tof, "\\??\\");
-    STRCAT(tof, to);
+    STRCPY(tof + STRLEN_LITERAL("\\??\\"), to);
 
     // Convert the names to wide characters.
     fromw = enc_to_utf16(fromf, NULL);


### PR DESCRIPTION
In `mch_init_g()`:
-> refactor to remove calls to `STRLEN()`.
-> use `vim_strnsave()` instead of `vim_strsave()`.
-> set a flag if `vimrun_path` is stored in allocated memory so it can be freed at exit.
In `mch_exit()` free `vimrun_path` if it was stored in allocated memory.
In `fname_case()` make a small optimisation by measuring the length of `name` only if needed.
In `copy_extattr()` make a small optimisation by replacing call to `STRCAT()` with `STRCPY()`.
