### PR TITLE
Small optimisation listing usercmds

### DIFF
--- a/src/testdir/Make_all.mak
+++ b/src/testdir/Make_all.mak
@@ -109,6 +109,7 @@ NEW_TESTS = \
 	test_cmdwin \
 	test_codestyle \
 	test_command_count \
+	test_command_list \
 	test_comments \
 	test_comparators \
 	test_compiler \
@@ -394,6 +395,7 @@ NEW_TESTS_RES = \
 	test_cmdwin.res \
 	test_codestyle.res \
 	test_command_count.res \
+	test_command_list.res \
 	test_comments.res \
 	test_comparators.res \
 	test_conceal.res \

--- a/src/testdir/test_command_list.vim
+++ b/src/testdir/test_command_list.vim
@@ -1,0 +1,20 @@
+" Test for listing user commands.
+
+func Test_command_list_0()
+  " Check space padding of attribute and name in command list
+  set vbs&
+  command! ShortCommand echo "ShortCommand"
+  command! VeryMuchLongerCommand echo "VeryMuchLongerCommand"
+
+  redi @"> | com | redi END
+  pu
+
+  let bl = matchbufline(bufnr('%'), "^    ShortCommand      0", 1, '$')
+  call assert_false(bl == [])
+  let bl = matchbufline(bufnr('%'), "^    VeryMuchLongerCommand 0", 1, '$')
+  call assert_false(bl == [])
+
+  bwipe!
+  delcommand ShortCommand
+  delcommand VeryMuchLongerCommand
+endfunc

--- a/src/usercmd.c
+++ b/src/usercmd.c
@@ -600,17 +600,21 @@ uc_list(char_u *name, size_t name_len)
 		msg_putchar('|');
 		--len;
 	    }
-	    while (len-- > 0)
-		msg_putchar(' ');
+	    if (len != 0)
+		msg_puts(&"    "[4 - len]);
 
 	    msg_outtrans_attr(cmd->uc_name, HL_ATTR(HLF_D));
 	    len = (int)cmd->uc_namelen + 4;
 
-	    do
+	    if (len < 21)
 	    {
-		msg_putchar(' ');
-		++len;
-	    } while (len < 22);
+		// Field padding spaces   12345678901234567
+		static char spaces[18] = "                 ";
+		msg_puts(&spaces[len - 4]);
+		len = 21;
+	    }
+	    msg_putchar(' ');
+	    ++len;
 
 	    // "over" is how much longer the name is than the column width for
 	    // the name, we'll try to align what comes after.


### PR DESCRIPTION
Issue #17402 reports an internal MS compiler error with the only suggestion to modify the code in the reported location, which was the function `uc_list()` in `usercmd.c`.

This change applies a small optimisation to the field padding when using `:command` in `uc_list()`. This is sufficient to allow VIM to compile successfully with the current VS 17.14.4, and likely earlier versions of VS 17.14.

There may be an option to abstract field padding, with spaces or other characters, for some other places, along with how the padding is used. For example, placing something on the screen or adding it to a buffer for later use.