### PR TITLE
Fix #17449: fuzzy score to be non-negative when match exists

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -4413,6 +4413,10 @@ fuzzy_match_compute_score(
     // Apply unmatched penalty
     unmatched = strSz - numMatches;
     score += UNMATCHED_LETTER_PENALTY * unmatched;
+    // In a long string, not all matches may be found due to the recursion limit.
+    // If at least one match is found, reset the score to a non-negative value.
+    if (score < 0 && numMatches > 0)
+	score = 0;
 
     // Apply ordering bonuses
     for (i = 0; i < numMatches; ++i)

--- a/src/testdir/test_matchfuzzy.vim
+++ b/src/testdir/test_matchfuzzy.vim
@@ -125,7 +125,7 @@ func Test_matchfuzzypos()
   call assert_equal([[], [], []], matchfuzzypos([], 'abc'))
 
   " match in a long string
-  call assert_equal([[repeat('x', 300) .. 'abc'], [[300, 301, 302]], [-60]],
+  call assert_equal([[repeat('x', 300) .. 'abc'], [[300, 301, 302]], [155]],
         \ matchfuzzypos([repeat('x', 300) .. 'abc'], 'abc'))
 
   " preference for camel case match
@@ -258,7 +258,7 @@ func Test_matchfuzzypos_mbyte()
   call assert_equal([[], [], []], ['세 마리의 작은 돼지', '마리의', '마리의 작은', '작은 돼지']->matchfuzzypos('파란 하늘'))
 
   " match in a long string
-  call assert_equal([[repeat('ぶ', 300) .. 'ẼẼẼ'], [[300, 301, 302]], [-110]],
+  call assert_equal([[repeat('ぶ', 300) .. 'ẼẼẼ'], [[300, 301, 302]], [105]],
         \ matchfuzzypos([repeat('ぶ', 300) .. 'ẼẼẼ'], 'ẼẼẼ'))
   " preference for camel case match
   call assert_equal([['xѳѵҁxxѳѴҁ'], [[6, 7, 8]], [219]], matchfuzzypos(['xѳѵҁxxѳѴҁ'], 'ѳѵҁ'))


### PR DESCRIPTION
The fuzzy algorithm may miss some matches in long strings due to recursion limits. As a result, the score can end up negative even when matches exist. In such cases, reset the score to ensure it is non-negative.

Fixes https://github.com/vim/vim/issues/17449


There's a related issue tracked in (https://github.com/vim/vim/issues/17449)(https://github.com/vim/vim/issues/17449), where fuzzy sorting doesn't occur when the completion menu first opens because `compl_leader` is empty.
Keeping the leader empty seems to be an intentional design choice by Bram to avoid unnecessary string comparisons.
However, it can be problematic for fuzzy sorting — particularly for `omnifunc` and `userfunc` — if the returned list isn't already pre-sorted by relevance.
I'm punting on this for now, as users can manually apply `matchfuzzy()` inside their `userfunc` if needed.
