### PR TITLE
Prevent out of bounds read in function insertchar

### DIFF
--- a/src/edit.c
+++ b/src/edit.c
@@ -2197,7 +2197,7 @@ insertchar(
 	    i -= middle_len;
 
 	    // Check some expected things before we go on
-	    if (i >= 0 && lead_end[end_len - 1] == end_comment_pending)
+	    if (i >= 0 && end_len > 0 && lead_end[end_len - 1] == end_comment_pending)
 	    {
 		// Backspace over all the stuff we want to replace
 		backspace_until_column(i);


### PR DESCRIPTION
In function insertchar, we have the following code:
```c
end_len = copy_option_part(&p, lead_end, COM_MAX_LEN, ",");
...
if (i >= 0 && end_len > 0 && lead_end[end_len - 1] == end_comment_pending)
``` 

When parsing the end-comment leader, end_len can be zero if copy_option_part() writes no characters. 
The existing check unconditionally accessed lead_end[end_len-1], causing potential underflow when end_len == 0.

This change adds an end_len > 0 guard to ensure we only index lead_end if there is at least one character.