### PR TITLE
runtime(zimbu): set commentstring option

### DIFF
--- a/runtime/ftplugin/zimbu.vim
+++ b/runtime/ftplugin/zimbu.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin file
 " Language:	Zimbu
 " Maintainer:	The Vim Project <https://github.com/vim/vim>
-" Last Change:	2023 Aug 10
+" Last Change:	2025 Jun 08
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Only do this when not done yet for this buffer
@@ -16,7 +16,7 @@ let b:did_ftplugin = 1
 let s:cpo_save = &cpo
 set cpo-=C
 
-let b:undo_ftplugin = "setl fo< com< ofu< efm< tw< et< sts< sw< | if has('vms') | setl isk< | endif"
+let b:undo_ftplugin = "setl fo< com< cms< ofu< efm< tw< et< sts< sw< | if has('vms') | setl isk< | endif"
 
 " Set 'formatoptions' to break comment lines but not other lines,
 " and insert the comment leader when hitting <CR> or using "o".
@@ -30,6 +30,7 @@ endif
 " Set 'comments' to format dashed lists in comments.
 " And to keep Zudocu comment characters.
 setlocal comments=sO:#\ -,mO:#\ \ ,exO:#/,s:/*,m:\ ,ex:*/,:#=,:#-,:#%,:#
+setlocal commentstring=#\ %s
 
 setlocal errorformat^=%f\ line\ %l\ col\ %c:\ %m,ERROR:\ %m
 


### PR DESCRIPTION
Based on the [zimbu language spec](https://www.moolenaar.net/z/zimbu/spec/zimbu.html#White%32Space%32and%32Comments_Comments)