### PR TITLE
runtime(lprolog): set com, cms options for lambda prolog

### DIFF
--- a/runtime/ftplugin/lprolog.vim
+++ b/runtime/ftplugin/lprolog.vim
@@ -2,7 +2,8 @@
 " Language:     LambdaProlog (Teyjus)
 " Maintainer:   Markus Mottl  <markus.mottl@gmail.com>
 " URL:          http://www.ocaml.info/vim/ftplugin/lprolog.vim
-" Last Change:  2025 Apr 16
+" Last Change:  2025 Jun 08 - set 'comments', 'commentstring'
+"               2025 Apr 16
 "               2025 Apr 16 - set 'cpoptions' for line continuation
 "               2023 Aug 28 - added undo_ftplugin (Vim Project)
 "               2006 Feb 05
@@ -26,7 +27,9 @@ setlocal efm=%+A./%f:%l.%c:\ %m
 " Formatting of comments
 setlocal formatprg=fmt\ -w75\ -p\\%
 
-let b:undo_ftplugin = "setlocal efm< fp<"
+setlocal comments=s1:/*,mb:*,ex:*/,:% commentstring=%\ %s
+
+let b:undo_ftplugin = "setlocal efm< fp< com< cms<"
 
 " Add mappings, unless the user didn't want this.
 if !exists("no_plugin_maps") && !exists("no_lprolog_maps")


### PR DESCRIPTION
The syntax is akin to regular prolog, and examples can be found [here](https://github.com/teyjus/teyjus/blob/5cb51538beee8b1ad6dbc47ee14d7491fefa6021/lyacc/blists.mod#L59)