### PR TITLE
runtime(plsql): set com, cms options

### DIFF
--- a/runtime/ftplugin/plsql.vim
+++ b/runtime/ftplugin/plsql.vim
@@ -4,14 +4,19 @@
 " Previous Maintainer: Jeff Lanzarotta (jefflanzarotta at yahoo dot com)
 " Previous Maintainer: C. Laurence Gonsalves (clgonsal@kami.com)
 " URL: https://github.com/lee-lindley/vim_plsql_syntax
-" Last Change: Feb 19, 2025
+" Last Change: Jun 08, 2025
 " History:  Enno Konfekt move handling of optional syntax folding from syntax
 "               file to ftplugin
 
 if exists("b:did_ftplugin") | finish | endif
 let b:did_ftplugin = 1
 
+setlocal commentstring=--\ %s
+setlocal comments=sO:*\ -,mO:*\ \ ,exO:*/,s1:/*,mb:*,ex:*/,:--
+
+let b:undo_ftplugin = "setl com< cms<"
+
 if get(g:,"plsql_fold",0) == 1
     setlocal foldmethod=syntax
-    let b:undo_ftplugin = "setl fdm< "
+    let b:undo_ftplugin .= "|setl fdm< "
 endif


### PR DESCRIPTION
It uses the same `--` syntax as SQL, plus `/* */` for multiline comments