### PR TITLE
runtime(ishd): set com, cms options

### DIFF
--- a/runtime/ftplugin/ishd.vim
+++ b/runtime/ftplugin/ishd.vim
@@ -2,7 +2,7 @@
 " Language:		InstallShield (ft=ishd)
 " Maintainer:		Doug Kearns <dougkearns@gmail.com>
 " Previous Maintainer:	Johannes Zellner <johannes@zellner.org>
-" Last Change:		2024 Jan 14
+" Last Change:		2025 Jun 08
 
 if exists("b:did_ftplugin") | finish | endif
 let b:did_ftplugin = 1
@@ -12,8 +12,10 @@ let s:cpo_save = &cpo
 set cpo-=C
 
 setlocal foldmethod=syntax
+setlocal commentstring=//\ %s
+setlocal comments=sO:*\ -,mO:*\ \ ,exO:*/,s1:/*,mb:*,ex:*/,://
 
-let b:undo_ftplugin = "setl fdm<"
+let b:undo_ftplugin = "setl fdm< com< cms"
 
 " matchit support
 if exists("loaded_matchit")


### PR DESCRIPTION
Uses C style comments according to the syntax file, and [this manual page](https://docs.revenera.com/installshield22helplib/Subsystems/installshield22langref/helplibrary/LangrefWriting_comments.htm)