### PR TITLE
Delete Dialog objects with no reference

### DIFF
--- a/src/gui_haiku.cc
+++ b/src/gui_haiku.cc
@@ -3820,7 +3820,9 @@ gui_mch_font_dialog(font_family* family, font_style* style, float* size)
 #if defined(FEAT_GUI_DIALOG)
 	// gui.vimWindow->Unlock();
     VimSelectFontDialog *dialog = new VimSelectFontDialog(family, style, size);
-    return dialog->Go();
+    bool ret = dialog->Go();
+	delete dialog;
+	return ret;
 #else
     return NOFONT;
 #endif // FEAT_GUI_DIALOG
@@ -4917,7 +4919,9 @@ gui_mch_dialog(
 {
     VimDialog *dialog = new VimDialog(type, (char*)title, (char*)message,
 	    (char*)buttons, dfltbutton, (char*)textfield, ex_cmd);
-    return dialog->Go();
+    bool ret = dialog->Go();
+    delete dialog;
+	return ret;
 }
 
 #endif // FEAT_GUI_DIALOG


### PR DESCRIPTION
Hi,

In the functions `gui_mch_dialog` and `gui_mch_font_dialog`, `Dialog` objects are created but never escape the function scope. The call to `dialog->Go()` only returns a boolean value and does not retain any reference to the `Dialog` object itself, which may lead to potential memory leak.

Fix this by deleting the object after using it.