### PR TITLE
Session has wrong arglist with :tcd and :arglocal

### DIFF
--- a/src/arglist.c
+++ b/src/arglist.c
@@ -561,7 +561,7 @@ check_arg_idx(win_T *win)
 }
 
 /*
- * ":args", ":argslocal" and ":argsglobal".
+ * ":args", ":arglocal" and ":argglobal".
  */
     void
 ex_args(exarg_T *eap)

--- a/src/session.c
+++ b/src/session.c
@@ -301,6 +301,7 @@ put_view_curpos(FILE *fd, win_T *wp, char *spaces)
 put_view(
     FILE	*fd,
     win_T	*wp,
+    tabpage_T	*tp,
     int		add_edit,	     // add ":edit" command to view
     unsigned	*flagp,		     // vop_flags or ssop_flags
     int		current_arg_idx,     // current argument index of the window,
@@ -328,6 +329,7 @@ put_view(
 	if (ses_arglist(fd, "arglocal", &wp->w_alist->al_ga,
 			flagp == &vop_flags
 			|| !(*flagp & SSOP_CURDIR)
+			|| tp->tp_localdir != NULL
 			|| wp->w_localdir != NULL, flagp) == FAIL)
 	    return FAIL;
     }
@@ -899,7 +901,8 @@ makeopens(
 	{
 	    if (!ses_do_win(wp))
 		continue;
-	    if (put_view(fd, wp, wp != edited_win, &ssop_flags, cur_arg_idx,
+	    if (put_view(fd, wp, tp, wp != edited_win, &ssop_flags,
+							 cur_arg_idx,
 #ifdef FEAT_TERMINAL
 							 &terminal_bufs
 #else
@@ -1335,8 +1338,8 @@ ex_mkrc(exarg_T	*eap)
 	    }
 	    else
 	    {
-		failed |= (put_view(fd, curwin, !using_vdir, flagp, -1, NULL)
-								      == FAIL);
+		failed |= (put_view(fd, curwin, curtab, !using_vdir, flagp, -1,
+								NULL) == FAIL);
 	    }
 	    if (put_line(fd, "let &g:so = s:so_save | let &g:siso = s:siso_save")
 								      == FAIL)

--- a/src/testdir/test_mksession.vim
+++ b/src/testdir/test_mksession.vim
@@ -32,6 +32,42 @@ func Test__mksession_arglocal()
   call delete('Xtest_mks.out')
 endfunc
 
+func Test_mksession_arglocal_localdir()
+  call mkdir('Xa', 'R')
+  call writefile(['This is Xb'], 'Xa/Xb.txt', 'D')
+  let olddir = getcwd()
+  let oldargs = argv()
+
+  for tabpage in [v:false, v:true]
+    let msg = tabpage ? 'tabpage-local' : 'window-local'
+
+    exe tabpage ? 'tabnew' : 'botright new'
+    exe tabpage ? 'tcd Xa' : 'lcd Xa'
+    let localdir = getcwd()
+    arglocal
+    $argadd Xb.txt
+    let localargs = argv()
+    exe tabpage ? 'tabprev' : 'wincmd p'
+    call assert_equal(olddir, getcwd(), msg)
+    call assert_equal(oldargs, argv(), msg)
+    mksession! Xtest_mks_localdir.out
+    exe tabpage ? '+tabclose' : '$close'
+    bwipe! Xa/Xb.txt
+
+    source Xtest_mks_localdir.out
+    exe tabpage ? 'tabnext' : 'wincmd b'
+    call assert_equal(localdir, getcwd(), msg)
+    call assert_equal(localargs, argv(), msg)
+    $argument
+    call assert_equal('This is Xb', getline(1), msg)
+
+    bwipe!
+    call assert_equal(olddir, getcwd(), msg)
+    call assert_equal(oldargs, argv(), msg)
+    call delete('Xtest_mks_localdir.out')
+  endfor
+endfunc
+
 func Test_mksession()
   tabnew
   let wrap_save = &wrap


### PR DESCRIPTION
Problem:  Session has wrong arglist with :tcd and :arglocal.
Solution: Also use absolute path for :argadd when there is tabpage-local
          directory.

related: neovim/neovim#34405
