### PR TITLE
Crash when pressing backspace with fuzzy completion

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -1415,17 +1415,19 @@ cp_compare_nearest(const void* a, const void* b)
     static void
 set_fuzzy_score(void)
 {
-    if (compl_leader.string != NULL && compl_leader.length > 0)
-    {
-	compl_T *compl = compl_first_match;
+    compl_T *compl;
 
-	do
-	{
-	    compl->cp_score = fuzzy_match_str(compl->cp_str.string,
-		    compl_leader.string);
-	    compl = compl->cp_next;
-	} while (compl != NULL && !is_first_match(compl));
-    }
+    if (!compl_first_match
+	    || compl_leader.string == NULL || compl_leader.length == 0)
+	return;
+
+    compl = compl_first_match;
+    do
+    {
+	compl->cp_score = fuzzy_match_str(compl->cp_str.string,
+		compl_leader.string);
+	compl = compl->cp_next;
+    } while (compl != NULL && !is_first_match(compl));
 }
 
 /*
@@ -1434,11 +1436,12 @@ set_fuzzy_score(void)
     static void
 sort_compl_match_list(int (*compare)(const void *, const void *))
 {
-    compl_T     *compl = compl_first_match->cp_prev;
+    compl_T     *compl;
 
     if (!compl_first_match || is_first_match(compl_first_match->cp_next))
 	return;
 
+    compl = compl_first_match->cp_prev;
     ins_compl_make_linear();
     if (compl_shows_dir_forward())
     {

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -4754,4 +4754,28 @@ func Test_complete_unloaded_buf_refresh_always()
   delfunc TestComplete
 endfunc
 
+func Test_complete_fuzzy_omnifunc_backspace()
+  let g:do_complete = v:false
+  func Omni_test(findstart, base)
+    if a:findstart
+      let g:do_complete = !g:do_complete
+    endif
+    if g:do_complete
+      return a:findstart ? 0 : [#{word: a:base .. 'def'}, #{word: a:base .. 'ghi'}]
+    endif
+    return a:findstart ? -3 : {}
+  endfunc
+
+  new
+  setlocal omnifunc=Omni_test
+  setlocal completeopt=menuone,fuzzy,noinsert
+  call setline(1, 'abc')
+  call feedkeys("A\<C-X>\<C-O>\<BS>\<Esc>0", 'tx!')
+  call assert_equal('ab', getline(1))
+
+  bwipe!
+  delfunc Omni_test
+  unlet g:do_complete
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab nofoldenable


### PR DESCRIPTION
Problem:  Crash when pressing backspace with fuzzy completion.
Solution: Don't dereference compl_first_match when it's NULL.

related: neovim/neovim#34419
