### PR TITLE
potential buffer-underflow with invalid hl_id

### DIFF
--- a/src/highlight.c
+++ b/src/highlight.c
@@ -3689,6 +3689,8 @@ syn_id2attr(int hl_id)
     hl_group_T	*sgp;
 
     hl_id = syn_get_final_id(hl_id);
+    // shouldn't happen
+    assert(hl_id > 0);
     sgp = &HL_TABLE()[hl_id - 1];	    // index is ID minus one
 
 #ifdef FEAT_GUI
@@ -3716,6 +3718,8 @@ syn_id2colors(int hl_id, guicolor_T *fgp, guicolor_T *bgp)
     hl_group_T	*sgp;
 
     hl_id = syn_get_final_id(hl_id);
+    // shouldn't happen
+    assert(hl_id > 0);
     sgp = &HL_TABLE()[hl_id - 1];	    // index is ID minus one
 
     *fgp = sgp->sg_gui_fg;
@@ -3734,6 +3738,8 @@ syn_id2cterm_bg(int hl_id, int *fgp, int *bgp)
     hl_group_T	*sgp;
 
     hl_id = syn_get_final_id(hl_id);
+    // shouldn't happen
+    assert(hl_id > 0);
     sgp = &HL_TABLE()[hl_id - 1];	    // index is ID minus one
     *fgp = sgp->sg_cterm_fg - 1;
     *bgp = sgp->sg_cterm_bg - 1;


### PR DESCRIPTION
Problem:  potential buffer-underflow with invalid hl_id
Solution: verify the return-code of syn_get_final_id()

As a safety check, syn_get_final_id() may return zero when either the provided hl_id is zero or larger than expected.

However, many callers of syn_get_final_id() do not check that the return value is larger than zero but re-use the returned highlight id directly like this:

  hl_id = syn_get_final_id(hl_id);
  sgp = &HL_TABLE()[hl_id - 1];	    // index is ID minus one

in which case, this would cause a buffer underrun and an access violation.

Let's check for this value directly.  When the callers expect a highlighting attribute directly, and don't provide an easy way to error out, let's just instead use the very-first entry from the HL_TABLE() macro.

fixes: #17475