### PR TITLE
docs: add more pointers to 'completeopt'

### DIFF
--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -659,6 +659,9 @@ and one of the CTRL-X commands.  You exit CTRL-X mode by typing a key that is
 not a valid CTRL-X mode command.  Valid keys are the CTRL-X command itself,
 CTRL-N (next), and CTRL-P (previous).
 
+By default, the possible completions are showed in a menu and the first
+completion is inserted into the text. This can be adjusted with 'completeopt'.
+
 To get the current completion information, |complete_info()| can be used.
 Also see the 'infercase' option if you want to adjust the case of the match.
 

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2249,6 +2249,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 		    completion in the preview window.  Only works in
 		    combination with "menu" or "menuone".
 
+	This option does not apply to |cmdline-completion|. See 'wildoptions'
+	for that.
+
 					*'completepopup'* *'cpp'*
 'completepopup' 'cpp'	string (default empty)
 			global
@@ -9809,6 +9812,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 'wildoptions' 'wop'	string	(default "")
 			global
 	A list of words that change how |cmdline-completion| is done.
+
 	The following values are supported:
 	  fuzzy		Use |fuzzy-matching| to find completion matches. When
 			this value is specified, wildcard expansion will not
@@ -9825,6 +9829,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 			is displayed per line.  Often used tag kinds are:
 				d	#define
 				f	function
+
+	This option does not apply to |ins-completion|. See 'completeopt' for
+	that.
 
 						*'winaltkeys'* *'wak'*
 'winaltkeys' 'wak'	string	(default "menu")


### PR DESCRIPTION
Before this commit, I had trouble finding information about configuring the insert mode completion. In particular, it was not clear that the 'wildopt' config that I already had in my vimrc does not apply here.

Also, `insert.txt` barely mentioned 'completeopt' except when describing popups (I was more interested in bash-like behavior where the unique prefix of all completions is completed first).

I'm hoping these edits will make the relevant docs easier to find.