### PR TITLE
Prefer new style `commentstring` for groff

### DIFF
--- a/runtime/ftplugin/groff.vim
+++ b/runtime/ftplugin/groff.vim
@@ -12,7 +12,7 @@ let b:nroff_is_groff = 1
 runtime! ftplugin/nroff.vim
 
 setlocal commentstring=\\#\ %s
-setlocal comments.=b:.\\\",b:\\#,b:\\\"
+setlocal comments=b:.\\\",b:\\#,b:\\\"
 
 let b:undo_ftplugin .= '| unlet! b:nroff_is_groff'
 let b:did_ftplugin = 1

--- a/runtime/ftplugin/groff.vim
+++ b/runtime/ftplugin/groff.vim
@@ -12,7 +12,7 @@ let b:nroff_is_groff = 1
 runtime! ftplugin/nroff.vim
 
 setlocal commentstring=\\#\ %s
-setlocal comments=b:.\\\",b:\\#,b:\\\"
+setlocal comments=:\\#,:.\\\",:\\\",:'\\\",:'''
 
 let b:undo_ftplugin .= '| unlet! b:nroff_is_groff'
 let b:did_ftplugin = 1

--- a/runtime/ftplugin/groff.vim
+++ b/runtime/ftplugin/groff.vim
@@ -11,5 +11,8 @@ let b:nroff_is_groff = 1
 
 runtime! ftplugin/nroff.vim
 
+setlocal commentstring=\\#\ %s
+setlocal comments.=b:.\\\",b:\\#,b:\\\"
+
 let b:undo_ftplugin .= '| unlet! b:nroff_is_groff'
 let b:did_ftplugin = 1

--- a/runtime/ftplugin/nroff.vim
+++ b/runtime/ftplugin/nroff.vim
@@ -19,7 +19,7 @@ let s:cpo_save = &cpo
 set cpo&vim
 
 setlocal commentstring=.\\\"\ %s
-setlocal comments=:.\\\"
+setlocal comments=b:.\\\",b:\\\"
 setlocal sections+=Sh
 setlocal define=.\s*de
 

--- a/runtime/ftplugin/nroff.vim
+++ b/runtime/ftplugin/nroff.vim
@@ -19,7 +19,7 @@ let s:cpo_save = &cpo
 set cpo&vim
 
 setlocal commentstring=.\\\"\ %s
-setlocal comments=b:.\\\",b:\\\"
+setlocal comments=:.\\\",:\\\",:'\\\",:'''
 setlocal sections+=Sh
 setlocal define=.\s*de
 


### PR DESCRIPTION
As per the [documentation](https://www.gnu.org/software/groff/manual/groff.html.node/Comments.html) provided by the GNU project, the preferred comment style for groff files should be `\# %s`.