### PR TITLE
runtime: Open should open file names with spaces in Windows

### DIFF
--- a/runtime/plugin/openPlugin.vim
+++ b/runtime/plugin/openPlugin.vim
@@ -12,14 +12,14 @@ g:loaded_openPlugin = 1
 
 import autoload 'dist/vim9.vim'
 
-command -complete=shellcmd -nargs=1 Launch vim9.Launch(trim(<q-args>))
+command -complete=shellcmd -nargs=1 Launch vim9.Launch(trim(<f-args>))
 
-# technically, -nargs=1 is correct, but this throws E480: No match 
+# technically, -nargs=1 is correct, but this throws E480: No match
 # when the argument contains a wildchar on Windows
-command -complete=file -nargs=* Open vim9.Open(trim(<q-args>))
+command -complete=file -nargs=* Open vim9.Open(trim(<f-args>))
 # Use URLOpen when you don't want completion to happen
 # (or because you want to avoid cmdline-special)
-command -nargs=1 URLOpen vim9.Open(trim(<q-args>))
+command -nargs=1 URLOpen vim9.Open(trim(<f-args>))
 
 const no_gx = get(g:, "nogx", get(g:, "netrw_nogx", false))
 if !no_gx


### PR DESCRIPTION
Use \<f-args> instead of \<q-args> in commands:

- :Open
- :Launch
- :URLOpen

Fixes #17468