### PR TITLE
Fix compile warnings for unused parameter

### DIFF
--- a/src/option.c
+++ b/src/option.c
@@ -8847,7 +8847,7 @@ option_set_callback_func(char_u *optval UNUSED, callback_T *optcb UNUSED)
  * Process the new 'showtabpanel' option value.
  */
     char *
-did_set_showtabpanel(optset_T *args)
+did_set_showtabpanel(optset_T *args UNUSED)
 {
     shell_new_columns();
     return NULL;

--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -3565,7 +3565,7 @@ did_set_rulerformat(optset_T *args)
  * Process the new 'tabpanelopt' option value.
  */
     char *
-did_set_tabpanelopt(optset_T *args)
+did_set_tabpanelopt(optset_T *args UNUSED)
 {
     if (tabpanelopt_changed() == FAIL)
 	return e_invalid_argument;


### PR DESCRIPTION
Compiling on archlinux using gcc 15.1.1 gives these warnings:
>gcc -Iproto -DHAVE_CONFIG_H -I/usr/include/gtk-2.0 -I/usr/lib/x86_64-linux-gnu/gtk-2.0/include -I/usr/include/pango-1.0 -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -I/usr/include/harfbuzz -I/usr/include/freetype2 -I/usr/include/libpng16 -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/fribidi -I/usr/include/uuid -I/usr/include/cairo -I/usr/include/pixman-1 -I/usr/include/gdk-pixbuf-2.0 -I/usr/include/x86_64-linux-gnu -I/usr/include/atk-1.0 -pthread -c -I.       -Iproto -DHAVE_CONFIG_H     -O -Wall -Wextra -Wshadow -Wstrict-prototypes -Wmissing-prototypes -Wno-deprecated-declarations -Wno-error=missing-field-initializers -Wno-error=maybe-uninitialized -Wunused-but-set-variable  -g -O0 -DABORT_ON_INTERNAL_ERROR -DEXITFREE -fsanitize-recover=all -fsanitize=address -fsanitize=undefined -fno-omit-frame-pointer     -D_REENTRANT       -o objects/option.o option.c
option.c: In function 'did_set_showtabpanel':
option.c:8850:32: warning: unused parameter 'args' [-Wunused-parameter]
 8850 | did_set_showtabpanel(optset_T *args)
      |                      ~~~~~~~~~~^~~~
gcc -Iproto -DHAVE_CONFIG_H -I/usr/include/gtk-2.0 -I/usr/lib/x86_64-linux-gnu/gtk-2.0/include -I/usr/include/pango-1.0 -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -I/usr/include/harfbuzz -I/usr/include/freetype2 -I/usr/include/libpng16 -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/fribidi -I/usr/include/uuid -I/usr/include/cairo -I/usr/include/pixman-1 -I/usr/include/gdk-pixbuf-2.0 -I/usr/include/x86_64-linux-gnu -I/usr/include/atk-1.0 -pthread -c -I.       -Iproto -DHAVE_CONFIG_H     -O -Wall -Wextra -Wshadow -Wstrict-prototypes -Wmissing-prototypes -Wno-deprecated-declarations -Wno-error=missing-field-initializers -Wno-error=maybe-uninitialized -Wunused-but-set-variable  -g -O0 -DABORT_ON_INTERNAL_ERROR -DEXITFREE -fsanitize-recover=all -fsanitize=address -fsanitize=undefined -fno-omit-frame-pointer     -D_REENTRANT       -o objects/optionstr.o optionstr.c
optionstr.c: In function 'did_set_tabpanelopt':
optionstr.c:3568:31: warning: unused parameter 'args' [-Wunused-parameter]
 3568 | did_set_tabpanelopt(optset_T *args)
      |                     ~~~~~~~~~~^~~~
