### PR TITLE
runtime(comment): toggle comment fails if commentstring has \

### DIFF
--- a/runtime/pack/dist/opt/comment/autoload/comment.vim
+++ b/runtime/pack/dist/opt/comment/autoload/comment.vim
@@ -19,7 +19,7 @@ export def Toggle(...args: list<string>): string
     if empty(&cms) || !&ma | return '' | endif
     var cms = substitute(substitute(&cms, '\S\zs%s\s*', ' %s', ''), '%s\ze\S', '%s ', '')
     var [lnum1, lnum2] = [line("'["), line("']")]
-    var cms_l = split(escape(cms, '*.'), '\s*%s\s*')
+    var cms_l = split(escape(cms, '*.\'), '\s*%s\s*')
 
     var first_col = indent(lnum1)
     var start_col = getpos("'[")[2] - 1

--- a/src/testdir/test_plugin_comment.vim
+++ b/src/testdir/test_plugin_comment.vim
@@ -59,6 +59,29 @@ func Test_basic_uncomment()
   call assert_equal(["# vim9script", "", "def Hello()", '  echo "Hello"', "enddef"], result)
 endfunc
 
+func Test_backward_slash_uncomment()
+  CheckScreendump
+  let lines =<< trim END
+    .\" .TL Test backward slash uncomment
+  END
+
+  let input_file = "Test_backward_slash_uncomment_input.mom"
+  call writefile(lines, input_file, "D")
+
+  let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
+
+  call term_sendkeys(buf, "gcc")
+  let output_file = "backward_slash_uncomment_test.mom"
+  call term_sendkeys(buf, $":w {output_file}\<CR>")
+  defer delete(output_file)
+
+  call StopVimInTerminal(buf)
+
+  let result = readfile(output_file)
+
+  call assert_equal([".TL Test backward slash uncomment"], result)
+endfunc
+
 func Test_caseinsensitive_uncomment()
   CheckScreendump
   let lines =<< trim END


### PR DESCRIPTION
groff could be commented using `.\"` or `.\#` and comment plugin fails to
uncomment such things.