### PR TITLE
Remove an obsolete item from todo.txt

### DIFF
--- a/runtime/doc/todo.txt
+++ b/runtime/doc/todo.txt
@@ -2202,8 +2202,6 @@ displayed in a window should return the value that's stored for that buffer.
 
 ":he ctrl_u" can be auto-corrected to ":he ctrl-u".
 
-Diff mode out of sync. (Gary Johnson, 2010 Aug 4)
-
 Win32: completion of file name ":e c:\!test" results in ":e c:\\!test", which
 does not work. (Nieko Maatjes, 2009 Jan 8, Ingo Karkat, 2009 Jan 22)
 


### PR DESCRIPTION
I cannot reproduce this defect.  The replication instructions refer to Mercurial version numbers and I no longer use Mercurial for my Vim source.  I tried comparing various Git versions of the example file, src/if_cscope.c, and still couldn't reproduce the defect.  Also, I use Vim's diff mode a lot and haven't seen such a problem in a long time. I am confident that it has been fixed.

Therefore, the item should be removed from todo.txt.