### PR TITLE
runtime(netrw): remove g:netrw_quiet and reindent to 4 spaces

### DIFF
--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -805,9 +805,7 @@ fun! netrw#Explore(indx,dosplit,style,...)
       keepalt NetrwKeepj call s:SetupNetrwStatusLine('%f %h%m%r%=%9*%{NetrwStatusLine()}')
 
     else
-      if !exists("g:netrw_quiet")
-        call netrw#msg#Notify('WARNING', 'your vim needs the +path_extra feature for Exploring with **!')
-      endif
+      call netrw#msg#Notify('WARNING', 'your vim needs the +path_extra feature for Exploring with **!')
       if has("clipboard") && g:netrw_clipboard
         if @* != keepregstar | sil! let @* = keepregstar | endif
         if @+ != keepregplus | sil! let @+ = keepregplus | endif
@@ -1099,7 +1097,7 @@ fun! netrw#Obtain(islocal,fname,...)
         call netrw#os#Execute(s:netrw_silentxfer."%!".s:netrw_ftp_cmd." -i ".netrw#os#Escape(g:netrw_machine,1))
       endif
       " If the result of the ftp operation isn't blank, show an error message (tnx to Doug Claar)
-      if getline(1) !~ "^$" && !exists("g:netrw_quiet") && getline(1) !~ '^Trying '
+      if getline(1) !~ "^$" && getline(1) !~ '^Trying '
         let debugkeep= &debug
         setl debug=msg
         call netrw#msg#Notify('ERROR', getline(1))
@@ -1157,9 +1155,7 @@ fun! netrw#Obtain(islocal,fname,...)
       call netrw#os#Execute(s:netrw_silentxfer."%!".s:netrw_ftp_cmd." ".g:netrw_ftp_options)
       " If the result of the ftp operation isn't blank, show an error message (tnx to Doug Claar)
       if getline(1) !~ "^$"
-        if !exists("g:netrw_quiet")
           call netrw#msg#Notify('ERROR', getline(1))
-        endif
       endif
 
     elseif b:netrw_method == 9
@@ -1177,9 +1173,7 @@ fun! netrw#Obtain(islocal,fname,...)
 
     else
       " protocol recognized but not supported for Obtain (yet?)
-      if !exists("g:netrw_quiet")
         call netrw#msg#Notify('ERROR', 'current protocol not supported for obtaining file')
-      endif
       return
     endif
 
@@ -1551,709 +1545,695 @@ endfun
 "         =3 obtain file, but leave in temporary format
 fun! netrw#NetRead(mode,...)
 
-  " NetRead: save options {{{3
-  call s:NetrwOptionsSave("w:")
-  call s:NetrwOptionsSafe(0)
-  call s:RestoreCursorline()
-  " NetrwSafeOptions sets a buffer up for a netrw listing, which includes buflisting off.
-  " However, this setting is not wanted for a remote editing session.  The buffer should be "nofile", still.
-  setl bl
+    " NetRead: save options {{{3
+    call s:NetrwOptionsSave("w:")
+    call s:NetrwOptionsSafe(0)
+    call s:RestoreCursorline()
+    " NetrwSafeOptions sets a buffer up for a netrw listing, which includes buflisting off.
+    " However, this setting is not wanted for a remote editing session.  The buffer should be "nofile", still.
+    setl bl
 
-  " NetRead: interpret mode into a readcmd {{{3
-  if     a:mode == 0 " read remote file before current line
-    let readcmd = "0r"
-  elseif a:mode == 1 " read file after current line
-    let readcmd = "r"
-  elseif a:mode == 2 " replace with remote file
-    let readcmd = "%r"
-  elseif a:mode == 3 " skip read of file (leave as temporary)
-    let readcmd = "t"
-  else
-    exe a:mode
-    let readcmd = "r"
-  endif
-  let ichoice = (a:0 == 0)? 0 : 1
-
-  " NetRead: get temporary filename {{{3
-  let tmpfile= s:GetTempfile("")
-  if tmpfile == ""
-    return
-  endif
-
-  while ichoice <= a:0
-
-    " attempt to repeat with previous host-file-etc
-    if exists("b:netrw_lastfile") && a:0 == 0
-      let choice = b:netrw_lastfile
-      let ichoice= ichoice + 1
-
+    " NetRead: interpret mode into a readcmd {{{3
+    if     a:mode == 0 " read remote file before current line
+        let readcmd = "0r"
+    elseif a:mode == 1 " read file after current line
+        let readcmd = "r"
+    elseif a:mode == 2 " replace with remote file
+        let readcmd = "%r"
+    elseif a:mode == 3 " skip read of file (leave as temporary)
+        let readcmd = "t"
     else
-      exe "let choice= a:" . ichoice
+        exe a:mode
+        let readcmd = "r"
+    endif
+    let ichoice = (a:0 == 0)? 0 : 1
 
-      if match(choice,"?") == 0
-        " give help
-        echomsg 'NetRead Usage:'
-        echomsg ':Nread machine:path                         uses rcp'
-        echomsg ':Nread "machine path"                       uses ftp   with <.netrc>'
-        echomsg ':Nread "machine id password path"           uses ftp'
-        echomsg ':Nread dav://machine[:port]/path            uses cadaver'
-        echomsg ':Nread fetch://machine/path                 uses fetch'
-        echomsg ':Nread ftp://[user@]machine[:port]/path     uses ftp   autodetects <.netrc>'
-        echomsg ':Nread http://[user@]machine/path           uses http  wget'
-        echomsg ':Nread file:///path                         uses elinks'
-        echomsg ':Nread https://[user@]machine/path          uses http  wget'
-        echomsg ':Nread rcp://[user@]machine/path            uses rcp'
-        echomsg ':Nread rsync://machine[:port]/path          uses rsync'
-        echomsg ':Nread scp://[user@]machine[[:#]port]/path  uses scp'
-        echomsg ':Nread sftp://[user@]machine[[:#]port]/path uses sftp'
-        sleep 4
-        break
+    " NetRead: get temporary filename {{{3
+    let tmpfile= s:GetTempfile("")
+    if tmpfile == ""
+        return
+    endif
 
-      elseif match(choice,'^"') != -1
-        " Reconstruct Choice if choice starts with '"'
-        if match(choice,'"$') != -1
-          " case "..."
-          let choice= strpart(choice,1,strlen(choice)-2)
+    while ichoice <= a:0
+
+        " attempt to repeat with previous host-file-etc
+        if exists("b:netrw_lastfile") && a:0 == 0
+            let choice = b:netrw_lastfile
+            let ichoice= ichoice + 1
+
         else
-          "  case "... ... ..."
-          let choice      = strpart(choice,1,strlen(choice)-1)
-          let wholechoice = ""
+            exe "let choice= a:" . ichoice
 
-          while match(choice,'"$') == -1
-            let wholechoice = wholechoice . " " . choice
-            let ichoice     = ichoice + 1
-            if ichoice > a:0
-              if !exists("g:netrw_quiet")
-                call netrw#msg#Notify('ERROR', printf('Unbalanced string in filename "%s"', wholechoice))
-              endif
-              return
+            if match(choice,"?") == 0
+                " give help
+                echomsg 'NetRead Usage:'
+                echomsg ':Nread machine:path                         uses rcp'
+                echomsg ':Nread "machine path"                       uses ftp   with <.netrc>'
+                echomsg ':Nread "machine id password path"           uses ftp'
+                echomsg ':Nread dav://machine[:port]/path            uses cadaver'
+                echomsg ':Nread fetch://machine/path                 uses fetch'
+                echomsg ':Nread ftp://[user@]machine[:port]/path     uses ftp   autodetects <.netrc>'
+                echomsg ':Nread http://[user@]machine/path           uses http  wget'
+                echomsg ':Nread file:///path                         uses elinks'
+                echomsg ':Nread https://[user@]machine/path          uses http  wget'
+                echomsg ':Nread rcp://[user@]machine/path            uses rcp'
+                echomsg ':Nread rsync://machine[:port]/path          uses rsync'
+                echomsg ':Nread scp://[user@]machine[[:#]port]/path  uses scp'
+                echomsg ':Nread sftp://[user@]machine[[:#]port]/path uses sftp'
+                sleep 4
+                break
+
+            elseif match(choice,'^"') != -1
+                " Reconstruct Choice if choice starts with '"'
+                if match(choice,'"$') != -1
+                    " case "..."
+                    let choice= strpart(choice,1,strlen(choice)-2)
+                else
+                    "  case "... ... ..."
+                    let choice      = strpart(choice,1,strlen(choice)-1)
+                    let wholechoice = ""
+
+                    while match(choice,'"$') == -1
+                        let wholechoice = wholechoice . " " . choice
+                        let ichoice     = ichoice + 1
+                        if ichoice > a:0
+                            call netrw#msg#Notify('ERROR', printf('Unbalanced string in filename "%s"', wholechoice))
+                            return
+                        endif
+                        let choice= a:{ichoice}
+                    endwhile
+                    let choice= strpart(wholechoice,1,strlen(wholechoice)-1) . " " . strpart(choice,0,strlen(choice)-1)
+                endif
             endif
-            let choice= a:{ichoice}
-          endwhile
-          let choice= strpart(wholechoice,1,strlen(wholechoice)-1) . " " . strpart(choice,0,strlen(choice)-1)
         endif
-      endif
-    endif
 
-    let ichoice= ichoice + 1
+        let ichoice= ichoice + 1
 
-    " NetRead: Determine method of read (ftp, rcp, etc) {{{3
-    call s:NetrwMethod(choice)
-    if !exists("b:netrw_method") || b:netrw_method < 0
-      return
-    endif
-    if !s:NetrwValidateHostname(g:netrw_machine)
-        call netrw#msg#Notify('ERROR', printf('Rejecting invalid hostname: <%s>', g:netrw_machine))
-        return
-    endif
-    let tmpfile= s:GetTempfile(b:netrw_fname) " apply correct suffix
+        " NetRead: Determine method of read (ftp, rcp, etc) {{{3
+        call s:NetrwMethod(choice)
+        if !exists("b:netrw_method") || b:netrw_method < 0
+            return
+        endif
+        if !s:NetrwValidateHostname(g:netrw_machine)
+            call netrw#msg#Notify('ERROR', printf('Rejecting invalid hostname: <%s>', g:netrw_machine))
+            return
+        endif
+        let tmpfile= s:GetTempfile(b:netrw_fname) " apply correct suffix
 
-    " Check whether or not NetrwBrowse() should be handling this request
-    if choice =~ "^.*[\/]$" && b:netrw_method != 5 && choice !~ '^https\=://'
-      NetrwKeepj call s:NetrwBrowse(0,choice)
-      return
-    endif
+        " Check whether or not NetrwBrowse() should be handling this request
+        if choice =~ "^.*[\/]$" && b:netrw_method != 5 && choice !~ '^https\=://'
+            NetrwKeepj call s:NetrwBrowse(0,choice)
+            return
+        endif
 
-    " ============
-    " NetRead: Perform Protocol-Based Read {{{3
-    " ===========================
-    if exists("g:netrw_silent") && g:netrw_silent == 0 && &ch >= 1
-      echo "(netrw) Processing your read request..."
-    endif
+        " ============
+        " NetRead: Perform Protocol-Based Read {{{3
+        " ===========================
+        if exists("g:netrw_silent") && g:netrw_silent == 0 && &ch >= 1
+            echo "(netrw) Processing your read request..."
+        endif
 
-    ".........................................
-    " NetRead: (rcp)  NetRead Method #1 {{{3
-    if  b:netrw_method == 1 " read with rcp
-      " ER: nothing done with g:netrw_uid yet?
-      " ER: on Win2K" rcp machine[.user]:file tmpfile
-      " ER: when machine contains '.' adding .user is required (use $USERNAME)
-      " ER: the tmpfile is full path: rcp sees C:\... as host C
-      if s:netrw_has_nt_rcp == 1
-        if exists("g:netrw_uid") && ( g:netrw_uid != "" )
-          let uid_machine = g:netrw_machine .'.'. g:netrw_uid
+        ".........................................
+        " NetRead: (rcp)  NetRead Method #1 {{{3
+        if  b:netrw_method == 1 " read with rcp
+            " ER: nothing done with g:netrw_uid yet?
+            " ER: on Win2K" rcp machine[.user]:file tmpfile
+            " ER: when machine contains '.' adding .user is required (use $USERNAME)
+            " ER: the tmpfile is full path: rcp sees C:\... as host C
+            if s:netrw_has_nt_rcp == 1
+                if exists("g:netrw_uid") && ( g:netrw_uid != "" )
+                    let uid_machine = g:netrw_machine .'.'. g:netrw_uid
+                else
+                    " Any way needed it machine contains a '.'
+                    let uid_machine = g:netrw_machine .'.'. $USERNAME
+                endif
+            else
+                if exists("g:netrw_uid") && ( g:netrw_uid != "" )
+                    let uid_machine = g:netrw_uid .'@'. g:netrw_machine
+                else
+                    let uid_machine = g:netrw_machine
+                endif
+            endif
+            call netrw#os#Execute(s:netrw_silentxfer."!".g:netrw_rcp_cmd." ".s:netrw_rcpmode." ".netrw#os#Escape(uid_machine.":".b:netrw_fname,1)." ".netrw#os#Escape(tmpfile,1))
+            let result           = s:NetrwGetFile(readcmd, tmpfile, b:netrw_method)
+            let b:netrw_lastfile = choice
+
+            ".........................................
+        " NetRead: (ftp + <.netrc>)  NetRead Method #2 {{{3
+        elseif b:netrw_method  == 2          " read with ftp + <.netrc>
+            let netrw_fname= b:netrw_fname
+            NetrwKeepj call s:SaveBufVars()|new|NetrwKeepj call s:RestoreBufVars()
+            let filtbuf= bufnr("%")
+            setl ff=unix
+            NetrwKeepj put =g:netrw_ftpmode
+            if exists("g:netrw_ftpextracmd")
+                NetrwKeepj put =g:netrw_ftpextracmd
+            endif
+            call setline(line("$")+1,'get "'.netrw_fname.'" '.tmpfile)
+            if exists("g:netrw_port") && g:netrw_port != ""
+                call netrw#os#Execute(s:netrw_silentxfer."%!".s:netrw_ftp_cmd." -i ".netrw#os#Escape(g:netrw_machine,1)." ".netrw#os#Escape(g:netrw_port,1))
+            else
+                call netrw#os#Execute(s:netrw_silentxfer."%!".s:netrw_ftp_cmd." -i ".netrw#os#Escape(g:netrw_machine,1))
+            endif
+            " If the result of the ftp operation isn't blank, show an error message (tnx to Doug Claar)
+            if getline(1) !~ "^$" && getline(1) !~ '^Trying '
+                let debugkeep = &debug
+                setl debug=msg
+                call netrw#msg#Notify('ERROR', getline(1))
+                let &debug    = debugkeep
+            endif
+            call s:SaveBufVars()
+            keepj bd!
+            if bufname("%") == "" && getline("$") == "" && line('$') == 1
+                " needed when one sources a file in a nolbl setting window via ftp
+                q!
+            endif
+            call s:RestoreBufVars()
+            let result           = s:NetrwGetFile(readcmd, tmpfile, b:netrw_method)
+            let b:netrw_lastfile = choice
+
+            ".........................................
+        " NetRead: (ftp + machine,id,passwd,filename)  NetRead Method #3 {{{3
+        elseif b:netrw_method == 3           " read with ftp + machine, id, passwd, and fname
+            " Construct execution string (four lines) which will be passed through filter
+            let netrw_fname= escape(b:netrw_fname,g:netrw_fname_escape)
+            NetrwKeepj call s:SaveBufVars()|new|NetrwKeepj call s:RestoreBufVars()
+            let filtbuf= bufnr("%")
+            setl ff=unix
+            if exists("g:netrw_port") && g:netrw_port != ""
+                NetrwKeepj put ='open '.g:netrw_machine.' '.g:netrw_port
+            else
+                NetrwKeepj put ='open '.g:netrw_machine
+            endif
+
+            if exists("g:netrw_uid") && g:netrw_uid != ""
+                if exists("g:netrw_ftp") && g:netrw_ftp == 1
+                    NetrwKeepj put =g:netrw_uid
+                    if exists("s:netrw_passwd")
+                        NetrwKeepj put ='\"'.s:netrw_passwd.'\"'
+                    endif
+                elseif exists("s:netrw_passwd")
+                    NetrwKeepj put ='user \"'.g:netrw_uid.'\" \"'.s:netrw_passwd.'\"'
+                endif
+            endif
+
+            if exists("g:netrw_ftpmode") && g:netrw_ftpmode != ""
+                NetrwKeepj put =g:netrw_ftpmode
+            endif
+            if exists("g:netrw_ftpextracmd")
+                NetrwKeepj put =g:netrw_ftpextracmd
+            endif
+            NetrwKeepj put ='get \"'.netrw_fname.'\" '.tmpfile
+
+            " perform ftp:
+            " -i       : turns off interactive prompting from ftp
+            " -n  unix : DON'T use <.netrc>, even though it exists
+            " -n  win32: quit being obnoxious about password
+            NetrwKeepj norm! 1G"_dd
+            call netrw#os#Execute(s:netrw_silentxfer."%!".s:netrw_ftp_cmd." ".g:netrw_ftp_options)
+            " If the result of the ftp operation isn't blank, show an error message (tnx to Doug Claar)
+            if getline(1) !~ "^$"
+                call netrw#msg#Notify('ERROR', getline(1))
+            endif
+            call s:SaveBufVars()|keepj bd!|call s:RestoreBufVars()
+            let result           = s:NetrwGetFile(readcmd, tmpfile, b:netrw_method)
+            let b:netrw_lastfile = choice
+
+            ".........................................
+        " NetRead: (scp) NetRead Method #4 {{{3
+        elseif     b:netrw_method  == 4      " read with scp
+            if exists("g:netrw_port") && g:netrw_port != ""
+                let useport= " ".g:netrw_scpport." ".g:netrw_port
+            else
+                let useport= ""
+            endif
+            " 'C' in 'C:\path\to\file' is handled as hostname on windows.
+            " This is workaround to avoid mis-handle windows local-path:
+            if g:netrw_scp_cmd =~ '^scp' && has("win32")
+                let tmpfile_get = substitute(tr(tmpfile, '\', '/'), '^\(\a\):[/\\]\(.*\)$', '/\1/\2', '')
+            else
+                let tmpfile_get = tmpfile
+            endif
+            call netrw#os#Execute(s:netrw_silentxfer."!".g:netrw_scp_cmd.useport." ".escape(netrw#os#Escape(g:netrw_machine.":".b:netrw_fname,1),' ')." ".netrw#os#Escape(tmpfile_get,1))
+            let result           = s:NetrwGetFile(readcmd, tmpfile, b:netrw_method)
+            let b:netrw_lastfile = choice
+
+            ".........................................
+        " NetRead: (http) NetRead Method #5 (wget) {{{3
+        elseif     b:netrw_method  == 5
+            if g:netrw_http_cmd == ""
+                call netrw#msg#Notify('ERROR', 'neither the wget nor the fetch command is available')
+                return
+            endif
+
+            if match(b:netrw_fname,"#") == -1 || exists("g:netrw_http_xcmd")
+                " using g:netrw_http_cmd (usually elinks, links, curl, wget, or fetch)
+                if exists("g:netrw_http_xcmd")
+                    call netrw#os#Execute(s:netrw_silentxfer."!".g:netrw_http_cmd." ".netrw#os#Escape(b:netrw_http."://".g:netrw_machine.b:netrw_fname,1)." ".g:netrw_http_xcmd." ".netrw#os#Escape(tmpfile,1))
+                else
+                    call netrw#os#Execute(s:netrw_silentxfer."!".g:netrw_http_cmd." ".netrw#os#Escape(tmpfile,1)." ".netrw#os#Escape(b:netrw_http."://".g:netrw_machine.b:netrw_fname,1))
+                endif
+                let result = s:NetrwGetFile(readcmd, tmpfile, b:netrw_method)
+
+            else
+                " wget/curl/fetch plus a jump to an in-page marker (ie. http://abc/def.html#aMarker)
+                let netrw_html= substitute(b:netrw_fname,"#.*$","","")
+                let netrw_tag = substitute(b:netrw_fname,"^.*#","","")
+                call netrw#os#Execute(s:netrw_silentxfer."!".g:netrw_http_cmd." ".netrw#os#Escape(tmpfile,1)." ".netrw#os#Escape(b:netrw_http."://".g:netrw_machine.netrw_html,1))
+                let result = s:NetrwGetFile(readcmd, tmpfile, b:netrw_method)
+                exe 'NetrwKeepj norm! 1G/<\s*a\s*name=\s*"'.netrw_tag.'"/'."\<CR>"
+            endif
+            let b:netrw_lastfile = choice
+            setl ro nomod
+
+            ".........................................
+        " NetRead: (dav) NetRead Method #6 {{{3
+        elseif     b:netrw_method  == 6
+
+            if !executable(g:netrw_dav_cmd)
+                call netrw#msg#Notify('ERROR', printf('%s is not executable', g:netrw_dav_cmd))
+                return
+            endif
+            if g:netrw_dav_cmd =~ "curl"
+                call netrw#os#Execute(s:netrw_silentxfer."!".g:netrw_dav_cmd." ".netrw#os#Escape("dav://".g:netrw_machine.b:netrw_fname,1)." ".netrw#os#Escape(tmpfile,1))
+            else
+                " Construct execution string (four lines) which will be passed through filter
+                let netrw_fname= escape(b:netrw_fname,g:netrw_fname_escape)
+                new
+                setl ff=unix
+                if exists("g:netrw_port") && g:netrw_port != ""
+                    NetrwKeepj put ='open '.g:netrw_machine.' '.g:netrw_port
+                else
+                    NetrwKeepj put ='open '.g:netrw_machine
+                endif
+                if exists("g:netrw_uid") && exists("s:netrw_passwd") && g:netrw_uid != ""
+                    NetrwKeepj put ='user '.g:netrw_uid.' '.s:netrw_passwd
+                endif
+                NetrwKeepj put ='get '.netrw_fname.' '.tmpfile
+                NetrwKeepj put ='quit'
+
+                " perform cadaver operation:
+                NetrwKeepj norm! 1G"_dd
+                call netrw#os#Execute(s:netrw_silentxfer."%!".g:netrw_dav_cmd)
+                keepj bd!
+            endif
+            let result           = s:NetrwGetFile(readcmd, tmpfile, b:netrw_method)
+            let b:netrw_lastfile = choice
+
+            ".........................................
+        " NetRead: (rsync) NetRead Method #7 {{{3
+        elseif     b:netrw_method  == 7
+            call netrw#os#Execute(s:netrw_silentxfer."!".g:netrw_rsync_cmd." ".netrw#os#Escape(g:netrw_machine.g:netrw_rsync_sep.b:netrw_fname,1)." ".netrw#os#Escape(tmpfile,1))
+            let result           = s:NetrwGetFile(readcmd,tmpfile, b:netrw_method)
+            let b:netrw_lastfile = choice
+
+            ".........................................
+        " NetRead: (fetch) NetRead Method #8 {{{3
+        "    fetch://[user@]host[:http]/path
+        elseif     b:netrw_method  == 8
+            if g:netrw_fetch_cmd == ""
+                call netrw#msg#Notify('ERROR', "fetch command not available")
+                return
+            endif
+            if exists("g:netrw_option") && g:netrw_option =~ ":https\="
+                let netrw_option= "http"
+            else
+                let netrw_option= "ftp"
+            endif
+
+            if exists("g:netrw_uid") && g:netrw_uid != "" && exists("s:netrw_passwd") && s:netrw_passwd != ""
+                call netrw#os#Execute(s:netrw_silentxfer."!".g:netrw_fetch_cmd." ".netrw#os#Escape(tmpfile,1)." ".netrw#os#Escape(netrw_option."://".g:netrw_uid.':'.s:netrw_passwd.'@'.g:netrw_machine."/".b:netrw_fname,1))
+            else
+                call netrw#os#Execute(s:netrw_silentxfer."!".g:netrw_fetch_cmd." ".netrw#os#Escape(tmpfile,1)." ".netrw#os#Escape(netrw_option."://".g:netrw_machine."/".b:netrw_fname,1))
+            endif
+
+            let result          = s:NetrwGetFile(readcmd,tmpfile, b:netrw_method)
+            let b:netrw_lastfile = choice
+            setl ro nomod
+
+            ".........................................
+        " NetRead: (sftp) NetRead Method #9 {{{3
+        elseif     b:netrw_method  == 9
+            call netrw#os#Execute(s:netrw_silentxfer."!".g:netrw_sftp_cmd." ".netrw#os#Escape(g:netrw_machine.":".b:netrw_fname,1)." ".tmpfile)
+            let result          = s:NetrwGetFile(readcmd, tmpfile, b:netrw_method)
+            let b:netrw_lastfile = choice
+
+            ".........................................
+        " NetRead: (file) NetRead Method #10 {{{3
+        elseif      b:netrw_method == 10 && exists("g:netrw_file_cmd")
+            call netrw#os#Execute(s:netrw_silentxfer."!".g:netrw_file_cmd." ".netrw#os#Escape(b:netrw_fname,1)." ".tmpfile)
+            let result           = s:NetrwGetFile(readcmd, tmpfile, b:netrw_method)
+            let b:netrw_lastfile = choice
+
+            ".........................................
+        " NetRead: Complain {{{3
         else
-          " Any way needed it machine contains a '.'
-          let uid_machine = g:netrw_machine .'.'. $USERNAME
+            call netrw#msg#Notify('WARNING', printf('unable to comply with your request<%s>', choice))
         endif
-      else
-        if exists("g:netrw_uid") && ( g:netrw_uid != "" )
-          let uid_machine = g:netrw_uid .'@'. g:netrw_machine
-        else
-          let uid_machine = g:netrw_machine
-        endif
-      endif
-      call netrw#os#Execute(s:netrw_silentxfer."!".g:netrw_rcp_cmd." ".s:netrw_rcpmode." ".netrw#os#Escape(uid_machine.":".b:netrw_fname,1)." ".netrw#os#Escape(tmpfile,1))
-      let result           = s:NetrwGetFile(readcmd, tmpfile, b:netrw_method)
-      let b:netrw_lastfile = choice
+    endwhile
 
-      ".........................................
-    " NetRead: (ftp + <.netrc>)  NetRead Method #2 {{{3
-    elseif b:netrw_method  == 2          " read with ftp + <.netrc>
-      let netrw_fname= b:netrw_fname
-      NetrwKeepj call s:SaveBufVars()|new|NetrwKeepj call s:RestoreBufVars()
-      let filtbuf= bufnr("%")
-      setl ff=unix
-      NetrwKeepj put =g:netrw_ftpmode
-      if exists("g:netrw_ftpextracmd")
-        NetrwKeepj put =g:netrw_ftpextracmd
-      endif
-      call setline(line("$")+1,'get "'.netrw_fname.'" '.tmpfile)
-      if exists("g:netrw_port") && g:netrw_port != ""
-        call netrw#os#Execute(s:netrw_silentxfer."%!".s:netrw_ftp_cmd." -i ".netrw#os#Escape(g:netrw_machine,1)." ".netrw#os#Escape(g:netrw_port,1))
-      else
-        call netrw#os#Execute(s:netrw_silentxfer."%!".s:netrw_ftp_cmd." -i ".netrw#os#Escape(g:netrw_machine,1))
-      endif
-      " If the result of the ftp operation isn't blank, show an error message (tnx to Doug Claar)
-      if getline(1) !~ "^$" && !exists("g:netrw_quiet") && getline(1) !~ '^Trying '
-        let debugkeep = &debug
-        setl debug=msg
-        call netrw#msg#Notify('ERROR', getline(1))
-        let &debug    = debugkeep
-      endif
-      call s:SaveBufVars()
-      keepj bd!
-      if bufname("%") == "" && getline("$") == "" && line('$') == 1
-        " needed when one sources a file in a nolbl setting window via ftp
-        q!
-      endif
-      call s:RestoreBufVars()
-      let result           = s:NetrwGetFile(readcmd, tmpfile, b:netrw_method)
-      let b:netrw_lastfile = choice
-
-      ".........................................
-    " NetRead: (ftp + machine,id,passwd,filename)  NetRead Method #3 {{{3
-    elseif b:netrw_method == 3           " read with ftp + machine, id, passwd, and fname
-      " Construct execution string (four lines) which will be passed through filter
-      let netrw_fname= escape(b:netrw_fname,g:netrw_fname_escape)
-      NetrwKeepj call s:SaveBufVars()|new|NetrwKeepj call s:RestoreBufVars()
-      let filtbuf= bufnr("%")
-      setl ff=unix
-      if exists("g:netrw_port") && g:netrw_port != ""
-        NetrwKeepj put ='open '.g:netrw_machine.' '.g:netrw_port
-      else
-        NetrwKeepj put ='open '.g:netrw_machine
-      endif
-
-      if exists("g:netrw_uid") && g:netrw_uid != ""
-        if exists("g:netrw_ftp") && g:netrw_ftp == 1
-          NetrwKeepj put =g:netrw_uid
-          if exists("s:netrw_passwd")
-            NetrwKeepj put ='\"'.s:netrw_passwd.'\"'
-          endif
-        elseif exists("s:netrw_passwd")
-          NetrwKeepj put ='user \"'.g:netrw_uid.'\" \"'.s:netrw_passwd.'\"'
-        endif
-      endif
-
-      if exists("g:netrw_ftpmode") && g:netrw_ftpmode != ""
-        NetrwKeepj put =g:netrw_ftpmode
-      endif
-      if exists("g:netrw_ftpextracmd")
-        NetrwKeepj put =g:netrw_ftpextracmd
-      endif
-      NetrwKeepj put ='get \"'.netrw_fname.'\" '.tmpfile
-
-      " perform ftp:
-      " -i       : turns off interactive prompting from ftp
-      " -n  unix : DON'T use <.netrc>, even though it exists
-      " -n  win32: quit being obnoxious about password
-      NetrwKeepj norm! 1G"_dd
-      call netrw#os#Execute(s:netrw_silentxfer."%!".s:netrw_ftp_cmd." ".g:netrw_ftp_options)
-      " If the result of the ftp operation isn't blank, show an error message (tnx to Doug Claar)
-      if getline(1) !~ "^$"
-        if !exists("g:netrw_quiet")
-          call netrw#msg#Notify('ERROR', getline(1))
-        endif
-      endif
-      call s:SaveBufVars()|keepj bd!|call s:RestoreBufVars()
-      let result           = s:NetrwGetFile(readcmd, tmpfile, b:netrw_method)
-      let b:netrw_lastfile = choice
-
-      ".........................................
-    " NetRead: (scp) NetRead Method #4 {{{3
-    elseif     b:netrw_method  == 4      " read with scp
-      if exists("g:netrw_port") && g:netrw_port != ""
-        let useport= " ".g:netrw_scpport." ".g:netrw_port
-      else
-        let useport= ""
-      endif
-      " 'C' in 'C:\path\to\file' is handled as hostname on windows.
-      " This is workaround to avoid mis-handle windows local-path:
-      if g:netrw_scp_cmd =~ '^scp' && has("win32")
-        let tmpfile_get = substitute(tr(tmpfile, '\', '/'), '^\(\a\):[/\\]\(.*\)$', '/\1/\2', '')
-      else
-        let tmpfile_get = tmpfile
-      endif
-      call netrw#os#Execute(s:netrw_silentxfer."!".g:netrw_scp_cmd.useport." ".escape(netrw#os#Escape(g:netrw_machine.":".b:netrw_fname,1),' ')." ".netrw#os#Escape(tmpfile_get,1))
-      let result           = s:NetrwGetFile(readcmd, tmpfile, b:netrw_method)
-      let b:netrw_lastfile = choice
-
-      ".........................................
-    " NetRead: (http) NetRead Method #5 (wget) {{{3
-    elseif     b:netrw_method  == 5
-      if g:netrw_http_cmd == ""
-        if !exists("g:netrw_quiet")
-          call netrw#msg#Notify('ERROR', 'neither the wget nor the fetch command is available')
-        endif
-        return
-      endif
-
-      if match(b:netrw_fname,"#") == -1 || exists("g:netrw_http_xcmd")
-        " using g:netrw_http_cmd (usually elinks, links, curl, wget, or fetch)
-        if exists("g:netrw_http_xcmd")
-          call netrw#os#Execute(s:netrw_silentxfer."!".g:netrw_http_cmd." ".netrw#os#Escape(b:netrw_http."://".g:netrw_machine.b:netrw_fname,1)." ".g:netrw_http_xcmd." ".netrw#os#Escape(tmpfile,1))
-        else
-          call netrw#os#Execute(s:netrw_silentxfer."!".g:netrw_http_cmd." ".netrw#os#Escape(tmpfile,1)." ".netrw#os#Escape(b:netrw_http."://".g:netrw_machine.b:netrw_fname,1))
-        endif
-        let result = s:NetrwGetFile(readcmd, tmpfile, b:netrw_method)
-
-      else
-        " wget/curl/fetch plus a jump to an in-page marker (ie. http://abc/def.html#aMarker)
-        let netrw_html= substitute(b:netrw_fname,"#.*$","","")
-        let netrw_tag = substitute(b:netrw_fname,"^.*#","","")
-        call netrw#os#Execute(s:netrw_silentxfer."!".g:netrw_http_cmd." ".netrw#os#Escape(tmpfile,1)." ".netrw#os#Escape(b:netrw_http."://".g:netrw_machine.netrw_html,1))
-        let result = s:NetrwGetFile(readcmd, tmpfile, b:netrw_method)
-        exe 'NetrwKeepj norm! 1G/<\s*a\s*name=\s*"'.netrw_tag.'"/'."\<CR>"
-      endif
-      let b:netrw_lastfile = choice
-      setl ro nomod
-
-      ".........................................
-    " NetRead: (dav) NetRead Method #6 {{{3
-    elseif     b:netrw_method  == 6
-
-      if !executable(g:netrw_dav_cmd)
-        call netrw#msg#Notify('ERROR', printf('%s is not executable', g:netrw_dav_cmd))
-        return
-      endif
-      if g:netrw_dav_cmd =~ "curl"
-        call netrw#os#Execute(s:netrw_silentxfer."!".g:netrw_dav_cmd." ".netrw#os#Escape("dav://".g:netrw_machine.b:netrw_fname,1)." ".netrw#os#Escape(tmpfile,1))
-      else
-        " Construct execution string (four lines) which will be passed through filter
-        let netrw_fname= escape(b:netrw_fname,g:netrw_fname_escape)
-        new
-        setl ff=unix
-        if exists("g:netrw_port") && g:netrw_port != ""
-          NetrwKeepj put ='open '.g:netrw_machine.' '.g:netrw_port
-        else
-          NetrwKeepj put ='open '.g:netrw_machine
-        endif
-        if exists("g:netrw_uid") && exists("s:netrw_passwd") && g:netrw_uid != ""
-          NetrwKeepj put ='user '.g:netrw_uid.' '.s:netrw_passwd
-        endif
-        NetrwKeepj put ='get '.netrw_fname.' '.tmpfile
-        NetrwKeepj put ='quit'
-
-        " perform cadaver operation:
-        NetrwKeepj norm! 1G"_dd
-        call netrw#os#Execute(s:netrw_silentxfer."%!".g:netrw_dav_cmd)
-        keepj bd!
-      endif
-      let result           = s:NetrwGetFile(readcmd, tmpfile, b:netrw_method)
-      let b:netrw_lastfile = choice
-
-      ".........................................
-    " NetRead: (rsync) NetRead Method #7 {{{3
-    elseif     b:netrw_method  == 7
-      call netrw#os#Execute(s:netrw_silentxfer."!".g:netrw_rsync_cmd." ".netrw#os#Escape(g:netrw_machine.g:netrw_rsync_sep.b:netrw_fname,1)." ".netrw#os#Escape(tmpfile,1))
-      let result           = s:NetrwGetFile(readcmd,tmpfile, b:netrw_method)
-      let b:netrw_lastfile = choice
-
-      ".........................................
-    " NetRead: (fetch) NetRead Method #8 {{{3
-    "    fetch://[user@]host[:http]/path
-    elseif     b:netrw_method  == 8
-      if g:netrw_fetch_cmd == ""
-        if !exists("g:netrw_quiet")
-          call netrw#msg#Notify('ERROR', "fetch command not available")
-        endif
-        return
-      endif
-      if exists("g:netrw_option") && g:netrw_option =~ ":https\="
-        let netrw_option= "http"
-      else
-        let netrw_option= "ftp"
-      endif
-
-      if exists("g:netrw_uid") && g:netrw_uid != "" && exists("s:netrw_passwd") && s:netrw_passwd != ""
-        call netrw#os#Execute(s:netrw_silentxfer."!".g:netrw_fetch_cmd." ".netrw#os#Escape(tmpfile,1)." ".netrw#os#Escape(netrw_option."://".g:netrw_uid.':'.s:netrw_passwd.'@'.g:netrw_machine."/".b:netrw_fname,1))
-      else
-        call netrw#os#Execute(s:netrw_silentxfer."!".g:netrw_fetch_cmd." ".netrw#os#Escape(tmpfile,1)." ".netrw#os#Escape(netrw_option."://".g:netrw_machine."/".b:netrw_fname,1))
-      endif
-
-      let result          = s:NetrwGetFile(readcmd,tmpfile, b:netrw_method)
-      let b:netrw_lastfile = choice
-      setl ro nomod
-
-      ".........................................
-    " NetRead: (sftp) NetRead Method #9 {{{3
-    elseif     b:netrw_method  == 9
-      call netrw#os#Execute(s:netrw_silentxfer."!".g:netrw_sftp_cmd." ".netrw#os#Escape(g:netrw_machine.":".b:netrw_fname,1)." ".tmpfile)
-      let result          = s:NetrwGetFile(readcmd, tmpfile, b:netrw_method)
-      let b:netrw_lastfile = choice
-
-      ".........................................
-    " NetRead: (file) NetRead Method #10 {{{3
-    elseif      b:netrw_method == 10 && exists("g:netrw_file_cmd")
-      call netrw#os#Execute(s:netrw_silentxfer."!".g:netrw_file_cmd." ".netrw#os#Escape(b:netrw_fname,1)." ".tmpfile)
-      let result           = s:NetrwGetFile(readcmd, tmpfile, b:netrw_method)
-      let b:netrw_lastfile = choice
-
-      ".........................................
-    " NetRead: Complain {{{3
-    else
-      call netrw#msg#Notify('WARNING', printf('unable to comply with your request<%s>', choice))
+    " NetRead: cleanup {{{3
+    if exists("b:netrw_method")
+        unlet b:netrw_method
+        unlet b:netrw_fname
     endif
-  endwhile
-
-  " NetRead: cleanup {{{3
-  if exists("b:netrw_method")
-    unlet b:netrw_method
-    unlet b:netrw_fname
-  endif
-  if s:FileReadable(tmpfile) && tmpfile !~ '.tar.bz2$' && tmpfile !~ '.tar.gz$' && tmpfile !~ '.zip' && tmpfile !~ '.tar' && readcmd != 't' && tmpfile !~ '.tar.xz$' && tmpfile !~ '.txz'
-    call netrw#fs#Remove(tmpfile)
-  endif
-  NetrwKeepj call s:NetrwOptionsRestore("w:")
+    if s:FileReadable(tmpfile) && tmpfile !~ '.tar.bz2$' && tmpfile !~ '.tar.gz$' && tmpfile !~ '.zip' && tmpfile !~ '.tar' && readcmd != 't' && tmpfile !~ '.tar.xz$' && tmpfile !~ '.txz'
+        call netrw#fs#Remove(tmpfile)
+    endif
+    NetrwKeepj call s:NetrwOptionsRestore("w:")
 
 endfun
 
 " netrw#NetWrite: responsible for writing a file over the net {{{2
 fun! netrw#NetWrite(...) range
 
-  " NetWrite: option handling {{{3
-  let mod= 0
-  call s:NetrwOptionsSave("w:")
-  call s:NetrwOptionsSafe(0)
+    " NetWrite: option handling {{{3
+    let mod= 0
+    call s:NetrwOptionsSave("w:")
+    call s:NetrwOptionsSafe(0)
 
-  " NetWrite: Get Temporary Filename {{{3
-  let tmpfile= s:GetTempfile("")
-  if tmpfile == ""
-    return
-  endif
-
-  if a:0 == 0
-    let ichoice = 0
-  else
-    let ichoice = 1
-  endif
-
-  let curbufname= expand("%")
-  if &binary
-    " For binary writes, always write entire file.
-    " (line numbers don't really make sense for that).
-    " Also supports the writing of tar and zip files.
-    exe "sil NetrwKeepj w! ".fnameescape(v:cmdarg)." ".fnameescape(tmpfile)
-  elseif g:netrw_cygwin
-    " write (selected portion of) file to temporary
-    let cygtmpfile= substitute(tmpfile,g:netrw_cygdrive.'/\(.\)','\1:','')
-    exe "sil NetrwKeepj ".a:firstline."," . a:lastline . "w! ".fnameescape(v:cmdarg)." ".fnameescape(cygtmpfile)
-  else
-    " write (selected portion of) file to temporary
-    exe "sil NetrwKeepj ".a:firstline."," . a:lastline . "w! ".fnameescape(v:cmdarg)." ".fnameescape(tmpfile)
-  endif
-
-  if curbufname == ""
-    " when the file is [No Name], and one attempts to Nwrite it, the buffer takes
-    " on the temporary file's name.  Deletion of the temporary file during
-    " cleanup then causes an error message.
-    0file!
-  endif
-
-  " NetWrite: while choice loop: {{{3
-  while ichoice <= a:0
-
-    " Process arguments: {{{4
-    " attempt to repeat with previous host-file-etc
-    if exists("b:netrw_lastfile") && a:0 == 0
-      let choice = b:netrw_lastfile
-      let ichoice= ichoice + 1
-    else
-      exe "let choice= a:" . ichoice
-
-      " Reconstruct Choice when choice starts with '"'
-      if match(choice,"?") == 0
-        echomsg 'NetWrite Usage:"'
-        echomsg ':Nwrite machine:path                        uses rcp'
-        echomsg ':Nwrite "machine path"                      uses ftp with <.netrc>'
-        echomsg ':Nwrite "machine id password path"          uses ftp'
-        echomsg ':Nwrite dav://[user@]machine/path           uses cadaver'
-        echomsg ':Nwrite fetch://[user@]machine/path         uses fetch'
-        echomsg ':Nwrite ftp://machine[#port]/path           uses ftp  (autodetects <.netrc>)'
-        echomsg ':Nwrite rcp://machine/path                  uses rcp'
-        echomsg ':Nwrite rsync://[user@]machine/path         uses rsync'
-        echomsg ':Nwrite scp://[user@]machine[[:#]port]/path uses scp'
-        echomsg ':Nwrite sftp://[user@]machine/path          uses sftp'
-        sleep 4
-        break
-
-      elseif match(choice,"^\"") != -1
-        if match(choice,"\"$") != -1
-          " case "..."
-          let choice=strpart(choice,1,strlen(choice)-2)
-        else
-          "  case "... ... ..."
-          let choice      = strpart(choice,1,strlen(choice)-1)
-          let wholechoice = ""
-
-          while match(choice,"\"$") == -1
-            let wholechoice= wholechoice . " " . choice
-            let ichoice    = ichoice + 1
-            if choice > a:0
-              if !exists("g:netrw_quiet")
-                call netrw#msg#Notify('ERROR', printf('Unbalanced string in filename "%s"', wholechoice))
-              endif
-              return
-            endif
-            let choice= a:{ichoice}
-          endwhile
-          let choice= strpart(wholechoice,1,strlen(wholechoice)-1) . " " . strpart(choice,0,strlen(choice)-1)
-        endif
-      endif
-    endif
-    let ichoice= ichoice + 1
-
-    " Determine method of write (ftp, rcp, etc) {{{4
-    NetrwKeepj call s:NetrwMethod(choice)
-    if !exists("b:netrw_method") || b:netrw_method < 0
-      return
-    endif
-    if !s:NetrwValidateHostname(g:netrw_machine)
-        call netrw#msg#Notify('ERROR', printf('Rejecting invalid hostname: <%s>', g:netrw_machine))
+    " NetWrite: Get Temporary Filename {{{3
+    let tmpfile= s:GetTempfile("")
+    if tmpfile == ""
         return
     endif
 
-    " =============
-    " NetWrite: Perform Protocol-Based Write {{{3
-    " ============================
-    if exists("g:netrw_silent") && g:netrw_silent == 0 && &ch >= 1
-      echo "(netrw) Processing your write request..."
-    endif
-
-    ".........................................
-    " NetWrite: (rcp) NetWrite Method #1 {{{3
-    if  b:netrw_method == 1
-      if s:netrw_has_nt_rcp == 1
-        if exists("g:netrw_uid") &&  ( g:netrw_uid != "" )
-          let uid_machine = g:netrw_machine .'.'. g:netrw_uid
-        else
-          let uid_machine = g:netrw_machine .'.'. $USERNAME
-        endif
-      else
-        if exists("g:netrw_uid") &&  ( g:netrw_uid != "" )
-          let uid_machine = g:netrw_uid .'@'. g:netrw_machine
-        else
-          let uid_machine = g:netrw_machine
-        endif
-      endif
-      call netrw#os#Execute(s:netrw_silentxfer."!".g:netrw_rcp_cmd." ".s:netrw_rcpmode." ".netrw#os#Escape(tmpfile,1)." ".netrw#os#Escape(uid_machine.":".b:netrw_fname,1))
-      let b:netrw_lastfile = choice
-
-      ".........................................
-    " NetWrite: (ftp + <.netrc>) NetWrite Method #2 {{{3
-    elseif b:netrw_method == 2
-      let netrw_fname = b:netrw_fname
-
-      " formerly just a "new...bd!", that changed the window sizes when equalalways.  Using enew workaround instead
-      let bhkeep      = &l:bh
-      let curbuf      = bufnr("%")
-      setl bh=hide
-      keepj keepalt enew
-
-      setl ff=unix
-      NetrwKeepj put =g:netrw_ftpmode
-      if exists("g:netrw_ftpextracmd")
-        NetrwKeepj put =g:netrw_ftpextracmd
-      endif
-      NetrwKeepj call setline(line("$")+1,'put "'.tmpfile.'" "'.netrw_fname.'"')
-      if exists("g:netrw_port") && g:netrw_port != ""
-        call netrw#os#Execute(s:netrw_silentxfer."%!".s:netrw_ftp_cmd." -i ".netrw#os#Escape(g:netrw_machine,1)." ".netrw#os#Escape(g:netrw_port,1))
-      else
-        call netrw#os#Execute(s:netrw_silentxfer."%!".s:netrw_ftp_cmd." -i ".netrw#os#Escape(g:netrw_machine,1))
-      endif
-      " If the result of the ftp operation isn't blank, show an error message (tnx to Doug Claar)
-      if getline(1) !~ "^$"
-        if !exists("g:netrw_quiet")
-          call netrw#msg#Notify('ERROR', getline(1))
-        endif
-        let mod=1
-      endif
-
-      " remove enew buffer (quietly)
-      let filtbuf= bufnr("%")
-      exe curbuf."b!"
-      let &l:bh            = bhkeep
-      exe filtbuf."bw!"
-
-      let b:netrw_lastfile = choice
-
-      ".........................................
-    " NetWrite: (ftp + machine, id, passwd, filename) NetWrite Method #3 {{{3
-    elseif b:netrw_method == 3
-      " Construct execution string (three or more lines) which will be passed through filter
-      let netrw_fname = b:netrw_fname
-      let bhkeep      = &l:bh
-
-      " formerly just a "new...bd!", that changed the window sizes when equalalways.  Using enew workaround instead
-      let curbuf      = bufnr("%")
-      setl bh=hide
-      keepj keepalt enew
-      setl ff=unix
-
-      if exists("g:netrw_port") && g:netrw_port != ""
-        NetrwKeepj put ='open '.g:netrw_machine.' '.g:netrw_port
-      else
-        NetrwKeepj put ='open '.g:netrw_machine
-      endif
-      if exists("g:netrw_uid") && g:netrw_uid != ""
-        if exists("g:netrw_ftp") && g:netrw_ftp == 1
-          NetrwKeepj put =g:netrw_uid
-          if exists("s:netrw_passwd") && s:netrw_passwd != ""
-            NetrwKeepj put ='\"'.s:netrw_passwd.'\"'
-          endif
-        elseif exists("s:netrw_passwd") && s:netrw_passwd != ""
-          NetrwKeepj put ='user \"'.g:netrw_uid.'\" \"'.s:netrw_passwd.'\"'
-        endif
-      endif
-      NetrwKeepj put =g:netrw_ftpmode
-      if exists("g:netrw_ftpextracmd")
-        NetrwKeepj put =g:netrw_ftpextracmd
-      endif
-      NetrwKeepj put ='put \"'.tmpfile.'\" \"'.netrw_fname.'\"'
-      " save choice/id/password for future use
-      let b:netrw_lastfile = choice
-
-      " perform ftp:
-      " -i       : turns off interactive prompting from ftp
-      " -n  unix : DON'T use <.netrc>, even though it exists
-      " -n  win32: quit being obnoxious about password
-      NetrwKeepj norm! 1G"_dd
-      call netrw#os#Execute(s:netrw_silentxfer."%!".s:netrw_ftp_cmd." ".g:netrw_ftp_options)
-      " If the result of the ftp operation isn't blank, show an error message (tnx to Doug Claar)
-      if getline(1) !~ "^$"
-        if  !exists("g:netrw_quiet")
-          call netrw#msg#Notify('ERROR', getline(1))
-        endif
-        let mod=1
-      endif
-
-      " remove enew buffer (quietly)
-      let filtbuf= bufnr("%")
-      exe curbuf."b!"
-      let &l:bh= bhkeep
-      exe filtbuf."bw!"
-
-      ".........................................
-    " NetWrite: (scp) NetWrite Method #4 {{{3
-    elseif     b:netrw_method == 4
-      if exists("g:netrw_port") && g:netrw_port != ""
-        let useport= " ".g:netrw_scpport." ".fnameescape(g:netrw_port)
-      else
-        let useport= ""
-      endif
-      call netrw#os#Execute(s:netrw_silentxfer."!".g:netrw_scp_cmd.useport." ".netrw#os#Escape(tmpfile,1)." ".netrw#os#Escape(g:netrw_machine.":".b:netrw_fname,1))
-      let b:netrw_lastfile = choice
-
-      ".........................................
-    " NetWrite: (http) NetWrite Method #5 {{{3
-    elseif     b:netrw_method == 5
-      let curl= substitute(g:netrw_http_put_cmd,'\s\+.*$',"","")
-      if executable(curl)
-        let url= g:netrw_choice
-        call netrw#os#Execute(s:netrw_silentxfer."!".g:netrw_http_put_cmd." ".netrw#os#Escape(tmpfile,1)." ".netrw#os#Escape(url,1) )
-      elseif !exists("g:netrw_quiet")
-        call netrw#msg#Notify('ERROR', printf("can't write to http using <%s>", g:netrw_http_put_cmd))
-      endif
-
-      ".........................................
-    " NetWrite: (dav) NetWrite Method #6 (cadaver) {{{3
-    elseif     b:netrw_method == 6
-
-      " Construct execution string (four lines) which will be passed through filter
-      let netrw_fname = escape(b:netrw_fname,g:netrw_fname_escape)
-      let bhkeep      = &l:bh
-
-      " formerly just a "new...bd!", that changed the window sizes when equalalways.  Using enew workaround instead
-      let curbuf      = bufnr("%")
-      setl bh=hide
-      keepj keepalt enew
-
-      setl ff=unix
-      if exists("g:netrw_port") && g:netrw_port != ""
-        NetrwKeepj put ='open '.g:netrw_machine.' '.g:netrw_port
-      else
-        NetrwKeepj put ='open '.g:netrw_machine
-      endif
-      if exists("g:netrw_uid") && exists("s:netrw_passwd") && g:netrw_uid != ""
-        NetrwKeepj put ='user '.g:netrw_uid.' '.s:netrw_passwd
-      endif
-      NetrwKeepj put ='put '.tmpfile.' '.netrw_fname
-
-      " perform cadaver operation:
-      NetrwKeepj norm! 1G"_dd
-      call netrw#os#Execute(s:netrw_silentxfer."%!".g:netrw_dav_cmd)
-
-      " remove enew buffer (quietly)
-      let filtbuf= bufnr("%")
-      exe curbuf."b!"
-      let &l:bh            = bhkeep
-      exe filtbuf."bw!"
-
-      let b:netrw_lastfile = choice
-
-      ".........................................
-    " NetWrite: (rsync) NetWrite Method #7 {{{3
-    elseif     b:netrw_method == 7
-      call netrw#os#Execute(s:netrw_silentxfer."!".g:netrw_rsync_cmd." ".netrw#os#Escape(tmpfile,1)." ".netrw#os#Escape(g:netrw_machine.g:netrw_rsync_sep.b:netrw_fname,1))
-      let b:netrw_lastfile = choice
-
-      ".........................................
-    " NetWrite: (sftp) NetWrite Method #9 {{{3
-    elseif     b:netrw_method == 9
-      let netrw_fname= escape(b:netrw_fname,g:netrw_fname_escape)
-      if exists("g:netrw_uid") &&  ( g:netrw_uid != "" )
-        let uid_machine = g:netrw_uid .'@'. g:netrw_machine
-      else
-        let uid_machine = g:netrw_machine
-      endif
-
-      " formerly just a "new...bd!", that changed the window sizes when equalalways.  Using enew workaround instead
-      let bhkeep = &l:bh
-      let curbuf = bufnr("%")
-      setl bh=hide
-      keepj keepalt enew
-
-      setl ff=unix
-      call setline(1,'put "'.escape(tmpfile,'\').'" '.netrw_fname)
-      let sftpcmd= substitute(g:netrw_sftp_cmd,"%TEMPFILE%",escape(tmpfile,'\'),"g")
-      call netrw#os#Execute(s:netrw_silentxfer."%!".sftpcmd.' '.netrw#os#Escape(uid_machine,1))
-      let filtbuf= bufnr("%")
-      exe curbuf."b!"
-      let &l:bh            = bhkeep
-      exe filtbuf."bw!"
-      let b:netrw_lastfile = choice
-
-      ".........................................
-    " NetWrite: Complain {{{3
+    if a:0 == 0
+        let ichoice = 0
     else
-      call netrw#msg#Notify('WARNING', printf('unable to comply with your request<%s>', choice))
-      let leavemod= 1
+        let ichoice = 1
     endif
-  endwhile
 
-  " NetWrite: Cleanup: {{{3
-  if s:FileReadable(tmpfile)
-    call netrw#fs#Remove(tmpfile)
-  endif
-  call s:NetrwOptionsRestore("w:")
+    let curbufname= expand("%")
+    if &binary
+        " For binary writes, always write entire file.
+        " (line numbers don't really make sense for that).
+        " Also supports the writing of tar and zip files.
+        exe "sil NetrwKeepj w! ".fnameescape(v:cmdarg)." ".fnameescape(tmpfile)
+    elseif g:netrw_cygwin
+        " write (selected portion of) file to temporary
+        let cygtmpfile= substitute(tmpfile,g:netrw_cygdrive.'/\(.\)','\1:','')
+        exe "sil NetrwKeepj ".a:firstline."," . a:lastline . "w! ".fnameescape(v:cmdarg)." ".fnameescape(cygtmpfile)
+    else
+        " write (selected portion of) file to temporary
+        exe "sil NetrwKeepj ".a:firstline."," . a:lastline . "w! ".fnameescape(v:cmdarg)." ".fnameescape(tmpfile)
+    endif
 
-  if a:firstline == 1 && a:lastline == line("$")
-    " restore modifiability; usually equivalent to set nomod
-    let &l:mod= mod
-  elseif !exists("leavemod")
-    " indicate that the buffer has not been modified since last written
-    setl nomod
-  endif
+    if curbufname == ""
+        " when the file is [No Name], and one attempts to Nwrite it, the buffer takes
+        " on the temporary file's name.  Deletion of the temporary file during
+        " cleanup then causes an error message.
+        0file!
+    endif
+
+    " NetWrite: while choice loop: {{{3
+    while ichoice <= a:0
+
+        " Process arguments: {{{4
+        " attempt to repeat with previous host-file-etc
+        if exists("b:netrw_lastfile") && a:0 == 0
+            let choice = b:netrw_lastfile
+            let ichoice= ichoice + 1
+        else
+            exe "let choice= a:" . ichoice
+
+            " Reconstruct Choice when choice starts with '"'
+            if match(choice,"?") == 0
+                echomsg 'NetWrite Usage:"'
+                echomsg ':Nwrite machine:path                        uses rcp'
+                echomsg ':Nwrite "machine path"                      uses ftp with <.netrc>'
+                echomsg ':Nwrite "machine id password path"          uses ftp'
+                echomsg ':Nwrite dav://[user@]machine/path           uses cadaver'
+                echomsg ':Nwrite fetch://[user@]machine/path         uses fetch'
+                echomsg ':Nwrite ftp://machine[#port]/path           uses ftp  (autodetects <.netrc>)'
+                echomsg ':Nwrite rcp://machine/path                  uses rcp'
+                echomsg ':Nwrite rsync://[user@]machine/path         uses rsync'
+                echomsg ':Nwrite scp://[user@]machine[[:#]port]/path uses scp'
+                echomsg ':Nwrite sftp://[user@]machine/path          uses sftp'
+                sleep 4
+                break
+
+            elseif match(choice,"^\"") != -1
+                if match(choice,"\"$") != -1
+                    " case "..."
+                    let choice=strpart(choice,1,strlen(choice)-2)
+                else
+                    "  case "... ... ..."
+                    let choice      = strpart(choice,1,strlen(choice)-1)
+                    let wholechoice = ""
+
+                    while match(choice,"\"$") == -1
+                        let wholechoice= wholechoice . " " . choice
+                        let ichoice    = ichoice + 1
+                        if choice > a:0
+                            call netrw#msg#Notify('ERROR', printf('Unbalanced string in filename "%s"', wholechoice))
+                            return
+                        endif
+                        let choice= a:{ichoice}
+                    endwhile
+                    let choice= strpart(wholechoice,1,strlen(wholechoice)-1) . " " . strpart(choice,0,strlen(choice)-1)
+                endif
+            endif
+        endif
+        let ichoice= ichoice + 1
+
+        " Determine method of write (ftp, rcp, etc) {{{4
+        NetrwKeepj call s:NetrwMethod(choice)
+        if !exists("b:netrw_method") || b:netrw_method < 0
+            return
+        endif
+        if !s:NetrwValidateHostname(g:netrw_machine)
+            call netrw#msg#Notify('ERROR', printf('Rejecting invalid hostname: <%s>', g:netrw_machine))
+            return
+        endif
+
+        " =============
+        " NetWrite: Perform Protocol-Based Write {{{3
+        " ============================
+        if exists("g:netrw_silent") && g:netrw_silent == 0 && &ch >= 1
+            echo "(netrw) Processing your write request..."
+        endif
+
+        ".........................................
+        " NetWrite: (rcp) NetWrite Method #1 {{{3
+        if  b:netrw_method == 1
+            if s:netrw_has_nt_rcp == 1
+                if exists("g:netrw_uid") &&  ( g:netrw_uid != "" )
+                    let uid_machine = g:netrw_machine .'.'. g:netrw_uid
+                else
+                    let uid_machine = g:netrw_machine .'.'. $USERNAME
+                endif
+            else
+                if exists("g:netrw_uid") &&  ( g:netrw_uid != "" )
+                    let uid_machine = g:netrw_uid .'@'. g:netrw_machine
+                else
+                    let uid_machine = g:netrw_machine
+                endif
+            endif
+            call netrw#os#Execute(s:netrw_silentxfer."!".g:netrw_rcp_cmd." ".s:netrw_rcpmode." ".netrw#os#Escape(tmpfile,1)." ".netrw#os#Escape(uid_machine.":".b:netrw_fname,1))
+            let b:netrw_lastfile = choice
+
+            ".........................................
+        " NetWrite: (ftp + <.netrc>) NetWrite Method #2 {{{3
+        elseif b:netrw_method == 2
+            let netrw_fname = b:netrw_fname
+
+            " formerly just a "new...bd!", that changed the window sizes when equalalways.  Using enew workaround instead
+            let bhkeep      = &l:bh
+            let curbuf      = bufnr("%")
+            setl bh=hide
+            keepj keepalt enew
+
+            setl ff=unix
+            NetrwKeepj put =g:netrw_ftpmode
+            if exists("g:netrw_ftpextracmd")
+                NetrwKeepj put =g:netrw_ftpextracmd
+            endif
+            NetrwKeepj call setline(line("$")+1,'put "'.tmpfile.'" "'.netrw_fname.'"')
+            if exists("g:netrw_port") && g:netrw_port != ""
+                call netrw#os#Execute(s:netrw_silentxfer."%!".s:netrw_ftp_cmd." -i ".netrw#os#Escape(g:netrw_machine,1)." ".netrw#os#Escape(g:netrw_port,1))
+            else
+                call netrw#os#Execute(s:netrw_silentxfer."%!".s:netrw_ftp_cmd." -i ".netrw#os#Escape(g:netrw_machine,1))
+            endif
+            " If the result of the ftp operation isn't blank, show an error message (tnx to Doug Claar)
+            if getline(1) !~ "^$"
+                call netrw#msg#Notify('ERROR', getline(1))
+                let mod=1
+            endif
+
+            " remove enew buffer (quietly)
+            let filtbuf= bufnr("%")
+            exe curbuf."b!"
+            let &l:bh            = bhkeep
+            exe filtbuf."bw!"
+
+            let b:netrw_lastfile = choice
+
+            ".........................................
+        " NetWrite: (ftp + machine, id, passwd, filename) NetWrite Method #3 {{{3
+        elseif b:netrw_method == 3
+            " Construct execution string (three or more lines) which will be passed through filter
+            let netrw_fname = b:netrw_fname
+            let bhkeep      = &l:bh
+
+            " formerly just a "new...bd!", that changed the window sizes when equalalways.  Using enew workaround instead
+            let curbuf      = bufnr("%")
+            setl bh=hide
+            keepj keepalt enew
+            setl ff=unix
+
+            if exists("g:netrw_port") && g:netrw_port != ""
+                NetrwKeepj put ='open '.g:netrw_machine.' '.g:netrw_port
+            else
+                NetrwKeepj put ='open '.g:netrw_machine
+            endif
+            if exists("g:netrw_uid") && g:netrw_uid != ""
+                if exists("g:netrw_ftp") && g:netrw_ftp == 1
+                    NetrwKeepj put =g:netrw_uid
+                    if exists("s:netrw_passwd") && s:netrw_passwd != ""
+                        NetrwKeepj put ='\"'.s:netrw_passwd.'\"'
+                    endif
+                elseif exists("s:netrw_passwd") && s:netrw_passwd != ""
+                    NetrwKeepj put ='user \"'.g:netrw_uid.'\" \"'.s:netrw_passwd.'\"'
+                endif
+            endif
+            NetrwKeepj put =g:netrw_ftpmode
+            if exists("g:netrw_ftpextracmd")
+                NetrwKeepj put =g:netrw_ftpextracmd
+            endif
+            NetrwKeepj put ='put \"'.tmpfile.'\" \"'.netrw_fname.'\"'
+            " save choice/id/password for future use
+            let b:netrw_lastfile = choice
+
+            " perform ftp:
+            " -i       : turns off interactive prompting from ftp
+            " -n  unix : DON'T use <.netrc>, even though it exists
+            " -n  win32: quit being obnoxious about password
+            NetrwKeepj norm! 1G"_dd
+            call netrw#os#Execute(s:netrw_silentxfer."%!".s:netrw_ftp_cmd." ".g:netrw_ftp_options)
+            " If the result of the ftp operation isn't blank, show an error message (tnx to Doug Claar)
+            if getline(1) !~ "^$"
+                call netrw#msg#Notify('ERROR', getline(1))
+                let mod=1
+            endif
+
+            " remove enew buffer (quietly)
+            let filtbuf= bufnr("%")
+            exe curbuf."b!"
+            let &l:bh= bhkeep
+            exe filtbuf."bw!"
+
+            ".........................................
+        " NetWrite: (scp) NetWrite Method #4 {{{3
+        elseif     b:netrw_method == 4
+            if exists("g:netrw_port") && g:netrw_port != ""
+                let useport= " ".g:netrw_scpport." ".fnameescape(g:netrw_port)
+            else
+                let useport= ""
+            endif
+            call netrw#os#Execute(s:netrw_silentxfer."!".g:netrw_scp_cmd.useport." ".netrw#os#Escape(tmpfile,1)." ".netrw#os#Escape(g:netrw_machine.":".b:netrw_fname,1))
+            let b:netrw_lastfile = choice
+
+            ".........................................
+        " NetWrite: (http) NetWrite Method #5 {{{3
+        elseif     b:netrw_method == 5
+            let curl= substitute(g:netrw_http_put_cmd,'\s\+.*$',"","")
+            if executable(curl)
+                let url= g:netrw_choice
+                call netrw#os#Execute(s:netrw_silentxfer."!".g:netrw_http_put_cmd." ".netrw#os#Escape(tmpfile,1)." ".netrw#os#Escape(url,1) )
+            else
+                call netrw#msg#Notify('ERROR', printf("can't write to http using <%s>", g:netrw_http_put_cmd))
+            endif
+
+            ".........................................
+        " NetWrite: (dav) NetWrite Method #6 (cadaver) {{{3
+        elseif     b:netrw_method == 6
+
+            " Construct execution string (four lines) which will be passed through filter
+            let netrw_fname = escape(b:netrw_fname,g:netrw_fname_escape)
+            let bhkeep      = &l:bh
+
+            " formerly just a "new...bd!", that changed the window sizes when equalalways.  Using enew workaround instead
+            let curbuf      = bufnr("%")
+            setl bh=hide
+            keepj keepalt enew
+
+            setl ff=unix
+            if exists("g:netrw_port") && g:netrw_port != ""
+                NetrwKeepj put ='open '.g:netrw_machine.' '.g:netrw_port
+            else
+                NetrwKeepj put ='open '.g:netrw_machine
+            endif
+            if exists("g:netrw_uid") && exists("s:netrw_passwd") && g:netrw_uid != ""
+                NetrwKeepj put ='user '.g:netrw_uid.' '.s:netrw_passwd
+            endif
+            NetrwKeepj put ='put '.tmpfile.' '.netrw_fname
+
+            " perform cadaver operation:
+            NetrwKeepj norm! 1G"_dd
+            call netrw#os#Execute(s:netrw_silentxfer."%!".g:netrw_dav_cmd)
+
+            " remove enew buffer (quietly)
+            let filtbuf= bufnr("%")
+            exe curbuf."b!"
+            let &l:bh            = bhkeep
+            exe filtbuf."bw!"
+
+            let b:netrw_lastfile = choice
+
+            ".........................................
+        " NetWrite: (rsync) NetWrite Method #7 {{{3
+        elseif     b:netrw_method == 7
+            call netrw#os#Execute(s:netrw_silentxfer."!".g:netrw_rsync_cmd." ".netrw#os#Escape(tmpfile,1)." ".netrw#os#Escape(g:netrw_machine.g:netrw_rsync_sep.b:netrw_fname,1))
+            let b:netrw_lastfile = choice
+
+            ".........................................
+        " NetWrite: (sftp) NetWrite Method #9 {{{3
+        elseif     b:netrw_method == 9
+            let netrw_fname= escape(b:netrw_fname,g:netrw_fname_escape)
+            if exists("g:netrw_uid") &&  ( g:netrw_uid != "" )
+                let uid_machine = g:netrw_uid .'@'. g:netrw_machine
+            else
+                let uid_machine = g:netrw_machine
+            endif
+
+            " formerly just a "new...bd!", that changed the window sizes when equalalways.  Using enew workaround instead
+            let bhkeep = &l:bh
+            let curbuf = bufnr("%")
+            setl bh=hide
+            keepj keepalt enew
+
+            setl ff=unix
+            call setline(1,'put "'.escape(tmpfile,'\').'" '.netrw_fname)
+            let sftpcmd= substitute(g:netrw_sftp_cmd,"%TEMPFILE%",escape(tmpfile,'\'),"g")
+            call netrw#os#Execute(s:netrw_silentxfer."%!".sftpcmd.' '.netrw#os#Escape(uid_machine,1))
+            let filtbuf= bufnr("%")
+            exe curbuf."b!"
+            let &l:bh            = bhkeep
+            exe filtbuf."bw!"
+            let b:netrw_lastfile = choice
+
+            ".........................................
+        " NetWrite: Complain {{{3
+        else
+            call netrw#msg#Notify('WARNING', printf('unable to comply with your request<%s>', choice))
+            let leavemod= 1
+        endif
+    endwhile
+
+    " NetWrite: Cleanup: {{{3
+    if s:FileReadable(tmpfile)
+        call netrw#fs#Remove(tmpfile)
+    endif
+    call s:NetrwOptionsRestore("w:")
+
+    if a:firstline == 1 && a:lastline == line("$")
+        " restore modifiability; usually equivalent to set nomod
+        let &l:mod= mod
+    elseif !exists("leavemod")
+        " indicate that the buffer has not been modified since last written
+        setl nomod
+    endif
 
 endfun
 
@@ -2262,80 +2242,80 @@ endfun
 "              then sources that file,
 "              then removes that file.
 fun! netrw#NetSource(...)
-  if a:0 > 0 && a:1 == '?'
-    " give help
-    echomsg 'NetSource Usage:'
-    echomsg ':Nsource dav://machine[:port]/path            uses cadaver'
-    echomsg ':Nsource fetch://machine/path                 uses fetch'
-    echomsg ':Nsource ftp://[user@]machine[:port]/path     uses ftp   autodetects <.netrc>'
-    echomsg ':Nsource http[s]://[user@]machine/path        uses http  wget'
-    echomsg ':Nsource rcp://[user@]machine/path            uses rcp'
-    echomsg ':Nsource rsync://machine[:port]/path          uses rsync'
-    echomsg ':Nsource scp://[user@]machine[[:#]port]/path  uses scp'
-    echomsg ':Nsource sftp://[user@]machine[[:#]port]/path uses sftp'
-    sleep 4
-  else
-    let i= 1
-    while i <= a:0
-      call netrw#NetRead(3,a:{i})
-      if s:FileReadable(s:netrw_tmpfile)
-        exe "so ".fnameescape(s:netrw_tmpfile)
-        if delete(s:netrw_tmpfile)
-          call netrw#msg#Notify('ERROR', 'unable to delete directory <%s>', s:netrw_tmpfile)
-        endif
-        unlet s:netrw_tmpfile
-      else
-        call netrw#msg#Notify('ERROR', printf('unable to source <%s>!', a:{i}))
-      endif
-      let i= i + 1
-    endwhile
-  endif
+    if a:0 > 0 && a:1 == '?'
+        " give help
+        echomsg 'NetSource Usage:'
+        echomsg ':Nsource dav://machine[:port]/path            uses cadaver'
+        echomsg ':Nsource fetch://machine/path                 uses fetch'
+        echomsg ':Nsource ftp://[user@]machine[:port]/path     uses ftp   autodetects <.netrc>'
+        echomsg ':Nsource http[s]://[user@]machine/path        uses http  wget'
+        echomsg ':Nsource rcp://[user@]machine/path            uses rcp'
+        echomsg ':Nsource rsync://machine[:port]/path          uses rsync'
+        echomsg ':Nsource scp://[user@]machine[[:#]port]/path  uses scp'
+        echomsg ':Nsource sftp://[user@]machine[[:#]port]/path uses sftp'
+        sleep 4
+    else
+        let i= 1
+        while i <= a:0
+            call netrw#NetRead(3,a:{i})
+            if s:FileReadable(s:netrw_tmpfile)
+                exe "so ".fnameescape(s:netrw_tmpfile)
+                if delete(s:netrw_tmpfile)
+                    call netrw#msg#Notify('ERROR', 'unable to delete directory <%s>', s:netrw_tmpfile)
+                endif
+                unlet s:netrw_tmpfile
+            else
+                call netrw#msg#Notify('ERROR', printf('unable to source <%s>!', a:{i}))
+            endif
+            let i= i + 1
+        endwhile
+    endif
 endfun
 
 " netrw#SetTreetop: resets the tree top to the current directory/specified directory {{{2
 "                   (implements the :Ntree command)
 fun! netrw#SetTreetop(iscmd,...)
 
-  " iscmd==0: netrw#SetTreetop called using gn mapping
-  " iscmd==1: netrw#SetTreetop called using :Ntree from the command line
-  " clear out the current tree
-  if exists("w:netrw_treetop")
-    let inittreetop= w:netrw_treetop
-    unlet w:netrw_treetop
-  endif
-  if exists("w:netrw_treedict")
-    unlet w:netrw_treedict
-  endif
-
-  if (a:iscmd == 0 || a:1 == "") && exists("inittreetop")
-    let treedir         = s:NetrwTreePath(inittreetop)
-  else
-    if isdirectory(s:NetrwFile(a:1))
-      let treedir         = a:1
-      let s:netrw_treetop = treedir
-    elseif exists("b:netrw_curdir") && (isdirectory(s:NetrwFile(b:netrw_curdir."/".a:1)) || a:1 =~ '^\a\{3,}://')
-      let treedir         = b:netrw_curdir."/".a:1
-      let s:netrw_treetop = treedir
-    else
-      " normally the cursor is left in the message window.
-      " However, here this results in the directory being listed in the message window, which is not wanted.
-      let netrwbuf= bufnr("%")
-      call netrw#msg#Notify('ERROR', printf("sorry, %s doesn't seem to be a directory!", a:1))
-      exe bufwinnr(netrwbuf)."wincmd w"
-      let treedir         = "."
-      let s:netrw_treetop = getcwd()
+    " iscmd==0: netrw#SetTreetop called using gn mapping
+    " iscmd==1: netrw#SetTreetop called using :Ntree from the command line
+    " clear out the current tree
+    if exists("w:netrw_treetop")
+        let inittreetop= w:netrw_treetop
+        unlet w:netrw_treetop
     endif
-  endif
+    if exists("w:netrw_treedict")
+        unlet w:netrw_treedict
+    endif
 
-  " determine if treedir is remote or local
-  let islocal= expand("%") !~ '^\a\{3,}://'
+    if (a:iscmd == 0 || a:1 == "") && exists("inittreetop")
+        let treedir         = s:NetrwTreePath(inittreetop)
+    else
+        if isdirectory(s:NetrwFile(a:1))
+            let treedir         = a:1
+            let s:netrw_treetop = treedir
+        elseif exists("b:netrw_curdir") && (isdirectory(s:NetrwFile(b:netrw_curdir."/".a:1)) || a:1 =~ '^\a\{3,}://')
+            let treedir         = b:netrw_curdir."/".a:1
+            let s:netrw_treetop = treedir
+        else
+            " normally the cursor is left in the message window.
+            " However, here this results in the directory being listed in the message window, which is not wanted.
+            let netrwbuf= bufnr("%")
+            call netrw#msg#Notify('ERROR', printf("sorry, %s doesn't seem to be a directory!", a:1))
+            exe bufwinnr(netrwbuf)."wincmd w"
+            let treedir         = "."
+            let s:netrw_treetop = getcwd()
+        endif
+    endif
 
-  " browse the resulting directory
-  if islocal
-    call netrw#LocalBrowseCheck(s:NetrwBrowseChgDir(islocal,treedir,0))
-  else
-    call s:NetrwBrowse(islocal,s:NetrwBrowseChgDir(islocal,treedir,0))
-  endif
+    " determine if treedir is remote or local
+    let islocal= expand("%") !~ '^\a\{3,}://'
+
+    " browse the resulting directory
+    if islocal
+        call netrw#LocalBrowseCheck(s:NetrwBrowseChgDir(islocal,treedir,0))
+    else
+        call s:NetrwBrowse(islocal,s:NetrwBrowseChgDir(islocal,treedir,0))
+    endif
 
 endfun
 
@@ -2346,94 +2326,94 @@ endfun
 "            == t  : leave file in temporary form (ie. don't read into buffer)
 fun! s:NetrwGetFile(readcmd, tfile, method)
 
-  " readcmd=='t': simply do nothing
-  if a:readcmd == 't'
-    return
-  endif
-
-  " get name of remote filename (ie. url and all)
-  let rfile= bufname("%")
-
-  if exists("*NetReadFixup")
-    " for the use of NetReadFixup (not otherwise used internally)
-    let line2= line("$")
-  endif
-
-  if a:readcmd[0] == '%'
-    " get file into buffer
-
-    " rename the current buffer to the temp file (ie. tfile)
-    if g:netrw_cygwin
-      let tfile= substitute(a:tfile,g:netrw_cygdrive.'/\(.\)','\1:','')
-    else
-      let tfile= a:tfile
-    endif
-    call s:NetrwBufRename(tfile)
-
-    " edit temporary file (ie. read the temporary file in)
-    if     rfile =~ '\.zip$'
-      call zip#Browse(tfile)
-    elseif rfile =~ '\.tar$'
-      call tar#Browse(tfile)
-    elseif rfile =~ '\.tar\.gz$'
-      call tar#Browse(tfile)
-    elseif rfile =~ '\.tar\.bz2$'
-      call tar#Browse(tfile)
-    elseif rfile =~ '\.tar\.xz$'
-      call tar#Browse(tfile)
-    elseif rfile =~ '\.txz$'
-      call tar#Browse(tfile)
-    else
-      NetrwKeepj e!
+    " readcmd=='t': simply do nothing
+    if a:readcmd == 't'
+        return
     endif
 
-    " rename buffer back to remote filename
-    call s:NetrwBufRename(rfile)
+    " get name of remote filename (ie. url and all)
+    let rfile= bufname("%")
 
-    " Jan 19, 2022: COMBAK -- bram problem with https://github.com/vim/vim/pull/9554.diff filetype
-    " Detect filetype of local version of remote file.
-    " Note that isk must not include a "/" for scripts.vim
-    " to process this detection correctly.
-    "   setl ft=
-    let iskkeep= &isk
-    setl isk-=/
-    filetype detect
-    let &l:isk= iskkeep
-    let line1 = 1
-    let line2 = line("$")
+    if exists("*NetReadFixup")
+        " for the use of NetReadFixup (not otherwise used internally)
+        let line2= line("$")
+    endif
 
-  elseif !&ma
-    " attempting to read a file after the current line in the file, but the buffer is not modifiable
-    call netrw#msg#Notify('WARNING', printf('attempt to read<%s> into a non-modifiable buffer!', a:tfile))
-    return
+    if a:readcmd[0] == '%'
+        " get file into buffer
 
-  elseif s:FileReadable(a:tfile)
-    " read file after current line
-    let curline = line(".")
-    let lastline= line("$")
-    exe "NetrwKeepj ".a:readcmd." ".fnameescape(v:cmdarg)." ".fnameescape(a:tfile)
-    let line1= curline + 1
-    let line2= line("$") - lastline + 1
+        " rename the current buffer to the temp file (ie. tfile)
+        if g:netrw_cygwin
+            let tfile= substitute(a:tfile,g:netrw_cygdrive.'/\(.\)','\1:','')
+        else
+            let tfile= a:tfile
+        endif
+        call s:NetrwBufRename(tfile)
 
-  else
-    " not readable
-    call netrw#msg#Notify('WARNING', printf('file <%s> not readable', a:tfile))
-    return
-  endif
+        " edit temporary file (ie. read the temporary file in)
+        if     rfile =~ '\.zip$'
+            call zip#Browse(tfile)
+        elseif rfile =~ '\.tar$'
+            call tar#Browse(tfile)
+        elseif rfile =~ '\.tar\.gz$'
+            call tar#Browse(tfile)
+        elseif rfile =~ '\.tar\.bz2$'
+            call tar#Browse(tfile)
+        elseif rfile =~ '\.tar\.xz$'
+            call tar#Browse(tfile)
+        elseif rfile =~ '\.txz$'
+            call tar#Browse(tfile)
+        else
+            NetrwKeepj e!
+        endif
 
-  " User-provided (ie. optional) fix-it-up command
-  if exists("*NetReadFixup")
-    NetrwKeepj call NetReadFixup(a:method, line1, line2)
-  endif
+        " rename buffer back to remote filename
+        call s:NetrwBufRename(rfile)
 
-  if has("gui") && has("menu") && has("gui_running") && &go =~# 'm' && g:netrw_menu
-    " update the Buffers menu
-    NetrwKeepj call s:UpdateBuffersMenu()
-  endif
+        " Jan 19, 2022: COMBAK -- bram problem with https://github.com/vim/vim/pull/9554.diff filetype
+        " Detect filetype of local version of remote file.
+        " Note that isk must not include a "/" for scripts.vim
+        " to process this detection correctly.
+        "   setl ft=
+        let iskkeep= &isk
+        setl isk-=/
+        filetype detect
+        let &l:isk= iskkeep
+        let line1 = 1
+        let line2 = line("$")
+
+    elseif !&ma
+        " attempting to read a file after the current line in the file, but the buffer is not modifiable
+        call netrw#msg#Notify('WARNING', printf('attempt to read<%s> into a non-modifiable buffer!', a:tfile))
+        return
+
+    elseif s:FileReadable(a:tfile)
+        " read file after current line
+        let curline = line(".")
+        let lastline= line("$")
+        exe "NetrwKeepj ".a:readcmd." ".fnameescape(v:cmdarg)." ".fnameescape(a:tfile)
+        let line1= curline + 1
+        let line2= line("$") - lastline + 1
+
+    else
+        " not readable
+        call netrw#msg#Notify('WARNING', printf('file <%s> not readable', a:tfile))
+        return
+    endif
+
+    " User-provided (ie. optional) fix-it-up command
+    if exists("*NetReadFixup")
+        NetrwKeepj call NetReadFixup(a:method, line1, line2)
+    endif
+
+    if has("gui") && has("menu") && has("gui_running") && &go =~# 'm' && g:netrw_menu
+        " update the Buffers menu
+        NetrwKeepj call s:UpdateBuffersMenu()
+    endif
 
 
-  " make sure file is being displayed
-  "  redraw!
+    " make sure file is being displayed
+    "  redraw!
 
 endfun
 
@@ -2457,216 +2437,214 @@ endfun
 "  g:netrw_choice = copy of input url (choice)
 fun! s:NetrwMethod(choice)
 
-  " sanity check: choice should have at least three slashes in it
-  if strlen(substitute(a:choice,'[^/]','','g')) < 3
-    call netrw#msg#Notify('ERROR', 'not a netrw-style url; netrw uses protocol://[user@]hostname[:port]/[path])')
-    let b:netrw_method = -1
-    return
-  endif
-
-  " record current g:netrw_machine, if any
-  " curmachine used if protocol == ftp and no .netrc
-  if exists("g:netrw_machine")
-    let curmachine= g:netrw_machine
-  else
-    let curmachine= "N O T A HOST"
-  endif
-  if exists("g:netrw_port")
-    let netrw_port= g:netrw_port
-  endif
-
-  " insure that netrw_ftp_cmd starts off every method determination
-  " with the current g:netrw_ftp_cmd
-  let s:netrw_ftp_cmd= g:netrw_ftp_cmd
-
-  " initialization
-  let b:netrw_method  = 0
-  let g:netrw_machine = ""
-  let b:netrw_fname   = ""
-  let g:netrw_port    = ""
-  let g:netrw_choice  = a:choice
-
-  " Patterns:
-  " mipf     : a:machine a:id password filename      Use ftp
-  " mf      : a:machine filename                     Use ftp + <.netrc> or g:netrw_uid s:netrw_passwd
-  " ftpurm   : ftp://[user@]host[[#:]port]/filename  Use ftp + <.netrc> or g:netrw_uid s:netrw_passwd
-  " rcpurm   : rcp://[user@]host/filename            Use rcp
-  " rcphf    : [user@]host:filename                  Use rcp
-  " scpurm   : scp://[user@]host[[#:]port]/filename  Use scp
-  " httpurm  : http[s]://[user@]host/filename        Use wget
-  " davurm   : dav[s]://host[:port]/path             Use cadaver/curl
-  " rsyncurm : rsync://host[:port]/path              Use rsync
-  " fetchurm : fetch://[user@]host[:http]/filename   Use fetch (defaults to ftp, override for http)
-  " sftpurm  : sftp://[user@]host/filename  Use scp
-  " fileurm  : file://[user@]host/filename           Use elinks or links
-  let mipf     = '^\(\S\+\)\s\+\(\S\+\)\s\+\(\S\+\)\s\+\(\S\+\)$'
-  let mf       = '^\(\S\+\)\s\+\(\S\+\)$'
-  let ftpurm   = '^ftp://\(\([^/]*\)@\)\=\([^/#:]\{-}\)\([#:]\d\+\)\=/\(.*\)$'
-  let rcpurm   = '^rcp://\%(\([^/]*\)@\)\=\([^/]\{-}\)/\(.*\)$'
-  let rcphf    = '^\(\(\h\w*\)@\)\=\(\h\w*\):\([^@]\+\)$'
-  let scpurm   = '^scp://\([^/#:]\+\)\%([#:]\(\d\+\)\)\=/\(.*\)$'
-  let httpurm  = '^https\=://\([^/]\{-}\)\(/.*\)\=$'
-  let davurm   = '^davs\=://\([^/]\+\)/\(.*/\)\([-_.~[:alnum:]]\+\)$'
-  let rsyncurm = '^rsync://\([^/]\{-}\)/\(.*\)\=$'
-  let fetchurm = '^fetch://\(\([^/]*\)@\)\=\([^/#:]\{-}\)\(:http\)\=/\(.*\)$'
-  let sftpurm  = '^sftp://\([^/]\{-}\)/\(.*\)\=$'
-  let fileurm  = '^file\=://\(.*\)$'
-
-  " Determine Method
-  " Method#1: rcp://user@hostname/...path-to-file {{{3
-  if match(a:choice,rcpurm) == 0
-    let b:netrw_method  = 1
-    let userid          = substitute(a:choice,rcpurm,'\1',"")
-    let g:netrw_machine = substitute(a:choice,rcpurm,'\2',"")
-    let b:netrw_fname   = substitute(a:choice,rcpurm,'\3',"")
-    if userid != ""
-      let g:netrw_uid= userid
+    " sanity check: choice should have at least three slashes in it
+    if strlen(substitute(a:choice,'[^/]','','g')) < 3
+        call netrw#msg#Notify('ERROR', 'not a netrw-style url; netrw uses protocol://[user@]hostname[:port]/[path])')
+        let b:netrw_method = -1
+        return
     endif
 
-  " Method#4: scp://user@hostname/...path-to-file {{{3
-  elseif match(a:choice,scpurm) == 0
-    let b:netrw_method  = 4
-    let g:netrw_machine = substitute(a:choice,scpurm,'\1',"")
-    let g:netrw_port    = substitute(a:choice,scpurm,'\2',"")
-    let b:netrw_fname   = substitute(a:choice,scpurm,'\3',"")
-
-  " Method#5: http[s]://user@hostname/...path-to-file {{{3
-  elseif match(a:choice,httpurm) == 0
-    let b:netrw_method = 5
-    let g:netrw_machine= substitute(a:choice,httpurm,'\1',"")
-    let b:netrw_fname  = substitute(a:choice,httpurm,'\2',"")
-    let b:netrw_http   = (a:choice =~ '^https:')? "https" : "http"
-
-  " Method#6: dav://hostname[:port]/..path-to-file.. {{{3
-  elseif match(a:choice,davurm) == 0
-    let b:netrw_method= 6
-    if a:choice =~ 'davs:'
-      let g:netrw_machine= 'https://'.substitute(a:choice,davurm,'\1/\2',"")
+    " record current g:netrw_machine, if any
+    " curmachine used if protocol == ftp and no .netrc
+    if exists("g:netrw_machine")
+        let curmachine= g:netrw_machine
     else
-      let g:netrw_machine= 'http://'.substitute(a:choice,davurm,'\1/\2',"")
+        let curmachine= "N O T A HOST"
     endif
-    let b:netrw_fname  = substitute(a:choice,davurm,'\3',"")
-
-  " Method#7: rsync://user@hostname/...path-to-file {{{3
-  elseif match(a:choice,rsyncurm) == 0
-    let b:netrw_method = 7
-    let g:netrw_machine= substitute(a:choice,rsyncurm,'\1',"")
-    let b:netrw_fname  = substitute(a:choice,rsyncurm,'\2',"")
-
-  " Methods 2,3: ftp://[user@]hostname[[:#]port]/...path-to-file {{{3
-  elseif match(a:choice,ftpurm) == 0
-    let userid         = substitute(a:choice,ftpurm,'\2',"")
-    let g:netrw_machine= substitute(a:choice,ftpurm,'\3',"")
-    let g:netrw_port   = substitute(a:choice,ftpurm,'\4',"")
-    let b:netrw_fname  = substitute(a:choice,ftpurm,'\5',"")
-    if userid != ""
-      let g:netrw_uid= userid
+    if exists("g:netrw_port")
+        let netrw_port= g:netrw_port
     endif
 
-    if curmachine != g:netrw_machine
-      if exists("s:netrw_hup[".g:netrw_machine."]")
-        call NetUserPass("ftp:".g:netrw_machine)
-      elseif exists("s:netrw_passwd")
-        " if there's a change in hostname, require password re-entry
-        unlet s:netrw_passwd
-      endif
-      if exists("netrw_port")
-        unlet netrw_port
-      endif
-    endif
+    " insure that netrw_ftp_cmd starts off every method determination
+    " with the current g:netrw_ftp_cmd
+    let s:netrw_ftp_cmd= g:netrw_ftp_cmd
 
-    if exists("g:netrw_uid") && exists("s:netrw_passwd")
-      let b:netrw_method = 3
+    " initialization
+    let b:netrw_method  = 0
+    let g:netrw_machine = ""
+    let b:netrw_fname   = ""
+    let g:netrw_port    = ""
+    let g:netrw_choice  = a:choice
+
+    " Patterns:
+    " mipf     : a:machine a:id password filename      Use ftp
+    " mf      : a:machine filename                     Use ftp + <.netrc> or g:netrw_uid s:netrw_passwd
+    " ftpurm   : ftp://[user@]host[[#:]port]/filename  Use ftp + <.netrc> or g:netrw_uid s:netrw_passwd
+    " rcpurm   : rcp://[user@]host/filename            Use rcp
+    " rcphf    : [user@]host:filename                  Use rcp
+    " scpurm   : scp://[user@]host[[#:]port]/filename  Use scp
+    " httpurm  : http[s]://[user@]host/filename        Use wget
+    " davurm   : dav[s]://host[:port]/path             Use cadaver/curl
+    " rsyncurm : rsync://host[:port]/path              Use rsync
+    " fetchurm : fetch://[user@]host[:http]/filename   Use fetch (defaults to ftp, override for http)
+    " sftpurm  : sftp://[user@]host/filename  Use scp
+    " fileurm  : file://[user@]host/filename           Use elinks or links
+    let mipf     = '^\(\S\+\)\s\+\(\S\+\)\s\+\(\S\+\)\s\+\(\S\+\)$'
+    let mf       = '^\(\S\+\)\s\+\(\S\+\)$'
+    let ftpurm   = '^ftp://\(\([^/]*\)@\)\=\([^/#:]\{-}\)\([#:]\d\+\)\=/\(.*\)$'
+    let rcpurm   = '^rcp://\%(\([^/]*\)@\)\=\([^/]\{-}\)/\(.*\)$'
+    let rcphf    = '^\(\(\h\w*\)@\)\=\(\h\w*\):\([^@]\+\)$'
+    let scpurm   = '^scp://\([^/#:]\+\)\%([#:]\(\d\+\)\)\=/\(.*\)$'
+    let httpurm  = '^https\=://\([^/]\{-}\)\(/.*\)\=$'
+    let davurm   = '^davs\=://\([^/]\+\)/\(.*/\)\([-_.~[:alnum:]]\+\)$'
+    let rsyncurm = '^rsync://\([^/]\{-}\)/\(.*\)\=$'
+    let fetchurm = '^fetch://\(\([^/]*\)@\)\=\([^/#:]\{-}\)\(:http\)\=/\(.*\)$'
+    let sftpurm  = '^sftp://\([^/]\{-}\)/\(.*\)\=$'
+    let fileurm  = '^file\=://\(.*\)$'
+
+    " Determine Method
+    " Method#1: rcp://user@hostname/...path-to-file {{{3
+    if match(a:choice,rcpurm) == 0
+        let b:netrw_method  = 1
+        let userid          = substitute(a:choice,rcpurm,'\1',"")
+        let g:netrw_machine = substitute(a:choice,rcpurm,'\2',"")
+        let b:netrw_fname   = substitute(a:choice,rcpurm,'\3',"")
+        if userid != ""
+            let g:netrw_uid= userid
+        endif
+
+    " Method#4: scp://user@hostname/...path-to-file {{{3
+    elseif match(a:choice,scpurm) == 0
+        let b:netrw_method  = 4
+        let g:netrw_machine = substitute(a:choice,scpurm,'\1',"")
+        let g:netrw_port    = substitute(a:choice,scpurm,'\2',"")
+        let b:netrw_fname   = substitute(a:choice,scpurm,'\3',"")
+
+    " Method#5: http[s]://user@hostname/...path-to-file {{{3
+    elseif match(a:choice,httpurm) == 0
+        let b:netrw_method = 5
+        let g:netrw_machine= substitute(a:choice,httpurm,'\1',"")
+        let b:netrw_fname  = substitute(a:choice,httpurm,'\2',"")
+        let b:netrw_http   = (a:choice =~ '^https:')? "https" : "http"
+
+    " Method#6: dav://hostname[:port]/..path-to-file.. {{{3
+    elseif match(a:choice,davurm) == 0
+        let b:netrw_method= 6
+        if a:choice =~ 'davs:'
+            let g:netrw_machine= 'https://'.substitute(a:choice,davurm,'\1/\2',"")
+        else
+            let g:netrw_machine= 'http://'.substitute(a:choice,davurm,'\1/\2',"")
+        endif
+        let b:netrw_fname  = substitute(a:choice,davurm,'\3',"")
+
+    " Method#7: rsync://user@hostname/...path-to-file {{{3
+    elseif match(a:choice,rsyncurm) == 0
+        let b:netrw_method = 7
+        let g:netrw_machine= substitute(a:choice,rsyncurm,'\1',"")
+        let b:netrw_fname  = substitute(a:choice,rsyncurm,'\2',"")
+
+    " Methods 2,3: ftp://[user@]hostname[[:#]port]/...path-to-file {{{3
+    elseif match(a:choice,ftpurm) == 0
+        let userid         = substitute(a:choice,ftpurm,'\2',"")
+        let g:netrw_machine= substitute(a:choice,ftpurm,'\3',"")
+        let g:netrw_port   = substitute(a:choice,ftpurm,'\4',"")
+        let b:netrw_fname  = substitute(a:choice,ftpurm,'\5',"")
+        if userid != ""
+            let g:netrw_uid= userid
+        endif
+
+        if curmachine != g:netrw_machine
+            if exists("s:netrw_hup[".g:netrw_machine."]")
+                call NetUserPass("ftp:".g:netrw_machine)
+            elseif exists("s:netrw_passwd")
+                " if there's a change in hostname, require password re-entry
+                unlet s:netrw_passwd
+            endif
+            if exists("netrw_port")
+                unlet netrw_port
+            endif
+        endif
+
+        if exists("g:netrw_uid") && exists("s:netrw_passwd")
+            let b:netrw_method = 3
+        else
+            let host= substitute(g:netrw_machine,'\..*$','','')
+            if exists("s:netrw_hup[host]")
+                call NetUserPass("ftp:".host)
+
+            elseif has("win32") && s:netrw_ftp_cmd =~# '-[sS]:'
+                if g:netrw_ftp_cmd =~# '-[sS]:\S*MACHINE\>'
+                    let s:netrw_ftp_cmd= substitute(g:netrw_ftp_cmd,'\<MACHINE\>',g:netrw_machine,'')
+                endif
+                let b:netrw_method= 2
+            elseif s:FileReadable(expand("$HOME/.netrc")) && !g:netrw_ignorenetrc
+                let b:netrw_method= 2
+            else
+                if !exists("g:netrw_uid") || g:netrw_uid == ""
+                    call NetUserPass()
+                elseif !exists("s:netrw_passwd") || s:netrw_passwd == ""
+                    call NetUserPass(g:netrw_uid)
+                    " else just use current g:netrw_uid and s:netrw_passwd
+                endif
+                let b:netrw_method= 3
+            endif
+        endif
+
+    " Method#8: fetch {{{3
+    elseif match(a:choice,fetchurm) == 0
+        let b:netrw_method = 8
+        let g:netrw_userid = substitute(a:choice,fetchurm,'\2',"")
+        let g:netrw_machine= substitute(a:choice,fetchurm,'\3',"")
+        let b:netrw_option = substitute(a:choice,fetchurm,'\4',"")
+        let b:netrw_fname  = substitute(a:choice,fetchurm,'\5',"")
+
+    " Method#3: Issue an ftp : "machine id password [path/]filename" {{{3
+    elseif match(a:choice,mipf) == 0
+        let b:netrw_method  = 3
+        let g:netrw_machine = substitute(a:choice,mipf,'\1',"")
+        let g:netrw_uid     = substitute(a:choice,mipf,'\2',"")
+        let s:netrw_passwd  = substitute(a:choice,mipf,'\3',"")
+        let b:netrw_fname   = substitute(a:choice,mipf,'\4',"")
+        call NetUserPass(g:netrw_machine,g:netrw_uid,s:netrw_passwd)
+
+    " Method#3: Issue an ftp: "hostname [path/]filename" {{{3
+    elseif match(a:choice,mf) == 0
+        if exists("g:netrw_uid") && exists("s:netrw_passwd")
+            let b:netrw_method  = 3
+            let g:netrw_machine = substitute(a:choice,mf,'\1',"")
+            let b:netrw_fname   = substitute(a:choice,mf,'\2',"")
+
+        elseif s:FileReadable(expand("$HOME/.netrc"))
+            let b:netrw_method  = 2
+            let g:netrw_machine = substitute(a:choice,mf,'\1',"")
+            let b:netrw_fname   = substitute(a:choice,mf,'\2',"")
+        endif
+
+    " Method#9: sftp://user@hostname/...path-to-file {{{3
+    elseif match(a:choice,sftpurm) == 0
+        let b:netrw_method = 9
+        let g:netrw_machine= substitute(a:choice,sftpurm,'\1',"")
+        let b:netrw_fname  = substitute(a:choice,sftpurm,'\2',"")
+
+    " Method#1: Issue an rcp: hostname:filename"  (this one should be last) {{{3
+    elseif match(a:choice,rcphf) == 0
+        let b:netrw_method  = 1
+        let userid          = substitute(a:choice,rcphf,'\2',"")
+        let g:netrw_machine = substitute(a:choice,rcphf,'\3',"")
+        let b:netrw_fname   = substitute(a:choice,rcphf,'\4',"")
+        if userid != ""
+            let g:netrw_uid= userid
+        endif
+
+    " Method#10: file://user@hostname/...path-to-file {{{3
+    elseif match(a:choice,fileurm) == 0 && exists("g:netrw_file_cmd")
+        let b:netrw_method = 10
+        let b:netrw_fname  = substitute(a:choice,fileurm,'\1',"")
+
+    " Cannot Determine Method {{{3
     else
-      let host= substitute(g:netrw_machine,'\..*$','','')
-      if exists("s:netrw_hup[host]")
-        call NetUserPass("ftp:".host)
-
-      elseif has("win32") && s:netrw_ftp_cmd =~# '-[sS]:'
-        if g:netrw_ftp_cmd =~# '-[sS]:\S*MACHINE\>'
-          let s:netrw_ftp_cmd= substitute(g:netrw_ftp_cmd,'\<MACHINE\>',g:netrw_machine,'')
-        endif
-        let b:netrw_method= 2
-      elseif s:FileReadable(expand("$HOME/.netrc")) && !g:netrw_ignorenetrc
-        let b:netrw_method= 2
-      else
-        if !exists("g:netrw_uid") || g:netrw_uid == ""
-          call NetUserPass()
-        elseif !exists("s:netrw_passwd") || s:netrw_passwd == ""
-          call NetUserPass(g:netrw_uid)
-          " else just use current g:netrw_uid and s:netrw_passwd
-        endif
-        let b:netrw_method= 3
-      endif
+        call netrw#msg#Notify('WARNING', 'cannot determine method (format: protocol://[user@]hostname[:port]/[path])')
+        let b:netrw_method  = -1
     endif
+    "}}}3
 
-  " Method#8: fetch {{{3
-  elseif match(a:choice,fetchurm) == 0
-    let b:netrw_method = 8
-    let g:netrw_userid = substitute(a:choice,fetchurm,'\2',"")
-    let g:netrw_machine= substitute(a:choice,fetchurm,'\3',"")
-    let b:netrw_option = substitute(a:choice,fetchurm,'\4',"")
-    let b:netrw_fname  = substitute(a:choice,fetchurm,'\5',"")
-
-  " Method#3: Issue an ftp : "machine id password [path/]filename" {{{3
-  elseif match(a:choice,mipf) == 0
-    let b:netrw_method  = 3
-    let g:netrw_machine = substitute(a:choice,mipf,'\1',"")
-    let g:netrw_uid     = substitute(a:choice,mipf,'\2',"")
-    let s:netrw_passwd  = substitute(a:choice,mipf,'\3',"")
-    let b:netrw_fname   = substitute(a:choice,mipf,'\4',"")
-    call NetUserPass(g:netrw_machine,g:netrw_uid,s:netrw_passwd)
-
-  " Method#3: Issue an ftp: "hostname [path/]filename" {{{3
-  elseif match(a:choice,mf) == 0
-    if exists("g:netrw_uid") && exists("s:netrw_passwd")
-      let b:netrw_method  = 3
-      let g:netrw_machine = substitute(a:choice,mf,'\1',"")
-      let b:netrw_fname   = substitute(a:choice,mf,'\2',"")
-
-    elseif s:FileReadable(expand("$HOME/.netrc"))
-      let b:netrw_method  = 2
-      let g:netrw_machine = substitute(a:choice,mf,'\1',"")
-      let b:netrw_fname   = substitute(a:choice,mf,'\2',"")
+    if g:netrw_port != ""
+        " remove any leading [:#] from port number
+        let g:netrw_port = substitute(g:netrw_port,'[#:]\+','','')
+    elseif exists("netrw_port")
+        " retain port number as implicit for subsequent ftp operations
+        let g:netrw_port= netrw_port
     endif
-
-  " Method#9: sftp://user@hostname/...path-to-file {{{3
-  elseif match(a:choice,sftpurm) == 0
-    let b:netrw_method = 9
-    let g:netrw_machine= substitute(a:choice,sftpurm,'\1',"")
-    let b:netrw_fname  = substitute(a:choice,sftpurm,'\2',"")
-
-  " Method#1: Issue an rcp: hostname:filename"  (this one should be last) {{{3
-  elseif match(a:choice,rcphf) == 0
-    let b:netrw_method  = 1
-    let userid          = substitute(a:choice,rcphf,'\2',"")
-    let g:netrw_machine = substitute(a:choice,rcphf,'\3',"")
-    let b:netrw_fname   = substitute(a:choice,rcphf,'\4',"")
-    if userid != ""
-      let g:netrw_uid= userid
-    endif
-
-  " Method#10: file://user@hostname/...path-to-file {{{3
-  elseif match(a:choice,fileurm) == 0 && exists("g:netrw_file_cmd")
-    let b:netrw_method = 10
-    let b:netrw_fname  = substitute(a:choice,fileurm,'\1',"")
-
-  " Cannot Determine Method {{{3
-  else
-    if !exists("g:netrw_quiet")
-      call netrw#msg#Notify('WARNING', 'cannot determine method (format: protocol://[user@]hostname[:port]/[path])')
-    endif
-    let b:netrw_method  = -1
-  endif
-  "}}}3
-
-  if g:netrw_port != ""
-    " remove any leading [:#] from port number
-    let g:netrw_port = substitute(g:netrw_port,'[#:]\+','','')
-  elseif exists("netrw_port")
-    " retain port number as implicit for subsequent ftp operations
-    let g:netrw_port= netrw_port
-  endif
 
 endfun
 
@@ -2690,92 +2668,92 @@ endfun
 fun! NetUserPass(...)
 
 
-  if !exists('s:netrw_hup')
-    let s:netrw_hup= {}
-  endif
-
-  if a:0 == 0
-    " case: no input arguments
-
-    " change host and username if not previously entered; get new password
-    if !exists("g:netrw_machine")
-      let g:netrw_machine= input('Enter hostname: ')
+    if !exists('s:netrw_hup')
+        let s:netrw_hup= {}
     endif
-    if !exists("g:netrw_uid") || g:netrw_uid == ""
-      " get username (user-id) via prompt
-      let g:netrw_uid= input('Enter username: ')
-    endif
-    " get password via prompting
-    let s:netrw_passwd= inputsecret("Enter Password: ")
 
-    " set up hup database
-    let host = substitute(g:netrw_machine,'\..*$','','')
-    if !exists('s:netrw_hup[host]')
-      let s:netrw_hup[host]= {}
-    endif
-    let s:netrw_hup[host].uid    = g:netrw_uid
-    let s:netrw_hup[host].passwd = s:netrw_passwd
+    if a:0 == 0
+        " case: no input arguments
 
-  elseif a:0 == 1
-    " case: one input argument
-
-    if a:1 =~ '^ftp:'
-      " get host from ftp:... url
-      " access userid and password from hup (host-user-passwd) dictionary
-      let host = substitute(a:1,'^ftp:','','')
-      let host = substitute(host,'\..*','','')
-      if exists("s:netrw_hup[host]")
-        let g:netrw_uid    = s:netrw_hup[host].uid
-        let s:netrw_passwd = s:netrw_hup[host].passwd
-      else
-        let g:netrw_uid    = input("Enter UserId: ")
-        let s:netrw_passwd = inputsecret("Enter Password: ")
-      endif
-
-    else
-      " case: one input argument, not an url.  Using it as a new user-id.
-      if exists("g:netrw_machine")
-        if g:netrw_machine =~ '[0-9.]\+'
-          let host= g:netrw_machine
-        else
-          let host= substitute(g:netrw_machine,'\..*$','','')
+        " change host and username if not previously entered; get new password
+        if !exists("g:netrw_machine")
+            let g:netrw_machine= input('Enter hostname: ')
         endif
-      else
-        let g:netrw_machine= input('Enter hostname: ')
-      endif
-      let g:netrw_uid = a:1
-      if exists("g:netrw_passwd")
-        " ask for password if one not previously entered
-        let s:netrw_passwd= g:netrw_passwd
-      else
-        let s:netrw_passwd = inputsecret("Enter Password: ")
-      endif
-    endif
+        if !exists("g:netrw_uid") || g:netrw_uid == ""
+            " get username (user-id) via prompt
+            let g:netrw_uid= input('Enter username: ')
+        endif
+        " get password via prompting
+        let s:netrw_passwd= inputsecret("Enter Password: ")
 
-    if exists("host")
-      if !exists('s:netrw_hup[host]')
-        let s:netrw_hup[host]= {}
-      endif
-      let s:netrw_hup[host].uid    = g:netrw_uid
-      let s:netrw_hup[host].passwd = s:netrw_passwd
-    endif
+        " set up hup database
+        let host = substitute(g:netrw_machine,'\..*$','','')
+        if !exists('s:netrw_hup[host]')
+            let s:netrw_hup[host]= {}
+        endif
+        let s:netrw_hup[host].uid    = g:netrw_uid
+        let s:netrw_hup[host].passwd = s:netrw_passwd
 
-  elseif a:0 == 2
-    let g:netrw_uid    = a:1
-    let s:netrw_passwd = a:2
+    elseif a:0 == 1
+        " case: one input argument
 
-  elseif a:0 == 3
-    " enter hostname, user-id, and password into the hup dictionary
-    let host = substitute(a:1,'^\a\+:','','')
-    let host = substitute(host,'\..*$','','')
-    if !exists('s:netrw_hup[host]')
-      let s:netrw_hup[host]= {}
+        if a:1 =~ '^ftp:'
+            " get host from ftp:... url
+            " access userid and password from hup (host-user-passwd) dictionary
+            let host = substitute(a:1,'^ftp:','','')
+            let host = substitute(host,'\..*','','')
+            if exists("s:netrw_hup[host]")
+                let g:netrw_uid    = s:netrw_hup[host].uid
+                let s:netrw_passwd = s:netrw_hup[host].passwd
+            else
+                let g:netrw_uid    = input("Enter UserId: ")
+                let s:netrw_passwd = inputsecret("Enter Password: ")
+            endif
+
+        else
+            " case: one input argument, not an url.  Using it as a new user-id.
+            if exists("g:netrw_machine")
+                if g:netrw_machine =~ '[0-9.]\+'
+                    let host= g:netrw_machine
+                else
+                    let host= substitute(g:netrw_machine,'\..*$','','')
+                endif
+            else
+                let g:netrw_machine= input('Enter hostname: ')
+            endif
+            let g:netrw_uid = a:1
+            if exists("g:netrw_passwd")
+                " ask for password if one not previously entered
+                let s:netrw_passwd= g:netrw_passwd
+            else
+                let s:netrw_passwd = inputsecret("Enter Password: ")
+            endif
+        endif
+
+        if exists("host")
+            if !exists('s:netrw_hup[host]')
+                let s:netrw_hup[host]= {}
+            endif
+            let s:netrw_hup[host].uid    = g:netrw_uid
+            let s:netrw_hup[host].passwd = s:netrw_passwd
+        endif
+
+    elseif a:0 == 2
+        let g:netrw_uid    = a:1
+        let s:netrw_passwd = a:2
+
+    elseif a:0 == 3
+        " enter hostname, user-id, and password into the hup dictionary
+        let host = substitute(a:1,'^\a\+:','','')
+        let host = substitute(host,'\..*$','','')
+        if !exists('s:netrw_hup[host]')
+            let s:netrw_hup[host]= {}
+        endif
+        let s:netrw_hup[host].uid    = a:2
+        let s:netrw_hup[host].passwd = a:3
+        let g:netrw_uid              = s:netrw_hup[host].uid
+        let s:netrw_passwd           = s:netrw_hup[host].passwd
     endif
-    let s:netrw_hup[host].uid    = a:2
-    let s:netrw_hup[host].passwd = a:3
-    let g:netrw_uid              = s:netrw_hup[host].uid
-    let s:netrw_passwd           = s:netrw_hup[host].passwd
-  endif
 
 endfun
 
@@ -2783,10 +2761,10 @@ endfun
 
 " s:ExplorePatHls: converts an Explore pattern into a regular expression search pattern {{{2
 fun! s:ExplorePatHls(pattern)
-  let repat= substitute(a:pattern,'^**/\{1,2}','','')
-  let repat= escape(repat,'][.\')
-  let repat= '\<'.substitute(repat,'\*','\\(\\S\\+ \\)*\\S\\+','g').'\>'
-  return repat
+    let repat= substitute(a:pattern,'^**/\{1,2}','','')
+    let repat= escape(repat,'][.\')
+    let repat= '\<'.substitute(repat,'\*','\\(\\S\\+ \\)*\\S\\+','g').'\>'
+    return repat
 endfun
 
 "  s:NetrwBookHistHandler: {{{2
@@ -2798,185 +2776,185 @@ endfun
 "    5: (user: <U>)    go down (next)     directory, using history
 "    6: (user: <mB>)   delete bookmark
 fun! s:NetrwBookHistHandler(chg,curdir)
-  if !exists("g:netrw_dirhistmax") || g:netrw_dirhistmax <= 0
-    return
-  endif
-
-  let ykeep    = @@
-  let curbufnr = bufnr("%")
-
-  if a:chg == 0
-    " bookmark the current directory
-    if exists("s:netrwmarkfilelist_{curbufnr}")
-      call s:NetrwBookmark(0)
-      echo "bookmarked marked files"
-    else
-      call s:MakeBookmark(a:curdir)
-      echo "bookmarked the current directory"
+    if !exists("g:netrw_dirhistmax") || g:netrw_dirhistmax <= 0
+        return
     endif
 
-    try
-      call s:NetrwBookHistSave()
-    catch
-    endtry
+    let ykeep    = @@
+    let curbufnr = bufnr("%")
 
-  elseif a:chg == 1
-    " change to the bookmarked directory
-    if exists("g:netrw_bookmarklist[v:count-1]")
-      exe "NetrwKeepj e ".fnameescape(g:netrw_bookmarklist[v:count-1])
-    else
-      echomsg "Sorry, bookmark#".v:count." doesn't exist!"
-    endif
-
-  elseif a:chg == 2
-    "   redraw!
-    let didwork= 0
-    " list user's bookmarks
-    if exists("g:netrw_bookmarklist")
-      let cnt= 1
-      for bmd in g:netrw_bookmarklist
-        echo printf("Netrw Bookmark#%-2d: %s",cnt,g:netrw_bookmarklist[cnt-1])
-        let didwork = 1
-        let cnt     = cnt + 1
-      endfor
-    endif
-
-    " list directory history
-    " Note: history is saved only when PerformListing is done;
-    "       ie. when netrw can re-use a netrw buffer, the current directory is not saved in the history.
-    let cnt     = g:netrw_dirhistcnt
-    let first   = 1
-    let histcnt = 0
-    if g:netrw_dirhistmax > 0
-      while ( first || cnt != g:netrw_dirhistcnt )
-        if exists("g:netrw_dirhist_{cnt}")
-          echo printf("Netrw  History#%-2d: %s",histcnt,g:netrw_dirhist_{cnt})
-          let didwork= 1
+    if a:chg == 0
+        " bookmark the current directory
+        if exists("s:netrwmarkfilelist_{curbufnr}")
+            call s:NetrwBookmark(0)
+            echo "bookmarked marked files"
+        else
+            call s:MakeBookmark(a:curdir)
+            echo "bookmarked the current directory"
         endif
-        let histcnt = histcnt + 1
-        let first   = 0
-        let cnt     = ( cnt - 1 ) % g:netrw_dirhistmax
-        if cnt < 0
-          let cnt= cnt + g:netrw_dirhistmax
+
+        try
+            call s:NetrwBookHistSave()
+        catch
+        endtry
+
+    elseif a:chg == 1
+        " change to the bookmarked directory
+        if exists("g:netrw_bookmarklist[v:count-1]")
+            exe "NetrwKeepj e ".fnameescape(g:netrw_bookmarklist[v:count-1])
+        else
+            echomsg "Sorry, bookmark#".v:count." doesn't exist!"
         endif
-      endwhile
-    else
-      let g:netrw_dirhistcnt= 0
-    endif
-    if didwork
-      call inputsave()|call input("Press <cr> to continue")|call inputrestore()
-    endif
 
-  elseif a:chg == 3
-    " saves most recently visited directories (when they differ)
-    if !exists("g:netrw_dirhistcnt") || !exists("g:netrw_dirhist_{g:netrw_dirhistcnt}") || g:netrw_dirhist_{g:netrw_dirhistcnt} != a:curdir
-      if g:netrw_dirhistmax > 0
-        let g:netrw_dirhistcnt                   = ( g:netrw_dirhistcnt + 1 ) % g:netrw_dirhistmax
-        let g:netrw_dirhist_{g:netrw_dirhistcnt} = a:curdir
-      endif
-    endif
-
-  elseif a:chg == 4
-    " u: change to the previous directory stored on the history list
-    if g:netrw_dirhistmax > 0
-      let g:netrw_dirhistcnt= ( g:netrw_dirhistcnt - v:count1 ) % g:netrw_dirhistmax
-      if g:netrw_dirhistcnt < 0
-        let g:netrw_dirhistcnt= g:netrw_dirhistcnt + g:netrw_dirhistmax
-      endif
-    else
-      let g:netrw_dirhistcnt= 0
-    endif
-    if exists("g:netrw_dirhist_{g:netrw_dirhistcnt}")
-      if exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST && exists("b:netrw_curdir")
-        setl ma noro
-        sil! NetrwKeepj %d _
-        setl nomod
-      endif
-      exe "NetrwKeepj e! ".fnameescape(g:netrw_dirhist_{g:netrw_dirhistcnt})
-    else
-      if g:netrw_dirhistmax > 0
-        let g:netrw_dirhistcnt= ( g:netrw_dirhistcnt + v:count1 ) % g:netrw_dirhistmax
-      else
-        let g:netrw_dirhistcnt= 0
-      endif
-      echo "Sorry, no predecessor directory exists yet"
-    endif
-
-  elseif a:chg == 5
-    " U: change to the subsequent directory stored on the history list
-    if g:netrw_dirhistmax > 0
-      let g:netrw_dirhistcnt= ( g:netrw_dirhistcnt + 1 ) % g:netrw_dirhistmax
-      if exists("g:netrw_dirhist_{g:netrw_dirhistcnt}")
-        if exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST && exists("b:netrw_curdir")
-          setl ma noro
-          sil! NetrwKeepj %d _
-          setl nomod
+    elseif a:chg == 2
+        "   redraw!
+        let didwork= 0
+        " list user's bookmarks
+        if exists("g:netrw_bookmarklist")
+            let cnt= 1
+            for bmd in g:netrw_bookmarklist
+                echo printf("Netrw Bookmark#%-2d: %s",cnt,g:netrw_bookmarklist[cnt-1])
+                let didwork = 1
+                let cnt     = cnt + 1
+            endfor
         endif
-        exe "NetrwKeepj e! ".fnameescape(g:netrw_dirhist_{g:netrw_dirhistcnt})
-      else
-        let g:netrw_dirhistcnt= ( g:netrw_dirhistcnt - 1 ) % g:netrw_dirhistmax
-        if g:netrw_dirhistcnt < 0
-          let g:netrw_dirhistcnt= g:netrw_dirhistcnt + g:netrw_dirhistmax
+
+        " list directory history
+        " Note: history is saved only when PerformListing is done;
+        "       ie. when netrw can re-use a netrw buffer, the current directory is not saved in the history.
+        let cnt     = g:netrw_dirhistcnt
+        let first   = 1
+        let histcnt = 0
+        if g:netrw_dirhistmax > 0
+            while ( first || cnt != g:netrw_dirhistcnt )
+                if exists("g:netrw_dirhist_{cnt}")
+                    echo printf("Netrw  History#%-2d: %s",histcnt,g:netrw_dirhist_{cnt})
+                    let didwork= 1
+                endif
+                let histcnt = histcnt + 1
+                let first   = 0
+                let cnt     = ( cnt - 1 ) % g:netrw_dirhistmax
+                if cnt < 0
+                    let cnt= cnt + g:netrw_dirhistmax
+                endif
+            endwhile
+        else
+            let g:netrw_dirhistcnt= 0
         endif
-        echo "Sorry, no successor directory exists yet"
-      endif
-    else
-      let g:netrw_dirhistcnt= 0
-      echo "Sorry, no successor directory exists yet (g:netrw_dirhistmax is ".g:netrw_dirhistmax.")"
-    endif
+        if didwork
+            call inputsave()|call input("Press <cr> to continue")|call inputrestore()
+        endif
 
-  elseif a:chg == 6
-    if exists("s:netrwmarkfilelist_{curbufnr}")
-      call s:NetrwBookmark(1)
-      echo "removed marked files from bookmarks"
-    else
-      " delete the v:count'th bookmark
-      let iremove = v:count
-      let dremove = g:netrw_bookmarklist[iremove - 1]
-      call s:MergeBookmarks()
-      NetrwKeepj call remove(g:netrw_bookmarklist,iremove-1)
-      echo "removed ".dremove." from g:netrw_bookmarklist"
-    endif
+    elseif a:chg == 3
+        " saves most recently visited directories (when they differ)
+        if !exists("g:netrw_dirhistcnt") || !exists("g:netrw_dirhist_{g:netrw_dirhistcnt}") || g:netrw_dirhist_{g:netrw_dirhistcnt} != a:curdir
+            if g:netrw_dirhistmax > 0
+                let g:netrw_dirhistcnt                   = ( g:netrw_dirhistcnt + 1 ) % g:netrw_dirhistmax
+                let g:netrw_dirhist_{g:netrw_dirhistcnt} = a:curdir
+            endif
+        endif
 
-    try
-      call s:NetrwBookHistSave()
-    catch
-    endtry
-  endif
-  call s:NetrwBookmarkMenu()
-  call s:NetrwTgtMenu()
-  let @@= ykeep
+    elseif a:chg == 4
+        " u: change to the previous directory stored on the history list
+        if g:netrw_dirhistmax > 0
+            let g:netrw_dirhistcnt= ( g:netrw_dirhistcnt - v:count1 ) % g:netrw_dirhistmax
+            if g:netrw_dirhistcnt < 0
+                let g:netrw_dirhistcnt= g:netrw_dirhistcnt + g:netrw_dirhistmax
+            endif
+        else
+            let g:netrw_dirhistcnt= 0
+        endif
+        if exists("g:netrw_dirhist_{g:netrw_dirhistcnt}")
+            if exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST && exists("b:netrw_curdir")
+                setl ma noro
+                sil! NetrwKeepj %d _
+                setl nomod
+            endif
+            exe "NetrwKeepj e! ".fnameescape(g:netrw_dirhist_{g:netrw_dirhistcnt})
+        else
+            if g:netrw_dirhistmax > 0
+                let g:netrw_dirhistcnt= ( g:netrw_dirhistcnt + v:count1 ) % g:netrw_dirhistmax
+            else
+                let g:netrw_dirhistcnt= 0
+            endif
+            echo "Sorry, no predecessor directory exists yet"
+        endif
+
+    elseif a:chg == 5
+        " U: change to the subsequent directory stored on the history list
+        if g:netrw_dirhistmax > 0
+            let g:netrw_dirhistcnt= ( g:netrw_dirhistcnt + 1 ) % g:netrw_dirhistmax
+            if exists("g:netrw_dirhist_{g:netrw_dirhistcnt}")
+                if exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST && exists("b:netrw_curdir")
+                    setl ma noro
+                    sil! NetrwKeepj %d _
+                    setl nomod
+                endif
+                exe "NetrwKeepj e! ".fnameescape(g:netrw_dirhist_{g:netrw_dirhistcnt})
+            else
+                let g:netrw_dirhistcnt= ( g:netrw_dirhistcnt - 1 ) % g:netrw_dirhistmax
+                if g:netrw_dirhistcnt < 0
+                    let g:netrw_dirhistcnt= g:netrw_dirhistcnt + g:netrw_dirhistmax
+                endif
+                echo "Sorry, no successor directory exists yet"
+            endif
+        else
+            let g:netrw_dirhistcnt= 0
+            echo "Sorry, no successor directory exists yet (g:netrw_dirhistmax is ".g:netrw_dirhistmax.")"
+        endif
+
+    elseif a:chg == 6
+        if exists("s:netrwmarkfilelist_{curbufnr}")
+            call s:NetrwBookmark(1)
+            echo "removed marked files from bookmarks"
+        else
+            " delete the v:count'th bookmark
+            let iremove = v:count
+            let dremove = g:netrw_bookmarklist[iremove - 1]
+            call s:MergeBookmarks()
+            NetrwKeepj call remove(g:netrw_bookmarklist,iremove-1)
+            echo "removed ".dremove." from g:netrw_bookmarklist"
+        endif
+
+        try
+            call s:NetrwBookHistSave()
+        catch
+        endtry
+    endif
+    call s:NetrwBookmarkMenu()
+    call s:NetrwTgtMenu()
+    let @@= ykeep
 endfun
 
 " s:NetrwBookHistRead: this function reads bookmarks and history {{{2
 "  Will source the history file (.netrwhist) only if the g:netrw_disthistmax is > 0.
 "                      Sister function: s:NetrwBookHistSave()
 fun! s:NetrwBookHistRead()
-  if !exists("g:netrw_dirhistmax") || g:netrw_dirhistmax <= 0
-    return
-  endif
-  let ykeep= @@
+    if !exists("g:netrw_dirhistmax") || g:netrw_dirhistmax <= 0
+        return
+    endif
+    let ykeep= @@
 
-  " read bookmarks
-  if !exists("s:netrw_initbookhist")
-    let home    = s:NetrwHome()
-    let savefile= home."/.netrwbook"
-    if filereadable(s:NetrwFile(savefile))
-      exe "keepalt NetrwKeepj so ".savefile
+    " read bookmarks
+    if !exists("s:netrw_initbookhist")
+        let home    = s:NetrwHome()
+        let savefile= home."/.netrwbook"
+        if filereadable(s:NetrwFile(savefile))
+            exe "keepalt NetrwKeepj so ".savefile
+        endif
+
+        " read history
+        if g:netrw_dirhistmax > 0
+            let savefile= home."/.netrwhist"
+            if filereadable(s:NetrwFile(savefile))
+                exe "keepalt NetrwKeepj so ".savefile
+            endif
+            let s:netrw_initbookhist= 1
+            au VimLeave * call s:NetrwBookHistSave()
+        endif
     endif
 
-    " read history
-    if g:netrw_dirhistmax > 0
-      let savefile= home."/.netrwhist"
-      if filereadable(s:NetrwFile(savefile))
-        exe "keepalt NetrwKeepj so ".savefile
-      endif
-      let s:netrw_initbookhist= 1
-      au VimLeave * call s:NetrwBookHistSave()
-    endif
-  endif
-
-  let @@= ykeep
+    let @@= ykeep
 endfun
 
 " s:NetrwBookHistSave: this function saves bookmarks and history to files {{{2
@@ -2987,75 +2965,75 @@ endfun
 "                      will be saved.
 "                      (s:NetrwBookHistHandler(3,...) used to record history)
 fun! s:NetrwBookHistSave()
-  if !exists("g:netrw_dirhistmax") || g:netrw_dirhistmax <= 0
-    return
-  endif
-
-  let savefile= s:NetrwHome()."/.netrwhist"
-  1split
-
-  " setting up a new buffer which will become .netrwhist
-  call s:NetrwEnew()
-  if g:netrw_use_noswf
-    setl cino= com= cpo-=a cpo-=A fo=nroql2 tw=0 report=10000 noswf
-  else
-    setl cino= com= cpo-=a cpo-=A fo=nroql2 tw=0 report=10000
-  endif
-  setl nocin noai noci magic nospell nohid wig= noaw
-  setl ma noro write
-  if exists("+acd") | setl noacd | endif
-  sil! NetrwKeepj keepalt %d _
-
-  " rename enew'd file: .netrwhist -- no attempt to merge
-  " record dirhistmax and current dirhistcnt
-  " save history
-  sil! keepalt file .netrwhist
-  call setline(1,"let g:netrw_dirhistmax  =".g:netrw_dirhistmax)
-  call setline(2,"let g:netrw_dirhistcnt =".g:netrw_dirhistcnt)
-  if g:netrw_dirhistmax > 0
-    let lastline = line("$")
-    let cnt      = g:netrw_dirhistcnt
-    let first    = 1
-    while ( first || cnt != g:netrw_dirhistcnt )
-      let lastline= lastline + 1
-      if exists("g:netrw_dirhist_{cnt}")
-        call setline(lastline,'let g:netrw_dirhist_'.cnt."='".g:netrw_dirhist_{cnt}."'")
-      endif
-      let first   = 0
-      let cnt     = ( cnt - 1 ) % g:netrw_dirhistmax
-      if cnt < 0
-        let cnt= cnt + g:netrw_dirhistmax
-      endif
-    endwhile
-    exe "sil! w! ".savefile
-  endif
-
-  " save bookmarks
-  sil NetrwKeepj %d _
-  if exists("g:netrw_bookmarklist") && g:netrw_bookmarklist != []
-    " merge and write .netrwbook
-    let savefile= s:NetrwHome()."/.netrwbook"
-
-    if filereadable(s:NetrwFile(savefile))
-      let booklist= deepcopy(g:netrw_bookmarklist)
-      exe "sil NetrwKeepj keepalt so ".savefile
-      for bdm in booklist
-        if index(g:netrw_bookmarklist,bdm) == -1
-          call add(g:netrw_bookmarklist,bdm)
-        endif
-      endfor
-      call sort(g:netrw_bookmarklist)
+    if !exists("g:netrw_dirhistmax") || g:netrw_dirhistmax <= 0
+        return
     endif
 
-    " construct and save .netrwbook
-    call setline(1,"let g:netrw_bookmarklist= ".string(g:netrw_bookmarklist))
-    exe "sil! w! ".savefile
-  endif
+    let savefile= s:NetrwHome()."/.netrwhist"
+    1split
 
-  " cleanup -- remove buffer used to construct history
-  let bgone= bufnr("%")
-  q!
-  exe "keepalt ".bgone."bwipe!"
+    " setting up a new buffer which will become .netrwhist
+    call s:NetrwEnew()
+    if g:netrw_use_noswf
+        setl cino= com= cpo-=a cpo-=A fo=nroql2 tw=0 report=10000 noswf
+    else
+        setl cino= com= cpo-=a cpo-=A fo=nroql2 tw=0 report=10000
+    endif
+    setl nocin noai noci magic nospell nohid wig= noaw
+    setl ma noro write
+    if exists("+acd") | setl noacd | endif
+    sil! NetrwKeepj keepalt %d _
+
+    " rename enew'd file: .netrwhist -- no attempt to merge
+    " record dirhistmax and current dirhistcnt
+    " save history
+    sil! keepalt file .netrwhist
+    call setline(1,"let g:netrw_dirhistmax  =".g:netrw_dirhistmax)
+    call setline(2,"let g:netrw_dirhistcnt =".g:netrw_dirhistcnt)
+    if g:netrw_dirhistmax > 0
+        let lastline = line("$")
+        let cnt      = g:netrw_dirhistcnt
+        let first    = 1
+        while ( first || cnt != g:netrw_dirhistcnt )
+            let lastline= lastline + 1
+            if exists("g:netrw_dirhist_{cnt}")
+                call setline(lastline,'let g:netrw_dirhist_'.cnt."='".g:netrw_dirhist_{cnt}."'")
+            endif
+            let first   = 0
+            let cnt     = ( cnt - 1 ) % g:netrw_dirhistmax
+            if cnt < 0
+                let cnt= cnt + g:netrw_dirhistmax
+            endif
+        endwhile
+        exe "sil! w! ".savefile
+    endif
+
+    " save bookmarks
+    sil NetrwKeepj %d _
+    if exists("g:netrw_bookmarklist") && g:netrw_bookmarklist != []
+        " merge and write .netrwbook
+        let savefile= s:NetrwHome()."/.netrwbook"
+
+        if filereadable(s:NetrwFile(savefile))
+            let booklist= deepcopy(g:netrw_bookmarklist)
+            exe "sil NetrwKeepj keepalt so ".savefile
+            for bdm in booklist
+                if index(g:netrw_bookmarklist,bdm) == -1
+                    call add(g:netrw_bookmarklist,bdm)
+                endif
+            endfor
+            call sort(g:netrw_bookmarklist)
+        endif
+
+        " construct and save .netrwbook
+        call setline(1,"let g:netrw_bookmarklist= ".string(g:netrw_bookmarklist))
+        exe "sil! w! ".savefile
+    endif
+
+    " cleanup -- remove buffer used to construct history
+    let bgone= bufnr("%")
+    q!
+    exe "keepalt ".bgone."bwipe!"
 
 endfun
 
@@ -3065,246 +3043,244 @@ endfun
 "  with the requested remote hostname first.
 "    Often called via:  Explore/e dirname/etc -> netrw#LocalBrowseCheck() -> s:NetrwBrowse()
 fun! s:NetrwBrowse(islocal,dirname)
-  if !exists("w:netrw_liststyle")|let w:netrw_liststyle= g:netrw_liststyle|endif
+    if !exists("w:netrw_liststyle")|let w:netrw_liststyle= g:netrw_liststyle|endif
 
-  " save alternate-file's filename if w:netrw_rexlocal doesn't exist
-  " This is useful when one edits a local file, then :e ., then :Rex
-  if a:islocal && !exists("w:netrw_rexfile") && bufname("#") != ""
-    let w:netrw_rexfile= bufname("#")
-  endif
-
-  " s:NetrwBrowse : initialize history {{{3
-  if !exists("s:netrw_initbookhist")
-    NetrwKeepj call s:NetrwBookHistRead()
-  endif
-
-  " s:NetrwBrowse : simplify the dirname (especially for ".."s in dirnames) {{{3
-  if a:dirname !~ '^\a\{3,}://'
-    let dirname= simplify(a:dirname)
-  else
-    let dirname= a:dirname
-  endif
-
-  " repoint t:netrw_lexbufnr if appropriate
-  if exists("t:netrw_lexbufnr") && bufnr("%") == t:netrw_lexbufnr
-    let repointlexbufnr= 1
-  endif
-
-  " s:NetrwBrowse : sanity checks: {{{3
-  if exists("s:netrw_skipbrowse")
-    unlet s:netrw_skipbrowse
-    return
-  endif
-  if !exists("*shellescape")
-    call netrw#msg#Notify('ERROR', "netrw can't run -- your vim is missing shellescape()")
-    return
-  endif
-  if !exists("*fnameescape")
-    call netrw#msg#Notify('ERROR', "netrw can't run -- your vim is missing fnameescape()")
-    return
-  endif
-
-  " s:NetrwBrowse : save options: {{{3
-  call s:NetrwOptionsSave("w:")
-
-  " s:NetrwBrowse : re-instate any marked files {{{3
-  if has("syntax") && exists("g:syntax_on") && g:syntax_on
-    if exists("s:netrwmarkfilelist_{bufnr('%')}")
-      exe "2match netrwMarkFile /".s:netrwmarkfilemtch_{bufnr("%")}."/"
-    endif
-  endif
-
-  if a:islocal && exists("w:netrw_acdkeep") && w:netrw_acdkeep
-    " s:NetrwBrowse : set up "safe" options for local directory/file {{{3
-    if s:NetrwLcd(dirname)
-      return
+    " save alternate-file's filename if w:netrw_rexlocal doesn't exist
+    " This is useful when one edits a local file, then :e ., then :Rex
+    if a:islocal && !exists("w:netrw_rexfile") && bufname("#") != ""
+        let w:netrw_rexfile= bufname("#")
     endif
 
-  elseif !a:islocal && dirname !~ '[\/]$' && dirname !~ '^"'
-    " s:NetrwBrowse :  remote regular file handler {{{3
-    if bufname(dirname) != ""
-      exe "NetrwKeepj b ".bufname(dirname)
+    " s:NetrwBrowse : initialize history {{{3
+    if !exists("s:netrw_initbookhist")
+        NetrwKeepj call s:NetrwBookHistRead()
+    endif
+
+    " s:NetrwBrowse : simplify the dirname (especially for ".."s in dirnames) {{{3
+    if a:dirname !~ '^\a\{3,}://'
+        let dirname= simplify(a:dirname)
     else
-      " attempt transfer of remote regular file
-
-      " remove any filetype indicator from end of dirname, except for the
-      " "this is a directory" indicator (/).
-      " There shouldn't be one of those here, anyway.
-      let path= substitute(dirname,'[*=@|]\r\=$','','e')
-      call s:RemotePathAnalysis(dirname)
-
-      " s:NetrwBrowse : remote-read the requested file into current buffer {{{3
-      call s:NetrwEnew(dirname)
-      call s:NetrwOptionsSafe(a:islocal)
-      setl ma noro
-      let b:netrw_curdir = dirname
-      let url            = s:method."://".((s:user == "")? "" : s:user."@").s:machine.(s:port ? ":".s:port : "")."/".s:path
-      call s:NetrwBufRename(url)
-      exe "sil! NetrwKeepj keepalt doau BufReadPre ".fnameescape(s:fname)
-      sil call netrw#NetRead(2,url)
-      " netrw.vim and tar.vim have already handled decompression of the tarball; avoiding gzip.vim error
-      if s:path =~ '.bz2'
-        exe "sil NetrwKeepj keepalt doau BufReadPost ".fnameescape(substitute(s:fname,'\.bz2$','',''))
-      elseif s:path =~ '.gz'
-        exe "sil NetrwKeepj keepalt doau BufReadPost ".fnameescape(substitute(s:fname,'\.gz$','',''))
-      elseif s:path =~ '.gz'
-        exe "sil NetrwKeepj keepalt doau BufReadPost ".fnameescape(substitute(s:fname,'\.txz$','',''))
-      else
-        exe "sil NetrwKeepj keepalt doau BufReadPost ".fnameescape(s:fname)
-      endif
+        let dirname= a:dirname
     endif
 
-    " s:NetrwBrowse : save certain window-oriented variables into buffer-oriented variables {{{3
-    call s:SetBufWinVars()
-    call s:NetrwOptionsRestore("w:")
-    setl ma nomod noro
-    return
-  endif
-
-  " use buffer-oriented WinVars if buffer variables exist but associated window variables don't {{{3
-  call s:UseBufWinVars()
-
-  " set up some variables {{{3
-  let b:netrw_browser_active = 1
-  let dirname                = dirname
-  let s:last_sort_by         = g:netrw_sort_by
-
-  " set up menu {{{3
-  NetrwKeepj call s:NetrwMenu(1)
-
-  " get/set-up buffer {{{3
-  let svpos  = winsaveview()
-
-  " NetrwGetBuffer might change buffers but s:rexposn_X was set for the
-  " previous buffer
-  let prevbufnr = bufnr('%')
-  let reusing= s:NetrwGetBuffer(a:islocal,dirname)
-  if exists("s:rexposn_".prevbufnr)
-    let s:rexposn_{bufnr('%')} = s:rexposn_{prevbufnr}
-  endif
-
-  " maintain markfile highlighting
-  if has("syntax") && exists("g:syntax_on") && g:syntax_on
-    if exists("s:netrwmarkfilemtch_{bufnr('%')}") && s:netrwmarkfilemtch_{bufnr("%")} != ""
-      exe "2match netrwMarkFile /".s:netrwmarkfilemtch_{bufnr("%")}."/"
-    else
-      2match none
+    " repoint t:netrw_lexbufnr if appropriate
+    if exists("t:netrw_lexbufnr") && bufnr("%") == t:netrw_lexbufnr
+        let repointlexbufnr= 1
     endif
-  endif
-  if reusing && line("$") > 1
-    call s:NetrwOptionsRestore("w:")
-    setl noma nomod nowrap
-    return
-  endif
 
-  " set b:netrw_curdir to the new directory name {{{3
-  let b:netrw_curdir= dirname
-  if b:netrw_curdir =~ '[/\\]$'
-    let b:netrw_curdir= substitute(b:netrw_curdir,'[/\\]$','','e')
-  endif
-  if b:netrw_curdir =~ '\a:$' && has("win32")
-    let b:netrw_curdir= b:netrw_curdir."/"
-  endif
-  if b:netrw_curdir == ''
-    if has("amiga")
-      " On the Amiga, the empty string connotes the current directory
-      let b:netrw_curdir= getcwd()
-    else
-      " under unix, when the root directory is encountered, the result
-      " from the preceding substitute is an empty string.
-      let b:netrw_curdir= '/'
+    " s:NetrwBrowse : sanity checks: {{{3
+    if exists("s:netrw_skipbrowse")
+        unlet s:netrw_skipbrowse
+        return
     endif
-  endif
-  if !a:islocal && b:netrw_curdir !~ '/$'
-    let b:netrw_curdir= b:netrw_curdir.'/'
-  endif
+    if !exists("*shellescape")
+        call netrw#msg#Notify('ERROR', "netrw can't run -- your vim is missing shellescape()")
+        return
+    endif
+    if !exists("*fnameescape")
+        call netrw#msg#Notify('ERROR', "netrw can't run -- your vim is missing fnameescape()")
+        return
+    endif
 
-  " ------------
-  " (local only) {{{3
-  " ------------
-  if a:islocal
-    " Set up ShellCmdPost handling.  Append current buffer to browselist
-    call s:LocalFastBrowser()
+    " s:NetrwBrowse : save options: {{{3
+    call s:NetrwOptionsSave("w:")
 
-    " handle g:netrw_keepdir: set vim's current directory to netrw's notion of the current directory {{{3
-    if !g:netrw_keepdir
-      if !exists("&l:acd") || !&l:acd
-        if s:NetrwLcd(b:netrw_curdir)
-          return
+    " s:NetrwBrowse : re-instate any marked files {{{3
+    if has("syntax") && exists("g:syntax_on") && g:syntax_on
+        if exists("s:netrwmarkfilelist_{bufnr('%')}")
+            exe "2match netrwMarkFile /".s:netrwmarkfilemtch_{bufnr("%")}."/"
         endif
-      endif
     endif
 
-  " --------------------------------
-  " remote handling: {{{3
-  " --------------------------------
-  else
+    if a:islocal && exists("w:netrw_acdkeep") && w:netrw_acdkeep
+        " s:NetrwBrowse : set up "safe" options for local directory/file {{{3
+        if s:NetrwLcd(dirname)
+            return
+        endif
 
-    " analyze dirname and g:netrw_list_cmd {{{3
-    if dirname =~# "^NetrwTreeListing\>"
-      let dirname= b:netrw_curdir
-    elseif exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST && exists("b:netrw_curdir")
-      let dirname= substitute(b:netrw_curdir,'\\','/','g')
-      if dirname !~ '/$'
-        let dirname= dirname.'/'
-      endif
-      let b:netrw_curdir = dirname
-    else
-      let dirname = substitute(dirname,'\\','/','g')
+    elseif !a:islocal && dirname !~ '[\/]$' && dirname !~ '^"'
+        " s:NetrwBrowse :  remote regular file handler {{{3
+        if bufname(dirname) != ""
+            exe "NetrwKeepj b ".bufname(dirname)
+        else
+            " attempt transfer of remote regular file
+
+            " remove any filetype indicator from end of dirname, except for the
+            " "this is a directory" indicator (/).
+            " There shouldn't be one of those here, anyway.
+            let path= substitute(dirname,'[*=@|]\r\=$','','e')
+            call s:RemotePathAnalysis(dirname)
+
+            " s:NetrwBrowse : remote-read the requested file into current buffer {{{3
+            call s:NetrwEnew(dirname)
+            call s:NetrwOptionsSafe(a:islocal)
+            setl ma noro
+            let b:netrw_curdir = dirname
+            let url            = s:method."://".((s:user == "")? "" : s:user."@").s:machine.(s:port ? ":".s:port : "")."/".s:path
+            call s:NetrwBufRename(url)
+            exe "sil! NetrwKeepj keepalt doau BufReadPre ".fnameescape(s:fname)
+            sil call netrw#NetRead(2,url)
+            " netrw.vim and tar.vim have already handled decompression of the tarball; avoiding gzip.vim error
+            if s:path =~ '.bz2'
+                exe "sil NetrwKeepj keepalt doau BufReadPost ".fnameescape(substitute(s:fname,'\.bz2$','',''))
+            elseif s:path =~ '.gz'
+                exe "sil NetrwKeepj keepalt doau BufReadPost ".fnameescape(substitute(s:fname,'\.gz$','',''))
+            elseif s:path =~ '.gz'
+                exe "sil NetrwKeepj keepalt doau BufReadPost ".fnameescape(substitute(s:fname,'\.txz$','',''))
+            else
+                exe "sil NetrwKeepj keepalt doau BufReadPost ".fnameescape(s:fname)
+            endif
+        endif
+
+        " s:NetrwBrowse : save certain window-oriented variables into buffer-oriented variables {{{3
+        call s:SetBufWinVars()
+        call s:NetrwOptionsRestore("w:")
+        setl ma nomod noro
+        return
     endif
 
-    let dirpat  = '^\(\w\{-}\)://\(\w\+@\)\=\([^/]\+\)/\(.*\)$'
-    if dirname !~ dirpat
-      if !exists("g:netrw_quiet")
-        call netrw#msg#Notify('ERROR', printf("netrw doesn't understand your dirname<%s>", dirname))
-      endif
-      NetrwKeepj call s:NetrwOptionsRestore("w:")
-      setl noma nomod nowrap
-      return
+    " use buffer-oriented WinVars if buffer variables exist but associated window variables don't {{{3
+    call s:UseBufWinVars()
+
+    " set up some variables {{{3
+    let b:netrw_browser_active = 1
+    let dirname                = dirname
+    let s:last_sort_by         = g:netrw_sort_by
+
+    " set up menu {{{3
+    NetrwKeepj call s:NetrwMenu(1)
+
+    " get/set-up buffer {{{3
+    let svpos  = winsaveview()
+
+    " NetrwGetBuffer might change buffers but s:rexposn_X was set for the
+    " previous buffer
+    let prevbufnr = bufnr('%')
+    let reusing= s:NetrwGetBuffer(a:islocal,dirname)
+    if exists("s:rexposn_".prevbufnr)
+        let s:rexposn_{bufnr('%')} = s:rexposn_{prevbufnr}
     endif
+
+    " maintain markfile highlighting
+    if has("syntax") && exists("g:syntax_on") && g:syntax_on
+        if exists("s:netrwmarkfilemtch_{bufnr('%')}") && s:netrwmarkfilemtch_{bufnr("%")} != ""
+            exe "2match netrwMarkFile /".s:netrwmarkfilemtch_{bufnr("%")}."/"
+        else
+            2match none
+        endif
+    endif
+    if reusing && line("$") > 1
+        call s:NetrwOptionsRestore("w:")
+        setl noma nomod nowrap
+        return
+    endif
+
+    " set b:netrw_curdir to the new directory name {{{3
     let b:netrw_curdir= dirname
-  endif  " (additional remote handling)
-
-  " -------------------------------
-  " Perform Directory Listing: {{{3
-  " -------------------------------
-  NetrwKeepj call s:NetrwMaps(a:islocal)
-  NetrwKeepj call s:NetrwCommands(a:islocal)
-  NetrwKeepj call s:PerformListing(a:islocal)
-
-  " restore option(s)
-  call s:NetrwOptionsRestore("w:")
-
-  " If there is a rexposn: restore position with rexposn
-  " Otherwise            : set rexposn
-  if exists("s:rexposn_".bufnr("%"))
-    NetrwKeepj call winrestview(s:rexposn_{bufnr('%')})
-    if exists("w:netrw_bannercnt") && line(".") < w:netrw_bannercnt
-      NetrwKeepj exe w:netrw_bannercnt
+    if b:netrw_curdir =~ '[/\\]$'
+        let b:netrw_curdir= substitute(b:netrw_curdir,'[/\\]$','','e')
     endif
-  else
-    NetrwKeepj call s:SetRexDir(a:islocal,b:netrw_curdir)
-  endif
+    if b:netrw_curdir =~ '\a:$' && has("win32")
+        let b:netrw_curdir= b:netrw_curdir."/"
+    endif
+    if b:netrw_curdir == ''
+        if has("amiga")
+            " On the Amiga, the empty string connotes the current directory
+            let b:netrw_curdir= getcwd()
+        else
+            " under unix, when the root directory is encountered, the result
+            " from the preceding substitute is an empty string.
+            let b:netrw_curdir= '/'
+        endif
+    endif
+    if !a:islocal && b:netrw_curdir !~ '/$'
+        let b:netrw_curdir= b:netrw_curdir.'/'
+    endif
 
-  if s:has_balloon && &beval == 0 && &l:bexpr == ""
-    let &l:bexpr= "netrw#BalloonHelp()"
-    setl beval
-  endif
+    " ------------
+    " (local only) {{{3
+    " ------------
+    if a:islocal
+        " Set up ShellCmdPost handling.  Append current buffer to browselist
+        call s:LocalFastBrowser()
 
-  " repoint t:netrw_lexbufnr if appropriate
-  if exists("repointlexbufnr")
-    let t:netrw_lexbufnr= bufnr("%")
-  endif
+        " handle g:netrw_keepdir: set vim's current directory to netrw's notion of the current directory {{{3
+        if !g:netrw_keepdir
+            if !exists("&l:acd") || !&l:acd
+                if s:NetrwLcd(b:netrw_curdir)
+                    return
+                endif
+            endif
+        endif
 
-  " restore position
-  if reusing
-    call winrestview(svpos)
-  endif
+    " --------------------------------
+    " remote handling: {{{3
+    " --------------------------------
+    else
 
-  " The s:LocalBrowseRefresh() function is called by an autocmd
-  " installed by s:LocalFastBrowser() when g:netrw_fastbrowse <= 1 (ie. slow or medium speed).
-  " However, s:NetrwBrowse() causes the FocusGained event to fire the first time.
-  return
+        " analyze dirname and g:netrw_list_cmd {{{3
+        if dirname =~# "^NetrwTreeListing\>"
+            let dirname= b:netrw_curdir
+        elseif exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST && exists("b:netrw_curdir")
+            let dirname= substitute(b:netrw_curdir,'\\','/','g')
+            if dirname !~ '/$'
+                let dirname= dirname.'/'
+            endif
+            let b:netrw_curdir = dirname
+        else
+            let dirname = substitute(dirname,'\\','/','g')
+        endif
+
+        let dirpat  = '^\(\w\{-}\)://\(\w\+@\)\=\([^/]\+\)/\(.*\)$'
+        if dirname !~ dirpat
+            call netrw#msg#Notify('ERROR', printf("netrw doesn't understand your dirname<%s>", dirname))
+            NetrwKeepj call s:NetrwOptionsRestore("w:")
+            setl noma nomod nowrap
+            return
+        endif
+        let b:netrw_curdir= dirname
+    endif  " (additional remote handling)
+
+    " -------------------------------
+    " Perform Directory Listing: {{{3
+    " -------------------------------
+    NetrwKeepj call s:NetrwMaps(a:islocal)
+    NetrwKeepj call s:NetrwCommands(a:islocal)
+    NetrwKeepj call s:PerformListing(a:islocal)
+
+    " restore option(s)
+    call s:NetrwOptionsRestore("w:")
+
+    " If there is a rexposn: restore position with rexposn
+    " Otherwise            : set rexposn
+    if exists("s:rexposn_".bufnr("%"))
+        NetrwKeepj call winrestview(s:rexposn_{bufnr('%')})
+        if exists("w:netrw_bannercnt") && line(".") < w:netrw_bannercnt
+            NetrwKeepj exe w:netrw_bannercnt
+        endif
+    else
+        NetrwKeepj call s:SetRexDir(a:islocal,b:netrw_curdir)
+    endif
+
+    if s:has_balloon && &beval == 0 && &l:bexpr == ""
+        let &l:bexpr= "netrw#BalloonHelp()"
+        setl beval
+    endif
+
+    " repoint t:netrw_lexbufnr if appropriate
+    if exists("repointlexbufnr")
+        let t:netrw_lexbufnr= bufnr("%")
+    endif
+
+    " restore position
+    if reusing
+        call winrestview(svpos)
+    endif
+
+    " The s:LocalBrowseRefresh() function is called by an autocmd
+    " installed by s:LocalFastBrowser() when g:netrw_fastbrowse <= 1 (ie. slow or medium speed).
+    " However, s:NetrwBrowse() causes the FocusGained event to fire the first time.
+    return
 endfun
 
 " s:NetrwFile: because of g:netrw_keepdir, isdirectory(), type(), etc may or {{{2
@@ -3314,85 +3290,85 @@ endfun
 " Returns a path to the file specified by a:fname
 fun! s:NetrwFile(fname)
 
-  " clean up any leading treedepthstring
-  if exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST
-    let fname= substitute(a:fname,'^'.s:treedepthstring.'\+','','')
-  else
-    let fname= a:fname
-  endif
-
-  if g:netrw_keepdir
-    " vim's idea of the current directory possibly may differ from netrw's
-    if !exists("b:netrw_curdir")
-      let b:netrw_curdir= getcwd()
-    endif
-
-    if !exists("g:netrw_cygwin") && has("win32")
-      if fname =~ '^\' || fname =~ '^\a:\'
-        " windows, but full path given
-        let ret= fname
-      else
-        " windows, relative path given
-        let ret= netrw#fs#ComposePath(b:netrw_curdir,fname)
-      endif
-
-    elseif fname =~ '^/'
-      " not windows, full path given
-      let ret= fname
+    " clean up any leading treedepthstring
+    if exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST
+        let fname= substitute(a:fname,'^'.s:treedepthstring.'\+','','')
     else
-      " not windows, relative path given
-      let ret= netrw#fs#ComposePath(b:netrw_curdir,fname)
+        let fname= a:fname
     endif
-  else
-    " vim and netrw agree on the current directory
-    let ret= fname
-  endif
 
-  return ret
+    if g:netrw_keepdir
+        " vim's idea of the current directory possibly may differ from netrw's
+        if !exists("b:netrw_curdir")
+            let b:netrw_curdir= getcwd()
+        endif
+
+        if !exists("g:netrw_cygwin") && has("win32")
+            if fname =~ '^\' || fname =~ '^\a:\'
+                " windows, but full path given
+                let ret= fname
+            else
+                " windows, relative path given
+                let ret= netrw#fs#ComposePath(b:netrw_curdir,fname)
+            endif
+
+        elseif fname =~ '^/'
+            " not windows, full path given
+            let ret= fname
+        else
+            " not windows, relative path given
+            let ret= netrw#fs#ComposePath(b:netrw_curdir,fname)
+        endif
+    else
+        " vim and netrw agree on the current directory
+        let ret= fname
+    endif
+
+    return ret
 endfun
 
 " s:NetrwFileInfo: supports qf (query for file information) {{{2
 fun! s:NetrwFileInfo(islocal,fname)
-  let ykeep= @@
-  if a:islocal
-    let lsopt= "-lsad"
-    if g:netrw_sizestyle =~# 'H'
-      let lsopt= "-lsadh"
-    elseif g:netrw_sizestyle =~# 'h'
-      let lsopt= "-lsadh --si"
-    endif
-    if (has("unix") || has("macunix")) && executable("/bin/ls")
+    let ykeep= @@
+    if a:islocal
+        let lsopt= "-lsad"
+        if g:netrw_sizestyle =~# 'H'
+            let lsopt= "-lsadh"
+        elseif g:netrw_sizestyle =~# 'h'
+            let lsopt= "-lsadh --si"
+        endif
+        if (has("unix") || has("macunix")) && executable("/bin/ls")
 
-      if getline(".") == "../"
-        echo system("/bin/ls ".lsopt." ".netrw#os#Escape(".."))
+            if getline(".") == "../"
+                echo system("/bin/ls ".lsopt." ".netrw#os#Escape(".."))
 
-      elseif w:netrw_liststyle == s:TREELIST && getline(".") !~ '^'.s:treedepthstring
-        echo system("/bin/ls ".lsopt." ".netrw#os#Escape(b:netrw_curdir))
+            elseif w:netrw_liststyle == s:TREELIST && getline(".") !~ '^'.s:treedepthstring
+                echo system("/bin/ls ".lsopt." ".netrw#os#Escape(b:netrw_curdir))
 
-      elseif exists("b:netrw_curdir")
-        echo system("/bin/ls ".lsopt." ".netrw#os#Escape(netrw#fs#ComposePath(b:netrw_curdir,a:fname)))
+            elseif exists("b:netrw_curdir")
+                echo system("/bin/ls ".lsopt." ".netrw#os#Escape(netrw#fs#ComposePath(b:netrw_curdir,a:fname)))
 
-      else
-        echo system("/bin/ls ".lsopt." ".netrw#os#Escape(s:NetrwFile(a:fname)))
-      endif
+            else
+                echo system("/bin/ls ".lsopt." ".netrw#os#Escape(s:NetrwFile(a:fname)))
+            endif
+        else
+            " use vim functions to return information about file below cursor
+            if !isdirectory(s:NetrwFile(a:fname)) && !filereadable(s:NetrwFile(a:fname)) && a:fname =~ '[*@/]'
+                let fname= substitute(a:fname,".$","","")
+            else
+                let fname= a:fname
+            endif
+            let t  = getftime(s:NetrwFile(fname))
+            let sz = getfsize(s:NetrwFile(fname))
+            if g:netrw_sizestyle =~# "[hH]"
+                let sz= s:NetrwHumanReadable(sz)
+            endif
+            echo a:fname.":  ".sz."  ".strftime(g:netrw_timefmt,getftime(s:NetrwFile(fname)))
+        endif
     else
-      " use vim functions to return information about file below cursor
-      if !isdirectory(s:NetrwFile(a:fname)) && !filereadable(s:NetrwFile(a:fname)) && a:fname =~ '[*@/]'
-        let fname= substitute(a:fname,".$","","")
-      else
-        let fname= a:fname
-      endif
-      let t  = getftime(s:NetrwFile(fname))
-      let sz = getfsize(s:NetrwFile(fname))
-      if g:netrw_sizestyle =~# "[hH]"
-        let sz= s:NetrwHumanReadable(sz)
-      endif
-      echo a:fname.":  ".sz."  ".strftime(g:netrw_timefmt,getftime(s:NetrwFile(fname)))
+        echo "sorry, \"qf\" not supported yet for remote files"
     endif
-  else
-    echo "sorry, \"qf\" not supported yet for remote files"
-  endif
-  let @@= ykeep
+    let @@= ykeep
 endfun
 
 " s:NetrwGetBuffer: [get a new|find an old netrw] buffer for a netrw listing {{{2
@@ -3400,336 +3376,336 @@ endfun
 "           1=re-used buffer (buffer not cleared)
 "  Nov 09, 2020: tst952 shows that when user does :set hidden that NetrwGetBuffer will come up with a [No Name] buffer (hid fix)
 fun! s:NetrwGetBuffer(islocal,dirname)
-  let dirname= a:dirname
+    let dirname= a:dirname
 
-  " re-use buffer if possible {{{3
-  if !exists("s:netrwbuf")
-    let s:netrwbuf= {}
-  endif
-
-  if exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST
-    let bufnum = -1
-
-    if !empty(s:netrwbuf) && has_key(s:netrwbuf,netrw#fs#AbsPath(dirname))
-      if has_key(s:netrwbuf,"NetrwTreeListing")
-        let bufnum= s:netrwbuf["NetrwTreeListing"]
-      else
-        let bufnum= s:netrwbuf[netrw#fs#AbsPath(dirname)]
-      endif
-      if !bufexists(bufnum)
-        call remove(s:netrwbuf,"NetrwTreeListing")
-        let bufnum= -1
-      endif
-    elseif bufnr("NetrwTreeListing") != -1
-      let bufnum= bufnr("NetrwTreeListing")
-    else
-      let bufnum= -1
+    " re-use buffer if possible {{{3
+    if !exists("s:netrwbuf")
+        let s:netrwbuf= {}
     endif
 
-  elseif has_key(s:netrwbuf,netrw#fs#AbsPath(dirname))
-    let bufnum= s:netrwbuf[netrw#fs#AbsPath(dirname)]
-    if !bufexists(bufnum)
-      call remove(s:netrwbuf,netrw#fs#AbsPath(dirname))
-      let bufnum= -1
-    endif
-
-  else
-    let bufnum= -1
-  endif
-
-  " highjack the current buffer
-  "   IF the buffer already has the desired name
-  "   AND it is empty
-  let curbuf = bufname("%")
-  if curbuf == '.'
-    let curbuf = getcwd()
-  endif
-  if dirname == curbuf && line("$") == 1 && getline("%") == ""
-    return 0
-  else  " DEBUG
-  endif
-  " Aug 14, 2021: was thinking about looking for a [No Name] buffer here and using it, but that might cause problems
-
-  " get enew buffer and name it -or- re-use buffer {{{3
-  if bufnum < 0      " get enew buffer and name it
-    call s:NetrwEnew(dirname)
-    " name the buffer
     if exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST
-      " Got enew buffer; transform into a NetrwTreeListing
-      let w:netrw_treebufnr = bufnr("%")
-      call s:NetrwBufRename("NetrwTreeListing")
-      if g:netrw_use_noswf
-        setl nobl bt=nofile noswf
-      else
-        setl nobl bt=nofile
-      endif
-      nnoremap <silent> <buffer> [[       :sil call <SID>TreeListMove('[[')<cr>
-      nnoremap <silent> <buffer> ]]       :sil call <SID>TreeListMove(']]')<cr>
-      nnoremap <silent> <buffer> []       :sil call <SID>TreeListMove('[]')<cr>
-      nnoremap <silent> <buffer> ][       :sil call <SID>TreeListMove('][')<cr>
-    else
-      call s:NetrwBufRename(dirname)
-      " enter the new buffer into the s:netrwbuf dictionary
-      let s:netrwbuf[netrw#fs#AbsPath(dirname)]= bufnr("%")
-    endif
+        let bufnum = -1
 
-  else " Re-use the buffer
-    " ignore all events
-    let eikeep= &ei
-    setl ei=all
+        if !empty(s:netrwbuf) && has_key(s:netrwbuf,netrw#fs#AbsPath(dirname))
+            if has_key(s:netrwbuf,"NetrwTreeListing")
+                let bufnum= s:netrwbuf["NetrwTreeListing"]
+            else
+                let bufnum= s:netrwbuf[netrw#fs#AbsPath(dirname)]
+            endif
+            if !bufexists(bufnum)
+                call remove(s:netrwbuf,"NetrwTreeListing")
+                let bufnum= -1
+            endif
+        elseif bufnr("NetrwTreeListing") != -1
+            let bufnum= bufnr("NetrwTreeListing")
+        else
+            let bufnum= -1
+        endif
 
-    if &ft == "netrw"
-      exe "sil! NetrwKeepj noswapfile b ".bufnum
-    else
-      call s:NetrwEditBuf(bufnum)
-    endif
-    if bufname("%") == '.'
-      call s:NetrwBufRename(getcwd())
-    endif
-
-    " restore ei
-    let &ei= eikeep
-
-    if line("$") <= 1 && getline(1) == ""
-      " empty buffer
-      NetrwKeepj call s:NetrwListSettings(a:islocal)
-      return 0
-
-    elseif g:netrw_fastbrowse == 0 || (a:islocal && g:netrw_fastbrowse == 1)
-      NetrwKeepj call s:NetrwListSettings(a:islocal)
-      sil NetrwKeepj %d _
-      return 0
-
-    elseif exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST
-      setl ma
-      sil NetrwKeepj %d _
-      NetrwKeepj call s:NetrwListSettings(a:islocal)
-      return 0
+    elseif has_key(s:netrwbuf,netrw#fs#AbsPath(dirname))
+        let bufnum= s:netrwbuf[netrw#fs#AbsPath(dirname)]
+        if !bufexists(bufnum)
+            call remove(s:netrwbuf,netrw#fs#AbsPath(dirname))
+            let bufnum= -1
+        endif
 
     else
-      return 1
+        let bufnum= -1
     endif
-  endif
 
-  " do netrw settings: make this buffer not-a-file, modifiable, not line-numbered, etc {{{3
-  "     fastbrowse  Local  Remote   Hiding a buffer implies it may be re-used (fast)
-  "  slow   0         D      D      Deleting a buffer implies it will not be re-used (slow)
-  "  med    1         D      H
-  "  fast   2         H      H
-  let fname= expand("%")
-  NetrwKeepj call s:NetrwListSettings(a:islocal)
-  call s:NetrwBufRename(fname)
+    " highjack the current buffer
+    "   IF the buffer already has the desired name
+    "   AND it is empty
+    let curbuf = bufname("%")
+    if curbuf == '.'
+        let curbuf = getcwd()
+    endif
+    if dirname == curbuf && line("$") == 1 && getline("%") == ""
+        return 0
+    else  " DEBUG
+    endif
+    " Aug 14, 2021: was thinking about looking for a [No Name] buffer here and using it, but that might cause problems
 
-  " delete all lines from buffer {{{3
-  sil! keepalt NetrwKeepj %d _
+    " get enew buffer and name it -or- re-use buffer {{{3
+    if bufnum < 0      " get enew buffer and name it
+        call s:NetrwEnew(dirname)
+        " name the buffer
+        if exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST
+            " Got enew buffer; transform into a NetrwTreeListing
+            let w:netrw_treebufnr = bufnr("%")
+            call s:NetrwBufRename("NetrwTreeListing")
+            if g:netrw_use_noswf
+                setl nobl bt=nofile noswf
+            else
+                setl nobl bt=nofile
+            endif
+            nnoremap <silent> <buffer> [[       :sil call <SID>TreeListMove('[[')<cr>
+            nnoremap <silent> <buffer> ]]       :sil call <SID>TreeListMove(']]')<cr>
+            nnoremap <silent> <buffer> []       :sil call <SID>TreeListMove('[]')<cr>
+            nnoremap <silent> <buffer> ][       :sil call <SID>TreeListMove('][')<cr>
+        else
+            call s:NetrwBufRename(dirname)
+            " enter the new buffer into the s:netrwbuf dictionary
+            let s:netrwbuf[netrw#fs#AbsPath(dirname)]= bufnr("%")
+        endif
 
-  return 0
+    else " Re-use the buffer
+        " ignore all events
+        let eikeep= &ei
+        setl ei=all
+
+        if &ft == "netrw"
+            exe "sil! NetrwKeepj noswapfile b ".bufnum
+        else
+            call s:NetrwEditBuf(bufnum)
+        endif
+        if bufname("%") == '.'
+            call s:NetrwBufRename(getcwd())
+        endif
+
+        " restore ei
+        let &ei= eikeep
+
+        if line("$") <= 1 && getline(1) == ""
+            " empty buffer
+            NetrwKeepj call s:NetrwListSettings(a:islocal)
+            return 0
+
+        elseif g:netrw_fastbrowse == 0 || (a:islocal && g:netrw_fastbrowse == 1)
+            NetrwKeepj call s:NetrwListSettings(a:islocal)
+            sil NetrwKeepj %d _
+            return 0
+
+        elseif exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST
+            setl ma
+            sil NetrwKeepj %d _
+            NetrwKeepj call s:NetrwListSettings(a:islocal)
+            return 0
+
+        else
+            return 1
+        endif
+    endif
+
+    " do netrw settings: make this buffer not-a-file, modifiable, not line-numbered, etc {{{3
+    "     fastbrowse  Local  Remote   Hiding a buffer implies it may be re-used (fast)
+    "  slow   0         D      D      Deleting a buffer implies it will not be re-used (slow)
+    "  med    1         D      H
+    "  fast   2         H      H
+    let fname= expand("%")
+    NetrwKeepj call s:NetrwListSettings(a:islocal)
+    call s:NetrwBufRename(fname)
+
+    " delete all lines from buffer {{{3
+    sil! keepalt NetrwKeepj %d _
+
+    return 0
 endfun
 
 "  s:NetrwGetWord: it gets the directory/file named under the cursor {{{2
 fun! s:NetrwGetWord()
-  let keepsol= &l:sol
-  setl nosol
+    let keepsol= &l:sol
+    setl nosol
 
-  call s:UseBufWinVars()
+    call s:UseBufWinVars()
 
-  " insure that w:netrw_liststyle is set up
-  if !exists("w:netrw_liststyle")
-    if exists("g:netrw_liststyle")
-      let w:netrw_liststyle= g:netrw_liststyle
+    " insure that w:netrw_liststyle is set up
+    if !exists("w:netrw_liststyle")
+        if exists("g:netrw_liststyle")
+            let w:netrw_liststyle= g:netrw_liststyle
+        else
+            let w:netrw_liststyle= s:THINLIST
+        endif
+    endif
+
+    if exists("w:netrw_bannercnt") && line(".") < w:netrw_bannercnt
+        " Active Banner support
+        NetrwKeepj norm! 0
+        let dirname= "./"
+        let curline= getline('.')
+
+        if curline =~# '"\s*Sorted by\s'
+            NetrwKeepj norm! "_s
+            let s:netrw_skipbrowse= 1
+            echo 'Pressing "s" also works'
+
+        elseif curline =~# '"\s*Sort sequence:'
+            let s:netrw_skipbrowse= 1
+            echo 'Press "S" to edit sorting sequence'
+
+        elseif curline =~# '"\s*Quick Help:'
+            NetrwKeepj norm! ?
+            let s:netrw_skipbrowse= 1
+
+        elseif curline =~# '"\s*\%(Hiding\|Showing\):'
+            NetrwKeepj norm! a
+            let s:netrw_skipbrowse= 1
+            echo 'Pressing "a" also works'
+
+        elseif line("$") > w:netrw_bannercnt
+            exe 'sil NetrwKeepj '.w:netrw_bannercnt
+        endif
+
+    elseif w:netrw_liststyle == s:THINLIST
+        NetrwKeepj norm! 0
+        let dirname= substitute(getline('.'),'\t -->.*$','','')
+
+    elseif w:netrw_liststyle == s:LONGLIST
+        NetrwKeepj norm! 0
+        let dirname= substitute(getline('.'),'^\(\%(\S\+ \)*\S\+\).\{-}$','\1','e')
+
+    elseif exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST
+        let dirname= substitute(getline('.'),'^\('.s:treedepthstring.'\)*','','e')
+        let dirname= substitute(dirname,'\t -->.*$','','')
+
     else
-      let w:netrw_liststyle= s:THINLIST
-    endif
-  endif
+        let dirname= getline('.')
 
-  if exists("w:netrw_bannercnt") && line(".") < w:netrw_bannercnt
-    " Active Banner support
-    NetrwKeepj norm! 0
-    let dirname= "./"
-    let curline= getline('.')
+        if !exists("b:netrw_cpf")
+            let b:netrw_cpf= 0
+            exe 'sil NetrwKeepj '.w:netrw_bannercnt.',$g/^./if virtcol("$") > b:netrw_cpf|let b:netrw_cpf= virtcol("$")|endif'
+            call histdel("/",-1)
+        endif
 
-    if curline =~# '"\s*Sorted by\s'
-      NetrwKeepj norm! "_s
-      let s:netrw_skipbrowse= 1
-      echo 'Pressing "s" also works'
+        let filestart = (virtcol(".")/b:netrw_cpf)*b:netrw_cpf
+        if filestart == 0
+            NetrwKeepj norm! 0ma
+        else
+            call cursor(line("."),filestart+1)
+            NetrwKeepj norm! ma
+        endif
 
-    elseif curline =~# '"\s*Sort sequence:'
-      let s:netrw_skipbrowse= 1
-      echo 'Press "S" to edit sorting sequence'
+        let dict={}
+        " save the unnamed register and register 0-9 and a
+        let dict.a=[getreg('a'), getregtype('a')]
+        for i in range(0, 9)
+            let dict[i] = [getreg(i), getregtype(i)]
+        endfor
+        let dict.unnamed = [getreg(''), getregtype('')]
 
-    elseif curline =~# '"\s*Quick Help:'
-      NetrwKeepj norm! ?
-      let s:netrw_skipbrowse= 1
+        let eofname= filestart + b:netrw_cpf + 1
+        if eofname <= col("$")
+            call cursor(line("."),filestart+b:netrw_cpf+1)
+            NetrwKeepj norm! "ay`a
+        else
+            NetrwKeepj norm! "ay$
+        endif
 
-    elseif curline =~# '"\s*\%(Hiding\|Showing\):'
-      NetrwKeepj norm! a
-      let s:netrw_skipbrowse= 1
-      echo 'Pressing "a" also works'
+        let dirname = @a
+        call s:RestoreRegister(dict)
 
-    elseif line("$") > w:netrw_bannercnt
-      exe 'sil NetrwKeepj '.w:netrw_bannercnt
-    endif
-
-  elseif w:netrw_liststyle == s:THINLIST
-    NetrwKeepj norm! 0
-    let dirname= substitute(getline('.'),'\t -->.*$','','')
-
-  elseif w:netrw_liststyle == s:LONGLIST
-    NetrwKeepj norm! 0
-    let dirname= substitute(getline('.'),'^\(\%(\S\+ \)*\S\+\).\{-}$','\1','e')
-
-  elseif exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST
-    let dirname= substitute(getline('.'),'^\('.s:treedepthstring.'\)*','','e')
-    let dirname= substitute(dirname,'\t -->.*$','','')
-
-  else
-    let dirname= getline('.')
-
-    if !exists("b:netrw_cpf")
-      let b:netrw_cpf= 0
-      exe 'sil NetrwKeepj '.w:netrw_bannercnt.',$g/^./if virtcol("$") > b:netrw_cpf|let b:netrw_cpf= virtcol("$")|endif'
-      call histdel("/",-1)
+        let dirname= substitute(dirname,'\s\+$','','e')
     endif
 
-    let filestart = (virtcol(".")/b:netrw_cpf)*b:netrw_cpf
-    if filestart == 0
-      NetrwKeepj norm! 0ma
-    else
-      call cursor(line("."),filestart+1)
-      NetrwKeepj norm! ma
-    endif
+    " symlinks are indicated by a trailing "@".  Remove it before further processing.
+    let dirname= substitute(dirname,"@$","","")
 
-    let dict={}
-    " save the unnamed register and register 0-9 and a
-    let dict.a=[getreg('a'), getregtype('a')]
-    for i in range(0, 9)
-      let dict[i] = [getreg(i), getregtype(i)]
-    endfor
-    let dict.unnamed = [getreg(''), getregtype('')]
+    " executables are indicated by a trailing "*".  Remove it before further processing.
+    let dirname= substitute(dirname,"\*$","","")
 
-    let eofname= filestart + b:netrw_cpf + 1
-    if eofname <= col("$")
-      call cursor(line("."),filestart+b:netrw_cpf+1)
-      NetrwKeepj norm! "ay`a
-    else
-      NetrwKeepj norm! "ay$
-    endif
+    let &l:sol= keepsol
 
-    let dirname = @a
-    call s:RestoreRegister(dict)
-
-    let dirname= substitute(dirname,'\s\+$','','e')
-  endif
-
-  " symlinks are indicated by a trailing "@".  Remove it before further processing.
-  let dirname= substitute(dirname,"@$","","")
-
-  " executables are indicated by a trailing "*".  Remove it before further processing.
-  let dirname= substitute(dirname,"\*$","","")
-
-  let &l:sol= keepsol
-
-  return dirname
+    return dirname
 endfun
 
 " s:NetrwListSettings: make standard settings for making a netrw listing {{{2
 "                      g:netrw_bufsettings will be used after the listing is produced.
 "                      Called by s:NetrwGetBuffer()
 fun! s:NetrwListSettings(islocal)
-  let fname= bufname("%")
-  "              nobl noma nomod nonu noma nowrap ro   nornu  (std g:netrw_bufsettings)
-  setl bt=nofile nobl ma         nonu      nowrap noro nornu
-  call s:NetrwBufRename(fname)
-  if g:netrw_use_noswf
-    setl noswf
-  endif
-  exe "setl ts=".(g:netrw_maxfilenamelen+1)
-  setl isk+=.,~,-
-  if g:netrw_fastbrowse > a:islocal
-    setl bh=hide
-  else
-    setl bh=delete
-  endif
+    let fname= bufname("%")
+    "              nobl noma nomod nonu noma nowrap ro   nornu  (std g:netrw_bufsettings)
+    setl bt=nofile nobl ma         nonu      nowrap noro nornu
+    call s:NetrwBufRename(fname)
+    if g:netrw_use_noswf
+        setl noswf
+    endif
+    exe "setl ts=".(g:netrw_maxfilenamelen+1)
+    setl isk+=.,~,-
+    if g:netrw_fastbrowse > a:islocal
+        setl bh=hide
+    else
+        setl bh=delete
+    endif
 endfun
 
 "  s:NetrwListStyle: change list style (thin - long - wide - tree) {{{2
 "  islocal=0: remote browsing
 "         =1: local browsing
 fun! s:NetrwListStyle(islocal)
-  let ykeep             = @@
-  let fname             = s:NetrwGetWord()
-  if !exists("w:netrw_liststyle")|let w:netrw_liststyle= g:netrw_liststyle|endif
-  let svpos            = winsaveview()
-  let w:netrw_liststyle = (w:netrw_liststyle + 1) % s:MAXLIST
+    let ykeep             = @@
+    let fname             = s:NetrwGetWord()
+    if !exists("w:netrw_liststyle")|let w:netrw_liststyle= g:netrw_liststyle|endif
+    let svpos            = winsaveview()
+    let w:netrw_liststyle = (w:netrw_liststyle + 1) % s:MAXLIST
 
-  " repoint t:netrw_lexbufnr if appropriate
-  if exists("t:netrw_lexbufnr") && bufnr("%") == t:netrw_lexbufnr
-    let repointlexbufnr= 1
-  endif
+    " repoint t:netrw_lexbufnr if appropriate
+    if exists("t:netrw_lexbufnr") && bufnr("%") == t:netrw_lexbufnr
+        let repointlexbufnr= 1
+    endif
 
-  if w:netrw_liststyle == s:THINLIST
-    " use one column listing
-    let g:netrw_list_cmd = substitute(g:netrw_list_cmd,' -l','','ge')
+    if w:netrw_liststyle == s:THINLIST
+        " use one column listing
+        let g:netrw_list_cmd = substitute(g:netrw_list_cmd,' -l','','ge')
 
-  elseif w:netrw_liststyle == s:LONGLIST
-    " use long list
-    let g:netrw_list_cmd = g:netrw_list_cmd." -l"
+    elseif w:netrw_liststyle == s:LONGLIST
+        " use long list
+        let g:netrw_list_cmd = g:netrw_list_cmd." -l"
 
-  elseif w:netrw_liststyle == s:WIDELIST
-    " give wide list
-    let g:netrw_list_cmd = substitute(g:netrw_list_cmd,' -l','','ge')
+    elseif w:netrw_liststyle == s:WIDELIST
+        " give wide list
+        let g:netrw_list_cmd = substitute(g:netrw_list_cmd,' -l','','ge')
 
-  elseif exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST
-    let g:netrw_list_cmd = substitute(g:netrw_list_cmd,' -l','','ge')
+    elseif exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST
+        let g:netrw_list_cmd = substitute(g:netrw_list_cmd,' -l','','ge')
 
-  else
-    call netrw#msg#Notify('WARNING', printf('bad value for g:netrw_liststyle (=%s)', w:netrw_liststyle))
-    let g:netrw_liststyle = s:THINLIST
-    let w:netrw_liststyle = g:netrw_liststyle
-    let g:netrw_list_cmd  = substitute(g:netrw_list_cmd,' -l','','ge')
-  endif
-  setl ma noro
+    else
+        call netrw#msg#Notify('WARNING', printf('bad value for g:netrw_liststyle (=%s)', w:netrw_liststyle))
+        let g:netrw_liststyle = s:THINLIST
+        let w:netrw_liststyle = g:netrw_liststyle
+        let g:netrw_list_cmd  = substitute(g:netrw_list_cmd,' -l','','ge')
+    endif
+    setl ma noro
 
-  " clear buffer - this will cause NetrwBrowse/LocalBrowseCheck to do a refresh
-  sil! NetrwKeepj %d _
-  " following prevents tree listing buffer from being marked "modified"
-  setl nomod
+    " clear buffer - this will cause NetrwBrowse/LocalBrowseCheck to do a refresh
+    sil! NetrwKeepj %d _
+    " following prevents tree listing buffer from being marked "modified"
+    setl nomod
 
-  " refresh the listing
-  NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
-  NetrwKeepj call s:NetrwCursor(0)
+    " refresh the listing
+    NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
+    NetrwKeepj call s:NetrwCursor(0)
 
-  " repoint t:netrw_lexbufnr if appropriate
-  if exists("repointlexbufnr")
-    let t:netrw_lexbufnr= bufnr("%")
-  endif
+    " repoint t:netrw_lexbufnr if appropriate
+    if exists("repointlexbufnr")
+        let t:netrw_lexbufnr= bufnr("%")
+    endif
 
-  " restore position; keep cursor on the filename
-  NetrwKeepj call winrestview(svpos)
-  let @@= ykeep
+    " restore position; keep cursor on the filename
+    NetrwKeepj call winrestview(svpos)
+    let @@= ykeep
 
 endfun
 
 " s:NetrwBannerCtrl: toggles the display of the banner {{{2
 fun! s:NetrwBannerCtrl(islocal)
-  let ykeep= @@
-  " toggle the banner (enable/suppress)
-  let g:netrw_banner= !g:netrw_banner
+    let ykeep= @@
+    " toggle the banner (enable/suppress)
+    let g:netrw_banner= !g:netrw_banner
 
-  " refresh the listing
-  let svpos= winsaveview()
-  call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
+    " refresh the listing
+    let svpos= winsaveview()
+    call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
 
-  " keep cursor on the filename
-  if g:netrw_banner && exists("w:netrw_bannercnt") && line(".") >= w:netrw_bannercnt
-    let fname= s:NetrwGetWord()
-    sil NetrwKeepj $
-    let result= search('\%(^\%(|\+\s\)\=\|\s\{2,}\)\zs'.escape(fname,'.\[]*$^').'\%(\s\{2,}\|$\)','bc')
-    if result <= 0 && exists("w:netrw_bannercnt")
-      exe "NetrwKeepj ".w:netrw_bannercnt
+    " keep cursor on the filename
+    if g:netrw_banner && exists("w:netrw_bannercnt") && line(".") >= w:netrw_bannercnt
+        let fname= s:NetrwGetWord()
+        sil NetrwKeepj $
+        let result= search('\%(^\%(|\+\s\)\=\|\s\{2,}\)\zs'.escape(fname,'.\[]*$^').'\%(\s\{2,}\|$\)','bc')
+        if result <= 0 && exists("w:netrw_bannercnt")
+            exe "NetrwKeepj ".w:netrw_bannercnt
+        endif
     endif
-  endif
-  let @@= ykeep
+    let @@= ykeep
 endfun
 
 " s:NetrwBookmark: supports :NetrwMB[!] [file]s                 {{{2
@@ -3743,58 +3719,58 @@ endfun
 "
 "  With bang: deletes files/directories from Netrw's bookmark system
 fun! s:NetrwBookmark(del,...)
-  if a:0 == 0
-    if &ft == "netrw"
-      let curbufnr = bufnr("%")
+    if a:0 == 0
+        if &ft == "netrw"
+            let curbufnr = bufnr("%")
 
-      if exists("s:netrwmarkfilelist_{curbufnr}")
-        " for every filename in the marked list
-        let svpos  = winsaveview()
-        let islocal= expand("%") !~ '^\a\{3,}://'
-        for fname in s:netrwmarkfilelist_{curbufnr}
-          if a:del|call s:DeleteBookmark(fname)|else|call s:MakeBookmark(fname)|endif
-        endfor
-        let curdir  = exists("b:netrw_curdir")? b:netrw_curdir : getcwd()
-        call s:NetrwUnmarkList(curbufnr,curdir)
-        NetrwKeepj call s:NetrwRefresh(islocal,s:NetrwBrowseChgDir(islocal,'./',0))
-        NetrwKeepj call winrestview(svpos)
-      else
-        let fname= s:NetrwGetWord()
-        if a:del|call s:DeleteBookmark(fname)|else|call s:MakeBookmark(fname)|endif
-      endif
+            if exists("s:netrwmarkfilelist_{curbufnr}")
+                " for every filename in the marked list
+                let svpos  = winsaveview()
+                let islocal= expand("%") !~ '^\a\{3,}://'
+                for fname in s:netrwmarkfilelist_{curbufnr}
+                    if a:del|call s:DeleteBookmark(fname)|else|call s:MakeBookmark(fname)|endif
+                endfor
+                let curdir  = exists("b:netrw_curdir")? b:netrw_curdir : getcwd()
+                call s:NetrwUnmarkList(curbufnr,curdir)
+                NetrwKeepj call s:NetrwRefresh(islocal,s:NetrwBrowseChgDir(islocal,'./',0))
+                NetrwKeepj call winrestview(svpos)
+            else
+                let fname= s:NetrwGetWord()
+                if a:del|call s:DeleteBookmark(fname)|else|call s:MakeBookmark(fname)|endif
+            endif
+
+        else
+            " bookmark currently open file
+            let fname= expand("%")
+            if a:del|call s:DeleteBookmark(fname)|else|call s:MakeBookmark(fname)|endif
+        endif
 
     else
-      " bookmark currently open file
-      let fname= expand("%")
-      if a:del|call s:DeleteBookmark(fname)|else|call s:MakeBookmark(fname)|endif
+        " bookmark specified files
+        "  attempts to infer if working remote or local
+        "  by deciding if the current file begins with an url
+        "  Globbing cannot be done remotely.
+        let islocal= expand("%") !~ '^\a\{3,}://'
+        let i = 1
+        while i <= a:0
+            if islocal
+                let mbfiles = glob(fnameescape(a:{i}), 0, 1, 1)
+            else
+                let mbfiles = [a:{i}]
+            endif
+            for mbfile in mbfiles
+                if a:del
+                    call s:DeleteBookmark(mbfile)
+                else
+                    call s:MakeBookmark(mbfile)
+                endif
+            endfor
+            let i= i + 1
+        endwhile
     endif
 
-  else
-    " bookmark specified files
-    "  attempts to infer if working remote or local
-    "  by deciding if the current file begins with an url
-    "  Globbing cannot be done remotely.
-    let islocal= expand("%") !~ '^\a\{3,}://'
-    let i = 1
-    while i <= a:0
-      if islocal
-        let mbfiles = glob(fnameescape(a:{i}), 0, 1, 1)
-      else
-        let mbfiles = [a:{i}]
-      endif
-      for mbfile in mbfiles
-        if a:del
-            call s:DeleteBookmark(mbfile)
-        else
-            call s:MakeBookmark(mbfile)
-        endif
-      endfor
-      let i= i + 1
-    endwhile
-  endif
-
-  " update the menu
-  call s:NetrwBookmarkMenu()
+    " update the menu
+    call s:NetrwBookmarkMenu()
 endfun
 
 " s:NetrwBookmarkMenu: Uses menu priorities {{{2
@@ -3802,57 +3778,57 @@ endfun
 "                      .3.[cnt] for history
 "                      (see s:NetrwMenu())
 fun! s:NetrwBookmarkMenu()
-  if !exists("s:netrw_menucnt")
-    return
-  endif
-
-  " the following test assures that gvim is running, has menus available, and has menus enabled.
-  if has("gui") && has("menu") && has("gui_running") && &go =~# 'm' && g:netrw_menu
-    if exists("g:NetrwTopLvlMenu")
-      exe 'sil! unmenu '.g:NetrwTopLvlMenu.'Bookmarks'
-      exe 'sil! unmenu '.g:NetrwTopLvlMenu.'Bookmarks\ and\ History.Bookmark\ Delete'
-    endif
-    if !exists("s:netrw_initbookhist")
-      call s:NetrwBookHistRead()
+    if !exists("s:netrw_menucnt")
+        return
     endif
 
-    " show bookmarked places
-    if exists("g:netrw_bookmarklist") && g:netrw_bookmarklist != [] && g:netrw_dirhistmax > 0
-      let cnt= 1
-      for bmd in g:netrw_bookmarklist
-        let bmd= escape(bmd,g:netrw_menu_escape)
-
-        " show bookmarks for goto menu
-        exe 'sil! menu '.g:NetrwMenuPriority.".2.".cnt." ".g:NetrwTopLvlMenu.'Bookmarks.'.bmd.'    :e '.bmd."\<cr>"
-
-        " show bookmarks for deletion menu
-        exe 'sil! menu '.g:NetrwMenuPriority.".8.2.".cnt." ".g:NetrwTopLvlMenu.'Bookmarks\ and\ History.Bookmark\ Delete.'.bmd.'   '.cnt."mB"
-        let cnt= cnt + 1
-      endfor
-
-    endif
-
-    " show directory browsing history
-    if g:netrw_dirhistmax > 0
-      let cnt     = g:netrw_dirhistcnt
-      let first   = 1
-      let histcnt = 0
-      while ( first || cnt != g:netrw_dirhistcnt )
-        let histcnt  = histcnt + 1
-        let priority = g:netrw_dirhistcnt + histcnt
-        if exists("g:netrw_dirhist_{cnt}")
-          let histdir= escape(g:netrw_dirhist_{cnt},g:netrw_menu_escape)
-          exe 'sil! menu '.g:NetrwMenuPriority.".3.".priority." ".g:NetrwTopLvlMenu.'History.'.histdir.'    :e '.histdir."\<cr>"
+    " the following test assures that gvim is running, has menus available, and has menus enabled.
+    if has("gui") && has("menu") && has("gui_running") && &go =~# 'm' && g:netrw_menu
+        if exists("g:NetrwTopLvlMenu")
+            exe 'sil! unmenu '.g:NetrwTopLvlMenu.'Bookmarks'
+            exe 'sil! unmenu '.g:NetrwTopLvlMenu.'Bookmarks\ and\ History.Bookmark\ Delete'
         endif
-        let first = 0
-        let cnt   = ( cnt - 1 ) % g:netrw_dirhistmax
-        if cnt < 0
-          let cnt= cnt + g:netrw_dirhistmax
+        if !exists("s:netrw_initbookhist")
+            call s:NetrwBookHistRead()
         endif
-      endwhile
-    endif
 
-  endif
+        " show bookmarked places
+        if exists("g:netrw_bookmarklist") && g:netrw_bookmarklist != [] && g:netrw_dirhistmax > 0
+            let cnt= 1
+            for bmd in g:netrw_bookmarklist
+                let bmd= escape(bmd,g:netrw_menu_escape)
+
+                " show bookmarks for goto menu
+                exe 'sil! menu '.g:NetrwMenuPriority.".2.".cnt." ".g:NetrwTopLvlMenu.'Bookmarks.'.bmd.'    :e '.bmd."\<cr>"
+
+                " show bookmarks for deletion menu
+                exe 'sil! menu '.g:NetrwMenuPriority.".8.2.".cnt." ".g:NetrwTopLvlMenu.'Bookmarks\ and\ History.Bookmark\ Delete.'.bmd.'   '.cnt."mB"
+                let cnt= cnt + 1
+            endfor
+
+        endif
+
+        " show directory browsing history
+        if g:netrw_dirhistmax > 0
+            let cnt     = g:netrw_dirhistcnt
+            let first   = 1
+            let histcnt = 0
+            while ( first || cnt != g:netrw_dirhistcnt )
+                let histcnt  = histcnt + 1
+                let priority = g:netrw_dirhistcnt + histcnt
+                if exists("g:netrw_dirhist_{cnt}")
+                    let histdir= escape(g:netrw_dirhist_{cnt},g:netrw_menu_escape)
+                    exe 'sil! menu '.g:NetrwMenuPriority.".3.".priority." ".g:NetrwTopLvlMenu.'History.'.histdir.'    :e '.histdir."\<cr>"
+                endif
+                let first = 0
+                let cnt   = ( cnt - 1 ) % g:netrw_dirhistmax
+                if cnt < 0
+                    let cnt= cnt + g:netrw_dirhistmax
+                endif
+            endwhile
+        endif
+
+    endif
 endfun
 
 "  s:NetrwBrowseChgDir: constructs a new directory based on the current {{{2
@@ -3863,632 +3839,632 @@ endfun
 "          =1: newdir is relative to the path to the word under the cursor in
 "              tree view
 fun! s:NetrwBrowseChgDir(islocal,newdir,cursor,...)
-  let ykeep= @@
-  if !exists("b:netrw_curdir")
-    let @@= ykeep
-    return
-  endif
-
-  " NetrwBrowseChgDir; save options and initialize {{{3
-  call s:SavePosn(s:netrw_posn)
-  NetrwKeepj call s:NetrwOptionsSave("s:")
-  NetrwKeepj call s:NetrwOptionsSafe(a:islocal)
-
-  let newdir = a:newdir
-  if a:cursor && exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST && exists("w:netrw_treetop")
-    " dirname is the path to the word under the cursor
-    let dirname = s:NetrwTreePath(w:netrw_treetop)
-    " newdir resolves to a directory and points to a directory in dirname
-    " /tmp/test/folder_symlink/ -> /tmp/test/original_folder/
-    if a:islocal && fnamemodify(dirname, ':t') == newdir && isdirectory(resolve(dirname)) && resolve(dirname) == resolve(newdir)
-      let dirname = fnamemodify(resolve(dirname), ':p:h:h')
-      let newdir = fnamemodify(resolve(newdir), ':t')
+    let ykeep= @@
+    if !exists("b:netrw_curdir")
+        let @@= ykeep
+        return
     endif
-    " Remove trailing "/"
-    let dirname = substitute(dirname, "/$", "", "")
 
-    " If the word under the cursor is a directory (except for ../), NetrwTreePath
-    " returns the full path, including the word under the cursor, remove it
-    if newdir =~ "/$" && newdir != "../"
-      let dirname = fnamemodify(dirname, ":h")
-    endif
-  else
-    let dirname = b:netrw_curdir
-  endif
-  if has("win32")
-    let dirname = substitute(dirname,'\\','/','ge')
-  endif
-  let dolockout = 0
-  let dorestore = 1
+    " NetrwBrowseChgDir; save options and initialize {{{3
+    call s:SavePosn(s:netrw_posn)
+    NetrwKeepj call s:NetrwOptionsSave("s:")
+    NetrwKeepj call s:NetrwOptionsSafe(a:islocal)
 
-  " ignore <cr>s when done in the banner
-  if g:netrw_banner
-    if exists("w:netrw_bannercnt") && line(".") < w:netrw_bannercnt && line("$") >= w:netrw_bannercnt
-      if getline(".") =~# 'Quick Help'
-        let g:netrw_quickhelp= (g:netrw_quickhelp + 1)%len(s:QuickHelp)
-        setl ma noro nowrap
-        NetrwKeepj call setline(line('.'),'"   Quick Help: <F1>:help  '.s:QuickHelp[g:netrw_quickhelp])
-        setl noma nomod nowrap
-        NetrwKeepj call s:NetrwOptionsRestore("s:")
-      endif
-    endif
-  endif
+    let newdir = a:newdir
+    if a:cursor && exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST && exists("w:netrw_treetop")
+        " dirname is the path to the word under the cursor
+        let dirname = s:NetrwTreePath(w:netrw_treetop)
+        " newdir resolves to a directory and points to a directory in dirname
+        " /tmp/test/folder_symlink/ -> /tmp/test/original_folder/
+        if a:islocal && fnamemodify(dirname, ':t') == newdir && isdirectory(resolve(dirname)) && resolve(dirname) == resolve(newdir)
+            let dirname = fnamemodify(resolve(dirname), ':p:h:h')
+            let newdir = fnamemodify(resolve(newdir), ':t')
+        endif
+        " Remove trailing "/"
+        let dirname = substitute(dirname, "/$", "", "")
 
-  " set up o/s-dependent directory recognition pattern
-  if has("amiga")
-    let dirpat= '[\/:]$'
-  else
-    let dirpat= '[\/]$'
-  endif
-
-  if dirname !~ dirpat
-    " apparently vim is "recognizing" that it is in a directory and
-    " is removing the trailing "/".  Bad idea, so let's put it back.
-    let dirname= dirname.'/'
-  endif
-
-  if newdir !~ dirpat && !(a:islocal && isdirectory(s:NetrwFile(netrw#fs#ComposePath(dirname,newdir))))
-    " ------------------------------
-    " NetrwBrowseChgDir: edit a file {{{3
-    " ------------------------------
-
-    " save position for benefit of Rexplore
-    let s:rexposn_{bufnr("%")}= winsaveview()
-
-    if exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST && exists("w:netrw_treedict") && newdir !~ '^\(/\|\a:\)'
-      if dirname =~ '/$'
-        let dirname= dirname.newdir
-      else
-        let dirname= dirname."/".newdir
-      endif
-    elseif newdir =~ '^\(/\|\a:\)'
-      let dirname= newdir
+        " If the word under the cursor is a directory (except for ../), NetrwTreePath
+        " returns the full path, including the word under the cursor, remove it
+        if newdir =~ "/$" && newdir != "../"
+            let dirname = fnamemodify(dirname, ":h")
+        endif
     else
-      let dirname= netrw#fs#ComposePath(dirname,newdir)
+        let dirname = b:netrw_curdir
     endif
-    " this lets netrw#BrowseX avoid the edit
-    if a:0 < 1
-      NetrwKeepj call s:NetrwOptionsRestore("s:")
-      let curdir= b:netrw_curdir
-      if !exists("s:didsplit")
-        if type(g:netrw_browse_split) == 3
-          " open file in server
-          " Note that g:netrw_browse_split is a List: [servername,tabnr,winnr]
-          call s:NetrwServerEdit(a:islocal,dirname)
-          return
+    if has("win32")
+        let dirname = substitute(dirname,'\\','/','ge')
+    endif
+    let dolockout = 0
+    let dorestore = 1
 
-        elseif g:netrw_browse_split == 1
-          " horizontally splitting the window first
-          let winsz= (g:netrw_winsize > 0)? (g:netrw_winsize*winheight(0))/100 : -g:netrw_winsize
-          exe "keepalt ".(g:netrw_alto? "bel " : "abo ").winsz."wincmd s"
-          if !&ea
-            keepalt wincmd _
-          endif
-          call s:SetRexDir(a:islocal,curdir)
+    " ignore <cr>s when done in the banner
+    if g:netrw_banner
+        if exists("w:netrw_bannercnt") && line(".") < w:netrw_bannercnt && line("$") >= w:netrw_bannercnt
+            if getline(".") =~# 'Quick Help'
+                let g:netrw_quickhelp= (g:netrw_quickhelp + 1)%len(s:QuickHelp)
+                setl ma noro nowrap
+                NetrwKeepj call setline(line('.'),'"   Quick Help: <F1>:help  '.s:QuickHelp[g:netrw_quickhelp])
+                setl noma nomod nowrap
+                NetrwKeepj call s:NetrwOptionsRestore("s:")
+            endif
+        endif
+    endif
 
-        elseif g:netrw_browse_split == 2
-          " vertically splitting the window first
-          let winsz= (g:netrw_winsize > 0)? (g:netrw_winsize*winwidth(0))/100 : -g:netrw_winsize
-          exe "keepalt ".(g:netrw_alto? "top " : "bot ")."vert ".winsz."wincmd s"
-          if !&ea
-            keepalt wincmd |
-          endif
-          call s:SetRexDir(a:islocal,curdir)
+    " set up o/s-dependent directory recognition pattern
+    if has("amiga")
+        let dirpat= '[\/:]$'
+    else
+        let dirpat= '[\/]$'
+    endif
 
-        elseif g:netrw_browse_split == 3
-          " open file in new tab
-          keepalt tabnew
-          if !exists("b:netrw_curdir")
-            let b:netrw_curdir= getcwd()
-          endif
-          call s:SetRexDir(a:islocal,curdir)
+    if dirname !~ dirpat
+        " apparently vim is "recognizing" that it is in a directory and
+        " is removing the trailing "/".  Bad idea, so let's put it back.
+        let dirname= dirname.'/'
+    endif
 
-        elseif g:netrw_browse_split == 4
-          " act like "P" (ie. open previous window)
-          if s:NetrwPrevWinOpen(2) == 3
-            let @@= ykeep
-            return
-          endif
-          call s:SetRexDir(a:islocal,curdir)
+    if newdir !~ dirpat && !(a:islocal && isdirectory(s:NetrwFile(netrw#fs#ComposePath(dirname,newdir))))
+        " ------------------------------
+        " NetrwBrowseChgDir: edit a file {{{3
+        " ------------------------------
+
+        " save position for benefit of Rexplore
+        let s:rexposn_{bufnr("%")}= winsaveview()
+
+        if exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST && exists("w:netrw_treedict") && newdir !~ '^\(/\|\a:\)'
+            if dirname =~ '/$'
+                let dirname= dirname.newdir
+            else
+                let dirname= dirname."/".newdir
+            endif
+        elseif newdir =~ '^\(/\|\a:\)'
+            let dirname= newdir
+        else
+            let dirname= netrw#fs#ComposePath(dirname,newdir)
+        endif
+        " this lets netrw#BrowseX avoid the edit
+        if a:0 < 1
+            NetrwKeepj call s:NetrwOptionsRestore("s:")
+            let curdir= b:netrw_curdir
+            if !exists("s:didsplit")
+                if type(g:netrw_browse_split) == 3
+                    " open file in server
+                    " Note that g:netrw_browse_split is a List: [servername,tabnr,winnr]
+                    call s:NetrwServerEdit(a:islocal,dirname)
+                    return
+
+                elseif g:netrw_browse_split == 1
+                    " horizontally splitting the window first
+                    let winsz= (g:netrw_winsize > 0)? (g:netrw_winsize*winheight(0))/100 : -g:netrw_winsize
+                    exe "keepalt ".(g:netrw_alto? "bel " : "abo ").winsz."wincmd s"
+                    if !&ea
+                        keepalt wincmd _
+                    endif
+                    call s:SetRexDir(a:islocal,curdir)
+
+                elseif g:netrw_browse_split == 2
+                    " vertically splitting the window first
+                    let winsz= (g:netrw_winsize > 0)? (g:netrw_winsize*winwidth(0))/100 : -g:netrw_winsize
+                    exe "keepalt ".(g:netrw_alto? "top " : "bot ")."vert ".winsz."wincmd s"
+                    if !&ea
+                        keepalt wincmd |
+                    endif
+                    call s:SetRexDir(a:islocal,curdir)
+
+                elseif g:netrw_browse_split == 3
+                    " open file in new tab
+                    keepalt tabnew
+                    if !exists("b:netrw_curdir")
+                        let b:netrw_curdir= getcwd()
+                    endif
+                    call s:SetRexDir(a:islocal,curdir)
+
+                elseif g:netrw_browse_split == 4
+                    " act like "P" (ie. open previous window)
+                    if s:NetrwPrevWinOpen(2) == 3
+                        let @@= ykeep
+                        return
+                    endif
+                    call s:SetRexDir(a:islocal,curdir)
+
+                else
+                    " handling a file, didn't split, so remove menu
+                    call s:NetrwMenu(0)
+                    " optional change to window
+                    if g:netrw_chgwin >= 1
+                        if winnr("$")+1 == g:netrw_chgwin
+                            " if g:netrw_chgwin is set to one more than the last window, then
+                            " vertically split the last window to make that window available.
+                            let curwin= winnr()
+                            exe "NetrwKeepj keepalt ".winnr("$")."wincmd w"
+                            vs
+                            exe "NetrwKeepj keepalt ".g:netrw_chgwin."wincmd ".curwin
+                        endif
+                        exe "NetrwKeepj keepalt ".g:netrw_chgwin."wincmd w"
+                    endif
+                    call s:SetRexDir(a:islocal,curdir)
+                endif
+
+            endif
+
+            " the point where netrw actually edits the (local) file
+            " if its local only: LocalBrowseCheck() doesn't edit a file, but NetrwBrowse() will
+            " use keepalt to support  :e #  to return to a directory listing
+            if !&mod
+                " if e the new file would fail due to &mod, then don't change any of the flags
+                let dolockout= 1
+            endif
+            if a:islocal
+                " some like c-^ to return to the last edited file
+                " others like c-^ to return to the netrw buffer
+                " Apr 30, 2020: used to have e! here.  That can cause loss of a modified file,
+                " so emit error E37 instead.
+                call s:NetrwEditFile("e","",dirname)
+                call s:NetrwCursor(1)
+                if &hidden || &bufhidden == "hide"
+                    " file came from vim's hidden storage.  Don't "restore" options with it.
+                    let dorestore= 0
+                endif
+            else
+            endif
+
+            " handle g:Netrw_funcref -- call external-to-netrw functions
+            "   This code will handle g:Netrw_funcref as an individual function reference
+            "   or as a list of function references.  It will ignore anything that's not
+            "   a function reference.  See  :help Funcref  for information about function references.
+            if exists("g:Netrw_funcref")
+                if type(g:Netrw_funcref) == 2
+                    NetrwKeepj call g:Netrw_funcref()
+                elseif type(g:Netrw_funcref) == 3
+                    for Fncref in g:Netrw_funcref
+                        if type(Fncref) == 2
+                            NetrwKeepj call Fncref()
+                        endif
+                    endfor
+                endif
+            endif
+        endif
+
+    elseif newdir =~ '^/'
+        " ----------------------------------------------------
+        " NetrwBrowseChgDir: just go to the new directory spec {{{3
+        " ----------------------------------------------------
+        let dirname = newdir
+        NetrwKeepj call s:SetRexDir(a:islocal,dirname)
+        NetrwKeepj call s:NetrwOptionsRestore("s:")
+        norm! m`
+
+    elseif newdir == './'
+        " ---------------------------------------------
+        " NetrwBrowseChgDir: refresh the directory list {{{3
+        " ---------------------------------------------
+        NetrwKeepj call s:SetRexDir(a:islocal,dirname)
+        norm! m`
+
+    elseif newdir == '../'
+        " --------------------------------------
+        " NetrwBrowseChgDir: go up one directory {{{3
+        " --------------------------------------
+
+        if w:netrw_liststyle == s:TREELIST && exists("w:netrw_treedict")
+            " force a refresh
+            setl noro ma
+            NetrwKeepj %d _
+        endif
+
+        if has("amiga")
+            " amiga
+            if a:islocal
+                let dirname= substitute(dirname,'^\(.*[/:]\)\([^/]\+$\)','\1','')
+                let dirname= substitute(dirname,'/$','','')
+            else
+                let dirname= substitute(dirname,'^\(.*[/:]\)\([^/]\+/$\)','\1','')
+            endif
+
+        elseif !g:netrw_cygwin && has("win32")
+            " windows
+            if a:islocal
+                let dirname= substitute(dirname,'^\(.*\)/\([^/]\+\)/$','\1','')
+                if dirname == ""
+                    let dirname= '/'
+                endif
+            else
+                let dirname= substitute(dirname,'^\(\a\{3,}://.\{-}/\{1,2}\)\(.\{-}\)\([^/]\+\)/$','\1\2','')
+            endif
+            if dirname =~ '^\a:$'
+                let dirname= dirname.'/'
+            endif
 
         else
-          " handling a file, didn't split, so remove menu
-          call s:NetrwMenu(0)
-          " optional change to window
-          if g:netrw_chgwin >= 1
-            if winnr("$")+1 == g:netrw_chgwin
-              " if g:netrw_chgwin is set to one more than the last window, then
-              " vertically split the last window to make that window available.
-              let curwin= winnr()
-              exe "NetrwKeepj keepalt ".winnr("$")."wincmd w"
-              vs
-              exe "NetrwKeepj keepalt ".g:netrw_chgwin."wincmd ".curwin
+            " unix or cygwin
+            if a:islocal
+                let dirname= substitute(dirname,'^\(.*\)/\([^/]\+\)/$','\1','')
+                if dirname == ""
+                    let dirname= '/'
+                endif
+            else
+                let dirname= substitute(dirname,'^\(\a\{3,}://.\{-}/\{1,2}\)\(.\{-}\)\([^/]\+\)/$','\1\2','')
             endif
-            exe "NetrwKeepj keepalt ".g:netrw_chgwin."wincmd w"
-          endif
-          call s:SetRexDir(a:islocal,curdir)
+        endif
+        NetrwKeepj call s:SetRexDir(a:islocal,dirname)
+        norm! m`
+
+    elseif exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST && exists("w:netrw_treedict")
+        " --------------------------------------
+        " NetrwBrowseChgDir: Handle Tree Listing {{{3
+        " --------------------------------------
+        " force a refresh (for TREELIST, NetrwTreeDir() will force the refresh)
+        setl noro ma
+        if !(exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST && exists("b:netrw_curdir"))
+            NetrwKeepj %d _
+        endif
+        let treedir      = s:NetrwTreeDir(a:islocal)
+        let s:treecurpos = winsaveview()
+        let haskey       = 0
+
+        " search treedict for tree dir as-is
+        if has_key(w:netrw_treedict,treedir)
+            let haskey= 1
+        else
         endif
 
-      endif
-
-      " the point where netrw actually edits the (local) file
-      " if its local only: LocalBrowseCheck() doesn't edit a file, but NetrwBrowse() will
-      " use keepalt to support  :e #  to return to a directory listing
-      if !&mod
-        " if e the new file would fail due to &mod, then don't change any of the flags
-        let dolockout= 1
-      endif
-      if a:islocal
-        " some like c-^ to return to the last edited file
-        " others like c-^ to return to the netrw buffer
-        " Apr 30, 2020: used to have e! here.  That can cause loss of a modified file,
-        " so emit error E37 instead.
-        call s:NetrwEditFile("e","",dirname)
-        call s:NetrwCursor(1)
-        if &hidden || &bufhidden == "hide"
-          " file came from vim's hidden storage.  Don't "restore" options with it.
-          let dorestore= 0
-        endif
-      else
-      endif
-
-      " handle g:Netrw_funcref -- call external-to-netrw functions
-      "   This code will handle g:Netrw_funcref as an individual function reference
-      "   or as a list of function references.  It will ignore anything that's not
-      "   a function reference.  See  :help Funcref  for information about function references.
-      if exists("g:Netrw_funcref")
-        if type(g:Netrw_funcref) == 2
-          NetrwKeepj call g:Netrw_funcref()
-        elseif type(g:Netrw_funcref) == 3
-          for Fncref in g:Netrw_funcref
-            if type(Fncref) == 2
-              NetrwKeepj call Fncref()
+        " search treedict for treedir with a [/@] appended
+        if !haskey && treedir !~ '[/@]$'
+            if has_key(w:netrw_treedict,treedir."/")
+                let treedir= treedir."/"
+                let haskey = 1
+            else
             endif
-          endfor
         endif
-      endif
-    endif
 
-  elseif newdir =~ '^/'
-    " ----------------------------------------------------
-    " NetrwBrowseChgDir: just go to the new directory spec {{{3
-    " ----------------------------------------------------
-    let dirname = newdir
-    NetrwKeepj call s:SetRexDir(a:islocal,dirname)
-    NetrwKeepj call s:NetrwOptionsRestore("s:")
-    norm! m`
-
-  elseif newdir == './'
-    " ---------------------------------------------
-    " NetrwBrowseChgDir: refresh the directory list {{{3
-    " ---------------------------------------------
-    NetrwKeepj call s:SetRexDir(a:islocal,dirname)
-    norm! m`
-
-  elseif newdir == '../'
-    " --------------------------------------
-    " NetrwBrowseChgDir: go up one directory {{{3
-    " --------------------------------------
-
-    if w:netrw_liststyle == s:TREELIST && exists("w:netrw_treedict")
-      " force a refresh
-      setl noro ma
-      NetrwKeepj %d _
-    endif
-
-    if has("amiga")
-      " amiga
-      if a:islocal
-        let dirname= substitute(dirname,'^\(.*[/:]\)\([^/]\+$\)','\1','')
-        let dirname= substitute(dirname,'/$','','')
-      else
-        let dirname= substitute(dirname,'^\(.*[/:]\)\([^/]\+/$\)','\1','')
-      endif
-
-    elseif !g:netrw_cygwin && has("win32")
-      " windows
-      if a:islocal
-        let dirname= substitute(dirname,'^\(.*\)/\([^/]\+\)/$','\1','')
-        if dirname == ""
-          let dirname= '/'
+        " search treedict for treedir with any trailing / elided
+        if !haskey && treedir =~ '/$'
+            let treedir= substitute(treedir,'/$','','')
+            if has_key(w:netrw_treedict,treedir)
+                let haskey = 1
+            else
+            endif
         endif
-      else
-        let dirname= substitute(dirname,'^\(\a\{3,}://.\{-}/\{1,2}\)\(.\{-}\)\([^/]\+\)/$','\1\2','')
-      endif
-      if dirname =~ '^\a:$'
-        let dirname= dirname.'/'
-      endif
 
-    else
-      " unix or cygwin
-      if a:islocal
-        let dirname= substitute(dirname,'^\(.*\)/\([^/]\+\)/$','\1','')
-        if dirname == ""
-          let dirname= '/'
+        if haskey
+            " close tree listing for selected subdirectory
+            call remove(w:netrw_treedict,treedir)
+            let dirname= w:netrw_treetop
+        else
+            " go down one directory
+            let dirname= substitute(treedir,'/*$','/','')
         endif
-      else
-        let dirname= substitute(dirname,'^\(\a\{3,}://.\{-}/\{1,2}\)\(.\{-}\)\([^/]\+\)/$','\1\2','')
-      endif
-    endif
-    NetrwKeepj call s:SetRexDir(a:islocal,dirname)
-    norm! m`
+        NetrwKeepj call s:SetRexDir(a:islocal,dirname)
+        let s:treeforceredraw = 1
 
-  elseif exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST && exists("w:netrw_treedict")
+    else
+        " ----------------------------------------
+        " NetrwBrowseChgDir: Go down one directory {{{3
+        " ----------------------------------------
+        let dirname    = netrw#fs#ComposePath(dirname,newdir)
+        NetrwKeepj call s:SetRexDir(a:islocal,dirname)
+        norm! m`
+    endif
+
     " --------------------------------------
-    " NetrwBrowseChgDir: Handle Tree Listing {{{3
+    " NetrwBrowseChgDir: Restore and Cleanup {{{3
     " --------------------------------------
-    " force a refresh (for TREELIST, NetrwTreeDir() will force the refresh)
-    setl noro ma
-    if !(exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST && exists("b:netrw_curdir"))
-      NetrwKeepj %d _
+    if dorestore
+        " dorestore is zero'd when a local file was hidden or bufhidden;
+        " in such a case, we want to keep whatever settings it may have.
+        NetrwKeepj call s:NetrwOptionsRestore("s:")
     endif
-    let treedir      = s:NetrwTreeDir(a:islocal)
-    let s:treecurpos = winsaveview()
-    let haskey       = 0
-
-    " search treedict for tree dir as-is
-    if has_key(w:netrw_treedict,treedir)
-      let haskey= 1
-    else
+    if dolockout && dorestore
+        if filewritable(dirname)
+            setl ma noro nomod
+        else
+            setl ma ro nomod
+        endif
     endif
+    call s:RestorePosn(s:netrw_posn)
+    let @@= ykeep
 
-    " search treedict for treedir with a [/@] appended
-    if !haskey && treedir !~ '[/@]$'
-      if has_key(w:netrw_treedict,treedir."/")
-        let treedir= treedir."/"
-        let haskey = 1
-      else
-      endif
-    endif
-
-    " search treedict for treedir with any trailing / elided
-    if !haskey && treedir =~ '/$'
-      let treedir= substitute(treedir,'/$','','')
-      if has_key(w:netrw_treedict,treedir)
-        let haskey = 1
-      else
-      endif
-    endif
-
-    if haskey
-      " close tree listing for selected subdirectory
-      call remove(w:netrw_treedict,treedir)
-      let dirname= w:netrw_treetop
-    else
-      " go down one directory
-      let dirname= substitute(treedir,'/*$','/','')
-    endif
-    NetrwKeepj call s:SetRexDir(a:islocal,dirname)
-    let s:treeforceredraw = 1
-
-  else
-    " ----------------------------------------
-    " NetrwBrowseChgDir: Go down one directory {{{3
-    " ----------------------------------------
-    let dirname    = netrw#fs#ComposePath(dirname,newdir)
-    NetrwKeepj call s:SetRexDir(a:islocal,dirname)
-    norm! m`
-  endif
-
-  " --------------------------------------
-  " NetrwBrowseChgDir: Restore and Cleanup {{{3
-  " --------------------------------------
-  if dorestore
-    " dorestore is zero'd when a local file was hidden or bufhidden;
-    " in such a case, we want to keep whatever settings it may have.
-    NetrwKeepj call s:NetrwOptionsRestore("s:")
-  endif
-  if dolockout && dorestore
-    if filewritable(dirname)
-      setl ma noro nomod
-    else
-      setl ma ro nomod
-    endif
-  endif
-  call s:RestorePosn(s:netrw_posn)
-  let @@= ykeep
-
-  return dirname
+    return dirname
 endfun
 
 " s:NetrwBrowseUpDir: implements the "-" mappings {{{2
 "    for thin, long, and wide: cursor placed just after banner
 "    for tree, keeps cursor on current filename
 fun! s:NetrwBrowseUpDir(islocal)
-  if exists("w:netrw_bannercnt") && line(".") < w:netrw_bannercnt-1
-    " this test needed because occasionally this function seems to be incorrectly called
-    " when multiple leftmouse clicks are taken when atop the one line help in the banner.
-    " I'm allowing the very bottom line to permit a "-" exit so that one may escape empty
-    " directories.
-    return
-  endif
+    if exists("w:netrw_bannercnt") && line(".") < w:netrw_bannercnt-1
+        " this test needed because occasionally this function seems to be incorrectly called
+        " when multiple leftmouse clicks are taken when atop the one line help in the banner.
+        " I'm allowing the very bottom line to permit a "-" exit so that one may escape empty
+        " directories.
+        return
+    endif
 
-  norm! 0
-  if exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST && exists("w:netrw_treedict")
-    let curline= getline(".")
-    let swwline= winline() - 1
-    if exists("w:netrw_treetop")
-      let b:netrw_curdir= w:netrw_treetop
-    elseif exists("b:netrw_curdir")
-      let w:netrw_treetop= b:netrw_curdir
-    else
-      let w:netrw_treetop= getcwd()
-      let b:netrw_curdir = w:netrw_treetop
-    endif
-    let curfile = getline(".")
-    let curpath = s:NetrwTreePath(w:netrw_treetop)
-    if a:islocal
-      call netrw#LocalBrowseCheck(s:NetrwBrowseChgDir(1,'../',0))
-    else
-      call s:NetrwBrowse(0,s:NetrwBrowseChgDir(0,'../',0))
-    endif
-    if w:netrw_treetop == '/'
-      keepj call search('^\M'.curfile,"w")
-    elseif curfile == '../'
-      keepj call search('^\M'.curfile,"wb")
-    else
-      while 1
-        keepj call search('^\M'.s:treedepthstring.curfile,"wb")
-        let treepath= s:NetrwTreePath(w:netrw_treetop)
-        if treepath == curpath
-          break
+    norm! 0
+    if exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST && exists("w:netrw_treedict")
+        let curline= getline(".")
+        let swwline= winline() - 1
+        if exists("w:netrw_treetop")
+            let b:netrw_curdir= w:netrw_treetop
+        elseif exists("b:netrw_curdir")
+            let w:netrw_treetop= b:netrw_curdir
+        else
+            let w:netrw_treetop= getcwd()
+            let b:netrw_curdir = w:netrw_treetop
         endif
-      endwhile
-    endif
+        let curfile = getline(".")
+        let curpath = s:NetrwTreePath(w:netrw_treetop)
+        if a:islocal
+            call netrw#LocalBrowseCheck(s:NetrwBrowseChgDir(1,'../',0))
+        else
+            call s:NetrwBrowse(0,s:NetrwBrowseChgDir(0,'../',0))
+        endif
+        if w:netrw_treetop == '/'
+            keepj call search('^\M'.curfile,"w")
+        elseif curfile == '../'
+            keepj call search('^\M'.curfile,"wb")
+        else
+            while 1
+                keepj call search('^\M'.s:treedepthstring.curfile,"wb")
+                let treepath= s:NetrwTreePath(w:netrw_treetop)
+                if treepath == curpath
+                    break
+                endif
+            endwhile
+        endif
 
-  else
-    call s:SavePosn(s:netrw_posn)
-    if exists("b:netrw_curdir")
-      let curdir= b:netrw_curdir
     else
-      let curdir= expand(getcwd())
+        call s:SavePosn(s:netrw_posn)
+        if exists("b:netrw_curdir")
+            let curdir= b:netrw_curdir
+        else
+            let curdir= expand(getcwd())
+        endif
+        if a:islocal
+            call netrw#LocalBrowseCheck(s:NetrwBrowseChgDir(1,'../',0))
+        else
+            call s:NetrwBrowse(0,s:NetrwBrowseChgDir(0,'../',0))
+        endif
+        call s:RestorePosn(s:netrw_posn)
+        let curdir= substitute(curdir,'^.*[\/]','','')
+        let curdir= '\<'. escape(curdir, '~'). '/'
+        call search(curdir,'wc')
     endif
-    if a:islocal
-      call netrw#LocalBrowseCheck(s:NetrwBrowseChgDir(1,'../',0))
-    else
-      call s:NetrwBrowse(0,s:NetrwBrowseChgDir(0,'../',0))
-    endif
-    call s:RestorePosn(s:netrw_posn)
-    let curdir= substitute(curdir,'^.*[\/]','','')
-    let curdir= '\<'. escape(curdir, '~'). '/'
-    call search(curdir,'wc')
-  endif
 endfun
 
 " netrw#BrowseX:  (implements "x") executes a special "viewer" script or program for the {{{2
 "              given filename; typically this means given their extension.
 "              0=local, 1=remote
 fun! netrw#BrowseX(fname,remote)
-  if a:remote == 1 && a:fname !~ '^https\=:' && a:fname =~ '/$'
-    " remote directory, not a webpage access, looks like an attempt to do a directory listing
-    norm! gf
-  endif
-
-  if exists("g:netrw_browsex_viewer") && exists("g:netrw_browsex_support_remote") && !g:netrw_browsex_support_remote
-    let remote = a:remote
-  else
-    let remote = 0
-  endif
-
-  let ykeep      = @@
-  let screenposn = winsaveview()
-
-  " need to save and restore aw setting as gx can invoke this function from non-netrw buffers
-  let awkeep     = &aw
-  set noaw
-
-  " special core dump handler
-  if a:fname =~ '/core\(\.\d\+\)\=$'
-    if exists("g:Netrw_corehandler")
-      if type(g:Netrw_corehandler) == 2
-        " g:Netrw_corehandler is a function reference (see :help Funcref)
-        call g:Netrw_corehandler(s:NetrwFile(a:fname))
-      elseif type(g:Netrw_corehandler) == 3
-        " g:Netrw_corehandler is a List of function references (see :help Funcref)
-        for Fncref in g:Netrw_corehandler
-          if type(Fncref) == 2
-            call Fncref(a:fname)
-          endif
-        endfor
-      endif
-      call winrestview(screenposn)
-      let @@= ykeep
-      let &aw= awkeep
-      return
+    if a:remote == 1 && a:fname !~ '^https\=:' && a:fname =~ '/$'
+        " remote directory, not a webpage access, looks like an attempt to do a directory listing
+        norm! gf
     endif
-  endif
 
-  " set up the filename
-  " (lower case the extension, make a local copy of a remote file)
-  let exten= substitute(a:fname,'.*\.\(.\{-}\)','\1','e')
-  if has("win32")
-    let exten= substitute(exten,'^.*$','\L&\E','')
-  endif
-  if exten =~ "[\\/]"
-    let exten= ""
-  endif
-
-  if remote == 1
-    " create a local copy
-    setl bh=delete
-    call netrw#NetRead(3,a:fname)
-    " attempt to rename tempfile
-    let basename= substitute(a:fname,'^\(.*\)/\(.*\)\.\([^.]*\)$','\2','')
-    let newname = substitute(s:netrw_tmpfile,'^\(.*\)/\(.*\)\.\([^.]*\)$','\1/'.basename.'.\3','')
-    if s:netrw_tmpfile != newname && newname != ""
-      if rename(s:netrw_tmpfile,newname) == 0
-        " renaming succeeded
-        let fname= newname
-      else
-        " renaming failed
-        let fname= s:netrw_tmpfile
-      endif
+    if exists("g:netrw_browsex_viewer") && exists("g:netrw_browsex_support_remote") && !g:netrw_browsex_support_remote
+        let remote = a:remote
     else
-      let fname= s:netrw_tmpfile
+        let remote = 0
     endif
-  else
-    let fname= a:fname
-    " special ~ handler for local
-    if fname =~ '^\~' && expand("$HOME") != ""
-      let fname= s:NetrwFile(substitute(fname,'^\~',expand("$HOME"),''))
+
+    let ykeep      = @@
+    let screenposn = winsaveview()
+
+    " need to save and restore aw setting as gx can invoke this function from non-netrw buffers
+    let awkeep     = &aw
+    set noaw
+
+    " special core dump handler
+    if a:fname =~ '/core\(\.\d\+\)\=$'
+        if exists("g:Netrw_corehandler")
+            if type(g:Netrw_corehandler) == 2
+                " g:Netrw_corehandler is a function reference (see :help Funcref)
+                call g:Netrw_corehandler(s:NetrwFile(a:fname))
+            elseif type(g:Netrw_corehandler) == 3
+                " g:Netrw_corehandler is a List of function references (see :help Funcref)
+                for Fncref in g:Netrw_corehandler
+                    if type(Fncref) == 2
+                        call Fncref(a:fname)
+                    endif
+                endfor
+            endif
+            call winrestview(screenposn)
+            let @@= ykeep
+            let &aw= awkeep
+            return
+        endif
     endif
-  endif
 
-  call netrw#os#Open(fname)
-
-  " cleanup: remove temporary file,
-  "          delete current buffer if success with handler,
-  "          return to prior buffer (directory listing)
-  "          Feb 12, 2008: had to de-activate removal of
-  "          temporary file because it wasn't getting seen.
-  "  if remote == 1 && fname != a:fname
-  "   call s:NetrwDelete(fname)
-  "  endif
-
-  if remote == 1
-    setl bh=delete bt=nofile
-    if g:netrw_use_noswf
-      setl noswf
+    " set up the filename
+    " (lower case the extension, make a local copy of a remote file)
+    let exten= substitute(a:fname,'.*\.\(.\{-}\)','\1','e')
+    if has("win32")
+        let exten= substitute(exten,'^.*$','\L&\E','')
     endif
-    exe "sil! NetrwKeepj norm! \<c-o>"
-  endif
-  call winrestview(screenposn)
-  let @@ = ykeep
-  let &aw= awkeep
+    if exten =~ "[\\/]"
+        let exten= ""
+    endif
+
+    if remote == 1
+        " create a local copy
+        setl bh=delete
+        call netrw#NetRead(3,a:fname)
+        " attempt to rename tempfile
+        let basename= substitute(a:fname,'^\(.*\)/\(.*\)\.\([^.]*\)$','\2','')
+        let newname = substitute(s:netrw_tmpfile,'^\(.*\)/\(.*\)\.\([^.]*\)$','\1/'.basename.'.\3','')
+        if s:netrw_tmpfile != newname && newname != ""
+            if rename(s:netrw_tmpfile,newname) == 0
+                " renaming succeeded
+                let fname= newname
+            else
+                " renaming failed
+                let fname= s:netrw_tmpfile
+            endif
+        else
+            let fname= s:netrw_tmpfile
+        endif
+    else
+        let fname= a:fname
+        " special ~ handler for local
+        if fname =~ '^\~' && expand("$HOME") != ""
+            let fname= s:NetrwFile(substitute(fname,'^\~',expand("$HOME"),''))
+        endif
+    endif
+
+    call netrw#os#Open(fname)
+
+    " cleanup: remove temporary file,
+    "          delete current buffer if success with handler,
+    "          return to prior buffer (directory listing)
+    "          Feb 12, 2008: had to de-activate removal of
+    "          temporary file because it wasn't getting seen.
+    "  if remote == 1 && fname != a:fname
+    "   call s:NetrwDelete(fname)
+    "  endif
+
+    if remote == 1
+        setl bh=delete bt=nofile
+        if g:netrw_use_noswf
+            setl noswf
+        endif
+        exe "sil! NetrwKeepj norm! \<c-o>"
+    endif
+    call winrestview(screenposn)
+    let @@ = ykeep
+    let &aw= awkeep
 endfun
 
 " s:NetrwBufRename: renames a buffer without the side effect of retaining an unlisted buffer having the old name {{{2
 "                   Using the file command on a "[No Name]" buffer does not seem to cause the old "[No Name]" buffer
 "                   to become an unlisted buffer, so in that case don't bwipe it.
 fun! s:NetrwBufRename(newname)
-  let oldbufname= bufname(bufnr("%"))
+    let oldbufname= bufname(bufnr("%"))
 
-  if oldbufname != a:newname
-    let b:junk= 1
-    exe 'sil! keepj keepalt file '.fnameescape(a:newname)
-    let oldbufnr= bufnr(oldbufname)
-    if oldbufname != "" && oldbufnr != -1 && oldbufnr != bufnr("%")
-      exe "bwipe! ".oldbufnr
+    if oldbufname != a:newname
+        let b:junk= 1
+        exe 'sil! keepj keepalt file '.fnameescape(a:newname)
+        let oldbufnr= bufnr(oldbufname)
+        if oldbufname != "" && oldbufnr != -1 && oldbufnr != bufnr("%")
+            exe "bwipe! ".oldbufnr
+        endif
     endif
-  endif
 
 endfun
 
 " netrw#CheckIfRemote: returns 1 if current file looks like an url, 0 else {{{2
 fun! netrw#CheckIfRemote(...)
-  if a:0 > 0
-    let curfile= a:1
-  else
-    let curfile= expand("%")
-  endif
-  if curfile =~ '^\a\{3,}://'
-    return 1
-  else
-    return 0
-  endif
+    if a:0 > 0
+        let curfile= a:1
+    else
+        let curfile= expand("%")
+    endif
+    if curfile =~ '^\a\{3,}://'
+        return 1
+    else
+        return 0
+    endif
 endfun
 
 " s:NetrwChgPerm: (implements "gp") change file permission {{{2
 fun! s:NetrwChgPerm(islocal,curdir)
-  let ykeep  = @@
-  call inputsave()
-  let newperm= input("Enter new permission: ")
-  call inputrestore()
-  let chgperm= substitute(g:netrw_chgperm,'\<FILENAME\>',netrw#os#Escape(expand("<cfile>")),'')
-  let chgperm= substitute(chgperm,'\<PERM\>',netrw#os#Escape(newperm),'')
-  call system(chgperm)
-  if v:shell_error != 0
-    NetrwKeepj call netrw#ErrorMsg(1,"changing permission on file<".expand("<cfile>")."> seems to have failed",75)
-  endif
-  if a:islocal
-    NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
-  endif
-  let @@= ykeep
+    let ykeep  = @@
+    call inputsave()
+    let newperm= input("Enter new permission: ")
+    call inputrestore()
+    let chgperm= substitute(g:netrw_chgperm,'\<FILENAME\>',netrw#os#Escape(expand("<cfile>")),'')
+    let chgperm= substitute(chgperm,'\<PERM\>',netrw#os#Escape(newperm),'')
+    call system(chgperm)
+    if v:shell_error != 0
+        NetrwKeepj call netrw#ErrorMsg(1,"changing permission on file<".expand("<cfile>")."> seems to have failed",75)
+    endif
+    if a:islocal
+        NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
+    endif
+    let @@= ykeep
 endfun
 
 " s:NetrwClearExplore: clear explore variables (if any) {{{2
 fun! s:NetrwClearExplore()
-  2match none
-  if exists("s:explore_match")        |unlet s:explore_match        |endif
-  if exists("s:explore_indx")         |unlet s:explore_indx         |endif
-  if exists("s:netrw_explore_prvdir") |unlet s:netrw_explore_prvdir |endif
-  if exists("s:dirstarstar")          |unlet s:dirstarstar          |endif
-  if exists("s:explore_prvdir")       |unlet s:explore_prvdir       |endif
-  if exists("w:netrw_explore_indx")   |unlet w:netrw_explore_indx   |endif
-  if exists("w:netrw_explore_listlen")|unlet w:netrw_explore_listlen|endif
-  if exists("w:netrw_explore_list")   |unlet w:netrw_explore_list   |endif
-  if exists("w:netrw_explore_bufnr")  |unlet w:netrw_explore_bufnr  |endif
-  "   redraw!
+    2match none
+    if exists("s:explore_match")        |unlet s:explore_match        |endif
+    if exists("s:explore_indx")         |unlet s:explore_indx         |endif
+    if exists("s:netrw_explore_prvdir") |unlet s:netrw_explore_prvdir |endif
+    if exists("s:dirstarstar")          |unlet s:dirstarstar          |endif
+    if exists("s:explore_prvdir")       |unlet s:explore_prvdir       |endif
+    if exists("w:netrw_explore_indx")   |unlet w:netrw_explore_indx   |endif
+    if exists("w:netrw_explore_listlen")|unlet w:netrw_explore_listlen|endif
+    if exists("w:netrw_explore_list")   |unlet w:netrw_explore_list   |endif
+    if exists("w:netrw_explore_bufnr")  |unlet w:netrw_explore_bufnr  |endif
+    "   redraw!
 endfun
 
 " s:NetrwEditBuf: decides whether or not to use keepalt to edit a buffer {{{2
 fun! s:NetrwEditBuf(bufnum)
-  if exists("g:netrw_altfile") && g:netrw_altfile && &ft == "netrw"
-    exe "sil! NetrwKeepj keepalt noswapfile b ".fnameescape(a:bufnum)
-  else
-    exe "sil! NetrwKeepj noswapfile b ".fnameescape(a:bufnum)
-  endif
+    if exists("g:netrw_altfile") && g:netrw_altfile && &ft == "netrw"
+        exe "sil! NetrwKeepj keepalt noswapfile b ".fnameescape(a:bufnum)
+    else
+        exe "sil! NetrwKeepj noswapfile b ".fnameescape(a:bufnum)
+    endif
 endfun
 
 " s:NetrwEditFile: decides whether or not to use keepalt to edit a file {{{2
 "    NetrwKeepj [keepalt] <OPT> <CMD> <FILENAME>
 fun! s:NetrwEditFile(cmd,opt,fname)
-  if exists("g:netrw_altfile") && g:netrw_altfile && &ft == "netrw"
-    exe "NetrwKeepj keepalt ".a:opt." ".a:cmd." ".fnameescape(a:fname)
-  else
-    if a:cmd =~# 'e\%[new]!' && !&hidden && getbufvar(bufname('%'), '&modified', 0)
-      call setbufvar(bufname('%'), '&bufhidden', 'hide')
+    if exists("g:netrw_altfile") && g:netrw_altfile && &ft == "netrw"
+        exe "NetrwKeepj keepalt ".a:opt." ".a:cmd." ".fnameescape(a:fname)
+    else
+        if a:cmd =~# 'e\%[new]!' && !&hidden && getbufvar(bufname('%'), '&modified', 0)
+            call setbufvar(bufname('%'), '&bufhidden', 'hide')
+        endif
+        exe "NetrwKeepj ".a:opt." ".a:cmd." ".fnameescape(a:fname)
     endif
-    exe "NetrwKeepj ".a:opt." ".a:cmd." ".fnameescape(a:fname)
-  endif
 endfun
 
 " s:NetrwExploreListUniq: {{{2
 fun! s:NetrwExploreListUniq(explist)
-  " this assumes that the list is already sorted
-  let newexplist= []
-  for member in a:explist
-    if !exists("uniqmember") || member != uniqmember
-      let uniqmember = member
-      let newexplist = newexplist + [ member ]
-    endif
-  endfor
-  return newexplist
+    " this assumes that the list is already sorted
+    let newexplist= []
+    for member in a:explist
+        if !exists("uniqmember") || member != uniqmember
+            let uniqmember = member
+            let newexplist = newexplist + [ member ]
+        endif
+    endfor
+    return newexplist
 endfun
 
 " s:NetrwForceChgDir: (gd support) Force treatment as a directory {{{2
 fun! s:NetrwForceChgDir(islocal,newdir)
-  let ykeep= @@
-  if a:newdir !~ '/$'
-    " ok, looks like force is needed to get directory-style treatment
-    if a:newdir =~ '@$'
-      let newdir= substitute(a:newdir,'@$','/','')
-    elseif a:newdir =~ '[*=|\\]$'
-      let newdir= substitute(a:newdir,'.$','/','')
+    let ykeep= @@
+    if a:newdir !~ '/$'
+        " ok, looks like force is needed to get directory-style treatment
+        if a:newdir =~ '@$'
+            let newdir= substitute(a:newdir,'@$','/','')
+        elseif a:newdir =~ '[*=|\\]$'
+            let newdir= substitute(a:newdir,'.$','/','')
+        else
+            let newdir= a:newdir.'/'
+        endif
     else
-      let newdir= a:newdir.'/'
+        " should already be getting treatment as a directory
+        let newdir= a:newdir
     endif
-  else
-    " should already be getting treatment as a directory
-    let newdir= a:newdir
-  endif
-  let newdir= s:NetrwBrowseChgDir(a:islocal,newdir,0)
-  call s:NetrwBrowse(a:islocal,newdir)
-  let @@= ykeep
+    let newdir= s:NetrwBrowseChgDir(a:islocal,newdir,0)
+    call s:NetrwBrowse(a:islocal,newdir)
+    let @@= ykeep
 endfun
 
 " s:NetrwForceFile: (gf support) Force treatment as a file {{{2
 fun! s:NetrwForceFile(islocal,newfile)
-  if a:newfile =~ '[/@*=|\\]$'
-    let newfile= substitute(a:newfile,'.$','','')
-  else
-    let newfile= a:newfile
-  endif
-  if a:islocal
-    call s:NetrwBrowseChgDir(a:islocal,newfile,0)
-  else
-    call s:NetrwBrowse(a:islocal,s:NetrwBrowseChgDir(a:islocal,newfile,0))
-  endif
+    if a:newfile =~ '[/@*=|\\]$'
+        let newfile= substitute(a:newfile,'.$','','')
+    else
+        let newfile= a:newfile
+    endif
+    if a:islocal
+        call s:NetrwBrowseChgDir(a:islocal,newfile,0)
+    else
+        call s:NetrwBrowse(a:islocal,s:NetrwBrowseChgDir(a:islocal,newfile,0))
+    endif
 endfun
 
 " s:NetrwHide: this function is invoked by the "a" map for browsing {{{2
@@ -4498,89 +4474,89 @@ endfun
 "                           1: show not-hidden files
 "                           2: show hidden files only
 fun! s:NetrwHide(islocal)
-  let ykeep= @@
-  let svpos= winsaveview()
+    let ykeep= @@
+    let svpos= winsaveview()
 
-  if exists("s:netrwmarkfilelist_{bufnr('%')}")
+    if exists("s:netrwmarkfilelist_{bufnr('%')}")
 
-    " hide the files in the markfile list
-    for fname in s:netrwmarkfilelist_{bufnr("%")}
-      if match(g:netrw_list_hide,'\<'.fname.'\>') != -1
-        " remove fname from hiding list
-        let g:netrw_list_hide= substitute(g:netrw_list_hide,'..\<'.escape(fname,g:netrw_fname_escape).'\>..','','')
-        let g:netrw_list_hide= substitute(g:netrw_list_hide,',,',',','g')
-        let g:netrw_list_hide= substitute(g:netrw_list_hide,'^,\|,$','','')
-      else
-        " append fname to hiding list
-        if exists("g:netrw_list_hide") && g:netrw_list_hide != ""
-          let g:netrw_list_hide= g:netrw_list_hide.',\<'.escape(fname,g:netrw_fname_escape).'\>'
-        else
-          let g:netrw_list_hide= '\<'.escape(fname,g:netrw_fname_escape).'\>'
+        " hide the files in the markfile list
+        for fname in s:netrwmarkfilelist_{bufnr("%")}
+            if match(g:netrw_list_hide,'\<'.fname.'\>') != -1
+                " remove fname from hiding list
+                let g:netrw_list_hide= substitute(g:netrw_list_hide,'..\<'.escape(fname,g:netrw_fname_escape).'\>..','','')
+                let g:netrw_list_hide= substitute(g:netrw_list_hide,',,',',','g')
+                let g:netrw_list_hide= substitute(g:netrw_list_hide,'^,\|,$','','')
+            else
+                " append fname to hiding list
+                if exists("g:netrw_list_hide") && g:netrw_list_hide != ""
+                    let g:netrw_list_hide= g:netrw_list_hide.',\<'.escape(fname,g:netrw_fname_escape).'\>'
+                else
+                    let g:netrw_list_hide= '\<'.escape(fname,g:netrw_fname_escape).'\>'
+                endif
+            endif
+        endfor
+        NetrwKeepj call s:NetrwUnmarkList(bufnr("%"),b:netrw_curdir)
+        let g:netrw_hide= 1
+
+    else
+
+        " switch between show-all/show-not-hidden/show-hidden
+        let g:netrw_hide=(g:netrw_hide+1)%3
+        exe "NetrwKeepj norm! 0"
+        if g:netrw_hide && g:netrw_list_hide == ""
+            call netrw#msg#Notify('WARNING', 'your hiding list is empty!')
+            let @@= ykeep
+            return
         endif
-      endif
-    endfor
-    NetrwKeepj call s:NetrwUnmarkList(bufnr("%"),b:netrw_curdir)
-    let g:netrw_hide= 1
-
-  else
-
-    " switch between show-all/show-not-hidden/show-hidden
-    let g:netrw_hide=(g:netrw_hide+1)%3
-    exe "NetrwKeepj norm! 0"
-    if g:netrw_hide && g:netrw_list_hide == ""
-      call netrw#msg#Notify('WARNING', 'your hiding list is empty!')
-      let @@= ykeep
-      return
     endif
-  endif
 
-  NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
-  NetrwKeepj call winrestview(svpos)
-  let @@= ykeep
+    NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
+    NetrwKeepj call winrestview(svpos)
+    let @@= ykeep
 endfun
 
 " s:NetrwHideEdit: allows user to edit the file/directory hiding list {{{2
 fun! s:NetrwHideEdit(islocal)
-  let ykeep= @@
-  " save current cursor position
-  let svpos= winsaveview()
+    let ykeep= @@
+    " save current cursor position
+    let svpos= winsaveview()
 
-  " get new hiding list from user
-  call inputsave()
-  let newhide= input("Edit Hiding List: ",g:netrw_list_hide)
-  call inputrestore()
-  let g:netrw_list_hide= newhide
+    " get new hiding list from user
+    call inputsave()
+    let newhide= input("Edit Hiding List: ",g:netrw_list_hide)
+    call inputrestore()
+    let g:netrw_list_hide= newhide
 
-  " refresh the listing
-  sil NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,"./",0))
+    " refresh the listing
+    sil NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,"./",0))
 
-  " restore cursor position
-  call winrestview(svpos)
-  let @@= ykeep
+    " restore cursor position
+    call winrestview(svpos)
+    let @@= ykeep
 endfun
 
 " s:NetrwHidden: invoked by "gh" {{{2
 fun! s:NetrwHidden(islocal)
-  let ykeep= @@
-  "  save current position
-  let svpos  = winsaveview()
+    let ykeep= @@
+    "  save current position
+    let svpos  = winsaveview()
 
-  if g:netrw_list_hide =~ '\(^\|,\)\\(^\\|\\s\\s\\)\\zs\\.\\S\\+'
-    " remove .file pattern from hiding list
-    let g:netrw_list_hide= substitute(g:netrw_list_hide,'\(^\|,\)\\(^\\|\\s\\s\\)\\zs\\.\\S\\+','','')
-  elseif strdisplaywidth(g:netrw_list_hide) >= 1
-    let g:netrw_list_hide= g:netrw_list_hide . ',\(^\|\s\s\)\zs\.\S\+'
-  else
-    let g:netrw_list_hide= '\(^\|\s\s\)\zs\.\S\+'
-  endif
-  if g:netrw_list_hide =~ '^,'
-    let g:netrw_list_hide= strpart(g:netrw_list_hide,1)
-  endif
+    if g:netrw_list_hide =~ '\(^\|,\)\\(^\\|\\s\\s\\)\\zs\\.\\S\\+'
+        " remove .file pattern from hiding list
+        let g:netrw_list_hide= substitute(g:netrw_list_hide,'\(^\|,\)\\(^\\|\\s\\s\\)\\zs\\.\\S\\+','','')
+    elseif strdisplaywidth(g:netrw_list_hide) >= 1
+        let g:netrw_list_hide= g:netrw_list_hide . ',\(^\|\s\s\)\zs\.\S\+'
+    else
+        let g:netrw_list_hide= '\(^\|\s\s\)\zs\.\S\+'
+    endif
+    if g:netrw_list_hide =~ '^,'
+        let g:netrw_list_hide= strpart(g:netrw_list_hide,1)
+    endif
 
-  " refresh screen and return to saved position
-  NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
-  NetrwKeepj call winrestview(svpos)
-  let @@= ykeep
+    " refresh screen and return to saved position
+    NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
+    NetrwKeepj call winrestview(svpos)
+    let @@= ykeep
 endfun
 
 "  s:NetrwHome: this function determines a "home" for saving bookmarks and history {{{2
@@ -4626,55 +4602,55 @@ endfunction
 
 " s:NetrwLeftmouse: handles the <leftmouse> when in a netrw browsing window {{{2
 fun! s:NetrwLeftmouse(islocal)
-  if exists("s:netrwdrag")
-    return
-  endif
-  if &ft != "netrw"
-    return
-  endif
-
-  let ykeep= @@
-  " check if the status bar was clicked on instead of a file/directory name
-  while getchar(0) != 0
-    "clear the input stream
-  endwhile
-  call feedkeys("\<LeftMouse>")
-  let c          = getchar()
-  let mouse_lnum = v:mouse_lnum
-  let wlastline  = line('w$')
-  let lastline   = line('$')
-  if mouse_lnum >= wlastline + 1 || v:mouse_win != winnr()
-    " appears to be a status bar leftmouse click
-    let @@= ykeep
-    return
-  endif
-  " Dec 04, 2013: following test prevents leftmouse selection/deselection of directories and files in treelist mode
-  " Windows are separated by vertical separator bars - but the mouse seems to be doing what it should when dragging that bar
-  " without this test when its disabled.
-  " May 26, 2014: edit file, :Lex, resize window -- causes refresh.  Reinstated a modified test.  See if problems develop.
-  if v:mouse_col > virtcol('.')
-    let @@= ykeep
-    return
-  endif
-
-  if a:islocal
-    if exists("b:netrw_curdir")
-      NetrwKeepj call netrw#LocalBrowseCheck(s:NetrwBrowseChgDir(1,s:NetrwGetWord(),1))
+    if exists("s:netrwdrag")
+        return
     endif
-  else
-    if exists("b:netrw_curdir")
-      NetrwKeepj call s:NetrwBrowse(0,s:NetrwBrowseChgDir(0,s:NetrwGetWord(),1))
+    if &ft != "netrw"
+        return
     endif
-  endif
-  let @@= ykeep
+
+    let ykeep= @@
+    " check if the status bar was clicked on instead of a file/directory name
+    while getchar(0) != 0
+        "clear the input stream
+    endwhile
+    call feedkeys("\<LeftMouse>")
+    let c          = getchar()
+    let mouse_lnum = v:mouse_lnum
+    let wlastline  = line('w$')
+    let lastline   = line('$')
+    if mouse_lnum >= wlastline + 1 || v:mouse_win != winnr()
+        " appears to be a status bar leftmouse click
+        let @@= ykeep
+        return
+    endif
+    " Dec 04, 2013: following test prevents leftmouse selection/deselection of directories and files in treelist mode
+    " Windows are separated by vertical separator bars - but the mouse seems to be doing what it should when dragging that bar
+    " without this test when its disabled.
+    " May 26, 2014: edit file, :Lex, resize window -- causes refresh.  Reinstated a modified test.  See if problems develop.
+    if v:mouse_col > virtcol('.')
+        let @@= ykeep
+        return
+    endif
+
+    if a:islocal
+        if exists("b:netrw_curdir")
+            NetrwKeepj call netrw#LocalBrowseCheck(s:NetrwBrowseChgDir(1,s:NetrwGetWord(),1))
+        endif
+    else
+        if exists("b:netrw_curdir")
+            NetrwKeepj call s:NetrwBrowse(0,s:NetrwBrowseChgDir(0,s:NetrwGetWord(),1))
+        endif
+    endif
+    let @@= ykeep
 endfun
 
 " s:NetrwCLeftmouse: used to select a file/directory for a target {{{2
 fun! s:NetrwCLeftmouse(islocal)
-  if &ft != "netrw"
-    return
-  endif
-  call s:NetrwMarkFileTgt(a:islocal)
+    if &ft != "netrw"
+        return
+    endif
+    call s:NetrwMarkFileTgt(a:islocal)
 endfun
 
 " s:NetrwServerEdit: edit file in a server gvim, usually NETRWSERVER  (implements <c-r>){{{2
@@ -4683,583 +4659,579 @@ endfun
 "   a:islocal=2 : <c-r>     used, remote
 "   a:islocal=3 : <c-r>     used, local
 fun! s:NetrwServerEdit(islocal,fname)
-  let islocal = a:islocal%2      " =0: remote           =1: local
-  let ctrlr   = a:islocal >= 2   " =0: <c-r> not used   =1: <c-r> used
+    let islocal = a:islocal%2      " =0: remote           =1: local
+    let ctrlr   = a:islocal >= 2   " =0: <c-r> not used   =1: <c-r> used
 
-  if (islocal && isdirectory(s:NetrwFile(a:fname))) || (!islocal && a:fname =~ '/$')
-    " handle directories in the local window -- not in the remote vim server
-    " user must have closed the NETRWSERVER window.  Treat as normal editing from netrw.
-    let g:netrw_browse_split= 0
-    if exists("s:netrw_browse_split") && exists("s:netrw_browse_split_".winnr())
-      let g:netrw_browse_split= s:netrw_browse_split_{winnr()}
-      unlet s:netrw_browse_split_{winnr()}
-    endif
-    call s:NetrwBrowse(islocal,s:NetrwBrowseChgDir(islocal,a:fname,0))
-    return
-  endif
-
-  if has("clientserver") && executable("gvim")
-
-    if exists("g:netrw_browse_split") && type(g:netrw_browse_split) == 3
-      let srvrname = g:netrw_browse_split[0]
-      let tabnum   = g:netrw_browse_split[1]
-      let winnum   = g:netrw_browse_split[2]
-
-      if serverlist() !~ '\<'.srvrname.'\>'
-        if !ctrlr
-          " user must have closed the server window and the user did not use <c-r>, but
-          " used something like <cr>.
-          if exists("g:netrw_browse_split")
-            unlet g:netrw_browse_split
-          endif
-          let g:netrw_browse_split= 0
-          if exists("s:netrw_browse_split_".winnr())
+    if (islocal && isdirectory(s:NetrwFile(a:fname))) || (!islocal && a:fname =~ '/$')
+        " handle directories in the local window -- not in the remote vim server
+        " user must have closed the NETRWSERVER window.  Treat as normal editing from netrw.
+        let g:netrw_browse_split= 0
+        if exists("s:netrw_browse_split") && exists("s:netrw_browse_split_".winnr())
             let g:netrw_browse_split= s:netrw_browse_split_{winnr()}
-          endif
-          call s:NetrwBrowseChgDir(islocal,a:fname,0)
-          return
-
-        elseif has("win32") && executable("start")
-          " start up remote netrw server under windows
-          call system("start gvim --servername ".srvrname)
-
-        else
-          " start up remote netrw server under linux
-          call system("gvim --servername ".srvrname)
+            unlet s:netrw_browse_split_{winnr()}
         endif
-      endif
-
-      call remote_send(srvrname,":tabn ".tabnum."\<cr>")
-      call remote_send(srvrname,":".winnum."wincmd w\<cr>")
-      call remote_send(srvrname,":e ".fnameescape(s:NetrwFile(a:fname))."\<cr>")
-    else
-
-      if serverlist() !~ '\<'.g:netrw_servername.'\>'
-
-        if !ctrlr
-          if exists("g:netrw_browse_split")
-            unlet g:netrw_browse_split
-          endif
-          let g:netrw_browse_split= 0
-          call s:NetrwBrowse(islocal,s:NetrwBrowseChgDir(islocal,a:fname,0))
-          return
-
-        else
-          if has("win32") && executable("start")
-            " start up remote netrw server under windows
-            call system("start gvim --servername ".g:netrw_servername)
-          else
-            " start up remote netrw server under linux
-            call system("gvim --servername ".g:netrw_servername)
-          endif
-        endif
-      endif
-
-      while 1
-        try
-          call remote_send(g:netrw_servername,":e ".fnameescape(s:NetrwFile(a:fname))."\<cr>")
-          break
-        catch /^Vim\%((\a\+)\)\=:E241/
-          sleep 200m
-        endtry
-      endwhile
-
-      if exists("g:netrw_browse_split")
-        if type(g:netrw_browse_split) != 3
-          let s:netrw_browse_split_{winnr()}= g:netrw_browse_split
-        endif
-        unlet g:netrw_browse_split
-      endif
-      let g:netrw_browse_split= [g:netrw_servername,1,1]
+        call s:NetrwBrowse(islocal,s:NetrwBrowseChgDir(islocal,a:fname,0))
+        return
     endif
 
-  else
-    call netrw#ErrorMsg(s:ERROR,"you need a gui-capable vim and client-server to use <ctrl-r>",98)
-  endif
+    if has("clientserver") && executable("gvim")
+
+        if exists("g:netrw_browse_split") && type(g:netrw_browse_split) == 3
+            let srvrname = g:netrw_browse_split[0]
+            let tabnum   = g:netrw_browse_split[1]
+            let winnum   = g:netrw_browse_split[2]
+
+            if serverlist() !~ '\<'.srvrname.'\>'
+                if !ctrlr
+                    " user must have closed the server window and the user did not use <c-r>, but
+                    " used something like <cr>.
+                    if exists("g:netrw_browse_split")
+                        unlet g:netrw_browse_split
+                    endif
+                    let g:netrw_browse_split= 0
+                    if exists("s:netrw_browse_split_".winnr())
+                        let g:netrw_browse_split= s:netrw_browse_split_{winnr()}
+                    endif
+                    call s:NetrwBrowseChgDir(islocal,a:fname,0)
+                    return
+
+                elseif has("win32") && executable("start")
+                    " start up remote netrw server under windows
+                    call system("start gvim --servername ".srvrname)
+
+                else
+                    " start up remote netrw server under linux
+                    call system("gvim --servername ".srvrname)
+                endif
+            endif
+
+            call remote_send(srvrname,":tabn ".tabnum."\<cr>")
+            call remote_send(srvrname,":".winnum."wincmd w\<cr>")
+            call remote_send(srvrname,":e ".fnameescape(s:NetrwFile(a:fname))."\<cr>")
+        else
+
+            if serverlist() !~ '\<'.g:netrw_servername.'\>'
+
+                if !ctrlr
+                    if exists("g:netrw_browse_split")
+                        unlet g:netrw_browse_split
+                    endif
+                    let g:netrw_browse_split= 0
+                    call s:NetrwBrowse(islocal,s:NetrwBrowseChgDir(islocal,a:fname,0))
+                    return
+
+                else
+                    if has("win32") && executable("start")
+                        " start up remote netrw server under windows
+                        call system("start gvim --servername ".g:netrw_servername)
+                    else
+                        " start up remote netrw server under linux
+                        call system("gvim --servername ".g:netrw_servername)
+                    endif
+                endif
+            endif
+
+            while 1
+                try
+                    call remote_send(g:netrw_servername,":e ".fnameescape(s:NetrwFile(a:fname))."\<cr>")
+                    break
+                catch /^Vim\%((\a\+)\)\=:E241/
+                    sleep 200m
+                endtry
+            endwhile
+
+            if exists("g:netrw_browse_split")
+                if type(g:netrw_browse_split) != 3
+                    let s:netrw_browse_split_{winnr()}= g:netrw_browse_split
+                endif
+                unlet g:netrw_browse_split
+            endif
+            let g:netrw_browse_split= [g:netrw_servername,1,1]
+        endif
+
+    else
+        call netrw#ErrorMsg(s:ERROR,"you need a gui-capable vim and client-server to use <ctrl-r>",98)
+    endif
 
 endfun
 
 " s:NetrwSLeftmouse: marks the file under the cursor.  May be dragged to select additional files {{{2
 fun! s:NetrwSLeftmouse(islocal)
-  if &ft != "netrw"
-    return
-  endif
+    if &ft != "netrw"
+        return
+    endif
 
-  let s:ngw= s:NetrwGetWord()
-  call s:NetrwMarkFile(a:islocal,s:ngw)
+    let s:ngw= s:NetrwGetWord()
+    call s:NetrwMarkFile(a:islocal,s:ngw)
 
 endfun
 
 " s:NetrwSLeftdrag: invoked via a shift-leftmouse and dragging {{{2
 "                   Used to mark multiple files.
 fun! s:NetrwSLeftdrag(islocal)
-  if !exists("s:netrwdrag")
-    let s:netrwdrag = winnr()
-    if a:islocal
-      nno <silent> <s-leftrelease> <leftmouse>:<c-u>call <SID>NetrwSLeftrelease(1)<cr>
-    else
-      nno <silent> <s-leftrelease> <leftmouse>:<c-u>call <SID>NetrwSLeftrelease(0)<cr>
+    if !exists("s:netrwdrag")
+        let s:netrwdrag = winnr()
+        if a:islocal
+            nno <silent> <s-leftrelease> <leftmouse>:<c-u>call <SID>NetrwSLeftrelease(1)<cr>
+        else
+            nno <silent> <s-leftrelease> <leftmouse>:<c-u>call <SID>NetrwSLeftrelease(0)<cr>
+        endif
     endif
-  endif
-  let ngw = s:NetrwGetWord()
-  if !exists("s:ngw") || s:ngw != ngw
-    call s:NetrwMarkFile(a:islocal,ngw)
-  endif
-  let s:ngw= ngw
+    let ngw = s:NetrwGetWord()
+    if !exists("s:ngw") || s:ngw != ngw
+        call s:NetrwMarkFile(a:islocal,ngw)
+    endif
+    let s:ngw= ngw
 endfun
 
 " s:NetrwSLeftrelease: terminates shift-leftmouse dragging {{{2
 fun! s:NetrwSLeftrelease(islocal)
-  if exists("s:netrwdrag")
-    nunmap <s-leftrelease>
-    let ngw = s:NetrwGetWord()
-    if !exists("s:ngw") || s:ngw != ngw
-      call s:NetrwMarkFile(a:islocal,ngw)
+    if exists("s:netrwdrag")
+        nunmap <s-leftrelease>
+        let ngw = s:NetrwGetWord()
+        if !exists("s:ngw") || s:ngw != ngw
+            call s:NetrwMarkFile(a:islocal,ngw)
+        endif
+        if exists("s:ngw")
+            unlet s:ngw
+        endif
+        unlet s:netrwdrag
     endif
-    if exists("s:ngw")
-      unlet s:ngw
-    endif
-    unlet s:netrwdrag
-  endif
 endfun
 
 " s:NetrwListHide: uses [range]g~...~d to delete files that match       {{{2
 "                  comma-separated patterns given in g:netrw_list_hide
 fun! s:NetrwListHide()
-  let ykeep= @@
+    let ykeep= @@
 
-  " find a character not in the "hide" string to use as a separator for :g and :v commands
-  " How-it-works: take the hiding command, convert it into a range.
-  " Duplicate characters don't matter.
-  " Remove all such characters from the '/~@#...890' string.
-  " Use the first character left as a separator character.
-  let listhide= g:netrw_list_hide
-  let sep     = strpart(substitute('~@#$%^&*{};:,<.>?|1234567890','['.escape(listhide,'-]^\').']','','ge'),1,1)
+    " find a character not in the "hide" string to use as a separator for :g and :v commands
+    " How-it-works: take the hiding command, convert it into a range.
+    " Duplicate characters don't matter.
+    " Remove all such characters from the '/~@#...890' string.
+    " Use the first character left as a separator character.
+    let listhide= g:netrw_list_hide
+    let sep     = strpart(substitute('~@#$%^&*{};:,<.>?|1234567890','['.escape(listhide,'-]^\').']','','ge'),1,1)
 
-  while listhide != ""
-    if listhide =~ ','
-      let hide     = substitute(listhide,',.*$','','e')
-      let listhide = substitute(listhide,'^.\{-},\(.*\)$','\1','e')
-    else
-      let hide     = listhide
-      let listhide = ""
+    while listhide != ""
+        if listhide =~ ','
+            let hide     = substitute(listhide,',.*$','','e')
+            let listhide = substitute(listhide,'^.\{-},\(.*\)$','\1','e')
+        else
+            let hide     = listhide
+            let listhide = ""
+        endif
+        if g:netrw_sort_by =~ '^[ts]'
+            if hide =~ '^\^'
+                let hide= substitute(hide,'^\^','^\(\\d\\+/\)','')
+            elseif hide =~ '^\\(\^'
+                let hide= substitute(hide,'^\\(\^','\\(^\\(\\d\\+/\\)','')
+            endif
+        endif
+
+        " Prune the list by hiding any files which match
+        if g:netrw_hide == 1
+            exe 'sil! NetrwKeepj '.w:netrw_bannercnt.',$g'.sep.hide.sep.'d'
+        elseif g:netrw_hide == 2
+            exe 'sil! NetrwKeepj '.w:netrw_bannercnt.',$g'.sep.hide.sep.'s@^@ /-KEEP-/ @'
+        endif
+    endwhile
+
+    if g:netrw_hide == 2
+        exe 'sil! NetrwKeepj '.w:netrw_bannercnt.',$v@^ /-KEEP-/ @d'
+        exe 'sil! NetrwKeepj '.w:netrw_bannercnt.',$s@^\%( /-KEEP-/ \)\+@@e'
     endif
-    if g:netrw_sort_by =~ '^[ts]'
-      if hide =~ '^\^'
-        let hide= substitute(hide,'^\^','^\(\\d\\+/\)','')
-      elseif hide =~ '^\\(\^'
-        let hide= substitute(hide,'^\\(\^','\\(^\\(\\d\\+/\\)','')
-      endif
-    endif
 
-    " Prune the list by hiding any files which match
-    if g:netrw_hide == 1
-      exe 'sil! NetrwKeepj '.w:netrw_bannercnt.',$g'.sep.hide.sep.'d'
-    elseif g:netrw_hide == 2
-      exe 'sil! NetrwKeepj '.w:netrw_bannercnt.',$g'.sep.hide.sep.'s@^@ /-KEEP-/ @'
-    endif
-  endwhile
+    " remove any blank lines that have somehow remained.
+    " This seems to happen under Windows.
+    exe 'sil! NetrwKeepj 1,$g@^\s*$@d'
 
-  if g:netrw_hide == 2
-    exe 'sil! NetrwKeepj '.w:netrw_bannercnt.',$v@^ /-KEEP-/ @d'
-    exe 'sil! NetrwKeepj '.w:netrw_bannercnt.',$s@^\%( /-KEEP-/ \)\+@@e'
-  endif
-
-  " remove any blank lines that have somehow remained.
-  " This seems to happen under Windows.
-  exe 'sil! NetrwKeepj 1,$g@^\s*$@d'
-
-  let @@= ykeep
+    let @@= ykeep
 endfun
 
 " s:NetrwMakeDir: this function makes a directory (both local and remote) {{{2
 "                 implements the "d" mapping.
 fun! s:NetrwMakeDir(usrhost)
 
-  let ykeep= @@
-  " get name of new directory from user.  A bare <CR> will skip.
-  " if its currently a directory, also request will be skipped, but with
-  " a message.
-  call inputsave()
-  let newdirname= input("Please give directory name: ")
-  call inputrestore()
+    let ykeep= @@
+    " get name of new directory from user.  A bare <CR> will skip.
+    " if its currently a directory, also request will be skipped, but with
+    " a message.
+    call inputsave()
+    let newdirname= input("Please give directory name: ")
+    call inputrestore()
 
-  if newdirname == ""
-    let @@= ykeep
-    return
-  endif
-
-  if a:usrhost == ""
-
-    " Local mkdir:
-    " sanity checks
-    let fullnewdir= b:netrw_curdir.'/'.newdirname
-    if isdirectory(s:NetrwFile(fullnewdir))
-      if !exists("g:netrw_quiet")
-        call netrw#msg#Notify('WARNING', printf('<%s> is already a directory!', newdirname))
-      endif
-      let @@= ykeep
-      return
-    endif
-    if s:FileReadable(fullnewdir)
-      if !exists("g:netrw_quiet")
-        call netrw#msg#Notify('WARNING', printf('<%s> is already a file!', newdirname))
-      endif
-      let @@= ykeep
-      return
-    endif
-
-    " requested new local directory is neither a pre-existing file or
-    " directory, so make it!
-    if exists("*mkdir")
-      if has("unix")
-        call mkdir(fullnewdir,"p",xor(0777, system("umask")))
-      else
-        call mkdir(fullnewdir,"p")
-      endif
-    else
-      let netrw_origdir= netrw#fs#Cwd(1)
-      if s:NetrwLcd(b:netrw_curdir)
-        return
-      endif
-      call netrw#os#Execute("sil! !".g:netrw_localmkdir.g:netrw_localmkdiropt.' '.netrw#os#Escape(newdirname,1))
-      if v:shell_error != 0
+    if newdirname == ""
         let @@= ykeep
-        call netrw#msg#Notify('ERROR', printf('consider setting g:netrw_localmkdir<%s> to something that works', g:netrw_localmkdir))
         return
-      endif
-      if !g:netrw_keepdir
-        if s:NetrwLcd(netrw_origdir)
-          return
+    endif
+
+    if a:usrhost == ""
+
+        " Local mkdir:
+        " sanity checks
+        let fullnewdir= b:netrw_curdir.'/'.newdirname
+        if isdirectory(s:NetrwFile(fullnewdir))
+            call netrw#msg#Notify('WARNING', printf('<%s> is already a directory!', newdirname))
+            let @@= ykeep
+            return
         endif
-      endif
+        if s:FileReadable(fullnewdir)
+            call netrw#msg#Notify('WARNING', printf('<%s> is already a file!', newdirname))
+            let @@= ykeep
+            return
+        endif
+
+        " requested new local directory is neither a pre-existing file or
+        " directory, so make it!
+        if exists("*mkdir")
+            if has("unix")
+                call mkdir(fullnewdir,"p",xor(0777, system("umask")))
+            else
+                call mkdir(fullnewdir,"p")
+            endif
+        else
+            let netrw_origdir= netrw#fs#Cwd(1)
+            if s:NetrwLcd(b:netrw_curdir)
+                return
+            endif
+            call netrw#os#Execute("sil! !".g:netrw_localmkdir.g:netrw_localmkdiropt.' '.netrw#os#Escape(newdirname,1))
+            if v:shell_error != 0
+                let @@= ykeep
+                call netrw#msg#Notify('ERROR', printf('consider setting g:netrw_localmkdir<%s> to something that works', g:netrw_localmkdir))
+                return
+            endif
+            if !g:netrw_keepdir
+                if s:NetrwLcd(netrw_origdir)
+                    return
+                endif
+            endif
+        endif
+
+        if v:shell_error == 0
+            " refresh listing
+            let svpos= winsaveview()
+            call s:NetrwRefresh(1,s:NetrwBrowseChgDir(1,'./',0))
+            call winrestview(svpos)
+        else
+            call netrw#msg#Notify('ERROR', printf('unable to make directory<%s>', newdirname))
+        endif
+
+    elseif !exists("b:netrw_method") || b:netrw_method == 4
+        " Remote mkdir:  using ssh
+        let mkdircmd  = s:MakeSshCmd(g:netrw_mkdir_cmd)
+        let newdirname= substitute(b:netrw_curdir,'^\%(.\{-}/\)\{3}\(.*\)$','\1','').newdirname
+        call netrw#os#Execute("sil! !".mkdircmd." ".netrw#os#Escape(newdirname,1))
+        if v:shell_error == 0
+            " refresh listing
+            let svpos= winsaveview()
+            NetrwKeepj call s:NetrwRefresh(0,s:NetrwBrowseChgDir(0,'./',0))
+            NetrwKeepj call winrestview(svpos)
+        else
+            call netrw#msg#Notify('ERROR', printf('unable to make directory<%s>', newdirname))
+        endif
+
+    elseif b:netrw_method == 2
+        " Remote mkdir:  using ftp+.netrc
+        let svpos= winsaveview()
+        if exists("b:netrw_fname")
+            let remotepath= b:netrw_fname
+        else
+            let remotepath= ""
+        endif
+        call s:NetrwRemoteFtpCmd(remotepath,g:netrw_remote_mkdir.' "'.newdirname.'"')
+        NetrwKeepj call s:NetrwRefresh(0,s:NetrwBrowseChgDir(0,'./',0))
+        NetrwKeepj call winrestview(svpos)
+
+    elseif b:netrw_method == 3
+        " Remote mkdir: using ftp + machine, id, passwd, and fname (ie. no .netrc)
+        let svpos= winsaveview()
+        if exists("b:netrw_fname")
+            let remotepath= b:netrw_fname
+        else
+            let remotepath= ""
+        endif
+        call s:NetrwRemoteFtpCmd(remotepath,g:netrw_remote_mkdir.' "'.newdirname.'"')
+        NetrwKeepj call s:NetrwRefresh(0,s:NetrwBrowseChgDir(0,'./',0))
+        NetrwKeepj call winrestview(svpos)
     endif
 
-    if v:shell_error == 0
-      " refresh listing
-      let svpos= winsaveview()
-      call s:NetrwRefresh(1,s:NetrwBrowseChgDir(1,'./',0))
-      call winrestview(svpos)
-    elseif !exists("g:netrw_quiet")
-      call netrw#msg#Notify('ERROR', printf('unable to make directory<%s>', newdirname))
-    endif
-
-  elseif !exists("b:netrw_method") || b:netrw_method == 4
-    " Remote mkdir:  using ssh
-    let mkdircmd  = s:MakeSshCmd(g:netrw_mkdir_cmd)
-    let newdirname= substitute(b:netrw_curdir,'^\%(.\{-}/\)\{3}\(.*\)$','\1','').newdirname
-    call netrw#os#Execute("sil! !".mkdircmd." ".netrw#os#Escape(newdirname,1))
-    if v:shell_error == 0
-      " refresh listing
-      let svpos= winsaveview()
-      NetrwKeepj call s:NetrwRefresh(0,s:NetrwBrowseChgDir(0,'./',0))
-      NetrwKeepj call winrestview(svpos)
-    elseif !exists("g:netrw_quiet")
-      call netrw#msg#Notify('ERROR', printf('unable to make directory<%s>', newdirname))
-    endif
-
-  elseif b:netrw_method == 2
-    " Remote mkdir:  using ftp+.netrc
-    let svpos= winsaveview()
-    if exists("b:netrw_fname")
-      let remotepath= b:netrw_fname
-    else
-      let remotepath= ""
-    endif
-    call s:NetrwRemoteFtpCmd(remotepath,g:netrw_remote_mkdir.' "'.newdirname.'"')
-    NetrwKeepj call s:NetrwRefresh(0,s:NetrwBrowseChgDir(0,'./',0))
-    NetrwKeepj call winrestview(svpos)
-
-  elseif b:netrw_method == 3
-    " Remote mkdir: using ftp + machine, id, passwd, and fname (ie. no .netrc)
-    let svpos= winsaveview()
-    if exists("b:netrw_fname")
-      let remotepath= b:netrw_fname
-    else
-      let remotepath= ""
-    endif
-    call s:NetrwRemoteFtpCmd(remotepath,g:netrw_remote_mkdir.' "'.newdirname.'"')
-    NetrwKeepj call s:NetrwRefresh(0,s:NetrwBrowseChgDir(0,'./',0))
-    NetrwKeepj call winrestview(svpos)
-  endif
-
-  let @@= ykeep
+    let @@= ykeep
 endfun
 
 " s:TreeSqueezeDir: allows a shift-cr (gvim only) to squeeze the current tree-listing directory {{{2
 fun! s:TreeSqueezeDir(islocal)
-  if exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST && exists("w:netrw_treedict")
-    " its a tree-listing style
-    let curdepth = substitute(getline('.'),'^\(\%('.s:treedepthstring.'\)*\)[^'.s:treedepthstring.'].\{-}$','\1','e')
-    let stopline = (exists("w:netrw_bannercnt")? (w:netrw_bannercnt + 1) : 1)
-    let depth    = strchars(substitute(curdepth,' ','','g'))
-    let srch     = -1
-    if depth >= 2
-      NetrwKeepj norm! 0
-      let curdepthm1= substitute(curdepth,'^'.s:treedepthstring,'','')
-      let srch      = search('^'.curdepthm1.'\%('.s:treedepthstring.'\)\@!','bW',stopline)
-    elseif depth == 1
-      NetrwKeepj norm! 0
-      let treedepthchr= substitute(s:treedepthstring,' ','','')
-      let srch        = search('^[^'.treedepthchr.']','bW',stopline)
+    if exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST && exists("w:netrw_treedict")
+        " its a tree-listing style
+        let curdepth = substitute(getline('.'),'^\(\%('.s:treedepthstring.'\)*\)[^'.s:treedepthstring.'].\{-}$','\1','e')
+        let stopline = (exists("w:netrw_bannercnt")? (w:netrw_bannercnt + 1) : 1)
+        let depth    = strchars(substitute(curdepth,' ','','g'))
+        let srch     = -1
+        if depth >= 2
+            NetrwKeepj norm! 0
+            let curdepthm1= substitute(curdepth,'^'.s:treedepthstring,'','')
+            let srch      = search('^'.curdepthm1.'\%('.s:treedepthstring.'\)\@!','bW',stopline)
+        elseif depth == 1
+            NetrwKeepj norm! 0
+            let treedepthchr= substitute(s:treedepthstring,' ','','')
+            let srch        = search('^[^'.treedepthchr.']','bW',stopline)
+        endif
+        if srch > 0
+            call s:NetrwBrowse(a:islocal,s:NetrwBrowseChgDir(a:islocal,s:NetrwGetWord(),1))
+            exe srch
+        endif
     endif
-    if srch > 0
-      call s:NetrwBrowse(a:islocal,s:NetrwBrowseChgDir(a:islocal,s:NetrwGetWord(),1))
-      exe srch
-    endif
-  endif
 endfun
 
 " s:NetrwMaps: {{{2
 fun! s:NetrwMaps(islocal)
 
-  " mouse <Plug> maps: {{{3
-  if g:netrw_mousemaps && g:netrw_retmap
-    if !hasmapto("<Plug>NetrwReturn")
-      if maparg("<2-leftmouse>","n") == "" || maparg("<2-leftmouse>","n") =~ '^-$'
-        nmap <unique> <silent> <2-leftmouse>       <Plug>NetrwReturn
-      elseif maparg("<c-leftmouse>","n") == ""
-        nmap <unique> <silent> <c-leftmouse>       <Plug>NetrwReturn
-      endif
+    " mouse <Plug> maps: {{{3
+    if g:netrw_mousemaps && g:netrw_retmap
+        if !hasmapto("<Plug>NetrwReturn")
+            if maparg("<2-leftmouse>","n") == "" || maparg("<2-leftmouse>","n") =~ '^-$'
+                nmap <unique> <silent> <2-leftmouse>       <Plug>NetrwReturn
+            elseif maparg("<c-leftmouse>","n") == ""
+                nmap <unique> <silent> <c-leftmouse>       <Plug>NetrwReturn
+            endif
+        endif
+        nno <silent> <Plug>NetrwReturn       :Rexplore<cr>
     endif
-    nno <silent> <Plug>NetrwReturn       :Rexplore<cr>
-  endif
 
-  " generate default <Plug> maps {{{3
-  if !hasmapto('<Plug>NetrwHide')              |nmap <buffer> <silent> <nowait> a       <Plug>NetrwHide_a|endif
-  if !hasmapto('<Plug>NetrwBrowseUpDir')       |nmap <buffer> <silent> <nowait> -       <Plug>NetrwBrowseUpDir|endif
-  if !hasmapto('<Plug>NetrwOpenFile')          |nmap <buffer> <silent> <nowait> %       <Plug>NetrwOpenFile|endif
-  if !hasmapto('<Plug>NetrwBadd_cb')           |nmap <buffer> <silent> <nowait> cb      <Plug>NetrwBadd_cb|endif
-  if !hasmapto('<Plug>NetrwBadd_cB')           |nmap <buffer> <silent> <nowait> cB      <Plug>NetrwBadd_cB|endif
-  if !hasmapto('<Plug>NetrwLcd')               |nmap <buffer> <silent> <nowait> cd      <Plug>NetrwLcd|endif
-  if !hasmapto('<Plug>NetrwSetChgwin')         |nmap <buffer> <silent> <nowait> C       <Plug>NetrwSetChgwin|endif
-  if !hasmapto('<Plug>NetrwRefresh')           |nmap <buffer> <silent> <nowait> <c-l>   <Plug>NetrwRefresh|endif
-  if !hasmapto('<Plug>NetrwLocalBrowseCheck')  |nmap <buffer> <silent> <nowait> <cr>    <Plug>NetrwLocalBrowseCheck|endif
-  if !hasmapto('<Plug>NetrwServerEdit')        |nmap <buffer> <silent> <nowait> <c-r>   <Plug>NetrwServerEdit|endif
-  if !hasmapto('<Plug>NetrwMakeDir')           |nmap <buffer> <silent> <nowait> d       <Plug>NetrwMakeDir|endif
-  if !hasmapto('<Plug>NetrwBookHistHandler_gb')|nmap <buffer> <silent> <nowait> gb      <Plug>NetrwBookHistHandler_gb|endif
+    " generate default <Plug> maps {{{3
+    if !hasmapto('<Plug>NetrwHide')              |nmap <buffer> <silent> <nowait> a       <Plug>NetrwHide_a|endif
+    if !hasmapto('<Plug>NetrwBrowseUpDir')       |nmap <buffer> <silent> <nowait> -       <Plug>NetrwBrowseUpDir|endif
+    if !hasmapto('<Plug>NetrwOpenFile')          |nmap <buffer> <silent> <nowait> %       <Plug>NetrwOpenFile|endif
+    if !hasmapto('<Plug>NetrwBadd_cb')           |nmap <buffer> <silent> <nowait> cb      <Plug>NetrwBadd_cb|endif
+    if !hasmapto('<Plug>NetrwBadd_cB')           |nmap <buffer> <silent> <nowait> cB      <Plug>NetrwBadd_cB|endif
+    if !hasmapto('<Plug>NetrwLcd')               |nmap <buffer> <silent> <nowait> cd      <Plug>NetrwLcd|endif
+    if !hasmapto('<Plug>NetrwSetChgwin')         |nmap <buffer> <silent> <nowait> C       <Plug>NetrwSetChgwin|endif
+    if !hasmapto('<Plug>NetrwRefresh')           |nmap <buffer> <silent> <nowait> <c-l>   <Plug>NetrwRefresh|endif
+    if !hasmapto('<Plug>NetrwLocalBrowseCheck')  |nmap <buffer> <silent> <nowait> <cr>    <Plug>NetrwLocalBrowseCheck|endif
+    if !hasmapto('<Plug>NetrwServerEdit')        |nmap <buffer> <silent> <nowait> <c-r>   <Plug>NetrwServerEdit|endif
+    if !hasmapto('<Plug>NetrwMakeDir')           |nmap <buffer> <silent> <nowait> d       <Plug>NetrwMakeDir|endif
+    if !hasmapto('<Plug>NetrwBookHistHandler_gb')|nmap <buffer> <silent> <nowait> gb      <Plug>NetrwBookHistHandler_gb|endif
 
-  if a:islocal
-    " local normal-mode maps {{{3
-    nnoremap <buffer> <silent> <Plug>NetrwHide_a                 :<c-u>call <SID>NetrwHide(1)<cr>
-    nnoremap <buffer> <silent> <Plug>NetrwBrowseUpDir            :<c-u>call <SID>NetrwBrowseUpDir(1)<cr>
-    nnoremap <buffer> <silent> <Plug>NetrwOpenFile               :<c-u>call <SID>NetrwOpenFile(1)<cr>
-    nnoremap <buffer> <silent> <Plug>NetrwBadd_cb                :<c-u>call <SID>NetrwBadd(1,0)<cr>
-    nnoremap <buffer> <silent> <Plug>NetrwBadd_cB                :<c-u>call <SID>NetrwBadd(1,1)<cr>
-    nnoremap <buffer> <silent> <Plug>NetrwLcd                    :<c-u>call <SID>NetrwLcd(b:netrw_curdir)<cr>
-    nnoremap <buffer> <silent> <Plug>NetrwSetChgwin              :<c-u>call <SID>NetrwSetChgwin()<cr>
-    nnoremap <buffer> <silent> <Plug>NetrwLocalBrowseCheck       :<c-u>call netrw#LocalBrowseCheck(<SID>NetrwBrowseChgDir(1,<SID>NetrwGetWord(),1))<cr>
-    nnoremap <buffer> <silent> <Plug>NetrwServerEdit             :<c-u>call <SID>NetrwServerEdit(3,<SID>NetrwGetWord())<cr>
-    nnoremap <buffer> <silent> <Plug>NetrwMakeDir                :<c-u>call <SID>NetrwMakeDir("")<cr>
-    nnoremap <buffer> <silent> <Plug>NetrwBookHistHandler_gb     :<c-u>call <SID>NetrwBookHistHandler(1,b:netrw_curdir)<cr>
-    " ---------------------------------------------------------------------
-    nnoremap <buffer> <silent> <nowait> gd       :<c-u>call <SID>NetrwForceChgDir(1,<SID>NetrwGetWord())<cr>
-    nnoremap <buffer> <silent> <nowait> gf       :<c-u>call <SID>NetrwForceFile(1,<SID>NetrwGetWord())<cr>
-    nnoremap <buffer> <silent> <nowait> gh       :<c-u>call <SID>NetrwHidden(1)<cr>
-    nnoremap <buffer> <silent> <nowait> gn       :<c-u>call netrw#SetTreetop(0,<SID>NetrwGetWord())<cr>
-    nnoremap <buffer> <silent> <nowait> gp       :<c-u>call <SID>NetrwChgPerm(1,b:netrw_curdir)<cr>
-    nnoremap <buffer> <silent> <nowait> I        :<c-u>call <SID>NetrwBannerCtrl(1)<cr>
-    nnoremap <buffer> <silent> <nowait> i        :<c-u>call <SID>NetrwListStyle(1)<cr>
-    nnoremap <buffer> <silent> <nowait> ma       :<c-u>call <SID>NetrwMarkFileArgList(1,0)<cr>
-    nnoremap <buffer> <silent> <nowait> mA       :<c-u>call <SID>NetrwMarkFileArgList(1,1)<cr>
-    nnoremap <buffer> <silent> <nowait> mb       :<c-u>call <SID>NetrwBookHistHandler(0,b:netrw_curdir)<cr>
-    nnoremap <buffer> <silent> <nowait> mB       :<c-u>call <SID>NetrwBookHistHandler(6,b:netrw_curdir)<cr>
-    nnoremap <buffer> <silent> <nowait> mc       :<c-u>call <SID>NetrwMarkFileCopy(1)<cr>
-    nnoremap <buffer> <silent> <nowait> md       :<c-u>call <SID>NetrwMarkFileDiff(1)<cr>
-    nnoremap <buffer> <silent> <nowait> me       :<c-u>call <SID>NetrwMarkFileEdit(1)<cr>
-    nnoremap <buffer> <silent> <nowait> mf       :<c-u>call <SID>NetrwMarkFile(1,<SID>NetrwGetWord())<cr>
-    nnoremap <buffer> <silent> <nowait> mF       :<c-u>call <SID>NetrwUnmarkList(bufnr("%"),b:netrw_curdir)<cr>
-    nnoremap <buffer> <silent> <nowait> mg       :<c-u>call <SID>NetrwMarkFileGrep(1)<cr>
-    nnoremap <buffer> <silent> <nowait> mh       :<c-u>call <SID>NetrwMarkHideSfx(1)<cr>
-    nnoremap <buffer> <silent> <nowait> mm       :<c-u>call <SID>NetrwMarkFileMove(1)<cr>
-    nnoremap <buffer> <silent> <nowait> mp       :<c-u>call <SID>NetrwMarkFilePrint(1)<cr>
-    nnoremap <buffer> <silent> <nowait> mr       :<c-u>call <SID>NetrwMarkFileRegexp(1)<cr>
-    nnoremap <buffer> <silent> <nowait> ms       :<c-u>call <SID>NetrwMarkFileSource(1)<cr>
-    nnoremap <buffer> <silent> <nowait> mT       :<c-u>call <SID>NetrwMarkFileTag(1)<cr>
-    nnoremap <buffer> <silent> <nowait> mt       :<c-u>call <SID>NetrwMarkFileTgt(1)<cr>
-    nnoremap <buffer> <silent> <nowait> mu       :<c-u>call <SID>NetrwUnMarkFile(1)<cr>
-    nnoremap <buffer> <silent> <nowait> mv       :<c-u>call <SID>NetrwMarkFileVimCmd(1)<cr>
-    nnoremap <buffer> <silent> <nowait> mx       :<c-u>call <SID>NetrwMarkFileExe(1,0)<cr>
-    nnoremap <buffer> <silent> <nowait> mX       :<c-u>call <SID>NetrwMarkFileExe(1,1)<cr>
-    nnoremap <buffer> <silent> <nowait> mz       :<c-u>call <SID>NetrwMarkFileCompress(1)<cr>
-    nnoremap <buffer> <silent> <nowait> O        :<c-u>call <SID>NetrwObtain(1)<cr>
-    nnoremap <buffer> <silent> <nowait> o        :call <SID>NetrwSplit(3)<cr>
-    nnoremap <buffer> <silent> <nowait> p        :<c-u>call <SID>NetrwPreview(<SID>NetrwBrowseChgDir(1,<SID>NetrwGetWord(),1,1))<cr>
-    nnoremap <buffer> <silent> <nowait> P        :<c-u>call <SID>NetrwPrevWinOpen(1)<cr>
-    nnoremap <buffer> <silent> <nowait> qb       :<c-u>call <SID>NetrwBookHistHandler(2,b:netrw_curdir)<cr>
-    nnoremap <buffer> <silent> <nowait> qf       :<c-u>call <SID>NetrwFileInfo(1,<SID>NetrwGetWord())<cr>
-    nnoremap <buffer> <silent> <nowait> qF       :<c-u>call <SID>NetrwMarkFileQFEL(1,getqflist())<cr>
-    nnoremap <buffer> <silent> <nowait> qL       :<c-u>call <SID>NetrwMarkFileQFEL(1,getloclist(v:count))<cr>
-    nnoremap <buffer> <silent> <nowait> s        :call <SID>NetrwSortStyle(1)<cr>
-    nnoremap <buffer> <silent> <nowait> S        :<c-u>call <SID>NetSortSequence(1)<cr>
-    nnoremap <buffer> <silent> <nowait> Tb       :<c-u>call <SID>NetrwSetTgt(1,'b',v:count1)<cr>
-    nnoremap <buffer> <silent> <nowait> t        :call <SID>NetrwSplit(4)<cr>
-    nnoremap <buffer> <silent> <nowait> Th       :<c-u>call <SID>NetrwSetTgt(1,'h',v:count)<cr>
-    nnoremap <buffer> <silent> <nowait> u        :<c-u>call <SID>NetrwBookHistHandler(4,expand("%"))<cr>
-    nnoremap <buffer> <silent> <nowait> U        :<c-u>call <SID>NetrwBookHistHandler(5,expand("%"))<cr>
-    nnoremap <buffer> <silent> <nowait> v        :call <SID>NetrwSplit(5)<cr>
-    nnoremap <buffer> <silent> <nowait> x        :<c-u>call netrw#BrowseX(<SID>NetrwBrowseChgDir(1,<SID>NetrwGetWord(),1,0),0)"<cr>
-    nnoremap <buffer> <silent> <nowait> X        :<c-u>call <SID>NetrwLocalExecute(expand("<cword>"))"<cr>
+    if a:islocal
+        " local normal-mode maps {{{3
+        nnoremap <buffer> <silent> <Plug>NetrwHide_a                 :<c-u>call <SID>NetrwHide(1)<cr>
+        nnoremap <buffer> <silent> <Plug>NetrwBrowseUpDir            :<c-u>call <SID>NetrwBrowseUpDir(1)<cr>
+        nnoremap <buffer> <silent> <Plug>NetrwOpenFile               :<c-u>call <SID>NetrwOpenFile(1)<cr>
+        nnoremap <buffer> <silent> <Plug>NetrwBadd_cb                :<c-u>call <SID>NetrwBadd(1,0)<cr>
+        nnoremap <buffer> <silent> <Plug>NetrwBadd_cB                :<c-u>call <SID>NetrwBadd(1,1)<cr>
+        nnoremap <buffer> <silent> <Plug>NetrwLcd                    :<c-u>call <SID>NetrwLcd(b:netrw_curdir)<cr>
+        nnoremap <buffer> <silent> <Plug>NetrwSetChgwin              :<c-u>call <SID>NetrwSetChgwin()<cr>
+        nnoremap <buffer> <silent> <Plug>NetrwLocalBrowseCheck       :<c-u>call netrw#LocalBrowseCheck(<SID>NetrwBrowseChgDir(1,<SID>NetrwGetWord(),1))<cr>
+        nnoremap <buffer> <silent> <Plug>NetrwServerEdit             :<c-u>call <SID>NetrwServerEdit(3,<SID>NetrwGetWord())<cr>
+        nnoremap <buffer> <silent> <Plug>NetrwMakeDir                :<c-u>call <SID>NetrwMakeDir("")<cr>
+        nnoremap <buffer> <silent> <Plug>NetrwBookHistHandler_gb     :<c-u>call <SID>NetrwBookHistHandler(1,b:netrw_curdir)<cr>
+        " ---------------------------------------------------------------------
+        nnoremap <buffer> <silent> <nowait> gd       :<c-u>call <SID>NetrwForceChgDir(1,<SID>NetrwGetWord())<cr>
+        nnoremap <buffer> <silent> <nowait> gf       :<c-u>call <SID>NetrwForceFile(1,<SID>NetrwGetWord())<cr>
+        nnoremap <buffer> <silent> <nowait> gh       :<c-u>call <SID>NetrwHidden(1)<cr>
+        nnoremap <buffer> <silent> <nowait> gn       :<c-u>call netrw#SetTreetop(0,<SID>NetrwGetWord())<cr>
+        nnoremap <buffer> <silent> <nowait> gp       :<c-u>call <SID>NetrwChgPerm(1,b:netrw_curdir)<cr>
+        nnoremap <buffer> <silent> <nowait> I        :<c-u>call <SID>NetrwBannerCtrl(1)<cr>
+        nnoremap <buffer> <silent> <nowait> i        :<c-u>call <SID>NetrwListStyle(1)<cr>
+        nnoremap <buffer> <silent> <nowait> ma       :<c-u>call <SID>NetrwMarkFileArgList(1,0)<cr>
+        nnoremap <buffer> <silent> <nowait> mA       :<c-u>call <SID>NetrwMarkFileArgList(1,1)<cr>
+        nnoremap <buffer> <silent> <nowait> mb       :<c-u>call <SID>NetrwBookHistHandler(0,b:netrw_curdir)<cr>
+        nnoremap <buffer> <silent> <nowait> mB       :<c-u>call <SID>NetrwBookHistHandler(6,b:netrw_curdir)<cr>
+        nnoremap <buffer> <silent> <nowait> mc       :<c-u>call <SID>NetrwMarkFileCopy(1)<cr>
+        nnoremap <buffer> <silent> <nowait> md       :<c-u>call <SID>NetrwMarkFileDiff(1)<cr>
+        nnoremap <buffer> <silent> <nowait> me       :<c-u>call <SID>NetrwMarkFileEdit(1)<cr>
+        nnoremap <buffer> <silent> <nowait> mf       :<c-u>call <SID>NetrwMarkFile(1,<SID>NetrwGetWord())<cr>
+        nnoremap <buffer> <silent> <nowait> mF       :<c-u>call <SID>NetrwUnmarkList(bufnr("%"),b:netrw_curdir)<cr>
+        nnoremap <buffer> <silent> <nowait> mg       :<c-u>call <SID>NetrwMarkFileGrep(1)<cr>
+        nnoremap <buffer> <silent> <nowait> mh       :<c-u>call <SID>NetrwMarkHideSfx(1)<cr>
+        nnoremap <buffer> <silent> <nowait> mm       :<c-u>call <SID>NetrwMarkFileMove(1)<cr>
+        nnoremap <buffer> <silent> <nowait> mp       :<c-u>call <SID>NetrwMarkFilePrint(1)<cr>
+        nnoremap <buffer> <silent> <nowait> mr       :<c-u>call <SID>NetrwMarkFileRegexp(1)<cr>
+        nnoremap <buffer> <silent> <nowait> ms       :<c-u>call <SID>NetrwMarkFileSource(1)<cr>
+        nnoremap <buffer> <silent> <nowait> mT       :<c-u>call <SID>NetrwMarkFileTag(1)<cr>
+        nnoremap <buffer> <silent> <nowait> mt       :<c-u>call <SID>NetrwMarkFileTgt(1)<cr>
+        nnoremap <buffer> <silent> <nowait> mu       :<c-u>call <SID>NetrwUnMarkFile(1)<cr>
+        nnoremap <buffer> <silent> <nowait> mv       :<c-u>call <SID>NetrwMarkFileVimCmd(1)<cr>
+        nnoremap <buffer> <silent> <nowait> mx       :<c-u>call <SID>NetrwMarkFileExe(1,0)<cr>
+        nnoremap <buffer> <silent> <nowait> mX       :<c-u>call <SID>NetrwMarkFileExe(1,1)<cr>
+        nnoremap <buffer> <silent> <nowait> mz       :<c-u>call <SID>NetrwMarkFileCompress(1)<cr>
+        nnoremap <buffer> <silent> <nowait> O        :<c-u>call <SID>NetrwObtain(1)<cr>
+        nnoremap <buffer> <silent> <nowait> o        :call <SID>NetrwSplit(3)<cr>
+        nnoremap <buffer> <silent> <nowait> p        :<c-u>call <SID>NetrwPreview(<SID>NetrwBrowseChgDir(1,<SID>NetrwGetWord(),1,1))<cr>
+        nnoremap <buffer> <silent> <nowait> P        :<c-u>call <SID>NetrwPrevWinOpen(1)<cr>
+        nnoremap <buffer> <silent> <nowait> qb       :<c-u>call <SID>NetrwBookHistHandler(2,b:netrw_curdir)<cr>
+        nnoremap <buffer> <silent> <nowait> qf       :<c-u>call <SID>NetrwFileInfo(1,<SID>NetrwGetWord())<cr>
+        nnoremap <buffer> <silent> <nowait> qF       :<c-u>call <SID>NetrwMarkFileQFEL(1,getqflist())<cr>
+        nnoremap <buffer> <silent> <nowait> qL       :<c-u>call <SID>NetrwMarkFileQFEL(1,getloclist(v:count))<cr>
+        nnoremap <buffer> <silent> <nowait> s        :call <SID>NetrwSortStyle(1)<cr>
+        nnoremap <buffer> <silent> <nowait> S        :<c-u>call <SID>NetSortSequence(1)<cr>
+        nnoremap <buffer> <silent> <nowait> Tb       :<c-u>call <SID>NetrwSetTgt(1,'b',v:count1)<cr>
+        nnoremap <buffer> <silent> <nowait> t        :call <SID>NetrwSplit(4)<cr>
+        nnoremap <buffer> <silent> <nowait> Th       :<c-u>call <SID>NetrwSetTgt(1,'h',v:count)<cr>
+        nnoremap <buffer> <silent> <nowait> u        :<c-u>call <SID>NetrwBookHistHandler(4,expand("%"))<cr>
+        nnoremap <buffer> <silent> <nowait> U        :<c-u>call <SID>NetrwBookHistHandler(5,expand("%"))<cr>
+        nnoremap <buffer> <silent> <nowait> v        :call <SID>NetrwSplit(5)<cr>
+        nnoremap <buffer> <silent> <nowait> x        :<c-u>call netrw#BrowseX(<SID>NetrwBrowseChgDir(1,<SID>NetrwGetWord(),1,0),0)"<cr>
+        nnoremap <buffer> <silent> <nowait> X        :<c-u>call <SID>NetrwLocalExecute(expand("<cword>"))"<cr>
 
-    nnoremap <buffer> <silent> <nowait> r        :<c-u>let g:netrw_sort_direction= (g:netrw_sort_direction =~# 'n')? 'r' : 'n'<bar>exe "norm! 0"<bar>call <SID>NetrwRefresh(1,<SID>NetrwBrowseChgDir(1,'./',0))<cr>
-    if !hasmapto('<Plug>NetrwHideEdit')
-      nmap <buffer> <unique> <c-h> <Plug>NetrwHideEdit
-    endif
-    nnoremap <buffer> <silent> <Plug>NetrwHideEdit               :call <SID>NetrwHideEdit(1)<cr>
-    if !hasmapto('<Plug>NetrwRefresh')
-      nmap <buffer> <unique> <c-l> <Plug>NetrwRefresh
-    endif
-    nnoremap <buffer> <silent> <Plug>NetrwRefresh                <c-l>:call <SID>NetrwRefresh(1,<SID>NetrwBrowseChgDir(1,(exists("w:netrw_liststyle") && exists("w:netrw_treetop") && w:netrw_liststyle == 3)? w:netrw_treetop : './',0))<cr>
-    if s:didstarstar || !mapcheck("<s-down>","n")
-      nnoremap <buffer> <silent> <s-down> :Nexplore<cr>
-    endif
-    if s:didstarstar || !mapcheck("<s-up>","n")
-      nnoremap <buffer> <silent> <s-up>   :Pexplore<cr>
-    endif
-    if !hasmapto('<Plug>NetrwTreeSqueeze')
-      nmap <buffer> <silent> <nowait> <s-cr>                      <Plug>NetrwTreeSqueeze
-    endif
-    nnoremap <buffer> <silent> <Plug>NetrwTreeSqueeze            :call <SID>TreeSqueezeDir(1)<cr>
-    let mapsafecurdir = escape(b:netrw_curdir, s:netrw_map_escape)
-    if g:netrw_mousemaps == 1
-      nmap <buffer>                       <leftmouse>             <Plug>NetrwLeftmouse
-      nmap <buffer>                       <c-leftmouse>           <Plug>NetrwCLeftmouse
-      nmap <buffer>                       <middlemouse>           <Plug>NetrwMiddlemouse
-      nmap <buffer>                       <s-leftmouse>           <Plug>NetrwSLeftmouse
-      nmap <buffer>                       <s-leftdrag>            <Plug>NetrwSLeftdrag
-      nmap <buffer>                       <2-leftmouse>           <Plug>Netrw2Leftmouse
-      imap <buffer>                       <leftmouse>             <Plug>ILeftmouse
-      imap <buffer>                       <middlemouse>           <Plug>IMiddlemouse
-      nno  <buffer> <silent>              <Plug>NetrwLeftmouse    :exec "norm! \<lt>leftmouse>"<bar>call <SID>NetrwLeftmouse(1)<cr>
-      nno  <buffer> <silent>              <Plug>NetrwCLeftmouse   :exec "norm! \<lt>leftmouse>"<bar>call <SID>NetrwCLeftmouse(1)<cr>
-      nno  <buffer> <silent>              <Plug>NetrwMiddlemouse  :exec "norm! \<lt>leftmouse>"<bar>call <SID>NetrwPrevWinOpen(1)<cr>
-      nno  <buffer> <silent>              <Plug>NetrwSLeftmouse   :exec "norm! \<lt>leftmouse>"<bar>call <SID>NetrwSLeftmouse(1)<cr>
-      nno  <buffer> <silent>              <Plug>NetrwSLeftdrag    :exec "norm! \<lt>leftmouse>"<bar>call <SID>NetrwSLeftdrag(1)<cr>
-      nmap <buffer> <silent>              <Plug>Netrw2Leftmouse   -
-        exe 'nnoremap <buffer> <silent> <rightmouse>  :exec "norm! \<lt>leftmouse>"<bar>call <SID>NetrwLocalRm("'.mapsafecurdir.'")<cr>'
-      exe 'vnoremap <buffer> <silent> <rightmouse>  :exec "norm! \<lt>leftmouse>"<bar>call <SID>NetrwLocalRm("'.mapsafecurdir.'")<cr>'
-    endif
-    exe 'nnoremap <buffer> <silent> <nowait> <del>       :call <SID>NetrwLocalRm("'.mapsafecurdir.'")<cr>'
-    exe 'nnoremap <buffer> <silent> <nowait> D           :call <SID>NetrwLocalRm("'.mapsafecurdir.'")<cr>'
-    exe 'nnoremap <buffer> <silent> <nowait> R           :call <SID>NetrwLocalRename("'.mapsafecurdir.'")<cr>'
-    exe 'nnoremap <buffer> <silent> <nowait> d           :call <SID>NetrwMakeDir("")<cr>'
-    exe 'vnoremap <buffer> <silent> <nowait> <del>       :call <SID>NetrwLocalRm("'.mapsafecurdir.'")<cr>'
-    exe 'vnoremap <buffer> <silent> <nowait> D           :call <SID>NetrwLocalRm("'.mapsafecurdir.'")<cr>'
-    exe 'vnoremap <buffer> <silent> <nowait> R           :call <SID>NetrwLocalRename("'.mapsafecurdir.'")<cr>'
-    nnoremap <buffer> <F1>                       :he netrw-quickhelp<cr>
+        nnoremap <buffer> <silent> <nowait> r        :<c-u>let g:netrw_sort_direction= (g:netrw_sort_direction =~# 'n')? 'r' : 'n'<bar>exe "norm! 0"<bar>call <SID>NetrwRefresh(1,<SID>NetrwBrowseChgDir(1,'./',0))<cr>
+        if !hasmapto('<Plug>NetrwHideEdit')
+            nmap <buffer> <unique> <c-h> <Plug>NetrwHideEdit
+        endif
+        nnoremap <buffer> <silent> <Plug>NetrwHideEdit               :call <SID>NetrwHideEdit(1)<cr>
+        if !hasmapto('<Plug>NetrwRefresh')
+            nmap <buffer> <unique> <c-l> <Plug>NetrwRefresh
+        endif
+        nnoremap <buffer> <silent> <Plug>NetrwRefresh                <c-l>:call <SID>NetrwRefresh(1,<SID>NetrwBrowseChgDir(1,(exists("w:netrw_liststyle") && exists("w:netrw_treetop") && w:netrw_liststyle == 3)? w:netrw_treetop : './',0))<cr>
+        if s:didstarstar || !mapcheck("<s-down>","n")
+            nnoremap <buffer> <silent> <s-down> :Nexplore<cr>
+        endif
+        if s:didstarstar || !mapcheck("<s-up>","n")
+            nnoremap <buffer> <silent> <s-up>   :Pexplore<cr>
+        endif
+        if !hasmapto('<Plug>NetrwTreeSqueeze')
+            nmap <buffer> <silent> <nowait> <s-cr>                      <Plug>NetrwTreeSqueeze
+        endif
+        nnoremap <buffer> <silent> <Plug>NetrwTreeSqueeze            :call <SID>TreeSqueezeDir(1)<cr>
+        let mapsafecurdir = escape(b:netrw_curdir, s:netrw_map_escape)
+        if g:netrw_mousemaps == 1
+            nmap <buffer>                       <leftmouse>             <Plug>NetrwLeftmouse
+            nmap <buffer>                       <c-leftmouse>           <Plug>NetrwCLeftmouse
+            nmap <buffer>                       <middlemouse>           <Plug>NetrwMiddlemouse
+            nmap <buffer>                       <s-leftmouse>           <Plug>NetrwSLeftmouse
+            nmap <buffer>                       <s-leftdrag>            <Plug>NetrwSLeftdrag
+            nmap <buffer>                       <2-leftmouse>           <Plug>Netrw2Leftmouse
+            imap <buffer>                       <leftmouse>             <Plug>ILeftmouse
+            imap <buffer>                       <middlemouse>           <Plug>IMiddlemouse
+            nno  <buffer> <silent>              <Plug>NetrwLeftmouse    :exec "norm! \<lt>leftmouse>"<bar>call <SID>NetrwLeftmouse(1)<cr>
+            nno  <buffer> <silent>              <Plug>NetrwCLeftmouse   :exec "norm! \<lt>leftmouse>"<bar>call <SID>NetrwCLeftmouse(1)<cr>
+            nno  <buffer> <silent>              <Plug>NetrwMiddlemouse  :exec "norm! \<lt>leftmouse>"<bar>call <SID>NetrwPrevWinOpen(1)<cr>
+            nno  <buffer> <silent>              <Plug>NetrwSLeftmouse   :exec "norm! \<lt>leftmouse>"<bar>call <SID>NetrwSLeftmouse(1)<cr>
+            nno  <buffer> <silent>              <Plug>NetrwSLeftdrag    :exec "norm! \<lt>leftmouse>"<bar>call <SID>NetrwSLeftdrag(1)<cr>
+            nmap <buffer> <silent>              <Plug>Netrw2Leftmouse   -
+                exe 'nnoremap <buffer> <silent> <rightmouse>  :exec "norm! \<lt>leftmouse>"<bar>call <SID>NetrwLocalRm("'.mapsafecurdir.'")<cr>'
+            exe 'vnoremap <buffer> <silent> <rightmouse>  :exec "norm! \<lt>leftmouse>"<bar>call <SID>NetrwLocalRm("'.mapsafecurdir.'")<cr>'
+        endif
+        exe 'nnoremap <buffer> <silent> <nowait> <del>       :call <SID>NetrwLocalRm("'.mapsafecurdir.'")<cr>'
+        exe 'nnoremap <buffer> <silent> <nowait> D           :call <SID>NetrwLocalRm("'.mapsafecurdir.'")<cr>'
+        exe 'nnoremap <buffer> <silent> <nowait> R           :call <SID>NetrwLocalRename("'.mapsafecurdir.'")<cr>'
+        exe 'nnoremap <buffer> <silent> <nowait> d           :call <SID>NetrwMakeDir("")<cr>'
+        exe 'vnoremap <buffer> <silent> <nowait> <del>       :call <SID>NetrwLocalRm("'.mapsafecurdir.'")<cr>'
+        exe 'vnoremap <buffer> <silent> <nowait> D           :call <SID>NetrwLocalRm("'.mapsafecurdir.'")<cr>'
+        exe 'vnoremap <buffer> <silent> <nowait> R           :call <SID>NetrwLocalRename("'.mapsafecurdir.'")<cr>'
+        nnoremap <buffer> <F1>                       :he netrw-quickhelp<cr>
 
-    " support user-specified maps
-    call netrw#UserMaps(1)
+        " support user-specified maps
+        call netrw#UserMaps(1)
 
-  else
-    " remote normal-mode maps {{{3
-    call s:RemotePathAnalysis(b:netrw_curdir)
-    nnoremap <buffer> <silent> <Plug>NetrwHide_a                 :<c-u>call <SID>NetrwHide(0)<cr>
-    nnoremap <buffer> <silent> <Plug>NetrwBrowseUpDir            :<c-u>call <SID>NetrwBrowseUpDir(0)<cr>
-    nnoremap <buffer> <silent> <Plug>NetrwOpenFile               :<c-u>call <SID>NetrwOpenFile(0)<cr>
-    nnoremap <buffer> <silent> <Plug>NetrwBadd_cb                :<c-u>call <SID>NetrwBadd(0,0)<cr>
-    nnoremap <buffer> <silent> <Plug>NetrwBadd_cB                :<c-u>call <SID>NetrwBadd(0,1)<cr>
-    nnoremap <buffer> <silent> <Plug>NetrwLcd                    :<c-u>call <SID>NetrwLcd(b:netrw_curdir)<cr>
-    nnoremap <buffer> <silent> <Plug>NetrwSetChgwin              :<c-u>call <SID>NetrwSetChgwin()<cr>
-    nnoremap <buffer> <silent> <Plug>NetrwRefresh                :<c-u>call <SID>NetrwRefresh(0,<SID>NetrwBrowseChgDir(0,'./',0))<cr>
-    nnoremap <buffer> <silent> <Plug>NetrwLocalBrowseCheck       :<c-u>call <SID>NetrwBrowse(0,<SID>NetrwBrowseChgDir(0,<SID>NetrwGetWord(),1))<cr>
-    nnoremap <buffer> <silent> <Plug>NetrwServerEdit             :<c-u>call <SID>NetrwServerEdit(2,<SID>NetrwGetWord())<cr>
-    nnoremap <buffer> <silent> <Plug>NetrwBookHistHandler_gb     :<c-u>call <SID>NetrwBookHistHandler(1,b:netrw_curdir)<cr>
-    " ---------------------------------------------------------------------
-    nnoremap <buffer> <silent> <nowait> gd       :<c-u>call <SID>NetrwForceChgDir(0,<SID>NetrwGetWord())<cr>
-    nnoremap <buffer> <silent> <nowait> gf       :<c-u>call <SID>NetrwForceFile(0,<SID>NetrwGetWord())<cr>
-    nnoremap <buffer> <silent> <nowait> gh       :<c-u>call <SID>NetrwHidden(0)<cr>
-    nnoremap <buffer> <silent> <nowait> gp       :<c-u>call <SID>NetrwChgPerm(0,b:netrw_curdir)<cr>
-    nnoremap <buffer> <silent> <nowait> I        :<c-u>call <SID>NetrwBannerCtrl(1)<cr>
-    nnoremap <buffer> <silent> <nowait> i        :<c-u>call <SID>NetrwListStyle(0)<cr>
-    nnoremap <buffer> <silent> <nowait> ma       :<c-u>call <SID>NetrwMarkFileArgList(0,0)<cr>
-    nnoremap <buffer> <silent> <nowait> mA       :<c-u>call <SID>NetrwMarkFileArgList(0,1)<cr>
-    nnoremap <buffer> <silent> <nowait> mb       :<c-u>call <SID>NetrwBookHistHandler(0,b:netrw_curdir)<cr>
-    nnoremap <buffer> <silent> <nowait> mB       :<c-u>call <SID>NetrwBookHistHandler(6,b:netrw_curdir)<cr>
-    nnoremap <buffer> <silent> <nowait> mc       :<c-u>call <SID>NetrwMarkFileCopy(0)<cr>
-    nnoremap <buffer> <silent> <nowait> md       :<c-u>call <SID>NetrwMarkFileDiff(0)<cr>
-    nnoremap <buffer> <silent> <nowait> me       :<c-u>call <SID>NetrwMarkFileEdit(0)<cr>
-    nnoremap <buffer> <silent> <nowait> mf       :<c-u>call <SID>NetrwMarkFile(0,<SID>NetrwGetWord())<cr>
-    nnoremap <buffer> <silent> <nowait> mF       :<c-u>call <SID>NetrwUnmarkList(bufnr("%"),b:netrw_curdir)<cr>
-    nnoremap <buffer> <silent> <nowait> mg       :<c-u>call <SID>NetrwMarkFileGrep(0)<cr>
-    nnoremap <buffer> <silent> <nowait> mh       :<c-u>call <SID>NetrwMarkHideSfx(0)<cr>
-    nnoremap <buffer> <silent> <nowait> mm       :<c-u>call <SID>NetrwMarkFileMove(0)<cr>
-    nnoremap <buffer> <silent> <nowait> mp       :<c-u>call <SID>NetrwMarkFilePrint(0)<cr>
-    nnoremap <buffer> <silent> <nowait> mr       :<c-u>call <SID>NetrwMarkFileRegexp(0)<cr>
-    nnoremap <buffer> <silent> <nowait> ms       :<c-u>call <SID>NetrwMarkFileSource(0)<cr>
-    nnoremap <buffer> <silent> <nowait> mT       :<c-u>call <SID>NetrwMarkFileTag(0)<cr>
-    nnoremap <buffer> <silent> <nowait> mt       :<c-u>call <SID>NetrwMarkFileTgt(0)<cr>
-    nnoremap <buffer> <silent> <nowait> mu       :<c-u>call <SID>NetrwUnMarkFile(0)<cr>
-    nnoremap <buffer> <silent> <nowait> mv       :<c-u>call <SID>NetrwMarkFileVimCmd(0)<cr>
-    nnoremap <buffer> <silent> <nowait> mx       :<c-u>call <SID>NetrwMarkFileExe(0,0)<cr>
-    nnoremap <buffer> <silent> <nowait> mX       :<c-u>call <SID>NetrwMarkFileExe(0,1)<cr>
-    nnoremap <buffer> <silent> <nowait> mz       :<c-u>call <SID>NetrwMarkFileCompress(0)<cr>
-    nnoremap <buffer> <silent> <nowait> O        :<c-u>call <SID>NetrwObtain(0)<cr>
-    nnoremap <buffer> <silent> <nowait> o        :call <SID>NetrwSplit(0)<cr>
-    nnoremap <buffer> <silent> <nowait> p        :<c-u>call <SID>NetrwPreview(<SID>NetrwBrowseChgDir(1,<SID>NetrwGetWord(),1,1))<cr>
-    nnoremap <buffer> <silent> <nowait> P        :<c-u>call <SID>NetrwPrevWinOpen(0)<cr>
-    nnoremap <buffer> <silent> <nowait> qb       :<c-u>call <SID>NetrwBookHistHandler(2,b:netrw_curdir)<cr>
-    nnoremap <buffer> <silent> <nowait> qf       :<c-u>call <SID>NetrwFileInfo(0,<SID>NetrwGetWord())<cr>
-    nnoremap <buffer> <silent> <nowait> qF       :<c-u>call <SID>NetrwMarkFileQFEL(0,getqflist())<cr>
-    nnoremap <buffer> <silent> <nowait> qL       :<c-u>call <SID>NetrwMarkFileQFEL(0,getloclist(v:count))<cr>
-    nnoremap <buffer> <silent> <nowait> r        :<c-u>let g:netrw_sort_direction= (g:netrw_sort_direction =~# 'n')? 'r' : 'n'<bar>exe "norm! 0"<bar>call <SID>NetrwBrowse(0,<SID>NetrwBrowseChgDir(0,'./',0))<cr>
-    nnoremap <buffer> <silent> <nowait> s        :call <SID>NetrwSortStyle(0)<cr>
-    nnoremap <buffer> <silent> <nowait> S        :<c-u>call <SID>NetSortSequence(0)<cr>
-    nnoremap <buffer> <silent> <nowait> Tb       :<c-u>call <SID>NetrwSetTgt(0,'b',v:count1)<cr>
-    nnoremap <buffer> <silent> <nowait> t        :call <SID>NetrwSplit(1)<cr>
-    nnoremap <buffer> <silent> <nowait> Th       :<c-u>call <SID>NetrwSetTgt(0,'h',v:count)<cr>
-    nnoremap <buffer> <silent> <nowait> u        :<c-u>call <SID>NetrwBookHistHandler(4,b:netrw_curdir)<cr>
-    nnoremap <buffer> <silent> <nowait> U        :<c-u>call <SID>NetrwBookHistHandler(5,b:netrw_curdir)<cr>
-    nnoremap <buffer> <silent> <nowait> v        :call <SID>NetrwSplit(2)<cr>
-    nnoremap <buffer> <silent> <nowait> x        :<c-u>call netrw#BrowseX(<SID>NetrwBrowseChgDir(0,<SID>NetrwGetWord(),1),1)<cr>
-    nmap     <buffer>          <nowait> gx       x
-    if !hasmapto('<Plug>NetrwHideEdit')
-      nmap <buffer> <c-h> <Plug>NetrwHideEdit
-    endif
-    nnoremap <buffer> <silent> <Plug>NetrwHideEdit       :call <SID>NetrwHideEdit(0)<cr>
-    if !hasmapto('<Plug>NetrwRefresh')
-      nmap <buffer> <c-l> <Plug>NetrwRefresh
-    endif
-    if !hasmapto('<Plug>NetrwTreeSqueeze')
-      nmap <buffer> <silent> <nowait> <s-cr>      <Plug>NetrwTreeSqueeze
-    endif
-    nnoremap <buffer> <silent> <Plug>NetrwTreeSqueeze    :call <SID>TreeSqueezeDir(0)<cr>
+    else
+        " remote normal-mode maps {{{3
+        call s:RemotePathAnalysis(b:netrw_curdir)
+        nnoremap <buffer> <silent> <Plug>NetrwHide_a                 :<c-u>call <SID>NetrwHide(0)<cr>
+        nnoremap <buffer> <silent> <Plug>NetrwBrowseUpDir            :<c-u>call <SID>NetrwBrowseUpDir(0)<cr>
+        nnoremap <buffer> <silent> <Plug>NetrwOpenFile               :<c-u>call <SID>NetrwOpenFile(0)<cr>
+        nnoremap <buffer> <silent> <Plug>NetrwBadd_cb                :<c-u>call <SID>NetrwBadd(0,0)<cr>
+        nnoremap <buffer> <silent> <Plug>NetrwBadd_cB                :<c-u>call <SID>NetrwBadd(0,1)<cr>
+        nnoremap <buffer> <silent> <Plug>NetrwLcd                    :<c-u>call <SID>NetrwLcd(b:netrw_curdir)<cr>
+        nnoremap <buffer> <silent> <Plug>NetrwSetChgwin              :<c-u>call <SID>NetrwSetChgwin()<cr>
+        nnoremap <buffer> <silent> <Plug>NetrwRefresh                :<c-u>call <SID>NetrwRefresh(0,<SID>NetrwBrowseChgDir(0,'./',0))<cr>
+        nnoremap <buffer> <silent> <Plug>NetrwLocalBrowseCheck       :<c-u>call <SID>NetrwBrowse(0,<SID>NetrwBrowseChgDir(0,<SID>NetrwGetWord(),1))<cr>
+        nnoremap <buffer> <silent> <Plug>NetrwServerEdit             :<c-u>call <SID>NetrwServerEdit(2,<SID>NetrwGetWord())<cr>
+        nnoremap <buffer> <silent> <Plug>NetrwBookHistHandler_gb     :<c-u>call <SID>NetrwBookHistHandler(1,b:netrw_curdir)<cr>
+        " ---------------------------------------------------------------------
+        nnoremap <buffer> <silent> <nowait> gd       :<c-u>call <SID>NetrwForceChgDir(0,<SID>NetrwGetWord())<cr>
+        nnoremap <buffer> <silent> <nowait> gf       :<c-u>call <SID>NetrwForceFile(0,<SID>NetrwGetWord())<cr>
+        nnoremap <buffer> <silent> <nowait> gh       :<c-u>call <SID>NetrwHidden(0)<cr>
+        nnoremap <buffer> <silent> <nowait> gp       :<c-u>call <SID>NetrwChgPerm(0,b:netrw_curdir)<cr>
+        nnoremap <buffer> <silent> <nowait> I        :<c-u>call <SID>NetrwBannerCtrl(1)<cr>
+        nnoremap <buffer> <silent> <nowait> i        :<c-u>call <SID>NetrwListStyle(0)<cr>
+        nnoremap <buffer> <silent> <nowait> ma       :<c-u>call <SID>NetrwMarkFileArgList(0,0)<cr>
+        nnoremap <buffer> <silent> <nowait> mA       :<c-u>call <SID>NetrwMarkFileArgList(0,1)<cr>
+        nnoremap <buffer> <silent> <nowait> mb       :<c-u>call <SID>NetrwBookHistHandler(0,b:netrw_curdir)<cr>
+        nnoremap <buffer> <silent> <nowait> mB       :<c-u>call <SID>NetrwBookHistHandler(6,b:netrw_curdir)<cr>
+        nnoremap <buffer> <silent> <nowait> mc       :<c-u>call <SID>NetrwMarkFileCopy(0)<cr>
+        nnoremap <buffer> <silent> <nowait> md       :<c-u>call <SID>NetrwMarkFileDiff(0)<cr>
+        nnoremap <buffer> <silent> <nowait> me       :<c-u>call <SID>NetrwMarkFileEdit(0)<cr>
+        nnoremap <buffer> <silent> <nowait> mf       :<c-u>call <SID>NetrwMarkFile(0,<SID>NetrwGetWord())<cr>
+        nnoremap <buffer> <silent> <nowait> mF       :<c-u>call <SID>NetrwUnmarkList(bufnr("%"),b:netrw_curdir)<cr>
+        nnoremap <buffer> <silent> <nowait> mg       :<c-u>call <SID>NetrwMarkFileGrep(0)<cr>
+        nnoremap <buffer> <silent> <nowait> mh       :<c-u>call <SID>NetrwMarkHideSfx(0)<cr>
+        nnoremap <buffer> <silent> <nowait> mm       :<c-u>call <SID>NetrwMarkFileMove(0)<cr>
+        nnoremap <buffer> <silent> <nowait> mp       :<c-u>call <SID>NetrwMarkFilePrint(0)<cr>
+        nnoremap <buffer> <silent> <nowait> mr       :<c-u>call <SID>NetrwMarkFileRegexp(0)<cr>
+        nnoremap <buffer> <silent> <nowait> ms       :<c-u>call <SID>NetrwMarkFileSource(0)<cr>
+        nnoremap <buffer> <silent> <nowait> mT       :<c-u>call <SID>NetrwMarkFileTag(0)<cr>
+        nnoremap <buffer> <silent> <nowait> mt       :<c-u>call <SID>NetrwMarkFileTgt(0)<cr>
+        nnoremap <buffer> <silent> <nowait> mu       :<c-u>call <SID>NetrwUnMarkFile(0)<cr>
+        nnoremap <buffer> <silent> <nowait> mv       :<c-u>call <SID>NetrwMarkFileVimCmd(0)<cr>
+        nnoremap <buffer> <silent> <nowait> mx       :<c-u>call <SID>NetrwMarkFileExe(0,0)<cr>
+        nnoremap <buffer> <silent> <nowait> mX       :<c-u>call <SID>NetrwMarkFileExe(0,1)<cr>
+        nnoremap <buffer> <silent> <nowait> mz       :<c-u>call <SID>NetrwMarkFileCompress(0)<cr>
+        nnoremap <buffer> <silent> <nowait> O        :<c-u>call <SID>NetrwObtain(0)<cr>
+        nnoremap <buffer> <silent> <nowait> o        :call <SID>NetrwSplit(0)<cr>
+        nnoremap <buffer> <silent> <nowait> p        :<c-u>call <SID>NetrwPreview(<SID>NetrwBrowseChgDir(1,<SID>NetrwGetWord(),1,1))<cr>
+        nnoremap <buffer> <silent> <nowait> P        :<c-u>call <SID>NetrwPrevWinOpen(0)<cr>
+        nnoremap <buffer> <silent> <nowait> qb       :<c-u>call <SID>NetrwBookHistHandler(2,b:netrw_curdir)<cr>
+        nnoremap <buffer> <silent> <nowait> qf       :<c-u>call <SID>NetrwFileInfo(0,<SID>NetrwGetWord())<cr>
+        nnoremap <buffer> <silent> <nowait> qF       :<c-u>call <SID>NetrwMarkFileQFEL(0,getqflist())<cr>
+        nnoremap <buffer> <silent> <nowait> qL       :<c-u>call <SID>NetrwMarkFileQFEL(0,getloclist(v:count))<cr>
+        nnoremap <buffer> <silent> <nowait> r        :<c-u>let g:netrw_sort_direction= (g:netrw_sort_direction =~# 'n')? 'r' : 'n'<bar>exe "norm! 0"<bar>call <SID>NetrwBrowse(0,<SID>NetrwBrowseChgDir(0,'./',0))<cr>
+        nnoremap <buffer> <silent> <nowait> s        :call <SID>NetrwSortStyle(0)<cr>
+        nnoremap <buffer> <silent> <nowait> S        :<c-u>call <SID>NetSortSequence(0)<cr>
+        nnoremap <buffer> <silent> <nowait> Tb       :<c-u>call <SID>NetrwSetTgt(0,'b',v:count1)<cr>
+        nnoremap <buffer> <silent> <nowait> t        :call <SID>NetrwSplit(1)<cr>
+        nnoremap <buffer> <silent> <nowait> Th       :<c-u>call <SID>NetrwSetTgt(0,'h',v:count)<cr>
+        nnoremap <buffer> <silent> <nowait> u        :<c-u>call <SID>NetrwBookHistHandler(4,b:netrw_curdir)<cr>
+        nnoremap <buffer> <silent> <nowait> U        :<c-u>call <SID>NetrwBookHistHandler(5,b:netrw_curdir)<cr>
+        nnoremap <buffer> <silent> <nowait> v        :call <SID>NetrwSplit(2)<cr>
+        nnoremap <buffer> <silent> <nowait> x        :<c-u>call netrw#BrowseX(<SID>NetrwBrowseChgDir(0,<SID>NetrwGetWord(),1),1)<cr>
+        nmap     <buffer>          <nowait> gx       x
+        if !hasmapto('<Plug>NetrwHideEdit')
+            nmap <buffer> <c-h> <Plug>NetrwHideEdit
+        endif
+        nnoremap <buffer> <silent> <Plug>NetrwHideEdit       :call <SID>NetrwHideEdit(0)<cr>
+        if !hasmapto('<Plug>NetrwRefresh')
+            nmap <buffer> <c-l> <Plug>NetrwRefresh
+        endif
+        if !hasmapto('<Plug>NetrwTreeSqueeze')
+            nmap <buffer> <silent> <nowait> <s-cr>      <Plug>NetrwTreeSqueeze
+        endif
+        nnoremap <buffer> <silent> <Plug>NetrwTreeSqueeze    :call <SID>TreeSqueezeDir(0)<cr>
 
-    let mapsafepath     = escape(s:path, s:netrw_map_escape)
-    let mapsafeusermach = escape(((s:user == "")? "" : s:user."@").s:machine, s:netrw_map_escape)
+        let mapsafepath     = escape(s:path, s:netrw_map_escape)
+        let mapsafeusermach = escape(((s:user == "")? "" : s:user."@").s:machine, s:netrw_map_escape)
 
-    nnoremap <buffer> <silent> <Plug>NetrwRefresh        :call <SID>NetrwRefresh(0,<SID>NetrwBrowseChgDir(0,'./',0))<cr>
-    if g:netrw_mousemaps == 1
-      nmap <buffer> <leftmouse>           <Plug>NetrwLeftmouse
-      nno  <buffer> <silent>              <Plug>NetrwLeftmouse    :exec "norm! \<lt>leftmouse>"<bar>call <SID>NetrwLeftmouse(0)<cr>
-      nmap <buffer> <c-leftmouse>         <Plug>NetrwCLeftmouse
-      nno  <buffer> <silent>              <Plug>NetrwCLeftmouse   :exec "norm! \<lt>leftmouse>"<bar>call <SID>NetrwCLeftmouse(0)<cr>
-      nmap <buffer> <s-leftmouse>         <Plug>NetrwSLeftmouse
-      nno  <buffer> <silent>              <Plug>NetrwSLeftmouse   :exec "norm! \<lt>leftmouse>"<bar>call <SID>NetrwSLeftmouse(0)<cr>
-      nmap <buffer> <s-leftdrag>          <Plug>NetrwSLeftdrag
-      nno  <buffer> <silent>              <Plug>NetrwSLeftdrag    :exec "norm! \<lt>leftmouse>"<bar>call <SID>NetrwSLeftdrag(0)<cr>
-      nmap <middlemouse>                  <Plug>NetrwMiddlemouse
-      nno  <buffer> <silent>              <middlemouse>           <Plug>NetrwMiddlemouse :exec "norm! \<lt>leftmouse>"<bar>call <SID>NetrwPrevWinOpen(0)<cr>
-      nmap <buffer> <2-leftmouse>         <Plug>Netrw2Leftmouse
-      nmap <buffer> <silent>              <Plug>Netrw2Leftmouse   -
-        imap <buffer> <leftmouse>           <Plug>ILeftmouse
-      imap <buffer> <middlemouse>         <Plug>IMiddlemouse
-      imap <buffer> <s-leftmouse>         <Plug>ISLeftmouse
-      exe 'nnoremap <buffer> <silent> <rightmouse> :exec "norm! \<lt>leftmouse>"<bar>call <SID>NetrwRemoteRm("'.mapsafeusermach.'","'.mapsafepath.'")<cr>'
-      exe 'vnoremap <buffer> <silent> <rightmouse> :exec "norm! \<lt>leftmouse>"<bar>call <SID>NetrwRemoteRm("'.mapsafeusermach.'","'.mapsafepath.'")<cr>'
-    endif
-    exe 'nnoremap <buffer> <silent> <nowait> <del>       :call <SID>NetrwRemoteRm("'.mapsafeusermach.'","'.mapsafepath.'")<cr>'
-    exe 'nnoremap <buffer> <silent> <nowait> d           :call <SID>NetrwMakeDir("'.mapsafeusermach.'")<cr>'
-    exe 'nnoremap <buffer> <silent> <nowait> D           :call <SID>NetrwRemoteRm("'.mapsafeusermach.'","'.mapsafepath.'")<cr>'
-    exe 'nnoremap <buffer> <silent> <nowait> R           :call <SID>NetrwRemoteRename("'.mapsafeusermach.'","'.mapsafepath.'")<cr>'
-    exe 'vnoremap <buffer> <silent> <nowait> <del>       :call <SID>NetrwRemoteRm("'.mapsafeusermach.'","'.mapsafepath.'")<cr>'
-    exe 'vnoremap <buffer> <silent> <nowait> D           :call <SID>NetrwRemoteRm("'.mapsafeusermach.'","'.mapsafepath.'")<cr>'
-    exe 'vnoremap <buffer> <silent> <nowait> R           :call <SID>NetrwRemoteRename("'.mapsafeusermach.'","'.mapsafepath.'")<cr>'
-    nnoremap <buffer> <F1>                       :he netrw-quickhelp<cr>
+        nnoremap <buffer> <silent> <Plug>NetrwRefresh        :call <SID>NetrwRefresh(0,<SID>NetrwBrowseChgDir(0,'./',0))<cr>
+        if g:netrw_mousemaps == 1
+            nmap <buffer> <leftmouse>           <Plug>NetrwLeftmouse
+            nno  <buffer> <silent>              <Plug>NetrwLeftmouse    :exec "norm! \<lt>leftmouse>"<bar>call <SID>NetrwLeftmouse(0)<cr>
+            nmap <buffer> <c-leftmouse>         <Plug>NetrwCLeftmouse
+            nno  <buffer> <silent>              <Plug>NetrwCLeftmouse   :exec "norm! \<lt>leftmouse>"<bar>call <SID>NetrwCLeftmouse(0)<cr>
+            nmap <buffer> <s-leftmouse>         <Plug>NetrwSLeftmouse
+            nno  <buffer> <silent>              <Plug>NetrwSLeftmouse   :exec "norm! \<lt>leftmouse>"<bar>call <SID>NetrwSLeftmouse(0)<cr>
+            nmap <buffer> <s-leftdrag>          <Plug>NetrwSLeftdrag
+            nno  <buffer> <silent>              <Plug>NetrwSLeftdrag    :exec "norm! \<lt>leftmouse>"<bar>call <SID>NetrwSLeftdrag(0)<cr>
+            nmap <middlemouse>                  <Plug>NetrwMiddlemouse
+            nno  <buffer> <silent>              <middlemouse>           <Plug>NetrwMiddlemouse :exec "norm! \<lt>leftmouse>"<bar>call <SID>NetrwPrevWinOpen(0)<cr>
+            nmap <buffer> <2-leftmouse>         <Plug>Netrw2Leftmouse
+            nmap <buffer> <silent>              <Plug>Netrw2Leftmouse   -
+                imap <buffer> <leftmouse>           <Plug>ILeftmouse
+            imap <buffer> <middlemouse>         <Plug>IMiddlemouse
+            imap <buffer> <s-leftmouse>         <Plug>ISLeftmouse
+            exe 'nnoremap <buffer> <silent> <rightmouse> :exec "norm! \<lt>leftmouse>"<bar>call <SID>NetrwRemoteRm("'.mapsafeusermach.'","'.mapsafepath.'")<cr>'
+            exe 'vnoremap <buffer> <silent> <rightmouse> :exec "norm! \<lt>leftmouse>"<bar>call <SID>NetrwRemoteRm("'.mapsafeusermach.'","'.mapsafepath.'")<cr>'
+        endif
+        exe 'nnoremap <buffer> <silent> <nowait> <del>       :call <SID>NetrwRemoteRm("'.mapsafeusermach.'","'.mapsafepath.'")<cr>'
+        exe 'nnoremap <buffer> <silent> <nowait> d           :call <SID>NetrwMakeDir("'.mapsafeusermach.'")<cr>'
+        exe 'nnoremap <buffer> <silent> <nowait> D           :call <SID>NetrwRemoteRm("'.mapsafeusermach.'","'.mapsafepath.'")<cr>'
+        exe 'nnoremap <buffer> <silent> <nowait> R           :call <SID>NetrwRemoteRename("'.mapsafeusermach.'","'.mapsafepath.'")<cr>'
+        exe 'vnoremap <buffer> <silent> <nowait> <del>       :call <SID>NetrwRemoteRm("'.mapsafeusermach.'","'.mapsafepath.'")<cr>'
+        exe 'vnoremap <buffer> <silent> <nowait> D           :call <SID>NetrwRemoteRm("'.mapsafeusermach.'","'.mapsafepath.'")<cr>'
+        exe 'vnoremap <buffer> <silent> <nowait> R           :call <SID>NetrwRemoteRename("'.mapsafeusermach.'","'.mapsafepath.'")<cr>'
+        nnoremap <buffer> <F1>                       :he netrw-quickhelp<cr>
 
-    " support user-specified maps
-    call netrw#UserMaps(0)
-  endif " }}}3
+        " support user-specified maps
+        call netrw#UserMaps(0)
+    endif " }}}3
 endfun
 
 " s:NetrwCommands: set up commands                              {{{2
@@ -5268,51 +5240,51 @@ endfun
 "  has been used at least once in the session.
 fun! s:NetrwCommands(islocal)
 
-  com! -nargs=* -complete=file -bang    NetrwMB call s:NetrwBookmark(<bang>0,<f-args>)
-  com! -nargs=*                         NetrwC  call s:NetrwSetChgwin(<q-args>)
-  com! Rexplore if exists("w:netrw_rexlocal")|call s:NetrwRexplore(w:netrw_rexlocal,exists("w:netrw_rexdir")? w:netrw_rexdir : ".")|else|call netrw#msg#Notify('WARNING', "win#".winnr()." not a former netrw window")|endif
-  if a:islocal
-    com! -buffer -nargs=+ -complete=file MF      call s:NetrwMarkFiles(1,<f-args>)
-  else
-    com! -buffer -nargs=+ -complete=file MF      call s:NetrwMarkFiles(0,<f-args>)
-  endif
-  com! -buffer -nargs=? -complete=file  MT      call s:NetrwMarkTarget(<q-args>)
+    com! -nargs=* -complete=file -bang    NetrwMB call s:NetrwBookmark(<bang>0,<f-args>)
+    com! -nargs=*                         NetrwC  call s:NetrwSetChgwin(<q-args>)
+    com! Rexplore if exists("w:netrw_rexlocal")|call s:NetrwRexplore(w:netrw_rexlocal,exists("w:netrw_rexdir")? w:netrw_rexdir : ".")|else|call netrw#msg#Notify('WARNING', "win#".winnr()." not a former netrw window")|endif
+    if a:islocal
+        com! -buffer -nargs=+ -complete=file MF      call s:NetrwMarkFiles(1,<f-args>)
+    else
+        com! -buffer -nargs=+ -complete=file MF      call s:NetrwMarkFiles(0,<f-args>)
+    endif
+    com! -buffer -nargs=? -complete=file  MT      call s:NetrwMarkTarget(<q-args>)
 
 endfun
 
 " s:NetrwMarkFiles: apply s:NetrwMarkFile() to named file(s) {{{2
 "                   glob()ing only works with local files
 fun! s:NetrwMarkFiles(islocal,...)
-  let curdir = s:NetrwGetCurdir(a:islocal)
-  let i      = 1
-  while i <= a:0
-    if a:islocal
-      let mffiles= glob(a:{i}, 0, 1, 1)
-    else
-      let mffiles= [a:{i}]
-    endif
-    for mffile in mffiles
-      call s:NetrwMarkFile(a:islocal,mffile)
-    endfor
-    let i= i + 1
-  endwhile
+    let curdir = s:NetrwGetCurdir(a:islocal)
+    let i      = 1
+    while i <= a:0
+        if a:islocal
+            let mffiles= glob(a:{i}, 0, 1, 1)
+        else
+            let mffiles= [a:{i}]
+        endif
+        for mffile in mffiles
+            call s:NetrwMarkFile(a:islocal,mffile)
+        endfor
+        let i= i + 1
+    endwhile
 endfun
 
 " s:NetrwMarkTarget: implements :MT (mark target) {{{2
 fun! s:NetrwMarkTarget(...)
-  if a:0 == 0 || (a:0 == 1 && a:1 == "")
-    let curdir = s:NetrwGetCurdir(1)
-    let tgt    = b:netrw_curdir
-  else
-    let curdir = s:NetrwGetCurdir((a:1 =~ '^\a\{3,}://')? 0 : 1)
-    let tgt    = a:1
-  endif
-  let s:netrwmftgt         = tgt
-  let s:netrwmftgt_islocal = tgt !~ '^\a\{3,}://'
-  let curislocal           = b:netrw_curdir !~ '^\a\{3,}://'
-  let svpos                = winsaveview()
-  call s:NetrwRefresh(curislocal,s:NetrwBrowseChgDir(curislocal,'./',0))
-  call winrestview(svpos)
+    if a:0 == 0 || (a:0 == 1 && a:1 == "")
+        let curdir = s:NetrwGetCurdir(1)
+        let tgt    = b:netrw_curdir
+    else
+        let curdir = s:NetrwGetCurdir((a:1 =~ '^\a\{3,}://')? 0 : 1)
+        let tgt    = a:1
+    endif
+    let s:netrwmftgt         = tgt
+    let s:netrwmftgt_islocal = tgt !~ '^\a\{3,}://'
+    let curislocal           = b:netrw_curdir !~ '^\a\{3,}://'
+    let svpos                = winsaveview()
+    call s:NetrwRefresh(curislocal,s:NetrwBrowseChgDir(curislocal,'./',0))
+    call winrestview(svpos)
 endfun
 
 " s:NetrwMarkFile: (invoked by mf) This function is used to both {{{2
@@ -5333,128 +5305,128 @@ endfun
 "    b:netrw_islocal
 fun! s:NetrwMarkFile(islocal,fname)
 
-  " sanity check
-  if empty(a:fname)
-    return
-  endif
-  let curdir = s:NetrwGetCurdir(a:islocal)
+    " sanity check
+    if empty(a:fname)
+        return
+    endif
+    let curdir = s:NetrwGetCurdir(a:islocal)
 
-  let ykeep   = @@
-  let curbufnr= bufnr("%")
-  let leader= '\%(^\|\s\)\zs'
-  if a:fname =~ '\a$'
-    let trailer = '\>[@=|\/\*]\=\ze\%(  \|\t\|$\)'
-  else
-    let trailer = '[@=|\/\*]\=\ze\%(  \|\t\|$\)'
-  endif
-
-  if exists("s:netrwmarkfilelist_".curbufnr)
-    " markfile list pre-exists
-    let b:netrw_islocal= a:islocal
-
-    if index(s:netrwmarkfilelist_{curbufnr},a:fname) == -1
-      " append filename to buffer's markfilelist
-      call add(s:netrwmarkfilelist_{curbufnr},a:fname)
-      let s:netrwmarkfilemtch_{curbufnr}= s:netrwmarkfilemtch_{curbufnr}.'\|'.leader.escape(a:fname,g:netrw_markfileesc).trailer
-
+    let ykeep   = @@
+    let curbufnr= bufnr("%")
+    let leader= '\%(^\|\s\)\zs'
+    if a:fname =~ '\a$'
+        let trailer = '\>[@=|\/\*]\=\ze\%(  \|\t\|$\)'
     else
-      " remove filename from buffer's markfilelist
-      call filter(s:netrwmarkfilelist_{curbufnr},'v:val != a:fname')
-      if s:netrwmarkfilelist_{curbufnr} == []
-        " local markfilelist is empty; remove it entirely
-        call s:NetrwUnmarkList(curbufnr,curdir)
-      else
-        " rebuild match list to display markings correctly
-        let s:netrwmarkfilemtch_{curbufnr}= ""
-        let first                         = 1
-        for fname in s:netrwmarkfilelist_{curbufnr}
-          if first
-            let s:netrwmarkfilemtch_{curbufnr}= s:netrwmarkfilemtch_{curbufnr}.leader.escape(fname,g:netrw_markfileesc).trailer
-          else
-            let s:netrwmarkfilemtch_{curbufnr}= s:netrwmarkfilemtch_{curbufnr}.'\|'.leader.escape(fname,g:netrw_markfileesc).trailer
-          endif
-          let first= 0
-        endfor
-      endif
+        let trailer = '[@=|\/\*]\=\ze\%(  \|\t\|$\)'
     endif
 
-  else
-    " initialize new markfilelist
+    if exists("s:netrwmarkfilelist_".curbufnr)
+        " markfile list pre-exists
+        let b:netrw_islocal= a:islocal
 
-    let s:netrwmarkfilelist_{curbufnr}= []
-    call add(s:netrwmarkfilelist_{curbufnr},substitute(a:fname,'[|@]$','',''))
+        if index(s:netrwmarkfilelist_{curbufnr},a:fname) == -1
+            " append filename to buffer's markfilelist
+            call add(s:netrwmarkfilelist_{curbufnr},a:fname)
+            let s:netrwmarkfilemtch_{curbufnr}= s:netrwmarkfilemtch_{curbufnr}.'\|'.leader.escape(a:fname,g:netrw_markfileesc).trailer
 
-    " build initial markfile matching pattern
-    if a:fname =~ '/$'
-      let s:netrwmarkfilemtch_{curbufnr}= leader.escape(a:fname,g:netrw_markfileesc)
+        else
+            " remove filename from buffer's markfilelist
+            call filter(s:netrwmarkfilelist_{curbufnr},'v:val != a:fname')
+            if s:netrwmarkfilelist_{curbufnr} == []
+                " local markfilelist is empty; remove it entirely
+                call s:NetrwUnmarkList(curbufnr,curdir)
+            else
+                " rebuild match list to display markings correctly
+                let s:netrwmarkfilemtch_{curbufnr}= ""
+                let first                         = 1
+                for fname in s:netrwmarkfilelist_{curbufnr}
+                    if first
+                        let s:netrwmarkfilemtch_{curbufnr}= s:netrwmarkfilemtch_{curbufnr}.leader.escape(fname,g:netrw_markfileesc).trailer
+                    else
+                        let s:netrwmarkfilemtch_{curbufnr}= s:netrwmarkfilemtch_{curbufnr}.'\|'.leader.escape(fname,g:netrw_markfileesc).trailer
+                    endif
+                    let first= 0
+                endfor
+            endif
+        endif
+
     else
-      let s:netrwmarkfilemtch_{curbufnr}= leader.escape(a:fname,g:netrw_markfileesc).trailer
-    endif
-  endif
+        " initialize new markfilelist
 
-  " handle global markfilelist
-  if exists("s:netrwmarkfilelist")
-    let dname= netrw#fs#ComposePath(b:netrw_curdir,a:fname)
-    if index(s:netrwmarkfilelist,dname) == -1
-      " append new filename to global markfilelist
-      call add(s:netrwmarkfilelist,netrw#fs#ComposePath(b:netrw_curdir,a:fname))
-    else
-      " remove new filename from global markfilelist
-      call filter(s:netrwmarkfilelist,'v:val != "'.dname.'"')
-      if s:netrwmarkfilelist == []
-        unlet s:netrwmarkfilelist
-      endif
-    endif
-  else
-    " initialize new global-directory markfilelist
-    let s:netrwmarkfilelist= []
-    call add(s:netrwmarkfilelist,netrw#fs#ComposePath(b:netrw_curdir,a:fname))
-  endif
+        let s:netrwmarkfilelist_{curbufnr}= []
+        call add(s:netrwmarkfilelist_{curbufnr},substitute(a:fname,'[|@]$','',''))
 
-  " set up 2match'ing to netrwmarkfilemtch_# list
-  if has("syntax") && exists("g:syntax_on") && g:syntax_on
-    if exists("s:netrwmarkfilemtch_{curbufnr}") && s:netrwmarkfilemtch_{curbufnr} != ""
-      if exists("g:did_drchip_netrwlist_syntax")
-        exe "2match netrwMarkFile /".s:netrwmarkfilemtch_{curbufnr}."/"
-      endif
-    else
-      2match none
+        " build initial markfile matching pattern
+        if a:fname =~ '/$'
+            let s:netrwmarkfilemtch_{curbufnr}= leader.escape(a:fname,g:netrw_markfileesc)
+        else
+            let s:netrwmarkfilemtch_{curbufnr}= leader.escape(a:fname,g:netrw_markfileesc).trailer
+        endif
     endif
-  endif
-  let @@= ykeep
+
+    " handle global markfilelist
+    if exists("s:netrwmarkfilelist")
+        let dname= netrw#fs#ComposePath(b:netrw_curdir,a:fname)
+        if index(s:netrwmarkfilelist,dname) == -1
+            " append new filename to global markfilelist
+            call add(s:netrwmarkfilelist,netrw#fs#ComposePath(b:netrw_curdir,a:fname))
+        else
+            " remove new filename from global markfilelist
+            call filter(s:netrwmarkfilelist,'v:val != "'.dname.'"')
+            if s:netrwmarkfilelist == []
+                unlet s:netrwmarkfilelist
+            endif
+        endif
+    else
+        " initialize new global-directory markfilelist
+        let s:netrwmarkfilelist= []
+        call add(s:netrwmarkfilelist,netrw#fs#ComposePath(b:netrw_curdir,a:fname))
+    endif
+
+    " set up 2match'ing to netrwmarkfilemtch_# list
+    if has("syntax") && exists("g:syntax_on") && g:syntax_on
+        if exists("s:netrwmarkfilemtch_{curbufnr}") && s:netrwmarkfilemtch_{curbufnr} != ""
+            if exists("g:did_drchip_netrwlist_syntax")
+                exe "2match netrwMarkFile /".s:netrwmarkfilemtch_{curbufnr}."/"
+            endif
+        else
+            2match none
+        endif
+    endif
+    let @@= ykeep
 endfun
 
 " s:NetrwMarkFileArgList: ma: move the marked file list to the argument list (tomflist=0) {{{2
 "                         mA: move the argument list to marked file list     (tomflist=1)
 "                            Uses the global marked file list
 fun! s:NetrwMarkFileArgList(islocal,tomflist)
-  let svpos    = winsaveview()
-  let curdir   = s:NetrwGetCurdir(a:islocal)
-  let curbufnr = bufnr("%")
+    let svpos    = winsaveview()
+    let curdir   = s:NetrwGetCurdir(a:islocal)
+    let curbufnr = bufnr("%")
 
-  if a:tomflist
-    " mA: move argument list to marked file list
-    while argc()
-      let fname= argv(0)
-      exe "argdel ".fnameescape(fname)
-      call s:NetrwMarkFile(a:islocal,fname)
-    endwhile
+    if a:tomflist
+        " mA: move argument list to marked file list
+        while argc()
+            let fname= argv(0)
+            exe "argdel ".fnameescape(fname)
+            call s:NetrwMarkFile(a:islocal,fname)
+        endwhile
 
-  else
-    " ma: move marked file list to argument list
-    if exists("s:netrwmarkfilelist")
+    else
+        " ma: move marked file list to argument list
+        if exists("s:netrwmarkfilelist")
 
-      " for every filename in the marked list
-      for fname in s:netrwmarkfilelist
-        exe "argadd ".fnameescape(fname)
-      endfor      " for every file in the marked list
+            " for every filename in the marked list
+            for fname in s:netrwmarkfilelist
+                exe "argadd ".fnameescape(fname)
+            endfor      " for every file in the marked list
 
-      " unmark list and refresh
-      call s:NetrwUnmarkList(curbufnr,curdir)
-      NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
-      NetrwKeepj call winrestview(svpos)
+            " unmark list and refresh
+            call s:NetrwUnmarkList(curbufnr,curdir)
+            NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
+            NetrwKeepj call winrestview(svpos)
+        endif
     endif
-  endif
 endfun
 
 " s:NetrwMarkFileCompress: (invoked by mz) This function is used to {{{2
@@ -5465,59 +5437,59 @@ endfun
 "                            g:netrw_compress        = "gzip"
 "                            g:netrw_decompress      = { ".gz" : "gunzip" , ".bz2" : "bunzip2" , ".zip" : "unzip" , ".tar" : "tar -xf", ".xz" : "unxz"}
 fun! s:NetrwMarkFileCompress(islocal)
-  let svpos    = winsaveview()
-  let curdir   = s:NetrwGetCurdir(a:islocal)
-  let curbufnr = bufnr("%")
+    let svpos    = winsaveview()
+    let curdir   = s:NetrwGetCurdir(a:islocal)
+    let curbufnr = bufnr("%")
 
-  " sanity check
-  if !exists("s:netrwmarkfilelist_{curbufnr}") || empty(s:netrwmarkfilelist_{curbufnr})
-    call netrw#msg#Notify('ERROR', 'there are no marked files in this window (:help netrw-mf)')
-    return
-  endif
+    " sanity check
+    if !exists("s:netrwmarkfilelist_{curbufnr}") || empty(s:netrwmarkfilelist_{curbufnr})
+        call netrw#msg#Notify('ERROR', 'there are no marked files in this window (:help netrw-mf)')
+        return
+    endif
 
-  if exists("s:netrwmarkfilelist_{curbufnr}") && exists("g:netrw_compress") && exists("g:netrw_decompress")
+    if exists("s:netrwmarkfilelist_{curbufnr}") && exists("g:netrw_compress") && exists("g:netrw_decompress")
 
-    " for every filename in the marked list
-    for fname in s:netrwmarkfilelist_{curbufnr}
-      let sfx= substitute(fname,'^.\{-}\(\.[[:alnum:]]\+\)$','\1','')
-      if exists("g:netrw_decompress['".sfx."']")
-        " fname has a suffix indicating that its compressed; apply associated decompression routine
-        let exe= g:netrw_decompress[sfx]
-        let exe= netrw#fs#WinPath(exe)
-        if a:islocal
-          if g:netrw_keepdir
-            let fname= netrw#os#Escape(netrw#fs#ComposePath(curdir,fname))
-          endif
-          call system(exe." ".fname)
-          if v:shell_error
-            call netrw#msg#Notify('WARNING', printf('unable to apply<%s> to file<%s>', exe, fname))
-          endif
-        else
-          let fname= netrw#os#Escape(b:netrw_curdir.fname,1)
-          NetrwKeepj call s:RemoteSystem(exe." ".fname)
-        endif
+        " for every filename in the marked list
+        for fname in s:netrwmarkfilelist_{curbufnr}
+            let sfx= substitute(fname,'^.\{-}\(\.[[:alnum:]]\+\)$','\1','')
+            if exists("g:netrw_decompress['".sfx."']")
+                " fname has a suffix indicating that its compressed; apply associated decompression routine
+                let exe= g:netrw_decompress[sfx]
+                let exe= netrw#fs#WinPath(exe)
+                if a:islocal
+                    if g:netrw_keepdir
+                        let fname= netrw#os#Escape(netrw#fs#ComposePath(curdir,fname))
+                    endif
+                    call system(exe." ".fname)
+                    if v:shell_error
+                        call netrw#msg#Notify('WARNING', printf('unable to apply<%s> to file<%s>', exe, fname))
+                    endif
+                else
+                    let fname= netrw#os#Escape(b:netrw_curdir.fname,1)
+                    NetrwKeepj call s:RemoteSystem(exe." ".fname)
+                endif
 
-      endif
-      unlet sfx
+            endif
+            unlet sfx
 
-      if exists("exe")
-        unlet exe
-      elseif a:islocal
-        " fname not a compressed file, so compress it
-        call system(netrw#fs#WinPath(g:netrw_compress)." ".netrw#os#Escape(netrw#fs#ComposePath(b:netrw_curdir,fname)))
-        if v:shell_error
-          call netrw#msg#Notify('WARNING', printf('consider setting g:netrw_compress<%s> to something that works', g:netrw_compress))
-        endif
-      else
-        " fname not a compressed file, so compress it
-        NetrwKeepj call s:RemoteSystem(netrw#fs#WinPath(g:netrw_compress)." ".netrw#os#Escape(fname))
-      endif
-    endfor       " for every file in the marked list
+            if exists("exe")
+                unlet exe
+            elseif a:islocal
+                " fname not a compressed file, so compress it
+                call system(netrw#fs#WinPath(g:netrw_compress)." ".netrw#os#Escape(netrw#fs#ComposePath(b:netrw_curdir,fname)))
+                if v:shell_error
+                    call netrw#msg#Notify('WARNING', printf('consider setting g:netrw_compress<%s> to something that works', g:netrw_compress))
+                endif
+            else
+                " fname not a compressed file, so compress it
+                NetrwKeepj call s:RemoteSystem(netrw#fs#WinPath(g:netrw_compress)." ".netrw#os#Escape(fname))
+            endif
+        endfor       " for every file in the marked list
 
-    call s:NetrwUnmarkList(curbufnr,curdir)
-    NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
-    NetrwKeepj call winrestview(svpos)
-  endif
+        call s:NetrwUnmarkList(curbufnr,curdir)
+        NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
+        NetrwKeepj call winrestview(svpos)
+    endif
 endfun
 
 " s:NetrwMarkFileCopy: (invoked by mc) copy marked files to target {{{2
@@ -5528,183 +5500,183 @@ endfun
 "                              0=failure
 fun! s:NetrwMarkFileCopy(islocal,...)
 
-  let curdir   = s:NetrwGetCurdir(a:islocal)
-  let curbufnr = bufnr("%")
-  if b:netrw_curdir !~ '/$'
-    if !exists("b:netrw_curdir")
-      let b:netrw_curdir= curdir
-    endif
-    let b:netrw_curdir= b:netrw_curdir."/"
-  endif
-
-  " sanity check
-  if !exists("s:netrwmarkfilelist_{curbufnr}") || empty(s:netrwmarkfilelist_{curbufnr})
-    call netrw#msg#Notify('ERROR', 'there are no marked files in this window (:help netrw-mf)')
-    return
-  endif
-
-  if !exists("s:netrwmftgt")
-    call netrw#msg#Notify('ERROR', 'your marked file target is empty! (:help netrw-mt)')
-    return 0
-  endif
-
-  if a:islocal &&  s:netrwmftgt_islocal
-    " Copy marked files, local directory to local directory
-    if !executable(g:netrw_localcopycmd)
-      call netrw#msg#Notify('ERROR', printf('g:netrw_localcopycmd<%s> not executable on your system, aborting', g:netrw_localcopycmd))
-      return
+    let curdir   = s:NetrwGetCurdir(a:islocal)
+    let curbufnr = bufnr("%")
+    if b:netrw_curdir !~ '/$'
+        if !exists("b:netrw_curdir")
+            let b:netrw_curdir= curdir
+        endif
+        let b:netrw_curdir= b:netrw_curdir."/"
     endif
 
-    " copy marked files while within the same directory (ie. allow renaming)
-    if simplify(s:netrwmftgt) ==# simplify(b:netrw_curdir)
-      if len(s:netrwmarkfilelist_{bufnr('%')}) == 1
-        " only one marked file
-        let args    = netrw#os#Escape(b:netrw_curdir.s:netrwmarkfilelist_{bufnr('%')}[0])
-        let oldname = s:netrwmarkfilelist_{bufnr('%')}[0]
-      elseif a:0 == 1
-        " this happens when the next case was used to recursively call s:NetrwMarkFileCopy()
-        let args    = netrw#os#Escape(b:netrw_curdir.a:1)
-        let oldname = a:1
-      else
-        " copy multiple marked files inside the same directory
-        let s:recursive= 1
-        for oldname in s:netrwmarkfilelist_{bufnr("%")}
-          let ret= s:NetrwMarkFileCopy(a:islocal,oldname)
-          if ret == 0
-            break
-          endif
-        endfor
-        unlet s:recursive
-        call s:NetrwUnmarkList(curbufnr,curdir)
-        return ret
-      endif
+    " sanity check
+    if !exists("s:netrwmarkfilelist_{curbufnr}") || empty(s:netrwmarkfilelist_{curbufnr})
+        call netrw#msg#Notify('ERROR', 'there are no marked files in this window (:help netrw-mf)')
+        return
+    endif
 
-      call inputsave()
-      let newname= input(printf("Copy %s to: ", oldname), oldname, 'file')
-      call inputrestore()
-
-      if empty(newname)
+    if !exists("s:netrwmftgt")
+        call netrw#msg#Notify('ERROR', 'your marked file target is empty! (:help netrw-mt)')
         return 0
-      endif
+    endif
 
-      let args = netrw#os#Escape(oldname)
-      let tgt = netrw#os#Escape(s:netrwmftgt.'/'.newname)
+    if a:islocal &&  s:netrwmftgt_islocal
+        " Copy marked files, local directory to local directory
+        if !executable(g:netrw_localcopycmd)
+            call netrw#msg#Notify('ERROR', printf('g:netrw_localcopycmd<%s> not executable on your system, aborting', g:netrw_localcopycmd))
+            return
+        endif
+
+        " copy marked files while within the same directory (ie. allow renaming)
+        if simplify(s:netrwmftgt) ==# simplify(b:netrw_curdir)
+            if len(s:netrwmarkfilelist_{bufnr('%')}) == 1
+                " only one marked file
+                let args    = netrw#os#Escape(b:netrw_curdir.s:netrwmarkfilelist_{bufnr('%')}[0])
+                let oldname = s:netrwmarkfilelist_{bufnr('%')}[0]
+            elseif a:0 == 1
+                " this happens when the next case was used to recursively call s:NetrwMarkFileCopy()
+                let args    = netrw#os#Escape(b:netrw_curdir.a:1)
+                let oldname = a:1
+            else
+                " copy multiple marked files inside the same directory
+                let s:recursive= 1
+                for oldname in s:netrwmarkfilelist_{bufnr("%")}
+                    let ret= s:NetrwMarkFileCopy(a:islocal,oldname)
+                    if ret == 0
+                        break
+                    endif
+                endfor
+                unlet s:recursive
+                call s:NetrwUnmarkList(curbufnr,curdir)
+                return ret
+            endif
+
+            call inputsave()
+            let newname= input(printf("Copy %s to: ", oldname), oldname, 'file')
+            call inputrestore()
+
+            if empty(newname)
+                return 0
+            endif
+
+            let args = netrw#os#Escape(oldname)
+            let tgt = netrw#os#Escape(s:netrwmftgt.'/'.newname)
+        else
+            let args = join(map(deepcopy(s:netrwmarkfilelist_{bufnr('%')}),"netrw#os#Escape(b:netrw_curdir.\"/\".v:val)"))
+            let tgt = netrw#os#Escape(s:netrwmftgt)
+        endif
+
+        if !g:netrw_cygwin && has("win32")
+            let args = substitute(args,'/','\\','g')
+            let tgt = substitute(tgt, '/','\\','g')
+        endif
+
+        if args =~ "'" |let args= substitute(args,"'\\(.*\\)'",'\1','')|endif
+        if tgt  =~ "'" |let tgt = substitute(tgt ,"'\\(.*\\)'",'\1','')|endif
+        if args =~ '//'|let args= substitute(args,'//','/','g')|endif
+        if tgt  =~ '//'|let tgt = substitute(tgt ,'//','/','g')|endif
+
+        let copycmd = g:netrw_localcopycmd
+        let copycmdopt = g:netrw_localcopycmdopt
+
+        if isdirectory(s:NetrwFile(args))
+            let copycmd = g:netrw_localcopydircmd
+            let copycmdopt = g:netrw_localcopydircmdopt
+            if has('win32') && !g:netrw_cygwin
+                " window's xcopy doesn't copy a directory to a target properly.  Instead, it copies a directory's
+                " contents to a target.  One must append the source directory name to the target to get xcopy to
+                " do the right thing.
+                let tgt= tgt.'\'.substitute(a:1,'^.*[\\/]','','')
+            endif
+        endif
+
+        call system(printf("%s %s '%s' '%s'", copycmd, copycmdopt, args, tgt))
+        if v:shell_error != 0
+            if exists("b:netrw_curdir") && b:netrw_curdir != getcwd() && g:netrw_keepdir
+                call netrw#msg#Notify('ERROR', printf("copy failed; perhaps due to vim's current directory<%s> not matching netrw's (%s) (see :help netrw-cd)", getcwd(), b:netrw_curdir))
+            else
+                call netrw#msg#Notify('ERROR', printf("tried using g:netrw_localcopycmd<%s>; it doesn't work!", g:netrw_localcopycmd))
+            endif
+            return 0
+        endif
+
+    elseif  a:islocal && !s:netrwmftgt_islocal
+        " Copy marked files, local directory to remote directory
+        NetrwKeepj call s:NetrwUpload(s:netrwmarkfilelist_{bufnr('%')},s:netrwmftgt)
+
+    elseif !a:islocal &&  s:netrwmftgt_islocal
+        " Copy marked files, remote directory to local directory
+        NetrwKeepj call netrw#Obtain(a:islocal,s:netrwmarkfilelist_{bufnr('%')},s:netrwmftgt)
+
+    elseif !a:islocal && !s:netrwmftgt_islocal
+        " Copy marked files, remote directory to remote directory
+        let curdir = getcwd()
+        let tmpdir = s:GetTempfile("")
+        if tmpdir !~ '/'
+            let tmpdir= curdir."/".tmpdir
+        endif
+        if exists("*mkdir")
+            call mkdir(tmpdir)
+        else
+            call netrw#os#Execute("sil! !".g:netrw_localmkdir.g:netrw_localmkdiropt.' '.netrw#os#Escape(tmpdir,1))
+            if v:shell_error != 0
+                call netrw#msg#Notify('WARNING', printf("consider setting g:netrw_localmkdir<%s> to something that works", g:netrw_localmkdir))
+                return
+            endif
+        endif
+        if isdirectory(s:NetrwFile(tmpdir))
+            if s:NetrwLcd(tmpdir)
+                return
+            endif
+            NetrwKeepj call netrw#Obtain(a:islocal,s:netrwmarkfilelist_{bufnr('%')},tmpdir)
+            let localfiles= map(deepcopy(s:netrwmarkfilelist_{bufnr('%')}),'substitute(v:val,"^.*/","","")')
+            NetrwKeepj call s:NetrwUpload(localfiles,s:netrwmftgt)
+            if getcwd() == tmpdir
+                for fname in s:netrwmarkfilelist_{bufnr('%')}
+                    call netrw#fs#Remove(fname)
+                endfor
+                if s:NetrwLcd(curdir)
+                    return
+                endif
+                if delete(tmpdir,"d")
+                    call netrw#msg#Notify('ERROR', printf('unable to delete directory <%s>!', tmpdir))
+                endif
+            else
+                if s:NetrwLcd(curdir)
+                    return
+                endif
+            endif
+        endif
+    endif
+
+    " -------
+    " cleanup
+    " -------
+    " remove markings from local buffer
+    call s:NetrwUnmarkList(curbufnr,curdir)                   " remove markings from local buffer
+    if exists("s:recursive")
     else
-      let args = join(map(deepcopy(s:netrwmarkfilelist_{bufnr('%')}),"netrw#os#Escape(b:netrw_curdir.\"/\".v:val)"))
-      let tgt = netrw#os#Escape(s:netrwmftgt)
     endif
-
-    if !g:netrw_cygwin && has("win32")
-      let args = substitute(args,'/','\\','g')
-      let tgt = substitute(tgt, '/','\\','g')
-    endif
-
-    if args =~ "'" |let args= substitute(args,"'\\(.*\\)'",'\1','')|endif
-    if tgt  =~ "'" |let tgt = substitute(tgt ,"'\\(.*\\)'",'\1','')|endif
-    if args =~ '//'|let args= substitute(args,'//','/','g')|endif
-    if tgt  =~ '//'|let tgt = substitute(tgt ,'//','/','g')|endif
-
-    let copycmd = g:netrw_localcopycmd
-    let copycmdopt = g:netrw_localcopycmdopt
-
-    if isdirectory(s:NetrwFile(args))
-      let copycmd = g:netrw_localcopydircmd
-      let copycmdopt = g:netrw_localcopydircmdopt
-      if has('win32') && !g:netrw_cygwin
-        " window's xcopy doesn't copy a directory to a target properly.  Instead, it copies a directory's
-        " contents to a target.  One must append the source directory name to the target to get xcopy to
-        " do the right thing.
-        let tgt= tgt.'\'.substitute(a:1,'^.*[\\/]','','')
-      endif
-    endif
-
-    call system(printf("%s %s '%s' '%s'", copycmd, copycmdopt, args, tgt))
-    if v:shell_error != 0
-      if exists("b:netrw_curdir") && b:netrw_curdir != getcwd() && g:netrw_keepdir
-        call netrw#msg#Notify('ERROR', printf("copy failed; perhaps due to vim's current directory<%s> not matching netrw's (%s) (see :help netrw-cd)", getcwd(), b:netrw_curdir))
-      else
-        call netrw#msg#Notify('ERROR', printf("tried using g:netrw_localcopycmd<%s>; it doesn't work!", g:netrw_localcopycmd))
-      endif
-      return 0
-    endif
-
-  elseif  a:islocal && !s:netrwmftgt_islocal
-    " Copy marked files, local directory to remote directory
-    NetrwKeepj call s:NetrwUpload(s:netrwmarkfilelist_{bufnr('%')},s:netrwmftgt)
-
-  elseif !a:islocal &&  s:netrwmftgt_islocal
-    " Copy marked files, remote directory to local directory
-    NetrwKeepj call netrw#Obtain(a:islocal,s:netrwmarkfilelist_{bufnr('%')},s:netrwmftgt)
-
-  elseif !a:islocal && !s:netrwmftgt_islocal
-    " Copy marked files, remote directory to remote directory
-    let curdir = getcwd()
-    let tmpdir = s:GetTempfile("")
-    if tmpdir !~ '/'
-      let tmpdir= curdir."/".tmpdir
-    endif
-    if exists("*mkdir")
-      call mkdir(tmpdir)
+    " see s:LocalFastBrowser() for g:netrw_fastbrowse interpretation (refreshing done for both slow and medium)
+    if g:netrw_fastbrowse <= 1
+        NetrwKeepj call s:LocalBrowseRefresh()
     else
-      call netrw#os#Execute("sil! !".g:netrw_localmkdir.g:netrw_localmkdiropt.' '.netrw#os#Escape(tmpdir,1))
-      if v:shell_error != 0
-        call netrw#msg#Notify('WARNING', printf("consider setting g:netrw_localmkdir<%s> to something that works", g:netrw_localmkdir))
-        return
-      endif
-    endif
-    if isdirectory(s:NetrwFile(tmpdir))
-      if s:NetrwLcd(tmpdir)
-        return
-      endif
-      NetrwKeepj call netrw#Obtain(a:islocal,s:netrwmarkfilelist_{bufnr('%')},tmpdir)
-      let localfiles= map(deepcopy(s:netrwmarkfilelist_{bufnr('%')}),'substitute(v:val,"^.*/","","")')
-      NetrwKeepj call s:NetrwUpload(localfiles,s:netrwmftgt)
-      if getcwd() == tmpdir
-        for fname in s:netrwmarkfilelist_{bufnr('%')}
-          call netrw#fs#Remove(fname)
-        endfor
-        if s:NetrwLcd(curdir)
-          return
+        " refresh local and targets for fast browsing
+        if !exists("s:recursive")
+            " remove markings from local buffer
+            NetrwKeepj call s:NetrwUnmarkList(curbufnr,curdir)
         endif
-        if delete(tmpdir,"d")
-          call netrw#msg#Notify('ERROR', printf('unable to delete directory <%s>!', tmpdir))
-        endif
-      else
-        if s:NetrwLcd(curdir)
-          return
-        endif
-      endif
-    endif
-  endif
 
-  " -------
-  " cleanup
-  " -------
-  " remove markings from local buffer
-  call s:NetrwUnmarkList(curbufnr,curdir)                   " remove markings from local buffer
-  if exists("s:recursive")
-  else
-  endif
-  " see s:LocalFastBrowser() for g:netrw_fastbrowse interpretation (refreshing done for both slow and medium)
-  if g:netrw_fastbrowse <= 1
-    NetrwKeepj call s:LocalBrowseRefresh()
-  else
-    " refresh local and targets for fast browsing
-    if !exists("s:recursive")
-      " remove markings from local buffer
-      NetrwKeepj call s:NetrwUnmarkList(curbufnr,curdir)
+        " refresh buffers
+        if s:netrwmftgt_islocal
+            NetrwKeepj call s:NetrwRefreshDir(s:netrwmftgt_islocal,s:netrwmftgt)
+        endif
+        if a:islocal && s:netrwmftgt != curdir
+            NetrwKeepj call s:NetrwRefreshDir(a:islocal,curdir)
+        endif
     endif
 
-    " refresh buffers
-    if s:netrwmftgt_islocal
-      NetrwKeepj call s:NetrwRefreshDir(s:netrwmftgt_islocal,s:netrwmftgt)
-    endif
-    if a:islocal && s:netrwmftgt != curdir
-      NetrwKeepj call s:NetrwRefreshDir(a:islocal,curdir)
-    endif
-  endif
-
-  return 1
+    return 1
 endfun
 
 " s:NetrwMarkFileDiff: (invoked by md) This function is used to {{{2
@@ -5712,32 +5684,32 @@ endfun
 "                      Either two or three files can be so handled.
 "                      Uses the global marked file list.
 fun! s:NetrwMarkFileDiff(islocal)
-  let curbufnr= bufnr("%")
+    let curbufnr= bufnr("%")
 
-  " sanity check
-  if !exists("s:netrwmarkfilelist_{curbufnr}") || empty(s:netrwmarkfilelist_{curbufnr})
-    call netrw#msg#Notify('ERROR', 'there are no marked files in this window (:help netrw-mf)')
-    return
-  endif
-  let curdir= s:NetrwGetCurdir(a:islocal)
+    " sanity check
+    if !exists("s:netrwmarkfilelist_{curbufnr}") || empty(s:netrwmarkfilelist_{curbufnr})
+        call netrw#msg#Notify('ERROR', 'there are no marked files in this window (:help netrw-mf)')
+        return
+    endif
+    let curdir= s:NetrwGetCurdir(a:islocal)
 
-  if exists("s:netrwmarkfilelist_{".curbufnr."}")
-    let cnt    = 0
-    for fname in s:netrwmarkfilelist
-      let cnt= cnt + 1
-      if cnt == 1
-        exe "NetrwKeepj e ".fnameescape(fname)
-        diffthis
-      elseif cnt == 2 || cnt == 3
-        below vsplit
-        exe "NetrwKeepj e ".fnameescape(fname)
-        diffthis
-      else
-        break
-      endif
-    endfor
-    call s:NetrwUnmarkList(curbufnr,curdir)
-  endif
+    if exists("s:netrwmarkfilelist_{".curbufnr."}")
+        let cnt    = 0
+        for fname in s:netrwmarkfilelist
+            let cnt= cnt + 1
+            if cnt == 1
+                exe "NetrwKeepj e ".fnameescape(fname)
+                diffthis
+            elseif cnt == 2 || cnt == 3
+                below vsplit
+                exe "NetrwKeepj e ".fnameescape(fname)
+                diffthis
+            else
+                break
+            endif
+        endfor
+        call s:NetrwUnmarkList(curbufnr,curdir)
+    endif
 
 endfun
 
@@ -5745,48 +5717,48 @@ endfun
 "                       Uses global markfilelist
 fun! s:NetrwMarkFileEdit(islocal)
 
-  let curdir   = s:NetrwGetCurdir(a:islocal)
-  let curbufnr = bufnr("%")
+    let curdir   = s:NetrwGetCurdir(a:islocal)
+    let curbufnr = bufnr("%")
 
-  " sanity check
-  if !exists("s:netrwmarkfilelist_{curbufnr}") || empty(s:netrwmarkfilelist_{curbufnr})
-    call netrw#msg#Notify('ERROR', 'there are no marked files in this window (:help netrw-mf)')
-    return
-  endif
+    " sanity check
+    if !exists("s:netrwmarkfilelist_{curbufnr}") || empty(s:netrwmarkfilelist_{curbufnr})
+        call netrw#msg#Notify('ERROR', 'there are no marked files in this window (:help netrw-mf)')
+        return
+    endif
 
-  if exists("s:netrwmarkfilelist_{curbufnr}")
-    call s:SetRexDir(a:islocal,curdir)
-    let flist= join(map(deepcopy(s:netrwmarkfilelist), "fnameescape(v:val)"))
-    " unmark markedfile list
-    "   call s:NetrwUnmarkList(curbufnr,curdir)
-    call s:NetrwUnmarkAll()
-    exe "sil args ".flist
-  endif
-  echo "(use :bn, :bp to navigate files; :Rex to return)"
+    if exists("s:netrwmarkfilelist_{curbufnr}")
+        call s:SetRexDir(a:islocal,curdir)
+        let flist= join(map(deepcopy(s:netrwmarkfilelist), "fnameescape(v:val)"))
+        " unmark markedfile list
+        "   call s:NetrwUnmarkList(curbufnr,curdir)
+        call s:NetrwUnmarkAll()
+        exe "sil args ".flist
+    endif
+    echo "(use :bn, :bp to navigate files; :Rex to return)"
 
 endfun
 
 " s:NetrwMarkFileQFEL: convert a quickfix-error or location list into a marked file list {{{2
 fun! s:NetrwMarkFileQFEL(islocal,qfel)
-  call s:NetrwUnmarkAll()
-  let curbufnr= bufnr("%")
+    call s:NetrwUnmarkAll()
+    let curbufnr= bufnr("%")
 
-  if !empty(a:qfel)
-    for entry in a:qfel
-      let bufnmbr= entry["bufnr"]
-      if !exists("s:netrwmarkfilelist_{curbufnr}")
-        call s:NetrwMarkFile(a:islocal,bufname(bufnmbr))
-      elseif index(s:netrwmarkfilelist_{curbufnr},bufname(bufnmbr)) == -1
-        " s:NetrwMarkFile will remove duplicate entries from the marked file list.
-        " So, this test lets two or more hits on the same pattern to be ignored.
-        call s:NetrwMarkFile(a:islocal,bufname(bufnmbr))
-      else
-      endif
-    endfor
-    echo "(use me to edit marked files)"
-  else
-    call netrw#msg#Notify('WARNING', "can't convert quickfix error list; its empty!")
-  endif
+    if !empty(a:qfel)
+        for entry in a:qfel
+            let bufnmbr= entry["bufnr"]
+            if !exists("s:netrwmarkfilelist_{curbufnr}")
+                call s:NetrwMarkFile(a:islocal,bufname(bufnmbr))
+            elseif index(s:netrwmarkfilelist_{curbufnr},bufname(bufnmbr)) == -1
+                " s:NetrwMarkFile will remove duplicate entries from the marked file list.
+                " So, this test lets two or more hits on the same pattern to be ignored.
+                call s:NetrwMarkFile(a:islocal,bufname(bufnmbr))
+            else
+            endif
+        endfor
+        echo "(use me to edit marked files)"
+    else
+        call netrw#msg#Notify('WARNING', "can't convert quickfix error list; its empty!")
+    endif
 
 endfun
 
@@ -5794,297 +5766,297 @@ endfun
 "                     mx enbloc=0: Uses the local marked-file list, applies command to each file individually
 "                     mX enbloc=1: Uses the global marked-file list, applies command to entire list
 fun! s:NetrwMarkFileExe(islocal,enbloc)
-  let svpos    = winsaveview()
-  let curdir   = s:NetrwGetCurdir(a:islocal)
-  let curbufnr = bufnr("%")
+    let svpos    = winsaveview()
+    let curdir   = s:NetrwGetCurdir(a:islocal)
+    let curbufnr = bufnr("%")
 
-  if a:enbloc == 0
-    " individually apply command to files, one at a time
-    " sanity check
-    if !exists("s:netrwmarkfilelist_{curbufnr}") || empty(s:netrwmarkfilelist_{curbufnr})
-      call netrw#msg#Notify('ERROR', 'there are no marked files in this window (:help netrw-mf)')
-      return
-    endif
+    if a:enbloc == 0
+        " individually apply command to files, one at a time
+        " sanity check
+        if !exists("s:netrwmarkfilelist_{curbufnr}") || empty(s:netrwmarkfilelist_{curbufnr})
+            call netrw#msg#Notify('ERROR', 'there are no marked files in this window (:help netrw-mf)')
+            return
+        endif
 
-    if exists("s:netrwmarkfilelist_{curbufnr}")
-      " get the command
-      call inputsave()
-      let cmd= input("Enter command: ","","file")
-      call inputrestore()
-      if cmd == ""
-        return
-      endif
+        if exists("s:netrwmarkfilelist_{curbufnr}")
+            " get the command
+            call inputsave()
+            let cmd= input("Enter command: ","","file")
+            call inputrestore()
+            if cmd == ""
+                return
+            endif
 
-      " apply command to marked files, individually.  Substitute: filename -> %
-      " If no %, then append a space and the filename to the command
-      for fname in s:netrwmarkfilelist_{curbufnr}
-        if a:islocal
-          if g:netrw_keepdir
-            let fname= netrw#os#Escape(netrw#fs#WinPath(netrw#fs#ComposePath(curdir,fname)))
-          endif
+            " apply command to marked files, individually.  Substitute: filename -> %
+            " If no %, then append a space and the filename to the command
+            for fname in s:netrwmarkfilelist_{curbufnr}
+                if a:islocal
+                    if g:netrw_keepdir
+                        let fname= netrw#os#Escape(netrw#fs#WinPath(netrw#fs#ComposePath(curdir,fname)))
+                    endif
+                else
+                    let fname= netrw#os#Escape(netrw#fs#WinPath(b:netrw_curdir.fname))
+                endif
+                if cmd =~ '%'
+                    let xcmd= substitute(cmd,'%',fname,'g')
+                else
+                    let xcmd= cmd.' '.fname
+                endif
+                if a:islocal
+                    let ret= system(xcmd)
+                else
+                    let ret= s:RemoteSystem(xcmd)
+                endif
+                if v:shell_error < 0
+                    call netrw#msg#Notify('ERROR', printf('command<%s> failed, aborting', xcmd))
+                    break
+                else
+                    if ret !=# ''
+                        echo "\n"
+                        " skip trailing new line
+                        echo ret[0:-2]
+                    else
+                        echo ret
+                    endif
+                endif
+            endfor
+
+            " unmark marked file list
+            call s:NetrwUnmarkList(curbufnr,curdir)
+
+            " refresh the listing
+            NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
+            NetrwKeepj call winrestview(svpos)
         else
-          let fname= netrw#os#Escape(netrw#fs#WinPath(b:netrw_curdir.fname))
+            call netrw#msg#Notify('ERROR', 'no files marked!')
+        endif
+
+    else " apply command to global list of files, en bloc
+
+        call inputsave()
+        let cmd= input("Enter command: ","","file")
+        call inputrestore()
+        if cmd == ""
+            return
         endif
         if cmd =~ '%'
-          let xcmd= substitute(cmd,'%',fname,'g')
+            let cmd= substitute(cmd,'%',join(map(s:netrwmarkfilelist,'netrw#os#Escape(v:val)'),' '),'g')
         else
-          let xcmd= cmd.' '.fname
+            let cmd= cmd.' '.join(map(s:netrwmarkfilelist,'netrw#os#Escape(v:val)'),' ')
         endif
         if a:islocal
-          let ret= system(xcmd)
+            call system(cmd)
+            if v:shell_error < 0
+                call netrw#msg#Notify('ERROR', printf('command<%s> failed, aborting',xcmd))
+            endif
         else
-          let ret= s:RemoteSystem(xcmd)
+            let ret= s:RemoteSystem(cmd)
         endif
-        if v:shell_error < 0
-          call netrw#msg#Notify('ERROR', printf('command<%s> failed, aborting', xcmd))
-          break
-        else
-          if ret !=# ''
-            echo "\n"
-            " skip trailing new line
-            echo ret[0:-2]
-          else
-            echo ret
-          endif
-        endif
-      endfor
+        call s:NetrwUnmarkAll()
 
-      " unmark marked file list
-      call s:NetrwUnmarkList(curbufnr,curdir)
+        " refresh the listing
+        NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
+        NetrwKeepj call winrestview(svpos)
 
-      " refresh the listing
-      NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
-      NetrwKeepj call winrestview(svpos)
-    else
-      call netrw#msg#Notify('ERROR', 'no files marked!')
     endif
-
-  else " apply command to global list of files, en bloc
-
-    call inputsave()
-    let cmd= input("Enter command: ","","file")
-    call inputrestore()
-    if cmd == ""
-      return
-    endif
-    if cmd =~ '%'
-      let cmd= substitute(cmd,'%',join(map(s:netrwmarkfilelist,'netrw#os#Escape(v:val)'),' '),'g')
-    else
-      let cmd= cmd.' '.join(map(s:netrwmarkfilelist,'netrw#os#Escape(v:val)'),' ')
-    endif
-    if a:islocal
-      call system(cmd)
-      if v:shell_error < 0
-        call netrw#msg#Notify('ERROR', printf('command<%s> failed, aborting',xcmd))
-      endif
-    else
-      let ret= s:RemoteSystem(cmd)
-    endif
-    call s:NetrwUnmarkAll()
-
-    " refresh the listing
-    NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
-    NetrwKeepj call winrestview(svpos)
-
-  endif
 endfun
 
 " s:NetrwMarkHideSfx: (invoked by mh) (un)hide files having same suffix
 "                  as the marked file(s) (toggles suffix presence)
 "                  Uses the local marked file list.
 fun! s:NetrwMarkHideSfx(islocal)
-  let svpos    = winsaveview()
-  let curbufnr = bufnr("%")
+    let svpos    = winsaveview()
+    let curbufnr = bufnr("%")
 
-  " s:netrwmarkfilelist_{curbufnr}: the List of marked files
-  if exists("s:netrwmarkfilelist_{curbufnr}")
+    " s:netrwmarkfilelist_{curbufnr}: the List of marked files
+    if exists("s:netrwmarkfilelist_{curbufnr}")
 
-    for fname in s:netrwmarkfilelist_{curbufnr}
-      " construct suffix pattern
-      if fname =~ '\.'
-        let sfxpat= "^.*".substitute(fname,'^.*\(\.[^. ]\+\)$','\1','')
-      else
-        let sfxpat= '^\%(\%(\.\)\@!.\)*$'
-      endif
-      " determine if its in the hiding list or not
-      let inhidelist= 0
-      if g:netrw_list_hide != ""
-        let itemnum = 0
-        let hidelist= split(g:netrw_list_hide,',')
-        for hidepat in hidelist
-          if sfxpat == hidepat
-            let inhidelist= 1
-            break
-          endif
-          let itemnum= itemnum + 1
+        for fname in s:netrwmarkfilelist_{curbufnr}
+            " construct suffix pattern
+            if fname =~ '\.'
+                let sfxpat= "^.*".substitute(fname,'^.*\(\.[^. ]\+\)$','\1','')
+            else
+                let sfxpat= '^\%(\%(\.\)\@!.\)*$'
+            endif
+            " determine if its in the hiding list or not
+            let inhidelist= 0
+            if g:netrw_list_hide != ""
+                let itemnum = 0
+                let hidelist= split(g:netrw_list_hide,',')
+                for hidepat in hidelist
+                    if sfxpat == hidepat
+                        let inhidelist= 1
+                        break
+                    endif
+                    let itemnum= itemnum + 1
+                endfor
+            endif
+            if inhidelist
+                " remove sfxpat from list
+                call remove(hidelist,itemnum)
+                let g:netrw_list_hide= join(hidelist,",")
+            elseif g:netrw_list_hide != ""
+                " append sfxpat to non-empty list
+                let g:netrw_list_hide= g:netrw_list_hide.",".sfxpat
+            else
+                " set hiding list to sfxpat
+                let g:netrw_list_hide= sfxpat
+            endif
         endfor
-      endif
-      if inhidelist
-        " remove sfxpat from list
-        call remove(hidelist,itemnum)
-        let g:netrw_list_hide= join(hidelist,",")
-      elseif g:netrw_list_hide != ""
-        " append sfxpat to non-empty list
-        let g:netrw_list_hide= g:netrw_list_hide.",".sfxpat
-      else
-        " set hiding list to sfxpat
-        let g:netrw_list_hide= sfxpat
-      endif
-    endfor
 
-    " refresh the listing
-    NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
-    NetrwKeepj call winrestview(svpos)
-  else
-    call netrw#msg#Notify('ERROR', 'no files marked!')
-  endif
+        " refresh the listing
+        NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
+        NetrwKeepj call winrestview(svpos)
+    else
+        call netrw#msg#Notify('ERROR', 'no files marked!')
+    endif
 endfun
 
 " s:NetrwMarkFileVimCmd: (invoked by mv) execute arbitrary vim command on marked files, one at a time {{{2
 "                     Uses the local marked-file list.
 fun! s:NetrwMarkFileVimCmd(islocal)
-  let svpos    = winsaveview()
-  let curdir   = s:NetrwGetCurdir(a:islocal)
-  let curbufnr = bufnr("%")
+    let svpos    = winsaveview()
+    let curdir   = s:NetrwGetCurdir(a:islocal)
+    let curbufnr = bufnr("%")
 
-  " sanity check
-  if !exists("s:netrwmarkfilelist_{curbufnr}") || empty(s:netrwmarkfilelist_{curbufnr})
-    call netrw#msg#Notify('ERROR', 'there are no marked files in this window (:help netrw-mf)')
-    return
-  endif
-
-  if exists("s:netrwmarkfilelist_{curbufnr}")
-    " get the command
-    call inputsave()
-    let cmd= input("Enter vim command: ","","file")
-    call inputrestore()
-    if cmd == ""
-      return
+    " sanity check
+    if !exists("s:netrwmarkfilelist_{curbufnr}") || empty(s:netrwmarkfilelist_{curbufnr})
+        call netrw#msg#Notify('ERROR', 'there are no marked files in this window (:help netrw-mf)')
+        return
     endif
 
-    " apply command to marked files.  Substitute: filename -> %
-    " If no %, then append a space and the filename to the command
-    for fname in s:netrwmarkfilelist_{curbufnr}
-      if a:islocal
-        1split
-        exe "sil! NetrwKeepj keepalt e ".fnameescape(fname)
-        exe cmd
-        exe "sil! keepalt wq!"
-      else
-        echo "sorry, \"mv\" not supported yet for remote files"
-      endif
-    endfor
+    if exists("s:netrwmarkfilelist_{curbufnr}")
+        " get the command
+        call inputsave()
+        let cmd= input("Enter vim command: ","","file")
+        call inputrestore()
+        if cmd == ""
+            return
+        endif
 
-    " unmark marked file list
-    call s:NetrwUnmarkList(curbufnr,curdir)
+        " apply command to marked files.  Substitute: filename -> %
+        " If no %, then append a space and the filename to the command
+        for fname in s:netrwmarkfilelist_{curbufnr}
+            if a:islocal
+                1split
+                exe "sil! NetrwKeepj keepalt e ".fnameescape(fname)
+                exe cmd
+                exe "sil! keepalt wq!"
+            else
+                echo "sorry, \"mv\" not supported yet for remote files"
+            endif
+        endfor
 
-    " refresh the listing
-    NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
-    NetrwKeepj call winrestview(svpos)
-  else
-    call netrw#msg#Notify('ERROR', 'no files marked!')
-  endif
+        " unmark marked file list
+        call s:NetrwUnmarkList(curbufnr,curdir)
+
+        " refresh the listing
+        NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
+        NetrwKeepj call winrestview(svpos)
+    else
+        call netrw#msg#Notify('ERROR', 'no files marked!')
+    endif
 endfun
 
 " s:NetrwMarkHideSfx: (invoked by mh) (un)hide files having same suffix
 "                  as the marked file(s) (toggles suffix presence)
 "                  Uses the local marked file list.
 fun! s:NetrwMarkHideSfx(islocal)
-  let svpos    = winsaveview()
-  let curbufnr = bufnr("%")
+    let svpos    = winsaveview()
+    let curbufnr = bufnr("%")
 
-  " s:netrwmarkfilelist_{curbufnr}: the List of marked files
-  if exists("s:netrwmarkfilelist_{curbufnr}")
+    " s:netrwmarkfilelist_{curbufnr}: the List of marked files
+    if exists("s:netrwmarkfilelist_{curbufnr}")
 
-    for fname in s:netrwmarkfilelist_{curbufnr}
-      " construct suffix pattern
-      if fname =~ '\.'
-        let sfxpat= "^.*".substitute(fname,'^.*\(\.[^. ]\+\)$','\1','')
-      else
-        let sfxpat= '^\%(\%(\.\)\@!.\)*$'
-      endif
-      " determine if its in the hiding list or not
-      let inhidelist= 0
-      if g:netrw_list_hide != ""
-        let itemnum = 0
-        let hidelist= split(g:netrw_list_hide,',')
-        for hidepat in hidelist
-          if sfxpat == hidepat
-            let inhidelist= 1
-            break
-          endif
-          let itemnum= itemnum + 1
+        for fname in s:netrwmarkfilelist_{curbufnr}
+            " construct suffix pattern
+            if fname =~ '\.'
+                let sfxpat= "^.*".substitute(fname,'^.*\(\.[^. ]\+\)$','\1','')
+            else
+                let sfxpat= '^\%(\%(\.\)\@!.\)*$'
+            endif
+            " determine if its in the hiding list or not
+            let inhidelist= 0
+            if g:netrw_list_hide != ""
+                let itemnum = 0
+                let hidelist= split(g:netrw_list_hide,',')
+                for hidepat in hidelist
+                    if sfxpat == hidepat
+                        let inhidelist= 1
+                        break
+                    endif
+                    let itemnum= itemnum + 1
+                endfor
+            endif
+            if inhidelist
+                " remove sfxpat from list
+                call remove(hidelist,itemnum)
+                let g:netrw_list_hide= join(hidelist,",")
+            elseif g:netrw_list_hide != ""
+                " append sfxpat to non-empty list
+                let g:netrw_list_hide= g:netrw_list_hide.",".sfxpat
+            else
+                " set hiding list to sfxpat
+                let g:netrw_list_hide= sfxpat
+            endif
         endfor
-      endif
-      if inhidelist
-        " remove sfxpat from list
-        call remove(hidelist,itemnum)
-        let g:netrw_list_hide= join(hidelist,",")
-      elseif g:netrw_list_hide != ""
-        " append sfxpat to non-empty list
-        let g:netrw_list_hide= g:netrw_list_hide.",".sfxpat
-      else
-        " set hiding list to sfxpat
-        let g:netrw_list_hide= sfxpat
-      endif
-    endfor
 
-    " refresh the listing
-    NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
-    NetrwKeepj call winrestview(svpos)
-  else
-    call netrw#msg#Notify('ERROR', 'no files marked!')
-  endif
+        " refresh the listing
+        NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
+        NetrwKeepj call winrestview(svpos)
+    else
+        call netrw#msg#Notify('ERROR', 'no files marked!')
+    endif
 endfun
 
 " s:NetrwMarkFileGrep: (invoked by mg) This function applies vimgrep to marked files {{{2
 "                     Uses the global markfilelist
 fun! s:NetrwMarkFileGrep(islocal)
-  let svpos    = winsaveview()
-  let curbufnr = bufnr("%")
-  let curdir   = s:NetrwGetCurdir(a:islocal)
+    let svpos    = winsaveview()
+    let curbufnr = bufnr("%")
+    let curdir   = s:NetrwGetCurdir(a:islocal)
 
-  if exists("s:netrwmarkfilelist")
-    let netrwmarkfilelist= join(map(deepcopy(s:netrwmarkfilelist), "fnameescape(v:val)"))
-    call s:NetrwUnmarkAll()
-  else
-    let netrwmarkfilelist= "*"
-  endif
-
-  " ask user for pattern
-  call inputsave()
-  let pat= input("Enter pattern: ","")
-  call inputrestore()
-  let patbang = ""
-  if pat =~ '^!'
-    let patbang = "!"
-    let pat     = strpart(pat,2)
-  endif
-  if pat =~ '^\i'
-    let pat    = escape(pat,'/')
-    let pat    = '/'.pat.'/'
-  else
-    let nonisi = pat[0]
-  endif
-
-  " use vimgrep for both local and remote
-  try
-    exe "NetrwKeepj noautocmd vimgrep".patbang." ".pat." ".netrwmarkfilelist
-  catch /^Vim\%((\a\+)\)\=:E480/
-    call netrw#msg#Notify('WARNING', printf('no match with pattern<%s>', pat))
-    return
-  endtry
-  echo "(use :cn, :cp to navigate, :Rex to return)"
-
-  2match none
-  NetrwKeepj call winrestview(svpos)
-
-  if exists("nonisi")
-    " original, user-supplied pattern did not begin with a character from isident
-    if pat =~# nonisi.'j$\|'.nonisi.'gj$\|'.nonisi.'jg$'
-      call s:NetrwMarkFileQFEL(a:islocal,getqflist())
+    if exists("s:netrwmarkfilelist")
+        let netrwmarkfilelist= join(map(deepcopy(s:netrwmarkfilelist), "fnameescape(v:val)"))
+        call s:NetrwUnmarkAll()
+    else
+        let netrwmarkfilelist= "*"
     endif
-  endif
+
+    " ask user for pattern
+    call inputsave()
+    let pat= input("Enter pattern: ","")
+    call inputrestore()
+    let patbang = ""
+    if pat =~ '^!'
+        let patbang = "!"
+        let pat     = strpart(pat,2)
+    endif
+    if pat =~ '^\i'
+        let pat    = escape(pat,'/')
+        let pat    = '/'.pat.'/'
+    else
+        let nonisi = pat[0]
+    endif
+
+    " use vimgrep for both local and remote
+    try
+        exe "NetrwKeepj noautocmd vimgrep".patbang." ".pat." ".netrwmarkfilelist
+    catch /^Vim\%((\a\+)\)\=:E480/
+        call netrw#msg#Notify('WARNING', printf('no match with pattern<%s>', pat))
+        return
+    endtry
+    echo "(use :cn, :cp to navigate, :Rex to return)"
+
+    2match none
+    NetrwKeepj call winrestview(svpos)
+
+    if exists("nonisi")
+        " original, user-supplied pattern did not begin with a character from isident
+        if pat =~# nonisi.'j$\|'.nonisi.'gj$\|'.nonisi.'jg$'
+            call s:NetrwMarkFileQFEL(a:islocal,getqflist())
+        endif
+    endif
 
 endfun
 
@@ -6093,140 +6065,140 @@ endfun
 "                      s:netrwmfloc= 0: target directory is remote
 "                                  = 1: target directory is local
 fun! s:NetrwMarkFileMove(islocal)
-  let curdir   = s:NetrwGetCurdir(a:islocal)
-  let curbufnr = bufnr("%")
+    let curdir   = s:NetrwGetCurdir(a:islocal)
+    let curbufnr = bufnr("%")
 
-  " sanity check
-  if !exists("s:netrwmarkfilelist_{curbufnr}") || empty(s:netrwmarkfilelist_{curbufnr})
-    call netrw#msg#Notify('ERROR', 'there are no marked files in this window (:help netrw-mf)')
-    return
-  endif
-
-  if !exists("s:netrwmftgt")
-    call netrw#msg#Notify('ERROR', 'your marked file target is empty! (:help netrw-mt)')
-    return 0
-  endif
-
-  if      a:islocal &&  s:netrwmftgt_islocal
-    " move: local -> local
-    if !executable(g:netrw_localmovecmd)
-      call netrw#msg#Notify('ERROR', printf('g:netrw_localmovecmd<%s> not executable on your system, aborting', g:netrw_localmovecmd))
-      return
+    " sanity check
+    if !exists("s:netrwmarkfilelist_{curbufnr}") || empty(s:netrwmarkfilelist_{curbufnr})
+        call netrw#msg#Notify('ERROR', 'there are no marked files in this window (:help netrw-mf)')
+        return
     endif
-    let tgt = netrw#os#Escape(s:netrwmftgt)
-    if !g:netrw_cygwin && has("win32")
-      let tgt= substitute(tgt, '/','\\','g')
-      if g:netrw_localmovecmd =~ '\s'
-        let movecmd     = substitute(g:netrw_localmovecmd,'\s.*$','','')
-        let movecmdargs = substitute(g:netrw_localmovecmd,'^.\{-}\(\s.*\)$','\1','')
-        let movecmd     = netrw#fs#WinPath(movecmd).movecmdargs
-      else
-        let movecmd = netrw#fs#WinPath(g:netrw_localmovecmd)
-      endif
-    else
-      let movecmd = netrw#fs#WinPath(g:netrw_localmovecmd)
+
+    if !exists("s:netrwmftgt")
+        call netrw#msg#Notify('ERROR', 'your marked file target is empty! (:help netrw-mt)')
+        return 0
     endif
-    for fname in s:netrwmarkfilelist_{bufnr("%")}
-      if g:netrw_keepdir
-        " Jul 19, 2022: fixing file move when g:netrw_keepdir is 1
-        let fname= b:netrw_curdir."/".fname
-      endif
-      if !g:netrw_cygwin && has("win32")
-        let fname= substitute(fname,'/','\\','g')
-      endif
-      let ret= system(movecmd.g:netrw_localmovecmdopt." ".netrw#os#Escape(fname)." ".tgt)
-      if v:shell_error != 0
-        if exists("b:netrw_curdir") && b:netrw_curdir != getcwd() && !g:netrw_keepdir
-          call netrw#msg#Notify('ERROR', printf("move failed; perhaps due to vim's current directory<%s> not matching netrw's (%s) (see :help netrw-cd)", getcwd(), b:netrw_curdir))
-        else
-          call netrw#msg#Notify('ERROR', printf("tried using g:netrw_localmovecmd<%s>; it doesn't work!", g:netrw_localmovecmd))
+
+    if      a:islocal &&  s:netrwmftgt_islocal
+        " move: local -> local
+        if !executable(g:netrw_localmovecmd)
+            call netrw#msg#Notify('ERROR', printf('g:netrw_localmovecmd<%s> not executable on your system, aborting', g:netrw_localmovecmd))
+            return
         endif
-        break
-      endif
-    endfor
+        let tgt = netrw#os#Escape(s:netrwmftgt)
+        if !g:netrw_cygwin && has("win32")
+            let tgt= substitute(tgt, '/','\\','g')
+            if g:netrw_localmovecmd =~ '\s'
+                let movecmd     = substitute(g:netrw_localmovecmd,'\s.*$','','')
+                let movecmdargs = substitute(g:netrw_localmovecmd,'^.\{-}\(\s.*\)$','\1','')
+                let movecmd     = netrw#fs#WinPath(movecmd).movecmdargs
+            else
+                let movecmd = netrw#fs#WinPath(g:netrw_localmovecmd)
+            endif
+        else
+            let movecmd = netrw#fs#WinPath(g:netrw_localmovecmd)
+        endif
+        for fname in s:netrwmarkfilelist_{bufnr("%")}
+            if g:netrw_keepdir
+                " Jul 19, 2022: fixing file move when g:netrw_keepdir is 1
+                let fname= b:netrw_curdir."/".fname
+            endif
+            if !g:netrw_cygwin && has("win32")
+                let fname= substitute(fname,'/','\\','g')
+            endif
+            let ret= system(movecmd.g:netrw_localmovecmdopt." ".netrw#os#Escape(fname)." ".tgt)
+            if v:shell_error != 0
+                if exists("b:netrw_curdir") && b:netrw_curdir != getcwd() && !g:netrw_keepdir
+                    call netrw#msg#Notify('ERROR', printf("move failed; perhaps due to vim's current directory<%s> not matching netrw's (%s) (see :help netrw-cd)", getcwd(), b:netrw_curdir))
+                else
+                    call netrw#msg#Notify('ERROR', printf("tried using g:netrw_localmovecmd<%s>; it doesn't work!", g:netrw_localmovecmd))
+                endif
+                break
+            endif
+        endfor
 
-  elseif  a:islocal && !s:netrwmftgt_islocal
-    " move: local -> remote
-    let mflist= s:netrwmarkfilelist_{bufnr("%")}
-    NetrwKeepj call s:NetrwMarkFileCopy(a:islocal)
-    for fname in mflist
-      let barefname = substitute(fname,'^\(.*/\)\(.\{-}\)$','\2','')
-      let ok        = s:NetrwLocalRmFile(b:netrw_curdir,barefname,1)
-    endfor
-    unlet mflist
+    elseif  a:islocal && !s:netrwmftgt_islocal
+        " move: local -> remote
+        let mflist= s:netrwmarkfilelist_{bufnr("%")}
+        NetrwKeepj call s:NetrwMarkFileCopy(a:islocal)
+        for fname in mflist
+            let barefname = substitute(fname,'^\(.*/\)\(.\{-}\)$','\2','')
+            let ok        = s:NetrwLocalRmFile(b:netrw_curdir,barefname,1)
+        endfor
+        unlet mflist
 
-  elseif !a:islocal &&  s:netrwmftgt_islocal
-    " move: remote -> local
-    let mflist= s:netrwmarkfilelist_{bufnr("%")}
-    NetrwKeepj call s:NetrwMarkFileCopy(a:islocal)
-    for fname in mflist
-      let barefname = substitute(fname,'^\(.*/\)\(.\{-}\)$','\2','')
-      let ok        = s:NetrwRemoteRmFile(b:netrw_curdir,barefname,1)
-    endfor
-    unlet mflist
+    elseif !a:islocal &&  s:netrwmftgt_islocal
+        " move: remote -> local
+        let mflist= s:netrwmarkfilelist_{bufnr("%")}
+        NetrwKeepj call s:NetrwMarkFileCopy(a:islocal)
+        for fname in mflist
+            let barefname = substitute(fname,'^\(.*/\)\(.\{-}\)$','\2','')
+            let ok        = s:NetrwRemoteRmFile(b:netrw_curdir,barefname,1)
+        endfor
+        unlet mflist
 
-  elseif !a:islocal && !s:netrwmftgt_islocal
-    " move: remote -> remote
-    let mflist= s:netrwmarkfilelist_{bufnr("%")}
-    NetrwKeepj call s:NetrwMarkFileCopy(a:islocal)
-    for fname in mflist
-      let barefname = substitute(fname,'^\(.*/\)\(.\{-}\)$','\2','')
-      let ok        = s:NetrwRemoteRmFile(b:netrw_curdir,barefname,1)
-    endfor
-    unlet mflist
-  endif
+    elseif !a:islocal && !s:netrwmftgt_islocal
+        " move: remote -> remote
+        let mflist= s:netrwmarkfilelist_{bufnr("%")}
+        NetrwKeepj call s:NetrwMarkFileCopy(a:islocal)
+        for fname in mflist
+            let barefname = substitute(fname,'^\(.*/\)\(.\{-}\)$','\2','')
+            let ok        = s:NetrwRemoteRmFile(b:netrw_curdir,barefname,1)
+        endfor
+        unlet mflist
+    endif
 
-  " -------
-  " cleanup
-  " -------
+    " -------
+    " cleanup
+    " -------
 
-  " remove markings from local buffer
-  call s:NetrwUnmarkList(curbufnr,curdir)                   " remove markings from local buffer
+    " remove markings from local buffer
+    call s:NetrwUnmarkList(curbufnr,curdir)                   " remove markings from local buffer
 
-  " refresh buffers
-  if !s:netrwmftgt_islocal
-    NetrwKeepj call s:NetrwRefreshDir(s:netrwmftgt_islocal,s:netrwmftgt)
-  endif
-  if a:islocal
-    NetrwKeepj call s:NetrwRefreshDir(a:islocal,b:netrw_curdir)
-  endif
-  if g:netrw_fastbrowse <= 1
-    NetrwKeepj call s:LocalBrowseRefresh()
-  endif
+    " refresh buffers
+    if !s:netrwmftgt_islocal
+        NetrwKeepj call s:NetrwRefreshDir(s:netrwmftgt_islocal,s:netrwmftgt)
+    endif
+    if a:islocal
+        NetrwKeepj call s:NetrwRefreshDir(a:islocal,b:netrw_curdir)
+    endif
+    if g:netrw_fastbrowse <= 1
+        NetrwKeepj call s:LocalBrowseRefresh()
+    endif
 
 endfun
 
 " s:NetrwMarkFilePrint: (invoked by mp) This function prints marked files {{{2
 "                       using the hardcopy command.  Local marked-file list only.
 fun! s:NetrwMarkFilePrint(islocal)
-  let curbufnr= bufnr("%")
+    let curbufnr= bufnr("%")
 
-  " sanity check
-  if !exists("s:netrwmarkfilelist_{curbufnr}") || empty(s:netrwmarkfilelist_{curbufnr})
-    call netrw#msg#Notify('ERROR', 'there are no marked files in this window (:help netrw-mf)')
-    return
-  endif
-  let curdir= s:NetrwGetCurdir(a:islocal)
+    " sanity check
+    if !exists("s:netrwmarkfilelist_{curbufnr}") || empty(s:netrwmarkfilelist_{curbufnr})
+        call netrw#msg#Notify('ERROR', 'there are no marked files in this window (:help netrw-mf)')
+        return
+    endif
+    let curdir= s:NetrwGetCurdir(a:islocal)
 
-  if exists("s:netrwmarkfilelist_{curbufnr}")
-    let netrwmarkfilelist = s:netrwmarkfilelist_{curbufnr}
-    call s:NetrwUnmarkList(curbufnr,curdir)
-    for fname in netrwmarkfilelist
-      if a:islocal
-        if g:netrw_keepdir
-          let fname= netrw#fs#ComposePath(curdir,fname)
-        endif
-      else
-        let fname= curdir.fname
-      endif
-      1split
-      " the autocmds will handle both local and remote files
-      exe "sil NetrwKeepj e ".fnameescape(fname)
-      hardcopy
-      q
-    endfor
-    2match none
-  endif
+    if exists("s:netrwmarkfilelist_{curbufnr}")
+        let netrwmarkfilelist = s:netrwmarkfilelist_{curbufnr}
+        call s:NetrwUnmarkList(curbufnr,curdir)
+        for fname in netrwmarkfilelist
+            if a:islocal
+                if g:netrw_keepdir
+                    let fname= netrw#fs#ComposePath(curdir,fname)
+                endif
+            else
+                let fname= curdir.fname
+            endif
+            1split
+            " the autocmds will handle both local and remote files
+            exe "sil NetrwKeepj e ".fnameescape(fname)
+            hardcopy
+            q
+        endfor
+        2match none
+    endif
 endfun
 
 " s:NetrwMarkFileRegexp: (invoked by mr) This function is used to mark {{{2
@@ -6234,139 +6206,139 @@ endfun
 "                        issued) (matches to name of files).
 fun! s:NetrwMarkFileRegexp(islocal)
 
-  " get the regular expression
-  call inputsave()
-  let regexp= input("Enter regexp: ","","file")
-  call inputrestore()
+    " get the regular expression
+    call inputsave()
+    let regexp= input("Enter regexp: ","","file")
+    call inputrestore()
 
-  if a:islocal
-    let curdir= s:NetrwGetCurdir(a:islocal)
-    " get the matching list of files using local glob()
-    let dirname = escape(b:netrw_curdir,g:netrw_glob_escape)
-    let filelist= glob(netrw#fs#ComposePath(dirname,regexp),0,1,1)
+    if a:islocal
+        let curdir= s:NetrwGetCurdir(a:islocal)
+        " get the matching list of files using local glob()
+        let dirname = escape(b:netrw_curdir,g:netrw_glob_escape)
+        let filelist= glob(netrw#fs#ComposePath(dirname,regexp),0,1,1)
 
-    " mark the list of files
-    for fname in filelist
-      if fname =~ '^'.fnameescape(curdir)
-        NetrwKeepj call s:NetrwMarkFile(a:islocal,substitute(fname,'^'.fnameescape(curdir).'/','',''))
-      else
-        NetrwKeepj call s:NetrwMarkFile(a:islocal,substitute(fname,'^.*/','',''))
-      endif
-    endfor
+        " mark the list of files
+        for fname in filelist
+            if fname =~ '^'.fnameescape(curdir)
+                NetrwKeepj call s:NetrwMarkFile(a:islocal,substitute(fname,'^'.fnameescape(curdir).'/','',''))
+            else
+                NetrwKeepj call s:NetrwMarkFile(a:islocal,substitute(fname,'^.*/','',''))
+            endif
+        endfor
 
-  else
+    else
 
-    " convert displayed listing into a filelist
-    let eikeep = &ei
-    let areg   = @a
-    sil NetrwKeepj %y a
-    setl ei=all ma
-    1split
-    NetrwKeepj call s:NetrwEnew()
-    NetrwKeepj call s:NetrwOptionsSafe(a:islocal)
-    sil NetrwKeepj norm! "ap
-    NetrwKeepj 2
-    let bannercnt= search('^" =====','W')
-    exe "sil NetrwKeepj 1,".bannercnt."d"
-    setl bt=nofile
-    if     g:netrw_liststyle == s:LONGLIST
-      sil NetrwKeepj %s/\s\{2,}\S.*$//e
-      call histdel("/",-1)
-    elseif g:netrw_liststyle == s:WIDELIST
-      sil NetrwKeepj %s/\s\{2,}/\r/ge
-      call histdel("/",-1)
-    elseif g:netrw_liststyle == s:TREELIST
-      exe 'sil NetrwKeepj %s/^'.s:treedepthstring.' //e'
-      sil! NetrwKeepj g/^ .*$/d
-      call histdel("/",-1)
-      call histdel("/",-1)
+        " convert displayed listing into a filelist
+        let eikeep = &ei
+        let areg   = @a
+        sil NetrwKeepj %y a
+        setl ei=all ma
+        1split
+        NetrwKeepj call s:NetrwEnew()
+        NetrwKeepj call s:NetrwOptionsSafe(a:islocal)
+        sil NetrwKeepj norm! "ap
+        NetrwKeepj 2
+        let bannercnt= search('^" =====','W')
+        exe "sil NetrwKeepj 1,".bannercnt."d"
+        setl bt=nofile
+        if     g:netrw_liststyle == s:LONGLIST
+            sil NetrwKeepj %s/\s\{2,}\S.*$//e
+            call histdel("/",-1)
+        elseif g:netrw_liststyle == s:WIDELIST
+            sil NetrwKeepj %s/\s\{2,}/\r/ge
+            call histdel("/",-1)
+        elseif g:netrw_liststyle == s:TREELIST
+            exe 'sil NetrwKeepj %s/^'.s:treedepthstring.' //e'
+            sil! NetrwKeepj g/^ .*$/d
+            call histdel("/",-1)
+            call histdel("/",-1)
+        endif
+        " convert regexp into the more usual glob-style format
+        let regexp= substitute(regexp,'\*','.*','g')
+        exe "sil! NetrwKeepj v/".escape(regexp,'/')."/d"
+        call histdel("/",-1)
+        let filelist= getline(1,line("$"))
+        q!
+        for filename in filelist
+            NetrwKeepj call s:NetrwMarkFile(a:islocal,substitute(filename,'^.*/','',''))
+        endfor
+        unlet filelist
+        let @a  = areg
+        let &ei = eikeep
     endif
-    " convert regexp into the more usual glob-style format
-    let regexp= substitute(regexp,'\*','.*','g')
-    exe "sil! NetrwKeepj v/".escape(regexp,'/')."/d"
-    call histdel("/",-1)
-    let filelist= getline(1,line("$"))
-    q!
-    for filename in filelist
-      NetrwKeepj call s:NetrwMarkFile(a:islocal,substitute(filename,'^.*/','',''))
-    endfor
-    unlet filelist
-    let @a  = areg
-    let &ei = eikeep
-  endif
-  echo "  (use me to edit marked files)"
+    echo "  (use me to edit marked files)"
 
 endfun
 
 " s:NetrwMarkFileSource: (invoked by ms) This function sources marked files {{{2
 "                        Uses the local marked file list.
 fun! s:NetrwMarkFileSource(islocal)
-  let curbufnr= bufnr("%")
+    let curbufnr= bufnr("%")
 
-  " sanity check
-  if !exists("s:netrwmarkfilelist_{curbufnr}") || empty(s:netrwmarkfilelist_{curbufnr})
-    call netrw#msg#Notify('ERROR', 'there are no marked files in this window (:help netrw-mf)')
-    return
-  endif
-  let curdir= s:NetrwGetCurdir(a:islocal)
+    " sanity check
+    if !exists("s:netrwmarkfilelist_{curbufnr}") || empty(s:netrwmarkfilelist_{curbufnr})
+        call netrw#msg#Notify('ERROR', 'there are no marked files in this window (:help netrw-mf)')
+        return
+    endif
+    let curdir= s:NetrwGetCurdir(a:islocal)
 
-  if exists("s:netrwmarkfilelist_{curbufnr}")
-    let netrwmarkfilelist = s:netrwmarkfilelist_{bufnr("%")}
-    call s:NetrwUnmarkList(curbufnr,curdir)
-    for fname in netrwmarkfilelist
-      if a:islocal
-        if g:netrw_keepdir
-          let fname= netrw#fs#ComposePath(curdir,fname)
-        endif
-      else
-        let fname= curdir.fname
-      endif
-      " the autocmds will handle sourcing both local and remote files
-      exe "so ".fnameescape(fname)
-    endfor
-    2match none
-  endif
+    if exists("s:netrwmarkfilelist_{curbufnr}")
+        let netrwmarkfilelist = s:netrwmarkfilelist_{bufnr("%")}
+        call s:NetrwUnmarkList(curbufnr,curdir)
+        for fname in netrwmarkfilelist
+            if a:islocal
+                if g:netrw_keepdir
+                    let fname= netrw#fs#ComposePath(curdir,fname)
+                endif
+            else
+                let fname= curdir.fname
+            endif
+            " the autocmds will handle sourcing both local and remote files
+            exe "so ".fnameescape(fname)
+        endfor
+        2match none
+    endif
 endfun
 
 " s:NetrwMarkFileTag: (invoked by mT) This function applies g:netrw_ctags to marked files {{{2
 "                     Uses the global markfilelist
 fun! s:NetrwMarkFileTag(islocal)
-  let svpos    = winsaveview()
-  let curdir   = s:NetrwGetCurdir(a:islocal)
-  let curbufnr = bufnr("%")
+    let svpos    = winsaveview()
+    let curdir   = s:NetrwGetCurdir(a:islocal)
+    let curbufnr = bufnr("%")
 
-  " sanity check
-  if !exists("s:netrwmarkfilelist_{curbufnr}") || empty(s:netrwmarkfilelist_{curbufnr})
-    call netrw#msg#Notify('ERROR', 'there are no marked files in this window (:help netrw-mf)')
-    return
-  endif
-
-  if exists("s:netrwmarkfilelist")
-    let netrwmarkfilelist= join(map(deepcopy(s:netrwmarkfilelist), "netrw#os#Escape(v:val,".!a:islocal.")"))
-    call s:NetrwUnmarkAll()
-
-    if a:islocal
-
-      call system(g:netrw_ctags." ".netrwmarkfilelist)
-      if v:shell_error
-        call netrw#msg#Notify('ERROR', printf('g:netrw_ctags<%s> is not executable!', g:netrw_ctags))
-      endif
-
-    else
-      let cmd   = s:RemoteSystem(g:netrw_ctags." ".netrwmarkfilelist)
-      call netrw#Obtain(a:islocal,"tags")
-      let curdir= b:netrw_curdir
-      1split
-      NetrwKeepj e tags
-      let path= substitute(curdir,'^\(.*\)/[^/]*$','\1/','')
-      exe 'NetrwKeepj %s/\t\(\S\+\)\t/\t'.escape(path,"/\n\r\\").'\1\t/e'
-      call histdel("/",-1)
-      wq!
+    " sanity check
+    if !exists("s:netrwmarkfilelist_{curbufnr}") || empty(s:netrwmarkfilelist_{curbufnr})
+        call netrw#msg#Notify('ERROR', 'there are no marked files in this window (:help netrw-mf)')
+        return
     endif
-    2match none
-    call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
-    call winrestview(svpos)
-  endif
+
+    if exists("s:netrwmarkfilelist")
+        let netrwmarkfilelist= join(map(deepcopy(s:netrwmarkfilelist), "netrw#os#Escape(v:val,".!a:islocal.")"))
+        call s:NetrwUnmarkAll()
+
+        if a:islocal
+
+            call system(g:netrw_ctags." ".netrwmarkfilelist)
+            if v:shell_error
+                call netrw#msg#Notify('ERROR', printf('g:netrw_ctags<%s> is not executable!', g:netrw_ctags))
+            endif
+
+        else
+            let cmd   = s:RemoteSystem(g:netrw_ctags." ".netrwmarkfilelist)
+            call netrw#Obtain(a:islocal,"tags")
+            let curdir= b:netrw_curdir
+            1split
+            NetrwKeepj e tags
+            let path= substitute(curdir,'^\(.*\)/[^/]*$','\1/','')
+            exe 'NetrwKeepj %s/\t\(\S\+\)\t/\t'.escape(path,"/\n\r\\").'\1\t/e'
+            call histdel("/",-1)
+            wq!
+        endif
+        2match none
+        call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
+        call winrestview(svpos)
+    endif
 endfun
 
 " s:NetrwMarkFileTgt:  (invoked by mt) This function sets up a marked file target {{{2
@@ -6375,130 +6347,121 @@ endfun
 "     s:netrwmftgt_islocal : 0=target directory is remote
 "                            1=target directory is local
 fun! s:NetrwMarkFileTgt(islocal)
-  let svpos  = winsaveview()
-  let curdir = s:NetrwGetCurdir(a:islocal)
-  let hadtgt = exists("s:netrwmftgt")
-  if !exists("w:netrw_bannercnt")
-    let w:netrw_bannercnt= b:netrw_bannercnt
-  endif
+    let svpos  = winsaveview()
+    let curdir = s:NetrwGetCurdir(a:islocal)
+    let hadtgt = exists("s:netrwmftgt")
+    if !exists("w:netrw_bannercnt")
+        let w:netrw_bannercnt= b:netrw_bannercnt
+    endif
 
-  " set up target
-  if line(".") < w:netrw_bannercnt
-    " if cursor in banner region, use b:netrw_curdir for the target unless its already the target
-    if exists("s:netrwmftgt") && exists("s:netrwmftgt_islocal") && s:netrwmftgt == b:netrw_curdir
-      unlet s:netrwmftgt s:netrwmftgt_islocal
-      if g:netrw_fastbrowse <= 1
+    " set up target
+    if line(".") < w:netrw_bannercnt
+        " if cursor in banner region, use b:netrw_curdir for the target unless its already the target
+        if exists("s:netrwmftgt") && exists("s:netrwmftgt_islocal") && s:netrwmftgt == b:netrw_curdir
+            unlet s:netrwmftgt s:netrwmftgt_islocal
+            if g:netrw_fastbrowse <= 1
+                call s:LocalBrowseRefresh()
+            endif
+            call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
+            call winrestview(svpos)
+            return
+        else
+            let s:netrwmftgt= b:netrw_curdir
+        endif
+
+    else
+        " get word under cursor.
+        "  * If directory, use it for the target.
+        "  * If file, use b:netrw_curdir for the target
+        let curword= s:NetrwGetWord()
+        let tgtdir = netrw#fs#ComposePath(curdir,curword)
+        if a:islocal && isdirectory(s:NetrwFile(tgtdir))
+            let s:netrwmftgt = tgtdir
+        elseif !a:islocal && tgtdir =~ '/$'
+            let s:netrwmftgt = tgtdir
+        else
+            let s:netrwmftgt = curdir
+        endif
+    endif
+    if a:islocal
+        " simplify the target (eg. /abc/def/../ghi -> /abc/ghi)
+        let s:netrwmftgt= simplify(s:netrwmftgt)
+    endif
+    if g:netrw_cygwin
+        let s:netrwmftgt= substitute(system("cygpath ".netrw#os#Escape(s:netrwmftgt)),'\n$','','')
+        let s:netrwmftgt= substitute(s:netrwmftgt,'\n$','','')
+    endif
+    let s:netrwmftgt_islocal= a:islocal
+
+    " need to do refresh so that the banner will be updated
+    "  s:LocalBrowseRefresh handles all local-browsing buffers when not fast browsing
+    if g:netrw_fastbrowse <= 1
         call s:LocalBrowseRefresh()
-      endif
-      call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
-      call winrestview(svpos)
-      return
-    else
-      let s:netrwmftgt= b:netrw_curdir
     endif
-
-  else
-    " get word under cursor.
-    "  * If directory, use it for the target.
-    "  * If file, use b:netrw_curdir for the target
-    let curword= s:NetrwGetWord()
-    let tgtdir = netrw#fs#ComposePath(curdir,curword)
-    if a:islocal && isdirectory(s:NetrwFile(tgtdir))
-      let s:netrwmftgt = tgtdir
-    elseif !a:islocal && tgtdir =~ '/$'
-      let s:netrwmftgt = tgtdir
+    "  call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
+    if exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST
+        call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,w:netrw_treetop,0))
     else
-      let s:netrwmftgt = curdir
+        call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
     endif
-  endif
-  if a:islocal
-    " simplify the target (eg. /abc/def/../ghi -> /abc/ghi)
-    let s:netrwmftgt= simplify(s:netrwmftgt)
-  endif
-  if g:netrw_cygwin
-    let s:netrwmftgt= substitute(system("cygpath ".netrw#os#Escape(s:netrwmftgt)),'\n$','','')
-    let s:netrwmftgt= substitute(s:netrwmftgt,'\n$','','')
-  endif
-  let s:netrwmftgt_islocal= a:islocal
-
-  " need to do refresh so that the banner will be updated
-  "  s:LocalBrowseRefresh handles all local-browsing buffers when not fast browsing
-  if g:netrw_fastbrowse <= 1
-    call s:LocalBrowseRefresh()
-  endif
-  "  call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
-  if exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST
-    call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,w:netrw_treetop,0))
-  else
-    call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
-  endif
-  call winrestview(svpos)
-  if !hadtgt
-    sil! NetrwKeepj norm! j
-  endif
+    call winrestview(svpos)
+    if !hadtgt
+        sil! NetrwKeepj norm! j
+    endif
 endfun
 
 " s:NetrwGetCurdir: gets current directory and sets up b:netrw_curdir if necessary {{{2
 fun! s:NetrwGetCurdir(islocal)
 
-  if exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST
-    let b:netrw_curdir = s:NetrwTreePath(w:netrw_treetop)
-  elseif !exists("b:netrw_curdir")
-    let b:netrw_curdir= getcwd()
-  endif
-
-  if b:netrw_curdir !~ '\<\a\{3,}://'
-    let curdir= b:netrw_curdir
-    if g:netrw_keepdir == 0
-      call s:NetrwLcd(curdir)
+    if exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST
+        let b:netrw_curdir = s:NetrwTreePath(w:netrw_treetop)
+    elseif !exists("b:netrw_curdir")
+        let b:netrw_curdir= getcwd()
     endif
-  endif
 
-  return b:netrw_curdir
+    if b:netrw_curdir !~ '\<\a\{3,}://'
+        let curdir= b:netrw_curdir
+        if g:netrw_keepdir == 0
+            call s:NetrwLcd(curdir)
+        endif
+    endif
+
+    return b:netrw_curdir
 endfun
 
 " s:NetrwOpenFile: query user for a filename and open it {{{2
 fun! s:NetrwOpenFile(islocal)
-  let ykeep= @@
-  call inputsave()
-  let fname= input("Enter filename: ")
-  call inputrestore()
+    let ykeep= @@
+    call inputsave()
+    let fname= input("Enter filename: ")
+    call inputrestore()
 
-  " determine if Lexplore is in use
-  if exists("t:netrw_lexbufnr")
-    " check if t:netrw_lexbufnr refers to a netrw window
-    let lexwinnr = bufwinnr(t:netrw_lexbufnr)
-    if lexwinnr != -1 && exists("g:netrw_chgwin") && g:netrw_chgwin != -1
-      exe "NetrwKeepj keepalt ".g:netrw_chgwin."wincmd w"
-      exe "NetrwKeepj e ".fnameescape(fname)
-      let @@= ykeep
+    " determine if Lexplore is in use
+    if exists("t:netrw_lexbufnr")
+        " check if t:netrw_lexbufnr refers to a netrw window
+        let lexwinnr = bufwinnr(t:netrw_lexbufnr)
+        if lexwinnr != -1 && exists("g:netrw_chgwin") && g:netrw_chgwin != -1
+            exe "NetrwKeepj keepalt ".g:netrw_chgwin."wincmd w"
+            exe "NetrwKeepj e ".fnameescape(fname)
+            let @@= ykeep
+        endif
     endif
-  endif
 
-  " Does the filename contain a path?
-  if fname !~ '[/\\]'
-    if exists("b:netrw_curdir")
-      if exists("g:netrw_quiet")
-        let netrw_quiet_keep = g:netrw_quiet
-      endif
-      let g:netrw_quiet = 1
-      " save position for benefit of Rexplore
-      let s:rexposn_{bufnr("%")}= winsaveview()
-      if b:netrw_curdir =~ '/$'
-        exe "NetrwKeepj e ".fnameescape(b:netrw_curdir.fname)
-      else
-        exe "e ".fnameescape(b:netrw_curdir."/".fname)
-      endif
-      if exists("netrw_quiet_keep")
-        let g:netrw_quiet= netrw_quiet_keep
-      else
-        unlet g:netrw_quiet
-      endif
+    " Does the filename contain a path?
+    if fname !~ '[/\\]'
+        if exists("b:netrw_curdir")
+            " save position for benefit of Rexplore
+            let s:rexposn_{bufnr("%")}= winsaveview()
+            if b:netrw_curdir =~ '/$'
+                exe "NetrwKeepj e ".fnameescape(b:netrw_curdir.fname)
+            else
+                exe "e ".fnameescape(b:netrw_curdir."/".fname)
+            endif
+        endif
+    else
+        exe "NetrwKeepj e ".fnameescape(fname)
     endif
-  else
-    exe "NetrwKeepj e ".fnameescape(fname)
-  endif
-  let @@= ykeep
+    let @@= ykeep
 endfun
 
 " netrw#Shrink: shrinks/expands a netrw or Lexplorer window {{{2
@@ -6506,57 +6469,57 @@ endfun
 "               netrwPlugin, you'll need to have had
 "               g:netrw_usetab set to non-zero.
 fun! netrw#Shrink()
-  let curwin  = winnr()
-  let wiwkeep = &wiw
-  set wiw=1
+    let curwin  = winnr()
+    let wiwkeep = &wiw
+    set wiw=1
 
-  if &ft == "netrw"
-    if winwidth(0) > g:netrw_wiw
-      let t:netrw_winwidth= winwidth(0)
-      exe "vert resize ".g:netrw_wiw
-      wincmd l
-      if winnr() == curwin
-        wincmd h
-      endif
+    if &ft == "netrw"
+        if winwidth(0) > g:netrw_wiw
+            let t:netrw_winwidth= winwidth(0)
+            exe "vert resize ".g:netrw_wiw
+            wincmd l
+            if winnr() == curwin
+                wincmd h
+            endif
+        else
+            exe "vert resize ".t:netrw_winwidth
+        endif
+
+    elseif exists("t:netrw_lexbufnr")
+        exe bufwinnr(t:netrw_lexbufnr)."wincmd w"
+        if     winwidth(bufwinnr(t:netrw_lexbufnr)) >  g:netrw_wiw
+            let t:netrw_winwidth= winwidth(0)
+            exe "vert resize ".g:netrw_wiw
+            wincmd l
+            if winnr() == curwin
+                wincmd h
+            endif
+        elseif winwidth(bufwinnr(t:netrw_lexbufnr)) >= 0
+            exe "vert resize ".t:netrw_winwidth
+        else
+            call netrw#Lexplore(0,0)
+        endif
+
     else
-      exe "vert resize ".t:netrw_winwidth
+        call netrw#Lexplore(0,0)
     endif
-
-  elseif exists("t:netrw_lexbufnr")
-    exe bufwinnr(t:netrw_lexbufnr)."wincmd w"
-    if     winwidth(bufwinnr(t:netrw_lexbufnr)) >  g:netrw_wiw
-      let t:netrw_winwidth= winwidth(0)
-      exe "vert resize ".g:netrw_wiw
-      wincmd l
-      if winnr() == curwin
-        wincmd h
-      endif
-    elseif winwidth(bufwinnr(t:netrw_lexbufnr)) >= 0
-      exe "vert resize ".t:netrw_winwidth
-    else
-      call netrw#Lexplore(0,0)
-    endif
-
-  else
-    call netrw#Lexplore(0,0)
-  endif
-  let wiw= wiwkeep
+    let wiw= wiwkeep
 
 endfun
 
 " s:NetSortSequence: allows user to edit the sorting sequence {{{2
 fun! s:NetSortSequence(islocal)
-  let ykeep= @@
-  let svpos= winsaveview()
-  call inputsave()
-  let newsortseq= input("Edit Sorting Sequence: ",g:netrw_sort_sequence)
-  call inputrestore()
+    let ykeep= @@
+    let svpos= winsaveview()
+    call inputsave()
+    let newsortseq= input("Edit Sorting Sequence: ",g:netrw_sort_sequence)
+    call inputrestore()
 
-  " refresh the listing
-  let g:netrw_sort_sequence= newsortseq
-  NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
-  NetrwKeepj call winrestview(svpos)
-  let @@= ykeep
+    " refresh the listing
+    let g:netrw_sort_sequence= newsortseq
+    NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
+    NetrwKeepj call winrestview(svpos)
+    let @@= ykeep
 endfun
 
 " s:NetrwUnmarkList: delete local marked file list and remove their contents from the global marked-file list {{{2
@@ -6564,48 +6527,48 @@ endfun
 "   Used by many MarkFile functions.
 fun! s:NetrwUnmarkList(curbufnr,curdir)
 
-  "  remove all files in local marked-file list from global list
-  if exists("s:netrwmarkfilelist")
-    for mfile in s:netrwmarkfilelist_{a:curbufnr}
-      let dfile = netrw#fs#ComposePath(a:curdir,mfile)       " prepend directory to mfile
-      let idx   = index(s:netrwmarkfilelist,dfile)    " get index in list of dfile
-      call remove(s:netrwmarkfilelist,idx)            " remove from global list
-    endfor
-    if s:netrwmarkfilelist == []
-      unlet s:netrwmarkfilelist
-    endif
+    "  remove all files in local marked-file list from global list
+    if exists("s:netrwmarkfilelist")
+        for mfile in s:netrwmarkfilelist_{a:curbufnr}
+            let dfile = netrw#fs#ComposePath(a:curdir,mfile)       " prepend directory to mfile
+            let idx   = index(s:netrwmarkfilelist,dfile)    " get index in list of dfile
+            call remove(s:netrwmarkfilelist,idx)            " remove from global list
+        endfor
+        if s:netrwmarkfilelist == []
+            unlet s:netrwmarkfilelist
+        endif
 
-    " getting rid of the local marked-file lists is easy
-    unlet s:netrwmarkfilelist_{a:curbufnr}
-  endif
-  if exists("s:netrwmarkfilemtch_{a:curbufnr}")
-    unlet s:netrwmarkfilemtch_{a:curbufnr}
-  endif
-  2match none
+        " getting rid of the local marked-file lists is easy
+        unlet s:netrwmarkfilelist_{a:curbufnr}
+    endif
+    if exists("s:netrwmarkfilemtch_{a:curbufnr}")
+        unlet s:netrwmarkfilemtch_{a:curbufnr}
+    endif
+    2match none
 endfun
 
 " s:NetrwUnmarkAll: remove the global marked file list and all local ones {{{2
 fun! s:NetrwUnmarkAll()
-  if exists("s:netrwmarkfilelist")
-    unlet s:netrwmarkfilelist
-  endif
-  sil call s:NetrwUnmarkAll2()
-  2match none
+    if exists("s:netrwmarkfilelist")
+        unlet s:netrwmarkfilelist
+    endif
+    sil call s:NetrwUnmarkAll2()
+    2match none
 endfun
 
 " s:NetrwUnmarkAll2: unmark all files from all buffers {{{2
 fun! s:NetrwUnmarkAll2()
-  redir => netrwmarkfilelist_let
-  let
-  redir END
-  let netrwmarkfilelist_list= split(netrwmarkfilelist_let,'\n')          " convert let string into a let list
-  call filter(netrwmarkfilelist_list,"v:val =~ '^s:netrwmarkfilelist_'") " retain only those vars that start as s:netrwmarkfilelist_
-  call map(netrwmarkfilelist_list,"substitute(v:val,'\\s.*$','','')")    " remove what the entries are equal to
-  for flist in netrwmarkfilelist_list
-    let curbufnr= substitute(flist,'s:netrwmarkfilelist_','','')
-    unlet s:netrwmarkfilelist_{curbufnr}
-    unlet s:netrwmarkfilemtch_{curbufnr}
-  endfor
+    redir => netrwmarkfilelist_let
+    let
+    redir END
+    let netrwmarkfilelist_list= split(netrwmarkfilelist_let,'\n')          " convert let string into a let list
+    call filter(netrwmarkfilelist_list,"v:val =~ '^s:netrwmarkfilelist_'") " retain only those vars that start as s:netrwmarkfilelist_
+    call map(netrwmarkfilelist_list,"substitute(v:val,'\\s.*$','','')")    " remove what the entries are equal to
+    for flist in netrwmarkfilelist_list
+        let curbufnr= substitute(flist,'s:netrwmarkfilelist_','','')
+        unlet s:netrwmarkfilelist_{curbufnr}
+        unlet s:netrwmarkfilemtch_{curbufnr}
+    endfor
 endfun
 
 " s:NetrwUnMarkFile: called via mu map; unmarks *all* marked files, both global and buffer-local {{{2
@@ -6617,123 +6580,123 @@ endfun
 " Marked files suitable for use with 2match are in:
 "    s:netrwmarkfilemtch_#   -- used with 2match to display marked files
 fun! s:NetrwUnMarkFile(islocal)
-  let svpos    = winsaveview()
-  let curbufnr = bufnr("%")
+    let svpos    = winsaveview()
+    let curbufnr = bufnr("%")
 
-  " unmark marked file list
-  " (although I expect s:NetrwUpload() to do it, I'm just making sure)
-  if exists("s:netrwmarkfilelist")
-    unlet s:netrwmarkfilelist
-  endif
-
-  let ibuf= 1
-  while ibuf < bufnr("$")
-    if exists("s:netrwmarkfilelist_".ibuf)
-      unlet s:netrwmarkfilelist_{ibuf}
-      unlet s:netrwmarkfilemtch_{ibuf}
+    " unmark marked file list
+    " (although I expect s:NetrwUpload() to do it, I'm just making sure)
+    if exists("s:netrwmarkfilelist")
+        unlet s:netrwmarkfilelist
     endif
-    let ibuf = ibuf + 1
-  endwhile
-  2match none
 
-  "  call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
-  call winrestview(svpos)
+    let ibuf= 1
+    while ibuf < bufnr("$")
+        if exists("s:netrwmarkfilelist_".ibuf)
+            unlet s:netrwmarkfilelist_{ibuf}
+            unlet s:netrwmarkfilemtch_{ibuf}
+        endif
+        let ibuf = ibuf + 1
+    endwhile
+    2match none
+
+    "  call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
+    call winrestview(svpos)
 endfun
 
 " s:NetrwMenu: generates the menu for gvim and netrw {{{2
 fun! s:NetrwMenu(domenu)
 
-  if !exists("g:NetrwMenuPriority")
-    let g:NetrwMenuPriority= 80
-  endif
+    if !exists("g:NetrwMenuPriority")
+        let g:NetrwMenuPriority= 80
+    endif
 
-  if has("menu") && has("gui_running") && &go =~# 'm' && g:netrw_menu
+    if has("menu") && has("gui_running") && &go =~# 'm' && g:netrw_menu
 
-    if !exists("s:netrw_menu_enabled") && a:domenu
-      let s:netrw_menu_enabled= 1
-      exe 'sil! menu '.g:NetrwMenuPriority.'.1      '.g:NetrwTopLvlMenu.'Help<tab><F1>    <F1>'
-      exe 'sil! menu '.g:NetrwMenuPriority.'.5      '.g:NetrwTopLvlMenu.'-Sep1-   :'
-      exe 'sil! menu '.g:NetrwMenuPriority.'.6      '.g:NetrwTopLvlMenu.'Go\ Up\ Directory<tab>-  -'
-      exe 'sil! menu '.g:NetrwMenuPriority.'.7      '.g:NetrwTopLvlMenu.'Apply\ Special\ Viewer<tab>x     x'
-      if g:netrw_dirhistmax > 0
-        exe 'sil! menu '.g:NetrwMenuPriority.'.8.1   '.g:NetrwTopLvlMenu.'Bookmarks\ and\ History.Bookmark\ Current\ Directory<tab>mb      mb'
-        exe 'sil! menu '.g:NetrwMenuPriority.'.8.4   '.g:NetrwTopLvlMenu.'Bookmarks\ and\ History.Goto\ Prev\ Dir\ (History)<tab>u u'
-        exe 'sil! menu '.g:NetrwMenuPriority.'.8.5   '.g:NetrwTopLvlMenu.'Bookmarks\ and\ History.Goto\ Next\ Dir\ (History)<tab>U U'
-        exe 'sil! menu '.g:NetrwMenuPriority.'.8.6   '.g:NetrwTopLvlMenu.'Bookmarks\ and\ History.List<tab>qb      qb'
-      else
-        exe 'sil! menu '.g:NetrwMenuPriority.'.8     '.g:NetrwTopLvlMenu.'Bookmarks\ and\ History  :echo "(disabled)"'."\<cr>"
-      endif
-      exe 'sil! menu '.g:NetrwMenuPriority.'.9.1    '.g:NetrwTopLvlMenu.'Browsing\ Control.Horizontal\ Split<tab>o        o'
-      exe 'sil! menu '.g:NetrwMenuPriority.'.9.2    '.g:NetrwTopLvlMenu.'Browsing\ Control.Vertical\ Split<tab>v  v'
-      exe 'sil! menu '.g:NetrwMenuPriority.'.9.3    '.g:NetrwTopLvlMenu.'Browsing\ Control.New\ Tab<tab>t t'
-      exe 'sil! menu '.g:NetrwMenuPriority.'.9.4    '.g:NetrwTopLvlMenu.'Browsing\ Control.Preview<tab>p  p'
-      exe 'sil! menu '.g:NetrwMenuPriority.'.9.5    '.g:NetrwTopLvlMenu.'Browsing\ Control.Edit\ File\ Hiding\ List<tab><ctrl-h>'."       \<c-h>'"
-      exe 'sil! menu '.g:NetrwMenuPriority.'.9.6    '.g:NetrwTopLvlMenu.'Browsing\ Control.Edit\ Sorting\ Sequence<tab>S  S'
-      exe 'sil! menu '.g:NetrwMenuPriority.'.9.7    '.g:NetrwTopLvlMenu.'Browsing\ Control.Quick\ Hide/Unhide\ Dot\ Files<tab>'."gh       gh"
-      exe 'sil! menu '.g:NetrwMenuPriority.'.9.8    '.g:NetrwTopLvlMenu.'Browsing\ Control.Refresh\ Listing<tab>'."<ctrl-l>       \<c-l>"
-      exe 'sil! menu '.g:NetrwMenuPriority.'.9.9    '.g:NetrwTopLvlMenu.'Browsing\ Control.Settings/Options<tab>:NetrwSettings    '.":NetrwSettings\<cr>"
-      exe 'sil! menu '.g:NetrwMenuPriority.'.10     '.g:NetrwTopLvlMenu.'Delete\ File/Directory<tab>D     D'
-      exe 'sil! menu '.g:NetrwMenuPriority.'.11.1   '.g:NetrwTopLvlMenu.'Edit\ File/Dir.Create\ New\ File<tab>%   %'
-      exe 'sil! menu '.g:NetrwMenuPriority.'.11.1   '.g:NetrwTopLvlMenu.'Edit\ File/Dir.In\ Current\ Window<tab><cr>      '."\<cr>"
-      exe 'sil! menu '.g:NetrwMenuPriority.'.11.2   '.g:NetrwTopLvlMenu.'Edit\ File/Dir.Preview\ File/Directory<tab>p     p'
-      exe 'sil! menu '.g:NetrwMenuPriority.'.11.3   '.g:NetrwTopLvlMenu.'Edit\ File/Dir.In\ Previous\ Window<tab>P        P'
-      exe 'sil! menu '.g:NetrwMenuPriority.'.11.4   '.g:NetrwTopLvlMenu.'Edit\ File/Dir.In\ New\ Window<tab>o     o'
-      exe 'sil! menu '.g:NetrwMenuPriority.'.11.5   '.g:NetrwTopLvlMenu.'Edit\ File/Dir.In\ New\ Tab<tab>t        t'
-      exe 'sil! menu '.g:NetrwMenuPriority.'.11.5   '.g:NetrwTopLvlMenu.'Edit\ File/Dir.In\ New\ Vertical\ Window<tab>v   v'
-      exe 'sil! menu '.g:NetrwMenuPriority.'.12.1   '.g:NetrwTopLvlMenu.'Explore.Directory\ Name  :Explore '
-      exe 'sil! menu '.g:NetrwMenuPriority.'.12.2   '.g:NetrwTopLvlMenu.'Explore.Filenames\ Matching\ Pattern\ (curdir\ only)<tab>:Explore\ */    :Explore */'
-      exe 'sil! menu '.g:NetrwMenuPriority.'.12.2   '.g:NetrwTopLvlMenu.'Explore.Filenames\ Matching\ Pattern\ (+subdirs)<tab>:Explore\ **/       :Explore **/'
-      exe 'sil! menu '.g:NetrwMenuPriority.'.12.3   '.g:NetrwTopLvlMenu.'Explore.Files\ Containing\ String\ Pattern\ (curdir\ only)<tab>:Explore\ *//     :Explore *//'
-      exe 'sil! menu '.g:NetrwMenuPriority.'.12.4   '.g:NetrwTopLvlMenu.'Explore.Files\ Containing\ String\ Pattern\ (+subdirs)<tab>:Explore\ **//        :Explore **//'
-      exe 'sil! menu '.g:NetrwMenuPriority.'.12.4   '.g:NetrwTopLvlMenu.'Explore.Next\ Match<tab>:Nexplore        :Nexplore<cr>'
-      exe 'sil! menu '.g:NetrwMenuPriority.'.12.4   '.g:NetrwTopLvlMenu.'Explore.Prev\ Match<tab>:Pexplore        :Pexplore<cr>'
-      exe 'sil! menu '.g:NetrwMenuPriority.'.13     '.g:NetrwTopLvlMenu.'Make\ Subdirectory<tab>d d'
-      exe 'sil! menu '.g:NetrwMenuPriority.'.14.1   '.g:NetrwTopLvlMenu.'Marked\ Files.Mark\ File<tab>mf  mf'
-      exe 'sil! menu '.g:NetrwMenuPriority.'.14.2   '.g:NetrwTopLvlMenu.'Marked\ Files.Mark\ Files\ by\ Regexp<tab>mr     mr'
-      exe 'sil! menu '.g:NetrwMenuPriority.'.14.3   '.g:NetrwTopLvlMenu.'Marked\ Files.Hide-Show-List\ Control<tab>a      a'
-      exe 'sil! menu '.g:NetrwMenuPriority.'.14.4   '.g:NetrwTopLvlMenu.'Marked\ Files.Copy\ To\ Target<tab>mc    mc'
-      exe 'sil! menu '.g:NetrwMenuPriority.'.14.5   '.g:NetrwTopLvlMenu.'Marked\ Files.Delete<tab>D       D'
-      exe 'sil! menu '.g:NetrwMenuPriority.'.14.6   '.g:NetrwTopLvlMenu.'Marked\ Files.Diff<tab>md        md'
-      exe 'sil! menu '.g:NetrwMenuPriority.'.14.7   '.g:NetrwTopLvlMenu.'Marked\ Files.Edit<tab>me        me'
-      exe 'sil! menu '.g:NetrwMenuPriority.'.14.8   '.g:NetrwTopLvlMenu.'Marked\ Files.Exe\ Cmd<tab>mx    mx'
-      exe 'sil! menu '.g:NetrwMenuPriority.'.14.9   '.g:NetrwTopLvlMenu.'Marked\ Files.Move\ To\ Target<tab>mm    mm'
-      exe 'sil! menu '.g:NetrwMenuPriority.'.14.10  '.g:NetrwTopLvlMenu.'Marked\ Files.Obtain<tab>O       O'
-      exe 'sil! menu '.g:NetrwMenuPriority.'.14.11  '.g:NetrwTopLvlMenu.'Marked\ Files.Print<tab>mp       mp'
-      exe 'sil! menu '.g:NetrwMenuPriority.'.14.12  '.g:NetrwTopLvlMenu.'Marked\ Files.Replace<tab>R      R'
-      exe 'sil! menu '.g:NetrwMenuPriority.'.14.13  '.g:NetrwTopLvlMenu.'Marked\ Files.Set\ Target<tab>mt mt'
-      exe 'sil! menu '.g:NetrwMenuPriority.'.14.14  '.g:NetrwTopLvlMenu.'Marked\ Files.Tag<tab>mT mT'
-      exe 'sil! menu '.g:NetrwMenuPriority.'.14.15  '.g:NetrwTopLvlMenu.'Marked\ Files.Zip/Unzip/Compress/Uncompress<tab>mz       mz'
-      exe 'sil! menu '.g:NetrwMenuPriority.'.15     '.g:NetrwTopLvlMenu.'Obtain\ File<tab>O       O'
-      exe 'sil! menu '.g:NetrwMenuPriority.'.16.1.1 '.g:NetrwTopLvlMenu.'Style.Listing.thin<tab>i :let w:netrw_liststyle=0<cr><c-L>'
-      exe 'sil! menu '.g:NetrwMenuPriority.'.16.1.1 '.g:NetrwTopLvlMenu.'Style.Listing.long<tab>i :let w:netrw_liststyle=1<cr><c-L>'
-      exe 'sil! menu '.g:NetrwMenuPriority.'.16.1.1 '.g:NetrwTopLvlMenu.'Style.Listing.wide<tab>i :let w:netrw_liststyle=2<cr><c-L>'
-      exe 'sil! menu '.g:NetrwMenuPriority.'.16.1.1 '.g:NetrwTopLvlMenu.'Style.Listing.tree<tab>i :let w:netrw_liststyle=3<cr><c-L>'
-      exe 'sil! menu '.g:NetrwMenuPriority.'.16.2.1 '.g:NetrwTopLvlMenu.'Style.Normal-Hide-Show.Show\ All<tab>a   :let g:netrw_hide=0<cr><c-L>'
-      exe 'sil! menu '.g:NetrwMenuPriority.'.16.2.3 '.g:NetrwTopLvlMenu.'Style.Normal-Hide-Show.Normal<tab>a      :let g:netrw_hide=1<cr><c-L>'
-      exe 'sil! menu '.g:NetrwMenuPriority.'.16.2.2 '.g:NetrwTopLvlMenu.'Style.Normal-Hide-Show.Hidden\ Only<tab>a        :let g:netrw_hide=2<cr><c-L>'
-      exe 'sil! menu '.g:NetrwMenuPriority.'.16.3   '.g:NetrwTopLvlMenu.'Style.Reverse\ Sorting\ Order<tab>'."r   r"
-      exe 'sil! menu '.g:NetrwMenuPriority.'.16.4.1 '.g:NetrwTopLvlMenu.'Style.Sorting\ Method.Name<tab>s       :let g:netrw_sort_by="name"<cr><c-L>'
-      exe 'sil! menu '.g:NetrwMenuPriority.'.16.4.2 '.g:NetrwTopLvlMenu.'Style.Sorting\ Method.Time<tab>s       :let g:netrw_sort_by="time"<cr><c-L>'
-      exe 'sil! menu '.g:NetrwMenuPriority.'.16.4.3 '.g:NetrwTopLvlMenu.'Style.Sorting\ Method.Size<tab>s       :let g:netrw_sort_by="size"<cr><c-L>'
-      exe 'sil! menu '.g:NetrwMenuPriority.'.16.4.3 '.g:NetrwTopLvlMenu.'Style.Sorting\ Method.Exten<tab>s      :let g:netrw_sort_by="exten"<cr><c-L>'
-      exe 'sil! menu '.g:NetrwMenuPriority.'.17     '.g:NetrwTopLvlMenu.'Rename\ File/Directory<tab>R     R'
-      exe 'sil! menu '.g:NetrwMenuPriority.'.18     '.g:NetrwTopLvlMenu.'Set\ Current\ Directory<tab>c    c'
-      let s:netrw_menucnt= 28
-      call s:NetrwBookmarkMenu() " provide some history!  uses priorities 2,3, reserves 4, 8.2.x
-      call s:NetrwTgtMenu()      " let bookmarks and history be easy targets
+        if !exists("s:netrw_menu_enabled") && a:domenu
+            let s:netrw_menu_enabled= 1
+            exe 'sil! menu '.g:NetrwMenuPriority.'.1      '.g:NetrwTopLvlMenu.'Help<tab><F1>    <F1>'
+            exe 'sil! menu '.g:NetrwMenuPriority.'.5      '.g:NetrwTopLvlMenu.'-Sep1-   :'
+            exe 'sil! menu '.g:NetrwMenuPriority.'.6      '.g:NetrwTopLvlMenu.'Go\ Up\ Directory<tab>-  -'
+            exe 'sil! menu '.g:NetrwMenuPriority.'.7      '.g:NetrwTopLvlMenu.'Apply\ Special\ Viewer<tab>x     x'
+            if g:netrw_dirhistmax > 0
+                exe 'sil! menu '.g:NetrwMenuPriority.'.8.1   '.g:NetrwTopLvlMenu.'Bookmarks\ and\ History.Bookmark\ Current\ Directory<tab>mb      mb'
+                exe 'sil! menu '.g:NetrwMenuPriority.'.8.4   '.g:NetrwTopLvlMenu.'Bookmarks\ and\ History.Goto\ Prev\ Dir\ (History)<tab>u u'
+                exe 'sil! menu '.g:NetrwMenuPriority.'.8.5   '.g:NetrwTopLvlMenu.'Bookmarks\ and\ History.Goto\ Next\ Dir\ (History)<tab>U U'
+                exe 'sil! menu '.g:NetrwMenuPriority.'.8.6   '.g:NetrwTopLvlMenu.'Bookmarks\ and\ History.List<tab>qb      qb'
+            else
+                exe 'sil! menu '.g:NetrwMenuPriority.'.8     '.g:NetrwTopLvlMenu.'Bookmarks\ and\ History  :echo "(disabled)"'."\<cr>"
+            endif
+            exe 'sil! menu '.g:NetrwMenuPriority.'.9.1    '.g:NetrwTopLvlMenu.'Browsing\ Control.Horizontal\ Split<tab>o        o'
+            exe 'sil! menu '.g:NetrwMenuPriority.'.9.2    '.g:NetrwTopLvlMenu.'Browsing\ Control.Vertical\ Split<tab>v  v'
+            exe 'sil! menu '.g:NetrwMenuPriority.'.9.3    '.g:NetrwTopLvlMenu.'Browsing\ Control.New\ Tab<tab>t t'
+            exe 'sil! menu '.g:NetrwMenuPriority.'.9.4    '.g:NetrwTopLvlMenu.'Browsing\ Control.Preview<tab>p  p'
+            exe 'sil! menu '.g:NetrwMenuPriority.'.9.5    '.g:NetrwTopLvlMenu.'Browsing\ Control.Edit\ File\ Hiding\ List<tab><ctrl-h>'."       \<c-h>'"
+            exe 'sil! menu '.g:NetrwMenuPriority.'.9.6    '.g:NetrwTopLvlMenu.'Browsing\ Control.Edit\ Sorting\ Sequence<tab>S  S'
+            exe 'sil! menu '.g:NetrwMenuPriority.'.9.7    '.g:NetrwTopLvlMenu.'Browsing\ Control.Quick\ Hide/Unhide\ Dot\ Files<tab>'."gh       gh"
+            exe 'sil! menu '.g:NetrwMenuPriority.'.9.8    '.g:NetrwTopLvlMenu.'Browsing\ Control.Refresh\ Listing<tab>'."<ctrl-l>       \<c-l>"
+            exe 'sil! menu '.g:NetrwMenuPriority.'.9.9    '.g:NetrwTopLvlMenu.'Browsing\ Control.Settings/Options<tab>:NetrwSettings    '.":NetrwSettings\<cr>"
+            exe 'sil! menu '.g:NetrwMenuPriority.'.10     '.g:NetrwTopLvlMenu.'Delete\ File/Directory<tab>D     D'
+            exe 'sil! menu '.g:NetrwMenuPriority.'.11.1   '.g:NetrwTopLvlMenu.'Edit\ File/Dir.Create\ New\ File<tab>%   %'
+            exe 'sil! menu '.g:NetrwMenuPriority.'.11.1   '.g:NetrwTopLvlMenu.'Edit\ File/Dir.In\ Current\ Window<tab><cr>      '."\<cr>"
+            exe 'sil! menu '.g:NetrwMenuPriority.'.11.2   '.g:NetrwTopLvlMenu.'Edit\ File/Dir.Preview\ File/Directory<tab>p     p'
+            exe 'sil! menu '.g:NetrwMenuPriority.'.11.3   '.g:NetrwTopLvlMenu.'Edit\ File/Dir.In\ Previous\ Window<tab>P        P'
+            exe 'sil! menu '.g:NetrwMenuPriority.'.11.4   '.g:NetrwTopLvlMenu.'Edit\ File/Dir.In\ New\ Window<tab>o     o'
+            exe 'sil! menu '.g:NetrwMenuPriority.'.11.5   '.g:NetrwTopLvlMenu.'Edit\ File/Dir.In\ New\ Tab<tab>t        t'
+            exe 'sil! menu '.g:NetrwMenuPriority.'.11.5   '.g:NetrwTopLvlMenu.'Edit\ File/Dir.In\ New\ Vertical\ Window<tab>v   v'
+            exe 'sil! menu '.g:NetrwMenuPriority.'.12.1   '.g:NetrwTopLvlMenu.'Explore.Directory\ Name  :Explore '
+            exe 'sil! menu '.g:NetrwMenuPriority.'.12.2   '.g:NetrwTopLvlMenu.'Explore.Filenames\ Matching\ Pattern\ (curdir\ only)<tab>:Explore\ */    :Explore */'
+            exe 'sil! menu '.g:NetrwMenuPriority.'.12.2   '.g:NetrwTopLvlMenu.'Explore.Filenames\ Matching\ Pattern\ (+subdirs)<tab>:Explore\ **/       :Explore **/'
+            exe 'sil! menu '.g:NetrwMenuPriority.'.12.3   '.g:NetrwTopLvlMenu.'Explore.Files\ Containing\ String\ Pattern\ (curdir\ only)<tab>:Explore\ *//     :Explore *//'
+            exe 'sil! menu '.g:NetrwMenuPriority.'.12.4   '.g:NetrwTopLvlMenu.'Explore.Files\ Containing\ String\ Pattern\ (+subdirs)<tab>:Explore\ **//        :Explore **//'
+            exe 'sil! menu '.g:NetrwMenuPriority.'.12.4   '.g:NetrwTopLvlMenu.'Explore.Next\ Match<tab>:Nexplore        :Nexplore<cr>'
+            exe 'sil! menu '.g:NetrwMenuPriority.'.12.4   '.g:NetrwTopLvlMenu.'Explore.Prev\ Match<tab>:Pexplore        :Pexplore<cr>'
+            exe 'sil! menu '.g:NetrwMenuPriority.'.13     '.g:NetrwTopLvlMenu.'Make\ Subdirectory<tab>d d'
+            exe 'sil! menu '.g:NetrwMenuPriority.'.14.1   '.g:NetrwTopLvlMenu.'Marked\ Files.Mark\ File<tab>mf  mf'
+            exe 'sil! menu '.g:NetrwMenuPriority.'.14.2   '.g:NetrwTopLvlMenu.'Marked\ Files.Mark\ Files\ by\ Regexp<tab>mr     mr'
+            exe 'sil! menu '.g:NetrwMenuPriority.'.14.3   '.g:NetrwTopLvlMenu.'Marked\ Files.Hide-Show-List\ Control<tab>a      a'
+            exe 'sil! menu '.g:NetrwMenuPriority.'.14.4   '.g:NetrwTopLvlMenu.'Marked\ Files.Copy\ To\ Target<tab>mc    mc'
+            exe 'sil! menu '.g:NetrwMenuPriority.'.14.5   '.g:NetrwTopLvlMenu.'Marked\ Files.Delete<tab>D       D'
+            exe 'sil! menu '.g:NetrwMenuPriority.'.14.6   '.g:NetrwTopLvlMenu.'Marked\ Files.Diff<tab>md        md'
+            exe 'sil! menu '.g:NetrwMenuPriority.'.14.7   '.g:NetrwTopLvlMenu.'Marked\ Files.Edit<tab>me        me'
+            exe 'sil! menu '.g:NetrwMenuPriority.'.14.8   '.g:NetrwTopLvlMenu.'Marked\ Files.Exe\ Cmd<tab>mx    mx'
+            exe 'sil! menu '.g:NetrwMenuPriority.'.14.9   '.g:NetrwTopLvlMenu.'Marked\ Files.Move\ To\ Target<tab>mm    mm'
+            exe 'sil! menu '.g:NetrwMenuPriority.'.14.10  '.g:NetrwTopLvlMenu.'Marked\ Files.Obtain<tab>O       O'
+            exe 'sil! menu '.g:NetrwMenuPriority.'.14.11  '.g:NetrwTopLvlMenu.'Marked\ Files.Print<tab>mp       mp'
+            exe 'sil! menu '.g:NetrwMenuPriority.'.14.12  '.g:NetrwTopLvlMenu.'Marked\ Files.Replace<tab>R      R'
+            exe 'sil! menu '.g:NetrwMenuPriority.'.14.13  '.g:NetrwTopLvlMenu.'Marked\ Files.Set\ Target<tab>mt mt'
+            exe 'sil! menu '.g:NetrwMenuPriority.'.14.14  '.g:NetrwTopLvlMenu.'Marked\ Files.Tag<tab>mT mT'
+            exe 'sil! menu '.g:NetrwMenuPriority.'.14.15  '.g:NetrwTopLvlMenu.'Marked\ Files.Zip/Unzip/Compress/Uncompress<tab>mz       mz'
+            exe 'sil! menu '.g:NetrwMenuPriority.'.15     '.g:NetrwTopLvlMenu.'Obtain\ File<tab>O       O'
+            exe 'sil! menu '.g:NetrwMenuPriority.'.16.1.1 '.g:NetrwTopLvlMenu.'Style.Listing.thin<tab>i :let w:netrw_liststyle=0<cr><c-L>'
+            exe 'sil! menu '.g:NetrwMenuPriority.'.16.1.1 '.g:NetrwTopLvlMenu.'Style.Listing.long<tab>i :let w:netrw_liststyle=1<cr><c-L>'
+            exe 'sil! menu '.g:NetrwMenuPriority.'.16.1.1 '.g:NetrwTopLvlMenu.'Style.Listing.wide<tab>i :let w:netrw_liststyle=2<cr><c-L>'
+            exe 'sil! menu '.g:NetrwMenuPriority.'.16.1.1 '.g:NetrwTopLvlMenu.'Style.Listing.tree<tab>i :let w:netrw_liststyle=3<cr><c-L>'
+            exe 'sil! menu '.g:NetrwMenuPriority.'.16.2.1 '.g:NetrwTopLvlMenu.'Style.Normal-Hide-Show.Show\ All<tab>a   :let g:netrw_hide=0<cr><c-L>'
+            exe 'sil! menu '.g:NetrwMenuPriority.'.16.2.3 '.g:NetrwTopLvlMenu.'Style.Normal-Hide-Show.Normal<tab>a      :let g:netrw_hide=1<cr><c-L>'
+            exe 'sil! menu '.g:NetrwMenuPriority.'.16.2.2 '.g:NetrwTopLvlMenu.'Style.Normal-Hide-Show.Hidden\ Only<tab>a        :let g:netrw_hide=2<cr><c-L>'
+            exe 'sil! menu '.g:NetrwMenuPriority.'.16.3   '.g:NetrwTopLvlMenu.'Style.Reverse\ Sorting\ Order<tab>'."r   r"
+            exe 'sil! menu '.g:NetrwMenuPriority.'.16.4.1 '.g:NetrwTopLvlMenu.'Style.Sorting\ Method.Name<tab>s       :let g:netrw_sort_by="name"<cr><c-L>'
+            exe 'sil! menu '.g:NetrwMenuPriority.'.16.4.2 '.g:NetrwTopLvlMenu.'Style.Sorting\ Method.Time<tab>s       :let g:netrw_sort_by="time"<cr><c-L>'
+            exe 'sil! menu '.g:NetrwMenuPriority.'.16.4.3 '.g:NetrwTopLvlMenu.'Style.Sorting\ Method.Size<tab>s       :let g:netrw_sort_by="size"<cr><c-L>'
+            exe 'sil! menu '.g:NetrwMenuPriority.'.16.4.3 '.g:NetrwTopLvlMenu.'Style.Sorting\ Method.Exten<tab>s      :let g:netrw_sort_by="exten"<cr><c-L>'
+            exe 'sil! menu '.g:NetrwMenuPriority.'.17     '.g:NetrwTopLvlMenu.'Rename\ File/Directory<tab>R     R'
+            exe 'sil! menu '.g:NetrwMenuPriority.'.18     '.g:NetrwTopLvlMenu.'Set\ Current\ Directory<tab>c    c'
+            let s:netrw_menucnt= 28
+            call s:NetrwBookmarkMenu() " provide some history!  uses priorities 2,3, reserves 4, 8.2.x
+            call s:NetrwTgtMenu()      " let bookmarks and history be easy targets
 
-    elseif !a:domenu
-      let s:netrwcnt = 0
-      let curwin     = winnr()
-      keepjumps windo if getline(2) =~# "Netrw"
-        let s:netrwcnt = s:netrwcnt + 1
-      endif
-      exe curwin."wincmd w"
+        elseif !a:domenu
+            let s:netrwcnt = 0
+            let curwin     = winnr()
+            keepjumps windo if getline(2) =~# "Netrw"
+            let s:netrwcnt = s:netrwcnt + 1
+        endif
+        exe curwin."wincmd w"
 
-      if s:netrwcnt <= 1
-        exe 'sil! unmenu '.g:NetrwTopLvlMenu
-        sil! unlet s:netrw_menu_enabled
-      endif
+        if s:netrwcnt <= 1
+            exe 'sil! unmenu '.g:NetrwTopLvlMenu
+            sil! unlet s:netrw_menu_enabled
+        endif
     endif
     return
   endif
@@ -6744,15 +6707,15 @@ endfun
 "                Used by the O maps (as <SID>NetrwObtain())
 fun! s:NetrwObtain(islocal)
 
-  let ykeep= @@
-  if exists("s:netrwmarkfilelist_{bufnr('%')}")
-    let islocal= s:netrwmarkfilelist_{bufnr('%')}[1] !~ '^\a\{3,}://'
-    call netrw#Obtain(islocal,s:netrwmarkfilelist_{bufnr('%')})
-    call s:NetrwUnmarkList(bufnr('%'),b:netrw_curdir)
-  else
-    call netrw#Obtain(a:islocal,s:NetrwGetWord())
-  endif
-  let @@= ykeep
+    let ykeep= @@
+    if exists("s:netrwmarkfilelist_{bufnr('%')}")
+        let islocal= s:netrwmarkfilelist_{bufnr('%')}[1] !~ '^\a\{3,}://'
+        call netrw#Obtain(islocal,s:netrwmarkfilelist_{bufnr('%')})
+        call s:NetrwUnmarkList(bufnr('%'),b:netrw_curdir)
+    else
+        call netrw#Obtain(a:islocal,s:NetrwGetWord())
+    endif
+    let @@= ykeep
 
 endfun
 
@@ -6764,111 +6727,111 @@ endfun
 "     choice = 2 : didn't save modified file, opened window
 "     choice = 3 : cancel open
 fun! s:NetrwPrevWinOpen(islocal)
-  let ykeep= @@
-  " grab a copy of the b:netrw_curdir to pass it along to newly split windows
-  let curdir = b:netrw_curdir
+    let ykeep= @@
+    " grab a copy of the b:netrw_curdir to pass it along to newly split windows
+    let curdir = b:netrw_curdir
 
-  " get last window number and the word currently under the cursor
-  let origwin   = winnr()
-  let lastwinnr = winnr("$")
-  let curword      = s:NetrwGetWord()
-  let choice       = 0
-  let s:prevwinopen= 1  " lets s:NetrwTreeDir() know that NetrwPrevWinOpen called it (s:NetrwTreeDir() will unlet s:prevwinopen)
-  let s:treedir = s:NetrwTreeDir(a:islocal)
-  let curdir    = s:treedir
+    " get last window number and the word currently under the cursor
+    let origwin   = winnr()
+    let lastwinnr = winnr("$")
+    let curword      = s:NetrwGetWord()
+    let choice       = 0
+    let s:prevwinopen= 1  " lets s:NetrwTreeDir() know that NetrwPrevWinOpen called it (s:NetrwTreeDir() will unlet s:prevwinopen)
+    let s:treedir = s:NetrwTreeDir(a:islocal)
+    let curdir    = s:treedir
 
-  let didsplit = 0
-  if lastwinnr == 1
-    " if only one window, open a new one first
-    " g:netrw_preview=0: preview window shown in a horizontally split window
-    " g:netrw_preview=1: preview window shown in a vertically   split window
-    if g:netrw_preview
-      " vertically split preview window
-      let winsz= (g:netrw_winsize > 0)? (g:netrw_winsize*winwidth(0))/100 : -g:netrw_winsize
-      exe (g:netrw_alto? "top " : "bot ")."vert ".winsz."wincmd s"
-    else
-      " horizontally split preview window
-      let winsz= (g:netrw_winsize > 0)? (g:netrw_winsize*winheight(0))/100 : -g:netrw_winsize
-      exe (g:netrw_alto? "bel " : "abo ").winsz."wincmd s"
-    endif
-    let didsplit = 1
-
-  else
-    NetrwKeepj call s:SaveBufVars()
-    let eikeep= &ei
-    setl ei=all
-    wincmd p
-
-    if exists("s:lexplore_win") && s:lexplore_win == winnr()
-      " whoops -- user trying to open file in the Lexplore window.
-      " Use Lexplore's opening-file window instead.
-      "    exe g:netrw_chgwin."wincmd w"
-      wincmd p
-      call s:NetrwBrowse(0,s:NetrwBrowseChgDir(0,s:NetrwGetWord(),1))
-    endif
-
-    " prevwinnr: the window number of the "prev" window
-    " prevbufnr: the buffer number of the buffer in the "prev" window
-    " bnrcnt   : the qty of windows open on the "prev" buffer
-    let prevwinnr   = winnr()
-    let prevbufnr   = bufnr("%")
-    let prevbufname = bufname("%")
-    let prevmod     = &mod
-    let bnrcnt      = 0
-    NetrwKeepj call s:RestoreBufVars()
-
-    " if the previous window's buffer has been changed (ie. its modified flag is set),
-    " and it doesn't appear in any other extant window, then ask the
-    " user if s/he wants to abandon modifications therein.
-    if prevmod
-      windo if winbufnr(0) == prevbufnr | let bnrcnt=bnrcnt+1 | endif
-      exe prevwinnr."wincmd w"
-
-      if bnrcnt == 1 && &hidden == 0
-        " only one copy of the modified buffer in a window, and
-        " hidden not set, so overwriting will lose the modified file.  Ask first...
-        let choice = confirm("Save modified buffer<".prevbufname."> first?","&Yes\n&No\n&Cancel")
-        let &ei= eikeep
-
-        if choice == 1
-          " Yes -- write file & then browse
-          let v:errmsg= ""
-          sil w
-          if v:errmsg != ""
-            call netrw#msg#Notify('ERROR', printf('unable to write <%s>!', (exists("prevbufname") ? prevbufname : 'n/a')))
-            exe origwin."wincmd w"
-            let &ei = eikeep
-            let @@  = ykeep
-            return choice
-          endif
-
-        elseif choice == 2
-          " No -- don't worry about changed file, just browse anyway
-          echomsg "**note** changes to ".prevbufname." abandoned"
-
+    let didsplit = 0
+    if lastwinnr == 1
+        " if only one window, open a new one first
+        " g:netrw_preview=0: preview window shown in a horizontally split window
+        " g:netrw_preview=1: preview window shown in a vertically   split window
+        if g:netrw_preview
+            " vertically split preview window
+            let winsz= (g:netrw_winsize > 0)? (g:netrw_winsize*winwidth(0))/100 : -g:netrw_winsize
+            exe (g:netrw_alto? "top " : "bot ")."vert ".winsz."wincmd s"
         else
-          " Cancel -- don't do this
-          exe origwin."wincmd w"
-          let &ei= eikeep
-          let @@ = ykeep
-          return choice
+            " horizontally split preview window
+            let winsz= (g:netrw_winsize > 0)? (g:netrw_winsize*winheight(0))/100 : -g:netrw_winsize
+            exe (g:netrw_alto? "bel " : "abo ").winsz."wincmd s"
         endif
-      endif
-    endif
-    let &ei= eikeep
-  endif
+        let didsplit = 1
 
-  " restore b:netrw_curdir (window split/enew may have lost it)
-  let b:netrw_curdir= curdir
-  if a:islocal < 2
-    if a:islocal
-      call netrw#LocalBrowseCheck(s:NetrwBrowseChgDir(a:islocal,curword,0))
     else
-      call s:NetrwBrowse(a:islocal,s:NetrwBrowseChgDir(a:islocal,curword,0))
+        NetrwKeepj call s:SaveBufVars()
+        let eikeep= &ei
+        setl ei=all
+        wincmd p
+
+        if exists("s:lexplore_win") && s:lexplore_win == winnr()
+            " whoops -- user trying to open file in the Lexplore window.
+            " Use Lexplore's opening-file window instead.
+            "    exe g:netrw_chgwin."wincmd w"
+            wincmd p
+            call s:NetrwBrowse(0,s:NetrwBrowseChgDir(0,s:NetrwGetWord(),1))
+        endif
+
+        " prevwinnr: the window number of the "prev" window
+        " prevbufnr: the buffer number of the buffer in the "prev" window
+        " bnrcnt   : the qty of windows open on the "prev" buffer
+        let prevwinnr   = winnr()
+        let prevbufnr   = bufnr("%")
+        let prevbufname = bufname("%")
+        let prevmod     = &mod
+        let bnrcnt      = 0
+        NetrwKeepj call s:RestoreBufVars()
+
+        " if the previous window's buffer has been changed (ie. its modified flag is set),
+        " and it doesn't appear in any other extant window, then ask the
+        " user if s/he wants to abandon modifications therein.
+        if prevmod
+            windo if winbufnr(0) == prevbufnr | let bnrcnt=bnrcnt+1 | endif
+            exe prevwinnr."wincmd w"
+
+            if bnrcnt == 1 && &hidden == 0
+                " only one copy of the modified buffer in a window, and
+                " hidden not set, so overwriting will lose the modified file.  Ask first...
+                let choice = confirm("Save modified buffer<".prevbufname."> first?","&Yes\n&No\n&Cancel")
+                let &ei= eikeep
+
+                if choice == 1
+                    " Yes -- write file & then browse
+                    let v:errmsg= ""
+                    sil w
+                    if v:errmsg != ""
+                        call netrw#msg#Notify('ERROR', printf('unable to write <%s>!', (exists("prevbufname") ? prevbufname : 'n/a')))
+                        exe origwin."wincmd w"
+                        let &ei = eikeep
+                        let @@  = ykeep
+                        return choice
+                    endif
+
+                elseif choice == 2
+                    " No -- don't worry about changed file, just browse anyway
+                    echomsg "**note** changes to ".prevbufname." abandoned"
+
+                else
+                    " Cancel -- don't do this
+                    exe origwin."wincmd w"
+                    let &ei= eikeep
+                    let @@ = ykeep
+                    return choice
+                endif
+            endif
+        endif
+        let &ei= eikeep
     endif
-  endif
-  let @@= ykeep
-  return choice
+
+    " restore b:netrw_curdir (window split/enew may have lost it)
+    let b:netrw_curdir= curdir
+    if a:islocal < 2
+        if a:islocal
+            call netrw#LocalBrowseCheck(s:NetrwBrowseChgDir(a:islocal,curword,0))
+        else
+            call s:NetrwBrowse(a:islocal,s:NetrwBrowseChgDir(a:islocal,curword,0))
+        endif
+    endif
+    let @@= ykeep
+    return choice
 endfun
 
 " s:NetrwUpload: load fname to tgt (used by NetrwMarkFileCopy()) {{{2
@@ -6877,272 +6840,272 @@ endfun
 "                call s:NetrwUpload(filename, target, fromdirectory)
 fun! s:NetrwUpload(fname,tgt,...)
 
-  if a:tgt =~ '^\a\{3,}://'
-    let tgtdir= substitute(a:tgt,'^\a\{3,}://[^/]\+/\(.\{-}\)$','\1','')
-  else
-    let tgtdir= substitute(a:tgt,'^\(.*\)/[^/]*$','\1','')
-  endif
-
-  if a:0 > 0
-    let fromdir= a:1
-  else
-    let fromdir= getcwd()
-  endif
-
-  if type(a:fname) == 1
-    " handle uploading a single file using NetWrite
-    1split
-    exe "NetrwKeepj e ".fnameescape(s:NetrwFile(a:fname))
-    if a:tgt =~ '/$'
-      let wfname= substitute(a:fname,'^.*/','','')
-      exe "w! ".fnameescape(a:tgt.wfname)
+    if a:tgt =~ '^\a\{3,}://'
+        let tgtdir= substitute(a:tgt,'^\a\{3,}://[^/]\+/\(.\{-}\)$','\1','')
     else
-      exe "w ".fnameescape(a:tgt)
+        let tgtdir= substitute(a:tgt,'^\(.*\)/[^/]*$','\1','')
     endif
-    q!
 
-  elseif type(a:fname) == 3
-    " handle uploading a list of files via scp
-    let curdir= getcwd()
-    if a:tgt =~ '^scp:'
-      if s:NetrwLcd(fromdir)
-        return
-      endif
-      let filelist= deepcopy(s:netrwmarkfilelist_{bufnr('%')})
-      let args    = join(map(filelist,"netrw#os#Escape(v:val, 1)"))
-      if exists("g:netrw_port") && g:netrw_port != ""
-        let useport= " ".g:netrw_scpport." ".g:netrw_port
-      else
-        let useport= ""
-      endif
-      let machine = substitute(a:tgt,'^scp://\([^/:]\+\).*$','\1','')
-      let tgt     = substitute(a:tgt,'^scp://[^/]\+/\(.*\)$','\1','')
-      call netrw#os#Execute(s:netrw_silentxfer."!".g:netrw_scp_cmd.netrw#os#Escape(useport,1)." ".args." ".netrw#os#Escape(machine.":".tgt,1))
-      if s:NetrwLcd(curdir)
-        return
-      endif
+    if a:0 > 0
+        let fromdir= a:1
+    else
+        let fromdir= getcwd()
+    endif
 
-    elseif a:tgt =~ '^ftp:'
-      call s:NetrwMethod(a:tgt)
-      if !s:NetrwValidateHostname(g:netrw_machine)
-          call netrw#msg#Notify('ERROR', printf('Rejecting invalid hostname: <%s>', g:netrw_machine))
-          return
-      endif
-
-      if b:netrw_method == 2
-        " handle uploading a list of files via ftp+.netrc
-        let netrw_fname = b:netrw_fname
-        sil NetrwKeepj new
-
-        NetrwKeepj put =g:netrw_ftpmode
-
-        if exists("g:netrw_ftpextracmd")
-          NetrwKeepj put =g:netrw_ftpextracmd
-        endif
-
-        NetrwKeepj call setline(line("$")+1,'lcd "'.fromdir.'"')
-
-        if tgtdir == ""
-          let tgtdir= '/'
-        endif
-        NetrwKeepj call setline(line("$")+1,'cd "'.tgtdir.'"')
-
-        for fname in a:fname
-          NetrwKeepj call setline(line("$")+1,'put "'.s:NetrwFile(fname).'"')
-        endfor
-
-        if exists("g:netrw_port") && g:netrw_port != ""
-          call netrw#os#Execute(s:netrw_silentxfer."%!".s:netrw_ftp_cmd." -i ".netrw#os#Escape(g:netrw_machine,1)." ".netrw#os#Escape(g:netrw_port,1))
+    if type(a:fname) == 1
+        " handle uploading a single file using NetWrite
+        1split
+        exe "NetrwKeepj e ".fnameescape(s:NetrwFile(a:fname))
+        if a:tgt =~ '/$'
+            let wfname= substitute(a:fname,'^.*/','','')
+            exe "w! ".fnameescape(a:tgt.wfname)
         else
-          call netrw#os#Execute(s:netrw_silentxfer."%!".s:netrw_ftp_cmd." -i ".netrw#os#Escape(g:netrw_machine,1))
+            exe "w ".fnameescape(a:tgt)
         endif
-        " If the result of the ftp operation isn't blank, show an error message (tnx to Doug Claar)
-        sil NetrwKeepj g/Local directory now/d
-        call histdel("/",-1)
-        if getline(1) !~ "^$" && !exists("g:netrw_quiet") && getline(1) !~ '^Trying '
-          call netrw#msg#Notify('ERROR', getline(1))
-        else
-          bw!|q
-        endif
+        q!
 
-      elseif b:netrw_method == 3
-        " upload with ftp + machine, id, passwd, and fname (ie. no .netrc)
-        let netrw_fname= b:netrw_fname
-        NetrwKeepj call s:SaveBufVars()|sil NetrwKeepj new|NetrwKeepj call s:RestoreBufVars()
-        let tmpbufnr= bufnr("%")
-        setl ff=unix
-
-        if exists("g:netrw_port") && g:netrw_port != ""
-          NetrwKeepj put ='open '.g:netrw_machine.' '.g:netrw_port
-        else
-          NetrwKeepj put ='open '.g:netrw_machine
-        endif
-
-        if exists("g:netrw_uid") && g:netrw_uid != ""
-          if exists("g:netrw_ftp") && g:netrw_ftp == 1
-            NetrwKeepj put =g:netrw_uid
-            if exists("s:netrw_passwd")
-              NetrwKeepj call setline(line("$")+1,'"'.s:netrw_passwd.'"')
+    elseif type(a:fname) == 3
+        " handle uploading a list of files via scp
+        let curdir= getcwd()
+        if a:tgt =~ '^scp:'
+            if s:NetrwLcd(fromdir)
+                return
             endif
-          elseif exists("s:netrw_passwd")
-            NetrwKeepj put ='user \"'.g:netrw_uid.'\" \"'.s:netrw_passwd.'\"'
-          endif
-        endif
+            let filelist= deepcopy(s:netrwmarkfilelist_{bufnr('%')})
+            let args    = join(map(filelist,"netrw#os#Escape(v:val, 1)"))
+            if exists("g:netrw_port") && g:netrw_port != ""
+                let useport= " ".g:netrw_scpport." ".g:netrw_port
+            else
+                let useport= ""
+            endif
+            let machine = substitute(a:tgt,'^scp://\([^/:]\+\).*$','\1','')
+            let tgt     = substitute(a:tgt,'^scp://[^/]\+/\(.*\)$','\1','')
+            call netrw#os#Execute(s:netrw_silentxfer."!".g:netrw_scp_cmd.netrw#os#Escape(useport,1)." ".args." ".netrw#os#Escape(machine.":".tgt,1))
+            if s:NetrwLcd(curdir)
+                return
+            endif
 
-        NetrwKeepj call setline(line("$")+1,'lcd "'.fromdir.'"')
+        elseif a:tgt =~ '^ftp:'
+            call s:NetrwMethod(a:tgt)
+            if !s:NetrwValidateHostname(g:netrw_machine)
+                call netrw#msg#Notify('ERROR', printf('Rejecting invalid hostname: <%s>', g:netrw_machine))
+                return
+            endif
 
-        if exists("b:netrw_fname") && b:netrw_fname != ""
-          NetrwKeepj call setline(line("$")+1,'cd "'.b:netrw_fname.'"')
-        endif
+            if b:netrw_method == 2
+                " handle uploading a list of files via ftp+.netrc
+                let netrw_fname = b:netrw_fname
+                sil NetrwKeepj new
 
-        if exists("g:netrw_ftpextracmd")
-          NetrwKeepj put =g:netrw_ftpextracmd
-        endif
+                NetrwKeepj put =g:netrw_ftpmode
 
-        for fname in a:fname
-          NetrwKeepj call setline(line("$")+1,'put "'.fname.'"')
-        endfor
+                if exists("g:netrw_ftpextracmd")
+                    NetrwKeepj put =g:netrw_ftpextracmd
+                endif
 
-        " perform ftp:
-        " -i       : turns off interactive prompting from ftp
-        " -n  unix : DON'T use <.netrc>, even though it exists
-        " -n  win32: quit being obnoxious about password
-        NetrwKeepj norm! 1G"_dd
-        call netrw#os#Execute(s:netrw_silentxfer."%!".s:netrw_ftp_cmd." ".g:netrw_ftp_options)
-        " If the result of the ftp operation isn't blank, show an error message (tnx to Doug Claar)
-        sil NetrwKeepj g/Local directory now/d
-        call histdel("/",-1)
-        if getline(1) !~ "^$" && !exists("g:netrw_quiet") && getline(1) !~ '^Trying '
-          let debugkeep= &debug
-          setl debug=msg
-          call netrw#msg#Notify('ERROR', getline(1))
-          let &debug = debugkeep
-          let mod    = 1
+                NetrwKeepj call setline(line("$")+1,'lcd "'.fromdir.'"')
+
+                if tgtdir == ""
+                    let tgtdir= '/'
+                endif
+                NetrwKeepj call setline(line("$")+1,'cd "'.tgtdir.'"')
+
+                for fname in a:fname
+                    NetrwKeepj call setline(line("$")+1,'put "'.s:NetrwFile(fname).'"')
+                endfor
+
+                if exists("g:netrw_port") && g:netrw_port != ""
+                    call netrw#os#Execute(s:netrw_silentxfer."%!".s:netrw_ftp_cmd." -i ".netrw#os#Escape(g:netrw_machine,1)." ".netrw#os#Escape(g:netrw_port,1))
+                else
+                    call netrw#os#Execute(s:netrw_silentxfer."%!".s:netrw_ftp_cmd." -i ".netrw#os#Escape(g:netrw_machine,1))
+                endif
+                " If the result of the ftp operation isn't blank, show an error message (tnx to Doug Claar)
+                sil NetrwKeepj g/Local directory now/d
+                call histdel("/",-1)
+                if getline(1) !~ "^$" && getline(1) !~ '^Trying '
+                    call netrw#msg#Notify('ERROR', getline(1))
+                else
+                    bw!|q
+                endif
+
+            elseif b:netrw_method == 3
+                " upload with ftp + machine, id, passwd, and fname (ie. no .netrc)
+                let netrw_fname= b:netrw_fname
+                NetrwKeepj call s:SaveBufVars()|sil NetrwKeepj new|NetrwKeepj call s:RestoreBufVars()
+                let tmpbufnr= bufnr("%")
+                setl ff=unix
+
+                if exists("g:netrw_port") && g:netrw_port != ""
+                    NetrwKeepj put ='open '.g:netrw_machine.' '.g:netrw_port
+                else
+                    NetrwKeepj put ='open '.g:netrw_machine
+                endif
+
+                if exists("g:netrw_uid") && g:netrw_uid != ""
+                    if exists("g:netrw_ftp") && g:netrw_ftp == 1
+                        NetrwKeepj put =g:netrw_uid
+                        if exists("s:netrw_passwd")
+                            NetrwKeepj call setline(line("$")+1,'"'.s:netrw_passwd.'"')
+                        endif
+                    elseif exists("s:netrw_passwd")
+                        NetrwKeepj put ='user \"'.g:netrw_uid.'\" \"'.s:netrw_passwd.'\"'
+                    endif
+                endif
+
+                NetrwKeepj call setline(line("$")+1,'lcd "'.fromdir.'"')
+
+                if exists("b:netrw_fname") && b:netrw_fname != ""
+                    NetrwKeepj call setline(line("$")+1,'cd "'.b:netrw_fname.'"')
+                endif
+
+                if exists("g:netrw_ftpextracmd")
+                    NetrwKeepj put =g:netrw_ftpextracmd
+                endif
+
+                for fname in a:fname
+                    NetrwKeepj call setline(line("$")+1,'put "'.fname.'"')
+                endfor
+
+                " perform ftp:
+                " -i       : turns off interactive prompting from ftp
+                " -n  unix : DON'T use <.netrc>, even though it exists
+                " -n  win32: quit being obnoxious about password
+                NetrwKeepj norm! 1G"_dd
+                call netrw#os#Execute(s:netrw_silentxfer."%!".s:netrw_ftp_cmd." ".g:netrw_ftp_options)
+                " If the result of the ftp operation isn't blank, show an error message (tnx to Doug Claar)
+                sil NetrwKeepj g/Local directory now/d
+                call histdel("/",-1)
+                if getline(1) !~ "^$" && getline(1) !~ '^Trying '
+                    let debugkeep= &debug
+                    setl debug=msg
+                    call netrw#msg#Notify('ERROR', getline(1))
+                    let &debug = debugkeep
+                    let mod    = 1
+                else
+                    bw!|q
+                endif
+            elseif !exists("b:netrw_method") || b:netrw_method < 0
+                return
+            endif
         else
-          bw!|q
+            call netrw#msg#Notify('ERROR', printf("can't obtain files with protocol from<%s>", a:tgt))
         endif
-      elseif !exists("b:netrw_method") || b:netrw_method < 0
-        return
-      endif
-    else
-      call netrw#msg#Notify('ERROR', printf("can't obtain files with protocol from<%s>", a:tgt))
     endif
-  endif
 
 endfun
 
 " s:NetrwPreview: supports netrw's "p" map {{{2
 fun! s:NetrwPreview(path) range
-  let ykeep= @@
-  NetrwKeepj call s:NetrwOptionsSave("s:")
-  if a:path !~ '^\*\{1,2}/' && a:path !~ '^\a\{3,}://'
-    NetrwKeepj call s:NetrwOptionsSafe(1)
-  else
-    NetrwKeepj call s:NetrwOptionsSafe(0)
-  endif
-  if has("quickfix")
-    if !isdirectory(s:NetrwFile(a:path))
-      if g:netrw_preview
-        " vertical split
-        let pvhkeep = &pvh
-        let winsz   = (g:netrw_winsize > 0)? (g:netrw_winsize*winwidth(0))/100 : -g:netrw_winsize
-        let &pvh    = winwidth(0) - winsz
-      else
-        " horizontal split
-        let pvhkeep = &pvh
-        let winsz   = (g:netrw_winsize > 0)? (g:netrw_winsize*winheight(0))/100 : -g:netrw_winsize
-        let &pvh    = winheight(0) - winsz
-      endif
-      " g:netrw_preview   g:netrw_alto
-      "    1 : vert        1: top       -- preview window is vertically   split off and on the left
-      "    1 : vert        0: bot       -- preview window is vertically   split off and on the right
-      "    0 :             1: top       -- preview window is horizontally split off and on the top
-      "    0 :             0: bot       -- preview window is horizontally split off and on the bottom
-      "
-      " Note that the file being previewed is already known to not be a directory, hence we can avoid doing a LocalBrowseCheck() check via
-      " the BufEnter event set up in netrwPlugin.vim
-      let eikeep = &ei
-      set ei=BufEnter
-      exe (g:netrw_alto? "top " : "bot ").(g:netrw_preview? "vert " : "")."pedit ".fnameescape(a:path)
-      let &ei= eikeep
-      if exists("pvhkeep")
-        let &pvh= pvhkeep
-      endif
-    elseif !exists("g:netrw_quiet")
-      call netrw#msg#Notify('WARNING', printf('sorry, cannot preview a directory such as <%s>', a:path))
+    let ykeep= @@
+    NetrwKeepj call s:NetrwOptionsSave("s:")
+    if a:path !~ '^\*\{1,2}/' && a:path !~ '^\a\{3,}://'
+        NetrwKeepj call s:NetrwOptionsSafe(1)
+    else
+        NetrwKeepj call s:NetrwOptionsSafe(0)
     endif
-  elseif !exists("g:netrw_quiet")
-    call netrw#msg#Notify('WARNING', 'sorry, to preview your vim needs the quickfix feature compiled in')
-  endif
-  NetrwKeepj call s:NetrwOptionsRestore("s:")
-  let @@= ykeep
+    if has("quickfix")
+        if !isdirectory(s:NetrwFile(a:path))
+            if g:netrw_preview
+                " vertical split
+                let pvhkeep = &pvh
+                let winsz   = (g:netrw_winsize > 0)? (g:netrw_winsize*winwidth(0))/100 : -g:netrw_winsize
+                let &pvh    = winwidth(0) - winsz
+            else
+                " horizontal split
+                let pvhkeep = &pvh
+                let winsz   = (g:netrw_winsize > 0)? (g:netrw_winsize*winheight(0))/100 : -g:netrw_winsize
+                let &pvh    = winheight(0) - winsz
+            endif
+            " g:netrw_preview   g:netrw_alto
+            "    1 : vert        1: top       -- preview window is vertically   split off and on the left
+            "    1 : vert        0: bot       -- preview window is vertically   split off and on the right
+            "    0 :             1: top       -- preview window is horizontally split off and on the top
+            "    0 :             0: bot       -- preview window is horizontally split off and on the bottom
+            "
+            " Note that the file being previewed is already known to not be a directory, hence we can avoid doing a LocalBrowseCheck() check via
+            " the BufEnter event set up in netrwPlugin.vim
+            let eikeep = &ei
+            set ei=BufEnter
+            exe (g:netrw_alto? "top " : "bot ").(g:netrw_preview? "vert " : "")."pedit ".fnameescape(a:path)
+            let &ei= eikeep
+            if exists("pvhkeep")
+                let &pvh= pvhkeep
+            endif
+        else
+            call netrw#msg#Notify('WARNING', printf('sorry, cannot preview a directory such as <%s>', a:path))
+        endif
+    else
+        call netrw#msg#Notify('WARNING', 'sorry, to preview your vim needs the quickfix feature compiled in')
+    endif
+    NetrwKeepj call s:NetrwOptionsRestore("s:")
+    let @@= ykeep
 endfun
 
 " s:NetrwRefresh: {{{2
 fun! s:NetrwRefresh(islocal,dirname)
-  " at the current time (Mar 19, 2007) all calls to NetrwRefresh() call NetrwBrowseChgDir() first.
-  setl ma noro
-  let ykeep      = @@
-  if exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST
-    if !exists("w:netrw_treetop")
-      if exists("b:netrw_curdir")
-        let w:netrw_treetop= b:netrw_curdir
-      else
-        let w:netrw_treetop= getcwd()
-      endif
+    " at the current time (Mar 19, 2007) all calls to NetrwRefresh() call NetrwBrowseChgDir() first.
+    setl ma noro
+    let ykeep      = @@
+    if exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST
+        if !exists("w:netrw_treetop")
+            if exists("b:netrw_curdir")
+                let w:netrw_treetop= b:netrw_curdir
+            else
+                let w:netrw_treetop= getcwd()
+            endif
+        endif
+        NetrwKeepj call s:NetrwRefreshTreeDict(w:netrw_treetop)
     endif
-    NetrwKeepj call s:NetrwRefreshTreeDict(w:netrw_treetop)
-  endif
 
-  " save the cursor position before refresh.
-  let screenposn = winsaveview()
+    " save the cursor position before refresh.
+    let screenposn = winsaveview()
 
-  sil! NetrwKeepj %d _
-  if a:islocal
-    NetrwKeepj call netrw#LocalBrowseCheck(a:dirname)
-  else
-    NetrwKeepj call s:NetrwBrowse(a:islocal,a:dirname)
-  endif
-
-  " restore position
-  NetrwKeepj call winrestview(screenposn)
-
-  " restore file marks
-  if has("syntax") && exists("g:syntax_on") && g:syntax_on
-    if exists("s:netrwmarkfilemtch_{bufnr('%')}") && s:netrwmarkfilemtch_{bufnr("%")} != ""
-      exe "2match netrwMarkFile /".s:netrwmarkfilemtch_{bufnr("%")}."/"
+    sil! NetrwKeepj %d _
+    if a:islocal
+        NetrwKeepj call netrw#LocalBrowseCheck(a:dirname)
     else
-      2match none
+        NetrwKeepj call s:NetrwBrowse(a:islocal,a:dirname)
     endif
-  endif
 
-  "  restore
-  let @@= ykeep
+    " restore position
+    NetrwKeepj call winrestview(screenposn)
+
+    " restore file marks
+    if has("syntax") && exists("g:syntax_on") && g:syntax_on
+        if exists("s:netrwmarkfilemtch_{bufnr('%')}") && s:netrwmarkfilemtch_{bufnr("%")} != ""
+            exe "2match netrwMarkFile /".s:netrwmarkfilemtch_{bufnr("%")}."/"
+        else
+            2match none
+        endif
+    endif
+
+    "  restore
+    let @@= ykeep
 endfun
 
 " s:NetrwRefreshDir: refreshes a directory by name {{{2
 "                    Called by NetrwMarkFileCopy()
 "                    Interfaces to s:NetrwRefresh() and s:LocalBrowseRefresh()
 fun! s:NetrwRefreshDir(islocal,dirname)
-  if g:netrw_fastbrowse == 0
-    " slowest mode (keep buffers refreshed, local or remote)
-    let tgtwin= bufwinnr(a:dirname)
+    if g:netrw_fastbrowse == 0
+        " slowest mode (keep buffers refreshed, local or remote)
+        let tgtwin= bufwinnr(a:dirname)
 
-    if tgtwin > 0
-      " tgtwin is being displayed, so refresh it
-      let curwin= winnr()
-      exe tgtwin."wincmd w"
-      NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
-      exe curwin."wincmd w"
+        if tgtwin > 0
+            " tgtwin is being displayed, so refresh it
+            let curwin= winnr()
+            exe tgtwin."wincmd w"
+            NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
+            exe curwin."wincmd w"
 
-    elseif bufnr(a:dirname) > 0
-      let bn= bufnr(a:dirname)
-      exe "sil keepj bd ".bn
+        elseif bufnr(a:dirname) > 0
+            let bn= bufnr(a:dirname)
+            exe "sil keepj bd ".bn
+        endif
+
+    elseif g:netrw_fastbrowse <= 1
+        NetrwKeepj call s:LocalBrowseRefresh()
     endif
-
-  elseif g:netrw_fastbrowse <= 1
-    NetrwKeepj call s:LocalBrowseRefresh()
-  endif
 endfun
 
 " s:NetrwSetChgwin: set g:netrw_chgwin; a <cr> will use the specified
@@ -7150,18 +7113,18 @@ endfun
 " Supports   [count]C  where the count, if present, is used to specify
 " a window to use for editing via the <cr> mapping.
 fun! s:NetrwSetChgwin(...)
-  if a:0 > 0
-    if a:1 == ""    " :NetrwC win#
-      let g:netrw_chgwin= winnr()
-    else              " :NetrwC
-      let g:netrw_chgwin= a:1
+    if a:0 > 0
+        if a:1 == ""    " :NetrwC win#
+            let g:netrw_chgwin= winnr()
+        else              " :NetrwC
+            let g:netrw_chgwin= a:1
+        endif
+    elseif v:count > 0 " [count]C
+        let g:netrw_chgwin= v:count
+    else               " C
+        let g:netrw_chgwin= winnr()
     endif
-  elseif v:count > 0 " [count]C
-    let g:netrw_chgwin= v:count
-  else               " C
-    let g:netrw_chgwin= winnr()
-  endif
-  echo "editing window now set to window#".g:netrw_chgwin
+    echo "editing window now set to window#".g:netrw_chgwin
 endfun
 
 " s:NetrwSetSort: sets up the sort based on the g:netrw_sort_sequence {{{2
@@ -7170,66 +7133,66 @@ endfun
 "          "files" that satisfy each pattern, putting the priority / in
 "          front.  An "*" pattern handles the default priority.
 fun! s:NetrwSetSort()
-  let ykeep= @@
-  if w:netrw_liststyle == s:LONGLIST
-    let seqlist  = substitute(g:netrw_sort_sequence,'\$','\\%(\t\\|\$\\)','ge')
-  else
-    let seqlist  = g:netrw_sort_sequence
-  endif
-  " sanity check -- insure that * appears somewhere
-  if seqlist == ""
-    let seqlist= '*'
-  elseif seqlist !~ '\*'
-    let seqlist= seqlist.',*'
-  endif
-  let priority = 1
-  while seqlist != ""
-    if seqlist =~ ','
-      let seq     = substitute(seqlist,',.*$','','e')
-      let seqlist = substitute(seqlist,'^.\{-},\(.*\)$','\1','e')
+    let ykeep= @@
+    if w:netrw_liststyle == s:LONGLIST
+        let seqlist  = substitute(g:netrw_sort_sequence,'\$','\\%(\t\\|\$\\)','ge')
     else
-      let seq     = seqlist
-      let seqlist = ""
+        let seqlist  = g:netrw_sort_sequence
     endif
-    if priority < 10
-      let spriority= "00".priority.g:netrw_sepchr
-    elseif priority < 100
-      let spriority= "0".priority.g:netrw_sepchr
-    else
-      let spriority= priority.g:netrw_sepchr
+    " sanity check -- insure that * appears somewhere
+    if seqlist == ""
+        let seqlist= '*'
+    elseif seqlist !~ '\*'
+        let seqlist= seqlist.',*'
+    endif
+    let priority = 1
+    while seqlist != ""
+        if seqlist =~ ','
+            let seq     = substitute(seqlist,',.*$','','e')
+            let seqlist = substitute(seqlist,'^.\{-},\(.*\)$','\1','e')
+        else
+            let seq     = seqlist
+            let seqlist = ""
+        endif
+        if priority < 10
+            let spriority= "00".priority.g:netrw_sepchr
+        elseif priority < 100
+            let spriority= "0".priority.g:netrw_sepchr
+        else
+            let spriority= priority.g:netrw_sepchr
+        endif
+
+        " sanity check
+        if w:netrw_bannercnt > line("$")
+            " apparently no files were left after a Hiding pattern was used
+            return
+        endif
+        if seq == '*'
+            let starpriority= spriority
+        else
+            exe 'sil NetrwKeepj '.w:netrw_bannercnt.',$g/'.seq.'/s/^/'.spriority.'/'
+            call histdel("/",-1)
+            " sometimes multiple sorting patterns will match the same file or directory.
+            " The following substitute is intended to remove the excess matches.
+            exe 'sil NetrwKeepj '.w:netrw_bannercnt.',$g/^\d\{3}'.g:netrw_sepchr.'\d\{3}\//s/^\d\{3}'.g:netrw_sepchr.'\(\d\{3}\/\).\@=/\1/e'
+            NetrwKeepj call histdel("/",-1)
+        endif
+        let priority = priority + 1
+    endwhile
+    if exists("starpriority")
+        exe 'sil NetrwKeepj '.w:netrw_bannercnt.',$v/^\d\{3}'.g:netrw_sepchr.'/s/^/'.starpriority.'/e'
+        NetrwKeepj call histdel("/",-1)
     endif
 
-    " sanity check
-    if w:netrw_bannercnt > line("$")
-      " apparently no files were left after a Hiding pattern was used
-      return
-    endif
-    if seq == '*'
-      let starpriority= spriority
-    else
-      exe 'sil NetrwKeepj '.w:netrw_bannercnt.',$g/'.seq.'/s/^/'.spriority.'/'
-      call histdel("/",-1)
-      " sometimes multiple sorting patterns will match the same file or directory.
-      " The following substitute is intended to remove the excess matches.
-      exe 'sil NetrwKeepj '.w:netrw_bannercnt.',$g/^\d\{3}'.g:netrw_sepchr.'\d\{3}\//s/^\d\{3}'.g:netrw_sepchr.'\(\d\{3}\/\).\@=/\1/e'
-      NetrwKeepj call histdel("/",-1)
-    endif
-    let priority = priority + 1
-  endwhile
-  if exists("starpriority")
-    exe 'sil NetrwKeepj '.w:netrw_bannercnt.',$v/^\d\{3}'.g:netrw_sepchr.'/s/^/'.starpriority.'/e'
+    " Following line associated with priority -- items that satisfy a priority
+    " pattern get prefixed by ###/ which permits easy sorting by priority.
+    " Sometimes files can satisfy multiple priority patterns -- only the latest
+    " priority pattern needs to be retained.  So, at this point, these excess
+    " priority prefixes need to be removed, but not directories that happen to
+    " be just digits themselves.
+    exe 'sil NetrwKeepj '.w:netrw_bannercnt.',$s/^\(\d\{3}'.g:netrw_sepchr.'\)\%(\d\{3}'.g:netrw_sepchr.'\)\+\ze./\1/e'
     NetrwKeepj call histdel("/",-1)
-  endif
-
-  " Following line associated with priority -- items that satisfy a priority
-  " pattern get prefixed by ###/ which permits easy sorting by priority.
-  " Sometimes files can satisfy multiple priority patterns -- only the latest
-  " priority pattern needs to be retained.  So, at this point, these excess
-  " priority prefixes need to be removed, but not directories that happen to
-  " be just digits themselves.
-  exe 'sil NetrwKeepj '.w:netrw_bannercnt.',$s/^\(\d\{3}'.g:netrw_sepchr.'\)\%(\d\{3}'.g:netrw_sepchr.'\)\+\ze./\1/e'
-  NetrwKeepj call histdel("/",-1)
-  let @@= ykeep
+    let @@= ykeep
 
 endfun
 
@@ -7239,43 +7202,43 @@ endfun
 "               See :help netrw-qb for how to make the choice.
 fun! s:NetrwSetTgt(islocal,bookhist,choice)
 
-  if     a:bookhist == 'b'
-    " supports choosing a bookmark as a target using a qb-generated list
-    let choice= a:choice - 1
-    if exists("g:netrw_bookmarklist[".choice."]")
-      call netrw#MakeTgt(g:netrw_bookmarklist[choice])
-    else
-      echomsg "Sorry, bookmark#".a:choice." doesn't exist!"
+    if     a:bookhist == 'b'
+        " supports choosing a bookmark as a target using a qb-generated list
+        let choice= a:choice - 1
+        if exists("g:netrw_bookmarklist[".choice."]")
+            call netrw#MakeTgt(g:netrw_bookmarklist[choice])
+        else
+            echomsg "Sorry, bookmark#".a:choice." doesn't exist!"
+        endif
+
+    elseif a:bookhist == 'h'
+        " supports choosing a history stack entry as a target using a qb-generated list
+        let choice= (a:choice % g:netrw_dirhistmax) + 1
+        if exists("g:netrw_dirhist_".choice)
+            let histentry = g:netrw_dirhist_{choice}
+            call netrw#MakeTgt(histentry)
+        else
+            echomsg "Sorry, history#".a:choice." not available!"
+        endif
     endif
 
-  elseif a:bookhist == 'h'
-    " supports choosing a history stack entry as a target using a qb-generated list
-    let choice= (a:choice % g:netrw_dirhistmax) + 1
-    if exists("g:netrw_dirhist_".choice)
-      let histentry = g:netrw_dirhist_{choice}
-      call netrw#MakeTgt(histentry)
-    else
-      echomsg "Sorry, history#".a:choice." not available!"
+    " refresh the display
+    if !exists("b:netrw_curdir")
+        let b:netrw_curdir= getcwd()
     endif
-  endif
-
-  " refresh the display
-  if !exists("b:netrw_curdir")
-    let b:netrw_curdir= getcwd()
-  endif
-  call s:NetrwRefresh(a:islocal,b:netrw_curdir)
+    call s:NetrwRefresh(a:islocal,b:netrw_curdir)
 
 endfun
 
 " s:NetrwSortStyle: change sorting style (name - time - size - exten) and refresh display {{{2
 fun! s:NetrwSortStyle(islocal)
-  NetrwKeepj call s:NetrwSaveWordPosn()
-  let svpos= winsaveview()
+    NetrwKeepj call s:NetrwSaveWordPosn()
+    let svpos= winsaveview()
 
-  let g:netrw_sort_by= (g:netrw_sort_by =~# '^n')? 'time' : (g:netrw_sort_by =~# '^t')? 'size' : (g:netrw_sort_by =~# '^siz')? 'exten' : 'name'
-  NetrwKeepj norm! 0
-  NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
-  NetrwKeepj call winrestview(svpos)
+    let g:netrw_sort_by= (g:netrw_sort_by =~# '^n')? 'time' : (g:netrw_sort_by =~# '^t')? 'size' : (g:netrw_sort_by =~# '^siz')? 'exten' : 'name'
+    NetrwKeepj norm! 0
+    NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
+    NetrwKeepj call winrestview(svpos)
 endfun
 
 " s:NetrwSplit: mode {{{2
@@ -7287,361 +7250,361 @@ endfun
 "           =5 : local and v
 fun! s:NetrwSplit(mode)
 
-  let ykeep= @@
-  call s:SaveWinVars()
+    let ykeep= @@
+    call s:SaveWinVars()
 
-  if a:mode == 0
-    " remote and o
-    let winsz= (g:netrw_winsize > 0)? (g:netrw_winsize*winheight(0))/100 : -g:netrw_winsize
-    if winsz == 0|let winsz= ""|endif
-    exe (g:netrw_alto? "bel " : "abo ").winsz."wincmd s"
-    let s:didsplit= 1
-    NetrwKeepj call s:RestoreWinVars()
-    NetrwKeepj call s:NetrwBrowse(0,s:NetrwBrowseChgDir(0,s:NetrwGetWord(),1))
-    unlet s:didsplit
+    if a:mode == 0
+        " remote and o
+        let winsz= (g:netrw_winsize > 0)? (g:netrw_winsize*winheight(0))/100 : -g:netrw_winsize
+        if winsz == 0|let winsz= ""|endif
+        exe (g:netrw_alto? "bel " : "abo ").winsz."wincmd s"
+        let s:didsplit= 1
+        NetrwKeepj call s:RestoreWinVars()
+        NetrwKeepj call s:NetrwBrowse(0,s:NetrwBrowseChgDir(0,s:NetrwGetWord(),1))
+        unlet s:didsplit
 
-  elseif a:mode == 1
-    " remote and t
-    let newdir  = s:NetrwBrowseChgDir(0,s:NetrwGetWord(),1)
-    tabnew
-    let s:didsplit= 1
-    NetrwKeepj call s:RestoreWinVars()
-    NetrwKeepj call s:NetrwBrowse(0,newdir)
-    unlet s:didsplit
+    elseif a:mode == 1
+        " remote and t
+        let newdir  = s:NetrwBrowseChgDir(0,s:NetrwGetWord(),1)
+        tabnew
+        let s:didsplit= 1
+        NetrwKeepj call s:RestoreWinVars()
+        NetrwKeepj call s:NetrwBrowse(0,newdir)
+        unlet s:didsplit
 
-  elseif a:mode == 2
-    " remote and v
-    let winsz= (g:netrw_winsize > 0)? (g:netrw_winsize*winwidth(0))/100 : -g:netrw_winsize
-    if winsz == 0|let winsz= ""|endif
-    exe (g:netrw_altv? "rightb " : "lefta ").winsz."wincmd v"
-    let s:didsplit= 1
-    NetrwKeepj call s:RestoreWinVars()
-    NetrwKeepj call s:NetrwBrowse(0,s:NetrwBrowseChgDir(0,s:NetrwGetWord(),1))
-    unlet s:didsplit
+    elseif a:mode == 2
+        " remote and v
+        let winsz= (g:netrw_winsize > 0)? (g:netrw_winsize*winwidth(0))/100 : -g:netrw_winsize
+        if winsz == 0|let winsz= ""|endif
+        exe (g:netrw_altv? "rightb " : "lefta ").winsz."wincmd v"
+        let s:didsplit= 1
+        NetrwKeepj call s:RestoreWinVars()
+        NetrwKeepj call s:NetrwBrowse(0,s:NetrwBrowseChgDir(0,s:NetrwGetWord(),1))
+        unlet s:didsplit
 
-  elseif a:mode == 3
-    " local and o
-    let winsz= (g:netrw_winsize > 0)? (g:netrw_winsize*winheight(0))/100 : -g:netrw_winsize
-    if winsz == 0|let winsz= ""|endif
-    exe (g:netrw_alto? "bel " : "abo ").winsz."wincmd s"
-    let s:didsplit= 1
-    NetrwKeepj call s:RestoreWinVars()
-    NetrwKeepj call netrw#LocalBrowseCheck(s:NetrwBrowseChgDir(1,s:NetrwGetWord(),1))
-    unlet s:didsplit
+    elseif a:mode == 3
+        " local and o
+        let winsz= (g:netrw_winsize > 0)? (g:netrw_winsize*winheight(0))/100 : -g:netrw_winsize
+        if winsz == 0|let winsz= ""|endif
+        exe (g:netrw_alto? "bel " : "abo ").winsz."wincmd s"
+        let s:didsplit= 1
+        NetrwKeepj call s:RestoreWinVars()
+        NetrwKeepj call netrw#LocalBrowseCheck(s:NetrwBrowseChgDir(1,s:NetrwGetWord(),1))
+        unlet s:didsplit
 
-  elseif a:mode == 4
-    " local and t
-    let cursorword  = s:NetrwGetWord()
-    let eikeep      = &ei
-    let netrw_winnr = winnr()
-    let netrw_line  = line(".")
-    let netrw_col   = virtcol(".")
-    NetrwKeepj norm! H0
-    let netrw_hline = line(".")
-    setl ei=all
-    exe "NetrwKeepj norm! ".netrw_hline."G0z\<CR>"
-    exe "NetrwKeepj norm! ".netrw_line."G0".netrw_col."\<bar>"
-    let &ei          = eikeep
-    let netrw_curdir = s:NetrwTreeDir(0)
-    tabnew
-    let b:netrw_curdir = netrw_curdir
-    let s:didsplit     = 1
-    NetrwKeepj call s:RestoreWinVars()
-    NetrwKeepj call netrw#LocalBrowseCheck(s:NetrwBrowseChgDir(1,cursorword,0))
-    if &ft == "netrw"
-      setl ei=all
-      exe "NetrwKeepj norm! ".netrw_hline."G0z\<CR>"
-      exe "NetrwKeepj norm! ".netrw_line."G0".netrw_col."\<bar>"
-      let &ei= eikeep
+    elseif a:mode == 4
+        " local and t
+        let cursorword  = s:NetrwGetWord()
+        let eikeep      = &ei
+        let netrw_winnr = winnr()
+        let netrw_line  = line(".")
+        let netrw_col   = virtcol(".")
+        NetrwKeepj norm! H0
+        let netrw_hline = line(".")
+        setl ei=all
+        exe "NetrwKeepj norm! ".netrw_hline."G0z\<CR>"
+        exe "NetrwKeepj norm! ".netrw_line."G0".netrw_col."\<bar>"
+        let &ei          = eikeep
+        let netrw_curdir = s:NetrwTreeDir(0)
+        tabnew
+        let b:netrw_curdir = netrw_curdir
+        let s:didsplit     = 1
+        NetrwKeepj call s:RestoreWinVars()
+        NetrwKeepj call netrw#LocalBrowseCheck(s:NetrwBrowseChgDir(1,cursorword,0))
+        if &ft == "netrw"
+            setl ei=all
+            exe "NetrwKeepj norm! ".netrw_hline."G0z\<CR>"
+            exe "NetrwKeepj norm! ".netrw_line."G0".netrw_col."\<bar>"
+            let &ei= eikeep
+        endif
+        unlet s:didsplit
+
+    elseif a:mode == 5
+        " local and v
+        let winsz= (g:netrw_winsize > 0)? (g:netrw_winsize*winwidth(0))/100 : -g:netrw_winsize
+        if winsz == 0|let winsz= ""|endif
+        exe (g:netrw_altv? "rightb " : "lefta ").winsz."wincmd v"
+        let s:didsplit= 1
+        NetrwKeepj call s:RestoreWinVars()
+        NetrwKeepj call netrw#LocalBrowseCheck(s:NetrwBrowseChgDir(1,s:NetrwGetWord(),1))
+        unlet s:didsplit
+
+    else
+        call netrw#msg#Notify('ERROR', '(NetrwSplit) unsupported mode='.a:mode)
     endif
-    unlet s:didsplit
 
-  elseif a:mode == 5
-    " local and v
-    let winsz= (g:netrw_winsize > 0)? (g:netrw_winsize*winwidth(0))/100 : -g:netrw_winsize
-    if winsz == 0|let winsz= ""|endif
-    exe (g:netrw_altv? "rightb " : "lefta ").winsz."wincmd v"
-    let s:didsplit= 1
-    NetrwKeepj call s:RestoreWinVars()
-    NetrwKeepj call netrw#LocalBrowseCheck(s:NetrwBrowseChgDir(1,s:NetrwGetWord(),1))
-    unlet s:didsplit
-
-  else
-    call netrw#msg#Notify('ERROR', '(NetrwSplit) unsupported mode='.a:mode)
-  endif
-
-  let @@= ykeep
+    let @@= ykeep
 endfun
 
 " s:NetrwTgtMenu: {{{2
 fun! s:NetrwTgtMenu()
-  if !exists("s:netrw_menucnt")
-    return
-  endif
-
-  " the following test assures that gvim is running, has menus available, and has menus enabled.
-  if has("gui") && has("menu") && has("gui_running") && &go =~# 'm' && g:netrw_menu
-    if exists("g:NetrwTopLvlMenu")
-      exe 'sil! unmenu '.g:NetrwTopLvlMenu.'Targets'
-    endif
-    if !exists("s:netrw_initbookhist")
-      call s:NetrwBookHistRead()
+    if !exists("s:netrw_menucnt")
+        return
     endif
 
-    " try to cull duplicate entries
-    let tgtdict={}
-
-    " target bookmarked places
-    if exists("g:netrw_bookmarklist") && g:netrw_bookmarklist != [] && g:netrw_dirhistmax > 0
-      let cnt= 1
-      for bmd in g:netrw_bookmarklist
-        if has_key(tgtdict,bmd)
-          let cnt= cnt + 1
-          continue
+    " the following test assures that gvim is running, has menus available, and has menus enabled.
+    if has("gui") && has("menu") && has("gui_running") && &go =~# 'm' && g:netrw_menu
+        if exists("g:NetrwTopLvlMenu")
+            exe 'sil! unmenu '.g:NetrwTopLvlMenu.'Targets'
         endif
-        let tgtdict[bmd]= cnt
-        let ebmd= escape(bmd,g:netrw_menu_escape)
-        " show bookmarks for goto menu
-        exe 'sil! menu <silent> '.g:NetrwMenuPriority.".19.1.".cnt." ".g:NetrwTopLvlMenu.'Targets.'.ebmd." :call netrw#MakeTgt('".bmd."')\<cr>"
-        let cnt= cnt + 1
-      endfor
-    endif
-
-    " target directory browsing history
-    if exists("g:netrw_dirhistmax") && g:netrw_dirhistmax > 0
-      let histcnt = 1
-      while histcnt <= g:netrw_dirhistmax
-        let priority = g:netrw_dirhistcnt + histcnt
-        if exists("g:netrw_dirhist_{histcnt}")
-          let histentry  = g:netrw_dirhist_{histcnt}
-          if has_key(tgtdict,histentry)
-            let histcnt = histcnt + 1
-            continue
-          endif
-          let tgtdict[histentry] = histcnt
-          let ehistentry         = escape(histentry,g:netrw_menu_escape)
-          exe 'sil! menu <silent> '.g:NetrwMenuPriority.".19.2.".priority." ".g:NetrwTopLvlMenu.'Targets.'.ehistentry."     :call netrw#MakeTgt('".histentry."')\<cr>"
+        if !exists("s:netrw_initbookhist")
+            call s:NetrwBookHistRead()
         endif
-        let histcnt = histcnt + 1
-      endwhile
+
+        " try to cull duplicate entries
+        let tgtdict={}
+
+        " target bookmarked places
+        if exists("g:netrw_bookmarklist") && g:netrw_bookmarklist != [] && g:netrw_dirhistmax > 0
+            let cnt= 1
+            for bmd in g:netrw_bookmarklist
+                if has_key(tgtdict,bmd)
+                    let cnt= cnt + 1
+                    continue
+                endif
+                let tgtdict[bmd]= cnt
+                let ebmd= escape(bmd,g:netrw_menu_escape)
+                " show bookmarks for goto menu
+                exe 'sil! menu <silent> '.g:NetrwMenuPriority.".19.1.".cnt." ".g:NetrwTopLvlMenu.'Targets.'.ebmd." :call netrw#MakeTgt('".bmd."')\<cr>"
+                let cnt= cnt + 1
+            endfor
+        endif
+
+        " target directory browsing history
+        if exists("g:netrw_dirhistmax") && g:netrw_dirhistmax > 0
+            let histcnt = 1
+            while histcnt <= g:netrw_dirhistmax
+                let priority = g:netrw_dirhistcnt + histcnt
+                if exists("g:netrw_dirhist_{histcnt}")
+                    let histentry  = g:netrw_dirhist_{histcnt}
+                    if has_key(tgtdict,histentry)
+                        let histcnt = histcnt + 1
+                        continue
+                    endif
+                    let tgtdict[histentry] = histcnt
+                    let ehistentry         = escape(histentry,g:netrw_menu_escape)
+                    exe 'sil! menu <silent> '.g:NetrwMenuPriority.".19.2.".priority." ".g:NetrwTopLvlMenu.'Targets.'.ehistentry."     :call netrw#MakeTgt('".histentry."')\<cr>"
+                endif
+                let histcnt = histcnt + 1
+            endwhile
+        endif
     endif
-  endif
 endfun
 
 " s:NetrwTreeDir: determine tree directory given current cursor position {{{2
 " (full path directory with trailing slash returned)
 fun! s:NetrwTreeDir(islocal)
 
-  if exists("s:treedir") && exists("s:prevwinopen")
-    " s:NetrwPrevWinOpen opens a "previous" window -- and thus needs to and does call s:NetrwTreeDir early
-    let treedir= s:treedir
-    unlet s:treedir
-    unlet s:prevwinopen
+    if exists("s:treedir") && exists("s:prevwinopen")
+        " s:NetrwPrevWinOpen opens a "previous" window -- and thus needs to and does call s:NetrwTreeDir early
+        let treedir= s:treedir
+        unlet s:treedir
+        unlet s:prevwinopen
+        return treedir
+    endif
+    if exists("s:prevwinopen")
+        unlet s:prevwinopen
+    endif
+
+    if !exists("b:netrw_curdir") || b:netrw_curdir == ""
+        let b:netrw_curdir= getcwd()
+    endif
+    let treedir = b:netrw_curdir
+    let s:treecurpos= winsaveview()
+
+    if exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST
+
+        " extract tree directory if on a line specifying a subdirectory (ie. ends with "/")
+        let curline= substitute(getline('.'),"\t -->.*$",'','')
+        if curline =~ '/$'
+            let treedir= substitute(getline('.'),'^\%('.s:treedepthstring.'\)*\([^'.s:treedepthstring.'].\{-}\)$','\1','e')
+        elseif curline =~ '@$'
+            let potentialdir= resolve(s:NetrwTreePath(w:netrw_treetop))
+        else
+            let treedir= ""
+        endif
+
+        " detect user attempting to close treeroot
+        if curline !~ '^'.s:treedepthstring && getline('.') != '..'
+            " now force a refresh
+            sil! NetrwKeepj %d _
+            return b:netrw_curdir
+        endif
+
+        " COMBAK: a symbolic link may point anywhere -- so it will be used to start a new treetop
+        "   if a:islocal && curline =~ '@$' && isdirectory(s:NetrwFile(potentialdir))
+        "    let newdir          = w:netrw_treetop.'/'.potentialdir
+        if a:islocal && curline =~ '@$'
+            if isdirectory(s:NetrwFile(potentialdir))
+                let treedir = potentialdir
+                let w:netrw_treetop = treedir
+            endif
+        else
+            let potentialdir= s:NetrwFile(substitute(curline,'^'.s:treedepthstring.'\+ \(.*\)@$','\1',''))
+            let treedir = s:NetrwTreePath(w:netrw_treetop)
+        endif
+    endif
+
+    " sanity maintenance: keep those //s away...
+    let treedir= substitute(treedir,'//$','/','')
     return treedir
-  endif
-  if exists("s:prevwinopen")
-    unlet s:prevwinopen
-  endif
-
-  if !exists("b:netrw_curdir") || b:netrw_curdir == ""
-    let b:netrw_curdir= getcwd()
-  endif
-  let treedir = b:netrw_curdir
-  let s:treecurpos= winsaveview()
-
-  if exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST
-
-    " extract tree directory if on a line specifying a subdirectory (ie. ends with "/")
-    let curline= substitute(getline('.'),"\t -->.*$",'','')
-    if curline =~ '/$'
-      let treedir= substitute(getline('.'),'^\%('.s:treedepthstring.'\)*\([^'.s:treedepthstring.'].\{-}\)$','\1','e')
-    elseif curline =~ '@$'
-      let potentialdir= resolve(s:NetrwTreePath(w:netrw_treetop))
-    else
-      let treedir= ""
-    endif
-
-    " detect user attempting to close treeroot
-    if curline !~ '^'.s:treedepthstring && getline('.') != '..'
-      " now force a refresh
-      sil! NetrwKeepj %d _
-      return b:netrw_curdir
-    endif
-
-    " COMBAK: a symbolic link may point anywhere -- so it will be used to start a new treetop
-    "   if a:islocal && curline =~ '@$' && isdirectory(s:NetrwFile(potentialdir))
-    "    let newdir          = w:netrw_treetop.'/'.potentialdir
-    if a:islocal && curline =~ '@$'
-      if isdirectory(s:NetrwFile(potentialdir))
-        let treedir = potentialdir
-        let w:netrw_treetop = treedir
-      endif
-    else
-      let potentialdir= s:NetrwFile(substitute(curline,'^'.s:treedepthstring.'\+ \(.*\)@$','\1',''))
-      let treedir = s:NetrwTreePath(w:netrw_treetop)
-    endif
-  endif
-
-  " sanity maintenance: keep those //s away...
-  let treedir= substitute(treedir,'//$','/','')
-  return treedir
 endfun
 
 " s:NetrwTreeDisplay: recursive tree display {{{2
 fun! s:NetrwTreeDisplay(dir,depth)
-  " ensure that there are no folds
-  setl nofen
+    " ensure that there are no folds
+    setl nofen
 
-  " install ../ and shortdir
-  if a:depth == ""
-    call setline(line("$")+1,'../')
-  endif
-  if a:dir =~ '^\a\{3,}://'
-    if a:dir == w:netrw_treetop
-      let shortdir= a:dir
-    else
-      let shortdir= substitute(a:dir,'^.*/\([^/]\+\)/$','\1/','e')
+    " install ../ and shortdir
+    if a:depth == ""
+        call setline(line("$")+1,'../')
     endif
-    call setline(line("$")+1,a:depth.shortdir)
-  else
-    let shortdir= substitute(a:dir,'^.*/','','e')
-    call setline(line("$")+1,a:depth.shortdir.'/')
-  endif
-  " append a / to dir if its missing one
-  let dir= a:dir
-
-  " display subtrees (if any)
-  let depth= s:treedepthstring.a:depth
-
-  " implement g:netrw_hide for tree listings (uses g:netrw_list_hide)
-  if     g:netrw_hide == 1
-    " hide given patterns
-    let listhide= split(g:netrw_list_hide,',')
-    for pat in listhide
-      call filter(w:netrw_treedict[dir],'v:val !~ "'.escape(pat,'\\').'"')
-    endfor
-
-  elseif g:netrw_hide == 2
-    " show given patterns (only)
-    let listhide= split(g:netrw_list_hide,',')
-    let entries=[]
-    for entry in w:netrw_treedict[dir]
-      for pat in listhide
-        if entry =~ pat
-          call add(entries,entry)
-          break
+    if a:dir =~ '^\a\{3,}://'
+        if a:dir == w:netrw_treetop
+            let shortdir= a:dir
+        else
+            let shortdir= substitute(a:dir,'^.*/\([^/]\+\)/$','\1/','e')
         endif
-      endfor
-    endfor
-    let w:netrw_treedict[dir]= entries
-  endif
-  if depth != ""
-    " always remove "." and ".." entries when there's depth
-    call filter(w:netrw_treedict[dir],'v:val !~ "\\.\\.$"')
-    call filter(w:netrw_treedict[dir],'v:val !~ "\\.\\./$"')
-    call filter(w:netrw_treedict[dir],'v:val !~ "\\.$"')
-    call filter(w:netrw_treedict[dir],'v:val !~ "\\./$"')
-  endif
+        call setline(line("$")+1,a:depth.shortdir)
+    else
+        let shortdir= substitute(a:dir,'^.*/','','e')
+        call setline(line("$")+1,a:depth.shortdir.'/')
+    endif
+    " append a / to dir if its missing one
+    let dir= a:dir
 
-  for entry in w:netrw_treedict[dir]
-    if dir =~ '/$'
-      let direntry= substitute(dir.entry,'[@/]$','','e')
-    else
-      let direntry= substitute(dir.'/'.entry,'[@/]$','','e')
+    " display subtrees (if any)
+    let depth= s:treedepthstring.a:depth
+
+    " implement g:netrw_hide for tree listings (uses g:netrw_list_hide)
+    if     g:netrw_hide == 1
+        " hide given patterns
+        let listhide= split(g:netrw_list_hide,',')
+        for pat in listhide
+            call filter(w:netrw_treedict[dir],'v:val !~ "'.escape(pat,'\\').'"')
+        endfor
+
+    elseif g:netrw_hide == 2
+        " show given patterns (only)
+        let listhide= split(g:netrw_list_hide,',')
+        let entries=[]
+        for entry in w:netrw_treedict[dir]
+            for pat in listhide
+                if entry =~ pat
+                    call add(entries,entry)
+                    break
+                endif
+            endfor
+        endfor
+        let w:netrw_treedict[dir]= entries
     endif
-    if entry =~ '/$' && has_key(w:netrw_treedict,direntry)
-      NetrwKeepj call s:NetrwTreeDisplay(direntry,depth)
-    elseif entry =~ '/$' && has_key(w:netrw_treedict,direntry.'/')
-      NetrwKeepj call s:NetrwTreeDisplay(direntry.'/',depth)
-    elseif entry =~ '@$' && has_key(w:netrw_treedict,direntry.'@')
-      NetrwKeepj call s:NetrwTreeDisplay(direntry.'@',depth)
-    else
-      sil! NetrwKeepj call setline(line("$")+1,depth.entry)
+    if depth != ""
+        " always remove "." and ".." entries when there's depth
+        call filter(w:netrw_treedict[dir],'v:val !~ "\\.\\.$"')
+        call filter(w:netrw_treedict[dir],'v:val !~ "\\.\\./$"')
+        call filter(w:netrw_treedict[dir],'v:val !~ "\\.$"')
+        call filter(w:netrw_treedict[dir],'v:val !~ "\\./$"')
     endif
-  endfor
+
+    for entry in w:netrw_treedict[dir]
+        if dir =~ '/$'
+            let direntry= substitute(dir.entry,'[@/]$','','e')
+        else
+            let direntry= substitute(dir.'/'.entry,'[@/]$','','e')
+        endif
+        if entry =~ '/$' && has_key(w:netrw_treedict,direntry)
+            NetrwKeepj call s:NetrwTreeDisplay(direntry,depth)
+        elseif entry =~ '/$' && has_key(w:netrw_treedict,direntry.'/')
+            NetrwKeepj call s:NetrwTreeDisplay(direntry.'/',depth)
+        elseif entry =~ '@$' && has_key(w:netrw_treedict,direntry.'@')
+            NetrwKeepj call s:NetrwTreeDisplay(direntry.'@',depth)
+        else
+            sil! NetrwKeepj call setline(line("$")+1,depth.entry)
+        endif
+    endfor
 endfun
 
 " s:NetrwRefreshTreeDict: updates the contents information for a tree (w:netrw_treedict) {{{2
 fun! s:NetrwRefreshTreeDict(dir)
-  if !exists("w:netrw_treedict")
-    return
-  endif
-
-  for entry in w:netrw_treedict[a:dir]
-    let direntry= substitute(a:dir.'/'.entry,'[@/]$','','e')
-
-    if entry =~ '/$' && has_key(w:netrw_treedict,direntry)
-      NetrwKeepj call s:NetrwRefreshTreeDict(direntry)
-      let filelist = s:NetrwLocalListingList(direntry,0)
-      let w:netrw_treedict[direntry] = sort(filelist)
-
-    elseif entry =~ '/$' && has_key(w:netrw_treedict,direntry.'/')
-      NetrwKeepj call s:NetrwRefreshTreeDict(direntry.'/')
-      let filelist = s:NetrwLocalListingList(direntry.'/',0)
-      let w:netrw_treedict[direntry] = sort(filelist)
-
-    elseif entry =~ '@$' && has_key(w:netrw_treedict,direntry.'@')
-      NetrwKeepj call s:NetrwRefreshTreeDict(direntry.'/')
-      let liststar   = netrw#fs#Glob(direntry.'/','*',1)
-      let listdotstar= netrw#fs#Glob(direntry.'/','.*',1)
-
-    else
+    if !exists("w:netrw_treedict")
+        return
     endif
-  endfor
+
+    for entry in w:netrw_treedict[a:dir]
+        let direntry= substitute(a:dir.'/'.entry,'[@/]$','','e')
+
+        if entry =~ '/$' && has_key(w:netrw_treedict,direntry)
+            NetrwKeepj call s:NetrwRefreshTreeDict(direntry)
+            let filelist = s:NetrwLocalListingList(direntry,0)
+            let w:netrw_treedict[direntry] = sort(filelist)
+
+        elseif entry =~ '/$' && has_key(w:netrw_treedict,direntry.'/')
+            NetrwKeepj call s:NetrwRefreshTreeDict(direntry.'/')
+            let filelist = s:NetrwLocalListingList(direntry.'/',0)
+            let w:netrw_treedict[direntry] = sort(filelist)
+
+        elseif entry =~ '@$' && has_key(w:netrw_treedict,direntry.'@')
+            NetrwKeepj call s:NetrwRefreshTreeDict(direntry.'/')
+            let liststar   = netrw#fs#Glob(direntry.'/','*',1)
+            let listdotstar= netrw#fs#Glob(direntry.'/','.*',1)
+
+        else
+        endif
+    endfor
 endfun
 
 " s:NetrwTreeListing: displays tree listing from treetop on down, using NetrwTreeDisplay() {{{2
 "                     Called by s:PerformListing()
 fun! s:NetrwTreeListing(dirname)
-  if exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST
+    if exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST
 
-    " update the treetop
-    if !exists("w:netrw_treetop")
-      let w:netrw_treetop= a:dirname
-      let s:netrw_treetop= w:netrw_treetop
-    " use \V in case the directory contains specials chars like '$' or '~'
-    elseif (w:netrw_treetop =~ ('^'.'\V'.a:dirname)
-          \ && strdisplaywidth(a:dirname) < strdisplaywidth(w:netrw_treetop))
-          \ || a:dirname !~ ('^'.'\V'.w:netrw_treetop)
-      let w:netrw_treetop= a:dirname
-      let s:netrw_treetop= w:netrw_treetop
+        " update the treetop
+        if !exists("w:netrw_treetop")
+            let w:netrw_treetop= a:dirname
+            let s:netrw_treetop= w:netrw_treetop
+        " use \V in case the directory contains specials chars like '$' or '~'
+        elseif (w:netrw_treetop =~ ('^'.'\V'.a:dirname)
+                    \ && strdisplaywidth(a:dirname) < strdisplaywidth(w:netrw_treetop))
+                    \ || a:dirname !~ ('^'.'\V'.w:netrw_treetop)
+            let w:netrw_treetop= a:dirname
+            let s:netrw_treetop= w:netrw_treetop
+        endif
+        if exists("w:netrw_treetop")
+            let s:netrw_treetop= w:netrw_treetop
+        else
+            let w:netrw_treetop= getcwd()
+            let s:netrw_treetop= w:netrw_treetop
+        endif
+
+        if !exists("w:netrw_treedict")
+            " insure that we have a treedict, albeit empty
+            let w:netrw_treedict= {}
+        endif
+
+        " update the dictionary for the current directory
+        exe "sil! NetrwKeepj keepp ".w:netrw_bannercnt.',$g@^\.\.\=/$@d _'
+        let w:netrw_treedict[a:dirname]= getline(w:netrw_bannercnt,line("$"))
+        exe "sil! NetrwKeepj ".w:netrw_bannercnt.",$d _"
+
+        " if past banner, record word
+        if exists("w:netrw_bannercnt") && line(".") > w:netrw_bannercnt
+            let fname= expand("<cword>")
+        else
+            let fname= ""
+        endif
+
+        " display from treetop on down
+        NetrwKeepj call s:NetrwTreeDisplay(w:netrw_treetop,"")
+
+        " remove any blank line remaining as line#1 (happens in treelisting mode with banner suppressed)
+        while getline(1) =~ '^\s*$' && byte2line(1) > 0
+            1d
+        endwhile
+
+        exe "setl ".g:netrw_bufsettings
+
+        return
     endif
-    if exists("w:netrw_treetop")
-      let s:netrw_treetop= w:netrw_treetop
-    else
-      let w:netrw_treetop= getcwd()
-      let s:netrw_treetop= w:netrw_treetop
-    endif
-
-    if !exists("w:netrw_treedict")
-      " insure that we have a treedict, albeit empty
-      let w:netrw_treedict= {}
-    endif
-
-    " update the dictionary for the current directory
-    exe "sil! NetrwKeepj keepp ".w:netrw_bannercnt.',$g@^\.\.\=/$@d _'
-    let w:netrw_treedict[a:dirname]= getline(w:netrw_bannercnt,line("$"))
-    exe "sil! NetrwKeepj ".w:netrw_bannercnt.",$d _"
-
-    " if past banner, record word
-    if exists("w:netrw_bannercnt") && line(".") > w:netrw_bannercnt
-      let fname= expand("<cword>")
-    else
-      let fname= ""
-    endif
-
-    " display from treetop on down
-    NetrwKeepj call s:NetrwTreeDisplay(w:netrw_treetop,"")
-
-    " remove any blank line remaining as line#1 (happens in treelisting mode with banner suppressed)
-    while getline(1) =~ '^\s*$' && byte2line(1) > 0
-      1d
-    endwhile
-
-    exe "setl ".g:netrw_bufsettings
-
-    return
-  endif
 endfun
 
 " s:NetrwTreePath: returns path to current file/directory in tree listing {{{2
@@ -7649,382 +7612,382 @@ endfun
 "                  user of the function ( netrw#SetTreetop() )
 "                  wipes that out prior to calling this function
 fun! s:NetrwTreePath(treetop)
-  if line(".") < w:netrw_bannercnt + 2
-    let treedir= a:treetop
-    if treedir !~ '/$'
-      let treedir= treedir.'/'
+    if line(".") < w:netrw_bannercnt + 2
+        let treedir= a:treetop
+        if treedir !~ '/$'
+            let treedir= treedir.'/'
+        endif
+        return treedir
     endif
-    return treedir
-  endif
 
-  let svpos = winsaveview()
-  let depth = substitute(getline('.'),'^\(\%('.s:treedepthstring.'\)*\)[^'.s:treedepthstring.'].\{-}$','\1','e')
-  let depth = substitute(depth,'^'.s:treedepthstring,'','')
-  let curline= getline('.')
-  if curline =~ '/$'
-    let treedir= substitute(curline,'^\%('.s:treedepthstring.'\)*\([^'.s:treedepthstring.'].\{-}\)$','\1','e')
-  elseif curline =~ '@\s\+-->'
-    let treedir= substitute(curline,'^\%('.s:treedepthstring.'\)*\([^'.s:treedepthstring.'].\{-}\)$','\1','e')
-    let treedir= substitute(treedir,'@\s\+-->.*$','','e')
-  else
-    let treedir= ""
-  endif
-  " construct treedir by searching backwards at correct depth
-  while depth != "" && search('^'.depth.'[^'.s:treedepthstring.'].\{-}/$','bW')
-    let dirname= substitute(getline('.'),'^\('.s:treedepthstring.'\)*','','e')
-    let treedir= dirname.treedir
-    let depth  = substitute(depth,'^'.s:treedepthstring,'','')
-  endwhile
-  if a:treetop =~ '/$'
-    let treedir= a:treetop.treedir
-  else
-    let treedir= a:treetop.'/'.treedir
-  endif
-  let treedir= substitute(treedir,'//$','/','')
-  call winrestview(svpos)
-  return treedir
+    let svpos = winsaveview()
+    let depth = substitute(getline('.'),'^\(\%('.s:treedepthstring.'\)*\)[^'.s:treedepthstring.'].\{-}$','\1','e')
+    let depth = substitute(depth,'^'.s:treedepthstring,'','')
+    let curline= getline('.')
+    if curline =~ '/$'
+        let treedir= substitute(curline,'^\%('.s:treedepthstring.'\)*\([^'.s:treedepthstring.'].\{-}\)$','\1','e')
+    elseif curline =~ '@\s\+-->'
+        let treedir= substitute(curline,'^\%('.s:treedepthstring.'\)*\([^'.s:treedepthstring.'].\{-}\)$','\1','e')
+        let treedir= substitute(treedir,'@\s\+-->.*$','','e')
+    else
+        let treedir= ""
+    endif
+    " construct treedir by searching backwards at correct depth
+    while depth != "" && search('^'.depth.'[^'.s:treedepthstring.'].\{-}/$','bW')
+        let dirname= substitute(getline('.'),'^\('.s:treedepthstring.'\)*','','e')
+        let treedir= dirname.treedir
+        let depth  = substitute(depth,'^'.s:treedepthstring,'','')
+    endwhile
+    if a:treetop =~ '/$'
+        let treedir= a:treetop.treedir
+    else
+        let treedir= a:treetop.'/'.treedir
+    endif
+    let treedir= substitute(treedir,'//$','/','')
+    call winrestview(svpos)
+    return treedir
 endfun
 
 " s:NetrwWideListing: {{{2
 fun! s:NetrwWideListing()
 
-  if w:netrw_liststyle == s:WIDELIST
-    " look for longest filename (cpf=characters per filename)
-    " cpf: characters per filename
-    " fpl: filenames per line
-    " fpc: filenames per column
-    setl ma noro
-    let dict={}
-    " save the unnamed register and register 0-9 and a
-    let dict.a=[getreg('a'), getregtype('a')]
-    for i in range(0, 9)
-      let dict[i] = [getreg(i), getregtype(i)]
-    endfor
-    let dict.unnamed = [getreg(''), getregtype('')]
-    let b:netrw_cpf= 0
-    if line("$") >= w:netrw_bannercnt
-      " determine the maximum filename size; use that to set cpf
-      exe 'sil NetrwKeepj '.w:netrw_bannercnt.',$g/^./if virtcol("$") > b:netrw_cpf|let b:netrw_cpf= virtcol("$")|endif'
-      NetrwKeepj call histdel("/",-1)
+    if w:netrw_liststyle == s:WIDELIST
+        " look for longest filename (cpf=characters per filename)
+        " cpf: characters per filename
+        " fpl: filenames per line
+        " fpc: filenames per column
+        setl ma noro
+        let dict={}
+        " save the unnamed register and register 0-9 and a
+        let dict.a=[getreg('a'), getregtype('a')]
+        for i in range(0, 9)
+            let dict[i] = [getreg(i), getregtype(i)]
+        endfor
+        let dict.unnamed = [getreg(''), getregtype('')]
+        let b:netrw_cpf= 0
+        if line("$") >= w:netrw_bannercnt
+            " determine the maximum filename size; use that to set cpf
+            exe 'sil NetrwKeepj '.w:netrw_bannercnt.',$g/^./if virtcol("$") > b:netrw_cpf|let b:netrw_cpf= virtcol("$")|endif'
+            NetrwKeepj call histdel("/",-1)
+        else
+            " restore stored registers
+            call s:RestoreRegister(dict)
+            return
+        endif
+        " allow for two spaces to separate columns
+        let b:netrw_cpf= b:netrw_cpf + 2
+
+        " determine qty files per line (fpl)
+        let w:netrw_fpl= winwidth(0)/b:netrw_cpf
+        if w:netrw_fpl <= 0
+            let w:netrw_fpl= 1
+        endif
+
+        " make wide display
+        "   fpc: files per column of wide listing
+        exe 'sil NetrwKeepj '.w:netrw_bannercnt.',$s/^.*$/\=escape(printf("%-'.b:netrw_cpf.'S",submatch(0)),"\\")/'
+        NetrwKeepj call histdel("/",-1)
+        let fpc         = (line("$") - w:netrw_bannercnt + w:netrw_fpl)/w:netrw_fpl
+        let newcolstart = w:netrw_bannercnt + fpc
+        let newcolend   = newcolstart + fpc - 1
+        if has("clipboard") && g:netrw_clipboard
+            sil! let keepregstar = @*
+            sil! let keepregplus = @+
+        endif
+        while line("$") >= newcolstart
+            if newcolend > line("$") | let newcolend= line("$") | endif
+            let newcolqty= newcolend - newcolstart
+            exe newcolstart
+            " COMBAK: both of the visual-mode using lines below are problematic vis-a-vis @*
+            if newcolqty == 0
+                exe "sil! NetrwKeepj norm! 0\<c-v>$h\"ax".w:netrw_bannercnt."G$\"ap"
+            else
+                exe "sil! NetrwKeepj norm! 0\<c-v>".newcolqty.'j$h"ax'.w:netrw_bannercnt.'G$"ap'
+            endif
+            exe "sil! NetrwKeepj ".newcolstart.','.newcolend.'d _'
+            exe 'sil! NetrwKeepj '.w:netrw_bannercnt
+        endwhile
+        if has("clipboard")
+            if @* != keepregstar | sil! let @* = keepregstar | endif
+            if @+ != keepregplus | sil! let @+ = keepregplus | endif
+        endif
+        exe "sil! NetrwKeepj ".w:netrw_bannercnt.',$s/\s\+$//e'
+        NetrwKeepj call histdel("/",-1)
+        exe 'nno <buffer> <silent> w :call search(''^.\\|\s\s\zs\S'',''W'')'."\<cr>"
+        exe 'nno <buffer> <silent> b :call search(''^.\\|\s\s\zs\S'',''bW'')'."\<cr>"
+        exe "setl ".g:netrw_bufsettings
+        call s:RestoreRegister(dict)
+        return
     else
-      " restore stored registers
-      call s:RestoreRegister(dict)
-      return
+        if hasmapto("w","n")
+            sil! nunmap <buffer> w
+        endif
+        if hasmapto("b","n")
+            sil! nunmap <buffer> b
+        endif
     endif
-    " allow for two spaces to separate columns
-    let b:netrw_cpf= b:netrw_cpf + 2
-
-    " determine qty files per line (fpl)
-    let w:netrw_fpl= winwidth(0)/b:netrw_cpf
-    if w:netrw_fpl <= 0
-      let w:netrw_fpl= 1
-    endif
-
-    " make wide display
-    "   fpc: files per column of wide listing
-    exe 'sil NetrwKeepj '.w:netrw_bannercnt.',$s/^.*$/\=escape(printf("%-'.b:netrw_cpf.'S",submatch(0)),"\\")/'
-    NetrwKeepj call histdel("/",-1)
-    let fpc         = (line("$") - w:netrw_bannercnt + w:netrw_fpl)/w:netrw_fpl
-    let newcolstart = w:netrw_bannercnt + fpc
-    let newcolend   = newcolstart + fpc - 1
-    if has("clipboard") && g:netrw_clipboard
-      sil! let keepregstar = @*
-      sil! let keepregplus = @+
-    endif
-    while line("$") >= newcolstart
-      if newcolend > line("$") | let newcolend= line("$") | endif
-      let newcolqty= newcolend - newcolstart
-      exe newcolstart
-      " COMBAK: both of the visual-mode using lines below are problematic vis-a-vis @*
-      if newcolqty == 0
-        exe "sil! NetrwKeepj norm! 0\<c-v>$h\"ax".w:netrw_bannercnt."G$\"ap"
-      else
-        exe "sil! NetrwKeepj norm! 0\<c-v>".newcolqty.'j$h"ax'.w:netrw_bannercnt.'G$"ap'
-      endif
-      exe "sil! NetrwKeepj ".newcolstart.','.newcolend.'d _'
-      exe 'sil! NetrwKeepj '.w:netrw_bannercnt
-    endwhile
-    if has("clipboard")
-      if @* != keepregstar | sil! let @* = keepregstar | endif
-      if @+ != keepregplus | sil! let @+ = keepregplus | endif
-    endif
-    exe "sil! NetrwKeepj ".w:netrw_bannercnt.',$s/\s\+$//e'
-    NetrwKeepj call histdel("/",-1)
-    exe 'nno <buffer> <silent> w :call search(''^.\\|\s\s\zs\S'',''W'')'."\<cr>"
-    exe 'nno <buffer> <silent> b :call search(''^.\\|\s\s\zs\S'',''bW'')'."\<cr>"
-    exe "setl ".g:netrw_bufsettings
-    call s:RestoreRegister(dict)
-    return
-  else
-    if hasmapto("w","n")
-      sil! nunmap <buffer> w
-    endif
-    if hasmapto("b","n")
-      sil! nunmap <buffer> b
-    endif
-  endif
 endfun
 
 " s:PerformListing: {{{2
 fun! s:PerformListing(islocal)
-  sil! NetrwKeepj %d _
-  "  call DechoBuf(bufnr("%"))
-
-  " set up syntax highlighting {{{3
-  sil! setl ft=netrw
-
-  NetrwKeepj call s:NetrwOptionsSafe(a:islocal)
-  setl noro ma
-
-
-  if exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST && exists("w:netrw_treedict")
-    " force a refresh for tree listings
     sil! NetrwKeepj %d _
-  endif
+    "  call DechoBuf(bufnr("%"))
 
-  " save current directory on directory history list
-  NetrwKeepj call s:NetrwBookHistHandler(3,b:netrw_curdir)
+    " set up syntax highlighting {{{3
+    sil! setl ft=netrw
 
-  " Set up the banner {{{3
-  if g:netrw_banner
-    NetrwKeepj call setline(1,'" ============================================================================')
-    if exists("g:netrw_pchk")
-      " this undocumented option allows pchk to run with different versions of netrw without causing spurious
-      " failure detections.
-      NetrwKeepj call setline(2,'" Netrw Directory Listing')
+    NetrwKeepj call s:NetrwOptionsSafe(a:islocal)
+    setl noro ma
+
+
+    if exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST && exists("w:netrw_treedict")
+        " force a refresh for tree listings
+        sil! NetrwKeepj %d _
+    endif
+
+    " save current directory on directory history list
+    NetrwKeepj call s:NetrwBookHistHandler(3,b:netrw_curdir)
+
+    " Set up the banner {{{3
+    if g:netrw_banner
+        NetrwKeepj call setline(1,'" ============================================================================')
+        if exists("g:netrw_pchk")
+            " this undocumented option allows pchk to run with different versions of netrw without causing spurious
+            " failure detections.
+            NetrwKeepj call setline(2,'" Netrw Directory Listing')
+        else
+            NetrwKeepj call setline(2,'" Netrw Directory Listing                                        (netrw '.g:loaded_netrw.')')
+        endif
+        if exists("g:netrw_pchk")
+            let curdir= substitute(b:netrw_curdir,expand("$HOME"),'~','')
+        else
+            let curdir= b:netrw_curdir
+        endif
+        if exists("g:netrw_bannerbackslash") && g:netrw_bannerbackslash
+            NetrwKeepj call setline(3,'"   '.substitute(curdir,'/','\\','g'))
+        else
+            NetrwKeepj call setline(3,'"   '.curdir)
+        endif
+        let w:netrw_bannercnt= 3
+        NetrwKeepj exe "sil! NetrwKeepj ".w:netrw_bannercnt
     else
-      NetrwKeepj call setline(2,'" Netrw Directory Listing                                        (netrw '.g:loaded_netrw.')')
+        NetrwKeepj 1
+        let w:netrw_bannercnt= 1
     endif
-    if exists("g:netrw_pchk")
-      let curdir= substitute(b:netrw_curdir,expand("$HOME"),'~','')
-    else
-      let curdir= b:netrw_curdir
+
+    " construct sortby string: [name|time|size|exten] [reversed]
+    let sortby= g:netrw_sort_by
+    if g:netrw_sort_direction =~# "^r"
+        let sortby= sortby." reversed"
     endif
-    if exists("g:netrw_bannerbackslash") && g:netrw_bannerbackslash
-      NetrwKeepj call setline(3,'"   '.substitute(curdir,'/','\\','g'))
-    else
-      NetrwKeepj call setline(3,'"   '.curdir)
+
+    " Sorted by... {{{3
+    if g:netrw_banner
+        if g:netrw_sort_by =~# "^n"
+            " sorted by name (also includes the sorting sequence in the banner)
+            NetrwKeepj put ='\"   Sorted by      '.sortby
+            NetrwKeepj put ='\"   Sort sequence: '.g:netrw_sort_sequence
+            let w:netrw_bannercnt= w:netrw_bannercnt + 2
+        else
+            " sorted by time, size, exten
+            NetrwKeepj put ='\"   Sorted by '.sortby
+            let w:netrw_bannercnt= w:netrw_bannercnt + 1
+        endif
+        exe "sil! NetrwKeepj ".w:netrw_bannercnt
     endif
-    let w:netrw_bannercnt= 3
-    NetrwKeepj exe "sil! NetrwKeepj ".w:netrw_bannercnt
-  else
-    NetrwKeepj 1
-    let w:netrw_bannercnt= 1
-  endif
 
-  " construct sortby string: [name|time|size|exten] [reversed]
-  let sortby= g:netrw_sort_by
-  if g:netrw_sort_direction =~# "^r"
-    let sortby= sortby." reversed"
-  endif
-
-  " Sorted by... {{{3
-  if g:netrw_banner
-    if g:netrw_sort_by =~# "^n"
-      " sorted by name (also includes the sorting sequence in the banner)
-      NetrwKeepj put ='\"   Sorted by      '.sortby
-      NetrwKeepj put ='\"   Sort sequence: '.g:netrw_sort_sequence
-      let w:netrw_bannercnt= w:netrw_bannercnt + 2
-    else
-      " sorted by time, size, exten
-      NetrwKeepj put ='\"   Sorted by '.sortby
-      let w:netrw_bannercnt= w:netrw_bannercnt + 1
+    " show copy/move target, if any {{{3
+    if g:netrw_banner
+        if exists("s:netrwmftgt") && exists("s:netrwmftgt_islocal")
+            NetrwKeepj put =''
+            if s:netrwmftgt_islocal
+                sil! NetrwKeepj call setline(line("."),'"   Copy/Move Tgt: '.s:netrwmftgt.' (local)')
+            else
+                sil! NetrwKeepj call setline(line("."),'"   Copy/Move Tgt: '.s:netrwmftgt.' (remote)')
+            endif
+            let w:netrw_bannercnt= w:netrw_bannercnt + 1
+        else
+        endif
+        exe "sil! NetrwKeepj ".w:netrw_bannercnt
     endif
-    exe "sil! NetrwKeepj ".w:netrw_bannercnt
-  endif
 
-  " show copy/move target, if any {{{3
-  if g:netrw_banner
-    if exists("s:netrwmftgt") && exists("s:netrwmftgt_islocal")
-      NetrwKeepj put =''
-      if s:netrwmftgt_islocal
-        sil! NetrwKeepj call setline(line("."),'"   Copy/Move Tgt: '.s:netrwmftgt.' (local)')
-      else
-        sil! NetrwKeepj call setline(line("."),'"   Copy/Move Tgt: '.s:netrwmftgt.' (remote)')
-      endif
-      let w:netrw_bannercnt= w:netrw_bannercnt + 1
-    else
+    " Hiding...  -or-  Showing... {{{3
+    if g:netrw_banner
+        if g:netrw_list_hide != "" && g:netrw_hide
+            if g:netrw_hide == 1
+                NetrwKeepj put ='\"   Hiding:        '.g:netrw_list_hide
+            else
+                NetrwKeepj put ='\"   Showing:       '.g:netrw_list_hide
+            endif
+            let w:netrw_bannercnt= w:netrw_bannercnt + 1
+        endif
+        exe "NetrwKeepj ".w:netrw_bannercnt
+
+        let quickhelp   = g:netrw_quickhelp%len(s:QuickHelp)
+        NetrwKeepj put ='\"   Quick Help: <F1>:help  '.s:QuickHelp[quickhelp]
+        NetrwKeepj put ='\" =============================================================================='
+        let w:netrw_bannercnt= w:netrw_bannercnt + 2
     endif
-    exe "sil! NetrwKeepj ".w:netrw_bannercnt
-  endif
 
-  " Hiding...  -or-  Showing... {{{3
-  if g:netrw_banner
-    if g:netrw_list_hide != "" && g:netrw_hide
-      if g:netrw_hide == 1
-        NetrwKeepj put ='\"   Hiding:        '.g:netrw_list_hide
-      else
-        NetrwKeepj put ='\"   Showing:       '.g:netrw_list_hide
-      endif
-      let w:netrw_bannercnt= w:netrw_bannercnt + 1
+    " bannercnt should index the line just after the banner
+    if g:netrw_banner
+        let w:netrw_bannercnt= w:netrw_bannercnt + 1
+        exe "sil! NetrwKeepj ".w:netrw_bannercnt
     endif
-    exe "NetrwKeepj ".w:netrw_bannercnt
 
-    let quickhelp   = g:netrw_quickhelp%len(s:QuickHelp)
-    NetrwKeepj put ='\"   Quick Help: <F1>:help  '.s:QuickHelp[quickhelp]
-    NetrwKeepj put ='\" =============================================================================='
-    let w:netrw_bannercnt= w:netrw_bannercnt + 2
-  endif
-
-  " bannercnt should index the line just after the banner
-  if g:netrw_banner
-    let w:netrw_bannercnt= w:netrw_bannercnt + 1
-    exe "sil! NetrwKeepj ".w:netrw_bannercnt
-  endif
-
-  " get list of files
-  if a:islocal
-    NetrwKeepj call s:LocalListing()
-  else " remote
-    NetrwKeepj let badresult= s:NetrwRemoteListing()
-    if badresult
-      return
+    " get list of files
+    if a:islocal
+        NetrwKeepj call s:LocalListing()
+    else " remote
+        NetrwKeepj let badresult= s:NetrwRemoteListing()
+        if badresult
+            return
+        endif
     endif
-  endif
 
-  " manipulate the directory listing (hide, sort) {{{3
-  if !exists("w:netrw_bannercnt")
-    let w:netrw_bannercnt= 0
-  endif
-
-  if !g:netrw_banner || line("$") >= w:netrw_bannercnt
-    if g:netrw_hide && g:netrw_list_hide != ""
-      NetrwKeepj call s:NetrwListHide()
+    " manipulate the directory listing (hide, sort) {{{3
+    if !exists("w:netrw_bannercnt")
+        let w:netrw_bannercnt= 0
     endif
+
     if !g:netrw_banner || line("$") >= w:netrw_bannercnt
-
-      if g:netrw_sort_by =~# "^n"
-        " sort by name
-        NetrwKeepj call s:NetrwSetSort()
-
-        if !g:netrw_banner || w:netrw_bannercnt < line("$")
-          if g:netrw_sort_direction =~# 'n'
-            " name: sort by name of file
-            exe 'sil NetrwKeepj '.w:netrw_bannercnt.',$sort'.' '.g:netrw_sort_options
-          else
-            " reverse direction sorting
-            exe 'sil NetrwKeepj '.w:netrw_bannercnt.',$sort!'.' '.g:netrw_sort_options
-          endif
+        if g:netrw_hide && g:netrw_list_hide != ""
+            NetrwKeepj call s:NetrwListHide()
         endif
+        if !g:netrw_banner || line("$") >= w:netrw_bannercnt
 
-        " remove priority pattern prefix
-        exe 'sil! NetrwKeepj '.w:netrw_bannercnt.',$s/^\d\{3}'.g:netrw_sepchr.'//e'
-        NetrwKeepj call histdel("/",-1)
+            if g:netrw_sort_by =~# "^n"
+                " sort by name
+                NetrwKeepj call s:NetrwSetSort()
 
-      elseif g:netrw_sort_by =~# "^ext"
-        " exten: sort by extension
-        "   The histdel(...,-1) calls remove the last search from the search history
-        exe 'sil NetrwKeepj '.w:netrw_bannercnt.',$g+/+s/^/001'.g:netrw_sepchr.'/'
-        NetrwKeepj call histdel("/",-1)
-        exe 'sil NetrwKeepj '.w:netrw_bannercnt.',$v+[./]+s/^/002'.g:netrw_sepchr.'/'
-        NetrwKeepj call histdel("/",-1)
-        exe 'sil NetrwKeepj '.w:netrw_bannercnt.',$v+['.g:netrw_sepchr.'/]+s/^\(.*\.\)\(.\{-\}\)$/\2'.g:netrw_sepchr.'&/e'
-        NetrwKeepj call histdel("/",-1)
-        if !g:netrw_banner || w:netrw_bannercnt < line("$")
-          if g:netrw_sort_direction =~# 'n'
-            " normal direction sorting
-            exe 'sil NetrwKeepj '.w:netrw_bannercnt.',$sort'.' '.g:netrw_sort_options
-          else
-            " reverse direction sorting
-            exe 'sil NetrwKeepj '.w:netrw_bannercnt.',$sort!'.' '.g:netrw_sort_options
-          endif
+                if !g:netrw_banner || w:netrw_bannercnt < line("$")
+                    if g:netrw_sort_direction =~# 'n'
+                        " name: sort by name of file
+                        exe 'sil NetrwKeepj '.w:netrw_bannercnt.',$sort'.' '.g:netrw_sort_options
+                    else
+                        " reverse direction sorting
+                        exe 'sil NetrwKeepj '.w:netrw_bannercnt.',$sort!'.' '.g:netrw_sort_options
+                    endif
+                endif
+
+                " remove priority pattern prefix
+                exe 'sil! NetrwKeepj '.w:netrw_bannercnt.',$s/^\d\{3}'.g:netrw_sepchr.'//e'
+                NetrwKeepj call histdel("/",-1)
+
+            elseif g:netrw_sort_by =~# "^ext"
+                " exten: sort by extension
+                "   The histdel(...,-1) calls remove the last search from the search history
+                exe 'sil NetrwKeepj '.w:netrw_bannercnt.',$g+/+s/^/001'.g:netrw_sepchr.'/'
+                NetrwKeepj call histdel("/",-1)
+                exe 'sil NetrwKeepj '.w:netrw_bannercnt.',$v+[./]+s/^/002'.g:netrw_sepchr.'/'
+                NetrwKeepj call histdel("/",-1)
+                exe 'sil NetrwKeepj '.w:netrw_bannercnt.',$v+['.g:netrw_sepchr.'/]+s/^\(.*\.\)\(.\{-\}\)$/\2'.g:netrw_sepchr.'&/e'
+                NetrwKeepj call histdel("/",-1)
+                if !g:netrw_banner || w:netrw_bannercnt < line("$")
+                    if g:netrw_sort_direction =~# 'n'
+                        " normal direction sorting
+                        exe 'sil NetrwKeepj '.w:netrw_bannercnt.',$sort'.' '.g:netrw_sort_options
+                    else
+                        " reverse direction sorting
+                        exe 'sil NetrwKeepj '.w:netrw_bannercnt.',$sort!'.' '.g:netrw_sort_options
+                    endif
+                endif
+                exe 'sil! NetrwKeepj '.w:netrw_bannercnt.',$s/^.\{-}'.g:netrw_sepchr.'//e'
+                NetrwKeepj call histdel("/",-1)
+
+            elseif a:islocal
+                if !g:netrw_banner || w:netrw_bannercnt < line("$")
+                    if g:netrw_sort_direction =~# 'n'
+                        exe 'sil! NetrwKeepj '.w:netrw_bannercnt.',$sort'.' '.g:netrw_sort_options
+                    else
+                        exe 'sil! NetrwKeepj '.w:netrw_bannercnt.',$sort!'.' '.g:netrw_sort_options
+                    endif
+                    exe 'sil! NetrwKeepj '.w:netrw_bannercnt.',$s/^\d\{-}\///e'
+                    NetrwKeepj call histdel("/",-1)
+                endif
+            endif
+
+        elseif g:netrw_sort_direction =~# 'r'
+            if !g:netrw_banner || w:netrw_bannercnt < line('$')
+                exe 'sil! NetrwKeepj '.w:netrw_bannercnt.',$g/^/m '.w:netrw_bannercnt
+                call histdel("/",-1)
+            endif
         endif
-        exe 'sil! NetrwKeepj '.w:netrw_bannercnt.',$s/^.\{-}'.g:netrw_sepchr.'//e'
-        NetrwKeepj call histdel("/",-1)
-
-      elseif a:islocal
-        if !g:netrw_banner || w:netrw_bannercnt < line("$")
-          if g:netrw_sort_direction =~# 'n'
-            exe 'sil! NetrwKeepj '.w:netrw_bannercnt.',$sort'.' '.g:netrw_sort_options
-          else
-            exe 'sil! NetrwKeepj '.w:netrw_bannercnt.',$sort!'.' '.g:netrw_sort_options
-          endif
-          exe 'sil! NetrwKeepj '.w:netrw_bannercnt.',$s/^\d\{-}\///e'
-          NetrwKeepj call histdel("/",-1)
-        endif
-      endif
-
-    elseif g:netrw_sort_direction =~# 'r'
-      if !g:netrw_banner || w:netrw_bannercnt < line('$')
-        exe 'sil! NetrwKeepj '.w:netrw_bannercnt.',$g/^/m '.w:netrw_bannercnt
-        call histdel("/",-1)
-      endif
     endif
-  endif
 
-  " convert to wide/tree listing {{{3
-  NetrwKeepj call s:NetrwWideListing()
-  NetrwKeepj call s:NetrwTreeListing(b:netrw_curdir)
+    " convert to wide/tree listing {{{3
+    NetrwKeepj call s:NetrwWideListing()
+    NetrwKeepj call s:NetrwTreeListing(b:netrw_curdir)
 
-  " resolve symbolic links if local and (thin or tree)
-  if a:islocal && (w:netrw_liststyle == s:THINLIST || (exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST))
-    sil! keepp g/@$/call s:ShowLink()
-  endif
+    " resolve symbolic links if local and (thin or tree)
+    if a:islocal && (w:netrw_liststyle == s:THINLIST || (exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST))
+        sil! keepp g/@$/call s:ShowLink()
+    endif
 
-  if exists("w:netrw_bannercnt") && (line("$") >= w:netrw_bannercnt || !g:netrw_banner)
-    " place cursor on the top-left corner of the file listing
-    exe 'sil! '.w:netrw_bannercnt
-    sil! NetrwKeepj norm! 0
-  else
-  endif
+    if exists("w:netrw_bannercnt") && (line("$") >= w:netrw_bannercnt || !g:netrw_banner)
+        " place cursor on the top-left corner of the file listing
+        exe 'sil! '.w:netrw_bannercnt
+        sil! NetrwKeepj norm! 0
+    else
+    endif
 
-  " record previous current directory
-  let w:netrw_prvdir= b:netrw_curdir
+    " record previous current directory
+    let w:netrw_prvdir= b:netrw_curdir
 
-  " save certain window-oriented variables into buffer-oriented variables {{{3
-  NetrwKeepj call s:SetBufWinVars()
-  NetrwKeepj call s:NetrwOptionsRestore("w:")
+    " save certain window-oriented variables into buffer-oriented variables {{{3
+    NetrwKeepj call s:SetBufWinVars()
+    NetrwKeepj call s:NetrwOptionsRestore("w:")
 
-  " set display to netrw display settings
-  exe "setl ".g:netrw_bufsettings
-  if g:netrw_liststyle == s:LONGLIST
-    exe "setl ts=".(g:netrw_maxfilenamelen+1)
-  endif
-  "  call DechoBuf(bufnr("%"))
+    " set display to netrw display settings
+    exe "setl ".g:netrw_bufsettings
+    if g:netrw_liststyle == s:LONGLIST
+        exe "setl ts=".(g:netrw_maxfilenamelen+1)
+    endif
+    "  call DechoBuf(bufnr("%"))
 
-  if exists("s:treecurpos")
-    NetrwKeepj call winrestview(s:treecurpos)
-    unlet s:treecurpos
-  endif
+    if exists("s:treecurpos")
+        NetrwKeepj call winrestview(s:treecurpos)
+        unlet s:treecurpos
+    endif
 
 endfun
 
 " s:SetupNetrwStatusLine: {{{2
 fun! s:SetupNetrwStatusLine(statline)
 
-  if !exists("s:netrw_setup_statline")
-    let s:netrw_setup_statline= 1
+    if !exists("s:netrw_setup_statline")
+        let s:netrw_setup_statline= 1
 
-    if !exists("s:netrw_users_stl")
-      let s:netrw_users_stl= &stl
+        if !exists("s:netrw_users_stl")
+            let s:netrw_users_stl= &stl
+        endif
+        if !exists("s:netrw_users_ls")
+            let s:netrw_users_ls= &laststatus
+        endif
+
+        " set up User9 highlighting as needed
+        let dict={}
+        let dict.a=[getreg('a'), getregtype('a')]
+        redir @a
+        try
+            hi User9
+        catch /^Vim\%((\a\{3,})\)\=:E411/
+            if &bg == "dark"
+                hi User9 ctermfg=yellow ctermbg=blue guifg=yellow guibg=blue
+            else
+                hi User9 ctermbg=yellow ctermfg=blue guibg=yellow guifg=blue
+            endif
+        endtry
+        redir END
+        call s:RestoreRegister(dict)
     endif
-    if !exists("s:netrw_users_ls")
-      let s:netrw_users_ls= &laststatus
-    endif
 
-    " set up User9 highlighting as needed
-    let dict={}
-    let dict.a=[getreg('a'), getregtype('a')]
-    redir @a
-    try
-      hi User9
-    catch /^Vim\%((\a\{3,})\)\=:E411/
-      if &bg == "dark"
-        hi User9 ctermfg=yellow ctermbg=blue guifg=yellow guibg=blue
-      else
-        hi User9 ctermbg=yellow ctermfg=blue guibg=yellow guifg=blue
-      endif
-    endtry
-    redir END
-    call s:RestoreRegister(dict)
-  endif
-
-  " set up status line (may use User9 highlighting)
-  " insure that windows have a statusline
-  " make sure statusline is displayed
-  let &l:stl=a:statline
-  setl laststatus=2
-  redraw
+    " set up status line (may use User9 highlighting)
+    " insure that windows have a statusline
+    " make sure statusline is displayed
+    let &l:stl=a:statline
+    setl laststatus=2
+    redraw
 
 endfun
 
@@ -8035,503 +7998,499 @@ endfun
 "  and reverse sorts will be requested of the server but not otherwise
 "  enforced here.
 fun! s:NetrwRemoteFtpCmd(path,listcmd)
-  " sanity check: {{{3
-  if !exists("w:netrw_method")
-    if exists("b:netrw_method")
-      let w:netrw_method= b:netrw_method
-    else
-      call netrw#msg#Notify('ERROR', '(s:NetrwRemoteFtpCmd) internal netrw error')
-      return
-    endif
-  endif
-
-  " WinXX ftp uses unix style input, so set ff to unix  " {{{3
-  let ffkeep= &ff
-  setl ma ff=unix noro
-
-  " clear off any older non-banner lines        " {{{3
-  " note that w:netrw_bannercnt indexes the line after the banner
-  exe "sil! NetrwKeepj ".w:netrw_bannercnt.",$d _"
-
-  ".........................................
-  if w:netrw_method == 2 || w:netrw_method == 5 " {{{3
-    " ftp + <.netrc>:  Method #2
-    if a:path != ""
-      NetrwKeepj put ='cd \"'.a:path.'\"'
-    endif
-    if exists("g:netrw_ftpextracmd")
-      NetrwKeepj put =g:netrw_ftpextracmd
-    endif
-    NetrwKeepj call setline(line("$")+1,a:listcmd)
-    if exists("g:netrw_port") && g:netrw_port != ""
-      exe s:netrw_silentxfer." NetrwKeepj ".w:netrw_bannercnt.",$!".s:netrw_ftp_cmd." -i ".netrw#os#Escape(g:netrw_machine,1)." ".netrw#os#Escape(g:netrw_port,1)
-    else
-      exe s:netrw_silentxfer." NetrwKeepj ".w:netrw_bannercnt.",$!".s:netrw_ftp_cmd." -i ".netrw#os#Escape(g:netrw_machine,1)
-    endif
-
-    ".........................................
-  elseif w:netrw_method == 3    " {{{3
-    " ftp + machine,id,passwd,filename:  Method #3
-    setl ff=unix
-    if exists("g:netrw_port") && g:netrw_port != ""
-      NetrwKeepj put ='open '.g:netrw_machine.' '.g:netrw_port
-    else
-      NetrwKeepj put ='open '.g:netrw_machine
-    endif
-
-    " handle userid and password
-    let host= substitute(g:netrw_machine,'\..*$','','')
-    if exists("s:netrw_hup") && exists("s:netrw_hup[host]")
-      call NetUserPass("ftp:".host)
-    endif
-    if exists("g:netrw_uid") && g:netrw_uid != ""
-      if exists("g:netrw_ftp") && g:netrw_ftp == 1
-        NetrwKeepj put =g:netrw_uid
-        if exists("s:netrw_passwd") && s:netrw_passwd != ""
-          NetrwKeepj put ='\"'.s:netrw_passwd.'\"'
+    " sanity check: {{{3
+    if !exists("w:netrw_method")
+        if exists("b:netrw_method")
+            let w:netrw_method= b:netrw_method
+        else
+            call netrw#msg#Notify('ERROR', '(s:NetrwRemoteFtpCmd) internal netrw error')
+            return
         endif
-      elseif exists("s:netrw_passwd")
-        NetrwKeepj put ='user \"'.g:netrw_uid.'\" \"'.s:netrw_passwd.'\"'
-      endif
     endif
 
-    if a:path != ""
-      NetrwKeepj put ='cd \"'.a:path.'\"'
-    endif
-    if exists("g:netrw_ftpextracmd")
-      NetrwKeepj put =g:netrw_ftpextracmd
-    endif
-    NetrwKeepj call setline(line("$")+1,a:listcmd)
+    " WinXX ftp uses unix style input, so set ff to unix  " {{{3
+    let ffkeep= &ff
+    setl ma ff=unix noro
 
-    " perform ftp:
-    " -i       : turns off interactive prompting from ftp
-    " -n  unix : DON'T use <.netrc>, even though it exists
-    " -n  win32: quit being obnoxious about password
-    if exists("w:netrw_bannercnt")
-      call netrw#os#Execute(s:netrw_silentxfer.w:netrw_bannercnt.",$!".s:netrw_ftp_cmd." ".g:netrw_ftp_options)
-    endif
+    " clear off any older non-banner lines        " {{{3
+    " note that w:netrw_bannercnt indexes the line after the banner
+    exe "sil! NetrwKeepj ".w:netrw_bannercnt.",$d _"
 
     ".........................................
-  elseif w:netrw_method == 9    " {{{3
-    " sftp username@machine: Method #9
-    " s:netrw_sftp_cmd
-    setl ff=unix
+    if w:netrw_method == 2 || w:netrw_method == 5 " {{{3
+        " ftp + <.netrc>:  Method #2
+        if a:path != ""
+            NetrwKeepj put ='cd \"'.a:path.'\"'
+        endif
+        if exists("g:netrw_ftpextracmd")
+            NetrwKeepj put =g:netrw_ftpextracmd
+        endif
+        NetrwKeepj call setline(line("$")+1,a:listcmd)
+        if exists("g:netrw_port") && g:netrw_port != ""
+            exe s:netrw_silentxfer." NetrwKeepj ".w:netrw_bannercnt.",$!".s:netrw_ftp_cmd." -i ".netrw#os#Escape(g:netrw_machine,1)." ".netrw#os#Escape(g:netrw_port,1)
+        else
+            exe s:netrw_silentxfer." NetrwKeepj ".w:netrw_bannercnt.",$!".s:netrw_ftp_cmd." -i ".netrw#os#Escape(g:netrw_machine,1)
+        endif
 
-    " restore settings
+        ".........................................
+    elseif w:netrw_method == 3    " {{{3
+        " ftp + machine,id,passwd,filename:  Method #3
+        setl ff=unix
+        if exists("g:netrw_port") && g:netrw_port != ""
+            NetrwKeepj put ='open '.g:netrw_machine.' '.g:netrw_port
+        else
+            NetrwKeepj put ='open '.g:netrw_machine
+        endif
+
+        " handle userid and password
+        let host= substitute(g:netrw_machine,'\..*$','','')
+        if exists("s:netrw_hup") && exists("s:netrw_hup[host]")
+            call NetUserPass("ftp:".host)
+        endif
+        if exists("g:netrw_uid") && g:netrw_uid != ""
+            if exists("g:netrw_ftp") && g:netrw_ftp == 1
+                NetrwKeepj put =g:netrw_uid
+                if exists("s:netrw_passwd") && s:netrw_passwd != ""
+                    NetrwKeepj put ='\"'.s:netrw_passwd.'\"'
+                endif
+            elseif exists("s:netrw_passwd")
+                NetrwKeepj put ='user \"'.g:netrw_uid.'\" \"'.s:netrw_passwd.'\"'
+            endif
+        endif
+
+        if a:path != ""
+            NetrwKeepj put ='cd \"'.a:path.'\"'
+        endif
+        if exists("g:netrw_ftpextracmd")
+            NetrwKeepj put =g:netrw_ftpextracmd
+        endif
+        NetrwKeepj call setline(line("$")+1,a:listcmd)
+
+        " perform ftp:
+        " -i       : turns off interactive prompting from ftp
+        " -n  unix : DON'T use <.netrc>, even though it exists
+        " -n  win32: quit being obnoxious about password
+        if exists("w:netrw_bannercnt")
+            call netrw#os#Execute(s:netrw_silentxfer.w:netrw_bannercnt.",$!".s:netrw_ftp_cmd." ".g:netrw_ftp_options)
+        endif
+
+        ".........................................
+    elseif w:netrw_method == 9    " {{{3
+        " sftp username@machine: Method #9
+        " s:netrw_sftp_cmd
+        setl ff=unix
+
+        " restore settings
+        let &l:ff= ffkeep
+        return
+
+        ".........................................
+    else  " {{{3
+        call netrw#msg#Notify('WARNING', printf('unable to comply with your request<%s>', bufname("%")))
+    endif
+
+    " cleanup for Windows " {{{3
+    if has("win32")
+        sil! NetrwKeepj %s/\r$//e
+        NetrwKeepj call histdel("/",-1)
+    endif
+    if a:listcmd == "dir"
+        " infer directory/link based on the file permission string
+        sil! NetrwKeepj g/d\%([-r][-w][-x]\)\{3}/NetrwKeepj s@$@/@e
+        sil! NetrwKeepj g/l\%([-r][-w][-x]\)\{3}/NetrwKeepj s/$/@/e
+        NetrwKeepj call histdel("/",-1)
+        NetrwKeepj call histdel("/",-1)
+        if w:netrw_liststyle == s:THINLIST || w:netrw_liststyle == s:WIDELIST || (exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST)
+            exe "sil! NetrwKeepj ".w:netrw_bannercnt.',$s/^\%(\S\+\s\+\)\{8}//e'
+            NetrwKeepj call histdel("/",-1)
+        endif
+    endif
+
+    " ftp's listing doesn't seem to include ./ or ../ " {{{3
+    if !search('^\.\/$\|\s\.\/$','wn')
+        exe 'NetrwKeepj '.w:netrw_bannercnt
+        NetrwKeepj put ='./'
+    endif
+    if !search('^\.\.\/$\|\s\.\.\/$','wn')
+        exe 'NetrwKeepj '.w:netrw_bannercnt
+        NetrwKeepj put ='../'
+    endif
+
+    " restore settings " {{{3
     let &l:ff= ffkeep
-    return
-
-    ".........................................
-  else  " {{{3
-    call netrw#msg#Notify('WARNING', printf('unable to comply with your request<%s>', bufname("%")))
-  endif
-
-  " cleanup for Windows " {{{3
-  if has("win32")
-    sil! NetrwKeepj %s/\r$//e
-    NetrwKeepj call histdel("/",-1)
-  endif
-  if a:listcmd == "dir"
-    " infer directory/link based on the file permission string
-    sil! NetrwKeepj g/d\%([-r][-w][-x]\)\{3}/NetrwKeepj s@$@/@e
-    sil! NetrwKeepj g/l\%([-r][-w][-x]\)\{3}/NetrwKeepj s/$/@/e
-    NetrwKeepj call histdel("/",-1)
-    NetrwKeepj call histdel("/",-1)
-    if w:netrw_liststyle == s:THINLIST || w:netrw_liststyle == s:WIDELIST || (exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST)
-      exe "sil! NetrwKeepj ".w:netrw_bannercnt.',$s/^\%(\S\+\s\+\)\{8}//e'
-      NetrwKeepj call histdel("/",-1)
-    endif
-  endif
-
-  " ftp's listing doesn't seem to include ./ or ../ " {{{3
-  if !search('^\.\/$\|\s\.\/$','wn')
-    exe 'NetrwKeepj '.w:netrw_bannercnt
-    NetrwKeepj put ='./'
-  endif
-  if !search('^\.\.\/$\|\s\.\.\/$','wn')
-    exe 'NetrwKeepj '.w:netrw_bannercnt
-    NetrwKeepj put ='../'
-  endif
-
-  " restore settings " {{{3
-  let &l:ff= ffkeep
 endfun
 
 " s:NetrwRemoteListing: {{{2
 fun! s:NetrwRemoteListing()
 
-  if !exists("w:netrw_bannercnt") && exists("s:bannercnt")
-    let w:netrw_bannercnt= s:bannercnt
-  endif
-  if !exists("w:netrw_bannercnt") && exists("b:bannercnt")
-    let w:netrw_bannercnt= b:bannercnt
-  endif
-
-  call s:RemotePathAnalysis(b:netrw_curdir)
-
-  " sanity check:
-  if exists("b:netrw_method") && b:netrw_method =~ '[235]'
-    if !executable("ftp")
-      if !exists("g:netrw_quiet")
-        call netrw#msg#Notify('ERROR', "this system doesn't support remote directory listing via ftp")
-      endif
-      call s:NetrwOptionsRestore("w:")
-      return -1
+    if !exists("w:netrw_bannercnt") && exists("s:bannercnt")
+        let w:netrw_bannercnt= s:bannercnt
+    endif
+    if !exists("w:netrw_bannercnt") && exists("b:bannercnt")
+        let w:netrw_bannercnt= b:bannercnt
     endif
 
-  elseif !exists("g:netrw_list_cmd") || g:netrw_list_cmd == ''
-    if !exists("g:netrw_quiet")
-      if g:netrw_list_cmd == ""
-        call netrw#msg#Notify('ERROR', printf('your g:netrw_list_cmd is empty; perhaps %s is not executable on your system', g:netrw_ssh_cmd))
-      else
-        call netrw#msg#Notify('ERROR', "this system doesn't support remote directory listing via ".g:netrw_list_cmd)
-      endif
+    call s:RemotePathAnalysis(b:netrw_curdir)
+
+    " sanity check:
+    if exists("b:netrw_method") && b:netrw_method =~ '[235]'
+        if !executable("ftp")
+            call netrw#msg#Notify('ERROR', "this system doesn't support remote directory listing via ftp")
+            call s:NetrwOptionsRestore("w:")
+            return -1
+        endif
+
+    elseif !exists("g:netrw_list_cmd") || g:netrw_list_cmd == ''
+        if g:netrw_list_cmd == ""
+            call netrw#msg#Notify('ERROR', printf('your g:netrw_list_cmd is empty; perhaps %s is not executable on your system', g:netrw_ssh_cmd))
+        else
+            call netrw#msg#Notify('ERROR', "this system doesn't support remote directory listing via ".g:netrw_list_cmd)
+        endif
+
+        NetrwKeepj call s:NetrwOptionsRestore("w:")
+        return -1
+    endif  " (remote handling sanity check)
+
+    if exists("b:netrw_method")
+        let w:netrw_method= b:netrw_method
     endif
-
-    NetrwKeepj call s:NetrwOptionsRestore("w:")
-    return -1
-  endif  " (remote handling sanity check)
-
-  if exists("b:netrw_method")
-    let w:netrw_method= b:netrw_method
-  endif
-
-  if s:method == "ftp"
-    " use ftp to get remote file listing {{{3
-    let s:method  = "ftp"
-    let listcmd = g:netrw_ftp_list_cmd
-    if g:netrw_sort_by =~# '^t'
-      let listcmd= g:netrw_ftp_timelist_cmd
-    elseif g:netrw_sort_by =~# '^s'
-      let listcmd= g:netrw_ftp_sizelist_cmd
-    endif
-    call s:NetrwRemoteFtpCmd(s:path,listcmd)
-
-    " report on missing file or directory messages
-    if search('[Nn]o such file or directory\|Failed to change directory')
-      let mesg= getline(".")
-      if exists("w:netrw_bannercnt")
-        setl ma
-        exe w:netrw_bannercnt.",$d _"
-        setl noma
-      endif
-      NetrwKeepj call s:NetrwOptionsRestore("w:")
-      call netrw#msg#Notify('WARNING', mesg)
-      return -1
-    endif
-
-    if w:netrw_liststyle == s:THINLIST || w:netrw_liststyle == s:WIDELIST || (exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST)
-      " shorten the listing
-      exe "sil! keepalt NetrwKeepj ".w:netrw_bannercnt
-
-      " cleanup
-      if g:netrw_ftp_browse_reject != ""
-        exe "sil! keepalt NetrwKeepj g/".g:netrw_ftp_browse_reject."/NetrwKeepj d"
-        NetrwKeepj call histdel("/",-1)
-      endif
-      sil! NetrwKeepj %s/\r$//e
-      NetrwKeepj call histdel("/",-1)
-
-      " if there's no ../ listed, then put ../ in
-      let line1= line(".")
-      exe "sil! NetrwKeepj ".w:netrw_bannercnt
-      let line2= search('\.\.\/\%(\s\|$\)','cnW')
-      if line2 == 0
-        sil! NetrwKeepj put='../'
-      endif
-      exe "sil! NetrwKeepj ".line1
-      sil! NetrwKeepj norm! 0
-
-      if search('^\d\{2}-\d\{2}-\d\{2}\s','n') " M$ ftp site cleanup
-        exe 'sil! NetrwKeepj '.w:netrw_bannercnt.',$s/^\d\{2}-\d\{2}-\d\{2}\s\+\d\+:\d\+[AaPp][Mm]\s\+\%(<DIR>\|\d\+\)\s\+//'
-        NetrwKeepj call histdel("/",-1)
-      else " normal ftp cleanup
-        exe 'sil! NetrwKeepj '.w:netrw_bannercnt.',$s/^\(\%(\S\+\s\+\)\{7}\S\+\)\s\+\(\S.*\)$/\2/e'
-        exe "sil! NetrwKeepj ".w:netrw_bannercnt.',$g/ -> /s# -> .*/$#/#e'
-        exe "sil! NetrwKeepj ".w:netrw_bannercnt.',$g/ -> /s# -> .*$#/#e'
-        NetrwKeepj call histdel("/",-1)
-        NetrwKeepj call histdel("/",-1)
-        NetrwKeepj call histdel("/",-1)
-      endif
-    endif
-
-  else
-    " use ssh to get remote file listing {{{3
-    let listcmd= s:MakeSshCmd(g:netrw_list_cmd)
-    if g:netrw_scp_cmd =~ '^pscp'
-      exe "NetrwKeepj r! ".listcmd.netrw#os#Escape(s:path, 1)
-      " remove rubbish and adjust listing format of 'pscp' to 'ssh ls -FLa' like
-      sil! NetrwKeepj g/^Listing directory/NetrwKeepj d
-      sil! NetrwKeepj g/^d[-rwx][-rwx][-rwx]/NetrwKeepj s+$+/+e
-      sil! NetrwKeepj g/^l[-rwx][-rwx][-rwx]/NetrwKeepj s+$+@+e
-      NetrwKeepj call histdel("/",-1)
-      NetrwKeepj call histdel("/",-1)
-      NetrwKeepj call histdel("/",-1)
-      if g:netrw_liststyle != s:LONGLIST
-        sil! NetrwKeepj g/^[dlsp-][-rwx][-rwx][-rwx]/NetrwKeepj s/^.*\s\(\S\+\)$/\1/e
-        NetrwKeepj call histdel("/",-1)
-      endif
-    else
-      if s:path == ""
-        exe "NetrwKeepj keepalt r! ".listcmd
-      else
-        exe "NetrwKeepj keepalt r! ".listcmd.' '.netrw#os#Escape(fnameescape(s:path),1)
-      endif
-    endif
-
-    " cleanup
-    if g:netrw_ssh_browse_reject != ""
-      exe "sil! g/".g:netrw_ssh_browse_reject."/NetrwKeepj d"
-      NetrwKeepj call histdel("/",-1)
-    endif
-  endif
-
-  if w:netrw_liststyle == s:LONGLIST
-    " do a long listing; these substitutions need to be done prior to sorting {{{3
 
     if s:method == "ftp"
-      " cleanup
-      exe "sil! NetrwKeepj ".w:netrw_bannercnt
-      while getline('.') =~# g:netrw_ftp_browse_reject
-        sil! NetrwKeepj d
-      endwhile
-      " if there's no ../ listed, then put ../ in
-      let line1= line(".")
-      sil! NetrwKeepj 1
-      sil! NetrwKeepj call search('^\.\.\/\%(\s\|$\)','W')
-      let line2= line(".")
-      if line2 == 0
-        if b:netrw_curdir != '/'
-          exe 'sil! NetrwKeepj '.w:netrw_bannercnt."put='../'"
+        " use ftp to get remote file listing {{{3
+        let s:method  = "ftp"
+        let listcmd = g:netrw_ftp_list_cmd
+        if g:netrw_sort_by =~# '^t'
+            let listcmd= g:netrw_ftp_timelist_cmd
+        elseif g:netrw_sort_by =~# '^s'
+            let listcmd= g:netrw_ftp_sizelist_cmd
         endif
-      endif
-      exe "sil! NetrwKeepj ".line1
-      sil! NetrwKeepj norm! 0
+        call s:NetrwRemoteFtpCmd(s:path,listcmd)
+
+        " report on missing file or directory messages
+        if search('[Nn]o such file or directory\|Failed to change directory')
+            let mesg= getline(".")
+            if exists("w:netrw_bannercnt")
+                setl ma
+                exe w:netrw_bannercnt.",$d _"
+                setl noma
+            endif
+            NetrwKeepj call s:NetrwOptionsRestore("w:")
+            call netrw#msg#Notify('WARNING', mesg)
+            return -1
+        endif
+
+        if w:netrw_liststyle == s:THINLIST || w:netrw_liststyle == s:WIDELIST || (exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST)
+            " shorten the listing
+            exe "sil! keepalt NetrwKeepj ".w:netrw_bannercnt
+
+            " cleanup
+            if g:netrw_ftp_browse_reject != ""
+                exe "sil! keepalt NetrwKeepj g/".g:netrw_ftp_browse_reject."/NetrwKeepj d"
+                NetrwKeepj call histdel("/",-1)
+            endif
+            sil! NetrwKeepj %s/\r$//e
+            NetrwKeepj call histdel("/",-1)
+
+            " if there's no ../ listed, then put ../ in
+            let line1= line(".")
+            exe "sil! NetrwKeepj ".w:netrw_bannercnt
+            let line2= search('\.\.\/\%(\s\|$\)','cnW')
+            if line2 == 0
+                sil! NetrwKeepj put='../'
+            endif
+            exe "sil! NetrwKeepj ".line1
+            sil! NetrwKeepj norm! 0
+
+            if search('^\d\{2}-\d\{2}-\d\{2}\s','n') " M$ ftp site cleanup
+                exe 'sil! NetrwKeepj '.w:netrw_bannercnt.',$s/^\d\{2}-\d\{2}-\d\{2}\s\+\d\+:\d\+[AaPp][Mm]\s\+\%(<DIR>\|\d\+\)\s\+//'
+                NetrwKeepj call histdel("/",-1)
+            else " normal ftp cleanup
+                exe 'sil! NetrwKeepj '.w:netrw_bannercnt.',$s/^\(\%(\S\+\s\+\)\{7}\S\+\)\s\+\(\S.*\)$/\2/e'
+                exe "sil! NetrwKeepj ".w:netrw_bannercnt.',$g/ -> /s# -> .*/$#/#e'
+                exe "sil! NetrwKeepj ".w:netrw_bannercnt.',$g/ -> /s# -> .*$#/#e'
+                NetrwKeepj call histdel("/",-1)
+                NetrwKeepj call histdel("/",-1)
+                NetrwKeepj call histdel("/",-1)
+            endif
+        endif
+
+    else
+        " use ssh to get remote file listing {{{3
+        let listcmd= s:MakeSshCmd(g:netrw_list_cmd)
+        if g:netrw_scp_cmd =~ '^pscp'
+            exe "NetrwKeepj r! ".listcmd.netrw#os#Escape(s:path, 1)
+            " remove rubbish and adjust listing format of 'pscp' to 'ssh ls -FLa' like
+            sil! NetrwKeepj g/^Listing directory/NetrwKeepj d
+            sil! NetrwKeepj g/^d[-rwx][-rwx][-rwx]/NetrwKeepj s+$+/+e
+            sil! NetrwKeepj g/^l[-rwx][-rwx][-rwx]/NetrwKeepj s+$+@+e
+            NetrwKeepj call histdel("/",-1)
+            NetrwKeepj call histdel("/",-1)
+            NetrwKeepj call histdel("/",-1)
+            if g:netrw_liststyle != s:LONGLIST
+                sil! NetrwKeepj g/^[dlsp-][-rwx][-rwx][-rwx]/NetrwKeepj s/^.*\s\(\S\+\)$/\1/e
+                NetrwKeepj call histdel("/",-1)
+            endif
+        else
+            if s:path == ""
+                exe "NetrwKeepj keepalt r! ".listcmd
+            else
+                exe "NetrwKeepj keepalt r! ".listcmd.' '.netrw#os#Escape(fnameescape(s:path),1)
+            endif
+        endif
+
+        " cleanup
+        if g:netrw_ssh_browse_reject != ""
+            exe "sil! g/".g:netrw_ssh_browse_reject."/NetrwKeepj d"
+            NetrwKeepj call histdel("/",-1)
+        endif
     endif
 
-    if search('^\d\{2}-\d\{2}-\d\{2}\s','n') " M$ ftp site cleanup
-      exe 'sil! NetrwKeepj '.w:netrw_bannercnt.',$s/^\(\d\{2}-\d\{2}-\d\{2}\s\+\d\+:\d\+[AaPp][Mm]\s\+\%(<DIR>\|\d\+\)\s\+\)\(\w.*\)$/\2\t\1/'
-    elseif exists("w:netrw_bannercnt") && w:netrw_bannercnt <= line("$")
-      exe 'sil NetrwKeepj '.w:netrw_bannercnt.',$s/ -> .*$//e'
-      exe 'sil NetrwKeepj '.w:netrw_bannercnt.',$s/^\(\%(\S\+\s\+\)\{7}\S\+\)\s\+\(\S.*\)$/\2 \t\1/e'
-      exe 'sil NetrwKeepj '.w:netrw_bannercnt
-      NetrwKeepj call histdel("/",-1)
-      NetrwKeepj call histdel("/",-1)
-      NetrwKeepj call histdel("/",-1)
+    if w:netrw_liststyle == s:LONGLIST
+        " do a long listing; these substitutions need to be done prior to sorting {{{3
+
+        if s:method == "ftp"
+            " cleanup
+            exe "sil! NetrwKeepj ".w:netrw_bannercnt
+            while getline('.') =~# g:netrw_ftp_browse_reject
+                sil! NetrwKeepj d
+            endwhile
+            " if there's no ../ listed, then put ../ in
+            let line1= line(".")
+            sil! NetrwKeepj 1
+            sil! NetrwKeepj call search('^\.\.\/\%(\s\|$\)','W')
+            let line2= line(".")
+            if line2 == 0
+                if b:netrw_curdir != '/'
+                    exe 'sil! NetrwKeepj '.w:netrw_bannercnt."put='../'"
+                endif
+            endif
+            exe "sil! NetrwKeepj ".line1
+            sil! NetrwKeepj norm! 0
+        endif
+
+        if search('^\d\{2}-\d\{2}-\d\{2}\s','n') " M$ ftp site cleanup
+            exe 'sil! NetrwKeepj '.w:netrw_bannercnt.',$s/^\(\d\{2}-\d\{2}-\d\{2}\s\+\d\+:\d\+[AaPp][Mm]\s\+\%(<DIR>\|\d\+\)\s\+\)\(\w.*\)$/\2\t\1/'
+        elseif exists("w:netrw_bannercnt") && w:netrw_bannercnt <= line("$")
+            exe 'sil NetrwKeepj '.w:netrw_bannercnt.',$s/ -> .*$//e'
+            exe 'sil NetrwKeepj '.w:netrw_bannercnt.',$s/^\(\%(\S\+\s\+\)\{7}\S\+\)\s\+\(\S.*\)$/\2 \t\1/e'
+            exe 'sil NetrwKeepj '.w:netrw_bannercnt
+            NetrwKeepj call histdel("/",-1)
+            NetrwKeepj call histdel("/",-1)
+            NetrwKeepj call histdel("/",-1)
+        endif
     endif
-  endif
 
 
-  return 0
+    return 0
 endfun
 
 " s:NetrwRemoteRm: remove/delete a remote file or directory {{{2
 fun! s:NetrwRemoteRm(usrhost,path) range
-  let svpos= winsaveview()
+    let svpos= winsaveview()
 
-  let all= 0
-  if exists("s:netrwmarkfilelist_{bufnr('%')}")
-    " remove all marked files
-    for fname in s:netrwmarkfilelist_{bufnr("%")}
-      let ok= s:NetrwRemoteRmFile(a:path,fname,all)
-      if ok =~# 'q\%[uit]'
-        break
-      elseif ok =~# 'a\%[ll]'
-        let all= 1
-      endif
-    endfor
-    call s:NetrwUnmarkList(bufnr("%"),b:netrw_curdir)
+    let all= 0
+    if exists("s:netrwmarkfilelist_{bufnr('%')}")
+        " remove all marked files
+        for fname in s:netrwmarkfilelist_{bufnr("%")}
+            let ok= s:NetrwRemoteRmFile(a:path,fname,all)
+            if ok =~# 'q\%[uit]'
+                break
+            elseif ok =~# 'a\%[ll]'
+                let all= 1
+            endif
+        endfor
+        call s:NetrwUnmarkList(bufnr("%"),b:netrw_curdir)
 
-  else
-    " remove files specified by range
+    else
+        " remove files specified by range
 
-    " preparation for removing multiple files/directories
-    let keepsol = &l:sol
-    setl nosol
-    let ctr    = a:firstline
+        " preparation for removing multiple files/directories
+        let keepsol = &l:sol
+        setl nosol
+        let ctr    = a:firstline
 
-    " remove multiple files and directories
-    while ctr <= a:lastline
-      exe "NetrwKeepj ".ctr
-      let ok= s:NetrwRemoteRmFile(a:path,s:NetrwGetWord(),all)
-      if ok =~# 'q\%[uit]'
-        break
-      elseif ok =~# 'a\%[ll]'
-        let all= 1
-      endif
-      let ctr= ctr + 1
-    endwhile
-    let &l:sol = keepsol
-  endif
+        " remove multiple files and directories
+        while ctr <= a:lastline
+            exe "NetrwKeepj ".ctr
+            let ok= s:NetrwRemoteRmFile(a:path,s:NetrwGetWord(),all)
+            if ok =~# 'q\%[uit]'
+                break
+            elseif ok =~# 'a\%[ll]'
+                let all= 1
+            endif
+            let ctr= ctr + 1
+        endwhile
+        let &l:sol = keepsol
+    endif
 
-  " refresh the (remote) directory listing
-  NetrwKeepj call s:NetrwRefresh(0,s:NetrwBrowseChgDir(0,'./',0))
-  NetrwKeepj call winrestview(svpos)
+    " refresh the (remote) directory listing
+    NetrwKeepj call s:NetrwRefresh(0,s:NetrwBrowseChgDir(0,'./',0))
+    NetrwKeepj call winrestview(svpos)
 endfun
 
 " s:NetrwRemoteRmFile: {{{2
 fun! s:NetrwRemoteRmFile(path,rmfile,all)
 
-  let all= a:all
-  let ok = ""
+    let all= a:all
+    let ok = ""
 
-  if a:rmfile !~ '^"' && (a:rmfile =~ '@$' || a:rmfile !~ '[\/]$')
-    " attempt to remove file
-    if !all
-      echohl Statement
-      call inputsave()
-      let ok= input("Confirm deletion of file<".a:rmfile."> ","[{y(es)},n(o),a(ll),q(uit)] ")
-      call inputrestore()
-      echohl NONE
-      if ok == ""
-        let ok="no"
-      endif
-      let ok= substitute(ok,'\[{y(es)},n(o),a(ll),q(uit)]\s*','','e')
-      if ok =~# 'a\%[ll]'
-        let all= 1
-      endif
-    endif
-
-    if all || ok =~# 'y\%[es]' || ok == ""
-      if exists("w:netrw_method") && (w:netrw_method == 2 || w:netrw_method == 3)
-        let path= a:path
-        if path =~ '^\a\{3,}://'
-          let path= substitute(path,'^\a\{3,}://[^/]\+/','','')
-        endif
-        sil! NetrwKeepj .,$d _
-        call s:NetrwRemoteFtpCmd(path,"delete ".'"'.a:rmfile.'"')
-      else
-        let netrw_rm_cmd= s:MakeSshCmd(g:netrw_rm_cmd)
-        if !exists("b:netrw_curdir")
-          call netrw#msg#Notify('ERROR', "for some reason b:netrw_curdir doesn't exist!")
-          let ok="q"
-        else
-          let remotedir= substitute(b:netrw_curdir,'^.\{-}//[^/]\+/\(.*\)$','\1','')
-          if remotedir != ""
-            let netrw_rm_cmd= netrw_rm_cmd." ".netrw#os#Escape(fnameescape(remotedir.a:rmfile))
-          else
-            let netrw_rm_cmd= netrw_rm_cmd." ".netrw#os#Escape(fnameescape(a:rmfile))
-          endif
-          let ret= system(netrw_rm_cmd)
-          if v:shell_error != 0
-            if exists("b:netrw_curdir") && b:netrw_curdir != getcwd() && !g:netrw_keepdir
-              call netrw#msg#Notify('ERROR', printf("remove failed; perhaps due to vim's current directory<%s> not matching netrw's (%s) (see :help netrw-cd)", getcwd(), b:netrw_curdir))
-            else
-              call netrw#msg#Notify('WARNING', printf('cmd<%s> failed', netrw_rm_cmd))
+    if a:rmfile !~ '^"' && (a:rmfile =~ '@$' || a:rmfile !~ '[\/]$')
+        " attempt to remove file
+        if !all
+            echohl Statement
+            call inputsave()
+            let ok= input("Confirm deletion of file<".a:rmfile."> ","[{y(es)},n(o),a(ll),q(uit)] ")
+            call inputrestore()
+            echohl NONE
+            if ok == ""
+                let ok="no"
             endif
-          elseif ret != 0
-            call netrw#msg#Notify('WARNING', printf('cmd<%s> failed', netrw_rm_cmd))
-          endif
+            let ok= substitute(ok,'\[{y(es)},n(o),a(ll),q(uit)]\s*','','e')
+            if ok =~# 'a\%[ll]'
+                let all= 1
+            endif
         endif
-      endif
-    elseif ok =~# 'q\%[uit]'
-    endif
 
-  else
-    " attempt to remove directory
-    if !all
-      call inputsave()
-      let ok= input("Confirm deletion of directory<".a:rmfile."> ","[{y(es)},n(o),a(ll),q(uit)] ")
-      call inputrestore()
-      if ok == ""
-        let ok="no"
-      endif
-      let ok= substitute(ok,'\[{y(es)},n(o),a(ll),q(uit)]\s*','','e')
-      if ok =~# 'a\%[ll]'
-        let all= 1
-      endif
-    endif
-
-    if all || ok =~# 'y\%[es]' || ok == ""
-      if exists("w:netrw_method") && (w:netrw_method == 2 || w:netrw_method == 3)
-        NetrwKeepj call s:NetrwRemoteFtpCmd(a:path,"rmdir ".a:rmfile)
-      else
-        let rmfile          = substitute(a:path.a:rmfile,'/$','','')
-        let netrw_rmdir_cmd = s:MakeSshCmd(netrw#fs#WinPath(g:netrw_rmdir_cmd)).' '.netrw#os#Escape(netrw#fs#WinPath(rmfile))
-        let ret= system(netrw_rmdir_cmd)
-
-        if v:shell_error != 0
-          let netrw_rmf_cmd= s:MakeSshCmd(netrw#fs#WinPath(g:netrw_rmf_cmd)).' '.netrw#os#Escape(netrw#fs#WinPath(substitute(rmfile,'[\/]$','','e')))
-          let ret= system(netrw_rmf_cmd)
-
-          if v:shell_error != 0 && !exists("g:netrw_quiet")
-            call netrw#msg#Notify('ERROR', printf('unable to remove directory<%s> -- is it empty?', rmfile))
-          endif
+        if all || ok =~# 'y\%[es]' || ok == ""
+            if exists("w:netrw_method") && (w:netrw_method == 2 || w:netrw_method == 3)
+                let path= a:path
+                if path =~ '^\a\{3,}://'
+                    let path= substitute(path,'^\a\{3,}://[^/]\+/','','')
+                endif
+                sil! NetrwKeepj .,$d _
+                call s:NetrwRemoteFtpCmd(path,"delete ".'"'.a:rmfile.'"')
+            else
+                let netrw_rm_cmd= s:MakeSshCmd(g:netrw_rm_cmd)
+                if !exists("b:netrw_curdir")
+                    call netrw#msg#Notify('ERROR', "for some reason b:netrw_curdir doesn't exist!")
+                    let ok="q"
+                else
+                    let remotedir= substitute(b:netrw_curdir,'^.\{-}//[^/]\+/\(.*\)$','\1','')
+                    if remotedir != ""
+                        let netrw_rm_cmd= netrw_rm_cmd." ".netrw#os#Escape(fnameescape(remotedir.a:rmfile))
+                    else
+                        let netrw_rm_cmd= netrw_rm_cmd." ".netrw#os#Escape(fnameescape(a:rmfile))
+                    endif
+                    let ret= system(netrw_rm_cmd)
+                    if v:shell_error != 0
+                        if exists("b:netrw_curdir") && b:netrw_curdir != getcwd() && !g:netrw_keepdir
+                            call netrw#msg#Notify('ERROR', printf("remove failed; perhaps due to vim's current directory<%s> not matching netrw's (%s) (see :help netrw-cd)", getcwd(), b:netrw_curdir))
+                        else
+                            call netrw#msg#Notify('WARNING', printf('cmd<%s> failed', netrw_rm_cmd))
+                        endif
+                    elseif ret != 0
+                        call netrw#msg#Notify('WARNING', printf('cmd<%s> failed', netrw_rm_cmd))
+                    endif
+                endif
+            endif
+        elseif ok =~# 'q\%[uit]'
         endif
-      endif
 
-    elseif ok =~# 'q\%[uit]'
+    else
+        " attempt to remove directory
+        if !all
+            call inputsave()
+            let ok= input("Confirm deletion of directory<".a:rmfile."> ","[{y(es)},n(o),a(ll),q(uit)] ")
+            call inputrestore()
+            if ok == ""
+                let ok="no"
+            endif
+            let ok= substitute(ok,'\[{y(es)},n(o),a(ll),q(uit)]\s*','','e')
+            if ok =~# 'a\%[ll]'
+                let all= 1
+            endif
+        endif
+
+        if all || ok =~# 'y\%[es]' || ok == ""
+            if exists("w:netrw_method") && (w:netrw_method == 2 || w:netrw_method == 3)
+                NetrwKeepj call s:NetrwRemoteFtpCmd(a:path,"rmdir ".a:rmfile)
+            else
+                let rmfile          = substitute(a:path.a:rmfile,'/$','','')
+                let netrw_rmdir_cmd = s:MakeSshCmd(netrw#fs#WinPath(g:netrw_rmdir_cmd)).' '.netrw#os#Escape(netrw#fs#WinPath(rmfile))
+                let ret= system(netrw_rmdir_cmd)
+
+                if v:shell_error != 0
+                    let netrw_rmf_cmd= s:MakeSshCmd(netrw#fs#WinPath(g:netrw_rmf_cmd)).' '.netrw#os#Escape(netrw#fs#WinPath(substitute(rmfile,'[\/]$','','e')))
+                    let ret= system(netrw_rmf_cmd)
+
+                    if v:shell_error != 0
+                        call netrw#msg#Notify('ERROR', printf('unable to remove directory<%s> -- is it empty?', rmfile))
+                    endif
+                endif
+            endif
+
+        elseif ok =~# 'q\%[uit]'
+        endif
     endif
-  endif
 
-  return ok
+    return ok
 endfun
 
 " s:NetrwRemoteRename: rename a remote file or directory {{{2
 fun! s:NetrwRemoteRename(usrhost,path) range
 
-  " preparation for removing multiple files/directories
-  let svpos      = winsaveview()
-  let ctr        = a:firstline
-  let rename_cmd = s:MakeSshCmd(g:netrw_rename_cmd)
+    " preparation for removing multiple files/directories
+    let svpos      = winsaveview()
+    let ctr        = a:firstline
+    let rename_cmd = s:MakeSshCmd(g:netrw_rename_cmd)
 
-  " rename files given by the markfilelist
-  if exists("s:netrwmarkfilelist_{bufnr('%')}")
-    for oldname in s:netrwmarkfilelist_{bufnr("%")}
-      if exists("subfrom")
-        let newname= substitute(oldname,subfrom,subto,'')
-      else
-        call inputsave()
-        let newname= input("Moving ".oldname." to : ",oldname)
-        call inputrestore()
-        if newname =~ '^s/'
-          let subfrom = substitute(newname,'^s/\([^/]*\)/.*/$','\1','')
-          let subto   = substitute(newname,'^s/[^/]*/\(.*\)/$','\1','')
-          let newname = substitute(oldname,subfrom,subto,'')
-        endif
-      endif
+    " rename files given by the markfilelist
+    if exists("s:netrwmarkfilelist_{bufnr('%')}")
+        for oldname in s:netrwmarkfilelist_{bufnr("%")}
+            if exists("subfrom")
+                let newname= substitute(oldname,subfrom,subto,'')
+            else
+                call inputsave()
+                let newname= input("Moving ".oldname." to : ",oldname)
+                call inputrestore()
+                if newname =~ '^s/'
+                    let subfrom = substitute(newname,'^s/\([^/]*\)/.*/$','\1','')
+                    let subto   = substitute(newname,'^s/[^/]*/\(.*\)/$','\1','')
+                    let newname = substitute(oldname,subfrom,subto,'')
+                endif
+            endif
 
-      if exists("w:netrw_method") && (w:netrw_method == 2 || w:netrw_method == 3)
-        NetrwKeepj call s:NetrwRemoteFtpCmd(a:path,"rename ".oldname." ".newname)
-      else
-        let oldname= netrw#os#Escape(a:path.oldname)
-        let newname= netrw#os#Escape(a:path.newname)
-        let ret    = system(netrw#fs#WinPath(rename_cmd).' '.oldname.' '.newname)
-      endif
+            if exists("w:netrw_method") && (w:netrw_method == 2 || w:netrw_method == 3)
+                NetrwKeepj call s:NetrwRemoteFtpCmd(a:path,"rename ".oldname." ".newname)
+            else
+                let oldname= netrw#os#Escape(a:path.oldname)
+                let newname= netrw#os#Escape(a:path.newname)
+                let ret    = system(netrw#fs#WinPath(rename_cmd).' '.oldname.' '.newname)
+            endif
 
-    endfor
-    call s:NetrwUnMarkFile(1)
+        endfor
+        call s:NetrwUnMarkFile(1)
 
-  else
+    else
 
-    " attempt to rename files/directories
-    let keepsol= &l:sol
-    setl nosol
-    while ctr <= a:lastline
-      exe "NetrwKeepj ".ctr
+        " attempt to rename files/directories
+        let keepsol= &l:sol
+        setl nosol
+        while ctr <= a:lastline
+            exe "NetrwKeepj ".ctr
 
-      let oldname= s:NetrwGetWord()
+            let oldname= s:NetrwGetWord()
 
-      call inputsave()
-      let newname= input("Moving ".oldname." to : ",oldname)
-      call inputrestore()
+            call inputsave()
+            let newname= input("Moving ".oldname." to : ",oldname)
+            call inputrestore()
 
-      if exists("w:netrw_method") && (w:netrw_method == 2 || w:netrw_method == 3)
-        call s:NetrwRemoteFtpCmd(a:path,"rename ".oldname." ".newname)
-      else
-        let oldname= netrw#os#Escape(a:path.oldname)
-        let newname= netrw#os#Escape(a:path.newname)
-        let ret    = system(netrw#fs#WinPath(rename_cmd).' '.oldname.' '.newname)
-      endif
+            if exists("w:netrw_method") && (w:netrw_method == 2 || w:netrw_method == 3)
+                call s:NetrwRemoteFtpCmd(a:path,"rename ".oldname." ".newname)
+            else
+                let oldname= netrw#os#Escape(a:path.oldname)
+                let newname= netrw#os#Escape(a:path.newname)
+                let ret    = system(netrw#fs#WinPath(rename_cmd).' '.oldname.' '.newname)
+            endif
 
-      let ctr= ctr + 1
-    endwhile
-    let &l:sol= keepsol
-  endif
+            let ctr= ctr + 1
+        endwhile
+        let &l:sol= keepsol
+    endif
 
-  " refresh the directory
-  NetrwKeepj call s:NetrwRefresh(0,s:NetrwBrowseChgDir(0,'./',0))
-  NetrwKeepj call winrestview(svpos)
+    " refresh the directory
+    NetrwKeepj call s:NetrwRefresh(0,s:NetrwBrowseChgDir(0,'./',0))
+    NetrwKeepj call winrestview(svpos)
 endfun
 
 "  Local Directory Browsing Support:    {{{1
@@ -8547,77 +8506,77 @@ endfun
 "                    file:///c:/foo.txt
 " and %XX (where X is [0-9a-fA-F] is converted into a character with the given hexadecimal value
 fun! netrw#FileUrlEdit(fname)
-  let fname = a:fname
-  if fname =~ '^file://localhost/'
-    let fname= substitute(fname,'^file://localhost/','file:///','')
-  endif
-  if has("win32")
-    if fname  =~ '^file:///\=\a[|:]/'
-      let fname = substitute(fname,'^file:///\=\(\a\)[|:]/','file://\1:/','')
+    let fname = a:fname
+    if fname =~ '^file://localhost/'
+        let fname= substitute(fname,'^file://localhost/','file:///','')
     endif
-  endif
-  let fname2396 = netrw#RFC2396(fname)
-  let fname2396e= fnameescape(fname2396)
-  let plainfname= substitute(fname2396,'file://\(.*\)','\1',"")
-  if has("win32")
-    if plainfname =~ '^/\+\a:'
-      let plainfname= substitute(plainfname,'^/\+\(\a:\)','\1','')
+    if has("win32")
+        if fname  =~ '^file:///\=\a[|:]/'
+            let fname = substitute(fname,'^file:///\=\(\a\)[|:]/','file://\1:/','')
+        endif
     endif
-  endif
+    let fname2396 = netrw#RFC2396(fname)
+    let fname2396e= fnameescape(fname2396)
+    let plainfname= substitute(fname2396,'file://\(.*\)','\1',"")
+    if has("win32")
+        if plainfname =~ '^/\+\a:'
+            let plainfname= substitute(plainfname,'^/\+\(\a:\)','\1','')
+        endif
+    endif
 
-  exe "sil doau BufReadPre ".fname2396e
-  exe 'NetrwKeepj keepalt edit '.plainfname
-  exe 'sil! NetrwKeepj keepalt bdelete '.fnameescape(a:fname)
+    exe "sil doau BufReadPre ".fname2396e
+    exe 'NetrwKeepj keepalt edit '.plainfname
+    exe 'sil! NetrwKeepj keepalt bdelete '.fnameescape(a:fname)
 
-  exe "sil doau BufReadPost ".fname2396e
+    exe "sil doau BufReadPost ".fname2396e
 endfun
 
 " netrw#LocalBrowseCheck: {{{2
 fun! netrw#LocalBrowseCheck(dirname)
-  " This function is called by netrwPlugin.vim's s:LocalBrowseCheck(), s:NetrwRexplore(),
-  " and by <cr> when atop a listed file/directory (via a buffer-local map)
-  "
-  " unfortunate interaction -- split window debugging can't be used here, must use
-  "                            D-echoRemOn or D-echoTabOn as the BufEnter event triggers
-  "                            another call to LocalBrowseCheck() when attempts to write
-  "                            to the DBG buffer are made.
-  "
-  " The &ft == "netrw" test was installed because the BufEnter event
-  " would hit when re-entering netrw windows, creating unexpected
-  " refreshes (and would do so in the middle of NetrwSaveOptions(), too)
-  " getting E930: Cannot use :redir inside execute
+    " This function is called by netrwPlugin.vim's s:LocalBrowseCheck(), s:NetrwRexplore(),
+    " and by <cr> when atop a listed file/directory (via a buffer-local map)
+    "
+    " unfortunate interaction -- split window debugging can't be used here, must use
+    "                            D-echoRemOn or D-echoTabOn as the BufEnter event triggers
+    "                            another call to LocalBrowseCheck() when attempts to write
+    "                            to the DBG buffer are made.
+    "
+    " The &ft == "netrw" test was installed because the BufEnter event
+    " would hit when re-entering netrw windows, creating unexpected
+    " refreshes (and would do so in the middle of NetrwSaveOptions(), too)
+    " getting E930: Cannot use :redir inside execute
 
-  let ykeep= @@
-  if isdirectory(s:NetrwFile(a:dirname))
+    let ykeep= @@
+    if isdirectory(s:NetrwFile(a:dirname))
 
-    if &ft != "netrw" || (exists("b:netrw_curdir") && b:netrw_curdir != a:dirname) || g:netrw_fastbrowse <= 1
-      sil! NetrwKeepj keepalt call s:NetrwBrowse(1,a:dirname)
+        if &ft != "netrw" || (exists("b:netrw_curdir") && b:netrw_curdir != a:dirname) || g:netrw_fastbrowse <= 1
+            sil! NetrwKeepj keepalt call s:NetrwBrowse(1,a:dirname)
 
-    elseif &ft == "netrw" && line("$") == 1
-      sil! NetrwKeepj keepalt call s:NetrwBrowse(1,a:dirname)
+        elseif &ft == "netrw" && line("$") == 1
+            sil! NetrwKeepj keepalt call s:NetrwBrowse(1,a:dirname)
 
-    elseif exists("s:treeforceredraw")
-      unlet s:treeforceredraw
-      sil! NetrwKeepj keepalt call s:NetrwBrowse(1,a:dirname)
+        elseif exists("s:treeforceredraw")
+            unlet s:treeforceredraw
+            sil! NetrwKeepj keepalt call s:NetrwBrowse(1,a:dirname)
+        endif
+        return
     endif
-    return
-  endif
 
-  " The following code wipes out currently unused netrw buffers
-  "       IF g:netrw_fastbrowse is zero (ie. slow browsing selected)
-  "   AND IF the listing style is not a tree listing
-  if exists("g:netrw_fastbrowse") && g:netrw_fastbrowse == 0 && g:netrw_liststyle != s:TREELIST
-    let ibuf    = 1
-    let buflast = bufnr("$")
-    while ibuf <= buflast
-      if bufwinnr(ibuf) == -1 && isdirectory(s:NetrwFile(bufname(ibuf)))
-        exe "sil! keepj keepalt ".ibuf."bw!"
-      endif
-      let ibuf= ibuf + 1
-    endwhile
-  endif
-  let @@= ykeep
-  " not a directory, ignore it
+    " The following code wipes out currently unused netrw buffers
+    "       IF g:netrw_fastbrowse is zero (ie. slow browsing selected)
+    "   AND IF the listing style is not a tree listing
+    if exists("g:netrw_fastbrowse") && g:netrw_fastbrowse == 0 && g:netrw_liststyle != s:TREELIST
+        let ibuf    = 1
+        let buflast = bufnr("$")
+        while ibuf <= buflast
+            if bufwinnr(ibuf) == -1 && isdirectory(s:NetrwFile(bufname(ibuf)))
+                exe "sil! keepj keepalt ".ibuf."bw!"
+            endif
+            let ibuf= ibuf + 1
+        endwhile
+    endif
+    let @@= ykeep
+    " not a directory, ignore it
 endfun
 
 " s:LocalBrowseRefresh: this function is called after a user has {{{2
@@ -8625,60 +8584,60 @@ endfun
 " buffers to be refreshed after a user has executed some shell command,
 " on the chance that s/he removed/created a file/directory with it.
 fun! s:LocalBrowseRefresh()
-  " determine which buffers currently reside in a tab
-  if !exists("s:netrw_browselist")
-    return
-  endif
-  if !exists("w:netrw_bannercnt")
-    return
-  endif
-  if !empty(getcmdwintype())
-    " cannot move away from cmdline window, see :h E11
-    return
-  endif
-  if exists("s:netrw_events") && s:netrw_events == 1
-    " s:LocalFastBrowser gets called (indirectly) from a
-    let s:netrw_events= 2
-    return
-  endif
-  let itab       = 1
-  let buftablist = []
-  let ykeep      = @@
-  while itab <= tabpagenr("$")
-    let buftablist = buftablist + tabpagebuflist()
-    let itab       = itab + 1
-    sil! tabn
-  endwhile
-  "  GO through all buffers on netrw_browselist (ie. just local-netrw buffers):
-  "   | refresh any netrw window
-  "   | wipe out any non-displaying netrw buffer
-  let curwinid = win_getid(winnr())
-  let ibl    = 0
-  for ibuf in s:netrw_browselist
-    if bufwinnr(ibuf) == -1 && index(buftablist,ibuf) == -1
-      " wipe out any non-displaying netrw buffer
-      " (ibuf not shown in a current window AND
-      "  ibuf not in any tab)
-      exe "sil! keepj bd ".fnameescape(ibuf)
-      call remove(s:netrw_browselist,ibl)
-      continue
-    elseif index(tabpagebuflist(),ibuf) != -1
-      " refresh any netrw buffer
-      exe bufwinnr(ibuf)."wincmd w"
-      if getline(".") =~# 'Quick Help'
-        " decrement g:netrw_quickhelp to prevent refresh from changing g:netrw_quickhelp
-        " (counteracts s:NetrwBrowseChgDir()'s incrementing)
-        let g:netrw_quickhelp= g:netrw_quickhelp - 1
-      endif
-      if exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST
-        NetrwKeepj call s:NetrwRefreshTreeDict(w:netrw_treetop)
-      endif
-      NetrwKeepj call s:NetrwRefresh(1,s:NetrwBrowseChgDir(1,'./',0))
+    " determine which buffers currently reside in a tab
+    if !exists("s:netrw_browselist")
+        return
     endif
-    let ibl= ibl + 1
-  endfor
-  call win_gotoid(curwinid)
-  let @@= ykeep
+    if !exists("w:netrw_bannercnt")
+        return
+    endif
+    if !empty(getcmdwintype())
+        " cannot move away from cmdline window, see :h E11
+        return
+    endif
+    if exists("s:netrw_events") && s:netrw_events == 1
+        " s:LocalFastBrowser gets called (indirectly) from a
+        let s:netrw_events= 2
+        return
+    endif
+    let itab       = 1
+    let buftablist = []
+    let ykeep      = @@
+    while itab <= tabpagenr("$")
+        let buftablist = buftablist + tabpagebuflist()
+        let itab       = itab + 1
+        sil! tabn
+    endwhile
+    "  GO through all buffers on netrw_browselist (ie. just local-netrw buffers):
+    "   | refresh any netrw window
+    "   | wipe out any non-displaying netrw buffer
+    let curwinid = win_getid(winnr())
+    let ibl    = 0
+    for ibuf in s:netrw_browselist
+        if bufwinnr(ibuf) == -1 && index(buftablist,ibuf) == -1
+            " wipe out any non-displaying netrw buffer
+            " (ibuf not shown in a current window AND
+            "  ibuf not in any tab)
+            exe "sil! keepj bd ".fnameescape(ibuf)
+            call remove(s:netrw_browselist,ibl)
+            continue
+        elseif index(tabpagebuflist(),ibuf) != -1
+            " refresh any netrw buffer
+            exe bufwinnr(ibuf)."wincmd w"
+            if getline(".") =~# 'Quick Help'
+                " decrement g:netrw_quickhelp to prevent refresh from changing g:netrw_quickhelp
+                " (counteracts s:NetrwBrowseChgDir()'s incrementing)
+                let g:netrw_quickhelp= g:netrw_quickhelp - 1
+            endif
+            if exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST
+                NetrwKeepj call s:NetrwRefreshTreeDict(w:netrw_treetop)
+            endif
+            NetrwKeepj call s:NetrwRefresh(1,s:NetrwBrowseChgDir(1,'./',0))
+        endif
+        let ibl= ibl + 1
+    endfor
+    call win_gotoid(curwinid)
+    let @@= ykeep
 endfun
 
 " s:LocalFastBrowser: handles setting up/taking down fast browsing for the local browser {{{2
@@ -8700,269 +8659,269 @@ endfun
 "                   =2: autocmds installed (doesn't ignore any FocusGained events)
 fun! s:LocalFastBrowser()
 
-  " initialize browselist, a list of buffer numbers that the local browser has used
-  if !exists("s:netrw_browselist")
-    let s:netrw_browselist= []
-  endif
+    " initialize browselist, a list of buffer numbers that the local browser has used
+    if !exists("s:netrw_browselist")
+        let s:netrw_browselist= []
+    endif
 
-  " append current buffer to fastbrowse list
-  if empty(s:netrw_browselist) || bufnr("%") > s:netrw_browselist[-1]
-    call add(s:netrw_browselist,bufnr("%"))
-  endif
+    " append current buffer to fastbrowse list
+    if empty(s:netrw_browselist) || bufnr("%") > s:netrw_browselist[-1]
+        call add(s:netrw_browselist,bufnr("%"))
+    endif
 
-  " enable autocmd events to handle refreshing/removing local browser buffers
-  "    If local browse buffer is currently showing: refresh it
-  "    If local browse buffer is currently hidden : wipe it
-  "    g:netrw_fastbrowse=0 : slow   speed, never re-use directory listing
-  "                      =1 : medium speed, re-use directory listing for remote only
-  "                      =2 : fast   speed, always re-use directory listing when possible
-  if g:netrw_fastbrowse <= 1 && !exists("#ShellCmdPost") && !exists("s:netrw_events")
-    let s:netrw_events= 1
-    augroup AuNetrwEvent
-      au!
-      if has("win32")
-        au ShellCmdPost                    *       call s:LocalBrowseRefresh()
-      else
-        au ShellCmdPost,FocusGained        *       call s:LocalBrowseRefresh()
-      endif
-    augroup END
+    " enable autocmd events to handle refreshing/removing local browser buffers
+    "    If local browse buffer is currently showing: refresh it
+    "    If local browse buffer is currently hidden : wipe it
+    "    g:netrw_fastbrowse=0 : slow   speed, never re-use directory listing
+    "                      =1 : medium speed, re-use directory listing for remote only
+    "                      =2 : fast   speed, always re-use directory listing when possible
+    if g:netrw_fastbrowse <= 1 && !exists("#ShellCmdPost") && !exists("s:netrw_events")
+        let s:netrw_events= 1
+        augroup AuNetrwEvent
+            au!
+            if has("win32")
+                au ShellCmdPost                    *       call s:LocalBrowseRefresh()
+            else
+                au ShellCmdPost,FocusGained        *       call s:LocalBrowseRefresh()
+            endif
+        augroup END
 
-  " user must have changed fastbrowse to its fast setting, so remove
-  " the associated autocmd events
-  elseif g:netrw_fastbrowse > 1 && exists("#ShellCmdPost") && exists("s:netrw_events")
-    unlet s:netrw_events
-    augroup AuNetrwEvent
-      au!
-    augroup END
-    augroup! AuNetrwEvent
-  endif
+    " user must have changed fastbrowse to its fast setting, so remove
+    " the associated autocmd events
+    elseif g:netrw_fastbrowse > 1 && exists("#ShellCmdPost") && exists("s:netrw_events")
+        unlet s:netrw_events
+        augroup AuNetrwEvent
+            au!
+        augroup END
+        augroup! AuNetrwEvent
+    endif
 endfun
 
 fun! s:NetrwLocalListingList(dirname,setmaxfilenamelen)
-  " get the list of files contained in the current directory
-  let dirname    = a:dirname
-  let dirnamelen = strlen(dirname)
-  let filelist   = netrw#fs#Glob(dirname,"*",0)
-  let filelist   = filelist + netrw#fs#Glob(dirname,".*",0)
+    " get the list of files contained in the current directory
+    let dirname    = a:dirname
+    let dirnamelen = strlen(dirname)
+    let filelist   = netrw#fs#Glob(dirname,"*",0)
+    let filelist   = filelist + netrw#fs#Glob(dirname,".*",0)
 
-  if g:netrw_cygwin == 0 && has("win32")
-  elseif index(filelist,'..') == -1 && dirname !~ '/'
-    " include ../ in the glob() entry if its missing
-    let filelist= filelist+[netrw#fs#ComposePath(dirname,"../")]
-  endif
+    if g:netrw_cygwin == 0 && has("win32")
+    elseif index(filelist,'..') == -1 && dirname !~ '/'
+        " include ../ in the glob() entry if its missing
+        let filelist= filelist+[netrw#fs#ComposePath(dirname,"../")]
+    endif
 
-  if a:setmaxfilenamelen && get(g:, 'netrw_dynamic_maxfilenamelen', 0)
-    let filelistcopy           = map(deepcopy(filelist),'fnamemodify(v:val, ":t")')
-    let g:netrw_maxfilenamelen = max(map(filelistcopy,'len(v:val)')) + 1
-  endif
+    if a:setmaxfilenamelen && get(g:, 'netrw_dynamic_maxfilenamelen', 0)
+        let filelistcopy           = map(deepcopy(filelist),'fnamemodify(v:val, ":t")')
+        let g:netrw_maxfilenamelen = max(map(filelistcopy,'len(v:val)')) + 1
+    endif
 
-  let resultfilelist = []
-  for filename in filelist
+    let resultfilelist = []
+    for filename in filelist
 
-    if getftype(filename) == "link"
-      " indicate a symbolic link
-      let pfile= filename."@"
+        if getftype(filename) == "link"
+            " indicate a symbolic link
+            let pfile= filename."@"
 
-    elseif getftype(filename) == "socket"
-      " indicate a socket
-      let pfile= filename."="
+        elseif getftype(filename) == "socket"
+            " indicate a socket
+            let pfile= filename."="
 
-    elseif getftype(filename) == "fifo"
-      " indicate a fifo
-      let pfile= filename."|"
+        elseif getftype(filename) == "fifo"
+            " indicate a fifo
+            let pfile= filename."|"
 
-    elseif isdirectory(s:NetrwFile(filename))
-      " indicate a directory
-      let pfile= filename."/"
+        elseif isdirectory(s:NetrwFile(filename))
+            " indicate a directory
+            let pfile= filename."/"
 
-    elseif exists("b:netrw_curdir") && b:netrw_curdir !~ '^.*://' && !isdirectory(s:NetrwFile(filename))
-      if has("win32")
-        if filename =~ '\.[eE][xX][eE]$' || filename =~ '\.[cC][oO][mM]$' || filename =~ '\.[bB][aA][tT]$'
-          " indicate an executable
-          let pfile= filename."*"
+        elseif exists("b:netrw_curdir") && b:netrw_curdir !~ '^.*://' && !isdirectory(s:NetrwFile(filename))
+            if has("win32")
+                if filename =~ '\.[eE][xX][eE]$' || filename =~ '\.[cC][oO][mM]$' || filename =~ '\.[bB][aA][tT]$'
+                    " indicate an executable
+                    let pfile= filename."*"
+                else
+                    " normal file
+                    let pfile= filename
+                endif
+            elseif executable(filename)
+                " indicate an executable
+                let pfile= filename."*"
+            else
+                " normal file
+                let pfile= filename
+            endif
+
         else
-          " normal file
-          let pfile= filename
+            " normal file
+            let pfile= filename
         endif
-      elseif executable(filename)
-        " indicate an executable
-        let pfile= filename."*"
-      else
-        " normal file
-        let pfile= filename
-      endif
 
-    else
-      " normal file
-      let pfile= filename
-    endif
+        if pfile =~ '//$'
+            let pfile= substitute(pfile,'//$','/','e')
+        endif
+        let pfile= strpart(pfile,dirnamelen)
+        let pfile= substitute(pfile,'^[/\\]','','e')
 
-    if pfile =~ '//$'
-      let pfile= substitute(pfile,'//$','/','e')
-    endif
-    let pfile= strpart(pfile,dirnamelen)
-    let pfile= substitute(pfile,'^[/\\]','','e')
+        if w:netrw_liststyle == s:LONGLIST
+            let longfile = printf("%-".g:netrw_maxfilenamelen."S",pfile)
+            let sz       = getfsize(filename)
+            let szlen    = 15 - (strdisplaywidth(longfile) - g:netrw_maxfilenamelen)
+            let szlen    = (szlen > 0) ? szlen : 0
 
-    if w:netrw_liststyle == s:LONGLIST
-      let longfile = printf("%-".g:netrw_maxfilenamelen."S",pfile)
-      let sz       = getfsize(filename)
-      let szlen    = 15 - (strdisplaywidth(longfile) - g:netrw_maxfilenamelen)
-      let szlen    = (szlen > 0) ? szlen : 0
+            if g:netrw_sizestyle =~# "[hH]"
+                let sz= s:NetrwHumanReadable(sz)
+            endif
+            let fsz  = printf("%".szlen."S",sz)
+            let pfile= longfile."  ".fsz." ".strftime(g:netrw_timefmt,getftime(filename))
+        endif
 
-      if g:netrw_sizestyle =~# "[hH]"
-        let sz= s:NetrwHumanReadable(sz)
-      endif
-      let fsz  = printf("%".szlen."S",sz)
-      let pfile= longfile."  ".fsz." ".strftime(g:netrw_timefmt,getftime(filename))
-    endif
+        if     g:netrw_sort_by =~# "^t"
+            " sort by time (handles time up to 1 quintillion seconds, US)
+            " Decorate listing by prepending a timestamp/  .  Sorting will then be done based on time.
+            let t  = getftime(filename)
+            let ft = printf("%018d",t)
+            let ftpfile= ft.'/'.pfile
+            let resultfilelist += [ftpfile]
 
-    if     g:netrw_sort_by =~# "^t"
-      " sort by time (handles time up to 1 quintillion seconds, US)
-      " Decorate listing by prepending a timestamp/  .  Sorting will then be done based on time.
-      let t  = getftime(filename)
-      let ft = printf("%018d",t)
-      let ftpfile= ft.'/'.pfile
-      let resultfilelist += [ftpfile]
+        elseif g:netrw_sort_by =~ "^s"
+            " sort by size (handles file sizes up to 1 quintillion bytes, US)
+            let sz   = getfsize(filename)
+            let fsz  = printf("%018d",sz)
+            let fszpfile= fsz.'/'.pfile
+            let resultfilelist += [fszpfile]
 
-    elseif g:netrw_sort_by =~ "^s"
-      " sort by size (handles file sizes up to 1 quintillion bytes, US)
-      let sz   = getfsize(filename)
-      let fsz  = printf("%018d",sz)
-      let fszpfile= fsz.'/'.pfile
-      let resultfilelist += [fszpfile]
+        else
+            " sort by name
+            let resultfilelist += [pfile]
+        endif
+    endfor
 
-    else
-      " sort by name
-      let resultfilelist += [pfile]
-    endif
-  endfor
-
-  return resultfilelist
+    return resultfilelist
 endfun
 
 "  s:LocalListing: does the job of "ls" for local directories {{{2
 fun! s:LocalListing()
 
-  let filelist = s:NetrwLocalListingList(b:netrw_curdir, 1)
-  for filename in filelist
-    sil! NetrwKeepj put =filename
-  endfor
+    let filelist = s:NetrwLocalListingList(b:netrw_curdir, 1)
+    for filename in filelist
+        sil! NetrwKeepj put =filename
+    endfor
 
-  " cleanup any windows mess at end-of-line
-  sil! NetrwKeepj g/^$/d
-  sil! NetrwKeepj %s/\r$//e
-  call histdel("/",-1)
-  exe "setl ts=".(g:netrw_maxfilenamelen+1)
+    " cleanup any windows mess at end-of-line
+    sil! NetrwKeepj g/^$/d
+    sil! NetrwKeepj %s/\r$//e
+    call histdel("/",-1)
+    exe "setl ts=".(g:netrw_maxfilenamelen+1)
 endfun
 
 " s:NetrwLocalExecute: uses system() to execute command under cursor ("X" command support) {{{2
 fun! s:NetrwLocalExecute(cmd)
-  let ykeep= @@
-  " sanity check
-  if !executable(a:cmd)
-    call netrw#msg#Notify('ERROR', printf("the file<%s> is not executable!", a:cmd))
+    let ykeep= @@
+    " sanity check
+    if !executable(a:cmd)
+        call netrw#msg#Notify('ERROR', printf("the file<%s> is not executable!", a:cmd))
+        let @@= ykeep
+        return
+    endif
+
+    let optargs= input(":!".a:cmd,"","file")
+    let result= system(a:cmd.optargs)
+
+    " strip any ansi escape sequences off
+    let result = substitute(result,"\e\\[[0-9;]*m","","g")
+
+    " show user the result(s)
+    echomsg result
     let @@= ykeep
-    return
-  endif
-
-  let optargs= input(":!".a:cmd,"","file")
-  let result= system(a:cmd.optargs)
-
-  " strip any ansi escape sequences off
-  let result = substitute(result,"\e\\[[0-9;]*m","","g")
-
-  " show user the result(s)
-  echomsg result
-  let @@= ykeep
 
 endfun
 
 " s:NetrwLocalRename: rename a local file or directory {{{2
 fun! s:NetrwLocalRename(path) range
 
-  if !exists("w:netrw_bannercnt")
-    let w:netrw_bannercnt= b:netrw_bannercnt
-  endif
+    if !exists("w:netrw_bannercnt")
+        let w:netrw_bannercnt= b:netrw_bannercnt
+    endif
 
-  " preparation for removing multiple files/directories
-  let ykeep     = @@
-  let ctr       = a:firstline
-  let svpos     = winsaveview()
-  let all       = 0
+    " preparation for removing multiple files/directories
+    let ykeep     = @@
+    let ctr       = a:firstline
+    let svpos     = winsaveview()
+    let all       = 0
 
-  " rename files given by the markfilelist
-  if exists("s:netrwmarkfilelist_{bufnr('%')}")
-    for oldname in s:netrwmarkfilelist_{bufnr("%")}
-      if exists("subfrom")
-        let newname= substitute(oldname,subfrom,subto,'')
-      else
-        call inputsave()
-        let newname= input("Moving ".oldname." to : ",oldname,"file")
-        call inputrestore()
-        if newname =~ ''
-          " two ctrl-x's : ignore all of string preceding the ctrl-x's
-          let newname = substitute(newname,'^.*','','')
-        elseif newname =~ ''
-          " one ctrl-x : ignore portion of string preceding ctrl-x but after last /
-          let newname = substitute(newname,'[^/]*','','')
-        endif
-        if newname =~ '^s/'
-          let subfrom = substitute(newname,'^s/\([^/]*\)/.*/$','\1','')
-          let subto   = substitute(newname,'^s/[^/]*/\(.*\)/$','\1','')
-          let newname = substitute(oldname,subfrom,subto,'')
-        endif
-      endif
-      if !all && filereadable(newname)
-        call inputsave()
-        let response= input("File<".newname."> already exists; do you want to overwrite it? (y/all/n) ")
-        call inputrestore()
-        if response == "all"
-          let all= 1
-        elseif response != "y" && response != "yes"
-          " refresh the directory
-          NetrwKeepj call s:NetrwRefresh(1,s:NetrwBrowseChgDir(1,'./',0))
-          NetrwKeepj call winrestview(svpos)
-          let @@= ykeep
-          return
-        endif
-      endif
-      call rename(oldname,newname)
-    endfor
-    call s:NetrwUnmarkList(bufnr("%"),b:netrw_curdir)
+    " rename files given by the markfilelist
+    if exists("s:netrwmarkfilelist_{bufnr('%')}")
+        for oldname in s:netrwmarkfilelist_{bufnr("%")}
+            if exists("subfrom")
+                let newname= substitute(oldname,subfrom,subto,'')
+            else
+                call inputsave()
+                let newname= input("Moving ".oldname." to : ",oldname,"file")
+                call inputrestore()
+                if newname =~ ''
+                    " two ctrl-x's : ignore all of string preceding the ctrl-x's
+                    let newname = substitute(newname,'^.*','','')
+                elseif newname =~ ''
+                    " one ctrl-x : ignore portion of string preceding ctrl-x but after last /
+                    let newname = substitute(newname,'[^/]*','','')
+                endif
+                if newname =~ '^s/'
+                    let subfrom = substitute(newname,'^s/\([^/]*\)/.*/$','\1','')
+                    let subto   = substitute(newname,'^s/[^/]*/\(.*\)/$','\1','')
+                    let newname = substitute(oldname,subfrom,subto,'')
+                endif
+            endif
+            if !all && filereadable(newname)
+                call inputsave()
+                let response= input("File<".newname."> already exists; do you want to overwrite it? (y/all/n) ")
+                call inputrestore()
+                if response == "all"
+                    let all= 1
+                elseif response != "y" && response != "yes"
+                    " refresh the directory
+                    NetrwKeepj call s:NetrwRefresh(1,s:NetrwBrowseChgDir(1,'./',0))
+                    NetrwKeepj call winrestview(svpos)
+                    let @@= ykeep
+                    return
+                endif
+            endif
+            call rename(oldname,newname)
+        endfor
+        call s:NetrwUnmarkList(bufnr("%"),b:netrw_curdir)
 
-  else
+    else
 
-    " attempt to rename files/directories
-    while ctr <= a:lastline
-      exe "NetrwKeepj ".ctr
+        " attempt to rename files/directories
+        while ctr <= a:lastline
+            exe "NetrwKeepj ".ctr
 
-      " sanity checks
-      if line(".") < w:netrw_bannercnt
-        let ctr= ctr + 1
-        continue
-      endif
-      let curword= s:NetrwGetWord()
-      if curword == "./" || curword == "../"
-        let ctr= ctr + 1
-        continue
-      endif
+            " sanity checks
+            if line(".") < w:netrw_bannercnt
+                let ctr= ctr + 1
+                continue
+            endif
+            let curword= s:NetrwGetWord()
+            if curword == "./" || curword == "../"
+                let ctr= ctr + 1
+                continue
+            endif
 
-      NetrwKeepj norm! 0
-      let oldname= netrw#fs#ComposePath(a:path,curword)
+            NetrwKeepj norm! 0
+            let oldname= netrw#fs#ComposePath(a:path,curword)
 
-      call inputsave()
-      let newname= input("Moving ".oldname." to : ",substitute(oldname,'/*$','','e'))
-      call inputrestore()
+            call inputsave()
+            let newname= input("Moving ".oldname." to : ",substitute(oldname,'/*$','','e'))
+            call inputrestore()
 
-      call rename(oldname,newname)
-      let ctr= ctr + 1
-    endwhile
-  endif
+            call rename(oldname,newname)
+            let ctr= ctr + 1
+        endwhile
+    endif
 
-  " refresh the directory
-  NetrwKeepj call s:NetrwRefresh(1,s:NetrwBrowseChgDir(1,'./',0))
-  NetrwKeepj call winrestview(svpos)
-  let @@= ykeep
+    " refresh the directory
+    NetrwKeepj call s:NetrwRefresh(1,s:NetrwBrowseChgDir(1,'./',0))
+    NetrwKeepj call winrestview(svpos)
+    let @@= ykeep
 endfun
 
 " s:NetrwLocalRm: {{{2
@@ -9088,7 +9047,7 @@ endfunction
 
 " netrw#Call: allows user-specified mappings to call internal netrw functions {{{2
 fun! netrw#Call(funcname,...)
-  return call("s:".a:funcname,a:000)
+    return call("s:".a:funcname,a:000)
 endfun
 
 " netrw#Expose: allows UserMaps and pchk to look at otherwise script-local variables {{{2
@@ -9096,36 +9055,36 @@ endfun
 "                 :PChkAssert netrw#Expose("netrwmarkfilelist")
 "               for example.
 fun! netrw#Expose(varname)
-  if exists("s:".a:varname)
-    exe "let retval= s:".a:varname
-    if exists("g:netrw_pchk")
-      if type(retval) == 3
-        let retval = copy(retval)
-        let i      = 0
-        while i < len(retval)
-          let retval[i]= substitute(retval[i],expand("$HOME"),'~','')
-          let i        = i + 1
-        endwhile
-      endif
-      return string(retval)
+    if exists("s:".a:varname)
+        exe "let retval= s:".a:varname
+        if exists("g:netrw_pchk")
+            if type(retval) == 3
+                let retval = copy(retval)
+                let i      = 0
+                while i < len(retval)
+                    let retval[i]= substitute(retval[i],expand("$HOME"),'~','')
+                    let i        = i + 1
+                endwhile
+            endif
+            return string(retval)
+        else
+        endif
     else
+        let retval= "n/a"
     endif
-  else
-    let retval= "n/a"
-  endif
 
-  return retval
+    return retval
 endfun
 
 " netrw#Modify: allows UserMaps to set (modify) script-local variables {{{2
 fun! netrw#Modify(varname,newvalue)
-  exe "let s:".a:varname."= ".string(a:newvalue)
+    exe "let s:".a:varname."= ".string(a:newvalue)
 endfun
 
 "  netrw#RFC2396: converts %xx into characters {{{2
 fun! netrw#RFC2396(fname)
-  let fname = escape(substitute(a:fname,'%\(\x\x\)','\=printf("%c","0x".submatch(1))','ge')," \t")
-  return fname
+    let fname = escape(substitute(a:fname,'%\(\x\x\)','\=printf("%c","0x".submatch(1))','ge')," \t")
+    return fname
 endfun
 
 " netrw#UserMaps: supports user-specified maps {{{2
@@ -9147,17 +9106,17 @@ endfun
 "                   netrw#Call(funcname,...)       -- call internal netrw function with optional arguments
 fun! netrw#UserMaps(islocal)
 
-  " set up usermaplist
-  if exists("g:Netrw_UserMaps") && type(g:Netrw_UserMaps) == 3
-    for umap in g:Netrw_UserMaps
-      " if umap[0] is a string and umap[1] is a string holding a function name
-      if type(umap[0]) == 1 && type(umap[1]) == 1
-        exe "nno <buffer> <silent> ".umap[0]." :call <SID>UserMaps(".a:islocal.",'".umap[1]."')<cr>"
-      else
-        call netrw#msg#Notify('WARNING', printf('ignoring usermap <%s> -- not a [string,funcref] entry', string(umap[0])))
-      endif
-    endfor
-  endif
+    " set up usermaplist
+    if exists("g:Netrw_UserMaps") && type(g:Netrw_UserMaps) == 3
+        for umap in g:Netrw_UserMaps
+            " if umap[0] is a string and umap[1] is a string holding a function name
+            if type(umap[0]) == 1 && type(umap[1]) == 1
+                exe "nno <buffer> <silent> ".umap[0]." :call <SID>UserMaps(".a:islocal.",'".umap[1]."')<cr>"
+            else
+                call netrw#msg#Notify('WARNING', printf('ignoring usermap <%s> -- not a [string,funcref] entry', string(umap[0])))
+            endif
+        endfor
+    endif
 endfun
 
 " s:NetrwBadd: adds marked files to buffer list or vice versa {{{2
@@ -9165,59 +9124,59 @@ endfun
 "              cB : bl2mf=1  use bufferlist to mark files
 "              (mnemonic: cb = copy (marked files) to buffer list)
 fun! s:NetrwBadd(islocal,bl2mf)
-  if a:bl2mf
-    " cB: add buffer list to marked files
-    redir => bufl
-    ls
-    redir END
-    let bufl = map(split(bufl,"\n"),'substitute(v:val,''^.\{-}"\(.*\)".\{-}$'',''\1'','''')')
-    for fname in bufl
-      call s:NetrwMarkFile(a:islocal,fname)
-    endfor
-  else
-    " cb: add marked files to buffer list
-    for fname in s:netrwmarkfilelist_{bufnr("%")}
-      exe "badd ".fnameescape(fname)
-    endfor
-    let curbufnr = bufnr("%")
-    let curdir   = s:NetrwGetCurdir(a:islocal)
-    call s:NetrwUnmarkList(curbufnr,curdir)                   " remove markings from local buffer
-  endif
+    if a:bl2mf
+        " cB: add buffer list to marked files
+        redir => bufl
+        ls
+        redir END
+        let bufl = map(split(bufl,"\n"),'substitute(v:val,''^.\{-}"\(.*\)".\{-}$'',''\1'','''')')
+        for fname in bufl
+            call s:NetrwMarkFile(a:islocal,fname)
+        endfor
+    else
+        " cb: add marked files to buffer list
+        for fname in s:netrwmarkfilelist_{bufnr("%")}
+            exe "badd ".fnameescape(fname)
+        endfor
+        let curbufnr = bufnr("%")
+        let curdir   = s:NetrwGetCurdir(a:islocal)
+        call s:NetrwUnmarkList(curbufnr,curdir)                   " remove markings from local buffer
+    endif
 endfun
 
 " s:DeleteBookmark: deletes a file/directory from Netrw's bookmark system {{{2
 "   Related Functions: s:MakeBookmark() s:NetrwBookHistHandler() s:NetrwBookmark()
 fun! s:DeleteBookmark(fname)
-  call s:MergeBookmarks()
+    call s:MergeBookmarks()
 
-  if exists("g:netrw_bookmarklist")
-    let indx= index(g:netrw_bookmarklist,a:fname)
-    if indx == -1
-      let indx= 0
-      while indx < len(g:netrw_bookmarklist)
-        if g:netrw_bookmarklist[indx] =~ a:fname
-          call remove(g:netrw_bookmarklist,indx)
-          let indx= indx - 1
+    if exists("g:netrw_bookmarklist")
+        let indx= index(g:netrw_bookmarklist,a:fname)
+        if indx == -1
+            let indx= 0
+            while indx < len(g:netrw_bookmarklist)
+                if g:netrw_bookmarklist[indx] =~ a:fname
+                    call remove(g:netrw_bookmarklist,indx)
+                    let indx= indx - 1
+                endif
+                let indx= indx + 1
+            endwhile
+        else
+            " remove exact match
+            call remove(g:netrw_bookmarklist,indx)
         endif
-        let indx= indx + 1
-      endwhile
-    else
-      " remove exact match
-      call remove(g:netrw_bookmarklist,indx)
     endif
-  endif
 
 endfun
 
 " s:FileReadable: o/s independent filereadable {{{2
 fun! s:FileReadable(fname)
-  if g:netrw_cygwin
-    let ret = filereadable(s:NetrwFile(substitute(a:fname,g:netrw_cygdrive.'/\(.\)','\1:/','')))
-  else
-    let ret = filereadable(s:NetrwFile(a:fname))
-  endif
+    if g:netrw_cygwin
+        let ret = filereadable(s:NetrwFile(substitute(a:fname,g:netrw_cygdrive.'/\(.\)','\1:/','')))
+    else
+        let ret = filereadable(s:NetrwFile(a:fname))
+    endif
 
-  return ret
+    return ret
 endfun
 
 "  s:GetTempfile: gets a tempname that'll work for various o/s's {{{2
@@ -9225,302 +9184,302 @@ endfun
 "                 using the suffix provided with fname
 fun! s:GetTempfile(fname)
 
-  if !exists("b:netrw_tmpfile")
-    " get a brand new temporary filename
-    let tmpfile= tempname()
+    if !exists("b:netrw_tmpfile")
+        " get a brand new temporary filename
+        let tmpfile= tempname()
 
-    let tmpfile= substitute(tmpfile,'\','/','ge')
+        let tmpfile= substitute(tmpfile,'\','/','ge')
 
-    " sanity check -- does the temporary file's directory exist?
-    if !isdirectory(s:NetrwFile(substitute(tmpfile,'[^/]\+$','','e')))
-      call netrw#msg#Notify('ERROR', printf('your <%s> directory is missing!', substitute(tmpfile,'[^/]\+$','','e')))
-      return ""
-    endif
+        " sanity check -- does the temporary file's directory exist?
+        if !isdirectory(s:NetrwFile(substitute(tmpfile,'[^/]\+$','','e')))
+            call netrw#msg#Notify('ERROR', printf('your <%s> directory is missing!', substitute(tmpfile,'[^/]\+$','','e')))
+            return ""
+        endif
 
-    " let netrw#NetSource() know about the tmpfile
-    let s:netrw_tmpfile= tmpfile " used by netrw#NetSource() and netrw#BrowseX()
+        " let netrw#NetSource() know about the tmpfile
+        let s:netrw_tmpfile= tmpfile " used by netrw#NetSource() and netrw#BrowseX()
 
-    " o/s dependencies
-    if g:netrw_cygwin != 0
-      let tmpfile = substitute(tmpfile,'^\(\a\):',g:netrw_cygdrive.'/\1','e')
-    elseif has("win32")
-      if !exists("+shellslash") || !&ssl
-        let tmpfile = substitute(tmpfile,'/','\','g')
-      endif
+        " o/s dependencies
+        if g:netrw_cygwin != 0
+            let tmpfile = substitute(tmpfile,'^\(\a\):',g:netrw_cygdrive.'/\1','e')
+        elseif has("win32")
+            if !exists("+shellslash") || !&ssl
+                let tmpfile = substitute(tmpfile,'/','\','g')
+            endif
+        else
+            let tmpfile = tmpfile
+        endif
+        let b:netrw_tmpfile= tmpfile
     else
-      let tmpfile = tmpfile
+        " re-use temporary filename
+        let tmpfile= b:netrw_tmpfile
     endif
-    let b:netrw_tmpfile= tmpfile
-  else
-    " re-use temporary filename
-    let tmpfile= b:netrw_tmpfile
-  endif
 
-  " use fname's suffix for the temporary file
-  if a:fname != ""
-    if a:fname =~ '\.[^./]\+$'
-      if a:fname =~ '\.tar\.gz$' || a:fname =~ '\.tar\.bz2$' || a:fname =~ '\.tar\.xz$'
-        let suffix = ".tar".substitute(a:fname,'^.*\(\.[^./]\+\)$','\1','e')
-      elseif a:fname =~ '.txz$'
-        let suffix = ".txz".substitute(a:fname,'^.*\(\.[^./]\+\)$','\1','e')
-      else
-        let suffix = substitute(a:fname,'^.*\(\.[^./]\+\)$','\1','e')
-      endif
-      let tmpfile= substitute(tmpfile,'\.tmp$','','e')
-      let tmpfile .= suffix
-      let s:netrw_tmpfile= tmpfile " supports netrw#NetSource()
+    " use fname's suffix for the temporary file
+    if a:fname != ""
+        if a:fname =~ '\.[^./]\+$'
+            if a:fname =~ '\.tar\.gz$' || a:fname =~ '\.tar\.bz2$' || a:fname =~ '\.tar\.xz$'
+                let suffix = ".tar".substitute(a:fname,'^.*\(\.[^./]\+\)$','\1','e')
+            elseif a:fname =~ '.txz$'
+                let suffix = ".txz".substitute(a:fname,'^.*\(\.[^./]\+\)$','\1','e')
+            else
+                let suffix = substitute(a:fname,'^.*\(\.[^./]\+\)$','\1','e')
+            endif
+            let tmpfile= substitute(tmpfile,'\.tmp$','','e')
+            let tmpfile .= suffix
+            let s:netrw_tmpfile= tmpfile " supports netrw#NetSource()
+        endif
     endif
-  endif
 
-  return tmpfile
+    return tmpfile
 endfun
 
 " s:MakeSshCmd: transforms input command using USEPORT HOSTNAME into {{{2
 "               a correct command for use with a system() call
 fun! s:MakeSshCmd(sshcmd)
-  if s:user == ""
-    let sshcmd = substitute(a:sshcmd,'\<HOSTNAME\>',s:machine,'')
-  else
-    let sshcmd = substitute(a:sshcmd,'\<HOSTNAME\>',s:user."@".s:machine,'')
-  endif
-  if exists("g:netrw_port") && g:netrw_port != ""
-    let sshcmd= substitute(sshcmd,"USEPORT",g:netrw_sshport.' '.g:netrw_port,'')
-  elseif exists("s:port") && s:port != ""
-    let sshcmd= substitute(sshcmd,"USEPORT",g:netrw_sshport.' '.s:port,'')
-  else
-    let sshcmd= substitute(sshcmd,"USEPORT ",'','')
-  endif
-  return sshcmd
+    if s:user == ""
+        let sshcmd = substitute(a:sshcmd,'\<HOSTNAME\>',s:machine,'')
+    else
+        let sshcmd = substitute(a:sshcmd,'\<HOSTNAME\>',s:user."@".s:machine,'')
+    endif
+    if exists("g:netrw_port") && g:netrw_port != ""
+        let sshcmd= substitute(sshcmd,"USEPORT",g:netrw_sshport.' '.g:netrw_port,'')
+    elseif exists("s:port") && s:port != ""
+        let sshcmd= substitute(sshcmd,"USEPORT",g:netrw_sshport.' '.s:port,'')
+    else
+        let sshcmd= substitute(sshcmd,"USEPORT ",'','')
+    endif
+    return sshcmd
 endfun
 
 " s:MakeBookmark: enters a bookmark into Netrw's bookmark system   {{{2
 fun! s:MakeBookmark(fname)
 
-  if !exists("g:netrw_bookmarklist")
-    let g:netrw_bookmarklist= []
-  endif
-
-  if index(g:netrw_bookmarklist,a:fname) == -1
-    " curdir not currently in g:netrw_bookmarklist, so include it
-    if isdirectory(s:NetrwFile(a:fname)) && a:fname !~ '/$'
-      call add(g:netrw_bookmarklist,a:fname.'/')
-    elseif a:fname !~ '/'
-      call add(g:netrw_bookmarklist,getcwd()."/".a:fname)
-    else
-      call add(g:netrw_bookmarklist,a:fname)
+    if !exists("g:netrw_bookmarklist")
+        let g:netrw_bookmarklist= []
     endif
-    call sort(g:netrw_bookmarklist)
-  endif
+
+    if index(g:netrw_bookmarklist,a:fname) == -1
+        " curdir not currently in g:netrw_bookmarklist, so include it
+        if isdirectory(s:NetrwFile(a:fname)) && a:fname !~ '/$'
+            call add(g:netrw_bookmarklist,a:fname.'/')
+        elseif a:fname !~ '/'
+            call add(g:netrw_bookmarklist,getcwd()."/".a:fname)
+        else
+            call add(g:netrw_bookmarklist,a:fname)
+        endif
+        call sort(g:netrw_bookmarklist)
+    endif
 
 endfun
 
 " s:MergeBookmarks: merge current bookmarks with saved bookmarks {{{2
 fun! s:MergeBookmarks()
-  " get bookmarks from .netrwbook file
-  let savefile= s:NetrwHome()."/.netrwbook"
-  if filereadable(s:NetrwFile(savefile))
-    NetrwKeepj call s:NetrwBookHistSave()
-    NetrwKeepj call delete(savefile)
-  endif
+    " get bookmarks from .netrwbook file
+    let savefile= s:NetrwHome()."/.netrwbook"
+    if filereadable(s:NetrwFile(savefile))
+        NetrwKeepj call s:NetrwBookHistSave()
+        NetrwKeepj call delete(savefile)
+    endif
 endfun
 
 " s:NetrwBMShow: {{{2
 fun! s:NetrwBMShow()
-  redir => bmshowraw
-  menu
-  redir END
-  let bmshowlist = split(bmshowraw,'\n')
-  if bmshowlist != []
-    let bmshowfuncs= filter(bmshowlist,'v:val =~# "<SNR>\\d\\+_BMShow()"')
-    if bmshowfuncs != []
-      let bmshowfunc = substitute(bmshowfuncs[0],'^.*:\(call.*BMShow()\).*$','\1','')
-      if bmshowfunc =~# '^call.*BMShow()'
-        exe "sil! NetrwKeepj ".bmshowfunc
-      endif
+    redir => bmshowraw
+    menu
+    redir END
+    let bmshowlist = split(bmshowraw,'\n')
+    if bmshowlist != []
+        let bmshowfuncs= filter(bmshowlist,'v:val =~# "<SNR>\\d\\+_BMShow()"')
+        if bmshowfuncs != []
+            let bmshowfunc = substitute(bmshowfuncs[0],'^.*:\(call.*BMShow()\).*$','\1','')
+            if bmshowfunc =~# '^call.*BMShow()'
+                exe "sil! NetrwKeepj ".bmshowfunc
+            endif
+        endif
     endif
-  endif
 endfun
 
 " s:NetrwCursor: responsible for setting cursorline/cursorcolumn based upon g:netrw_cursor {{{2
 fun! s:NetrwCursor(editfile)
-  if !exists("w:netrw_liststyle")
-    let w:netrw_liststyle= g:netrw_liststyle
-  endif
+    if !exists("w:netrw_liststyle")
+        let w:netrw_liststyle= g:netrw_liststyle
+    endif
 
 
-  if &ft != "netrw"
-  " if the current window isn't a netrw directory listing window, then use user cursorline/column
-  " settings.  Affects when netrw is used to read/write a file using scp/ftp/etc.
+    if &ft != "netrw"
+    " if the current window isn't a netrw directory listing window, then use user cursorline/column
+    " settings.  Affects when netrw is used to read/write a file using scp/ftp/etc.
 
-  elseif g:netrw_cursor == 8
-    if w:netrw_liststyle == s:WIDELIST
-      setl cursorline
-      setl cursorcolumn
+    elseif g:netrw_cursor == 8
+        if w:netrw_liststyle == s:WIDELIST
+            setl cursorline
+            setl cursorcolumn
+        else
+            setl cursorline
+        endif
+    elseif g:netrw_cursor == 7
+        setl cursorline
+    elseif g:netrw_cursor == 6
+        if w:netrw_liststyle == s:WIDELIST
+            setl cursorline
+        endif
+    elseif g:netrw_cursor == 4
+        " all styles: cursorline, cursorcolumn
+        setl cursorline
+        setl cursorcolumn
+
+    elseif g:netrw_cursor == 3
+        " thin-long-tree: cursorline, user's cursorcolumn
+        " wide          : cursorline, cursorcolumn
+        if w:netrw_liststyle == s:WIDELIST
+            setl cursorline
+            setl cursorcolumn
+        else
+            setl cursorline
+        endif
+
+    elseif g:netrw_cursor == 2
+        " thin-long-tree: cursorline, user's cursorcolumn
+        " wide          : cursorline, user's cursorcolumn
+        setl cursorline
+
+    elseif g:netrw_cursor == 1
+        " thin-long-tree: user's cursorline, user's cursorcolumn
+        " wide          : cursorline,        user's cursorcolumn
+        if w:netrw_liststyle == s:WIDELIST
+            setl cursorline
+        else
+        endif
+
     else
-      setl cursorline
+        " all styles: user's cursorline, user's cursorcolumn
+        let &l:cursorline   = s:netrw_usercul
+        let &l:cursorcolumn = s:netrw_usercuc
     endif
-  elseif g:netrw_cursor == 7
-    setl cursorline
-  elseif g:netrw_cursor == 6
-    if w:netrw_liststyle == s:WIDELIST
-      setl cursorline
-    endif
-  elseif g:netrw_cursor == 4
-    " all styles: cursorline, cursorcolumn
-    setl cursorline
-    setl cursorcolumn
-
-  elseif g:netrw_cursor == 3
-    " thin-long-tree: cursorline, user's cursorcolumn
-    " wide          : cursorline, cursorcolumn
-    if w:netrw_liststyle == s:WIDELIST
-      setl cursorline
-      setl cursorcolumn
-    else
-      setl cursorline
-    endif
-
-  elseif g:netrw_cursor == 2
-    " thin-long-tree: cursorline, user's cursorcolumn
-    " wide          : cursorline, user's cursorcolumn
-    setl cursorline
-
-  elseif g:netrw_cursor == 1
-    " thin-long-tree: user's cursorline, user's cursorcolumn
-    " wide          : cursorline,        user's cursorcolumn
-    if w:netrw_liststyle == s:WIDELIST
-      setl cursorline
-    else
-    endif
-
-  else
-    " all styles: user's cursorline, user's cursorcolumn
-    let &l:cursorline   = s:netrw_usercul
-    let &l:cursorcolumn = s:netrw_usercuc
-  endif
 
 endfun
 
 " s:RestoreCursorline: restores cursorline/cursorcolumn to original user settings {{{2
 fun! s:RestoreCursorline()
-  if exists("s:netrw_usercul")
-    let &l:cursorline   = s:netrw_usercul
-  endif
-  if exists("s:netrw_usercuc")
-    let &l:cursorcolumn = s:netrw_usercuc
-  endif
+    if exists("s:netrw_usercul")
+        let &l:cursorline   = s:netrw_usercul
+    endif
+    if exists("s:netrw_usercuc")
+        let &l:cursorcolumn = s:netrw_usercuc
+    endif
 endfun
 
 " s:RestoreRegister: restores all registers given in the dict {{{2
 fun! s:RestoreRegister(dict)
-  for [key, val] in items(a:dict)
-    if key == 'unnamed'
-      let key = ''
-    endif
-    call setreg(key, val[0], val[1])
-  endfor
+    for [key, val] in items(a:dict)
+        if key == 'unnamed'
+            let key = ''
+        endif
+        call setreg(key, val[0], val[1])
+    endfor
 endfun
 
 " s:NetrwEnew: opens a new buffer, passes netrw buffer variables through {{{2
 fun! s:NetrwEnew(...)
 
-  " Clean out the last buffer:
-  " Check if the last buffer has # > 1, is unlisted, is unnamed, and does not appear in a window
-  " If so, delete it.
-  let bufid = bufnr('$')
-  if bufid > 1 && !buflisted(bufid) && bufloaded(bufid) && bufname(bufid) == "" && bufwinid(bufid) == -1
-    execute printf("silent! bdelete! %s", bufid)
-  endif
-
-  " grab a function-local-variable copy of buffer variables
-  if exists("b:netrw_bannercnt")      |let netrw_bannercnt       = b:netrw_bannercnt      |endif
-  if exists("b:netrw_browser_active") |let netrw_browser_active  = b:netrw_browser_active |endif
-  if exists("b:netrw_cpf")            |let netrw_cpf             = b:netrw_cpf            |endif
-  if exists("b:netrw_curdir")         |let netrw_curdir          = b:netrw_curdir         |endif
-  if exists("b:netrw_explore_bufnr")  |let netrw_explore_bufnr   = b:netrw_explore_bufnr  |endif
-  if exists("b:netrw_explore_indx")   |let netrw_explore_indx    = b:netrw_explore_indx   |endif
-  if exists("b:netrw_explore_line")   |let netrw_explore_line    = b:netrw_explore_line   |endif
-  if exists("b:netrw_explore_list")   |let netrw_explore_list    = b:netrw_explore_list   |endif
-  if exists("b:netrw_explore_listlen")|let netrw_explore_listlen = b:netrw_explore_listlen|endif
-  if exists("b:netrw_explore_mtchcnt")|let netrw_explore_mtchcnt = b:netrw_explore_mtchcnt|endif
-  if exists("b:netrw_fname")          |let netrw_fname           = b:netrw_fname          |endif
-  if exists("b:netrw_lastfile")       |let netrw_lastfile        = b:netrw_lastfile       |endif
-  if exists("b:netrw_liststyle")      |let netrw_liststyle       = b:netrw_liststyle      |endif
-  if exists("b:netrw_method")         |let netrw_method          = b:netrw_method         |endif
-  if exists("b:netrw_option")         |let netrw_option          = b:netrw_option         |endif
-  if exists("b:netrw_prvdir")         |let netrw_prvdir          = b:netrw_prvdir         |endif
-
-  NetrwKeepj call s:NetrwOptionsRestore("w:")
-  " when tree listing uses file TreeListing... a new buffer is made.
-  " Want the old buffer to be unlisted.
-  " COMBAK: this causes a problem, see P43
-  "  setl nobl
-  let netrw_keepdiff= &l:diff
-  call s:NetrwEditFile("enew!","","")
-  let &l:diff= netrw_keepdiff
-  NetrwKeepj call s:NetrwOptionsSave("w:")
-
-  " copy function-local-variables to buffer variable equivalents
-  if exists("netrw_bannercnt")      |let b:netrw_bannercnt       = netrw_bannercnt      |endif
-  if exists("netrw_browser_active") |let b:netrw_browser_active  = netrw_browser_active |endif
-  if exists("netrw_cpf")            |let b:netrw_cpf             = netrw_cpf            |endif
-  if exists("netrw_curdir")         |let b:netrw_curdir          = netrw_curdir         |endif
-  if exists("netrw_explore_bufnr")  |let b:netrw_explore_bufnr   = netrw_explore_bufnr  |endif
-  if exists("netrw_explore_indx")   |let b:netrw_explore_indx    = netrw_explore_indx   |endif
-  if exists("netrw_explore_line")   |let b:netrw_explore_line    = netrw_explore_line   |endif
-  if exists("netrw_explore_list")   |let b:netrw_explore_list    = netrw_explore_list   |endif
-  if exists("netrw_explore_listlen")|let b:netrw_explore_listlen = netrw_explore_listlen|endif
-  if exists("netrw_explore_mtchcnt")|let b:netrw_explore_mtchcnt = netrw_explore_mtchcnt|endif
-  if exists("netrw_fname")          |let b:netrw_fname           = netrw_fname          |endif
-  if exists("netrw_lastfile")       |let b:netrw_lastfile        = netrw_lastfile       |endif
-  if exists("netrw_liststyle")      |let b:netrw_liststyle       = netrw_liststyle      |endif
-  if exists("netrw_method")         |let b:netrw_method          = netrw_method         |endif
-  if exists("netrw_option")         |let b:netrw_option          = netrw_option         |endif
-  if exists("netrw_prvdir")         |let b:netrw_prvdir          = netrw_prvdir         |endif
-
-  if a:0 > 0
-    let b:netrw_curdir= a:1
-    if b:netrw_curdir =~ '/$'
-      if exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST
-        setl nobl
-        file NetrwTreeListing
-        setl nobl bt=nowrite bh=hide
-        nno <silent> <buffer> [    :sil call <SID>TreeListMove('[')<cr>
-        nno <silent> <buffer> ]    :sil call <SID>TreeListMove(']')<cr>
-      else
-        call s:NetrwBufRename(b:netrw_curdir)
-      endif
+    " Clean out the last buffer:
+    " Check if the last buffer has # > 1, is unlisted, is unnamed, and does not appear in a window
+    " If so, delete it.
+    let bufid = bufnr('$')
+    if bufid > 1 && !buflisted(bufid) && bufloaded(bufid) && bufname(bufid) == "" && bufwinid(bufid) == -1
+        execute printf("silent! bdelete! %s", bufid)
     endif
-  endif
 
-  if s:has_balloon
-    let &l:bexpr = "netrw#BalloonHelp()"
-  endif
+    " grab a function-local-variable copy of buffer variables
+    if exists("b:netrw_bannercnt")      |let netrw_bannercnt       = b:netrw_bannercnt      |endif
+    if exists("b:netrw_browser_active") |let netrw_browser_active  = b:netrw_browser_active |endif
+    if exists("b:netrw_cpf")            |let netrw_cpf             = b:netrw_cpf            |endif
+    if exists("b:netrw_curdir")         |let netrw_curdir          = b:netrw_curdir         |endif
+    if exists("b:netrw_explore_bufnr")  |let netrw_explore_bufnr   = b:netrw_explore_bufnr  |endif
+    if exists("b:netrw_explore_indx")   |let netrw_explore_indx    = b:netrw_explore_indx   |endif
+    if exists("b:netrw_explore_line")   |let netrw_explore_line    = b:netrw_explore_line   |endif
+    if exists("b:netrw_explore_list")   |let netrw_explore_list    = b:netrw_explore_list   |endif
+    if exists("b:netrw_explore_listlen")|let netrw_explore_listlen = b:netrw_explore_listlen|endif
+    if exists("b:netrw_explore_mtchcnt")|let netrw_explore_mtchcnt = b:netrw_explore_mtchcnt|endif
+    if exists("b:netrw_fname")          |let netrw_fname           = b:netrw_fname          |endif
+    if exists("b:netrw_lastfile")       |let netrw_lastfile        = b:netrw_lastfile       |endif
+    if exists("b:netrw_liststyle")      |let netrw_liststyle       = b:netrw_liststyle      |endif
+    if exists("b:netrw_method")         |let netrw_method          = b:netrw_method         |endif
+    if exists("b:netrw_option")         |let netrw_option          = b:netrw_option         |endif
+    if exists("b:netrw_prvdir")         |let netrw_prvdir          = b:netrw_prvdir         |endif
+
+    NetrwKeepj call s:NetrwOptionsRestore("w:")
+    " when tree listing uses file TreeListing... a new buffer is made.
+    " Want the old buffer to be unlisted.
+    " COMBAK: this causes a problem, see P43
+    "  setl nobl
+    let netrw_keepdiff= &l:diff
+    call s:NetrwEditFile("enew!","","")
+    let &l:diff= netrw_keepdiff
+    NetrwKeepj call s:NetrwOptionsSave("w:")
+
+    " copy function-local-variables to buffer variable equivalents
+    if exists("netrw_bannercnt")      |let b:netrw_bannercnt       = netrw_bannercnt      |endif
+    if exists("netrw_browser_active") |let b:netrw_browser_active  = netrw_browser_active |endif
+    if exists("netrw_cpf")            |let b:netrw_cpf             = netrw_cpf            |endif
+    if exists("netrw_curdir")         |let b:netrw_curdir          = netrw_curdir         |endif
+    if exists("netrw_explore_bufnr")  |let b:netrw_explore_bufnr   = netrw_explore_bufnr  |endif
+    if exists("netrw_explore_indx")   |let b:netrw_explore_indx    = netrw_explore_indx   |endif
+    if exists("netrw_explore_line")   |let b:netrw_explore_line    = netrw_explore_line   |endif
+    if exists("netrw_explore_list")   |let b:netrw_explore_list    = netrw_explore_list   |endif
+    if exists("netrw_explore_listlen")|let b:netrw_explore_listlen = netrw_explore_listlen|endif
+    if exists("netrw_explore_mtchcnt")|let b:netrw_explore_mtchcnt = netrw_explore_mtchcnt|endif
+    if exists("netrw_fname")          |let b:netrw_fname           = netrw_fname          |endif
+    if exists("netrw_lastfile")       |let b:netrw_lastfile        = netrw_lastfile       |endif
+    if exists("netrw_liststyle")      |let b:netrw_liststyle       = netrw_liststyle      |endif
+    if exists("netrw_method")         |let b:netrw_method          = netrw_method         |endif
+    if exists("netrw_option")         |let b:netrw_option          = netrw_option         |endif
+    if exists("netrw_prvdir")         |let b:netrw_prvdir          = netrw_prvdir         |endif
+
+    if a:0 > 0
+        let b:netrw_curdir= a:1
+        if b:netrw_curdir =~ '/$'
+            if exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST
+                setl nobl
+                file NetrwTreeListing
+                setl nobl bt=nowrite bh=hide
+                nno <silent> <buffer> [    :sil call <SID>TreeListMove('[')<cr>
+                nno <silent> <buffer> ]    :sil call <SID>TreeListMove(']')<cr>
+            else
+                call s:NetrwBufRename(b:netrw_curdir)
+            endif
+        endif
+    endif
+
+    if s:has_balloon
+        let &l:bexpr = "netrw#BalloonHelp()"
+    endif
 
 endfun
 
 " s:NetrwInsureWinVars: insure that a netrw buffer has its w: variables in spite of a wincmd v or s {{{2
 fun! s:NetrwInsureWinVars()
-  if !exists("w:netrw_liststyle")
-    let curbuf = bufnr("%")
-    let curwin = winnr()
-    let iwin   = 1
-    while iwin <= winnr("$")
-      exe iwin."wincmd w"
-      if winnr() != curwin && bufnr("%") == curbuf && exists("w:netrw_liststyle")
-        " looks like ctrl-w_s or ctrl-w_v was used to split a netrw buffer
-        let winvars= w:
-        break
-      endif
-      let iwin= iwin + 1
-    endwhile
-    exe "keepalt ".curwin."wincmd w"
-    if exists("winvars")
-      for k in keys(winvars)
-        let w:{k}= winvars[k]
-      endfor
+    if !exists("w:netrw_liststyle")
+        let curbuf = bufnr("%")
+        let curwin = winnr()
+        let iwin   = 1
+        while iwin <= winnr("$")
+            exe iwin."wincmd w"
+            if winnr() != curwin && bufnr("%") == curbuf && exists("w:netrw_liststyle")
+                " looks like ctrl-w_s or ctrl-w_v was used to split a netrw buffer
+                let winvars= w:
+                break
+            endif
+            let iwin= iwin + 1
+        endwhile
+        exe "keepalt ".curwin."wincmd w"
+        if exists("winvars")
+            for k in keys(winvars)
+                let w:{k}= winvars[k]
+            endfor
+        endif
     endif
-  endif
 endfun
 
 " s:NetrwLcd: handles changing the (local) directory {{{2
@@ -9528,121 +9487,121 @@ endfun
 "           -1=failed
 fun! s:NetrwLcd(newdir)
 
-  let err472= 0
-  try
-    exe 'NetrwKeepj sil lcd '.fnameescape(a:newdir)
-  catch /^Vim\%((\a\+)\)\=:E344/
-    " Vim's lcd fails with E344 when attempting to go above the 'root' of a Windows share.
-    " Therefore, detect if a Windows share is present, and if E344 occurs, just settle at
-    " 'root' (ie. '\').  The share name may start with either backslashes ('\\Foo') or
-    " forward slashes ('//Foo'), depending on whether backslashes have been converted to
-    " forward slashes by earlier code; so check for both.
-    if has("win32") && !g:netrw_cygwin
-      if a:newdir =~ '^\\\\\w\+' || a:newdir =~ '^//\w\+'
-        let dirname = '\'
-        exe 'NetrwKeepj sil lcd '.fnameescape(dirname)
-      endif
-    endif
-  catch /^Vim\%((\a\+)\)\=:E472/
-    let err472= 1
-  endtry
+    let err472= 0
+    try
+        exe 'NetrwKeepj sil lcd '.fnameescape(a:newdir)
+    catch /^Vim\%((\a\+)\)\=:E344/
+        " Vim's lcd fails with E344 when attempting to go above the 'root' of a Windows share.
+        " Therefore, detect if a Windows share is present, and if E344 occurs, just settle at
+        " 'root' (ie. '\').  The share name may start with either backslashes ('\\Foo') or
+        " forward slashes ('//Foo'), depending on whether backslashes have been converted to
+        " forward slashes by earlier code; so check for both.
+        if has("win32") && !g:netrw_cygwin
+            if a:newdir =~ '^\\\\\w\+' || a:newdir =~ '^//\w\+'
+                let dirname = '\'
+                exe 'NetrwKeepj sil lcd '.fnameescape(dirname)
+            endif
+        endif
+    catch /^Vim\%((\a\+)\)\=:E472/
+        let err472= 1
+    endtry
 
-  if err472
-    call netrw#msg#Notify('ERROR', printf('unable to change directory to <%s> (permissions?)', a:newdir))
-    if exists("w:netrw_prvdir")
-      let a:newdir= w:netrw_prvdir
-    else
-      call s:NetrwOptionsRestore("w:")
-      exe "setl ".g:netrw_bufsettings
-      let a:newdir= dirname
+    if err472
+        call netrw#msg#Notify('ERROR', printf('unable to change directory to <%s> (permissions?)', a:newdir))
+        if exists("w:netrw_prvdir")
+            let a:newdir= w:netrw_prvdir
+        else
+            call s:NetrwOptionsRestore("w:")
+            exe "setl ".g:netrw_bufsettings
+            let a:newdir= dirname
+        endif
+        return -1
     endif
-    return -1
-  endif
 
-  return 0
+    return 0
 endfun
 
 " s:NetrwSaveWordPosn: used to keep cursor on same word after refresh, {{{2
 " changed sorting, etc.  Also see s:NetrwRestoreWordPosn().
 fun! s:NetrwSaveWordPosn()
-  let s:netrw_saveword= '^'.fnameescape(getline('.')).'$'
+    let s:netrw_saveword= '^'.fnameescape(getline('.')).'$'
 endfun
 
 " s:NetrwHumanReadable: takes a number and makes it "human readable" {{{2
 "                       1000 -> 1K, 1000000 -> 1M, 1000000000 -> 1G
 fun! s:NetrwHumanReadable(sz)
 
-  if g:netrw_sizestyle == 'h'
-    if a:sz >= 1000000000
-      let sz = printf("%.1f",a:sz/1000000000.0)."g"
-    elseif a:sz >= 10000000
-      let sz = printf("%d",a:sz/1000000)."m"
-    elseif a:sz >= 1000000
-      let sz = printf("%.1f",a:sz/1000000.0)."m"
-    elseif a:sz >= 10000
-      let sz = printf("%d",a:sz/1000)."k"
-    elseif a:sz >= 1000
-      let sz = printf("%.1f",a:sz/1000.0)."k"
+    if g:netrw_sizestyle == 'h'
+        if a:sz >= 1000000000
+            let sz = printf("%.1f",a:sz/1000000000.0)."g"
+        elseif a:sz >= 10000000
+            let sz = printf("%d",a:sz/1000000)."m"
+        elseif a:sz >= 1000000
+            let sz = printf("%.1f",a:sz/1000000.0)."m"
+        elseif a:sz >= 10000
+            let sz = printf("%d",a:sz/1000)."k"
+        elseif a:sz >= 1000
+            let sz = printf("%.1f",a:sz/1000.0)."k"
+        else
+            let sz= a:sz
+        endif
+
+    elseif g:netrw_sizestyle == 'H'
+        if a:sz >= 1073741824
+            let sz = printf("%.1f",a:sz/1073741824.0)."G"
+        elseif a:sz >= 10485760
+            let sz = printf("%d",a:sz/1048576)."M"
+        elseif a:sz >= 1048576
+            let sz = printf("%.1f",a:sz/1048576.0)."M"
+        elseif a:sz >= 10240
+            let sz = printf("%d",a:sz/1024)."K"
+        elseif a:sz >= 1024
+            let sz = printf("%.1f",a:sz/1024.0)."K"
+        else
+            let sz= a:sz
+        endif
+
     else
-      let sz= a:sz
+        let sz= a:sz
     endif
 
-  elseif g:netrw_sizestyle == 'H'
-    if a:sz >= 1073741824
-      let sz = printf("%.1f",a:sz/1073741824.0)."G"
-    elseif a:sz >= 10485760
-      let sz = printf("%d",a:sz/1048576)."M"
-    elseif a:sz >= 1048576
-      let sz = printf("%.1f",a:sz/1048576.0)."M"
-    elseif a:sz >= 10240
-      let sz = printf("%d",a:sz/1024)."K"
-    elseif a:sz >= 1024
-      let sz = printf("%.1f",a:sz/1024.0)."K"
-    else
-      let sz= a:sz
-    endif
-
-  else
-    let sz= a:sz
-  endif
-
-  return sz
+    return sz
 endfun
 
 " s:NetrwRestoreWordPosn: used to keep cursor on same word after refresh, {{{2
 "  changed sorting, etc.  Also see s:NetrwSaveWordPosn().
 fun! s:NetrwRestoreWordPosn()
-  sil! call search(s:netrw_saveword,'w')
+    sil! call search(s:netrw_saveword,'w')
 endfun
 
 " s:RestoreBufVars: {{{2
 fun! s:RestoreBufVars()
 
-  if exists("s:netrw_curdir")        |let b:netrw_curdir         = s:netrw_curdir        |endif
-  if exists("s:netrw_lastfile")      |let b:netrw_lastfile       = s:netrw_lastfile      |endif
-  if exists("s:netrw_method")        |let b:netrw_method         = s:netrw_method        |endif
-  if exists("s:netrw_fname")         |let b:netrw_fname          = s:netrw_fname         |endif
-  if exists("s:netrw_machine")       |let b:netrw_machine        = s:netrw_machine       |endif
-  if exists("s:netrw_browser_active")|let b:netrw_browser_active = s:netrw_browser_active|endif
+    if exists("s:netrw_curdir")        |let b:netrw_curdir         = s:netrw_curdir        |endif
+    if exists("s:netrw_lastfile")      |let b:netrw_lastfile       = s:netrw_lastfile      |endif
+    if exists("s:netrw_method")        |let b:netrw_method         = s:netrw_method        |endif
+    if exists("s:netrw_fname")         |let b:netrw_fname          = s:netrw_fname         |endif
+    if exists("s:netrw_machine")       |let b:netrw_machine        = s:netrw_machine       |endif
+    if exists("s:netrw_browser_active")|let b:netrw_browser_active = s:netrw_browser_active|endif
 
 endfun
 
 " s:RemotePathAnalysis: {{{2
 fun! s:RemotePathAnalysis(dirname)
 
-  "                method   ://    user  @      machine      :port            /path
-  let dirpat  = '^\(\w\{-}\)://\(\(\w\+\)@\)\=\([^/:#]\+\)\%([:#]\(\d\+\)\)\=/\(.*\)$'
-  let s:method  = substitute(a:dirname,dirpat,'\1','')
-  let s:user    = substitute(a:dirname,dirpat,'\3','')
-  let s:machine = substitute(a:dirname,dirpat,'\4','')
-  let s:port    = substitute(a:dirname,dirpat,'\5','')
-  let s:path    = substitute(a:dirname,dirpat,'\6','')
-  let s:fname   = substitute(s:path,'^.*/\ze.','','')
-  if s:machine =~ '@'
-    let dirpat    = '^\(.*\)@\(.\{-}\)$'
-    let s:user    = s:user.'@'.substitute(s:machine,dirpat,'\1','')
-    let s:machine = substitute(s:machine,dirpat,'\2','')
-  endif
+    "                method   ://    user  @      machine      :port            /path
+    let dirpat  = '^\(\w\{-}\)://\(\(\w\+\)@\)\=\([^/:#]\+\)\%([:#]\(\d\+\)\)\=/\(.*\)$'
+    let s:method  = substitute(a:dirname,dirpat,'\1','')
+    let s:user    = substitute(a:dirname,dirpat,'\3','')
+    let s:machine = substitute(a:dirname,dirpat,'\4','')
+    let s:port    = substitute(a:dirname,dirpat,'\5','')
+    let s:path    = substitute(a:dirname,dirpat,'\6','')
+    let s:fname   = substitute(s:path,'^.*/\ze.','','')
+    if s:machine =~ '@'
+        let dirpat    = '^\(.*\)@\(.\{-}\)$'
+        let s:user    = s:user.'@'.substitute(s:machine,dirpat,'\1','')
+        let s:machine = substitute(s:machine,dirpat,'\2','')
+    endif
 
 
 endfun
@@ -9653,44 +9612,44 @@ endfun
 "    [cd REMOTEDIRPATH;] a:cmd
 " Note that it doesn't do netrw#os#Escape(a:cmd)!
 fun! s:RemoteSystem(cmd)
-  if !executable(g:netrw_ssh_cmd)
-    call netrw#msg#Notify('ERROR', printf('g:netrw_ssh_cmd<%s> is not executable!', g:netrw_ssh_cmd))
-  elseif !exists("b:netrw_curdir")
-    call netrw#msg#Notify('ERROR', "for some reason b:netrw_curdir doesn't exist!")
-  else
-    let cmd      = s:MakeSshCmd(g:netrw_ssh_cmd." USEPORT HOSTNAME")
-    let remotedir= substitute(b:netrw_curdir,'^.*//[^/]\+/\(.*\)$','\1','')
-    if remotedir != ""
-      let cmd= cmd.' cd '.netrw#os#Escape(remotedir).";"
+    if !executable(g:netrw_ssh_cmd)
+        call netrw#msg#Notify('ERROR', printf('g:netrw_ssh_cmd<%s> is not executable!', g:netrw_ssh_cmd))
+    elseif !exists("b:netrw_curdir")
+        call netrw#msg#Notify('ERROR', "for some reason b:netrw_curdir doesn't exist!")
     else
-      let cmd= cmd.' '
+        let cmd      = s:MakeSshCmd(g:netrw_ssh_cmd." USEPORT HOSTNAME")
+        let remotedir= substitute(b:netrw_curdir,'^.*//[^/]\+/\(.*\)$','\1','')
+        if remotedir != ""
+            let cmd= cmd.' cd '.netrw#os#Escape(remotedir).";"
+        else
+            let cmd= cmd.' '
+        endif
+        let cmd= cmd.a:cmd
+        let ret= system(cmd)
     endif
-    let cmd= cmd.a:cmd
-    let ret= system(cmd)
-  endif
-  return ret
+    return ret
 endfun
 
 " s:RestoreWinVars: (used by Explore() and NetrwSplit()) {{{2
 fun! s:RestoreWinVars()
-  if exists("s:bannercnt")      |let w:netrw_bannercnt       = s:bannercnt      |unlet s:bannercnt      |endif
-  if exists("s:col")            |let w:netrw_col             = s:col            |unlet s:col            |endif
-  if exists("s:curdir")         |let w:netrw_curdir          = s:curdir         |unlet s:curdir         |endif
-  if exists("s:explore_bufnr")  |let w:netrw_explore_bufnr   = s:explore_bufnr  |unlet s:explore_bufnr  |endif
-  if exists("s:explore_indx")   |let w:netrw_explore_indx    = s:explore_indx   |unlet s:explore_indx   |endif
-  if exists("s:explore_line")   |let w:netrw_explore_line    = s:explore_line   |unlet s:explore_line   |endif
-  if exists("s:explore_listlen")|let w:netrw_explore_listlen = s:explore_listlen|unlet s:explore_listlen|endif
-  if exists("s:explore_list")   |let w:netrw_explore_list    = s:explore_list   |unlet s:explore_list   |endif
-  if exists("s:explore_mtchcnt")|let w:netrw_explore_mtchcnt = s:explore_mtchcnt|unlet s:explore_mtchcnt|endif
-  if exists("s:fpl")            |let w:netrw_fpl             = s:fpl            |unlet s:fpl            |endif
-  if exists("s:hline")          |let w:netrw_hline           = s:hline          |unlet s:hline          |endif
-  if exists("s:line")           |let w:netrw_line            = s:line           |unlet s:line           |endif
-  if exists("s:liststyle")      |let w:netrw_liststyle       = s:liststyle      |unlet s:liststyle      |endif
-  if exists("s:method")         |let w:netrw_method          = s:method         |unlet s:method         |endif
-  if exists("s:prvdir")         |let w:netrw_prvdir          = s:prvdir         |unlet s:prvdir         |endif
-  if exists("s:treedict")       |let w:netrw_treedict        = s:treedict       |unlet s:treedict       |endif
-  if exists("s:treetop")        |let w:netrw_treetop         = s:treetop        |unlet s:treetop        |endif
-  if exists("s:winnr")          |let w:netrw_winnr           = s:winnr          |unlet s:winnr          |endif
+    if exists("s:bannercnt")      |let w:netrw_bannercnt       = s:bannercnt      |unlet s:bannercnt      |endif
+    if exists("s:col")            |let w:netrw_col             = s:col            |unlet s:col            |endif
+    if exists("s:curdir")         |let w:netrw_curdir          = s:curdir         |unlet s:curdir         |endif
+    if exists("s:explore_bufnr")  |let w:netrw_explore_bufnr   = s:explore_bufnr  |unlet s:explore_bufnr  |endif
+    if exists("s:explore_indx")   |let w:netrw_explore_indx    = s:explore_indx   |unlet s:explore_indx   |endif
+    if exists("s:explore_line")   |let w:netrw_explore_line    = s:explore_line   |unlet s:explore_line   |endif
+    if exists("s:explore_listlen")|let w:netrw_explore_listlen = s:explore_listlen|unlet s:explore_listlen|endif
+    if exists("s:explore_list")   |let w:netrw_explore_list    = s:explore_list   |unlet s:explore_list   |endif
+    if exists("s:explore_mtchcnt")|let w:netrw_explore_mtchcnt = s:explore_mtchcnt|unlet s:explore_mtchcnt|endif
+    if exists("s:fpl")            |let w:netrw_fpl             = s:fpl            |unlet s:fpl            |endif
+    if exists("s:hline")          |let w:netrw_hline           = s:hline          |unlet s:hline          |endif
+    if exists("s:line")           |let w:netrw_line            = s:line           |unlet s:line           |endif
+    if exists("s:liststyle")      |let w:netrw_liststyle       = s:liststyle      |unlet s:liststyle      |endif
+    if exists("s:method")         |let w:netrw_method          = s:method         |unlet s:method         |endif
+    if exists("s:prvdir")         |let w:netrw_prvdir          = s:prvdir         |unlet s:prvdir         |endif
+    if exists("s:treedict")       |let w:netrw_treedict        = s:treedict       |unlet s:treedict       |endif
+    if exists("s:treetop")        |let w:netrw_treetop         = s:treetop        |unlet s:treetop        |endif
+    if exists("s:winnr")          |let w:netrw_winnr           = s:winnr          |unlet s:winnr          |endif
 endfun
 
 " s:Rexplore: implements returning from a buffer to a netrw directory {{{2
@@ -9702,49 +9661,49 @@ endfun
 "
 "             s:rexposn_BUFNR used to save/restore cursor position
 fun! s:NetrwRexplore(islocal,dirname)
-  if exists("s:netrwdrag")
-    return
-  endif
-
-  if &ft == "netrw" && exists("w:netrw_rexfile") && w:netrw_rexfile != ""
-    " a :Rex while in a netrw buffer means: edit the file in w:netrw_rexfile
-    exe "NetrwKeepj e ".w:netrw_rexfile
-    unlet w:netrw_rexfile
-    return
-  endif
-
-  " ---------------------------
-  " :Rex issued while in a file
-  " ---------------------------
-
-  " record current file so :Rex can return to it from netrw
-  let w:netrw_rexfile= expand("%")
-
-  if !exists("w:netrw_rexlocal")
-    return
-  endif
-  if w:netrw_rexlocal
-    NetrwKeepj call netrw#LocalBrowseCheck(w:netrw_rexdir)
-  else
-    NetrwKeepj call s:NetrwBrowse(0,w:netrw_rexdir)
-  endif
-  if exists("s:initbeval")
-    setl beval
-  endif
-  if exists("s:rexposn_".bufnr("%"))
-    " restore position in directory listing
-    NetrwKeepj call winrestview(s:rexposn_{bufnr('%')})
-    if exists("s:rexposn_".bufnr('%'))
-      unlet s:rexposn_{bufnr('%')}
+    if exists("s:netrwdrag")
+        return
     endif
-  else
-  endif
 
-  if has("syntax") && exists("g:syntax_on") && g:syntax_on
-    if exists("s:explore_match")
-      exe "2match netrwMarkFile /".s:explore_match."/"
+    if &ft == "netrw" && exists("w:netrw_rexfile") && w:netrw_rexfile != ""
+        " a :Rex while in a netrw buffer means: edit the file in w:netrw_rexfile
+        exe "NetrwKeepj e ".w:netrw_rexfile
+        unlet w:netrw_rexfile
+        return
     endif
-  endif
+
+    " ---------------------------
+    " :Rex issued while in a file
+    " ---------------------------
+
+    " record current file so :Rex can return to it from netrw
+    let w:netrw_rexfile= expand("%")
+
+    if !exists("w:netrw_rexlocal")
+        return
+    endif
+    if w:netrw_rexlocal
+        NetrwKeepj call netrw#LocalBrowseCheck(w:netrw_rexdir)
+    else
+        NetrwKeepj call s:NetrwBrowse(0,w:netrw_rexdir)
+    endif
+    if exists("s:initbeval")
+        setl beval
+    endif
+    if exists("s:rexposn_".bufnr("%"))
+        " restore position in directory listing
+        NetrwKeepj call winrestview(s:rexposn_{bufnr('%')})
+        if exists("s:rexposn_".bufnr('%'))
+            unlet s:rexposn_{bufnr('%')}
+        endif
+    else
+    endif
+
+    if has("syntax") && exists("g:syntax_on") && g:syntax_on
+        if exists("s:explore_match")
+            exe "2match netrwMarkFile /".s:explore_match."/"
+        endif
+    endif
 
 endfun
 
@@ -9752,60 +9711,60 @@ endfun
 "                use s:RestoreBufVars() to restore b: variables from s: variables
 fun! s:SaveBufVars()
 
-  if exists("b:netrw_curdir")        |let s:netrw_curdir         = b:netrw_curdir        |endif
-  if exists("b:netrw_lastfile")      |let s:netrw_lastfile       = b:netrw_lastfile      |endif
-  if exists("b:netrw_method")        |let s:netrw_method         = b:netrw_method        |endif
-  if exists("b:netrw_fname")         |let s:netrw_fname          = b:netrw_fname         |endif
-  if exists("b:netrw_machine")       |let s:netrw_machine        = b:netrw_machine       |endif
-  if exists("b:netrw_browser_active")|let s:netrw_browser_active = b:netrw_browser_active|endif
+    if exists("b:netrw_curdir")        |let s:netrw_curdir         = b:netrw_curdir        |endif
+    if exists("b:netrw_lastfile")      |let s:netrw_lastfile       = b:netrw_lastfile      |endif
+    if exists("b:netrw_method")        |let s:netrw_method         = b:netrw_method        |endif
+    if exists("b:netrw_fname")         |let s:netrw_fname          = b:netrw_fname         |endif
+    if exists("b:netrw_machine")       |let s:netrw_machine        = b:netrw_machine       |endif
+    if exists("b:netrw_browser_active")|let s:netrw_browser_active = b:netrw_browser_active|endif
 
 endfun
 
 " s:SavePosn: saves position associated with current buffer into a dictionary {{{2
 fun! s:SavePosn(posndict)
 
-  if !exists("a:posndict[bufnr('%')]")
-    let a:posndict[bufnr("%")]= []
-  endif
-  call add(a:posndict[bufnr("%")],winsaveview())
+    if !exists("a:posndict[bufnr('%')]")
+        let a:posndict[bufnr("%")]= []
+    endif
+    call add(a:posndict[bufnr("%")],winsaveview())
 
-  return a:posndict
+    return a:posndict
 endfun
 
 " s:RestorePosn: restores position associated with current buffer using dictionary {{{2
 fun! s:RestorePosn(posndict)
-  if exists("a:posndict")
-    if has_key(a:posndict,bufnr("%"))
-      let posnlen= len(a:posndict[bufnr("%")])
-      if posnlen > 0
-        let posnlen= posnlen - 1
-        call winrestview(a:posndict[bufnr("%")][posnlen])
-        call remove(a:posndict[bufnr("%")],posnlen)
-      endif
+    if exists("a:posndict")
+        if has_key(a:posndict,bufnr("%"))
+            let posnlen= len(a:posndict[bufnr("%")])
+            if posnlen > 0
+                let posnlen= posnlen - 1
+                call winrestview(a:posndict[bufnr("%")][posnlen])
+                call remove(a:posndict[bufnr("%")],posnlen)
+            endif
+        endif
     endif
-  endif
 endfun
 
 " s:SaveWinVars: (used by Explore() and NetrwSplit()) {{{2
 fun! s:SaveWinVars()
-  if exists("w:netrw_bannercnt")      |let s:bannercnt       = w:netrw_bannercnt      |endif
-  if exists("w:netrw_col")            |let s:col             = w:netrw_col            |endif
-  if exists("w:netrw_curdir")         |let s:curdir          = w:netrw_curdir         |endif
-  if exists("w:netrw_explore_bufnr")  |let s:explore_bufnr   = w:netrw_explore_bufnr  |endif
-  if exists("w:netrw_explore_indx")   |let s:explore_indx    = w:netrw_explore_indx   |endif
-  if exists("w:netrw_explore_line")   |let s:explore_line    = w:netrw_explore_line   |endif
-  if exists("w:netrw_explore_listlen")|let s:explore_listlen = w:netrw_explore_listlen|endif
-  if exists("w:netrw_explore_list")   |let s:explore_list    = w:netrw_explore_list   |endif
-  if exists("w:netrw_explore_mtchcnt")|let s:explore_mtchcnt = w:netrw_explore_mtchcnt|endif
-  if exists("w:netrw_fpl")            |let s:fpl             = w:netrw_fpl            |endif
-  if exists("w:netrw_hline")          |let s:hline           = w:netrw_hline          |endif
-  if exists("w:netrw_line")           |let s:line            = w:netrw_line           |endif
-  if exists("w:netrw_liststyle")      |let s:liststyle       = w:netrw_liststyle      |endif
-  if exists("w:netrw_method")         |let s:method          = w:netrw_method         |endif
-  if exists("w:netrw_prvdir")         |let s:prvdir          = w:netrw_prvdir         |endif
-  if exists("w:netrw_treedict")       |let s:treedict        = w:netrw_treedict       |endif
-  if exists("w:netrw_treetop")        |let s:treetop         = w:netrw_treetop        |endif
-  if exists("w:netrw_winnr")          |let s:winnr           = w:netrw_winnr          |endif
+    if exists("w:netrw_bannercnt")      |let s:bannercnt       = w:netrw_bannercnt      |endif
+    if exists("w:netrw_col")            |let s:col             = w:netrw_col            |endif
+    if exists("w:netrw_curdir")         |let s:curdir          = w:netrw_curdir         |endif
+    if exists("w:netrw_explore_bufnr")  |let s:explore_bufnr   = w:netrw_explore_bufnr  |endif
+    if exists("w:netrw_explore_indx")   |let s:explore_indx    = w:netrw_explore_indx   |endif
+    if exists("w:netrw_explore_line")   |let s:explore_line    = w:netrw_explore_line   |endif
+    if exists("w:netrw_explore_listlen")|let s:explore_listlen = w:netrw_explore_listlen|endif
+    if exists("w:netrw_explore_list")   |let s:explore_list    = w:netrw_explore_list   |endif
+    if exists("w:netrw_explore_mtchcnt")|let s:explore_mtchcnt = w:netrw_explore_mtchcnt|endif
+    if exists("w:netrw_fpl")            |let s:fpl             = w:netrw_fpl            |endif
+    if exists("w:netrw_hline")          |let s:hline           = w:netrw_hline          |endif
+    if exists("w:netrw_line")           |let s:line            = w:netrw_line           |endif
+    if exists("w:netrw_liststyle")      |let s:liststyle       = w:netrw_liststyle      |endif
+    if exists("w:netrw_method")         |let s:method          = w:netrw_method         |endif
+    if exists("w:netrw_prvdir")         |let s:prvdir          = w:netrw_prvdir         |endif
+    if exists("w:netrw_treedict")       |let s:treedict        = w:netrw_treedict       |endif
+    if exists("w:netrw_treetop")        |let s:treetop         = w:netrw_treetop        |endif
+    if exists("w:netrw_winnr")          |let s:winnr           = w:netrw_winnr          |endif
 endfun
 
 " s:SetBufWinVars: (used by NetrwBrowse() and LocalBrowseCheck()) {{{2
@@ -9815,93 +9774,93 @@ endfun
 "   variables are not inherited by the new window.  SetBufWinVars() and
 "   UseBufWinVars() get around that.
 fun! s:SetBufWinVars()
-  if exists("w:netrw_liststyle")      |let b:netrw_liststyle      = w:netrw_liststyle      |endif
-  if exists("w:netrw_bannercnt")      |let b:netrw_bannercnt      = w:netrw_bannercnt      |endif
-  if exists("w:netrw_method")         |let b:netrw_method         = w:netrw_method         |endif
-  if exists("w:netrw_prvdir")         |let b:netrw_prvdir         = w:netrw_prvdir         |endif
-  if exists("w:netrw_explore_indx")   |let b:netrw_explore_indx   = w:netrw_explore_indx   |endif
-  if exists("w:netrw_explore_listlen")|let b:netrw_explore_listlen= w:netrw_explore_listlen|endif
-  if exists("w:netrw_explore_mtchcnt")|let b:netrw_explore_mtchcnt= w:netrw_explore_mtchcnt|endif
-  if exists("w:netrw_explore_bufnr")  |let b:netrw_explore_bufnr  = w:netrw_explore_bufnr  |endif
-  if exists("w:netrw_explore_line")   |let b:netrw_explore_line   = w:netrw_explore_line   |endif
-  if exists("w:netrw_explore_list")   |let b:netrw_explore_list   = w:netrw_explore_list   |endif
+    if exists("w:netrw_liststyle")      |let b:netrw_liststyle      = w:netrw_liststyle      |endif
+    if exists("w:netrw_bannercnt")      |let b:netrw_bannercnt      = w:netrw_bannercnt      |endif
+    if exists("w:netrw_method")         |let b:netrw_method         = w:netrw_method         |endif
+    if exists("w:netrw_prvdir")         |let b:netrw_prvdir         = w:netrw_prvdir         |endif
+    if exists("w:netrw_explore_indx")   |let b:netrw_explore_indx   = w:netrw_explore_indx   |endif
+    if exists("w:netrw_explore_listlen")|let b:netrw_explore_listlen= w:netrw_explore_listlen|endif
+    if exists("w:netrw_explore_mtchcnt")|let b:netrw_explore_mtchcnt= w:netrw_explore_mtchcnt|endif
+    if exists("w:netrw_explore_bufnr")  |let b:netrw_explore_bufnr  = w:netrw_explore_bufnr  |endif
+    if exists("w:netrw_explore_line")   |let b:netrw_explore_line   = w:netrw_explore_line   |endif
+    if exists("w:netrw_explore_list")   |let b:netrw_explore_list   = w:netrw_explore_list   |endif
 endfun
 
 " s:SetRexDir: set directory for :Rexplore {{{2
 fun! s:SetRexDir(islocal,dirname)
-  let w:netrw_rexdir         = a:dirname
-  let w:netrw_rexlocal       = a:islocal
-  let s:rexposn_{bufnr("%")} = winsaveview()
+    let w:netrw_rexdir         = a:dirname
+    let w:netrw_rexlocal       = a:islocal
+    let s:rexposn_{bufnr("%")} = winsaveview()
 endfun
 
 " s:ShowLink: used to modify thin and tree listings to show links {{{2
 fun! s:ShowLink()
-  if exists("b:netrw_curdir")
-    keepp :norm! $?\a
-    "call histdel("/",-1)
-    if exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST && exists("w:netrw_treetop")
-      let basedir = s:NetrwTreePath(w:netrw_treetop)
-    else
-      let basedir = b:netrw_curdir.'/'
+    if exists("b:netrw_curdir")
+        keepp :norm! $?\a
+        "call histdel("/",-1)
+        if exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST && exists("w:netrw_treetop")
+            let basedir = s:NetrwTreePath(w:netrw_treetop)
+        else
+            let basedir = b:netrw_curdir.'/'
+        endif
+        let fname = basedir.s:NetrwGetWord()
+        let resname = resolve(fname)
+        if resname =~ '^\M'.basedir
+            let dirlen  = strlen(basedir)
+            let resname = strpart(resname,dirlen)
+        endif
+        let modline = getline(".")."\t --> ".resname
+        setl noro ma
+        call setline(".",modline)
+        setl ro noma nomod
     endif
-    let fname = basedir.s:NetrwGetWord()
-    let resname = resolve(fname)
-    if resname =~ '^\M'.basedir
-      let dirlen  = strlen(basedir)
-      let resname = strpart(resname,dirlen)
-    endif
-    let modline = getline(".")."\t --> ".resname
-    setl noro ma
-    call setline(".",modline)
-    setl ro noma nomod
-  endif
 endfun
 
 " s:ShowStyle: {{{2
 fun! s:ShowStyle()
-  if !exists("w:netrw_liststyle")
-    let liststyle= g:netrw_liststyle
-  else
-    let liststyle= w:netrw_liststyle
-  endif
-  if     liststyle == s:THINLIST
-    return s:THINLIST.":thin"
-  elseif liststyle == s:LONGLIST
-    return s:LONGLIST.":long"
-  elseif liststyle == s:WIDELIST
-    return s:WIDELIST.":wide"
-  elseif liststyle == s:TREELIST
-    return s:TREELIST.":tree"
-  else
-    return 'n/a'
-  endif
+    if !exists("w:netrw_liststyle")
+        let liststyle= g:netrw_liststyle
+    else
+        let liststyle= w:netrw_liststyle
+    endif
+    if     liststyle == s:THINLIST
+        return s:THINLIST.":thin"
+    elseif liststyle == s:LONGLIST
+        return s:LONGLIST.":long"
+    elseif liststyle == s:WIDELIST
+        return s:WIDELIST.":wide"
+    elseif liststyle == s:TREELIST
+        return s:TREELIST.":tree"
+    else
+        return 'n/a'
+    endif
 endfun
 
 " s:TreeListMove: supports [[, ]], [], and ][ in tree mode {{{2
 fun! s:TreeListMove(dir)
-  let curline      = getline('.')
-  let prvline      = (line(".") > 1)?         getline(line(".")-1) : ''
-  let nxtline      = (line(".") < line("$"))? getline(line(".")+1) : ''
-  let curindent    = substitute(getline('.'),'^\(\%('.s:treedepthstring.'\)*\)[^'.s:treedepthstring.'].\{-}$','\1','e')
-  let indentm1     = substitute(curindent,'^'.s:treedepthstring,'','')
-  let treedepthchr = substitute(s:treedepthstring,' ','','g')
-  let stopline     = exists("w:netrw_bannercnt")? w:netrw_bannercnt : 1
-  "  COMBAK : need to handle when on a directory
-  "  COMBAK : need to handle ]] and ][.  In general, needs work!!!
-  if curline !~ '/$'
-    if     a:dir == '[[' && prvline != ''
-      NetrwKeepj norm! 0
-      let nl = search('^'.indentm1.'\%('.s:treedepthstring.'\)\@!','bWe',stopline) " search backwards
-    elseif a:dir == '[]' && nxtline != ''
-      NetrwKeepj norm! 0
-      let nl = search('^\%('.curindent.'\)\@!','We') " search forwards
-      if nl != 0
-        NetrwKeepj norm! k
-      else
-        NetrwKeepj norm! G
-      endif
+    let curline      = getline('.')
+    let prvline      = (line(".") > 1)?         getline(line(".")-1) : ''
+    let nxtline      = (line(".") < line("$"))? getline(line(".")+1) : ''
+    let curindent    = substitute(getline('.'),'^\(\%('.s:treedepthstring.'\)*\)[^'.s:treedepthstring.'].\{-}$','\1','e')
+    let indentm1     = substitute(curindent,'^'.s:treedepthstring,'','')
+    let treedepthchr = substitute(s:treedepthstring,' ','','g')
+    let stopline     = exists("w:netrw_bannercnt")? w:netrw_bannercnt : 1
+    "  COMBAK : need to handle when on a directory
+    "  COMBAK : need to handle ]] and ][.  In general, needs work!!!
+    if curline !~ '/$'
+        if     a:dir == '[[' && prvline != ''
+            NetrwKeepj norm! 0
+            let nl = search('^'.indentm1.'\%('.s:treedepthstring.'\)\@!','bWe',stopline) " search backwards
+        elseif a:dir == '[]' && nxtline != ''
+            NetrwKeepj norm! 0
+            let nl = search('^\%('.curindent.'\)\@!','We') " search forwards
+            if nl != 0
+                NetrwKeepj norm! k
+            else
+                NetrwKeepj norm! G
+            endif
+        endif
     endif
-  endif
 
 endfun
 
@@ -9910,29 +9869,29 @@ endfun
 "                      can't be called except via emenu.  But due to locale, that menu line may not be called
 "                      Buffers.Refresh; hence, s:NetrwBMShow() utilizes a "cheat" to call that function anyway.
 fun! s:UpdateBuffersMenu()
-  if has("gui") && has("menu") && has("gui_running") && &go =~# 'm' && g:netrw_menu
-    try
-      sil emenu Buffers.Refresh\ menu
-    catch /^Vim\%((\a\+)\)\=:E/
-      let v:errmsg= ""
-      sil NetrwKeepj call s:NetrwBMShow()
-    endtry
-  endif
+    if has("gui") && has("menu") && has("gui_running") && &go =~# 'm' && g:netrw_menu
+        try
+            sil emenu Buffers.Refresh\ menu
+        catch /^Vim\%((\a\+)\)\=:E/
+            let v:errmsg= ""
+            sil NetrwKeepj call s:NetrwBMShow()
+        endtry
+    endif
 endfun
 
 " s:UseBufWinVars: (used by NetrwBrowse() and LocalBrowseCheck() {{{2
 "              Matching function to s:SetBufWinVars()
 fun! s:UseBufWinVars()
-  if exists("b:netrw_liststyle")       && !exists("w:netrw_liststyle")      |let w:netrw_liststyle       = b:netrw_liststyle      |endif
-  if exists("b:netrw_bannercnt")       && !exists("w:netrw_bannercnt")      |let w:netrw_bannercnt       = b:netrw_bannercnt      |endif
-  if exists("b:netrw_method")          && !exists("w:netrw_method")         |let w:netrw_method          = b:netrw_method         |endif
-  if exists("b:netrw_prvdir")          && !exists("w:netrw_prvdir")         |let w:netrw_prvdir          = b:netrw_prvdir         |endif
-  if exists("b:netrw_explore_indx")    && !exists("w:netrw_explore_indx")   |let w:netrw_explore_indx    = b:netrw_explore_indx   |endif
-  if exists("b:netrw_explore_listlen") && !exists("w:netrw_explore_listlen")|let w:netrw_explore_listlen = b:netrw_explore_listlen|endif
-  if exists("b:netrw_explore_mtchcnt") && !exists("w:netrw_explore_mtchcnt")|let w:netrw_explore_mtchcnt = b:netrw_explore_mtchcnt|endif
-  if exists("b:netrw_explore_bufnr")   && !exists("w:netrw_explore_bufnr")  |let w:netrw_explore_bufnr   = b:netrw_explore_bufnr  |endif
-  if exists("b:netrw_explore_line")    && !exists("w:netrw_explore_line")   |let w:netrw_explore_line    = b:netrw_explore_line   |endif
-  if exists("b:netrw_explore_list")    && !exists("w:netrw_explore_list")   |let w:netrw_explore_list    = b:netrw_explore_list   |endif
+    if exists("b:netrw_liststyle")       && !exists("w:netrw_liststyle")      |let w:netrw_liststyle       = b:netrw_liststyle      |endif
+    if exists("b:netrw_bannercnt")       && !exists("w:netrw_bannercnt")      |let w:netrw_bannercnt       = b:netrw_bannercnt      |endif
+    if exists("b:netrw_method")          && !exists("w:netrw_method")         |let w:netrw_method          = b:netrw_method         |endif
+    if exists("b:netrw_prvdir")          && !exists("w:netrw_prvdir")         |let w:netrw_prvdir          = b:netrw_prvdir         |endif
+    if exists("b:netrw_explore_indx")    && !exists("w:netrw_explore_indx")   |let w:netrw_explore_indx    = b:netrw_explore_indx   |endif
+    if exists("b:netrw_explore_listlen") && !exists("w:netrw_explore_listlen")|let w:netrw_explore_listlen = b:netrw_explore_listlen|endif
+    if exists("b:netrw_explore_mtchcnt") && !exists("w:netrw_explore_mtchcnt")|let w:netrw_explore_mtchcnt = b:netrw_explore_mtchcnt|endif
+    if exists("b:netrw_explore_bufnr")   && !exists("w:netrw_explore_bufnr")  |let w:netrw_explore_bufnr   = b:netrw_explore_bufnr  |endif
+    if exists("b:netrw_explore_line")    && !exists("w:netrw_explore_line")   |let w:netrw_explore_line    = b:netrw_explore_line   |endif
+    if exists("b:netrw_explore_list")    && !exists("w:netrw_explore_list")   |let w:netrw_explore_list    = b:netrw_explore_list   |endif
 endfun
 
 " s:UserMaps: supports user-defined UserMaps {{{2
@@ -9940,30 +9899,30 @@ endfun
 "               * interprets result
 "             See netrw#UserMaps()
 fun! s:UserMaps(islocal,funcname)
-  if !exists("b:netrw_curdir")
-    let b:netrw_curdir= getcwd()
-  endif
-  let Funcref = function(a:funcname)
-  let result  = Funcref(a:islocal)
-
-  if     type(result) == 1
-    " if result from user's funcref is a string...
-    if result == "refresh"
-      call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
-    elseif result != ""
-      exe result
+    if !exists("b:netrw_curdir")
+        let b:netrw_curdir= getcwd()
     endif
+    let Funcref = function(a:funcname)
+    let result  = Funcref(a:islocal)
 
-  elseif type(result) == 3
-    " if result from user's funcref is a List...
-    for action in result
-      if action == "refresh"
-        call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
-      elseif action != ""
-        exe action
-      endif
-    endfor
-  endif
+    if     type(result) == 1
+        " if result from user's funcref is a string...
+        if result == "refresh"
+            call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
+        elseif result != ""
+            exe result
+        endif
+
+    elseif type(result) == 3
+        " if result from user's funcref is a List...
+        for action in result
+            if action == "refresh"
+                call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
+            elseif action != ""
+                exe action
+            endif
+        endfor
+    endif
 endfun
 
 " Deprecated: {{{1


### PR DESCRIPTION
This is one of the numerous patches for netrw v182. It is a mess because I've changed the indentation from 2 to 4 spaces. I needed to do it once so the next pathches are less noisy since i use 4 spaces everywhere.