### PR TITLE
feat: support gv in operator pending mode

### DIFF
--- a/src/normal.c
+++ b/src/normal.c
@@ -5676,9 +5676,6 @@ nv_gv_cmd(cmdarg_T *cap)
     pos_T	tpos;
     int		i;
 
-    if (checkclearop(cap->oap))
-	return;
-
     if (curbuf->b_visual.vi_start.lnum == 0
 	    || curbuf->b_visual.vi_start.lnum > curbuf->b_ml.ml_line_count
 	    || curbuf->b_visual.vi_end.lnum == 0)

--- a/src/testdir/test_normal.vim
+++ b/src/testdir/test_normal.vim
@@ -2604,8 +2604,14 @@ func Test_normal33_g_cmd2()
   exe "norm! G0\<c-v>4k4ly"
   exe "norm! gvood"
   call assert_equal(['', 'abfgh', 'abfgh', 'abfgh', 'fgh', 'fgh', 'fgh', 'fgh', 'fgh'], getline(1,'$'))
-  " gv cannot be used in operator pending mode
-  call assert_beeps('normal! cgv')
+  " gv works in operator pending mode
+  call assert_nobeep('normal! cgvxyza')
+  call assert_equal(['', 'abfgh', 'abfgh', 'abfgh', 'xyza', 'xyza', 'xyza', 'xyza', 'xyza'], getline(1,'$'))
+  exe "norm! ^\<c-v>Gydgv..cgvbc"
+  call assert_equal(['', 'abfgh', 'abfgh', 'abfgh', 'bc', 'bc', 'bc', 'bc', 'bc'], getline(1,'$'))
+  exe "norm! v^GragggUgv"
+  call assert_equal(['', 'abfgh', 'abfgh', 'abfgh', 'bA', 'AA', 'AA', 'AA', 'Ac'], getline(1,'$'))
+
   " gv should beep without a previously selected visual area
   new
   call assert_beeps('normal! gv')


### PR DESCRIPTION
Problem: gv don't work in operator pending mode

Solution: it seems already work without `checkclearop`

Related: https://github.com/vim/vim/issues/3666