### PR TITLE
Integer overflow in getmarklist() after linewise operation

### DIFF
--- a/src/mark.c
+++ b/src/mark.c
@@ -1464,7 +1464,7 @@ add_mark(list_T *l, char_u *mname, pos_T *pos, int bufnr, char_u *fname)
 
     list_append_number(lpos, bufnr);
     list_append_number(lpos, pos->lnum);
-    list_append_number(lpos, pos->col + 1);
+    list_append_number(lpos, pos->col < MAXCOL ? pos->col + 1 : MAXCOL);
     list_append_number(lpos, pos->coladd);
 
     if (dict_add_string(d, "mark", mname) == FAIL

--- a/src/testdir/test_marks.vim
+++ b/src/testdir/test_marks.vim
@@ -302,6 +302,11 @@ func Test_getmarklist()
   call assert_equal({'mark' : "'r", 'pos' : [bufnr(), 2, 2, 0]},
         \ bufnr()->getmarklist()[0])
   call assert_equal([], {}->getmarklist())
+  normal! yy
+  call assert_equal([
+        \ {'mark': "'[", 'pos': [bufnr(), 2, 1, 0]},
+        \ {'mark': "']", 'pos': [bufnr(), 2, v:maxcol, 0]},
+        \ ], getmarklist(bufnr())[-2:])
   close!
 endfunc
 


### PR DESCRIPTION
Problem:  Integer overflow in getmarklist() after linewise operation.
Solution: Don't add 1 to MAXCOL.

related: neovim/neovim#34524
