### PR TITLE
Fix warning message when folding disabled

### DIFF
--- a/runtime/syntax/sh.vim
+++ b/runtime/syntax/sh.vim
@@ -147,8 +147,8 @@ endif
 if !exists("g:sh_fold_enabled")
  let g:sh_fold_enabled= 0
 elseif g:sh_fold_enabled != 0 && !has("folding")
- let g:sh_fold_enabled= 0
  echomsg "Ignoring g:sh_fold_enabled=".g:sh_fold_enabled."; need to re-compile vim for +fold support"
+ let g:sh_fold_enabled= 0
 endif
 let s:sh_fold_functions= and(g:sh_fold_enabled,1)
 let s:sh_fold_heredoc  = and(g:sh_fold_enabled,2)


### PR DESCRIPTION
# Abstract
When Vim using -folding and g:sh_fold_enabled was set to 1 or more, the warning message "g:sh_fold_enabled=0" was displayed.
Displaying a warning after initializing variables(g:sh_fold_enabled) can be confusing.
So we changed a warning before initializing variables.

# Repro
1. Comment out the following in src/features.h and build vim.
```
#ifdef FEAT_NORMAL
//# define FEAT_FOLDING
#endif
```

2. Build & install vim.
```sh
./configure
make -j4
sudo make install
```

2. Set "let g:sh_fold_enabled= 7" in .vimrc

4. Open the shell script (*.sh)

# See
#10701

# Screen shot (after)
![image](https://github.com/user-attachments/assets/66575a66-c88d-40c5-9b82-e26e685ea917)
