### PR TITLE
Add Plug mappings for open and comment plugins

### DIFF
--- a/runtime/pack/dist/opt/comment/doc/comment.txt
+++ b/runtime/pack/dist/opt/comment/doc/comment.txt
@@ -85,6 +85,13 @@ Options:
     Use g:comment_first_col to change it globally or b:comment_first_col to
     target specific filetype(s).
 
+*g:comment_mappings*
+    Set to false to disable the default keyboard mappings, e.g. in your vimrc
+>
+        let g:comment_mappings = v:false
+<
+    This option must be set before the package is activated using |packadd|.
+
 ==============================================================================
 Mappings:
 

--- a/runtime/pack/dist/opt/comment/doc/comment.txt
+++ b/runtime/pack/dist/opt/comment/doc/comment.txt
@@ -19,16 +19,17 @@ gc{motion}	to toggle comments for the selected motion
 
 Since gc operates on a motion, it can be used with any motion, for example _
 to comment the current line, or ip to comment the current paragraph.
-A default mapping `gcc` to `gc_` is defined:
+Default mappings are defined for `gc_` and `gc$`:
 							*gcc*
-gcc		to comment/uncomment current line
+gcc		to comment/uncomment current line (same as `gc_`)
 
-To comment the rest of the line by  `gC`  whenever the filetype plugin
-supports it (that is, whenever the comment marker precedes the code) and fall
-back to `gcc` otherwise, add the following mapping to your vimrc: >
+							*gC*
+gC              to comment/uncomment to end of current line (same as `gc$`)
 
-	nnoremap <silent> <expr> gC comment#Toggle() .. '$'
-<
+Commenting to the end of a line using `gC` works whenever the filetype plugin
+supports it (that is, whenever the comment marker precedes the code) and falls
+back to `gcc` otherwise.
+
 Note: using `gC` may not always result in valid comment markers depending on
 the language used.
 
@@ -105,7 +106,7 @@ keyboard mappings.
     Normal mode only, mapped to gcc by default
 
 *<Plug>(comment-toggle-end)*
-    Normal mode only, not mapped by default
+    Normal mode only, mapped to gC by default
 
 *<Plug>(comment-text-object-inner)*
     Operator pending and visual modes, mapped to ic by default
@@ -119,16 +120,12 @@ to customise them in your vimrc:
     nmap gc <Plug>(comment-toggle)
     xmap gc <Plug>(comment-toggle)
     nmap gcc <Plug>(comment-toggle-line)
+    nmap gC <Plug>(comment-toggle-end)
 
     omap ic <Plug>(comment-text-object-inner)
     omap ac <Plug>(comment-text-object-outer)
     xmap ic <Plug>(comment-text-object-inner)
     xmap ac <Plug>(comment-text-object-outer)
-<
-As there is no default mapping for <Plug>(comment-toggle-end), to enable this
-you must add a mapping to your vimrc, e.g.
->
-     nmap gC <Plug>(comment-toggle-end)
 <
 ==============================================================================
 vim:tw=78:ts=8:fo=tcq2:ft=help:

--- a/runtime/pack/dist/opt/comment/doc/comment.txt
+++ b/runtime/pack/dist/opt/comment/doc/comment.txt
@@ -86,4 +86,42 @@ Options:
     target specific filetype(s).
 
 ==============================================================================
+Mappings:
+
+The following |<Plug>| mappings are included, which you can use to customise the
+keyboard mappings.
+
+*<Plug>(comment-toggle)*
+    Normal and visual modes, mapped to gc by default
+
+*<Plug>(comment-toggle-line)*
+    Normal mode only, mapped to gcc by default
+
+*<Plug>(comment-toggle-end)*
+    Normal mode only, not mapped by default
+
+*<Plug>(comment-text-object-inner)*
+    Operator pending and visual modes, mapped to ic by default
+
+*<Plug>(comment-text-object-outer)*
+    Operator pending and visual modes, mapped to ac by default
+
+The default keyboard mappings are shown below, you can copy these if you wish
+to customise them in your vimrc:
+>
+    nmap gc <Plug>(comment-toggle)
+    xmap gc <Plug>(comment-toggle)
+    nmap gcc <Plug>(comment-toggle-line)
+
+    omap ic <Plug>(comment-text-object-inner)
+    omap ac <Plug>(comment-text-object-outer)
+    xmap ic <Plug>(comment-text-object-inner)
+    xmap ac <Plug>(comment-text-object-outer)
+<
+As there is no default mapping for <Plug>(comment-toggle-end), to enable this
+you must add a mapping to your vimrc, e.g.
+>
+     nmap gC <Plug>(comment-toggle-end)
+<
+==============================================================================
 vim:tw=78:ts=8:fo=tcq2:ft=help:

--- a/runtime/pack/dist/opt/comment/plugin/comment.vim
+++ b/runtime/pack/dist/opt/comment/plugin/comment.vim
@@ -10,16 +10,18 @@ xnoremap <silent> <expr> <Plug>(comment-toggle) comment.Toggle()
 nnoremap <silent> <expr> <Plug>(comment-toggle-line) comment.Toggle() .. '_'
 nnoremap <silent> <expr> <Plug>(comment-toggle-end) comment.Toggle() .. '$'
 
-nmap gc <Plug>(comment-toggle)
-xmap gc <Plug>(comment-toggle)
-nmap gcc <Plug>(comment-toggle-line)
-
 onoremap <silent> <Plug>(comment-text-object-inner) <scriptcmd>comment.ObjComment(v:true)<CR>
 onoremap <silent> <Plug>(comment-text-object-outer) <scriptcmd>comment.ObjComment(v:false)<CR>
 xnoremap <silent> <Plug>(comment-text-object-inner) <esc><scriptcmd>comment.ObjComment(v:true)<CR>
 xnoremap <silent> <Plug>(comment-text-object-outer) <esc><scriptcmd>comment.ObjComment(v:false)<CR>
 
-omap ic <Plug>(comment-text-object-inner)
-omap ac <Plug>(comment-text-object-outer)
-xmap ic <Plug>(comment-text-object-inner)
-xmap ac <Plug>(comment-text-object-outer)
+if get(g:, 'comment_mappings', true)
+  nmap gc <Plug>(comment-toggle)
+  xmap gc <Plug>(comment-toggle)
+  nmap gcc <Plug>(comment-toggle-line)
+
+  omap ic <Plug>(comment-text-object-inner)
+  omap ac <Plug>(comment-text-object-outer)
+  xmap ic <Plug>(comment-text-object-inner)
+  xmap ac <Plug>(comment-text-object-outer)
+endif

--- a/runtime/pack/dist/opt/comment/plugin/comment.vim
+++ b/runtime/pack/dist/opt/comment/plugin/comment.vim
@@ -19,6 +19,7 @@ if get(g:, 'comment_mappings', true)
   nmap gc <Plug>(comment-toggle)
   xmap gc <Plug>(comment-toggle)
   nmap gcc <Plug>(comment-toggle-line)
+  nmap gC <Plug>(comment-toggle-end)
 
   omap ic <Plug>(comment-text-object-inner)
   omap ac <Plug>(comment-text-object-outer)

--- a/runtime/pack/dist/opt/comment/plugin/comment.vim
+++ b/runtime/pack/dist/opt/comment/plugin/comment.vim
@@ -5,11 +5,21 @@ vim9script
 
 import autoload 'comment.vim'
 
-nnoremap <silent> <expr> gc comment.Toggle()
-xnoremap <silent> <expr> gc comment.Toggle()
-nnoremap <silent> <expr> gcc comment.Toggle() .. '_'
+nnoremap <silent> <expr> <Plug>(comment-toggle) comment.Toggle()
+xnoremap <silent> <expr> <Plug>(comment-toggle) comment.Toggle()
+nnoremap <silent> <expr> <Plug>(comment-toggle-line) comment.Toggle() .. '_'
+nnoremap <silent> <expr> <Plug>(comment-toggle-end) comment.Toggle() .. '$'
 
-onoremap <silent>ic <scriptcmd>comment.ObjComment(v:true)<CR>
-onoremap <silent>ac <scriptcmd>comment.ObjComment(v:false)<CR>
-xnoremap <silent>ic <esc><scriptcmd>comment.ObjComment(v:true)<CR>
-xnoremap <silent>ac <esc><scriptcmd>comment.ObjComment(v:false)<CR>
+nmap gc <Plug>(comment-toggle)
+xmap gc <Plug>(comment-toggle)
+nmap gcc <Plug>(comment-toggle-line)
+
+onoremap <silent> <Plug>(comment-text-object-inner) <scriptcmd>comment.ObjComment(v:true)<CR>
+onoremap <silent> <Plug>(comment-text-object-outer) <scriptcmd>comment.ObjComment(v:false)<CR>
+xnoremap <silent> <Plug>(comment-text-object-inner) <esc><scriptcmd>comment.ObjComment(v:true)<CR>
+xnoremap <silent> <Plug>(comment-text-object-outer) <esc><scriptcmd>comment.ObjComment(v:false)<CR>
+
+omap ic <Plug>(comment-text-object-inner)
+omap ac <Plug>(comment-text-object-outer)
+xmap ic <Plug>(comment-text-object-inner)
+xmap ac <Plug>(comment-text-object-outer)

--- a/runtime/plugin/openPlugin.vim
+++ b/runtime/plugin/openPlugin.vim
@@ -34,10 +34,12 @@ if !no_gx
   enddef
 
   if maparg('gx', 'n') == ""
-    nnoremap <unique> gx <scriptcmd>vim9.Open(GetWordUnderCursor())<CR>
+    nnoremap <Plug>(open-word-under-cursor) <scriptcmd>vim9.Open(GetWordUnderCursor())<CR>
+    nmap gx <Plug>(open-word-under-cursor)
   endif
   if maparg('gx', 'x') == ""
-    xnoremap <unique> gx <scriptcmd>vim9.Open(getregion(getpos('v'), getpos('.'), { type: mode() })->join())<CR>
+    xnoremap <Plug>(open-word-under-cursor) <scriptcmd>vim9.Open(getregion(getpos('v'), getpos('.'), { type: mode() })->join())<CR>
+    xmap gx <Plug>(open-word-under-cursor)
   endif
 endif
 


### PR DESCRIPTION
The open and comment plugins included with Vim do not work with [https://github.com/liuchengxu/vim-which-key](vim-which-key). This is because they use vim9script in mappings, which, as far as I can tell, cannot currently be reliably applied outside of the script files within which they were defined. There are two reasons for this:

* `<expr>` mappings relying on imports cannot be evaluated outside of a script containing the necessary imports, and `vim-which-key` assumes that the RHS of an expression mapping can be evaluated using `eval()`

* `<scriptcmd>` mappings relying on imports do not work with `feedkeys()` for similar reasons, and `vim-which-key` relies on `feedkeys()` to apply these mappings

Example errors from `vim-which-key`:

```
Error detected while processing function which_key#start[29]..<SNR>25_cache_key[5]..which_key#mappings#parse:
line   63:
E121: Undefined variable: comment
E15: Invalid expression: "comment.Toggle() .. '_'"
E121: Undefined variable: comment
E15: Invalid expression: "comment.Toggle()"
E121: Undefined variable: comment
E15: Invalid expression: "comment.Toggle()"
...
E476: Invalid command: vim9.Open(GetWordUnderCursor())
```

These errors are not specific to `vim-which-key`, I just came across them while using `vim-which-key`. They can be reproduced using `eval()` and `feedkeys()`, e.g.

```
:call eval('comment.Toggle()')
E121: Undefined variable: comment
E15: Invalid expression: "comment.Toggle()"
...
:call feedkeys("\<scriptcmd>vim9.Open(GetWordUnderCursor())\<CR>", "nt")
E476: Invalid command: vim9.Open(GetWordUnderCursor())
```

This PR adds `<Plug>` mappings to both of these plugins included with Vim, which allows them to work with `vim-which-key`, and any other vimscript code/plugins which programmatically applies mappings using `feedkeys()` and `eval()`.

The `<Plug>` mappings have the added benefit, IMHO, of describing the expected behaviour (especially useful to novice Vim users as `<expr>` and `<scriptcmd>` mappings can require quite a lot or prior knowledge about Vim to understand, and Vim currently has no feature to add a description to mappings). 

That being said, I am by no means wedded to them, it's just one way of solving this problem. Alternatively, autoload syntax would fix the `<expr>` mappings, and `<cmd>` could be used instead of `<scriptcmd>` (though it would be nice if `<scriptcmd>` could somehow work with `feedkeys()` even when relying on imports).

A better fix for vim9script `<expr>` mappings might be adding something like `<scriptexpr>` as a feature to Vim, with information about which script files need to be imported included in `mapping-dict` so other code could use `maparg()` to determine that this is a vim9script expression which requires specific imports to be applied.

Fixes: #17523