### PR TITLE
runtime(doc): Remove obsolete labelling from 'h' occasion in :help 'highlight'

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4565,7 +4565,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 	|hl-Directory|	 d  directories in CTRL-D listing and other special
 			    things in listings
 	|hl-ErrorMsg|	 e  error messages
-			 h  (obsolete, ignored)
 	|hl-IncSearch|	 i  'incsearch' highlighting
 	|hl-CurSearch|	 y  current instance of last search pattern
 	|hl-Search|	 l  last search pattern highlighting (see 'hlsearch')


### PR DESCRIPTION
The 'h' occasion is now used for "matched text of currently inserted completion" (defaulting to ComplMatchIns).

