### PR TITLE
if_py_both.h: PySequence_Fast_{GET_SIZE,GET_ITEM} removed

### DIFF
--- a/src/if_py_both.h
+++ b/src/if_py_both.h
@@ -2409,18 +2409,18 @@ DictionaryUpdate(DictionaryObject *self, PyObject *args, PyObject *kwargs)
 
 		Py_DECREF(item);
 
-		if (PySequence_Fast_GET_SIZE(fast) != 2)
+		if (PySequence_Size(fast) != 2)
 		{
 		    Py_DECREF(iterator);
 		    Py_DECREF(fast);
 		    PyErr_FORMAT(PyExc_ValueError,
 			    N_("expected sequence element of size 2, "
 			    "but got sequence of size %d"),
-			    (int) PySequence_Fast_GET_SIZE(fast));
+			    (int) PySequence_Size(fast));
 		    return NULL;
 		}
 
-		keyObject = PySequence_Fast_GET_ITEM(fast, 0);
+		keyObject = PySequence_GetItem(fast, 0);
 
 		if (!(key = StringToChars(keyObject, &todecref)))
 		{
@@ -2442,7 +2442,7 @@ DictionaryUpdate(DictionaryObject *self, PyObject *args, PyObject *kwargs)
 		}
 		di->di_tv.v_type = VAR_UNKNOWN;
 
-		valObject = PySequence_Fast_GET_ITEM(fast, 1);
+		valObject = PySequence_GetItem(fast, 1);
 
 		if (ConvertFromPyObject(valObject, &di->di_tv) == -1)
 		{


### PR DESCRIPTION
Python 3.14 removed those two functions from stable API because of reasoning these function shouldn't be part of stable API at the first place.

Moving to PySequence_GetSize and PySequence_GetItem fixes the build failure when Vim is built with dynamic Python and stable API for Python 3.8.

```
# ./configure --enable-python3interp=dynamic --with-python3-stable-abi
# make
if_py_both.h: In function ‘DictionaryUpdate’:
if_py_both.h:2412:21: error: implicit declaration of function ‘PySequence_Fast_GET_SIZE’ [-Wimplicit-function-declaration]
 2412 |                 if (PySequence_Fast_GET_SIZE(fast) != 2)
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~
if_py_both.h:2423:29: error: implicit declaration of function ‘PySequence_Fast_GET_ITEM’; did you mean ‘PySequence_GetItem’? [-Wimplicit-function-declaration]
 2423 |                 keyObject = PySequence_Fast_GET_ITEM(fast, 0);
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~
      |                             PySequence_GetItem
if_py_both.h:2423:27: error: assignment to ‘PyObject *’ {aka ‘struct _object *’} from ‘int’ makes pointer from integer without a cast [-Wint-conversion]
 2423 |                 keyObject = PySequence_Fast_GET_ITEM(fast, 0);
      |                           ^
if_py_both.h:2445:27: error: assignment to ‘PyObject *’ {aka ‘struct _object *’} from ‘int’ makes pointer from integer without a cast [-Wint-conversion]
 2445 |                 valObject = PySequence_Fast_GET_ITEM(fast, 1);
      |                           ^
```