### PR TITLE
Add out-of-memory check to mark.c

### DIFF
--- a/src/mark.c
+++ b/src/mark.c
@@ -783,6 +783,11 @@ show_one_mark(
 	if (name == NULL && current)
 	{
 	    name = mark_line(p, 15);
+	    if (name == NULL)
+	    {
+		emsg(_(e_out_of_memory));
+		return;
+	    }
 	    mustfree = TRUE;
 	}
 	if (!message_filtered(name))


### PR DESCRIPTION
In `show_one_mark()` add an out-of-memory check to the call of `mark_line()`.

Cheers
John