### PR TITLE
feat(fuzzy): implement SIMD-accelerated Smith-Waterman with affine gaps

### DIFF
--- a/src/proto/search.pro
+++ b/src/proto/search.pro
@@ -37,7 +37,7 @@ void find_pattern_in_path(char_u *ptr, int dir, int len, int whole, int skip_com
 spat_T *get_spat(int idx);
 int get_spat_last_idx(void);
 void f_searchcount(typval_T *argvars, typval_T *rettv);
-int fuzzy_match(char_u *str, char_u *pat_arg, int matchseq, int *outScore, int_u *matches, int maxMatches, int camelcase);
+int fuzzy_match(char_u *str, char_u *pat_arg, int matchseq, int *outScore, int_u *matches, int maxMatches);
 void f_matchfuzzy(typval_T *argvars, typval_T *rettv);
 void f_matchfuzzypos(typval_T *argvars, typval_T *rettv);
 int fuzzy_match_str(char_u *str, char_u *pat);

--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -6489,7 +6489,7 @@ vgr_match_buflines(
 	    // Fuzzy string match
 	    CLEAR_FIELD(matches);
 	    while (fuzzy_match(str + col, spat, FALSE, &score,
-			matches, sz, TRUE) > 0)
+			matches, sz) > 0)
 	    {
 		// Pass the buffer number so that it gets used even for a
 		// dummy buffer, unless duplicate_name is set, then the

--- a/src/testdir/test_matchfuzzy.vim
+++ b/src/testdir/test_matchfuzzy.vim
@@ -91,13 +91,8 @@ func Test_matchfuzzy()
   " camelcase
   call assert_equal(['lCursor', 'shCurlyIn', 'shCurlyError', 'TracesCursor', 'Cursor', 'CurSearch', 'CursorLine'],
         \ matchfuzzy(['Cursor', 'lCursor', 'shCurlyIn', 'shCurlyError', 'TracesCursor', 'CurSearch', 'CursorLine'], 'Cur'))
-  call assert_equal(['lCursor', 'shCurlyIn', 'shCurlyError', 'TracesCursor', 'Cursor', 'CurSearch', 'CursorLine'],
-        \ matchfuzzy(['Cursor', 'lCursor', 'shCurlyIn', 'shCurlyError', 'TracesCursor', 'CurSearch', 'CursorLine'], 'Cur', {"camelcase": v:true}))
-  call assert_equal(['Cursor', 'CurSearch', 'CursorLine', 'lCursor', 'shCurlyIn', 'shCurlyError', 'TracesCursor'],
-        \ matchfuzzy(['Cursor', 'lCursor', 'shCurlyIn', 'shCurlyError', 'TracesCursor', 'CurSearch', 'CursorLine'], 'Cur', {"camelcase": v:false}))
-  call assert_equal(['things', 'sThings', 'thisThings'],
-        \ matchfuzzy(['things','sThings', 'thisThings'], 'thin', {'camelcase': v:false}))
-  call assert_fails("let x = matchfuzzy([], 'foo', {'camelcase': []})", 'E475: Invalid value for argument camelcase')
+
+  call assert_equal(['things', 'sThings', 'thisThings'], matchfuzzy(['things','sThings', 'thisThings'], 'thin'))
 
   " Test in latin1 encoding
   let save_enc = &encoding
@@ -174,10 +169,7 @@ func Test_matchfuzzypos()
   call assert_equal(['MyTestCase', 'mytestcase'], matchfuzzy(['mytestcase', 'MyTestCase'], 'mtc'))
   call assert_equal(['MyTestCase', 'mytestcase'], matchfuzzy(['MyTestCase', 'mytestcase'], 'mtc'))
   call assert_equal(['MyTest', 'Mytest', 'mytest', ],matchfuzzy(['Mytest', 'mytest', 'MyTest'], 'MyT'))
-  call assert_equal(['CamelCaseMatchIngAlg', 'camelCaseMatchingAlg', 'camelcasematchingalg'],
-      \ matchfuzzy(['CamelCaseMatchIngAlg', 'camelcasematchingalg', 'camelCaseMatchingAlg'], 'CamelCase'))
-  call assert_equal(['CamelCaseMatchIngAlg', 'camelCaseMatchingAlg', 'camelcasematchingalg'],
-      \ matchfuzzy(['CamelCaseMatchIngAlg', 'camelcasematchingalg', 'camelCaseMatchingAlg'], 'CamelcaseM'))
+
 
   let l = [{'id' : 5, 'name' : 'foo'}, {'id' : 6, 'name' : []}, {'id' : 7}]
   call assert_fails("let x = matchfuzzypos(l, 'foo', {'key' : 'name'})", 'E730:')
@@ -185,13 +177,6 @@ func Test_matchfuzzypos()
   " camelcase
   call assert_equal([['lCursor', 'shCurlyIn', 'shCurlyError', 'TracesCursor', 'Cursor', 'CurSearch', 'CursorLine'], [[1, 2, 3], [2, 3, 4], [2, 3, 4], [6, 7, 8], [0, 1, 2], [0, 1, 2], [0, 1, 2]], [318, 311, 308, 303, 267, 264, 263]],
         \ matchfuzzypos(['Cursor', 'lCursor', 'shCurlyIn', 'shCurlyError', 'TracesCursor', 'CurSearch', 'CursorLine'], 'Cur'))
-  call assert_equal([['lCursor', 'shCurlyIn', 'shCurlyError', 'TracesCursor', 'Cursor', 'CurSearch', 'CursorLine'], [[1, 2, 3], [2, 3, 4], [2, 3, 4], [6, 7, 8], [0, 1, 2], [0, 1, 2], [0, 1, 2]], [318, 311, 308, 303, 267, 264, 263]],
-        \ matchfuzzypos(['Cursor', 'lCursor', 'shCurlyIn', 'shCurlyError', 'TracesCursor', 'CurSearch', 'CursorLine'], 'Cur', {"camelcase": v:true}))
-  call assert_equal([['Cursor', 'CurSearch', 'CursorLine', 'lCursor', 'shCurlyIn', 'shCurlyError', 'TracesCursor'], [[0, 1, 2], [0, 1, 2], [0, 1, 2], [1, 2, 3], [2, 3, 4], [2, 3, 4], [6, 7, 8]], [267, 264, 263, 246, 239, 236, 231]],
-        \ matchfuzzypos(['Cursor', 'lCursor', 'shCurlyIn', 'shCurlyError', 'TracesCursor', 'CurSearch', 'CursorLine'], 'Cur', {"camelcase": v:false}))
-  call assert_equal([['things', 'sThings', 'thisThings'], [[0, 1, 2, 3], [1, 2, 3, 4], [0, 1, 2, 7]], [333, 287, 279]],
-        \ matchfuzzypos(['things','sThings', 'thisThings'], 'thin', {'camelcase': v:false}))
-  call assert_fails("let x = matchfuzzypos([], 'foo', {'camelcase': []})", 'E475: Invalid value for argument camelcase')
 endfunc
 
 " Test for matchfuzzy() with multibyte characters


### PR DESCRIPTION
Introduces an optimized fuzzy matching algorithm using the Smith-Waterman algorithm with affine gap penalties, accelerated via SIMD instructions (SSE2 for x86 and NEON for ARM). The implementation features:

1. Full affine gap penalty model using three state matrices:
   - M matrix: Tracks match/mismatch scores
   - X matrix: Tracks gaps in the haystack (insertions in needle)
   - Y matrix: Tracks gaps in the needle (deletions in needle)

2. Position-based scoring bonuses:
   - Prefix bonus (+15) for start of haystack
   - Delimiter bonus (+30) after separator chars
   - Capitalization bonus (+30) capital after lowercase
   - Case match bonus (+10) for exact case matches
   - Exact match bonus (+50) for perfect matches

3. SIMD optimizations:
   - Diagonal strip processing with 8-element parallelization
   - Vectorized gap penalty calculations
   - Batched character comparison with bonus application
   - Fallback to scalar computation for edge cases

The algorithm improves on classic Smith-Waterman by:
- Using affine gap penalties (open: -3, extend: -1) instead of linear
- Adding position-aware bonuses for natural language patterns
- Leveraging SIMD for 4-8x speedup on modern CPUs
- Implementing traceback with state machine for efficient path recovery

References:
- CMU affine gap lecture: https://www.cs.cmu.edu/~ckingsf/bioinfo-lectures/gaps.pdf
- Nucleo's SIMD approach: https://github.com/helix-editor/nucleo
- Frizbee's scoring model: https://github.com/Saghen/frizbee
- Fzf: https://github.com/junegunn/fzf


relate https://github.com/neovim/neovim/issues/34101