### PR TITLE
Unused assignment in ex_uniq()

### DIFF
--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -729,15 +729,9 @@ ex_uniq(exarg_T *eap)
 	}
     }
 
-    // Make an array with all line numbers.  This avoids having to copy all
-    // the lines into allocated memory.
-    // When remove deplicating on strings "start_col_nr" is the offset in the
-    // line, for numbers remove deplicating it's the number to uniq on.  This
-    // means the pattern matching only has to be done once per line.
-    // Also get the longest line length for allocating "sortbuf".
+    // Find the length of the longest line.
     for (lnum = eap->line1; lnum <= eap->line2; ++lnum)
     {
-	s = ml_get(lnum);
 	len = ml_get_len(lnum);
 	if (maxlen < len)
 	    maxlen = len;


### PR DESCRIPTION
Problem:  Unused assignment in ex_uniq().
Solution: Remove the assignment and the wrong comments above.
