### PR TITLE
doc: Improve documentation style in editing.txt

### DIFF
--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -1346,7 +1346,7 @@ can add the following as the final filter on Windows: >
 
 	All Files\t(*.*)\t*\n
 <
-or the following on other platforms, so that the user can still access any
+Or the following on other platforms, so that the user can still access any
 desired file: >
 
 	All Files\t(*)\t*\n

--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -1342,15 +1342,15 @@ b:browsefilter variable.  You would most likely set b:browsefilter in a
 filetype plugin, so that the browse dialog would contain entries related to
 the type of file you are currently editing.  Disadvantage: This makes it
 difficult to start editing a file of a different type.  To overcome this, you
-may want to add >
+can add the following as the final filter on Windows: >
 
 	All Files\t(*.*)\t*\n
 <
-as the final filter on Windows or >
+or the following on other platforms, so that the user can still access any
+desired file: >
 
 	All Files\t(*)\t*\n
 <
-on other platforms, so that the user can still access any desired file.
 
 To avoid setting browsefilter when Vim does not actually support it, you can
 use has("browsefilter"): >


### PR DESCRIPTION
Usually, Vim's document provides example code after explanations.  E.g.:
- https://github.com/vim/vim/blob/468c62e4fd155eae08b7265f33838b48b48e5ecc/runtime/doc/options.txt#L222-L223
- https://github.com/vim/vim/blob/468c62e4fd155eae08b7265f33838b48b48e5ecc/runtime/doc/editing.txt#L835-L839
- etc, etc, etc...

However some part of the editing.txt doesn't follow the style, therefore this PR modifies it so that it follows the usual style.