### PR TITLE
Add more translatable messages

### DIFF
--- a/src/drawscreen.c
+++ b/src/drawscreen.c
@@ -734,7 +734,10 @@ win_redr_ruler(win_T *wp, int always, int ignore_pum)
 	    wp->w_p_list = TRUE;
 	}
 
-	bufferlen = vim_snprintf((char *)buffer, RULER_BUF_LEN, "%ld,",
+	// row number, column number is appended
+	// l10n: leave as-is unless a space after the comma is preferred
+	// l10n: do not add any row/column label, due to the limited space
+	bufferlen = vim_snprintf((char *)buffer, RULER_BUF_LEN, _("%ld,"),
 		(wp->w_buffer->b_ml.ml_flags & ML_EMPTY)
 		    ? 0L
 		    : (long)(wp->w_cursor.lnum));

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -3189,7 +3189,8 @@ msg_add_lines(
 
     if (shortmess(SHM_LINES))
 	vim_snprintf((char *)IObuff + len, IOSIZE - (size_t)len,
-		"%s%ldL, %lldB", insert_space ? " " : "", lnum, (varnumber_T)nchars);
+		// l10n: L as in line, B as in byte
+		_("%s%ldL, %lldB"), insert_space ? " " : "", lnum, (varnumber_T)nchars);
     else
     {
 	len += vim_snprintf((char *)IObuff + len, IOSIZE - (size_t)len,


### PR DESCRIPTION
Row/Column indicator separator is currently not customizable. Some languages have a space after the comma as the usual practice, plus this would help translators use a custom separator like colons if necessary.

Additionally, after a save, the line and the byte indicator is also hardcoded, this enables i18n for that as well.