### PR TITLE
Fix the mismatch between the :uniq document's description and examples

### DIFF
--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -2032,7 +2032,7 @@ Also see |:sort-uniq|.
 
 			For example, to remove adjacent duplicate lines based
 			on the second comma-separated field: >
-				:uniq r /[^,]*,/
+				:uniq /[^,]*,/
 <			Or to keep only unique lines ignoring the first 5
 			characters: >
 				:uniq u /.\{5}/


### PR DESCRIPTION
https://github.com/vim/vim/pull/17604#issuecomment-3006626328

The example has been made the same as `:sort`.