### PR TITLE
runtime(netrw): upstream snapshot of v182

### DIFF
--- a/runtime/doc/pi_netrw.txt
+++ b/runtime/doc/pi_netrw.txt
@@ -2735,11 +2735,6 @@ your browsing preferences.  (see also: |netrw-settings|)
 				     rightmouse      : remove file/directory
 				=0: disables mouse maps
 
-  *g:netrw_nobeval*		doesn't exist (default)
-				If this variable exists, then balloon
-				evaluation will be suppressed
-				(see |'ballooneval'|)
-
  *g:netrw_sizestyle*		not defined: actual bytes (default)
 				="b" : actual bytes       (default)
 				="h" : human-readable (ex. 5k, 4m, 3g)

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -7765,7 +7765,6 @@ g:netrw_maxfilenamelen	pi_netrw.txt	/*g:netrw_maxfilenamelen*
 g:netrw_menu	pi_netrw.txt	/*g:netrw_menu*
 g:netrw_mkdir_cmd	pi_netrw.txt	/*g:netrw_mkdir_cmd*
 g:netrw_mousemaps	pi_netrw.txt	/*g:netrw_mousemaps*
-g:netrw_nobeval	pi_netrw.txt	/*g:netrw_nobeval*
 g:netrw_preview	pi_netrw.txt	/*g:netrw_preview*
 g:netrw_rcp_cmd	pi_netrw.txt	/*g:netrw_rcp_cmd*
 g:netrw_remote_mkdir	pi_netrw.txt	/*g:netrw_remote_mkdir*

--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -32,19 +32,11 @@ setl cpo&vim
 "  Netrw Variables: {{{1
 
 " s:NetrwInit: initializes variables if they haven't been defined {{{2
-"            Loosely,  varname = value.
-function s:NetrwInit(varname,value)
-  if !exists(a:varname)
-    if type(a:value) == 0
-      exe "let ".a:varname."=".a:value
-    elseif type(a:value) == 1 && a:value =~ '^[{[]'
-      exe "let ".a:varname."=".a:value
-    elseif type(a:value) == 1
-      exe "let ".a:varname."="."'".a:value."'"
-    else
-      exe "let ".a:varname."=".a:value
+
+function s:NetrwInit(name, default)
+    if !exists(a:name)
+        let {a:name} = a:default
     endif
-  endif
 endfunction
 
 "  Netrw Constants: {{{2
@@ -56,12 +48,6 @@ if !exists("s:LONGLIST")
   call s:NetrwInit("s:TREELIST",3)
   call s:NetrwInit("s:MAXLIST" ,4)
 endif
-
-let s:has_balloon = !has('nvim') &&
-            \ has("balloon_eval") &&
-            \ has("syntax") &&
-            \ exists("g:syntax_on") &&
-            \ !exists("g:netrw_nobeval")
 
 " Default option values: {{{2
 call s:NetrwInit("g:netrw_localcopycmdopt","")
@@ -178,35 +164,35 @@ call s:NetrwInit("g:netrw_dirhistcnt"      , 0)
 let s:xz_opt = has('unix') ? "XZ_OPT=-T0" :
       \ (has("win32") && &shell =~? '\vcmd(\.exe)?$' ?
       \ "setx XZ_OPT=-T0 &&" : "")
-call s:NetrwInit("g:netrw_decompress ", "{"
-      \ .."'.lz4':      'lz4 -d',"
-      \ .."'.lzo':      'lzop -d',"
-      \ .."'.lz':       'lzip -dk',"
-      \ .."'.7z':       '7za x',"
-      \ .."'.001':      '7za x',"
-      \ .."'.zip':      'unzip',"
-      \ .."'.bz':       'bunzip2 -k',"
-      \ .."'.bz2':      'bunzip2 -k',"
-      \ .."'.gz':       'gunzip -k',"
-      \ .."'.lzma':     'unlzma -T0 -k',"
-      \ .."'.xz':       'unxz -T0 -k',"
-      \ .."'.zst':      'zstd -T0 -d',"
-      \ .."'.Z':        'uncompress -k',"
-      \ .."'.tar':      'tar -xvf',"
-      \ .."'.tar.bz':   'tar -xvjf',"
-      \ .."'.tar.bz2':  'tar -xvjf',"
-      \ .."'.tbz':      'tar -xvjf',"
-      \ .."'.tbz2':     'tar -xvjf',"
-      \ .."'.tar.gz':   'tar -xvzf',"
-      \ .."'.tgz':      'tar -xvzf',"
-      \ .."'.tar.lzma': '"..s:xz_opt.." tar -xvf --lzma',"
-      \ .."'.tlz':      '"..s:xz_opt.." tar -xvf --lzma',"
-      \ .."'.tar.xz':   '"..s:xz_opt.." tar -xvfJ',"
-      \ .."'.txz':      '"..s:xz_opt.." tar -xvfJ',"
-      \ .."'.tar.zst':  '"..s:xz_opt.." tar -xvf --use-compress-program=unzstd',"
-      \ .."'.tzst':     '"..s:xz_opt.." tar -xvf --use-compress-program=unzstd',"
-      \ .."'.rar':      '"..(executable("unrar")?"unrar x -ad":"rar x -ad").."'"
-      \ .."}")
+call s:NetrwInit("g:netrw_decompress", {
+            \ '.lz4': 'lz4 -d',
+            \ '.lzo': 'lzop -d',
+            \ '.lz': 'lzip -dk',
+            \ '.7z': '7za x',
+            \ '.001': '7za x',
+            \ '.zip': 'unzip',
+            \ '.bz': 'bunzip2 -k',
+            \ '.bz2': 'bunzip2 -k',
+            \ '.gz': 'gunzip -k',
+            \ '.lzma': 'unlzma -T0 -k',
+            \ '.xz': 'unxz -T0 -k',
+            \ '.zst': 'zstd -T0 -d',
+            \ '.Z': 'uncompress -k',
+            \ '.tar': 'tar -xvf',
+            \ '.tar.bz': 'tar -xvjf',
+            \ '.tar.bz2': 'tar -xvjf',
+            \ '.tbz': 'tar -xvjf',
+            \ '.tbz2': 'tar -xvjf',
+            \ '.tar.gz': 'tar -xvzf',
+            \ '.tgz': 'tar -xvzf',
+            \ '.tar.lzma': s:xz_opt .. ' tar -xvf --lzma',
+            \ '.tlz': s:xz_opt .. ' tar -xvf --lzma',
+            \ '.tar.xz': s:xz_opt .. ' tar -xvfJ',
+            \ '.txz': s:xz_opt .. ' tar -xvfJ',
+            \ '.tar.zst': s:xz_opt .. ' tar -xvf --use-compress-program=unzstd',
+            \ '.tzst': s:xz_opt .. ' tar -xvf --use-compress-program=unzstd',
+            \ '.rar': (executable("unrar")?"unrar x -ad":"rar x -ad"),
+            \ })
 unlet s:xz_opt
 call s:NetrwInit("g:netrw_dirhistmax"       , 10)
 call s:NetrwInit("g:netrw_fastbrowse"       , 1)
@@ -395,19 +381,13 @@ if has("gui_running") && (&enc == 'utf-8' || &enc == 'utf-16' || &enc == 'ucs-4'
 else
   let s:treedepthstring= "| "
 endif
-call s:NetrwInit("s:netrw_posn",'{}')
+call s:NetrwInit("s:netrw_posn", {})
 
 " BufEnter event ignored by decho when following variable is true
 "  Has a side effect that doau BufReadPost doesn't work, so
 "  files read by network transfer aren't appropriately highlighted.
 
 "  Netrw Initialization: {{{1
-if s:has_balloon
-  let &l:bexpr = "netrw#BalloonHelp()"
-  au FileType netrw setl beval
-  au WinLeave * if &ft == "netrw" && exists("s:initbeval") | let &beval = s:initbeval | endif
-  au VimEnter * let s:initbeval = &beval
-endif
 
 au WinEnter * if &ft == "netrw" | call s:NetrwInsureWinVars() | endif
 
@@ -419,48 +399,6 @@ else
 endif
 
 "  Netrw Utility Functions: {{{1
-
-" netrw#BalloonHelp: {{{2
-
-if s:has_balloon
-    function netrw#BalloonHelp()
-        if exists("s:popuperr_id") && popup_getpos(s:popuperr_id) != {}
-            if exists("s:popuperr_text") && s:popuperr_text != "" && v:beval_text != s:popuperr_text
-                " text under mouse hasn't changed; only close window when it changes
-                call popup_close(s:popuperr_id)
-                unlet s:popuperr_text
-            else
-                let s:popuperr_text= v:beval_text
-            endif
-            return ""
-
-        elseif v:beval_text == "Netrw" || v:beval_text == "Directory" || v:beval_text == "Listing"
-            return "i: thin-long-wide-tree  gh: quick hide/unhide of dot-files   qf: quick file info  %:open new file"
-
-        elseif getline(v:beval_lnum) =~ '^"\s*/'
-            return "<cr>: edit/enter   o: edit/enter in horiz window   t: edit/enter in new tab   v:edit/enter in vert window"
-
-        elseif v:beval_text == "Sorted" || v:beval_text == "by"
-            return 's: sort by name, time, file size, extension   r: reverse sorting order   mt: mark target'
-
-        elseif v:beval_text == "Sort"   || v:beval_text == "sequence"
-            return "S: edit sorting sequence"
-
-        elseif v:beval_text == "Hiding" || v:beval_text == "Showing"
-            return "a: hiding-showing-all   ctrl-h: editing hiding list   mh: hide/show by suffix"
-
-        elseif v:beval_text == "Quick" || v:beval_text == "Help"
-            return "Help: press <F1>"
-
-        elseif v:beval_text == "Copy/Move" || v:beval_text == "Tgt"
-            return "mt: mark target   mc: copy marked file to target   mm: move marked file to target"
-
-        endif
-
-        return ""
-    endfunction
-endif
-
 " netrw#Explore: launch the local browser in the directory of the current file {{{2
 "          indx:  == -1: Nexplore
 "                 == -2: Pexplore
@@ -3242,11 +3180,6 @@ function s:NetrwBrowse(islocal,dirname)
         NetrwKeepj call s:SetRexDir(a:islocal,b:netrw_curdir)
     endif
 
-    if s:has_balloon && &beval == 0 && &l:bexpr == ""
-        let &l:bexpr= "netrw#BalloonHelp()"
-        setl beval
-    endif
-
     " repoint t:netrw_lexbufnr if appropriate
     if exists("repointlexbufnr")
         let t:netrw_lexbufnr= bufnr("%")
@@ -3818,7 +3751,7 @@ endfunction
 "    cursor=0: newdir is relative to b:netrw_curdir
 "          =1: newdir is relative to the path to the word under the cursor in
 "              tree view
-function s:NetrwBrowseChgDir(islocal,newdir,cursor,...)
+function s:NetrwBrowseChgDir(islocal, newdir, cursor, ...)
     let ykeep= @@
     if !exists("b:netrw_curdir")
         let @@= ykeep
@@ -3831,29 +3764,22 @@ function s:NetrwBrowseChgDir(islocal,newdir,cursor,...)
     NetrwKeepj call s:NetrwOptionsSafe(a:islocal)
 
     let newdir = a:newdir
-    if a:cursor && exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST && exists("w:netrw_treetop")
+    let dirname = b:netrw_curdir
+
+    if a:cursor && w:netrw_liststyle == s:TREELIST
         " dirname is the path to the word under the cursor
         let dirname = s:NetrwTreePath(w:netrw_treetop)
-        " newdir resolves to a directory and points to a directory in dirname
-        " /tmp/test/folder_symlink/ -> /tmp/test/original_folder/
-        if a:islocal && fnamemodify(dirname, ':t') == newdir && isdirectory(resolve(dirname)) && resolve(dirname) == resolve(newdir)
-            let dirname = fnamemodify(resolve(dirname), ':p:h:h')
-            let newdir = fnamemodify(resolve(newdir), ':t')
-        endif
-        " Remove trailing "/"
-        let dirname = substitute(dirname, "/$", "", "")
-
         " If the word under the cursor is a directory (except for ../), NetrwTreePath
         " returns the full path, including the word under the cursor, remove it
-        if newdir =~ "/$" && newdir != "../"
+        if newdir != "../"
             let dirname = fnamemodify(dirname, ":h")
         endif
-    else
-        let dirname = b:netrw_curdir
     endif
+
     if has("win32")
-        let dirname = substitute(dirname,'\\','/','ge')
+        let dirname = substitute(dirname, '\\', '/', 'ge')
     endif
+
     let dolockout = 0
     let dorestore = 1
 
@@ -3871,19 +3797,9 @@ function s:NetrwBrowseChgDir(islocal,newdir,cursor,...)
     endif
 
     " set up o/s-dependent directory recognition pattern
-    if has("amiga")
-        let dirpat= '[\/:]$'
-    else
-        let dirpat= '[\/]$'
-    endif
+    let dirpat = has("amiga") ? '[\/:]$' : '[\/]$'
 
-    if dirname !~ dirpat
-        " apparently vim is "recognizing" that it is in a directory and
-        " is removing the trailing "/".  Bad idea, so let's put it back.
-        let dirname= dirname.'/'
-    endif
-
-    if newdir !~ dirpat && !(a:islocal && isdirectory(s:NetrwFile(netrw#fs#ComposePath(dirname,newdir))))
+    if newdir !~ dirpat && !(a:islocal && isdirectory(s:NetrwFile(netrw#fs#ComposePath(dirname, newdir))))
         " ------------------------------
         " NetrwBrowseChgDir: edit a file {{{3
         " ------------------------------
@@ -3891,17 +3807,10 @@ function s:NetrwBrowseChgDir(islocal,newdir,cursor,...)
         " save position for benefit of Rexplore
         let s:rexposn_{bufnr("%")}= winsaveview()
 
-        if exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST && exists("w:netrw_treedict") && newdir !~ '^\(/\|\a:\)'
-            if dirname =~ '/$'
-                let dirname= dirname.newdir
-            else
-                let dirname= dirname."/".newdir
-            endif
-        elseif newdir =~ '^\(/\|\a:\)'
-            let dirname= newdir
-        else
-            let dirname= netrw#fs#ComposePath(dirname,newdir)
-        endif
+        let dirname = isabsolutepath(newdir)
+                    \ ? netrw#fs#AbsPath(newdir)
+                    \ : netrw#fs#ComposePath(dirname, newdir)
+
         " this lets netrw#BrowseX avoid the edit
         if a:0 < 1
             NetrwKeepj call s:NetrwOptionsRestore("s:")
@@ -3974,6 +3883,7 @@ function s:NetrwBrowseChgDir(islocal,newdir,cursor,...)
                 " if e the new file would fail due to &mod, then don't change any of the flags
                 let dolockout= 1
             endif
+
             if a:islocal
                 " some like c-^ to return to the last edited file
                 " others like c-^ to return to the netrw buffer
@@ -3985,7 +3895,6 @@ function s:NetrwBrowseChgDir(islocal,newdir,cursor,...)
                     " file came from vim's hidden storage.  Don't "restore" options with it.
                     let dorestore= 0
                 endif
-            else
             endif
 
             " handle g:Netrw_funcref -- call external-to-netrw functions
@@ -4025,6 +3934,8 @@ function s:NetrwBrowseChgDir(islocal,newdir,cursor,...)
         " --------------------------------------
         " NetrwBrowseChgDir: go up one directory {{{3
         " --------------------------------------
+
+        let dirname = netrw#fs#Dirname(dirname)
 
         if w:netrw_liststyle == s:TREELIST && exists("w:netrw_treedict")
             " force a refresh
@@ -4213,104 +4124,30 @@ endfunction
 
 " netrw#BrowseX:  (implements "x") executes a special "viewer" script or program for the {{{2
 "              given filename; typically this means given their extension.
-"              0=local, 1=remote
-function netrw#BrowseX(fname,remote)
-    if a:remote == 1 && a:fname !~ '^https\=:' && a:fname =~ '/$'
-        " remote directory, not a webpage access, looks like an attempt to do a directory listing
-        norm! gf
-    endif
-
-    if exists("g:netrw_browsex_viewer") && exists("g:netrw_browsex_support_remote") && !g:netrw_browsex_support_remote
-        let remote = a:remote
-    else
-        let remote = 0
-    endif
-
-    let ykeep      = @@
-    let screenposn = winsaveview()
-
-    " need to save and restore aw setting as gx can invoke this function from non-netrw buffers
-    let awkeep     = &aw
-    set noaw
-
+function netrw#BrowseX(fname)
     " special core dump handler
-    if a:fname =~ '/core\(\.\d\+\)\=$'
-        if exists("g:Netrw_corehandler")
-            if type(g:Netrw_corehandler) == 2
-                " g:Netrw_corehandler is a function reference (see :help Funcref)
-                call g:Netrw_corehandler(s:NetrwFile(a:fname))
-            elseif type(g:Netrw_corehandler) == 3
-                " g:Netrw_corehandler is a List of function references (see :help Funcref)
-                for Fncref in g:Netrw_corehandler
-                    if type(Fncref) == 2
-                        call Fncref(a:fname)
-                    endif
-                endfor
-            endif
-            call winrestview(screenposn)
-            let @@= ykeep
-            let &aw= awkeep
-            return
+    if a:fname =~ '/core\(\.\d\+\)\=$' && exists("g:Netrw_corehandler")
+        if type(g:Netrw_corehandler) == v:t_func
+            " g:Netrw_corehandler is a function reference (see :help Funcref)
+            call g:Netrw_corehandler(s:NetrwFile(a:fname))
+        elseif type(g:Netrw_corehandler) == v:t_list
+            " g:Netrw_corehandler is a List of function references (see :help Funcref)
+            for Fncref in g:Netrw_corehandler
+                if type(Fncref) == v:t_func
+                    call Fncref(a:fname)
+                endif
+            endfor
         endif
+        return
     endif
 
-    " set up the filename
-    " (lower case the extension, make a local copy of a remote file)
-    let exten= substitute(a:fname,'.*\.\(.\{-}\)','\1','e')
-    if has("win32")
-        let exten= substitute(exten,'^.*$','\L&\E','')
-    endif
-    if exten =~ "[\\/]"
-        let exten= ""
+    let fname = a:fname
+    " special ~ handler for local
+    if fname =~ '^\~' && expand("$HOME") != ""
+        let fname = substitute(fname, '^\~', expand("$HOME"), '')
     endif
 
-    if remote == 1
-        " create a local copy
-        setl bh=delete
-        call netrw#NetRead(3,a:fname)
-        " attempt to rename tempfile
-        let basename= substitute(a:fname,'^\(.*\)/\(.*\)\.\([^.]*\)$','\2','')
-        let newname = substitute(s:netrw_tmpfile,'^\(.*\)/\(.*\)\.\([^.]*\)$','\1/'.basename.'.\3','')
-        if s:netrw_tmpfile != newname && newname != ""
-            if rename(s:netrw_tmpfile,newname) == 0
-                " renaming succeeded
-                let fname= newname
-            else
-                " renaming failed
-                let fname= s:netrw_tmpfile
-            endif
-        else
-            let fname= s:netrw_tmpfile
-        endif
-    else
-        let fname= a:fname
-        " special ~ handler for local
-        if fname =~ '^\~' && expand("$HOME") != ""
-            let fname= s:NetrwFile(substitute(fname,'^\~',expand("$HOME"),''))
-        endif
-    endif
-
-    call netrw#os#Open(fname)
-
-    " cleanup: remove temporary file,
-    "          delete current buffer if success with handler,
-    "          return to prior buffer (directory listing)
-    "          Feb 12, 2008: had to de-activate removal of
-    "          temporary file because it wasn't getting seen.
-    "  if remote == 1 && fname != a:fname
-    "   call s:NetrwDelete(fname)
-    "  endif
-
-    if remote == 1
-        setl bh=delete bt=nofile
-        if g:netrw_use_noswf
-            setl noswf
-        endif
-        exe "sil! NetrwKeepj norm! \<c-o>"
-    endif
-    call winrestview(screenposn)
-    let @@ = ykeep
-    let &aw= awkeep
+    call netrw#os#Open(s:NetrwFile(fname))
 endfunction
 
 " s:NetrwBufRename: renames a buffer without the side effect of retaining an unlisted buffer having the old name {{{2
@@ -5050,7 +4887,7 @@ function s:NetrwMaps(islocal)
         nnoremap <buffer> <silent> <nowait> u        :<c-u>call <SID>NetrwBookHistHandler(4,expand("%"))<cr>
         nnoremap <buffer> <silent> <nowait> U        :<c-u>call <SID>NetrwBookHistHandler(5,expand("%"))<cr>
         nnoremap <buffer> <silent> <nowait> v        :call <SID>NetrwSplit(5)<cr>
-        nnoremap <buffer> <silent> <nowait> x        :<c-u>call netrw#BrowseX(<SID>NetrwBrowseChgDir(1,<SID>NetrwGetWord(),1,0),0)"<cr>
+        nnoremap <buffer> <silent> <nowait> x        :<c-u>call netrw#BrowseX(<SID>NetrwBrowseChgDir(1,<SID>NetrwGetWord(),1,0))"<cr>
         nnoremap <buffer> <silent> <nowait> X        :<c-u>call <SID>NetrwLocalExecute(expand("<cword>"))"<cr>
 
         nnoremap <buffer> <silent> <nowait> r        :<c-u>let g:netrw_sort_direction= (g:netrw_sort_direction =~# 'n')? 'r' : 'n'<bar>exe "norm! 0"<bar>call <SID>NetrwRefresh(1,<SID>NetrwBrowseChgDir(1,'./',0))<cr>
@@ -5163,8 +5000,6 @@ function s:NetrwMaps(islocal)
         nnoremap <buffer> <silent> <nowait> u        :<c-u>call <SID>NetrwBookHistHandler(4,b:netrw_curdir)<cr>
         nnoremap <buffer> <silent> <nowait> U        :<c-u>call <SID>NetrwBookHistHandler(5,b:netrw_curdir)<cr>
         nnoremap <buffer> <silent> <nowait> v        :call <SID>NetrwSplit(2)<cr>
-        nnoremap <buffer> <silent> <nowait> x        :<c-u>call netrw#BrowseX(<SID>NetrwBrowseChgDir(0,<SID>NetrwGetWord(),1),1)<cr>
-        nmap     <buffer>          <nowait> gx       x
         if !hasmapto('<Plug>NetrwHideEdit')
             nmap <buffer> <c-h> <Plug>NetrwHideEdit
         endif
@@ -6617,8 +6452,7 @@ function s:NetrwMenu(domenu)
         elseif !a:domenu
             let s:netrwcnt = 0
             let curwin     = winnr()
-            keepjumps windo if getline(2) =~# "Netrw"
-            let s:netrwcnt = s:netrwcnt + 1
+            windo if getline(2) =~# "Netrw" | let s:netrwcnt= s:netrwcnt + 1 | endif
         endif
         exe curwin."wincmd w"
 
@@ -7766,7 +7600,9 @@ function s:PerformListing(islocal)
 
     " get list of files
     if a:islocal
-        NetrwKeepj call s:LocalListing()
+        let filelist = s:NetrwLocalListingList(b:netrw_curdir, 1)
+        call append(w:netrw_bannercnt - 1, filelist)
+        execute printf("setl ts=%d", g:netrw_maxfilenamelen + 1)
     else " remote
         NetrwKeepj let badresult= s:NetrwRemoteListing()
         if badresult
@@ -8630,8 +8466,7 @@ function s:NetrwLocalListingList(dirname,setmaxfilenamelen)
     " get the list of files contained in the current directory
     let dirname    = a:dirname
     let dirnamelen = strlen(dirname)
-    let filelist   = netrw#fs#Glob(dirname,"*",0)
-    let filelist   = filelist + netrw#fs#Glob(dirname,".*",0)
+    let filelist   = map(['.', '..'] + readdir(dirname), 'netrw#fs#PathJoin(dirname, v:val)')
 
     if g:netrw_cygwin == 0 && has("win32")
     elseif index(filelist,'..') == -1 && dirname !~ '/'
@@ -8647,19 +8482,20 @@ function s:NetrwLocalListingList(dirname,setmaxfilenamelen)
     let resultfilelist = []
     for filename in filelist
 
-        if getftype(filename) == "link"
+        let ftype = getftype(filename)
+        if ftype ==# "link"
             " indicate a symbolic link
             let pfile= filename."@"
 
-        elseif getftype(filename) == "socket"
+        elseif ftype ==# "socket"
             " indicate a socket
             let pfile= filename."="
 
-        elseif getftype(filename) == "fifo"
+        elseif ftype ==# "fifo"
             " indicate a fifo
             let pfile= filename."|"
 
-        elseif isdirectory(s:NetrwFile(filename))
+        elseif ftype ==# "dir"
             " indicate a directory
             let pfile= filename."/"
 
@@ -8726,21 +8562,6 @@ function s:NetrwLocalListingList(dirname,setmaxfilenamelen)
     endfor
 
     return resultfilelist
-endfunction
-
-"  s:LocalListing: does the job of "ls" for local directories {{{2
-function s:LocalListing()
-
-    let filelist = s:NetrwLocalListingList(b:netrw_curdir, 1)
-    for filename in filelist
-        sil! NetrwKeepj put =filename
-    endfor
-
-    " cleanup any windows mess at end-of-line
-    sil! NetrwKeepj g/^$/d
-    sil! NetrwKeepj %s/\r$//e
-    call histdel("/",-1)
-    exe "setl ts=".(g:netrw_maxfilenamelen+1)
 endfunction
 
 " s:NetrwLocalExecute: uses system() to execute command under cursor ("X" command support) {{{2
@@ -9380,11 +9201,6 @@ function s:NetrwEnew(...)
             endif
         endif
     endif
-
-    if s:has_balloon
-        let &l:bexpr = "netrw#BalloonHelp()"
-    endif
-
 endfunction
 
 " s:NetrwInsureWinVars: insure that a netrw buffer has its w: variables in spite of a wincmd v or s {{{2

--- a/runtime/pack/dist/opt/netrw/autoload/netrw/fs.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw/fs.vim
@@ -72,18 +72,22 @@ endfunction
 " }}}
 " netrw#fs#AbsPath: returns the full path to a directory and/or file {{{
 
-function! netrw#fs#AbsPath(filename)
-    let filename = a:filename
+function! netrw#fs#AbsPath(path)
+    let path = a:path->substitute(s:slash . '$', '', 'e')
 
-    if filename !~ '^/'
-        let filename = resolve(getcwd() . '/' . filename)
+    " Nothing to do
+    if isabsolutepath(path)
+        return path
     endif
 
-    if filename != "/" && filename =~ '/$'
-        let filename = substitute(filename, '/$', '', '')
-    endif
+    return path->fnamemodify(':p')->substitute(s:slash . '$', '', 'e')
+endfunction
 
-    return filename
+" }}}
+" netrw#fs#Dirname: {{{
+
+function netrw#fs#Dirname(path)
+    return netrw#fs#AbsPath(a:path)->fnamemodify(':h')
 endfunction
 
 " }}}

--- a/runtime/pack/dist/opt/netrw/doc/netrw.txt
+++ b/runtime/pack/dist/opt/netrw/doc/netrw.txt
@@ -2735,11 +2735,6 @@ your browsing preferences.  (see also: |netrw-settings|)
 				     rightmouse      : remove file/directory
 				=0: disables mouse maps
 
-  *g:netrw_nobeval*		doesn't exist (default)
-				If this variable exists, then balloon
-				evaluation will be suppressed
-				(see |'ballooneval'|)
-
  *g:netrw_sizestyle*		not defined: actual bytes (default)
 				="b" : actual bytes       (default)
 				="h" : human-readable (ex. 5k, 4m, 3g)


### PR DESCRIPTION
relevant commits:
- refactor: cleanup netrw#BrowseX
- fix: correctly handle symlinks in treeview
- chore: add minimalrc for reproducing issues
- refactor: simplify s:NetrwInit with the 'newer' assignment syntax
- refactor: remove balloon functionality
- Tune local file listing especially for Windows network drives
- interim fix for browse open with multiple windows