### PR TITLE
Make sure the user gets VI if they ask for it

### DIFF
--- a/runtime/defaults.vim
+++ b/runtime/defaults.vim
@@ -1,7 +1,7 @@
 " The default vimrc file.
 "
 " Maintainer:	The Vim Project <https://github.com/vim/vim>
-" Last Change:	2025 Apr 10
+" Last Change:	2025 Jun 27
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 "
 " This is loaded if no vimrc file was found.
@@ -11,6 +11,11 @@
 
 " When started as "evim", evim.vim will already have done these settings.
 if v:progname =~? "evim"
+  finish
+endif
+
+" If the user wants "vi", let's make sure they get the VI-experience
+if v:progname ==# 'vi'
   finish
 endif
 


### PR DESCRIPTION
Currently when a user types `vi` on a fresh macOS or on a fresh Debian, they end up with `vim` launched in `nocompatible` mode.
Thatʼs because `vi` on those UNIX-like platforms is just a symlink to `vim` and `vim` will load the `defaults.vim`.

This makes those downstream platforms non-POSIX compliant when it comes to `vi`.

Letʼs help downstream and make sure that when a user wants `vi` they get the VI-experience.