### PR TITLE
doc: fix :vmap example to avoid unwanted spaces with JJ

### DIFF
--- a/runtime/doc/visual.txt
+++ b/runtime/doc/visual.txt
@@ -392,7 +392,7 @@ want only part of the line to be replaced you will have to make a mapping for
 it.  In a future release ":" may work on partial lines.
 
 Here is an example, to replace the selected text with the output of "date": >
-	:vmap _a <Esc>`>a<CR><Esc>`<i<CR><Esc>!!date<CR>kJJ
+	:vmap _a <Esc>`>a<CR><Esc>`<i<CR><Esc>!!date<CR>kgJgJ
 
 (In the <> notation |<>|, when typing it you should type it literally; you
 need to remove the 'B' and '<' flags from 'cpoptions')


### PR DESCRIPTION
This PR fixes #17621 by replacing JJ with gJgJ to prevent the insertion of unwanted spaces when joining lines. The updated macro now behaves as expected.