### PR TITLE
Don't use $XDG_SEAT when determining Wayland seat

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -10086,8 +10086,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	specifically the clipboard.  If the seat does not exist, then the
 	option will still be set to the new value, with the Wayland clipboard
 	being unavailable as a result.  If an empty value is passed then Vim
-	will attempt to use the value of $XDG_SEAT if it exists, if not then
-	it resorts to using the first seat found available.  Updating this
+	will attempt to use the first seat found available.  Updating this
 	option will also update |v:clipmethod|.
 
 				*'wlsteal'* *'wst'* *'nowlsteal'* *'nowst'*

--- a/src/wayland.c
+++ b/src/wayland.c
@@ -907,21 +907,14 @@ vwl_destroy_seat(vwl_seat_T *seat)
 
 /*
  * Return a seat with the give name/label. If none exists then NULL is returned.
- * If NULL or an empty string is passed as the label then $XDG_SEAT is used
- * else the first available seat found is used.
+ * If NULL or an empty string is passed as the label then the first available
+ * seat found is used.
  */
     static vwl_seat_T *
 vwl_get_seat(const char *label)
 {
     if ((STRCMP(label, "") == 0 || label == NULL) && vwl_seats.ga_len > 0)
-    {
-	const char *xdg_seat = (char*)mch_getenv("XDG_SEAT");
-
-	if (xdg_seat == NULL)
 	    return &((vwl_seat_T *)vwl_seats.ga_data)[0];
-	else
-	    label = xdg_seat;
-    }
 
     for (int i = 0; i < vwl_seats.ga_len; i++)
     {


### PR DESCRIPTION
$XDG_SEAT is meant for seats, not Wayland seats. Remove the functionality for using it as a way to find the Wayland seat.