### PR TITLE
The tutor-mode files are not copied in the installer.

### DIFF
--- a/nsis/gvim.nsi
+++ b/nsis/gvim.nsi
@@ -498,7 +498,7 @@ Section "$(str_section_exe)" id_section_exe
 	File ${VIMRT}\tools\*.*
 
 	SetOutPath $0\tutor
-	File /x Makefile /x *.info ${VIMRT}\tutor\*.*
+	File /r /x *.info ${VIMRT}\tutor\*.*
 SectionEnd
 
 ##########################################################


### PR DESCRIPTION
Problem: missing directories and files \<lang>\\*.tutor (see [comment#issuecomment-3006573326](https://github.com/vim/vim/pull/17600#issuecomment-3006573326))
Solution: added the `/r` switch for recursive processing of the "tutor" directory.
Also closing the [issue vim-win32-istaller#382](https://github.com/vim/vim-win32-installer/issues/382) in the _vim-win32-installer_ repository.
Other: The `/x makefile` switch has been removed, as it is no longer required, see commit 8d9d2b2