### PR TITLE
CI changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,6 +319,13 @@ jobs:
         run: |
           make ${SHADOWOPT} ${TEST}
 
+      # Enable to debug failing tests live and ssh into the CI runners
+      # - name: Setup tmate session
+      #   if: ${{ failure() }}
+      #   uses: mxschmitt/action-tmate@v3
+      #   with:
+      #     limit-access-to-actor: true
+
       - if: ${{ !cancelled() }}
         uses: ./.github/actions/test_artifacts
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -729,16 +729,17 @@ jobs:
       #    name: vim${{ matrix.bits }}-${{ matrix.toolchain }}
       #    path: ./artifacts
 
-      - name: Install packages for testing
-        shell: bash
-        run: |
-          if ${{ matrix.features != 'TINY' }}; then
-            if ${{ matrix.arch == 'x64' }}; then
-              choco install netbeans --no-progress
-            else
-              exit 0
-            fi
-          fi
+      # disabled because of https://github.com/tunisiano187/Chocolatey-packages/issues/3916
+      #- name: Install packages for testing
+      #  shell: bash
+      #  run: |
+      #    if ${{ matrix.features != 'TINY' }}; then
+      #      if ${{ matrix.arch == 'x64' }}; then
+      #        choco install netbeans --no-progress
+      #      else
+      #        exit 0
+      #      fi
+      #    fi
 
       - name: Test and show the result of testing gVim
         if: matrix.GUI == 'yes' || matrix.VIMDLL == 'yes'


### PR DESCRIPTION
This PR does 2 things:
- disable installing netbeans package until https://github.com/tunisiano187/Chocolatey-packages/issues/3916 has been resolved
- optionally enable [tmate](https://github.com/mxschmitt/action-tmate) to allow easier debugging of failing tests. Note this is commented out, but you can uncomment it in your own fork and ssh into failing containers.