### PR TITLE
filetype: no support for numbat files

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1765,6 +1765,9 @@ au BufNewFile,BufRead *.nt			setf ntriples
 " Nu
 au BufNewFile,BufRead *.nu		setf nu
 
+" Numbat
+au BufNewFile,BufRead *.nbt		setf numbat
+
 " Oblivion Language and Oblivion Script Extender
 au BufNewFile,BufRead *.obl,*.obse,*.oblivion,*.obscript  setf obse
 

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -565,6 +565,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     nsis: ['file.nsi', 'file.nsh'],
     ntriples: ['file.nt'],
     nu: ['file.nu'],
+    numbat: ['file.nbt'],
     obj: ['file.obj'],
     objdump: ['file.objdump', 'file.cppobjdump'],
     obse: ['file.obl', 'file.obse', 'file.oblivion', 'file.obscript'],


### PR DESCRIPTION
filetype for https://github.com/sharkdp/numbat

you can see the extension being used in both of these links:
https://github.com/sharkdp/numbat/tree/master/numbat/modules
https://numbat.dev/doc/cli-customization.html#custom-functions-constants-units