### PR TITLE
filetype: no support for haxe files

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1097,6 +1097,9 @@ au BufNewFile,BufRead *.persistentmodels	setf haskellpersistent
 au BufNewFile,BufRead *.ht			setf haste
 au BufNewFile,BufRead *.htpp			setf hastepreproc
 
+" Haxe
+au BufNewFile,BufRead *.hx			setf haxe
+
 " HCL
 au BufRead,BufNewFile *.hcl			setf hcl
 

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -347,6 +347,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     haskellpersistent: ['file.persistentmodels'],
     haste: ['file.ht'],
     hastepreproc: ['file.htpp'],
+    haxe: ['file.hx'],
     hb: ['file.hb'],
     hcl: ['file.hcl'],
     heex: ['file.heex'],


### PR DESCRIPTION
filetype for https://haxe.org/

you can see the file extension being used in the hello world example:
https://code.haxe.org/category/beginner/hello-world.html

> This tutorial demonstrates how to write and compile a Hello World Haxe program. It explains the involved file-format (.hx) and gives a basic explanation of what the Haxe Compiler does with them.