### PR TITLE
filetype: no support for quickbms files

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -2086,6 +2086,9 @@ au BufRead,BufNewFile qmldir			setf qmldir
 " Quarto
 au BufRead,BufNewFile *.qmd			setf quarto
 
+" QuickBms
+au BufRead,BufNewFile *.bms			setf quickbms
+
 " Racket (formerly detected as "scheme")
 au BufNewFile,BufRead *.rkt,*.rktd,*.rktl	setf racket
 

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -641,6 +641,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     qmldir: ['qmldir'],
     quake: ['anybaseq2/file.cfg', 'anyid1/file.cfg', 'quake3/file.cfg', 'baseq2/file.cfg', 'id1/file.cfg', 'quake1/file.cfg', 'some-baseq2/file.cfg', 'some-id1/file.cfg', 'some-quake1/file.cfg'],
     quarto: ['file.qmd'],
+    quickbms: ['file.bms'],
     r: ['file.r', '.Rhistory', '.Rprofile', 'Rprofile', 'Rprofile.site'],
     racket: ['file.rkt', 'file.rktd', 'file.rktl'],
     radiance: ['file.rad', 'file.mat'],


### PR DESCRIPTION
filetype for https://aluigi.altervista.org/quickbms.htm

example of plenty of scripts already using this extension for it:
https://github.com/search?q=quickbms+path%3A%2F%5C.bms%24%2F&type=code