### PR TITLE
filetype: no support for flix files

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -893,6 +893,9 @@ au BufNewFile,BufRead *.fish			setf fish
 " Flatpak config
 au BufNewFile,BufRead */flatpak/repo/config	setf dosini
 
+" Flix
+au BufNewFile,BufRead *.flix			setf flix
+
 " Focus Executable
 au BufNewFile,BufRead *.fex,*.focexec		setf focexec
 

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -287,6 +287,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     fgl: ['file.4gl', 'file.4gh', 'file.m4gl'],
     firrtl: ['file.fir'],
     fish: ['file.fish'],
+    flix: ['file.flix'],
     focexec: ['file.fex', 'file.focexec'],
     form: ['file.frm'],
     forth: ['file.ft', 'file.fth', 'file.4th'],


### PR DESCRIPTION
add filetype for https://flix.dev/

example of getting started guide adding the filetype detection for neovim:

https://doc.flix.dev/getting-started.html#:~:text=Set%20Flix%20as%20the%20filetype (you might have to reload the page to get it to scroll correctly)