### PR TITLE
feat: allow functions in 'complete' to complete from non-keyword

### DIFF
--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -648,7 +648,7 @@ Completion can be done for:
 10. User defined completion				|i_CTRL-X_CTRL-U|
 11. omni completion					|i_CTRL-X_CTRL-O|
 12. Spelling suggestions				|i_CTRL-X_s|
-13. keywords in 'complete'				|i_CTRL-N| |i_CTRL-P|
+13. completions from 'complete'				|i_CTRL-N| |i_CTRL-P|
 14. contents from registers				|i_CTRL-X_CTRL-R|
 
 Additionally, |i_CTRL-X_CTRL-Z| stops completion without changing the text.
@@ -1103,25 +1103,23 @@ CTRL-X s		Locate the word in front of the cursor and find the
 			previous one.
 
 
-Completing keywords from different sources		*compl-generic*
+Completing from different sources			*compl-generic*
 
 							*i_CTRL-N*
-CTRL-N			Find next match for words that start with the
-			keyword in front of the cursor, looking in places
-			specified with the 'complete' option.  The found
-			keyword is inserted in front of the cursor.
+CTRL-N			Find the next match for a word ending at the cursor,
+			using the sources specified in the 'complete' option.
+			All sources complete from keywords, except functions,
+			which may complete from non-keyword.  The matched
+			text is inserted before the cursor.
 
 							*i_CTRL-P*
-CTRL-P			Find previous match for words that start with the
-			keyword in front of the cursor, looking in places
-			specified with the 'complete' option.  The found
-			keyword is inserted in front of the cursor.
+CTRL-P			Same as CTRL-N, but find the previous match.
 
-	CTRL-N		Search forward for next matching keyword.  This
-			keyword replaces the previous matching keyword.
+	CTRL-N		Search forward through the matches and insert the
+			next one.
 
-	CTRL-P		Search backwards for next matching keyword.  This
-			keyword replaces the previous matching keyword.
+	CTRL-P		Search backward through the matches and insert the
+			previous one.
 
 	CTRL-X CTRL-N or
 	CTRL-X CTRL-P	Further use of CTRL-X CTRL-N or CTRL-X CTRL-P will

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2123,15 +2123,12 @@ A jump table for the options with a short description can be found at |Q_op|.
 		name of a function or a |Funcref|.  For |Funcref| values,
 		spaces must be escaped with a backslash ('\'), and commas with
 		double backslashes ('\\') (see |option-backslash|).
+		Unlike other sources, functions can provide completions starting
+		from a non-keyword character before the cursor, and their
+		start position for replacing text may differ from other sources.
 		If the Dict returned by the {func} includes {"refresh": "always"},
 		the function will be invoked again whenever the leading text
 		changes.
-		Completion matches are always inserted at the keyword
-		boundary, regardless of the column returned by {func} when
-		a:findstart is 1.  This ensures compatibility with other
-		completion sources.
-		To make further modifications to the inserted text, {func}
-		can make use of |CompleteDonePre|.
 		If generating matches is potentially slow, |complete_check()|
 		should be used to avoid blocking and preserve editor
 		responsiveness.

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -133,8 +133,7 @@ func Test_omni_dash()
   %d
   set complete=o
   exe "normal Gofind -\<C-n>"
-  " 'complete' inserts at 'iskeyword' boundary (so you get --help)
-  call assert_equal("find --help", getline('$'))
+  call assert_equal("find -help", getline('$'))
 
   bwipe!
   delfunc Omni
@@ -392,7 +391,7 @@ func Test_CompleteDone_vevent_keys()
   call assert_equal('spell', g:complete_type)
 
   bwipe!
-  set completeopt& omnifunc& completefunc& spell& spelllang& dictionary&
+  set completeopt& omnifunc& completefunc& spell& spelllang& dictionary& complete&
   autocmd! CompleteDone
   delfunc OnDone
   delfunc CompleteFunc
@@ -1037,6 +1036,7 @@ func Test_completefunc_invalid_data()
   exe "normal i\<C-N>"
   call assert_equal('moon', getline(1))
   set completefunc& complete&
+  delfunc! CompleteFunc
   bw!
 endfunc
 
@@ -4859,6 +4859,122 @@ func Test_complete_fuzzy_omnifunc_backspace()
   bwipe!
   delfunc Omni_test
   unlet g:do_complete
+endfunc
+
+" Test 'complete' containing F{func} that complete from nonkeyword
+func Test_nonkeyword_trigger()
+
+  " Trigger expansion even when another char is waiting in the typehead
+  call test_override("char_avail", 1)
+
+  let g:CallCount = 0
+  func! NonKeywordComplete(findstart, base)
+    let line = getline('.')->strpart(0, col('.') - 1)
+    let nonkeyword2 = len(line) > 1 && match(line[-2:-2], '\k') != 0
+    if a:findstart
+      return nonkeyword2 ? col('.') - 3 : (col('.') - 2)
+    else
+      let g:CallCount += 1
+      return [$"{a:base}foo", $"{a:base}bar"]
+    endif
+  endfunc
+
+  new
+  inoremap <buffer> <F2> <Cmd>let b:matches = complete_info(["matches"]).matches<CR>
+  inoremap <buffer> <F3> <Cmd>let b:selected = complete_info(["selected"]).selected<CR>
+  call setline(1, ['abc', 'abcd', 'fo', 'b', ''])
+
+  " Test 1a: Nonkeyword before cursor lists words with at least two letters
+  call feedkeys("GS=\<C-N>\<F2>\<Esc>0", 'tx!')
+  call assert_equal(['abc', 'abcd', 'fo'], b:matches->mapnew('v:val.word'))
+  call assert_equal('=abc', getline('.'))
+
+  " Test 1b: With F{func} nonkeyword collects matches
+  set complete=.,FNonKeywordComplete
+  for noselect in range(2)
+    if noselect
+      set completeopt+=noselect
+    endif
+    let g:CallCount = 0
+    call feedkeys("S=\<C-N>\<F2>\<Esc>0", 'tx!')
+    call assert_equal(['abc', 'abcd', 'fo', '=foo', '=bar'], b:matches->mapnew('v:val.word'))
+    call assert_equal(1, g:CallCount)
+    call assert_equal(noselect ? '=' : '=abc', getline('.'))
+    let g:CallCount = 0
+    call feedkeys("S->\<C-N>\<F2>\<Esc>0", 'tx!')
+    call assert_equal(['abc', 'abcd', 'fo', '->foo', '->bar'], b:matches->mapnew('v:val.word'))
+    call assert_equal(1, g:CallCount)
+    call assert_equal(noselect ? '->' : '->abc', getline('.'))
+    set completeopt&
+  endfor
+
+  " Test 1c: Keyword collects from {func}
+  let g:CallCount = 0
+  call feedkeys("Sa\<C-N>\<F2>\<Esc>0", 'tx!')
+  call assert_equal(['abc', 'abcd', 'afoo', 'abar'], b:matches->mapnew('v:val.word'))
+  call assert_equal(1, g:CallCount)
+  call assert_equal('abc', getline('.'))
+
+  set completeopt+=noselect
+  let g:CallCount = 0
+  call feedkeys("Sa\<C-N>\<F2>\<Esc>0", 'tx!')
+  call assert_equal(['abc', 'abcd', 'afoo', 'abar'], b:matches->mapnew('v:val.word'))
+  call assert_equal(1, g:CallCount)
+  call assert_equal('a', getline('.'))
+
+  " Test 1d: Nonkeyword after keyword collects items again
+  let g:CallCount = 0
+  call feedkeys("Sa\<C-N>#\<C-N>\<F2>\<Esc>0", 'tx!')
+  call assert_equal(['abc', 'abcd', 'fo', '#foo', '#bar'], b:matches->mapnew('v:val.word'))
+  call assert_equal(2, g:CallCount)
+  call assert_equal('a#', getline('.'))
+  set completeopt&
+
+  " Test 2: Filter nonkeyword and keyword matches with differet startpos
+  set completeopt+=menuone,noselect
+  call feedkeys("S#a\<C-N>b\<F2>\<F3>\<Esc>0", 'tx!')
+  call assert_equal(['abc', 'abcd', '#abar'], b:matches->mapnew('v:val.word'))
+  call assert_equal(-1, b:selected)
+  call assert_equal('#ab', getline('.'))
+
+  set completeopt+=fuzzy
+  call feedkeys("S#a\<C-N>b\<F2>\<F3>\<Esc>0", 'tx!')
+  call assert_equal(['#abar', 'abc', 'abcd'], b:matches->mapnew('v:val.word'))
+  call assert_equal(-1, b:selected)
+  call assert_equal('#ab', getline('.'))
+  set completeopt&
+
+  " Test 3: Navigate menu containing nonkeyword and keyword items
+  call feedkeys("S->\<C-N>\<F2>\<Esc>0", 'tx!')
+  call assert_equal(['abc', 'abcd', 'fo', '->foo', '->bar'], b:matches->mapnew('v:val.word'))
+  call assert_equal('->abc', getline('.'))
+  call feedkeys("S->" . repeat("\<C-N>", 3) . "\<Esc>0", 'tx!')
+  call assert_equal('->fo', getline('.'))
+  call feedkeys("S->" . repeat("\<C-N>", 4) . "\<Esc>0", 'tx!')
+  call assert_equal('->foo', getline('.'))
+  call feedkeys("S->" . repeat("\<C-N>", 4) . "\<C-P>\<Esc>0", 'tx!')
+  call assert_equal('->fo', getline('.'))
+  call feedkeys("S->" . repeat("\<C-N>", 5) . "\<Esc>0", 'tx!')
+  call assert_equal('->bar', getline('.'))
+  call feedkeys("S->" . repeat("\<C-N>", 5) . "\<C-P>\<Esc>0", 'tx!')
+  call assert_equal('->foo', getline('.'))
+  call feedkeys("S->" . repeat("\<C-N>", 6) . "\<Esc>0", 'tx!')
+  call assert_equal('->', getline('.'))
+  call feedkeys("S->" . repeat("\<C-N>", 7) . "\<Esc>0", 'tx!')
+  call assert_equal('->abc', getline('.'))
+  call feedkeys("S->" . repeat("\<C-P>", 7) . "\<Esc>0", 'tx!')
+  call assert_equal('->fo', getline('.'))
+  " Replace
+  call feedkeys("S# x y z\<Esc>0lR\<C-N>\<Esc>0", 'tx!')
+  call assert_equal('#abcy z', getline('.'))
+  call feedkeys("S# x y z\<Esc>0lR" . repeat("\<C-P>", 4) . "\<Esc>0", 'tx!')
+  call assert_equal('#bary z', getline('.'))
+
+  bw!
+  call test_override("char_avail", 0)
+  delfunc NonKeywordComplete
+  set complete&
+  unlet g:CallCount
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab nofoldenable


### PR DESCRIPTION
**Allow functions in 'complete' to complete from non-keyword**

Previously, functions specified in the `'complete'` option were restricted to starting completion only from keyword characters during `<C-N>` / `<C-P>` completion (as introduced in PR #17065). This PR lifts that restriction.

With this change, user-defined functions (e.g., `omnifunc`, `userfunc`) used in `'complete'` can now initiate completion even when triggered from non-keyword characters. This makes it easier to reuse existing functions alongside other sources without having to consider whether the cursor is on a keyword or non-keyword character, or worry about where the replacement should begin (i.e., the `findstart=1` return value).

The logic for both the “collection” and “filtering” phases now fully respects each source’s specified start column. This also extends to fuzzy matching, making completions more predictable.

The existing behavior — where `<C-N>` shows a menu of all words of at least 2 characters when triggered from a non-keyword — remains unchanged.

Internally, this builds on previously merged infrastructure that tracks per-source metadata. This PR focuses on applying that metadata to compute the leader string and insertion text appropriately for each match.


