### PR TITLE
tests: missing cleanup in Test_search_cmdline_incsearch_highlight()

### DIFF
--- a/src/testdir/test_search.vim
+++ b/src/testdir/test_search.vim
@@ -843,6 +843,7 @@ func Test_search_cmdline_incsearch_highlight()
 
   " clean up
   set noincsearch nohlsearch
+  call test_override("char_avail", 0)
   bw!
 endfunc
 


### PR DESCRIPTION
Problem:  tests: missing cleanup test_override('char_avail', 0) in
          Test_search_cmdline_incsearch_highlight().
Solution: Add the missing cleanup.
