### PR TITLE
tests: two edit tests change v:testing from 1 to 0

### DIFF
--- a/src/testdir/runtest.vim
+++ b/src/testdir/runtest.vim
@@ -180,6 +180,7 @@ endif
 
 
 " Prepare for calling test_garbagecollect_now().
+" Also avois some delays in Insert mode completion.
 let v:testing = 1
 
 " By default, copy each buffer line into allocated memory, so that valgrind can

--- a/src/testdir/test_edit.vim
+++ b/src/testdir/test_edit.vim
@@ -709,12 +709,9 @@ func Test_edit_CTRL_K()
   %d
   call setline(1, 'A')
   call cursor(1, 1)
-  let v:testing = 1
   try
     call feedkeys("A\<c-x>\<c-k>\<esc>", 'tnix')
   catch
-    " error sleeps 2 seconds, when v:testing is not set
-    let v:testing = 0
   endtry
 
   call test_override("char_avail", 1)
@@ -962,12 +959,9 @@ func Test_edit_CTRL_T()
   %d
   call setline(1, 'mad')
   call cursor(1, 1)
-  let v:testing = 1
   try
     call feedkeys("A\<c-x>\<c-t>\<esc>", 'tnix')
   catch
-    " error sleeps 2 seconds, when v:testing is not set
-    let v:testing = 0
   endtry
   call assert_equal(['mad'], getline(1, '$'))
   bw!


### PR DESCRIPTION
Problem:  tests: two edit tests change v:testing from 1 to 0.
Solution: Don't change v:testing in these two tests, since it's already
          set to 1 in runtest.vim.
