### PR TITLE
Search completion may use invalid memory

### DIFF
--- a/src/cmdexpand.c
+++ b/src/cmdexpand.c
@@ -4609,14 +4609,11 @@ copy_substring_from_pos(pos_T *start, pos_T *end, char_u **match,
 	    || (start->lnum == end->lnum && start->col >= end->col))
 	return FAIL; // invalid range
 
-    // Get line pointers
-    start_line = ml_get(start->lnum);
-    end_line = ml_get(end->lnum);
-
     // Use a growable string (ga)
     ga_init2(&ga, 1, 128);
 
     // Append start line from start->col to end
+    start_line = ml_get(start->lnum);
     char_u  *start_ptr = start_line + start->col;
     int	    is_single_line = start->lnum == end->lnum;
 
@@ -4643,6 +4640,7 @@ copy_substring_from_pos(pos_T *start, pos_T *end, char_u **match,
     }
 
     // Append partial end line (up to word end)
+    end_line = ml_get(end->lnum);
     word_end = find_word_end(end_line + end->col);
     segment_len = (int)(word_end - end_line);
     if (ga_grow(&ga, segment_len) != OK)

--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -4493,6 +4493,7 @@ func Test_search_wildmenu_screendump()
   CheckScreendump
 
   let lines =<< trim [SCRIPT]
+    call test_override('alloc_lines', 1)
     set wildmenu wildcharm=<f5>
     call setline(1, ['the', 'these', 'the', 'foobar', 'thethe', 'thethere'])
   [SCRIPT]


### PR DESCRIPTION
Problem:  Search completion may use invalid memory (after 9.1.1490).
Solution: Don't get two line pointers at the same time.
