### PR TITLE
runtime(go): fix `b:undo_ftplugin`

### DIFF
--- a/runtime/ftplugin/go.vim
+++ b/runtime/ftplugin/go.vim
@@ -56,10 +56,10 @@ if !exists("no_plugin_maps") && !exists("no_go_maps")
   noremap <silent> <buffer> [[ <Cmd>call <SID>GoFindSection('prev_start', v:count1)<CR>
   noremap <silent> <buffer> [] <Cmd>call <SID>GoFindSection('prev_end', v:count1)<CR>
   let b:undo_ftplugin .= ''
-                      \ . '| unmap <buffer> ]]'
-                      \ . '| unmap <buffer> ]['
-                      \ . '| unmap <buffer> [['
-                      \ . '| unmap <buffer> []'
+                      \ . "| silent! exe 'unmap <buffer> ]]'"
+                      \ . "| silent! exe 'unmap <buffer> ]['"
+                      \ . "| silent! exe 'unmap <buffer> [['"
+                      \ . "| silent! exe 'unmap <buffer> []'"
 endif
 
 function! <SID>GoFindSection(dir, count)


### PR DESCRIPTION
## Problem

`b:undo_ftplugin` in `ftplugin/go.vim` is not reentrant.

## Description

The last `unmap` in `b:undo_ftplugin` can cause the error "E31: No such mapping" when `doaudocmd FileType go` if appending other commands to `b:undo_ftplugin` i.e. the space and the next bar as `let b:undo_ftplugin .= ' | setl ...'`.

## Steps to repro.

test.vim
```
let b:test_var = 1
let b:undo_ftplugin .= ' | unlet! b:test_var'
```

Run:
```
vim --clean main.go
:so test.vim
:doautocmd FileType go
```
```
Error detected while processing FileType Autocommands for "*"..function <SNR>4_LoadFTPlugin:
line    3:
E31: No such mapping
```

## Solution

* Replace with `exe 'unmap ...'`, same as other ftplugin scripts