### PR TITLE
runtime(netrw): fix blank lines between directories and files

### DIFF
--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -7602,7 +7602,6 @@ function s:PerformListing(islocal)
     if a:islocal
         let filelist = s:NetrwLocalListingList(b:netrw_curdir, 1)
         call append(w:netrw_bannercnt - 1, filelist)
-        " cleanup any blank lines
         sil! NetrwKeepj g/^$/d
         execute printf("setl ts=%d", g:netrw_maxfilenamelen + 1)
     else " remote

--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -7602,6 +7602,8 @@ function s:PerformListing(islocal)
     if a:islocal
         let filelist = s:NetrwLocalListingList(b:netrw_curdir, 1)
         call append(w:netrw_bannercnt - 1, filelist)
+        " cleanup any blank lines
+        sil! NetrwKeepj g/^$/d
         execute printf("setl ts=%d", g:netrw_maxfilenamelen + 1)
     else " remote
         NetrwKeepj let badresult= s:NetrwRemoteListing()

--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -7602,7 +7602,8 @@ function s:PerformListing(islocal)
     if a:islocal
         let filelist = s:NetrwLocalListingList(b:netrw_curdir, 1)
         call append(w:netrw_bannercnt - 1, filelist)
-        sil! NetrwKeepj g/^$/d
+        silent! NetrwKeepj g/^$/d
+        silent! NetrwKeepj %s/\r$//e
         execute printf("setl ts=%d", g:netrw_maxfilenamelen + 1)
     else " remote
         NetrwKeepj let badresult= s:NetrwRemoteListing()


### PR DESCRIPTION
v182 refactoring removed the blank line cleanup (`g/^$/d`) from `s:LocalListing()`.

This restores the missing cleanup in `s:PerformListing()` after the `append()` call.

Fixes regression introduced in ef925556c (runtime(netrw): upstream snapshot of v182).