### PR TITLE
tests: Test_termdebug_decimal_breakpoints() fails

### DIFF
--- a/src/testdir/test_plugin_termdebug.vim
+++ b/src/testdir/test_plugin_termdebug.vim
@@ -200,6 +200,8 @@ func Test_termdebug_decimal_breakpoints()
   Break 9
   call term_wait(gdb_buf)
   redraw!
+  Run
+  call term_wait(gdb_buf, 400)
 
   let i = 2
   while i <= 258


### PR DESCRIPTION
Problem:  Test_termdebug_decimal_breakpoints() fails with List Index Out
          of Range, because when adding the second breakpoint, the
          cursor is still on the very first line and therefore gdb
          refuses to set the breakpoint with:
          msg="No compiled code for line 1 in file XTD_decimal.c"
Solution: Run the program, so that it will break at the very first
          defined breakpoint and then once we are in the program,
          set further breakpoints