### PR TITLE
feat(termdebug): allow custom breakpoint signs

### DIFF
--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -1711,6 +1711,9 @@ than 99 will be displayed as "9+".
 
 If you want to customize the breakpoint signs to show `>>` in the signcolumn: >
 	let g:termdebug_config['sign'] = '>>'
+You can also specify individual signs for the first several breakpoints: >
+	let g:termdebug_config['signs'] = ['>1', '>2', '>3', '>4', '>5', '>6', '>7', '>8', '>9']
+	let g:termdebug_config['sign'] = '>>'
 If you would like to use decimal (base 10) breakpoint signs: >
 	let g:termdebug_config['sign_decimal'] = 1
 If the variable g:termdebug_config does not yet exist, you can use: >

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -1917,14 +1917,21 @@ def CreateBreakpoint(id: number, subid: number, enabled: string)
       hiName = "debugBreakpoint"
     endif
     var label = ''
-    if exists('g:termdebug_config') && has_key(g:termdebug_config, 'sign')
-      label = g:termdebug_config['sign']
-    elseif exists('g:termdebug_config') && has_key(g:termdebug_config, 'sign_decimal')
-      label = printf('%02d', id)
-      if id > 99
-        label = '9+'
+    if exists('g:termdebug_config')
+      if has_key(g:termdebug_config, 'signs')
+        label = get(g:termdebug_config.signs, id - 1, '')
       endif
-    else
+      if label == '' && has_key(g:termdebug_config, 'sign')
+        label = g:termdebug_config['sign']
+      endif
+      if label == '' && has_key(g:termdebug_config, 'sign_decimal')
+        label = printf('%02d', id)
+        if id > 99
+          label = '9+'
+        endif
+      endif
+    endif
+    if label == ''
       label = printf('%02X', id)
       if id > 255
         label = 'F+'

--- a/src/testdir/test_plugin_termdebug.vim
+++ b/src/testdir/test_plugin_termdebug.vim
@@ -97,15 +97,46 @@ func Test_termdebug_basic()
   Continue
   call term_wait(gdb_buf)
 
+  let g:termdebug_config = {}
+  let g:termdebug_config['signs'] = ['>1', '>2', '>3']
+  let g:termdebug_config['sign'] = '>>'
+  let g:termdebug_config['sign_decimal'] = 1
+
   let i = 2
   while i <= 258
     Break
     call term_wait(gdb_buf)
     if i == 2
-      call WaitForAssert({-> assert_equal(sign_getdefined('debugBreakpoint2.0')[0].text, '02')})
+      call WaitForAssert({-> assert_equal(sign_getdefined('debugBreakpoint2.0')[0].text, '>2')})
+    endif
+    if i == 3
+      call WaitForAssert({-> assert_equal(sign_getdefined('debugBreakpoint3.0')[0].text, '>3')})
+    endif
+    if i == 4
+      call WaitForAssert({-> assert_equal(sign_getdefined('debugBreakpoint4.0')[0].text, '>>')})
+    endif
+    if i == 5
+      call WaitForAssert({-> assert_equal(sign_getdefined('debugBreakpoint5.0')[0].text, '>>')})
+      unlet g:termdebug_config['sign']
+    endif
+    if i == 6
+      call WaitForAssert({-> assert_equal(sign_getdefined('debugBreakpoint6.0')[0].text, '06')})
     endif
     if i == 10
-      call WaitForAssert({-> assert_equal(sign_getdefined('debugBreakpoint10.0')[0].text, '0A')})
+      call WaitForAssert({-> assert_equal(sign_getdefined('debugBreakpoint10.0')[0].text, '10')})
+    endif
+    if i == 99
+      call WaitForAssert({-> assert_equal(sign_getdefined('debugBreakpoint99.0')[0].text, '99')})
+    endif
+    if i == 100
+      call WaitForAssert({-> assert_equal(sign_getdefined('debugBreakpoint100.0')[0].text, '9+')})
+    endif
+    if i == 110
+      call WaitForAssert({-> assert_equal(sign_getdefined('debugBreakpoint110.0')[0].text, '9+')})
+      unlet g:termdebug_config
+    endif
+    if i == 128
+      call WaitForAssert({-> assert_equal(sign_getdefined('debugBreakpoint128.0')[0].text, '80')})
     endif
     if i == 168
       call WaitForAssert({-> assert_equal(sign_getdefined('debugBreakpoint168.0')[0].text, 'A8')})
@@ -178,64 +209,6 @@ func Test_termdebug_basic()
 
   call s:cleanup_files(bin_name)
   %bw!
-endfunc
-
-func Test_termdebug_decimal_breakpoints()
-  let bin_name = 'XTD_decimal'
-  let src_name = bin_name .. '.c'
-  call s:generate_files(bin_name)
-
-  exe "edit " .. src_name
-
-  let g:termdebug_config = {}
-  let g:termdebug_config['sign_decimal'] = 1
-
-  exe "Termdebug " .. bin_name
-  call WaitForAssert({-> assert_true(get(g:, "termdebug_is_running", v:false))})
-  call WaitForAssert({-> assert_equal(3, winnr('$'))})
-  let gdb_buf = winbufnr(1)
-  wincmd b
-  Break 9
-  call term_wait(gdb_buf)
-  redraw!
-  Run
-  call term_wait(gdb_buf, 400)
-
-  let i = 2
-  while i <= 258
-    Break
-    call term_wait(gdb_buf)
-    if i == 2
-      call WaitForAssert({-> assert_equal(sign_getdefined('debugBreakpoint2.0')[0].text, '02')})
-    endif
-    if i == 10
-      call WaitForAssert({-> assert_equal(sign_getdefined('debugBreakpoint10.0')[0].text, '10')})
-    endif
-    if i == 168
-      call WaitForAssert({-> assert_equal(sign_getdefined('debugBreakpoint168.0')[0].text, '9+')})
-    endif
-    if i == 255
-      call WaitForAssert({-> assert_equal(sign_getdefined('debugBreakpoint255.0')[0].text, '9+')})
-    endif
-    if i == 256
-      call WaitForAssert({-> assert_equal(sign_getdefined('debugBreakpoint256.0')[0].text, '9+')})
-    endif
-    if i == 258
-      call WaitForAssert({-> assert_equal(sign_getdefined('debugBreakpoint258.0')[0].text, '9+')})
-    endif
-    let i += 1
-  endwhile
-
-  wincmd t
-  quit!
-  redraw!
-  call WaitForAssert({-> assert_equal(1, winnr('$'))})
-  call assert_equal([], sign_getplaced('', #{group: 'TermDebug'})[0].signs)
-
-  call s:cleanup_files(bin_name)
-  %bw!
-
-  unlet g:termdebug_config
 endfunc
 
 func Test_termdebug_tbreak()


### PR DESCRIPTION
For example, one can do something like this:

```vim
let g:termdebug_config['signs'] = ['>1', '>2', '>3', '>4', '>5', '>6', '>7', '>8', '>9']
let g:termdebug_config['sign'] = '>>'
```

where the first 9 breakpoints will have their own signs and the rest will be the same (>>).