### PR TITLE
CI: Manage multibyte characters in syntax tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -23,7 +23,7 @@ freebsd_task:
     - sudo -u cirrus make test
   on_failure:
     test_artifacts:
-      name: "Cirrus-CI-freebsd-failed-tests"
+      name: "Cirrus-${CIRRUS_BUILD_ID}-freebsd-failed-tests"
       path: |
         runtime/indent/testdir/*.fail
         runtime/syntax/testdir/failed/*

--- a/.github/actions/test_artifacts/action.yml
+++ b/.github/actions/test_artifacts/action.yml
@@ -7,7 +7,7 @@ runs:
       uses: actions/upload-artifact@v4
       with:
         # Name of the artifact to upload.
-        name: ${{ github.workflow }}-${{ github.job }}-${{ join(matrix.*, '-') }}-failed-tests
+        name: GH-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}-${{ join(matrix.*, '-') }}-failed-tests
 
         # A file, directory or wildcard pattern that describes what
         # to upload.

--- a/runtime/syntax/Makefile
+++ b/runtime/syntax/Makefile
@@ -13,7 +13,7 @@ VIMRUNTIME = ../..
 # Uncomment this line to use valgrind for memory leaks and extra warnings.
 # VALGRIND = valgrind --tool=memcheck --leak-check=yes --num-callers=45 --log-file=valgrind.$*
 
-# Trace ruler liveness on demand.
+# Trace liveness on demand.
 # VIM_SYNTAX_TEST_LOG = `pwd`/testdir/failed/00-TRACE_LOG
 
 # ENVVARS = LC_ALL=C VIM_SYNTAX_TEST_LOG="$(VIM_SYNTAX_TEST_LOG)"
@@ -39,7 +39,7 @@ test:
 	@# the "vimcmd" file is used by the screendump utils
 	@echo "../$(VIMPROG)" > testdir/vimcmd
 	@echo "$(RUN_VIMTEST)" >> testdir/vimcmd
-	@# Trace ruler liveness on demand.
+	@# Trace liveness on demand.
 	@#mkdir -p testdir/failed
 	@#touch "$(VIM_SYNTAX_TEST_LOG)"
 	VIMRUNTIME=$(VIMRUNTIME) $(ENVVARS) $(VIMPROG) --clean --not-a-term $(DEBUGLOG) -u testdir/runtest.vim > /dev/null

--- a/runtime/syntax/testdir/README.txt
+++ b/runtime/syntax/testdir/README.txt
@@ -61,8 +61,6 @@ an "input/setup/java.vim" script file with the following lines:
 Both inline setup commands and setup scripts may be used at the same time, the
 script file will be sourced before any VIM_TEST_SETUP commands are executed.
 
-Every line of a source file must not be longer than 1425 (19 x 75) characters.
-
 If there is no further setup required, you can now run all tests:
 
 	make test
@@ -110,6 +108,20 @@ If they look OK, move them to the "dumps" directory:
 	...
 
 If you now run the test again, it will succeed.
+
+
+Limitations for syntax plugin tests
+-----------------------------------
+
+Do not compose ASCII lines that do not fit a 19 by 75 window (1425 columns).
+
+Use multibyte characters, if at all, sparingly (see #16559).  When possible,
+move multibyte characters closer to the end of a line and keep the line short:
+no more than a 75-byte total of displayed characters.  A poorly rendered line
+may otherwise become wrapped when enough of spurious U+FFFD (0xEF 0xBF 0xBD)
+characters claim more columns than are available (75) and then invalidate line
+correspondence under test.  Refrain from mixing non-spurious U+FFFD characters
+with other multibyte characters in the same line.
 
 
 Adjusting a syntax plugin test

--- a/runtime/syntax/testdir/dumps/c_character_constant_00.vim
+++ b/runtime/syntax/testdir/dumps/c_character_constant_00.vim
@@ -1,2 +1,0 @@
-" Replace known non-Latin-1 characters.
-%s+[🍌猫�]+?+ge

--- a/runtime/syntax/testdir/dumps/c_character_constant_01.vim
+++ b/runtime/syntax/testdir/dumps/c_character_constant_01.vim
@@ -1,2 +1,0 @@
-" Replace known non-Latin-1 characters.
-%s+[🍌猫�]+?+ge

--- a/runtime/syntax/testdir/dumps/c_character_constant_02.vim
+++ b/runtime/syntax/testdir/dumps/c_character_constant_02.vim
@@ -1,2 +1,0 @@
-" Replace known non-Latin-1 characters.
-%s+[🍌猫�]+?+ge

--- a/runtime/syntax/testdir/dumps/c_string_literal_00.vim
+++ b/runtime/syntax/testdir/dumps/c_string_literal_00.vim
@@ -1,2 +1,0 @@
-" Replace known non-Latin-1 characters.
-%s+[🍌猫�]+?+ge

--- a/runtime/syntax/testdir/dumps/c_string_literal_01.vim
+++ b/runtime/syntax/testdir/dumps/c_string_literal_01.vim
@@ -1,2 +1,0 @@
-" Replace known non-Latin-1 characters.
-%s+[🍌猫�]+?+ge

--- a/runtime/syntax/testdir/dumps/c_string_literal_02.vim
+++ b/runtime/syntax/testdir/dumps/c_string_literal_02.vim
@@ -1,2 +1,0 @@
-" Replace known non-Latin-1 characters.
-%s+[🍌猫�]+?+ge

--- a/runtime/syntax/testdir/dumps/c_string_literal_03.vim
+++ b/runtime/syntax/testdir/dumps/c_string_literal_03.vim
@@ -1,2 +1,0 @@
-" Replace known non-Latin-1 characters.
-%s+[🍌猫�]+?+ge

--- a/runtime/syntax/testdir/dumps/java_methods_indent2_00.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_indent2_00.vim
@@ -1,2 +1,0 @@
-" Replace known non-Latin-1 characters.
-%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_indent2_01.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_indent2_01.vim
@@ -1,2 +1,0 @@
-" Replace known non-Latin-1 characters.
-%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_indent2_02.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_indent2_02.vim
@@ -1,2 +1,0 @@
-" Replace known non-Latin-1 characters.
-%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_indent2_03.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_indent2_03.vim
@@ -1,2 +1,0 @@
-" Replace known non-Latin-1 characters.
-%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_indent2_04.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_indent2_04.vim
@@ -1,2 +1,0 @@
-" Replace known non-Latin-1 characters.
-%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_indent2_06.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_indent2_06.vim
@@ -1,2 +1,0 @@
-" Replace known non-Latin-1 characters.
-%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_indent2_signature_00.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_indent2_signature_00.vim
@@ -1,2 +1,0 @@
-" Replace known non-Latin-1 characters.
-%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_indent2_signature_01.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_indent2_signature_01.vim
@@ -1,2 +1,0 @@
-" Replace known non-Latin-1 characters.
-%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_indent2_signature_02.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_indent2_signature_02.vim
@@ -1,2 +1,0 @@
-" Replace known non-Latin-1 characters.
-%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_indent2_signature_03.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_indent2_signature_03.vim
@@ -1,2 +1,0 @@
-" Replace known non-Latin-1 characters.
-%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_indent2_signature_04.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_indent2_signature_04.vim
@@ -1,2 +1,0 @@
-" Replace known non-Latin-1 characters.
-%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_indent2_signature_05.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_indent2_signature_05.vim
@@ -1,2 +1,0 @@
-" Replace known non-Latin-1 characters.
-%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_indent4_00.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_indent4_00.vim
@@ -1,2 +1,0 @@
-" Replace known non-Latin-1 characters.
-%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_indent4_01.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_indent4_01.vim
@@ -1,2 +1,0 @@
-" Replace known non-Latin-1 characters.
-%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_indent4_02.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_indent4_02.vim
@@ -1,2 +1,0 @@
-" Replace known non-Latin-1 characters.
-%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_indent4_03.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_indent4_03.vim
@@ -1,2 +1,0 @@
-" Replace known non-Latin-1 characters.
-%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_indent4_04.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_indent4_04.vim
@@ -1,2 +1,0 @@
-" Replace known non-Latin-1 characters.
-%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_indent4_06.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_indent4_06.vim
@@ -1,2 +1,0 @@
-" Replace known non-Latin-1 characters.
-%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_indent4_signature_00.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_indent4_signature_00.vim
@@ -1,2 +1,0 @@
-" Replace known non-Latin-1 characters.
-%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_indent4_signature_01.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_indent4_signature_01.vim
@@ -1,2 +1,0 @@
-" Replace known non-Latin-1 characters.
-%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_indent4_signature_02.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_indent4_signature_02.vim
@@ -1,2 +1,0 @@
-" Replace known non-Latin-1 characters.
-%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_indent4_signature_03.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_indent4_signature_03.vim
@@ -1,2 +1,0 @@
-" Replace known non-Latin-1 characters.
-%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_indent4_signature_04.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_indent4_signature_04.vim
@@ -1,2 +1,0 @@
-" Replace known non-Latin-1 characters.
-%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_indent4_signature_05.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_indent4_signature_05.vim
@@ -1,2 +1,0 @@
-" Replace known non-Latin-1 characters.
-%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_indent8_00.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_indent8_00.vim
@@ -1,2 +1,0 @@
-" Replace known non-Latin-1 characters.
-%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_indent8_01.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_indent8_01.vim
@@ -1,2 +1,0 @@
-" Replace known non-Latin-1 characters.
-%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_indent8_02.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_indent8_02.vim
@@ -1,2 +1,0 @@
-" Replace known non-Latin-1 characters.
-%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_indent8_03.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_indent8_03.vim
@@ -1,2 +1,0 @@
-" Replace known non-Latin-1 characters.
-%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_indent8_04.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_indent8_04.vim
@@ -1,2 +1,0 @@
-" Replace known non-Latin-1 characters.
-%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_indent8_06.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_indent8_06.vim
@@ -1,2 +1,0 @@
-" Replace known non-Latin-1 characters.
-%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_indent8_signature_00.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_indent8_signature_00.vim
@@ -1,2 +1,0 @@
-" Replace known non-Latin-1 characters.
-%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_indent8_signature_01.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_indent8_signature_01.vim
@@ -1,2 +1,0 @@
-" Replace known non-Latin-1 characters.
-%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_indent8_signature_02.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_indent8_signature_02.vim
@@ -1,2 +1,0 @@
-" Replace known non-Latin-1 characters.
-%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_indent8_signature_03.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_indent8_signature_03.vim
@@ -1,2 +1,0 @@
-" Replace known non-Latin-1 characters.
-%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_indent8_signature_04.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_indent8_signature_04.vim
@@ -1,2 +1,0 @@
-" Replace known non-Latin-1 characters.
-%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_indent8_signature_05.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_indent8_signature_05.vim
@@ -1,2 +1,0 @@
-" Replace known non-Latin-1 characters.
-%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_indent8_signature_06.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_indent8_signature_06.vim
@@ -1,2 +1,0 @@
-" Replace known non-Latin-1 characters.
-%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_style_00.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_style_00.vim
@@ -1,2 +1,0 @@
-" Replace known non-Latin-1 characters.
-%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_style_01.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_style_01.vim
@@ -1,2 +1,0 @@
-" Replace known non-Latin-1 characters.
-%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_style_02.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_style_02.vim
@@ -1,2 +1,0 @@
-" Replace known non-Latin-1 characters.
-%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_style_03.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_style_03.vim
@@ -1,2 +1,0 @@
-" Replace known non-Latin-1 characters.
-%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_style_04.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_style_04.vim
@@ -1,2 +1,0 @@
-" Replace known non-Latin-1 characters.
-%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_style_signature_00.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_style_signature_00.vim
@@ -1,2 +1,0 @@
-" Replace known non-Latin-1 characters.
-%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_style_signature_01.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_style_signature_01.vim
@@ -1,2 +1,0 @@
-" Replace known non-Latin-1 characters.
-%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_style_signature_02.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_style_signature_02.vim
@@ -1,2 +1,0 @@
-" Replace known non-Latin-1 characters.
-%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_style_signature_03.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_style_signature_03.vim
@@ -1,2 +1,0 @@
-" Replace known non-Latin-1 characters.
-%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/java_methods_style_signature_04.vim
+++ b/runtime/syntax/testdir/dumps/java_methods_style_signature_04.vim
@@ -1,2 +1,0 @@
-" Replace known non-Latin-1 characters.
-%s+[ƒɐɘʬʭΑ-Ωα-ω�]+?+Ige

--- a/runtime/syntax/testdir/dumps/vim9_ex_loadkeymap_01.vim
+++ b/runtime/syntax/testdir/dumps/vim9_ex_loadkeymap_01.vim
@@ -1,2 +1,0 @@
-" Replace known non-Latin-1 characters.
-%s+[“�]+?+ge

--- a/runtime/syntax/testdir/dumps/vim_ex_loadkeymap_01.vim
+++ b/runtime/syntax/testdir/dumps/vim_ex_loadkeymap_01.vim
@@ -1,2 +1,0 @@
-" Replace known non-Latin-1 characters.
-%s+[“�]+?+ge

--- a/runtime/syntax/testdir/runtest.vim
+++ b/runtime/syntax/testdir/runtest.vim
@@ -106,15 +106,54 @@ func HandleSwapExists()
   endif
 endfunc
 
-" Trace ruler liveness on demand.
 if !empty($VIM_SYNTAX_TEST_LOG) && filewritable($VIM_SYNTAX_TEST_LOG)
-  def s:TraceRulerLiveness(context: string, times: number, tail: string)
+  " Trace liveness.
+  def s:TraceLiveness(context: string, times: number, tail: string)
     writefile([printf('%s: %4d: %s', context, times, tail)],
 	$VIM_SYNTAX_TEST_LOG,
 	'a')
   enddef
+
+  " Anticipate rendering idiosyncrasies (see #16559).
+  def s:CanFindRenderedFFFDChars(
+	  buf: number,
+	  in_name_and_out_name: string,
+	  times: number): bool
+    if CannotUseRealEstate(in_name_and_out_name)
+      return false
+    endif
+    # Expect a 20-line terminal buffer (see "term_util#RunVimInTerminal()"),
+    # where the bottom, reserved line is of the default "&cmdheight".
+    var lines: list<number> = []
+    for lnum: number in range(1, 19)
+      if stridx(term_getline(buf, lnum), "\xef\xbf\xbd") >= 0
+	add(lines, lnum)
+      endif
+    endfor
+    TraceLiveness('F', times, string(lines))
+    return !empty(lines)
+  enddef
 else
-  def s:TraceRulerLiveness(_: string, _: number, _: string)
+  " Do not trace liveness.
+  def s:TraceLiveness(_: string, _: number, _: string)
+  enddef
+
+  " Anticipate rendering idiosyncrasies (see #16559).
+  def s:CanFindRenderedFFFDChars(
+	  buf: number,
+	  in_name_and_out_name: string,
+	  _: number): bool
+    if CannotUseRealEstate(in_name_and_out_name)
+      return false
+    endif
+    # Expect a 20-line terminal buffer (see "term_util#RunVimInTerminal()"),
+    # where the bottom, reserved line is of the default "&cmdheight".
+    for lnum: number in range(1, 19)
+      if stridx(term_getline(buf, lnum), "\xef\xbf\xbd") >= 0
+	return true
+      endif
+    endfor
+    return false
   enddef
 endif
 
@@ -142,6 +181,68 @@ def s:CannotDumpShellFirstPage(buf: number, _: list<string>, ruler: list<string>
       get(term_getcursor(buf), 0) != 20)
 enddef
 
+def s:CannotUseRealEstate(in_name_and_out_name: string): bool
+  # Expect defaults from "term_util#RunVimInTerminal()".
+  if winwidth(1) != 75 || winheight(1) != 20
+    ch_log(printf('Aborting for %s: (75 x 20) != (%d x %d)',
+	in_name_and_out_name,
+	winwidth(1),
+	winheight(1)))
+    return true
+  endif
+  return false
+enddef
+
+" Throw an "FFFD" string if U+FFFD characters are found in the terminal buffer
+" during a non-last test round; otherwise, generate a screendump and proceed
+" with its verification.
+def s:VerifyScreenDumpOrThrowFFFD(
+	buf: number,
+	which_page: string,
+	in_name_and_out_name: string,
+	aborted_count: number,
+	max_aborted_count: number,
+	basename: string,
+	opts: dict<any>,
+	page_quota: dict<number>,
+	seen_pages: list<number>,
+	page_nr: number): number
+  if !has_key(page_quota, page_nr)
+    # Constrain management of unseen pages to the product of "wait" times
+    # "max_aborted_count" (see "opts" below).  When _test repetition_ and
+    # _line rewriting_ FAIL page verification, the page gets to keep its
+    # unseen mark; when _test repetition_ is FAILING for a later page, all
+    # earlier unseen pages get another chance at _test repetition_ etc. before
+    # further progress can be made for the later page.
+    page_quota[page_nr] = max_aborted_count
+  endif
+  const with_fffd: bool = CanFindRenderedFFFDChars(
+      buf,
+      in_name_and_out_name,
+      (max_aborted_count - aborted_count + 1))
+  if with_fffd && aborted_count > 1
+    throw 'FFFD'
+  endif
+  ch_log(which_page .. ' screendump for ' .. in_name_and_out_name)
+  # Generate a screendump of every 19 lines of "buf", reusing the bottom line
+  # (or the bottom six or so lines for "*_01.dump") from the previous dump as
+  # the top line(s) in the next dump for continuity.  Constrain generation of
+  # unseen pages for the last test round (via "wait").
+  const status: number = g:VerifyScreenDump(
+      buf,
+      basename,
+      (aborted_count != max_aborted_count)
+	  ? extend({wait: max_aborted_count}, opts, 'keep')
+	  : opts)
+  if !with_fffd || (!status || !page_quota[page_nr])
+    add(seen_pages, page_nr)
+  else
+    TraceLiveness('Q', (max_aborted_count - aborted_count + 1), string(page_quota))
+  endif
+  page_quota[page_nr] -= 1
+  return status
+enddef
+
 " Poll for updates of the cursor position in the terminal buffer occupying the
 " first window.  (ALWAYS call the function or its equivalent before calling
 " "VerifyScreenDump()" *and* after calling any number of "term_sendkeys()".)
@@ -149,12 +250,7 @@ def s:TermPollRuler(
 	CannotDumpPage: func,	# (TYPE FOR LEGACY CONTEXT CALL SITES.)
 	buf: number,
 	in_name_and_out_name: string): list<string>
-  # Expect defaults from "term_util#RunVimInTerminal()".
-  if winwidth(1) != 75 || winheight(1) != 20
-    ch_log(printf('Aborting for %s: (75 x 20) != (%d x %d)',
-      in_name_and_out_name,
-      winwidth(1),
-      winheight(1)))
+  if CannotUseRealEstate(in_name_and_out_name)
     return ['0,0-1', 'All']
   endif
   # A two-fold role for redrawing:
@@ -177,7 +273,7 @@ def s:TermPollRuler(
       redraw
     endif
   endwhile
-  TraceRulerLiveness('P', (2048 - times), in_name_and_out_name)
+  TraceLiveness('P', (2048 - times), in_name_and_out_name)
   return ruler
 enddef
 
@@ -186,12 +282,7 @@ enddef
 " the terminal buffer.  (Call the function before calling "VerifyScreenDump()"
 " for the first time.)
 def s:TermWaitAndPollRuler(buf: number, in_name_and_out_name: string): list<string>
-  # Expect defaults from "term_util#RunVimInTerminal()".
-  if winwidth(1) != 75 || winheight(1) != 20
-    ch_log(printf('Aborting for %s: (75 x 20) != (%d x %d)',
-      in_name_and_out_name,
-      winwidth(1),
-      winheight(1)))
+  if CannotUseRealEstate(in_name_and_out_name)
     return ['0,0-1', 'All']
   endif
   # The contents of "ruler".
@@ -210,7 +301,7 @@ def s:TermWaitAndPollRuler(buf: number, in_name_and_out_name: string): list<stri
       redraw
     endif
   endwhile
-  TraceRulerLiveness('W', (32768 - times), in_name_and_out_name)
+  TraceLiveness('W', (32768 - times), in_name_and_out_name)
   if strpart(ruler, 0, 8) !=# 'is_nonce'
     # Retain any of "b:is_(bash|dash|kornshell|posix|sh)" entries and let
     # "CannotDumpShellFirstPage()" win the cursor race.
@@ -282,6 +373,34 @@ func RunTest()
       " END [runtime/defaults.vim]
       redraw!
     endfunc
+
+    def CollectFFFDChars()
+      const fffd: string = "\xef\xbf\xbd"
+      const flags: string = 'eW'
+      const pos: list<number> = getpos('.')
+      var fffds: list<list<number>> = []
+      try
+	cursor(1, 1)
+	var prev: list<number> = [0, 0]
+	var next: list<number> = [0, 0]
+	next = searchpos(fffd, 'c' .. flags)
+	while next[0] > 0 && prev != next
+	  add(fffds, next)
+	  prev = next
+	  next = searchpos(fffd, flags)
+	endwhile
+      finally
+	setpos('.', pos)
+      endtry
+      if !empty(fffds)
+	# Use "actions/upload-artifact@v4" of ci.yml for delivery.
+	writefile(
+	  [printf('%s: %s', bufname('%'), string(fffds))],
+	  'failed/10-FFFDS',
+	  'a')
+      endif
+      redraw!
+    enddef
 
     def s:AssertCursorForwardProgress(): bool
       const curnum: number = line('.')
@@ -383,12 +502,18 @@ func RunTest()
       return AssertCursorForwardProgress()
     enddef
   END
+  let MAX_ABORTED_COUNT = 5
   let MAX_FAILED_COUNT = 5
-  let DUMP_OPTS = exists("$VIM_SYNTAX_TEST_WAIT_TIME") &&
+  let DUMP_OPTS = extend(
+	  \ exists("$VIM_SYNTAX_TEST_WAIT_TIME") &&
 	  \ !empty($VIM_SYNTAX_TEST_WAIT_TIME)
-      \ ? {'wait': max([1, str2nr($VIM_SYNTAX_TEST_WAIT_TIME)])}
-      \ : {}
-  lockvar DUMP_OPTS MAX_FAILED_COUNT XTESTSCRIPT
+	      \ ? {'wait': max([1, str2nr($VIM_SYNTAX_TEST_WAIT_TIME)])}
+	      \ : {},
+      \ {'FileComparisonPreAction':
+	  \ function('g:ScreenDumpDiscardFFFDChars'),
+      \ 'NonEqualLineComparisonPostAction':
+	  \ function('g:ScreenDumpLookForFFFDChars')})
+  lockvar DUMP_OPTS MAX_FAILED_COUNT MAX_ABORTED_COUNT XTESTSCRIPT
   let ok_count = 0
   let disused_pages = []
   let failed_tests = []
@@ -456,64 +581,118 @@ func RunTest()
       let args = !empty(path)
 	\ ? prefix .. ' -S ' .. path
 	\ : prefix
-      let buf = RunVimInTerminal(args, {})
-      " edit the file only after catching the SwapExists event
-      call term_sendkeys(buf, ":edit " .. fname .. "\<CR>")
-      " set up the testing environment
-      call term_sendkeys(buf, ":call SetUpVim()\<CR>")
-      " load filetype specific settings
-      call term_sendkeys(buf, ":call LoadFiletype('" .. filetype .. "')\<CR>")
+      let fail = 0
 
-      " Make a synchronisation point between buffers by requesting to echo
-      " a known token in the terminal buffer and asserting its availability
-      " with "s:TermWaitAndPollRuler()".
-      if filetype == 'sh'
-	call term_sendkeys(buf, ":call ShellInfo()\<CR>")
-      else
-	call term_sendkeys(buf, ":echo 'is_nonce'\<CR>")
-      endif
-
-      let root_00 = root .. '_00'
-      let in_name_and_out_name = fname .. ': failed/' .. root_00 .. '.dump'
-      " Queue up all "term_sendkeys()"es and let them finish before returning
-      " from "s:TermWaitAndPollRuler()".
-      let ruler = s:TermWaitAndPollRuler(buf, in_name_and_out_name)
-      call ch_log('First screendump for ' .. in_name_and_out_name)
-      " Make a screendump at the start of the file: failed/root_00.dump
-      let fail = VerifyScreenDump(buf, root_00, DUMP_OPTS)
-      let nr = 0
-
-      " Accommodate the next code block to "buf"'s contingency for self
-      " wipe-out.
       try
-	let keys_a = ":call ScrollToSecondPage((18 * 75 + 1), 19, 5) | redraw!\<CR>"
-	let keys_b = ":call ScrollToNextPage((18 * 75 + 1), 19, 5) | redraw!\<CR>"
-	while s:CannotSeeLastLine(ruler)
-	  call term_sendkeys(buf, keys_a)
-	  let keys_a = keys_b
-	  let nr += 1
-	  let root_next = printf('%s_%02d', root, nr)
-	  let in_name_and_out_name = fname .. ': failed/' .. root_next .. '.dump'
-	  let ruler = s:TermPollRuler(
-	      \ function('s:CannotDumpNextPage', [buf, ruler]),
-	      \ buf,
-	      \ in_name_and_out_name)
-	  call ch_log('Next screendump for ' .. in_name_and_out_name)
-	  " Make a screendump of every 18 lines of the file: failed/root_NN.dump
-	  let fail += VerifyScreenDump(buf, root_next, DUMP_OPTS)
+	let aborted_count = MAX_ABORTED_COUNT
+	let collected_count = 0
+	let seen_pages = []
+	let page_quota = {}
+
+	" See #16559.  For each processed page, repeat pre-verification steps
+	" from scratch (subject to page cacheing) whenever U+FFFD characters
+	" are found in the terminal buffer with "term_getline()", i.e. treat
+	" these pages as if they were distinct test files.  U+FFFD characters
+	" found at the last attempt (see "MAX_ABORTED_COUNT") will be ignored
+	" and "VerifyScreenDump()" will take over with own filtering.
+	while aborted_count > 0
+	  let buf = RunVimInTerminal(args, {})
+	  try
+	    " edit the file only after catching the SwapExists event
+	    call term_sendkeys(buf, ":edit " .. fname .. "\<CR>")
+	    " set up the testing environment
+	    call term_sendkeys(buf, ":call SetUpVim()\<CR>")
+	    " load filetype specific settings
+	    call term_sendkeys(buf, ":call LoadFiletype('" .. filetype .. "')\<CR>")
+
+	    " Collect all *non-spurious* U+FFFD characters for scrutiny.
+	    if aborted_count == 1 && collected_count != 1
+	      let collected_count = 1
+	      call term_sendkeys(buf, ":call CollectFFFDChars()\<CR>")
+	    endif
+
+	    " Make a synchronisation point between a terminal buffer and
+	    " another buffer by requesting to echo a known token in the former
+	    " and asserting its availability with "s:TermWaitAndPollRuler()"
+	    " from the latter.
+	    if filetype == 'sh'
+	      call term_sendkeys(buf, ":call ShellInfo()\<CR>")
+	    else
+	      call term_sendkeys(buf, ":echo 'is_nonce'\<CR>")
+	    endif
+
+	    let page_nr = 0
+	    let root_00 = root .. '_00'
+	    let in_name_and_out_name = fname .. ': failed/' .. root_00 .. '.dump'
+	    " Queue up all "term_sendkeys()"es and let them finish before
+	    " returning from "s:TermWaitAndPollRuler()".
+	    let ruler = s:TermWaitAndPollRuler(buf, in_name_and_out_name)
+	    if index(seen_pages, page_nr) < 0
+	      let fail += s:VerifyScreenDumpOrThrowFFFD(
+		  \ buf,
+		  \ 'First',
+		  \ in_name_and_out_name,
+		  \ aborted_count,
+		  \ MAX_ABORTED_COUNT,
+		  \ root_00,
+		  \ DUMP_OPTS,
+		  \ page_quota,
+		  \ seen_pages,
+		  \ page_nr)
+	      " Reset "aborted_count" for another page.
+	      let aborted_count = MAX_ABORTED_COUNT
+	    endif
+	    let keys_a = ":call ScrollToSecondPage((18 * 75 + 1), 19, 5) | redraw!\<CR>"
+	    let keys_b = ":call ScrollToNextPage((18 * 75 + 1), 19, 5) | redraw!\<CR>"
+
+	    while s:CannotSeeLastLine(ruler)
+	      call term_sendkeys(buf, keys_a)
+	      let keys_a = keys_b
+	      let page_nr += 1
+	      let root_next = printf('%s_%02d', root, page_nr)
+	      let in_name_and_out_name = fname .. ': failed/' .. root_next .. '.dump'
+	      let ruler = s:TermPollRuler(
+		  \ function('s:CannotDumpNextPage', [buf, ruler]),
+		  \ buf,
+		  \ in_name_and_out_name)
+	      if index(seen_pages, page_nr) < 0
+		let fail += s:VerifyScreenDumpOrThrowFFFD(
+		    \ buf,
+		    \ 'Next',
+		    \ in_name_and_out_name,
+		    \ aborted_count,
+		    \ MAX_ABORTED_COUNT,
+		    \ root_next,
+		    \ DUMP_OPTS,
+		    \ page_quota,
+		    \ seen_pages,
+		    \ page_nr)
+		" Reset "aborted_count" for another page.
+		let aborted_count = MAX_ABORTED_COUNT
+	      endif
+	    endwhile
+	    call StopVimInTerminal(buf)
+	    break
+	  catch /^FFFD$/
+	    " Clear out.
+	    call StopVimInTerminal(buf)
+	    while winnr('$') > 1
+	      close
+	    endwhile
+	    let aborted_count -= 1
+	  endtry
 	endwhile
-	call StopVimInTerminal(buf)
       finally
 	call delete('Xtestscript')
       endtry
 
-      let nr += 1
-      let pagename = printf('dumps/%s_%02d.dump', root, nr)
+      let page_nr += 1
+      let pagename = printf('dumps/%s_%02d.dump', root, page_nr)
 
       while filereadable(pagename)
 	call add(disused_pages, pagename)
-	let nr += 1
-	let pagename = printf('dumps/%s_%02d.dump', root, nr)
+	let page_nr += 1
+	let pagename = printf('dumps/%s_%02d.dump', root, page_nr)
       endwhile
 
       " redraw here to avoid the following messages to get mixed up with screen

--- a/src/testdir/util/screendump.vim
+++ b/src/testdir/util/screendump.vim
@@ -105,6 +105,7 @@ enddef
 "	    some dictionary with some state entries;
 "	    the file contents of the newly generated screen dump;
 "	    the zero-based number of the line whose copies are not equal.
+" (See an example in runtime/syntax/testdir/runtest.vim.)
 "
 " The file name used is "dumps/{filename}.dump".
 "

--- a/src/testdir/util/screendump.vim
+++ b/src/testdir/util/screendump.vim
@@ -29,11 +29,83 @@ def ReadAndFilter(fname: string, filter: string): list<string>
   return contents
 enddef
 
+" Accommodate rendering idiosyncrasies (see #16559).  For details, refer to
+" "VerifyScreenDump()" and the "options" dictionary passed to it: this is
+" an implementation of its "FileComparisonPreAction" entry.  (This function
+" runs in couples with "g:ScreenDumpLookForFFFDChars()".)
+def g:ScreenDumpDiscardFFFDChars(
+	state: dict<number>,
+	testdump: list<string>,
+	refdump: list<string>)
+  if empty(state) || len(testdump) != len(refdump)
+    return
+  endif
+  for lstr: string in keys(state)
+    const lnum: number = str2nr(lstr)
+    const fst_fffd_idx: number = stridx(testdump[lnum], "\xef\xbf\xbd")
+    # Retroactively discard non-equal line suffixes.  It is assumed that no
+    # runs of U+EFU+BFU+BD and no U+FFFDs are present in "refdump".
+    if fst_fffd_idx >= 0
+      # Mask the "||" character cells and the cursor cell ">.".
+      const masked_part: string = substitute(
+	  substitute(
+	      strpart(testdump[lnum], 0, (fst_fffd_idx - 1)),
+	      '[>|]|', '|.', 'g'),
+	  '|\@<!>', '|', 'g')
+      const prev_cell_idx: number = strridx(masked_part, '|')
+      # A series of repeated characters will be found recorded in shorthand;
+      # e.g. "|α@3" stands for a cell of four "α"s.  Replacing any repeated
+      # multibyte character of a series with a U+FFFD character will split the
+      # series and its shorthand record will reflect this fact: "|α@2|�".
+      # Therefore, a common prefix to share for two corresponding lines can
+      # extend to either an ASCII character(s) cell before the leftmost U+FFFD
+      # character cell; or, a last-but-one arbitrary cell before the leftmost
+      # U+FFFD character cell; or, an empty string.
+      const prefix: number = (prev_cell_idx >= 0)
+	  ? (char2nr(strpart(masked_part, (prev_cell_idx + 1), 1), true) < 128)
+	      ? fst_fffd_idx - 1
+	      : (strridx(masked_part, '|', (prev_cell_idx - 1)) >= 0)
+		  ? prev_cell_idx
+		  : 0
+	  : 0
+      refdump[lnum] = strpart(refdump[lnum], 0, prefix)
+      testdump[lnum] = strpart(testdump[lnum], 0, prefix)
+    endif
+  endfor
+enddef
+
+" Accommodate rendering idiosyncrasies (see #16559).  For details, refer to
+" "VerifyScreenDump()" and the "options" dictionary passed to it: this is
+" an implementation of its "NonEqualLineComparisonPostAction" entry.  (This
+" function runs in couples with "g:ScreenDumpDiscardFFFDChars()".)
+def g:ScreenDumpLookForFFFDChars(
+	state: dict<number>,
+	testdump: list<string>,
+	lnum: number)
+  if stridx(testdump[lnum], "\xef\xbf\xbd") >= 0
+    state[string(lnum)] = 1
+  endif
+enddef
 
 " Verify that Vim running in terminal buffer "buf" matches the screen dump.
-" "options" is passed to term_dumpwrite().
-" Additionally, the "wait" entry can specify the maximum time to wait for the
-" screen dump to match in msec (default 1000 msec).
+"
+" A copy of "options" is passed to "term_dumpwrite()".  For convenience, this
+" dictionary supports other optional entries:
+"   "wait", (default to 1000 msec at least)
+"	the maximum time to wait for the screen dump to match in msec.
+"   "FileComparisonPreAction", (default to a no-op action)
+"	some Funcref to call, passing the following three arguments, each time
+"	before the file contents of two screen dumps are compared:
+"	    some dictionary with some state entries;
+"	    the file contents of the newly generated screen dump;
+"	    the file contents of the reference screen dump.
+"   "NonEqualLineComparisonPostAction", (default to a no-op action)
+"	some Funcref to call, passing the following three arguments, each time
+"	after a corresponding pair of lines is found not equal:
+"	    some dictionary with some state entries;
+"	    the file contents of the newly generated screen dump;
+"	    the zero-based number of the line whose copies are not equal.
+"
 " The file name used is "dumps/{filename}.dump".
 "
 " To ignore part of the dump, provide a "dumps/{filename}.vim" file with
@@ -53,7 +125,24 @@ func VerifyScreenDump(buf, filename, options, ...)
   let filter = 'dumps/' . a:filename . '.vim'
   let testfile = 'failed/' . a:filename . '.dump'
 
-  let max_loops = get(a:options, 'wait', 1000) / 1
+  let options_copy = copy(a:options)
+  if has_key(options_copy, 'wait')
+    let max_loops = max([0, remove(options_copy, 'wait')])
+  else
+    let max_loops = 1000
+  endif
+  if has_key(options_copy, 'FileComparisonPreAction')
+    let FileComparisonPreAction = remove(options_copy, 'FileComparisonPreAction')
+    let CopyStringList = {_refdump -> copy(_refdump)}
+  else
+    let FileComparisonPreAction = {_state, _testdump, _refdump -> 0}
+    let CopyStringList = {_refdump -> _refdump}
+  endif
+  if has_key(options_copy, 'NonEqualLineComparisonPostAction')
+    let NonEqualLineComparisonPostAction = remove(options_copy, 'NonEqualLineComparisonPostAction')
+  else
+    let NonEqualLineComparisonPostAction = {_state, _testdump, _lnum -> 0}
+  endif
 
   " Starting a terminal to make a screendump is always considered flaky.
   let g:test_is_flaky = 1
@@ -76,21 +165,25 @@ func VerifyScreenDump(buf, filename, options, ...)
     " Leave a bit of time for updating the original window while we spin wait.
     sleep 10m
     call delete(testfile)
-    call term_dumpwrite(a:buf, testfile, a:options)
+    call term_dumpwrite(a:buf, testfile, options_copy)
     call assert_report('See new dump file: call term_dumpload("testdir/' .. testfile .. '")')
     " No point in retrying.
     let g:run_nr = 10
     return 1
   endif
 
-  let refdump = ReadAndFilter(reference, filter)
+  let refdump_orig = ReadAndFilter(reference, filter)
+  let state = {}
   let i = 0
   while 1
     " Leave a bit of time for updating the original window while we spin wait.
     sleep 1m
     call delete(testfile)
-    call term_dumpwrite(a:buf, testfile, a:options)
+    call term_dumpwrite(a:buf, testfile, options_copy)
+    " Filtering done with "FileComparisonPreAction()" may change "refdump*".
+    let refdump = CopyStringList(refdump_orig)
     let testdump = ReadAndFilter(testfile, filter)
+    call FileComparisonPreAction(state, testdump, refdump)
     if refdump == testdump
       call delete(testfile)
       if did_mkdir
@@ -116,6 +209,7 @@ func VerifyScreenDump(buf, filename, options, ...)
       endif
       if testdump[j] != refdump[j]
 	let msg = msg . '; difference in line ' . (j + 1) . ': "' . testdump[j] . '"'
+	call NonEqualLineComparisonPostAction(state, testdump, j)
       endif
     endfor
 


### PR DESCRIPTION
As reported in #16559, bytes of a multibyte character may  
be written as separate U+FFFD characters in a `:terminal`  
window on a busy machine.  The testing facilities currently  
offer an optional filtering step to be carried out between  
reading and comparing the contents of two screendump files  
for each such file.  This filtering has been resorted to  
(#14767 and #16560) in an attempt to unconditionally replace  
known non-Latin-1 characters with an arbitrary substitute  
ASCII character and avoid this rendering mishap leading to  
syntax tests failures.  However, it has been overlooked at  
the time that metadata description (in shorthand) to follow  
spurious U+FFFD characters may be *distinct* and make the  
remainder of such a line, ASCII characters and whatnot, also  
unequal between compared screendump files.

While it is straightforward to adapt current filter files to  
ignore the line characters after the leftmost U+FFFD,

> It is challenging and error-prone to keep up to date filter  
> files because moving around examples in source files will  
> likely make redundant some previously required filter files  
> and, at the same time, it may require creating new filter  
> files for the same source file; substituting one multibyte  
> character for another multibyte character will also demand  
> a coordinated change for filter files.

Besides, unconditionally dropping arbitrary parts of a line  
is rather too blunt an instrument.  An alternative approach  
is to not use the supported filtering for this purpose; let  
a syntax test pass or fail initially; then *if* the same  
failure is imminent, drop the leftmost U+FFFD and the rest  
of the previously seen line (repeating it for all previously  
seen unequal lines) before another round of file contents  
comparing.  The obvious disadvantage with this filtering,  
unconditional and otherwise, is that if there are consistent  
failures for _other reasons_ and the unequal parts happen to  
be after U+FFFDs, then spurious test passing can happen when  
stars align for _a particular test runner_.

Hence syntax test authors should strive to write as little  
significant text after multibyte characters as syntactically  
permissible, write multibyte characters closer to EOL in  
general, and make sure that their checked-in and published  
`*.dump` files do not have any U+FFFDs.

It is also practical to refrain from attempting screendump  
generation if U+FFFDs can already be discovered, and instead  
try re-running from scratch the syntax test in hand, while  
accepting other recently generated screendumps without going  
through with new rounds of verification.

Reference:
https://github.com/vim/vim/pull/16470#issuecomment-2599848525
