### PR TITLE
tests: test_plugin_comment uses wrong :Check command

### DIFF
--- a/src/testdir/test_plugin_comment.vim
+++ b/src/testdir/test_plugin_comment.vim
@@ -1,7 +1,7 @@
 " Test for the comment package
 
+CheckRunVimInTerminal
 func Test_basic_comment()
-  CheckScreendump
   let lines =<< trim END
     vim9script
 
@@ -14,7 +14,6 @@ func Test_basic_comment()
   call writefile(lines, input_file, "D")
 
   let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
-
   call term_sendkeys(buf, "gcc")
   call term_sendkeys(buf, "2jgcip")
   let output_file = "comment_basic_test.vim"
@@ -22,14 +21,11 @@ func Test_basic_comment()
   defer delete(output_file)
 
   call StopVimInTerminal(buf)
-
   let result = readfile(output_file)
-
   call assert_equal(["# vim9script", "", "# def Hello()", '#   echo "Hello"', "# enddef"], result)
 endfunc
 
 func Test_basic_uncomment()
-  CheckScreendump
   let lines =<< trim END
     vim9script
 
@@ -42,7 +38,6 @@ func Test_basic_uncomment()
   call writefile(lines, input_file, "D")
 
   let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
-
   call term_sendkeys(buf, "gcc")
   call term_sendkeys(buf, "2jgcip")
   let output_file = "uncomment_basic_test.vim"
@@ -50,15 +45,12 @@ func Test_basic_uncomment()
   defer delete(output_file)
 
   call StopVimInTerminal(buf)
-
   let result = readfile(output_file)
-
   call assert_equal(["# vim9script", "", "def Hello()", '  echo "Hello"', "enddef"], result)
 endfunc
 
 func Test_backward_slash_uncomment()
   " Note this test depends on 'commentstring' setting in nroff ftplugin
-  CheckScreendump
   let lines =<< trim END
     .\" .TL Test backward slash uncomment
   END
@@ -67,21 +59,17 @@ func Test_backward_slash_uncomment()
   call writefile(lines, input_file, "D")
 
   let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
-
   call term_sendkeys(buf, "gcc")
   let output_file = "backward_slash_uncomment_test.mom"
   call term_sendkeys(buf, $":w {output_file}\<CR>")
   defer delete(output_file)
 
   call StopVimInTerminal(buf)
-
   let result = readfile(output_file)
-
   call assert_equal([".TL Test backward slash uncomment"], result)
 endfunc
 
 func Test_caseinsensitive_uncomment()
-  CheckScreendump
   let lines =<< trim END
       rem echo "Hello"
   END
@@ -90,21 +78,17 @@ func Test_caseinsensitive_uncomment()
   call writefile(lines, input_file, "D")
 
   let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
-
   call term_sendkeys(buf, "gcc")
   let output_file = "comment_testinsensitive_uncomment_test.bat"
   call term_sendkeys(buf, $":w {output_file}\<CR>")
   defer delete(output_file)
 
   call StopVimInTerminal(buf)
-
   let result = readfile(output_file)
-
   call assert_equal(['echo "Hello"'], result)
 endfunc
 
 func Test_bothends_comment()
-  CheckScreendump
   let lines =<< trim END
     int main() {}
   END
@@ -113,21 +97,17 @@ func Test_bothends_comment()
   call writefile(lines, input_file, "D")
 
   let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
-
   call term_sendkeys(buf, "gcc")
   let output_file = "comment_bothends_test.c"
   call term_sendkeys(buf, $":w {output_file}\<CR>")
   defer delete(output_file)
 
   call StopVimInTerminal(buf)
-
   let result = readfile(output_file)
-
   call assert_equal(["/* int main() {} */"], result)
 endfunc
 
 func Test_bothends_uncomment()
-  CheckScreendump
   let lines =<< trim END
     /* int main() { */
     /*   return 0; */
@@ -138,21 +118,17 @@ func Test_bothends_uncomment()
   call writefile(lines, input_file, "D")
 
   let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
-
   call term_sendkeys(buf, "gcip")
   let output_file = "uncomment_bothends_test.c"
   call term_sendkeys(buf, $":w {output_file}\<CR>")
   defer delete(output_file)
 
   call StopVimInTerminal(buf)
-
   let result = readfile(output_file)
-
   call assert_equal(["int main() {", "  return 0;", "}"], result)
 endfunc
 
 func Test_mixed_comment()
-  CheckScreendump
   let lines =<< trim END
     for x in range(10):
       # print(x)
@@ -163,21 +139,17 @@ func Test_mixed_comment()
   call writefile(lines, input_file, "D")
 
   let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
-
   call term_sendkeys(buf, "gcG")
   let output_file = "comment_mixed_test.py"
   call term_sendkeys(buf, $":w {output_file}\<CR>")
   defer delete(output_file)
 
   call StopVimInTerminal(buf)
-
   let result = readfile(output_file)
-
   call assert_equal(["# for x in range(10):", "#   # print(x)", "#   # print(x*x)"], result)
 endfunc
 
 func Test_mixed_comment2()
-  CheckScreendump
   let lines =<< trim END
     # for x in range(10):
       print(x)
@@ -188,42 +160,34 @@ func Test_mixed_comment2()
   call writefile(lines, input_file, "D")
 
   let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
-
   call term_sendkeys(buf, "gcG")
   let output_file = "comment_mixed_test2.py"
   call term_sendkeys(buf, $":w {output_file}\<CR>")
   defer delete(output_file)
 
   call StopVimInTerminal(buf)
-
   let result = readfile(output_file)
-
   call assert_equal(["# # for x in range(10):", "#   print(x)", "#   # print(x*x)"], result)
 endfunc
 
 func Test_mixed_indent_comment()
-  CheckScreendump
   let lines = ["int main() {", "\tif 1 {", "\t  return 0;", "\t}", "    return 1;", "}"]
 
   let input_file = "test_mixed_indent_comment_input.c"
   call writefile(lines, input_file, "D")
 
   let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
-
   call term_sendkeys(buf, "gcip")
   let output_file = "comment_mixed_indent_test.c"
   call term_sendkeys(buf, $":w {output_file}\<CR>")
   defer delete(output_file)
 
   call StopVimInTerminal(buf)
-
   let result = readfile(output_file)
-
   call assert_equal(["/* int main() { */", "\t/* if 1 { */", "\t  /* return 0; */",  "\t/* } */", "    /* return 1; */", "/* } */"], result)
 endfunc
 
 func Test_buffer_first_col_comment()
-  CheckScreendump
   let lines =<< trim END
     def Hello():
       print("Hello")
@@ -234,21 +198,17 @@ func Test_buffer_first_col_comment()
   call writefile(lines, input_file, "D")
 
   let buf = RunVimInTerminal('-c "packadd comment" -c "let b:comment_first_col=1" ' .. input_file, {})
-
   call term_sendkeys(buf, "jgcc")
   let output_file = "comment_first_col_test.py"
   call term_sendkeys(buf, $":w {output_file}\<CR>")
   defer delete(output_file)
 
   call StopVimInTerminal(buf)
-
   let result = readfile(output_file)
-
   call assert_equal(["def Hello():", '#   print("Hello")', "  pass"], result)
 endfunc
 
 func Test_global_first_col_comment()
-  CheckScreendump
   let lines =<< trim END
     def Hello():
       print("Hello")
@@ -259,21 +219,17 @@ func Test_global_first_col_comment()
   call writefile(lines, input_file, "D")
 
   let buf = RunVimInTerminal('-c "packadd comment" -c "let g:comment_first_col=1" ' .. input_file, {})
-
   call term_sendkeys(buf, "jgcj")
   let output_file = "comment_first_col_test.py"
   call term_sendkeys(buf, $":w {output_file}\<CR>")
   defer delete(output_file)
 
   call StopVimInTerminal(buf)
-
   let result = readfile(output_file)
-
   call assert_equal(["def Hello():", '#   print("Hello")', "#   pass"], result)
 endfunc
 
 func Test_textobj_icomment()
-  CheckScreendump
   let lines =<< trim END
     for x in range(10):
       print(x) # printing stuff
@@ -291,21 +247,17 @@ func Test_textobj_icomment()
   call writefile(lines, input_file, "D")
 
   let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
-
   call term_sendkeys(buf, "dic..")
   let output_file = "comment_textobj_icomment.py"
   call term_sendkeys(buf, $":w {output_file}\<CR>")
   defer delete(output_file)
 
   call StopVimInTerminal(buf)
-
   let result = readfile(output_file)
-
   call assert_equal(["for x in range(10):", "  print(x) ", "  print(x*x*x*x) ", "  print(x*x*x*x*x) ", "", "  print(x*x*x*x*x)"], result)
 endfunc
 
 func Test_textobj_icomment2()
-  CheckScreendump
   let lines =<< trim END
     #include <stdio.h>
 
@@ -323,21 +275,17 @@ func Test_textobj_icomment2()
   call writefile(lines, input_file, "D")
 
   let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
-
   call term_sendkeys(buf, "dic..")
   let output_file = "comment_textobj_icomment2.c"
   call term_sendkeys(buf, $":w {output_file}\<CR>")
   defer delete(output_file)
 
   call StopVimInTerminal(buf)
-
   let result = readfile(output_file)
-
   call assert_equal(["#include <stdio.h>", "", "int main() {", "    printf(\"hello\");  printf(\" world\\n\");", "    ", "", "    return 0;", "}"], result)
 endfunc
 
 func Test_textobj_icomment3()
-  CheckScreendump
   let lines =<< trim END
     #include <stdio.h>
 
@@ -351,21 +299,17 @@ func Test_textobj_icomment3()
   call writefile(lines, input_file, "D")
 
   let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
-
   call term_sendkeys(buf, "jjjdic")
   let output_file = "comment_textobj_icomment3.c"
   call term_sendkeys(buf, $":w {output_file}\<CR>")
   defer delete(output_file)
 
   call StopVimInTerminal(buf)
-
   let result = readfile(output_file)
-
   call assert_equal(["#include <stdio.h>", "", "int main() {", "    printf(\"hello\");printf(\" world\\n\");",  "    return 0;", "}"], result)
 endfunc
 
 func Test_textobj_acomment()
-  CheckScreendump
   let lines =<< trim END
     for x in range(10):
       print(x) # printing stuff
@@ -383,21 +327,17 @@ func Test_textobj_acomment()
   call writefile(lines, input_file, "D")
 
   let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
-
   call term_sendkeys(buf, "dac..")
   let output_file = "comment_textobj_acomment.py"
   call term_sendkeys(buf, $":w {output_file}\<CR>")
   defer delete(output_file)
 
   call StopVimInTerminal(buf)
-
   let result = readfile(output_file)
-
   call assert_equal(["for x in range(10):", "  print(x)", "  print(x*x*x*x)", "  print(x*x*x*x*x)", "", "  print(x*x*x*x*x)"], result)
 endfunc
 
 func Test_textobj_acomment2()
-  CheckScreendump
   let lines =<< trim END
     #include <stdio.h>
 
@@ -415,21 +355,17 @@ func Test_textobj_acomment2()
   call writefile(lines, input_file, "D")
 
   let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
-
   call term_sendkeys(buf, "dac.")
   let output_file = "comment_textobj_acomment2.c"
   call term_sendkeys(buf, $":w {output_file}\<CR>")
   defer delete(output_file)
 
   call StopVimInTerminal(buf)
-
   let result = readfile(output_file)
-
   call assert_equal(["#include <stdio.h>", "", "int main() {", "    printf(\"hello\");printf(\" world\\n\");", "    return 0;", "}"], result)
 endfunc
 
 func Test_textobj_acomment3()
-  CheckScreendump
   let lines =<< trim END
     #include <stdio.h>
 
@@ -443,21 +379,17 @@ func Test_textobj_acomment3()
   call writefile(lines, input_file, "D")
 
   let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
-
   call term_sendkeys(buf, "jjjdac")
   let output_file = "comment_textobj_acomment3.c"
   call term_sendkeys(buf, $":w {output_file}\<CR>")
   defer delete(output_file)
 
   call StopVimInTerminal(buf)
-
   let result = readfile(output_file)
-
   call assert_equal(["#include <stdio.h>", "", "int main() {", "    printf(\"hello\");printf(\" world\\n\");",  "    return 0;", "}"], result)
 endfunc
 
 func Test_textobj_firstline_comment()
-  CheckScreendump
   let lines =<< trim END
     /*#include <stdio.h>*/
 
@@ -468,21 +400,17 @@ func Test_textobj_firstline_comment()
   call writefile(lines, input_file, "D")
 
   let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
-
   call term_sendkeys(buf, "dac")
   let output_file = "comment_textobj_firstline_comment.c"
   call term_sendkeys(buf, $":w {output_file}\<CR>")
   defer delete(output_file)
 
   call StopVimInTerminal(buf)
-
   let result = readfile(output_file)
-
   call assert_equal(["int main() {}"], result)
 endfunc
 
 func Test_textobj_noleading_space_comment()
-  CheckScreendump
   let lines =<< trim END
     int main() {// main start
     }/* main end */
@@ -492,21 +420,17 @@ func Test_textobj_noleading_space_comment()
   call writefile(lines, input_file, "D")
 
   let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
-
   call term_sendkeys(buf, "dacdic")
   let output_file = "comment_textobj_noleading_space_comment.c"
   call term_sendkeys(buf, $":w {output_file}\<CR>")
   defer delete(output_file)
 
   call StopVimInTerminal(buf)
-
   let result = readfile(output_file)
-
   call assert_equal(["int main() {", "}"], result)
 endfunc
 
 func Test_textobj_noleading_space_comment2()
-  CheckScreendump
   let lines =<< trim END
     int main() {// main start
     }    /* main end */
@@ -516,63 +440,51 @@ func Test_textobj_noleading_space_comment2()
   call writefile(lines, input_file, "D")
 
   let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
-
   call term_sendkeys(buf, "dac.")
   let output_file = "comment_textobj_noleading_space_comment2.c"
   call term_sendkeys(buf, $":w {output_file}\<CR>")
   defer delete(output_file)
 
   call StopVimInTerminal(buf)
-
   let result = readfile(output_file)
-
   call assert_equal(["int main() {", "}"], result)
 endfunc
 
 func Test_textobj_trailing_spaces_comment()
-  CheckScreendump
   let lines = ['# print("hello")   ', '# print("world")   ', "#", 'print("!")']
 
   let input_file = "test_textobj_trailing_spaces_input.py"
   call writefile(lines, input_file, "D")
 
   let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
-
   call term_sendkeys(buf, "jdac")
   let output_file = "comment_textobj_trailing_spaces_comment.py"
   call term_sendkeys(buf, $":w {output_file}\<CR>")
   defer delete(output_file)
 
   call StopVimInTerminal(buf)
-
   let result = readfile(output_file)
-
   call assert_equal(['print("!")'], result)
 endfunc
 
 func Test_textobj_trailing_spaces_last_comment()
-  CheckScreendump
   let lines = ['# print("hello")   ', '# print("world")   ', "#", '', '']
 
   let input_file = "test_textobj_trailing_spaces_last_input.py"
   call writefile(lines, input_file, "D")
 
   let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
-
   call term_sendkeys(buf, "jdac")
   let output_file = "comment_textobj_trailing_spaces_last_comment.py"
   call term_sendkeys(buf, $":w {output_file}\<CR>")
   defer delete(output_file)
 
   call StopVimInTerminal(buf)
-
   let result = readfile(output_file)
-
   call assert_equal([], result)
 endfunc
 
 func Test_textobj_last_line_empty_comment()
-  CheckScreendump
   let lines =<< trim END
     # print("hello")
     #
@@ -583,21 +495,17 @@ func Test_textobj_last_line_empty_comment()
   call writefile(lines, input_file, "D")
 
   let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
-
   call term_sendkeys(buf, "dac")
   let output_file = "comment_textobj_last_line_empty_comment.py"
   call term_sendkeys(buf, $":w {output_file}\<CR>")
   defer delete(output_file)
 
   call StopVimInTerminal(buf)
-
   let result = readfile(output_file)
-
   call assert_equal([], result)
 endfunc
 
 func Test_textobj_cursor_on_leading_space_comment()
-  CheckScreendump
   let lines =<< trim END
     int main() {
         // multilple comments
@@ -609,21 +517,17 @@ func Test_textobj_cursor_on_leading_space_comment()
   call writefile(lines, input_file, "D")
 
   let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
-
   call term_sendkeys(buf, "jjdac")
   let output_file = "comment_textobj_cursor_on_leading_space_comment.c"
   call term_sendkeys(buf, $":w {output_file}\<CR>")
   defer delete(output_file)
 
   call StopVimInTerminal(buf)
-
   let result = readfile(output_file)
-
   call assert_equal(["int main() {", "}"], result)
 endfunc
 
 func Test_textobj_conseq_comment()
-  CheckScreendump
   let lines =<< trim END
     int main() {
         printf("hello"); // hello
@@ -636,21 +540,17 @@ func Test_textobj_conseq_comment()
   call writefile(lines, input_file, "D")
 
   let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
-
   call term_sendkeys(buf, "dac")
   let output_file = "comment_textobj_conseq_comment.c"
   call term_sendkeys(buf, $":w {output_file}\<CR>")
   defer delete(output_file)
 
   call StopVimInTerminal(buf)
-
   let result = readfile(output_file)
-
   call assert_equal(["int main() {", "    printf(\"hello\");", "    printf(\"world\");", "}"], result)
 endfunc
 
 func Test_textobj_conseq_comment2()
-  CheckScreendump
   let lines =<< trim END
     int main() {
         printf("hello"); // hello
@@ -664,21 +564,17 @@ func Test_textobj_conseq_comment2()
   call writefile(lines, input_file, "D")
 
   let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
-
   call term_sendkeys(buf, "dac")
   let output_file = "comment_textobj_conseq_comment2.c"
   call term_sendkeys(buf, $":w {output_file}\<CR>")
   defer delete(output_file)
 
   call StopVimInTerminal(buf)
-
   let result = readfile(output_file)
-
   call assert_equal(["int main() {", "    printf(\"hello\");", "", "    // world", "    printf(\"world\");", "}"], result)
 endfunc
 
 func Test_inline_comment()
-  CheckScreendump
   let lines =<< trim END
     echo "Hello" This should be a comment
   END
@@ -687,7 +583,6 @@ func Test_inline_comment()
   call writefile(lines, input_file, "D")
 
   let buf = RunVimInTerminal('-c "packadd comment" -c "nnoremap <expr> gC comment#Toggle()..''$''" ' .. input_file, {})
-
   call term_sendkeys(buf, "fTgC")
 
   let output_file = "comment_inline_test.vim"
@@ -695,13 +590,11 @@ func Test_inline_comment()
   defer delete(output_file)
 
   call StopVimInTerminal(buf)
-
   let result = readfile(output_file)
   call assert_equal(['echo "Hello" " This should be a comment'], result)
 endfunc
 
 func Test_inline_uncomment()
-  CheckScreendump
   let lines =<< trim END
     echo "Hello" " This should be a comment
   END
@@ -710,7 +603,6 @@ func Test_inline_uncomment()
   call writefile(lines, input_file, "D")
 
   let buf = RunVimInTerminal('-c "packadd comment" -c "nnoremap <expr> gC comment#Toggle()..''$''" ' .. input_file, {})
-
   call term_sendkeys(buf, '$F"gC')
 
   let output_file = "uncomment_inline_test.vim"
@@ -718,13 +610,11 @@ func Test_inline_uncomment()
   defer delete(output_file)
 
   call StopVimInTerminal(buf)
-
   let result = readfile(output_file)
   call assert_equal(['echo "Hello" This should be a comment'], result)
 endfunc
 
 func Test_textobj_selection_exclusive_inline_comment()
-  CheckScreendump
   let lines =<< trim END
     print("Hello") # selection exclusive
   END
@@ -733,7 +623,6 @@ func Test_textobj_selection_exclusive_inline_comment()
   call writefile(lines, input_file, "D")
 
   let buf = RunVimInTerminal('-c "set selection=exclusive" -c "packadd comment" ' .. input_file, {})
-
   call term_sendkeys(buf, "dac")
 
   let output_file = "test_selection_exclusive_inline_comment.py"
@@ -741,7 +630,6 @@ func Test_textobj_selection_exclusive_inline_comment()
   defer delete(output_file)
 
   call StopVimInTerminal(buf)
-
   let result = readfile(output_file)
   call assert_equal(['print("Hello")'], result)
 endfunc


### PR DESCRIPTION
Problem:  tests: test_plugin_comment uses :CheckScreenDump check but
          doesn't actually make use of a screen dump.

Solution: test_plugin_comment uses :CheckScreenDump in each single test
          case.  However, since we are not actually using screen dumps,
          it would be more correct to use :CheckRunVimInTerminal, since
          this is the actual command that we want to run. And instead of
          verifying this in each single test case, let's just do it once
          when sourcing the file. While doing this, also remove some
          white spaces

fyi @habamax 