### PR TITLE
Add "-indentonly" option to the `:retab` command

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -4333,6 +4333,7 @@ getcompletion({pat}, {type} [, {filtered}])		*getcompletion()*
 		messages	|:messages| suboptions
 		option		options
 		packadd		optional package |pack-add| names
+		retab		|:retab| suboptions
 		runtime		|:runtime| completion
 		scriptnames	sourced script names |:scriptnames|
 		shellcmd	Shell command

--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -991,22 +991,26 @@ This replaces each 'E' character with a euro sign.  Read more in |<Char->|.
 
 4.4 Changing tabs					*change-tabs*
 							*:ret* *:retab* *:retab!*
-:[range]ret[ab][!] [new_tabstop]
+:[range]ret[ab][!] [-indentonly] [{new-tabstop}]
 			Replace all sequences of white-space containing a
-			<Tab> with new strings of white-space using the new
-			tabstop value given.  If you do not specify a new
-			tabstop size or it is zero, Vim uses the current value
-			of 'tabstop'.
+			<Tab> with new strings of white-space using
+			{new-tabstop}.  If you do not specify {new-tabstop} or
+			it is zero, Vim uses the current value of 'tabstop'.
 			The current value of 'tabstop' is always used to
 			compute the width of existing tabs.
 			With !, Vim also replaces strings of only normal
 			spaces with tabs where appropriate.
 			With 'expandtab' on, Vim replaces all tabs with the
 			appropriate number of spaces.
-			This command sets 'tabstop' to the new value given,
-			and if performed on the whole file, which is default,
-			should not make any visible change.
-			Careful: This command modifies any <Tab> characters
+			This command sets 'tabstop' to {new-tabstop} and if
+			performed on the whole file, which is default, should
+			not make any visible change.
+
+			When [-indentonly] is specified, only the leading
+			white-space will be targeted. Any other consecutive
+			white-space will not be changed.
+
+			Warning: This command modifies any <Tab> characters
 			inside of strings in a C program.  Use "\t" to avoid
 			this (that's a good habit anyway).
 			`:retab!` may also change a sequence of spaces by

--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -1654,6 +1654,7 @@ completion can be enabled:
 	-complete=messages	|:messages| suboptions
 	-complete=option	options
 	-complete=packadd	optional package |pack-add| names
+	-complete=retab		|:retab| suboptions
 	-complete=runtime	file and directory names in |'runtimepath'|
 	-complete=scriptnames	sourced script names
 	-complete=shellcmd	Shell command

--- a/src/cmdexpand.c
+++ b/src/cmdexpand.c
@@ -2622,6 +2622,11 @@ set_context_by_cmdname(
 	    xp->xp_pattern = arg;
 	    break;
 
+	case CMD_retab:
+	    xp->xp_context = EXPAND_RETAB;
+	    xp->xp_pattern = arg;
+	    break;
+
 	case CMD_messages:
 	    xp->xp_context = EXPAND_MESSAGES;
 	    xp->xp_pattern = arg;
@@ -3206,6 +3211,18 @@ get_scriptnames_arg(expand_T *xp UNUSED, int idx)
 
 /*
  * Function given to ExpandGeneric() to obtain the possible arguments of the
+ * ":retab {-indentonly}" option.
+ */
+    static char_u *
+get_retab_arg(expand_T *xp UNUSED, int idx)
+{
+    if (idx == 0)
+	return (char_u *)"-indentonly";
+    return NULL;
+}
+
+/*
+ * Function given to ExpandGeneric() to obtain the possible arguments of the
  * ":messages {clear}" command.
  */
     static char_u *
@@ -3294,6 +3311,7 @@ ExpandOther(
 	{EXPAND_BREAKPOINT, get_breakadd_arg, TRUE, TRUE},
 	{EXPAND_SCRIPTNAMES, get_scriptnames_arg, TRUE, FALSE},
 #endif
+	{EXPAND_RETAB, get_retab_arg, TRUE, TRUE},
     };
     int	i;
     int ret = FAIL;

--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -764,6 +764,11 @@ func Test_getcompletion()
   let l = getcompletion('not', 'mapclear')
   call assert_equal([], l)
 
+  let l = getcompletion('', 'retab')
+  call assert_true(index(l, '-indentonly') >= 0)
+  let l = getcompletion('not', 'retab')
+  call assert_equal([], l)
+
   let l = getcompletion('.', 'shellcmd')
   call assert_equal(['./', '../'], filter(l, 'v:val =~ "\\./"'))
   call assert_equal(-1, match(l[2:], '^\.\.\?/$'))
@@ -820,6 +825,8 @@ func Test_getcompletion()
   call assert_equal([], l)
   let l = getcompletion('autocmd BufEnter * map <bu', 'cmdline')
   call assert_equal(['<buffer>'], l)
+  let l = getcompletion('retab! ', 'cmdline')
+  call assert_true(index(l, '-indentonly') >= 0)
 
   func T(a, c, p)
     let g:cmdline_compl_params = [a:a, a:c, a:p]

--- a/src/testdir/test_retab.vim
+++ b/src/testdir/test_retab.vim
@@ -9,9 +9,12 @@ func TearDown()
   bwipe!
 endfunc
 
-func Retab(bang, n, subopt='')
+func Retab(bang, n, subopt='', test_line='')
   let l:old_tabstop = &tabstop
   let l:old_line = getline(1)
+  if a:test_line != ''
+    call setline(1, a:test_line)
+  endif
   exe "retab" . a:bang . ' ' . a:subopt . ' ' . a:n
   let l:line = getline(1)
   call setline(1, l:old_line)
@@ -116,6 +119,24 @@ func Test_retab()
   call assert_equal("    a  \t    b        c    ",        Retab('!', 3, so))
   call assert_equal("    a  \t    b        c    ",        Retab('',  5, so))
   call assert_equal("    a  \t    b        c    ",        Retab('!', 5, so))
+
+  " Test for variations in leading whitespace
+  let so='-indentonly'
+  let test_line="    \t    a\t        "
+  set tabstop=8 noexpandtab
+  call assert_equal("\t    a\t        ",    Retab('',  '', so, test_line))
+  call assert_equal("\t    a\t        ",    Retab('!',  '', so, test_line))
+  set tabstop=8 expandtab
+  call assert_equal("            a\t        ", Retab('',  '', so, test_line))
+  call assert_equal("            a\t        ", Retab('!',  '', so, test_line))
+
+  let test_line="            a\t        "
+  set tabstop=8 noexpandtab
+  call assert_equal(test_line,              Retab('',  '', so, test_line))
+  call assert_equal("\t    a\t        ",    Retab('!',  '', so, test_line))
+  set tabstop=8 expandtab
+  call assert_equal(test_line,              Retab('',  '', so, test_line))
+  call assert_equal(test_line,              Retab('!',  '', so, test_line))
 
   set tabstop& expandtab&
 endfunc

--- a/src/testdir/test_retab.vim
+++ b/src/testdir/test_retab.vim
@@ -9,10 +9,10 @@ func TearDown()
   bwipe!
 endfunc
 
-func Retab(bang, n)
+func Retab(bang, n, subopt='')
   let l:old_tabstop = &tabstop
   let l:old_line = getline(1)
-  exe "retab" . a:bang . a:n
+  exe "retab" . a:bang . ' ' . a:subopt . ' ' . a:n
   let l:line = getline(1)
   call setline(1, l:old_line)
   if a:n > 0
@@ -71,6 +71,52 @@ func Test_retab()
   call assert_equal("    a       b        c    ",         Retab('',  5))
   call assert_equal("    a       b        c    ",         Retab('!', 5))
 
+  " Test with '-indentonly'
+  let so='-indentonly'
+  set tabstop=8 noexpandtab
+  call assert_equal("\ta  \t    b        c    ",          Retab('',  '', so))
+  call assert_equal("\ta  \t    b        c    ",          Retab('',  0, so))
+  call assert_equal("\ta  \t    b        c    ",          Retab('',  8, so))
+  call assert_equal("\ta  \t    b        c    ",          Retab('!', '', so))
+  call assert_equal("\ta  \t    b        c    ",          Retab('!', 0, so))
+  call assert_equal("\ta  \t    b        c    ",          Retab('!', 8, so))
+
+  call assert_equal("\t\ta  \t    b        c    ",        Retab('',  4, so))
+  call assert_equal("\t\ta  \t    b        c    ",        Retab('!', 4, so))
+
+  call assert_equal("        a  \t    b        c    ",    Retab('',  10, so))
+  call assert_equal("        a  \t    b        c    ",    Retab('!', 10, so))
+
+  set tabstop=8 expandtab
+  call assert_equal("        a  \t    b        c    ",    Retab('',  '', so))
+  call assert_equal("        a  \t    b        c    ",    Retab('',  0, so))
+  call assert_equal("        a  \t    b        c    ",    Retab('',  8, so))
+  call assert_equal("        a  \t    b        c    ",    Retab('!', '', so))
+  call assert_equal("        a  \t    b        c    ",    Retab('!', 0, so))
+  call assert_equal("        a  \t    b        c    ",    Retab('!', 8, so))
+
+  call assert_equal("        a  \t    b        c    ",    Retab(' ', 4, so))
+  call assert_equal("        a  \t    b        c    ",    Retab('!', 4, so))
+
+  call assert_equal("        a  \t    b        c    ",    Retab(' ', 10, so))
+  call assert_equal("        a  \t    b        c    ",    Retab('!', 10, so))
+
+  set tabstop=4 noexpandtab
+  call assert_equal("\ta  \t    b        c    ",          Retab('',  '', so))
+  call assert_equal("\ta  \t    b        c    ",          Retab('!', '', so))
+  call assert_equal("\t a  \t    b        c    ",         Retab('',  3, so))
+  call assert_equal("\t a  \t    b        c    ",         Retab('!', 3, so))
+  call assert_equal("    a  \t    b        c    ",        Retab('',  5, so))
+  call assert_equal("    a  \t    b        c    ",        Retab('!', 5, so))
+
+  set tabstop=4 expandtab
+  call assert_equal("    a  \t    b        c    ",        Retab('',  '', so))
+  call assert_equal("    a  \t    b        c    ",        Retab('!', '', so))
+  call assert_equal("    a  \t    b        c    ",        Retab('',  3, so))
+  call assert_equal("    a  \t    b        c    ",        Retab('!', 3, so))
+  call assert_equal("    a  \t    b        c    ",        Retab('',  5, so))
+  call assert_equal("    a  \t    b        c    ",        Retab('!', 5, so))
+
   set tabstop& expandtab&
 endfunc
 
@@ -80,6 +126,9 @@ func Test_retab_error()
   call assert_fails('ret -1000', 'E487:')
   call assert_fails('ret 10000', 'E475:')
   call assert_fails('ret 80000000000000000000', 'E475:')
+  call assert_fails('retab! -in', 'E475:')
+  call assert_fails('retab! -indentonly2', 'E475:')
+  call assert_fails('retab! -indentonlyx 0', 'E475:')
 endfunc
 
 func RetabLoop()

--- a/src/testdir/test_usercommands.vim
+++ b/src/testdir/test_usercommands.vim
@@ -425,6 +425,10 @@ func Test_CmdCompletion()
   call feedkeys(":DoCmd \<C-A>\<C-B>\"\<CR>", 'tx')
   call assert_equal('"DoCmd mswin xterm', @:)
 
+  com! -nargs=1 -complete=retab DoCmd :
+  call feedkeys(":DoCmd \<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"DoCmd -indentonly', @:)
+
   " Test for file name completion
   com! -nargs=1 -complete=file DoCmd :
   call feedkeys(":DoCmd READM\<Tab>\<C-B>\"\<CR>", 'tx')

--- a/src/usercmd.c
+++ b/src/usercmd.c
@@ -88,6 +88,7 @@ static keyvalue_T command_complete_tab[] =
     KEYVALUE_ENTRY(EXPAND_MESSAGES, "messages"),
     KEYVALUE_ENTRY(EXPAND_SETTINGS, "option"),
     KEYVALUE_ENTRY(EXPAND_PACKADD, "packadd"),
+    KEYVALUE_ENTRY(EXPAND_RETAB, "retab"),
     KEYVALUE_ENTRY(EXPAND_RUNTIME, "runtime"),
 #if defined(FEAT_EVAL)
     KEYVALUE_ENTRY(EXPAND_SCRIPTNAMES, "scriptnames"),

--- a/src/vim.h
+++ b/src/vim.h
@@ -860,6 +860,7 @@ extern int (*dyn_libintl_wputenv)(const wchar_t *envstring);
 #define EXPAND_HIGHLIGHT_GROUP  62
 #define EXPAND_FILETYPECMD	63
 #define EXPAND_PATTERN_IN_BUF	64
+#define EXPAND_RETAB		65
 
 
 // Values for exmode_active (0 is no exmode)


### PR DESCRIPTION
https://github.com/vim/vim/commit/57d6d004331f1770b5f04ba28ac242c0e0c8a005#r161938469

> I see. However, if a user accidentally indents using only spaces, running :retab won’t correctly convert them into tabs and spaces. A command that only applies :retab! to leading whitespace would be desirable. Or is this already possible with the current setup?