### PR TITLE
Fix the rendering of Unicode named literals.

### DIFF
--- a/runtime/syntax/python.vim
+++ b/runtime/syntax/python.vim
@@ -160,7 +160,8 @@ syn match   pythonEscape	"\\\o\{1,3}" contained
 syn match   pythonEscape	"\\x\x\{2}" contained
 syn match   pythonEscape	"\%(\\u\x\{4}\|\\U\x\{8}\)" contained
 " Python allows case-insensitive Unicode IDs: http://www.unicode.org/charts/
-syn match   pythonEscape	"\\N{\a\+\%(\s\a\+\)*}" contained
+" The specification: https://www.unicode.org/versions/Unicode16.0.0/core-spec/chapter-4/#G135165
+syn match   pythonEscape	"\\N{\a\+\%(\%(\s\a\+[[:alnum:]]*\)\|\%(-[[:alnum:]]\+\)\)*}" contained
 syn match   pythonEscape	"\\$"
 
 " It is very important to understand all details before changing the


### PR DESCRIPTION
The change:

* enforces that the alias starts with a letter
* allows the other words in an alias to be separated by either a space or a hyphen, but not both or double separators
* allows only a letter after space, possibly followed by letters or digits
* allows both letters and digits after a hyphen

Tested with:

    a = '\N{Cyrillic Small Letter Zhe} is pronounced as zh in pleasure'
    b = '\N{NO-BREAK SPACE} is needed here'
    # ... other tests here
    r = '\N{HENTAIGANA LETTER E-1} is a Japanese hiragana letter archaic ye'
    s = '\N{CUNEIFORM SIGN NU11 TENU} is a correction alias'
    t = '\N{RECYCLING SYMBOL FOR TYPE-1 PLASTICS} base shape is a triangle'
    print(a)
    print(b)
    print(r)
    print(s)
    print(t)

The tests confirm the behavior and are selected from real Unicode tables/aliases to check these combinations based on the specification.

Resolves https://github.com/vim/vim/issues/17323.