### PR TITLE
Fix: Issue #17725

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -2395,6 +2395,8 @@ ins_compl_need_restart(void)
 ins_compl_new_leader(void)
 {
     int	    cur_cot_flags = get_cot_flags();
+    int	    save_w_wrow;
+    int	    save_w_leftcol;
 
     ins_compl_del_pum();
     ins_compl_delete();
@@ -2424,8 +2426,10 @@ ins_compl_new_leader(void)
 	    out_flush_cursor(FALSE, FALSE);
 	}
 #endif
+	save_w_wrow = curwin->w_wrow;
+	save_w_leftcol = curwin->w_leftcol;
 	compl_restarting = TRUE;
-	if (ins_complete(Ctrl_N, TRUE) == FAIL)
+	if (ins_complete(Ctrl_N, FALSE) == FAIL)
 	    compl_cont_status = 0;
 	compl_restarting = FALSE;
     }
@@ -2451,7 +2455,8 @@ ins_compl_new_leader(void)
     compl_enter_selects = !compl_used_match && compl_selected_item != -1;
 
     // Show the popup menu with a different set of matches.
-    ins_compl_show_pum();
+    if (!compl_interrupted)
+	show_pum(save_w_wrow, save_w_leftcol);
 
     // Don't let Enter select the original text when there is no popup menu.
     if (compl_match_array == NULL)


### PR DESCRIPTION
Fixes https://github.com/vim/vim/issues/17725

Popup menu was not built after fuzzy sorting when interrupted (fast typing), so internal state wasn't reflected on screen.

No test. Couldn't get the terminal test to trigger both interruption and refresh together.

