### PR TITLE
Prevent repeated insertion and deletion of leader during {func} completion

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -6978,7 +6978,7 @@ setup_cpt_sources(void)
 	}
     }
     if (count == 0)
-	return OK;
+	goto theend;
 
     cpt_sources_clear();
     cpt_sources_count = count;
@@ -6986,6 +6986,7 @@ setup_cpt_sources(void)
     if (cpt_sources_array == NULL)
     {
 	cpt_sources_count = 0;
+	vim_free(cpt);
 	return FAIL;
     }
 
@@ -7005,6 +7006,7 @@ setup_cpt_sources(void)
 	}
     }
 
+theend:
     vim_free(cpt);
     return OK;
 }


### PR DESCRIPTION
Prevent unnecessary insertion and deletion of 'compl_orig_text' during expansion of function present in 'complete' option. This was happening during 'findstart=1' phase of completion.

Other minor refactoring.