### PR TITLE
An enum or a class with self references is not freed

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -6025,7 +6025,8 @@ partial_free(partial_T *pt)
     }
     else
 	func_ptr_unref(pt->pt_func);
-    object_unref(pt->pt_obj);
+    if (pt->pt_obj != NULL)
+	object_unref(pt->pt_obj);
 
     // "out_up" is no longer used, decrement refcount on partial that owns it.
     partial_unref(pt->pt_outer.out_up_partial);

--- a/src/testdir/test_vim9_class.vim
+++ b/src/testdir/test_vim9_class.vim
@@ -11032,7 +11032,6 @@ def Test_method_string()
   v9.CheckScriptSuccess(lines)
 enddef
 
-
 " Test for using a class in the class definition
 def Test_Ref_Class_Within_Same_Class()
   var lines =<< trim END
@@ -13151,5 +13150,22 @@ def Test_obj_class_member_type()
   END
   v9.CheckSourceFailure(lines, 'E1013: Argument 2: type mismatch, expected dict<number> but got dict<string> in extend()', 7)
 enddef
+
+" Test for garbage collecting a class with a member referring to the class
+" (self reference)
+func Test_class_selfref_gc()
+  let lines =<< trim END
+    vim9script
+    class Foo
+      static var MyFoo = Foo.new()
+      static var d = {a: [1, 2]}
+      static var l = [{a: 'a', b: 'b'}]
+    endclass
+    assert_equal(2, test_refcount(Foo))
+    test_garbagecollect_now()
+    assert_equal(2, test_refcount(Foo))
+  END
+  call v9.CheckSourceSuccess(lines)
+endfunc
 
 " vim: ts=8 sw=2 sts=2 expandtab tw=80 fdm=marker

--- a/src/testdir/test_vim9_enum.vim
+++ b/src/testdir/test_vim9_enum.vim
@@ -1647,4 +1647,21 @@ def Test_enum_echo()
   v9.CheckScriptSuccess(lines)
 enddef
 
+" Test for garbage collecting an enum with a complex member variables.
+func Test_class_selfref_gc()
+  let lines =<< trim END
+    vim9script
+    enum Foo
+      Red,
+      Blue
+      static var d = {a: [1, 2]}
+      static var l = [{a: 'a', b: 'b'}]
+    endenum
+    assert_equal(3, test_refcount(Foo))
+    test_garbagecollect_now()
+    assert_equal(3, test_refcount(Foo))
+  END
+  call v9.CheckSourceSuccess(lines)
+endfunc
+
 " vim: ts=8 sw=2 sts=2 expandtab tw=80 fdm=marker


### PR DESCRIPTION

An enum or a class with members which are objects of that class are not freed.   This is exposed by
the example given by @zzzyxwvut for the PR #17313 (generic function support).  As this is not
directly related to generic functions, I am creating a separate PR for this change.