### PR TITLE
runtime(swig): 'comments', 'commentstring' support

### DIFF
--- a/runtime/ftplugin/swig.vim
+++ b/runtime/ftplugin/swig.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin file
 " Language:	SWIG
 " Maintainer:	Julien Marrec <julien.marrec 'at' gmail com>
-" Last Change:	2023 November 23
+" Last Change:	2025 July 14
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin")
@@ -9,5 +9,7 @@ if exists("b:did_ftplugin")
 endif
 let b:did_ftplugin = 1
 
-let b:undo_ftplugin = "setlocal iskeyword<"
+let b:undo_ftplugin = "setlocal iskeyword< comments< commentstring<"
 setlocal iskeyword+=%
+setlocal comments=sO:*\ -,mO:*\ \ ,exO:*/,s1:/*,mb:*,ex:*/,://
+setlocal commentstring=//\ %s


### PR DESCRIPTION
Supports C/C++ style comments: https://www.swig.org/Doc1.3/SWIG.html#SWIG_nn5