### PR TITLE
Fix: Prevent crash when omnifunc completes in command-window

### DIFF
--- a/src/popupmenu.c
+++ b/src/popupmenu.c
@@ -1159,12 +1159,14 @@ pum_set_selected(int n, int repeat UNUSED)
 	 * 'completeopt' contains "preview" or "popup" or "popuphidden".
 	 * Skip this when tried twice already.
 	 * Skip this also when there is not much room.
+	 * Skip this for command-window when 'completeopt' contains "preview".
 	 * NOTE: Be very careful not to sync undo!
 	 */
 	if (pum_array[pum_selected].pum_info != NULL
 		&& Rows > 10
 		&& repeat <= 1
-		&& (cur_cot_flags & COT_ANY_PREVIEW))
+		&& (cur_cot_flags & COT_ANY_PREVIEW)
+		&& !((cur_cot_flags & COT_PREVIEW) && cmdwin_type != 0))
 	{
 	    win_T	*curwin_save = curwin;
 	    tabpage_T   *curtab_save = curtab;

--- a/src/testdir/test_popup.vim
+++ b/src/testdir/test_popup.vim
@@ -2289,6 +2289,7 @@ func Test_popup_complete_cmdwin_preview()
   endfunc
   set omnifunc=CompleteWithPreview
   call feedkeys("q:if\<C-X>\<C-O>\<C-N>\<ESC>\<CR>", 'tx!')
+  set omnifunc&
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_popup.vim
+++ b/src/testdir/test_popup.vim
@@ -2278,5 +2278,17 @@ func Test_pum_position_when_wrap()
   call StopVimInTerminal(buf)
 endfunc
 
+" Test that Vim does not crash when completion inside cmdwin opens a 'info'
+" preview window.
+func Test_popup_complete_cmdwin_preview()
+  func! CompleteWithPreview(findstart, base)
+    if a:findstart
+      return getline('.')->strpart(0, col('.') - 1)
+    endif
+    return [#{word: 'echo', info: 'bar'}, #{word: 'echomsg', info: 'baz'}]
+  endfunc
+  set omnifunc=CompleteWithPreview
+  call feedkeys("q:if\<C-X>\<C-O>\<C-N>\<ESC>\<CR>", 'tx!')
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION


**Problem:**

Vim crashes during omnifunc completion inside the command-line window (`q:`) if the completion item attempts to open an "info" preview window. This is caused by a failed assert.

**Solution:**

Avoid opening preview windows while inside the command-line window.