### PR TITLE
fix(build): PKG_CONFIG is defined too late

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -25,6 +25,10 @@ AC_EXEEXT
 
 AC_HEADER_SYS_WAIT
 
+if test -z "$PKG_CONFIG"; then
+  AC_PATH_TOOL(PKG_CONFIG, pkg-config, no)
+fi
+
 dnl Check that the C99 features that Vim uses are supported:
 if test x"$ac_cv_prog_cc_c99" != xno; then
   dnl If the compiler doesn't explicitly support C99, then check
@@ -2884,10 +2888,6 @@ AC_DEFUN([GNOME_INIT_HOOK],
 AC_DEFUN([GNOME_INIT],[
 	GNOME_INIT_HOOK([],fail)
 ])
-
-if test -z "$PKG_CONFIG"; then
-  AC_PATH_TOOL(PKG_CONFIG, pkg-config, no)
-fi
 
 dnl ---------------------------------------------------------------------------
 dnl Check for GTK3. If it succeeds, skip the check for GTK2.


### PR DESCRIPTION
(Incl. in https://github.com/vim/vim/pull/17772)

Discovered this while working on `pkg-config` for the recent wayland support.

It seems like this was an oversight. Its first defined here:
https://github.com/vim/vim/blame/master/src/configure.ac#L2857

But used earlier:
https://github.com/vim/vim/blob/master/src/configure.ac#L2704-L2857

Which means these checks won't work without this change.

Also note this comment here.  I believe this is correct and for backwards compat. Maybe this should be documented instead at the top and this comment removed?
https://github.com/vim/vim/blob/master/src/configure.ac#L2715-L2717

Can you confirm the premise of the comment @chrisbra ?

Is there still a reason why we can't use `pkg.m4` aka `PKG_CHECK_MODULES` as of today.

This which would make these autoconf scripts simpler. I think especially https://github.com/vim/vim/blob/master/src/configure.ac could use some refactoring and uniform style for easier maintenance going forward.