### PR TITLE
tests: Test_popup_complete_info_01() fails when run alone

### DIFF
--- a/src/testdir/test_popup.vim
+++ b/src/testdir/test_popup.vim
@@ -214,6 +214,8 @@ func Test_popup_complete()
   call feedkeys("aM\<f5>\<enter>\<esc>", 'tx')
   call assert_equal(["March", "M", "March"], getline(1,4))
   %d
+
+  set completeopt&
 endfunc
 
 
@@ -1078,6 +1080,7 @@ func Test_popup_complete_info_01()
   setlocal thesaurus=Xdummy.txt
   setlocal omnifunc=syntaxcomplete#Complete
   setlocal completefunc=syntaxcomplete#Complete
+  setlocal completeopt+=noinsert
   setlocal spell
   for [keys, mode_name] in [
         \ ["", ''],


### PR DESCRIPTION
Problem:  tests: Test_popup_complete_info_01() fails when run alone.
Solution: Set buffer-local competeopt+=noinsert and add missing cleanup
          in Test_popup_complete().
