### PR TITLE
translation: mark vim.pot as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,13 +1,15 @@
 src/testdir/test42.in diff
 
-# vim.pot may change just by incrementing a patch number
-# so ignore the following differences:
-# - POT-Creation Date
-# - comments pointing to the message source location in
-#   *.c/*.h/*.vim/*.cpp/*.in/*.xs files followed by line numbers
-# set this up using:
-# git config diff.ignore_vim_pot.textconv "grep -Ev '^.(POT-Creation-Date:|.*\\.([ch]|vim|in|xs|cpp):).*$'"
-src/po/vim.pot diff=ignore_vim_pot
+# `vim.pot` is updated every time any of the *.c files are modified.  And as it
+# contains line numbers for strings from *.c files, inserting a line into a
+# single .c file may cause many lines in the `vim.pot` file to be updated.
+#
+# This generates a lot of "noise" in the diffs.  And especially considering that
+# `vim.pot` is a generated file, looking at changes in this file is not useful.
+#
+# By marking it as binary we tell the git machinery that it should not be
+# presented to the user in patches.
+src/po/vim.pot -diff
 
 # GitHub reacts to the `linguist-generated` attribute, by ignoring marked files
 # for the repository's language statistics and hiddning changes in these files


### PR DESCRIPTION
`vim.pot` is included in the repository after

```gitcommit
commit 59bd74ed4c9ab366182c93bdc430b186729abbad
Author: Christian Brabandt <cb@256bit.org>
Date:   Sun Jul 13 08:26:57 2025 +0200

    translation: include vim.pot in the repository
```

And it adds quite a lot of noise to the diffs since then.  See the reasoning in a comment in `.gitattributes`.

I'm not 100% sure that marking it as binary would have no negative side effects.  But I was not able to find a better option in `git help attributes`.

Solution suggested in

```gitcommit
commit 5d552d652b0197063565ab937d30f92a9ed28545
Author: Christian Brabandt <cb@256bit.org>
Date:   Tue Jul 15 20:42:48 2025 +0200

    translation: ignore vim.pot creation date, regenerate it, rm allfiles

    Signed-off-by: Christian Brabandt <cb@256bit.org>
```

does not seem to be solving the problem.  It only hides the `POT-Creation` line from the `vim.pot` diff.  Maybe a more elaborate filter could be used - one that replaces lines numbers in `vim.pot` with `xxxx`, thus removing the most annoying and useless part of the diff.

One downside is that it requires everyone to install such a filter locally - it can not be part of the repo config, as far as I understand.

I can write such a filter, if marking the whole file as binary is not an acceptable solution.