### PR TITLE
runtime(compiler): Add PHPStan compiler

### DIFF
--- a/runtime/compiler/phpstan.vim
+++ b/runtime/compiler/phpstan.vim
@@ -1,0 +1,12 @@
+" Vim compiler file
+" Compiler:	PHPStan
+" Maintainer:	Dietrich Moerman <dietrich.moerman@gmail.com>
+" Last Change:	2025 Jul 17
+
+if exists("current_compiler")
+  finish
+endif
+let current_compiler = "phpstan"
+
+CompilerSet makeprg=composer\ exec\ --\ phpstan\ analyse\ -v\ --no-progress\ --error-format=raw
+CompilerSet errorformat=%f:%l:%m,%-G%.%#


### PR DESCRIPTION
PHPStan is a static analyser for PHP.

This compiler plugin runs it using `composer exec` and enables verbosity level 1 to show error identifiers (useful for adding ignore comments).