### PR TITLE
translation: mark vim.pot as mostly ignored for GitHub

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,10 @@ src/testdir/test42.in diff
 # set this up using:
 # git config diff.ignore_pot_date.textconv 'grep -Ev "^.(POT-Creation-Date:|.*version\.c).*"'
 src/po/vim.pot diff=ignore_pot_date
+
+# GitHub reacts to the `linguist-generated` attribute, by ignoring marked files
+# for the repository's language statistics and hiddning changes in these files
+# by default in diffs.
+#
+# https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github
+src/po/vim.pot linguist-generated=true


### PR DESCRIPTION
This change is also part of https://github.com/vim/vim/pull/17775.
But if we want to merge it in separately, we can do so using this PR.