### PR TITLE
fix(build): wayland disabled on `--with-features=tiny`

### DIFF
--- a/src/auto/configure
+++ b/src/auto/configure
@@ -9216,12 +9216,20 @@ if test ${with_wayland+y}
 then :
   withval=$with_wayland; with_wayland=$withval
 else case e in #(
-  e) with_wayland=yes ;;
+  e) if test "x$features" = xtiny
+then :
+  with_wayland=no
+			 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: cannot use wayland with tiny features" >&5
+printf "%s\n" "cannot use wayland with tiny features" >&6; }
+else case e in #(
+  e) with_wayland=yes
+			 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; } ;;
+esac
+fi ;;
 esac
 fi
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $with_wayland" >&5
-printf "%s\n" "$with_wayland" >&6; }
 
 if test "$with_wayland" = yes; then
 cflags_save=$CFLAGS
@@ -14442,18 +14450,18 @@ then :
 fi
 if test "$enable_largefile,$enable_year2038" != no,no
 then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CC option to enable large file support" >&5
-printf %s "checking for $CC option to enable large file support... " >&6; }
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CPPFLAGS option for large files" >&5
+printf %s "checking for $CPPFLAGS option for large files... " >&6; }
 if test ${ac_cv_sys_largefile_opts+y}
 then :
   printf %s "(cached) " >&6
 else case e in #(
-  e) ac_save_CC="$CC"
+  e) ac_save_CPPFLAGS=$CPPFLAGS
   ac_opt_found=no
-  for ac_opt in "none needed" "-D_FILE_OFFSET_BITS=64" "-D_LARGE_FILES=1" "-n32"; do
+  for ac_opt in "none needed" "-D_FILE_OFFSET_BITS=64" "-D_LARGE_FILES=1"; do
     if test x"$ac_opt" != x"none needed"
 then :
-  CC="$ac_save_CC $ac_opt"
+  CPPFLAGS="$ac_save_CPPFLAGS $ac_opt"
 fi
     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -14482,12 +14490,12 @@ then :
   if test x"$ac_opt" = x"none needed"
 then :
   # GNU/Linux s390x and alpha need _FILE_OFFSET_BITS=64 for wide ino_t.
-	 CC="$CC -DFTYPE=ino_t"
+	 CPPFLAGS="$CPPFLAGS -DFTYPE=ino_t"
 	 if ac_fn_c_try_compile "$LINENO"
 then :
 
 else case e in #(
-  e) CC="$CC -D_FILE_OFFSET_BITS=64"
+  e) CPPFLAGS="$CPPFLAGS -D_FILE_OFFSET_BITS=64"
 	    if ac_fn_c_try_compile "$LINENO"
 then :
   ac_opt='-D_FILE_OFFSET_BITS=64'
@@ -14503,7 +14511,7 @@ fi
 rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
     test $ac_opt_found = no || break
   done
-  CC="$ac_save_CC"
+  CPPFLAGS=$ac_save_CPPFLAGS
 
   test $ac_opt_found = yes || ac_cv_sys_largefile_opts="support not detected" ;;
 esac
@@ -14527,16 +14535,14 @@ printf "%s\n" "#define _FILE_OFFSET_BITS 64" >>confdefs.h
 
 printf "%s\n" "#define _LARGE_FILES 1" >>confdefs.h
  ;; #(
-  "-n32") :
-    CC="$CC -n32" ;; #(
   *) :
     as_fn_error $? "internal error: bad value for \$ac_cv_sys_largefile_opts" "$LINENO" 5 ;;
 esac
 
 if test "$enable_year2038" != no
 then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CC option for timestamps after 2038" >&5
-printf %s "checking for $CC option for timestamps after 2038... " >&6; }
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CPPFLAGS option for timestamps after 2038" >&5
+printf %s "checking for $CPPFLAGS option for timestamps after 2038... " >&6; }
 if test ${ac_cv_sys_year2038_opts+y}
 then :
   printf %s "(cached) " >&6

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -2408,8 +2408,11 @@ AC_MSG_CHECKING(--with-wayland argument)
 AC_ARG_WITH(wayland,
 	[  --with-wayland	  Include support for the Wayland protocol.],
 	[with_wayland=$withval],
-	[with_wayland=yes])
-AC_MSG_RESULT([$with_wayland])
+	AS_IF([test "x$features" = xtiny], 
+			[with_wayland=no
+			 AC_MSG_RESULT([cannot use wayland with tiny features])],
+			[with_wayland=yes
+			 AC_MSG_RESULT([yes])]))
 
 if test "$with_wayland" = yes; then
 cflags_save=$CFLAGS


### PR DESCRIPTION
```
...
checking --disable-netbeans argument... cannot use NetBeans with tiny features
checking --disable-channel argument... cannot use channels with tiny features
checking --enable-terminal argument... defaulting to no
checking --enable-autoservername argument... no
checking --enable-multibyte argument... yes
checking --disable-rightleft argument... no
checking --disable-arabic argument... no
checking --enable-xim argument... defaulting to auto
checking --enable-fontset argument... no
checking if shm_open is available... yes
checking --with-wayland argument... cannot use wayland with tiny features
...
```