### PR TITLE
fix(syntax): sh: unhandled errors

### DIFF
--- a/runtime/syntax/sh.vim
+++ b/runtime/syntax/sh.vim
@@ -174,9 +174,15 @@ endif
 
 " Set up folding commands for shell {{{1
 " =================================
-sil! delc ShFoldFunctions
-sil! delc ShFoldHereDoc
-sil! delc ShFoldIfDoFor
+if (":ShFoldFunctions") == 2
+  sil! delc ShFoldFunctions
+endif
+if (":ShFoldIfHereDoc") == 2
+  sil! delc ShFoldHereDoc
+endif
+if (":ShFoldIfDoFor") == 2
+  sil! delc ShFoldIfDoFor
+endif
 if s:sh_fold_functions
  com! -nargs=* ShFoldFunctions <args> fold
 else


### PR DESCRIPTION
These errors are subtle, but will populate `v:errmsg` and trigger `CmdLineLeave` autocmd  when moving/inserting in `.sh` files..

I probably only found these, because I had worked on an "*auto-jump* to vimscript line-no" function - regardless its nicer if these are handled and doesn't pollute the current editor sesson with unwanted behaviour.