### PR TITLE
Fix crash when opening popup to closing buffer

### DIFF
--- a/src/errors.h
+++ b/src/errors.h
@@ -3742,3 +3742,7 @@ EXTERN char e_cannot_have_more_than_nr_diff_anchors[]
 EXTERN char e_failed_to_find_all_diff_anchors[]
 	INIT(= N_("E1550: Failed to find all diff anchors"));
 #endif
+#ifdef FEAT_PROP_POPUP
+EXTERN char e_cannot_open_a_popup_window_to_a_closing_buffer[]
+	INIT(= N_("E1551: Cannot open a popup window to a closing buffer"));
+#endif

--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -2092,6 +2092,14 @@ popup_create(typval_T *argvars, typval_T *rettv, create_type_T type)
     else if (popup_is_notification(type))
 	tabnr = -1;  // show on all tabs
 
+    if (buf != NULL && buf->b_locked_split)
+    {
+	// disallow opening a popup to a closing buffer, which like splitting,
+	// can result in more windows displaying it
+	emsg(_(e_cannot_open_a_popup_window_to_a_closing_buffer));
+	return NULL;
+    }
+
     // Create the window and buffer.
     wp = win_alloc_popup_win();
     if (wp == NULL)

--- a/src/testdir/test_popupwin.vim
+++ b/src/testdir/test_popupwin.vim
@@ -4491,4 +4491,21 @@ func Test_popupwin_callback_closes_popupwin()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_popupwin_closing_buffer()
+  augroup Test_popupwin_closing_buffer
+    autocmd!
+    autocmd BufWipeout * ++once
+          \ call assert_fails('call popup_create(bufnr(), {})', 'E1551:')
+  augroup END
+
+  new
+  setlocal bufhidden=wipe
+  quit  " Popup window to closed buffer used to remain
+  redraw!  " Would crash
+
+  autocmd! Test_popupwin_closing_buffer
+  augroup! Test_popupwin_closing_buffer
+  %bd!
+endfunc
+
 " vim: shiftwidth=2 sts=2


### PR DESCRIPTION
Problem: can open a popup window to a closing buffer, leading to the buffer remaining open in the window after it's soon unloaded, causing crashes.

Solution: check b_locked_split when opening a popup window to an existing buffer.