### PR TITLE
Fix environment variable expansion for 'path' option

### DIFF
--- a/src/option.c
+++ b/src/option.c
@@ -2927,14 +2927,16 @@ option_expand(int opt_idx, char_u *val)
 
     /*
      * Expanding this with NameBuff, expand_env() must not be passed IObuff.
-     * Escape spaces when expanding 'tags', they are used to separate file
-     * names.
+     * Escape spaces when expanding 'tags' or 'path', they are used to separate
+     * file names.
      * For 'spellsuggest' expand after "file:".
      */
-    expand_env_esc(val, NameBuff, MAXPATHL,
-	    (char_u **)options[opt_idx].var == &p_tags, FALSE,
+    char_u ** var = (char_u **)options[opt_idx].var;
+    int esc = var == &p_tags || var == &p_path;
+
+    expand_env_esc(val, NameBuff, MAXPATHL, esc, FALSE,
 #ifdef FEAT_SPELL
-	    (char_u **)options[opt_idx].var == &p_sps ? (char_u *)"file:" :
+	    var == &p_sps ? (char_u *)"file:" :
 #endif
 				  NULL);
     if (STRCMP(NameBuff, val) == 0)   // they are the same

--- a/src/testdir/test_findfile.vim
+++ b/src/testdir/test_findfile.vim
@@ -834,5 +834,36 @@ func Test_findfunc_callback()
   %bw!
 endfunc
 
+" Test using environment variables with spaces
+func Test_path_env_variable_with_whitespaces()
+    let save_path = &path
+    defer execute('let &path = save_path')
+
+    let $testdir = 'Xpath with some whites'
+    call mkdir($testdir, 'R')
+
+    " Check direct usage yields the same result that autocomplete
+    call feedkeys(':set path=$testdir' .. "\<C-A>\<CR>", 'xt')
+    let auto_testpath = &path
+    " include autocomplete suffix
+    exe "set path=$testdir" .. "/"
+    call assert_equal(auto_testpath, &path)
+
+    " Check a file can be found using environment variables
+    let expanded_test_path = expand('$testdir/test.txt')
+    call writefile(['testing...'], expanded_test_path)
+
+    " hinting an environment variable path
+    call assert_equal(expanded_test_path, findfile('test.txt', $test_dir))
+
+    " using 'path' option with an environment variable
+    set path=$testdir
+    call assert_equal(expanded_test_path, findfile('test.txt'))
+
+    " using :find instead of findfile()
+    find test.txt
+    call assert_equal(expanded_test_path, expand('%:.'))
+    enew
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Using environment variables in `'path'` does not work if they contain whitespaces.
The whitespaces must be escaped in this option as in the `'tags'` option. For example:
```vim
set path=$ProgramFiles
```
ends up with `C:/Program Files` instead of `C:/Program\ Files`.
Curiously the autocompletion does not have this bug, doing:
```vim
call feedkeys(':set path=$ProgramFiles' .. "\<C-A>\<CR>", 'xt')
``` 
ends up with `C:/Program\ Files`.

It is a linux issue too but in windows environment variables with whitespaces are far more common.