### PR TITLE
Fix: Prevent redundant CmdlineChanged events

### DIFF
--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -4691,4 +4691,53 @@ func Test_pum_scroll_noselect()
   call StopVimInTerminal(buf)
 endfunc
 
+" CmdlineChanged shouldn't trigger if command-line text is unchanged
+func Test_cmdline_changed()
+  let g:cmdchg_count = 0
+  let g:cmdprefix = ''
+  augroup test_CmdlineAugrp | autocmd!
+    autocmd CmdlineChanged * if getcmdline() =~ g:cmdprefix | let g:cmdchg_count += 1 | endif
+  augroup END
+
+  new
+  set wildmenu
+  set wildmode=full
+
+  let g:cmdprefix = 'echomsg'
+  let g:cmdchg_count = 0
+  call feedkeys(":echomsg\<Tab>", "tx")
+  call assert_equal(1, g:cmdchg_count) " once only for 'g', not again for <Tab>
+
+  let g:cmdchg_count = 0
+  let g:cmdprefix = 'echo'
+  call feedkeys(":ech\<Tab>", "tx")
+  call assert_equal(1, g:cmdchg_count) " (once for 'h' and) once for 'o'
+
+  set wildmode=noselect,full
+  let g:cmdchg_count = 0
+  let g:cmdprefix = 'ech'
+  call feedkeys(":ech\<Tab>", "tx")
+  call assert_equal(1, g:cmdchg_count) " once for 'h', not again for <tab>
+
+  command! -nargs=+ -complete=custom,TestComplete Test echo
+
+  func TestComplete(arglead, cmdline, cursorpos)
+    return "AbC"
+  endfunc
+
+  set wildoptions=fuzzy wildmode=full
+  let g:cmdchg_count = 0
+  let g:cmdprefix = 'Test \(AbC\|abc\)'
+  call feedkeys(":Test abc\<Tab>", "tx")
+  call assert_equal(2, g:cmdchg_count) " once for 'c', again for 'AbC'
+
+  bw!
+  set wildmode& wildmenu& wildoptions&
+  augroup test_CmdlineAugrp | autocmd! | augroup END
+  unlet g:cmdchg_count
+  unlet g:cmdprefix
+  delfunc TestComplete
+  delcommand Test
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem: The `CmdlineChanged` event was firing unnecessarily, even when the command line's content hadn't actually changed.

Solution: I've added a check to compare the command-line buffer's state before and after key processing. The `CmdlineChanged` event now only triggers if the buffer's contents are genuinely different.
