### PR TITLE
Add Bold, Italic and BoldItalic default highlight groups

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -262,6 +262,9 @@ you can see the actual color, except for "Ignore"):
 	 Debug		debugging statements
 
 	*Underlined	text that stands out, HTML links
+	*Bold		bold text
+	*Italic		italic text
+	*BoldItalic	bold and italic text
 
 	*Ignore		left blank, hidden  |hl-Ignore|
 

--- a/runtime/syntax/help.vim
+++ b/runtime/syntax/help.vim
@@ -179,6 +179,9 @@ syn match helpDelimiter		"\t[* ]Delimiter\t\+[a-z].*"
 syn match helpSpecialComment	"\t[* ]SpecialComment\t\+[a-z].*"
 syn match helpDebug		"\t[* ]Debug\t\+[a-z].*"
 syn match helpUnderlined	"\t[* ]Underlined\t\+[a-z].*"
+syn match helpBold		"\t[* ]Bold\t\+[a-z].*"
+syn match helpItalic		"\t[* ]Italic\t\+[a-z].*"
+syn match helpBoldItalic	"\t[* ]BoldItalic\t\+[a-z].*"
 syn match helpError		"\t[* ]Error\t\+[a-z].*"
 syn match helpTodo		"\t[* ]Todo\t\+[a-z].*"
 
@@ -250,6 +253,9 @@ hi def link helpDelimiter	Delimiter
 hi def link helpSpecialComment	SpecialComment
 hi def link helpDebug		Debug
 hi def link helpUnderlined	Underlined
+hi def link helpBold		Bold
+hi def link helpItalic		Italic
+hi def link helpBoldItalic	BoldItalic
 hi def link helpError		Error
 hi def link helpTodo		Todo
 hi def link helpURL		String

--- a/runtime/syntax/syncolor.vim
+++ b/runtime/syntax/syncolor.vim
@@ -62,6 +62,9 @@ else
 endif
 SynColor Error		term=reverse cterm=NONE ctermfg=White ctermbg=Red gui=NONE guifg=White guibg=Red
 SynColor Todo		term=standout cterm=NONE ctermfg=Black ctermbg=Yellow gui=NONE guifg=Blue guibg=Yellow
+SynColor Bold		term=bold cterm=bold ctermfg=NONE ctermbg=NONE gui=bold guifg=NONE guibg=NONE
+SynColor Italic		term=italic cterm=italic ctermfg=NONE ctermbg=NONE gui=italic guifg=NONE guibg=NONE
+SynColor BoldItalic	term=bold,italic cterm=bold,italic ctermfg=NONE ctermbg=NONE gui=bold,italic guifg=NONE guibg=NONE
 
 " Common groups that link to default highlighting.
 " You can specify other highlighting easily.

--- a/src/testdir/test_syntax.vim
+++ b/src/testdir/test_syntax.vim
@@ -191,14 +191,14 @@ func Test_syntax_completion()
   " Check that clearing "Aap" avoids it showing up before Boolean.
   hi Aap ctermfg=blue
   call feedkeys(":syn list \<C-A>\<C-B>\"\<CR>", 'tx')
-  call assert_match('^"syn list Aap Added Boolean Changed Character ', @:)
+  call assert_match('^"syn list Aap Added Bold BoldItalic Boolean Changed Character ', @:)
   hi clear Aap
 
   call feedkeys(":syn list \<C-A>\<C-B>\"\<CR>", 'tx')
-  call assert_match('^"syn list Added Boolean Changed Character ', @:)
+  call assert_match('^"syn list Added Bold BoldItalic Boolean Changed Character ', @:)
 
   call feedkeys(":syn match \<C-A>\<C-B>\"\<CR>", 'tx')
-  call assert_match('^"syn match Added Boolean Changed Character ', @:)
+  call assert_match('^"syn match Added Bold BoldItalic Boolean Changed Character ', @:)
 
   syn cluster Aax contains=Aap
   call feedkeys(":syn list @A\<C-A>\<C-B>\"\<CR>", 'tx')


### PR DESCRIPTION
<img width="1019" height="613" alt="image" src="https://github.com/user-attachments/assets/47c2e21d-ce27-449b-a85a-695edcc64784" />

Useful to retain specific (markdown, html, reStructuredText, Asciidoc, etc) Bold, Italic and BoldItalic highlight groups.

E.g. now instead of:

```
hi def rstEmphasis term=italic cterm=italic gui=italic
hi def rstStrongEmphasis term=bold cterm=bold gui=bold
```

it would be possible to define:

```
hi def link rstEmphasis Italic
hi def link rstStrongEmphasis Bold
```

Which would survive colorscheme change (bold things would still be bold, italic - italic).