### PR TITLE
Feat: Add wildtrigger() function for command-line autocompletion

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -12338,7 +12338,7 @@ wildtrigger()						*wildtrigger()*
 		See |cmdline-completion|.
 
 		This function also enables completion in search patterns such
-		as |/|, |?|, |:s|, |:g|, |:v|, and |:vim|.
+		as |/|, |?|, |:s|, |:g|, |:v|, and |:vimgrep|.
 
 		Unlike pressing 'wildchar' manually, this function does not
 		produce a beep when no matches are found and generally

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -757,6 +757,7 @@ virtcol2col({winid}, {lnum}, {col})
 				Number  byte index of a character on screen
 visualmode([{expr}])		String	last visual mode used
 wildmenumode()			Number	whether 'wildmenu' mode is active
+wildtrigger()			Number	start wildcard expansion
 win_execute({id}, {command} [, {silent}])
 				String	execute {command} in window {id}
 win_findbuf({bufnr})		List	find windows containing {bufnr}
@@ -12327,6 +12328,33 @@ wildmenumode()					*wildmenumode()*
     :cnoremap <expr> <C-j> wildmenumode() ? "\<Down>\<Tab>" : "\<c-j>"
 <
 		(Note: this needs the 'wildcharm' option set appropriately).
+
+		Return type: |Number|
+
+
+wildtrigger()						*wildtrigger()*
+		Start wildcard expansion in the command-line, using the
+		behavior defined by the 'wildmode' and 'wildoptions' settings.
+		See |cmdline-completion|.
+
+		This function also enables completion in search patterns such
+		as |/|, |?|, |:s|, |:g|, |:v|, and |:vim|.
+
+		Unlike pressing 'wildchar' manually, this function does not
+		produce a beep when no matches are found and generally
+		operates more quietly.  This makes it suitable for triggering
+		completion automatically, such as from an |:autocmd|.
+							*cmdline-autocompletion*
+		Example: To make the completion menu pop up automatically as
+		you type on the command line, use: >
+			autocmd CmdlineChanged [:/?] call wildtrigger()
+			set wildmode=noselect:lastused,full wildoptions=pum
+<
+		To retain normal history navigation (up/down keys): >
+			cnoremap <Up>   <C-U><Up>
+			cnoremap <Down> <C-U><Down>
+<
+		Return value is always 0.
 
 		Return type: |Number|
 

--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -479,6 +479,8 @@ When repeating 'wildchar' or CTRL-N you cycle through the matches, eventually
 ending up back to what was typed.  If the first match is not what you wanted,
 you can use <S-Tab> or CTRL-P to go straight back to what you typed.
 
+See also |wildtrigger()|.
+
 The 'wildmenu' option can be set to show the matches just above the command
 line.
 

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -9794,7 +9794,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 <	'wildchar' also enables completion in search pattern contexts such as
 	|/|, |?|, |:s|, |:g|, |:v|, and |:vim|.  To insert a literal <Tab>
 	instead of triggering completion, type <C-V><Tab> or "\t".
-	See also |'wildoptions'|.
+	See also 'wildoptions' and |wildtrigger()|.
 	NOTE: This option is set to the Vi default value when 'compatible' is
 	set and to the Vim default value when 'compatible' is reset.
 

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -6614,6 +6614,7 @@ cmdarg-variable	eval.txt	/*cmdarg-variable*
 cmdbang-variable	eval.txt	/*cmdbang-variable*
 cmdcomplete_info()	builtin.txt	/*cmdcomplete_info()*
 cmdline-arguments	vi_diff.txt	/*cmdline-arguments*
+cmdline-autocompletion	builtin.txt	/*cmdline-autocompletion*
 cmdline-changed	version5.txt	/*cmdline-changed*
 cmdline-completion	cmdline.txt	/*cmdline-completion*
 cmdline-editing	cmdline.txt	/*cmdline-editing*
@@ -11603,6 +11604,7 @@ whitespace	pattern.txt	/*whitespace*
 wildcard	editing.txt	/*wildcard*
 wildcards	editing.txt	/*wildcards*
 wildmenumode()	builtin.txt	/*wildmenumode()*
+wildtrigger()	builtin.txt	/*wildtrigger()*
 win-scrolled-resized	windows.txt	/*win-scrolled-resized*
 win16	os_win32.txt	/*win16*
 win32	os_win32.txt	/*win32*

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -1233,6 +1233,7 @@ Mappings and Menus:			    *mapping-functions*
 	mapset()		restore a mapping
 	menu_info()		get information about a menu item
 	wildmenumode()		check if the wildmode is active
+	wildtrigger()		start wildcard expansion
 
 Testing:				    *test-functions*
 	assert_equal()		assert that two expressions values are equal

--- a/src/cmdexpand.c
+++ b/src/cmdexpand.c
@@ -238,6 +238,7 @@ nextwild(
     cmdline_info_T	*ccline = get_cmdline_info();
     int		i;
     char_u	*p;
+    int		from_wildtrigger_func = options & WILD_FUNC_TRIGGER;
 
     if (xp->xp_numfiles == -1)
     {
@@ -269,16 +270,21 @@ nextwild(
 	return FAIL;
     }
 
+    i = (int)(xp->xp_pattern - ccline->cmdbuff);
+    xp->xp_pattern_len = ccline->cmdpos - i;
+
+    // Skip showing matches if prefix is invalid during wildtrigger()
+    if (from_wildtrigger_func && xp->xp_context == EXPAND_COMMANDS
+	    && xp->xp_pattern_len == 0)
+	return FAIL;
+
     // If cmd_silent is set then don't show the dots, because redrawcmd() below
     // won't remove them.
-    if (!cmd_silent)
+    if (!cmd_silent && !from_wildtrigger_func)
     {
 	msg_puts("...");	    // show that we are busy
 	out_flush();
     }
-
-    i = (int)(xp->xp_pattern - ccline->cmdbuff);
-    xp->xp_pattern_len = ccline->cmdpos - i;
 
     if (type == WILD_NEXT || type == WILD_PREV
 	    || type == WILD_PAGEUP || type == WILD_PAGEDOWN)

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -3126,6 +3126,8 @@ static funcentry_T global_functions[] =
 			ret_string,	    f_visualmode},
     {"wildmenumode",	0, 0, 0,	    NULL,
 			ret_number,	    f_wildmenumode},
+    {"wildtrigger",	0, 0, 0,	    NULL,
+			ret_void,	    f_wildtrigger},
     {"win_execute",	2, 3, FEARG_2,	    arg23_win_execute,
 			ret_string,	    f_win_execute},
     {"win_findbuf",	1, 1, FEARG_1,	    arg1_number,

--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -957,9 +957,11 @@ cmdline_wildchar_complete(
     }
     else		    // typed p_wc first time
     {
-	if (c == p_wc || c == p_wcm)
+	if (c == p_wc || c == p_wcm || c == K_WILD)
 	{
 	    options |= WILD_MAY_EXPAND_PATTERN;
+	    if (c == K_WILD)
+		options |= WILD_FUNC_TRIGGER;
 	    if (pre_incsearch_pos)
 		xp->xp_pre_incsearch_pos = *pre_incsearch_pos;
 	    else
@@ -1395,7 +1397,7 @@ cmdline_browse_history(
     for (;;)
     {
 	// one step backwards
-	if (c == K_UP|| c == K_S_UP || c == Ctrl_P
+	if (c == K_UP || c == K_S_UP || c == Ctrl_P
 		|| c == K_PAGEUP || c == K_KPAGEUP)
 	{
 	    if (hiscnt == get_hislen())	// first time
@@ -1818,9 +1820,9 @@ getcmdline_int(
      */
     for (;;)
     {
-	int trigger_cmdlinechanged = TRUE;
-	int end_wildmenu;
-	int prev_cmdpos = ccline.cmdpos;
+	int	trigger_cmdlinechanged = TRUE;
+	int	end_wildmenu;
+	int	prev_cmdpos = ccline.cmdpos;
 
 	VIM_CLEAR(prev_cmdbuff);
 
@@ -2058,9 +2060,11 @@ getcmdline_int(
 	    }
 	}
 
-	// Completion for 'wildchar' or 'wildcharm' key.
-	if ((c == p_wc && !gotesc && KeyTyped) || c == p_wcm)
+	// Completion for 'wildchar', 'wildcharm', and wildtrigger()
+	if ((c == p_wc && !gotesc && KeyTyped) || c == p_wcm || c == K_WILD)
 	{
+	    if (c == K_WILD)
+		++emsg_silent;  // Silence the bell
 	    res = cmdline_wildchar_complete(c, firstc != '@', &did_wild_list,
 		    &wim_index, &xpc, &gotesc,
 #ifdef FEAT_SEARCH_EXTRA
@@ -2069,8 +2073,12 @@ getcmdline_int(
 		    NULL
 #endif
 		    );
+	    if (c == K_WILD)
+		--emsg_silent;
 	    if (res == CMDLINE_CHANGED)
 		goto cmdline_changed;
+	    if (c == K_WILD)
+		goto cmdline_not_changed;
 	}
 
 	gotesc = FALSE;
@@ -5109,3 +5117,30 @@ get_user_input(
     cmd_silent = cmd_silent_save;
 }
 #endif
+
+/*
+ * "wildtrigger()" function
+ */
+    void
+f_wildtrigger(typval_T *argvars UNUSED, typval_T *rettv UNUSED)
+{
+    if (!(State & MODE_CMDLINE) || char_avail() || wild_menu_showing
+	    || cmdline_pum_active())
+	return;
+
+    int cmd_type = get_cmdline_type();
+
+    if (cmd_type == ':' || cmd_type == '/' || cmd_type == '?')
+    {
+	// Add K_WILD as a single special key
+	char_u	key_string[4];
+
+	key_string[0] = K_SPECIAL;
+	key_string[1] = KS_EXTRA;
+	key_string[2] = KE_WILD;
+	key_string[3] = NUL;
+
+	// Insert it into the typeahead buffer
+	ins_typebuf(key_string, REMAP_NONE, 0, TRUE, FALSE);
+    }
+}

--- a/src/keymap.h
+++ b/src/keymap.h
@@ -279,6 +279,7 @@ enum key_extra
     , KE_S_BS = 105		// shift + <BS>
     , KE_SID = 106		// <SID> special key, followed by {nr};
     , KE_ESC = 107		// used for K_ESC
+    , KE_WILD = 108		// triggers wildmode completion
 };
 
 /*
@@ -490,6 +491,8 @@ enum key_extra
 #define K_COMMAND	TERMCAP2KEY(KS_EXTRA, KE_COMMAND)
 #define K_SCRIPT_COMMAND TERMCAP2KEY(KS_EXTRA, KE_SCRIPT_COMMAND)
 #define K_SID		TERMCAP2KEY(KS_EXTRA, KE_SID)
+
+#define K_WILD		TERMCAP2KEY(KS_EXTRA, KE_WILD)
 
 // Bits for modifier mask
 // 0x01 cannot be used, because the modifier must be 0x02 or higher

--- a/src/proto/ex_getln.pro
+++ b/src/proto/ex_getln.pro
@@ -39,6 +39,7 @@ void f_getcmdscreenpos(typval_T *argvars, typval_T *rettv);
 void f_getcmdtype(typval_T *argvars, typval_T *rettv);
 void f_setcmdline(typval_T *argvars, typval_T *rettv);
 void f_setcmdpos(typval_T *argvars, typval_T *rettv);
+void f_wildtrigger(typval_T *argvars, typval_T *rettv);
 int get_cmdline_firstc(void);
 int get_list_range(char_u **str, int *num1, int *num2);
 char *did_set_cedit(optset_T *args);

--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -4329,42 +4329,63 @@ func Test_cmdcomplete_info()
     autocmd CmdlineLeavePre * call expand('test_cmdline.*')
     autocmd CmdlineLeavePre * let g:cmdcomplete_info = string(cmdcomplete_info())
   augroup END
-  new
-  call assert_equal({}, cmdcomplete_info())
-  call feedkeys(":h echom\<cr>", "tx") " No expansion
-  call assert_equal('{}', g:cmdcomplete_info)
-  call feedkeys(":h echoms\<tab>\<cr>", "tx")
-  call assert_equal('{''cmdline_orig'': '''', ''pum_visible'': 0, ''matches'': [], ''selected'': 0}', g:cmdcomplete_info)
-  call feedkeys(":h echom\<tab>\<cr>", "tx")
-  call assert_equal(
-        \ '{''cmdline_orig'': ''h echom'', ''pum_visible'': 0, ''matches'': ['':echom'', '':echomsg''], ''selected'': 0}',
-        \ g:cmdcomplete_info)
-  call feedkeys(":h echom\<tab>\<tab>\<cr>", "tx")
-  call assert_equal(
-        \ '{''cmdline_orig'': ''h echom'', ''pum_visible'': 0, ''matches'': ['':echom'', '':echomsg''], ''selected'': 1}',
-        \ g:cmdcomplete_info)
-  call feedkeys(":h echom\<tab>\<tab>\<tab>\<cr>", "tx")
-  call assert_equal(
-        \ '{''cmdline_orig'': ''h echom'', ''pum_visible'': 0, ''matches'': ['':echom'', '':echomsg''], ''selected'': -1}',
-        \ g:cmdcomplete_info)
 
-  set wildoptions=pum
-  call feedkeys(":h echoms\<tab>\<cr>", "tx")
-  call assert_equal('{''cmdline_orig'': '''', ''pum_visible'': 0, ''matches'': [], ''selected'': 0}', g:cmdcomplete_info)
-  call feedkeys(":h echom\<tab>\<cr>", "tx")
-  call assert_equal(
-        \ '{''cmdline_orig'': ''h echom'', ''pum_visible'': 1, ''matches'': ['':echom'', '':echomsg''], ''selected'': 0}',
-        \ g:cmdcomplete_info)
-  call feedkeys(":h echom\<tab>\<tab>\<cr>", "tx")
-  call assert_equal(
-        \ '{''cmdline_orig'': ''h echom'', ''pum_visible'': 1, ''matches'': ['':echom'', '':echomsg''], ''selected'': 1}',
-        \ g:cmdcomplete_info)
-  call feedkeys(":h echom\<tab>\<tab>\<tab>\<cr>", "tx")
-  call assert_equal(
-        \ '{''cmdline_orig'': ''h echom'', ''pum_visible'': 1, ''matches'': ['':echom'', '':echomsg''], ''selected'': -1}',
-        \ g:cmdcomplete_info)
-  bw!
-  set wildoptions&
+  " Disable char_avail so that wildtrigger() does not bail out
+  call test_override("char_avail", 1)
+
+  cnoremap <F8> <C-R>=wildtrigger()[-1]<CR>
+
+  call assert_equal({}, cmdcomplete_info())
+
+  for trig in ["\<Tab>", "\<F8>"]
+    new
+    call assert_equal({}, cmdcomplete_info())
+    call feedkeys(":h echom\<cr>", "tx") " No expansion
+    call assert_equal('{}', g:cmdcomplete_info)
+    call feedkeys($":h echoms{trig}\<cr>", "tx")
+    call assert_equal('{''cmdline_orig'': '''', ''pum_visible'': 0, ''matches'': [], ''selected'': 0}', g:cmdcomplete_info)
+    call feedkeys($":h echom{trig}\<cr>", "tx")
+    call assert_equal(
+          \ '{''cmdline_orig'': ''h echom'', ''pum_visible'': 0, ''matches'': ['':echom'', '':echomsg''], ''selected'': 0}',
+          \ g:cmdcomplete_info)
+    call feedkeys($":h echom{trig}\<tab>\<cr>", "tx")
+    call assert_equal(
+          \ '{''cmdline_orig'': ''h echom'', ''pum_visible'': 0, ''matches'': ['':echom'', '':echomsg''], ''selected'': 1}',
+          \ g:cmdcomplete_info)
+    call feedkeys($":h echom{trig}\<tab>\<tab>\<cr>", "tx")
+    call assert_equal(
+          \ '{''cmdline_orig'': ''h echom'', ''pum_visible'': 0, ''matches'': ['':echom'', '':echomsg''], ''selected'': -1}',
+          \ g:cmdcomplete_info)
+
+    set wildoptions=pum
+    call feedkeys($":h echoms{trig}\<cr>", "tx")
+    call assert_equal('{''cmdline_orig'': '''', ''pum_visible'': 0, ''matches'': [], ''selected'': 0}', g:cmdcomplete_info)
+    call feedkeys($":h echom{trig}\<cr>", "tx")
+    call assert_equal(
+          \ '{''cmdline_orig'': ''h echom'', ''pum_visible'': 1, ''matches'': ['':echom'', '':echomsg''], ''selected'': 0}',
+          \ g:cmdcomplete_info)
+    call feedkeys($":h echom{trig}\<tab>\<cr>", "tx")
+    call assert_equal(
+          \ '{''cmdline_orig'': ''h echom'', ''pum_visible'': 1, ''matches'': ['':echom'', '':echomsg''], ''selected'': 1}',
+          \ g:cmdcomplete_info)
+    call feedkeys($":h echom{trig}\<tab>\<tab>\<cr>", "tx")
+    call assert_equal(
+          \ '{''cmdline_orig'': ''h echom'', ''pum_visible'': 1, ''matches'': ['':echom'', '':echomsg''], ''selected'': -1}',
+          \ g:cmdcomplete_info)
+    bw!
+    set wildoptions&
+  endfor
+
+  " wildtrigger() should not show matches when prefix is invalid
+  for pat in ["", " ", "22"]
+    call feedkeys($":{pat}\<F8>\<cr>", "tx") " No expansion
+    call assert_equal('{}', g:cmdcomplete_info)
+  endfor
+
+  augroup test_CmdlineLeavePre | autocmd! | augroup END
+  call test_override("char_avail", 0)
+  unlet g:cmdcomplete_info
+  cunmap <F8>
 endfunc
 
 func Test_redrawtabpanel_error()
@@ -4387,6 +4408,7 @@ func Test_search_complete()
 
   new
   cnoremap <buffer><expr> <F9> GetComplInfo()
+  cnoremap <buffer> <F8> <C-R>=wildtrigger()[-1]<CR>
 
   " Pressing <Tab> inserts tab character
   set wildchar=0
@@ -4397,7 +4419,7 @@ func Test_search_complete()
 
   call setline(1, ['the', 'these', 'thethe', 'thethere', 'foobar'])
 
-  for trig in ["\<tab>", "\<c-z>"]
+  for trig in ["\<tab>", "\<c-z>", "\<F8>"]
     " Test menu first item and order
     call feedkeys($"gg2j/t{trig}\<f9>", 'tx')
     call assert_equal(['the', 'thethere', 'there', 'these', 'thethe'], g:compl_info.matches)
@@ -4610,10 +4632,11 @@ func Test_range_complete()
   endfunc
   new
   cnoremap <buffer><expr> <F9> GetComplInfo()
+  cnoremap <buffer> <F8> <C-R>=wildtrigger()[-1]<CR>
 
   call setline(1, ['ab', 'ba', 'ca', 'af'])
 
-  for trig in ["\<tab>", "\<c-z>"]
+  for trig in ["\<tab>", "\<c-z>", "\<F8>"]
     call feedkeys($":%s/a{trig}\<f9>", 'xt')
     call assert_equal(['ab', 'a', 'af'], g:compl_info.matches)
     call feedkeys($":vim9cmd :%s/a{trig}\<f9>", 'xt')
@@ -4699,25 +4722,35 @@ func Test_cmdline_changed()
     autocmd CmdlineChanged * if getcmdline() =~ g:cmdprefix | let g:cmdchg_count += 1 | endif
   augroup END
 
+  " Disable char_avail so that wildtrigger() does not bail out
+  call test_override("char_avail", 1)
+
   new
+  cnoremap <buffer> <F8> <C-R>=wildtrigger()[-1]<CR>
   set wildmenu
   set wildmode=full
 
   let g:cmdprefix = 'echomsg'
-  let g:cmdchg_count = 0
-  call feedkeys(":echomsg\<Tab>", "tx")
-  call assert_equal(1, g:cmdchg_count) " once only for 'g', not again for <Tab>
+  for trig in ["\<Tab>", "\<F8>"]
+    let g:cmdchg_count = 0
+    call feedkeys($":echomsg{trig}", "tx")
+    call assert_equal(1, g:cmdchg_count) " once only for 'g', not again for <Tab>
+  endfor
 
-  let g:cmdchg_count = 0
   let g:cmdprefix = 'echo'
-  call feedkeys(":ech\<Tab>", "tx")
-  call assert_equal(1, g:cmdchg_count) " (once for 'h' and) once for 'o'
+  for trig in ["\<Tab>", "\<F8>"]
+    let g:cmdchg_count = 0
+    call feedkeys($":ech{trig}", "tx")
+    call assert_equal(1, g:cmdchg_count) " (once for 'h' and) once for 'o'
+  endfor
 
   set wildmode=noselect,full
-  let g:cmdchg_count = 0
   let g:cmdprefix = 'ech'
-  call feedkeys(":ech\<Tab>", "tx")
-  call assert_equal(1, g:cmdchg_count) " once for 'h', not again for <tab>
+  for trig in ["\<Tab>", "\<F8>"]
+    let g:cmdchg_count = 0
+    call feedkeys($":ech{trig}", "tx")
+    call assert_equal(1, g:cmdchg_count) " once for 'h', not again for <tab>
+  endfor
 
   command! -nargs=+ -complete=custom,TestComplete Test echo
 
@@ -4726,10 +4759,12 @@ func Test_cmdline_changed()
   endfunc
 
   set wildoptions=fuzzy wildmode=full
-  let g:cmdchg_count = 0
   let g:cmdprefix = 'Test \(AbC\|abc\)'
-  call feedkeys(":Test abc\<Tab>", "tx")
-  call assert_equal(2, g:cmdchg_count) " once for 'c', again for 'AbC'
+  for trig in ["\<Tab>", "\<F8>"]
+    let g:cmdchg_count = 0
+    call feedkeys($":Test abc{trig}", "tx")
+    call assert_equal(2, g:cmdchg_count) " once for 'c', again for 'AbC'
+  endfor
 
   bw!
   set wildmode& wildmenu& wildoptions&
@@ -4738,6 +4773,7 @@ func Test_cmdline_changed()
   unlet g:cmdprefix
   delfunc TestComplete
   delcommand Test
+  call test_override("char_avail", 0)
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/vim.h
+++ b/src/vim.h
@@ -897,6 +897,7 @@ extern int (*dyn_libintl_wputenv)(const wchar_t *envstring);
 #define BUF_DIFF_FILTER		    0x2000
 #define WILD_KEEP_SOLE_ITEM	    0x4000
 #define WILD_MAY_EXPAND_PATTERN	    0x8000
+#define WILD_FUNC_TRIGGER	    0x10000 // called from wildtrigger()
 
 // Flags for expand_wildcards()
 #define EW_DIR		0x01	// include directory names


### PR DESCRIPTION
This PR introduces a new `wildtrigger()` function.

See `:h wildtrigger()` (diffs in `builtin.txt` for how to enable command-line autocompletion).

`wildtrigger()` behaves like pressing the `wildchar,` but provides a more refined and controlled completion experience:

- Suppresses beeps when no matches are found.
- Avoids displaying irrelevant completions (like full command lists) when the prefix is insufficient or doesn't match.
- Skips completion if the typeahead buffer has pending input or if a wildmenu is already active.
- Does not print "..." before completion.

This is an improvement on the `feedkeys()` based autocompletion script given in https://github.com/vim/vim/pull/16759.

----------

Added:

Beyond reducing the amount of typing, autocompletion system can be used to build fuzzy pickers and interactive command interfaces. Below are two examples:

**Fuzzy file picker**: Transforms the native `:find` command into a fzf-like experience.

```vim
set findfunc=FuzzyFind

func FuzzyFind(cmdarg, _)
  if s:allfiles == []
    let s:allfiles = systemlist('find . \! \( -path "*/.git" -prune -o -name "*.sw?" \) -type f -follow')
  endif
  return a:cmdarg == '' ? s:allfiles : matchfuzzy(s:allfiles, a:cmdarg)
endfunc

let s:allfiles = []
autocmd CmdlineEnter : let s:allfiles = []
```

**Live grep**: Dynamically search and display matching lines as you type.

```vim
command! -nargs=+ -complete=customlist,GrepComplete Grep call VisitFile()

func GrepComplete(arglead, cmdline, cursorpos)
  let l:cmd = $'grep -REIHns "{a:arglead}" --exclude-dir=.git --exclude=".*"'
  let s:selected = ''
  return len(a:arglead) > 1 ? systemlist(l:cmd) : [] " Trigger after 2 chars
endfunc

func VisitFile()
  if (s:selected != '')
    let l:item = getqflist(#{lines: [s:selected]}).items[0]
    if l:item->has_key('bufnr')
      let l:pos = l:item.vcol > 0 ? 'setcharpos' : 'setpos'
      exec $':b +call\ {l:pos}(".",\ [0,\ {l:item.lnum},\ {l:item.col},\ 0]) {l:item.bufnr}'
      call setbufvar(l:item.bufnr, '&buflisted', 1)
    endif
  endif
endfunc
```

Auto-select the first item in the completion list, and (in case of grep) add the typed pattern into the command-line history:

```vim
autocmd CmdlineLeavePre :
      \ if get(cmdcomplete_info(), 'matches', []) != [] |
      \   let s:info = cmdcomplete_info() |
      \   if getcmdline() =~ '^\s*fin\%[d]\s' && s:info.selected == -1 |
      \     call setcmdline($'find {s:info.matches[0]}') |
      \   endif |
      \   if getcmdline() =~ '^\s*Grep\s' |
      \     let s:selected = s:info.selected != -1 ? s:info.matches[s:info.selected] : s:info.matches[0] |
      \     call setcmdline(s:info.cmdline_orig) |
      \   endif |
      \ endif
```

**NOTE**: It's usually not necessary to make these commands asynchronous using `job_start()` and polling for input with `getchar()`, as they perform well enough for typical use cases.

[![asciicast](https://asciinema.org/a/f03zEUzfsU034RDDFctGcq5i8.svg)](https://asciinema.org/a/f03zEUzfsU034RDDFctGcq5i8)

