### PR TITLE
patch 9.1.xxx gvim window lost its icons

### DIFF
--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -2704,6 +2704,10 @@ global_event_filter(GdkXEvent *xev,
     static void
 mainwin_realize(GtkWidget *widget UNUSED, gpointer data UNUSED)
 {
+#include "../runtime/vim16x16.xpm"
+#include "../runtime/vim32x32.xpm"
+#include "../runtime/vim48x48.xpm"
+
     GdkWindow * const mainwin_win = gtk_widget_get_window(gui.mainwin);
 
     // When started with "--echo-wid" argument, write window ID on stdout.
@@ -2718,10 +2722,32 @@ mainwin_realize(GtkWidget *widget UNUSED, gpointer data UNUSED)
 
     if (vim_strchr(p_go, GO_ICON) != NULL)
     {
-	/*
-	 * Add an icon to the main window. For fun and convenience of the user.
-	 */
-	gtk_window_set_icon_name(GTK_WINDOW(gui.mainwin), "gvim");
+	GtkIconTheme *icon_theme;
+
+	icon_theme = gtk_icon_theme_get_default();
+
+	if (icon_theme && gtk_icon_theme_has_icon(icon_theme, "gvim"))
+	{
+	    gtk_window_set_icon_name(GTK_WINDOW(gui.mainwin), "gvim");
+	}
+	else
+	{
+	    /*
+	     * Add an icon to the main window. For fun and convenience of the user.
+	     */
+	    GList *icons = NULL;
+
+	    icons = g_list_prepend(icons, gdk_pixbuf_new_from_xpm_data((const char **)vim16x16));
+	    icons = g_list_prepend(icons, gdk_pixbuf_new_from_xpm_data((const char **)vim32x32));
+	    icons = g_list_prepend(icons, gdk_pixbuf_new_from_xpm_data((const char **)vim48x48));
+
+	    gtk_window_set_icon_list(GTK_WINDOW(gui.mainwin), icons);
+
+	    // TODO: is this type cast OK?
+	    g_list_foreach(icons, (GFunc)(void *)&g_object_unref, NULL);
+	    g_list_free(icons);
+	}
+	g_object_unref(icon_theme);
     }
 
 #if !defined(USE_GNOME_SESSION)


### PR DESCRIPTION
Problem:  Since patch 9.1.1199 the gvim window no longer had _NET_WM_ICON
          nor WM_HINTS icon information, for example when not using a
	  Gnome or KDE desktop.

Solution: Check if the icon theme as used in patch 1199 contains a gvim
          icon. If so, set the window's icon from that. Otherwise
	  use the previous method.

closes:   #17703