### PR TITLE
Update instructions in autoconf.ac comments to say 2.72

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -1,6 +1,6 @@
 dnl configure.ac: autoconf script for Vim
 
-dnl Process this file with autoconf 2.71 to produce "configure".
+dnl Process this file with autoconf 2.72 to produce "configure".
 
 AC_INIT
 AC_CONFIG_SRCDIR([vim.h])


### PR DESCRIPTION
Vim v9.1.1369 updated the autoconf generation to be done using 2.72. Update comments to reflect that.

Relevant commit: 9670f61d46