### PR TITLE
chore(gui): deprecate GVIM_ENABLE_WAYLAND

### DIFF
--- a/runtime/doc/gui_x11.txt
+++ b/runtime/doc/gui_x11.txt
@@ -649,9 +649,8 @@ X11R5 with a library for X11R6 probably doesn't work (although the linking
 won't give an error message, Vim will crash later).
 
 							*gui-wayland*
-Initial support for the Wayland display server protocol has landed in patch
-9.1.0064. To enable it, you need to set the environment variable
-"$GVIM_ENABLE_WAYLAND" in your shell.
+Support for the Wayland display server protocol has landed in patch
+9.1.0064.
 
 Note: The Wayland protocol is subject to some restrictions, so the following
 functions won't work: |getwinpos()|, |getwinposx()|, |getwinposy()| and the

--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -1732,15 +1732,6 @@ gui_mch_init_check(void)
     }
 #endif
 
-#if GTK_CHECK_VERSION(3,10,0)
-    // Vim currently assumes that Gtk means X11, so it cannot use native Gtk
-    // support for other backends such as Wayland.
-    //
-    // Use an environment variable to enable unfinished Wayland support.
-    if (getenv("GVIM_ENABLE_WAYLAND") == NULL)
-	gdk_set_allowed_backends ("x11");
-#endif
-
 #ifdef FEAT_GUI_GNOME
     if (gtk_socket_id == 0)
 	using_gnome = 1;


### PR DESCRIPTION
I believe this can be removed. It seems like only a blocker for enabling the now maturing `FEAT_WAYLAND`.

I tried unsetting `WAYLAND_DISPLAY` as well and seeing how it would react, but this blocks.

The fallback of `clipmethod` works as expected and changing to `clipmethod=x11` from `clipmethod=wayland,x11` still works

Btw, I tried looking into making wayland independent of X11 libs with gvim - but this wasn't that straight-forward the X11 structures seems deeply ingrained in the `gvim` source.

Another thing I noticed going thru the docs - Its very sparse on human-details of the wayland clipboard feature, its mostly technical; https://github.com/vim/vim/blob/master/runtime/doc/wayland.txt#L52-L93

The closest you can find searching `wayland+clipboard` in same sentence is; https://github.com/vim/vim/blob/master/runtime/doc/various.txt#L528 - just a feature description.

I'm thinking it should probably improved here (mentioned and linked):
https://github.com/vim/vim/blob/master/runtime/doc/gui.txt#L437-L446
