### PR TITLE
Check the return value of skip_generic_func_type_args()

### DIFF
--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -5219,7 +5219,8 @@ common_function(typval_T *argvars, typval_T *rettv, int is_funcref)
 	{
 	    // generic function
 	    start_bracket = name;
-	    skip_generic_func_type_args(&name);
+	    if (skip_generic_func_type_args(&name) == FAIL)
+		goto theend;
 	}
 	if (*name != NUL)
 	    s = NULL;


### PR DESCRIPTION
Fix a static analysis warning.