### PR TITLE
vim9type: fix memory leak in parse_type_tuple()

### DIFF
--- a/src/vim9type.c
+++ b/src/vim9type.c
@@ -1886,8 +1886,10 @@ parse_type_tuple(
     ret_type = alloc_tuple_type(typecount, type_gap);
     ret_type->tt_flags = flags;
     ret_type->tt_argcount = typecount;
-    if (tuple_type_add_types(ret_type, typecount, type_gap) == FAIL)
-	return NULL;
+    if (tuple_type_add_types(ret_type, typecount, type_gap) == FAIL) {
+	ret_type = NULL;
+	goto on_err;
+	}
     mch_memmove(ret_type->tt_args, tuple_types_ga.ga_data,
 						sizeof(type_T *) * typecount);
 


### PR DESCRIPTION
In parse_type_tuple() at src/vim9type.c, we allocate memory in `tuple_types_ga` by ga_grow(), but forget to free it when tuple_type_add_types() fails. Replace `return NULL` with `goto on_err` to fix leak.