### PR TITLE
vim9generics: fix leak in parse_generic_func_type_args

### DIFF
--- a/src/vim9generics.c
+++ b/src/vim9generics.c
@@ -305,8 +305,10 @@ parse_generic_func_type_args(
 	char	*ret_name = type_name(type_arg, &ret_free);
 
 	// create space for the name and the new type
-	if (ga_grow(&gfatab->gfat_args, 1) == FAIL)
+	if (ga_grow(&gfatab->gfat_args, 1) == FAIL) {
+		vim_free(ret_free);
 	    return NULL;
+	}
 	generic_arg = (generic_T *)gfatab->gfat_args.ga_data +
 						gfatab->gfat_args.ga_len;
 	gfatab->gfat_args.ga_len++;


### PR DESCRIPTION
In parse_generic_func_type_args() at vim9generics.c, we allocate memory in ret_name and should free it by calling vim_free(ret_free). If ga_grow on gfatab->gfat_args failed, we forget to call vim_free(ret_free) thus would cause a leak. Add vim_free(ret_free) before return NULL.