### PR TITLE
Give an error when defining an enum or an interface inside a function

### DIFF
--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -4618,6 +4618,8 @@ E143	autocmd.txt	/*E143*
 E1432	vim9.txt	/*E1432*
 E1433	vim9.txt	/*E1433*
 E1434	vim9.txt	/*E1434*
+E1435	vim9class.txt	/*E1435*
+E1436	vim9class.txt	/*E1436*
 E144	various.txt	/*E144*
 E145	starting.txt	/*E145*
 E146	change.txt	/*E146*

--- a/runtime/doc/vim9class.txt
+++ b/runtime/doc/vim9class.txt
@@ -584,6 +584,8 @@ protected object methods, class variables and class methods.
 An interface can extend another interface using "extends".  The sub-interface
 inherits all the instance variables and methods from the super interface.
 
+An interface cannot be defined inside a function.	*E1436*
+
 ==============================================================================
 
 6.  More class details				*Vim9-class* *Class* *class*
@@ -971,7 +973,7 @@ of that class.  Unlike typical object instantiation with the |new()| method,
 enum instances cannot be created this way.
 
 An enum can only be defined in a |Vim9| script file.	*E1414*
-An enum cannot be defined inside a function.
+An enum cannot be defined inside a function.		*E1435*
 
 							*E1415*
 An enum name must start with an uppercase letter.  The name of an enum value

--- a/src/errors.h
+++ b/src/errors.h
@@ -3630,8 +3630,12 @@ EXTERN char e_concrete_method_str_override_with_generic_method_in_class_str[]
 	INIT(= N_("E1433: Overriding concrete method \"%s\" in class \"%s\" with a generic method"));
 EXTERN char e_generic_method_str_type_arguments_mismatch_in_class_str[]
 	INIT(= N_("E1434: Mismatched number of type variables for generic method  \"%s\" in class \"%s\""));
+EXTERN char e_enum_can_only_be_used_in_script[]
+	INIT(= N_("E1435: Enum can only be used in a script"));
+EXTERN char e_interface_can_only_be_used_in_script[]
+	INIT(= N_("E1436: Interface can only be used in a script"));
 #endif
-// E1435 - E1499 unused (reserved for Vim9 class support)
+// E1437 - E1499 unused (reserved for Vim9 class support)
 EXTERN char e_cannot_mix_positional_and_non_positional_str[]
 	INIT(= N_("E1500: Cannot mix positional and non-positional arguments: %s"));
 EXTERN char e_fmt_arg_nr_unused_str[]

--- a/src/testdir/test_vim9_class.vim
+++ b/src/testdir/test_vim9_class.vim
@@ -13168,4 +13168,18 @@ func Test_class_selfref_gc()
   call v9.CheckSourceSuccess(lines)
 endfunc
 
+" Test for defining an interface in a function
+def Test_interface_defined_in_function()
+  var lines =<< trim END
+    vim9script
+    def Fn()
+      var x = 1
+      interface Foo
+      endinterface
+    enddef
+    defcompile
+  END
+  v9.CheckScriptFailure(lines, 'E1436: Interface can only be used in a script', 2)
+enddef
+
 " vim: ts=8 sw=2 sts=2 expandtab tw=80 fdm=marker

--- a/src/testdir/test_vim9_enum.vim
+++ b/src/testdir/test_vim9_enum.vim
@@ -1664,4 +1664,19 @@ func Test_class_selfref_gc()
   call v9.CheckSourceSuccess(lines)
 endfunc
 
+" Test for defining an enum in a function
+def Test_enum_defined_in_function()
+  var lines =<< trim END
+    vim9script
+    def Fn()
+      var x = 1
+      enum Foo
+        Red,
+      endenum
+    enddef
+    defcompile
+  END
+  v9.CheckScriptFailure(lines, 'E1435: Enum can only be used in a script', 2)
+enddef
+
 " vim: ts=8 sw=2 sts=2 expandtab tw=80 fdm=marker

--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -4750,6 +4750,14 @@ compile_def_function_body(
 		    emsg(_(e_class_can_only_be_used_in_script));
 		    return FAIL;
 
+	    case CMD_enum:
+		    emsg(_(e_enum_can_only_be_used_in_script));
+		    return FAIL;
+
+	    case CMD_interface:
+		    emsg(_(e_interface_can_only_be_used_in_script));
+		    return FAIL;
+
 	    case CMD_type:
 		    emsg(_(e_type_can_only_be_used_in_script));
 		    return FAIL;


### PR DESCRIPTION
Fixes #17834 and #17835.