### PR TITLE
runtime(ccomplete): return partial results on complete_check()

### DIFF
--- a/runtime/autoload/ccomplete.vim
+++ b/runtime/autoload/ccomplete.vim
@@ -3,7 +3,7 @@ vim9script noclear
 # Vim completion script
 # Language:	C
 # Maintainer:	The Vim Project <https://github.com/vim/vim>
-# Last Change:	2025 Jul 23
+# Last Change:	2025 Jul 24
 #		Rewritten in Vim9 script by github user lacygoill
 # Former Maintainer:   Bram Moolenaar <Bram@vim.org>
 

--- a/runtime/autoload/ccomplete.vim
+++ b/runtime/autoload/ccomplete.vim
@@ -82,9 +82,6 @@ export def Complete(findstart: bool, abase: string): any # {{{1
   var s: number = 0
   var arrays: number = 0
   while 1
-    if complete_check()
-        return v:none
-    endif
     var e: number = base->charidx(match(base, '\.\|->\|\[', s))
     if e < 0
       if s == 0 || base[s - 1] != ']'
@@ -107,9 +104,6 @@ export def Complete(findstart: bool, abase: string): any # {{{1
       s = e
       ++e
       while e < strcharlen(base)
-        if complete_check()
-            return v:none
-        endif
         if base[e] == ']'
           if n == 0
             break
@@ -200,10 +194,6 @@ export def Complete(findstart: bool, abase: string): any # {{{1
     endif
   endif
 
-  if complete_check()
-      return res
-  endif
-
   if len(items) == 1 || len(items) == arrays + 1
     # Only one part, no "." or "->": complete from tags file.
     var tags: list<dict<any>>
@@ -224,10 +214,6 @@ export def Complete(findstart: bool, abase: string): any # {{{1
               || bufnr('%') == bufnr(v['filename']))
 
     res = res->extend(tags->map((_, v: dict<any>) => Tag2item(v)))
-  endif
-
-  if complete_check()
-      return res
   endif
 
   if len(res) == 0
@@ -259,10 +245,6 @@ export def Complete(findstart: bool, abase: string): any # {{{1
         endif
       endif
     endfor
-  endif
-
-  if complete_check()
-      return res
   endif
 
   if len(res) == 0 && items[0]->searchdecl(true) == 0

--- a/runtime/autoload/ccomplete.vim
+++ b/runtime/autoload/ccomplete.vim
@@ -492,9 +492,11 @@ def Nextitem( # {{{1
     # Use the tags file to find out if this is a typedef.
     var diclist: list<dict<any>> = taglist('^' .. tokens[tidx] .. '$')
     for tagidx: number in len(diclist)->range()
-    if complete_check()
+
+      if complete_check()
         return res
-    endif
+      endif
+
       var item: dict<any> = diclist[tagidx]
 
       # New ctags has the "typeref" field.  Patched version has "typename".

--- a/runtime/autoload/ccomplete.vim
+++ b/runtime/autoload/ccomplete.vim
@@ -146,7 +146,7 @@ export def Complete(findstart: bool, abase: string): any # {{{1
       var col2: number = col - 1
       while line[col2] != ';'
         if complete_check()
-            return v:none
+            return res
         endif
         --col2
       endwhile
@@ -159,7 +159,7 @@ export def Complete(findstart: bool, abase: string): any # {{{1
       var col2: number = col - 1
       while line[col2] != ','
         if complete_check()
-            return v:none
+            return res
         endif
         --col2
       endwhile
@@ -201,7 +201,7 @@ export def Complete(findstart: bool, abase: string): any # {{{1
   endif
 
   if complete_check()
-      return v:none
+      return res
   endif
 
   if len(items) == 1 || len(items) == arrays + 1
@@ -227,7 +227,7 @@ export def Complete(findstart: bool, abase: string): any # {{{1
   endif
 
   if complete_check()
-      return v:none
+      return res
   endif
 
   if len(res) == 0
@@ -262,7 +262,7 @@ export def Complete(findstart: bool, abase: string): any # {{{1
   endif
 
   if complete_check()
-      return v:none
+      return res
   endif
 
   if len(res) == 0 && items[0]->searchdecl(true) == 0
@@ -278,7 +278,7 @@ export def Complete(findstart: bool, abase: string): any # {{{1
   var brackets: string = ''
   while last >= 0
     if complete_check()
-        return v:none
+        return res
     endif
     if items[last][0] != '['
       break
@@ -346,7 +346,7 @@ def Dict2info(dict: dict<any>): string # {{{1
   var info: string = ''
   for k: string in dict->keys()->sort()
     if complete_check()
-        return ""
+        return info
     endif
     info  ..= k .. repeat(' ', 10 - strlen(k))
     if k == 'cmd'
@@ -384,7 +384,7 @@ def ParseTagline(line: string): dict<any> # {{{1
     endif
     for i: number in range(n + 1, len(l) - 1)
       if complete_check()
-        return {}
+        return d
       endif
       if l[i] == 'file:'
         d['static'] = 1
@@ -482,7 +482,7 @@ def Nextitem( # {{{1
   var res: list<dict<string>>
   for tidx: number in len(tokens)->range()
     if complete_check()
-        return []
+        return res
     endif
 
     # Skip tokens starting with a non-ID character.
@@ -511,7 +511,7 @@ def Nextitem( # {{{1
     var diclist: list<dict<any>> = taglist('^' .. tokens[tidx] .. '$')
     for tagidx: number in len(diclist)->range()
     if complete_check()
-        return []
+        return res
     endif
       var item: dict<any> = diclist[tagidx]
 
@@ -702,7 +702,7 @@ def SearchMembers( # {{{1
   var res: list<dict<string>>
   for i: number in len(matches)->range()
     if complete_check()
-        return []
+        return res
     endif
     var typename: string = ''
     var line: string

--- a/runtime/autoload/ccomplete.vim
+++ b/runtime/autoload/ccomplete.vim
@@ -226,7 +226,7 @@ export def Complete(findstart: bool, abase: string): any # {{{1
     res = []
     for i: number in len(diclist)->range()
       if complete_check()
-          return []
+          return res
       endif
       # New ctags has the "typeref" field.  Patched version has "typename".
       if diclist[i]->has_key('typename')
@@ -654,7 +654,7 @@ def StructMembers( # {{{1
     ++idx
     while 1
       if complete_check()
-        return []
+        return matches
       endif
       if idx >= len(items)
         return matches  # No further items, return the result.


### PR DESCRIPTION
Return partial results when `complete_check()` is triggered.

@girishji could you please check if it works with `set ac`?

PS, works for me with `set ac` and vim's `alloc.h`

https://asciinema.org/a/zykGcZxQ6xUlV9pB8wepZxJkg