### PR TITLE
Add option to use UNIX domain sockets for clientserver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,12 @@ jobs:
           - features: normal
             compiler: gcc
             extra: [vimtags]
+          - features: huge
+            compiler: gcc
+            extra: [no_x11]
+          - features: huge
+            compiler: gcc
+            extra: [socketserver]
 
     steps:
       - name: Checkout repository from github
@@ -220,7 +226,7 @@ jobs:
           tiny)
             echo "TEST=testtiny"
             if ${{ contains(matrix.extra, 'nogui') }}; then
-              echo "CONFOPT=--disable-gui"
+              CONFOPT="--disable-gui"
             fi
             ;;
           normal)
@@ -232,10 +238,16 @@ jobs:
               PYTHON3_CONFOPT="--with-python3-stable-abi=3.8"
             fi
             # The ubuntu-24.04 CI runner does not provide a python2 package.
-            echo "CONFOPT=--enable-perlinterp=${INTERFACE} --enable-pythoninterp=no --enable-python3interp=${INTERFACE} --enable-rubyinterp=${INTERFACE} --enable-luainterp=${INTERFACE} --enable-tclinterp=${INTERFACE} ${PYTHON3_CONFOPT}"
+            CONFOPT="--enable-perlinterp=${INTERFACE} --enable-pythoninterp=no --enable-python3interp=${INTERFACE} --enable-rubyinterp=${INTERFACE} --enable-luainterp=${INTERFACE} --enable-tclinterp=${INTERFACE} ${PYTHON3_CONFOPT}"
             ;;
           esac
 
+          if ${{ contains(matrix.extra, 'no_x11') }}; then
+            CONFOPT="${CONFOPT} --without-x --disable-gui"
+          fi
+          if ${{ contains(matrix.extra, 'socketserver') }}; then
+            CONFOPT="${CONFOPT} --enable-socketserver"
+          fi
           if ${{ matrix.coverage == true }}; then
             CFLAGS="${CFLAGS} --coverage -DUSE_GCOV_FLUSH"
             echo "LDFLAGS=--coverage"
@@ -259,6 +271,7 @@ jobs:
             echo "TEST=-C runtime/doc vimtags VIMEXE=../../${SRCDIR}/vim"
           fi
           echo "CFLAGS=${CFLAGS}"
+          echo "CONFOPT=${CONFOPT}"
           # Disables GTK attempt to integrate with the accessibility service that does run in CI.
           echo "NO_AT_BRIDGE=1"
           ) >> $GITHUB_ENV

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -13042,6 +13042,7 @@ scrollbind		Compiled with 'scrollbind' support. (always true)
 showcmd			Compiled with 'showcmd' support.
 signs			Compiled with |:sign| support.
 smartindent		Compiled with 'smartindent' support. (always true)
+socketserver		Compiled with socket server functionality. (Unix only)
 sodium			Compiled with libsodium for better crypt support
 sound			Compiled with sound support, e.g. `sound_playevent()`
 spell			Compiled with spell checking support |spell|.

--- a/runtime/doc/remote.txt
+++ b/runtime/doc/remote.txt
@@ -61,7 +61,10 @@ The following command line arguments are available:
    --servername {name}		Become the server {name}.  When used together
 				with one of the --remote commands: connect to
 				server {name} instead of the default (see
-				below).  The name used will be uppercase.
+				below).  The name used will be uppercase.  If
+				using the socketserver, you can specify a
+				path, see |socketserver-name| for more
+				details.
 								*--remote-send*
    --remote-send {keys}		Send {keys} to server and exit.  The {keys}
 				are not mapped.  Special key names are
@@ -72,6 +75,12 @@ The following command line arguments are available:
 				on stdout.
 								*--serverlist*
    --serverlist			Output a list of server names.
+								*--clientserver*
+   --clientserver {method}	Use the specified method {method} as the
+				backend for clientserver functionality. Can
+				either be "socket" or "x11".
+				{only available when Vim is compiled with both
+				|+X11| and |+socketserver| features}
 
 
 Examples ~
@@ -105,7 +114,8 @@ specified name is not available, a postfix is applied until a free name is
 encountered, i.e. "gvim1" for the second invocation of gvim on a particular
 X-server.  The resulting name is available in the servername builtin variable
 |v:servername|.  The case of the server name is ignored, thus "gvim" and
-"GVIM" are considered equal.
+"GVIM" are considered equal.  Note if a socket server is being used, there are
+some differences, see |socketserver-differences|.
 
 When Vim is invoked with --remote, --remote-wait or --remote-send it will try
 to locate the server name determined by the invocation name and --servername
@@ -119,7 +129,8 @@ itself.  This way it is not necessary to know whether gvim is already started
 when sending command to it.
 
 The --serverlist argument will cause Vim to print a list of registered command
-servers on the standard output (stdout) and exit.
+servers on the standard output (stdout) and exit.  If a socket server is being
+used, there are caveats, see |socketserver-differences|.
 							*{server}*
 The {server} argument is used by several functions.  When this is an empty
 string then on Unix the default server name is used, which is "GVIM".  On
@@ -206,4 +217,64 @@ When using gvim, the --remote-wait only works properly this way: >
 
 	start /w gvim --remote-wait file.txt
 <
+==============================================================================
+3. Socket server specific items			    *socketserver-clientserver*
+				    *E1563* *E1564* *E1565* *E1566* *E1567*
+
+The communication between client and server is done using Unix domain sockets.
+These sockets are either placed in these directories in the following order of
+availability:
+    1. "$XDG_RUTIME_DIR/vim" if $XDG_RUNTIME_DIR is set in the environment.
+    2. "$TMPDIR/vim-[uid]", where "[uid]" is the uid of the user. This
+       directory will have the access permissions set to 700 so only the user
+       can read or write from/to it. If $TMPDIR is not set, "/tmp" is used.
+
+						    *socketserver-name*
+When specifying the server id/name, it can be taken as a generic name or an
+absolute or relative path.  If the server id starts with either a "/"
+(absolute) or "./" | "../" (relative), then it is taken as path to the socket.
+Otherwise the server id will be the filename of the socket which will be
+placed in the above common directories.  Note that a server id/name can only
+contain slashes "/" if it is taken as a path, so names such as "abc/dir" will
+be invalid.
+
+Socket server functionality is available in both GTK GUI and terminal versions of
+Vim.  Unless Vim is compiled with |+autoservername| feature, the socket server
+will have to started explicitly, just like X11, even in the GUI.
+
+If Vim crashes or does not exit cleanly, the socket server will not remove the
+socket file and it will be left around.  This is generally not a problem,
+because if a socket name is taken, Vim checks if the socket in its place is
+dead (not attached to any process), and can replace it instead of finding a
+new name.
+
+To send commands to a Vim socket server from another application, read the
+source file src/os_unix.c, there is detailed description of the protocol used.
+
+						    *socketserver-differences*
+Most of the functionality is the same as X11, however unlike X11, where the
+client does not need to be a server in order to communicate with another
+server, the socket server requires the server to be running even as a client.
+The exception is |serverlist()| or the |--serverlist| argument, which does not
+require the server to be running.
+
+Additionally, the server id or client id will not be a number like X11 or
+MS-Windows (shown in hex representation), instead it is the absolute path to
+the socket.  This can be seen via the |v:servername| variable.
+
+The |--serverlist| argument will act just like X11, however it only checks the
+given common directories above.  If a custom path is used for a socket, it
+will not be detected, such as a path either not in $XDG_RUNTIME_DIR or
+<$TMPDIR or /tmp>/vim of the |--serverlist| Vim process.
+
+If you have both |+socketserver| and |+X11| compiled, you will need to add
+|--clientserver| set to "socket" in combination with |--serverlist| to list
+the available servers.  You cannot list both types of backends in one command.
+
+						    *socketserver-x11*
+If Vim is compiled with both |+X11| and |+socketserver|, then deciding which
+backend to use is done at startup time, via the |--clientserver| argument.  By
+default if it is not specified, then X11 will be used.  A Vim instance using a
+socket server cannot communicate with one using X11.
+
  vim:tw=78:sw=4:ts=8:noet:ft=help:norl:

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -1495,6 +1495,7 @@ $quote	eval.txt	/*$quote*
 +scrollbind	various.txt	/*+scrollbind*
 +signs	various.txt	/*+signs*
 +smartindent	various.txt	/*+smartindent*
++socketserver	various.txt	/*+socketserver*
 +sodium	various.txt	/*+sodium*
 +sound	various.txt	/*+sound*
 +spell	various.txt	/*+spell*
@@ -1555,6 +1556,7 @@ $quote	eval.txt	/*$quote*
 --	starting.txt	/*--*
 ---	starting.txt	/*---*
 --clean	starting.txt	/*--clean*
+--clientserver	remote.txt	/*--clientserver*
 --cmd	starting.txt	/*--cmd*
 --echo-wid	starting.txt	/*--echo-wid*
 --gui-dialog-file	starting.txt	/*--gui-dialog-file*
@@ -4695,6 +4697,11 @@ E156	sign.txt	/*E156*
 E1560	vim9.txt	/*E1560*
 E1561	vim9.txt	/*E1561*
 E1562	options.txt	/*E1562*
+E1563	remote.txt	/*E1563*
+E1564	remote.txt	/*E1564*
+E1565	remote.txt	/*E1565*
+E1566	remote.txt	/*E1566*
+E1567	remote.txt	/*E1567*
 E157	sign.txt	/*E157*
 E158	sign.txt	/*E158*
 E159	sign.txt	/*E159*
@@ -10221,6 +10228,10 @@ slow-fast-terminal	term.txt	/*slow-fast-terminal*
 slow-start	starting.txt	/*slow-start*
 slow-terminal	term.txt	/*slow-terminal*
 socket-interface	channel.txt	/*socket-interface*
+socketserver-clientserver	remote.txt	/*socketserver-clientserver*
+socketserver-differences	remote.txt	/*socketserver-differences*
+socketserver-name	remote.txt	/*socketserver-name*
+socketserver-x11	remote.txt	/*socketserver-x11*
 sort()	builtin.txt	/*sort()*
 sorting	change.txt	/*sorting*
 sound-functions	usr_41.txt	/*sound-functions*

--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -487,6 +487,8 @@ m  *+ruby/dyn*		Ruby interface |ruby-dynamic| |/dyn|
 T  *+scrollbind*	'scrollbind'
 N  *+signs*		|:sign|
 T  *+smartindent*	'smartindent'
+N  *+socketserver*	Unix only: socket server backend for clientserver
+			functionality
 H  *+sodium*		compiled with libsodium for better encryption support
 H  *+sound*		|sound_playevent()|, |sound_playfile()| functions, etc.
 N  *+spell*		spell checking support, see |spell|

--- a/runtime/doc/vim.1
+++ b/runtime/doc/vim.1
@@ -499,7 +499,14 @@ List the names of all Vim servers that can be found.
 .TP
 \-\-servername {name}
 Use {name} as the server name.  Used for the current Vim, unless used with a
-\-\-remote argument, then it's the name of the server to connect to.
+\-\-remote argument, then it's the name of the server to connect to.  If the
+socketserver backend is being used, if the name starts with "/", "./", or "../",
+it is taken as either an absolute, relative or relative path to the socket.
+.TP
+\-\-clientserver {backend}
+Use {backend} as the backend for clientserver functionality, either "socket" or
+"x11" respectively.  Only available when compiled with both socketserver and X11
+features present
 .TP
 \-\-socketid {id}
 GTK GUI only: Use the GtkPlug mechanism to run gVim in another window.

--- a/runtime/plugin/rrhelper.vim
+++ b/runtime/plugin/rrhelper.vim
@@ -16,9 +16,10 @@ function SetupRemoteReplies()
   let max = argc()
 
   let id = expand("<client>")
-  if id == 0
+  if (type(id) == v:t_number && id == 0) || (type(id) == v:t_string && id == '')
     return
   endif
+
   while cnt < max
     " Handle same file from more clients and file being more than once
     " on the command line by encoding this stuff in the group name

--- a/src/auto/configure
+++ b/src/auto/configure
@@ -852,6 +852,7 @@ enable_netbeans
 enable_channel
 enable_terminal
 enable_autoservername
+enable_socketserver
 enable_multibyte
 enable_rightleft
 enable_arabic
@@ -1532,6 +1533,7 @@ Optional Features:
   --disable-channel       Disable process communication support.
   --enable-terminal       Enable terminal emulation support.
   --enable-autoservername Automatically define servername at vim startup.
+  --enable-socketserver Use sockets for clientserver communication.
   --enable-multibyte      Include multibyte editing support.
   --disable-rightleft     Do not include Right-to-Left language support.
   --disable-arabic        Do not include Arabic language support.
@@ -9080,6 +9082,40 @@ printf "%s\n" "$enable_autoservername" >&6; }
 if test "$enable_autoservername" = "yes"; then
   printf "%s\n" "#define FEAT_AUTOSERVERNAME 1" >>confdefs.h
 
+fi
+
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking --enable-socketserver argument" >&5
+printf %s "checking --enable-socketserver argument... " >&6; }
+# Check whether --enable-socketserver was given.
+if test ${enable_socketserver+y}
+then :
+  enableval=$enable_socketserver; enable_socketserver=$enableval
+else case e in #(
+  e) if test "x$features" = xtiny
+then :
+  enable_socketserver=no_auto
+			 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: cannot use socketserver with tiny features" >&5
+printf "%s\n" "cannot use socketserver with tiny features" >&6; }
+else case e in #(
+  e) enable_socketserver=auto ;;
+esac
+fi ;;
+esac
+fi
+
+if test "$enable_socketserver" = "yes"; then
+  printf "%s\n" "#define WANT_SOCKETSERVER 1" >>confdefs.h
+
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; }
+elif test "$enable_socketserver" = "auto"; then
+  printf "%s\n" "#define MAYBE_SOCKETSERVER 1" >>confdefs.h
+
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: auto" >&5
+printf "%s\n" "auto" >&6; }
+elif test "$enable_socketserver" = "no"; then
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
 fi
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking --enable-multibyte argument" >&5

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -406,6 +406,12 @@
 /* Define if you want to always define a server name at vim startup. */
 #undef FEAT_AUTOSERVERNAME
 
+/* Define if you want to use sockets for clientserver communication. */
+#undef WANT_SOCKETSERVER
+
+/* Define if you want to use sockets for clientserver communication if it makes sense. */
+#undef MAYBE_SOCKETSERVER
+
 /* Define if you want to include fontset support. */
 #undef FEAT_XFONTSET
 

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -2340,6 +2340,24 @@ if test "$enable_autoservername" = "yes"; then
   AC_DEFINE(FEAT_AUTOSERVERNAME)
 fi
 
+AC_MSG_CHECKING(--enable-socketserver argument)
+AC_ARG_ENABLE(socketserver,
+	[  --enable-socketserver Use sockets for clientserver communication.],
+	[enable_socketserver=$enableval],
+	AS_IF([test "x$features" = xtiny], 
+			[enable_socketserver=no_auto
+			 AC_MSG_RESULT([cannot use socketserver with tiny features])],
+			[enable_socketserver=auto]))
+if test "$enable_socketserver" = "yes"; then
+  AC_DEFINE(WANT_SOCKETSERVER)
+  AC_MSG_RESULT([yes])
+elif test "$enable_socketserver" = "auto"; then
+  AC_DEFINE(MAYBE_SOCKETSERVER)
+  AC_MSG_RESULT([auto])
+elif test "$enable_socketserver" = "no"; then
+  AC_MSG_RESULT([no])
+fi
+
 AC_MSG_CHECKING(--enable-multibyte argument)
 AC_ARG_ENABLE(multibyte,
 	[  --enable-multibyte      Include multibyte editing support.], ,

--- a/src/errors.h
+++ b/src/errors.h
@@ -3782,3 +3782,15 @@ EXTERN char e_duplicate_type_var_name_str[]
 EXTERN char e_diff_anchors_with_hidden_windows[]
 	INIT(= N_("E1562: Diff anchors cannot be used with hidden diff windows"));
 #endif
+#ifdef FEAT_SOCKETSERVER
+EXTERN char e_socket_path_too_big[]
+	INIT(= N_("E1563: Socket path is too big"));
+EXTERN char e_socket_name_no_slashes[]
+	INIT(= N_("E1564: Socket name cannot have slashes in it without being a path"));
+EXTERN char e_socket_server_not_online[]
+	INIT(= N_("E1565: Socket server is not online, call remote_startserver() first"));
+EXTERN char e_socket_server_failed_connecting[]
+	INIT(= N_("E1566: Failed connecting to socket %s: %s"));
+EXTERN char e_socket_server_unavailable[]
+	INIT(= N_("E1567: Cannot start socket server, socket path is unavailable"));
+#endif

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -6767,6 +6767,13 @@ f_has(typval_T *argvars, typval_T *rettv)
 		0
 #endif
 		},
+	{"socketserver",
+#ifdef FEAT_SOCKETSERVER
+		1
+#else
+		0
+#endif
+		},
 	{"balloon_eval",
 #ifdef FEAT_BEVAL_GUI
 		1

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -10039,9 +10039,29 @@ eval_vars(
 
 #ifdef FEAT_CLIENTSERVER
 	case SPEC_CLIENT:	// Source of last submitted input
+#ifdef MSWIN
 		sprintf((char *)strbuf, PRINTF_HEX_LONG_U,
 							(long_u)clientWindow);
 		result = strbuf;
+#else
+# ifdef FEAT_SOCKETSERVER
+		if (clientserver_method == CLIENTSERVER_METHOD_SOCKET)
+		{
+		    if (client_socket == NULL)
+			result = (char_u *)"";
+		    else
+			result = client_socket;
+		}
+# endif
+# ifdef FEAT_X11
+		if (clientserver_method == CLIENTSERVER_METHOD_X11)
+		{
+		    sprintf((char *)strbuf, PRINTF_HEX_LONG_U,
+							(long_u)clientWindow);
+		    result = strbuf;
+		}
+# endif
+#endif
 		break;
 #endif
 

--- a/src/feature.h
+++ b/src/feature.h
@@ -946,10 +946,19 @@
 #endif
 
 /*
+ * +socketserver	 Use UNIX domain sockets for clientserver communication
+ */
+#if defined(UNIX) && (defined(WANT_SOCKETSERVER) || \
+	(defined(MAYBE_SOCKETSERVER) && !defined(HAVE_X11)))
+#define FEAT_SOCKETSERVER
+#endif
+
+/*
  * +clientserver	Remote control via the remote_send() function
  *			and the --remote argument
  */
-#if (defined(MSWIN) || defined(FEAT_XCLIPBOARD)) && defined(FEAT_EVAL)
+#if (defined(MSWIN) || defined(FEAT_XCLIPBOARD) || defined(FEAT_SOCKETSERVER)) \
+    && defined(FEAT_EVAL)
 # define FEAT_CLIENTSERVER
 #endif
 

--- a/src/globals.h
+++ b/src/globals.h
@@ -1868,7 +1868,7 @@ EXTERN Window	commWindow INIT(= None);
 EXTERN Window	clientWindow INIT(= None);
 EXTERN Atom	commProperty INIT(= None);
 EXTERN char_u	*serverDelayedStartName INIT(= NULL);
-# else
+# elif defined(MSWIN)
 #  ifdef PROTO
 typedef int HWND;
 #  endif
@@ -2089,4 +2089,36 @@ EXTERN char *wayland_display_name INIT(= NULL);
 // Wayland display file descriptor; set by wayland_init_client()
 EXTERN int wayland_display_fd;
 
+#endif
+
+#if defined(FEAT_CLIENTSERVER) && !defined(MSWIN)
+
+// Backend for clientserver functionality
+typedef enum {
+    CLIENTSERVER_METHOD_NONE,
+    CLIENTSERVER_METHOD_X11,
+    CLIENTSERVER_METHOD_SOCKET
+} clientserver_method_T;
+
+// Default to X11 if compiled with support for it, else use socket server.
+# if defined(FEAT_X11) && defined(FEAT_SOCKETSERVER)
+EXTERN clientserver_method_T clientserver_method
+# else
+// Since we aren't going to be changing clientserver_method, make it constant to
+// allow compiler optimizations.
+EXTERN const clientserver_method_T clientserver_method
+# endif
+# ifdef FEAT_X11
+INIT(= CLIENTSERVER_METHOD_X11);
+# elif defined(FEAT_SOCKETSERVER)
+INIT(= CLIENTSERVER_METHOD_SOCKET);
+# else
+INIT(= CLIENTSERVER_METHOD_NONE);
+# endif
+
+#endif
+
+#ifdef FEAT_SOCKETSERVER
+// Path to socket of last client that communicated with us
+EXTERN char_u *client_socket INIT(= NULL);
 #endif

--- a/src/gui.c
+++ b/src/gui.c
@@ -150,6 +150,12 @@ gui_start(char_u *arg UNUSED)
 	// Reset clipmethod to CLIPMETHOD_NONE
 	choose_clipmethod();
 
+#ifdef FEAT_SOCKETSERVER
+    // Install socket server listening socket if we are running it
+    if (socket_server_valid())
+	gui_gtk_init_socket_server();
+#endif
+
     vim_free(old_term);
 
     // If the GUI started successfully, trigger the GUIEnter event, otherwise

--- a/src/if_xcmdsrv.c
+++ b/src/if_xcmdsrv.c
@@ -14,7 +14,7 @@
 #include "vim.h"
 #include "version.h"
 
-#if defined(FEAT_CLIENTSERVER) || defined(PROTO)
+#if (defined(FEAT_CLIENTSERVER) && defined(FEAT_X11)) || defined(PROTO)
 
 # ifdef FEAT_X11
 #  include <X11/Intrinsic.h>

--- a/src/main.c
+++ b/src/main.c
@@ -1855,7 +1855,8 @@ getout(int exitval)
  * Get the name of the display, before gui_prepare() removes it from
  * argv[].  Used for the xterm-clipboard display.
  *
- * Also find the --server... arguments and --socketid and --windowid
+ * Also find the --server, --clientserver... arguments and --socketid and
+ * --windowid
  */
     static void
 early_arg_scan(mparm_T *parmp UNUSED)
@@ -1900,6 +1901,22 @@ early_arg_scan(mparm_T *parmp UNUSED)
 		gui.dofork = FALSE;
 #  endif
 	}
+#  if defined(FEAT_X11) && defined(FEAT_SOCKETSERVER)
+	else if (STRNICMP(argv[i], "--clientserver", 14) == 0)
+	{
+	    char_u *arg;
+	    if (i == argc - 1)
+		mainerr_arg_missing((char_u *)argv[i]);
+	    arg = (char_u *)argv[++i];
+
+	    if (STRICMP(arg, "socket") == 0)
+		clientserver_method = CLIENTSERVER_METHOD_SOCKET;
+	    else if (STRICMP(arg, "x11") == 0)
+		clientserver_method = CLIENTSERVER_METHOD_X11;
+	    else
+		mainerr(ME_UNKNOWN_OPTION, arg);
+	}
+#  endif
 # endif
 
 # if defined(FEAT_GUI_GTK) || defined(FEAT_GUI_MSWIN)
@@ -2220,7 +2237,11 @@ command_line_scan(mparm_T *parmp)
 		else if (STRNICMP(argv[0] + argv_idx, "serverlist", 10) == 0)
 		    ; // already processed -- no arg
 		else if (STRNICMP(argv[0] + argv_idx, "servername", 10) == 0
-		       || STRNICMP(argv[0] + argv_idx, "serversend", 10) == 0)
+		       || STRNICMP(argv[0] + argv_idx, "serversend", 10) == 0
+# if defined(FEAT_X11) && defined(FEAT_SOCKETSERVER)
+		       || STRNICMP(argv[0] + argv_idx, "clientserver", 12) == 0
+# endif
+		       )
 		{
 		    // already processed -- snatch the following arg
 		    if (argc > 1)
@@ -3712,6 +3733,9 @@ usage(void)
     main_msg(_("-Y\t\t\tDo not connect to Wayland compositor"));
 #endif
 #ifdef FEAT_CLIENTSERVER
+# if defined(FEAT_X11) && defined(FEAT_SOCKETSERVER)
+    main_msg(_("--clientserver <socket|x11> Backend for clientserver communication"));
+# endif
     main_msg(_("--remote <files>\tEdit <files> in a Vim server if possible"));
     main_msg(_("--remote-silent <files>  Same, don't complain if there is no server"));
     main_msg(_("--remote-wait <files>  As --remote but wait for files to have been edited"));

--- a/src/proto/gui_gtk_x11.pro
+++ b/src/proto/gui_gtk_x11.pro
@@ -8,6 +8,8 @@ void gui_mch_stop_blink(int may_call_gui_update_cursor);
 void gui_mch_start_blink(void);
 int gui_mch_early_init_check(int give_message);
 int gui_mch_init_check(void);
+void gui_gtk_init_socket_server(void);
+void gui_gtk_uninit_socket_server(void);
 void gui_mch_set_dark_theme(int dark);
 void gui_mch_show_tabline(int showit);
 int gui_mch_showing_tabline(void);

--- a/src/proto/option.pro
+++ b/src/proto/option.pro
@@ -68,6 +68,7 @@ char *did_set_shellslash(optset_T *args);
 char *did_set_shiftwidth_tabstop(optset_T *args);
 char *did_set_showtabline(optset_T *args);
 char *did_set_smoothscroll(optset_T *args);
+char *did_set_socktimeoutlen(optset_T *args);
 char *did_set_spell(optset_T *args);
 char *did_set_swapfile(optset_T *args);
 char *did_set_termguicolors(optset_T *args);

--- a/src/proto/optionstr.pro
+++ b/src/proto/optionstr.pro
@@ -34,6 +34,8 @@ int expand_set_casemap(optexpand_T *args, int *numMatches, char_u ***matches);
 int expand_set_clipboard(optexpand_T *args, int *numMatches, char_u ***matches);
 char *did_set_clipmethod(optset_T *args);
 int expand_set_clipmethod(optexpand_T *args, int *numMatches, char_u ***matches);
+char *did_set_clientserver(optset_T *args UNUSED);
+int expand_set_clientserver(optexpand_T *args, int *numMatches, char_u ***matches);
 char *did_set_chars_option(optset_T *args);
 int expand_set_chars_option(optexpand_T *args, int *numMatches, char_u ***matches);
 char *did_set_cinoptions(optset_T *args);

--- a/src/proto/os_unix.pro
+++ b/src/proto/os_unix.pro
@@ -94,4 +94,15 @@ void stop_timeout(void);
 volatile sig_atomic_t *start_timeout(long msec);
 void delete_timer(void);
 int mch_create_anon_file(void);
+int socket_server_init(char_u *sock_path);
+void socket_server_uninit(void);
+char_u *socket_server_list_sockets(void);
+void socket_server_accept_client(void);
+int socket_server_valid(void);
+int socket_server_send(char_u *sock_path, char_u *cmd, char_u **result, char_u **receiver, int is_expr, int timeout, int silent);
+int socket_server_read_reply(char_u *sender, char_u **str, int timeout);
+int socket_server_peek_reply(char_u *sender, char_u **str);
+int socket_server_send_reply(char_u *client, char_u *str);
+int socket_server_get_fd(void);
+int socket_server_waiting_accept(void);
 /* vim: set ft=c : */

--- a/src/testdir/test_vim9_builtin.vim
+++ b/src/testdir/test_vim9_builtin.vim
@@ -3,6 +3,11 @@
 source util/screendump.vim
 import './util/vim9.vim' as v9
 
+" Socket backend for remote functions require the socket server to be running
+if v:servername == ""
+  call remote_startserver('VIMSOCKETSERVERTEST')
+endif
+
 " Test for passing too many or too few arguments to builtin functions
 func Test_internalfunc_arg_error()
   let l =<< trim END

--- a/src/testdir/test_wayland.vim
+++ b/src/testdir/test_wayland.vim
@@ -79,6 +79,10 @@ func Test_wayland_startup()
   call s:PreTest()
   call s:CheckXConnection()
 
+  if v:servername == ""
+    call remote_startserver('VIMSOCKETSERVER')
+  endif
+
   let l:name = 'WLVIMTEST'
   let l:cmd = GetVimCommand() .. ' --servername ' .. l:name
   let l:job = job_start(cmd, {'stoponexit': 'kill', 'out_io': 'null'})
@@ -372,6 +376,10 @@ func Test_wayland_autoselect_works()
 
   call writefile(l:lines, 'Wltester', 'D')
 
+  if v:servername == ""
+    call remote_startserver('VIMSOCKETSERVER')
+  endif
+
   let l:name = 'WLVIMTEST'
   let l:cmd = GetVimCommand() .. ' -S Wltester --servername ' .. l:name
   let l:job = job_start(cmd, {'stoponexit': 'kill', 'out_io': 'null'})
@@ -415,6 +423,10 @@ func Test_no_wayland_connect_cmd_flag()
   call s:PreTest()
   call s:CheckXConnection()
 
+  if v:servername == ""
+    call remote_startserver('VIMSOCKETSERVER')
+  endif
+
   let l:name = 'WLFLAGVIMTEST'
   let l:cmd = GetVimCommand() .. ' -Y --servername ' .. l:name
   let l:job = job_start(cmd, {'stoponexit': 'kill', 'out_io': 'null'})
@@ -452,6 +464,10 @@ endfunc
 func Test_wayland_become_inactive()
   call s:PreTest()
   call s:CheckXConnection()
+
+  if v:servername == ""
+    call remote_startserver('VIMSOCKETSERVER')
+  endif
 
   let l:name = 'WLLOSEVIMTEST'
   let l:cmd = GetVimCommand() .. ' --servername ' .. l:name
@@ -543,6 +559,10 @@ func Test_wayland_bad_environment()
 
   let l:old = $XDG_RUNTIME_DIR
   unlet $XDG_RUNTIME_DIR
+
+  if v:servername == ""
+    call remote_startserver('VIMSOCKETSERVER')
+  endif
 
   let l:name = 'WLVIMTEST'
   let l:cmd = GetVimCommand() .. ' --servername ' .. l:name

--- a/src/ui.c
+++ b/src/ui.c
@@ -407,7 +407,19 @@ inchar_loop(
 
 	if ((resize_func != NULL && resize_func(TRUE))
 #if defined(FEAT_CLIENTSERVER) && defined(UNIX)
-		|| server_waiting()
+		|| (
+# ifdef FEAT_X11
+		    (clientserver_method == CLIENTSERVER_METHOD_X11 &&
+		    server_waiting())
+# endif
+# if defined(FEAT_X11) && defined(FEAT_SOCKETSERVER)
+		    ||
+# endif
+# ifdef FEAT_SOCKETSERVER
+		    (clientserver_method == CLIENTSERVER_METHOD_SOCKET &&
+		     socket_server_waiting_accept())
+# endif
+		)
 #endif
 #ifdef MESSAGE_QUEUE
 		|| interrupted

--- a/src/version.c
+++ b/src/version.c
@@ -516,6 +516,11 @@ static char *(features[]) =
 	"-signs",
 #endif
 	"+smartindent",
+#ifdef FEAT_SOCKETSERVER
+	"+socketserver",
+#else
+	"-socketserver",
+#endif
 #ifdef FEAT_SODIUM
 # ifdef DYNAMIC_SODIUM
 	"+sodium/dyn",


### PR DESCRIPTION
Should fix #3509. Uses UNIX domain sockets to facilitate client-server communication. Deciding which method is used is done at startup time, and can be manually done using the `--clientserver` command flag, which is only available if Vim is compiled with both X11 and socket server (this PR) features.

I didn't use the existing channel/IPC functionality because
1. There is very little internal API, most of it seems to be for vimscript
2. In my opinion, it is overkill for this use-case, the entire lifecycle of the socket server is literally just: poll -> accept -> process command -> maybe send a reply back -> close.