### PR TITLE
Cannot disable cscope interface using configure

### DIFF
--- a/src/auto/configure
+++ b/src/auto/configure
@@ -8653,14 +8653,14 @@ if test ${enable_cscope+y}
 then :
   enableval=$enable_cscope;
 else case e in #(
-  e) enable_cscope="no" ;;
+  e) enable_cscope="yes" ;;
 esac
 fi
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $enable_cscope" >&5
 printf "%s\n" "$enable_cscope" >&6; }
 if test "$enable_cscope" = "yes"; then
-  printf "%s\n" "#define FEAT_CSCOPE 1" >>confdefs.h
+  printf "%s\n" "#define ENABLE_CSCOPE 1" >>confdefs.h
 
 fi
 

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -395,7 +395,7 @@
 #undef HAVE_SYSMOUSE
 
 /* Define if you want to include the Cscope interface. */
-#undef FEAT_CSCOPE
+#undef ENABLE_CSCOPE
 
 /* Define if you don't want to include right-left support. */
 #undef DISABLE_RIGHTLEFT

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -2168,10 +2168,10 @@ AC_SUBST(RUBY_LIBS)
 AC_MSG_CHECKING(--enable-cscope argument)
 AC_ARG_ENABLE(cscope,
 	[  --enable-cscope         Include cscope interface.], ,
-	[enable_cscope="no"])
+	[enable_cscope="yes"])
 AC_MSG_RESULT($enable_cscope)
 if test "$enable_cscope" = "yes"; then
-  AC_DEFINE(FEAT_CSCOPE)
+  AC_DEFINE(ENABLE_CSCOPE)
 fi
 
 AC_MSG_CHECKING(--disable-netbeans argument)

--- a/src/feature.h
+++ b/src/feature.h
@@ -236,7 +236,7 @@
 /*
  * +cscope		Unix only: Cscope support.
  */
-#if defined(UNIX) && defined(FEAT_HUGE) && !defined(FEAT_CSCOPE) && !defined(MACOS_X)
+#if defined(UNIX) && defined(FEAT_HUGE) && defined(ENABLE_CSCOPE) && !defined(MACOS_X)
 # define FEAT_CSCOPE
 #endif
 


### PR DESCRIPTION
Problem:  Cannot disable cscope interface using configure, because in
          feature.h FEAT_CSCOPE will always be enabled for huge builds
Solution: Don't define FEAT_CSCOPE from configure script but set the
          ENABLE_CSCOPE flag and check for the presence of that flag in
          feature.h

fixes: #17825