### PR TITLE
runtime(netrw): upstream snapshot v184

### DIFF
--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -19,7 +19,7 @@ if &cp || exists("g:loaded_netrw")
     finish
 endif
 
-let g:loaded_netrw = "v183"
+let g:loaded_netrw = "v184"
 
 if !has("patch-9.1.1054") && !has('nvim')
     echoerr 'netrw needs Vim v9.1.1054'
@@ -4861,7 +4861,6 @@ function s:NetrwMaps(islocal)
         nnoremap <buffer> <silent> <nowait> mg       :<c-u>call <SID>NetrwMarkFileGrep(1)<cr>
         nnoremap <buffer> <silent> <nowait> mh       :<c-u>call <SID>NetrwMarkHideSfx(1)<cr>
         nnoremap <buffer> <silent> <nowait> mm       :<c-u>call <SID>NetrwMarkFileMove(1)<cr>
-        nnoremap <buffer> <silent> <nowait> mp       :<c-u>call <SID>NetrwMarkFilePrint(1)<cr>
         nnoremap <buffer> <silent> <nowait> mr       :<c-u>call <SID>NetrwMarkFileRegexp(1)<cr>
         nnoremap <buffer> <silent> <nowait> ms       :<c-u>call <SID>NetrwMarkFileSource(1)<cr>
         nnoremap <buffer> <silent> <nowait> mT       :<c-u>call <SID>NetrwMarkFileTag(1)<cr>
@@ -4973,7 +4972,6 @@ function s:NetrwMaps(islocal)
         nnoremap <buffer> <silent> <nowait> mg       :<c-u>call <SID>NetrwMarkFileGrep(0)<cr>
         nnoremap <buffer> <silent> <nowait> mh       :<c-u>call <SID>NetrwMarkHideSfx(0)<cr>
         nnoremap <buffer> <silent> <nowait> mm       :<c-u>call <SID>NetrwMarkFileMove(0)<cr>
-        nnoremap <buffer> <silent> <nowait> mp       :<c-u>call <SID>NetrwMarkFilePrint(0)<cr>
         nnoremap <buffer> <silent> <nowait> mr       :<c-u>call <SID>NetrwMarkFileRegexp(0)<cr>
         nnoremap <buffer> <silent> <nowait> ms       :<c-u>call <SID>NetrwMarkFileSource(0)<cr>
         nnoremap <buffer> <silent> <nowait> mT       :<c-u>call <SID>NetrwMarkFileTag(0)<cr>
@@ -5932,39 +5930,6 @@ function s:NetrwMarkFileMove(islocal)
 
 endfunction
 
-" s:NetrwMarkFilePrint: (invoked by mp) This function prints marked files {{{2
-"                       using the hardcopy command.  Local marked-file list only.
-function s:NetrwMarkFilePrint(islocal)
-    let curbufnr= bufnr("%")
-
-    " sanity check
-    if !exists("s:netrwmarkfilelist_{curbufnr}") || empty(s:netrwmarkfilelist_{curbufnr})
-        call netrw#msg#Notify('ERROR', 'there are no marked files in this window (:help netrw-mf)')
-        return
-    endif
-    let curdir= s:NetrwGetCurdir(a:islocal)
-
-    if exists("s:netrwmarkfilelist_{curbufnr}")
-        let netrwmarkfilelist = s:netrwmarkfilelist_{curbufnr}
-        call s:NetrwUnmarkList(curbufnr,curdir)
-        for fname in netrwmarkfilelist
-            if a:islocal
-                if g:netrw_keepdir
-                    let fname= netrw#fs#ComposePath(curdir,fname)
-                endif
-            else
-                let fname= curdir.fname
-            endif
-            1split
-            " the autocmds will handle both local and remote files
-            exe "sil NetrwKeepj e ".fnameescape(fname)
-            hardcopy
-            q
-        endfor
-        2match none
-    endif
-endfunction
-
 " s:NetrwMarkFileRegexp: (invoked by mr) This function is used to mark {{{2
 "                        files when given a regexp (for which a prompt is
 "                        issued) (matches to name of files).
@@ -6195,37 +6160,20 @@ endfunction
 
 " s:NetrwOpenFile: query user for a filename and open it {{{2
 function s:NetrwOpenFile(islocal)
-    let ykeep= @@
     call inputsave()
-    let fname= input("Enter filename: ")
+    let fname = input("Enter filename: ")
     call inputrestore()
 
-    " determine if Lexplore is in use
-    if exists("t:netrw_lexbufnr")
-        " check if t:netrw_lexbufnr refers to a netrw window
-        let lexwinnr = bufwinnr(t:netrw_lexbufnr)
-        if lexwinnr != -1 && exists("g:netrw_chgwin") && g:netrw_chgwin != -1
-            exe "NetrwKeepj keepalt ".g:netrw_chgwin."wincmd w"
-            exe "NetrwKeepj e ".fnameescape(fname)
-            let @@= ykeep
-        endif
+    if empty(fname)
+        return
     endif
 
-    " Does the filename contain a path?
-    if fname !~ '[/\\]'
-        if exists("b:netrw_curdir")
-            " save position for benefit of Rexplore
-            let s:rexposn_{bufnr("%")}= winsaveview()
-            if b:netrw_curdir =~ '/$'
-                exe "NetrwKeepj e ".fnameescape(b:netrw_curdir.fname)
-            else
-                exe "e ".fnameescape(b:netrw_curdir."/".fname)
-            endif
-        endif
-    else
-        exe "NetrwKeepj e ".fnameescape(fname)
-    endif
-    let @@= ykeep
+    " save position for benefit of Rexplore
+    let s:rexposn_{bufnr("%")}= winsaveview()
+
+    execute "NetrwKeepj e " . fnameescape(!isabsolutepath(fname)
+                \ ? netrw#fs#ComposePath(b:netrw_curdir, fname)
+                \ : fname)
 endfunction
 
 " netrw#Shrink: shrinks/expands a netrw or Lexplorer window {{{2
@@ -6425,7 +6373,6 @@ function s:NetrwMenu(domenu)
             exe 'sil! menu '.g:NetrwMenuPriority.'.14.8   '.g:NetrwTopLvlMenu.'Marked\ Files.Exe\ Cmd<tab>mx    mx'
             exe 'sil! menu '.g:NetrwMenuPriority.'.14.9   '.g:NetrwTopLvlMenu.'Marked\ Files.Move\ To\ Target<tab>mm    mm'
             exe 'sil! menu '.g:NetrwMenuPriority.'.14.10  '.g:NetrwTopLvlMenu.'Marked\ Files.Obtain<tab>O       O'
-            exe 'sil! menu '.g:NetrwMenuPriority.'.14.11  '.g:NetrwTopLvlMenu.'Marked\ Files.Print<tab>mp       mp'
             exe 'sil! menu '.g:NetrwMenuPriority.'.14.12  '.g:NetrwTopLvlMenu.'Marked\ Files.Replace<tab>R      R'
             exe 'sil! menu '.g:NetrwMenuPriority.'.14.13  '.g:NetrwTopLvlMenu.'Marked\ Files.Set\ Target<tab>mt mt'
             exe 'sil! menu '.g:NetrwMenuPriority.'.14.14  '.g:NetrwTopLvlMenu.'Marked\ Files.Tag<tab>mT mT'

--- a/runtime/pack/dist/opt/netrw/doc/netrw.txt
+++ b/runtime/pack/dist/opt/netrw/doc/netrw.txt
@@ -90,7 +90,6 @@ Copyright: Copyright (C) 2017 Charles E Campbell    *netrw-copyright*
       Marked Files: Grep..................................|netrw-mg|
       Marked Files: Hiding and Unhiding by Suffix.........|netrw-mh|
       Marked Files: Moving................................|netrw-mm|
-      Marked Files: Printing..............................|netrw-mp|
       Marked Files: Sourcing..............................|netrw-ms|
       Marked Files: Setting the Target Directory..........|netrw-mt|
       Marked Files: Tagging...............................|netrw-mT|
@@ -1066,7 +1065,6 @@ QUICK REFERENCE: MAPS				*netrw-browse-maps* {{{2
 	   mg	Apply vimgrep to marked files                        |netrw-mg|
 	   mh	Toggle marked file suffices' presence on hiding list |netrw-mh|
 	   mm	Move marked files to marked-file target directory    |netrw-mm|
-	   mp	Print marked files                                   |netrw-mp|
 	   mr	Mark files using a shell-style |regexp|                |netrw-mr|
 	   mt	Current browsing directory becomes markfile target   |netrw-mt|
 	   mT	Apply ctags to marked files                          |netrw-mT|
@@ -2001,7 +1999,6 @@ The following netrw maps make use of marked files:
     |netrw-mF|	Unmark marked files
     |netrw-mg|	Apply vimgrep to marked files
     |netrw-mm|	Move marked files to target
-    |netrw-mp|	Print marked files
     |netrw-ms|	Netrw will source marked files
     |netrw-mt|	Set target for |netrw-mm| and |netrw-mc|
     |netrw-mT|	Generate tags using marked files
@@ -2265,15 +2262,6 @@ select file(s) (see |netrw-mf|), and press "mm".  The move is done
 from the current window (where one does the mf) to the target.
 
 Associated setting variable: |g:netrw_localmovecmd| |g:netrw_ssh_cmd|
-
-MARKED FILES: PRINTING						*netrw-mp* {{{2
-	    (See |netrw-mf| and |netrw-mr| for how to mark files)
-		      (uses the local marked file list)
-
-When "mp" is used, netrw will apply the |:hardcopy| command to marked files.
-What netrw does is open each file in a one-line window, execute hardcopy, then
-close the one-line window.
-
 
 MARKED FILES: SOURCING						*netrw-ms* {{{2
 	    (See |netrw-mf| and |netrw-mr| for how to mark files)

--- a/runtime/pack/dist/opt/netrw/plugin/netrwPlugin.vim
+++ b/runtime/pack/dist/opt/netrw/plugin/netrwPlugin.vim
@@ -15,7 +15,7 @@ if &cp || exists("g:loaded_netrwPlugin")
     finish
 endif
 
-let g:loaded_netrwPlugin = "v183"
+let g:loaded_netrwPlugin = "v184"
 
 let s:keepcpo = &cpo
 set cpo&vim


### PR DESCRIPTION
relevant commits:
- fix: remove black lines in directory listing
- fix: correctly create new file when using Lexplore
- refactor: remove print functionality

The main highlight is removing print functionality that was broken both in neovim and vim.