### PR TITLE
translation: auto-completion of fields in the `vim.pot` file

### DIFF
--- a/src/po/Make_mvc.mak
+++ b/src/po/Make_mvc.mak
@@ -12,7 +12,8 @@
 !ENDIF
 
 !IFNDEF LANGUAGE
-! IF [powershell.exe -nologo -noprofile $$lng=(Get-UICulture).TwoLetterISOLanguageName; \
+! IF [powershell.exe -nologo -noprofile \
+	$$lng=(Get-UICulture).TwoLetterISOLanguageName; \
 	$$Env:LANGUAGE=$$lng;Set-Content -Path .\lng.tmp -Value "LANGUAGE=$$lng"]
 ! ENDIF
 # In order for the "install" and "cleanup-po" rule to work.
@@ -53,8 +54,8 @@ GETTEXT_PATH = D:\Programs\GetText\bin
 # Starting from version 0.22, msgfmt forcibly converts text to UTF-8 regardless
 # of the value of the "charset" field.
 !IF [%comspec% /v:on /e:on /c "for /F "tokens=4 delims= " %G in \
-	('"$(GETTEXT_PATH)\msgfmt.exe" --version^|findstr /rc:[0-9^]\.[0-9^][0-9^]') do \
-		@(set "v=%G" && if !v:~2^,2! GEQ 22 exit /b 1)"]
+	('"$(GETTEXT_PATH)\msgfmt.exe" --version^|findstr /rc:[0-9^]\.[0-9^][0-9^]')\
+	do @(set "v=%G" && if !v:~2^,2! GEQ 22 exit /b 1)"]
 MSGFMT = "$(GETTEXT_PATH)\msgfmt.exe" -v --no-convert
 !ELSE
 MSGFMT = "$(GETTEXT_PATH)\msgfmt.exe" -v
@@ -94,6 +95,14 @@ PSFLAGS = -NoLogo -NoProfile -Command
 
 INSTALLDIR = $(VIMRUNTIME)\lang\$(LANGUAGE)\LC_MESSAGES
 
+!IF [%comspec% /C \
+	"for /F %G in ('wmic Path Win32_LocalTime Get Year /format:list ^| \
+	findstr /R [0-9^]') do @(echo:%G> .\_date.tmp)"]
+!ENDIF
+!INCLUDE .\_date.tmp
+!IF [$(RM) .\_date.tmp]
+!ENDIF
+
 .SUFFIXES:
 .SUFFIXES: .po .mo .pot .ck
 
@@ -104,8 +113,8 @@ originals : $(MOFILES)
 converted: $(MOCONVERTED)
 
 .po.ck:
-	"$(VIMPROG)" -u NONE --noplugins -e -s -X --cmd "set enc=utf-8" -S check.vim \
-		-c "if error == 0 | q | else | num 2 | cq | endif" $<
+	"$(VIMPROG)" -u NONE --noplugins -e -s -X --cmd "set enc=utf-8" \
+		-S check.vim -c "if error == 0 | q | else | num 2 | cq | endif" $<
 	$(TOUCH_TARGET)
 
 check: $(CHECKFILES)
@@ -456,11 +465,14 @@ first_time: files
 	@ copy /b .\files+.\vim_to_js .\allfiles
 	set OLD_PO_FILE_INPUT=yes
 	set OLD_PO_FILE_OUTPUT=yes
-	$(XGETTEXT) --default-domain=$(LANGUAGE) --add-comments $(XGETTEXT_KEYWORDS) \
-		--files-from=.\allfiles
+	$(XGETTEXT) --default-domain=$(LANGUAGE) --add-comments \
+		$(XGETTEXT_KEYWORDS) --files-from=.\allfiles \
+		--copyright-holder="$(Year), The Vim Project" --package-name=Vim \
+		--msgid-bugs-address="vim-dev@vim.org"
 	"$(VIMPROG)" -u NONE --not-a-term -S fixfilenames.vim $(LANGUAGE).po \
 		$(PO_VIM_INPUTLIST)
 	$(RM) *.js .\vim_to_js
+	@$(MAKE) -lf Make_mvc.mak clean
 
 $(PACKAGE).pot: files
 	"$(VIMPROG)" -u NONE --not-a-term -S tojavascript.vim $(PACKAGE).pot \
@@ -469,10 +481,13 @@ $(PACKAGE).pot: files
 	set OLD_PO_FILE_INPUT=yes
 	set OLD_PO_FILE_OUTPUT=yes
 	$(XGETTEXT) --default-domain=$(PACKAGE) --output=$(PACKAGE).pot \
-		--add-comments $(XGETTEXT_KEYWORDS) --files-from=.\allfiles
+		--add-comments $(XGETTEXT_KEYWORDS) --files-from=.\allfiles \
+		--no-location --copyright-holder="$(Year), The Vim Project" \
+		--package-name=Vim --msgid-bugs-address="vim-dev@vim.org"
 	"$(VIMPROG)" -u NONE --not-a-term -S fixfilenames.vim $(PACKAGE).pot \
 		$(PO_VIM_INPUTLIST)
 	$(RM) *.js .\vim_to_js
+	@$(MAKE) -lf Make_mvc.mak clean
 
 # Only original translations with default encoding should be updated.
 # The files that are converted to a different encoding clearly state "DO NOT EDIT".
@@ -480,7 +495,7 @@ update-po: $(MOFILES:.mo=)
 
 # Don't add a dependency here, we only want to update the .po files manually.
 $(LANGUAGES):
-	@$(MAKE) -nologo -f Make_mvc.mak GETTEXT_PATH="$(GETTEXT_PATH)" $(PACKAGE).pot
+	@$(MAKE) -lf Make_mvc.mak GETTEXT_PATH="$(GETTEXT_PATH)" $(PACKAGE).pot
 	$(CP) $@.po $@.po.orig
 	$(MV) $@.po $@.po.old
 	$(MSGMERGE) $@.po.old $(PACKAGE).pot -o $@.po

--- a/src/po/Makefile
+++ b/src/po/Makefile
@@ -41,7 +41,8 @@ converted: $(MOCONVERTED)
 
 .po.ck:
 	$(VIMPROG) -u NONE --noplugins -e -s -X --cmd "set enc=utf-8" \
-		-S check.vim -c "if error == 0 | q | else | num 2 | cq | endif" $< >/dev/null
+		-S check.vim -c "if error == 0 | q | else | num 2 | cq | endif" \
+		$< >/dev/null
 	touch $@
 
 check: $(CHECKFILES)
@@ -269,7 +270,8 @@ $(PACKAGE).pot: $(PO_INPUTLIST) $(PO_VIM_INPUTLIST)
 	# Create vim.pot.
 	$(XGETTEXT) --default-domain=$(PACKAGE) --output=$(PACKAGE).pot \
 		--add-comments $(XGETTEXT_KEYWORDS) --files-from=./allfiles \
-		--no-location
+		--no-location --copyright-holder="$$(date +%Y), The Vim Project" \
+		--package-name=Vim --msgid-bugs-address="vim-dev@vim.org"
 	# Fix Vim scripts names, so that "gf" works.
 	$(VIMPROG) -u NONE --not-a-term -S fixfilenames.vim $(PACKAGE).pot \
 		$(PO_VIM_INPUTLIST)


### PR DESCRIPTION
auto-completion of fields in the `vim.pot` file

> \# SOME DESCRIPTIVE TITLE.
> \# **Copyright (C) YEAR 2025, The Vim Project**
> \# This file is distributed under the same license as the Vim package.
> \# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
> \#
> \#, fuzzy
> msgid ""
> msgstr ""
> **"Project-Id-Version: Vim\n"**
> **"Report-Msgid-Bugs-To: vim-dev@vim.org\n"**
> "POT-Creation-Date: 2025-07-26 16:34+0300\n"
> "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
> "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
> "Language-Team: LANGUAGE <LL@li.org>\n"
> "Language: \n"
> "MIME-Version: 1.0\n"
> "Content-Type: text/plain; charset=CHARSET\n"
> "Content-Transfer-Encoding: 8bit\n"
> "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"

