### PR TITLE
runtime(vimscript): add simple vimscript complete function

### DIFF
--- a/runtime/autoload/vimcomplete.vim
+++ b/runtime/autoload/vimcomplete.vim
@@ -11,17 +11,8 @@ vim9script
 # Simple complete function for the Vimscript
 
 var trigger: string = ""
+var prefix: string = ""
 
-def Filter(haystack: list<any>, needle: string): list<any>
-    if empty(needle)
-        return haystack
-    endif
-    if &completeopt =~ 'fuzzy'
-        return haystack->matchfuzzy(needle, {key: 'word', camelcase: false})
-    else
-        return haystack->filter((_, v) => stridx(v.word, needle) == 0)
-    endif
-enddef
 
 def GetTrigger(line: string): list<any>
     var result = ""
@@ -36,22 +27,8 @@ def GetTrigger(line: string): list<any>
     elseif line =~ '[lvgsb]:\k*$'
         result = 'var'
         result_len = 2
-    elseif line =~ '\vhi%[ghlight]!?\s+%(def%[ault]\s+)?link\s+(\k+\s+)?\k*$'
-        result = 'highlight_def_link'
-    elseif line =~ '\vhi%[ghlight]!?\s+def%[ault]\s+\k*$'
-        result = 'highlight_def'
-    elseif line =~ '\vhi%[ghlight]!?\s+%(def%[ault]\s+)?\k+%(\s+\k+\=%(\k+,?)+)*%(\s+%(cterm|gui)\=)%(\k+,)*\k*$'
-        result = 'highlight_attr_noncolor'
-    elseif line =~ '\vhi%[ghlight]!?\s+%(def%[ault]\s+)?\k+%(\s+\k+\=%(\k+,?)+)*%(\s+cterm[fb]g\=)\k*$'
-        result = 'highlight_attr_color_cterm'
-    elseif line =~ '\vhi%[ghlight]!?\s+%(def%[ault]\s+)?\k+%(\s+\k+\=%(\k+,?)+)*%(\s+gui[fb]g\=)\k*$'
-        result = 'highlight_attr_color_gui'
-    elseif line =~ '\vhi%[ghlight]!?\s+%(def%[ault]\s+)?\k+%(\s+\k+\=%(\k+,?)+)*\s+\k*$'
-        result = 'highlight_attr'
-    elseif line =~ '\vhi%[ghlight]!?\s+\k*$'
-        result = 'highlight'
     else
-        result = getcompletiontype(line)
+        result = getcompletiontype(line) ?? 'cmdline'
     endif
     return [result, result_len]
 enddef
@@ -69,71 +46,27 @@ export def Complete(findstart: number, base: string): any
         if keyword->empty() && trigger->empty()
             return -2
         endif
+        prefix = line
         return line->len() - keyword->len() - trigger_len
     endif
 
-    var funcs = getcompletion(base, 'function')
-        ->mapnew((_, v) => ({word: v, kind: 'v', menu: 'Function', dup: 0}))
-    var exprs = getcompletion(base, 'expression')
-        ->mapnew((_, v) => ({word: v, kind: 'v', menu: 'Expression', dup: 0}))
-    var commands = getcompletion(base, 'command')
-        ->mapnew((_, v) => ({word: v, kind: 'v', menu: 'Command', dup: 0}))
-    var options = getcompletion(base, 'option')
-        ->mapnew((_, v) => ({word: v, kind: 'v', menu: 'Option', dup: 0}))
-    var vars = getcompletion(base, 'var')
-        ->mapnew((_, v) => ({word: v, kind: 'v', menu: 'Variable', dup: 0}))
-    var events = getcompletion(base, 'event')
-        ->mapnew((_, v) => ({word: v, kind: 'v', menu: 'Autocommand event', dup: 0}))
-    var highlights = getcompletion(base, 'highlight')
-        ->mapnew((_, v) => ({word: v, kind: 'v', menu: 'Highlight group', dup: 0}))
 
     var items = []
     if trigger == 'function'
-        items = funcs
+        items = getcompletion(base, 'function')
+            ->mapnew((_, v) => ({word: v, kind: 'v', menu: 'Function', dup: 0}))
     elseif trigger == 'option'
-        items = options
+        items = getcompletion(base, 'option')
+            ->mapnew((_, v) => ({word: v, kind: 'v', menu: 'Option', dup: 0}))
     elseif trigger == 'var'
-        items = vars
+        items = getcompletion(base, 'var')
+            ->mapnew((_, v) => ({word: v, kind: 'v', menu: 'Variable', dup: 0}))
     elseif trigger == 'expression'
-        items = exprs
-    elseif trigger == 'event'
-        items = events
-    elseif trigger == 'highlight_def_link'
-        items = highlights
-    elseif trigger == 'highlight_def'
-        items = [
-            {word: 'link', kind: 'v', menu: 'Link first highlight group to the second one.'}
-        ]->Filter(base)
-        + highlights
-    elseif trigger == 'highlight'
-        items = [
-            {word: 'default', kind: 'v', menu: 'Set default highlighting.'},
-            {word: 'link', kind: 'v', menu: 'Link first highlight group to the second one.'}
-        ]->Filter(base)
-        + highlights
-    elseif trigger == 'highlight_attr'
-        items = [
-            'gui', 'cterm', 'guibg', 'ctermbg', 'guifg', 'ctermfg',
-        ]->mapnew((_, v) => ({word: v, kind: 'v', menu: 'Highlight group attribute', dup: 0}))
-        ->Filter(base)
-    elseif trigger == 'highlight_attr_noncolor'
-        items = [
-            'bold', 'italic', 'underline', 'NONE', 'reverse',
-            'undercurl', 'underdouble', 'underdouble', 'strikethrough', 'standout'
-        ]->mapnew((_, v) => ({word: v, kind: 'v', menu: 'gui= or term= value', dup: 0}))
-        ->Filter(base)
-    elseif trigger == 'highlight_attr_color_cterm'
-        items = [
-            'black', 'white', 'red', 'darkred', 'green', 'darkgreen', 'yellow', 'darkyellow',
-            'blue', 'darkblue', 'magenta', 'darkmagenta', 'cyan', 'darkcyan', 'gray', 'darkgray'
-        ]->mapnew((_, v) => ({word: v, kind: 'v', menu: 'cterm color', dup: 0}))
-        ->Filter(base)
-    elseif trigger == 'highlight_attr_color_gui'
-        items = v:colornames->keys()
-            ->mapnew((_, v) => ({word: v:colornames[v], kind: 'v', menu: $"Color: {v}", dup: 0}))
-            ->Filter(base)
-    elseif !empty(base)
-        items = commands->extend(funcs)
+        items = getcompletion(base, 'expression')
+            ->mapnew((_, v) => ({word: v, kind: 'v', menu: 'Expression', dup: 0}))
+    else
+        items = getcompletion(prefix, 'cmdline')
+            ->mapnew((_, v) => ({word: v->matchstr('\k\+'), kind: 'v', dup: 0}))
     endif
 
     return items->empty() ? v:none : items

--- a/runtime/autoload/vimcomplete.vim
+++ b/runtime/autoload/vimcomplete.vim
@@ -64,6 +64,12 @@ export def Complete(findstart: number, base: string): any
     elseif trigger == 'expression'
         items = getcompletion(base, 'expression')
             ->mapnew((_, v) => ({word: v, kind: 'v', menu: 'Expression', dup: 0}))
+    elseif trigger == 'command'
+        var commands = getcompletion(base, 'command')
+            ->mapnew((_, v) => ({word: v, kind: 'v', menu: 'Command', dup: 0}))
+        var functions = getcompletion(base, 'function')
+            ->mapnew((_, v) => ({word: v, kind: 'v', menu: 'Function', dup: 0}))
+        items = commands + functions
     else
         items = getcompletion(prefix, 'cmdline')
             ->mapnew((_, v) => ({word: v->matchstr('\k\+'), kind: 'v', dup: 0}))

--- a/runtime/autoload/vimcomplete.vim
+++ b/runtime/autoload/vimcomplete.vim
@@ -17,7 +17,7 @@ def GetTrigger(line: string): list<any>
     var result_len = 0
     if line =~ '->\k*$' || line =~ '\vcall\s+\k*$'
         result = 'func'
-    elseif line =~ '\v%(^|\s+)\&\k*$' || line =~ '\vset%(\s+\k*)*$'
+    elseif line =~ '\v%(^|\s+)\&\k*$' || line =~ '\vset%(\s+\k+%([-+^]?\=\S+(\\\s)|\S+)*)*$'
         result = 'option'
     elseif line =~ '\vecho%[msg]\s+\k*$' || line =~ '[\[(]\s*$'
         result = 'expr'

--- a/runtime/autoload/vimcomplete.vim
+++ b/runtime/autoload/vimcomplete.vim
@@ -50,7 +50,6 @@ export def Complete(findstart: number, base: string): any
         return line->len() - keyword->len() - trigger_len
     endif
 
-
     var items = []
     if trigger == 'function'
         items = getcompletion(base, 'function')
@@ -73,6 +72,11 @@ export def Complete(findstart: number, base: string): any
     else
         items = getcompletion(prefix, 'cmdline')
             ->mapnew((_, v) => ({word: v->matchstr('\k\+'), kind: 'v', dup: 0}))
+
+        if empty(items) && !empty(base)
+            items = getcompletion(base, 'expression')
+                ->mapnew((_, v) => ({word: v, kind: 'v', menu: 'Expression', dup: 0}))
+        endif
     endif
 
     return items->empty() ? v:none : items

--- a/runtime/autoload/vimcomplete.vim
+++ b/runtime/autoload/vimcomplete.vim
@@ -1,0 +1,122 @@
+vim9script
+
+# Vim completion script
+# Language:    Vimscript
+# Maintainer:  Maxim Kim <habamax@gmail.com>
+# Last Change: 2025-07-28
+#
+# Usage:
+# setlocal omnifunc=vimcomplete#Complete
+#
+# Simple complete function for the Vimscript
+
+var trigger: string = ""
+
+def GetTrigger(line: string): list<any>
+    var result = ""
+    var result_len = 0
+    if line =~ '->\k*$' || line =~ '\vcall\s+\k*$'
+        result = 'func'
+    elseif line =~ '\v%(^|\s+)\&\k*$' || line =~ '\vset%(\s+\k*)*$'
+        result = 'option'
+    elseif line =~ '\vecho%[msg]\s+\k*$' || line =~ '[\[(]\s*$'
+        result = 'expr'
+    elseif line =~ '[lvgsb]:'
+        result = 'var'
+        result_len = 2
+    elseif line =~ '\vau%[tocmd]\s+\k*$'
+        result = 'event'
+    elseif line =~ '\vhi%[ghlight]!?\s+%(def%[ault]\s+)?link\s+(\k+\s+)?\k*$'
+        result = 'highlight_def_link'
+    elseif line =~ '\vhi%[ghlight]!?\s+def%[ault]\s+\k*$'
+        result = 'highlight_def'
+    elseif line =~ '\vhi%[ghlight]!?\s+%(def%[ault]\s+)?\k+%(\s+\k+\=%(\k+,?)+)*%(\s+%(cterm|gui)\=)%(\k+,)*\k*$'
+        result = 'highlight_attr_noncolor'
+    elseif line =~ '\vhi%[ghlight]!?\s+%(def%[ault]\s+)?\k+%(\s+\k+\=%(\k+,?)+)*%(\s+cterm[fb]g\=)\k*$'
+        result = 'highlight_attr_color_cterm'
+    elseif line =~ '\vhi%[ghlight]!?\s+%(def%[ault]\s+)?\k+%(\s+\k+\=%(\k+,?)+)*%(\s+gui[fb]g\=)\k*$'
+        result = 'highlight_attr_color_gui'
+    elseif line =~ '\vhi%[ghlight]!?\s+%(def%[ault]\s+)?\k+%(\s+\k+\=%(\k+,?)+)*\s+\k*$'
+        result = 'highlight_attr'
+    elseif line =~ '\vhi%[ghlight]!?\s+\k*$'
+        result = 'highlight'
+    endif
+    return [result, result_len]
+enddef
+
+export def Complete(findstart: number, base: string): any
+    if findstart > 0
+        var line = getline('.')->strpart(0, col('.') - 1)
+        var keyword = line->matchstr('\k\+$')
+        var stx = synstack(line('.'), col('.') - 1)->map('synIDattr(v:val, "name")')->join()
+        if stx =~? 'Comment' || (stx =~ 'String' && stx !~ 'vimStringInterpolationExpr')
+            return -2
+        endif
+        var trigger_len: number = 0
+        [trigger, trigger_len] = GetTrigger(line)
+        if keyword->empty() && trigger->empty()
+            return -2
+        endif
+        return line->len() - keyword->len() - trigger_len
+    endif
+
+    var funcs = getcompletion(base, 'function')
+        ->mapnew((_, v) => ({word: v, kind: 'v', menu: 'Function', dup: 0}))
+    var exprs = getcompletion(base, 'expression')
+        ->mapnew((_, v) => ({word: v, kind: 'v', menu: 'Expression', dup: 0}))
+    var commands = getcompletion(base, 'command')
+        ->mapnew((_, v) => ({word: v, kind: 'v', menu: 'Command', dup: 0}))
+    var options = getcompletion(base, 'option')
+        ->mapnew((_, v) => ({word: v, kind: 'v', menu: 'Option', dup: 0}))
+    var vars = getcompletion(base, 'var')
+        ->mapnew((_, v) => ({word: v, kind: 'v', menu: 'Variable', dup: 0}))
+    var events = getcompletion(base, 'event')
+        ->mapnew((_, v) => ({word: v, kind: 'v', menu: 'Autocommand event', dup: 0}))
+    var highlights = getcompletion(base, 'highlight')
+        ->mapnew((_, v) => ({word: v, kind: 'v', menu: 'Highlight group', dup: 0}))
+
+    var items = []
+    if trigger == 'func'
+        items = funcs
+    elseif trigger == 'option'
+        items = options
+    elseif trigger == 'var'
+        items = vars
+    elseif trigger == 'expr'
+        items = exprs
+    elseif trigger == 'event'
+        items = events
+    elseif trigger == 'highlight_def_link'
+        items = highlights
+    elseif trigger == 'highlight_def'
+        items = [
+            {word: 'link', kind: 'v', menu: 'Link first highlight group to the second one.'}
+        ] + highlights
+    elseif trigger == 'highlight'
+        items = [
+            {word: 'default', kind: 'v', menu: 'Set default highlighting.'},
+            {word: 'link', kind: 'v', menu: 'Link first highlight group to the second one.'}
+        ] + highlights
+    elseif trigger == 'highlight_attr'
+        items = [
+            'gui', 'cterm', 'guibg', 'ctermbg', 'guifg', 'ctermfg',
+        ]->mapnew((_, v) => ({word: v, kind: 'v', menu: 'Highlight group attribute', dup: 0}))
+    elseif trigger == 'highlight_attr_noncolor'
+        items = [
+            'bold', 'italic', 'underline', 'NONE', 'reverse',
+            'undercurl', 'underdouble', 'underdouble', 'strikethrough', 'standout'
+        ]->mapnew((_, v) => ({word: v, kind: 'v', menu: 'gui= or term= value', dup: 0}))
+    elseif trigger == 'highlight_attr_color_cterm'
+        items = [
+            'black', 'white', 'red', 'darkred', 'green', 'darkgreen', 'yellow', 'darkyellow',
+            'blue', 'darkblue', 'magenta', 'darkmagenta', 'cyan', 'darkcyan', 'gray', 'darkgray'
+        ]
+    elseif trigger == 'highlight_attr_color_gui'
+        items = v:colornames->keys()
+            ->mapnew((_, v) => ({word: v:colornames[v], kind: 'v', menu: $"Color: {v}", dup: 0}))
+    elseif !empty(base)
+        items = commands->extend(funcs)
+    endif
+
+    return items->empty() ? v:none : items
+enddef

--- a/runtime/autoload/vimcomplete.vim
+++ b/runtime/autoload/vimcomplete.vim
@@ -15,17 +15,16 @@ var trigger: string = ""
 def GetTrigger(line: string): list<any>
     var result = ""
     var result_len = 0
-    if line =~ '->\k*$' || line =~ '\vcall\s+\k*$'
-        result = 'func'
-    elseif line =~ '\v%(^|\s+)\&\k*$' || line =~ '\vset%(\s+\k+%([-+^]?\=\S+(\\\s)|\S+)*)*$'
+
+    if line =~ '->\k*$'
+        result = 'function'
+    elseif line =~ '\v%(^|\s+)\&\k*$'
         result = 'option'
-    elseif line =~ '\vecho%[msg]\s+\k*$' || line =~ '[\[(]\s*$'
-        result = 'expr'
-    elseif line =~ '[lvgsb]:'
+    elseif line =~ '[\[(]\s*$'
+        result = 'expression'
+    elseif line =~ '[lvgsb]:\k*$'
         result = 'var'
         result_len = 2
-    elseif line =~ '\vau%[tocmd]\s+\k*$'
-        result = 'event'
     elseif line =~ '\vhi%[ghlight]!?\s+%(def%[ault]\s+)?link\s+(\k+\s+)?\k*$'
         result = 'highlight_def_link'
     elseif line =~ '\vhi%[ghlight]!?\s+def%[ault]\s+\k*$'
@@ -40,6 +39,8 @@ def GetTrigger(line: string): list<any>
         result = 'highlight_attr'
     elseif line =~ '\vhi%[ghlight]!?\s+\k*$'
         result = 'highlight'
+    else
+        result = getcompletiontype(line)
     endif
     return [result, result_len]
 enddef
@@ -76,13 +77,13 @@ export def Complete(findstart: number, base: string): any
         ->mapnew((_, v) => ({word: v, kind: 'v', menu: 'Highlight group', dup: 0}))
 
     var items = []
-    if trigger == 'func'
+    if trigger == 'function'
         items = funcs
     elseif trigger == 'option'
         items = options
     elseif trigger == 'var'
         items = vars
-    elseif trigger == 'expr'
+    elseif trigger == 'expression'
         items = exprs
     elseif trigger == 'event'
         items = events

--- a/runtime/ftplugin/vim.vim
+++ b/runtime/ftplugin/vim.vim
@@ -20,7 +20,7 @@ set cpo&vim
 
 if !exists('*VimFtpluginUndo')
   func VimFtpluginUndo()
-    setl fo< isk< com< tw< commentstring< include< define< keywordprg<
+    setl fo< isk< com< tw< commentstring< include< define< keywordprg< omnifunc<
     sil! delc -buffer VimKeywordPrg
     if exists('b:did_add_maps')
       silent! nunmap <buffer> [[
@@ -115,6 +115,9 @@ setlocal include=\\v^\\s*import\\s*(autoload)?
 
 " set 'define' to recognize export commands
 setlocal define=\\v^\\s*export\\s*(def\|const\|var\|final)
+
+" set omnifunc completeion
+setlocal omnifunc=vimcomplete#Complete
 
 " Format comments to be up to 78 characters long
 if &tw == 0

--- a/runtime/ftplugin/vim.vim
+++ b/runtime/ftplugin/vim.vim
@@ -116,7 +116,7 @@ setlocal include=\\v^\\s*import\\s*(autoload)?
 " set 'define' to recognize export commands
 setlocal define=\\v^\\s*export\\s*(def\|const\|var\|final)
 
-" set omnifunc completeion
+" set omnifunc completion
 setlocal omnifunc=vimcomplete#Complete
 
 " Format comments to be up to 78 characters long


### PR DESCRIPTION
I have come up with a simple omnicomplete function for vimscript to complete different things (commands, functions, options, global/buffer variables, expressions, highlight command).

It works nicely with the `set autocomplete`. While it is not super smart, it might be better than nothing and as usual there is a room for future improvements.

Set `setlocal complete^=o^10` if you would like to use it with `set autocomplete` or just trigger it manually with `C-x C-o`:

[![asciicast](https://asciinema.org/a/730271.svg)](https://asciinema.org/a/730271)

@chrisbra, @girishji, @lifepillar, @yegappan could you please check if it works for you? And in general if it makes sense to put it into vim's core.