### PR TITLE
runtime: detect more filetypes

### DIFF
--- a/runtime/autoload/dist/script.vim
+++ b/runtime/autoload/dist/script.vim
@@ -264,6 +264,7 @@ def DetectFromText(line1: string)
 
   # ELM Mail files
   elseif line1 =~ '^From \([a-zA-Z][a-zA-Z_0-9\.=-]*\(@[^ ]*\)\=\|-\) .* \(19\|20\)\d\d$'
+      || line1 =~ '^\creturn-path:\s<.*@.*>$'
     setl ft=mail
 
   # Mason
@@ -452,6 +453,12 @@ def DetectFromText(line1: string)
     # before any trailing comment text
   elseif line1 =~ '^#n\%($\|\s\)'
     setl ft=sed
+
+  elseif line1 =~ '^#\s\+Reconstructed via infocmp from file:'
+    setl ft=terminfo
+
+  elseif line1 =~ '^File: .*\.info,  Node: .*,  \%(Next\|Prev\): .*,  Up: \|This is the top of the INFO tree.'
+    setl ft=info
 
   else
     var lnum = 1

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -3024,6 +3024,39 @@ func Test_org_file()
   filetype off
 endfunc
 
+func Test_info_file()
+  filetype on
+
+  call writefile(['File: coreutils.info,  Node: Top,  Next: Introduction,  Up: (dir)', 'D'])
+  split Xfile.org
+  call assert_equal('info', &filetype)
+  bwipe!
+
+  filetype off
+endfunc
+
+func Test_mail_file()
+  filetype on
+
+  call writefile(['Return-path: <lgc@debian.home.arpa>', 'D'])
+  split Xfile.org
+  call assert_equal('mail', &filetype)
+  bwipe!
+
+  filetype off
+endfunc
+
+func Test_terminfo_file()
+  filetype on
+
+  call writefile(['#	Reconstructed via infocmp from file: /etc/terminfo/x/xterm', 'D'])
+  split Xfile.org
+  call assert_equal('terminfo', &filetype)
+  bwipe!
+
+  filetype off
+endfunc
+
 " Filetypes detected from names of existing files
 func Test_pacmanlog()
   filetype on


### PR DESCRIPTION
This PR adds filetype detection for `info(1)`, `infocmp(1)`, `mail(1)`, and `terminfo(5)` output.

This is useful for when we run commands such as:

    $ infocmp -1x xterm | vim -
    $ info coreutils | vim -

The `mail` filetype detection is useful for when we read a local mail with `mail(1)` which is too long to fit in one screen.  Typically, `mail(1)` automatically invokes `less(1)`; but we can pipe `less(1)` output to Vim.  For example, by pressing `E` after adding this line to `~/.config/less/keys` (and `export`ing `LESSKEYIN=$HOME/.config/less/keys`):

    E noaction g|$vim --not-a-term -^M

A mail then looks like this:

    Return-path: <lgc@debian.home.arpa>
    Envelope-to: lgc@localhost
    Delivery-date: Mon, 07 Jul 2025 10:02:36 +0200
    Received: from lgc by debian.home.arpa with local (Exim 4.96)
            (envelope-from <lgc@debian.home.arpa>)
            id ...
            for lgc@localhost;
            Mon, 07 Jul 2025 10:02:36 +0200
    Subject: systemd-maintenance
    To: <lgc@localhost>
    User-Agent: mail (GNU Mailutils 3.15)
    Date: Mon,  7 Jul 2025 10:02:36 +0200
    Message-Id: ...
    From: Lacygoill <lgc@debian.home.arpa>
    X-UID: 3
    Status: OR

    ...
