### PR TITLE
runtime(vim): make gf support :import lines

### DIFF
--- a/runtime/autoload/vim.vim
+++ b/runtime/autoload/vim.vim
@@ -3,19 +3,21 @@ vim9script
 # Interface {{{1
 export def Find(editcmd: string) #{{{2
     var curline: string = getline('.')
+    var cmd: string = editcmd
+        ->substitute('<C-W>', "\<C-W>", 'g')
 
     if curline =~ '^\s*\%(:\s*\)\=packadd!\=\s'
-        HandlePackaddLine(editcmd, curline)
+        HandlePackaddLine(cmd, curline)
         return
     endif
 
     if curline =~ '^\s*\%(:\s*\)\=import\s'
-        HandleImportLine(editcmd, curline)
+        HandleImportLine(cmd, curline)
         return
     endif
 
     try
-        execute 'normal! ' .. editcmd
+        execute 'normal! ' .. cmd
     catch
         Error(v:exception)
     endtry
@@ -93,8 +95,8 @@ def HandleImportLine(editcmd: string, curline: string) #{{{2
 
     var how_to_split: string = {
         gF: 'edit',
-        '<C-W>F': 'split',
-        '<C-W>gF': 'tab split',
+        "\<C-W>F": 'split',
+        "\<C-W>gF": 'tab split',
     }[editcmd]
     execute how_to_split .. ' ' .. filepath
 enddef

--- a/runtime/autoload/vim.vim
+++ b/runtime/autoload/vim.vim
@@ -3,21 +3,19 @@ vim9script
 # Interface {{{1
 export def Find(editcmd: string) #{{{2
     var curline: string = getline('.')
-    var cmd: string = editcmd
-        ->substitute('<C-W>', "\<C-W>", 'g')
 
     if curline =~ '^\s*\%(:\s*\)\=packadd!\=\s'
-        HandlePackaddLine(cmd, curline)
+        HandlePackaddLine(editcmd, curline)
         return
     endif
 
     if curline =~ '^\s*\%(:\s*\)\=import\s'
-        HandleImportLine(cmd, curline)
+        HandleImportLine(editcmd, curline)
         return
     endif
 
     try
-        execute 'normal! ' .. cmd
+        execute 'normal! ' .. editcmd
     catch
         Error(v:exception)
     endtry

--- a/runtime/autoload/vim.vim
+++ b/runtime/autoload/vim.vim
@@ -1,0 +1,123 @@
+vim9script
+
+# Interface {{{1
+export def Find(editcmd: string) #{{{2
+    var curline: string = getline('.')
+
+    if curline =~ '^\s*packadd!\=\s'
+        HandlePackaddLine(editcmd, curline)
+        return
+    endif
+
+    if curline =~ '^\s*import\s'
+        HandleImportLine(editcmd, curline)
+        return
+    endif
+
+    try
+        execute 'normal! ' .. editcmd
+    catch
+        Error(v:exception)
+    endtry
+enddef
+#}}}1
+# Core {{{1
+def HandlePackaddLine(editcmd: string, curline: string) #{{{2
+    var pat: string = '^\s*packadd!\=\s\+\zs\S\+$'
+    var plugin: string = curline
+        ->matchstr(pat)
+        ->substitute('^vim-\|\.vim$', '', 'g')
+
+    if plugin == ''
+        try
+            execute 'normal! ' .. editcmd .. 'zv'
+        catch
+            Error(v:exception)
+            return
+        endtry
+    else
+        var split: string = editcmd[0] == 'g' ? 'edit' : editcmd[1] == 'g' ? 'tabedit' : 'split'
+        # In the  past, we passed  `runtime` to `getcompletion()`,  instead of
+        # `cmdline`.  But the  output was tricky to use,  because it contained
+        # paths relative to inconsistent root directories.
+        var files: list<string> = getcompletion($'edit **/plugin/{plugin}.vim', 'cmdline')
+            ->filter((_, path: string): bool => filereadable(path))
+        if empty(files)
+            echo 'Could not find any plugin file for ' .. string(plugin)
+            return
+        endif
+        files->window.OpenOrFocus(split)
+    endif
+enddef
+
+def HandleImportLine(editcmd: string, curline: string) #{{{2
+    var fname: string
+    var import_cmd: string = '^\s*import\s\+\%(autoload\s\+\)\='
+    var import_alias: string = '\%(\s\+as\s\+\w\+\)\=$'
+    var import_string: string = import_cmd .. '\([''"]\)\zs.*\ze\1' .. import_alias
+    var import_expr: string = import_cmd .. '\zs.*\ze' .. import_alias
+    # the script is referred to by its name in a quoted string
+    if curline =~ import_string
+        fname = curline->matchstr(import_string)
+    # the script is referred to by an expression
+    elseif curline =~ import_expr
+        try
+            fname = curline
+                ->matchstr(import_expr)
+                ->eval()
+        catch
+            Error(v:exception)
+            return
+        endtry
+    endif
+
+    var filepath: string
+    if fname->isabsolutepath()
+        filepath = fname
+    elseif fname[0] == '.'
+        filepath = (expand('%:h') .. '/' .. fname)->simplify()
+    else
+        var subdir: string = curline =~ '^\s*import\s\+autoload\>' ? 'autoload' : 'import'
+        # Matching patterns in `'wildignore'` can be slow.
+        # Let's set `{nosuf}` to `true` to avoid `globpath()` to be slow.
+        filepath = globpath(&runtimepath, subdir .. '/' .. fname, true, true)
+            ->get(0, '')
+    endif
+
+    if !filepath->filereadable()
+        printf('E447: Can''t find file "%s" in path', fname)
+            ->Error()
+        return
+    endif
+
+    var how_to_split: string = {
+        gF: 'edit',
+        "\<C-W>F": 'split',
+        "\<C-W>gF": 'tab split',
+    }[editcmd]
+    execute how_to_split .. ' ' .. filepath
+enddef
+
+def OpenOrFocus(fname: string, how: string) #{{{2
+    # Open given filename in given way, but only if it's not already displayed
+    # in a window.  If it is, just focus the latter instead.
+    var winid: number = ($'^{fname}$')
+        ->bufnr()
+        ->win_findbuf()
+        ->get(0, -1)
+
+    if winid != -1
+        win_gotoid(winid)
+        return
+    endif
+
+    execute $'{how} {fname}'
+    cursor(1, 1)
+enddef
+#}}}1
+# Util {{{1
+def Error(msg: string) #{{{2
+    echohl ErrorMsg
+    echomsg msg
+    echohl NONE
+enddef

--- a/runtime/autoload/vim.vim
+++ b/runtime/autoload/vim.vim
@@ -42,6 +42,7 @@ def HandlePackaddLine(editcmd: string, curline: string) #{{{2
         # paths relative to inconsistent root directories.
         var files: list<string> = getcompletion($'edit **/plugin/{plugin}.vim', 'cmdline')
             ->filter((_, path: string): bool => filereadable(path))
+            ->map((_, fname: string) => fname->fnamemodify(':p'))
         if empty(files)
             echo 'Could not find any plugin file for ' .. string(plugin)
             return

--- a/runtime/autoload/vim.vim
+++ b/runtime/autoload/vim.vim
@@ -47,7 +47,7 @@ def HandlePackaddLine(editcmd: string, curline: string) #{{{2
             echo 'Could not find any plugin file for ' .. string(plugin)
             return
         endif
-        files->OpenOrFocus(split)
+        files->Open(split)
     endif
 enddef
 
@@ -99,7 +99,7 @@ def HandleImportLine(editcmd: string, curline: string) #{{{2
     execute how_to_split .. ' ' .. filepath
 enddef
 
-def OpenOrFocus(what: any, how: string) #{{{2
+def Open(what: any, how: string) #{{{2
     var fname: string
     if what->typename() == 'list<string>'
         if what->empty()
@@ -113,16 +113,6 @@ def OpenOrFocus(what: any, how: string) #{{{2
         fname = what
     endif
 
-    # Open given filename in given way, but only if it's not already displayed
-    # in a window.  If it is, just focus the latter instead.
-    var winid: number = ($'^{fname}$')
-        ->bufnr()
-        ->win_findbuf()
-        ->get(0, -1)
-    if winid != -1
-        win_gotoid(winid)
-        return
-    endif
     execute $'{how} {fname}'
     cursor(1, 1)
 

--- a/runtime/autoload/vim.vim
+++ b/runtime/autoload/vim.vim
@@ -4,12 +4,12 @@ vim9script
 export def Find(editcmd: string) #{{{2
     var curline: string = getline('.')
 
-    if curline =~ '^\s*packadd!\=\s'
+    if curline =~ '^\s*\%(:\s*\)\=packadd!\=\s'
         HandlePackaddLine(editcmd, curline)
         return
     endif
 
-    if curline =~ '^\s*import\s'
+    if curline =~ '^\s*\%(:\s*\)\=import\s'
         HandleImportLine(editcmd, curline)
         return
     endif
@@ -63,7 +63,7 @@ def HandleImportLine(editcmd: string, curline: string) #{{{2
     # the script is referred to by an expression
     elseif curline =~ import_expr
         try
-            fname = curline
+            sandbox fname = curline
                 ->matchstr(import_expr)
                 ->eval()
         catch
@@ -93,13 +93,13 @@ def HandleImportLine(editcmd: string, curline: string) #{{{2
 
     var how_to_split: string = {
         gF: 'edit',
-        "\<C-W>F": 'split',
-        "\<C-W>gF": 'tab split',
+        '<C-W>F': 'split',
+        '<C-W>gF': 'tab split',
     }[editcmd]
     execute how_to_split .. ' ' .. filepath
 enddef
 
-export def OpenOrFocus(what: any, how: string) #{{{1
+def OpenOrFocus(what: any, how: string) #{{{2
     var fname: string
     if what->typename() == 'list<string>'
         if what->empty()

--- a/runtime/ftplugin/vim.vim
+++ b/runtime/ftplugin/vim.vim
@@ -163,8 +163,8 @@ if !exists("no_plugin_maps") && !exists("no_vim_maps")
   " }}}
   " We use the `F` variants, instead of the `f` ones, because they're smarter.
   nnoremap <silent><buffer> gf :<C-U>call vim#Find('gF')<CR>
-  nnoremap <silent><buffer> <C-W>f :<C-U>call vim#Find('<lt>C-W>F')<CR>
-  nnoremap <silent><buffer> <C-W>gf :<C-U>call vim#Find('<lt>C-W>gF')<CR>
+  nnoremap <silent><buffer> <C-W>f :<C-U>call vim#Find("\<lt>C-W>F")<CR>
+  nnoremap <silent><buffer> <C-W>gf :<C-U>call vim#Find("\<lt>C-W>gF")<CR>
 endif
 
 " Let the matchit plugin know what items can be matched.

--- a/runtime/ftplugin/vim.vim
+++ b/runtime/ftplugin/vim.vim
@@ -35,6 +35,9 @@ if !exists('*VimFtpluginUndo')
       silent! xunmap <buffer> ]"
       silent! nunmap <buffer> ["
       silent! xunmap <buffer> ["
+      silent! nunmap <buffer> gf
+      silent! nunmap <buffer> <C-W>f
+      silent! nunmap <buffer> <C-W>gf
     endif
     unlet! b:match_ignorecase b:match_words b:match_skip b:did_add_maps
   endfunc
@@ -139,6 +142,29 @@ if !exists("no_plugin_maps") && !exists("no_vim_maps")
   xnoremap <silent><buffer> ]" :<C-U>exe "normal! gv"<Bar>call search('\%(^\s*".*\n\)\@<!\%(^\s*"\)', "W")<CR>
   nnoremap <silent><buffer> [" :call search('\%(^\s*".*\n\)\%(^\s*"\)\@!', "bW")<CR>
   xnoremap <silent><buffer> [" :<C-U>exe "normal! gv"<Bar>call search('\%(^\s*".*\n\)\%(^\s*"\)\@!', "bW")<CR>
+
+    " Purpose: Handle `:import` and `:packadd` lines in a smarter way. {{{
+    "
+    " `:import` is followed by a filename or filepath.  Find it.
+    "
+    " `:packadd`  is  followed  by the  name  of  a  package,  which we  might  have
+    " configured in scripts under `~/.vim/plugin`.  Find it.
+    "
+    " ---
+    "
+    " We can't handle the `:import` lines simply by setting `'includeexpr'`, because
+    " the option would be ignored if:
+    "
+    "    - the name of the imported script is the same as the current one
+    "    - `'path'` includes the `.` item
+    "
+    " Indeed,  in that  case, Vim  finds the  current file,  and simply  reloads the
+    " buffer.
+    " }}}
+    " We use the `F` variants, instead of the `f` ones, because they're smarter.
+  nnoremap <silent><buffer> gf :<C-U>call gf#Find('gF')<CR>
+  nnoremap <silent><buffer> <C-W>f :<C-U>call gf#Find('<C-W>F')<CR>
+  nnoremap <silent><buffer> <C-W>gf :<C-U>call gf#Find('<C-W>gF')<CR>
 endif
 
 " Let the matchit plugin know what items can be matched.

--- a/runtime/ftplugin/vim.vim
+++ b/runtime/ftplugin/vim.vim
@@ -162,9 +162,9 @@ if !exists("no_plugin_maps") && !exists("no_vim_maps")
   " buffer.
   " }}}
   " We use the `F` variants, instead of the `f` ones, because they're smarter.
-  nnoremap <silent><buffer> gf :<C-U>call gf#Find('gF')<CR>
-  nnoremap <silent><buffer> <C-W>f :<C-U>call gf#Find('<C-W>F')<CR>
-  nnoremap <silent><buffer> <C-W>gf :<C-U>call gf#Find('<C-W>gF')<CR>
+  nnoremap <silent><buffer> gf :<C-U>call vim#Find('gF')<CR>
+  nnoremap <silent><buffer> <C-W>f :<C-U>call vim#Find('<C-W>F')<CR>
+  nnoremap <silent><buffer> <C-W>gf :<C-U>call vim#Find('<C-W>gF')<CR>
 endif
 
 " Let the matchit plugin know what items can be matched.

--- a/runtime/ftplugin/vim.vim
+++ b/runtime/ftplugin/vim.vim
@@ -163,8 +163,8 @@ if !exists("no_plugin_maps") && !exists("no_vim_maps")
   " }}}
   " We use the `F` variants, instead of the `f` ones, because they're smarter.
   nnoremap <silent><buffer> gf :<C-U>call vim#Find('gF')<CR>
-  nnoremap <silent><buffer> <C-W>f :<C-U>call vim#Find('<C-W>F')<CR>
-  nnoremap <silent><buffer> <C-W>gf :<C-U>call vim#Find('<C-W>gF')<CR>
+  nnoremap <silent><buffer> <C-W>f :<C-U>call vim#Find('<lt>C-W>F')<CR>
+  nnoremap <silent><buffer> <C-W>gf :<C-U>call vim#Find('<lt>C-W>gF')<CR>
 endif
 
 " Let the matchit plugin know what items can be matched.

--- a/runtime/ftplugin/vim.vim
+++ b/runtime/ftplugin/vim.vim
@@ -143,25 +143,25 @@ if !exists("no_plugin_maps") && !exists("no_vim_maps")
   nnoremap <silent><buffer> [" :call search('\%(^\s*".*\n\)\%(^\s*"\)\@!', "bW")<CR>
   xnoremap <silent><buffer> [" :<C-U>exe "normal! gv"<Bar>call search('\%(^\s*".*\n\)\%(^\s*"\)\@!', "bW")<CR>
 
-    " Purpose: Handle `:import` and `:packadd` lines in a smarter way. {{{
-    "
-    " `:import` is followed by a filename or filepath.  Find it.
-    "
-    " `:packadd`  is  followed  by the  name  of  a  package,  which we  might  have
-    " configured in scripts under `~/.vim/plugin`.  Find it.
-    "
-    " ---
-    "
-    " We can't handle the `:import` lines simply by setting `'includeexpr'`, because
-    " the option would be ignored if:
-    "
-    "    - the name of the imported script is the same as the current one
-    "    - `'path'` includes the `.` item
-    "
-    " Indeed,  in that  case, Vim  finds the  current file,  and simply  reloads the
-    " buffer.
-    " }}}
-    " We use the `F` variants, instead of the `f` ones, because they're smarter.
+  " Purpose: Handle `:import` and `:packadd` lines in a smarter way. {{{
+  "
+  " `:import` is followed by a filename or filepath.  Find it.
+  "
+  " `:packadd`  is  followed  by the  name  of  a  package,  which we  might  have
+  " configured in scripts under `~/.vim/plugin`.  Find it.
+  "
+  " ---
+  "
+  " We can't handle the `:import` lines simply by setting `'includeexpr'`, because
+  " the option would be ignored if:
+  "
+  "    - the name of the imported script is the same as the current one
+  "    - `'path'` includes the `.` item
+  "
+  " Indeed,  in that  case, Vim  finds the  current file,  and simply  reloads the
+  " buffer.
+  " }}}
+  " We use the `F` variants, instead of the `f` ones, because they're smarter.
   nnoremap <silent><buffer> gf :<C-U>call gf#Find('gF')<CR>
   nnoremap <silent><buffer> <C-W>f :<C-U>call gf#Find('<C-W>F')<CR>
   nnoremap <silent><buffer> <C-W>gf :<C-U>call gf#Find('<C-W>gF')<CR>


### PR DESCRIPTION
This PR tries to make `gf` & friends smarter.  That is, when pressed on an `:import` line, make it jump to the corresponding imported script.  Same thing with `:packadd`: make `gf` jump to the corresponding plugin script.

It works for me, in my default configuration, but I'm not sure I properly extracted the code for this PR.  Can someone test it, and give some feedback?  Does it work?  Is it useful?
