### PR TITLE
Feature Request: Add scope parameter to chdir() for control cd/lcd/tcd

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -1790,9 +1790,9 @@ chdir({dir} [, {scope}])				*chdir()*
 			- If the {scope} is present and it is "global", then
 			  changes the global directory.
 			- Otherwise, if the {scope} is present and it is
-			  "window", then changes the window local directory.
-			- Otherwise, if the {scope} is present and it is
 			  "tabpage", then changes the tabpage local directory.
+			- Otherwise, if the {scope} is present and it is
+			  "window", then changes the window local directory.
 			- Otherwise, if the current window has a window-local
 			  directory (|:lcd|), then changes the window local
 			  directory.
@@ -1802,7 +1802,7 @@ chdir({dir} [, {scope}])				*chdir()*
 			- Otherwise, changes the global directory.
 		{dir} must be a String.
 		If {scope} is present it must be a String and must be one of
-		"cd", "lcd", or "tcd".
+		"global", "tabpage", or "window".
 		If successful, returns the previous working directory.  Pass
 		this to another chdir() to restore the directory.
 		On failure, returns an empty string.

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -1787,12 +1787,12 @@ chdir({dir} [, {scope}])				*chdir()*
 		Change the current working directory to {dir}.  The scope of
 		the directory change depends on the directory of the current
 		window:
-			- If the {scope} is present and it is "cd", then
+			- If the {scope} is present and it is "global", then
 			  changes the global directory.
-			- Otherwise, if the {scope} is present and it is "lcd",
-			  then changes the window local directory.
-			- Otherwise, if the {scope} is present and it is "tcd",
-			  then changes the tabpage local directory.
+			- Otherwise, if the {scope} is present and it is
+			  "window", then changes the window local directory.
+			- Otherwise, if the {scope} is present and it is
+			  "tabpage", then changes the tabpage local directory.
 			- Otherwise, if the current window has a window-local
 			  directory (|:lcd|), then changes the window local
 			  directory.

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -1783,17 +1783,26 @@ charidx({string}, {idx} [, {countcc} [, {utf16}]])
 		Return type: |Number|
 
 
-chdir({dir})						*chdir()*
+chdir({dir} [, {scope}])				*chdir()*
 		Change the current working directory to {dir}.  The scope of
 		the directory change depends on the directory of the current
 		window:
-			- If the current window has a window-local directory
-			  (|:lcd|), then changes the window local directory.
+			- If the {scope} is present and it is "cd", then
+			  changes the global directory.
+			- Otherwise, if the {scope} is present and it is "lcd",
+			  then changes the window local directory.
+			- Otherwise, if the {scope} is present and it is "tcd",
+			  then changes the tabpage local directory.
+			- Otherwise, if the current window has a window-local
+			  directory (|:lcd|), then changes the window local
+			  directory.
 			- Otherwise, if the current tabpage has a local
 			  directory (|:tcd|) then changes the tabpage local
 			  directory.
 			- Otherwise, changes the global directory.
 		{dir} must be a String.
+		If {scope} is present it must be a String and must be one of
+		"cd", "lcd", or "tcd".
 		If successful, returns the previous working directory.  Pass
 		this to another chdir() to restore the directory.
 		On failure, returns an empty string.

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -1784,25 +1784,23 @@ charidx({string}, {idx} [, {countcc} [, {utf16}]])
 
 
 chdir({dir} [, {scope}])				*chdir()*
-		Change the current working directory to {dir}.  The scope of
-		the directory change depends on the directory of the current
-		window:
-			- If the {scope} is present and it is "global", then
-			  changes the global directory.
-			- Otherwise, if the {scope} is present and it is
-			  "tabpage", then changes the tabpage local directory.
-			- Otherwise, if the {scope} is present and it is
-			  "window", then changes the window local directory.
-			- Otherwise, if the current window has a window-local
-			  directory (|:lcd|), then changes the window local
-			  directory.
-			- Otherwise, if the current tabpage has a local
-			  directory (|:tcd|) then changes the tabpage local
-			  directory.
-			- Otherwise, changes the global directory.
+		Changes the current working directory to {dir}.  The scope of
+		the change is determined as follows:
+		If {scope} is not present, the current working directory is
+		changed to the scope of the current directory:
+		    - If the window local directory (|:lcd|) is set, it
+		      changes the current working directory for that scope.
+		    - Otherwise, if the tab page local directory (|:tcd|) is
+		      set, it changes the current directory for that scope.
+		    - Otherwise, changes the global directory for that scope.
+
+		If {scope} is present, changes the current working directory
+		for the specified scope:
+		    "window"	Changes the window local directory.  |:lcd|
+		    "tabpage"	Changes the tab page local directory.  |:tcd|
+		    "global"	Changes the global directory.  |:cd|
+
 		{dir} must be a String.
-		If {scope} is present it must be a String and must be one of
-		"global", "tabpage", or "window".
 		If successful, returns the previous working directory.  Pass
 		this to another chdir() to restore the directory.
 		On failure, returns an empty string.

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -2086,7 +2086,7 @@ static funcentry_T global_functions[] =
 			ret_number,	    f_charcol},
     {"charidx",		2, 4, FEARG_1,	    arg4_string_number_bool_bool,
 			ret_number,	    f_charidx},
-    {"chdir",		1, 1, FEARG_1,	    arg1_string,
+    {"chdir",		1, 2, FEARG_1,	    arg2_string,
 			ret_string,	    f_chdir},
     {"cindent",		1, 1, FEARG_1,	    arg1_lnum,
 			ret_number,	    f_cindent},

--- a/src/filepath.c
+++ b/src/filepath.c
@@ -827,6 +827,9 @@ f_chdir(typval_T *argvars, typval_T *rettv)
 	    (void) check_for_string_arg(argvars, 0);
 	return;
     }
+    if (in_vim9script()
+	    && (check_for_opt_string_arg(argvars, 1) == FAIL))
+	return;
 
     // Return the current directory
     cwd = alloc(MAXPATHL);
@@ -842,7 +845,22 @@ f_chdir(typval_T *argvars, typval_T *rettv)
 	vim_free(cwd);
     }
 
-    if (curwin->w_localdir != NULL)
+    if (argvars[1].v_type != VAR_UNKNOWN)
+    {
+	char_u *s = tv_get_string(&argvars[1]);
+	if (STRCMP(s, "cd") == 0)
+	    scope = CDSCOPE_GLOBAL;
+	else if (STRCMP(s, "lcd") == 0)
+	    scope = CDSCOPE_WINDOW;
+	else if (STRCMP(s, "tcd") == 0)
+	    scope = CDSCOPE_TABPAGE;
+	else
+	{
+	    semsg(_(e_invalid_expression_str), s);
+	    return;
+	}
+    }
+    else if (curwin->w_localdir != NULL)
 	scope = CDSCOPE_WINDOW;
     else if (curtab->tp_localdir != NULL)
 	scope = CDSCOPE_TABPAGE;

--- a/src/filepath.c
+++ b/src/filepath.c
@@ -848,11 +848,11 @@ f_chdir(typval_T *argvars, typval_T *rettv)
     if (argvars[1].v_type != VAR_UNKNOWN)
     {
 	char_u *s = tv_get_string(&argvars[1]);
-	if (STRCMP(s, "cd") == 0)
+	if (STRCMP(s, "global") == 0)
 	    scope = CDSCOPE_GLOBAL;
-	else if (STRCMP(s, "lcd") == 0)
+	else if (STRCMP(s, "window") == 0)
 	    scope = CDSCOPE_WINDOW;
-	else if (STRCMP(s, "tcd") == 0)
+	else if (STRCMP(s, "tabpage") == 0)
 	    scope = CDSCOPE_TABPAGE;
 	else
 	{

--- a/src/filepath.c
+++ b/src/filepath.c
@@ -827,9 +827,6 @@ f_chdir(typval_T *argvars, typval_T *rettv)
 	    (void) check_for_string_arg(argvars, 0);
 	return;
     }
-    if (in_vim9script()
-	    && (check_for_opt_string_arg(argvars, 1) == FAIL))
-	return;
 
     // Return the current directory
     cwd = alloc(MAXPATHL);

--- a/src/filepath.c
+++ b/src/filepath.c
@@ -850,10 +850,10 @@ f_chdir(typval_T *argvars, typval_T *rettv)
 	char_u *s = tv_get_string(&argvars[1]);
 	if (STRCMP(s, "global") == 0)
 	    scope = CDSCOPE_GLOBAL;
-	else if (STRCMP(s, "window") == 0)
-	    scope = CDSCOPE_WINDOW;
 	else if (STRCMP(s, "tabpage") == 0)
 	    scope = CDSCOPE_TABPAGE;
+	else if (STRCMP(s, "window") == 0)
+	    scope = CDSCOPE_WINDOW;
 	else
 	{
 	    semsg(_(e_invalid_value_for_argument_str_str), "scope", s);

--- a/src/filepath.c
+++ b/src/filepath.c
@@ -856,7 +856,7 @@ f_chdir(typval_T *argvars, typval_T *rettv)
 	    scope = CDSCOPE_TABPAGE;
 	else
 	{
-	    semsg(_(e_invalid_expression_str), s);
+	    semsg(_(e_invalid_value_for_argument_str_str), "scope", s);
 	    return;
 	}
     }

--- a/src/testdir/test_cd.vim
+++ b/src/testdir/test_cd.vim
@@ -108,7 +108,7 @@ func Test_chdir_func()
   call assert_fails("call chdir('dir-abcd')", 'E344:')
   silent! let d = chdir("dir_abcd")
   call assert_equal("", d)
-  call assert_fails("call chdir('.', 'illegal')", 'E475:')
+  call assert_fails("call chdir('.', test_null_string())", 'E475:')
   call assert_fails("call chdir('.', [])", 'E730:')
   " Should not crash
   call chdir(d)

--- a/src/testdir/test_cd.vim
+++ b/src/testdir/test_cd.vim
@@ -96,10 +96,20 @@ func Test_chdir_func()
   call assert_equal('y', fnamemodify(getcwd(3, 2), ':t'))
   call assert_equal('testdir', fnamemodify(getcwd(1, 1), ':t'))
 
+  " Forcing scope
+  call chdir('.', 'cd')
+  call assert_match('^\[global\]', trim(execute('verbose pwd')))
+  call chdir('.', 'lcd')
+  call assert_match('^\[window\]', trim(execute('verbose pwd')))
+  call chdir('.', 'tcd')
+  call assert_match('^\[tabpage\]', trim(execute('verbose pwd')))
+
   " Error case
   call assert_fails("call chdir('dir-abcd')", 'E344:')
   silent! let d = chdir("dir_abcd")
   call assert_equal("", d)
+  call assert_fails("call chdir('.', '_cd')", 'E15:')
+  call assert_fails("call chdir('.', [])", 'E730:')
   " Should not crash
   call chdir(d)
   call assert_equal('', chdir([]))

--- a/src/testdir/test_cd.vim
+++ b/src/testdir/test_cd.vim
@@ -97,18 +97,18 @@ func Test_chdir_func()
   call assert_equal('testdir', fnamemodify(getcwd(1, 1), ':t'))
 
   " Forcing scope
-  call chdir('.', 'cd')
+  call chdir('.', 'global')
   call assert_match('^\[global\]', trim(execute('verbose pwd')))
-  call chdir('.', 'lcd')
+  call chdir('.', 'window')
   call assert_match('^\[window\]', trim(execute('verbose pwd')))
-  call chdir('.', 'tcd')
+  call chdir('.', 'tabpage')
   call assert_match('^\[tabpage\]', trim(execute('verbose pwd')))
 
   " Error case
   call assert_fails("call chdir('dir-abcd')", 'E344:')
   silent! let d = chdir("dir_abcd")
   call assert_equal("", d)
-  call assert_fails("call chdir('.', '_cd')", 'E15:')
+  call assert_fails("call chdir('.', 'illegal')", 'E15:')
   call assert_fails("call chdir('.', [])", 'E730:')
   " Should not crash
   call chdir(d)

--- a/src/testdir/test_cd.vim
+++ b/src/testdir/test_cd.vim
@@ -108,7 +108,7 @@ func Test_chdir_func()
   call assert_fails("call chdir('dir-abcd')", 'E344:')
   silent! let d = chdir("dir_abcd")
   call assert_equal("", d)
-  call assert_fails("call chdir('.', 'illegal')", 'E15:')
+  call assert_fails("call chdir('.', 'illegal')", 'E475:')
   call assert_fails("call chdir('.', [])", 'E730:')
   " Should not crash
   call chdir(d)

--- a/src/testdir/test_cd.vim
+++ b/src/testdir/test_cd.vim
@@ -99,10 +99,10 @@ func Test_chdir_func()
   " Forcing scope
   call chdir('.', 'global')
   call assert_match('^\[global\]', trim(execute('verbose pwd')))
-  call chdir('.', 'window')
-  call assert_match('^\[window\]', trim(execute('verbose pwd')))
   call chdir('.', 'tabpage')
   call assert_match('^\[tabpage\]', trim(execute('verbose pwd')))
+  call chdir('.', 'window')
+  call assert_match('^\[window\]', trim(execute('verbose pwd')))
 
   " Error case
   call assert_fails("call chdir('dir-abcd')", 'E344:')

--- a/src/testdir/test_vim9_builtin.vim
+++ b/src/testdir/test_vim9_builtin.vim
@@ -771,7 +771,7 @@ enddef
 def Test_chdir()
   assert_fails('chdir(true)', 'E1174:')
   assert_fails('chdir(".", test_null_string())', 'E475:')
-  assert_fails('chdir(".", [])', 'E1174:')
+  assert_fails('chdir(".", [])', 'E730:')
 enddef
 
 def Test_cindent()

--- a/src/testdir/test_vim9_builtin.vim
+++ b/src/testdir/test_vim9_builtin.vim
@@ -770,6 +770,8 @@ enddef
 
 def Test_chdir()
   assert_fails('chdir(true)', 'E1174:')
+  assert_fails('chdir(".", test_null_string())', 'E475:')
+  assert_fails('chdir(".", [])', 'E1174:')
 enddef
 
 def Test_cindent()


### PR DESCRIPTION
# Background
Currently, `chdir()` operates within the scope.
`:cd`, `:lcd`, and `:tcd` are able to specify the scope. but changing to a path containing certain symbols are difficult because `file-pattern` is applied.

# Feature Request
I want to add optional `scope` parameter to `chdir()` to specify the scope.

Possible values of `scope` are currently ~`"cd"`, `"lcd"`, or `"tcd"`~(change to `"global"`, `"tabpage"`, or `"window"`).
If you have any other suggestions, please feel free to suggest any other possible values for the scope parameter.