### PR TITLE
diff: Better error messages for diff anchors with hidden buffers

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3016,6 +3016,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	If some of the {address} do not resolve to a line in each buffer (e.g.
 	a pattern search that does not match anything), none of the anchors
 	will be used.
+								*E1562*
+	Diff anchors can only be used when there are no hidden diff buffers.
 
 						*'dex'* *'diffexpr'*
 'diffexpr' 'dex'	string	(default "")

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -4694,6 +4694,7 @@ E1559	vim9.txt	/*E1559*
 E156	sign.txt	/*E156*
 E1560	vim9.txt	/*E1560*
 E1561	vim9.txt	/*E1561*
+E1562	options.txt	/*E1562*
 E157	sign.txt	/*E157*
 E158	sign.txt	/*E158*
 E159	sign.txt	/*E159*

--- a/src/diff.c
+++ b/src/diff.c
@@ -2768,8 +2768,15 @@ parse_diffanchors(int check_only, buf_T *buf, linenr_T *anchors, int *num_anchor
 	FOR_ALL_WINDOWS(bufwin)
 	    if (bufwin->w_buffer == buf && bufwin->w_p_diff)
 		break;
-	if (bufwin == NULL)
-	    return FAIL; // should not really happen
+	if (bufwin == NULL && *dia != NUL)
+	{
+	    // The buffer is hidden. Currently this is not supported due to the
+	    // edge cases of needing to decide if an address is window-specific
+	    // or not. We could add more checks in the future so we can detect
+	    // whether an address relies on curwin to make this more fleixble.
+	    emsg(_(e_diff_anchors_with_hidden_windows));
+	    return FAIL;
+	}
     }
 
     for (i = 0; i < MAX_DIFF_ANCHORS && *dia != NUL; i++)

--- a/src/errors.h
+++ b/src/errors.h
@@ -3778,3 +3778,7 @@ EXTERN char e_not_a_generic_function_str[]
 EXTERN char e_duplicate_type_var_name_str[]
 	INIT(= N_("E1561: Duplicate type variable name: %s"));
 #endif
+#if defined(FEAT_DIFF)
+EXTERN char e_diff_anchors_with_hidden_windows[]
+	INIT(= N_("E1562: Diff anchors cannot be used with hidden diff windows"));
+#endif

--- a/src/testdir/test_diffmode.vim
+++ b/src/testdir/test_diffmode.vim
@@ -3483,6 +3483,10 @@ func Test_diffanchors_invalid()
   call assert_fails('diffupdate', 'E1550:')
   call assert_equal('orig_search_pat', @/)
 
+  " Hidden buffers are not supported right now
+  hide
+  call assert_fails('diffupdate', 'E1562:')
+
   %bw!
   set diffopt&
   set diffanchors&


### PR DESCRIPTION
Diff anchors currently will fail to parse if a buffer used for diff'ing is hidden. Previously it would just fail as the code assumes it would not happen normally, but this is actually possible to do if `closeoff` and `hideoff` are not set in diffopt. Git's default diff tool "vimdiff3" also takes advantage of this.

This fix this properly would require the `{address}` parser to be smarter about whether a particular address relies on window position or not (e.g. the `'.` address requires an active window, but `'a` or `1234` do not). Since hidden diff buffers seem relatively niche, just provide a better error message / documentation for now. This could be improved later if there's a demand for it.

Related: #17615