### PR TITLE
runtime(syntax): add missing JavaScript import as keyword

### DIFF
--- a/runtime/syntax/javascript.vim
+++ b/runtime/syntax/javascript.vim
@@ -67,7 +67,7 @@ syn keyword javaScriptMessage		alert confirm prompt status
 syn keyword javaScriptGlobal		self window top parent
 syn keyword javaScriptMember		document event location 
 syn keyword javaScriptDeprecated	escape unescape
-syn keyword javaScriptReserved		abstract boolean byte char class const debugger double enum export extends final float from goto implements import int interface let long native package private protected public short super synchronized throws transient var volatile async
+syn keyword javaScriptReserved		abstract as boolean byte char class const debugger double enum export extends final float from goto implements import int interface let long native package private protected public short super synchronized throws transient var volatile async
 syn keyword javaScriptModifier  static
 
 syn cluster  javaScriptEmbededExpr	contains=javaScriptBoolean,javaScriptNull,javaScriptIdentifier,javaScriptStringD,javaScriptStringS,javaScriptStringT


### PR DESCRIPTION
Problem: Currently when editing JavaScript files and using an import statement with the `as` keyword, Vim doesn't highlight it as a reserved word even though it is part of the JavaScript spec: https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-imports

Solution: Add the `as` keyword to the reserved keywords in the JavaScript syntax file.