### PR TITLE
:bnext doesn't go to unlisted help buffers

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -1371,8 +1371,11 @@ do_buffer_ext(
     }
     else
     {
+	int help_only = (flags & DOBUF_SKIPHELP) != 0 && buf->b_help;
+
 	bp = NULL;
-	while (count > 0 || (!unload && !buf->b_p_bl && bp != buf))
+	while (count > 0 || (bp != buf && !unload
+				&& !(help_only ? buf->b_help : buf->b_p_bl)))
 	{
 	    // remember the buffer where we start, we come back there when all
 	    // buffers are unlisted.
@@ -1390,14 +1393,17 @@ do_buffer_ext(
 		if (buf == NULL)
 		    buf = lastbuf;
 	    }
+	    // Avoid non-help buffers if the starting point was a help buffer
+	    // and vice-versa.
 	    // Don't count unlisted buffers.
-	    // Avoid non-help buffers if the starting point was a non-help buffer and
-	    // vice-versa.
-	    if (unload || (buf->b_p_bl
-			&& ((flags & DOBUF_SKIPHELP) == 0 || buf->b_help == bp->b_help)))
+	    if (unload
+		    || (help_only
+			? buf->b_help
+			: (buf->b_p_bl && ((flags & DOBUF_SKIPHELP) == 0
+							    || !buf->b_help))))
 	    {
-		 --count;
-		 bp = NULL;	// use this buffer as new starting point
+		--count;
+		bp = NULL;	// use this buffer as new starting point
 	    }
 	    if (bp == buf)
 	    {

--- a/src/testdir/test_buffer.vim
+++ b/src/testdir/test_buffer.vim
@@ -167,6 +167,17 @@ func Test_bnext_bprev_help()
   b XHelp1
   blast   | call assert_equal(b4, bufnr())
 
+  " Cycling through help buffers works even if they aren't listed.
+  b XHelp1
+  setlocal nobuflisted
+  bnext | call assert_equal(b3, bufnr())
+  bnext | call assert_equal(b1, bufnr())
+  bprev | call assert_equal(b3, bufnr())
+  setlocal nobuflisted
+  bprev | call assert_equal(b1, bufnr())
+  bprev | call assert_equal(b3, bufnr())
+  bnext | call assert_equal(b1, bufnr())
+
   %bwipe!
 endfunc
 


### PR DESCRIPTION
Problem:  :bnext doesn't go to unlisted help buffers when cycling
          through help buffers (after 9.1.0557).
Solution: Don't check if a help buffer is listed.

related: #4478
related: #15198

From <https://github.com/vim/vim/issues/4478#issuecomment-498831057>:

> I think we should fix that, since once you get to a non-help buffer
> all unlisted buffers are skipped, thus you won't encounter another
> help buffer.

This implies that cycling through help buffers should work even if help
buffers are unlisted. Otherwise this part of :bnext isn't really useful,
as :h makes help buffers unlisted by default.
