### PR TITLE
runtime(matchit): update matchit.txt

### DIFF
--- a/runtime/pack/dist/opt/matchit/doc/matchit.txt
+++ b/runtime/pack/dist/opt/matchit/doc/matchit.txt
@@ -1,8 +1,5 @@
 *matchit.txt*   Extended "%" matching
 
-For instructions on installing this file, type
-	`:help matchit-install`
-inside Vim.
 
 For Vim version 9.1.  Last change:  2024 May 20
 


### PR DESCRIPTION
Problem:
- The note "For instruction on how to install this file" seems useless, because if users can see the file in their Vim, it means they already "install" (`:packadd[!]`) the matchit package

Solution
- Remove that note

Ping @chrisbra 