### PR TITLE
runtime(doc): clean up netrwSettings.vim related stuff

### DIFF
--- a/runtime/doc/pi_netrw.txt
+++ b/runtime/doc/pi_netrw.txt
@@ -7,8 +7,8 @@ Original Author:  Charles E. Campbell
 
 Copyright: Copyright (C) 2017 Charles E Campbell    *netrw-copyright*
 	The VIM LICENSE applies to the files in this package, including
-        netrw.vim, netrw.txt, netrwSettings.vim, and
-	syntax/netrw.vim.  Like anything else that's free, netrw.vim and its
+	netrw.vim, netrw.txt, and syntax/netrw.vim.
+	Like anything else that's free, netrw.vim and its
 	associated files are provided *as is* and comes with no warranty of
 	any kind, either expressed or implied.  No guarantees of
 	merchantability.  No guarantees of suitability for any purpose.  By
@@ -98,7 +98,6 @@ Copyright: Copyright (C) 2017 Charles E Campbell    *netrw-copyright*
       Marked Files: Unmarking.............................|netrw-mu|
       Netrw Browser Variables.............................|netrw-browser-var|
       Netrw Browsing And Option Incompatibilities.........|netrw-incompatible|
-      Netrw Settings Window...............................|netrw-settings-window|
       Obtaining A File....................................|netrw-O|
       Preview Window......................................|netrw-p|
       Previous Window.....................................|netrw-P|


### PR DESCRIPTION
Since netrwSettings.vim has been removed, there is no reason to keep the related stuff