### PR TITLE
runtime(optwin.vim): Suppressing error E94

### DIFF
--- a/runtime/optwin.vim
+++ b/runtime/optwin.vim
@@ -1,11 +1,11 @@
 " These commands create the option window.
 "
 " Maintainer:	The Vim Project <https://github.com/vim/vim>
-" Last Change:	2025 Jul 25
+" Last Change:	2025 Aug 07
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " If there already is an option window, jump to that one.
-let buf = bufnr('option-window')
+let buf = bufexists('option-window') ? bufnr('option-window') : -1
 if buf >= 0
   let winids = win_findbuf(buf)
   if len(winids) > 0


### PR DESCRIPTION
Problem:
When the parameter `debug=msg` is set and the command `:option` is entered, error E94 will be displayed.

Reproduce:
```
vim --clean -c "set debug=msg" -c "option"
```
> Error detected while processing command line..script D:\Programs\Vim\vim91\optwin.vim:
> line    9:
> E94: No matching buffer for option-window

Solution: 
Add a check for the existence of the buffer before getting the buffer number “option-window”