### PR TITLE
Fix Buffers menu performance regression and properly fix its handling of Unicode file names

### DIFF
--- a/runtime/menu.vim
+++ b/runtime/menu.vim
@@ -2,7 +2,7 @@
 " You can also use this as a start for your own set of menus.
 "
 " Maintainer:	The Vim Project <https://github.com/vim/vim>
-" Last Change:	2025 Jun 04
+" Last Change:	2023 Aug 10
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Note that ":an" (short for ":anoremenu") is often used to make a menu work
@@ -693,7 +693,12 @@ def s:BMAdd()
     if s:bmenu_count == &menuitems && s:bmenu_short == 0
       s:BMShow()
     else
-      s:BMRedraw()
+      var name = expand("<afile>")
+      var num = str2nr(expand("<abuf>"))
+      if s:BMCanAdd(name, num)
+	s:BMFilename(name, num)
+	s:bmenu_count += 1
+      endif
     endif
   endif
 enddef
@@ -741,10 +746,6 @@ def s:BMShow()
   s:bmenu_count = 0
   s:bmenu_items = {}
 
-  s:BMRedraw()
-enddef
-
-def s:BMRedraw()
   # Remove old menu, if it exists; keep one entry to avoid a torn off menu to
   # disappear.  Use try/catch to avoid setting v:errmsg
   try 
@@ -767,36 +768,48 @@ def s:BMRedraw()
   unmenu &Buffers.Dummy
 
   # figure out how many buffers there are
-  var buffer_menu_items = []
   var buf = 1
   while buf <= bufnr('$')
-    var name = bufname(buf)
-    if s:BMCanAdd(name, buf)
-      add(buffer_menu_items, [substitute(name, ".", '\L\0', ""), name, buf])
+    if s:BMCanAdd(bufname(buf), buf)
+      s:bmenu_count = s:bmenu_count + 1
     endif
     buf += 1
   endwhile
-  s:bmenu_count = len(buffer_menu_items)
-
   if s:bmenu_count <= &menuitems
     s:bmenu_short = 0
   endif
 
   # iterate through buffer list, adding each buffer to the menu:
-  sort(buffer_menu_items)
-
-  var i = 0
-  for menu_item in buffer_menu_items
-    s:BMFilename(menu_item[1], menu_item[2], i)
-    i += 1
-  endfor
-
+  buf = 1
+  while buf <= bufnr('$')
+    var name = bufname(buf)
+    if s:BMCanAdd(name, buf)
+      call s:BMFilename(name, buf)
+    endif
+    buf += 1
+  endwhile
   s:bmenu_wait = 0
   aug buffer_list
     au!
     au BufCreate,BufFilePost * call s:BMAdd()
     au BufDelete,BufFilePre * call s:BMRemove()
   aug END
+enddef
+
+def s:BMHash(name: string): number
+  # Make name all upper case, so that chars are between 32 and 96
+  var nm = substitute(name, ".*", '\U\0', "")
+  var sp: number
+  if has("ebcdic")
+    # HACK: Replace all non alphabetics with 'Z'
+    #       Just to make it work for now.
+    nm = substitute(nm, "[^A-Z]", 'Z', "g")
+    sp = char2nr('A') - 1
+  else
+    sp = char2nr(' ')
+  endif
+  # convert first six chars into a number for sorting:
+  return (char2nr(nm[0]) - sp) * 0x800000 + (char2nr(nm[1]) - sp) * 0x20000 + (char2nr(nm[2]) - sp) * 0x1000 + (char2nr(nm[3]) - sp) * 0x80 + (char2nr(nm[4]) - sp) * 0x20 + (char2nr(nm[5]) - sp)
 enddef
 
 def s:BMHash2(name: string): string
@@ -819,16 +832,17 @@ def s:BMHash2(name: string): string
 enddef
 
 " Insert a buffer name into the buffer menu.
-def s:BMFilename(name: string, num: number, index: number)
+def s:BMFilename(name: string, num: number)
   var munge = s:BMMunge(name, num)
+  var hash = s:BMHash(munge)
   var cmd: string
   if s:bmenu_short == 0
     s:bmenu_items[num] = munge
-    cmd = 'an ' .. g:bmenu_priority .. '.9999.' .. index .. ' &Buffers.' .. munge
+    cmd = 'an ' .. g:bmenu_priority .. '.' .. hash .. ' &Buffers.' .. munge
   else
     var menu_name = s:BMHash2(munge) .. munge
     s:bmenu_items[num] = menu_name
-    cmd = 'an ' .. g:bmenu_priority .. '.9999.0.' .. index .. ' &Buffers.' .. menu_name
+    cmd = 'an ' .. g:bmenu_priority .. '.' .. hash .. '.' .. hash .. ' &Buffers.' .. menu_name
   endif
   exe cmd .. ' :confirm b' .. num .. '<CR>'
 enddef

--- a/runtime/menu.vim
+++ b/runtime/menu.vim
@@ -2,7 +2,7 @@
 " You can also use this as a start for your own set of menus.
 "
 " Maintainer:	The Vim Project <https://github.com/vim/vim>
-" Last Change:	2023 Aug 10
+" Last Change:	2025 Aug 7
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Note that ":an" (short for ":anoremenu") is often used to make a menu work
@@ -797,8 +797,21 @@ def s:BMShow()
 enddef
 
 def s:BMHash(name: string): number
-  # Make name all upper case, so that chars are between 32 and 96
-  var nm = substitute(name, ".*", '\U\0', "")
+  # Create a sortable numeric hash of the name. This number has to be within
+  # the bounds of a signed 32-bit integer as this is what Vim GUI uses
+  # internally for the index.
+
+  # Make name all upper case, so that alphanumeric chars are between 32 and 96
+  var nm = toupper(name)
+
+  if char2nr(nm[0]) < 32 || char2nr(nm[0]) > 96
+    # We don't have an ASCII character, so just return the raw character value
+    # for first character (clamped to 2^31) and set the high bit to make it
+    # sort after other items. This means only the first character will be
+    # sorted, unfortunately.
+    return or(and(char2nr(nm), 0x7fffffff), 0x40000000)
+  endif
+
   var sp: number
   if has("ebcdic")
     # HACK: Replace all non alphabetics with 'Z'
@@ -808,12 +821,18 @@ def s:BMHash(name: string): number
   else
     sp = char2nr(' ')
   endif
-  # convert first six chars into a number for sorting:
-  return (char2nr(nm[0]) - sp) * 0x800000 + (char2nr(nm[1]) - sp) * 0x20000 + (char2nr(nm[2]) - sp) * 0x1000 + (char2nr(nm[3]) - sp) * 0x80 + (char2nr(nm[4]) - sp) * 0x20 + (char2nr(nm[5]) - sp)
+  # convert first five chars into a number for sorting by compressing each
+  # char into 5 bits (0-63), to a total of 30 bits. If any character is not
+  # ASCII, it will simply be clamped to prevent overflow.
+  return (max([0, min([63, char2nr(nm[0]) - sp])]) << 24) +
+    (max([0, min([63, char2nr(nm[1]) - sp])]) << 18) +
+    (max([0, min([63, char2nr(nm[2]) - sp])]) << 12) +
+    (max([0, min([63, char2nr(nm[3]) - sp])]) <<  6) +
+    max([0, min([63, char2nr(nm[4]) - sp])])
 enddef
 
 def s:BMHash2(name: string): string
-  var nm = substitute(name, ".", '\L\0', "")
+  var nm = tolower(name[0])
   if nm[0] < 'a' || nm[0] > 'z'
     return '&others.'
   elseif nm[0] <= 'd'

--- a/src/testdir/test_gui.vim
+++ b/src/testdir/test_gui.vim
@@ -1767,4 +1767,37 @@ func Test_CursorHold_not_triggered_at_startup()
   call assert_equal(['g:cursorhold_triggered=0'], found)
 endfunc
 
+" Test that Buffers menu generates the correct index for different buffer
+" names for sorting.
+func Test_Buffers_Menu()
+  doautocmd LoadBufferMenu VimEnter
+
+  " Non-ASCII characters only use the first character as idx
+  let idx_emoji = or(char2nr('😑'), 0x40000000)
+
+  " Only first five letters are used for alphanumeric:
+  " ('a'-32) << 24 + ('b'-32) << 18 + ('c'-32) << 12 + ('d'-32) << 6 + ('e'-32)
+  let idx_abcde = 0x218A3925
+  " ('a'-32) << 24 + ('b'-32) << 18 + ('c'-32) << 12 + ('d'-32) << 6 + ('f'-32)
+  let idx_abcdf = 0x218A3926
+  " ('a'-32) << 24 + 63 (clamped) << 18 + ('c'-32) << 12 + ('d'-32) << 6 + ('e'-32)
+  let idx_a_emoji_cde = 0x21FE3925
+
+  let names = ['😑', '😑1', '😑2', 'abcde', 'abcdefghi', 'abcdf', 'a😑cde']
+  let indices = [idx_emoji, idx_emoji, idx_emoji, idx_abcde, idx_abcde, idx_abcdf, idx_a_emoji_cde]
+  for i in range(len(names))
+    let name = names[i]
+    let idx = indices[i]
+    exe ':badd ' .. name
+    let nr = bufnr('$')
+
+    let cmd = printf(':amenu Buffers.%s\ (%d)', name, nr)
+    let menu = split(execute(cmd), '\n')[1]
+    call assert_inrange(0, 0x7FFFFFFF, idx)
+    call assert_match('^' .. idx .. ' '.. name, menu)
+  endfor
+
+  %bw!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_gui.vim
+++ b/src/testdir/test_gui.vim
@@ -1767,17 +1767,4 @@ func Test_CursorHold_not_triggered_at_startup()
   call assert_equal(['g:cursorhold_triggered=0'], found)
 endfunc
 
-" Test that buffer names are shown at the end in the :Buffers menu
-func Test_Buffers_Menu()
-  doautocmd LoadBufferMenu VimEnter
-
-  let name = '天'
-  exe ':badd ' .. name
-  let nr = bufnr('$')
-
-  let cmd = printf(':amenu Buffers.%s\ (%d)', name, nr)
-  let menu = split(execute(cmd), '\n')[1]
-  call assert_match('^9999 '.. name, menu)
-endfunc
-
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
# Revert "patch 9.1.1432: GTK GUI: Buffer menu does not handle unicode correctly"

This reverts commit 08896dd330c6dc8324618fde482db968e6f71088.

The previous change to support Unicode characters properly in the buffers menu resorted to removing all buffer menus and re-add the buffers after doing a sort, per each buffer addition. This was quite slow because if Vim is trying to load in multiple buffers at once (e.g.  when loading a session) this scales in O(n^2) and Vim can freeze for dozens of seconds when adding a few hundred buffers.

Related: #17405

Close #17897

# Fix non-ASCII buffer names in Buffers menu

The Buffers menu uses a BMHash() function to generate a sortable number to be used for the menu idex. It used a naive (and incorrect) way of encoding multiple ASCII values into a single integer, but assumes each character to be only in the ASCII 32-96 range. This means if we use non-ASCII file names (e.g. Unicode values like CJK or emojis) we get integer underflow and overflow, causing the menu index to wrap around.  Vim's GUI implementations internally use a signed 32-bit integer for the `gui_mch_add_menu_item` function and so we need to make sure the menu index is in the (0, 2^31-1) range.

To do this, if the file name starts with a non-ASCII value, we just use the first character's value and set the high bit so it sorts after the other ASCII ones. Otherwise, we just take the first 5 characters, and use 5 bit for each character to encode a 30-bit number that can be sorted.

This means Unicode file names won't be sorted beyond the first character. This is likely going to be fine as there are lots of ways to query buffers.

---

This fixes #17897. I split the commits into two so we have a clean revert and a more proper fix. Note that the original issue discussion (#17403) likely misidentified the problem with the original implementation. It wasn't because GTK couldn't handle high menu index numbers. The issue was that the Vimscript implementation for BMHash() had an integer overflow issue as it made naive assumptions about the range of values of the characters.