### PR TITLE
completion: hang or E684 when 'tagfunc' calls complete()

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -5353,11 +5353,6 @@ ins_compl_get_exp(pos_T *ini)
 	    }
 	}
 
-	// If complete() was called then compl_pattern has been reset.  The
-	// following won't work then, bail out.
-	if (compl_pattern.string == NULL)
-	    break;
-
 	if (compl_autocomplete && type == CTRL_X_FUNCTION)
 	    // LSP servers may sporadically take >1s to respond (e.g., while
 	    // loading modules), but other sources might already have matches.
@@ -5369,6 +5364,11 @@ ins_compl_get_exp(pos_T *ini)
 
 	// get the next set of completion matches
 	found_new_match = get_next_completion_match(type, &st, &start_pos);
+
+	// If complete() was called then compl_pattern has been reset.  The
+	// following won't work then, bail out.
+	if (compl_pattern.string == NULL)
+	    break;
 
 	if (may_advance_cpt_idx)
 	{

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -3208,6 +3208,35 @@ func Test_tagfunc_wipes_out_buffer()
   bwipe!
 endfunc
 
+func s:TagfuncComplete(t,f,o)
+  call complete(1, ['ddd', 'eee', 'fff'])
+  return []
+endfunc
+
+" 'tagfunc' calling complete() should not cause hang or E684.
+func Test_tagfunc_calls_complete()
+  new
+  call setline(1, ['aaa', 'bbb', 'ccc'])
+  setlocal tagfunc=s:TagfuncComplete
+  setlocal completeopt=menu,noselect
+
+  let v:errmsg = ''
+
+  " This used to hang.
+  setlocal complete=.,t
+  call feedkeys("Go\<C-N>\<C-E>\<Esc>", 'tx')
+  call assert_equal('', getline('.'))
+  call assert_equal('', v:errmsg)
+
+  " This used to cause E684.
+  setlocal complete=t,.
+  call feedkeys("cc\<C-N>\<C-E>\<Esc>", 'tx')
+  call assert_equal('', getline('.'))
+  call assert_equal('', v:errmsg)
+
+  bwipe!
+endfunc
+
 func Test_ins_complete_popup_position()
   CheckScreendump
 


### PR DESCRIPTION
Problem:  completion: hang (after 9.1.1471) or E684 (after 9.1.1410)
          when 'tagfunc' calls complete().
Solution: Check if complete() has been called immediately after getting
          matches instead of in the next loop iteration.

related: #1668
related: neovim/neovim#34416
related: neovim/neovim#35163
