### PR TITLE
xxd may cause a buffer overflow with bitwise output

### DIFF
--- a/src/testdir/test_xxd.vim
+++ b/src/testdir/test_xxd.vim
@@ -680,4 +680,25 @@ func Test_xxd_color2()
   call delete('XXDfile_colors')
   unlet! $PS1
 endfunc
+
+" this caused a buffer overflow
+func Test_xxd_overflow()
+  CheckUnix
+  CheckExecutable /bin/true
+  new
+  " we are only checking, that there are addresses in the first 5 lines
+  let expected = [
+        \ '00000000: ',
+        \ '00000080: ',
+        \ '00000100: ',
+        \ '00000180: ',
+        \ '00000200: ']
+  exe "0r! " s:xxd_cmd "-b -E -c 128 -g 256 /bin/true 2>&1"
+  " there should not be an ASAN error message
+  call getline(1, '$')->join('\n')->assert_notmatch('runtime error')
+  6,$d
+  %s/^\x\+: \zs.*//g
+  call assert_equal(expected, getline(1, 5))
+  bw!
+endfunc
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/xxd/Makefile
+++ b/src/xxd/Makefile
@@ -1,7 +1,9 @@
 # The most simplistic Makefile
 
+# SANITIZER_CFLAGS=-g -O0  -fsanitize-recover=all -fsanitize=address -fsanitize=undefined -fno-omit-frame-pointer
+
 xxd: xxd.c
-	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -DUNIX -o xxd xxd.c $(LIBS)
+	$(CC) $(SANITIZER_CFLAGS) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -DUNIX -o xxd xxd.c $(LIBS)
 
 clean:
 	rm -f xxd xxd.o

--- a/src/xxd/xxd.c
+++ b/src/xxd/xxd.c
@@ -148,7 +148,7 @@ extern void perror __P((char *));
 # endif
 #endif
 
-char version[] = "xxd 2025-06-15 by Juergen Weigert et al.";
+char version[] = "xxd 2025-08-08 by Juergen Weigert et al.";
 #ifdef WIN32
 char osver[] = " (Win32)";
 #else
@@ -228,10 +228,9 @@ char osver[] = "";
 #define LLEN_NO_COLOR \
     (39            /* addr: ⌈log10(ULONG_MAX)⌉ if "-d" flag given. We assume ULONG_MAX = 2**128 */ \
     + 2            /* ": " */ \
-    + 2 * COLS    /* hex dump */ \
-    + (COLS - 1)   /* whitespace between groups if "-g1" option given and "-c" maxed out */ \
+    + 9 * COLS     /* hex dump, worst case: bitwise output using -b */ \
     + 2            /* whitespace */ \
-    + COLS    /* ASCII dump */ \
+    + COLS         /* ASCII dump */ \
     + 2)           /* "\n\0" */
 
 char hexxa[] = "0123456789abcdef0123456789ABCDEF", *hexx = hexxa;
@@ -1182,9 +1181,7 @@ main(int argc, char *argv[])
 
       c += addrlen + 3 + p;
       if (color)
-	{
 	  colors[c] = cur_color;
-	}
       l[c++] =
 #if defined(__MVS__) && __CHARSET_LIB == 0
 	  (e >= 64)


### PR DESCRIPTION
Problem:  xxd may cause a buffer overflow with bitwise output Solution: Update LLEN_NO_COLOR macro definition for the max line output
          (using bitwise output -b)

fixes: #17944