### PR TITLE
Doc proofreading usr_41.txt

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -6556,7 +6556,7 @@ libcall({libname}, {funcname}, {argument})
 libcallnr({libname}, {funcname}, {argument})
 		Just like |libcall()|, but used for a function that returns an
 		int instead of a string.
-		{only in Win32 on some Unix versions, when the |+libcall|
+		{only in Win32 and some Unix versions, when the |+libcall|
 		feature is present}
 		Examples: >
 			:echo libcallnr("/usr/lib/libc.so", "getpid", "")

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -749,7 +749,7 @@ String manipulation:					*string-functions*
 	str2list()		get list of numbers from a string
 	str2nr()		convert a string to a Number
 	str2float()		convert a string to a Float
-	printf()		format a string according to % items
+	printf()		format a string according to "%" items
 	escape()		escape characters in a string with a '\'
 	shellescape()		escape a string for use with a shell command
 	fnameescape()		escape a file name for use with a Vim command

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -1605,7 +1605,7 @@ once for every line in the range, with the cursor in that line.  Example: >
 
 If you call this function with: >
 
-	:10,15Number()
+	:10,15 call Number()
 
 The function will be called six times, starting on line 10 and ending on line
 15.

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -925,7 +925,7 @@ Other computation:					*bitwise-function*
 	invert()		bitwise invert
 	or()			bitwise OR
 	xor()			bitwise XOR
-	sha256()		SHA-256 hash (|+cryptv|)
+	sha256()		SHA-256 hash
 	rand()			get a pseudo-random number
 	srand()			initialize seed used by rand()
 
@@ -963,7 +963,6 @@ Cursor and mark position:		*cursor-functions* *mark-functions*
 	setpos()		set position of cursor, mark, etc.
 	getmarklist()		list of global/local marks
 	byte2line()		get line number at a specific byte count
-				(|+byte_offset|)
 	line2byte()		byte count at a specific line
 	diff_filler()		get the number of filler lines above a line
 	screenattr()		get attribute at a screen line/row
@@ -1050,11 +1049,8 @@ Date and Time:				*date-functions* *time-functions*
 	strftime()		convert time to a string
 	strptime()		convert a date/time string to time
 	reltime()		get the current or elapsed time accurately
-				(|+reltime|)
 	reltimestr()		convert reltime() result to a string
-				(|+reltime|)
 	reltimefloat()		convert reltime() result to a Float
-				(|+reltime|)
 
 Autocmds:					*autocmd-functions*
 	autocmd_add()		add a list of autocmds and groups
@@ -1143,9 +1139,7 @@ Folding:					*folding-functions*
 	foldclosedend()		like foldclosed() but return the last line
 	foldlevel()		check for the fold level at a specific line
 	foldtext()		generate the line displayed for a closed fold
-				(|+folding|)
 	foldtextresult()	get the text displayed for a closed fold
-				(|+folding|)
 
 Syntax and highlighting:	  *syntax-functions* *highlighting-functions*
 	clearmatches()		clear all matches defined by |matchadd()| and
@@ -1184,8 +1178,7 @@ History:					*history-functions*
 Interactive:					*interactive-functions*
 	browse()		put up a file requester
 	browsedir()		put up a directory requester
-	confirm()		let the user make a choice (|+dialog_con|,
-				|+dialog_con_gui| or |+dialog_gui|)
+	confirm()		let the user make a choice
  
 	getchar()		get a character from the user
 	getcharstr()		get a character from the user as a string
@@ -1206,25 +1199,18 @@ GUI:						*gui-functions*
 	getwinpos()		position of the Vim window
 	getwinposx()		X position of the Vim window
 	getwinposy()		Y position of the Vim window
-	balloon_show()		set the balloon content (|+balloon_eval| or
-				|+balloon_eval_term|)
+	balloon_show()		set the balloon content
 	balloon_split()		split a message for a balloon
-				(|+balloon_eval_term|)
 	balloon_gettext()	get the text in the balloon
 
 Vim server:					*server-functions*
 	serverlist()		return the list of server names
-				(|+clientserver|)
-	remote_startserver()	run a server (|+clientserver|)
+	remote_startserver()	run a server
 	remote_send()		send command characters to a Vim server
-				(|+clientserver|) 
 	remote_expr()		evaluate an expression in a Vim server
-				(|+clientserver|)
 	server2client()		send a reply to a client of a Vim server
-				(|+clientserver|)
 	remote_peek()		check if there is a reply from a Vim server
-				(|+clientserver|)
-	remote_read()		read a reply from a Vim server (|+clientserver|)
+	remote_read()		read a reply from a Vim server
 	foreground()		move the Vim window to the foreground
 	remote_foreground()	move the Vim server window to the foreground
 
@@ -1238,10 +1224,10 @@ Window size and position:			*window-size-functions*
 	winrestview()		restore saved view of current window
 
 Mappings and Menus:			    *mapping-functions*
-	digraph_get()		get |digraph| (|+digraph|) 
-	digraph_getlist()	get all |digraph|s (|+digraph|)
-	digraph_set()		register |digraph| (|+digraph|)
-	digraph_setlist()	register multiple |digraph|s (|+digraph|)
+	digraph_get()		get |digraph|
+	digraph_getlist()	get all |digraph|s
+	digraph_set()		register |digraph|
+	digraph_setlist()	register multiple |digraph|s
 	hasmapto()		check if a mapping exists
 	mapcheck()		check if a matching mapping exists
 	maparg()		get rhs of a mapping
@@ -1392,11 +1378,11 @@ Popup window:					*popup-window-functions*
 	popup_locate()		get popup window ID from its screen position
 
 Timers:						*timer-functions*
-	timer_start()		create a timer (|+timers|)
-	timer_pause()		pause or unpause a timer (|+timers|)
-	timer_stop()		stop a timer (|+timers|)
-	timer_stopall()		stop all timers (|+timers|)
-	timer_info()		get information about timers (|+timers|)
+	timer_start()		create a timer
+	timer_pause()		pause or unpause a timer
+	timer_stop()		stop a timer
+	timer_stopall()		stop all timers
+	timer_info()		get information about timers
 
 Tags:						*tag-functions*
 	taglist()		get list of matching tags
@@ -1406,11 +1392,9 @@ Tags:						*tag-functions*
 
 Prompt Buffer:					*promptbuffer-functions*
 	prompt_getprompt()	get the effective prompt text for a buffer
-				(|+channel|)
-	prompt_setcallback()	set prompt callback for a buffer (|+channel|)
+	prompt_setcallback()	set prompt callback for a buffer
 	prompt_setinterrupt()	set interrupt callback for a buffer
-				(|+channel|)
-	prompt_setprompt()	set the prompt text for a buffer (|+channel|)
+	prompt_setprompt()	set the prompt text for a buffer
 
 Registers:					*register-functions*
 	getreg()		get contents of a register
@@ -1434,10 +1418,10 @@ Text Properties:				*text-property-functions*
 	prop_type_list()	return a list of all property types
 
 Sound:							*sound-functions*
-	sound_clear()		stop playing all sounds (|+sound|)
-	sound_playevent()	play an event's sound (|+sound|)
-	sound_playfile()	play a sound file (|+sound|)
-	sound_stop()		stop playing a sound (|+sound|)
+	sound_clear()		stop playing all sounds
+	sound_playevent()	play an event's sound
+	sound_playfile()	play a sound file
+	sound_stop()		stop playing a sound
 
 Various:					*various-functions*
 	mode()			get current editing mode
@@ -1461,8 +1445,7 @@ Various:					*various-functions*
 	terminalprops()		properties of the terminal
 
 	libcall()		call a function in an external library
-				(|+libcall|)
-	libcallnr()		idem, returning a number (|+libcall|)
+	libcallnr()		idem, returning a number
 
 	undofile()		get the name of the undo file
 	undotree()		return the state of the undo tree for a buffer
@@ -1473,14 +1456,13 @@ Various:					*various-functions*
 
 	id()			get unique string for item to use as a key
 
-	luaeval()		evaluate |Lua| expression (|+lua|)
-	mzeval()		evaluate |MzScheme| expression (|+mzscheme|)
-	perleval()		evaluate Perl expression (|+perl|)
-	py3eval()		evaluate Python expression (|+python3|)
-	pyeval()		evaluate Python expression (|+python|)
-	pyxeval()		evaluate |python_x| expression (|+python| or
-				|+python3|)
-	rubyeval()		evaluate |Ruby| expression (|+ruby|)
+	luaeval()		evaluate |Lua| expression
+	mzeval()		evaluate |MzScheme| expression
+	perleval()		evaluate Perl expression
+	py3eval()		evaluate Python expression
+	pyeval()		evaluate Python expression
+	pyxeval()		evaluate |python_x| expression
+	rubyeval()		evaluate |Ruby| expression
 
 	debugbreak()		interrupt a program being debugged
 

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -30,10 +30,10 @@ Table of contents: |usr_toc.txt|
 *41.1*	Introduction				*vim-script-intro* *script*
 
 Let's start with some nomenclature. A Vim script is any file that Vim can
-interpret and execute.  This includes files written in Vim's scripting language
-like for example .vim files or configuration files like .vimrc and .gvimrc.
-These scripts may define functions, commands and settings that Vim uses to
-customize and extend its behavior.
+interpret and execute.  This includes files written in Vim's scripting
+language like for example .vim files or configuration files like .vimrc and
+.gvimrc.  These scripts may define functions, commands and settings that Vim
+uses to customize and extend its behavior.
 
 						*vim-script-notation*
 The correct notation is "Vim script" (or "Vim9 script" when refering to the
@@ -125,8 +125,8 @@ make such a loop, it can be written much more compact: >
 	  echo $"count is {i}"
 	endfor
 
-We won't explain how `for`, `range()` and `$"string"` work until later.  Follow
-the links if you are impatient.
+We won't explain how `for`, `range()` and `$"string"` work until later.
+Follow the links if you are impatient.
 
 
 TRYING OUT EXAMPLES

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -1179,7 +1179,6 @@ Interactive:					*interactive-functions*
 	browse()		put up a file requester
 	browsedir()		put up a directory requester
 	confirm()		let the user make a choice
- 
 	getchar()		get a character from the user
 	getcharstr()		get a character from the user as a string
 	getcharmod()		get modifiers for the last typed character

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -1460,7 +1460,8 @@ Various:					*various-functions*
 	windowsversion()	get MS-Windows version
 	terminalprops()		properties of the terminal
 
-	libcall()		call a function in an external library (|+libcall|)
+	libcall()		call a function in an external library
+				(|+libcall|)
 	libcallnr()		idem, returning a number (|+libcall|)
 
 	undofile()		get the name of the undo file

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -1242,7 +1242,7 @@ Mappings and Menus:			    *mapping-functions*
 	digraph_getlist()	get all |digraph|s (|+digraph|)
 	digraph_set()		register |digraph| (|+digraph|)
 	digraph_setlist()	register multiple |digraph|s (|+digraph|)
-	hasmapto()		check if a mapping exists 
+	hasmapto()		check if a mapping exists
 	mapcheck()		check if a matching mapping exists
 	maparg()		get rhs of a mapping
 	maplist()		get list of all mappings

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -832,9 +832,8 @@ List manipulation:					*list-functions*
 	range()			return a List with a sequence of numbers
 	string()		String representation of a List
 	call()			call a function with List as arguments
-	index()			index of a value in a List or Blob
-	indexof()		index in a List or Blob where an expression
-				evaluates to true
+	index()			index of a value in a List
+	indexof()		index in a List where an expression evaluates to true
 	max()			maximum value in a List
 	min()			minimum value in a List
 	count()			count number of times a value appears in a List
@@ -918,6 +917,8 @@ Blob manipulation:					*blob-functions*
 	blob2list()		get a list of numbers from a blob
 	list2blob()		get a blob from a list of numbers
 	reverse()		reverse the order of numbers in a blob
+	index()			index of a value in a Blob
+	indexof()		index in a Blob where an expression evaluates to true
 
 Other computation:					*bitwise-function*
 	and()			bitwise AND

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -925,7 +925,7 @@ Other computation:					*bitwise-function*
 	invert()		bitwise invert
 	or()			bitwise OR
 	xor()			bitwise XOR
-	sha256()		SHA-256 hash
+	sha256()		SHA-256 hash (|+cryptv|)
 	rand()			get a pseudo-random number
 	srand()			initialize seed used by rand()
 
@@ -962,7 +962,7 @@ Cursor and mark position:		*cursor-functions* *mark-functions*
 	getpos()		get position of cursor, mark, etc.
 	setpos()		set position of cursor, mark, etc.
 	getmarklist()		list of global/local marks
-	byte2line()		get line number at a specific byte count
+	byte2line()		get line number at a specific byte count (|+byte_offset|)
 	line2byte()		byte count at a specific line
 	diff_filler()		get the number of filler lines above a line
 	screenattr()		get attribute at a screen line/row
@@ -1048,9 +1048,9 @@ Date and Time:				*date-functions* *time-functions*
 	localtime()		get current time in seconds
 	strftime()		convert time to a string
 	strptime()		convert a date/time string to time
-	reltime()		get the current or elapsed time accurately
-	reltimestr()		convert reltime() result to a string
-	reltimefloat()		convert reltime() result to a Float
+	reltime()		get the current or elapsed time accurately (|+reltime|)
+	reltimestr()		convert reltime() result to a string (|+reltime|)
+	reltimefloat()		convert reltime() result to a Float (|+reltime|)
 
 Autocmds:					*autocmd-functions*
 	autocmd_add()		add a list of autocmds and groups
@@ -1138,8 +1138,8 @@ Folding:					*folding-functions*
 	foldclosed()		check for a closed fold at a specific line
 	foldclosedend()		like foldclosed() but return the last line
 	foldlevel()		check for the fold level at a specific line
-	foldtext()		generate the line displayed for a closed fold
-	foldtextresult()	get the text displayed for a closed fold
+	foldtext()		generate the line displayed for a closed fold (|+folding|)
+	foldtextresult()	get the text displayed for a closed fold (|+folding|)
 
 Syntax and highlighting:	  *syntax-functions* *highlighting-functions*
 	clearmatches()		clear all matches defined by |matchadd()| and
@@ -1178,7 +1178,9 @@ History:					*history-functions*
 Interactive:					*interactive-functions*
 	browse()		put up a file requester
 	browsedir()		put up a directory requester
-	confirm()		let the user make a choice
+	confirm()		let the user make a choice (|+dialog_con|,
+				|+dialog_con_gui| or |+dialog_gui|)
+ 
 	getchar()		get a character from the user
 	getcharstr()		get a character from the user as a string
 	getcharmod()		get modifiers for the last typed character
@@ -1198,18 +1200,18 @@ GUI:						*gui-functions*
 	getwinpos()		position of the Vim window
 	getwinposx()		X position of the Vim window
 	getwinposy()		Y position of the Vim window
-	balloon_show()		set the balloon content
-	balloon_split()		split a message for a balloon
+	balloon_show()		set the balloon content (|+balloon_eval| or |+balloon_eval_term|)
+	balloon_split()		split a message for a balloon (|+balloon_eval_term|)
 	balloon_gettext()	get the text in the balloon
 
 Vim server:					*server-functions*
-	serverlist()		return the list of server names
-	remote_startserver()	run a server
-	remote_send()		send command characters to a Vim server
-	remote_expr()		evaluate an expression in a Vim server
-	server2client()		send a reply to a client of a Vim server
-	remote_peek()		check if there is a reply from a Vim server
-	remote_read()		read a reply from a Vim server
+	serverlist()		return the list of server names (|+clientserver|)
+	remote_startserver()	run a server (|+clientserver|)
+	remote_send()		send command characters to a Vim server (|+clientserver|) 
+	remote_expr()		evaluate an expression in a Vim server (|+clientserver|)
+	server2client()		send a reply to a client of a Vim server (|+clientserver|)
+	remote_peek()		check if there is a reply from a Vim server (|+clientserver|)
+	remote_read()		read a reply from a Vim server (|+clientserver|)
 	foreground()		move the Vim window to the foreground
 	remote_foreground()	move the Vim server window to the foreground
 
@@ -1223,11 +1225,11 @@ Window size and position:			*window-size-functions*
 	winrestview()		restore saved view of current window
 
 Mappings and Menus:			    *mapping-functions*
-	digraph_get()		get |digraph|
-	digraph_getlist()	get all |digraph|s
-	digraph_set()		register |digraph|
-	digraph_setlist()	register multiple |digraph|s
-	hasmapto()		check if a mapping exists
+	digraph_get()		get |digraph| (|+digraph|) 
+	digraph_getlist()	get all |digraph|s (|+digraph|)
+	digraph_set()		register |digraph| (|+digraph|)
+	digraph_setlist()	register multiple |digraph|s (|+digraph|)
+	hasmapto()		check if a mapping exists 
 	mapcheck()		check if a matching mapping exists
 	maparg()		get rhs of a mapping
 	maplist()		get list of all mappings
@@ -1377,11 +1379,11 @@ Popup window:					*popup-window-functions*
 	popup_locate()		get popup window ID from its screen position
 
 Timers:						*timer-functions*
-	timer_start()		create a timer
-	timer_pause()		pause or unpause a timer
-	timer_stop()		stop a timer
-	timer_stopall()		stop all timers
-	timer_info()		get information about timers
+	timer_start()		create a timer (|+timers|)
+	timer_pause()		pause or unpause a timer (|+timers|)
+	timer_stop()		stop a timer (|+timers|)
+	timer_stopall()		stop all timers (|+timers|)
+	timer_info()		get information about timers (|+timers|)
 
 Tags:						*tag-functions*
 	taglist()		get list of matching tags
@@ -1390,10 +1392,10 @@ Tags:						*tag-functions*
 	settagstack()		modify the tag stack of a window
 
 Prompt Buffer:					*promptbuffer-functions*
-	prompt_getprompt()	get the effective prompt text for a buffer
-	prompt_setcallback()	set prompt callback for a buffer
-	prompt_setinterrupt()	set interrupt callback for a buffer
-	prompt_setprompt()	set the prompt text for a buffer
+	prompt_getprompt()	get the effective prompt text for a buffer (|+channel|)
+	prompt_setcallback()	set prompt callback for a buffer (|+channel|)
+	prompt_setinterrupt()	set interrupt callback for a buffer (|+channel|)
+	prompt_setprompt()	set the prompt text for a buffer (|+channel|)
 
 Registers:					*register-functions*
 	getreg()		get contents of a register
@@ -1417,10 +1419,10 @@ Text Properties:				*text-property-functions*
 	prop_type_list()	return a list of all property types
 
 Sound:							*sound-functions*
-	sound_clear()		stop playing all sounds
-	sound_playevent()	play an event's sound
-	sound_playfile()	play a sound file
-	sound_stop()		stop playing a sound
+	sound_clear()		stop playing all sounds (|+sound|)
+	sound_playevent()	play an event's sound (|+sound|)
+	sound_playfile()	play a sound file (|+sound|)
+	sound_stop()		stop playing a sound (|+sound|)
 
 Various:					*various-functions*
 	mode()			get current editing mode
@@ -1443,8 +1445,8 @@ Various:					*various-functions*
 	windowsversion()	get MS-Windows version
 	terminalprops()		properties of the terminal
 
-	libcall()		call a function in an external library
-	libcallnr()		idem, returning a number
+	libcall()		call a function in an external library (|+libcall|)
+	libcallnr()		idem, returning a number (|+libcall|)
 
 	undofile()		get the name of the undo file
 	undotree()		return the state of the undo tree for a buffer
@@ -1455,13 +1457,13 @@ Various:					*various-functions*
 
 	id()			get unique string for item to use as a key
 
-	luaeval()		evaluate |Lua| expression
-	mzeval()		evaluate |MzScheme| expression
+	luaeval()		evaluate |Lua| expression (|+lua|)
+	mzeval()		evaluate |MzScheme| expression (|+mzscheme|)
 	perleval()		evaluate Perl expression (|+perl|)
 	py3eval()		evaluate Python expression (|+python3|)
 	pyeval()		evaluate Python expression (|+python|)
-	pyxeval()		evaluate |python_x| expression
-	rubyeval()		evaluate |Ruby| expression
+	pyxeval()		evaluate |python_x| expression (|+python| or |+python3|)
+	rubyeval()		evaluate |Ruby| expression (|+ruby|)
 
 	debugbreak()		interrupt a program being debugged
 

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -125,7 +125,7 @@ make such a loop, it can be written much more compact: >
 	  echo $"count is {i}"
 	endfor
 
-We won't explain how `for`, `range()`and `$"string"` work until later.  Follow
+We won't explain how `for`, `range()` and `$"string"` work until later.  Follow
 the links if you are impatient.
 
 

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -833,7 +833,7 @@ List manipulation:					*list-functions*
 	string()		String representation of a List
 	call()			call a function with List as arguments
 	index()			index of a value in a List
-	indexof()		index in a List where an expression evaluates to true
+	indexof()		index in a List where an expression is true
 	max()			maximum value in a List
 	min()			minimum value in a List
 	count()			count number of times a value appears in a List
@@ -918,7 +918,7 @@ Blob manipulation:					*blob-functions*
 	list2blob()		get a blob from a list of numbers
 	reverse()		reverse the order of numbers in a blob
 	index()			index of a value in a Blob
-	indexof()		index in a Blob where an expression evaluates to true
+	indexof()		index in a Blob where an expression is true
 
 Other computation:					*bitwise-function*
 	and()			bitwise AND
@@ -962,7 +962,8 @@ Cursor and mark position:		*cursor-functions* *mark-functions*
 	getpos()		get position of cursor, mark, etc.
 	setpos()		set position of cursor, mark, etc.
 	getmarklist()		list of global/local marks
-	byte2line()		get line number at a specific byte count (|+byte_offset|)
+	byte2line()		get line number at a specific byte count
+				(|+byte_offset|)
 	line2byte()		byte count at a specific line
 	diff_filler()		get the number of filler lines above a line
 	screenattr()		get attribute at a screen line/row
@@ -1048,9 +1049,12 @@ Date and Time:				*date-functions* *time-functions*
 	localtime()		get current time in seconds
 	strftime()		convert time to a string
 	strptime()		convert a date/time string to time
-	reltime()		get the current or elapsed time accurately (|+reltime|)
-	reltimestr()		convert reltime() result to a string (|+reltime|)
-	reltimefloat()		convert reltime() result to a Float (|+reltime|)
+	reltime()		get the current or elapsed time accurately
+				(|+reltime|)
+	reltimestr()		convert reltime() result to a string
+				(|+reltime|)
+	reltimefloat()		convert reltime() result to a Float
+				(|+reltime|)
 
 Autocmds:					*autocmd-functions*
 	autocmd_add()		add a list of autocmds and groups
@@ -1138,8 +1142,10 @@ Folding:					*folding-functions*
 	foldclosed()		check for a closed fold at a specific line
 	foldclosedend()		like foldclosed() but return the last line
 	foldlevel()		check for the fold level at a specific line
-	foldtext()		generate the line displayed for a closed fold (|+folding|)
-	foldtextresult()	get the text displayed for a closed fold (|+folding|)
+	foldtext()		generate the line displayed for a closed fold
+				(|+folding|)
+	foldtextresult()	get the text displayed for a closed fold
+				(|+folding|)
 
 Syntax and highlighting:	  *syntax-functions* *highlighting-functions*
 	clearmatches()		clear all matches defined by |matchadd()| and
@@ -1200,17 +1206,24 @@ GUI:						*gui-functions*
 	getwinpos()		position of the Vim window
 	getwinposx()		X position of the Vim window
 	getwinposy()		Y position of the Vim window
-	balloon_show()		set the balloon content (|+balloon_eval| or |+balloon_eval_term|)
-	balloon_split()		split a message for a balloon (|+balloon_eval_term|)
+	balloon_show()		set the balloon content (|+balloon_eval| or
+				|+balloon_eval_term|)
+	balloon_split()		split a message for a balloon
+				(|+balloon_eval_term|)
 	balloon_gettext()	get the text in the balloon
 
 Vim server:					*server-functions*
-	serverlist()		return the list of server names (|+clientserver|)
+	serverlist()		return the list of server names
+				(|+clientserver|)
 	remote_startserver()	run a server (|+clientserver|)
-	remote_send()		send command characters to a Vim server (|+clientserver|) 
-	remote_expr()		evaluate an expression in a Vim server (|+clientserver|)
-	server2client()		send a reply to a client of a Vim server (|+clientserver|)
-	remote_peek()		check if there is a reply from a Vim server (|+clientserver|)
+	remote_send()		send command characters to a Vim server
+				(|+clientserver|) 
+	remote_expr()		evaluate an expression in a Vim server
+				(|+clientserver|)
+	server2client()		send a reply to a client of a Vim server
+				(|+clientserver|)
+	remote_peek()		check if there is a reply from a Vim server
+				(|+clientserver|)
 	remote_read()		read a reply from a Vim server (|+clientserver|)
 	foreground()		move the Vim window to the foreground
 	remote_foreground()	move the Vim server window to the foreground
@@ -1392,9 +1405,11 @@ Tags:						*tag-functions*
 	settagstack()		modify the tag stack of a window
 
 Prompt Buffer:					*promptbuffer-functions*
-	prompt_getprompt()	get the effective prompt text for a buffer (|+channel|)
+	prompt_getprompt()	get the effective prompt text for a buffer
+				(|+channel|)
 	prompt_setcallback()	set prompt callback for a buffer (|+channel|)
-	prompt_setinterrupt()	set interrupt callback for a buffer (|+channel|)
+	prompt_setinterrupt()	set interrupt callback for a buffer
+				(|+channel|)
 	prompt_setprompt()	set the prompt text for a buffer (|+channel|)
 
 Registers:					*register-functions*
@@ -1462,7 +1477,8 @@ Various:					*various-functions*
 	perleval()		evaluate Perl expression (|+perl|)
 	py3eval()		evaluate Python expression (|+python3|)
 	pyeval()		evaluate Python expression (|+python|)
-	pyxeval()		evaluate |python_x| expression (|+python| or |+python3|)
+	pyxeval()		evaluate |python_x| expression (|+python| or
+				|+python3|)
 	rubyeval()		evaluate |Ruby| expression (|+ruby|)
 
 	debugbreak()		interrupt a program being debugged


### PR DESCRIPTION
Proofreading of runtime/doc (mostly) usr_41.txt

- Fix typos.
- Split index() and indexof() entries in List functions to also Blob functions (as they were in Tuples).
- Add additional compile features info.