### PR TITLE
fix: incorrect selected index returned from complete_info()

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -4185,7 +4185,7 @@ get_complete_info(list_T *what_list, dict_T *retdict)
 			    && compl_curr_match->cp_number == match->cp_number)
 			selected_idx = list_idx;
 		    if (!has_matches || match->cp_in_match_array)
-			list_idx += 1;
+			list_idx++;
 		}
 		match = match->cp_next;
 	    }

--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -4184,7 +4184,7 @@ get_complete_info(list_T *what_list, dict_T *retdict)
 		    if (compl_curr_match != NULL
 			    && compl_curr_match->cp_number == match->cp_number)
 			selected_idx = list_idx;
-		    if (match->cp_in_match_array)
+		    if (!has_matches || match->cp_in_match_array)
 			list_idx += 1;
 		}
 		match = match->cp_next;

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -3945,7 +3945,7 @@ func Test_completeopt_preinsert()
   call assert_equal("fobar", g:line)
   call assert_equal(2, g:col)
 
-  call feedkeys("S\<C-X>\<C-O>foo\<F5><ESC>", 'tx')
+  call feedkeys("S\<C-X>\<C-O>foo\<F5>\<ESC>", 'tx')
   call assert_equal("foobar", g:line)
 
   call feedkeys("S\<C-X>\<C-O>foo\<BS>\<BS>\<BS>", 'tx')

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -3520,7 +3520,7 @@ func Test_complete_opt_fuzzy()
   set cot+=noinsert
   call feedkeys("i\<C-R>=CompAnother()\<CR>f", 'tx')
   call assert_equal("for", g:abbr)
-  call assert_equal(0, g:selected)
+  call assert_equal(2, g:selected)
 
   set cot=menu,menuone,noselect,fuzzy
   call feedkeys("i\<C-R>=CompAnother()\<CR>\<C-N>\<C-N>\<C-N>\<C-N>", 'tx')
@@ -3901,6 +3901,36 @@ func Test_complete_info_completed()
 
   bw!
   delfunc ShownInfo
+  set cot&
+endfunc
+
+func Test_complete_info_selected()
+  set completeopt=menuone,noselect
+
+  new
+  call setline(1, ["ward", "werd", "wurd", "wxrd"])
+  exe "normal! Gow\<c-n>u\<c-n>\<c-r>=complete_info().selected\<cr>"
+  call assert_equal('wurd2', getline(5))
+  bw!
+
+  new
+  call setline(1, ["ward", "werd", "wurd", "wxrd"])
+  exe "normal! Gow\<c-n>u\<c-n>\<c-r>=complete_info(['selected']).selected\<cr>"
+  call assert_equal('wurd2', getline(5))
+  bw!
+
+  new
+  call setline(1, ["ward", "werd", "wurd", "wxrd"])
+  exe "normal! Gow\<c-n>u\<c-n>\<c-r>=complete_info(['items', 'selected']).selected\<cr>"
+  call assert_equal('wurd2', getline(5))
+  bw!
+
+  new
+  call setline(1, ["ward", "werd", "wurd", "wxrd"])
+  exe "normal! Gow\<c-n>u\<c-n>\<c-r>=complete_info(['matches', 'selected']).selected\<cr>"
+  call assert_equal('wurd0', getline(5))
+  bw!
+
   set cot&
 endfunc
 
@@ -5067,7 +5097,7 @@ func Test_autocomplete_trigger()
 
   new
   inoremap <buffer> <F2> <Cmd>let b:matches = complete_info(["matches"]).matches<CR>
-  inoremap <buffer> <F3> <Cmd>let b:selected = complete_info(["selected"]).selected<CR>
+  inoremap <buffer> <F3> <Cmd>let b:selected = complete_info(["matches", "selected"]).selected<CR>
 
   call setline(1, ['abc', 'abcd', 'fo', 'b', ''])
   set autocomplete

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -3912,13 +3912,13 @@ func Test_complete_info_selected()
   exe "normal! Gow\<c-n>u\<c-n>\<c-r>=complete_info().selected\<cr>"
   call assert_equal('wurd2', getline(5))
 
-  exe "normal! \<esc>Sw\<c-n>u\<c-n>\<c-r>=complete_info(['selected']).selected\<cr>"
+  exe "normal! Sw\<c-n>u\<c-n>\<c-r>=complete_info(['selected']).selected\<cr>"
   call assert_equal('wurd2', getline(5))
 
-  exe "normal! \<esc>Sw\<c-n>u\<c-n>\<c-r>=complete_info(['items', 'selected']).selected\<cr>"
+  exe "normal! Sw\<c-n>u\<c-n>\<c-r>=complete_info(['items', 'selected']).selected\<cr>"
   call assert_equal('wurd2', getline(5))
 
-  exe "normal! \<esc>Sw\<c-n>u\<c-n>\<c-r>=complete_info(['matches', 'selected']).selected\<cr>"
+  exe "normal! Sw\<c-n>u\<c-n>\<c-r>=complete_info(['matches', 'selected']).selected\<cr>"
   call assert_equal('wurd0', getline(5))
 
   bw!

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -3906,31 +3906,22 @@ endfunc
 
 func Test_complete_info_selected()
   set completeopt=menuone,noselect
-
   new
   call setline(1, ["ward", "werd", "wurd", "wxrd"])
+
   exe "normal! Gow\<c-n>u\<c-n>\<c-r>=complete_info().selected\<cr>"
   call assert_equal('wurd2', getline(5))
-  bw!
 
-  new
-  call setline(1, ["ward", "werd", "wurd", "wxrd"])
-  exe "normal! Gow\<c-n>u\<c-n>\<c-r>=complete_info(['selected']).selected\<cr>"
+  exe "normal! \<esc>Sw\<c-n>u\<c-n>\<c-r>=complete_info(['selected']).selected\<cr>"
   call assert_equal('wurd2', getline(5))
-  bw!
 
-  new
-  call setline(1, ["ward", "werd", "wurd", "wxrd"])
-  exe "normal! Gow\<c-n>u\<c-n>\<c-r>=complete_info(['items', 'selected']).selected\<cr>"
+  exe "normal! \<esc>Sw\<c-n>u\<c-n>\<c-r>=complete_info(['items', 'selected']).selected\<cr>"
   call assert_equal('wurd2', getline(5))
-  bw!
 
-  new
-  call setline(1, ["ward", "werd", "wurd", "wxrd"])
-  exe "normal! Gow\<c-n>u\<c-n>\<c-r>=complete_info(['matches', 'selected']).selected\<cr>"
+  exe "normal! \<esc>Sw\<c-n>u\<c-n>\<c-r>=complete_info(['matches', 'selected']).selected\<cr>"
   call assert_equal('wurd0', getline(5))
-  bw!
 
+  bw!
   set cot&
 endfunc
 


### PR DESCRIPTION
Problem: complete_info() returned an incorrect selected index after 0ac1eb3555445f4c458c06cef7c411de1c8d1020. Effectively it became an index into "matches" instead of "items". 
Solution: Return the index into "items" by default to restore the previous behavior, unless "matches" was requested.