### PR TITLE
fix unsequenced writes in mb_decompose

### DIFF
--- a/src/regexp.c
+++ b/src/regexp.c
@@ -1722,7 +1722,8 @@ mb_decompose(int c, int *c1, int *c2, int *c3)
     else
     {
 	*c1 = c;
-	*c2 = *c3 = 0;
+	*c2 = 0;
+	*c3 = 0;
     }
 }
 


### PR DESCRIPTION
Calling `mb_decompose(c1, &c11, &junk, &junk)` will result in `c2` and `c3` being equal inside the function, which will result in undefined behavior on `*c2 = *c3 = 0;`.