### PR TITLE
Tweak documentation

### DIFF
--- a/runtime/autoload/vimcomplete.vim
+++ b/runtime/autoload/vimcomplete.vim
@@ -1,14 +1,14 @@
 vim9script
 
 # Vim completion script
-# Language:    Vimscript
+# Language:    Vim script
 # Maintainer:  Maxim Kim <habamax@gmail.com>
 # Last Change: 2025-07-28
 #
 # Usage:
 # setlocal omnifunc=vimcomplete#Complete
 #
-# Simple complete function for the Vimscript
+# Simple complete function for Vim script
 
 var trigger: string = ""
 var prefix: string = ""

--- a/runtime/doc/develop.txt
+++ b/runtime/doc/develop.txt
@@ -308,11 +308,11 @@ Vim's main Makefiles target maximum portability, relying solely on features
 defined in POSIX.1-2001 `make` and ignoring later POSIX standards or GNU/BSD
 extensions.  In practical terms, avoid:
 
-	– % pattern rules
-	– modern assignment (`:=`, `::=`) outside POSIX.1-2001
-	– special targets (`.ONESHELL`, `.NOTPARALLEL`, `.SILENT`, …)
-	– order-only prerequisites (`|`) or automatic directory creation
-	– GNU/BSD conditionals (`ifdef`, `ifndef`, `.for`/`.endfor`, …)
+	- % pattern rules
+	- modern assignment (`:=`, `::=`) outside POSIX.1-2001
+	- special targets (`.ONESHELL`, `.NOTPARALLEL`, `.SILENT`, ...)
+	- order-only prerequisites (`|`) or automatic directory creation
+	- GNU/BSD conditionals (`ifdef`, `ifndef`, `.for`/`.endfor`, ...)
 
 Since POSIX.1-2001 supports only traditional suffix rules, every object built
 in a separate directory must have an explicit rule.  For example:
@@ -339,9 +339,9 @@ Therefore, the latest ISO C standard we follow is:
 	`C95` (ISO/IEC 9899:1990/AMD1:1995)
 
 In addition, the following `C99` features are explicitly allowed:
-	– logical lines may contain up to 4095 characters;
-	– `//` comments, as required by |style-comments|;
-	– the `_Bool` type.
+	- `//` comments, as required by |style-comments|;
+	- the `_Bool` type.
+	- logical lines may contain up to 4095 characters;
 
 Platform-specific code may use any newer compiler features supported on that
 platform.
@@ -349,11 +349,11 @@ platform.
 
 SIZE OF VARIABLES				*assumptions-variables*
 
-We follow POSIX.1‑2001 (SUSv3) for type sizes, which in practice means:
+We follow POSIX.1-2001 (SUSv3) for type sizes, which in practice means:
 
-	char_u      8-bit unsigned
-	int         ≥ 32-bit signed
-	unsigned    ≥ 32-bit unsigned
+	char_u	    8-bit unsigned
+	int	    32-bit or larger signed
+	unsigned    32-bit or larger unsigned
 
 
 ==============================================================================

--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -1072,7 +1072,7 @@ The Vim filetype plugin defines the following mappings:
     ]"		move to the next (legacy) comment
     ["		move to the previous (legacy) comment
     gf		edit the file under the cursor
-    CTRL-W gf	edit the file under the cursor in a new tab
+    CTRL-W gf	edit the file under the cursor in a new tab page
     CTRL-W f	edit the file under the cursor in a new window
 
 

--- a/runtime/ftplugin/vim.vim
+++ b/runtime/ftplugin/vim.vim
@@ -9,7 +9,7 @@
 "                    @lacygoill
 " Last Change:       2025 Mar 05
 " 2025 Aug 06 by Vim Project (add gf maps #17881)
-" 2025 Aug 08 by Vim Project (add vimscript complete function #17871)
+" 2025 Aug 08 by Vim Project (add Vim script complete function #17871)
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin")

--- a/runtime/pack/dist/opt/helptoc/doc/helptoc.txt
+++ b/runtime/pack/dist/opt/helptoc/doc/helptoc.txt
@@ -178,7 +178,7 @@ brackets preceding and following each heading's text.
 
 3.7 vim						*HelpToc-vim-filetype*
 
-Vimscript and Vim9 script do not have headings or levels inherently like
+Vim script and Vim9 script do not have headings or levels inherently like
 markup languages.  However, Vim provides for |folds| defined by markers (|{{{|),
 which themselves may be succeeded by a number explicitly indicating the fold
 level.  This is the structure recognized and supported by helptoc.vim.


### PR DESCRIPTION
doc/develop.txt
- Eliminate UTF-8 code
- Changed the order of C99 features

doc/filetype.txt
- Changed `tab` to `tab page`.

others
- s/\cVimscript/Vim script/