### PR TITLE
runtime(python): Also sync syntax at 'async def'

### DIFF
--- a/runtime/syntax/python.vim
+++ b/runtime/syntax/python.vim
@@ -367,8 +367,8 @@ if !exists("python_no_doctest_highlight")
   endif
 endif
 
-" Sync at the beginning of class, function, or method definition.
-syn sync match pythonSync grouphere NONE "^\%(def\|class\)\s\+\h\w*\s*[(:]"
+" Sync at the beginning of (async) function or class definitions.
+syn sync match pythonSync grouphere NONE "^\%(async\s\+def\|def\|class\)\s\+\h\w*\s*[(:]"
 
 " The default highlight links.  Can be overridden later.
 hi def link pythonStatement		Statement


### PR DESCRIPTION
A file containing only async functions (`async def func()`) wouldn't previously match the pythonSync pattern.

Also, this pattern only matches at the beginning of the line, so it won't ever match method definitions (which are indented within class scopes). Update the comment accordingly.