### PR TITLE
doc: add more C99 features

### DIFF
--- a/runtime/doc/develop.txt
+++ b/runtime/doc/develop.txt
@@ -340,8 +340,14 @@ Therefore, the latest ISO C standard we follow is:
 
 In addition, the following `C99` features are explicitly allowed:
 	- `//` comments, as required by |style-comments|;
-	- the `_Bool` type.
-	- logical lines may contain up to 4095 characters;
+	- Mixed declarations and statements in a block;
+	- Variadic macros `(..., __VA_ARGS__)`;
+	- Trailing comma in `enum` lists;
+	- `_Bool` type (with `<stdbool.h>` for `bool`, `true`, `false`);
+	- `__func__` predefined identifier;
+	- `inline` functions (use `static inline` for portability);
+	- Compound literals `(type){ initializer-list }`;
+	- Logical source lines up to 4095 characters.
 
 Platform-specific code may use any newer compiler features supported on that
 platform.


### PR DESCRIPTION
Originally I found [that document](http://odl.sysworks.biz/disk$axpdocmar012/progtool/cpqc64/5492p.htm) about the C99 features supported by Compaq C 6.4.

Looking at Vim’s code that does compile on VMS, I realised that mixing declarations and statements was ok too. So I did more research and found a document on [supported features for Compaq C 6.2](http://odl.sysworks.biz/disk$axpdocsep002/progtool/cpqc62a/5492p.htm)

The list of supported C99 features is now updated. @arpadffy please have a look at the list.