### PR TITLE
Fix: Autocompletion slow when "i" (include files) and "t" (tags) are present in 'complete'

### DIFF
--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -9432,8 +9432,8 @@ exec_normal(int was_typed, int use_vpeekc, int may_use_terminal_loop UNUSED)
 ex_checkpath(exarg_T *eap)
 {
     find_pattern_in_path(NULL, 0, 0, FALSE, FALSE, CHECK_PATH, 1L,
-				   eap->forceit ? ACTION_SHOW_ALL : ACTION_SHOW,
-					      (linenr_T)1, (linenr_T)MAXLNUM, eap->forceit);
+	    eap->forceit ? ACTION_SHOW_ALL : ACTION_SHOW,
+	    (linenr_T)1, (linenr_T)MAXLNUM, eap->forceit, FALSE);
 }
 
 #if defined(FEAT_QUICKFIX)
@@ -9501,9 +9501,9 @@ ex_findpat(exarg_T *eap)
     }
     if (!eap->skip)
 	find_pattern_in_path(eap->arg, 0, (int)STRLEN(eap->arg),
-			    whole, !eap->forceit,
-			    *eap->cmd == 'd' ?	FIND_DEFINE : FIND_ANY,
-			    n, action, eap->line1, eap->line2, eap->forceit);
+		whole, !eap->forceit,
+		*eap->cmd == 'd' ? FIND_DEFINE : FIND_ANY, n, action,
+		eap->line1, eap->line2, eap->forceit, FALSE);
 }
 #endif
 

--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -2042,8 +2042,7 @@ ins_compl_files(
 	leader_len = (int)ins_compl_leader_len();
     }
 
-    for (i = 0; i < count && !got_int && !compl_interrupted
-	    && !compl_time_slice_expired; i++)
+    for (i = 0; i < count && !got_int && !ins_compl_interrupted(); i++)
     {
 	fp = mch_fopen((char *)files[i], "r");  // open dictionary file
 	if (flags != DICT_EXACT && !shortmess(SHM_COMPLETIONSCAN)
@@ -2060,7 +2059,7 @@ ins_compl_files(
 
 	// Read dictionary file line by line.
 	// Check each line for a match.
-	while (!got_int && !compl_interrupted && !compl_time_slice_expired
+	while (!got_int && !ins_compl_interrupted()
 	       && !vim_fgets(buf, LSIZE, fp))
 	{
 	    ptr = buf;
@@ -2297,7 +2296,7 @@ ins_compl_init_get_longest(void)
     int
 ins_compl_interrupted(void)
 {
-    return compl_interrupted;
+    return compl_interrupted || compl_time_slice_expired;
 }
 
 /*
@@ -3841,10 +3840,7 @@ f_complete_check(typval_T *argvars UNUSED, typval_T *rettv)
     RedrawingDisabled = 0;
 
     ins_compl_check_keys(0, TRUE);
-    if (compl_autocomplete && compl_time_slice_expired)
-	rettv->vval.v_number = TRUE;
-    else
-	rettv->vval.v_number = ins_compl_interrupted();
+    rettv->vval.v_number = ins_compl_interrupted();
 
     RedrawingDisabled = save_RedrawingDisabled;
 }
@@ -4462,7 +4458,7 @@ get_next_include_file_completion(int compl_type)
 	    (compl_type == CTRL_X_PATH_DEFINES
 	     && !(compl_cont_status & CONT_SOL))
 	    ? FIND_DEFINE : FIND_ANY, 1L, ACTION_EXPAND,
-	    (linenr_T)1, (linenr_T)MAXLNUM, FALSE);
+	    (linenr_T)1, (linenr_T)MAXLNUM, FALSE, compl_autocomplete);
 }
 #endif
 

--- a/src/normal.c
+++ b/src/normal.c
@@ -4478,7 +4478,7 @@ nv_brackets(cmdarg_T *cap)
 			    SAFE_islower(cap->nchar) ? ACTION_SHOW : ACTION_GOTO,
 		cap->cmdchar == ']' ? curwin->w_cursor.lnum + 1 : (linenr_T)1,
 		(linenr_T)MAXLNUM,
-		FALSE);
+		FALSE, FALSE);
 	    vim_free(ptr);
 	    curwin->w_set_curswant = TRUE;
 	}

--- a/src/proto/search.pro
+++ b/src/proto/search.pro
@@ -33,7 +33,7 @@ int check_linecomment(char_u *line);
 void showmatch(int c);
 int current_search(long count, int forward);
 int linewhite(linenr_T lnum);
-void find_pattern_in_path(char_u *ptr, int dir, int len, int whole, int skip_comments, int type, long count, int action, linenr_T start_lnum, linenr_T end_lnum, int forceit);
+void find_pattern_in_path(char_u *ptr, int dir, int len, int whole, int skip_comments, int type, long count, int action, linenr_T start_lnum, linenr_T end_lnum, int forceit, int silent);
 spat_T *get_spat(int idx);
 int get_spat_last_idx(void);
 void f_searchcount(typval_T *argvars, typval_T *rettv);

--- a/src/search.c
+++ b/src/search.c
@@ -3406,7 +3406,8 @@ find_pattern_in_path(
     int		action,		// What to do when we find it
     linenr_T	start_lnum,	// first line to start searching
     linenr_T	end_lnum,	// last line for searching
-    int		forceit)	// If true, always switch to the found path
+    int		forceit,	// If true, always switch to the found path
+    int		silent)		// Do not print messages when ACTION_EXPAND
 {
     SearchedFile *files;		// Stack of included files
     SearchedFile *bigger;		// When we need more space
@@ -3680,7 +3681,8 @@ find_pattern_in_path(
 		    files[depth].name = curr_fname = new_fname;
 		    files[depth].lnum = 0;
 		    files[depth].matched = FALSE;
-		    if (action == ACTION_EXPAND)
+		    if (action == ACTION_EXPAND
+			    && !shortmess(SHM_COMPLETIONSCAN) && !silent)
 		    {
 			msg_hist_off = TRUE;	// reset in msg_trunc_attr()
 			vim_snprintf((char*)IObuff, IOSIZE,
@@ -3909,8 +3911,8 @@ search_line:
 		else if (action == ACTION_SHOW)
 		{
 		    show_pat_in_path(line, type, did_show, action,
-			(depth == -1) ? NULL : files[depth].fp,
-			(depth == -1) ? &lnum : &files[depth].lnum, 1L);
+			    (depth == -1) ? NULL : files[depth].fp,
+			    (depth == -1) ? &lnum : &files[depth].lnum, 1L);
 		    did_show = TRUE;
 		}
 		else
@@ -4060,7 +4062,7 @@ exit_matched:
 		msg(_("No included files"));
 	}
     }
-    else if (!found && action != ACTION_EXPAND)
+    else if (!found && action != ACTION_EXPAND && !silent)
     {
 	if (got_int || ins_compl_interrupted())
 	    emsg(_(e_interrupted));

--- a/src/window.c
+++ b/src/window.c
@@ -698,7 +698,8 @@ wingotofile:
 
 		find_pattern_in_path(ptr, 0, len, TRUE,
 			Prenum == 0 ? TRUE : FALSE, type,
-			Prenum1, ACTION_SPLIT, (linenr_T)1, (linenr_T)MAXLNUM, FALSE);
+			Prenum1, ACTION_SPLIT, (linenr_T)1, (linenr_T)MAXLNUM,
+			FALSE, FALSE);
 		vim_free(ptr);
 		curwin->w_set_curswant = TRUE;
 		break;


### PR DESCRIPTION
**Problem:** Running `vim *` in `vim/src` was slower than expected when `'autocomplete'` was enabled.
Include-file and tag-file completion sources were not subject to the timeout check, causing unnecessary delays.

**Solution:** Apply the timeout check to these sources as well, improving autocompletion responsiveness.