### PR TITLE
runtime(python): highlight 'self' and 'cls'

### DIFF
--- a/runtime/syntax/python.vim
+++ b/runtime/syntax/python.vim
@@ -105,7 +105,6 @@ syn keyword pythonOperator	and in is not or
 syn keyword pythonException	except finally raise try
 syn keyword pythonInclude	from import
 syn keyword pythonAsync		async await
-syn keyword pythonClassVar	self cls
 
 " Soft keywords
 " These keywords do not mean anything unless used in the right context.
@@ -113,6 +112,10 @@ syn keyword pythonClassVar	self cls
 " for more on this.
 syn match   pythonConditional   "^\s*\zscase\%(\s\+.*:.*$\)\@="
 syn match   pythonConditional   "^\s*\zsmatch\%(\s\+.*:\s*\%(#.*\)\=$\)\@="
+
+" These names are special by convention. While they aren't real keywords,
+" giving them distinct highlighting provides a nice visual cue.
+syn keyword pythonClassVar	self cls
 
 " Decorators
 " A dot must be allowed because of @MyClass.myfunc decorators.

--- a/runtime/syntax/python.vim
+++ b/runtime/syntax/python.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:	Python
 " Maintainer:	Zvezdan Petkovic <zpetkovic@acm.org>
-" Last Change:	2025 Aug 10
+" Last Change:	2025 Aug 11
 " Credits:	Neil Schemenauer <nas@python.ca>
 "		Dmitry Vasiliev
 "		Rob B
@@ -105,6 +105,7 @@ syn keyword pythonOperator	and in is not or
 syn keyword pythonException	except finally raise try
 syn keyword pythonInclude	from import
 syn keyword pythonAsync		async await
+syn keyword pythonClassVar	self cls
 
 " Soft keywords
 " These keywords do not mean anything unless used in the right context.
@@ -378,6 +379,7 @@ hi def link pythonOperator		Operator
 hi def link pythonException		Exception
 hi def link pythonInclude		Include
 hi def link pythonAsync			Statement
+hi def link pythonClassVar		Identifier
 hi def link pythonDecorator		Define
 hi def link pythonDecoratorName		Function
 hi def link pythonClass			Structure


### PR DESCRIPTION
These are special names by convention, and giving them distinct highlighting is a nice visual cue (using Identifier by default).

This group is named 'pythonClassVar' to match the name used by python-syntax. Some third-party color schemes are aware of this name and customized their colors accordingly.