### PR TITLE
Added calendar plugin

### DIFF
--- a/runtime/pack/dist/opt/calendar/autoload/calendar.vim
+++ b/runtime/pack/dist/opt/calendar/autoload/calendar.vim
@@ -1,0 +1,1286 @@
+vim9script
+
+if !exists("g:calendar_mark")
+ || (g:calendar_mark != 'left'
+ && g:calendar_mark != 'left-fit'
+ && g:calendar_mark != 'right')
+  g:calendar_mark = 'left'
+endif
+if !exists("g:calendar_navi")
+ || (g:calendar_navi != 'top'
+ && g:calendar_navi != 'bottom'
+ && g:calendar_navi != 'both'
+ && g:calendar_navi != '')
+  g:calendar_navi = 'top'
+endif
+if !exists("g:calendar_navi_label")
+  g:calendar_navi_label = "Prev, Today, Next"
+endif
+if !exists("g:calendar_diary_list_curr_idx")
+  g:calendar_diary_list_curr_idx = 0
+endif
+if !exists("g:calendar_diary")
+  if exists("g:calendar_diary_list") && len(g:calendar_diary_list) > 0
+      && g:calendar_diary_list_curr_idx >= 0
+      && g:calendar_diary_list_curr_idx < len(g:calendar_diary_list)
+    g:calendar_diary = g:calendar_diary_list[g:calendar_diary_list_curr_idx].path
+    g:calendar_diary_extension = g:calendar_diary_list[g:calendar_diary_list_curr_idx].ext
+  else
+    g:calendar_diary = "~/diary"
+  endif
+endif
+if !exists("g:calendar_focus_today")
+  g:calendar_focus_today = 0
+endif
+if !exists("g:calendar_datetime")
+ || (g:calendar_datetime != ''
+ && g:calendar_datetime != 'title'
+ && g:calendar_datetime != 'statusline')
+  g:calendar_datetime = 'title'
+endif
+if !exists("g:calendar_options")
+  g:calendar_options = "fdc=0 nonu"
+  if has("+relativenumber") || exists("+relativenumber")
+    g:calendar_options ..= " nornu"
+  endif
+endif
+if !exists("g:calendar_filetype")
+  g:calendar_filetype = "markdown"
+endif
+if !exists("g:calendar_diary_extension")
+    g:calendar_diary_extension = ".md"
+endif
+if !exists("g:calendar_search_grepprg")
+  g:calendar_search_grepprg = "grep"
+endif
+
+
+#*****************************************************************
+#* Default Calendar key bindings
+#*****************************************************************
+var calendar_keys = {
+ close: 'q',
+ do_action: '<CR>',
+ goto_today: 't',
+ show_help: '?',
+ redisplay: 'r',
+ goto_next_month: '<RIGHT>',
+ goto_prev_month: '<LEFT>',
+ goto_next_year: '<UP>',
+ goto_prev_year: '<DOWN>',
+}
+
+if exists("g:calendar_keys") && typename(g:calendar_keys) == 'dict<string>'
+   extend(calendar_keys, g:calendar_keys)
+endif
+
+var bufautocommandsset = false
+var fridaycol = 0
+var saturdaycol = 0
+#*****************************************************************
+#* CalendarClose : close the calendar
+#*----------------------------------------------------------------
+#*****************************************************************
+def Close()
+  bw!
+enddef
+
+#*****************************************************************
+#* CalendarDoAction : call the action handler function
+#*----------------------------------------------------------------
+#*****************************************************************
+def Action(arg: string = '')
+  # for switch calendar list.
+  var text = getline(".")
+  var curl = line(".")
+  if text =~ "^( )"
+    var list_idx = 0
+    curl -= 1
+    while curl > 1
+      if getline(curl) =~ "^([\* ])"
+        list_idx += 1
+        curl -= 1
+      else
+        g:calendar_diary_list_curr_idx = list_idx
+        g:calendar_diary = g:calendar_diary_list[list_idx].path
+        g:calendar_diary_extension = g:calendar_diary_list[list_idx].ext
+        Show(b:CalendarDir, b:CalendarYear, b:CalendarMonth)
+        return
+      endif
+    endwhile
+  endif
+
+  # for navi
+  if exists('g:calendar_navi')
+    var navi = !empty(arg) ? arg : expand("<cWORD>")
+    curl = line(".")
+    var curp = getpos(".")
+    if navi == $"<{get(split(g:calendar_navi_label, ', '), 0, '')}"
+      if b:CalendarMonth > 1
+        Show(b:CalendarDir, b:CalendarYear, b:CalendarMonth - 1)
+      else
+        Show(b:CalendarDir, b:CalendarYear - 1, 12)
+      endif
+    elseif navi == $"{get(split(g:calendar_navi_label, ', '), 2, '')}>"
+      if b:CalendarMonth < 12
+        Show(b:CalendarDir, b:CalendarYear, b:CalendarMonth + 1)
+      else
+        Show(b:CalendarDir, b:CalendarYear + 1, 1)
+      endif
+    elseif navi == get(split(g:calendar_navi_label, ', '), 1, '')
+      Show(b:CalendarDir)
+      if exists('g:calendar_today')
+        var CalendarToday = function(g:calendar_today)
+        CalendarToday()
+      endif
+    elseif navi == 'NextYear'
+      Show(b:CalendarDir, b:CalendarYear + 1, b:CalendarMonth)
+      setpos('.', curp)
+      return
+    elseif navi == 'PrevYear'
+      Show(b:CalendarDir, b:CalendarYear - 1, b:CalendarMonth)
+      setpos('.', curp)
+      return
+    else
+      navi = ''
+    endif
+    if navi != ''
+      if g:calendar_focus_today == 1 && search("\*", "w") > 0
+        silent execute "normal! gg/\*\<cr>"
+        return
+      else
+        if curl < line('$') / 2
+          silent execute $"normal! gg0/{navi}\<cr>"
+        else
+          silent execute $"normal! G$?{navi}\<cr>"
+        endif
+        return
+      endif
+    endif
+  endif
+
+  var dir = ''
+  var cnr = 0
+  var week = 0
+  if b:CalendarDir == 0 || b:CalendarDir == 3
+    dir = 'V'
+    cnr = 1
+    week = ((col(".") + 1) / 3) - 1
+  elseif b:CalendarDir == 1
+    dir = 'H'
+    if exists('g:calendar_weeknm')
+      cnr = col('.') - (col('.') % (24 + 5)) + 1
+    else
+      cnr = col('.') - (col('.') % (24)) + 1
+    endif
+    week = ((col(".") - cnr - 1 + cnr / 49) / 3)
+  elseif b:CalendarDir == 2
+    dir = 'T'
+    cnr = 1
+    week = ((col(".") + 1) / 3) - 1
+  endif
+  var lnr = 1
+  var hdr = 1
+  var sline = ''
+  while 1
+    if lnr > line('.')
+      break
+    endif
+    sline = getline(lnr)
+    if sline =~ '^\s*$'
+      hdr = lnr + 1
+    endif
+    lnr = lnr + 1
+  endwhile
+  lnr = line('.')
+
+  if exists('g:calendar_monday') && g:calendar_monday
+    week = week + 1
+  elseif week == 0
+    week = 7
+  endif
+  if lnr - hdr < 2
+    return
+  endif
+
+  sline = substitute(strpart(getline(hdr), cnr, 21), '\s*\(.*\)\s*', '\1', '')
+  var day = ''
+  if b:CalendarDir != 2
+    if (col(".") - cnr) > 21
+      return
+    endif
+
+    # extract day
+    if g:calendar_mark == 'right' && col('.') > 1
+      normal! h
+      day = matchstr(expand("<cword>"), '[^0].*')
+      normal! l
+    else
+      day = matchstr(expand("<cword>"), '[^0].*')
+    endif
+  else
+    var c = string(col('.'))
+    day = ''
+    var lnum = line('.')
+    var cursorchar = getline(lnum)[col('.') - 1]
+    while day == '' && lnum > 2 && cursorchar != '-' && cursorchar != '+'
+      day = matchstr(getline(lnum), '^.*|\zs[^|]\{-}\%' .. c .. 'c[^|]\{-}\ze|.*$')
+            ->matchstr('\d\+')
+      lnum = lnum - 1
+      cursorchar = getline(lnum)[col('.') - 1]
+    endwhile
+  endif
+  if day == ''
+    return
+  endif
+
+  # extract year and month
+  var year = -2000
+  var month = 99
+  if exists('g:calendar_erafmt') && g:calendar_erafmt !~ "^\s*$"
+    year = str2nr(matchstr(substitute(sline, '/.*', '', ''), '\d\+'))
+    month = str2nr(matchstr(substitute(sline, '.*/\(\d\d\=\).*', '\1', ""), '[^0].*'))
+    if g:calendar_erafmt =~ '.*, [+-]*\d\+'
+      var veranum = substitute(g:calendar_erafmt, '.*, \([+-]*\d\+\)', '\1', '')->str2nr()
+      if year - veranum > 0
+        year = year - veranum
+      endif
+    endif
+  else
+    year  = str2nr(matchstr(substitute(sline, '/.*', '', ''), '[^0].*'))
+    month = str2nr(matchstr(substitute(sline, '\d*/\(\d\d\=\).*', '\1', ""), '[^0].*'))
+  endif
+  # call the action function
+  call(CalendarAction, [str2nr(day), month, year, week, dir])
+enddef
+
+#*****************************************************************
+#* Calendar : build calendar
+#*----------------------------------------------------------------
+#*   a1 : direction (mandatory)
+#*   a2 : month(if given a3, it's year)
+#*   a3 : if given, it's month
+#*****************************************************************
+export def Show(a1: number, a2: number = -1, a3: number = -1): string # TODO
+
+  #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  #+++ ready for build
+  #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  # remember today
+  # divide strftime('%d') by 1 so as to get "1,2,3 .. 9" instead of "01, 02, 03 .. 09"
+  var vtoday = $'{strftime('%Y')}{strftime('%m')}{strftime('%d')}'
+
+  # get arguments
+  var dir = a1
+  var vyear = str2nr(strftime('%Y'))
+  var vmnth = str2nr(matchstr(strftime('%m'), '[^0].*'))
+  if a2 != -1 && a3 == -1
+    vmnth = a2
+  elseif a2 != -1 && a3 != -1
+    vyear = a2
+    vmnth = a3
+  endif
+
+  # remember constant
+  var vmnth_org: number = vmnth
+  var vyear_org: number = vyear
+
+  if dir != 2
+    # start with last month
+    vmnth = vmnth - 1
+    if vmnth < 1
+      vmnth = 12
+      vyear = vyear - 1
+    endif
+  endif
+
+  # reset display variables
+  var vdisplay1 = ''
+  var vdisplay2 = ''
+  var vheight = 1
+
+  #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  #+++ build display
+  #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  if exists("g:calendar_begin")
+    var CalendarBegin = function(g:calendar_begin)
+    CalendarBegin()
+  endif
+
+  var vmcntmax = 1
+  var whitehrz = ''
+  var whiteleft = ''
+  var whitevrt = ''
+  var width = 0
+  var height = 0
+  var whitevrtweeknm = ''
+  var vwruler = "Su Mo Tu We Th Fr Sa"
+  var borderhrz = ''
+  if dir == 2
+    if !exists('b:CalendarDir') && !(bufname('%') == '' && !&modified)
+      width = &columns
+      height = &lines - 2
+    else
+      width = winwidth(0)
+      height = winheight(0)
+    endif
+    var hrz = width / 8 - 5
+    if hrz < 0
+      hrz = 0
+    endif
+    var h = 0
+    while h < hrz
+      whitehrz = $'{whitehrz} '
+      h = h + 1
+    endwhile
+    whitehrz = $'{whitehrz}|'
+    var navifix = exists('g:calendar_navi') && g:calendar_navi == 'both' ? 2 : 0
+    var vrt = (height - &cmdheight - 3 - navifix) / 6 - 2
+    if vrt < 0
+      vrt = 0
+    endif
+    var whitevrta = ''
+    if whitehrz == '|'
+      whitevrta = whitehrz
+    else
+      whitevrta = whitehrz[1 : ]
+    endif
+    h = 0
+    var leftmargin = (width - (strlen(whitehrz) + 3) * 7 - 1) / 2
+    while h < leftmargin
+      whiteleft = $'{whiteleft} '
+      h = h + 1
+    endwhile
+    h = 0
+    while h < vrt
+      whitevrt = $"{whitevrt}\n{whiteleft}|"
+      var i = 0
+      while i < 7
+        whitevrt = $"{whitevrt}   {whitehrz}"
+        i = i + 1
+      endwhile
+      h = h + 1
+    endwhile
+    whitevrt = $"{whitevrt}\n"
+    var whitevrt2 = $"{whiteleft}+"
+    h = 0
+    borderhrz = $"---{substitute(substitute(whitehrz, ' ', '-', 'g'), '|', '+', '')}"
+    while h < 7
+      whitevrt2 = $"{whitevrt2}{borderhrz}"
+      h = h + 1
+    endwhile
+    whitevrtweeknm = $"{whitevrt}{whitevrt2}\n"
+    whitevrt = $"{whitevrta}{whitevrt}{whitevrt2}\n"
+    fridaycol = (strlen(whitehrz) + 3) * 5 + strlen(whiteleft) + 1
+    saturdaycol = (strlen(whitehrz) + 3) * 6 + strlen(whiteleft) + 1
+  else
+    vmcntmax = get(g:, 'calendar_number_of_months', 3)
+  endif
+
+  # Init variables for while loop
+  var vcolumn = 22
+  var vnweek = -1
+  var vmdays = 0
+  var vparam = 0
+  var vsmnth = ''
+
+  var vmcnt = 0
+  while vmcnt < vmcntmax
+    vwruler = "Su Mo Tu We Th Fr Sa"
+    vcolumn = 22
+    vnweek = -1
+    vmdays = 0
+    vparam = 0
+    vsmnth = ''
+    #--------------------------------------------------------------
+    #--- calculating
+    #--------------------------------------------------------------
+    # set boundary of the month
+    if vmnth == 1
+      vmdays = 31
+      vparam = 1
+      vsmnth = 'Jan'
+    elseif vmnth == 2
+      vmdays = 28
+      vparam = 32
+      vsmnth = 'Feb'
+    elseif vmnth == 3
+      vmdays = 31
+      vparam = 60
+      vsmnth = 'Mar'
+    elseif vmnth == 4
+      vmdays = 30
+      vparam = 91
+      vsmnth = 'Apr'
+    elseif vmnth == 5
+      vmdays = 31
+      vparam = 121
+      vsmnth = 'May'
+    elseif vmnth == 6
+      vmdays = 30
+      vparam = 152
+      vsmnth = 'Jun'
+    elseif vmnth == 7
+      vmdays = 31
+      vparam = 182
+      vsmnth = 'Jul'
+    elseif vmnth == 8
+      vmdays = 31
+      vparam = 213
+      vsmnth = 'Aug'
+    elseif vmnth == 9
+      vmdays = 30
+      vparam = 244
+      vsmnth = 'Sep'
+    elseif vmnth == 10
+      vmdays = 31
+      vparam = 274
+      vsmnth = 'Oct'
+    elseif vmnth == 11
+      vmdays = 30
+      vparam = 305
+      vsmnth = 'Nov'
+    elseif vmnth == 12
+      vmdays = 31
+      vparam = 335
+      vsmnth = 'Dec'
+    else
+      echo 'Invalid Year or Month'
+      return ''
+    endif
+    var vleap = false
+    if vyear % 400 == 0
+      vleap = true
+      if vmnth == 2
+        vmdays = 29
+      elseif vmnth >= 3
+        vparam = vparam + 1
+      endif
+    elseif vyear % 100 == 0
+      if vmnth == 2
+        vmdays = 28
+      endif
+    elseif vyear % 4 == 0
+      vleap = true
+      if vmnth == 2
+        vmdays = 29
+      elseif vmnth >= 3
+        vparam = vparam + 1
+      endif
+    endif
+
+    # calc vnweek of the day
+    if vnweek == -1
+      vnweek = ( vyear * 365 ) + vparam
+      vnweek = vnweek + ( vyear / 4 ) - ( vyear / 100 ) + ( vyear / 400 )
+      if vleap
+        vnweek = vnweek - 1
+      endif
+      vnweek = vnweek - 1
+    endif
+
+    # fix Gregorian
+    if vyear <= 1752
+      vnweek = vnweek - 3
+    endif
+
+    vnweek = vnweek % 7
+
+    if exists('g:calendar_monday') && g:calendar_monday
+      # if given g:calendar_monday, the week start with monday
+      if vnweek == 0
+        vnweek = 7
+      endif
+      vnweek = vnweek - 1
+    endif
+
+    var vfweek = 0
+    var vfweekl = 0
+    var viweek = 0
+    if exists('g:calendar_weeknm')
+      # if given g:calendar_weeknm, show week number(ref:ISO8601)
+
+      #vparam <= 1. day of month
+      #vnweek <= 1. weekday of month (0-6)
+      #viweek <= number of week
+      #vfweek <= 1. day of year
+
+      # Mon Tue Wed Thu Fri Sat Sun
+      # 6   5   4   3   2   1   0  vfweek
+      # 0   1   2   3   4   5   6  vnweek
+
+      vfweek = ((vparam % 7)  - vnweek + 14 - 2) % 7
+      viweek = (vparam - vfweek - 2 + 7 ) / 7 + 1
+
+      if vfweek < 3
+        viweek = viweek - 1
+      endif
+
+      #vfweekl  <=year length
+      vfweekl = 52
+      if vfweek == 3 || (vfweek == 4 && vleap)
+        vfweekl = 53
+      endif
+
+      if viweek == 0
+        #belongs to last week number of previous year
+        viweek = 52
+        vleap = ((vyear - 1) % 4 == 0 &&
+          ((vyear - 1) % 100 != 0 || (vyear - 1) % 400 == 0))
+        if vfweek == 2 || (vfweek == 1 && vleap)
+          viweek = 53
+        endif
+      endif
+
+      vcolumn = vcolumn + 5
+      if g:calendar_weeknm == 5
+        vcolumn = vcolumn - 2
+      endif
+    endif
+
+    #--------------------------------------------------------------
+    #--- displaying
+    #--------------------------------------------------------------
+    # build header
+    if exists('g:calendar_erafmt') && g:calendar_erafmt !~ "^\s*$"
+      if g:calendar_erafmt =~ '.*, [+-]*\d\+'
+        var veranum = str2nr(substitute(g:calendar_erafmt, '.*, \([+-]*\d\+\)', '\1', ''))
+        if vyear + veranum > 0
+          vdisplay2 = substitute(g:calendar_erafmt, '\(.*\), .*', '\1', '')
+          vdisplay2 = $"{vdisplay2}{string(vyear + veranum)}/{string(vmnth)}("
+        else
+          vdisplay2 = $"{string(vyear)}/{string(vmnth)}("
+        endif
+      else
+        vdisplay2 = $"{string(vyear)}/{string(vmnth)}("
+      endif
+      vdisplay2 = strpart("                           ",
+        1, (vcolumn - strlen(vdisplay2)) / 2 - 2) .. vdisplay2
+    else
+      vdisplay2 = $"{string(vyear)}/{string(vmnth)}("
+      vdisplay2 = strpart("                           ",
+        1, (vcolumn - strlen(vdisplay2)) / 2 - 2) .. vdisplay2
+    endif
+
+    if exists('g:calendar_mruler') && g:calendar_mruler !~ "^\s*$"
+      vdisplay2 = $"{vdisplay2}{get(split(g:calendar_mruler, ', '), vmnth - 1, '')})\n"
+    else
+      vdisplay2 = $"{vdisplay2}{vsmnth})\n"
+    endif
+
+    if exists('g:calendar_wruler') && g:calendar_wruler !~ "^\s*$"
+      vwruler = g:calendar_wruler
+    endif
+
+    if exists('g:calendar_monday') && g:calendar_monday
+      vwruler = $"{strpart(vwruler, stridx(vwruler, ' ') + 1)} "
+        .. strpart(vwruler, 0, stridx(vwruler, ' '))
+    endif
+
+    if dir == 2
+      var whiteruler = substitute(substitute(whitehrz, ' ', '_', 'g'), '__', '  ', '')
+      vwruler = $"| {substitute(vwruler, ' ', whiteruler .. ' ', 'g')}{whiteruler}"
+      vdisplay2 = $"{vdisplay2}{whiteleft}{vwruler}\n"
+    else
+      vdisplay2 = $"{vdisplay2} {vwruler}\n"
+    endif
+
+    if g:calendar_mark == 'right' && dir != 2
+      vdisplay2 = $"{vdisplay2} "
+    endif
+
+    # build calendar
+    var vinpcur = 0
+    while (vinpcur < vnweek)
+      if dir == 2
+        if vinpcur % 7 != 0
+          vdisplay2 = $"{vdisplay2}{whitehrz}"
+        else
+          vdisplay2 = $"{vdisplay2}{whiteleft}|"
+        endif
+      endif
+      vdisplay2 = $"{vdisplay2}   "
+      vinpcur = vinpcur + 1
+    endwhile
+
+    var vdaycur = 1
+    while (vdaycur <= vmdays)
+      if dir == 2
+        if vinpcur % 7 != 0
+          vdisplay2 = $"{vdisplay2}{whitehrz}"
+        else
+          vdisplay2 = $"{vdisplay2}{whiteleft}|"
+        endif
+      endif
+      var vtarget = ''
+      if vmnth < 10
+        vtarget = $"{string(vyear)}0{string(vmnth)}"
+      else
+        vtarget = $"{string(vyear)}{string(vmnth)}"
+      endif
+      if vdaycur < 10
+        vtarget = $"{vtarget}0{vdaycur}"
+      else
+        vtarget = $"{vtarget}{vdaycur}"
+      endif
+      # TODO: what is tried to achieve? --------------------
+      # if exists("g:calendar_sign") && g:calendar_sign != ""
+      #   exe "let vsign = " . g:calendar_sign . "(vdaycur, vmnth, vyear)"
+      #   if vsign != ""
+      #     let vsign = vsign[0]
+      #     if vsign !~ "[+!#$%&@?]"
+      #       let vsign = "+"
+      #     endif
+      #   endif
+      # else
+      #   let vsign = ''
+      # endif
+      # ----------------------------------------------------
+      #
+      # Vim9 patch
+      var vsign = Sign(vdaycur, vmnth, vyear) ? '+' : ''
+
+      # show mark
+      if g:calendar_mark == 'right'
+        if vdaycur < 10
+          vdisplay2 = $"{vdisplay2} "
+        endif
+        vdisplay2 = $"{vdisplay2}{vdaycur}"
+      elseif g:calendar_mark == 'left-fit'
+        if vdaycur < 10
+          vdisplay2 = $"{vdisplay2} "
+        endif
+      endif
+
+      if vtarget == vtoday
+        vdisplay2 = $"{vdisplay2}*"
+      elseif vsign != ''
+        vdisplay2 = $"{vdisplay2}{vsign}"
+      else
+        vdisplay2 = $"{vdisplay2} "
+      endif
+      if g:calendar_mark == 'left'
+        if vdaycur < 10
+          vdisplay2 = $"{vdisplay2} "
+        endif
+        vdisplay2 = $"{vdisplay2}{vdaycur}"
+      endif
+      if g:calendar_mark == 'left-fit'
+        vdisplay2 = $"{vdisplay2}{vdaycur}"
+      endif
+      vdaycur = vdaycur + 1
+
+      # fix Gregorian
+      if vyear == 1752 && vmnth == 9 && vdaycur == 3
+        vdaycur = 14
+      endif
+
+      vinpcur = vinpcur + 1
+      if vinpcur % 7 == 0
+        if exists('g:calendar_weeknm')
+          if dir == 2
+            vdisplay2 = $"{vdisplay2}{whitehrz}"
+          endif
+          if g:calendar_mark != 'right'
+            vdisplay2 = $"{vdisplay2} "
+          endif
+          # if given g:calendar_weeknm, show week number
+          if viweek < 10
+            if g:calendar_weeknm == 1
+              vdisplay2 = $"{vdisplay2}WK0{viweek}"
+            elseif g:calendar_weeknm == 2
+              vdisplay2 = $"{vdisplay2}WK {viweek}"
+            elseif g:calendar_weeknm == 3
+              vdisplay2 = $"{vdisplay2}KW0{viweek}"
+            elseif g:calendar_weeknm == 4
+              vdisplay2 = $"{vdisplay2}KW {viweek}"
+            elseif g:calendar_weeknm == 5
+              vdisplay2 = $"{vdisplay2} {viweek}"
+            endif
+          else
+            if g:calendar_weeknm <= 2
+              vdisplay2 = $"{vdisplay2}WK{viweek}"
+            elseif g:calendar_weeknm == 3 || g:calendar_weeknm == 4
+              vdisplay2 = $"{vdisplay2}KW{viweek}"
+            elseif g:calendar_weeknm == 5
+              vdisplay2 = $"{vdisplay2}{viweek}"
+            endif
+          endif
+          viweek = viweek + 1
+
+          if viweek > vfweekl
+            viweek = 1
+          endif
+
+        endif
+        vdisplay2 = $"{vdisplay2}\n"
+        if g:calendar_mark == 'right' && dir != 2
+          vdisplay2 = $"{vdisplay2} "
+        endif
+      endif
+    endwhile
+
+    # if it is needed, fill with space
+    if vinpcur % 7 != 0
+      while (vinpcur % 7 != 0)
+        if dir == 2
+          vdisplay2 = $"{vdisplay2}{whitehrz}"
+        endif
+        vdisplay2 = $"{vdisplay2}   "
+        vinpcur = vinpcur + 1
+      endwhile
+      if exists('g:calendar_weeknm')
+        if dir == 2
+          vdisplay2 = $"{vdisplay2}{whitehrz}"
+        endif
+        if g:calendar_mark != 'right'
+          vdisplay2 = $"{vdisplay2} "
+        endif
+        if viweek < 10
+          if g:calendar_weeknm == 1
+            vdisplay2 = $"{vdisplay2}WK0{viweek}"
+          elseif g:calendar_weeknm == 2
+            vdisplay2 = $"{vdisplay2}WK{viweek}"
+          elseif g:calendar_weeknm == 3
+            vdisplay2 = $"{vdisplay2}KW0{viweek}"
+          elseif g:calendar_weeknm == 4
+            vdisplay2 = $"{vdisplay2}KW{viweek}"
+          elseif g:calendar_weeknm == 5
+            vdisplay2 = $"{vdisplay2} {viweek}"
+          endif
+        else
+          if g:calendar_weeknm <= 2
+            vdisplay2 = $"{vdisplay2}WK{viweek}"
+          elseif g:calendar_weeknm == 3 || g:calendar_weeknm == 4
+            vdisplay2 = $"{vdisplay2}KW{viweek}"
+          elseif g:calendar_weeknm == 5
+            vdisplay2 = $"{vdisplay2}{viweek}"
+          endif
+        endif
+      endif
+    endif
+
+    # build display
+    var vstrline = ''
+    var vtokline = 1
+    var vtoken1 = ''
+    var vtoken2 = ''
+    if dir == 1
+      # for horizontal
+      #--------------------------------------------------------------
+      # +---+   +---+   +------+
+      # |   |   |   |   |      |
+      # | 1 | + | 2 | = |  1'  |
+      # |   |   |   |   |      |
+      # +---+   +---+   +------+
+      #--------------------------------------------------------------
+      while 1
+        vtoken1 = get(split(vdisplay1, "\n"), vtokline - 1, '')
+        vtoken2 = get(split(vdisplay2, "\n"), vtokline - 1, '')
+        if vtoken1 == '' && vtoken2 == ''
+          break
+        endif
+        while strlen(vtoken1) < (vcolumn + 1) * vmcnt
+          if strlen(vtoken1) % (vcolumn + 1) == 0
+            vtoken1 = $"{vtoken1}|"
+          else
+            vtoken1 = $"{vtoken1} "
+          endif
+        endwhile
+        vstrline = $"{vstrline}{vtoken1}|{vtoken2} \n"
+        vtokline = vtokline + 1
+      endwhile
+      vdisplay1 = vstrline
+      vheight = vtokline - 1
+    elseif (dir == 0 || dir == 3)
+      # for vertical
+      #--------------------------------------------------------------
+      # +---+   +---+   +---+
+      # | 1 | + | 2 | = |   |
+      # +---+   +---+   | 1'|
+      #                 |   |
+      #                 +---+
+      #--------------------------------------------------------------
+      vtokline = 1
+      while 1
+        vtoken1 = get(split(vdisplay1, "\n"), vtokline - 1, '')
+        if vtoken1 == ''
+          break
+        endif
+        vstrline = $"{vstrline}{vtoken1}\n"
+        vtokline = vtokline + 1
+        vheight = vheight + 1
+      endwhile
+      if vstrline != ''
+        vstrline = $"{vstrline} \n"
+        vheight = vheight + 1
+      endif
+      vtokline = 1
+      while 1
+        vtoken2 = get(split(vdisplay2, "\n"), vtokline - 1, '')
+        if vtoken2 == ''
+          break
+        endif
+        while strlen(vtoken2) < vcolumn
+          vtoken2 = $"{vtoken2} "
+        endwhile
+        vstrline = $"{vstrline}{vtoken2}\n"
+        vtokline = vtokline + 1
+        vheight = vtokline + 1
+      endwhile
+      vdisplay1 = vstrline
+    else
+      vtokline = 1
+      while 1
+        vtoken1 = get(split(vdisplay1, "\n"), vtokline - 1, '')
+        vtoken2 = get(split(vdisplay2, "\n"), vtokline - 1, '')
+        if vtoken1 == '' && vtoken2 == ''
+          break
+        endif
+        while strlen(vtoken1) < (vcolumn + 1) * vmcnt
+          if strlen(vtoken1) % (vcolumn + 1) == 0
+            vtoken1 = $"{vtoken1}|"
+          else
+            vtoken1 = $"{vtoken1} "
+          endif
+        endwhile
+        var vright = ''
+        if vtokline > 2
+          if exists('g:calendar_weeknm')
+            vright = whitevrtweeknm
+          elseif whitehrz == '|'
+            vright = whitevrt
+          else
+            vright = $" {whitevrt}"
+          endif
+        else
+          vright = "\n"
+        endif
+        vstrline = $"{vstrline}{vtoken1}{vtoken2}{vright}"
+        vtokline = vtokline + 1
+      endwhile
+      vdisplay1 = vstrline
+      vheight = vtokline - 1
+    endif
+
+    vmnth = vmnth + 1
+    vmcnt = vmcnt + 1
+    if vmnth > 12
+      vmnth = 1
+      vyear = vyear + 1
+    endif
+  endwhile
+
+  if exists("g:calendar_end")
+    var CalendarEnd = function(g:calendar_end)
+    CalendarEnd()
+  endif
+  if a1 == -1 && empty(a2) && empty(a3)
+    return vdisplay1
+  endif
+
+  var diary_list = ''
+  if exists("g:calendar_diary_list") && len(g:calendar_diary_list) > 0
+    vdisplay1 = $"{vdisplay1}\nCalendar\n{repeat("-", vcolumn)}"
+    var diary_index = 0
+    for diary in g:calendar_diary_list
+      if diary_index == g:calendar_diary_list_curr_idx
+        diary_list = $"(*) {diary["name"]}"
+        diary_list = $"\n{diary_list}{repeat(' ', vcolumn - len(diary_list))}"
+      else
+        diary_list = $"( ) {diary["name"]}"
+        diary_list = $"\n{diary_list}{repeat(' ', vcolumn - len(diary_list))}"
+      endif
+      vdisplay1 = $"{vdisplay1}{diary_list}"
+      diary_index = diary_index + 1
+    endfor
+  endif
+
+  #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  #+++ build window
+  #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  # make window
+  var vwinnum = bufnr('__Calendar')
+  if getbufvar(vwinnum, 'Calendar') == 'Calendar'
+    vwinnum = bufwinnr(vwinnum)
+  else
+    vwinnum = - 1
+  endif
+
+  if vwinnum >= 0
+    # if already exist
+    if vwinnum != bufwinnr('%')
+      exe $"{vwinnum}wincmd w"
+    endif
+    setlocal modifiable
+    deletebufline('%', 1, '$')
+  else
+    # make title
+    if g:calendar_datetime == "title" && !bufautocommandsset
+      auto BufEnter *Calendar b:sav_titlestring = &titlestring | &titlestring = '%{strftime("%c")}'
+      auto BufLeave *Calendar if exists('b:sav_titlestring') | &titlestring = b:sav_titlestring | endif
+      bufautocommandsset = true
+    endif
+
+    if exists('g:calendar_navi') && !empty(dir)
+      if g:calendar_navi == 'both'
+        vheight = vheight + 4
+      else
+        vheight = vheight + 2
+      endif
+    endif
+
+    # or not
+    if dir == 1
+      silent execute $"bo :{vheight}split __Calendar"
+      setlocal winfixheight
+    elseif dir == 0
+      silent execute $"to :{vcolumn}vsplit __Calendar"
+      setlocal winfixwidth
+    elseif dir == 3
+      silent execute $"bo :{vcolumn}vsplit __Calendar"
+      setlocal winfixwidth
+    elseif bufname('%') == '' && !&modified
+      silent execute 'edit __Calendar'
+    else
+      silent execute 'tabnew __Calendar'
+    endif
+    CalendarBuildKeymap(dir, vyear, vmnth)
+    setlocal noswapfile
+    setlocal buftype=nofile
+    setlocal bufhidden=delete
+    silent! exe $"setlocal {g:calendar_options}"
+    var nontext_columns = &nu ? &foldcolumn + &numberwidth : &foldcolumn
+    if has("+relativenumber") || exists("+relativenumber")
+      nontext_columns += &rnu ? &numberwidth : 0
+    endif
+    # Without this, the 'sidescrolloff' setting may cause the left side of the
+    # calendar to disappear if the last inserted element is near the right
+    # window border.
+    setlocal nowrap
+    setlocal norightleft
+    setlocal modifiable
+    setlocal nolist
+    b:Calendar = 'Calendar'
+    setlocal filetype=calendar
+    # is this a vertical (0) or a horizontal (1) split?
+    if dir != 2
+      exe $":{vcolumn + nontext_columns}:wincmd |"
+    endif
+  endif
+  if g:calendar_datetime == "statusline"
+    setlocal statusline=%{strftime('%c')}
+  endif
+  b:CalendarDir = dir
+  b:CalendarYear = vyear_org
+  b:CalendarMonth = vmnth_org
+
+  # navi
+  var navcol = 0
+  if exists('g:calendar_navi')
+    var navi_label = '<'
+      .. $"{get(split(g:calendar_navi_label, ', '), 0, '')} "
+      .. $"{get(split(g:calendar_navi_label, ', '), 1, '')} "
+      .. $"{get(split(g:calendar_navi_label, ', '), 2, '')}> "
+    if dir == 1
+      navcol = vcolumn + (vcolumn - strlen(navi_label) + 2) / 2
+    elseif (dir == 0 || dir == 3)
+      navcol = (vcolumn - strlen(navi_label) + 2) / 2
+    else
+      navcol = (width - strlen(navi_label)) / 2
+    endif
+    if navcol < 3
+      navcol = 3
+    endif
+
+    if g:calendar_navi == 'top'
+      execute $"normal gg{navcol}i "
+      silent exec $"normal! a{navi_label}\<cr>\<cr>"
+      silent put! = vdisplay1
+    endif
+    if g:calendar_navi == 'bottom'
+      silent put! = vdisplay1
+      silent exec "normal! Gi\<cr>"
+      silent execute $"normal {navcol}i "
+      silent exec $"normal! a{navi_label}"
+    endif
+    if g:calendar_navi == 'both'
+      execute $"normal gg{navcol}i "
+      silent exec $"normal! a{navi_label}\<cr>\<cr>"
+      silent put! = vdisplay1
+      silent exec "normal! Gi\<cr>"
+      silent execute $"normal {navcol}i "
+      silent exec $"normal! a{navi_label}"
+    endif
+  else
+    silent put! = vdisplay1
+  endif
+
+  setlocal nomodifiable
+  # In case we've gotten here from insert mode (via <C-O>:Calendar<CR>)...
+  stopinsert
+
+  vyear = vyear_org
+  vmnth = vmnth_org
+
+  #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  #+++ build highlight
+  #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  # today
+  syn clear
+  if g:calendar_mark =~ 'left-fit'
+    syn match CalToday display "\s*\*\d*"
+    syn match CalMemo display "\s*[+!#$%&@?]\d*"
+  elseif g:calendar_mark =~ 'right'
+    syn match CalToday display "\d*\*\s*"
+    syn match CalMemo display "\d*[+!#$%&@?]\s*"
+  else
+    syn match CalToday display "\*\s*\d*"
+    syn match CalMemo display "[+!#$%&@?]\s*\d*"
+  endif
+  # header
+  syn match CalHeader display "[^ ]*\d\+\/\d\+([^)]*)"
+
+  # navi
+  if exists('g:calendar_navi')
+    exec "syn match CalNavi display \"\\(<"
+      .. get(split(g:calendar_navi_label, ', '), 0, '') .. "\\|"
+      .. get(split(g:calendar_navi_label, ', '), 2, '') .. ">\\)\""
+    exec 'syn match CalNavi display "\s'
+      .. get(split(g:calendar_navi_label, ', '), 1, '') .. '\s"hs=s+1,he=e-1'
+  endif
+
+  # saturday, sunday
+  if exists('g:calendar_monday') && g:calendar_monday
+    if dir == 1
+      syn match CalSaturday display /|.\{15}\s\([0-9\ ]\d\)/hs=e-1 contains=ALL
+      syn match CalSunday display /|.\{18}\s\([0-9\ ]\d\)/hs=e-1 contains=ALL
+    elseif (dir == 0 || dir == 3)
+      syn match CalSaturday display /^.\{15}\s\([0-9\ ]\d\)/hs=e-1 contains=ALL
+      syn match CalSunday display /^.\{18}\s\([0-9\ ]\d\)/hs=e-1 contains=ALL
+    else
+      exec printf('syn match CalSunday display /^.\{%d}\s\?\([0-9\ ]\d\)/hs=e-1 contains=ALL', fridaycol)
+      exec printf('syn match CalSaturday display /^.\{%d}\s\?\([0-9\ ]\d\)/hs=e-1 contains=ALL', saturdaycol)
+    endif
+  else
+    if dir == 1
+      syn match CalSaturday display /|.\{18}\s\([0-9\ ]\d\)/hs=e-1 contains=ALL
+      syn match CalSunday display /|\s\([0-9\ ]\d\)/hs=e-1 contains=ALL
+    elseif (dir == 0 || dir == 3)
+      syn match CalSaturday display /^.\{18}\s\([0-9\ ]\d\)/hs=e-1 contains=ALL
+      syn match CalSunday display /^\s\([0-9\ ]\d\)/hs=e-1 contains=ALL
+    else
+      exec printf('syn match CalSaturday display /^.\{%d}\s\?\([0-9\ ]\d\)/hs=e-1 contains=ALL', saturdaycol)
+      syn match CalSunday display /^\s*|\s*\([0-9\ ]\d\)/hs=e-1 contains=ALL
+    endif
+  endif
+
+  syn match CalCurrList display "^(\*).*$"
+
+  # week number
+  if !exists('g:calendar_weeknm') || g:calendar_weeknm <= 2
+    syn match CalWeeknm display "WK[0-9\ ]\d"
+  else
+    syn match CalWeeknm display "KW[0-9\ ]\d"
+  endif
+
+  # ruler
+  execute $'syn match CalRuler "{vwruler}"'
+
+  if search("\*", "w") > 0
+    silent execute "normal! gg/\*\<cr>"
+  endif
+
+  # --+--
+  if dir == 2
+    exec "syn match CalNormal display " string(borderhrz)
+    exec "syn match CalNormal display " string($'^{whiteleft}+')
+  endif
+
+  return ''
+enddef
+
+# #*****************************************************************
+# #* Make_dir : make directory
+# #*----------------------------------------------------------------
+# #*   dir : directory
+# #*****************************************************************
+def MakeDir(dir: string): number
+  var rc: number = 0
+  if (has("unix"))
+    system($"mkdir {dir}")
+    rc = v:shell_error
+  elseif (has("win16") || has("win32") || has("win95") ||
+      has("dos16") || has("dos32") || has("os2"))
+    system($"mkdir \"{dir}\"")
+    rc = v:shell_error
+  else
+    rc = 1
+  endif
+  if rc != 0
+    confirm($"can't create directory: {dir}", "&OK")
+  endif
+  return rc
+enddef
+
+# #*****************************************************************
+# #* diary : calendar hook function
+# #*----------------------------------------------------------------
+# #*   day   : day you actioned
+# #*   month : month you actioned
+# #*   year  : year you actioned
+# #*****************************************************************
+def Diary(day: number, month: number, year: number, week: number, dir: string)
+  # build the file name and create directories as needed
+  if !isdirectory(expand(g:calendar_diary))
+    confirm("please create diary directory: {g:calendar_diary}", 'OK')
+    return
+  endif
+  var sfile = $"{expand(g:calendar_diary)}/{printf("%04d", year)}"
+  if isdirectory(sfile) == 0
+    if MakeDir(sfile) != 0
+      return
+    endif
+  endif
+  sfile = $"{sfile}/{printf("%02d", month)}"
+  if isdirectory(sfile) == 0
+    if MakeDir(sfile) != 0
+      return
+    endif
+  endif
+  sfile = $'{expand(sfile)}/{printf("%02d", day)}{g:calendar_diary_extension}'
+  sfile = substitute(sfile, ' ', '\\ ', 'g')
+  var vbufnr = bufnr('__Calendar')
+
+  # load the file
+  exe "wincmd w"
+  exe $"edit  {sfile}"
+  exe $"setfiletype {g:calendar_filetype}"
+  var folder = getbufvar(vbufnr, "CalendarDir")
+  var vyear = getbufvar(vbufnr, "CalendarYear")
+  var vmnth = getbufvar(vbufnr, "CalendarMonth")
+  exe $"auto BufDelete {escape(sfile, ' \\')} Show({folder}, {vyear}, {vmnth})"
+enddef
+
+var CalendarAction = function("Diary")
+if exists("g:calendar_action")
+  CalendarAction = function(g:calendar_action)
+endif
+
+# #*****************************************************************
+# #* sign : calendar sign function
+# #*----------------------------------------------------------------
+# #*   day   : day of sign
+# #*   month : month of sign
+# #*   year  : year of sign
+# #*****************************************************************
+def Sign(day: number, month: number, year: number): bool
+  var sfile = $'{g:calendar_diary}/{printf("%04d", year)}/{printf("%02d", month)}/'
+   .. $'{printf("%02d", day)}{g:calendar_diary_extension}'
+  return filereadable(expand(sfile))
+enddef
+
+var CalendarSign = function("Sign")
+if exists("g:calendar_sign")
+  CalendarSign = function(g:calendar_sign)
+endif
+
+#*****************************************************************
+#* CalendarBuildKeymap : build keymap
+#*----------------------------------------------------------------
+#*****************************************************************
+def CalendarBuildKeymap(dir: number, vyear: number, vmnth: number)
+# make keymap
+nnoremap <silent> <buffer> <Plug>CalendarClose <ScriptCmd>Close()<cr>
+nnoremap <silent> <buffer> <Plug>CalendarDoAction <ScriptCmd>Action()<cr>
+nnoremap <silent> <buffer> <Plug>CalendarDoAction <ScriptCmd>Action()<cr>
+nnoremap <silent> <buffer> <Plug>CalendarGotoToday <ScriptCmd>Show(b:CalendarDir)<cr>
+nnoremap <silent> <buffer> <Plug>CalendarShowHelp <ScriptCmd>CalendarHelp()<cr>
+execute $'nnoremap <silent> <buffer> <Plug>CalendarReDisplay <ScriptCmd>Show({dir}, {vyear}, {vmnth})<cr>'
+var pnav = get(split(g:calendar_navi_label, ', '), 0, '')
+var nnav = get(split(g:calendar_navi_label, ', '), 2, '')
+execute $'nnoremap <silent> <buffer> <Plug>CalendarGotoPrevMonth <ScriptCmd>Action("<{pnav}")<cr>'
+execute $'nnoremap <silent> <buffer> <Plug>CalendarGotoNextMonth <ScriptCmd>Action("{nnav}>")<cr>'
+execute 'nnoremap <silent> <buffer> <Plug>CalendarGotoPrevYear <ScriptCmd>Action("PrevYear")<cr>'
+execute 'nnoremap <silent> <buffer> <Plug>CalendarGotoNextYear <ScriptCmd>Action("NextYear")<cr>'
+
+nmap <buffer> <2-LeftMouse> <Plug>CalendarDoAction
+
+execute $'nmap <buffer> {calendar_keys['close']} <Plug>CalendarClose'
+execute $'nmap <buffer> {calendar_keys['do_action']} <Plug>CalendarDoAction'
+execute $'nmap <buffer> {calendar_keys['goto_today']} <Plug>CalendarGotoToday'
+execute $'nmap <buffer> {calendar_keys['show_help']} <Plug>CalendarShowHelp'
+execute $'nmap <buffer> {calendar_keys['redisplay']} <Plug>CalendarRedisplay'
+
+execute $'nmap <buffer> {calendar_keys['goto_next_month']} <Plug>CalendarGotoNextMonth'
+execute $'nmap <buffer> {calendar_keys['goto_prev_month']} <Plug>CalendarGotoPrevMonth'
+execute $'nmap <buffer> {calendar_keys['goto_next_year']} <Plug>CalendarGotoNextYear'
+execute $'nmap <buffer> {calendar_keys['goto_prev_year']} <Plug>CalendarGotoPrevYear'
+enddef
+
+# #*****************************************************************
+# #* CalendarHelp : show help for Calendar
+# #*----------------------------------------------------------------
+# #*****************************************************************
+def CalendarHelp()
+  var ck = calendar_keys
+  var max_width = values(ck)->mapnew((_, val) => len(val))->max()
+  var offsets = ck->mapnew((_, val) => 1 + max_width - len(val))
+
+  echohl SpecialKey
+  echo $"{ck['goto_prev_month']}{repeat(' ', offsets['goto_prev_month'])}': goto prev month'"
+  echo $"{ck['goto_next_month']}{repeat(' ', offsets['goto_next_month'])}': goto next month'"
+  echo $"{ck['goto_prev_year']}{repeat(' ', offsets['goto_prev_year'])}': goto prev year'"
+  echo $"{ck['goto_next_year']}{repeat(' ', offsets['goto_next_year'])}': goto next year'"
+  echo $"{ck['goto_today']}{repeat(' ', offsets['goto_today'])}': goto today'"
+  echo $"{ck['close']}{repeat(' ', offsets['close'])}': close window'"
+  echo $"{ck['redisplay']}{repeat(' ', offsets['redisplay'])}': re-display window'"
+  echo $"{ck['show_help']}{repeat(' ', offsets['show_help'])}': show this help'"
+  if CalendarAction == function("Diary")
+    echo $"{ck['do_action']}{repeat(' ', offsets['do_action'])}': show diary'"
+  endif
+  echo ''
+  echohl Question
+
+  var vk = [
+    'calendar_erafmt',
+    'calendar_mruler',
+    'calendar_wruler',
+    'calendar_weeknm',
+    'calendar_navi_label',
+    'calendar_diary',
+    'calendar_mark',
+    'calendar_navi',
+  ]
+  max_width = max(map(copy(vk), 'len(v:val)'))
+
+  for v in vk
+    var vv = get(g:, v, '')
+    echo $"{v}{repeat(' ', max_width - len(v))} = {vv}"
+  endfor
+  echohl MoreMsg
+  echo "[Hit any key]"
+  echohl None
+  getchar()
+  redraw!
+enddef
+
+export def Search(keyword: string)
+  if g:calendar_search_grepprg == "internal"
+    exe $"vimgrep /{keyword}/{escape(g:calendar_diary, " ")}/**/*{g:calendar_diary_extension}|cw"
+  else
+    silent execute $"{g:calendar_search_grepprg} '{keyword}' {escape(g:calendar_diary, ' ')}/**/*{g:calendar_diary_extension}"
+    silent execute "cw"
+  endif
+enddef
+
+hi def link CalNavi     Search
+hi def link CalSaturday Type
+hi def link CalSunday   Statement
+hi def link CalRuler    StatusLine
+hi def link CalWeeknm   Comment
+hi def link CalToday    Directory
+hi def link CalHeader   Special
+hi def link CalMemo     Identifier
+hi def link CalNormal   Normal
+hi def link CalCurrList Error

--- a/runtime/pack/dist/opt/calendar/doc/calendar.txt
+++ b/runtime/pack/dist/opt/calendar/doc/calendar.txt
@@ -1,0 +1,257 @@
+*calendar.txt* Calendar utility for vim
+
+Author:  Yasuhiro Matsumoto <mattn.jp@gmail.com>
+
+INTRODUCTION                                    *calendar*
+
+This script creates a calendar window in vim.  It does not rely on any
+external program, such as cal, etc.
+
+COMMANDS                                        *calendar-commands*
+
+calendar.vim makes the following commands available:
+
+                                                *calendar-:Calendar*
+:Calendar [[year], month] Show calendar at this year and this month in a
+                          vertical split.  When [year] is omitted, the
+                          calendar will show the given month in the current
+                          year.  When both [year] and [month] are omitted, the
+                          calendar will show the current month.
+
+                                                *calendar-:CalendarH*
+:CalendarH [[year], month] Show calendar at this year and this month in a
+                          horizontal split.  When [year] is omitted, the
+                          calendar will show the given month in the current
+                          year.  When both [year] and [month] are omitted, the
+                          calendar will show the current month.
+
+                                                *calendar-:CalendarT*
+:CalendarT [[year], month] Show calendar at this year and this month in a
+                          full-screen window.  When [year] is omitted, the
+                          calendar will show the given month in the current
+                          year.  When both [year] and [month] are omitted, the
+                          calendar will show the current month.
+
+                                                *calendar-:CalendarVR*
+:CalendarVR [[year], month] Show calendar at this year and this month in a
+                          vertical split at the right site.  When [year] is
+                          omitted, the calendar will show the given month in
+                          the current year.  When both [year] and [month] are
+                          omitted, the calendar will show the current month.
+
+                                            *calendar-:CalendarSearch*
+:CalendarSearch [keyword]  Search keyword in current calendar diary book.
+
+
+MAPPINGS                                        *calendar-mappings*
+
+calendar.vim makes the following normal mode mappings available:
+
+                                                *calendar-cal*
+<LocalLeader>cal          Brings up the calendar in a vertical split.
+                          Equivalent to calling |:Calendar|.
+
+                                                *calendar-caL*
+<LocalLeader>caL          Brings up the calendar in a horizontal split.
+                          Equivalent to calling |:CalendarH|.
+
+SETTINGS                                        *calendar-settings*
+
+calendar.vim can be configured using the following settings:
+
+                                                *g:calendar_no_mappings*
+Disable default mappings:
+  g:calendar_no_mappings=0
+
+                                                *g:calendar_focus_today*
+Keeps focus when moving to next or previous calendar: >
+  g:calendar_focus_today = true
+<
+
+                                                *g:calendar_keys*
+To change the key bindings in the calendar window, add entries to this
+dictionary.   Possible keys, the action bound to the keycode given in the
+respective value for this key and the default binding are listed below.
+close                     Closes calendar window.             'q'
+do_action                 Executes |calendar_action|.           '<CR>'
+goto_today                Executes |calendar_today|.            't'
+show_help                 Displays a short help message.      '?'
+redisplay                 Redraws calendar window.            'r'
+goto_next_month           Jumps to the next month.            '<Right>'
+goto_prev_month           Jumps to the previous month.        '<Left>'
+goto_next_year            Jumps to the next year.             '<Up>'
+goto_prev_year            Jumps to the previous year.         '<Down>'
+An example in your .vimrc might look like this: >
+  g:calendar_keys = {goto_next_month: '<C-Right>', goto_prev_month: '<C-Left>'}
+<
+
+                                                *g:calendar_mark*
+Place a '*' or '+' mark after the day.  Acceptable values are 'left',
+'left-fit', and 'right': >
+  g:calendar_mark = 'right'
+<
+
+                                                *g:calendar_diary*
+Specify the directory for the diary files.  The default value is $HOME/diary. >
+  g:calendar_diary=$HOME.'/.vim/diary'
+<
+
+                                           *g:calendar_diary_list*
+Specify multiple diary configurations. >
+  g:calendar_diary_list = [
+       {'name': 'Note', 'path': $HOME.'/note', 'ext': '.md'},
+       {'name': 'Diary', 'path': $HOME.'/diary', 'ext': '.diary.md'},
+     ]
+<
+
+                                  *g:calendar_diary_list_curr_idx*
+Specify multiple diary default configuration. The default value is 0. >
+  g:calendar_diary_list_curr_idx = 1
+<
+
+                                                *g:calendar_navi*
+To control the calendar navigator, set this variable.  Acceptable values are
+'top', 'bottom', or 'both'. >
+  g:calendar_navi = ''
+<
+
+                                                *g:calendar_navi_label*
+To set the labels for the calendar navigator, for example to change the
+language, use this variable.  Entries should be comma separated. >
+  g:calendar_navi_label = 'Prev, Today, Next'
+<
+
+                                                *g:calendar_erafmt*
+To change the dating system, set the following variable.  Include the name of
+the dating system and its offset from the Georgian calendar (A.D.).  For
+example, to use the current Japanese era (Heisei), you would set: >
+  g:calendar_erafmt = 'Heisei,-1988'
+<
+
+                                                *g:calendar_mruler*
+To change the month names for the calendar headings, set this variable.  The
+value is expected to be a comma-separated list of twelve values, starting with
+January: >
+  g:calendar_mruler = 'Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct, Nov, Dec'
+<
+
+                                                *g:calendar_wruler*
+To change the week names for the calendar headings, set this variable.  The
+value is expected to be a space-separated list of seven values, starting with
+Sunday: >
+  g:calendar_wruler = 'Su Mo Tu We Th Fr Sa'
+<
+
+                                                *g:calendar_monday*
+To make the week start on Monday rather than Sunday, set this variable.  Note
+that the value of |g:calendar_wruler| is not affected by this; it should
+always begin with Sunday: >
+  g:calendar_monday = true
+<
+
+                                                *g:calendar_weeknm*
+To show the week number, set this variable.  There are four valid settings: >
+  g:calendar_weeknm = 1 # WK01
+  g:calendar_weeknm = 2 # WK 1
+  g:calendar_weeknm = 3 # KW01
+  g:calendar_weeknm = 4 # KW 1
+  g:calendar_weeknm = 5 # 1
+<
+
+                                                *g:calendar_datetime*
+To control display of the current date and time, set this variable.
+Acceptable values are 'title', 'statusline', and '': >
+  g:calendar_datetime = 'title'
+<
+                                                *g:calendar_filetype*
+To control the filetype of calendar entries, set this variable. It defaults to
+'markdown'. Acceptable values are values that are acceptable for |filetype|
+like e.g. 'markdown' or 'pandoc':
+  let g:calendar_filetype = 'pandoc'
+
+                                                *g:calendar_number_of_months*
+To control the number of months per view, set this variable. The default value
+is 3. >
+  g:calendar_number_of_months = 5
+<
+
+                                                *g:calendar_search_grepprg*
+To set the command |:CalendarSearch| grepprg config. default value is 'grep',
+using system default grep program. If you want use Vim internal grep command
+|:vimgrep|, set value to 'internal'. >
+  g:calendar_search_grepprg = 'internal'
+<
+
+HOOKS                                           *calendar-hooks*
+
+calendar.vim provides a number of hooks which allow you to run custom code on
+certain events.  These are documented below.
+
+                                                *g:calendar_action*
+The function declared in the |g:calendar_action| variable is run when the user
+presses enter on a date.  Implement and set your function as follows: >
+  def g:MyCalAction(day,month,year,week,dir)
+    # day   : day you actioned
+    # month : month you actioned
+    # year  : year you actioned
+    # week  : day of week (Mo=1 ... Su=7)
+    # dir   : direction of calendar
+  enddef
+  g:calendar_action = 'g:MyCalAction'
+<
+
+                                                *g:calendar_begin*
+The function declared in the |g:calendar_begin| variable is run just before the
+calendar is displayed.  Implement and set your function as follows: >
+  def g:MyCalBegin()
+    echo "Calendar open"
+  enddef
+  g:calendar_begin = 'g:MyCalBegin'
+<
+
+                                                *g:calendar_end*
+The function declared in the calendar_end variable is run just after the
+calendar is displayed.  Implement and set your function as follows: >
+  def g:MyCalEnd()
+    echo "Calendar close"
+  enddef
+  g:calendar_end = 'g:MyCalEnd'
+<
+
+                                                *g:calendar_sign*
+The function declared in the |g:calendar_sign| variable can be used to set a mark
+next to certain dates.  Implement and set your function as follows: >
+  def g:MyCalSign(day: number, month: number, year:number)
+    # day   : day you actioned
+    # month : month you actioned
+    # year  : year you actioned
+    if day == 1 && month == 1
+      return 1 " happy new year
+    else
+      return 0 " or not
+    endif
+  enddef
+  g:calendar_sign = 'g:MyCalSign'
+<
+
+                                                *g:calendar_today*
+The function declared in the calendar_today variable is run when the user
+presses Today on the navigation panel.  
+Implement and set your function as follows: >
+  def g:MyCalToday()
+    echo "Today!"
+  enddef
+  g:calendar_today = 'g:MyCalToday'
+<
+
+ABOUT                                           *calendar-about*
+
+The original calendar.vim in Vim legacy language is available on GitHub:
+
+  http://github.com/mattn/calendar-vim
+
+and also on VimScripts:
+
+  http://www.vim.org/scripts/script.php?script_id=52
+
+vim:tw=78:et:ft=help:norl:

--- a/runtime/pack/dist/opt/calendar/plugin/calendar.vim
+++ b/runtime/pack/dist/opt/calendar/plugin/calendar.vim
@@ -1,0 +1,241 @@
+vim9script
+
+#=============================================================================
+# What Is This: Calendar
+# File: calendar.vim
+# Author: Yasuhiro Matsumoto <mattn.jp@gmail.com>
+# Last Change: 2025 Aug 10
+# Version: 2.9 TODO ???
+# Thanks:
+#     Ubaldo Tiberi                 : porting to Vim9
+#     Tobias Columbus               : customizable key bindings
+#     Daniel P. Wright              : doc/calendar.txt
+#     SethMilliken                  : gave a hint for 2.4
+#     bw1                           : bug fix, new weeknm format
+#     Ingo Karkat                   : bug fix
+#     Thinca                        : bug report, bug fix
+#     Yu Pei                        : bug report
+#     Per Winkvist                  : bug fix
+#     Serge (gentoosiast) Koksharov : bug fix
+#     Vitor Antunes                 : bug fix
+#     Olivier Mengue                : bug fix
+#     Noel Henson                   : today action
+#     Per Winkvist                  : bug report
+#     Peter Findeisen               : bug fix
+#     Chip Campbell                 : gave a hint for 1.3z
+#     PAN Shizhu                    : gave a hint for 1.3y
+#     Eric Wald                     : bug fix
+#     Sascha Wuestemann             : advise
+#     Linas Vasiliauskas            : bug report
+#     Per Winkvist                  : bug report
+#     Ronald Hoelwarth              : gave a hint for 1.3s
+#     Vikas Agnihotri               : bug report
+#     Steve Hall                    : gave a hint for 1.3q
+#     James Devenish                : bug fix
+#     Carl Mueller                  : gave a hint for 1.3o
+#     Klaus Fabritius               : bug fix
+#     Stucki                        : gave a hint for 1.3m
+#     Rosta                         : bug report
+#     Richard Bair                  : bug report
+#     Yin Hao Liew                  : bug report
+#     Bill McCarthy                 : bug fix and gave a hint
+#     Srinath Avadhanula            : bug fix
+#     Ronald Hoellwarth             : few advices
+#     Juan Orlandini                : added higlighting of days with data
+#     Ray                           : bug fix
+#     Ralf.Schandl                  : gave a hint for 1.3
+#     Bhaskar Karambelkar           : bug fix
+#     Suresh Govindachar            : gave a hint for 1.2, bug fix
+#     Michael Geddes                : bug fix
+#     Leif Wickland                 : bug fix
+# ChangeLog:
+#     2.8  : bug fix
+#     2.7  : vim7ish, customizable key bindings
+#     2.6  : new week number format
+#     2.5  : bug fix, 7.2 don't have relativenumber.
+#     2.4  : added g:calendar_options.
+#     2.3  : week number like ISO8601
+#            g:calendar_monday and g:calendar_weeknm work together
+#     2.2  : http://gist.github.com/355513#file_customizable_keymap.diff
+#            http://gist.github.com/355513#file_winfixwidth.diff
+#     2.1  : bug fix, set filetype 'calendar'.
+#     2.0  : bug fix, many bug fix and enhancements.
+#     1.9  : bug fix, use nnoremap.
+#     1.8  : bug fix, E382 when close diary.
+#     1.7  : bug fix, week number was broken on 2008.
+#     1.6  : added calendar_begin action.
+#            added calendar_end action.
+#     1.5  : bug fix, fixed ruler formating with strpart.
+#            bug fix, using winfixheight.
+#     1.4a : bug fix, week number was broken on 2005.
+#            added calendar_today action.
+#            bug fix, about wrapscan.
+#            bug fix, about today mark.
+#            bug fix, about today navigation.
+#     1.4  : bug fix, and one improvement.
+#            bug 1:
+#              when marking the current date, there is not distinguished e.g. between
+#              20041103 and 20040113, both dates are marked as today
+#            bug 2:
+#              the navigation mark "today" doesn't work
+#            improvement:
+#              the mapping t worked only when today was displayed, now it works always
+#              and redisplays the cuurent month and today
+#     1.3z : few changes
+#            asign <Left>, <Right> for navigation.
+#            set ws for search navigation.
+#            add tag for GetLatestVimScripts(AutoInstall)
+#     1.3y : bug fix, few changes
+#            changed color syntax name. (ex. CalNavi, see bottom of this)
+#            changed a map CalendarV for <Leader>cal
+#            changed a map CalendarH for <Leader>caL
+#            (competitive map for cvscommand.vim)
+#            the date on the right-hand side didn't work correctoly.
+#            make a map to rebuild Calendar window(r).
+#     1.3x : bug fix
+#            viweek can't refer when not set calendar_weeknm.
+#     1.3w : bug fix
+#            on leap year, week number decreases.
+#     1.3v : bug fix
+#            add nowrapscan
+#            use s:bufautocommandsset for making title
+#            don't focus to navi when doubleclick bottom next>.
+#     1.3u : bug fix
+#             when enter diary first time,
+#              it don't warn that you don't have diary directory.
+#     1.3t : bug fix
+#             make sure the variables for help
+#     1.3s : bug fix
+#             make a map CalendarV for <Leader>ca
+#            add option calendar_navi_label
+#             see Additional:
+#            add option calendar_focus_today
+#             see Additional:
+#            add map ? for help
+#     1.3r : bug fix
+#             if clicked navigator, cursor go to strange position.
+#     1.3q : bug fix
+#             coundn't set calendar_navi
+#              in its horizontal direction
+#     1.3p : bug fix
+#             coundn't edit diary when the calendar is
+#              in its horizontal direction
+#     1.3o : add option calendar_mark, and delete calendar_rmark
+#             see Additional:
+#            add option calendar_navi
+#             see Additional:
+#     1.3n : bug fix
+#             s:CalendarSign() should use filereadable(expand(sfile)).
+#     1.3m : tuning
+#             using topleft or botright for opening Calendar.
+#            use filereadable for s:CalendarSign().
+#     1.3l : bug fix
+#             if set calendar_monday, it can see that Sep 1st is Sat
+#               as well as Aug 31st.
+#     1.3k : bug fix
+#             it didn't escape the file name on calendar.
+#     1.3j : support for fixed Gregorian
+#             added the part of Sep 1752.
+#     1.3i : bug fix
+#             Calculation mistake for week number.
+#     1.3h : add option for position of displaying '*' or '+'.
+#             see Additional:
+#     1.3g : centering header
+#            add option for show name of era.
+#             see Additional:
+#            bug fix
+#             <Leader>ca didn't show current month.
+#     1.3f : bug fix
+#            there was yet another bug of today's sign.
+#     1.3e : added usage for <Leader>
+#            support handler for sign.
+#            see Additional:
+#     1.3d : added higlighting of days that have calendar data associated
+#             with it.
+#            bug fix for calculates date.
+#     1.3c : bug fix for MakeDir()
+#            if CalendarMakeDir(sfile) != 0
+#               v
+#            if s:CalendarMakeDir(sfile) != 0
+#     1.3b : bug fix for calendar_monday.
+#            it didn't work g:calendar_monday correctly.
+#            add g:calendar_version.
+#            add argument on action handler.
+#            see Additional:
+#     1.3a : bug fix for MakeDir().
+#            it was not able to make directory.
+#     1.3  : support handler for action.
+#            see Additional:
+#     1.2g : bug fix for today's sign.
+#            it could not display today's sign correctly.
+#     1.2f : bug fix for current Date.
+#            vtoday variable calculates date as 'YYYYMMDD'
+#            while the loop calculates date as 'YYYYMMD' i.e just 1 digit
+#            for date if < 10 so if current date is < 10 , the if condiction
+#            to check for current date fails and current date is not
+#            highlighted.
+#            simple solution changed vtoday calculation line divide the
+#            current-date by 1 so as to get 1 digit date.
+#     1.2e : change the way for setting title.
+#            auto configuration for g:calendar_wruler with g:calendar_monday
+#     1.2d : add option for show week number.
+#              let g:calendar_weeknm = 1
+#            add separator if horizontal.
+#            change all option's name
+#              g:calendar_mnth -> g:calendar_mruler
+#              g:calendar_week -> g:calendar_wruler
+#              g:calendar_smnd -> g:calendar_monday
+#     1.2c : add option for that the week starts with monday.
+#              let g:calendar_smnd = 1
+#     1.2b : bug fix for modifiable.
+#            setlocal nomodifiable (was set)
+#     1.2a : add default options.
+#            nonumber,foldcolumn=0,nowrap... as making gap
+#     1.2  : support wide display.
+#            add a command CalendarH
+#            add map <s-left> <s-right>
+#     1.1c : extra.
+#            add a titlestring for today.
+#     1.1b : bug fix by Michael Geddes.
+#            it happend when do ':Calender' twice
+#     1.1a : fix misspell.
+#            Calender -> Calendar
+#     1.1  : bug fix.
+#            it"s about strftime("%m")
+#     1.0a : bug fix by Leif Wickland.
+#            it"s about strftime("%w")
+#     1.0  : first release.
+# TODO:
+#     add the option for diary which is separate or single file.
+
+# *****************************************************************
+# * Calendar commands
+# *****************************************************************
+
+if exists('g:loaded_calendar') && g:loaded_calendar
+  finish
+endif
+g:loaded_calendar = true
+
+import autoload "../autoload/calendar.vim"
+
+command! -nargs=* Calendar  calendar.Show(0, <args>)
+command! -nargs=* CalendarVR  calendar.Show(3, <args>)
+command! -nargs=* CalendarH calendar.Show(1, <args>)
+command! -nargs=* CalendarT calendar.Show(2, <args>)
+
+command! -nargs=* CalendarSearch calendar.Search("<args>")
+
+if !get(g:, 'calendar_no_mappings', false)
+  if !hasmapto('<Plug>CalendarV')
+    nmap <unique> <Leader>cal <Plug>CalendarV
+  endif
+  if !hasmapto('<Plug>CalendarH')
+    nmap <unique> <Leader>caL <Plug>CalendarH
+  endif
+endif
+nnoremap <silent> <Plug>CalendarV <ScriptCmd>calendar.Show(0)<CR>
+nnoremap <silent> <Plug>CalendarH <ScriptCmd>calendar.Show(1)<CR>
+nnoremap <silent> <Plug>CalendarT <ScriptCmd>calendar.Show(2)<CR>
+
+# vi: et sw=2 ts=2

--- a/src/testdir/Make_all.mak
+++ b/src/testdir/Make_all.mak
@@ -242,6 +242,7 @@ NEW_TESTS = \
 	test_partial \
 	test_paste \
 	test_perl \
+	test_plugin_calendar \
 	test_plugin_comment \
 	test_plugin_glvs \
 	test_plugin_helptoc \
@@ -515,6 +516,7 @@ NEW_TESTS_RES = \
 	test_partial.res \
 	test_paste.res \
 	test_perl.res \
+	test_plugin_calendar.res \
 	test_plugin_comment.res \
 	test_plugin_glvs.res \
 	test_plugin_helptoc.res \

--- a/src/testdir/test_plugin_calendar.vim
+++ b/src/testdir/test_plugin_calendar.vim
@@ -1,0 +1,677 @@
+" Test for the calendar plugin.
+" Some features are not tested, like CalendarT since it depends on the screen 
+" resolution and the screen size. The same for the test 
+
+
+packadd calendar
+
+func Test_calendar_basic()
+
+  Calendar 1998, 10
+  call WaitForAssert({-> assert_equal(2, winnr('$'))})
+
+  " Check the current layout should be something like: ['row', [['leaf', 1000], ['leaf', 1003]]]
+  let expected_value = 'row'
+  call assert_equal(expected_value, winlayout()[0])
+  let expected_value = 2
+  call assert_equal(expected_value, len(winlayout()))
+  call assert_equal(expected_value, len(winlayout()[1]))
+
+  " Check October 1998
+  let expected_value =<< END
+   <Prev Today Next> 
+
+     1998/9(Sep)      
+ Su Mo Tu We Th Fr Sa 
+        1  2  3  4  5 
+  6  7  8  9 10 11 12 
+ 13 14 15 16 17 18 19 
+ 20 21 22 23 24 25 26 
+ 27 28 29 30          
+ 
+     1998/10(Oct)     
+ Su Mo Tu We Th Fr Sa 
+              1  2  3 
+  4  5  6  7  8  9 10 
+ 11 12 13 14 15 16 17 
+ 18 19 20 21 22 23 24 
+ 25 26 27 28 29 30 31 
+ 
+     1998/11(Nov)     
+ Su Mo Tu We Th Fr Sa 
+  1  2  3  4  5  6  7 
+  8  9 10 11 12 13 14 
+ 15 16 17 18 19 20 21 
+ 22 23 24 25 26 27 28 
+ 29 30                
+
+END
+  call assert_equal(expected_value, getline(1, '$'))
+
+  " Move to next page
+  exe "norm \<right>"
+
+  let expected_value_right =<< END
+   <Prev Today Next> 
+
+     1998/10(Oct)     
+ Su Mo Tu We Th Fr Sa 
+              1  2  3 
+  4  5  6  7  8  9 10 
+ 11 12 13 14 15 16 17 
+ 18 19 20 21 22 23 24 
+ 25 26 27 28 29 30 31 
+ 
+     1998/11(Nov)     
+ Su Mo Tu We Th Fr Sa 
+  1  2  3  4  5  6  7 
+  8  9 10 11 12 13 14 
+ 15 16 17 18 19 20 21 
+ 22 23 24 25 26 27 28 
+ 29 30                
+ 
+     1998/12(Dec)     
+ Su Mo Tu We Th Fr Sa 
+        1  2  3  4  5 
+  6  7  8  9 10 11 12 
+ 13 14 15 16 17 18 19 
+ 20 21 22 23 24 25 26 
+ 27 28 29 30 31       
+
+END
+  call assert_equal(expected_value_right, getline(1, '$'))
+
+  " Move back to the previous page
+  exe "norm \<left>"
+  call assert_equal(expected_value, getline(1, '$'))
+
+  " Close calendar
+  exe "norm q"
+  call assert_equal(1, winnr('$'))
+
+  %bw!
+endfunc
+
+func Test_calendarH_basic()
+
+  CalendarH 2020, 2
+  call WaitForAssert({-> assert_equal(2, winnr('$'))})
+
+  " Check the current layout should be something like: ['col', [['leaf', 1000], ['leaf', 1003]]]
+  let expected_value = 'col'
+  call assert_equal(expected_value, winlayout()[0])
+  let expected_value = 2
+  call assert_equal(expected_value, len(winlayout()))
+  call assert_equal(expected_value, len(winlayout()[1]))
+
+  " Check February 2020 (Covid time!)
+  let expected_value =<< END
+                         <Prev Today Next> 
+
+|     2020/1(Jan)      |     2020/2(Feb)      |     2020/3(Mar) 
+| Su Mo Tu We Th Fr Sa | Su Mo Tu We Th Fr Sa | Su Mo Tu We Th Fr Sa 
+|           1  2  3  4 |                    1 |  1  2  3  4  5  6  7 
+|  5  6  7  8  9 10 11 |  2  3  4  5  6  7  8 |  8  9 10 11 12 13 14 
+| 12 13 14 15 16 17 18 |  9 10 11 12 13 14 15 | 15 16 17 18 19 20 21 
+| 19 20 21 22 23 24 25 | 16 17 18 19 20 21 22 | 22 23 24 25 26 27 28 
+| 26 27 28 29 30 31    | 23 24 25 26 27 28 29 | 29 30 31             
+
+END
+  call assert_equal(expected_value, getline(1, '$'))
+
+  " Move to next page
+  exe "norm \<right>"
+
+  let expected_value_right =<< END
+                         <Prev Today Next> 
+
+|     2020/2(Feb)      |     2020/3(Mar)      |     2020/4(Apr) 
+| Su Mo Tu We Th Fr Sa | Su Mo Tu We Th Fr Sa | Su Mo Tu We Th Fr Sa 
+|                    1 |  1  2  3  4  5  6  7 |           1  2  3  4 
+|  2  3  4  5  6  7  8 |  8  9 10 11 12 13 14 |  5  6  7  8  9 10 11 
+|  9 10 11 12 13 14 15 | 15 16 17 18 19 20 21 | 12 13 14 15 16 17 18 
+| 16 17 18 19 20 21 22 | 22 23 24 25 26 27 28 | 19 20 21 22 23 24 25 
+| 23 24 25 26 27 28 29 | 29 30 31             | 26 27 28 29 30       
+
+END
+  call assert_equal(expected_value_right, getline(1, '$'))
+
+  " Move back to the previous page
+  exe "norm \<left>"
+  call assert_equal(expected_value, getline(1, '$'))
+
+  " Close calendar
+  exe "norm q"
+  call assert_equal(1, winnr('$'))
+
+  %bw!
+endfunc
+
+func Test_calendarVR_basic()
+  " OBS: this test is identical to Test_calendar_basic()
+
+  CalendarVR 1998, 10
+  call WaitForAssert({-> assert_equal(2, winnr('$'))})
+
+  " Check the current layout should be something like: ['row', [['leaf', 1000], ['leaf', 1003]]]
+  let expected_value = 'row'
+  call assert_equal(expected_value, winlayout()[0])
+  let expected_value = 2
+  call assert_equal(expected_value, len(winlayout()))
+  call assert_equal(expected_value, len(winlayout()[1]))
+
+  " Check October 1998
+  let expected_value =<< END
+   <Prev Today Next> 
+
+     1998/9(Sep)      
+ Su Mo Tu We Th Fr Sa 
+        1  2  3  4  5 
+  6  7  8  9 10 11 12 
+ 13 14 15 16 17 18 19 
+ 20 21 22 23 24 25 26 
+ 27 28 29 30          
+ 
+     1998/10(Oct)     
+ Su Mo Tu We Th Fr Sa 
+              1  2  3 
+  4  5  6  7  8  9 10 
+ 11 12 13 14 15 16 17 
+ 18 19 20 21 22 23 24 
+ 25 26 27 28 29 30 31 
+ 
+     1998/11(Nov)     
+ Su Mo Tu We Th Fr Sa 
+  1  2  3  4  5  6  7 
+  8  9 10 11 12 13 14 
+ 15 16 17 18 19 20 21 
+ 22 23 24 25 26 27 28 
+ 29 30                
+
+END
+  call assert_equal(expected_value, getline(1, '$'))
+
+  " Move to next page
+  exe "norm \<right>"
+
+  let expected_value_right =<< END
+   <Prev Today Next> 
+
+     1998/10(Oct)     
+ Su Mo Tu We Th Fr Sa 
+              1  2  3 
+  4  5  6  7  8  9 10 
+ 11 12 13 14 15 16 17 
+ 18 19 20 21 22 23 24 
+ 25 26 27 28 29 30 31 
+ 
+     1998/11(Nov)     
+ Su Mo Tu We Th Fr Sa 
+  1  2  3  4  5  6  7 
+  8  9 10 11 12 13 14 
+ 15 16 17 18 19 20 21 
+ 22 23 24 25 26 27 28 
+ 29 30                
+ 
+     1998/12(Dec)     
+ Su Mo Tu We Th Fr Sa 
+        1  2  3  4  5 
+  6  7  8  9 10 11 12 
+ 13 14 15 16 17 18 19 
+ 20 21 22 23 24 25 26 
+ 27 28 29 30 31       
+
+END
+  call assert_equal(expected_value_right, getline(1, '$'))
+
+  " Move back to the previous page
+  exe "norm \<left>"
+  call assert_equal(expected_value, getline(1, '$'))
+
+  " Close calendar
+  exe "norm q"
+  call assert_equal(1, winnr('$'))
+
+  %bw!
+endfunc
+
+" TODO: help in writing this test
+" func Test_calendarSearch_basic()
+"   " Create file
+"   let year = strftime('%y')
+"   let month = strftime('%m')
+"   let day = strftime('%m')
+
+"   let filename = $"~/diary/{year}/{month}/{day}.md"->fnamemodify(':p')
+
+"   Calendar
+"   call WaitForAssert({-> assert_equal(2, winnr('$'))})
+"   exe "norm \<cr>"
+
+"   norm! iFoo
+"   exe "norm! :wq\<cr>"
+
+"   %bw!
+" endfunc
+
+func Test_config()
+  " test g:calendar_navi
+  let g:calendar_navi = 'both'
+  let g:calendar_navi_label = '<--, |, -->'
+
+  Calendar
+  call WaitForAssert({-> assert_equal(2, winnr('$'))})
+
+  " Check the current layout should be something like: ['row', [['leaf', 1000], ['leaf', 1003]]]
+  let expected_value = 'row'
+  call assert_equal(expected_value, winlayout()[0])
+  let expected_value = 2
+  call assert_equal(expected_value, len(winlayout()))
+  call assert_equal(expected_value, len(winlayout()[1]))
+
+  " Check label both on top and in the bottom
+  let expected_value = '<<-- | -->>'
+  call assert_match(expected_value, trim(getline(1)))
+  call assert_match(expected_value, trim(getline('$')))
+
+  exe "norm q"
+  call assert_equal(1, winnr('$'))
+
+  " test g:calendar_mark
+  let g:calendar_mark = 'right'
+  let today = strftime('%d')
+  let expected_value = $'{today}\*'
+  Calendar
+  call WaitForAssert({-> assert_equal(2, winnr('$'))})
+  call assert_match(matchstr(getline('.'), today), today)
+  exe "norm q"
+  call assert_equal(1, winnr('$'))
+
+  let g:calendar_mark = 'left-fit'
+  let expected_value = $'\*{today}'
+  Calendar
+  call WaitForAssert({-> assert_equal(2, winnr('$'))})
+  call assert_match(matchstr(getline('.'), today), today)
+  exe "norm q"
+  call assert_equal(1, winnr('$'))
+
+  " Test other opts
+  let g:calendar_mruler = 'Gen, Feb, Mar, Apr, Mag, Giu, Lug, Ago, Set, Ott, Nov, Dic'
+  let g:calendar_wruler = 'Do Lu Ma Me Gi Ve Sa'
+  Calendar 2012, 1
+  call WaitForAssert({-> assert_equal(2, winnr('$'))})
+  
+  let expected_value =<< END
+      <<-- | -->> 
+
+     2011/12(Dic)     
+ Do Lu Ma Me Gi Ve Sa 
+              1  2  3 
+  4  5  6  7  8  9 10 
+ 11 12 13 14 15 16 17 
+ 18 19 20 21 22 23 24 
+ 25 26 27 28 29 30 31 
+ 
+     2012/1(Gen)      
+ Do Lu Ma Me Gi Ve Sa 
+  1  2  3  4  5  6  7 
+  8  9 10 11 12 13 14 
+ 15 16 17 18 19 20 21 
+ 22 23 24 25 26 27 28 
+ 29 30 31             
+ 
+     2012/2(Feb)      
+ Do Lu Ma Me Gi Ve Sa 
+           1  2  3  4 
+  5  6  7  8  9 10 11 
+ 12 13 14 15 16 17 18 
+ 19 20 21 22 23 24 25 
+ 26 27 28 29          
+
+      <<-- | -->> 
+END
+  call assert_equal(expected_value, getline(1, '$')) 
+  exe "norm q"
+  call assert_equal(1, winnr('$'))
+  
+  " start from monday
+  let g:calendar_monday = v:true
+  CalendarVR 1990, 4
+
+  let expected_value =<< END
+      <<-- | -->> 
+
+     1990/3(Mar)      
+ Lu Ma Me Gi Ve Sa Do 
+           1  2  3  4 
+  5  6  7  8  9 10 11 
+ 12 13 14 15 16 17 18 
+ 19 20 21 22 23 24 25 
+ 26 27 28 29 30 31    
+ 
+     1990/4(Apr)      
+ Lu Ma Me Gi Ve Sa Do 
+                    1 
+  2  3  4  5  6  7  8 
+  9 10 11 12 13 14 15 
+ 16 17 18 19 20 21 22 
+ 23 24 25 26 27 28 29 
+ 30                   
+ 
+     1990/5(Mag)      
+ Lu Ma Me Gi Ve Sa Do 
+     1  2  3  4  5  6 
+  7  8  9 10 11 12 13 
+ 14 15 16 17 18 19 20 
+ 21 22 23 24 25 26 27 
+ 28 29 30 31          
+
+      <<-- | -->> 
+END
+
+  echom assert_equal(expected_value, getline(1, '$')) 
+  exe "norm q"
+  call assert_equal(1, winnr('$'))
+  
+  
+  let g:calendar_weeknm = 2 " WK 1
+  CalendarVR 1989, 11
+  
+  let expected_value =<< END
+        <<-- | -->> 
+
+       1989/10(Ott)        
+ Lu Ma Me Gi Ve Sa Do      
+                    1 WK39 
+  2  3  4  5  6  7  8 WK40 
+  9 10 11 12 13 14 15 WK41 
+ 16 17 18 19 20 21 22 WK42 
+ 23 24 25 26 27 28 29 WK43 
+ 30 31                WK44 
+ 
+       1989/11(Nov)        
+ Lu Ma Me Gi Ve Sa Do      
+        1  2  3  4  5 WK44 
+  6  7  8  9 10 11 12 WK45 
+ 13 14 15 16 17 18 19 WK46 
+ 20 21 22 23 24 25 26 WK47 
+ 27 28 29 30          WK48 
+ 
+       1989/12(Dic)        
+ Lu Ma Me Gi Ve Sa Do      
+              1  2  3 WK48 
+  4  5  6  7  8  9 10 WK49 
+ 11 12 13 14 15 16 17 WK50 
+ 18 19 20 21 22 23 24 WK51 
+ 25 26 27 28 29 30 31 WK52 
+
+        <<-- | -->> 
+END
+  
+  echom assert_equal(expected_value, getline(1, '$')) 
+  exe "norm q"
+  call assert_equal(1, winnr('$'))
+
+  " multiple months per calendar
+  let g:calendar_number_of_months = 5
+  Calendar 1023, 9
+  call WaitForAssert({-> assert_equal(2, winnr('$'))})
+
+  let expected_value =<< END
+        <<-- | -->> 
+
+        1023/8(Ago)        
+ Lu Ma Me Gi Ve Sa Do      
+     1  2  3  4  5  6 WK31 
+  7  8  9 10 11 12 13 WK32 
+ 14 15 16 17 18 19 20 WK33 
+ 21 22 23 24 25 26 27 WK34 
+ 28 29 30 31          WK35 
+ 
+        1023/9(Set)        
+ Lu Ma Me Gi Ve Sa Do      
+              1  2  3 WK35 
+  4  5  6  7  8  9 10 WK36 
+ 11 12 13 14 15 16 17 WK37 
+ 18 19 20 21 22 23 24 WK38 
+ 25 26 27 28 29 30    WK39 
+ 
+       1023/10(Ott)        
+ Lu Ma Me Gi Ve Sa Do      
+                    1 WK39 
+  2  3  4  5  6  7  8 WK40 
+  9 10 11 12 13 14 15 WK41 
+ 16 17 18 19 20 21 22 WK42 
+ 23 24 25 26 27 28 29 WK43 
+ 30 31                WK44 
+ 
+       1023/11(Nov)        
+ Lu Ma Me Gi Ve Sa Do      
+        1  2  3  4  5 WK44 
+  6  7  8  9 10 11 12 WK45 
+ 13 14 15 16 17 18 19 WK46 
+ 20 21 22 23 24 25 26 WK47 
+ 27 28 29 30          WK48 
+ 
+       1023/12(Dic)        
+ Lu Ma Me Gi Ve Sa Do      
+              1  2  3 WK48 
+  4  5  6  7  8  9 10 WK49 
+ 11 12 13 14 15 16 17 WK50 
+ 18 19 20 21 22 23 24 WK51 
+ 25 26 27 28 29 30 31 WK52 
+
+        <<-- | -->> 
+END
+
+  echom assert_equal(expected_value, getline(1, '$')) 
+  exe "norm q"
+  call assert_equal(1, winnr('$'))
+
+  " eras
+  let g:calendar_erafmt = 'Heisei,-1988'
+
+  Calendar 2000, 1
+  call WaitForAssert({-> assert_equal(2, winnr('$'))})
+  
+  let expected_value =<< END
+        <<-- | -->> 
+
+       1999/12(Dic)        
+ Lu Ma Me Gi Ve Sa Do      
+        1  2  3  4  5 WK48 
+  6  7  8  9 10 11 12 WK49 
+ 13 14 15 16 17 18 19 WK50 
+ 20 21 22 23 24 25 26 WK51 
+ 27 28 29 30 31       WK52 
+ 
+        2000/1(Gen)        
+ Lu Ma Me Gi Ve Sa Do      
+                 1  2 WK52 
+  3  4  5  6  7  8  9 WK 1 
+ 10 11 12 13 14 15 16 WK 2 
+ 17 18 19 20 21 22 23 WK 3 
+ 24 25 26 27 28 29 30 WK 4 
+ 31                   WK5  
+ 
+        2000/2(Feb)        
+ Lu Ma Me Gi Ve Sa Do      
+     1  2  3  4  5  6 WK 5 
+  7  8  9 10 11 12 13 WK 6 
+ 14 15 16 17 18 19 20 WK 7 
+ 21 22 23 24 25 26 27 WK 8 
+ 28 29                WK9  
+ 
+        2000/3(Mar)        
+ Lu Ma Me Gi Ve Sa Do      
+        1  2  3  4  5 WK 9 
+  6  7  8  9 10 11 12 WK10 
+ 13 14 15 16 17 18 19 WK11 
+ 20 21 22 23 24 25 26 WK12 
+ 27 28 29 30 31       WK13 
+ 
+        2000/4(Apr)        
+ Lu Ma Me Gi Ve Sa Do      
+                 1  2 WK13 
+  3  4  5  6  7  8  9 WK14 
+ 10 11 12 13 14 15 16 WK15 
+ 17 18 19 20 21 22 23 WK16 
+ 24 25 26 27 28 29 30 WK17 
+
+        <<-- | -->> 
+END
+
+  echom assert_equal(expected_value, getline(1, '$'))
+  exe "norm q"
+  call assert_equal(1, winnr('$'))
+
+  " Teardown optional variables and reset of some variables
+  let g:calendar_number_of_months = 3
+  let g:calendar_navi_label = 'Prev, Today, Next'
+  unlet g:calendar_monday
+  unlet g:calendar_mruler
+  unlet g:calendar_wruler
+  unlet g:calendar_weeknm
+  unlet g:calendar_erafmt
+
+  " %bw!
+endfunc
+
+func Test_syntax_highlight()
+
+  Calendar 2020, 3
+  call WaitForAssert({-> assert_equal(2, winnr('$'))})
+
+  "2020/2(Feb)
+  let linenr = 3
+  let date_idx = getline(linenr)->match('\S') + 1
+  let hi_group = synIDattr(synID(linenr, date_idx, 1), 'name')
+  call assert_match(hi_group, 'CalHeader')
+
+  " Su Mo Tu ...
+  let linenr = 4
+  let week_day = getline(linenr)->match('\S') + 1
+  let hi_group = synIDattr(synID(linenr, week_day, 1), 'name')
+  call assert_match(hi_group, 'CalRuler')
+
+  " 8th line is this:
+  " 16 17 18 19 20 21 22 
+  let linenr = 8
+  " CalSunday
+  let first_day_idx = getline(linenr)->match('\S') + 1
+  let hi_group = synIDattr(synID(linenr, first_day_idx, 1), 'name')
+  call assert_match(hi_group, 'CalSunday')
+
+  " Check in the middle, column 5
+  " No hlgroup
+  let middle_idx = 5
+  let hi_group = synIDattr(synID(linenr, middle_idx, 1), 'name')
+  call assert_true(empty(hi_group))
+
+  " Check end
+  " CalSaturday
+  let last_day_idx = len(getline(linenr)) - 1 
+  let hi_group = synIDattr(synID(linenr, last_day_idx, 1), 'name')
+  call assert_match(hi_group, 'CalSaturday')
+
+  exe "norm q"
+  call assert_equal(1, winnr('$'))
+
+  " Test CalendarH
+  CalendarH 2020, 3
+
+  "2020/2(Feb)
+  let linenr = 2
+  let date_idx = getline(linenr)->match('\S') + 1
+  let hi_group = synIDattr(synID(linenr, date_idx, 1), 'name')
+  call assert_match(hi_group, 'CalHeader')
+
+  " Su Mo Tu ...
+  let linenr = 3
+  let week_day = getline(linenr)->match('\S') + 1
+  let hi_group = synIDattr(synID(linenr, week_day, 1), 'name')
+  call assert_match(hi_group, 'CalRuler')
+
+  " February
+  let linenr = 8
+  let first_day_idx = getline(linenr)->match('\S') + 1
+  let hi_group = synIDattr(synID(linenr, first_day_idx, 1), 'name')
+  call assert_match(hi_group, 'CalSunday')
+
+  let middle_idx = 13
+  let hi_group = synIDattr(synID(linenr, middle_idx, 1), 'name')
+  call assert_true(empty(hi_group))
+
+  let last_day_idx = 22
+  let hi_group = synIDattr(synID(linenr, last_day_idx, 1), 'name')
+  call assert_match(hi_group, 'CalSaturday')
+
+  " March
+  let first_day_idx = 26
+  let hi_group = synIDattr(synID(linenr, first_day_idx, 1), 'name')
+  call assert_match(hi_group, 'CalSunday')
+
+  let middle_idx = 30
+  let hi_group = synIDattr(synID(linenr, middle_idx, 1), 'name')
+  call assert_true(empty(hi_group))
+
+  let last_day_idx = 45
+  let hi_group = synIDattr(synID(linenr, last_day_idx, 1), 'name')
+  call assert_match(hi_group, 'CalSaturday')
+
+  " April
+  let first_day_idx = 50
+  let hi_group = synIDattr(synID(linenr, first_day_idx, 1), 'name')
+  call assert_match(hi_group, 'CalSunday')
+
+  let middle_idx = 56
+  let hi_group = synIDattr(synID(linenr, middle_idx, 1), 'name')
+  call assert_true(empty(hi_group))
+
+  let last_day_idx = 68
+  let hi_group = synIDattr(synID(linenr, last_day_idx, 1), 'name')
+  call assert_match(hi_group, 'CalSaturday')
+
+  exe "norm q"
+  call assert_equal(1, winnr('$'))
+
+  %bw!
+endfunc
+
+func Test_hooks()
+
+  function g:MyCalBegin()
+    call setreg('a', "Calendar started")
+  endfunction
+  let g:calendar_begin = 'g:MyCalBegin'
+  
+  function g:MyCalToday()
+    call setreg('b', "Calendar today")
+  endfunction
+  let g:calendar_today = 'g:MyCalToday'
+
+  function g:MyCalEnd()
+    call setreg('c', "Calendar ended")
+  endfunction
+  let g:calendar_end = 'g:MyCalEnd'
+
+  Calendar 1624, 12
+  call WaitForAssert({-> assert_equal(2, winnr('$'))})
+  let actual_value = getreg('a')
+  call assert_match("Calendar started", actual_value)
+
+  " Select "Today" in the navigation panel on top
+  exe "norm ggfT\<cr>"
+  let actual_value = getreg('b')
+  call assert_match("Calendar today", actual_value)
+
+  exe "norm q"
+  let actual_value = getreg('c')
+  call assert_match("Calendar ended", actual_value)
+
+  unlet g:calendar_begin
+  unlet g:calendar_today
+  unlet g:calendar_end
+
+  %bw!
+endfunc


### PR DESCRIPTION
Given the beauty and utility of this plugin—because, after all, everyone needs a calendar—I wanted to pay homage by converting it to Vim9 script. I’m therefore proposing to include it in the main Vim distribution.
The original plugin is available here: https://github.com/mattn/calendar-vim. The author, @mattn, is also part of the Vim project.

Some notes:

1. I tried to keep the conversion as close as possible to the original to facilitate side-by-side comparison.
2. However, due to differences between legacy Vim script and Vim9 script, some parts had to be adjusted. Certain design patterns are no longer allowed, scopes are more clearly defined in Vim9, and types are strongly enforced.
3. CalendarVar() has been removed, as it was not used anywhere.
4. Sundays are now in red and Saturdays in yellow (the original had the opposite).
5. There are a couple of TODO comments in the source code where I wasn’t sure what the code was meant to do— @mattn might be able to clarify these.
6. The tests cover a lot but not absolutely everything, as I’m not sure how to test certain parts (see the TODO notes in the tests).
7. Feedback and help to improve this request are welcome. A genuine review from the original author, @mattn , would be greatly appreciated, but constructive feedback from others is just as welcome. 
8. Along the same line, any help to secure the integration would be highly appreciated (I see some tests are failing but I cannot really understand what shall be done). 