### PR TITLE
Enable cscope on macOS

### DIFF
--- a/src/feature.h
+++ b/src/feature.h
@@ -236,7 +236,7 @@
 /*
  * +cscope		Unix only: Cscope support.
  */
-#if defined(UNIX) && defined(FEAT_HUGE) && defined(ENABLE_CSCOPE) && !defined(MACOS_X)
+#if defined(UNIX) && defined(FEAT_HUGE) && defined(ENABLE_CSCOPE)
 # define FEAT_CSCOPE
 #endif
 


### PR DESCRIPTION
`+cscope` is described as “Unix only”.

macOS has been UNIX certified since 2007.

MacVim already builds with `+cscope`.

Besides, `./configure --enable-cscope && make` did not build with `+cscope` which was quite confusing to me.