### PR TITLE
tests: fuzzy bufname completion test doesn't match successfully

### DIFF
--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -3220,11 +3220,11 @@ func Test_fuzzy_completion_bufname_fullpath()
   edit Xcmd/Xstate/Xfile.js
   cd Xcmd/Xstate
   enew
-  call feedkeys(":b CmdStateFile\<Tab>\<C-B>\"\<CR>", 'tx')
-  call assert_equal('"b CmdStateFile', @:)
+  call feedkeys(":b cmdstatefile\<Tab>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"b cmdstatefile', @:)
   set wildoptions=fuzzy
-  call feedkeys(":b CmdStateFile\<Tab>\<C-B>\"\<CR>", 'tx')
-  call assert_equal('"b CmdStateFile', @:)
+  call feedkeys(":b cmdstatefile\<Tab>\<C-B>\"\<CR>", 'tx')
+  call assert_match('Xcmd/Xstate/Xfile.js$', @:)
   cd -
   set wildoptions&
 endfunc

--- a/src/testdir/test_search_stat.vim
+++ b/src/testdir/test_search_stat.vim
@@ -492,6 +492,9 @@ endfunc
 func Test_search_stat_option()
   " Asan causes wrong results, because the search times out
   CheckNotAsan
+  " Mark the test as flaky as the search may still occasionally time out
+  let g:test_is_flaky = 1
+
   enew
   set shortmess-=S
   set maxsearchcount=999


### PR DESCRIPTION
Problem:  tests: fuzzy buffer name completion test doesn't match
          successfully (after 9.1.1627).
Solution: Update the pattern to account for change in case sensitivity.
          Also mark Test_search_stat_option() as flaky as it can still
          sometimes fail (e.g. <https://github.com/vim/vim/actions/runs/16919563215/job/47941992737>).
