### PR TITLE
runtime(vim9): Use Open() when sets shellslash

### DIFF
--- a/runtime/autoload/dist/vim9.vim
+++ b/runtime/autoload/dist/vim9.vim
@@ -3,7 +3,7 @@ vim9script
 # Vim runtime support library
 #
 # Maintainer:   The Vim Project <https://github.com/vim/vim>
-# Last Change:  2025 Jan 29
+# Last Change:  2025 Aug 15
 
 export def IsSafeExecutable(filetype: string, executable: string): bool
   if empty(exepath(executable))
@@ -121,6 +121,10 @@ def Viewer(): string
 enddef
 
 export def Open(file: string)
+  if exists('+shellslash') && &shellslash
+    &shellslash = false
+    defer setbufvar('%', '&shellslash', true)
+  endif
   Launch($"{Viewer()} {shellescape(file, 1)}")
 enddef
 


### PR DESCRIPTION
When using explorer on Windows, the URL should be contained in double quote.
But when setting shellslash,  shellescape() will return URL in single quote.
So disable shellslash when opens a URL.

closes: #17995