### PR TITLE
xxd: Avoid null dereference in autoskip colorless

### DIFF
--- a/src/xxd/xxd.c
+++ b/src/xxd/xxd.c
@@ -597,7 +597,10 @@ xxdline(FILE *fp, char *l, char *colors, int nz)
   if (!nz && zero_seen == 1)
     {
       strcpy(z, l);
-      memcpy(z_colors, colors, strlen(z));
+      if (colors)
+	{
+	  memcpy(z_colors, colors, strlen(z));
+	}
     }
 
   if (nz || !zero_seen++)


### PR DESCRIPTION
Fixes bug introduced in 6897f18ee6e5bb78b32c97616e484030fd514750 (v9.1.1459) which does a memcpy from NULL when color=never and the autoskip option is used.

Before:

```
dd if=/dev/zero bs=100 count=1 status=none | xxd -a -R never
00000000: 0000 0000 0000 0000 0000 0000 0000 0000  ................
Segmentation fault (core dumped)
```

After:

```
dd if=/dev/zero bs=100 count=1 status=none | ./xxd/xxd -a -R never
00000000: 0000 0000 0000 0000 0000 0000 0000 0000  ................
*
00000060: 0000 0000                                ....
```