### PR TITLE
feat: auto-enable vim9script for .vim9 extension

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -2831,7 +2831,7 @@ au BufNewFile,BufRead *.tape			setf vhs
 au BufNewFile,BufRead *.hdl,*.vhd,*.vhdl,*.vbe,*.vst,*.vho  setf vhdl
 
 " Vim script
-au BufNewFile,BufRead *.vim,.exrc,_exrc,.netrwhist	setf vim
+au BufNewFile,BufRead *.vim,.exrc,_exrc,.netrwhist,*.vim9   setf vim
 
 " Viminfo file
 au BufNewFile,BufRead .viminfo,_viminfo		setf viminfo

--- a/src/errors.h
+++ b/src/errors.h
@@ -3234,7 +3234,7 @@ EXTERN char e_cmd_mapping_must_end_with_cr[]
 EXTERN char e_string_or_function_required_for_argument_nr[]
 	INIT(= N_("E1256: String or function required for argument %d"));
 EXTERN char e_imported_script_must_use_as_or_end_in_dot_vim_str[]
-	INIT(= N_("E1257: Imported script must use \"as\" or end in .vim: %s"));
+	INIT(= N_("E1257: Imported script must use \"as\" or end in .vim or .vim9: %s"));
 EXTERN char e_no_dot_after_imported_name_str[]
 	INIT(= N_("E1258: No '.' after imported name: %s"));
 EXTERN char e_missing_name_after_imported_name_str[]
@@ -3242,7 +3242,7 @@ EXTERN char e_missing_name_after_imported_name_str[]
 EXTERN char e_cannot_unlet_imported_item_str[]
 	INIT(= N_("E1260: Cannot unlet an imported item: %s"));
 EXTERN char e_cannot_import_dot_vim_without_using_as[]
-	INIT(= N_("E1261: Cannot import .vim without using \"as\""));
+	INIT(= N_("E1261: Cannot import .vim or .vim9 without using \"as\""));
 EXTERN char e_cannot_import_same_script_twice_str[]
 	INIT(= N_("E1262: Cannot import the same script twice: %s"));
 EXTERN char e_cannot_use_name_with_hash_in_vim9_script_use_export_instead[]

--- a/src/main.c
+++ b/src/main.c
@@ -504,6 +504,14 @@ vim_main2(void)
 # endif
 		;
 
+	char_u *plugin_pattern9 = (char_u *)
+# if defined(VMS) || defined(AMIGA)
+		"plugin/*.vim9"
+# else
+		"plugin/**/*.vim9"
+# endif
+		;
+
 	// First add all package directories to 'runtimepath', so that their
 	// autoload directories can be found.  Only if not done already with a
 	// :packloadall command.
@@ -515,6 +523,8 @@ vim_main2(void)
 	    add_pack_start_dirs();
 	}
 
+	source_in_path(rtp_copy == NULL ? p_rtp : rtp_copy, plugin_pattern9,
+		DIP_ALL | DIP_NOAFTER, NULL);
 	source_in_path(rtp_copy == NULL ? p_rtp : rtp_copy, plugin_pattern,
 		DIP_ALL | DIP_NOAFTER, NULL);
 	TIME_MSG("loading plugins");
@@ -526,6 +536,7 @@ vim_main2(void)
 	    load_start_packages();
 	TIME_MSG("loading packages");
 
+	source_runtime(plugin_pattern9, DIP_ALL | DIP_AFTER);
 	source_runtime(plugin_pattern, DIP_ALL | DIP_AFTER);
 	TIME_MSG("loading after plugins");
     }

--- a/src/testdir/test_vim9_import.vim
+++ b/src/testdir/test_vim9_import.vim
@@ -588,7 +588,7 @@ def Test_import_fails()
       vim9script
       import './Ximport/.vim'
   END
-  v9.CheckScriptFailure(lines, 'E1261: Cannot import .vim without using "as"')
+  v9.CheckScriptFailure(lines, 'E1261: Cannot import .vim or .vim9 without using "as"')
   lines =<< trim END
       vim9script
       import './Ximport/.vim' as vim
@@ -600,7 +600,7 @@ def Test_import_fails()
       vim9script
       import './Ximport/.vimrc'
   END
-  v9.CheckScriptFailure(lines, 'E1257: Imported script must use "as" or end in .vim')
+  v9.CheckScriptFailure(lines, 'E1257: Imported script must use "as" or end in .vim or .vim9')
   lines =<< trim END
       vim9script
       import './Ximport/.vimrc' as vimrc
@@ -619,7 +619,7 @@ def Test_import_fails()
   assert_fails('source Xbar.vim', 'E488: Trailing characters: ask expo')
   writefile([], 'Xtemp')
   call writefile(['vim9script', "import './Xtemp'"], 'Xbar.vim')
-  assert_fails('source Xbar.vim', 'E1257: Imported script must use "as" or end in .vim: Xtemp')
+  assert_fails('source Xbar.vim', 'E1257: Imported script must use "as" or end in .vim or .vim9: Xtemp')
   delete('Xtemp')
   call writefile(['vim9script', "import './Xfoo.vim' as abc | foobar"], 'Xbar.vim')
   assert_fails('source Xbar.vim', 'E492: Not an editor command:  foobar')

--- a/src/vim9script.c
+++ b/src/vim9script.c
@@ -592,18 +592,35 @@ handle_import(
     else
     {
 	char_u *p = gettail(tv.vval.v_string);
-	char_u *end = (char_u *)strstr((char *)p, ".vim");
+	char_u *end = NULL;
+	int     found_extension = FALSE;
 
 	if (!ends_excmd2(arg_start, expr_end))
 	{
 	    semsg(_(e_trailing_characters_str), expr_end);
 	    goto erret;
 	}
-	if (end == NULL || end[4] != NUL)
+
+	// Check for .vim9 extension first
+	size_t p_len = STRLEN(p);
+	if (p_len >= 5 && STRCMP(p + p_len - 5, ".vim9") == 0)
+	{
+	    end = p + p_len - 5;
+	    found_extension = TRUE;
+	}
+	// Check for .vim extension
+	else if (p_len >= 4 && STRCMP(p + p_len - 4, ".vim") == 0)
+	{
+	    end = p + p_len - 4;
+	    found_extension = TRUE;
+	}
+
+	if (!found_extension)
 	{
 	    semsg(_(e_imported_script_must_use_as_or_end_in_dot_vim_str), p);
 	    goto erret;
 	}
+
 	if (end == p)
 	{
 	    semsg(_(e_cannot_import_dot_vim_without_using_as), p);


### PR DESCRIPTION
.vim9 files now automatically use vim9script syntax without explicit declaration


I tested using https://github.com/yegappan/lsp and https://github.com/ubaldot/vim-calendar. renamed all .vim to .vim9 and removed the vim9script declaration from each line. before I do more debugging on other vim dirs, I just want to confirm if we need this otherwise feel free close this.

<img width="460" height="377" alt="image" src="https://github.com/user-attachments/assets/705d43ba-cfcd-47db-9fdd-ce1febfb4236" />



<img width="362" height="372" alt="image" src="https://github.com/user-attachments/assets/ccdc50f8-8355-4ede-9e17-62e8e0ad0fdf" />
