### PR TITLE
configure: fix inverted C99 feature test logic

### DIFF
--- a/src/auto/configure
+++ b/src/auto/configure
@@ -4640,7 +4640,7 @@ fi
 
 fi
 
-if test x"$ac_cv_prog_cc_c99" != xno; then
+if test x"$ac_cv_prog_cc_c99" = xno; then
 
 
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for unsigned long long int" >&5

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -30,7 +30,7 @@ if test -z "$PKG_CONFIG"; then
 fi
 
 dnl Check that the C99 features that Vim uses are supported:
-if test x"$ac_cv_prog_cc_c99" != xno; then
+if test x"$ac_cv_prog_cc_c99" = xno; then
   dnl If the compiler doesn't explicitly support C99, then check
   dnl for the specific features Vim uses
 
@@ -2408,7 +2408,7 @@ AC_MSG_CHECKING(--with-wayland argument)
 AC_ARG_WITH(wayland,
 	[  --with-wayland	  Include support for the Wayland protocol.],
 	[with_wayland=$withval],
-	AS_IF([test "x$features" = xtiny], 
+	AS_IF([test "x$features" = xtiny],
 			[with_wayland=no
 			 AC_MSG_RESULT([cannot use wayland with tiny features])],
 			[with_wayland=yes


### PR DESCRIPTION
The logic behind that bloc was : if no C99 compiler is found, then let’s try the features that Vim still needs.
The original commit message for that change said:
> Use AC_PROG_CC_C99 and when C99 isn't fully supported check the features we need.

@arpadffy do you rely on that code for VMS compilation ? Because now the code will execute and if it finds no C99 compiler, it will ask for `long long` and abort if not satisfied.