### PR TITLE
feat(syntax): Add syntax for Cangjie language

### DIFF
--- a/.github/MAINTAINERS
+++ b/.github/MAINTAINERS
@@ -449,6 +449,7 @@ runtime/syntax/bzr.vim					@hdima
 runtime/syntax/cabal.vim				@coot
 runtime/syntax/cabalconfig.vim				@coot
 runtime/syntax/cabalproject.vim				@coot
+runtime/syntax/cangjie.vim				@WuJunkai2004
 runtime/syntax/cf.vim					@ernstvanderlinden
 runtime/syntax/chatito.vim				@ObserverOfTime
 runtime/syntax/chicken.vim				@evhan

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1116,6 +1116,17 @@ in the "after" directory in 'runtimepath'.  For Unix this would be
     syn sync fromstart
     set foldmethod=syntax
 
+CANGJIE					*cangjie.vim* *ft-cangjie-syntax*
+The Cangjie programming language is a new-generation programming language
+oriented to full-scenario intelligence.  See |cangjie.vim| for all the settings
+that are available for Cangjie.
+
+To enable or disable the highlights by setting the variables in vimrc, you can
+control the syntax highlighting of Cangjie.  Example: >
+	:let g:cangjie_keyword_color = 0
+This will disable the highlighting of keywords in Cangjie.
+See more highlighting variables in |cangjie.vim|.
+
 CH						*ch.vim* *ft-ch-syntax*
 
 C/C++ interpreter.  Ch has similar syntax highlighting to C and builds upon

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1118,15 +1118,20 @@ in the "after" directory in 'runtimepath'.  For Unix this would be
 
 CANGJIE					*cangjie.vim* *ft-cangjie-syntax*
 
-The Cangjie programming language is a new-generation programming language
-oriented to full-scenario intelligence.  See |cangjie.vim| for all the settings
-that are available for Cangjie.
+This file provides syntax highlighting for the Cangjie programming language, a
+new-generation language oriented to full-scenario intelligence.
 
-To enable or disable the highlights by setting the variables in vimrc, you can
-control the syntax highlighting of Cangjie.  Example: >
+All highlighting is enabled by default.  To disable highlighting for a
+specific group, set the corresponding variable to 0 in your |vimrc|.
+All options to disable highlighting are: >
+	:let g:cangjie_comment_color = 0
+	:let g:cangjie_identifier_color = 0
 	:let g:cangjie_keyword_color = 0
-This will disable the highlighting of keywords in Cangjie.
-See more highlighting variables in |cangjie.vim|.
+	:let g:cangjie_macro_color = 0
+	:let g:cangjie_number_color = 0
+	:let g:cangjie_operator_color = 0
+	:let g:cangjie_string_color = 0
+	:let g:cangjie_type_color = 0
 
 CH						*ch.vim* *ft-ch-syntax*
 

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1117,6 +1117,7 @@ in the "after" directory in 'runtimepath'.  For Unix this would be
     set foldmethod=syntax
 
 CANGJIE					*cangjie.vim* *ft-cangjie-syntax*
+
 The Cangjie programming language is a new-generation programming language
 oriented to full-scenario intelligence.  See |cangjie.vim| for all the settings
 that are available for Cangjie.

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -6486,6 +6486,7 @@ c_space_errors	syntax.txt	/*c_space_errors*
 c_syntax_for_h	syntax.txt	/*c_syntax_for_h*
 c_wildchar	cmdline.txt	/*c_wildchar*
 call()	builtin.txt	/*call()*
+cangjie.vim	syntax.txt	/*cangjie.vim*
 carriage-return	intro.txt	/*carriage-return*
 case	change.txt	/*case*
 catch-all	eval.txt	/*catch-all*
@@ -7424,6 +7425,7 @@ ft-bash-syntax	syntax.txt	/*ft-bash-syntax*
 ft-basic-syntax	syntax.txt	/*ft-basic-syntax*
 ft-c-omni	insert.txt	/*ft-c-omni*
 ft-c-syntax	syntax.txt	/*ft-c-syntax*
+ft-cangjie-syntax	syntax.txt	/*ft-cangjie-syntax*
 ft-ch-syntax	syntax.txt	/*ft-ch-syntax*
 ft-changelog-plugin	filetype.txt	/*ft-changelog-plugin*
 ft-changelog-syntax	syntax.txt	/*ft-changelog-syntax*

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -2433,6 +2433,9 @@ au BufNewFile,BufRead *.il,*.ils,*.cdf		setf skill
 " Cadence
 au BufNewFile,BufRead *.cdc			setf cdc
 
+" Cangjie
+au BufNewFile,BufRead *.cangjie     setf cangjie
+
 " SLRN
 au BufNewFile,BufRead .slrnrc			setf slrnrc
 au BufNewFile,BufRead *.score			setf slrnsc

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -2434,7 +2434,7 @@ au BufNewFile,BufRead *.il,*.ils,*.cdf		setf skill
 au BufNewFile,BufRead *.cdc			setf cdc
 
 " Cangjie
-au BufNewFile,BufRead *.cangjie     setf cangjie
+au BufNewFile,BufRead *.cj			setf cangjie
 
 " SLRN
 au BufNewFile,BufRead .slrnrc			setf slrnrc

--- a/runtime/makemenu.vim
+++ b/runtime/makemenu.vim
@@ -124,6 +124,7 @@ SynMenu C.C++:cpp
 SynMenu C.C#:cs
 SynMenu C.Cabal\ Haskell\ build\ file:cabal
 SynMenu C.Calendar:calendar
+SynMenu C.Cangjie:cangjie
 SynMenu C.Cascading\ Style\ Sheets:css
 SynMenu C.CDL:cdl
 SynMenu C.Cdrdao\ TOC:cdrtoc

--- a/runtime/synmenu.vim
+++ b/runtime/synmenu.vim
@@ -110,6 +110,7 @@ an 50.20.110 &Syntax.C.C++ :cal SetSyn("cpp")<CR>
 an 50.20.120 &Syntax.C.C# :cal SetSyn("cs")<CR>
 an 50.20.130 &Syntax.C.Cabal\ Haskell\ build\ file :cal SetSyn("cabal")<CR>
 an 50.20.140 &Syntax.C.Calendar :cal SetSyn("calendar")<CR>
+an 50.20.140 &Syntax.C.Cangjie :cal SetSyn("cangjie")<CR>
 an 50.20.150 &Syntax.C.Cascading\ Style\ Sheets :cal SetSyn("css")<CR>
 an 50.20.160 &Syntax.C.CDL :cal SetSyn("cdl")<CR>
 an 50.20.170 &Syntax.C.Cdrdao\ TOC :cal SetSyn("cdrtoc")<CR>

--- a/runtime/syntax/cangjie.vim
+++ b/runtime/syntax/cangjie.vim
@@ -1,0 +1,151 @@
+" Vim syntax file
+" Language: Cangjie
+" Maintainer: Wu Junkai <wu.junkai@qq.com>
+" Last Change: 2025 Aug 17
+"
+" The Cangjie programming language is a new-generation programming
+" language oriented to full-scenario intelligence. It features
+" native intelligence, being naturally suitable for all scenarios,
+" high performance and strong security. It is mainly applied in
+" scenarios such as native applications and service applications
+" of HarmonyOS NEXT, providing developers with a good programming
+" experience.
+"
+" For more information, see:
+" - https://cangjie-lang.cn/
+" - https://gitcode.com/Cangjie
+
+" quit when a syntax file was already loaded
+if exists("b:current_syntax")
+	finish
+endif
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+" 0. check the user's settings
+" use let g:cangjie_<item>_color to enable/disable syntax highlighting
+function! s:enabled(item) abort
+	return get(g:, 'cangjie_' . a:item . '_color', 1)
+endfunction
+
+syn case match
+
+" 1. comments
+syn keyword cjTodo	TODO FIXME XXX NOTE BUG contained
+syn match   cjComment /\v\/\/.*/				contains=cjTodo
+syn region  cjComment start=/\/\*/ end=/\*\//	contains=cjTodo,@Spell
+syn cluster cjCommentCluster contains=cjComment,cjTodo
+if s:enabled('comment')
+	hi def link cjTodo		Todo
+	hi def link cjComment	Comment
+endif
+
+" 2. keywords
+syn keyword cjDeclaration	abstract extend macro foreign
+syn keyword cjDeclaration	interface open operator override private prop protected
+syn keyword cjDeclaration	public redef static type
+syn keyword cjStatement		as break case catch continue do else finally for in
+syn keyword cjStatement		if in is match quote return spawn super synchronized
+syn keyword cjStatement		throw try unsafe where while
+syn keyword cjIdentlike		false init main this true
+syn keyword cjVariable		const let var
+syn keyword cjOption		Option Some None
+syn keyword cjDeclaration   func struct class enum import package nextgroup=cjTypeName skipwhite
+syn cluster cjKeywordCluster	contains=cjDeclaration,cjStatement,cjIdentlike,cjVariable,cjOption
+if s:enabled('keyword')
+	hi def link cjDeclaration	Keyword
+	hi def link cjStatement		Statement
+	hi def link cjIdentlike		Keyword
+	hi def link cjVariable		Keyword
+	hi def link cjOption		Keyword
+endif
+
+" 3. Attributes (e.g., @override)
+syn match cjAttribute /@\h\w*/
+if s:enabled('attribute')
+	hi def link cjAttribute PreProc
+endif
+
+" 4. Type and Function Names
+syn match cjTypeName /\h\w*/ contained
+if s:enabled('type_name')
+	hi def link cjTypeName Type
+endif
+
+" 5. specail identifiers
+syn region cjSP_Identifier start=/`/ end=/`/ oneline
+if s:enabled('identifier')
+	hi def link cjSP_Identifier Identifier
+endif
+
+" 6. types
+syn keyword cjSpType		Any Nothing Range Unit Iterable
+syn keyword cjArrayType		Array ArrayList VArray
+syn keyword cjHashType		HashMap HashSet
+syn keyword cjCommonType	Bool Byte Rune String
+syn keyword cjFloatType		Float16 Float32 Float64
+syn keyword cjIntType		Int8 Int16 Int32 Int64 IntNative
+syn keyword cjUIntType		UInt8 UInt16 UInt32 UInt64 UIntNative
+syn cluster cjTypeCluster contains=cjSpType,cjArrayType,cjHashType,cjCommonType,cjFloatType,cjIntType,cjUIntType
+if s:enabled('type')
+	hi def link cjSpType		Type
+	hi def link cjArrayType		Type
+	hi def link cjHashType		Type
+	hi def link cjCommonType	Type
+	hi def link cjFloatType		Type
+	hi def link cjIntType		Type
+	hi def link cjUIntType		Type
+endif
+
+" 7. character and strings
+syn cluster cjInterpolatedPart contains=@cjKeywordCluster,cjSP_Identifier,@cjTypeCluster,@cjNumberCluster,cjOperator,cjComment
+syn region  cjInterpolation contained keepend start=/\${/ end=/}/ contains=@cjInterpolatedPart matchgroup=cjInterpolationDelimiter
+syn match cjRune /\vr'.'/
+syn region cjString start=/"/ skip=/\\\\\|\\"/ end=/"/ oneline contains=cjInterpolation
+syn region cjString start=/'/ skip=/\\\\\|\\'/ end=/'/ oneline contains=cjInterpolation
+syn region cjString start=/"""/ skip=/\\\\\|\\"/ end=/"""/ contains=cjInterpolation keepend
+syn region cjString start=/'''/ skip=/\\\\\|\\'/ end=/'''/ contains=cjInterpolation keepend
+syn region cjRawString start='\z(#*\)#"'  end='"#\z1'
+syn region cjRawString start='\z(#*\)#\'' end='\'#\z1'
+if s:enabled('string')
+	hi def link cjRune		Character
+	hi def link cjString	String
+	hi def link cjRawString	String
+endif
+
+" 8. number
+syn match cjFloatNumber		/\v\c<\d[0-9_]*\.\d[0-9_]*([eE][-+]?\d[0-9_]*)?>/
+syn match cjFloatNumber		/\v\c<\d[0-9_]*\.([eE][-+]?\d[0-9_]*)?>/
+syn match cjFloatNumber		/\v\c\.\d[0-9_]*([eE][-+]?\d[0-9_]*)?>/
+syn match cjScienceNumber	/\v\c<\d[0-9_]*[eE][-+]?\d[0-9_]*>/
+syn match cjHexNumber		/\v\c<0x[0-9a-fA-F_]+>/
+syn match cjOctalNumber		/\v\c<0o[0-7_]+>/
+syn match cjBinaryNumber	/\v\c<0b[01_]+>/
+syn match cjDecimalNumber	/\v\c<\d[0-9_]*>/
+syn cluster cjNumberCluster contains=cjFloatNumber,cjScienceNumber,cjHexNumber,cjOctalNumber,cjBinaryNumber,cjDecimalNumber
+if s:enabled('number')
+	hi def link cjFloatNumber	Float
+	hi def link cjScienceNumber	Float
+	hi def link cjHexNumber		Number
+	hi def link cjOctalNumber	Number
+	hi def link cjBinaryNumber	Number
+	hi def link cjDecimalNumber	Number
+endif
+
+" 9. operators
+syn match cjOperator /[-+%<>!&|^*=]=\?/
+syn match cjOperator /\/\%(=\|\ze[^/*]\)/
+syn match cjOperator /\%(<<\|>>\|&^\)=\?/
+syn match cjOperator /:=\|||\|<-\|++\|--/
+syn match cjOperator /[~]/
+syn match cjOperator /[:]/
+syn match cjOperator /\.\.\./
+if s:enabled('operator')
+	hi def link cjOperator	Operator
+endif
+
+let b:current_syntax = "cangjie"
+
+let &cpo = s:save_cpo
+unlet s:save_cpo

--- a/runtime/syntax/cangjie.vim
+++ b/runtime/syntax/cangjie.vim
@@ -61,15 +61,15 @@ if s:enabled('keyword')
 	hi def link cjOption		Keyword
 endif
 
-" 3. Attributes (e.g., @override)
+" 3. macro (e.g., @override)
 syn match cjAttribute /@\h\w*/
-if s:enabled('attribute')
+if s:enabled('macro')
 	hi def link cjAttribute PreProc
 endif
 
 " 4. Type and Function Names
 syn match cjTypeName /\h\w*/ contained
-if s:enabled('type_name')
+if s:enabled('type')
 	hi def link cjTypeName Type
 endif
 

--- a/runtime/syntax/cangjie.vim
+++ b/runtime/syntax/cangjie.vim
@@ -71,7 +71,8 @@ syn cluster cangjieTypeCluster contains=cangjieSpType,cangjieArrayType,cangjieHa
 " 7. character and strings
 syn cluster cangjieInterpolatedPart contains=@cangjieKeywordCluster,cangjieSpIdentifier,@cangjieTypeCluster,@cangjieNumberCluster,cangjieOperator
 syn region  cangjieInterpolation contained keepend start=/\${/ end=/}/ contains=@cangjieInterpolatedPart matchgroup=cangjieInterpolationDelimiter
-syn match cangjieRune /\vr'.'/
+syn region cangjieRune   start=/r'/ skip=/\\\\\|\\'/ end=/'/ oneline
+syn region cangjieRune   start=/b'/ skip=/\\\\\|\\'/ end=/'/ oneline
 syn region cangjieString start=/"/ skip=/\\\\\|\\"/ end=/"/ oneline contains=cangjieInterpolation
 syn region cangjieString start=/'/ skip=/\\\\\|\\'/ end=/'/ oneline contains=cangjieInterpolation
 syn region cangjieString start=/"""/ skip=/\\\\\|\\"/ end=/"""/ contains=cangjieInterpolation keepend
@@ -80,14 +81,14 @@ syn region cangjieRawString start='\z(#*\)#"'  end='"#\z1'
 syn region cangjieRawString start='\z(#*\)#\'' end='\'#\z1'
 
 " 8. number
-syn match cangjieFloatNumber	/\v\c<\d[0-9_]*\.\d[0-9_]*([eE][-+]?\d[0-9_]*)?>/
-syn match cangjieFloatNumber	/\v\c<\d[0-9_]*\.([eE][-+]?\d[0-9_]*)?>/
-syn match cangjieFloatNumber	/\v\c\.\d[0-9_]*([eE][-+]?\d[0-9_]*)?>/
-syn match cangjieScienceNumber	/\v\c<\d[0-9_]*[eE][-+]?\d[0-9_]*>/
-syn match cangjieHexNumber		/\v\c<0x[0-9a-fA-F_]+>/
-syn match cangjieOctalNumber	/\v\c<0o[0-7_]+>/
-syn match cangjieBinaryNumber	/\v\c<0b[01_]+>/
-syn match cangjieDecimalNumber	/\v\c<\d[0-9_]*>/
+syn match cangjieFloatNumber	/\v\c<\d[0-9_]*\.\d[0-9_]*([ep][-+]?\d[0-9_]*)?(f(16|32|64))?>/
+syn match cangjieFloatNumber	/\v\c<\d[0-9_]*\.([ep][-+]?\d[0-9_]*)?(f(16|32|64))?>/
+syn match cangjieFloatNumber	/\v\c\.\d[0-9_]*([ep][-+]?\d[0-9_]*)?(f(16|32|64))?>/
+syn match cangjieScienceNumber	/\v\c<\d[0-9_]*[e][-+]?\d[0-9_]*>/
+syn match cangjieHexNumber		/\v\c<0x[0-9a-f_]+([iu](8|16|32|64))?>/
+syn match cangjieOctalNumber	/\v\c<0o[0-7_]+([iu](8|16|32|64))?>/
+syn match cangjieBinaryNumber	/\v\c<0b[01_]+([iu](8|16|32|64))?>/
+syn match cangjieDecimalNumber	/\v\c<\d[0-9_]*([iu](8|16|32|64))?>/
 syn cluster cangjieNumberCluster contains=cangjieFloatNumber,cangjieScienceNumber,cangjieHexNumber,cangjieOctalNumber,cangjieBinaryNumber,cangjieDecimalNumber
 
 " 9. operators
@@ -97,7 +98,8 @@ syn match cangjieOperator /\%(<<\|>>\|&^\)=\?/
 syn match cangjieOperator /:=\|||\|<-\|++\|--/
 syn match cangjieOperator /[~]/
 syn match cangjieOperator /[:]/
-syn match cangjieOperator /\.\.\./
+syn match cangjieOperator /\.\./
+syn match cangjieVarArgs  /\.\.\./
 
 " finally, link the syntax groups to the highlight groups
 if s:enabled('comment')
@@ -127,6 +129,7 @@ if s:enabled('number')
 endif
 if s:enabled('operator')
 	hi def link cangjieOperator			Operator
+	hi def link cangjieVarArgs			Operator
 endif
 if s:enabled('string')
 	hi def link cangjieRune				Character

--- a/runtime/syntax/cangjie.vim
+++ b/runtime/syntax/cangjie.vim
@@ -32,117 +32,116 @@ endfunction
 syn case match
 
 " 1. comments
-syn keyword cjTodo	TODO FIXME XXX NOTE BUG contained
-syn match   cjComment /\v\/\/.*/				contains=cjTodo
-syn region  cjComment start=/\/\*/ end=/\*\//	contains=cjTodo,@Spell
-syn cluster cjCommentCluster contains=cjComment,cjTodo
-if s:enabled('comment')
-	hi def link cjTodo		Todo
-	hi def link cjComment	Comment
-endif
+syn keyword cangjieTodo	TODO FIXME XXX NOTE BUG contained
+syn match   cangjieComment /\v\/\/.*/				contains=cangjieTodo
+syn region  cangjieComment start=/\/\*/ end=/\*\//	contains=cangjieTodo,@Spell
 
 " 2. keywords
-syn keyword cjDeclaration	abstract extend macro foreign
-syn keyword cjDeclaration	interface open operator override private prop protected
-syn keyword cjDeclaration	public redef static type
-syn keyword cjStatement		as break case catch continue do else finally for in
-syn keyword cjStatement		if in is match quote return spawn super synchronized
-syn keyword cjStatement		throw try unsafe where while
-syn keyword cjIdentlike		false init main this true
-syn keyword cjVariable		const let var
-syn keyword cjOption		Option Some None
-syn keyword cjDeclaration   func struct class enum import package nextgroup=cjTypeName skipwhite
-syn cluster cjKeywordCluster	contains=cjDeclaration,cjStatement,cjIdentlike,cjVariable,cjOption
-if s:enabled('keyword')
-	hi def link cjDeclaration	Keyword
-	hi def link cjStatement		Statement
-	hi def link cjIdentlike		Keyword
-	hi def link cjVariable		Keyword
-	hi def link cjOption		Keyword
-endif
+syn keyword cangjieDeclaration	abstract extend macro foreign
+syn keyword cangjieDeclaration	interface open operator override private prop protected
+syn keyword cangjieDeclaration	public redef static type
+syn keyword cangjieStatement	as break case catch continue do else finally for in
+syn keyword cangjieStatement	if in is match quote return spawn super synchronized
+syn keyword cangjieStatement	throw try unsafe where while
+syn keyword cangjieIdentlike	false init main this true
+syn keyword cangjieVariable		const let var
+syn keyword cangjieOption		Option Some None
+syn keyword cangjieDeclaration	func struct class enum import package nextgroup=cangjieTypeName skipwhite
+syn cluster cangjieKeywordCluster	contains=cangjieDeclaration,cangjieStatement,cangjieIdentlike,cangjieVariable,cangjieOption
 
 " 3. macro (e.g., @override)
-syn match cjAttribute /@\h\w*/
-if s:enabled('macro')
-	hi def link cjAttribute PreProc
-endif
+syn match cangjieMacro /@\h\w*/
 
 " 4. Type and Function Names
-syn match cjTypeName /\h\w*/ contained
-if s:enabled('type')
-	hi def link cjTypeName Type
-endif
+syn match cangjieTypeName /\h\w*/ contained
 
 " 5. specail identifiers
-syn region cjSP_Identifier start=/`/ end=/`/ oneline
-if s:enabled('identifier')
-	hi def link cjSP_Identifier Identifier
-endif
+syn region cangjieSpIdentifier start=/`/ end=/`/ oneline
 
 " 6. types
-syn keyword cjSpType		Any Nothing Range Unit Iterable
-syn keyword cjArrayType		Array ArrayList VArray
-syn keyword cjHashType		HashMap HashSet
-syn keyword cjCommonType	Bool Byte Rune String
-syn keyword cjFloatType		Float16 Float32 Float64
-syn keyword cjIntType		Int8 Int16 Int32 Int64 IntNative
-syn keyword cjUIntType		UInt8 UInt16 UInt32 UInt64 UIntNative
-syn cluster cjTypeCluster contains=cjSpType,cjArrayType,cjHashType,cjCommonType,cjFloatType,cjIntType,cjUIntType
-if s:enabled('type')
-	hi def link cjSpType		Type
-	hi def link cjArrayType		Type
-	hi def link cjHashType		Type
-	hi def link cjCommonType	Type
-	hi def link cjFloatType		Type
-	hi def link cjIntType		Type
-	hi def link cjUIntType		Type
-endif
+syn keyword cangjieSpType		Any Nothing Range Unit Iterable
+syn keyword cangjieArrayType	Array ArrayList VArray
+syn keyword cangjieHashType		HashMap HashSet
+syn keyword cangjieCommonType	Bool Byte Rune String
+syn keyword cangjieFloatType	Float16 Float32 Float64
+syn keyword cangjieIntType		Int8 Int16 Int32 Int64 IntNative
+syn keyword cangjieUIntType		UInt8 UInt16 UInt32 UInt64 UIntNative
+syn cluster cangjieTypeCluster contains=cangjieSpType,cangjieArrayType,cangjieHashType,cangjieCommonType,cangjieFloatType,cangjieIntType,cangjieUIntType
 
 " 7. character and strings
-syn cluster cjInterpolatedPart contains=@cjKeywordCluster,cjSP_Identifier,@cjTypeCluster,@cjNumberCluster,cjOperator,cjComment
-syn region  cjInterpolation contained keepend start=/\${/ end=/}/ contains=@cjInterpolatedPart matchgroup=cjInterpolationDelimiter
-syn match cjRune /\vr'.'/
-syn region cjString start=/"/ skip=/\\\\\|\\"/ end=/"/ oneline contains=cjInterpolation
-syn region cjString start=/'/ skip=/\\\\\|\\'/ end=/'/ oneline contains=cjInterpolation
-syn region cjString start=/"""/ skip=/\\\\\|\\"/ end=/"""/ contains=cjInterpolation keepend
-syn region cjString start=/'''/ skip=/\\\\\|\\'/ end=/'''/ contains=cjInterpolation keepend
-syn region cjRawString start='\z(#*\)#"'  end='"#\z1'
-syn region cjRawString start='\z(#*\)#\'' end='\'#\z1'
-if s:enabled('string')
-	hi def link cjRune		Character
-	hi def link cjString	String
-	hi def link cjRawString	String
-endif
+syn cluster cangjieInterpolatedPart contains=@cangjieKeywordCluster,cangjieSpIdentifier,@cangjieTypeCluster,@cangjieNumberCluster,cangjieOperator
+syn region  cangjieInterpolation contained keepend start=/\${/ end=/}/ contains=@cangjieInterpolatedPart matchgroup=cangjieInterpolationDelimiter
+syn match cangjieRune /\vr'.'/
+syn region cangjieString start=/"/ skip=/\\\\\|\\"/ end=/"/ oneline contains=cangjieInterpolation
+syn region cangjieString start=/'/ skip=/\\\\\|\\'/ end=/'/ oneline contains=cangjieInterpolation
+syn region cangjieString start=/"""/ skip=/\\\\\|\\"/ end=/"""/ contains=cangjieInterpolation keepend
+syn region cangjieString start=/'''/ skip=/\\\\\|\\'/ end=/'''/ contains=cangjieInterpolation keepend
+syn region cangjieRawString start='\z(#*\)#"'  end='"#\z1'
+syn region cangjieRawString start='\z(#*\)#\'' end='\'#\z1'
 
 " 8. number
-syn match cjFloatNumber		/\v\c<\d[0-9_]*\.\d[0-9_]*([eE][-+]?\d[0-9_]*)?>/
-syn match cjFloatNumber		/\v\c<\d[0-9_]*\.([eE][-+]?\d[0-9_]*)?>/
-syn match cjFloatNumber		/\v\c\.\d[0-9_]*([eE][-+]?\d[0-9_]*)?>/
-syn match cjScienceNumber	/\v\c<\d[0-9_]*[eE][-+]?\d[0-9_]*>/
-syn match cjHexNumber		/\v\c<0x[0-9a-fA-F_]+>/
-syn match cjOctalNumber		/\v\c<0o[0-7_]+>/
-syn match cjBinaryNumber	/\v\c<0b[01_]+>/
-syn match cjDecimalNumber	/\v\c<\d[0-9_]*>/
-syn cluster cjNumberCluster contains=cjFloatNumber,cjScienceNumber,cjHexNumber,cjOctalNumber,cjBinaryNumber,cjDecimalNumber
-if s:enabled('number')
-	hi def link cjFloatNumber	Float
-	hi def link cjScienceNumber	Float
-	hi def link cjHexNumber		Number
-	hi def link cjOctalNumber	Number
-	hi def link cjBinaryNumber	Number
-	hi def link cjDecimalNumber	Number
-endif
+syn match cangjieFloatNumber	/\v\c<\d[0-9_]*\.\d[0-9_]*([eE][-+]?\d[0-9_]*)?>/
+syn match cangjieFloatNumber	/\v\c<\d[0-9_]*\.([eE][-+]?\d[0-9_]*)?>/
+syn match cangjieFloatNumber	/\v\c\.\d[0-9_]*([eE][-+]?\d[0-9_]*)?>/
+syn match cangjieScienceNumber	/\v\c<\d[0-9_]*[eE][-+]?\d[0-9_]*>/
+syn match cangjieHexNumber		/\v\c<0x[0-9a-fA-F_]+>/
+syn match cangjieOctalNumber	/\v\c<0o[0-7_]+>/
+syn match cangjieBinaryNumber	/\v\c<0b[01_]+>/
+syn match cangjieDecimalNumber	/\v\c<\d[0-9_]*>/
+syn cluster cangjieNumberCluster contains=cangjieFloatNumber,cangjieScienceNumber,cangjieHexNumber,cangjieOctalNumber,cangjieBinaryNumber,cangjieDecimalNumber
 
 " 9. operators
-syn match cjOperator /[-+%<>!&|^*=]=\?/
-syn match cjOperator /\/\%(=\|\ze[^/*]\)/
-syn match cjOperator /\%(<<\|>>\|&^\)=\?/
-syn match cjOperator /:=\|||\|<-\|++\|--/
-syn match cjOperator /[~]/
-syn match cjOperator /[:]/
-syn match cjOperator /\.\.\./
+syn match cangjieOperator /[-+%<>!&|^*=]=\?/
+syn match cangjieOperator /\/\%(=\|\ze[^/*]\)/
+syn match cangjieOperator /\%(<<\|>>\|&^\)=\?/
+syn match cangjieOperator /:=\|||\|<-\|++\|--/
+syn match cangjieOperator /[~]/
+syn match cangjieOperator /[:]/
+syn match cangjieOperator /\.\.\./
+
+" finally, link the syntax groups to the highlight groups
+if s:enabled('comment')
+	hi def link cangjieTodo				Todo
+	hi def link cangjieComment			Comment
+endif
+if s:enabled('identifier')
+	hi def link cangjieSpIdentifier		Identifier
+endif
+if s:enabled('keyword')
+	hi def link cangjieDeclaration		Keyword
+	hi def link cangjieStatement		Statement
+	hi def link cangjieIdentlike		Keyword
+	hi def link cangjieVariable			Keyword
+	hi def link cangjieOption			Keyword
+endif
+if s:enabled('macro')
+	hi def link cangjieMacro			PreProc
+endif
+if s:enabled('number')
+	hi def link cangjieFloatNumber		Float
+	hi def link cangjieScienceNumber	Float
+	hi def link cangjieHexNumber		Number
+	hi def link cangjieOctalNumber		Number
+	hi def link cangjieBinaryNumber		Number
+	hi def link cangjieDecimalNumber	Number
+endif
 if s:enabled('operator')
-	hi def link cjOperator	Operator
+	hi def link cangjieOperator			Operator
+endif
+if s:enabled('string')
+	hi def link cangjieRune				Character
+	hi def link cangjieString			String
+	hi def link cangjieRawString		String
+endif
+if s:enabled('type')
+	hi def link cangjieTypeName			Type
+	hi def link cangjieSpType			Type
+	hi def link cangjieArrayType		Type
+	hi def link cangjieHashType			Type
+	hi def link cangjieCommonType		Type
+	hi def link cangjieFloatType		Type
+	hi def link cangjieIntType			Type
+	hi def link cangjieUIntType			Type
 endif
 
 let b:current_syntax = "cangjie"

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -156,6 +156,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     cabalproject: ['cabal.project', 'cabal.project.local'],
     cairo: ['file.cairo'],
     calendar: ['calendar', '/.calendar/file', '/share/calendar/any/calendar.file', '/share/calendar/calendar.file', 'any/share/calendar/any/calendar.file', 'any/share/calendar/calendar.file'],
+    cangjie: ['file.cj'],
     capnp: ['file.capnp'],
     catalog: ['catalog', 'sgml.catalogfile', 'sgml.catalog', 'sgml.catalog-file'],
     cdc: ['file.cdc'],


### PR DESCRIPTION
About issues #18014

This PR introduces a new, comprehensive syntax highlighting file for the Cangjie programming language.

**What is Cangjie?**

Cangjie is a new-generation programming language developed by Huawei. It is designed for all-scenario intelligence and features high performance and strong security. More information can be found at [here](https://cangjie-lang.cn/).

**Summary of Changes**

This PR includes all necessary components for adding a new language syntax:

1.  **New File**: `runtime/syntax/cangjie.vim`
2.  **Filetype Detection**: Added a rule to `runtime/filetype.vim` to recognize the `.cj` extension.
3.  **Documentation**: Updated `runtime/doc/syntax.txt` to include `cangjie` in the help document.
4.  **Menus**: Some menus.

**Features of the Syntax File**

The provided syntax script is robust and covers all major aspects of the Cangjie language, following modern Vim syntax best practices:

-   **Keywords & Types**: Full coverage of keywords and built-in types.
-   **Contextual Highlighting**: `func` and `struct` keywords trigger special highlighting for the following type/function name.
-   **Numbers**: Supports integers, floats, scientific notation, hex, binary, and octal, including `_` separators.
-   **Strings**: Supports single, double, triple-quoted strings, raw strings, and character runes.
-   **Interpolation]**: Correctly handles `${...}` interpolation.
-   **Operators**: A comprehensive and correctly ordered list of operators to prevent conflicts.
-   **Attributes**: Highlights annotations like `@override`.

The file has been tested with a sample covering these features. This contribution will provide a high-quality out-of-the-box experience for Cangjie developers using Vim.

Thank you for your consideration. Love U