### PR TITLE
gui: Implement 'guidarkmode'

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4344,6 +4344,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	  prefer_dark	Apply the dark mode to the GUI elements.
 	  prefer_light	Apply the light mode to the GUI elements.
 	  use_bg	Follow the value of Vim's |background| option.
+	  use_theme	Use the theme foreground and background colors to style the
+			titlebar.
 
 					*'guifontset'* *'gfs'*
 					*E250* *E252* *E234* *E597* *E598*

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4333,6 +4333,18 @@ A jump table for the options with a short description can be found at |Q_op|.
 	In its simplest form the value is just one font name.
 	See |gui-font| for the details.
 
+					*'guidarkmode'*
+'guidarkmode'		string	(default "automatic")
+			global
+			{only available when compiled with GUI enabled}
+	This option specifies whether Vim GUI elements should be drawn using a
+	dark color scheme if available.
+	The allowed values are:
+	  automatic	Follow the current system's preference.
+	  prefer_dark	Apply the dark mode to the GUI elements.
+	  prefer_light	Apply the light mode to the GUI elements.
+	  use_bg	Follow the value of Vim's |background| option.
+
 					*'guifontset'* *'gfs'*
 					*E250* *E252* *E234* *E597* *E598*
 'guifontset' 'gfs'	string	(default "")
@@ -4432,7 +4444,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 		choices.
 								*'go-d'*
 	  'd'	Use dark theme variant if available. Currently only works for
-		GTK+ GUI.
+		Win32 and GTK+ GUI.
 								*'go-e'*
 	  'e'	Add tab pages when indicated with 'showtabline'.
 		'guitablabel' can be used to change the text in the labels.

--- a/src/feature.h
+++ b/src/feature.h
@@ -508,7 +508,7 @@
 /*
  * GUI dark theme variant
  */
-#if defined(FEAT_GUI_GTK) && defined(USE_GTK3)
+#if (defined(FEAT_GUI_GTK) && defined(USE_GTK3)) || defined(FEAT_GUI_MSWIN)
 # define FEAT_GUI_DARKTHEME
 #endif
 

--- a/src/gui.c
+++ b/src/gui.c
@@ -749,6 +749,7 @@ gui_init(void)
 	resettitle();
 
 	init_gui_options();
+
 #ifdef FEAT_ARABIC
 	// Our GUI can't do bidi.
 	p_tbidi = FALSE;
@@ -3472,7 +3473,6 @@ static int	prev_which_scrollbars[3];
 gui_init_which_components(char_u *oldval UNUSED)
 {
 #ifdef FEAT_GUI_DARKTHEME
-    static int	prev_dark_theme = -1;
     int		using_dark_theme = FALSE;
 #endif
 #ifdef FEAT_MENU
@@ -3576,10 +3576,10 @@ gui_init_which_components(char_u *oldval UNUSED)
     fix_size = FALSE;
 
 #ifdef FEAT_GUI_DARKTHEME
-    if (using_dark_theme != prev_dark_theme)
+    if (*p_guidarkmode == NUL)
     {
-	gui_mch_set_dark_theme(using_dark_theme);
-	prev_dark_theme = using_dark_theme;
+	gui.prefer_dark_theme = using_dark_theme ? DM_PREFER_DARK : DM_PREFER_LIGHT;
+	gui_mch_set_dark_theme();
     }
 #endif
 
@@ -4710,6 +4710,11 @@ init_gui_options(void)
 	set_option_value_give_err((char_u *)"bg", 0L, gui_bg_default(), 0);
 	highlight_changed();
     }
+
+#ifdef FEAT_GUI_DARKTHEME
+    // Apply the user preference now that the GUI window is open.
+    gui_mch_set_dark_theme();
+#endif
 }
 
 #if defined(FEAT_GUI_X11) || defined(PROTO)

--- a/src/gui.h
+++ b/src/gui.h
@@ -146,6 +146,15 @@
 				// is no console input possible
 #endif
 
+typedef enum
+{
+    DM_DEFAULT,			// Use the default value for the system.
+    DM_AUTOMATIC,
+    DM_PREFER_LIGHT,
+    DM_PREFER_DARK,
+    DM_USE_BACKGROUND,
+} dm_pref_T;
+
 typedef struct GuiScrollbar
 {
     long	ident;		// Unique identifier for each scrollbar
@@ -260,6 +269,10 @@ typedef struct Gui
     int		left_sbar_x;	    // Calculated x coord for left scrollbar
     int		right_sbar_x;	    // Calculated x coord for right scrollbar
     int         force_redraw;       // Force a redraw even e.g. not resized
+#ifdef FEAT_GUI_DARKTHEME
+    dm_pref_T	prefer_dark_theme;   // Whether to follow or not the global system dark
+				    // mode preference.
+#endif
 
 #ifdef FEAT_MENU
 # ifndef FEAT_GUI_GTK

--- a/src/gui.h
+++ b/src/gui.h
@@ -153,6 +153,7 @@ typedef enum
     DM_PREFER_LIGHT,
     DM_PREFER_DARK,
     DM_USE_BACKGROUND,
+    DM_USE_THEME,
 } dm_pref_T;
 
 typedef struct GuiScrollbar

--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -3230,11 +3230,11 @@ gui_mch_set_dark_theme(void)
     }
 # endif
 
-    switch (sys_prefer_dark_theme)
+    switch (gui.prefer_dark_theme)
     {
 	case DM_PREFER_LIGHT:
 	case DM_PREFER_DARK:
-	    dark = (sys_prefer_dark_theme == DM_PREFER_DARK);
+	    dark = (gui.prefer_dark_theme == DM_PREFER_DARK);
 	    break;
 	case DM_DEFAULT:
 	case DM_AUTOMATIC:

--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -3230,11 +3230,11 @@ gui_mch_set_dark_theme(void)
     }
 # endif
 
-    switch (gui.sys_prefer_dark_theme)
+    switch (sys_prefer_dark_theme)
     {
 	case DM_PREFER_LIGHT:
 	case DM_PREFER_DARK:
-	    dark = (gui.sys_prefer_dark_theme == DM_PREFER_DARK);
+	    dark = (sys_prefer_dark_theme == DM_PREFER_DARK);
 	    break;
 	case DM_DEFAULT:
 	case DM_AUTOMATIC:

--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -3247,6 +3247,8 @@ gui_mch_set_dark_theme(void)
 	    dark = sys_prefer_dark_theme;
 # endif
 	    break;
+	case DM_USE_THEME:
+	    // Not supported for GTK.
 	case DM_USE_BACKGROUND:
 	    dark = (*p_bg == 'd');
 	    break;

--- a/src/highlight.c
+++ b/src/highlight.c
@@ -3940,6 +3940,10 @@ highlight_changed(void)
     term_update_colors_all();
     term_update_wincolor_all();
 #endif
+#ifdef FEAT_GUI_DARKTHEME
+    if (gui.in_use)
+	gui_mch_set_dark_theme();
+#endif
 
     // Clear all attributes.
     for (hlf = 0; hlf < (int)HLF_COUNT; ++hlf)

--- a/src/option.h
+++ b/src/option.h
@@ -667,6 +667,7 @@ EXTERN char_u	*p_header;	// 'printheader'
 #endif
 EXTERN int	p_prompt;	// 'prompt'
 #ifdef FEAT_GUI
+EXTERN char_u	*p_guidarkmode; // 'guidarkmode'
 EXTERN char_u	*p_guifont;	// 'guifont'
 # ifdef FEAT_XFONTSET
 EXTERN char_u	*p_guifontset;	// 'guifontset'

--- a/src/optiondefs.h
+++ b/src/optiondefs.h
@@ -1230,6 +1230,15 @@ static struct vimoption options[] =
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
 			    SCTX_INIT},
+    {"guidarkmode",  NULL,  P_STRING|P_VI_DEF|P_RCLR,
+#if defined(FEAT_GUI_DARKTHEME)
+			    (char_u *)&p_guidarkmode, PV_NONE, did_set_guidarkmode, NULL,
+			    {(char_u *)"automatic", (char_u *)0L}
+#else
+			    (char_u *)NULL, PV_NONE, NULL,
+			    {(char_u *)NULL, (char_u *)0L}
+#endif
+			    SCTX_INIT},
     {"guifont",	    "gfn",  P_STRING|P_VI_DEF|P_RCLR|P_ONECOMMA|P_NODUP
 #if !defined(FEAT_GUI_GTK)
 				|P_COLON

--- a/src/optiondefs.h
+++ b/src/optiondefs.h
@@ -1235,7 +1235,7 @@ static struct vimoption options[] =
 			    (char_u *)&p_guidarkmode, PV_NONE, did_set_guidarkmode, NULL,
 			    {(char_u *)"automatic", (char_u *)0L}
 #else
-			    (char_u *)NULL, PV_NONE, NULL,
+			    (char_u *)NULL, PV_NONE, NULL, NULL,
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
 			    SCTX_INIT},

--- a/src/optiondefs.h
+++ b/src/optiondefs.h
@@ -1233,7 +1233,7 @@ static struct vimoption options[] =
     {"guidarkmode",  NULL,  P_STRING|P_VI_DEF|P_RCLR,
 #if defined(FEAT_GUI_DARKTHEME)
 			    (char_u *)&p_guidarkmode, PV_NONE, did_set_guidarkmode, NULL,
-			    {(char_u *)"automatic", (char_u *)0L}
+			    {(char_u *)"", (char_u *)0L}
 #else
 			    (char_u *)NULL, PV_NONE, NULL, NULL,
 			    {(char_u *)NULL, (char_u *)0L}

--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -2645,6 +2645,8 @@ did_set_guidarkmode(optset_T *args UNUSED)
 	gui.prefer_dark_theme = DM_PREFER_LIGHT;
     else if (!STRCMP(p_guidarkmode, "use_bg"))
 	gui.prefer_dark_theme = DM_USE_BACKGROUND;
+    else if (!STRCMP(p_guidarkmode, "use_theme"))
+	gui.prefer_dark_theme = DM_USE_THEME;
     else
 	return e_invalid_argument;
 

--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -2599,7 +2599,6 @@ did_set_guifont(optset_T *args UNUSED)
     return errmsg;
 }
 
-#if defined(FEAT_GUI_DARKTHEME) || defined(PROTO)
 /*
  * Expand the 'guifont' option. Only when GUI is being used. Each platform has
  * specific behaviors.
@@ -2621,6 +2620,7 @@ expand_set_guifont(optexpand_T *args, int *numMatches, char_u ***matches)
 # endif
 }
 
+#if defined(FEAT_GUI_DARKTHEME) || defined(PROTO)
 /*
  * The 'guidarkmode' option is changed.
  */

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -232,11 +232,9 @@ static BOOL use_alternate_screen_buffer = FALSE;
  * Get version number including build number
  */
 typedef BOOL (WINAPI *PfnRtlGetVersion)(LPOSVERSIONINFOW);
-#define MAKE_VER(major, minor, build) \
-    (((major) << 24) | ((minor) << 16) | (build))
 
-    static DWORD
-get_build_number(void)
+    DWORD
+get_win_version(void)
 {
     OSVERSIONINFOW	osver;
     HMODULE		hNtdll;
@@ -8592,7 +8590,7 @@ mch_setenv(char *var, char *value, int x UNUSED)
     static void
 vtp_flag_init(void)
 {
-    DWORD   ver = get_build_number();
+    DWORD   ver = get_win_version();
 #if !defined(FEAT_GUI_MSWIN) || defined(VIMDLL)
     DWORD   mode;
     HANDLE  out;

--- a/src/os_win32.h
+++ b/src/os_win32.h
@@ -229,3 +229,6 @@ Trace(char *pszFormat, ...);
 #endif
 #define mch_getenv(x) (char_u *)getenv((char *)(x))
 #define vim_mkdir(x, y) mch_mkdir(x)
+
+#define MAKE_VER(major, minor, build) \
+    (((major) << 24) | ((minor) << 16) | (build))

--- a/src/proto/gui_gtk_x11.pro
+++ b/src/proto/gui_gtk_x11.pro
@@ -8,7 +8,7 @@ void gui_mch_stop_blink(int may_call_gui_update_cursor);
 void gui_mch_start_blink(void);
 int gui_mch_early_init_check(int give_message);
 int gui_mch_init_check(void);
-void gui_mch_set_dark_theme(int dark);
+void gui_mch_set_dark_theme(void);
 void gui_mch_show_tabline(int showit);
 int gui_mch_showing_tabline(void);
 void gui_mch_update_tabline(void);

--- a/src/proto/gui_w32.pro
+++ b/src/proto/gui_w32.pro
@@ -42,6 +42,7 @@ void gui_mch_show_tabline(int showit);
 int gui_mch_showing_tabline(void);
 void gui_mch_update_tabline(void);
 void gui_mch_set_curtab(int nr);
+void gui_mch_set_dark_theme(void);
 void ex_simalt(exarg_T *eap);
 void gui_mch_find_dialog(exarg_T *eap);
 void gui_mch_replace_dialog(exarg_T *eap);

--- a/src/proto/optionstr.pro
+++ b/src/proto/optionstr.pro
@@ -92,6 +92,7 @@ int expand_set_foldopen(optexpand_T *args, int *numMatches, char_u ***matches);
 char *did_set_formatoptions(optset_T *args);
 int expand_set_formatoptions(optexpand_T *args, int *numMatches, char_u ***matches);
 char *did_set_guicursor(optset_T *args);
+char *did_set_guidarkmode(optset_T *args);
 char *did_set_guifont(optset_T *args);
 int expand_set_guifont(optexpand_T *args, int *numMatches, char_u ***matches);
 char *did_set_guifontset(optset_T *args);

--- a/src/proto/os_win32.pro
+++ b/src/proto/os_win32.pro
@@ -1,4 +1,5 @@
 /* os_win32.c */
+DWORD get_win_version(void);
 void mch_get_exe_name(void);
 HINSTANCE vimLoadLib(const char *name);
 int mch_is_gui_executable(void);

--- a/src/testdir/util/gen_opt_test.vim
+++ b/src/testdir/util/gen_opt_test.vim
@@ -225,6 +225,7 @@ let test_values = {
       \		'v', 'b', 'l', 'm', 'M', 'B', '1', ']', 'j', 'p', 'vt', 'v,t'],
       \		['xxx']],
       \ 'guicursor': [['', 'n:block-Cursor'], ['xxx']],
+      \ 'guidarkmode': [['', 'automatic', 'prefer_light'], ['xxx', '1', 'automatic,prefer_light']],
       \ 'guifont': [['', fontname], []],
       \ 'guifontset': [['', fontname], []],
       \ 'guifontwide': [['', fontname], []],


### PR DESCRIPTION
Allow gvim to follow the system dark mode and allow the user to override this choice.

The option is already being honored by the GTK UI when 'guioptions' cointains 'd', but this new option gives more freedom to implement different strategies (e.g. the `use_bg` one that follows the 'bg' value) as needed.

Closes #3922

cc @ychin as we had discussed the `'guidarkmode'` behaviour quite some time ago.