### PR TITLE
runtime(python): optimize pythonSync pattern

### DIFF
--- a/runtime/syntax/python.vim
+++ b/runtime/syntax/python.vim
@@ -372,7 +372,7 @@ if !exists("python_no_doctest_highlight")
 endif
 
 " Sync at the beginning of (async) function or class definitions.
-syn sync match pythonSync grouphere NONE "^\%(async\s\+def\|def\|class\)\s\+\h\w*\s*[(:]"
+syn sync match pythonSync grouphere NONE "^\%(def\|class\|async\s\+def\)\s\+\h\w*\s*[(:]"
 
 " The default highlight links.  Can be overridden later.
 hi def link pythonStatement		Statement


### PR DESCRIPTION
Order the keywords by expected frequency: `def` and `class` are assumed to be more likely than `async def` in the majority of Python code.