### PR TITLE
Add v:termda1 and t_Ms

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2911,6 +2911,12 @@ v:termu7resp	The escape sequence returned by the terminal for the |t_u7|
 		this option is set, the TermResponseAll autocommand event is
 		fired, with <amatch> set to "ambiguouswidth".
 
+						*v:termda1*
+v:termda1	The escape sequence returned by a primary device attributes
+		(DA1) query from the terminal.  When this option is set, the
+		TermResponseAll autocommand event is fired, with <amatch> set
+		to "da1".
+
 					*v:testing* *testing-variable*
 v:testing	Must be set before using `test_garbagecollect_now()`.
 		Also, when set certain error messages won't be shown for 2

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -1102,6 +1102,7 @@ $quote	eval.txt	/*$quote*
 't_KJ'	term.txt	/*'t_KJ'*
 't_KK'	term.txt	/*'t_KK'*
 't_KL'	term.txt	/*'t_KL'*
+'t_Ms'	term.txt	/*'t_Ms'*
 't_PE'	term.txt	/*'t_PE'*
 't_PS'	term.txt	/*'t_PS'*
 't_RB'	term.txt	/*'t_RB'*
@@ -10587,6 +10588,7 @@ t_KI	term.txt	/*t_KI*
 t_KJ	term.txt	/*t_KJ*
 t_KK	term.txt	/*t_KK*
 t_KL	term.txt	/*t_KL*
+t_Ms	term.txt	/*t_Ms*
 t_PE	term.txt	/*t_PE*
 t_PS	term.txt	/*t_PS*
 t_RB	term.txt	/*t_RB*
@@ -11257,6 +11259,7 @@ v:t_string	eval.txt	/*v:t_string*
 v:t_tuple	eval.txt	/*v:t_tuple*
 v:t_typealias	eval.txt	/*v:t_typealias*
 v:termblinkresp	eval.txt	/*v:termblinkresp*
+v:termda1	eval.txt	/*v:termda1*
 v:termrbgresp	eval.txt	/*v:termrbgresp*
 v:termresponse	eval.txt	/*v:termresponse*
 v:termrfgresp	eval.txt	/*v:termrfgresp*

--- a/runtime/doc/term.txt
+++ b/runtime/doc/term.txt
@@ -644,6 +644,9 @@ Note: Use the <> form if possible
 		<FocusGained>	Vim window got focus (internal only)
 		<FocusLost>	Vim window lost focus (internal only)
 
+	t_Ms			OSC 52 command format (empty	*t_Ms* *'t_Ms'*
+				if terminal doesn't support it)
+
 Note about t_so and t_mr: When the termcap entry "so" is not present the
 entry for "mr" is used.  And vice versa.  The same is done for "se" and "me".
 If your terminal supports both inversion and standout mode, you can see two

--- a/src/evalvars.c
+++ b/src/evalvars.c
@@ -164,7 +164,8 @@ static struct vimvar
     {VV_NAME("stacktrace",	 VAR_LIST), &t_list_dict_any, VV_RO},
     {VV_NAME("t_tuple",		 VAR_NUMBER), NULL, VV_RO},
     {VV_NAME("wayland_display",  VAR_STRING), NULL, VV_RO},
-    {VV_NAME("clipmethod",  VAR_STRING), NULL, VV_RO},
+    {VV_NAME("clipmethod",	 VAR_STRING), NULL, VV_RO},
+    {VV_NAME("termda1",		 VAR_STRING), NULL, VV_RO},
 };
 
 // shorthand

--- a/src/term.c
+++ b/src/term.c
@@ -1719,7 +1719,7 @@ static char *(key_names[]) =
     "k7", "k8", "k9", "k;", "F1", "F2",
     "%1", "&8", "kb", "kI", "kD", "kh",
     "@7", "kP", "kN", "K1", "K3", "K4", "K5", "kB",
-    "PS", "PE",
+    "PS", "PE", "Ms",
     NULL
 };
 #endif
@@ -5495,6 +5495,8 @@ handle_csi_function_key(
  *	{lead}[ABCDEFHPQRS]
  *	{lead}1;{modifier}[ABCDEFHPQRS]
  *
+ * - DA1 query response: {lead}?...;c
+ *
  * Return 0 for no match, -1 for partial match, > 0 for full match.
  */
     static int
@@ -5605,6 +5607,22 @@ handle_csi(
 	key_name[0] = (int)KS_EXTRA;
 	key_name[1] = (int)KE_IGNORE;
 	*slen = csi_len;
+    }
+
+    // Primary device attributes (DA1) response
+    else if (first == '?' && trail == 'c')
+    {
+	LOG_TRN("Received DA1 response: %s", tp);
+
+	*slen = csi_len;
+#ifdef FEAT_EVAL
+	set_vim_var_string(VV_TERMDA1, tp, *slen);
+#endif
+	apply_autocmds(EVENT_TERMRESPONSEALL,
+					(char_u *)"da1", NULL, FALSE, curbuf);
+
+	key_name[0] = (int)KS_EXTRA;
+	key_name[1] = (int)KE_IGNORE;
     }
 
     // Version string: Eat it when there is at least one digit and

--- a/src/testdir/test_termcodes.vim
+++ b/src/testdir/test_termcodes.vim
@@ -2803,4 +2803,9 @@ func Test_xterm_direct_no_termguicolors()
   close
 endfunc
 
+func Test_da1_handling()
+  call feedkeys("\<Esc>[?62,52;c", 'Lx!')
+  call assert_equal("\<Esc>[?62,52;c", v:termda1)
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/vim.h
+++ b/src/vim.h
@@ -2239,7 +2239,8 @@ typedef int sock_T;
 #define VV_TYPE_TUPLE	111
 #define VV_WAYLAND_DISPLAY 112
 #define VV_CLIPMETHOD 113
-#define VV_LEN		114	// number of v: vars
+#define VV_TERMDA1 114
+#define VV_LEN		115	// number of v: vars
 
 // used for v_number in VAR_BOOL and VAR_SPECIAL
 #define VVAL_FALSE	0L	// VAR_BOOL


### PR DESCRIPTION
Adds `v:termda1` vim var and the respective TermResponseAll <amatch> value `da1`. Information about the primary device attributes (DA1) sequence can be found [here](https://vt100.net/docs/vt510-rm/DA1.html), but can be used to find if the terminal supports the OSC 52 command.

The `t_Ms` option is a termcap entry for what it seems the format of an OSC 52 command, so it should be empty if the terminal doesn't support it. But it seems that it is poorly supported and problematic + I've found many terminals have $TERM set to `xterm`, which has the Ms entry defined despite the terminal not supporting OSC 52. But I think we should still add it for more coverage I suppose...

Relevant issues: https://github.com/neovim/neovim/issues/34472 https://github.com/tmux/tmux/issues/4532