### PR TITLE
Revamp `make proto`

### DIFF
--- a/.github/MAINTAINERS
+++ b/.github/MAINTAINERS
@@ -689,6 +689,7 @@ src/po/ru.po						@RestorerZ
 src/po/sr.po						@eevan78
 src/po/tr.po						@bitigchi
 src/po/uk.po						@sakhnik
+src/proto/gen_prototypes.py				@h-east
 src/xxd/						@jnweiger
 
 # vim:ft=codeowners

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
             architecture: arm64
           - features: normal
             compiler: gcc
-            extra: [vimtags]
+            extra: [vimtags, proto]
           - features: huge
             compiler: gcc
             extra: [no_x11]
@@ -182,6 +182,9 @@ jobs:
               libattr1-dev
             )
           fi
+          if ${{ contains(matrix.extra, 'proto') }}; then
+            PKGS+=( python3-clang )
+          fi
           sudo apt-get update && sudo apt-get upgrade -y --allow-downgrades && sudo apt-get install -y --allow-downgrades "${PKGS[@]}"
 
       - name: Install gcc-${{ env.GCC_VER }}
@@ -270,6 +273,9 @@ jobs:
           if ${{ contains(matrix.extra, 'vimtags') }}; then
             echo "TEST=-C runtime/doc vimtags VIMEXE=../../${SRCDIR}/vim"
           fi
+          if ${{ contains(matrix.extra, 'proto') }}; then
+            echo "TEST=-C src protoclean proto"
+          fi
           echo "CFLAGS=${CFLAGS}"
           echo "CONFOPT=${CONFOPT}"
           # Disables GTK attempt to integrate with the accessibility service that does run in CI.
@@ -351,6 +357,15 @@ jobs:
             git diff --exit-code -- tags
             make html; rm *.html tags.ref;
             test -f errors.log && exit 3;
+            true
+          )
+
+      - name: Generate Proto files
+        if: contains(matrix.extra, 'proto')
+        run: |
+          # This will exit with an error code if the generated proto files differ from source
+          (
+            git diff --exit-code -- src/proto/
             true
           )
 

--- a/Filelist
+++ b/Filelist
@@ -251,6 +251,7 @@ SRC_ALL =	\
 		src/testdir/viewdumps.vim \
 		src/proto.h \
 		src/protodef.h \
+		src/proto/gen_prototypes.py \
 		src/proto/alloc.pro \
 		src/proto/arabic.pro \
 		src/proto/arglist.pro \

--- a/src/Makefile
+++ b/src/Makefile
@@ -1290,7 +1290,7 @@ HAIKUGUI_BUNDLE =
 
 # All GUI files
 ALL_GUI_SRC  = gui.c gui_gtk.c gui_gtk_f.c gui_motif.c gui_xmdlg.c gui_xmebw.c gui_gtk_x11.c gui_x11.c gui_haiku.cc
-ALL_GUI_PRO  = gui.pro gui_gtk.pro gui_motif.pro gui_xmdlg.pro gui_gtk_x11.pro gui_x11.pro gui_w32.pro gui_photon.pro
+ALL_GUI_PRO  = proto/gui.pro proto/gui_gtk.pro proto/gui_motif.pro proto/gui_xmdlg.pro proto/gui_gtk_x11.pro proto/gui_x11.pro proto/gui_w32.pro proto/gui_photon.pro
 
 # }}}
 
@@ -1337,27 +1337,6 @@ XDIFF_INCL = \
 ### Need to change "-I /<path>" to "-isystem /<path>" for GCC 3.x.
 CPP_DEPEND = $(CC) -I$(srcdir) -M$(CPP_MM) \
 		`echo "$(DEPEND_CFLAGS)" $(DEPEND_CFLAGS_FILTER)`
-
-# flags for cproto
-#     This is for cproto 3 patchlevel 8 or below
-#     __inline, __attribute__ and __extension__ are not recognized by cproto
-#     G_IMPLEMENT_INLINES is to avoid functions defined in glib/gutils.h.
-#NO_ATTR = -D__inline= -D__inline__= -DG_IMPLEMENT_INLINES \
-#	  -D"__attribute__\\(x\\)=" -D"__asm__\\(x\\)=" \
-#	  -D__extension__= -D__restrict="" \
-#	  -D__gnuc_va_list=char -D__builtin_va_list=char
-#
-#     This is for cproto 3 patchlevel 9 or above (currently 4.6, 4.7g)
-#     __inline and __attribute__ are now recognized by cproto
-#     __attribute() is not recognized and used in X11/Intrinsic.h
-#     -D"foo()=" is not supported by all compilers so do not use it
-NO_ATTR = -D"__attribute\\(x\\)="
-#
-# Use this for cproto 3 patchlevel 6 or below (use "cproto -V" to check):
-# PROTO_FLAGS = -f4 -d -E"$(CPP)" $(NO_ATTR)
-#
-# Use this for cproto 3 patchlevel 7 or above (use "cproto -V" to check):
-PROTO_FLAGS = -d -E"$(CPP)" $(NO_ATTR)
 
 
 ################################################
@@ -1848,145 +1827,148 @@ ALL_OBJ = $(OBJ_COMMON) \
 	  $(OBJ_MESSAGE_TEST)
 
 
-PRO_AUTO = \
-	alloc.pro \
-	arabic.pro \
-	arglist.pro \
-	autocmd.pro \
-	beval.pro \
-	blob.pro \
-	blowfish.pro \
-	buffer.pro \
-	bufwrite.pro \
-	change.pro \
-	channel.pro \
-	charset.pro \
-	cindent.pro \
-	clientserver.pro \
-	clipboard.pro \
-	cmdexpand.pro \
-	cmdhist.pro \
-	crypt.pro \
-	crypt_zip.pro \
-	debugger.pro \
-	dict.pro \
-	diff.pro \
-	linematch.pro \
-	digraph.pro \
-	drawline.pro \
-	drawscreen.pro \
-	edit.pro \
-	eval.pro \
-	evalbuffer.pro \
-	evalfunc.pro \
-	evalvars.pro \
-	evalwindow.pro \
-	ex_cmds.pro \
-	ex_cmds2.pro \
-	ex_docmd.pro \
-	ex_eval.pro \
-	ex_getln.pro \
-	fileio.pro \
-	filepath.pro \
-	findfile.pro \
-	float.pro \
-	fold.pro \
-	fuzzy.pro \
-	getchar.pro \
-	gc.pro \
-	gui_xim.pro \
-	gui_beval.pro \
-	hardcopy.pro \
-	hashtab.pro \
-	help.pro \
-	highlight.pro \
-	if_cscope.pro \
-	if_lua.pro \
-	if_mzsch.pro \
-	if_python.pro \
-	if_python3.pro \
-	if_ruby.pro \
-	if_xcmdsrv.pro \
-	indent.pro \
-	insexpand.pro \
-	job.pro \
-	json.pro \
-	list.pro \
-	locale.pro \
-	logfile.pro \
-	main.pro \
-	map.pro \
-	mark.pro \
-	match.pro \
-	mbyte.pro \
-	memfile.pro \
-	memline.pro \
-	menu.pro \
-	message.pro \
-	misc1.pro \
-	misc2.pro \
-	mouse.pro \
-	move.pro \
-	netbeans.pro \
-	normal.pro \
-	ops.pro \
-	option.pro \
-	optionstr.pro \
-	os_mac_conv.pro \
-	os_unix.pro \
-	popupmenu.pro \
-	popupwin.pro \
-	profiler.pro \
-	pty.pro \
-	quickfix.pro \
-	regexp.pro \
-	register.pro \
-	screen.pro \
-	scriptfile.pro \
-	search.pro \
-	session.pro \
-	sha256.pro \
-	sign.pro \
-	sound.pro \
-	spell.pro \
-	spellfile.pro \
-	spellsuggest.pro \
-	strings.pro \
-	syntax.pro \
-	tabpanel.pro \
-	tag.pro \
-	term.pro \
-	terminal.pro \
-	termlib.pro \
-	testing.pro \
-	textformat.pro \
-	textobject.pro \
-	textprop.pro \
-	time.pro \
-	tuple.pro \
-	typval.pro \
-	ui.pro \
-	undo.pro \
-	usercmd.pro \
-	userfunc.pro \
-	version.pro \
-	vim9class.pro \
-	vim9cmds.pro \
-	vim9compile.pro \
-	vim9execute.pro \
-	vim9expr.pro \
-	vim9generics.pro \
-	vim9instr.pro \
-	vim9script.pro \
-	vim9type.pro \
-	viminfo.pro \
-	wayland.pro \
-	window.pro \
-	$(ALL_GUI_PRO) \
-	$(TCL_PRO)
-
-PRO_MANUAL = os_amiga.pro os_win32.pro \
-	os_mswin.pro winclip.pro os_vms.pro $(PERL_PRO)
+PROTO_FILES = \
+	proto/alloc.pro \
+	proto/arabic.pro \
+	proto/arglist.pro \
+	proto/autocmd.pro \
+	proto/beval.pro \
+	proto/blob.pro \
+	proto/blowfish.pro \
+	proto/buffer.pro \
+	proto/bufwrite.pro \
+	proto/change.pro \
+	proto/channel.pro \
+	proto/charset.pro \
+	proto/cindent.pro \
+	proto/clientserver.pro \
+	proto/clipboard.pro \
+	proto/cmdexpand.pro \
+	proto/cmdhist.pro \
+	proto/crypt.pro \
+	proto/crypt_zip.pro \
+	proto/debugger.pro \
+	proto/dict.pro \
+	proto/diff.pro \
+	proto/digraph.pro \
+	proto/drawline.pro \
+	proto/drawscreen.pro \
+	proto/edit.pro \
+	proto/eval.pro \
+	proto/evalbuffer.pro \
+	proto/evalfunc.pro \
+	proto/evalvars.pro \
+	proto/evalwindow.pro \
+	proto/ex_cmds.pro \
+	proto/ex_cmds2.pro \
+	proto/ex_docmd.pro \
+	proto/ex_eval.pro \
+	proto/ex_getln.pro \
+	proto/fileio.pro \
+	proto/filepath.pro \
+	proto/findfile.pro \
+	proto/float.pro \
+	proto/fold.pro \
+	proto/fuzzy.pro \
+	proto/gc.pro \
+	proto/getchar.pro \
+	proto/gui_beval.pro \
+	proto/gui_xim.pro \
+	proto/hardcopy.pro \
+	proto/hashtab.pro \
+	proto/help.pro \
+	proto/highlight.pro \
+	proto/if_cscope.pro \
+	proto/if_lua.pro \
+	proto/if_mzsch.pro \
+	proto/if_python.pro \
+	proto/if_python3.pro \
+	proto/if_ruby.pro \
+	proto/if_tcl.pro \
+	proto/if_xcmdsrv.pro \
+	proto/indent.pro \
+	proto/insexpand.pro \
+	proto/job.pro \
+	proto/json.pro \
+	proto/linematch.pro \
+	proto/list.pro \
+	proto/locale.pro \
+	proto/logfile.pro \
+	proto/main.pro \
+	proto/map.pro \
+	proto/mark.pro \
+	proto/match.pro \
+	proto/mbyte.pro \
+	proto/memfile.pro \
+	proto/memline.pro \
+	proto/menu.pro \
+	proto/message.pro \
+	proto/misc1.pro \
+	proto/misc2.pro \
+	proto/mouse.pro \
+	proto/move.pro \
+	proto/netbeans.pro \
+	proto/normal.pro \
+	proto/ops.pro \
+	proto/option.pro \
+	proto/optionstr.pro \
+	proto/os_amiga.pro \
+	proto/os_mac_conv.pro \
+	proto/os_mswin.pro \
+	proto/os_qnx.pro \
+	proto/os_unix.pro \
+	proto/os_vms.pro \
+	proto/os_win32.pro \
+	proto/popupmenu.pro \
+	proto/popupwin.pro \
+	proto/profiler.pro \
+	proto/pty.pro \
+	proto/quickfix.pro \
+	proto/regexp.pro \
+	proto/register.pro \
+	proto/screen.pro \
+	proto/scriptfile.pro \
+	proto/search.pro \
+	proto/session.pro \
+	proto/sha256.pro \
+	proto/sign.pro \
+	proto/sound.pro \
+	proto/spell.pro \
+	proto/spellfile.pro \
+	proto/spellsuggest.pro \
+	proto/strings.pro \
+	proto/syntax.pro \
+	proto/tabpanel.pro \
+	proto/tag.pro \
+	proto/term.pro \
+	proto/terminal.pro \
+	proto/termlib.pro \
+	proto/testing.pro \
+	proto/textformat.pro \
+	proto/textobject.pro \
+	proto/textprop.pro \
+	proto/time.pro \
+	proto/tuple.pro \
+	proto/typval.pro \
+	proto/ui.pro \
+	proto/undo.pro \
+	proto/usercmd.pro \
+	proto/userfunc.pro \
+	proto/version.pro \
+	proto/vim9class.pro \
+	proto/vim9cmds.pro \
+	proto/vim9compile.pro \
+	proto/vim9execute.pro \
+	proto/vim9expr.pro \
+	proto/vim9generics.pro \
+	proto/vim9instr.pro \
+	proto/vim9script.pro \
+	proto/vim9type.pro \
+	proto/viminfo.pro \
+	proto/wayland.pro \
+	proto/winclip.pro \
+	proto/window.pro \
+	$(ALL_GUI_PRO)
 
 # Default target is making the executable and tools
 all: $(VIMTARGET) $(TOOLS) languages $(GUI_BUNDLE)
@@ -2119,67 +2101,56 @@ languages:
 update-po:
 	cd $(PODIR); CC="$(CC)" $(MAKE) prefix=$(DESTDIR)$(prefix) update-po
 
-# Generate function prototypes.  This is not needed to compile vim, but if
-# you want to use it, cproto is out there on the net somewhere -- Webb
+# Generate function prototypes.  Previously, cproto was used, but since there
+# was a lot of fiddling to do to generate them correctly, so we switched to a
+# Python script using libclang.  It has the following features:
+# - Only the bare minimum of macro definitions is required.
+# - Generates the same .pro file even across different operating systems.
+#   (maybe)
 #
-# When generating os_amiga.pro and os_win32.pro there will be a
-# few include files that can not be found, that's OK.
+# How to set up environment to run `make proto`
+# On Ubuntu 24.04:
+# - Install libclang
+#   Use the package provided by Ubuntu.
+#     $ sudo apt install python3-clang
+#   Or, Create venv (if you want to use it freely with pip)
+#     $ python3 -m venv ~/venv
+#     $ source ~/venv/bin/activate
+#     $ pip install --upgrade pip
+#     $ pip install libclang
+# On Windows 11 (using Git Bash):
+# - Install GNU Make 3.81 or later.
+# - Download and install Python from the Python official website.
+# - Install libclang
+#   $ python -m pip install libclang
+# - Change the following lines in this file:
+#   s/^PYTHON=python3/PYTHON=python/
+#   s/^tags TAGS: notags/tags: notags/
+PYTHON=python3
 
-proto: $(PRO_AUTO) $(PRO_MANUAL)
+# The preprocessor directive parsing algorithm is explained below:
+# - `#include` does not result in an error even if the file is unreadable.
+#    (The include directory path specifies only `.`)
+# - Standalone `#if 0`, `#ifdef _DEBUG`, `#ifndef PROTO` and
+#   `#if !defined(PROTO)` are treated as false.
+#   (Parse something like `#else`, if present)
+# - If the condition of `#if <expr>` contains `defined(PROTO)`, evaluate it
+#   and parse it if it is true.
+#   (If false, parse something like `#else`, if present)
+# - Parse any other `#if <expr>` as true.
 
-# Filter out arguments that cproto doesn't support.
-# Don't pass "-pthread", "-fwrapv" and similar arguments to cproto, it sees
-# them as a list of individual flags.
-# The -E"gcc -E" argument must be separate to avoid problems with shell
-# quoting.
-# Strip -O2, it may cause cproto to write stderr to the file "2".
-CPROTO = cproto $(PROTO_FLAGS) -DPROTO \
-	 `echo '$(LINT_CFLAGS)' | sed -e 's/ -[a-z-]\+//g' -e 's/ -O[^ ]\+//g'`
+.PHONY: proto protoclean
+proto: $(PROTO_FILES)
 
-### Would be nice if this would work for "normal" make.
-### Currently it only works for (Free)BSD make.
-#$(PRO_AUTO): $$(*F).c
-#	$(CPROTO) -DFEAT_GUI $(*F).c > $@
+protoclean:
+	-rm -f $(PROTO_FILES)
 
-# Always define FEAT_GUI.  This may generate a few warnings if it's also
-# defined in auto/config.h, you can ignore that.
-.c.pro:
-	$(CPROTO) -DFEAT_GUI $< > proto/$@
-	echo "/* vim: set ft=c : */" >> proto/$@
+GEN_PROTO_CMD = proto/gen_prototypes.py
+GEN_PROTO_ARG = -DPROTO -DFEAT_GUI -DFEAT_WAYLAND -DFEAT_WAYLAND_CLIPBOARD -I.
 
-os_amiga.pro: os_amiga.c
-	$(CPROTO) -DAMIGA -UHAVE_CONFIG_H -DBPTR=char* $< > proto/$@
-	echo "/* vim: set ft=c : */" >> proto/$@
-
-os_win32.pro: os_win32.c
-	$(CPROTO) -DWIN32 -UHAVE_CONFIG_H $< > proto/$@
-	echo "/* vim: set ft=c : */" >> proto/$@
-
-os_mswin.pro: os_mswin.c
-	$(CPROTO) -DWIN32 -UHAVE_CONFIG_H $< > proto/$@
-	echo "/* vim: set ft=c : */" >> proto/$@
-
-winclip.pro: winclip.c
-	$(CPROTO) -DWIN32 -UHAVE_CONFIG_H $< > proto/$@
-	echo "/* vim: set ft=c : */" >> proto/$@
-
-os_vms.pro: os_vms.c
-# must use os_vms_conf.h for auto/config.h
-	mv auto/config.h auto/config.h.save
-	cp os_vms_conf.h auto/config.h
-	$(CPROTO) -DVMS -UFEAT_GUI_MOTIF -UFEAT_GUI_GTK $< > proto/$@
-	echo "/* vim: set ft=c : */" >> proto/$@
-	rm auto/config.h
-	mv auto/config.h.save auto/config.h
-
-# if_perl.pro is special: Use the generated if_perl.c for input and remove
-# prototypes for local functions.
-if_perl.pro: auto/if_perl.c
-	$(CPROTO) -DFEAT_GUI auto/if_perl.c | sed "/_VI/d" > proto/$@
-
-gui_gtk_gresources.pro: auto/gui_gtk_gresources.c
-	$(CPROTO) -DFEAT_GUI $< > proto/$@
-	echo "/* vim: set ft=c : */" >> proto/$@
+# Add `GENPROTO_DEBUG=1` before $(PYTHON) to get debug output.
+proto/%.pro: %.c
+	@$(PYTHON) $(GEN_PROTO_CMD) $< $(GEN_PROTO_ARG)
 
 notags:
 	-rm -f tags
@@ -3102,6 +3073,9 @@ depend:
 	-for i in $(XDIFF_SRC); do echo $$i; \
 		$(CPP_DEPEND) $$i | \
 		sed -e 's+^\([^ ]*\.o\)+objects/\1+' -e 's+xdiff/\.\./++g' >> tmp_make; done
+	-for i in $(PROTO_FILES); do \
+		base=`basename $$i .pro`; \
+		echo "$$i: $$base.c" >> tmp_make; done
 	mv tmp_make Makefile
 
 # Run lint.  Clean up the *.ln files that are sometimes left behind.
@@ -4655,3 +4629,151 @@ objects/xpatience.o: xdiff/xpatience.c xdiff/xinclude.h auto/config.h \
  ex_cmds.h spell.h proto.h globals.h \
  errors.h xdiff/xtypes.h xdiff/xutils.h xdiff/xprepare.h \
  xdiff/xdiffi.h xdiff/xemit.h
+proto/alloc.pro: alloc.c
+proto/arabic.pro: arabic.c
+proto/arglist.pro: arglist.c
+proto/autocmd.pro: autocmd.c
+proto/beval.pro: beval.c
+proto/blob.pro: blob.c
+proto/blowfish.pro: blowfish.c
+proto/buffer.pro: buffer.c
+proto/bufwrite.pro: bufwrite.c
+proto/change.pro: change.c
+proto/channel.pro: channel.c
+proto/charset.pro: charset.c
+proto/cindent.pro: cindent.c
+proto/clientserver.pro: clientserver.c
+proto/clipboard.pro: clipboard.c
+proto/cmdexpand.pro: cmdexpand.c
+proto/cmdhist.pro: cmdhist.c
+proto/crypt.pro: crypt.c
+proto/crypt_zip.pro: crypt_zip.c
+proto/debugger.pro: debugger.c
+proto/dict.pro: dict.c
+proto/diff.pro: diff.c
+proto/digraph.pro: digraph.c
+proto/drawline.pro: drawline.c
+proto/drawscreen.pro: drawscreen.c
+proto/edit.pro: edit.c
+proto/eval.pro: eval.c
+proto/evalbuffer.pro: evalbuffer.c
+proto/evalfunc.pro: evalfunc.c
+proto/evalvars.pro: evalvars.c
+proto/evalwindow.pro: evalwindow.c
+proto/ex_cmds.pro: ex_cmds.c
+proto/ex_cmds2.pro: ex_cmds2.c
+proto/ex_docmd.pro: ex_docmd.c
+proto/ex_eval.pro: ex_eval.c
+proto/ex_getln.pro: ex_getln.c
+proto/fileio.pro: fileio.c
+proto/filepath.pro: filepath.c
+proto/findfile.pro: findfile.c
+proto/float.pro: float.c
+proto/fold.pro: fold.c
+proto/fuzzy.pro: fuzzy.c
+proto/gc.pro: gc.c
+proto/getchar.pro: getchar.c
+proto/gui_beval.pro: gui_beval.c
+proto/gui_xim.pro: gui_xim.c
+proto/hardcopy.pro: hardcopy.c
+proto/hashtab.pro: hashtab.c
+proto/help.pro: help.c
+proto/highlight.pro: highlight.c
+proto/if_cscope.pro: if_cscope.c
+proto/if_lua.pro: if_lua.c
+proto/if_mzsch.pro: if_mzsch.c
+proto/if_python.pro: if_python.c
+proto/if_python3.pro: if_python3.c
+proto/if_ruby.pro: if_ruby.c
+proto/if_tcl.pro: if_tcl.c
+proto/if_xcmdsrv.pro: if_xcmdsrv.c
+proto/indent.pro: indent.c
+proto/insexpand.pro: insexpand.c
+proto/job.pro: job.c
+proto/json.pro: json.c
+proto/linematch.pro: linematch.c
+proto/list.pro: list.c
+proto/locale.pro: locale.c
+proto/logfile.pro: logfile.c
+proto/main.pro: main.c
+proto/map.pro: map.c
+proto/mark.pro: mark.c
+proto/match.pro: match.c
+proto/mbyte.pro: mbyte.c
+proto/memfile.pro: memfile.c
+proto/memline.pro: memline.c
+proto/menu.pro: menu.c
+proto/message.pro: message.c
+proto/misc1.pro: misc1.c
+proto/misc2.pro: misc2.c
+proto/mouse.pro: mouse.c
+proto/move.pro: move.c
+proto/netbeans.pro: netbeans.c
+proto/normal.pro: normal.c
+proto/ops.pro: ops.c
+proto/option.pro: option.c
+proto/optionstr.pro: optionstr.c
+proto/os_amiga.pro: os_amiga.c
+proto/os_mac_conv.pro: os_mac_conv.c
+proto/os_mswin.pro: os_mswin.c
+proto/os_qnx.pro: os_qnx.c
+proto/os_unix.pro: os_unix.c
+proto/os_vms.pro: os_vms.c
+proto/os_win32.pro: os_win32.c
+proto/popupmenu.pro: popupmenu.c
+proto/popupwin.pro: popupwin.c
+proto/profiler.pro: profiler.c
+proto/pty.pro: pty.c
+proto/quickfix.pro: quickfix.c
+proto/regexp.pro: regexp.c
+proto/register.pro: register.c
+proto/screen.pro: screen.c
+proto/scriptfile.pro: scriptfile.c
+proto/search.pro: search.c
+proto/session.pro: session.c
+proto/sha256.pro: sha256.c
+proto/sign.pro: sign.c
+proto/sound.pro: sound.c
+proto/spell.pro: spell.c
+proto/spellfile.pro: spellfile.c
+proto/spellsuggest.pro: spellsuggest.c
+proto/strings.pro: strings.c
+proto/syntax.pro: syntax.c
+proto/tabpanel.pro: tabpanel.c
+proto/tag.pro: tag.c
+proto/term.pro: term.c
+proto/terminal.pro: terminal.c
+proto/termlib.pro: termlib.c
+proto/testing.pro: testing.c
+proto/textformat.pro: textformat.c
+proto/textobject.pro: textobject.c
+proto/textprop.pro: textprop.c
+proto/time.pro: time.c
+proto/tuple.pro: tuple.c
+proto/typval.pro: typval.c
+proto/ui.pro: ui.c
+proto/undo.pro: undo.c
+proto/usercmd.pro: usercmd.c
+proto/userfunc.pro: userfunc.c
+proto/version.pro: version.c
+proto/vim9class.pro: vim9class.c
+proto/vim9cmds.pro: vim9cmds.c
+proto/vim9compile.pro: vim9compile.c
+proto/vim9execute.pro: vim9execute.c
+proto/vim9expr.pro: vim9expr.c
+proto/vim9generics.pro: vim9generics.c
+proto/vim9instr.pro: vim9instr.c
+proto/vim9script.pro: vim9script.c
+proto/vim9type.pro: vim9type.c
+proto/viminfo.pro: viminfo.c
+proto/wayland.pro: wayland.c
+proto/winclip.pro: winclip.c
+proto/window.pro: window.c
+proto/gui.pro: gui.c
+proto/gui_gtk.pro: gui_gtk.c
+proto/gui_motif.pro: gui_motif.c
+proto/gui_xmdlg.pro: gui_xmdlg.c
+proto/gui_gtk_x11.pro: gui_gtk_x11.c
+proto/gui_x11.pro: gui_x11.c
+proto/gui_w32.pro: gui_w32.c
+proto/gui_photon.pro: gui_photon.c

--- a/src/Makefile
+++ b/src/Makefile
@@ -2128,17 +2128,6 @@ update-po:
 #   s/^tags TAGS: notags/tags: notags/
 PYTHON=python3
 
-# The preprocessor directive parsing algorithm is explained below:
-# - `#include` does not result in an error even if the file is unreadable.
-#    (The include directory path specifies only `.`)
-# - Standalone `#if 0`, `#ifdef _DEBUG`, `#ifndef PROTO` and
-#   `#if !defined(PROTO)` are treated as false.
-#   (Parse something like `#else`, if present)
-# - If the condition of `#if <expr>` contains `defined(PROTO)`, evaluate it
-#   and parse it if it is true.
-#   (If false, parse something like `#else`, if present)
-# - Parse any other `#if <expr>` as true.
-
 .PHONY: proto protoclean
 proto: $(PROTO_FILES)
 

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -17,7 +17,7 @@
  * Various routines dealing with allocation and deallocation of memory.
  */
 
-#if defined(MEM_PROFILE) || defined(PROTO)
+#if defined(MEM_PROFILE)
 
 # define MEM_SIZES  8200
 static long_u mem_allocs[MEM_SIZES];
@@ -151,7 +151,7 @@ alloc(size_t size)
     return lalloc(size, TRUE);
 }
 
-#if defined(FEAT_QUICKFIX) || defined(PROTO)
+#if defined(FEAT_QUICKFIX)
 /*
  * alloc() with an ID for alloc_fail().
  */
@@ -293,7 +293,7 @@ theend:
 /*
  * lalloc() with an ID for alloc_fail().
  */
-#if defined(FEAT_SIGNS) || defined(PROTO)
+#if defined(FEAT_SIGNS)
     void *
 lalloc_id(size_t size, int message, alloc_id_T id UNUSED)
 {
@@ -305,7 +305,7 @@ lalloc_id(size_t size, int message, alloc_id_T id UNUSED)
 }
 #endif
 
-#if defined(MEM_PROFILE) || defined(PROTO)
+#if defined(MEM_PROFILE)
 /*
  * realloc() with memory profiling.
  */
@@ -350,7 +350,7 @@ do_outofmem_msg(size_t size)
 	mch_exit(123);
 }
 
-#if defined(EXITFREE) || defined(PROTO)
+#if defined(EXITFREE)
 
 /*
  * Free everything that we allocated.
@@ -645,7 +645,7 @@ ga_clear_strings(garray_T *gap)
     ga_clear(gap);
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Copy a growing array that contains a list of strings.
  */
@@ -877,8 +877,7 @@ ga_append(garray_T *gap, int c)
     return OK;
 }
 
-#if (defined(UNIX) && !defined(USE_SYSTEM)) || defined(MSWIN) \
-	|| defined(PROTO)
+#if (defined(UNIX) && !defined(USE_SYSTEM)) || defined(MSWIN)
 /*
  * Append the text in "gap" below the cursor line and clear "gap".
  */

--- a/src/arabic.c
+++ b/src/arabic.c
@@ -30,7 +30,7 @@
 
 #include "vim.h"
 
-#if defined(FEAT_ARABIC) || defined(PROTO)
+#if defined(FEAT_ARABIC)
 
 // Unicode values for Arabic characters.
 #define a_HAMZA				0x0621

--- a/src/arglist.c
+++ b/src/arglist.c
@@ -89,7 +89,7 @@ alist_new(void)
     }
 }
 
-#if !defined(UNIX) || defined(PROTO)
+#if !defined(UNIX)
 /*
  * Expand the file names in the global argument list.
  * If "fnum_list" is not NULL, use "fnum_list[fnum_len]" as a list of buffer
@@ -213,7 +213,7 @@ alist_add(
     curwin->w_locked = FALSE;
 }
 
-#if defined(BACKSLASH_IN_FILENAME) || defined(PROTO)
+#if defined(BACKSLASH_IN_FILENAME)
 /*
  * Adjust slashes in file names.  Called after 'shellslash' was set.
  */
@@ -299,7 +299,7 @@ get_arglist(garray_T *gap, char_u *str, int escaped)
     return OK;
 }
 
-#if defined(FEAT_QUICKFIX) || defined(FEAT_SYN_HL) || defined(FEAT_SPELL) || defined(PROTO)
+#if defined(FEAT_QUICKFIX) || defined(FEAT_SYN_HL) || defined(FEAT_SPELL)
 /*
  * Parse a list of arguments (file names), expand them and return in
  * "fnames[fcountp]".  When "wig" is TRUE, removes files matching 'wildignore'.
@@ -1394,7 +1394,7 @@ arg_all(void)
     return retval;
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * "argc([window id])" function
  */

--- a/src/auto/configure
+++ b/src/auto/configure
@@ -691,14 +691,12 @@ NETBEANS_SRC
 RUBY_LIBS
 RUBY_CFLAGS_EXTRA
 RUBY_CFLAGS
-RUBY_PRO
 RUBY_OBJ
 RUBY_SRC
 vi_cv_path_ruby
 TCL_LIBS
 TCL_CFLAGS_EXTRA
 TCL_CFLAGS
-TCL_PRO
 TCL_OBJ
 TCL_SRC
 vi_cv_path_tcl
@@ -729,14 +727,12 @@ MZSCHEME_MZC
 MZSCHEME_EXTRA
 MZSCHEME_CFLAGS
 MZSCHEME_LIBS
-MZSCHEME_PRO
 MZSCHEME_OBJ
 MZSCHEME_SRC
 vi_cv_path_mzscheme
 LUA_CFLAGS_EXTRA
 LUA_CFLAGS
 LUA_LIBS
-LUA_PRO
 LUA_OBJ
 LUA_SRC
 vi_cv_path_plain_lua
@@ -6269,7 +6265,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.beam \
       LUA_CFLAGS="-I${vi_cv_path_lua_pfx}/include${LUA_INC}"
       LUA_SRC="if_lua.c"
       LUA_OBJ="objects/if_lua.o"
-      LUA_PRO="if_lua.pro"
       printf "%s\n" "#define FEAT_LUA 1" >>confdefs.h
 
     fi
@@ -6753,7 +6748,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.beam \
     if test $mzs_ok = yes; then
       MZSCHEME_SRC="if_mzsch.c"
       MZSCHEME_OBJ="objects/if_mzsch.o"
-      MZSCHEME_PRO="if_mzsch.pro"
       printf "%s\n" "#define FEAT_MZSCHEME 1" >>confdefs.h
 
     else
@@ -6969,7 +6963,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.beam \
 	PERL_LIBS=$perllibs
 	PERL_SRC="auto/if_perl.c"
 	PERL_OBJ="objects/if_perl.o"
-	PERL_PRO="if_perl.pro"
+	PERL_PRO="proto/if_perl.pro"
 	printf "%s\n" "#define FEAT_PERL 1" >>confdefs.h
 
       fi
@@ -8461,7 +8455,6 @@ printf "%s\n" "<not found>" >&6; }
 
 	  TCL_SRC=if_tcl.c
 	  TCL_OBJ=objects/if_tcl.o
-	  TCL_PRO=if_tcl.pro
 	  TCL_CFLAGS="-I$TCL_INC $TCL_DEFS"
 	fi
       fi
@@ -8618,7 +8611,6 @@ printf "%s\n" "$rubyhdrdir" >&6; }
 
 	RUBY_SRC="if_ruby.c"
 	RUBY_OBJ="objects/if_ruby.o"
-	RUBY_PRO="if_ruby.pro"
 	printf "%s\n" "#define FEAT_RUBY 1" >>confdefs.h
 
 	if test "$enable_rubyinterp" = "dynamic"; then

--- a/src/autocmd.c
+++ b/src/autocmd.c
@@ -630,7 +630,7 @@ autocmd_init(void)
     CLEAR_FIELD(aucmd_win);
 }
 
-#if defined(EXITFREE) || defined(PROTO)
+#if defined(EXITFREE)
     void
 free_all_autocmds(void)
 {
@@ -850,7 +850,7 @@ check_ei(char_u *ei)
     return OK;
 }
 
-# if defined(FEAT_SYN_HL) || defined(PROTO)
+# if defined(FEAT_SYN_HL)
 
 /*
  * Add "what" to 'eventignore' to skip loading syntax highlighting for every
@@ -2030,7 +2030,7 @@ has_cmdundefined(void)
     return (first_autopat[(int)EVENT_CMDUNDEFINED] != NULL);
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Return TRUE when there is a TextYankPost autocommand defined.
  */
@@ -2041,7 +2041,7 @@ has_textyankpost(void)
 }
 #endif
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Return TRUE when there is a CompleteChanged autocommand defined.
  */
@@ -2052,7 +2052,7 @@ has_completechanged(void)
 }
 #endif
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Return TRUE when there is a ModeChanged autocommand defined.
  */
@@ -2678,7 +2678,7 @@ auto_next_pat(
     }
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Get the script context where autocommand "acp" is defined.
  */
@@ -2929,7 +2929,7 @@ has_tabclosedpre(void)
     return (first_autopat[(int)EVENT_TABCLOSEDPRE] != NULL);
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Return TRUE if autocmd is supported.
  */

--- a/src/beval.c
+++ b/src/beval.c
@@ -10,7 +10,7 @@
 
 #include "vim.h"
 
-#if defined(FEAT_BEVAL) || defined(FEAT_PROP_POPUP) || defined(PROTO)
+#if defined(FEAT_BEVAL) || defined(FEAT_PROP_POPUP)
 /*
  * Find text under the mouse position "row" / "col".
  * If "getword" is TRUE the returned text in "*textp" is not the whole line but
@@ -130,7 +130,7 @@ find_word_under_cursor(
 }
 #endif
 
-#if defined(FEAT_BEVAL) || defined(PROTO)
+#if defined(FEAT_BEVAL)
 
 /*
  * Get the text and position to be evaluated for "beval".

--- a/src/beval.h
+++ b/src/beval.h
@@ -7,7 +7,7 @@
  * Do ":help credits" in Vim to see a list of people who contributed.
  */
 
-#if !defined(BEVAL__H) && (defined(FEAT_BEVAL) || defined(PROTO))
+#if !defined(BEVAL__H) && defined(FEAT_BEVAL)
 #define BEVAL__H
 
 #ifdef FEAT_GUI_GTK

--- a/src/blob.c
+++ b/src/blob.c
@@ -13,7 +13,7 @@
 
 #include "vim.h"
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 
 /*
  * Allocate an empty blob.

--- a/src/blowfish.c
+++ b/src/blowfish.c
@@ -22,7 +22,7 @@
 
 #include "vim.h"
 
-#if defined(FEAT_CRYPT) || defined(PROTO)
+#if defined(FEAT_CRYPT)
 
 #define BF_BLOCK    8
 #define BF_BLOCK_MASK 7

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -167,7 +167,7 @@ read_buffer(
     return retval;
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Ensure buffer "buf" is loaded.  Does not trigger the swap-exists action.
  */
@@ -2066,7 +2066,7 @@ enter_buffer(buf_T *buf)
     redraw_later(UPD_NOT_VALID);
 }
 
-#if defined(FEAT_AUTOCHDIR) || defined(PROTO)
+#if defined(FEAT_AUTOCHDIR)
 /*
  * Change to the directory of the current buffer.
  * Don't do this while still starting up.
@@ -3768,7 +3768,7 @@ buflist_add(char_u *fname, int flags)
     return 0;
 }
 
-#if defined(BACKSLASH_IN_FILENAME) || defined(PROTO)
+#if defined(BACKSLASH_IN_FILENAME)
 /*
  * Adjust slashes in file names.  Called after 'shellslash' was set.
  */
@@ -3856,7 +3856,7 @@ otherfile_buf(
     return TRUE;
 }
 
-#if defined(UNIX) || defined(PROTO)
+#if defined(UNIX)
 /*
  * Set inode and device number for a buffer.
  * Must always be called when b_fname is changed!.
@@ -4295,7 +4295,7 @@ resettitle(void)
     mch_settitle(lasttitle, lasticon);
 }
 
-# if defined(EXITFREE) || defined(PROTO)
+# if defined(EXITFREE)
     void
 free_titles(void)
 {
@@ -4305,7 +4305,7 @@ free_titles(void)
 # endif
 
 
-#if defined(FEAT_STL_OPT) || defined(FEAT_GUI_TABLINE) || defined(PROTO)
+#if defined(FEAT_STL_OPT) || defined(FEAT_GUI_TABLINE)
 
 /*
  * Used for building in the status line.
@@ -5986,7 +5986,7 @@ bt_prompt(buf_T *buf)
     return buf != NULL && buf->b_p_bt[0] == 'p' && buf->b_p_bt[1] == 'r';
 }
 
-#if defined(FEAT_PROP_POPUP) || defined(PROTO)
+#if defined(FEAT_PROP_POPUP)
 /*
  * Return TRUE if "buf" is a buffer for a popup window.
  */
@@ -6025,7 +6025,7 @@ bt_nofileread(buf_T *buf)
 	    || buf->b_p_bt[0] == 'p');
 }
 
-#if defined(FEAT_QUICKFIX) || defined(PROTO)
+#if defined(FEAT_QUICKFIX)
 /*
  * Return TRUE if "buf" has 'buftype' set to "nofile".
  */

--- a/src/channel.c
+++ b/src/channel.c
@@ -12,7 +12,7 @@
 
 #include "vim.h"
 
-#if defined(FEAT_JOB_CHANNEL) || defined(PROTO)
+#if defined(FEAT_JOB_CHANNEL)
 
 // TRUE when netbeans is running with a GUI.
 #ifdef FEAT_GUI
@@ -396,7 +396,7 @@ free_unused_channels(int copyID, int mask)
     }
 }
 
-#if defined(FEAT_GUI) || defined(PROTO)
+#if defined(FEAT_GUI)
 
 # if defined(FEAT_GUI_X11) || defined(FEAT_GUI_GTK)
 /*
@@ -3135,7 +3135,7 @@ may_invoke_callback(channel_T *channel, ch_part_T part)
     return TRUE;
 }
 
-#if defined(FEAT_NETBEANS_INTG) || defined(PROTO)
+#if defined(FEAT_NETBEANS_INTG)
 /*
  * Return TRUE when channel "channel" is open for writing to.
  * Also returns FALSE or invalid "channel".
@@ -3472,7 +3472,7 @@ channel_clear(channel_T *channel)
     free_callback(&channel->ch_close_cb);
 }
 
-#if defined(EXITFREE) || defined(PROTO)
+#if defined(EXITFREE)
     void
 channel_free_all(void)
 {
@@ -4143,7 +4143,7 @@ theend:
     free_job_options(&opt);
 }
 
-#if defined(MSWIN) || defined(__HAIKU__) || defined(FEAT_GUI) || defined(PROTO)
+#if defined(MSWIN) || defined(__HAIKU__) || defined(FEAT_GUI)
 /*
  * Check the channels for anything that is ready to be read.
  * The data is put in the read queue.
@@ -4194,7 +4194,7 @@ channel_handle_events(int only_keep_open)
 }
 #endif
 
-# if defined(FEAT_GUI) || defined(PROTO)
+# if defined(FEAT_GUI)
 /*
  * Return TRUE when there is any channel with a keep_open flag.
  */
@@ -4645,7 +4645,7 @@ ch_raw_common(typval_T *argvars, typval_T *rettv, int eval)
 
 #define KEEP_OPEN_TIME 20  // msec
 
-#if (defined(UNIX) && !defined(HAVE_SELECT)) || defined(PROTO)
+#if defined(UNIX) && !defined(HAVE_SELECT)
 /*
  * Add open channels to the poll struct.
  * Return the adjusted struct index.
@@ -4738,7 +4738,7 @@ channel_poll_check(int ret_in, void *fds_in)
 }
 #endif // UNIX && !HAVE_SELECT
 
-#if (!defined(MSWIN) && defined(HAVE_SELECT)) || defined(PROTO)
+#if !defined(MSWIN) && defined(HAVE_SELECT)
 
 /*
  * The "fd_set" type is hidden to avoid problems with the function proto.

--- a/src/charset.c
+++ b/src/charset.c
@@ -773,7 +773,7 @@ chartabsize(char_u *p, colnr_T col)
     RET_WIN_BUF_CHARTABSIZE(curwin, curbuf, p, col)
 }
 
-#if defined(FEAT_LINEBREAK) || defined(PROTO)
+#if defined(FEAT_LINEBREAK)
     int
 win_chartabsize(win_T *wp, char_u *p, colnr_T col)
 {
@@ -1006,7 +1006,7 @@ vim_isfilec(int c)
     return (c >= 0x100 || (c > 0 && (g_chartab[c] & CT_FNAME_CHAR)));
 }
 
-#if defined(FEAT_SPELL) || defined(PROTO)
+#if defined(FEAT_SPELL)
 /*
  * Return TRUE if 'c' is a valid file-name character, including characters left
  * out of 'isfname' to make "gf" work, such as comma, space, '@', etc.
@@ -1880,7 +1880,7 @@ skipwhite(char_u *q)
     return p;
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * skip over ' ', '\t' and '\n'.
  */
@@ -1924,7 +1924,7 @@ skipdigits(char_u *q)
     return p;
 }
 
-#if defined(FEAT_SYN_HL) || defined(FEAT_SPELL) || defined(PROTO)
+#if defined(FEAT_SYN_HL) || defined(FEAT_SPELL)
 /*
  * skip over binary digits
  */

--- a/src/cindent.c
+++ b/src/cindent.c
@@ -4232,7 +4232,7 @@ do_c_expr_indent(void)
 	fixthisline(get_c_indent);
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * "cindent(lnum)" function
  */

--- a/src/clientserver.c
+++ b/src/clientserver.c
@@ -13,7 +13,7 @@
 
 #include "vim.h"
 
-#if defined(FEAT_CLIENTSERVER) || defined(PROTO)
+#if defined(FEAT_CLIENTSERVER)
 
 #ifdef FEAT_SOCKETSERVER
 # include <sys/socket.h>
@@ -182,7 +182,7 @@ serverConvert(
 }
 #endif
 
-#if (defined(FEAT_CLIENTSERVER) && !defined(NO_VIM_MAIN)) || defined(PROTO)
+#if defined(FEAT_CLIENTSERVER) && !defined(NO_VIM_MAIN)
 
 /*
  * Common code for the X command server and the Win32 command server.
@@ -975,7 +975,7 @@ fail:
 }
 #endif
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * "remote_expr()" function
  */

--- a/src/clipboard.c
+++ b/src/clipboard.c
@@ -29,7 +29,7 @@
 // versions of these for the 'clipboard' selection, as Visual mode has no use
 // for them.
 
-#if defined(FEAT_CLIPBOARD) || defined(PROTO)
+#if defined(FEAT_CLIPBOARD)
 
 #if defined(FEAT_WAYLAND_CLIPBOARD)
 
@@ -128,7 +128,7 @@ static int clip_wl_own_selection(Clipboard_T *cbd);
 static void clip_wl_lose_selection(Clipboard_T *cbd);
 static void clip_wl_set_selection(Clipboard_T *cbd);
 
-# if defined(USE_SYSTEM) || defined(PROTO)
+# if defined(USE_SYSTEM)
 static bool clip_wl_owner_exists(Clipboard_T *cbd);
 # endif
 
@@ -1053,7 +1053,7 @@ clip_process_selection(
 #endif
 }
 
-# if defined(FEAT_GUI) || defined(PROTO)
+# if defined(FEAT_GUI)
 /*
  * Redraw part of the selection if character at "row,col" is inside of it.
  * Only used for the GUI.
@@ -1408,7 +1408,7 @@ clip_gen_request_selection(Clipboard_T *cbd UNUSED)
 }
 
 #if (defined(FEAT_X11) && defined(FEAT_XCLIPBOARD) && defined(USE_SYSTEM)) \
-	|| defined(PROTO)
+
     static int
 clip_x11_owner_exists(Clipboard_T *cbd)
 {
@@ -1416,8 +1416,8 @@ clip_x11_owner_exists(Clipboard_T *cbd)
 }
 #endif
 
-#if ((defined(FEAT_X11) || defined(FEAT_WAYLAND_CLIPBOARD)) \
-	&& defined(USE_SYSTEM)) || defined(PROTO)
+#if (defined(FEAT_X11) || defined(FEAT_WAYLAND_CLIPBOARD)) \
+	&& defined(USE_SYSTEM)
     int
 clip_gen_owner_exists(Clipboard_T *cbd UNUSED)
 {
@@ -1548,7 +1548,7 @@ did_set_clipboard(optset_T *args UNUSED)
  * Stuff for the X clipboard.  Shared between VMS and Unix.
  */
 
-#if defined(FEAT_XCLIPBOARD) || defined(FEAT_GUI_X11) || defined(PROTO)
+#if defined(FEAT_XCLIPBOARD) || defined(FEAT_GUI_X11)
 # include <X11/Xatom.h>
 # include <X11/Intrinsic.h>
 
@@ -1740,7 +1740,7 @@ clip_x11_notify_cb(Widget w UNUSED, Atom *sel_atom UNUSED, Atom *target UNUSED)
 /*
  * Property callback to get a timestamp for XtOwnSelection.
  */
-# if (defined(FEAT_X11) && defined(FEAT_XCLIPBOARD)) || defined(PROTO)
+# if defined(FEAT_X11) && defined(FEAT_XCLIPBOARD)
     static void
 clip_x11_timestamp_cb(
     Widget	w,
@@ -2035,8 +2035,7 @@ clip_x11_set_selection(Clipboard_T *cbd UNUSED)
 
 #endif
 
-#if defined(FEAT_XCLIPBOARD) || defined(FEAT_GUI_X11) \
-    || defined(FEAT_GUI_GTK) || defined(PROTO)
+#if defined(FEAT_XCLIPBOARD) || defined(FEAT_GUI_X11) || defined(FEAT_GUI_GTK)
 /*
  * Get the contents of the X CUT_BUFFER0 and put it in "cbd".
  */
@@ -2112,7 +2111,7 @@ yank_cut_buffer0(Display *dpy, Clipboard_T *cbd)
  * 'permanent' of the two), otherwise the PRIMARY one.
  * For now, use a hard-coded sanity limit of 1Mb of data.
  */
-#if (defined(FEAT_X11) && defined(FEAT_CLIPBOARD)) || defined(PROTO)
+#if defined(FEAT_X11) && defined(FEAT_CLIPBOARD)
     void
 x11_export_final_selection(void)
 {
@@ -3416,7 +3415,7 @@ clip_wl_set_selection(Clipboard_T *cbd UNUSED)
 {
 }
 
-#if defined(USE_SYSTEM) || defined(PROTO)
+#if defined(USE_SYSTEM)
 /*
  * Return true if we own the selection corresponding to cbd or another client
  * does.

--- a/src/cmdexpand.c
+++ b/src/cmdexpand.c
@@ -4484,7 +4484,7 @@ wildmenu_cleanup(cmdline_info_T *cclp UNUSED)
 	RedrawingDisabled = 0;
 #endif
 
-#if defined(FEAT_SEARCH_EXTRA) || defined(PROTO)
+#if defined(FEAT_SEARCH_EXTRA)
     // Clear highlighting applied during wildmenu activity
     set_no_hlsearch(TRUE);
 #endif
@@ -4521,7 +4521,7 @@ wildmenu_cleanup(cmdline_info_T *cclp UNUSED)
 #endif
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * "getcompletion()" function
  */
@@ -4863,7 +4863,7 @@ concat_pattern_with_buffer_match(
     mch_memmove(match, pat, pat_len);
     if (match_len > 0)
     {
-#if defined(FEAT_EVAL) || defined(FEAT_SPELL) || defined(PROTO)
+#if defined(FEAT_EVAL) || defined(FEAT_SPELL)
 	if (lowercase)
 	{
 	    char_u  *mword = vim_strnsave(line + end_match_pos->col,
@@ -4884,7 +4884,7 @@ concat_pattern_with_buffer_match(
     match[pat_len + match_len] = NUL;
     return match;
 
-#if defined(FEAT_EVAL) || defined(FEAT_SPELL) || defined(PROTO)
+#if defined(FEAT_EVAL) || defined(FEAT_SPELL)
 cleanup:
     vim_free(match);
     return NULL;

--- a/src/cmdhist.c
+++ b/src/cmdhist.c
@@ -37,7 +37,7 @@ get_histentry(int hist_type)
     return history[hist_type];
 }
 
-#if defined(FEAT_VIMINFO) || defined(PROTO)
+#if defined(FEAT_VIMINFO)
     void
 set_histentry(int hist_type, histentry_T *entry)
 {
@@ -51,7 +51,7 @@ get_hisidx(int hist_type)
     return &hisidx[hist_type];
 }
 
-#if defined(FEAT_VIMINFO) || defined(PROTO)
+#if defined(FEAT_VIMINFO)
     int *
 get_hisnum(int hist_type)
 {
@@ -365,7 +365,7 @@ add_to_history(
 	last_maptick = maptick;
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 
 /*
  * Get identifier of newest history entry.
@@ -668,7 +668,7 @@ f_histnr(typval_T *argvars UNUSED, typval_T *rettv)
 }
 #endif // FEAT_EVAL
 
-#if defined(FEAT_CRYPT) || defined(PROTO)
+#if defined(FEAT_CRYPT)
 /*
  * Very specific function to remove the value in ":set key=val" from the
  * history.

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -783,7 +783,6 @@ if test "$enable_luainterp" = "yes" -o "$enable_luainterp" = "dynamic"; then
       LUA_CFLAGS="-I${vi_cv_path_lua_pfx}/include${LUA_INC}"
       LUA_SRC="if_lua.c"
       LUA_OBJ="objects/if_lua.o"
-      LUA_PRO="if_lua.pro"
       AC_DEFINE(FEAT_LUA)
     fi
     if test "$enable_luainterp" = "dynamic"; then
@@ -848,7 +847,6 @@ if test "$enable_luainterp" = "yes" -o "$enable_luainterp" = "dynamic"; then
   fi
   AC_SUBST(LUA_SRC)
   AC_SUBST(LUA_OBJ)
-  AC_SUBST(LUA_PRO)
   AC_SUBST(LUA_LIBS)
   AC_SUBST(LUA_CFLAGS)
   AC_SUBST(LUA_CFLAGS_EXTRA)
@@ -1107,7 +1105,6 @@ if test "$enable_mzschemeinterp" = "yes"; then
     if test $mzs_ok = yes; then
       MZSCHEME_SRC="if_mzsch.c"
       MZSCHEME_OBJ="objects/if_mzsch.o"
-      MZSCHEME_PRO="if_mzsch.pro"
       AC_DEFINE(FEAT_MZSCHEME)
     else
       MZSCHEME_CFLAGS=
@@ -1118,7 +1115,6 @@ if test "$enable_mzschemeinterp" = "yes"; then
   fi
   AC_SUBST(MZSCHEME_SRC)
   AC_SUBST(MZSCHEME_OBJ)
-  AC_SUBST(MZSCHEME_PRO)
   AC_SUBST(MZSCHEME_LIBS)
   AC_SUBST(MZSCHEME_CFLAGS)
   AC_SUBST(MZSCHEME_EXTRA)
@@ -1248,7 +1244,7 @@ if test "$enable_perlinterp" = "yes" -o "$enable_perlinterp" = "dynamic"; then
 	PERL_LIBS=$perllibs
 	PERL_SRC="auto/if_perl.c"
 	PERL_OBJ="objects/if_perl.o"
-	PERL_PRO="if_perl.pro"
+	PERL_PRO="proto/if_perl.pro"
 	AC_DEFINE(FEAT_PERL)
       fi
      fi
@@ -2074,7 +2070,6 @@ if test "$enable_tclinterp" = "yes" -o "$enable_tclinterp" = "dynamic"; then
 	  AC_DEFINE(FEAT_TCL)
 	  TCL_SRC=if_tcl.c
 	  TCL_OBJ=objects/if_tcl.o
-	  TCL_PRO=if_tcl.pro
 	  TCL_CFLAGS="-I$TCL_INC $TCL_DEFS"
 	fi
       fi
@@ -2094,7 +2089,6 @@ if test "$enable_tclinterp" = "yes" -o "$enable_tclinterp" = "dynamic"; then
 fi
 AC_SUBST(TCL_SRC)
 AC_SUBST(TCL_OBJ)
-AC_SUBST(TCL_PRO)
 AC_SUBST(TCL_CFLAGS)
 AC_SUBST(TCL_CFLAGS_EXTRA)
 AC_SUBST(TCL_LIBS)
@@ -2163,7 +2157,6 @@ if test "$enable_rubyinterp" = "yes" -o "$enable_rubyinterp" = "dynamic"; then
 
 	RUBY_SRC="if_ruby.c"
 	RUBY_OBJ="objects/if_ruby.o"
-	RUBY_PRO="if_ruby.pro"
 	AC_DEFINE(FEAT_RUBY)
 	if test "$enable_rubyinterp" = "dynamic"; then
 	  libruby_soname=`$vi_cv_path_ruby -r rbconfig -e "puts $ruby_rbconfig::CONFIG[['LIBRUBY_ALIASES']].split[[0]]"`
@@ -2191,7 +2184,6 @@ if test "$enable_rubyinterp" = "yes" -o "$enable_rubyinterp" = "dynamic"; then
 fi
 AC_SUBST(RUBY_SRC)
 AC_SUBST(RUBY_OBJ)
-AC_SUBST(RUBY_PRO)
 AC_SUBST(RUBY_CFLAGS)
 AC_SUBST(RUBY_CFLAGS_EXTRA)
 AC_SUBST(RUBY_LIBS)

--- a/src/crypt.c
+++ b/src/crypt.c
@@ -12,7 +12,7 @@
  */
 #include "vim.h"
 
-#if defined(FEAT_CRYPT) || defined(PROTO)
+#if defined(FEAT_CRYPT)
 /*
  * Optional encryption support.
  * Mohsin Ahmed, mosh@sasi.com, 1998-09-24
@@ -77,7 +77,7 @@ typedef struct {
 static int crypt_sodium_init_(cryptstate_T *state, char_u *key, crypt_arg_T *arg);
 static long crypt_sodium_buffer_decode(cryptstate_T *state, char_u *from, size_t len, char_u **buf_out, int last);
 static long crypt_sodium_buffer_encode(cryptstate_T *state, char_u *from, size_t len, char_u **buf_out, int last);
-# if defined(FEAT_SODIUM) || defined(PROTO)
+# if defined(FEAT_SODIUM)
 static void crypt_long_long_to_char(long long n, char_u *s);
 static void crypt_int_to_char(int n, char_u *s);
 static long long crypt_char_to_long_long(char_u *s);
@@ -191,7 +191,7 @@ static cryptmethod_T cryptmethods[CRYPT_M_COUNT] = {
     // to avoid that a text file is recognized as encrypted.
 };
 
-#if defined(FEAT_SODIUM) || defined(PROTO)
+#if defined(FEAT_SODIUM)
 typedef struct {
     size_t	    count;
     unsigned char   key[crypto_box_SEEDBYTES];
@@ -332,7 +332,7 @@ load_sodium(void)
 }
 # endif
 
-# if defined(DYNAMIC_SODIUM) || defined(PROTO)
+# if defined(DYNAMIC_SODIUM)
     int
 sodium_enabled(int verbose)
 {
@@ -437,7 +437,7 @@ crypt_get_header_len(int method_nr)
 }
 
 
-#if defined(FEAT_SODIUM) || defined(PROTO)
+#if defined(FEAT_SODIUM)
 /*
  * Get maximum crypt method specific length of the file header in bytes.
  */
@@ -1287,7 +1287,7 @@ crypt_sodium_buffer_decode(
 # endif
 }
 
-# if defined(FEAT_SODIUM) || defined(PROTO)
+# if defined(FEAT_SODIUM)
     void
 crypt_sodium_lock_key(char_u *key)
 {
@@ -1319,7 +1319,7 @@ crypt_sodium_randombytes_random(void)
     return randombytes_random();
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
     static void
 crypt_sodium_report_hash_params(
 	unsigned long long opslimit,

--- a/src/crypt_zip.c
+++ b/src/crypt_zip.c
@@ -12,7 +12,7 @@
  */
 #include "vim.h"
 
-#if defined(FEAT_CRYPT) || defined(PROTO)
+#if defined(FEAT_CRYPT)
 /*
  * Optional encryption support.
  * Mohsin Ahmed, mosh@sasi.com, 98-09-24

--- a/src/debugger.c
+++ b/src/debugger.c
@@ -13,7 +13,7 @@
 
 #include "vim.h"
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 static int debug_greedy = FALSE;	// batch mode debugging: don't save
 					// and restore typeahead.
 static void do_setdebugtracelevel(char_u *arg);
@@ -929,7 +929,7 @@ dbg_find_breakpoint(
     return debuggy_find(file, fname, after, &dbg_breakp, NULL);
 }
 
-#if defined(FEAT_PROFILE) || defined(PROTO)
+#if defined(FEAT_PROFILE)
 #if defined(PROF_CACHE_LOG)
 static int count_lookups[2];
 #endif

--- a/src/dict.c
+++ b/src/dict.c
@@ -13,7 +13,7 @@
 
 #include "vim.h"
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 
 // List head for garbage collection. Although there can be a reference loop
 // from partial to dict to partial, we don't need to keep track of the partial,

--- a/src/diff.c
+++ b/src/diff.c
@@ -19,7 +19,7 @@
 #include "vim.h"
 #include "xdiff/xdiff.h"
 
-#if defined(FEAT_DIFF) || defined(PROTO)
+#if defined(FEAT_DIFF)
 
 static int diff_busy = FALSE;	    // using diff structs, don't change them
 static int diff_need_update = FALSE; // ex_diffupdate needs to be called
@@ -3822,7 +3822,7 @@ diff_find_change(
     return added;
 }
 
-#if defined(FEAT_FOLDING) || defined(PROTO)
+#if defined(FEAT_FOLDING)
 /*
  * Return TRUE if line "lnum" is not close to a diff block, this line should
  * be in a fold.
@@ -4668,7 +4668,7 @@ xdiff_out_unified(
 
 #endif	// FEAT_DIFF
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 
 /*
  * "diff_filler()" function

--- a/src/digraph.c
+++ b/src/digraph.c
@@ -13,7 +13,7 @@
 
 #include "vim.h"
 
-#if defined(FEAT_DIGRAPHS) || defined(PROTO)
+#if defined(FEAT_DIGRAPHS)
 
 typedef int result_T;
 
@@ -2066,7 +2066,7 @@ digraph_set_common(typval_T *argchars, typval_T *argdigraph)
 
 #endif // FEAT_DIGRAPHS
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * "digraph_get()" function
  */
@@ -2215,7 +2215,7 @@ f_digraph_setlist(typval_T * argvars, typval_T *rettv)
 #endif // FEAT_EVAL
 
 
-#if defined(FEAT_KEYMAP) || defined(PROTO)
+#if defined(FEAT_KEYMAP)
 
 // structure used for b_kmap_ga.ga_data
 typedef struct

--- a/src/drawline.c
+++ b/src/drawline.c
@@ -624,7 +624,7 @@ handle_showbreak_and_filler(win_T *wp, winlinevars_T *wlv)
 }
 #endif
 
-#if defined(FEAT_PROP_POPUP) || defined(PROTO)
+#if defined(FEAT_PROP_POPUP)
 /*
  * Return the cell size of virtual text after truncation.
  */

--- a/src/drawscreen.c
+++ b/src/drawscreen.c
@@ -1046,7 +1046,7 @@ redraw_win_toolbar(win_T *wp)
 }
 #endif
 
-#if defined(FEAT_FOLDING) || defined(PROTO)
+#if defined(FEAT_FOLDING)
 /*
  * Copy "buf[len]" to ScreenLines["off"] and set attributes to "attr".
  */
@@ -2875,7 +2875,7 @@ update_finish(void)
 }
 #endif
 
-#if defined(FEAT_NETBEANS_INTG) || defined(PROTO)
+#if defined(FEAT_NETBEANS_INTG)
     void
 update_debug_sign(buf_T *buf, linenr_T lnum)
 {
@@ -2925,7 +2925,7 @@ update_debug_sign(buf_T *buf, linenr_T lnum)
 }
 #endif
 
-#if defined(FEAT_GUI) || defined(PROTO)
+#if defined(FEAT_GUI)
 /*
  * Update a single window, its status line and maybe the command line msg.
  * Used for the GUI scrollbar.
@@ -3277,7 +3277,7 @@ redraw_buf_later(buf_T *buf, int type)
 #endif
 }
 
-#if defined(FEAT_SIGNS) || defined(PROTO)
+#if defined(FEAT_SIGNS)
     void
 redraw_buf_line_later(buf_T *buf, linenr_T lnum)
 {
@@ -3290,7 +3290,7 @@ redraw_buf_line_later(buf_T *buf, linenr_T lnum)
 }
 #endif
 
-#if defined(FEAT_JOB_CHANNEL) || defined(PROTO)
+#if defined(FEAT_JOB_CHANNEL)
     void
 redraw_buf_and_status_later(buf_T *buf, int type)
 {

--- a/src/edit.c
+++ b/src/edit.c
@@ -49,7 +49,7 @@ static void ins_ctrl_o(void);
 static void ins_shift(int c, int lastc);
 static void ins_del(void);
 static int  ins_bs(int c, int mode, int *inserted_space_p);
-#if defined(FEAT_GUI_TABLINE) || defined(PROTO)
+#if defined(FEAT_GUI_TABLINE)
 static void ins_tabline(int c);
 #endif
 static void ins_left(void);
@@ -1769,7 +1769,7 @@ edit_putchar(int c, int highlight)
     screen_putchar(c, pc_row, pc_col, attr);
 }
 
-#if defined(FEAT_JOB_CHANNEL) || defined(PROTO)
+#if defined(FEAT_JOB_CHANNEL)
 /*
  * Set the insert start position for when using a prompt buffer.
  */
@@ -2636,7 +2636,7 @@ set_last_insert(int c)
     last_insert_skip = 0;
 }
 
-#if defined(EXITFREE) || defined(PROTO)
+#if defined(EXITFREE)
     void
 free_last_insert(void)
 {
@@ -3380,7 +3380,7 @@ replace_do_bs(int limit_col)
 	(void)del_char_after_col(limit_col);
 }
 
-#if defined(FEAT_RIGHTLEFT) || defined(PROTO)
+#if defined(FEAT_RIGHTLEFT)
 /*
  * Map Hebrew keyboard when in hkmap mode.
  */
@@ -4611,7 +4611,7 @@ bracketed_paste(paste_mode_T mode, int drop, garray_T *gap)
     return ret_char;
 }
 
-#if defined(FEAT_GUI_TABLINE) || defined(PROTO)
+#if defined(FEAT_GUI_TABLINE)
     static void
 ins_tabline(int c)
 {
@@ -4634,7 +4634,7 @@ ins_tabline(int c)
 }
 #endif
 
-#if defined(FEAT_GUI) || defined(PROTO)
+#if defined(FEAT_GUI)
     void
 ins_scroll(void)
 {

--- a/src/eval.c
+++ b/src/eval.c
@@ -14,7 +14,7 @@
 
 #include "vim.h"
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 
 #ifdef VMS
 # include <float.h>
@@ -97,7 +97,7 @@ eval_init(void)
     func_init();
 }
 
-#if defined(EXITFREE) || defined(PROTO)
+#if defined(EXITFREE)
     void
 eval_clear(void)
 {
@@ -1005,7 +1005,7 @@ call_func_retlist(
     return rettv.vval.v_list;
 }
 
-#if defined(FEAT_FOLDING) || defined(PROTO)
+#if defined(FEAT_FOLDING)
 /*
  * Evaluate "arg", which is 'foldexpr'.
  * Note: caller must set "curwin" to match "arg".

--- a/src/evalbuffer.c
+++ b/src/evalbuffer.c
@@ -13,7 +13,7 @@
 
 #include "vim.h"
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Mark references in functions of buffers.
  */
@@ -933,7 +933,7 @@ f_setline(typval_T *argvars, typval_T *rettv)
 }
 #endif  // FEAT_EVAL
 
-#if defined(FEAT_PYTHON) || defined(FEAT_PYTHON3) || defined(PROTO)
+#if defined(FEAT_PYTHON) || defined(FEAT_PYTHON3)
 /*
  * Make "buf" the current buffer.  restore_buffer() MUST be called to undo.
  * No autocommands will be executed.  Use aucmd_prepbuf() if there are any.

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -14,7 +14,7 @@
 
 #include "vim.h"
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 
 #ifdef VMS
 # include <float.h>
@@ -4634,7 +4634,7 @@ execute_redir_str(char_u *value, int value_len)
     redir_execute_ga.ga_len += len;
 }
 
-#if defined(FEAT_LUA) || defined(PROTO)
+#if defined(FEAT_LUA)
 /*
  * Get next line from a string containing NL separated lines.
  * Called by do_cmdline() to get the next line.
@@ -9680,7 +9680,7 @@ f_min(typval_T *argvars, typval_T *rettv)
     max_min(argvars, rettv, FALSE);
 }
 
-#if defined(FEAT_MZSCHEME) || defined(PROTO)
+#if defined(FEAT_MZSCHEME)
 /*
  * "mzeval()" function
  */

--- a/src/evalvars.c
+++ b/src/evalvars.c
@@ -13,7 +13,7 @@
 
 #include "vim.h"
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 
 static dictitem_T	globvars_var;		// variable used for g:
 static dict_T		globvardict;		// Dictionary with g: variables
@@ -287,7 +287,7 @@ evalvars_init(void)
     set_reg_var(0);
 }
 
-#if defined(EXITFREE) || defined(PROTO)
+#if defined(EXITFREE)
 /*
  * Free all vim variables information on exit
  */
@@ -416,7 +416,7 @@ eval_charconvert(
     return OK;
 }
 
-# if defined(FEAT_POSTSCRIPT) || defined(PROTO)
+# if defined(FEAT_POSTSCRIPT)
     int
 eval_printexpr(char_u *fname, char_u *args)
 {
@@ -446,7 +446,7 @@ eval_printexpr(char_u *fname, char_u *args)
 }
 # endif
 
-# if defined(FEAT_DIFF) || defined(PROTO)
+# if defined(FEAT_DIFF)
     void
 eval_diff(
     char_u	*origfile,
@@ -504,7 +504,7 @@ eval_patch(
 }
 # endif
 
-#if defined(FEAT_SPELL) || defined(PROTO)
+#if defined(FEAT_SPELL)
 /*
  * Evaluate an expression to a list with suggestions.
  * For the "expr:" part of 'spellsuggest'.
@@ -2520,7 +2520,7 @@ item_lock(typval_T *tv, int deep, int lock, int check_refcount)
     --recurse;
 }
 
-#if (defined(FEAT_MENU) && defined(FEAT_MULTI_LANG)) || defined(PROTO)
+#if defined(FEAT_MENU) && defined(FEAT_MULTI_LANG)
 /*
  * Delete all "menutrans_" variables.
  */

--- a/src/evalwindow.c
+++ b/src/evalwindow.c
@@ -13,7 +13,7 @@
 
 #include "vim.h"
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 
     static int
 win_getid(typval_T *argvars)
@@ -1306,8 +1306,7 @@ f_winwidth(typval_T *argvars, typval_T *rettv)
 }
 #endif // FEAT_EVAL
 
-#if defined(FEAT_EVAL) || defined(FEAT_PYTHON) || defined(FEAT_PYTHON3) \
-	|| defined(PROTO)
+#if defined(FEAT_EVAL) || defined(FEAT_PYTHON) || defined(FEAT_PYTHON3)
 /*
  * Set "win" to be the curwin and "tp" to be the current tab page.
  * restore_win() MUST be called to undo, also when FAIL is returned.

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -1077,7 +1077,7 @@ ex_copy(linenr_T line1, linenr_T line2, linenr_T n)
 
 static char_u	*prevcmd = NULL;	// the previous command
 
-#if defined(EXITFREE) || defined(PROTO)
+#if defined(EXITFREE)
     void
 free_prev_shellcmd(void)
 {
@@ -5579,7 +5579,7 @@ set_old_sub(char_u *val)
 }
 #endif // FEAT_VIMINFO
 
-#if defined(EXITFREE) || defined(PROTO)
+#if defined(EXITFREE)
     void
 free_old_sub(void)
 {
@@ -5587,7 +5587,7 @@ free_old_sub(void)
 }
 #endif
 
-#if defined(FEAT_QUICKFIX) || defined(PROTO)
+#if defined(FEAT_QUICKFIX)
 /*
  * Set up for a tagpreview.
  * Makes the preview window the current window.
@@ -5871,7 +5871,7 @@ skip_vimgrep_pat_ext(char_u *p, char_u **s, int *flags, char_u **nulp, int *cp)
     return p;
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * List v:oldfiles in a nice way.
  */

--- a/src/ex_cmds2.c
+++ b/src/ex_cmds2.c
@@ -126,9 +126,9 @@ check_changed(buf_T *buf, int flags)
     return FALSE;
 }
 
-#if defined(FEAT_GUI_DIALOG) || defined(FEAT_CON_DIALOG) || defined(PROTO)
+#if defined(FEAT_GUI_DIALOG) || defined(FEAT_CON_DIALOG)
 
-#if defined(FEAT_BROWSE) || defined(PROTO)
+#if defined(FEAT_BROWSE)
 /*
  * When wanting to write a file without a file name, ask the user for a name.
  */
@@ -835,9 +835,9 @@ ex_compiler(exarg_T *eap)
 }
 #endif
 
-#if defined(FEAT_PYTHON3) || defined(FEAT_PYTHON) || defined(PROTO)
+#if defined(FEAT_PYTHON3) || defined(FEAT_PYTHON)
 
-# if (defined(FEAT_PYTHON) && defined(FEAT_PYTHON3)) || defined(PROTO)
+# if defined(FEAT_PYTHON) && defined(FEAT_PYTHON3)
 /*
  * Detect Python 3 or 2, and initialize 'pyxversion'.
  */

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -1430,7 +1430,7 @@ do_cmdline(
     return retval;
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Handle when "did_throw" is set after executing commands.
  */
@@ -1624,7 +1624,7 @@ getline_cookie(
 #endif
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Get the next line source line without advancing.
  */
@@ -3250,7 +3250,7 @@ has_cmdmod(cmdmod_T *cmod, int ignore_silent)
 	    || cmod->cmod_filter_regmatch.regprog != NULL;
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * If Vim9 script and "cmdmod" has anything set give an error and return TRUE.
  */
@@ -3571,7 +3571,7 @@ append_command(char_u *cmd)
     *d = NUL;
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * If "start" points "&opt", "&l:opt", "&g:opt" or "$ENV" return a pointer to
  * the name.  Otherwise just return "start".
@@ -3629,7 +3629,7 @@ one_letter_cmd(char_u *p, cmdidx_T *idx)
     return FALSE;
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Return TRUE if "cmd" starts with "123->", a number followed by a method
  * call.
@@ -4043,7 +4043,7 @@ find_ex_command(
     return p;
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 typedef struct
 {
     char	*name;
@@ -5893,8 +5893,7 @@ ends_excmd2(char_u *cmd_start UNUSED, char_u *cmd)
     return c == '"';
 }
 
-#if defined(FEAT_SYN_HL) || defined(FEAT_SEARCH_EXTRA) || defined(FEAT_EVAL) \
-	|| defined(PROTO)
+#if defined(FEAT_SYN_HL) || defined(FEAT_SEARCH_EXTRA) || defined(FEAT_EVAL)
 /*
  * Return the next command, after the first '|' or '\n'.
  * Return NULL if not found.
@@ -6798,7 +6797,7 @@ ex_shell(exarg_T *eap UNUSED)
     do_shell(NULL, 0);
 }
 
-#if defined(HAVE_DROP_FILE) || defined(PROTO)
+#if defined(HAVE_DROP_FILE)
 
 static int drop_busy = FALSE;
 static int drop_filec;
@@ -6974,7 +6973,7 @@ ex_wrongmodifier(exarg_T *eap)
     eap->errmsg = ex_errmsg(e_invalid_command_str, eap->cmd);
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 
 // callback function for 'findfunc'
 static callback_T ffu_cb;
@@ -7157,7 +7156,7 @@ did_set_findfunc(optset_T *args UNUSED)
     return NULL;
 }
 
-# if defined(EXITFREE) || defined(PROTO)
+# if defined(EXITFREE)
     void
 free_findfunc_option(void)
 {
@@ -7989,7 +7988,7 @@ ex_read(exarg_T *eap)
 
 static char_u	*prev_dir = NULL;
 
-#if defined(EXITFREE) || defined(PROTO)
+#if defined(EXITFREE)
     void
 free_cd_dir(void)
 {
@@ -9060,7 +9059,7 @@ close_redir(void)
 #endif
 }
 
-#if (defined(FEAT_SESSION) || defined(FEAT_EVAL)) || defined(PROTO)
+#if defined(FEAT_SESSION) || defined(FEAT_EVAL)
     int
 vim_mkdir_emsg(char_u *name, int prot UNUSED)
 {
@@ -10179,7 +10178,7 @@ expand_sfile(char_u *arg)
     return result;
 }
 
-#if defined(FEAT_GUI_DIALOG) || defined(FEAT_CON_DIALOG) || defined(PROTO)
+#if defined(FEAT_GUI_DIALOG) || defined(FEAT_CON_DIALOG)
 /*
  * Make a dialog message in "buff[DIALOG_MSG_SIZE]".
  * "format" must contain "%s".
@@ -10349,7 +10348,7 @@ ex_digraphs(exarg_T *eap UNUSED)
 #endif
 }
 
-#if defined(FEAT_SEARCH_EXTRA) || defined(PROTO)
+#if defined(FEAT_SEARCH_EXTRA)
     void
 set_no_hlsearch(int flag)
 {
@@ -10420,7 +10419,7 @@ ex_folddo(exarg_T *eap)
 }
 #endif
 
-#if defined(FEAT_QUICKFIX) || defined(PROTO)
+#if defined(FEAT_QUICKFIX)
 /*
  * Returns TRUE if the supplied Ex cmdidx is for a location list command
  * instead of a quickfix command.

--- a/src/ex_eval.c
+++ b/src/ex_eval.c
@@ -13,7 +13,7 @@
 
 #include "vim.h"
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 
 static char	*get_end_emsg(cstack_T *cstack);
 

--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -2014,7 +2014,7 @@ getcmdline_int(
 #endif
 	    trigger_cmd_autocmd(cmdline_type, EVENT_CMDLINELEAVEPRE);
 	    event_cmdlineleavepre_triggered = TRUE;
-#if defined(FEAT_SEARCH_EXTRA) || defined(PROTO)
+#if defined(FEAT_SEARCH_EXTRA)
 	    if ((c == ESC || c == Ctrl_C) && (wim_flags[0] & WIM_LIST))
 		set_no_hlsearch(TRUE);
 #endif
@@ -2783,7 +2783,7 @@ theend:
     }
 }
 
-#if (defined(FEAT_CRYPT) || defined(FEAT_EVAL)) || defined(PROTO)
+#if defined(FEAT_CRYPT) || defined(FEAT_EVAL)
 /*
  * Get a command line with a prompt.
  * This is prepared to be called recursively from getcmdline() (e.g. by
@@ -3350,8 +3350,7 @@ cmdline_overstrike(void)
     return ccline.overstrike;
 }
 
-# if defined(MCH_CURSOR_SHAPE) || defined(FEAT_GUI) \
-	 || defined(FEAT_MOUSESHAPE) || defined(PROTO)
+# if defined(MCH_CURSOR_SHAPE) || defined(FEAT_GUI) || defined(FEAT_MOUSESHAPE)
 /*
  * Return TRUE if the cursor is at the end of the cmdline.
  */
@@ -3362,7 +3361,7 @@ cmdline_at_end(void)
 }
 #endif
 
-#if (defined(FEAT_XIM) && (defined(FEAT_GUI_GTK))) || defined(PROTO)
+#if defined(FEAT_XIM) && (defined(FEAT_GUI_GTK))
 /*
  * Return the virtual column number at the current cursor position.
  * This is used by the IM code to obtain the start of the preedit string.
@@ -3533,10 +3532,10 @@ realloc_cmdbuff(int len)
     return OK;
 }
 
-#if defined(FEAT_ARABIC) || defined(PROTO)
+#if defined(FEAT_ARABIC)
 static char_u	*arshape_buf = NULL;
 
-# if defined(EXITFREE) || defined(PROTO)
+# if defined(EXITFREE)
     void
 free_arshape_buf(void)
 {
@@ -4333,7 +4332,7 @@ get_cmdline_type(void)
     return p->cmdfirstc;
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Get the current command line in allocated memory.
  * Only works when the command line is being edited.
@@ -5057,7 +5056,7 @@ script_get(exarg_T *eap UNUSED, char_u *cmd UNUSED)
 #endif
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * This function is used by f_input() and f_inputdialog() functions. The third
  * argument to f_input() specifies the type of completion to use at the

--- a/src/feature.h
+++ b/src/feature.h
@@ -341,7 +341,7 @@
  * +syntax		syntax highlighting.  When using this, it's a good
  *			idea to have +eval too.
  */
-#if defined(FEAT_NORMAL) || defined(PROTO)
+#if defined(FEAT_NORMAL)
 # define FEAT_SYN_HL
 #endif
 
@@ -356,14 +356,14 @@
 /*
  * +spell		spell checking
  */
-#if (defined(FEAT_NORMAL) || defined(PROTO))
+#if defined(FEAT_NORMAL)
 # define FEAT_SPELL
 #endif
 
 /*
  * +cryptv		Encryption (originally by Mohsin Ahmed <mosh@sasi.com>).
  */
-#if defined(FEAT_NORMAL) && !defined(FEAT_CRYPT) || defined(PROTO)
+#if defined(FEAT_NORMAL) && !defined(FEAT_CRYPT)
 # define FEAT_CRYPT
 #endif
 

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -2750,7 +2750,7 @@ theend:
     return retval;
 }
 
-#if defined(OPEN_CHR_FILES) || defined(PROTO)
+#if defined(OPEN_CHR_FILES)
 /*
  * Returns TRUE if the file name argument is of the form "/dev/fd/\d\+",
  * which is the name of files used for process substitution output by
@@ -2955,7 +2955,7 @@ readfile_charconvert(
 }
 #endif
 
-#if defined(FEAT_CRYPT) || defined(PROTO)
+#if defined(FEAT_CRYPT)
 /*
  * Check for magic number used for encryption.  Applies to the current buffer.
  * If found, the magic number is removed from ptr[*sizep] and *sizep and
@@ -3068,7 +3068,7 @@ check_file_readonly(
 	);
 }
 
-#if defined(HAVE_FSYNC) || defined(PROTO)
+#if defined(HAVE_FSYNC)
 /*
  * Call fsync() with Mac-specific exception.
  * Return fsync() result: zero for success.
@@ -3305,7 +3305,7 @@ get_fio_flags(char_u *ptr)
     return 0;
 }
 
-#if defined(MSWIN) || defined(PROTO)
+#if defined(MSWIN)
 /*
  * Check "ptr" for a MS-Windows codepage name and return the FIO_ flags needed
  * for the conversion MS-Windows can do for us.  Also accept "utf-8".
@@ -3334,7 +3334,7 @@ get_win_fio_flags(char_u *ptr)
 }
 #endif
 
-#if defined(MACOS_CONVERT) || defined(PROTO)
+#if defined(MACOS_CONVERT)
 /*
  * Check "ptr" for a Carbon supported encoding and return the FIO_ flags
  * needed for the internal conversion to/from utf-8 or latin1.
@@ -3545,8 +3545,7 @@ shorten_fnames(int force)
 
 #if (defined(FEAT_DND) && defined(FEAT_GUI_GTK)) \
 	|| defined(FEAT_GUI_MSWIN) \
-	|| defined(FEAT_GUI_HAIKU) \
-	|| defined(PROTO)
+	|| defined(FEAT_GUI_HAIKU)
 /*
  * Shorten all filenames in "fnames[count]" by current directory.
  */
@@ -4949,7 +4948,7 @@ compare_readdir_item(const void *s1, const void *s2)
 }
 #endif
 
-#if defined(TEMPDIRNAMES) || defined(FEAT_EVAL) || defined(PROTO)
+#if defined(TEMPDIRNAMES) || defined(FEAT_EVAL)
 /*
  * Core part of "readdir()" and "readdirex()" function.
  * Retrieve the list of files/directories of "path" into "gap".
@@ -5218,7 +5217,7 @@ delete_recursive(char_u *name)
 }
 #endif
 
-#if defined(TEMPDIRNAMES) || defined(PROTO)
+#if defined(TEMPDIRNAMES)
 static long	temp_count = 0;		// Temp filename counter.
 
 # if defined(UNIX) && defined(HAVE_FLOCK) && defined(HAVE_DIRFD)
@@ -5529,7 +5528,7 @@ vim_tempname(
 #endif // TEMPDIRNAMES
 }
 
-#if defined(BACKSLASH_IN_FILENAME) || defined(PROTO)
+#if defined(BACKSLASH_IN_FILENAME)
 /*
  * Convert all backslashes in fname to forward slashes in-place, unless when
  * it looks like a URL.
@@ -5840,7 +5839,7 @@ file_pat_to_reg_pat(
     return reg_pat;
 }
 
-#if defined(EINTR) || defined(PROTO)
+#if defined(EINTR)
 /*
  * Version of read() that retries when interrupted by EINTR (possibly
  * by a SIGWINCH).

--- a/src/filepath.c
+++ b/src/filepath.c
@@ -809,7 +809,7 @@ file_is_readable(char_u *fname)
     return FALSE;
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 
 /*
  * "chdir(dir)" function
@@ -2446,7 +2446,7 @@ f_writefile(typval_T *argvars, typval_T *rettv)
 
 #endif // FEAT_EVAL
 
-#if defined(FEAT_BROWSE) || defined(PROTO)
+#if defined(FEAT_BROWSE)
 /*
  * Generic browse function.  Calls gui_mch_browse() when possible.
  * Later this may pop-up a non-GUI file selector (external command?).
@@ -2608,7 +2608,7 @@ do_browse(
 }
 #endif
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 
 /*
  * "browse(save, title, initdir, default)" function
@@ -3753,8 +3753,7 @@ dos_expandpath(
 }
 #endif // MSWIN
 
-#if (defined(UNIX) && !defined(VMS)) || defined(USE_UNIXFILENAME) \
-	|| defined(PROTO)
+#if (defined(UNIX) && !defined(VMS)) || defined(USE_UNIXFILENAME)
 /*
  * Unix style wildcard expansion code.
  * It's here because it's used both for Unix and Mac.

--- a/src/findfile.c
+++ b/src/findfile.c
@@ -1738,7 +1738,7 @@ find_file_in_path(
 	    file_to_find, search_ctx);
 }
 
-# if defined(EXITFREE) || defined(PROTO)
+# if defined(EXITFREE)
     void
 free_findfile(void)
 {
@@ -2987,7 +2987,7 @@ simplify_filename(char_u *filename)
 #endif // !AMIGA
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * "simplify()" function
  */

--- a/src/float.c
+++ b/src/float.c
@@ -14,7 +14,7 @@
 
 #include "vim.h"
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 
 #ifdef VMS
 # include <float.h>
@@ -338,7 +338,7 @@ f_fmod(typval_T *argvars, typval_T *rettv)
 	rettv->vval.v_float = 0.0;
 }
 
-# if defined(HAVE_MATH_H) || defined(PROTO)
+# if defined(HAVE_MATH_H)
 /*
  * "isinf()" function
  */

--- a/src/fold.c
+++ b/src/fold.c
@@ -14,7 +14,7 @@
 
 #include "vim.h"
 
-#if defined(FEAT_FOLDING) || defined(PROTO)
+#if defined(FEAT_FOLDING)
 
 // local declarations. {{{1
 // typedef fold_T {{{2
@@ -3532,7 +3532,7 @@ foldlevelSyntax(fline_T *flp)
 
 // functions for storing the fold state in a View {{{1
 // put_folds() {{{2
-#if defined(FEAT_SESSION) || defined(PROTO)
+#if defined(FEAT_SESSION)
 static int put_folds_recurse(FILE *fd, garray_T *gap, linenr_T off);
 static int put_foldopen_recurse(FILE *fd, win_T *wp, garray_T *gap, linenr_T off);
 static int put_fold_open_close(FILE *fd, fold_T *fp, linenr_T off);
@@ -3663,9 +3663,9 @@ put_fold_open_close(FILE *fd, fold_T *fp, linenr_T off)
 #endif // FEAT_SESSION
 
 // }}}1
-#endif // defined(FEAT_FOLDING) || defined(PROTO)
+#endif // defined(FEAT_FOLDING)
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 
 /*
  * "foldclosed()" and "foldclosedend()" functions

--- a/src/gc.c
+++ b/src/gc.c
@@ -13,7 +13,7 @@
 
 #include "vim.h"
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 
 /*
  * When recursively copying lists and dicts we need to remember which ones we
@@ -363,8 +363,7 @@ set_ref_in_ht(
     return abort;
 }
 
-#if defined(FEAT_LUA) || defined(FEAT_PYTHON) || defined(FEAT_PYTHON3) \
-							|| defined(PROTO)
+#if defined(FEAT_LUA) || defined(FEAT_PYTHON) || defined(FEAT_PYTHON3)
 /*
  * Mark a dict and its items with "copyID".
  * Returns TRUE if setting references failed somehow.

--- a/src/getchar.c
+++ b/src/getchar.c
@@ -436,7 +436,7 @@ stuff_empty(void)
 	 && readbuf2.bh_first.b_next == NULL);
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Return TRUE if readbuf1 is empty.  There may still be redo characters in
  * redbuf2.
@@ -717,7 +717,7 @@ stuffReadbuffLen(char_u *s, long len)
     add_buff(&readbuf1, s, len);
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Stuff "s" into the stuff buffer, leaving special key codes unmodified and
  * escaping other K_SPECIAL and CSI bytes.
@@ -1700,7 +1700,7 @@ closescript(void)
 	--curscript;
 }
 
-#if defined(EXITFREE) || defined(PROTO)
+#if defined(EXITFREE)
     void
 close_all_scripts(void)
 {
@@ -2335,7 +2335,7 @@ vpeekc(void)
     return vgetorpeek(FALSE);
 }
 
-#if defined(FEAT_TERMRESPONSE) || defined(FEAT_TERMINAL) || defined(PROTO)
+#if defined(FEAT_TERMRESPONSE) || defined(FEAT_TERMINAL)
 /*
  * Like vpeekc(), but don't allow mapping.  Do allow checking for terminal
  * codes.
@@ -2391,7 +2391,7 @@ char_avail(void)
     return (retval != NUL);
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * "getchar()" and "getcharstr()" functions
  */
@@ -2582,7 +2582,7 @@ f_getcharmod(typval_T *argvars UNUSED, typval_T *rettv)
 }
 #endif // FEAT_EVAL
 
-#if defined(MESSAGE_QUEUE) || defined(PROTO)
+#if defined(MESSAGE_QUEUE)
 # define MAX_REPEAT_PARSE 8
 
 /*
@@ -4189,7 +4189,7 @@ fix_input_buffer(char_u *buf, int len)
     return len;
 }
 
-#if defined(USE_INPUT_BUF) || defined(PROTO)
+#if defined(USE_INPUT_BUF)
 /*
  * Return TRUE when bytes are in the input buffer or in the typeahead buffer.
  * Normally the input buffer would be sufficient, but the server_to_input_buf()
@@ -4314,7 +4314,7 @@ getcmdkeycmd(
     return (char_u *)line_ga.ga_data;
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * If there was a mapping we get its SID.  Otherwise, use "last_used_sid", it
  * is set when redo'ing.
@@ -4379,7 +4379,7 @@ do_cmdkey_command(int key UNUSED, int flags)
     return res;
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
     void
 reset_last_used_map(mapblock_T *mp)
 {

--- a/src/globals.h
+++ b/src/globals.h
@@ -1869,9 +1869,6 @@ EXTERN Window	clientWindow INIT(= None);
 EXTERN Atom	commProperty INIT(= None);
 EXTERN char_u	*serverDelayedStartName INIT(= NULL);
 # elif defined(MSWIN)
-#  ifdef PROTO
-typedef int HWND;
-#  endif
 EXTERN HWND	clientWindow INIT(= 0);
 # endif
 #endif
@@ -2023,9 +2020,6 @@ EXTERN evalarg_T EVALARG_EVALUATE
 #endif
 
 #ifdef MSWIN
-# ifdef PROTO
-typedef int HINSTANCE;
-# endif
 EXTERN int ctrl_break_was_pressed INIT(= FALSE);
 EXTERN HINSTANCE g_hinst INIT(= NULL);
 #endif

--- a/src/globals.h
+++ b/src/globals.h
@@ -1601,7 +1601,7 @@ EXTERN int	listcmd_busy INIT(= FALSE); // set when :argdo, :windo or
 					    // :bufdo is executing
 EXTERN int	need_start_insertmode INIT(= FALSE);
 					    // start insert mode soon
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 EXTERN char_u	last_mode[MODE_MAX_LENGTH] INIT(= "n"); // for ModeChanged event
 #endif
 EXTERN char_u	*last_cmdline INIT(= NULL); // last command line (for ":)

--- a/src/gui.c
+++ b/src/gui.c
@@ -25,7 +25,7 @@ static int gui_outstr_nowrap(char_u *s, int len, int flags, guicolor_T fg, guico
 static void gui_delete_lines(int row, int count);
 static void gui_insert_lines(int row, int count);
 static int gui_xy2colrow(int x, int y, int *colp);
-#if defined(FEAT_GUI_TABLINE) || defined(PROTO)
+#if defined(FEAT_GUI_TABLINE)
 static int gui_has_tabline(void);
 #endif
 static void gui_do_scrollbar(win_T *wp, int which, int enable);
@@ -859,7 +859,7 @@ gui_exit(int rc)
 }
 
 #if defined(FEAT_GUI_GTK) || defined(FEAT_GUI_X11) || defined(FEAT_GUI_MSWIN) \
-	|| defined(FEAT_GUI_PHOTON) || defined(PROTO)
+	|| defined(FEAT_GUI_PHOTON)
 # define NEED_GUI_UPDATE_SCREEN 1
 /*
  * Called when the GUI shell is closed by the user.  If there are no changed
@@ -1078,7 +1078,7 @@ gui_get_wide_font(void)
     return OK;
 }
 
-#if defined(FEAT_GUI_GTK) || defined(FEAT_GUI_MSWIN) || defined(PROTO)
+#if defined(FEAT_GUI_GTK) || defined(FEAT_GUI_MSWIN)
 /*
  * Set list of ascii characters that combined can create ligature.
  * Store them in char map for quick access from gui_gtk2_draw_string.
@@ -1410,7 +1410,7 @@ gui_update_cursor(
     gui.highlight_mask = old_hl_mask;
 }
 
-#if defined(FEAT_MENU) || defined(PROTO)
+#if defined(FEAT_MENU)
     static void
 gui_position_menu(void)
 {
@@ -3445,7 +3445,7 @@ gui_xy2colrow(int x, int y, int *colp)
     return row;
 }
 
-#if defined(FEAT_MENU) || defined(PROTO)
+#if defined(FEAT_MENU)
 /*
  * Callback function for when a menu entry has been selected.
  */
@@ -3725,7 +3725,7 @@ gui_init_which_components(char_u *oldval UNUSED)
 	shell_new_rows();	// recompute window positions and heights
 }
 
-#if defined(FEAT_GUI_TABLINE) || defined(PROTO)
+#if defined(FEAT_GUI_TABLINE)
 /*
  * Return TRUE if the GUI is taking care of the tabline.
  * It may still be hidden if 'showtabline' is zero.
@@ -4735,7 +4735,7 @@ init_gui_options(void)
     }
 }
 
-#if defined(FEAT_GUI_X11) || defined(PROTO)
+#if defined(FEAT_GUI_X11)
     void
 gui_new_scrollbar_colors(void)
 {
@@ -5011,10 +5011,10 @@ ex_gui(exarg_T *eap)
 	ex_next(eap);
 }
 
-#if ((defined(FEAT_GUI_X11) || defined(FEAT_GUI_GTK) \
+#if (defined(FEAT_GUI_X11) || defined(FEAT_GUI_GTK) \
 	    || defined(FEAT_GUI_MSWIN) || defined(FEAT_GUI_PHOTON) \
 	    || defined(FEAT_GUI_HAIKU)) \
-	    && defined(FEAT_TOOLBAR)) || defined(PROTO)
+	    && defined(FEAT_TOOLBAR)
 /*
  * This is shared between Haiku, Motif, and GTK.
  */
@@ -5049,7 +5049,7 @@ gui_find_bitmap(char_u *name, char_u *buffer, char *ext)
     return OK;
 }
 
-# if !defined(FEAT_GUI_GTK) || defined(PROTO)
+# if !defined(FEAT_GUI_GTK)
 /*
  * Given the name of the "icon=" argument, try finding the bitmap file for the
  * icon.  If it is an absolute path name, use it as it is.  Otherwise append
@@ -5069,8 +5069,7 @@ gui_find_iconfile(char_u *name, char_u *buffer, char *ext)
 # endif
 #endif
 
-#if defined(FEAT_GUI_GTK) || defined(FEAT_GUI_X11)|| defined(FEAT_GUI_HAIKU) \
-	|| defined(PROTO)
+#if defined(FEAT_GUI_GTK) || defined(FEAT_GUI_X11)|| defined(FEAT_GUI_HAIKU)
     void
 display_errors(void)
 {
@@ -5100,7 +5099,7 @@ display_errors(void)
 }
 #endif
 
-#if defined(NO_CONSOLE_INPUT) || defined(PROTO)
+#if defined(NO_CONSOLE_INPUT)
 /*
  * Return TRUE if still starting up and there is no place to enter text.
  * For GTK and X11 we check if stderr is not a tty, which means we were
@@ -5119,8 +5118,7 @@ no_console_input(void)
 #endif
 
 #if defined(FIND_REPLACE_DIALOG) \
-	|| defined(NEED_GUI_UPDATE_SCREEN) \
-	|| defined(PROTO)
+	|| defined(NEED_GUI_UPDATE_SCREEN)
 /*
  * Update the current window and the screen.
  */
@@ -5185,7 +5183,7 @@ gui_update_screen(void)
 }
 #endif
 
-#if defined(FIND_REPLACE_DIALOG) || defined(PROTO)
+#if defined(FIND_REPLACE_DIALOG)
 /*
  * Get the text to use in a find/replace dialog.  Uses the last search pattern
  * if the argument is empty.
@@ -5396,7 +5394,7 @@ gui_do_findrepl(
 
 #endif
 
-#if defined(HAVE_DROP_FILE) || defined(PROTO)
+#if defined(HAVE_DROP_FILE)
 /*
  * Jump to the window at specified point (x, y).
  */

--- a/src/gui_beval.c
+++ b/src/gui_beval.c
@@ -10,10 +10,10 @@
 
 #include "vim.h"
 
-#if defined(FEAT_BEVAL_GUI) || defined(PROTO)
+#if defined(FEAT_BEVAL_GUI)
 
 // on Win32 only get_beval_info() is required
-#if !defined(FEAT_GUI_MSWIN) || defined(PROTO)
+#if !defined(FEAT_GUI_MSWIN)
 
 #ifdef FEAT_GUI_GTK
 # if GTK_CHECK_VERSION(3,0,0)
@@ -138,7 +138,7 @@ gui_mch_create_beval_area(
     return beval;
 }
 
-#if defined(FEAT_BEVAL_TIP) || defined(PROTO)
+#if defined(FEAT_BEVAL_TIP)
 /*
  * Destroy a balloon-eval and free its associated memory.
  */
@@ -175,7 +175,7 @@ gui_mch_disable_beval_area(BalloonEval *beval)
 	removeEventHandler(beval);
 }
 
-#if defined(FEAT_BEVAL_TIP) || defined(PROTO)
+#if defined(FEAT_BEVAL_TIP)
 /*
  * This function returns the BalloonEval * associated with the currently
  * displayed tooltip.  Returns NULL if there is no tooltip currently showing.
@@ -190,8 +190,8 @@ gui_mch_currently_showing_beval(void)
 #endif
 #endif // !FEAT_GUI_MSWIN
 
-#if defined(FEAT_NETBEANS_INTG) || defined(FEAT_EVAL) || defined(PROTO)
-# if !defined(FEAT_GUI_MSWIN) || defined(PROTO)
+#if defined(FEAT_NETBEANS_INTG) || defined(FEAT_EVAL)
+# if !defined(FEAT_GUI_MSWIN)
 
 /*
  * Show a balloon with "mesg".
@@ -207,10 +207,10 @@ gui_mch_post_balloon(BalloonEval *beval, char_u *mesg)
 	undrawBalloon(beval);
 }
 # endif // !FEAT_GUI_MSWIN
-#endif // FEAT_NETBEANS_INTG || PROTO
+#endif // FEAT_NETBEANS_INTG || FEAT_EVAL
 
-#if !defined(FEAT_GUI_MSWIN) || defined(PROTO)
-#if defined(FEAT_BEVAL_TIP) || defined(PROTO)
+#if !defined(FEAT_GUI_MSWIN)
+#if defined(FEAT_BEVAL_TIP)
 /*
  * Hide the given balloon.
  */

--- a/src/gui_gtk.c
+++ b/src/gui_gtk.c
@@ -101,7 +101,7 @@ typedef int GtkWidget;
 static void entry_activate_cb(GtkWidget *widget, gpointer data);
 static void entry_changed_cb(GtkWidget *entry, GtkWidget *dialog);
 static void find_replace_cb(GtkWidget *widget, gpointer data);
-#if defined(FEAT_BROWSE) || defined(PROTO)
+#if defined(FEAT_BROWSE)
 static void recent_func_log_func(
 	const gchar *log_domain,
 	GLogLevelFlags log_level,
@@ -420,7 +420,7 @@ toolbar_button_focus_in_event(GtkWidget *widget UNUSED,
 }
 #endif // FEAT_TOOLBAR
 
-#if defined(FEAT_TOOLBAR) || defined(PROTO)
+#if defined(FEAT_TOOLBAR)
 
     void
 gui_gtk_register_stock_icons(void)
@@ -531,7 +531,7 @@ gui_gtk_register_stock_icons(void)
 
 #endif // FEAT_TOOLBAR
 
-#if defined(FEAT_MENU) || defined(PROTO)
+#if defined(FEAT_MENU)
 
 /*
  * Translate Vim's mnemonic tagging to GTK+ style and convert to UTF-8
@@ -846,7 +846,7 @@ gui_mch_set_text_area_pos(int x, int y, int w, int h)
 }
 
 
-#if defined(FEAT_MENU) || defined(PROTO)
+#if defined(FEAT_MENU)
 /*
  * Enable or disable accelerators for the toplevel menus.
  */
@@ -920,7 +920,7 @@ get_menu_position(vimmenu_T *menu)
 #endif // FEAT_TOOLBAR
 
 
-#if defined(FEAT_TOOLBAR) || defined(PROTO)
+#if defined(FEAT_TOOLBAR)
     void
 gui_mch_menu_set_tip(vimmenu_T *menu)
 {
@@ -944,7 +944,7 @@ gui_mch_menu_set_tip(vimmenu_T *menu)
 #endif // FEAT_TOOLBAR
 
 
-#if defined(FEAT_MENU) || defined(PROTO)
+#if defined(FEAT_MENU)
 /*
  * Destroy the machine specific menu widget.
  */
@@ -1185,7 +1185,7 @@ gui_mch_destroy_scrollbar(scrollbar_T *sb)
     gui_mch_update();
 }
 
-#if defined(FEAT_BROWSE) || defined(PROTO)
+#if defined(FEAT_BROWSE)
 /*
  * Implementation of the file selector related stuff
  */
@@ -1485,7 +1485,7 @@ gui_mch_browsedir(
 
 #endif	// FEAT_BROWSE
 
-#if defined(FEAT_GUI_DIALOG) || defined(PROTO)
+#if defined(FEAT_GUI_DIALOG)
 
     static GtkWidget *
 create_message_dialog(int type, char_u *title, char_u *message)
@@ -1880,7 +1880,7 @@ gui_mch_dialog(int	type,	    // type of dialog
 #endif // FEAT_GUI_DIALOG
 
 
-#if defined(FEAT_MENU) || defined(PROTO)
+#if defined(FEAT_MENU)
 
     void
 gui_mch_show_popupmenu(vimmenu_T *menu)
@@ -2681,7 +2681,7 @@ ex_helpfind(exarg_T *eap UNUSED)
     do_cmdline_cmd((char_u *)"emenu ToolBar.FindHelp");
 }
 
-#if defined(FEAT_BROWSE) || defined(PROTO)
+#if defined(FEAT_BROWSE)
     static void
 recent_func_log_func(const gchar *log_domain UNUSED,
 		     GLogLevelFlags log_level UNUSED,

--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -56,29 +56,7 @@
 extern void bonobo_dock_item_set_behavior(BonoboDockItem *dock_item, BonoboDockItemBehavior beh);
 #endif
 
-#if !defined(FEAT_GUI_GTK) && defined(PROTO)
-// When generating prototypes we don't want syntax errors.
-# define GdkAtom int
-# define GdkEventExpose int
-# define GdkEventFocus int
-# define GdkEventVisibility int
-# define GdkEventProperty int
-# define GtkContainer int
-# define GtkTargetEntry int
-# define GtkType int
-# define GtkWidget int
-# define gint int
-# define gpointer int
-# define guint int
-# define GdkEventKey int
-# define GdkEventSelection int
-# define GtkSelectionData int
-# define GdkEventMotion int
-# define GdkEventButton int
-# define GdkDragContext int
-# define GdkEventConfigure int
-# define GdkEventClient int
-#else
+#if defined(FEAT_GUI_GTK)
 # if GTK_CHECK_VERSION(3,0,0)
 #  include <gdk/gdkkeysyms-compat.h>
 #  include <gtk/gtkx.h>
@@ -723,7 +701,7 @@ gui_mch_prepare(int *argc, char **argv)
     gui_argv[gui_argc] = NULL;
 }
 
-#if defined(EXITFREE) || defined(PROTO)
+#if defined(EXITFREE)
     void
 gui_mch_free_all(void)
 {
@@ -1889,7 +1867,7 @@ gui_gtk_get_pointer(GtkWidget       *widget,
     return gdk_window_get_device_position(win, dev , x, y, state);
 }
 
-# if defined(FEAT_GUI_TABLINE) || defined(PROTO)
+# if defined(FEAT_GUI_TABLINE)
     static GdkWindow *
 gui_gtk_window_at_position(GtkWidget *widget,
 			   gint      *x,
@@ -2695,7 +2673,7 @@ global_event_filter(GdkXEvent *xev,
 }
 #endif // !USE_GNOME_SESSION
 
-#if defined(FEAT_SOCKETSERVER) || defined(PROTO)
+#if defined(FEAT_SOCKETSERVER)
 
 /*
  * Callback for new events from the socket server listening socket
@@ -3261,7 +3239,7 @@ update_window_manager_hints(int force_width, int force_height)
     }
 }
 
-#if defined(FEAT_GUI_DARKTHEME) || defined(PROTO)
+#if defined(FEAT_GUI_DARKTHEME)
     void
 gui_mch_set_dark_theme(int dark)
 {
@@ -3374,7 +3352,7 @@ set_toolbar_style(GtkToolbar *toolbar)
 
 #endif // FEAT_TOOLBAR
 
-#if defined(FEAT_GUI_TABLINE) || defined(PROTO)
+#if defined(FEAT_GUI_TABLINE)
 static int ignore_tabline_evt = FALSE;
 static GtkWidget *tabline_menu;
 # if !GTK_CHECK_VERSION(3,0,0)
@@ -4193,7 +4171,7 @@ gui_mch_init(void)
     return OK;
 }
 
-#if defined(USE_GNOME_SESSION) || defined(PROTO)
+#if defined(USE_GNOME_SESSION)
 /*
  * This is called from gui_start() after a fork() has been done.
  * We have to tell the session manager our new PID.
@@ -4903,7 +4881,7 @@ gui_mch_settitle(char_u *title, char_u *icon UNUSED)
 	vim_free(title);
 }
 
-#if defined(FEAT_MENU) || defined(PROTO)
+#if defined(FEAT_MENU)
     void
 gui_mch_enable_menu(int showit)
 {
@@ -4929,7 +4907,7 @@ gui_mch_enable_menu(int showit)
 }
 #endif // FEAT_MENU
 
-#if defined(FEAT_TOOLBAR) || defined(PROTO)
+#if defined(FEAT_TOOLBAR)
     void
 gui_mch_show_toolbar(int showit)
 {
@@ -5434,7 +5412,7 @@ gui_mch_get_font(char_u *name, int report_error)
     return font;
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Return the name of font "font" in allocated memory.
  */
@@ -6372,7 +6350,7 @@ gui_mch_haskey(char_u *name)
     return FAIL;
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Return the text window-id and display.  Only required for X-based GUI's
  */
@@ -6524,7 +6502,7 @@ gui_mch_iconify(void)
     gtk_window_iconify(GTK_WINDOW(gui.mainwin));
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Bring the Vim window to the foreground.
  */
@@ -7118,7 +7096,7 @@ clip_mch_set_selection(Clipboard_T *cbd UNUSED)
 {
 }
 
-#if (defined(FEAT_XCLIPBOARD) && defined(USE_SYSTEM)) || defined(PROTO)
+#if defined(FEAT_XCLIPBOARD) && defined(USE_SYSTEM)
     int
 clip_gtk_owner_exists(Clipboard_T *cbd)
 {
@@ -7127,7 +7105,7 @@ clip_gtk_owner_exists(Clipboard_T *cbd)
 #endif
 
 
-#if defined(FEAT_MENU) || defined(PROTO)
+#if defined(FEAT_MENU)
 /*
  * Make a menu item appear either active or not active (grey or not grey).
  */
@@ -7277,7 +7255,7 @@ gui_mch_mousehide(int hide)
     }
 }
 
-#if defined(FEAT_MOUSESHAPE) || defined(PROTO)
+#if defined(FEAT_MOUSESHAPE)
 
 # if GTK_CHECK_VERSION(3,0,0)
 static const char * mshape_css_names[] =
@@ -7380,7 +7358,7 @@ mch_set_mouse_shape(int shape)
 #endif // FEAT_MOUSESHAPE
 
 
-#if defined(FEAT_SIGN_ICONS) || defined(PROTO)
+#if defined(FEAT_SIGN_ICONS)
 /*
  * Signs are currently always 2 chars wide.  With GTK+ 2, the image will be
  * scaled down if the current font is not big enough, or scaled up if the image

--- a/src/gui_haiku.cc
+++ b/src/gui_haiku.cc
@@ -3742,7 +3742,7 @@ gui_mch_create_scrollbar(
     }
 }
 
-#if defined(FEAT_WINDOWS) || defined(FEAT_GUI_HAIKU) || defined(PROTO)
+#if defined(FEAT_WINDOWS) || defined(FEAT_GUI_HAIKU)
 void
 gui_mch_destroy_scrollbar(
 	scrollbar_T *sb)
@@ -4225,7 +4225,7 @@ gui_mch_iconify()
     }
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Bring the Vim window to the foreground.
  */
@@ -4476,7 +4476,7 @@ gui_mch_insert_lines(
     gui.vimTextArea->mchInsertLines(row, num_lines);
 }
 
-#if defined(FEAT_MENU) || defined(PROTO)
+#if defined(FEAT_MENU)
 /*
  * Menu stuff.
  */
@@ -5024,7 +5024,7 @@ gui_mch_set_toolbar_pos(int x, int y, int w, int h)
     }
 }
 
-#if defined(FEAT_GUI_TABLINE) || defined(PROTO)
+#if defined(FEAT_GUI_TABLINE)
 
 /*
  * Show or hide the tabline.

--- a/src/gui_motif.c
+++ b/src/gui_motif.c
@@ -674,7 +674,7 @@ manage_centered(Widget dialog_child)
     XtVaSetValues(shell, XmNmappedWhenManaged, mappedWhenManaged, NULL);
 }
 
-#if defined(FEAT_MENU) || defined(FEAT_GUI_DIALOG) || defined(PROTO)
+#if defined(FEAT_MENU) || defined(FEAT_GUI_DIALOG)
 
 /*
  * Encapsulate the way an XmFontList is created.
@@ -699,7 +699,7 @@ gui_motif_create_fontlist(XFontStruct *font)
     return font_list;
 }
 
-# if ((XmVersion > 1001) && defined(FEAT_XFONTSET)) || defined(PROTO)
+# if ((XmVersion > 1001) && defined(FEAT_XFONTSET))
     XmFontList
 gui_motif_fontset2fontlist(XFontSet *fontset)
 {
@@ -719,7 +719,7 @@ gui_motif_fontset2fontlist(XFontSet *fontset)
 
 #endif
 
-#if defined(FEAT_MENU) || defined(PROTO)
+#if defined(FEAT_MENU)
 /*
  * Menu stuff.
  */
@@ -1363,7 +1363,7 @@ gui_mch_add_menu_item(vimmenu_T *menu, int idx)
     }
 }
 
-#if (XmVersion <= 1002) || defined(PROTO)
+#if (XmVersion <= 1002)
 /*
  * This function will destroy/create the popup menus dynamically,
  * according to the value of 'mousemodel'.
@@ -1450,7 +1450,7 @@ gui_mch_new_menu_font(void)
     ui_new_shellsize();
 }
 
-#if defined(FEAT_BEVAL_GUI) || defined(PROTO)
+#if defined(FEAT_BEVAL_GUI)
     void
 gui_mch_new_tooltip_font(void)
 {
@@ -2097,7 +2097,7 @@ set_fontlist(Widget id)
 }
 #endif
 
-#if defined(FEAT_BROWSE) || defined(PROTO)
+#if defined(FEAT_BROWSE)
 
 /*
  * file selector related stuff
@@ -2353,7 +2353,7 @@ DialogAcceptCB(
 
 #endif // FEAT_BROWSE
 
-#if defined(FEAT_GUI_DIALOG) || defined(PROTO)
+#if defined(FEAT_GUI_DIALOG)
 
 static int	dialogStatus;
 
@@ -2832,7 +2832,7 @@ gui_mch_dialog(
 }
 #endif // FEAT_GUI_DIALOG
 
-#if defined(FEAT_TOOLBAR) || defined(PROTO)
+#if defined(FEAT_TOOLBAR)
     void
 gui_mch_show_toolbar(int showit)
 {
@@ -3058,7 +3058,7 @@ motif_get_toolbar_colors(
 }
 #endif
 
-#if defined(FEAT_GUI_TABLINE) || defined(PROTO)
+#if defined(FEAT_GUI_TABLINE)
 /*
  * Show or hide the tabline.
  */

--- a/src/gui_photon.c
+++ b/src/gui_photon.c
@@ -13,11 +13,8 @@
 
 #include "vim.h"
 
-// cproto fails on missing include files
-#ifndef PROTO
-# ifdef FEAT_TOOLBAR
-#  include <photon/PxImage.h>
-# endif
+#ifdef FEAT_TOOLBAR
+# include <photon/PxImage.h>
 #endif
 
 #if !defined(__QNX__)
@@ -1377,7 +1374,7 @@ gui_mch_wait_for_chars(int wtime)
     }
 }
 
-#if defined(FEAT_BROWSE) || defined(PROTO)
+#if defined(FEAT_BROWSE)
 /*
  * Put up a file requester.
  * Returns the selected name in allocated memory, or NULL for Cancel.
@@ -1457,7 +1454,7 @@ gui_mch_browse(
 }
 #endif
 
-#if defined(FEAT_GUI_DIALOG) || defined(PROTO)
+#if defined(FEAT_GUI_DIALOG)
 static PtWidget_t *gui_ph_dialog_text = NULL;
 
     static int
@@ -1720,7 +1717,7 @@ gui_mch_iconify(void)
     PtForwardWindowEvent(&event);
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Bring the Vim window to the foreground.
  */
@@ -1852,7 +1849,7 @@ gui_mch_destroy_scrollbar(scrollbar_T *sb)
 ////////////////////////////////////////////////////////////////////////////
 // Mouse functions
 
-#if defined(FEAT_MOUSESHAPE) || defined(PROTO)
+#if defined(FEAT_MOUSESHAPE)
 // The last set mouse pointer shape is remembered, to be used when it goes
 // from hidden to not hidden.
 static int last_shape = 0;
@@ -2449,7 +2446,7 @@ gui_ph_toolbar_find_icon(vimmenu_T *menu)
 }
 #endif
 
-#if defined(FEAT_MENU) || defined(PROTO)
+#if defined(FEAT_MENU)
     void
 gui_mch_enable_menu(int flag)
 {
@@ -2740,7 +2737,7 @@ gui_mch_toggle_tearoffs(int enable)
 
 #endif
 
-#if defined(FEAT_TOOLBAR) || defined(PROTO)
+#if defined(FEAT_TOOLBAR)
     void
 gui_mch_show_toolbar(int showit)
 {
@@ -2967,7 +2964,7 @@ gui_mch_get_font(char_u *vim_font_name, int report_error)
     return FAIL;
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Return the name of font "font" in allocated memory.
  * Don't know how to get the actual name, thus use the provided name.

--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -326,66 +326,6 @@ gui_mch_set_rendering_options(char_u *s)
 # define DWMWA_TEXT_COLOR		36
 #endif
 
-#ifdef PROTO
-/*
- * Define a few things for generating prototypes.  This is just to avoid
- * syntax errors, the defines do not need to be correct.
- */
-# define APIENTRY
-# define CALLBACK
-# define CONST
-# define FAR
-# define NEAR
-# define WINAPI
-# undef _cdecl
-# define _cdecl
-typedef int BOOL;
-typedef int BYTE;
-typedef int DWORD;
-typedef int WCHAR;
-typedef int ENUMLOGFONT;
-typedef int FINDREPLACE;
-typedef int HANDLE;
-typedef int HBITMAP;
-typedef int HBRUSH;
-typedef int HDROP;
-typedef int INT;
-typedef int LOGFONTW[];
-typedef int LPARAM;
-typedef int LPCREATESTRUCT;
-typedef int LPCSTR;
-typedef int LPCTSTR;
-typedef int LPRECT;
-typedef int LPSTR;
-typedef int LPWINDOWPOS;
-typedef int LPWORD;
-typedef int LRESULT;
-typedef int HRESULT;
-# undef MSG
-typedef int MSG;
-typedef int NEWTEXTMETRIC;
-typedef int NMHDR;
-typedef int OSVERSIONINFO;
-typedef int PWORD;
-typedef int RECT;
-typedef int SIZE;
-typedef int UINT;
-typedef int WORD;
-typedef int WPARAM;
-typedef int POINT;
-typedef void *HINSTANCE;
-typedef void *HMENU;
-typedef void *HWND;
-typedef void *HDC;
-typedef void VOID;
-typedef int LPNMHDR;
-typedef int LONG;
-typedef int WNDPROC;
-typedef int UINT_PTR;
-typedef int COLORREF;
-typedef int HCURSOR;
-#endif
-
 static void _OnPaint(HWND hwnd);
 static void fill_rect(const RECT *rcp, HBRUSH hbr, COLORREF color);
 static void clear_rect(RECT *rcp);

--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -130,7 +130,7 @@ static void keycode_trans_strategy_init(void)
 
 }
 
-#if defined(FEAT_RENDER_OPTIONS) || defined(PROTO)
+#if defined(FEAT_RENDER_OPTIONS)
     int
 gui_mch_set_rendering_options(char_u *s)
 {
@@ -272,12 +272,9 @@ gui_mch_set_rendering_options(char_u *s)
 # include <tchar.h>
 #endif
 
-// cproto fails on missing include files
-#ifndef PROTO
-# include <shellapi.h>
-# include <commctrl.h>
-# include <windowsx.h>
-#endif // PROTO
+#include <shellapi.h>
+#include <commctrl.h>
+#include <windowsx.h>
 
 #ifdef FEAT_MENU
 # define MENUHINTS		// show menu hints in command line
@@ -1920,7 +1917,7 @@ gui_mch_get_font(
     return font;
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Return the name of font "font" in allocated memory.
  * Don't know how to get the actual name, thus use the provided name.
@@ -2752,7 +2749,7 @@ gui_mch_set_menu_pos(
     // It will be in the right place anyway
 }
 
-#if defined(FEAT_MENU) || defined(PROTO)
+#if defined(FEAT_MENU)
 /*
  * Make menu item hidden or not hidden
  */
@@ -2793,7 +2790,7 @@ gui_mch_get_rgb(guicolor_T pixel)
 							   + GetBValue(pixel));
 }
 
-#if defined(FEAT_GUI_DIALOG) || defined(PROTO)
+#if defined(FEAT_GUI_DIALOG)
 /*
  * Convert pixels in X to dialog units
  */
@@ -2911,7 +2908,7 @@ CenterWindow(
 }
 #endif // FEAT_GUI_DIALOG
 
-#if defined(FEAT_TOOLBAR) || defined(PROTO)
+#if defined(FEAT_TOOLBAR)
     void
 gui_mch_show_toolbar(int showit)
 {
@@ -2934,7 +2931,7 @@ gui_mch_show_toolbar(int showit)
 
 #endif
 
-#if defined(FEAT_GUI_TABLINE) || defined(PROTO)
+#if defined(FEAT_GUI_TABLINE)
     static void
 add_tabline_popup_menu_entry(HMENU pmenu, UINT item_id, char_u *item_text)
 {
@@ -3963,7 +3960,7 @@ gui_mch_settitle(
     set_window_title(s_hwnd, (title == NULL ? "VIM" : (char *)title));
 }
 
-#if defined(FEAT_MOUSESHAPE) || defined(PROTO)
+#if defined(FEAT_MOUSESHAPE)
 // Table for shape IDCs.  Keep in sync with the mshape_names[] table in
 // misc2.c!
 static LPCSTR mshape_idcs[] =
@@ -4014,7 +4011,7 @@ mch_set_mouse_shape(int shape)
 }
 #endif
 
-#if defined(FEAT_BROWSE) || defined(PROTO)
+#if defined(FEAT_BROWSE)
 /*
  * Wide version of convert_filter().
  */
@@ -5346,7 +5343,7 @@ ole_error(char *arg)
 }
 #endif
 
-#if defined(GUI_MAY_SPAWN) || defined(PROTO)
+#if defined(GUI_MAY_SPAWN)
     static char *
 gvim_error(void)
 {
@@ -6190,7 +6187,7 @@ GetResultStr(HWND hwnd, int GCS, int *lenp)
 #endif
 
 // For global functions we need prototypes.
-#if defined(FEAT_MBYTE_IME) || defined(PROTO)
+#if defined(FEAT_MBYTE_IME)
 
 /*
  * set font to IM.
@@ -6806,7 +6803,7 @@ gui_mch_get_screen_dimensions(int *screen_w, int *screen_h)
 }
 
 
-#if defined(FEAT_MENU) || defined(PROTO)
+#if defined(FEAT_MENU)
 /*
  * Add a sub menu to the menu bar.
  */
@@ -6891,7 +6888,7 @@ gui_make_popup(char_u *path_name, int mouse_pos)
     gui_mch_show_popupmenu_at(menu, (int)p.x, (int)p.y);
 }
 
-# if defined(FEAT_TEAROFF) || defined(PROTO)
+# if defined(FEAT_TEAROFF)
 /*
  * Given a menu descriptor, e.g. "File.New", find it in the menu hierarchy and
  * create it as a pseudo-"tearoff menu".
@@ -7107,7 +7104,7 @@ gui_mch_menu_grey(
 #define add_word(x)		*p++ = (x)
 #define add_long(x)		dwp = (DWORD *)p; *dwp++ = (x); p = (WORD *)dwp
 
-#if defined(FEAT_GUI_DIALOG) || defined(PROTO)
+#if defined(FEAT_GUI_DIALOG)
 /*
  * stuff for dialogs
  */
@@ -8261,7 +8258,7 @@ gui_mch_tearoff(
 }
 #endif
 
-#if defined(FEAT_TOOLBAR) || defined(PROTO)
+#if defined(FEAT_TOOLBAR)
 # include "gui_w32_rc.h"
 
 /*
@@ -8404,7 +8401,7 @@ get_toolbar_bitmap(vimmenu_T *menu)
 }
 #endif
 
-#if defined(FEAT_GUI_TABLINE) || defined(PROTO)
+#if defined(FEAT_GUI_TABLINE)
     static void
 initialise_tabline(void)
 {
@@ -8542,7 +8539,7 @@ tabline_wndproc(
 }
 #endif
 
-#if defined(FEAT_OLE) || defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_OLE) || defined(FEAT_EVAL)
 /*
  * Make the GUI window come to the foreground.
  */
@@ -8609,7 +8606,7 @@ dyn_imm_load(void)
 
 #endif
 
-#if defined(FEAT_SIGN_ICONS) || defined(PROTO)
+#if defined(FEAT_SIGN_ICONS)
 
 # ifdef FEAT_XPM_W32
 #  define IMAGE_XPM   100
@@ -8768,7 +8765,7 @@ gui_mch_destroy_sign(void *sign)
 }
 #endif
 
-#if defined(FEAT_BEVAL_GUI) || defined(PROTO)
+#if defined(FEAT_BEVAL_GUI)
 
 /*
  * BALLOON-EVAL IMPLEMENTATION FOR WINDOWS.
@@ -9025,7 +9022,7 @@ gui_mch_destroy_beval_area(BalloonEval *beval)
 }
 #endif // FEAT_BEVAL_GUI
 
-#if defined(FEAT_NETBEANS_INTG) || defined(PROTO)
+#if defined(FEAT_NETBEANS_INTG)
 /*
  * We have multiple signs to draw at the same location. Draw the
  * multi-sign indicator (down-arrow) instead. This is the Win32 version.
@@ -9061,7 +9058,7 @@ netbeans_draw_multisign_indicator(int row)
 }
 #endif
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 
 // TODO: at the moment, this is just a copy of test_gui_mouse_event.
 // But, we could instead generate actual Win32 mouse event messages,

--- a/src/gui_x11.c
+++ b/src/gui_x11.c
@@ -622,7 +622,7 @@ gui_x11_expose_cb(
     gui_mch_update();
 }
 
-#if (defined(FEAT_NETBEANS_INTG) && defined(FEAT_GUI_MOTIF)) || defined(PROTO)
+#if defined(FEAT_NETBEANS_INTG) && defined(FEAT_GUI_MOTIF)
 /*
  * This function fills in the XRectangle object with the current x,y
  * coordinates and height, width so that an XtVaSetValues to the same shell of
@@ -1546,7 +1546,7 @@ gui_mch_open(void)
     return OK;
 }
 
-#if defined(FEAT_BEVAL_GUI) || defined(PROTO)
+#if defined(FEAT_BEVAL_GUI)
 /*
  * Convert the tooltip fontset name to an XFontSet.
  */
@@ -1567,7 +1567,7 @@ gui_init_tooltip_font(void)
 }
 #endif
 
-#if defined(FEAT_MENU) || defined(PROTO)
+#if defined(FEAT_MENU)
 // Convert the menu font/fontset name to an XFontStruct/XFontset
     void
 gui_init_menu_font(void)
@@ -1865,7 +1865,7 @@ gui_mch_get_font(char_u *name, int giveErrorIfMissing)
     return (GuiFont)font;
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Return the name of font "font" in allocated memory.
  */
@@ -1950,7 +1950,7 @@ gui_mch_set_font(GuiFont font)
 #endif
 }
 
-#if defined(FEAT_XFONTSET) || defined(PROTO)
+#if defined(FEAT_XFONTSET)
 /*
  * Set the current text fontset.
  * Adjust the ascent, in case it's different.
@@ -1973,7 +1973,7 @@ gui_mch_free_font(GuiFont font)
 	XFreeFont(gui.dpy, (XFontStruct *)font);
 }
 
-#if defined(FEAT_XFONTSET) || defined(PROTO)
+#if defined(FEAT_XFONTSET)
 /*
  * If a fontset is not going to be used, free its structure.
  */
@@ -2482,7 +2482,7 @@ gui_mch_iconify(void)
     XIconifyWindow(gui.dpy, XtWindow(vimShell), DefaultScreen(gui.dpy));
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Bring the Vim window to the foreground.
  */
@@ -2792,7 +2792,7 @@ clip_mch_set_selection(
     clip_x11_set_selection(cbd);
 }
 
-#if defined(FEAT_MENU) || defined(PROTO)
+#if defined(FEAT_MENU)
 /*
  * Menu stuff.
  */
@@ -3103,7 +3103,7 @@ gui_mch_setmouse(int x, int y)
 	XWarpPointer(gui.dpy, (Window)0, gui.wid, 0, 0, 0, 0, x, y);
 }
 
-#if (defined(FEAT_GUI_MOTIF) && defined(FEAT_MENU)) || defined(PROTO)
+#if defined(FEAT_GUI_MOTIF) && defined(FEAT_MENU)
     XButtonPressedEvent *
 gui_x11_get_last_mouse_event(void)
 {
@@ -3111,7 +3111,7 @@ gui_x11_get_last_mouse_event(void)
 }
 #endif
 
-#if defined(FEAT_SIGN_ICONS) || defined(PROTO)
+#if defined(FEAT_SIGN_ICONS)
 
 // Signs are currently always 2 chars wide.  Hopefully the font is big enough
 // to provide room for the bitmap!
@@ -3208,7 +3208,7 @@ gui_mch_mousehide(
 #endif
 }
 
-#if defined(FEAT_MOUSESHAPE) || defined(PROTO)
+#if defined(FEAT_MOUSESHAPE)
 
 // Table for shape IDs.  Keep in sync with the mshape_names[] table in
 // misc2.c!
@@ -3263,7 +3263,7 @@ mch_set_mouse_shape(int shape)
 }
 #endif
 
-#if (defined(FEAT_TOOLBAR) && defined(FEAT_BEVAL_GUI)) || defined(PROTO)
+#if defined(FEAT_TOOLBAR) && defined(FEAT_BEVAL_GUI)
 /*
  * Set the balloon-eval used for the tooltip of a toolbar menu item.
  * The check for a non-toolbar item was added, because there is a crash when

--- a/src/gui_xim.c
+++ b/src/gui_xim.c
@@ -16,14 +16,6 @@
 #if !defined(GTK_CHECK_VERSION)
 # define GTK_CHECK_VERSION(a, b, c) 0
 #endif
-#if !defined(FEAT_GUI_GTK) && defined(PROTO)
-typedef int GtkWidget;
-typedef int GtkIMContext;
-typedef int gchar;
-typedef int gpointer;
-typedef int PangoAttrIterator;
-typedef int GdkEventKey;
-#endif
 
 #if defined(FEAT_GUI_GTK) && defined(FEAT_XIM)
 # if GTK_CHECK_VERSION(3,0,0)
@@ -79,9 +71,8 @@ xim_log(char *s, ...)
 # define USE_IMSTATUSFUNC (*p_imsf != NUL)
 #endif
 
-#if (defined(FEAT_EVAL) && \
-     (defined(FEAT_XIM) || defined(IME_WITHOUT_XIM) || defined(VIMDLL))) || \
-    defined(PROTO)
+#if defined(FEAT_EVAL) && \
+     (defined(FEAT_XIM) || defined(IME_WITHOUT_XIM) || defined(VIMDLL))
 static callback_T imaf_cb;	    // 'imactivatefunc' callback function
 static callback_T imsf_cb;	    // 'imstatusfunc' callback function
 
@@ -137,7 +128,7 @@ call_imstatusfunc(void)
 }
 #endif
 
-#if defined(EXITFREE) || defined(PROTO)
+#if defined(EXITFREE)
     void
 free_xim_stuff(void)
 {
@@ -149,7 +140,7 @@ free_xim_stuff(void)
 }
 #endif
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Mark the global 'imactivatefunc' and 'imstatusfunc' callbacks with "copyID"
  * so that they are not garbage collected.
@@ -169,9 +160,9 @@ set_ref_in_im_funcs(int copyID UNUSED)
 #endif
 
 
-#if defined(FEAT_XIM) || defined(PROTO)
+#if defined(FEAT_XIM)
 
-# if defined(FEAT_GUI_GTK) || defined(PROTO)
+# if defined(FEAT_GUI_GTK)
 static int xim_has_preediting = FALSE;  // IM current status
 
 /*
@@ -1358,7 +1349,7 @@ xim_set_preedit(void)
     }
 }
 
-#  if defined(FEAT_GUI_X11) || defined(PROTO)
+#  if defined(FEAT_GUI_X11)
 #   if defined(XtSpecificationRelease) && XtSpecificationRelease >= 6 && !defined(SUN_SYSTEM)
 #    define USE_X11R6_XIM
 #   endif
@@ -1678,7 +1669,7 @@ im_get_status(void)
 
 # endif // !FEAT_GUI_GTK
 
-# if !defined(FEAT_GUI_GTK) || defined(PROTO)
+# if !defined(FEAT_GUI_GTK)
 /*
  * Set up the status area.
  *
@@ -1795,7 +1786,7 @@ xim_get_status_area_height(void)
 
 #else // !defined(FEAT_XIM)
 
-# if defined(IME_WITHOUT_XIM) || defined(VIMDLL) || defined(PROTO)
+# if defined(IME_WITHOUT_XIM) || defined(VIMDLL)
 static int im_was_set_active = FALSE;
 
     int

--- a/src/hardcopy.c
+++ b/src/hardcopy.c
@@ -14,7 +14,7 @@
 #include "vim.h"
 #include "version.h"
 
-#if defined(FEAT_PRINTER) || defined(PROTO)
+#if defined(FEAT_PRINTER)
 /*
  * To implement printing on a platform, the following functions must be
  * defined:
@@ -149,7 +149,7 @@ parse_printoptions(optset_T *args UNUSED)
     return parse_list_options(p_popt, printer_opts, OPT_PRINT_NUM_OPTIONS);
 }
 
-#if defined(FEAT_POSTSCRIPT) || defined(PROTO)
+#if defined(FEAT_POSTSCRIPT)
 /*
  * Parse 'printmbfont' and set the flags in "mbfont_opts".
  * Returns an error message or NULL;
@@ -939,7 +939,7 @@ hardcopy_line(
     return col;
 }
 
-# if defined(FEAT_POSTSCRIPT) || defined(PROTO)
+# if defined(FEAT_POSTSCRIPT)
 
 /*
  * PS printer stuff.

--- a/src/hashtab.c
+++ b/src/hashtab.c
@@ -95,7 +95,7 @@ hash_clear(hashtab_T *ht)
 	vim_free(ht->ht_array);
 }
 
-#if defined(FEAT_SPELL) || defined(FEAT_TERMINAL) || defined(PROTO)
+#if defined(FEAT_SPELL) || defined(FEAT_TERMINAL)
 /*
  * Free the array of a hash table and all the keys it contains.  The keys must
  * have been allocated.  "off" is the offset from the start of the allocate
@@ -194,7 +194,7 @@ hash_lookup(hashtab_T *ht, char_u *key, hash_T hash)
     }
 }
 
-#if defined(FEAT_EVAL) || defined(FEAT_SYN_HL) || defined(PROTO)
+#if defined(FEAT_EVAL) || defined(FEAT_SYN_HL)
 /*
  * Print the efficiency of hashtable lookups.
  * Useful when trying different hash algorithms.
@@ -309,7 +309,7 @@ hash_lock(hashtab_T *ht)
     ++ht->ht_locked;
 }
 
-#if defined(FEAT_PROP_POPUP) || defined(PROTO)
+#if defined(FEAT_PROP_POPUP)
 /*
  * Lock a hashtable at the specified number of entries.
  * Caller must make sure no more than "size" entries will be added.

--- a/src/help.c
+++ b/src/help.c
@@ -219,7 +219,7 @@ ex_helpclose(exarg_T *eap UNUSED)
     }
 }
 
-#if defined(FEAT_MULTI_LANG) || defined(PROTO)
+#if defined(FEAT_MULTI_LANG)
 /*
  * In an argument search for a language specifiers in the form "@xx".
  * Changes the "@" to NUL if found, and returns a pointer to "xx".

--- a/src/highlight.c
+++ b/src/highlight.c
@@ -461,7 +461,7 @@ static char *(highlight_init_dark[]) = {
     NULL
 };
 
-#if defined(FEAT_SYN_HL) || defined(PROTO)
+#if defined(FEAT_SYN_HL)
 /*
  * Returns the number of highlight groups.
  */
@@ -1999,7 +1999,7 @@ do_highlight(
     }
 }
 
-#if defined(EXITFREE) || defined(PROTO)
+#if defined(EXITFREE)
     void
 free_highlight(void)
 {
@@ -2117,7 +2117,7 @@ highlight_clear(int idx)
 #endif
 }
 
-#if defined(FEAT_GUI) || defined(FEAT_TERMGUICOLORS) || defined(PROTO)
+#if defined(FEAT_GUI) || defined(FEAT_TERMGUICOLORS)
 /*
  * Set the normal foreground and background colors according to the "Normal"
  * highlighting group.  For X11 also set "Menu", "Scrollbar" and "Tooltip"
@@ -2214,7 +2214,7 @@ set_normal_colors(void)
 }
 #endif
 
-#if defined(FEAT_GUI) || defined(PROTO)
+#if defined(FEAT_GUI)
 /*
  * Set the colors for "Normal", "Menu", "TitleBar", "TitleBarNC", "Tooltip" or
  * "Scrollbar".
@@ -2448,7 +2448,7 @@ hl_do_font(
 
 #endif // FEAT_GUI
 
-#if defined(FEAT_GUI) || defined(FEAT_TERMGUICOLORS) || defined(PROTO)
+#if defined(FEAT_GUI) || defined(FEAT_TERMGUICOLORS)
 /*
  * Return the handle for a color name.
  * Returns INVALCOLOR when failed.
@@ -2833,7 +2833,7 @@ get_attr_entry(garray_T *table, attrentry_T *aep)
     return (table->ga_len - 1 + ATTR_OFF);
 }
 
-#if defined(FEAT_TERMINAL) || defined(PROTO)
+#if defined(FEAT_TERMINAL)
 /*
  * Get an attribute index for a cterm entry.
  * Uses an existing entry when possible or adds one when needed.
@@ -2858,7 +2858,7 @@ get_cterm_attr_idx(int attr, int fg, int bg)
 }
 #endif
 
-#if (defined(FEAT_TERMINAL) && defined(FEAT_TERMGUICOLORS)) || defined(PROTO)
+#if defined(FEAT_TERMINAL) && defined(FEAT_TERMGUICOLORS)
 /*
  * Get an attribute index for a 'termguicolors' entry.
  * Uses an existing entry when possible or adds one when needed.
@@ -2887,7 +2887,7 @@ get_tgc_attr_idx(int attr, guicolor_T fg, guicolor_T bg)
 }
 #endif
 
-#if (defined(FEAT_TERMINAL) && defined(FEAT_GUI)) || defined(PROTO)
+#if defined(FEAT_TERMINAL) && defined(FEAT_GUI)
 /*
  * Get an attribute index for a cterm entry.
  * Uses an existing entry when possible or adds one when needed.
@@ -3271,7 +3271,7 @@ highlight_list_arg(
     return didh;
 }
 
-#if (((defined(FEAT_EVAL) || defined(FEAT_PRINTER))) && defined(FEAT_SYN_HL)) || defined(PROTO)
+#if ((defined(FEAT_EVAL) || defined(FEAT_PRINTER))) && defined(FEAT_SYN_HL)
 /*
  * Return "1" if highlight group "id" has attribute "flag".
  * Return NULL otherwise.
@@ -3305,7 +3305,7 @@ highlight_has_attr(
 }
 #endif
 
-#if (defined(FEAT_SYN_HL) && defined(FEAT_EVAL)) || defined(PROTO)
+#if defined(FEAT_SYN_HL) && defined(FEAT_EVAL)
 /*
  * Return color name of highlight group "id".
  */
@@ -3396,9 +3396,9 @@ highlight_color(
 }
 #endif
 
-#if (defined(FEAT_SYN_HL) \
+#if defined(FEAT_SYN_HL) \
 	    && (defined(FEAT_GUI) || defined(FEAT_TERMGUICOLORS)) \
-	&& defined(FEAT_PRINTER)) || defined(PROTO)
+	&& defined(FEAT_PRINTER)
 /*
  * Return color name of highlight group "id" as RGB value.
  */
@@ -3609,7 +3609,7 @@ syn_name2attr(char_u *name)
     return 0;
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Return TRUE if highlight group "name" exists.
  */
@@ -3619,7 +3619,7 @@ highlight_exists(char_u *name)
     return (syn_name2id(name) > 0);
 }
 
-# if defined(FEAT_SEARCH_EXTRA) || defined(PROTO)
+# if defined(FEAT_SEARCH_EXTRA)
 /*
  * Return the name of highlight group "id".
  * When not a valid ID return an empty string.
@@ -3793,7 +3793,7 @@ syn_id2attr(int hl_id)
     return attr;
 }
 
-#if defined(FEAT_GUI) || defined(FEAT_TERMGUICOLORS) || defined(PROTO)
+#if defined(FEAT_GUI) || defined(FEAT_TERMGUICOLORS)
 /*
  * Get the GUI colors and attributes for a group ID.
  * NOTE: the colors will be INVALCOLOR when not set, the color otherwise.
@@ -3817,7 +3817,7 @@ syn_id2colors(int hl_id, guicolor_T *fgp, guicolor_T *bgp)
 #if (defined(MSWIN) \
 	    && (!defined(FEAT_GUI_MSWIN) || defined(VIMDLL)) \
 	    && defined(FEAT_TERMGUICOLORS)) \
-	|| defined(FEAT_TERMINAL) || defined(PROTO)
+	|| defined(FEAT_TERMINAL)
     void
 syn_id2cterm_bg(int hl_id, int *fgp, int *bgp)
 {
@@ -3857,7 +3857,7 @@ syn_get_final_id(int hl_id)
     return hl_id;
 }
 
-#if defined(FEAT_GUI) || defined(FEAT_TERMGUICOLORS) || defined(PROTO)
+#if defined(FEAT_GUI) || defined(FEAT_TERMGUICOLORS)
 /*
  * Call this function just after the GUI has started.
  * Also called when 'termguicolors' was set, gui.in_use will be FALSE then.
@@ -4667,7 +4667,7 @@ expand_highlight_group(
 	    -1);
 }
 
-#if defined(FEAT_GUI) || defined(PROTO)
+#if defined(FEAT_GUI)
 /*
  * Free all the highlight group fonts.
  * Used when quitting for systems which need it.
@@ -4699,7 +4699,7 @@ free_highlight_fonts(void)
 }
 #endif
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Convert each of the highlight attribute bits (bold, standout, underline,
  * etc.) set in 'hlattr' into a separate boolean item in a Dictionary with

--- a/src/if_cscope.c
+++ b/src/if_cscope.c
@@ -11,7 +11,7 @@
 
 #include "vim.h"
 
-#if defined(FEAT_CSCOPE) || defined(PROTO)
+#if defined(FEAT_CSCOPE)
 
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -439,7 +439,7 @@ cs_print_tags(void)
  *
  *		Note: All string comparisons are case sensitive!
  */
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
     static int
 cs_connection(int num, char_u *dbpath, char_u *ppath)
 {
@@ -2515,7 +2515,7 @@ cs_end(void)
 
 #endif	// FEAT_CSCOPE
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 
 /*
  * "cscope_connection([{num} , {dbpath} [, {prepend}]])" function

--- a/src/if_lua.c
+++ b/src/if_lua.c
@@ -24,7 +24,7 @@
 
 // Only do the following when the feature is enabled.  Needed for "make
 // depend".
-#if defined(FEAT_LUA) || defined(PROTO)
+#if defined(FEAT_LUA)
 
 #define LUAVIM_CHUNKNAME "vim chunk"
 #define LUAVIM_NAME "vim"
@@ -472,7 +472,7 @@ lua_link_init(char *libname, int verbose)
 }
 #endif // DYNAMIC_LUA
 
-#if defined(DYNAMIC_LUA) || defined(PROTO)
+#if defined(DYNAMIC_LUA)
     int
 lua_enabled(int verbose)
 {

--- a/src/if_mzsch.c
+++ b/src/if_mzsch.c
@@ -27,7 +27,7 @@
 
 // Only do the following when the feature is enabled.  Needed for "make
 // depend".
-#if defined(FEAT_MZSCHEME) || defined(PROTO)
+#if defined(FEAT_MZSCHEME)
 
 /*
  * scheme_register_tls_space is only available on 32-bit Windows until
@@ -203,7 +203,7 @@ static int window_fixup_proc(void *obj)
 # define BUFFER_REF(buf) (vim_mz_buffer *)((buf)->b_mzscheme_ref)
 #endif
 
-#if defined(DYNAMIC_MZSCHEME) || defined(PROTO)
+#if defined(DYNAMIC_MZSCHEME)
 static Scheme_Object *dll_scheme_eof;
 static Scheme_Object *dll_scheme_false;
 static Scheme_Object *dll_scheme_void;
@@ -361,7 +361,7 @@ static void (*dll_scheme_register_embedded_load)(intptr_t len, const char *s);
 static void (*dll_scheme_set_config_path)(Scheme_Object *p);
 # endif
 
-#if defined(DYNAMIC_MZSCHEME) // not when defined(PROTO)
+#if defined(DYNAMIC_MZSCHEME)
 
 // arrays are imported directly
 # define scheme_eof dll_scheme_eof
@@ -821,7 +821,7 @@ mzvim_check_threads(void)
 }
 #endif
 
-#if defined(MZSCHEME_GUI_THREADS) || defined(PROTO)
+#if defined(MZSCHEME_GUI_THREADS)
 static void setup_timer(void);
 static void remove_timer(void);
 

--- a/src/if_mzsch.c
+++ b/src/if_mzsch.c
@@ -29,19 +29,6 @@
 // depend".
 #if defined(FEAT_MZSCHEME) || defined(PROTO)
 
-#ifdef PROTO
-typedef int Scheme_Object;
-typedef int Scheme_Closed_Prim;
-typedef int Scheme_Env;
-typedef int Scheme_Hash_Table;
-typedef int Scheme_Type;
-typedef int Scheme_Thread;
-typedef int Scheme_Closed_Prim;
-typedef int mzshort;
-typedef int Scheme_Prim;
-typedef int HINSTANCE;
-#endif
-
 /*
  * scheme_register_tls_space is only available on 32-bit Windows until
  * racket-6.3.  See

--- a/src/if_mzsch.h
+++ b/src/if_mzsch.h
@@ -10,11 +10,6 @@
 # include <stdint.h>
 #endif
 
-#ifdef PROTO
-// avoid syntax error for defining Thread_Local_Variables.
-# define __thread // empty
-#endif
-
 // #ifdef needed for "make depend"
 #ifdef FEAT_MZSCHEME
 # include <schvers.h>

--- a/src/if_perl.xs
+++ b/src/if_perl.xs
@@ -151,7 +151,7 @@ EXTERN_C void boot_DynaLoader(pTHX_ CV*);
 /*
  * For dynamic linked perl.
  */
-#if defined(DYNAMIC_PERL) || defined(PROTO)
+#if defined(DYNAMIC_PERL)
 
 # ifndef DYNAMIC_PERL /* just generating prototypes */
 #  ifdef MSWIN

--- a/src/if_python.c
+++ b/src/if_python.c
@@ -82,15 +82,6 @@
 #define PyBytes_AsStringAndSize PyString_AsStringAndSize
 #define PyBytes_FromStringAndSize   PyString_FromStringAndSize
 
-#if !defined(FEAT_PYTHON) && defined(PROTO)
-// Use this to be able to generate prototypes without python being used.
-# define PyObject Py_ssize_t
-# define PyThreadState Py_ssize_t
-# define PyTypeObject Py_ssize_t
-struct PyMethodDef { Py_ssize_t a; };
-# define PySequenceMethods Py_ssize_t
-#endif
-
 #if defined(PY_VERSION_HEX) && PY_VERSION_HEX >= 0x02070000
 # define PY_USE_CAPSULE
 #endif
@@ -125,7 +116,7 @@ struct PyMethodDef { Py_ssize_t a; };
 # define PY_CAN_RECURSE
 #endif
 
-#if defined(DYNAMIC_PYTHON) || defined(PROTO)
+#if defined(DYNAMIC_PYTHON)
 # ifndef DYNAMIC_PYTHON
 #  define HINSTANCE long_u		// for generating prototypes
 # endif
@@ -900,7 +891,7 @@ python_end(void)
     --recurse;
 }
 
-#if (defined(DYNAMIC_PYTHON) && defined(FEAT_PYTHON3)) || defined(PROTO)
+#if defined(DYNAMIC_PYTHON) && defined(FEAT_PYTHON3)
     int
 python_loaded(void)
 {

--- a/src/if_python3.c
+++ b/src/if_python3.c
@@ -135,7 +135,7 @@ typedef PySliceObject PySliceObject_T;
 static HINSTANCE hinstPy3 = 0; // Instance of python.dll
 #endif
 
-#if defined(DYNAMIC_PYTHON3) || defined(PROTO)
+#if defined(DYNAMIC_PYTHON3)
 
 # ifdef MSWIN
 #  define load_dll vimLoadLib
@@ -1218,7 +1218,7 @@ python3_end(void)
     --recurse;
 }
 
-#if (defined(DYNAMIC_PYTHON3) && defined(DYNAMIC_PYTHON) && defined(FEAT_PYTHON) && defined(UNIX)) || defined(PROTO)
+#if defined(DYNAMIC_PYTHON3) && defined(DYNAMIC_PYTHON) && defined(FEAT_PYTHON) && defined(UNIX)
     int
 python3_loaded(void)
 {

--- a/src/if_ruby.c
+++ b/src/if_ruby.c
@@ -204,12 +204,6 @@
 # endif
 #endif
 
-#if defined(PROTO) && !defined(FEAT_RUBY)
-// Define these to be able to generate the function prototypes.
-# define VALUE int
-# define RUBY_DATA_FUNC int
-#endif
-
 static int ruby_initialized = 0;
 static void *ruby_stack_start;
 static VALUE objtbl;
@@ -231,9 +225,6 @@ static int ruby_convert_to_vim_value(VALUE val, typval_T *rettv);
 #endif
 
 #if defined(DYNAMIC_RUBY) || defined(PROTO)
-# if defined(PROTO) && !defined(HINSTANCE)
-#  define HINSTANCE int		// for generating prototypes
-# endif
 
 /*
  * Wrapper defines

--- a/src/if_ruby.c
+++ b/src/if_ruby.c
@@ -224,7 +224,7 @@ static int ruby_convert_to_vim_value(VALUE val, typval_T *rettv);
 # define ruby_init_stack(addr) ruby_init_stack((addr), rb_ia64_bsp())
 #endif
 
-#if defined(DYNAMIC_RUBY) || defined(PROTO)
+#if defined(DYNAMIC_RUBY)
 
 /*
  * Wrapper defines
@@ -794,7 +794,7 @@ ruby_enabled(int verbose)
 {
     return ruby_runtime_link_init((char *)p_rubydll, verbose) == OK;
 }
-#endif // defined(DYNAMIC_RUBY) || defined(PROTO)
+#endif // defined(DYNAMIC_RUBY)
 
     void
 ruby_end(void)

--- a/src/if_tcl.c
+++ b/src/if_tcl.c
@@ -148,7 +148,7 @@ static struct ref refsdeleted;	// dummy object for deleted ref list
 // TCL interface manager
 ////////////////////////////////////////////////////////////////////////////
 
-#if defined(DYNAMIC_TCL) || defined(PROTO)
+#if defined(DYNAMIC_TCL)
 # ifndef DYNAMIC_TCL_DLL
 #  define DYNAMIC_TCL_DLL "tcl83.dll"
 # endif
@@ -233,7 +233,7 @@ tcl_runtime_link_init(char *libname, int verbose)
     }
     return OK;
 }
-#endif // defined(DYNAMIC_TCL) || defined(PROTO)
+#endif // defined(DYNAMIC_TCL)
 
 #ifdef DYNAMIC_TCL
 static char *find_executable_arg = NULL;
@@ -249,7 +249,7 @@ vim_tcl_init(char *arg)
 #endif
 }
 
-#if defined(DYNAMIC_TCL) || defined(PROTO)
+#if defined(DYNAMIC_TCL)
 
 static int stubs_initialized = FALSE;
 
@@ -282,7 +282,7 @@ tcl_enabled(int verbose)
 }
 #endif
 
-#if defined(EXITFREE) || defined(PROTO)
+#if defined(EXITFREE)
 /*
  * Called once when exiting.
  */

--- a/src/if_xcmdsrv.c
+++ b/src/if_xcmdsrv.c
@@ -14,7 +14,7 @@
 #include "vim.h"
 #include "version.h"
 
-#if (defined(FEAT_CLIENTSERVER) && defined(FEAT_X11)) || defined(PROTO)
+#if (defined(FEAT_CLIENTSERVER) && defined(FEAT_X11))
 
 # ifdef FEAT_X11
 #  include <X11/Intrinsic.h>
@@ -321,7 +321,7 @@ DoRegisterName(Display *dpy, char_u *name)
     return -2;
 }
 
-#if defined(FEAT_GUI) || defined(PROTO)
+#if defined(FEAT_GUI)
 /*
  * Clean out new ID from registry and set it as comm win.
  * Change any registered window ID.

--- a/src/indent.c
+++ b/src/indent.c
@@ -13,7 +13,7 @@
 
 #include "vim.h"
 
-#if defined(FEAT_VARTABS) || defined(PROTO)
+#if defined(FEAT_VARTABS)
 
 /*
  * Set the integer values corresponding to the string setting of 'vartabstop'.
@@ -299,7 +299,7 @@ tabstop_eq(int *ts1, int *ts2)
     return TRUE;
 }
 
-# if defined(FEAT_BEVAL) || defined(PROTO)
+# if defined(FEAT_BEVAL)
 /*
  * Copy a tabstop array, allocating space for the new array.
  */
@@ -428,7 +428,7 @@ get_indent_lnum(linenr_T lnum)
 #endif
 }
 
-#if defined(FEAT_FOLDING) || defined(PROTO)
+#if defined(FEAT_FOLDING)
 /*
  * Count the size (in window cells) of the indent in line "lnum" of buffer
  * "buf".
@@ -474,7 +474,7 @@ get_indent_str(
     return count;
 }
 
-#if defined(FEAT_VARTABS) || defined(PROTO)
+#if defined(FEAT_VARTABS)
 /*
  * Count the size (in window cells) of the indent in line "ptr", using
  * variable tabstops.
@@ -870,7 +870,7 @@ get_number_indent(linenr_T lnum)
     return (int)col;
 }
 
-#if defined(FEAT_LINEBREAK) || defined(PROTO)
+#if defined(FEAT_LINEBREAK)
 /*
  * Check "briopt" as 'breakindentopt' and update the members of "wp".
  * This is called when 'breakindentopt' is changed and when a window is
@@ -1945,7 +1945,7 @@ ex_retab(exarg_T *eap)
     u_clearline();
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Get indent level from 'indentexpr'.
  */
@@ -2302,7 +2302,7 @@ fix_indent(void)
 	do_c_expr_indent();
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * "indent()" function
  */

--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -1385,7 +1385,7 @@ pum_enough_matches(void)
     return (i >= 2);
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Allocate Dict for the completed item.
  * { word, abbr, menu, kind, info }
@@ -3684,7 +3684,7 @@ theend:
 }
 #endif // FEAT_COMPL_FUNC
 
-#if defined(FEAT_COMPL_FUNC) || defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_COMPL_FUNC) || defined(FEAT_EVAL)
 
     static inline int
 get_user_highlight_attr(char_u *hlname)
@@ -7526,7 +7526,7 @@ quote_meta(char_u *dest, char_u *src, int len)
     return m;
 }
 
-#if defined(EXITFREE) || defined(PROTO)
+#if defined(EXITFREE)
     void
 free_insexpand_stuff(void)
 {

--- a/src/job.c
+++ b/src/job.c
@@ -12,7 +12,7 @@
 
 #include "vim.h"
 
-#if defined(FEAT_JOB_CHANNEL) || defined(PROTO)
+#if defined(FEAT_JOB_CHANNEL)
 
 #define FOR_ALL_JOBS(job) \
     for ((job) = first_job; (job) != NULL; (job) = (job)->jv_next)
@@ -838,7 +838,7 @@ free_jobs_to_free_later(void)
     }
 }
 
-#if defined(EXITFREE) || defined(PROTO)
+#if defined(EXITFREE)
     void
 job_free_all(void)
 {
@@ -891,7 +891,7 @@ job_still_useful(job_T *job)
     return job_need_end_check(job) || job_channel_still_useful(job);
 }
 
-#if defined(GUI_MAY_FORK) || defined(GUI_MAY_SPAWN) || defined(PROTO)
+#if defined(GUI_MAY_FORK) || defined(GUI_MAY_SPAWN)
 /*
  * Return TRUE when there is any running job that we care about.
  */
@@ -915,7 +915,7 @@ job_any_running(void)
 # define USE_ARGV
 #endif
 
-#if !defined(USE_ARGV) || defined(PROTO)
+#if !defined(USE_ARGV)
 /*
  * Escape one argument for an external command.
  * Returns the escaped string in allocated memory.  NULL when out of memory.

--- a/src/json.c
+++ b/src/json.c
@@ -16,7 +16,7 @@
 
 #include "vim.h"
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 
 static int json_encode_item(garray_T *gap, typval_T *val, int copyID, int options);
 
@@ -55,7 +55,7 @@ json_encode(typval_T *val, int options)
     return ga.ga_data;
 }
 
-#if defined(FEAT_JOB_CHANNEL) || defined(PROTO)
+#if defined(FEAT_JOB_CHANNEL)
 /*
  * Encode ["nr", "val"] into a JSON format string in allocated memory.
  * "options" can contain JSON_JS, JSON_NO_NONE and JSON_NL.
@@ -1211,7 +1211,7 @@ json_decode_all(js_read_T *reader, typval_T *res, int options)
     return OK;
 }
 
-#if defined(FEAT_JOB_CHANNEL) || defined(PROTO)
+#if defined(FEAT_JOB_CHANNEL)
 /*
  * Decode the JSON from "reader" and store the result in "res".
  * "options" can be JSON_JS or zero;

--- a/src/list.c
+++ b/src/list.c
@@ -13,7 +13,7 @@
 
 #include "vim.h"
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 
 // List heads for garbage collection.
 static list_T		*first_list = NULL;	// list of all lists

--- a/src/locale.c
+++ b/src/locale.c
@@ -91,7 +91,7 @@ gettext_lang(char_u *name)
 }
 #endif
 
-#if defined(FEAT_MULTI_LANG) || defined(PROTO)
+#if defined(FEAT_MULTI_LANG)
 /*
  * Return TRUE when "lang" starts with a valid language name.
  * Rejects NULL, empty string, "C", "C.UTF-8" and others.
@@ -169,7 +169,7 @@ get_mess_env(void)
 }
 #endif
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 
 /*
  * Set the "v:lang" variable according to the current locale setting.
@@ -212,7 +212,7 @@ set_lang_var(void)
 }
 #endif
 
-#if defined(HAVE_LOCALE_H) || defined(X_LOCALE) || defined(PROTO)
+#if defined(HAVE_LOCALE_H) || defined(X_LOCALE)
 /*
  * Setup to use the current locale (for ctype() and many other things).
  */
@@ -511,7 +511,7 @@ init_locales(void)
     locales = find_locales();
 }
 
-# if defined(EXITFREE) || defined(PROTO)
+# if defined(EXITFREE)
     void
 free_locales(void)
 {

--- a/src/logfile.c
+++ b/src/logfile.c
@@ -14,7 +14,7 @@
 
 #include "vim.h"
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 
 // Log file opened with ch_logfile().
 static FILE *log_fd = NULL;
@@ -136,7 +136,7 @@ ch_error(channel_T *ch, const char *fmt, ...)
 }
 #endif
 
-#if defined(FEAT_JOB_CHANNEL) || defined(PROTO)
+#if defined(FEAT_JOB_CHANNEL)
 /*
  * Log a message "buf[len]" for channel "ch" part "part".
  * Only to be called when ch_log_active() returns TRUE.

--- a/src/main.c
+++ b/src/main.c
@@ -1128,7 +1128,7 @@ is_not_a_term_or_gui(void)
 	;
 }
 
-#if defined(EXITFREE) || defined(PROTO)
+#if defined(EXITFREE)
     void
 free_vbuf(void)
 {
@@ -1143,7 +1143,7 @@ free_vbuf(void)
 }
 #endif
 
-#if defined(FEAT_GUI) || defined(PROTO)
+#if defined(FEAT_GUI)
 /*
  * If a --gui-dialog-file argument was given return the file name.
  * Otherwise return NULL.
@@ -1226,7 +1226,7 @@ state_no_longer_safe(char *reason UNUSED)
     was_safe = FALSE;
 }
 
-#if defined(FEAT_EVAL) || defined(MESSAGE_QUEUE) || defined(PROTO)
+#if defined(FEAT_EVAL) || defined(MESSAGE_QUEUE)
     int
 get_was_safe_state(void)
 {
@@ -1234,7 +1234,7 @@ get_was_safe_state(void)
 }
 #endif
 
-#if defined(MESSAGE_QUEUE) || defined(PROTO)
+#if defined(MESSAGE_QUEUE)
 /*
  * Invoked when leaving code that invokes callbacks.  Then trigger
  * SafeStateAgain, if it was safe when starting to wait for a character.
@@ -1642,7 +1642,7 @@ theend:
 }
 
 
-#if defined(USE_XSMP) || defined(FEAT_GUI) || defined(PROTO)
+#if defined(USE_XSMP) || defined(FEAT_GUI)
 /*
  * Exit, but leave behind swap files for modified buffers.
  */

--- a/src/map.c
+++ b/src/map.c
@@ -1118,7 +1118,7 @@ map_clear_mode(
     }
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
     int
 mode_str2flags(char_u *modechars)
 {
@@ -2331,7 +2331,7 @@ check_map_keycodes(void)
     estack_pop();
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Check the string "keys" against the lhs of all mappings.
  * Return pointer to rhs of mapping (mapblock->m_str).
@@ -2981,7 +2981,7 @@ add_map(char_u *map, int mode, int nore)
     p_cpo = cpo_save;
 }
 
-#if defined(FEAT_LANGMAP) || defined(PROTO)
+#if defined(FEAT_LANGMAP)
 /*
  * Any character has an equivalent 'langmap' character.  This is used for
  * keyboards that have a special language mode that sends characters above

--- a/src/mark.c
+++ b/src/mark.c
@@ -1416,7 +1416,7 @@ set_last_cursor(win_T *win)
 	win->w_buffer->b_last_cursor = win->w_cursor;
 }
 
-#if defined(EXITFREE) || defined(PROTO)
+#if defined(EXITFREE)
     void
 free_all_marks(void)
 {
@@ -1428,7 +1428,7 @@ free_all_marks(void)
 }
 #endif
 
-#if defined(FEAT_VIMINFO) || defined(PROTO)
+#if defined(FEAT_VIMINFO)
 /*
  * Return a pointer to the named file marks.
  */
@@ -1439,7 +1439,7 @@ get_namedfm(void)
 }
 #endif
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Add information about mark 'mname' to list 'l'
  */

--- a/src/match.c
+++ b/src/match.c
@@ -13,7 +13,7 @@
 
 #include "vim.h"
 
-#if defined(FEAT_SEARCH_EXTRA) || defined(PROTO)
+#if defined(FEAT_SEARCH_EXTRA)
 
 # define SEARCH_HL_PRIORITY 0
 
@@ -937,7 +937,7 @@ get_search_match_hl(win_T *wp, match_T *search_hl, long col, int *char_attr)
 
 #endif // FEAT_SEARCH_EXTRA
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 # ifdef FEAT_SEARCH_EXTRA
     static int
 matchadd_dict_arg(typval_T *tv, char_u **conceal_char, win_T **win)
@@ -1357,7 +1357,7 @@ f_matchdelete(typval_T *argvars UNUSED, typval_T *rettv UNUSED)
 }
 #endif
 
-#if defined(FEAT_SEARCH_EXTRA) || defined(PROTO)
+#if defined(FEAT_SEARCH_EXTRA)
 /*
  * ":[N]match {group} {pattern}"
  * Sets nextcmd to the start of the next command, if any.  Also called when

--- a/src/mbyte.c
+++ b/src/mbyte.c
@@ -794,7 +794,7 @@ bomb_size(void)
     return n;
 }
 
-#if defined(FEAT_QUICKFIX) || defined(PROTO)
+#if defined(FEAT_QUICKFIX)
 /*
  * Remove all BOM from "s" by moving remaining text.
  */
@@ -1346,7 +1346,7 @@ static struct interval ambiguous[] =
     {0x100000, 0x10fffd}
 };
 
-#if defined(FEAT_TERMINAL) || defined(PROTO)
+#if defined(FEAT_TERMINAL)
 /*
  * utf_char2cells() with different argument type for libvterm.
  */
@@ -1921,7 +1921,7 @@ mb_cptr2char_adv(char_u **pp)
     return c;
 }
 
-#if defined(FEAT_ARABIC) || defined(PROTO)
+#if defined(FEAT_ARABIC)
 /*
  * Check if the character pointed to by "p2" is a composing character when it
  * comes after "p1".  For Arabic sometimes "ab" is replaced with "c", which
@@ -2296,7 +2296,7 @@ utf_char2bytes(int c, char_u *buf)
     return 6;
 }
 
-#if defined(FEAT_TERMINAL) || defined(PROTO)
+#if defined(FEAT_TERMINAL)
 /*
  * utf_iscomposing() with different argument type for libvterm.
  */
@@ -4321,7 +4321,7 @@ theend:
     convert_setup(&vimconv, NULL, NULL);
 }
 
-#if defined(FEAT_GUI_GTK) || defined(FEAT_SPELL) || defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_GUI_GTK) || defined(FEAT_SPELL) || defined(FEAT_EVAL)
 /*
  * Return TRUE if string "s" is a valid utf-8 string.
  * When "end" is NULL stop at the first NUL.  Otherwise stop at "end".
@@ -4348,7 +4348,7 @@ utf_valid_string(char_u *s, char_u *end)
 }
 #endif
 
-#if defined(FEAT_GUI) || defined(PROTO)
+#if defined(FEAT_GUI)
 /*
  * Special version of mb_tail_off() for use in ScreenLines[].
  */
@@ -4764,7 +4764,7 @@ enc_locale(void)
 #endif
 }
 
-# if defined(MSWIN) || defined(PROTO) || defined(FEAT_CYGWIN_WIN32_CLIPBOARD)
+# if defined(MSWIN) || defined(FEAT_CYGWIN_WIN32_CLIPBOARD)
 /*
  * Convert an encoding name to an MS-Windows codepage.
  * Returns zero if no codepage can be figured out.
@@ -4793,7 +4793,7 @@ encname2codepage(char_u *name)
 }
 # endif
 
-# if defined(USE_ICONV) || defined(PROTO)
+# if defined(USE_ICONV)
 
 /*
  * Call iconv_open() with a check if iconv() works properly (there are broken
@@ -4951,7 +4951,7 @@ iconv_string(
     return result;
 }
 
-#  if defined(DYNAMIC_ICONV) || defined(PROTO)
+#  if defined(DYNAMIC_ICONV)
 /*
  * Dynamically load the "iconv.dll" on Win32.
  */
@@ -5062,7 +5062,7 @@ iconv_end(void)
 #  endif // DYNAMIC_ICONV
 # endif // USE_ICONV
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * "getimstatus()" function
  */
@@ -5241,8 +5241,7 @@ convert_setup_ext(
     return OK;
 }
 
-#if defined(FEAT_GUI) || defined(AMIGA) || defined(MSWIN) \
-	|| defined(PROTO)
+#if defined(FEAT_GUI) || defined(AMIGA) || defined(MSWIN)
 /*
  * Do conversion on typed input characters in-place.
  * The input and output are not NUL terminated!
@@ -5570,7 +5569,7 @@ get_cellwidth(int c UNUSED)
 #endif
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 
 /*
  * Table set by setcellwidths().

--- a/src/memline.c
+++ b/src/memline.c
@@ -421,7 +421,7 @@ error:
     return FAIL;
 }
 
-#if defined(FEAT_CRYPT) || defined(PROTO)
+#if defined(FEAT_CRYPT)
 /*
  * Swapfile encryption is not supported by XChaCha20.  If this crypt method is
  * used then disable the swapfile, to avoid plain text being written to disk,
@@ -2132,7 +2132,7 @@ recover_names(
     return file_count;
 }
 
-#if defined(UNIX) || defined(MSWIN) || defined(PROTO)
+#if defined(UNIX) || defined(MSWIN)
 /*
  * Need _very_ long file names.
  * Append the full path to name with path separators made into percent
@@ -2172,7 +2172,7 @@ make_percent_swname(char_u *dir, char_u *dir_end, char_u *name)
 static int process_still_running;
 #endif
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Return information found in swapfile "fname" in dictionary "d".
  * This is used by the swapinfo() function.
@@ -3533,8 +3533,8 @@ ml_append_flags(
 }
 
 
-#if defined(FEAT_SPELL) || defined(FEAT_QUICKFIX) || defined(FEAT_PROP_POPUP) \
-	|| defined(PROTO)
+#if defined(FEAT_SPELL) || defined(FEAT_QUICKFIX) || defined(FEAT_PROP_POPUP)
+
 /*
  * Like ml_append() but for an arbitrary buffer.  The buffer must already have
  * a memline.
@@ -4567,7 +4567,7 @@ ml_lineadd(buf_T *buf, int count)
     }
 }
 
-#if defined(HAVE_READLINK) || defined(PROTO)
+#if defined(HAVE_READLINK)
 /*
  * Resolve a symlink in the last component of a file name.
  * Note that f_resolve() does it for every part of the path, we don't do that
@@ -5525,7 +5525,7 @@ ml_setflags(buf_T *buf)
     }
 }
 
-#if defined(FEAT_CRYPT) || defined(PROTO)
+#if defined(FEAT_CRYPT)
 /*
  * If "data" points to a data block encrypt the text in it and return a copy
  * in allocated memory.  Return NULL when out of memory.
@@ -5676,7 +5676,7 @@ ml_crypt_prepare(memfile_T *mfp, off_T offset, int reading)
 #endif
 
 
-#if defined(FEAT_BYTEOFF) || defined(PROTO)
+#if defined(FEAT_BYTEOFF)
 
 #define MLCS_MAXL 800	// max no of lines in chunk
 #define MLCS_MINL 400   // should be half of MLCS_MAXL

--- a/src/menu.c
+++ b/src/menu.c
@@ -14,7 +14,7 @@
 
 #include "vim.h"
 
-#if defined(FEAT_MENU) || defined(PROTO)
+#if defined(FEAT_MENU)
 
 #define MENUDEPTH   10		// maximum depth of menus
 
@@ -1772,7 +1772,7 @@ popup_mode_name(char_u *name, int idx)
     return p;
 }
 
-#if defined(FEAT_GUI) || defined(PROTO)
+#if defined(FEAT_GUI)
 /*
  * Return the index into the menu->strings or menu->noremap arrays for the
  * current state.  Returns MENU_INDEX_INVALID if there is no mapping for the
@@ -1889,7 +1889,7 @@ menu_is_popup(char_u *name)
     return (STRNCMP(name, "PopUp", 5) == 0);
 }
 
-#if (defined(FEAT_GUI_MOTIF) && (XmVersion <= 1002)) || defined(PROTO)
+#if defined(FEAT_GUI_MOTIF) && (XmVersion <= 1002)
 /*
  * Return TRUE if "name" is part of a popup menu.
  */
@@ -1943,7 +1943,7 @@ menu_is_tearoff(char_u *name UNUSED)
 #endif
 }
 
-#if defined(FEAT_GUI) || defined(FEAT_TERM_POPUP_MENU) || defined(PROTO)
+#if defined(FEAT_GUI) || defined(FEAT_TERM_POPUP_MENU)
 
     static int
 get_menu_mode(void)
@@ -2029,7 +2029,7 @@ show_popupmenu(void)
 }
 #endif
 
-#if defined(FEAT_GUI) || defined(PROTO)
+#if defined(FEAT_GUI)
 
 /*
  * Check that a pointer appears in the menu tree.  Used to protect from using
@@ -2140,7 +2140,7 @@ gui_update_menus(int modes)
 }
 
 # if defined(FEAT_GUI_MSWIN) || defined(FEAT_GUI_MOTIF) \
-    || defined(FEAT_GUI_GTK) || defined(FEAT_GUI_PHOTON) || defined(PROTO)
+    || defined(FEAT_GUI_GTK) || defined(FEAT_GUI_PHOTON)
 /*
  * Check if a key is used as a mnemonic for a toplevel menu.
  * Case of the key is ignored.
@@ -2161,7 +2161,7 @@ gui_is_menu_shortcut(int key)
 # endif
 #endif // FEAT_GUI
 
-#if (defined(FEAT_GUI_MSWIN) && defined(FEAT_TEAROFF)) || defined(PROTO)
+#if defined(FEAT_GUI_MSWIN) && defined(FEAT_TEAROFF)
 
 /*
  * Deal with tearoff items that are added like a menu item.
@@ -2595,7 +2595,7 @@ winbar_click(win_T *wp, int col)
 
 #if defined(FEAT_GUI_MSWIN) || defined(FEAT_GUI_GTK) \
 	|| defined(FEAT_TERM_POPUP_MENU) || defined(FEAT_GUI_HAIKU) \
-	|| defined(FEAT_BEVAL_TIP) || defined(PROTO)
+	|| defined(FEAT_BEVAL_TIP)
 /*
  * Given a menu descriptor, e.g. "File.New", find it in the menu hierarchy.
  */

--- a/src/message.c
+++ b/src/message.c
@@ -592,7 +592,7 @@ emsg_not_now(void)
     return FALSE;
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 static garray_T ignore_error_list = GA_EMPTY;
 
     void
@@ -620,7 +620,7 @@ ignore_error(const char *msg)
 }
 #endif
 
-#if !defined(HAVE_STRERROR) || defined(PROTO)
+#if !defined(HAVE_STRERROR)
 /*
  * Replacement for perror() that behaves more or less like emsg() was called.
  * v:errmsg will be set and called_emsg will be incremented.
@@ -912,7 +912,7 @@ internal_error(char *where)
     siemsg(_(e_internal_error_str), where);
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Like internal_error() but do not call abort(), to avoid tests using
  * test_unknown() and test_void() causing Vim to exit.
@@ -936,7 +936,7 @@ emsg_invreg(int name)
     semsg(_(e_invalid_register_name_str), transchar_buf(NULL, name));
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Give an error message which contains %s for "name[len]".
  */
@@ -1212,7 +1212,7 @@ ex_messages(exarg_T *eap)
     msg_hist_off = FALSE;
 }
 
-#if defined(FEAT_CON_DIALOG) || defined(FIND_REPLACE_DIALOG) || defined(PROTO)
+#if defined(FEAT_CON_DIALOG) || defined(FIND_REPLACE_DIALOG)
 /*
  * Call this after prompting the user.  This will avoid a hit-return message
  * and a delay.
@@ -1659,7 +1659,7 @@ msg_home_replace(char_u *fname)
     msg_home_replace_attr(fname, 0);
 }
 
-#if defined(FEAT_FIND_ID) || defined(PROTO)
+#if defined(FEAT_FIND_ID)
     void
 msg_home_replace_hl(char_u *fname)
 {
@@ -1820,7 +1820,7 @@ msg_outtrans_len_attr(char_u *msgstr, int len, int attr)
     return retval;
 }
 
-#if defined(FEAT_QUICKFIX) || defined(PROTO)
+#if defined(FEAT_QUICKFIX)
     void
 msg_make(char_u *arg)
 {
@@ -1891,7 +1891,7 @@ msg_outtrans_special(
     return retval;
 }
 
-#if defined(FEAT_EVAL) || defined(FEAT_SPELL) || defined(PROTO)
+#if defined(FEAT_EVAL) || defined(FEAT_SPELL)
 /*
  * Return the lhs or rhs of a mapping, with the key codes turned into printable
  * strings, in an allocated string.
@@ -3494,7 +3494,7 @@ do_more_prompt(int typed_char)
 #endif
 }
 
-#if defined(USE_MCH_ERRMSG) || defined(PROTO)
+#if defined(USE_MCH_ERRMSG)
 
 #ifdef mch_errmsg
 # undef mch_errmsg
@@ -4121,7 +4121,7 @@ give_warning_with_source(char_u *message, int hl, int with_source)
     --no_wait_return;
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
     void
 give_warning2(char_u *message, char_u *a1, int hl)
 {
@@ -4199,7 +4199,7 @@ msg_warn_missing_clipboard(bool plus UNUSED, bool star UNUSED)
 #endif
 }
 
-#if defined(FEAT_CON_DIALOG) || defined(PROTO)
+#if defined(FEAT_CON_DIALOG)
 /*
  * Used for "confirm()" function, and the :confirm command prefix.
  * Versions which haven't got flexible dialogs yet, and console

--- a/src/misc1.c
+++ b/src/misc1.c
@@ -344,7 +344,7 @@ plines_win(
     linenr_T	lnum,
     int		limit_winheight)	// when TRUE limit to window height
 {
-#if defined(FEAT_DIFF) || defined(PROTO)
+#if defined(FEAT_DIFF)
     // Check for filler lines above this buffer line.  When folded the result
     // is one line anyway.
     return plines_win_nofill(wp, lnum, limit_winheight)
@@ -675,7 +675,7 @@ ask_yesno(char_u *str, int direct)
     return r;
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 
 /*
  * Returns the current mode as a string in "buf[MODE_MAX_LENGTH]", NUL
@@ -1349,7 +1349,7 @@ init_homedir(void)
     }
 }
 
-#if defined(EXITFREE) || defined(PROTO)
+#if defined(EXITFREE)
     void
 free_homedir(void)
 {
@@ -1363,7 +1363,7 @@ free_users(void)
 }
 #endif
 
-#if defined(MSWIN) || defined(PROTO)
+#if defined(MSWIN)
 /*
  * Initialize $VIM and $VIMRUNTIME when 'enc' is updated.
  */
@@ -2044,7 +2044,7 @@ vim_unsetenv_ext(char_u *var)
 	didset_vimruntime = FALSE;
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Set environment variable "name" and take care of side effects.
  */
@@ -2372,7 +2372,7 @@ fast_breakcheck(void)
     }
 }
 
-# if defined(FEAT_SPELL) || defined(PROTO)
+# if defined(FEAT_SPELL)
 /*
  * Like line_breakcheck() but check 100 times less often.
  */
@@ -2388,8 +2388,7 @@ veryfast_breakcheck(void)
 #endif
 
 #if defined(VIM_BACKTICK) || defined(FEAT_EVAL) \
-	|| (defined(HAVE_LOCALE_H) || defined(X_LOCALE)) \
-	|| defined(PROTO)
+	|| (defined(HAVE_LOCALE_H) || defined(X_LOCALE))
 
 #ifndef SEEK_SET
 # define SEEK_SET 0
@@ -2497,7 +2496,7 @@ done:
     return buffer;
 }
 
-# if defined(FEAT_EVAL) || defined(PROTO)
+# if defined(FEAT_EVAL)
 
     static void
 get_cmd_output_as_rettv(
@@ -2802,7 +2801,7 @@ path_with_url(char_u *fname)
     return path_is_url(p);
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Return the dictionary of v:event.
  * Save and clear the value in case it already has items.

--- a/src/misc2.c
+++ b/src/misc2.c
@@ -2046,8 +2046,7 @@ same_directory(char_u *f1, char_u *f2)
 
 #if defined(FEAT_SESSION) || defined(FEAT_AUTOCHDIR) \
 	|| defined(MSWIN) || defined(FEAT_GUI_GTK) \
-	|| defined(FEAT_NETBEANS_INTG) \
-	|| defined(PROTO)
+	|| defined(FEAT_NETBEANS_INTG)
 /*
  * Change to a file's directory.
  * Caller must call shorten_fnames()!
@@ -2082,7 +2081,7 @@ vim_chdirfile(char_u *fname, char *trigger_autocmd)
 }
 #endif
 
-#if defined(STAT_IGNORES_SLASH) || defined(PROTO)
+#if defined(STAT_IGNORES_SLASH)
 /*
  * Check if "name" ends in a slash and is not a directory.
  * Used for systems where stat() ignores a trailing slash on a file name.
@@ -2112,7 +2111,7 @@ vim_stat(const char *name, stat_T *stp)
 }
 #endif
 
-#if defined(CURSOR_SHAPE) || defined(PROTO)
+#if defined(CURSOR_SHAPE)
 
 /*
  * Handling of cursor and mouse pointer shapes in various modes.
@@ -2420,7 +2419,7 @@ parse_shape_opt(int what)
 }
 
 # if defined(MCH_CURSOR_SHAPE) || defined(FEAT_GUI) \
-	|| defined(FEAT_MOUSESHAPE) || defined(PROTO)
+	|| defined(FEAT_MOUSESHAPE)
 /*
  * Return the index into shape_table[] for the current mode.
  * When "mouse" is TRUE, consider indexes valid for the mouse pointer.
@@ -2473,7 +2472,7 @@ get_shape_idx(int mouse)
 }
 #endif
 
-# if defined(FEAT_MOUSESHAPE) || defined(PROTO)
+# if defined(FEAT_MOUSESHAPE)
 static int current_mouse_shape = 0;
 
 /*
@@ -2527,7 +2526,7 @@ update_mouseshape(int shape_idx)
 
 #endif // CURSOR_SHAPE
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Mainly for tests: get the name of the current mouse shape.
  */
@@ -2536,7 +2535,7 @@ f_getmouseshape(typval_T *argvars UNUSED, typval_T *rettv)
 {
     rettv->v_type = VAR_STRING;
     rettv->vval.v_string = NULL;
-# if defined(FEAT_MOUSESHAPE) || defined(PROTO)
+# if defined(FEAT_MOUSESHAPE)
     if (current_mouse_shape >= 0
 			      && current_mouse_shape < (int)MSHAPE_NAMES_COUNT)
 	rettv->vval.v_string = vim_strnsave(
@@ -2592,7 +2591,7 @@ get_user_name(char_u *buf, int len)
     return OK;
 }
 
-#if defined(EXITFREE) || defined(PROTO)
+#if defined(EXITFREE)
 /*
  * Free the memory allocated by get_user_name()
  */
@@ -2810,7 +2809,7 @@ vimpty_getenv(const char_u *string)
 
 #endif // !defined(HAVE_SETENV) && !defined(HAVE_PUTENV)
 
-#if defined(FEAT_EVAL) || defined(FEAT_SPELL) || defined(PROTO)
+#if defined(FEAT_EVAL) || defined(FEAT_SPELL)
 /*
  * Return 0 for not writable, 1 for writable file, 2 for a dir which we have
  * rights to write into.
@@ -2845,7 +2844,7 @@ filewritable(char_u *fname)
 }
 #endif
 
-#if defined(FEAT_SPELL) || defined(FEAT_PERSISTENT_UNDO) || defined(PROTO)
+#if defined(FEAT_SPELL) || defined(FEAT_PERSISTENT_UNDO)
 /*
  * Read 2 bytes from "fd" and turn them into an int, MSB first.
  * Returns -1 when encountering EOF.
@@ -2987,8 +2986,7 @@ elapsed(DWORD start_tick)
 
 #if defined(FEAT_JOB_CHANNEL) \
 	|| (defined(UNIX) && (!defined(USE_SYSTEM) \
-	|| (defined(FEAT_GUI) && defined(FEAT_TERMINAL)))) \
-	|| defined(PROTO)
+	|| (defined(FEAT_GUI) && defined(FEAT_TERMINAL))))
 /*
  * Parse "cmd" and put the white-separated parts in "argv".
  * "argv" is an allocated array with "argc" entries and room for 4 more.
@@ -3095,7 +3093,7 @@ build_argv_from_string(char_u *cmd, char ***argv, int *argc)
     return OK;
 }
 
-# if defined(FEAT_JOB_CHANNEL) || defined(PROTO)
+# if defined(FEAT_JOB_CHANNEL)
 /*
  * Build "argv[argc]" from the list "l".
  * "argv[argc]" is set to NULL;

--- a/src/mouse.c
+++ b/src/mouse.c
@@ -1487,7 +1487,7 @@ set_mouse_termcode(
 	has_mouse_termcode |= HMT_NORMAL;
 }
 
-#if defined(UNIX) || defined(VMS) || defined(PROTO)
+#if defined(UNIX) || defined(VMS)
     void
 del_mouse_termcode(
     int		n)	// KS_MOUSE, KS_NETTERM_MOUSE or KS_DEC_MOUSE
@@ -3224,7 +3224,7 @@ mouse_find_win(int *rowp, int *colp, mouse_find_T popup UNUSED)
 }
 
 #if defined(NEED_VCOL2COL) || defined(FEAT_BEVAL) || defined(FEAT_PROP_POPUP) \
-	|| defined(FEAT_EVAL) || defined(PROTO)
+	|| defined(FEAT_EVAL)
 /*
  * Convert a virtual (screen) column to a character column.
  * The first column is zero.
@@ -3254,7 +3254,7 @@ vcol2col(win_T *wp, linenr_T lnum, int vcol, colnr_T *coladdp)
 }
 #endif
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * "getmousepos()" function.
  */

--- a/src/move.c
+++ b/src/move.c
@@ -676,7 +676,7 @@ changed_window_setting_win(win_T *wp)
     redraw_win_later(wp, UPD_NOT_VALID);
 }
 
-#if defined(FEAT_PROP_POPUP) || defined(PROTO)
+#if defined(FEAT_PROP_POPUP)
 /*
  * Call changed_window_setting_win() for every window containing "buf".
  */
@@ -775,7 +775,7 @@ changed_line_abv_curs_win(win_T *wp)
 						|VALID_CHEIGHT|VALID_TOPLINE);
 }
 
-#if defined(FEAT_PROP_POPUP) || defined(PROTO)
+#if defined(FEAT_PROP_POPUP)
 /*
  * Display of line has changed for "buf", invalidate cursor position and
  * w_botline.
@@ -858,7 +858,7 @@ validate_cursor(void)
 	curs_columns(TRUE);
 }
 
-#if defined(FEAT_GUI) || defined(PROTO)
+#if defined(FEAT_GUI)
 /*
  * validate w_cline_row.
  */
@@ -1442,7 +1442,7 @@ curs_columns(
     curwin->w_valid |= VALID_WCOL|VALID_WROW|VALID_VIRTCOL;
 }
 
-#if (defined(FEAT_EVAL) || defined(FEAT_PROP_POPUP)) || defined(PROTO)
+#if defined(FEAT_EVAL) || defined(FEAT_PROP_POPUP)
 /*
  * Compute the screen position of text character at "pos" in window "wp"
  * The resulting values are one-based, zero when character is not visible.
@@ -1528,7 +1528,7 @@ textpos2screenpos(
 }
 #endif
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * "screenpos({winid}, {lnum}, {col})" function
  */

--- a/src/netbeans.c
+++ b/src/netbeans.c
@@ -25,7 +25,7 @@
 
 #include "vim.h"
 
-#if defined(FEAT_NETBEANS_INTG) || defined(PROTO)
+#if defined(FEAT_NETBEANS_INTG)
 
 #ifndef MSWIN
 # include <netdb.h>
@@ -2449,7 +2449,7 @@ netbeans_keyname(int key, char *buf)
     strcat(buf, name);
 }
 
-#if defined(FEAT_BEVAL) || defined(PROTO)
+#if defined(FEAT_BEVAL)
 /*
  * Function to be called for balloon evaluation.  Grabs the text under the
  * cursor and sends it to the debugger for evaluation.  The debugger should
@@ -2552,7 +2552,7 @@ netbeans_send_disconnect(void)
     }
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
     int
 set_ref_in_nb_channel(int copyID)
 {
@@ -2569,7 +2569,7 @@ set_ref_in_nb_channel(int copyID)
 }
 #endif
 
-#if defined(FEAT_GUI_X11) || defined(FEAT_GUI_MSWIN) || defined(PROTO)
+#if defined(FEAT_GUI_X11) || defined(FEAT_GUI_MSWIN)
 /*
  * Tell netbeans that the window was moved or resized.
  */
@@ -3004,7 +3004,7 @@ netbeans_is_guarded(linenr_T top, linenr_T bot)
     return FALSE;
 }
 
-#if defined(FEAT_GUI_X11) || defined(PROTO)
+#if defined(FEAT_GUI_X11)
 /*
  * We have multiple signs to draw at the same location. Draw the
  * multi-sign indicator instead. This is the Motif version.

--- a/src/normal.c
+++ b/src/normal.c
@@ -3036,7 +3036,7 @@ nv_hor_scrollbar(cmdarg_T *cap)
 }
 #endif
 
-#if defined(FEAT_GUI_TABLINE) || defined(PROTO)
+#if defined(FEAT_GUI_TABLINE)
 /*
  * Click in GUI tab.
  */

--- a/src/ops.c
+++ b/src/ops.c
@@ -105,7 +105,7 @@ op_on_lines(int op)
     return opchars[op][2] & OPF_LINES;
 }
 
-#if defined(FEAT_JOB_CHANNEL) || defined(PROTO)
+#if defined(FEAT_JOB_CHANNEL)
 /*
  * Return TRUE if operator "op" changes text.
  */
@@ -3676,7 +3676,7 @@ did_set_operatorfunc(optset_T *args UNUSED)
     return NULL;
 }
 
-#if defined(EXITFREE) || defined(PROTO)
+#if defined(EXITFREE)
     void
 free_operatorfunc_option(void)
 {
@@ -3686,7 +3686,7 @@ free_operatorfunc_option(void)
 }
 #endif
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Mark the global 'operatorfunc' callback with "copyID" so that it is not
  * garbage collected.

--- a/src/option.c
+++ b/src/option.c
@@ -45,7 +45,7 @@ static char_u *find_dup_item(char_u *origval, char_u *newval, size_t newvallen, 
 static char_u *option_expand(int opt_idx, char_u *val);
 static void didset_options(void);
 static void didset_options2(void);
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 static long_u *insecure_flag(win_T *wp, int opt_idx, int opt_flags);
 #else
 # define insecure_flag(wp, opt_idx, opt_flags) (&options[opt_idx].flags)
@@ -69,7 +69,7 @@ static void check_winopt(winopt_T *wop);
 static int wc_use_keyname(char_u *varp, long *wcp);
 static void compatible_set(void);
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 static char *(p_bin_dep_opts[])    = {"textwidth", "wrapmargin", "modeline", "expandtab", NULL};
 static char *(p_paste_dep_opts[])  = {"autoindent", "expandtab", "ruler", "showmatch", "smarttab",
     "softtabstop", "textwidth", "wrapmargin",
@@ -961,7 +961,7 @@ set_number_default(char *name, long val)
 	options[opt_idx].def_val[VI_DEFAULT] = (char_u *)(long_i)val;
 }
 
-#if defined(FEAT_PROP_POPUP) || defined(PROTO)
+#if defined(FEAT_PROP_POPUP)
 /*
  * Set all window-local and buffer-local options to the Vim default.
  * local-global options will use the global value.
@@ -995,7 +995,7 @@ set_local_options_default(win_T *wp, int do_buffer)
 }
 #endif
 
-#if defined(EXITFREE) || defined(PROTO)
+#if defined(EXITFREE)
 /*
  * Free all options.
  */
@@ -1310,7 +1310,7 @@ set_init_3(void)
     set_title_defaults();
 }
 
-#if defined(FEAT_MULTI_LANG) || defined(PROTO)
+#if defined(FEAT_MULTI_LANG)
 /*
  * When 'helplang' is still at its default value, set it to "lang".
  * Only the first two characters of "lang" are used.
@@ -2919,7 +2919,7 @@ set_options_bin(
 	    p_et = p_et_nobin;
 	}
     }
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
     // Remember where the dependent option were reset
     didset_options_sctx(opt_flags, p_bin_dep_opts);
 #endif
@@ -3065,7 +3065,7 @@ set_term_option_alloced(char_u **p)
     return opt_idx;
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Return TRUE when option "opt" was set from a modeline or in secure mode.
  * Return FALSE when it wasn't.
@@ -3161,7 +3161,7 @@ valid_name(char_u *val, char *allowed)
     return TRUE;
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Set the script_ctx for an option, taking care of setting the buffer- or
  * window-local value.
@@ -3293,7 +3293,7 @@ apply_optionset_autocmd(
 }
 #endif
 
-#if defined(FEAT_ARABIC) || defined(PROTO)
+#if defined(FEAT_ARABIC)
 /*
  * Process the updated 'arabic' option value.
  */
@@ -3374,7 +3374,7 @@ did_set_arabic(optset_T *args UNUSED)
 }
 #endif
 
-#if defined(FEAT_AUTOCHDIR) || defined(PROTO)
+#if defined(FEAT_AUTOCHDIR)
 /*
  * Process the updated 'autochdir' option value.
  */
@@ -3387,7 +3387,7 @@ did_set_autochdir(optset_T *args UNUSED)
 }
 #endif
 
-#if defined(FEAT_BEVAL_GUI) || defined(PROTO)
+#if defined(FEAT_BEVAL_GUI)
 /*
  * Process the updated 'ballooneval' option value.
  */
@@ -3406,7 +3406,7 @@ did_set_ballooneval(optset_T *args)
 }
 #endif
 
-#if defined(FEAT_BEVAL_TERM) || defined(PROTO)
+#if defined(FEAT_BEVAL_TERM)
 /*
  * Process the updated 'balloonevalterm' option value.
  */
@@ -3486,7 +3486,7 @@ did_set_compatible(optset_T *args UNUSED)
     return NULL;
 }
 
-#if defined(FEAT_CONCEAL) || defined(PROTO)
+#if defined(FEAT_CONCEAL)
 /*
  * Process the new 'conceallevel' option value.
  */
@@ -3520,7 +3520,7 @@ did_set_conceallevel(optset_T *args UNUSED)
 }
 #endif
 
-#if defined(FEAT_DIFF) || defined(PROTO)
+#if defined(FEAT_DIFF)
 /*
  * Process the updated 'diff' option value.
  */
@@ -3561,7 +3561,7 @@ did_set_equalalways(optset_T *args)
     return NULL;
 }
 
-#if defined(FEAT_FOLDING) || defined(PROTO)
+#if defined(FEAT_FOLDING)
 /*
  * Process the new 'foldcolumn' option value.
  */
@@ -3628,7 +3628,7 @@ did_set_foldnestmax(optset_T *args UNUSED)
 }
 #endif
 
-#if defined(FEAT_SEARCH_EXTRA) || defined(PROTO)
+#if defined(FEAT_SEARCH_EXTRA)
 /*
  * Process the updated 'hlsearch' option value.
  */
@@ -3653,7 +3653,7 @@ did_set_ignorecase(optset_T *args UNUSED)
     return NULL;
 }
 
-#if defined(HAVE_INPUT_METHOD) || defined(PROTO)
+#if defined(HAVE_INPUT_METHOD)
 /*
  * Process the updated 'imdisable' option value.
  */
@@ -3713,7 +3713,7 @@ did_set_imsearch(optset_T *args UNUSED)
     return errmsg;
 }
 
-#if (defined(FEAT_XIM) && defined(FEAT_GUI_GTK)) || defined(PROTO)
+#if defined(FEAT_XIM) && defined(FEAT_GUI_GTK)
 /*
  * Process the new 'imstyle' option value.
  */
@@ -3755,7 +3755,7 @@ did_set_insertmode(optset_T *args)
     return NULL;
 }
 
-#if defined(FEAT_LANGMAP) || defined(PROTO)
+#if defined(FEAT_LANGMAP)
 /*
  * Process the updated 'langnoremap' option value.
  */
@@ -3789,7 +3789,7 @@ did_set_laststatus(optset_T *args UNUSED)
     return NULL;
 }
 
-#if defined(FEAT_GUI) || defined(PROTO)
+#if defined(FEAT_GUI)
 /*
  * Process the new 'linespace' option value.
  */
@@ -3864,7 +3864,7 @@ did_set_modified(optset_T *args)
     return NULL;
 }
 
-#if defined(FEAT_GUI) || defined(PROTO)
+#if defined(FEAT_GUI)
 /*
  * Process the updated 'mousehide' option value.
  */
@@ -3883,7 +3883,7 @@ did_set_mousehide(optset_T *args UNUSED)
     char *
 did_set_number_relativenumber(optset_T *args UNUSED)
 {
-#if (defined(FEAT_SIGNS) && defined(FEAT_GUI)) || defined(PROTO)
+#if defined(FEAT_SIGNS) && defined(FEAT_GUI)
     if (gui.in_use
 	    && (*curwin->w_p_scl == 'n' && *(curwin->w_p_scl + 1) == 'u')
 	    && curbuf->b_signlist != NULL)
@@ -3901,7 +3901,7 @@ did_set_number_relativenumber(optset_T *args UNUSED)
     return NULL;
 }
 
-#if defined(FEAT_LINEBREAK) || defined(PROTO)
+#if defined(FEAT_LINEBREAK)
 /*
  * Process the new 'numberwidth' option value.
  */
@@ -4103,7 +4103,7 @@ did_set_paste(optset_T *args UNUSED)
 
     old_p_paste = p_paste;
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
     // Remember where the dependent options were reset
     didset_options_sctx((OPT_LOCAL | OPT_GLOBAL), p_paste_dep_opts);
 #endif
@@ -4136,7 +4136,7 @@ did_set_previewwindow(optset_T *args UNUSED)
 }
 #endif
 
-#if defined(FEAT_PYTHON) || defined(FEAT_PYTHON3) || defined(PROTO)
+#if defined(FEAT_PYTHON) || defined(FEAT_PYTHON3)
 /*
  * Process the new 'pyxversion' option value.
  */
@@ -4210,7 +4210,7 @@ did_set_maxsearchcount(optset_T *args UNUSED)
 }
 
 
-#if defined(BACKSLASH_IN_FILENAME) || defined(PROTO)
+#if defined(BACKSLASH_IN_FILENAME)
 /*
  * Process the updated 'shellslash' option value.
  */
@@ -4329,7 +4329,7 @@ did_set_smoothscroll(optset_T *args UNUSED)
     return NULL;
 }
 
-#if defined(FEAT_SPELL) || defined(PROTO)
+#if defined(FEAT_SPELL)
 /*
  * Process the updated 'spell' option value.
  */
@@ -4359,7 +4359,7 @@ did_set_swapfile(optset_T *args UNUSED)
     return NULL;
 }
 
-#if defined(FEAT_TERMGUICOLORS) || defined(PROTO)
+#if defined(FEAT_TERMGUICOLORS)
     char *
 did_set_termguicolors(optset_T *args UNUSED)
 {
@@ -4402,7 +4402,7 @@ did_set_termguicolors(optset_T *args UNUSED)
 }
 #endif
 
-#if defined(FEAT_TERMINAL) || defined(PROTO)
+#if defined(FEAT_TERMINAL)
 /*
  * Process the updated 'termwinscroll' option value.
  */
@@ -4535,7 +4535,7 @@ did_set_titlelen(optset_T *args)
     return errmsg;
 }
 
-#if defined(FEAT_PERSISTENT_UNDO) || defined(PROTO)
+#if defined(FEAT_PERSISTENT_UNDO)
 /*
  * Process the updated 'undofile' option value.
  */
@@ -4795,7 +4795,7 @@ did_set_winwidth(optset_T *args UNUSED)
     return errmsg;
 }
 
-#if defined(FEAT_WAYLAND_CLIPBOARD) || defined(PROTO)
+#if defined(FEAT_WAYLAND_CLIPBOARD)
 /*
  * Process the new 'wlsteal' option value.
  */
@@ -4808,7 +4808,7 @@ did_set_wlsteal(optset_T *args UNUSED)
 }
 #endif
 
-#if defined(FEAT_WAYLAND) || defined(PROTO)
+#if defined(FEAT_WAYLAND)
 /*
  * Process the new 'wltimeoutlen' option value.
  */
@@ -5293,7 +5293,7 @@ findoption(char_u *arg)
 }
 
 #if defined(FEAT_EVAL) || defined(FEAT_TCL) || defined(FEAT_MZSCHEME) \
-	|| defined(FEAT_SPELL) || defined(PROTO)
+	|| defined(FEAT_SPELL)
 /*
  * Get the value for an option.
  *
@@ -5400,7 +5400,7 @@ get_option_value(
 }
 #endif
 
-#if defined(FEAT_PYTHON) || defined(FEAT_PYTHON3) || defined(PROTO)
+#if defined(FEAT_PYTHON) || defined(FEAT_PYTHON3)
 /*
  * Returns the option attributes and its value. Unlike the above function it
  * will return either global value or local value of the option depending on
@@ -5659,7 +5659,7 @@ is_hidden_option(int opt_idx)
     return options[opt_idx].var == NULL;
 }
 
-#if defined(FEAT_CRYPT) || defined(PROTO)
+#if defined(FEAT_CRYPT)
 /*
  * Returns TRUE if the option at 'opt_idx' is a crypt key option
  */
@@ -5828,7 +5828,7 @@ get_encoding_default(void)
     return (char_u *)NULL;
 }
 
-#if defined(FEAT_QUICKFIX) || defined(PROTO)
+#if defined(FEAT_QUICKFIX)
     int
 is_option_allocated(char *name)
 {
@@ -6178,7 +6178,7 @@ makeset(FILE *fd, int opt_flags, int local_only)
     return OK;
 }
 
-#if defined(FEAT_FOLDING) || defined(PROTO)
+#if defined(FEAT_FOLDING)
 /*
  * Generate set commands for the local fold options only.  Used when
  * 'sessionoptions' or 'viewoptions' contains "folds" but not "options".
@@ -6445,7 +6445,7 @@ istermoption_idx(int opt_idx)
     return istermoption(&options[opt_idx]);
 }
 
-#if defined(FEAT_PYTHON) || defined(FEAT_PYTHON3) || defined(PROTO)
+#if defined(FEAT_PYTHON) || defined(FEAT_PYTHON3)
 /*
  * Unset local option value, similar to ":set opt<".
  */
@@ -6966,7 +6966,7 @@ get_option_var(int opt_idx)
     return options[opt_idx].var;
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Return the full name of the option at 'opt_idx'
  */
@@ -8744,7 +8744,7 @@ get_bkc_flags(buf_T *buf)
     return buf->b_bkc_flags ? buf->b_bkc_flags : bkc_flags;
 }
 
-#if defined(FEAT_LINEBREAK) || defined(PROTO)
+#if defined(FEAT_LINEBREAK)
 /*
  * Get the local or global value of 'formatlistpat'.
  */
@@ -8767,7 +8767,7 @@ get_ve_flags(void)
 	    & ~(VE_NONE | VE_NONEU);
 }
 
-#if defined(FEAT_LINEBREAK) || defined(PROTO)
+#if defined(FEAT_LINEBREAK)
 /*
  * Get the local or global value of 'showbreak'.
  */
@@ -8782,7 +8782,7 @@ get_showbreak_value(win_T *win)
 }
 #endif
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Get window or buffer local options.
  */
@@ -8821,7 +8821,7 @@ get_winbuf_options(int bufopt)
 }
 #endif
 
-#if defined(FEAT_SYN_HL) || defined(PROTO)
+#if defined(FEAT_SYN_HL)
 /*
  * This is called when 'culopt' is changed
  */
@@ -8978,7 +8978,7 @@ option_set_callback_func(char_u *optval UNUSED, callback_T *optcb UNUSED)
 #endif
 }
 
-#if defined(FEAT_TABPANEL) || defined(PROTO)
+#if defined(FEAT_TABPANEL)
 /*
  * Process the new 'showtabpanel' option value.
  */
@@ -8990,7 +8990,7 @@ did_set_showtabpanel(optset_T *args UNUSED)
 }
 #endif
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
     static void
 didset_options_sctx(int opt_flags, char **buf)
 {

--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -182,7 +182,7 @@ didset_string_options(void)
     (void)opt_strings_flags(p_tcl, p_tcl_values, &tcl_flags, TRUE);
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Trigger the OptionSet autocommand.
  * "opt_idx"	is the index of the option being set.
@@ -494,8 +494,7 @@ set_string_option_direct(
 # endif
 }
 
-#if defined(FEAT_PROP_POPUP) || \
-    (defined(FEAT_DIFF) && defined(FEAT_FOLDING)) || defined(PROTO)
+#if defined(FEAT_PROP_POPUP) || (defined(FEAT_DIFF) && defined(FEAT_FOLDING))
 /*
  * Like set_string_option_direct(), but for a window-local option in "wp".
  * Blocks autocommands to avoid the old curwin becoming invalid.
@@ -521,7 +520,7 @@ set_string_option_direct_in_win(
 }
 #endif
 
-#if defined(FEAT_PROP_POPUP) || defined(PROTO)
+#if defined(FEAT_PROP_POPUP)
 /*
  * Like set_string_option_direct(), but for a buffer-local option in "buf".
  * Blocks autocommands to avoid the old curbuf becoming invalid.
@@ -1240,7 +1239,7 @@ expand_set_belloff(optexpand_T *args, int *numMatches, char_u ***matches)
 	    matches);
 }
 
-#if defined(FEAT_LINEBREAK) || defined(PROTO)
+#if defined(FEAT_LINEBREAK)
 /*
  * The 'breakat' option is changed.
  */
@@ -1294,7 +1293,7 @@ expand_set_breakindentopt(
 }
 #endif
 
-#if defined(FEAT_BROWSE) || defined(PROTO)
+#if defined(FEAT_BROWSE)
 /*
  * The 'browsedir' option is changed.
  */
@@ -1391,7 +1390,7 @@ expand_set_casemap(optexpand_T *args, int *numMatches, char_u ***matches)
 	    matches);
 }
 
-#if defined(FEAT_CLIPBOARD) || defined(PROTO)
+#if defined(FEAT_CLIPBOARD)
     int
 expand_set_clipboard(optexpand_T *args, int *numMatches, char_u ***matches)
 {
@@ -1524,7 +1523,7 @@ did_set_cinoptions(optset_T *args UNUSED)
     return NULL;
 }
 
-#if defined(FEAT_SYN_HL) || defined(PROTO)
+#if defined(FEAT_SYN_HL)
 /*
  * The 'colorcolumn' option is changed.
  */
@@ -1577,7 +1576,7 @@ did_set_comments(optset_T *args)
     return errmsg;
 }
 
-#if defined(FEAT_FOLDING) || defined(PROTO)
+#if defined(FEAT_FOLDING)
 /*
  * The 'commentstring' option is changed.
  */
@@ -1801,7 +1800,7 @@ did_set_completeitemalign(optset_T *args UNUSED)
     return NULL;
 }
 
-#if (defined(FEAT_PROP_POPUP) && defined(FEAT_QUICKFIX)) || defined(PROTO)
+#if defined(FEAT_PROP_POPUP) && defined(FEAT_QUICKFIX)
 /*
  * The 'completepopup' option is changed.
  */
@@ -1816,7 +1815,7 @@ did_set_completepopup(optset_T *args UNUSED)
 }
 #endif
 
-#if defined(BACKSLASH_IN_FILENAME) || defined(PROTO)
+#if defined(BACKSLASH_IN_FILENAME)
 /*
  * The 'completeslash' option is changed.
  */
@@ -1842,7 +1841,7 @@ expand_set_completeslash(optexpand_T *args, int *numMatches, char_u ***matches)
 }
 #endif
 
-#if defined(FEAT_CONCEAL) || defined(PROTO)
+#if defined(FEAT_CONCEAL)
 /*
  * The 'concealcursor' option is changed.
  */
@@ -1880,7 +1879,7 @@ expand_set_cpoptions(optexpand_T *args, int *numMatches, char_u ***matches)
     return expand_set_opt_listflag(args, (char_u*)CPO_ALL, numMatches, matches);
 }
 
-#if defined(FEAT_CRYPT) || defined(PROTO)
+#if defined(FEAT_CRYPT)
 /*
  * The 'cryptkey' option is changed.
  */
@@ -1983,7 +1982,7 @@ expand_set_cryptmethod(optexpand_T *args, int *numMatches, char_u ***matches)
 }
 #endif
 
-#if (defined(FEAT_CSCOPE) && defined(FEAT_QUICKFIX)) || defined(PROTO)
+#if defined(FEAT_CSCOPE) && defined(FEAT_QUICKFIX)
 /*
  * The 'cscopequickfix' option is changed.
  */
@@ -2013,7 +2012,7 @@ did_set_cscopequickfix(optset_T *args UNUSED)
 }
 #endif
 
-#if defined(FEAT_SYN_HL) || defined(PROTO)
+#if defined(FEAT_SYN_HL)
 /*
  * The 'cursorlineopt' option is changed.
  */
@@ -2061,7 +2060,7 @@ expand_set_debug(optexpand_T *args, int *numMatches, char_u ***matches)
 	    matches);
 }
 
-#if defined(FEAT_DIFF) || defined(PROTO)
+#if defined(FEAT_DIFF)
 /*
  * The 'diffanchors' option is changed.
  */
@@ -2410,7 +2409,7 @@ did_set_filetype_or_syntax(optset_T *args)
     return NULL;
 }
 
-#if defined(FEAT_FOLDING) || defined(PROTO)
+#if defined(FEAT_FOLDING)
 /*
  * The 'foldclose' option is changed.
  */
@@ -2432,7 +2431,7 @@ expand_set_foldclose(optexpand_T *args, int *numMatches, char_u ***matches)
 }
 #endif
 
-#if (defined(FEAT_EVAL) && defined(FEAT_FOLDING)) || defined(PROTO)
+#if defined(FEAT_EVAL) && defined(FEAT_FOLDING)
 /*
  * The 'foldexpr' option is changed.
  */
@@ -2446,7 +2445,7 @@ did_set_foldexpr(optset_T *args)
 }
 #endif
 
-#if defined(FEAT_FOLDING) || defined(PROTO)
+#if defined(FEAT_FOLDING)
 /*
  * The 'foldignore' option is changed.
  */
@@ -2545,7 +2544,7 @@ expand_set_formatoptions(optexpand_T *args, int *numMatches, char_u ***matches)
     return expand_set_opt_listflag(args, (char_u*)FO_ALL, numMatches, matches);
 }
 
-#if defined(CURSOR_SHAPE) || defined(PROTO)
+#if defined(CURSOR_SHAPE)
 /*
  * The 'guicursor' option is changed.
  */
@@ -2556,7 +2555,7 @@ did_set_guicursor(optset_T *args UNUSED)
 }
 #endif
 
-#if defined(FEAT_GUI) || defined(PROTO)
+#if defined(FEAT_GUI)
 /*
  * The 'guifont' option is changed.
  */
@@ -2620,7 +2619,7 @@ expand_set_guifont(optexpand_T *args, int *numMatches, char_u ***matches)
 # endif
 }
 
-# if defined(FEAT_XFONTSET) || defined(PROTO)
+# if defined(FEAT_XFONTSET)
 /*
  * The 'guifontset' option is changed.
  */
@@ -2655,7 +2654,7 @@ did_set_guifontwide(optset_T *args UNUSED)
 }
 #endif
 
-#if defined(FEAT_GUI_GTK) || defined(FEAT_GUI_MSWIN) || defined(PROTO)
+#if defined(FEAT_GUI_GTK) || defined(FEAT_GUI_MSWIN)
 /*
  * The 'guiligatures' option is changed.
  */
@@ -2667,7 +2666,7 @@ did_set_guiligatures(optset_T *args UNUSED)
 }
 #endif
 
-#if defined(FEAT_GUI) || defined(PROTO)
+#if defined(FEAT_GUI)
 /*
  * The 'guioptions' option is changed.
  */
@@ -2693,7 +2692,7 @@ expand_set_guioptions(optexpand_T *args, int *numMatches, char_u ***matches)
 }
 #endif
 
-#if defined(FEAT_GUI_TABLINE) || defined(PROTO)
+#if defined(FEAT_GUI_TABLINE)
 /*
  * The 'guitablabel' option is changed.
  */
@@ -2719,7 +2718,7 @@ did_set_helpfile(optset_T *args UNUSED)
     return NULL;
 }
 
-#if defined(FEAT_MULTI_LANG) || defined(PROTO)
+#if defined(FEAT_MULTI_LANG)
 /*
  * The 'helplang' option is changed.
  */
@@ -2911,7 +2910,7 @@ did_set_iconstring(optset_T *args)
     return parse_titleiconstring(args, flagval);
 }
 
-#if (defined(FEAT_XIM) && defined(FEAT_GUI_GTK)) || defined(PROTO)
+#if defined(FEAT_XIM) && defined(FEAT_GUI_GTK)
 /*
  * The 'imactivatekey' option is changed.
  */
@@ -3027,7 +3026,7 @@ expand_set_jumpoptions(optexpand_T *args, int *numMatches, char_u ***matches)
 	    matches);
 }
 
-#if defined(FEAT_KEYMAP) || defined(PROTO)
+#if defined(FEAT_KEYMAP)
 /*
  * The 'keymap' option is changed.
  */
@@ -3245,7 +3244,7 @@ expand_set_messagesopt(optexpand_T *args, int *numMatches, char_u ***matches)
 	    matches);
 }
 
-#if defined(FEAT_SPELL) || defined(PROTO)
+#if defined(FEAT_SPELL)
 /*
  * The 'mkspellmem' option is changed.
  */
@@ -3275,7 +3274,7 @@ did_set_mouse(optset_T *args)
 	redraw_tabline = TRUE;
 	if (tabline_height() > 0)
 	    update_screen(UPD_VALID);
-#if (defined(FEAT_PROP_POPUP) && defined(FEAT_QUICKFIX)) || defined(PROTO)
+#if defined(FEAT_PROP_POPUP) && defined(FEAT_QUICKFIX)
 	popup_close_info(); // Close info popup to apply new properties
 #endif
     }
@@ -3317,7 +3316,7 @@ expand_set_mousemodel(optexpand_T *args, int *numMatches, char_u ***matches)
 	    matches);
 }
 
-#if defined(FEAT_MOUSESHAPE) || defined(PROTO)
+#if defined(FEAT_MOUSESHAPE)
     char *
 did_set_mouseshape(optset_T *args UNUSED)
 {
@@ -3352,7 +3351,7 @@ expand_set_nrformats(optexpand_T *args, int *numMatches, char_u ***matches)
 	    matches);
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * One of the '*expr' options is changed: 'balloonexpr', 'diffexpr',
  * 'foldexpr', 'foldtext', 'formatexpr', 'includeexpr', 'indentexpr',
@@ -3399,7 +3398,7 @@ did_set_pastetoggle(optset_T *args UNUSED)
     return NULL;
 }
 
-#if defined(FEAT_PROP_POPUP) || defined(PROTO)
+#if defined(FEAT_PROP_POPUP)
 /*
  * The 'previewpopup' option is changed.
  */
@@ -3465,7 +3464,7 @@ expand_set_popupoption(optexpand_T *args, int *numMatches, char_u ***matches)
 }
 #endif
 
-#if defined(FEAT_POSTSCRIPT) || defined(PROTO)
+#if defined(FEAT_POSTSCRIPT)
 /*
  * The 'printencoding' option is changed.
  */
@@ -3497,7 +3496,7 @@ did_set_printencoding(optset_T *args UNUSED)
 }
 #endif
 
-#if defined(FEAT_PRINTER) || defined(PROTO)
+#if defined(FEAT_PRINTER)
 
     static char_u *
 get_printoptions_names(expand_T *xp UNUSED, int idx)
@@ -3521,7 +3520,7 @@ expand_set_printoptions(optexpand_T *args, int *numMatches, char_u ***matches)
 }
 #endif
 
-#if defined(FEAT_STL_OPT) || defined(PROTO)
+#if defined(FEAT_STL_OPT)
 /*
  * The 'statusline' or the 'tabline' or the 'rulerformat' option is changed.
  * "rulerformat" is TRUE if the 'rulerformat' option is changed.
@@ -3563,7 +3562,7 @@ parse_statustabline_rulerformat(optset_T *args, int rulerformat)
 }
 #endif
 
-#if defined(FEAT_RENDER_OPTIONS) || defined(PROTO)
+#if defined(FEAT_RENDER_OPTIONS)
 /*
  * The 'renderoptions' option is changed.
  */
@@ -3577,7 +3576,7 @@ did_set_renderoptions(optset_T *args UNUSED)
 }
 #endif
 
-#if defined(FEAT_RIGHTLEFT) || defined(PROTO)
+#if defined(FEAT_RIGHTLEFT)
 /*
  * The 'rightleftcmd' option is changed.
  */
@@ -3744,7 +3743,8 @@ expand_set_pumborder(optexpand_T *args, int *numMatches, char_u ***matches)
 	    matches);
 }
 
-#if defined(FEAT_STL_OPT) || defined(PROTO)
+#if defined(FEAT_STL_OPT)
+
 /*
  * The 'rulerformat' option is changed.
  */
@@ -3755,7 +3755,7 @@ did_set_rulerformat(optset_T *args)
 }
 #endif
 
-#if defined(FEAT_TABPANEL) || defined(PROTO)
+#if defined(FEAT_TABPANEL)
 /*
  * Process the new 'tabpanelopt' option value.
  */
@@ -3877,7 +3877,7 @@ expand_set_selectmode(optexpand_T *args, int *numMatches, char_u ***matches)
 	    matches);
 }
 
-#if defined(FEAT_SESSION) || defined(PROTO)
+#if defined(FEAT_SESSION)
 /*
  * The 'sessionoptions' option is changed.
  */
@@ -3930,7 +3930,7 @@ expand_set_shortmess(optexpand_T *args, int *numMatches, char_u ***matches)
     return expand_set_opt_listflag(args, (char_u*)SHM_ALL, numMatches, matches);
 }
 
-#if defined(FEAT_LINEBREAK) || defined(PROTO)
+#if defined(FEAT_LINEBREAK)
 /*
  * The 'showbreak' option is changed.
  */
@@ -3976,7 +3976,7 @@ expand_set_showcmdloc(optexpand_T *args, int *numMatches, char_u ***matches)
 	    matches);
 }
 
-#if defined(FEAT_SIGNS) || defined(PROTO)
+#if defined(FEAT_SIGNS)
 /*
  * The 'signcolumn' option is changed.
  */
@@ -4009,7 +4009,7 @@ expand_set_signcolumn(optexpand_T *args, int *numMatches, char_u ***matches)
 }
 #endif
 
-#if defined(FEAT_SPELL) || defined(PROTO)
+#if defined(FEAT_SPELL)
 /*
  * The 'spellcapcheck' option is changed.
  */
@@ -4122,7 +4122,7 @@ expand_set_splitkeep(optexpand_T *args, int *numMatches, char_u ***matches)
 	    matches);
 }
 
-#if defined(FEAT_STL_OPT) || defined(PROTO)
+#if defined(FEAT_STL_OPT)
 /*
  * The 'statusline' option is changed.
  */
@@ -4193,7 +4193,7 @@ expand_set_tabclose(optexpand_T *args, int *numMatches, char_u ***matches)
 	    matches);
 }
 
-#if defined(FEAT_STL_OPT) || defined(PROTO)
+#if defined(FEAT_STL_OPT)
 /*
  * The 'tabline' option is changed.
  */
@@ -4336,7 +4336,7 @@ did_set_term_option(optset_T *args)
     return NULL;
 }
 
-#if defined(FEAT_TERMINAL) || defined(PROTO)
+#if defined(FEAT_TERMINAL)
 /*
  * The 'termwinkey' option is changed.
  */
@@ -4370,7 +4370,7 @@ did_set_termwinsize(optset_T *args)
     return NULL;
 }
 
-# if defined(MSWIN) || defined(PROTO)
+# if defined(MSWIN)
 /*
  * The 'termwintype' option is changed.
  */
@@ -4407,7 +4407,7 @@ did_set_titlestring(optset_T *args)
     return parse_titleiconstring(args, flagval);
 }
 
-#if (defined(FEAT_TOOLBAR) && !defined(FEAT_GUI_MSWIN)) || defined(PROTO)
+#if defined(FEAT_TOOLBAR) && !defined(FEAT_GUI_MSWIN)
 /*
  * The 'toolbar' option is changed.
  */
@@ -4436,7 +4436,7 @@ expand_set_toolbar(optexpand_T *args, int *numMatches, char_u ***matches)
 }
 #endif
 
-#if (defined(FEAT_TOOLBAR) && defined(FEAT_GUI_GTK)) || defined(PROTO)
+#if defined(FEAT_TOOLBAR) && defined(FEAT_GUI_GTK)
 /*
  * The 'toolbariconsize' option is changed.  GTK+ 2 only.
  */
@@ -4467,7 +4467,7 @@ expand_set_toolbariconsize(
 }
 #endif
 
-#if defined(UNIX) || defined(VMS) || defined(PROTO)
+#if defined(UNIX) || defined(VMS)
 /*
  * The 'ttymouse' option is changed.
  */
@@ -4501,7 +4501,7 @@ expand_set_ttymouse(optexpand_T *args, int *numMatches, char_u ***matches)
 }
 #endif
 
-#if defined(FEAT_VARTABS) || defined(PROTO)
+#if defined(FEAT_VARTABS)
 /*
  * The 'varsofttabstop' option is changed.
  */
@@ -4590,7 +4590,7 @@ did_set_verbosefile(optset_T *args UNUSED)
     return NULL;
 }
 
-#if defined(FEAT_SESSION) || defined(PROTO)
+#if defined(FEAT_SESSION)
 /*
  * The 'viewoptions' option is changed.
  */
@@ -4601,7 +4601,7 @@ did_set_viewoptions(optset_T *args UNUSED)
 }
 #endif
 
-#if defined(FEAT_VIMINFO) || defined(PROTO)
+#if defined(FEAT_VIMINFO)
 /*
  * The 'viminfo' option is changed.
  */
@@ -4778,7 +4778,7 @@ expand_set_wildoptions(optexpand_T *args, int *numMatches, char_u ***matches)
 	    matches);
 }
 
-#if defined(FEAT_WAK) || defined(PROTO)
+#if defined(FEAT_WAK)
 /*
  * The 'winaltkeys' option is changed.
  */
@@ -5045,7 +5045,7 @@ did_set_string_option(
     if (varp == &p_rtp)
     {
 	export_myvimdir();
-#if defined(FEAT_LUA) || defined(PROTO)
+#if defined(FEAT_LUA)
 	update_package_paths_in_lua();
 #endif
     }

--- a/src/os_amiga.c
+++ b/src/os_amiga.c
@@ -23,9 +23,6 @@
 #undef TRUE		// will be redefined by exec/types.h
 #undef FALSE
 
-// cproto fails on missing include files, skip them
-#ifndef PROTO
-
 #ifndef LATTICE
 # include <exec/exec.h>
 # include <intuition/intuition.h>
@@ -56,8 +53,6 @@
 #if defined(LATTICE) && !defined(SASC) && defined(FEAT_ARP)
 # include <libraries/arp_pragmas.h>
 #endif
-
-#endif // PROTO
 
 /*
  * Set stack size to 1 MiB on NG systems. This should be enough even for
@@ -302,9 +297,7 @@ mch_init(void)
 #endif
 }
 
-#ifndef PROTO
-# include <workbench/startup.h>
-#endif
+#include <workbench/startup.h>
 
 /*
  * Check_win checks whether we have an interactive window.
@@ -1040,9 +1033,7 @@ mch_settmode(tmode_T tmode)
  * Heavely modified by mool.
  */
 
-#ifndef PROTO
-# include <devices/conunit.h>
-#endif
+#include <devices/conunit.h>
 
 /*
  * Get console size in a system friendly way on AROS and MorphOS.
@@ -1215,11 +1206,9 @@ out_num(long n)
  * say 'oml lib:amiga.lib -r sendpacket.o'
  */
 
-#ifndef PROTO
-// #include <proto/exec.h>
-// #include <proto/dos.h>
-# include <exec/memory.h>
-#endif
+//#include <proto/exec.h>
+//#include <proto/dos.h>
+#include <exec/memory.h>
 
 /*
  * Function - dos_packet written by Phil Lindsay, Carolyn Scheppner, and Andy

--- a/src/os_amiga.h
+++ b/src/os_amiga.h
@@ -56,9 +56,6 @@
 # define TEMPNAMELEN	12
 #endif
 
-// cproto fails on missing include files
-#ifndef PROTO
-
 #include <exec/types.h>
 #include <libraries/dos.h>
 #include <libraries/dosextens.h>
@@ -69,8 +66,6 @@
 # include <proto/dos.h>
 # include <proto/intuition.h>
 #endif
-
-#endif // PROTO
 
 #define FNAME_ILLEGAL ";*?`#%" // illegal characters in a file name
 
@@ -97,15 +92,12 @@ typedef long off_t;
 
 #include <time.h>	// for strftime() and others
 
-#ifndef PROTO
 /*
  * arpbase.h must be included before functions.h
  */
 #ifdef FEAT_ARP
 # include <libraries/arpbase.h>
 #endif
-
-#endif // PROTO
 
 /*
  * This won't be needed if you have a version of Lattice 4.01 without broken

--- a/src/os_mac_conv.c
+++ b/src/os_mac_conv.c
@@ -24,13 +24,6 @@
 
 #if defined(MACOS_CONVERT) || defined(PROTO)
 
-# ifdef PROTO
-// A few dummy types to be able to generate function prototypes.
-typedef int UniChar;
-typedef int *TECObjectRef;
-typedef int CFStringRef;
-# endif
-
 static char_u	    *mac_utf16_to_utf8(UniChar *from, size_t fromLen, size_t *actualLen);
 static UniChar	    *mac_utf8_to_utf16(char_u *from, size_t fromLen, size_t *actualLen);
 

--- a/src/os_mac_conv.c
+++ b/src/os_mac_conv.c
@@ -17,12 +17,10 @@
 
 #include "vim.h"
 
-#if !defined(PROTO)
-# include <CoreServices/CoreServices.h>
-#endif
+#include <CoreServices/CoreServices.h>
 
 
-#if defined(MACOS_CONVERT) || defined(PROTO)
+#if defined(MACOS_CONVERT)
 
 static char_u	    *mac_utf16_to_utf8(UniChar *from, size_t fromLen, size_t *actualLen);
 static UniChar	    *mac_utf8_to_utf16(char_u *from, size_t fromLen, size_t *actualLen);

--- a/src/os_mswin.c
+++ b/src/os_mswin.c
@@ -35,57 +35,6 @@
 # endif
 #endif // PROTO
 
-/*
- * When generating prototypes for Win32 on Unix, these lines make the syntax
- * errors disappear.  They do not need to be correct.
- */
-#ifdef PROTO
-# define WINAPI
-# define WINBASEAPI
-typedef int BOOL;
-typedef int CALLBACK;
-typedef int COLORREF;
-typedef int CONSOLE_CURSOR_INFO;
-typedef int COORD;
-typedef int DWORD;
-typedef int ENUMLOGFONTW;
-typedef int HANDLE;
-typedef int HDC;
-typedef int HFONT;
-typedef int HICON;
-typedef int HWND;
-typedef int INPUT_RECORD;
-typedef int INT_PTR;
-typedef int KEY_EVENT_RECORD;
-typedef int LOGFONTW;
-typedef int LPARAM;
-typedef int LPBOOL;
-typedef int LPCSTR;
-typedef int LPCWSTR;
-typedef int LPDWORD;
-typedef int LPSTR;
-typedef int LPTSTR;
-typedef int LPVOID;
-typedef int LPWSTR;
-typedef int LRESULT;
-typedef int MOUSE_EVENT_RECORD;
-typedef int NEWTEXTMETRICW;
-typedef int PACL;
-typedef int PRINTDLGW;
-typedef int PSECURITY_DESCRIPTOR;
-typedef int PSID;
-typedef int SECURITY_INFORMATION;
-typedef int SHORT;
-typedef int SMALL_RECT;
-typedef int TEXTMETRIC;
-typedef int UINT;
-typedef int WCHAR;
-typedef int WNDENUMPROC;
-typedef int WORD;
-typedef int WPARAM;
-typedef void VOID;
-#endif
-
 // Record all output and all keyboard & mouse input
 // #define MCH_WRITE_DUMP
 

--- a/src/os_mswin.c
+++ b/src/os_mswin.c
@@ -19,21 +19,18 @@
 #include <signal.h>
 #include <limits.h>
 
-// cproto fails on missing include files
-#ifndef PROTO
-# include <process.h>
-# include <direct.h>
+#include <process.h>
+#include <direct.h>
 
-# if !defined(FEAT_GUI_MSWIN)
-#  include <shellapi.h>
-# endif
+#if !defined(FEAT_GUI_MSWIN)
+# include <shellapi.h>
+#endif
 
-# if defined(FEAT_PRINTER) && !defined(FEAT_POSTSCRIPT)
-#  include <dlgs.h>
-#  include <winspool.h>
-#  include <commdlg.h>
-# endif
-#endif // PROTO
+#if defined(FEAT_PRINTER) && !defined(FEAT_POSTSCRIPT)
+# include <dlgs.h>
+# include <winspool.h>
+# include <commdlg.h>
+#endif
 
 // Record all output and all keyboard & mouse input
 // #define MCH_WRITE_DUMP
@@ -66,7 +63,7 @@ SaveInst(HINSTANCE hInst)
     g_hinst = hInst;
 }
 
-#if defined(FEAT_GUI_MSWIN) || defined(PROTO)
+#if defined(FEAT_GUI_MSWIN)
 /*
  * GUI version of mch_exit().
  * Shut down and exit with status `r'
@@ -512,7 +509,7 @@ vim_stat(const char *name, stat_T *stp)
     return stat_impl(name, stp, TRUE);
 }
 
-#if (defined(FEAT_GUI_MSWIN) && !defined(VIMDLL)) || defined(PROTO)
+#if defined(FEAT_GUI_MSWIN) && !defined(VIMDLL)
     void
 mch_settmode(tmode_T tmode UNUSED)
 {
@@ -552,7 +549,7 @@ mch_suspend(void)
     suspend_shell();
 }
 
-#if defined(USE_MCH_ERRMSG) || defined(PROTO)
+#if defined(USE_MCH_ERRMSG)
 
 # ifdef display_errors
 #  undef display_errors
@@ -692,7 +689,7 @@ mch_char_avail(void)
     return TRUE;
 }
 
-# if defined(FEAT_TERMINAL) || defined(PROTO)
+# if defined(FEAT_TERMINAL)
 /*
  * Check for any pending input or messages.
  */
@@ -706,7 +703,7 @@ mch_check_messages(void)
 #endif
 
 
-#if defined(FEAT_LIBCALL) || defined(PROTO)
+#if defined(FEAT_LIBCALL)
 /*
  * Call a DLL routine which takes either a string or int param
  * and returns an allocated string.
@@ -969,7 +966,7 @@ Trace(
 
 #endif //_DEBUG
 
-#if !defined(FEAT_GUI) || defined(VIMDLL) || defined(PROTO)
+#if !defined(FEAT_GUI) || defined(VIMDLL)
 extern HWND g_hWnd;	// This is in os_win32.c.
 
 /*
@@ -1021,7 +1018,7 @@ mch_set_winpos(int x, int y)
 }
 #endif
 
-#if (defined(FEAT_PRINTER) && !defined(FEAT_POSTSCRIPT)) || defined(PROTO)
+#if defined(FEAT_PRINTER) && !defined(FEAT_POSTSCRIPT)
 
 //=================================================================
 // Win32 printer stuff
@@ -1698,10 +1695,8 @@ mch_print_set_fg(long_u fgcol)
 
 
 
-#if defined(FEAT_SHORTCUT) || defined(PROTO)
-# ifndef PROTO
-#  include <shlobj.h>
-# endif
+#if defined(FEAT_SHORTCUT)
+# include <shlobj.h>
 
 # define is_path_sep(c)	    ((c) == L'\\' || (c) == L'/')
 
@@ -1883,7 +1878,7 @@ mch_resolve_path(char_u *fname, int reparse_point)
 }
 #endif
 
-#if (defined(FEAT_EVAL) && (!defined(FEAT_GUI) || defined(VIMDLL))) || defined(PROTO)
+#if defined(FEAT_EVAL) && (!defined(FEAT_GUI) || defined(VIMDLL))
 /*
  * Bring ourselves to the foreground.  Does work if the OS doesn't allow it.
  */
@@ -1896,7 +1891,7 @@ win32_set_foreground(void)
 }
 #endif
 
-#if defined(FEAT_CLIENTSERVER) || defined(PROTO)
+#if defined(FEAT_CLIENTSERVER)
 /*
  * Client-server code for Vim
  *
@@ -2630,8 +2625,7 @@ serverProcessPendingMessages(void)
 
 #endif // FEAT_CLIENTSERVER
 
-#if defined(FEAT_GUI) || (defined(FEAT_PRINTER) && !defined(FEAT_POSTSCRIPT)) \
-	|| defined(PROTO)
+#if defined(FEAT_GUI) || (defined(FEAT_PRINTER) && !defined(FEAT_POSTSCRIPT))
 
 struct charset_pair
 {
@@ -3240,7 +3234,7 @@ theend:
 
 #endif // defined(FEAT_GUI) || defined(FEAT_PRINTER)
 
-#if defined(FEAT_JOB_CHANNEL) || defined(PROTO)
+#if defined(FEAT_JOB_CHANNEL)
 /*
  * Initialize the Winsock dll.
  */

--- a/src/os_qnx.c
+++ b/src/os_qnx.c
@@ -31,7 +31,7 @@ void qnx_init(void)
 #endif
 }
 
-#if (defined(FEAT_GUI_PHOTON) && defined(FEAT_CLIPBOARD)) || defined(PROTO)
+#if defined(FEAT_GUI_PHOTON) && defined(FEAT_CLIPBOARD)
 
 #define CLIP_TYPE_VIM "VIMTYPE"
 #define CLIP_TYPE_TEXT "TEXT"

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -147,7 +147,7 @@ Window	    x11_window = 0;
 Display	    *x11_display = NULL;
 #endif
 
-#if defined(FEAT_SOCKETSERVER) || defined(PROTO)
+#if defined(FEAT_SOCKETSERVER)
 # include <sys/socket.h>
 # include <sys/un.h>
 
@@ -614,7 +614,7 @@ mch_char_avail(void)
     return WaitForChar(0L, NULL, FALSE);
 }
 
-#if defined(FEAT_TERMINAL) || defined(PROTO)
+#if defined(FEAT_TERMINAL)
 /*
  * Check for any pending input or messages.
  */
@@ -625,7 +625,7 @@ mch_check_messages(void)
 }
 #endif
 
-#if defined(HAVE_TOTAL_MEM) || defined(PROTO)
+#if defined(HAVE_TOTAL_MEM)
 # ifdef HAVE_SYS_RESOURCE_H
 #  include <sys/resource.h>
 # endif
@@ -900,7 +900,7 @@ check_stack_growth(char *p)
 }
 #endif
 
-#if defined(HAVE_STACK_LIMIT) || defined(PROTO)
+#if defined(HAVE_STACK_LIMIT)
 static char *stack_limit = NULL;
 
 #if defined(_THREAD_SAFE) && defined(HAVE_PTHREAD_NP_H)
@@ -1132,10 +1132,9 @@ sig_alarm SIGDEFARG(sigarg)
 }
 #endif
 
-#if (defined(HAVE_SETJMP_H) \
+#if defined(HAVE_SETJMP_H) \
 	&& ((defined(FEAT_X11) && defined(FEAT_XCLIPBOARD)) \
-	    || defined(FEAT_LIBCALL))) \
-    || defined(PROTO)
+	    || defined(FEAT_LIBCALL))
 # define USING_SETJMP 1
 
 // argument to SETJMP()
@@ -1648,7 +1647,7 @@ set_signals(void)
 #endif
 }
 
-#if defined(SIGINT) || defined(PROTO)
+#if defined(SIGINT)
 /*
  * Catch CTRL-C (only works while in Cooked mode).
  */
@@ -1829,7 +1828,7 @@ xopen_message(long elapsed_msec)
 # endif
 #endif
 
-#if defined(FEAT_X11) || defined(PROTO)
+#if defined(FEAT_X11)
 /*
  * A few functions shared by X11 title and clipboard code.
  */
@@ -1900,7 +1899,7 @@ x_connect_to_server(void)
     return TRUE;
 }
 
-#if defined(FEAT_X11) && defined(FEAT_XCLIPBOARD) || defined(PROTO)
+#if defined(FEAT_X11) && defined(FEAT_XCLIPBOARD)
 # if defined(USING_SETJMP)
 /*
  * An X IO Error handler, used to catch error while opening the display.
@@ -2584,7 +2583,7 @@ vim_is_xterm(char_u *name)
 		|| STRCMP(name, "builtin_xterm") == 0);
 }
 
-#if defined(FEAT_MOUSE_XTERM) || defined(PROTO)
+#if defined(FEAT_MOUSE_XTERM)
 /*
  * Return TRUE if "name" appears to be that of a terminal
  * known to support the xterm-style mouse protocol.
@@ -2637,7 +2636,7 @@ vim_is_iris(char_u *name)
 	    || STRCMP(name, "builtin_iris-ansi") == 0);
 }
 
-#if defined(VMS) || defined(PROTO)
+#if defined(VMS)
 /*
  * Return TRUE if "name" is a vt300-like terminal name.
  */
@@ -2981,7 +2980,7 @@ mch_isFullName(char_u *fname)
 #endif
 }
 
-#if defined(USE_FNAME_CASE) || defined(PROTO)
+#if defined(USE_FNAME_CASE)
 /*
  * Set the case of the file name, if it already exists.  This will cause the
  * file name to remain exactly the same.
@@ -3089,7 +3088,7 @@ mch_setperm(char_u *name, long perm)
 		    (mode_t)perm) == 0 ? OK : FAIL);
 }
 
-#if defined(HAVE_FCHMOD) || defined(PROTO)
+#if defined(HAVE_FCHMOD)
 /*
  * Set file permission for open file "fd" to "perm".
  * Return FAIL for failure, OK otherwise.
@@ -3101,7 +3100,7 @@ mch_fsetperm(int fd, long perm)
 }
 #endif
 
-#if defined(HAVE_ACL) || defined(PROTO)
+#if defined(HAVE_ACL)
 # ifdef HAVE_SYS_ACL_H
 #  include <sys/acl.h>
 # endif
@@ -3116,7 +3115,7 @@ typedef struct vim_acl_solaris_T {
 } vim_acl_solaris_T;
 # endif
 
-#if defined(HAVE_SELINUX) || defined(PROTO)
+#if defined(HAVE_SELINUX)
 /*
  * Copy security info from "from_file" to "to_file".
  */
@@ -3252,7 +3251,7 @@ mch_copy_sec(char_u *from_file, char_u *to_file)
 }
 #endif // HAVE_SMACK
 
-#if defined(FEAT_XATTR) || defined(PROTO)
+#if defined(FEAT_XATTR)
 /*
  * Copy extended attributes from_file to to_file
  */
@@ -3687,7 +3686,7 @@ mch_early_init(void)
 #endif
 }
 
-#if defined(EXITFREE) || defined(PROTO)
+#if defined(EXITFREE)
     void
 mch_free_mem(void)
 {
@@ -4262,7 +4261,7 @@ mch_setmouse(int on)
 #endif
 }
 
-#if defined(FEAT_BEVAL_TERM) || defined(PROTO)
+#if defined(FEAT_BEVAL_TERM)
 /*
  * Called when 'balloonevalterm' changed.
  */
@@ -4561,7 +4560,7 @@ mch_calc_cell_size(struct cellsize *cs_out)
 #endif
 }
 
-#if defined(FEAT_TERMINAL) || defined(PROTO)
+#if defined(FEAT_TERMINAL)
 /*
  * Report the windows size "rows" and "cols" to tty "fd".
  */
@@ -4833,7 +4832,7 @@ may_send_sigint(int c UNUSED, pid_t pid UNUSED, pid_t wpid UNUSED)
 # endif
 }
 
-#if !defined(USE_SYSTEM) || defined(FEAT_TERMINAL) || defined(PROTO)
+#if !defined(USE_SYSTEM) || defined(FEAT_TERMINAL)
 
 /*
  * Parse "cmd" and return the result in "argvp" which is an allocated array of
@@ -5928,7 +5927,7 @@ mch_call_shell(
 #endif
 }
 
-#if defined(FEAT_JOB_CHANNEL) || defined(PROTO)
+#if defined(FEAT_JOB_CHANNEL)
     void
 mch_job_start(char **argv, job_T *job, jobopt_T *options, int is_terminal)
 {
@@ -6452,7 +6451,7 @@ mch_clear_job(job_T *job)
 }
 #endif
 
-#if defined(FEAT_TERMINAL) || defined(PROTO)
+#if defined(FEAT_TERMINAL)
     int
 mch_create_pty_channel(job_T *job, jobopt_T *options)
 {
@@ -7738,7 +7737,7 @@ have_dollars(int num, char_u **file)
     return FALSE;
 }
 
-#if !defined(HAVE_RENAME) || defined(PROTO)
+#if !defined(HAVE_RENAME)
 /*
  * Scaled-down version of rename(), which is missing in Xenix.
  * This version can only move regular files and will fail if the
@@ -7759,8 +7758,8 @@ mch_rename(const char *src, const char *dest)
 }
 #endif // !HAVE_RENAME
 
-#if defined(FEAT_MOUSE_GPM) || defined(PROTO)
-# if defined(DYNAMIC_GPM) || defined(PROTO)
+#if defined(FEAT_MOUSE_GPM)
+# if defined(DYNAMIC_GPM)
 /*
  * Initialize Gpm's symbols for dynamic linking.
  * Must be called only if libgpm_hinst is NULL.
@@ -8095,7 +8094,7 @@ mch_get_random(char_u *buf, int len)
     return dev_urandom_state;
 }
 
-#if defined(FEAT_LIBCALL) || defined(PROTO)
+#if defined(FEAT_LIBCALL)
 typedef char_u * (*STRPROCSTR)(char_u *);
 typedef char_u * (*INTPROCSTR)(int);
 typedef int (*STRPROCINT)(char_u *);
@@ -8265,7 +8264,7 @@ mch_libcall(
 }
 #endif
 
-#if (defined(FEAT_X11) && defined(FEAT_XCLIPBOARD)) || defined(PROTO)
+#if defined(FEAT_X11) && defined(FEAT_XCLIPBOARD)
 static int	xterm_trace = -1;	// default: disabled
 static int	xterm_button;
 
@@ -8489,7 +8488,7 @@ do_xterm_trace(void)
     return TRUE;
 }
 
-# if defined(FEAT_GUI) || defined(FEAT_XCLIPBOARD) || defined(PROTO)
+# if defined(FEAT_GUI) || defined(FEAT_XCLIPBOARD)
 /*
  * Destroy the display, window and app_context.  Required for GTK.
  */
@@ -8608,7 +8607,7 @@ clip_xterm_set_selection(Clipboard_T *cbd)
 #endif
 
 
-#if defined(USE_XSMP) || defined(PROTO)
+#if defined(USE_XSMP)
 /*
  * Code for X Session Management Protocol.
  */
@@ -8866,8 +8865,8 @@ xsmp_close(void)
 }
 #endif // USE_XSMP
 
-#if defined(FEAT_RELTIME) || defined(PROTO)
-# if defined(PROF_NSEC) || defined(PROTO)
+#if defined(FEAT_RELTIME)
+# if defined(PROF_NSEC)
 /*
  * Implement timeout with timer_create() and timer_settime().
  */
@@ -9136,7 +9135,7 @@ mch_create_anon_file(void)
     return fd;
 }
 
-#if defined(FEAT_SOCKETSERVER) || defined(PROTO)
+#if defined(FEAT_SOCKETSERVER)
 
 /*
  * Initialize socket server called "name" (the socket filename). If "name" is a

--- a/src/os_unix.h
+++ b/src/os_unix.h
@@ -159,8 +159,6 @@ typedef void (*sighandler_T) SIGPROTOARG;
 #endif
 
 
-#ifndef PROTO
-
 #ifdef VMS
 # include <unixio.h>
 # include <unixlib.h>
@@ -197,8 +195,6 @@ typedef void (*sighandler_T) SIGPROTOARG;
 #ifdef HAVE_FLOCK
 # include <sys/file.h>
 #endif
-
-#endif // PROTO
 
 #ifdef VMS
 typedef struct dsc$descriptor   DESC;

--- a/src/os_vms.c
+++ b/src/os_vms.c
@@ -12,8 +12,8 @@
 #include "vim.h"
 
 // define _generic_64 for use in time functions
-#if !defined(VAX) && !defined(PROTO)
-#   include <gen64def.h>
+#if !defined(VAX)
+# include <gen64def.h>
 #else
 // based on Alpha's gen64def.h; the file is absent on VAX
 typedef struct _generic_64 {

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -52,65 +52,6 @@
 FILE* fdDump = NULL;
 #endif
 
-/*
- * When generating prototypes for Win32 on Unix, these lines make the syntax
- * errors disappear.  They do not need to be correct.
- */
-#ifdef PROTO
-# define WINAPI
-typedef char * LPCSTR;
-typedef char * LPWSTR;
-typedef int ACCESS_MASK;
-typedef int BOOL;
-typedef int BOOLEAN;
-typedef int CALLBACK;
-typedef int COLORREF;
-typedef int CONSOLE_CURSOR_INFO;
-typedef int COORD;
-typedef int DWORD;
-typedef int HANDLE;
-typedef int LPHANDLE;
-typedef int HDC;
-typedef int HFONT;
-typedef int HICON;
-typedef int HINSTANCE;
-typedef int HWND;
-typedef int INPUT_RECORD;
-typedef int INT;
-typedef int KEY_EVENT_RECORD;
-typedef int LOGFONT;
-typedef int LPBOOL;
-typedef int LPCTSTR;
-typedef int LPDWORD;
-typedef int LPSTR;
-typedef int LPTSTR;
-typedef int LPVOID;
-typedef int MOUSE_EVENT_RECORD;
-typedef int PACL;
-typedef int PDWORD;
-typedef int PHANDLE;
-typedef int PRINTDLG;
-typedef int PSECURITY_DESCRIPTOR;
-typedef int PSID;
-typedef int SECURITY_INFORMATION;
-typedef int SHORT;
-typedef int SMALL_RECT;
-typedef int TEXTMETRIC;
-typedef int TOKEN_INFORMATION_CLASS;
-typedef int TRUSTEE;
-typedef int WORD;
-typedef int WCHAR;
-typedef void VOID;
-typedef int BY_HANDLE_FILE_INFORMATION;
-typedef int SE_OBJECT_TYPE;
-typedef int PSNSECINFO;
-typedef int PSNSECINFOW;
-typedef int STARTUPINFO;
-typedef int PROCESS_INFORMATION;
-typedef int LPSECURITY_ATTRIBUTES;
-# define __stdcall // empty
-#endif
-
 #if !defined(FEAT_GUI_MSWIN) || defined(VIMDLL)
 // Win32 Console handles for input and output
 static HANDLE g_hConIn  = INVALID_HANDLE_VALUE;

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -30,19 +30,16 @@
 #include <signal.h>
 #include <limits.h>
 
-// cproto fails on missing include files
-#ifndef PROTO
-# include <process.h>
-# include <winternl.h>
-# include <direct.h>
+#include <process.h>
+#include <winternl.h>
+#include <direct.h>
 
-# if !defined(FEAT_GUI_MSWIN)
-#  include <shellapi.h>
-# endif
+#if !defined(FEAT_GUI_MSWIN)
+# include <shellapi.h>
+#endif
 
-# ifdef FEAT_JOB_CHANNEL
-#  include <tlhelp32.h>
-# endif
+#ifdef FEAT_JOB_CHANNEL
+# include <tlhelp32.h>
 #endif
 
 // Record all output and all keyboard & mouse input
@@ -517,7 +514,7 @@ vimLoadLib(const char *name)
     return dll;
 }
 
-#if defined(VIMDLL) || defined(PROTO)
+#if defined(VIMDLL)
 /*
  * Check if the current executable file is for the GUI subsystem.
  */
@@ -540,7 +537,7 @@ mch_is_gui_executable(void)
 #endif
 
 #if defined(DYNAMIC_ICONV) || defined(DYNAMIC_GETTEXT) \
-    || defined(FEAT_PYTHON3) || defined(PROTO)
+    || defined(FEAT_PYTHON3)
 /*
  * Get related information about 'funcname' which is imported by 'hInst'.
  * If 'info' is 0, return the function address.
@@ -647,7 +644,7 @@ hook_dll_import_func(HINSTANCE hInst, const char *funcname, const void *hook)
 }
 #endif
 
-#if defined(FEAT_PYTHON3) || defined(PROTO)
+#if defined(FEAT_PYTHON3)
 /*
  * Check if the specified DLL is a function forwarder.
  * If yes, return the instance of the forwarded DLL.
@@ -706,7 +703,7 @@ get_forwarded_dll(HINSTANCE hInst)
 }
 #endif
 
-#if defined(DYNAMIC_GETTEXT) || defined(PROTO)
+#if defined(DYNAMIC_GETTEXT)
 # ifndef GETTEXT_DLL
 #  define GETTEXT_DLL "libintl.dll"
 #  define GETTEXT_DLL_ALT1 "libintl-8.dll"
@@ -873,9 +870,7 @@ null_libintl_wputenv(const wchar_t *envstring UNUSED)
 #endif
 
 #ifdef HAVE_ACL
-# ifndef PROTO
-#  include <aclapi.h>
-# endif
+# include <aclapi.h>
 # ifndef PROTECTED_DACL_SECURITY_INFORMATION
 #  define PROTECTED_DACL_SECURITY_INFORMATION	0x80000000L
 # endif
@@ -1441,7 +1436,7 @@ mch_setmouse(int on)
 }
 
 
-# if defined(FEAT_BEVAL_TERM) || defined(PROTO)
+# if defined(FEAT_BEVAL_TERM)
 /*
  * Called when 'balloonevalterm' changed.
  */
@@ -2065,7 +2060,7 @@ test_mswin_event(char_u *event, dict_T *args)
 }
 #endif // FEAT_EVAL
 
-#if defined(MCH_CURSOR_SHAPE) || defined(PROTO)
+#if defined(MCH_CURSOR_SHAPE)
 /*
  * Set the shape of the cursor.
  * 'thickness' can be from 1 (thin) to 99 (block)
@@ -2332,7 +2327,7 @@ mch_char_avail(void)
     return WaitForChar(0L, FALSE);
 }
 
-# if defined(FEAT_TERMINAL) || defined(PROTO)
+# if defined(FEAT_TERMINAL)
 /*
  * Check for any pending input or messages.
  */
@@ -4811,7 +4806,7 @@ vim_shell_execute(
 }
 
 
-#if defined(FEAT_GUI_MSWIN) || defined(PROTO)
+#if defined(FEAT_GUI_MSWIN)
 
 /*
  * Specialised version of system() for Win32 GUI mode.
@@ -5812,7 +5807,7 @@ mch_call_shell(
     return x;
 }
 
-#if defined(FEAT_JOB_CHANNEL) || defined(PROTO)
+#if defined(FEAT_JOB_CHANNEL)
     static HANDLE
 job_io_file_open(
 	char_u *fname,
@@ -8601,7 +8596,7 @@ vtp_flag_init(void)
 	conpty_fix_type = 1;
 }
 
-#if !defined(FEAT_GUI_MSWIN) || defined(VIMDLL) || defined(PROTO)
+#if !defined(FEAT_GUI_MSWIN) || defined(VIMDLL)
 
     static void
 vtp_init(void)
@@ -8868,7 +8863,7 @@ set_console_color_rgb(void)
 # endif
 }
 
-# if defined(FEAT_TERMGUICOLORS) || defined(PROTO)
+# if defined(FEAT_TERMGUICOLORS)
     void
 get_default_console_color(
     int *cterm_fg,
@@ -9019,7 +9014,7 @@ get_conpty_fix_type(void)
     return conpty_fix_type;
 }
 
-#if !defined(FEAT_GUI_MSWIN) || defined(VIMDLL) || defined(PROTO)
+#if !defined(FEAT_GUI_MSWIN) || defined(VIMDLL)
     void
 resize_console_buf(void)
 {
@@ -9068,7 +9063,7 @@ GetWin32Error(void)
     return msg;
 }
 
-#if defined(FEAT_RELTIME) || defined(PROTO)
+#if defined(FEAT_RELTIME)
 static HANDLE   timer_handle;
 static int      timer_active = FALSE;
 

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -1458,12 +1458,7 @@ encode_key_event(dict_T *args, INPUT_RECORD *ir)
 /*
  * For the GUI the mouse handling is in gui_w32.c.
  */
-#if defined(FEAT_GUI_MSWIN) && !defined(VIMDLL)
-    void
-mch_setmouse(int on UNUSED)
-{
-}
-#else  // !FEAT_GUI_MSWIN || VIMDLL
+#if !defined(FEAT_GUI_MSWIN) || defined(VIMDLL)
 static int g_fMouseAvail = FALSE;   // mouse present
 static int g_fMouseActive = FALSE;  // mouse enabled
 static int g_nMouseClick = -1;	    // mouse status
@@ -2035,7 +2030,12 @@ read_input_record_buffer(INPUT_RECORD* irEvents, int nMaxLength)
     }
     return nCount;
 }
-#endif // !FEAT_GUI_MSWIN || VIMDLL
+#else  // FEAT_GUI_MSWIN && !VIMDLL
+    void
+mch_setmouse(int on UNUSED)
+{
+}
+#endif // FEAT_GUI_MSWIN && !VIMDLL
 
 #ifdef FEAT_EVAL
 /*
@@ -2769,9 +2769,9 @@ theend:
 # endif
     return len;
 
-#else // FEAT_GUI_MSWIN
+#else // FEAT_GUI_MSWIN && !VIMDLL
     return 0;
-#endif // FEAT_GUI_MSWIN
+#endif // FEAT_GUI_MSWIN && !VIMDLL
 }
 
 /*
@@ -3721,7 +3721,7 @@ mch_exit_c(int r)
 
     exit(r);
 }
-#endif // !FEAT_GUI_MSWIN
+#endif // !FEAT_GUI_MSWIN || VIMDLL
 
     void
 mch_init(void)
@@ -4809,7 +4809,7 @@ mch_set_winsize_now(void)
     }
     suppress_winsize = 0;
 }
-#endif // FEAT_GUI_MSWIN
+#endif
 
     static BOOL
 vim_create_process(
@@ -6499,19 +6499,10 @@ termcap_mode_end(void)
     SetConsoleCursorInfo(g_hConOut, &g_cci);
     g_fTermcapMode = FALSE;
 }
-#endif // !FEAT_GUI_MSWIN || VIMDLL
+#endif
 
 
-#if defined(FEAT_GUI_MSWIN) && !defined(VIMDLL)
-    void
-mch_write(
-    char_u  *s UNUSED,
-    int	    len UNUSED)
-{
-    // never used
-}
-
-#else
+#if !defined(FEAT_GUI_MSWIN) || defined(VIMDLL)
 
 /*
  * clear `n' chars, starting from `coord'
@@ -7580,7 +7571,16 @@ notsgr:
 # endif
 }
 
-#endif // FEAT_GUI_MSWIN
+#else // FEAT_GUI_MSWIN && !VIMDLL
+    void
+mch_write(
+    char_u  *s UNUSED,
+    int	    len UNUSED)
+{
+    // never used
+}
+
+#endif
 
 
 /*

--- a/src/os_win32.h
+++ b/src/os_win32.h
@@ -11,10 +11,7 @@
  */
 
 #include "os_dos.h"		// common MS-DOS and Win32 stuff
-// cproto fails on missing include files
-#ifndef PROTO
-# include <direct.h>		// for _mkdir()
-#endif
+#include <direct.h>		// for _mkdir()
 
 #define BINARY_FILE_IO
 #define USE_EXE_NAME		// use argv[0] for $VIM
@@ -84,19 +81,18 @@
 #ifndef COBJMACROS
 # define COBJMACROS	// For OLE: Enable "friendlier" access to objects
 #endif
-#ifndef PROTO
+
 // Must include winsock2.h before windows.h since it conflicts with winsock.h
 // (included in windows.h).
-# include <winsock2.h>
-# include <ws2tcpip.h>
-# include <windows.h>
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#include <windows.h>
 
 // Weird: rpcndr.h defines "small" to "char", which causes trouble
 #undef small
 
-# ifndef SM_CXPADDEDBORDER
-#  define SM_CXPADDEDBORDER     92
-# endif
+#ifndef SM_CXPADDEDBORDER
+# define SM_CXPADDEDBORDER     92
 #endif
 
 typedef void (*sighandler_T)(int, int);

--- a/src/popupmenu.c
+++ b/src/popupmenu.c
@@ -1044,7 +1044,7 @@ pum_redraw(void)
 #endif
 }
 
-#if (defined(FEAT_PROP_POPUP) && defined(FEAT_QUICKFIX)) || defined(PROTO)
+#if defined(FEAT_PROP_POPUP) && defined(FEAT_QUICKFIX)
 /*
  * Position the info popup relative to the popup menu item.
  */
@@ -1527,7 +1527,7 @@ pum_get_height(void)
     return pum_height;
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Add size information about the pum to "dict".
  */
@@ -1546,7 +1546,7 @@ pum_set_event_info(dict_T *dict)
 }
 #endif
 
-#if defined(FEAT_BEVAL_TERM) || defined(FEAT_TERM_POPUP_MENU) || defined(PROTO)
+#if defined(FEAT_BEVAL_TERM) || defined(FEAT_TERM_POPUP_MENU)
     static void
 pum_position_at_mouse(int min_width)
 {
@@ -1616,7 +1616,7 @@ pum_position_at_mouse(int min_width)
 
 #endif
 
-#if defined(FEAT_BEVAL_TERM) || defined(PROTO)
+#if defined(FEAT_BEVAL_TERM)
 static pumitem_T *balloon_array = NULL;
 static int balloon_arraysize;
 
@@ -1852,7 +1852,7 @@ ui_may_remove_balloon(void)
 }
 #endif
 
-#if defined(FEAT_TERM_POPUP_MENU) || defined(PROTO)
+#if defined(FEAT_TERM_POPUP_MENU)
 /*
  * Select the pum entry at the mouse position.
  */

--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -13,7 +13,7 @@
 
 #include "vim.h"
 
-#if defined(FEAT_PROP_POPUP) || defined(PROTO)
+#if defined(FEAT_PROP_POPUP)
 
 typedef struct {
     char	*pp_name;
@@ -3422,7 +3422,7 @@ f_popup_getoptions(typval_T *argvars, typval_T *rettv)
 # endif
 }
 
-# if defined(FEAT_TERMINAL) || defined(PROTO)
+# if defined(FEAT_TERMINAL)
 /*
  * Return TRUE if the current window is running a terminal in a popup window.
  * Return FALSE when the job has ended.
@@ -4479,7 +4479,7 @@ popup_is_popup(win_T *wp)
     return wp->w_popup_flags != 0;
 }
 
-#if defined(FEAT_QUICKFIX) || defined(PROTO)
+#if defined(FEAT_QUICKFIX)
 /*
  * Find an existing popup used as the preview window, in the current tab page.
  * Return NULL if not found.
@@ -4547,7 +4547,7 @@ f_popup_findpreview(typval_T *argvars UNUSED, typval_T *rettv)
 #endif
 }
 
-#if defined(FEAT_QUICKFIX) || defined(PROTO)
+#if defined(FEAT_QUICKFIX)
 /*
  * Create a popup to be used as the preview or info window.
  * NOTE: this makes the popup the current window, so that the file can be
@@ -4630,7 +4630,7 @@ popup_overlaps_cmdline(void)
     return popup_on_cmdline;
 }
 
-#if defined(HAS_MESSAGE_WINDOW) || defined(PROTO)
+#if defined(HAS_MESSAGE_WINDOW)
 
 /*
  * Get the message window.
@@ -4813,7 +4813,7 @@ popup_set_title(win_T *wp)
     redraw_win_later(wp, UPD_VALID);
 }
 
-# if defined(FEAT_QUICKFIX) || defined(PROTO)
+# if defined(FEAT_QUICKFIX)
 /*
  * If there is a preview window, update the title.
  * Used after changing directory.

--- a/src/profiler.c
+++ b/src/profiler.c
@@ -13,8 +13,8 @@
 
 #include "vim.h"
 
-#if defined(FEAT_EVAL) || defined(PROTO)
-# if defined(FEAT_PROFILE) || defined(FEAT_RELTIME) || defined(PROTO)
+#if defined(FEAT_EVAL)
+# if defined(FEAT_PROFILE) || defined(FEAT_RELTIME)
 /*
  * Store the current time in "tm".
  */
@@ -172,7 +172,7 @@ profile_zero(proftime_T *tm)
 
 # endif  // FEAT_PROFILE || FEAT_RELTIME
 
-#if defined(FEAT_SYN_HL) && defined(FEAT_RELTIME) && defined(FEAT_PROFILE) || defined(PROTO)
+#if defined(FEAT_SYN_HL) && defined(FEAT_RELTIME) && defined(FEAT_PROFILE)
 # if defined(HAVE_MATH_H)
 #  include <math.h>
 # endif
@@ -200,7 +200,7 @@ profile_divide(proftime_T *tm, int count, proftime_T *tm2)
 }
 #endif
 
-# if defined(FEAT_PROFILE) || defined(PROTO)
+# if defined(FEAT_PROFILE)
 /*
  * Functions for profiling.
  */

--- a/src/proto/gen_prototypes.py
+++ b/src/proto/gen_prototypes.py
@@ -1,0 +1,462 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import os
+import re
+import sys
+from pathlib import Path
+from typing import List, Tuple
+from clang.cindex import Index, CursorKind, StorageClass, TokenKind
+
+SHOW_DIAGS = os.environ.get("GENPROTO_SHOW_DIAGS", "") not in ("", "0", "false", "no")
+DEBUG_LOG  = os.environ.get("GENPROTO_DEBUG", "") not in ("", "0", "false", "no")
+
+# Preprocessor directive detection
+_DIR_RE = re.compile(r'^\s*#\s*(if|ifdef|ifndef|elif|else|endif)\b')
+_IF0_RE = re.compile(r'^\s*#\s*if\s+0\s*(//.*)?$')
+_IFDEF_DEBUG_RE = re.compile(r'^\s*#\s*ifdef\s+_DEBUG\s*(//.*)?$')
+
+# Keep legacy behavior: drop whole group for #ifndef PROTO and #if !defined(PROTO)
+_IFNDEF_PROTO_RE   = re.compile(r'^\s*#\s*ifndef\s+PROTO\s*(//.*)?$')
+_IF_NOTDEF_PROTO_RE = re.compile(r'^\s*#\s*if\s*!defined\s*\(\s*PROTO\s*\)\s*(//.*)?$')
+
+# Helpers to detect defined(PROTO) inside an expression line
+_DEFINED_CALL_RE      = re.compile(r'\bdefined\s*\(\s*PROTO\s*\)')
+
+def _ends_with_bs(line: str) -> bool:
+    return line.rstrip("\r\n").rstrip().endswith("\\")
+
+def _has_proto_defined_from_argv(argv: List[str]) -> bool:
+    """Return True if -DPROTO (or -DPROTO=...) appears in clang args."""
+    for a in argv:
+        if a == "-DPROTO" or a.startswith("-DPROTO="):
+            return True
+    return False
+
+def _eval_condition_with_defined_proto(cond: str, proto_is_defined: bool) -> bool:
+    """
+    Evaluate a simple C preprocessor condition only when it contains defined(PROTO).
+    - Replace defined(PROTO)/!defined(PROTO) based on proto_is_defined
+    - Map C logical operators (&&, ||, !) to Python (and, or, not)
+    - Treat unknown identifiers as 0 (false)
+    - Prevent tokens like 'True(' / 'False(' / '0(' turning into call syntax
+    On any parsing error, return True (fail-open -> keep the branch).
+    """
+    s = cond
+
+    if DEBUG_LOG:
+        print(f"[eval] raw condition: {cond.strip()}", file=sys.stderr)
+        print(f"[eval] proto_is_defined={proto_is_defined}", file=sys.stderr)
+
+    # Normalize spacing
+    s = s.strip()
+
+    # Replace !defined(PROTO) first, then defined(PROTO)
+    if proto_is_defined:
+        s = re.sub(r'!+\s*defined\s*\(\s*PROTO\s*\)', "False", s)
+        s = re.sub(r'defined\s*\(\s*PROTO\s*\)', "True", s)
+    else:
+        s = re.sub(r'!+\s*defined\s*\(\s*PROTO\s*\)', "True", s)
+        s = re.sub(r'defined\s*\(\s*PROTO\s*\)', "False", s)
+
+    # Translate C logical ops to Python
+    # Replace defined(PROTO) and !defined(PROTO) depending on -DPROTO
+    if proto_is_defined:
+        s = re.sub(r'!defined\s*\(\s*PROTO\s*\)', "False", s)
+        s = re.sub(r'defined\s*\(\s*PROTO\s*\)', "True", s)
+    else:
+        s = re.sub(r'!defined\s*\(\s*PROTO\s*\)', "True", s)
+        s = re.sub(r'defined\s*\(\s*PROTO\s*\)', "False", s)
+
+    # Any other defined(MACRO) should be considered unknown
+    s = re.sub(r'!defined\s*\(\s*[A-Za-z_]\w*\s*\)', "True", s)
+    s = re.sub(r'defined\s*\(\s*[A-Za-z_]\w*\s*\)', "False", s)
+
+    # Translate C logical operators to Python
+    s = s.replace("&&", " and ")
+    s = s.replace("||", " or ")
+    # Replace '!' with ' not ' but do not touch '!='
+    s = re.sub(r'(?<![=!])!', " not ", s)
+
+    # Replace remaining identifiers (macros) with 0 (false)
+    # Keep True/False and numbers as-is; also keep Python logical keywords
+    s = re.sub(r'\b(?!True\b|False\b|and\b|or\b|not\b)[A-Za-z_]\w*', "0", s)
+
+    # Prevent literals followed by '(' from looking like a call: True(  False(  0(
+    s = re.sub(r'\b(True|False|0)\s*\(', r'(\1) and (', s)
+
+    # Safety: collapse excessive whitespace
+    s = re.sub(r'\s+', " ", s).strip()
+
+    try:
+        return bool(eval(s, {}, {}))
+    except Exception:
+        # Fail-open to avoid accidentally dropping code
+        if DEBUG_LOG:
+            print(f"[warn] condition eval failed: {cond!r} -> {s!r}", file=sys.stderr)
+        return True
+
+def rewrite_conditionals_first_branch(text: str) -> str:
+    """
+    Keep only the first branch of #if/#ifdef/#ifndef groups, remove others.
+    Extensions:
+      - Drop whole group for #if 0.
+      - Drop whole group for #ifndef PROTO and #if !defined(PROTO).
+      - If an '#if <expr>' contains defined(PROTO) anywhere in the expression,
+        evaluate the condition: if False, drop the whole group; if True, keep only
+        the first branch (same as legacy behavior).
+    """
+    lines = text.splitlines(keepends=True)
+    out: List[str] = []
+    i, n = 0, len(lines)
+
+    def _collect_group(start: int) -> Tuple[int, List[Tuple[str, int, int]]]:
+        """Collect a full #if...#endif group and return (end_index, bodies).
+        bodies is a list of (tag, body_s, body_e) for each if/elif/else branch.
+        """
+        h = start
+        # Skip backslash-continued header lines
+        while True:
+            h += 1
+            if h >= n or not _ends_with_bs(lines[h - 1]):
+                break
+        depth = 1
+        j = h
+        marks: List[Tuple[str, int]] = [("if", start)]
+        while j < n and depth > 0:
+            m = _DIR_RE.match(lines[j])
+            if m:
+                kw2 = m.group(1)
+                if kw2 in ("if", "ifdef", "ifndef"):
+                    depth += 1
+                elif kw2 == "endif":
+                    depth -= 1
+                    if depth == 0:
+                        break
+                elif depth == 1 and kw2 in ("elif", "else"):
+                    marks.append((kw2, j))
+            j += 1
+        else:
+            # Unterminated: keep as-is from start to EOF
+            return n, [("text", start, n)]
+
+        def _after_header_line(pos: int) -> int:
+            """
+            Return the first index after a possibly backslash-continued header line
+            starting at `pos`. It consumes all continuation lines that belong to
+            the directive header.
+            """
+            k = pos + 1
+            # Consume lines as long as the previous line ends with a backslash
+            while k < n and _ends_with_bs(lines[k - 1]):
+                k += 1
+            return k
+
+        def _after_header_line(pos: int) -> int:
+            """
+            Return the first index after a possibly backslash-continued header line
+            starting at `pos`. It consumes all continuation lines that belong to
+            the directive header.
+            """
+            k = pos + 1
+            # Consume lines as long as the previous line ends with a backslash
+            while k < n and _ends_with_bs(lines[k - 1]):
+                k += 1
+            return k
+
+        bodies: List[Tuple[str, int, int]] = []
+        header_positions = [pos for _, pos in marks] + [j]
+        tags = [tag for tag, _ in marks]
+        for idx, tag in enumerate(tags):
+            header = header_positions[idx]
+            # Start body right after the whole (possibly multi-line) header
+            body_s = _after_header_line(header)
+            next_header = header_positions[idx + 1]
+            body_e = next_header
+            bodies.append((tag, body_s, body_e))
+        return j + 1, bodies
+
+    # Detect whether PROTO is defined from argv (clang args passed after src path)
+    proto_is_defined = _has_proto_defined_from_argv(sys.argv[2:])
+
+    while i < n:
+        line = lines[i]
+        m = _DIR_RE.match(line)
+        if not m:
+            out.append(line)
+            i += 1
+            continue
+
+        kw = m.group(1)
+        if kw in ("if", "ifdef", "ifndef"):
+            # Hard drops first (legacy behavior)
+            if _IF0_RE.match(line) or _IFDEF_DEBUG_RE.match(line) or _IFNDEF_PROTO_RE.match(line) or _IF_NOTDEF_PROTO_RE.match(line):
+                group_end, _ = _collect_group(i)
+                i = group_end
+                continue
+
+            # If '#if <expr>' contains defined(PROTO), evaluate; otherwise, legacy behavior
+            evaluate = (kw == "if") and (
+                _DEFINED_CALL_RE.search(line) is not None
+            )
+
+            if evaluate:
+                # Extract condition text after 'if'
+                try:
+                    cond_text = line.split("if", 1)[1]
+                except Exception:
+                    cond_text = ""
+                keep_first = _eval_condition_with_defined_proto(cond_text, proto_is_defined)
+                if not keep_first:
+                    group_end, _ = _collect_group(i)
+                    i = group_end
+                    continue
+
+            # Keep only the first branch
+            group_end, bodies = _collect_group(i)
+            if not bodies:
+                i = group_end
+                continue
+            keep_s, keep_e = bodies[0][1], bodies[0][2]
+            kept_text = "".join(lines[keep_s:keep_e])
+            kept_rewritten = rewrite_conditionals_first_branch(kept_text)
+
+            if DEBUG_LOG:
+                print(f"[group] first body lines {keep_s}:{keep_e}", file=sys.stderr)
+                # Print the first non-empty line of the kept body for quick context
+                for ln in kept_text.splitlines():
+                    if ln.strip():
+                        print(f"[group] kept starts with: {ln.strip()}", file=sys.stderr)
+                        break
+
+            out.append(kept_rewritten)
+            i = group_end
+        else:
+            # For 'elif/else/endif' lines encountered directly, output a blank line to preserve line count
+            out.append("\n" if line.endswith("\n") else "")
+            i += 1
+
+    return "".join(out)
+
+def collapse_star_spaces(s: str) -> str:
+    return re.sub(r"\*\s+", "*", s)
+
+def fix_spacing(s: str) -> str:
+    s = re.sub(r"\(\s+", "(", s)
+    s = re.sub(r"\s+\)", ")", s)
+    s = re.sub(r"(?<=[\w\)])\s+\((?!\*)", "(", s)
+    s = re.sub(r"\s+,", ",", s)
+    s = re.sub(r",(?=[^\s),])", ", ", s)
+    s = re.sub(r"\s+\[", "[", s)
+    s = re.sub(r"\[\s+", "[", s)
+    s = re.sub(r"\s+\]", "]", s)
+    return s
+
+def strip_unused_macros(s: str) -> str:
+    s = re.sub(r"\bUNUSED\b\s*\([^)]*\)", " ", s)
+    s = re.sub(r"\bUNUSED\b", " ", s)
+    return s
+
+def normalize_ws(s: str) -> str:
+    return re.sub(r"\s+", " ", s).strip()
+
+def tokens_for_function_header(cur) -> List[str]:
+    toks = [t for t in cur.get_tokens() if t.kind != TokenKind.COMMENT]
+    if not toks:
+        return []
+    name_idx = None
+    for i, t in enumerate(toks):
+        if t.kind == TokenKind.IDENTIFIER and t.spelling == cur.spelling:
+            name_idx = i
+            break
+    if name_idx is None:
+        return []
+    lpar_idx = None
+    for i in range(name_idx + 1, len(toks)):
+        if toks[i].spelling == '(':
+            lpar_idx = i
+            break
+    if lpar_idx is None:
+        return []
+    depth, rpar_idx = 0, None
+    for i in range(lpar_idx, len(toks)):
+        if toks[i].spelling == '(':
+            depth += 1
+        elif toks[i].spelling == ')':
+            depth -= 1
+            if depth == 0:
+                rpar_idx = i
+                break
+    if rpar_idx is None:
+        return []
+    return [t.spelling for t in toks[:rpar_idx + 1]]
+
+def join_tokens(tokens: List[str]) -> str:
+    s = " ".join(tokens)
+    s = strip_unused_macros(s)
+    s = normalize_ws(s)
+    s = collapse_star_spaces(s)
+    s = fix_spacing(s)
+    return s
+
+def header_from_cursor(cur) -> str:
+    """
+    Fallback header builder for cases where get_tokens() returns empty
+    (e.g., macro-expanded function definitions). Uses cursor spelling and
+    type information to construct "ret name(param, ...)".
+    """
+    try:
+        ret = getattr(cur, "result_type", None)
+        ret_sp = ret.spelling if ret is not None else ""
+    except Exception:
+        ret_sp = ""
+    if not ret_sp:
+        # As a last resort, try cur.type.get_result() if available.
+        try:
+            ret_sp = cur.type.get_result().spelling
+        except Exception:
+            ret_sp = "void"
+    name_sp = cur.spelling or ""
+    params = []
+    try:
+        for a in cur.get_arguments() or []:
+            t = getattr(a, "type", None)
+            t_sp = t.spelling if t is not None else ""
+            a_sp = a.spelling or ""
+            seg = (t_sp + (" " + a_sp if a_sp else "")).strip()
+            params.append(seg if seg else "void")
+    except Exception:
+        pass
+    params_s = ", ".join(params) if params else "void"
+    s = f"{ret_sp} {name_sp}({params_s})"
+    s = strip_unused_macros(s)
+    s = normalize_ws(s)
+    s = collapse_star_spaces(s)
+    s = fix_spacing(s)
+    return s
+
+def in_this_file(cur, src_path: Path) -> bool:
+    try:
+        loc = cur.extent.start
+        f = (loc.file or cur.location.file)
+        if not f:
+            # Macro-expanded function definitions may lack an attached file.
+            # Allow them only if we can actually extract a concrete function header.
+            try:
+                toks = tokens_for_function_header(cur)
+                return bool(toks)
+            except Exception:
+                return False
+        cur_path = os.path.normcase(os.path.abspath(str(f.name)))
+        src_abs  = os.path.normcase(os.path.abspath(src_path.as_posix()))
+        # Accept the main source file
+        if cur_path == src_abs or os.path.basename(cur_path) == os.path.basename(src_abs):
+            return True
+        # Additionally accept quoted .c includes located in the same directory
+        # (e.g., #include "regexp_nfa.c" next to the main source).
+        src_dir = os.path.normcase(os.path.abspath(src_path.parent.as_posix()))
+        if cur_path.endswith(".c") and os.path.dirname(cur_path) == src_dir:
+            return True
+        return False
+    except Exception:
+        return False
+
+def collect_function_defs(tu, src_path: Path):
+    def walk(node, depth=0):
+        if DEBUG_LOG:
+            print(f"{'  '*depth}{node.kind} {node.spelling}", file=sys.stderr)
+        if node.kind == CursorKind.FUNCTION_DECL:
+            if in_this_file(node, src_path):
+                if node.storage_class != StorageClass.STATIC and node.is_definition():
+                    yield node
+        for ch in node.get_children():
+            yield from walk(ch, depth+1)
+    yield from walk(tu.cursor)
+
+def parse_with_clang(src_path: Path, text: str, args: List[str]):
+    index = Index.create()
+    src_abs = os.path.abspath(src_path.as_posix())
+    unsaved = [(src_abs, text)]
+    proto_h = src_path.parent / "proto.h"
+    if proto_h.exists():
+        unsaved.append((str(proto_h), "/* stubbed */\n"))
+    final_args = (args or []) + [
+        "-std=c99", "-ferror-limit=0", "-w",
+        "-Wno-implicit-function-declaration"
+    ]
+    tu = index.parse(src_abs, args=final_args, unsaved_files=unsaved, options=0)
+    if SHOW_DIAGS:
+        for d in getattr(tu, "diagnostics", []):
+            print(d, file=sys.stderr)
+    return tu
+
+def generate_prototypes(tu, src_path: Path) -> List[str]:
+    """Collect unique function prototypes from a translation unit."""
+    protos: List[str] = []
+    for fn in collect_function_defs(tu, src_path):
+        if DEBUG_LOG:
+            try:
+                sr = fn.extent.start
+                er = fn.extent.end
+                print(f"[def] {fn.spelling}  {sr.line}:{sr.column} - {er.line}:{er.column}", file=sys.stderr)
+            except Exception:
+                print(f"[def] {fn.spelling}", file=sys.stderr)
+        toks = tokens_for_function_header(fn)
+        header = join_tokens(toks) if toks else header_from_cursor(fn)
+        if header:
+            protos.append(f"{header};")
+
+    seen, unique = set(), []
+    for p in protos:
+        if p not in seen:
+            unique.append(p)
+            seen.add(p)
+    return unique
+
+def write_prototypes(out_path: Path, headers: List[str], src_name: str) -> None:
+    """Write collected prototypes to the output .pro file."""
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with out_path.open("w", encoding="utf-8", newline="\n") as f:
+            f.write(f"/* {src_name} */\n")
+            for h in headers:
+                f.write(h + "\n")
+            f.write("/* vim: set ft=c : */\n")
+    except Exception as e:
+        print(f"write failed: {e}", file=sys.stderr)
+        sys.exit(4)
+    print(f"Generated {out_path.as_posix()} with {len(headers)} prototypes.")
+
+def main():
+    args = sys.argv[1:]
+    if not args:
+        print("Usage: gen_prototypes.py source.c [clang-args...]", file=sys.stderr)
+        sys.exit(1)
+
+    src_path = Path(args[0])
+    clang_args = args[1:]
+    if not src_path.exists():
+        print(f"not found: {src_path}", file=sys.stderr)
+        sys.exit(2)
+
+    # Load and preprocess source
+    try:
+        original = src_path.read_text(encoding="utf-8", errors="ignore")
+    except Exception as e:
+        print(f"read error: {e}", file=sys.stderr)
+        sys.exit(2)
+    rewritten = rewrite_conditionals_first_branch(original)
+
+    # Parse with libclang
+    try:
+        tu = parse_with_clang(src_path, rewritten, clang_args)
+    except Exception as e:
+        print(f"parse failed: {e}", file=sys.stderr)
+        sys.exit(3)
+
+    headers = generate_prototypes(tu, src_path)
+    out_file = Path("proto") / (src_path.stem + ".pro")
+    write_prototypes(out_file, headers, src_path.name)
+
+if __name__ == "__main__":
+    main()

--- a/src/proto/if_mzsch.pro
+++ b/src/proto/if_mzsch.pro
@@ -1,4 +1,5 @@
 /* if_mzsch.c */
+Thread_Local_Variables *scheme_external_get_thread_local_variables(void);
 int mzscheme_enabled(int verbose);
 void mzvim_check_threads(void);
 char *did_set_mzquantum(optset_T *args);

--- a/src/proto/insexpand.pro
+++ b/src/proto/insexpand.pro
@@ -26,6 +26,7 @@ int has_compl_option(int dict_opt);
 int vim_is_ctrl_x_key(int c);
 int ins_compl_accept_char(int c);
 int ins_compl_add_infercase(char_u *str_arg, int len, int icase, char_u *fname, int dir, int cont_s_ipos, int score);
+int ins_compl_is_match_selected(void);
 int ins_compl_preinsert_longest(void);
 char_u *ins_compl_leader(void);
 int ins_compl_col_range_attr(linenr_T lnum, int col);
@@ -77,5 +78,4 @@ int ins_complete(int c, int enable_pum);
 void ins_compl_enable_autocomplete(void);
 void free_insexpand_stuff(void);
 void f_preinserted(typval_T *argvars, typval_T *rettv);
-int ins_compl_is_match_selected(void);
 /* vim: set ft=c : */

--- a/src/proto/optionstr.pro
+++ b/src/proto/optionstr.pro
@@ -136,6 +136,8 @@ int expand_set_printoptions(optexpand_T *args, int *numMatches, char_u ***matche
 char *did_set_renderoptions(optset_T *args);
 char *did_set_rightleftcmd(optset_T *args);
 int expand_set_rightleftcmd(optexpand_T *args, int *numMatches, char_u ***matches);
+char *did_set_pumborder(optset_T *args);
+int expand_set_pumborder(optexpand_T *args, int *numMatches, char_u ***matches);
 char *did_set_rulerformat(optset_T *args);
 char *did_set_tabpanelopt(optset_T *args);
 int expand_set_tabpanelopt(optexpand_T *args, int *numMatches, char_u ***matches);
@@ -209,6 +211,4 @@ int check_ff_value(char_u *p);
 void save_clear_shm_value(void);
 void restore_shm_value(void);
 void export_myvimdir(void);
-char *did_set_pumborder(optset_T *args);
-int expand_set_pumborder(optexpand_T *args, int *numMatches, char_u ***matches);
 /* vim: set ft=c : */

--- a/src/proto/os_amiga.pro
+++ b/src/proto/os_amiga.pro
@@ -37,7 +37,6 @@ void mch_set_shellsize(void);
 void mch_new_shellsize(void);
 int mch_call_shell(char_u *cmd, int options);
 void mch_breakcheck(int force);
-long Chk_Abort(void);
 int mch_expandpath(garray_T *gap, char_u *pat, int flags);
 int mch_has_exp_wildcard(char_u *p);
 int mch_has_wildcard(char_u *p);

--- a/src/proto/os_mswin.pro
+++ b/src/proto/os_mswin.pro
@@ -22,6 +22,8 @@ void display_errors(void);
 int mch_has_exp_wildcard(char_u *p);
 int mch_has_wildcard(char_u *p);
 int mch_chdir(char *path);
+int mch_char_avail(void);
+int mch_check_messages(void);
 int mch_icon_load(HANDLE *iconp);
 int mch_get_random(char_u *buf, int len);
 int mch_libcall(char_u *libname, char_u *funcname, char_u *argstring, int argint, char_u **string_result, int *number_result);

--- a/src/proto/os_qnx.pro
+++ b/src/proto/os_qnx.pro
@@ -1,6 +1,6 @@
 /* os_qnx.c */
 void qnx_init(void);
-void qnx_clip_init (void);
+void qnx_clip_init(void);
 int clip_mch_own_selection(Clipboard_T *cbd);
 void clip_mch_lose_selection(Clipboard_T *cbd);
 void clip_mch_request_selection(Clipboard_T *cbd);

--- a/src/proto/os_qnx.pro
+++ b/src/proto/os_qnx.pro
@@ -1,6 +1,7 @@
 /* os_qnx.c */
-void qnx_init(void);
+void qnx_init (void);
 void qnx_clip_init(void);
+int qnx_not_exist_function(void);
 int clip_mch_own_selection(Clipboard_T *cbd);
 void clip_mch_lose_selection(Clipboard_T *cbd);
 void clip_mch_request_selection(Clipboard_T *cbd);

--- a/src/proto/os_qnx.pro
+++ b/src/proto/os_qnx.pro
@@ -1,7 +1,6 @@
 /* os_qnx.c */
-void qnx_init (void);
+void qnx_init(void);
 void qnx_clip_init(void);
-int qnx_not_exist_function(void);
 int clip_mch_own_selection(Clipboard_T *cbd);
 void clip_mch_lose_selection(Clipboard_T *cbd);
 void clip_mch_request_selection(Clipboard_T *cbd);

--- a/src/proto/popupmenu.pro
+++ b/src/proto/popupmenu.pro
@@ -1,4 +1,7 @@
 /* popupmenu.c */
+void pum_set_border(int enable);
+void pum_set_shadow(int enable);
+void pum_set_margin(int enable);
 void pum_display(pumitem_T *array, int size, int selected);
 void pum_call_update_screen(void);
 int pum_under_menu(int row, int col, int only_redrawing);
@@ -18,8 +21,5 @@ void ui_may_remove_balloon(void);
 void pum_show_popupmenu(vimmenu_T *menu);
 void pum_make_popup(char_u *path_name, int use_mouse_pos);
 void pum_set_border_chars(int top, int right, int bottom, int left, int top_left, int top_right, int bottom_right, int bottom_left);
-void pum_set_border(int enable);
-void pum_set_shadow(int enable);
-void pum_set_margin(int enable);
 void put_shadow_char(int row, int col);
 /* vim: set ft=c : */

--- a/src/protodef.h
+++ b/src/protodef.h
@@ -7,12 +7,8 @@
  */
 
 #ifdef PROTO
-//// cproto runs into trouble when these types are missing
-//typedef double _Float16;
-//typedef double _Float32;
-//typedef double _Float64;
-//typedef double _Float128;
-//typedef double _Float32x;
-//typedef double _Float64x;
+
+# define WINAPI
+
 #endif
 

--- a/src/protodef.h
+++ b/src/protodef.h
@@ -7,12 +7,12 @@
  */
 
 #ifdef PROTO
-// cproto runs into trouble when these types are missing
-typedef double _Float16;
-typedef double _Float32;
-typedef double _Float64;
-typedef double _Float128;
-typedef double _Float32x;
-typedef double _Float64x;
+//// cproto runs into trouble when these types are missing
+//typedef double _Float16;
+//typedef double _Float32;
+//typedef double _Float64;
+//typedef double _Float128;
+//typedef double _Float32x;
+//typedef double _Float64x;
 #endif
 

--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -13,7 +13,7 @@
 
 #include "vim.h"
 
-#if defined(FEAT_QUICKFIX) || defined(PROTO)
+#if defined(FEAT_QUICKFIX)
 
 struct dir_stack_T
 {
@@ -2203,7 +2203,7 @@ decr_quickfix_busy(void)
 #endif
 }
 
-#if defined(EXITFREE) || defined(PROTO)
+#if defined(EXITFREE)
     void
 check_quickfix_busy(void)
 {
@@ -7128,7 +7128,7 @@ unload_dummy_buffer(buf_T *buf, char_u *dirname_start)
     restore_start_dir(dirname_start);
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Copy the specified quickfix entry items into a new dict and append the dict
  * to 'list'.  Returns OK on success.
@@ -8565,7 +8565,7 @@ ex_cbuffer(exarg_T *eap)
     decr_quickfix_busy();
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Return the autocmd name for the :cexpr Ex commands.
  */
@@ -8988,7 +8988,7 @@ ex_helpgrep(exarg_T *eap)
     }
 }
 
-# if defined(EXITFREE) || defined(PROTO)
+# if defined(EXITFREE)
     void
 free_quickfix(void)
 {
@@ -9006,7 +9006,7 @@ free_quickfix(void)
 
 #endif // FEAT_QUICKFIX
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 # ifdef FEAT_QUICKFIX
     static void
 get_qf_loc_list(int is_qf, win_T *wp, typval_T *what_arg, typval_T *rettv)

--- a/src/regexp.c
+++ b/src/regexp.c
@@ -50,7 +50,7 @@ toggle_Magic(int x)
     return Magic(x);
 }
 
-#if defined(FEAT_RELTIME) || defined(PROTO)
+#if defined(FEAT_RELTIME)
 static int timeout_nesting = 0;
 
 /*
@@ -80,7 +80,7 @@ disable_regexp_timeout(void)
 }
 #endif
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 # ifdef FEAT_RELTIME
 static sig_atomic_t *saved_timeout_flag;
 # endif
@@ -362,7 +362,7 @@ static int	regnzpar;	// \z() count.
 static int	re_has_z;	// \z item detected
 #endif
 static unsigned	regflags;	// RF_ flags for prog
-#if defined(FEAT_SYN_HL) || defined(PROTO)
+#if defined(FEAT_SYN_HL)
 static int	had_eol;	// TRUE when EOL found by vim_regcomp()
 #endif
 
@@ -2144,12 +2144,12 @@ vim_regsub_multi(
     return result;
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 // When nesting more than a couple levels it's probably a mistake.
 # define MAX_REGSUB_NESTING 4
 static char_u   *eval_result[MAX_REGSUB_NESTING] = {NULL, NULL, NULL, NULL};
 
-# if defined(EXITFREE) || defined(PROTO)
+# if defined(EXITFREE)
     void
 free_resub_eval_result(void)
 {
@@ -3025,7 +3025,7 @@ vim_regfree(regprog_T *prog)
 	prog->engine->regfree(prog);
 }
 
-#if defined(EXITFREE) || defined(PROTO)
+#if defined(EXITFREE)
     void
 free_regexp_stuff(void)
 {
@@ -3050,7 +3050,7 @@ report_re_switch(char_u *pat)
 }
 #endif
 
-#if defined(FEAT_X11) || defined(PROTO)
+#if defined(FEAT_X11)
 /*
  * Return whether "prog" is currently being executed.
  */
@@ -3137,7 +3137,7 @@ vim_regexec_string(
     return result > 0;
 }
 
-#if defined(FEAT_SPELL) || defined(FEAT_EVAL) || defined(FEAT_X11) || defined(PROTO)
+#if defined(FEAT_SPELL) || defined(FEAT_EVAL) || defined(FEAT_X11)
 /*
  * Note: "*prog" may be freed and changed.
  * Return TRUE if there is a match, FALSE if not.

--- a/src/regexp_bt.c
+++ b/src/regexp_bt.c
@@ -478,7 +478,7 @@ regcomp_start(
     regsize = 0L;
     reg_toolong = FALSE;
     regflags = 0;
-#if defined(FEAT_SYN_HL) || defined(PROTO)
+#if defined(FEAT_SYN_HL)
     had_eol = FALSE;
 #endif
 }
@@ -1261,7 +1261,7 @@ regatom(int *flagp)
 
       case Magic('$'):
 	ret = regnode(EOL);
-#if defined(FEAT_SYN_HL) || defined(PROTO)
+#if defined(FEAT_SYN_HL)
 	had_eol = TRUE;
 #endif
 	break;
@@ -1284,7 +1284,7 @@ regatom(int *flagp)
 	if (c == '$')		// "\_$" is end-of-line
 	{
 	    ret = regnode(EOL);
-#if defined(FEAT_SYN_HL) || defined(PROTO)
+#if defined(FEAT_SYN_HL)
 	    had_eol = TRUE;
 #endif
 	    break;
@@ -2595,7 +2595,7 @@ bt_regcomp(char_u *expr, int re_flags)
     return (regprog_T *)r;
 }
 
-#if defined(FEAT_SYN_HL) || defined(PROTO)
+#if defined(FEAT_SYN_HL)
 /*
  * Check if during the previous call to vim_regcomp the EOL item "$" has been
  * found.  This is messy, but it works fine.

--- a/src/regexp_nfa.c
+++ b/src/regexp_nfa.c
@@ -1321,7 +1321,7 @@ nfa_regatom(void)
 
 	case Magic('$'):
 	    EMIT(NFA_EOL);
-#if defined(FEAT_SYN_HL) || defined(PROTO)
+#if defined(FEAT_SYN_HL)
 	    had_eol = TRUE;
 #endif
 	    break;
@@ -1347,7 +1347,7 @@ nfa_regatom(void)
 	    if (c == '$')	// "\_$" is end-of-line
 	    {
 		EMIT(NFA_EOL);
-#if defined(FEAT_SYN_HL) || defined(PROTO)
+#if defined(FEAT_SYN_HL)
 		had_eol = TRUE;
 #endif
 		break;

--- a/src/register.c
+++ b/src/register.c
@@ -38,7 +38,7 @@ static void	copy_yank_reg(yankreg_T *reg);
 #endif
 static void	dis_msg(char_u *p, int skip_esc);
 
-#if defined(FEAT_VIMINFO) || defined(PROTO)
+#if defined(FEAT_VIMINFO)
     yankreg_T *
 get_y_regs(void)
 {
@@ -46,7 +46,7 @@ get_y_regs(void)
 }
 #endif
 
-#if defined(FEAT_CLIPBOARD) || defined(PROTO)
+#if defined(FEAT_CLIPBOARD)
     yankreg_T *
 get_y_register(int reg)
 {
@@ -85,7 +85,7 @@ reset_y_append(void)
 }
 
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Keep the last expression line here, for repeating.
  */
@@ -346,7 +346,7 @@ put_register(int name, void *reg)
 #endif
 }
 
-#if defined(FEAT_CLIPBOARD) || defined(PROTO)
+#if defined(FEAT_CLIPBOARD)
     void
 free_register(void *reg)
 {
@@ -499,7 +499,7 @@ stuff_yank(int regname, char_u *p)
  */
 static int execreg_lastc = NUL;
 
-#if defined(FEAT_VIMINFO) || defined(PROTO)
+#if defined(FEAT_VIMINFO)
     int
 get_execreg_lastc(void)
 {
@@ -1113,7 +1113,7 @@ init_yank(void)
 	y_regs[i].y_array = NULL;
 }
 
-#if defined(EXITFREE) || defined(PROTO)
+#if defined(EXITFREE)
     void
 clear_registers(void)
 {
@@ -2357,7 +2357,7 @@ get_register_name(int num)
 	return num + 'a' - 10;
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Return the index of the register "" points to.
  */
@@ -2564,7 +2564,7 @@ dis_msg(
     ui_breakcheck();
 }
 
-#if defined(FEAT_DND) || defined(PROTO)
+#if defined(FEAT_DND)
 /*
  * Replace the contents of the '~' register with str.
  */
@@ -2624,7 +2624,7 @@ get_reg_type(int regname, long *reglen)
     return MAUTO;
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * When "flags" has GREG_LIST return a list with text "s".
  * Otherwise just return "s".
@@ -3084,4 +3084,4 @@ str_to_reg(
     y_ptr->y_time_set = vim_time();
 # endif
 }
-#endif // FEAT_CLIPBOARD || FEAT_EVAL || PROTO
+#endif // FEAT_CLIPBOARD || FEAT_EVAL

--- a/src/screen.c
+++ b/src/screen.c
@@ -59,7 +59,7 @@ static void recording_mode(int attr);
 // Ugly global: overrule attribute used by screen_char()
 static int screen_char_attr = 0;
 
-#if defined(FEAT_CONCEAL) || defined(PROTO)
+#if defined(FEAT_CONCEAL)
 /*
  * Return TRUE if the cursor line in window "wp" may be concealed, according
  * to the 'concealcursor' option.
@@ -229,7 +229,7 @@ win_draw_end(
     set_empty_rows(wp, row);
 }
 
-#if defined(FEAT_FOLDING) || defined(PROTO)
+#if defined(FEAT_FOLDING)
 /*
  * Compute the width of the foldcolumn.  Based on 'foldcolumn' and how much
  * space is available for window "wp", minus "col".
@@ -371,7 +371,7 @@ char_needs_redraw(int off_from, int off_to, int cols)
     return FALSE;
 }
 
-#if defined(FEAT_TERMINAL) || defined(PROTO)
+#if defined(FEAT_TERMINAL)
 /*
  * Return the index in ScreenLines[] for the current screen line.
  */
@@ -887,7 +887,7 @@ screen_line(
     }
 }
 
-#if defined(FEAT_RIGHTLEFT) || defined(PROTO)
+#if defined(FEAT_RIGHTLEFT)
 /*
  * Mirror text "str" for right-left displaying.
  * Only works for single-byte characters (e.g., numbers).
@@ -1006,7 +1006,7 @@ get_keymap_str(
     return plen;
 }
 
-#if defined(FEAT_STL_OPT) || defined(PROTO)
+#if defined(FEAT_STL_OPT)
 /*
  * Redraw the status line or ruler of window "wp".
  * When "wp" is NULL redraw the tab pages line from 'tabline'.
@@ -1550,7 +1550,7 @@ screen_puts_len(
     }
 }
 
-#if defined(FEAT_SEARCH_EXTRA) || defined(PROTO)
+#if defined(FEAT_SEARCH_EXTRA)
 /*
  * Prepare for 'hlsearch' highlighting.
  */
@@ -4622,7 +4622,7 @@ comp_col(void)
 #endif
 }
 
-#if defined(FEAT_LINEBREAK) || defined(PROTO)
+#if defined(FEAT_LINEBREAK)
 /*
  * Return the width of the 'number' and 'relativenumber' column.
  * Caller may need to check if 'number' or 'relativenumber' is set.
@@ -4670,7 +4670,7 @@ number_width(win_T *wp)
 }
 #endif
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Return the current cursor column. This is the actual position on the
  * screen. First column is 0.

--- a/src/scriptfile.c
+++ b/src/scriptfile.c
@@ -13,7 +13,7 @@
 
 #include "vim.h"
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 // The names of packages that once were loaded are remembered.
 static garray_T		ga_loaded = {0, 0, sizeof(char_u *), 4, NULL};
 #endif
@@ -70,7 +70,7 @@ estack_push(etype_T type, char_u *name, long lnum)
     return entry;
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Add a user function to the execution stack.
  */
@@ -758,7 +758,7 @@ source_in_path(char_u *path, char_u *name, int flags, int *ret_sid)
     return do_in_path_and_pp(path, name, flags, source_callback, ret_sid);
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 
 /*
  * Find "name" in 'runtimepath'. If found a new scriptitem is created for it
@@ -1419,7 +1419,7 @@ ex_source(exarg_T *eap)
 	cmd_source(eap->arg, eap);
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * ":options"
  */
@@ -1442,7 +1442,7 @@ ex_options(
  * ":source" and associated commands.
  */
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Return the address holding the next breakpoint line for a source cookie.
  */
@@ -2048,7 +2048,7 @@ do_source(
 }
 
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 
 /*
  * ":scriptnames"
@@ -2106,7 +2106,7 @@ ex_scriptnames(exarg_T *eap)
     }
 }
 
-# if defined(BACKSLASH_IN_FILENAME) || defined(PROTO)
+# if defined(BACKSLASH_IN_FILENAME)
 /*
  * Fix slashes in the list of script names for 'shellslash'.
  */
@@ -2143,7 +2143,7 @@ get_scriptname(scid_T id)
     return SCRIPT_ITEM(id)->sn_name;
 }
 
-# if defined(EXITFREE) || defined(PROTO)
+# if defined(EXITFREE)
     void
 free_scriptnames(void)
 {
@@ -2677,7 +2677,7 @@ ex_scriptversion(exarg_T *eap UNUSED)
     }
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * ":finish": Mark a sourced file as finished.
  */

--- a/src/search.c
+++ b/src/search.c
@@ -309,7 +309,7 @@ restore_search_patterns(void)
 #endif
 }
 
-#if defined(EXITFREE) || defined(PROTO)
+#if defined(EXITFREE)
     void
 free_search_patterns(void)
 {
@@ -492,7 +492,7 @@ pat_has_uppercase(char_u *pat)
     return FALSE;
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
     char_u *
 last_csearch(void)
 {
@@ -3366,7 +3366,7 @@ update_search_stat(
     p_ws = save_ws;
 }
 
-#if defined(FEAT_FIND_ID) || defined(PROTO)
+#if defined(FEAT_FIND_ID)
 
 /*
  * Get line "lnum" and copy it into "buf[LSIZE]".

--- a/src/session.c
+++ b/src/session.c
@@ -13,7 +13,7 @@
 
 #include "vim.h"
 
-#if defined(FEAT_SESSION) || defined(PROTO)
+#if defined(FEAT_SESSION)
 
 static int did_lcd;	// whether ":lcd" was produced for a session
 
@@ -1076,8 +1076,7 @@ ex_loadview(exarg_T *eap)
 }
 
 # if defined(FEAT_GUI_GNOME) \
-	|| (defined(GUI_MAY_SPAWN) && defined(EXPERIMENTAL_GUI_CMD)) \
-	|| defined(PROTO)
+	|| (defined(GUI_MAY_SPAWN) && defined(EXPERIMENTAL_GUI_CMD))
 /*
  * Generate a script that can be used to restore the current editing session.
  * Save the value of v:this_session before running :mksession in order to make
@@ -1395,7 +1394,7 @@ theend:
     apply_autocmds(EVENT_SESSIONWRITEPOST, NULL, NULL, FALSE, curbuf);
 }
 
-#if (defined(FEAT_VIMINFO) || defined(FEAT_SESSION)) || defined(PROTO)
+#if defined(FEAT_VIMINFO) || defined(FEAT_SESSION)
     var_flavour_T
 var_flavour(char_u *varname)
 {

--- a/src/sha256.c
+++ b/src/sha256.c
@@ -263,7 +263,7 @@ sha256_finish(context_sha256_T *ctx, char_u digest[32])
 }
 #endif // FEAT_CRYPT || FEAT_PERSISTENT_UNDO
 
-#if defined(FEAT_CRYPT) || defined(PROTO)
+#if defined(FEAT_CRYPT)
 /*
  * Returns hex digest of "buf[buf_len]" in a static array.
  * if "salt" is not NULL also do "salt[salt_len]".

--- a/src/sign.c
+++ b/src/sign.c
@@ -13,7 +13,7 @@
 
 #include "vim.h"
 
-#if defined(FEAT_SIGNS) || defined(PROTO)
+#if defined(FEAT_SIGNS)
 
 /*
  * Struct to hold the sign properties.
@@ -675,7 +675,7 @@ buf_findsign_id(buf_T *buf, // buffer whose sign we are searching for
     return 0;
 }
 
-# if defined(FEAT_NETBEANS_INTG) || defined(PROTO)
+# if defined(FEAT_NETBEANS_INTG)
 /*
  * See if a given type of sign exists on a specific line.
  */
@@ -699,7 +699,7 @@ buf_findsigntype_id(buf_T *buf, // buffer whose sign we are searching for
     return 0;
 }
 
-#  if defined(FEAT_SIGN_ICONS) || defined(PROTO)
+#  if defined(FEAT_SIGN_ICONS)
 /*
  * Return the number of icons on the given line.
  */
@@ -1919,7 +1919,7 @@ sign_get_placed(buf_T *buf,
     }
 }
 
-# if defined(FEAT_SIGN_ICONS) || defined(PROTO)
+# if defined(FEAT_SIGN_ICONS)
 /*
  * Allocate the icons.  Called when the GUI has started.  Allows defining
  * signs before it starts.
@@ -2040,7 +2040,7 @@ sign_undefine(sign_T *sp, sign_T *sp_prev)
     vim_free(sp);
 }
 
-# if defined(FEAT_SIGN_ICONS) || defined(PROTO)
+# if defined(FEAT_SIGN_ICONS)
 void *
 sign_get_image(int typenr) // the attribute which may have a sign
 {

--- a/src/sound.c
+++ b/src/sound.c
@@ -13,7 +13,7 @@
 
 #include "vim.h"
 
-#if defined(FEAT_SOUND) || defined(PROTO)
+#if defined(FEAT_SOUND)
 
 static long sound_id = 0;
 
@@ -109,7 +109,7 @@ delete_sound_callback(soundcb_T *soundcb)
         }
 }
 
-# if defined(HAVE_CANBERRA) || defined(PROTO)
+# if defined(HAVE_CANBERRA)
 
 /*
  * Sound implementation for Linux/Unix using libcanberra.
@@ -279,7 +279,7 @@ f_sound_clear(typval_T *argvars UNUSED, typval_T *rettv UNUSED)
     context = NULL;
 }
 
-#  if defined(EXITFREE) || defined(PROTO)
+#  if defined(EXITFREE)
 void
 sound_free(void)
 {
@@ -510,7 +510,7 @@ f_sound_clear(typval_T *argvars UNUSED, typval_T *rettv UNUSED)
     sound_mch_clear();
 }
 
-#  if defined(EXITFREE) || defined(PROTO)
+#  if defined(EXITFREE)
 void
 sound_free(void)
 {

--- a/src/spell.c
+++ b/src/spell.c
@@ -58,7 +58,7 @@
 #define IN_SPELL_C
 #include "vim.h"
 
-#if defined(FEAT_SPELL) || defined(PROTO)
+#if defined(FEAT_SPELL)
 
 #include <time.h>
 
@@ -3138,7 +3138,7 @@ make_case_word(char_u *fword, char_u *cword, int flags)
 	STRCPY(cword, fword);
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Soundfold a string, for soundfold().
  * Result is in allocated memory, NULL for an error.

--- a/src/spellfile.c
+++ b/src/spellfile.c
@@ -239,7 +239,7 @@
 
 #include "vim.h"
 
-#if defined(FEAT_SPELL) || defined(PROTO)
+#if defined(FEAT_SPELL)
 
 #include <time.h>	// for time_t
 

--- a/src/spellsuggest.c
+++ b/src/spellsuggest.c
@@ -13,7 +13,7 @@
 
 #include "vim.h"
 
-#if defined(FEAT_SPELL) || defined(PROTO)
+#if defined(FEAT_SPELL)
 
 /*
  * Use this to adjust the score after finding suggestions, based on the

--- a/src/strings.c
+++ b/src/strings.c
@@ -346,7 +346,7 @@ vim_strup(
 	*p2++ = (c < 'a' || c > 'z') ? c : (c - 0x20);
 }
 
-#if defined(FEAT_EVAL) || defined(FEAT_SPELL) || defined(PROTO)
+#if defined(FEAT_EVAL) || defined(FEAT_SPELL)
 /*
  * Make string "s" all upper-case and return it in allocated memory.
  * Handles multi-byte characters as well as possible.
@@ -538,7 +538,7 @@ vim_strlen_maxlen(char *s, size_t maxlen)
     return i;
 }
 
-#if (!defined(HAVE_STRCASECMP) && !defined(HAVE_STRICMP)) || defined(PROTO)
+#if !defined(HAVE_STRCASECMP) && !defined(HAVE_STRICMP)
 /*
  * Compare two strings, ignoring case, using current locale.
  * Doesn't work for multi-byte characters.
@@ -563,7 +563,7 @@ vim_stricmp(char *s1, char *s2)
 }
 #endif
 
-#if (!defined(HAVE_STRNCASECMP) && !defined(HAVE_STRNICMP)) || defined(PROTO)
+#if !defined(HAVE_STRNCASECMP) && !defined(HAVE_STRNICMP)
 /*
  * Compare two strings, for length "len", ignoring case, using current locale.
  * Doesn't work for multi-byte characters.
@@ -755,7 +755,7 @@ sort_strings(
     qsort((void *)files, (size_t)count, sizeof(char_u *), sort_compare);
 }
 
-#if defined(FEAT_QUICKFIX) || defined(FEAT_SPELL) || defined(PROTO)
+#if defined(FEAT_QUICKFIX) || defined(FEAT_SPELL)
 /*
  * Return TRUE if string "s" contains a non-ASCII character (128 or higher).
  * When "s" is NULL FALSE is returned.
@@ -795,7 +795,7 @@ concat_str(char_u *str1, char_u *str2)
     return dest;
 }
 
-#if defined(FEAT_EVAL) || defined(FEAT_RIGHTLEFT) || defined(PROTO)
+#if defined(FEAT_EVAL) || defined(FEAT_RIGHTLEFT)
 /*
  * Reverse text into allocated memory.
  * Returns the allocated string, NULL when out of memory.
@@ -825,7 +825,7 @@ reverse_text(char_u *s)
 }
 #endif
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Return string "str" in ' quotes, doubling ' characters.
  * If "str" is NULL an empty string is assumed.

--- a/src/structs.h
+++ b/src/structs.h
@@ -1439,20 +1439,11 @@ typedef long_u hash_T;		// Type for hi_hash
 
 // Use 64-bit Number.
 #ifdef MSWIN
-# ifdef PROTO
-   // workaround for cproto that doesn't recognize __int64
-   typedef long			varnumber_T;
-   typedef unsigned long	uvarnumber_T;
-#  define VARNUM_MIN		LONG_MIN
-#  define VARNUM_MAX		LONG_MAX
-#  define UVARNUM_MAX		ULONG_MAX
-# else
    typedef __int64		varnumber_T;
    typedef unsigned __int64	uvarnumber_T;
-#  define VARNUM_MIN		_I64_MIN
-#  define VARNUM_MAX		_I64_MAX
-#  define UVARNUM_MAX		_UI64_MAX
-# endif
+# define VARNUM_MIN		_I64_MIN
+# define VARNUM_MAX		_I64_MAX
+# define UVARNUM_MAX		_UI64_MAX
 #elif defined(HAVE_NO_LONG_LONG)
 # if defined(HAVE_STDINT_H)
    typedef int64_t		varnumber_T;

--- a/src/structs.h
+++ b/src/structs.h
@@ -959,7 +959,7 @@ typedef struct sign_attrs_S {
     int		sat_priority;
 } sign_attrs_T;
 
-#if defined(FEAT_SIGNS) || defined(PROTO)
+#if defined(FEAT_SIGNS)
 // Macros to get the sign group structure from the group name
 #define SGN_KEY_OFF	offsetof(signgroup_T, sg_name)
 #define HI2SG(hi)	((signgroup_T *)((hi)->hi_key - SGN_KEY_OFF))
@@ -1883,7 +1883,7 @@ typedef enum {
 
 typedef struct svar_S svar_T;
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Info used by a ":for" loop.
  */
@@ -3613,7 +3613,7 @@ struct file_buffer
 }; // file_buffer
 
 
-#if defined(FEAT_DIFF) || defined(PROTO)
+#if defined(FEAT_DIFF)
 /*
  * Stuff for diff mode.
  */

--- a/src/syntax.c
+++ b/src/syntax.c
@@ -13,7 +13,7 @@
 
 #include "vim.h"
 
-#if defined(FEAT_SYN_HL) || defined(PROTO)
+#if defined(FEAT_SYN_HL)
 
 // different types of offsets that are possible
 #define SPO_MS_OFF	0	// match  start offset
@@ -6511,7 +6511,7 @@ syn_get_id(
     return (trans ? current_trans_id : current_id);
 }
 
-#if defined(FEAT_CONCEAL) || defined(PROTO)
+#if defined(FEAT_CONCEAL)
 /*
  * Get extra information about the syntax item.  Must be called right after
  * get_syntax_attr().
@@ -6535,7 +6535,7 @@ syn_get_sub_char(void)
 }
 #endif
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Return the syntax ID at position "i" in the current stack.
  * The caller must have called syn_get_id() before to fill the stack.
@@ -6556,7 +6556,7 @@ syn_get_stack_item(int i)
 }
 #endif
 
-#if defined(FEAT_FOLDING) || defined(PROTO)
+#if defined(FEAT_FOLDING)
     static int
 syn_cur_foldlevel(void)
 {
@@ -6619,7 +6619,7 @@ syn_get_foldlevel(win_T *wp, long lnum)
 }
 #endif
 
-#if defined(FEAT_PROFILE) || defined(PROTO)
+#if defined(FEAT_PROFILE)
 /*
  * ":syntime".
  */

--- a/src/tabpanel.c
+++ b/src/tabpanel.c
@@ -13,7 +13,7 @@
 
 #include "vim.h"
 
-#if defined(FEAT_TABPANEL) || defined(PROTO)
+#if defined(FEAT_TABPANEL)
 
 static void do_by_tplmode(int tplmode, int col_start, int col_end,
 	int *pcurtab_row, int *ptabpagenr);

--- a/src/tag.c
+++ b/src/tag.c
@@ -163,7 +163,7 @@ static callback_T tfu_cb;	    // 'tagfunc' callback function
 // Used instead of NUL to separate tag fields in the growarrays.
 #define TAG_SEP 0x02
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Reads the 'tagfunc' option value and convert that to a callback value.
  * Invoked when the 'tagfunc' option is set. The option value can be a name of
@@ -189,7 +189,7 @@ did_set_tagfunc(optset_T *args UNUSED)
 }
 #endif
 
-# if defined(EXITFREE) || defined(PROTO)
+# if defined(EXITFREE)
     void
 free_tagfunc_option(void)
 {
@@ -199,7 +199,7 @@ free_tagfunc_option(void)
 }
 # endif
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Mark the global 'tagfunc' callback with "copyID" so that it is not garbage
  * collected.
@@ -3279,7 +3279,7 @@ found_tagfile_cb(char_u *fname, void *cookie UNUSED)
     ((char_u **)(tag_fnames.ga_data))[tag_fnames.ga_len++] = tag_fname;
 }
 
-#if defined(EXITFREE) || defined(PROTO)
+#if defined(EXITFREE)
     void
 free_tag_stuff(void)
 {
@@ -4330,7 +4330,7 @@ expand_tags(
     return ret;
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Add a tag field to the dictionary "dict".
  * Return OK or FAIL.

--- a/src/term.c
+++ b/src/term.c
@@ -1388,7 +1388,7 @@ builtin_tcap_T builtin_terminals[] = {
     {NULL,	    NULL},  // end marker
 };
 
-#if defined(FEAT_TERMGUICOLORS) || defined(PROTO)
+#if defined(FEAT_TERMGUICOLORS)
     static guicolor_T
 termgui_mch_get_color(char_u *name)
 {
@@ -1518,7 +1518,7 @@ init_term_props(int all)
 	    term_props[i].tpr_status = TPR_UNKNOWN;
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
     void
 f_terminalprops(typval_T *argvars UNUSED, typval_T *rettv)
 {
@@ -2389,7 +2389,7 @@ set_termname(char_u *term)
     return OK;
 }
 
-#if defined(EXITFREE) || defined(PROTO)
+#if defined(EXITFREE)
 
 # ifdef HAVE_DEL_CURTERM
 #  include <term.h>	    // declares cur_term
@@ -2464,7 +2464,7 @@ vim_tgetstr(char *s, char_u **pp)
 }
 #endif // HAVE_TGETENT
 
-#if defined(HAVE_TGETENT) && (defined(UNIX) || defined(VMS) || defined(MACOS_X)) || defined(PROTO)
+#if defined(HAVE_TGETENT) && (defined(UNIX) || defined(VMS) || defined(MACOS_X))
 /*
  * Get Columns and Rows from the termcap. Used after a window signal if the
  * ioctl() fails. It doesn't make sense to call tgetent each time if the "co"
@@ -2641,7 +2641,7 @@ term_7to8bit(char_u *p)
     return 0;
 }
 
-#if defined(FEAT_GUI) || defined(PROTO)
+#if defined(FEAT_GUI)
     int
 term_is_gui(char_u *name)
 {
@@ -2649,7 +2649,7 @@ term_is_gui(char_u *name)
 }
 #endif
 
-#if !defined(HAVE_TGETENT) || defined(AMIGA) || defined(PROTO)
+#if !defined(HAVE_TGETENT) || defined(AMIGA)
 
     char_u *
 tltoa(unsigned long i)
@@ -3030,7 +3030,7 @@ term_delete_lines(int line_count)
     OUT_STR(tgoto((char *)T_CDL, 0, line_count));
 }
 
-#if defined(UNIX) || defined(VMS) || defined(PROTO)
+#if defined(UNIX) || defined(VMS)
     void
 term_enable_mouse(int enable)
 {
@@ -3039,7 +3039,7 @@ term_enable_mouse(int enable)
 }
 #endif
 
-#if defined(HAVE_TGETENT) || defined(PROTO)
+#if defined(HAVE_TGETENT)
     void
 term_set_winpos(int x, int y)
 {
@@ -3051,7 +3051,7 @@ term_set_winpos(int x, int y)
     OUT_STR(tgoto((char *)T_CWP, y, x));
 }
 
-# if defined(FEAT_TERMRESPONSE) || defined(PROTO)
+# if defined(FEAT_TERMRESPONSE)
 /*
  * Return TRUE if we can request the terminal for a response.
  */
@@ -3105,7 +3105,7 @@ static int winpos_x = -1;
 static int winpos_y = -1;
 static int did_request_winpos = 0;
 
-#  if defined(FEAT_EVAL) || defined(FEAT_TERMINAL) || defined(PROTO)
+#  if defined(FEAT_EVAL) || defined(FEAT_TERMINAL)
 /*
  * Try getting the Vim window position from the terminal.
  * Returns OK or FAIL.
@@ -3276,7 +3276,7 @@ term_bg_default(void)
 #endif
 }
 
-#if defined(FEAT_TERMGUICOLORS) || defined(PROTO)
+#if defined(FEAT_TERMGUICOLORS)
 
 # define RED(rgb)   (((long_u)(rgb) >> 16) & 0xFF)
 # define GREEN(rgb) (((long_u)(rgb) >>  8) & 0xFF)
@@ -3333,7 +3333,7 @@ term_ul_rgb_color(guicolor_T rgb)
 }
 #endif
 
-#if (defined(UNIX) || defined(VMS) || defined(MACOS_X)) || defined(PROTO)
+#if defined(UNIX) || defined(VMS) || defined(MACOS_X)
 /*
  * Generic function to set window title, using t_ts and t_fs.
  */
@@ -3502,8 +3502,7 @@ ttest(int pairs)
     }
 }
 
-#if (defined(FEAT_GUI) && (defined(FEAT_MENU) || !defined(USE_ON_FLY_SCROLL))) \
-	|| defined(PROTO)
+#if defined(FEAT_GUI) && (defined(FEAT_MENU) || !defined(USE_ON_FLY_SCROLL))
 /*
  * Represent the given long_u as individual bytes, with the most significant
  * byte first, and store them in dst.
@@ -4080,7 +4079,7 @@ stoptermcap(void)
     out_flush();
 }
 
-#if defined(FEAT_TERMRESPONSE) || defined(PROTO)
+#if defined(FEAT_TERMRESPONSE)
 /*
  * Request version string (for xterm) when needed.
  * Only do this after switching to raw mode, otherwise the result will be
@@ -4349,7 +4348,7 @@ cursor_unsleep(void)
     cursor_on();
 }
 
-#if defined(CURSOR_SHAPE) || defined(PROTO)
+#if defined(CURSOR_SHAPE)
 /*
  * Set cursor shape to match Insert or Replace mode.
  */
@@ -4401,7 +4400,7 @@ term_cursor_mode(int forced)
     }
 }
 
-# if defined(FEAT_TERMINAL) || defined(PROTO)
+# if defined(FEAT_TERMINAL)
     void
 term_cursor_color(char_u *color)
 {
@@ -4854,7 +4853,7 @@ static linenr_T orig_topline = 0;
 static int orig_topfill = 0;
 # endif
 #endif
-#if defined(CHECK_DOUBLE_CLICK) || defined(PROTO)
+#if defined(CHECK_DOUBLE_CLICK)
 /*
  * Checking for double-clicks ourselves.
  * "orig_topline" is used to avoid detecting a double-click when the window
@@ -6735,7 +6734,7 @@ handle_osc:
     return 0;			    // no match found
 }
 
-#if (defined(FEAT_TERMINAL) && defined(FEAT_TERMRESPONSE)) || defined(PROTO)
+#if defined(FEAT_TERMINAL) && defined(FEAT_TERMRESPONSE)
 /*
  * Get the text foreground color, if known.
  */
@@ -7237,7 +7236,7 @@ show_one_termcode(char_u *name, char_u *code, int printit)
     return len;
 }
 
-#if defined(FEAT_TERMRESPONSE) || defined(PROTO)
+#if defined(FEAT_TERMRESPONSE)
 /*
  * For Xterm >= 140 compiled with OPT_TCAP_QUERY: Obtain the actually used
  * termcap codes from the terminal itself.
@@ -7448,7 +7447,7 @@ check_for_codes_from_term(void)
 }
 #endif
 
-#if (defined(MSWIN) && (!defined(FEAT_GUI) || defined(VIMDLL))) || defined(PROTO)
+#if defined(MSWIN) && (!defined(FEAT_GUI) || defined(VIMDLL))
 static char ksme_str[20];
 static char ksmr_str[20];
 static char ksmd_str[20];
@@ -7600,8 +7599,7 @@ swap_tcap(void)
 #endif
 
 
-#if (defined(MSWIN) && (!defined(FEAT_GUI_MSWIN) || defined(VIMDLL))) || defined(FEAT_TERMINAL) \
-	|| defined(PROTO)
+#if (defined(MSWIN) && (!defined(FEAT_GUI_MSWIN) || defined(VIMDLL))) || defined(FEAT_TERMINAL)
 static int cube_value[] = {
     0x00, 0x5F, 0x87, 0xAF, 0xD7, 0xFF
 };

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -40,7 +40,7 @@
 
 #include "vim.h"
 
-#if defined(FEAT_TERMINAL) || defined(PROTO)
+#if defined(FEAT_TERMINAL)
 
 #ifndef MIN
 # define MIN(x,y) ((x) < (y) ? (x) : (y))
@@ -1071,7 +1071,7 @@ expand_terminal_opt(
 	    FALSE);
 }
 
-#if defined(FEAT_SESSION) || defined(PROTO)
+#if defined(FEAT_SESSION)
 /*
  * Write a :terminal command to the session file to restore the terminal in
  * window "wp".
@@ -2189,7 +2189,7 @@ may_move_terminal_to_buffer(term_T *term, int redraw)
     }
 }
 
-#if defined(FEAT_TIMERS) || defined(PROTO)
+#if defined(FEAT_TIMERS)
 /*
  * Check if any terminal timer expired.  If so, copy text from the terminal to
  * the buffer.
@@ -2593,7 +2593,7 @@ term_get_highlight_id(term_T *term, win_T *wp)
     return syn_name2id(name);
 }
 
-#if defined(FEAT_GUI) || defined(PROTO)
+#if defined(FEAT_GUI)
     cursorentry_T *
 term_get_cursor_shape(guicolor_T *fg, guicolor_T *bg)
 {
@@ -3737,7 +3737,7 @@ term_after_channel_closed(term_T *term)
     return FALSE;
 }
 
-#if defined(FEAT_PROP_POPUP) || defined(PROTO)
+#if defined(FEAT_PROP_POPUP)
 /*
  * If the current window is a terminal in a popup window and the job has
  * finished, close the popup window and to back to the previous window.
@@ -6629,7 +6629,7 @@ f_term_sendkeys(typval_T *argvars, typval_T *rettv UNUSED)
     }
 }
 
-#if defined(FEAT_GUI) || defined(FEAT_TERMGUICOLORS) || defined(PROTO)
+#if defined(FEAT_GUI) || defined(FEAT_TERMGUICOLORS)
 /*
  * "term_getansicolors(buf)" function
  */
@@ -6938,7 +6938,7 @@ term_send_eof(channel_T *ch)
 	}
 }
 
-#if defined(FEAT_GUI) || defined(PROTO)
+#if defined(FEAT_GUI)
     job_T *
 term_getjob(term_T *term)
 {
@@ -6946,7 +6946,7 @@ term_getjob(term_T *term)
 }
 #endif
 
-# if defined(MSWIN) || defined(PROTO)
+# if defined(MSWIN)
 
 ///////////////////////////////////////
 // 2. MS-Windows implementation.
@@ -7276,8 +7276,6 @@ use_conpty(void)
     return has_conpty;
 }
 
-#  ifndef PROTO
-
 #define WINPTY_SPAWN_FLAG_AUTO_SHUTDOWN 1ul
 #define WINPTY_SPAWN_FLAG_EXIT_AFTER_SHUTDOWN 2ull
 #define WINPTY_MOUSE_MODE_FORCE		2
@@ -7302,7 +7300,6 @@ HANDLE (*winpty_agent_process)(void*);
 #define WINPTY_DLL "winpty.dll"
 
 static HINSTANCE hWinPtyDLL = NULL;
-#  endif
 
     static int
 dyn_winpty_init(int verbose)

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -6950,20 +6950,6 @@ term_getjob(term_T *term)
 
 ///////////////////////////////////////
 // 2. MS-Windows implementation.
-#ifdef PROTO
-typedef int COORD;
-typedef int DWORD;
-typedef int HANDLE;
-typedef int *DWORD_PTR;
-typedef int HPCON;
-typedef int HRESULT;
-typedef int LPPROC_THREAD_ATTRIBUTE_LIST;
-typedef int SIZE_T;
-typedef int PSIZE_T;
-typedef int PVOID;
-typedef int BOOL;
-# define WINAPI
-#endif
 
 HRESULT (WINAPI *pCreatePseudoConsole)(COORD, HANDLE, HANDLE, DWORD, HPCON*);
 HRESULT (WINAPI *pResizePseudoConsole)(HPCON, COORD);

--- a/src/testing.c
+++ b/src/testing.c
@@ -13,7 +13,7 @@
 
 #include "vim.h"
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 
 /*
  * Prepare "gap" for an assert error and add the sourcing position.
@@ -1201,7 +1201,7 @@ f_test_null_blob(typval_T *argvars UNUSED, typval_T *rettv)
     rettv->vval.v_blob = NULL;
 }
 
-#if defined(FEAT_JOB_CHANNEL) || defined(PROTO)
+#if defined(FEAT_JOB_CHANNEL)
     void
 f_test_null_channel(typval_T *argvars UNUSED, typval_T *rettv)
 {
@@ -1216,7 +1216,7 @@ f_test_null_dict(typval_T *argvars UNUSED, typval_T *rettv)
     rettv_dict_set(rettv, NULL);
 }
 
-#if defined(FEAT_JOB_CHANNEL) || defined(PROTO)
+#if defined(FEAT_JOB_CHANNEL)
     void
 f_test_null_job(typval_T *argvars UNUSED, typval_T *rettv)
 {

--- a/src/textformat.c
+++ b/src/textformat.c
@@ -915,7 +915,7 @@ op_format(
     }
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Implementation of the format operator 'gq' for when using 'formatexpr'.
  */

--- a/src/textobject.c
+++ b/src/textobject.c
@@ -1206,7 +1206,7 @@ current_block(
     return OK;
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Return TRUE if the cursor is on a "<aaa>" tag.  Ignore "<aaa/>".
  * When "end_tag" is TRUE return TRUE if the cursor is on "</aaa>".

--- a/src/textprop.c
+++ b/src/textprop.c
@@ -13,7 +13,7 @@
 
 #include "vim.h"
 
-#if defined(FEAT_PROP_POPUP) || defined(PROTO)
+#if defined(FEAT_PROP_POPUP)
 
 /*
  * In a hashtable item "hi_key" points to "pt_name" in a proptype_T.
@@ -2130,7 +2130,7 @@ clear_ht_prop_types(hashtab_T *ht)
     vim_free(ht);
 }
 
-#if defined(EXITFREE) || defined(PROTO)
+#if defined(EXITFREE)
 /*
  * Free all global property types.
  */

--- a/src/time.c
+++ b/src/time.c
@@ -127,7 +127,7 @@ get_ctime(time_t thetime, int add_newline)
     return buf;
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 
 #if defined(MACOS_X)
 # include <time.h>	// for time_t
@@ -281,7 +281,7 @@ f_reltimestr(typval_T *argvars UNUSED, typval_T *rettv)
 # endif
 }
 
-# if defined(HAVE_STRFTIME) || defined(PROTO)
+# if defined(HAVE_STRFTIME)
 /*
  * "strftime({format}[, {time}])" function
  */
@@ -353,7 +353,7 @@ f_strftime(typval_T *argvars, typval_T *rettv)
 }
 # endif
 
-# if defined(HAVE_STRPTIME) || defined(PROTO)
+# if defined(HAVE_STRPTIME)
 /*
  * "strptime({format}, {timestring})" function
  */
@@ -393,7 +393,7 @@ f_strptime(typval_T *argvars, typval_T *rettv)
 }
 # endif
 
-# if defined(FEAT_TIMERS) || defined(PROTO)
+# if defined(FEAT_TIMERS)
 static timer_T	*first_timer = NULL;
 static long	last_timer_id = 0;
 
@@ -799,7 +799,7 @@ timer_valid(timer_T *timer)
     return FALSE;
 }
 
-# if defined(EXITFREE) || defined(PROTO)
+# if defined(EXITFREE)
     void
 timer_free_all(void)
 {
@@ -944,7 +944,7 @@ f_timer_stopall(typval_T *argvars UNUSED, typval_T *rettv UNUSED)
 
 # endif // FEAT_TIMERS
 
-# if defined(STARTUPTIME) || defined(PROTO)
+# if defined(STARTUPTIME)
 static struct timeval	prev_timeval;
 
 #  ifdef MSWIN
@@ -1048,7 +1048,7 @@ time_msg(
 # endif	// STARTUPTIME
 #endif // FEAT_EVAL
 
-#if defined(FEAT_SPELL) || defined(FEAT_PERSISTENT_UNDO) || defined(PROTO)
+#if defined(FEAT_SPELL) || defined(FEAT_PERSISTENT_UNDO)
 /*
  * Read 8 bytes from "fd" and turn them into a time_T, MSB first.
  * Returns -1 when encountering EOF.

--- a/src/tuple.c
+++ b/src/tuple.c
@@ -13,7 +13,7 @@
 
 #include "vim.h"
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 
 // Tuple heads for garbage collection.
 static tuple_T		*first_tuple = NULL;	// list of all tuples

--- a/src/typval.c
+++ b/src/typval.c
@@ -13,7 +13,7 @@
 
 #include "vim.h"
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 
 /*
  * Allocate memory for a variable type-value, and make it empty (0 or NULL
@@ -697,7 +697,7 @@ check_for_opt_nonnull_dict_arg(typval_T *args, int idx)
 	    || check_for_nonnull_dict_arg(args, idx) != FAIL) ? OK : FAIL;
 }
 
-#if defined(FEAT_JOB_CHANNEL) || defined(PROTO)
+#if defined(FEAT_JOB_CHANNEL)
 /*
  * Give an error and return FAIL unless "args[idx]" is a channel or a job.
  */

--- a/src/ui.c
+++ b/src/ui.c
@@ -63,7 +63,7 @@ ui_write(char_u *s, int len, int console UNUSED)
 #endif
 }
 
-#if defined(UNIX) || defined(VMS) || defined(PROTO) || defined(MSWIN)
+#if defined(UNIX) || defined(VMS) || defined(MSWIN)
 /*
  * When executing an external program, there may be some typed characters that
  * are not consumed by it.  Give them back to ui_inchar() and they are stored
@@ -248,7 +248,7 @@ theend:
     return retval;
 }
 
-#if defined(UNIX) || defined(VMS) || defined(FEAT_GUI) || defined(PROTO)
+#if defined(UNIX) || defined(VMS) || defined(FEAT_GUI)
 /*
  * Common code for mch_inchar() and gui_inchar(): Wait for a while or
  * indefinitely until characters are available, dealing with timers and
@@ -436,7 +436,7 @@ inchar_loop(
 }
 #endif
 
-#if defined(FEAT_TIMERS) || defined(PROTO)
+#if defined(FEAT_TIMERS)
 /*
  * Wait for a timer to fire or "wait_func" to return non-zero.
  * Returns OK when something was read.
@@ -578,7 +578,7 @@ ui_suspend(void)
     mch_suspend();
 }
 
-#if !defined(UNIX) || !defined(SIGTSTP) || defined(PROTO)
+#if !defined(UNIX) || !defined(SIGTSTP)
 /*
  * When the OS can't really suspend, call this function to start a shell.
  * This is never called in the GUI.
@@ -659,11 +659,10 @@ ui_new_shellsize(void)
     }
 }
 
-#if ((defined(FEAT_EVAL) || defined(FEAT_TERMINAL)) \
+#if (defined(FEAT_EVAL) || defined(FEAT_TERMINAL)) \
 	    && (defined(FEAT_GUI) \
 		|| defined(MSWIN) \
-		|| (defined(HAVE_TGETENT) && defined(FEAT_TERMRESPONSE)))) \
-	|| defined(PROTO)
+		|| (defined(HAVE_TGETENT) && defined(FEAT_TERMRESPONSE)))
 /*
  * Get the window position in pixels, if possible.
  * Return FAIL when not possible.
@@ -739,7 +738,7 @@ ui_breakcheck_force(int force)
 // For the client-server code in the console the received keys are put in the
 // input buffer.
 
-#if defined(USE_INPUT_BUF) || defined(PROTO)
+#if defined(USE_INPUT_BUF)
 
 /*
  * Internal typeahead buffer.  Includes extra space for long key code
@@ -778,7 +777,7 @@ vim_is_input_buf_empty(void)
     return (inbufcount == 0);
 }
 
-#if defined(FEAT_OLE) || defined(PROTO)
+#if defined(FEAT_OLE)
     int
 vim_free_in_input_buf(void)
 {
@@ -786,7 +785,7 @@ vim_free_in_input_buf(void)
 }
 #endif
 
-#if defined(FEAT_GUI_GTK) || defined(PROTO)
+#if defined(FEAT_GUI_GTK)
     int
 vim_used_in_input_buf(void)
 {
@@ -1083,7 +1082,7 @@ read_error_exit(void)
     preserve_exit();
 }
 
-#if defined(CURSOR_SHAPE) || defined(PROTO)
+#if defined(CURSOR_SHAPE)
 /*
  * May update the shape of the cursor.
  */
@@ -1252,7 +1251,7 @@ ui_focus_change(
 	maketitle();
 }
 
-#if defined(HAVE_INPUT_METHOD) || defined(PROTO)
+#if defined(HAVE_INPUT_METHOD)
 /*
  * Save current Input Method status to specified place.
  */

--- a/src/undo.c
+++ b/src/undo.c
@@ -138,7 +138,7 @@ static int	undo_undoes = FALSE;
 
 static int	lastmark = 0;
 
-#if defined(U_DEBUG) || defined(PROTO)
+#if defined(U_DEBUG)
 /*
  * Check the undo structures for being valid.  Print a warning when something
  * looks wrong.
@@ -760,7 +760,7 @@ nomem:
     return FAIL;
 }
 
-#if defined(FEAT_PERSISTENT_UNDO) || defined(PROTO)
+#if defined(FEAT_PERSISTENT_UNDO)
 
 # define UF_START_MAGIC	    "Vim\237UnDo\345"  // magic at start of undofile
 # define UF_START_MAGIC_LEN	9
@@ -3634,7 +3634,7 @@ curbufIsChanged(void)
     return bufIsChanged(curbuf);
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 
 /*
  * For undotree(): Append the list of undo blocks at "first_uhp" to "list".

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -13,7 +13,7 @@
 
 #include "vim.h"
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * All user-defined functions are found in this hashtable.
  */
@@ -740,7 +740,7 @@ alloc_ufunc(char_u *name, size_t namelen)
     return fp;
 }
 
-#if defined(FEAT_LUA) || defined(PROTO)
+#if defined(FEAT_LUA)
 /*
  * Registers a native C callback which can be called from Vim script.
  * Returns the name of the Vim script function.
@@ -3592,7 +3592,7 @@ delete_script_functions(int sid)
     }
 }
 
-#if defined(EXITFREE) || defined(PROTO)
+#if defined(EXITFREE)
     void
 free_all_functions(void)
 {
@@ -6095,7 +6095,7 @@ function_exists(char_u *name, int no_deref)
     return n;
 }
 
-#if defined(FEAT_PYTHON) || defined(FEAT_PYTHON3) || defined(PROTO)
+#if defined(FEAT_PYTHON) || defined(FEAT_PYTHON3)
     char_u *
 get_expanded_name(char_u *name, int check)
 {

--- a/src/version.c
+++ b/src/version.c
@@ -28,8 +28,8 @@
 char		*Version = VIM_VERSION_SHORT;
 static char	*mediumVersion = VIM_VERSION_MEDIUM;
 
-#if defined(HAVE_DATE_TIME) || defined(PROTO)
-# if (defined(VMS) && defined(VAXC)) || defined(PROTO)
+#if defined(HAVE_DATE_TIME)
+# if defined(VMS) && defined(VAXC)
 char	longVersion[sizeof(VIM_VERSION_LONG_DATE) + sizeof(__DATE__)
 						      + sizeof(__TIME__) + 3];
 
@@ -4427,7 +4427,7 @@ highest_patch(void)
     return included_patches[0];
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Return TRUE if patch "n" has been included.
  */

--- a/src/vim.h
+++ b/src/vim.h
@@ -17,7 +17,7 @@
 # define MSWIN
 #endif
 
-#if defined(MSWIN) && !defined(PROTO)
+#if defined(MSWIN)
 # include <io.h>
 #endif
 

--- a/src/vim.h
+++ b/src/vim.h
@@ -272,9 +272,11 @@
 # include <clib/exec_protos.h>
 #endif
 
-#ifdef __HAIKU__
-# include "os_haiku.h"
-# define __ARGS(x)  x
+#ifndef PROTO
+# ifdef __HAIKU__
+#  include "os_haiku.h"
+#  define __ARGS(x)  x
+# endif
 #endif
 
 #if (defined(UNIX) || defined(VMS)) \
@@ -313,25 +315,27 @@
 // cause compilation failures even though the headers are correct.  For
 // a concrete example, gcc-3.2 enforces exception specifications, and
 // glibc-2.2.5 has them in their system headers.
-#if !defined(__cplusplus) && defined(UNIX) \
+#ifndef PROTO
+# if !defined(__cplusplus) && defined(UNIX) \
 	&& !defined(MACOS_X) // MACOS_X doesn't yet support osdef.h
-# include "auto/osdef.h"	// bring missing declarations in
-#endif
+#  include "auto/osdef.h"	// bring missing declarations in
+# endif
 
-#ifdef AMIGA
-# include "os_amiga.h"
-#endif
+# ifdef AMIGA
+#  include "os_amiga.h"
+# endif
 
-#ifdef MSWIN
-# include "os_win32.h"
-#endif
+# ifdef MSWIN
+#  include "os_win32.h"
+# endif
 
-#if defined(MACOS_X)
-# include "os_mac.h"
-#endif
+# if defined(MACOS_X)
+#  include "os_mac.h"
+# endif
 
-#ifdef __QNX__
-# include "os_qnx.h"
+# ifdef __QNX__
+#  include "os_qnx.h"
+# endif
 #endif
 
 #ifdef X_LOCALE
@@ -437,11 +441,7 @@ typedef __int64 off_T;
 #  define vim_ftell _ftelli64
 # endif
 #else
-# ifdef PROTO
-typedef long off_T;
-# else
 typedef off_t off_T;
-# endif
 # ifdef HAVE_FSEEKO
 #  define vim_lseek lseek
 #  define vim_ftell ftello
@@ -2030,15 +2030,11 @@ typedef enum {
  * bits elsewhere.  That causes memory corruption.  Define time_T and use it
  * for global variables to avoid that.
  */
-#ifdef PROTO
-typedef long  time_T;
-#else
 # ifdef MSWIN
 typedef __time64_t  time_T;
 # else
 typedef time_t	    time_T;
 # endif
-#endif
 
 #ifdef _WIN64
 typedef __int64 sock_T;
@@ -3004,9 +3000,6 @@ long elapsed(struct timeval *start_tv);
 # define ELAPSED_TICKCOUNT
 # define ELAPSED_INIT(v) v = GetTickCount()
 # define ELAPSED_FUNC(v) elapsed(v)
-# ifdef PROTO
-typedef int DWORD;
-# endif
 typedef DWORD elapsed_T;
 # ifndef PROTO
 long elapsed(DWORD start_tick);

--- a/src/vim9class.c
+++ b/src/vim9class.c
@@ -14,7 +14,7 @@
 #define USING_FLOAT_STUFF
 #include "vim.h"
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 
 static class_T *first_class = NULL;
 static class_T *next_nonref_class = NULL;

--- a/src/vim9class.c
+++ b/src/vim9class.c
@@ -16,11 +16,6 @@
 
 #if defined(FEAT_EVAL) || defined(PROTO)
 
-// When not generating protos this is included in proto.h
-#ifdef PROTO
-# include "vim9.h"
-#endif
-
 static class_T *first_class = NULL;
 static class_T *next_nonref_class = NULL;
 

--- a/src/vim9cmds.c
+++ b/src/vim9cmds.c
@@ -14,7 +14,7 @@
 #define USING_FLOAT_STUFF
 #include "vim.h"
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 
 /*
  * Get the index of the current instruction.
@@ -2636,7 +2636,7 @@ compile_redir(char_u *line, exarg_T *eap, cctx_T *cctx)
     return compile_exec(line, eap, cctx);
 }
 
-#if defined(FEAT_QUICKFIX) || defined(PROTO)
+#if defined(FEAT_QUICKFIX)
     char_u *
 compile_cexpr(char_u *line, exarg_T *eap, cctx_T *cctx)
 {

--- a/src/vim9cmds.c
+++ b/src/vim9cmds.c
@@ -16,11 +16,6 @@
 
 #if defined(FEAT_EVAL) || defined(PROTO)
 
-// When not generating protos this is included in proto.h
-#ifdef PROTO
-# include "vim9.h"
-#endif
-
 /*
  * Get the index of the current instruction.
  * This compensates for a preceding ISN_CMDMOD and ISN_PROF_START.

--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -16,11 +16,6 @@
 
 #if defined(FEAT_EVAL) || defined(PROTO)
 
-// When not generating protos this is included in proto.h
-#ifdef PROTO
-# include "vim9.h"
-#endif
-
 // Functions defined with :def are stored in this growarray.
 // They are never removed, so that they can be found by index.
 // Deleted functions have the df_deleted flag set.

--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -14,7 +14,7 @@
 #define USING_FLOAT_STUFF
 #include "vim.h"
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 
 // Functions defined with :def are stored in this growarray.
 // They are never removed, so that they can be found by index.
@@ -5232,7 +5232,7 @@ link_def_function(ufunc_T *ufunc)
     ++dfunc->df_refcount;
 }
 
-#if defined(EXITFREE) || defined(PROTO)
+#if defined(EXITFREE)
 /*
  * Free all functions defined with ":def".
  */

--- a/src/vim9execute.c
+++ b/src/vim9execute.c
@@ -14,7 +14,7 @@
 #define USING_FLOAT_STUFF
 #include "vim.h"
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 
 // Structure put on ec_trystack when ISN_TRY is encountered.
 typedef struct {

--- a/src/vim9execute.c
+++ b/src/vim9execute.c
@@ -16,12 +16,6 @@
 
 #if defined(FEAT_EVAL) || defined(PROTO)
 
-// When not generating protos this is included in proto.h
-#ifdef PROTO
-# include "vim9.h"
-#endif
-
-
 // Structure put on ec_trystack when ISN_TRY is encountered.
 typedef struct {
     int	    tcd_frame_idx;	// ec_frame_idx at ISN_TRY

--- a/src/vim9expr.c
+++ b/src/vim9expr.c
@@ -14,7 +14,7 @@
 #define USING_FLOAT_STUFF
 #include "vim.h"
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 
 // flag passed from compile_subscript() to compile_load_scriptvar()
 static int paren_follows_after_expr = 0;

--- a/src/vim9expr.c
+++ b/src/vim9expr.c
@@ -16,11 +16,6 @@
 
 #if defined(FEAT_EVAL) || defined(PROTO)
 
-// When not generating protos this is included in proto.h
-#ifdef PROTO
-# include "vim9.h"
-#endif
-
 // flag passed from compile_subscript() to compile_load_scriptvar()
 static int paren_follows_after_expr = 0;
 

--- a/src/vim9generics.c
+++ b/src/vim9generics.c
@@ -13,7 +13,7 @@
 
 #include "vim.h"
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 
 
 /*

--- a/src/vim9instr.c
+++ b/src/vim9instr.c
@@ -16,12 +16,6 @@
 
 #if defined(FEAT_EVAL) || defined(PROTO)
 
-// When not generating protos this is included in proto.h
-#ifdef PROTO
-# include "vim9.h"
-#endif
-
-
 /////////////////////////////////////////////////////////////////////
 // Following generate_ functions expect the caller to call ga_grow().
 

--- a/src/vim9instr.c
+++ b/src/vim9instr.c
@@ -14,7 +14,7 @@
 #define USING_FLOAT_STUFF
 #include "vim.h"
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 
 /////////////////////////////////////////////////////////////////////
 // Following generate_ functions expect the caller to call ga_grow().
@@ -2632,7 +2632,7 @@ generate_SCRIPTCTX_SET(cctx_T *cctx, sctx_T new_sctx)
     return OK;
 }
 
-#if defined(FEAT_PROFILE) || defined(PROTO)
+#if defined(FEAT_PROFILE)
     void
 may_generate_prof_end(cctx_T *cctx, int prof_lnum)
 {

--- a/src/vim9script.c
+++ b/src/vim9script.c
@@ -28,7 +28,7 @@ in_vim9script(void)
 		&& !(cmdmod.cmod_flags & CMOD_LEGACY);
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Return TRUE when currently in a script with script version smaller than
  * "max_version" or command modifiers forced it.
@@ -141,7 +141,7 @@ ex_vim9script(exarg_T *eap UNUSED)
 #endif
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * When in Vim9 script give an error and return FAIL.
  */
@@ -205,7 +205,7 @@ vim9_comment_start(char_u *p)
 #endif
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 
 /*
  * "++nr" and "--nr" commands.

--- a/src/vim9script.c
+++ b/src/vim9script.c
@@ -13,11 +13,6 @@
 
 #include "vim.h"
 
-// When not generating protos this is included in proto.h
-#ifdef PROTO
-# include "vim9.h"
-#endif
-
 /*
  * Return TRUE when currently using Vim9 script syntax.
  * Does not go up the stack, a ":function" inside vim9script uses legacy

--- a/src/vim9type.c
+++ b/src/vim9type.c
@@ -20,11 +20,6 @@
 # include <float.h>
 #endif
 
-// When not generating protos this is included in proto.h
-#ifdef PROTO
-# include "vim9.h"
-#endif
-
 /*
  * Allocate memory for a type_T and add the pointer to type_gap, so that it can
  * be easily freed later.

--- a/src/vim9type.c
+++ b/src/vim9type.c
@@ -14,7 +14,7 @@
 #define USING_FLOAT_STUFF
 #include "vim.h"
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 
 #ifdef VMS
 # include <float.h>

--- a/src/viminfo.c
+++ b/src/viminfo.c
@@ -41,7 +41,7 @@ typedef struct {
     int		bv_allocated;	// bv_string was allocated
 } bval_T;
 
-#if defined(FEAT_VIMINFO) || defined(PROTO)
+#if defined(FEAT_VIMINFO)
 
 static int  viminfo_errcnt;
 
@@ -1242,7 +1242,7 @@ viminfo_encoding(vir_T *virp)
     return viminfo_readline(virp);
 }
 
-#if defined(FEAT_EVAL) || defined(PROTO)
+#if defined(FEAT_EVAL)
 /*
  * Restore global vars that start with a capital from the viminfo file
  */

--- a/src/wayland.c
+++ b/src/wayland.c
@@ -748,7 +748,7 @@ wayland_update(void)
     return vwl_connection_roundtrip(wayland_ct);
 }
 
-#if !defined(HAVE_SELECT) || defined(PROTO)
+#if !defined(HAVE_SELECT)
 
     void
 wayland_poll_check(int revents)
@@ -777,7 +777,7 @@ wayland_poll_check(int revents)
 }
 
 #endif
-#if defined(HAVE_SELECT) || defined(PROTO)
+#if defined(HAVE_SELECT)
 
     void
 wayland_select_check(bool is_set)
@@ -862,7 +862,7 @@ ex_wlrestore(exarg_T *eap)
     choose_clipmethod();
 }
 
-#if defined(FEAT_WAYLAND_CLIPBOARD) || defined(PROTO)
+#if defined(FEAT_WAYLAND_CLIPBOARD)
 
 /*
  * Get a suitable data device manager from connection. "supported" should be

--- a/src/winclip.c
+++ b/src/winclip.c
@@ -27,22 +27,6 @@
 #endif
 
 /*
- * When generating prototypes for Win32 on Unix, these lines make the syntax
- * errors disappear.  They do not need to be correct.
- */
-#ifdef PROTO
-#define WINAPI
-#define WINBASEAPI
-typedef int DWORD;
-typedef int LPBOOL;
-typedef int LPCSTR;
-typedef int LPCWSTR;
-typedef int LPSTR;
-typedef int LPWSTR;
-typedef int UINT;
-#endif
-
-/*
  * Convert an UTF-8 string to UTF-16.
  * "instr[inlen]" is the input.  "inlen" is in bytes.
  * When "outstr" is NULL only return the number of UTF-16 words produced.

--- a/src/window.c
+++ b/src/window.c
@@ -2415,7 +2415,7 @@ win_equal_rec(
     }
 }
 
-#if defined(FEAT_JOB_CHANNEL) || defined(PROTO)
+#if defined(FEAT_JOB_CHANNEL)
     void
 leaving_window(win_T *win)
 {
@@ -3512,7 +3512,7 @@ win_free_mem(
     return wp;
 }
 
-#if defined(EXITFREE) || defined(PROTO)
+#if defined(EXITFREE)
     void
 win_free_all(void)
 {
@@ -5340,7 +5340,7 @@ win_goto(win_T *wp)
 #endif
 }
 
-#if defined(FEAT_PERL) || defined(PROTO)
+#if defined(FEAT_PERL)
 /*
  * Find window number "winnr" (counting top to bottom).
  */
@@ -5356,7 +5356,7 @@ win_find_nr(int winnr)
 }
 #endif
 
-#if ((defined(FEAT_PYTHON) || defined(FEAT_PYTHON3))) || defined(PROTO)
+#if defined(FEAT_PYTHON) || defined(FEAT_PYTHON3)
 /*
  * Find the tabpage for window "win".
  */
@@ -6038,7 +6038,7 @@ win_unlisted(win_T *wp)
     return is_aucmd_win(wp) || WIN_IS_POPUP(wp);
 }
 
-#if defined(FEAT_PROP_POPUP) || defined(PROTO)
+#if defined(FEAT_PROP_POPUP)
 /*
  * Free a popup window.  This does not take the window out of the window list
  * and assumes there is only one toplevel frame, no split.
@@ -7913,7 +7913,7 @@ restore_snapshot_rec(frame_T *sn, frame_T *fr)
     return wp;
 }
 
-#if defined(FEAT_GUI) || defined(PROTO)
+#if defined(FEAT_GUI)
 /*
  * Return TRUE if there is any vertically split window.
  */
@@ -7934,7 +7934,7 @@ win_hasvertsplit(void)
 }
 #endif
 
-#if defined(FEAT_PYTHON) || defined(FEAT_PYTHON3) || defined(PROTO)
+#if defined(FEAT_PYTHON) || defined(FEAT_PYTHON3)
     int
 get_win_number(win_T *wp, win_T *first_win)
 {
@@ -8004,7 +8004,7 @@ frame_check_width(frame_T *topfrp, int width)
     return TRUE;
 }
 
-#if defined(FEAT_SYN_HL) || defined(PROTO)
+#if defined(FEAT_SYN_HL)
 /*
  * Simple int comparison function for use with qsort()
  */


### PR DESCRIPTION
Instead of `cproto`, use `clang.cindex` from Python to create prototype declaration files (.pro) from source code.

I'm working on Ubuntu 24.04.

```bash
$ sudo apt install python3-clang
```