### PR TITLE
fix build failure when FEAT_DIFF is not defined

### DIFF
--- a/src/proto.h
+++ b/src/proto.h
@@ -73,9 +73,7 @@ extern int _stricoll(char *a, char *b);
 # include "if_cscope.pro"
 # include "debugger.pro"
 # include "dict.pro"
-# ifdef FEAT_DIFF
 # include "diff.pro"
-# endif
 # include "linematch.pro"
 # include "digraph.pro"
 # include "drawline.pro"

--- a/src/structs.h
+++ b/src/structs.h
@@ -3671,6 +3671,9 @@ struct diffline_S
     int bufidx;
     int lineoff;
 };
+#else  // FEAT_DIFF
+typedef void diffline_T;
+typedef void diffline_change_T;
 #endif
 
 #define SNAP_HELP_IDX	0


### PR DESCRIPTION
related: #18026 