### PR TITLE
runtime(doc): correct another problem in :h items()

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -1,4 +1,4 @@
-*builtin.txt*	For Vim version 9.1.  Last change: 2025 Aug 18
+*builtin.txt*	For Vim version 9.1.  Last change: 2025 Aug 19
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -6315,7 +6315,8 @@ items({expr})						*items()*
 		Each |List| item is a list with two items:
 		- for a |Dict|: the key and the value
 		- for a |List|, |Tuple| or |String|: the index and the value
-		The |List| is in arbitrary order.
+		The returned |List| is in arbitrary order for a |Dict|,
+		otherwise it's in ascending order of the index.
 
 		Also see |keys()| and |values()|.
 


### PR DESCRIPTION
The returned value is only in arbitrary order for a Dict.
