### PR TITLE
Patch 9.1.1653 remove non-native z/OS library call

### DIFF
--- a/src/version.c
+++ b/src/version.c
@@ -725,6 +725,8 @@ static char *(features[]) =
 static int included_patches[] =
 {   /* Add new patch number below this line */
 /**/
+    1653,
+/**/
     1652,
 /**/
     1651,

--- a/src/xxd/xxd.c
+++ b/src/xxd/xxd.c
@@ -68,6 +68,7 @@
  * 11.11.2024  improve end-of-options argument parser #9285
  * 07.12.2024  fix overflow with xxd --autoskip and large sparse files #16175
  * 15.06.2025  improve color code logic
+ * 08.19.2025  remove external library call for autoconversion on z/OS (MVS)
  *
  * (c) 1990-1998 by Juergen Weigert (jnweiger@gmail.com)
  *
@@ -1008,10 +1009,6 @@ main(int argc, char *argv[])
 	}
       rewind(fpo);
     }
-#ifdef __MVS__
-  // Disable auto-conversion on input file descriptors
-  __disableautocvt(fileno(fp));
-#endif
 
   if (revert)
     switch (hextype)


### PR DESCRIPTION
Problem: Commit 48a75f3dfb906a2d333a7b1c3545e2eb359596db introduces a call to __disableautocvt() which can only be found in a non-native z/OS library.  This requires installing the external zoslib library in order to work, which is not present on all z/OS systems

Solution: remove the call to __disableautocvt() and rely on library routines that are available to all z/OS users

See https://ibmruntimes.github.io/zoslib/zos-io_8cc.html for more details

Note: I have been applying my own personal patch to this edit since it came out since I compile vim on z/OS without the zoslib library.