### PR TITLE
small refactoring of `Make_mvc.mak` files

### DIFF
--- a/Filelist
+++ b/Filelist
@@ -569,6 +569,7 @@ SRC_DOS_UNIX =	\
 
 # Source files for MS Windows (also in the extra archive).
 SRC_DOS =	\
+		src/auto/nmake/tools.mak \
 		src/GvimExt/*.mak \
 		src/GvimExt/GvimExt.reg \
 		src/GvimExt/Makefile \

--- a/runtime/doc/Make_mvc.mak
+++ b/runtime/doc/Make_mvc.mak
@@ -1,32 +1,26 @@
 #
 # Makefile for the Vim documentation on Windows
 #
-# 20.03.24, Restorer, <restorer@mail2k.ru>
+# 2024-03-20, Restorer, <restorer@mail2k.ru>
+#
+
+# included common tools
+!INCLUDE ..\..\src\auto\nmake\tools.mak
 
 # Common components
-!INCLUDE Make_all.mak
+!INCLUDE .\Make_all.mak
 
 
 # TODO: to think about what to use instead of awk. PowerShell?
 #AWK =
 
-# Correct the following line for the where executable file vim is installed.
+# Correct the following line for the where executable file Vim is installed.
 # Please do not put the path in quotes.
 VIMPROG = ..\..\src\vim.exe
 
 # Correct the following line for the directory where iconv installed.
 # Please do not put the path in quotes.
 ICONV_PATH = D:\Programs\GetText\bin
-
-# In case some package like GnuWin32, UnixUtils
-# or something similar is installed on the system.
-# If the "touch" program is installed on the system, but it is not registered
-# in the %PATH% environment variable, then specify the full path to this file.
-!IF EXIST ("touch.exe")
-TOUCH = touch.exe %1
-!ELSE
-TOUCH = if exist %1 ( copy /b %1+,, ) else ( type nul >%1 )
-!ENDIF
 
 # In case some package like GnuWin32, UnixUtils, gettext
 # or something similar is installed on the system.
@@ -38,11 +32,6 @@ ICONV = iconv.exe
 ICONV = "$(ICONV_PATH)\iconv.exe"
 !ENDIF
 
-RM = del /q
-PS = PowerShell.exe
-
-PSFLAGS = -NoLogo -NoProfile -Command
-
 .SUFFIXES :
 .SUFFIXES : .c .o .txt .html
 
@@ -53,7 +42,8 @@ all : tags perlhtml $(CONVERTED)
 tags : doctags $(DOCS)
 	doctags.exe $(DOCS) | sort /L C /O tags
 	$(PS) $(PSFLAGS) \
-		(Get-Content -Raw tags ^| Get-Unique ^| %%{$$_ -replace \"`r\", \"\"}) \
+		(Get-Content -Raw tags ^| Get-Unique ^| %%{$$_ \
+		-replace \"`r\", \"\"}) \
 		^| New-Item -Path . -Name tags -ItemType file -Force
 
 doctags : doctags.c
@@ -63,7 +53,7 @@ doctags : doctags.c
 # Use Vim to generate the tags file.  Can only be used when Vim has been
 # compiled and installed.  Supports multiple languages.
 vimtags : $(DOCS)
-	@"$(VIMPROG)" --clean -esX -V1 -u doctags.vim
+	@ "$(VIMPROG)" --clean -esX -V1 -u doctags.vim
 
 # TODO:
 #html: noerrors tags $(HTMLS)
@@ -104,99 +94,96 @@ clean :
 
 
 arabic.txt :
-	<<touch.bat $@
+	@ <<touch.bat $@
 @$(TOUCH)
 <<
 
 farsi.txt :
-	<<touch.bat $@
+	@ <<touch.bat $@
 @$(TOUCH)
 <<
 
 hebrew.txt :
-	<<touch.bat $@
+	@ <<touch.bat $@
 @$(TOUCH)
 <<
 
 russian.txt :
-	<<touch.bat $@
+	@ <<touch.bat $@
 @$(TOUCH)
 <<
 
 gui_w32.txt :
-	<<touch.bat $@
+	@ <<touch.bat $@
 @$(TOUCH)
 <<
 
 if_ole.txt :
-	<<touch.bat $@
+	@ <<touch.bat $@
 @$(TOUCH)
 <<
 
 os_390.txt :
-	<<touch.bat $@
+	@ <<touch.bat $@
 @$(TOUCH)
 <<
 
 os_amiga.txt :
-	<<touch.bat $@
+	@ <<touch.bat $@
 @$(TOUCH)
 <<
 
 os_beos.txt :
-	<<touch.bat $@
+	@ <<touch.bat $@
 @$(TOUCH)
 <<
 
 os_dos.txt :
-	<<touch.bat $@
+	@ <<touch.bat $@
 @$(TOUCH)
 <<
 
 os_haiku.txt :
-	<<touch.bat $@
+	@ <<touch.bat $@
 @$(TOUCH)
 <<
 
 os_mac.txt :
-	<<touch.bat $@
+	@ <<touch.bat $@
 @$(TOUCH)
 <<
 
 os_mint.txt :
-	<<touch.bat $@
+	@ <<touch.bat $@
 @$(TOUCH)
 <<
 
 os_msdos.txt :
-	<<touch.bat $@
+	@ <<touch.bat $@
 @$(TOUCH)
 <<
 
 os_os2.txt :
-	<<touch.bat $@
+	@ <<touch.bat $@
 @$(TOUCH)
 <<
 
 os_qnx.txt :
-	<<touch.bat $@
+	@ <<touch.bat $@
 @$(TOUCH)
 <<
 
 os_risc.txt :
-	<<touch.bat $@
+	@ <<touch.bat $@
 @$(TOUCH)
 <<
 
 os_win32.txt :
-	<<touch.bat $@
+	@ <<touch.bat $@
 @$(TOUCH)
 <<
 
 convert-all : $(CONVERTED)
-!IF [$(PS) $(PSFLAGS) "exit $$psversiontable.psversion.major"] == 2
-!ERROR The program "PowerShell" version 3.0 or higher is required to work
-!ENDIF
 
 vim-da.UTF-8.1 : vim-da.1
 !IF DEFINED (ICONV)
@@ -204,8 +191,9 @@ vim-da.UTF-8.1 : vim-da.1
 !ELSE
 # Conversion to UTF-8 encoding without BOM and with UNIX-like line ending
 	$(PS) $(PSFLAGS) \
-		[IO.File]::ReadAllText(\"$?\", [Text.Encoding]::GetEncoding(28591)) ^| \
-		1>nul New-Item -Force -Path . -ItemType file -Name $@
+		[IO.File]::ReadAllText(\"$?\", \
+		[Text.Encoding]::GetEncoding(28591)) ^| \
+		1>nul New-Item -Path . -Name $@ -ItemType file -Force
 !ENDIF
 
 vimdiff-da.UTF-8.1 : vimdiff-da.1
@@ -214,8 +202,9 @@ vimdiff-da.UTF-8.1 : vimdiff-da.1
 !ELSE
 # Conversion to UTF-8 encoding without BOM and with UNIX-like line ending
 	$(PS) $(PSFLAGS) \
-		[IO.File]::ReadAllText(\"$?\", [Text.Encoding]::GetEncoding(28591)) ^| \
-		1>nul New-Item -Force -Path . -ItemType file -Name $@
+		[IO.File]::ReadAllText(\"$?\", \
+		[Text.Encoding]::GetEncoding(28591)) ^| \
+		1>nul New-Item -Path . -Name $@ -ItemType file -Force
 !ENDIF
 
 vimtutor-da.UTF-8.1 : vimtutor-da.1
@@ -224,8 +213,9 @@ vimtutor-da.UTF-8.1 : vimtutor-da.1
 !ELSE
 # Conversion to UTF-8 encoding without BOM and with UNIX-like line ending
 	$(PS) $(PSFLAGS) \
-		[IO.File]::ReadAllText(\"$?\", [Text.Encoding]::GetEncoding(28591)) ^| \
-		1>nul New-Item -Force -Path . -ItemType file -Name $@
+		[IO.File]::ReadAllText(\"$?\", \
+		[Text.Encoding]::GetEncoding(28591)) ^| \
+		1>nul New-Item -Path . -Name $@ -ItemType file -Force
 !ENDIF
 
 vim-de.UTF-8.1 : vim-de.1
@@ -234,8 +224,9 @@ vim-de.UTF-8.1 : vim-de.1
 !ELSE
 # Conversion to UTF-8 encoding without BOM and with UNIX-like line ending
 	$(PS) $(PSFLAGS) \
-		[IO.File]::ReadAllText(\"$?\", [Text.Encoding]::GetEncoding(28591)) ^| \
-		1>nul New-Item -Force -Path . -ItemType file -Name $@
+		[IO.File]::ReadAllText(\"$?\", \
+		[Text.Encoding]::GetEncoding(28591)) ^| \
+		1>nul New-Item -Path . -Name $@ -ItemType file -Force
 !ENDIF
 
 evim-fr.UTF-8.1 : evim-fr.1
@@ -244,8 +235,9 @@ evim-fr.UTF-8.1 : evim-fr.1
 !ELSE
 # Conversion to UTF-8 encoding without BOM and with UNIX-like line ending
 	$(PS) $(PSFLAGS) \
-		[IO.File]::ReadAllText(\"$?\", [Text.Encoding]::GetEncoding(28591)) ^| \
-		1>nul New-Item -Force -Path . -ItemType file -Name $@
+		[IO.File]::ReadAllText(\"$?\", \
+		[Text.Encoding]::GetEncoding(28591)) ^| \
+		1>nul New-Item -Path . -Name $@ -ItemType file -Force
 !ENDIF
 
 vim-fr.UTF-8.1 : vim-fr.1
@@ -254,8 +246,9 @@ vim-fr.UTF-8.1 : vim-fr.1
 !ELSE
 # Conversion to UTF-8 encoding without BOM and with UNIX-like line ending
 	$(PS) $(PSFLAGS) \
-		[IO.File]::ReadAllText(\"$?\", [Text.Encoding]::GetEncoding(28591)) ^| \
-		1>nul New-Item -Force -Path . -ItemType file -Name $@
+		[IO.File]::ReadAllText(\"$?\", \
+		[Text.Encoding]::GetEncoding(28591)) ^| \
+		1>nul New-Item -Path . -Name $@ -ItemType file -Force
 !ENDIF
 
 vimdiff-fr.UTF-8.1 : vimdiff-fr.1
@@ -264,8 +257,9 @@ vimdiff-fr.UTF-8.1 : vimdiff-fr.1
 !ELSE
 # Conversion to UTF-8 encoding without BOM and with UNIX-like line ending
 	$(PS) $(PSFLAGS) \
-		[IO.File]::ReadAllText(\"$?\", [Text.Encoding]::GetEncoding(28591)) ^| \
-		1>nul New-Item -Force -Path . -ItemType file -Name $@
+		[IO.File]::ReadAllText(\"$?\", \
+		[Text.Encoding]::GetEncoding(28591)) ^| \
+		1>nul New-Item -Path . -Name $@ -ItemType file -Force
 !ENDIF
 
 vimtutor-fr.UTF-8.1 : vimtutor-fr.1
@@ -274,8 +268,9 @@ vimtutor-fr.UTF-8.1 : vimtutor-fr.1
 !ELSE
 # Conversion to UTF-8 encoding without BOM and with UNIX-like line ending
 	$(PS) $(PSFLAGS) \
-		[IO.File]::ReadAllText(\"$?\", [Text.Encoding]::GetEncoding(28591)) ^| \
-		1>nul New-Item -Force -Path . -ItemType file -Name $@
+		[IO.File]::ReadAllText(\"$?\", \
+		[Text.Encoding]::GetEncoding(28591)) ^| \
+		1>nul New-Item -Path . -Name $@ -ItemType file -Force
 !ENDIF
 
 xxd-fr.UTF-8.1 : xxd-fr.1
@@ -284,8 +279,9 @@ xxd-fr.UTF-8.1 : xxd-fr.1
 !ELSE
 # Conversion to UTF-8 encoding without BOM and with UNIX-like line ending
 	$(PS) $(PSFLAGS) \
-		[IO.File]::ReadAllText(\"$?\", [Text.Encoding]::GetEncoding(28591)) ^| \
-		1>nul New-Item -Force -Path . -ItemType file -Name $@
+		[IO.File]::ReadAllText(\"$?\", \
+		[Text.Encoding]::GetEncoding(28591)) ^| \
+		1>nul New-Item -Path . -Name $@ -ItemType file -Force
 !ENDIF
 
 evim-it.UTF-8.1 : evim-it.1
@@ -294,8 +290,9 @@ evim-it.UTF-8.1 : evim-it.1
 !ELSE
 # Conversion to UTF-8 encoding without BOM and with UNIX-like line ending
 	$(PS) $(PSFLAGS) \
-		[IO.File]::ReadAllText(\"$?\", [Text.Encoding]::GetEncoding(28591)) ^| \
-		1>nul New-Item -Force -Path . -ItemType file -Name $@
+		[IO.File]::ReadAllText(\"$?\", \
+		[Text.Encoding]::GetEncoding(28591)) ^| \
+		1>nul New-Item -Path . -Name $@ -ItemType file -Force
 !ENDIF
 
 vim-it.UTF-8.1 : vim-it.1
@@ -304,8 +301,9 @@ vim-it.UTF-8.1 : vim-it.1
 !ELSE
 # Conversion to UTF-8 encoding without BOM and with UNIX-like line ending
 	$(PS) $(PSFLAGS) \
-		[IO.File]::ReadAllText(\"$?\", [Text.Encoding]::GetEncoding(28591)) ^| \
-		1>nul New-Item -Force -Path . -ItemType file -Name $@
+		[IO.File]::ReadAllText(\"$?\", \
+		[Text.Encoding]::GetEncoding(28591)) ^| \
+		1>nul New-Item -Path . -Name $@ -ItemType file -Force
 !ENDIF
 
 vimdiff-it.UTF-8.1 : vimdiff-it.1
@@ -314,8 +312,9 @@ vimdiff-it.UTF-8.1 : vimdiff-it.1
 !ELSE
 # Conversion to UTF-8 encoding without BOM and with UNIX-like line ending
 	$(PS) $(PSFLAGS) \
-		[IO.File]::ReadAllText(\"$?\", [Text.Encoding]::GetEncoding(28591)) ^| \
-		1>nul New-Item -Force -Path . -ItemType file -Name $@
+		[IO.File]::ReadAllText(\"$?\", \
+		[Text.Encoding]::GetEncoding(28591)) ^| \
+		1>nul New-Item -Path . -Name $@ -ItemType file -Force
 !ENDIF
 
 vimtutor-it.UTF-8.1 : vimtutor-it.1
@@ -324,8 +323,9 @@ vimtutor-it.UTF-8.1 : vimtutor-it.1
 !ELSE
 # Conversion to UTF-8 encoding without BOM and with UNIX-like line ending
 	$(PS) $(PSFLAGS) \
-		[IO.File]::ReadAllText(\"$?\", [Text.Encoding]::GetEncoding(28591)) ^| \
-		1>nul New-Item -Force -Path . -ItemType file -Name $@
+		[IO.File]::ReadAllText(\"$?\", \
+		[Text.Encoding]::GetEncoding(28591)) ^| \
+		1>nul New-Item -Path . -Name $@ -ItemType file -Force
 !ENDIF
 
 xxd-it.UTF-8.1 : xxd-it.1
@@ -334,8 +334,9 @@ xxd-it.UTF-8.1 : xxd-it.1
 !ELSE
 # Conversion to UTF-8 encoding without BOM and with UNIX-like line ending
 	$(PS) $(PSFLAGS) \
-		[IO.File]::ReadAllText(\"$?\", [Text.Encoding]::GetEncoding(28591)) ^| \
-		1>nul New-Item -Force -Path . -ItemType file -Name $@
+		[IO.File]::ReadAllText(\"$?\", \
+		[Text.Encoding]::GetEncoding(28591)) ^| \
+		1>nul New-Item -Path . -Name $@ -ItemType file -Force
 !ENDIF
 
 evim-pl.UTF-8.1 : evim-pl.1
@@ -344,8 +345,9 @@ evim-pl.UTF-8.1 : evim-pl.1
 !ELSE
 # Conversion to UTF-8 encoding without BOM and with UNIX-like line ending
 	$(PS) $(PSFLAGS) \
-		[IO.File]::ReadAllText(\"$?\", [Text.Encoding]::GetEncoding(28592)) ^| \
-		1>nul New-Item -Force -Path . -ItemType file -Name $@
+		[IO.File]::ReadAllText(\"$?\", \
+		[Text.Encoding]::GetEncoding(28592)) ^| \
+		1>nul New-Item -Path . -Name $@ -ItemType file -Force
 !ENDIF
 
 vim-pl.UTF-8.1 : vim-pl.1
@@ -354,8 +356,9 @@ vim-pl.UTF-8.1 : vim-pl.1
 !ELSE
 # Conversion to UTF-8 encoding without BOM and with UNIX-like line ending
 	$(PS) $(PSFLAGS) \
-		[IO.File]::ReadAllText(\"$?\", [Text.Encoding]::GetEncoding(28592)) ^| \
-		1>nul New-Item -Force -Path . -ItemType file -Name $@
+		[IO.File]::ReadAllText(\"$?\", \
+		[Text.Encoding]::GetEncoding(28592)) ^| \
+		1>nul New-Item -Path . -Name $@ -ItemType file -Force
 !ENDIF
 
 vimdiff-pl.UTF-8.1 : vimdiff-pl.1
@@ -364,8 +367,9 @@ vimdiff-pl.UTF-8.1 : vimdiff-pl.1
 !ELSE
 # Conversion to UTF-8 encoding without BOM and with UNIX-like line ending
 	$(PS) $(PSFLAGS) \
-		[IO.File]::ReadAllText(\"$?\", [Text.Encoding]::GetEncoding(28592)) ^| \
-		1>nul New-Item -Force -Path . -ItemType file -Name $@
+		[IO.File]::ReadAllText(\"$?\", \
+		[Text.Encoding]::GetEncoding(28592)) ^| \
+		1>nul New-Item -Path . -Name $@ -ItemType file -Force
 !ENDIF
 
 vimtutor-pl.UTF-8.1 : vimtutor-pl.1
@@ -374,8 +378,9 @@ vimtutor-pl.UTF-8.1 : vimtutor-pl.1
 !ELSE
 # Conversion to UTF-8 encoding without BOM and with UNIX-like line ending
 	$(PS) $(PSFLAGS) \
-		[IO.File]::ReadAllText(\"$?\", [Text.Encoding]::GetEncoding(28592)) ^| \
-		1>nul New-Item -Force -Path . -ItemType file -Name $@
+		[IO.File]::ReadAllText(\"$?\", \
+		[Text.Encoding]::GetEncoding(28592)) ^| \
+		1>nul New-Item -Path . -Name $@ -ItemType file -Force
 !ENDIF
 
 xxd-pl.UTF-8.1 : xxd-pl.1
@@ -384,8 +389,9 @@ xxd-pl.UTF-8.1 : xxd-pl.1
 !ELSE
 # Conversion to UTF-8 encoding without BOM and with UNIX-like line ending
 	$(PS) $(PSFLAGS) \
-		[IO.File]::ReadAllText(\"$?\", [Text.Encoding]::GetEncoding(28592)) ^| \
-		1>nul New-Item -Force -Path . -ItemType file -Name $@
+		[IO.File]::ReadAllText(\"$?\", \
+		[Text.Encoding]::GetEncoding(28592)) ^| \
+		1>nul New-Item -Path . -Name $@ -ItemType file -Force
 !ENDIF
 
 evim-ru.UTF-8.1 : evim-ru.1
@@ -394,8 +400,9 @@ evim-ru.UTF-8.1 : evim-ru.1
 !ELSE
 # Conversion to UTF-8 encoding without BOM and with UNIX-like line ending
 	$(PS) $(PSFLAGS) \
-		[IO.File]::ReadAllText(\"$?\", [Text.Encoding]::GetEncoding(20866)) ^| \
-		1>nul New-Item -Force -Path . -ItemType file -Name $@
+		[IO.File]::ReadAllText(\"$?\", \
+		[Text.Encoding]::GetEncoding(20866)) ^| \
+		1>nul New-Item -Path . -Name $@ -ItemType file -Force
 !ENDIF
 
 vim-ru.UTF-8.1 : vim-ru.1
@@ -404,8 +411,9 @@ vim-ru.UTF-8.1 : vim-ru.1
 !ELSE
 # Conversion to UTF-8 encoding without BOM and with UNIX-like line ending
 	$(PS) $(PSFLAGS) \
-		[IO.File]::ReadAllText(\"$?\", [Text.Encoding]::GetEncoding(20866)) ^| \
-		1>nul New-Item -Force -Path . -ItemType file -Name $@
+		[IO.File]::ReadAllText(\"$?\", \
+		[Text.Encoding]::GetEncoding(20866)) ^| \
+		1>nul New-Item -Path . -Name $@ -ItemType file -Force
 !ENDIF
 
 vimdiff-ru.UTF-8.1 : vimdiff-ru.1
@@ -414,8 +422,9 @@ vimdiff-ru.UTF-8.1 : vimdiff-ru.1
 !ELSE
 # Conversion to UTF-8 encoding without BOM and with UNIX-like line ending
 	$(PS) $(PSFLAGS) \
-		[IO.File]::ReadAllText(\"$?\", [Text.Encoding]::GetEncoding(20866)) ^| \
-		1>nul New-Item -Force -Path . -ItemType file -Name $@
+		[IO.File]::ReadAllText(\"$?\", \
+		[Text.Encoding]::GetEncoding(20866)) ^| \
+		1>nul New-Item -Path . -Name $@ -ItemType file -Force
 !ENDIF
 
 vimtutor-ru.UTF-8.1 : vimtutor-ru.1
@@ -424,8 +433,9 @@ vimtutor-ru.UTF-8.1 : vimtutor-ru.1
 !ELSE
 # Conversion to UTF-8 encoding without BOM and with UNIX-like line ending
 	$(PS) $(PSFLAGS) \
-		[IO.File]::ReadAllText(\"$?\", [Text.Encoding]::GetEncoding(20866)) ^| \
-		1>nul New-Item -Force -Path . -ItemType file -Name $@
+		[IO.File]::ReadAllText(\"$?\", \
+		[Text.Encoding]::GetEncoding(20866)) ^| \
+		1>nul New-Item -Path . -Name $@ -ItemType file -Force
 !ENDIF
 
 xxd-ru.UTF-8.1 : xxd-ru.1
@@ -434,8 +444,9 @@ xxd-ru.UTF-8.1 : xxd-ru.1
 !ELSE
 # Conversion to UTF-8 encoding without BOM and with UNIX-like line ending
 	$(PS) $(PSFLAGS) \
-		[IO.File]::ReadAllText(\"$?\", [Text.Encoding]::GetEncoding(20866)) ^| \
-		1>nul New-Item -Force -Path . -ItemType file -Name $@
+		[IO.File]::ReadAllText(\"$?\", \
+		[Text.Encoding]::GetEncoding(20866)) ^| \
+		1>nul New-Item -Path . -Name $@ -ItemType file -Force
 !ENDIF
 
 evim-tr.UTF-8.1 : evim-tr.1
@@ -444,8 +455,9 @@ evim-tr.UTF-8.1 : evim-tr.1
 !ELSE
 # Conversion to UTF-8 encoding without BOM and with UNIX-like line ending
 	$(PS) $(PSFLAGS) \
-		[IO.File]::ReadAllText(\"$?\", [Text.Encoding]::GetEncoding(28599)) ^| \
-		1>nul New-Item -Force -Path . -ItemType file -Name $@
+		[IO.File]::ReadAllText(\"$?\", \
+		[Text.Encoding]::GetEncoding(28599)) ^| \
+		1>nul New-Item -Path . -Name $@ -ItemType file -Force
 !ENDIF
 
 vim-tr.UTF-8.1 : vim-tr.1
@@ -454,8 +466,9 @@ vim-tr.UTF-8.1 : vim-tr.1
 !ELSE
 # Conversion to UTF-8 encoding without BOM and with UNIX-like line ending
 	$(PS) $(PSFLAGS) \
-		[IO.File]::ReadAllText(\"$?\", [Text.Encoding]::GetEncoding(28599)) ^| \
-		1>nul New-Item -Force -Path . -ItemType file -Name $@
+		[IO.File]::ReadAllText(\"$?\", \
+		[Text.Encoding]::GetEncoding(28599)) ^| \
+		1>nul New-Item -Path . -Name $@ -ItemType file -Force
 !ENDIF
 
 vimdiff-tr.UTF-8.1 : vimdiff-tr.1
@@ -464,8 +477,9 @@ vimdiff-tr.UTF-8.1 : vimdiff-tr.1
 !ELSE
 # Conversion to UTF-8 encoding without BOM and with UNIX-like line ending
 	$(PS) $(PSFLAGS) \
-		[IO.File]::ReadAllText(\"$?\", [Text.Encoding]::GetEncoding(28599)) ^| \
-		1>nul New-Item -Force -Path . -ItemType file -Name $@
+		[IO.File]::ReadAllText(\"$?\", \
+		[Text.Encoding]::GetEncoding(28599)) ^| \
+		1>nul New-Item -Path . -Name $@ -ItemType file -Force
 !ENDIF
 
 vimtutor-tr.UTF-8.1 : vimtutor-tr.1
@@ -474,8 +488,9 @@ vimtutor-tr.UTF-8.1 : vimtutor-tr.1
 !ELSE
 # Conversion to UTF-8 encoding without BOM and with UNIX-like line ending
 	$(PS) $(PSFLAGS) \
-		[IO.File]::ReadAllText(\"$?\", [Text.Encoding]::GetEncoding(28599)) ^| \
-		1>nul New-Item -Force -Path . -ItemType file -Name $@
+		[IO.File]::ReadAllText(\"$?\", \
+		[Text.Encoding]::GetEncoding(28599)) ^| \
+		1>nul New-Item -Path . -Name $@ -ItemType file -Force
 !ENDIF
 
-# vim: set noet sw=8 ts=8 sts=0 wm=0 tw=0 ft=make:
+# vim: set noet sw=8 ts=8 sts=0 wm=0 tw=79 ft=make:

--- a/runtime/indent/Make_mvc.mak
+++ b/runtime/indent/Make_mvc.mak
@@ -1,10 +1,17 @@
+#
 # Makefile for running indent tests on OS Windows.
 # Made on the base of a indent/Makefile.
-# Restorer, 13.03.2024
+# 2024-03-13, Restorer
+#
+
+# included common tools
+!INCLUDE ..\..\src\auto\nmake\tools.mak
+
+LSFLAGS = /A:-D /B /O:N /L /S
 
 .SUFFIXES:
 
-VIMPROG = vim.exe
+VIMPROG = ..\..\src\vim.exe
 VIMRUNTIME = ..
 
 # Run the tests that didn't run yet or failed previously.
@@ -12,10 +19,22 @@ VIMRUNTIME = ..
 # If a test fails a testdir\*.fail file will be written.
 test :
 	@ set "VIMRUNTIME=$(VIMRUNTIME)"
-	$(VIMPROG) --clean --not-a-term -u testdir\runtest.vim
-
+	@ $(VIMPROG) --clean --not-a-term -u testdir\runtest.vim && \
+		(echo:&echo:    INDENT TESTS: DONE &echo:) || \
+		<<echofail.bat
+set "retval=%ERRORLEVEL%"
+@echo off
+echo:&echo:    INDENT TESTS: FAILED
+for /F %%G in ('2^> nul $(LS) $(LSFLAGS) testdir\*.fail') do (
+call set "fail=%%fail%% %%G")
+if defined fail (
+for %%G in (%fail%) do @(echo:&echo:    %%~nxG:&echo: && type %%G)
+)
+exit /B %retval%
+<<
 
 clean testclean :
-	@ if exist testdir\*.fail del /q testdir\*.fail
-	@ if exist testdir\*.out del /q testdir\*.out
+	@ if exist testdir\*.fail $(RM) testdir\*.fail
+	@ if exist testdir\*.out $(RM) testdir\*.out
 
+# vim: set noet sw=8 ts=8 sts=0 wm=0 tw=79 ft=make:

--- a/runtime/lang/Make_mvc.mak
+++ b/runtime/lang/Make_mvc.mak
@@ -1,14 +1,14 @@
 #
 # Makefile for converted the Vim menu files on Windows
 #
-# 08.11.23, Restorer, <restorer@mail2k.ru>
+# 2023-11-08, Restorer, <restorer@mail2k.ru>
+#
 
-!IF [powershell -nologo -noprofile "exit $$psversiontable.psversion.major"] == 2
-!ERROR The program "PowerShell" version 3.0 or higher is required to work
-!ENDIF
+# included common tools
+!INCLUDE ..\..\src\auto\nmake\tools.mak
 
 # Common components
-!INCLUDE Make_all.mak
+!INCLUDE .\Make_all.mak
 
 # Correct the following line for the directory where iconv is installed.
 # Please do not put the path in quotes.
@@ -24,17 +24,11 @@ ICONV = "iconv.exe"
 ICONV = "$(ICONV_PATH)\iconv.exe"
 !ENDIF
 
-RM = del /q
-PS = PowerShell.exe
-
-PSFLAGS = -NoLogo -NoProfile -Command
-
-
 all : $(CONVERTED)
 
-# Convert menu_zh_cn.utf-8.vim to create menu_chinese_gb.936.vim.
+# Convert menu_zh_cn.utf-8.vim to menu_chinese_gb.936.vim.
 menu_chinese_gb.936.vim : menu_zh_cn.utf-8.vim
-	-$(RM) $@
+	- $(RM) $@
 !IF DEFINED (ICONV)
 	$(ICONV) -f UTF-8 -t CP936 $? >$@
 !ELSE
@@ -46,13 +40,13 @@ menu_chinese_gb.936.vim : menu_zh_cn.utf-8.vim
 	$(PS) $(PSFLAGS) $$out = [System.IO.File]::ReadAllText(\"$@\", \
 		[System.Text.Encoding]::GetEncoding(936)) -replace \
 		'scriptencoding utf-8', 'scriptencoding cp936' -replace \
-		' Original translations', ' Generated from $?, DO NOT EDIT'; \
+		'Original translations', 'Generated from $?, DO NOT EDIT'; \
 		[System.IO.File]::WriteAllText(\"$@\", $$out, \
 		[System.Text.Encoding]::GetEncoding(936))
 
-# Convert menu_zh_tw.utf-8.vim to create menu_chinese_taiwan.950.vim.
+# Convert menu_zh_tw.utf-8.vim to menu_chinese_taiwan.950.vim.
 menu_chinese_taiwan.950.vim : menu_zh_tw.utf-8.vim
-	-$(RM) $@
+	- $(RM) $@
 !IF DEFINED (ICONV)
 	$(ICONV) -f UTF-8 -t CP950 $? >$@
 !ELSE
@@ -64,13 +58,13 @@ menu_chinese_taiwan.950.vim : menu_zh_tw.utf-8.vim
 	$(PS) $(PSFLAGS) $$out = [System.IO.File]::ReadAllText(\"$@\", \
 		[System.Text.Encoding]::GetEncoding(950)) -replace \
 		'scriptencoding utf-8', 'scriptencoding cp950' -replace \
-		' Original translations', ' Generated from $?, DO NOT EDIT'; \
+		'Original translations', 'Generated from $?, DO NOT EDIT'; \
 		[System.IO.File]::WriteAllText(\"$@\", $$out, \
 		[System.Text.Encoding]::GetEncoding(950))
 
-# Convert menu_cs_cz.utf-8.vim to create menu_cs_cz.iso_8859-2.vim.
+# Convert menu_cs_cz.utf-8.vim to menu_cs_cz.iso_8859-2.vim.
 menu_cs_cz.iso_8859-2.vim : menu_cs_cz.utf-8.vim
-	-$(RM) $@
+	- $(RM) $@
 !IF DEFINED (ICONV)
 	$(ICONV) -f UTF-8 -t ISO-8859-2 $? >$@
 !ELSE
@@ -81,15 +75,15 @@ menu_cs_cz.iso_8859-2.vim : menu_cs_cz.utf-8.vim
 !ENDIF
 	$(PS) $(PSFLAGS) $$out = [System.IO.File]::ReadAllText(\"$@\", \
 		[System.Text.Encoding]::GetEncoding(28592)) -replace \
-		' Czech \(UTF-8\)', ' Czech (ISO-8859-2)' -replace \
-		\"scriptencoding utf-8\", \"scriptencoding iso-8859-2\" -replace \
-		\" Original translations\", \" Generated from $?, DO NOT EDIT\"; \
+		'Czech \(UTF-8\)', 'Czech (ISO-8859-2)' -replace \
+		'scriptencoding utf-8', 'scriptencoding iso-8859-2' -replace \
+		'Original translations', 'Generated from $?, DO NOT EDIT'; \
 		[System.IO.File]::WriteAllText(\"$@\", $$out, \
 		[System.Text.Encoding]::GetEncoding(28592))
 
-# Convert menu_cs_cz.utf-8.vim to create menu_czech_czech_republic.1250.vim.
+# Convert menu_cs_cz.utf-8.vim to menu_czech_czech_republic.1250.vim.
 menu_czech_czech_republic.1250.vim : menu_cs_cz.utf-8.vim
-	-$(RM) $@
+	- $(RM) $@
 !IF DEFINED (ICONV)
 	$(ICONV) -f UTF-8 -t CP1250 $? >$@
 !ELSE
@@ -100,35 +94,41 @@ menu_czech_czech_republic.1250.vim : menu_cs_cz.utf-8.vim
 !ENDIF
 	$(PS) $(PSFLAGS) $$out = [System.IO.File]::ReadAllText(\"$@\", \
 		[System.Text.Encoding]::GetEncoding(1250)) -replace \
-		' Czech \(UTF-8\)', ' Czech (CP1250)' -replace \
-		\"scriptencoding utf-8\", \"scriptencoding cp1250\" -replace \
-		\" Original translations\", \" Generated from $?, DO NOT EDIT\"; \
+		'Czech \(UTF-8\)', 'Czech (CP1250)' -replace \
+		'scriptencoding utf-8', 'scriptencoding cp1250' -replace \
+		'Original translations', 'Generated from $?, DO NOT EDIT'; \
 		[System.IO.File]::WriteAllText(\"$@\", $$out, \
 		[System.Text.Encoding]::GetEncoding(1250))
 
-# Convert menu_cs_cz.utf-8.vim to create menu_czech_czech_republic.ascii.vim.
+# Convert menu_cs_cz.utf-8.vim to menu_czech_czech_republic.ascii.vim.
 menu_czech_czech_republic.ascii.vim : menu_cs_cz.utf-8.vim
-	-$(RM) $@
+	- $(RM) $@
 	$(PS) $(PSFLAGS) [System.IO.File]::ReadAllText(\"$?\", \
 		[System.Text.Encoding]::GetEncoding(65001)) -replace \
 		'scriptencoding utf-8', 'scriptencoding latin1' -replace \
-		' Original translations', ' Generated from $?, DO NOT EDIT' -replace \
-		'Czech \(UTF-8\)', 'Czech (ASCII - without diacritics)' -creplace \
-		[char]193, 'A' -creplace [char]225, 'a' -creplace [char]268, 'C' -creplace \
-		[char]269, 'c' -creplace [char]270, 'D' -creplace [char]271, 'd' -creplace \
-		[char]201, 'E' -creplace [char]233, 'e' -creplace [char]282, 'E' -creplace \
-		[char]283, 'e' -creplace [char]205, 'I' -creplace [char]237, 'i' -creplace \
-		[char]327, 'N' -creplace [char]328, 'n' -creplace [char]211, 'O' -creplace \
-		[char]243, 'o' -creplace [char]344, 'R' -creplace [char]345, 'r' -creplace \
-		[char]352, 'S' -creplace [char]353, 's' -creplace [char]356, 'T' -creplace \
-		[char]357, 't' -creplace [char]218, 'U' -creplace [char]250, 'u' -creplace \
-		[char]366, 'U' -creplace [char]367, 'u' -creplace [char]221, 'Y' -creplace \
-		[char]253, 'y' -creplace [char]381, 'Z' -creplace [char]382, 'z' ^| \
-		1>nul New-Item -Force -Path . -ItemType file -Name $@
+		'Original translations', 'Generated from $?, DO NOT EDIT' \
+		-replace 'Czech \(UTF-8\)', \
+		'Czech (ASCII - without diacritics)' \
+		-creplace [char]193, 'A' -creplace [char]225, 'a' \
+		-creplace [char]268, 'C' -creplace [char]269, 'c' \
+		-creplace [char]270, 'D' -creplace [char]271, 'd' \
+		-creplace [char]201, 'E' -creplace [char]233, 'e' \
+		-creplace [char]282, 'E' -creplace [char]283, 'e' \
+		-creplace [char]205, 'I' -creplace [char]237, 'i' \
+		-creplace [char]327, 'N' -creplace [char]328, 'n' \
+		-creplace [char]211, 'O' -creplace [char]243, 'o' \
+		-creplace [char]344, 'R' -creplace [char]345, 'r' \
+		-creplace [char]352, 'S' -creplace [char]353, 's' \
+		-creplace [char]356, 'T' -creplace [char]357, 't' \
+		-creplace [char]218, 'U' -creplace [char]250, 'u' \
+		-creplace [char]366, 'U' -creplace [char]367, 'u' \
+		-creplace [char]221, 'Y' -creplace [char]253, 'y' \
+		-creplace [char]381, 'Z' -creplace [char]382, 'z' \
+		^| 1>nul New-Item -Path . -Name $@ -ItemType file -Force
 
-# Convert menu_hu_hu.utf-8.vim to create menu_hu_hu.iso_8859-2.vim.
+# Convert menu_hu_hu.utf-8.vim to menu_hu_hu.iso_8859-2.vim.
 menu_hu_hu.iso_8859-2.vim : menu_hu_hu.utf-8.vim
-	-$(RM) $@
+	- $(RM) $@
 !IF DEFINED (ICONV)
 	$(ICONV) -f UTF-8 -t ISO-8859-2 $? >$@
 !ELSE
@@ -140,13 +140,13 @@ menu_hu_hu.iso_8859-2.vim : menu_hu_hu.utf-8.vim
 	$(PS) $(PSFLAGS) $$out = [System.IO.File]::ReadAllText(\"$@\", \
 		[System.Text.Encoding]::GetEncoding(28592)) -replace \
 		'scriptencoding utf-8', 'scriptencoding iso-8859-2' -replace \
-		' Original translations', ' Generated from $?, DO NOT EDIT'; \
+		'Original translations', 'Generated from $?, DO NOT EDIT'; \
 		[System.IO.File]::WriteAllText(\"$@\", $$out, \
 		[System.Text.Encoding]::GetEncoding(28592))
 
-# Convert menu_ja_jp.utf-8.vim to create menu_ja_jp.euc-jp.vim.
+# Convert menu_ja_jp.utf-8.vim to menu_ja_jp.euc-jp.vim.
 menu_ja_jp.euc-jp.vim : menu_ja_jp.utf-8.vim
-	-$(RM) $@
+	- $(RM) $@
 !IF DEFINED (ICONV)
 	$(ICONV) -f UTF-8 -t EUC-JP $? >$@
 !ELSE
@@ -159,13 +159,13 @@ menu_ja_jp.euc-jp.vim : menu_ja_jp.utf-8.vim
 		[System.Text.Encoding]::GetEncoding(51932)) -replace \
 		'Japanese \(UTF-8\)', 'Japanese (EUC-JP)' -replace \
 		'scriptencoding utf-8', 'scriptencoding euc-jp' -replace \
-		' Original translations', ' Generated from $?, DO NOT EDIT'; \
+		'Original translations', 'Generated from $?, DO NOT EDIT'; \
 		[System.IO.File]::WriteAllText(\"$@\", $$out, \
 		[System.Text.Encoding]::GetEncoding(51932))
 
-# Convert menu_ja_jp.utf-8.vim to create menu_japanese_japan.932.vim.
+# Convert menu_ja_jp.utf-8.vim to menu_japanese_japan.932.vim.
 menu_japanese_japan.932.vim : menu_ja_jp.utf-8.vim
-	-$(RM) $@
+	- $(RM) $@
 !IF DEFINED (ICONV)
 	$(ICONV) -f UTF-8 -t CP932 $? >$@
 !ELSE
@@ -178,13 +178,13 @@ menu_japanese_japan.932.vim : menu_ja_jp.utf-8.vim
 		[System.Text.Encoding]::GetEncoding(932)) -replace \
 		'Japanese \(UTF-8\)', 'Japanese (CP932)' -replace \
 		'scriptencoding utf-8', 'scriptencoding cp932' -replace \
-		' Original translations', ' Generated from $?, DO NOT EDIT'; \
+		'Original translations', 'Generated from $?, DO NOT EDIT'; \
 		[System.IO.File]::WriteAllText(\"$@\", $$out, \
 		[System.Text.Encoding]::GetEncoding(932))
 
-# Convert menu_ko_kr.utf-8.vim to create menu_ko_kr.euckr.vim.
+# Convert menu_ko_kr.utf-8.vim to menu_ko_kr.euckr.vim.
 menu_ko_kr.euckr.vim : menu_ko_kr.utf-8.vim
-	-$(RM) $@
+	- $(RM) $@
 !IF DEFINED (ICONV)
 	$(ICONV) -f UTF-8 -t EUC-KR $? >$@
 !ELSE
@@ -196,13 +196,13 @@ menu_ko_kr.euckr.vim : menu_ko_kr.utf-8.vim
 	$(PS) $(PSFLAGS) $$out = [System.IO.File]::ReadAllText(\"$@\", \
 		[System.Text.Encoding]::GetEncoding(51949)) -replace \
 		'scriptencoding utf-8', 'scriptencoding euc-kr' -replace \
-		' Original translations', ' Generated from $?, DO NOT EDIT'; \
+		'Original translations', 'Generated from $?, DO NOT EDIT'; \
 		[System.IO.File]::WriteAllText(\"$@\", $$out, \
 		[System.Text.Encoding]::GetEncoding(51949))
 
-# Convert menu_pl_pl.utf-8.vim to create menu_pl_pl.iso_8859-2.vim.
+# Convert menu_pl_pl.utf-8.vim to menu_pl_pl.iso_8859-2.vim.
 menu_pl_pl.iso_8859-2.vim : menu_pl_pl.utf-8.vim
-	-$(RM) $@
+	- $(RM) $@
 !IF DEFINED (ICONV)
 	$(ICONV) -f UTF-8 -t ISO-8859-2 $? >$@
 !ELSE
@@ -214,13 +214,13 @@ menu_pl_pl.iso_8859-2.vim : menu_pl_pl.utf-8.vim
 	$(PS) $(PSFLAGS) $$out = [System.IO.File]::ReadAllText(\"$@\", \
 		[System.Text.Encoding]::GetEncoding(28592)) -replace \
 		'scriptencoding utf-8', 'scriptencoding iso-8859-2' -replace \
-		' Original translations', ' Generated from $?, DO NOT EDIT'; \
+		'Original translations', 'Generated from $?, DO NOT EDIT'; \
 		[System.IO.File]::WriteAllText(\"$@\", $$out, \
 		[System.Text.Encoding]::GetEncoding(28592))
 
-# Convert menu_pl_pl.utf-8.vim to create menu_polish_poland.1250.vim.
+# Convert menu_pl_pl.utf-8.vim to menu_polish_poland.1250.vim.
 menu_polish_poland.1250.vim : menu_pl_pl.utf-8.vim
-	-$(RM) $@
+	- $(RM) $@
 !IF DEFINED (ICONV)
 	$(ICONV) -f UTF-8 -t CP1250 $? >$@
 !ELSE
@@ -232,13 +232,13 @@ menu_polish_poland.1250.vim : menu_pl_pl.utf-8.vim
 	$(PS) $(PSFLAGS) $$out = [System.IO.File]::ReadAllText(\"$@\", \
 		[System.Text.Encoding]::GetEncoding(1250)) -replace \
 		'scriptencoding utf-8', 'scriptencoding cp1250' -replace \
-		' Original translations', ' Generated from $?, DO NOT EDIT'; \
+		'Original translations', 'Generated from $?, DO NOT EDIT'; \
 		[System.IO.File]::WriteAllText(\"$@\", $$out, \
 		[System.Text.Encoding]::GetEncoding(1250))
 
-# Convert menu_ru_ru.utf-8.vim to create menu_ru_ru.cp1251.vim.
+# Convert menu_ru_ru.utf-8.vim to menu_ru_ru.cp1251.vim.
 menu_ru_ru.cp1251.vim : menu_ru_ru.utf-8.vim
-	-$(RM) $@
+	- $(RM) $@
 !IF DEFINED (ICONV)
 	$(ICONV) -f UTF-8 -t CP1251 $? >$@
 !ELSE
@@ -250,13 +250,13 @@ menu_ru_ru.cp1251.vim : menu_ru_ru.utf-8.vim
 	$(PS) $(PSFLAGS) $$out = [System.IO.File]::ReadAllText(\"$@\", \
 		[System.Text.Encoding]::GetEncoding(1251)) -replace \
 		'scriptencoding utf-8', 'scriptencoding cp1251' -replace \
-		' Original translations', ' Generated from $?, DO NOT EDIT'; \
+		'Original translations', 'Generated from $?, DO NOT EDIT'; \
 		[System.IO.File]::WriteAllText(\"$@\", $$out, \
 		[System.Text.Encoding]::GetEncoding(1251))
 
-# Convert menu_ru_ru.utf-8.vim to create menu_ru_ru.koi8-r.vim.
+# Convert menu_ru_ru.utf-8.vim to menu_ru_ru.koi8-r.vim.
 menu_ru_ru.koi8-r.vim : menu_ru_ru.utf-8.vim
-	-$(RM) $@
+	- $(RM) $@
 !IF DEFINED (ICONV)
 	$(ICONV) -f UTF-8 -t KOI8-R $? >$@
 !ELSE
@@ -268,13 +268,13 @@ menu_ru_ru.koi8-r.vim : menu_ru_ru.utf-8.vim
 	$(PS) $(PSFLAGS) $$out = [System.IO.File]::ReadAllText(\"$@\", \
 		[System.Text.Encoding]::GetEncoding(20866)) -replace \
 		'scriptencoding utf-8', 'scriptencoding koi8-r' -replace \
-		' Original translations', ' Generated from $?, DO NOT EDIT'; \
+		'Original translations', 'Generated from $?, DO NOT EDIT'; \
 		[System.IO.File]::WriteAllText(\"$@\", $$out, \
 		[System.Text.Encoding]::GetEncoding(20866))
 
-# Convert menu_slovak_slovak_republic.1250.vim to create menu_sk_sk.iso_8859-2.vim.
+# Convert menu_slovak_slovak_republic.1250.vim to menu_sk_sk.iso_8859-2.vim.
 menu_sk_sk.iso_8859-2.vim : menu_slovak_slovak_republic.1250.vim
-	-$(RM) $@
+	- $(RM) $@
 !IF DEFINED (ICONV)
 	$(ICONV) -f CP1250 -t ISO-8859-2 $? >$@
 !ELSE
@@ -286,13 +286,13 @@ menu_sk_sk.iso_8859-2.vim : menu_slovak_slovak_republic.1250.vim
 	$(PS) $(PSFLAGS) $$out = [System.IO.File]::ReadAllText(\"$@\", \
 		[System.Text.Encoding]::GetEncoding(28592)) -replace \
 		'scriptencoding cp1250', 'scriptencoding iso-8859-2' -replace \
-		' Original translations', ' Generated from $?, DO NOT EDIT'; \
+		'Original translations', 'Generated from $?, DO NOT EDIT'; \
 		[System.IO.File]::WriteAllText(\"$@\", $$out, \
 		[System.Text.Encoding]::GetEncoding(28592))
 
-# Convert menu_sl_si.utf-8.vim to create menu_sl_si.cp1250.vim.
+# Convert menu_sl_si.utf-8.vim to menu_sl_si.cp1250.vim.
 menu_sl_si.cp1250.vim : menu_sl_si.utf-8.vim
-	-$(RM) $@
+	- $(RM) $@
 !IF DEFINED (ICONV)
 	$(ICONV) -f UTF-8 -t CP1250 $? >$@
 !ELSE
@@ -304,13 +304,13 @@ menu_sl_si.cp1250.vim : menu_sl_si.utf-8.vim
 	$(PS) $(PSFLAGS) $$out = [System.IO.File]::ReadAllText(\"$@\", \
 		[System.Text.Encoding]::GetEncoding(1250)) -replace \
 		'scriptencoding utf-8', 'scriptencoding cp1250' -replace \
-		' Original translations', ' Generated from $?, DO NOT EDIT'; \
+		'Original translations', 'Generated from $?, DO NOT EDIT'; \
 		[System.IO.File]::WriteAllText(\"$@\", $$out, \
 		[System.Text.Encoding]::GetEncoding(1250))
 
-# Convert menu_sl_si.utf-8.vim to create menu_sl_si.latin2.vim.
+# Convert menu_sl_si.utf-8.vim to menu_sl_si.latin2.vim.
 menu_sl_si.latin2.vim : menu_sl_si.utf-8.vim
-	-$(RM) $@
+	- $(RM) $@
 !IF DEFINED (ICONV)
 	$(ICONV) -f UTF-8 -t ISO-8859-2 $? >$@
 !ELSE
@@ -322,71 +322,93 @@ menu_sl_si.latin2.vim : menu_sl_si.utf-8.vim
 	$(PS) $(PSFLAGS) $$out = [System.IO.File]::ReadAllText(\"$@\", \
 		[System.Text.Encoding]::GetEncoding(28592)) -replace \
 		'scriptencoding utf-8', 'scriptencoding iso-8859-2' -replace \
-		' Original translations', ' Generated from $?, DO NOT EDIT'; \
+		'Original translations', 'Generated from $?, DO NOT EDIT'; \
 		[System.IO.File]::WriteAllText(\"$@\", $$out, \
 		[System.Text.Encoding]::GetEncoding(28592))
 
-# Convert menu_sr_rs.utf-8.vim to create menu_sr_rs.ascii.vim.
+# Convert menu_sr_rs.utf-8.vim to menu_sr_rs.ascii.vim.
 menu_sr_rs.ascii.vim : menu_sr_rs.utf-8.vim
-	-$(RM) $@
+	- $(RM) $@
 	$(PS) $(PSFLAGS) [System.IO.File]::ReadAllText(\"$?\", \
 		[System.Text.Encoding]::GetEncoding(65001)) -replace \
 		'scriptencoding utf-8', 'scriptencoding latin1' -replace \
-		' Original translations', ' Generated from $?, DO NOT EDIT' -creplace \
-		[char]1072, 'a' -creplace [char]1073, 'b' -creplace [char]1074, 'v' -creplace \
-		[char]1075, 'g' -creplace [char]1076, 'd' -creplace [char]1106, 'dj' -creplace \
-		[char]1077, 'e' -creplace [char]1078, 'z' -creplace [char]1079, 'z' -creplace \
-		[char]1080, 'i' -creplace [char]1112, 'j' -creplace [char]1082, 'k' -creplace \
-		[char]1083, 'l' -creplace [char]1113, 'lj' -creplace [char]1084, 'm' -creplace \
-		[char]1085, 'n' -creplace [char]1114, 'nj' -creplace [char]1086, 'o' -creplace \
-		[char]1087, 'p' -creplace [char]1088, 'r' -creplace [char]1089, 's' -creplace \
-		[char]1090, 't' -creplace [char]1115, 'c' -creplace [char]1091, 'u' -creplace \
-		[char]1092, 'f' -creplace [char]1093, 'h' -creplace [char]1094, 'c' -creplace \
-		[char]1095, 'c' -creplace [char]1119, 'dz' -creplace [char]1096, 's' -creplace \
-		[char]1040, 'A' -creplace [char]1041, 'B' -creplace [char]1042, 'V' -creplace \
-		[char]1043, 'G' -creplace [char]1044, 'D' -creplace [char]1026, 'Đ' -creplace \
-		[char]1045, 'E' -creplace [char]1046, 'Z' -creplace [char]1047, 'Z' -creplace \
-		[char]1048, 'I' -creplace [char]1032, 'J' -creplace [char]1050, 'K' -creplace \
-		[char]1051, 'L' -creplace [char]1033, 'Lj' -creplace [char]1052, 'M' -creplace \
-		[char]1053, 'N' -creplace [char]1034, 'Nj' -creplace [char]1054, 'O' -creplace \
-		[char]1055, 'P' -creplace [char]1056, 'R' -creplace [char]1057, 'S' -creplace \
-		[char]1058, 'T' -creplace [char]1035, 'C' -creplace [char]1059, 'U' -creplace \
-		[char]1060, 'F' -creplace [char]1061, 'H' -creplace [char]1062, 'C' -creplace \
-		[char]1063, 'C' -creplace [char]1039, 'Dz' -creplace [char]1064, 'S' ^| \
-		1>nul New-Item -Force -Path . -ItemType file -Name $@
+		'Original translations', 'Generated from $?, DO NOT EDIT' \
+		-creplace [char]1072, 'a' -creplace [char]1073, 'b' \
+		-creplace [char]1074, 'v' -creplace [char]1075, 'g' \
+		-creplace [char]1076, 'd' -creplace [char]1106, 'dj' \
+		-creplace [char]1077, 'e' -creplace [char]1078, 'z' \
+		-creplace [char]1079, 'z' -creplace [char]1080, 'i' \
+		-creplace [char]1112, 'j' -creplace [char]1082, 'k' \
+		-creplace [char]1083, 'l' -creplace [char]1113, 'lj' \
+		-creplace [char]1084, 'm' -creplace [char]1085, 'n' \
+		-creplace [char]1114, 'nj' -creplace [char]1086, 'o' \
+		-creplace [char]1087, 'p' -creplace [char]1088, 'r' \
+		-creplace [char]1089, 's' -creplace [char]1090, 't' \
+		-creplace [char]1115, 'c' -creplace [char]1091, 'u' \
+		-creplace [char]1092, 'f' -creplace [char]1093, 'h' \
+		-creplace [char]1094, 'c' -creplace [char]1095, 'c' \
+		-creplace [char]1119, 'dz' -creplace [char]1096, 's' \
+		-creplace [char]1040, 'A' -creplace [char]1041, 'B' \
+		-creplace [char]1042, 'V' -creplace [char]1043, 'G' \
+		-creplace [char]1044, 'D' -creplace [char]1026, 'Đ' \
+		-creplace [char]1045, 'E' -creplace [char]1046, 'Z' \
+		-creplace [char]1047, 'Z' -creplace [char]1048, 'I' \
+		-creplace [char]1032, 'J' -creplace [char]1050, 'K' \
+		-creplace [char]1051, 'L' -creplace [char]1033, 'Lj' \
+		-creplace [char]1052, 'M' -creplace [char]1053, 'N' \
+		-creplace [char]1034, 'Nj' -creplace [char]1054, 'O' \
+		-creplace [char]1055, 'P' -creplace [char]1056, 'R' \
+		-creplace [char]1057, 'S' -creplace [char]1058, 'T' \
+		-creplace [char]1035, 'C' -creplace [char]1059, 'U' \
+		-creplace [char]1060, 'F' -creplace [char]1061, 'H' \
+		-creplace [char]1062, 'C' -creplace [char]1063, 'C' \
+		-creplace [char]1039, 'Dz' -creplace [char]1064, 'S' ^| \
+		1>nul New-Item -Path . -Name $@ -ItemType file -Force
 
-# Convert menu_sr_rs.utf-8.vim to create menu_sr_rs.iso_8859-2.vim.
+# Convert menu_sr_rs.utf-8.vim to menu_sr_rs.iso_8859-2.vim.
 menu_sr_rs.iso_8859-2.vim : menu_sr_rs.utf-8.vim
-	-$(RM) $@
+	- $(RM) $@
 	$(PS) $(PSFLAGS) $$out = [System.IO.File]::ReadAllText(\"$?\", \
-		[System.Text.Encoding]::GetEncoding(65001)) -creplace \
-		[char]1072, 'a' -creplace [char]1073, 'b' -creplace [char]1074, 'v' -creplace \
-		[char]1075, 'g' -creplace [char]1076, 'd' -creplace [char]1106, [char]273 -creplace \
-		[char]1077, 'e' -creplace [char]1078, [char]382 -creplace [char]1079, 'z' -creplace \
-		[char]1080, 'i' -creplace [char]1112, 'j' -creplace [char]1082, 'k' -creplace \
-		[char]1083, 'l' -creplace [char]1113, 'lj' -creplace [char]1084, 'm' -creplace \
-		[char]1085, 'n' -creplace [char]1114, 'nj' -creplace [char]1086, 'o' -creplace \
-		[char]1087, 'p' -creplace [char]1088, 'r' -creplace [char]1089, 's' -creplace \
-		[char]1090, 't' -creplace [char]1115, [char]263 -creplace [char]1091, 'u' -creplace \
-		[char]1092, 'f' -creplace [char]1093, 'h' -creplace [char]1094, 'c' -creplace \
-		[char]1095, [char]269 -creplace [char]1119, 'dz' -creplace [char]1096, [char]353 -creplace \
-		[char]1040, 'A' -creplace [char]1041, 'B' -creplace [char]1042, 'V' -creplace \
-		[char]1043, 'G' -creplace [char]1044, 'D' -creplace [char]1026, 'Đ' -creplace \
-		[char]1045, 'E' -creplace [char]1046, [char]381 -creplace [char]1047, 'Z' -creplace \
-		[char]1048, 'I' -creplace [char]1032, 'J' -creplace [char]1050, 'K' -creplace \
-		[char]1051, 'L' -creplace [char]1033, 'Lj'-creplace [char]1052, 'M' -creplace \
-		[char]1053, 'N' -creplace [char]1034, 'Nj' -creplace [char]1054, 'O' -creplace \
-		[char]1055, 'P' -creplace [char]1056, 'R' -creplace [char]1057, 'S' -creplace \
-		[char]1058, 'T' -creplace [char]1035, [char]262 -creplace [char]1059, 'U' -creplace \
-		[char]1060, 'F' -creplace [char]1061, 'H' -creplace [char]1062, 'C' -creplace \
-		[char]1063, [char]268 -creplace [char]1039, 'Dz' -creplace [char]1064, [char]352 -replace \
-		'scriptencoding utf-8', 'scriptencoding iso-8859-2' -replace \
-		' Original translations', ' Generated from $?, DO NOT EDIT'; \
-		[System.IO.File]::WriteAllText(\"$@\", $$out, [System.Text.Encoding]::GetEncoding(28592))
+		[System.Text.Encoding]::GetEncoding(65001)) \
+		-creplace [char]1072, 'a' -creplace [char]1073, 'b' \
+		-creplace [char]1074, 'v' -creplace [char]1075, 'g' \
+		-creplace [char]1076, 'd' -creplace [char]1106, [char]273 \
+		-creplace [char]1077, 'e' -creplace [char]1078, [char]382 \
+		-creplace [char]1079, 'z' -creplace [char]1080, 'i' \
+		-creplace [char]1112, 'j' -creplace [char]1082, 'k' \
+		-creplace [char]1083, 'l' -creplace [char]1113, 'lj' \
+		-creplace [char]1084, 'm' -creplace [char]1085, 'n' \
+		-creplace [char]1114, 'nj' -creplace [char]1086, 'o' \
+		-creplace [char]1087, 'p' -creplace [char]1088, 'r' \
+		-creplace [char]1089, 's' -creplace [char]1090, 't' \
+		-creplace [char]1115, [char]263 -creplace [char]1091, 'u' \
+		-creplace [char]1092, 'f' -creplace [char]1093, 'h' \
+		-creplace [char]1094, 'c' -creplace [char]1095, [char]269 \
+		-creplace [char]1119, 'dz' -creplace [char]1096, [char]353 \
+		-creplace [char]1040, 'A' -creplace [char]1041, 'B' \
+		-creplace [char]1042, 'V' -creplace [char]1043, 'G' \
+		-creplace [char]1044, 'D' -creplace [char]1026, 'Đ' \
+		-creplace [char]1045, 'E' -creplace [char]1046, [char]381 \
+		-creplace [char]1047, 'Z' -creplace [char]1048, 'I' \
+		-creplace [char]1032, 'J' -creplace [char]1050, 'K' \
+		-creplace [char]1051, 'L' -creplace [char]1033, 'Lj'\
+		-creplace [char]1052, 'M' -creplace [char]1053, 'N' \
+		-creplace [char]1034, 'Nj' -creplace [char]1054, 'O' \
+		-creplace [char]1055, 'P' -creplace [char]1056, 'R' \
+		-creplace [char]1057, 'S' -creplace [char]1058, 'T' \
+		-creplace [char]1035, [char]262 -creplace [char]1059, 'U' \
+		-creplace [char]1060, 'F' -creplace [char]1061, 'H' \
+		-creplace [char]1062, 'C' -creplace [char]1063, [char]268 \
+		-creplace [char]1039, 'Dz' -creplace [char]1064, [char]352 \
+		-replace 'scriptencoding utf-8', 'scriptencoding iso-8859-2' \
+		-replace \
+		'Original translations', 'Generated from $?, DO NOT EDIT'; \
+		[System.IO.File]::WriteAllText(\"$@\", $$out, \
+		[System.Text.Encoding]::GetEncoding(28592))
 
-# Convert menu_sr_rs.utf-8.vim to create menu_sr_rs.iso_8859-5.vim.
+# Convert menu_sr_rs.utf-8.vim to menu_sr_rs.iso_8859-5.vim.
 menu_sr_rs.iso_8859-5.vim : menu_sr_rs.utf-8.vim
-	-$(RM) $@
+	- $(RM) $@
 !IF DEFINED (ICONV)
 	$(ICONV) -f UTF-8 -t ISO-8859-5 $? >$@
 !ELSE
@@ -398,13 +420,13 @@ menu_sr_rs.iso_8859-5.vim : menu_sr_rs.utf-8.vim
 	$(PS) $(PSFLAGS) $$out = [System.IO.File]::ReadAllText(\"$@\", \
 		[System.Text.Encoding]::GetEncoding(28595)) -replace \
 		'scriptencoding utf-8', 'scriptencoding iso-8859-5' -replace \
-		' Original translations', ' Generated from $?, DO NOT EDIT'; \
+		'Original translations', 'Generated from $?, DO NOT EDIT'; \
 		[System.IO.File]::WriteAllText(\"$@\", $$out, \
 		[System.Text.Encoding]::GetEncoding(28595))
 
-# Convert menu_tr_tr.utf-8.vim to create menu_tr_tr.cp1254.vim.
+# Convert menu_tr_tr.utf-8.vim to menu_tr_tr.cp1254.vim.
 menu_tr_tr.cp1254.vim : menu_tr_tr.utf-8.vim
-	-$(RM) $@
+	- $(RM) $@
 !IF DEFINED (ICONV)
 	$(ICONV) -f UTF-8 -t CP1254 $? >$@
 !ELSE
@@ -416,13 +438,13 @@ menu_tr_tr.cp1254.vim : menu_tr_tr.utf-8.vim
 	$(PS) $(PSFLAGS) $$out = [System.IO.File]::ReadAllText(\"$@\", \
 		[System.Text.Encoding]::GetEncoding(1254)) -replace \
 		'scriptencoding utf-8', 'scriptencoding cp1254' -replace \
-		' Original translations', ' Generated from $?, DO NOT EDIT'; \
+		'Original translations', 'Generated from $?, DO NOT EDIT'; \
 		[System.IO.File]::WriteAllText(\"$@\", $$out, \
 		[System.Text.Encoding]::GetEncoding(1254))
 
-# Convert menu_tr_tr.utf-8.vim to create menu_tr_tr.iso_8859-9.vim.
+# Convert menu_tr_tr.utf-8.vim to menu_tr_tr.iso_8859-9.vim.
 menu_tr_tr.iso_8859-9.vim : menu_tr_tr.utf-8.vim
-	-$(RM) $@
+	- $(RM) $@
 !IF DEFINED (ICONV)
 	$(ICONV) -f UTF-8 -t ISO-8859-9 $? >$@
 !ELSE
@@ -434,13 +456,13 @@ menu_tr_tr.iso_8859-9.vim : menu_tr_tr.utf-8.vim
 	$(PS) $(PSFLAGS) $$out = [System.IO.File]::ReadAllText(\"$@\", \
 		[System.Text.Encoding]::GetEncoding(28599)) -replace \
 		'scriptencoding utf-8', 'scriptencoding iso-8859-9' -replace \
-		' Original translations', ' Generated from $?, DO NOT EDIT'; \
+		'Original translations', 'Generated from $?, DO NOT EDIT'; \
 		[System.IO.File]::WriteAllText(\"$@\", $$out, \
 		[System.Text.Encoding]::GetEncoding(28599))
 
-# Convert menu_uk_ua.utf-8.vim to create menu_uk_ua.cp1251.vim.
+# Convert menu_uk_ua.utf-8.vim to menu_uk_ua.cp1251.vim.
 menu_uk_ua.cp1251.vim : menu_uk_ua.utf-8.vim
-	-$(RM) $@
+	- $(RM) $@
 !IF DEFINED (ICONV)
 	$(ICONV) -f UTF-8 -t CP1251 $? >$@
 !ELSE
@@ -452,13 +474,13 @@ menu_uk_ua.cp1251.vim : menu_uk_ua.utf-8.vim
 	$(PS) $(PSFLAGS) $$out = [System.IO.File]::ReadAllText(\"$@\", \
 		[System.Text.Encoding]::GetEncoding(1251)) -replace \
 		'scriptencoding utf-8', 'scriptencoding cp1251' -replace \
-		' Original translations', ' Generated from $?, DO NOT EDIT'; \
+		'Original translations', 'Generated from $?, DO NOT EDIT'; \
 		[System.IO.File]::WriteAllText(\"$@\", $$out, \
 		[System.Text.Encoding]::GetEncoding(1251))
 
-# Convert menu_uk_ua.utf-8.vim to create menu_uk_ua.koi8-u.vim.
+# Convert menu_uk_ua.utf-8.vim to menu_uk_ua.koi8-u.vim.
 menu_uk_ua.koi8-u.vim : menu_uk_ua.utf-8.vim
-	-$(RM) $@
+	- $(RM) $@
 !IF DEFINED (ICONV)
 	$(ICONV) -f UTF-8 -t KOI8-U $? >$@
 !ELSE
@@ -470,11 +492,11 @@ menu_uk_ua.koi8-u.vim : menu_uk_ua.utf-8.vim
 	$(PS) $(PSFLAGS) $$out = [System.IO.File]::ReadAllText(\"$@\", \
 		[System.Text.Encoding]::GetEncoding(21866)) -replace \
 		'scriptencoding utf-8', 'scriptencoding koi8-u' -replace \
-		' Original translations', ' Generated from $?, DO NOT EDIT'; \
+		'Original translations', 'Generated from $?, DO NOT EDIT'; \
 		[System.IO.File]::WriteAllText(\"$@\", $$out, \
 		[System.Text.Encoding]::GetEncoding(21866))
 
 clean :
-	@for %%G in ($(CONVERTED)) do (if exist .\%%G ($(RM) %%G))
+	@ for %%G in ($(CONVERTED)) do @(if exist .\%%G $(RM) %%G)
 
-# vim: set noet sw=8 ts=8 sts=0 wm=0 tw=0 ft=make:
+# vim: set noet sw=8 ts=8 sts=0 wm=0 tw=79 ft=make:

--- a/src/GvimExt/Make_mvc.mak
+++ b/src/GvimExt/Make_mvc.mak
@@ -5,45 +5,48 @@
 #   			automatically from CPUNR
 #
 
+# included common tools
+!INCLUDE ..\auto\nmake\tools.mak
+
 TARGETOS = WINNT
 
-!ifndef APPVER
+!IFNDEF APPVER
 APPVER = 6.01
-!endif
+!ENDIF
 # Set the default $(WINVER) to make it work with Windows 7.
-!ifndef WINVER
+!IFNDEF WINVER
 WINVER = 0x0601
-!endif
+!ENDIF
 
-!if "$(DEBUG)" != "yes"
+!IF "$(DEBUG)" != "yes"
 NODEBUG = 1
-!endif
+!ENDIF
 
-!ifndef CPU
+!IFNDEF CPU
 CPU = i386
-! ifndef PLATFORM
-!  ifdef TARGET_CPU
+! IFNDEF PLATFORM
+!  IFDEF TARGET_CPU
 PLATFORM = $(TARGET_CPU)
-!  elseif defined(VSCMD_ARG_TGT_ARCH)
+!  ELSEIF defined(VSCMD_ARG_TGT_ARCH)
 PLATFORM = $(VSCMD_ARG_TGT_ARCH)
-!  endif
-! endif
-! ifdef PLATFORM
-!  if ("$(PLATFORM)" == "x64") || ("$(PLATFORM)" == "X64")
+!  ENDIF
+! ENDIF
+! IFDEF PLATFORM
+!  IF ("$(PLATFORM)" == "x64") || ("$(PLATFORM)" == "X64")
 CPU = AMD64
-!  elseif ("$(PLATFORM)" == "arm64") || ("$(PLATFORM)" == "ARM64")
+!  ELSEIF ("$(PLATFORM)" == "arm64") || ("$(PLATFORM)" == "ARM64")
 CPU = ARM64
-!  elseif ("$(PLATFORM)" != "x86") && ("$(PLATFORM)" != "X86")
-!   error *** ERROR Unknown target platform "$(PLATFORM)". Make aborted.
-!  endif
-! endif
-!endif
+!  ELSEIF ("$(PLATFORM)" != "x86") && ("$(PLATFORM)" != "X86")
+!   ERROR *** ERROR Unknown target platform "$(PLATFORM)". Make aborted.
+!  ENDIF
+! ENDIF
+!ENDIF
 
-!ifdef SDK_INCLUDE_DIR
-! include $(SDK_INCLUDE_DIR)\Win32.mak
-!elseif "$(USE_WIN32MAK)"=="yes"
-! include <Win32.mak>
-!else
+!IFDEF SDK_INCLUDE_DIR
+! INCLUDE $(SDK_INCLUDE_DIR)\Win32.mak
+!ELSEIF "$(USE_WIN32MAK)"=="yes"
+! INCLUDE <Win32.mak>
+!ELSE
 cc = cl
 link = link
 rc = rc
@@ -51,7 +54,7 @@ cflags = -nologo -c
 lflags = -incremental:no -nologo
 rcflags = /r
 olelibsdll = ole32.lib uuid.lib oleaut32.lib user32.lib gdi32.lib advapi32.lib
-!endif
+!ENDIF
 
 # include CPUARG
 cflags = $(cflags) $(CPUARG)
@@ -59,26 +62,27 @@ cflags = $(cflags) $(CPUARG)
 # set WINVER and _WIN32_WINNT
 cflags = $(cflags) -DWINVER=$(WINVER) -D_WIN32_WINNT=$(WINVER)
 
-!if "$(CL)" == "/D_USING_V110_SDK71_"
+!IF "$(CL)" == "/D_USING_V110_SDK71_"
 rcflags = $(rcflags) /D_USING_V110_SDK71_
-!endif
+!ENDIF
 
 SUBSYSTEM = console
-!if "$(SUBSYSTEM_VER)" != ""
+!IF "$(SUBSYSTEM_VER)" != ""
 SUBSYSTEM = $(SUBSYSTEM),$(SUBSYSTEM_VER)
-!endif
+!ENDIF
 
-!if "$(CPU)" == "AMD64" || "$(CPU)" == "ARM64"
+!IF "$(CPU)" == "AMD64" || "$(CPU)" == "ARM64"
 OFFSET = 0x11C000000
-!else
+!ELSE
 OFFSET = 0x1C000000
-!endif
+!ENDIF
 
 all: gvimext.dll
 
-gvimext.dll:    gvimext.obj	\
-		gvimext.res
-	$(link) $(lflags) -dll -def:gvimext.def -base:$(OFFSET) -out:$*.dll $** $(olelibsdll) shell32.lib comctl32.lib -subsystem:$(SUBSYSTEM)
+gvimext.dll: gvimext.obj gvimext.res
+	$(link) $(lflags) -dll -def:gvimext.def -base:$(OFFSET) \
+		-out:$*.dll $** $(olelibsdll) shell32.lib comctl32.lib \
+		-subsystem:$(SUBSYSTEM)
 
 gvimext.obj: gvimext.h
 
@@ -86,11 +90,13 @@ gvimext.obj: gvimext.h
 	$(cc) $(cflags) -DFEAT_GETTEXT $(cvarsmt) $*.cpp
 
 gvimext.res: gvimext.rc
-	$(rc) /nologo $(rcflags) $(rcvars)  gvimext.rc
+	$(rc) /nologo $(rcflags) $(rcvars) gvimext.rc
 
 clean:
-	- if exist gvimext.dll del gvimext.dll
-	- if exist gvimext.lib del gvimext.lib
-	- if exist gvimext.exp del gvimext.exp
-	- if exist gvimext.obj del gvimext.obj
-	- if exist gvimext.res del gvimext.res
+	- if exist gvimext.dll $(RM) gvimext.dll
+	- if exist gvimext.lib $(RM) gvimext.lib
+	- if exist gvimext.exp $(RM) gvimext.exp
+	- if exist gvimext.obj $(RM) gvimext.obj
+	- if exist gvimext.res $(RM) gvimext.res
+
+# vim: set noet sw=8 ts=8 sts=0 wm=0 tw=79 ft=make:

--- a/src/auto/nmake/tools.mak
+++ b/src/auto/nmake/tools.mak
@@ -1,0 +1,46 @@
+#
+# Makefile for setting up common tools used in Make_mvc.mak
+#
+# 2023-11-28, Restorer, <restorer@mail2k.ru>
+#
+
+CP = copy /Y
+LS = dir
+MKD = mkdir
+MV = move /Y
+DELTREE = rmdir /Q /S
+RD = rmdir /Q /S
+RM = del /F /Q
+MKHLNK = mklink /H
+MKDLNK = mklink /D
+MKJLNK = mklink /J
+MKSLNK = mklink
+
+PS = PowerShell.exe
+PSFLAGS = -NoLogo -NoProfile -Command
+
+!IF [$(PS) $(PSFLAGS) "exit $$psversiontable.psversion.major"] == 2
+!ERROR The PowerShell program version 3.0 or higher is required for work.
+!ENDIF
+
+!IF ![echo $(COMSPEC) | 1> nul find "cmd.exe"]
+CMD = $(COMSPEC)
+!ELSE
+CMD = $(SYSTEMROOT)\System32\cmd.exe
+!ENDIF
+CMDFLAGS = /Q /C
+CMDFLAGSEX = /V:ON /E:ON $(CMDFLAGS)
+
+# or something similar is installed on the system.
+# If the "touch" program is installed on the system, but it is not registered
+# in the %PATH% environment variable, then specify the full path to this file.
+!IF EXIST (touch.exe)
+TOUCH = touch.exe %1
+!ELSE
+TOUCH = if exist %1 (copy /b %1+,, %1) else (break> %1)
+#TOUCH = $(PS) $(PSFLAGS) if (Test-Path $$input -PathType Leaf) \
+#	{(Get-ChildItem $$input).LastWriteTime = Get-Date} else \
+#	{New-Item $$input -Type file}
+!ENDIF
+
+# vim: set noet sw=8 ts=8 sts=0 wm=0 tw=79 ft=make:

--- a/src/po/Make_mvc.mak
+++ b/src/po/Make_mvc.mak
@@ -2,21 +2,19 @@
 # (based on make_ming.mak)
 #
 # Mike Williams, <mrw@eandem.co.uk>
-# 06.01.24, Restorer, <restorer@mail2k.ru>
+# 2024-01-06, Restorer, <restorer@mail2k.ru>
 #
 # Please read README_mvc.txt before using this file.
 #
 
-!IF [powershell.exe -nologo -noprofile "exit $$psversiontable.psversion.major"] == 2
-!ERROR The program "PowerShell" version 3.0 or higher is required to work
-!ENDIF
+# included common tools
+!INCLUDE ..\auto\nmake\tools.mak
 
 !IFNDEF LANGUAGE
-! IF ![powershell.exe -NoLogo -NoProfile -Command \
-	Set-Content -Path .\_lng.tmp \
+! IF ![$(PS) $(PSFLAGS) Set-Content -Path .\_lng.tmp \
 	-Value "LANGUAGE=$$((Get-UICulture).TwoLetterISOLanguageName)"]
-!  INCLUDE _lng.tmp
-!  IF [del /q .\_lng.tmp]
+!  INCLUDE .\_lng.tmp
+!  IF [$(RM) .\_lng.tmp]
 !  ENDIF
 !  MESSAGE
 !  MESSAGE The %LANGUAGE% environment variable is not set.
@@ -29,13 +27,12 @@
 !ENDIF
 
 # Get LANGUAGES, MOFILES, MOCONVERTED and others.
-!INCLUDE Make_all.mak
+!INCLUDE .\Make_all.mak
 
 !IFNDEF VIMRUNTIME
 VIMRUNTIME = ..\..\runtime
 !ENDIF
 
-PACKAGE = vim
 # Correct the following line for the where executable file vim is
 # installed.  Please do not put the path in quotes.
 !IFNDEF VIMPROG
@@ -48,11 +45,12 @@ VIMPROG = ..\vim.exe
 GETTEXT_PATH = D:\Programs\GetText\bin
 !ENDIF
 
+INSTALLDIR = $(VIMRUNTIME)\lang\$(LANGUAGE)\LC_MESSAGES
+PACKAGE = vim
+
 # Starting from version 0.22, msgfmt forcibly converts text to UTF-8 regardless
 # of the value of the "charset" field.
-!IF [%comspec% /v:on /e:on /c "for /F "tokens=4 delims= " %G in \
-	('"$(GETTEXT_PATH)\msgfmt.exe" --version^|findstr /rc:[0-9^]\.[0-9^][0-9^]')\
-	do @(set "v=%G" && if !v:~2^,2! GEQ 22 exit /b 1)"]
+!IF ![$(GETTEXT_PATH)\msgfmt.exe --help | 1> nul find "--no-convert"]
 MSGFMT = "$(GETTEXT_PATH)\msgfmt.exe" -v --no-convert
 !ELSE
 MSGFMT = "$(GETTEXT_PATH)\msgfmt.exe" -v
@@ -70,27 +68,7 @@ ICONV = iconv.exe
 ICONV = "$(GETTEXT_PATH)\iconv.exe"
 !ENDIF
 
-# In case some package like GnuWin32, UnixUtils
-# or something similar is installed on the system.
-# If the "touch" program is installed on the system, but it is not registered
-# in the %PATH% environment variable, then specify the full path to this file.
-!IF EXIST ("touch.exe")
-TOUCH_TARGET = touch.exe $@
-!ELSE
-TOUCH_TARGET = @if exist $@ ( copy /b $@+,, ) else ( type nul >$@ )
-!ENDIF
-
-MV = move /y
-CP = copy /y
-RM = del /q
-MKD = mkdir
-LS = dir
-PS = PowerShell.exe
-
-LSFLAGS = /b /on /l /s
-PSFLAGS = -NoLogo -NoProfile -Command
-
-INSTALLDIR = $(VIMRUNTIME)\lang\$(LANGUAGE)\LC_MESSAGES
+LSFLAGS = /B /ON /L /S
 
 !IF ![$(PS) $(PSFLAGS) Set-Content -Path .\_year.tmp \
 	-Value Year=$$((Get-Date).Year)]
@@ -109,26 +87,26 @@ originals : $(MOFILES)
 converted: $(MOCONVERTED)
 
 .po.ck:
-	"$(VIMPROG)" -u NONE --noplugins -e -s -X --cmd "set enc=utf-8" \
-		-S check.vim -c "if error == 0 | q | else | num 2 | cq | endif" $<
-	$(TOUCH_TARGET)
+	"$(VIMPROG)" -u NONE --noplugins -e -s --cmd "set enc=utf-8" \
+		-S check.vim \
+		-c "if error == 0 | q | else | num 2 | cq | endif" $<
+	@ <<touch.bat $@
+$(TOUCH)
+<<
 
 check: $(CHECKFILES)
 
 checkclean:
 	$(RM) *.ck
 
-nl.po:
-	@( echo ^# >> nl.po )
-
 # Norwegian/Bokmal: "nb" is an alias for "no".
 nb.po: no.po
-	$(CP) no.po nb.po
+	$(MKHLNK) $@ $?
 
 # Convert ja.po to create ja.sjis.po.
 ja.sjis.po: ja.po
-	@$(MAKE) -nologo -f Make_mvc.mak sjiscorr
-	-$(RM) $@
+	@ $(MAKE) -nologo -f Make_mvc.mak sjiscorr
+	- $(RM) $@
 !IF DEFINED (ICONV)
 	$(ICONV) -f UTF-8 -t CP932 $? | .\sjiscorr.exe > $@
 !ELSE
@@ -136,8 +114,8 @@ ja.sjis.po: ja.po
 		[System.IO.File]::ReadAllText(\"$?\", \
 		[System.Text.Encoding]::GetEncoding(65001)), \
 		[System.Text.Encoding]::GetEncoding(932))
-	type $@ | .\sjiscorr.exe > tmp.$@
-	@$(MV) tmp.$@ $@
+	type $@ | .\sjiscorr.exe > $@.tmp
+	@ $(MV) $@.tmp $@
 !ENDIF
 	$(PS) $(PSFLAGS) $$out = [System.IO.File]::ReadAllText(\"$@\", \
 		[System.Text.Encoding]::GetEncoding(932)) \
@@ -150,7 +128,7 @@ sjiscorr: sjiscorr.c
 
 # Convert ja.po to create ja.euc-jp.po.
 ja.euc-jp.po: ja.po
-	-$(RM) $@
+	- $(RM) $@
 !IF DEFINED (ICONV)
 	$(ICONV) -f UTF-8 -t EUC-JP $? > $@
 !ELSE
@@ -161,11 +139,7 @@ ja.euc-jp.po: ja.po
 !ENDIF
 	$(PS) $(PSFLAGS) $$out = [System.IO.File]::ReadAllText(\"$@\", \
 		[System.Text.Encoding]::GetEncoding(20932)) -replace \
-		'charset=utf-8', 'charset=EUC-JP'; \
-		[System.IO.File]::WriteAllText(\"$@\", $$out, \
-		[System.Text.Encoding]::GetEncoding(20932))
-	$(PS) $(PSFLAGS) $$out = [System.IO.File]::ReadAllText(\"$@\", \
-		[System.Text.Encoding]::GetEncoding(20932)) -replace \
+		'charset=utf-8', 'charset=EUC-JP' -replace \
 		'# Original translations', \
 		'# Generated from $?, DO NOT EDIT'; \
 		[System.IO.File]::WriteAllText(\"$@\", $$out, \
@@ -173,7 +147,7 @@ ja.euc-jp.po: ja.po
 
 # Convert cs.po to create cs.cp1250.po.
 cs.cp1250.po: cs.po
-	-$(RM) $@
+	- $(RM) $@
 !IF DEFINED (ICONV)
 	$(ICONV) -f ISO-8859-2 -t CP1250 $? > $@
 !ELSE
@@ -184,11 +158,7 @@ cs.cp1250.po: cs.po
 !ENDIF
 	$(PS) $(PSFLAGS) $$out = [System.IO.File]::ReadAllText(\"$@\", \
 		[System.Text.Encoding]::GetEncoding(1250)) -replace \
-		'charset=iso-8859-2', 'charset=CP1250'; \
-		[System.IO.File]::WriteAllText(\"$@\", $$out, \
-		[System.Text.Encoding]::GetEncoding(1250))
-	$(PS) $(PSFLAGS) $$out = [System.IO.File]::ReadAllText(\"$@\", \
-		[System.Text.Encoding]::GetEncoding(1250)) -replace \
+		'charset=iso-8859-2', 'charset=CP1250' -replace \
 		'# Original translations', \
 		'# Generated from $?, DO NOT EDIT'; \
 		[System.IO.File]::WriteAllText(\"$@\", $$out, \
@@ -196,7 +166,7 @@ cs.cp1250.po: cs.po
 
 # Convert pl.po to create pl.cp1250.po.
 pl.cp1250.po: pl.po
-	-$(RM) $@
+	- $(RM) $@
 !IF DEFINED (ICONV)
 	$(ICONV) -f ISO-8859-2 -t CP1250 $? > $@
 !ELSE
@@ -207,11 +177,7 @@ pl.cp1250.po: pl.po
 !ENDIF
 	$(PS) $(PSFLAGS) $$out = [System.IO.File]::ReadAllText(\"$@\", \
 		[System.Text.Encoding]::GetEncoding(1250)) -replace \
-		'charset=iso-8859-2', 'charset=CP1250'; \
-		[System.IO.File]::WriteAllText(\"$@\", $$out, \
-		[System.Text.Encoding]::GetEncoding(1250))
-	$(PS) $(PSFLAGS) $$out = [System.IO.File]::ReadAllText(\"$@\", \
-		[System.Text.Encoding]::GetEncoding(1250)) -replace \
+		'charset=iso-8859-2', 'charset=CP1250' -replace \
 		'# Original translations', \
 		'# Generated from $?, DO NOT EDIT'; \
 		[System.IO.File]::WriteAllText(\"$@\", $$out, \
@@ -219,7 +185,7 @@ pl.cp1250.po: pl.po
 
 # Convert pl.po to create pl.UTF-8.po.
 pl.UTF-8.po: pl.po
-	-$(RM) $@
+	- $(RM) $@
 !IF DEFINED (ICONV)
 	$(ICONV) -f ISO-8859-2 -t UTF-8 $? > $@
 !ELSE
@@ -228,16 +194,14 @@ pl.UTF-8.po: pl.po
 		[System.Text.Encoding]::GetEncoding(28592)))
 !ENDIF
 	$(PS) $(PSFLAGS) (Get-Content -Raw -Encoding UTF8 $@ \
-		^| % {$$_-replace 'charset=iso-8859-2', 'charset=UTF-8'}) \
-		^| 1>nul New-Item -Force -Path . -ItemType file -Name $@
-	$(PS) $(PSFLAGS) (Get-Content -Raw -Encoding UTF8 $@ \
-		^| % {$$_-replace '# Original translations', \
+		^| % {$$_-replace 'charset=iso-8859-2', 'charset=UTF-8' \
+		-replace '# Original translations', \
 		'# Generated from $?, DO NOT EDIT'}) \
-		^| 1>nul New-Item -Force -Path . -ItemType file -Name $@
+		^| 1>nul New-Item -Path . -Name $@ -ItemType file -Force
 
 # Convert sk.po to create sk.cp1250.po.
 sk.cp1250.po: sk.po
-	-$(RM) $@
+	- $(RM) $@
 !IF DEFINED (ICONV)
 	$(ICONV) -f ISO-8859-2 -t CP1250 $? > $@
 !ELSE
@@ -248,11 +212,7 @@ sk.cp1250.po: sk.po
 !ENDIF
 	$(PS) $(PSFLAGS) $$out = [System.IO.File]::ReadAllText(\"$@\", \
 		[System.Text.Encoding]::GetEncoding(1250)) -replace \
-		'charset=iso-8859-2', 'charset=CP1250'; \
-		[System.IO.File]::WriteAllText(\"$@\", $$out, \
-		[System.Text.Encoding]::GetEncoding(1250))
-	$(PS) $(PSFLAGS) $$out = [System.IO.File]::ReadAllText(\"$@\", \
-		[System.Text.Encoding]::GetEncoding(1250)) -replace \
+		'charset=iso-8859-2', 'charset=CP1250' -replace \
 		'# Original translations', \
 		'# Generated from $?, DO NOT EDIT'; \
 		[System.IO.File]::WriteAllText(\"$@\", $$out, \
@@ -260,7 +220,7 @@ sk.cp1250.po: sk.po
 
 # Convert zh_CN.UTF-8.po to create zh_CN.po.
 zh_CN.po: zh_CN.UTF-8.po
-	-$(RM) $@
+	- $(RM) $@
 !IF DEFINED (ICONV)
 	$(ICONV) -f UTF-8 -t GB2312 $? > $@
 !ELSE
@@ -272,11 +232,7 @@ zh_CN.po: zh_CN.UTF-8.po
 !ENDIF
 	$(PS) $(PSFLAGS) $$out = [System.IO.File]::ReadAllText(\"$@\", \
 		[System.Text.Encoding]::GetEncoding(936)) -replace \
-		'charset=UTF-8', 'charset=GB2312'; \
-		[System.IO.File]::WriteAllText(\"$@\", $$out, \
-		[System.Text.Encoding]::GetEncoding(936))
-	$(PS) $(PSFLAGS) $$out = [System.IO.File]::ReadAllText(\"$@\", \
-		[System.Text.Encoding]::GetEncoding(936)) -replace \
+		'charset=UTF-8', 'charset=GB2312' -replace \
 		'# Original translations', \
 		'# Generated from $?, DO NOT EDIT'; \
 		[System.IO.File]::WriteAllText(\"$@\", $$out, \
@@ -286,7 +242,7 @@ zh_CN.po: zh_CN.UTF-8.po
 # Set 'charset' to gbk to avoid that msfmt generates a warning.
 # This used to convert from zh_CN.po, but that results in a conversion error.
 zh_CN.cp936.po: zh_CN.UTF-8.po
-	-$(RM) $@
+	- $(RM) $@
 !IF DEFINED (ICONV)
 	$(ICONV) -f UTF-8 -t CP936 $? > $@
 !ELSE
@@ -297,16 +253,16 @@ zh_CN.cp936.po: zh_CN.UTF-8.po
 
 !ENDIF
 	$(PS) $(PSFLAGS) $$out = [System.IO.File]::ReadAllText(\"$@\", \
-		[System.Text.Encoding]::GetEncoding(20936)) \
-		-replace 'charset=UTF-8', 'charset=GBK'\
-		-replace '# Original translations', \
+		[System.Text.Encoding]::GetEncoding(20936)) -replace \
+		'charset=UTF-8', 'charset=GBK' -replace \
+		'# Original translations', \
 		'# Generated from $?, DO NOT EDIT'; \
 		[System.IO.File]::WriteAllText(\"$@\", $$out, \
 		[System.Text.Encoding]::GetEncoding(20936))
 
 # Convert zh_TW.UTF-8.po to create zh_TW.po.
 zh_TW.po: zh_TW.UTF-8.po
-	-$(RM) $@
+	- $(RM) $@
 !IF DEFINED (ICONV)
 	$(ICONV) -f UTF-8 -t BIG5 $? > $@
 !ELSE
@@ -317,11 +273,7 @@ zh_TW.po: zh_TW.UTF-8.po
 !ENDIF
 	$(PS) $(PSFLAGS) $$out = [System.IO.File]::ReadAllText(\"$@\", \
 		[System.Text.Encoding]::GetEncoding(950)) -replace \
-		'charset=UTF-8', 'charset=BIG5'; \
-		[System.IO.File]::WriteAllText(\"$@\", $$out, \
-		[System.Text.Encoding]::GetEncoding(950))
-	$(PS) $(PSFLAGS) $$out = [System.IO.File]::ReadAllText(\"$@\", \
-		[System.Text.Encoding]::GetEncoding(950)) -replace \
+		'charset=UTF-8', 'charset=BIG5' -replace \
 		'# Original translations', \
 		'# Generated from $?, DO NOT EDIT'; \
 		[System.IO.File]::WriteAllText(\"$@\", $$out, \
@@ -346,7 +298,7 @@ zh_TW.po: zh_TW.UTF-8.po
 
 #zh_TW.po: zh_TW.UTF-8.po
 #	@$(MAKE) -nologo -f Make_mvc.mak big5corr
-#	-$(RM) $@
+#	- $(RM) $@
 #!IF DEFINED (ICONV)
 #	$(ICONV) -f UTF-8 -t BIG5 $? | .\big5corr.exe > $@
 #!ELSE
@@ -369,7 +321,7 @@ zh_TW.po: zh_TW.UTF-8.po
 
 # Convert ko.UTF-8.po to create ko.po.
 ko.po: ko.UTF-8.po
-	-$(RM) $@
+	- $(RM) $@
 !IF DEFINED (ICONV)
 	$(ICONV) -f UTF-8 -t EUC-KR $? > $@
 !ELSE
@@ -381,11 +333,7 @@ ko.po: ko.UTF-8.po
 !ENDIF
 	$(PS) $(PSFLAGS) $$out = [System.IO.File]::ReadAllText(\"$@\", \
 		[System.Text.Encoding]::GetEncoding(51949)) -replace \
-		'charset=UTF-8', 'charset=EUC-KR'; \
-		[System.IO.File]::WriteAllText(\"$@\", $$out, \
-		[System.Text.Encoding]::GetEncoding(51949))
-	$(PS) $(PSFLAGS) $$out = [System.IO.File]::ReadAllText(\"$@\", \
-		[System.Text.Encoding]::GetEncoding(51949)) -replace \
+		'charset=UTF-8', 'charset=EUC-KR' -replace \
 		'# Original translations', \
 		'# Generated from $?, DO NOT EDIT'; \
 		[System.IO.File]::WriteAllText(\"$@\", $$out, \
@@ -393,7 +341,7 @@ ko.po: ko.UTF-8.po
 
 # Convert ru.po to create ru.cp1251.po.
 ru.cp1251.po: ru.po
-	-$(RM) $@
+	- $(RM) $@
 !IF DEFINED (ICONV)
 	$(ICONV) -f UTF-8 -t CP1251 $? > $@
 !ELSE
@@ -404,11 +352,7 @@ ru.cp1251.po: ru.po
 !ENDIF
 	$(PS) $(PSFLAGS) $$out = [System.IO.File]::ReadAllText(\"$@\", \
 		[System.Text.Encoding]::GetEncoding(1251)) -replace \
-		'charset=UTF-8', 'charset=CP1251'; \
-		[System.IO.File]::WriteAllText(\"$@\", $$out, \
-		[System.Text.Encoding]::GetEncoding(1251))
-	$(PS) $(PSFLAGS) $$out = [System.IO.File]::ReadAllText(\"$@\", \
-		[System.Text.Encoding]::GetEncoding(1251)) -replace \
+		'charset=UTF-8', 'charset=CP1251' -replace \
 		'# Original translations', \
 		'# Generated from $?, DO NOT EDIT'; \
 		[System.IO.File]::WriteAllText(\"$@\", $$out, \
@@ -416,7 +360,7 @@ ru.cp1251.po: ru.po
 
 # Convert uk.po to create uk.cp1251.po.
 uk.cp1251.po: uk.po
-	-$(RM) $@
+	- $(RM) $@
 !IF DEFINED (ICONV)
 	$(ICONV) -f UTF-8 -t CP1251 $? > $@
 !ELSE
@@ -427,11 +371,7 @@ uk.cp1251.po: uk.po
 !ENDIF
 	$(PS) $(PSFLAGS) $$out = [System.IO.File]::ReadAllText(\"$@\", \
 		[System.Text.Encoding]::GetEncoding(1251)) -replace \
-		'charset=UTF-8', 'charset=CP1251'; \
-		[System.IO.File]::WriteAllText(\"$@\", $$out, \
-		[System.Text.Encoding]::GetEncoding(1251))
-	$(PS) $(PSFLAGS) $$out = [System.IO.File]::ReadAllText(\"$@\", \
-		[System.Text.Encoding]::GetEncoding(1251)) -replace \
+		'charset=UTF-8', 'charset=CP1251' -replace \
 		'# Original translations', \
 		'# Generated from $?, DO NOT EDIT'; \
 		[System.IO.File]::WriteAllText(\"$@\", $$out, \
@@ -458,22 +398,22 @@ files: $(PO_INPUTLIST)
 first_time: files
 	"$(VIMPROG)" -u NONE --not-a-term -S tojavascript.vim $(LANGUAGE).po \
 		$(PO_VIM_INPUTLIST)
-	@ copy /b .\files+.\vim_to_js .\allfiles
+	@ $(CP) /B .\files+.\vim_to_js .\allfiles
 	set OLD_PO_FILE_INPUT=yes
 	set OLD_PO_FILE_OUTPUT=yes
 	$(XGETTEXT) --default-domain=$(LANGUAGE) --add-comments \
 		$(XGETTEXT_KEYWORDS) --files-from=.\allfiles \
-		--copyright-holder="$(Year), The Vim Project" --package-name=Vim \
-		--msgid-bugs-address="vim-dev@vim.org"
+		--copyright-holder="$(Year), The Vim Project" \
+		--package-name=Vim --msgid-bugs-address="vim-dev@vim.org"
 	"$(VIMPROG)" -u NONE --not-a-term -S fixfilenames.vim $(LANGUAGE).po \
 		$(PO_VIM_INPUTLIST)
 	$(RM) *.js .\vim_to_js
-	@$(MAKE) -lf Make_mvc.mak clean
+	@ $(MAKE) -lf Make_mvc.mak clean
 
 $(PACKAGE).pot: files
 	"$(VIMPROG)" -u NONE --not-a-term -S tojavascript.vim $(PACKAGE).pot \
 		$(PO_VIM_INPUTLIST)
-	@ copy /b .\files+.\vim_to_js .\allfiles
+	@ $(CP) /B .\files+.\vim_to_js .\allfiles
 	set OLD_PO_FILE_INPUT=yes
 	set OLD_PO_FILE_OUTPUT=yes
 	$(XGETTEXT) --default-domain=$(PACKAGE) --output=$(PACKAGE).pot \
@@ -483,7 +423,7 @@ $(PACKAGE).pot: files
 	"$(VIMPROG)" -u NONE --not-a-term -S fixfilenames.vim $(PACKAGE).pot \
 		$(PO_VIM_INPUTLIST)
 	$(RM) *.js .\vim_to_js
-	@$(MAKE) -lf Make_mvc.mak clean
+	@ $(MAKE) -lf Make_mvc.mak clean
 
 # Only original translations with default encoding should be updated.
 # The files that are converted to a different encoding clearly state "DO NOT EDIT".
@@ -491,7 +431,7 @@ update-po: $(MOFILES:.mo=)
 
 # Don't add a dependency here, we only want to update the .po files manually.
 $(LANGUAGES):
-	@$(MAKE) -lf Make_mvc.mak GETTEXT_PATH="$(GETTEXT_PATH)" $(PACKAGE).pot
+	@ $(MAKE) -lf Make_mvc.mak "GETTEXT_PATH=$(GETTEXT_PATH)" $(PACKAGE).pot
 	$(CP) $@.po $@.po.orig
 	$(MV) $@.po $@.po.old
 	$(MSGMERGE) $@.po.old $(PACKAGE).pot -o $@.po
@@ -502,16 +442,17 @@ install: $(LANGUAGE).mo
 	$(CP) $(LANGUAGE).mo "$(INSTALLDIR)\$(PACKAGE).mo"
 
 install-all: all
-	for %%l in ($(LANGUAGES)) do @if not exist "$(VIMRUNTIME)\lang\%%l\LC_MESSAGES" \
+	for %%l in ($(LANGUAGES)) do \
+		@if not exist "$(VIMRUNTIME)\lang\%%l\LC_MESSAGES" \
 		$(MKD) "$(VIMRUNTIME)\lang\%%l\LC_MESSAGES"
 	for %%l in ($(LANGUAGES)) do @$(CP) %%l.mo \
 		"$(VIMRUNTIME)\lang\%%l\LC_MESSAGES\$(PACKAGE).mo"
 
 cleanup-po: $(LANGUAGE).po
-	"$(VIMPROG)" -u NONE -e -X -S cleanup.vim -c wq $(LANGUAGE).po
+	@ "$(VIMPROG)" -u NONE -e -s -S cleanup.vim -c wq $(LANGUAGE).po
 
 cleanup-po-all: $(POFILES)
-	!"$(VIMPROG)" -u NONE -e -X -S cleanup.vim -c wq $**
+	!@ "$(VIMPROG)" -u NONE -e -s -S cleanup.vim -c wq $**
 
 #######
 # For translations of plug-ins
@@ -544,4 +485,4 @@ clean: checkclean
 #	- $(RM) *.pot
 #	- $(RM) big5corr.obj big5corr.exe
 
-# vim: set noet sw=8 ts=8 sts=0 wm=0 tw=0 ft=make:
+# vim: set noet sw=8 ts=8 sts=0 wm=0 tw=79 ft=make:

--- a/src/tee/Make_mvc.mak
+++ b/src/tee/Make_mvc.mak
@@ -1,9 +1,12 @@
 # A very (if not the most) simplistic Makefile for MSVC
 
+# included common tools
+!INCLUDE ..\auto\nmake\tools.mak
+
 SUBSYSTEM = console
-!if "$(SUBSYSTEM_VER)" != ""
+!IF "$(SUBSYSTEM_VER)" != ""
 SUBSYSTEM = $(SUBSYSTEM),$(SUBSYSTEM_VER)
-!endif
+!ENDIF
 
 CC=cl
 CFLAGS=/O2 /nologo
@@ -15,5 +18,7 @@ tee.obj: tee.c
 	$(CC) $(CFLAGS) /c $**
 
 clean:
-	- del tee.obj
-	- del tee.exe
+	- $(RM) tee.obj
+	- $(RM) tee.exe
+
+# vim: set noet sw=8 ts=8 sts=0 wm=0 tw=79 ft=make:

--- a/src/testdir/Make_mvc.mak
+++ b/src/testdir/Make_mvc.mak
@@ -2,6 +2,10 @@
 # Makefile to run all tests for Vim, on Dos-like machines.
 #
 # Requires a set of Unix tools: echo, diff, etc.
+#
+
+# included common tools
+!INCLUDE ..\auto\nmake\tools.mak
 
 # Testing may be done with a debug build 
 !IF EXIST(..\\vimd.exe) && !EXIST(..\\vim.exe)
@@ -10,10 +14,11 @@ VIMPROG = ..\\vimd.exe
 VIMPROG = ..\\vim.exe
 !ENDIF
 
+DIFF = diff.exe
 
 default: nongui
 
-!include Make_all.mak
+!INCLUDE .\Make_all.mak
 
 # Explicit dependencies.
 test_options_all.res: opt_test.vim
@@ -37,59 +42,59 @@ tiny:	nolog tinytests report
 benchmark: $(SCRIPTS_BENCH)
 
 report:
-	@rem without the +eval feature test_result.log is a copy of test.log
-	@if exist test.log ( copy /y test.log test_result.log > nul ) \
+	@ rem without the +eval feature test_result.log is a copy of test.log
+	@ if exist test.log ( $(CP) test.log test_result.log > nul ) \
 		else ( echo No failures reported > test_result.log )
 	$(VIMPROG) -u NONE $(COMMON_ARGS) -S util\summarize.vim messages
-	-if exist starttime del starttime
-	@echo:
-	@echo Test results:
-	@cmd /c type test_result.log
-	@if exist test.log ( echo TEST FAILURE & exit /b 1 ) \
+	- if exist starttime $(RM) starttime
+	@ echo:
+	@ echo Test results:
+	@ $(CMD) /C type test_result.log
+	@ if exist test.log ( echo TEST FAILURE & exit /b 1 ) \
 		else ( echo ALL DONE )
 
 
 # Execute an individual new style test, e.g.:
 # 	nmake -f Make_mvc.mak test_largefile
 $(NEW_TESTS):
-	-if exist $@.res del $@.res
-	-if exist test.log del test.log
-	-if exist messages del messages
-	-if exist starttime del starttime
-	@$(MAKE) -nologo -f Make_mvc.mak VIMPROG=$(VIMPROG) $@.res
-	@type messages
-	@if exist test.log exit 1
+	- if exist $@.res $(RM) $@.res
+	- if exist test.log $(RM) test.log
+	- if exist messages $(RM) messages
+	- if exist starttime $(RM) starttime
+	@ $(MAKE) -lf Make_mvc.mak VIMPROG=$(VIMPROG) $@.res
+	@ type messages
+	@ if exist test.log exit 1
 
 
 # Delete files that may interfere with running tests.  This includes some files
 # that may result from working on the tests, not only from running them.
 clean:
-	-if exist *.out del *.out
-	-if exist *.failed del *.failed
-	-if exist *.res del *.res
-	-if exist $(DOSTMP) rd /s /q $(DOSTMP)
-	-if exist test.in del test.in
-	-if exist test.ok del test.ok
-	-if exist Xdir1 rd /s /q Xdir1
-	-if exist Xfind rd /s /q Xfind
-	-if exist XfakeHOME rd /s /q XfakeHOME
-	-if exist X* del X*
-	-for /d %i in (X*) do @rd /s/q %i
-	-if exist viminfo del viminfo
-	-if exist test.log del test.log
-	-if exist test_result.log del test_result.log
-	-if exist messages del messages
-	-if exist starttime del starttime
-	-if exist benchmark.out del benchmark.out
-	-if exist opt_test.vim del opt_test.vim
-	-if exist guidialog del guidialog
-	-if exist guidialogfile del guidialogfile
+	- if exist *.out $(RM) *.out
+	- if exist *.failed $(RM) *.failed
+	- if exist *.res $(RM) *.res
+	- if exist $(DOSTMP) $(RD) $(DOSTMP)
+	- if exist test.in $(RM) test.in
+	- if exist test.ok $(RM) test.ok
+	- if exist Xdir1 $(RD) Xdir1
+	- if exist Xfind $(RD) Xfind
+	- if exist XfakeHOME $(RD) XfakeHOME
+	- if exist X* $(RM) X*
+	- for /d %i in (X*) do @$(RD) %i
+	- if exist viminfo $(RM) viminfo
+	- if exist test.log $(RM) test.log
+	- if exist test_result.log $(RM) test_result.log
+	- if exist messages $(RM) messages
+	- if exist starttime $(RM) starttime
+	- if exist benchmark.out $(RM) benchmark.out
+	- if exist opt_test.vim $(RM) opt_test.vim
+	- if exist guidialog $(RM) guidialog
+	- if exist guidialogfile $(RM) guidialogfile
 
 nolog:
-	-if exist test.log del test.log
-	-if exist test_result.log del test_result.log
-	-if exist messages del messages
-	-if exist starttime del starttime
+	- if exist test.log $(RM) test.log
+	- if exist test_result.log $(RM) test_result.log
+	- if exist messages $(RM) messages
+	- if exist starttime $(RM) starttime
 
 
 # Tiny tests.  Works even without the +eval feature.
@@ -97,34 +102,34 @@ tinytests: $(SCRIPTS_TINY_OUT)
 
 # Copy the input files to dostmp, changing the fileformat to dos.
 $(DOSTMP_INFILES): $(*B).in
-	if not exist $(DOSTMP)\NUL md $(DOSTMP)
-	if exist $@ del $@
+	if not exist $(DOSTMP)\NUL $(MKD) $(DOSTMP)
+	if exist $@ $(RM) $@
 	$(VIMPROG) -u util\dos.vim $(COMMON_ARGS) "+set ff=dos|f $@|wq" $(*B).in
 
 # For each input file dostmp/test99.in run the tests.
 # This moves test99.in to test99.in.bak temporarily.
 $(TEST_OUTFILES): $(DOSTMP)\$(*B).in
-	-@if exist test.out DEL test.out
-	-@if exist $(DOSTMP)\$(*B).out DEL $(DOSTMP)\$(*B).out
-	move $(*B).in $(*B).in.bak > nul
-	copy $(DOSTMP)\$(*B).in $(*B).in > nul
-	copy $(*B).ok test.ok > nul
+	-@ if exist test.out $(RM) test.out
+	-@ if exist $(DOSTMP)\$(*B).out $(RM) $(DOSTMP)\$(*B).out
+	$(MV) $(*B).in $(*B).in.bak > nul
+	$(CP) $(DOSTMP)\$(*B).in $(*B).in > nul
+	$(CP) $(*B).ok test.ok > nul
 	$(VIMPROG) -u util\dos.vim $(COMMON_ARGS) -s dotest.in $(*B).in
-	-@if exist test.out MOVE /y test.out $(DOSTMP)\$(*B).out > nul
-	-@if exist $(*B).in.bak move /y $(*B).in.bak $(*B).in > nul
-	-@if exist test.ok del test.ok
-	-@if exist Xdir1 rd /s /q Xdir1
-	-@if exist Xfind rd /s /q Xfind
-	-@if exist XfakeHOME rd /s /q XfakeHOME
-	-@del X*
-	-@if exist viminfo del viminfo
+	-@ if exist test.out $(MV) test.out $(DOSTMP)\$(*B).out > nul
+	-@ if exist $(*B).in.bak $(MV) $(*B).in.bak $(*B).in > nul
+	-@ if exist test.ok $(RM) test.ok
+	-@ if exist Xdir1 $(RD) Xdir1
+	-@ if exist Xfind $(RD) Xfind
+	-@ if exist XfakeHOME $(RD) XfakeHOME
+	-@ $(RM) X*
+	-@ if exist viminfo $(RM) viminfo
 	$(VIMPROG) -u util\dos.vim $(COMMON_ARGS) "+set ff=unix|f test.out|wq" \
 		$(DOSTMP)\$(*B).out
-	@diff test.out $*.ok & if errorlevel 1 \
-		( move /y test.out $*.failed > nul \
-		 & del $(DOSTMP)\$(*B).out \
+	@ $(DIFF) test.out $*.ok & if errorlevel 1 \
+		( $(MV) test.out $*.failed > nul \
+		 & $(RM) $(DOSTMP)\$(*B).out \
 		 & echo $* FAILED >> test.log ) \
-		else ( move /y test.out $*.out > nul )
+		else ( $(MV) test.out $*.out > nul )
 
 
 # New style of tests uses Vim script with assert calls.  These are easier
@@ -132,32 +137,36 @@ $(TEST_OUTFILES): $(DOSTMP)\$(*B).in
 # Limitation: Only works with the +eval feature.
 
 newtests: newtestssilent
-	@if exist messages type messages
+	@ if exist messages type messages
 
 newtestssilent: $(NEW_TESTS_RES)
 
 .vim.res:
-	@echo $(VIMPROG) > vimcmd
+	@ echo $(VIMPROG) > vimcmd
 	$(VIMPROG) -u NONE $(COMMON_ARGS) -S runtest.vim $*.vim
-	@del vimcmd
+	@ $(RM) vimcmd
 
 test_gui.res: test_gui.vim
-	@echo $(VIMPROG) > vimcmd
+	@ echo $(VIMPROG) > vimcmd
 	$(VIMPROG) -u NONE $(COMMON_ARGS) -S runtest.vim $*.vim
-	@del vimcmd
+	@ $(RM) vimcmd
 
 test_gui_init.res: test_gui_init.vim
-	@echo $(VIMPROG) > vimcmd
-	$(VIMPROG) -u util\gui_preinit.vim -U util\gui_init.vim $(NO_PLUGINS) -S runtest.vim $*.vim
-	@del vimcmd
+	@ echo $(VIMPROG) > vimcmd
+	$(VIMPROG) -u util\gui_preinit.vim -U util\gui_init.vim $(NO_PLUGINS) \
+		-S runtest.vim $*.vim
+	@ $(RM) vimcmd
 
-opt_test.vim: util/gen_opt_test.vim ../optiondefs.h ../../runtime/doc/options.txt
+opt_test.vim: util/gen_opt_test.vim ../optiondefs.h \
+		../../runtime/doc/options.txt
 	$(VIMPROG) -e -s -u NONE $(COMMON_ARGS) --nofork -S $**
-	@if exist test.log ( type test.log & exit /b 1 )
+	@ if exist test.log ( type test.log & exit /b 1 )
 
 test_bench_regexp.res: test_bench_regexp.vim
-	-if exist benchmark.out del benchmark.out
-	@echo $(VIMPROG) > vimcmd
+	- if exist benchmark.out $(RM) benchmark.out
+	@ echo $(VIMPROG) > vimcmd
 	$(VIMPROG) -u NONE $(COMMON_ARGS) -S runtest.vim $*.vim
-	@del vimcmd
-	@IF EXIST benchmark.out ( type benchmark.out )
+	@ $(RM) vimcmd
+	@ if exist benchmark.out ( type benchmark.out )
+
+# vim: set noet sw=8 ts=8 sts=0 wm=0 tw=79 ft=make:

--- a/src/xxd/Make_mvc.mak
+++ b/src/xxd/Make_mvc.mak
@@ -1,19 +1,25 @@
 # The most simplistic Makefile for Win32 using Microsoft Visual C++
 # (NT and Windows 95)
 
+# included common tools
+!INCLUDE ..\auto\nmake\tools.mak
+
 SUBSYSTEM = console
-!if "$(SUBSYSTEM_VER)" != ""
+!IF "$(SUBSYSTEM_VER)" != ""
 SUBSYSTEM = $(SUBSYSTEM),$(SUBSYSTEM_VER)
-!endif
+!ENDIF
 
 xxd: xxd.exe
 
 xxd.exe: xxd.c
-	cl /nologo /source-charset:utf-8 -DWIN32 xxd.c -link -subsystem:$(SUBSYSTEM)
+	cl /nologo /source-charset:utf-8 -DWIN32 xxd.c -link \
+		-subsystem:$(SUBSYSTEM)
 
 # This was for an older compiler
 #    cl /nologo -DWIN32 xxd.c /link setargv.obj
 
 clean:
-	- if exist xxd.obj del xxd.obj
-	- if exist xxd.exe del xxd.exe
+	- if exist xxd.obj $(RM) xxd.obj
+	- if exist xxd.exe $(RM) xxd.exe
+
+# vim: set noet sw=8 ts=8 sts=0 wm=0 tw=79 ft=make:


### PR DESCRIPTION
Common components have been moved to the `src/auto/nmake/tools.mak` file.  
The files use a consistent style of operators and alignment at the 80-character boundary.  