### PR TITLE
Feat: Set v:char to last key in CmdlineLeave events

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -644,6 +644,10 @@ CmdlineLeave			Before leaving the command line; including
 				<afile> is set to a single character,
 				indicating the type of command-line.
 				|cmdwin-char|
+				Sets the |v:event| dictionary entry
+				"cmdline_leave_key" to the numeric value of
+				the key that exited the command-line (e.g. 13
+				for <CR>).  Use |nr2char()| to get the string.
 							*CmdlineLeavePre*
 CmdlineLeavePre			Just before leaving the command line, and
 				before |CmdlineLeave|.  Useful for capturing
@@ -656,6 +660,7 @@ CmdlineLeavePre			Just before leaving the command line, and
 				or <Esc>.  <afile> is set to a single
 				character indicating the command-line type.
 				See |cmdwin-char| for details.
+				Sets |v:event| as with |CmdlineLeave|.
 							*CmdwinEnter*
 CmdwinEnter			After entering the command-line window.
 				Useful for setting options specifically for

--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -644,10 +644,8 @@ CmdlineLeave			Before leaving the command line; including
 				<afile> is set to a single character,
 				indicating the type of command-line.
 				|cmdwin-char|
-				Sets the |v:event| dictionary entry
-				"cmdline_leave_key" to the numeric value of
-				the key that exited the command-line (e.g. 13
-				for <CR>).  Use |nr2char()| to get the string.
+				Sets the |v:char| to the key that exited the
+				command-line (e.g. <CR>, <CTRL-C>, <Esc>).
 							*CmdlineLeavePre*
 CmdlineLeavePre			Just before leaving the command line, and
 				before |CmdlineLeave|.  Useful for capturing
@@ -660,7 +658,7 @@ CmdlineLeavePre			Just before leaving the command line, and
 				or <Esc>.  <afile> is set to a single
 				character indicating the command-line type.
 				See |cmdwin-char| for details.
-				Sets |v:event| as with |CmdlineLeave|.
+				Sets |v:char| as with |CmdlineLeave|.
 							*CmdwinEnter*
 CmdwinEnter			After entering the command-line window.
 				Useful for setting options specifically for

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2227,8 +2227,8 @@ v:beval_winid	The |window-ID| of the window, over which the mouse pointer
 					*v:char* *char-variable*
 v:char		Argument for evaluating 'formatexpr' and used for the typed
 		character when using <expr> in an abbreviation |:map-<expr>|.
-		It is also used by the |InsertCharPre|, |InsertEnter| and
-		|KeyInputPre| events.
+		It is also used by the |InsertCharPre|, |InsertEnter|,
+		|KeyInputPre|, |CmdlineLeave| and |CmdlineLeavePre| events.
 
 			*v:charconvert_from* *charconvert_from-variable*
 v:charconvert_from

--- a/src/cmdexpand.c
+++ b/src/cmdexpand.c
@@ -4678,7 +4678,7 @@ f_getcompletiontype(typval_T *argvars, typval_T *rettv)
  * "cmdcomplete_info()" function
  */
     void
-f_cmdcomplete_info(typval_T *argvars UNUSED, typval_T *rettv)
+f_cmdcomplete_info(typval_T *argvars, typval_T *rettv)
 {
     cmdline_info_T  *ccline = get_cmdline_info();
     dict_T	    *retdict;

--- a/src/cmdexpand.c
+++ b/src/cmdexpand.c
@@ -4678,7 +4678,7 @@ f_getcompletiontype(typval_T *argvars, typval_T *rettv)
  * "cmdcomplete_info()" function
  */
     void
-f_cmdcomplete_info(typval_T *argvars, typval_T *rettv)
+f_cmdcomplete_info(typval_T *argvars UNUSED, typval_T *rettv)
 {
     cmdline_info_T  *ccline = get_cmdline_info();
     dict_T	    *retdict;

--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -1991,7 +1991,9 @@ getcmdline_int(
 #endif
 		    || c == Ctrl_C))
 	{
+#ifdef FEAT_EVAL
 	    set_vim_var_char(c);  // Set v:char
+#endif
 	    trigger_cmd_autocmd(cmdline_type, EVENT_CMDLINELEAVEPRE);
 	    event_cmdlineleavepre_triggered = TRUE;
 #if defined(FEAT_SEARCH_EXTRA) || defined(PROTO)
@@ -2659,7 +2661,9 @@ returncmd:
     // Trigger CmdlineLeavePre autocommands if not already triggered.
     if (!event_cmdlineleavepre_triggered)
     {
+#ifdef FEAT_EVAL
 	set_vim_var_char(c);  // Set v:char
+#endif
 	trigger_cmd_autocmd(cmdline_type, EVENT_CMDLINELEAVEPRE);
     }
 
@@ -2719,7 +2723,9 @@ returncmd:
 	need_wait_return = FALSE;
 
     // Trigger CmdlineLeave autocommands.
+#ifdef FEAT_EVAL
     set_vim_var_char(c);  // Set v:char
+#endif
     trigger_cmd_autocmd(cmdline_type, EVENT_CMDLINELEAVE);
 
     State = save_State;

--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -66,6 +66,23 @@ trigger_cmd_autocmd(int typechar, int evt)
     apply_autocmds(evt, typestr, typestr, FALSE, curbuf);
 }
 
+    static void
+trigger_cmd_autocmd_vevent(int typechar, int evt, int cmdline_leave_key UNUSED)
+{
+#ifdef FEAT_EVAL
+    dict_T	    *v_event;
+    save_v_event_T  save_v_event;
+
+    v_event = get_v_event(&save_v_event);
+    (void)dict_add_number(v_event, "cmdline_leave_key", cmdline_leave_key);
+    dict_set_items_ro(v_event);
+#endif
+    trigger_cmd_autocmd(typechar, evt);
+#ifdef FEAT_EVAL
+    restore_v_event(v_event, &save_v_event);
+#endif
+}
+
 /*
  * Abandon the command line.
  */
@@ -1991,7 +2008,7 @@ getcmdline_int(
 #endif
 		    || c == Ctrl_C))
 	{
-	    trigger_cmd_autocmd(cmdline_type, EVENT_CMDLINELEAVEPRE);
+	    trigger_cmd_autocmd_vevent(cmdline_type, EVENT_CMDLINELEAVEPRE, c);
 	    event_cmdlineleavepre_triggered = TRUE;
 #if defined(FEAT_SEARCH_EXTRA) || defined(PROTO)
 	    if ((c == ESC || c == Ctrl_C) && (wim_flags[0] & WIM_LIST))
@@ -2657,7 +2674,7 @@ cmdline_changed:
 returncmd:
     // Trigger CmdlineLeavePre autocommands if not already triggered.
     if (!event_cmdlineleavepre_triggered)
-	trigger_cmd_autocmd(cmdline_type, EVENT_CMDLINELEAVEPRE);
+	trigger_cmd_autocmd_vevent(cmdline_type, EVENT_CMDLINELEAVEPRE, c);
 
 #ifdef FEAT_RIGHTLEFT
     cmdmsg_rl = FALSE;
@@ -2715,7 +2732,7 @@ returncmd:
 	need_wait_return = FALSE;
 
     // Trigger CmdlineLeave autocommands.
-    trigger_cmd_autocmd(cmdline_type, EVENT_CMDLINELEAVE);
+    trigger_cmd_autocmd_vevent(cmdline_type, EVENT_CMDLINELEAVE, c);
 
     State = save_State;
 

--- a/src/proto/cmdexpand.pro
+++ b/src/proto/cmdexpand.pro
@@ -25,5 +25,5 @@ int wildmenu_process_key(cmdline_info_T *cclp, int key, expand_T *xp);
 void wildmenu_cleanup(cmdline_info_T *cclp);
 void f_getcompletion(typval_T *argvars, typval_T *rettv);
 void f_getcompletiontype(typval_T *argvars, typval_T *rettv);
-void f_cmdcomplete_info(typval_T *argvars, typval_T *rettv);
+void f_cmdcomplete_info(typval_T *argvars UNUSED, typval_T *rettv);
 /* vim: set ft=c : */

--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -4889,4 +4889,23 @@ func Test_noselect_expand_env_var()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_CmdlineLeave_vevent_keys()
+  func OnLeave()
+    let g:leave_key = get(v:event, 'cmdline_leave_key', -1)
+  endfunction
+
+  new
+  for event in ["CmdlineLeavePre", "CmdlineLeave"]
+    exec "autocmd" event "* :call OnLeave()"
+    for key in ["\<C-C>", "\<Esc>", "\<CR>"]
+      call feedkeys($":echo{key}", 'tx')
+      call assert_equal(key, nr2char(g:leave_key))
+    endfor
+    exec "autocmd!" event
+  endfor
+  bwipe!
+  delfunc OnLeave
+  unlet g:leave_key
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -4889,9 +4889,9 @@ func Test_noselect_expand_env_var()
   call StopVimInTerminal(buf)
 endfunc
 
-func Test_CmdlineLeave_vevent_keys()
+func Test_CmdlineLeave_vchar_keys()
   func OnLeave()
-    let g:leave_key = get(v:event, 'cmdline_leave_key', -1)
+    let g:leave_key = v:char
   endfunction
 
   new
@@ -4899,7 +4899,7 @@ func Test_CmdlineLeave_vevent_keys()
     exec "autocmd" event "* :call OnLeave()"
     for key in ["\<C-C>", "\<Esc>", "\<CR>"]
       call feedkeys($":echo{key}", 'tx')
-      call assert_equal(key, nr2char(g:leave_key))
+      call assert_equal(key, g:leave_key)
     endfor
     exec "autocmd!" event
   endfor


### PR DESCRIPTION
`v:char` stores the key that caused the command-line to exit. Examples: `<CR>`, `<Esc>`, `<C-C>`. Applies to `CmdlineLeave` and `CmdlineLeavePre` events.

See https://github.com/vim/vim/pull/17806#issuecomment-3200256268