### PR TITLE
Drop useless #ifndef UNIX around <time.h>

### DIFF
--- a/src/memline.c
+++ b/src/memline.c
@@ -44,9 +44,7 @@
 
 #include "vim.h"
 
-#ifndef UNIX		// it's in os_unix.h for Unix
-# include <time.h>
-#endif
+#include <time.h>
 
 #if defined(SASC) || defined(__amigaos4__)
 # include <proto/dos.h>	    // for Open() and Close()

--- a/src/spell.c
+++ b/src/spell.c
@@ -60,7 +60,7 @@
 
 #if defined(FEAT_SPELL) || defined(PROTO)
 
-include <time.h>
+#include <time.h>
 
 #define REGION_ALL 0xff		// word valid in all regions
 

--- a/src/spell.c
+++ b/src/spell.c
@@ -60,9 +60,7 @@
 
 #if defined(FEAT_SPELL) || defined(PROTO)
 
-#ifndef UNIX		// it's in os_unix.h for Unix
-# include <time.h>	// for time_t
-#endif
+include <time.h>
 
 #define REGION_ALL 0xff		// word valid in all regions
 

--- a/src/spellfile.c
+++ b/src/spellfile.c
@@ -241,13 +241,7 @@
 
 #if defined(FEAT_SPELL) || defined(PROTO)
 
-#ifndef UNIX		// it's in os_unix.h for Unix
-# include <time.h>	// for time_t
-#endif
-
-#ifndef UNIX		// it's in os_unix.h for Unix
-# include <time.h>	// for time_t
-#endif
+#include <time.h>	// for time_t
 
 // Special byte values for <byte>.  Some are only used in the tree for
 // postponed prefixes, some only in the other trees.  This is a bit messy...


### PR DESCRIPTION
`<time.h>` exists on all supported platforms and has its own include guards.
The conditional on UNIX is redundant and removed.