### PR TITLE
Remove outdated comment

### DIFF
--- a/runtime/doc/version9.txt
+++ b/runtime/doc/version9.txt
@@ -41827,7 +41827,7 @@ Ex-Commands: ~
 
 Options: ~
 
-'autocompletion'	Enable auto completion |ins-autocompletion|
+'autocomplete'		Enable auto completion |ins-autocompletion|
 'autocompletedelay'	Delay in msec before menu appears after typing
 'chistory'		Size of the quickfix stack |quickfix-stack|.
 'clipmethod'		How to access the clipboard.

--- a/src/eval.c
+++ b/src/eval.c
@@ -3550,8 +3550,6 @@ eval0_retarg(
  * "arg" must point to the first non-white of the expression.
  * "arg" is advanced to just after the recognized expression.
  *
- * Note: "rettv.v_lock" is not set.
- *
  * Return OK or FAIL.
  */
     int


### PR DESCRIPTION
Problem:  Outdated comment in eval.c.
Solution: Remove the comment, which is no longer true after 8.2.1672.
          Also fix a typo in version9.txt.
