### PR TITLE
fix(pum): restore cursor position after preinserting multiline match

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -189,7 +189,8 @@ static int	  compl_length = 0;
 static linenr_T	  compl_lnum = 0;           // lnum where the completion start
 static colnr_T	  compl_col = 0;	    // column where the text starts
 					    // that is being completed
-static colnr_T	  compl_ins_end_col = 0;
+static pos_T	  compl_ins_end_pos;	    // last postion of cursor after
+					    // insert match
 static string_T	  compl_orig_text = {NULL, 0};  // text as it was before
 					    // completion started
 static int	  compl_cont_mode = 0;
@@ -1045,7 +1046,7 @@ ins_compl_insert_bytes(char_u *p, int len)
     if (len == -1)
 	len = (int)STRLEN(p);
     ins_bytes_len(p, len);
-    compl_ins_end_col = curwin->w_cursor.col;
+    compl_ins_end_pos = curwin->w_cursor;
 }
 
 /*
@@ -1065,12 +1066,12 @@ ins_compl_col_range_attr(linenr_T lnum, int col)
 
     start_col = compl_col + (int)ins_compl_leader_len();
     if (!ins_compl_has_multiple())
-	return (col >= start_col && col < compl_ins_end_col) ? attr : -1;
+	return (col >= start_col && col < compl_ins_end_pos.col) ? attr : -1;
 
     // Multiple lines
     if ((lnum == compl_lnum && col >= start_col && col < MAXCOL) ||
 	(lnum > compl_lnum && lnum < curwin->w_cursor.lnum) ||
-	(lnum == curwin->w_cursor.lnum && col <= compl_ins_end_col))
+	(lnum == curwin->w_cursor.lnum && col <= compl_ins_end_pos.col))
 	return attr;
 
     return -1;
@@ -1749,7 +1750,6 @@ ins_compl_build_pum(void)
     void
 ins_compl_show_pum(void)
 {
-    int		i;
     int		cur = -1;
     colnr_T	col;
 
@@ -1765,7 +1765,7 @@ ins_compl_show_pum(void)
     else
     {
 	// popup menu already exists, only need to find the current item.
-	for (i = 0; i < compl_match_arraysize; ++i)
+	for (int i = 0; i < compl_match_arraysize; ++i)
 	{
 	    if (compl_match_array[i].pum_text == compl_shown_match->cp_str.string
 		    || compl_match_array[i].pum_text
@@ -1797,6 +1797,11 @@ ins_compl_show_pum(void)
     compl_selected_item = cur;
     pum_display(compl_match_array, compl_match_arraysize, cur);
     curwin->w_cursor.col = col;
+    if  (ins_compl_has_multiple() && (get_cot_flags() & COT_PREINSERT))
+    {
+	curwin->w_cursor.lnum = compl_lnum;
+	curwin->w_cursor.col = compl_col;
+    }
 
     // After adding leader, set the current match to shown match.
     if (compl_started && compl_curr_match != compl_shown_match)
@@ -2235,7 +2240,8 @@ ins_compl_clear(void)
     compl_cfc_longest_ins = FALSE;
     compl_matches = 0;
     compl_selected_item = -1;
-    compl_ins_end_col = 0;
+    compl_ins_end_pos.col = 0;
+    compl_ins_end_pos.lnum = 0;
     compl_curr_win = NULL;
     compl_curr_buf = NULL;
     VIM_CLEAR_STRING(compl_pattern);
@@ -2350,7 +2356,7 @@ ins_compl_preinsert_effect(void)
     if (!ins_compl_has_preinsert())
 	return FALSE;
 
-    return curwin->w_cursor.col < compl_ins_end_col;
+    return curwin->w_cursor.col < compl_ins_end_pos.col;
 }
 
 /*
@@ -5659,14 +5665,15 @@ ins_compl_delete(void)
 {
     // In insert mode: Delete the typed part.
     // In replace mode: Put the old characters back, if any.
-    int col = compl_col + (compl_status_adding() ? compl_length : 0);
+    int		col = compl_col + (compl_status_adding() ? compl_length : 0);
     string_T	remaining = {NULL, 0};
-    int	    orig_col;
-    int	has_preinsert = ins_compl_preinsert_effect();
+    int		orig_col;
+    int		has_preinsert = ins_compl_preinsert_effect();
+
     if (has_preinsert)
     {
 	col += (int)ins_compl_leader_len();
-	curwin->w_cursor.col = compl_ins_end_col;
+	curwin->w_cursor = compl_ins_end_pos;
     }
 
     if (curwin->w_cursor.lnum > compl_lnum)
@@ -5703,7 +5710,7 @@ ins_compl_delete(void)
 	    return;
 	}
 	backspace_until_column(col);
-	compl_ins_end_col = curwin->w_cursor.col;
+	compl_ins_end_pos = curwin->w_cursor;
     }
 
     if (remaining.string != NULL)
@@ -5752,7 +5759,7 @@ ins_compl_expand_multiple(char_u *str)
     if (curr > start)
 	ins_char_bytes(start, (int)(curr - start));
 
-    compl_ins_end_col = curwin->w_cursor.col;
+    compl_ins_end_pos = curwin->w_cursor;
 }
 
 /*

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -3937,6 +3937,8 @@ func Test_completeopt_preinsert()
   func GetLine()
     let g:line = getline('.')
     let g:col = col('.')
+    let g:lnum = line('.')
+    let g:second_line = getline(g:lnum + 1)
   endfunc
 
   new
@@ -4065,6 +4067,13 @@ func Test_completeopt_preinsert()
   call assert_equal(4, g:col)
   call assert_equal("wp.", getline('.'))
 
+  inoremap <buffer> <f3> <cmd>call complete(col("."), [ "single line", "multiple line1\nline2"])<CR>
+  call feedkeys("ggdGS\<F3>\<C-N>\<F5>", 'tx')
+  call assert_equal("multiple line1", g:line)
+  call assert_equal("line2", g:second_line)
+  call assert_equal(1, g:col)
+  call assert_equal(1, g:lnum)
+
   %delete _
   let &l:undolevels = &l:undolevels
   normal! ifoo
@@ -4106,6 +4115,10 @@ func Test_completeopt_preinsert()
   %delete _
   delfunc CheckUndo
 
+  unlet g:line
+  unlet g:lnum
+  unlet g:col
+  unlet g:second_line
   bw!
   set cot&
   set omnifunc&


### PR DESCRIPTION
Problem:
When a match containing multiple lines is preinserted, the cursor position becomes incorrect.

Solution:
Record the cursor position after inserting the match, and restore the original position after displaying the popup menu.

Fix #18081