### PR TITLE
Another outdated comment in eval.c

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -3398,7 +3398,6 @@ skipwhite_and_linebreak(char_u *arg, evalarg_T *evalarg)
  * Handle zero level expression.
  * This calls eval1() and handles error message and nextcmd.
  * Put the result in "rettv" when returning OK and "evaluate" is TRUE.
- * Note: "rettv.v_lock" is not set.
  * "evalarg" can be NULL, EVALARG_EVALUATE or a pointer.
  * Return OK or FAIL.
  */

--- a/src/testdir/test_filter_map.vim
+++ b/src/testdir/test_filter_map.vim
@@ -221,6 +221,16 @@ func Test_mapnew_dict()
 
   const dconst = #{one: 1, two: 2, three: 3}
   call assert_equal(#{one: 2, two: 3, three: 4}, mapnew(dconst, {_, v -> v + 1}))
+
+  " return value of mapnew() can be modified
+  let dout = mapnew(dconst, {k, v -> $'{k}={v}'})
+  let dout.one ..= '!'
+  call assert_equal(#{one: 'one=1!', two: 'two=2', three: 'three=3'}, dout)
+  unlet dout.three
+  call assert_equal(#{one: 'one=1!', two: 'two=2'}, dout)
+  " original Dict is still locked
+  call assert_fails('unlet dconst.three', 'E741:')
+  call assert_fails('let dconst.one += 1', 'E741:')
 endfunc
 
 func Test_mapnew_list()
@@ -231,6 +241,16 @@ func Test_mapnew_list()
 
   const lconst = [1, 2, 3]
   call assert_equal([2, 3, 4], mapnew(lconst, {_, v -> v + 1}))
+
+  " return value of mapnew() can be modified
+  let lout = mapnew(lconst, {k, v -> $'{k}={v}'})
+  let lout[0] ..= '!'
+  call assert_equal(['0=1!', '1=2', '2=3'], lout)
+  unlet lout[2]
+  call assert_equal(['0=1!', '1=2'], lout)
+  " original List is still locked
+  call assert_fails('unlet lconst[2]', 'E741:')
+  call assert_fails('let lconst[0] += 1', 'E741:')
 endfunc
 
 func Test_mapnew_blob()


### PR DESCRIPTION
Problem:  Another outdated comment in eval.c (after 9.1.1665).
Solution: Remove that comment as well. Add a few more tests for mapnew()
          that fail without patch 8.2.1672.
