### PR TITLE
runtime(python): support 'type's soft keyword form

### DIFF
--- a/runtime/syntax/python.vim
+++ b/runtime/syntax/python.vim
@@ -113,7 +113,7 @@ syn keyword pythonAsync		async await
 " for more on this.
 syn match   pythonConditional   "^\s*\zscase\%(\s\+.*:.*$\)\@="
 syn match   pythonConditional   "^\s*\zsmatch\%(\s\+.*:\s*\%(#.*\)\=$\)\@="
-syn match   pythonStatement     "\<type\>\ze\s\+\h\w*" nextgroup=pythonType skipwhite
+syn match   pythonStatement     "\<type\ze\s\+\h\w*" nextgroup=pythonType skipwhite
 
 " These names are special by convention. While they aren't real keywords,
 " giving them distinct highlighting provides a nice visual cue.
@@ -305,7 +305,7 @@ if !exists("python_no_builtin_highlight")
   syn keyword pythonBuiltin	setattr slice sorted staticmethod str sum super
   syn keyword pythonBuiltin	tuple vars zip __import__
   " only match `type` as a builtin when it's not followed by an identifier
-  syn match   pythonbuiltin	"\<type\>\ze\(\s\+\h\w*\)\@!"
+  syn match   pythonbuiltin	"\<type\ze\(\s\+\h\w*\)\@!"
   " avoid highlighting attributes as builtins
   syn match   pythonAttribute	/\.\h\w*/hs=s+1
 	\ contains=ALLBUT,pythonBuiltin,pythonClass,pythonFunction,pythonType,pythonAsync

--- a/runtime/syntax/python.vim
+++ b/runtime/syntax/python.vim
@@ -1,10 +1,11 @@
 " Vim syntax file
 " Language:	Python
 " Maintainer:	Zvezdan Petkovic <zpetkovic@acm.org>
-" Last Change:	2025 Aug 18
+" Last Change:	2025 Aug 23
 " Credits:	Neil Schemenauer <nas@python.ca>
 "		Dmitry Vasiliev
 "		Rob B
+"		Jon Parise
 "
 "		This version is a major rewrite by Zvezdan Petkovic.
 "
@@ -112,6 +113,7 @@ syn keyword pythonAsync		async await
 " for more on this.
 syn match   pythonConditional   "^\s*\zscase\%(\s\+.*:.*$\)\@="
 syn match   pythonConditional   "^\s*\zsmatch\%(\s\+.*:\s*\%(#.*\)\=$\)\@="
+syn match   pythonStatement     "\<type\>\ze\s\+\h\w*" nextgroup=pythonType skipwhite
 
 " These names are special by convention. While they aren't real keywords,
 " giving them distinct highlighting provides a nice visual cue.
@@ -128,22 +130,23 @@ syn match   pythonDecoratorName	"@\s*\h\%(\w\|\.\)*" display contains=pythonDeco
 " Single line multiplication.
 syn match   pythonMatrixMultiply
       \ "\%(\w\|[])]\)\s*@"
-      \ contains=ALLBUT,pythonDecoratorName,pythonDecorator,pythonClass,pythonFunction,pythonDoctestValue
+      \ contains=ALLBUT,pythonDecoratorName,pythonDecorator,pythonClass,pythonFunction,pythonType,pythonDoctestValue
       \ transparent
 " Multiplication continued on the next line after backslash.
 syn match   pythonMatrixMultiply
       \ "[^\\]\\\s*\n\%(\s*\.\.\.\s\)\=\s\+@"
-      \ contains=ALLBUT,pythonDecoratorName,pythonDecorator,pythonClass,pythonFunction,pythonDoctestValue
+      \ contains=ALLBUT,pythonDecoratorName,pythonDecorator,pythonClass,pythonFunction,pythonType,pythonDoctestValue
       \ transparent
 " Multiplication in a parenthesized expression over multiple lines with @ at
 " the start of each continued line; very similar to decorators and complex.
 syn match   pythonMatrixMultiply
       \ "^\s*\%(\%(>>>\|\.\.\.\)\s\+\)\=\zs\%(\h\|\%(\h\|[[(]\).\{-}\%(\w\|[])]\)\)\s*\n\%(\s*\.\.\.\s\)\=\s\+@\%(.\{-}\n\%(\s*\.\.\.\s\)\=\s\+@\)*"
-      \ contains=ALLBUT,pythonDecoratorName,pythonDecorator,pythonClass,pythonFunction,pythonDoctestValue
+      \ contains=ALLBUT,pythonDecoratorName,pythonDecorator,pythonClass,pythonFunction,pythonType,pythonDoctestValue
       \ transparent
 
 syn match   pythonClass		"\h\w*" display contained
 syn match   pythonFunction	"\h\w*" display contained
+syn match   pythonType		"\h\w*" display contained
 
 syn match   pythonComment	"#.*$" contains=pythonTodo,@Spell
 syn keyword pythonTodo		FIXME NOTE NOTES TODO XXX contained
@@ -300,10 +303,12 @@ if !exists("python_no_builtin_highlight")
   syn keyword pythonBuiltin	memoryview min next object oct open ord pow
   syn keyword pythonBuiltin	print property range repr reversed round set
   syn keyword pythonBuiltin	setattr slice sorted staticmethod str sum super
-  syn keyword pythonBuiltin	tuple type vars zip __import__
+  syn keyword pythonBuiltin	tuple vars zip __import__
+  " only match `type` as a builtin when it's not followed by an identifier
+  syn match   pythonbuiltin	"\<type\>\ze\(\s\+\h\w*\)\@!"
   " avoid highlighting attributes as builtins
   syn match   pythonAttribute	/\.\h\w*/hs=s+1
-	\ contains=ALLBUT,pythonBuiltin,pythonClass,pythonFunction,pythonAsync
+	\ contains=ALLBUT,pythonBuiltin,pythonClass,pythonFunction,pythonType,pythonAsync
 	\ transparent
 endif
 
@@ -360,7 +365,7 @@ if !exists("python_no_doctest_highlight")
   if !exists("python_no_doctest_code_highlight")
     syn region pythonDoctest
 	  \ start="^\s*>>>\s" end="^\s*$"
-	  \ contained contains=ALLBUT,pythonDoctest,pythonClass,pythonFunction,@Spell
+	  \ contained contains=ALLBUT,pythonDoctest,pythonClass,pythonFunction,pythonType,@Spell
     syn region pythonDoctestValue
 	  \ start=+^\s*\%(>>>\s\|\.\.\.\s\|"""\|'''\)\@!\S\++ end="$"
 	  \ contained
@@ -387,6 +392,7 @@ hi def link pythonDecorator		Define
 hi def link pythonDecoratorName		Function
 hi def link pythonClass			Structure
 hi def link pythonFunction		Function
+hi def link pythonType			Type
 hi def link pythonComment		Comment
 hi def link pythonTodo			Todo
 hi def link pythonString		String

--- a/runtime/syntax/python.vim
+++ b/runtime/syntax/python.vim
@@ -305,7 +305,7 @@ if !exists("python_no_builtin_highlight")
   syn keyword pythonBuiltin	setattr slice sorted staticmethod str sum super
   syn keyword pythonBuiltin	tuple vars zip __import__
   " only match `type` as a builtin when it's not followed by an identifier
-  syn match   pythonbuiltin	"\<type\ze\(\s\+\h\w*\)\@!"
+  syn match   pythonBuiltin	"\<type\ze\(\s\+\h\w*\)\@!"
   " avoid highlighting attributes as builtins
   syn match   pythonAttribute	/\.\h\w*/hs=s+1
 	\ contains=ALLBUT,pythonBuiltin,pythonClass,pythonFunction,pythonType,pythonAsync


### PR DESCRIPTION
`type` became a soft keyword in Python 3.12. In that form, it is a statement that declares a type alias:

    # type_stmt ::= 'type' identifier [type_params] "=" expression
    type Point = tuple[float, float]

To implement support for this, this change does three things:

1. adds a `pythonType` group (linked to `Type`)
2. matches `type` followed by an identifier as `pythonStatement`
3. continues to match `type` in other forms as `pythonBuiltin`

Ref:
- https://docs.python.org/3/reference/lexical_analysis.html#soft-keywords
- https://docs.python.org/3/reference/simple_stmts.html#the-type-statement