### PR TITLE
cscope: possible buffer-under run on MS-Windows

### DIFF
--- a/src/if_cscope.c
+++ b/src/if_cscope.c
@@ -1940,12 +1940,18 @@ cs_pathcomponents(char *path)
 
     s = path + strlen(path) - 1;
     for (i = 0; i < p_cspc; ++i)
-	while (s > path && *--s != '/'
+    {
+	while (s > path)
+	{
+	   s--;
+	   if (*s == '/'
 #ifdef MSWIN
-		&& *--s != '\\'
+		|| *s == '\\'
 #endif
 		)
-	    ;
+	      break;
+	}
+    }
     if ((s > path && *s == '/')
 #ifdef MSWIN
 	|| (s > path && *s == '\\')


### PR DESCRIPTION
Problem:  possible buffer under run in cs_pathcomponents
          (Murali Aniruddhan)
Solution: Fix the loop and do not decrement the pointer twice.