### PR TITLE
if_python: Remove code for Python 1.4 and below

### DIFF
--- a/src/if_python.c
+++ b/src/if_python.c
@@ -838,10 +838,6 @@ static int PythonMod_Init(void);
 ///////////////////////////////////////////////////////
 // 1. Python interpreter main program.
 
-#if PYTHON_API_VERSION < 1007 // Python 1.4
-typedef PyObject PyThreadState;
-#endif
-
 #ifndef PY_CAN_RECURSE
 static PyThreadState *saved_python_thread = NULL;
 
@@ -1560,17 +1556,6 @@ do_pyeval(char_u *str, dict_T *locals, typval_T *rettv)
 	rettv->vval.v_number = 0;
     }
 }
-
-// Don't generate a prototype for the next function, it generates an error on
-// newer Python versions.
-#if PYTHON_API_VERSION < 1007 /* Python 1.4 */ && !defined(PROTO)
-
-    char *
-Py_GetProgramName(void)
-{
-    return "vim";
-}
-#endif // Python 1.4
 
     int
 set_ref_in_python(int copyID)


### PR DESCRIPTION
PYTHON_API_VERSION was `1006` in Python 1.4 (before 1996 !!), so I think it's safe to remove it now.
```
#if PYTHON_API_VERSION < 1007 // Python 1.4
```

https://github.com/python/cpython/blob/ab1bef8ad27ad531a1109cfc016ea627d94f9cc1/Include/modsupport.h#L59-L93