### PR TITLE
remove "Ms" value from key_names array

### DIFF
--- a/src/term.c
+++ b/src/term.c
@@ -1719,7 +1719,7 @@ static char *(key_names[]) =
     "k7", "k8", "k9", "k;", "F1", "F2",
     "%1", "&8", "kb", "kI", "kD", "kh",
     "@7", "kP", "kN", "K1", "K3", "K4", "K5", "kB",
-    "PS", "PE", "Ms",
+    "PS", "PE",
     NULL
 };
 #endif


### PR DESCRIPTION
For some reason causes Vim to replace the buffer with "5c" occasionally. It seems to only happen in the kitty terminal, so I'm pretty sure this is actually a bug with kitty instead. However this enty isn't really that important anyways, so we can leave it out.