### PR TITLE
Introduce iso646 in vim.h

### DIFF
--- a/src/cmdexpand.c
+++ b/src/cmdexpand.c
@@ -2306,7 +2306,7 @@ set_context_by_cmdname(
 	expand_T	*xp,
 	char_u		*arg,
 	long		argt,
-	int		compl,
+	int		completion_type,
 	int		forceit)
 {
     char_u  *nextcmd;
@@ -2534,8 +2534,8 @@ set_context_by_cmdname(
 #endif
 	case CMD_USER:
 	case CMD_USER_BUF:
-	    return set_context_in_user_cmdarg(cmd, arg, argt, compl, xp,
-								forceit);
+	    return set_context_in_user_cmdarg(cmd, arg, argt, completion_type,
+		    xp, forceit);
 
 	case CMD_map:	    case CMD_noremap:
 	case CMD_nmap:	    case CMD_nnoremap:
@@ -2704,7 +2704,7 @@ set_one_cmd_context(
     char_u		*cmd, *arg;
     int			len = 0;
     exarg_T		ea;
-    int			compl = EXPAND_NOTHING;
+    int			completion_type = EXPAND_NOTHING;
     int			forceit = FALSE;
     int			usefilter = FALSE;  // filter instead of file name
 
@@ -2742,7 +2742,7 @@ set_one_cmd_context(
 	return cmd + 1;			// There's another command
 
     // Get the command index.
-    p = set_cmd_index(cmd, &ea, xp, &compl);
+    p = set_cmd_index(cmd, &ea, xp, &completion_type);
     if (p == NULL)
 	return NULL;
 
@@ -2886,11 +2886,11 @@ set_one_cmd_context(
     }
 
     if (ea.argt & EX_XFILE)
-	set_context_for_wildcard_arg(&ea, arg, usefilter, xp, &compl);
+	set_context_for_wildcard_arg(&ea, arg, usefilter, xp, &completion_type);
 
     // 6. Switch on command name.
-    return set_context_by_cmdname(cmd, ea.cmdidx, xp, arg, ea.argt, compl,
-								forceit);
+    return set_context_by_cmdname(cmd, ea.cmdidx, xp, arg, ea.argt,
+	    completion_type, forceit);
 }
 
 /*

--- a/src/usercmd.c
+++ b/src/usercmd.c
@@ -1085,7 +1085,7 @@ uc_add_command(
     long	argt,
     long	def,
     int		flags,
-    int		compl,
+    int		completion_type,
     char_u	*compl_arg UNUSED,
     cmd_addr_T	addr_type,
     int		force)
@@ -1179,7 +1179,7 @@ uc_add_command(
     cmd->uc_rep = rep_buf;
     cmd->uc_argt = argt;
     cmd->uc_def = def;
-    cmd->uc_compl = compl;
+    cmd->uc_compl = completion_type;
     cmd->uc_script_ctx = current_sctx;
     if (flags & UC_VIM9)
 	cmd->uc_script_ctx.sc_version = SCRIPT_VERSION_VIM9;
@@ -1258,7 +1258,7 @@ ex_command(exarg_T *eap)
     long	argt = 0;
     long	def = -1;
     int		flags = 0;
-    int		compl = EXPAND_NOTHING;
+    int		completion_type = EXPAND_NOTHING;
     char_u	*compl_arg = NULL;
     cmd_addr_T	addr_type_arg = ADDR_NONE;
     int		has_attr = (eap->arg[0] == '-');
@@ -1271,7 +1271,7 @@ ex_command(exarg_T *eap)
     {
 	++p;
 	end = skiptowhite(p);
-	if (uc_scan_attr(p, end - p, &argt, &def, &flags, &compl,
+	if (uc_scan_attr(p, end - p, &argt, &def, &flags, &completion_type,
 					   &compl_arg, &addr_type_arg) == FAIL)
 	    goto theend;
 	p = skipwhite(end);
@@ -1307,7 +1307,7 @@ ex_command(exarg_T *eap)
     {
 	emsg(_(e_reserved_name_cannot_be_used_for_user_defined_command));
     }
-    else if (compl > 0 && (argt & EX_EXTRA) == 0)
+    else if (completion_type > 0 && (argt & EX_EXTRA) == 0)
     {
 	// Some plugins rely on silently ignoring the mistake, only make this
 	// an error in Vim9 script.
@@ -1324,8 +1324,8 @@ ex_command(exarg_T *eap)
 
 	p = may_get_cmd_block(eap, p, &tofree, &flags);
 
-	uc_add_command(name, end - name, p, argt, def, flags, compl, compl_arg,
-						  addr_type_arg, eap->forceit);
+	uc_add_command(name, end - name, p, argt, def, flags, completion_type,
+		compl_arg, addr_type_arg, eap->forceit);
 	vim_free(tofree);
 
 	return;  // success

--- a/src/vim.h
+++ b/src/vim.h
@@ -528,6 +528,9 @@ typedef long long vimlong_T;
 #include <stddef.h>
 #include <stdbool.h>
 
+// C95 addition
+#include <iso646.h>
+
 #if defined(HAVE_SYS_SELECT_H) && \
 	(!defined(HAVE_SYS_TIME_H) || defined(SYS_SELECT_WITH_SYS_TIME))
 # include <sys/select.h>


### PR DESCRIPTION
The iso646 header is part of C95 which is now officially supported by Vim.
For the convenience of every dev, it is now included in `vim.h`.

One of the defines in the header is
```C
#define compl   ~
```
so I had to rename a few variables along the way.

---
EDIT

For who may wonder, the `<iso646.h>` header is only doing this :
```C
#define and     &&
#define and_eq  &=
#define bitand  &
#define bitor   |
#define compl   ~
#define not     !
#define not_eq  !=
#define or      ||
#define or_eq   |=
#define xor     ^
#define xor_eq  ^=
```

In C++ those words are language keywords. In a language like Python `and`, `or` and `not` are keywords.