### PR TITLE
Loading the termdebug plugin twice leads to errors

### DIFF
--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -52,14 +52,6 @@ def Echowarn(msg: string)
 enddef
 
 # Variables to keep their status among multiple instances of Termdebug
-# Avoid to source the script twice.
-if exists('g:termdebug_loaded')
-  if DEBUG
-    Echoerr('Termdebug already loaded.')
-  endif
-  finish
-endif
-g:termdebug_loaded = true
 g:termdebug_is_running = false
 
 

--- a/src/testdir/test_plugin_termdebug.vim
+++ b/src/testdir/test_plugin_termdebug.vim
@@ -597,22 +597,4 @@ function Test_termdebug_config_types()
   unlet g:termdebug_config
 endfunction
 
-function Test_termdebug_config_debug()
-  let s:error_message = '\[termdebug\] Termdebug already loaded'
-
-  " USER mode: No error message shall be displayed
-  packadd termdebug
-  call assert_true(execute('messages') !~ s:error_message)
-
-  " DEBUG mode: Error message shall now be displayed
-  let g:termdebug_config = {}
-  let g:termdebug_config['debug'] = 1
-  packadd termdebug
-  call assert_true(execute('messages') =~ s:error_message)
-
-  unlet g:termdebug_config
-  unlet g:termdebug_loaded
-  " Revert DEBUG mode, by reloading the plugin
-  source $VIMRUNTIME/pack/dist/opt/termdebug/plugin/termdebug.vim
-endfunction
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION

If the termdebug plugin is loaded twice, invoking the :Termdebug command results
in the following error:

```
:packadd termdebug
:packadd termdebug
[termdebug] Termdebug already loaded.
:Termdebug
E117: Unknown function: StartDebug
```

This occurs because the termdebug plugin has been converted to a vim9script.
Unlike legacy Vim scripts, a vim9script can be sourced multiple times without 
issue. Therefore, the existing protection that prevents the plugin from being
loaded more than once is no longer necessary and should be removed.
