### PR TITLE
Add <Del> support in CmdlineChanged autocmd

### DIFF
--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -2622,9 +2622,10 @@ cmdline_changed:
 	// Trigger CmdlineChanged autocommands.
 	if (trigger_cmdlinechanged
 		&& (ccline.cmdpos != prev_cmdpos
-		    || (prev_cmdbuff != NULL && STRNCMP(prev_cmdbuff,
-			    ccline.cmdbuff, prev_cmdpos) != 0)))
+		    || (prev_cmdbuff != NULL &&
+			STRCMP(prev_cmdbuff, ccline.cmdbuff) != 0))) {
 	    trigger_cmd_autocmd(cmdline_type, EVENT_CMDLINECHANGED);
+	}
 
 	// Trigger CursorMovedC autocommands.
 	if (ccline.cmdpos != prev_cmdpos)

--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -2623,9 +2623,8 @@ cmdline_changed:
 	if (trigger_cmdlinechanged
 		&& (ccline.cmdpos != prev_cmdpos
 		    || (prev_cmdbuff != NULL &&
-			STRCMP(prev_cmdbuff, ccline.cmdbuff) != 0))) {
+			STRCMP(prev_cmdbuff, ccline.cmdbuff) != 0)))
 	    trigger_cmd_autocmd(cmdline_type, EVENT_CMDLINECHANGED);
-	}
 
 	// Trigger CursorMovedC autocommands.
 	if (ccline.cmdpos != prev_cmdpos)

--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -1855,7 +1855,7 @@ getcmdline_int(
 
 	if (ccline.cmdbuff != NULL)
 	{
-	    prev_cmdbuff = vim_strnsave(ccline.cmdbuff, ccline.cmdpos);
+	    prev_cmdbuff = vim_strsave(ccline.cmdbuff);
 	    if (prev_cmdbuff == NULL)
 		goto returncmd;
 	}

--- a/src/testdir/test_autocmd.vim
+++ b/src/testdir/test_autocmd.vim
@@ -2183,6 +2183,17 @@ func Test_Cmdline()
         \ '0abc1abc2abc3',
         \ ], g:log)
 
+  " <Del> should be triggered.
+  let g:log = []
+  call feedkeys(":foo\<Left>\<Left>\<Del>\<Del>\<Esc>", 'xt')
+  call assert_equal([
+        \ 'f',
+        \ 'fo',
+        \ 'foo',
+        \ 'fo',
+        \ 'f',
+        \ ], g:log)
+
   unlet g:log
   au! CmdlineChanged
 

--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -2621,10 +2621,6 @@ func Test_cmd_map_cmdlineChanged()
   call feedkeys(":\<F1>\<CR>", 'xt')
   call assert_equal(['a', 'ab'], g:log)
 
-  let g:log = []
-  call feedkeys(":foo\<Left>\<Left>\<Del>\<Del>\<Esc>", 'xt')
-  call assert_equal(['f', 'fo', 'foo', 'fo', 'f'], g:log)
-
   unlet g:log
   cunmap <F1>
   augroup test_CmdlineChanged
@@ -4827,6 +4823,25 @@ func Test_cmdline_changed()
   delfunc TestComplete
   delcommand Test
   call test_override("char_avail", 0)
+endfunc
+
+func Test_cmdline_changed_del()
+  let g:log = []
+  augroup test_CmdlineChanged
+    autocmd!
+    autocmd CmdlineChanged : let g:log += [getcmdline()]
+  augroup END
+
+  " <Del> should be triggered.
+  let g:log = []
+  call feedkeys(":foo\<Left>\<Left>\<Del>\<Del>\<Esc>", 'xt')
+  call assert_equal(['f', 'fo', 'foo', 'fo', 'f'], g:log)
+
+  unlet g:log
+  augroup test_CmdlineChanged
+    autocmd!
+  augroup END
+  augroup! test_CmdlineChanged
 endfunc
 
 func Test_wildtrigger_update_screen()

--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -4825,25 +4825,6 @@ func Test_cmdline_changed()
   call test_override("char_avail", 0)
 endfunc
 
-func Test_cmdline_changed_del()
-  let g:log = []
-  augroup test_CmdlineChanged
-    autocmd!
-    autocmd CmdlineChanged : let g:log += [getcmdline()]
-  augroup END
-
-  " <Del> should be triggered.
-  let g:log = []
-  call feedkeys(":foo\<Left>\<Left>\<Del>\<Del>\<Esc>", 'xt')
-  call assert_equal(['f', 'fo', 'foo', 'fo', 'f'], g:log)
-
-  unlet g:log
-  augroup test_CmdlineChanged
-    autocmd!
-  augroup END
-  augroup! test_CmdlineChanged
-endfunc
-
 func Test_wildtrigger_update_screen()
   CheckScreendump
   let lines =<< trim [SCRIPT]

--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -2621,6 +2621,10 @@ func Test_cmd_map_cmdlineChanged()
   call feedkeys(":\<F1>\<CR>", 'xt')
   call assert_equal(['a', 'ab'], g:log)
 
+  let g:log = []
+  call feedkeys(":foo\<Left>\<Left>\<Del>\<Del>\<Esc>", 'xt')
+  call assert_equal(['f', 'fo', 'foo', 'fo', 'f'], g:log)
+
   unlet g:log
   cunmap <F1>
   augroup test_CmdlineChanged


### PR DESCRIPTION
#18042 

https://github.com/vim/vim/issues/18042#issuecomment-3195670020

There was an issue with this routine: when `prev_cmdpos` did not change, `CmdlineChanged` would not react, so I fixed it.
~~However, there seems to be one problem. The value of `prev_cmdbuff` is not what I expected, which is causing the test to fail.
I have confirmed that `ccline.cmdbuff` is correct.~~