### PR TITLE
Bound recursion in unix_expandpath and dos_expandpath

### DIFF
--- a/src/filepath.c
+++ b/src/filepath.c
@@ -3543,7 +3543,7 @@ dos_expandpath(
     size_t	len;
     int		starstar = FALSE;
     static int	stardepth = 0;	    // depth for "**" expansion
-	static int	wildcarddepth = 0;	    // depth for other wildcard expansions
+    static int	wildcarddepth = 0;	// depth for other wildcard expansions
 
     HANDLE		hFind = INVALID_HANDLE_VALUE;
     WIN32_FIND_DATAW    wfb;
@@ -3804,7 +3804,7 @@ unix_expandpath(
     size_t	len;
     int		starstar = FALSE;
     static int	stardepth = 0;	    // depth for "**" expansion
-	static int	wildcarddepth = 0;	    // depth for other wildcard expansions
+    static int	wildcarddepth = 0;	// depth for other wildcard expansions
 
     DIR		*dirp;
     struct dirent *dp;

--- a/src/filepath.c
+++ b/src/filepath.c
@@ -3955,14 +3955,14 @@ unix_expandpath(
 		vim_snprintf((char *)buf + len, buflen - len, "%s", path_end);
 		if (mch_has_exp_wildcard(path_end)) // handle more wildcards
 		{
-			if (stardepth < 100)
-			{
-			    // need to expand another component of the path
-			    // remove backslashes for the remaining components only
-			    ++stardepth;
-			    (void)unix_expandpath(gap, buf, len + 1, flags, FALSE);
-			    --stardepth;
-			}
+		    if (stardepth < 100)
+		    {
+			// need to expand another component of the path
+			// remove backslashes for the remaining components only
+			++stardepth;
+			(void)unix_expandpath(gap, buf, len + 1, flags, FALSE);
+			--stardepth;
+		    }
 		}
 		else
 		{

--- a/src/filepath.c
+++ b/src/filepath.c
@@ -3543,6 +3543,8 @@ dos_expandpath(
     size_t	len;
     int		starstar = FALSE;
     static int	stardepth = 0;	    // depth for "**" expansion
+	static int	wildcarddepth = 0;	    // depth for other wildcard expansions
+
     HANDLE		hFind = INVALID_HANDLE_VALUE;
     WIN32_FIND_DATAW    wfb;
     WCHAR		*wn = NULL;	// UCS-2 name, NULL when not used.
@@ -3709,9 +3711,14 @@ dos_expandpath(
 		vim_snprintf((char *)buf + len, buflen - len, "%s", path_end);
 		if (mch_has_exp_wildcard(path_end))
 		{
-		    // need to expand another component of the path
-		    // remove backslashes for the remaining components only
-		    (void)dos_expandpath(gap, buf, len + 1, flags, FALSE);
+			if (wildcarddepth < 100)
+			{
+				// need to expand another component of the path
+				// remove backslashes for the remaining components only
+				++wildcarddepth;
+				(void)dos_expandpath(gap, buf, len + 1, flags, FALSE);
+				--wildcarddepth;
+			}
 		}
 		else
 		{
@@ -3797,6 +3804,7 @@ unix_expandpath(
     size_t	len;
     int		starstar = FALSE;
     static int	stardepth = 0;	    // depth for "**" expansion
+	static int	wildcarddepth = 0;	    // depth for other wildcard expansions
 
     DIR		*dirp;
     struct dirent *dp;
@@ -3950,9 +3958,14 @@ unix_expandpath(
 		vim_snprintf((char *)buf + len, buflen - len, "%s", path_end);
 		if (mch_has_exp_wildcard(path_end)) // handle more wildcards
 		{
-		    // need to expand another component of the path
-		    // remove backslashes for the remaining components only
-		    (void)unix_expandpath(gap, buf, len + 1, flags, FALSE);
+			if (wildcarddepth < 100)
+			{
+				// need to expand another component of the path
+				// remove backslashes for the remaining components only
+				++wildcarddepth;
+				(void)unix_expandpath(gap, buf, len + 1, flags, FALSE);
+				--wildcarddepth;
+			}
 		}
 		else
 		{

--- a/src/filepath.c
+++ b/src/filepath.c
@@ -3543,7 +3543,6 @@ dos_expandpath(
     size_t	len;
     int		starstar = FALSE;
     static int	stardepth = 0;	    // depth for "**" expansion
-
     HANDLE		hFind = INVALID_HANDLE_VALUE;
     WIN32_FIND_DATAW    wfb;
     WCHAR		*wn = NULL;	// UCS-2 name, NULL when not used.

--- a/src/filepath.c
+++ b/src/filepath.c
@@ -3709,14 +3709,14 @@ dos_expandpath(
 		vim_snprintf((char *)buf + len, buflen - len, "%s", path_end);
 		if (mch_has_exp_wildcard(path_end))
 		{
-			if (stardepth < 100)
-			{
-			    // need to expand another component of the path
-			    // remove backslashes for the remaining components only
-			    ++stardepth;
-			    (void)dos_expandpath(gap, buf, len + 1, flags, FALSE);
-			    --stardepth;
-			}
+		    if (stardepth < 100)
+		    {
+			// need to expand another component of the path
+			// remove backslashes for the remaining components only
+			++stardepth;
+			(void)dos_expandpath(gap, buf, len + 1, flags, FALSE);
+			--stardepth;
+		    }
 		}
 		else
 		{

--- a/src/filepath.c
+++ b/src/filepath.c
@@ -3711,11 +3711,11 @@ dos_expandpath(
 		{
 			if (stardepth < 100)
 			{
-				// need to expand another component of the path
-				// remove backslashes for the remaining components only
-				++stardepth;
-				(void)dos_expandpath(gap, buf, len + 1, flags, FALSE);
-				--stardepth;
+			    // need to expand another component of the path
+			    // remove backslashes for the remaining components only
+			    ++stardepth;
+			    (void)dos_expandpath(gap, buf, len + 1, flags, FALSE);
+			    --stardepth;
 			}
 		}
 		else
@@ -3957,11 +3957,11 @@ unix_expandpath(
 		{
 			if (stardepth < 100)
 			{
-				// need to expand another component of the path
-				// remove backslashes for the remaining components only
-				++stardepth;
-				(void)unix_expandpath(gap, buf, len + 1, flags, FALSE);
-				--stardepth;
+			    // need to expand another component of the path
+			    // remove backslashes for the remaining components only
+			    ++stardepth;
+			    (void)unix_expandpath(gap, buf, len + 1, flags, FALSE);
+			    --stardepth;
 			}
 		}
 		else

--- a/src/filepath.c
+++ b/src/filepath.c
@@ -3543,7 +3543,6 @@ dos_expandpath(
     size_t	len;
     int		starstar = FALSE;
     static int	stardepth = 0;	    // depth for "**" expansion
-    static int	wildcarddepth = 0;	// depth for other wildcard expansions
 
     HANDLE		hFind = INVALID_HANDLE_VALUE;
     WIN32_FIND_DATAW    wfb;
@@ -3711,13 +3710,13 @@ dos_expandpath(
 		vim_snprintf((char *)buf + len, buflen - len, "%s", path_end);
 		if (mch_has_exp_wildcard(path_end))
 		{
-			if (wildcarddepth < 100)
+			if (stardepth < 100)
 			{
 				// need to expand another component of the path
 				// remove backslashes for the remaining components only
-				++wildcarddepth;
+				++stardepth;
 				(void)dos_expandpath(gap, buf, len + 1, flags, FALSE);
-				--wildcarddepth;
+				--stardepth;
 			}
 		}
 		else
@@ -3804,7 +3803,6 @@ unix_expandpath(
     size_t	len;
     int		starstar = FALSE;
     static int	stardepth = 0;	    // depth for "**" expansion
-    static int	wildcarddepth = 0;	// depth for other wildcard expansions
 
     DIR		*dirp;
     struct dirent *dp;
@@ -3958,13 +3956,13 @@ unix_expandpath(
 		vim_snprintf((char *)buf + len, buflen - len, "%s", path_end);
 		if (mch_has_exp_wildcard(path_end)) // handle more wildcards
 		{
-			if (wildcarddepth < 100)
+			if (stardepth < 100)
 			{
 				// need to expand another component of the path
 				// remove backslashes for the remaining components only
-				++wildcarddepth;
+				++stardepth;
 				(void)unix_expandpath(gap, buf, len + 1, flags, FALSE);
-				--wildcarddepth;
+				--stardepth;
 			}
 		}
 		else


### PR DESCRIPTION
Addresses #18099
We limit recursion by introducing a new static variable wildcarddepth to keep track of other wildcard recursions. This way ** expansion limit is not changed (still 100) and overall recursion is bounded.
Set wildcarddepth max limit to 100.