### PR TITLE
Fix tabnr from `getwininfo` for popup windows

### DIFF
--- a/src/evalwindow.c
+++ b/src/evalwindow.c
@@ -563,9 +563,10 @@ f_getwininfo(typval_T *argvars, typval_T *rettv)
 	{
 	    tabnr++;
 	    FOR_ALL_POPUPWINS_IN_TAB(tp, wp)
-	    if (wp == wparg)
-		break;
+		if (wp == wparg)
+		    goto found;
 	}
+found:
 	d = get_win_info(wparg, tp == NULL ? 0 : tabnr, 0);
 	if (d != NULL)
 	    list_append_dict(rettv->vval.v_list, d);

--- a/src/testdir/test_popupwin.vim
+++ b/src/testdir/test_popupwin.vim
@@ -4619,4 +4619,19 @@ func Test_popupwin_bottom_position_without_decoration()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_popup_getwininfo_tabnr()
+  tab split
+  let winid1 = popup_create('sup', #{tabpage: 1})
+  let winid2 = popup_create('sup', {})
+  let winid3 = popup_create('sup', #{tabpage: -1})
+  call assert_equal(1, getwininfo(winid1)[0].tabnr)
+  call assert_equal(2, getwininfo(winid2)[0].tabnr)
+  call assert_equal(0, getwininfo(winid3)[0].tabnr)
+
+  call popup_close(winid1)
+  call popup_close(winid2)
+  call popup_close(winid3)
+  tabonly
+endfunc
+
 " vim: shiftwidth=2 sts=2


### PR DESCRIPTION
Problem: `getwininfo` has logic for getting the tabnr of a local popup window, but due to only breaking from the inner loop, `tp` is eventually set to `NULL`, so tabnr is always 0.

Solution: break out of both loops. Continue to use 0 for global popup windows.

That said, should anything be changed for `win_id2tabwin`? It currently returns `[0, 0]` for popups.  
Maybe it should return `[tabnr, 0]` for popup windows instead, but then 0 can't be used as the tabnr for global popups (that'd mean `[0, 0]` is ambiguous with whether it refers to a global popup or an invalid window ID). Maybe better to leave it alone?