### PR TITLE
Memzero the crypt key using sodium_zero to prevent it being optimized away

### DIFF
--- a/src/crypt.c
+++ b/src/crypt.c
@@ -780,13 +780,16 @@ crypt_decode_inplace(
     void
 crypt_free_key(char_u *key)
 {
+    // Create a safe memset which cannot be optimized away by compiler
+    void *(* volatile vim_memset_safe)(void *s, int c, size_t n) = memset;
     if (key != NULL)
     {
 #ifdef FEAT_SODIUM
-	sodium_memzero(key, STRLEN(key));
-#else
-	vim_memset(key, 0, STRLEN(key));
+	if (sodium_init() >= 0)
+	    sodium_memzero(key, STRLEN(key));
+	else
 #endif
+	    vim_memset_safe(key, 0, STRLEN(key));
 	vim_free(key);
     }
 }

--- a/src/crypt.c
+++ b/src/crypt.c
@@ -783,12 +783,11 @@ crypt_free_key(char_u *key)
     if (key != NULL)
     {
 #ifdef FEAT_SODIUM
-    sodium_memzero(key, STRLEN(key));
-    sodium_free(key);
+	sodium_memzero(key, STRLEN(key));
 #else
-    vim_memset(key, 0, STRLEN(key));
-    vim_free(key);
+	vim_memset(key, 0, STRLEN(key));
 #endif
+	vim_free(key);
     }
 }
 

--- a/src/crypt.c
+++ b/src/crypt.c
@@ -780,13 +780,15 @@ crypt_decode_inplace(
     void
 crypt_free_key(char_u *key)
 {
-    char_u *p;
-
     if (key != NULL)
     {
-	for (p = key; *p != NUL; ++p)
-	    *p = 0;
-	vim_free(key);
+#ifdef FEAT_SODIUM
+    sodium_memzero(key, STRLEN(key));
+    sodium_free(key);
+#else
+	vim_memset(key, 0, STRLEN(key));
+    vim_free(key);
+#endif
     }
 }
 

--- a/src/crypt.c
+++ b/src/crypt.c
@@ -786,7 +786,7 @@ crypt_free_key(char_u *key)
     sodium_memzero(key, STRLEN(key));
     sodium_free(key);
 #else
-	vim_memset(key, 0, STRLEN(key));
+    vim_memset(key, 0, STRLEN(key));
     vim_free(key);
 #endif
     }


### PR DESCRIPTION

The function definition of crypt_free_key is as shown:
https://github.com/vim/vim/blob/3b3b9361257c6659abb79586712886d8636387c5/src/crypt.c#L776-L791

The code looks as follows:
for (p = key; *p != NUL; ++p)
   *p = 0;
vim_free(key);

The key is first cleared by setting each byte to 0. Then it is freed. This behaviour of setting each byte to 0 to get rid of it in memory can be optimized away by the compiler as I observed in a smaller minimized example of the code snippet. This can still lead to the key persisting in memory.

There are other places in code where sensitive data is zeroed out properly with sodium_memzero which cannot be optimized away
eg. 
https://github.com/vim/vim/blob/3b3b9361257c6659abb79586712886d8636387c5/src/crypt.c#L648-L648
https://github.com/vim/vim/blob/3b3b9361257c6659abb79586712886d8636387c5/src/crypt.c#L935-L935

Additionally it should not be vim_free but sodium_free for the key.