### PR TITLE
Fix scheduler priority clamping on macOS

### DIFF
--- a/src/os_mac.h
+++ b/src/os_mac.h
@@ -47,6 +47,11 @@
 #include <dirent.h>
 
 /*
+ * Mach interface
+ */
+#include <mach/task.h>
+
+/*
  * MacOS specific #define
  */
 

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -3676,6 +3676,15 @@ mch_early_init(void)
     signal_stack = alloc(get_signal_stack_size());
     init_signal_stack();
 #endif
+
+    /*
+     * Inform the macOS scheduler that Vim renders UI, and so shouldn’t have its
+     * threads’ quality of service classes clamped.
+     */
+#ifdef MACOS_X
+    integer_t policy = TASK_DEFAULT_APPLICATION;
+    task_policy_set(mach_task_self(), TASK_CATEGORY_POLICY, &policy, 1);
+#endif
 }
 
 #if defined(EXITFREE) || defined(PROTO)


### PR DESCRIPTION
This PR allows Vim to run at the same priority as GUI applications on macOS. This makes Vim as responsive as other apps are when the system is under load.

https://github.com/user-attachments/assets/530051c2-3c5b-4dff-b95d-e244ac2e414a

The left terminal is before, and the right terminal is after. At first the system isn’t under load and both Vim instances scroll smoothly. Once I start a test program which pins all the cores of my machine, the left Vim instance’s responsiveness falls dramatically while the right one is barely affected.

Please let me know if I’ve put the code in the wrong spot, or if I should expand on how this change works.