### PR TITLE
Place global_functions[] in read-only memory

### DIFF
--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -1934,7 +1934,7 @@ typedef struct
 # define TERM_FUNC(name) NULL
 #endif
 
-static funcentry_T global_functions[] =
+static const funcentry_T global_functions[] =
 {
     {"abs",		1, 1, FEARG_1,	    arg1_float_or_nr,
 			ret_any,	    f_abs},
@@ -3360,7 +3360,7 @@ internal_func_check_arg_types(
 		return FAIL;
     }
 
-    argcheck_T	*argchecks = global_functions[idx].f_argcheck;
+    const argcheck_T	*argchecks = global_functions[idx].f_argcheck;
 
     if (argchecks == NULL)
 	return OK;

--- a/src/testdir/test_function_lists.vim
+++ b/src/testdir/test_function_lists.vim
@@ -17,7 +17,7 @@ func Test_function_lists()
   " Create a file of the functions in evalfunc.c:global_functions[].
   enew!
   read ../evalfunc.c
-  1,/^static funcentry_T global_functions\[\] =$/d
+  1,/^static const funcentry_T global_functions\[\] =$/d
   call search('^};$')
   .,$d
   v/^    {/d

--- a/src/testdir/test_function_lists.vim
+++ b/src/testdir/test_function_lists.vim
@@ -38,7 +38,7 @@ func Test_function_lists()
   " not obsolete, sorted in ASCII order.
   enew!
   read ../evalfunc.c
-  1,/^static funcentry_T global_functions\[\] =$/d
+  1,/^static const funcentry_T global_functions\[\] =$/d
   call search('^};$')
   .,$d
   v/^    {/d


### PR DESCRIPTION
Mark global_functions[] as `static const`.  The table is never modified at runtime, so keeping it in writable `.data` has no benefit.

Only a local pointer in func_check_arg_types() needed adjusting to `const`.  No functional changes.