### PR TITLE
The rule for `nl.po` in Makefile is outdated.

### DIFF
--- a/src/po/Makefile
+++ b/src/po/Makefile
@@ -91,11 +91,6 @@ tryoutinstall: $(MOFILES) $(MOCONVERTED)
 	  fi; \
 	done
 
-# nl.po was added later, if it does not exist use a file with just a # in it
-# (an empty file doesn't work with old msgfmt).
-nl.po:
-	@( echo \# >> nl.po )
-
 # Norwegian/Bokmal: "nb" is an alias for "no".
 # Copying the file is not efficient, but I don't know of another way to make
 # this work.


### PR DESCRIPTION
The rule for `nl.po` in src/po/Makefile is outdated and no longer needed.
See this: commit 84f7235, commit 8d61617 , commit 02938a9