### PR TITLE
runtime(indent):silent writing of results in `runtest.vim`

### DIFF
--- a/runtime/indent/testdir/runtest.vim
+++ b/runtime/indent/testdir/runtest.vim
@@ -125,10 +125,10 @@ for fname in glob('testdir/*.in', 1, 1)
 
     if failed
       let failed_count += 1
-      exe 'write ' .. root .. '.fail'
+      silent exe 'write ' .. root .. '.fail'
       echoerr 'Test ' .. fname .. ' FAILED!'
     else
-      exe 'write ' .. root .. '.out'
+      silent exe 'write ' .. root .. '.out'
       echo "Test " .. fname .. " OK\n"
     endif
 


### PR DESCRIPTION
To avoid littering the terminal output, silent writing of result files has been added.