### PR TITLE
filetype: recognize .bxl as bzl files

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -319,7 +319,7 @@ au BufNewFile,BufRead *.brs			setf brightscript
 au BufNewFile,BufRead *.bsd,*.bsdl			setf bsdl
 
 " Bazel (https://bazel.build) and Buck2 (https://buck2.build/)
-autocmd BufRead,BufNewFile *.bzl,*.bazel,WORKSPACE,WORKSPACE.bzlmod	setf bzl
+autocmd BufRead,BufNewFile *.bzl,*.bxl,*.bazel,WORKSPACE,WORKSPACE.bzlmod	setf bzl
 if has("fname_case")
   " There is another check for BUILD and BUCK further below.
   autocmd BufRead,BufNewFile *.BUILD,BUILD,BUCK		setf bzl

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -152,7 +152,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     brightscript: ['file.brs'],
     bsdl: ['file.bsd', 'file.bsdl'],
     bst: ['file.bst'],
-    bzl: ['file.bazel', 'file.bzl', 'WORKSPACE', 'WORKSPACE.bzlmod'],
+    bzl: ['file.bazel', 'file.bzl', 'file.bxl', 'WORKSPACE', 'WORKSPACE.bzlmod'],
     bzr: ['bzr_log.any', 'bzr_log.file'],
     c: ['enlightenment/file.cfg', 'file.qc', 'file.c', 'some-enlightenment/file.cfg', 'file.mdh', 'file.epro'],
     c3: ['file.c3', 'file.c3i', 'file.c3t'],


### PR DESCRIPTION
Problem: Buck eXtension Language files aren't recognized by Vim
automatically as Starlark. (docs: https://buck2.build/docs/bxl/)

Solution: Add detection of .bxl as Starlark in the filetype plugin.