### PR TITLE
Fix gettimeofday on windows when compiled with ruby support

### DIFF
--- a/src/proto/time.pro
+++ b/src/proto/time.pro
@@ -20,7 +20,7 @@ void f_timer_pause(typval_T *argvars, typval_T *rettv);
 void f_timer_start(typval_T *argvars, typval_T *rettv);
 void f_timer_stop(typval_T *argvars, typval_T *rettv);
 void f_timer_stopall(typval_T *argvars, typval_T *rettv);
-#if defined(MSWIN) || defined(__MINGW32__)
+#if (defined(MSWIN) || defined(__MINGW32__)) && !defined(FEAT_RUBY)
 int gettimeofday(struct timeval *tv, char *dummy);
 #endif
 void time_push(void *tv_rel, void *tv_start);

--- a/src/time.c
+++ b/src/time.c
@@ -127,7 +127,8 @@ get_ctime(time_t thetime, int add_newline)
     return buf;
 }
 
-#if defined(MSWIN) || defined(__MINGW32__)
+// Ruby has its own version of gettimeofday
+#if (defined(MSWIN) || defined(__MINGW32__)) && !defined(FEAT_RUBY)
 /*
  * Windows doesn't have gettimeofday(), although it does have struct timeval.
  */


### PR DESCRIPTION
Fixes #18143