### PR TITLE
Screen not redrawn properly on t_RB response

### DIFF
--- a/src/term.c
+++ b/src/term.c
@@ -5740,8 +5740,11 @@ handle_osc(char_u *tp, int len, char_u *key_name, int *slen)
 #ifdef FEAT_EVAL
 	    set_vim_var_string_direct(VV_TERMOSC, osc_state.buf.ga_data);
 #endif
+	    char_u savebg = *p_bg;
 	    apply_autocmds(EVENT_TERMRESPONSEALL, (char_u *)"osc",
 		    NULL, FALSE, curbuf);
+	    if (*p_bg != savebg)
+		redraw_asap(UPD_CLEAR);
 	    return OK;
 	}
 


### PR DESCRIPTION
Problem:  screen not redrawn properly on t_RB response (after v9.1.1703)
Solution: call redraw_asap() if necessary

#### Steps to reproduce the bug:

1. Terminal: kitty, os: Arch Linux, shell: bash
2. `$ cat reqbg.vim`
```viml
let &t_RF = "\e]10;?\e\\"
let &t_RB = "\e]11;?\e\\"
colo lunaperche
```

4. `$ vim --clean  +'runtime plugin/colorresp.vim' +'so reqbg.vim'`


Result: bg=light is used initially, bg=dark is detected but the screen stays white. On user input the screen is redrawn with bg=dark.

[2025-08-28_02-56_38.webm](https://github.com/user-attachments/assets/c6a3a8cd-8acd-420a-9253-3d98ffd5fac8)


Expected behavior: vim should use dark bg as soon as it is detected.

My first idea was to fix this with a simple `:redraw` command in colorresp.vim,

```diff
diff --git i/runtime/plugin/colorresp.vim w/runtime/plugin/colorresp.vim
index f597dc7eb..381609b5b 100644
--- i/runtime/plugin/colorresp.vim
+++ w/runtime/plugin/colorresp.vim
@@ -29,6 +29,7 @@ augroup ColorResp

         v:termrbgresp = v:termosc
         &background = new_bg_val
+        redraw
         # For backwards compatibility
         if exists('#TermResponseAll#background')
           doautocmd <nomodeline> TermResponseAll background
```

but if we do this then the intro message disappears immediately.
We have to call redraw_asap() which handles maybe_intro_message() correctly.
