### PR TITLE
fix fvwm2rc.m4 ft detection

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -601,31 +601,36 @@ enddef
 
 # For files ending in *.m4, distinguish:
 #  – *.html.m4 files
+#  - fvwm2rc.m4
 #  – files in the Autoconf M4 dialect
 #  – files in POSIX M4
 export def FTm4()
   var fname = expand('%:t')
   var path  = expand('%:p:h')
 
-  # Case 0: canonical Autoconf file
-  if fname ==# 'aclocal.m4'
-    setf config
+  if fname ==# 'fvwm2rc.m4'
+    setf fvwm2m4
     return
   endif
 
-  # Case 1: html.m4
   if fname =~# 'html\.m4$'
     setf htmlm4
     return
   endif
 
-  # Case 2: repo heuristic (nearby configure.ac)
+  # Canonical Autoconf file
+  if fname ==# 'aclocal.m4'
+    setf config
+    return
+  endif
+
+  # Repo heuristic for Autoconf M4 (nearby configure.ac)
   if filereadable(path .. '/../configure.ac') || filereadable(path .. '/configure.ac')
     setf config
     return
   endif
 
-  # Case 3: content heuristic (scan first ~200 lines)
+  # Content heuristic for Autoconf M4 (scan first ~200 lines)
   # Signals:
   #   - Autoconf macro prefixes: AC_/AM_/AS_/AU_/AT_
   var n = 1
@@ -639,7 +644,7 @@ export def FTm4()
     n += 1
   endwhile
 
-  # Case 4: default to POSIX M4
+  # Default to POSIX M4
   setf m4
 enddef
 

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -309,6 +309,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     func: ['file.fc'],
     fusion: ['file.fusion'],
     fvwm: ['/.fvwm/file', 'any/.fvwm/file'],
+    fvwm2m4: ['fvwm2rc.m4'],
     gdb: ['.gdbinit', 'gdbinit', '.cuda-gdbinit', 'cuda-gdbinit', 'file.gdb', '.config/gdbearlyinit', '.gdbearlyinit'],
     gdmo: ['file.mo', 'file.gdmo'],
     gdresource: ['file.tscn', 'file.tres'],


### PR DESCRIPTION
Fix filetype detection for `fvwm2rc.m4` which has its own dedicated filetype `fvwm2m4`.

I added a new line to the filetype test so that kind of bug will not happen anymore.