### PR TITLE
runtime(doc): Add [range] spec to :help :tcl and :help :tclfile

### DIFF
--- a/runtime/doc/if_tcl.txt
+++ b/runtime/doc/if_tcl.txt
@@ -26,7 +26,7 @@ comments, ideas etc to <Ingo.Wilken@informatik.uni-oldenburg.de>
 1. Commands				*tcl-ex-commands* *E571* *E572*
 
 							*:tcl*
-:tcl {cmd}		Execute Tcl command {cmd}.  A simple check if `:tcl`
+:[range]tcl {cmd}	Execute Tcl command {cmd}.  A simple check if `:tcl`
 			is working: >
 				:tcl puts "Hello"
 
@@ -69,7 +69,8 @@ To see what version of Tcl you have: >
 			See |tcl-var-line| and |tcl-var-lnum|.
 
 							*:tclfile* *:tclf*
-:tclf[ile] {file}	Execute the Tcl script in {file}.  This is the same as
+:[range]tclf[ile] {file}
+			Execute the Tcl script in {file}.  This is the same as
 			":tcl source {file}", but allows file name completion.
 
 


### PR DESCRIPTION
A range is allowed for all :tcl* commands.
