### PR TITLE
filetype: recognize KYAML

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1377,6 +1377,9 @@ au BufNewFile,BufRead *.ks			setf kscript
 " Kconfig
 au BufNewFile,BufRead Kconfig,Kconfig.debug,Config.in	setf kconfig
 
+" Kyaml
+au BufNewFile,BufRead *.kyaml,*.kyml		setf yaml
+
 " Lace (ISE)
 au BufNewFile,BufRead *.ace,*.ACE		setf lace
 

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -929,7 +929,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     xsd: ['file.xsd'],
     xslt: ['file.xsl', 'file.xslt'],
     yacc: ['file.yy', 'file.yxx', 'file.y++'],
-    yaml: ['file.yaml', 'file.yml', 'file.eyaml', 'any/.bundle/config', '.clangd', '.clang-format', '.clang-tidy', 'file.mplstyle', 'matplotlibrc', 'yarn.lock',
+    yaml: ['file.yaml', 'file.yml', 'file.eyaml', 'file.kyaml', 'file.kyml', 'any/.bundle/config', '.clangd', '.clang-format', '.clang-tidy', 'file.mplstyle', 'matplotlibrc', 'yarn.lock',
            '/home/user/.kube/config', '.condarc', 'condarc', 'pixi.lock'],
     yang: ['file.yang'],
     yuck: ['file.yuck'],


### PR DESCRIPTION
Add support for KYAML - a strict subset of YAML from Kubernetes
https://kubernetes.io/blog/2025/08/27/kubernetes-v1-34-release/#alpha-support-for-kyaml-a-kubernetes-dialect-of-yaml