### PR TITLE
Revert globalized `gettimeofday()` function on Windows

### DIFF
--- a/src/proto/time.pro
+++ b/src/proto/time.pro
@@ -20,9 +20,6 @@ void f_timer_pause(typval_T *argvars, typval_T *rettv);
 void f_timer_start(typval_T *argvars, typval_T *rettv);
 void f_timer_stop(typval_T *argvars, typval_T *rettv);
 void f_timer_stopall(typval_T *argvars, typval_T *rettv);
-#if (defined(MSWIN) || defined(__MINGW32__)) && !defined(FEAT_RUBY)
-int gettimeofday(struct timeval *tv, char *dummy);
-#endif
 void time_push(void *tv_rel, void *tv_start);
 void time_pop(void *tp);
 void time_msg(char *mesg, void *tv_start);

--- a/src/time.c
+++ b/src/time.c
@@ -127,21 +127,6 @@ get_ctime(time_t thetime, int add_newline)
     return buf;
 }
 
-// Ruby has its own version of gettimeofday
-#if (defined(MSWIN) || defined(__MINGW32__)) && !defined(FEAT_RUBY)
-/*
- * Windows doesn't have gettimeofday(), although it does have struct timeval.
- */
-    int
-gettimeofday(struct timeval *tv, char *dummy UNUSED)
-{
-    long t = clock();
-    tv->tv_sec = t / CLOCKS_PER_SEC;
-    tv->tv_usec = (t - tv->tv_sec * CLOCKS_PER_SEC) * 1000000 / CLOCKS_PER_SEC;
-    return 0;
-}
-#endif
-
 #if defined(FEAT_EVAL) || defined(PROTO)
 
 #if defined(MACOS_X)
@@ -961,6 +946,20 @@ f_timer_stopall(typval_T *argvars UNUSED, typval_T *rettv UNUSED)
 
 # if defined(STARTUPTIME) || defined(PROTO)
 static struct timeval	prev_timeval;
+
+#  ifdef MSWIN
+/*
+ * Windows doesn't have gettimeofday(), although it does have struct timeval.
+ */
+    static int
+gettimeofday(struct timeval *tv, char *dummy UNUSED)
+{
+    long t = clock();
+    tv->tv_sec = t / CLOCKS_PER_SEC;
+    tv->tv_usec = (t - tv->tv_sec * CLOCKS_PER_SEC) * 1000000 / CLOCKS_PER_SEC;
+    return 0;
+}
+#  endif
 
 /*
  * Save the previous time before doing something that could nest.


### PR DESCRIPTION
NOTE: Merge this PR after merging #18147 and #18165.

Fixes #18162 #18161 #18170 