### PR TITLE
fix: wrong indent

### DIFF
--- a/src/drawline.c
+++ b/src/drawline.c
@@ -3481,9 +3481,10 @@ win_line(
 			wlv.extra_attr = hl_combine_attr(wlv.win_attr,
 							       HL_ATTR(HLF_8));
 #ifdef FEAT_PROP_POPUP
-		    if (text_prop_type != NULL &&
-			     text_prop_flags & PT_FLAG_OVERRIDE)
-			wlv.extra_attr = hl_combine_attr(text_prop_attr, wlv.extra_attr);
+			if (text_prop_type != NULL &&
+				 text_prop_flags & PT_FLAG_OVERRIDE)
+			    wlv.extra_attr = hl_combine_attr(text_prop_attr,
+							       wlv.extra_attr);
 #endif
 
 			saved_attr2 = wlv.char_attr; // save current attr


### PR DESCRIPTION
Problem: The code inside a macro was indented incorrectly.
Solution: Adjusted the indentation by one level.