### PR TITLE
fix: silence uninitialized variable warning by clang

### DIFF
--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -9773,7 +9773,7 @@ eval_vars(
 {
     int		i;
     char_u	*s;
-    char_u	*result;
+    char_u	*result = (char_u *)"";
     char_u	*resultbuf = NULL;
     size_t	resultlen;
     buf_T	*buf;
@@ -10064,10 +10064,6 @@ eval_vars(
 #endif
 		break;
 #endif
-
-	default:
-		result = (char_u *)""; // avoid gcc warning
-		break;
 	}
 
 	resultlen = STRLEN(result);	// length of new string


### PR DESCRIPTION
This PR fixes an uninitialized variable warning produced by clang 21.1.0.

```
clang -c -I. -Iproto -DHAVE_CONFIG_H   -DMACOS_X -DMACOS_X_DARWIN -DMACOS_X -DMACOS_X_DARWIN -DMACOS_X -DMACOS_X_DARWIN -DMACOS_X -DMACOS_X_DARWIN -DMACOS_X -DMACOS_X_DARWIN -DMACOS_X -DMACOS_X_DARWIN -I/opt/homebrew/Cellar/libsodium/1.0.20/include  -O2   -Wall -Wno-deprecated-declarations -I/opt/homebrew/Cellar/libsodium/1.0.20/include -D_REENTRANT -I/opt/homebrew/Cellar/libsodium/1.0.20/include -I/opt/homebrew/Cellar/libsodium/1.0.20/include -I/opt/homebrew/Cellar/libsodium/1.0.20/include -I/opt/homebrew/Cellar/libsodium/1.0.20/include  -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1        -o objects/ex_docmd.o ex_docmd.c
ex_docmd.c:10048:7: warning: variable 'result' is used uninitialized whenever 'if' condition is false [-Wsometimes-uninitialized]
 10048 |                 if (clientserver_method == CLIENTSERVER_METHOD_SOCKET)
       |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ex_docmd.c:10073:21: note: uninitialized use occurs here
 10073 |         resultlen = STRLEN(result);     // length of new string
       |                            ^~~~~~
ex_docmd.c:10048:3: note: remove the 'if' if its condition is always true
 10048 |                 if (clientserver_method == CLIENTSERVER_METHOD_SOCKET)
       |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 10049 |                 {
ex_docmd.c:9776:19: note: initialize the variable 'result' to silence this warning
 9776 |     char_u      *result;
      |                        ^
      |                         = NULL
```

**Environment**

- Compiler: `clang --version`
   ```
   Homebrew clang version 21.1.0
   Target: arm64-apple-darwin24.5.0
   Thread model: posix
   InstalledDir: /opt/homebrew/Cellar/llvm/21.1.0/bin
   Configuration file: /opt/homebrew/etc/clang/arm64-apple-darwin24.cfg
   ```
- OS: macOS 15.5 Sequoia