### PR TITLE
 feat: Run :make command using builtin terminal

### DIFF
--- a/src/errors.h
+++ b/src/errors.h
@@ -3797,3 +3797,7 @@ EXTERN char e_osc_response_timed_out[]
 EXTERN char e_cannot_add_listener_in_listener_callback[]
 	INIT(= N_("E1569: Cannot use listener_add in a listener callback"));
 #endif
+#if defined(FEAT_QUICKFIX) && defined(FEAT_TERMINAL)
+EXTERN char e_already_running_make_command[]
+	INIT(= N_("E1569: Already running a make command"));
+#endif

--- a/src/evalvars.c
+++ b/src/evalvars.c
@@ -5207,6 +5207,24 @@ f_setbufvar(typval_T *argvars, typval_T *rettv UNUSED)
 }
 
 /*
+ * Create a callback from the given function pointer callback.
+ */
+    callback_T
+create_callback(void (*callback)(typval_T *argvars, typval_T *rettv))
+{
+    callback_T res;
+
+    CLEAR_FIELD(res);
+
+    // We don't want a NULL or empty cb_name since we may be ignored thinking
+    // the callback is empty.
+    res.cb_name = (char_u *)" ";
+    res.cb_fp = callback;
+
+    return res;
+}
+
+/*
  * Get a callback from "arg".  It can be a Funcref or a function name.
  * When "arg" is zero "res.cb_name" is set to an empty string.
  * If "res.cb_name" is allocated then "res.cb_free_name" is set to TRUE.
@@ -5270,11 +5288,16 @@ put_callback(callback_T *cb, typval_T *tv)
 	tv->vval.v_partial = cb->cb_partial;
 	++tv->vval.v_partial->pt_refcount;
     }
-    else
+    else if (cb->cb_fp == NULL)
     {
 	tv->v_type = VAR_FUNC;
 	tv->vval.v_string = vim_strsave(cb->cb_name);
 	func_ref(cb->cb_name);
+    }
+    else
+    {
+	tv->v_type = VAR_UNKNOWN;
+	internal_error("put_callback()");
     }
 }
 
@@ -5285,11 +5308,19 @@ put_callback(callback_T *cb, typval_T *tv)
     void
 set_callback(callback_T *dest, callback_T *src)
 {
+    if (src->cb_fp != NULL)
+    {
+	dest->cb_name = src->cb_name;
+	dest->cb_fp = src->cb_fp;
+	return;
+    }
+
     if (src->cb_partial == NULL)
     {
 	// just a function name, make a copy
 	dest->cb_name = vim_strsave(src->cb_name);
 	dest->cb_free_name = TRUE;
+	dest->cb_fp = NULL;
     }
     else
     {
@@ -5306,17 +5337,26 @@ set_callback(callback_T *dest, callback_T *src)
     void
 copy_callback(callback_T *dest, callback_T *src)
 {
+    if (src->cb_fp != NULL)
+    {
+	dest->cb_name = src->cb_name;
+	dest->cb_fp = src->cb_fp;
+	return;
+    }
+
     dest->cb_partial = src->cb_partial;
     if (dest->cb_partial != NULL)
     {
 	dest->cb_name = src->cb_name;
 	dest->cb_free_name = FALSE;
+	dest->cb_fp = NULL;
 	++dest->cb_partial->pt_refcount;
     }
     else
     {
 	dest->cb_name = vim_strsave(src->cb_name);
 	dest->cb_free_name = TRUE;
+	dest->cb_fp = NULL;
 	func_ref(src->cb_name);
     }
 }
@@ -5390,6 +5430,7 @@ free_callback(callback_T *callback)
 	callback->cb_free_name = FALSE;
     }
     callback->cb_name = NULL;
+    callback->cb_fp = NULL;
 }
 
 #endif // FEAT_EVAL

--- a/src/ex_cmds.h
+++ b/src/ex_cmds.h
@@ -1974,13 +1974,13 @@ struct exarg
 #ifdef FEAT_EVAL
     cstack_T	*cstack;	// condition stack for ":if" etc.
 #endif
-    // Used by :make
+#ifdef FEAT_TERMINAL
+    // Used by :make ++term
     struct {
-	long rows;
-	long cols;
-	int use_term;
-	int term_hidden;
+	int	    use_term;   // ++term
+	jobopt_T    opt;
     } make_info;
+#endif
 };
 
 #define FORCE_BIN 1		// ":edit ++bin file"

--- a/src/ex_cmds.h
+++ b/src/ex_cmds.h
@@ -1974,6 +1974,13 @@ struct exarg
 #ifdef FEAT_EVAL
     cstack_T	*cstack;	// condition stack for ":if" etc.
 #endif
+    // Used by :make
+    struct {
+	long rows;
+	long cols;
+	int use_term;
+	int term_hidden;
+    } make_info;
 };
 
 #define FORCE_BIN 1		// ":edit ++bin file"

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -5019,6 +5019,9 @@ replace_makeprg(exarg_T *eap, char_u *p, char_u **cmdlinep)
 
 	p = skipwhite(p);
 
+#ifdef FEAT_TERMINAL
+	init_job_options(&eap->make_info.opt);
+
 	// Check for ++term and ++hidden arguments for :make/:lmake
 	while (p[0] == '+' && p[1] == '+')
 	{
@@ -5030,16 +5033,21 @@ replace_makeprg(exarg_T *eap, char_u *p, char_u **cmdlinep)
 	    if (STRNCMP(p, "term", 4) == 0)
 		eap->make_info.use_term = TRUE;
 	    else if (STRNCMP(p, "hidden", 6) == 0)
-		eap->make_info.term_hidden = TRUE;
+		eap->make_info.opt.jo_hidden = TRUE;
 	    else if (STRNCMP(p, "rows", 4) == 0 && ep != NULL
 		    && SAFE_isdigit(ep[1]))
-		eap->make_info.rows = atoi((char *)ep + 1);
+		eap->make_info.opt.jo_term_rows = atoi((char *)ep + 1);
 	    else if (STRNCMP(p, "cols", 4) == 0 && ep != NULL
 		    && SAFE_isdigit(ep[1]))
-		eap->make_info.cols = atoi((char *)ep + 1);
+		eap->make_info.opt.jo_term_cols = atoi((char *)ep + 1);
+	    else if (STRNCMP(p, "open", 4) == 0)
+		eap->make_info.opt.jo_term_finish = 'o';
+	    else if (STRNCMP(p, "curwin", 4) == 0)
+		eap->make_info.opt.jo_curwin = TRUE;
 
 	    p = skipwhite(skiptowhite(p));
 	}
+#endif
 
 	if ((pos = (char_u *)strstr((char *)program, "$*")) != NULL)
 	{

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -5019,6 +5019,28 @@ replace_makeprg(exarg_T *eap, char_u *p, char_u **cmdlinep)
 
 	p = skipwhite(p);
 
+	// Check for ++term and ++hidden arguments for :make/:lmake
+	while (p[0] == '+' && p[1] == '+')
+	{
+	    char_u *ep;
+
+	    p += 2;
+	    ep = vim_strchr(p, '=');
+
+	    if (STRNCMP(p, "term", 4) == 0)
+		eap->make_info.use_term = TRUE;
+	    else if (STRNCMP(p, "hidden", 6) == 0)
+		eap->make_info.term_hidden = TRUE;
+	    else if (STRNCMP(p, "rows", 4) == 0 && ep != NULL
+		    && SAFE_isdigit(ep[1]))
+		eap->make_info.rows = atoi((char *)ep + 1);
+	    else if (STRNCMP(p, "cols", 4) == 0 && ep != NULL
+		    && SAFE_isdigit(ep[1]))
+		eap->make_info.cols = atoi((char *)ep + 1);
+
+	    p = skipwhite(skiptowhite(p));
+	}
+
 	if ((pos = (char_u *)strstr((char *)program, "$*")) != NULL)
 	{
 	    // replace $* by given arguments

--- a/src/proto/evalvars.pro
+++ b/src/proto/evalvars.pro
@@ -105,6 +105,7 @@ void f_settabvar(typval_T *argvars, typval_T *rettv);
 void f_settabwinvar(typval_T *argvars, typval_T *rettv);
 void f_setwinvar(typval_T *argvars, typval_T *rettv);
 void f_setbufvar(typval_T *argvars, typval_T *rettv);
+callback_T create_callback(void (*callback)(typval_T *argvars, typval_T *rettv));
 callback_T get_callback(typval_T *arg);
 void put_callback(callback_T *cb, typval_T *tv);
 void set_callback(callback_T *dest, callback_T *src);

--- a/src/proto/terminal.pro
+++ b/src/proto/terminal.pro
@@ -1,6 +1,6 @@
 /* terminal.c */
 void init_job_options(jobopt_T *opt);
-buf_T *term_start(typval_T *argvar, char **argv, jobopt_T *opt, int flags);
+buf_T *term_start(typval_T *argvar, char **argv, jobopt_T *opt, int flags, char_u *pattern);
 void ex_terminal(exarg_T *eap);
 int expand_terminal_opt(char_u *pat, expand_T *xp, regmatch_T *rmp, char_u ***matches, int *numMatches);
 int term_write_session(FILE *fd, win_T *wp, hashtab_T *terminal_bufs);
@@ -67,6 +67,7 @@ void f_term_setapi(typval_T *argvars, typval_T *rettv);
 void f_term_setrestore(typval_T *argvars, typval_T *rettv);
 void f_term_setkill(typval_T *argvars, typval_T *rettv);
 void f_term_start(typval_T *argvars, typval_T *rettv);
+void term_wait(buf_T *buf, long wait);
 void f_term_wait(typval_T *argvars, typval_T *rettv);
 void term_send_eof(channel_T *ch);
 job_T *term_getjob(term_T *term);

--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -162,6 +162,17 @@ typedef struct qf_delq_S
 } qf_delq_T;
 static qf_delq_T *qf_delq_head = NULL;
 
+// Contains info for current make command running in the terminal
+typedef struct {
+    bool	running;
+    bool	jump_to_first;
+    cmdidx_T	cmdidx;
+    char_u	*cmd;
+    win_T	*wp;
+    buf_T	*buf;
+    bufref_T	bufref; // Buffer :make was called in
+} qf_make_info;
+
 // Counter to prevent autocmds from freeing up location lists when they are
 // still being used.
 static int	quickfix_busy = 0;
@@ -5440,6 +5451,112 @@ make_get_fullcmd(char_u *makecmd, char_u *fname)
     return cmd;
 }
 
+#ifdef FEAT_TERMINAL
+
+static qf_make_info make_info;
+
+    static void
+make_command_exit_cb(typval_T *args UNUSED, typval_T *rettv UNUSED)
+{
+    char_u	*au_name;
+    int		res;
+    int_u	save_qfid;
+    qf_info_T	*qi = ql_info;
+    win_T	*wp = NULL;
+
+    if (!make_info.running)
+	return;
+
+    if (make_info.cmdidx == CMD_lmake)
+    {
+	// Check if window is still valid
+	if (!win_valid_any_tab(make_info.wp))
+	    goto exit;
+
+	qi = ll_get_or_alloc_list(make_info.wp);
+	wp = make_info.wp;
+    }
+    if (qi == NULL)
+	goto exit;
+
+    // Wait for terminal to finish
+    term_wait(make_info.buf, -1);
+
+    incr_quickfix_busy();
+
+    // Create quickfix/location list from terminal buffer
+    res = qf_init_ext(qi, qi->qf_curlist, NULL, make_info.buf, NULL, p_efm,
+	    TRUE, 1, make_info.buf->b_ml.ml_line_count, make_info.cmd, NULL);
+
+    if (qf_stack_empty(qi))
+    {
+	decr_quickfix_busy();
+	goto exit;
+    }
+    if (res >= 0)
+	qf_list_changed(qf_get_curlist(qi));
+
+    au_name = make_get_auname(make_info.cmdidx);
+
+    // Remember the current quickfix list identifier, so that we can
+    // check for autocommands changing the current quickfix list.
+    save_qfid = qf_get_curlist(qi)->qf_id;
+
+    if (au_name != NULL && bufref_valid(&make_info.bufref))
+	// Call autocmd in context of buffer that :make was called in
+	apply_autocmds(EVENT_QUICKFIXCMDPOST, au_name,
+		make_info.bufref.br_buf->b_fname, TRUE, make_info.bufref.br_buf);
+
+    // Jump to first error if there are any and user didn't specify not to
+    if (res > 0 && make_info.jump_to_first && qflist_valid(wp, save_qfid))
+	qf_jump_first(qi, save_qfid, FALSE);
+
+    decr_quickfix_busy();
+exit:
+    make_info.running = false;
+    vim_free(make_info.cmd);
+}
+
+    static void
+run_make_in_terminal(exarg_T *eap)
+{
+    typval_T	argvar[2];
+    jobopt_T    opt;
+
+    init_job_options(&opt);
+
+    argvar[0].v_type = VAR_STRING;
+    argvar[0].vval.v_string = eap->arg;
+    argvar[1].v_type = VAR_UNKNOWN;
+
+    opt.jo_hidden = eap->make_info.term_hidden;
+    if (eap->make_info.rows > 0)
+    {
+	opt.jo_term_rows = eap->make_info.rows;
+	opt.jo_set2 |= JO2_TERM_ROWS;
+    }
+    if (eap->make_info.cols > 0)
+    {
+	opt.jo_term_cols = eap->make_info.cols;
+	opt.jo_set2 |= JO2_TERM_COLS;
+    }
+
+    opt.jo_exit_cb = create_callback(make_command_exit_cb);
+    opt.jo_set |= JO_EXIT_CB;
+
+    make_info.running = true;
+    make_info.cmdidx = eap->cmdidx;
+    make_info.cmd = vim_strsave(eap->arg);
+    make_info.jump_to_first = !eap->forceit;
+    make_info.wp = curwin;
+
+    set_bufref(&make_info.bufref, curbuf);
+
+    make_info.buf = term_start(argvar, NULL, &opt, 0, make_get_auname(eap->cmdidx));
+}
+
+# endif
+
 /*
  * Used for ":make", ":lmake", ":grep", ":lgrep", ":grepadd", and ":lgrepadd"
  */
@@ -5457,6 +5574,15 @@ ex_make(exarg_T *eap)
     char_u	*errorformat = p_efm;
     int		newlist = TRUE;
 
+#ifdef FEAT_TERMINAL
+    if (eap->cmdidx == CMD_make || eap->cmdidx == CMD_lmake)
+	if (make_info.running)
+	{
+	    emsg(_(e_already_running_make_command));
+	    return;
+	}
+#endif
+
     // Redirect ":grep" to ":vimgrep" if 'grepprg' is "internal".
     if (grep_internal(eap->cmdidx))
     {
@@ -5473,6 +5599,15 @@ ex_make(exarg_T *eap)
 	    return;
 #endif
     }
+
+#ifdef FEAT_TERMINAL
+    if (eap->make_info.use_term)
+    {
+	run_make_in_terminal(eap);
+	return;
+    }
+#endif
+
     enc = (*curbuf->b_p_menc != NUL) ? curbuf->b_p_menc : p_menc;
 
     if (is_loclist_cmd(eap->cmdidx))

--- a/src/structs.h
+++ b/src/structs.h
@@ -1474,7 +1474,8 @@ typedef long_u hash_T;		// Type for hi_hash
 #endif
 
 // Struct that holds both a normal function name and a partial_T, as used for a
-// callback argument.
+// callback argument. It could also instead hold a function pointer to directly
+// be called instead. if it is not NULL.
 // When used temporarily "cb_name" is not allocated.  The refcounts to either
 // the function or the partial are incremented and need to be decremented
 // later with free_callback().
@@ -1482,6 +1483,7 @@ typedef struct {
     char_u	*cb_name;
     partial_T	*cb_partial;
     int		cb_free_name;	    // cb_name was allocated
+    void	(*cb_fp)(typval_T *argvars, typval_T *rettv);
 } callback_T;
 
 typedef struct isn_S isn_T;	    // instruction
@@ -2698,6 +2700,8 @@ struct channel_S {
     void	(*ch_nb_close_cb)(void);
 				// callback for Netbeans when channel is
 				// closed
+    void	(*ch_make_callback)(channel_T *ch, char_u *msg);
+    void	(*ch_make_exit_cb)(channel_T *ch, char_u *msg);
 
 #ifdef MSWIN
     int		ch_named_pipe;	// using named pipe instead of pty

--- a/src/testdir/test_quickfix.vim
+++ b/src/testdir/test_quickfix.vim
@@ -6958,4 +6958,13 @@ func Test_vimgrep_dummy_buffer_keep()
   %bw!
 endfunc
 
+" Test if :make with ++term option works correctly
+func Test_terminal_make()
+  set makeprg=
+
+
+
+  set makeprg&
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -3796,6 +3796,14 @@ call_callback(
     funcexe_T	funcexe;
     int		ret;
 
+    if (callback->cb_fp != NULL)
+    {
+	// Callback is a function pointer, just call it.
+	rettv->v_type = VAR_UNKNOWN;
+	callback->cb_fp(argvars, rettv);
+	return OK;
+    }
+
     if (callback->cb_name == NULL || *callback->cb_name == NUL)
 	return FAIL;
 


### PR DESCRIPTION
Pass ++term to `:make` or `:lmake` to run it in a terminal in a new tab. The quickfix/location list will be populated when the command is finished, autocmds triggered, and first error jumped to if specified. It is partially implemented in C and the rest in Vimscript.