### PR TITLE
Do not use += in configure

### DIFF
--- a/src/auto/configure
+++ b/src/auto/configure
@@ -9326,12 +9326,10 @@ fi
 
     if test "$enable_wayland_fs" = "yes"
 then :
-  WAYLAND_SRC+=" \
-            auto/wayland/xdg-shell.c \
-            auto/wayland/primary-selection-unstable-v1.c"
-           WAYLAND_OBJ+=" \
-            objects/xdg-shell.o \
-            objects/primary-selection-unstable-v1.o"
+  as_fn_append WAYLAND_SRC " auto/wayland/xdg-shell.c"
+          as_fn_append WAYLAND_SRC " auto/wayland/primary-selection-unstable-v1.c"
+          as_fn_append WAYLAND_OBJ " objects/xdg-shell.o"
+          as_fn_append WAYLAND_OBJ " objects/primary-selection-unstable-v1.o"
 fi
 
 

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -2499,12 +2499,10 @@ if test "$with_wayland" = yes; then
       objects/wayland.o"
 
     AS_IF([test "$enable_wayland_fs" = "yes"],
-          [WAYLAND_SRC+=" \
-            auto/wayland/xdg-shell.c \
-            auto/wayland/primary-selection-unstable-v1.c"
-           WAYLAND_OBJ+=" \
-            objects/xdg-shell.o \
-            objects/primary-selection-unstable-v1.o"])
+          [AS_VAR_APPEND([WAYLAND_SRC], " auto/wayland/xdg-shell.c")
+          AS_VAR_APPEND([WAYLAND_SRC], " auto/wayland/primary-selection-unstable-v1.c")
+          AS_VAR_APPEND([WAYLAND_OBJ], " objects/xdg-shell.o")
+          AS_VAR_APPEND([WAYLAND_OBJ], " objects/primary-selection-unstable-v1.o")])
 
     AC_SUBST(WAYLAND_CPPFLAGS)
     AC_SUBST(WAYLAND_CFLAGS)


### PR DESCRIPTION
In POSIX sh, += is undefined.
This can cause builds to fail on, for example, Alpine Linux.

Build log:
https://github.com/thinca/dockerfile-vim/actions/runs/17385519273/job/49351197764#step:4:623