### PR TITLE
syntax(m4): several fixes

### DIFF
--- a/runtime/syntax/m4.vim
+++ b/runtime/syntax/m4.vim
@@ -1,9 +1,7 @@
 " Vim syntax file
-" Language:		M4
+" Language:	M4
 " Maintainer:	Claudio Fleiner (claudio@fleiner.com)
-" URL:			http://www.fleiner.com/vim/syntax/m4.vim
-" 				(outdated)
-" Last Change:	2022 Jun 12
+" Last Change:	2025 Sep 1
 
 " This file will highlight user function calls if they use only
 " capital letters and have at least one argument (i.e. the '('
@@ -18,6 +16,23 @@ if !exists("main_syntax")
   let main_syntax='m4'
 endif
 
+" Reference: The Open Group Base Specifications, M4
+" https://pubs.opengroup.org/onlinepubs/9799919799/
+
+" Quoting in M4:
+" – Quotes are nestable;
+" – The delimiters can be redefined with changequote(); here we only handle
+"   the default pair: ` ... ';
+" – Quoted text in M4 is rescanned, not treated as a literal string;
+"   Therefore the region is marked transparent so contained items retain
+"   their normal highlighting.
+syn region m4Quoted
+  \ matchgroup=m4QuoteDelim
+  \ start=+`+
+  \ end=+'+
+  \ contains=@m4Top
+  \ transparent
+
 " define the m4 syntax
 syn match  m4Variable contained "\$\d\+"
 syn match  m4Special  contained "$[@*#]"
@@ -30,28 +45,26 @@ syn region m4Paren    matchgroup=m4Delimiter start="(" end=")" contained contain
 syn region m4Command  matchgroup=m4Function  start="\<\(m4_\)\=\(define\|defn\|pushdef\)(" end=")" contains=@m4Top
 syn region m4Command  matchgroup=m4Preproc   start="\<\(m4_\)\=\(include\|sinclude\)("he=e-1 end=")" contains=@m4Top
 syn region m4Command  matchgroup=m4Statement start="\<\(m4_\)\=\(syscmd\|esyscmd\|ifdef\|ifelse\|indir\|builtin\|shift\|errprint\|m4exit\|changecom\|changequote\|changeword\|m4wrap\|debugfile\|divert\|undivert\)("he=e-1 end=")" contains=@m4Top
-syn region m4Command  matchgroup=m4builtin start="\<\(m4_\)\=\(len\|index\|regexp\|substr\|translit\|patsubst\|format\|incr\|decr\|eval\|maketemp\)("he=e-1 end=")" contains=@m4Top
+syn region m4Command  matchgroup=m4Builtin start="\<\(m4_\)\=\(len\|index\|regexp\|substr\|translit\|patsubst\|format\|incr\|decr\|eval\|maketemp\)("he=e-1 end=")" contains=@m4Top
 syn keyword m4Statement divert undivert
 syn region m4Command  matchgroup=m4Type      start="\<\(m4_\)\=\(undefine\|popdef\)("he=e-1 end=")" contains=@m4Top
 syn region m4Function matchgroup=m4Type      start="\<[_A-Z][_A-Z0-9]*("he=e-1 end=")" contains=@m4Top
-syn region m4String   start="`" end="'" contains=SpellErrors
-syn cluster m4Top     contains=m4Comment,m4Constants,m4Special,m4Variable,m4String,m4Paren,m4Command,m4Statement,m4Function
+syn cluster m4Top     contains=m4Comment,m4Constants,m4Special,m4Variable,m4Paren,m4Command,m4Statement,m4Function,m4Quoted
 
 " Define the default highlighting.
 " Only when an item doesn't have highlighting yet
-hi def link m4Delimiter Delimiter
-hi def link m4Comment   Comment
-hi def link m4Function  Function
-hi def link m4Keyword   Keyword
-hi def link m4Special   Special
-hi def link m4String    String
-hi def link m4Statement Statement
-hi def link m4Preproc   PreProc
-hi def link m4Type      Type
-hi def link m4Special   Special
-hi def link m4Variable  Special
-hi def link m4Constants Constant
-hi def link m4Builtin   Statement
+hi def link m4QuoteDelim  Delimiter
+hi def link m4Delimiter   Delimiter
+hi def link m4Comment     Comment
+hi def link m4Function    Function
+hi def link m4Keyword     Keyword
+hi def link m4Special     Special
+hi def link m4Statement   Statement
+hi def link m4Preproc     PreProc
+hi def link m4Type        Type
+hi def link m4Variable    Special
+hi def link m4Constants   Constant
+hi def link m4Builtin     Statement
 
 let b:current_syntax = "m4"
 


### PR DESCRIPTION
**Summary**
This PR aligns the M4 syntax file with how quoting actually works in M4 (see #15903).
- In M4 there are no “strings” in the usual sense. Instead, M4 has quotes, but the text inside a quoted region is rescanned just like outside, and quotes can be nested.
- The old m4String region was misleading and removed. A new m4Quoted region reflects proper quoting semantics.

**Other fixes**
- Removed a duplicate highlight rule.
- Fixed a typo in a highlight group name (m4builtin → m4Builtin).
- Added a reference link to the POSIX M4 specification.
- Removed outdated maintainer URL.