### PR TITLE
Vimgoto additions

### DIFF
--- a/runtime/autoload/vimgoto.vim
+++ b/runtime/autoload/vimgoto.vim
@@ -20,7 +20,7 @@ export def Find(editcmd: string) #{{{2
         return
     endif
 
-    if curline =~ '^\s*\%(:\s*\)\=ru\%[ntime]!\=\s'
+    if curline =~ '^\s*\%(:\s*\)\=ru\%[ntime]!\='
         HandleRuntimeLine(editcmd, curline, expand('<cfile>'))
         return
     endif
@@ -83,7 +83,7 @@ def HandleRuntimeLine(editcmd: string, curline: string, cfile: string) #{{{2
 
     if cfile == 'runtime' || cfile =~# $'^{where_pat}$'
         # then the cursor was not on one of the filenames, jump to the first file:
-        var fname_pat: string = $'\s*\%(:\s*\)\=ru\%[ntime]!\=\s\+\%({where_pat}\s\+\)\=\zs\S\+\>\ze'
+        var fname_pat: string = $'\s*\%(:\s*\)\=ru\%[ntime]\%(!\s*\|\s\+\)\%({where_pat}\s\+\)\=\zs\S\+\>\ze'
         fname = curline->matchstr(fname_pat)
     else
         fname = cfile

--- a/runtime/autoload/vimgoto.vim
+++ b/runtime/autoload/vimgoto.vim
@@ -43,7 +43,7 @@ export def Find(editcmd: string) #{{{2
         var resolved_path = globpath(&runtimepath, path)
 
         if resolved_path != ''
-            var function_pattern: string = $'^\s*fun\%[ction]!\=\s\+\zs{curfunc}('
+            var function_pattern: string = $'^\s*\%(:\s*\)\=fun\%[ction]!\=\s\+\zs{curfunc}('
             resolved_path->Open(editcmd, function_pattern)
         endif
         return

--- a/runtime/autoload/vimgoto.vim
+++ b/runtime/autoload/vimgoto.vim
@@ -78,7 +78,7 @@ def HandlePackaddLine(editcmd: string, curline: string) #{{{2
 enddef
 
 def HandleRuntimeLine(editcmd: string, curline: string) #{{{2
-    var pat: string = '\s*\%(:\s*\)\=runtime!\=\s\+\zs\S\+\>\ze'
+    var pat: string = '\s*\%(:\s*\)\=ru\%[ntime]!\=\s\+\zs\S\+\>\ze'
     var fname: string = curline->matchstr(pat)
 
     if fname == ''

--- a/runtime/autoload/vimgoto.vim
+++ b/runtime/autoload/vimgoto.vim
@@ -35,14 +35,7 @@ export def Find(editcmd: string) #{{{2
         return
     endif
 
-    var curfunc = ''
-    var saved_iskeyword = &iskeyword
-    try
-        set iskeyword+=#
-        curfunc = expand('<cword>')
-    finally
-        &iskeyword = saved_iskeyword
-    endtry
+    var curfunc = FindCurfunc()
 
     if stridx(curfunc, '#') >= 0
         var parts = split(curfunc, '#')
@@ -71,12 +64,7 @@ def HandlePackaddLine(editcmd: string, curline: string) #{{{2
         ->substitute('^vim-\|\.vim$', '', 'g')
 
     if plugin == ''
-        try
-            execute 'normal! ' .. editcmd .. 'zv'
-        catch
-            Error(v:exception)
-            return
-        endtry
+        Fallback(editcmd)
     else
         var files: list<string> = getcompletion($'plugin/{plugin}', 'runtime')
             ->map((_, fname: string) => fname->findfile(&rtp)->fnamemodify(':p'))
@@ -94,12 +82,7 @@ def HandleRuntimeLine(editcmd: string, curline: string) #{{{2
     var fname: string = curline->matchstr(pat)
 
     if fname == ''
-        try
-            execute 'normal! ' .. editcmd .. 'zv'
-        catch
-            Error(v:exception)
-            return
-        endtry
+        Fallback(editcmd)
     else
         var file: string = fname
             ->findfile(&rtp)
@@ -117,12 +100,7 @@ def HandleColoLine(editcmd: string, curline: string) #{{{2
     var colo: string = curline->matchstr(pat)
 
     if colo == ''
-        try
-            execute 'normal! ' .. editcmd .. 'zv'
-        catch
-            Error(v:exception)
-            return
-        endtry
+        Fallback(editcmd)
     else
         var files: list<string> = getcompletion($'colors/{colo}', 'runtime')
             ->map((_, fname: string) => fname->findfile(&rtp)->fnamemodify(':p'))
@@ -226,6 +204,28 @@ def Error(msg: string) #{{{2
     echohl ErrorMsg
     echomsg msg
     echohl NONE
+enddef
+
+def Fallback(editcmd: string) #{{{2
+    try
+        execute 'normal! ' .. editcmd .. 'zv'
+    catch
+        Error(v:exception)
+    endtry
+enddef
+
+def FindCurfunc(): string #{{{2
+    var curfunc = ''
+    var saved_iskeyword = &iskeyword
+
+    try
+        set iskeyword+=#
+        curfunc = expand('<cword>')
+    finally
+        &iskeyword = saved_iskeyword
+    endtry
+
+    return curfunc
 enddef
 
 # vim: sw=4 et

--- a/runtime/autoload/vimgoto.vim
+++ b/runtime/autoload/vimgoto.vim
@@ -5,9 +5,9 @@ vim9script
 #               Shane-XB-Qian
 # Last Change:  2025 Aug 13
 #
-# Vim Script to handle
-# :import, :packadd and :colorscheme
-# lines and allows to easily jump to it using gf
+# Vim Script to handle jumping to the targets of several types of Vim commands
+# (:import, :packadd, :runtime, :colorscheme), and to autoloaded functions of
+# the style <path>#<function_name>.
 #
 # see runtime/ftplugin/vim.vim
 

--- a/runtime/autoload/vimgoto.vim
+++ b/runtime/autoload/vimgoto.vim
@@ -20,6 +20,11 @@ export def Find(editcmd: string) #{{{2
         return
     endif
 
+    if curline =~ '^\s*\%(:\s*\)\=runtime!\=\s'
+        HandleRuntimeLine(editcmd, curline)
+        return
+    endif
+
     if curline =~ '^\s*\%(:\s*\)\=colo\%[rscheme]\s'
         HandleColoLine(editcmd, curline)
         return
@@ -84,6 +89,30 @@ def HandlePackaddLine(editcmd: string, curline: string) #{{{2
             return
         endif
         files->Open(split)
+    endif
+enddef
+
+def HandleRuntimeLine(editcmd: string, curline: string) #{{{2
+    var pat: string = '\s*\%(:\s*\)\=runtime!\=\s\+\zs\S\+\>\ze'
+    var fname: string = curline->matchstr(pat)
+
+    if fname == ''
+        try
+            execute 'normal! ' .. editcmd .. 'zv'
+        catch
+            Error(v:exception)
+            return
+        endtry
+    else
+        var split: string = editcmd[0] == 'g' ? 'edit' : editcmd[1] == 'g' ? 'tabedit' : 'split'
+        var file: string = fname
+            ->findfile(&rtp)
+            ->fnamemodify(':p')
+        if file == '' || !filereadable(file)
+            echo 'Could not be found in the runtimepath: ' .. string(fname)
+            return
+        endif
+        file->Open(split)
     endif
 enddef
 

--- a/runtime/autoload/vimgoto.vim
+++ b/runtime/autoload/vimgoto.vim
@@ -185,10 +185,6 @@ def Open(target: any, editcmd: string, search_pattern: string = '') #{{{2
 
     execute $'{split} {cmd} {fname}'
 
-    if search_pattern == ''
-        cursor(1, 1)
-    endif
-
     # If there are several files to open, put them into an arglist.
     if target->typename() == 'list<string>'
             && target->len() > 1

--- a/runtime/autoload/vimgoto.vim
+++ b/runtime/autoload/vimgoto.vim
@@ -21,7 +21,7 @@ export def Find(editcmd: string) #{{{2
     endif
 
     if curline =~ '^\s*\%(:\s*\)\=ru\%[ntime]!\=\s'
-        HandleRuntimeLine(editcmd, curline)
+        HandleRuntimeLine(editcmd, curline, expand('<cfile>'))
         return
     endif
 
@@ -77,9 +77,17 @@ def HandlePackaddLine(editcmd: string, curline: string) #{{{2
     endif
 enddef
 
-def HandleRuntimeLine(editcmd: string, curline: string) #{{{2
-    var pat: string = '\s*\%(:\s*\)\=ru\%[ntime]!\=\s\+\zs\S\+\>\ze'
-    var fname: string = curline->matchstr(pat)
+def HandleRuntimeLine(editcmd: string, curline: string, cfile: string) #{{{2
+    var fname: string
+    var where_pat: string = '\%(START\|OPT\|PACK\|ALL\)'
+
+    if cfile == 'runtime' || cfile =~# $'^{where_pat}$'
+        # then the cursor was not on one of the filenames, jump to the first file:
+        var fname_pat: string = $'\s*\%(:\s*\)\=ru\%[ntime]!\=\s\+\%({where_pat}\s\+\)\=\zs\S\+\>\ze'
+        fname = curline->matchstr(fname_pat)
+    else
+        fname = cfile
+    endif
 
     if fname == ''
         Fallback(editcmd)

--- a/runtime/autoload/vimgoto.vim
+++ b/runtime/autoload/vimgoto.vim
@@ -20,7 +20,7 @@ export def Find(editcmd: string) #{{{2
         return
     endif
 
-    if curline =~ '^\s*\%(:\s*\)\=runtime!\=\s'
+    if curline =~ '^\s*\%(:\s*\)\=ru\%[ntime]!\=\s'
         HandleRuntimeLine(editcmd, curline)
         return
     endif


### PR DESCRIPTION
This PR adds two additional `gf` targets for Vimscript files. I only recently noticed that there was a built-in custom gf implementation for these because it overrode my own custom include expression 😅. These two features are taken from that one.

- Pressing `gf` on `foo#bar#Baz()` will look for `autoload/foo/bar.vim` in the runtimepath
- Pressing `gf` on `runtime some/path.vim` will look for the path in the runtimepath

I've tried to follow a similar code style to the existing code. A few things look duplicated to me, which is why I have a separate branch that extracts some helper functions and makes the code a bit simpler, I think: https://github.com/AndrewRadev/vim/compare/vimgoto-additions...AndrewRadev:vim:vimgoto-additions-refactoring. I can merge that one as well into this PR if the changes seem reasonable. (Update: merged)