### PR TITLE
ops.c: make opchars table const

### DIFF
--- a/src/ops.c
+++ b/src/ops.c
@@ -30,7 +30,7 @@ static void	pbyte(pos_T lp, int c);
  * IMPORTANT: Index must correspond with defines in vim.h!!!
  * The third field holds OPF_ flags.
  */
-static char opchars[][3] =
+static const char opchars[][3] =
 {
     {NUL, NUL, 0},			// OP_NOP
     {'d', NUL, OPF_CHANGE},		// OP_DELETE


### PR DESCRIPTION
Mark `opchars[][]` as static const. The table is never modified at runtime, so keeping it in writable .data has no benefit.