### PR TITLE
runtime(netrw): Going up in the browsing windows doesn't work over ssh

### DIFF
--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -4062,6 +4062,12 @@ function s:NetrwBrowseChgDir(islocal, newdir, cursor, ...)
     call s:RestorePosn(s:netrw_posn)
     let @@= ykeep
 
+    if dirname !~ dirpat
+        " apparently vim is "recognizing" that it is in a directory and
+        " is removing the trailing "/".  Bad idea, so let's put it back.
+        let dirname .= has("win32") ? '\\' : '/'
+    endif
+
     return dirname
 endfunction
 

--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -4062,12 +4062,6 @@ function s:NetrwBrowseChgDir(islocal, newdir, cursor, ...)
     call s:RestorePosn(s:netrw_posn)
     let @@= ykeep
 
-    if dirname !~ dirpat
-        " apparently vim is "recognizing" that it is in a directory and
-        " is removing the trailing "/".  Bad idea, so let's put it back.
-        let dirname .= has("win32") ? '\\' : '/'
-    endif
-
     return dirname
 endfunction
 

--- a/runtime/pack/dist/opt/netrw/autoload/netrw/fs.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw/fs.vim
@@ -88,7 +88,7 @@ endfunction
 
 function netrw#fs#Dirname(path)
     " Keep a slash as directory recognition pattern
-    return (a:path !~ s:slash . '$') ? a:path . s:slash : a:path
+    return netrw#fs#AbsPath(a:path) . s:slash
 endfunction
 
 " }}}

--- a/runtime/pack/dist/opt/netrw/autoload/netrw/fs.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw/fs.vim
@@ -87,7 +87,8 @@ endfunction
 " netrw#fs#Dirname: {{{
 
 function netrw#fs#Dirname(path)
-    return netrw#fs#AbsPath(a:path)->fnamemodify(':h')
+    " Keep a slash as directory recognition pattern
+    return (a:path !~ s:slash . '$') ? a:path . s:slash : a:path
 endfunction
 
 " }}}


### PR DESCRIPTION
Over `ssh` the `netrw` *browsing window* cannot go up (tries to open a non-existing file).
The `s:NetrwBrowse()` function requires a:
https://github.com/vim/vim/blob/f165798184dc03895709704df864bd1e43eaf09f/runtime/pack/dist/opt/netrw/autoload/netrw.vim#L3034
for remote files that is missing in this case.
The pull request merely restores the old behaviour as fix:
https://github.com/vim/vim/blob/223189389a18acf6e074ab0ca1a3bb6a4ec27ef7/runtime/pack/dist/opt/netrw/autoload/netrw.vim#L3882