### PR TITLE
Tweak documentation in vi_diff.txt

### DIFF
--- a/runtime/doc/vi_diff.txt
+++ b/runtime/doc/vi_diff.txt
@@ -1392,12 +1392,12 @@ The following operating systems are no longer supported:
 
 System				| Status:~
 --------------------------------+-----------------------------------------
-Atari MiNT			| support was dropped with v8.2.1215
+Atari MiNT:			| support was dropped with v8.2.1215
 BeOS:				| support was dropped with v8.2.0849
 MS-DOS:				| support was dropped with v7.4.1399
 MS-Windows XP and Vista:	| support was dropped with v9.0.0496
-OS/2				| support was dropped with v7.4.1008
+OS/2:				| support was dropped with v7.4.1008
 RISC OS:			| support was dropped with v7.3.0187
-NextStep Systems		| support was deprecated with v9.1.1727
+NeXTSTEP:			| support was deprecated with v9.1.1727
 
  vim:tw=78:ts=8:noet:ft=help:norl:


### PR DESCRIPTION
`NeXTSTEP` was the official notation used in NeXT's official releases, manuals, and advertisements.
This notation was used consistently, especially from the NeXTSTEP 3.x era (1992–1995) onward.
At least `Systems` is not required.