### PR TITLE
runtime(filetype): fix and improve Bitbake filetype detection

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -779,26 +779,32 @@ export def FTinc()
   if exists("g:filetype_inc")
     exe "setf " .. g:filetype_inc
   else
-    var lines = getline(1) .. getline(2) .. getline(3)
-    if lines =~? "perlscript"
-      setf aspperl
-    elseif lines =~ "<%"
-      setf aspvbs
-    elseif lines =~ "<?"
-      setf php
-    # Pascal supports // comments but they're vary rarely used for file
-    # headers so assume POV-Ray
-    elseif lines =~ '^\s*\%({\|(\*\)' || lines =~? ft_pascal_keywords
-      setf pascal
-    elseif lines =~# '\<\%(require\|inherit\)\>' || lines =~# '[A-Z][A-Za-z0-9_:${}]*\s\+\%(??\|[?:+]\)\?= '
-      setf bitbake
-    else
-      FTasmsyntax()
-      if exists("b:asmsyntax")
-        exe "setf " .. fnameescape(b:asmsyntax)
-      else
-        setf pov
+    for lnum in range(1, min([line("$"), 20]))
+      var line = getline(lnum)
+      if line =~? "perlscript"
+        setf aspperl
+        return
+      elseif line =~ "<%"
+        setf aspvbs
+        return
+      elseif line =~ "<?"
+        setf php
+        return
+      # Pascal supports // comments but they're vary rarely used for file
+      # headers so assume POV-Ray
+      elseif line =~ '^\s*\%({\|(\*\)' || line =~? ft_pascal_keywords
+        setf pascal
+        return
+      elseif line =~# '\<\%(require\|inherit\)\>' || line =~# '[A-Z][A-Za-z0-9_:${}]*\s\+\%(??\|[?:+]\)\?= '
+        setf bitbake
+        return
       endif
+    endfor
+    FTasmsyntax()
+    if exists("b:asmsyntax")
+      exe "setf " .. fnameescape(b:asmsyntax)
+    else
+      setf pov
     endif
   endif
 enddef

--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -795,7 +795,7 @@ export def FTinc()
       elseif line =~ '^\s*\%({\|(\*\)' || line =~? ft_pascal_keywords
         setf pascal
         return
-      elseif line =~# '\<\%(require\|inherit\)\>' || line =~# '[A-Z][A-Za-z0-9_:${}]*\s\+\%(??\|[?:+]\)\?= '
+      elseif line =~# '\<\%(require\|inherit\)\>' || line =~# '[A-Z][A-Za-z0-9_:${}/]*\s\+\%(??\|[?:+.]\)\?=.\? '
         setf bitbake
         return
       endif

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -2625,6 +2625,21 @@ func Test_inc_file()
   call assert_equal('bitbake', &filetype)
   bwipe!
 
+  call writefile(['PREFERRED_PROVIDER_virtual/kernel = "linux-yocto"'], 'Xfile.inc')
+  split Xfile.inc
+  call assert_equal('bitbake', &filetype)
+  bwipe!
+
+  call writefile(['MACHINEOVERRIDES =. "qemuall:"'], 'Xfile.inc')
+  split Xfile.inc
+  call assert_equal('bitbake', &filetype)
+  bwipe!
+
+  call writefile(['BBPATH .= ":${LAYERDIR}"'], 'Xfile.inc')
+  split Xfile.inc
+  call assert_equal('bitbake', &filetype)
+  bwipe!
+
   " asm
   call writefile(['asmsyntax=foo'], 'Xfile.inc')
   split Xfile.inc


### PR DESCRIPTION
Fix the detection of .inc files containing Pascal and BitBake code. The concatenated string, merged from three lines, only contains one beginning and the pattern `^` would not match as expected. Use a `range()` loop to iterate each line string individually. This way, the pattern `^` works for beginning of lines.

Additionally, parse twenty instead of just three lines, to accommodate for potential comments at the beginning of files.

Improve BitBake include file detection by also matching forward-slashes `/` in variable names and assignment operators with a dot `.=` and `=.`. Valid examples, which should match, are:
```bitbake
PREFERRED_PROVIDER_virtual/kernel = "linux-yocto"
MACHINEOVERRIDES =. "qemuall:"
BBPATH .= ":${LAYERDIR}"
```