### PR TITLE
match.c: fix early-return leak of compiled regex; centralize cleanup in `fail:`

### DIFF
--- a/src/match.c
+++ b/src/match.c
@@ -21,7 +21,7 @@
  * Add match to the match list of window "wp".
  * If "pat" is not NULL the pattern will be highlighted with the group "grp"
  * with priority "prio".
- * If "pos_list" is not NULL the list of posisions defines the highlights.
+ * If "pos_list" is not NULL the list of positions defines the highlights.
  * Optionally, a desired ID "id" can be specified (greater than or equal to 1).
  * If no particular ID is desired, -1 must be specified for "id".
  * Return ID of added match, -1 on failure.

--- a/src/match.c
+++ b/src/match.c
@@ -38,7 +38,7 @@ match_add(
 {
     matchitem_T	*cur;
     matchitem_T	*prev;
-    matchitem_T	*m;
+    matchitem_T	*m = NULL;
     int		hlg_id;
     regprog_T	*regprog = NULL;
     int		rtype = UPD_SOME_VALID;
@@ -86,15 +86,12 @@ match_add(
     // Build new match.
     m = ALLOC_CLEAR_ONE(matchitem_T);
     if (m == NULL)
-	return -1;
+	goto fail;
     if (pos_list != NULL && pos_list->lv_len > 0)
     {
 	m->mit_pos_array = ALLOC_CLEAR_MULT(llpos_T, pos_list->lv_len);
 	if (m->mit_pos_array == NULL)
-	{
-	    vim_free(m);
-	    return -1;
-	}
+	    goto fail;
 	m->mit_pos_count = pos_list->lv_len;
     }
     m->mit_id = id;
@@ -213,9 +210,14 @@ match_add(
     return id;
 
 fail:
-    vim_free(m->mit_pattern);
-    vim_free(m->mit_pos_array);
-    vim_free(m);
+    if (regprog != NULL)
+	vim_regfree(regprog);
+    if (m != NULL)
+    {
+	vim_free(m->mit_pattern);
+	vim_free(m->mit_pos_array);
+	vim_free(m);
+    }
     return -1;
 }
 


### PR DESCRIPTION
**Summary**
This PR fixes a memory leak in `match_add()` when an early return occurs after compiling a pattern but before the `matchitem_T` is fully constructed/inserted. Cleanup is centralized through the existing `fail:` label, m is initialized to NULL,