### PR TITLE
Remove compile condition due to unsupport for XP

### DIFF
--- a/src/Make_cyg_ming.mak
+++ b/src/Make_cyg_ming.mak
@@ -665,9 +665,7 @@ endif
 
 ifeq ($(CHANNEL),yes)
 DEFINES += -DFEAT_JOB_CHANNEL -DFEAT_IPV6
- ifeq ($(shell expr "$$(($(WINVER)))" \>= "$$((0x600))"),1)
 DEFINES += -DHAVE_INET_NTOP
- endif
 endif
 
 ifeq ($(TERMINAL),yes)


### PR DESCRIPTION
Vim's latest version is unsupport for Windows XP now. It is no use to judge whether the version of Windows is upper than Windows XP.