### PR TITLE
syntax(m4): fix m4Define

### DIFF
--- a/runtime/syntax/m4.vim
+++ b/runtime/syntax/m4.vim
@@ -57,12 +57,12 @@ syn match  m4Constants "\<\(m4_\)\=__file__"
 syn match  m4Constants "\<\(m4_\)\=__line__"
 syn keyword m4Constants divnum sysval m4_divnum m4_sysval
 syn region m4Paren    matchgroup=m4Delimiter start="(" end=")" contained contains=@m4Top
-syn region m4Command  matchgroup=m4Function  start="\<\(m4_\)\=\(define\|defn\|pushdef\)(" end=")" contains=@m4Top
+syn region m4Command  matchgroup=m4Define  start="\<\(m4_\)\=\(define\|defn\|pushdef\)(" end=")" contains=@m4Top
 syn region m4Command  matchgroup=m4Preproc   start="\<\(m4_\)\=\(include\|sinclude\)("he=e-1 end=")" contains=@m4Top
 syn region m4Command  matchgroup=m4Statement start="\<\(m4_\)\=\(syscmd\|esyscmd\|ifdef\|ifelse\|indir\|builtin\|shift\|errprint\|m4exit\|changecom\|changequote\|changeword\|m4wrap\|debugfile\|divert\|undivert\)("he=e-1 end=")" contains=@m4Top
 syn region m4Command  matchgroup=m4Builtin start="\<\(m4_\)\=\(len\|index\|regexp\|substr\|translit\|patsubst\|format\|incr\|decr\|eval\|maketemp\)("he=e-1 end=")" contains=@m4Top
 syn keyword m4Statement divert undivert
-syn region m4Command  matchgroup=m4Type      start="\<\(m4_\)\=\(undefine\|popdef\)("he=e-1 end=")" contains=@m4Top
+syn region m4Command  matchgroup=m4Define      start="\<\(m4_\)\=\(undefine\|popdef\)("he=e-1 end=")" contains=@m4Top
 syn cluster m4Top     contains=m4Comment,m4Constants,m4Special,m4Variable,m4Paren,m4Command,m4Statement,m4Quoted
 
 " Define the default highlighting.
@@ -71,6 +71,7 @@ hi def link m4QuoteDelim  Delimiter
 hi def link m4Delimiter   Delimiter
 hi def link m4Comment     Comment
 hi def link m4Keyword     Keyword
+hi def link m4Define      Define
 hi def link m4Special     Special
 hi def link m4Statement   Statement
 hi def link m4Preproc     PreProc

--- a/runtime/syntax/m4.vim
+++ b/runtime/syntax/m4.vim
@@ -75,7 +75,6 @@ hi def link m4Define      Define
 hi def link m4Special     Special
 hi def link m4Statement   Statement
 hi def link m4Preproc     PreProc
-hi def link m4Type        Type
 hi def link m4Variable    Special
 hi def link m4Constants   Constant
 hi def link m4Builtin     Statement


### PR DESCRIPTION
In my previous PR I forgot to remove one instance of `m4Function` which broke syntax highlighting of `define`.

So here I take the opportunity to create `m4Define` and link it to `Define` (as it should be ?).

Also `undefine` was put in `m4Type` 🤔 , so I put it in `m4Define` too.