### PR TITLE
Matches may be listed twice with wildmode=longest,list

### DIFF
--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -1038,6 +1038,8 @@ cmdline_wildchar_complete(
 			    nextwild(xp, WILD_NEXT, options, escape);
 			(void)showmatches(xp, p_wmnu, wim_list_next,
 				wim_noselect_next);
+			if (wim_list_next)
+			    *did_wild_list = TRUE;
 		    }
 		}
 	    }

--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -2829,6 +2829,8 @@ func Test_wildmenu_pum()
   call term_sendkeys(buf, "\<C-U>set wildmode=longest,list\<CR>")
   call term_sendkeys(buf, ":cn\<Tab>")
   call VerifyScreenDump(buf, 'Test_wildmenu_pum_30', {})
+  call term_sendkeys(buf, "\<Tab>")
+  call VerifyScreenDump(buf, 'Test_wildmenu_pum_30', {})
   call term_sendkeys(buf, "s")
   call VerifyScreenDump(buf, 'Test_wildmenu_pum_31', {})
 


### PR DESCRIPTION
Problem:  Matches may be listed twice with wildmode=longest,list when
          "longest" doesn't change command line (after 9.1.1737).
Solution: Set did_wild_list when trying "list" after "longest".
