### PR TITLE
Haiku fullscreen

### DIFF
--- a/runtime/doc/os_haiku.txt
+++ b/runtime/doc/os_haiku.txt
@@ -76,6 +76,9 @@ version with GUI tries to determine if it was started from the Tracker instead
 of the Terminal, and if so, uses the GUI anyway.  However, the current detection
 scheme is fooled if you use the command "vim - </dev/null".
 
+Toggling between normal managed window and fullscreen mode can be done by
+pressing <Alt-Enter>.
+
 Stuff that does not work yet:
 
 - Mouse up events are not generated when outside the window.  You can notice

--- a/runtime/doc/os_haiku.txt
+++ b/runtime/doc/os_haiku.txt
@@ -89,7 +89,9 @@ Stuff that does not work yet:
   in when the window is activated or deactivated (so it works best with focus-
   follows-mouse turned on).
 - The cursor does not flash.
-
+- Switching windows using <C-Tab-Up> and <C-Tab-Down> in Twitcher does not
+  work. This is due to each gvim window being managed by a separate instance
+  completely unaware of other vim processes.
 
 4. The $VIM directory					*haiku-vimdir*
 


### PR DESCRIPTION
While there might be an accepted commit or two by me going into vim-runtime through other repos, this is my first contribution to the actual vim git. Please do make me aware of all my mistakes. 

This change adds support for fullscreen mode on Haiku, as well as updates to Haiku specific documentation.

I've personally run on on my Haiku laptop since mid-July, the week before polishing it up into a commit. The patch was added to the vim version distributed through HaikuDepot [three weeks ago][7fd378] and has thus been run by others since then. Its hard to say how widely verified a feature needs to be before being upstreamed, but I assume this is now ready to be considered.

Adding tests for this is hard. According to [`:help testing`](https://vimhelp.org/testing.txt.html), `test_gui_event("key" …)` only works on MS-Windows and even if it would be possible to send the event, I'm not sure how to detect whether it successfully enters or leaves fullscreen mode. Practical ideas are welcome.

[7fd378]: https://github.com/haikuports/haikuports/commit/7fd3f8d8495ffb158aed1ddef6b3e22d7ad15953