### PR TITLE
potential buffer-overflow in find_pattern_in_path()

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -3795,7 +3795,7 @@ search_line:
 		    break;
 		found = TRUE;
 		aux = p = startp;
-		if (compl_status_adding())
+		if (compl_status_adding() && (int)STRLEN(p) >= ins_compl_len())
 		{
 		    p += ins_compl_len();
 		    if (vim_iswordp(p))


### PR DESCRIPTION
Problem:  potential buffer-overflow in find_pattern_in_path()
Problem:  Verify ptr p has enough room before adding ins_compl_len()

fixes: #18195