### PR TITLE
Fix: redo (.) now works with preinsert and autocompletion

### DIFF
--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -247,6 +247,7 @@ If you want to keep the changed buffer without saving it, switch on the
 							*:fin* *:find*
 :fin[d][!] [++opt] [+cmd] {file}
 			Find {file} in 'path' and then |:edit| it.
+			See also: 'findfunc'.
 
 :{count}fin[d][!] [++opt] [+cmd] {file}
 			Just like ":find", but use the {count} match in

--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -154,9 +154,8 @@ static string_T	  compl_leader = {NULL, 0};
 static int	  compl_get_longest = FALSE;	// put longest common string
 						// in compl_leader
 
-// This flag indicates that one of the items in the match list is currently
-// selected.  FALSE when no match is selected or the match was edited or using
-// the longest common string.
+// This flag is FALSE when no match is selected (by ^N/^P) or the match was
+// edited or using the longest common string.
 static int	  compl_used_match;
 
 // didn't finish finding completions.
@@ -5960,7 +5959,8 @@ ins_compl_insert(int move_cursor, int preinsert_prefix)
 		curwin->w_cursor.col -= (colnr_T)(cp_str_len - leader_len);
 	}
     }
-    if (match_at_original_text(compl_shown_match) || preinsert)
+    if (match_at_original_text(compl_shown_match)
+	    || (preinsert && !compl_autocomplete))
 	compl_used_match = FALSE;
     else
 	compl_used_match = TRUE;

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -5634,6 +5634,13 @@ func Test_autocomplete_completeopt_preinsert()
   " Should not work with fuzzy
   set cot+=fuzzy
   call DoTest("f", 'f', 2)
+  set cot-=fuzzy
+
+  " Verify that redo (dot) works
+  call setline(1, ["foobar", "foozbar", "foobaz", "changed", "change"])
+  call feedkeys($"/foo\<CR>", 'tx')
+  call feedkeys($"cwch\<C-N>\<Esc>n.n.", 'tx')
+  call assert_equal(repeat(['changed'], 3), getline(1, 3))
 
   %delete _
   let &l:undolevels = &l:undolevels


### PR DESCRIPTION
Broken due to https://github.com/vim/vim/pull/18213

Also: fixed https://github.com/vim/vim/issues/18250
