### PR TITLE
Problem: leaking memory in cs_find_common()

### DIFF
--- a/src/if_cscope.c
+++ b/src/if_cscope.c
@@ -1233,7 +1233,10 @@ cs_find_common(
 	win_T	    *wp = NULL;
 
 	if (tmp == NULL)
+	{
+	    vim_free(nummatches);
 	    return FALSE;
+	}
 
 	f = mch_fopen((char *)tmp, "w");
 	if (f == NULL)


### PR DESCRIPTION
Problem:  leaking memory in cs_find_common()
          (after v9.1.1746)
Solution: Also free nummatches before returning