### PR TITLE
Fix: Spurious insertion of matches during preinsert

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -2531,9 +2531,7 @@ ins_compl_new_leader(void)
 	if (compl_started && compl_autocomplete
 		&& !ins_compl_preinsert_effect())
 	{
-	    if (ins_compl_insert(TRUE, TRUE) != OK)
-		(void)ins_compl_insert(FALSE, FALSE);
-	    else
+	    if (ins_compl_insert(TRUE, TRUE) == OK)
 		compl_autocomplete_preinsert = TRUE;
 	}
 	else

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -5642,6 +5642,12 @@ func Test_autocomplete_completeopt_preinsert()
   call feedkeys($"cwch\<C-N>\<Esc>n.n.", 'tx')
   call assert_equal(repeat(['changed'], 3), getline(1, 3))
 
+  " Select a match and delete up to text equal to another match
+  %delete
+  call setline(1, ["foobar", "foo"])
+  call feedkeys("Go\<ESC>", 'tx')
+  call DoTest("f\<C-N>\<C-N>\<BS>\<BS>\<BS>\<BS>", 'foo', 3)
+
   %delete _
   let &l:undolevels = &l:undolevels
   normal! ifoo


### PR DESCRIPTION
When autocomplete is enabled with *preinsert*, deleting text after selecting a longer match could cause unintended reinsertion.

**Example:**

* Matches available: `foo` and `foobar`.
* User selects `foobar` with Ctrl-N
* User deletes characters back to `foo`.
* Autocomplete then incorrectly re-inserts `bar`, preventing deletion past `foo`.

This fix removes the unwanted reinsertion so text can be deleted correctly.