### PR TITLE
runtime(doc): improve docs related to 'autocomplete'

### DIFF
--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -1,4 +1,4 @@
-*insert.txt*    For Vim version 9.1.  Last change: 2025 Sep 08
+*insert.txt*    For Vim version 9.1.  Last change: 2025 Sep 10
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -1151,7 +1151,7 @@ autocompletion.  To use |i_CTRL-N| or |i_CTRL-X_CTRL-N| specifically, press
 |CTRL-E| first to dismiss the popup menu (see |complete_CTRL-E|).
 
 						*ins-autocompletion-example*
-Example setup~
+Example setup ~
 A typical configuration for automatic completion with a popup menu: >
 	set autocomplete
 	set complete=.^5,w^5,b^5,u^5

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2301,12 +2301,12 @@ A jump table for the options with a short description can be found at |Q_op|.
 		    {only works when compiled with the |+textprop| feature}
 
 	   preinsert
-		    When autocompletion is not enabled, inserts the part of the
+		    When 'autocomplete' is not active, inserts the part of the
 		    first candidate word beyond the current completion leader,
-		    highlighted with |hl-PreInsert|.  The cursor does not
-		    move.  Requires 'fuzzy' unset and 'menuone' in 'completeopt'.
+		    highlighted with |hl-PreInsert|.  The cursor doesn't move.
+		    Requires "fuzzy" unset and "menuone" in 'completeopt'.
 
-		    When 'autocomplete' is enabled, inserts the longest common
+		    When 'autocomplete' is active, inserts the longest common
 		    prefix of matches (from all shown items or from the
 		    current buffer items).  This occurs only when no menu item
 		    is selected.  Press CTRL-Y to accept.


### PR DESCRIPTION
Manual completion can still be used when 'autocomplete' is set, so
saying "active" is better than "enabled".
