### PR TITLE
runtime(netrw): only keep cursor position in tree listing mode

### DIFF
--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -3083,7 +3083,7 @@ function s:NetrwBrowse(islocal,dirname)
     " previous buffer
     let prevbufnr = bufnr('%')
     let reusing= s:NetrwGetBuffer(a:islocal,dirname)
-    if exists("s:rexposn_".prevbufnr)
+    if exists("s:rexposn_".prevbufnr) && exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST
         let s:rexposn_{bufnr('%')} = s:rexposn_{prevbufnr}
     endif
 


### PR DESCRIPTION
Fixes #16255

PR #15996 introduced a change to keep the cursor position when a new buffer was allocated when browsing since we don't want the cursor to jump to the top in tree listing mode. But this needed to be applied only in tree listing mode, which it wasn't.