### PR TITLE
:helptags doesn't skip examples with syntax

### DIFF
--- a/src/help.c
+++ b/src/help.c
@@ -965,7 +965,6 @@ helptags_one(
     int		this_utf8;
     int		firstline;
     int		in_example;
-    int		len;
     int		mix = FALSE;	// detected mixed encodings
 
     // Find all *.txt files.
@@ -1117,10 +1116,16 @@ helptags_one(
 		}
 		p1 = p2;
 	    }
-	    len = (int)STRLEN(IObuff);
-	    if ((len == 2 && STRCMP(&IObuff[len - 2], ">\n") == 0)
-		    || (len >= 3 && STRCMP(&IObuff[len - 3], " >\n") == 0))
-		in_example = TRUE;
+	    size_t off = STRLEN(IObuff);
+	    if (off >= 2 && IObuff[off - 1] == '\n')
+	    {
+		off -= 2;
+		while (off > 0 && (ASCII_ISLOWER(IObuff[off])
+						  || VIM_ISDIGIT(IObuff[off])))
+		    off--;
+		if (IObuff[off] == '>' && (off == 0 || IObuff[off - 1] == ' '))
+		    in_example = TRUE;
+	    }
 	    line_breakcheck();
 	}
 

--- a/src/testdir/test_help.vim
+++ b/src/testdir/test_help.vim
@@ -139,11 +139,17 @@ func Test_helptag_cmd()
   call delete('Xtagdir/tags')
 
   " Test parsing tags
-  call writefile(['*tag1*', 'Example: >', '  *notag*', 'Example end: *tag2*'],
+  call writefile(['*tag1*', 'Example: >', '  *notag1*', 'Example end: *tag2*',
+                \ '>', '  *notag2*', '<',
+                \ '*tag3*', 'Code: >vim', '  *notag3*', 'Code end: *tag4*',
+                \ '>i3config', '  *notag4*', '<'],
     \ 'Xtagdir/a/doc/sample.txt')
   helptags Xtagdir
   call assert_equal(["tag1\ta/doc/sample.txt\t/*tag1*",
-                  \  "tag2\ta/doc/sample.txt\t/*tag2*"], readfile('Xtagdir/tags'))
+                   \ "tag2\ta/doc/sample.txt\t/*tag2*",
+                   \ "tag3\ta/doc/sample.txt\t/*tag3*",
+                   \ "tag4\ta/doc/sample.txt\t/*tag4*"],
+    \ readfile('Xtagdir/tags'))
 
   " Duplicate tags in the help file
   call writefile(['*tag1*', '*tag1*', '*tag2*'], 'Xtagdir/a/doc/sample.txt')


### PR DESCRIPTION
Problem:  :helptags doesn't skip examples with syntax.
Solution: Check for examples with syntax.

fixes: #18273
