### PR TITLE
Clarify {startcol} starts with 1 in complete()

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -1921,7 +1921,7 @@ complete({startcol}, {matches})			*complete()* *E785*
 		text start.  The text up to the cursor is the original text
 		that will be replaced by the matches.  Use col('.') for an
 		empty string.  "col('.') - 1" will replace one character by a
-		match.
+		match.  Use 1 for entire line.
 		{matches} must be a |List|.  Each |List| item is one match.
 		See |complete-items| for the kind of items that are possible.
 		"longest" in 'completeopt' is ignored.


### PR DESCRIPTION
This was not clear to me. I was trying with 0 as [completefunc](https://vimhelp.org/insert.txt.html#complete-functions) uses 0. It didn't work and there was no errors. 