### PR TITLE
syntax(Autoconf M4): add `+=` error

### DIFF
--- a/runtime/syntax/config.vim
+++ b/runtime/syntax/config.vim
@@ -1,5 +1,5 @@
 " Vim syntax file
-" Language:		configure.in script: M4 with sh
+" Language:		Autoconf M4
 " Former Maintainer:	Christian Hammesr <ch@lathspell.westend.com>
 " Last Change:	2018 Feb 03
 " 				(patch from Yngve Inntjore Levinsen to detect AC_MSG)
@@ -34,6 +34,9 @@ syn region  configstring    start=+\z(["'`]\)+ skip=+\\\z1+ end=+\z1+ contains=@
 syn region  configmsg matchgroup=configfunction start="AC_MSG_[A-Z]*\ze(\[" matchgroup=configdelimiter end="\])" contains=configdelimiter,@Spell
 syn region  configmsg matchgroup=configfunction start="AC_MSG_[A-Z]*\ze([^[]" matchgroup=configdelimiter end=")" contains=configdelimiter,@Spell
 
+" Help write portable shell code
+syn match acPlusEq '\v\+\=' containedin=ALLBUT,configcomment
+
 " Define the default highlighting.
 " Only when an item doesn't have highlighting yet
 
@@ -47,6 +50,7 @@ hi def link configkeyword   Keyword
 hi def link configspecial   Special
 hi def link configstring    String
 hi def link configmsg       String
+hi def link acPlusEq        Error
 
 
 let b:current_syntax = "config"


### PR DESCRIPTION
This should help avoid things like #18190 