### PR TITLE
Allow listener_add mechanism to provide unbuffered notifications.

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -369,7 +369,7 @@ lispindent({lnum})		Number	Lisp indent for line {lnum}
 list2blob({list})		Blob	turn {list} of numbers into a Blob
 list2str({list} [, {utf8}])	String	turn {list} of numbers into a String
 list2tuple({list})		Tuple	turn {list} of items into a tuple
-listener_add({callback} [, {buf}])
+listener_add({callback} [, {buf} [, {unbuffered}]])
 				Number	add a callback to listen to changes
 listener_flush([{buf}])		none	invoke listener callbacks
 listener_remove({id})		none	remove a listener callback
@@ -6715,7 +6715,7 @@ list2tuple({list})					*list2tuple()*
 		Return type: tuple<{type}> (depending on the given |List|)
 
 
-listener_add({callback} [, {buf}])			*listener_add()*
+listener_add({callback} [, {buf} [, {unbuffered}]])	*listener_add()*
 		Add a callback function that will be invoked when changes have
 		been made to buffer {buf}.
 		{buf} refers to a buffer name or number. For the accepted
@@ -6723,7 +6723,13 @@ listener_add({callback} [, {buf}])			*listener_add()*
 		buffer is used.
 		Returns a unique ID that can be passed to |listener_remove()|.
 
-		The {callback} is invoked with five arguments:
+		If the {buf} already has registered callbacks then the
+		equivalent of >
+		    listener_flush({buf})
+<               is performed before the new callback is added.
+
+		When {unbuffered} is |FALSE| or omitted, the {callback} is
+		invoked with five arguments:
 		    bufnr	the buffer that was changed
 		    start	first changed line number
 		    end		first line number below the change
@@ -6770,14 +6776,36 @@ listener_add({callback} [, {buf}])			*listener_add()*
 		when the callback is invoked, but later changes may make them
 		invalid, thus keeping a copy for later might not work.
 
-		The {callback} is invoked just before the screen is updated,
-		when |listener_flush()| is called or when a change is being
-		made that changes the line count in a way it causes a line
-		number in the list of changes to become invalid.
+<		When {unbuffered} is |TRUE|, the {callback} is
+		invoked with:
+		    bufnr	the buffer that was changed
+		    start	first changed line number
+		    end		first line number below the change
+		    added	number of lines added, negative if lines were
+				deleted
+		    col		first column in "start" that was affected by
+				the change; one if unknown or the whole line
+				was affected; this is a byte index, first
+				character has a value of one.
+
+		Example: >
+	    func Listener(bufnr, start, end, added, col)
+	      echo a:start .. '.' .. a:col .. ' until ' .. a:end .. ' changed'
+	    endfunc
+	    call listener_add('Listener', bufnr, v:true)
+
+>		When {ubuffered} is |TRUE| the callback is invoked for every
+		single change. Otherwise the {callback} is invoked just before
+		the screen is updated, when |listener_flush()| is called or
+		when a change is being made that changes the line count in a
+		way that causes a line number in the list of changes to become
+		invalid.
 
 		The {callback} is invoked with the text locked, see
 		|textlock|.  If you do need to make changes to the buffer, use
 		a timer to do this later |timer_start()|.
+
+		You may not call listener_add() during the {callback}. *E1562*
 
 		The {callback} is not invoked when the buffer is first loaded.
 		Use the |BufReadPost| autocmd event to handle the initial text

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -6726,10 +6726,9 @@ listener_add({callback} [, {buf} [, {unbuffered}]])	*listener_add()*
 		If the {buf} already has registered callbacks then the
 		equivalent of >
 		    listener_flush({buf})
-<               is performed before the new callback is added.
+<		is performed before the new callback is added.
 
-		When {unbuffered} is |FALSE| or omitted, the {callback} is
-		invoked with five arguments:
+		The {callback} is invoked with five arguments:
 		    bufnr	the buffer that was changed
 		    start	first changed line number
 		    end		first line number below the change
@@ -6771,35 +6770,30 @@ listener_add({callback} [, {buf} [, {unbuffered}]])	*listener_add()*
 		    added	0
 		    col		first column with a change or 1
 
+		When {ubuffered} is |FALSE| or not provided the {callback} is
+		invoked:
+
+		1. Just before the screen is updated.
+		2. When |listener_flush()| is called.
+		3. When a change is being made that changes the line count in
+		   a way that causes a line number in the list of changes to
+		   become invalid.
+
 		The entries are in the order the changes were made, thus the
-		most recent change is at the end.  The line numbers are valid
-		when the callback is invoked, but later changes may make them
-		invalid, thus keeping a copy for later might not work.
+		most recent change is at the end.
 
-<		When {unbuffered} is |TRUE|, the {callback} is
-		invoked with:
-		    bufnr	the buffer that was changed
-		    start	first changed line number
-		    end		first line number below the change
-		    added	number of lines added, negative if lines were
-				deleted
-		    col		first column in "start" that was affected by
-				the change; one if unknown or the whole line
-				was affected; this is a byte index, first
-				character has a value of one.
+		Because of the third trigger reason for triggering a callback
+		listed above, the line numbers passed to the callback are not
+		guaranteed to be valid. If this is a problem then make
+		{unbuffered} |TRUE|.
 
-		Example: >
-	    func Listener(bufnr, start, end, added, col)
-	      echo a:start .. '.' .. a:col .. ' until ' .. a:end .. ' changed'
-	    endfunc
-	    call listener_add('Listener', bufnr, v:true)
-
->		When {ubuffered} is |TRUE| the callback is invoked for every
-		single change. Otherwise the {callback} is invoked just before
-		the screen is updated, when |listener_flush()| is called or
-		when a change is being made that changes the line count in a
-		way that causes a line number in the list of changes to become
-		invalid.
+		When {ubuffered} is |TRUE| the {callback} is invoked for every
+		single change. The changes list only holds a single dictionary
+		and the "start", "end" and "added" values in the dictionary are
+		the same as the corresponding callback arguments. The line
+		numbers are valid when the callback is invoked, but later
+		changes may make them invalid, thus keeping a copy for later
+		might not work.
 
 		The {callback} is invoked with the text locked, see
 		|textlock|.  If you do need to make changes to the buffer, use

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -6805,7 +6805,7 @@ listener_add({callback} [, {buf} [, {unbuffered}]])	*listener_add()*
 		|textlock|.  If you do need to make changes to the buffer, use
 		a timer to do this later |timer_start()|.
 
-		You may not call listener_add() during the {callback}. *E1562*
+		You may not call listener_add() during the {callback}. *E1569*
 
 		The {callback} is not invoked when the buffer is first loaded.
 		Use the |BufReadPost| autocmd event to handle the initial text

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -4734,7 +4734,6 @@ E1559	vim9.txt	/*E1559*
 E156	sign.txt	/*E156*
 E1560	vim9.txt	/*E1560*
 E1561	vim9.txt	/*E1561*
-E1562	builtin.txt	/*E1562*
 E1562	options.txt	/*E1562*
 E1563	remote.txt	/*E1563*
 E1564	remote.txt	/*E1564*
@@ -4742,6 +4741,7 @@ E1565	remote.txt	/*E1565*
 E1566	remote.txt	/*E1566*
 E1567	remote.txt	/*E1567*
 E1568	options.txt	/*E1568*
+E1569	builtin.txt	/*E1569*
 E157	sign.txt	/*E157*
 E158	sign.txt	/*E158*
 E159	sign.txt	/*E159*

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -4734,6 +4734,7 @@ E1559	vim9.txt	/*E1559*
 E156	sign.txt	/*E156*
 E1560	vim9.txt	/*E1560*
 E1561	vim9.txt	/*E1561*
+E1562	builtin.txt	/*E1562*
 E1562	options.txt	/*E1562*
 E1563	remote.txt	/*E1563*
 E1564	remote.txt	/*E1564*

--- a/src/change.c
+++ b/src/change.c
@@ -245,8 +245,7 @@ check_recorded_changes(
 	linenr_T	lnume,
 	long		xtra)
 {
-    if (houskeeping_required)
-	perform_listener_housekeeping();
+    perform_listener_housekeeping();
     if (buf->b_recorded_changes == NULL || xtra == 0)
 	return;
 
@@ -286,8 +285,7 @@ may_record_change(
 {
     dict_T	*dict;
 
-    if (houskeeping_required)
-	perform_listener_housekeeping();
+    perform_listener_housekeeping();
     if (curbuf->b_listener == NULL)
 	return;
 
@@ -365,8 +363,7 @@ f_listener_add(typval_T *argvars, typval_T *rettv)
     // Perform any pending housekeeping and then make sure any buffered change
     // reports are flushed so that the new listener does not see out of date
     // changes.
-    if (houskeeping_required)
-	perform_listener_housekeeping();
+    perform_listener_housekeeping();
     invoke_listeners(buf);
 
     if (unbuffered)
@@ -408,8 +405,7 @@ f_listener_flush(typval_T *argvars, typval_T *rettv UNUSED)
 	if (buf == NULL)
 	    return;
     }
-    if (houskeeping_required)
-	perform_listener_housekeeping();
+    perform_listener_housekeeping();
     invoke_listeners(buf);
 }
 
@@ -483,7 +479,7 @@ may_invoke_listeners(buf_T *buf, linenr_T lnum, linenr_T lnume, int added)
 
 /*
  * Called when any sequence of change occurs: listeners added with the
- * "unbuffered" flag set.
+ * "unbuffered" parameter set.
  */
     static void
 invoke_sync_listeners(
@@ -498,7 +494,7 @@ invoke_sync_listeners(
     typval_T	argv[6];
     int		save_updating_screen = updating_screen;
 
-    if (curbuf->b_sync_listener == NULL)
+    if (recursive || curbuf->b_sync_listener == NULL)
 	return;
 
     argv[0].v_type = VAR_NUMBER;
@@ -517,7 +513,7 @@ invoke_sync_listeners(
 
     // Block messages on channels from being handled, so that they don't make
     // text changes here.
-    ++updating_screen;
+    updating_screen = TRUE;
 
     for (lnr = buf->b_sync_listener; lnr != NULL; lnr = lnr->lr_next)
     {
@@ -558,7 +554,7 @@ invoke_listeners(buf_T *buf)
 
     // Block messages on channels from being handled, so that they don't make
     // text changes here.
-    ++updating_screen;
+    updating_screen = TRUE;
 
     argv[0].v_type = VAR_NUMBER;
     argv[0].vval.v_number = buf->b_fnum; // a:bufnr

--- a/src/errors.h
+++ b/src/errors.h
@@ -3776,6 +3776,8 @@ EXTERN char e_not_a_generic_function_str[]
 	INIT(= N_("E1560: Not a generic function: %s"));
 EXTERN char e_duplicate_type_var_name_str[]
 	INIT(= N_("E1561: Duplicate type variable name: %s"));
+EXTERN char e_cannot_add_listener_in_listener_callback[]
+	INIT(= N_("E1562: Cannot use listener_add in a listener callback"));
 #endif
 #if defined(FEAT_DIFF)
 EXTERN char e_diff_anchors_with_hidden_windows[]

--- a/src/errors.h
+++ b/src/errors.h
@@ -3776,8 +3776,6 @@ EXTERN char e_not_a_generic_function_str[]
 	INIT(= N_("E1560: Not a generic function: %s"));
 EXTERN char e_duplicate_type_var_name_str[]
 	INIT(= N_("E1561: Duplicate type variable name: %s"));
-EXTERN char e_cannot_add_listener_in_listener_callback[]
-	INIT(= N_("E1562: Cannot use listener_add in a listener callback"));
 #endif
 #if defined(FEAT_DIFF)
 EXTERN char e_diff_anchors_with_hidden_windows[]
@@ -3797,3 +3795,7 @@ EXTERN char e_socket_server_unavailable[]
 #endif
 EXTERN char e_osc_response_timed_out[]
 	INIT(= N_("E1568: OSC command response timed out: %.*s"));
+#ifdef FEAT_EVAL
+EXTERN char e_cannot_add_listener_in_listener_callback[]
+	INIT(= N_("E1569: Cannot use listener_add in a listener callback"));
+#endif

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -1258,7 +1258,6 @@ static argcheck_T arg1_string_or_list_any[] = {arg_string_or_list_any};
 static argcheck_T arg1_string_or_list_string[] = {arg_string_or_list_string};
 static argcheck_T arg1_string_or_nr[] = {arg_string_or_nr};
 static argcheck_T arg1_string_or_blob[] = {arg_string_or_blob};
-static argcheck_T arg2_any_buffer[] = {arg_any, arg_buffer};
 static argcheck_T arg2_buffer_any[] = {arg_buffer, arg_any};
 static argcheck_T arg2_buffer_bool[] = {arg_buffer, arg_bool};
 static argcheck_T arg2_buffer_list_any[] = {arg_buffer, arg_list_any};
@@ -1301,6 +1300,7 @@ static argcheck_T arg2_string_or_list_number[] = {arg_string_or_list_any, arg_nu
 static argcheck_T arg2_string_string_or_number[] = {arg_string, arg_string_or_nr};
 static argcheck_T arg2_blob_dict[] = {arg_blob, arg_dict_any};
 static argcheck_T arg2_list_or_tuple_string[] = {arg_list_or_tuple, arg_string};
+static argcheck_T arg3_any_buffer_bool[] = {arg_any, arg_buffer, arg_bool};
 static argcheck_T arg3_any_list_dict[] = {arg_any, arg_list_any, arg_dict_any};
 static argcheck_T arg3_buffer_lnum_lnum[] = {arg_buffer, arg_lnum, arg_lnum};
 static argcheck_T arg3_buffer_number_number[] = {arg_buffer, arg_number, arg_number};
@@ -2507,7 +2507,7 @@ static const funcentry_T global_functions[] =
 			ret_string,	    f_list2str},
     {"list2tuple",	1, 1, FEARG_1,	    arg1_list_any,
 			ret_tuple_any,	    f_list2tuple},
-    {"listener_add",	1, 2, FEARG_2,	    arg2_any_buffer,
+    {"listener_add",	1, 3, FEARG_2,	    arg3_any_buffer_bool,
 			ret_number,	    f_listener_add},
     {"listener_flush",	0, 1, FEARG_1,	    arg1_buffer,
 			ret_void,	    f_listener_flush},

--- a/src/structs.h
+++ b/src/structs.h
@@ -3496,7 +3496,8 @@ struct file_buffer
     dictitem_T	b_bufvar;	// variable for "b:" Dictionary
     dict_T	*b_vars;	// internal variables, local to buffer
 
-    listener_T	*b_listener;
+    listener_T	*b_listener;       // Listeners accepting buffered reports.
+    listener_T	*b_sync_listener;  // Listeners requiring unbuffered reports.
     list_T	*b_recorded_changes;
 #endif
 #ifdef FEAT_PROP_POPUP

--- a/src/testdir/test_listener.vim
+++ b/src/testdir/test_listener.vim
@@ -8,6 +8,10 @@ func s:StoreList(s, e, a, l)
   let s:list = a:l
 endfunc
 
+func s:StoreListUnbuffered(s, e, a, c)
+  let s:list2 = [{'lnum': a:s, 'end': a:e, 'col': a:c, 'added': a:a}]
+endfunc
+
 func s:AnotherStoreList(l)
   let s:list2 = a:l
 endfunc
@@ -131,15 +135,135 @@ func Test_listening()
   call setline(1, 'asdfasdf')
   redraw
   call assert_equal([], s:list)
+  bwipe!
+endfunc
 
-  " Trying to change the list fails
+func Test_change_list_is_locked()
+  " Trying to change the list passed to the callback fails
+  new
+  call setline(1, ['one', 'two'])
   let id = listener_add({b, s, e, a, l -> s:EvilStoreList(l)})
+
   let s:list3 = []
   call setline(1, 'asdfasdf')
   redraw
   call assert_equal([{'lnum': 1, 'end': 2, 'col': 1, 'added': 0}], s:list3)
 
   eval id->listener_remove()
+  bwipe!
+endfunc
+
+func Test_new_listener_does_not_receive_ood_changes()
+  new
+  call setline(1, ['one', 'two', 'three'])
+  let s:list = []
+  let s:list2 = []
+
+  " Add a listener and make a change.
+  let id = listener_add({b, s, e, a, l -> s:StoreList(s, e, a, l)})
+  call setline(1, 'one one')
+
+  " Add a second listener, it should not see the above change to the buffer,
+  " only the change after it was added.
+  let id = listener_add({b, s, e, a, l -> s:AnotherStoreList(l)})
+  call setline(2, 'two two')
+
+  redraw
+  call assert_equal([{'lnum': 2, 'end': 3, 'col': 1, 'added': 0}], s:list)
+
+  call listener_remove(id)
+  bwipe!
+endfunc
+
+func Test_clean_up_after_last_listener_removed()
+  new
+  call setline(1, ['one', 'two', 'three'])
+  let s:list = []
+
+  " Add a listener, make a change, but then remove the listener before the
+  " listener gets invoked.
+  let id = listener_add({b, s, e, a, l -> s:StoreList(s, e, a, l)})
+  call setline(3, 'three three')
+  let ok = listener_remove(id)
+  call assert_equal(1, ok)
+
+  " Further buffer changes should (obviously) have no effect.
+  let s:list = []
+  call setline(2, 'two two')
+  redraw
+  call assert_equal([], s:list)
+
+  " Add a new listener, it should not see the above change to line 3 of the
+  " buffer.
+  let id = listener_add({b, s, e, a, l -> s:StoreList(s, e, a, l)})
+  redraw
+  call assert_equal([], s:list)
+
+  call listener_remove(id)
+  bwipe!
+endfunc
+
+func Test_a_callback_may_not_add_a_listener()
+  func ListenerWotAdds_listener(bufnr, start, end, added, changes)
+    call s:StoreList(a:start, a:end, a:added, a:changes)
+    call assert_fails(
+        \ "call listener_add({b, s, e, a, l -> s:AnotherStoreList(l)})", "E1562:")
+  endfunc
+
+  new
+  call setline(1, ['one', 'two', 'three'])
+  let s:list = []
+
+  " Add a listener, make a change, but then remove the listener before the
+  " listener gets invoked.
+  let id = listener_add("ListenerWotAdds_listener")
+  call setline(3, 'three three')
+  redraw
+  call assert_equal([{'lnum': 3, 'end': 4, 'col': 1, 'added': 0}], s:list)
+
+  let s:list2 = []
+  call setline(2, 'two two')
+  redraw
+  call assert_equal([{'lnum': 2, 'end': 3, 'col': 1, 'added': 0}], s:list)
+  call assert_equal([], s:list2)
+
+  call listener_remove(id)
+  bwipe!
+endfunc
+
+func Test_changes_can_be_unbuffered()
+  new
+  call setline(1, ['one', 'two', 'three'])
+  let s:list = []
+  let s:list2 = []
+
+  " Add both a buffered and an unbuffered listener.
+  let id_a = listener_add({b, s, e, a, l -> s:StoreList(s, e, a, l)})
+  let id_b = listener_add(
+      \ {b, s, e, a, c -> s:StoreListUnbuffered(s, e, a, c)},
+      \ bufnr(), v:true)
+
+  " Make a change, which only the second listener should see immediately.
+  call setline(2, 'two two')
+  call assert_equal([{'lnum': 2, 'end': 3, 'col': 1, 'added': 0}], s:list2)
+  call assert_equal([], s:list)
+
+  " Make another change, which only the second listener should see immediately.
+  call setline(3, 'three three')
+  call assert_equal([{'lnum': 3, 'end': 4, 'col': 1, 'added': 0}], s:list2)
+  call assert_equal([], s:list)
+
+  " Force changes to be flushed. Only the first listener should be invoked,
+  " with both the above changes.
+  let s:list2 = []
+  redraw
+  call assert_equal([
+      \ {'lnum': 2, 'end': 3, 'col': 1, 'added': 0},
+      \ {'lnum': 3, 'end': 4, 'col': 1, 'added': 0}], s:list)
+  call assert_equal([], s:list2)
+
+  call listener_remove(id_a)
+  call listener_remove(id_b)
   bwipe!
 endfunc
 
@@ -375,7 +499,7 @@ endfunc
 func Test_remove_listener_in_callback()
   new
   let s:ID = listener_add('Listener')
-  func Listener(...)
+  func! Listener(...)
     call listener_remove(s:ID)
     let g:listener_called = 'yes'
   endfunc


### PR DESCRIPTION
This is a fix for issue #18183.

I came across some sub-issues whilst implementing these changes. Trying to fix them as separate bug did not seem a sensible approach, given the core changes #18183 needed, so I have taken the liberty of rolling some extra changes.

1. The listener_add function flushes any pending change reports *before* adding the new listener.
2. When the last (buffered) listener is removed for a buffer, any un-flushed change reports are deleted.
3. Use of the listener_add function is disallowed while a listener callback is in progress. 

I will, of course, make suitable changes if necessary.