### PR TITLE
float.c: set v_type in f_isinf() and f_isnan()

### DIFF
--- a/src/float.c
+++ b/src/float.c
@@ -345,6 +345,9 @@ f_fmod(typval_T *argvars, typval_T *rettv)
     void
 f_isinf(typval_T *argvars, typval_T *rettv)
 {
+    rettv->v_type = VAR_NUMBER;
+    rettv->vval.v_number = 0;
+
     if (in_vim9script() && check_for_float_or_nr_arg(argvars, 0) == FAIL)
 	return;
 
@@ -358,6 +361,9 @@ f_isinf(typval_T *argvars, typval_T *rettv)
     void
 f_isnan(typval_T *argvars, typval_T *rettv)
 {
+    rettv->v_type = VAR_NUMBER;
+    rettv->vval.v_number = 0;
+
     if (in_vim9script() && check_for_float_or_nr_arg(argvars, 0) == FAIL)
 	return;
 


### PR DESCRIPTION
Both builtins wrote only `rettv->vval.v_number` and relied on `call_func()` initialising `rettv->v_type` to `VAR_NUMBER`.  Explicitly set
```
    rettv->v_type = VAR_NUMBER;
    rettv->vval.v_number = 0;
```
at function entry to avoid undefined behaviour and make the return type self-contained.