### PR TITLE
Fix wrong code of netrw

### DIFF
--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -3048,12 +3048,12 @@ function s:NetrwBrowse(islocal,dirname)
             exe "sil! NetrwKeepj keepalt doau BufReadPre ".fnameescape(s:fname)
             sil call netrw#NetRead(2,url)
             " netrw.vim and tar.vim have already handled decompression of the tarball; avoiding gzip.vim error
-            if s:path =~ '.bz2'
+            if s:path =~ '\.bz2$'
                 exe "sil NetrwKeepj keepalt doau BufReadPost ".fnameescape(substitute(s:fname,'\.bz2$','',''))
-            elseif s:path =~ '.gz'
+            elseif s:path =~ '\.gz$'
                 exe "sil NetrwKeepj keepalt doau BufReadPost ".fnameescape(substitute(s:fname,'\.gz$','',''))
-            elseif s:path =~ '.gz'
-                exe "sil NetrwKeepj keepalt doau BufReadPost ".fnameescape(substitute(s:fname,'\.txz$','',''))
+            elseif s:path =~ '\.xz$'
+                exe "sil NetrwKeepj keepalt doau BufReadPost ".fnameescape(substitute(s:fname,'\.xz$','',''))
             else
                 exe "sil NetrwKeepj keepalt doau BufReadPost ".fnameescape(s:fname)
             endif


### PR DESCRIPTION
This issue was reported by @KSR-Yasuda  on vim-jp.
https://github.com/vim-jp/issues/issues/1450

There seems to be some strange code in `runtime/pack/dist/opt/netrw/autoload/netrw.vim`.
This PR should fix it, but I haven't been able to test it.
(I've disabled netrw for long years, and after some experimentation, the code in question doesn't seem to run on local files.)
Sorry, but could someone please confirm this?
It appears to work on remote `*.tar.bz2`, `*.tar.gz`, and `*.tar.xy` files.