### PR TITLE
Feat: Make 'autocomplete' local to buffer

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -913,7 +913,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 			*'autocomplete'* *'ac'* *'noautocomplete'* *'noac'*
 'autocomplete' 'ac'	boolean (default off)
-			global
+			global or local to buffer |global-local|
 			{only available on platforms with timing support}
 	When on, Vim shows a completion menu as you type, similar to using
 	|i_CTRL-N|, but triggered automatically.  See |ins-autocompletion|.

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -2534,6 +2534,7 @@ free_buf_options(
 #endif
     clear_string_option(&buf->b_p_tsr);
     clear_string_option(&buf->b_p_qe);
+    buf->b_p_ac = -1;
     buf->b_p_ar = -1;
     buf->b_p_ul = NO_LOCAL_UNDOLEVEL;
     clear_string_option(&buf->b_p_lw);

--- a/src/edit.c
+++ b/src/edit.c
@@ -146,6 +146,7 @@ edit(
 #ifdef FEAT_CONCEAL
     int		cursor_line_was_concealed;
 #endif
+    int		do_autocomplete = curbuf->b_p_ac >= 0 ? curbuf->b_p_ac : p_ac;
 
     // Remember whether editing was restarted after CTRL-O.
     did_restart_edit = restart_edit;
@@ -987,7 +988,7 @@ doESCkey:
 	case Ctrl_H:
 	    did_backspace = ins_bs(c, BACKSPACE_CHAR, &inserted_space);
 	    auto_format(FALSE, TRUE);
-	    if (did_backspace && curbuf->b_p_ac && !char_avail()
+	    if (did_backspace && do_autocomplete && !char_avail()
 		    && curwin->w_cursor.col > 0)
 	    {
 		c = char_before_cursor();
@@ -1418,7 +1419,7 @@ normalchar:
 	    foldOpenCursor();
 #endif
 	    // Trigger autocompletion
-	    if (curbuf->b_p_ac && !char_avail() && vim_isprintc(c))
+	    if (do_autocomplete && !char_avail() && vim_isprintc(c))
 	    {
 		update_screen(UPD_VALID); // Show character immediately
 		out_flush();

--- a/src/edit.c
+++ b/src/edit.c
@@ -987,7 +987,7 @@ doESCkey:
 	case Ctrl_H:
 	    did_backspace = ins_bs(c, BACKSPACE_CHAR, &inserted_space);
 	    auto_format(FALSE, TRUE);
-	    if (did_backspace && p_ac && !char_avail()
+	    if (did_backspace && curbuf->b_p_ac && !char_avail()
 		    && curwin->w_cursor.col > 0)
 	    {
 		c = char_before_cursor();
@@ -1418,7 +1418,7 @@ normalchar:
 	    foldOpenCursor();
 #endif
 	    // Trigger autocompletion
-	    if (p_ac && !char_avail() && vim_isprintc(c))
+	    if (curbuf->b_p_ac && !char_avail() && vim_isprintc(c))
 	    {
 		update_screen(UPD_VALID); // Show character immediately
 		out_flush();

--- a/src/edit.c
+++ b/src/edit.c
@@ -146,7 +146,6 @@ edit(
 #ifdef FEAT_CONCEAL
     int		cursor_line_was_concealed;
 #endif
-    int		do_autocomplete = curbuf->b_p_ac >= 0 ? curbuf->b_p_ac : p_ac;
 
     // Remember whether editing was restarted after CTRL-O.
     did_restart_edit = restart_edit;
@@ -695,7 +694,7 @@ edit(
 		{
 		    ins_compl_delete();
 		    if (ins_compl_has_preinsert()
-			    && ins_compl_has_autocomplete())
+			    && ins_compl_autocomplete_enabled())
 			(void)ins_compl_insert(FALSE, TRUE);
 		    else
 			(void)ins_compl_insert(FALSE, FALSE);
@@ -988,7 +987,7 @@ doESCkey:
 	case Ctrl_H:
 	    did_backspace = ins_bs(c, BACKSPACE_CHAR, &inserted_space);
 	    auto_format(FALSE, TRUE);
-	    if (did_backspace && do_autocomplete && !char_avail()
+	    if (did_backspace && ins_compl_has_autocomplete() && !char_avail()
 		    && curwin->w_cursor.col > 0)
 	    {
 		c = char_before_cursor();
@@ -1419,7 +1418,8 @@ normalchar:
 	    foldOpenCursor();
 #endif
 	    // Trigger autocompletion
-	    if (do_autocomplete && !char_avail() && vim_isprintc(c))
+	    if (ins_compl_has_autocomplete() && !char_avail()
+		    && vim_isprintc(c))
 	    {
 		update_screen(UPD_VALID); // Show character immediately
 		out_flush();

--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -2498,7 +2498,7 @@ ins_compl_new_leader(void)
 	save_w_wrow = curwin->w_wrow;
 	save_w_leftcol = curwin->w_leftcol;
 	compl_restarting = TRUE;
-	if (p_ac)
+	if (curbuf->b_p_ac)
 	    compl_autocomplete = TRUE;
 	if (ins_complete(Ctrl_N, FALSE) == FAIL)
 	    compl_cont_status = 0;

--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -2498,8 +2498,8 @@ ins_compl_new_leader(void)
 	save_w_wrow = curwin->w_wrow;
 	save_w_leftcol = curwin->w_leftcol;
 	compl_restarting = TRUE;
-	if (curbuf->b_p_ac)
-	    compl_autocomplete = TRUE;
+	compl_autocomplete = (curbuf->b_p_ac >= 0
+		? curbuf->b_p_ac : p_ac) != 0;
 	if (ins_complete(Ctrl_N, FALSE) == FAIL)
 	    compl_cont_status = 0;
 	compl_restarting = FALSE;

--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -2375,7 +2375,7 @@ ins_compl_preinsert_effect(void)
  * Returns TRUE if autocompletion is active.
  */
     int
-ins_compl_has_autocomplete(void)
+ins_compl_autocomplete_enabled(void)
 {
     return compl_autocomplete;
 }
@@ -2450,6 +2450,16 @@ ins_compl_need_restart(void)
 }
 
 /*
+ * Return TRUE if 'autocomplete' option is set
+ */
+    int
+ins_compl_has_autocomplete(void)
+{
+    // Use buffer-local setting if defined (>= 0), otherwise use global
+    return curbuf->b_p_ac >= 0 ? curbuf->b_p_ac : p_ac;
+}
+
+/*
  * Called after changing "compl_leader".
  * Show the popup menu with a different set of matches.
  * May also search for matches again if the previous search was interrupted.
@@ -2498,8 +2508,7 @@ ins_compl_new_leader(void)
 	save_w_wrow = curwin->w_wrow;
 	save_w_leftcol = curwin->w_leftcol;
 	compl_restarting = TRUE;
-	compl_autocomplete = (curbuf->b_p_ac >= 0
-		? curbuf->b_p_ac : p_ac) != 0;
+	compl_autocomplete = ins_compl_has_autocomplete();
 	if (ins_complete(Ctrl_N, FALSE) == FAIL)
 	    compl_cont_status = 0;
 	compl_restarting = FALSE;

--- a/src/option.c
+++ b/src/option.c
@@ -6441,6 +6441,9 @@ unset_global_local_option(char_u *name, void *from)
 	case PV_PATH:
 	    clear_string_option(&buf->b_p_path);
 	    break;
+	case PV_AC:
+	    buf->b_p_ac = -1;
+	    break;
 	case PV_AR:
 	    buf->b_p_ar = -1;
 	    break;
@@ -6593,6 +6596,7 @@ get_varp_scope(struct vimoption *p, int scope)
 	    case PV_EP:   return (char_u *)&(curbuf->b_p_ep);
 	    case PV_KP:   return (char_u *)&(curbuf->b_p_kp);
 	    case PV_PATH: return (char_u *)&(curbuf->b_p_path);
+	    case PV_AC:   return (char_u *)&(curbuf->b_p_ac);
 	    case PV_AR:   return (char_u *)&(curbuf->b_p_ar);
 	    case PV_TAGS: return (char_u *)&(curbuf->b_p_tags);
 	    case PV_TC:   return (char_u *)&(curbuf->b_p_tc);
@@ -6669,6 +6673,8 @@ get_varp(struct vimoption *p)
 				    ? (char_u *)&curbuf->b_p_kp : p->var;
 	case PV_PATH:	return *curbuf->b_p_path != NUL
 				    ? (char_u *)&(curbuf->b_p_path) : p->var;
+	case PV_AC:	return curbuf->b_p_ac >= 0
+				    ? (char_u *)&(curbuf->b_p_ac) : p->var;
 	case PV_AR:	return curbuf->b_p_ar >= 0
 				    ? (char_u *)&(curbuf->b_p_ar) : p->var;
 	case PV_TAGS:	return *curbuf->b_p_tags != NUL
@@ -7371,6 +7377,7 @@ buf_copy_options(buf_T *buf, int flags)
 		buf->b_p_swf = p_swf;
 		COPY_OPT_SCTX(buf, BV_SWF);
 	    }
+	    buf->b_p_ac = p_ac;
 	    buf->b_p_cpt = vim_strsave(p_cpt);
 	    COPY_OPT_SCTX(buf, BV_CPT);
 #ifdef FEAT_COMPL_FUNC

--- a/src/option.c
+++ b/src/option.c
@@ -695,6 +695,7 @@ set_init_1(int clean_arg)
 #endif
 
     curbuf->b_p_initialized = TRUE;
+    curbuf->b_p_ac = -1;
     curbuf->b_p_ar = -1;	// no local 'autoread' value
     curbuf->b_p_ul = NO_LOCAL_UNDOLEVEL;
     check_buf_options(curbuf);
@@ -2206,6 +2207,8 @@ do_set_option_bool(
     {
 	// For 'autoread' -1 means to use global value.
 	if ((int *)varp == &curbuf->b_p_ar && opt_flags == OPT_LOCAL)
+	    value = -1;
+	else if ((int *)varp == &curbuf->b_p_ac && opt_flags == OPT_LOCAL)
 	    value = -1;
 	else
 	    value = *(int *)get_varp_scope(&(options[opt_idx]), OPT_GLOBAL);
@@ -7377,7 +7380,6 @@ buf_copy_options(buf_T *buf, int flags)
 		buf->b_p_swf = p_swf;
 		COPY_OPT_SCTX(buf, BV_SWF);
 	    }
-	    buf->b_p_ac = p_ac;
 	    buf->b_p_cpt = vim_strsave(p_cpt);
 	    COPY_OPT_SCTX(buf, BV_CPT);
 #ifdef FEAT_COMPL_FUNC
@@ -7508,6 +7510,7 @@ buf_copy_options(buf_T *buf, int flags)
 
 	    // options that are normally global but also have a local value
 	    // are not copied, start using the global value
+	    buf->b_p_ac = -1;
 	    buf->b_p_ar = -1;
 	    buf->b_p_ul = NO_LOCAL_UNDOLEVEL;
 	    buf->b_p_bkc = empty_option;

--- a/src/option.h
+++ b/src/option.h
@@ -1168,6 +1168,7 @@ EXTERN int	p_xtermcodes;	// 'xtermcodes'
 enum
 {
     BV_AI = 0
+    , BV_AC
     , BV_AR
     , BV_BH
     , BV_BKC

--- a/src/optiondefs.h
+++ b/src/optiondefs.h
@@ -26,6 +26,7 @@
 
 // Definition of the PV_ values for buffer-local options.
 // The BV_ values are defined in option.h.
+#define PV_AC		OPT_BOTH(OPT_BUF(BV_AC))
 #define PV_AI		OPT_BUF(BV_AI)
 #define PV_AR		OPT_BOTH(OPT_BUF(BV_AR))
 #define PV_BKC		OPT_BOTH(OPT_BUF(BV_BKC))
@@ -390,7 +391,7 @@ static struct vimoption options[] =
 			    SCTX_INIT},
 #ifdef ELAPSED_FUNC
     {"autocomplete",  "ac", P_BOOL|P_VI_DEF,
-			    (char_u *)&p_ac, PV_NONE, NULL,
+			    (char_u *)&p_ac, PV_AC, NULL,
 			    NULL, {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"autocompletedelay", "acl", P_NUM|P_VI_DEF,
 			    (char_u *)&p_acl, PV_NONE, NULL, NULL,

--- a/src/proto/insexpand.pro
+++ b/src/proto/insexpand.pro
@@ -49,7 +49,7 @@ colnr_T ins_compl_col(void);
 int ins_compl_len(void);
 int ins_compl_has_preinsert(void);
 int ins_compl_preinsert_effect(void);
-int ins_compl_has_autocomplete(void);
+int ins_compl_autocomplete_enabled(void);
 int ins_compl_bs(void);
 void ins_compl_addleader(int c);
 void ins_compl_addfrommatch(void);
@@ -76,4 +76,5 @@ void ins_compl_check_keys(int frequency, int in_compl_func);
 int ins_complete(int c, int enable_pum);
 void ins_compl_enable_autocomplete(void);
 void free_insexpand_stuff(void);
+int ins_compl_has_autocomplete(void);
 /* vim: set ft=c : */

--- a/src/structs.h
+++ b/src/structs.h
@@ -3285,6 +3285,7 @@ struct file_buffer
     sctx_T	b_p_script_ctx[BV_COUNT]; // SCTXs for buffer-local options
 #endif
 
+    int		b_p_ac;		// 'autocomplete'
     int		b_p_ai;		// 'autoindent'
     int		b_p_ai_nopaste;	// b_p_ai saved for paste mode
     char_u	*b_p_bkc;	// 'backupcopy'

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -5439,7 +5439,7 @@ func Test_scriptlocal_autoload_func()
   call test_override("char_avail", 1)
   new
   inoremap <buffer> <F2> <Cmd>let b:matches = complete_info(["matches"]).matches<CR>
-  set autocomplete
+  setlocal autocomplete
 
   setlocal complete=.,Fcompl#Func
   call feedkeys("im\<F2>\<Esc>0", 'xt!')
@@ -5450,7 +5450,6 @@ func Test_scriptlocal_autoload_func()
   call assert_equal(['foo', 'foobar'], b:matches->mapnew('v:val.word'))
 
   setlocal complete&
-  set autocomplete&
   bwipe!
   call test_override("char_avail", 0)
   let &rtp = save_rtp
@@ -5548,7 +5547,7 @@ func Test_autocompletedelay()
 
   let lines =<< trim [SCRIPT]
     call setline(1, ['foo', 'foobar', 'foobarbaz'])
-    set autocomplete
+    setlocal autocomplete
   [SCRIPT]
   call writefile(lines, 'XTest_autocomplete_delay', 'D')
   let buf = RunVimInTerminal('-S XTest_autocomplete_delay', {'rows': 10})


### PR DESCRIPTION
Make 'autocomplete' global or local to buffer.
Fixes https://github.com/vim/vim/issues/18320