### PR TITLE
feat: file type for Mamba configuration file

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -630,6 +630,9 @@ au BufNewFile,BufRead lynx.cfg			setf lynx
 " LyRiCs
 au BufNewFile,BufRead *.lrc			setf lyrics
 
+" Mamba configuration file
+au BufNewFile,BufRead .mambarc,mambarc		setf yaml
+
 " MLIR
 au BufNewFile,BufRead *.mlir			setf mlir
 

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -935,7 +935,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     xslt: ['file.xsl', 'file.xslt'],
     yacc: ['file.yy', 'file.yxx', 'file.y++'],
     yaml: ['file.yaml', 'file.yml', 'file.eyaml', 'file.kyaml', 'file.kyml', 'any/.bundle/config', '.clangd', '.clang-format', '.clang-tidy', 'file.mplstyle', 'matplotlibrc', 'yarn.lock',
-           '/home/user/.kube/config', '/home/user/.kube/kuberc', '.condarc', 'condarc', 'pixi.lock'],
+           '/home/user/.kube/config', '/home/user/.kube/kuberc', '.condarc', 'condarc', '.mambarc', 'mambarc', 'pixi.lock'],
     yang: ['file.yang'],
     yuck: ['file.yuck'],
     z8a: ['file.z8a'],


### PR DESCRIPTION
See https://mamba.readthedocs.io/en/latest/user_guide/configuration.html.

Mamba is an alternative for conda. The file type info for conda config file has already existed in Vim.