### PR TITLE
runtime(ft): fix FTtf()

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -1401,12 +1401,12 @@ export def FTtf()
   for i in range(1, numberOfLines)
     var currentLine = trim(getline(i))
     var firstCharacter = currentLine[0]
-    if firstCharacter !=? ";" && firstCharacter !=? "/" && firstCharacter !=? ""
-      setf terraform
+    if firstCharacter ==? ";" || firstCharacter ==? "/" || firstCharacter ==? ""
+      setf tf
       return
     endif
   endfor
-  setf tf
+  setf terraform
 enddef
 
 var ft_krl_header = '\&\w+'


### PR DESCRIPTION
tf mud client was identified as terraform and the other way round.