### PR TITLE
sha256() treats empty blob and null blob differently

### DIFF
--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -11760,12 +11760,9 @@ f_sha256(typval_T *argvars, typval_T *rettv)
     if (argvars[0].v_type == VAR_BLOB)
     {
 	blob_T *blob = argvars[0].vval.v_blob;
-	if (blob != NULL)
-	{
-	    p = (char_u *)blob->bv_ga.ga_data;
-	    len = blob->bv_ga.ga_len;
-	    rettv->vval.v_string = vim_strsave(sha256_bytes(p, len, NULL, 0));
-	}
+	p = blob != NULL ? (char_u *)blob->bv_ga.ga_data : (char_u *)"";
+	len = blob != NULL ? blob->bv_ga.ga_len : 0;
+	rettv->vval.v_string = vim_strsave(sha256_bytes(p, len, NULL, 0));
     }
     else
     {

--- a/src/testdir/test_sha256.vim
+++ b/src/testdir/test_sha256.vim
@@ -4,24 +4,25 @@ CheckFeature cryptv
 CheckFunction sha256
 
 function Test_sha256()
-  " test for empty string:
+  " tests for string:
+  " empty string
   call assert_equal('e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855', sha256(""))
-
-  "'test for 1 char:
+  " null string
+  call assert_equal('e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855', sha256(test_null_string()))
+  " string with 1 char
   call assert_equal('ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb', sha256("a"))
-  "
-  "test for 3 chars:
+  " string with 3 chars
   call assert_equal('ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad', "abc"->sha256())
-
-  " test for contains meta char:
+  " string containing meta char
   call assert_equal('807eff6267f3f926a21d234f7b0cf867a86f47e07a532f15e8cc39ed110ca776', sha256("foo\nbar"))
-
-  " test for contains non-ascii char:
+  " string containing non-ascii char
   call assert_equal('5f78c33274e43fa9de5659265c1d917e25c03722dcb0b8d27db8d5feaa813953', sha256("\xde\xad\xbe\xef"))
 
-  " test for blob:
+  " tests for blob:
   " empty blob
   call assert_equal('e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855', sha256(0z))
+  " null blob
+  call assert_equal('e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855', sha256(test_null_blob()))
   " blob with single byte
   call assert_equal('ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb', sha256(0z61))
   " blob with "abc"


### PR DESCRIPTION
Problem:  sha256() treats empty blob and null blob differently (after
          9.1.1774).
Solution: Handle null blob the same as empty blob.
