### PR TITLE
Mouse click to open fold doesn't work with Unicode "foldclose"

### DIFF
--- a/src/mouse.c
+++ b/src/mouse.c
@@ -2109,7 +2109,8 @@ retnomove:
 #ifdef FEAT_FOLDING
 	// Remember the character under the mouse, it might be a '-' or '+' in
 	// the fold column.
-	mouse_char = ScreenLines[off];
+	mouse_char = enc_utf8 && ScreenLinesUC[off] != 0
+				       ? ScreenLinesUC[off] : ScreenLines[off];
 #endif
     }
 

--- a/src/testdir/test_termcodes.vim
+++ b/src/testdir/test_termcodes.vim
@@ -1068,7 +1068,7 @@ func Test_mouse_alt_leftclick()
   bw!
 endfunc
 
-func Test_xterm_mouse_click_in_fold_columns()
+func Run_test_xterm_mouse_click_in_fold_columns()
   new
   let save_mouse = &mouse
   let save_term = &term
@@ -1118,6 +1118,15 @@ func Test_xterm_mouse_click_in_fold_columns()
   let &term = save_term
   let &mouse = save_mouse
   bwipe!
+endfunc
+
+func Test_xterm_mouse_click_in_fold_columns()
+  call Run_test_xterm_mouse_click_in_fold_columns()
+  set fillchars+=foldclose:▶
+  call Run_test_xterm_mouse_click_in_fold_columns()
+  set fillchars-=foldclose:▶ fillchars+=foldclose:!
+  call Run_test_xterm_mouse_click_in_fold_columns()
+  set fillchars&
 endfunc
 
 " Left or right click in Ex command line sets position of the cursor.


### PR DESCRIPTION
Problem:  Mouse click to open fold doesn't work if 'fillchars'
          "foldclose" is a Unicode character.
Solution: Use ScreenLinesUC[off] if it is set.

fixes: #18344
