### PR TITLE
runtime/doc/vim9.txt - Sections 5 to 8 updated

### DIFF
--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -8299,6 +8299,7 @@ help-context	help.txt	/*help-context*
 help-curwin	tips.txt	/*help-curwin*
 help-notation	helphelp.txt	/*help-notation*
 help-summary	usr_02.txt	/*help-summary*
+help-tags	tags	1
 help-toc-install	helphelp.txt	/*help-toc-install*
 help-translated	helphelp.txt	/*help-translated*
 help-writing	helphelp.txt	/*help-writing*
@@ -11126,6 +11127,7 @@ type-checking	vim9.txt	/*type-checking*
 type-inference	vim9.txt	/*type-inference*
 type-mistakes	tips.txt	/*type-mistakes*
 type-parameter-naming	vim9.txt	/*type-parameter-naming*
+type-variable-naming	vim9.txt	/*type-variable-naming*
 typealias	vim9class.txt	/*typealias*
 typename()	builtin.txt	/*typename()*
 typescript.vim	syntax.txt	/*typescript.vim*

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -8049,6 +8049,7 @@ ge	motion.txt	/*ge*
 gender-neutral	helphelp.txt	/*gender-neutral*
 generic-function-call	vim9.txt	/*generic-function-call*
 generic-function-declaration	vim9.txt	/*generic-function-declaration*
+generic-function-example	vim9.txt	/*generic-function-example*
 generic-functions	vim9.txt	/*generic-functions*
 get()	builtin.txt	/*get()*
 get()-blob	builtin.txt	/*get()-blob*
@@ -8298,7 +8299,6 @@ help-context	help.txt	/*help-context*
 help-curwin	tips.txt	/*help-curwin*
 help-notation	helphelp.txt	/*help-notation*
 help-summary	usr_02.txt	/*help-summary*
-help-tags	tags	1
 help-toc-install	helphelp.txt	/*help-toc-install*
 help-translated	helphelp.txt	/*help-translated*
 help-writing	helphelp.txt	/*help-writing*
@@ -11125,7 +11125,7 @@ type-casting	vim9.txt	/*type-casting*
 type-checking	vim9.txt	/*type-checking*
 type-inference	vim9.txt	/*type-inference*
 type-mistakes	tips.txt	/*type-mistakes*
-type-variable-naming	vim9.txt	/*type-variable-naming*
+type-parameter-naming	vim9.txt	/*type-parameter-naming*
 typealias	vim9class.txt	/*typealias*
 typename()	builtin.txt	/*typename()*
 typescript.vim	syntax.txt	/*typescript.vim*

--- a/runtime/doc/vim9.txt
+++ b/runtime/doc/vim9.txt
@@ -1,4 +1,4 @@
-*vim9.txt*	For Vim version 9.1.  Last change: 2025 Sep 30
+*vim9.txt*	For Vim version 9.1.  Last change: 2025 Oct 06
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -18,8 +18,28 @@ features in Vim9 script.
 5.  Generic functions			|generic-functions|
 6.  Namespace, Import and Export	|vim9script|
 7.  Classes and interfaces		|vim9-classes|
-
 8.  Rationale				|vim9-rationale|
+
+
+------------------------------------------------------------------------------
+
+  NOTE: In this vim9.txt help file, the Vim9 script code blocks beginning
+	with `vim9script` are Vim9 script syntax highlighted.  Also, they are
+	sourceable, meaning you can run them to see what they output.  To
+	source them, use `:'<,'>source` (see |source-range|), which is done by
+	visually selecting the line(s) with |V| and typing `:so`.
+	For example, try it on the following Vim9 script: >vim9
+
+		vim9script
+		echowindow "Welcome to Vim9 script!"
+<
+	There are also code examples that should not be sourced - they
+	explain concepts that don't require a sourceable example.  Such code
+	blocks appear in generic code syntax highlighting, like this: >
+
+		def ThisFunction()          # script-local
+		def g:ThatFunction()        # global
+		export def Function()       # for import and import autoload
 
 ==============================================================================
 
@@ -1903,126 +1923,250 @@ A generic function allows using the same function with different type
 arguments, while retaining type checking for arguments and the return value.
 This provides type safety and code reusability.
 
+
 Declaration~
 						*generic-function-declaration*
-						*E1553* *E1554* *E1559*
-The type parameters for a generic function are declared in angle brackets "<"
-and ">" directly after the function name.  Multiple type names are separated
-by commas: >
+						*E1553* *E1554*
+The type parameters for a generic function are declared within angle brackets
+("<" and ">") directly after the function name.  Multiple type parameters are
+separated by commas: >
 
-    def[!] {funcname}<{type} [, {types}]>([arguments])[: {return-type}]
-	{function body}
-    enddef
-<
-These type parameters can then be used like any other type within the function
-signature and body.  Example: >
+	def[!] {funcname}<{type} [, {types}]>([arguments])[: {return-type}]
+	    {function body}
+	enddef
+<						*generic-function-example*
+These type parameters may then be used as arguments' types and type variables,
+like any other type, within the function signature and body.  The following
+example, combines two lists into a list of tuples: >vim9
 
-    def MyFunc<T, A, B>(param1: T): T
-	var f: A
-	var x = param1
-	return x
-    enddef
+	vim9script
+	def Zip<T, U>(first: list<T>, second: list<U>): list<tuple<T, U>>
+	    const LEN: number = ([first->len(), second->len()])->min()
+	    final result: list<tuple<T, U>> = []
+	    for i in range(LEN)
+	        result->add((first[i], second[i]))
+	    endfor
+	    return result
+	enddef
+	var n: list<number> = [61, 62, 63]
+	var s: list<string> = ['a', 'b', 'c']
+	echo $"Zip example #1: {Zip<number, string>(n, s)}"
+	echo $"Zip example #2: {Zip<string, number>(s, n)}"
 <
 						*type-variable-naming* *E1552*
-The convention is to use a single uppercase letter for a type variable (e.g.,
-T, A, X), although longer names are allowed.  The name must start with an
-uppercase letter.
+						*type-parameter-naming*
+As in the preceding example, the convention is to use a single capital letter
+for a type parameter/variable (e.g., T, U, A, etc.).  Although they may
+comprise more than one letter, parameter names must start with a capital
+letter.  In this example, "Ok" is valid whereas "n" is not: >vim9
 
-						*E1558* *E1560*
-A function must be declared and used either as generic or as a regular
-function - but not both.
+	vim9script
+	def MyFail<Ok, n>(): void
+	enddef
+	# E1552: Type variable name must start with an uppercase letter: n...
+<
+						*E1558* *E1559* *E1560*
+A function must be declared and used either as a generic function or as a
+regular function, but not both.  Also, a generic function must be called
+specifying all its required parameters.  The following Vim9 scripts
+demonstrate these errors: >vim9
 
+	vim9script
+	My1558<number>()
+	# Vim(eval):E1558: Unknown generic function: My1558
+< >vim9
+	vim9script
+	def My1559<T>(): T
+	enddef
+	My1559()
+	# Vim(eval):E1559: Type arguments missing for generic function ...
+< >vim9
+	vim9script
+	def My1560(): void
+	enddef
+	My1560<string>()
+	# Vim(echo):E1560: Not a generic function: My1560
+<
 						*E1561*
-A type variable name must not conflict with other defined names, such as class
-names, type aliases, enum names, function names or other type variable names.
+Type parameter names must be unique within the declaration of a generic
+function: >vim9
+
+	vim9script
+	def My1561<D, E, D>(): D
+	enddef
+	# E1561: Duplicate type variable name: D
+
+Also, a type parameter name must not conflict with other defined names, such
+as class names, type aliases, enum names, or function names.  Trying to do
+so results in error |E1041|.  For example: >vim9
+
+	vim9script
+	enum E
+	  Yes, No
+	endenum
+	def My1041<E>(): E
+	enddef
+	# E0141: Redefining script item "E"
+<
 
 Calling a generic function~
 						*generic-function-call*
 To call a generic function, specify the concrete types in "<" and ">"
 between the function name and the argument list: >
 
-    MyFunc<number, string, list<number>>()
+	MyFunc<number, string, list<number>>()
 <
+	NOTE: There are several working examples in this section, which may
+	      be sourced, including |generic-function-example|.
+
 						*E1555* *E1556* *E1557*
 The number of concrete types provided when calling a generic function must
-match the number of type variables in the function.  An empty type list is not
-allowed.  Any Vim9 type (|vim9-types|) can be used as a concrete type in a
-generic function.
+match the number of type parameters in the function.  An empty type list is
+not allowed.   Examples: >vim9
 
-Spaces are not allowed between the function name and "<", or between ">" and
-the opening "(".
+	vim9script
+	def My1555<>(): void
+	enddef
+	# E1555: Empty type list specified for generic function ...
+< >vim9
+	vim9script
+	def My1556<T>(): void
+	enddef
+	My1556<bool, bool>()
+	# E1556: Too many types specified for generic function ...
+< >vim9
+	vim9script
+	def My1557<T, U>(): void
+	enddef
+	My1557<bool>()
+	# E1557: Not enough types specified for generic function ...
+<
+Any Vim9 type (|vim9-types|) can be used as a concrete type in a generic
+function.
+
+Spaces are not allowed:
+- Between the function name and "<" (|E1068|)
+- Between ">" and the opening "(" (|E1068|), or
+- Within the "<" and ">", except where required after the comma separating
+  the types (|E1202|).
 
 A generic function can be exported and imported like a regular function.
 See |:export| and |:import|.
 
 A generic function can be defined inside another regular or generic function.
-
-Referencing type variables in generic types~
-
-Instead of concrete types, type variables can be used with generic types.
-This is useful for complex data structures like lists of dictionaries or
-dictionaries of lists.  Example: >
-
-    vim9script
-
-    def Flatten<T>(x: list<list<T>>): list<T>
-	var result: list<T> = []
-	for inner in x
-	    result += inner
-	endfor
-	return result
-    enddef
-
-    echo Flatten<number>([[1, 2], [3]])
+Example: >vim9
+	vim9script
+	def Outer(): void
+	  # Returns either the first item of a list or a default value
+	  def FirstOrDefault<T, U>(lst: list<T>, default: U): any
+	    return lst->len() > 0 ? lst[0] : default
+	  enddef
+	  echo FirstOrDefault<string, bool>(['B', 'C'], false)	# echos B
+	  echo FirstOrDefault<number, number>([], 42)		# echos 42
+	enddef
+	Outer()
 <
+
+Referencing type parameters in generic types~
+
+Instead of concrete types, type parameters can be used with generic types.
+This is useful for complex data structures like dictionaries of lists or,
+as in the following example, lists of dictionaries: >vim9
+
+	vim9script
+	def Flatten<T>(x: list<list<T>>): list<T>
+	    final result: list<T> = []
+	    for inner in x
+	        result->extend(inner)
+	    endfor
+	    return result
+	enddef
+	const ENGLISH: list<dict<string>> = [{1: 'one'}, {2: 'two'}]
+	const MANDARIN: list<dict<string>> = [{1: '壹'}, {2: '贰'}]
+	const ARABIC_N: list<dict<number>> = [{1: 1}, {2: 2}]
+	echo Flatten<dict<string>>([ENGLISH, MANDARIN])
+	echo Flatten<dict<any>>([ENGLISH, ARABIC_N])
+<
+In "Flatten<T>", "T" is a declared type parameter.  Everywhere else in
+the function, "T" is a type variable referencing that type parameter.
+
+
+Using a type variable as a type argument ~
+
+A type variable may also be passed as a type argument.  For example: >vim9
+
+	vim9script
+	# T is declared as a type parameter
+	# It is used for the 'value' parameter and the return type
+	def Main<T>(value: T): T
+	    return value
+	enddef
+	# U is declared as a type parameter
+	# It is used for the 'value' parameter and the return type
+	def UseMain<U>(value: U): U
+	    # U is a type variable passed/used as a type argument
+	    return Main<U>(value)
+	enddef
+	echo UseMain<string>('I am') .. ' ' .. UseMain<number>(42)
+
 
 Generic class method~
 
-A Vim9 class method can be a generic function: >
+A Vim9 class method can be a generic function: >vim9
 
-    class A
-	def Foo<X, Y>()
-	enddef
-    endclass
-    var a = A.new()
-    a.Foo<number, string>()
+	vim9script
+	class Config
+	    var settings: dict<any>
+	    def Get<T>(key: string): T
+	        return this.settings[key]
+	    enddef
+	endclass
+	var c: Config = Config.new({timeout: 30, debug: true})
+	echo c.Get<number>('timeout')
+	echo c.Get<bool>('debug')
 <
 						*E1432* *E1433* *E1434*
 A generic class method in a base class can be overridden by a generic method
-in a child class. The number of type variables must match between both
+in a child class.  The number of type variables must match between both
 methods.  A concrete class method cannot be overridden by a generic method,
 and vice versa.
+
 
 Generic function reference~
 
 A function reference (|Funcref|) can be a generic function.  This allows for
-creating factories of functions that operate on specific types: >
+creating factories of functions that operate on specific types: >vim9
 
-    vim9script
-
-    def MakeEcho<T>(): func(T): T
-	return (x: T): T => x
-    enddef
-
-    var EchoNumber = MakeEcho<number>()
-    echo EchoNumber(123)
-
-    var EchoString = MakeEcho<string>()
-    echo EchoString('abc')
+	vim9script
+	# Match a specified character in a string or the decimal value of the
+	# character in a list.  Note: '*' is decimal 42 (U+002A)
+	var c: string = "*"
+	var char_dec: tuple<string, string> = (c, c->char2nr()->string())
+	def Matcher<T>(pattern: string): func(T): bool
+	    return (value: T): bool => match(value, pattern) >= 0
+	enddef
+	var StringMatch = Matcher<string>(char_dec[0])
+	echo "*+"->StringMatch()			    # true (has *)
+	echo ",-"->StringMatch()			    # false
+	var ListMatch = Matcher<list<number>>(char_dec[1])
+	echo [42, 43]->ListMatch()			    # true (has 42)
+	echo [44, 45]->ListMatch()			    # false
 <
+
 Compiling and Disassembling Generic functions~
 
 The |:defcompile| command can be used to compile a generic function with a
 specific list of concrete types: >
 
-    defcompile MyFunc<number, list<number>, dict<string>>
+	defcompile MyFunc<number, list<number>, dict<string>>
 <
 The |:disassemble| command can be used to list the instructions generated for
 a generic function: >
 
-    disassemble MyFunc<string, dict<string>>
-    disassemble MyFunc<number, list<blob>>
+	disassemble MyFunc<string, dict<string>>
+	disassemble MyFunc<number, list<blob>>
 <
+
 Limitations and Future Work~
 
 Currently, Vim does not support:
@@ -2085,26 +2229,39 @@ In the |vimrc| file sourced on startup this does not happen.
 							*vim9-mix*
 There is one way to use both legacy and Vim9 syntax in one script file: >vim9
 
-	" legacy Vim script comments may go here
+	" _legacy Vim script_ comments here
 	if !has('vim9script')
-	   " legacy Vim script commands go here
+	   " _legacy Vim script_ comments/commands here
 	   finish
 	endif
 	vim9script
-	# Vim9 script commands go here
-
+	# _Vim9 script_ commands/commands from here onwards
+	echowindow $"has('vim9script') == {has('vim9script')}"
+<
 This allows for writing a script that takes advantage of the Vim9 script
-syntax if possible, but will also work on a Vim version without it.
+syntax if possible, and prevents the vim9script command from throwing an
+error if used in a version of Vim without 'vim9script'.
 
 Note that Vim9 syntax changed before Vim 9 so that scripts using the current
 syntax (such as "import from" instead of "import") might throw errors.
-To prevent these, a safer check could be for |v:version| >= 900 instead.
+To prevent these, a safer check may be |v:version| >= 900 instead (because
+"has('vim9script')" will return `v:true` back to Vim 8.2 with patch 3965).
+Sometimes it is prudent to cut off even later.  Vim9 script's feature set
+continues to grow so, for example, if tuples are used (introduced in Vim 9.1
+patch 1232), a better condition is: >vim9
 
-This can only work in two ways:
-1. The "if" statement evaluates to false, the commands up to `endif` are
-   skipped and `vim9script` is then the first command actually executed.
-2. The "if" statement evaluates to true, the commands up to `endif` are
-   executed and `finish` bails out before reaching `vim9script`.
+	if !has('patch-9.1.1232')
+	  echowindow $"Fail: Vim does not have patch 9.1.1232"
+	  finish
+	endif
+	vim9script
+	echowindow $"Pass: version {v:versionlong}.  Continuing ..."
+<
+Whichever vim-mix condition is used, it only works in one of two ways:
+    1. The "if" statement evaluates to false, the commands up to `endif` are
+       skipped and `vim9script` is then the first command actually executed.
+    2. The "if" statement evaluates to true, the commands up to `endif` are
+       executed and `finish` bails out before reaching `vim9script`.
 
 
 Export ~
@@ -2129,13 +2286,13 @@ interfaces and enums can be exported.
 Import ~
 				*:import* *:imp* *E1094* *E1047* *E1262*
 				*E1048* *E1049* *E1053* *E1071* *E1088* *E1236*
-The exported items can be imported in another script. The import syntax has
-two forms. The simple form: >
+The exported items can be imported in another script.  The import syntax has
+two forms.  The simple form: >
 	import {filename}
 <
 Where {filename} is an expression that must evaluate to a string.  In this
 form the filename should end in ".vim" and the portion before ".vim" will
-become the script local name of the namespace. For example: >
+become the script local name of the namespace.  For example: >
 	import "myscript.vim"
 <
 This makes each exported item in "myscript.vim" available as "myscript.item".
@@ -2211,7 +2368,7 @@ Note that this does not work for variables, only for functions.
 
 					    *import-legacy* *legacy-import*
 `:import` can also be used in legacy Vim script.  The imported namespace still
-becomes script-local, even when the "s:" prefix is not given. For example: >
+becomes script-local, even when the "s:" prefix is not given.  For example: >
 	import "myfile.vim"
 	call s:myfile.MyFunc()
 
@@ -2226,8 +2383,8 @@ However, the namespace cannot be resolved on its own: >
 <
 This also affects the use of |<SID>| in the legacy mapping context.  Since
 |<SID>| is only a valid prefix for a function and NOT for a namespace, you
-cannot use it to scope a function in a script local namespace. Instead of
-prefixing the function with |<SID>| you should use|<ScriptCmd>|. For example:
+cannot use it to scope a function in a script local namespace.  Instead of
+prefixing the function with |<SID>| you should use |<ScriptCmd>|.  For example:
 >
 	noremap ,a <ScriptCmd>:call s:that.OtherFunc()<CR>
 <
@@ -2245,43 +2402,47 @@ Importing an autoload script ~
 For optimal startup speed, loading scripts should be postponed until they are
 actually needed.  Using the autoload mechanism is recommended:
 							*E1264*
-1. In the plugin define user commands, functions and/or mappings that refer to
-   items imported from an autoload script. >
+     1. In the plugin, define user commands, functions and/or mappings
+        referring to items imported from an autoload script. >
+
 	import autoload 'for/search.vim'
 	command -nargs=1 SearchForStuff search.Stuff(<f-args>)
 
-<   This goes in .../plugin/anyname.vim.  "anyname.vim" can be freely chosen.
-   The "SearchForStuff" command is now available to the user.
+<        This goes in .../plugin/anyname.vim.  "anyname.vim" can be freely
+        chosen.  The "SearchForStuff" command is now available to the user.
 
-   The "autoload" argument to `:import` means that the script is not loaded
-   until one of the items is actually used.  The script will be found under
-   the "autoload" directory in 'runtimepath' instead of the "import"
-   directory.  Alternatively a relative or absolute name can be used, see
-   below.
+        The "autoload" argument to `:import` means that the script is not
+        loaded until one of the items is actually used.  The script will be
+        found under the "autoload" directory in 'runtimepath' instead of the
+        "import" directory.  Alternatively, either a relative or absolute
+        name can be used - see below.
 
-2. In the autoload script put the bulk of the code. >
+     2. In the autoload script put the bulk of the code. >
+
 	vim9script
-	export def Stuff(arg: string)
+	export def Stuff(arg: string): void
 	  ...
 
-<   This goes in .../autoload/for/search.vim.
+<       This goes in .../autoload/for/search.vim.
 
-   Putting the "search.vim" script under the "/autoload/for/" directory has
-   the effect that "for#search#" will be prefixed to every exported item.  The
-   prefix is obtained from the file name, as you would to manually in a
-   legacy autoload script.  Thus the exported function can be found with
-   "for#search#Stuff", but you would normally use `import autoload` and not
-   use the prefix (which has the side effect of loading the autoload script
-   when compiling a function that encounters this name).
+       Putting the "search.vim" script under the "/autoload/for/" directory
+       has the effect that "for#search#" will be prefixed to every exported
+       item.  The prefix is obtained from the file name, just as you would
+       add it manually in a legacy autoload script.  Thus the exported
+       function can be found with "for#search#Stuff", but you would normally
+       use `import autoload` and not use the prefix (which has the side effect
+       of loading the autoload script when compiling a function that
+       encounters this name).
 
-   You can split up the functionality and import other scripts from the
-   autoload script as you like.  This way you can share code between plugins.
+       You can split up the functionality and import other scripts from the
+       autoload script as you like.  This way you can share code between
+       plugins.
 
 Searching for the autoload script in all entries in 'runtimepath' can be a bit
 slow.  If the plugin knows where the script is located, quite often a relative
 path can be used.  This avoids the search and should be quite a bit faster.
-Another advantage is that the script name does not need to be unique.  An
-absolute path is also possible.  Examples: >
+Another advantage is that the script name does not need to be unique.  Also,
+an absolute path is possible.  Examples: >
 	import autoload '../lib/implement.vim'
 	import autoload MyScriptsDir .. '/lib/implement.vim'
 
@@ -2318,14 +2479,14 @@ Or: >
 
 7. Classes and interfaces				*vim9-classes*
 
-In legacy script a Dictionary could be used as a kind-of object, by adding
+In legacy Vim script, a Dictionary could be used as a kind-of object by adding
 members that are functions.  However, this is quite inefficient and requires
 the writer to do the work of making sure all the objects have the right
 members.  See |Dictionary-function|.
 
-In |Vim9| script you can have classes, objects and interfaces like in most
-popular object-oriented programming languages.  Since this is a lot of
-functionality it is located in a separate help file: |vim9class.txt|.
+In |Vim9| script you can have classes, objects, interfaces, and enums like
+in most popular object-oriented programming languages.  Since this is a lot
+of functionality, it is located in a separate help file: |vim9class.txt|.
 
 
 ==============================================================================
@@ -2347,7 +2508,7 @@ which allows for a function with different semantics.  Most things still work
 as before, but some parts do not.  A new way to define a function was
 considered the best way to separate the legacy style code from Vim9 style code.
 
-Using "def" to define a function comes from Python. Other languages use
+Using "def" to define a function comes from Python.  Other languages use
 "function" which clashes with legacy Vim script.
 
 
@@ -2362,11 +2523,19 @@ arguments and decide what kind of addition to do.  And when the type is
 dictionary throw an error.  If the types are known to be numbers then an "add
 number" instruction can be used, which is faster.  The error can be given at
 compile time, no error handling is needed at runtime, since adding two numbers
-cannot fail.
+almost never fails.
 
-The syntax for types, using <type> for compound types, is similar to Java.  It
-is easy to understand and widely used.  The type names are what were used in
-Vim before, with some additions such as "void" and "bool".
+    NOTE: As a tangential point, the exception is integer overflow, where the
+    result exceeds the maximum integer value.  For example, adding to a 64-bit
+    signed integer where the result is greater than 2^63: >vim9
+
+	vim9script
+	echo 9223372036854775807 + 1     # -9223372036854775808
+	echo 2->pow(63)->float2nr() + 1  # -9223372036854775808
+<
+The syntax for types, using <type> for compound types, is similar to Java.
+It is easy to understand and widely used.  The type names are what were used
+in Vim before, with some additions such as "void" and "bool".
 
 
 Removing clutter and weirdness ~
@@ -2477,11 +2646,11 @@ This is how we put types in a declaration: >
 	def Func(arg1: number, arg2: string): bool
 
 Two alternatives were considered:
-1. Put the type before the name, like Dart: >
+    1. Put the type before the name, like Dart: >
 	var list<string> mylist
 	final list<string> mylist = ['foo']
 	def Func(number arg1, string arg2) bool
-2. Put the type after the variable name, but do not use a colon, like Go: >
+<    2. Put the type after the variable name, but do not use a colon, like Go: >
 	var mylist list<string>
 	final mylist list<string> = ['foo']
 	def Func(arg1 number, arg2 string) bool
@@ -2521,17 +2690,21 @@ functions return these values, and changing that causes more problems than it
 solves.  After using this for a while it turned out to work well.
 
 If you have any type of value and want to use it as a boolean, use the `!!`
-operator:
-	true: `!!'text'`   `!![99]`   `!!{'x': 1}`   `!!99`
-	false: `!!''`   `!![]`   `!!{}`
+operator (see |expr-!|): >vim9
 
+	vim9script
+	# The following are all true:
+	echo [!!'text', !![1], !!{'x': 1}, !!1, !!1.1]
+	# And these are all false:
+	echo [!!'', !![], !!{}, !!0, !!0.0]
+<
 From a language like JavaScript we have this handy construct: >
 	GetName() || 'unknown'
 However, this conflicts with only allowing a boolean for a condition.
 Therefore the "??" operator was added: >
 	GetName() ?? 'unknown'
 Here you can explicitly express your intention to use the value as-is and not
-result in a boolean. This is called the |falsy-operator|.
+result in a boolean.  This is called the |falsy-operator|.
 
 
 Import and Export ~
@@ -2556,9 +2729,9 @@ that works like one would expect:
   not needed.
 - The Vim-specific use of "s:" to make things script-local can be dropped.
 
-When sourcing a Vim9 script (from a Vim9 or legacy script), only the items
-defined globally can be used, not the exported items.  Alternatives
-considered:
+When sourcing a Vim9 script (from either a Vim9 script or legacy Vim script),
+only the items defined globally can be used, not the exported items.
+Alternatives considered:
 - All the exported items become available as script-local items.  This makes
   it uncontrollable what items get defined and likely soon leads to trouble.
 - Use the exported items and make them global.  Disadvantage is that it's then
@@ -2609,8 +2782,8 @@ and channels.  We can try to make this easier somehow.
 Using an external tool also has disadvantages.  An alternative is to convert
 the tool into Vim script.  For that to be possible without too much
 translation, and keeping the code fast at the same time, the constructs of the
-tool need to be supported.  Since most languages support classes the lack of
-support for classes in Vim is then a problem.
+tool need to be supported.  Since Vim9 script now includes support for
+classes, objects, interfaces, and enums, that is increasingly feasible.
 
 
 


### PR DESCRIPTION
# vim9.txt fixes and enhancements: Sections 5-8

(**[vim9.txt.5678.pdf](https://github.com/user-attachments/files/22439377/vim9.txt.5678.pdf)**, if it makes reviewing this PR easier.)

_This update, aside from the few lines added after the contents (see General, point 2), only changes Sections 5 through 8.  I have Sections 1 to 4 well advanced too, though, [as requested](https://github.com/vim/vim/pull/18278?notification_referrer_id=NT_kwDOA9uqj7QxODg2NjEwNjA3Mzo2NDcyNzY5NQ#issuecomment-3300019901), those will come later (as two or three PRs) to keep it more manageable._

## General

1. In most instances, except where impracticable, such as when explaining `import`, code-complete examples are provided.  The current help infrequently provides complete, sourceable examples.  The newer Section 5, Generic Functions, has a few, though they are enhanced in this update.
2. Most of the code blocks have `>vim` rather than only `>`.  This enables Vim9 script syntax highlighting.  There are a few areas it’s not perfect because of the syntax file itself (e.g., a `#` comment following an `echo` needs to be preceded by a `|` to ensure it’s syntax highlighted as a comment).  The only thing needed to enable this is to have a standalone `vim9script` anywhere in the first 32 lines (i.e., as required by `syntax/vim.vim`).  It has been made to look intentional with a welcome message.  The benefit of this is not only aesthetic.  The Vim9 script sourceable scripts are in Vim9 script syntax highlighting whereas snippets and incomplete scripts are not.  This means readers can quickly see whether or not they can source a script to see its output.
3. References to `legacy script` are now `legacy Vim script`.  There were more instances of `legacy Vim script` than `legacy script`, so this is change is for consistency.
4. Several instances of full stops missing their second space (to delineate a Vim sentence) are fixed.

NOTE: In the bullets below, the numbers are to line references in the _updated_ help file.

## 5. Generic Functions

- 1916 ― `E1559` has been relocated to line 1953; _see_ 1953, below.
- 1917 ― “The type parameters ...” paragraph is adjusted slightly.  This includes changing inconsistent use of, “type names”, to “type parameters”.
- 1924 ― The tag, `generic-function-example` is added.  This is helpful for `:h generic` CTRL-D searching and similar.  It is referenced specifically later at, “Calling a generic function” too.
- 1925 ― “These type parameters ...” paragraph is also adjusted, particularly heralding what the new working example, `Zip`, does.
- 1928 ― As just noted, a meaningful working example, `Zip`, which is better for hands-on learning, replaces the theoretical `MyFunc` example.
- 1942 ― The tag is changed to, `type-parameter-naming`, for consistency.
- 1943 ― The paragraph is made consistent (i.e., “parameter”, again), and introduces an example of what is, and what is not, valid.  The value in providing the non-working example is that anyone who gets error `E1552` and uses, `:h E1552`, immediately can see what the error is _in the context of the short example_.
- 1953 ― The tag, `E1559`, is relocated here because it, as well as `E1558` and `E1560`, now have [non-]working examples to illustrate how you would get each error.
- 1954 ― The paragraph is expanded to cover not only the point about generic/regular function declaration/usage, but also the _missing arguments_ point.  The three short examples show what causes those errors.
- 1976 ― The uniqueness requirement is distinguished (from not conflicting with other names).  The reason for that is `E1561` is _exclusively about uniqueness_, which is also demonstrated in a [non-]working example (i.e., it shows what happens if you declare a parameter twice with the same name).
- 1984 ― The point about not allowing conflicts with other defined names is moved to a standalone paragraph.  This is important because conflicts do not generate error `E1561`.  An example shows what happens when an enum, `E`, is used as a conflicting name.  It includes the actual error message and number (`E1041`) and, in the explanation, a hotlink.
- 2004 ― A `NOTE` is added to point to the initial working example, which is at line 1928.  This will be helpful for anyone following the link to `:h generic-function-call`.
- 2008 ― The paragraph is shortened by relocating the `vim9-types` sentence.  It now clearly introduces the three [non-]working examples (`E1555`, `E1556`, and `E1557`).
- 2029 ― This is a relocated sentence (noted in the explanation of line 2008), but is otherwise verbatim from the current help.
- 2032 ―  “Spaces are not allowed”, is now explained in a list of distinct points.  That should make them easier to understand, especially because they are extended to include, “Within the "<" and ">"” (which will also cause an error _except_ where a space is required after a comma separator).  These three points also have hotlinks to the error tags for further reading.  An example could be provided, though, since these are not errors specific to generic functions, that may be too much.
- 2042 ― A working example is added.  It shows a generic function defined inside a regular function.  This illustrates line 2041’s point, not demonstrated in the current help.
- 2055 ― More consistent naming is applied to this and line 2057 (“parameters”).
- 2057 ― The order of the complex structures is transposed to herald the re-worked example....
- 2061 ― The example is improved.  First, the current example does not demonstrate either, “lists of dictionaries or dictionaries of lists”, which is what it suggests is coming.  Instead, it provides a working example of _lists of lists_.  So, although somewhat helpful, it is not on point.  Providing a directly meaningful use case is better.  The new example does that.  The `1` and `2` from spoken languages and Arabic digits (so, multiple types), using dictionaries and string/number types, is richer and should not take much to conceptually understand how it could be useful.  For example, using the flattened `list<dict<any>>` to more easily identify what `2` is in various languages, which could be extended, though would make the example quite long.  The output, `[{'1': 'one'}, {'2': 'two'}, {'1': 'tahi'}, {'2': 'rua'}, {'1': '壹'}, {'2': '贰'}, {'1': 1}, {'2': 2}]`, is clearly a **flattened list of dictionaries**.
- 2080 ― A more meaningful example is provided to show how a class method can be a generic function.  [_This could be added to `vim9class.txt`?  Alternatively, a hotlink from `vim9class.txt` to this example could work?_]
- 2092 ― _Observation only:_ A working example following this paragraph could help, though I suspect it would be rather long, so I have left it as-is.
- 2103 ― A richer example is provided.  The current example simply echoes strings, which is not that helpful.  The new example shows a flexible string/list item matcher, which goes to the point, ”creating factories of functions that operation on specific types”.  It may be a little long, but that is better than providing a not-so-meaningful example.  The new script is only 14 lines (or 12 if you ignore the comment).

## 6. Namespace, Import, and Export

- 2195 ― The example is tweaked, mostly for presentation (`" #` ensures the legacy Vim script comments are presented in Vim9 script syntax highlighting), though is substantively the same complete, working example, which can be sourced, so has been made `>vim`.
- 2202 ― The paragraph has been adjusted to be less ambiguous.  Maybe it is obvious, maybe not, but “...will also work on a Vim version without [vim9script].”, is not right.  It will not throw and error, sure, but it will not mean the Vim9 script _works_.
- 2206 ― The `Note` is expanded significantly.  Its current “safer check”, `v:version >= 900`, misses the point that there may be other relevant cut off points.  The additional example provided now is if tuples are used.  If so, the cut off minimum is 9.1.1232.  (Not included, because it would make it quite long, and its relevance diminishes as time goes by, is the converse.  That is, it is possible you wish to enable _before_ `has('vim9script')` — i.e., [8.2.3965](https://github.com/vim/vim/commit/b79ee0c299d786627784f7304ba84b80e78ece26) — if your Vim9 script runs perfectly in earlier 8.2 versions.  For example, if `ModeChanged` is found to be the key limitation, you could have a cut off of [8.2.3434](https://github.com/vim/vim/commit/28e591dd5080bbcd0f468f9d9597cedb716e28c9), the patch when `ModeChanged` works successfully).
- 2348 ― `|<ScriptCmd>|` was missing a space after "use".


## 7. Classes and interfaces

- 2448 ― The final paragraph is expanded to include the missing enum type.

## 8. Rationale

- 2478 ― This first paragraph, in Type checking, read, “adding two numbers cannot fail”.  That is changed to, “adding two numbers almost never fails”, which is more precise.  The following `NOTE`, and example, explain why.
- 2654 ― The `expr-!` hotlink is added (where `!!` is covered).
- 2656 ― The `!!` example is improved by provided a working script.  It also includes missing examples (i.e.,  `!!0`, `!!0.0` and `!!1.1`).
- 2746 ― The final sentence in the current help, “Since most languages support classes the lack of support for classes in Vim is then a problem.”, is incorrect now.  It is reworded to conclude on a positive note.
