### PR TITLE
"adding" expansion doesn't work with cfc=keyword

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -5005,8 +5005,9 @@ get_next_default_completion(ins_compl_next_state_T *st, pos_T *start_pos)
     int		looped_around = FALSE;
     char_u	*ptr = NULL;
     int		len = 0;
-    int		in_fuzzy_collect = (cfc_has_mode() && compl_length > 0)
-	|| ((get_cot_flags() & COT_FUZZY) && compl_autocomplete);
+    int		in_fuzzy_collect = !compl_status_adding()
+		&& ((cfc_has_mode() && compl_length > 0)
+		    || ((get_cot_flags() & COT_FUZZY) && compl_autocomplete));
     char_u	*leader = ins_compl_leader();
     int		score = FUZZY_SCORE_NONE;
     int		in_curbuf = st->ins_buf == curbuf;
@@ -7113,11 +7114,6 @@ ins_compl_start(void)
 	    compl_length = 0;
 	    compl_col = curwin->w_cursor.col;
 	    compl_lnum = curwin->w_cursor.lnum;
-	}
-	else if (ctrl_x_mode_normal() && cfc_has_mode())
-	{
-	    compl_startpos = curwin->w_cursor;
-	    compl_cont_status &= CONT_S_IPOS;
 	}
     }
     else

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -3607,6 +3607,14 @@ func Test_complete_fuzzy_collect()
   call feedkeys("A\<C-X>\<C-N>\<C-N>\<Esc>0", 'tx!')
   call assert_equal('你的 我的 我的', getline('.'))
 
+  " check that "adding" expansion works
+  call setline(1, ['hello world foo bar'])
+  call feedkeys("Ohlo\<C-X>\<C-N>\<C-X>\<C-N>\<C-X>\<C-N>\<C-X>\<C-N>\<Esc>0", 'tx!')
+  call assert_equal('hello world foo bar', getline('.'))
+  call feedkeys("Swld\<C-X>\<C-N>\<C-X>\<C-N>\<C-X>\<C-N>\<Esc>0", 'tx!')
+  call assert_equal('world foo bar', getline('.'))
+  %delete
+
   " fuzzy on file
   call writefile([''], 'fobar', 'D')
   call writefile([''], 'foobar', 'D')


### PR DESCRIPTION
Problem:  "adding" expansion doesn't work with cfc=keyword.
Solution: Remove incorrect assignment to compl_cont_status. Don't use
          fuzzy collection in "adding" status.

related: neovim/neovim#35842
