### PR TITLE
mbyte: fix Unicode character class range for punctuation symbols

### DIFF
--- a/src/mbyte.c
+++ b/src/mbyte.c
@@ -2913,7 +2913,7 @@ utf_class_buf(int c, buf_T *buf)
 	{0x202f, 0x202f, 0},
 	{0x2030, 0x205e, 1},		// punctuation and symbols
 	{0x205f, 0x205f, 0},
-	{0x2060, 0x27ff, 1},		// punctuation and symbols
+	{0x2060, 0x206f, 1},		// punctuation and symbols
 	{0x2070, 0x207f, 0x2070},	// superscript
 	{0x2080, 0x2094, 0x2080},	// subscript
 	{0x20a0, 0x27ff, 1},		// all kinds of symbols


### PR DESCRIPTION
The constant `classes[]` defined at the beginning of `utf_class_buf` in `mbyte.c` is intended to be
a "sorted list of non-overlapping intervals" (l. 2869), but there is an error that will be corrected.

Reference: "General Punctuation" in [Blocks.txt](https://www.unicode.org/Public/UCD/latest/ucd/Blocks.txt) of the Unicode Character Database.