### PR TITLE
ins_compl_leader() defined too far away from ins_compl_leader_len()

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -3439,7 +3439,7 @@ may_call_simple_func(
  * Handle zero level expression with optimization for a simple function call.
  * Same arguments and return value as eval0().
  */
-    int
+    static int
 eval0_simple_funccal(
     char_u	*arg,
     typval_T	*rettv,

--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -1058,6 +1058,15 @@ ins_compl_insert_bytes(char_u *p, int len)
 }
 
 /*
+ * Get current completion leader
+ */
+    char_u *
+ins_compl_leader(void)
+{
+    return compl_leader.string != NULL ? compl_leader.string : compl_orig_text.string;
+}
+
+/*
  * Get current completion leader length
  */
     static size_t
@@ -1835,15 +1844,6 @@ ins_compl_show_pum(void)
 
 #define DICT_FIRST	(1)	// use just first element in "dict"
 #define DICT_EXACT	(2)	// "dict" is the exact name of a file
-
-/*
- * Get current completion leader
- */
-    char_u *
-ins_compl_leader(void)
-{
-    return compl_leader.string != NULL ? compl_leader.string : compl_orig_text.string;
-}
 
 /*
  * Add any identifiers that match the given pattern "pat" in the list of


### PR DESCRIPTION
Problem:  ins_compl_leader() defined too far away from
          ins_compl_leader_len() (after 9.1.1781).
Solution: Move ins_compl_leader() just before ins_compl_leader_len().
          Add missing "static" to eval0_simple_funccal() definition.
