### PR TITLE
feat(folds): add `foldinner` fillchar

### DIFF
--- a/runtime/doc/fold.txt
+++ b/runtime/doc/fold.txt
@@ -595,7 +595,8 @@ A closed fold is indicated with a '+'.
 These characters can be changed with the 'fillchars' option.
 
 Where the fold column is too narrow to display all nested folds, digits are
-shown to indicate the nesting level.
+shown to indicate the nesting level.  To override this behavior you can use
+the "foldinner" character of the 'fillchars' option.
 
 The mouse can also be used to open and close folds by clicking in the
 fold column:

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3853,6 +3853,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 	  foldopen	'-'		mark the beginning of a fold
 	  foldclose	'+'		show a closed fold
 	  foldsep	'|'		open fold middle character
+	  foldinner	none		character to show instead of the
+					numeric foldlevel when it would be
+					repeated in a narrow 'foldcolumn'
 	  diff		'-'		deleted lines of the 'diff' option
 	  eob		'~'		empty lines below the end of a buffer
 	  lastline	'@'		'display' contains lastline/truncate

--- a/runtime/doc/version9.txt
+++ b/runtime/doc/version9.txt
@@ -322,6 +322,8 @@ Improvements in 'fillchars':
   "eob" in 'fillchars'.
 - Support for using multibyte items with the "stl", "stlnc", "foldopen",
   "foldclose" and "foldsep" items in the 'fillchars' option.
+- Support for configuring the character used inside a fold level region using
+  "foldinner" in 'fillchars'.
 
 Support for the XChaCha20 encryption method. 'cryptmethod'
 

--- a/src/screen.c
+++ b/src/screen.c
@@ -287,6 +287,8 @@ fill_foldcolumn(
 	    symbol = wp->w_fill_chars.foldopen;
 	else if (first_level == 1)
 	    symbol = wp->w_fill_chars.foldsep;
+	else if (wp->w_fill_chars.foldinner != NUL)
+	    symbol = wp->w_fill_chars.foldinner;
 	else if (first_level + i <= 9)
 	    symbol = '0' + first_level + i;
 	else
@@ -4738,6 +4740,7 @@ static struct charstab filltab[] =
     CHARSTAB_ENTRY(&fill_chars.foldopen,    "foldopen"),
     CHARSTAB_ENTRY(&fill_chars.foldclosed,  "foldclose"),
     CHARSTAB_ENTRY(&fill_chars.foldsep,	    "foldsep"),
+    CHARSTAB_ENTRY(&fill_chars.foldinner,   "foldinner"),
     CHARSTAB_ENTRY(&fill_chars.diff,	    "diff"),
     CHARSTAB_ENTRY(&fill_chars.eob,	    "eob"),
     CHARSTAB_ENTRY(&fill_chars.lastline,    "lastline"),
@@ -4856,6 +4859,7 @@ set_chars_option(win_T *wp, char_u *value, int is_listchars, int apply,
 		fill_chars.foldopen = '-';
 		fill_chars.foldclosed = '+';
 		fill_chars.foldsep = '|';
+		fill_chars.foldinner = NUL;
 		fill_chars.diff = '-';
 		fill_chars.eob = '~';
 		fill_chars.lastline = '@';

--- a/src/structs.h
+++ b/src/structs.h
@@ -3913,6 +3913,7 @@ typedef struct
     int	foldopen;
     int	foldclosed;
     int	foldsep;
+    int	foldinner;
     int	diff;
     int	eob;
     int	lastline;

--- a/src/testdir/test_display.vim
+++ b/src/testdir/test_display.vim
@@ -340,6 +340,32 @@ func Test_fold_fillchars()
         \ ]
   call assert_equal(expected, lines)
 
+  " check setting foldinner
+  set fdc=1 foldmethod=indent foldlevel=10
+  call setline(1, ['one', '	two', '	two', '		three', '		three', 'four'])
+  let lines = ScreenLines([1, 6], 22)
+  let expected = [
+        \ ' one                  ',
+        \ '[        two          ',
+        \ '-        two          ',
+        \ '[                three',
+        \ '2                three',
+        \ ' four                 ',
+        \ ]
+  call assert_equal(expected, lines)
+
+  set fillchars+=foldinner:\ 
+  let lines = ScreenLines([1, 6], 22)
+  let expected = [
+        \ ' one                  ',
+        \ '[        two          ',
+        \ '-        two          ',
+        \ '[                three',
+        \ '                 three',
+        \ ' four                 ',
+        \ ]
+  call assert_equal(expected, lines)
+
   %bw!
   set fillchars& fdc& foldmethod& foldenable&
 endfunc


### PR DESCRIPTION
Addresses https://github.com/neovim/neovim/issues/21740.

This PR adds a new `fillchar` character that when present will be used when constructing the fold column instead of displaying the fold level.