### PR TITLE
Fully lock changes list for listener callbacks.

### DIFF
--- a/src/testdir/test_listener.vim
+++ b/src/testdir/test_listener.vim
@@ -21,8 +21,21 @@ func s:AnotherStoreList(l)
 endfunc
 
 func s:EvilStoreList(l)
+  func! Modify_dict_in_list(the_list, key)
+    let a:the_list[0][a:key] = a:the_list[0][a:key] + 1
+  endfunc
+  func! Modify_list_entry(the_list)
+    let a:the_list[0] = 42
+  endfunc
+
   let s:list3 = a:l
-  call assert_fails("call add(a:l, 'myitem')", "E742:")
+  call assert_fails("call add(a:l, 'myitem')", "E741:")
+  call assert_fails("call remove(a:l, 1)", "E741:")
+  call assert_fails("call Modify_dict_in_list(a:l, 'lnum')", "E741:")
+  call assert_fails("call Modify_dict_in_list(a:l, 'end')", "E741:")
+  call assert_fails("call Modify_dict_in_list(a:l, 'col')", "E741:")
+  call assert_fails("call Modify_dict_in_list(a:l, 'added')", "E741:")
+  call assert_fails("call Modify_list_entry(a:l)", "E741:")
 endfunc
 
 func Test_listening()


### PR DESCRIPTION
Currently the list of changes passed to listener_add callbacks is locked against adding and removing entries, but not
replacing existing entries. Also, each dictionary in the list can be modified.

This change, recursively locks the list so that no form of modification is possible - I believe.

I worked out a mechanism to perform the recursive lock, but I am not confident that it is the best one.