### PR TITLE
Using void with type() generates an internal error

### DIFF
--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -12623,9 +12623,11 @@ f_type(typval_T *argvars, typval_T *rettv)
 		}
 		break;
 	    }
+	case VAR_VOID:
+	    emsg(_(e_cannot_use_void_value));
+	    break;
 	case VAR_UNKNOWN:
 	case VAR_ANY:
-	case VAR_VOID:
 	    internal_error_no_abort("f_type(UNKNOWN)");
 	    n = -1;
 	    break;

--- a/src/evalvars.c
+++ b/src/evalvars.c
@@ -3359,7 +3359,7 @@ eval_variable(
 		    }
 		}
 	    }
-	    copy_tv(tv, rettv);
+	    ret = copy_tv(tv, rettv);
 	}
     }
 

--- a/src/proto/typval.pro
+++ b/src/proto/typval.pro
@@ -66,7 +66,7 @@ char_u *tv_get_string_buf_chk(typval_T *varp, char_u *buf);
 char_u *tv_get_string_buf_chk_strict(typval_T *varp, char_u *buf, int strict);
 char_u *tv_stringify(typval_T *varp, char_u *buf);
 int tv_check_lock(typval_T *tv, char_u *name, int use_gettext);
-void copy_tv(typval_T *from, typval_T *to);
+int copy_tv(typval_T *from, typval_T *to);
 int typval_compare2(typval_T *tv1, typval_T *tv2, exprtype_T type, int ic, int *res);
 int typval_compare(typval_T *tv1, typval_T *tv2, exprtype_T type, int ic);
 int typval_compare_list(typval_T *tv1, typval_T *tv2, exprtype_T type, int ic, int *res);

--- a/src/testdir/test_vim9_script.vim
+++ b/src/testdir/test_vim9_script.vim
@@ -5580,6 +5580,17 @@ def Test_multikey_dict_in_block()
   unlet g:TestDict
 enddef
 
+" Test for using the type() function with void
+def Test_type_func_with_void()
+  var lines =<< trim END
+    vim9script
+    def GetVoidValue(): void
+    enddef
+    echo type(GetVoidValue())
+  END
+  v9.CheckSourceFailure(lines, 'E1031: Cannot use void value', 4)
+enddef
+
 " Keep this last, it messes up highlighting.
 def Test_substitute_cmd()
   new

--- a/src/testdir/test_vimscript.vim
+++ b/src/testdir/test_vimscript.vim
@@ -6522,7 +6522,7 @@ func Test_type()
     endif
     call assert_equal(v:t_blob, type(test_null_blob()))
 
-    call assert_fails("call type(test_void())", ['E340:', 'E685:'])
+    call assert_fails("call type(test_void())", ['E1031: Cannot use void value', 'E1031: Cannot use void value'])
     call assert_fails("call type(test_unknown())", ['E340:', 'E685:'])
 
     call assert_equal(0, 0 + v:false)
@@ -6598,6 +6598,10 @@ func Test_type()
     call assert_false(empty(v:true))
     call assert_true(empty(v:null))
     call assert_true(empty(v:none))
+
+    def s:GetVoidValue(): void
+    enddef
+    call assert_fails('let x = type(s:GetVoidValue())', 'E1031: Cannot use void value')
 
     func ChangeYourMind()
 	try

--- a/src/typval.c
+++ b/src/typval.c
@@ -1357,9 +1357,11 @@ tv_check_lock(typval_T *tv, char_u *name, int use_gettext)
  * It is OK for "from" and "to" to point to the same item.  This is used to
  * make a copy later.
  */
-    void
+    int
 copy_tv(typval_T *from, typval_T *to)
 {
+    int		ret = OK;
+
     to->v_type = from->v_type;
     to->v_lock = 0;
     switch (from->v_type)
@@ -1465,12 +1467,16 @@ copy_tv(typval_T *from, typval_T *to)
 	    break;
 	case VAR_VOID:
 	    emsg(_(e_cannot_use_void_value));
+	    ret = FAIL;
 	    break;
 	case VAR_UNKNOWN:
 	case VAR_ANY:
 	    internal_error_no_abort("copy_tv(UNKNOWN)");
+	    ret = FAIL;
 	    break;
     }
+
+    return ret;
 }
 
 /*


### PR DESCRIPTION

Fixes the issue reported in #17310.