### PR TITLE
src(gui_w32): stop marking std guifonts bold

### DIFF
--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -3719,7 +3719,7 @@ logfont2name(LOGFONTW lf)
 	    res_size - res_len,
 	    "%s%s%s%s",
 	    lf.lfItalic ? ":i" : "",
-	    lf.lfWeight ? ":b" : "",
+	    lf.lfWeight == FW_BOLD ? ":b" : "",
 	    lf.lfUnderline ? ":u" : "",
 	    lf.lfStrikeOut ? ":s" : "");
 


### PR DESCRIPTION
Fixes https://github.com/vim/vim/issues/18383

Commit 411ae58 replaced an operator conditional

`if lf.lfWeight == FW_BOLD`

with a truthiness check

`if lf.lfWeight`

This conditional determines whether `:b` is inserted into the value of `guifont`. The truthiness check allowed both FW_STANDARD and FW_BOLD font weights to trigger the insertion of `:b` into the `guifont` string. This commit restores the `== FW_BOLD` condition.