### PR TITLE
Disable setting wrapping via modeline

### DIFF
--- a/runtime/autoload/ada.vim
+++ b/runtime/autoload/ada.vim
@@ -21,10 +21,11 @@
 "			      autoload
 "		05.11.2006 MK Bram suggested to save on spaces
 "		08.07.2007 TV fix mapleader problems.
-"	        09.05.2007 MK Session just won't work no matter how much
+"		09.05.2007 MK Session just won't work no matter how much
 "			      tweaking is done
 "		19.09.2007 NO still some mapleader problems
 "		31.01.2017 MB fix more mapleader problems
+"		26.09.2025 by Vim Project: remove nowrap modeline (#18399)
 "    Help Page: ft-ada-functions
 "------------------------------------------------------------------------------
 
@@ -633,5 +634,5 @@ finish " 1}}}
 "
 "   Vim is Charityware - see ":help license" or uganda.txt for licence details.
 "------------------------------------------------------------------------------
-" vim: textwidth=78 wrap tabstop=8 shiftwidth=3 softtabstop=3 noexpandtab
+" vim: textwidth=78 tabstop=8 shiftwidth=3 softtabstop=3 noexpandtab
 " vim: foldmethod=marker

--- a/runtime/autoload/adacomplete.vim
+++ b/runtime/autoload/adacomplete.vim
@@ -16,6 +16,7 @@
 "			      autoload
 "		05.11.2006 MK Bram suggested against using setlocal omnifunc 
 "		05.11.2006 MK Bram suggested to save on spaces
+"		26.09.2025 by Vim Project: remove nowrap modeline (#18399)
 "    Help Page: ft-ada-omni
 "------------------------------------------------------------------------------
 
@@ -105,5 +106,5 @@ finish " 1}}}
 "
 "   Vim is Charityware - see ":help license" or uganda.txt for licence details.
 "------------------------------------------------------------------------------
-" vim: textwidth=78 wrap tabstop=8 shiftwidth=3 softtabstop=3 noexpandtab
+" vim: textwidth=78 tabstop=8 shiftwidth=3 softtabstop=3 noexpandtab
 " vim: foldmethod=marker

--- a/runtime/autoload/decada.vim
+++ b/runtime/autoload/decada.vim
@@ -10,10 +10,11 @@
 "    $Revision: 887 $
 "     $HeadURL: https://gnuada.svn.sourceforge.net/svnroot/gnuada/trunk/tools/vim/autoload/decada.vim $
 "      History: 21.07.2006 MK New Dec Ada
-"               15.10.2006 MK Bram's suggestion for runtime integration
-"               05.11.2006 MK Bram suggested not to use include protection for
-"                             autoload
+"		15.10.2006 MK Bram's suggestion for runtime integration
+"		05.11.2006 MK Bram suggested not to use include protection for
+"			      autoload
 "		05.11.2006 MK Bram suggested to save on spaces
+"		26.09.2025 by Vim Project: remove nowrap modeline (#18399)
 "    Help Page: compiler-decada
 "------------------------------------------------------------------------------
 
@@ -71,5 +72,5 @@ finish " 1}}}
 "
 "   Vim is Charityware - see ":help license" or uganda.txt for licence details.
 "------------------------------------------------------------------------------
-" vim: textwidth=78 wrap tabstop=8 shiftwidth=3 softtabstop=3 noexpandtab
+" vim: textwidth=78 tabstop=8 shiftwidth=3 softtabstop=3 noexpandtab
 " vim: foldmethod=marker

--- a/runtime/autoload/freebasic.vim
+++ b/runtime/autoload/freebasic.vim
@@ -2,6 +2,7 @@
 " Language:	FreeBASIC
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:	2022 June 24
+" 2025 Sep 09 by Vim project: remove nowrap modeline
 
 " Dialects can be one of fb, qb, fblite, or deprecated
 " Precedence is forcelang > #lang > lang
@@ -37,4 +38,4 @@ function! freebasic#GetDialect() abort
   return dialect
 endfunction
 
-" vim: nowrap sw=2 sts=2 ts=8 noet fdm=marker:
+" vim: sw=2 sts=2 ts=8 noet fdm=marker:

--- a/runtime/autoload/getscript.vim
+++ b/runtime/autoload/getscript.vim
@@ -14,6 +14,7 @@
 "   2024 Nov 12 by Vim Project: fix problems on Windows (#16036)
 "   2025 Feb 28 by Vim Project: add support for bzip3 (#16755)
 "   2025 May 11 by Vim Project: check network connectivity (#17249)
+"   2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 "  }}}
 "
 " GetLatestVimScripts: 642 1 :AutoInstall: getscript.vim
@@ -644,4 +645,4 @@ unlet s:keepcpo
 
 " ---------------------------------------------------------------------
 "  Modelines: {{{1
-" vim: ts=8 sts=2 fdm=marker nowrap
+" vim: ts=8 sts=2 fdm=marker

--- a/runtime/autoload/gnat.vim
+++ b/runtime/autoload/gnat.vim
@@ -13,11 +13,12 @@
 "      History: 24.05.2006 MK Unified Headers
 "		16.07.2006 MK Ada-Mode as vim-ball
 "		05.08.2006 MK Add session support
-"               15.10.2006 MK Bram's suggestion for runtime integration
-"               05.11.2006 MK Bram suggested not to use include protection for
-"                             autoload
+"		15.10.2006 MK Bram's suggestion for runtime integration
+"		05.11.2006 MK Bram suggested not to use include protection for
+"			     autoload
 "		05.11.2006 MK Bram suggested to save on spaces
 "		19.09.2007 NO use project file only when there is a project
+"		26.09.2025 by Vim Project: remove nowrap modeline (#18399)
 "    Help Page: compiler-gnat
 "------------------------------------------------------------------------------
 
@@ -143,5 +144,5 @@ finish " 1}}}
 "
 "   Vim is Charityware - see ":help license" or uganda.txt for licence details.
 "------------------------------------------------------------------------------
-" vim: textwidth=0 wrap tabstop=8 shiftwidth=3 softtabstop=3 noexpandtab
+" vim: textwidth=0 tabstop=8 shiftwidth=3 softtabstop=3 noexpandtab
 " vim: foldmethod=marker

--- a/runtime/autoload/modula2.vim
+++ b/runtime/autoload/modula2.vim
@@ -2,6 +2,7 @@
 " Language:	Modula-2
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:	2024 Jan 04
+" 2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 
 " Dialect can be one of pim, iso, r10
 function modula2#GetDialect() abort
@@ -28,4 +29,4 @@ function modula2#SetDialect(dialect, extension = "") abort
   lockvar! b:modula2
 endfunction
 
-" vim: nowrap sw=2 sts=2 ts=8 noet fdm=marker:
+" vim: sw=2 sts=2 ts=8 noet fdm=marker:

--- a/runtime/compiler/decada.vim
+++ b/runtime/compiler/decada.vim
@@ -12,6 +12,7 @@
 "      History: 21.07.2006 MK New Dec Ada
 "               15.10.2006 MK Bram's suggestion for runtime integration
 "               08.09.2006 MK Correct double load protection.
+"               26.09.2025 by Vim Project: remove nowrap modeline (#18399)
 "    Help Page: compiler-decada
 "------------------------------------------------------------------------------
 " Last Change:	2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
@@ -48,5 +49,5 @@ finish " 1}}}
 "
 "   Vim is Charityware - see ":help license" or uganda.txt for licence details.
 "------------------------------------------------------------------------------
-" vim: textwidth=78 wrap tabstop=8 shiftwidth=3 softtabstop=3 noexpandtab
+" vim: textwidth=78 tabstop=8 shiftwidth=3 softtabstop=3 noexpandtab
 " vim: foldmethod=marker

--- a/runtime/compiler/eruby.vim
+++ b/runtime/compiler/eruby.vim
@@ -4,6 +4,7 @@
 " URL:			https://github.com/vim-ruby/vim-ruby
 " Release Coordinator:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:		2024 Apr 03
+" 2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 
 if exists("current_compiler")
   finish
@@ -33,4 +34,4 @@ CompilerSet errorformat=
 let &cpo = s:cpo_save
 unlet s:cpo_save
 
-" vim: nowrap sw=2 sts=2 ts=8:
+" vim: sw=2 sts=2 ts=8:

--- a/runtime/compiler/gnat.vim
+++ b/runtime/compiler/gnat.vim
@@ -12,8 +12,9 @@
 "     $HeadURL: https://gnuada.svn.sourceforge.net/svnroot/gnuada/trunk/tools/vim/compiler/gnat.vim $
 "      History: 24.05.2006 MK Unified Headers
 "		16.07.2006 MK Ada-Mode as vim-ball
-"               15.10.2006 MK Bram's suggestion for runtime integration
+"		15.10.2006 MK Bram's suggestion for runtime integration
 "		19.09.2007 NO use project file only when there is a project
+"		26.09.2025 by Vim Project: remove nowrap modeline (#18399)
 "    Help Page: compiler-gnat
 "------------------------------------------------------------------------------
 
@@ -65,5 +66,5 @@ finish " 1}}}
 "
 "   Vim is Charityware - see ":help license" or uganda.txt for licence details.
 "------------------------------------------------------------------------------
-" vim: textwidth=0 wrap tabstop=8 shiftwidth=3 softtabstop=3 noexpandtab
+" vim: textwidth=0 tabstop=8 shiftwidth=3 softtabstop=3 noexpandtab
 " vim: foldmethod=marker

--- a/runtime/compiler/rake.vim
+++ b/runtime/compiler/rake.vim
@@ -4,7 +4,8 @@
 " URL:			https://github.com/vim-ruby/vim-ruby
 " Release Coordinator:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:		2018 Mar 02
-"			2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
+"			2024 Apr 03 by Vim Project: removed :CompilerSet definition
+"			2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 
 if exists("current_compiler")
   finish
@@ -34,4 +35,4 @@ CompilerSet errorformat=
 let &cpo = s:cpo_save
 unlet s:cpo_save
 
-" vim: nowrap sw=2 sts=2 ts=8:
+" vim: sw=2 sts=2 ts=8:

--- a/runtime/compiler/rspec.vim
+++ b/runtime/compiler/rspec.vim
@@ -4,7 +4,8 @@
 " URL:			https://github.com/vim-ruby/vim-ruby
 " Release Coordinator:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:		2018 Aug 07
-"			2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
+"			2024 Apr 03 by Vim Project (removed :CompilerSet definition)
+"			2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 
 if exists("current_compiler")
   finish
@@ -30,4 +31,4 @@ CompilerSet errorformat=
 let &cpo = s:cpo_save
 unlet s:cpo_save
 
-" vim: nowrap sw=2 sts=2 ts=8:
+" vim: sw=2 sts=2 ts=8:

--- a/runtime/compiler/ruby.vim
+++ b/runtime/compiler/ruby.vim
@@ -5,7 +5,8 @@
 " URL:			https://github.com/vim-ruby/vim-ruby
 " Release Coordinator:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:		2019 Jan 06
-"			2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
+"			2024 Apr 03 by Vim Project: removed :CompilerSet definition
+"			2025 Sep 26 by Vim project: remove nowrap modeline (#18399)
 
 if exists("current_compiler")
   finish
@@ -39,4 +40,4 @@ CompilerSet errorformat=
 let &cpo = s:cpo_save
 unlet s:cpo_save
 
-" vim: nowrap sw=2 sts=2 ts=8:
+" vim: sw=2 sts=2 ts=8:

--- a/runtime/compiler/rubyunit.vim
+++ b/runtime/compiler/rubyunit.vim
@@ -4,7 +4,8 @@
 " URL:			https://github.com/vim-ruby/vim-ruby
 " Release Coordinator:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:		2014 Mar 23
-"			2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
+"			2024 Apr 03 by Vim Project (removed :CompilerSet definition)
+"			2025 Sep 26 by Vim project: remove nowrap modeline (#18399)
 
 if exists("current_compiler")
   finish
@@ -30,4 +31,4 @@ CompilerSet errorformat=\%W\ %\\+%\\d%\\+)\ Failure:,
 let &cpo = s:cpo_save
 unlet s:cpo_save
 
-" vim: nowrap sw=2 sts=2 ts=8:
+" vim: sw=2 sts=2 ts=8:

--- a/runtime/doc/ft_ada.txt
+++ b/runtime/doc/ft_ada.txt
@@ -508,5 +508,5 @@ The GNU Ada Project distribution (http://gnuada.sourceforge.net) of Vim
 contains all of the above.
 
 ==============================================================================
-vim: textwidth=78 nowrap tabstop=8 shiftwidth=4 softtabstop=4 noexpandtab
+vim: textwidth=78 tabstop=8 shiftwidth=4 softtabstop=4 noexpandtab
 vim: filetype=help

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -10257,8 +10257,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 		:set sidescroll=5
 		:set listchars+=precedes:<,extends:>
 <	See 'sidescroll', 'listchars' and |wrap-off|.
-	This option can't be set from a |modeline| when the 'diff' option is
-	on.
+	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
 
 						*'wrapmargin'* *'wm'*
 'wrapmargin' 'wm'	number	(default 0)

--- a/runtime/ftplugin/ada.vim
+++ b/runtime/ftplugin/ada.vim
@@ -24,6 +24,7 @@
 "			      set undo_ftplugin
 "			      mark as unmaintained
 "			      use buffer-local abbreviation
+"		26.09.2025    remove nowrap modeline (#18399)
 "    Help Page: ft-ada-plugin
 "------------------------------------------------------------------------------
 " Provides mapping overrides for tag jumping that figure out the current
@@ -217,5 +218,5 @@ finish " 1}}}
 "
 "   Vim is Charityware - see ":help license" or uganda.txt for licence details.
 "------------------------------------------------------------------------------
-" vim: textwidth=78 nowrap tabstop=8 shiftwidth=3 softtabstop=3 noexpandtab
+" vim: textwidth=78 tabstop=8 shiftwidth=3 softtabstop=3 noexpandtab
 " vim: foldmethod=marker

--- a/runtime/ftplugin/apache.vim
+++ b/runtime/ftplugin/apache.vim
@@ -2,6 +2,7 @@
 " Language:	apache configuration file
 " Maintainer:	Per Juchtmans <dubgeiser+vimNOSPAM@gmail.com>
 " Last Change:	2022 Oct 22
+" 2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 
 if exists("b:did_ftplugin")
   finish
@@ -13,4 +14,4 @@ setlocal commentstring=#\ %s
 
 let b:undo_ftplugin = "setlocal comments< commentstring<"
 
-" vim: nowrap sw=2 sts=2 ts=8 noet:
+" vim: sw=2 sts=2 ts=8 noet:

--- a/runtime/ftplugin/autohotkey.vim
+++ b/runtime/ftplugin/autohotkey.vim
@@ -2,6 +2,7 @@
 " Language:     AutoHotkey
 " Maintainer:   Peter Aronoff <peteraronoff@fastmail.com>
 " Last Changed: 2024 Jul 25
+" 2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 
 if exists("b:did_ftplugin")
   finish
@@ -13,4 +14,4 @@ setlocal commentstring=;\ %s
 
 let b:undo_ftplugin = "setlocal comments< commentstring<"
 
-" vim: nowrap sw=2 sts=2 ts=8 noet:
+" vim: sw=2 sts=2 ts=8 noet:

--- a/runtime/ftplugin/awk.vim
+++ b/runtime/ftplugin/awk.vim
@@ -3,6 +3,7 @@
 " Maintainer:		Doug Kearns <dougkearns@gmail.com>
 " Previous Maintainer:	Antonio Colombo <azc100@gmail.com>
 " Last Change:		2024 Jan 14
+" 2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 
 " This plugin was prepared by Mark Sikora
 " This plugin was updated as proposed by Doug Kearns
@@ -60,4 +61,4 @@ endif
 let &cpo = s:cpo_save
 unlet s:cpo_save
 
-" vim: nowrap sw=2 sts=2 ts=8
+" vim: sw=2 sts=2 ts=8

--- a/runtime/ftplugin/basic.vim
+++ b/runtime/ftplugin/basic.vim
@@ -2,6 +2,7 @@
 " Language:	BASIC (QuickBASIC 4.5)
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:	2024 Jan 14
+" 2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 
 if exists("b:did_ftplugin")
   finish
@@ -58,4 +59,4 @@ endif
 let &cpo = s:cpo_save
 unlet s:cpo_save
 
-" vim: nowrap sw=2 sts=2 ts=8 noet fdm=marker:
+" vim: sw=2 sts=2 ts=8 noet fdm=marker:

--- a/runtime/ftplugin/eiffel.vim
+++ b/runtime/ftplugin/eiffel.vim
@@ -2,6 +2,7 @@
 " Language:	Eiffel
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:	2024 Jan 14
+" 2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 
 if (exists("b:did_ftplugin"))
   finish
@@ -97,4 +98,4 @@ endif
 let &cpo = s:cpo_save
 unlet s:cpo_save
 
-" vim: nowrap sw=2 sts=2 ts=8
+" vim: sw=2 sts=2 ts=8

--- a/runtime/ftplugin/eruby.vim
+++ b/runtime/ftplugin/eruby.vim
@@ -6,6 +6,7 @@
 " Last Change:		2022 May 15
 "			2024 Jan 14 by Vim Project (browsefilter)
 "			2024 May 23 by Riley Bruins <ribru17@gmail.com> ('commentstring')
+" 			2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin")
@@ -139,4 +140,4 @@ function! ErubyAtCursor() abort
   return !empty(filter(synstack(line('.'), col('.')), 'index(groups, v:val) >= 0'))
 endfunction
 
-" vim: nowrap sw=2 sts=2 ts=8:
+" vim: sw=2 sts=2 ts=8:

--- a/runtime/ftplugin/expect.vim
+++ b/runtime/ftplugin/expect.vim
@@ -2,6 +2,7 @@
 " Language:	Expect
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:	2024 Jan 14
+" 2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 
 if exists("b:did_ftplugin")
   finish
@@ -25,4 +26,4 @@ endif
 let &cpo = s:cpo_save
 unlet s:cpo_save
 
-" vim: nowrap sw=2 sts=2 ts=8
+" vim: sw=2 sts=2 ts=8

--- a/runtime/ftplugin/fpcmake.vim
+++ b/runtime/ftplugin/fpcmake.vim
@@ -2,6 +2,7 @@
 " Language:	Free Pascal Makefile Generator
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:	2024 Jan 14
+" 2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 
 if exists("b:did_ftplugin")
   finish
@@ -26,4 +27,4 @@ endif
 let &cpo = s:cpo_save
 unlet s:cpo_save
 
-" vim: nowrap sw=2 sts=2 ts=8 noet:
+" vim: sw=2 sts=2 ts=8 noet:

--- a/runtime/ftplugin/freebasic.vim
+++ b/runtime/ftplugin/freebasic.vim
@@ -2,6 +2,7 @@
 " Language:	FreeBASIC
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:	2023 Aug 22
+" 2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 
 " Setup {{{1
 if exists("b:did_ftplugin")
@@ -82,4 +83,4 @@ endif
 let &cpo = s:cpo_save
 unlet s:cpo_save s:dialect
 
-" vim: nowrap sw=2 sts=2 ts=8 noet fdm=marker:
+" vim: sw=2 sts=2 ts=8 noet fdm=marker:

--- a/runtime/ftplugin/icon.vim
+++ b/runtime/ftplugin/icon.vim
@@ -2,6 +2,7 @@
 " Language:	Icon
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:	2024 Jan 14
+" 2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 
 if exists("b:did_ftplugin")
   finish
@@ -37,4 +38,4 @@ endif
 let &cpo = s:cpo_save
 unlet s:cpo_save
 
-" vim: nowrap sw=2 sts=2 ts=8
+" vim: sw=2 sts=2 ts=8

--- a/runtime/ftplugin/lua.vim
+++ b/runtime/ftplugin/lua.vim
@@ -10,6 +10,7 @@
 "			@konfekt
 " Last Change:		2025 Apr 04
 " 2025 May 06 by Vim Project update 'path' setting #17267
+" 2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 
 if exists("b:did_ftplugin")
   finish
@@ -187,4 +188,4 @@ enddef
 let &cpo = s:cpo_save
 unlet s:cpo_save
 
-" vim: nowrap sw=2 sts=2 ts=8 noet:
+" vim: sw=2 sts=2 ts=8 noet:

--- a/runtime/ftplugin/luau.vim
+++ b/runtime/ftplugin/luau.vim
@@ -2,6 +2,7 @@
 " Language:	Luau
 " Maintainer:	None yet
 " Last Change:	2023 Apr 30
+" 2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 
 if exists("b:did_ftplugin")
   finish
@@ -11,4 +12,4 @@ endif
 runtime! ftplugin/lua.vim
 
 
-" vim: nowrap sw=2 sts=2 ts=8
+" vim: sw=2 sts=2 ts=8

--- a/runtime/ftplugin/lynx.vim
+++ b/runtime/ftplugin/lynx.vim
@@ -2,6 +2,7 @@
 " Language:	Lynx Web Browser Configuration
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:	2024 Jan 14
+" 2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 
 if exists("b:did_ftplugin")
   finish
@@ -30,4 +31,4 @@ endif
 let &cpo = s:cpo_save
 unlet s:cpo_save
 
-" vim: nowrap sw=2 sts=2 ts=8 noet:
+" vim: sw=2 sts=2 ts=8 noet:

--- a/runtime/ftplugin/m3build.vim
+++ b/runtime/ftplugin/m3build.vim
@@ -2,6 +2,7 @@
 " Language:	Modula-3 Makefile
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:	2024 Jan 14
+" 2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 
 if exists("b:did_ftplugin")
   finish
@@ -24,4 +25,4 @@ endif
 let &cpo = s:cpo_save
 unlet s:cpo_save
 
-" vim: nowrap sw=2 sts=2 ts=8 noet:
+" vim: sw=2 sts=2 ts=8 noet:

--- a/runtime/ftplugin/m3quake.vim
+++ b/runtime/ftplugin/m3quake.vim
@@ -2,6 +2,7 @@
 " Language:	Modula-3 Quake
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:	2024 Jan 14
+" 2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 
 if exists("b:did_ftplugin")
   finish
@@ -36,4 +37,4 @@ endif
 let &cpo = s:cpo_save
 unlet s:cpo_save
 
-" vim: nowrap sw=2 sts=2 ts=8 noet:
+" vim: sw=2 sts=2 ts=8 noet:

--- a/runtime/ftplugin/modula2.vim
+++ b/runtime/ftplugin/modula2.vim
@@ -3,6 +3,7 @@
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:	2024 Jan 14
 " 		2024 May 23 by Riley Bruins <ribru17@gmail.com> ('commentstring')
+"		2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 
 if exists("b:did_ftplugin")
   finish
@@ -52,4 +53,4 @@ endif
 let &cpo = s:cpo_save
 unlet s:cpo_save
 
-" vim: nowrap sw=2 sts=2 ts=8 noet:
+" vim: sw=2 sts=2 ts=8 noet:

--- a/runtime/ftplugin/modula3.vim
+++ b/runtime/ftplugin/modula3.vim
@@ -3,6 +3,7 @@
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:	2024 Jan 14
 " 		2024 May 24 by Riley Bruins <ribru17@gmail.com> ('commentstring')
+"		2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 
 if exists("b:did_ftplugin")
   finish
@@ -44,4 +45,4 @@ endif
 let &cpo = s:cpo_save
 unlet s:cpo_save
 
-" vim: nowrap sw=2 sts=2 ts=8 noet:
+" vim: sw=2 sts=2 ts=8 noet:

--- a/runtime/ftplugin/octave.vim
+++ b/runtime/ftplugin/octave.vim
@@ -2,6 +2,7 @@
 " Language:	GNU Octave
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:	2024 Jan 14
+" 2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 
 if exists("b:did_ftplugin")
   finish
@@ -64,4 +65,4 @@ let b:undo_ftplugin = "setl com< cms< fo< kp< " ..
 let &cpo = s:cpo_save
 unlet s:cpo_save
 
-" vim: nowrap sw=2 sts=2 ts=8 noet:
+" vim: sw=2 sts=2 ts=8 noet:

--- a/runtime/ftplugin/pascal.vim
+++ b/runtime/ftplugin/pascal.vim
@@ -4,6 +4,7 @@
 " Previous Maintainer:	Dan Sharp
 " Last Change:		2024 Jan 14
 " 			2024 May 23 by Riley Bruins <ribru17@gmail.com> ('commentstring')
+" 			2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 
 if exists("b:did_ftplugin") | finish | endif
 let b:did_ftplugin = 1
@@ -52,4 +53,4 @@ let b:undo_ftplugin = "setl fo< cms< com< " ..
 let &cpo = s:cpo_save
 unlet s:cpo_save
 
-" vim: nowrap sw=2 sts=2 ts=8 noet:
+" vim: sw=2 sts=2 ts=8 noet:

--- a/runtime/ftplugin/pbtxt.vim
+++ b/runtime/ftplugin/pbtxt.vim
@@ -4,6 +4,7 @@
 " Last Change:          2020 Nov 17
 "                       2023 Aug 28 by Vim Project (undo_ftplugin)
 " Homepage:             https://github.com/lakshayg/vim-pbtxt
+" 2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 
 if exists("b:did_ftplugin")
   finish
@@ -14,4 +15,4 @@ setlocal commentstring=#\ %s
 
 let b:undo_ftplugin = "setlocal commentstring<"
 
-" vim: nowrap sw=2 sts=2 ts=8 noet
+" vim: sw=2 sts=2 ts=8 noet

--- a/runtime/ftplugin/php.vim
+++ b/runtime/ftplugin/php.vim
@@ -3,7 +3,8 @@
 " Maintainer:		Doug Kearns <dougkearns@gmail.com>
 " Previous Maintainer:	Dan Sharp
 " Last Change:		2024 Jan 14
-" Last Change:		2024 May 23 by Riley Bruins <ribru17@gmail.com> ('commentstring')
+" 2024 May 23 by Riley Bruins <ribru17@gmail.com> ('commentstring')
+" 2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 
 if exists("b:did_ftplugin")
   finish
@@ -155,4 +156,4 @@ let b:undo_ftplugin ..= " | " .. s:undo_ftplugin
 let &cpo = s:keepcpo
 unlet s:keepcpo
 
-" vim: nowrap sw=2 sts=2 ts=8 noet:
+" vim: sw=2 sts=2 ts=8 noet:

--- a/runtime/ftplugin/poke.vim
+++ b/runtime/ftplugin/poke.vim
@@ -2,6 +2,7 @@
 " Language:	GNU Poke
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:	2024 Jan 14
+" 2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 
 if exists("b:did_ftplugin")
     finish
@@ -33,4 +34,4 @@ endif
 let &cpo = s:cpo_save
 unlet s:cpo_save
 
-" vim: nowrap sw=2 sts=2 ts=8
+" vim: sw=2 sts=2 ts=8

--- a/runtime/ftplugin/qb64.vim
+++ b/runtime/ftplugin/qb64.vim
@@ -1,6 +1,7 @@
 " Vim filetype plugin file
 " Language:	QB64
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
+" 2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 
 if exists("b:did_ftplugin")
   finish
@@ -23,4 +24,4 @@ unlet s:not_end
 let &cpo = s:cpo_save
 unlet s:cpo_save
 
-" vim: nowrap sw=2 sts=2 ts=8 noet fdm=marker:
+" vim: sw=2 sts=2 ts=8 noet fdm=marker:

--- a/runtime/ftplugin/readline.vim
+++ b/runtime/ftplugin/readline.vim
@@ -4,6 +4,7 @@
 " Previous Maintainer:	Nikolai Weibull <now@bitwi.se>
 " Last Change:		2024 Sep 19 (simplify keywordprg #15696)
 " 2024 Jul 22 by Vim project (use :hor term #17822)
+" 2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 
 if exists("b:did_ftplugin")
   finish
@@ -46,4 +47,4 @@ endif
 let &cpo = s:cpo_save
 unlet s:cpo_save
 
-" vim: nowrap sw=2 sts=2 ts=8 noet:
+" vim: sw=2 sts=2 ts=8 noet:

--- a/runtime/ftplugin/routeros.vim
+++ b/runtime/ftplugin/routeros.vim
@@ -3,6 +3,7 @@
 " Maintainer:	zainin <z@wintr.dev>
 " Last Change:	2021 Nov 14
 "		2024 Jan 14 by Vim Project (browsefilter)
+"		2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 
 if exists("b:did_ftplugin")
   finish
@@ -31,4 +32,4 @@ endif
 let &cpo = s:save_cpo
 unlet! s:save_cpo
 
-" vim: nowrap sw=2 sts=2 ts=8 noet:
+" vim: sw=2 sts=2 ts=8 noet:

--- a/runtime/ftplugin/ruby.vim
+++ b/runtime/ftplugin/ruby.vim
@@ -4,6 +4,7 @@
 " URL:			https://github.com/vim-ruby/vim-ruby
 " Last Change:		2023 Dec 31
 "			2024 Jan 14 by Vim Project (browsefilter)
+"			2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 
 if (exists("b:did_ftplugin"))
   finish
@@ -458,4 +459,4 @@ endfunction
 " differs on Windows.  Email gsinclair@soyabean.com.au if you need help.
 "
 
-" vim: nowrap sw=2 sts=2 ts=8:
+" vim: sw=2 sts=2 ts=8:

--- a/runtime/ftplugin/sed.vim
+++ b/runtime/ftplugin/sed.vim
@@ -2,6 +2,7 @@
 " Language:	sed
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:	2024 Jan 14
+" 2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 
 if exists("b:did_ftplugin")
     finish
@@ -30,4 +31,4 @@ endif
 let &cpo = s:cpo_save
 unlet s:cpo_save
 
-" vim: nowrap sw=2 sts=2 ts=8
+" vim: sw=2 sts=2 ts=8

--- a/runtime/ftplugin/sh.vim
+++ b/runtime/ftplugin/sh.vim
@@ -8,6 +8,7 @@
 "			2024 Dec 29 by Vim Project (improve setting shellcheck compiler)
 "			2025 Mar 09 by Vim Project (set b:match_skip)
 "			2025 Jul 22 by phanium (use :hor term #17822)
+"			2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 
 if exists("b:did_ftplugin")
   finish
@@ -77,4 +78,4 @@ endif
 let &cpo = s:save_cpo
 unlet s:save_cpo s:is_sh s:is_bash s:is_kornshell
 
-" vim: nowrap sw=2 sts=2 ts=8 noet:
+" vim: sw=2 sts=2 ts=8 noet:

--- a/runtime/ftplugin/solution.vim
+++ b/runtime/ftplugin/solution.vim
@@ -2,6 +2,7 @@
 " Language:	Microsoft Visual Studio Solution
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:	2024 Jan 14
+" 2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 
 if exists("b:did_ftplugin")
   finish
@@ -38,4 +39,4 @@ endif
 let &cpo = s:cpo_save
 unlet s:cpo_save
 
-" vim: nowrap sw=2 sts=2 ts=8 noet:
+" vim: sw=2 sts=2 ts=8 noet:

--- a/runtime/ftplugin/tidy.vim
+++ b/runtime/ftplugin/tidy.vim
@@ -2,6 +2,7 @@
 " Language:	HTML Tidy Configuration
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:	2024 Jan 14
+" 2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 
 if exists("b:did_ftplugin")
   finish
@@ -33,4 +34,4 @@ endif
 let &cpo = s:cpo_save
 unlet s:cpo_save
 
-" vim: nowrap sw=2 sts=2 ts=8
+" vim: sw=2 sts=2 ts=8

--- a/runtime/ftplugin/wget.vim
+++ b/runtime/ftplugin/wget.vim
@@ -2,6 +2,7 @@
 " Language:	Wget configuration file (/etc/wgetrc ~/.wgetrc)
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:	2024 Jan 14
+" 2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 
 if exists("b:did_ftplugin")
   finish
@@ -30,4 +31,4 @@ endif
 let &cpo = s:cpo_save
 unlet s:cpo_save
 
-" vim: nowrap sw=2 sts=2 ts=8
+" vim: sw=2 sts=2 ts=8

--- a/runtime/ftplugin/wget2.vim
+++ b/runtime/ftplugin/wget2.vim
@@ -2,6 +2,7 @@
 " Language:	Wget2 configuration file (/etc/wget2rc ~/.wget2rc)
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:	2024 Jan 14
+" 2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 
 if exists("b:did_ftplugin")
   finish
@@ -30,4 +31,4 @@ endif
 let &cpo = s:cpo_save
 unlet s:cpo_save
 
-" vim: nowrap sw=2 sts=2 ts=8
+" vim: sw=2 sts=2 ts=8

--- a/runtime/indent/ada.vim
+++ b/runtime/indent/ada.vim
@@ -16,7 +16,8 @@
 "		15.10.2006 MK Bram's suggestion for runtime integration
 "		05.11.2006 MK Bram suggested to save on spaces
 "		19.09.2007 NO g: missing before ada#Comment
-"		2022 April: b:undo_indent added by Doug Kearns
+"		08.04.2022 b:undo_indent added by Doug Kearns
+"		26.09.2025 by Vim Project: remove nowrap modeline (#18399)
 "    Help Page: ft-vim-indent
 "------------------------------------------------------------------------------
 " ToDo:
@@ -307,5 +308,5 @@ finish " 1}}}
 "
 "   Vim is Charityware - see ":help license" or uganda.txt for licence details.
 "------------------------------------------------------------------------------
-" vim: textwidth=78 wrap tabstop=8 shiftwidth=3 softtabstop=3 noexpandtab
+" vim: textwidth=78 tabstop=8 shiftwidth=3 softtabstop=3 noexpandtab
 " vim: foldmethod=marker

--- a/runtime/lang/menu_chinese_taiwan.950.vim
+++ b/runtime/lang/menu_chinese_taiwan.950.vim
@@ -2,6 +2,7 @@
 " Translated By:	Hung-Te Lin	<piaip@csie.ntu.edu.tw>
 " Last Change:		2012 May 01
 " Generated from menu_zh_tw.utf-8.vim, DO NOT EDIT
+" 2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 
 " {{{ Quit when menu translations have already been done.
 if exists("did_menu_trans")
@@ -289,4 +290,4 @@ endif
 let &cpo = s:keepcpo
 unlet s:keepcpo
 
-" vim:foldmethod=marker:nowrap:foldcolumn=2:foldlevel=1
+" vim:foldmethod=marker:foldcolumn=2:foldlevel=1

--- a/runtime/lang/menu_zh_tw.utf-8.vim
+++ b/runtime/lang/menu_zh_tw.utf-8.vim
@@ -1,6 +1,7 @@
 " Menu Translations:	Traditional Chinese
 " Translated By:	Hung-Te Lin	<piaip@csie.ntu.edu.tw>
 " Last Change:		2012 May 01
+" 2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 " Original translations
 
 " {{{ Quit when menu translations have already been done.
@@ -289,4 +290,4 @@ endif
 let &cpo = s:keepcpo
 unlet s:keepcpo
 
-" vim:foldmethod=marker:nowrap:foldcolumn=2:foldlevel=1
+" vim:foldmethod=marker:foldcolumn=2:foldlevel=1

--- a/runtime/plugin/getscriptPlugin.vim
+++ b/runtime/plugin/getscriptPlugin.vim
@@ -3,6 +3,7 @@
 "  Maintainer:	This runtime file is looking for a new maintainer.
 "  Original Author:	Charles E. Campbell
 "  Date:	Nov 29, 2013
+"  2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 "  Installing:	:help glvs-install
 "  Usage:	:help glvs
 "
@@ -39,4 +40,4 @@ let &cpo= s:keepcpo
 unlet s:keepcpo
 
 " ---------------------------------------------------------------------
-" vim: ts=8 sts=2 fdm=marker nowrap
+" vim: ts=8 sts=2 fdm=marker

--- a/runtime/syntax/abnf.vim
+++ b/runtime/syntax/abnf.vim
@@ -3,6 +3,7 @@
 " Maintainer:	A4-Tacks <wdsjxhno1001@163.com>
 " Last Change:	2025 Mar 05
 " Upstream:	https://github.com/A4-Tacks/abnf.vim
+" 2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 
 " Implementing RFC-5234, RFC-7405
 
@@ -30,4 +31,4 @@ hi def link abnfProse		String
 hi def link abnfNumVal		Number
 hi def link abnfRepeat		Repeat
 
-" vim:noet:ts=8:sts=8:nowrap
+" vim:noet:ts=8:sts=8

--- a/runtime/syntax/ada.vim
+++ b/runtime/syntax/ada.vim
@@ -20,6 +20,7 @@
 "		15.10.2006 MK Bram's suggestion for runtime integration
 "		05.11.2006 MK Spell check for comments and strings only
 "		05.11.2006 MK Bram suggested to save on spaces
+"		26.09.2025 Vim Project: remove nowrap modeline (#18399)
 "    Help Page: help ft-ada-syntax
 "------------------------------------------------------------------------------
 " The formal spec of Ada 2005 (ARM) is the "Ada 2005 Reference Manual".
@@ -364,5 +365,5 @@ finish " 1}}}
 "
 "   Vim is Charityware - see ":help license" or uganda.txt for licence details.
 "------------------------------------------------------------------------------
-"vim: textwidth=78 nowrap tabstop=8 shiftwidth=3 softtabstop=3 noexpandtab
+"vim: textwidth=78 tabstop=8 shiftwidth=3 softtabstop=3 noexpandtab
 "vim: foldmethod=marker

--- a/runtime/syntax/asciidoc.vim
+++ b/runtime/syntax/asciidoc.vim
@@ -8,6 +8,7 @@
 " Licence:         GPL (http://www.gnu.org)
 " Remarks:         Vim 6 or greater
 " Last Update:     2020 May 03 (see Issue 240)
+" 2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 " Limitations:
 "
 " - Nested quoted text formatting is highlighted according to the outer
@@ -182,4 +183,4 @@ hi def link asciidocTwoLineTitle Title
 hi def link asciidocURL Macro
 let b:current_syntax = "asciidoc"
 
-" vim: wrap et sw=2 sts=2:
+" vim: et sw=2 sts=2:

--- a/runtime/syntax/asm.vim
+++ b/runtime/syntax/asm.vim
@@ -5,6 +5,7 @@
 "			Kevin Dahlhausen <kdahlhaus@yahoo.com>
 " Contributors:		Ori Avtalion, Lakshay Garg, Nir Lichtman
 " Last Change:		2025 Jan 26
+" 2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 
 " quit when a syntax file was already loaded
 if exists("b:current_syntax")
@@ -164,4 +165,4 @@ let b:current_syntax = "asm"
 let &cpo = s:cpo_save
 unlet s:cpo_save
 
-" vim: nowrap sw=2 sts=2 ts=8 noet
+" vim: sw=2 sts=2 ts=8 noet

--- a/runtime/syntax/asmh8300.vim
+++ b/runtime/syntax/asmh8300.vim
@@ -3,6 +3,7 @@
 " Maintainer:		Doug Kearns <dougkearns@gmail.com>
 " Previous Maintainer:	Kevin Dahlhausen <kdahlhaus@yahoo.com>
 " Last Change:		2020 Oct 31
+" 2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 
 if exists("b:current_syntax")
   finish
@@ -55,4 +56,4 @@ hi def link asmRegister	Identifier
 
 let b:current_syntax = "asmh8300"
 
-" vim: nowrap sw=2 sts=2 ts=8 noet
+" vim: sw=2 sts=2 ts=8 noet

--- a/runtime/syntax/basic.vim
+++ b/runtime/syntax/basic.vim
@@ -4,6 +4,7 @@
 " Previous Maintainer:	Allan Kelly <allan@fruitloaf.co.uk>
 " Contributors:		Thilo Six
 " Last Change:		2022 Jun 22
+" 2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 
 " First version based on Micro$soft QBASIC circa 1989, as documented in
 " 'Learn BASIC Now' by Halvorson&Rygmyr. Microsoft Press 1989.
@@ -377,4 +378,4 @@ let b:current_syntax = "basic"
 let &cpo = s:cpo_save
 unlet s:cpo_save
 
-" vim: nowrap sw=2 sts=2 ts=8 noet fdm=marker:
+" vim: sw=2 sts=2 ts=8 noet fdm=marker:

--- a/runtime/syntax/chaiscript.vim
+++ b/runtime/syntax/chaiscript.vim
@@ -1,6 +1,7 @@
 " Vim syntax file
 " Language:	ChaiScript
 " Maintainer:	Jason Turner <lefticus 'at' gmail com>
+" 2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 
 " Quit when a (custom) syntax file was already loaded
 if exists("b:current_syntax")
@@ -91,4 +92,4 @@ hi def link chaiscriptEval	        Special
 
 let b:current_syntax = "chaiscript"
 
-" vim: nowrap sw=2 sts=2 ts=8 noet
+" vim: sw=2 sts=2 ts=8 noet

--- a/runtime/syntax/cmake.vim
+++ b/runtime/syntax/cmake.vim
@@ -8,6 +8,7 @@
 " Maintainer:   Dimitri Merejkowsky <d.merej@gmail.com>
 " Former Maintainer: Karthik Krishnan <karthik.krishnan@kitware.com>
 " Last Change:  2023 Jul 13
+" 2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 "
 " License:      The CMake license applies to this file. See
 "               https://cmake.org/licensing
@@ -4976,5 +4977,3 @@ let b:current_syntax = "cmake"
 
 let &cpo = s:keepcpo
 unlet s:keepcpo
-
-" vim: set nowrap:

--- a/runtime/syntax/cobol.vim
+++ b/runtime/syntax/cobol.vim
@@ -6,6 +6,7 @@
 "     (formerly Sitaram Chamarty <sitaram@diac.com> and
 "               James Mitchell <james_mitchell@acm.org>)
 " Last Change:    2019 Mar 22
+" 2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 " Ankit Jain      22.03.2019     Changes & fixes:
 "                                1. Include inline comments
 "                                2. Use comment highlight for bad lines
@@ -257,4 +258,4 @@ hi def link cobolStart          Comment
 
 let b:current_syntax = "cobol"
 
-" vim: ts=6 nowrap
+" vim: ts=6

--- a/runtime/syntax/eruby.vim
+++ b/runtime/syntax/eruby.vim
@@ -4,6 +4,7 @@
 " URL:			https://github.com/vim-ruby/vim-ruby
 " Release Coordinator:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:		2022 Mar 18
+" 2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 
 if exists("b:current_syntax")
   finish
@@ -76,4 +77,4 @@ if main_syntax == 'eruby'
   unlet main_syntax
 endif
 
-" vim: nowrap sw=2 sts=2 ts=8:
+" vim: sw=2 sts=2 ts=8:

--- a/runtime/syntax/fpcmake.vim
+++ b/runtime/syntax/fpcmake.vim
@@ -2,6 +2,7 @@
 " Language:	Free Pascal Makefile Definition Files
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:	2021 Apr 23
+" 2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 
 if exists("b:current_syntax")
   finish
@@ -55,4 +56,4 @@ hi def link fpcmakeRule			Identifier
 
 let b:current_syntax = "fpcmake"
 
-" vim: nowrap sw=2 sts=2 ts=8 noet:
+" vim: sw=2 sts=2 ts=8 noet:

--- a/runtime/syntax/haskell.vim
+++ b/runtime/syntax/haskell.vim
@@ -2,6 +2,7 @@
 " Language:		Haskell
 " Maintainer:		Haskell Cafe mailinglist <haskell-cafe@haskell.org>
 " Last Change:		2024 Mar 28 by Enrico Maria De Angelis <enricomaria.dean6elis@gmail.com>
+" 2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 " Original Author:	John Williams <jrw@pobox.com>
 "
 " Thanks to Ryan Crumley for suggestions and John Meacham for
@@ -191,4 +192,4 @@ hi def link cCppOut			  Comment
 
 let b:current_syntax = "haskell"
 
-" Options for vi: ts=8 sw=2 sts=2 nowrap noexpandtab ft=vim
+" Options for vi: ts=8 sw=2 sts=2 noexpandtab ft=vim

--- a/runtime/syntax/html.vim
+++ b/runtime/syntax/html.vim
@@ -6,6 +6,7 @@
 " Last Change:		2023 Nov 28
 " 2024 Jul 30 by Vim Project: increase syn-sync-minlines to 250
 " 2025 May 10 by Vim Project: update comment
+" 2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 
 " See :help html.vim for some comments and a description of the options
 
@@ -411,4 +412,4 @@ endif
 let &cpo = s:cpo_save
 unlet s:cpo_save
 
-" vim: nowrap sw=2 sts=2 ts=8 noet fdm=marker:
+" vim: sw=2 sts=2 ts=8 noet fdm=marker:

--- a/runtime/syntax/icon.vim
+++ b/runtime/syntax/icon.vim
@@ -3,6 +3,7 @@
 " Maintainer:		Doug Kearns <dougkearns@gmail.com>
 " Previous Maintainer:	Wendell Turner <wendell@adsi-m4.com> (invalid last known address)
 " Last Change:		2022 Jun 16
+" 2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 " Contributor:		eschen@alumni.princeton.edu 2002.09.18
 
 " Prelude {{{1
@@ -208,4 +209,4 @@ hi def link iconDocumentation	Comment
 " Postscript  {{{1
 let b:current_syntax = "icon"
 
-" vim: nowrap sw=2 sts=2 ts=8 noet fdm=marker:
+" vim: sw=2 sts=2 ts=8 noet fdm=marker:

--- a/runtime/syntax/idris2.vim
+++ b/runtime/syntax/idris2.vim
@@ -2,6 +2,7 @@
 " Language:		Idris 2
 " Maintainer:		Idris Hackers (https://github.com/edwinb/idris2-vim), Serhii Khoma <srghma@gmail.com>
 " Last Change:		2024 Nov 05
+" 2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 " Original Author:	raichoo (raichoo@googlemail.com)
 " License:		Vim (see :h license)
 " Repository:		https://github.com/ShinKage/idris2-nvim
@@ -83,4 +84,4 @@ highlight def link idris2Backtick Operator
 
 let b:current_syntax = "idris2"
 
-" vim: nowrap sw=2 sts=2 ts=8 noexpandtab ft=vim
+" vim: sw=2 sts=2 ts=8 noexpandtab ft=vim

--- a/runtime/syntax/lisp.vim
+++ b/runtime/syntax/lisp.vim
@@ -4,6 +4,7 @@
 " Former Maintainer:  Charles E. Campbell
 " Last Change: Nov 10, 2021
 "   2024 Feb 19 by Vim Project (announce adoption)
+"   2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 " Version:     31
 " Former URL:	http://www.drchip.org/astronaut/vim/index.html#SYNTAX_LISP
 "
@@ -621,4 +622,4 @@ endif
 let b:current_syntax = "lisp"
 
 " ---------------------------------------------------------------------
-" vim: ts=8 nowrap fdm=marker
+" vim: ts=8 fdm=marker

--- a/runtime/syntax/luau.vim
+++ b/runtime/syntax/luau.vim
@@ -2,6 +2,7 @@
 " Language:	Luau
 " Maintainer:	None yet
 " Last Change:	2023 Apr 30
+" 2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 
 if exists("b:current_syntax")
   finish
@@ -12,4 +13,4 @@ runtime! syntax/lua.vim
 
 let b:current_syntax = "luau"
 
-" vim: nowrap sw=2 sts=2 ts=8 noet:
+" vim: sw=2 sts=2 ts=8 noet:

--- a/runtime/syntax/lynx.vim
+++ b/runtime/syntax/lynx.vim
@@ -2,6 +2,7 @@
 " Language:	Lynx Web Browser Configuration (lynx.cfg)
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:	2023 Nov 09
+" 2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 
 " Lynx 2.8.9
 
@@ -148,4 +149,4 @@ let b:current_syntax = "lynx"
 let &cpo = s:cpo_save
 unlet s:cpo_save
 
-" vim: nowrap sw=2 sts=2 ts=8 noet fdm=marker:
+" vim: sw=2 sts=2 ts=8 noet fdm=marker:

--- a/runtime/syntax/m3build.vim
+++ b/runtime/syntax/m3build.vim
@@ -2,6 +2,7 @@
 " Language:	Modula-3 Makefile
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:	2021 April 15
+" 2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 
 if exists("b:current_syntax")
   finish
@@ -174,4 +175,4 @@ hi def link m3buildProcedure	      Function
 
 let b:current_syntax = "m3build"
 
-" vim: nowrap sw=2 sts=2 ts=8 noet fdm=marker:
+" vim: sw=2 sts=2 ts=8 noet fdm=marker:

--- a/runtime/syntax/m3quake.vim
+++ b/runtime/syntax/m3quake.vim
@@ -2,6 +2,7 @@
 " Language:	Modula-3 Quake
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:	2021 April 15
+" 2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 
 if exists("b:current_syntax")
   finish
@@ -71,4 +72,4 @@ hi def link m3quakeTodo	       Todo
 
 let b:current_syntax = "m3quake"
 
-" vim: nowrap sw=2 sts=2 ts=8 noet fdm=marker:
+" vim: sw=2 sts=2 ts=8 noet fdm=marker:

--- a/runtime/syntax/modula2.vim
+++ b/runtime/syntax/modula2.vim
@@ -4,6 +4,7 @@
 " Previous Maintainer:	pf@artcom0.north.de (Peter Funk)
 " Last Change:		2024 Jan 04
 " 2025 Apr 16 by Vim Project (set 'cpoptions' for line continuation, #17121)
+" 2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 
 if exists("b:current_syntax")
   finish
@@ -20,4 +21,4 @@ let b:current_syntax = "modula2"
 let &cpo = s:cpo_save
 unlet s:cpo_save
 
-" vim: nowrap sw=2 sts=2 ts=8 noet:
+" vim: sw=2 sts=2 ts=8 noet:

--- a/runtime/syntax/modula3.vim
+++ b/runtime/syntax/modula3.vim
@@ -3,6 +3,7 @@
 " Maintainer:		Doug Kearns <dougkearns@gmail.com>
 " Previous Maintainer:	Timo Pedersen <dat97tpe@ludat.lth.se>
 " Last Change:		2022 Oct 31
+" 2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 
 if exists("b:current_syntax")
   finish
@@ -142,4 +143,4 @@ hi def link modula3Type		Type		"}}}
 
 let b:current_syntax = "modula3"
 
-" vim: nowrap sw=2 sts=2 ts=8 noet fdm=marker:
+" vim: sw=2 sts=2 ts=8 noet fdm=marker:

--- a/runtime/syntax/pascal.vim
+++ b/runtime/syntax/pascal.vim
@@ -4,6 +4,7 @@
 " Previous Maintainers:	Xavier Crégut <xavier.cregut@enseeiht.fr>
 "			Mario Eusebio <bio@dq.fct.unl.pt>
 " Last Change:		2021 May 20
+" 2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 
 " Contributors: Tim Chase <tchase@csc.com>,
 "		Stas Grabois <stsi@vtrails.com>,
@@ -381,4 +382,4 @@ hi def link pascalShowTab		Error
 
 let b:current_syntax = "pascal"
 
-" vim: nowrap sw=2 sts=2 ts=8 noet:
+" vim: sw=2 sts=2 ts=8 noet:

--- a/runtime/syntax/pbtxt.vim
+++ b/runtime/syntax/pbtxt.vim
@@ -2,6 +2,7 @@
 " Language:             Protobuf Text Format
 " Maintainer:           Lakshay Garg <lakshayg@outlook.in>
 " Last Change:          2020 Nov 17
+" 2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 " Homepage:             https://github.com/lakshayg/vim-pbtxt
 
 if exists("b:current_syntax")
@@ -41,4 +42,4 @@ let b:current_syntax = "pbtxt"
 let &cpo = s:cpo_save
 unlet s:cpo_save
 
-" vim: nowrap sw=2 sts=2 ts=8 noet
+" vim: sw=2 sts=2 ts=8 noet

--- a/runtime/syntax/qb64.vim
+++ b/runtime/syntax/qb64.vim
@@ -2,6 +2,7 @@
 " Language:	QB64
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:	2022 Jan 21
+" 2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 
 " Prelude {{{1
 if exists("b:current_syntax")
@@ -406,4 +407,4 @@ let b:current_syntax = "qb64"
 let &cpo = s:cpo_save
 unlet s:cpo_save
 
-" vim: nowrap sw=2 sts=2 ts=8 noet fdm=marker:
+" vim: sw=2 sts=2 ts=8 noet fdm=marker:

--- a/runtime/syntax/rib.vim
+++ b/runtime/syntax/rib.vim
@@ -2,7 +2,7 @@
 " Language:	Renderman Interface Bytestream
 " Maintainer:	Andrew Bromage <ajb@spamcop.net>
 " Last Change:	2003 May 11
-"
+" 2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 
 " quit when a syntax file was already loaded
 if exists("b:current_syntax")
@@ -59,4 +59,4 @@ hi def link ribFloat		Float
 
 let b:current_syntax = "rib"
 
-" Options for vi: ts=8 sw=2 sts=2 nowrap noexpandtab ft=vim
+" Options for vi: ts=8 sw=2 sts=2 noexpandtab ft=vim

--- a/runtime/syntax/ruby.vim
+++ b/runtime/syntax/ruby.vim
@@ -4,6 +4,7 @@
 " URL:			https://github.com/vim-ruby/vim-ruby
 " Release Coordinator:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:		2023 Mar 16
+" 2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 " ----------------------------------------------------------------------------
 "
 " Previous Maintainer:	Mirko Nasato
@@ -603,4 +604,4 @@ unlet! s:cpo_sav
 
 delc SynFold
 
-" vim: nowrap sw=2 sts=2 ts=8 noet fdm=marker:
+" vim: sw=2 sts=2 ts=8 noet fdm=marker:

--- a/runtime/syntax/sed.vim
+++ b/runtime/syntax/sed.vim
@@ -4,6 +4,7 @@
 " Previous Maintainer:	Haakon Riiser <hakonrk@fys.uio.no>
 " Contributor:		Jack Haden-Enneking
 " Last Change:		2022 Oct 15
+" 2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 
 " quit when a syntax file was already loaded
 if exists("b:current_syntax")
@@ -120,4 +121,4 @@ unlet s:highlight_tabs
 
 let b:current_syntax = "sed"
 
-" vim: nowrap sw=2 sts=2 ts=8 noet:
+" vim: sw=2 sts=2 ts=8 noet:

--- a/runtime/syntax/tcsh.vim
+++ b/runtime/syntax/tcsh.vim
@@ -3,6 +3,7 @@
 " Maintainer:		Doug Kearns <dougkearns@gmail.com>
 " Previous Maintainer:	Gautam Iyer <gi1242+vim@NoSpam.com> where NoSpam=gmail (Original Author)
 " Last Change:		2021 Oct 15
+" 2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 
 " Description: We break up each statement into a "command" and an "end" part.
 " All groups are either a "command" or part of the "end" of a statement (ie
@@ -252,4 +253,4 @@ unlet s:oldcpo
 
 let b:current_syntax = 'tcsh'
 
-" vim: nowrap sw=2 sts=2 ts=8 noet fdm=marker:
+" vim: sw=2 sts=2 ts=8 noet fdm=marker:

--- a/runtime/syntax/unison.vim
+++ b/runtime/syntax/unison.vim
@@ -3,6 +3,7 @@
 " Language:        unison
 " Maintainer:      Anton Parkhomenko <anton@chuwy.me>
 " Last Change:     Aug 7, 2023
+" 2025 Sep 26 by Vim Project: remove nowrap modeline (#18399)
 " Original Author: John Williams, Paul Chiusano and Rúnar Bjarnason
 
 if exists("b:current_syntax")
@@ -100,4 +101,4 @@ hi def link       unisonTypedef                         Typedef
 
 let b:current_syntax = "unison"
 
-" Options for vi: ts=8 sw=2 sts=2 nowrap noexpandtab ft=vim
+" Options for vi: ts=8 sw=2 sts=2 noexpandtab ft=vim

--- a/src/optiondefs.h
+++ b/src/optiondefs.h
@@ -3027,7 +3027,7 @@ static struct vimoption options[] =
 			    {(char_u *)NULL, (char_u *)0L}
 #endif
 			    SCTX_INIT},
-    {"wrap",	    NULL,   P_BOOL|P_VI_DEF|P_RWIN,
+    {"wrap",	    NULL,   P_BOOL|P_VI_DEF|P_RWIN|P_SECURE,
 			    (char_u *)VAR_WIN, PV_WRAP, did_set_wrap, NULL,
 			    {(char_u *)TRUE, (char_u *)0L} SCTX_INIT},
     {"wrapmargin",  "wm",   P_NUM|P_VI_DEF,

--- a/src/testdir/test_modeline.vim
+++ b/src/testdir/test_modeline.vim
@@ -345,12 +345,11 @@ endfunc
 
 " Some options cannot be set from the modeline when 'diff' option is set
 func Test_modeline_diff_buffer()
-  call writefile(['vim: diff foldmethod=marker wrap'], 'Xmdifile', 'D')
-  set foldmethod& nowrap
+  call writefile(['vim: diff foldmethod=marker'], 'Xmdifile', 'D')
+  set foldmethod&
   new Xmdifile
   call assert_equal('manual', &foldmethod)
-  call assert_false(&wrap)
-  set wrap&
+  call assert_true(&diff)
   bw
 endfunc
 
@@ -359,6 +358,28 @@ func Test_modeline_disable()
   call writefile(['vim: sw=2', 'vim: nomodeline', 'vim: sw=3'], 'Xmodeline_disable', 'D')
   edit Xmodeline_disable
   call assert_equal(2, &sw)
+endfunc
+
+" Some wrap option is not allowed in a modeline
+func Test_modeline_wrap_option_disabled()
+  new
+  call writefile(['vim: wrap'], 'Xwrapfile', 'D')
+  set nowrap
+  try
+    edit Xwrapfile
+  catch /^Vim\%((\a\+)\)\=:E520:/
+  endtry
+  call assert_false(&wrap)
+  bw!
+
+  call writefile(['vim: nowrap'], 'Xwrapfile', 'D')
+  set wrap
+  try
+    edit Xwrapfile
+  catch /^Vim\%((\a\+)\)\=:E520:/
+  endtry
+  call assert_true(&wrap)
+  bw!
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem: wrapping can be disabled in a modeline to hide text
Solution: Add P_SECURE flag

fixes: #18214

I have been thinking about the above discussion and checked how less/more/cat handled this. Although they by default enable wrapping, at least in the less case if you disable wrapping and display a suspicious file, it makes it obvious by displaying a visual indicator that makes it obvious something is hidden (similar to Vims `extends` char for `'listchars'`).

In contrast, Vim does not make this obvious and in combination with a modeline, this can be used to hide some content.

Try this in a 80x20 window:
```bash
~ cat /tmp/evil.sh
#!/bin/sh


                                                                                                                                                                                                                                                                                                      # rm -rf /tmp/*
exit 0

# vim:nowrap
~ vim --clean /tmp/evil.sh
```

I don't like this so I think it would be a good idea to disable setting the `'wrap'` option in a modeline. Note: this is slightly backwards incompatible change, but I'd allow this for this issue.

Let me know what you think.
