### PR TITLE
Modify popup_show() to return -1 for an invalid popup window id

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -451,7 +451,7 @@ popup_setbuf({id}, {buf})	Bool	set the buffer for the popup window {id}
 popup_setoptions({id}, {options})
 				none	set options for popup window {id}
 popup_settext({id}, {text})	none	set the text of popup window {id}
-popup_show({id})		none	unhide popup window {id}
+popup_show({id})		Number	unhide popup window {id}
 pow({x}, {y})			Float	{x} to the power of {y}
 prevnonblank({lnum})		Number	line nr of non-blank line <= {lnum}
 printf({fmt}, {expr1}...)	String	format text

--- a/runtime/doc/popup.txt
+++ b/runtime/doc/popup.txt
@@ -639,10 +639,17 @@ popup_settext({id}, {text})				*popup_settext()*
 
 
 popup_show({id})						*popup_show()*
-		If {id} is a hidden popup, show it now.
-		For {id} see `popup_hide()`.
-		If {id} is the info popup it will be positioned next to the
-		current popup menu item.
+		Show a hidden popup window identified by {id}.
+		Use {id} as returned by |popup_create()|.
+
+		If the popup is currently hidden, it will be made visible.
+		See |popup_hide()| to hide a popup.
+
+		If {id} refers to an info popup, it will be positioned next to
+		the currently selected item in the popup menu.
+
+		Returns -1 if a popup window with {id} does not exist.
+		Returns 0 on success.
 
 		Return type: |Number|
 

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -2652,7 +2652,7 @@ static const funcentry_T global_functions[] =
     {"popup_settext",	2, 2, FEARG_1,	    arg2_number_string_or_list,
 			ret_void,	    PROP_FUNC(f_popup_settext)},
     {"popup_show",	1, 1, FEARG_1,	    arg1_number,
-			ret_void,	    PROP_FUNC(f_popup_show)},
+			ret_number,	    PROP_FUNC(f_popup_show)},
     {"pow",		2, 2, FEARG_1,	    arg2_float_or_nr,
 			ret_float,	    f_pow},
     {"prevnonblank",	1, 1, FEARG_1,	    arg1_lnum,

--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -2832,6 +2832,9 @@ f_popup_show(typval_T *argvars, typval_T *rettv UNUSED)
     int		id;
     win_T	*wp;
 
+    rettv->v_type = VAR_NUMBER;
+    rettv->vval.v_number = -1;
+
     if (in_vim9script() && check_for_number_arg(argvars, 0) == FAIL)
 	return;
 
@@ -2846,6 +2849,8 @@ f_popup_show(typval_T *argvars, typval_T *rettv UNUSED)
     if (wp->w_popup_flags & POPF_INFO)
 	pum_position_info_popup(wp);
 #endif
+
+    rettv->vval.v_number = 0;
 }
 
 /*

--- a/src/testdir/test_popupwin.vim
+++ b/src/testdir/test_popupwin.vim
@@ -1264,7 +1264,7 @@ func Test_popup_hide()
 
   " no error non-existing window
   eval 1234234->popup_hide()
-  call popup_show(41234234)
+  call assert_equal(-1, popup_show(41234234))
 
   bwipe!
 endfunc
@@ -2623,7 +2623,7 @@ func Test_popup_hidden()
   exe "normal anot used by filter\<Esc>"
   call assert_equal('not used by filter', getline(1))
 
-  call popup_show(winid)
+  call assert_equal(0, popup_show(winid))
   call feedkeys('y', "xt")
   call assert_equal(1, s:cb_res)
 

--- a/src/testdir/test_vim9_builtin.vim
+++ b/src/testdir/test_vim9_builtin.vim
@@ -3269,6 +3269,7 @@ enddef
 def Test_popup_show()
   v9.CheckSourceDefAndScriptFailure(['popup_show("a")'], ['E1013: Argument 1: type mismatch, expected number but got string', 'E1210: Number required for argument 1'])
   v9.CheckSourceDefAndScriptFailure(['popup_show(true)'], ['E1013: Argument 1: type mismatch, expected number but got bool', 'E1210: Number required for argument 1'])
+  v9.CheckSourceDefAndScriptSuccess(['assert_equal(-1, popup_show(100))'])
 enddef
 
 def Test_prevnonblank()


### PR DESCRIPTION

Fix the issue reported in #18389.