### PR TITLE
runtime/syntax/make: highlights in define..undef block

### DIFF
--- a/runtime/syntax/make.vim
+++ b/runtime/syntax/make.vim
@@ -34,6 +34,14 @@ if get(b:, 'make_flavor', s:make_flavor) == 'microsoft'
 endif
 
 " identifiers; treat $$X like $X inside makeDefine
+syn match makeIdent	"\$\$\w*"
+syn match makeIdent	"\$\$\$\$\w*" containedin=makeDefine
+syn match makeIdent	"\$[^({]"
+syn match makeIdent	"\$\$[^({]" containedin=makeDefine
+syn match makeIdent	"^ *[^:#= \t]*\s*[:+?!*]="me=e-2
+syn match makeIdent	"^ *[^:#= \t]*\s*::="me=e-3
+syn match makeIdent	"^ *[^:#= \t]*\s*="me=e-1
+syn match makeIdent	"%"
 if get(b:, 'make_flavor', s:make_flavor) == 'microsoft'
   syn region makeIdent	start="\$(" end=")" contains=makeStatement,makeIdent
   syn region makeIdent	start="\${" end="}" contains=makeStatement,makeIdent
@@ -45,14 +53,6 @@ else
   syn region makeIdent	start="\$\$(" skip="\\)\|\\\\" end=")" containedin=makeDefine contains=makeStatement,makeIdent
   syn region makeIdent	start="\$\${" skip="\\}\|\\\\" end="}" containedin=makeDefine contains=makeStatement,makeIdent
 endif
-syn match makeIdent	"\$\$\w*"
-syn match makeIdent	"\$\$\$\$\w*" containedin=makeDefine
-syn match makeIdent	"\$[^({]"
-syn match makeIdent	"\$\$[^({]" containedin=makeDefine
-syn match makeIdent	"^ *[^:#= \t]*\s*[:+?!*]="me=e-2
-syn match makeIdent	"^ *[^:#= \t]*\s*::="me=e-3
-syn match makeIdent	"^ *[^:#= \t]*\s*="me=e-1
-syn match makeIdent	"%"
 
 " Makefile.in variables
 syn match makeConfig "@[A-Za-z0-9_]\+@"


### PR DESCRIPTION
Previously contents in `makeDefine` are nearly highlighted as Define, so comments and targets shares the same color as Define, making it hard to distinguish if someone write large block of targets-recipes as defined function.

Such scenario is common in building data analysis pipeline. Recipes are reused and targets may have multiple variables, and a single % implicit rule is not enough.