### PR TITLE
runtime(help): Update syntax, add vim9 example language

### DIFF
--- a/runtime/doc/helphelp.txt
+++ b/runtime/doc/helphelp.txt
@@ -1,4 +1,4 @@
-*helphelp.txt*	For Vim version 9.1.  Last change: 2025 Sep 15
+*helphelp.txt*	For Vim version 9.1.  Last change: 2025 Sep 27
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -463,12 +463,14 @@ To quote a block of ex-commands verbatim, place a greater than (>) character
 at the end of the line before the block and a less than (<) character as the
 first non-blank on a line following the block.  Any line starting in column 1
 also implicitly stops the block of ex-commands before it.  E.g. >
+
 	function Example_Func()
 	  echo "Example"
 	endfunction
 <
 To enable syntax highlighting for a block of code, place a language name
 annotation (e.g. "vim") after a greater than (>) character.  E.g. >vim
+
 	function Example_Func()
 	  echo "Example"
 	endfunction
@@ -476,7 +478,8 @@ annotation (e.g. "vim") after a greater than (>) character.  E.g. >vim
 						*g:help_example_languages*
 By default, help files only support Vim script highlighting.  If you need
 syntax highlighting for other languages, add to your |vimrc|: >
-	:let g:help_example_languages = { "vim": "vim", "sh": "bash" }
+	:let g:help_example_languages = {
+	      \	"vim": "vim", "vim9": "vim", "bash": "sh" }
 The key represents the annotation marker name, and the value is the 'syntax'
 name.
 

--- a/runtime/doc/usr_05.txt
+++ b/runtime/doc/usr_05.txt
@@ -308,6 +308,7 @@ This switches on three very clever mechanisms:
 
 
 				*restore-cursor* *last-position-jump*  >vim
+
     augroup RestoreCursor
       autocmd!
       autocmd BufReadPost *

--- a/runtime/doc/usr_52.txt
+++ b/runtime/doc/usr_52.txt
@@ -347,7 +347,7 @@ Have a look at the package located at $VIMRUNTIME/pack/dist/opt/comment/
 HIGHLIGHT YANK PLUGIN
 
 Vim comes with the highlight-yank plugin, written in Vim9 script
-|hlyank-install|, here is a simplified implementation: >vim
+|hlyank-install|, here is a simplified implementation: >vim9
 
 	vim9script
 

--- a/runtime/syntax/generator/vim.vim.base
+++ b/runtime/syntax/generator/vim.vim.base
@@ -2,7 +2,7 @@
 " Language:	   Vim script
 " Maintainer:	   Hirohito Higashi <h.east.727 ATMARK gmail.com>
 "	   Doug Kearns <dougkearns@gmail.com>
-" Last Change:	   2025 Sep 26
+" Last Change:	   2025 Sep 27
 " Former Maintainer: Charles E. Campbell
 
 " DO NOT CHANGE DIRECTLY.
@@ -18,7 +18,8 @@ set cpo&vim
 
 " Feature testing {{{1
 
-let s:vim9script = "\n" .. getline(1, 32)->join("\n") =~# '\n\s*vim9\%[script]\>'
+" NOTE: vimsyn_force_vim9 for internal use only
+let s:vim9script = get(b:, "vimsyn_force_vim9", v:false) || "\n" .. getline(1, 32)->join("\n") =~# '\n\s*vim9\%[script]\>'
 
 function s:has(feature)
   return has(a:feature) || index(get(g:, "vimsyn_vim_features", []), a:feature) != -1

--- a/runtime/syntax/help.vim
+++ b/runtime/syntax/help.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:		Vim help file
 " Maintainer:		Doug Kearns <dougkearns@gmail.com>
-" Last Change:		2025 Jul 20
+" Last Change:		2025 Sep 26
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Quit when a (custom) syntax file was already loaded
@@ -15,7 +15,7 @@ set cpo&vim
 syn iskeyword @,48-57,_,192-255
 
 if !exists('g:help_example_languages')
-  let g:help_example_languages = #{ vim: 'vim' }
+  let g:help_example_languages = #{ vim: 'vim', vim9: 'vim' }
 endif
 
 syn match helpHeadline		"^[A-Z.][-A-Z0-9 .,()_']*?\=\ze\(\s\+\*\|$\)"
@@ -32,9 +32,18 @@ endif
 
 for [s:lang, s:syntax] in g:help_example_languages->items()
   unlet! b:current_syntax
+
+  if s:lang == "vim9"
+    let b:vimsyn_force_vim9 = v:true
+  endif
+
   " silent! to prevent E403
   execute 'silent! syn include' $'@helpExampleHighlight_{s:lang}'
         \ $'syntax/{s:syntax}.vim'
+
+  if s:lang == "vim9"
+    unlet b:vimsyn_force_vim9
+  endif
 
   execute $'syn region helpExampleHighlight_{s:lang} matchgroup=helpIgnore'
         \ $'start=/\%(^\| \)>{s:lang}$/'

--- a/runtime/syntax/vim.vim
+++ b/runtime/syntax/vim.vim
@@ -2,7 +2,7 @@
 " Language:	   Vim script
 " Maintainer:	   Hirohito Higashi <h.east.727 ATMARK gmail.com>
 "	   Doug Kearns <dougkearns@gmail.com>
-" Last Change:	   2025 Sep 26
+" Last Change:	   2025 Sep 27
 " Former Maintainer: Charles E. Campbell
 
 " DO NOT CHANGE DIRECTLY.
@@ -18,7 +18,8 @@ set cpo&vim
 
 " Feature testing {{{1
 
-let s:vim9script = "\n" .. getline(1, 32)->join("\n") =~# '\n\s*vim9\%[script]\>'
+" NOTE: vimsyn_force_vim9 for internal use only
+let s:vim9script = get(b:, "vimsyn_force_vim9", v:false) || "\n" .. getline(1, 32)->join("\n") =~# '\n\s*vim9\%[script]\>'
 
 function s:has(feature)
   return has(a:feature) || index(get(g:, "vimsyn_vim_features", []), a:feature) != -1


### PR DESCRIPTION
"vim9" is Vim9 script and "vim" is legacy script.

See: https://github.com/vim/vim/pull/18350#discussion_r2372462539
