### PR TITLE
runtime(doc): improve preinserted() doc

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -1,4 +1,4 @@
-*builtin.txt*	For Vim version 9.1.  Last change: 2025 Sep 26
+*builtin.txt*	For Vim version 9.1.  Last change: 2025 Sep 27
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -8036,9 +8036,9 @@ pow({x}, {y})						*pow()*
 
 preinserted()						*preinserted()*
 		Returns non-zero if text has been inserted after the cursor
-		because "preinsert" is present in 'completeopt', or if
+		because "preinsert" is present in 'completeopt', or because
 		"longest" is present in 'completeopt' while 'autocomplete'
-		is enabled.  Otherwise returns zero.
+		is active.  Otherwise returns zero.
 
 		Return type: |Number|
 


### PR DESCRIPTION
Change the second "if" to "because", otherwise it may be misinterpreted
that preinserted() can return non-zero just because these options are
set.
