### PR TITLE
'nowrap' in a modeline may hide malicious code

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1,4 +1,4 @@
-*options.txt*	For Vim version 9.1.  Last change: 2025 Sep 26
+*options.txt*	For Vim version 9.1.  Last change: 2025 Sep 28
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -10259,6 +10259,11 @@ A jump table for the options with a short description can be found at |Q_op|.
 <	See 'sidescroll', 'listchars' and |wrap-off|.
 	This option can't be set from a |modeline| when the 'diff' option is
 	on.
+	If 'nowrap' was set from a |modeline| or in the |sandbox|, '>' is used
+	as the |lcs-extends| character regardless of the value of the 'list'
+	and 'listchars' options.  This is to prevent malicious code outside
+	the viewport from going unnoticed.  Use `:setlocal nowrap` manually
+	afterwards to disable this behavior.
 
 						*'wrapmargin'* *'wm'*
 'wrapmargin' 'wm'	number	(default 0)

--- a/src/option.c
+++ b/src/option.c
@@ -3081,6 +3081,7 @@ insecure_flag(int opt_idx, int opt_flags)
     if (opt_flags & OPT_LOCAL)
 	switch ((int)options[opt_idx].indir)
 	{
+	    case PV_WRAP:	return &curwin->w_p_wrap_flags;
 #ifdef FEAT_STL_OPT
 	    case PV_STL:	return &curwin->w_p_stl_flags;
 #endif

--- a/src/structs.h
+++ b/src/structs.h
@@ -4214,6 +4214,7 @@ struct window_S
 #define GLOBAL_WO(p)	((char *)(p) + sizeof(winopt_T))
 
     // A few options have local flags for P_INSECURE.
+    long_u	w_p_wrap_flags;	    // flags for 'wrap'
 #ifdef FEAT_STL_OPT
     long_u	w_p_stl_flags;	    // flags for 'statusline'
 #endif

--- a/src/testdir/test_modeline.vim
+++ b/src/testdir/test_modeline.vim
@@ -361,4 +361,53 @@ func Test_modeline_disable()
   call assert_equal(2, &sw)
 endfunc
 
+" If 'nowrap' is set from a modeline, '>' is used forcibly as lcs-extends.
+func Test_modeline_nowrap_lcs_extends()
+  call writefile([
+        \ 'aaa',
+        \ 'bbb',
+        \ 'ccc                    evil',
+        \ 'ddd                    vim: nowrap',
+        \ ], 'Xmodeline_nowrap', 'D')
+  call NewWindow(10, 20)
+
+  setlocal nolist listchars=
+  edit Xmodeline_nowrap
+  let expect_insecure = [
+        \ 'aaa                 ',
+        \ 'bbb                 ',
+        \ 'ccc                >',
+        \ 'ddd                >',
+        \ '~                   ',
+        \ ]
+  call assert_equal(expect_insecure, ScreenLines([1, 5], 20))
+
+  setlocal nowrap
+  let expect_secure = [
+        \ 'aaa                 ',
+        \ 'bbb                 ',
+        \ 'ccc                 ',
+        \ 'ddd                 ',
+        \ '~                   ',
+        \ ]
+  call assert_equal(expect_secure, ScreenLines([1, 5], 20))
+
+  setlocal list listchars=extends:+
+  let expect_secure = [
+        \ 'aaa                 ',
+        \ 'bbb                 ',
+        \ 'ccc                +',
+        \ 'ddd                +',
+        \ '~                   ',
+        \ ]
+  call assert_equal(expect_secure, ScreenLines([1, 5], 20))
+
+  edit Xmodeline_nowrap
+  call assert_equal(expect_insecure, ScreenLines([1, 5], 20))
+  setlocal nowrap
+  call assert_equal(expect_secure, ScreenLines([1, 5], 20))
+
+  call CloseWindow()
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  'nowrap' in a modeline may hide malicious code.
Solution: Forcibly use '>' as 'listchars' "extends" if 'nowrap' was set
          from a modeline.

Manual `:setlocal nowrap` disables this behavior.  There is a separate
problem with `:set nowrap` that also applies to some other options.

related: #18214
related: #18399
