### PR TITLE
runtime(termdebug): Allow remote debugging over tty (ssh, wsl, docker ...)

### DIFF
--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -10941,8 +10941,11 @@ termdebug-example	terminal.txt	/*termdebug-example*
 termdebug-frames	terminal.txt	/*termdebug-frames*
 termdebug-mappings	terminal.txt	/*termdebug-mappings*
 termdebug-prompt	terminal.txt	/*termdebug-prompt*
+termdebug-remote	terminal.txt	/*termdebug-remote*
+termdebug-remote-window	terminal.txt	/*termdebug-remote-window*
 termdebug-starting	terminal.txt	/*termdebug-starting*
 termdebug-stepping	terminal.txt	/*termdebug-stepping*
+termdebug-substitute-path	terminal.txt	/*termdebug-substitute-path*
 termdebug-timeout	terminal.txt	/*termdebug-timeout*
 termdebug-variables	terminal.txt	/*termdebug-variables*
 termdebug_contributing	terminal.txt	/*termdebug_contributing*

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -10942,6 +10942,7 @@ termdebug-frames	terminal.txt	/*termdebug-frames*
 termdebug-mappings	terminal.txt	/*termdebug-mappings*
 termdebug-prompt	terminal.txt	/*termdebug-prompt*
 termdebug-remote	terminal.txt	/*termdebug-remote*
+termdebug-remote-example	terminal.txt	/*termdebug-remote-example*
 termdebug-remote-window	terminal.txt	/*termdebug-remote-window*
 termdebug-starting	terminal.txt	/*termdebug-starting*
 termdebug-stepping	terminal.txt	/*termdebug-stepping*

--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -1635,19 +1635,47 @@ interrupt the running program.  But after using the MI command
 "continue" being used for the `:Continue` command, instead of using the
 communication channel.
 
-Remote Debugging ~
+
+Remote debugging ~
 							*termdebug-remote*
 One of the main issues of remote debugging is the access to the debuggee's
 source files. The plugin can profit from system and vim's networking
 capabilities to workaround this.
+						*termdebug-remote-example*
+The |termdebug-example| can be replicated by running the `gdb` debugger and the
+Vim debuggee on a remote Linux machine accessible via `ssh`.
+
+- Build Vim as explained in the local example.
+
+- Set up |termdebug_use_prompt|: >
+    :let g:termdebug_config = {}
+    :let g:termdebug_config['use_prompt'] = v:true
+
+- Specify the command line to run the remote `gdb` instance: >
+    :let g:termdebug_config['command'] = ['ssh', 'hostname', 'gdb']
+<  Explaining `ssh` is beyond the scope of this example, but notice the command
+  line can be greatly simplified by specifying the user, keys and other options
+  into the `$HOME/.ssh/config` file.
+
+- Provide a hint for translating remote paths into |netrw| paths: >
+    :let g:termdebug_config['substitute_path'] = { '/': 'scp://hostname//' }
+
+- Load the termdebug plugin and start debugging Vim: >
+    :packadd termdebug
+    :Termdebug vim
+
+You now have the same three windows of the local example and can follow the
+very same steps. The only difference is that the source windows displays a
+netrw buffer instead of a local one.
+
 						*termdebug-substitute-path*
 Use the `g:termdebug_config['substitute_path']` entry to map remote to local
-files using the same strategy that gdb's `substitute-path` command.
+files using the same strategy that gdb's `substitute-path` command uses.
 For example:
 - Use |netrw| to access files remoting via ssh: >
     let g:termdebug_config['command'] = ['ssh', 'hostname', 'gdb']
     let g:termdebug_config['substitute_path'] = { '/': 'scp://hostname//' }
-< Note: that first is specified the remote machine root path and later
+< Note: that the key specifies the remote machine root path and the value
   the local one.
 - Use Windows' `UNC` paths to access `WSL2` sources: >
     let g:termdebug_config['command'] = ['wsl', 'gdb']
@@ -1660,11 +1688,15 @@ For example:
 The plugin "program window" is linked to `gdb` using `pty slave devices`.
 Those must be local to the `gdb` instance, thus remote debugging only works
 on `prompt mode` (see |termdebug_use_prompt|).
-In this mode any `ssh` or `wsl` command would be detected and a similar command
-used to launch a remote `tty` terminal session and connect it to `gdb`.
+In this mode any `ssh` or `wsl` command would be detected and a similar
+command would be used to launch `socat` in a remote `tty` terminal session
+and connect it to `gdb`.
+If `socat` is not available a plain remote terminal would be used as
+fallback.
+The next session shows how to override this default behaviour.
 
 						*termdebug-remote-window*
-In order to use another remote terminal clients, set "remote_window" entry
+In order to use another remote terminal client, set "remote_window" entry
 in g:termdebug_config variable before invoking `:Termdebug`. For example: >
     let g:termdebug_config['use_prompt'] = v:true
     let g:termdebug_config['command'] = ['docker', 'run', '-i',

--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -1647,7 +1647,8 @@ Vim debuggee on a remote Linux machine accessible via `ssh`.
 
 - Build Vim as explained in the local example.
 
-- Set up |termdebug_use_prompt|: >
+- If 'socat' is not available in the remote machine 'terminal' mode will not
+  work properly. Fall back to |termdebug_use_prompt|: >
     :let g:termdebug_config = {}
     :let g:termdebug_config['use_prompt'] = v:true
 
@@ -1685,9 +1686,6 @@ For example:
 < Note: that several mappings are required: one for each drive unit
   and one for the linux filesystem (queried via `wslpath`).
 
-The plugin "program window" is linked to `gdb` using `pty slave devices`.
-Those must be local to the `gdb` instance, thus remote debugging only works
-on `prompt mode` (see |termdebug_use_prompt|).
 In this mode any `ssh` or `wsl` command would be detected and a similar
 command would be used to launch `socat` in a remote `tty` terminal session
 and connect it to `gdb`.
@@ -1696,17 +1694,34 @@ fallback.
 The next session shows how to override this default behaviour.
 
 						*termdebug-remote-window*
-In order to use another remote terminal client, set "remote_window" entry
-in g:termdebug_config variable before invoking `:Termdebug`. For example: >
+In order to use another remote terminal client, set 'remote_window' entry
+in `g:termdebug_config` variable before invoking `:Termdebug`. For example:
+- Debugging inside a docker container on 'prompt' mode: >
     let g:termdebug_config['use_prompt'] = v:true
     let g:termdebug_config['command'] = ['docker', 'run', '-i',
 	\ '--rm', '--name', 'container-name', 'image-name', 'gdb']
     let g:termdebug_config['remote_window'] =
-	\ ['docker', 'exec', '-it', 'container-name', 'bash']
+	\ ['docker', 'exec', '-ti', 'container-name'
+	\ ,'socat', '-dd', '-', 'PTY,raw,echo=0']
 
-Note: 'command' cannot use `-t` because the |prompt-buffer| cannot use `tty`.
-'remote_window' must use `-t` because otherwise it will lack a
-`pty slave device` for gdb linking.
+- Debugging inside a docker container on a 'terminal buffer'.
+  The container should be already running because unlike the previous
+  case for `terminal mode` 'program' and 'communication' ptys are created
+  before the gdb one: >
+    $ docker run -ti --rm --name container-name immage-name
+<  Then, launch the debugger: >
+    let g:termdebug_config['use_prompt'] = v:false " default
+    let g:termdebug_config['command'] =
+	\ ['docker', 'exec', '-ti', 'container-name', 'gdb']
+    let g:termdebug_config['remote_window'] =
+	\ ['docker', 'exec', '-ti', 'container-name'
+	\ ,'socat', '-dd', '-', 'PTY,raw,echo=0']
+
+Note: 'command' cannot use `-t` on |termdebug-prompt| mode because prompt
+buffers cannot handle `tty` connections.
+The 'remote_window' command must use `-t` because otherwise it will lack
+a `pty slave device` for gdb to connect.
+Note: 'socat' must be available in the remote machine on 'terminal' mode.
 Note: docker container sources can be accessible combining `volumes`
 with mappings (see |termdebug-substitute-path|).
 
@@ -1729,6 +1744,13 @@ If there is no g:termdebug_config you can use: >
 Several arguments will be added to make gdb work well for the debugger.
 If you want to modify them, add a function to filter the argument list: >
 	let g:termdebug_config['command_filter'] = MyDebugFilter
+
+A 'command_filter' scenario is solving escaping issues on remote debugging
+over 'ssh'. For convenience a default filter is provided for escaping
+whitespaces inside the arguments. It is automatically configured for 'ssh',
+but can be employed in other use cases like this: >
+	let g:termdebug_config['command_filter'] =
+	/   function('g:Termdebug_escape_whitespace')
 
 If you do not want the arguments to be added, but you do need to set the
 "pty", use a function to add the necessary arguments: >

--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -44,6 +44,7 @@ If the result is "1" you have it.
       Prompt mode				|termdebug-prompt|
       Mappings					|termdebug-mappings|
       Communication				|termdebug-communication|
+      Remote Debugging				|termdebug-remote|
       Customizing				|termdebug-customizing|
 
 {only available when compiled with the |+terminal| feature}
@@ -1634,6 +1635,48 @@ interrupt the running program.  But after using the MI command
 "continue" being used for the `:Continue` command, instead of using the
 communication channel.
 
+Remote Debugging ~
+							*termdebug-remote*
+One of the main issues of remote debugging is the access to the debuggee's
+source files. The plugin can profit from system and vim's networking
+capabilities to workaround this.
+						*termdebug-substitute-path*
+Use the `g:termdebug_config['substitute_path']` entry to map remote to local
+files using the same strategy that gdb's `substitute-path` command.
+For example:
+- Use |netrw| to access files remoting via ssh: >
+    let g:termdebug_config['command'] = ['ssh', 'hostname', 'gdb']
+    let g:termdebug_config['substitute_path'] = { '/': 'scp://hostname//' }
+< Note: that first is specified the remote machine root path and later
+  the local one.
+- Use Windows' `UNC` paths to access `WSL2` sources: >
+    let g:termdebug_config['command'] = ['wsl', 'gdb']
+    let g:termdebug_config['substitute_path'] = {
+	\ '/': '\\wsl.localhost\Ubuntu-22.04\',
+	\ '/mnt/c/': 'C:/' }
+< Note: that several mappings are required: one for each drive unit
+  and one for the linux filesystem (queried via `wslpath`).
+
+The plugin "program window" is linked to `gdb` using `pty slave devices`.
+Those must be local to the `gdb` instance, thus remote debugging only works
+on `prompt mode` (see |termdebug_use_prompt|).
+In this mode any `ssh` or `wsl` command would be detected and a similar command
+used to launch a remote `tty` terminal session and connect it to `gdb`.
+
+						*termdebug-remote-window*
+In order to use another remote terminal clients, set "remote_window" entry
+in g:termdebug_config variable before invoking `:Termdebug`. For example: >
+    let g:termdebug_config['use_prompt'] = v:true
+    let g:termdebug_config['command'] = ['docker', 'run', '-i',
+	\ '--rm', '--name', 'container-name', 'image-name', 'gdb']
+    let g:termdebug_config['remote_window'] =
+	\ ['docker', 'exec', '-it', 'container-name', 'bash']
+
+Note: 'command' cannot use `-t` because the |prompt-buffer| cannot use `tty`.
+'remote_window' must use `-t` because otherwise it will lack a
+`pty slave device` for gdb linking.
+Note: docker container sources can be accessible combining `volumes`
+with mappings (see |termdebug-substitute-path|).
 
 GDB command ~
 							*g:termdebugger*

--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -1643,11 +1643,12 @@ source files. The plugin can profit from system and vim's networking
 capabilities to workaround this.
 						*termdebug-remote-example*
 The |termdebug-example| can be replicated by running the `gdb` debugger and the
-Vim debuggee on a remote Linux machine accessible via `ssh`.
+The |termdebug-example| can be replicated by running the `gdb` debugger to
+to debug Vim on a remote Linux machine accessible via `ssh`.
 
 - Build Vim as explained in the local example.
 
-- If 'socat' is not available in the remote machine 'terminal' mode will not
+- If "socat" is not available in the remote machine 'terminal' mode will not
   work properly. Fall back to |termdebug_use_prompt|: >
     :let g:termdebug_config = {}
     :let g:termdebug_config['use_prompt'] = v:true
@@ -1694,9 +1695,9 @@ fallback.
 The next session shows how to override this default behaviour.
 
 						*termdebug-remote-window*
-In order to use another remote terminal client, set 'remote_window' entry
+In order to use another remote terminal client, set "remote_window" entry
 in `g:termdebug_config` variable before invoking `:Termdebug`. For example:
-- Debugging inside a docker container on 'prompt' mode: >
+- Debugging inside a docker container using "prompt" mode: >
     let g:termdebug_config['use_prompt'] = v:true
     let g:termdebug_config['command'] = ['docker', 'run', '-i',
 	\ '--rm', '--name', 'container-name', 'image-name', 'gdb']
@@ -1704,9 +1705,9 @@ in `g:termdebug_config` variable before invoking `:Termdebug`. For example:
 	\ ['docker', 'exec', '-ti', 'container-name'
 	\ ,'socat', '-dd', '-', 'PTY,raw,echo=0']
 
-- Debugging inside a docker container on a 'terminal buffer'.
+- Debugging inside a docker container using a "terminal buffer".
   The container should be already running because unlike the previous
-  case for `terminal mode` 'program' and 'communication' ptys are created
+  case for `terminal mode` "program" and "communication" ptys are created
   before the gdb one: >
     $ docker run -ti --rm --name container-name immage-name
 <  Then, launch the debugger: >
@@ -1717,11 +1718,11 @@ in `g:termdebug_config` variable before invoking `:Termdebug`. For example:
 	\ ['docker', 'exec', '-ti', 'container-name'
 	\ ,'socat', '-dd', '-', 'PTY,raw,echo=0']
 
-Note: 'command' cannot use `-t` on |termdebug-prompt| mode because prompt
+Note: "command" cannot use `-t` on |termdebug-prompt| mode because prompt
 buffers cannot handle `tty` connections.
 The 'remote_window' command must use `-t` because otherwise it will lack
 a `pty slave device` for gdb to connect.
-Note: 'socat' must be available in the remote machine on 'terminal' mode.
+Note: "socat" must be available in the remote machine on "terminal" mode.
 Note: docker container sources can be accessible combining `volumes`
 with mappings (see |termdebug-substitute-path|).
 
@@ -1745,9 +1746,9 @@ Several arguments will be added to make gdb work well for the debugger.
 If you want to modify them, add a function to filter the argument list: >
 	let g:termdebug_config['command_filter'] = MyDebugFilter
 
-A 'command_filter' scenario is solving escaping issues on remote debugging
-over 'ssh'. For convenience a default filter is provided for escaping
-whitespaces inside the arguments. It is automatically configured for 'ssh',
+A "command_filter" scenario is solving escaping issues on remote debugging
+over "ssh". For convenience a default filter is provided for escaping
+whitespaces inside the arguments. It is automatically configured for "ssh",
 but can be employed in other use cases like this: >
 	let g:termdebug_config['command_filter'] =
 	/   function('g:Termdebug_escape_whitespace')

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -541,12 +541,16 @@ enddef
 
 def CreateCommunicationPty(cmd: list<string> = null_list): string
   # Create a hidden terminal window to communicate with gdb
-  commbufnr = term_start(!cmd ? 'NONE' : cmd, {
-    term_name: commbufname,
-    out_cb: CommOutput,
-    term_cols: 500, # avoid message wrapping that prevents proper parsing
-    hidden: 1
-  })
+  var options: dict<any> = { term_name: commbufname, out_cb: CommOutput, hidden: 1 }
+
+  if !cmd
+    commbufnr = term_start('NONE', options)
+  else
+    # avoid message wrapping that prevents proper parsing
+    options['term_cols'] = 500
+    commbufnr = term_start(cmd, options)
+  endif
+
   if commbufnr == 0
     return null_string
   endif

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -657,16 +657,17 @@ def StartDebug_prompt(dict: dict<any>)
   var gdb_args = get(dict, 'gdb_args', [])
   var proc_args = get(dict, 'proc_args', [])
 
-  # Add -quiet to avoid the intro message causing a hit-enter prompt.
-  gdb_cmd += ['-quiet']
+  # directly communicate via mi2. This option must precede any -iex options for proper
+  # interpretation.
+  gdb_cmd += ['--interpreter=mi2']
   # Disable pagination, it causes everything to stop at the gdb, needs to be run early
-  gdb_cmd += ['-iex', 'set pagination off']
+  gdb_cmd += ['-iex', '"set pagination off"']
   # Interpret commands while the target is running.  This should usually only
   # be exec-interrupt, since many commands don't work properly while the
   # target is running (so execute during startup).
-  gdb_cmd += ['-iex', 'set mi-async on']
-  # directly communicate via mi2
-  gdb_cmd += ['--interpreter=mi2']
+  gdb_cmd += ['-iex', '"set mi-async on"']
+  # Add -quiet to avoid the intro message causing a hit-enter prompt.
+  gdb_cmd += ['-quiet']
 
   # Adding arguments requested by the user
   gdb_cmd += gdb_args

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -34,6 +34,7 @@ vim9script
 # Gdb is run as a job with callbacks for I/O.
 # On Unix another terminal window is opened to run the debugged program
 # On MS-Windows a separate console is opened to run the debugged program
+# but a terminal window is used to run remote debugged programs.
 
 # The communication with gdb uses GDB/MI.  See:
 # https://sourceware.org/gdb/current/onlinedocs/gdb/GDB_002fMI.html

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -702,8 +702,15 @@ def StartDebug_prompt(dict: dict<any>)
       if gdb_pos > 0
         # strip debugger call
         term_cmd = gdb_cmd[0 : gdb_pos - 1]
-        # create a devoted tty slave device and link to stdin/stdout
-        term_cmd += ['socat', '-d', '-d', '-', 'PTY,raw,echo=0']
+        # roundtrip to check if socat is available on the remote side
+        silent call system(join(term_cmd, ' ') .. ' socat -h')
+        if v:shell_error
+          Echowarn('Install socat on the remote machine for a program window better experience')
+        else
+          # create a devoted tty slave device and link to stdin/stdout
+          term_cmd += ['socat', '-d', '-d', '-', 'PTY,raw,echo=0']
+        endif
+        ch_log($'launching program windows as "{join(term_cmd)}"')
       endif
     endif
   endif

--- a/src/testdir/test_plugin_termdebug.vim
+++ b/src/testdir/test_plugin_termdebug.vim
@@ -689,4 +689,70 @@ func Test_termdebug_toggle_break()
   %bw!
 endfunc
 
+" Check substitution capabilities and simulate remote debugging
+func Test_termdebug_remote_basic()
+  let bin_name = 'XTD_basicremote'
+  let src_name = bin_name .. '.c'
+  call s:generate_files(bin_name)
+  defer s:cleanup_files(bin_name)
+
+  " Duplicate sources to test the mapping
+  const src_shadow_dir = "shadow"
+  call mkdir(src_shadow_dir)
+  const src_shadow_file = $"{src_shadow_dir}/{src_name}"
+  call filecopy(src_name, src_shadow_file)
+  defer delete(src_shadow_dir, 'rf')
+
+  " Set up mock remote and mapping
+  let g:termdebug_config = {}
+
+  let g:termdebug_config['use_prompt'] = v:true
+  let g:termdebug_config['remote_window'] = ['sh']
+
+  let g:termdebug_config['substitute_path'] = {}
+  const pwd = getcwd()
+  let g:termdebug_config['substitute_path'][pwd] = pwd . '/' . src_shadow_dir
+  defer execute("unlet g:termdebug_config")
+
+  " Launch the debugger and set breakpoints in the shadow file instead
+  exe $"edit {src_shadow_file}"
+  exe $"Termdebug ./{bin_name}"
+  call WaitForAssert({-> assert_true(get(g:, "termdebug_is_running", v:false))})
+  call WaitForAssert({-> assert_equal(3, winnr('$'))})
+  let gdb_buf = winbufnr(1)
+  wincmd b
+  Break 9
+  sleep 100m
+  redraw!
+  call assert_equal([
+        \ {'lnum': 9, 'id': 1014, 'name': 'debugBreakpoint1.0',
+        \  'priority': 110, 'group': 'TermDebug'}],
+        \ sign_getplaced('', #{group: 'TermDebug'})[0].signs)
+  Run
+  call term_wait(gdb_buf, 400)
+  redraw!
+  call WaitForAssert({-> assert_equal([
+        \ {'lnum': 9, 'id': 12, 'name': 'debugPC', 'priority': 110,
+        \  'group': 'TermDebug'},
+        \ {'lnum': 9, 'id': 1014, 'name': 'debugBreakpoint1.0',
+        \  'priority': 110, 'group': 'TermDebug'}],
+        \ sign_getplaced('', #{group: 'TermDebug'})[0].signs)})
+  Finish
+  call term_wait(gdb_buf)
+  redraw!
+  call WaitForAssert({-> assert_equal([
+        \ {'lnum': 9, 'id': 1014, 'name': 'debugBreakpoint1.0',
+        \  'priority': 110, 'group': 'TermDebug'},
+        \ {'lnum': 20, 'id': 12, 'name': 'debugPC',
+        \  'priority': 110, 'group': 'TermDebug'}],
+        \ sign_getplaced('', #{group: 'TermDebug'})[0].signs)})
+
+  " Cleanup, make sure the gdb job is terminated before return
+  " otherwise may interfere with next test
+  Gdb
+  bw!
+  call WaitForAssert({-> assert_equal(1, winnr('$'))})
+  %bw!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
The `termdebug` plugin doesn't work with `gdbserver` because is focus on `tty`. This plugin allows launching gdb connecting it via `tty` to the program windows.

This PR modifies it to allow using a remote `tty device` by launching the program window terminal remotely too. It automatically detects remoting if `g:termdebug_config['command']` uses `ssh` or `wsl` (vim can access the sources directly on that case).

For other use cases (like `docker`) a `g:termdebug_config['remote_windows']` allows customization.

This only works in [prompt-buffer mode](https://github.com/vim/vim/blob/ca6a260ef1a4b4ae94bc71c17cbabf8f12bf0f8c/runtime/doc/terminal.txt#L1547) because `termina-job mode` (default) specifically creates a local `tty` window.

The PR provides `g:termdebug_config['substitute_path']` entry to map remote to local files using the same strategy that gdb's `substitute-path` command.

## Examples

### ssh
In this case the [netrw](https://github.com/vim/vim/blob/ca6a260ef1a4b4ae94bc71c17cbabf8f12bf0f8c/runtime/pack/dist/opt/netrw/doc/netrw.txt#L440) builtin plugin retrieves the sources automatically from the remote machine.
```vim
let g:termdebug_config = {}
let g:termdebug_config['use_prompt'] = v:true
let g:termdebug_config['command'] = ['ssh', 'hostname', 'gdb']
let g:termdebug_config['substitute_path'] = { '/': 'scp://hostname//' }
```
### wsl
In this case the Windows OS will use special [UNC paths](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/62e862f4-2a51-452e-8eeb-dc4ff5ee33cc) for the linux filesystem and mounts for the windows drives.
```vim
let g:termdebug_config = {}
let g:termdebug_config['use_prompt'] = v:true
let g:termdebug_config['command'] = ['wsl', 'gdb']
let g:termdebug_config['substitute_path'] = {
    \ '/': '\\wsl.localhost\Ubuntu-22.04\',
    \ '/mnt/c/': 'C:/' }
```
> **Note:** the `UNC path` can be queried using `wslpath` tool.