### PR TITLE
"longest" doesn't work for manual completion when 'ac' is on

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -2511,7 +2511,10 @@ ins_compl_new_leader(void)
 	save_w_wrow = curwin->w_wrow;
 	save_w_leftcol = curwin->w_leftcol;
 	compl_restarting = TRUE;
-	compl_autocomplete = ins_compl_has_autocomplete();
+	if (ins_compl_has_autocomplete())
+	    ins_compl_enable_autocomplete();
+	else
+	    compl_autocomplete = FALSE;
 	if (ins_complete(Ctrl_N, FALSE) == FAIL)
 	    compl_cont_status = 0;
 	compl_restarting = FALSE;
@@ -3100,8 +3103,7 @@ ins_compl_prep(int c)
     if (ctrl_x_mode_not_defined_yet()
 			   || (ctrl_x_mode_normal() && !compl_started))
     {
-	compl_get_longest = (get_cot_flags() & COT_LONGEST)
-	    && !ins_compl_has_autocomplete();
+	compl_get_longest = (get_cot_flags() & COT_LONGEST);
 	compl_used_match = TRUE;
     }
 
@@ -7388,6 +7390,7 @@ ins_compl_enable_autocomplete(void)
 {
 #ifdef ELAPSED_FUNC
     compl_autocomplete = TRUE;
+    compl_get_longest = FALSE;
 #endif
 }
 

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -5871,7 +5871,7 @@ func Test_autocomplete_longest()
   call feedkeys("Go\<ESC>", 'tx')
   call DoTest("f\<C-N>\<C-N>\<BS>\<BS>\<BS>\<BS>", 'foo', 3)
 
-  " Issue #18410: When both 'preinsert' and 'longest' are set, 'preinsert'
+  " Issue #18410: When both "preinsert" and "longest" are set, "preinsert"
   " takes precedence
   %delete
   set autocomplete completeopt+=longest,preinsert
@@ -5921,6 +5921,21 @@ func Test_autocomplete_longest()
 
   %delete _
   delfunc CheckUndo
+
+  " Check that behavior of "longest" in manual completion is unchanged.
+  for ac in [v:false, v:true]
+    let &ac = ac
+    set completeopt=menuone,longest
+    call feedkeys("Ssign u\<C-X>\<C-V>", 'tx')
+    call assert_equal('sign un', getline('.'))
+    call feedkeys("Ssign u\<C-X>\<C-V>\<C-V>", 'tx')
+    call assert_equal('sign undefine', getline('.'))
+    call feedkeys("Ssign u\<C-X>\<C-V>\<C-V>\<C-V>", 'tx')
+    call assert_equal('sign unplace', getline('.'))
+    call feedkeys("Ssign u\<C-X>\<C-V>\<C-V>\<C-V>\<C-V>", 'tx')
+    call assert_equal('sign u', getline('.'))
+    %delete
+  endfor
 
   bw!
   set cot& autocomplete&


### PR DESCRIPTION
Problem:  "longest" doesn't work for manual completion when
          'autocomplete' is on (after 9.1.1800).
Solution: Only reset compl_get_longest when enabling autocompletion.
