### PR TITLE
Remove winclip.pro from PRO_AUTO in src/Makefile (after v9.1.1806)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1981,7 +1981,6 @@ PRO_AUTO = \
 	vim9type.pro \
 	viminfo.pro \
 	wayland.pro \
-	winclip.pro \
 	window.pro \
 	$(ALL_GUI_PRO) \
 	$(TCL_PRO)


### PR DESCRIPTION
`winclip.pro` was already included in PRO_MANUAL.

Related: #18406