### PR TITLE
Tweak documentation style

### DIFF
--- a/runtime/doc/develop.txt
+++ b/runtime/doc/develop.txt
@@ -388,7 +388,7 @@ unreliable, fails on major platforms (e.g., macOS), and is only part of the
 new release workflow.  In practice, contributors edit the relevant `.pro` files
 by hand when adding, removing, or modifying a function signatures.
 
-This system has been in place since at least v1.24, when Vim’s functions were
+This system has been in place since at least v1.24, when Vim's functions were
 still written in K&R style.
 
 ==============================================================================
@@ -425,12 +425,12 @@ For any non-trivial change, please always create a pull request on github,
 since this triggers the test suite.
 
 A PR should ideally contain a single commit for a single logical change.
-However, you can include several commits if you want to group multiple
-logical, atomic changes in one PR.  This can also make longer PRs easier to
-review.  Be sure to describe the reasoning for your changes in each commit
-message, as this greatly helps with the review process.  In cases where each
-commit handles different logical changes, they will also be applied as
-separate patches in Vim’s repository.
+However, you can include several commits if you want to group multiple logical,
+atomic changes in one PR.  This can also make longer PRs easier to review.  Be
+sure to describe the reasoning for your changes in each commit message, as
+this greatly helps with the review process.  In cases where each commit
+handles different logical changes, they will also be applied as separate
+patches in Vim's repository.
 
 							*style-clang-format*
 sound.c and sign.c can be (semi-) automatically formatted using the

--- a/runtime/doc/helphelp.txt
+++ b/runtime/doc/helphelp.txt
@@ -478,8 +478,8 @@ annotation (e.g. "vim") after a greater than (>) character.  E.g. >vim
 						*g:help_example_languages*
 By default, help files only support Vim script highlighting.  If you need
 syntax highlighting for other languages, add to your |vimrc|: >
-	:let g:help_example_languages = {
-	      \	"vim": "vim", "vim9": "vim", "bash": "sh" }
+	:let g:help_example_languages = #{
+	      \	vim: "vim", vim9: "vim", bash: "sh" }
 The key represents the annotation marker name, and the value is the 'syntax'
 name.
 


### PR DESCRIPTION
develop.txt
- I tried to use normal ASCII characters as much as possible.   (2 places).
  `s/’/'/`
- Tweak line break.

helphelp.txt
- Use the #{} form for dictionary.

