### PR TITLE
Fix: Prevent flicker when LSP server is slow

### DIFF
--- a/src/globals.h
+++ b/src/globals.h
@@ -1133,6 +1133,9 @@ EXTERN int	secure INIT(= FALSE);
 				// allowed, e.g. when sourcing .exrc or .vimrc
 				// in current directory
 
+EXTERN int	no_flush INIT(= 0);
+				// non-zero to prevent flushing output buffer
+
 EXTERN int	textlock INIT(= 0);
 				// non-zero when changing text and jumping to
 				// another window or editing another buffer is

--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -3599,11 +3599,12 @@ expand_by_function(int type, char_u *base, callback_T *cb)
     // Insert mode in another buffer.
     ++textlock;
 
-    // Suppress flushing of the output buffer.
-    // Without this, text deleted by ins_compl_delete() may briefly vanish,
-    // causing flicker (typed chars disappear and are redrawn) when a user
-    // func runs slowly (e.g. an LSP server). Such funcs may call ':sleep',
-    // which indirectly triggers out_flush().
+    // Suppress flushing of the output buffer. Without this, text removed
+    // temporarily by ins_compl_delete() is flushed to the terminal and shown
+    // as deleted, only to be redrawn later. This causes visible flicker (typed
+    // chars disappear and reappear) when a user func (e.g. an LSP server)
+    // responds slowly. Such funcs may call sleep(), which indirectly triggers
+    // out_flush(). We want deleted text to remain visible.
     ++no_flush;
 
     retval = call_callback(cb, 0, &rettv, 2, args);

--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -3599,11 +3599,11 @@ expand_by_function(int type, char_u *base, callback_T *cb)
     // Insert mode in another buffer.
     ++textlock;
 
-    // Suppress flushing of the output buffer. Without this, deleted text from
-    // ins_compl_delete() may briefly appear on screen, causing flicker (the
-    // typed character disappears and is redrawn) when the LSP server responds
-    // slowly. The LSP client may call sleep(), which indirectly triggers
-    // out_flush().
+    // Suppress flushing of the output buffer.
+    // Without this, text deleted by ins_compl_delete() may briefly vanish,
+    // causing flicker (typed chars disappear and are redrawn) when a user
+    // func runs slowly (e.g. an LSP server). Such funcs may call ':sleep',
+    // which indirectly triggers out_flush().
     ++no_flush;
 
     retval = call_callback(cb, 0, &rettv, 2, args);

--- a/src/term.c
+++ b/src/term.c
@@ -2772,7 +2772,7 @@ out_flush(void)
 {
     int	    len;
 
-    if (out_pos == 0)
+    if (no_flush > 0 || out_pos == 0)
 	return;
 
     // set out_pos to 0 before ui_write, to avoid recursiveness

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -420,7 +420,7 @@ func Test_CompleteDoneDict()
   au CompleteDone * :call <SID>CompleteDone_CheckCompletedItemDict(0)
 
   set complete=.,F<SID>CompleteDone_CompleteFuncDict
-  execute "normal a\<C-N>\<C-Y>"
+  execute "normal dda\<C-N>\<C-Y>"
   set complete&
 
   call assert_equal(['one', 'two'], v:completed_item[ 'user_data' ])
@@ -473,7 +473,7 @@ func Test_CompleteDoneDictNoUserData()
   let s:called_completedone = 0
 
   set complete=.,F<SID>CompleteDone_CompleteFuncDictNoUserData
-  execute "normal a\<C-N>\<C-Y>"
+  execute "normal dda\<C-N>\<C-Y>"
   set complete&
 
   call assert_equal('', v:completed_item[ 'user_data' ])


### PR DESCRIPTION
Ref: https://github.com/girishji/vimcomplete/issues/101#issuecomment-3343063245

In insert-mode completion, the leader text is temporarily deleted while searching for completion candidates.
If the LSP server responds slowly, the client may call `:sleep` to wait, which triggers `out_flush()`.
This causes the deleted text to briefly disappear before being redrawn when results arrive, producing a visible flicker.

There are two possible fixes:

1. Suppress flushing while a user function (e.g. LSP client) is waiting.
2. Reinsert the deleted text before invoking the user function.

This PR implements (1), which is the simpler solution, though somewhat heavy-handed. If you think this may introduce unwanted side effects, I can rework it to use (2).