### PR TITLE
NSIS:refactoring of the `gvim.nsi` file

### DIFF
--- a/Filelist
+++ b/Filelist
@@ -639,6 +639,7 @@ SRC_DOS =	\
 		src/tee/tee.c \
 		src/xxd/Make_ming.mak \
 		src/xxd/Make_mvc.mak \
+		nsis/auxiliary.nsh \
 		nsis/gvim.nsi \
 		nsis/gvim_version.nsh \
 		nsis/Makefile \

--- a/nsis/auxiliary.nsh
+++ b/nsis/auxiliary.nsh
@@ -1,0 +1,148 @@
+# -*- coding: utf-8 -*-
+# NSIS helper file for creating a self-installing exe for Vim.
+# Contains service macros and functions. 
+# Last Change:	2025-09-03
+#
+
+!ifndef __AUXILIARY__NSH__
+  !define __AUXILIARY__NSH__
+
+# See https://nsis.sourceforge.io/LogicLib
+;FileExists is already part of LogicLib, but returns true for directories
+;as well as files
+  !macro _FileExists2 _a _b _t _f
+    !insertmacro _LOGICLIB_TEMP
+    StrCpy $_LOGICLIB_TEMP "0"
+;if path is not blank, continue to next check
+    StrCmp `${_b}` `` +4 0
+;if path exists, continue to next check (IfFileExists returns true if this
+;is a directory)
+    IfFileExists `${_b}` `0` +3
+;if path is not a directory, continue to confirm exists
+    IfFileExists `${_b}\*.*` +2 0
+    StrCpy $_LOGICLIB_TEMP "1" ;file exists
+;now we have a definitive value - the file exists or it does not
+    StrCmp $_LOGICLIB_TEMP "1" `${_t}` `${_f}`
+  !macroend
+  !undef FileExists
+  !define FileExists `"" FileExists2`
+  !macro _DirExists _a _b _t _f
+    !insertmacro _LOGICLIB_TEMP
+    StrCpy $_LOGICLIB_TEMP "0"
+;if path is not blank, continue to next check
+    StrCmp `${_b}` `` +3 0
+;if directory exists, continue to confirm exists
+    IfFileExists `${_b}\*.*` 0 +2
+    StrCpy $_LOGICLIB_TEMP "1"
+    StrCmp $_LOGICLIB_TEMP "1" `${_t}` `${_f}`
+  !macroend
+  !define DirExists `"" DirExists`
+
+# Get parent directory
+# Share this function both on installer and uninstaller
+  !macro GetParent un
+    Function ${un}GetParent
+      Exch $0  ; old $0 is on top of stack
+      Push $1
+      Push $2
+      StrCpy $1 -1
+      ${Do}
+	StrCpy $2 $0 1 $1
+	${If} $2 == ""
+	${OrIf} $2 == "\"
+	  ${ExitDo}
+	${EndIf}
+	IntOp $1 $1 - 1
+      ${Loop}
+      StrCpy $0 $0 $1
+      Pop $2
+      Pop $1
+      Exch $0  ; put $0 on top of stack, restore $0 to original value
+    FunctionEnd
+  !macroend
+
+  !insertmacro GetParent ""
+  !insertmacro GetParent "un."
+
+# Get home directory
+  !macro GetHomeDir un
+    Function ${un}GetHomeDir
+      Push $0
+      Push $1
+      ReadEnvStr $0 "HOME"
+      ${If} $0 == ""
+	ReadEnvStr $0 "HOMEDRIVE"
+	ReadEnvStr $1 "HOMEPATH"
+	StrCpy $0 "$0$1"
+	${If} $0 == ""
+	  ReadEnvStr $0 "USERPROFILE"
+	${EndIf}
+      ${EndIf}
+      Pop $1
+      Exch $0  ; put $0 on top of stack, restore $0 to original value
+    FunctionEnd
+  !macroend
+
+  !insertmacro GetHomeDir ""
+  !insertmacro GetHomeDir "un."
+
+# Saving the status of sections of the current installation in the registry
+  !macro SaveSectionSelection section_id reg_value
+    ${If} ${SectionIsSelected} ${section_id}
+      WriteRegDWORD HKLM "${UNINST_REG_KEY_VIM}" ${reg_value} 1
+    ${Else}
+      WriteRegDWORD HKLM "${UNINST_REG_KEY_VIM}" ${reg_value} 0
+    ${EndIf}
+  !macroend
+
+# Reading the status of sections from the registry of the previous installation 
+  !macro LoadSectionSelection section_id reg_value
+    ClearErrors
+    ReadRegDWORD $3 HKLM "${UNINST_REG_KEY_VIM}" ${reg_value}
+    ${IfNot} ${Errors}
+      ${If} $3 = 1
+	!insertmacro SelectSection ${section_id}
+      ${Else}
+	!insertmacro UnselectSection ${section_id}
+      ${EndIf}
+    ${EndIf}
+  !macroend
+
+# Reading the settings for _vimrc from the registry of a previous installation
+  !macro LoadDefaultVimrc out_var reg_value default_value
+    ClearErrors
+    ReadRegStr ${out_var} HKLM "${UNINST_REG_KEY_VIM}" ${reg_value}
+    ${If} ${Errors}
+    ${OrIf} ${out_var} == ""
+      StrCpy ${out_var} ${default_value}
+    ${EndIf}
+  !macroend
+
+# Get user locale
+  !if ${HAVE_NLS}
+    Var lng_usr  ; variable containing the locale of the current user
+
+    !include "StrFunc.nsh"
+    ${StrRep}
+
+    Function GetUserLocale
+      ClearErrors
+      System::Call \
+	  'kernel32::GetUserDefaultLocaleName(t.r19, *i${NSIS_MAX_STRLEN})'
+      StrCmp $R9 "zh-cn" coincide 0
+      StrCmp $R9 "zh-tw" coincide 0
+      StrCmp $R9 "pt-br" 0 part
+      coincide:
+      System::Call 'User32::CharLower(t r19 r19)*i${NSIS_MAX_STRLEN}'
+      ${StrRep} $lng_usr "$R9" "-" "_"
+      Goto done
+      part:
+      StrCpy $lng_usr $R9 2
+      done:
+    FunctionEnd
+  !endif
+
+
+
+!endif # __AUXILIARY__NSH__
+# vi:set ts=8 sw=2 sts=2 tw=79 wm=0 ft=nsis:

--- a/nsis/gvim.nsi
+++ b/nsis/gvim.nsi
@@ -1,6 +1,7 @@
 # NSIS file to create a self-installing exe for Vim.
 # It requires NSIS version 3.0 or later.
-# Last Change:	2025 Feb 24
+# Last Change:	2025-08-30
+#
 
 Unicode true
 
@@ -93,35 +94,35 @@ ${StrRep}
 ;FileExists is already part of LogicLib, but returns true for directories
 ;as well as files
 !macro _FileExists2 _a _b _t _f
-	!insertmacro _LOGICLIB_TEMP
-	StrCpy $_LOGICLIB_TEMP "0"
+  !insertmacro _LOGICLIB_TEMP
+  StrCpy $_LOGICLIB_TEMP "0"
 ;if path is not blank, continue to next check
-	StrCmp `${_b}` `` +4 0
+  StrCmp `${_b}` `` +4 0
 ;if path exists, continue to next check (IfFileExists returns true if this
 ;is a directory)
-	IfFileExists `${_b}` `0` +3
+  IfFileExists `${_b}` `0` +3
 ;if path is not a directory, continue to confirm exists
-	IfFileExists `${_b}\*.*` +2 0
-	StrCpy $_LOGICLIB_TEMP "1" ;file exists
+  IfFileExists `${_b}\*.*` +2 0
+StrCpy $_LOGICLIB_TEMP "1" ;file exists
 ;now we have a definitive value - the file exists or it does not
-	StrCmp $_LOGICLIB_TEMP "1" `${_t}` `${_f}`
+  StrCmp $_LOGICLIB_TEMP "1" `${_t}` `${_f}`
 !macroend
 !undef FileExists
 !define FileExists `"" FileExists2`
 !macro _DirExists _a _b _t _f
-	!insertmacro _LOGICLIB_TEMP
-	StrCpy $_LOGICLIB_TEMP "0"
+  !insertmacro _LOGICLIB_TEMP
+  StrCpy $_LOGICLIB_TEMP "0"
 ;if path is not blank, continue to next check
-	StrCmp `${_b}` `` +3 0
+  StrCmp `${_b}` `` +3 0
 ;if directory exists, continue to confirm exists
-	IfFileExists `${_b}\*.*` 0 +2
-	StrCpy $_LOGICLIB_TEMP "1"
-	StrCmp $_LOGICLIB_TEMP "1" `${_t}` `${_f}`
+  IfFileExists `${_b}\*.*` 0 +2
+  StrCpy $_LOGICLIB_TEMP "1"
+  StrCmp $_LOGICLIB_TEMP "1" `${_t}` `${_f}`
 !macroend
 !define DirExists `"" DirExists`
 
 !define PRODUCT		"Vim ${VER_MAJOR}.${VER_MINOR}"
-!define UNINST_REG_KEY	"Software\Microsoft\Windows\CurrentVersion\Uninstall"
+!define UNINST_REG_KEY  "Software\Microsoft\Windows\CurrentVersion\Uninstall"
 !define UNINST_REG_KEY_VIM  "${UNINST_REG_KEY}\${PRODUCT}"
 
 !if ${WIN64}
@@ -146,9 +147,9 @@ RequestExecutionLevel highest
 !endif
 
 !if ${WIN64}
-!define BIT	64
+  !define BIT 64
 !else
-!define BIT	32
+  !define BIT 32
 !endif
 
 ##########################################################
@@ -164,26 +165,26 @@ RequestExecutionLevel highest
 !define MUI_LANGDLL_ALLLANGUAGES
 # Always show dialog choice language
 #!define MUI_LANGDLL_ALWAYSSHOW
-!define MUI_LANGDLL_REGISTRY_ROOT       "HKCU"
-!define MUI_LANGDLL_REGISTRY_KEY        "Software\Vim"
+!define MUI_LANGDLL_REGISTRY_ROOT	"HKCU"
+!define MUI_LANGDLL_REGISTRY_KEY	"Software\Vim"
 !define MUI_LANGDLL_REGISTRY_VALUENAME  "Installer Language"
 
-!define MUI_WELCOMEFINISHPAGE_BITMAP       "icons\welcome.bmp"
-!define MUI_UNWELCOMEFINISHPAGE_BITMAP     "icons\uninstall.bmp"
+!define MUI_WELCOMEFINISHPAGE_BITMAP	"icons\welcome.bmp"
+!define MUI_UNWELCOMEFINISHPAGE_BITMAP	"icons\uninstall.bmp"
 !define MUI_HEADERIMAGE
-!define MUI_HEADERIMAGE_BITMAP             "icons\header.bmp"
-!define MUI_HEADERIMAGE_UNBITMAP           "icons\un_header.bmp"
+!define MUI_HEADERIMAGE_BITMAP		"icons\header.bmp"
+!define MUI_HEADERIMAGE_UNBITMAP	"icons\un_header.bmp"
 
-!define MUI_WELCOMEFINISHPAGE_BITMAP_STRETCH    "AspectFitHeight"
+!define MUI_WELCOMEFINISHPAGE_BITMAP_STRETCH	"AspectFitHeight"
 !define MUI_UNWELCOMEFINISHPAGE_BITMAP_STRETCH  "AspectFitHeight"
-!define MUI_HEADERIMAGE_BITMAP_STRETCH          "AspectFitHeight"
-!define MUI_HEADERIMAGE_UNBITMAP_STRETCH        "AspectFitHeight"
+!define MUI_HEADERIMAGE_BITMAP_STRETCH		"AspectFitHeight"
+!define MUI_HEADERIMAGE_UNBITMAP_STRETCH	"AspectFitHeight"
 
 !define MUI_COMPONENTSPAGE_SMALLDESC
 !define MUI_LICENSEPAGE_CHECKBOX
 !define MUI_FINISHPAGE_SHOWREADME
-!define MUI_FINISHPAGE_SHOWREADME_TEXT	    $(str_show_readme)
-!define MUI_FINISHPAGE_SHOWREADME_FUNCTION  LaunchApplication
+!define MUI_FINISHPAGE_SHOWREADME_TEXT		$(str_show_readme)
+!define MUI_FINISHPAGE_SHOWREADME_FUNCTION	LaunchApplication
 
 # This adds '\Vim' to the user choice automagically.  The actual value is
 # obtained below with CheckOldVim.
@@ -232,18 +233,18 @@ Page custom SetCustom ValidateCustom
 
 # Include support for other languages:
 !if ${HAVE_MULTI_LANG}
-    !include "lang\portuguesebr.nsi"
-    !include "lang\danish.nsi"
-    !include "lang\dutch.nsi"
-    !include "lang\german.nsi"
-    !include "lang\greek.nsi"
-    !include "lang\italian.nsi"
-    !include "lang\japanese.nsi"
-    !include "lang\russian.nsi"
-    !include "lang\serbian.nsi"
-    !include "lang\simpchinese.nsi"
-    !include "lang\tradchinese.nsi"
-    !include "lang\turkish.nsi"
+  !include "lang\portuguesebr.nsi"
+  !include "lang\danish.nsi"
+  !include "lang\dutch.nsi"
+  !include "lang\german.nsi"
+  !include "lang\greek.nsi"
+  !include "lang\italian.nsi"
+  !include "lang\japanese.nsi"
+  !include "lang\russian.nsi"
+  !include "lang\serbian.nsi"
+  !include "lang\simpchinese.nsi"
+  !include "lang\tradchinese.nsi"
+  !include "lang\turkish.nsi"
 !endif
 
 ##########################################################
@@ -253,8 +254,10 @@ VIAddVersionKey /LANG=${LANG_ENGLISH} "ProductName" "Vim"
 VIAddVersionKey /LANG=${LANG_ENGLISH} "CompanyName" "The Vim Project"
 VIAddVersionKey /LANG=${LANG_ENGLISH} "LegalTrademarks" "Vim"
 VIAddVersionKey /LANG=${LANG_ENGLISH} "LegalCopyright" "Copyright (C) 1996"
-VIAddVersionKey /LANG=${LANG_ENGLISH} "FileDescription" "Vi Improved - A Text Editor"
-VIAddVersionKey /LANG=${LANG_ENGLISH} "FileVersion" "${VER_MAJOR}.${VER_MINOR}.${PATCHLEVEL}.0"
+VIAddVersionKey /LANG=${LANG_ENGLISH} "FileDescription" \
+    "Vi Improved - A Text Editor"
+VIAddVersionKey /LANG=${LANG_ENGLISH} "FileVersion" \
+    "${VER_MAJOR}.${VER_MINOR}.${PATCHLEVEL}.0"
 VIProductVersion "${VER_MAJOR}.${VER_MINOR}.${PATCHLEVEL}.0"
 
 # Global variables
@@ -266,9 +269,8 @@ Var vim_compat_stat
 Var vim_keymap_stat
 Var vim_mouse_stat
 !if ${HAVE_NLS}
-Var lng_usr
+  Var lng_usr
 !endif
-
 
 # Reserve files
 ReserveFile ${VIMSRC}\installw32.exe
@@ -337,9 +339,9 @@ Function CheckOldVim
   ${EndIf}
 
   ClearErrors
-  StrCpy $0  ""   # Installed directory
-  StrCpy $R0 0    # Sub-key index
-  StrCpy $R1 ""   # Sub-key
+  StrCpy $0 ""	# Installed directory
+  StrCpy $R0 0	# Sub-key index
+  StrCpy $R1 ""	# Sub-key
   ${Do}
     # Eumerate the sub-key:
     EnumRegKey $R1 HKLM ${UNINST_REG_KEY} $R0
@@ -376,7 +378,7 @@ Function CheckOldVim
     Push $R2
     call GetParent
     call GetParent
-    Pop $0   # Vim directory
+    Pop $0  # Vim directory
     ${ExitDo}
 
   ${Loop}
@@ -392,447 +394,443 @@ Function CheckOldVim
 FunctionEnd
 
 Function LaunchApplication
-   SetOutPath $0
-   ShellExecAsUser::ShellExecAsUser "" "$0\gvim.exe" '-R "$0\$(vim_readme_file)"'
+  SetOutPath $0
+  ShellExecAsUser::ShellExecAsUser "" "$0\gvim.exe" '-R "$0\$(vim_readme_file)"'
 FunctionEnd
 
 ##########################################################
 Section "$(str_section_old_ver)" id_section_old_ver
-	SectionIn 1 2 3 RO
+  SectionIn 1 2 3 RO
 
-	# run the install program to check for already installed versions
-	SetOutPath $TEMP
-	File /oname=install.exe ${VIMSRC}\installw32.exe
-	DetailPrint "$(str_msg_uninstalling)"
-	${Do}
-	  nsExec::Exec "$TEMP\install.exe -uninstall-check"
-	  Pop $3
+  # run the install program to check for already installed versions
+  SetOutPath $TEMP
+  File /oname=install.exe ${VIMSRC}\installw32.exe
+  DetailPrint "$(str_msg_uninstalling)"
+  ${Do}
+    nsExec::Exec "$TEMP\install.exe -uninstall-check"
+    Pop $3
 
-	  call CheckOldVim
-	  Pop $3
-	  ${If} $3 == ""
-	    ${ExitDo}
-	  ${Else}
-	    # It seems that the old version is still remaining.
-	    # TODO: Should we show a warning and run the uninstaller again?
+    call CheckOldVim
+    Pop $3
+    ${If} $3 == ""
+      ${ExitDo}
+    ${Else}
+      # It seems that the old version is still remaining.
+      # TODO: Should we show a warning and run the uninstaller again?
 
-	    ${ExitDo}	# Just ignore for now.
-	  ${EndIf}
-	${Loop}
-	Delete $TEMP\install.exe
-	Delete $TEMP\vimini.ini   # install.exe creates this, but we don't need it.
+      ${ExitDo}	# Just ignore for now.
+    ${EndIf}
+  ${Loop}
+  Delete $TEMP\install.exe
+  Delete $TEMP\vimini.ini   # install.exe creates this, but we don't need it.
 
-	# We may have been put to the background when uninstall did something.
-	BringToFront
+  # We may have been put to the background when uninstall did something.
+  BringToFront
 SectionEnd
 
 ##########################################################
 Section "$(str_section_exe)" id_section_exe
-	SectionIn 1 2 3 RO
+  SectionIn 1 2 3 RO
 
-	# we need also this here if the user changes the instdir
-	StrCpy $0 "$INSTDIR\vim${VER_MAJOR}${VER_MINOR}"
+  # we need also this here if the user changes the instdir
+  StrCpy $0 "$INSTDIR\vim${VER_MAJOR}${VER_MINOR}"
 
-	SetOutPath $0
-	File /oname=gvim.exe ${VIMSRC}\gvim_ole.exe
-!if /FileExists "${VIMSRC}\vim${BIT}.dll"
-	File ${VIMSRC}\vim${BIT}.dll
-!endif
-	File /oname=install.exe ${VIMSRC}\installw32.exe
-	File /oname=uninstall.exe ${VIMSRC}\uninstallw32.exe
-	File ${VIMSRC}\vimrun.exe
-	File /oname=tee.exe ${VIMSRC}\teew32.exe
-	File /oname=xxd.exe ${VIMSRC}\xxdw32.exe
-	File ..\vimtutor.bat
-	File ..\README.txt
-	File /oname=LICENSE.txt ..\LICENSE
-	File ..\uninstall.txt
-	File ${VIMRT}\*.vim
+  SetOutPath $0
+  File /oname=gvim.exe ${VIMSRC}\gvim_ole.exe
+  !if /FileExists "${VIMSRC}\vim${BIT}.dll"
+    File ${VIMSRC}\vim${BIT}.dll
+  !endif
+  File /oname=install.exe ${VIMSRC}\installw32.exe
+  File /oname=uninstall.exe ${VIMSRC}\uninstallw32.exe
+  File ${VIMSRC}\vimrun.exe
+  File /oname=tee.exe ${VIMSRC}\teew32.exe
+  File /oname=xxd.exe ${VIMSRC}\xxdw32.exe
+  File ..\vimtutor.bat
+  File ..\README.txt
+  File /oname=LICENSE.txt ..\LICENSE
+  File ..\uninstall.txt
+  File ${VIMRT}\*.vim
 
-!if /FileExists "${VIMTOOLS}\diff.exe"
-	File ${VIMTOOLS}\diff.exe
-!endif
-!if /FileExists "${VIMTOOLS}\winpty${BIT}.dll"
-	File ${VIMTOOLS}\winpty${BIT}.dll
-!endif
-!if /FileExists "${VIMTOOLS}\winpty-agent.exe"
-	File ${VIMTOOLS}\winpty-agent.exe
-!endif
-!if /FileExists "${VIMTOOLS}\libsodium.dll"
-	File ${VIMTOOLS}\libsodium.dll
-!endif
+  !if /FileExists "${VIMTOOLS}\diff.exe"
+    File ${VIMTOOLS}\diff.exe
+  !endif
+  !if /FileExists "${VIMTOOLS}\winpty${BIT}.dll"
+    File ${VIMTOOLS}\winpty${BIT}.dll
+  !endif
+  !if /FileExists "${VIMTOOLS}\winpty-agent.exe"
+    File ${VIMTOOLS}\winpty-agent.exe
+  !endif
+  !if /FileExists "${VIMTOOLS}\libsodium.dll"
+    File ${VIMTOOLS}\libsodium.dll
+  !endif
 
-	SetOutPath $0\colors
-	File /r ${VIMRT}\colors\*.*
+  SetOutPath $0\colors
+  File /r ${VIMRT}\colors\*.*
 
-	SetOutPath $0\compiler
-	File ${VIMRT}\compiler\*.*
+  SetOutPath $0\compiler
+  File ${VIMRT}\compiler\*.*
 
-	SetOutPath $0\doc
-	File /x uganda.nsis.txt ${VIMRT}\doc\*.txt
-	File ${VIMRT}\doc\tags
+  SetOutPath $0\doc
+  File /x uganda.nsis.txt ${VIMRT}\doc\*.txt
+  File ${VIMRT}\doc\tags
 
-	SetOutPath $0\ftplugin
-	File ${VIMRT}\ftplugin\*.*
+  SetOutPath $0\ftplugin
+  File ${VIMRT}\ftplugin\*.*
 
-	SetOutPath $0\indent
-	File ${VIMRT}\indent\README.txt
-	File ${VIMRT}\indent\*.vim
+  SetOutPath $0\indent
+  File ${VIMRT}\indent\README.txt
+  File ${VIMRT}\indent\*.vim
 
-	SetOutPath $0\keymap
-	File ${VIMRT}\keymap\README.txt
-	File ${VIMRT}\keymap\*.vim
+  SetOutPath $0\keymap
+  File ${VIMRT}\keymap\README.txt
+  File ${VIMRT}\keymap\*.vim
 
-	SetOutPath $0\macros
-	File /r /x *.info ${VIMRT}\macros\*.*
+  SetOutPath $0\macros
+  File /r /x *.info ${VIMRT}\macros\*.*
 
-	SetOutPath $0\pack
-	File /r ${VIMRT}\pack\*.*
+  SetOutPath $0\pack
+  File /r ${VIMRT}\pack\*.*
 
-	SetOutPath $0\plugin
-	File ${VIMRT}\plugin\*.*
+  SetOutPath $0\plugin
+  File ${VIMRT}\plugin\*.*
 
-	SetOutPath $0\autoload
-	File /r ${VIMRT}\autoload\*.*
+  SetOutPath $0\autoload
+  File /r ${VIMRT}\autoload\*.*
 
-	SetOutPath $0\import\dist
-	File ${VIMRT}\import\dist\*.*
+  SetOutPath $0\import\dist
+  File ${VIMRT}\import\dist\*.*
 
-	SetOutPath $0\bitmaps
-	File ${VIMSRC}\vim.ico
+  SetOutPath $0\bitmaps
+  File ${VIMSRC}\vim.ico
 
-	SetOutPath $0\syntax
-	File /r /x testdir /x generator /x Makefile ${VIMRT}\syntax\*.*
+  SetOutPath $0\syntax
+  File /r /x testdir /x generator /x Makefile ${VIMRT}\syntax\*.*
 
-	SetOutPath $0\spell
-	File ${VIMRT}\spell\*.txt
-	File ${VIMRT}\spell\*.vim
-	File ${VIMRT}\spell\*.spl
-	File ${VIMRT}\spell\*.sug
+  SetOutPath $0\spell
+  File ${VIMRT}\spell\*.txt
+  File ${VIMRT}\spell\*.vim
+  File ${VIMRT}\spell\*.spl
+  File ${VIMRT}\spell\*.sug
 
-	SetOutPath $0\tools
-	File ${VIMRT}\tools\*.*
+  SetOutPath $0\tools
+  File ${VIMRT}\tools\*.*
 
-	SetOutPath $0\tutor
-	File /r /x *.info ${VIMRT}\tutor\*.*
+  SetOutPath $0\tutor
+  File /r /x *.info ${VIMRT}\tutor\*.*
 SectionEnd
 
 ##########################################################
 Section "$(str_section_console)" id_section_console
-	SectionIn 1 3
+  SectionIn 1 3
 
-	SetOutPath $0
-	File /oname=vim.exe ${VIMSRC}\vimw32.exe
-	StrCpy $2 "$2 vim view vimdiff"
+  SetOutPath $0
+  File /oname=vim.exe ${VIMSRC}\vimw32.exe
+  StrCpy $2 "$2 vim view vimdiff"
 SectionEnd
 
 ##########################################################
 Section "$(str_section_batch)" id_section_batch
-	SectionIn 3
+  SectionIn 3
 
-	StrCpy $1 "$1 -create-batfiles $2"
+  StrCpy $1 "$1 -create-batfiles $2"
 SectionEnd
 
 ##########################################################
 SectionGroup $(str_group_icons) id_group_icons
-	Section "$(str_section_desktop)" id_section_desktop
-		SectionIn 1 3
+  Section "$(str_section_desktop)" id_section_desktop
+    SectionIn 1 3
 
-		StrCpy $1 "$1 -install-icons"
-	SectionEnd
+    StrCpy $1 "$1 -install-icons"
+  SectionEnd
 
-	Section "$(str_section_start_menu)" id_section_startmenu
-		SectionIn 1 3
+  Section "$(str_section_start_menu)" id_section_startmenu
+    SectionIn 1 3
 
-		StrCpy $1 "$1 -add-start-menu"
-	SectionEnd
+    StrCpy $1 "$1 -add-start-menu"
+  SectionEnd
 SectionGroupEnd
 
 ##########################################################
 Section "$(str_section_edit_with)" id_section_editwith
-	SectionIn 1 3
+  SectionIn 1 3
 
-	SetOutPath $0
+  SetOutPath $0
 
-	${If} ${RunningX64}
-	  # Install 64-bit gvimext.dll into the GvimExt64 directory.
-	  SetOutPath $0\GvimExt64
-	  ClearErrors
-	  !define LIBRARY_SHELL_EXTENSION
-	  !define LIBRARY_X64
-	  !insertmacro InstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
-	      "${VIMSRC}\GvimExt\gvimext64.dll" \
-	      "$0\GvimExt64\gvimext.dll" "$0"
-	  !undef LIBRARY_X64
-	  !undef LIBRARY_SHELL_EXTENSION
-	${EndIf}
+  ${If} ${RunningX64}
+    # Install 64-bit gvimext.dll into the GvimExt64 directory.
+    SetOutPath $0\GvimExt64
+    ClearErrors
+    !define LIBRARY_SHELL_EXTENSION
+    !define LIBRARY_X64
+    !insertmacro InstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
+	"${VIMSRC}\GvimExt\gvimext64.dll" "$0\GvimExt64\gvimext.dll" "$0"
+    !undef LIBRARY_X64
+    !undef LIBRARY_SHELL_EXTENSION
+  ${EndIf}
 
-	# Install 32-bit gvimext.dll into the GvimExt32 directory.
-	SetOutPath $0\GvimExt32
-	ClearErrors
-	!define LIBRARY_SHELL_EXTENSION
-	!insertmacro InstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
-	    "${VIMSRC}\GvimExt\gvimext.dll" \
-	    "$0\GvimExt32\gvimext.dll" "$0"
-	!undef LIBRARY_SHELL_EXTENSION
+  # Install 32-bit gvimext.dll into the GvimExt32 directory.
+  SetOutPath $0\GvimExt32
+  ClearErrors
+  !define LIBRARY_SHELL_EXTENSION
+  !insertmacro InstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
+      "${VIMSRC}\GvimExt\gvimext.dll" "$0\GvimExt32\gvimext.dll" "$0"
+  !undef LIBRARY_SHELL_EXTENSION
 
-	# We don't have a separate entry for the "Open With..." menu, assume
-	# the user wants either both or none.
-	StrCpy $1 "$1 -install-popup -install-openwith"
+  # We don't have a separate entry for the "Open With..." menu, assume
+  # the user wants either both or none.
+  StrCpy $1 "$1 -install-popup -install-openwith"
 SectionEnd
 
 ##########################################################
 Section "$(str_section_vim_rc)" id_section_vimrc
-	SectionIn 1 3
+  SectionIn 1 3
 
-	StrCpy $1 "$1 -create-vimrc"
+  StrCpy $1 "$1 -create-vimrc"
 
-	${If} ${RunningX64}
-	  SetRegView 64
-	${EndIf}
-	WriteRegStr HKLM "${UNINST_REG_KEY_VIM}" "vim_compat" "$vim_compat_stat"
-	WriteRegStr HKLM "${UNINST_REG_KEY_VIM}" "vim_keyremap" "$vim_keymap_stat"
-	WriteRegStr HKLM "${UNINST_REG_KEY_VIM}" "vim_mouse" "$vim_mouse_stat"
-	${If} ${RunningX64}
-	  SetRegView lastused
-	${EndIf}
+  ${If} ${RunningX64}
+    SetRegView 64
+  ${EndIf}
+  WriteRegStr HKLM "${UNINST_REG_KEY_VIM}" "vim_compat"   "$vim_compat_stat"
+  WriteRegStr HKLM "${UNINST_REG_KEY_VIM}" "vim_keyremap" "$vim_keymap_stat"
+  WriteRegStr HKLM "${UNINST_REG_KEY_VIM}" "vim_mouse"    "$vim_mouse_stat"
+  ${If} ${RunningX64}
+    SetRegView lastused
+  ${EndIf}
 
-	${If} $vim_compat_stat == "vi"
-	  StrCpy $1 "$1 -vimrc-compat vi"
-	${ElseIf} $vim_compat_stat == "vim"
-	  StrCpy $1 "$1 -vimrc-compat vim"
-	${ElseIf} $vim_compat_stat == "defaults"
-	  StrCpy $1 "$1 -vimrc-compat defaults"
-	${Else}
-	  StrCpy $1 "$1 -vimrc-compat all"
-	${EndIf}
+  ${If} $vim_compat_stat == "vi"
+    StrCpy $1 "$1 -vimrc-compat vi"
+  ${ElseIf} $vim_compat_stat == "vim"
+    StrCpy $1 "$1 -vimrc-compat vim"
+  ${ElseIf} $vim_compat_stat == "defaults"
+    StrCpy $1 "$1 -vimrc-compat defaults"
+  ${Else}
+    StrCpy $1 "$1 -vimrc-compat all"
+  ${EndIf}
 
-	${If} $vim_keymap_stat == "default"
-	  StrCpy $1 "$1 -vimrc-remap no"
-	${Else}
-	  StrCpy $1 "$1 -vimrc-remap win"
-	${EndIf}
+  ${If} $vim_keymap_stat == "default"
+    StrCpy $1 "$1 -vimrc-remap no"
+  ${Else}
+    StrCpy $1 "$1 -vimrc-remap win"
+  ${EndIf}
 
-	${If} $vim_mouse_stat == "default"
-	  StrCpy $1 "$1 -vimrc-behave default"
-	${ElseIf} $vim_mouse_stat == "windows"
-	  StrCpy $1 "$1 -vimrc-behave mswin"
-	${Else}
-	  StrCpy $1 "$1 -vimrc-behave unix"
-	${EndIf}
-
+  ${If} $vim_mouse_stat == "default"
+    StrCpy $1 "$1 -vimrc-behave default"
+  ${ElseIf} $vim_mouse_stat == "windows"
+    StrCpy $1 "$1 -vimrc-behave mswin"
+  ${Else}
+    StrCpy $1 "$1 -vimrc-behave unix"
+  ${EndIf}
 SectionEnd
 
 ##########################################################
 SectionGroup $(str_group_plugin) id_group_plugin
-	Section "$(str_section_plugin_home)" id_section_pluginhome
-		SectionIn 1 3
+  Section "$(str_section_plugin_home)" id_section_pluginhome
+    SectionIn 1 3
+    # use ShellExecAsUser below instead
+    # StrCpy $1 "$1 -create-directories home"
+  SectionEnd
 
-		# use ShellExecAsUser below instead
-		# StrCpy $1 "$1 -create-directories home"
-	SectionEnd
-
-	Section "$(str_section_plugin_vim)" id_section_pluginvim
-		SectionIn 3
-
-		StrCpy $1 "$1 -create-directories vim"
-	SectionEnd
+  Section "$(str_section_plugin_vim)" id_section_pluginvim
+    SectionIn 3
+    StrCpy $1 "$1 -create-directories vim"
+  SectionEnd
 SectionGroupEnd
 
 ##########################################################
 !if ${HAVE_NLS}
-Section "$(str_section_nls)" id_section_nls
-	SectionIn 1 3
+  Section "$(str_section_nls)" id_section_nls
+    SectionIn 1 3
 
-	SetOutPath $INSTDIR
-!if /FileExists "..\lang\README.*.txt"
-	File ..\lang\README.*.txt
-	CopyFiles /SILENT /FILESONLY $INSTDIR\README.$lng_usr.txt \
-	       	$INSTDIR\vim${VER_MAJOR}${VER_MINOR}\README.$lng_usr.txt
-	Delete $INSTDIR\README.*.txt
-!endif
-!if /FileExists "..\lang\LICENSE.??.txt"
-	File ..\lang\LICENSE.??.txt
-!if /FileExists "..\lang\LICENSE.??_??.txt"
+    SetOutPath $INSTDIR
+    !if /FileExists "..\lang\README.*.txt"
+      File ..\lang\README.*.txt
+      CopyFiles /SILENT /FILESONLY $INSTDIR\README.$lng_usr.txt \
+	  $INSTDIR\vim${VER_MAJOR}${VER_MINOR}\README.$lng_usr.txt
+      Delete $INSTDIR\README.*.txt
+    !endif
+    !if /FileExists "..\lang\LICENSE.??.txt"
+      File ..\lang\LICENSE.??.txt
+      !if /FileExists "..\lang\LICENSE.??_??.txt"
 	File ..\lang\LICENSE.??_??.txt
-!endif
-	CopyFiles /SILENT /FILESONLY $INSTDIR\LICENSE.$lng_usr.txt \
-	       	$INSTDIR\vim${VER_MAJOR}${VER_MINOR}\LICENSE.$lng_usr.txt
-	Delete $INSTDIR\LICENSE.*.txt
-!endif
+      !endif
+      CopyFiles /SILENT /FILESONLY $INSTDIR\LICENSE.$lng_usr.txt \
+	  $INSTDIR\vim${VER_MAJOR}${VER_MINOR}\LICENSE.$lng_usr.txt
+      Delete $INSTDIR\LICENSE.*.txt
+    !endif
 
-	SetOutPath $0\lang
-	File /r /x Makefile ${VIMRT}\lang\*.*
-	SetOutPath $0
-	!insertmacro InstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
-	    "${GETTEXT}\gettext${BIT}\libintl-8.dll" \
-	    "$0\libintl-8.dll" "$0"
-	!insertmacro InstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
-	    "${GETTEXT}\gettext${BIT}\libiconv-2.dll" \
-	    "$0\libiconv-2.dll" "$0"
-!if ${INCLUDE_LIBGCC}
-!if /FileExists "${GETTEXT}\gettext${BIT}\libgcc_s_sjlj-1.dll"
+    SetOutPath $0\lang
+    File /r /x Makefile ${VIMRT}\lang\*.*
+    SetOutPath $0
+    !insertmacro InstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
+	"${GETTEXT}\gettext${BIT}\libintl-8.dll" "$0\libintl-8.dll" "$0"
+    !insertmacro InstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
+	"${GETTEXT}\gettext${BIT}\libiconv-2.dll" "$0\libiconv-2.dll" "$0"
+    !if ${INCLUDE_LIBGCC}
+      !if /FileExists "${GETTEXT}\gettext${BIT}\libgcc_s_sjlj-1.dll"
 	# Install libgcc_s_sjlj-1.dll only if it is needed.
 	!insertmacro InstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
 	    "${GETTEXT}\gettext${BIT}\libgcc_s_sjlj-1.dll" \
 	    "$0\libgcc_s_sjlj-1.dll" "$0"
-!endif
-!endif
+      !endif
+    !endif
 
-	${If} ${SectionIsSelected} ${id_section_editwith}
-	  ${If} ${RunningX64}
-	    # Install DLLs for 64-bit gvimext.dll into the GvimExt64 directory.
-	    SetOutPath $0\GvimExt64
-	    ClearErrors
-	    !define LIBRARY_X64
-	    !insertmacro InstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
-		"${GETTEXT}\gettext64\libintl-8.dll" \
-		"$0\GvimExt64\libintl-8.dll" "$0\GvimExt64"
-	    !insertmacro InstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
-		"${GETTEXT}\gettext64\libiconv-2.dll" \
-		"$0\GvimExt64\libiconv-2.dll" "$0\GvimExt64"
-	    !undef LIBRARY_X64
-	  ${EndIf}
+    ${If} ${SectionIsSelected} ${id_section_editwith}
+      ${If} ${RunningX64}
+	# Install DLLs for 64-bit gvimext.dll into the GvimExt64 directory.
+	SetOutPath $0\GvimExt64
+	ClearErrors
+	!define LIBRARY_X64
+	!insertmacro InstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
+	    "${GETTEXT}\gettext64\libintl-8.dll" \
+	    "$0\GvimExt64\libintl-8.dll" "$0\GvimExt64"
+	!insertmacro InstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
+	    "${GETTEXT}\gettext64\libiconv-2.dll" \
+	    "$0\GvimExt64\libiconv-2.dll" "$0\GvimExt64"
+	!undef LIBRARY_X64
+      ${EndIf}
 
-	  # Install DLLs for 32-bit gvimext.dll into the GvimExt32 directory.
-	  SetOutPath $0\GvimExt32
-	  ClearErrors
-	  !insertmacro InstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
-	      "${GETTEXT}\gettext32\libintl-8.dll" \
-	      "$0\GvimExt32\libintl-8.dll" "$0\GvimExt32"
-	  !insertmacro InstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
-	      "${GETTEXT}\gettext32\libiconv-2.dll" \
-	      "$0\GvimExt32\libiconv-2.dll" "$0\GvimExt32"
-!if ${INCLUDE_LIBGCC}
-!if /FileExists "${GETTEXT}\gettext32\libgcc_s_sjlj-1.dll"
-	  # Install libgcc_s_sjlj-1.dll only if it is needed.
-	  !insertmacro InstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
-	      "${GETTEXT}\gettext32\libgcc_s_sjlj-1.dll" \
-	      "$0\GvimExt32\libgcc_s_sjlj-1.dll" "$0\GvimExt32"
-!endif
-!endif
-	${EndIf}
-SectionEnd
+      # Install DLLs for 32-bit gvimext.dll into the GvimExt32 directory.
+      SetOutPath $0\GvimExt32
+      ClearErrors
+      !insertmacro InstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
+	  "${GETTEXT}\gettext32\libintl-8.dll" \
+	  "$0\GvimExt32\libintl-8.dll" "$0\GvimExt32"
+      !insertmacro InstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
+	  "${GETTEXT}\gettext32\libiconv-2.dll" \
+	  "$0\GvimExt32\libiconv-2.dll" "$0\GvimExt32"
+      !if ${INCLUDE_LIBGCC}
+	!if /FileExists "${GETTEXT}\gettext32\libgcc_s_sjlj-1.dll"
+	    # Install libgcc_s_sjlj-1.dll only if it is needed.
+	    !insertmacro InstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
+		"${GETTEXT}\gettext32\libgcc_s_sjlj-1.dll" \
+		"$0\GvimExt32\libgcc_s_sjlj-1.dll" "$0\GvimExt32"
+	!endif
+      !endif
+    ${EndIf}
+  SectionEnd
 !endif
 
 ##########################################################
 Section -call_install_exe
-	SetOutPath $0
-	DetailPrint "$(str_msg_registering)"
-	nsExec::Exec "$0\install.exe $1"
-	Pop $3
+  SetOutPath $0
+  DetailPrint "$(str_msg_registering)"
+  nsExec::Exec "$0\install.exe $1"
+  Pop $3
 
-	${If} ${SectionIsSelected} ${id_section_pluginhome}
-	  ReadEnvStr $3 "COMSPEC"
-	  Call GetHomeDir
-	  Pop $4
-	  ShellExecAsUser::ShellExecAsUser "" "$3" '/c "cd /d "$4" & mkdir vimfiles & cd vimfiles & mkdir colors compiler doc ftdetect ftplugin indent keymap plugin syntax"' SW_HIDE
-	${EndIf}
+  ${If} ${SectionIsSelected} ${id_section_pluginhome}
+    ReadEnvStr $3 "COMSPEC"
+    Call GetHomeDir
+    Pop $4
+    ShellExecAsUser::ShellExecAsUser "" "$3" '/c "cd /d "$4" & mkdir vimfiles \
+	& cd vimfiles & mkdir colors compiler doc ftdetect ftplugin indent \
+	keymap plugin syntax"' SW_HIDE
+  ${EndIf}
 SectionEnd
 
 ##########################################################
 !macro SaveSectionSelection section_id reg_value
-	${If} ${SectionIsSelected} ${section_id}
-	  WriteRegDWORD HKLM "${UNINST_REG_KEY_VIM}" ${reg_value} 1
-	${Else}
-	  WriteRegDWORD HKLM "${UNINST_REG_KEY_VIM}" ${reg_value} 0
-	${EndIf}
+  ${If} ${SectionIsSelected} ${section_id}
+    WriteRegDWORD HKLM "${UNINST_REG_KEY_VIM}" ${reg_value} 1
+  ${Else}
+    WriteRegDWORD HKLM "${UNINST_REG_KEY_VIM}" ${reg_value} 0
+  ${EndIf}
 !macroend
 
 Section -post
+  # Get estimated install size
+  SectionGetSize ${id_section_exe} $3
+  ${If} ${SectionIsSelected} ${id_section_console}
+    SectionGetSize ${id_section_console} $4
+    IntOp $3 $3 + $4
+  ${EndIf}
+  ${If} ${SectionIsSelected} ${id_section_editwith}
+    SectionGetSize ${id_section_editwith} $4
+    IntOp $3 $3 + $4
+  ${EndIf}
+  !if ${HAVE_NLS}
+    ${If} ${SectionIsSelected} ${id_section_nls}
+      SectionGetSize ${id_section_nls} $4
+      IntOp $3 $3 + $4
+    ${EndIf}
+  !endif
 
-	# Get estimated install size
-	SectionGetSize ${id_section_exe} $3
-	${If} ${SectionIsSelected} ${id_section_console}
-	  SectionGetSize ${id_section_console} $4
-	  IntOp $3 $3 + $4
-	${EndIf}
-	${If} ${SectionIsSelected} ${id_section_editwith}
-	  SectionGetSize ${id_section_editwith} $4
-	  IntOp $3 $3 + $4
-	${EndIf}
-!if ${HAVE_NLS}
-	${If} ${SectionIsSelected} ${id_section_nls}
-	  SectionGetSize ${id_section_nls} $4
-	  IntOp $3 $3 + $4
-	${EndIf}
-!endif
+  # Register EstimatedSize and AllowSilent.
+  # Other information will be set by the install.exe (dosinst.c).
+  ${If} ${RunningX64}
+    SetRegView 64
+  ${EndIf}
+  WriteRegDWORD HKLM "${UNINST_REG_KEY_VIM}" "EstimatedSize" $3
+  WriteRegDWORD HKLM "${UNINST_REG_KEY_VIM}" "AllowSilent" 1
+  ${If} ${RunningX64}
+    SetRegView lastused
+  ${EndIf}
 
-	# Register EstimatedSize and AllowSilent.
-	# Other information will be set by the install.exe (dosinst.c).
-	${If} ${RunningX64}
-	  SetRegView 64
-	${EndIf}
-	WriteRegDWORD HKLM "${UNINST_REG_KEY_VIM}" "EstimatedSize" $3
-	WriteRegDWORD HKLM "${UNINST_REG_KEY_VIM}" "AllowSilent" 1
-	${If} ${RunningX64}
-	  SetRegView lastused
-	${EndIf}
+  # Store the selections to the registry.
+  ${If} ${RunningX64}
+    SetRegView 64
+  ${EndIf}
+  !insertmacro SaveSectionSelection ${id_section_console}    "select_console"
+  !insertmacro SaveSectionSelection ${id_section_batch}      "select_batch"
+  !insertmacro SaveSectionSelection ${id_section_desktop}    "select_desktop"
+  !insertmacro SaveSectionSelection ${id_section_startmenu}  "select_startmenu"
+  !insertmacro SaveSectionSelection ${id_section_editwith}   "select_editwith"
+  !insertmacro SaveSectionSelection ${id_section_vimrc}      "select_vimrc"
+  !insertmacro SaveSectionSelection ${id_section_pluginhome} \
+      "select_pluginhome"
+  !insertmacro SaveSectionSelection ${id_section_pluginvim}  "select_pluginvim"
+  !if ${HAVE_NLS}
+    !insertmacro SaveSectionSelection ${id_section_nls}      "select_nls"
+  !endif
+  ${If} ${RunningX64}
+    SetRegView lastused
+  ${EndIf}
 
-	# Store the selections to the registry.
-	${If} ${RunningX64}
-	  SetRegView 64
-	${EndIf}
-	!insertmacro SaveSectionSelection ${id_section_console}    "select_console"
-	!insertmacro SaveSectionSelection ${id_section_batch}      "select_batch"
-	!insertmacro SaveSectionSelection ${id_section_desktop}    "select_desktop"
-	!insertmacro SaveSectionSelection ${id_section_startmenu}  "select_startmenu"
-	!insertmacro SaveSectionSelection ${id_section_editwith}   "select_editwith"
-	!insertmacro SaveSectionSelection ${id_section_vimrc}      "select_vimrc"
-	!insertmacro SaveSectionSelection ${id_section_pluginhome} "select_pluginhome"
-	!insertmacro SaveSectionSelection ${id_section_pluginvim}  "select_pluginvim"
-!if ${HAVE_NLS}
-	!insertmacro SaveSectionSelection ${id_section_nls}        "select_nls"
-!endif
-	${If} ${RunningX64}
-	  SetRegView lastused
-	${EndIf}
-
-	BringToFront
+  BringToFront
 SectionEnd
 
 ##########################################################
 !macro LoadSectionSelection section_id reg_value
-	ClearErrors
-	ReadRegDWORD $3 HKLM "${UNINST_REG_KEY_VIM}" ${reg_value}
-	${IfNot} ${Errors}
-	  ${If} $3 = 1
-	    !insertmacro SelectSection ${section_id}
-	  ${Else}
-	    !insertmacro UnselectSection ${section_id}
-	  ${EndIf}
-	${EndIf}
+  ClearErrors
+  ReadRegDWORD $3 HKLM "${UNINST_REG_KEY_VIM}" ${reg_value}
+  ${IfNot} ${Errors}
+    ${If} $3 = 1
+      !insertmacro SelectSection ${section_id}
+    ${Else}
+      !insertmacro UnselectSection ${section_id}
+    ${EndIf}
+  ${EndIf}
 !macroend
 
 !macro LoadDefaultVimrc out_var reg_value default_value
-	ClearErrors
-	ReadRegStr ${out_var} HKLM "${UNINST_REG_KEY_VIM}" ${reg_value}
-	${If} ${Errors}
-	${OrIf} ${out_var} == ""
-	  StrCpy ${out_var} ${default_value}
-	${EndIf}
+  ClearErrors
+  ReadRegStr ${out_var} HKLM "${UNINST_REG_KEY_VIM}" ${reg_value}
+  ${If} ${Errors}
+  ${OrIf} ${out_var} == ""
+    StrCpy ${out_var} ${default_value}
+  ${EndIf}
 !macroend
 
 Function .onInit
-!if ${HAVE_MULTI_LANG}
-  # Select a language (or read from the registry).
-  !insertmacro MUI_LANGDLL_DISPLAY
-!endif
+  !if ${HAVE_MULTI_LANG}
+    # Select a language (or read from the registry).
+    !insertmacro MUI_LANGDLL_DISPLAY
+  !endif
 
-!if ${HAVE_NLS}
-  ClearErrors
-  System::Call 'kernel32::GetUserDefaultLocaleName(t.r19, *i${NSIS_MAX_STRLEN})'
-  StrCmp $R9 "zh-cn" coincide 0
-  StrCmp $R9 "zh-tw" coincide 0
-  StrCmp $R9 "pt-br" 0 part
-  coincide:
-  System::Call 'User32::CharLower(t r19 r19)*i${NSIS_MAX_STRLEN}'
-  ${StrRep} $lng_usr "$R9" "-" "_"
-  Goto done
-  part:
-  StrCpy $lng_usr $R9 2
-  done:
-!endif
+  !if ${HAVE_NLS}
+    ClearErrors
+    System::Call \
+	'kernel32::GetUserDefaultLocaleName(t.r19, *i${NSIS_MAX_STRLEN})'
+    StrCmp $R9 "zh-cn" coincide 0
+    StrCmp $R9 "zh-tw" coincide 0
+    StrCmp $R9 "pt-br" 0 part
+    coincide:
+    System::Call 'User32::CharLower(t r19 r19)*i${NSIS_MAX_STRLEN}'
+    ${StrRep} $lng_usr "$R9" "-" "_"
+    Goto done
+    part:
+    StrCpy $lng_usr $R9 2
+    done:
+  !endif
 
   ${If} $INSTDIR == ${DEFAULT_INSTDIR}
     # Check $VIM
@@ -865,15 +863,16 @@ Function .onInit
   !insertmacro LoadSectionSelection ${id_section_startmenu}  "select_startmenu"
   !insertmacro LoadSectionSelection ${id_section_editwith}   "select_editwith"
   !insertmacro LoadSectionSelection ${id_section_vimrc}      "select_vimrc"
-  !insertmacro LoadSectionSelection ${id_section_pluginhome} "select_pluginhome"
+  !insertmacro LoadSectionSelection ${id_section_pluginhome} \
+      "select_pluginhome"
   !insertmacro LoadSectionSelection ${id_section_pluginvim}  "select_pluginvim"
-!if ${HAVE_NLS}
-  !insertmacro LoadSectionSelection ${id_section_nls}        "select_nls"
-!endif
+  !if ${HAVE_NLS}
+    !insertmacro LoadSectionSelection ${id_section_nls}      "select_nls"
+  !endif
   # Load the default _vimrc settings from the registry (if any).
-  !insertmacro LoadDefaultVimrc $vim_compat_stat "vim_compat" "all"
+  !insertmacro LoadDefaultVimrc $vim_compat_stat "vim_compat"   "all"
   !insertmacro LoadDefaultVimrc $vim_keymap_stat "vim_keyremap" "default"
-  !insertmacro LoadDefaultVimrc $vim_mouse_stat "vim_mouse" "default"
+  !insertmacro LoadDefaultVimrc $vim_mouse_stat  "vim_mouse"    "default"
   ${If} ${RunningX64}
     SetRegView lastused
   ${EndIf}
@@ -899,151 +898,152 @@ FunctionEnd
 
 ##########################################################
 Function SetCustom
-	# Display the _vimrc setting dialog using nsDialogs.
+  # Display the _vimrc setting dialog using nsDialogs.
 
-	# Check if a _vimrc should be created
-	${IfNot} ${SectionIsSelected} ${id_section_vimrc}
-	  Abort
-	${EndIf}
+  # Check if a _vimrc should be created
+  ${IfNot} ${SectionIsSelected} ${id_section_vimrc}
+    Abort
+  ${EndIf}
 
-	!insertmacro MUI_HEADER_TEXT \
-	    $(str_vimrc_page_title) $(str_vimrc_page_subtitle)
+  !insertmacro MUI_HEADER_TEXT \
+      $(str_vimrc_page_title) $(str_vimrc_page_subtitle)
 
-	nsDialogs::Create 1018
-	Pop $vim_dialog
+  nsDialogs::Create 1018
+  Pop $vim_dialog
 
-	${If} $vim_dialog == error
-	  Abort
-	${EndIf}
+  ${If} $vim_dialog == error
+    Abort
+  ${EndIf}
 
-	${If} ${RunningX64}
-	  SetRegView 64
-	${EndIf}
+  ${If} ${RunningX64}
+    SetRegView 64
+  ${EndIf}
 
-	GetFunctionAddress $3 ValidateCustom
-	nsDialogs::OnBack $3
+  GetFunctionAddress $3 ValidateCustom
+  nsDialogs::OnBack $3
 
+  # 1st group - Compatibility
+  ${NSD_CreateGroupBox} 0u 0u 296u 44u $(str_msg_compat_title)
+  Pop $3
 
-	# 1st group - Compatibility
-	${NSD_CreateGroupBox} 0u 0u 296u 44u $(str_msg_compat_title)
-	Pop $3
+  ${NSD_CreateLabel} 16u 14u 269u 10u $(str_msg_compat_desc)
+  Pop $3
+  ${NSD_CreateDropList} 42u 26u 237u 13u ""
+  Pop $vim_nsd_compat
+  ${NSD_CB_AddString} $vim_nsd_compat $(str_msg_compat_vi)
+  ${NSD_CB_AddString} $vim_nsd_compat $(str_msg_compat_vim)
+  ${NSD_CB_AddString} $vim_nsd_compat $(str_msg_compat_defaults)
+  ${NSD_CB_AddString} $vim_nsd_compat $(str_msg_compat_all)
 
-	${NSD_CreateLabel} 16u 14u 269u 10u $(str_msg_compat_desc)
-	Pop $3
-	${NSD_CreateDropList} 42u 26u 237u 13u ""
-	Pop $vim_nsd_compat
-	${NSD_CB_AddString} $vim_nsd_compat $(str_msg_compat_vi)
-	${NSD_CB_AddString} $vim_nsd_compat $(str_msg_compat_vim)
-	${NSD_CB_AddString} $vim_nsd_compat $(str_msg_compat_defaults)
-	${NSD_CB_AddString} $vim_nsd_compat $(str_msg_compat_all)
+  ${If} $vim_compat_stat == "defaults"
+    StrCpy $4 2
+  ${ElseIf} $vim_compat_stat == "vim"
+    StrCpy $4 1
+  ${ElseIf} $vim_compat_stat == "vi"
+    StrCpy $4 0
+  ${Else} # default
+    StrCpy $4 3
+  ${EndIf}
+  ${NSD_CB_SetSelectionIndex} $vim_nsd_compat $4
 
-	${If} $vim_compat_stat == "defaults"
-	  StrCpy $4 2
-	${ElseIf} $vim_compat_stat == "vim"
-	  StrCpy $4 1
-	${ElseIf} $vim_compat_stat == "vi"
-	  StrCpy $4 0
-	${Else} # default
-	  StrCpy $4 3
-	${EndIf}
-	${NSD_CB_SetSelectionIndex} $vim_nsd_compat $4
+  # 2nd group - Key remapping
+  ${NSD_CreateGroupBox} 0u 48u 296u 44u $(str_msg_keymap_title)
+  Pop $3
 
+  ${NSD_CreateLabel} 16u 62u 269u 10u $(str_msg_keymap_desc)
+  Pop $3
+  ${NSD_CreateDropList} 42u 74u 236u 13u ""
+  Pop $vim_nsd_keymap
+  ${NSD_CB_AddString} $vim_nsd_keymap $(str_msg_keymap_default)
+  ${NSD_CB_AddString} $vim_nsd_keymap $(str_msg_keymap_windows)
 
-	# 2nd group - Key remapping
-	${NSD_CreateGroupBox} 0u 48u 296u 44u $(str_msg_keymap_title)
-	Pop $3
+  ${If} $vim_keymap_stat == "windows"
+    StrCpy $4 1
+  ${Else} # default
+    StrCpy $4 0
+  ${EndIf}
+  ${NSD_CB_SetSelectionIndex} $vim_nsd_keymap $4
 
-	${NSD_CreateLabel} 16u 62u 269u 10u $(str_msg_keymap_desc)
-	Pop $3
-	${NSD_CreateDropList} 42u 74u 236u 13u ""
-	Pop $vim_nsd_keymap
-	${NSD_CB_AddString} $vim_nsd_keymap $(str_msg_keymap_default)
-	${NSD_CB_AddString} $vim_nsd_keymap $(str_msg_keymap_windows)
+  # 3rd group - Mouse behavior
+  ${NSD_CreateGroupBox} 0u 95u 296u 44u $(str_msg_mouse_title)
+  Pop $3
 
-	${If} $vim_keymap_stat == "windows"
-	  StrCpy $4 1
-	${Else} # default
-	  StrCpy $4 0
-	${EndIf}
-	${NSD_CB_SetSelectionIndex} $vim_nsd_keymap $4
+  ${NSD_CreateLabel} 16u 108u 269u 10u $(str_msg_mouse_desc)
+  Pop $3
+  ${NSD_CreateDropList} 42u 121u 237u 13u ""
+  Pop $vim_nsd_mouse
+  ${NSD_CB_AddString} $vim_nsd_mouse $(str_msg_mouse_default)
+  ${NSD_CB_AddString} $vim_nsd_mouse $(str_msg_mouse_windows)
+  ${NSD_CB_AddString} $vim_nsd_mouse $(str_msg_mouse_unix)
 
+  ${If} $vim_mouse_stat == "xterm"
+    StrCpy $4 2
+  ${ElseIf} $vim_mouse_stat == "windows"
+    StrCpy $4 1
+  ${Else} # default
+    StrCpy $4 0
+  ${EndIf}
+  ${NSD_CB_SetSelectionIndex} $vim_nsd_mouse $4
 
-	# 3rd group - Mouse behavior
-	${NSD_CreateGroupBox} 0u 95u 296u 44u $(str_msg_mouse_title)
-	Pop $3
+  ${If} ${RunningX64}
+    SetRegView lastused
+  ${EndIf}
 
-	${NSD_CreateLabel} 16u 108u 269u 10u $(str_msg_mouse_desc)
-	Pop $3
-	${NSD_CreateDropList} 42u 121u 237u 13u ""
-	Pop $vim_nsd_mouse
-	${NSD_CB_AddString} $vim_nsd_mouse $(str_msg_mouse_default)
-	${NSD_CB_AddString} $vim_nsd_mouse $(str_msg_mouse_windows)
-	${NSD_CB_AddString} $vim_nsd_mouse $(str_msg_mouse_unix)
-
-	${If} $vim_mouse_stat == "xterm"
-	  StrCpy $4 2
-	${ElseIf} $vim_mouse_stat == "windows"
-	  StrCpy $4 1
-	${Else} # default
-	  StrCpy $4 0
-	${EndIf}
-	${NSD_CB_SetSelectionIndex} $vim_nsd_mouse $4
-
-	${If} ${RunningX64}
-	  SetRegView lastused
-	${EndIf}
-
-	nsDialogs::Show
+  nsDialogs::Show
 FunctionEnd
 
 Function ValidateCustom
-	${NSD_CB_GetSelectionIndex} $vim_nsd_compat $3
-	${If} $3 = 0
-	  StrCpy $vim_compat_stat "vi"
-	${ElseIf} $3 = 1
-	  StrCpy $vim_compat_stat "vim"
-	${ElseIf} $3 = 2
-	  StrCpy $vim_compat_stat "defaults"
-	${Else}
-	  StrCpy $vim_compat_stat "all"
-	${EndIf}
+  ${NSD_CB_GetSelectionIndex} $vim_nsd_compat $3
+  ${If} $3 = 0
+    StrCpy $vim_compat_stat "vi"
+  ${ElseIf} $3 = 1
+    StrCpy $vim_compat_stat "vim"
+  ${ElseIf} $3 = 2
+    StrCpy $vim_compat_stat "defaults"
+  ${Else}
+    StrCpy $vim_compat_stat "all"
+  ${EndIf}
 
-	${NSD_CB_GetSelectionIndex} $vim_nsd_keymap $3
-	${If} $3 = 0
-	  StrCpy $vim_keymap_stat "default"
-	${Else}
-	  StrCpy $vim_keymap_stat "windows"
-	${EndIf}
+  ${NSD_CB_GetSelectionIndex} $vim_nsd_keymap $3
+  ${If} $3 = 0
+    StrCpy $vim_keymap_stat "default"
+  ${Else}
+    StrCpy $vim_keymap_stat "windows"
+  ${EndIf}
 
-	${NSD_CB_GetSelectionIndex} $vim_nsd_mouse $3
-	${If} $3 = 0
-	  StrCpy $vim_mouse_stat "default"
-	${ElseIf} $3 = 1
-	  StrCpy $vim_mouse_stat "windows"
-	${Else}
-	  StrCpy $vim_mouse_stat "xterm"
-	${EndIf}
+  ${NSD_CB_GetSelectionIndex} $vim_nsd_mouse $3
+  ${If} $3 = 0
+    StrCpy $vim_mouse_stat "default"
+  ${ElseIf} $3 = 1
+    StrCpy $vim_mouse_stat "windows"
+  ${Else}
+    StrCpy $vim_mouse_stat "xterm"
+  ${EndIf}
 FunctionEnd
 
 ##########################################################
 # Description for Installer Sections
 
 !insertmacro MUI_FUNCTION_DESCRIPTION_BEGIN
-    !insertmacro MUI_DESCRIPTION_TEXT ${id_section_old_ver}     $(str_desc_old_ver)
-    !insertmacro MUI_DESCRIPTION_TEXT ${id_section_exe}         $(str_desc_exe)
-    !insertmacro MUI_DESCRIPTION_TEXT ${id_section_console}     $(str_desc_console)
-    !insertmacro MUI_DESCRIPTION_TEXT ${id_section_batch}       $(str_desc_batch)
-    !insertmacro MUI_DESCRIPTION_TEXT ${id_group_icons}         $(str_desc_icons)
-    !insertmacro MUI_DESCRIPTION_TEXT ${id_section_desktop}     $(str_desc_desktop)
-    !insertmacro MUI_DESCRIPTION_TEXT ${id_section_startmenu}   $(str_desc_start_menu)
-    !insertmacro MUI_DESCRIPTION_TEXT ${id_section_editwith}    $(str_desc_edit_with)
-    !insertmacro MUI_DESCRIPTION_TEXT ${id_section_vimrc}       $(str_desc_vim_rc)
-    !insertmacro MUI_DESCRIPTION_TEXT ${id_group_plugin}        $(str_desc_plugin)
-    !insertmacro MUI_DESCRIPTION_TEXT ${id_section_pluginhome}  $(str_desc_plugin_home)
-    !insertmacro MUI_DESCRIPTION_TEXT ${id_section_pluginvim}   $(str_desc_plugin_vim)
-!if ${HAVE_NLS}
-    !insertmacro MUI_DESCRIPTION_TEXT ${id_section_nls}         $(str_desc_nls)
-!endif
+  !insertmacro MUI_DESCRIPTION_TEXT ${id_section_old_ver}   $(str_desc_old_ver)
+  !insertmacro MUI_DESCRIPTION_TEXT ${id_section_exe}	    $(str_desc_exe)
+  !insertmacro MUI_DESCRIPTION_TEXT ${id_section_console}   $(str_desc_console)
+  !insertmacro MUI_DESCRIPTION_TEXT ${id_section_batch}	    $(str_desc_batch)
+  !insertmacro MUI_DESCRIPTION_TEXT ${id_group_icons}	    $(str_desc_icons)
+  !insertmacro MUI_DESCRIPTION_TEXT ${id_section_desktop}   $(str_desc_desktop)
+  !insertmacro MUI_DESCRIPTION_TEXT ${id_section_startmenu} \
+      $(str_desc_start_menu)
+  !insertmacro MUI_DESCRIPTION_TEXT ${id_section_editwith}  \
+      $(str_desc_edit_with)
+  !insertmacro MUI_DESCRIPTION_TEXT ${id_section_vimrc}	    $(str_desc_vim_rc)
+  !insertmacro MUI_DESCRIPTION_TEXT ${id_group_plugin}	    $(str_desc_plugin)
+  !insertmacro MUI_DESCRIPTION_TEXT ${id_section_pluginhome} \
+      $(str_desc_plugin_home)
+  !insertmacro MUI_DESCRIPTION_TEXT ${id_section_pluginvim} \
+      $(str_desc_plugin_vim)
+  !if ${HAVE_NLS}
+    !insertmacro MUI_DESCRIPTION_TEXT ${id_section_nls}	    $(str_desc_nls)
+  !endif
 !insertmacro MUI_FUNCTION_DESCRIPTION_END
 
 
@@ -1051,192 +1051,197 @@ FunctionEnd
 # Uninstaller Functions and Sections
 
 Function un.onInit
-!if ${HAVE_MULTI_LANG}
-  # Get the language from the registry.
-  !insertmacro MUI_UNGETLANGUAGE
-!endif
+  !if ${HAVE_MULTI_LANG}
+    # Get the language from the registry.
+    !insertmacro MUI_UNGETLANGUAGE
+  !endif
 FunctionEnd
 
 Section "un.$(str_unsection_register)" id_unsection_register
-	SectionIn RO
+  SectionIn RO
 
-	# Apparently $INSTDIR is set to the directory where the uninstaller is
-	# created.  Thus the "vim91" directory is included in it.
-	StrCpy $0 "$INSTDIR"
+  # Apparently $INSTDIR is set to the directory where the uninstaller is
+  # created.  Thus the "vim91" directory is included in it.
+  StrCpy $0 "$INSTDIR"
 
-	# delete the context menu entry and batch files
-	DetailPrint "$(str_msg_unregistering)"
-	nsExec::Exec "$0\uninstall.exe -nsis"
-	Pop $3
+  # delete the context menu entry and batch files
+  DetailPrint "$(str_msg_unregistering)"
+  nsExec::Exec "$0\uninstall.exe -nsis"
+  Pop $3
 
-	# We may have been put to the background when uninstall did something.
-	BringToFront
+  # We may have been put to the background when uninstall did something.
+  BringToFront
 
-	# Delete the installer language setting.
-	DeleteRegKey ${MUI_LANGDLL_REGISTRY_ROOT} ${MUI_LANGDLL_REGISTRY_KEY}
+  # Delete the installer language setting.
+  DeleteRegKey ${MUI_LANGDLL_REGISTRY_ROOT} ${MUI_LANGDLL_REGISTRY_KEY}
 SectionEnd
 
 Section "un.$(str_unsection_exe)" id_unsection_exe
+  StrCpy $0 "$INSTDIR"
 
-	StrCpy $0 "$INSTDIR"
+  # Delete gettext and iconv DLLs
+  ${If} ${FileExists} "$0\libiconv-2.dll"
+    !insertmacro UninstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
+	"$0\libiconv-2.dll"
+  ${EndIf}
+  ${If} ${FileExists} "$0\libintl-8.dll"
+    !insertmacro UninstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
+	"$0\libintl-8.dll"
+  ${EndIf}
+  ${If} ${FileExists} "$0\libgcc_s_sjlj-1.dll"
+    !insertmacro UninstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
+	"$0\libgcc_s_sjlj-1.dll"
+  ${EndIf}
 
-	# Delete gettext and iconv DLLs
-	${If} ${FileExists} "$0\libiconv-2.dll"
-	  !insertmacro UninstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
-	      "$0\libiconv-2.dll"
-	${EndIf}
-	${If} ${FileExists} "$0\libintl-8.dll"
-	  !insertmacro UninstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
-	      "$0\libintl-8.dll"
-	${EndIf}
-	${If} ${FileExists} "$0\libgcc_s_sjlj-1.dll"
-	  !insertmacro UninstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
-	      "$0\libgcc_s_sjlj-1.dll"
-	${EndIf}
+  # Delete other DLLs
+  Delete /REBOOTOK $0\*.dll
 
-	# Delete other DLLs
-	Delete /REBOOTOK $0\*.dll
+  # Delete 64-bit GvimExt
+  ${If} ${RunningX64}
+    !define LIBRARY_X64
+    ${If} ${FileExists} "$0\GvimExt64\gvimext.dll"
+      !insertmacro UninstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
+	  "$0\GvimExt64\gvimext.dll"
+    ${EndIf}
+    ${If} ${FileExists} "$0\GvimExt64\libiconv-2.dll"
+      !insertmacro UninstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
+	  "$0\GvimExt64\libiconv-2.dll"
+    ${EndIf}
+    ${If} ${FileExists} "$0\GvimExt64\libintl-8.dll"
+      !insertmacro UninstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
+	  "$0\GvimExt64\libintl-8.dll"
+    ${EndIf}
+    ${If} ${FileExists} "$0\GvimExt64\libwinpthread-1.dll"
+      !insertmacro UninstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
+	  "$0\GvimExt64\libwinpthread-1.dll"
+    ${EndIf}
+    !undef LIBRARY_X64
+    RMDir /r $0\GvimExt64
+  ${EndIf}
 
-	# Delete 64-bit GvimExt
-	${If} ${RunningX64}
-	  !define LIBRARY_X64
-	  ${If} ${FileExists} "$0\GvimExt64\gvimext.dll"
-	    !insertmacro UninstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
-		"$0\GvimExt64\gvimext.dll"
-	  ${EndIf}
-	  ${If} ${FileExists} "$0\GvimExt64\libiconv-2.dll"
-	    !insertmacro UninstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
-		"$0\GvimExt64\libiconv-2.dll"
-	  ${EndIf}
-	  ${If} ${FileExists} "$0\GvimExt64\libintl-8.dll"
-	    !insertmacro UninstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
-		"$0\GvimExt64\libintl-8.dll"
-	  ${EndIf}
-	  ${If} ${FileExists} "$0\GvimExt64\libwinpthread-1.dll"
-	    !insertmacro UninstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
-		"$0\GvimExt64\libwinpthread-1.dll"
-	  ${EndIf}
-	  !undef LIBRARY_X64
-	  RMDir /r $0\GvimExt64
-	${EndIf}
+  # Delete 32-bit GvimExt
+  ${If} ${FileExists} "$0\GvimExt32\gvimext.dll"
+    !insertmacro UninstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
+	"$0\GvimExt32\gvimext.dll"
+  ${EndIf}
+  ${If} ${FileExists} "$0\GvimExt32\libiconv-2.dll"
+    !insertmacro UninstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
+	"$0\GvimExt32\libiconv-2.dll"
+  ${EndIf}
+  ${If} ${FileExists} "$0\GvimExt32\libintl-8.dll"
+    !insertmacro UninstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
+	"$0\GvimExt32\libintl-8.dll"
+  ${EndIf}
+  ${If} ${FileExists} "$0\GvimExt32\libgcc_s_sjlj-1.dll"
+    !insertmacro UninstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
+	"$0\GvimExt32\libgcc_s_sjlj-1.dll"
+  ${EndIf}
+  RMDir /r $0\GvimExt32
 
-	# Delete 32-bit GvimExt
-	${If} ${FileExists} "$0\GvimExt32\gvimext.dll"
-	  !insertmacro UninstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
-	      "$0\GvimExt32\gvimext.dll"
-	${EndIf}
-	${If} ${FileExists} "$0\GvimExt32\libiconv-2.dll"
-	  !insertmacro UninstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
-	      "$0\GvimExt32\libiconv-2.dll"
-	${EndIf}
-	${If} ${FileExists} "$0\GvimExt32\libintl-8.dll"
-	  !insertmacro UninstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
-	      "$0\GvimExt32\libintl-8.dll"
-	${EndIf}
-	${If} ${FileExists} "$0\GvimExt32\libgcc_s_sjlj-1.dll"
-	  !insertmacro UninstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
-	      "$0\GvimExt32\libgcc_s_sjlj-1.dll"
-	${EndIf}
-	RMDir /r $0\GvimExt32
+  ClearErrors
+  # Remove everything but *.dll files.  Avoids that
+  # a lot remains when gvimext.dll cannot be deleted.
+  RMDir /r $0\autoload
+  RMDir /r $0\colors
+  RMDir /r $0\compiler
+  RMDir /r $0\doc
+  RMDir /r $0\ftplugin
+  RMDir /r $0\import
+  RMDir /r $0\indent
+  RMDir /r $0\macros
+  RMDir /r $0\pack
+  RMDir /r $0\plugin
+  RMDir /r $0\spell
+  RMDir /r $0\syntax
+  RMDir /r $0\tools
+  RMDir /r $0\tutor
+  RMDir /r $0\lang
+  RMDir /r $0\keymap
+  RMDir /r $0\bitmaps
+  Delete $0\*.exe
+  Delete $0\*.bat
+  Delete $0\*.vim
+  Delete $0\*.txt
 
-	ClearErrors
-	# Remove everything but *.dll files.  Avoids that
-	# a lot remains when gvimext.dll cannot be deleted.
-	RMDir /r $0\autoload
-	RMDir /r $0\colors
-	RMDir /r $0\compiler
-	RMDir /r $0\doc
-	RMDir /r $0\ftplugin
-	RMDir /r $0\import
-	RMDir /r $0\indent
-	RMDir /r $0\macros
-	RMDir /r $0\pack
-	RMDir /r $0\plugin
-	RMDir /r $0\spell
-	RMDir /r $0\syntax
-	RMDir /r $0\tools
-	RMDir /r $0\tutor
-	RMDir /r $0\lang
-	RMDir /r $0\keymap
-	RMDir /r $0\bitmaps
-	Delete $0\*.exe
-	Delete $0\*.bat
-	Delete $0\*.vim
-	Delete $0\*.txt
+  ${If} ${Errors}
+    MessageBox MB_OK|MB_ICONEXCLAMATION $(str_msg_rm_exe_fail) /SD IDOK
+  ${EndIf}
 
-	${If} ${Errors}
-	  MessageBox MB_OK|MB_ICONEXCLAMATION $(str_msg_rm_exe_fail) /SD IDOK
-	${EndIf}
-
-	# No error message if the "vim91" directory can't be removed, the
-	# gvimext.dll may still be there.
-	RMDir $0
+  # No error message if the "vim91" directory can't be removed, the
+  # gvimext.dll may still be there.
+  RMDir $0
 SectionEnd
 
 # Remove "vimfiles" directory under the specified directory.
 !macro RemoveVimfiles dir
-	${If} ${FileExists} ${dir}\_viminfo
-	  Delete ${dir}\_viminfo
-	${EndIf}
-	${If} ${DirExists} ${dir}\vimfiles
-	  RMDir ${dir}\vimfiles\colors
-	  RMDir ${dir}\vimfiles\compiler
-	  RMDir ${dir}\vimfiles\doc
-	  RMDir ${dir}\vimfiles\ftdetect
-	  RMDir ${dir}\vimfiles\ftplugin
-	  RMDir ${dir}\vimfiles\indent
-	  RMDir ${dir}\vimfiles\keymap
-	  RMDir ${dir}\vimfiles\plugin
-	  RMDir ${dir}\vimfiles\syntax
-	  ${If} ${FileExists} ${dir}\vimfiles\.netrwhist*
-	    Delete ${dir}\vimfiles\.netrwhist*
-	  ${EndIf}
-	  RMDir ${dir}\vimfiles
-	${EndIf}
+  ${If} ${FileExists} ${dir}\_viminfo
+    Delete ${dir}\_viminfo
+  ${EndIf}
+  ${If} ${DirExists} ${dir}\vimfiles
+    RMDir ${dir}\vimfiles\colors
+    RMDir ${dir}\vimfiles\compiler
+    RMDir ${dir}\vimfiles\doc
+    RMDir ${dir}\vimfiles\ftdetect
+    RMDir ${dir}\vimfiles\ftplugin
+    RMDir ${dir}\vimfiles\indent
+    RMDir ${dir}\vimfiles\keymap
+    RMDir ${dir}\vimfiles\plugin
+    RMDir ${dir}\vimfiles\syntax
+    ${If} ${FileExists} ${dir}\vimfiles\.netrwhist*
+      Delete ${dir}\vimfiles\.netrwhist*
+    ${EndIf}
+    RMDir ${dir}\vimfiles
+  ${EndIf}
 !macroend
 
 SectionGroup "un.$(str_ungroup_plugin)" id_ungroup_plugin
-	Section /o "un.$(str_unsection_plugin_home)" id_unsection_plugin_home
-		# get the home dir
-		Call un.GetHomeDir
-		Pop $0
+  Section /o "un.$(str_unsection_plugin_home)" id_unsection_plugin_home
+  # get the home dir
+    Call un.GetHomeDir
+    Pop $0
 
-		${If} $0 != ""
-		  !insertmacro RemoveVimfiles $0
-		${EndIf}
-	SectionEnd
+    ${If} $0 != ""
+      !insertmacro RemoveVimfiles $0
+    ${EndIf}
+  SectionEnd
 
-	Section "un.$(str_unsection_plugin_vim)" id_unsection_plugin_vim
-		# get the parent dir of the installation
-		Push $INSTDIR
-		Call un.GetParent
-		Pop $0
+  Section "un.$(str_unsection_plugin_vim)" id_unsection_plugin_vim
+    # get the parent dir of the installation
+    Push $INSTDIR
+    Call un.GetParent
+    Pop $0
 
-		# if a plugin dir was created at installation remove it
-		!insertmacro RemoveVimfiles $0
-	SectionEnd
+    # if a plugin dir was created at installation remove it
+    !insertmacro RemoveVimfiles $0
+  SectionEnd
 SectionGroupEnd
 
 Section "un.$(str_unsection_rootdir)" id_unsection_rootdir
-	# get the parent dir of the installation
-	Push $INSTDIR
-	Call un.GetParent
-	Pop $0
+# get the parent dir of the installation
+  Push $INSTDIR
+  Call un.GetParent
+  Pop $0
 
-	${IfNot} ${Silent}
-	  Delete $0\_vimrc
-	${Endif}
-	RMDir $0
+  ${IfNot} ${Silent}
+    Delete $0\_vimrc
+  ${Endif}
+  RMDir $0
 SectionEnd
 
 ##########################################################
 # Description for Uninstaller Sections
 
 !insertmacro MUI_UNFUNCTION_DESCRIPTION_BEGIN
-    !insertmacro MUI_DESCRIPTION_TEXT ${id_unsection_register}    $(str_desc_unregister)
-    !insertmacro MUI_DESCRIPTION_TEXT ${id_unsection_exe}         $(str_desc_rm_exe)
-    !insertmacro MUI_DESCRIPTION_TEXT ${id_ungroup_plugin}        $(str_desc_rm_plugin)
-    !insertmacro MUI_DESCRIPTION_TEXT ${id_unsection_plugin_home} $(str_desc_rm_plugin_home)
-    !insertmacro MUI_DESCRIPTION_TEXT ${id_unsection_plugin_vim}  $(str_desc_rm_plugin_vim)
-    !insertmacro MUI_DESCRIPTION_TEXT ${id_unsection_rootdir}     $(str_desc_rm_rootdir)
+  !insertmacro MUI_DESCRIPTION_TEXT ${id_unsection_register}	\
+      $(str_desc_unregister)
+  !insertmacro MUI_DESCRIPTION_TEXT ${id_unsection_exe}  $(str_desc_rm_exe)
+  !insertmacro MUI_DESCRIPTION_TEXT ${id_ungroup_plugin} $(str_desc_rm_plugin)
+  !insertmacro MUI_DESCRIPTION_TEXT ${id_unsection_plugin_home} \
+      $(str_desc_rm_plugin_home)
+  !insertmacro MUI_DESCRIPTION_TEXT ${id_unsection_plugin_vim}	\
+      $(str_desc_rm_plugin_vim)
+  !insertmacro MUI_DESCRIPTION_TEXT ${id_unsection_rootdir}	\
+      $(str_desc_rm_rootdir)
 !insertmacro MUI_UNFUNCTION_DESCRIPTION_END
+
+# vi:set ts=8 sw=2 sts=2 tw=79 wm=0 ft=nsis:

--- a/nsis/gvim.nsi
+++ b/nsis/gvim.nsi
@@ -1,6 +1,6 @@
 # NSIS file to create a self-installing exe for Vim.
 # It requires NSIS version 3.0 or later.
-# Last Change:	2025-08-30
+# Last Change:	2025-09-03
 #
 
 Unicode true
@@ -87,39 +87,8 @@ Unicode true
 !include "nsDialogs.nsh"
 !include "Sections.nsh"
 !include "x64.nsh"
-!include "StrFunc.nsh"
-${StrRep}
 
-# See https://nsis.sourceforge.io/LogicLib
-;FileExists is already part of LogicLib, but returns true for directories
-;as well as files
-!macro _FileExists2 _a _b _t _f
-  !insertmacro _LOGICLIB_TEMP
-  StrCpy $_LOGICLIB_TEMP "0"
-;if path is not blank, continue to next check
-  StrCmp `${_b}` `` +4 0
-;if path exists, continue to next check (IfFileExists returns true if this
-;is a directory)
-  IfFileExists `${_b}` `0` +3
-;if path is not a directory, continue to confirm exists
-  IfFileExists `${_b}\*.*` +2 0
-StrCpy $_LOGICLIB_TEMP "1" ;file exists
-;now we have a definitive value - the file exists or it does not
-  StrCmp $_LOGICLIB_TEMP "1" `${_t}` `${_f}`
-!macroend
-!undef FileExists
-!define FileExists `"" FileExists2`
-!macro _DirExists _a _b _t _f
-  !insertmacro _LOGICLIB_TEMP
-  StrCpy $_LOGICLIB_TEMP "0"
-;if path is not blank, continue to next check
-  StrCmp `${_b}` `` +3 0
-;if directory exists, continue to confirm exists
-  IfFileExists `${_b}\*.*` 0 +2
-  StrCpy $_LOGICLIB_TEMP "1"
-  StrCmp $_LOGICLIB_TEMP "1" `${_t}` `${_f}`
-!macroend
-!define DirExists `"" DirExists`
+!include .\auxiliary.nsh	# helper file
 
 !define PRODUCT		"Vim ${VER_MAJOR}.${VER_MINOR}"
 !define UNINST_REG_KEY  "Software\Microsoft\Windows\CurrentVersion\Uninstall"
@@ -268,63 +237,12 @@ Var vim_nsd_mouse
 Var vim_compat_stat
 Var vim_keymap_stat
 Var vim_mouse_stat
-!if ${HAVE_NLS}
-  Var lng_usr
-!endif
 
 # Reserve files
 ReserveFile ${VIMSRC}\installw32.exe
 
 ##########################################################
 # Functions
-
-# Get parent directory
-# Share this function both on installer and uninstaller
-!macro GetParent un
-Function ${un}GetParent
-  Exch $0 ; old $0 is on top of stack
-  Push $1
-  Push $2
-  StrCpy $1 -1
-  ${Do}
-    StrCpy $2 $0 1 $1
-    ${If} $2 == ""
-    ${OrIf} $2 == "\"
-      ${ExitDo}
-    ${EndIf}
-    IntOp $1 $1 - 1
-  ${Loop}
-  StrCpy $0 $0 $1
-  Pop $2
-  Pop $1
-  Exch $0 ; put $0 on top of stack, restore $0 to original value
-FunctionEnd
-!macroend
-
-!insertmacro GetParent ""
-!insertmacro GetParent "un."
-
-# Get home directory
-!macro GetHomeDir un
-Function ${un}GetHomeDir
-  Push $0
-  Push $1
-  ReadEnvStr $0 "HOME"
-  ${If} $0 == ""
-    ReadEnvStr $0 "HOMEDRIVE"
-    ReadEnvStr $1 "HOMEPATH"
-    StrCpy $0 "$0$1"
-    ${If} $0 == ""
-      ReadEnvStr $0 "USERPROFILE"
-    ${EndIf}
-  ${EndIf}
-  Pop $1
-  Exch $0  # put $0 on top of stack, restore $0 to original value
-FunctionEnd
-!macroend
-
-!insertmacro GetHomeDir ""
-!insertmacro GetHomeDir "un."
 
 # Check if Vim is already installed.
 # return: Installed directory. If not found, it will be empty.
@@ -728,14 +646,6 @@ Section -call_install_exe
 SectionEnd
 
 ##########################################################
-!macro SaveSectionSelection section_id reg_value
-  ${If} ${SectionIsSelected} ${section_id}
-    WriteRegDWORD HKLM "${UNINST_REG_KEY_VIM}" ${reg_value} 1
-  ${Else}
-    WriteRegDWORD HKLM "${UNINST_REG_KEY_VIM}" ${reg_value} 0
-  ${EndIf}
-!macroend
-
 Section -post
   # Get estimated install size
   SectionGetSize ${id_section_exe} $3
@@ -789,27 +699,6 @@ Section -post
 SectionEnd
 
 ##########################################################
-!macro LoadSectionSelection section_id reg_value
-  ClearErrors
-  ReadRegDWORD $3 HKLM "${UNINST_REG_KEY_VIM}" ${reg_value}
-  ${IfNot} ${Errors}
-    ${If} $3 = 1
-      !insertmacro SelectSection ${section_id}
-    ${Else}
-      !insertmacro UnselectSection ${section_id}
-    ${EndIf}
-  ${EndIf}
-!macroend
-
-!macro LoadDefaultVimrc out_var reg_value default_value
-  ClearErrors
-  ReadRegStr ${out_var} HKLM "${UNINST_REG_KEY_VIM}" ${reg_value}
-  ${If} ${Errors}
-  ${OrIf} ${out_var} == ""
-    StrCpy ${out_var} ${default_value}
-  ${EndIf}
-!macroend
-
 Function .onInit
   !if ${HAVE_MULTI_LANG}
     # Select a language (or read from the registry).
@@ -817,19 +706,7 @@ Function .onInit
   !endif
 
   !if ${HAVE_NLS}
-    ClearErrors
-    System::Call \
-	'kernel32::GetUserDefaultLocaleName(t.r19, *i${NSIS_MAX_STRLEN})'
-    StrCmp $R9 "zh-cn" coincide 0
-    StrCmp $R9 "zh-tw" coincide 0
-    StrCmp $R9 "pt-br" 0 part
-    coincide:
-    System::Call 'User32::CharLower(t r19 r19)*i${NSIS_MAX_STRLEN}'
-    ${StrRep} $lng_usr "$R9" "-" "_"
-    Goto done
-    part:
-    StrCpy $lng_usr $R9 2
-    done:
+    call GetUserLocale
   !endif
 
   ${If} $INSTDIR == ${DEFAULT_INSTDIR}


### PR DESCRIPTION
1. Alignment to the 80-character boundary, indentation changed.
2. Separation into auxiliary and main code. Auxiliary code moved to the
`auxiliary.nsh` file.
3. Some code blocks moved to combine them into appropriate groups.
4. Changed the logic for checking and copying translated licence files.
5. Fixed a bug with the `readme.txt` file at the end of the installation when
native language support is disabled.
