### PR TITLE
runtime(doc): make :h virtcol() more accurate

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -1,4 +1,4 @@
-*builtin.txt*	For Vim version 9.1.  Last change: 2025 Sep 29
+*builtin.txt*	For Vim version 9.1.  Last change: 2025 Oct 01
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -12346,9 +12346,9 @@ values({dict})						*values()*
 
 virtcol({expr} [, {list} [, {winid}]])			*virtcol()*
 		The result is a Number, which is the screen column of the file
-		position given with {expr}.  That is, the last screen position
-		occupied by the character at that position, when the screen
-		would be of unlimited width.  When there is a <Tab> at the
+		position given with {expr}.  That is, the total number of
+		screen cells occupied by the part of the line until the end of
+		the character at that position.  When there is a <Tab> at the
 		position, the returned Number will be the column at the end of
 		the <Tab>.  For example, for a <Tab> in column 1, with 'ts'
 		set to 8, it returns 8. |conceal| is ignored.


### PR DESCRIPTION
The current description (especially the "unlimited width" part) is
inaccurate in several ways:
- The size of virtual text can depend on window width. In particular,
  the size of "above" virtual text can be equal to window width.
- A double-width character that doesn't fit adds 1 to the virtual column
  of the following characters.
- The size of 'showbreak' and 'breakindent' is counted.

related: #5713
