### PR TITLE
runtime(doc): Whitespace fixes

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -236,7 +236,7 @@ autocmds.
 
 							*:autocmd-verbose*
 When 'verbose' is non-zero, listing an autocommand will also display where it
-was last defined. Example: >
+was last defined.  Example: >
 
     :verbose autocmd BufEnter
     FileExplorer  BufEnter
@@ -344,7 +344,8 @@ Name			triggered by ~
 |GUIEnter|		after starting the GUI successfully
 |GUIFailed|		after starting the GUI failed
 |TermResponse|		after the terminal response to |t_RV| is received
-|TermResponseAll|	after the terminal response to |t_RV| and others is received
+|TermResponseAll|	after the terminal response to |t_RV| and others is
+			received
 
 |QuitPre|		when using `:quit`, before deciding whether to exit
 |ExitPre|		when using a command that may make Vim exit
@@ -381,7 +382,8 @@ Name			triggered by ~
 |FocusGained|		Vim got input focus
 |FocusLost|		Vim lost input focus
 |CursorHold|		the user doesn't press a key for a while
-|CursorHoldI|		the user doesn't press a key for a while in Insert mode
+|CursorHoldI|		the user doesn't press a key for a while in Insert
+			mode
 |CursorMoved|		the cursor was moved in Normal mode
 |CursorMovedC|		the cursor was moved in the |Command-line|
 |CursorMovedI|		the cursor was moved in Insert mode
@@ -566,7 +568,8 @@ BufWinEnter			After a buffer is displayed in a window.  This
 				since it reloads that buffer.
 				Does not happen for a terminal window, because
 				it starts in Terminal-Job mode and Normal mode
-				commands won't work. Use |TerminalOpen| instead.
+				commands won't work.  Use |TerminalOpen|
+				instead.
 							*BufWinLeave*
 BufWinLeave			Before a buffer is removed from a window.
 				Not when it's still visible in another window.
@@ -679,7 +682,7 @@ ColorScheme			After loading a color scheme. |:colorscheme|
 				Not triggered if the color scheme is not
 				found.
 				The pattern is matched against the
-				colorscheme name. <afile> can be used for the
+				colorscheme name.  <afile> can be used for the
 				name of the actual file where this option was
 				set, and <amatch> for the new colorscheme
 				name.
@@ -748,7 +751,7 @@ CursorHold			When the user doesn't press a key for the time
 				triggered. |q|
 							*<CursorHold>*
 				Internally the autocommand is triggered by the
-				<CursorHold> key. In an expression mapping
+				<CursorHold> key.  In an expression mapping
 				|getchar()| may see this character.
 
 				Note: Interactive commands cannot be used for
@@ -1014,7 +1017,7 @@ InsertLeave			Just after leaving Insert mode.  Also when
 				using CTRL-O |i_CTRL-O|.  But not for |i_CTRL-C|.
 							*KeyInputPre*
 KeyInputPre			Just before a key is processed after mappings
-				have been applied. The pattern is matched
+				have been applied.  The pattern is matched
 				against a string that indicates the current
 				mode, which is the same as what is returned by
 				`mode(1)`.
@@ -1046,7 +1049,7 @@ MenuPopup			Just before showing the popup menu (under the
 					c	Command line
 					tl	Terminal
 							*ModeChanged*
-ModeChanged			After changing the mode. The pattern is
+ModeChanged			After changing the mode.  The pattern is
 				matched against `'old_mode:new_mode'`, for
 				example match against `*:c*` to simulate
 				|CmdlineEnter|.
@@ -1082,7 +1085,7 @@ OptionSet			After setting an option.  The pattern is
 
 				|v:option_oldlocal| is only set when |:set|
 				or |:setlocal| or a |modeline| was used to set
-				the option. Similarly |v:option_oldglobal| is
+				the option.  Similarly |v:option_oldglobal| is
 				only set when |:set| or |:setglobal| was used.
 
 				This does not set |<abuf>|, you could use
@@ -1090,10 +1093,10 @@ OptionSet			After setting an option.  The pattern is
 
 				Note that when setting a |global-local| string
 				option with |:set|, then |v:option_old| is the
-				old global value. However, for all other kinds
-				of options (local string options, global-local
-				number options, ...) it is the old local
-				value.
+				old global value.  However, for all other
+				kinds of options (local string options,
+				global-local number options, ...) it is the
+				old local value.
 
 				OptionSet is not triggered on startup and for
 				the 'key' option for obvious reasons.
@@ -1105,7 +1108,7 @@ OptionSet			After setting an option.  The pattern is
 
 				Note: It's a bad idea to reset an option
 				during this autocommand, this may break a
-				plugin. You can always use `:noa` to prevent
+				plugin.  You can always use `:noa` to prevent
 				triggering this autocommand.
 
 				When using |:set| in the autocommand the event
@@ -1130,7 +1133,7 @@ QuickFixCmdPre			Before a quickfix command is run (|:make|,
 							*QuickFixCmdPost*
 QuickFixCmdPost			Like QuickFixCmdPre, but after a quickfix
 				command is run, before jumping to the first
-				location. For |:cfile| and |:lfile| commands
+				location.  For |:cfile| and |:lfile| commands
 				it is run after the error file is read and
 				before moving to the first error.
 				See |QuickFixCmdPost-example|.
@@ -1174,7 +1177,7 @@ SafeState			When nothing is pending, going to wait for the
 				screen was scrolled for messages.
 							*SafeStateAgain*
 SafeStateAgain			Like SafeState but after processing any
-				messages and invoking callbacks. This may be
+				messages and invoking callbacks.  This may be
 				triggered often, don't do something that takes
 				time.
 
@@ -1278,12 +1281,12 @@ TermChanged			After the value of 'term' has changed.  Useful
 				settings.  Executed for all loaded buffers.
 							*TerminalOpen*
 TerminalOpen			Just after a terminal buffer was created, with
-				`:terminal` or |term_start()|. This event is
+				`:terminal` or |term_start()|.  This event is
 				triggered even if the buffer is created
 				without a window, with the ++hidden option.
 							*TerminalWinOpen*
 TerminalWinOpen			Just after a terminal buffer was created, with
-				`:terminal` or |term_start()|. This event is
+				`:terminal` or |term_start()|.  This event is
 				triggered only if the buffer is created
 				with a window.  Can be used to set window
 				local options for the terminal window.
@@ -1480,7 +1483,7 @@ WinLeave			Before leaving a window.  If the window to be
 				Not used for ":qa" or ":q" when exiting Vim.
 
 							*WinNewPre*
-WinNewPre			Before creating a new window. Triggered
+WinNewPre			Before creating a new window.  Triggered
 				before commands that modify window layout by
 				creating a split.
 				Not done when creating tab pages and for the
@@ -1789,8 +1792,8 @@ option will not cause any commands to be executed.
 			After applying the autocommands the modelines are
 			processed, so that their settings overrule the
 			settings from autocommands, like what happens when
-			editing a file. This is skipped when the <nomodeline>
-			argument is present. You probably want to use
+			editing a file.  This is skipped when the <nomodeline>
+			argument is present.  You probably want to use
 			<nomodeline> for events that are not used when loading
 			a buffer, such as |User|.
 			Processing modelines is also skipped when no
@@ -1802,7 +1805,7 @@ option will not cause any commands to be executed.
 			loaded buffer.  The current buffer is done last.
 
 			Note that [fname] is used to select the autocommands,
-			not the buffers to which they are applied. Example: >
+			not the buffers to which they are applied.  Example: >
 				augroup mine
 				  autocmd!
 				  autocmd FileType * echo expand('<amatch>')

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -889,7 +889,7 @@ append({lnum}, {text})					*append()*
 appendbufline({buf}, {lnum}, {text})			*appendbufline()*
 		Like |append()| but append the text in buffer {buf}.
 
-		This function works only for loaded buffers. First call
+		This function works only for loaded buffers.  First call
 		|bufload()| if needed.
 
 		For the use of {buf}, see |bufname()|.
@@ -903,7 +903,7 @@ appendbufline({buf}, {lnum}, {text})			*appendbufline()*
 		In |Vim9| script an error is given for an invalid {lnum}.
 
 		If {buf} is not a valid buffer or {lnum} is not valid, an
-		error message is given. Example: >
+		error message is given.  Example: >
 			:let failed = appendbufline(13, 0, "# THE START")
 <		However, when {text} is an empty list then no error is given
 		for an invalid {lnum}, since {lnum} isn't actually used.
@@ -1036,19 +1036,19 @@ autocmd_add({acmds})					*autocmd_add()*
 				If this item is specified, then the "pattern"
 				item is ignored.
 		    cmd		Ex command to execute for this autocmd event
-		    event	autocmd event name. Refer to |autocmd-events|.
+		    event	autocmd event name.  Refer to |autocmd-events|.
 				This can be either a String with a single
 				event name or a List of event names.
-		    group	autocmd group name. Refer to |autocmd-groups|.
+		    group	autocmd group name.  Refer to |autocmd-groups|.
 				If this group doesn't exist then it is
 				created.  If not specified or empty, then the
 				default group is used.
 		    nested	boolean flag, set to v:true to add a nested
 				autocmd.  Refer to |autocmd-nested|.
 		    once	boolean flag, set to v:true to add an autocmd
-				which executes only once. Refer to
+				which executes only once.  Refer to
 				|autocmd-once|.
-		    pattern	autocmd pattern string. Refer to
+		    pattern	autocmd pattern string.  Refer to
 				|autocmd-patterns|.  If "bufnr" item is
 				present, then this item is ignored.  This can
 				be a String with a single pattern or a List of
@@ -1057,7 +1057,8 @@ autocmd_add({acmds})					*autocmd_add()*
 				commands associated with the specified autocmd
 				event and group and add the {cmd}.  This is
 				useful to avoid adding the same command
-				multiple times for an autocmd event in a group.
+				multiple times for an autocmd event in a
+				group.
 
 		Returns v:true on success and v:false on failure.
 		Examples: >
@@ -1080,21 +1081,21 @@ autocmd_delete({acmds})					*autocmd_delete()*
 
 		The {acmds} argument is a List where each item is a Dict with
 		the following optional items:
-		    bufnr	buffer number to delete a buffer-local autocmd.
-				If this item is specified, then the "pattern"
-				item is ignored.
+		    bufnr	buffer number to delete a buffer-local
+				autocmd.  If this item is specified, then the
+				"pattern" item is ignored.
 		    cmd		Ex command for this autocmd event
-		    event	autocmd event name. Refer to |autocmd-events|.
+		    event	autocmd event name.  Refer to |autocmd-events|.
 				If '*' then all the autocmd events in this
 				group are deleted.
-		    group	autocmd group name. Refer to |autocmd-groups|.
+		    group	autocmd group name.  Refer to |autocmd-groups|.
 				If not specified or empty, then the default
 				group is used.
 		    nested	set to v:true for a nested autocmd.
 				Refer to |autocmd-nested|.
 		    once	set to v:true for an autocmd which executes
-				only once. Refer to |autocmd-once|.
-		    pattern	autocmd pattern string. Refer to
+				only once.  Refer to |autocmd-once|.
+		    pattern	autocmd pattern string.  Refer to
 				|autocmd-patterns|.  If "bufnr" item is
 				present, then this item is ignored.
 
@@ -1128,22 +1129,22 @@ autocmd_delete({acmds})					*autocmd_delete()*
 
 
 autocmd_get([{opts}])					*autocmd_get()*
-		Returns a |List| of autocmds. If {opts} is not supplied, then
+		Returns a |List| of autocmds.  If {opts} is not supplied, then
 		returns the autocmds for all the events in all the groups.
 
 		The optional {opts} Dict argument supports the following
 		items:
-		    group	Autocmd group name. If specified, returns only
-				the autocmds defined in this group. If the
-				specified group doesn't exist, results in an
-				error message.  If set to an empty string,
+		    group	Autocmd group name.  If specified, returns
+				only the autocmds defined in this group.  If
+				the specified group doesn't exist, results in
+				an error message.  If set to an empty string,
 				then the default autocmd group is used.
-		    event	Autocmd event name. If specified, returns only
-				the autocmds defined for this event.  If set
-				to "*", then returns autocmds for all the
+		    event	Autocmd event name.  If specified, returns
+				only the autocmds defined for this event.  If
+				set to "*", then returns autocmds for all the
 				events.  If the specified event doesn't exist,
 				results in an error message.
-		    pattern	Autocmd pattern. If specified, returns only
+		    pattern	Autocmd pattern.  If specified, returns only
 				the autocmds defined for this pattern.
 		A combination of the above three times can be supplied in
 		{opts}.
@@ -1155,11 +1156,12 @@ autocmd_get([{opts}])					*autocmd_get()*
 		    event	Autocmd event name.
 		    group	Autocmd group name.
 		    nested	Boolean flag, set to v:true for a nested
-				autocmd. See |autocmd-nested|.
+				autocmd.  See |autocmd-nested|.
 		    once	Boolean flag, set to v:true, if the autocmd
-				will be executed only once. See |autocmd-once|.
+				will be executed only once.  See |autocmd-once|.
 		    pattern	Autocmd pattern.  For a buffer-local
-				autocmd, this will be of the form "<buffer=n>".
+				autocmd, this will be of the form
+				"<buffer=n>".
 		If there are multiple commands for an autocmd event in a
 		group, then separate items are returned for each command.
 
@@ -1510,7 +1512,7 @@ bufnr([{buf} [, {create}]])				*bufnr()*
 		{create} argument is present and TRUE, a new, unlisted,
 		buffer is created and its number is returned.  Example: >
 			let newbuf = bufnr('Scratch001', 1)
-<		Using an empty name uses the current buffer. To create a new
+<		Using an empty name uses the current buffer.  To create a new
 		buffer with an empty name use |bufadd()|.
 
 		bufnr("$") is the last buffer: >
@@ -1698,7 +1700,8 @@ char2nr({string} [, {utf8}])					*char2nr()*
 		Examples: >
 			char2nr(" ")		returns 32
 			char2nr("ABC")		returns 65
-<		When {utf8} is omitted or zero, the current 'encoding' is used.
+<		When {utf8} is omitted or zero, the current 'encoding' is
+		used.
 		Example for "utf-8": >
 			char2nr("á")		returns 225
 			char2nr("á"[0])		returns 195
@@ -1763,7 +1766,7 @@ charidx({string}, {idx} [, {countcc} [, {utf16}]])
 		index in the String {expr} instead of as the byte index.
 
 		Returns -1 if the arguments are invalid or if there are less
-		than {idx} bytes. If there are exactly {idx} bytes the length
+		than {idx} bytes.  If there are exactly {idx} bytes the length
 		of the string in characters is returned.
 
 		An error is given and -1 is returned if the first argument is
@@ -1855,7 +1858,7 @@ cmdcomplete_info()					*cmdcomplete_info()*
 				completion began.
 		   pum_visible	|TRUE| if popup menu is visible.
 				See |pumvisible()|.
-		   matches	List of all completion candidates. Each item
+		   matches	List of all completion candidates.  Each item
 				is a string.
 		   selected	Selected item index.  First index is zero.
 				Index is -1 if no item is selected (showing
@@ -1877,7 +1880,7 @@ col({expr} [, {winid}])					*col()*
 		When {expr} is "$", it means the end of the cursor line, so
 		the result is the number of bytes in the cursor line plus one.
 		Additionally {expr} can be [lnum, col]: a |List| with the line
-		and column number. Most useful when the column is "$", to get
+		and column number.  Most useful when the column is "$", to get
 		the last column of a specific line.  When "lnum" or "col" is
 		out of range then col() returns zero.
 
@@ -1914,7 +1917,7 @@ col({expr} [, {winid}])					*col()*
 
 
 complete({startcol}, {matches})			*complete()* *E785*
-		Set the matches for Insert mode completion. Can only be
+		Set the matches for Insert mode completion.  Can only be
 		used in Insert mode.  Typically invoked from a mapping with
 		CTRL-R = (see |i_CTRL-R|), but may also be called from a
 		|<Cmd>| or |<ScriptCmd>| mapping.  It does not work after
@@ -2001,12 +2004,13 @@ complete_info([{what}])				*complete_info()*
 				See |complete_info_mode| for the values.
 		   pum_visible	|TRUE| if popup menu is visible.
 				See |pumvisible()|.
-		   items	List of all completion candidates. Each item
+		   items	List of all completion candidates.  Each item
 				is a dictionary containing the entries "word",
-				"abbr", "menu", "kind", "info" and "user_data".
+				"abbr", "menu", "kind", "info" and
+				"user_data".
 				See |complete-items|.
 		   matches	Same as "items", but only returns items that
-				are matching current query. If both "matches"
+				are matching current query.  If both "matches"
 				and "items" are in "what", the returned list
 				will still be named "items", but each item
 				will have an additional "match" field.
@@ -2045,7 +2049,7 @@ complete_info([{what}])				*complete_info()*
 		{what} are silently ignored.
 
 		To get the position and size of the popup menu, see
-		|pum_getpos()|. It's also available in |v:event| during the
+		|pum_getpos()|.  It's also available in |v:event| during the
 		|CompleteChanged| event.
 
 		Returns an empty |Dictionary| on error.
@@ -2065,13 +2069,13 @@ complete_info([{what}])				*complete_info()*
 
 complete_match([{lnum}, {col}])			*complete_match()*
 		Searches backward from the given position and returns a List
-		of matches according to the 'isexpand' option. When no
+		of matches according to the 'isexpand' option.  When no
 		arguments are provided, uses the current cursor position.
 
 		Each match is represented as a List containing
 		[startcol, trigger_text] where:
 		- startcol: column position where completion should start,
-		  or -1 if no trigger position is found. For multi-character
+		  or -1 if no trigger position is found.  For multi-character
 		  triggers, returns the column of the first character.
 		- trigger_text: the matching trigger string from 'isexpand',
 		  or empty string if no match was found or when using the
@@ -2228,7 +2232,7 @@ count({comp}, {expr} [, {ic} [, {start}]])		*count()* *E706*
 		When {ic} is given and it's |TRUE| then case is ignored.
 
 		When {comp} is a string then the number of not overlapping
-		occurrences of {expr} is returned. Zero is returned when
+		occurrences of {expr} is returned.  Zero is returned when
 		{expr} is an empty string.
 
 		Can also be used as a |method|: >
@@ -2322,7 +2326,7 @@ cursor({list})
 debugbreak({pid})					*debugbreak()*
 		Specifically used to interrupt a program being debugged.  It
 		will cause process {pid} to get a SIGTRAP.  Behavior for other
-		processes is undefined. See |terminal-debugger|.
+		processes is undefined.  See |terminal-debugger|.
 		{only available on MS-Windows}
 
 		Returns |TRUE| if successfully interrupted the program.
@@ -2397,13 +2401,13 @@ deletebufline({buf}, {first} [, {last}])		*deletebufline()*
 		If {last} is omitted then delete line {first} only.
 		On success 0 is returned, on failure 1 is returned.
 
-		This function works only for loaded buffers. First call
+		This function works only for loaded buffers.  First call
 		|bufload()| if needed.
 
 		For the use of {buf}, see |bufname()| above.
 
-		{first} and {last} are used like with |getline()|. Note that
-		when using |line()| this refers to the current buffer. Use "$"
+		{first} and {last} are used like with |getline()|.  Note that
+		when using |line()| this refers to the current buffer.  Use "$"
 		to refer to the last line in buffer {buf}.
 
 		Can also be used as a |method|: >
@@ -2640,7 +2644,7 @@ digraph_setlist({digraphlist})				*digraph_setlist()*
 
 echoraw({string})					*echoraw()*
 		Output {string} as-is, including unprintable characters.
-		This can be used to output a terminal code. For example, to
+		This can be used to output a terminal code.  For example, to
 		disable modifyOtherKeys: >
 			call echoraw(&t_TE)
 <		and to enable it again: >
@@ -2673,7 +2677,7 @@ empty({expr})						*empty()*
 
 
 environ()						*environ()*
-		Return all of environment variables as dictionary. You can
+		Return all of environment variables as dictionary.  You can
 		check if an environment variable exists like this: >
 			:echo has_key(environ(), 'HOME')
 <		Note that the variable name may be CamelCase; to ignore case
@@ -3157,21 +3161,21 @@ feedkeys({string} [, {mode}])				*feedkeys()*
 		{string}.
 
 		To include special keys into {string}, use double-quotes
-		and "\..." notation |expr-quote|. For example,
-		feedkeys("\<CR>") simulates pressing of the <Enter> key. But
+		and "\..." notation |expr-quote|.  For example,
+		feedkeys("\<CR>") simulates pressing of the <Enter> key.  But
 		feedkeys('\<CR>') pushes 5 characters.
 		A special code that might be useful is <Ignore>, it exits the
 		wait for a character without doing anything.  *<Ignore>*
 
 		{mode} is a String, which can contain these character flags:
-		'm'	Remap keys. This is default.  If {mode} is absent,
+		'm'	Remap keys.  This is default.  If {mode} is absent,
 			keys are remapped.
 		'n'	Do not remap keys.
 		't'	Handle keys as if typed; otherwise they are handled as
 			if coming from a mapping.  This matters for undo,
 			opening folds, etc.
 		'L'	Lowlevel input.  Only works for Unix or when using the
-			GUI. Keys are used as if they were coming from the
+			GUI.  Keys are used as if they were coming from the
 			terminal.  Other flags are not used.  *E980*
 			When a CTRL-C interrupts and 't' is included it sets
 			the internal "got_int" flag.
@@ -3191,7 +3195,7 @@ feedkeys({string} [, {mode}])				*feedkeys()*
 			legacy script syntax applies, "s:var" does not work,
 			etc.  Note that if the string being fed sets a script
 			context this still applies.
-		'!'	When used with 'x' will not end Insert mode. Can be
+		'!'	When used with 'x' will not end Insert mode.  Can be
 			used in a test when a timer is set to exit Insert mode
 			a little later.  Useful for testing CursorHoldI.
 
@@ -3204,7 +3208,7 @@ feedkeys({string} [, {mode}])				*feedkeys()*
 
 
 filecopy({from}, {to})					*filecopy()*
-		Copy the file pointed to by the name {from} to {to}. The
+		Copy the file pointed to by the name {from} to {to}.  The
 		result is a Number, which is |TRUE| if the file was copied
 		successfully, and |FALSE| when it failed.
 		If a file with name {to} already exists, it will fail.
@@ -3265,7 +3269,7 @@ filter({expr1}, {expr2})				*filter()*
 		of the current item.  For a |Dictionary| |v:key| has the key
 		of the current item and for a |List| |v:key| has the index of
 		the current item.  For a |Blob| |v:key| has the index of the
-		current byte. For a |String| |v:key| has the index of the
+		current byte.  For a |String| |v:key| has the index of the
 		current character.
 		Examples: >
 			call filter(mylist, 'v:val !~ "OLD"')
@@ -3307,8 +3311,8 @@ filter({expr1}, {expr2})				*filter()*
 		or a new |Blob| or |String|.
 		When an error is encountered while evaluating {expr2} no
 		further items in {expr1} are processed.
-		When {expr2} is a Funcref errors inside a function are ignored,
-		unless it was defined with the "abort" flag.
+		When {expr2} is a Funcref errors inside a function are
+		ignored, unless it was defined with the "abort" flag.
 
 		Can also be used as a |method|: >
 			mylist->filter(expr2)
@@ -3588,7 +3592,7 @@ foldtextresult({lnum})					*foldtextresult()*
 foreach({expr1}, {expr2})				*foreach()* *E1525*
 		{expr1} must be a |List|, |Tuple|, |String|, |Blob| or
 		|Dictionary|.
-		For each item in {expr1} execute {expr2}. {expr1} is not
+		For each item in {expr1} execute {expr2}.  {expr1} is not
 		modified; its values may be, as with |:lockvar| 1. |E741|
 		See |map()| and |filter()| to modify {expr1}.
 
@@ -3598,7 +3602,7 @@ foreach({expr1}, {expr2})				*foreach()* *E1525*
 		of the current item.  For a |Dictionary| |v:key| has the key
 		of the current item and for a |List| or a |Tuple| |v:key| has
 		the index of the current item.  For a |Blob| |v:key| has the
-		index of the current byte. For a |String| |v:key| has the
+		index of the current byte.  For a |String| |v:key| has the
 		index of the current character.
 		Examples: >
 			call foreach(mylist, 'used[v:val] = true')
@@ -3619,8 +3623,8 @@ foreach({expr1}, {expr2})				*foreach()* *E1525*
 		Returns {expr1} in all cases.
 		When an error is encountered while executing {expr2} no
 		further items in {expr1} are processed.
-		When {expr2} is a Funcref errors inside a function are ignored,
-		unless it was defined with the "abort" flag.
+		When {expr2} is a Funcref errors inside a function are
+		ignored, unless it was defined with the "abort" flag.
 
 		Can also be used as a |method|: >
 			mylist->foreach(expr2)
@@ -3672,7 +3676,7 @@ funcref({name} [, {arglist}] [, {dict}])		*funcref()*
 		It only works for an autoloaded function if it has already
 		been loaded (to avoid mistakenly loading the autoload script
 		when only intending to use the function name, use |function()|
-		instead). {name} cannot be a builtin function.
+		instead).  {name} cannot be a builtin function.
 		Returns 0 on error.
 
 		Can also be used as a |method|: >
@@ -3688,7 +3692,7 @@ function({name} [, {arglist}] [, {dict}])
 
 		{name} can also be a Funcref or a partial.  When it is a
 		partial the dict stored in it will be used and the {dict}
-		argument is not allowed. E.g.: >
+		argument is not allowed.  E.g.: >
 			let FuncWithArg = function(dict.Func, [arg])
 			let Broken = function(dict.Func, [arg], dict)
 <
@@ -3697,8 +3701,8 @@ function({name} [, {arglist}] [, {dict}])
 		same function.
 
 		When {arglist} or {dict} is present this creates a partial.
-		That means the argument list and/or the dictionary is stored in
-		the Funcref and will be used when the Funcref is called.
+		That means the argument list and/or the dictionary is stored
+		in the Funcref and will be used when the Funcref is called.
 
 		The arguments are passed to the function in front of other
 		arguments, but after any argument from |method|.  Example: >
@@ -3732,7 +3736,7 @@ function({name} [, {arglist}] [, {dict}])
 			call Callback('one', 'two', 'name')
 
 <		The Dictionary is only useful when calling a "dict" function.
-		In that case the {dict} is passed in as "self". Example: >
+		In that case the {dict} is passed in as "self".  Example: >
 			function Callback() dict
 			   echo "called for " .. self.name
 			endfunction
@@ -4004,12 +4008,14 @@ getcellpixels()						*getcellpixels()*
 		Returns a |List| of terminal cell pixel size.
 		List format is [xpixel, ypixel].
 
-		Only works on Unix (terminal and gVim) and Windows (gVim only).
+		Only works on Unix (terminal and gVim) and Windows (gVim
+		only).
 		Returns [] on other systems or on failure.
-		Note that there could be variations across different terminals.
+		Note that there could be variations across different
+		terminals.
 		On macOS, system Terminal.app returns sizes in points (before
-		Retina scaling), whereas third-party terminals return raw pixel
-		sizes (post Retina scaling).
+		Retina scaling), whereas third-party terminals return raw
+		pixel sizes (post Retina scaling).
 
 		Return type: list<any>
 
@@ -4024,8 +4030,8 @@ getcellwidths()						*getcellwidths()*
 
 
 getchangelist([{buf}])					*getchangelist()*
-		Returns the |changelist| for the buffer {buf}. For the use
-		of {buf}, see |bufname()| above. If buffer {buf} doesn't
+		Returns the |changelist| for the buffer {buf}.  For the use
+		of {buf}, see |bufname()| above.  If buffer {buf} doesn't
 		exist, an empty list is returned.
 
 		The returned list contains two entries: a list with the change
@@ -4036,7 +4042,7 @@ getchangelist([{buf}])					*getchangelist()*
 			coladd		column offset for 'virtualedit'
 			lnum		line number
 		If buffer {buf} is the current buffer, then the current
-		position refers to the position in the list. For other
+		position refers to the position in the list.  For other
 		buffers, it is set to the length of the list.
 
 		Can also be used as a |method|: >
@@ -4143,7 +4149,7 @@ getchar([{expr} [, {opts}]])				*getchar()*
 			:endfunction
 <
 		You may also receive synthetic characters, such as
-		|<CursorHold>|. Often you will want to ignore this and get
+		|<CursorHold>|.  Often you will want to ignore this and get
 		another character: >
 			:function GetKey()
 			:  let c = getchar()
@@ -4176,7 +4182,7 @@ getcharmod()						*getcharmod()*
 
 
 getcharpos({expr})					*getcharpos()*
-		Get the position for String {expr}. Same as |getpos()| but the
+		Get the position for String {expr}.  Same as |getpos()| but the
 		column number in the returned List is a character index
 		instead of a byte index.
 		If |getpos()| returns a very large column number, equal to
@@ -4300,7 +4306,7 @@ getcmdscreenpos()					*getcmdscreenpos()*
 
 
 getcmdtype()						*getcmdtype()*
-		Return the current command-line type. Possible return values
+		Return the current command-line type.  Possible return values
 		are:
 		    :	normal Ex command
 		    >	debug mode command |debug-mode|
@@ -4318,15 +4324,15 @@ getcmdtype()						*getcmdtype()*
 
 
 getcmdwintype()						*getcmdwintype()*
-		Return the current |command-line-window| type. Possible return
-		values are the same as |getcmdtype()|. Returns an empty string
+		Return the current |command-line-window| type.  Possible return
+		values are the same as |getcmdtype()|.  Returns an empty string
 		when not in the command-line window.
 
 		Return type: |String|
 
 
 getcompletion({pat}, {type} [, {filtered}])		*getcompletion()*
-		Return a list of command-line completion matches. The String
+		Return a list of command-line completion matches.  The String
 		{type} argument specifies what for.  The following completion
 		types are supported:
 
@@ -4383,10 +4389,10 @@ getcompletion({pat}, {type} [, {filtered}])		*getcompletion()*
 
 		If the optional {filtered} flag is set to 1, then 'wildignore'
 		is applied to filter the results.  Otherwise all the matches
-		are returned. The 'wildignorecase' option always applies.
+		are returned.  The 'wildignorecase' option always applies.
 
 		If the 'wildoptions' option contains 'fuzzy', then fuzzy
-		matching is used to get the completion matches. Otherwise
+		matching is used to get the completion matches.  Otherwise
 		regular expression matching is used.  Thus this function
 		follows the user preference, what happens on the command line.
 		If you do not want this you can make 'wildoptions' empty
@@ -4423,8 +4429,8 @@ getcurpos([{winid}])
 		cursor vertically.  After |$| command it will be a very large
 		number equal to |v:maxcol|.  Also see |getcursorcharpos()| and
 		|getpos()|.
-		The first "bufnum" item is always zero. The byte position of
-		the cursor is returned in 'col'. To get the character
+		The first "bufnum" item is always zero.  The byte position of
+		the cursor is returned in 'col'.  To get the character
 		position, use |getcursorcharpos()|.
 
 		The optional {winid} argument can specify the window.  It can
@@ -4472,7 +4478,7 @@ getcwd([{winnr} [, {tabnr}]])				*getcwd()*
 		directory.  See also |haslocaldir()|.
 
 		With {winnr} and {tabnr} return the local current directory of
-		the window in the specified tab page. If {winnr} is -1 return
+		the window in the specified tab page.  If {winnr} is -1 return
 		the working directory of the tabpage.
 		If {winnr} is zero use the current window, if {tabnr} is zero
 		use the current tabpage.
@@ -4679,19 +4685,19 @@ getloclist({nr} [, {what}])				*getloclist()*
 
 		For a location list window, the displayed location list is
 		returned.  For an invalid window number {nr}, an empty list is
-		returned. Otherwise, same as |getqflist()|.
+		returned.  Otherwise, same as |getqflist()|.
 
 		If the optional {what} dictionary argument is supplied, then
-		returns the items listed in {what} as a dictionary. Refer to
+		returns the items listed in {what} as a dictionary.  Refer to
 		|getqflist()| for the supported items in {what}.
 
 		In addition to the items supported by |getqflist()| in {what},
 		the following item is supported by |getloclist()|:
 
 			filewinid	id of the window used to display files
-					from the location list. This field is
+					from the location list.  This field is
 					applicable only when called from a
-					location list window. See
+					location list window.  See
 					|location-list-file-window| for more
 					details.
 
@@ -4852,7 +4858,7 @@ getpos({expr})							*getpos()*
 
 		For getting the cursor position see |getcurpos()|.
 		The column number in the returned List is the byte position
-		within the line. To get the character position in the line,
+		within the line.  To get the character position in the line,
 		use |getcharpos()|.
 
 		Note that for '< and '> Visual mode matters: when it is "V"
@@ -4898,7 +4904,7 @@ getqflist([{what}])					*getqflist()*
 				any type.
 
 		When there is no error list or it's empty, an empty list is
-		returned. Quickfix list entries with a non-existing buffer
+		returned.  Quickfix list entries with a non-existing buffer
 		number are returned with "bufnr" set to zero (Note: some
 		functions accept buffer number zero for the alternate buffer,
 		you may need to explicitly check for zero).
@@ -4911,12 +4917,12 @@ getqflist([{what}])					*getqflist()*
 			:endfor
 <
 		If the optional {what} dictionary argument is supplied, then
-		returns only the items listed in {what} as a dictionary. The
+		returns only the items listed in {what} as a dictionary.  The
 		following string items are supported in {what}:
 			changedtick	get the total number of changes made
 					to the list |quickfix-changedtick|
 			context	get the |quickfix-context|
-			efm	errorformat to use when parsing "lines". If
+			efm	errorformat to use when parsing "lines".  If
 				not present, then the 'errorformat' option
 				value is used.
 			id	get information for the quickfix list with
@@ -4930,24 +4936,24 @@ getqflist([{what}])					*getqflist()*
 			lines	parse a list of lines using 'efm' and return
 				the resulting entries.  Only a |List| type is
 				accepted.  The current quickfix list is not
-				modified. See |quickfix-parse|.
+				modified.  See |quickfix-parse|.
 			nr	get information for this quickfix list; zero
 				means the current quickfix list and "$" means
 				the last quickfix list
 			qfbufnr number of the buffer displayed in the quickfix
-				window. Returns 0 if the quickfix buffer is
-				not present. See |quickfix-buffer|.
+				window.  Returns 0 if the quickfix buffer is
+				not present.  See |quickfix-buffer|.
 			size	number of entries in the quickfix list
 			title	get the list title |quickfix-title|
 			winid	get the quickfix |window-ID|
 			all	all of the above quickfix properties
-		Non-string items in {what} are ignored. To get the value of a
+		Non-string items in {what} are ignored.  To get the value of a
 		particular item, set it to zero.
 		If "nr" is not present then the current quickfix list is used.
 		If both "nr" and a non-zero "id" are specified, then the list
 		specified by "id" is used.
 		To get the number of lists in the quickfix stack, set "nr" to
-		"$" in {what}. The "nr" value in the returned dictionary
+		"$" in {what}.  The "nr" value in the returned dictionary
 		contains the quickfix stack size.
 		When "lines" is specified, all the other items except "efm"
 		are ignored.  The returned dictionary contains the entry
@@ -4956,22 +4962,23 @@ getqflist([{what}])					*getqflist()*
 		The returned dictionary contains the following entries:
 			changedtick	total number of changes made to the
 					list |quickfix-changedtick|
-			context	quickfix list context. See |quickfix-context|
+			context	quickfix list context.  See |quickfix-context|
 				If not present, set to "".
-			id	quickfix list ID |quickfix-ID|. If not
+			id	quickfix list ID |quickfix-ID|.  If not
 				present, set to 0.
-			idx	index of the quickfix entry in the list. If not
-				present, set to 0.
-			items	quickfix list entries. If not present, set to
+			idx	index of the quickfix entry in the list.  If
+				not present, set to 0.
+			items	quickfix list entries.  If not present, set to
 				an empty list.
-			nr	quickfix list number. If not present, set to 0
+			nr	quickfix list number.  If not present, set to
+				0
 			qfbufnr	number of the buffer displayed in the quickfix
-				window. If not present, set to 0.
-			size	number of entries in the quickfix list. If not
-				present, set to 0.
-			title	quickfix list title text. If not present, set
+				window.  If not present, set to 0.
+			size	number of entries in the quickfix list.  If
+				not present, set to 0.
+			title	quickfix list title text.  If not present, set
 				to "".
-			winid	quickfix |window-ID|. If not present, set to 0
+			winid	quickfix |window-ID|.  If not present, set to 0
 
 		Examples (See also |getqflist-examples|): >
 			:echo getqflist({'all': 1})
@@ -4996,7 +5003,7 @@ getreg([{regname} [, 1 [, {list}]]])			*getreg()*
 		argument is ignored, thus you can always give it.
 
 		If {list} is present and |TRUE|, the result type is changed
-		to |List|. Each list item is one text line. Use it if you care
+		to |List|.  Each list item is one text line.  Use it if you care
 		about zero bytes possibly present inside register: without
 		third argument both NLs and zero bytes are represented as NLs
 		(see |NL-used-for-Nul|).
@@ -5170,7 +5177,7 @@ getscriptinfo([{opts}])					*getscriptinfo()*
 
 		The optional Dict argument {opts} supports the following
 		optional items:
-		    name	Script name match pattern. If specified,
+		    name	Script name match pattern.  If specified,
 				and "sid" is not specified, information about
 				scripts with a name that match the pattern
 				"name" are returned.
@@ -5224,7 +5231,7 @@ getstacktrace()						*getstacktrace()*
 
 gettabinfo([{tabnr}])					*gettabinfo()*
 		If {tabnr} is not specified, then information about all the
-		tab pages is returned as a |List|. Each List item is a
+		tab pages is returned as a |List|.  Each List item is a
 		|Dictionary|.  Otherwise, {tabnr} specifies the tab page
 		number and information about that one is returned.  If the tab
 		page does not exist an empty List is returned.
@@ -5290,16 +5297,17 @@ gettabwinvar({tabnr}, {winnr}, {varname} [, {def}])		*gettabwinvar()*
 
 
 gettagstack([{winnr}])					*gettagstack()*
-		The result is a Dict, which is the tag stack of window {winnr}.
+		The result is a Dict, which is the tag stack of window
+		{winnr}.
 		{winnr} can be the window number or the |window-ID|.
 		When {winnr} is not specified, the current window is used.
 		When window {winnr} doesn't exist, an empty Dict is returned.
 
 		The returned dictionary contains the following entries:
-			curidx		Current index in the stack. When at
+			curidx		Current index in the stack.  When at
 					top of the stack, set to (length + 1).
 					Index of bottom of the stack is 1.
-			items		List of items in the stack. Each item
+			items		List of items in the stack.  Each item
 					is a dictionary containing the
 					entries described below.
 			length		Number of entries in the stack.
@@ -5310,9 +5318,9 @@ gettagstack([{winnr}])					*gettagstack()*
 			from		cursor position before the tag jump.
 					See |getpos()| for the format of the
 					returned list.
-			matchnr		current matching tag number. Used when
-					multiple matching tags are found for a
-					name.
+			matchnr		current matching tag number.  Used
+					when multiple matching tags are found
+					for a name.
 			tagname		name of the tag
 
 		See |tagstack| for more information about the tag stack.
@@ -5417,7 +5425,7 @@ getwinpos([{timeout}])					*getwinpos()*
 
 getwinposx()						*getwinposx()*
 		The result is a Number, which is the X coordinate in pixels of
-		the left hand side of the GUI Vim window. Also works for an
+		the left hand side of the GUI Vim window.  Also works for an
 		xterm (uses a timeout of 100 msec).
 		The result will be -1 if the information is not available
 		(e.g. on the Wayland backend).
@@ -5460,7 +5468,7 @@ glob({expr} [, {nosuf} [, {list} [, {alllinks}]]])		*glob()*
 		'wildignorecase' always applies.
 
 		When {list} is present and it is |TRUE| the result is a |List|
-		with all matching files. The advantage of using a List is,
+		with all matching files.  The advantage of using a List is,
 		you also get filenames containing newlines correctly.
 		Otherwise the result is a String and when there are several
 		matches, they are separated by <NL> characters.
@@ -5530,10 +5538,10 @@ globpath({path}, {expr} [, {nosuf} [, {list} [, {alllinks}]]])
 		'suffixes' affect the ordering of matches.
 
 		When {list} is present and it is |TRUE| the result is a |List|
-		with all matching files. The advantage of using a List is, you
-		also get filenames containing newlines correctly. Otherwise
-		the result is a String and when there are several matches,
-		they are separated by <NL> characters.  Example: >
+		with all matching files.  The advantage of using a List is,
+		you also get filenames containing newlines correctly.
+		Otherwise the result is a String and when there are several
+		matches, they are separated by <NL> characters.  Example: >
 			:echo globpath(&rtp, "syntax/c.vim", 0, 1)
 <
 		{alllinks} is used as with |glob()|.
@@ -5804,24 +5812,24 @@ hlget([{name} [, {resolve}]])				*hlget()*
 			cleared	boolean flag, set to v:true if the highlight
 				group attributes are cleared or not yet
 				specified.  See |highlight-clear|.
-			cterm	cterm attributes. See |highlight-cterm|.
+			cterm	cterm attributes.  See |highlight-cterm|.
 			ctermbg	cterm background color.
 				See |highlight-ctermbg|.
 			ctermfg	cterm foreground color.
 				See |highlight-ctermfg|.
 			ctermul	cterm underline color.  See |highlight-ctermul|.
 			default boolean flag, set to v:true if the highlight
-				group link is a default link. See
+				group link is a default link.  See
 				|highlight-default|.
 			font	highlight group font.  See |highlight-font|.
-			gui	gui attributes. See |highlight-gui|.
+			gui	gui attributes.  See |highlight-gui|.
 			guibg	gui background color.  See |highlight-guibg|.
 			guifg	gui foreground color.  See |highlight-guifg|.
 			guisp	gui special color.  See |highlight-guisp|.
 			id	highlight group ID.
 			linksto	linked highlight group name.
 				See |:highlight-link|.
-			name	highlight group name. See |group-name|.
+			name	highlight group name.  See |group-name|.
 			start	start terminal keycode.  See |highlight-start|.
 			stop	stop terminal keycode.  See |highlight-stop|.
 			term	term attributes.  See |highlight-term|.
@@ -5845,7 +5853,7 @@ hlget([{name} [, {resolve}]])				*hlget()*
 hlset({list})						*hlset()*
 		Creates or modifies the attributes of a List of highlight
 		groups.  Each item in {list} is a dictionary containing the
-		attributes of a highlight group. See |hlget()| for the list of
+		attributes of a highlight group.  See |hlget()| for the list of
 		supported items in this dictionary.
 
 		In addition to the items described in |hlget()|, the following
@@ -5947,16 +5955,16 @@ iconv({string}, {from}, {to})				*iconv()*
 
 id({item})							*id()*
 		The result is a unique String associated with the {item} and
-		not with the {item}'s contents. It is only valid while the
-		{item} exists and is referenced. It is valid only in the
-		instance of vim that produces the result. The whole idea is
+		not with the {item}'s contents.  It is only valid while the
+		{item} exists and is referenced.  It is valid only in the
+		instance of vim that produces the result.  The whole idea is
 		that `id({item})` does not change if the contents of {item}
-		changes. This is useful as a `key` for creating an identity
+		changes.  This is useful as a `key` for creating an identity
 		dictionary, rather than one based on equals.
 
 		This operation does not reference {item} and there is no
-		function to convert the `id` to the {item}. It may be useful to
-		have a map of `id` to {item}. The following >
+		function to convert the `id` to the {item}.  It may be useful to
+		have a map of `id` to {item}.  The following >
 		    var referenceMap: dict<any>
 		    var id = item->id()
 		    referenceMap[id] = item
@@ -5964,7 +5972,7 @@ id({item})							*id()*
 		way to get the {item} from the `id`.
 
 		{item} may be a List, Tuple, Dictionary, Object, Job, Channel
-		or Blob. If the item is not a permitted type, or it is a null
+		or Blob.  If the item is not a permitted type, or it is a null
 		value, then an empty String is returned.
 
 		Can also be used as a |method|: >
@@ -6160,7 +6168,8 @@ inputrestore()						*inputrestore()*
 		Restore typeahead that was saved with a previous |inputsave()|.
 		Should be called the same number of times inputsave() is
 		called.  Calling it more often is harmless though.
-		Returns TRUE when there is nothing to restore, FALSE otherwise.
+		Returns TRUE when there is nothing to restore, FALSE
+		otherwise.
 
 		Return type: |Number|
 
@@ -6259,10 +6268,11 @@ invert({expr})						*invert()*
 isabsolutepath({path})					*isabsolutepath()*
 		The result is a Number, which is |TRUE| when {path} is an
 		absolute path.
-		On Unix, a path is considered absolute when it starts with '/'.
-		On MS-Windows, it is considered absolute when it starts with an
-		optional drive prefix and is followed by a '\' or '/'. UNC paths
-		are always absolute.
+		On Unix, a path is considered absolute when it starts with
+		'/'.
+		On MS-Windows, it is considered absolute when it starts with
+		an optional drive prefix and is followed by a '\' or '/'.  UNC
+		paths are always absolute.
 		Example: >
 			echo isabsolutepath('/usr/share/')	" 1
 			echo isabsolutepath('./foobar')		" 0
@@ -6408,7 +6418,7 @@ js_encode({expr})					*js_encode()*
 			[1,,{one:1},,] ~
 		While json_encode() would produce:
 			[1,null,{"one":1},null] ~
-		This encoding is valid for JavaScript. It is more efficient
+		This encoding is valid for JavaScript.  It is more efficient
 		than JSON, especially when using an array with optional items.
 
 		Can also be used as a |method|: >
@@ -6427,7 +6437,7 @@ json_decode({string})				*json_decode()* *E491*
 		- Integer keys are accepted in objects, e.g. {1:2} is the
 		  same as {"1":2}.
 		- More floating point numbers are recognized, e.g. "1." for
-		  "1.0", or "001.2" for "1.2". Special floating point values
+		  "1.0", or "001.2" for "1.2".  Special floating point values
 		  "Infinity", "-Infinity" and "NaN" (capitalization ignored)
 		  are accepted.
 		- Leading zeroes in integer numbers are ignored, e.g. "012"
@@ -6690,7 +6700,8 @@ list2str({list} [, {utf8}])				*list2str()*
 			join(map(list, {nr, val -> nr2char(val)}), '')
 <		|str2list()| does the opposite.
 
-		When {utf8} is omitted or zero, the current 'encoding' is used.
+		When {utf8} is omitted or zero, the current 'encoding' is
+		used.
 		When {utf8} is TRUE, always return UTF-8 characters.
 		With UTF-8 composing characters work as expected: >
 			list2str([97, 769])	returns "á"
@@ -6725,7 +6736,7 @@ list2tuple({list})					*list2tuple()*
 listener_add({callback} [, {buf} [, {unbuffered}]])	*listener_add()*
 		Add a callback function that will be invoked when changes have
 		been made to buffer {buf}.
-		{buf} refers to a buffer name or number. For the accepted
+		{buf} refers to a buffer name or number.  For the accepted
 		values, see |bufname()|.  When {buf} is omitted the current
 		buffer is used.
 		Returns a unique ID that can be passed to |listener_remove()|.
@@ -6791,16 +6802,16 @@ listener_add({callback} [, {buf} [, {unbuffered}]])	*listener_add()*
 
 		Because of the third trigger reason for triggering a callback
 		listed above, the line numbers passed to the callback are not
-		guaranteed to be valid. If this is a problem then make
+		guaranteed to be valid.  If this is a problem then make
 		{unbuffered} |TRUE|.
 
 		When {unbuffered} is |TRUE| the {callback} is invoked for every
-		single change. The changes list only holds a single dictionary
-		and the "start", "end" and "added" values in the dictionary are
-		the same as the corresponding callback arguments. The line
-		numbers are valid when the callback is invoked, but later
-		changes may make them invalid, thus keeping a copy for later
-		might not work.
+		single change.  The changes list only holds a single
+		dictionary and the "start", "end" and "added" values in the
+		dictionary are the same as the corresponding callback
+		arguments.  The line numbers are valid when the callback is
+		invoked, but later changes may make them invalid, thus keeping
+		a copy for later might not work.
 
 		The {callback} is invoked with the text locked, see
 		|textlock|.  If you do need to make changes to the buffer, use
@@ -6827,7 +6838,7 @@ listener_flush([{buf}])					*listener_flush()*
 		Invoke listener callbacks for buffer {buf}.  If there are no
 		pending changes then no callbacks are invoked.
 
-		{buf} refers to a buffer name or number. For the accepted
+		{buf} refers to a buffer name or number.  For the accepted
 		values, see |bufname()|.  When {buf} is omitted the current
 		buffer is used.
 
@@ -6890,7 +6901,7 @@ log10({expr})						*log10()*
 
 luaeval({expr} [, {expr}])					*luaeval()*
 		Evaluate Lua expression {expr} and return its result converted
-		to Vim data structures. Second {expr} may hold additional
+		to Vim data structures.  Second {expr} may hold additional
 		argument accessible as _A inside first {expr}.
 		Strings are returned as they are.
 		Boolean objects are converted to numbers.
@@ -6927,7 +6938,7 @@ map({expr1}, {expr2})					*map()*
 		of the current item.  For a |Dictionary| |v:key| has the key
 		of the current item and for a |List| |v:key| has the index of
 		the current item.  For a |Blob| |v:key| has the index of the
-		current byte. For a |String| |v:key| has the index of the
+		current byte.  For a |String| |v:key| has the index of the
 		current character.
 		Example: >
 			:call map(mylist, '"> " .. v:val .. " <"')
@@ -6945,7 +6956,7 @@ map({expr1}, {expr2})					*map()*
 		accepts one argument, but with a Vim9 lambda you get "E1106:
 		One argument too many", the number of arguments must match.
 
-		The function must return the new value of the item. Example
+		The function must return the new value of the item.  Example
 		that changes each value by "key-value": >
 			func KeyValue(key, val)
 			  return a:key .. '-' .. a:val
@@ -6966,8 +6977,8 @@ map({expr1}, {expr2})					*map()*
 		or a new |Blob| or |String|.
 		When an error is encountered while evaluating {expr2} no
 		further items in {expr1} are processed.
-		When {expr2} is a Funcref errors inside a function are ignored,
-		unless it was defined with the "abort" flag.
+		When {expr2} is a Funcref errors inside a function are
+		ignored, unless it was defined with the "abort" flag.
 
 		Can also be used as a |method|: >
 			mylist->map(expr2)
@@ -6980,8 +6991,8 @@ maparg({name} [, {mode} [, {abbr} [, {dict}]]])			*maparg()*
 		When {dict} is omitted or zero: Return the rhs of mapping
 		{name} in mode {mode}.  The returned String has special
 		characters translated like in the output of the ":map" command
-		listing. When {dict} is TRUE a dictionary is returned, see
-		below. To get a list of all mappings see |maplist()|.
+		listing.  When {dict} is TRUE a dictionary is returned, see
+		below.  To get a list of all mappings see |maplist()|.
 
 		When there is no mapping for {name}, an empty String is
 		returned if {dict} is FALSE, otherwise returns an empty Dict.
@@ -7020,7 +7031,7 @@ maparg({name} [, {mode} [, {abbr} [, {dict}]]])			*maparg()*
 		  "script"   1 if mapping was defined with <script>.
 		  "expr"     1 for an expression mapping (|:map-<expr>|).
 		  "buffer"   1 for a buffer local mapping (|:map-local|).
-		  "mode"     Modes for which the mapping is defined. In
+		  "mode"     Modes for which the mapping is defined.  In
 			     addition to the modes mentioned above, these
 			     characters will be used:
 			     " "     Normal, Visual and Operator-pending
@@ -7036,7 +7047,7 @@ maparg({name} [, {mode} [, {abbr} [, {dict}]]])			*maparg()*
 		  "abbr"     True if this is an abbreviation |abbreviations|.
 		  "mode_bits" Vim's internal binary representation of "mode".
 			     |mapset()| ignores this; only "mode" is used.
-			     See |maplist()| for usage examples. The values
+			     See |maplist()| for usage examples.  The values
 			     are from src/vim.h and may change in the future.
 
 		The dictionary can be used to restore a mapping with
@@ -7104,9 +7115,9 @@ maplist([{abbr}])					*maplist()*
 			echo maplist()->filter(
 				(_, m) => match(m.rhs, 'MultiMatch') >= 0)
 <		It can be tricky to find mappings for particular |:map-modes|.
-		|mapping-dict|'s "mode_bits" can simplify this. For example,
+		|mapping-dict|'s "mode_bits" can simplify this.  For example,
 		the mode_bits for Normal, Insert or Command-line modes are
-		0x19. To find all the mappings available in those modes you
+		0x19.  To find all the mappings available in those modes you
 		can do: >
 			vim9script
 			var saved_maps = []
@@ -7118,7 +7129,7 @@ maplist([{abbr}])					*maplist()*
 			echo saved_maps->mapnew((_, m) => m.lhs)
 <		The values of the mode_bits are defined in Vim's src/vim.h
 		file and they can be discovered at runtime using
-		|:map-commands| and "maplist()". Example: >
+		|:map-commands| and "maplist()".  Example: >
 			vim9script
 			omap xyzzy <Nop>
 			var op_bit = maplist()->filter(
@@ -7144,8 +7155,9 @@ mapset({dict})
 		Restore a mapping from a dictionary, possibly returned by
 		|maparg()| or |maplist()|.  A buffer mapping, when dict.buffer
 		is true, is set on the current buffer; it is up to the caller
-		to ensure that the intended buffer is the current buffer. This
-		feature allows copying mappings from one buffer to another.
+		to ensure that the intended buffer is the current buffer.
+		This feature allows copying mappings from one buffer to
+		another.
 		The dict.mode value may restore a single mapping that covers
 		more than one mode, like with mode values of '!', ' ', 'nox',
 		or 'v'. *E1276*
@@ -7284,9 +7296,9 @@ matchadd({group}, {pattern} [, {priority} [, {id} [, {dict}]]])
 		automatically chooses a free ID, which is at least 1000.
 
 		The optional {dict} argument allows for further custom
-		values. Currently this is used to specify a match specific
+		values.  Currently this is used to specify a match specific
 		conceal character that will be shown for |hl-Conceal|
-		highlighted matches. The dict can have the following members:
+		highlighted matches.  The dict can have the following members:
 
 			conceal	    Special character to show instead of the
 				    match (only for |hl-Conceal| highlighted
@@ -7318,9 +7330,9 @@ matchadd({group}, {pattern} [, {priority} [, {id} [, {dict}]]])
 							*matchaddpos()*
 matchaddpos({group}, {pos} [, {priority} [, {id} [, {dict}]]])
 		Same as |matchadd()|, but requires a list of positions {pos}
-		instead of a pattern. This command is faster than |matchadd()|
+		instead of a pattern.  This command is faster than |matchadd()|
 		because it does not handle regular expressions and it sets
-		buffer line boundaries to redraw screen. It is supposed to be
+		buffer line boundaries to redraw screen.  It is supposed to be
 		used when fast match additions and deletions are required, for
 		example to highlight matching parentheses.
 
@@ -7328,14 +7340,14 @@ matchaddpos({group}, {pos} [, {priority} [, {id} [, {dict}]]])
 		these:
 		- A number.  This whole line will be highlighted.  The first
 		  line has number 1.
-		- A list with one number, e.g., [23]. The whole line with this
-		  number will be highlighted.
-		- A list with two numbers, e.g., [23, 11]. The first number is
-		  the line number, the second one is the column number (first
-		  column is 1, the value must correspond to the byte index as
-		  |col()| would return).  The character at this position will
-		  be highlighted.
-		- A list with three numbers, e.g., [23, 11, 3]. As above, but
+		- A list with one number, e.g., [23].  The whole line with
+		  this number will be highlighted.
+		- A list with two numbers, e.g., [23, 11].  The first number
+		  is the line number, the second one is the column number
+		  (first column is 1, the value must correspond to the byte
+		  index as |col()| would return).  The character at this
+		  position will be highlighted.
+		- A list with three numbers, e.g., [23, 11, 3].  As above, but
 		  the third number gives the length of the highlight in bytes.
 
 		Returns -1 on error.
@@ -7365,7 +7377,7 @@ matcharg({nr})							*matcharg()*
 		When there is no match item set returns ['', ''].
 		This is useful to save and restore a |:match|.
 		Highlighting matches using the |:match| commands are limited
-		to three matches. |matchadd()| does not have this limitation.
+		to three matches.  |matchadd()| does not have this limitation.
 
 		Can also be used as a |method|: >
 			GetMatch()->matcharg()
@@ -7389,7 +7401,7 @@ matchbufline({buf}, {pat}, {lnum}, {end}, [, {dict}])
 		    text	matched string
 		Note that there can be multiple matches in a single line.
 
-		This function works only for loaded buffers. First call
+		This function works only for loaded buffers.  First call
 		|bufload()| if needed.
 
 		See |match-pattern| for information about the effect of some
@@ -7466,7 +7478,7 @@ matchend({expr}, {pat} [, {start} [, {count}]])			*matchend()*
 
 matchfuzzy({list}, {str} [, {dict}])			*matchfuzzy()*
 		If {list} is a list of strings, then returns a |List| with all
-		the strings in {list} that fuzzy match {str}. The strings in
+		the strings in {list} that fuzzy match {str}.  The strings in
 		the returned list are sorted based on the matching score.
 
 		The optional {dict} argument always supports the following
@@ -7480,7 +7492,7 @@ matchfuzzy({list}, {str} [, {dict}])			*matchfuzzy()*
 		If {list} is a list of dictionaries, then the optional {dict}
 		argument supports the following additional items:
 		    key		Key of the item which is fuzzy matched against
-				{str}. The value of this item should be a
+				{str}.  The value of this item should be a
 				string.
 		    text_cb	|Funcref| that will be called for every item
 				in {list} to get the text for fuzzy matching.
@@ -7496,7 +7508,7 @@ matchfuzzy({list}, {str} [, {dict}])			*matchfuzzy()*
 		then the list of strings that have all the words is returned.
 
 		If there are no matching strings or there is an error, then an
-		empty list is returned. If length of {str} is greater than
+		empty list is returned.  If length of {str} is greater than
 		256, then returns an empty list.
 
 		When {limit} is given, matchfuzzy() will find up to this
@@ -7659,7 +7671,7 @@ matchstrpos({expr}, {pat} [, {start} [, {count}]])		*matchstrpos()*
 
 
 max({expr})							*max()*
-		Return the maximum value of all items in {expr}. Example: >
+		Return the maximum value of all items in {expr}.  Example: >
 			echo max([apples, pears, oranges])
 
 <		{expr} can be a |List|, a |Tuple| or a |Dictionary|.  For a
@@ -7677,8 +7689,8 @@ max({expr})							*max()*
 
 menu_info({name} [, {mode}])				*menu_info()*
 		Return information about the specified menu {name} in
-		mode {mode}. The menu name should be specified without the
-		shortcut character ('&'). If {name} is "", then the top-level
+		mode {mode}.  The menu name should be specified without the
+		shortcut character ('&').  If {name} is "", then the top-level
 		menu names are returned.
 
 		{mode} can be one of these strings:
@@ -7702,7 +7714,7 @@ menu_info({name} [, {mode}])				*menu_info()*
 		  icon		name of the icon file (for toolbar)
 				|toolbar-icon|
 		  iconidx	index of a built-in icon
-		  modes		modes for which the menu is defined. In
+		  modes		modes for which the menu is defined.  In
 				addition to the modes mentioned above, these
 				characters will be used:
 				" "	Normal, Visual and Operator-pending
@@ -7710,11 +7722,11 @@ menu_info({name} [, {mode}])				*menu_info()*
 		  noremenu	v:true if the {rhs} of the menu item is not
 				remappable else v:false.
 		  priority	menu order priority |menu-priority|
-		  rhs		right-hand-side of the menu item. The returned
-				string has special characters translated like
-				in the output of the ":menu" command listing.
-				When the {rhs} of a menu item is empty, then
-				"<Nop>" is returned.
+		  rhs		right-hand-side of the menu item.  The
+				returned string has special characters
+				translated like in the output of the ":menu"
+				command listing.  When the {rhs} of a menu
+				item is empty, then "<Nop>" is returned.
 		  script	v:true if script-local remapping of {rhs} is
 				allowed else v:false.  See |:menu-script|.
 		  shortcut	shortcut key (character after '&' in
@@ -7869,8 +7881,8 @@ mode([{expr}])							*mode()*
 		with |remote_expr()| In most other places it always returns
 		"c" or "n".
 		Note that in the future more modes and more specific modes may
-		be added. It's better not to compare the whole string but only
-		the leading character(s).
+		be added.  It's better not to compare the whole string but
+		only the leading character(s).
 		Also see |visualmode()|.
 
 		Can also be used as a |method|: >
@@ -7923,7 +7935,7 @@ nextnonblank({lnum})					*nextnonblank()*
 ngettext({single}, {plural}, {number}[, {domain})	*ngettext()*
 		Return a string that contains the correct value for a
 		message based on the rules for plural form(s) in
-		a language. Examples: >
+		a language.  Examples: >
 			ngettext("File", "Files", 2)  # returns "Files"
 <
 		Can be used as a |method|: >
@@ -7997,8 +8009,8 @@ pathshorten({path} [, {len}])				*pathshorten()*
 
 perleval({expr})					*perleval()*
 		Evaluate Perl expression {expr} in scalar context and return
-		its result converted to Vim data structures. If value can't be
-		converted, it is returned as a string Perl representation.
+		its result converted to Vim data structures.  If value can't
+		be converted, it is returned as a string Perl representation.
 		Note: If you want an array or hash, {expr} must return a
 		reference to it.
 		Example: >
@@ -8105,8 +8117,8 @@ printf({fmt}, {expr1} ...)				*printf()*
 			% [pos-argument] [flags] [field-width] [.precision] type
 
 		pos-argument
-			At most one positional argument specifier. These
-			take the form {n$}, where n is >= 1.
+			At most one positional argument specifier.  These take
+			the form {n$}, where n is >= 1.
 
 		flags
 			Zero or more of the following flags:
@@ -8182,7 +8194,7 @@ printf({fmt}, {expr1} ...)				*printf()*
 		positional argument specifier, and a '*' is used to indicate
 		that a number argument is to be used to specify the width or
 		precision, the argument(s) to be used must also be specified
-		using a {n$} positional argument specifier. See |printf-$|.
+		using a {n$} positional argument specifier.  See |printf-$|.
 
 		The conversion specifiers and their meanings are:
 
@@ -8209,7 +8221,7 @@ printf({fmt}, {expr1} ...)				*printf()*
 			The b and B conversion specifiers never take a width
 			modifier and always assume their argument is a 64 bit
 			integer.
-			Generally, these modifiers are not useful. They are
+			Generally, these modifiers are not useful.  They are
 			ignored when type is known from the argument.
 
 		i	alias for d
@@ -8281,9 +8293,9 @@ printf({fmt}, {expr1} ...)				*printf()*
 							*printf-$*
 		In certain languages, error and informative messages are
 		more readable when the order of words is different from the
-		corresponding message in English. To accommodate translations
+		corresponding message in English.  To accommodate translations
 		having a different word order, positional arguments may be
-		used to indicate this. For instance: >
+		used to indicate this.  For instance: >
 
 		    #, c-format
 		    msgid "%s returning %s"
@@ -8302,9 +8314,9 @@ printf({fmt}, {expr1} ...)				*printf()*
 			"Bram", "Moolenaar")
 <		    In Belgium, vim's creator's name is: Moolenaar Bram
 
-		Width (and precision) can be specified using the '*' specifier.
-		In this case, you must specify the field width position in the
-		argument list. >
+		Width (and precision) can be specified using the '*'
+		specifier.  In this case, you must specify the field width
+		position in the argument list. >
 
 		    echo printf("%1$*2$.*3$d", 1, 2, 3)
 <		    001 >
@@ -8504,8 +8516,8 @@ py3eval({expr} [, {locals}])				*py3eval()*
 		Evaluate Python expression {expr} and return its result
 		converted to Vim data structures.
 		If a {locals} |Dictionary| is given, it defines set of local
-		variables available in the expression. The keys are variable
-		names and the values are the variable values. |Dictionary|,
+		variables available in the expression.  The keys are variable
+		names and the values are the variable values.  |Dictionary|,
 		|List| and |Tuple| values are referenced, and may be updated
 		by the expression (as if |python-bindeval| was used).
 		Numbers and strings are returned as they are (strings are
@@ -8655,8 +8667,8 @@ readdir({directory} [, {expr} [, {dict}]])			*readdir()*
 		  readdir(dirname, {n -> n !~ '^\.\|\~$'})
 <								*E857*
 		The optional {dict} argument allows for further custom
-		values. Currently this is used to specify if and how sorting
-		should be performed. The dict can have the following members:
+		values.  Currently this is used to specify if and how sorting
+		should be performed.  The dict can have the following members:
 
 		    sort    How to sort the result returned from the system.
 			    Valid values are:
@@ -8707,9 +8719,9 @@ readdirex({directory} [, {expr} [, {dict}]])			*readdirex()*
 		following items:
 			group	Group name of the entry. (Only on Unix)
 			name	Name of the entry.
-			perm	Permissions of the entry. See |getfperm()|.
-			size	Size of the entry. See |getfsize()|.
-			time	Timestamp of the entry. See |getftime()|.
+			perm	Permissions of the entry.  See |getfperm()|.
+			size	Size of the entry.  See |getfsize()|.
+			time	Timestamp of the entry.  See |getftime()|.
 			type	Type of the entry.
 				On Unix, almost same as |getftype()| except:
 				    Symlink to a dir	"linkd"
@@ -8891,8 +8903,8 @@ reltimestr({time})				*reltimestr()*
 			call MyFunction()
 			echo reltimestr(reltime(start))
 <		Note that overhead for the commands will be added to the time.
-		The accuracy depends on the system. Use reltimefloat() for the
-		greatest accuracy which is nanoseconds on some systems.
+		The accuracy depends on the system.  Use reltimefloat() for
+		the greatest accuracy which is nanoseconds on some systems.
 		Leading spaces are used to make the string align nicely.  You
 		can use split() to remove it. >
 			echo split(reltimestr(reltime(start)))[0]
@@ -9132,7 +9144,7 @@ resolve({filename})					*resolve()* *E655*
 		On MS-Windows, when {filename} is a shortcut (a .lnk file),
 		returns the path the shortcut points to in a simplified form.
 		When {filename} is a symbolic link or junction point, return
-		the full path to the target. If the target of junction is
+		the full path to the target.  If the target of junction is
 		removed, return {filename}.
 		On Unix, repeat resolving symbolic links in all path
 		components of {filename} and return the simplified result.
@@ -9249,13 +9261,13 @@ screenchars({row}, {col})					*screenchars()*
 
 screencol()							*screencol()*
 		The result is a Number, which is the current screen column of
-		the cursor. The leftmost column has number 1.
+		the cursor.  The leftmost column has number 1.
 		This function is mainly used for testing.
 
 		Note: Always returns the current screen column, thus if used
 		in a command (e.g. ":echo screencol()") it will return the
 		column inside the command line, which is 1 when the command is
-		executed. To get the cursor position in the file use one of
+		executed.  To get the cursor position in the file use one of
 		the following mappings: >
 			nnoremap <expr> GG ":echom " .. screencol() .. "\n"
 			nnoremap <silent> GG :echom screencol()<CR>
@@ -9341,7 +9353,7 @@ search({pattern} [, {flags} [, {stopline} [, {timeout} [, {skip}]]]])
 		If neither 'w' or 'W' is given, the 'wrapscan' option applies.
 
 		If the 's' flag is supplied, the ' mark is set, only if the
-		cursor is moved. The 's' flag cannot be combined with the 'n'
+		cursor is moved.  The 's' flag cannot be combined with the 'n'
 		flag.
 
 		'ignorecase', 'smartcase' and 'magic' are used.
@@ -9436,7 +9448,7 @@ searchcount([{options}])					*searchcount()*
 		without the "S" flag in 'shortmess'.  This works even if
 		'shortmess' does contain the "S" flag.
 
-		This returns a |Dictionary|. The dictionary is empty if the
+		This returns a |Dictionary|.  The dictionary is empty if the
 		previous pattern was not set and "pattern" was not specified.
 
 		  key		type		meaning ~
@@ -9453,10 +9465,10 @@ searchcount([{options}])					*searchcount()*
 		For {options} see further down.
 
 		To get the last search count when |n| or |N| was pressed, call
-		this function with `recompute: 0` . This sometimes returns
+		this function with `recompute: 0` .  This sometimes returns
 		wrong information because of 'maxsearchcount'.
 		If the count exceeded 'maxsearchcount', the result must be
-		'maxsearchcount' + 1. If you want to get correct information,
+		'maxsearchcount' + 1.  If you want to get correct information,
 		specify `recompute: 1`: >
 
 			" result == 'maxsearchcount' + 1 when many matches
@@ -9519,7 +9531,7 @@ searchcount([{options}])					*searchcount()*
 			" search again
 			call searchcount()
 <
-		{options} must be a |Dictionary|. It can contain:
+		{options} must be a |Dictionary|.  It can contain:
 		  key		type		meaning ~
 		  recompute	|Boolean|	if |TRUE|, recompute the count
 						like |n| or |N| was executed.
@@ -9677,7 +9689,7 @@ searchpair({start}, {middle}, {end} [, {flags} [, {skip}
 searchpairpos({start}, {middle}, {end} [, {flags} [, {skip}
 				[, {stopline} [, {timeout}]]]])
 		Same as |searchpair()|, but returns a |List| with the line and
-		column position of the match. The first element of the |List|
+		column position of the match.  The first element of the |List|
 		is the line number and the second element is the byte index of
 		the column position of the match.  If no match is found,
 		returns [0, 0]. >
@@ -9691,9 +9703,9 @@ searchpairpos({start}, {middle}, {end} [, {flags} [, {skip}
 							*searchpos()*
 searchpos({pattern} [, {flags} [, {stopline} [, {timeout} [, {skip}]]]])
 		Same as |search()|, but returns a |List| with the line and
-		column position of the match. The first element of the |List|
+		column position of the match.  The first element of the |List|
 		is the line number and the second element is the byte index of
-		the column position of the match. If no match is found,
+		the column position of the match.  If no match is found,
 		returns [0, 0].
 		Example: >
 	:let [lnum, col] = searchpos('mypattern', 'n')
@@ -9744,7 +9756,7 @@ setbufline({buf}, {lnum}, {text})			*setbufline()*
 		Set line {lnum} to {text} in buffer {buf}.  This works like
 		|setline()| for the specified buffer.
 
-		This function works only for loaded buffers. First call
+		This function works only for loaded buffers.  First call
 		|bufload()| if needed.
 
 		To insert lines use |appendbufline()|.
@@ -9967,7 +9979,7 @@ setfperm({fname}, {mode})				*setfperm()* *chmod*
 
 setline({lnum}, {text})					*setline()*
 		Set line {lnum} of the current buffer to {text}.  To insert
-		lines use |append()|. To set lines in another buffer use
+		lines use |append()|.  To set lines in another buffer use
 		|setbufline()|.
 		Any text properties in {lnum} are cleared.  See
 		|text-prop-cleared|
@@ -9979,8 +9991,8 @@ setline({lnum}, {text})					*setline()*
 		converted to a String.  When {text} is an empty List then
 		nothing is changed and FALSE is returned.
 
-		If this succeeds, FALSE is returned.  If this fails (most likely
-		because {lnum} is invalid) TRUE is returned.
+		If this succeeds, FALSE is returned.  If this fails (most
+		likely because {lnum} is invalid) TRUE is returned.
 		In |Vim9| script an error is given if {lnum} is invalid.
 
 		Example: >
@@ -10016,7 +10028,7 @@ setloclist({nr}, {list} [, {action} [, {what}]])		*setloclist()*
 		For {action} see |setqflist-action|.
 
 		If the optional {what} dictionary argument is supplied, then
-		only the items listed in {what} are set. Refer to |setqflist()|
+		only the items listed in {what} are set.  Refer to |setqflist()|
 		for the list of supported keys in {what}.
 
 		Can also be used as a |method|, the base is passed as the
@@ -10060,10 +10072,10 @@ setpos({expr}, {list})					*setpos()*
 
 		"lnum" and "col" are the position in the buffer.  The first
 		column is 1.  Use a zero "lnum" to delete a mark.  If "col" is
-		smaller than 1 then 1 is used. To use the character count
+		smaller than 1 then 1 is used.  To use the character count
 		instead of the byte count, use |setcharpos()|.
 
-		The "off" number is only used when 'virtualedit' is set. Then
+		The "off" number is only used when 'virtualedit' is set.  Then
 		it is the offset in screen columns from the start of the
 		character.  E.g., a position within a <Tab> or after the last
 		character.
@@ -10099,14 +10111,14 @@ setqflist({list} [, {action} [, {what}]])		*setqflist()*
 		Create or replace or add to the quickfix list.
 
 		If the optional {what} dictionary argument is supplied, then
-		only the items listed in {what} are set. The first {list}
+		only the items listed in {what} are set.  The first {list}
 		argument is ignored.  See below for the supported items in
 		{what}.
 							*setqflist-what*
-		When {what} is not present, the items in {list} are used.  Each
-		item must be a dictionary.  Non-dictionary items in {list} are
-		ignored.  Each dictionary item can contain the following
-		entries:
+		When {what} is not present, the items in {list} are used.
+		Each item must be a dictionary.  Non-dictionary items in
+		{list} are ignored.  Each dictionary item can contain the
+		following entries:
 
 		    bufnr	buffer number; must be the number of a valid
 				buffer
@@ -10145,7 +10157,7 @@ setqflist({list} [, {action} [, {what}]])		*setqflist()*
 
 		{action} values:		*setqflist-action* *E927*
 		'a'	The items from {list} are added to the existing
-			quickfix list. If there is no existing list, then a
+			quickfix list.  If there is no existing list, then a
 			new list is created.
 
 		'r'	The items from the current quickfix list are replaced
@@ -10159,23 +10171,23 @@ setqflist({list} [, {action} [, {what}]])		*setqflist()*
 			freed.
 
 		If {action} is not present or is set to ' ', then a new list
-		is created. The new quickfix list is added after the current
+		is created.  The new quickfix list is added after the current
 		quickfix list in the stack and all the following lists are
-		freed. To add a new quickfix list at the end of the stack,
+		freed.  To add a new quickfix list at the end of the stack,
 		set "nr" in {what} to "$".
 
 		The following items can be specified in dictionary {what}:
-		    context	quickfix list context. See |quickfix-context|
+		    context	quickfix list context.  See |quickfix-context|
 		    efm		errorformat to use when parsing text from
-				"lines". If this is not present, then the
+				"lines".  If this is not present, then the
 				'errorformat' option value is used.
 				See |quickfix-parse|
 		    id		quickfix list identifier |quickfix-ID|
 		    idx		index of the current entry in the quickfix
-				list specified by 'id' or 'nr'. If set to '$',
-				then the last entry in the list is set as the
-				current entry.  See |quickfix-index|
-		    items	list of quickfix entries. Same as the {list}
+				list specified by 'id' or 'nr'.  If set to
+				'$', then the last entry in the list is set as
+				the current entry.  See |quickfix-index|
+		    items	list of quickfix entries.  Same as the {list}
 				argument.
 		    lines	use 'errorformat' to parse a list of lines and
 				add the resulting entries to the quickfix list
@@ -10190,11 +10202,11 @@ setqflist({list} [, {action} [, {what}]])		*setqflist()*
 				a function or a funcref or a lambda.  Refer to
 				|quickfix-window-function| for an explanation
 				of how to write the function and an example.
-		    title	quickfix list title text. See |quickfix-title|
+		    title	quickfix list title text.  See |quickfix-title|
 		Unsupported keys in {what} are ignored.
-		If the "nr" item is not present, then the current quickfix list
-		is modified. When creating a new quickfix list, "nr" can be
-		set to a value one greater than the quickfix stack size.
+		If the "nr" item is not present, then the current quickfix
+		list is modified.  When creating a new quickfix list, "nr" can
+		be set to a value one greater than the quickfix stack size.
 		When modifying a quickfix list, to guarantee that the correct
 		list is modified, "id" should be used instead of "nr" to
 		specify the list.
@@ -10239,14 +10251,14 @@ setreg({regname}, {value} [, {options}])			*setreg()*
 
 		If {options} contains no register settings, then the default
 		is to use character mode unless {value} ends in a <NL> for
-		string {value} and linewise mode for list {value}. Blockwise
+		string {value} and linewise mode for list {value}.  Blockwise
 		mode is never selected automatically.
 		Returns zero for success, non-zero for failure.
 
 							*E883*
 		Note: you may not use |List| containing more than one item to
-		      set search and expression registers. Lists containing no
-		      items act like empty strings.
+		      set search and expression registers.  Lists containing
+		      no items act like empty strings.
 
 		Examples: >
 			:call setreg(v:register, @*)
@@ -10326,7 +10338,7 @@ settagstack({nr}, {dict} [, {action}])			*settagstack()*
 		{nr} can be the window number or the |window-ID|.
 
 		For a list of supported items in {dict}, refer to
-		|gettagstack()|. "curidx" takes effect before changing the tag
+		|gettagstack()|.  "curidx" takes effect before changing the tag
 		stack.
 							*E962*
 		How the tag stack is modified depends on the {action}
@@ -10400,7 +10412,7 @@ shellescape({string} [, {special}])			*shellescape()*
 		replace all "'" with "'\''".
 
 		The {special} argument adds additional escaping of keywords
-		used in Vim commands. When it is not omitted and a non-zero
+		used in Vim commands.  When it is not omitted and a non-zero
 		number or a non-empty String (|non-zero-arg|), then special
 		items such as "!", "%", "#" and "<cword>" (as listed in
 		|expand()|) will be preceded by a backslash.
@@ -10416,8 +10428,8 @@ shellescape({string} [, {special}])			*shellescape()*
 		escaped a second time.
 
 		The "\" character will be escaped when 'shell' contains "fish"
-		in the tail. That is because for fish "\" is used as an escape
-		character inside single quotes.
+		in the tail.  That is because for fish "\" is used as an
+		escape character inside single quotes.
 
 		Example of use with a |:!| command: >
 		    :exe '!dir ' .. shellescape(expand('<cfile>'), 1)
@@ -10433,16 +10445,17 @@ shellescape({string} [, {special}])			*shellescape()*
 
 
 shiftwidth([{col}])						*shiftwidth()*
-		Returns the effective value of 'shiftwidth'. This is the
+		Returns the effective value of 'shiftwidth'.  This is the
 		'shiftwidth' value unless it is zero, in which case it is the
 		'tabstop' value.  This function was introduced with patch
 		7.3.694 in 2012, everybody should have it by now (however it
 		did not allow for the optional {col} argument until 8.1.542).
 
 		When there is one argument {col} this is used as column number
-		for which to return the 'shiftwidth' value. This matters for the
-		'vartabstop' feature. If the 'vartabstop' setting is enabled and
-		no {col} argument is given, column 1 will be assumed.
+		for which to return the 'shiftwidth' value.  This matters for
+		the 'vartabstop' feature.  If the 'vartabstop' setting is
+		enabled and no {col} argument is given, column 1 will be
+		assumed.
 
 		Can also be used as a |method|: >
 			GetColumn()->shiftwidth()
@@ -10458,7 +10471,7 @@ simplify({filename})					*simplify()*
 		Unix) are not resolved.  If the first path component in
 		{filename} designates the current directory, this will be
 		valid for the result as well.  A trailing path separator is
-		not removed either. On Unix "//path" is unchanged, but
+		not removed either.  On Unix "//path" is unchanged, but
 		"///path" is simplified to "/path" (this follows the Posix
 		standard).
 		Example: >
@@ -10540,11 +10553,11 @@ sort({list} [, {how} [, {dict}]])			*sort()* *E702*
 		can be used to ignore case.  Zero means to not ignore case.
 
 		When {how} is given and it is 'l' then the current collation
-		locale is used for ordering. Implementation details: strcoll()
-		is used to compare strings. See |:language| check or set the
-		collation locale. |v:collate| can also be used to check the
-		current locale. Sorting using the locale typically ignores
-		case. Example: >
+		locale is used for ordering.  Implementation details:
+		strcoll() is used to compare strings.  See |:language| check
+		or set the collation locale.  |v:collate| can also be used to
+		check the current locale.  Sorting using the locale typically
+		ignores case.  Example: >
 			" ö is sorted similarly to o with English locale.
 			:language collate en_US.UTF8
 			:echo sort(['n', 'o', 'O', 'ö', 'p', 'z'], 'l')
@@ -10563,11 +10576,11 @@ sort({list} [, {how} [, {dict}]])			*sort()* *E702*
 		sort a list of strings with numbers!
 
 		When {how} is given and it is 'N' then all items will be
-		sorted numerical. This is like 'n' but a string containing
+		sorted numerical.  This is like 'n' but a string containing
 		digits will be used as the number they represent.
 
 		When {how} is given and it is 'f' then all items will be
-		sorted numerical. All values must be a Number or a Float.
+		sorted numerical.  All values must be a Number or a Float.
 
 		When {how} is a |Funcref| or a function name, this function
 		is called to compare items.  The function is invoked with two
@@ -10579,7 +10592,7 @@ sort({list} [, {how} [, {dict}]])			*sort()* *E702*
 		used to set the local variable "self". |Dictionary-function|
 
 		The sort is stable, items which compare equal (as number or as
-		string) will keep their relative position. E.g., when sorting
+		string) will keep their relative position.  E.g., when sorting
 		on numbers, text strings will sort next to each other, in the
 		same order as they were originally.
 
@@ -10675,7 +10688,7 @@ sound_stop({id})					*sound_stop()*
 		package, otherwise sound may not stop.
 
 		On MS-Windows, this does not work for event sound started by
-		`sound_playevent()`. To stop event sounds, use `sound_clear()`.
+		`sound_playevent()`.  To stop event sounds, use `sound_clear()`.
 
 		Can also be used as a |method|: >
 			soundid->sound_stop()
@@ -10761,7 +10774,7 @@ split({string} [, {pattern} [, {keepempty}]])			*split()*
 		empty each white space separated sequence of characters
 		becomes an item.
 		Otherwise the string is split where {pattern} matches,
-		removing the matched characters. 'ignorecase' is not used
+		removing the matched characters.  'ignorecase' is not used
 		here, add \c to ignore case. |/\c|
 		When the first or last item is empty it is omitted, unless the
 		{keepempty} argument is given and it's non-zero.
@@ -10929,7 +10942,8 @@ str2list({string} [, {utf8}])					*str2list()*
 			str2list("ABC")		returns [65, 66, 67]
 <		|list2str()| does the opposite.
 
-		When {utf8} is omitted or zero, the current 'encoding' is used.
+		When {utf8} is omitted or zero, the current 'encoding' is
+		used.
 		When {utf8} is TRUE, always treat the String as UTF-8
 		characters.  With UTF-8 composing characters are handled
 		properly: >
@@ -11047,7 +11061,8 @@ strdisplaywidth({string} [, {col}])			*strdisplaywidth()*
 		matters for anything that's displayed differently, such as
 		'tabstop' and 'display'.
 		When {string} contains characters with East Asian Width Class
-		Ambiguous, this function's return value depends on 'ambiwidth'.
+		Ambiguous, this function's return value depends on
+		'ambiwidth'.
 		Returns zero on error.
 		Also see |strlen()|, |strwidth()| and |strchars()|.
 
@@ -11305,7 +11320,8 @@ strwidth({string})					*strwidth()*
 		String {string} occupies.  A Tab character is counted as one
 		cell, alternatively use |strdisplaywidth()|.
 		When {string} contains characters with East Asian Width Class
-		Ambiguous, this function's return value depends on 'ambiwidth'.
+		Ambiguous, this function's return value depends on
+		'ambiwidth'.
 		Returns zero on error.
 		Also see |strlen()|, |strdisplaywidth()| and |strchars()|.
 
@@ -11378,7 +11394,7 @@ substitute({string}, {pat}, {sub}, {flags})		*substitute()*
 <		results in "TESTING".
 
 		When {sub} starts with "\=", the remainder is interpreted as
-		an expression. See |sub-replace-expression|.  Example: >
+		an expression.  See |sub-replace-expression|.  Example: >
 		   :echo substitute(s, '%\(\x\x\)',
 			   \ '\=nr2char("0x" .. submatch(1))', 'g')
 
@@ -11414,7 +11430,7 @@ swapfilelist()						*swapfilelist()*
 
 swapinfo({fname})					*swapinfo()*
 		The result is a dictionary, which holds information about the
-		swapfile {fname}. The available fields are:
+		swapfile {fname}.  The available fields are:
 			version Vim version
 			user	user name
 			host	host name
@@ -11543,14 +11559,14 @@ synconcealed({lnum}, {col})				*synconcealed()*
 		1. The first item in the list is 0 if the character at the
 		   position {lnum} and {col} is not part of a concealable
 		   region, 1 if it is.  {lnum} is used like with |getline()|.
-		2. The second item in the list is a string. If the first item
+		2. The second item in the list is a string.  If the first item
 		   is 1, the second item contains the text which will be
 		   displayed in place of the concealed text, depending on the
 		   current setting of 'conceallevel' and 'listchars'.
 		3. The third and final item in the list is a number
 		   representing the specific syntax region matched in the
-		   line. When the character is not concealed the value is
-		   zero. This allows detection of the beginning of a new
+		   line.  When the character is not concealed the value is
+		   zero.  This allows detection of the beginning of a new
 		   concealable region if there are two consecutive regions
 		   with the same replacement character.  For an example, if
 		   the text is "123456" and both "23" and "45" are concealed
@@ -11660,10 +11676,10 @@ system({expr} [, {input}])				*system()* *E677*
 
 systemlist({expr} [, {input}])				*systemlist()*
 		Same as |system()|, but returns a |List| with lines (parts of
-		output separated by NL) with NULs transformed into NLs. Output
-		is the same as |readfile()| will output with {binary} argument
-		set to "b", except that there is no extra empty item when the
-		result ends in a NL.
+		output separated by NL) with NULs transformed into NLs.
+		Output is the same as |readfile()| will output with {binary}
+		argument set to "b", except that there is no extra empty item
+		when the result ends in a NL.
 		Note that on MS-Windows you may get trailing CR characters.
 
 		To see the difference between "echo hello" and "echo -n hello"
@@ -11681,7 +11697,7 @@ systemlist({expr} [, {input}])				*systemlist()*
 tabpagebuflist([{arg}])					*tabpagebuflist()*
 		The result is a |List|, where each item is the number of the
 		buffer associated with each window in the current tab page.
-		{arg} specifies the number of the tab page to be used. When
+		{arg} specifies the number of the tab page to be used.  When
 		omitted the current tab page is used.
 		When {arg} is invalid the number zero is returned.
 		To get a list of all buffers in all tabs use this: >
@@ -11744,7 +11760,7 @@ taglist({expr} [, {filename}])				*taglist()*
 		Returns a |List| of tags matching the regular expression {expr}.
 
 		If {filename} is passed it is used to prioritize the results
-		in the same way that |:tselect| does. See |tag-priority|.
+		in the same way that |:tselect| does.  See |tag-priority|.
 		{filename} should be the full path of the file.
 
 		Each list item is a dictionary with at least the following
@@ -11780,7 +11796,7 @@ taglist({expr} [, {filename}])				*taglist()*
 		search regular expression pattern.
 
 		Refer to 'tags' for information about how the tags file is
-		located by Vim. Refer to |tags-file-format| for the format of
+		located by Vim.  Refer to |tags-file-format| for the format of
 		the tags file generated by the different ctags tools.
 
 		Can also be used as a |method|: >
@@ -11933,7 +11949,7 @@ timer_pause({timer}, {paused})				*timer_pause()*
 timer_start({time}, {callback} [, {options}])
 		Create a timer and return the timer ID.
 
-		{time} is the waiting time in milliseconds. This is the
+		{time} is the waiting time in milliseconds.  This is the
 		minimum time before invoking the callback.  When the system is
 		busy or Vim is not waiting for input the time will be longer.
 		Zero can be used to execute the callback when Vim is back in
@@ -12311,8 +12327,9 @@ utf16idx({string}, {idx} [, {countcc} [, {charidx}]])
 		downwards to the beginning of that sequence.
 
 		Returns -1 if the arguments are invalid or if there are less
-		than {idx} bytes in {string}. If there are exactly {idx} bytes
-		the length of the string in UTF-16 code units is returned.
+		than {idx} bytes in {string}.  If there are exactly {idx}
+		bytes the length of the string in UTF-16 code units is
+		returned.
 
 		See |byteidx()| and |byteidxcomp()| for getting the byte index
 		from the UTF-16 index and |charidx()| for getting the
@@ -12351,7 +12368,7 @@ virtcol({expr} [, {list} [, {winid}]])			*virtcol()*
 		the character at that position.  When there is a <Tab> at the
 		position, the returned Number will be the column at the end of
 		the <Tab>.  For example, for a <Tab> in column 1, with 'ts'
-		set to 8, it returns 8. |conceal| is ignored.
+		set to 8, it returns 8.  |conceal| is ignored.
 		For the byte position use |col()|.
 
 		For the use of {expr} see |getpos()| and |col()|.
@@ -12413,7 +12430,7 @@ virtcol2col({winid}, {lnum}, {col})			*virtcol2col()*
 		byte in the character is returned.
 
 		The {winid} argument can be the window number or the
-		|window-ID|. If this is zero, then the current window is used.
+		|window-ID|.  If this is zero, then the current window is used.
 
 		Returns -1 if the window {winid} doesn't exist or the buffer
 		line {lnum} or virtual column {col} is invalid.
@@ -12451,7 +12468,7 @@ wildmenumode()					*wildmenumode()*
 		Returns |TRUE| when the wildmenu is active and |FALSE|
 		otherwise.  See 'wildmenu' and 'wildmode'.
 		This can be used in mappings to handle the 'wildcharm' option
-		gracefully. (Makes only sense with |mapmode-c| mappings).
+		gracefully.  (Makes only sense with |mapmode-c| mappings).
 
 		For example to make <c-j> work like <down> in wildmode, use: >
     :cnoremap <expr> <C-j> wildmenumode() ? "\<Down>\<Tab>" : "\<c-j>"
@@ -12534,7 +12551,7 @@ win_getid([{win} [, {tab}]])				*win_getid()*
 
 win_gettype([{nr}])					*win_gettype()*
 		Return the type of the window:
-			"autocmd"	autocommand window. Temporary window
+			"autocmd"	autocommand window.  Temporary window
 					used to execute autocommands.
 			"command"	command-line window |cmdwin|
 			(empty)		normal window
@@ -12592,14 +12609,14 @@ win_id2win({expr})					*win_id2win()*
 
 win_move_separator({nr}, {offset})			*win_move_separator()*
 		Move window {nr}'s vertical separator (i.e., the right border)
-		by {offset} columns, as if being dragged by the mouse. {nr}
-		can be a window number or |window-ID|. A positive {offset}
-		moves right and a negative {offset} moves left. Moving a
+		by {offset} columns, as if being dragged by the mouse.  {nr}
+		can be a window number or |window-ID|.  A positive {offset}
+		moves right and a negative {offset} moves left.  Moving a
 		window's vertical separator will change the width of the
 		window and the width of other windows adjacent to the vertical
-		separator. The magnitude of movement may be smaller than
+		separator.  The magnitude of movement may be smaller than
 		specified (e.g., as a consequence of maintaining
-		'winminwidth'). Returns TRUE if the window can be found and
+		'winminwidth').  Returns TRUE if the window can be found and
 		FALSE otherwise.
 		This will fail for the rightmost window and a full-width
 		window, since it has no separator on the right.
@@ -12613,14 +12630,14 @@ win_move_separator({nr}, {offset})			*win_move_separator()*
 
 win_move_statusline({nr}, {offset})			*win_move_statusline()*
 		Move window {nr}'s status line (i.e., the bottom border) by
-		{offset} rows, as if being dragged by the mouse. {nr} can be a
-		window number or |window-ID|. A positive {offset} moves down
-		and a negative {offset} moves up. Moving a window's status
-		line will change the height of the window and the height of
-		other windows adjacent to the status line. The magnitude of
-		movement may be smaller than specified (e.g., as a consequence
-		of maintaining 'winminheight'). Returns TRUE if the window can
-		be found and FALSE otherwise.
+		{offset} rows, as if being dragged by the mouse.  {nr} can be
+		a window number or |window-ID|.  A positive {offset} moves
+		down and a negative {offset} moves up.  Moving a window's
+		status line will change the height of the window and the
+		height of other windows adjacent to the status line.  The
+		magnitude of movement may be smaller than specified (e.g., as
+		a consequence of maintaining 'winminheight').  Returns TRUE if
+		the window can be found and FALSE otherwise.
 		Only works for the current tab page.
 
 		Can also be used as a |method|: >
@@ -12723,7 +12740,7 @@ winlayout([{tabnr}])					*winlayout()*
 		in a tabpage.
 
 		Without {tabnr} use the current tabpage, otherwise the tabpage
-		with number {tabnr}. If the tabpage {tabnr} is not found,
+		with number {tabnr}.  If the tabpage {tabnr} is not found,
 		returns an empty list.
 
 		For a leaf window, it returns:
@@ -12818,14 +12835,15 @@ winrestview({dict})						*winrestview()*
 		Uses the |Dictionary| returned by |winsaveview()| to restore
 		the view of the current window.
 		Note: The {dict} does not have to contain all values, that are
-		returned by |winsaveview()|. If values are missing, those
-		settings won't be restored. So you can use: >
+		returned by |winsaveview()|.  If values are missing, those
+		settings won't be restored.  So you can use: >
 		    :call winrestview({'curswant': 4})
 <
 		This will only set the curswant value (the column the cursor
 		wants to move on vertical movements) of the cursor to column 5
 		(yes, that is 5), while all other settings will remain the
-		same. This is useful, if you set the cursor position manually.
+		same.  This is useful, if you set the cursor position
+		manually.
 
 		If you have changed the values the result is unpredictable.
 		If the window size changed the result won't be the same.
@@ -12844,7 +12862,7 @@ winsaveview()							*winsaveview()*
 		buffer and you want to go back to the original view.
 		This does not save fold information.  Use the 'foldenable'
 		option to temporarily switch off folding, so that folds are
-		not opened when moving around. This may have side effects.
+		not opened when moving around.  This may have side effects.
 		The return value includes:
 			lnum		cursor line number
 			col		cursor column (Note: the first column
@@ -13233,7 +13251,8 @@ xpm			Compiled with pixmap support.
 xpm_w32			Compiled with pixmap support for Win32. (Only for
 			backward compatibility. Use "xpm" instead.)
 xsmp			Compiled with X session management support.
-xsmp_interact		Compiled with interactive X session management support.
+xsmp_interact		Compiled with interactive X session management
+			support.
 xterm_clipboard		Compiled with support for xterm clipboard.
 xterm_save		Compiled with support for saving and restoring the
 			xterm screen.

--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -101,7 +101,7 @@ An exception for the d{motion} command: If the motion is not linewise, the
 start and end of the motion are not in the same line, and there are only
 blanks before the start and there are no non-blanks after the end of the
 motion, the delete becomes linewise.  This means that the delete also removes
-the line of blanks that you might expect to remain. Use the |o_v| operator to
+the line of blanks that you might expect to remain.  Use the |o_v| operator to
 force the motion to be characterwise or remove the "z" flag from 'cpoptions'
 (see |cpo-z|) to disable this peculiarity.
 
@@ -382,7 +382,7 @@ CTRL-A			Add [count] to the number or alphabetic character at
 
 							*v_g_CTRL-A*
 {Visual}g CTRL-A	Add [count] to the number or alphabetic character in
-			the highlighted text. If several lines are
+			the highlighted text.  If several lines are
 		        highlighted, each one will be incremented by an
 			additional [count] (so effectively creating a
 			[count] incrementing sequence).
@@ -413,7 +413,7 @@ CTRL-X			Subtract [count] from the number or alphabetic
 <
 							*v_g_CTRL-X*
 {Visual}g CTRL-X	Subtract [count] from the number or alphabetic
-			character in the highlighted text. If several lines
+			character in the highlighted text.  If several lines
 			are highlighted, each value will be decremented by an
 			additional [count] (so effectively creating a [count]
 			decrementing sequence).
@@ -866,7 +866,7 @@ the |substitute()| function with the following exceptions:
   - magic is always set without regard to 'magic'.
   - A ~ inserts a tilde literally.
   - <CR> and \r inserts a carriage-return (CTRL-M).
-  - \<CR> does not have a special meaning. It's just one of \x.
+  - \<CR> does not have a special meaning.  It's just one of \x.
 
 Examples: >
   :s/a\|b/xxx\0xxx/g		 modifies "a b"	     to "xxxaxxx xxxbxxx"
@@ -878,7 +878,7 @@ Examples: >
 
 Note: "\L\u" can be used to capitalize the first letter of a word.  This is
 not compatible with Vi and older versions of Vim, where the "\u" would cancel
-out the "\L". Same for "\U\l".
+out the "\L".  Same for "\U\l".
 
 Note: In previous versions CTRL-V was handled in a special way.  Since this is
 not Vi compatible, this was removed.  Use a backslash instead.
@@ -950,7 +950,7 @@ real <NL> character (which will be a NUL in the file).
 
 The "\=" notation can also be used inside the third argument {sub} of
 |substitute()| function.  In this case, the special meaning for characters as
-mentioned at |sub-replace-special| does not apply at all. Especially, <CR> and
+mentioned at |sub-replace-special| does not apply at all.  Especially, <CR> and
 <NL> are interpreted not as a line break but as a carriage-return and a
 new-line respectively.
 
@@ -1092,7 +1092,7 @@ inside of strings can change!  Also see 'softtabstop' option. >
 			with `zp`.  (for {Visual} see |Visual-mode|)
 
 							*:y* *:yank* *E850*
-:[range]y[ank] [x]	Yank [range] lines [into register x]. Yanking to the
+:[range]y[ank] [x]	Yank [range] lines [into register x].  Yanking to the
 			"* or "+ registers is possible only when the
 			|+clipboard| feature is included.
 
@@ -1173,9 +1173,9 @@ inside of strings can change!  Also see 'softtabstop' option. >
 			or 'a'.
 
 ["x]zp		    or					*zp* *zP*
-["x]zP			Like "p" and "P", except without adding trailing spaces
-			when pasting a block.  Thus the inserted text will not
-			always be a rectangle.  Especially useful in
+["x]zP			Like "p" and "P", except without adding trailing
+			spaces when pasting a block.  Thus the inserted text
+			will not always be a rectangle.  Especially useful in
 			combination with |v_zy|.
 
 You can use these commands to copy text from one place to another.  Do this
@@ -1210,7 +1210,7 @@ With |p| the previously selected text is put in the unnamed register (and
 possibly the selection and/or clipboard).  This is useful if you want to put
 that text somewhere else.  But you cannot repeat the same change.
 With |P| the unnamed register is not changed (and neither the selection or
-clipboard), you can repeat the same change. But the deleted text cannot be
+clipboard), you can repeat the same change.  But the deleted text cannot be
 used.  If you do need it you can use |p| with another register.  E.g., yank
 the text to copy, Visually select the text to replace and use "0p .  You can
 repeat this as many times as you like, and the unnamed register will be
@@ -1291,8 +1291,8 @@ text is less than one line (the small delete register is used then).  An
 exception is made for the delete operator with these movement commands: |%|,
 |(|, |)|, |`|, |/|, |?|, |n|, |N|, |{| and |}|.
 Register "1 is always used then (this is Vi compatible).  The "- register is
-used as well if the delete is within a line. Note that these characters may be
-mapped.  E.g. |%| is mapped by the matchit plugin.
+used as well if the delete is within a line.  Note that these characters may
+be mapped.  E.g. |%| is mapped by the matchit plugin.
    With each successive deletion or change, Vim shifts the previous contents
 of register 1 into register 2, 2 into 3, and so forth, losing the previous
 contents of register 9.
@@ -1608,11 +1608,11 @@ type of comment string.  A part consists of:
 
   e	End of a three-piece comment
 
-  l	Left align. Used together with 's' or 'e', the leftmost character of
+  l	Left align.  Used together with 's' or 'e', the leftmost character of
 	start or end will line up with the leftmost character from the middle.
-	This is the default and can be omitted. See below for more details.
+	This is the default and can be omitted.  See below for more details.
 
-  r	Right align. Same as above but rightmost instead of leftmost. See
+  r	Right align.  Same as above but rightmost instead of leftmost.  See
 	below for more details.
 
   O	Don't consider this comment for the "O" command.
@@ -1624,8 +1624,8 @@ type of comment string.  A part consists of:
 
   {digits}
 	When together with 's' or 'e': add {digit} amount of offset to an
-	automatically inserted middle or end comment leader. The offset begins
-	from a left alignment. See below for more details.
+	automatically inserted middle or end comment leader.  The offset
+	begins from a left alignment.  See below for more details.
 
   -{digits}
 	Like {digits} but reduce the indent.  This only works when there is
@@ -1664,7 +1664,7 @@ part which is longer, the end part is used.  This makes a C style comment work
 without requiring the middle part to end with a space.
 
 Here is an example of alignment flags at work to make a comment stand out
-(kind of looks like a 1 too). Consider comment string: >
+(kind of looks like a 1 too).  Consider comment string: >
 	:set comments=sr:/***,m:**,ex-2:******/
 <
                                    /*** ~
@@ -1675,7 +1675,7 @@ offset 2 spaces for the "-2" flag--->** ~
 In this case, the first comment was typed, then return was pressed 4 times,
 then "/" was pressed to end the comment.
 
-Here are some finer points of three part comments. There are three times when
+Here are some finer points of three part comments.  There are three times when
 alignment and offset flags are taken into consideration: opening a new line
 after a start-comment, opening a new line before an end-comment, and
 automatically ending a three-piece comment.  The end alignment flag has a
@@ -1686,11 +1686,11 @@ will override the "r" and "l" flag.
 
 Enabling 'cindent' will override the alignment flags in many cases.
 Reindenting using a different method like |gq| or |=| will not consult
-alignment flags either. The same behaviour can be defined in those other
-formatting options. One consideration is that 'cindent' has additional options
-for context based indenting of comments but cannot replicate many three piece
-indent alignments.  However, 'indentexpr' has the ability to work better with
-three piece comments.
+alignment flags either.  The same behaviour can be defined in those other
+formatting options.  One consideration is that 'cindent' has additional
+options for context based indenting of comments but cannot replicate many
+three piece indent alignments.  However, 'indentexpr' has the ability to work
+better with three piece comments.
 
 Other examples: >
    "b:*"	Includes lines starting with "*", but not if the "*" is
@@ -1787,7 +1787,7 @@ B	When joining lines, don't insert a space between two multibyte
 1	Don't break a line after a one-letter word.  It's broken before it
 	instead (if possible).
 							*fo-]*
-]	Respect 'textwidth' rigorously. With this flag set, no line can be
+]	Respect 'textwidth' rigorously.  With this flag set, no line can be
 	longer than 'textwidth', unless line-break-prohibition rules make this
 	impossible.  Mainly for CJK scripts and works only if 'encoding' is
 	"utf-8".
@@ -1825,8 +1825,8 @@ is when the 'a' flag is present. |auto-format|
 
 Note that when 'paste' is on, Vim does no formatting at all.
 
-Note that 'textwidth' can be non-zero even if Vim never performs auto-wrapping;
-'textwidth' is still useful for formatting with "gq".
+Note that 'textwidth' can be non-zero even if Vim never performs
+auto-wrapping; 'textwidth' is still useful for formatting with "gq".
 
 If the 'comments' option includes "/*", "*" and/or "*/", then Vim has some
 built in stuff to treat these types of comments a bit more cleverly.
@@ -1913,8 +1913,8 @@ Also see |:uniq|.
 							*:sort-l*
 			With [l] sort uses the current collation locale.
 			Implementation details: strcoll() is used to compare
-			strings. See |:language| to check or set the collation
-			locale. Example: >
+			strings.  See |:language| to check or set the collation
+			locale.  Example: >
 				:language collate en_US.UTF-8
 				:%sort l
 <			|v:collate| can also used to check the current locale.
@@ -1930,7 +1930,7 @@ Also see |:uniq|.
 			With [f] sorting is done on the Float in the line.
 			The value of Float is determined similar to passing
 			the text (after or inside a {pattern} match) to
-			str2float() function. This option is available only
+			str2float() function.  This option is available only
 			if Vim was compiled with Floating point support.
 
 			With [x] sorting is done on the first hexadecimal

--- a/runtime/doc/channel.txt
+++ b/runtime/doc/channel.txt
@@ -89,7 +89,8 @@ The number will increase every time you send a message.
 The server can send a command to Vim.  Type this on T1 (literally, including
 the quotes):
 	["ex","echo 'hi there'"] ~
-And you should see the message in Vim. You can move the cursor a word forward:
+And you should see the message in Vim.  You can move the cursor a word
+forward:
 	["normal","w"] ~
 
 To handle asynchronous communication a callback needs to be used: >
@@ -234,7 +235,7 @@ what you want!  Stopping the job with job_stop() might be better.
 All readahead is discarded, callbacks will no longer be invoked.
 
 Note that a channel is closed in three stages:
-  - The I/O ends, log message: "Closing channel". There can still be queued
+  - The I/O ends, log message: "Closing channel".  There can still be queued
     messages to read or callbacks to invoke.
   - The readahead is cleared, log message: "Clearing channel".  Some variables
     may still reference the channel.
@@ -478,7 +479,7 @@ To read from the error output use the "part" option:
 	{"part": "err"} ~
 To read a message with a specific ID, on a JS or JSON channel:
 	{"id": 99} ~
-When no ID is specified or the ID is -1, the first message is returned. This
+When no ID is specified or the ID is -1, the first message is returned.  This
 overrules any callback waiting for this message.
 
 For a RAW channel this returns whatever is available, since Vim does not know
@@ -571,7 +572,8 @@ ch_evalraw({handle}, {string} [, {options}])		*ch_evalraw()*
 		Return type: dict<any> or |String|
 
 ch_getbufnr({handle}, {what})				 *ch_getbufnr()*
-		Get the buffer number that {handle} is using for String {what}.
+		Get the buffer number that {handle} is using for String
+		{what}.
 		{handle} can be a Channel or a Job that has a Channel.
 		{what} can be "err" for stderr, "out" for stdout or empty for
 		socket output.
@@ -728,7 +730,7 @@ ch_sendexpr({handle}, {expr} [, {options}])			*ch_sendexpr()*
 		{handle} can be a Channel or a Job that has a Channel.
 		When using the "lsp" channel mode, {expr} must be a |Dict|.
 
-		If the channel mode is "lsp", then returns a Dict. Otherwise
+		If the channel mode is "lsp", then returns a Dict.  Otherwise
 		returns an empty String.  If the "callback" item is present in
 		{options}, then the returned Dict contains the ID of the
 		request message.  The ID can be used to send a cancellation
@@ -813,12 +815,12 @@ been received and not parsed correctly.
 If the command produces a line of output that you want to deal with, specify
 a handler for stdout: >
     let job = job_start(command, {"out_cb": "MyHandler"})
-The function will be called with the channel and a message. You would define
+The function will be called with the channel and a message.  You would define
 it like this: >
     func MyHandler(channel, msg)
 
 Without the handler you need to read the output with |ch_read()| or
-|ch_readraw()|. You can do this in the close callback, see |read-in-close-cb|.
+|ch_readraw()|.  You can do this in the close callback, see |read-in-close-cb|.
 
 Note that if the job exits before you read the output, the output may be lost.
 This depends on the system (on Unix this happens because closing the write end
@@ -856,7 +858,7 @@ To run a job that reads from a buffer: >
 	    \ {'in_io': 'buffer', 'in_name': 'mybuffer'})
 <
 							*E915* *E918*
-The buffer is found by name, similar to |bufnr()|. The buffer must exist and
+The buffer is found by name, similar to |bufnr()|.  The buffer must exist and
 be loaded when job_start() is called.
 
 By default this reads the whole buffer.  This can be changed with the "in_top"
@@ -933,7 +935,8 @@ job_info([{job}])					*job_info()*
 		Returns a Dictionary with information about {job}:
 		   "status"	what |job_status()| returns
 		   "channel"	what |job_getchannel()| returns
-		   "cmd"	List of command arguments used to start the job
+		   "cmd"	List of command arguments used to start the
+				job
 		   "process"	process ID
 		   "tty_in"	terminal input name, empty when none
 		   "tty_out"	terminal output name, empty when none
@@ -985,11 +988,11 @@ job_start({command} [, {options}])			*job_start()*
 		passed to execvp().  Arguments in double quotes can contain
 		white space.
 
-		{command} can be a List, where the first item is the executable
-		and further items are the arguments.  All items are converted
-		to String.  This works best on Unix.
+		{command} can be a List, where the first item is the
+		executable and further items are the arguments.  All items are
+		converted to String.  This works best on Unix.
 
-		On MS-Windows, job_start() makes a GUI application hidden. If
+		On MS-Windows, job_start() makes a GUI application hidden.  If
 		you want to show it, use |:!start| instead.
 
 		The command is executed directly, not through a shell, the
@@ -1311,7 +1314,7 @@ To get the status of a job: >
 To make a job stop running: >
 	job_stop(job)
 
-This is the normal way to end a job. On Unix it sends a SIGTERM to the job.
+This is the normal way to end a job.  On Unix it sends a SIGTERM to the job.
 It is possible to use other ways to stop the job, or even send arbitrary
 signals.  E.g. to force a job to stop, "kill it": >
 	job_stop(job, "kill")
@@ -1327,10 +1330,10 @@ If you want to type input for the job in a Vim window you have a few options:
 - Use a terminal window.  This works well if what you type goes directly to
   the job and the job output is directly displayed in the window.
   See |terminal-window|.
-- Use a window with a prompt buffer. This works well when entering a line for
+- Use a window with a prompt buffer.  This works well when entering a line for
   the job in Vim while displaying (possibly filtered) output from the job.
 
-A prompt buffer is created by setting 'buftype' to "prompt". You would
+A prompt buffer is created by setting 'buftype' to "prompt".  You would
 normally only do that in a newly created buffer.
 
 The user can edit and enter one line of text at the very last line of the
@@ -1339,8 +1342,8 @@ buffer.  When pressing Enter in the prompt line the callback set with
 Another callback would receive the output from the job and display it in the
 buffer, below the prompt (and above the next prompt).
 
-Only the text in the last line, after the prompt, is editable. The rest of the
-buffer is not modifiable with Normal mode commands.  It can be modified by
+Only the text in the last line, after the prompt, is editable.  The rest of
+the buffer is not modifiable with Normal mode commands.  It can be modified by
 calling functions, such as |append()|.  Using other commands may mess up the
 buffer.
 
@@ -1348,8 +1351,8 @@ After setting 'buftype' to "prompt" Vim does not automatically start Insert
 mode, use `:startinsert` if you want to enter Insert mode, so that the user
 can start typing a line.
 
-The text of the prompt can be set with the |prompt_setprompt()| function. If
-no prompt is set with |prompt_setprompt()|, "% " is used. You can get the
+The text of the prompt can be set with the |prompt_setprompt()| function.  If
+no prompt is set with |prompt_setprompt()|, "% " is used.  You can get the
 effective prompt text for a buffer, with |prompt_getprompt()|.
 
 The user can go to Normal mode and navigate through the buffer.  This can be
@@ -1357,7 +1360,7 @@ useful to see older output or copy text.
 
 The CTRL-W key can be used to start a window command, such as CTRL-W w to
 switch to the next window.  This also works in Insert mode (use Shift-CTRL-W
-to delete a word). When leaving the window Insert mode will be stopped.  When
+to delete a word).  When leaving the window Insert mode will be stopped.  When
 coming back to the prompt window Insert mode will be restored.
 
 Any command that starts Insert mode, such as "a", "i", "A" and "I", will move
@@ -1476,7 +1479,7 @@ To open a channel using the 'lsp' mode, set the 'mode' item in the |ch_open()|
     let ch = ch_open(..., #{mode: 'lsp'})
 
 To open a channel using the 'lsp' mode with a job, set the 'in_mode' and
-'out_mode' items in the |job_start()| {options} argument to 'lsp'. Example: >
+'out_mode' items in the |job_start()| {options} argument to 'lsp'.  Example: >
 
     let cmd = ['clangd', '--background-index', '--clang-tidy']
     let opts = {}
@@ -1494,8 +1497,8 @@ formats appropriately or you should use a separate callback function for
 "out_cb" and "err_cb" to handle them as shown above.
 
 To synchronously send a JSON-RPC request to the server, use the
-|ch_evalexpr()| function. This function will wait and return the decoded
-response message from the server. You can use either the |channel-timeout| or
+|ch_evalexpr()| function.  This function will wait and return the decoded
+response message from the server.  You can use either the |channel-timeout| or
 the 'timeout' field in the {options} argument to control the response wait
 time.  If the request times out, then an empty |Dict| is returned.  Example: >
 
@@ -1509,9 +1512,10 @@ time.  If the request times out, then an empty |Dict| is returned.  Example: >
         ... <handle failure>
     endif
 
-Note that in the request message the 'id' field should not be specified. If it
-is specified, then Vim will overwrite the value with an internally generated
-identifier.  Vim currently supports only a number type for the 'id' field.
+Note that in the request message the 'id' field should not be specified.  If
+it is specified, then Vim will overwrite the value with an internally
+generated identifier.  Vim currently supports only a number type for the 'id'
+field.
 The callback function will be invoked for both a successful and a failed RPC
 request.
 
@@ -1549,14 +1553,14 @@ for the request.  Example: >
     call ch_sendexpr(ch, notif)
 
 To send a JSON-RPC notification message to the server, use the |ch_sendexpr()|
-function. As the server will not send a response message to the notification,
+function.  As the server will not send a response message to the notification,
 don't specify the "callback" item.  Example: >
 
     call ch_sendexpr(ch, #{method: 'initialized'})
 
 To respond to a JSON-RPC request message from the server, use the
 |ch_sendexpr()| function.  In the response message, copy the 'id' field value
-from the server request message. Example: >
+from the server request message.  Example: >
 
     let resp = {}
     let resp.id = req.id

--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -162,7 +162,8 @@ CTRL-R {register}					*c_CTRL-R* *c_<C-R>*
 				the last delete or yank
 			'%'	the current file name
 			'#'	the alternate file name
-			'*'	the clipboard contents (X11: primary selection)
+			'*'	the clipboard contents (X11: primary
+				selection)
 			'+'	the clipboard contents
 			'/'	the last search pattern
 			':'	the last command-line
@@ -440,7 +441,8 @@ CTRL-D		List names that match the pattern in front of the cursor.
 		<S-Tab> does not work everywhere.
 							*c_CTRL-N*
 CTRL-N		After using 'wildchar' which got multiple matches, go to next
-		match.  Otherwise recall more recent command-line from history.
+		match.  Otherwise recall more recent command-line from
+		history.
 							*c_CTRL-P*
 CTRL-P		After using 'wildchar' which got multiple matches, go to
 		previous match.  Otherwise recall older command-line from
@@ -728,9 +730,9 @@ See also |`=|.
 
 							*:_!*
 The '!' (bang) character after an Ex command makes the command behave in a
-different way.  The '!' should be placed immediately after the command, without
-any blanks in between.  If you insert blanks the '!' will be seen as an
-argument for the command, which has a different meaning.  For example:
+different way.  The '!' should be placed immediately after the command,
+without any blanks in between.  If you insert blanks the '!' will be seen as
+an argument for the command, which has a different meaning.  For example:
 	:w! name	write the current buffer to file "name", overwriting
 			any existing file
 	:w !name	send the current buffer as standard input to command
@@ -1105,8 +1107,9 @@ Note: these are typed literally, they are not special keys!
 							 *filename-modifiers*
 *:_%:* *::8* *::p* *::.* *::~* *::h* *::t* *::r* *::e* *::s* *::gs* *::S*
      *%:8* *%:p* *%:.* *%:~* *%:h* *%:t* *%:r* *%:e* *%:s* *%:gs* *%:S*
-The file name modifiers can be used after "%", "#", "#n", "<cfile>", "<sfile>",
-"<afile>" or "<abuf>".  They are also used with the |fnamemodify()| function.
+The file name modifiers can be used after "%", "#", "#n", "<cfile>",
+"<sfile>", "<afile>" or "<abuf>".  They are also used with the |fnamemodify()|
+function.
 
 These modifiers can be given, in this order:
 	:p	Make file name a full path.  Must be the first modifier.  Also
@@ -1159,7 +1162,7 @@ These modifiers can be given, in this order:
 		Substitute all occurrences of "pat" with "sub".  Otherwise
 		this works like ":s".
 	:S	Escape special characters for use with a shell command (see
-		|shellescape()|). Must be the last one. Examples: >
+		|shellescape()|).  Must be the last one.  Examples: >
 		    :!dir <cfile>:S
 		    :call system('chmod +w -- ' .. expand('%:S'))
 
@@ -1240,9 +1243,9 @@ Therefore "\file\foo" is a valid file name, you don't have to type the
 backslash twice.
 
 An exception is the '$' sign.  It is a valid character in a file name.  But
-to avoid a file name like "$home" to be interpreted as an environment variable,
-it needs to be preceded by a backslash.  Therefore you need to use "/\$home"
-for the file "$home" in the root directory.  A few examples:
+to avoid a file name like "$home" to be interpreted as an environment
+variable, it needs to be preceded by a backslash.  Therefore you need to use
+"/\$home" for the file "$home" in the root directory.  A few examples:
 
 	FILE NAME	INTERPRETED AS	~
 	$home		expanded to value of environment var $home

--- a/runtime/doc/debug.txt
+++ b/runtime/doc/debug.txt
@@ -71,8 +71,8 @@ some steps to provide a useful bug report.
 3.1 GENERIC ~
 
 You must obtain the debugger symbols (PDB) file for your executable: gvim.pdb
-for gvim.exe, or vim.pdb for vim.exe. The PDB should be available from the
-same place that you obtained the executable. Be sure to use the PDB that
+for gvim.exe, or vim.pdb for vim.exe.  The PDB should be available from the
+same place that you obtained the executable.  Be sure to use the PDB that
 matches the EXE (same date).
 
 If you built the executable yourself with the Microsoft Visual C++ compiler,
@@ -115,7 +115,7 @@ If you have a non-free version of Visual Studio, you can save a minidump via
 the Debug menu and send it with the bug report.  A minidump is a small file
 (<100KB), which contains information about the state of your process.
 Visual C++ 2005 Express Edition cannot save minidumps and it cannot be
-installed as a just-in-time debugger. Use WinDbg, |debug-windbg|, if you
+installed as a just-in-time debugger.  Use WinDbg, |debug-windbg|, if you
 need to save minidumps or you want a just-in-time (postmortem) debugger.
 
 								*debug-windbg*
@@ -125,21 +125,21 @@ See |get-ms-debuggers| to obtain a copy of WinDbg.
 
 As with the Visual Studio IDE, you can attach WinDbg to a running Vim process.
 You can also have your system automatically invoke WinDbg as a postmortem
-debugger. To set WinDbg as your postmortem debugger, run "windbg -I".
+debugger.  To set WinDbg as your postmortem debugger, run "windbg -I".
 
-To attach WinDbg to a running Vim process, launch WinDbg. On the File menu,
-choose Attach to a Process. Select the Vim process and click OK.
+To attach WinDbg to a running Vim process, launch WinDbg.  On the File menu,
+choose Attach to a Process.  Select the Vim process and click OK.
 
 At this point, choose Symbol File Path on the File menu, and add the folder
-containing your Vim PDB to the sympath. If you have Vim source available,
-use Source File Path on the File menu. You can now open source files in WinDbg
-and set breakpoints, if you like. Reproduce your crash. WinDbg should open the
-source file at the point of the crash. Using the View menu, you can examine
-the call stack, local variables, watch windows, and so on.
+containing your Vim PDB to the sympath.  If you have Vim source available,
+use Source File Path on the File menu.  You can now open source files in
+WinDbg and set breakpoints, if you like.  Reproduce your crash.  WinDbg should
+open the source file at the point of the crash.  Using the View menu, you can
+examine the call stack, local variables, watch windows, and so on.
 
 If WinDbg is your postmortem debugger, you do not need to attach WinDbg to
-your Vim process. Simply reproduce the crash and WinDbg will launch
-automatically. As above, set the Symbol File Path and the Source File Path.
+your Vim process.  Simply reproduce the crash and WinDbg will launch
+automatically.  As above, set the Symbol File Path and the Source File Path.
 
 To save a minidump, type the following at the WinDbg command line: >
         .dump vim.dmp
@@ -150,11 +150,11 @@ To save a minidump, type the following at the WinDbg command line: >
 If you have a minidump file, you can open it in Visual Studio or in WinDbg.
 
 In Visual Studio 2005: on the File menu, choose Open, then Project/Solution.
-Navigate to the .dmp file and open it. Now press F5 to invoke the debugger.
+Navigate to the .dmp file and open it.  Now press F5 to invoke the debugger.
 Follow the instructions in |debug-vs2005| to set the Symbol File Path.
 
-In WinDbg: choose Open Crash Dump on the File menu. Follow the instructions in
-|debug-windbg| to set the Symbol File Path.
+In WinDbg: choose Open Crash Dump on the File menu.  Follow the instructions
+in |debug-windbg| to set the Symbol File Path.
 
 							*get-ms-debuggers*
 3.5 Obtaining Microsoft Debugging Tools ~

--- a/runtime/doc/debugger.txt
+++ b/runtime/doc/debugger.txt
@@ -51,9 +51,9 @@ Many debuggers mark specific lines by placing a small sign or color highlight
 on the line.  The |:sign| command lets the debugger set this graphic mark.  Some
 examples where this feature would be used would be a debugger showing an arrow
 representing the Program Counter (PC) of the program being debugged.  Another
-example would be a small stop sign for a line with a breakpoint.  These visible
-highlights let the user keep track of certain parts of the state of the
-debugger.
+example would be a small stop sign for a line with a breakpoint.  These
+visible highlights let the user keep track of certain parts of the state of
+the debugger.
 
 This feature can be used with more than debuggers, too.  An IPE can use a sign
 to highlight build errors, searched text, or other things.  The sign feature

--- a/runtime/doc/diff.txt
+++ b/runtime/doc/diff.txt
@@ -74,7 +74,8 @@ See `:diffoff` for an easy way to revert the options.
 The differences shown are actually the differences in the buffer.  Thus if you
 make changes after loading a file, these will be included in the displayed
 diffs.  You might have to do ":diffupdate" now and then, not all changes are
-immediately taken into account, especially when using an external diff command.
+immediately taken into account, especially when using an external diff
+command.
 
 In your .vimrc file you could do something special when Vim was started in
 diff mode.  You could use a construct like this: >
@@ -292,7 +293,7 @@ that the buffers will be equal within the specified range.
 
 							*do*
 [count]do	Same as ":diffget" without range.  The "o" stands for "obtain"
-		("dg" can't be used, it could be the start of "dgg"!). Note:
+		("dg" can't be used, it could be the start of "dgg"!).  Note:
 		this doesn't work in Visual mode.
 		If you give a [count], it is used as the [bufspec] argument
 		for ":diffget".
@@ -465,7 +466,7 @@ Also see 'diffopt' and the "diff" item of 'fillchars'.
 
 					    *diff-slow* *diff_translations*
 For very long lines, the diff syntax highlighting might be slow, especially
-since it tries to match all different kind of localisations. To disable
+since it tries to match all different kind of localisations.  To disable
 localisations and speed up the syntax highlighting, set the global variable
 g:diff_translations to zero: >
 
@@ -547,7 +548,7 @@ The `redraw!` command may not be needed, depending on whether executing a
 shell command shows something on the display or not.
 
 If the 'diffexpr' expression starts with s: or |<SID>|, then it is replaced
-with the script ID (|local-function|). Example: >
+with the script ID (|local-function|).  Example: >
 		set diffexpr=s:MyDiffExpr()
 		set diffexpr=<SID>SomeDiffExpr()
 Otherwise, the expression is evaluated in the context of the script where the
@@ -608,7 +609,7 @@ directory are accidentally patched.  Vim will also delete files starting with
 v:fname_in and ending in ".rej" and ".orig".
 
 If the 'patchexpr' expression starts with s: or |<SID>|, then it is replaced
-with the script ID (|local-function|). Example: >
+with the script ID (|local-function|).  Example: >
 		set patchexpr=s:MyPatchExpr()
 		set patchexpr=<SID>SomePatchExpr()
 Otherwise, the expression is evaluated in the context of the script where the

--- a/runtime/doc/digraph.txt
+++ b/runtime/doc/digraph.txt
@@ -112,7 +112,7 @@ mode.  After leaving the Insert mode everything is fine.  On some Unix systems
 this means you have to define the environment-variable LC_CTYPE.  If you are
 using csh, then put the following line in your .cshrc: >
 	setenv LC_CTYPE en_US.utf8
-(or similar for a different language or country). The value must be a valid
+(or similar for a different language or country).  The value must be a valid
 locale on your system, i.e. on Unix-like systems it must be present in the
 output of >
 	locale -a

--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -134,11 +134,11 @@ set, Vim renames or copies the original file before it will be overwritten.
 You can use this file if you discover that you need the original file.  See
 also the 'patchmode' option.  The name of the backup file is normally the same
 as the original file with 'backupext' appended.  The default "~" is a bit
-strange to avoid accidentally overwriting existing files.  If you prefer ".bak"
-change the 'backupext' option.  Extra dots are replaced with '_' on MS-Windows
-machines, when Vim has detected that an MS-DOS-like filesystem is being used
-(e.g., messydos or crossdos) or when the 'shortname' option is on.  The
-backup file can be placed in another directory by setting 'backupdir'.
+strange to avoid accidentally overwriting existing files.  If you prefer
+".bak" change the 'backupext' option.  Extra dots are replaced with '_' on
+MS-Windows machines, when Vim has detected that an MS-DOS-like filesystem is
+being used (e.g., messydos or crossdos) or when the 'shortname' option is on.
+The backup file can be placed in another directory by setting 'backupdir'.
 
 							*auto-shortname*
 Technical: On the Amiga you can use 30 characters for a file name.  But on an
@@ -297,7 +297,7 @@ CTRL-^			Edit the alternate file.  Mostly the alternate file is
 			Mnemonic: "goto file".
 			Uses the 'isfname' option to find out which characters
 			are supposed to be in a file name.  Trailing
-			punctuation characters ".,:;!" are ignored. Escaped
+			punctuation characters ".,:;!" are ignored.  Escaped
 			spaces "\ " are reduced to a single space.
 			Uses the 'path' option as a list of directory names to
 			look for the file.  See the 'path' option for details
@@ -335,7 +335,7 @@ CTRL-^			Edit the alternate file.  Mostly the alternate file is
 			the file.
 			The file name and the number must be separated by a
 			non-filename (see 'isfname') and non-numeric
-			character. " line " is also recognized, like it is
+			character.  " line " is also recognized, like it is
 			used in the output of `:verbose command UserCmd`
 			White space between the filename, the separator and
 			the number are ignored.
@@ -387,7 +387,7 @@ is to use "path\[[]abc]", this matches the file "path\[abc]".
 
 					*starstar-wildcard*
 Expanding "**" is possible on Unix, Win32, macOS and a few other systems (but
-it may depend on your 'shell' setting on Unix and macOS. It's known to work
+it may depend on your 'shell' setting on Unix and macOS.  It's known to work
 correctly for zsh; for bash this requires at least bash version >= 4.X).
 This allows searching a directory tree.  This goes up to 100 directories deep.
 Note there are some commands where this works slightly differently, see
@@ -400,7 +400,7 @@ Finds files:
 	a/b/c/d/ccc.txt ~
 When non-wildcard characters are used right before or after "**" these are
 only matched in the top directory.  They are not used for directories further
-down in the tree. For example: >
+down in the tree.  For example: >
 	:n /usr/inc**/types.h
 Finds files:
 	/usr/include/types.h ~
@@ -418,9 +418,9 @@ argument, for example: >
 Vim will run the command in backticks using the 'shell' and use the standard
 output as argument for the given Vim command (error messages from the shell
 command will be discarded).
-To see what shell command Vim is running, set the 'verbose' option to 4. When
+To see what shell command Vim is running, set the 'verbose' option to 4.  When
 the shell command returns a non-zero exit code, an error message will be
-displayed and the Vim command will be aborted. To avoid this make the shell
+displayed and the Vim command will be aborted.  To avoid this make the shell
 always return zero like so: >
        :next `find . -name ver\\*.c -print \|\| true`
 
@@ -669,7 +669,7 @@ list of the current window.
 			[count] is used like with |:argadd|.
 			If the current file cannot be |abandon|ed {name}s will
 			still be added to the argument list, but won't be
-			edited. No check for duplicates is done.
+			edited.  No check for duplicates is done.
 			Also see |++opt| and |+cmd|.
 
 :[count]arga[dd] {name} ...			*:arga* *:argadd* *E479*
@@ -1429,7 +1429,7 @@ present in 'cpoptions' and "!" is not used in the command.
 			Also see |getcwd()|.
 							*:pwd-verbose*
 			When 'verbose' is non-zero, |:pwd| will also display
-			what scope the current directory was set. Example: >
+			what scope the current directory was set.  Example: >
 
 				" Set by :cd
 				:verbose pwd
@@ -1459,8 +1459,8 @@ When a |:tcd| command has been used for a tab page, the specified directory
 becomes the current directory for the current tab page and the current window.
 The current directory of other tab pages is not affected.  When jumping to
 another tab page, the current directory is changed to the last specified local
-directory for that tab page. If the current tab has no local current directory
-the global current directory is used.
+directory for that tab page.  If the current tab has no local current
+directory the global current directory is used.
 
 When a |:cd| command is used, the current window and tab page will lose the
 local current directory and will use the global current directory from now on.
@@ -1588,7 +1588,7 @@ To test for blowfish support you can use these conditions: >
 	has('crypt-blowfish')
 	has('crypt-blowfish2')
 This works since Vim 7.4.1099 while blowfish support was added earlier.
-Thus the condition failing doesn't mean blowfish is not supported. You can
+Thus the condition failing doesn't mean blowfish is not supported.  You can
 test for blowfish with: >
 	v:version >= 703
 And for blowfish2 with: >
@@ -1652,7 +1652,7 @@ Notes:
   algorithm in detail.
 - The implementation of 'cryptmethod' "blowfish" has a flaw.  It is possible
   to crack the first 64 bytes of a file and in some circumstances more of the
-  file. Use of it is not recommended, but it's still the strongest method
+  file.  Use of it is not recommended, but it's still the strongest method
   supported by Vim 7.3 and 7.4.  The "zip" method is even weaker.
 - Vim originates from the Netherlands.  That is where the sources come from.
   Thus the encryption code is not exported from the USA.
@@ -1744,24 +1744,24 @@ ask if you really want to overwrite the file:
 	WARNING: The file has been changed since reading it!!!
 	Do you really want to write to it (y/n)?
 
-If you hit 'y' Vim will continue writing the file.  If you hit 'n' the write is
-aborted.  If you used ":wq" or "ZZ" Vim will not exit, you will get another
+If you hit 'y' Vim will continue writing the file.  If you hit 'n' the write
+is aborted.  If you used ":wq" or "ZZ" Vim will not exit, you will get another
 chance to write the file.
 
 The message would normally mean that somebody has written to the file after
 the edit session started.  This could be another person, in which case you
 probably want to check if your changes to the file and the changes from the
-other person should be merged.  Write the file under another name and check for
-differences (the "diff" program can be used for this).
+other person should be merged.  Write the file under another name and check
+for differences (the "diff" program can be used for this).
 
 It is also possible that you modified the file yourself, from another edit
 session or with another command (e.g., a filter command).  Then you will know
 which version of the file you want to keep.
 
 The accuracy of the time check depends on the filesystem.  On Unix it is
-usually sub-second.  With old file systems and on MS-Windows it is normally one
-second.  Use `has('nanotime')` to check if sub-second time stamp checks are
-available.
+usually sub-second.  With old file systems and on MS-Windows it is normally
+one second.  Use `has('nanotime')` to check if sub-second time stamp checks
+are available.
 
 There is one situation where you get the message while there is nothing wrong:
 On a Win32 system on the day daylight saving time starts.  There is something
@@ -1791,8 +1791,8 @@ There are three different types of searching:
       - It ONLY matches directories.
       - It matches up to 30 directories deep by default, so you can use it to
 	search an entire directory tree
-      - The maximum number of levels matched can be given by appending a number
-	to '**'.
+      - The maximum number of levels matched can be given by appending a
+        number to '**'.
 	Thus '/usr/**2' can match: >
 		/usr
 		/usr/include

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -86,7 +86,7 @@ Job		Used for a job, see |job_start()|. *Job* *Jobs*
 
 Channel		Used for a channel, see |ch_open()|. *Channel* *Channels*
 
-Blob		Binary Large Object. Stores any sequence of bytes.  See |Blob|
+Blob		Binary Large Object.  Stores any sequence of bytes.  See |Blob|
 		for details
 		Example: 0zFF00ED015DAF
 		0z is an empty Blob.
@@ -1020,7 +1020,7 @@ Blob modification ~
 To change a specific byte of a blob use |:let| this way: >
 	:let blob[4] = 0x44
 
-When the index is just one beyond the end of the Blob, it is appended. Any
+When the index is just one beyond the end of the Blob, it is appended.  Any
 higher index is an error.
 
 To change a sequence of bytes the [:] notation can be used: >
@@ -1536,8 +1536,8 @@ byte under the cursor: >
 
 In |Vim9| script:					*E1147* *E1148*
 If expr10 is a String this results in a String that contains the expr1'th
-single character (including any composing characters) from expr10.  To use byte
-indexes use |strpart()|.
+single character (including any composing characters) from expr10.  To use
+byte indexes use |strpart()|.
 
 Index zero gives the first byte or character.  Careful: text column numbers
 start with one!
@@ -1595,7 +1595,7 @@ Examples: >
 							*slice*
 If expr10 is a |List| this results in a new |List| with the items indicated by
 the indexes expr1a and expr1b.  This works like with a String, as explained
-just above. Also see |sublist| below.  Examples: >
+just above.  Also see |sublist| below.  Examples: >
 	:let l = mylist[:3]		" first four items
 	:let l = mylist[4:4]		" List with one item
 	:let l = mylist[:]		" shallow copy of a List
@@ -1786,8 +1786,8 @@ A string constant accepts these special characters:
 	Don't use <Char-xxxx> to get a UTF-8 character, use \uxxxx as
 	mentioned above.
 \<*xxx>	Like \<xxx> but prepends a modifier instead of including it in the
-	character.  E.g. "\<C-w>" is one character 0x17 while "\<*C-w>" is four
-	bytes: 3 for the CTRL modifier and then character "W".
+	character.  E.g. "\<C-w>" is one character 0x17 while "\<*C-w>" is
+	four bytes: 3 for the CTRL modifier and then character "W".
 
 Note that "\xff" is stored as the byte 255, which may be invalid in some
 encodings.  Use "\u00ff" to store character 255 according to the current value
@@ -2185,7 +2185,7 @@ variables for each buffer.  Use local buffer variables instead |b:var|.
 PREDEFINED VIM VARIABLES			*vim-variable* *v:var* *v:*
 							*E963* *E1063*
 Most variables are read-only, when a variable can be set by the user, it will
-be mentioned at the variable description below. The type cannot be changed.
+be mentioned at the variable description below.  The type cannot be changed.
 
 					*v:argv* *argv-variable*
 v:argv		The command line arguments Vim was invoked with.  This is a
@@ -2198,11 +2198,11 @@ v:beval_col	The number of the column, over which the mouse pointer is.
 		Only valid while evaluating the 'balloonexpr' option.
 
 					*v:beval_bufnr* *beval_bufnr-variable*
-v:beval_bufnr	The number of the buffer, over which the mouse pointer is. Only
-		valid while evaluating the 'balloonexpr' option.
+v:beval_bufnr	The number of the buffer, over which the mouse pointer is.
+		Only valid while evaluating the 'balloonexpr' option.
 
 					*v:beval_lnum* *beval_lnum-variable*
-v:beval_lnum	The number of the line, over which the mouse pointer is. Only
+v:beval_lnum	The number of the line, over which the mouse pointer is.  Only
 		valid while evaluating the 'balloonexpr' option.
 
 					*v:beval_text* *beval_text-variable*
@@ -2215,9 +2215,9 @@ v:beval_text	The text under or after the mouse pointer.  Usually a word as
 		Only valid while evaluating the 'balloonexpr' option.
 
 					*v:beval_winnr* *beval_winnr-variable*
-v:beval_winnr	The number of the window, over which the mouse pointer is. Only
-		valid while evaluating the 'balloonexpr' option.  The first
-		window has number zero (unlike most other places where a
+v:beval_winnr	The number of the window, over which the mouse pointer is.
+		Only valid while evaluating the 'balloonexpr' option.  The
+		first window has number zero (unlike most other places where a
 		window gets a number).
 
 					*v:beval_winid* *beval_winid-variable*
@@ -2280,8 +2280,8 @@ v:collate	The current locale setting for collation order of the runtime
 		See |multi-lang|.
 
 								*v:colornames*
-v:colornames    A dictionary that maps color names to hex color strings. These
-		color names can be used with the |highlight-guifg|,
+v:colornames	A dictionary that maps color names to hex color strings.
+		These color names can be used with the |highlight-guifg|,
 		|highlight-guibg|, and |highlight-guisp| parameters.
 
 		The key values in the dictionary (the color names) should be
@@ -2289,20 +2289,20 @@ v:colornames    A dictionary that maps color names to hex color strings. These
 		name.
 
 		Updating an entry in v:colornames has no immediate effect on
-		the syntax highlighting. The highlight commands (probably in a
-		colorscheme script) need to be re-evaluated in order to use
-		the updated color values. For example: >
+		the syntax highlighting.  The highlight commands (probably in
+		a colorscheme script) need to be re-evaluated in order to use
+		the updated color values.  For example: >
 
 		    :let v:colornames['fuscia'] = '#cf3ab4'
 		    :let v:colornames['mauve'] = '#915f6d'
 		    :highlight Normal guifg=fuscia guibg=mauve
 <
 		This cannot be used to override the |cterm-colors| but it can
-		be used to override other colors. For example, the X11 colors
+		be used to override other colors.  For example, the X11 colors
 		defined in the `colors/lists/default.vim` (previously defined
-		in |rgb.txt|). When defining new color names in a plugin, the
+		in |rgb.txt|).  When defining new color names in a plugin, the
 		recommended practice is to set a color entry only when it does
-		not already exist. For example: >
+		not already exist.  For example: >
 
 		    :call extend(v:colornames, {
 			\ 'fuscia': '#cf3ab4',
@@ -2310,20 +2310,20 @@ v:colornames    A dictionary that maps color names to hex color strings. These
 			\ }, 'keep')
 <
 		Using |extend()| with the 'keep' option updates each color only
-		if it did not exist in |v:colornames|. Doing so allows the
+		if it did not exist in |v:colornames|.  Doing so allows the
 		user to choose the precise color value for a common name
 		by setting it in their |.vimrc|.
 
 		It is possible to remove entries from this dictionary but
 		doing so is NOT recommended, because it is disruptive to
-		other scripts. It is also unlikely to achieve the desired
+		other scripts.  It is also unlikely to achieve the desired
 		result because the |:colorscheme| and |:highlight| commands
 		will both automatically load all `colors/lists/default.vim`
 		color scripts.
 
 		You can make changes to that file, but make sure to add new
-		keys instead of updating existing ones, otherwise Vim will skip
-		loading the file (thinking it hasn't been changed).
+		keys instead of updating existing ones, otherwise Vim will
+		skip loading the file (thinking it hasn't been changed).
 
 				*v:completed_item* *completed_item-variable*
 v:completed_item
@@ -2426,7 +2426,7 @@ v:exception	The value of the exception most recently caught and not
 <		Output: "caught oops".
 
 					*v:false* *false-variable*
-v:false		A Number with value zero. Used to put "false" in JSON.  See
+v:false		A Number with value zero.  Used to put "false" in JSON.  See
 		|json_encode()|.
 		When used as a string this evaluates to "v:false". >
 			echo v:false
@@ -2519,7 +2519,7 @@ v:foldstart	Used for 'foldtext': first line of closed fold.
 					*v:hlsearch* *hlsearch-variable*
 v:hlsearch	Variable that indicates whether search highlighting is on.
 		Setting it makes sense only if 'hlsearch' is enabled which
-		requires |+extra_search|. Setting this variable to zero acts
+		requires |+extra_search|.  Setting this variable to zero acts
 		like the |:nohlsearch| command, setting it to one acts like >
 			let &hlsearch = &hlsearch
 <		Note that the value is restored when returning from a
@@ -2587,7 +2587,7 @@ v:mouse_col	Column number for a mouse click obtained with |getchar()|.
 		value is zero when there was no mouse button click.
 
 					*v:none* *none-variable* *None*
-v:none		An empty String. Used to put an empty item in JSON.  See
+v:none		An empty String.  Used to put an empty item in JSON.  See
 		|json_encode()|.
 		This can also be used as a function argument to use the
 		default value, see |none-function_argument|.
@@ -2601,7 +2601,7 @@ v:none		An empty String. Used to put an empty item in JSON.  See
 		an error.  Instead, use `is v:none` and `isnot v:none` .
 
 					*v:null* *null-variable*
-v:null		An empty String. Used to put "null" in JSON.  See
+v:null		An empty String.  Used to put "null" in JSON.  See
 		|json_encode()|.
 		When used as a number this evaluates to zero.
 		When used as a string this evaluates to "v:null". >
@@ -2637,27 +2637,27 @@ v:oldfiles	List of file names that is loaded from the |viminfo| file on
 		{only when compiled with the |+viminfo| feature}
 
 						    *v:option_new*
-v:option_new    New value of the option. Valid while executing an |OptionSet|
+v:option_new    New value of the option.  Valid while executing an |OptionSet|
 		autocommand.
 						    *v:option_old*
-v:option_old    Old value of the option. Valid while executing an |OptionSet|
-		autocommand. Depending on the command used for setting and the
-		kind of option this is either the local old value or the
+v:option_old    Old value of the option.  Valid while executing an |OptionSet|
+		autocommand.  Depending on the command used for setting and
+		the kind of option this is either the local old value or the
 		global old value.
 						    *v:option_oldlocal*
 v:option_oldlocal
-		Old local value of the option. Valid while executing an
+		Old local value of the option.  Valid while executing an
 		|OptionSet| autocommand.
 						    *v:option_oldglobal*
 v:option_oldglobal
-		Old global value of the option. Valid while executing an
+		Old global value of the option.  Valid while executing an
 		|OptionSet| autocommand.
 						    *v:option_type*
-v:option_type   Scope of the set command. Valid while executing an
-		|OptionSet| autocommand. Can be either "global" or "local"
+v:option_type   Scope of the set command.  Valid while executing an
+		|OptionSet| autocommand.  Can be either "global" or "local"
 						    *v:option_command*
 v:option_command
-		Command used to set the option. Valid while executing an
+		Command used to set the option.  Valid while executing an
 		|OptionSet| autocommand.
 			value		option was set via   ~
 			"setlocal"	|:setlocal| or ":let l:xxx"
@@ -2704,7 +2704,7 @@ v:progpath	Contains the command with which Vim was invoked, in a form
 		To get the full path use: >
 			echo exepath(v:progpath)
 <		If the command has a relative path it will be expanded to the
-		full path, so that it still works after `:cd`. Thus starting
+		full path, so that it still works after `:cd`.  Thus starting
 		"./vim" results in "/home/user/path/to/vim/src/vim".
 		On Linux and other systems it will always be the full path.
 		On Mac it may just be "vim" and using exepath() as mentioned
@@ -2871,9 +2871,9 @@ v:termresponse	The escape sequence returned by the terminal for the |t_RV|
 		terminal.  The TermResponseAll event is also fired, with
 		<amatch> set to "version".  You can use |terminalprops()| to
 		see what Vim figured out about the terminal.
-		The response from a new xterm is: "<Esc>[> Pp ; Pv ; Pc c".  Pp
-		is the terminal type: 0 for vt100 and 1 for vt220.  Pv is the
-		patch level (since this was introduced in patch 95, it's
+		The response from a new xterm is: "<Esc>[> Pp ; Pv ; Pc c".
+		Pp is the terminal type: 0 for vt100 and 1 for vt220.  Pv is
+		the patch level (since this was introduced in patch 95, it's
 		always 95 or higher).  Pc is always zero.
 		If Pv is 141 or higher then Vim will try to request terminal
 		codes.  This only works with xterm |xterm-codes|.
@@ -2882,7 +2882,7 @@ v:termresponse	The escape sequence returned by the terminal for the |t_RV|
 				    *v:termblinkresp* *termblinkresp-variable*
 v:termblinkresp	The escape sequence returned by the terminal for the |t_RC|
 		termcap entry.  This is used to find out whether the terminal
-		cursor is blinking. This is used by |term_getcursor()|.  When
+		cursor is blinking.  This is used by |term_getcursor()|.  When
 		this variable is set, the TermResponseAll autocommand event is
 		fired, with <amatch> set to "cursorblink".
 
@@ -2951,7 +2951,7 @@ v:throwpoint	The point where the exception most recently caught and not
 <		Output: "Exception from test.vim, line 2"
 
 						*v:true* *true-variable*
-v:true		A Number with value one. Used to put "true" in JSON.  See
+v:true		A Number with value one.  Used to put "true" in JSON.  See
 		|json_encode()|.
 		When used as a string this evaluates to "v:true". >
 			echo v:true
@@ -2991,7 +2991,8 @@ v:vim_did_enter	Zero until most of startup is done.  It is set to one just
 		before |VimEnter| autocommands are triggered.
 
 					*v:warningmsg* *warningmsg-variable*
-v:warningmsg	Last given warning message.  It's allowed to set this variable.
+v:warningmsg	Last given warning message.  It's allowed to set this
+		variable.
 
 				*v:wayland_display* *wayland_display-variable*
 v:wayland_display
@@ -3289,7 +3290,8 @@ text...
 				END
 <			There can be multiple Vim expressions in a single line
 			but an expression cannot span multiple lines.  If any
-			expression evaluation fails, then the assignment fails.
+			expression evaluation fails, then the assignment
+			fails.
 
 			{endmarker} must not contain white space.
 			{endmarker} cannot start with a lower case character.
@@ -5212,7 +5214,7 @@ $VIMRUNTIME/plugin/openPlugin.vim
 dist#vim9#Open(file: string) ~
 
 Opens `path` with the system default handler (macOS `open`, Windows
-`explorer.exe`, Linux `xdg-open`, …). If the variable |g:Openprg| exists the
+`explorer.exe`, Linux `xdg-open`, …).  If the variable |g:Openprg| exists the
 string specified in the variable is used instead.
 
 The |:Open| user command uses file completion for its argument.
@@ -5224,11 +5226,11 @@ This function is by default called using the gx mapping.  In visual mode
 tries to open the visually selected text.
 
 Associated setting variables:
-`g:gx_word`: control how gx picks up the text under the cursor. Uses
+`g:gx_word`: control how gx picks up the text under the cursor.  Uses
 	     `g:netrw_gx` as a fallback for backward compatibility.
 	     (default: `<cfile>`)
 
-`g:nogx`: disables the gx mapping. Uses `g:netrw_nogx` as a fallback for
+`g:nogx`: disables the gx mapping.  Uses `g:netrw_nogx` as a fallback for
 	  backward compatibility. (default: `unset`)
 
 
@@ -5242,7 +5244,7 @@ Usage: >vim
 						*dist#vim9#Launch()* *:Launch*
 dist#vim9#Launch(file: string) ~
 
-Launches <args> with the appropriate system programs. Intended for launching
+Launches <args> with the appropriate system programs.  Intended for launching
 GUI programs within Vim.
 
 The |:Launch| user command uses shell completion for its first argument.

--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -530,12 +530,13 @@ g:changelog_new_date_format
 				%%	insert a single '%' character
 				%d	insert the date from above
 				%u	insert the user from above
-				%p	insert result of b:changelog_entry_prefix
+				%p	insert result of
+					b:changelog_entry_prefix
 				%c	where to position cursor when done
-			The default is "%d  %u\n\n\t* %p%c\n\n", which produces
-			something like (| is where cursor will be, unless at
-			the start of the line where it denotes the beginning
-			of the line) >
+			The default is "%d  %u\n\n\t* %p%c\n\n", which
+			produces something like (| is where cursor will be,
+			unless at the start of the line where it denotes the
+			beginning of the line) >
 				|2003-01-14  Full Name  <user@host>
 				|
 				|        * prefix|
@@ -544,7 +545,8 @@ g:changelog_new_entry_format
 			The format used when creating a new entry.
 			The following table describes special tokens in the
 			string:
-				%p	insert result of b:changelog_entry_prefix
+				%p	insert result of
+					b:changelog_entry_prefix
 				%c	where to position cursor when done
 			The default is "\t*%c", which produces something
 			similar to >
@@ -604,8 +606,9 @@ Options:
 'expandtab'	is switched on to avoid tabs as required by the Fortran
 		standards unless the user has set fortran_have_tabs in .vimrc.
 'textwidth'	is set to 80 for fixed source format whereas it is set to 132
-		for free source format. Setting the fortran_extended_line_length
-		variable increases the width to 132 for fixed source format.
+		for free source format.  Setting the
+		fortran_extended_line_length variable increases the width to
+		132 for fixed source format.
 'formatoptions' is set to break code and comment lines and to preserve long
 		lines.  You can format comments with |gq|.
 For further discussion of fortran_have_tabs and the method used for the
@@ -889,7 +892,7 @@ not running man {name} if no page is found, then use this: >
 <
 						*g:ft_man_implementation*
 The completion for the :Man command tries to guess which implementation of man
-the system has. If it guesses wrong, you can set g:ft_man_implementation to
+the system has.  If it guesses wrong, you can set g:ft_man_implementation to
 one of these values:
 	'man-db'	https://man-db.nongnu.org/
 	''		Unknown, fall back to completing shell commands
@@ -969,27 +972,27 @@ QF QUICKFIX					    *qf.vim* *ft-qf-plugin*
 The "qf" filetype is used for the quickfix window, see |quickfix-window|.
 
 The quickfix filetype plugin includes configuration for displaying the command
-that produced the quickfix list in the |status-line|. To disable this setting,
+that produced the quickfix list in the |status-line|.  To disable this setting,
 configure as follows: >
 	:let g:qf_disable_statusline = 1
 
 
 R MARKDOWN						*ft-rmd-plugin*
 
-By default ftplugin/html.vim is not sourced. If you want it sourced, add to
+By default ftplugin/html.vim is not sourced.  If you want it sourced, add to
 your |vimrc|: >
 	let rmd_include_html = 1
 
 The 'formatexpr' option is set dynamically with different values for R code
-and for Markdown code. If you prefer that 'formatexpr' is not set, add to your
-|vimrc|: >
+and for Markdown code.  If you prefer that 'formatexpr' is not set, add to
+your |vimrc|: >
 	let rmd_dynamic_comments = 0
 
 
 R RESTRUCTURED TEXT					*ft-rrst-plugin*
 
 The 'formatexpr' option is set dynamically with different values for R code
-and for ReStructured text. If you prefer that 'formatexpr' is not set, add to
+and for ReStructured text.  If you prefer that 'formatexpr' is not set, add to
 your |vimrc|: >
 	let rrst_dynamic_comments = 0
 
@@ -1006,7 +1009,7 @@ To enable this behavior, set the following variable in your vimrc: >
 RNOWEB							*ft-rnoweb-plugin*
 
 The 'formatexpr' option is set dynamically with different values for R code
-and for LaTeX code. If you prefer that 'formatexpr' is not set, add to your
+and for LaTeX code.  If you prefer that 'formatexpr' is not set, add to your
 |vimrc|: >
 	let rnw_dynamic_comments = 0
 
@@ -1100,8 +1103,8 @@ To disable this behavior, set |g:zig_recommended_style| to 0: >
 	let g:zig_recommended_style = 0
 <
 							*g:zig_std_dir*
-The path to the Zig standard library. The Zig |ftplugin| reads |g:zig_std_dir|
-and appends it to the 'path' for Zig files. Where the Zig standard library
+The path to the Zig standard library.  The Zig |ftplugin| reads |g:zig_std_dir|
+and appends it to the 'path' for Zig files.  Where the Zig standard library
 is located is system and installation method dependent.
 
 One can automatically set |g:zig_std_dir| using `zig env`: >

--- a/runtime/doc/gui.txt
+++ b/runtime/doc/gui.txt
@@ -164,7 +164,7 @@ window Vim is running in with these commands: >
 							*gui-IME* *iBus*
 Input methods for international characters in X that rely on the XIM
 framework, most notably iBus, have been known to produce undesirable results
-in gvim. These may include an inability to enter spaces, or long delays
+in gvim.  These may include an inability to enter spaces, or long delays
 between typing a character and it being recognized by the application.
 
 One workaround that has been successful, for unknown reasons, is to prevent
@@ -574,8 +574,8 @@ the mouse button down on this will pop up a menu containing the item
 which when selected, performs the operation.
 
 To create a menu for terminal mode, use |:tlmenu| instead of |:tmenu| unlike
-key mapping (|:tmap|). This is because |:tmenu| is already used for defining
-tooltips for menus. See |terminal-typing|.
+key mapping (|:tmap|).  This is because |:tmenu| is already used for defining
+tooltips for menus.  See |terminal-typing|.
 
 Special characters in a menu name:
 
@@ -851,7 +851,7 @@ not wrap.
 
 Note that Vim may be in any mode when executing these commands.  The menu
 should be defined for Normal mode and will be executed without changing the
-current mode. Thus if the current window is in Visual mode and the menu
+current mode.  Thus if the current window is in Visual mode and the menu
 command does not intentionally change the mode, Vim will remain in Visual
 mode.  Best is to use `:nnoremenu` to avoid side effects.
 
@@ -1019,8 +1019,8 @@ The tip is defined like this: >
 And delete it with: >
 	:tunmenu MyMenu.Hello
 
-Tooltips are currently only supported for the X11 and Win32 GUI.  However, they
-should appear for the other gui platforms in the not too distant future.
+Tooltips are currently only supported for the X11 and Win32 GUI.  However,
+they should appear for the other gui platforms in the not too distant future.
 
 The ":tmenu" command works just like other menu commands, it uses the same
 arguments.  ":tunmenu" deletes an existing menu tip, in the same way as the
@@ -1158,12 +1158,12 @@ Examples: >
 
 See also |font-sizes|.
 
-Note on Weights: Fonts often come with a variety of weights. "Normal" weights
+Note on Weights: Fonts often come with a variety of weights.  "Normal" weights
 in Windows have a value of 400 and, left unspecified, this is the value that
-will be used when attempting to find fonts. Windows will often match fonts
+will be used when attempting to find fonts.  Windows will often match fonts
 based on their weight with higher priority than the font name which means a
 Book or Medium variant of a font might be used despite specifying a Light or
-ExtraLight variant. If you are experiencing heavier weight substitution, then
+ExtraLight variant.  If you are experiencing heavier weight substitution, then
 explicitly setting a lower weight value may mitigate against this unwanted
 substitution.
 

--- a/runtime/doc/gui_x11.txt
+++ b/runtime/doc/gui_x11.txt
@@ -602,7 +602,7 @@ your pkg-config works with your GTK+ 2: >
 
     $ pkg-config --modversion gtk+-2.0
 
-Replace gtk+-2.0 with gtk+-3.0 for GTK+ 3. If you get the correct version
+Replace gtk+-2.0 with gtk+-3.0 for GTK+ 3.  If you get the correct version
 number of your GTK+, you can proceed; if not, you probably need to do some
 system administration chores to set up pkg-config and GTK+ correctly.
 

--- a/runtime/doc/helphelp.txt
+++ b/runtime/doc/helphelp.txt
@@ -297,9 +297,9 @@ the following pattern is used: >
 
 	^\w\+@\w\+:\f\+\$\s
 
-This is meant to match a default bash prompt.  If it doesn't match your prompt,
-you can change the regex with the `shell_prompt` key from the `g:helptoc`
-dictionary variable: >
+This is meant to match a default bash prompt.  If it doesn't match your
+prompt, you can change the regex with the `shell_prompt` key from the
+`g:helptoc` dictionary variable: >
 
 	let g:helptoc = {'shell_prompt': 'regex matching your shell prompt'}
 
@@ -456,8 +456,8 @@ This will highlight the column heading in a different color.  E.g.
 Column heading~
 
 To separate sections in a help file, place a series of '=' characters in a
-line starting from the first column.  The section separator line is highlighted
-differently.
+line starting from the first column.  The section separator line is
+highlighted differently.
 
 To quote a block of ex-commands verbatim, place a greater than (>) character
 at the end of the line before the block and a less than (<) character as the

--- a/runtime/doc/if_cscop.txt
+++ b/runtime/doc/if_cscop.txt
@@ -255,7 +255,7 @@ started will have no effect!
 					    *cscopequickfix* *csqf* *E469*
 {not available when compiled without the |+quickfix| feature}
 'cscopequickfix' specifies whether to use quickfix window to show cscope
-results.  This is a list of comma-separated values. Each item consists of
+results.  This is a list of comma-separated values.  Each item consists of
 |cscope-find| command (s, g, d, c, t, e, f, i or a) and flag (+, - or 0).
 '+' indicates that results must be appended to quickfix window,
 '-' implies previous results clearance, '0' or command absence - don't use

--- a/runtime/doc/if_lua.txt
+++ b/runtime/doc/if_lua.txt
@@ -71,7 +71,7 @@ If you use LuaJIT you can also use this: >
 			argument being set to the text of each line in turn,
 			without a trailing <EOL>, and the current line number.
 			If the value returned by the function is a string it
-			becomes the text of the line in the current turn. The
+			becomes the text of the line in the current turn.  The
 			default for [range] is the whole file: "1,$".
 
 Examples:
@@ -96,14 +96,14 @@ Examples:
 <
 
 All these commands execute a Lua chunk from either the command line (:lua and
-:luado) or a file (:luafile) with the given line [range]. Similarly to the Lua
-interpreter, each chunk has its own scope and so only global variables are
-shared between command calls. All Lua default libraries are available. In
+:luado) or a file (:luafile) with the given line [range].  Similarly to the
+Lua interpreter, each chunk has its own scope and so only global variables are
+shared between command calls.  All Lua default libraries are available.  In
 addition, Lua "print" function has its output redirected to the Vim message
 area, with arguments separated by a white space instead of a tab.
 
 Lua uses the "vim" module (see |lua-vim|) to issue commands to Vim
-and manage buffers (|lua-buffer|) and windows (|lua-window|). However,
+and manage buffers (|lua-buffer|) and windows (|lua-window|).  However,
 procedures that alter buffer content, open new buffers, and change cursor
 position are restricted when the command is executed in the |sandbox|.
 
@@ -111,18 +111,18 @@ position are restricted when the command is executed in the |sandbox|.
 ==============================================================================
 2. The vim module					*lua-vim*
 
-Lua interfaces Vim through the "vim" module. The first and last line of the
-input range are stored in "vim.firstline" and "vim.lastline" respectively. The
-module also includes routines for buffer, window, and current line queries,
-Vim evaluation and command execution, and others.
+Lua interfaces Vim through the "vim" module.  The first and last line of the
+input range are stored in "vim.firstline" and "vim.lastline" respectively.
+The module also includes routines for buffer, window, and current line
+queries, Vim evaluation and command execution, and others.
 
 	vim.list([arg])		Returns an empty list or, if "arg" is a Lua
 				table with numeric keys 1, ..., n (a
 				"sequence"), returns a list l such that l[i] =
 				arg[i] for i = 1, ..., n (see |List|).
 				Non-numeric keys are not used to initialize
-				the list. See also |lua-eval| for conversion
-				rules. Example: >
+				the list.  See also |lua-eval| for conversion
+				rules.  Example: >
 				    :lua t = {math.pi, false, say = 'hi'}
 				    :echo luaeval('vim.list(t)')
 				    :" [3.141593, v:false], 'say' is ignored
@@ -130,10 +130,10 @@ Vim evaluation and command execution, and others.
 	vim.dict([arg])		Returns an empty dictionary or, if "arg" is a
 				Lua table, returns a dict d such that d[k] =
 				arg[k] for all string keys k in "arg" (see
-				|Dictionary|). Number keys are converted to
-				strings. Keys that are not strings are not
-				used to initialize the dictionary. See also
-				|lua-eval| for conversion rules. Example: >
+				|Dictionary|).  Number keys are converted to
+				strings.  Keys that are not strings are not
+				used to initialize the dictionary.  See also
+				|lua-eval| for conversion rules.  Example: >
 				    :lua t = {math.pi, false, say = 'hi'}
 				    :echo luaeval('vim.dict(t)')
 				    :" {'1': 3.141593, '2': v:false,
@@ -148,29 +148,29 @@ Vim evaluation and command execution, and others.
 				    :" 0z31326162.0080FEFF
 <
 	vim.funcref({name})	Returns a Funcref to function {name} (see
-				|Funcref|). It is equivalent to Vim's
+				|Funcref|).  It is equivalent to Vim's
 				function().
 
 	vim.buffer([arg])	If "arg" is a number, returns buffer with
 				number "arg" in the buffer list or, if "arg"
-				is a string, returns buffer whose full or short
-				name is "arg". In both cases, returns 'nil'
-				(nil value, not string) if the buffer is not
-				found. Otherwise, if "toboolean(arg)" is
+				is a string, returns buffer whose full or
+				short name is "arg".  In both cases, returns
+				'nil' (nil value, not string) if the buffer is
+				not found.  Otherwise, if "toboolean(arg)" is
 				'true' returns the first buffer in the buffer
 				list or else the current buffer.
 
 	vim.window([arg])	If "arg" is a number, returns window with
 				number "arg" or 'nil' (nil value, not string)
-				if not found. Otherwise, if "toboolean(arg)"
+				if not found.  Otherwise, if "toboolean(arg)"
 				is 'true' returns the first window or else the
 				current window.
 
-	vim.type({arg})		Returns the type of {arg}. It is equivalent to
-				Lua's "type" function, but returns "list",
+	vim.type({arg})		Returns the type of {arg}.  It is equivalent
+				to Lua's "type" function, but returns "list",
 				"dict", "funcref", "buffer", or "window" if
 				{arg} is a list, dictionary, funcref, buffer,
-				or window, respectively. Examples: >
+				or window, respectively.  Examples: >
 					:lua l = vim.list()
 					:lua print(type(l), vim.type(l))
 					:" list
@@ -190,7 +190,7 @@ Vim evaluation and command execution, and others.
 	vim.eval({expr})	Evaluates expression {expr} (see |expression|),
 				converts the result to Lua, and returns it.
 				Vim strings and numbers are directly converted
-				to Lua strings and numbers respectively. Vim
+				to Lua strings and numbers respectively.  Vim
 				lists and dictionaries are converted to Lua
 				userdata (see |lua-list| and |lua-dict|).
 				Examples: >
@@ -203,16 +203,16 @@ Vim evaluation and command execution, and others.
 	vim.beep()		Beeps.
 
 	vim.open({fname})	Opens a new buffer for file {fname} and
-				returns it. Note that the buffer is not set as
-				current.
+				returns it.  Note that the buffer is not set
+				as current.
 
 	vim.call({name} [, {args}])
 				Proxy to call Vim function named {name} with
 				arguments {args}.  Example: >
 					:lua print(vim.call('has', 'timers'))
 <
-	vim.fn			Proxy to call Vim functions. Proxy methods are
-				created on demand.  Example: >
+	vim.fn			Proxy to call Vim functions.  Proxy methods
+				are created on demand.  Example: >
 					:lua print(vim.fn.has('timers'))
 <
 	vim.lua_version		The Lua version Vim was compiled with, in the
@@ -227,7 +227,7 @@ Vim evaluation and command execution, and others.
                                                         *lua-vim-variables*
 The Vim editor global dictionaries |g:| |w:| |b:| |t:| |v:| can be accessed
 from Lua conveniently and idiomatically by referencing the `vim.*` Lua tables
-described below. In this way you can easily read and modify global Vim script
+described below.  In this way you can easily read and modify global Vim script
 variables from Lua.
 
 Example: >
@@ -260,8 +260,8 @@ vim.v                                                   *vim.v*
 3. List userdata					*lua-list*
 
 List userdata represent vim lists, and the interface tries to follow closely
-Vim's syntax for lists. Since lists are objects, changes in list references in
-Lua are reflected in Vim and vice-versa. A list "l" has the following
+Vim's syntax for lists.  Since lists are objects, changes in list references
+in Lua are reflected in Vim and vice-versa.  A list "l" has the following
 properties and methods:
 
 NOTE: In patch 8.2.1066 array indexes were changed from zero-based to
@@ -274,23 +274,23 @@ Properties
 	    in Vim.
 	o "l[k]" returns the k-th item in "l"; "l" is one-indexed, as in Lua.
 	    To modify the k-th item, simply do "l[k] = newitem"; in
-	    particular, "l[k] = nil" removes the k-th item from "l". Item can
+	    particular, "l[k] = nil" removes the k-th item from "l".  Item can
 	    be added to the end of the list by "l[#l + 1] = newitem"
 	o "l()" returns an iterator for "l".
 	o "table.insert(l, newitem)" inserts an item at the end of the list.
 	    (only Lua 5.3 and later)
 	o "table.insert(l, position, newitem)" inserts an item at the
-	    specified position. "position" is one-indexed.  (only Lua 5.3 and
+	    specified position.  "position" is one-indexed.  (only Lua 5.3 and
 	    later)
 	o "table.remove(l, position)" removes an item at the specified
-	    position. "position" is one-indexed.
+	    position.  "position" is one-indexed.
 
 
 Methods
 -------
 	o "l:add(item)" appends "item" to the end of "l".
 	o "l:insert(item[, pos])" inserts "item" at (optional)
-	    position "pos" in the list. The default value for "pos" is 0.
+	    position "pos" in the list.  The default value for "pos" is 0.
 
 Examples:
 >
@@ -312,8 +312,8 @@ Examples:
 4. Dict userdata					*lua-dict*
 
 Similarly to list userdata, dict userdata represent vim dictionaries; since
-dictionaries are also objects, references are kept between Lua and Vim. A dict
-"d" has the following properties:
+dictionaries are also objects, references are kept between Lua and Vim.  A
+dict "d" has the following properties:
 
 Properties
 ----------
@@ -340,7 +340,7 @@ Examples:
 ==============================================================================
 5. Blob userdata					*lua-blob*
 
-Blob userdata represent vim blobs. A blob "b" has the following properties:
+Blob userdata represent vim blobs.  A blob "b" has the following properties:
 
 Properties
 ----------
@@ -367,7 +367,7 @@ Examples:
 ==============================================================================
 6. Funcref userdata					*lua-funcref*
 
-Funcref userdata represent funcref variables in Vim. Funcrefs that were
+Funcref userdata represent funcref variables in Vim.  Funcrefs that were
 defined with a "dict" attribute need to be obtained as a dictionary key
 in order to have "self" properly assigned to the dictionary (see examples
 below.) A funcref "f" has the following properties:
@@ -408,8 +408,8 @@ can be accessed in Vim scripts.  Example:
 ==============================================================================
 7. Buffer userdata					*lua-buffer*
 
-Buffer userdata represent vim buffers. A buffer userdata "b" has the following
-properties and methods:
+Buffer userdata represent vim buffers.  A buffer userdata "b" has the
+following properties and methods:
 
 Properties
 ----------
@@ -425,8 +425,8 @@ Properties
 Methods
 -------
 	o "b:insert(newline[, pos])" inserts string "newline" at (optional)
-	    position "pos" in the buffer. The default value for "pos" is
-	    "#b + 1". If "pos == 0" then "newline" becomes the first line in
+	    position "pos" in the buffer.  The default value for "pos" is
+	    "#b + 1".  If "pos == 0" then "newline" becomes the first line in
 	    the buffer.
 	o "b:next()" returns the buffer next to "b" in the buffer list.
 	o "b:previous()" returns the buffer previous to "b" in the buffer
@@ -460,7 +460,7 @@ Examples:
 ==============================================================================
 8. Window userdata					*lua-window*
 
-Window objects represent vim windows. A window userdata "w" has the following
+Window objects represent vim windows.  A window userdata "w" has the following
 properties and methods:
 
 Properties
@@ -493,8 +493,9 @@ Examples:
 9. luaeval() Vim function				*lua-luaeval* *lua-eval*
 
 The (dual) equivalent of "vim.eval" for passing Lua values to Vim is
-"luaeval". "luaeval" takes an expression string and an optional argument and
-returns the result of the expression. It is semantically equivalent in Lua to:
+"luaeval".  "luaeval" takes an expression string and an optional argument and
+returns the result of the expression.  It is semantically equivalent in Lua
+to:
 >
 	local chunkheader = "local _A = select(1, ...) return "
 	function luaeval (expstr, arg)
@@ -502,9 +503,9 @@ returns the result of the expression. It is semantically equivalent in Lua to:
 	    return chunk(arg) -- return typval
 	end
 <
-Note that "_A" receives the argument to "luaeval". Lua numbers, strings, and
+Note that "_A" receives the argument to "luaeval".  Lua numbers, strings, and
 list, dict, blob, and funcref userdata are converted to their Vim respective
-types, while Lua booleans are converted to numbers. An error is thrown if
+types, while Lua booleans are converted to numbers.  An error is thrown if
 conversion of any of the remaining Lua types, including userdata other than
 lists, dicts, blobs, and funcrefs, is attempted.
 

--- a/runtime/doc/if_mzsch.txt
+++ b/runtime/doc/if_mzsch.txt
@@ -20,7 +20,7 @@ The MzScheme Interface to Vim				*mzscheme* *MzScheme*
 Based on the work of Brent Fulgham.
 Dynamic loading added by Sergey Khorev
 
-MzScheme and PLT Scheme names have been rebranded as Racket. For more
+MzScheme and PLT Scheme names have been rebranded as Racket.  For more
 information please check http://racket-lang.org
 
 Futures and places of Racket version 5.x up to and including 5.3.1 do not
@@ -67,8 +67,8 @@ MzScheme interface defines exception exn:vim, derived from exn.
 It is raised for various Vim errors.
 
 During compilation, the MzScheme interface will remember the current MzScheme
-collection path. If you want to specify additional paths use the
-'current-library-collection-paths' parameter. E.g., to cons the user-local
+collection path.  If you want to specify additional paths use the
+'current-library-collection-paths' parameter.  E.g., to cons the user-local
 MzScheme collection path: >
     :mz << EOF
     (current-library-collection-paths
@@ -150,9 +150,9 @@ Auto-instantiation of vimext module (can be placed in your |vimrc|): >
 ==============================================================================
 3. Threads						*mzscheme-threads*
 
-The MzScheme interface supports threads. They are independent from OS threads,
-thus scheduling is required. The option 'mzquantum' determines how often
-Vim should poll for available MzScheme threads.
+The MzScheme interface supports threads.  They are independent from OS
+threads, thus scheduling is required.  The option 'mzquantum' determines how
+often Vim should poll for available MzScheme threads.
 NOTE
 Thread scheduling in the console version of Vim is less reliable than in the
 GUI version.
@@ -181,12 +181,12 @@ Common
     (get-option {option-name} [buffer-or-window]) Get Vim option value (either
 				    local or global, see set-option).
     (set-option {string} [buffer-or-window])
-				    Set a Vim option. String must have option
+				    Set a Vim option.  String must have option
 				    setting form (like optname=optval, or
 				    optname+=optval, etc.) When called with
 				    {buffer} or {window} the local option will
-				    be set. The symbol 'global can be passed
-				    as {buffer-or-window}. Then |:setglobal|
+				    be set.  The symbol 'global can be passed
+				    as {buffer-or-window}.  Then |:setglobal|
 				    will be used.
 
 Buffers							 *mzscheme-buffer*
@@ -197,17 +197,17 @@ Buffers							 *mzscheme-buffer*
     (get-buff-line {linenr} [buffer])
 				    Get line from a buffer.
     (set-buff-line {linenr} {string} [buffer])
-				    Set a line in a buffer. If {string} is #f,
-				    the line gets deleted.  The [buffer]
-				    argument is optional. If omitted, the
+				    Set a line in a buffer.  If {string} is
+				    #f, the line gets deleted.  The [buffer]
+				    argument is optional.  If omitted, the
 				    current buffer will be used.
     (get-buff-line-list {start} {end} [buffer])
-				    Get a list of lines in a buffer. {Start}
+				    Get a list of lines in a buffer.  {Start}
 				    and {end} are 1-based and inclusive.
     (set-buff-line-list {start} {end} {string-list} [buffer])
-				    Set a list of lines in a buffer. If
+				    Set a list of lines in a buffer.  If
 				    string-list is #f or null, the lines get
-				    deleted. If a list is shorter than
+				    deleted.  If a list is shorter than
 				    {end}-{start} the remaining lines will
 				    be deleted.
     (get-buff-name [buffer])	    Get a buffer's text name.
@@ -215,13 +215,14 @@ Buffers							 *mzscheme-buffer*
     (get-buff-size [buffer])	    Get buffer line count.
     (insert-buff-line-list {linenr} {string/string-list} [buffer])
 				    Insert a list of lines into a buffer after
-				    {linenr}. If {linenr} is 0, lines will be
+				    {linenr}.  If {linenr} is 0, lines will be
 				    inserted at start.
-    (curr-buff)			    Get the current buffer. Use other MzScheme
-				    interface procedures to change it.
+    (curr-buff)			    Get the current buffer.  Use other
+				    MzScheme interface procedures to change
+				    it.
     (buff-count)		    Get count of total buffers in the editor.
     (get-next-buff [buffer])	    Get next buffer.
-    (get-prev-buff [buffer])	    Get previous buffer. Return #f when there
+    (get-prev-buff [buffer])	    Get previous buffer.  Return #f when there
 				    are no more buffers.
     (open-buff {filename})	    Open a new buffer (for file "name")
     (get-buff-by-name {buffername}) Get a buffer by its filename or #f
@@ -258,7 +259,7 @@ evaluate MzScheme expressions and pass their values to Vim script.
 6. Using Function references				    *mzscheme-funcref*
 
 MzScheme interface allows use of |Funcref|s so you can call Vim functions
-directly from Scheme. For instance: >
+directly from Scheme.  For instance: >
     function! MyAdd2(arg)
 	return a:arg + 2
     endfunction
@@ -273,7 +274,7 @@ directly from Scheme. For instance: >
 ==============================================================================
 7. Dynamic loading				*mzscheme-dynamic* *E815*
 
-On MS-Windows the MzScheme libraries can be loaded dynamically. The |:version|
+On MS-Windows the MzScheme libraries can be loaded dynamically.  The |:version|
 output then includes |+mzscheme/dyn|.
 
 This means that Vim will search for the MzScheme DLL files only when needed.
@@ -291,7 +292,7 @@ name of the library to load.  The initial value is specified at build time.
 
 The version of the DLL must match the MzScheme version Vim was compiled with.
 For MzScheme version 209 they will be "libmzsch209_000.dll" and
-"libmzgc209_000.dll". To know for sure look at the output of the ":version"
+"libmzgc209_000.dll".  To know for sure look at the output of the ":version"
 command, look for -DDYNAMIC_MZSCH_DLL="something" and
 -DDYNAMIC_MZGC_DLL="something" in the "Compilation" info.
 

--- a/runtime/doc/if_perl.txt
+++ b/runtime/doc/if_perl.txt
@@ -17,9 +17,9 @@ Perl and Vim				*perl* *Perl*
 1. Editing Perl files					*perl-editing*
 
 Vim syntax highlighting supports Perl and POD files.  Vim assumes a file is
-Perl code if the filename has a .pl or .pm suffix.  Vim also examines the first
-line of a file, regardless of the filename suffix, to check if a file is a
-Perl script (see scripts.vim in Vim's syntax directory).  Vim assumes a file
+Perl code if the filename has a .pl or .pm suffix.  Vim also examines the
+first line of a file, regardless of the filename suffix, to check if a file is
+a Perl script (see scripts.vim in Vim's syntax directory).  Vim assumes a file
 is POD text if the filename has a .POD suffix.
 
 To use tags with Perl, you need Universal/Exuberant Ctags.  Look here:
@@ -90,9 +90,9 @@ To see what version of Perl you have: >
 							*:perldo* *:perld*
 :[range]perld[o] {cmd}	Execute Perl command {cmd} for each line in the
 			[range], with $_ being set to the text of each line in
-			turn, without a trailing <EOL>.  Setting $_ will change
-			the text, but note that it is not possible to add or
-			delete lines using this command.
+			turn, without a trailing <EOL>.  Setting $_ will
+			change the text, but note that it is not possible to
+			add or delete lines using this command.
 			The default for [range] is the whole file: "1,$".
 
 Here are some things you can try: >
@@ -296,8 +296,8 @@ version of the shared library must match the Perl version Vim was compiled
 with.
 
 Note: If you are building Perl locally, you have to use a version compiled
-with threading support for it for Vim to successfully link against it. You can
-use the `-Dusethreads` flags when configuring Perl, and check that a Perl
+with threading support for it for Vim to successfully link against it.  You
+can use the `-Dusethreads` flags when configuring Perl, and check that a Perl
 binary has it enabled by running `perl -V` and verify that `USE_ITHREADS` is
 under "Compile-time options".
 

--- a/runtime/doc/if_pyth.txt
+++ b/runtime/doc/if_pyth.txt
@@ -80,9 +80,9 @@ and "EOF" do not have any indent.
 			{body}" for each line in the [range], with the
 			function arguments being set to the text of each line
 			in turn, without a trailing <EOL>, and the current
-			line number. The function should return a string or
-			None. If a string is returned, it becomes the text of
-			the line in the current turn. The default for [range]
+			line number.  The function should return a string or
+			None.  If a string is returned, it becomes the text of
+			the line in the current turn.  The default for [range]
 			is the whole file: "1,$".
 
 Examples:
@@ -91,7 +91,7 @@ Examples:
 	:pydo if line: return "%4d: %s" % (linenr, line)
 <
 One can use `:pydo` in possible conjunction with `:py` to filter a range using
-python. For example: >
+python.  For example: >
 
 	:py3 << EOF
 	needle = vim.eval('@a')
@@ -205,12 +205,12 @@ vim.eval(str)						*python-eval*
 	'eval_expr', 'kind': 'f', 'filename': './src/eval.c'}] ~
 
 	NOTE: In Vim9 script, local variables in def functions are not visible
-	to python evaluations. To pass local variables to python evaluations,
+	to python evaluations.  To pass local variables to python evaluations,
 	use the {locals} dict when calling |py3eval()| and friends.
 
 vim.bindeval(str)					*python-bindeval*
 	Like |python-eval|, but returns special objects described in
-	|python-bindeval-objects|. These python objects let you modify
+	|python-bindeval-objects|.  These python objects let you modify
 	(|List|, |Tuple| or |Dictionary|) or call (|Funcref|) vim objects.
 
 vim.strwidth(str)					*python-strwidth*
@@ -220,14 +220,14 @@ vim.strwidth(str)					*python-strwidth*
 vim.foreach_rtp(callable)				*python-foreach_rtp*
 	Call the given callable for each path in 'runtimepath' until either
 	callable returns something but None, the exception is raised or there
-	are no longer paths. If stopped in case callable returned non-None,
+	are no longer paths.  If stopped in case callable returned non-None,
 	vim.foreach_rtp function returns the value returned by callable.
 
 vim.chdir(*args, **kwargs)				*python-chdir*
 vim.fchdir(*args, **kwargs)				*python-fchdir*
 	Run os.chdir or os.fchdir, then all appropriate vim stuff.
 	Note: you should not use these functions directly, use os.chdir and
-	      os.fchdir instead. Behavior of vim.fchdir is undefined in case
+	      os.fchdir instead.  Behavior of vim.fchdir is undefined in case
 	      os.fchdir does not exist.
 
 Error object of the "vim" module
@@ -265,12 +265,12 @@ vim.windows						*python-windows*
 <	Note: vim.windows object always accesses current tab page.
 	|python-tabpage|.windows objects are bound to parent |python-tabpage|
 	object and always use windows from that tab page (or throw vim.error
-	in case tab page was deleted). You can keep a reference to both
+	in case tab page was deleted).  You can keep a reference to both
 	without keeping a reference to vim module object or |python-tabpage|,
 	they will not lose their properties in this case.
 
 vim.tabpages						*python-tabpages*
-	A sequence object providing access to the list of vim tab pages. The
+	A sequence object providing access to the list of vim tab pages.  The
 	object supports the following operations: >
 	    :py t = vim.tabpages[i]	# Indexing (read-only)
 	    :py t in vim.tabpages	# Membership test
@@ -293,10 +293,10 @@ vim.current						*python-current*
 
 	Note: When assigning to vim.current.{buffer,window,tabpage} it expects
 	valid |python-buffer|, |python-window| or |python-tabpage| objects
-	respectively. Assigning triggers normal (with |autocommand|s)
-	switching to given buffer, window or tab page. It is the only way to
+	respectively.  Assigning triggers normal (with |autocommand|s)
+	switching to given buffer, window or tab page.  It is the only way to
 	switch UI objects in python: you can't assign to
-	|python-tabpage|.window attribute. To switch without triggering
+	|python-tabpage|.window attribute.  To switch without triggering
 	autocommands use >
 	    py << EOF
 	    saved_eventignore = vim.options['eventignore']
@@ -310,16 +310,16 @@ vim.current						*python-current*
 vim.vars						*python-vars*
 vim.vvars						*python-vvars*
 	Dictionary-like objects holding dictionaries with global (|g:|) and
-	vim (|v:|) variables respectively. Identical to `vim.bindeval("g:")`,
+	vim (|v:|) variables respectively.  Identical to `vim.bindeval("g:")`,
 	but faster.
 
 vim.options						*python-options*
 	Object partly supporting mapping protocol (supports setting and
 	getting items) providing a read-write access to global options.
-	Note: unlike |:set| this provides access only to global options. You
+	Note: unlike |:set| this provides access only to global options.  You
 	cannot use this object to obtain or set local options' values or
-	access local-only options in any fashion. Raises KeyError if no global
-	option with such name exists (i.e. does not raise KeyError for
+	access local-only options in any fashion.  Raises KeyError if no
+	global option with such name exists (i.e. does not raise KeyError for
 	|global-local| options and global only options, but does for window-
 	and buffer-local ones).  Use |python-buffer| objects to access to
 	buffer-local options and |python-window| objects to access to
@@ -340,8 +340,8 @@ Output from Python					*python-output*
 
 							*python-input*
 	Input (via sys.stdin, including input() and raw_input()) is not
-	supported, and may cause the program to crash.  This should probably be
-	fixed.
+	supported, and may cause the program to crash.  This should probably
+	be fixed.
 
 		    *python2-directory* *python3-directory* *pythonx-directory*
 Python 'runtimepath' handling				*python-special-path*
@@ -401,11 +401,11 @@ Implementation is similar to the following, but written in C: >
 
     sys.path_hooks.append(hook)
 
-vim.VIM_SPECIAL_PATH					*python-VIM_SPECIAL_PATH*
-	String constant used in conjunction with vim path hook. If path hook
+vim.VIM_SPECIAL_PATH				*python-VIM_SPECIAL_PATH*
+	String constant used in conjunction with vim path hook.  If path hook
 	installed by vim is requested to handle anything but path equal to
-	vim.VIM_SPECIAL_PATH constant it raises ImportError. In the only other
-	case it uses special loader.
+	vim.VIM_SPECIAL_PATH constant it raises ImportError.  In the only
+	other case it uses special loader.
 
 	Note: you must not use value of this constant directly, always use
 	      vim.VIM_SPECIAL_PATH object.
@@ -422,7 +422,7 @@ vim.find_spec(...)					*python-find_spec*
 
 vim._get_paths						*python-_get_paths*
 	Methods returning a list of paths which will be searched for by path
-	hook. You should not rely on this method being present in future
+	hook.  You should not rely on this method being present in future
 	versions, but can use it for debugging.
 
 	It returns a list of {rtp}/python2 (or {rtp}/python3) and
@@ -431,7 +431,8 @@ vim._get_paths						*python-_get_paths*
 ==============================================================================
 3. Buffer objects					*python-buffer*
 
-Buffer objects represent vim buffers.  You can obtain them in a number of ways:
+Buffer objects represent vim buffers.  You can obtain them in a number of
+ways:
 	- via vim.current.buffer (|python-current|)
 	- from indexing vim.buffers (|python-buffers|)
 	- from the "buffer" attribute of a window (|python-window|)
@@ -445,9 +446,10 @@ act as if they were lists (yes, they are mutable) of strings, with each
 element being a line of the buffer.  All of the usual sequence operations,
 including indexing, index assignment, slicing and slice assignment, work as
 you would expect.  Note that the result of indexing (slicing) a buffer is a
-string (list of strings).  This has one unusual consequence - b[:] is different
-from b.  In particular, "b[:] = None" deletes the whole of the buffer, whereas
-"b = None" merely updates the variable b, with no effect on the buffer.
+string (list of strings).  This has one unusual consequence - b[:] is
+different from b.  In particular, "b[:] = None" deletes the whole of the
+buffer, whereas "b = None" merely updates the variable b, with no effect on
+the buffer.
 
 Buffer indexes start at zero, as is normal in Python.  This differs from vim
 line numbers, which start from 1.  This is particularly relevant when dealing
@@ -458,17 +460,17 @@ The buffer object attributes are:
 			|buffer-variable|s.
 	b.options	Mapping object (supports item getting, setting and
 			deleting) that provides access to buffer-local options
-			and buffer-local values of |global-local| options. Use
+			and buffer-local values of |global-local| options.  Use
 			|python-window|.options if option is window-local,
-			this object will raise KeyError. If option is
+			this object will raise KeyError.  If option is
 			|global-local| and local value is missing getting it
 			will return None.
-	b.name		String, RW. Contains buffer name (full path).
+	b.name		String, RW.  Contains buffer name (full path).
 			Note: when assigning to b.name |BufFilePre| and
 			|BufFilePost| autocommands are launched.
-	b.number	Buffer number. Can be used as |python-buffers| key.
+	b.number	Buffer number.  Can be used as |python-buffers| key.
 			Read-only.
-	b.valid		True or False. Buffer object becomes invalid when
+	b.valid		True or False.  Buffer object becomes invalid when
 			corresponding buffer is wiped out.
 
 The buffer object methods are:
@@ -541,7 +543,8 @@ Example (assume r is the current range): >
 ==============================================================================
 5. Window objects					*python-window*
 
-Window objects represent vim windows.  You can obtain them in a number of ways:
+Window objects represent vim windows.  You can obtain them in a number of
+ways:
 	- via vim.current.window (|python-current|)
 	- from indexing vim.windows (|python-windows|)
 	- from indexing "windows" attribute of a tab page (|python-tabpage|)

--- a/runtime/doc/if_ruby.txt
+++ b/runtime/doc/if_ruby.txt
@@ -69,14 +69,14 @@ To see what version of Ruby you have: >
 						*:rubydo* *:rubyd* *E265*
 :[range]rubyd[o] {cmd}	Evaluate Ruby command {cmd} for each line in the
 			[range], with $_ being set to the text of each line in
-			turn, without a trailing <EOL>.  Setting $_ will change
-			the text, but note that it is not possible to add or
-			delete lines using this command.
+			turn, without a trailing <EOL>.  Setting $_ will
+			change the text, but note that it is not possible to
+			add or delete lines using this command.
 			The default for [range] is the whole file: "1,$".
 
 							*:rubyfile* *:rubyf*
-:rubyf[ile] {file}	Execute the Ruby script in {file}.  This is the same as
-			`:ruby load 'file'`, but allows file name completion.
+:rubyf[ile] {file}	Execute the Ruby script in {file}.  This is the same
+			as `:ruby load 'file'`, but allows file name completion.
 
 Executing Ruby commands is not possible in the |sandbox|.
 
@@ -148,8 +148,8 @@ Class Methods:
 
 current		Returns the current buffer object.
 count		Returns the number of buffers.
-self[{n}]	Returns the buffer object for the number {n}.  The first number
-		is 0.
+self[{n}]	Returns the buffer object for the number {n}.  The first
+		number is 0.
 
 Methods:
 
@@ -157,10 +157,10 @@ name		Returns the full name of the buffer.
 number		Returns the number of the buffer.
 count		Returns the number of lines.
 length		Returns the number of lines.
-self[{n}]	Returns a line from the buffer. {n} is the line number.
+self[{n}]	Returns a line from the buffer.  {n} is the line number.
 self[{n}] = {str}
-		Sets a line in the buffer. {n} is the line number.
-delete({n})	Deletes a line from the buffer. {n} is the line number.
+		Sets a line in the buffer.  {n} is the line number.
+delete({n})	Deletes a line from the buffer.  {n} is the line number.
 append({n}, {str})
 		Appends a line after the line {n}.
 line		Returns the current line of the buffer if the buffer is
@@ -178,8 +178,8 @@ Class Methods:
 
 current		Returns the current window object.
 count		Returns the number of windows.
-self[{n}]	Returns the window object for the number {n}.  The first number
-		is 0.
+self[{n}]	Returns the window object for the number {n}.  The first
+		number is 0.
 
 Methods:
 

--- a/runtime/doc/if_tcl.txt
+++ b/runtime/doc/if_tcl.txt
@@ -234,8 +234,8 @@ The ::vim::current(window) variable contains the name of the window command
 for the current window.  A window command is automatically deleted when the
 corresponding vim window is closed.
 
-Let's assume the name of the window command is stored in the Tcl variable "win",
-i.e. "$win" calls the command.  The following options are available: >
+Let's assume the name of the window command is stored in the Tcl variable
+"win", i.e. "$win" calls the command.  The following options are available: >
 
 	$win buffer		# Create Tcl command for window's buffer.
 	$win command {cmd}	# Execute Ex command in windows context.
@@ -264,7 +264,8 @@ Options:
 		array set here [$win cursor]
 <	"here(row)" and "here(column)" now contain the cursor position.
 	With a single argument, the argument is interpreted as the name of a
-	Tcl array variable, which must contain two elements "row" and "column".
+	Tcl array variable, which must contain two elements "row" and
+	"column".
 	These are used to set the cursor to the new position: >
 		$win cursor here	;# not $here !
 <	With two arguments, sets the cursor to the specified row and column: >
@@ -313,8 +314,8 @@ changed, all marks in the buffer are automatically adjusted.  Any changes to
 the buffer's contents made by Tcl commands can be undone with the "undo" vim
 command (see |undo|).
 
-Let's assume the name of the buffer command is stored in the Tcl variable "buf",
-i.e. "$buf" calls the command.  The following options are available: >
+Let's assume the name of the buffer command is stored in the Tcl variable
+"buf", i.e. "$buf" calls the command.  The following options are available: >
 
 	$buf append {n} {str}	# Append a line to buffer, after line {n}.
 	$buf command {cmd}	# Execute Ex command in buffers context.
@@ -404,8 +405,8 @@ Options:
 	deleted from the buffer.
 
 	$buf windows					*tcl-buffer-windows*
-	Creates a window command for each window that displays this buffer, and
-	returns a list of the command names as the result.
+	Creates a window command for each window that displays this buffer,
+	and returns a list of the command names as the result.
 	Example: >
 		set winlist [$buf windows]
 		foreach win $winlist { $win height 4 }

--- a/runtime/doc/indent.txt
+++ b/runtime/doc/indent.txt
@@ -44,7 +44,8 @@ These five options control C program indenting:
 'cinkeys'	Specifies which keys trigger reindenting in insert mode.
 'cinoptions'	Sets your preferred indent style.
 'cinwords'	Defines keywords that start an extra indent in the next line.
-'cinscopedecls'	Defines strings that are recognized as a C++ scope declaration.
+'cinscopedecls'	Defines strings that are recognized as a C++ scope
+		declaration.
 
 If 'lisp' is not on and 'equalprg' is empty, the "=" operator indents using
 Vim's built-in algorithm rather than calling an external program.
@@ -229,8 +230,8 @@ The examples below assume a 'shiftwidth' of 4.
 		  }		      }			  }
 <
 							*cino-L*
-	LN    Controls placement of jump labels. If N is negative, the label
-	      will be placed at column 1. If N is non-negative, the indent of
+	LN    Controls placement of jump labels.  If N is negative, the label
+	      will be placed at column 1.  If N is non-negative, the indent of
 	      the label will be the prevailing indent minus N.  (default -1).
 
 		cino=               cino=L2             cino=Ls >
@@ -291,8 +292,8 @@ The examples below assume a 'shiftwidth' of 4.
 <
 							*cino-g*
 	gN    Place C++ scope declarations N characters from the indent of the
-	      block they are in.  (default 'shiftwidth'). By default, a scope
-	      declaration is "public:", "protected:" or "private:". This can
+	      block they are in.  (default 'shiftwidth').  By default, a scope
+	      declaration is "public:", "protected:" or "private:".  This can
 	      be adjusted with the 'cinscopedecls' option.
 
 		cino=		    cino=g0 >
@@ -714,13 +715,13 @@ FORTRAN							*ft-fortran-indent*
 
 Block if, select case, select type, select rank,  where, forall, type,
 interface, associate, block, enum, critical, and change team constructs are
-indented. The indenting of subroutines, functions, modules, and program blocks
-is optional. Comments, labeled statements, and continuation lines are indented
-if the Fortran is in free source form, whereas they are not indented if the
-Fortran is in fixed source form because of the left margin requirements. Hence
-manual indent corrections will be necessary for labeled statements and
-continuation lines when fixed source form is being used.  For further
-discussion of the method used for the detection of source format see
+indented.  The indenting of subroutines, functions, modules, and program
+blocks is optional.  Comments, labeled statements, and continuation lines are
+indented if the Fortran is in free source form, whereas they are not indented
+if the Fortran is in fixed source form because of the left margin
+requirements.  Hence manual indent corrections will be necessary for labeled
+statements and continuation lines when fixed source form is being used.  For
+further discussion of the method used for the detection of source format see
 |ft-fortran-syntax|.
 
 Do loops ~
@@ -819,19 +820,19 @@ Idris 2 indentation can be configured with several variables that control the
 indentation level for different language constructs:
 
 The "g:idris2_indent_if" variable controls the indentation of `then` and `else`
-blocks after `if` statements. Defaults to 3.
+blocks after `if` statements.  Defaults to 3.
 
 The "g:idris2_indent_case" variable controls the indentation of patterns in
-`case` expressions. Defaults to 5.
+`case` expressions.  Defaults to 5.
 
 The "g:idris2_indent_let" variable controls the indentation after `let`
-bindings. Defaults to 4.
+bindings.  Defaults to 4.
 
 The "g:idris2_indent_rewrite" variable controls the indentation after `rewrite`
-expressions. Defaults to 8.
+expressions.  Defaults to 8.
 
 The "g:idris2_indent_where" variable controls the indentation of `where`
-blocks. Defaults to 6.
+blocks.  Defaults to 6.
 
 The "g:idris2_indent_do" variable controls the indentation in `do` blocks.
 Defaults to 3.
@@ -951,7 +952,7 @@ To indent 'case:' and 'default:' statements in switch() blocks: >
 
 In PHP braces are not required inside 'case/default' blocks therefore 'case:'
 and 'default:' are indented at the same level than the 'switch()' to avoid
-meaningless indentation. You can use the above option to return to the
+meaningless indentation.  You can use the above option to return to the
 traditional way.
 -------------
 
@@ -978,7 +979,7 @@ You will obtain the following result: >
 Extra indentation levels to add to parameters in multi-line function calls. >
     let g:PHP_IndentFunctionCallParameters = 1
 
-Function call arguments will indent 1 extra level. For two-space indentation: >
+Function call arguments will indent 1 extra level.  For two-space indentation: >
 
     function call_the_thing(
       $with_this,
@@ -997,7 +998,7 @@ Extra indentation levels to add to arguments in multi-line function
 definitions. >
     let g:PHP_IndentFunctionDeclarationParameters = 1
 
-Function arguments in declarations will indent 1 extra level. For two-space
+Function arguments in declarations will indent 1 extra level.  For two-space
 indentation: >
 
     function call_the_thing(
@@ -1027,8 +1028,8 @@ Indent after a nested paren: >
 Indent for a continuation line: >
 	let g:python_indent.continue = 'shiftwidth() * 2'
 
-By default, the closing paren on a multiline construct lines up under the first
-non-whitespace character of the previous line.
+By default, the closing paren on a multiline construct lines up under the
+first non-whitespace character of the previous line.
 If you prefer that it's lined up under the first character of the line that
 starts the multiline construct, reset this key: >
 	let g:python_indent.closed_paren_align_last_line = v:false
@@ -1053,15 +1054,15 @@ For backward compatibility, these variables are also supported: >
 
 R								*ft-r-indent*
 
-Function arguments are aligned if they span for multiple lines. If you prefer
+Function arguments are aligned if they span for multiple lines.  If you prefer
 do not have the arguments of functions aligned, put in your |vimrc|:
 >
    let r_indent_align_args = 0
 <
 All lines beginning with a comment character, #, get the same indentation
-level of the normal R code. Users of Emacs/ESS may be used to have lines
+level of the normal R code.  Users of Emacs/ESS may be used to have lines
 beginning with a single # indented in the 40th column, ## indented as R code,
-and ### not indented. If you prefer that lines beginning with comment
+and ### not indented.  If you prefer that lines beginning with comment
 characters are aligned as they are by Emacs/ESS, put in your |vimrc|:
 >
    let r_indent_ess_comments = 1
@@ -1072,8 +1073,8 @@ r_indent_comment_column, as in the example below:
 >
    let r_indent_comment_column = 30
 <
-Any code after a line that ends with "<-" is indented. Emacs/ESS does not
-indent the code if it is a top-level function. If you prefer a behavior like
+Any code after a line that ends with "<-" is indented.  Emacs/ESS does not
+indent the code if it is a top-level function.  If you prefer a behavior like
 Emacs/ESS one in this regard, put in your |vimrc|:
 >
    let r_indent_ess_compatible = 1
@@ -1088,7 +1089,7 @@ Below is an example of indentation with and without this option enabled:
    }                                             }
 <
 The code will be indented after lines that match the pattern
-`'\(&\||\|+\|-\|\*\|/\|=\|\~\|%\|->\)\s*$'`. If you want indentation after
+`'\(&\||\|+\|-\|\*\|/\|=\|\~\|%\|->\)\s*$'`.  If you want indentation after
 lines that match a different pattern, you should set the appropriate value of
 `r_indent_op_pattern` in your |vimrc|.
 
@@ -1153,7 +1154,7 @@ Make sure to do ":set cmdheight=2" first to allow the display of the message.
 
 VHDL							*ft-vhdl-indent*
 
-Alignment of generic/port mapping statements are performed by default. This
+Alignment of generic/port mapping statements are performed by default.  This
 causes the following alignment example: >
 
   ENTITY sync IS
@@ -1183,7 +1184,7 @@ to the .vimrc file, which causes the previous alignment example to change: >
 ----------------------------------------
 
 Alignment of right-hand side assignment "<=" statements are performed by
-default. This causes the following alignment example: >
+default.  This causes the following alignment example: >
 
   sig_out <= (bus_a(1) AND
              (sig_b OR sig_c)) OR
@@ -1201,9 +1202,9 @@ to the .vimrc file, which causes the previous alignment example to change: >
 
 ----------------------------------------
 
-Full-line comments (lines that begin with "--") are indented to be aligned with
-the very previous line's comment, PROVIDED that a whitespace follows after
-"--".
+Full-line comments (lines that begin with "--") are indented to be aligned
+with the very previous line's comment, PROVIDED that a whitespace follows
+after "--".
 
 For example: >
 
@@ -1255,9 +1256,9 @@ results in: >
 Notice that "--debug_code:" does not align with "-- comment 2"
 because there is no whitespace that follows after "--" in "--debug_code:".
 
-Given the dynamic nature of indenting comments, indenting should be done TWICE.
-On the first pass, code will be indented. On the second pass, full-line
-comments will be indented according to the correctly indented code.
+Given the dynamic nature of indenting comments, indenting should be done
+TWICE.  On the first pass, code will be indented.  On the second pass,
+full-line comments will be indented according to the correctly indented code.
 
 
 VIM							*ft-vim-indent*

--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -129,7 +129,7 @@ CTRL-R {register}				*i_CTRL-R*
 			'.'	the last inserted text
 							*i_CTRL-R_-*
 			'-'	the last small (less than a line) delete
-				register. This is repeatable using |.| since
+				register.  This is repeatable using |.| since
 				it remembers the register to put instead of
 				the literal text to insert.
 							*i_CTRL-R_=*
@@ -166,12 +166,12 @@ CTRL-R CTRL-R {register}			*i_CTRL-R_CTRL-R*
 CTRL-R CTRL-O {register}			*i_CTRL-R_CTRL-O*
 		Insert the contents of a register literally and don't
 		auto-indent.  Does the same as pasting with the mouse
-		|<MiddleMouse>|. When the register is linewise this will
+		|<MiddleMouse>|.  When the register is linewise this will
 		insert the text above the current line, like with `P`.
 		The '.' register (last inserted text) is still inserted as
 		typed.
 		After this command, the '.' register contains the command
-		typed and not the text. I.e., the literals "^R^O" and not the
+		typed and not the text.  I.e., the literals "^R^O" and not the
 		text from the register.
 		Does not replace characters in |Replace-mode|!
 
@@ -181,7 +181,7 @@ CTRL-R CTRL-P {register}			*i_CTRL-R_CTRL-P*
 		The '.' register (last inserted text) is still inserted as
 		typed.
 		After this command, the '.' register contains the command
-		typed and not the text. I.e., the literals "^R^P" and not the
+		typed and not the text.  I.e., the literals "^R^P" and not the
 		text from the register.
 		Does not replace characters in |Replace-mode|!
 
@@ -558,10 +558,10 @@ extra spaces to get where you want to be.
 
 							*ins-smarttab*
 When the 'smarttab' option is on, the <Tab> key indents by 'shiftwidth' if the
-cursor is in leading whitespace.  The <BS> key has the opposite effect. This
-behaves as if 'softtabstop' were set to the value of 'shiftwidth'. This option
-allows the user to set 'softtabstop' to a value other than 'shiftwidth' and
-still use the <Tab> key for indentation.
+cursor is in leading whitespace.  The <BS> key has the opposite effect.  This
+behaves as if 'softtabstop' were set to the value of 'shiftwidth'.  This
+option allows the user to set 'softtabstop' to a value other than 'shiftwidth'
+and still use the <Tab> key for indentation.
 
 ==============================================================================
 5. Replace mode				*Replace* *Replace-mode* *mode-replace*
@@ -662,7 +662,8 @@ not a valid CTRL-X mode command.  Valid keys are the CTRL-X command itself,
 CTRL-N (next), and CTRL-P (previous).
 
 By default, the possible completions are showed in a menu and the first
-completion is inserted into the text. This can be adjusted with 'completeopt'.
+completion is inserted into the text.  This can be adjusted with
+'completeopt'.
 
 To get the current completion information, |complete_info()| can be used.
 Also see the 'infercase' option if you want to adjust the case of the match.
@@ -888,7 +889,7 @@ Completing keywords with 'thesaurusfunc'		*compl-thesaurusfunc*
 
 If the 'thesaurusfunc' option is set, then the user specified function is
 invoked to get the list of completion matches and the 'thesaurus' option is
-not used. See |complete-functions| for an explanation of how the function is
+not used.  See |complete-functions| for an explanation of how the function is
 invoked and what it should return.
 
 Here is an example that uses the "aiksaurus" command (provided by Magnus
@@ -1138,8 +1139,8 @@ CTRL-X CTRL-Z		Stop completion without changing the text.
 AUTOCOMPLETION						*ins-autocompletion*
 
 Vim can display a completion menu as you type, similar to using |i_CTRL-N|,
-but triggered automatically.  See 'autocomplete'. The menu items are collected
-from the sources listed in the 'complete' option, in order.
+but triggered automatically.  See 'autocomplete'.  The menu items are
+collected from the sources listed in the 'complete' option, in order.
 
 A decaying timeout keeps Vim responsive.  Sources earlier in the 'complete'
 list get more time (higher priority), but all sources receive at least a small
@@ -1247,7 +1248,7 @@ items:
 			items to be equal; when omitted zero is used, thus
 			items that only differ in case are added
 	equal		when non-zero, always treat this item to be equal when
-			comparing. Which means, "equal=1" disables filtering
+			comparing.  Which means, "equal=1" disables filtering
 			of this item.
 	dup		when non-zero this match will be added even when an
 			item with the same word is already present.
@@ -1263,7 +1264,7 @@ items:
 			properties (with higher priority) like strikethrough
 			to the completion items abbreviation
 	kind_hlgroup	an additional highlight group specifically for setting
-			the highlight attributes of the completion kind. When
+			the highlight attributes of the completion kind.  When
 			this field is present, it will override the
 			|hl-PmenuKind| highlight group, allowing for the
 			customization of ctermfg and guifg properties for the
@@ -1454,7 +1455,8 @@ any printable, non-white character:
 		  Add this character and reduce the number of matches.
 
 In all three states these can be used:
-CTRL-Y		  Yes: Accept the currently selected match and stop completion.
+CTRL-Y		  Yes: Accept the currently selected match and stop
+		  completion.
 CTRL-E		  End completion, go back to what was there before selecting a
 		  match (what was typed or longest common string).
 <PageUp>	  Select a match several entries back, but don't insert it.
@@ -1558,7 +1560,7 @@ XHTML							*ft-xhtml-omni*
 
 CTRL-X CTRL-O provides completion of various elements of (X)HTML files.  It is
 designed to support writing of XHTML 1.0 Strict files but will also work for
-other versions of HTML. Features:
+other versions of HTML.  Features:
 
 - after "<" complete tag name depending on context (no div suggestion inside
   of an a tag); '/>' indicates empty tags
@@ -1576,7 +1578,7 @@ other versions of HTML. Features:
 
 Note: When used first time completion menu will be shown with little delay
 - this is time needed for loading of data file.
-Note: Completion may fail in badly formatted documents. In such case try to
+Note: Completion may fail in badly formatted documents.  In such case try to
 run |:make| command to detect formatting problems.
 
 
@@ -1590,7 +1592,7 @@ When doing completion outside of any other tag you will have possibility to
 choose DOCTYPE and the appropriate data file will be loaded and used for all
 next completions.
 
-More about format of data file in |xml-omni-datafile|. Some of the data files
+More about format of data file in |xml-omni-datafile|.  Some of the data files
 may be found on the Vim website (|www|).
 
 Note that b:html_omni_flavor may point to a file with any XML data.  This
@@ -1619,8 +1621,8 @@ of external files).
 DOM compatibility
 
 At the moment (beginning of 2006) there are two main browsers - MS Internet
-Explorer and Mozilla Firefox. These two applications are covering over 90% of
-market. Theoretically standards are created by W3C organisation
+Explorer and Mozilla Firefox.  These two applications are covering over 90% of
+market.  Theoretically standards are created by W3C organisation
 (http://www.w3c.org) but they are not always followed/implemented.
 
 		IE	FF	W3C  Omni completion ~
@@ -1630,16 +1632,16 @@ market. Theoretically standards are created by W3C organisation
 		-	+	-    -		     ~
 
 Regardless from state of implementation in browsers but if element is defined
-in standards, completion plugin will place element in suggestion list. When
+in standards, completion plugin will place element in suggestion list.  When
 both major engines implemented element, even if this is not in standards it
-will be suggested. All other elements are not placed in suggestion list.
+will be suggested.  All other elements are not placed in suggestion list.
 
 
 PHP							*ft-php-omni*
 
 Completion of PHP code requires a tags file for completion of data from
-external files and for class aware completion. You should use Universal/
-Exuberant ctags version 5.5.4 or newer. You can find it here:
+external files and for class aware completion.  You should use Universal/
+Exuberant ctags version 5.5.4 or newer.  You can find it here:
 
 	Universal Ctags: https://ctags.io
 	Exuberant Ctags: http://ctags.sourceforge.net
@@ -1647,11 +1649,12 @@ Exuberant ctags version 5.5.4 or newer. You can find it here:
 Script completes:
 
 - after $ variables name
-  - if variable was declared as object add "->", if tags file is available show
-    name of class
+  - if variable was declared as object add "->", if tags file is available
+    show name of class
   - after "->" complete only function and variable names specific for given
-    class. To find class location and contents tags file is required. Because
-    PHP isn't strongly typed language user can use @var tag to declare class: >
+    class.  To find class location and contents tags file is required.
+    Because PHP isn't strongly typed language user can use @var tag to declare
+    class: >
 
 	/* @var $myVar myClass */
 	$myVar->
@@ -1669,11 +1672,11 @@ Script completes:
 
 
 Note: when doing completion first time Vim will load all necessary data into
-memory. It may take several seconds. After next use of completion delay
+memory.  It may take several seconds.  After next use of completion delay
 should not be noticeable.
 
-Script detects if cursor is inside <?php ?> tags. If it is outside it will
-automatically switch to HTML/CSS/JavaScript completion. Note: contrary to
+Script detects if cursor is inside <?php ?> tags.  If it is outside it will
+automatically switch to HTML/CSS/JavaScript completion.  Note: contrary to
 original HTML files completion of tags (and only tags) isn't context aware.
 
 
@@ -1700,11 +1703,11 @@ The completions provided by CTRL-X CTRL-O are sensitive to the context:
 
 Notes:
  - Vim will load/evaluate code in order to provide completions.  This may
-   cause some code execution, which may be a concern. This is no longer
+   cause some code execution, which may be a concern.  This is no longer
    enabled by default, to enable this feature add >
      let g:rubycomplete_buffer_loading = 1
 <- In context 1 above, Vim can parse the entire buffer to add a list of
-   classes to the completion results. This feature is turned off by default,
+   classes to the completion results.  This feature is turned off by default,
    to enable it add >
      let g:rubycomplete_classes_in_global = 1
 <  to your vimrc
@@ -1712,7 +1715,7 @@ Notes:
  - In context 3 above, Vim will attempt to determine the methods supported by
    the object.
  - Vim can detect and load the Rails environment for files within a rails
-   project. The feature is disabled by default, to enable it add >
+   project.  The feature is disabled by default, to enable it add >
      let g:rubycomplete_rails = 1
 <  to your vimrc
 
@@ -1749,11 +1752,11 @@ a look at the PHP filetype to see how this works.
 If you edit a file called, index.php, run the following command: >
     syntax list
 
-The first thing you will notice is that there are many different syntax groups.
-The PHP language can include elements from different languages like HTML,
-JavaScript and many more.  The syntax plugin will only include syntax groups
-that begin with the filetype, "php", in this case.  For example these syntax
-groups are included by default with the PHP: phpEnvVar, phpIntVar,
+The first thing you will notice is that there are many different syntax
+groups.  The PHP language can include elements from different languages like
+HTML, JavaScript and many more.  The syntax plugin will only include syntax
+groups that begin with the filetype, "php", in this case.  For example these
+syntax groups are included by default with the PHP: phpEnvVar, phpIntVar,
 phpFunctions.
 
 If you wish non-filetype syntax items to also be included, you can use a
@@ -1872,7 +1875,7 @@ be used in commands.  It should be a unique name which will not create
 conflicts.  For example, the name xhtml10s.vim means it is the data file for
 XHTML 1.0 Strict.
 
-Each file contains a variable with a name like g:xmldata_xhtml10s . It is
+Each file contains a variable with a name like g:xmldata_xhtml10s .  It is
 a compound from two parts:
 
 1. "g:xmldata_"  general prefix, constant for all data files
@@ -2089,7 +2092,7 @@ These two commands will keep on asking for lines, until you type a line
 containing only a ".".  Watch out for lines starting with a backslash, see
 |line-continuation|.
 
-Text typed after a "|" command separator is used first. So the following
+Text typed after a "|" command separator is used first.  So the following
 command in ex mode: >
 	:a|one
 	two

--- a/runtime/doc/intro.txt
+++ b/runtime/doc/intro.txt
@@ -99,7 +99,8 @@ There are several mailing lists for Vim:
 	For discussions about using and improving the Macintosh version of
 	Vim.
 <vim-security@googlegroups.com>			*vim-security*
-	This list is for (privately) discussing security relevant issues of Vim.
+	This list is for (privately) discussing security relevant issues of
+	Vim.
 
 See http://www.vim.org/maillist.php for the latest information.
 
@@ -236,7 +237,8 @@ Vim would never have become what it is now, without the help of these people!
 	Felix von Leitner	Previous maintainer of Vim Mailing Lists
 	David Leonard		Port of Python extensions to Unix
 	Avner Lottem		Edit in right-to-left windows
-	Flemming Madsen		X11 client-server, various features and patches
+	Flemming Madsen		X11 client-server, various features and
+				patches
 	Tony Mechelynck		answers many user questions
 	Paul Moore		Python interface extensions, many patches
 	Katsuhito Nagano	Work on multibyte versions
@@ -606,8 +608,8 @@ Operator-pending mode	This is like Normal mode, but after an operator
 
 Replace mode		Replace mode is a special case of Insert mode.  You
 			can do the same things as in Insert mode, but for
-			each character you enter, one character of the existing
-			text is deleted.  See |Replace-mode|.
+			each character you enter, one character of the
+			existing text is deleted.  See |Replace-mode|.
 			If the 'showmode' option is on "-- REPLACE --" is
 			shown at the bottom of the window.
 

--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -105,7 +105,7 @@ modes.
 			map command applies.  The mapping may remain defined
 			for other modes where it applies.
 			It also works when {lhs} matches the {rhs} of a
-			mapping. This is for when an abbreviation applied.
+			mapping.  This is for when an abbreviation applied.
 			Note: Trailing spaces are included in the {lhs}.
 			See |map-trailing-white|.
 
@@ -295,7 +295,7 @@ In case you want the mapping to not do anything, you can have the expression
 evaluate to an empty string.  If something changed that requires Vim to
 go through the main loop (e.g. to update the display), return "\<Ignore>".
 This is similar to "nothing" but makes Vim return from the loop that waits for
-input. Example: >
+input.  Example: >
 	func s:OpenPopup()
 	  call popup_create(... arguments ...)
 	  return "\<Ignore>"
@@ -330,7 +330,7 @@ For this reason the following is blocked:
 If you want the mapping to do any of these let the returned characters do
 that, or use a |<Cmd>| mapping instead.
 
-You can use getchar(), it consumes typeahead if there is any. E.g., if you
+You can use getchar(), it consumes typeahead if there is any.  E.g., if you
 have these mappings: >
   inoremap <expr> <C-L> nr2char(getchar())
   inoremap <expr> <C-L>x "foo"
@@ -542,7 +542,7 @@ it's just used here for this situation.
    The simplest way to load a set of related language mappings is by using the
 'keymap' option.  See |45.5|.
    In Insert mode and in Command-line mode the mappings can be disabled with
-the CTRL-^ command |i_CTRL-^| |c_CTRL-^|. These commands change the value of
+the CTRL-^ command |i_CTRL-^| |c_CTRL-^|.  These commands change the value of
 the 'iminsert' option.  When starting to enter a normal command line (not a
 search pattern) the mappings are disabled until a CTRL-^ is typed.  The state
 last used is remembered for Insert mode and Search patterns separately.  The
@@ -590,7 +590,7 @@ e.g. from a timer callback. *E1309*
 
 							*:map-verbose*
 When 'verbose' is non-zero, the detected and used 'keyprotocol' value will be
-displayed in the first line. Also a key map will also display where it was
+displayed in the first line.  Also a key map will also display where it was
 last defined.  Example: >
 
 	:verbose map <C-W>*
@@ -748,7 +748,7 @@ Upper and lowercase differences are ignored.
 
 							*map-comments*
 It is not possible to put a comment after these commands, because the '"'
-character is considered to be part of the {lhs} or {rhs}. However, one can
+character is considered to be part of the {lhs} or {rhs}.  However, one can
 use |", since this starts a new, empty command with a comment.
 
 							*map_bar* *map-bar*
@@ -827,7 +827,7 @@ Multiplying a count
 When you type a count before triggering a mapping, it's like the count was
 typed before the {lhs}.  For example, with this mapping: >
    :map <F4>  3w
-Typing 2<F4> will result in "23w". Thus not moving 2 * 3 words but 23 words.
+Typing 2<F4> will result in "23w".  Thus not moving 2 * 3 words but 23 words.
 If you want to multiply counts use the expression register: >
    :map <F4>  @='3w'<CR>
 The part between quotes is the expression being executed. |@=|
@@ -960,7 +960,7 @@ configuration).  For that, you can add the line: >
 
 	set convert-meta on
 
-to your ~/.inputrc file. If you're creating the file, you might want to use: >
+to your ~/.inputrc file.  If you're creating the file, you might want to use: >
 
 	$include /etc/inputrc
 
@@ -991,8 +991,8 @@ in Insert mode: >
 1.12 MAPPING SUPER-KEYS or COMMAND-KEYS	     *:map-super-keys* *:map-cmd-key*
 
 The Super modifier is available in GUI mode (when |gui_running| is 1) for gVim
-on Linux and MacVim on Mac OS. If you're on a Mac, this represents the Command
-key, on Linux with the GTK GUI it represents the Super key.
+on Linux and MacVim on Mac OS.  If you're on a Mac, this represents the
+Command key, on Linux with the GTK GUI it represents the Super key.
 The character "D" is used for the Super / Command modifier.
 
 For example, to map Command-b in Insert mode: >
@@ -1244,7 +1244,7 @@ an additional rule:
 full-id	  In front of the match is a non-keyword character, or this is where
 	  the line or insertion starts.  Exception: When the abbreviation is
 	  only one character, it is not recognized if there is a non-keyword
-	  character in front of it, other than a space or a tab. However, for
+	  character in front of it, other than a space or a tab.  However, for
 	  the command line "'<,'>" (or any other marks) is ignored, as if the
 	  command line starts after it.
 
@@ -1502,8 +1502,8 @@ be the user command ":Cc2" without an argument, or the command ":Cc" with
 argument "2".  It is advised to put a space between the command name and the
 argument to avoid these problems.
 
-When using a user-defined command, the command can be abbreviated.  However, if
-an abbreviation is not unique, an error will be issued.  Furthermore, a
+When using a user-defined command, the command can be abbreviated.  However,
+if an abbreviation is not unique, an error will be issued.  Furthermore, a
 built-in command will always take precedence.
 
 Example: >
@@ -1519,8 +1519,8 @@ It is recommended that full names for user-defined commands are used in
 scripts.
 
 :com[mand]						*:com* *:command*
-			List all user-defined commands.  When listing commands,
-			the characters in the first columns are:
+			List all user-defined commands.  When listing
+			commands, the characters in the first columns are:
 			    !	Command has the -bang attribute
 			    "	Command has the -register attribute
 			    |   Command has the -bar attribute
@@ -1535,7 +1535,7 @@ scripts.
 
 							*:command-verbose*
 When 'verbose' is non-zero, listing a command will also display where it was
-last defined and any completion argument. Example: >
+last defined and any completion argument.  Example: >
 
     :verbose command TOhtml
 <	Name	    Args Range Complete  Definition ~
@@ -1571,10 +1571,10 @@ See |:verbose-cmd| for more information.
 
 Command attributes ~
 							*command-attributes*
-User-defined commands are treated by Vim just like any other Ex commands.  They
-can have arguments, or have a range specified.  Arguments are subject to
-completion as filenames, buffers, etc.  Exactly how this works depends upon the
-command's attributes, which are specified when the command is defined.
+User-defined commands are treated by Vim just like any other Ex commands.
+They can have arguments, or have a range specified.  Arguments are subject to
+completion as filenames, buffers, etc.  Exactly how this works depends upon
+the command's attributes, which are specified when the command is defined.
 
 When defining a user command in a script, it will be able to call functions
 local to the script and use mappings local to the script.  When the user
@@ -1659,7 +1659,7 @@ completion can be enabled:
 	-complete=scriptnames	sourced script names
 	-complete=shellcmd	Shell command
 	-complete=shellcmdline	First is a shell command and subsequent ones
-				are filenames. The same behavior as |:!cmd|
+				are filenames.  The same behavior as |:!cmd|
 	-complete=sign		|:sign| suboptions
 	-complete=syntax	syntax file names 'syntax'
 	-complete=syntime	|:syntime| suboptions
@@ -1684,8 +1684,8 @@ function with the following signature: >
 
 	:function {func}(ArgLead, CmdLine, CursorPos)
 
-The function need not use all these arguments. The function should provide the
-completion candidates as the return value.
+The function need not use all these arguments.  The function should provide
+the completion candidates as the return value.
 
 For the "custom" argument, the function should return the completion
 candidates one per line in a newline separated string.
@@ -1701,7 +1701,7 @@ The function arguments are:
 The function may use these for determining context.  For the "custom"
 argument, it is not necessary to filter candidates against the (implicit
 pattern in) ArgLead.  Vim will filter the candidates with its regexp engine
-after function return, and this is probably more efficient in most cases. If
+after function return, and this is probably more efficient in most cases.  If
 'wildoptions' contains "fuzzy", then the candidates will be filtered using
 |fuzzy-matching|.  For the "customlist" argument, Vim will not
 filter the returned completion candidates and the user supplied function
@@ -1833,8 +1833,8 @@ The valid escape sequences are
 		command was executed with a ! modifier, otherwise
 		expands to nothing.
 					*<mods>* *<q-mods>* *:command-modifiers*
-	<mods>  The command modifiers, if specified. Otherwise, expands to
-		nothing. Supported modifiers are |:aboveleft|, |:belowright|,
+	<mods>  The command modifiers, if specified.  Otherwise, expands to
+		nothing.  Supported modifiers are |:aboveleft|, |:belowright|,
 		|:botright|, |:browse|, |:confirm|, |:hide|, |:horizontal|,
 		|:keepalt|, |:keepjumps|, |:keepmarks|, |:keeppatterns|,
 		|:leftabove|, |:lockmarks|, |:noautocmd|, |:noswapfile|,
@@ -1943,9 +1943,9 @@ A more substantial example: >
    :endfunction
    :command -nargs=+ -complete=command Allargs call Allargs(<q-args>)
 
-The command Allargs takes any Vim command(s) as argument and executes it on all
-files in the argument list.  Usage example (note use of the "e" flag to ignore
-errors and the "update" command to write modified buffers): >
+The command Allargs takes any Vim command(s) as argument and executes it on
+all files in the argument list.  Usage example (note use of the "e" flag to
+ignore errors and the "update" command to write modified buffers): >
 	:Allargs %s/foo/bar/ge|update
 This will invoke: >
 	:call Allargs("%s/foo/bar/ge|update")

--- a/runtime/doc/mbyte.txt
+++ b/runtime/doc/mbyte.txt
@@ -1138,8 +1138,8 @@ it to the Vim maintainer for inclusion in the distribution:
 
 HEBREW KEYMAP						*keymap-hebrew*
 
-This file explains what characters are available in UTF-8 and CP1255 encodings,
-and what the keymaps are to get those characters:
+This file explains what characters are available in UTF-8 and CP1255
+encodings, and what the keymaps are to get those characters:
 
 glyph   encoding	   keymap ~
 Char UTF-8 cp1255  hebrew  hebrewp  name ~
@@ -1270,9 +1270,9 @@ Combining forms:
 ==============================================================================
 10.  Input with imactivatefunc()				*mbyte-func*
 
-Vim has the 'imactivatefunc' and 'imstatusfunc' options. These are useful to
-activate/deactivate the input method from Vim in any way, also with an external
-command. For example, fcitx provide fcitx-remote command: >
+Vim has the 'imactivatefunc' and 'imstatusfunc' options.  These are useful to
+activate/deactivate the input method from Vim in any way, also with an
+external command.  For example, fcitx provide fcitx-remote command: >
 
 	set iminsert=2
 	set imsearch=2

--- a/runtime/doc/message.txt
+++ b/runtime/doc/message.txt
@@ -126,7 +126,7 @@ path leading to the file.
   Cannot switch buffer. 'winfixbuf' is enabled ~
 
 If a window has 'winfixbuf' enabled, you cannot change that window's current
-buffer. You need to set 'nowinfixbuf' before continuing. You may use [!] to
+buffer.  You need to set 'nowinfixbuf' before continuing.  You may use [!] to
 force the window to switch buffers, if your command supports it.
 
 							*E72*

--- a/runtime/doc/mlang.txt
+++ b/runtime/doc/mlang.txt
@@ -81,7 +81,7 @@ use of "-" and "_".
 			This sets $LC_TIME.
 			With the "collate" argument the language used for the
 			collation order is set.  This affects sorting of
-			characters. This sets $LC_COLLATE.
+			characters.  This sets $LC_COLLATE.
 			Without an argument all are set, and additionally
 			$LANG is set.
 			If available the LC_NUMERIC value will always be set

--- a/runtime/doc/motion.txt
+++ b/runtime/doc/motion.txt
@@ -66,7 +66,7 @@ the two counts are multiplied.  For example: "2d3w" deletes six words.
 						*operator-doubled*
 When doubling the operator it operates on a line.  When using a count, before
 or after the first character, that many lines are operated upon.  Thus `3dd`
-deletes three lines. A count before and after the first character is
+deletes three lines.  A count before and after the first character is
 multiplied, thus `2y3y` yanks six lines.
 						*operator-resulting-pos*
 After applying the operator the cursor is mostly left at the start of the text
@@ -300,11 +300,11 @@ T{char}			Till after [count]'th occurrence of {char} to the
 			{char} can be entered like with the |f| command.
 
 							*;*
-;			Repeat latest f, t, F or T [count] times. See |cpo-;|
+;			Repeat latest f, t, F or T [count] times.  See |cpo-;|
 
 							*,*
 ,			Repeat latest f, t, F or T in opposite direction
-			[count] times. See also |cpo-;|
+			[count] times.  See also |cpo-;|
 
 ==============================================================================
 3. Up-down motions					*up-down-motions*
@@ -625,11 +625,11 @@ ab			"a block", select [count] blocks, from "[count] [(" to
 
 i)							*v_i)* *i)* *i(*
 i(							*vib* *v_ib* *v_i(* *ib*
-ib			"inner block", select [count] blocks, from "[count] [("
-			to the matching ')', excluding the '(' and ')' (see
-			|[(|).  If the cursor is not inside a () block, then
-			find the next "(".  It's an error to select an empty
-			inner block like "()".  The |cpo-M| option flag
+ib			"inner block", select [count] blocks, from "[count]
+			[(" to the matching ')', excluding the '(' and ')'
+			(see |[(|).  If the cursor is not inside a () block,
+			then find the next "(".  It's an error to select an
+			empty inner block like "()".  The |cpo-M| option flag
 			is used to handle escaped parenthesis.
 			When used in Visual mode it is made characterwise.
 
@@ -673,11 +673,11 @@ aB			"a Block", select [count] Blocks, from "[count] [{" to
 
 i}							*v_i}* *i}* *i{*
 i{							*v_iB* *v_i{* *iB*
-iB			"inner Block", select [count] Blocks, from "[count] [{"
-			to the matching '}', excluding the '{' and '}' (see
-			|[{|).  It's an error to select an empty inner block
-			like "{}".  The |cpo-M| option flag is used to handle
-			escaped braces.
+iB			"inner Block", select [count] Blocks, from "[count]
+			[{" to the matching '}', excluding the '{' and '}'
+			(see |[{|).  It's an error to select an empty inner
+			block like "{}".  The |cpo-M| option flag is used to
+			handle escaped braces.
 			When used in Visual mode it is made characterwise.
 
 a"							*v_aquote* *aquote*
@@ -876,9 +876,9 @@ buffer list.  If you remove the file from the buffer list, all its marks are
 lost.  If you delete a line that contains a mark, that mark is erased.
 
 Lowercase marks can be used in combination with operators.  For example: "d't"
-deletes the lines from the cursor position to mark 't'.  Hint: Use mark 't' for
-Top, 'b' for Bottom, etc..  Lowercase marks are restored when using undo and
-redo.
+deletes the lines from the cursor position to mark 't'.  Hint: Use mark 't'
+for Top, 'b' for Bottom, etc..  Lowercase marks are restored when using undo
+and redo.
 
 Uppercase marks 'A to 'Z include the file name.  You can use them to jump from
 file to file.  You can only use an uppercase mark with an operator if the mark
@@ -1159,9 +1159,9 @@ stored in the viminfo file and restored when starting Vim.
 							*jumplist-stack*
 When 'jumpoptions' option includes "stack", the jumplist behaves like the tag
 stack.  When jumping to a new location from the middle of the jumplist, the
-locations after the current position will be discarded. With this option set
-you can move through a tree of jump locations. When going back up a branch and
-then down another branch, CTRL-O still takes you further up the tree.
+locations after the current position will be discarded.  With this option set
+you can move through a tree of jump locations.  When going back up a branch
+and then down another branch, CTRL-O still takes you further up the tree.
 
 Given a jumplist like the following in which CTRL-O has been used to move back
 three times to location X: >
@@ -1263,7 +1263,7 @@ remembered.
 
 							*%*
 %			Find the next item in this line after or under the
-			cursor and jump to its match. |inclusive| motion.
+			cursor and jump to its match.  |inclusive| motion.
 			Items can be:
 			([{}])		parenthesis or (curly/square) brackets
 					(this can be changed with the
@@ -1334,13 +1334,13 @@ bring you back to the switch statement.
 			similar structured language).  When not after the
 			start of a method, jump to the start or end of the
 			class.  When no '{' is found before the cursor this is
-			an error. |exclusive| motion.
+			an error.  |exclusive| motion.
 						*[M*
 [M			Go to [count] previous end of a method (for Java or
 			similar structured language).  When not after the
 			end of a method, jump to the start or end of the
 			class.  When no '}' is found before the cursor this is
-			an error. |exclusive| motion.
+			an error.  |exclusive| motion.
 
 The above four commands assume that the file contains a class with methods.
 The class definition is surrounded in '{' and '}'.  Each method in the class
@@ -1375,7 +1375,8 @@ Using "3[m" will jump to the start of the class.
 
 These two commands work in C programs that contain #if/#else/#endif
 constructs.  It brings you to the start or end of the #if/#else/#endif where
-the current line is included.  You can then use "%" to go to the matching line.
+the current line is included.  You can then use "%" to go to the matching
+line.
 
 						*[star* *[/*
 [*  or  [/		Go to [count] previous start of a C comment "/*".

--- a/runtime/doc/netbeans.txt
+++ b/runtime/doc/netbeans.txt
@@ -35,10 +35,10 @@ longer exists for recent versions of NetBeans but the protocol was developed
 in such a way that any IDE can use it to integrate Vim.
 
 The NetBeans protocol of Vim is a text based communication protocol, over a
-classical TCP socket. There is no dependency on Java or NetBeans. Any language
-or environment providing a socket interface can control Vim using this
-protocol. There are existing implementations in C, C++, Python and Java. The
-name NetBeans is kept today for historical reasons.
+classical TCP socket.  There is no dependency on Java or NetBeans.  Any
+language or environment providing a socket interface can control Vim using
+this protocol.  There are existing implementations in C, C++, Python and Java.
+The name NetBeans is kept today for historical reasons.
 
 Active project using the NetBeans protocol of Vim:
 - Eclim, (dead link) eclim.org/
@@ -252,7 +252,7 @@ environment variable "__NETBEANS_SOCKET" is used or the default 3219.
 environment variable "__NETBEANS_VIM_PASSWORD" is used or "changeme".
 
 Vim will initiate a socket connection (client side) to the specified host and
-port upon startup. The password will be sent with the AUTH event when the
+port upon startup.  The password will be sent with the AUTH event when the
 connection has been established.
 
 
@@ -262,7 +262,7 @@ connection has been established.
 The communication between the Vim Controller and Vim uses plain text
 messages.  This protocol was first designed to work with the external editor
 module of NetBeans.  Later it was extended to work with Agide (A-A-P GUI IDE,
-see http://www.a-a-p.org) and then with other IDE. The extensions are marked
+see http://www.a-a-p.org) and then with other IDE.  The extensions are marked
 with "version 2.1".
 
 Version 2.2 of the protocol has several minor changes which should only affect
@@ -285,7 +285,7 @@ mechanism.
 Netbeans messages are processed when Vim is idle, waiting for user input.
 When Vim is run in non-interactive mode, for example when running an automated
 test case that sources a Vim script, the idle loop may not be called often
-enough. In that case, insert |:sleep| commands in the Vim script. The |:sleep|
+enough.  In that case, insert |:sleep| commands in the Vim script.  The |:sleep|
 command does invoke Netbeans messages processing.
 
 6.1 Kinds of messages		|nb-messages|
@@ -442,7 +442,7 @@ editFile pathname
 		Normal way for the IDE to tell the editor to edit a file.
 
 		You must set a bufId different of 0 with this command to
-		assign a bufId to the buffer. It will trigger an event
+		assign a bufId to the buffer.  It will trigger an event
 		fileOpened with a bufId of 0 but the buffer has been assigned.
 
 		If the IDE is going to pass the file text to the editor use
@@ -470,8 +470,8 @@ initDone	Mark the buffer as ready for use.  Implicitly makes the buffer
 insertDone starteol readonly
 		Sent by Vim Controller to tell Vim an initial file insert is
 		done.  This triggers a read message being printed.  If
-		"starteol" is "F" then the last line doesn't have a EOL. If
-		"readonly" is "T" then the file is marked as readonly. Prior
+		"starteol" is "F" then the last line doesn't have a EOL.  If
+		"readonly" is "T" then the file is marked as readonly.  Prior
 		to version 2.3, no read messages were displayed after opening
 		a file.  New in version 2.3.
 
@@ -862,7 +862,7 @@ These errors occur when a message violates the protocol:
 			':echo has("netbeans_enabled")'
 
 							*:nbclose*
-:nbc[lose]		Close the current NetBeans session. Remove all placed
+:nbc[lose]		Close the current NetBeans session.  Remove all placed
 			signs.
 
 							*:nbkey*
@@ -871,7 +871,7 @@ These errors occur when a message violates the protocol:
 			command, this command can be used to generate a hotkey
 			message to the Vim Controller.
 			This command can also be used to pass any text to the
-			Vim  Controller. It is used by Pyclewn, for example,
+			Vim  Controller.  It is used by Pyclewn, for example,
 			to build the complete set of gdb commands as Vim user
 			commands.
 			The events newDotAndMark, keyCommand and keyAtPos are
@@ -885,7 +885,7 @@ NUL bytes are not possible.  For editor -> IDE they will appear as NL
 characters.  For IDE -> editor they cannot be inserted.
 
 A NetBeans session may be initiated with Vim running in a terminal, and
-continued later in a GUI environment after running the |:gui| command. In this
+continued later in a GUI environment after running the |:gui| command.  In this
 case, the highlighting defined for the NetBeans annotations may be cleared
 when the ":gui" command sources .gvimrc and this file loads a colorscheme
 that runs the command ":highlight clear".
@@ -935,14 +935,14 @@ version of NetBeans.
 
 10.1. Downloading NetBeans			*netbeans-download*
 
-The NetBeans IDE is available for download from netbeans.org.  You can download
-a released version, download sources, or use CVS to download the current
-source tree.  If you choose to download sources, follow directions from
-netbeans.org on building NetBeans.
+The NetBeans IDE is available for download from netbeans.org.  You can
+download a released version, download sources, or use CVS to download the
+current source tree.  If you choose to download sources, follow directions
+from netbeans.org on building NetBeans.
 
 Depending on the version of NetBeans you download, you may need to do further
-work to get the required External Editor module.  This is the module which lets
-NetBeans work with gvim (or xemacs :-).  See (dead link)
+work to get the required External Editor module.  This is the module which
+lets NetBeans work with gvim (or xemacs :-).  See (dead link)
 externaleditor.netbeans.org
 for details on downloading this module if your NetBeans release does not have
 it.

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -32,8 +32,8 @@ achieve special effects.  These options come in three forms:
 
 :se[t] termcap		Show all terminal options.  Note that in the GUI the
 			key codes are not shown, because they are generated
-			internally and can't be changed.  Changing the terminal
-			codes in the GUI is not useful either...
+			internally and can't be changed.  Changing the
+			terminal codes in the GUI is not useful either...
 			The options have the form t_AB, see
 			|terminal-options|.
 
@@ -1493,8 +1493,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 			{not available when compiled without the |+linebreak|
 			feature}
 	Every wrapped line will continue visually indented (same amount of
-	space as the beginning of that line), thus preserving horizontal blocks
-	of text.
+	space as the beginning of that line), thus preserving horizontal
+	blocks of text.
 	NOTE: This option is reset when 'compatible' is set.
 
 						*'breakindentopt'* *'briopt'*
@@ -1839,13 +1839,14 @@ A jump table for the options with a short description can be found at |Q_op|.
 			register '*' for all yank, delete, change and put
 			operations which would normally go to the unnamed
 			register.  When "unnamed" is also included to the
-			option, yank operations (but not delete, change or put)
-			will additionally copy the text into register '*'.  If
-			Wayland is being used and the compositor does not
-			support the primary-selection-unstable-v1 protocol,
-			then the regular selection is used in its place.  Only
-			available with the |+X11| or |+wayland_clipboard|
-			feature.  Availability can be checked with: >
+			option, yank operations (but not delete, change or
+			put) will additionally copy the text into register
+			'*'.  If Wayland is being used and the compositor does
+			not support the primary-selection-unstable-v1
+			protocol, then the regular selection is used in its
+			place.  Only available with the |+X11| or
+			|+wayland_clipboard| feature.  Availability can be
+			checked with: >
 			if has('unnamedplus')
 <
 						*clipboard-autoselect*
@@ -2147,12 +2148,12 @@ A jump table for the options with a short description can be found at |Q_op|.
 		|i_CTRL-X_CTRL-D|
 	]	tag completion
 	t	same as "]"
-	F{func}	call the function {func}.  Multiple "F" flags may be specified.
-		Refer to |complete-functions| for details on how the function
-		is invoked and what it should return.  The value can be the
-		name of a function or a |Funcref|.  For |Funcref| values,
-		spaces must be escaped with a backslash ('\'), and commas with
-		double backslashes ('\\') (see |option-backslash|).
+	F{func}	call the function {func}.  Multiple "F" flags may be
+		specified.  Refer to |complete-functions| for details on how
+		the function is invoked and what it should return.  The value
+		can be the name of a function or a |Funcref|.  For |Funcref|
+		values, spaces must be escaped with a backslash ('\'), and
+		commas with double backslashes ('\\') (see |option-backslash|).
 		Unlike other sources, functions can provide completions
 		starting from a non-keyword character before the cursor, and
 		their start position for replacing text may differ from other
@@ -2354,7 +2355,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	  completion in insert mode.  This is useful when editing HTML tag, or
 	  Makefile with 'noshellslash' on MS-Windows.
 	- When this option is set to "backslash", backslash is used.  This is
-	  useful when editing a batch file with 'shellslash' set on MS-Windows.
+	  useful when editing a batch file with 'shellslash' set on
+	  MS-Windows.
 	- When this option is empty, same character is used as for
 	  'shellslash'.
 	For Insert mode completion the buffer-local value is used.  For
@@ -5575,8 +5577,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 			global
 			{only available when compiled with the |+langmap|
 			feature}
-	When off, setting 'langmap' does not apply to characters resulting from
-	a mapping.  This basically means, if you noticed that setting
+	When off, setting 'langmap' does not apply to characters resulting
+	from a mapping.  This basically means, if you noticed that setting
 	'langmap' disables some of your mappings, try resetting this option.
 	This option defaults to on for backwards compatibility.  Set it off if
 	that works for you to avoid mappings to break.
@@ -5599,8 +5601,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	executing macros, registers and other commands that have not been
 	typed.  Also, updating the window title is postponed.  To force an
 	update use |:redraw|.
-	This may occasionally cause display errors.  It is only meant to be set
-	temporarily when performing an operation where redrawing may cause
+	This may occasionally cause display errors.  It is only meant to be
+	set temporarily when performing an operation where redrawing may cause
 	flickering or cause a slowdown.
 
 						*'lhistory'* *'lhi'*
@@ -6517,10 +6519,10 @@ A jump table for the options with a short description can be found at |Q_op|.
 	some text from one window and paste it in Vim.  This will avoid
 	unexpected effects.
 	Setting this option is useful when using Vim in a terminal, where Vim
-	cannot distinguish between typed text and pasted text.  In the GUI, Vim
-	knows about pasting and will mostly do the right thing without 'paste'
-	being set.  The same is true for a terminal where Vim handles the
-	mouse clicks itself.
+	cannot distinguish between typed text and pasted text.  In the GUI,
+	Vim knows about pasting and will mostly do the right thing without
+	'paste' being set.  The same is true for a terminal where Vim handles
+	the mouse clicks itself.
 	This option is reset when starting the GUI.  Thus if you set it in
 	your .vimrc it will work in a terminal, but not in the GUI.  Setting
 	'paste' in the GUI has side effects: e.g., the Paste toolbar button
@@ -6566,8 +6568,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	'pastetoggle' works in Insert mode and Normal mode, but not in
 	Command-line mode.
 	Mappings are checked first, thus overrule 'pastetoggle'.  However,
-	when 'paste' is on mappings are ignored in Insert mode, thus you can do
-	this: >
+	when 'paste' is on mappings are ignored in Insert mode, thus you can
+	do this: >
 	    :map <F10> :set paste<CR>
 	    :map <F11> :set nopaste<CR>
 	    :imap <F10> <C-O>:set paste<CR>

--- a/runtime/doc/os_amiga.txt
+++ b/runtime/doc/os_amiga.txt
@@ -74,8 +74,8 @@ example to get white text on a blue background: >
 
 When using multiple commands with a filter command, e.g. >
   :r! echo this; echo that
-Only the output of the last command is used.  To fix this you have to group the
-commands.  This depends on the shell you use (that is why it is not done
+Only the output of the last command is used.  To fix this you have to group
+the commands.  This depends on the shell you use (that is why it is not done
 automatically in Vim).  Examples: >
   :r! (echo this; echo that)
   :r! {echo this; echo that}

--- a/runtime/doc/os_haiku.txt
+++ b/runtime/doc/os_haiku.txt
@@ -40,7 +40,7 @@ instance (r,g,b)=(168,168,168)) with black letters also works nicely.
 
 2. Compiling Vim					*haiku-compiling*
 
-Vim can be compiled using the standard configure/make approach. Running
+Vim can be compiled using the standard configure/make approach.  Running
 ./configure without any arguments or passing --enable-gui=haiku, will compile
 vim with the Haiku GUI support.  Run ./configure --help , to find out other
 features you can enable/disable.
@@ -73,8 +73,8 @@ additionally installed over the GUI version.  Typical build commands are:
 
 Normally Vim starts with the GUI if you start it as gvim or vim -g.  The vim
 version with GUI tries to determine if it was started from the Tracker instead
-of the Terminal, and if so, uses the GUI anyway.  However, the current detection
-scheme is fooled if you use the command "vim - </dev/null".
+of the Terminal, and if so, uses the GUI anyway.  However, the current
+detection scheme is fooled if you use the command "vim - </dev/null".
 
 Toggling between normal managed window and fullscreen mode can be done by
 pressing <Alt-Enter>.
@@ -90,7 +90,7 @@ Stuff that does not work yet:
   follows-mouse turned on).
 - The cursor does not flash.
 - Switching windows using <C-Tab-Up> and <C-Tab-Down> in Twitcher does not
-  work. This is due to each gvim window being managed by a separate instance
+  work.  This is due to each gvim window being managed by a separate instance
   completely unaware of other vim processes.
 
 4. The $VIM directory					*haiku-vimdir*
@@ -141,7 +141,7 @@ open the files instead.  This works from the Tracker but also from the command
 line.  In the latter case, non-file (option) arguments are not supported.
 Another drawback of the Single Launch is silent ignore of "Open With ..."
 requests by vim instance that running as non-GUI application even GUI support
-was compiled in. Vim instance running with GUI has no such problems.
+was compiled in.  Vim instance running with GUI has no such problems.
 
 NB: Only the GUI version has a BApplication (and hence Application Flags).
 This section does not apply to the GUI-less version, should you compile one.
@@ -201,14 +201,14 @@ $VIM/macros/swapmous.vim for an example.		|gui-mouse-mapping|
 
 11. Color names						*haiku-colors*
 
-Vim has a number of color names built-in. Additional names can be defined in
-|v:colornames|. See |:colorscheme| for details.
+Vim has a number of color names built-in.  Additional names can be defined in
+|v:colornames|.  See |:colorscheme| for details.
 
 
 12. GUI Toolbar Images					*haiku-toolbar-images*
 
 Alternative set of toolbar images should be the PNG image of any height you
-like. Image width is calculated to contain at least 32 buttons in one-row
+like.  Image width is calculated to contain at least 32 buttons in one-row
 cells.
 The image should be stored under the name $VIRUNTIME/bitmaps/builtin-tools.png
 More info about the buttons assignment are at |builtin-tools|.
@@ -229,8 +229,8 @@ Thank you, all!
 
 14. Bugs & to-do					*haiku-bugs*
 
-The port is under development now and far away from the perfect state. For bug
-reports, patches and wishes, please use the Vim mailing list or Vim Github
+The port is under development now and far away from the perfect state.  For
+bug reports, patches and wishes, please use the Vim mailing list or Vim Github
 repository.
 
 Mailing list: https://www.vim.org/maillist.php

--- a/runtime/doc/os_mac.txt
+++ b/runtime/doc/os_mac.txt
@@ -36,7 +36,7 @@ Indianapolis IN 46220 USA
 1. Filename Convention					*mac-filename*
 
 Starting with Vim version 7 you can just use the unix path separators with
-Vim. In order to determine if the specified filename is relative to the
+Vim.  In order to determine if the specified filename is relative to the
 current folder or absolute (i.e. relative to the "Desktop"), the following
 algorithm is used:
 

--- a/runtime/doc/os_mint.txt
+++ b/runtime/doc/os_mint.txt
@@ -5,7 +5,7 @@
 
 
 							*MiNT* *Atari*
-The Atari MiNT support was removed with patch 8.2.1215. It probably didn't
+The Atari MiNT support was removed with patch 8.2.1215.  It probably didn't
 work at that time, since the code was old and not maintained.
 
 

--- a/runtime/doc/os_qnx.txt
+++ b/runtime/doc/os_qnx.txt
@@ -22,8 +22,8 @@ Vim on QNX behaves much like other unix versions. |os_unix.txt|
 
 2. Compiling Vim					*qnx-compiling*
 
-Vim can be compiled using the standard configure/make approach.  If you want to
-compile for X11, pass the --with-x option to configure.  Otherwise, running
+Vim can be compiled using the standard configure/make approach.  If you want
+to compile for X11, pass the --with-x option to configure.  Otherwise, running
 ./configure without any arguments or passing --enable-gui=photon, will compile
 vim with the Photon gui support.  Run ./configure --help , to find out other
 features you can enable/disable.

--- a/runtime/doc/os_vms.txt
+++ b/runtime/doc/os_vms.txt
@@ -80,9 +80,9 @@ See the file [.SRC]INSTALLVMS.TXT.
 4. Problems						*vms-problems*
 
 The code has been tested under Open VMS 6.2 - 9.2 on Alpha, VAX, IA64 and
-X86_64 platforms with the DEC C compiler. It should work without major problems.
-If your system does not have some include libraries you can tune in the
-OS_VMS_CONF.H file.
+X86_64 platforms with the DEC C compiler.  It should work without major
+problems.  If your system does not have some include libraries you can tune in
+the OS_VMS_CONF.H file.
 
 If you decided to build Vim with +perl, +python, etc. options, first you need
 to download OpenVMS distributions of Perl and Python.  Build and deploy the
@@ -96,7 +96,8 @@ VAX C compiler is not fully ANSI C compatible in pre-processor directives
 semantics, therefore you have to use a converter program that will do the lion
 part of the job.  For detailed instructions read file INSTALLvms.txt
 
-To build XXD.EXE, you should change to the subdirectory and build it separately.
+To build XXD.EXE, you should change to the subdirectory and build it
+separately.
 
 CTAGS is not part of the Vim source distribution anymore, however the OpenVMS
 specific source might contain CTAGS source files as described above.
@@ -216,8 +217,8 @@ Example LOGIN.COM: >
 	$ set term/inq/ins ! inquire the terminal capabilities
 	$ set disp/create/node=192.168.10.202/trans=tcpip
 
-Note: This set-up should be enough, if you are working on a standalone server or
-clustered environment, but if you want to use Vim as an internode editor in
+Note: This set-up should be enough, if you are working on a standalone server
+or clustered environment, but if you want to use Vim as an internode editor in
 DECNET environment, it will satisfy as well.
 You just have to define the "whole" path: >
 
@@ -291,8 +292,8 @@ can be downloaded from http://www.polarhome.com/vim/).
 
 	$ set disp/create/node=<your IP address>/trans=<transport-name>
 <
-   and start Vim as in point 1.  You can find more help in VMS documentation or
-   type: help set disp in VMS prompt.
+   and start Vim as in point 1.  You can find more help in VMS documentation
+   or type: help set disp in VMS prompt.
    Examples: >
 
 	$ set disp/create/node=192.168.5.159		 ! default trans is DECnet
@@ -456,7 +457,8 @@ Try to force to inquire the terminal capabilities with: >
 
 	$ set term/inquire
 
-If the inquire did not help, the solutions is to define the default terminal name: >
+If the inquire did not help, the solutions is to define the default terminal
+name: >
 
 	$ ! unknown terminal name.  Let us use vt320 or ansi instead.
 	$ ! Note: it's case sensitive
@@ -487,9 +489,9 @@ special commands to execute executables: >
 
 OpenVMS users always have to be aware that the Vim command :! "just" drop them
 to DCL prompt.  This feature is possible to use without any problem with all
-DCL commands, but if we want to execute some programs such as XXD, CTAGS, JTAGS,
-etc.  we're running into trouble if we follow the Vim documentation (see: help
-xxd).
+DCL commands, but if we want to execute some programs such as XXD, CTAGS,
+JTAGS, etc.  we're running into trouble if we follow the Vim documentation
+(see: help xxd).
 
 Solution: Execute with the MC command and add the full path to the executable.
 Example: Instead of :%!xxd command use: >
@@ -707,7 +709,7 @@ console mode can avoid performance problems.
 In a cluster that contains nodes with different architectures like below:
 
 $show cluster
-View of Cluster from system ID 11655  node: TOR                                                                     18-AUG-2008 11:58:31
+View of Cluster from system ID 11655  node: TOR  18-AUG-2008 11:58:31
 +---------------------------------+
 |        SYSTEMS        | MEMBERS |
 +-----------------------+---------|
@@ -773,17 +775,20 @@ GNU_TOOLS.ZIP package downloadable from http://www.polarhome.com/vim/
 
 Version 9.0 (2023 Nov 27)
 - Vim is ported to the X86_64 architecture
-	- IMPORTANT: because of the getline function name used in structs like in ex_cmds.h
-	on X86_64 the CRTL_VER is kept under 80500000 level. The proper solution would be
-	to rename the getline function to something else in the struct (and in all places
-	it is used) - and avoiding to use POSIX functions in structs, but this change would
-	impact on all other operating systems. (added to the VMS TODO list)
-	Read more about at https://forum.vmssoftware.com/viewtopic.php?f=38&t=8914&p=20049
+	- IMPORTANT: because of the getline function name used in structs like
+	in ex_cmds.h on X86_64 the CRTL_VER is kept under 80500000 level. The
+	proper solution would be to rename the getline function to something
+	else in the struct (and in all places it is used) - and avoiding to
+	use POSIX functions in structs, but this change would impact on all
+	other operating systems. (added to the VMS TODO list)
+	Read more about at:
+	    https://forum.vmssoftware.com/viewtopic.php?f=38&t=8914&p=20049
 - os_vms_conf.h includes have been reviewed for all architectures
 - added support for the MODIFIED_BY define
 
 Version 8.2 (2020 Feb 6)
-- make all changes needed for clean compile build of v8.2 on VMS on all platforms
+- make all changes needed for clean compile build of v8.2 on VMS on all
+  platforms
 - fix the call mkdir bug (vicente_polo@yahoo.es)
 - test on VSI OpenVMS Alpha and Itanium platforms
 - added LUA support
@@ -797,21 +802,23 @@ Version 8.1 (2019 Jan 9)
 
 Version 8.0 (2016 Nov 21)
 - solve the 100% cpu usage issue while waiting for a keystroke
-- correct the VMS warnings and errors around handling the INFINITY (used in json.c)
+- correct the VMS warnings and errors around handling the INFINITY (used in
+  json.c)
 - minor VMS port related changes
 - correct the make_vms.mms file for 8.0
 - fix [.TESTDIR]make_vms.mms for 8.0
 
 Version 7.4 (2013 Aug 10)
-- Undo: VMS can not handle more than one dot in the filenames use "dir/name" -> "dir/_un_name"
+- Undo: VMS can not handle more than one dot in the filenames use
+  "dir/name" -> "dir/_un_name"
   add _un_ at the beginning to keep the extension
 - correct swap file name wildcard handling
 - handle iconv usage correctly
 - do not optimize on vax - otherwise it hangs compiling crypto files
 - fileio.c fix the comment
 - correct RealWaitForChar
-- after 7.4-119 use different functions lib$cvtf_to_internal_time because Alpha and VAX have
-  G_FLOAT but IA64 uses IEEE float otherwise Vim crashes
+- after 7.4-119 use different functions lib$cvtf_to_internal_time because
+  Alpha and VAX have G_FLOAT but IA64 uses IEEE float otherwise Vim crashes
 - guard against crashes that are caused by mixed filenames
 - [TESTDIR]make_vms.mms changed to see the output files
 - Improve tests, update known issues
@@ -820,7 +827,8 @@ Version 7.4 (2013 Aug 10)
 
 Version 7.3 (2010 Aug 15)
 - CTAGS 5.8 included
-- VMS compile warnings fixed - floating-point overflow warning corrected on VAX
+- VMS compile warnings fixed - floating-point overflow warning corrected on
+  VAX
 - filepath completion corrected - too many chars were escaped in filename
   and shell commands
 - the following plugins are included into VMS runtime:

--- a/runtime/doc/os_win32.txt
+++ b/runtime/doc/os_win32.txt
@@ -153,7 +153,7 @@ Alternatively use three quotes to get one: >
 The quotation rules are:
 
 1. A `"` starts quotation.
-2. Another `"` or `""` ends quotation. If the quotation ends with `""`, a `"`
+2. Another `"` or `""` ends quotation.  If the quotation ends with `""`, a `"`
    is produced at the end of the quoted string.
 
 Examples, with [] around an argument:
@@ -295,7 +295,7 @@ A. You can't!  This is a limitation of the NT console.  NT 5.0 is reported to
 							*:!start*
 Q. How can I asynchronously run an external command or program, or open a
    document or URL with its default program?
-A. When using :! to run an external command, you can run it with "start". For
+A. When using :! to run an external command, you can run it with "start".  For
    example, to run notepad: >
 	:!start notepad
 <   To open "image.jpg" with the default image viewer: >
@@ -320,14 +320,14 @@ A. When using :! to run an external command, you can run it with "start". For
 Q. How do I avoid getting a window for programs that I run asynchronously?
 A. You have three possible solutions depending on what you want:
    1) You may use the /min flag in order to run program in a minimized state
-      with no other changes. It will work equally for console and GUI
+      with no other changes.  It will work equally for console and GUI
       applications.
    2) You can use the /b flag to run console applications without creating a
-      console window for them (GUI applications are not affected). But you
+      console window for them (GUI applications are not affected).  But you
       should use this flag only if the application you run doesn't require any
       input.  Otherwise it will get an EOF error because its input stream
       (stdin) would be redirected to \\.\NUL (stdout and stderr too).
-   3) Set the '!' flag in the 'guioptions' option |'go-!'|. This will make Vim
+   3) Set the '!' flag in the 'guioptions' option |'go-!'|.  This will make Vim
       run the "start" command inside Vims terminal window and not open a
       console window.
 

--- a/runtime/doc/pattern.txt
+++ b/runtime/doc/pattern.txt
@@ -288,9 +288,9 @@ When searching backwards, searching starts at the start of the line, using the
 cursor position is used.
 
 In Vi the ":tag" command sets the last search pattern when the tag is searched
-for.  In Vim this is not done, the previous search pattern is still remembered,
-unless the 't' flag is present in 'cpoptions'.  The search pattern is always
-put in the search history.
+for.  In Vim this is not done, the previous search pattern is still
+remembered, unless the 't' flag is present in 'cpoptions'.  The search pattern
+is always put in the search history.
 
 If the 'wrapscan' option is on (which is the default), searches wrap around
 the end of the buffer.  If 'wrapscan' is not set, the backward search stops
@@ -1151,11 +1151,12 @@ x	A single character, with no special meaning, matches itself
 	in the collection: "[^xyz]" matches anything but 'x', 'y' and 'z'.
 	- If two characters in the sequence are separated by '-', this is
 	  shorthand for the full list of ASCII characters between them.  E.g.,
-	  "[0-9]" matches any decimal digit.  If the starting character exceeds
-	  the ending character, e.g. [c-a], E944 occurs.  Non-ASCII characters
-	  can be used, but the character values must not be more than 256 apart
-	  in the old regexp engine.  For example, searching by [\u3000-\u4000]
-	  after setting re=1 emits a E945 error.  Prepending \%#=2 will fix it.
+	  "[0-9]" matches any decimal digit.  If the starting character
+	  exceeds the ending character, e.g. [c-a], E944 occurs.  Non-ASCII
+	  characters can be used, but the character values must not be more
+	  than 256 apart in the old regexp engine.  For example, searching by
+	  [\u3000-\u4000] after setting re=1 emits a E945 error.  Prepending
+	  \%#=2 will fix it.
 	- A character class expression is evaluated to the set of characters
 	  belonging to that character class.  The following character classes
 	  are supported:

--- a/runtime/doc/popup.txt
+++ b/runtime/doc/popup.txt
@@ -314,7 +314,7 @@ popup_dialog({what}, {options})				*popup_dialog()*
 				\ padding: [],
 				\ mapping: 0,
 				\})
-<		Use {options} to change the properties. E.g. add a 'filter'
+<		Use {options} to change the properties.  E.g. add a 'filter'
 		option with value 'popup_filter_yesno'.  Example: >
 			call popup_create('do you want to quit (Yes/no)?', #{
 				\ filter: 'popup_filter_yesno',
@@ -331,7 +331,7 @@ popup_dialog({what}, {options})				*popup_dialog()*
 
 
 popup_filter_menu({id}, {key})				*popup_filter_menu()*
-		Filter that can be used for a popup. These keys can be used:
+		Filter that can be used for a popup.  These keys can be used:
 		    j <Down> <C-N>	select item below
 		    k <Up> <C-P>	select item above
 		    <Space> <Enter>	accept current selection
@@ -354,7 +354,7 @@ popup_filter_menu({id}, {key})				*popup_filter_menu()*
 
 
 popup_filter_yesno({id}, {key})				*popup_filter_yesno()*
-		Filter that can be used for a popup. It handles only the keys
+		Filter that can be used for a popup.  It handles only the keys
 		'y', 'Y' and 'n' or 'N'.  Invokes the "callback" of the
 		popup menu with the 1 for 'y' or 'Y' and zero for 'n' or 'N'
 		as the second argument.  Pressing Esc and 'x' works like
@@ -460,7 +460,7 @@ popup_getpos({id})					*popup_getpos()*
 
 
 popup_hide({id})						*popup_hide()*
-		If {id} is a displayed popup, hide it now. If the popup has a
+		If {id} is a displayed popup, hide it now.  If the popup has a
 		filter it will not be invoked for so long as the popup is
 		hidden.
 		If window {id} does not exist nothing happens.  If window {id}
@@ -491,8 +491,8 @@ popup_locate({row}, {col})				 *popup_locate()*
 popup_menu({what}, {options})				 *popup_menu()*
 		Show the {what} near the cursor, handle selecting one of the
 		items with cursorkeys, and close it an item is selected with
-		Space or Enter. {what} should have multiple lines to make this
-		useful.  This works like: >
+		Space or Enter.  {what} should have multiple lines to make
+		this useful.  This works like: >
 			call popup_create({what}, #{
 				\ pos: 'center',
 				\ zindex: 200,
@@ -627,7 +627,7 @@ popup_setoptions({id}, {options})			*popup_setoptions()*
 
 
 popup_settext({id}, {text})				*popup_settext()*
-		Set the text of the buffer in popup win {id}. {text} is
+		Set the text of the buffer in popup win {id}.  {text} is
 		a string or a list of strings to be displayed in the popup.
 		Does not change the window size or position, other than caused
 		by the different text.
@@ -710,7 +710,7 @@ The second argument of |popup_create()| is a dictionary with options:
 			omitted or invalid the current window is used.  Used
 			when "textprop" is present.
 	textpropid	Used to identify the text property when "textprop" is
-			present. Use zero to reset.
+			present.  Use zero to reset.
 	fixed		When FALSE (the default), and:
 			 - "pos" is "botleft" or "topleft", and
 			 - the popup would be truncated at the right edge of
@@ -753,7 +753,7 @@ The second argument of |popup_create()| is a dictionary with options:
 	wrap		TRUE to make the lines wrap (default TRUE).
 	drag		TRUE to allow the popup to be dragged with the mouse
 			by grabbing at the border.  Has no effect if the
-			popup does not have a border. As soon as dragging
+			popup does not have a border.  As soon as dragging
 			starts and "pos" is "center" it is changed to
 			"topleft".
 	dragall		TRUE to allow the popup to be dragged from every
@@ -803,10 +803,10 @@ The second argument of |popup_create()| is a dictionary with options:
 	scrollbar	1 or true: show a scrollbar when the text doesn't fit.
 			zero: do not show a scrollbar.  Default is non-zero.
 			Also see |popup-scrollbar|.
-	scrollbarhighlight  Highlight group name for the scrollbar. The
+	scrollbarhighlight  Highlight group name for the scrollbar.  The
 			background color is what matters.  When not given then
 			PmenuSbar is used.
-	thumbhighlight  Highlight group name for the scrollbar thumb. The
+	thumbhighlight  Highlight group name for the scrollbar thumb.  The
 			background color is what matters.  When not given then
 			PmenuThumb is used.
 	zindex		Priority for the popup, default 50.  Minimum value is
@@ -831,7 +831,7 @@ The second argument of |popup_create()| is a dictionary with options:
 			line or to another window.
 	mousemoved	Like "moved" but referring to the mouse pointer
 			position
-	cursorline	TRUE:	 Highlight the cursor line. Also scrolls the
+	cursorline	TRUE:	 Highlight the cursor line.  Also scrolls the
 				 text to show this line (only works properly
 				 when 'wrap' is off).
 			zero:	 Do not highlight the cursor line.

--- a/runtime/doc/print.txt
+++ b/runtime/doc/print.txt
@@ -178,7 +178,7 @@ value for non-MS-Windows a trick is used: Adding "v:shell_error" will result
 in a non-zero number when the system() call fails.
 
 If the expression starts with s: or |<SID>|, then it is replaced with the
-script ID (|local-function|). Example: >
+script ID (|local-function|).  Example: >
 		set printexpr=s:MyPrintFile()
 		set printexpr=<SID>SomePrintFile()
 Otherwise, the expression is evaluated in the context of the script where the
@@ -545,8 +545,9 @@ There are a number of possible causes as to why the printing may have failed:
   not support the requested paper size.  By default Vim uses A4 paper.  Find
   out what size paper your printer normally uses and set the appropriate paper
   size with 'printoptions'.  If you cannot find the name of the paper used,
-  measure a sheet and compare it with the table of supported paper sizes listed
-  for 'printoptions', using the paper that is closest in both width AND height.
+  measure a sheet and compare it with the table of supported paper sizes
+  listed for 'printoptions', using the paper that is closest in both width AND
+  height.
   Note: The dimensions of actual paper may vary slightly from the ones listed.
   If there is no paper listed close enough, then you may want to try psresize
   from PSUtils, discussed below.

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -45,13 +45,13 @@ compiler (see |errorformat| below).
 
 					*quickfix-stack* *quickfix-ID* *E1545*
 Each quickfix list has a unique identifier called the quickfix ID and this
-number will not change within a Vim session. The |getqflist()| function can be
-used to get the identifier assigned to a list. There is also a quickfix list
+number will not change within a Vim session.  The |getqflist()| function can be
+used to get the identifier assigned to a list.  There is also a quickfix list
 number which may change whenever more than 'chistory' lists are added to a
 quickfix stack.
 
 						*location-list* *E776*
-A location list is a window-local quickfix list. You get one after commands
+A location list is a window-local quickfix list.  You get one after commands
 like `:lvimgrep`, `:lgrep`, `:lhelpgrep`, `:lmake`, etc., which create a
 location list instead of a quickfix list as the corresponding `:vimgrep`,
 `:grep`, `:helpgrep`, `:make` do.
@@ -67,7 +67,7 @@ the location list is destroyed.
 						*quickfix-changedtick*
 Every quickfix and location list has a read-only changedtick variable that
 tracks the total number of changes made to the list.  Every time the quickfix
-list is modified, this count is incremented. This can be used to perform an
+list is modified, this count is incremented.  This can be used to perform an
 action only when the list has changed.  The |getqflist()| and |getloclist()|
 functions can be used to query the current value of changedtick.  You cannot
 change the changedtick variable.
@@ -87,9 +87,9 @@ processing a quickfix or location list command, it will be aborted.
 							*:cc*
 :cc[!] [nr]		Display error [nr].  If [nr] is omitted, the same
 :[nr]cc[!]		error is displayed again.  Without [!] this doesn't
-			work when jumping to another buffer, the current buffer
-			has been changed, there is the only window for the
-			buffer and both 'hidden' and 'autowrite' are off.
+			work when jumping to another buffer, the current
+			buffer has been changed, there is the only window for
+			the buffer and both 'hidden' and 'autowrite' are off.
 			When jumping to another buffer with [!] any changes to
 			the current buffer are lost, unless 'hidden' is set or
 			there is another window for this buffer.
@@ -131,10 +131,10 @@ processing a quickfix or location list command, it will be aborted.
 			used.  If there are no errors, then an error message
 			is displayed.  Assumes that the entries in a quickfix
 			list are sorted by their buffer number and line
-			number. If there are multiple errors on the same line,
-			then only the first entry is used.  If [count] exceeds
-			the number of entries above the current line, then the
-			first error in the file is selected.
+			number.  If there are multiple errors on the same
+			line, then only the first entry is used.  If [count]
+			exceeds the number of entries above the current line,
+			then the first error in the file is selected.
 
 							*:lab* *:labove*
 :[count]lab[ove]	Same as ":cabove", except the location list for the
@@ -276,7 +276,7 @@ processing a quickfix or location list command, it will be aborted.
 
 							*:caddf* *:caddfile*
 :caddf[ile] [errorfile]	Read the error file and add the errors from the
-			errorfile to the current quickfix list. If a quickfix
+			errorfile to the current quickfix list.  If a quickfix
 			list is not present, then a new list is created.
 			If the encoding of the error file differs from the
 			'encoding' option, you can use the 'makeencoding'
@@ -317,7 +317,7 @@ processing a quickfix or location list command, it will be aborted.
 			Read the error list from the current buffer and add
 			the errors to the current quickfix list.  If a
 			quickfix list is not present, then a new list is
-			created. Otherwise, same as ":cbuffer".
+			created.  Otherwise, same as ":cbuffer".
 
 							*:laddb* *:laddbuffer*
 :[range]laddb[uffer] [bufnr]
@@ -354,9 +354,9 @@ processing a quickfix or location list command, it will be aborted.
 
 							*:cadde* *:caddexpr*
 :cadde[xpr] {expr}	Evaluate {expr} and add the resulting lines to the
-			current quickfix list. If a quickfix list is not
-			present, then a new list is created. The current
-			cursor position will not be changed. See |:cexpr| for
+			current quickfix list.  If a quickfix list is not
+			present, then a new list is created.  The current
+			cursor position will not be changed.  See |:cexpr| for
 			more information.
 			Example: >
     :g/mypattern/caddexpr expand("%") .. ":" .. line(".") ..  ":" .. getline(".")
@@ -368,11 +368,12 @@ processing a quickfix or location list command, it will be aborted.
 							*:cl* *:clist*
 :cl[ist] [from] [, [to]]
 			List all errors that are valid |quickfix-valid|.
-			If numbers [from] and/or [to] are given, the respective
-			range of errors is listed.  A negative number counts
-			from the last error backwards, -1 being the last error.
+			If numbers [from] and/or [to] are given, the
+			respective range of errors is listed.  A negative
+			number counts from the last error backwards, -1 being
+			the last error.
 			The |:filter| command can be used to display only the
-			quickfix entries matching a supplied pattern. The
+			quickfix entries matching a supplied pattern.  The
 			pattern is matched against the filename, module name,
 			pattern and text of the entry.
 
@@ -408,7 +409,7 @@ the error location may not be correct.  If you quit Vim and start again the
 marks are lost and the error locations may not be correct anymore.
 
 Two autocommands are available for running commands before and after a
-quickfix command (':make', ':grep' and so on) is executed. See
+quickfix command (':make', ':grep' and so on) is executed.  See
 |QuickFixCmdPre| and |QuickFixCmdPost| for details.
 
 						*QuickFixCmdPost-example*
@@ -427,11 +428,11 @@ use this code: >
 Another option is using 'makeencoding'.
 
 							*quickfix-title*
-Every quickfix and location list has a title. By default the title is set to
-the command that created the list. The |getqflist()| and |getloclist()|
+Every quickfix and location list has a title.  By default the title is set to
+the command that created the list.  The |getqflist()| and |getloclist()|
 functions can be used to get the title of a quickfix and a location list
-respectively. The |setqflist()| and |setloclist()| functions can be used to
-modify the title of a quickfix and location list respectively. Examples: >
+respectively.  The |setqflist()| and |setloclist()| functions can be used to
+modify the title of a quickfix and location list respectively.  Examples: >
 	call setqflist([], 'a', {'title' : 'Cmd output'})
 	echo getqflist({'title' : 1})
 	call setloclist(3, [], 'a', {'title' : 'Cmd output'})
@@ -440,32 +441,32 @@ modify the title of a quickfix and location list respectively. Examples: >
 							*quickfix-index*
 When you jump to a quickfix/location list entry using any of the quickfix
 commands (e.g. |:cc|, |:cnext|, |:cprev|, etc.), that entry becomes the
-currently selected entry. The index of the currently selected entry in a
+currently selected entry.  The index of the currently selected entry in a
 quickfix/location list can be obtained using the getqflist()/getloclist()
-functions. Examples: >
+functions.  Examples: >
 	echo getqflist({'idx' : 0}).idx
 	echo getqflist({'id' : qfid, 'idx' : 0}).idx
 	echo getloclist(2, {'idx' : 0}).idx
 <
 For a new quickfix list, the first entry is selected and the index is 1.  Any
 entry in any quickfix/location list can be set as the currently selected entry
-using the setqflist() function. Examples: >
+using the setqflist() function.  Examples: >
 	call setqflist([], 'a', {'idx' : 12})
 	call setqflist([], 'a', {'id' : qfid, 'idx' : 7})
 	call setloclist(1, [], 'a', {'idx' : 7})
 <
 							*quickfix-size*
 You can get the number of entries (size) in a quickfix and a location list
-using the |getqflist()| and |getloclist()| functions respectively. Examples: >
+using the |getqflist()| and |getloclist()| functions respectively.  Examples: >
 	echo getqflist({'size' : 1})
 	echo getloclist(5, {'size' : 1})
 <
 							*quickfix-context*
 Any Vim type can be associated as a context with a quickfix or location list.
 The |setqflist()| and the |setloclist()| functions can be used to associate a
-context with a quickfix and a location list respectively. The |getqflist()|
+context with a quickfix and a location list respectively.  The |getqflist()|
 and the |getloclist()| functions can be used to retrieve the context of a
-quickfix and a location list respectively. This is useful for a Vim plugin
+quickfix and a location list respectively.  This is useful for a Vim plugin
 dealing with multiple quickfix/location lists.
 Examples: >
 
@@ -479,11 +480,11 @@ Examples: >
 <
 							*quickfix-parse*
 You can parse a list of lines using 'errorformat' without creating or
-modifying a quickfix list using the |getqflist()| function. Examples: >
+modifying a quickfix list using the |getqflist()| function.  Examples: >
 	echo getqflist({'lines' : ["F1:10:Line10", "F2:20:Line20"]})
 	echo getqflist({'lines' : systemlist('grep -Hn quickfix *')})
 This returns a dictionary where the "items" key contains the list of quickfix
-entries parsed from lines. The following shows how to use a custom
+entries parsed from lines.  The following shows how to use a custom
 'errorformat' to parse the lines without modifying the 'errorformat' option: >
 	echo getqflist({'efm' : '%f#%l#%m', 'lines' : ['F1#10#Line']})
 <
@@ -562,11 +563,11 @@ Then you can use the following commands to filter a quickfix/location list: >
     :Lfilter[!] /{pat}/
 
 The |:Cfilter| command creates a new quickfix list from the entries matching
-{pat} in the current quickfix list. {pat} is a Vim |regular-expression|
-pattern. Both the file name and the text of the entries are matched against
-{pat}. If the optional ! is supplied, then the entries not matching {pat} are
-used. The pattern can be optionally enclosed using one of the following
-characters: ', ", /. If the pattern is empty, then the last used search
+{pat} in the current quickfix list.  {pat} is a Vim |regular-expression|
+pattern.  Both the file name and the text of the entries are matched against
+{pat}.  If the optional ! is supplied, then the entries not matching {pat} are
+used.  The pattern can be optionally enclosed using one of the following
+characters: ', ", /.  If the pattern is empty, then the last used search
 pattern is used.
 
 The |:Lfilter| command does the same as |:Cfilter| but operates on the current
@@ -595,19 +596,19 @@ can go back to the unfiltered list using the |:colder|/|:lolder| command.
 			'buftype' equal to "quickfix".  Don't change this!
 			The window will have the w:quickfix_title variable set
 			which will indicate the command that produced the
-			quickfix list. This can be used to compose a custom
+			quickfix list.  This can be used to compose a custom
 			status line if the value of 'statusline' is adjusted
-			properly. Whenever this buffer is modified by a
+			properly.  Whenever this buffer is modified by a
 			quickfix command or function, the |b:changedtick|
 			variable is incremented.  You can get the number of
 			this buffer using the getqflist() and getloclist()
-			functions by passing the "qfbufnr" item. For a
+			functions by passing the "qfbufnr" item.  For a
 			location list, this buffer is wiped out when the
 			location list is removed.
 
 							*:lop* *:lopen*
 :lop[en] [height]	Open a window to show the location list for the
-			current window. Works only when the location list for
+			current window.  Works only when the location list for
 			the current window is present.  You can have more than
 			one location window opened at a time.  Otherwise, it
 			acts the same as ":copen".
@@ -714,7 +715,7 @@ The location list window displays the entries in a location list.  When you
 open a location list window, it is created below the current window and
 displays the location list for the current window.  The location list window
 is similar to the quickfix window, except that you can have more than one
-location list window open at a time. When you use a location list command in
+location list window open at a time.  When you use a location list command in
 this window, the displayed location list is used.
 
 When you select a file from the location list window, the following steps are
@@ -743,7 +744,7 @@ present).  Examples: >
 <
 							*getqflist-examples*
 The |getqflist()| and |getloclist()| functions can be used to get the various
-attributes of a quickfix and location list respectively. Some examples for
+attributes of a quickfix and location list respectively.  Some examples for
 using these functions are below:
 >
     " get the title of the current quickfix list
@@ -809,7 +810,7 @@ using these functions are below:
 <
 							*setqflist-examples*
 The |setqflist()| and |setloclist()| functions can be used to set the various
-attributes of a quickfix and location list respectively. Some examples for
+attributes of a quickfix and location list respectively.  Some examples for
 using these functions are below:
 >
     " create an empty quickfix list with a title and a context
@@ -893,7 +894,7 @@ existing error lists as the current one.
 			  error list 3 of 3; 15 errors   :grep ex_help *.c ~
 
 			When [count] is given, then the count'th quickfix
-			list is made the current list. Example: >
+			list is made the current list.  Example: >
 				" Make the 4th quickfix list current
 				:4chistory
 <
@@ -910,7 +911,7 @@ lists, use ":cnewer 99" first.
 
 To get the number of lists in the quickfix and location list stack, you can
 use the |getqflist()| and |getloclist()| functions respectively with the list
-number set to the special value '$'. Examples: >
+number set to the special value '$'.  Examples: >
 	echo getqflist({'nr' : '$'}).nr
 	echo getloclist(3, {'nr' : '$'}).nr
 To get the number of the current list in the stack: >
@@ -1066,7 +1067,7 @@ commands can be combined to create a NewGrep command: >
 			     buffer are abandoned.
 
 			'f'  When the 'f' flag is specified, fuzzy string
-			     matching is used to find matching lines. In this
+			     matching is used to find matching lines.  In this
 			     case, {pattern} is treated as a literal string
 			     instead of a regular expression.  See
 			     |fuzzy-matching| for more information about fuzzy
@@ -1181,8 +1182,8 @@ arguments to :grep are passed straight to the "grep" program, so you can use
 whatever options your "grep" supports.
 
 By default, :grep invokes grep with the -n option (show file and line
-numbers).  You can change this with the 'grepprg' option.  You will need to set
-'grepprg' if:
+numbers).  You can change this with the 'grepprg' option.  You will need to
+set 'grepprg' if:
 
 a)	You are using a program that isn't called "grep"
 b)	You have to call grep with a full path
@@ -1282,7 +1283,7 @@ Use the |compiler-make| plugin to undo the effect of a compiler plugin.
 
 CPPCHECK			*quickfix-cppcheck* *compiler-cppcheck*
 
-Use g/b:`c_cppcheck_params` to set cppcheck parameters. The global
+Use g/b:`c_cppcheck_params` to set cppcheck parameters.  The global
 settings by default include
 
 - `--verbose`: Enables verbose output.
@@ -1297,10 +1298,10 @@ For C++ files (`filetype == 'cpp'`), the `--language=c++` option is added to
 ensure Cppcheck treats the file as C++.
 
 If compile_commands.json is present in the current directory, it is added as a
-`--project` parameter to the command line. Otherwise, by default the
-directories in &path are passed as include directories. These can be set by
-g/b:`c_cppcheck_includes` as a list of `-I` flags. Tim Pope's vim-apathy
-plug-in [0] can expand &path. To also append the folders in a git repo use >
+`--project` parameter to the command line.  Otherwise, by default the
+directories in &path are passed as include directories.  These can be set by
+g/b:`c_cppcheck_includes` as a list of `-I` flags.  Tim Pope's vim-apathy
+plug-in [0] can expand &path.  To also append the folders in a git repo use >
 
   let &l:path = join(systemlist('git ls-tree -d --name-only -r HEAD'), ',')
 
@@ -1308,12 +1309,13 @@ plug-in [0] can expand &path. To also append the folders in a git repo use >
 
 DOTNET							*compiler-dotnet*
 
-The .NET CLI compiler outputs both errors and warnings by default. The output
+The .NET CLI compiler outputs both errors and warnings by default.  The output
 may be limited to include only errors, by setting the g:dotnet_errors_only
 variable to |v:true|.
 
-The associated project name is included in each error and warning. To suppress
-the project name, set the g:dotnet_show_project_file variable to |v:false|.
+The associated project name is included in each error and warning.  To
+suppress the project name, set the g:dotnet_show_project_file variable to
+|v:false|.
 
 Example: limit output to only display errors, and suppress the project name: >
 	let dotnet_errors_only = v:true
@@ -1600,9 +1602,9 @@ manpage) as input and expects that the output file type extension is passed to
 make, say :make html or :make pdf.
 
 Additional arguments can be passed to groff by setting them in
-`b:groff_compiler_args` or `g:groff_compiler_args`. The `language` argument
+`b:groff_compiler_args` or `g:groff_compiler_args`.  The `language` argument
 passed to groff is set using 'spelllang'; it can be overridden by setting
-`b:groff_compiler_lang`. The default encoding is `UTF-8` and can be changed
+`b:groff_compiler_lang`.  The default encoding is `UTF-8` and can be changed
 by setting `b:groff_compiler_encoding` or `g:groff_compiler_encoding`.
 
 PANDOC					*quickfix-pandoc* *compiler-pandoc*
@@ -1690,8 +1692,8 @@ Included in the distribution compiler for TeX ($VIMRUNTIME/compiler/tex.vim)
 uses make command if possible.  If the compiler finds a file named "Makefile"
 or "makefile" in the current directory, it supposes that you want to process
 your *TeX files with make, and the makefile does the right work.  In this case
-compiler sets 'errorformat' for *TeX output and leaves 'makeprg' untouched.  If
-neither "Makefile" nor "makefile" is found, the compiler will not use make.
+compiler sets 'errorformat' for *TeX output and leaves 'makeprg' untouched.
+If neither "Makefile" nor "makefile" is found, the compiler will not use make.
 You can force the compiler to ignore makefiles by defining
 b:tex_ignore_makefile or g:tex_ignore_makefile variable (they are checked for
 existence only).
@@ -1731,13 +1733,13 @@ b/g:tsc_makeprg variable.  For example: >
 
 TYPST COMPILER						*compiler-typst*
 
-Vim includes a compiler plugin for Typst files. This compiler is enabled
+Vim includes a compiler plugin for Typst files.  This compiler is enabled
 automatically in Typst buffers by the Typst filetype plugin |ft-typst-plugin|.
 Run |:make| to compile the current Typst file.
 
 							*g:typst_cmd*
-By default Vim will use "typst" as the command to run the Typst compiler. This
-can be changed by setting the |g:typst_cmd| variable: >
+By default Vim will use "typst" as the command to run the Typst compiler.
+This can be changed by setting the |g:typst_cmd| variable: >
 	let g:typst_cmd = "/path/to/other/command"
 
 =============================================================================
@@ -1824,11 +1826,11 @@ or >
 to indicate the column of the error.  This is to be used in a multi-line error
 message.  See |errorformat-javac| for a  useful example.
 
-The "%s" conversion specifies the text to search for, to locate the error line.
-The text is used as a literal string.  The anchors "^" and "$" are added to
-the text to locate the error line exactly matching the search text and the
-text is prefixed with the "\V" atom to make it "very nomagic".  The "%s"
-conversion can be used to locate lines without a line number in the error
+The "%s" conversion specifies the text to search for, to locate the error
+line.  The text is used as a literal string.  The anchors "^" and "$" are
+added to the text to locate the error line exactly matching the search text
+and the text is prefixed with the "\V" atom to make it "very nomagic".  The
+"%s" conversion can be used to locate lines without a line number in the error
 output.  Like the output of the "grep" shell command.
 When the pattern is present the line number will not be used.
 
@@ -2019,7 +2021,8 @@ be escaped), meta symbols have to be written with leading '%':
 	%~		The single '~' character.
 When using character classes in expressions (see |/\i| for an overview),
 terms containing the "\+" quantifier can be written in the scanf() "%*"
-notation.  Example: "%\\d%\\+" ("\d\+", "any number") is equivalent to "%*\\d".
+notation.  Example: "%\\d%\\+" ("\d\+", "any number") is equivalent to
+"%*\\d".
 Important note: The \(...\) grouping of sub-matches can not be used in format
 specifications because it is reserved for internal conversions.
 
@@ -2227,7 +2230,7 @@ You need to put the following in "vim-javac-filter" somewhere in your path
 In English, that sed script:
 - Changes single tabs to single spaces and
 - Moves the line with the filename, line number, error message to just after
-  the pointer line. That way, the unused error text between doesn't break
+  the pointer line.  That way, the unused error text between doesn't break
   vim's notion of a "multi-line message" and also doesn't force us to include
   it as a "continuation of a multi-line message."
 
@@ -2356,40 +2359,40 @@ The values displayed in each line correspond to the "bufnr", "lnum", "col" and
 For some quickfix/location lists, the displayed text needs to be customized.
 For example, if only the filename is present for a quickfix entry, then the
 two "|" field separator characters after the filename are not needed.  Another
-use case is to customize the path displayed for a filename. By default, the
+use case is to customize the path displayed for a filename.  By default, the
 complete path (which may be too long) is displayed for files which are not
-under the current directory tree. The file path may need to be simplified to a
-common parent directory.
+under the current directory tree.  The file path may need to be simplified to
+a common parent directory.
 
 The displayed text can be customized by setting the 'quickfixtextfunc' option
 to a Vim function.  This function will be called with a dict argument and
 should return a List of strings to be displayed in the quickfix or location
-list window. The dict argument will have the following fields:
+list window.  The dict argument will have the following fields:
 
     quickfix	set to 1 when called for a quickfix list and 0 when called for
 		a location list.
     winid	for a location list, set to the id of the window with the
-		location list. For a quickfix list, set to 0. Can be used in
+		location list.  For a quickfix list, set to 0.  Can be used in
 		getloclist() to get the location list entry.
     id		quickfix or location list identifier
     start_idx	index of the first entry for which text should be returned
     end_idx	index of the last entry for which text should be returned
 
 The function should return a single line of text to display in the quickfix
-window for each entry from start_idx to end_idx. The function can obtain
+window for each entry from start_idx to end_idx.  The function can obtain
 information about the entries using the |getqflist()| function and specifying
-the quickfix list identifier "id". For a location list, getloclist() function
-can be used with the "winid" argument. If an empty list is returned, then the
-default format is used to display all the entries. If an item in the returned
+the quickfix list identifier "id".  For a location list, getloclist() function
+can be used with the "winid" argument.  If an empty list is returned, then the
+default format is used to display all the entries.  If an item in the returned
 list is an empty string, then the default format is used to display the
 corresponding entry.
 
 If a quickfix or location list specific customization is needed, then the
 'quickfixtextfunc' attribute of the list can be set using the |setqflist()| or
-|setloclist()| function. This overrides the global 'quickfixtextfunc' option.
+|setloclist()| function.  This overrides the global 'quickfixtextfunc' option.
 
 The example below displays the list of old files (|v:oldfiles|) in a quickfix
-window. As there is no line, column number and error text information
+window.  As there is no line, column number and error text information
 associated with each entry, the 'quickfixtextfunc' function returns only the
 filename.
 Example: >

--- a/runtime/doc/recover.txt
+++ b/runtime/doc/recover.txt
@@ -88,7 +88,7 @@ The 'swapfile' option can be reset to avoid creating a swapfile.  And the
 |:noswapfile| modifier can be used to not create a swapfile for a new buffer.
 
 :nos[wapfile]   {command}			*:nos* *:noswapfile*
-		Execute {command}. If it contains a command that loads a new
+		Execute {command}.  If it contains a command that loads a new
 		buffer, it will be loaded without creating a swapfile and the
 		'swapfile' option will be reset.  If a buffer already had a
 		swapfile it is not removed and 'swapfile' is not reset.

--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -86,7 +86,7 @@ line is aborted and the global command continues with the next marked or
 unmarked line.
 								*E147*
 When the command is used recursively, it only works on one line.  Giving a
-range is then not allowed. This is useful to find all lines that match a
+range is then not allowed.  This is useful to find all lines that match a
 pattern and do not match another pattern: >
 	:g/found/v/notfound/{cmd}
 This first finds all lines containing "found", but only executes {cmd} when
@@ -157,18 +157,18 @@ q			Stops recording.  (Implementation note: The 'q' that
 @@			Repeat the previous @{0-9a-z":*} [count] times.
 
 								*:@*
-:[addr]@{0-9a-z".=*+}	Execute the contents of register {0-9a-z".=*+} as an Ex
-			command.  First set cursor at line [addr] (default is
-			current line).  When the last line in the register does
-			not have a <CR> it will be added automatically when
-			the 'e' flag is present in 'cpoptions'.
+:[addr]@{0-9a-z".=*+}	Execute the contents of register {0-9a-z".=*+} as an
+			Ex command.  First set cursor at line [addr] (default
+			is current line).  When the last line in the register
+			does not have a <CR> it will be added automatically
+			when the 'e' flag is present in 'cpoptions'.
 			For ":@=" the last used expression is used.  The
 			result of evaluating the expression is executed as an
 			Ex command.
 			Mappings are not recognized in these commands.
 			When the |line-continuation| character (\) is present
 			at the beginning of a line in a linewise register,
-			then it is combined with the previous line. This is
+			then it is combined with the previous line.  This is
 			useful for yanking and executing parts of a Vim
 			script.
 			Future: Will execute the register for each line in the
@@ -206,7 +206,7 @@ For writing a Vim script, see chapter 41 of the user manual |usr_41.txt|.
 
 			When sourcing commands from the current buffer, the
 			same script-ID |<SID>| is used even if the buffer is
-			sourced multiple times. If a buffer is sourced more
+			sourced multiple times.  If a buffer is sourced more
 			than once, then the functions in the buffer are
 			defined again.
 
@@ -226,9 +226,9 @@ For writing a Vim script, see chapter 41 of the user manual |usr_41.txt|.
 			This works like the range started with the
 			":vim9script noclear" command.  The "++clear" argument
 			can be used to clear the script-local variables and
-			functions before sourcing the script. This works like
+			functions before sourcing the script.  This works like
 			the range started with the `:vim9script` command
-			without the "noclear" argument. See |vim9-reload| for
+			without the "noclear" argument.  See |vim9-reload| for
 			more information.
 			Examples: >
 				:4,5source
@@ -390,7 +390,7 @@ For writing a Vim script, see chapter 41 of the user manual |usr_41.txt|.
 			to use ":scriptencoding utf-8" then.
 
 			If you set the 'encoding' option in your |.vimrc|,
-			`:scriptencoding` must be placed after that. E.g.: >
+			`:scriptencoding` must be placed after that.  E.g.: >
 				set encoding=utf-8
 				scriptencoding utf-8
 <
@@ -615,8 +615,8 @@ advantages over normal plugins:
 
 Using a package and loading automatically ~
 
-Let's assume your Vim files are in the "~/.vim" directory and you want to add a
-package from a zip archive "/tmp/foopack.zip": >
+Let's assume your Vim files are in the "~/.vim" directory and you want to add
+a package from a zip archive "/tmp/foopack.zip": >
 	% mkdir -p ~/.vim/pack/foo
 	% cd ~/.vim/pack/foo
 	% unzip /tmp/foopack.zip
@@ -647,9 +647,9 @@ find the syntax/some.vim file, because its directory is in 'runtimepath'.
 
 Vim will also load ftdetect files, if there are any.
 
-Note that the files under "pack/foo/opt" are not loaded automatically, only the
-ones under "pack/foo/start".  See |pack-add| below for how the "opt" directory
-is used.
+Note that the files under "pack/foo/opt" are not loaded automatically, only
+the ones under "pack/foo/start".  See |pack-add| below for how the "opt"
+directory is used.
 
 Loading packages automatically will not happen if loading plugins is disabled,
 see |load-plugins|.
@@ -725,8 +725,8 @@ This assumes you write one or more plugins that you distribute as a package.
 
 If you have two unrelated plugins you would use two packages, so that Vim
 users can choose what they include or not.  Or you can decide to use one
-package with optional plugins, and tell the user to add the preferred ones with
-`:packadd`.
+package with optional plugins, and tell the user to add the preferred ones
+with `:packadd`.
 
 Decide how you want to distribute the package.  You can create an archive or
 you could use a repository.  An archive can be used by more users, but is a
@@ -790,7 +790,7 @@ Where:
 
 The directory structure where the message translation files should be placed
 is (from the top-level directory of the package):
-"lang/<lang_id>/LC_MESSAGES". For the format of <lang_id> see |multi-lang|.
+"lang/<lang_id>/LC_MESSAGES".  For the format of <lang_id> see |multi-lang|.
 This function needs to be called only once during the initialization of the
 plugin.
 Once this is done, the |gettext()| function can be used to retrieve translated
@@ -818,27 +818,28 @@ PLUGPACKAGE		A variable containing the name of the package that we
 			|gettext()| functions, for example, "foobar".
 PO_PLUG_INPUTLIST	A variable containing scripts that have strings
 			to translate, i.e. where we specified the |gettext()|
-			function. Scripts are specified with an absolute
-			or relative path. Example: start/foobar/plugin/bar.vim
+			function.  Scripts are specified with an absolute
+			or relative path.  Example:
+			start/foobar/plugin/bar.vim
 			use blanks to separate scripts.
 POT_PLUGPACKAGE_PATH	A variable containing the directory where the prepared
-			POT file will be saved. This is not a required variable,
-			if no directory is specified, then the POT file will
-			be placed in the "src/po" directory.
+			POT file will be saved.  This is not a required
+			variable, if no directory is specified, then the POT
+			file will be placed in the "src/po" directory.
 VIMPROG			A variable containing a directory with a working Vim.
 			If the Vim editor is already built and installed, and
 			is contained in the $PATH environment variable,
 			then you can specify just the name of the vim
 			executable.
-{package}.pot		This is the Target. It is specified as the name of
+{package}.pot		This is the Target.  It is specified as the name of
 			the package, for example, "foobar" with the addition
 			of the .pot extension.
 Once a POT file is created, its contents are copied into separate PO files for
 each language for which the translation will be prepared.
 
 When the translation is finished, it is necessary to convert the PO files into
-binary MO-files format and place these MO-files into the "lang/" directory, the
-structure of which we created earlier.
+binary MO-files format and place these MO-files into the "lang/" directory,
+the structure of which we created earlier.
 To do this, run the following commands:
 >
 	cd ~/forkvim/src/po
@@ -851,15 +852,16 @@ Where:
 PLUGPACKAGE		A variable containing the name of the package that we
 			specified in the |bindtextdomain()| and |gettext()|
 			functions, for example, "foobar".
-PO_PLUGPACKAGE		A variable containing a PO file. The file is specified
-			with an absolute or relative path. For example,
-			"~/myproject/translate/en.po"
+PO_PLUGPACKAGE		A variable containing a PO file.  The file is
+			specified with an absolute or relative path.  For
+			example, "~/myproject/translate/en.po"
 MO_PLUGPACKAGE_PATH	A variable containing the structure of the "lang/"
 			directory, where the file with translations will be
-			placed, for example, "foobar.mo". This is not
-			a required variable, if the directory is not specified,
-			the MO file will be saved in the "src/po" directory.
-{package}.mo		This is the Target. It is specified as the name of
+			placed, for example, "foobar.mo".  This is not
+			a required variable, if the directory is not
+			specified, the MO file will be saved in the "src/po"
+			directory.
+{package}.mo		This is the Target.  It is specified as the name of
 			the package, for example, "foobar" with the addition
 			of the .mo extension.
 
@@ -978,7 +980,7 @@ And the PO file in German:
     msgstr "Alle Dateien (*)\t*\n"~
 
 Now convert these files into MO files so that |gettext()| can display message
-translations. Note that since this is not a specialized plugin package, we
+translations.  Note that since this is not a specialized plugin package, we
 will put the MO files in the "lang/" directory of the Vim editor.
 Type the following commands:
 >
@@ -998,7 +1000,7 @@ Type the following commands:
 That's it, the translations are ready and you can see the plugin's messages
 in your native language.
 
-Let's also try to translate a plugin package. For example, when a package
+Let's also try to translate a plugin package.  For example, when a package
 contains several scripts containing strings that need to be translated.
 For example, let's translate the "netrw" package into Japanese.
 For this example, we will translate only a few lines from this package.
@@ -1096,7 +1098,7 @@ plug-in packages.
 
 Dependencies between plugins ~
 							*packload-two-steps*
-Suppose you have two plugins that depend on the same functionality. You can
+Suppose you have two plugins that depend on the same functionality.  You can
 put the common functionality in an autoload directory, so that it will be
 found automatically.  Your package would have these files:
 
@@ -1284,7 +1286,7 @@ DEFINING BREAKPOINTS
 
 :breaka[dd] expr {expression}
 		Sets a breakpoint, that will break whenever the {expression}
-		evaluates to a different value. Example: >
+		evaluates to a different value.  Example: >
 			:breakadd expr g:lnum
 <		Will break, whenever the global variable lnum changes.
 
@@ -1399,7 +1401,7 @@ For example, to profile the one_script.vim script file: >
 
 :prof[ile] stop
 		Write the collected profiling information to the logfile and
-		stop profiling. You can use the `:profile start` command to
+		stop profiling.  You can use the `:profile start` command to
 		clear the profiling statistics and start profiling again.
 
 :prof[ile] pause
@@ -1431,8 +1433,8 @@ For example, to profile the one_script.vim script file: >
 		collect the profiling statistics.
 
 :profd[el] ...						*:profd* *:profdel*
-		Stop profiling for the arguments specified. See |:breakdel|
-		for the arguments. Examples: >
+		Stop profiling for the arguments specified.  See |:breakdel|
+		for the arguments.  Examples: >
 			profdel func MyFunc
 			profdel file MyScript.vim
 			profdel here
@@ -1480,9 +1482,9 @@ Profiling should give a good indication of where time is spent, but keep in
 mind there are various things that may clobber the results:
 
 - The accuracy of the time measured depends on the gettimeofday(), or
-  clock_gettime() if available, system function. The accuracy ranges from
-  1/100 second to nanoseconds. With clock_gettime() the times are displayed in
-  nanoseconds, otherwise microseconds.  You can use `has("prof_nsec")`.
+  clock_gettime() if available, system function.  The accuracy ranges from
+  1/100 second to nanoseconds.  With clock_gettime() the times are displayed
+  in nanoseconds, otherwise microseconds.  You can use `has("prof_nsec")`.
 
 - Real elapsed time is measured, if other processes are busy they may cause
   delays at unpredictable moments.  You may want to run the profiling several

--- a/runtime/doc/sign.txt
+++ b/runtime/doc/sign.txt
@@ -56,20 +56,20 @@ The color of the column is set with the SignColumn highlight group
 If 'cursorline' is enabled, then the CursorLineSign highlight group is used
 |hl-CursorLineSign|.
 							*sign-identifier*
-Each placed sign is identified by a number called the sign identifier. This
-identifier is used to jump to the sign or to remove the sign. The identifier
+Each placed sign is identified by a number called the sign identifier.  This
+identifier is used to jump to the sign or to remove the sign.  The identifier
 is assigned when placing the sign using the |:sign-place| command or the
-|sign_place()| function. Each sign identifier should be a unique number. If
+|sign_place()| function.  Each sign identifier should be a unique number.  If
 multiple placed signs use the same identifier, then jumping to or removing a
-sign becomes unpredictable. To avoid overlapping identifiers, sign groups can
-be used. The |sign_place()| function can be called with a zero sign identifier
+sign becomes unpredictable.  To avoid overlapping identifiers, sign groups can
+be used.  The |sign_place()| function can be called with a zero sign identifier
 to allocate the next available identifier.
 
 							*sign-group*
 Each placed sign can be assigned to either the global group or a named group.
 When placing a sign, if a group name is not supplied, or an empty string is
-used, then the sign is placed in the global group. Otherwise the sign is
-placed in the named group. The sign identifier is unique within a group. The
+used, then the sign is placed in the global group.  Otherwise the sign is
+placed in the named group.  The sign identifier is unique within a group.  The
 sign group allows Vim plugins to use unique signs without interfering with
 other plugins using signs.
 
@@ -78,9 +78,9 @@ Other signs will not show in a popup window.  The group name "PopUpMenu" is
 used by popup windows where 'cursorline' is set.
 
 							*sign-priority*
-Each placed sign is assigned a priority value. When multiple signs are placed
+Each placed sign is assigned a priority value.  When multiple signs are placed
 on the same line, the attributes of the sign with the highest priority is used
-independently of the sign group. The default priority for a sign is 10, this
+independently of the sign group.  The default priority for a sign is 10, this
 value can be changed for different signs by specifying a different value at
 definition time.  The priority is assigned at the time of placing a sign.
 
@@ -213,8 +213,8 @@ See |sign_place()| for the equivalent Vim script function.
 		By default, the sign is placed in the global sign group.
 
 		By default, the sign is assigned a default priority of 10,
-		unless specified otherwise by the sign definition.  To assign a
-		different priority value, use "priority={prio}" to specify a
+		unless specified otherwise by the sign definition.  To assign
+		a different priority value, use "priority={prio}" to specify a
 		value.  The priority is used to determine the sign that is
 		displayed when multiple signs are placed on the same line.
 
@@ -312,7 +312,8 @@ See |sign_unplace()| for the equivalent Vim script function.
 		all the files it appears in.
 
 :sig[n] unplace *
-		Remove all placed signs in the global group from all the files.
+		Remove all placed signs in the global group from all the
+		files.
 
 :sig[n] unplace * group={group}
 		Remove all placed signs in group {group} from all the files.
@@ -321,8 +322,8 @@ See |sign_unplace()| for the equivalent Vim script function.
 		Remove all placed signs in all the groups from all the files.
 
 :sig[n] unplace
-		Remove a placed sign at the cursor position. If multiple signs
-		are placed in the line, then only one is removed.
+		Remove a placed sign at the cursor position.  If multiple
+		signs are placed in the line, then only one is removed.
 
 :sig[n] unplace group={group}
 		Remove a placed sign in group {group} at the cursor
@@ -380,7 +381,7 @@ See |sign_jump()| for the equivalent Vim script function.
 
 :sig[n] jump {id} [buffer={nr}]				*E934*
 		Same, but use buffer {nr}.  This fails if buffer {nr} does not
-		have a name. If the buffer argument is not given, use the
+		have a name.  If the buffer argument is not given, use the
 		current buffer.
 
 :sig[n] jump {id} group={group} [buffer={nr}]
@@ -448,7 +449,7 @@ sign_getdefined([{name}])				*sign_getdefined()*
 		This is similar to the |:sign-list| command.
 
 		If the {name} is not supplied, then a list of all the defined
-		signs is returned. Otherwise the attribute of the specified
+		signs is returned.  Otherwise the attribute of the specified
 		sign is returned.
 
 		Each list item in the returned value is a dictionary with the
@@ -491,15 +492,15 @@ sign_getplaced([{buf} [, {dict}]])			*sign_getplaced()*
 
 		If the optional buffer name {buf} is specified, then only the
 		list of signs placed in that buffer is returned.  For the use
-		of {buf}, see |bufname()|. The optional {dict} can contain
+		of {buf}, see |bufname()|.  The optional {dict} can contain
 		the following entries:
 		   group	select only signs in this group
 		   id		select sign with this identifier
-		   lnum		select signs placed in this line. For the use
+		   lnum		select signs placed in this line.  For the use
 				of {lnum}, see |line()|.
 		If {group} is '*', then signs in all the groups including the
-		global group are returned. If {group} is not supplied or is an
-		empty string, then only signs in the global group are
+		global group are returned.  If {group} is not supplied or is
+		an empty string, then only signs in the global group are
 		returned.  If no arguments are supplied, then signs in the
 		global group placed in all the buffers are returned.
 		See |sign-group|.
@@ -507,12 +508,12 @@ sign_getplaced([{buf} [, {dict}]])			*sign_getplaced()*
 		Each list item in the returned value is a dictionary with the
 		following entries:
 			bufnr	number of the buffer with the sign
-			signs	list of signs placed in {bufnr}. Each list
+			signs	list of signs placed in {bufnr}.  Each list
 				item is a dictionary with the below listed
 				entries
 
 		The dictionary for each sign contains the following entries:
-			group	 sign group. Set to '' for the global group.
+			group	 sign group.  Set to '' for the global group.
 			id	 identifier of the sign
 			lnum	 line number where the sign is placed
 			name	 name of the defined sign
@@ -559,7 +560,7 @@ sign_jump({id}, {group}, {buf})				*sign_jump()*
 		If {group} is an empty string, then the global group is used.
 		For the use of {buf}, see |bufname()|.
 
-		Returns the line number of the sign. Returns -1 if the
+		Returns the line number of the sign.  Returns -1 if the
 		arguments are invalid.
 
 		Example: >
@@ -579,21 +580,21 @@ sign_place({id}, {group}, {name}, {buf} [, {dict}])
 		similar to the |:sign-place| command.
 
 		If the sign identifier {id} is zero, then a new identifier is
-		allocated.  Otherwise the specified number is used. {group} is
-		the sign group name. To use the global sign group, use an
+		allocated.  Otherwise the specified number is used.  {group}
+		is the sign group name.  To use the global sign group, use an
 		empty string.  {group} functions as a namespace for {id}, thus
-		two groups can use the same IDs. Refer to |sign-identifier|
+		two groups can use the same IDs.  Refer to |sign-identifier|
 		and |sign-group| for more information.
 
 		{name} refers to a defined sign.
-		{buf} refers to a buffer name or number. For the accepted
+		{buf} refers to a buffer name or number.  For the accepted
 		values, see |bufname()|.
 
 		The optional {dict} argument supports the following entries:
 			lnum		line number in the file or buffer
 					{buf} where the sign is to be placed.
 					For the accepted values, see |line()|.
-			priority	priority of the sign. See
+			priority	priority of the sign.  See
 					|sign-priority| for more information.
 
 		If the optional {dict} is not specified, then it modifies the
@@ -630,35 +631,35 @@ sign_place({id}, {group}, {name}, {buf} [, {dict}])
 sign_placelist({list})				*sign_placelist()*
 		Place one or more signs.  This is similar to the
 		|sign_place()| function.  The {list} argument specifies the
-		List of signs to place. Each list item is a dict with the
+		List of signs to place.  Each list item is a dict with the
 		following sign attributes:
-		    buffer	Buffer name or number. For the accepted
+		    buffer	Buffer name or number.  For the accepted
 				values, see |bufname()|.
-		    group	Sign group. {group} functions as a namespace
+		    group	Sign group.  {group} functions as a namespace
 				for {id}, thus two groups can use the same
-				IDs. If not specified or set to an empty
+				IDs.  If not specified or set to an empty
 				string, then the global group is used.   See
 				|sign-group| for more information.
-		    id		Sign identifier. If not specified or zero,
+		    id		Sign identifier.  If not specified or zero,
 				then a new unique identifier is allocated.
-				Otherwise the specified number is used. See
+				Otherwise the specified number is used.  See
 				|sign-identifier| for more information.
 		    lnum	Line number in the buffer where the sign is to
-				be placed. For the accepted values, see
+				be placed.  For the accepted values, see
 				|line()|.
-		    name	Name of the sign to place. See |sign_define()|
+		    name	Name of the sign to place.  See |sign_define()|
 				for more information.
-		    priority	Priority of the sign. When multiple signs are
+		    priority	Priority of the sign.  When multiple signs are
 				placed on a line, the sign with the highest
-				priority is used. If not specified, the
+				priority is used.  If not specified, the
 				default value of 10 is used, unless specified
-				otherwise by the sign definition. See
+				otherwise by the sign definition.  See
 				|sign-priority| for more information.
 
 		If {id} refers to an existing sign, then the existing sign is
 		modified to use the specified {name} and/or {priority}.
 
-		Returns a List of sign identifiers. If failed to place a
+		Returns a List of sign identifiers.  If failed to place a
 		sign, the corresponding list item is set to -1.
 
 		Examples: >
@@ -694,12 +695,12 @@ sign_placelist({list})				*sign_placelist()*
 
 sign_undefine([{name}])					*sign_undefine()*
 sign_undefine({list})
-		Deletes a previously defined sign {name}. This is similar to
-		the |:sign-undefine| command. If {name} is not supplied, then
+		Deletes a previously defined sign {name}.  This is similar to
+		the |:sign-undefine| command.  If {name} is not supplied, then
 		deletes all the defined signs.
 
 		The one argument {list} can be used to undefine a list of
-		signs. Each list item is the name of a sign.
+		signs.  Each list item is the name of a sign.
 
 		Returns 0 on success and -1 on failure.  For the one argument
 		{list} call, returns a list of values one for each undefined
@@ -725,13 +726,13 @@ sign_unplace({group} [, {dict}])			*sign_unplace()*
 		Remove a previously placed sign in one or more buffers.  This
 		is similar to the |:sign-unplace| command.
 
-		{group} is the sign group name. To use the global sign group,
+		{group} is the sign group name.  To use the global sign group,
 		use an empty string.  If {group} is set to '*', then all the
 		groups including the global group are used.
 		The signs in {group} are selected based on the entries in
 		{dict}.  The following optional entries in {dict} are
 		supported:
-			buffer	buffer name or number. See |bufname()|.
+			buffer	buffer name or number.  See |bufname()|.
 			id	sign identifier
 		If {dict} is not supplied, then all the signs in {group} are
 		removed.
@@ -775,15 +776,15 @@ sign_unplacelist({list})				*sign_unplacelist()*
 
 		The {list} argument specifies the List of signs to remove.
 		Each list item is a dict with the following sign attributes:
-		    buffer	buffer name or number. For the accepted
-				values, see |bufname()|. If not specified,
+		    buffer	buffer name or number.  For the accepted
+				values, see |bufname()|.  If not specified,
 				then the specified sign is removed from all
 				the buffers.
-		    group	sign group name. If not specified or set to an
-				empty string, then the global sign group is
-				used. If set to '*', then all the groups
+		    group	sign group name.  If not specified or set to
+				an empty string, then the global sign group is
+				used.  If set to '*', then all the groups
 				including the global group are used.
-		    id		sign identifier. If not specified, then all
+		    id		sign identifier.  If not specified, then all
 				the signs in the specified group are removed.
 
 		Returns a List where an entry is set to 0 if the corresponding

--- a/runtime/doc/spell.txt
+++ b/runtime/doc/spell.txt
@@ -140,7 +140,7 @@ zuG			Undo |zW| and |zG|, remove the word from the internal
 
 			There are no normal mode commands to mark words as
 			rare as this is a fairly uncommon command and all
-			intuitive commands for this are already taken. If you
+			intuitive commands for this are already taken.  If you
 			want you can add mappings with e.g.: >
 		nnoremap z?  :exe ':spellrare  ' .. expand('<cWORD>')<CR>
 		nnoremap z/  :exe ':spellrare! ' .. expand('<cWORD>')<CR>
@@ -300,7 +300,7 @@ In a table:
 
 							*spell-cjk*
 Chinese, Japanese and other East Asian characters are normally marked as
-errors, because spell checking of these characters is not supported. If
+errors, because spell checking of these characters is not supported.  If
 'spelllang' includes "cjk", these characters are not marked as errors.  This
 is useful when editing text with spell checking while some Asian words are
 present.
@@ -507,8 +507,8 @@ Vim uses a binary file format for spelling.  This greatly speeds up loading
 the word list and keeps it small.
 						    *.aff* *.dic* *Myspell*
 You can create a Vim spell file from the .aff and .dic files that Myspell
-uses.  Myspell is used by OpenOffice.org and Mozilla. The OpenOffice .oxt
-files are zip files which contain the .aff and .dic files. You should be able
+uses.  Myspell is used by OpenOffice.org and Mozilla.  The OpenOffice .oxt
+files are zip files which contain the .aff and .dic files.  You should be able
 to find them here:
 	http://extensions.services.openoffice.org/dictionary
 The older, OpenOffice 2 files may be used if this doesn't work:
@@ -842,8 +842,8 @@ starting with an upper-case letter.
 
 When the word includes an upper-case letter, this means the upper-case letter
 is required at this position.  The same word with a lower-case letter at this
-position will not match. When some of the other letters are upper-case it will
-not match either.
+position will not match.  When some of the other letters are upper-case it
+will not match either.
 
 The word with all upper-case characters will always be OK,
 
@@ -1182,9 +1182,10 @@ WORDS WITH A SLASH					*spell-SLASH*
 
 The slash is used in the .dic file to separate the basic word from the affix
 letters and other flags.  Unfortunately, this means you cannot use a slash in
-a word.  Thus "TCP/IP" is not a word but "TCP" with the flags "IP".  To include
-a slash in the word put a backslash before it: "TCP\/IP".  In the rare case
-you want to use a backslash inside a word you need to use two backslashes.
+a word.  Thus "TCP/IP" is not a word but "TCP" with the flags "IP".  To
+include a slash in the word put a backslash before it: "TCP\/IP".  In the rare
+case you want to use a backslash inside a word you need to use two
+backslashes.
 Any other use of the backslash is reserved for future expansion.
 
 
@@ -1614,7 +1615,7 @@ CHECKCOMPOUNDTRIPLE  (Hunspell)			*spell-CHECKCOMPOUNDTRIPLE*
 
 CHECKSHARPS  (Hunspell)				*spell-CHECKSHARPS*
 		SS letter pair in uppercased (German) words may be upper case
-		sharp s (ß). Not supported.
+		sharp s (ß).  Not supported.
 
 COMPLEXPREFIXES  (Hunspell)				*spell-COMPLEXPREFIXES*
 		Enables using two prefixes.  Not supported.

--- a/runtime/doc/sponsor.txt
+++ b/runtime/doc/sponsor.txt
@@ -35,7 +35,7 @@ More explanations can be found in the |register-faq|.
 VOTE FOR FEATURES					*vote-for-features*
 
 Note: Voting for features has been discontinued since the passing of |Bram| in
-2023. The following two links still work, but they are no longer updated. So
+2023.  The following two links still work, but they are no longer updated.  So
 they now only provide a historic view as of summer 2023.
 
 The voting results appear on the results page, which is visible for everybody:

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -43,8 +43,8 @@ filename	One or more file names.  The first one will be the current
 		To avoid a file name starting with a '-' being interpreted as
 		an option, precede the arglist with "--", e.g.: >
 			vim -- -filename
-<		All arguments after the "--" will be interpreted as file names,
-		no other options or "+command" argument can follow.
+<		All arguments after the "--" will be interpreted as file
+		names, no other options or "+command" argument can follow.
 		For behavior of quotes on MS-Windows, see |win32-quotes|.
 
 							*--*
@@ -174,7 +174,7 @@ a slash.  Thus "-R" means recovery and "-/R" readonly.
 		"pat" in the first file being edited (see |pattern| for the
 		available search patterns).  The search starts at the cursor
 		position, which can be the first line or the cursor position
-		last used from |viminfo|. To force a search from the first
+		last used from |viminfo|.  To force a search from the first
 		line use "+1 +/pat".
 
 +{command}						*-+c* *-c*
@@ -262,7 +262,7 @@ a slash.  Thus "-R" means recovery and "-/R" readonly.
 		shell command, it has only been made difficult.
 
 							*-g*
--g		Start Vim in GUI mode.  See |gui|. For the opposite see |-v|.
+-g		Start Vim in GUI mode.  See |gui|.  For the opposite see |-v|.
 
 							*-v*
 -v		Start Ex in Vi mode.  Only makes a difference when the
@@ -585,7 +585,7 @@ a slash.  Thus "-R" means recovery and "-/R" readonly.
 		characters are appended.  See also |complex-repeat|.
 		{scriptout} cannot start with a digit.
 		If you want to record what is typed in a human readable form,
-		you can use |ch_logfile()|. It adds "raw key input" lines.
+		you can use |ch_logfile()|.  It adds "raw key input" lines.
 		Also see |--log|.
 
 							*-W*
@@ -830,7 +830,7 @@ accordingly.  Vim proceeds in this order:
 	one that is found is read.
 
 	RECOMMENDATION: Put all your Vim configuration stuff in the
-	$HOME/.vim/ directory ($HOME/vimfiles/ for MS-Windows). That makes it
+	$HOME/.vim/ directory ($HOME/vimfiles/ for MS-Windows).  That makes it
 	easy to copy it to another system.
 
 	If Vim was started with "-u filename", the file "filename" is used.
@@ -1089,7 +1089,7 @@ recommended to add these lines somewhere near the top: >
 	source $VIMRUNTIME/defaults.vim
 Then Vim works like before you had a .vimrc.
 Copying $VIMRUNTIME/vimrc_example.vim to your .vimrc is another way to do
-this. Alternatively, you can copy defaults.vim to your .vimrc and modify it
+this.  Alternatively, you can copy defaults.vim to your .vimrc and modify it
 (but then you won't get updates when it changes).
 
 If you don't like some of the defaults, you can still source defaults.vim and
@@ -1112,8 +1112,8 @@ The specification can be found online at
 https://specifications.freedesktop.org/basedir-spec/latest/
 
 The location of this standard configuration directory is configurable by the
-user, using an environment variable but should also give fallback in case those
-variables weren't set.
+user, using an environment variable but should also give fallback in case
+those variables weren't set.
 
 This is not an exhaustive list of those directories:
   Environment var	Default location	Description ~
@@ -1129,7 +1129,7 @@ Vim will only use the `$XDG_CONFIG_HOME` directory, the others are not
 Vim, on Unix systems, will look at `$XDG_CONFIG_HOME/vim/vimrc` for its
 configuration (see |vimrc|) but it will source it only if no other
 initialization file is found in `$HOME` or `$HOME/.vim` (thus making this
-feature backward compatible). However, if you want to migrate to use
+feature backward compatible).  However, if you want to migrate to use
 `$XDG_CONFIG_HOME/vim/` directory, you will have to move away your `~/.vimrc`
 and `~/.vim/vimrc` file.
 
@@ -1637,8 +1637,8 @@ has marks for.
 							*viminfo-file-marks*
 Uppercase marks ('A to 'Z) are stored when writing the viminfo file.  The
 numbered marks ('0 to '9) are a bit special.  When the viminfo file is written
-(when exiting or with the ":wviminfo" command), '0 is set to the current cursor
-position and file.  The old '0 is moved to '1, '1 to '2, etc.  This
+(when exiting or with the ":wviminfo" command), '0 is set to the current
+cursor position and file.  The old '0 is moved to '1, '1 to '2, etc.  This
 resembles what happens with the "1 to "9 delete registers.  If the current
 cursor position is already present in '0 to '9, it is moved to '0, to avoid
 having the same position twice.  The result is that with "'0", you can jump
@@ -1738,8 +1738,8 @@ most of the information will be restored).
 			The information in the file is first read in to make
 			a merge between old and new info.  When [!] is used,
 			the old information is not read first, only the
-			internal info is written.  If 'viminfo' is empty, marks
-			for up to 100 files will be written.
+			internal info is written.  If 'viminfo' is empty,
+			marks for up to 100 files will be written.
 			When you get error "E929: Too many viminfo temp
 			files", check that no old temp files were left behind
 			(e.g. ~/.viminf*) and that you can write in the

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -380,12 +380,12 @@ Upon loading a file, Vim finds the relevant syntax file as follows:
 4. Conversion to HTML				*2html.vim* *convert-to-HTML*
 
 2html is not a syntax file itself, but a script that converts the current
-window into HTML. Vim opens a new window in which it builds the HTML file.
+window into HTML.  Vim opens a new window in which it builds the HTML file.
 
-After you save the resulting file, you can view it with any browser. The
+After you save the resulting file, you can view it with any browser.  The
 colors should be exactly the same as you see them in Vim.  With
 |g:html_line_ids| you can jump to specific lines by adding (for example) #L123
-or #123 to the end of the URL in your browser's address bar. And with
+or #123 to the end of the URL in your browser's address bar.  And with
 |g:html_dynamic_folds| enabled, you can show or hide the text that is folded
 in Vim.
 
@@ -394,7 +394,7 @@ Source the script to convert the current file: >
 
 	:runtime! syntax/2html.vim
 <
-Many variables affect the output of 2html.vim; see below. Any of the on/off
+Many variables affect the output of 2html.vim; see below.  Any of the on/off
 options listed below can be enabled or disabled by setting them explicitly to
 the desired value, or restored to their default by removing the variable using
 |:unlet|.
@@ -421,17 +421,17 @@ and last line to be converted.  Example, using the last set Visual area: >
 <
 							*:TOhtml*
 :[range]TOhtml		The ":TOhtml" command is defined in a standard plugin.
-			This command will source |2html.vim| for you. When a
+			This command will source |2html.vim| for you.  When a
 			range is given, this command sets |g:html_start_line|
 			and |g:html_end_line| to the start and end of the
-			range, respectively. Default range is the entire
+			range, respectively.  Default range is the entire
 			buffer.
 
 			If the current window is part of a |diff|, unless
 			|g:html_diff_one_file| is set, :TOhtml will convert
 			all windows which are part of the diff in the current
 			tab and place them side-by-side in a <table> element
-			in the generated HTML. With |g:html_line_ids| you can
+			in the generated HTML.  With |g:html_line_ids| you can
 			jump to lines in specific windows with (for example)
 			#W1L42 for line 42 in the first diffed window, or
 			#W3L87 for line 87 in the third.
@@ -445,7 +445,7 @@ and last line to be converted.  Example, using the last set Visual area: >
 							*g:html_diff_one_file*
 Default: 0.
 When 0, and using |:TOhtml| all windows involved in a |diff| in the current tab
-page are converted to HTML and placed side-by-side in a <table> element. When
+page are converted to HTML and placed side-by-side in a <table> element.  When
 1, only the current buffer is converted.
 Example: >
 
@@ -465,9 +465,9 @@ not set.
 Default: 0.
 When 0, display a progress bar in the statusline for each major step in the
 2html.vim conversion process.
-When 1, do not display the progress bar. This offers a minor speed improvement
-but you won't have any idea how much longer the conversion might take; for big
-files it can take a long time!
+When 1, do not display the progress bar.  This offers a minor speed
+improvement but you won't have any idea how much longer the conversion might
+take; for big files it can take a long time!
 Example: >
 
 	let g:html_no_progress = 1
@@ -480,17 +480,17 @@ moves through the buffer, switches windows, and the like: >
 <
 Note that the -s flag prevents loading your .vimrc and any plugins, so you
 need to explicitly source/enable anything that will affect the HTML
-conversion. See |-E| and |-s-ex| for details. It is probably best to create a
+conversion.  See |-E| and |-s-ex| for details.  It is probably best to create a
 script to replace all the -c commands and use it with the -u flag instead of
 specifying each command separately.
 
 				    *hl-TOhtmlProgress* *TOhtml-progress-color*
 When displayed, the progress bar will show colored boxes along the statusline
-as the HTML conversion proceeds. By default, the background color as the
-current "DiffDelete" highlight group is used. If "DiffDelete" and "StatusLine"
+as the HTML conversion proceeds.  By default, the background color as the
+current "DiffDelete" highlight group is used.  If "DiffDelete" and "StatusLine"
 have the same background color, TOhtml will automatically adjust the color to
-differ. If you do not like the automatically selected colors, you can define
-your own highlight colors for the progress bar. Example: >
+differ.  If you do not like the automatically selected colors, you can define
+your own highlight colors for the progress bar.  Example: >
 
 	hi TOhtmlProgress guifg=#c0ffee ctermbg=7
 <
@@ -509,11 +509,11 @@ Go back to the default to use 'number' by deleting the variable: >
 							*g:html_line_ids*
 Default: 1 if |g:html_number_lines| is set, 0 otherwise.
 When 1, adds an HTML id attribute to each line number, or to an empty <span>
-inserted for that purpose if no line numbers are shown. This ID attribute
+inserted for that purpose if no line numbers are shown.  This ID attribute
 takes the form of L123 for single-buffer HTML pages, or W2L123 for diff-view
 pages, and is used to jump to a specific line (in a specific window of a diff
-view). Javascript is inserted to open any closed dynamic folds
-(|g:html_dynamic_folds|) containing the specified line before jumping. The
+view).  Javascript is inserted to open any closed dynamic folds
+(|g:html_dynamic_folds|) containing the specified line before jumping.  The
 javascript also allows omitting the window ID in the url, and the leading L.
 For example: >
 
@@ -527,7 +527,7 @@ For example: >
 Default: 1.
 When 1, generate valid HTML 5 markup with CSS styling, supported in all modern
 browsers and many old browsers.
-When 0, generate <font> tags and similar outdated markup. This is not
+When 0, generate <font> tags and similar outdated markup.  This is not
 recommended but it may work better in really old browsers, email clients,
 forum posts, and similar situations where basic CSS support is unavailable.
 Example: >
@@ -549,10 +549,10 @@ included in the generated HTML (unless it is folded): >
 						       *g:html_ignore_folding*
 Default: 0.
 When 0, text in a closed fold is replaced by the text shown for the fold in
-Vim (|fold-foldtext|). See |g:html_dynamic_folds| if you also want to allow
+Vim (|fold-foldtext|).  See |g:html_dynamic_folds| if you also want to allow
 the user to expand the fold as in Vim to see the text inside.
 When 1, include all text from the buffer in the generated HTML; whether the
-text is in a fold has no impact at all. |g:html_dynamic_folds| has no effect.
+text is in a fold has no impact at all.  |g:html_dynamic_folds| has no effect.
 
 Either of these commands will ensure that all text in the buffer is included
 in the generated HTML (unless it is concealed): >
@@ -576,7 +576,7 @@ This variable is ignored when |g:html_ignore_folding| is set.
 Default: 0.
 When 0, if |g:html_dynamic_folds| is 1, generate a column of text similar to
 Vim's foldcolumn (|fold-foldcolumn|) the user can click on to toggle folds
-open or closed. The minimum width of the generated text column is the current
+open or closed.  The minimum width of the generated text column is the current
 'foldcolumn' setting.
 When 1, do not generate this column; instead, hovering the mouse cursor over
 folded text will open the fold as if |g:html_hover_unfold| were set.
@@ -586,10 +586,10 @@ folded text will open the fold as if |g:html_hover_unfold| were set.
 				*TOhtml-uncopyable-text* *g:html_prevent_copy*
 Default: Empty string.
 This option prevents certain regions of the generated HTML from being copied,
-when you select all text in document rendered in a browser and copy it. Useful
-for allowing users to copy-paste only the source text even if a fold column or
-line numbers are shown in the generated content. Specify regions to be
-affected in this way as follows:
+when you select all text in document rendered in a browser and copy it.
+Useful for allowing users to copy-paste only the source text even if a fold
+column or line numbers are shown in the generated content.  Specify regions to
+be affected in this way as follows:
 	f:	fold column
 	n:	line numbers (also within fold text)
 	t:	fold text
@@ -606,9 +606,9 @@ Default: "none"
 If |g:html_prevent_copy| is non-empty, then:
 
 When "all", read-only <input> elements are used in place of normal text for
-uncopyable regions. In some browsers, especially older browsers, after
+uncopyable regions.  In some browsers, especially older browsers, after
 selecting an entire page and copying the selection, the <input> tags are not
-pasted with the page text. If |g:html_no_invalid| is 0, the <input> tags have
+pasted with the page text.  If |g:html_no_invalid| is 0, the <input> tags have
 invalid type; this works in more browsers, but the page will not validate.
 Note: This method does NOT work in recent versions of Chrome and equivalent
 browsers; the <input> tags get pasted with the text.
@@ -616,23 +616,23 @@ browsers; the <input> tags get pasted with the text.
 When "fallback" (default value), the same <input> elements are generated for
 older browsers, but newer browsers (detected by CSS feature query) hide the
 <input> elements and instead use generated content in an ::before pseudoelement
-to display the uncopyable text. This method should work with the largest
+to display the uncopyable text.  This method should work with the largest
 number of browsers, both old and new.
 
-When "none", the <input> elements are not generated at all. Only the
-generated-content method is used. This means that old browsers, notably
+When "none", the <input> elements are not generated at all.  Only the
+generated-content method is used.  This means that old browsers, notably
 Internet Explorer, will either copy the text intended not to be copyable, or
-the non-copyable text may not appear at all. However, this is the most
+the non-copyable text may not appear at all.  However, this is the most
 standards-based method, and there will be much less markup.
 
 							   *g:html_no_invalid*
 Default: 0.
 When 0, if |g:html_prevent_copy| is non-empty and |g:html_use_input_for_pc| is
 not "none", an invalid attribute is intentionally inserted into the <input>
-element for the uncopyable areas. This prevents pasting the <input> elements
-in some applications. Specifically, some versions of Microsoft Word will not
-paste the <input> elements if they contain this invalid attribute. When 1, no
-invalid markup is inserted, and the generated page should validate. However,
+element for the uncopyable areas.  This prevents pasting the <input> elements
+in some applications.  Specifically, some versions of Microsoft Word will not
+paste the <input> elements if they contain this invalid attribute.  When 1, no
+invalid markup is inserted, and the generated page should validate.  However,
 <input> elements may be pasted into some applications and can be difficult to
 remove afterward.
 
@@ -641,7 +641,7 @@ Default: 0.
 When 0, the only way to open a fold generated by 2html.vim with
 |g:html_dynamic_folds| set, is to click on the generated fold column.
 When 1, use CSS 2.0 to allow the user to open a fold by moving the mouse
-cursor over the displayed fold text. This is useful to allow users with
+cursor over the displayed fold text.  This is useful to allow users with
 disabled javascript to view the folded text.
 
 Note that old browsers (notably Internet Explorer 6) will not support this
@@ -654,11 +654,11 @@ they will not be openable without a foldcolumn.
 							      *g:html_id_expr*
 Default: ""
 Dynamic folding and jumping to line IDs rely on unique IDs within the document
-to work. If generated HTML is copied into a larger document, these IDs are no
-longer guaranteed to be unique. Set g:html_id_expr to an expression Vim can
+to work.  If generated HTML is copied into a larger document, these IDs are no
+longer guaranteed to be unique.  Set g:html_id_expr to an expression Vim can
 evaluate to get a unique string to append to each ID used in a given document,
 so that the full IDs will be unique even when combined with other content in a
-larger HTML document. Example, to append _ and the buffer number to each ID: >
+larger HTML document.  Example, to append _ and the buffer number to each ID: >
 
 	:let g:html_id_expr = '"_" .. bufnr("%")'
 <
@@ -687,11 +687,11 @@ Go back to default, determine wrapping from 'wrap' setting: >
 							       *g:html_no_pre*
 Default: 0.
 When 0, buffer text in the generated HTML is surrounded by <pre>...</pre>
-tags. Series of whitespace is shown as in Vim without special markup, and tab
+tags.  Series of whitespace is shown as in Vim without special markup, and tab
 characters can be included literally (see |g:html_expand_tabs|).
 When 1 (not recommended), the <pre> tags are omitted, and a plain <div> is
-used instead. Whitespace is replaced by a series of &nbsp; character
-references, and <br> is used to end each line. This is another way to allow
+used instead.  Whitespace is replaced by a series of &nbsp; character
+references, and <br> is used to end each line.  This is another way to allow
 text in the generated HTML is wrap (see |g:html_pre_wrap|) which also works in
 old browsers, but may cause noticeable differences between Vim's display and
 the rendered page generated by 2html.vim.
@@ -701,8 +701,8 @@ the rendered page generated by 2html.vim.
 							       *g:html_no_doc*
 Default: 0.
 When 1 it doesn't generate a full HTML document with a DOCTYPE, <head>,
-<body>, etc. If |g:html_use_css| is enabled (the default) you'll have to
-define the CSS manually. The |g:html_dynamic_folds| and |g:html_line_ids|
+<body>, etc.  If |g:html_use_css| is enabled (the default) you'll have to
+define the CSS manually.  The |g:html_dynamic_folds| and |g:html_line_ids|
 settings (off by default) also insert some JavaScript.
 
 
@@ -721,9 +721,9 @@ Default: 0 if 'tabstop' is 8, 'expandtab' is 0, 'vartabstop' is not in use,
 When 1, <Tab> characters in the buffer text are replaced with an appropriate
 number of space characters, or &nbsp; references if |g:html_no_pre| is 1.
 When 0, if |g:html_no_pre| is 0 or unset, <Tab> characters in the buffer text
-are included as-is in the generated HTML. This is useful for when you want to
+are included as-is in the generated HTML.  This is useful for when you want to
 allow copy and paste from a browser without losing the actual whitespace in
-the source document. Note that this can easily break text alignment and
+the source document.  Note that this can easily break text alignment and
 indentation in the HTML, unless set by default.
 
 Force |2html.vim| to keep <Tab> characters: >
@@ -738,14 +738,15 @@ It is highly recommended to set your desired encoding with
 
 If you do not specify an encoding, |2html.vim| uses the preferred IANA name
 for the current value of 'fileencoding' if set, or 'encoding' if not.
-'encoding' is always used for certain 'buftype' values. 'fileencoding' will be
-set to match the chosen document encoding.
+'encoding' is always used for certain 'buftype' values.  'fileencoding' will
+be set to match the chosen document encoding.
 
 Automatic detection works for the encodings mentioned specifically by name in
 |encoding-names|, but TOhtml will only automatically use those encodings with
-wide browser support. However, you can override this to support specific
+wide browser support.  However, you can override this to support specific
 encodings that may not be automatically detected by default (see options
-below). See http://www.iana.org/assignments/character-sets for the IANA names.
+below).  See http://www.iana.org/assignments/character-sets for the IANA
+names.
 
 Note: By default all Unicode encodings are converted to UTF-8 with no BOM in
 the generated HTML, as recommended by W3C:
@@ -756,7 +757,7 @@ the generated HTML, as recommended by W3C:
 							 *g:html_use_encoding*
 Default: none, uses IANA name for current 'fileencoding' as above.
 To overrule all automatic charset detection, set g:html_use_encoding to the
-name of the charset to be used. It is recommended to set this variable to
+name of the charset to be used.  It is recommended to set this variable to
 something widely supported, like UTF-8, for anything you will be hosting on a
 webserver: >
    :let g:html_use_encoding = "UTF-8"
@@ -785,10 +786,10 @@ Default: none, autoload/tohtml.vim contains default conversions for encodings
 		mentioned by name at |encoding-names| and which have wide
 		browser support.
 This option allows |2html.vim| to detect the HTML charset for any
-'fileencoding' or 'encoding' which is not detected automatically. You can also
-use it to override specific existing encoding-charset pairs. For example,
-TOhtml will by default use UTF-8 for all Unicode/UCS encodings. To use UTF-16
-and UTF-32 instead, use: >
+'fileencoding' or 'encoding' which is not detected automatically.  You can
+also use it to override specific existing encoding-charset pairs.  For
+example, TOhtml will by default use UTF-8 for all Unicode/UCS encodings.  To
+use UTF-16 and UTF-32 instead, use: >
    :let g:html_charset_override = {'ucs-4': 'UTF-32', 'utf-16': 'UTF-16'}
 
 Note that documents encoded in either UTF-32 or UTF-16 have known
@@ -797,12 +798,12 @@ compatibility problems with some major browsers.
 								 *g:html_font*
 Default: "monospace"
 You can specify the font or fonts used in the converted document using
-g:html_font. If this option is set to a string, then the value will be
-surrounded with single quotes. If this option is set to a list then each list
-item is surrounded by single quotes and the list is joined with commas. Either
-way, "monospace" is added as the fallback generic family name and the entire
-result used as the font family (using CSS) or font face (if not using CSS).
-Examples: >
+g:html_font.  If this option is set to a string, then the value will be
+surrounded with single quotes.  If this option is set to a list then each list
+item is surrounded by single quotes and the list is joined with commas.
+Either way, "monospace" is added as the fallback generic family name and the
+entire result used as the font family (using CSS) or font face (if not using
+CSS).  Examples: >
 
    " font-family: 'Consolas', monospace;
    :let g:html_font = "Consolas"
@@ -876,9 +877,9 @@ version 2.2.3.
 ASSEMBLY	*ft-asm-syntax* *ft-asmh8300-syntax* *ft-nasm-syntax*
 		*ft-masm-syntax* *ft-asm68k-syntax* *fasm.vim*
 
-Files matching "*.i" could be Progress or Assembly.  If the automatic detection
-doesn't work for you, or you don't edit Progress at all, use this in your
-startup vimrc: >
+Files matching "*.i" could be Progress or Assembly.  If the automatic
+detection doesn't work for you, or you don't edit Progress at all, use this in
+your startup vimrc: >
    :let filetype_i = "asm"
 Replace "asm" with the type of assembly you use.
 
@@ -893,7 +894,7 @@ files are included:
 	ia64		Intel Itanium 64
 	fasm		Flat assembly (http://flatassembler.net)
 	masm		Microsoft assembly (.masm files are compiled with
-			Microsoft's Macro Assembler. This is only supported
+			Microsoft's Macro Assembler.  This is only supported
 			for x86, x86_64, ARM and AARCH64 CPU families)
 	nasm		Netwide assembly
 	tasm		Turbo Assembly (with opcodes 80x86 up to Pentium, and
@@ -965,7 +966,7 @@ For Visual Basic use: >
 
 ASYMPTOTE					*asy.vim* *ft-asy-syntax*
 
-By default, only basic Asymptote keywords are highlighted. To highlight
+By default, only basic Asymptote keywords are highlighted.  To highlight
 extended geometry keywords: >
 
 	:let g:asy_syn_plain = 1
@@ -974,7 +975,7 @@ and for highlighting keywords related to 3D constructions: >
 
 	:let g:asy_syn_three = 1
 
-By default, Asymptote-defined colors (e.g: lightblue) are highlighted. To
+By default, Asymptote-defined colors (e.g: lightblue) are highlighted.  To
 highlight TeX-defined colors (e.g: BlueViolet) use: >
 
 	:let g:asy_syn_texcolors = 1
@@ -986,8 +987,8 @@ or for Xorg colors (e.g: AliceBlue): >
 BAAN						    *baan.vim* *baan-syntax*
 
 The baan.vim gives syntax support for BaanC of release BaanIV up to SSA ERP LN
-for both 3 GL and 4 GL programming. Large number of standard defines/constants
-are supported.
+for both 3 GL and 4 GL programming.  Large number of standard
+defines/constants are supported.
 
 Some special violation of coding standards will be signalled when one specify
 in ones |.vimrc|: >
@@ -996,7 +997,7 @@ in ones |.vimrc|: >
 *baan-folding*
 
 Syntax folding can be enabled at various levels through the variables
-mentioned below (Set those in your |.vimrc|). The more complex folding on
+mentioned below (Set those in your |.vimrc|).  The more complex folding on
 source blocks and SQL can be CPU intensive.
 
 To allow any folding and enable folding at function level use: >
@@ -1009,9 +1010,9 @@ Folding can be enabled for embedded SQL blocks as SELECT, SELECTDO,
 SELECTEMPTY, ... The indentation preceding the begin/end keywords has to
 match (spaces are not considered equal to a tab). >
 	let baan_fold_sql=1
-Note: Block folding can result in many small folds. It is suggested to |:set|
+Note: Block folding can result in many small folds.  It is suggested to |:set|
 the options 'foldminlines' and 'foldnestmax' in |.vimrc| or use |:setlocal| in
-.../after/syntax/baan.vim (see |after-directory|). Eg: >
+.../after/syntax/baan.vim (see |after-directory|).  Eg: >
 	set foldminlines=5
 	set foldnestmax=6
 
@@ -1062,7 +1063,7 @@ Variable		Highlight ~
 *c_syntax_for_h*	use C syntax for *.h files instead of C++/ObjC/ObjC++
 			(NOTE: This variable is deprecated and no longer
 			 necessary, as *.h files now default to C, unless the
-			 file contains C++ or Objective-C syntax. If the
+			 file contains C++ or Objective-C syntax.  If the
 			 automated detection fails, the default filetype can
 			 be adjusted using `g:filetype_h`.)
 *c_no_if0*		don't highlight "#if 0" blocks as comments
@@ -1273,7 +1274,7 @@ variable.
 CSV							*ft-csv-syntax*
 
 If you change the delimiter of a CSV file, its syntax highlighting will no
-longer match the changed file content. You will need to unlet the following
+longer match the changed file content.  You will need to unlet the following
 variable: >
 
 	:unlet b:csv_delimiter
@@ -1289,10 +1290,10 @@ Now the syntax engine should determine the newly changed CSV delimiter.
 CYNLIB						*cynlib.vim* *ft-cynlib-syntax*
 
 Cynlib files are C++ files that use the Cynlib class library to enable
-hardware modelling and simulation using C++.  Typically Cynlib files have a .cc
-or a .cpp extension, which makes it very difficult to distinguish them from a
-normal C++ file.  Thus, to enable Cynlib highlighting for .cc files, add this
-line to your .vimrc file: >
+hardware modelling and simulation using C++.  Typically Cynlib files have a
+.cc or a .cpp extension, which makes it very difficult to distinguish them
+from a normal C++ file.  Thus, to enable Cynlib highlighting for .cc files,
+add this line to your .vimrc file: >
 
 	:let cynlib_cyntax_for_cc=1
 
@@ -1332,9 +1333,9 @@ following variables:
 DART						*dart.vim* *ft-dart-syntax*
 
 Dart is an object-oriented, typed, class defined, garbage collected language
-used for developing mobile, desktop, web, and back-end applications.  Dart uses
-a C-like syntax derived from C, Java, and JavaScript, with features adopted
-from Smalltalk, Python, Ruby, and others.
+used for developing mobile, desktop, web, and back-end applications.  Dart
+uses a C-like syntax derived from C, Java, and JavaScript, with features
+adopted from Smalltalk, Python, Ruby, and others.
 
 More information about the language and its development environment at the
 official Dart language website at https://dart.dev
@@ -1450,7 +1451,7 @@ Doxygen generates code documentation using a special documentation format
 (similar to Javadoc).  This syntax script adds doxygen highlighting to c, cpp,
 idl and php files, and should also work with java.
 
-There are a few of ways to turn on doxygen formatting. It can be done
+There are a few of ways to turn on doxygen formatting.  It can be done
 explicitly or in a modeline by appending '.doxygen' to the syntax of the file.
 Example: >
 	:set syntax=c.doxygen
@@ -1558,7 +1559,7 @@ to your startup file.
 
 EUPHORIA	    *euphoria3.vim* *euphoria4.vim* *ft-euphoria-syntax*
 
-Two syntax highlighting files exist for Euphoria. One for Euphoria
+Two syntax highlighting files exist for Euphoria.  One for Euphoria
 version 3.1.1, which is the default syntax highlighting file, and one for
 Euphoria version 4.0.5 or later.
 
@@ -1584,7 +1585,7 @@ add the following line to your startup file: >
 Elixir and Euphoria share the *.ex file extension.  If the filetype is
 specifically set as Euphoria with the g:filetype_euphoria variable, or the
 file is determined to be Euphoria based on keywords in the file, then the
-filetype will be set as Euphoria. Otherwise, the filetype will default to
+filetype will be set as Euphoria.  Otherwise, the filetype will default to
 Elixir.
 
 
@@ -1644,10 +1645,10 @@ The following file extensions are auto-detected as Elixir file types:
 
 	*.ex, *.exs, *.eex, *.leex, *.lock
 
-Elixir and Euphoria share the *.ex file extension. If the filetype is
+Elixir and Euphoria share the *.ex file extension.  If the filetype is
 specifically set as Euphoria with the g:filetype_euphoria variable, or the
 file is determined to be Euphoria based on keywords in the file, then the
-filetype will be set as Euphoria. Otherwise, the filetype will default to
+filetype will be set as Euphoria.  Otherwise, the filetype will default to
 Elixir.
 
 
@@ -1659,12 +1660,12 @@ NOTE: This site currently doesn't work, on Wikipedia is mentioned that
 development stopped in 2009.
 
 Syntax highlighting is available for the most common elements of FlexWiki
-syntax. The associated ftplugin script sets some buffer-local options to make
-editing FlexWiki pages more convenient. FlexWiki considers a newline as the
+syntax.  The associated ftplugin script sets some buffer-local options to make
+editing FlexWiki pages more convenient.  FlexWiki considers a newline as the
 start of a new paragraph, so the ftplugin sets 'tw'=0 (unlimited line length),
 'wrap' (wrap long lines instead of using horizontal scrolling), 'linebreak'
 (to wrap at a character in 'breakat' instead of at the last char on screen),
-and so on. It also includes some keymaps that are disabled by default.
+and so on.  It also includes some keymaps that are disabled by default.
 
 If you want to enable the keymaps that make "j" and "k" and the cursor keys
 move up and down by display lines, add this to your .vimrc: >
@@ -1725,7 +1726,7 @@ edit F# or Fortran at all, use this in your startup vimrc: >
 FORTRAN					*fortran.vim* *ft-fortran-syntax*
 
 Default highlighting and dialect ~
-Vim highlights according to Fortran 2023 (the most recent standard). This
+Vim highlights according to Fortran 2023 (the most recent standard).  This
 choice should be appropriate for most users most of the time because Fortran
 2023 is almost a superset of previous versions (Fortran 2018, 2008, 2003, 95,
 90, 77, and 66).  A few legacy constructs deleted or declared obsolescent,
@@ -1750,21 +1751,21 @@ in your .vimrc prior to the :syntax on command.
 
 If the form of the source code depends, in a non-standard way, upon the file
 extension, then it is most convenient to set fortran_free_source in a ftplugin
-file.  For more information on ftplugin files, see |ftplugin|. Note that this
+file.  For more information on ftplugin files, see |ftplugin|.  Note that this
 will work only if the "filetype plugin indent on" command precedes the "syntax
 on" command in your .vimrc file.
 
 When you edit an existing Fortran file, the syntax script will assume free
 source form if the fortran_free_source variable has been set, and assumes
 fixed source form if the fortran_fixed_source variable has been set.  Suppose
-neither of these variables have been set. In that case, the syntax script
+neither of these variables have been set.  In that case, the syntax script
 attempts to determine which source form has been used by examining the file
 extension using conventions common to the ifort, gfortran, Cray, NAG, and
 PathScale compilers (.f, .for, .f77 for fixed-source, .f90, .f95, .f03, .f08
 for free-source).  No default is used for the .fpp and .ftn file extensions
-because different compilers treat them differently. If none of this works,
+because different compilers treat them differently.  If none of this works,
 then the script examines the first five columns of the first 500 lines of your
-file. If no signs of free source form are detected, then the file is assumed
+file.  If no signs of free source form are detected, then the file is assumed
 to be in fixed source form.  The algorithm should work in the vast majority of
 cases.  In some cases, such as a file that begins with 500 or more full-line
 comments, the script may incorrectly decide that the code is in fixed form.
@@ -1809,8 +1810,8 @@ fortran_fold in your .vimrc with a command such as >
 to instruct the syntax script to define fold regions for program units, that
 is main programs starting with a program statement, subroutines, function
 subprograms, modules, submodules, blocks of comment lines, and block data
-units. Block, interface, associate, critical, type definition, and change team
-constructs will also be folded.  If you also set the variable
+units.  Block, interface, associate, critical, type definition, and change
+team constructs will also be folded.  If you also set the variable
 fortran_fold_conditionals with a command such as >
     :let fortran_fold_conditionals=1
 then fold regions will also be defined for do loops, if blocks, select case,
@@ -2291,7 +2292,7 @@ JSON			*json.vim* *ft-json-syntax* *g:vim_json_conceal*
 						*g:vim_json_warnings*
 
 The json syntax file provides syntax highlighting with conceal support by
-default. To disable concealment: >
+default.  To disable concealment: >
 	let g:vim_json_conceal = 0
 
 To disable syntax highlighting of errors: >
@@ -2447,7 +2448,7 @@ instead, and the name of your source file should be *.pike
 
 LUA						*lua.vim* *ft-lua-syntax*
 
-The Lua syntax file can be used for versions 4.0, 5.0+. You can select one of
+The Lua syntax file can be used for versions 4.0, 5.0+.  You can select one of
 these versions using the global variables |g:lua_version| and
 |g:lua_subversion|.
 
@@ -2455,9 +2456,9 @@ these versions using the global variables |g:lua_version| and
 MAIL						*mail.vim* *ft-mail.vim*
 
 Vim highlights all the standard elements of an email (headers, signatures,
-quoted text and URLs / email addresses).  In keeping with standard conventions,
-signatures begin in a line containing only "--" followed optionally by
-whitespaces and end with a newline.
+quoted text and URLs / email addresses).  In keeping with standard
+conventions, signatures begin in a line containing only "--" followed
+optionally by whitespaces and end with a newline.
 
 Vim treats lines beginning with ']', '}', '|', '>' or a word followed by '>'
 as quoted text.  However Vim highlights headers and signatures in quoted text
@@ -2498,8 +2499,9 @@ MAPLE						*maple.vim* *ft-maple-syntax*
 
 Maple V, by Waterloo Maple Inc, supports symbolic algebra.  The language
 supports many packages of functions which are selectively loaded by the user.
-The standard set of packages' functions as supplied in Maple V release 4 may be
-highlighted at the user's discretion.  Users may place in their .vimrc file: >
+The standard set of packages' functions as supplied in Maple V release 4 may
+be highlighted at the user's discretion.  Users may place in their .vimrc
+file: >
 
 	:let mvpkg_all= 1
 
@@ -2553,13 +2555,13 @@ have the following in your .vimrc: >
 MBSYNC					*mbsync.vim* *ft-mbsync-syntax*
 
 The mbsync application uses a configuration file to setup mailboxes names,
-user and password. All files ending with `.mbsyncrc` or with the name
+user and password.  All files ending with `.mbsyncrc` or with the name
 `isyncrc` will be recognized as mbsync configuration files.
 
 MEDIAWIKI					*ft-mediawiki-syntax*
 
 By default, syntax highlighting includes basic HTML tags like style and
-headers |html.vim|. For strict Mediawiki syntax highlighting: >
+headers |html.vim|.  For strict Mediawiki syntax highlighting: >
 
 	let g:html_no_rendering = 1
 
@@ -2587,7 +2589,7 @@ The syntax for a dialect tag comment is: >
 	  m2pim = 'm2pim', m2iso = 'm2iso', m2r10 = 'm2r10'
 
 A dialect tag comment is recognised by Vim if it occurs within the first 200
-lines of the source file. Only the very first such comment is recognised, any
+lines of the source file.  Only the very first such comment is recognised, any
 additional dialect tag comments are ignored.
 
 Example: >
@@ -2792,7 +2794,7 @@ To do so, set the *g:filetype_md* var: >
 
 	:let g:filetype_md = 'pandoc'
 
-The pandoc syntax plugin uses |conceal| for pretty highlighting. Default is 1 >
+The pandoc syntax plugin uses |conceal| for pretty highlighting.  Default is 1 >
 
 	:let g:pandoc#syntax#conceal#use = 1
 
@@ -2821,8 +2823,8 @@ This is a list of the rules which can be used here:
   - inlinecode
   - inlinemath
 
-You can customize the way concealing works. For example, if you prefer to mark
-footnotes with the `*` symbol: >
+You can customize the way concealing works.  For example, if you prefer to
+mark footnotes with the `*` symbol: >
 
 	:let g:pandoc#syntax#conceal#cchar_overrides = {"footnote" : "*"}
 
@@ -2842,8 +2844,8 @@ specified. Default = 1 >
 	:let g:pandoc#syntax#codeblocks#embeds#use = 1
 
 For specify what languages and using what syntax files to highlight embeds.
-This is a list of language names. When the language pandoc and vim use don't
-match, you can use the "PANDOC=VIM" syntax. For example: >
+This is a list of language names.  When the language pandoc and vim use don't
+match, you can use the "PANDOC=VIM" syntax.  For example: >
 
 	:let g:pandoc#syntax#codeblocks#embeds#langs = ["ruby", "bash=sh"]
 
@@ -2858,8 +2860,8 @@ To add underline subscript, superscript and strikeout text styles. Default = 1 >
 
 	:let g:pandoc#syntax#style#underline_special = 1
 
-Detect and highlight definition lists. Disabling this can improve performance.
-Default = 1 (i.e., enabled by default) >
+Detect and highlight definition lists.  Disabling this can improve
+performance. Default = 1 (i.e., enabled by default) >
 
 	:let g:pandoc#syntax#style#use_definition_lists = 1
 
@@ -2867,7 +2869,7 @@ The pandoc syntax script also comes with the following commands: >
 
 	:PandocHighlight LANG
 
-Enables embedded highlighting for language LANG in codeblocks. Uses the
+Enables embedded highlighting for language LANG in codeblocks.  Uses the
 syntax for items in g:pandoc#syntax#codeblocks#embeds#langs. >
 
 	:PandocUnhighlight LANG
@@ -3280,7 +3282,7 @@ commands than are actually available to you by the game.
 R							*r.vim* *ft-r-syntax*
 
 The parsing of R code for syntax highlight starts 40 lines backwards, but you
-can set a different value in your |vimrc|. Example: >
+can set a different value in your |vimrc|.  Example: >
 	let r_syntax_minlines = 60
 
 You can also turn off syntax highlighting of ROxygen: >
@@ -3306,9 +3308,9 @@ To highlight R code in knitr chunk headers: >
 	let rmd_syn_hl_chunk = 1
 
 By default, chunks of R code will be highlighted following the rules of R
-language. Moreover, whenever the buffer is saved, Vim scans the buffer and
-highlights other languages if they are present in new chunks. LaTeX code also
-is automatically recognized and highlighted when the buffer is saved. This
+language.  Moreover, whenever the buffer is saved, Vim scans the buffer and
+highlights other languages if they are present in new chunks.  LaTeX code also
+is automatically recognized and highlighted when the buffer is saved.  This
 behavior can be controlled with the variables `rmd_dynamic_fenced_languages`,
 and `rmd_include_latex` whose valid values are: >
 	let rmd_dynamic_fenced_languages = 0 " No autodetection of languages
@@ -3331,10 +3333,10 @@ To highlight R code in knitr chunk headers, add to your |vimrc|: >
 
 RASI					*rasi.vim* *ft-rasi-syntax*
 
-Rasi stands for Rofi Advanced Style Information. It is used by the program
-rofi to style the rendering of the search window. The language is heavily
-inspired by CSS stylesheet. Files with the following extensions are recognized
-as rasi files: .rasi.
+Rasi stands for Rofi Advanced Style Information.  It is used by the program
+rofi to style the rendering of the search window.  The language is heavily
+inspired by CSS stylesheet.  Files with the following extensions are
+recognized as rasi files: .rasi.
 
 READLINE				*readline.vim* *ft-readline-syntax*
 
@@ -3686,7 +3688,7 @@ the following line in your .vimrc: >
  Sh: EMBEDDING LANGUAGES~
 
 You may wish to embed languages into sh.  I'll give an example courtesy of
-Lorance Stinson on how to do this with awk as an example. Put the following
+Lorance Stinson on how to do this with awk as an example.  Put the following
 file into $HOME/.vim/after/syntax/sh/awkembed.vim: >
 
     " AWK Embedding:
@@ -3783,7 +3785,7 @@ to a larger number: >
 
 This will make the syntax synchronization start 1000 lines before the first
 displayed line.  If you set "tcsh_minlines" to "fromstart", then
-synchronization is done from the start of the file. The default value for
+synchronization is done from the start of the file.  The default value for
 tcsh_minlines is 100.  The disadvantage of using a larger number is that
 redrawing can become slow.
 
@@ -3992,7 +3994,7 @@ substitution will not be made.
 						*g:tex_isk* *g:tex_stylish*
  Tex: Controlling iskeyword~
 
-Normally, LaTeX keywords support 0-9, a-z, A-z, and 192-255 only. Latex
+Normally, LaTeX keywords support 0-9, a-z, A-z, and 192-255 only.  Latex
 keywords don't support the underscore - except when in *.sty files.  The
 syntax highlighting script handles this with the following logic:
 
@@ -4045,7 +4047,8 @@ syntax highlighting script handles this with the following logic:
 <	If you don't want matching to occur inside bold and italicized
 	regions, >
 		let g:tex_excludematcher= 1
-<	will prevent the texMatcher group from being included in those regions.
+<	will prevent the texMatcher group from being included in those
+	regions.
 
 TF						*tf.vim* *ft-tf-syntax*
 
@@ -4063,7 +4066,7 @@ There is one option to control the TypeScript syntax highlighting.
 
 						*g:typescript_host_keyword*
 When this variable is set to 1, host-specific APIs such as `addEventListener`
-are highlighted. To disable set it to zero in your .vimrc: >
+are highlighted.  To disable set it to zero in your .vimrc: >
 
 	let g:typescript_host_keyword = 0
 <
@@ -4073,8 +4076,8 @@ TYPST						    *ft-typst-syntax*
 
 						*g:typst_embedded_languages*
 Typst files can embed syntax highlighting for other languages by setting the
-|g:typst_embedded_languages| variable. This variable is a list of language
-names whose syntax definitions will be included in Typst files. Example: >
+|g:typst_embedded_languages| variable.  This variable is a list of language
+names whose syntax definitions will be included in Typst files.  Example: >
 
     let g:typst_embedded_languages = ['python', 'r']
 
@@ -4167,8 +4170,8 @@ using Neovim), set >
 
 WDL							*wdl.vim* *wdl-syntax*
 
-The Workflow Description Language is a way to specify data processing workflows
-with a human-readable and writeable syntax.  This is used a lot in
+The Workflow Description Language is a way to specify data processing
+workflows with a human-readable and writeable syntax.  This is used a lot in
 bioinformatics.  More info on the spec can be found here:
 https://github.com/openwdl/wdl
 
@@ -4236,11 +4239,11 @@ YAML						*yaml.vim* *ft-yaml-syntax*
 
 					*g:yaml_schema* *b:yaml_schema*
 A YAML schema is a combination of a set of tags and a mechanism for resolving
-non-specific tags. For user this means that YAML parser may, depending on
+non-specific tags.  For user this means that YAML parser may, depending on
 plain scalar contents, treat plain scalar (which can actually be only string
 and nothing else) as a value of the other type: null, boolean, floating-point,
-integer. `g:yaml_schema` option determines according to which schema values
-will be highlighted specially. Supported schemas are
+integer.  `g:yaml_schema` option determines according to which schema values
+will be highlighted specially.  Supported schemas are
 
 Schema		Description ~
 failsafe	No additional highlighting.
@@ -4690,7 +4693,7 @@ concealends						*:syn-concealends*
 When the "concealends" argument is given, the start and end matches of
 the region, but not the contents of the region, are marked as concealable.
 Whether or not they are actually concealed depends on the setting on the
-'conceallevel' option. The ends of a region can only be concealed separately
+'conceallevel' option.  The ends of a region can only be concealed separately
 in this way when they have their own highlighting via "matchgroup".  The
 |synconcealed()| function can be used to retrieve information about conealed
 items.
@@ -4974,7 +4977,7 @@ IMPLICIT CONCEAL					*:syn-conceal-implicit*
 
 :sy[ntax] conceal [on|off]
 	This defines if the following ":syntax" commands will define keywords,
-	matches or regions with the "conceal" flag set. After ":syn conceal
+	matches or regions with the "conceal" flag set.  After ":syn conceal
 	on", all subsequent ":syn keyword", ":syn match" or ":syn region"
 	defined will have the "conceal" flag set implicitly. ":syn conceal
 	off" returns to the normal state where the "conceal" flag must be
@@ -5476,8 +5479,9 @@ of colors by using the `:colorscheme` command, for example: >
 <			In case g:colors_name has not been defined :colo will
 			output "default".  Its palette is defined in the file
 			"$VIMRUNTIME/syntax/syncolor.vim" and is based on
-			legacy versions of peachpuff and desert.  When compiled
-			without the |+eval| feature it will output "unknown".
+			legacy versions of peachpuff and desert.  When
+			compiled without the |+eval| feature it will output
+			"unknown".
 
 :colo[rscheme] {name}	Load color scheme {name}.  This searches 'runtimepath'
 			for the file "colors/{name}.vim".  The first one that
@@ -5575,7 +5579,7 @@ in their own color.
 
 :hi[ghlight] [default] {group-name} {key}={arg} ...
 			Add a highlight group, or change the highlighting for
-			an existing group. If a given color name is not
+			an existing group.  If a given color name is not
 			recognized, each `colors/lists/default.vim` found on
 			'runtimepath' will be loaded.
 			See |highlight-args| for the {key}={arg} arguments.
@@ -5610,7 +5614,7 @@ also tell where it was last set.  Example: >
 	   Last set from /home/mool/vim/vim7/runtime/syntax/syncolor.vim ~
 
 When ":hi clear" is used then the script where this command is used will be
-mentioned for the default values. See |:verbose-cmd| for more information.
+mentioned for the default values.  See |:verbose-cmd| for more information.
 
 					*highlight-args* *E416* *E417* *E423*
 There are three types of terminals for highlighting:
@@ -5811,9 +5815,9 @@ ctermul={color-nr}				*highlight-ctermul*
 	"fg" and "bg" colors will not be adjusted.
 
 ctermfont={font-nr}				*highlight-ctermfont*
-	This gives the alternative font number to use in the terminal. The
+	This gives the alternative font number to use in the terminal.  The
 	available fonts depend on the terminal, and if the terminal is not set
-	up for alternative fonts this simply won't do anything. The range of
+	up for alternative fonts this simply won't do anything.  The range of
 	{font-nr} is 0-10 where 0 resets the font to the default font, 1-9
 	selects one of the 9 alternate fonts, and 10 selects the Fraktur font.
 	For more information see your terminal's handling of SGR parameters
@@ -5907,10 +5911,10 @@ guisp={color-name}					*highlight-guisp*
 	    colorscheme alt
 <
 	If you want to develop a color list that can be relied on by others,
-	it is best to prefix your color names. By convention these color lists
-	are placed in the colors/lists directory. You can see an example in
-	'$VIMRUNTIME/colors/lists/csscolors.vim'. This list would be sourced
-	by a color scheme using: >
+	it is best to prefix your color names.  By convention these color
+	lists are placed in the colors/lists directory.  You can see an
+	example in '$VIMRUNTIME/colors/lists/csscolors.vim'.  This list would
+	be sourced by a color scheme using: >
 
 	    :runtime colors/lists/csscolors.vim
 	    :highlight Comment guifg=css_turquoise
@@ -5936,7 +5940,8 @@ lCursor		Character under the cursor when |language-mapping|
 							*hl-CursorIM*
 CursorIM	Like Cursor, but used when in IME mode. |CursorIM|
 							*hl-CursorColumn*
-CursorColumn	Screen column that the cursor is in when 'cursorcolumn' is set.
+CursorColumn	Screen column that the cursor is in when 'cursorcolumn' is
+		set.
 							*hl-CursorLine*
 CursorLine	Screen line that the cursor is in when 'cursorline' is set.
 							*hl-Directory*
@@ -6022,10 +6027,10 @@ PmenuSbar	Popup menu: Scrollbar.
 							*hl-PmenuThumb*
 PmenuThumb	Popup menu: Thumb of the scrollbar.
 							*hl-PmenuMatch*
-PmenuMatch	Popup menu: Matched text in normal item. Applied in
+PmenuMatch	Popup menu: Matched text in normal item.  Applied in
 		combination with |hl-Pmenu|.
 							*hl-PmenuMatchSel*
-PmenuMatchSel	Popup menu: Matched text in selected item. Applied in
+PmenuMatchSel	Popup menu: Matched text in selected item.  Applied in
 		combination with |hl-PmenuSel|.
 							*hl-PmenuBorder*
 PmenuBorder	Popup menu: Border characters.
@@ -6328,12 +6333,12 @@ And put these lines in your .vimrc: >
 ==============================================================================
 18. Window-local syntax				*:ownsyntax*
 
-Normally all windows on a buffer share the same syntax settings. It is
+Normally all windows on a buffer share the same syntax settings.  It is
 possible, however, to set a particular window on a file to have its own
-private syntax setting. A possible example would be to edit LaTeX source
+private syntax setting.  A possible example would be to edit LaTeX source
 with conventional highlighting in one window, while seeing the same source
 highlighted differently (so as to hide control sequences and indicate bold,
-italic etc regions) in another. The 'scrollbind' option is useful here.
+italic etc regions) in another.  The 'scrollbind' option is useful here.
 
 To set the current window to have the syntax "foo", separately from all other
 windows on the buffer: >
@@ -6348,7 +6353,7 @@ Note: This resets the 'spell', 'spellcapcheck', 'spellfile' and 'spelloptions'
 options.
 
 Once a window has its own syntax, syntax commands executed from other windows
-on the same buffer (including :syntax clear) have no effect. Conversely,
+on the same buffer (including :syntax clear) have no effect.  Conversely,
 syntax commands executed from that window do not affect other windows on the
 same buffer.
 
@@ -6533,7 +6538,7 @@ it took to match them against the text.
 			current window.  Use a wider display to see more of
 			the output.
 
-			The list is sorted by total time. The columns are:
+			The list is sorted by total time.  The columns are:
 			TOTAL		Total time in seconds spent on
 					matching this pattern.
 			COUNT		Number of times the pattern was used.

--- a/runtime/doc/tabpage.txt
+++ b/runtime/doc/tabpage.txt
@@ -145,7 +145,7 @@ something else.
 		    :tabclose $	    " close the last tab page
 		    :tabclose #     " close the last accessed tab page
 
-When a tab page is closed the next tab page will become the current one. This
+When a tab page is closed the next tab page will become the current one.  This
 behaviour can be customized using the 'tabclose' option.
 
 							*:tabo* *:tabonly*
@@ -277,7 +277,7 @@ REORDERING TAB PAGES:
 
 
 Note that although it is possible to move a tab page behind the N-th one by
-using :Ntabmove. And move it by N places by using :+Ntabmove. For
+using :Ntabmove.  And move it by N places by using :+Ntabmove.  For
 clarification what +N means in this context see |[range]|.
 
 

--- a/runtime/doc/tagsrch.txt
+++ b/runtime/doc/tagsrch.txt
@@ -44,7 +44,7 @@ below.
 			{name} can be a regexp pattern, see |tag-regexp|.
 			When there are several matching tags for {name}, jump
 			to the [count] one.  When [count] is omitted the
-			first one is jumped to. See |tag-matchlist| for
+			first one is jumped to.  See |tag-matchlist| for
 			jumping to other matching tags.
 
 g<LeftMouse>						*g<LeftMouse>*
@@ -54,7 +54,7 @@ CTRL-]			Jump to the definition of the keyword under the
 			keyword under or after cursor.
 			When there are several matching tags for {name}, jump
 			to the [count] one.  When no [count] is given the
-			first one is jumped to. See |tag-matchlist| for
+			first one is jumped to.  See |tag-matchlist| for
 			jumping to other matching tags.
 
 							*v_CTRL-]*
@@ -103,7 +103,7 @@ The ignore-case matches are found when:
 
 Note that using ignore-case tag searching disables binary searching in the
 tags file, which causes a slowdown.  This can be avoided by fold-case sorting
-the tag file. See the 'tagbsearch' option for an explanation.
+the tag file.  See the 'tagbsearch' option for an explanation.
 
 ==============================================================================
 2. Tag stack				*tag-stack* *tagstack* *E425*
@@ -182,7 +182,7 @@ commands explained above the tag stack will look like this:
    1  1 main		1  harddisk2:text/vim/test
    2  1 FuncB	       59  harddisk2:text/vim/src/main.c
 
-The |gettagstack()| function returns the tag stack of a specified window. The
+The |gettagstack()| function returns the tag stack of a specified window.  The
 |settagstack()| function modifies the tag stack of a window.
 
 							*tagstack-examples*
@@ -308,7 +308,7 @@ g CTRL-]		Like CTRL-], but use ":tjump" instead of ":tag".
 			not given, the last tag name from the tag stack is
 			used.  The search pattern to locate the tag line is
 			prefixed with "\V" to escape all the special
-			characters (very nomagic). The location list showing
+			characters (very nomagic).  The location list showing
 			the matching tags is independent of the tag stack.
 			See |tag-!| for [!].
 
@@ -441,7 +441,7 @@ current file  changed	!   option	option	      action	~
   This works because the tag is put on the stack anyway.  If you want to lose
   the changes you can use the ":tag!" command.
 - If the tag is in another file and the window includes 'winfixbuf', the
-  command will fail. If the tag is in the same file then it may succeed.
+  command will fail.  If the tag is in the same file then it may succeed.
 
 							*tag-security*
 Note that Vim forbids some commands, for security reasons.  This works like
@@ -455,8 +455,8 @@ would otherwise go unnoticed.  Example: >
 	:$d|/tag-function-name/
 
 In Vi the ":tag" command sets the last search pattern when the tag is searched
-for.  In Vim this is not done, the previous search pattern is still remembered,
-unless the 't' flag is present in 'cpoptions'.
+for.  In Vim this is not done, the previous search pattern is still
+remembered, unless the 't' flag is present in 'cpoptions'.
 
 					*emacs-tags* *emacs_tags* *E430*
 Emacs style tag files are only supported if Vim was compiled with the
@@ -465,7 +465,7 @@ files here, it is only supported for backwards compatibility :-).
 
 Lines in Emacs tags files can be very long.  Vim only deals with lines of up
 to about 510 bytes.  To see whether lines are ignored set 'verbose' to 5 or
-higher. Non-Emacs tags file lines can be any length.
+higher.  Non-Emacs tags file lines can be any length.
 
 							*tags-option*
 The 'tags' option is a list of file names.  Each of these files is searched
@@ -535,7 +535,7 @@ Some programs that generate tags files:
 ctags			As found on most Unix systems.  Only supports C.  Only
 			does the basic work.
 universal ctags		A maintained version of ctags based on exuberant
-			ctags. See https://ctags.io.
+			ctags.  See https://ctags.io.
 							*Exuberant_ctags*
 exuberant ctags		This is a very good one.  It works for C, C++, Java,
 			Fortran, Eiffel and others.  It can generate tags for
@@ -586,7 +586,7 @@ ctags).
 {term}		;" The two characters semicolon and double quote.  This is
 		interpreted by Vi as the start of a comment, which makes the
 		following be ignored.  This is for backwards compatibility
-		with Vi, it ignores the following fields. Example: >
+		with Vi, it ignores the following fields.  Example: >
 			APP	file	/^static int APP;$/;"	v
 <		When {tagaddress} is not a line number or search pattern, then
 		{term} must be |;".  Here the bar ends the command (excluding
@@ -928,7 +928,8 @@ The function should return a List of Dict entries.  Each Dict must at least
 include the following entries and each value must be a string:
 	name		Name of the tag.
 	filename	Name of the file where the tag is defined.  It is
-			either relative to the current directory or a full path.
+			either relative to the current directory or a full
+			path.
 	cmd		Ex command used to locate the tag in the file.  This
 			can be either an Ex search pattern or a line number.
 Note that the format is similar to that of |taglist()|, which makes it possible

--- a/runtime/doc/term.txt
+++ b/runtime/doc/term.txt
@@ -676,7 +676,7 @@ anymore.
 
 							*xterm-true-color*
 Vim supports using true colors in the terminal (taken from |highlight-guifg|
-and |highlight-guibg|), given that the terminal supports this. To make this
+and |highlight-guibg|), given that the terminal supports this.  To make this
 work the 'termguicolors' option needs to be set.
 See https://github.com/termstandard/colors for a list of terminals that
 support true colors.
@@ -746,8 +746,8 @@ Note: When 't_EI' is not set then 't_SI' and 't_SR' will not be sent.  And
 when 't_SI' or 't_SR' is not set then 't_EI' is sent only once.
 
 This can be used to change the shape or color of the cursor in Insert or
-Replace mode. These are not standard termcap/terminfo entries, you need to set
-them yourself.
+Replace mode.  These are not standard termcap/terminfo entries, you need to
+set them yourself.
 Example for an xterm, this changes the color of the cursor: >
     if &term =~ "xterm"
 	let &t_SI = "\<Esc>]12;purple\x7"
@@ -1111,7 +1111,8 @@ which characters are included in a word.  A double click on a character
 that has a match selects until that match (like using "v%").  If the match is
 an #if/#else/#endif block, the selection becomes linewise.
 For MS-Windows and xterm the time for double clicking can be set with the
-'mousetime' option.  For the other systems this time is defined outside of Vim.
+'mousetime' option.  For the other systems this time is defined outside of
+Vim.
 An example, for using a double click to jump to the tag under the cursor: >
 	:map <2-LeftMouse> :exe "tag " .. expand("<cword>")<CR>
 
@@ -1140,10 +1141,10 @@ modifiers.
 When working with several windows, the size of the windows can be changed by
 dragging the status line with the mouse.  Point the mouse at a status line,
 press the left button, move the mouse to the new position of the status line,
-release the button.  Just clicking the mouse in a status line makes that window
-the current window, without moving the cursor.  If by selecting a window it
-will change position or size, the dragging of the status line will look
-confusing, but it will work (just try it).
+release the button.  Just clicking the mouse in a status line makes that
+window the current window, without moving the cursor.  If by selecting a
+window it will change position or size, the dragging of the status line will
+look confusing, but it will work (just try it).
 
 					*<MiddleRelease>* *<MiddleDrag>*
 Mouse clicks can be mapped.  The codes for mouse clicks are:

--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -54,7 +54,7 @@ The terminal feature requires the |+job| and |+channel| features.
 1. Basic use						*terminal-use*
 
 This feature is for running a terminal emulator in a Vim window.  A job can be
-started connected to the terminal emulator. For example, to run a shell: >
+started connected to the terminal emulator.  For example, to run a shell: >
      :term bash
 
 Or to run build command: >
@@ -71,7 +71,8 @@ the job.  This uses a pty when possible.  You can click outside of the
 terminal window to move keyboard focus elsewhere.
 
 						*t_CTRL-W_CTRL-W* *t_CTRL-W_:*
-CTRL-W can be used to navigate between windows and other CTRL-W commands, e.g.:
+CTRL-W can be used to navigate between windows and other CTRL-W commands,
+e.g.:
 	CTRL-W CTRL-W	move focus to the next window
 	CTRL-W :	enter an Ex command
 See |CTRL-W| for more commands.
@@ -271,12 +272,12 @@ Command syntax ~
 					the terminal window) the command line
 					height will be reduced as needed.
 			++cols={width}  Use {width} for the terminal window
-					width. If the terminal uses the full
+					width.  If the terminal uses the full
 					Vim width (no window left or right of
 					the terminal window) this value is
 					ignored.
 			++eof={text}	When using [range]: text to send after
-					the last line was written. Cannot
+					the last line was written.  Cannot
 					contain white space.  A CR is
 					appended.  For MS-Windows the default
 					is to send CTRL-D.
@@ -322,13 +323,13 @@ fails, use ! to force, as usual.
 							*terminal-close*
 When the terminal job finishes and no [command] was given (e.g. the 'shell'
 command was executed), the terminal window will be closed by default (unless
-the buffer in next window receiving the space has the 'nobuflisted' option set,
-in which case the terminal window would not be closed automatically, but a new
-empty buffer would be opened in that window).
+the buffer in next window receiving the space has the 'nobuflisted' option
+set, in which case the terminal window would not be closed automatically, but
+a new empty buffer would be opened in that window).
 
 When the terminal window is closed, e.g. when the shell exits and "++close"
 argument was used, and this is the last normal Vim window, then Vim will exit.
-This is like using |:quit| in a normal window. Help and preview windows are
+This is like using |:quit| in a normal window.  Help and preview windows are
 not counted.
 
 To have a background job run without a window, and open the window when it's
@@ -384,7 +385,7 @@ Use CTRL-W N (or 'termwinkey' N) to switch to Terminal-Normal mode.  Now the
 contents of the terminal window is under control of Vim, the job output is
 suspended.  CTRL-\ CTRL-N does the same.
 
-Terminal-Job mode is where |:tmap| mappings are applied. Keys sent by
+Terminal-Job mode is where |:tmap| mappings are applied.  Keys sent by
 |term_sendkeys()| are not subject to tmap, but keys from |feedkeys()| are.
 
 It is not possible to enter Insert mode from Terminal-Job mode.
@@ -394,7 +395,7 @@ In Terminal-Normal mode you can move the cursor around with the usual Vim
 commands, Visually mark text, yank text, etc.  But you cannot change the
 contents of the buffer.  The commands that would start insert mode, such as
 'i' and 'a', return to Terminal-Job mode.  The window will be updated to show
-the contents of the terminal. |:startinsert| is ineffective.
+the contents of the terminal.  |:startinsert| is ineffective.
 
 In Terminal-Normal mode the statusline and window title show "(Terminal)".  If
 the job ends while in Terminal-Normal mode this changes to
@@ -402,7 +403,7 @@ the job ends while in Terminal-Normal mode this changes to
 
 When the job outputs lines in the terminal, such that the contents scrolls off
 the top, those lines are remembered and can be seen in Terminal-Normal mode.
-The number of lines is limited by the 'termwinscroll' option. When going over
+The number of lines is limited by the 'termwinscroll' option.  When going over
 this limit, the first 10% of the scrolled lines are deleted and are lost.
 
 
@@ -486,10 +487,10 @@ version, rename to winpty32.dll and winpty64.dll to match the way Vim was
 build.
 							*ConPTY* *E982*
 On more recent versions of MS-Windows 10 (beginning with the "October 2018
-Update"), winpty is no longer required. On those versions, |:terminal| will use
+Update"), winpty is no longer required.  On those versions, |:terminal| will use
 Windows' built-in support for hosting terminal applications, "ConPTY".  When
 ConPTY is in use, there may be rendering artifacts regarding ambiguous-width
-characters. If you encounter any such issues, install "winpty".  Until the
+characters.  If you encounter any such issues, install "winpty".  Until the
 ConPTY problems have been fixed "winpty" will be preferred.
 
 Environment variables are used to pass information to the running job:
@@ -540,7 +541,7 @@ term_dumpdiff({filename}, {filename} [, {options}])
 		   "norestore"	     do not add the terminal window to a
 				     session file
 
-		Each character in the middle part indicates a difference. If
+		Each character in the middle part indicates a difference.  If
 		there are multiple differences only the first in this list is
 		used:
 			X	different character
@@ -641,8 +642,8 @@ term_getattr({attr}, {what})				*term_getattr()*
 
 
 term_getcursor({buf})					*term_getcursor()*
-		Get the cursor position of terminal {buf}. Returns a list with
-		two numbers and a dictionary: [row, col, dict].
+		Get the cursor position of terminal {buf}.  Returns a list
+		with two numbers and a dictionary: [row, col, dict].
 
 		"row" and "col" are one based, the first screen cell is row
 		1, column 1.  This is the cursor position of the terminal
@@ -657,7 +658,7 @@ term_getcursor({buf})					*term_getcursor()*
 				for a vertical bar.
 		   "color"	color of the cursor, e.g. "green"
 
-		{buf} must be the buffer number of a terminal window. If the
+		{buf} must be the buffer number of a terminal window.  If the
 		buffer does not exist or is not a terminal window, an empty
 		list is returned.
 
@@ -670,7 +671,7 @@ term_getcursor({buf})					*term_getcursor()*
 term_getjob({buf})					*term_getjob()*
 		Get the Job associated with terminal window {buf}.
 		{buf} is used as with |term_getsize()|.
-		Returns |v:null| when there is no job. In Vim9 script, return
+		Returns |v:null| when there is no job.  In Vim9 script, return
 		|null_job| when there is no job.
 
 		Can also be used as a |method|: >
@@ -713,7 +714,7 @@ term_getscrolled({buf})					*term_getscrolled()*
 
 
 term_getsize({buf})					*term_getsize()*
-		Get the size of terminal {buf}. Returns a list with two
+		Get the size of terminal {buf}.  Returns a list with two
 		numbers: [rows, cols].  This is the size of the terminal, not
 		the window containing the terminal.
 
@@ -728,14 +729,14 @@ term_getsize({buf})					*term_getsize()*
 
 
 term_getstatus({buf})					*term_getstatus()*
-		Get the status of terminal {buf}. This returns a String with
+		Get the status of terminal {buf}.  This returns a String with
 		a comma-separated list of these items:
 			running		job is running
 			finished	job has finished
 			normal		in Terminal-Normal mode
 		One of "running" or "finished" is always present.
 
-		{buf} must be the buffer number of a terminal window. If the
+		{buf} must be the buffer number of a terminal window.  If the
 		buffer does not exist or is not a terminal window, an empty
 		string is returned.
 
@@ -746,10 +747,10 @@ term_getstatus({buf})					*term_getstatus()*
 
 
 term_gettitle({buf})					*term_gettitle()*
-		Get the title of terminal {buf}. This is the title that the
+		Get the title of terminal {buf}.  This is the title that the
 		job in the terminal has set.
 
-		{buf} must be the buffer number of a terminal window. If the
+		{buf} must be the buffer number of a terminal window.  If the
 		buffer does not exist or is not a terminal window, an empty
 		string is returned.
 
@@ -764,8 +765,8 @@ term_gettty({buf} [, {input}])				*term_gettty()*
 		terminal window {buf}.  {buf} is used as with |term_getsize()|.
 
 		When {input} is omitted or 0, return the name for writing
-		(stdout). When {input} is 1 return the name for reading
-		(stdin). On UNIX, both return same name.
+		(stdout).  When {input} is 1 return the name for reading
+		(stdin).  On UNIX, both return same name.
 
 		Can also be used as a |method|: >
 			GetBufnr()->term_gettty()
@@ -808,7 +809,7 @@ term_sendkeys({buf}, {keys})				*term_sendkeys()*
 		Send keystrokes {keys} to terminal {buf}.
 		{buf} is used as with |term_getsize()|.
 
-		{keys} are translated as key sequences. For example, "\<c-x>"
+		{keys} are translated as key sequences.  For example, "\<c-x>"
 		means the character CTRL-X.
 
 		Can also be used as a |method|: >
@@ -904,7 +905,7 @@ term_setrestore({buf}, {command})			*term_setrestore()*
 
 
 term_setsize({buf}, {rows}, {cols})		*term_setsize()* *E955*
-		Set the size of terminal {buf}. The size of the window
+		Set the size of terminal {buf}.  The size of the window
 		containing the terminal will also be adjusted, if possible.
 		If {rows} or {cols} is zero or negative, that dimension is not
 		changed.
@@ -922,7 +923,7 @@ term_setsize({buf}, {rows}, {cols})		*term_setsize()* *E955*
 term_start({cmd} [, {options}])			*term_start()*
 		Open a terminal window and run {cmd} in it.
 
-		{cmd} can be a string or a List, like with |job_start()|. The
+		{cmd} can be a string or a List, like with |job_start()|.  The
 		string "NONE" can be used to open a terminal window without
 		starting a job, the pty of the terminal can be used by a
 		command like gdb.
@@ -969,17 +970,17 @@ term_start({cmd} [, {options}])			*term_start()*
 					"open": open window if needed
 				     Note that "open" can be interruptive.
 				     See |term++close| and |term++open|.
-		   "term_opencmd"    command to use for opening the window when
-				     "open" is used for "term_finish"; must
-				     have "%d" where the buffer number goes,
-				     e.g. "10split|buffer %d"; when not
+		   "term_opencmd"    command to use for opening the window
+				     when "open" is used for "term_finish";
+				     must have "%d" where the buffer number
+				     goes, e.g. "10split|buffer %d"; when not
 				     specified "botright sbuf %d" is used
 		   "term_highlight"  highlight group to use instead of
 				     "Terminal"
 		   "eof_chars"	     Text to send after all buffer lines were
 				     written to the terminal.  When not set
-				     CTRL-D is used on MS-Windows. For Python
-				     use CTRL-Z or "exit()". For a shell use
+				     CTRL-D is used on MS-Windows.  For Python
+				     use CTRL-Z or "exit()".  For a shell use
 				     "exit".  A CR is always added.
 		   "ansi_colors"     A list of 16 color names or hex codes
 				     defining the ANSI palette used in GUI
@@ -1014,7 +1015,7 @@ term_wait({buf} [, {time}])					*term_wait()*
 There are several ways to communicate with the job running in a terminal:
 - Use |term_sendkeys()| to send text and escape sequences from Vim to the job.
 - Use the JSON API to send encoded commands from the job to Vim.
-- Use the |client-server| mechanism. This works on machines with an X server
+- Use the |client-server| mechanism.  This works on machines with an X server
   and on MS-Windows.
 
 
@@ -1180,7 +1181,7 @@ Writing a screen dump test for Vim ~
 							*terminal-dumptest*
 For an example see the Test_syntax_c() function in
 src/testdir/test_syntax.vim.  The main parts are:
-- Write a file you want to test with. This is useful for testing syntax
+- Write a file you want to test with.  This is useful for testing syntax
   highlighting.  You can also start Vim with an empty buffer.
 - Run Vim in a terminal with a specific size.  The default is 20 lines of 75
   characters.  This makes sure the dump is always this size.  The function
@@ -1258,7 +1259,7 @@ kind of difference:
 	+	character missing in first
 	-	character missing in second
 
-Alternatively, press "s" to swap the first and second dump. Do this several
+Alternatively, press "s" to swap the first and second dump.  Do this several
 times so that you can spot the difference in the context of the text.
 
 ==============================================================================
@@ -1313,7 +1314,7 @@ Only one debugger can be active at a time.
 						*termdebug-timeout*
 Depending on how gdb is launched, termdebug startup time may vary.
 To avoid termdebug to get stuck if the startup process of gdb takes too long,
-a configurable timeout is included. Such time out is configurable in terms of
+a configurable timeout is included.  Such time out is configurable in terms of
 multiple of 10ms: >
     let g:termdebug_config['timeout'] = 500 # 500 * 10ms = 5 seconds.
 
@@ -1360,7 +1361,7 @@ You can use CTRL-W CTRL-W or the mouse to move focus between windows.
 Put focus on the gdb window and type: >
 	break ex_help
 	run
-Vim will start running in the program window. Put focus there and type: >
+Vim will start running in the program window.  Put focus there and type: >
 	:help gui
 Gdb will run into the ex_help breakpoint.  The source window now shows the
 ex_cmds.c file.  A red "1 " marker will appear in the signcolumn where the
@@ -1388,7 +1389,7 @@ executed.
 
 You can type more advanced commands in the gdb window.  For example, type: >
 	watch curbuf
-Now click "Cont" in the toolbar (or type "cont" in the gdb window). Execution
+Now click "Cont" in the toolbar (or type "cont" in the gdb window).  Execution
 will now continue until the value of "curbuf" changes, which is in do_ecmd().
 To remove this watchpoint again type in the gdb window: >
 	delete 3
@@ -1500,7 +1501,7 @@ Other commands ~
  *:Asm*	     jump to the window with the disassembly, create it if there
 	     isn't one
  *:Var*	     jump to the window with the local and argument variables,
-	     create it if there isn't one. This window updates whenever the
+	     create it if there isn't one.  This window updates whenever the
 	     program is stopped
 
 Events ~
@@ -1809,8 +1810,8 @@ However, the latter form will be deprecated in future releases.
 Change default signs ~
 							*termdebug_signs*
 Termdebug uses the hex number of the breakpoint ID in the signcolumn to
-represent breakpoints. If it is greater than "0xFF", then it will be displayed
-as "F+", due to we really only have two screen cells for the sign.
+represent breakpoints.  If it is greater than "0xFF", then it will be
+displayed as "F+", due to we really only have two screen cells for the sign.
 You may also use decimal breakpoint signs instead, in which case IDs greater
 than 99 will be displayed as "9+".
 
@@ -1857,7 +1858,7 @@ Set the wide value to 1 to use a vertical split without ever changing
 
 Evaluate in Popup Window at Cursor ~
 						*termdebug_evaluate_in_popup*
-By default |:Evaluate| will simply echo its output. For larger entities this
+By default |:Evaluate| will simply echo its output.  For larger entities this
 might become difficult to read or even truncated.
 Alternatively, the evaluation result may be output into a popup window at the
 current cursor position: >

--- a/runtime/doc/testing.txt
+++ b/runtime/doc/testing.txt
@@ -26,7 +26,7 @@ There are two types of tests added over time:
 
 						*new-style-testing*
 New tests should be added as new style tests.  The test scripts are named
-test_<feature>.vim (replace <feature> with the feature under test). These use
+test_<feature>.vim (replace <feature> with the feature under test).  These use
 functions such as |assert_equal()| to keep the test commands and the expected
 result in one place.
 						*old-style-testing*
@@ -58,7 +58,7 @@ test_autochdir()					*test_autochdir()*
 
 test_feedinput({string})				*test_feedinput()*
 		Characters in {string} are queued for processing as if they
-		were typed by the user. This uses a low level input buffer.
+		were typed by the user.  This uses a low level input buffer.
 		This function works only when with |+unix| or GUI is running.
 
 		Can also be used as a |method|: >
@@ -96,7 +96,7 @@ test_getvalue({name})					*test_getvalue()*
 						*test_gui_event()*
 test_gui_event({event}, {args})
 		Generate a GUI {event} with arguments {args} for testing Vim
-		functionality. This function works only when the GUI is
+		functionality.  This function works only when the GUI is
 		running.
 
 		{event} is a String and the supported values are:
@@ -116,7 +116,7 @@ test_gui_event({event}, {args})
 		    files:	List of file names
 		    row:	window row number
 		    col:	window column number
-		    modifiers:	key modifiers. The supported values are:
+		    modifiers:	key modifiers.  The supported values are:
 				    0x4	Shift
 				    0x8	Alt
 				   0x10	Ctrl
@@ -131,7 +131,7 @@ test_gui_event({event}, {args})
 		  in {args} are:
 		    find_text:	string to find.
 		    repl_text:	replacement string.
-		    flags:	flags controlling the find/replace. Supported
+		    flags:	flags controlling the find/replace.  Supported
 				values are:
 				    1	search next string (find dialog)
 				    2	search next string (replace dialog)
@@ -176,7 +176,7 @@ test_gui_event({event}, {args})
 		  Set or drag the left, right or horizontal scrollbar.  Only
 		  works when the scrollbar actually exists.  The supported
 		  items in {args} are:
-		    which:	Selects the scrollbar. The supported values
+		    which:	Selects the scrollbar.  The supported values
 				are:
 				    left  Left scrollbar of the current window
 				    right Right scrollbar of the current window
@@ -202,14 +202,14 @@ test_gui_event({event}, {args})
 
 		"tabline":
 		  Inject a mouse click event on the tabline to select a
-		  tabpage. The supported items in {args} are:
+		  tabpage.  The supported items in {args} are:
 		    tabnr:	tab page number
 
 		"tabmenu":
-		  Inject an event to select a tabline menu entry. The
+		  Inject an event to select a tabline menu entry.  The
 		  supported items in {args} are:
 		    tabnr:	tab page number
-		    item:	tab page menu item number. 1 for the first
+		    item:	tab page menu item number.  1 for the first
 				menu item, 2 for the second item and so on.
 
 		After injecting the GUI events you probably should call
@@ -299,7 +299,7 @@ test_mswin_event({event}, {args})		*test_mswin_event()*
 				    8	alt is pressed
 				Note: These values are different from the
 				mouse modifiers.
-		    execute:	Optional. Similar to |feedkeys()| mode x.
+		    execute:	Optional.  Similar to |feedkeys()| mode x.
 				When this is included and set to true
 				(non-zero) then Vim will process any buffered
 				unprocessed key events.  All other {args}
@@ -307,8 +307,8 @@ test_mswin_event({event}, {args})		*test_mswin_event()*
 
 		"set_keycode_trans_strategy":
 		  |w32-experimental-keycode-trans-strategy|
-		  Switch the keycode translation method. The supported methods
-		  are:
+		  Switch the keycode translation method.  The supported
+		  methods are:
 		    experimental:   The method used after Patch v8.2.4807
 				    using ToUnicode() Win API call.
 		    classic:	    The method used pre Patch v8.2.4807
@@ -323,55 +323,55 @@ test_mswin_event({event}, {args})		*test_mswin_event()*
 		Return type: |vim9-boolean|
 
 test_null_blob()					*test_null_blob()*
-		Return a |Blob| that is null. Only useful for testing.
+		Return a |Blob| that is null.  Only useful for testing.
 
 		Return type: |Blob|
 
 test_null_channel()					*test_null_channel()*
-		Return a |Channel| that is null. Only useful for testing.
+		Return a |Channel| that is null.  Only useful for testing.
 		{only available when compiled with the +channel feature}
 
 		Return type: |Channel|
 
 test_null_dict()					*test_null_dict()*
-		Return a |Dict| that is null. Only useful for testing.
+		Return a |Dict| that is null.  Only useful for testing.
 
 		Return type: dict<any>
 
 test_null_function()					*test_null_function()*
-		Return a |Funcref| that is null. Only useful for testing.
+		Return a |Funcref| that is null.  Only useful for testing.
 
 		Return type: func(...): unknown
 
 test_null_job()						*test_null_job()*
-		Return a |Job| that is null. Only useful for testing.
+		Return a |Job| that is null.  Only useful for testing.
 		{only available when compiled with the +job feature}
 
 		Return type: |job|
 
 test_null_list()					*test_null_list()*
-		Return a |List| that is null. Only useful for testing.
+		Return a |List| that is null.  Only useful for testing.
 
 		Return type: list<any>
 
 test_null_partial()					*test_null_partial()*
-		Return a |Partial| that is null. Only useful for testing.
+		Return a |Partial| that is null.  Only useful for testing.
 
 		Return type: func(...): unknown
 
 test_null_string()					*test_null_string()*
-		Return a |String| that is null. Only useful for testing.
+		Return a |String| that is null.  Only useful for testing.
 
 		Return type: |String|
 
 test_null_tuple()					*test_null_tuple()*
-		Return a |Tuple| that is null. Only useful for testing.
+		Return a |Tuple| that is null.  Only useful for testing.
 
 		Return type: |Tuple|
 
 test_option_not_set({name})				*test_option_not_set()*
 		Reset the flag that indicates option {name} was set.  Thus it
-		looks like it still has the default value. Use like this: >
+		looks like it still has the default value.  Use like this: >
 			set ambiwidth=double
 			call test_option_not_set('ambiwidth')
 <		Now the 'ambiwidth' option behaves like it was never changed,
@@ -384,8 +384,8 @@ test_option_not_set({name})				*test_option_not_set()*
 		Return type: |Number|
 
 test_override({name}, {val})				*test_override()*
-		Overrides certain parts of Vim's internal processing to be able
-		to run tests. Only to be used for testing Vim!
+		Overrides certain parts of Vim's internal processing to be
+		able to run tests.  Only to be used for testing Vim!
 		The override is enabled when {val} is non-zero and removed
 		when {val} is zero.
 		Current supported values for {name} are:
@@ -422,7 +422,7 @@ test_override({name}, {val})				*test_override()*
 
 		"starting" is to be used when a test should behave like
 		startup was done.  Since the tests are run by sourcing a
-		script the "starting" variable is non-zero. This is usually a
+		script the "starting" variable is non-zero.  This is usually a
 		good thing (tests run faster), but sometimes this changes
 		behavior in a way that the test doesn't work properly.
 		When using: >
@@ -481,12 +481,12 @@ test_srand_seed([{seed}])				*test_srand_seed()*
 		Return type: |Number|
 
 test_unknown()						*test_unknown()*
-		Return a value with unknown type. Only useful for testing.
+		Return a value with unknown type.  Only useful for testing.
 
 		Return type: unknown
 
 test_void()						*test_void()*
-		Return a value with void type. Only useful for testing.
+		Return a value with void type.  Only useful for testing.
 
 		Return type: void
 
@@ -565,7 +565,7 @@ assert_fails({cmd} [, {error} [, {msg} [, {lnum} [, {context}]]]])
 		error message.  Also see |assert-return|.
 							*E856*
 		When {error} is a string it must be found literally in the
-		first reported error. Most often this will be the error code,
+		first reported error.  Most often this will be the error code,
 		including the colon, e.g. "E123:". >
 			call assert_fails('bad cmd', 'E987:')
 <
@@ -575,8 +575,8 @@ assert_fails({cmd} [, {error} [, {msg} [, {lnum} [, {context}]]]])
 			call assert_fails('cmd', ['E987:.*expected bool'])
 <		The second pattern, if present, is matched against the last
 		reported error.
-		If there is only one error then both patterns must match. This
-		can be used to check that there is only one error.
+		If there is only one error then both patterns must match.
+		This can be used to check that there is only one error.
 		To only match the last error use an empty string for the first
 		error: >
 			call assert_fails('cmd', ['', 'E987:'])
@@ -586,7 +586,7 @@ assert_fails({cmd} [, {error} [, {msg} [, {lnum} [, {context}]]]])
 							*E1115*
 		When {lnum} is present and not negative, and the {error}
 		argument is present and matches, then this is compared with
-		the line number at which the error was reported. That can be
+		the line number at which the error was reported.  That can be
 		the line number in a function or in a script.
 							*E1116*
 		When {context} is present it is used as a pattern and matched
@@ -609,7 +609,7 @@ assert_false({actual} [, {msg}])			*assert_false()*
 		location of the assert when run from a script.
 		Also see |assert-return|.
 
-		A value is false when it is zero. When {actual} is not a
+		A value is false when it is zero.  When {actual} is not a
 		number the assert fails.
 
 		Can also be used as a |method|: >

--- a/runtime/doc/textprop.txt
+++ b/runtime/doc/textprop.txt
@@ -194,7 +194,7 @@ prop_add({lnum}, {col}, {props})
 		the property type does not have "end_incl" set.
 
 		"type" will first be looked up in the buffer the property is
-		added to. When not found, the global property types are used.
+		added to.  When not found, the global property types are used.
 		If not found an error is given.
 							*virtual-text*
 		When "text" is used and the column is non-zero then this text
@@ -329,14 +329,14 @@ prop_list({lnum} [, {props}])				*prop_list()*
 				A negative value is used as an offset from the
 				last buffer line; -1 refers to the last buffer
 				line.
-		   types	List of property type names. Return only text
+		   types	List of property type names.  Return only text
 				properties that match one of the type names.
-		   ids		List of property identifiers. Return only text
-				properties with one of these identifiers.
+		   ids		List of property identifiers.  Return only
+				text properties with one of these identifiers.
 
 		The properties are ordered by starting column and priority.
 		Each property is a Dict with these entries:
-		   lnum		starting line number. Present only when
+		   lnum		starting line number.  Present only when
 				returning text properties between {lnum} and
 				{end_lnum}.
 		   col		starting column

--- a/runtime/doc/tips.txt
+++ b/runtime/doc/tips.txt
@@ -183,10 +183,10 @@ To make this easier, you could use these mappings: >
 You then lose the ability to copy text from the line above/below the cursor
 |i_CTRL-E|.
 
-Also consider setting 'scrolloff' to a larger value, so that you can always see
-some context around the cursor.  If 'scrolloff' is bigger than half the window
-height, the cursor will always be in the middle and the text is scrolled when
-the cursor is moved up/down.
+Also consider setting 'scrolloff' to a larger value, so that you can always
+see some context around the cursor.  If 'scrolloff' is bigger than half the
+window height, the cursor will always be in the middle and the text is
+scrolled when the cursor is moved up/down.
 
 ==============================================================================
 Smooth scrolling					*scroll-smooth*

--- a/runtime/doc/undo.txt
+++ b/runtime/doc/undo.txt
@@ -112,7 +112,7 @@ parts.  E.g., for each sentence.  |i_CTRL-G_u|
 
 Setting the value of 'undolevels' also closes the undo block.  Even when the
 new value is equal to the old value.  Use `g:undolevels` to explicitly read
-and write only the global value of 'undolevels'. In |Vim9| script: >
+and write only the global value of 'undolevels'.  In |Vim9| script: >
 	&g:undolevels = &g:undolevels
 In legacy script: >
 	let &g:undolevels = &g:undolevels
@@ -156,7 +156,7 @@ This is explained in the user manual: |usr_32.txt|.
 			    MM/DD HH:MM:SS       idem, with month and day
 			    YYYY/MM/DD HH:MM:SS  idem, with year
 			The "saved" column specifies, if this change was
-			written to disk and which file write it was. This can
+			written to disk and which file write it was.  This can
 			be used with the |:later| and |:earlier| commands.
 			For more details use the |undotree()| function.
 
@@ -256,7 +256,7 @@ for, you can use a BufWritePre autocommand: >
 	au BufWritePre /tmp/* setlocal noundofile
 
 Vim saves undo trees in a separate undo file, one for each edited file, using
-a simple scheme that maps filesystem paths directly to undo files. Vim will
+a simple scheme that maps filesystem paths directly to undo files.  Vim will
 detect if an undo file is no longer synchronized with the file it was written
 for (with a hash of the file contents) and ignore it when the file was changed
 after the undo file was written, to prevent corruption.  An undo file is also
@@ -285,11 +285,11 @@ respectively:
 		(the magic number at the start of the file is wrong), then
 		this fails, unless the ! was added.
 		If it exists and does look like an undo file it is
-		overwritten. If there is no undo-history, nothing will be
+		overwritten.  If there is no undo-history, nothing will be
 		written.
 		Implementation detail: Overwriting happens by first deleting
 		the existing file and then creating a new file with the same
-		name. So it is not possible to overwrite an existing undofile
+		name.  So it is not possible to overwrite an existing undofile
 		in a write-protected directory.
 
 :rundo {file}	Read undo history from {file}.
@@ -384,11 +384,12 @@ information you can use these commands: >
 
 Note use of `&l:undolevels` to explicitly read the local value of 'undolevels'
 and the use of `:setlocal` to change only the local option (which takes
-precedence over the corresponding global option value).  Saving the option value
-via the use of `&undolevels` is unpredictable; it reads either the local value
-(if one has been set) or the global value (otherwise).  Also, if a local value
-has been set, changing the option via `:set undolevels` will change both the
-global and local values, requiring extra work to save and restore both values.
+precedence over the corresponding global option value).  Saving the option
+value via the use of `&undolevels` is unpredictable; it reads either the local
+value (if one has been set) or the global value (otherwise).  Also, if a local
+value has been set, changing the option via `:set undolevels` will change both
+the global and local values, requiring extra work to save and restore both
+values.
 
 Marks for the buffer ('a to 'z) are also saved and restored, together with the
 text.

--- a/runtime/doc/userfunc.txt
+++ b/runtime/doc/userfunc.txt
@@ -65,7 +65,7 @@ define a global function.
 <
 							*:function-verbose*
 When 'verbose' is non-zero, listing a function will also display where it was
-last defined. Example: >
+last defined.  Example: >
 
     :verbose function SetFileTypeSH
 	function SetFileTypeSH(name)

--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -586,13 +586,13 @@ N  *+X11*		Unix only: can restore window title |X11|
 :redi[r] @{a-z}>>	Append messages to register {a-z}.
 
 :redi[r] @*>
-:redi[r] @+>		Redirect messages to the selection or clipboard. For
+:redi[r] @+>		Redirect messages to the selection or clipboard.  For
 			backward compatibility, the ">" after the register
-			name can be omitted. See |quotestar| and |quoteplus|.
+			name can be omitted.  See |quotestar| and |quoteplus|.
 :redi[r] @*>>
 :redi[r] @+>>		Append messages to the selection or clipboard.
 
-:redi[r] @">		Redirect messages to the unnamed register. For
+:redi[r] @">		Redirect messages to the unnamed register.  For
 			backward compatibility, the ">" after the register
 			name can be omitted.
 :redi[r] @">>		Append messages to the unnamed register.
@@ -628,16 +628,17 @@ N  *+X11*		Unix only: can restore window title |X11|
 <			If the [!] is given, restrict the output of {command}
 			to lines that do NOT match {pattern}.
 
-			{pattern} is a Vim search pattern.  Instead of enclosing
-			it in / any non-ID character (see 'isident') can be
-			used, so long as it does not appear in {pattern}.
+			{pattern} is a Vim search pattern.  Instead of
+			enclosing it in / any non-ID character (see 'isident')
+			can be used, so long as it does not appear in
+			{pattern}.
 			Without the enclosing character the pattern cannot
-			include the bar character. 'ignorecase' is not used.
+			include the bar character.  'ignorecase' is not used.
 
 			The pattern is matched against the relevant part of
-			the output, not necessarily the whole line. Only some
+			the output, not necessarily the whole line.  Only some
 			commands support filtering, try it out to check if it
-			works. Some of the commands that support filtering:
+			works.  Some of the commands that support filtering:
 			   |:#|          - filter whole line
 			   |:clist|      - filter by file name or module name
 			   |:command|    - filter by command name
@@ -706,7 +707,7 @@ N  *+X11*		Unix only: can restore window title |X11|
 						*:verb* *:verbose*
 :[count]verb[ose] {command}
 			Execute {command} with 'verbose' set to [count].  If
-			[count] is omitted one is used. ":0verbose" can be
+			[count] is omitted one is used.  ":0verbose" can be
 			used to set 'verbose' to zero.
 			The additional use of ":silent" makes messages
 			generated but not displayed.
@@ -787,10 +788,10 @@ K			Run a program to lookup the keyword under the
 :[N]sl[eep]! [N][m]	Same as above, but hide the cursor.
 
 							*:xrestore* *:xr*
-:xr[estore] [display]	Reinitializes the connection to the X11 server. Useful
-			after the X server restarts, e.g. when running Vim for
-			long time inside screen/tmux and connecting from
-			different machines.
+:xr[estore] [display]	Reinitializes the connection to the X11 server.
+			Useful after the X server restarts, e.g. when running
+			Vim for long time inside screen/tmux and connecting
+			from different machines.
 			[display] should be in the format of the $DISPLAY
 			environment variable (e.g. "localhost:10.0")
 			If [display] is	omitted, then it reinitializes the

--- a/runtime/doc/vi_diff.txt
+++ b/runtime/doc/vi_diff.txt
@@ -174,7 +174,8 @@ Multiple windows and buffers.				|windows.txt|
 	is called a hidden buffer.  Many commands and options have been added
 	for this facility.
 	Vim can also use multiple tab pages, each with one or more windows.  A
-	line with tab labels can be used to quickly switch between these pages.
+	line with tab labels can be used to quickly switch between these
+	pages.
 	|tab-page|
 
 Terminal window.					|:terminal|
@@ -1373,7 +1374,7 @@ Vim tries to support some old operating systems, however support for older
 operating systems might be dropped if maintenance becomes a burden or can no
 longer be verified.
 
-Here is the status of some operating systems. Note fully supported means,
+Here is the status of some operating systems.  Note fully supported means,
 support is verified as part of the CI test suite.
 
 System				| Status:~

--- a/runtime/doc/visual.txt
+++ b/runtime/doc/visual.txt
@@ -128,8 +128,8 @@ gN			Like |gn| but searches backward, like with `N`.
 			active it is stopped.  Only when 'mouse' option
 			contains 'n' or 'a'.  If the position is within 'so'
 			lines from the last line on the screen the text is
-			scrolled up.  If the position is within 'so' lines from
-			the first line on the screen the text is scrolled
+			scrolled up.  If the position is within 'so' lines
+			from the first line on the screen the text is scrolled
 			down.
 
 							*<RightMouse>*
@@ -352,10 +352,10 @@ all lines.
 
 								*v_b_<*
 Visual-block Shift						*v_b_>*
-The block is shifted by 'shiftwidth'.  The RHS of the block is irrelevant.  The
-LHS of the block determines the point from which to apply a right shift, and
-padding includes TABs optimally according to 'ts' and 'et'.  The LHS of the
-block determines the point up to which to shift left.
+The block is shifted by 'shiftwidth'.  The RHS of the block is irrelevant.
+The LHS of the block determines the point from which to apply a right shift,
+and padding includes TABs optimally according to 'ts' and 'et'.  The LHS of
+the block determines the point up to which to shift left.
 See |v_b_>_example|.
 See |v_b_<_example|.
 

--- a/runtime/doc/wayland.txt
+++ b/runtime/doc/wayland.txt
@@ -26,7 +26,8 @@ should equal to "gui" when running the GUI.
 
 Wayland commands:
 							*:wlrestore* *:wl*
-:wl[restore] [display]	Reinitializes the connection to the Wayland compositor.
+:wl[restore] [display]	Reinitializes the connection to the Wayland
+			compositor.
 			Useful when running Vim in a screen/tmux session that
 			continues running after the Wayland compositor
 			restarts.
@@ -105,7 +106,7 @@ To solve this problem, Vim implements a way of gaining focus in order to
 access the clipboard, by creating a temporary transparent top-level surface.
 This is by default disabled and can be enabled via the 'wlsteal' option.
 Moreover, a seat that has a keyboard is also required, see 'wlseat', and the
-xdg-shell protocol must be available. Additionally, Vim must be compiled with
+xdg-shell protocol must be available.  Additionally, Vim must be compiled with
 the |+wayland_focus_steal| feature.
 
 Note that this method can have several side effects from the result of focus

--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -72,7 +72,7 @@ Each buffer has a unique number and the number will not change within a Vim
 session.  The |bufnr()| and |bufname()| functions can be used to convert
 between a buffer name and the buffer number.  There is one exception: if a new
 empty buffer is created and it is not modified, the buffer will be re-used
-when loading another file into that buffer. This also means the buffer number
+when loading another file into that buffer.  This also means the buffer number
 will not change.
 
 The main Vim window can hold several split windows.  There are also tab pages
@@ -80,7 +80,7 @@ The main Vim window can hold several split windows.  There are also tab pages
 
 					*window-ID* *winid* *windowid*
 Each window has a unique identifier called the window ID.  This identifier
-will not change within a Vim session. The |win_getid()| and |win_id2tabwin()|
+will not change within a Vim session.  The |win_getid()| and |win_id2tabwin()|
 functions can be used to convert between the window/tab number and the
 identifier.  There is also the window number, which may change whenever
 windows are opened or closed, see |winnr()|.
@@ -142,9 +142,9 @@ that have termcap codes for italics.
 
 							*filler-lines*
 The lines after the last buffer line in a window are called filler lines.  By
-default, these lines start with a tilde (~) character. The 'eob' item in the
-'fillchars' option can be used to change this character. By default, these
-characters are highlighted as NonText (|hl-NonText|). The EndOfBuffer
+default, these lines start with a tilde (~) character.  The 'eob' item in the
+'fillchars' option can be used to change this character.  By default, these
+characters are highlighted as NonText (|hl-NonText|).  The EndOfBuffer
 highlight group (|hl-EndOfBuffer|) can be used to change the highlighting of
 the filler characters.
 
@@ -912,7 +912,7 @@ CTRL-W CTRL-F	Split current window in two.  Edit file name under cursor.
 
 CTRL-W F						*CTRL-W_F*
 		Split current window in two.  Edit file name under cursor and
-		jump to the line number following the file name. See |gF| for
+		jump to the line number following the file name.  See |gF| for
 		details on how the line number is obtained.
 
 CTRL-W gf						*CTRL-W_gf*
@@ -1217,7 +1217,7 @@ list of buffers. |unlisted-buffer|
 		Actually, the buffer isn't completely deleted, it is removed
 		from the buffer list |unlisted-buffer| and option values,
 		variables and mappings/abbreviations for the buffer are
-		cleared. Examples: >
+		cleared.  Examples: >
 		    :.,$-bdelete    " delete buffers from the current one to
 				    " last but one
 		    :%bdelete	    " delete all buffers
@@ -1244,7 +1244,7 @@ list of buffers. |unlisted-buffer|
 		related to the buffer is lost.  All marks in this buffer
 		become invalid, option settings are lost, the jumplist and
 		tagstack data will be purged, etc.  Don't use this
-		unless you know what you are doing. Examples: >
+		unless you know what you are doing.  Examples: >
 		    :.+,$bwipeout   " wipe out all buffers after the current
 				    " one
 		    :%bwipeout	    " wipe out all buffers
@@ -1428,7 +1428,7 @@ help		Contains a help file.  Will only be created with the |:help|
 		and can't be changed.  The 'buflisted' option will be reset
 		for a help buffer.
 
-terminal	A terminal window buffer, see |terminal|. The contents cannot
+terminal	A terminal window buffer, see |terminal|.  The contents cannot
 		be read or changed until the job ends.
 
 directory	Displays directory contents.  Can be used by a file explorer


### PR DESCRIPTION
Use double sentence spacing and wrap lines at 'textwidth'.  Code examples and tables were not wrapped unless this had already been done locally.

Do we update the "Last Change" header for whitespace changes?