### PR TITLE
netrw: navigate to parent folder under Windows OS 

### DIFF
--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -3945,7 +3945,8 @@ function s:NetrwBrowseChgDir(islocal, newdir, cursor, ...)
         " NetrwBrowseChgDir: go up one directory {{{3
         " --------------------------------------
 
-        let dirname = netrw#fs#Dirname(dirname)
+        " The following regexps expect '/' as path separator
+        let dirname = substitute(netrw#fs#AbsPath(dirname), '\\', '/', 'ge') . '/'
 
         if w:netrw_liststyle == s:TREELIST && exists("w:netrw_treedict")
             " force a refresh

--- a/runtime/pack/dist/opt/netrw/autoload/netrw/fs.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw/fs.vim
@@ -2,18 +2,18 @@
 " THESE FUNCTIONS DON'T COMMIT TO ANY BACKWARDS COMPATIBILITY. SO CHANGES AND
 " BREAKAGES IF USED OUTSIDE OF NETRW.VIM ARE EXPECTED.
 
-let s:slash = !exists('+shellslash') || &shellslash ? '/' : '\'
 
 " netrw#fs#PathJoin: Appends a new part to a path taking different systems into consideration {{{
 
 function! netrw#fs#PathJoin(...)
+    const slash = !exists('+shellslash') || &shellslash ? '/' : '\'
     let path = ""
 
     for arg in a:000
         if empty(path)
             let path = arg
         else
-            let path .= s:slash . arg
+            let path .= slash . arg
         endif
     endfor
 
@@ -73,22 +73,14 @@ endfunction
 " netrw#fs#AbsPath: returns the full path to a directory and/or file {{{
 
 function! netrw#fs#AbsPath(path)
-    let path = a:path->substitute(s:slash . '$', '', 'e')
+    let path = a:path->substitute('[\/]$', '', 'e')
 
     " Nothing to do
     if isabsolutepath(path)
         return path
     endif
 
-    return path->fnamemodify(':p')->substitute(s:slash . '$', '', 'e')
-endfunction
-
-" }}}
-" netrw#fs#Dirname: {{{
-
-function netrw#fs#Dirname(path)
-    " Keep a slash as directory recognition pattern
-    return netrw#fs#AbsPath(a:path) . s:slash
+    return path->fnamemodify(':p')->substitute('[\/]$', '', 'e')
 endfunction
 
 " }}}


### PR DESCRIPTION
This addresses https://github.com/vim/vim/issues/18421 by fixing https://github.com/vim/vim/pull/18199#issuecomment-3350731608
> Reviewing #18421 I realized this PR only works properly on windows if `'shellslash'` is on (not the default).
> 
> The main issue is there are several places in the sources where **the directory goes up**:
> 
> * A. In the original netrw is was performed using regexp: https://github.com/vim/vim/blob/f165798184dc03895709704df864bd1e43eaf09f/runtime/pack/dist/opt/netrw/autoload/netrw.vim#L3962-L3974
>   
>   that code remains in place but is no longer functional because `dirname` no longer ends in `/`.
> * B. In the last revamp (Luca) it was performed in a devoted function:  https://github.com/vim/vim/blob/f165798184dc03895709704df864bd1e43eaf09f/runtime/pack/dist/opt/netrw/autoload/netrw/fs.vim#L89-L91
> 
> As was revamp:
> 
> * Local filesystem **goes updir** in A and B is ignored (no `/` ending).
> * SSH paths: neither A nor B goes updir (the original PR issue):
>   
>   * A just remove the terminal `/`
>   * B doesn't work without terminal `/`.
> 
> After this PR B never **goes updir** and A does the job again ... at least if `'shellslash`' is on. If `'shellslash`' is off (default) then A fails because `dirname` ends in `\` instead.
> 
> The fix is not as easy as using `/` in `netrw#fs#Dirname()` because the A regex expect all separators to be `/`. The easiest workaround is normalizing all _path separators_ to `/` before using the regexp or modify the regexp to cope with any separator.
