### PR TITLE
NSIS: Getting the Vim version number via makensis

### DIFF
--- a/Filelist
+++ b/Filelist
@@ -641,7 +641,6 @@ SRC_DOS =	\
 		src/xxd/Make_mvc.mak \
 		nsis/auxiliary.nsh \
 		nsis/gvim.nsi \
-		nsis/gvim_version.nsh \
 		nsis/icons/README.txt \
 		nsis/Makefile \
 		nsis/Make_mvc.mak \

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ MINOR = 1
 # - Update Vim version number.  For a test version in: src/version.h,
 #   READMEdir/Contents, MAJOR/MINOR above, VIMMAJOR and VIMMINOR in
 #   src/Makefile, README.txt, README.md, src/README.md, READMEdir/README*.txt,
-#   runtime/doc/*.txt and make nsis/gvim_version.nsh.
+#   runtime/doc/*.txt.
 #   For a minor/major version: src/GvimExt/GvimExt.reg, src/vim.manifest.
 # - Compile Vim with GTK, Perl, Python, Python3, TCL, Ruby, Lua, Cscope and
 #   "huge" features.  Add MZscheme if you can make it work.
@@ -410,7 +410,7 @@ amisrc: dist prepare
 	mv dist/vim$(VERSION)src.tar.gz dist/vim$(VERSION)src.tgz
 
 # MS-DOS sources
-dossrc: dist dist/$(COMMENT_SRC) license nsis/gvim_version.nsh
+dossrc: dist dist/$(COMMENT_SRC) license
 	-rm -rf dist/vim$(VERSION)src.zip
 	-rm -rf dist/vim
 	mkdir dist/vim
@@ -423,7 +423,6 @@ dossrc: dist dist/$(COMMENT_SRC) license nsis/gvim_version.nsh
 		$(SRC_DOS_UNIX) \
 		lang/LICENSE.*.txt \
 		lang/README.*.txt \
-		nsis/gvim_version.nsh \
 		| (cd dist/vim/$(VIMRTDIR); tar xf -)
 	mv dist/vim/$(VIMRTDIR)/runtime/* dist/vim/$(VIMRTDIR)
 	rmdir dist/vim/$(VIMRTDIR)/runtime
@@ -431,9 +430,6 @@ dossrc: dist dist/$(COMMENT_SRC) license nsis/gvim_version.nsh
 
 license:
 	cd nsis && $(MAKE) -f Makefile $@
-
-nsis/gvim_version.nsh: Makefile
-	cd nsis && $(MAKE) -f Makefile $(@F)
 
 dosrt: dist dist/$(COMMENT_RT) dosrt_files
 	-rm -rf dist/vim$(VERSION)rt.zip

--- a/nsis/Make_mvc.mak
+++ b/nsis/Make_mvc.mak
@@ -1,59 +1,11 @@
 #
 # Makefile for MS Windows for create self-installing exe of Vim.
-# 2024‐04-05, Restorer, restorer@mail2k.ru
+# 2025‐10-02, Restorer, restorer@mail2k.ru
 #
 
 
 # included common tools
 !INCLUDE ..\src\auto\nmake\tools.mak
-
-# Read MAJOR and MINOR from version.h.
-!IFNDEF MAJOR
-! IF ![for /F "tokens=3" %G in \
-	('findstr /RC:"VIM_VERSION_MAJOR[	^]*[0-9^]" ..\src\version.h') \
-	do @(echo:MAJOR=%G>> .\_major.tmp)]
-!  INCLUDE .\_major.tmp
-!  IF [$(RM) .\_major.tmp]
-!  ENDIF
-! ELSE
-MAJOR = 9
-! ENDIF
-!ENDIF
-
-!IFNDEF MINOR
-! IF ![for /F "tokens=3" %G in \
-	('findstr /RC:"VIM_VERSION_MINOR[	^]*[0-9^]" ..\src\version.h') \
-	do @(echo:MINOR=%G>> .\_minor.tmp)]
-!  INCLUDE .\_minor.tmp
-!  IF [$(RM) .\_minor.tmp]
-!  ENDIF
-! ELSE
-MINOR = 1
-! ENDIF
-!ENDIF
-
-# Read PATCHLEVEL from version.c
-!IFNDEF PATCHLEVEL
-! IF ![for /F %G in \
-	('findstr /NBLC:"static int included_patches" ..\src\version.c \
-	^| (set /p "_t=" ^& set /a _t+=2 ^)') do \
-	@$(CMD) $(CMDFLAGS) "for /F "skip=%G delims=, " %H in \
-	(..\src\version.c) do (echo:PATCHLEVEL=%H> .\_patchlvl.tmp & exit /b)"]
-!  INCLUDE .\_patchlvl.tmp
-!  IF [$(RM) .\_patchlvl.tmp]
-!  ENDIF
-! ELSE
-PATCHLEVEL = 0
-! ENDIF
-!ENDIF
-
-!IF $(PATCHLEVEL) < 10
-PATCHLEVEL = 000$(PATCHLEVEL)
-!ELSEIF $(PATCHLEVEL) < 100
-PATCHLEVEL = 00$(PATCHLEVEL)
-!ELSEIF $(PATCHLEVEL) < 1000
-PATCHLEVEL = 0$(PATCHLEVEL)
-!ENDIF
 
 .SUFFIXES :
 
@@ -119,23 +71,13 @@ all : makeinst
 makeinst : prepare
 	^"$(MKNSIS)" $(MKNSISFLAGS) gvim.nsi $(XX)
 
-prepare : unzipicons gvim_version.nsh license rename
+prepare : unzipicons license rename
 
 unzipicons : icons.zip
 	@ if exist %|fF\nul $(RD) %|fF
 	@ $(PS) $(PSFLAGS) \
 		Add-Type -AssemblyName 'System.IO.Compression.FileSystem'; \
-		[System.IO.Compression.ZipFile]::ExtractToDirectory(\"$**\", \
-		\".\")
-
-gvim_version.nsh : Make_mvc.mak
-	@ 1> $@ echo:^# Generated from Makefile: define the version numbers
-	@ 1>> $@ echo:^!ifndef __GVIM_VER__NSH__
-	@ 1>> $@ echo:^!define __GVIM_VER__NSH__
-	@ 1>> $@ echo:^!define VER_MAJOR $(MAJOR)
-	@ 1>> $@ echo:^!define VER_MINOR $(MINOR)
-	@ 1>> $@ echo:^!define PATCHLEVEL $(PATCHLEVEL)
-	@ 1>> $@ echo:^!endif
+		[System.IO.Compression.ZipFile]::ExtractToDirectory('$**', '.')
 
 license : ..\lang\LICENSE.*.txt ..\LICENSE
 	!@ $(PS) $(PSFLAGS) \
@@ -146,7 +88,6 @@ rename :
 	@ ..\tools\rename.bat "$(SRC)" "$(DST)" 1> nul
 
 clean :
-	@ if exist .\gvim_version.nsh $(RM) .\gvim_version.nsh
 	@ if exist ..\lang\LICENSE*.nsis.txt $(RM) ..\lang\LICENSE*.nsis.txt
 	@ if exist .\icons\nul $(RD) .\icons
 	@ if exist .\gvim??.exe $(RM) .\gvim??.exe

--- a/nsis/Makefile
+++ b/nsis/Makefile
@@ -1,6 +1,6 @@
 #
 # Makefile for UNIX-like for create self-installing exe of Vim.
-# 15/12/2024, Restorer restorer@mail2k.ru
+# 2025-10-02, Restorer, restorer@mail2k.ru
 #
 
 
@@ -51,13 +51,6 @@ ifdef X
 XX := -X"$(X:;=" -X")"
 endif
 
-MAJOR != grep -E 'VIM_VERSION_MAJOR\s{2,}' ../src/version.h | \
-	awk '{ printf "%d",$$3 }'
-MINOR != grep -E 'VIM_VERSION_MINOR\s{2,}' ../src/version.h | \
-	awk '{ printf "%d",$$3 }'
-PATCH != awk '/number below this line/,/,/' ../src/version.c | \
-	awk 'NR == 3 { printf "%04d",$$1 }' | sed -e 's/[ ,]//g'
-
 MKNSISFLAGS := -INPUTCHARSET UTF8 $(MKNSISFLAGS)
 
 all: makeinst
@@ -65,20 +58,11 @@ all: makeinst
 makeinst: prepare
 	makensis $(MKNSISFLAGS) gvim.nsi $(XX)
 
-prepare: unzipicons gvim_version.nsh license rename
+prepare: unzipicons license rename
 
 unzipicons: icons.zip
 	if test -d `basename $? .zip` ; then rm -rf `basename $? .zip` ; fi
 	unzip $?
-
-gvim_version.nsh: Makefile
-	echo "# Generated from Makefile: define the version numbers" > $@
-	echo "!ifndef __GVIM_VER__NSH__"  >> $@
-	echo "!define __GVIM_VER__NSH__"  >> $@
-	echo "!define VER_MAJOR $(MAJOR)" >> $@
-	echo "!define VER_MINOR $(MINOR)" >> $@
-	echo "!define PATCHLEVEL $(PATCH)" >> $@
-	echo "!endif" >> $@
 
 license: ../lang/LICENSE.*.txt ../LICENSE
 	for lic in $? ; do \
@@ -91,7 +75,6 @@ rename:
 	../tools/rename.bat "$(SRC)" "$(DST)"
 
 clean:
-	if test -f gvim_version.nsh ; then rm -f gvim_version.nsh ; fi
 	rm -f ../lang/LICENSE*.nsis.txt
 	if test -d icons ; then rm -rf icons ; fi
 	if test -f gvim??.exe ; then rm -f gvim??.exe ; fi

--- a/nsis/gvim.nsi
+++ b/nsis/gvim.nsi
@@ -73,11 +73,18 @@ Unicode true  ; !include defaults to UTF-8 after Unicode True since 3.0 Alpha 2
   !define INCLUDE_LIBGCC 1
 !endif
 
-!include .\gvim_version.nsh	; for version numbers
+# Get version numbers
+!getdllversion "${VIMSRC}\gvim_ole.exe" VimVer_
+!echo "Vim version MAJOR=${VimVer_1} MINOR=${VimVer_2} PATCHLEVEL=${VimVer_3}"
 
-# Definition of Patch for Vim.
+!ifndef VER_MAJOR
+  !define VER_MAJOR  ${VimVer_1}
+!endif
+!ifndef VER_MINOR
+  !define VER_MINOR  ${VimVer_2}
+!endif
 !ifndef PATCHLEVEL
-  !define PATCHLEVEL 0
+  !define PATCHLEVEL ${VimVer_3}
 !endif
 
 # ----------- No configurable settings below this line -----------

--- a/nsis/gvim_version.nsh
+++ b/nsis/gvim_version.nsh
@@ -1,7 +1,0 @@
-# Generated from Makefile: define the version numbers
-!ifndef __GVIM_VER__NSH__
-!define __GVIM_VER__NSH__
-!define VER_MAJOR 9
-!define VER_MINOR 1
-!define PATCHLEVEL 0
-!endif


### PR DESCRIPTION

Problem: When creating an installer, the version numbers of the Vim editor are required.
Solution: Get the major, minor, and patch numbers using makensis commands directly when compiling the installer.
This eliminates the need for additional files and third-party tools when creating the installer and is more universal.
