### PR TITLE
CI: stop using macos-13 runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -391,7 +391,7 @@ jobs:
       fail-fast: false
       matrix:
         features: [tiny, normal, huge]
-        runner: [macos-13, macos-15]
+        runner: [macos-15-intel, macos-15]
 
     steps:
       - name: Checkout repository from github
@@ -402,12 +402,6 @@ jobs:
         run: |
           brew install lua libtool
           echo "LUA_PREFIX=$(brew --prefix)" >> $GITHUB_ENV
-
-      - name: Set up Xcode
-        if: matrix.runner == 'macos-15'
-        run: |
-          # Xcode 16 has compiler bugs which are fixed in 16.2+
-          sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
 
       - name: Set up environment
         run: |


### PR DESCRIPTION
> The macOS 13 runner image will be retired by December 4th, 2025.

Update to the macos-15-intel runner.

It seems that runners ending with "large" require an enterprise plan, so
macos-15-intel is the only other available macOS Intel runner.

Also both macOS 15 runners now use Xcode 16.4 by default, so there is no
need to install it manually.
