### PR TITLE
if_perl: Removed support for Perl < 5.005

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -3120,9 +3120,8 @@ lintinstall:
 	$(CCC) $<
 
 auto/if_perl.c: if_perl.xs
-	$(PERL) -e 'unless ( $$] >= 5.005 ) { for (qw(na defgv errgv)) { print "#define PL_$$_ $$_\n" }}' > $@
 	$(PERL) $(PERL_XSUBPP) -prototypes -typemap \
-	    $(PERLLIB)/ExtUtils/typemap if_perl.xs >> $@
+	    $(PERLLIB)/ExtUtils/typemap if_perl.xs > $@
 
 auto/osdef.h: auto/config.h osdef.sh osdef1.h.in osdef2.h.in
 	CC="$(CC) $(OSDEF_CFLAGS)" srcdir=$(srcdir) sh $(srcdir)/osdef.sh


### PR DESCRIPTION
Perl 5.005 was released in 1998. It's too old, so I don't think it needs support.
I changed the src/Makefile rule that generates auto/if_perl.c to directly execute xsubpp and redirect the output to the target file.