### PR TITLE
docs: improve visual alignment in usr_04.txt

### DIFF
--- a/runtime/doc/usr_04.txt
+++ b/runtime/doc/usr_04.txt
@@ -1,4 +1,4 @@
-*usr_04.txt*	For Vim version 9.1.  Last change: 2021 Feb 22
+*usr_04.txt*	For Vim version 9.1.  Last change: 2025 Oct 3
 
 		     VIM USER MANUAL - by Bram Moolenaar
 
@@ -280,8 +280,8 @@ move the cursor to where you want to put the line and use the "p" (put)
 command.  The line is inserted on the line below the cursor.
 
 	a line		a line	      a line
-	line 2	  dd	line 3	  p   line 3
-	line 3			      line 2
+	line 2	  dd	line 3	      line 3
+	line 3			  p   line 2
 
 Because you deleted an entire line, the "p" command placed the text line below
 the cursor.  If you delete part of a line (a word, for instance), the "p"


### PR DESCRIPTION
## Summary
Improved the visual alignment in `usr_04.txt` (04.5 Moving text) command example to make the operation flow more intuitive for beginners.

## Changes Made
- Adjusted line alignment in the example to clearly show which line is being operated on.
- Makes the relationship between delete and put operations more visually apparent.

## Before
```
a line          a line	  a line
line 2     dd line 3    p line 3
line 3                         line 2
```

## After 
```
a line          a line       a line
line 2     dd line 3       line 3
line 3                       p line 2
```

This adjustment helps beginners better understand that:
- `dd` deletes the second line (line 2).
- `p` pastes after the current line (line 3), resulting in the former line 2 appearing below line 3.