### PR TITLE
runtime(help): Match Vim9 return types in builtin function specifications

### DIFF
--- a/runtime/syntax/help.vim
+++ b/runtime/syntax/help.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:		Vim help file
 " Maintainer:		Doug Kearns <dougkearns@gmail.com>
-" Last Change:		2025 Sep 29
+" Last Change:		2025 Oct 03
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Quit when a (custom) syntax file was already loaded
@@ -61,6 +61,14 @@ if has_key(g:help_example_languages, "vim9")
 	\ contains=@vimLegacyTop,vimComment,vimLineComment
   syn cluster helpExampleHighlight_vim9 add=vim9LegacyHeader_HelpExample
 endif
+
+" builtin.txt
+syn region helpReturnType
+      \ start="^\t\tReturn type: "
+      \ end="^$"
+      \ contains=@vimType,helpHyperTextJump,helpSpecial
+      \ transparent
+syn match helpSpecial		contained "{type}" containedin=vimCompoundType
 
 if has("ebcdic")
   syn match helpHyperTextJump	"\\\@<!|[^"*|]\+|" contains=helpBar


### PR DESCRIPTION
Match Vim9 return types in builtin function specifications.
