### PR TITLE
Fix: Local variables shadowed by import names in legacy script

### DIFF
--- a/src/testdir/test_vim9_import.vim
+++ b/src/testdir/test_vim9_import.vim
@@ -3694,4 +3694,29 @@ def Test_import_member_initializer()
   v9.CheckScriptSuccess(lines)
 enddef
 
+def Test_import_name_conflict_with_local_variable()
+  var lines =<< trim END
+    vim9script
+
+    export class Foo
+      def Method(): string
+        return 'Method'
+      enddef
+    endclass
+  END
+  writefile(lines, 'Xvim9.vim', 'D')
+
+  lines =<< trim END
+    import './Xvim9.vim'
+
+    function! s:Main() abort
+      let Xvim9 = s:Xvim9.Foo.new()
+      call assert_equal('Method', Xvim9.Method())
+    endfunction
+
+    call s:Main()
+  END
+  v9.CheckScriptSuccess(lines)
+enddef
+
 " vim: ts=8 sw=2 sts=2 expandtab tw=80 fdm=marker


### PR DESCRIPTION
Problem:
In legacy Vim script, local variables cannot be used when their names conflict with imported namespace names.

Example that fails:

vim9.vim
```vim
vim9script

export class Foo
  def Method()
    echo 'method'
  enddef
endclass
```

example.vim
```vim
import './vim9.vim'

function! s:Main() abort
  " local variable `vim9` is same name to imported vim9.vim
  let vim9 = s:vim9.Foo.new()
  call vim9.Method() " Error: E1048: Item not found in script: Method
endfunction
```

The error occurs because `vim9.Method()` tries to look up `Method` in the imported script instead of calling the method on the local variable `vim9`.

Expected behavior:
According to `:help import-legacy`, imported namespaces must be accessed with the s: prefix in legacy script:

```vim
call s:vim9.SomeFunc()  " Access import - requires s:
call vim9.Method()      " Access local variable - no s:
```

Without `s:`, it should refer to a regular variable (local, script-local, or global), not an import.

Solution:
Check for `s:` prefix before treating a name as an import in legacy script.  This allows local variables to work normally even when their names match import names.
