### PR TITLE
runtime(doc): Add explanation for Vim's IME On MS-Windows

### DIFF
--- a/runtime/doc/mbyte.txt
+++ b/runtime/doc/mbyte.txt
@@ -1,4 +1,4 @@
-*mbyte.txt*     For Vim version 9.1.  Last change: 2025 Aug 10
+*mbyte.txt*     For Vim version 9.1.  Last change: 2025 Oct 3
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar et al.
@@ -969,6 +969,35 @@ of Windows you use.  For example, on my Windows 2000 box:
 3. Input Locales Tab
 4. Add Installed input locales -> Chinese(PRC)
    The default is still English (United Stated)
+
+
+MS-Windows IME Compatibility			*multibyte-ime-compatibility*
+
+Vim manages input methods on Windows systems via the `imm32.dll` (Input Method
+Manager).  The implementation, primarily dating back to the Windows 2000 era,
+may not be fully compatible with modern input methods.  Modern input method
+processing has shifted to the Text Services Framework (TSF), whose behavior
+may not fully align with the traditional IME interface.  For details about IME
+and TSF, refer to the Microsoft documentation website.
+
+Due to an unknown cause, Vim might incorrectly enable the Input Method (IM) in
+Normal mode upon startup when the Windows display language is set to a CJK
+language.  To work around this issue, try adding the following configuration
+to your |gvimrc| file: >
+
+	autocmd VimEnter * set imdisable | set noimdisable
+<
+If you make any progress in diagnosing or resolving these issues, feedback is
+welcome.
+
+NOTE: IME behavior can vary due to differences in implementations by different
+vendors.  If you encounter issues with a specific input method, it is
+recommended to test with an alternative one.
+
+For proper integration with Vim's `multi_byte_ime` system, changes in the
+input method's status must be detectable by the `ImmGetOpenStatus()` function.
+Currently, some input methods that support multi-language input may have
+internal state changes that gVim cannot capture.
 
 
 Cursor color when IME or XIM is on				*CursorIM*

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -9097,6 +9097,7 @@ multi-lang	mlang.txt	/*multi-lang*
 multi-repeat	repeat.txt	/*multi-repeat*
 multibyte	mbyte.txt	/*multibyte*
 multibyte-ime	mbyte.txt	/*multibyte-ime*
+multibyte-ime-compatibility	mbyte.txt	/*multibyte-ime-compatibility*
 multibyte-input	mbyte.txt	/*multibyte-input*
 multilang	mlang.txt	/*multilang*
 multilang-menus	mlang.txt	/*multilang-menus*


### PR DESCRIPTION
This update enhances the Vim documentation by providing critical technical context for Windows IME support. It clarifies that the legacy imm32.dll-based implementation is inherently incompatible with modern input methods and the TSF framework, which explains persistent state synchronization issues. By documenting the root cause and known limitations, we set clear user expectations and provide essential workarounds, reducing frustration and unnecessary bug reports.

relate: #10513