### PR TITLE
tests: no test for displaying 'foldcolumn' with Unicode "foldinner"

### DIFF
--- a/runtime/doc/version9.txt
+++ b/runtime/doc/version9.txt
@@ -1,4 +1,4 @@
-*version9.txt*  For Vim version 9.1.  Last change: 2025 Oct 03
+*version9.txt*  For Vim version 9.1.  Last change: 2025 Oct 04
 
 
 		  VIM REFERENCE MANUAL    by Bram Moolenaar
@@ -322,8 +322,6 @@ Improvements in 'fillchars':
   "eob" in 'fillchars'.
 - Support for using multibyte items with the "stl", "stlnc", "foldopen",
   "foldclose" and "foldsep" items in the 'fillchars' option.
-- Support for configuring the character used inside a fold level region using
-  "foldinner" in 'fillchars'.
 
 Support for the XChaCha20 encryption method. 'cryptmethod'
 
@@ -41717,6 +41715,8 @@ Options: ~
 - Setting 'nowrap' in a modeline could cause long lines to be hidden
   off-screen.  To make this visible, the listchars "extend" suboption is set
   to ">" by default, indicating text that extends beyond the window width.
+- Support for configuring the character used inside a fold level region using
+  "foldinner" in 'fillchars'.
 
 Ex commands: ~
 - allow to specify a priority when defining a new sign |:sign-define|

--- a/src/testdir/test_display.vim
+++ b/src/testdir/test_display.vim
@@ -340,7 +340,6 @@ func Test_fold_fillchars()
         \ ]
   call assert_equal(expected, lines)
 
-  " check setting foldinner
   set fdc=1 foldmethod=indent foldlevel=10
   call setline(1, ['one', '	two', '	two', '		three', '		three', 'four'])
   let lines = ScreenLines([1, 6], 22)
@@ -354,6 +353,7 @@ func Test_fold_fillchars()
         \ ]
   call assert_equal(expected, lines)
 
+  " check setting foldinner
   set fillchars+=foldinner:\ 
   let lines = ScreenLines([1, 6], 22)
   let expected = [
@@ -363,6 +363,42 @@ func Test_fold_fillchars()
         \ '[                three',
         \ '                 three',
         \ ' four                 ',
+        \ ]
+  call assert_equal(expected, lines)
+
+  " check Unicode chars
+  set fillchars=foldopen:▼,foldclose:▶,fold:⋯,foldsep:‖,foldinner:⋮
+  let lines = ScreenLines([1, 6], 22)
+  let expected = [
+        \ ' one                  ',
+        \ '▼        two          ',
+        \ '‖        two          ',
+        \ '▼                three',
+        \ '⋮                three',
+        \ ' four                 ',
+        \ ]
+  call assert_equal(expected, lines)
+
+  set fillchars-=foldinner:⋮
+  let lines = ScreenLines([1, 6], 22)
+  let expected = [
+        \ ' one                  ',
+        \ '▼        two          ',
+        \ '‖        two          ',
+        \ '▼                three',
+        \ '2                three',
+        \ ' four                 ',
+        \ ]
+  call assert_equal(expected, lines)
+
+  normal! 5ggzc
+  let lines = ScreenLines([1, 5], 24)
+  let expected = [
+        \ ' one                    ',
+        \ '▼        two            ',
+        \ '‖        two            ',
+        \ '▶+---  2 lines: three⋯⋯⋯',
+        \ ' four                   ',
         \ ]
   call assert_equal(expected, lines)
 


### PR DESCRIPTION
Problem:  tests: no test for displaying 'foldcolumn' with Unicode
          "foldinner" in 'fillchars'.
Solution: Add a few more test cases.  Also fix misplaced "foldinner"
          entry in version9.txt.
