### PR TITLE
runtime: add self to `:h credits`

### DIFF
--- a/runtime/doc/intro.txt
+++ b/runtime/doc/intro.txt
@@ -268,6 +268,8 @@ Vim would never have become what it is now, without the help of these people!
 	Kazunobu Kuriyama	GTK 3
 	Christian Brabandt	many fixes, features, user support, etc.
 	Yegappan Lakshmanan	many quickfix features
+	Girish Palya		insert & cmdline autocompletion,
+				search/substitute completion, etc.
 
 I wish to thank all the people that sent me bug reports and suggestions.  The
 list is too long to mention them all here.  Vim would not be the same without


### PR DESCRIPTION

This PR adds myself to the Vim credits for my contributions to the completion system. My contributions include:
 
- **Insert mode autocompletion** (`:help ins-autocompletion`) [[1](https://github.com/vim/vim/pull/17812), [2](https://github.com/vim/vim/pull/17960), [3](https://github.com/vim/vim/pull/17967), [4](https://github.com/vim/vim/pull/18387)]  
- Support for **external completion sources (e.g. LSP)** [[1](https://github.com/vim/vim/pull/17065), [2](https://github.com/vim/vim/pull/17651), [3](https://github.com/vim/vim/pull/17396)]  
- **Command-line autocompletion** and enhancements (`:help cmdline-autocompletion`) [[1](https://github.com/vim/vim/pull/17806), [2](https://github.com/vim/vim/pull/16759), [3](https://github.com/vim/vim/pull/17115)]  
- **Completion for search and replace commands (`/`, `?`, `s`, `g`, `v`, etc.)** [[1](https://github.com/vim/vim/pull/17570), [2](https://github.com/vim/vim/pull/17667)]
- Integration of a **better fuzzy matching algorithm** [[1](https://github.com/vim/vim/pull/17900)]  
- **Completion menu usability improvements** [[1](https://github.com/vim/vim/pull/17076), [2](https://github.com/vim/vim/pull/17087)]  

All of my merged PRs (~80) can be found here:: https://github.com/vim/vim/pulls?q=is%3Apr+author%3Agirishji