### PR TITLE
runtime(filetype): update KerML comments to handle more cases

### DIFF
--- a/runtime/ftplugin/kerml.vim
+++ b/runtime/ftplugin/kerml.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin
 " Language:         KerML
 " Author:           Daumantas Kavolis <daumantas.kavolis@sensmetry.com>
-" Last Change:      2025-10-03
+" Last Change:      2025-10-06
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin")
@@ -11,9 +11,11 @@ endif
 " Don't load another plugin for this buffer
 let b:did_ftplugin = 1
 
-" Set 'comments' to format dashed lists in comments.
-setlocal comments=sO:*\ -,mO:*\ \ ,exO:*/,s1://*,mb:*,ex:*/,:///,://
-setlocal commentstring=//*\ %s\ */
+" Set 'comments' to format dashed and starred lists in comments,
+" include /*...*/ in 'comments' for formatting even if it technically
+" is not
+setlocal comments=sO:*\ -,mO:*\ \ ,exO:*/,sO:*\ *,mO:*\ \ ,exO:*/,sr://*,mb:*,ex:*/,sr:/*,mb:*,ex:*/,:///,://
+setlocal commentstring=//\ %s
 
 " Set 'formatoptions' to break comment lines but not other lines,
 " and insert the comment leader when hitting <CR> or using "o"


### PR DESCRIPTION
This PR updates KerML `comments` with more cases:

- In addition to dashed lists, added starred lists for compatibility with markdown documentation and preview.
- Added `/* ... */` so that comment formatting applies to them. These should be used far more often than multiline comments (`//* ... */`) as they are directly visible in the AST.

Changed to `commentstring` to single line comments as toggling multiline comment lines inside or around other multiline comments may break parsers.