### PR TITLE
'culopt' "screenline" not redrawn with line("w0") and :retab

### DIFF
--- a/src/misc2.c
+++ b/src/misc2.c
@@ -60,11 +60,8 @@ coladvance_force(colnr_T wcol)
     if (wcol == MAXCOL)
 	curwin->w_valid &= ~VALID_VIRTCOL;
     else
-    {
 	// Virtcol is valid
-	curwin->w_valid |= VALID_VIRTCOL;
-	curwin->w_virtcol = wcol;
-    }
+	set_valid_virtcol(curwin, wcol);
     return rc;
 }
 
@@ -101,11 +98,8 @@ coladvance(colnr_T wantcol)
     if (wantcol == MAXCOL || rc == FAIL)
 	curwin->w_valid &= ~VALID_VIRTCOL;
     else if (*ml_get_cursor() != TAB)
-    {
 	// Virtcol is valid when not on a TAB
-	curwin->w_valid |= VALID_VIRTCOL;
-	curwin->w_virtcol = wantcol;
-    }
+	set_valid_virtcol(curwin, wantcol);
     return rc;
 }
 

--- a/src/move.c
+++ b/src/move.c
@@ -194,6 +194,20 @@ redraw_for_cursorcolumn(win_T *wp)
 #endif
 
 /*
+ * Set wp->w_virtcol to a value ("vcol") that is already valid.
+ * Handles redrawing if wp->w_virtcol was previously invalid.
+ */
+    void
+set_valid_virtcol(win_T *wp, colnr_T vcol)
+{
+    wp->w_virtcol = vcol;
+#ifdef FEAT_SYN_HL
+    redraw_for_cursorcolumn(wp);
+#endif
+    wp->w_valid |= VALID_VIRTCOL;
+}
+
+/*
  * Calculates how much the 'listchars' "precedes" or 'smoothscroll' "<<<"
  * marker overlaps with buffer text for window "wp".
  * Parameter "extra2" should be the padding on the 2nd line, not the first

--- a/src/proto/move.pro
+++ b/src/proto/move.pro
@@ -1,5 +1,6 @@
 /* move.c */
 int adjust_plines_for_skipcol(win_T *wp);
+void set_valid_virtcol(win_T *wp, colnr_T vcol);
 int sms_marker_overlap(win_T *wp, int extra2);
 void update_topline_redraw(void);
 void update_topline(void);

--- a/src/testdir/dumps/Test_cursorline_screenline_3.dump
+++ b/src/testdir/dumps/Test_cursorline_screenline_3.dump
@@ -1,0 +1,8 @@
+|x+0&#ffffff0|y|z| |x|y|z| |x|y|z| |x|y|z| |x|y|z| |x|y|z| |x|y|z| |x|y|z| |x|y|z| |x|y|z| |x|y|z| |x|y|z| |x|y|z| |x|y|z| |x|y|z| |x|y|z| |x|y|z| |x|y|z| |x|y|z
+> +8&&|x|y|z| |x|y|z| |x|y|z| |x|y|z| |x|y|z| |x|y|z| |x|y|z| |x|y|z| |x|y|z| |x|y|z| |x|y|z| @30
+|~+0#4040ff13&| @73
+|~| @73
+|~| @73
+|~| @73
+|~| @73
+|-+2#0000000&@1| |I|N|S|E|R|T| |-@1| +0&&@44|1|,|7|6| @9|A|l@1| 

--- a/src/testdir/test_cursorline.vim
+++ b/src/testdir/test_cursorline.vim
@@ -292,9 +292,17 @@ func Test_cursorline_screenline_update()
   CheckScreendump
 
   let lines =<< trim END
+      func TestRetab()
+        let w = winwidth(0)
+        call cursor([1, w + 1, 0, w + 1])
+        call line('w0')
+        retab 8
+      endfunc
+
       call setline(1, repeat('xyz ', 30))
-      set cursorline cursorlineopt=screenline
+      set cursorline cursorlineopt=screenline tabstop=8
       inoremap <F2> <Cmd>call cursor(1, 1)<CR>
+      inoremap <F3> <Cmd>call TestRetab()<CR>
   END
   call writefile(lines, 'Xcul_screenline', 'D')
 
@@ -303,6 +311,8 @@ func Test_cursorline_screenline_update()
   call VerifyScreenDump(buf, 'Test_cursorline_screenline_1', {})
   call term_sendkeys(buf, "\<F2>")
   call VerifyScreenDump(buf, 'Test_cursorline_screenline_2', {})
+  call term_sendkeys(buf, "\<F3>")
+  call VerifyScreenDump(buf, 'Test_cursorline_screenline_3', {})
   call term_sendkeys(buf, "\<Esc>")
 
   call StopVimInTerminal(buf)

--- a/src/window.c
+++ b/src/window.c
@@ -7077,7 +7077,7 @@ set_fraction(win_T *wp)
  * calculate the new scroll position.
  * TODO: Ensure this also works with wrapped lines.
  * Requires a not fully visible cursor line to be allowed at the bottom of
- * a window("zb"), probably only when 'smoothscroll' is also set.
+ * a window ("zb"), probably only when 'smoothscroll' is also set.
  */
     static void
 win_fix_scroll(int resize)


### PR DESCRIPTION
Problem:  'cursorlineopt' "screenline" isn't redrawn when moving cursor
          and then using line("w0") and :retab that does nothing.
Solution: Call redraw_for_cursorcolumn() when setting a valid w_virtcol.
