### PR TITLE
docs: Add reference to 'wildoptions' in fuzzy-matching docs

### DIFF
--- a/runtime/doc/pattern.txt
+++ b/runtime/doc/pattern.txt
@@ -1551,6 +1551,7 @@ a List of strings.  |matchfuzzy()| returns the matching strings, while
 The "f" flag of `:vimgrep` enables fuzzy matching.
 
 To enable fuzzy matching for |ins-completion|, add the "fuzzy" value to the
-'completeopt' option.
+'completeopt' option.  To do so for |cmdline-completion|, add the "fuzzy"
+value to the 'wildoptions' option.
 
  vim:tw=78:ts=8:noet:ft=help:norl:


### PR DESCRIPTION
The docs for fuzzy matching seems to try to list every possible use case, but misses this one. It's a good idea to be consistent.