### PR TITLE
runtime(vim): fix indentation after `:registers +`

### DIFF
--- a/runtime/autoload/dist/vimindent.vim
+++ b/runtime/autoload/dist/vimindent.vim
@@ -341,7 +341,8 @@ const PLUS_MINUS_COMMAND: string = '^\s*[+-]\s*$'
 patterns =<< trim eval END
     {'\'}<argd\%[elete]\s\+\*\s*$
     \<[lt]\=cd!\=\s\+-\s*$
-    \<norm\%[al]!\=\s*\S\+$
+    \<norm\%[al]!\=\s\+.*$
+    \<reg\%[isters]\%(\s\+\S\+\)\+$
     \%(\<sil\%[ent]!\=\s\+\)\=\<[nvxsoilct]\=\%(nore\|un\)\=map!\=\s
     \<set\%(\%[global]\|\%[local]\)\>.*,$
     {PLUS_MINUS_COMMAND}

--- a/runtime/indent/testdir/vim.in
+++ b/runtime/indent/testdir/vim.in
@@ -218,3 +218,8 @@ endif
 set path=.,,
 set clipboard=unnamed,unnamedplus
 " END_INDENT
+
+" START_INDENT
+registers +
+echo 'text'
+" END_INDENT

--- a/runtime/indent/testdir/vim.ok
+++ b/runtime/indent/testdir/vim.ok
@@ -218,3 +218,8 @@ endif
 set path=.,,
 set clipboard=unnamed,unnamedplus
 " END_INDENT
+
+" START_INDENT
+registers +
+echo 'text'
+" END_INDENT


### PR DESCRIPTION
`:registers` is a tricky command because its (optional) argument can be conflated with an operator (e.g. `:registers +`).  Because of this, the indentation of a line following `:registers` might be wrong.  This PR tries to fix that.
