### PR TITLE
Add additional runtime features for the clipboard and fix +clipboard_working feature

### DIFF
--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -380,6 +380,12 @@ N  *+clientserver*	Unix and Win32: Remote invocation |clientserver|
    *+clipboard*		|clipboard| support compiled-in
 N  *+clipboard_provider*  |clipboard-providers| support compiled-in
    *+clipboard_working*	|clipboard| support compiled-in and working
+   *+clipboard_star_avail*
+			|clipboard| support compiled-in and star "*" register
+			available
+   *+clipboard_plus_avail*
+			|clipboard| support compiled-in and separate plus "+"
+			register available
 T  *+cmdline_compl*	command line completion |cmdline-completion|
 T  *+cmdline_hist*	command line history |cmdline-history|
 T  *+cmdline_info*	'showcmd' and 'ruler'; Always enabled since

--- a/src/clipboard.c
+++ b/src/clipboard.c
@@ -3555,7 +3555,7 @@ get_clipmethod(char_u *str, bool *regular, bool *primary)
 		*regular = reg == 1;
 		*primary = pri == 1;
 	    }
-	    else if (reg == -1)
+	    else if (reg == -1 || pri == -1)
 #endif
 	    {
 		ret = CLIPMETHOD_FAIL;

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -7930,7 +7930,21 @@ f_has(typval_T *argvars, typval_T *rettv)
 	{
 	    x = TRUE;
 #ifdef FEAT_CLIPBOARD
+	    n = clip_star.available || clip_plus.available;
+#endif
+	}
+	else if (STRICMP(name, "clipboard_star_avail") == 0)
+	{
+	    x = TRUE;
+#ifdef FEAT_CLIPBOARD
 	    n = clip_star.available;
+#endif
+	}
+	else if (STRICMP(name, "clipboard_plus_avail") == 0)
+	{
+	    x = TRUE;
+#ifdef FEAT_CLIPBOARD
+	    n = clip_plus.available && &clip_star != &clip_plus;
 #endif
 	}
     }

--- a/src/testdir/test_eval_stuff.vim
+++ b/src/testdir/test_eval_stuff.vim
@@ -727,4 +727,48 @@ func Test_eval_string_in_special_key()
   silent! echo 0{1-$"\<S--{>n|nö% 
 endfunc
 
+func AvailableTest()
+  return g:vim_test_plus .. g:vim_test_star
+endfunc
+
+func Test_clipboard_runtime_features()
+  " Use clipboard provider because we can change if a register is available or
+  " not.
+  CheckFeature clipboard_provider
+  CheckFeature clipboard
+
+    let g:vim_test_plus = ''
+    let g:vim_test_star = ''
+
+  let v:clipproviders["evaltest"] = {
+        \ "available": function("AvailableTest")
+        \ }
+
+  set clipmethod=evaltest
+
+  if has('win32') || has('macunix')
+    let g:vim_test_plus = '+'
+    let g:vim_test_star = '*'
+    clipreset
+
+    " plus register should be disabled on windows or macos
+    call assert_equal(0, has('clipboard_plus_avail'))
+    call assert_equal(1, has('clipboard_star_avail'))
+  else
+    let g:vim_test_plus = '+'
+    let g:vim_test_star = '*'
+    clipreset
+
+    call assert_equal(1, has('clipboard_plus_avail'))
+    call assert_equal(1, has('clipboard_star_avail'))
+
+    let g:vim_test_plus = ""
+    clipreset
+
+    call assert_equal(0, has('clipboard_plus_avail'))
+  endif
+
+  set clipmethod&
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
- Since either the "*" or "+" register can be available, `+clipboard_working` should check either.
- Add more runtime features `+feature` to the list