### PR TITLE
More Prompt - Go Forward/Backward One Screen With CTRL-F/CTRL-B

### DIFF
--- a/runtime/doc/message.txt
+++ b/runtime/doc/message.txt
@@ -859,26 +859,27 @@ This message is given when the screen is filled with messages.  It is only
 given when the 'more' option is on.  It is highlighted with the |hl-MoreMsg|
 group.
 
-Type					effect ~
-     <CR> or <NL> or j or <Down>	one more line
-     d					down a page (half a screen)
-     <Space> or f or <PageDown>		down a screen
-     G					down all the way, until the hit-enter
-					prompt
+Type						effect ~
+     <CR> or <NL> or j or <Down>		one more line
+     d						down a page (half a screen)
+     <Space> or f or <PageDown> or CTRL-F	down a screen
+     G						down all the way, until the
+						hit-enter prompt
 
-     <BS> or k or <Up>			one line back
-     u					up a page (half a screen)
-     b or <PageUp>			back a screen
-     g					back to the start
+     <BS> or k or <Up>				one line back
+     u						up a page (half a screen)
+     b or <PageUp> or CTRL-B			back a screen
+     g						back to the start
 
-     q, <Esc> or CTRL-C			stop the listing
-     :					stop the listing and enter a
-					     command-line
-    <C-Y>				yank (copy) a modeless selection to
-					the clipboard ("* and "+ registers)
-    {menu-entry}			what the menu is defined to in
-					Cmdline-mode.
-    <LeftMouse>				next page (*)
+     q, <Esc> or CTRL-C				stop the listing
+     :						stop the listing and enter a
+						command-line
+    <C-Y>					yank (copy) a modeless
+						selection to the clipboard
+						("* and "+ registers)
+    {menu-entry}				what the menu is defined to
+						in Cmdline-mode.
+    <LeftMouse>					next page (*)
 
 Any other key causes the meaning of the keys to be displayed.
 

--- a/src/message.c
+++ b/src/message.c
@@ -1356,7 +1356,7 @@ wait_return(int redraw)
 		*/
 		if (p_more && !p_cp)
 		{
-		    if (c == 'b' || c == 'k' || c == 'u' || c == 'g'
+		    if (c == 'b' || c == Ctrl_B || c == 'k' || c == 'u' || c == 'g'
 						|| c == K_UP || c == K_PAGEUP)
 		    {
 			if (msg_scrolled > Rows)
@@ -1385,7 +1385,7 @@ wait_return(int redraw)
 			}
 		    }
 		    else if (msg_scrolled > Rows - 2
-			    && (c == 'j' || c == 'd' || c == 'f'
+			    && (c == 'j' || c == 'd' || c == 'f' || c == Ctrl_F
 					    || c == K_DOWN || c == K_PAGEDOWN))
 			c = K_IGNORE;
 		}

--- a/src/message.c
+++ b/src/message.c
@@ -3318,12 +3318,14 @@ do_more_prompt(int typed_char)
 	    break;
 
 	case 'b':		// one page back
+	case Ctrl_B:
 	case K_PAGEUP:
 	    toscroll = -(Rows - 1);
 	    break;
 
 	case ' ':		// one extra page
 	case 'f':
+	case Ctrl_F:
 	case K_PAGEDOWN:
 	case K_LEFTMOUSE:
 	    toscroll = Rows - 1;

--- a/src/testdir/test_messages.vim
+++ b/src/testdir/test_messages.vim
@@ -343,6 +343,11 @@ func Test_message_more_scrollback()
   call term_sendkeys(buf, 'b')
   call VerifyScreenDump(buf, 'Test_more_scrollback_2', {})
 
+  call term_sendkeys(buf, "\<C-F>")
+  call TermWait(buf)
+  call term_sendkeys(buf, "\<C-B>")
+  call VerifyScreenDump(buf, 'Test_more_scrollback_2', {})
+
   call term_sendkeys(buf, 'q')
   call TermWait(buf)
   call StopVimInTerminal(buf)

--- a/src/testdir/test_messages.vim
+++ b/src/testdir/test_messages.vim
@@ -278,6 +278,13 @@ func Test_message_more()
   call WaitForAssert({-> assert_equal(':%p#', term_getline(buf, 1))})
   call WaitForAssert({-> assert_equal('-- More --', term_getline(buf, 6))})
 
+  " All the way down. Pressing Ctrl-B should not end the more prompt.
+  call term_sendkeys(buf, 'G')
+  call WaitForAssert({-> assert_equal('100 100', term_getline(buf, 5))})
+  call WaitForAssert({-> assert_equal('Press ENTER or type command to continue', term_getline(buf, 6))})
+  call term_sendkeys(buf, "\<C-B>")
+  call WaitForAssert({-> assert_equal('-- More --', term_getline(buf, 6))})
+
   " All the way down. Pressing f or Ctrl-F should do nothing but pressing
   " space should end the more prompt.
   call term_sendkeys(buf, 'G')

--- a/src/testdir/test_messages.vim
+++ b/src/testdir/test_messages.vim
@@ -278,13 +278,16 @@ func Test_message_more()
   call WaitForAssert({-> assert_equal(':%p#', term_getline(buf, 1))})
   call WaitForAssert({-> assert_equal('-- More --', term_getline(buf, 6))})
 
-  " All the way down. Pressing f should do nothing but pressing
+  " All the way down. Pressing f or Ctrl-F should do nothing but pressing
   " space should end the more prompt.
   call term_sendkeys(buf, 'G')
   call WaitForAssert({-> assert_equal('100 100', term_getline(buf, 5))})
   call WaitForAssert({-> assert_equal('Press ENTER or type command to continue', term_getline(buf, 6))})
   call term_sendkeys(buf, 'f')
   call WaitForAssert({-> assert_equal('100 100', term_getline(buf, 5))})
+  call term_sendkeys(buf, "\<C-F>")
+  call WaitForAssert({-> assert_equal('100 100', term_getline(buf, 5))})
+  call WaitForAssert({-> assert_equal('Press ENTER or type command to continue', term_getline(buf, 6))})
   call term_sendkeys(buf, ' ')
   call WaitForAssert({-> assert_equal('100', term_getline(buf, 5))})
 

--- a/src/testdir/test_messages.vim
+++ b/src/testdir/test_messages.vim
@@ -232,18 +232,20 @@ func Test_message_more()
   call term_sendkeys(buf, "\<Down>")
   call WaitForAssert({-> assert_equal('  9 9', term_getline(buf, 5))})
 
-  " Down a screen with <Space>, f, or <PageDown>.
+  " Down a screen with <Space>, f, <C-F> or <PageDown>.
   call term_sendkeys(buf, 'f')
   call WaitForAssert({-> assert_equal(' 14 14', term_getline(buf, 5))})
   call WaitForAssert({-> assert_equal('-- More --', term_getline(buf, 6))})
-  call term_sendkeys(buf, ' ')
+  call term_sendkeys(buf, "\<C-F>")
   call WaitForAssert({-> assert_equal(' 19 19', term_getline(buf, 5))})
-  call term_sendkeys(buf, "\<PageDown>")
+  call term_sendkeys(buf, ' ')
   call WaitForAssert({-> assert_equal(' 24 24', term_getline(buf, 5))})
+  call term_sendkeys(buf, "\<PageDown>")
+  call WaitForAssert({-> assert_equal(' 29 29', term_getline(buf, 5))})
 
   " Down a page (half a screen) with d.
   call term_sendkeys(buf, 'd')
-  call WaitForAssert({-> assert_equal(' 27 27', term_getline(buf, 5))})
+  call WaitForAssert({-> assert_equal(' 32 32', term_getline(buf, 5))})
 
   " Down all the way with 'G'.
   call term_sendkeys(buf, 'G')
@@ -258,15 +260,17 @@ func Test_message_more()
   call term_sendkeys(buf, "\<Up>")
   call WaitForAssert({-> assert_equal(' 97 97', term_getline(buf, 5))})
 
-  " Up a screen with b or <PageUp>.
+  " Up a screen with b, <C-B> or <PageUp>.
   call term_sendkeys(buf, 'b')
   call WaitForAssert({-> assert_equal(' 92 92', term_getline(buf, 5))})
-  call term_sendkeys(buf, "\<PageUp>")
+  call term_sendkeys(buf, "\<C-B>")
   call WaitForAssert({-> assert_equal(' 87 87', term_getline(buf, 5))})
+  call term_sendkeys(buf, "\<PageUp>")
+  call WaitForAssert({-> assert_equal(' 82 82', term_getline(buf, 5))})
 
   " Up a page (half a screen) with u.
   call term_sendkeys(buf, 'u')
-  call WaitForAssert({-> assert_equal(' 84 84', term_getline(buf, 5))})
+  call WaitForAssert({-> assert_equal(' 79 79', term_getline(buf, 5))})
 
   " Up all the way with 'g'.
   call term_sendkeys(buf, 'g')

--- a/src/testdir/test_messages.vim
+++ b/src/testdir/test_messages.vim
@@ -278,13 +278,6 @@ func Test_message_more()
   call WaitForAssert({-> assert_equal(':%p#', term_getline(buf, 1))})
   call WaitForAssert({-> assert_equal('-- More --', term_getline(buf, 6))})
 
-  " All the way down. Pressing Ctrl-B should not end the more prompt.
-  call term_sendkeys(buf, 'G')
-  call WaitForAssert({-> assert_equal('100 100', term_getline(buf, 5))})
-  call WaitForAssert({-> assert_equal('Press ENTER or type command to continue', term_getline(buf, 6))})
-  call term_sendkeys(buf, "\<C-B>")
-  call WaitForAssert({-> assert_equal('-- More --', term_getline(buf, 6))})
-
   " All the way down. Pressing f or Ctrl-F should do nothing but pressing
   " space should end the more prompt.
   call term_sendkeys(buf, 'G')


### PR DESCRIPTION
## Changes

#### Current Behavior

Currently in `vim`s "more prompt" using ctrl + f/b is not possible.\
It triggers this usage:
<img width="768" height="26" alt="more_prompt_usage" src="https://github.com/user-attachments/assets/c7334dfb-979b-4f8a-8e7a-0355912d20d5" />

#### After The Change

Moving forward or backward one screen in a more prompt with ctrl + f/b is possible.

## Rationale

Inside `vim` you move forward/backwards one screen with ctrl + f/b.\
Not being able to do this in a more prompt is **inconsistent**.

I use ctrl + f/b in a lot of tools (`bat`, `less`, `zathura`) and always \
trip over this not working in `vim`s "more prompt".