### PR TITLE
runtime(doc): Add missing optional tail command-name specs

### DIFF
--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -40,8 +40,8 @@ the |CTRL-^| command to toggle between the current and the alternate file.
 However, the alternate file name is not changed when |:keepalt| is used.
 An alternate file name is remembered for each window.
 
-							*:keepalt* *:keepa*
-:keepalt {cmd}		Execute {cmd} while keeping the current alternate file
+							*:keepa* *:keepalt*
+:keepa[lt] {cmd}	Execute {cmd} while keeping the current alternate file
 			name.  Note that commands invoked indirectly (e.g.,
 			with a function) may still set the alternate file
 			name.
@@ -1418,7 +1418,7 @@ present in 'cpoptions' and "!" is not used in the command.
 			to another window will stop using {path}.
 
 							*:lcd-*
-:lcd[!] -		Change to the previous current directory, before the
+:lc[d][!] -		Change to the previous current directory, before the
 			last ":lcd {path}" command.
 
 							*:lch* *:lchdir*

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -516,8 +516,8 @@ EXECUTE A COMMAND IN ALL THE BUFFERS IN QUICKFIX OR LOCATION LIST:
 			Also see |:bufdo|, |:tabdo|, |:argdo|, |:windo|,
 			|:ldo|, |:cfdo| and |:lfdo|.
 
-							*:cfdo*
-:cfdo[!] {cmd}		Execute {cmd} in each file in the quickfix list.
+							*:cfd* *:cfdo*
+:cfd[o][!] {cmd}	Execute {cmd} in each file in the quickfix list.
 			It works like doing this: >
 				:cfirst
 				:{cmd}
@@ -526,7 +526,7 @@ EXECUTE A COMMAND IN ALL THE BUFFERS IN QUICKFIX OR LOCATION LIST:
 				etc.
 <			Otherwise it works the same as `:cdo`.
 
-							*:ldo*
+							*:ld* *:ldo*
 :ld[o][!] {cmd}		Execute {cmd} in each valid entry in the location list
 			for the current window.
 			It works like doing this: >
@@ -538,8 +538,8 @@ EXECUTE A COMMAND IN ALL THE BUFFERS IN QUICKFIX OR LOCATION LIST:
 <			Only valid entries in the location list are used.
 			Otherwise it works the same as `:cdo`.
 
-							*:lfdo*
-:lfdo[!] {cmd}		Execute {cmd} in each file in the location list for
+							*:lfd* *:lfdo*
+:lfd[o][!] {cmd}	Execute {cmd} in each file in the location list for
 			the current window.
 			It works like doing this: >
 				:lfirst

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -2425,6 +2425,7 @@ $quote	eval.txt	/*$quote*
 :cex	quickfix.txt	/*:cex*
 :cexpr	quickfix.txt	/*:cexpr*
 :cf	quickfix.txt	/*:cf*
+:cfd	quickfix.txt	/*:cfd*
 :cfdo	quickfix.txt	/*:cfdo*
 :cfi	quickfix.txt	/*:cfi*
 :cfile	quickfix.txt	/*:cfile*
@@ -2847,6 +2848,7 @@ $quote	eval.txt	/*$quote*
 :lclose	quickfix.txt	/*:lclose*
 :lcs	if_cscop.txt	/*:lcs*
 :lcscope	if_cscop.txt	/*:lcscope*
+:ld	quickfix.txt	/*:ld*
 :ldo	quickfix.txt	/*:ldo*
 :le	change.txt	/*:le*
 :left	change.txt	/*:left*
@@ -3227,6 +3229,7 @@ $quote	eval.txt	/*$quote*
 :rubydo	if_ruby.txt	/*:rubydo*
 :rubyf	if_ruby.txt	/*:rubyf*
 :rubyfile	if_ruby.txt	/*:rubyfile*
+:rund	undo.txt	/*:rund*
 :rundo	undo.txt	/*:rundo*
 :runtime	repeat.txt	/*:runtime*
 :rv	starting.txt	/*:rv*
@@ -3720,6 +3723,7 @@ $quote	eval.txt	/*$quote*
 :write_a	editing.txt	/*:write_a*
 :write_c	editing.txt	/*:write_c*
 :write_f	editing.txt	/*:write_f*
+:wu	undo.txt	/*:wu*
 :wundo	undo.txt	/*:wundo*
 :wv	starting.txt	/*:wv*
 :wviminfo	starting.txt	/*:wviminfo*

--- a/runtime/doc/undo.txt
+++ b/runtime/doc/undo.txt
@@ -278,8 +278,8 @@ guaranteed.
 
 You can also save and restore undo histories by using ":wundo" and ":rundo"
 respectively:
-							*:wundo* *:rundo*
-:wundo[!] {file}
+							*:wu* *:wundo*
+:wu[ndo][!] {file}
 		Write undo history to {file}.
 		When {file} exists and it does not look like an undo file
 		(the magic number at the start of the file is wrong), then
@@ -292,7 +292,8 @@ respectively:
 		name. So it is not possible to overwrite an existing undofile
 		in a write-protected directory.
 
-:rundo {file}	Read undo history from {file}.
+							*:rund* *:rundo*
+:rund[o] {file}	Read undo history from {file}.
 
 You can use these in autocommands to explicitly specify the name of the
 history file.  E.g.: >

--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -1223,17 +1223,18 @@ list of buffers. |unlisted-buffer|
 		    :%bdelete	    " delete all buffers
 <
 
-:bdelete[!] {bufname}						*E93* *E94*
+:bd[elete][!] {bufname}						*E93* *E94*
 		Like ":bdelete[!] [N]", but buffer given by name, see
 		|{bufname}|.
 
-:bdelete[!] N1 N2 ...
+:bd[elete][!] N1 N2 ...
 		Do ":bdelete[!]" for buffer N1, N2, etc.  The arguments can be
 		buffer numbers or buffer names (but not buffer names that are
 		a number).  Insert a backslash before a space in a buffer
 		name.
 
-:N,Mbdelete[!]	Do ":bdelete[!]" for all buffers in the range N to M
+:N,Mbd[elete][!]
+		Do ":bdelete[!]" for all buffers in the range N to M
 		|inclusive|.
 
 :[N]bw[ipeout][!]			*:bw* *:bwipe* *:bwipeout* *E517*
@@ -1262,14 +1263,15 @@ list of buffers. |unlisted-buffer|
 		This is the most recent entry in the jump list that points
 		into a loaded buffer.
 
-:bunload[!] {bufname}
+:bun[load][!] {bufname}
 		Like ":bunload[!] [N]", but buffer given by name.
 		Also see |{bufname}|.
 
-:N,Mbunload[!]	Do ":bunload[!]" for all buffers in the range N to M
+:N,Mbun[load][!]
+		Do ":bunload[!]" for all buffers in the range N to M
 		|inclusive|.
 
-:bunload[!] N1 N2 ...
+:bun[load][!] N1 N2 ...
 		Do ":bunload[!]" for buffer N1, N2, etc.  The arguments can be
 		buffer numbers or buffer names (but not buffer names that are
 		a number).  Insert a backslash before a space in a buffer


### PR DESCRIPTION
- Use the optional tail command-name specs at help entries for :keepalt, :lcd, :cfdo, :lfdo, :wundo, :rundo, :bdelete and :bunload.
- Add missing shortname tags.
