### PR TITLE
runtime(doc): Replace rotted URL links

### DIFF
--- a/runtime/doc/netbeans.txt
+++ b/runtime/doc/netbeans.txt
@@ -1,4 +1,4 @@
-*netbeans.txt*  For Vim version 9.1.  Last change: 2025 Aug 10
+*netbeans.txt*  For Vim version 9.1.  Last change: 2025 Oct 12
 
 
 		  VIM REFERENCE MANUAL    by Gordon Prieur et al.
@@ -134,11 +134,11 @@ Without it the toolbar and signs will be disabled.
 
 The XPM library is provided by Arnaud Le Hors of the French National Institute
 for Research in Computer Science and Control.  It can be downloaded from
-http://cgit.freedesktop.org/xorg/lib/libXpm.  The current release, as of this
-writing, is xpm-3.4k-solaris.tgz, which is a gzip'ed tar file.  If you create
-the directory /usr/local/xpm and untar the file there you can use the
-uncommented lines in the Makefile without changing them.  If you use another
-xpm directory you will need to change the XPM_DIR in src/Makefile.
+https://ftp.nluug.nl/ftp/windowing/X/contrib/libraries/.  The current release,
+as of this writing, is xpm-3.4k-solaris.tgz, which is a gzip'ed tar file.  If
+you create the directory /usr/local/xpm and untar the file there you can use
+the uncommented lines in the Makefile without changing them.  If you use
+another xpm directory you will need to change the XPM_DIR in src/Makefile.
 
 
 On MS-Windows:

--- a/runtime/doc/spell.txt
+++ b/runtime/doc/spell.txt
@@ -1,4 +1,4 @@
-*spell.txt*	For Vim version 9.1.  Last change: 2025 Sep 02
+*spell.txt*	For Vim version 9.1.  Last change: 2025 Oct 12
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -510,7 +510,7 @@ You can create a Vim spell file from the .aff and .dic files that Myspell
 uses.  Myspell is used by OpenOffice.org and Mozilla. The OpenOffice .oxt
 files are zip files which contain the .aff and .dic files. You should be able
 to find them here:
-	http://extensions.services.openoffice.org/dictionary
+	https://extensions.openoffice.org/en/search@f[0]=field_project_application%253A1&f[1]=field_project_tags%253A94.html
 The older, OpenOffice 2 files may be used if this doesn't work:
 	http://wiki.services.openoffice.org/wiki/Dictionaries
 You can also use a plain word list.  The results are the same, the choice

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1,4 +1,4 @@
-*syntax.txt*	For Vim version 9.1.  Last change: 2025 Oct 09
+*syntax.txt*	For Vim version 9.1.  Last change: 2025 Oct 12
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -1979,7 +1979,7 @@ are read during initialization) >
 	:let html_my_rendering=1
 
 If you'd like to see an example download mysyntax.vim at
-https://www.fleiner.com/vim/download.html
+https://web.archive.org/web/20241129015117/https://www.fleiner.com/vim/download.html
 
 You can also disable this rendering by adding the following line to your
 vimrc file: >

--- a/runtime/spell/README_en.txt
+++ b/runtime/spell/README_en.txt
@@ -709,7 +709,7 @@ English.
 ---
 
 This is a locally hosted copy of the English dictionaries with fixed dash handling and new ligature and phonetic suggestion support extension:
-http://extensions.openoffice.org/en/node/3785
+https://web.archive.org/web/20250830102911/http://extensions.openoffice.org/en/node/3785
 
 Original version of the en_GB dictionary:
 http://www.openoffice.org/issues/show_bug.cgi/id=72145


### PR DESCRIPTION
Both links to `libXpm` and `mysyntax.vim` are up but the listed  
`libXpm` version is not offered anymore and `mysyntax.vim` is no  
longer served at all.  The link for searching dictionary  
extensions of Apache OpenOffice is broken; an alternative  
link can be discovered from the home page.  Finally, the  
English dictionaries Apache OpenOffice extension is probably  
gone for good (is it incompatible with more recent versions  
of the suite?) as its page neither available directly nor  
discoverable through search.
