### PR TITLE
No cmdline completion for :echoconsole and :echowindow

### DIFF
--- a/src/cmdexpand.c
+++ b/src/cmdexpand.c
@@ -2482,6 +2482,8 @@ set_context_by_cmdname(
 	case CMD_execute:
 	case CMD_echomsg:
 	case CMD_echoerr:
+	case CMD_echoconsole:
+	case CMD_echowindow:
 	case CMD_call:
 	case CMD_return:
 	case CMD_cexpr:

--- a/src/eval.c
+++ b/src/eval.c
@@ -3113,6 +3113,8 @@ set_context_for_expression(
 		|| cmdidx == CMD_echo
 		|| cmdidx == CMD_echon
 		|| cmdidx == CMD_echomsg
+		|| cmdidx == CMD_echoerr
+		|| cmdidx == CMD_echoconsole
 		|| cmdidx == CMD_echowindow)
 	    && xp->xp_context == EXPAND_EXPRESSION)
     {

--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -1333,11 +1333,12 @@ endfunc
 
 func Test_cmdline_complete_expression()
   let g:SomeVar = 'blah'
-  for cmd in ['exe', 'echo', 'echon', 'echomsg']
+  for cmd in ['exe', 'echo', 'echon', 'echomsg', 'echoerr',
+        \ 'echoconsole', 'echowindow']
     call feedkeys(":" .. cmd .. " SomeV\<Tab>\<C-B>\"\<CR>", 'tx')
-    call assert_match('"' .. cmd .. ' SomeVar', @:)
+    call assert_match('"' .. cmd .. ' SomeVar', @:, cmd)
     call feedkeys(":" .. cmd .. " foo SomeV\<Tab>\<C-B>\"\<CR>", 'tx')
-    call assert_match('"' .. cmd .. ' foo SomeVar', @:)
+    call assert_match('"' .. cmd .. ' foo SomeVar', @:, cmd)
   endfor
   unlet g:SomeVar
 endfunc


### PR DESCRIPTION
Problem:  No cmdline completion for :echoconsole, :echowindow and second
          expression after :echoerr.
Solution: Set EXPAND_EXPRESSION for :echoconsole and :echowindow, and
          check for multiple expressions after :echoerr.
