### PR TITLE
runtime(vimcomplete): do not complete on empty line

### DIFF
--- a/runtime/autoload/vimcomplete.vim
+++ b/runtime/autoload/vimcomplete.vim
@@ -36,6 +36,9 @@ enddef
 export def Complete(findstart: number, base: string): any
     if findstart > 0
         var line = getline('.')->strpart(0, col('.') - 1)
+        if line =~ '^\s*$'
+            return -2
+        endif
         var keyword = line->matchstr('\k\+$')
         var stx = synstack(line('.'), col('.') - 1)->map('synIDattr(v:val, "name")')->join()
         if stx =~? 'Comment' || (stx =~ 'String' && stx !~ 'vimStringInterpolationExpr')

--- a/runtime/autoload/vimcomplete.vim
+++ b/runtime/autoload/vimcomplete.vim
@@ -36,7 +36,7 @@ enddef
 export def Complete(findstart: number, base: string): any
     if findstart > 0
         var line = getline('.')->strpart(0, col('.') - 1)
-        if line =~ '^\s*$'
+        if line =~ '\s\+$'
             return -2
         endif
         var keyword = line->matchstr('\k\+$')


### PR DESCRIPTION
vim's omnicomplete should not start completion on the empty line.