### PR TITLE
runtime(bitbake): fix multiline Python function parameter syntax

### DIFF
--- a/runtime/syntax/bitbake.vim
+++ b/runtime/syntax/bitbake.vim
@@ -95,7 +95,7 @@ syn region bbPyFuncRegion       matchgroup=bbDelimiter start="{\s*$" end="^}\s*$
 
 " BitBake 'def'd python functions
 syn keyword bbPyDef             def contained
-syn region bbPyDefRegion        start='^\(def\s\+\)\([0-9A-Za-z_-]\+\)\(\s*(.*)\s*\):\s*$' end='^\(\s\|$\)\@!' contains=@python
+syn region bbPyDefRegion        start='^\(def\s\+\)\([0-9A-Za-z_-]\+\)\(\s*(\_.*)\s*\):\s*$' end='^\(\s\|$\)\@!' contains=@python
 
 " Highlighting Definitions
 hi def link bbUnmatched         Error


### PR DESCRIPTION
Fix syntax highlighting for def-style Python functions, with their parameters spanning multiple lines. E.g. the following should match as valid Python code in Bitbake recipes:
```
def myFunction(one, two, \
               three, four):
    pass
```
For this to work, use the prefix modifier `\_` before the wildcard `.`, to also match newline characters.