### PR TITLE
runtime(rst): Sync with development branch

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -3382,6 +3382,9 @@ To enable folding of sections: >
 
 Note that folding can cause performance issues on some platforms.
 
+The minimum line syntax sync is set to 50.  To modify this number:
+	let rst_minlines = 100
+
 
 REXX						*rexx.vim* *ft-rexx-syntax*
 

--- a/runtime/ftplugin/rst.vim
+++ b/runtime/ftplugin/rst.vim
@@ -18,7 +18,7 @@ if !exists('g:rst_fold_enabled')
   let g:rst_fold_enabled = 0
 endif
 
-let b:undo_ftplugin = "setl com< cms< et< fo<"
+let b:undo_ftplugin = "setlocal comments< commentstring< expandtab< formatoptions<"
 
 setlocal comments=fb:.. commentstring=..\ %s expandtab
 setlocal formatoptions+=tcroql
@@ -32,15 +32,17 @@ setlocal formatoptions+=tcroql
 
 if exists("g:rst_style") && g:rst_style != 0
     setlocal expandtab shiftwidth=3 softtabstop=3 tabstop=8
+    let b:undo_ftplugin .= " | setlocal softtabstop< shiftwidth< tabstop<"
 endif
 
-if g:rst_fold_enabled != 0 && has('patch-7.3.867')  " Introduced the TextChanged event.
+if g:rst_fold_enabled != 0
   setlocal foldmethod=expr
   setlocal foldexpr=RstFold#GetRstFold()
   setlocal foldtext=RstFold#GetRstFoldText()
   augroup RstFold
     autocmd TextChanged,InsertLeave <buffer> unlet! b:RstFoldCache
   augroup END
+  let b:undo_ftplugin .= " | setlocal foldexpr< foldmethod< foldtext<"
 endif
 
 let &cpo = s:cpo_save

--- a/runtime/indent/rst.vim
+++ b/runtime/indent/rst.vim
@@ -11,6 +11,10 @@ if exists("b:did_indent")
 endif
 let b:did_indent = 1
 
+" Save and modify cpoptions
+let s:save_cpo = &cpo
+set cpo&vim
+
 setlocal indentexpr=GetRSTIndent()
 setlocal indentkeys=!^F,o,O
 setlocal nosmartindent
@@ -27,7 +31,8 @@ let s:note_pattern = '^\.\. '
 
 function! s:get_paragraph_start()
     let paragraph_mark_start = getpos("'{")[1]
-    return getline(paragraph_mark_start) =~ '\S' ? paragraph_mark_start : paragraph_mark_start + 1
+    return getline(paragraph_mark_start) =~
+        \ '\S' ? paragraph_mark_start : paragraph_mark_start + 1
 endfunction
 
 function GetRSTIndent()
@@ -42,7 +47,7 @@ function GetRSTIndent()
   let psnum = s:get_paragraph_start()
   if psnum != 0
       if getline(psnum) =~ s:note_pattern
-          let ind = 3
+          let ind = max([3, ind])
       endif
   endif
 
@@ -75,3 +80,7 @@ function GetRSTIndent()
 
   return ind
 endfunction
+
+" Restore 'cpoptions'
+let &cpo = s:save_cpo
+unlet s:save_cpo

--- a/runtime/syntax/rst.vim
+++ b/runtime/syntax/rst.vim
@@ -246,11 +246,11 @@ for s:filetype in keys(g:rst_syntax_code_list)
     unlet! prior_isk
 endfor
 
+
 " Enable top level spell checking
 syntax spell toplevel
 
-" TODO: Use better syncing.
-syn sync minlines=50 linebreaks=2
+exe "syn sync minlines=" . get(g:, 'rst_minlines', 50) . " linebreaks=2"
 
 hi def link rstTodo                         Todo
 hi def link rstComment                      Comment

--- a/runtime/syntax/rst.vim
+++ b/runtime/syntax/rst.vim
@@ -17,8 +17,9 @@ syn case ignore
 syn match   rstTransition  /^[=`:.'"~^_*+#-]\{4,}\s*$/
 
 syn cluster rstCruft                contains=rstEmphasis,rstStrongEmphasis,
-      \ rstInterpretedText,rstInlineLiteral,rstSubstitutionReference,
-      \ rstInlineInternalTargets,rstFootnoteReference,rstHyperlinkReference
+      \ rstInterpretedTextOrHyperlinkReference,rstInlineLiteral,
+      \ rstSubstitutionReference,rstInlineInternalTargets,rstFootnoteReference,
+      \ rstHyperlinkReference
 
 syn region  rstLiteralBlock         matchgroup=rstDelimiter
       \ start='\(^\z(\s*\).*\)\@<=::\n\s*\n' skip='^\s*$' end='^\(\z1\s\+\)\@!'
@@ -87,7 +88,7 @@ syn region rstHyperlinkTarget matchgroup=rstDirective
 execute 'syn region rstExDirective contained matchgroup=rstDirective' .
       \ ' start=+' . s:ReferenceName . '::\_s+' .
       \ ' skip=+^$+' .
-      \ ' end=+^\s\@!+ contains=@rstCruft,rstLiteralBlock'
+      \ ' end=+^\s\@!+ contains=@rstCruft,rstLiteralBlock,rstExplicitMarkup'
 
 execute 'syn match rstSubstitutionDefinition contained' .
       \ ' /|.*|\_s\+/ nextgroup=@rstDirectives'

--- a/runtime/syntax/rst.vim
+++ b/runtime/syntax/rst.vim
@@ -66,14 +66,17 @@ syn region rstComment
       \ start='\v^\z(\s*)\.\.(\_s+[\[|_]|\_s+.*::)@!' skip=+^$+ end=/^\(\z1   \)\@!/
       \ contains=@Spell,rstTodo
 
+" Note: Order matters for rstCitation and rstFootnote as the regex for
+" citations also matches numeric only patterns, e.g. [1], which are footnotes.
+" Since we define rstFootnote after rstCitation, it takes precedence, see
+" |:syn-define|.
+execute 'syn region rstCitation contained matchgroup=rstDirective' .
+      \ ' start=+\[' . s:ReferenceName . '\]\_s+' .
+      \ ' skip=+^$+' .
+      \ ' end=+^\s\@!+ contains=@Spell,@rstCruft'
 
 execute 'syn region rstFootnote contained matchgroup=rstDirective' .
       \ ' start=+\[\%(\d\+\|#\%(' . s:ReferenceName . '\)\=\|\*\)\]\_s+' .
-      \ ' skip=+^$+' .
-      \ ' end=+^\s\@!+ contains=@rstCruft,@NoSpell'
-
-execute 'syn region rstCitation contained matchgroup=rstDirective' .
-      \ ' start=+\[' . s:ReferenceName . '\]\_s+' .
       \ ' skip=+^$+' .
       \ ' end=+^\s\@!+ contains=@rstCruft,@NoSpell'
 

--- a/runtime/syntax/rst.vim
+++ b/runtime/syntax/rst.vim
@@ -2,8 +2,9 @@
 " Language: reStructuredText documentation format
 " Maintainer: Marshall Ward <marshall.ward@gmail.com>
 " Previous Maintainer: Nikolai Weibull <now@bitwi.se>
+" Reference: https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html
 " Website: https://github.com/marshallward/vim-restructuredtext
-" Latest Revision: 2020-03-31
+" Latest Revision: 2025-10-13
 
 if exists("b:current_syntax")
   finish
@@ -12,7 +13,8 @@ endif
 let s:cpo_save = &cpo
 set cpo&vim
 
-syn case ignore
+" reStructuredText is case-insensitive
+syntax case ignore
 
 syn match   rstTransition  /^[=`:.'"~^_*+#-]\{4,}\s*$/
 
@@ -96,6 +98,9 @@ execute 'syn region rstExDirective contained matchgroup=rstDirective' .
 
 execute 'syn match rstSubstitutionDefinition contained' .
       \ ' /|.*|\_s\+/ nextgroup=@rstDirectives'
+
+
+"" Inline Markup ""
 
 function! s:DefineOneInlineMarkup(name, start, middle, end, char_left, char_right)
   " Only escape the first char of a multichar delimiter (e.g. \* inside **)
@@ -190,6 +195,8 @@ execute 'syn match rstHyperlinkReference' .
 syn match   rstStandaloneHyperlink  contains=@NoSpell
       \ "\<\%(\%(\%(https\=\|file\|ftp\|gopher\)://\|\%(mailto\|news\):\)[^[:space:]'\"<>]\+\|www[[:alnum:]_-]*\.[[:alnum:]_-]\+\.[^[:space:]'\"<>]\+\)[[:alnum:]/]"
 
+" `code` is the standard reST directive for source code.
+" `code-block` and `sourcecode` are nearly identical directives in Sphinx.
 syn region rstCodeBlock contained matchgroup=rstDirective
       \ start=+\%(sourcecode\|code\%(-block\)\=\)::\s*\(\S*\)\?\s*\n\%(\s*:.*:\s*.*\s*\n\)*\n\ze\z(\s\+\)+
       \ skip=+^$+

--- a/runtime/syntax/rst.vim
+++ b/runtime/syntax/rst.vim
@@ -52,7 +52,8 @@ syn cluster rstDirectives           contains=rstFootnote,rstCitation,
       \ rstHyperlinkTarget,rstExDirective
 
 syn match   rstExplicitMarkup       '^\s*\.\.\_s'
-      \ nextgroup=@rstDirectives,rstComment,rstSubstitutionDefinition
+      \ nextgroup=@rstDirectives,rstSubstitutionDefinition
+      \ contains=rstComment
 
 " "Simple reference names are single words consisting of alphanumerics plus
 " isolated (no two adjacent) internal hyphens, underscores, periods, colons
@@ -61,10 +62,10 @@ let s:ReferenceName = '[[:alnum:]]\%([-_.:+]\?[[:alnum:]]\+\)*'
 
 syn keyword     rstTodo             contained FIXME TODO XXX NOTE
 
-execute 'syn region rstComment contained' .
-      \ ' start=/.*/'
-      \ ' skip=+^$+' .
-      \ ' end=/^\s\@!/ contains=rstTodo'
+syn region rstComment
+      \ start='\v^\z(\s*)\.\.(\_s+[\[|_]|\_s+.*::)@!' skip=+^$+ end=/^\(\z1   \)\@!/
+      \ contains=@Spell,rstTodo
+
 
 execute 'syn region rstFootnote contained matchgroup=rstDirective' .
       \ ' start=+\[\%(\d\+\|#\%(' . s:ReferenceName . '\)\=\|\*\)\]\_s+' .

--- a/runtime/syntax/rst.vim
+++ b/runtime/syntax/rst.vim
@@ -28,8 +28,11 @@ syn region  rstQuotedLiteralBlock   matchgroup=rstDelimiter
       \ start="::\_s*\n\ze\z([!\"#$%&'()*+,-./:;<=>?@[\]^_`{|}~]\)"
       \ end='^\z1\@!' contains=@NoSpell
 
-syn region  rstDoctestBlock         oneline display matchgroup=rstDelimiter
+syn region  rstDoctestBlock         matchgroup=rstDoctestBlockPrompt
       \ start='^>>>\s' end='^$'
+      \ contains=rstDoctestBlockPrompt
+
+syn match   rstDoctestBlockPrompt   contained '^>>>\s'
 
 syn region  rstTable                transparent start='^\n\s*+[-=+]\+' end='^$'
       \ contains=rstTableLines,@rstCruft
@@ -256,6 +259,7 @@ hi def link rstTransition                   rstSections
 hi def link rstLiteralBlock                 String
 hi def link rstQuotedLiteralBlock           String
 hi def link rstDoctestBlock                 PreProc
+hi def link rstDoctestBlockPrompt           rstDelimiter
 hi def link rstTableLines                   rstDelimiter
 hi def link rstSimpleTableLines             rstTableLines
 hi def link rstExplicitMarkup               rstDirective

--- a/runtime/syntax/rst.vim
+++ b/runtime/syntax/rst.vim
@@ -78,7 +78,7 @@ execute 'syn region rstCitation contained matchgroup=rstDirective' .
 execute 'syn region rstFootnote contained matchgroup=rstDirective' .
       \ ' start=+\[\%(\d\+\|#\%(' . s:ReferenceName . '\)\=\|\*\)\]\_s+' .
       \ ' skip=+^$+' .
-      \ ' end=+^\s\@!+ contains=@rstCruft,@NoSpell'
+      \ ' end=+^\s\@!+ contains=@Spell,@rstCruft'
 
 syn region rstHyperlinkTarget contained matchgroup=rstDirective
       \ start='_\%(_\|[^:\\]*\%(\\.[^:\\]*\)*\):\_s' skip=+^$+ end=+^\s\@!+
@@ -92,7 +92,7 @@ syn region rstHyperlinkTarget matchgroup=rstDirective
 execute 'syn region rstExDirective contained matchgroup=rstDirective' .
       \ ' start=+' . s:ReferenceName . '::\_s+' .
       \ ' skip=+^$+' .
-      \ ' end=+^\s\@!+ contains=@rstCruft,rstLiteralBlock,rstExplicitMarkup'
+      \ ' end=+^\s\@!+ contains=@Spell,@rstCruft,rstLiteralBlock,rstExplicitMarkup'
 
 execute 'syn match rstSubstitutionDefinition contained' .
       \ ' /|.*|\_s\+/ nextgroup=@rstDirectives'
@@ -106,10 +106,10 @@ function! s:DefineOneInlineMarkup(name, start, middle, end, char_left, char_righ
   endif
 
   if a:start != '``'
-    let rst_contains=' contains=rstEscape' . a:name
+    let rst_contains=' contains=@Spell,rstEscape' . a:name
     execute 'syn match rstEscape'.a:name.' +\\\\\|\\'.first.'+'.' contained'
   else
-    let rst_contains=''
+    let rst_contains=' contains=@Spell'
   endif
 
   execute 'syn region rst' . a:name .


### PR DESCRIPTION
This PR includes several features which have been in the vim-restructuredtext development repository for a long time, but were never passed along to the main vim repo.

* Better docstring highlight support (37ff1181ed1624e12f12b5ef969a8c9e878ccf91)
* Consistent minlines (31f506edde3d2c7af959a36fa1a16f917c1d1fdc)
* Wider spellcheck support in blocks and directives (89bdfb30365bfe038937c46466f9757d1d6aca47)
* Existing directive indentation is now preserved (dea2fa9ee446ae7f8c56bbb21003a0bff5de5e17)

Bugfixes:
* Nested directives (21914fe39371fbea45fd9db39b5de265cd0f0f34)
* Nested comments (8ab3ff926ad194f1c6bac712df1194f98c7a8510)
* Numeric footnotes (c404b26482ebc6ecf4f2b8a8c056eb9d312ce776)
* Disable escape characters inside of inline literals (f41d61cd32cd08fd216d9156dab13f7fd6d53537)
* Correct evaluation of `undo_indent`, `undo_ftplugin` (78150aff61fd56d9b5533633393a58db74df4bd0)

These patches are long overdue, hopefully there won't be any disruption.  Although content has been separated by commit and author, let me know if you'd prefer submission in a different format.