### PR TITLE
runtime(vimcomplete): do not complete 'shellcmd' on WSL and Windows

### DIFF
--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -1745,7 +1745,7 @@ Notes
 <
   These completions might take several seconds to gather candidates.
 
-- set completion can't complete "no" options:
+- 'autocomplete' can't complete "no" options:
 >
      set noautoindent
      set nobuflisted

--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -1743,7 +1743,7 @@ Notes
      terminal dir
      !dir
 <
-  These completion might take several seconds to gather candidates.
+  These completions might take several seconds to gather candidates.
 
 - set completion can't complete "no" options:
 >

--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -1721,6 +1721,36 @@ Notes:
 <  to your vimrc
 
 
+VIM							*ft-vim-omni*
+
+Simple completion of Vimscript and Vim9script languages.
+
+Complete:
+
+- set and & options
+- commands and command arguments
+- function names after ->
+- expressions
+- l:, v:, g:, s: and b: variables
+- fallback to command line completion to get candidates
+
+Notes
+
+- It doesn't complete command arguments that rely on 'shellcmd' completion
+  type in Windows and WSL due to general slowness of canditate gathering,
+  e.g.
+>
+     terminal dir
+     !dir
+<
+  These completion might take several seconds to gather candidates.
+
+- set completion can't complete "no" options:
+>
+     set noautoindent
+     set nobuflisted
+<
+
 SYNTAX							*ft-syntax-omni*
 
 Vim has the ability to color syntax highlight nearly 500 languages.  Part of


### PR DESCRIPTION
- shellcmd completion is VERY slow on both WSL and Windows, e.g. `term something` or `!something` might take ~10 seconds to show first results. Do not complete it there.

- revert previous change to not complete on whitespace, do not complete on *empty* lines instead.