### PR TITLE
Prevent makeTargetinDefine matching extra line

### DIFF
--- a/runtime/syntax/make.vim
+++ b/runtime/syntax/make.vim
@@ -65,6 +65,7 @@ syn match makeImplicit		"^\.[A-Za-z0-9_./\t -]\+\s*:[^=]"me=e-2
 syn region makeTargetinDefine transparent matchgroup=makeTargetinDefine
 	\ start="^[~A-Za-z0-9_./$(){}%-][A-Za-z0-9_./\t ${}()%-]*&\?:\?:\{1,2}[^:=]"rs=e-1
 	\ end="[^\\]$"
+	\ keepend
 syn match makeTargetinDefine           "^[~A-Za-z0-9_./$(){}%*@-][A-Za-z0-9_./\t $(){}%*@-]*&\?::\=\s*$"
 	\ contains=makeIdent,makeSpecTarget,makeComment
 


### PR DESCRIPTION
This fixes a bug introduced in 2a33b499a3d7f46dc307234847a6562cef6cf1d8: When makeTargetinDefine ends with makeIdent, makeSpecTarget or makeComment, the following line is also matched as makeTargetinDefine.

So, add keepend to prevent that just as makeTarget does.