### PR TITLE
runtime(doc): Miscellaneous documentation fixes

### DIFF
--- a/runtime/doc/arabic.txt
+++ b/runtime/doc/arabic.txt
@@ -191,7 +191,7 @@ o  Enable Arabic settings [short-cut]
 
       To activate the Arabic keymap (i.e. to remap your English/Latin
       keyboard to look-n-feel like a standard Arabic one), set the
-      'keymap' command to "arabic".  This is done by entering
+      'keymap' option to "arabic".  This is done by entering
 >
 		:set keymap=arabic
 <

--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -1137,12 +1137,12 @@ inside of strings can change!  Also see 'softtabstop' option. >
 			current line).  This always works |linewise|, thus
 			this command can be used to put a yanked block as new
 			lines.
-			If no register is specified, it depends on the 'cb'
-			option: If 'cb' contains "unnamedplus", paste from the
-			+ register |quoteplus|.  Otherwise, if 'cb' contains
-			"unnamed", paste from the * register |quotestar|.
-			Otherwise, paste from the unnamed register
-			|quote_quote|.
+			If no register is specified, it depends on the
+			'clipboard' option: If 'clipboard' contains
+			"unnamedplus", paste from the + register |quoteplus|.
+			Otherwise, if 'clipboard' contains "unnamed", paste
+			from the * register |quotestar|.  Otherwise, paste from
+			the unnamed register |quote_quote|.
 			The register can also be '=' followed by an optional
 			expression.  The expression continues until the end of
 			the command.  You need to escape the '|' and '"'

--- a/runtime/doc/diff.txt
+++ b/runtime/doc/diff.txt
@@ -139,7 +139,7 @@ file for a moment and come back to the same file and be in diff mode again.
 		buffers.
 
 The `:diffoff` command resets the relevant options to the values they had when
-using `:diffsplit`, `:diffpatch`, `:diffthis`. or starting Vim in diff mode.
+using `:diffsplit`, `:diffpatch`, `:diffthis`, or starting Vim in diff mode.
 When using `:diffoff` twice the last saved values are restored.
 Otherwise they are set to their default value:
 

--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -137,7 +137,7 @@ as the original file with 'backupext' appended.  The default "~" is a bit
 strange to avoid accidentally overwriting existing files.  If you prefer
 ".bak" change the 'backupext' option.  Extra dots are replaced with '_' on
 MS-Windows machines, when Vim has detected that an MS-DOS-like filesystem is
-being used (e.g., messydos or crossdos) or when the 'shortname' option is on.
+being used, or when the 'shortname' option is on.
 The backup file can be placed in another directory by setting 'backupdir'.
 
 							*auto-shortname*

--- a/runtime/doc/if_mzsch.txt
+++ b/runtime/doc/if_mzsch.txt
@@ -68,7 +68,7 @@ It is raised for various Vim errors.
 
 During compilation, the MzScheme interface will remember the current MzScheme
 collection path.  If you want to specify additional paths use the
-'current-library-collection-paths' parameter.  E.g., to cons the user-local
+"current-library-collection-paths" parameter.  E.g., to cons the user-local
 MzScheme collection path: >
     :mz << EOF
     (current-library-collection-paths

--- a/runtime/doc/if_perl.txt
+++ b/runtime/doc/if_perl.txt
@@ -18,9 +18,9 @@ Perl and Vim				*perl* *Perl*
 
 Vim syntax highlighting supports Perl and POD files.  Vim assumes a file is
 Perl code if the filename has a .pl or .pm suffix.  Vim also examines the
-first line of a file, regardless of the filename suffix, to check if a file is
-a Perl script (see scripts.vim in Vim's syntax directory).  Vim assumes a file
-is POD text if the filename has a .POD suffix.
+shebang line of a file, if no filetype has been detected, to check if a file
+is a Perl script.  Vim assumes a file is POD text if the filename has a .POD
+suffix.
 
 To use tags with Perl, you need Universal/Exuberant Ctags.  Look here:
 	Universal Ctags (preferred): https://ctags.io

--- a/runtime/doc/indent.txt
+++ b/runtime/doc/indent.txt
@@ -717,12 +717,11 @@ Block if, select case, select type, select rank,  where, forall, type,
 interface, associate, block, enum, critical, and change team constructs are
 indented.  The indenting of subroutines, functions, modules, and program
 blocks is optional.  Comments, labeled statements, and continuation lines are
-indented if the Fortran is in free source form, whereas they are not indented
-if the Fortran is in fixed source form because of the left margin
-requirements.  Hence manual indent corrections will be necessary for labeled
-statements and continuation lines when fixed source form is being used.  For
-further discussion of the method used for the detection of source format see
-|ft-fortran-syntax|.
+indented in free source form, whereas they are not indented in fixed source
+form because of the left margin requirements.  Hence manual indent corrections
+will be necessary for labeled statements and continuation lines when fixed
+source form is being used.  For further discussion of the method used for the
+detection of source format see |ft-fortran-syntax|.
 
 Do loops ~
 All do loops are left unindented by default.  Do loops can be unstructured in

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -5916,7 +5916,7 @@ guisp={color-name}					*highlight-guisp*
 	If you want to develop a color list that can be relied on by others,
 	it is best to prefix your color names.  By convention these color
 	lists are placed in the colors/lists directory.  You can see an
-	example in '$VIMRUNTIME/colors/lists/csscolors.vim'.  This list would
+	example in "$VIMRUNTIME/colors/lists/csscolors.vim".  This list would
 	be sourced by a color scheme using: >
 
 	    :runtime colors/lists/csscolors.vim

--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -1811,9 +1811,9 @@ Change default signs ~
 							*termdebug_signs*
 Termdebug uses the hex number of the breakpoint ID in the signcolumn to
 represent breakpoints.  If it is greater than "0xFF", then it will be
-displayed as "F+", due to we really only have two screen cells for the sign.
-You may also use decimal breakpoint signs instead, in which case IDs greater
-than 99 will be displayed as "9+".
+displayed as "F+", because there are only two screen cells available for the
+sign.  You may also use decimal breakpoint signs instead, in which case IDs
+greater than 99 will be displayed as "9+".
 
 If you want to customize the breakpoint signs to show `>>` in the signcolumn: >
 	let g:termdebug_config['sign'] = '>>'

--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -127,11 +127,11 @@ This option can be local to the window, so that you can have a different
 status line in each window.
 
 Normally, inversion is used to display the status line.  This can be changed
-with the 's' character in the 'highlight' option.  For example, "sb" sets it to
-bold characters.  If no highlighting is used for the status line ("sn"), the
-'^' character is used for the current window, and '=' for other windows.  If
-the mouse is supported and enabled with the 'mouse' option, a status line can
-be dragged to resize windows.
+with the 's' character in the 'highlight' option.  For example, "sb" sets it
+to bold characters.  If no highlighting is used for the status line ("sn"),
+the '^' character is used for the current window, and '=' for other windows.
+If the mouse is supported and enabled with the 'mouse' option, a status line
+can be dragged to resize windows.
 
 Note: If you expect your status line to be in reverse video and it isn't,
 check if the 'highlight' option contains "si".  In version 3.0, this meant to
@@ -142,7 +142,7 @@ that have termcap codes for italics.
 
 							*filler-lines*
 The lines after the last buffer line in a window are called filler lines.  By
-default, these lines start with a tilde (~) character.  The 'eob' item in the
+default, these lines start with a tilde (~) character.  The "eob" item in the
 'fillchars' option can be used to change this character.  By default, these
 characters are highlighted as NonText (|hl-NonText|).  The EndOfBuffer
 highlight group (|hl-EndOfBuffer|) can be used to change the highlighting of


### PR DESCRIPTION
- Use full option name for 'clipboard' at :help :put.
- Minor rewordings, typo fixes, and formatting fixes.

Related: #18453
