### PR TITLE
runtime(odin): fix indent for mis-identified case statements

### DIFF
--- a/runtime/indent/odin.vim
+++ b/runtime/indent/odin.vim
@@ -4,7 +4,7 @@ vim9script
 # Language: Odin
 # Maintainer: Maxim Kim <habamax@gmail.com>
 # Website: https://github.com/habamax/vim-odin
-# Last Change: 2024-01-15
+# Last Change: 2025-10-15
 
 if exists("b:did_indent")
     finish
@@ -14,7 +14,7 @@ b:did_indent = 1
 b:undo_indent = 'setlocal cindent< cinoptions< cinkeys< indentexpr<'
 
 setlocal cindent
-setlocal cinoptions=L0,m1,(s,j1,J1,l1,+0,:0,#1
+setlocal cinoptions=L0,m1,(s,j1,J1,l1,+0,:0,#3
 setlocal cinkeys=0{,0},0),0],!^F,:,o,O
 
 setlocal indentexpr=GetOdinIndent(v:lnum)
@@ -67,14 +67,14 @@ def GetOdinIndent(lnum: number): number
         else
             indent = pindent
         endif
-    elseif pline =~ 'switch\s.*{\s*$'
+    elseif pline =~ '\<switch\>\s.*{\s*$'
         indent = pindent
-    elseif pline =~ 'case\s*.*,\s*\(//.*\)\?$' # https://github.com/habamax/vim-odin/issues/8
-        indent = pindent + matchstr(pline, 'case\s*')->strcharlen()
-    elseif line =~ '^\s*case\s\+.*,\s*$'
+    elseif pline =~ '\<case\>\s*.*,\s*\(//.*\)\?$' # https://github.com/habamax/vim-odin/issues/8
+        indent = pindent + matchstr(pline, '\<case\s*')->strcharlen()
+    elseif line =~ '^\s*case\>\s\+.*,\s*$'
         indent = pindent - shiftwidth()
-    elseif pline =~ 'case\s*.*:\s*\(//.*\)\?$'
-        if line !~ '^\s*}\s*$' && line !~ '^\s*case[[:space:]:]'
+    elseif pline =~ '\<case\>\s*.*:\s*\(//.*\)\?$'
+        if line !~ '^\s*}\s*$' && line !~ '^\s*case\>[[:space:]:]'
             indent = pindent + shiftwidth()
         endif
     elseif pline =~ '^\s*@.*' && line !~ '^\s*}'
@@ -82,7 +82,7 @@ def GetOdinIndent(lnum: number): number
     elseif pline =~ ':[:=].*}\s*$'
         indent = pindent
     elseif pline =~ '^\s*}\s*$'
-        if line !~ '^\s*}' && line !~ 'case\s*.*:\s*$'
+        if line !~ '^\s*}' && line !~ '\<case\>\s*.*:\s*$'
             indent = pindent
         else
             indent = pindent - shiftwidth()
@@ -96,7 +96,7 @@ def GetOdinIndent(lnum: number): number
             if plnum < 1
                 break
             endif
-            if getline(idx) =~ '^\s*case\s.*,\s*$'
+            if getline(idx) =~ '^\s*case\>\s.*,\s*$'
                 indent = indent(idx) + shiftwidth()
                 break
             endif


### PR DESCRIPTION
Fixes https://github.com/habamax/vim-odin/issues/11