### PR TITLE
v:register not reset after Visual mode command

### DIFF
--- a/src/normal.c
+++ b/src/normal.c
@@ -968,6 +968,10 @@ normal_cmd(
     if (old_mapped_len > 0)
 	old_mapped_len = typebuf_maplen();
 
+#ifdef FEAT_EVAL
+    int prev_VIsual_active = VIsual_active;
+#endif
+
     // If an operation is pending, handle it.  But not for K_IGNORE or
     // K_MOUSEMOVE.
     if (ca.cmdchar != K_IGNORE && ca.cmdchar != K_MOUSEMOVE)
@@ -984,7 +988,7 @@ normal_end:
     msg_nowait = FALSE;
 
 #ifdef FEAT_EVAL
-    if (finish_op)
+    if (finish_op || prev_VIsual_active)
 	reset_reg_var();
 #endif
 

--- a/src/testdir/test_registers.vim
+++ b/src/testdir/test_registers.vim
@@ -699,8 +699,13 @@ func Test_v_register()
 
   let s:register = ''
   call feedkeys('"_ddS', 'mx')
-  call assert_equal('test@', getline('.'))  " fails before 8.2.0929
   call assert_equal('"', s:register)        " fails before 8.2.0929
+  call assert_equal('test@', getline('.'))  " fails before 8.2.0929
+
+  let s:register = ''
+  call feedkeys('V"_dS', 'mx')
+  call assert_equal('"', s:register)
+  call assert_equal('test@', getline('.'))
 
   let s:register = ''
   call feedkeys('"zS', 'mx')
@@ -718,6 +723,11 @@ func Test_v_register()
   normal "_ddS
   call assert_equal('"', s:register)        " fails before 8.2.0929
   call assert_equal('test@', getline('.'))  " fails before 8.2.0929
+
+  let s:register = ''
+  normal V"_dS
+  call assert_equal('"', s:register)
+  call assert_equal('test@', getline('.'))
 
   let s:register = ''
   execute 'normal "z:call' "s:Put()\n"


### PR DESCRIPTION
Problem:  v:register not reset after Visual mode command.
Solution: Reset v:register if Visual mode was active before
          do_pending_operator().

fixes: #18579
related: #5305
