### PR TITLE
Change operation may reset restart_edit

### DIFF
--- a/src/ops.c
+++ b/src/ops.c
@@ -4375,9 +4375,9 @@ do_pending_operator(cmdarg_T *cap, int old_col, int gui_yank)
 	    {
 		// This is a new edit command, not a restart.  Need to
 		// remember it to make 'insertmode' work with mappings for
-		// Visual mode.  But do this only once and not when typed and
-		// 'insertmode' isn't set.
-		if (p_im || !KeyTyped)
+		// Visual mode.  But do this only once and only when
+		// 'insertmode' is set.
+		if (p_im)
 		    restart_edit_save = restart_edit;
 		else
 		    restart_edit_save = 0;

--- a/src/testdir/test_mapping.vim
+++ b/src/testdir/test_mapping.vim
@@ -1949,5 +1949,15 @@ func Test_mapclear_while_listing()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_operator_map_with_normal_op_change()
+  new
+  call setline(1, ['one two three', 'four five six'])
+  onoremap <buffer> gb <cmd>normal! V<cr>
+  call cursor(1, 2)
+  " the first <ESC> should enter insert mode directly
+  call feedkeys("a\<C-o>cgb\<esc>athree two one\<esc>", 'tx')
+  call assert_equal('three two one', getline(1))
+  bw!
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  Change operation may reset restart_edit when coming from a
          mapping (Pierre Ganty).
Solution: Only save and restore restart_edit when insertmode is set;
          handle commands coming from mappings the same as when they
          were actually typed.

fixes: #18567