### PR TITLE
Fix clipboard provider tests

### DIFF
--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -7944,7 +7944,11 @@ f_has(typval_T *argvars, typval_T *rettv)
 	{
 	    x = TRUE;
 #ifdef FEAT_CLIPBOARD
-	    n = clip_plus.available && &clip_star != &clip_plus;
+# ifdef ONE_CLIPBOARD
+	    n = FALSE;
+# else
+	    n = clip_plus.available;
+# endif
 #endif
 	}
     }

--- a/src/testdir/test_clipboard_provider.vim
+++ b/src/testdir/test_clipboard_provider.vim
@@ -37,6 +37,8 @@ endfunc
 " Test if "available" function works properly for provider
 func Test_clipboard_provider_available()
     CheckUnix
+    CheckFeature clipboard_plus_avail
+
     let v:clipproviders["test"] = {
                 \ "available": function("AvailablePlus"),
                 \ "paste": {

--- a/src/testdir/test_eval_stuff.vim
+++ b/src/testdir/test_eval_stuff.vim
@@ -746,17 +746,19 @@ func Test_clipboard_runtime_features()
 
   set clipmethod=evaltest
 
-  if has('win32') || has('macunix')
+  if has('win32') || has('macunix') ||
+        \ (!has('wayland_clipboard') && !has('xterm_clipboard'))
     let g:vim_test_plus = '+'
     let g:vim_test_star = '*'
     clipreset
 
-    " plus register should be disabled on windows or macos
+    " plus register should be disabled on windows or macos, or if Wayland and
+    " X11 is not enabled.
     call assert_equal(0, has('clipboard_plus_avail'))
     call assert_equal(1, has('clipboard_star_avail'))
   else
-    let g:vim_test_plus = '+'
     let g:vim_test_star = '*'
+    let g:vim_test_plus = '+'
     clipreset
 
     call assert_equal(1, has('clipboard_plus_avail'))


### PR DESCRIPTION
Also fixes a possible warning from evalfunc.c:
```c
evalfunc.c: In function ‘f_has’:
evalfunc.c:7947:51: warning: self-comparison always evaluates to false [-Wtautological-compare]
 7947 |             n = clip_plus.available && &clip_star != &clip_plus;
      |
```