### PR TITLE
Fix incorrect spelling of `Vim script` language name

### DIFF
--- a/runtime/autoload/vimgoto.vim
+++ b/runtime/autoload/vimgoto.vim
@@ -6,7 +6,7 @@ vim9script
 #               Andrew Radev
 # Last Change:  2025 Sep 21
 #
-# Vim Script to handle jumping to the targets of several types of Vim commands
+# Vim script to handle jumping to the targets of several types of Vim commands
 # (:import, :packadd, :runtime, :colorscheme), and to autoloaded functions of
 # the style <path>#<function_name>.
 #

--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -1706,7 +1706,7 @@ Notes:
 
 VIM							*ft-vim-omni*
 
-Simple completion of Vimscript and Vim9script languages.
+Simple completion of Vim script and Vim9 script languages.
 
 Complete:
 

--- a/runtime/pack/dist/opt/helptoc/autoload/helptoc.vim
+++ b/runtime/pack/dist/opt/helptoc/autoload/helptoc.vim
@@ -486,7 +486,7 @@ def SetToc() #{{{2
             ->substitute('\\\([&%$_#{}~\\^]\)', '\1', 'g')
 
     # SANITIZE_VIM {{{3
-    # #1 - Omit leading Vim9 script # or vimscript " markers and blanks
+    # #1 - Omit leading Vim9 script # or Vim script " markers and blanks
     # #2 - Omit numbered 3x { markers
     const SANITIZE_VIM = (text: string): string =>
         text->substitute('\v^[#[:blank:]"]*(.+)\ze[{]{3}([1-6])',

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -4637,7 +4637,7 @@ trans_function_name_ext(
 		else
 		{
 		    // dropping "g:" without setting "is_global" won't work in
-		    // Vim9script, put it back later
+		    // Vim9 script, put it back later
 		    prefix_g = TRUE;
 		    extra = 2;
 		}


### PR DESCRIPTION
Also `Vim9 script`