### PR TITLE
v:register is wrong in v_: command

### DIFF
--- a/src/normal.c
+++ b/src/normal.c
@@ -968,10 +968,6 @@ normal_cmd(
     if (old_mapped_len > 0)
 	old_mapped_len = typebuf_maplen();
 
-#ifdef FEAT_EVAL
-    int prev_VIsual_active = VIsual_active;
-#endif
-
     // If an operation is pending, handle it.  But not for K_IGNORE or
     // K_MOUSEMOVE.
     if (ca.cmdchar != K_IGNORE && ca.cmdchar != K_MOUSEMOVE)
@@ -988,7 +984,7 @@ normal_end:
     msg_nowait = FALSE;
 
 #ifdef FEAT_EVAL
-    if (finish_op || prev_VIsual_active)
+    if (finish_op)
 	reset_reg_var();
 #endif
 

--- a/src/testdir/test_registers.vim
+++ b/src/testdir/test_registers.vim
@@ -692,7 +692,9 @@ func Test_v_register()
     exec 'normal! "' .. v:register .. 'P'
   endfunc
   nnoremap <buffer> <plug>(test) :<c-u>call s:Put()<cr>
+  xnoremap <buffer> <plug>(test) :<c-u>call s:Put()<cr>
   nmap <buffer> S <plug>(test)
+  xmap <buffer> S <plug>(test)
 
   let @z = "testz\n"
   let @" = "test@\n"
@@ -704,16 +706,29 @@ func Test_v_register()
 
   let s:register = ''
   call feedkeys('V"_dS', 'mx')
-  call assert_equal('"', s:register)
-  call assert_equal('test@', getline('.'))
+  " FIXME
+  " call assert_equal('"', s:register)
+  " call assert_equal('test@', getline('.'))
 
   let s:register = ''
   call feedkeys('"zS', 'mx')
   call assert_equal('z', s:register)
+  call assert_equal('testz', getline('.'))
 
   let s:register = ''
   call feedkeys('"zSS', 'mx')
   call assert_equal('"', s:register)
+  call assert_equal('test@', getline('.'))
+
+  let s:register = ''
+  call feedkeys('V"zS', 'mx')
+  call assert_equal('z', s:register)
+  call assert_equal('testz', getline('.'))
+
+  let s:register = ''
+  call feedkeys('V"zSS', 'mx')
+  call assert_equal('"', s:register)
+  call assert_equal('test@', getline('.'))
 
   let s:register = ''
   call feedkeys('"_S', 'mx')
@@ -723,11 +738,6 @@ func Test_v_register()
   normal "_ddS
   call assert_equal('"', s:register)        " fails before 8.2.0929
   call assert_equal('test@', getline('.'))  " fails before 8.2.0929
-
-  let s:register = ''
-  normal V"_dS
-  call assert_equal('"', s:register)
-  call assert_equal('test@', getline('.'))
 
   let s:register = ''
   execute 'normal "z:call' "s:Put()\n"


### PR DESCRIPTION
Problem:  v:register is wrong in v_: command (after 9.1.1858).
Solution: Revert patch 9.1.1858 for now. Add a test.

related: https://github.com/vim/vim/pull/18583#issuecomment-3418030021