### PR TITLE
v:register is wrong in v_: command

### DIFF
--- a/src/normal.c
+++ b/src/normal.c
@@ -695,6 +695,9 @@ normal_cmd(
     int		idx;
     int		set_prevcount = FALSE;
     int		save_did_cursorhold = did_cursorhold;
+#ifdef FEAT_EVAL
+    int		did_visual_op = FALSE;
+#endif
 
     CLEAR_FIELD(ca);	// also resets ca.retval
     ca.oap = oap;
@@ -968,14 +971,18 @@ normal_cmd(
     if (old_mapped_len > 0)
 	old_mapped_len = typebuf_maplen();
 
-#ifdef FEAT_EVAL
-    int prev_VIsual_active = VIsual_active;
-#endif
-
     // If an operation is pending, handle it.  But not for K_IGNORE or
     // K_MOUSEMOVE.
     if (ca.cmdchar != K_IGNORE && ca.cmdchar != K_MOUSEMOVE)
+    {
+#ifdef FEAT_EVAL
+	did_visual_op = VIsual_active && oap->op_type != OP_NOP
+			// For OP_COLON, do_pending_operator() stuffs ':' into
+			// the read buffer, which isn't executed immediately.
+			&& oap->op_type != OP_COLON;
+#endif
 	do_pending_operator(&ca, old_col, FALSE);
+    }
 
     // Wait for a moment when a message is displayed that will be overwritten
     // by the mode message.
@@ -988,7 +995,7 @@ normal_end:
     msg_nowait = FALSE;
 
 #ifdef FEAT_EVAL
-    if (finish_op || prev_VIsual_active)
+    if (finish_op || did_visual_op)
 	reset_reg_var();
 #endif
 

--- a/src/testdir/test_registers.vim
+++ b/src/testdir/test_registers.vim
@@ -692,7 +692,9 @@ func Test_v_register()
     exec 'normal! "' .. v:register .. 'P'
   endfunc
   nnoremap <buffer> <plug>(test) :<c-u>call s:Put()<cr>
+  xnoremap <buffer> <plug>(test) :<c-u>call s:Put()<cr>
   nmap <buffer> S <plug>(test)
+  xmap <buffer> S <plug>(test)
 
   let @z = "testz\n"
   let @" = "test@\n"
@@ -710,13 +712,39 @@ func Test_v_register()
   let s:register = ''
   call feedkeys('"zS', 'mx')
   call assert_equal('z', s:register)
+  call assert_equal('testz', getline('.'))
 
   let s:register = ''
   call feedkeys('"zSS', 'mx')
   call assert_equal('"', s:register)
+  call assert_equal('test@', getline('.'))
+
+  let s:register = ''
+  call feedkeys("\"z\<Ignore>S", 'mx')
+  call assert_equal('z', s:register)
+  call assert_equal('testz', getline('.'))
 
   let s:register = ''
   call feedkeys('"_S', 'mx')
+  call assert_equal('_', s:register)
+
+  let s:register = ''
+  call feedkeys('V"zS', 'mx')
+  call assert_equal('z', s:register)
+  call assert_equal('testz', getline('.'))
+
+  let s:register = ''
+  call feedkeys('V"zSS', 'mx')
+  call assert_equal('"', s:register)
+  call assert_equal('test@', getline('.'))
+
+  let s:register = ''
+  call feedkeys("V\"z\<Ignore>S", 'mx')
+  call assert_equal('z', s:register)
+  call assert_equal('testz', getline('.'))
+
+  let s:register = ''
+  call feedkeys('V"_S', 'mx')
   call assert_equal('_', s:register)
 
   let s:register = ''


### PR DESCRIPTION
Problem:  v:register is wrong in v_: command (after 9.1.1858).
Solution: Don't reset v:register for OP_COLON.

related: https://github.com/vim/vim/pull/18583#issuecomment-3418030021
