### PR TITLE
Fixing systemlist() on Windows

### DIFF
--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -454,7 +454,7 @@ def GetRemotePtyCmd(gdb_cmd: list<string>): list<string>
         term_cmd = gdb_cmd[0 : gdb_pos - 1]
         # roundtrip to check if socat is available on the remote side
         silent call system(join(term_cmd, ' ') .. ' socat -h')
-        if v:shell_error
+        if v:shell_error != 0
           Echowarn('Install socat on the remote machine for a program window better experience')
         else
           # create a devoted tty slave device and link to stdin/stdout

--- a/src/misc1.c
+++ b/src/misc1.c
@@ -2623,7 +2623,14 @@ get_cmd_output_as_rettv(
 	for (i = 0; i < len; ++i)
 	{
 	    start = res + i;
+#ifdef USE_CRNL
+	    if (*start == NL)
+		continue;
+
+	    while (i < len && res[i] != CAR && res[i] != NL)
+#else
 	    while (i < len && res[i] != NL)
+#endif
 		++i;
 	    end = res + i;
 

--- a/src/testdir/test_vim9_builtin.vim
+++ b/src/testdir/test_vim9_builtin.vim
@@ -4642,11 +4642,7 @@ enddef
 def Test_systemlist()
   v9.CheckSourceDefAndScriptFailure(['systemlist(1)'], ['E1013: Argument 1: type mismatch, expected string but got number', 'E1174: String required for argument 1'])
   v9.CheckSourceDefAndScriptFailure(['systemlist("a", {})'], ['E1013: Argument 2: type mismatch, expected string but got dict<any>', 'E1224: String, Number or List required for argument 2'])
-  if has('win32')
-    call assert_equal(["123\r"], systemlist('echo 123'))
-  else
-    call assert_equal(['123'], systemlist('echo 123'))
-  endif
+  call assert_equal(['123'], systemlist('echo 123'))
 enddef
 
 def Test_tabpagebuflist()


### PR DESCRIPTION
System list doesn't return a list on lines on Windows.
A basic command like:
```vim
:echo systemlist('dir C:\')
```
returns nonsense.