### PR TITLE
runtime(ftplugin): don't create new user commands for keywordprg

### DIFF
--- a/runtime/ftplugin/go.vim
+++ b/runtime/ftplugin/go.vim
@@ -22,7 +22,11 @@ setlocal formatprg=gofmt
 
 setlocal comments=s1:/*,mb:*,ex:*/,://
 setlocal commentstring=//\ %s
-let &l:keywordprg = ':call ' .. expand('<SID>') .. 'GoKeywordPrg() "'
+
+let s:sid = expand('<SID>')
+
+" Trailing comment marks `"` is to avoid processing further arg
+let &l:keywordprg = ':call ' .. s:sid .. 'GoKeywordPrg() "'
 
 let b:undo_ftplugin = 'setl fo< com< cms< fp< kp<'
                   \ . '| delcommand -buffer GoKeywordPrg'
@@ -32,7 +36,7 @@ if get(g:, 'go_recommended_style', 1)
   let b:undo_ftplugin .= ' | setl et< sts< sw<'
 endif
 
-if !exists('*' . expand('<SID>') . 'GoKeywordPrg')
+if !exists('*' . s:sid . 'GoKeywordPrg')
   func! s:GoKeywordPrg()
     let temp_isk = &l:iskeyword
     setl iskeyword+=.

--- a/runtime/ftplugin/go.vim
+++ b/runtime/ftplugin/go.vim
@@ -22,9 +22,7 @@ setlocal formatprg=gofmt
 
 setlocal comments=s1:/*,mb:*,ex:*/,://
 setlocal commentstring=//\ %s
-setlocal keywordprg=:GoKeywordPrg
-
-command! -buffer -nargs=* GoKeywordPrg call s:GoKeywordPrg()
+let &l:keywordprg = ':call ' .. expand('<SID>') .. 'GoKeywordPrg() "'
 
 let b:undo_ftplugin = 'setl fo< com< cms< fp< kp<'
                   \ . '| delcommand -buffer GoKeywordPrg'

--- a/runtime/ftplugin/sh.vim
+++ b/runtime/ftplugin/sh.vim
@@ -32,7 +32,7 @@ if exists("loaded_matchit") && !exists("b:match_words")
 	\  s:sol .. '\%(for\|while\)\>:' .. s:sol .. 'done\>,' ..
 	\  s:sol .. 'case\>:' .. s:sol .. 'esac\>'
   unlet s:sol
-  let b:match_skip = "synIDattr(synID(line('.'),col('.'),0),'name') =~ 'shSnglCase'" 
+  let b:match_skip = "synIDattr(synID(line('.'),col('.'),0),'name') =~ 'shSnglCase'"
   let b:undo_ftplugin ..= " | unlet! b:match_ignorecase b:match_words b:match_skip"
 endif
 
@@ -56,12 +56,15 @@ if s:is_bash
   function! s:KeywordPrg() abort
     let keyword = expand('<cword>')
     if exists(':terminal') == 2
-      execute ':hor term bash -c "help ' . keyword . ' 2>/dev/null'
+      execute ':hor term bash -c "help ' .. keyword .. ' 2>/dev/null'
     else
-      return system('bash -c "help ' . keyword . ' 2>/dev/null"')
+      return system('bash -c "help ' .. keyword .. ' 2>/dev/null"')
     endif
   endfunction
+
+  " Trailing comment marks `"` is to avoid processing further arg
   let &l:keywordprg=':call ' .. expand('<SID>') .. 'KeywordPrg() "'
+
   let b:undo_ftplugin ..= " | setl kp< | sil! delc -buffer ShKeywordPrg"
 endif
 

--- a/runtime/ftplugin/sh.vim
+++ b/runtime/ftplugin/sh.vim
@@ -53,12 +53,15 @@ let s:is_bash = get(b:, "is_bash", get(g:, "is_bash", 0))
 let s:is_kornshell = get(b:, "is_kornshell", get(g:, "is_kornshell", 0))
 
 if s:is_bash
-  if exists(':terminal') == 2
-    command! -buffer -nargs=1 ShKeywordPrg silent exe ':hor term bash -c "help "<args>" 2>/dev/null || man "<args>""'
-  else
-    command! -buffer -nargs=1 ShKeywordPrg echo system('bash -c "help <args>" 2>/dev/null || MANPAGER= man "<args>"')
-  endif
-  setlocal keywordprg=:ShKeywordPrg
+  function! s:KeywordPrg() abort
+    let keyword = expand('<cword>')
+    if exists(':terminal') == 2
+      execute ':hor term bash -c "help ' . keyword . ' 2>/dev/null'
+    else
+      return system('bash -c "help ' . keyword . ' 2>/dev/null"')
+    endif
+  endfunction
+  let &l:keywordprg=':call ' .. expand('<SID>') .. 'KeywordPrg() "'
   let b:undo_ftplugin ..= " | setl kp< | sil! delc -buffer ShKeywordPrg"
 endif
 

--- a/runtime/ftplugin/vim.vim
+++ b/runtime/ftplugin/vim.vim
@@ -61,8 +61,8 @@ setlocal isk+=#
 " Use :help to lookup the keyword under the cursor with K.
 " Distinguish between commands, options and functions.
 if !exists("*" .. expand("<SID>") .. "Help")
-  function s:Help(topic) abort
-    let topic = a:topic
+  function s:Help() abort
+    let topic = expand('<cword>')
 
     " keyword is not necessarily under the cursor, see :help K
     let line = getline('.')
@@ -78,35 +78,34 @@ if !exists("*" .. expand("<SID>") .. "Help")
     if get(g:, 'syntax_on', 0)
       let syn = synIDattr(synID(line('.'), col('.'), 1), 'name')
       if syn ==# 'vimFuncName'
-        return topic .. '()'
+        exe 'help' topic .. '()'
       elseif syn ==# 'vimOption' || syn ==# 'vimOptionVarName'
-        return "'" .. topic .. "'"
+        exe 'help' "'" .. topic .. "'"
       elseif syn ==# 'vimUserCmdAttrKey'
-        return ':command-' .. topic
+        exe 'help' ':command-' .. topic
       elseif syn ==# 'vimCommand'
-        return ':' .. topic
+        exe 'help' ':' .. topic
       endif
     endif
 
     if pre =~# '^\s*:\=$' || pre =~# '\%(\\\||\)\@<!|\s*:\=$'
-      return ':' .. topic
+      exe 'help' ':' .. topic
     elseif pre =~# '\<v:$'
-      return 'v:' .. topic
+      exe 'help' 'v:' .. topic
     elseif pre =~# '<$'
-      return '<' .. topic .. '>'
+      exe 'help' '<' .. topic .. '>'
     elseif pre =~# '\\$'
-      return '/\' .. topic
+      exe 'help' '/\' .. topic
     elseif topic ==# 'v' && post =~# ':\w\+'
-      return 'v' .. matchstr(post, ':\w\+')
+      exe 'help' 'v' .. matchstr(post, ':\w\+')
     elseif pre =~# '&\%([lg]:\)\=$'
-      return "'" .. topic .. "'"
+      exe 'help' "'" .. topic .. "'"
     else
-      return topic
+      exe 'help' topic
     endif
   endfunction
 endif
-command! -buffer -nargs=1 VimKeywordPrg :exe 'help' s:Help(<q-args>)
-setlocal keywordprg=:VimKeywordPrg
+let &l:keywordprg = ':call ' .. expand('<SID>') .. 'Help() "'
 
 " Comments starts with # in Vim9 script.  We have to guess which one to use.
 if "\n" .. getline(1, 32)->join("\n") =~# '\n\s*vim9\%[script]\>'

--- a/runtime/ftplugin/vim.vim
+++ b/runtime/ftplugin/vim.vim
@@ -58,9 +58,11 @@ setlocal fo-=t fo+=croql
 " keyword character.  E.g., for netrw#Nread().
 setlocal isk+=#
 
+let s:sid = expand("<SID>")
+
 " Use :help to lookup the keyword under the cursor with K.
 " Distinguish between commands, options and functions.
-if !exists("*" .. expand("<SID>") .. "Help")
+if !exists("*" .. s:sid .. "Help")
   function s:Help() abort
     let topic = expand('<cword>')
 
@@ -80,32 +82,34 @@ if !exists("*" .. expand("<SID>") .. "Help")
       if syn ==# 'vimFuncName'
         exe 'help' topic .. '()'
       elseif syn ==# 'vimOption' || syn ==# 'vimOptionVarName'
-        exe 'help' "'" .. topic .. "'"
+        exe "help '" .. topic .. "'"
       elseif syn ==# 'vimUserCmdAttrKey'
         exe 'help :command-' .. topic
       elseif syn ==# 'vimCommand'
-        exe 'help' ':' .. topic
+        exe 'help :' .. topic
       endif
     endif
 
     if pre =~# '^\s*:\=$' || pre =~# '\%(\\\||\)\@<!|\s*:\=$'
-      exe 'help' ':' .. topic
+      exe 'help :' .. topic
     elseif pre =~# '\<v:$'
-      exe 'help' 'v:' .. topic
+      exe 'help v:' .. topic
     elseif pre =~# '<$'
-      exe 'help' '<' .. topic .. '>'
+      exe 'help <' .. topic .. '>'
     elseif pre =~# '\\$'
-      exe 'help' '/\' .. topic
+      exe 'help /\' .. topic
     elseif topic ==# 'v' && post =~# ':\w\+'
-      exe 'help' 'v' .. matchstr(post, ':\w\+')
+      exe 'help v' .. matchstr(post, ':\w\+')
     elseif pre =~# '&\%([lg]:\)\=$'
-      exe 'help' "'" .. topic .. "'"
+      exe "help '" .. topic .. "'"
     else
       exe 'help' topic
     endif
   endfunction
 endif
-let &l:keywordprg = ':call ' .. expand('<SID>') .. 'Help() "'
+
+" Trailing comment marks `"` is to avoid processing further arg
+let &l:keywordprg = ':call ' .. s:sid .. 'Help() "'
 
 " Comments starts with # in Vim9 script.  We have to guess which one to use.
 if "\n" .. getline(1, 32)->join("\n") =~# '\n\s*vim9\%[script]\>'

--- a/runtime/ftplugin/vim.vim
+++ b/runtime/ftplugin/vim.vim
@@ -82,7 +82,7 @@ if !exists("*" .. expand("<SID>") .. "Help")
       elseif syn ==# 'vimOption' || syn ==# 'vimOptionVarName'
         exe 'help' "'" .. topic .. "'"
       elseif syn ==# 'vimUserCmdAttrKey'
-        exe 'help' ':command-' .. topic
+        exe 'help :command-' .. topic
       elseif syn ==# 'vimCommand'
         exe 'help' ':' .. topic
       endif


### PR DESCRIPTION
Problems
- Creating a new user command for 'keywordprg' makes it visible to users in 'wildmenu', even though that command is not intended to be used directly by users.

Solution:
- Use `let &l:keywordprg = ':call '..expand('<SID>')..'KeywordFunc()"'` pattern instead