### PR TITLE
Add jinja2 filetype for .j2 files

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -2157,6 +2157,8 @@ const ft_from_ext = {
   "jgr": "jgraph",
   # Jinja
   "jinja": "jinja",
+  # Jinja2
+  "j2": "jinja2",
   # Jujutsu
   "jjdescription": "jjdescription",
   # Jovial


### PR DESCRIPTION
This PR adds `.j2` filetype detection in Vim, so that Jinja2 templates can be recognized. This is a prerequisite for integrating a future `j2lint` linter in ALE. No syntax highlighting changes are included.