### PR TITLE
Fix netrw remote uri parse

### DIFF
--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -9312,7 +9312,7 @@ endfunction
 function s:RemotePathAnalysis(dirname)
 
     "                method   ://    user  @      machine      :port            /path
-    let dirpat  = '^\(\w\{-}\)://\(\(\w\+\)@\)\=\([^/:#]\+\)\%([:#]\(\d\+\)\)\=/\(.*\)$'
+    let dirpat  = '^\(\w\{-}\)://\(\([^@]\+\)@\)\=\([^/:#]\+\)\%([:#]\(\d\+\)\)\=/\(.*\)$'
     let s:method  = substitute(a:dirname,dirpat,'\1','')
     let s:user    = substitute(a:dirname,dirpat,'\3','')
     let s:machine = substitute(a:dirname,dirpat,'\4','')

--- a/src/testdir/Make_all.mak
+++ b/src/testdir/Make_all.mak
@@ -248,6 +248,7 @@ NEW_TESTS = \
 	test_plugin_helptoc \
 	test_plugin_man \
 	test_plugin_matchparen \
+	test_plugin_netrw_remote_parse \
 	test_plugin_tar \
 	test_plugin_termdebug \
 	test_plugin_tohtml \
@@ -522,6 +523,7 @@ NEW_TESTS_RES = \
 	test_plugin_helptoc.res \
 	test_plugin_man.res \
 	test_plugin_matchparen.res \
+	test_plugin_netrw_remote_parse.res \
 	test_plugin_tar.res \
 	test_plugin_termdebug.res \
 	test_plugin_tohtml.res \

--- a/src/testdir/test_plugin_netrw_remote_parse.vim
+++ b/src/testdir/test_plugin_netrw_remote_parse.vim
@@ -1,0 +1,119 @@
+
+
+
+let s:netrw_path =        $VIMRUNTIME . '/pack/dist/opt/netrw/autoload/netrw.vim'
+let s:netrw_test_dir  =   'samples'
+let s:netrw_test_path =   s:netrw_test_dir . '/netrw.vim'
+
+"make copy of netrw script and add function to print local variables"
+func s:appendDebugToNetrw(netrw_path, netrw_test_path)
+  let netrwScript = readfile(a:netrw_path)
+
+  let netrwScript += [
+       \ '\n',
+       \ '"-- test helpers ---"',
+       \ 'function! TestNetrwCaptureRemotePath(dirname)',
+       \ '  call s:RemotePathAnalysis(a:dirname)',
+       \ '  return {"method": s:method, "user": s:user, "machine": s:machine, "port": s:port, "path": s:path, "fname": s:fname}',
+       \ 'endfunction'
+       \ ]
+
+  call writefile(netrwScript, a:netrw_test_path)
+  execute 'source' a:netrw_test_path
+endfunction
+
+func s:setup()
+  call s:appendDebugToNetrw(s:netrw_path, s:netrw_test_path)
+endfunction
+
+func s:cleanup()
+  call delete(s:netrw_test_path)
+endfunction
+
+func s:combine
+  \( usernames
+  \, methods
+  \, hosts
+  \, ports
+  \, dirs
+  \, files)
+  for username in a:usernames 
+    for method in a:methods
+      for host in a:hosts
+        for port in a:ports
+          for dir in a:dirs
+            for file in a:files
+               " --- Build a full remote path ---
+
+              let port_str = empty(port) ? "" : ':' . port
+              let remote = printf('%s://%s@%s%s/%s%s', method, username, host, port_str, dir, file)
+
+              let result = TestNetrwCaptureRemotePath(remote)
+
+              call assert_equal(result.method, method)
+              call assert_equal(result.user, username)
+              call assert_equal(result.machine, host)
+              call assert_equal(result.port, port)
+              call assert_equal(result.path, dir . file)
+            endfor
+          endfor
+        endfor
+      endfor
+    endfor
+  endfor
+endfunction
+
+
+func Test_netrw_parse_remote_simple()
+  call s:setup()
+  let result = TestNetrwCaptureRemotePath('scp://user@localhost:2222/test.txt')
+  call assert_equal(result.method, 'scp')
+  call assert_equal(result.user, 'user')
+  call assert_equal(result.machine, 'localhost')
+  call assert_equal(result.port, '2222')
+  call assert_equal(result.path, 'test.txt')
+  call s:cleanup()
+endfunction
+
+"testing different combinations"
+func Test__netrw_parse_regular_usernames()
+  call s:setup()
+
+  " --- sample data for combinations ---"
+  let usernames = ["root", "toor", "user01", "skillIssue"] 
+  let methods = ["scp", "ssh", "ftp", "sftp"]
+  let hosts = ["localhost", "server.com", "fit-workspaces.ksi.fit.cvut.cz", "192.168.1.42"]
+  let ports = ["", "22","420", "443", "2222", "1234"]
+  let dirs = ["", "somefolder/", "path/to/the/bottom/of/the/world/please/send/help/"]
+  let files = ["test.txt", "tttt.vim", "Makefile"] 
+
+  call s:combine(usernames, methods, hosts, ports, dirs, files)
+
+  call s:cleanup()
+endfunc
+
+"Host myserver
+"    HostName 192.168.1.42
+"    User alice
+func Test__netrw_parse_ssh_config_entries()
+  call s:setup()
+  let result = TestNetrwCaptureRemotePath('scp://myserver//etc/nginx/nginx.conf')
+  call assert_equal(result.method, 'scp')
+  call assert_equal(result.user, '')
+  call assert_equal(result.machine, 'myserver')
+  call assert_equal(result.port, '')
+  call assert_equal(result.path, '/etc/nginx/nginx.conf')
+  call s:cleanup()
+endfunction
+
+"username containing special-chars"
+func Test_netrw_parse_special_char_user ()
+  call s:setup()
+  let result = TestNetrwCaptureRemotePath('scp://user-01@localhost:2222/test.txt')
+  call assert_equal(result.method, 'scp')
+  call assert_equal(result.user, 'user-01')
+  call assert_equal(result.machine, 'localhost')
+  call assert_equal(result.port, '2222')
+  call assert_equal(result.path, 'test.txt')
+  call s:cleanup()
+endfunction

--- a/src/testdir/test_plugin_netrw_remote_parse.vim
+++ b/src/testdir/test_plugin_netrw_remote_parse.vim
@@ -76,7 +76,7 @@ func Test_netrw_parse_remote_simple()
 endfunction
 
 "testing different combinations"
-func Test__netrw_parse_regular_usernames()
+func Test_netrw_parse_regular_usernames()
   call s:setup()
 
   " --- sample data for combinations ---"
@@ -95,7 +95,7 @@ endfunc
 "Host myserver
 "    HostName 192.168.1.42
 "    User alice
-func Test__netrw_parse_ssh_config_entries()
+func Test_netrw_parse_ssh_config_entries()
   call s:setup()
   let result = TestNetrwCaptureRemotePath('scp://myserver//etc/nginx/nginx.conf')
   call assert_equal(result.method, 'scp')

--- a/src/testdir/test_plugin_netrw_remote_parse.vim
+++ b/src/testdir/test_plugin_netrw_remote_parse.vim
@@ -1,6 +1,3 @@
-
-
-
 let s:netrw_path =        $VIMRUNTIME . '/pack/dist/opt/netrw/autoload/netrw.vim'
 let s:netrw_test_dir  =   'samples'
 let s:netrw_test_path =   s:netrw_test_dir . '/netrw.vim'
@@ -37,7 +34,7 @@ func s:combine
   \, ports
   \, dirs
   \, files)
-  for username in a:usernames 
+  for username in a:usernames
     for method in a:methods
       for host in a:hosts
         for port in a:ports
@@ -80,12 +77,12 @@ func Test_netrw_parse_regular_usernames()
   call s:setup()
 
   " --- sample data for combinations ---"
-  let usernames = ["root", "toor", "user01", "skillIssue"] 
+  let usernames = ["root", "toor", "user01", "skillIssue"]
   let methods = ["scp", "ssh", "ftp", "sftp"]
   let hosts = ["localhost", "server.com", "fit-workspaces.ksi.fit.cvut.cz", "192.168.1.42"]
   let ports = ["", "22","420", "443", "2222", "1234"]
   let dirs = ["", "somefolder/", "path/to/the/bottom/of/the/world/please/send/help/"]
-  let files = ["test.txt", "tttt.vim", "Makefile"] 
+  let files = ["test.txt", "tttt.vim", "Makefile"]
 
   call s:combine(usernames, methods, hosts, ports, dirs, files)
 


### PR DESCRIPTION
## Netrw remote parsing username bug

please let me know if i have to setup mail subscription i wasnt sure

### Problem overview:

current implementation doesnt support remote usernames containing chars like `-`, `~`, ... in netrw dir listing such as:
- scp://**user-01**@remote/dir

netrw puts **@** in front of the username

### Example of problem:

`vim scp://user-01@localost:2222/`
netrw log:
```
...
continuing in <SNR>15_NetrwBookHistRead
No matching autocommands: FileType netrw
Calling shell to execute: "(ssh -p 2222 @user-01@localhost ls -FLa)>/var/folders/tm/3b4nbt4s0njcv3by50zsd7r00000gn/T/vcYg8jp/1 2>&1"

shell returned 255
```

### Solution:

The problem was in parsing netrw remote uri in function `RemotePathAnalysis`

in regexp for user is \w\+ which refers to 1+ word characters 

i replaced this with [^@]\+ which refers to 1+ anyhthing thats not `@`

i think this was same issue (https://github.com/vim/vim/issues/1222) and solution

i provided tests aswell but dont know if this is correct way to implement them - i couldnt get to netrw local variables so  i made copy of netrw

also tested compiling vim and testing if it works with the change - for me it does
(testing against docker img running shh and 2 users 'root' and 'user-01')

**i dont undestand what `if @` does (what it solves) in `RemotePathAnalysis` so maybe im missing something**  
- so i keep it there 

- decoded regexps with example below

### i had this tests failing on my machine:
- Test_cmdwin_restore_3.dump
- Test_colorcolumn_2.dump
- Test_colorcolumn_3.dump
- Test_popupwin_04a.dump
- Test_pum_completeitemalign_07.dump
- Test_pum_maxwidth_05.dump

### Problem Workaround:
make .ssh/config
```
Host u1
  HostName <host> 
  User user-01
```
``` bash
vim scp://u1/dir/file.txt #will work fine 
```

### Example diff and what `if @` does


here is what i used for quick testing just `:source` the file
```vim
" s:RemotePathAnalysis: {{{2


function s:RemotePathAnalysis(dirname)

    "                method   ://    user  @      machine      :port            /path
    let dirpat  = '^\(\w\{-}\)://\(\(\w\+\)@\)\=\([^/:#]\+\)\%([:#]\(\d\+\)\)\=/\(.*\)$'
    let s:method  = substitute(a:dirname,dirpat,'\1','')
    let s:user    = substitute(a:dirname,dirpat,'\3','')
    let s:machine = substitute(a:dirname,dirpat,'\4','')
    let s:port    = substitute(a:dirname,dirpat,'\5','')
    let s:path    = substitute(a:dirname,dirpat,'\6','')
    let s:fname   = substitute(s:path,'^.*/\ze.','','')

    echo 'user:' s:user
    echo 'machine:' s:machine
    echo 'method:' s:method
    echo 'port:' s:port
    echo 'path:' s:path
    echo 'fname:' s:fname

    if s:machine =~ '@' "machine contains @"
        echo '==> machine contains @'
        let dirpat    = '^\(.*\)@\(.\{-}\)$' "split machine by @"
        let s:user    = s:user.'@'.substitute(s:machine,dirpat,'\1','') "makes user@<machine_part1>"
        let s:machine = substitute(s:machine,dirpat,'\2','')  "makes user@<machine_part2>"

        echo 'user:' s:user
        echo 'machine:' s:machine
        echo 'method:' s:method
        echo 'port:' s:port
        echo 'path:' s:path
        echo 'fname:' s:fname
    endif
endfunction

function s:RemotePathAnalysisNew(dirname)

    "                method   ://    user  @      machine      :port            /path
    let dirpat  = '^\(\w\{-}\)://\(\([^@]\+\)@\)\=\([^/:#]\+\)\%([:#]\(\d\+\)\)\=/\(.*\)$'
    let s:method  = substitute(a:dirname,dirpat,'\1','')
    let s:user    = substitute(a:dirname,dirpat,'\3','')
    let s:machine = substitute(a:dirname,dirpat,'\4','')
    let s:port    = substitute(a:dirname,dirpat,'\5','')
    let s:path    = substitute(a:dirname,dirpat,'\6','')
    let s:fname   = substitute(s:path,'^.*/\ze.','','')

    echo 'user:' s:user
    echo 'machine:' s:machine
    echo 'method:' s:method
    echo 'port:' s:port
    echo 'path:' s:path
    echo 'fname:' s:fname

    if s:machine =~ '@' "machine contains @"
        echo '==========='
        let dirpat    = '^\(.*\)@\(.\{-}\)$' "split by @"
        let s:user    = s:user.'@'.substitute(s:machine,dirpat,'\1','')  "makes user@<machine_part1>"
        let s:machine = substitute(s:machine,dirpat,'\2','') "makes user@<machine_part2>"

        echo 'user:' s:user
        echo 'machine:' s:machine
        echo 'method:' s:method
        echo 'port:' s:port
        echo 'path:' s:path
        echo 'fname:' s:fname
    endif
endfunction


echo '============='
echo '===OLD ONE==='
echo '============='
call s:RemotePathAnalysis('scp://user-01@localhost:2222//home/user-01/test.txt')
echo '============='
echo '===NEW ONE==='
echo '============='
call s:RemotePathAnalysisNew('scp://user-01@localhost:2222//home/user-01/test.txt')
echo '============='
echo '===IF CASE==='
echo '============='
call s:RemotePathAnalysis('scp://why@is_thre@if/test.txt')
```
output:
```
=============
===OLD ONE===
=============
user: 
machine: user-01@localhost
method: scp
port: 2222
path: /home/user-01/test.txt
fname: test.txt
==> machine contains @
user: @user-01
machine: localhost
method: scp
port: 2222
path: /home/user-01/test.txt
fname: test.txt
=============
===NEW ONE===
=============
user: user-01
machine: localhost
method: scp
port: 2222
path: /home/user-01/test.txt
fname: test.txt
=============
===IF CASE===
=============
user: why                                                                                                            
machine: is_thre@if                                                                                                   
method: scp                                                                                                          
port:                                                                                                                
path: test.txt                                                                                                       
fname: test.txt                                                                                                      
==> machine contains @                                                                                               
user: why@is_thre                                                                                                    
machine: if                                                                                                           
method: scp                                                                                                          
port:                                                                                                                
path: test.txt                                                                                                       
fname: test.txt 
```
