### PR TITLE
ft: add j2 as jinja

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -2157,6 +2157,7 @@ const ft_from_ext = {
   "jgr": "jgraph",
   # Jinja
   "jinja": "jinja",
+  "j2": "jinja",
   # Jujutsu
   "jjdescription": "jjdescription",
   # Jovial

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -405,7 +405,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     javascriptreact: ['file.jsx'],
     jess: ['file.clp'],
     jgraph: ['file.jgr'],
-    jinja: ['file.jinja'],
+    jinja: ['file.jinja', 'file.j2'],
     jjdescription: ['file.jjdescription'],
     jovial: ['file.jov', 'file.j73', 'file.jovial'],
     jproperties: ['file.properties', 'file.properties_xx', 'file.properties_xx_xx', 'some.properties_xx_xx_file', 'org.eclipse.xyz.prefs'],


### PR DESCRIPTION
Recognizes `.j2` files as Jinja templates by adding a `"j2": "jinja"` mapping in `vim/runtime/autoload/dist/ft.vim`, enabling syntax highlighting.