### PR TITLE
fix(new-tutor): set buftype to 'nowrite' instead of 'nofile'

### DIFF
--- a/runtime/autoload/tutor.vim
+++ b/runtime/autoload/tutor.vim
@@ -225,7 +225,7 @@ endfunction
 function! tutor#EnableInteractive(enable)
     let enable = a:enable
     if enable
-        setlocal buftype=nofile
+        setlocal buftype=nowrite
         setlocal concealcursor+=inv
         setlocal conceallevel=2
         call tutor#ApplyMarks()

--- a/src/testdir/test_plugin_tutor.vim
+++ b/src/testdir/test_plugin_tutor.vim
@@ -10,7 +10,7 @@ endfunc
 
 func Test_auto_enable_interactive()
   Tutor
-  call assert_equal('nofile', &buftype)
+  call assert_equal('nowrite', &buftype)
   call assert_match('tutor#EnableInteractive', b:undo_ftplugin)
 
   edit Xtutor/Xtest.tutor


### PR DESCRIPTION
Problem:
After I have opened the tutor with `:Tutor`, then I close its window with `:q`, then if I run `:Tutor` to open the tutor again, it will open an empty buffer instead of the tutor content. This is a very confusing behavior.

Related issue https://github.com/neovim/neovim/issues/36228

Solution:
I believe the point of `set buftype=nofile` is just to prevent users from accidentally writing changes to the tutor file, so why not use `nowrite` instead?