### PR TITLE
Refactor strings.c to remove calls to STRLEN()

### DIFF
--- a/src/strings.c
+++ b/src/strings.c
@@ -1263,10 +1263,7 @@ string_from_blob(blob_T *blob, long *start_idx)
 	ga_append(&str_ga, byte);
     }
 
-    ga_append(&str_ga, NUL);
-
-    char_u *ret_str = vim_strnsave(str_ga.ga_data, str_ga.ga_len - 1);	// -1 to allow for the NUL
-									// in the ga_append() above.
+    char_u *ret_str = vim_strnsave(str_ga.ga_data, str_ga.ga_len);
     *start_idx = idx;
 
     ga_clear(&str_ga);

--- a/src/strings.c
+++ b/src/strings.c
@@ -194,7 +194,7 @@ vim_strsave_shellescape(char_u *string, int do_special, int do_newline)
 	if (*p == '\'')
 	{
 	    if (powershell)
-		length +=2;		// ' => ''
+		length += 2;		// ' => ''
 	    else
 		length += 3;		// ' => '\''
 	}
@@ -880,20 +880,20 @@ string_count(char_u *haystack, char_u *needle, int ic)
     long	n = 0;
     char_u	*p = haystack;
     char_u	*next;
+    size_t	needlelen;
 
     if (p == NULL || needle == NULL || *needle == NUL)
 	return 0;
 
+    needlelen = STRLEN(needle);
     if (ic)
     {
-	size_t len = STRLEN(needle);
-
 	while (*p != NUL)
 	{
-	    if (MB_STRNICMP(p, needle, len) == 0)
+	    if (MB_STRNICMP(p, needle, needlelen) == 0)
 	    {
 		++n;
-		p += len;
+		p += needlelen;
 	    }
 	    else
 		MB_PTR_ADV(p);
@@ -903,7 +903,7 @@ string_count(char_u *haystack, char_u *needle, int ic)
 	while ((next = (char_u *)strstr((char *)p, (char *)needle)) != NULL)
 	{
 	    ++n;
-	    p = next + STRLEN(needle);
+	    p = next + needlelen;
 	}
 
     return n;
@@ -911,7 +911,7 @@ string_count(char_u *haystack, char_u *needle, int ic)
 
 /*
  * Make a typval_T of the first character of "input" and store it in "output".
- * Return OK or FAIL.
+ * Return -1 on failure or v_string's length on success.
  */
     static int
 copy_first_char_to_tv(char_u *input, typval_T *output)
@@ -920,15 +920,15 @@ copy_first_char_to_tv(char_u *input, typval_T *output)
     int		len;
 
     if (input == NULL || output == NULL)
-	return FAIL;
+	return -1;
 
     len = has_mbyte ? mb_ptr2len(input) : 1;
     STRNCPY(buf, input, len);
     buf[len] = NUL;
     output->v_type = VAR_STRING;
-    output->vval.v_string = vim_strsave(buf);
+    output->vval.v_string = vim_strnsave(buf, len);
 
-    return output->vval.v_string == NULL ? FAIL : OK;
+    return output->vval.v_string == NULL ? -1 : len;
 }
 
 /*
@@ -963,9 +963,9 @@ string_filter_map(
     ga_init2(&ga, sizeof(char), 80);
     for (p = str; *p != NUL; p += len)
     {
-	if (copy_first_char_to_tv(p, &tv) == FAIL)
+	len = copy_first_char_to_tv(p, &tv);
+	if (len < 0)
 	    break;
-	len = (int)STRLEN(tv.vval.v_string);
 
 	set_vim_var_nr(VV_KEY, idx);
 	if (filter_map_one(&tv, expr, filtermap, fc, &newtv, &rem) == FAIL
@@ -1026,9 +1026,10 @@ string_reduce(
 	    semsg(_(e_reduce_of_an_empty_str_with_no_initial_value), "String");
 	    return;
 	}
-	if (copy_first_char_to_tv(p, rettv) == FAIL)
+	len = copy_first_char_to_tv(p, rettv);
+	if (len < 0)
 	    return;
-	p += STRLEN(rettv->vval.v_string);
+	p += len;
     }
     else if (check_for_string_arg(argvars, 2) == FAIL)
 	return;
@@ -1041,9 +1042,9 @@ string_reduce(
     for ( ; *p != NUL; p += len)
     {
 	argv[0] = *rettv;
-	if (copy_first_char_to_tv(p, &argv[1]) == FAIL)
+	len = copy_first_char_to_tv(p, &argv[1]);
+	if (len < 0)
 	    break;
-	len = (int)STRLEN(argv[1].vval.v_string);
 
 	r = eval_expr_typval(expr, TRUE, argv, 2, fc, rettv);
 
@@ -1221,17 +1222,15 @@ convert_string(char_u *str, char_u *from, char_u *to)
     static void
 blob_from_string(char_u *str, blob_T *blob)
 {
-    size_t len = STRLEN(str);
+    char_u  *p;
 
-    for (size_t i = 0; i < len; i++)
+    for (p = str; *p != NUL; ++p)
     {
-	int	ch = str[i];
-
-	if (str[i] == NL)
+	if (*p == NL)
 	    // Translate newlines in the string to NUL character
-	    ch = NUL;
+	    *p = NUL;
 
-	ga_append(&blob->bv_ga, ch);
+	ga_append(&blob->bv_ga, (int)*p);
     }
 }
 
@@ -1269,7 +1268,7 @@ string_from_blob(blob_T *blob, long *start_idx)
 
     ga_append(&str_ga, NUL);
 
-    char_u *ret_str = vim_strsave(str_ga.ga_data);
+    char_u *ret_str = vim_strnsave(str_ga.ga_data, str_ga.ga_len);
     *start_idx = idx;
 
     ga_clear(&str_ga);
@@ -2648,7 +2647,7 @@ vim_snprintf_safelen(char *str, size_t str_m, const char *fmt, ...)
     int	    str_l;
 
     va_start(ap, fmt);
-    str_l = vim_vsnprintf(str, str_m, fmt, ap);
+    str_l = vim_vsnprintf_typval(str, str_m, fmt, ap, NULL);
     va_end(ap);
 
     if (str_l < 0)

--- a/src/strings.c
+++ b/src/strings.c
@@ -1226,11 +1226,8 @@ blob_from_string(char_u *str, blob_T *blob)
 
     for (p = str; *p != NUL; ++p)
     {
-	if (*p == NL)
-	    // Translate newlines in the string to NUL character
-	    *p = NUL;
-
-	ga_append(&blob->bv_ga, (int)*p);
+	// Translate newlines in the string to NUL character
+	ga_append(&blob->bv_ga, (*p == NL) ? NUL : (int)*p);
     }
 }
 
@@ -1268,7 +1265,8 @@ string_from_blob(blob_T *blob, long *start_idx)
 
     ga_append(&str_ga, NUL);
 
-    char_u *ret_str = vim_strnsave(str_ga.ga_data, str_ga.ga_len);
+    char_u *ret_str = vim_strnsave(str_ga.ga_data, str_ga.ga_len - 1);	// -1 to allow for the NUL
+									// in the ga_append() above.
     *start_idx = idx;
 
     ga_clear(&str_ga);

--- a/src/strings.c
+++ b/src/strings.c
@@ -880,12 +880,11 @@ string_count(char_u *haystack, char_u *needle, int ic)
     long	n = 0;
     char_u	*p = haystack;
     char_u	*next;
-    size_t	needlelen;
 
     if (p == NULL || needle == NULL || *needle == NUL)
 	return 0;
 
-    needlelen = STRLEN(needle);
+    size_t  needlelen = STRLEN(needle);
     if (ic)
     {
 	while (*p != NUL)


### PR DESCRIPTION
This PR does some same refactoring of functions in strings.c to remove calls to `STRLEN()`.

Specifically:
In `vim_strsave_shellescape()` a small cosmetic change.
In `string_count()` move the call to `STRLEN()` outside the `while` loop.
In `copy_first_char_to_tv()` change to return `-1` on failure or the length of resulting `v_string`. Change `string_filter_map()` and `string_reduce()` to use the return value of `copy_first_char_to_tv()`.
In `blob_from_string()` refactor to remove call to `STRLEN()`.
In `string_from_blob()` call `vim_strnsave()` instead of `vim_strsave()`.
In `vim_snprintf_safelen()` call `vim_vsnprintf_typval()` directly instead of `vim_vsnprintf()` which then calls `vim_vsnprintf_typval()`.

Cheers
John