### PR TITLE
Fix Python 3.14 test failures in Test_python3_errors

### DIFF
--- a/src/testdir/test_python3.vim
+++ b/src/testdir/test_python3.vim
@@ -28,6 +28,7 @@ func Test_AAA_python3_setup()
     py37_exception_repr = re.compile(r'([^\(\),])(\)+)$')
     py39_type_error_pattern = re.compile(r'\w+\.([^(]+\(\) takes)')
     py310_type_error_pattern = re.compile(r'takes (\d+) positional argument but (\d+) were given')
+    py314_type_error_tuple_pattern = re.compile(r'must be (\d+)-item tuple')
 
     def emsg(ei):
       return ei[0].__name__ + ':' + repr(ei[1].args)
@@ -64,6 +65,8 @@ func Test_AAA_python3_setup()
                         # Python 3.9 reports errors like "vim.command() takes ..." instead of "command() takes ..."
                         msg = py39_type_error_pattern.sub(r'\1', msg)
                         msg = py310_type_error_pattern.sub(r'takes exactly \1 positional argument (\2 given)', msg)
+                        # Python 3.14 has specific error messages for Tuple's
+                        msg = py314_type_error_tuple_pattern.sub(r'must be \1-item sequence', msg)
                 elif sys.version_info >= (3, 5) and e.__class__ is ValueError and str(e) == 'embedded null byte':
                     msg = repr((TypeError, TypeError('expected bytes with no null')))
                 else:


### PR DESCRIPTION
Python 3.14 changed the error message from "argument must be 2-item sequence" to "argument must be 2-item tuple". Fix test to account for that. Otherwise the error message for the `vim.current.window.cursor = True` line would not match.

---

This does not happen in Vim CI right now because it's not using the new Python 3.14 yet. I saw this on MacVim's CI which does. The [failed test without this fix](https://github.com/macvim-dev/macvim/actions/runs/18765240626/job/53554122262) looks like this:

```
Found errors in Test_python3_errors():
command line..script /Users/ychin/Dev/external/vim/src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_python3_errors line 1205: Expected 'vim.current.window.cursor = True:(<class ''TypeError''>, TypeError(''argument must be 2-item sequence, not bool'',))' but got 'vim.current.window.cursor = True:(<class ''TypeError''>, TypeError(''argument must be 3-item sequence, not bool'',))'
```