### PR TITLE
runtime(rmd): force function override

### DIFF
--- a/runtime/ftplugin/rmd.vim
+++ b/runtime/ftplugin/rmd.vim
@@ -6,6 +6,7 @@
 " Last Change:
 "  2024 Feb 28 by Vim Project
 "  2024 Sep 23 by Vim Project: properly restore fex option
+"  2025 Oct 24 by Vim Project: force override functions
 " Original work by Alex Zvoleff (adjusted from R help for rmd by Michel Kuhlmann)
 
 " Only do this when not yet done for this buffer
@@ -26,7 +27,7 @@ setlocal iskeyword=@,48-57,_,.
 let s:cpo_save = &cpo
 set cpo&vim
 
-function FormatRmd()
+function! FormatRmd()
   if search("^[ \t]*```[ ]*{r", "bncW") > search("^[ \t]*```$", "bncW")
     setlocal comments=:#',:###,:##,:#
   else
@@ -36,7 +37,7 @@ function FormatRmd()
 endfunction
 
 let s:last_line = 0
-function SetRmdCommentStr()
+function! SetRmdCommentStr()
   if line('.') == s:last_line
     return
   endif


### PR DESCRIPTION
In certain cases, ftplugin gets in a bad state with R Markdown files where:

- `FormatRmd`
- `SetRmdCommentStr`

give errors on loading new or existing buffers into windows. `b:did_ftplugin` might not be set, but then again, it also happens on new buffers.

I've only noticed this problem with Quarto/R Markdown files but I haven't identified its pattern yet (or why or when ftplugin goes into a state where it gives those errors), but it might happen with other ftplugins. This is a workaround until I discover what the root cause is.

<img width="1195" height="156" alt="Screenshot 2025-10-24 at 15 21 04" src="https://github.com/user-attachments/assets/2030d49c-0c55-49bc-a3a2-b85296bff28c" />

My platform:

VIM - Vi IMproved 9.1 (2024 Jan 02, compiled Oct 12 2025 14:37:02) Included patches: 1-1850