### PR TITLE
cindent: wrong indentation after an array declaration

### DIFF
--- a/src/cindent.c
+++ b/src/cindent.c
@@ -3476,7 +3476,7 @@ get_c_indent(void)
 			    amount = cur_amount;
 
 			    n = (int)STRLEN(l);
-			    if (terminated == ',' && (*skipwhite(l) == ']'
+			    if (curbuf->b_ind_js && terminated == ',' && (*skipwhite(l) == ']'
 					|| (n >=2 && l[n - 2] == ']')))
 				break;
 

--- a/src/testdir/test_cindent.vim
+++ b/src/testdir/test_cindent.vim
@@ -1106,6 +1106,11 @@ def Test_cindent_1()
   }
   }
 
+  void foo() {
+  float a[5],
+  b;
+  }
+
   /* end of AUTO */
   [CODE]
 
@@ -2081,6 +2086,11 @@ def Test_cindent_1()
   			baz();
   			break;
   	}
+  }
+
+  void foo() {
+  	float a[5],
+  		  b;
   }
 
   /* end of AUTO */


### PR DESCRIPTION
Problem:
cindent matches a javascript syntax for C files
causing wrong indentation in the following case
float a[5],
b; <- this is not aligned with 'a' if we are inside curly braces

Solution:
check if the filetype if javascript before matching the syntax

I am not totally sure, what is the purpose of matching that syntax,
but based on the commits that introduced it (7.4.670, 7.4.891),
I assume it is meant for javascript. At least it is not useful in C.