### PR TITLE
Not able to use a lambda with :defer

### DIFF
--- a/runtime/doc/userfunc.txt
+++ b/runtime/doc/userfunc.txt
@@ -449,6 +449,15 @@ or altering execution outside of deferred functions.
 No range is accepted.  The function can be a partial with extra arguments, but
 not with a dictionary. *E1300*
 
+In a |:def| function, a lambda can be used with |:defer|.  Example: >
+
+    def Fn()
+      set lazyredraw
+      defer () => {
+        set lazyredraw&
+      }()
+    enddef
+<
 ==============================================================================
 
 4. Automatically loading functions ~

--- a/src/proto/vim9expr.pro
+++ b/src/proto/vim9expr.pro
@@ -7,6 +7,7 @@ int compile_load(char_u **arg, size_t namelen, char_u *end_arg, cctx_T *cctx, in
 int compile_arguments(char_u **arg, cctx_T *cctx, int *argcount, ca_special_T special_fn);
 char_u *to_name_end(char_u *arg, int use_namespace);
 char_u *to_name_const_end(char_u *arg);
+int compile_lambda(char_u **arg, cctx_T *cctx);
 int get_lambda_tv_and_compile(char_u **arg, typval_T *rettv, int types_optional, evalarg_T *evalarg);
 exprtype_T get_compare_type(char_u *p, int *len, int *type_is);
 void skip_expr_cctx(char_u **arg, cctx_T *cctx);

--- a/src/vim9expr.c
+++ b/src/vim9expr.c
@@ -1747,7 +1747,7 @@ compile_tuple(
  * "*arg" points to the '('.
  * Returns OK/FAIL when a lambda is recognized, NOTDONE if it's not a lambda.
  */
-    static int
+    int
 compile_lambda(char_u **arg, cctx_T *cctx)
 {
     int		r;


### PR DESCRIPTION
Support using a lambda function with a command-block in a `:defer` command.

Fixes the issue reported in #18626.