### PR TITLE
runtime(doc): Clean up file header whitespace

### DIFF
--- a/runtime/doc/arabic.txt
+++ b/runtime/doc/arabic.txt
@@ -1,7 +1,7 @@
 *arabic.txt*	For Vim version 9.1.  Last change: 2025 Oct 26
 
 
-		  VIM REFERENCE MANUAL    by Nadim Shaikli
+		  VIM REFERENCE MANUAL	  by Nadim Shaikli
 
 
 Arabic Language support (options & mappings) for Vim		*Arabic*

--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -1,7 +1,7 @@
-*autocmd.txt*   For Vim version 9.1.  Last change: 2025 Oct 12
+*autocmd.txt*	For Vim version 9.1.  Last change: 2025 Oct 12
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 Automatic commands				*autocommand* *autocommands*

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -1,7 +1,7 @@
 *builtin.txt*	For Vim version 9.1.  Last change: 2025 Oct 26
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 Builtin functions				*builtin-functions*

--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -1,7 +1,7 @@
-*change.txt*    For Vim version 9.1.  Last change: 2025 Oct 26
+*change.txt*	For Vim version 9.1.  Last change: 2025 Oct 26
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 This file describes commands that delete or change text.  In this context,

--- a/runtime/doc/channel.txt
+++ b/runtime/doc/channel.txt
@@ -1,7 +1,7 @@
-*channel.txt*      For Vim version 9.1.  Last change: 2025 Oct 26
+*channel.txt*	For Vim version 9.1.  Last change: 2025 Oct 26
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 		      Inter-process communication		*channel*

--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -1,7 +1,7 @@
-*cmdline.txt*   For Vim version 9.1.  Last change: 2025 Oct 26
+*cmdline.txt*	For Vim version 9.1.  Last change: 2025 Oct 26
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 				*Cmdline-mode* *Command-line-mode*

--- a/runtime/doc/debug.txt
+++ b/runtime/doc/debug.txt
@@ -1,7 +1,7 @@
-*debug.txt*     For Vim version 9.1.  Last change: 2025 Oct 12
+*debug.txt*	For Vim version 9.1.  Last change: 2025 Oct 12
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 Debugging Vim						*debug-vim*

--- a/runtime/doc/debugger.txt
+++ b/runtime/doc/debugger.txt
@@ -1,7 +1,7 @@
-*debugger.txt*  For Vim version 9.1.  Last change: 2025 Oct 12
+*debugger.txt*	For Vim version 9.1.  Last change: 2025 Oct 12
 
 
-		  VIM REFERENCE MANUAL    by Gordon Prieur
+		  VIM REFERENCE MANUAL	  by Gordon Prieur
 
 
 Debugger Support Features				*debugger-support*

--- a/runtime/doc/develop.txt
+++ b/runtime/doc/develop.txt
@@ -1,7 +1,7 @@
-*develop.txt*   For Vim version 9.1.  Last change: 2025 Oct 09
+*develop.txt*	For Vim version 9.1.  Last change: 2025 Oct 09
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 Development of Vim.					*development*

--- a/runtime/doc/diff.txt
+++ b/runtime/doc/diff.txt
@@ -1,7 +1,7 @@
-*diff.txt*      For Vim version 9.1.  Last change: 2025 Oct 14
+*diff.txt*	For Vim version 9.1.  Last change: 2025 Oct 14
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 				*diff* *vimdiff* *gvimdiff* *diff-mode*

--- a/runtime/doc/digraph.txt
+++ b/runtime/doc/digraph.txt
@@ -1,7 +1,7 @@
-*digraph.txt*   For Vim version 9.1.  Last change: 2025 Oct 12
+*digraph.txt*	For Vim version 9.1.  Last change: 2025 Oct 12
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 Digraphs					*digraph* *digraphs* *Digraphs*

--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -1,7 +1,7 @@
-*editing.txt*   For Vim version 9.1.  Last change: 2025 Oct 14
+*editing.txt*	For Vim version 9.1.  Last change: 2025 Oct 14
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 Editing files						*edit-files*

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1,7 +1,7 @@
 *eval.txt*	For Vim version 9.1.  Last change: 2025 Nov 01
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 Expression evaluation			*expression* *expr* *E15* *eval*

--- a/runtime/doc/farsi.txt
+++ b/runtime/doc/farsi.txt
@@ -1,7 +1,7 @@
-*farsi.txt*     For Vim version 9.1.  Last change: 2019 May 05
+*farsi.txt*	For Vim version 9.1.  Last change: 2019 May 05
 
 
-		  VIM REFERENCE MANUAL    by Mortaza Ghassab Shiran
+		  VIM REFERENCE MANUAL	  by Mortaza Ghassab Shiran
 
 
 Right to Left and Farsi Mapping for Vim		*farsi* *Farsi*

--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -1,7 +1,7 @@
 *filetype.txt*	For Vim version 9.1.  Last change: 2025 Oct 12
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 Filetypes						*filetype* *file-type*

--- a/runtime/doc/fold.txt
+++ b/runtime/doc/fold.txt
@@ -1,7 +1,7 @@
-*fold.txt*      For Vim version 9.1.  Last change: 2025 Oct 03
+*fold.txt*	For Vim version 9.1.  Last change: 2025 Oct 03
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 Folding						*Folding* *folding* *folds*

--- a/runtime/doc/gui.txt
+++ b/runtime/doc/gui.txt
@@ -1,7 +1,7 @@
-*gui.txt*       For Vim version 9.1.  Last change: 2025 Oct 12
+*gui.txt*	For Vim version 9.1.  Last change: 2025 Oct 12
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 Vim's Graphical User Interface				*gui* *GUI*

--- a/runtime/doc/gui_w32.txt
+++ b/runtime/doc/gui_w32.txt
@@ -1,7 +1,7 @@
-*gui_w32.txt*   For Vim version 9.1.  Last change: 2025 Oct 11
+*gui_w32.txt*	For Vim version 9.1.  Last change: 2025 Oct 11
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 Vim's Win32 Graphical User Interface			*gui-w32* *win32-gui*

--- a/runtime/doc/gui_x11.txt
+++ b/runtime/doc/gui_x11.txt
@@ -1,7 +1,7 @@
-*gui_x11.txt*   For Vim version 9.1.  Last change: 2025 Oct 12
+*gui_x11.txt*	For Vim version 9.1.  Last change: 2025 Oct 12
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 Vim's Graphical User Interface				*gui-x11* *GUI-X11*

--- a/runtime/doc/hangulin.txt
+++ b/runtime/doc/hangulin.txt
@@ -1,7 +1,8 @@
-*hangulin.txt*  For Vim version 9.1.  Last change: 2019 Nov 21
+*hangulin.txt*	For Vim version 9.1.  Last change: 2019 Nov 21
 
 
-		  VIM REFERENCE MANUAL    by Chi-Deok Hwang and Sung-Hyun Nam
+		  VIM REFERENCE MANUAL	  by Chi-Deok Hwang and Sung-Hyun Nam
+
 
 						*hangul*
 Vim had built-in support for hangul, the Korean language, for users without

--- a/runtime/doc/hebrew.txt
+++ b/runtime/doc/hebrew.txt
@@ -1,7 +1,7 @@
-*hebrew.txt*    For Vim version 9.1.  Last change: 2025 Oct 26
+*hebrew.txt*	For Vim version 9.1.  Last change: 2025 Oct 26
 
 
-		  VIM REFERENCE MANUAL    by Ron Aaron and Avner Lottem
+		  VIM REFERENCE MANUAL	  by Ron Aaron and Avner Lottem
 
 
 Hebrew Language support (options & mapping) for Vim		*hebrew*

--- a/runtime/doc/helphelp.txt
+++ b/runtime/doc/helphelp.txt
@@ -1,7 +1,7 @@
 *helphelp.txt*	For Vim version 9.1.  Last change: 2025 Oct 12
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 Help on help files					*helphelp*

--- a/runtime/doc/howto.txt
+++ b/runtime/doc/howto.txt
@@ -1,7 +1,7 @@
 *howto.txt*	For Vim version 9.1.  Last change: 2025 Oct 26
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 How to ...				*howdoi* *how-do-i* *howto* *how-to*

--- a/runtime/doc/if_cscop.txt
+++ b/runtime/doc/if_cscop.txt
@@ -1,7 +1,8 @@
-*if_cscop.txt*  For Vim version 9.1.  Last change: 2025 Oct 12
+*if_cscop.txt*	For Vim version 9.1.  Last change: 2025 Oct 12
 
 
-		  VIM REFERENCE MANUAL    by Andy Kahn
+		  VIM REFERENCE MANUAL	  by Andy Kahn
+
 
 							*cscope* *Cscope*
 This document explains how to use Vim's cscope interface.

--- a/runtime/doc/if_lua.txt
+++ b/runtime/doc/if_lua.txt
@@ -1,7 +1,7 @@
-*if_lua.txt*    For Vim version 9.1.  Last change: 2025 Oct 12
+*if_lua.txt*	For Vim version 9.1.  Last change: 2025 Oct 12
 
 
-		  VIM REFERENCE MANUAL    by Luis Carvalho
+		  VIM REFERENCE MANUAL	  by Luis Carvalho
 
 
 The Lua Interface to Vim				*lua* *Lua*

--- a/runtime/doc/if_mzsch.txt
+++ b/runtime/doc/if_mzsch.txt
@@ -1,7 +1,7 @@
-*if_mzsch.txt*  For Vim version 9.1.  Last change: 2025 Oct 14
+*if_mzsch.txt*	For Vim version 9.1.  Last change: 2025 Oct 14
 
 
-		  VIM REFERENCE MANUAL    by Sergey Khorev
+		  VIM REFERENCE MANUAL	  by Sergey Khorev
 
 
 The MzScheme Interface to Vim				*mzscheme* *MzScheme*

--- a/runtime/doc/if_ole.txt
+++ b/runtime/doc/if_ole.txt
@@ -1,7 +1,7 @@
-*if_ole.txt*    For Vim version 9.1.  Last change: 2023 Nov 19
+*if_ole.txt*	For Vim version 9.1.  Last change: 2023 Nov 19
 
 
-		  VIM REFERENCE MANUAL    by Paul Moore
+		  VIM REFERENCE MANUAL	  by Paul Moore
 
 
 The OLE Interface to Vim				*ole-interface*

--- a/runtime/doc/if_perl.txt
+++ b/runtime/doc/if_perl.txt
@@ -1,8 +1,9 @@
-*if_perl.txt*   For Vim version 9.1.  Last change: 2025 Oct 26
+*if_perl.txt*	For Vim version 9.1.  Last change: 2025 Oct 26
 
 
-		  VIM REFERENCE MANUAL    by Sven Verdoolaege
+		  VIM REFERENCE MANUAL	  by Sven Verdoolaege
 					  and Matt Gerassimof
+
 
 Perl and Vim				*perl* *Perl*
 

--- a/runtime/doc/if_pyth.txt
+++ b/runtime/doc/if_pyth.txt
@@ -1,7 +1,7 @@
-*if_pyth.txt*   For Vim version 9.1.  Last change: 2025 Oct 12
+*if_pyth.txt*	For Vim version 9.1.  Last change: 2025 Oct 12
 
 
-		  VIM REFERENCE MANUAL    by Paul Moore
+		  VIM REFERENCE MANUAL	  by Paul Moore
 
 
 The Python Interface to Vim				*python* *Python*

--- a/runtime/doc/if_ruby.txt
+++ b/runtime/doc/if_ruby.txt
@@ -1,7 +1,8 @@
-*if_ruby.txt*   For Vim version 9.1.  Last change: 2025 Oct 12
+*if_ruby.txt*	For Vim version 9.1.  Last change: 2025 Oct 12
 
 
-		  VIM REFERENCE MANUAL    by Shugo Maeda
+		  VIM REFERENCE MANUAL	  by Shugo Maeda
+
 
 The Ruby Interface to Vim				*ruby* *Ruby*
 

--- a/runtime/doc/if_sniff.txt
+++ b/runtime/doc/if_sniff.txt
@@ -1,7 +1,7 @@
 *if_sniff.txt*	For Vim version 9.1.  Last change: 2025 Oct 26
 
 
-		  VIM REFERENCE MANUAL    by Anton Leherbauer
+		  VIM REFERENCE MANUAL	  by Anton Leherbauer
 
 
 The SNiFF+ support was removed at patch 7.4.1433.  If you want to check it out

--- a/runtime/doc/if_tcl.txt
+++ b/runtime/doc/if_tcl.txt
@@ -1,7 +1,7 @@
-*if_tcl.txt*    For Vim version 9.1.  Last change: 2025 Oct 12
+*if_tcl.txt*	For Vim version 9.1.  Last change: 2025 Oct 12
 
 
-		  VIM REFERENCE MANUAL    by Ingo Wilken
+		  VIM REFERENCE MANUAL	  by Ingo Wilken
 
 
 The Tcl Interface to Vim				*tcl* *Tcl* *TCL*

--- a/runtime/doc/indent.txt
+++ b/runtime/doc/indent.txt
@@ -1,7 +1,7 @@
-*indent.txt*    For Vim version 9.1.  Last change: 2025 Oct 14
+*indent.txt*	For Vim version 9.1.  Last change: 2025 Oct 14
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 This file is about indenting C programs and other files.

--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -1,7 +1,8 @@
-*index.txt*     For Vim version 9.1.  Last change: 2025 Oct 31
+*index.txt*	For Vim version 9.1.  Last change: 2025 Oct 31
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
+
 
 								*index*
 This file contains a list of all commands for each mode, with a tag and a

--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -1,7 +1,7 @@
-*insert.txt*    For Vim version 9.1.  Last change: 2025 Oct 17
+*insert.txt*	For Vim version 9.1.  Last change: 2025 Oct 17
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 						*Insert* *Insert-mode*

--- a/runtime/doc/intro.txt
+++ b/runtime/doc/intro.txt
@@ -1,7 +1,7 @@
-*intro.txt*     For Vim version 9.1.  Last change: 2025 Oct 12
+*intro.txt*	For Vim version 9.1.  Last change: 2025 Oct 12
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 Introduction to Vim					*ref* *reference*

--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -1,7 +1,7 @@
-*map.txt*       For Vim version 9.1.  Last change: 2025 Oct 12
+*map.txt*	For Vim version 9.1.  Last change: 2025 Oct 12
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 Key mapping, abbreviations and user-defined commands.

--- a/runtime/doc/mbyte.txt
+++ b/runtime/doc/mbyte.txt
@@ -1,7 +1,7 @@
-*mbyte.txt*     For Vim version 9.1.  Last change: 2025 Nov 01
+*mbyte.txt*	For Vim version 9.1.  Last change: 2025 Nov 01
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar et al.
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar et al.
 
 
 Multi-byte support				*multibyte* *multi-byte*

--- a/runtime/doc/message.txt
+++ b/runtime/doc/message.txt
@@ -1,7 +1,7 @@
-*message.txt*   For Vim version 9.1.  Last change: 2025 Nov 01
+*message.txt*	For Vim version 9.1.  Last change: 2025 Nov 01
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 This file contains an alphabetical list of messages and error messages that

--- a/runtime/doc/mlang.txt
+++ b/runtime/doc/mlang.txt
@@ -1,7 +1,7 @@
-*mlang.txt*     For Vim version 9.1.  Last change: 2025 Oct 12
+*mlang.txt*	For Vim version 9.1.  Last change: 2025 Oct 12
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 Multi-language features				*multilang* *multi-lang*

--- a/runtime/doc/motion.txt
+++ b/runtime/doc/motion.txt
@@ -1,7 +1,7 @@
-*motion.txt*    For Vim version 9.1.  Last change: 2025 Oct 12
+*motion.txt*	For Vim version 9.1.  Last change: 2025 Oct 12
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 Cursor motions					*cursor-motions* *navigation*

--- a/runtime/doc/netbeans.txt
+++ b/runtime/doc/netbeans.txt
@@ -1,7 +1,7 @@
-*netbeans.txt*  For Vim version 9.1.  Last change: 2025 Oct 12
+*netbeans.txt*	For Vim version 9.1.  Last change: 2025 Oct 12
 
 
-		  VIM REFERENCE MANUAL    by Gordon Prieur et al.
+		  VIM REFERENCE MANUAL	  by Gordon Prieur et al.
 
 
 					*netbeans* *NetBeans* *netbeans-support*

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1,7 +1,7 @@
 *options.txt*	For Vim version 9.1.  Last change: 2025 Oct 28
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 Options							*options*

--- a/runtime/doc/os_390.txt
+++ b/runtime/doc/os_390.txt
@@ -1,7 +1,8 @@
-*os_390.txt*    For Vim version 9.1.  Last change: 2025 Oct 26
+*os_390.txt*	For Vim version 9.1.  Last change: 2025 Oct 26
 
 
-		  VIM REFERENCE MANUAL    by Ralf Schandl
+		  VIM REFERENCE MANUAL	  by Ralf Schandl
+
 
 					*zOS* *z/OS* *OS390* *os390* *MVS*
 This file contains the particulars for the z/OS UNIX version of Vim.

--- a/runtime/doc/os_amiga.txt
+++ b/runtime/doc/os_amiga.txt
@@ -1,7 +1,7 @@
-*os_amiga.txt*  For Vim version 9.1.  Last change: 2025 Oct 12
+*os_amiga.txt*	For Vim version 9.1.  Last change: 2025 Oct 12
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 							*Amiga*

--- a/runtime/doc/os_beos.txt
+++ b/runtime/doc/os_beos.txt
@@ -1,7 +1,7 @@
 *os_beos.txt*	For Vim version 9.1.  Last change: 2020 Jun 07
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 						*beos* *BeOS* *BeBox*

--- a/runtime/doc/os_dos.txt
+++ b/runtime/doc/os_dos.txt
@@ -1,7 +1,7 @@
-*os_dos.txt*    For Vim version 9.1.  Last change: 2025 Aug 06
+*os_dos.txt*	For Vim version 9.1.  Last change: 2025 Aug 06
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 							*dos* *DOS*

--- a/runtime/doc/os_haiku.txt
+++ b/runtime/doc/os_haiku.txt
@@ -1,7 +1,7 @@
 *os_haiku.txt*	For Vim version 9.1.  Last change: 2025 Oct 12
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 							*Haiku*

--- a/runtime/doc/os_mac.txt
+++ b/runtime/doc/os_mac.txt
@@ -1,7 +1,7 @@
-*os_mac.txt*    For Vim version 9.1.  Last change: 2025 Oct 12
+*os_mac.txt*	For Vim version 9.1.  Last change: 2025 Oct 12
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar et al.
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar et al.
 
 
 					*mac* *Mac* *macintosh* *Macintosh*

--- a/runtime/doc/os_mint.txt
+++ b/runtime/doc/os_mint.txt
@@ -1,7 +1,7 @@
-*os_mint.txt*   For Vim version 9.1.  Last change: 2025 Oct 12
+*os_mint.txt*	For Vim version 9.1.  Last change: 2025 Oct 12
 
 
-		  VIM REFERENCE MANUAL    by Jens M. Felderhoff
+		  VIM REFERENCE MANUAL	  by Jens M. Felderhoff
 
 
 							*MiNT* *Atari*

--- a/runtime/doc/os_msdos.txt
+++ b/runtime/doc/os_msdos.txt
@@ -1,7 +1,7 @@
-*os_msdos.txt*  For Vim version 9.1.  Last change: 2016 Feb 26
+*os_msdos.txt*	For Vim version 9.1.  Last change: 2016 Feb 26
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 					*msdos* *ms-dos* *MSDOS* *MS-DOS*

--- a/runtime/doc/os_os2.txt
+++ b/runtime/doc/os_os2.txt
@@ -1,7 +1,7 @@
-*os_os2.txt*    For Vim version 9.1.  Last change: 2015 Dec 31
+*os_os2.txt*	For Vim version 9.1.  Last change: 2015 Dec 31
 
 
-		  VIM REFERENCE MANUAL    by Paul Slootman
+		  VIM REFERENCE MANUAL	  by Paul Slootman
 
 
 							*os2* *OS2* *OS/2*

--- a/runtime/doc/os_qnx.txt
+++ b/runtime/doc/os_qnx.txt
@@ -1,7 +1,7 @@
-*os_qnx.txt*    For Vim version 9.1.  Last change: 2025 Oct 12
+*os_qnx.txt*	For Vim version 9.1.  Last change: 2025 Oct 12
 
 
-		  VIM REFERENCE MANUAL    by Julian Kinraid
+		  VIM REFERENCE MANUAL	  by Julian Kinraid
 
 
 							*QNX* *qnx*

--- a/runtime/doc/os_risc.txt
+++ b/runtime/doc/os_risc.txt
@@ -1,7 +1,7 @@
-*os_risc.txt*   For Vim version 9.1.  Last change: 2011 May 10
+*os_risc.txt*	For Vim version 9.1.  Last change: 2011 May 10
 
 
-		  VIM REFERENCE MANUAL    by Thomas Leonard
+		  VIM REFERENCE MANUAL	  by Thomas Leonard
 
 
 						*riscos* *RISCOS* *RISC-OS*

--- a/runtime/doc/os_unix.txt
+++ b/runtime/doc/os_unix.txt
@@ -1,7 +1,7 @@
-*os_unix.txt*   For Vim version 9.1.  Last change: 2022 Nov 25
+*os_unix.txt*	For Vim version 9.1.  Last change: 2022 Nov 25
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 							*unix* *Unix*

--- a/runtime/doc/os_vms.txt
+++ b/runtime/doc/os_vms.txt
@@ -1,4 +1,4 @@
-*os_vms.txt*    For Vim version 9.1.  Last change: 2025 Oct 12
+*os_vms.txt*	For Vim version 9.1.  Last change: 2025 Oct 12
 
 
 		  VIM REFERENCE MANUAL

--- a/runtime/doc/os_win32.txt
+++ b/runtime/doc/os_win32.txt
@@ -1,7 +1,7 @@
-*os_win32.txt*  For Vim version 9.1.  Last change: 2025 Oct 12
+*os_win32.txt*	For Vim version 9.1.  Last change: 2025 Oct 12
 
 
-		  VIM REFERENCE MANUAL    by George Reilly
+		  VIM REFERENCE MANUAL	  by George Reilly
 
 
 						*win32* *Win32* *MS-Windows*

--- a/runtime/doc/pattern.txt
+++ b/runtime/doc/pattern.txt
@@ -1,7 +1,7 @@
-*pattern.txt*   For Vim version 9.1.  Last change: 2025 Oct 12
+*pattern.txt*	For Vim version 9.1.  Last change: 2025 Oct 12
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 Patterns and search commands				*pattern-searches*

--- a/runtime/doc/pi_gzip.txt
+++ b/runtime/doc/pi_gzip.txt
@@ -1,7 +1,7 @@
-*pi_gzip.txt*   For Vim version 9.1.  Last change: 2025 Mar 05
+*pi_gzip.txt*	For Vim version 9.1.  Last change: 2025 Mar 05
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 Editing compressed files with Vim		*gzip* *bzip2* *compress*

--- a/runtime/doc/pi_paren.txt
+++ b/runtime/doc/pi_paren.txt
@@ -1,7 +1,7 @@
-*pi_paren.txt*  For Vim version 9.1.  Last change: 2024 Nov 04
+*pi_paren.txt*	For Vim version 9.1.  Last change: 2024 Nov 04
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 Highlighting matching parens			*matchparen*

--- a/runtime/doc/popup.txt
+++ b/runtime/doc/popup.txt
@@ -1,7 +1,7 @@
-*popup.txt*  For Vim version 9.1.  Last change: 2025 Oct 12
+*popup.txt*	For Vim version 9.1.  Last change: 2025 Oct 12
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 Displaying text in a floating window.	*popup* *popup-window* *popupwin*

--- a/runtime/doc/print.txt
+++ b/runtime/doc/print.txt
@@ -1,7 +1,7 @@
-*print.txt*     For Vim version 9.1.  Last change: 2025 Oct 12
+*print.txt*	For Vim version 9.1.  Last change: 2025 Oct 12
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 Printing						*printing*

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -1,7 +1,7 @@
 *quickfix.txt*  For Vim version 9.1.  Last change: 2025 Oct 28
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 This subject is introduced in section |30.1| of the user manual.

--- a/runtime/doc/quickref.txt
+++ b/runtime/doc/quickref.txt
@@ -1,7 +1,8 @@
-*quickref.txt*  For Vim version 9.1.  Last change: 2025 Aug 23
+*quickref.txt*	For Vim version 9.1.  Last change: 2025 Aug 23
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
+
 
 			    Quick reference guide
 

--- a/runtime/doc/quotes.txt
+++ b/runtime/doc/quotes.txt
@@ -1,7 +1,7 @@
-*quotes.txt*    For Vim version 9.1.  Last change: 2018 Mar 29
+*quotes.txt*	For Vim version 9.1.  Last change: 2018 Mar 29
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 							*quotes*

--- a/runtime/doc/recover.txt
+++ b/runtime/doc/recover.txt
@@ -1,7 +1,7 @@
-*recover.txt*   For Vim version 9.1.  Last change: 2025 Oct 12
+*recover.txt*	For Vim version 9.1.  Last change: 2025 Oct 12
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 Recovery after a crash					*crash-recovery*

--- a/runtime/doc/remote.txt
+++ b/runtime/doc/remote.txt
@@ -1,7 +1,7 @@
-*remote.txt*    For Vim version 9.1.  Last change: 2025 Aug 22
+*remote.txt*	For Vim version 9.1.  Last change: 2025 Aug 22
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 Vim client-server communication				*client-server*

--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -1,7 +1,7 @@
-*repeat.txt*    For Vim version 9.1.  Last change: 2025 Nov 01
+*repeat.txt*	For Vim version 9.1.  Last change: 2025 Nov 01
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 Repeating commands, Vim scripts and debugging			*repeating*
@@ -113,7 +113,7 @@ Which is two characters shorter!
 
 When using "global" in Ex mode, a special case is using ":visual" as a
 command.  This will move to a matching line, go to Normal mode to let you
-execute commands there until you use |Q| to return to Ex mode.  This will be
+execute commands there until you use |Q| to return to Ex mode.	This will be
 repeated for each matching line.  While doing this you cannot use ":global".
 To abort this type CTRL-C twice.
 
@@ -122,7 +122,7 @@ To abort this type CTRL-C twice.
 
 							*q* *recording*
 q{0-9a-zA-Z"}		Record typed characters into register {0-9a-zA-Z"}
-			(uppercase to append).  The 'q' command is disabled
+			(uppercase to append).	The 'q' command is disabled
 			while executing a register, and it doesn't work inside
 			a mapping and |:normal|.
 
@@ -143,7 +143,7 @@ q			Stops recording.  (Implementation note: The 'q' that
 
 							*@*
 @{0-9a-z".=*+}		Execute the contents of register {0-9a-z".=*+} [count]
-			times.  Note that register '%' (name of the current
+			times.	Note that register '%' (name of the current
 			file) and '#' (name of the alternate file) cannot be
 			used.
 			The register is executed like a mapping, that means
@@ -224,7 +224,7 @@ For writing a Vim script, see chapter 41 of the user manual |usr_41.txt|.
 			Vim9 script context, the previously defined
 			script-local variables and functions are not cleared.
 			This works like the range started with the
-			":vim9script noclear" command.  The "++clear" argument
+			":vim9script noclear" command.	The "++clear" argument
 			can be used to clear the script-local variables and
 			functions before sourcing the script.  This works like
 			the range started with the `:vim9script` command
@@ -240,7 +240,7 @@ For writing a Vim script, see chapter 41 of the user manual |usr_41.txt|.
 			but only if a two line specifiers range was used.
 
 							*:source!*
-:so[urce]! {file}	Read Vim commands from {file}.  These are commands
+:so[urce]! {file}	Read Vim commands from {file}.	These are commands
 			that are executed from Normal mode, like you type
 			them.
 			When used after |:global|, |:argdo|, |:windo|,
@@ -320,7 +320,7 @@ For writing a Vim script, see chapter 41 of the user manual |usr_41.txt|.
 			When the optional ! is added no plugin files or
 			ftdetect scripts are loaded, only the matching
 			directories are added to 'runtimepath'.  This is
-			useful in your .vimrc.  The plugins will then be
+			useful in your .vimrc.	The plugins will then be
 			loaded during initialization, see |load-plugins| (note
 			that the loading order will be reversed, because each
 			directory is inserted before others).
@@ -385,7 +385,7 @@ For writing a Vim script, see chapter 41 of the user manual |usr_41.txt|.
 				... not converted ...
 
 <			When conversion isn't supported by the system, there
-			is no error message and no conversion is done.  When a
+			is no error message and no conversion is done.	When a
 			line can't be converted there is no error and the
 			original line is kept.
 
@@ -410,7 +410,7 @@ For writing a Vim script, see chapter 41 of the user manual |usr_41.txt|.
 			If {version} is higher than what the current Vim
 			version supports E999 will be given.  You either need
 			to rewrite the script to make it work with an older
-			Vim version, or update Vim to a newer version.  See
+			Vim version, or update Vim to a newer version.	See
 			|vimscript-version| for what changed between versions.
 
 :vim9s[cript] [noclear]				*:vim9s* *:vim9script*
@@ -490,7 +490,7 @@ nested as deep as the number of files that can be opened at one time (about
 
 You can use the "<sfile>" string (literally, this is not a special key) inside
 of the sourced file, in places where a file name is expected.  It will be
-replaced by the file name of the sourced file.  For example, if you have a
+replaced by the file name of the sourced file.	For example, if you have a
 "other.vimrc" file in the same directory as your ".vimrc" file, you can source
 it from your ".vimrc" file with this command: >
 	:source <sfile>:h/other.vimrc
@@ -507,7 +507,7 @@ the <t_xx> termcap codes, these can only be used in mappings.
 Win32: Files that are read with ":source" normally have <CR><NL> <EOL>s.
 These always work.  If you are using a file with <NL> <EOL>s (for example, a
 file made on Unix), this will be recognized if 'fileformats' is not empty and
-the first line does not end in a <CR>.  This fails if the first line has
+the first line does not end in a <CR>.	This fails if the first line has
 something like ":map <F1> :help^M", where "^M" is a <CR>.  If the first line
 ends in a <CR>, but following ones don't, you will get an error message,
 because the <CR> from the first lines will be lost.
@@ -515,12 +515,12 @@ because the <CR> from the first lines will be lost.
 Mac Classic: Files that are read with ":source" normally have <CR> <EOL>s.
 These always work.  If you are using a file with <NL> <EOL>s (for example, a
 file made on Unix), this will be recognized if 'fileformats' is not empty and
-the first line does not end in a <CR>.  Be careful not to use a file with <NL>
+the first line does not end in a <CR>.	Be careful not to use a file with <NL>
 linebreaks which has a <CR> in first line.
 
 On other systems, Vim expects ":source"ed files to end in a <NL>.  These
 always work.  If you are using a file with <CR><NL> <EOL>s (for example, a
-file made on MS-Windows), all lines will have a trailing <CR>.  This may cause
+file made on MS-Windows), all lines will have a trailing <CR>.	This may cause
 problems for some commands (e.g., mappings).  There is no automatic <EOL>
 detection, because it's common to start with a line that defines a mapping
 that ends in a <CR>, which will confuse the automaton.
@@ -691,7 +691,7 @@ To load an optional plugin from a pack use the `:packadd` command: >
 This searches for "pack/*/opt/foodebug" in 'packpath' and will find
 ~/.vim/pack/foo/opt/foodebug/plugin/debugger.vim and source it.
 
-This could be done if some conditions are met.  For example, depending on
+This could be done if some conditions are met.	For example, depending on
 whether Vim supports a feature or a dependency is missing.
 
 You can also load an optional plugin at startup, by putting this command in
@@ -712,7 +712,7 @@ you put them below "pack/*/opt", for example
 ".vim/pack/mycolors/opt/dark/colors/very_dark.vim".
 
 Filetype plugins should go under "pack/*/start", so that they are always
-found.  Unless you have more than one plugin for a file type and want to
+found.	Unless you have more than one plugin for a file type and want to
 select which one to load with `:packadd`.  E.g. depending on the compiler
 version: >
 	if foo_compiler_version > 34
@@ -734,9 +734,9 @@ users can choose what they include or not.  Or you can decide to use one
 package with optional plugins, and tell the user to add the preferred ones
 with `:packadd`.
 
-Decide how you want to distribute the package.  You can create an archive or
+Decide how you want to distribute the package.	You can create an archive or
 you could use a repository.  An archive can be used by more users, but is a
-bit harder to update to a new version.  A repository can usually be kept
+bit harder to update to a new version.	A repository can usually be kept
 up-to-date easily, but it requires a program like "git" to be available.
 You can do both, github can automatically create an archive for a release.
 
@@ -1169,7 +1169,7 @@ Once in debugging mode, the usual Ex commands can be used.  For example, to
 inspect the value of a variable: >
 	echo idx
 When inside a user function, this will print the value of the local variable
-"idx".  Prepend "g:" to get the value of a global variable: >
+"idx".	Prepend "g:" to get the value of a global variable: >
 	echo g:idx
 All commands are executed in the context of the current function or script.
 You can also set options, for example setting or resetting 'verbose' will show
@@ -1191,7 +1191,7 @@ continuation, only the first line is printed before the debugging prompt.
 The line number for a function line is relative to the start of the function.
 If you have trouble figuring out where you are, edit the file that defines
 the function in another Vim, search for the start of the function and do
-"99j".  Replace "99" with the line number.
+"99j".	Replace "99" with the line number.
 
 Additionally, these commands can be used:
 							*>cont*
@@ -1202,7 +1202,7 @@ Additionally, these commands can be used:
 			everything.  Still stops at the next breakpoint.
 							*>next*
 	next		Execute the command and come back to debug mode when
-			it's finished.  This steps over user function calls
+			it's finished.	This steps over user function calls
 			and sourced files.
 							*>step*
 	step		Execute the command and come back to debug mode for
@@ -1235,7 +1235,7 @@ About the additional commands in debug mode:
 - There is no command-line completion for them, you get the completion for the
   normal Ex commands only.
 - You can shorten them, up to a single character, unless more than one command
-  starts with the same letter.  "f" stands for "finish", use "fr" for "frame".
+  starts with the same letter.	"f" stands for "finish", use "fr" for "frame".
 - Hitting <CR> will repeat the previous one.  When doing another command, this
   is reset (because it's not clear what you want to repeat).
 - When you want to use the Ex command with the same name, prepend a colon:
@@ -1312,9 +1312,9 @@ this line.  When omitted line 1 is used.
 
 							*:debug-name*
 {name} is a pattern that is matched with the file or function name.  The
-pattern is like what is used for autocommands.  There must be a full match (as
+pattern is like what is used for autocommands.	There must be a full match (as
 if the pattern starts with "^" and ends in "$").  A "*" matches any sequence
-of characters.  'ignorecase' is not used, but "\c" can be used in the pattern
+of characters.	'ignorecase' is not used, but "\c" can be used in the pattern
 to ignore case |/\c|.  Don't include the () for the function name!
 
 The match for sourced scripts is done against the full file name.  If no path
@@ -1475,7 +1475,7 @@ the "Total" time reduced by time spent in:
 - external (shell) commands
 
 Lines 7-11 show the time spent in each executed line.  Lines that are not
-executed do not count.  Thus a comment line is never counted.
+executed do not count.	Thus a comment line is never counted.
 
 The Count column shows how many times a line was executed.  Note that the
 "for" command in line 7 is executed one more time as the following lines.
@@ -1489,7 +1489,7 @@ mind there are various things that may clobber the results:
 
 - The accuracy of the time measured depends on the gettimeofday(), or
   clock_gettime() if available, system function.  The accuracy ranges from
-  1/100 second to nanoseconds.  With clock_gettime() the times are displayed
+  1/100 second to nanoseconds.	With clock_gettime() the times are displayed
   in nanoseconds, otherwise microseconds.  You can use `has("prof_nsec")`.
 
 - Real elapsed time is measured, if other processes are busy they may cause
@@ -1503,7 +1503,7 @@ mind there are various things that may clobber the results:
   function.  There is some overhead in between.
 
 - Functions that are deleted before Vim exits will not produce profiling
-  information.  You can check the |v:profiling| variable if needed: >
+  information.	You can check the |v:profiling| variable if needed: >
 	:if !v:profiling
 	:   delfunc MyFunc
 	:endif

--- a/runtime/doc/rileft.txt
+++ b/runtime/doc/rileft.txt
@@ -1,7 +1,7 @@
-*rileft.txt*    For Vim version 9.1.  Last change: 2022 Oct 12
+*rileft.txt*	For Vim version 9.1.  Last change: 2022 Oct 12
 
 
-		  VIM REFERENCE MANUAL    by Avner Lottem
+		  VIM REFERENCE MANUAL	  by Avner Lottem
 					  updated by Nadim Shaikli
 
 

--- a/runtime/doc/russian.txt
+++ b/runtime/doc/russian.txt
@@ -1,7 +1,7 @@
-*russian.txt*   For Vim version 9.1.  Last change: 2006 Apr 24
+*russian.txt*	For Vim version 9.1.  Last change: 2006 Apr 24
 
 
-		  VIM REFERENCE MANUAL    by Vassily Ragosin
+		  VIM REFERENCE MANUAL	  by Vassily Ragosin
 
 
 Russian language localization and support in Vim	   *russian* *Russian*

--- a/runtime/doc/scroll.txt
+++ b/runtime/doc/scroll.txt
@@ -1,7 +1,7 @@
-*scroll.txt*    For Vim version 9.1.  Last change: 2024 Jul 06
+*scroll.txt*	For Vim version 9.1.  Last change: 2024 Jul 06
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 Scrolling						*scrolling*

--- a/runtime/doc/sign.txt
+++ b/runtime/doc/sign.txt
@@ -1,7 +1,7 @@
-*sign.txt*      For Vim version 9.1.  Last change: 2025 Oct 12
+*sign.txt*	For Vim version 9.1.  Last change: 2025 Oct 12
 
 
-		  VIM REFERENCE MANUAL    by Gordon Prieur
+		  VIM REFERENCE MANUAL	  by Gordon Prieur
 					  and Bram Moolenaar
 
 

--- a/runtime/doc/sponsor.txt
+++ b/runtime/doc/sponsor.txt
@@ -1,7 +1,7 @@
-*sponsor.txt*   For Vim version 9.1.  Last change: 2025 Nov 01
+*sponsor.txt*	For Vim version 9.1.  Last change: 2025 Nov 01
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -1,7 +1,7 @@
-*starting.txt*  For Vim version 9.1.  Last change: 2025 Nov 01
+*starting.txt*	For Vim version 9.1.  Last change: 2025 Nov 01
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 Starting Vim						*starting*

--- a/runtime/doc/tabpage.txt
+++ b/runtime/doc/tabpage.txt
@@ -1,7 +1,7 @@
-*tabpage.txt*   For Vim version 9.1.  Last change: 2025 Oct 12
+*tabpage.txt*	For Vim version 9.1.  Last change: 2025 Oct 12
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 Editing with windows in multiple tab pages.		*tab-page* *tabpage*

--- a/runtime/doc/tagsrch.txt
+++ b/runtime/doc/tagsrch.txt
@@ -1,7 +1,7 @@
-*tagsrch.txt*   For Vim version 9.1.  Last change: 2025 Oct 12
+*tagsrch.txt*	For Vim version 9.1.  Last change: 2025 Oct 12
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 Tags and special searches				*tags-and-searches*

--- a/runtime/doc/term.txt
+++ b/runtime/doc/term.txt
@@ -1,7 +1,7 @@
-*term.txt*      For Vim version 9.1.  Last change: 2025 Oct 12
+*term.txt*	For Vim version 9.1.  Last change: 2025 Oct 12
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 Terminal information					*terminal-info*

--- a/runtime/doc/textprop.txt
+++ b/runtime/doc/textprop.txt
@@ -1,7 +1,7 @@
-*textprop.txt*  For Vim version 9.1.  Last change: 2025 Oct 14
+*textprop.txt*	For Vim version 9.1.  Last change: 2025 Oct 14
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 Displaying text with properties attached.	*textprop* *text-properties*

--- a/runtime/doc/tips.txt
+++ b/runtime/doc/tips.txt
@@ -1,7 +1,7 @@
-*tips.txt*      For Vim version 9.1.  Last change: 2025 Oct 12
+*tips.txt*	For Vim version 9.1.  Last change: 2025 Oct 12
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 Tips and ideas for using Vim				*tips*

--- a/runtime/doc/todo.txt
+++ b/runtime/doc/todo.txt
@@ -1,4 +1,4 @@
-*todo.txt*      For Vim version 9.1.  Last change: 2025 Sep 02
+*todo.txt*	For Vim version 9.1.  Last change: 2025 Sep 02
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar

--- a/runtime/doc/uganda.txt
+++ b/runtime/doc/uganda.txt
@@ -1,7 +1,7 @@
-*uganda.txt*    For Vim version 9.1.  Last change: 2025 Nov 01
+*uganda.txt*	For Vim version 9.1.  Last change: 2025 Nov 01
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 			*uganda* *Uganda* *copying* *copyright* *license*

--- a/runtime/doc/undo.txt
+++ b/runtime/doc/undo.txt
@@ -1,4 +1,4 @@
-*undo.txt*      For Vim version 9.1.  Last change: 2025 Oct 26
+*undo.txt*	For Vim version 9.1.  Last change: 2025 Oct 26
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar

--- a/runtime/doc/usr_01.txt
+++ b/runtime/doc/usr_01.txt
@@ -1,7 +1,7 @@
 *usr_01.txt*	For Vim version 9.1.  Last change: 2025 Nov 01
 
 
-		     VIM USER MANUAL      by Bram Moolenaar
+		     VIM USER MANUAL	by Bram Moolenaar
 
 
 			      About the manuals

--- a/runtime/doc/usr_02.txt
+++ b/runtime/doc/usr_02.txt
@@ -1,7 +1,7 @@
 *usr_02.txt*	For Vim version 9.1.  Last change: 2025 Oct 26
 
 
-		     VIM USER MANUAL      by Bram Moolenaar
+		     VIM USER MANUAL	by Bram Moolenaar
 
 
 			    The first steps in Vim

--- a/runtime/doc/usr_03.txt
+++ b/runtime/doc/usr_03.txt
@@ -1,7 +1,7 @@
 *usr_03.txt*	For Vim version 9.1.  Last change: 2025 Oct 26
 
 
-		     VIM USER MANUAL	  by Bram Moolenaar
+		     VIM USER MANUAL	by Bram Moolenaar
 
 
 			     Moving around

--- a/runtime/doc/usr_04.txt
+++ b/runtime/doc/usr_04.txt
@@ -1,7 +1,7 @@
 *usr_04.txt*	For Vim version 9.1.  Last change: 2025 Oct 26
 
 
-		     VIM USER MANUAL	  by Bram Moolenaar
+		     VIM USER MANUAL	by Bram Moolenaar
 
 
 			     Making small changes

--- a/runtime/doc/usr_05.txt
+++ b/runtime/doc/usr_05.txt
@@ -1,7 +1,7 @@
 *usr_05.txt*	For Vim version 9.1.  Last change: 2025 Oct 26
 
 
-		     VIM USER MANUAL	  by Bram Moolenaar
+		     VIM USER MANUAL	by Bram Moolenaar
 
 
 			      Set your settings

--- a/runtime/doc/usr_06.txt
+++ b/runtime/doc/usr_06.txt
@@ -1,7 +1,7 @@
 *usr_06.txt*	For Vim version 9.1.  Last change: 2025 Oct 26
 
 
-		     VIM USER MANUAL	  by Bram Moolenaar
+		     VIM USER MANUAL	by Bram Moolenaar
 
 
 			  Using syntax highlighting

--- a/runtime/doc/usr_07.txt
+++ b/runtime/doc/usr_07.txt
@@ -1,7 +1,7 @@
 *usr_07.txt*	For Vim version 9.1.  Last change: 2025 Oct 26
 
 
-		     VIM USER MANUAL	  by Bram Moolenaar
+		     VIM USER MANUAL	by Bram Moolenaar
 
 
 			  Editing more than one file

--- a/runtime/doc/usr_08.txt
+++ b/runtime/doc/usr_08.txt
@@ -1,7 +1,7 @@
 *usr_08.txt*	For Vim version 9.1.  Last change: 2025 Oct 26
 
 
-		     VIM USER MANUAL	  by Bram Moolenaar
+		     VIM USER MANUAL	by Bram Moolenaar
 
 
 			      Splitting windows

--- a/runtime/doc/usr_09.txt
+++ b/runtime/doc/usr_09.txt
@@ -1,7 +1,7 @@
 *usr_09.txt*	For Vim version 9.1.  Last change: 2025 Oct 26
 
 
-		     VIM USER MANUAL	  by Bram Moolenaar
+		     VIM USER MANUAL	by Bram Moolenaar
 
 
 				Using the GUI

--- a/runtime/doc/usr_10.txt
+++ b/runtime/doc/usr_10.txt
@@ -1,7 +1,7 @@
 *usr_10.txt*	For Vim version 9.1.  Last change: 2025 Oct 26
 
 
-		     VIM USER MANUAL	  by Bram Moolenaar
+		     VIM USER MANUAL	by Bram Moolenaar
 
 
 			     Making big changes

--- a/runtime/doc/usr_11.txt
+++ b/runtime/doc/usr_11.txt
@@ -1,7 +1,7 @@
 *usr_11.txt*	For Vim version 9.1.  Last change: 2025 Oct 26
 
 
-		     VIM USER MANUAL	  by Bram Moolenaar
+		     VIM USER MANUAL	by Bram Moolenaar
 
 
 			   Recovering from a crash

--- a/runtime/doc/usr_12.txt
+++ b/runtime/doc/usr_12.txt
@@ -1,7 +1,7 @@
 *usr_12.txt*	For Vim version 9.1.  Last change: 2025 Oct 26
 
 
-		     VIM USER MANUAL	  by Bram Moolenaar
+		     VIM USER MANUAL	by Bram Moolenaar
 
 
 				Clever tricks

--- a/runtime/doc/usr_20.txt
+++ b/runtime/doc/usr_20.txt
@@ -1,7 +1,7 @@
 *usr_20.txt*	For Vim version 9.1.  Last change: 2025 Oct 26
 
 
-		     VIM USER MANUAL	  by Bram Moolenaar
+		     VIM USER MANUAL	by Bram Moolenaar
 
 
 		     Typing command-line commands quickly

--- a/runtime/doc/usr_21.txt
+++ b/runtime/doc/usr_21.txt
@@ -1,7 +1,7 @@
 *usr_21.txt*	For Vim version 9.1.  Last change: 2025 Oct 26
 
 
-		     VIM USER MANUAL	  by Bram Moolenaar
+		     VIM USER MANUAL	by Bram Moolenaar
 
 
 			   Go away and come back

--- a/runtime/doc/usr_22.txt
+++ b/runtime/doc/usr_22.txt
@@ -1,7 +1,7 @@
 *usr_22.txt*	For Vim version 9.1.  Last change: 2025 Oct 26
 
 
-		     VIM USER MANUAL	  by Bram Moolenaar
+		     VIM USER MANUAL	by Bram Moolenaar
 
 
 			   Finding the file to edit

--- a/runtime/doc/usr_23.txt
+++ b/runtime/doc/usr_23.txt
@@ -1,7 +1,7 @@
 *usr_23.txt*	For Vim version 9.1.  Last change: 2025 Oct 26
 
 
-		     VIM USER MANUAL	  by Bram Moolenaar
+		     VIM USER MANUAL	by Bram Moolenaar
 
 
 			     Editing other files

--- a/runtime/doc/usr_24.txt
+++ b/runtime/doc/usr_24.txt
@@ -1,7 +1,7 @@
 *usr_24.txt*	For Vim version 9.1.  Last change: 2025 Oct 26
 
 
-		     VIM USER MANUAL	  by Bram Moolenaar
+		     VIM USER MANUAL	by Bram Moolenaar
 
 
 			     Inserting quickly

--- a/runtime/doc/usr_25.txt
+++ b/runtime/doc/usr_25.txt
@@ -1,7 +1,7 @@
 *usr_25.txt*	For Vim version 9.1.  Last change: 2025 Oct 26
 
 
-		     VIM USER MANUAL	  by Bram Moolenaar
+		     VIM USER MANUAL	by Bram Moolenaar
 
 
 			     Editing formatted text

--- a/runtime/doc/usr_26.txt
+++ b/runtime/doc/usr_26.txt
@@ -1,7 +1,7 @@
 *usr_26.txt*	For Vim version 9.1.  Last change: 2025 Oct 26
 
 
-		     VIM USER MANUAL	  by Bram Moolenaar
+		     VIM USER MANUAL	by Bram Moolenaar
 
 
 				  Repeating

--- a/runtime/doc/usr_27.txt
+++ b/runtime/doc/usr_27.txt
@@ -1,7 +1,7 @@
 *usr_27.txt*	For Vim version 9.1.  Last change: 2025 Oct 26
 
 
-		     VIM USER MANUAL	  by Bram Moolenaar
+		     VIM USER MANUAL	by Bram Moolenaar
 
 
 			 Search commands and patterns

--- a/runtime/doc/usr_28.txt
+++ b/runtime/doc/usr_28.txt
@@ -1,7 +1,7 @@
 *usr_28.txt*	For Vim version 9.1.  Last change: 2025 Oct 26
 
 
-		     VIM USER MANUAL	  by Bram Moolenaar
+		     VIM USER MANUAL	by Bram Moolenaar
 
 
 				   Folding

--- a/runtime/doc/usr_29.txt
+++ b/runtime/doc/usr_29.txt
@@ -1,7 +1,7 @@
 *usr_29.txt*	For Vim version 9.1.  Last change: 2025 Oct 26
 
 
-		     VIM USER MANUAL	  by Bram Moolenaar
+		     VIM USER MANUAL	by Bram Moolenaar
 
 
 			    Moving through programs

--- a/runtime/doc/usr_30.txt
+++ b/runtime/doc/usr_30.txt
@@ -1,7 +1,7 @@
 *usr_30.txt*	For Vim version 9.1.  Last change: 2025 Oct 26
 
 
-		     VIM USER MANUAL	  by Bram Moolenaar
+		     VIM USER MANUAL	by Bram Moolenaar
 
 
 			      Editing programs

--- a/runtime/doc/usr_31.txt
+++ b/runtime/doc/usr_31.txt
@@ -1,7 +1,7 @@
 *usr_31.txt*	For Vim version 9.1.  Last change: 2025 Oct 26
 
 
-		     VIM USER MANUAL	  by Bram Moolenaar
+		     VIM USER MANUAL	by Bram Moolenaar
 
 
 			      Exploiting the GUI

--- a/runtime/doc/usr_32.txt
+++ b/runtime/doc/usr_32.txt
@@ -1,7 +1,7 @@
 *usr_32.txt*	For Vim version 9.1.  Last change: 2025 Oct 26
 
 
-		     VIM USER MANUAL	  by Bram Moolenaar
+		     VIM USER MANUAL	by Bram Moolenaar
 
 
 			      The undo tree

--- a/runtime/doc/usr_40.txt
+++ b/runtime/doc/usr_40.txt
@@ -1,7 +1,7 @@
 *usr_40.txt*	For Vim version 9.1.  Last change: 2025 Oct 26
 
 
-		     VIM USER MANUAL	  by Bram Moolenaar
+		     VIM USER MANUAL	by Bram Moolenaar
 
 
 			      Make new commands

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -1,7 +1,7 @@
 *usr_41.txt*	For Vim version 9.1.  Last change: 2025 Oct 26
 
 
-		     VIM USER MANUAL	  by Bram Moolenaar
+		     VIM USER MANUAL	by Bram Moolenaar
 
 
 			      Write a Vim script

--- a/runtime/doc/usr_42.txt
+++ b/runtime/doc/usr_42.txt
@@ -1,7 +1,7 @@
 *usr_42.txt*	For Vim version 9.1.  Last change: 2025 Oct 26
 
 
-		     VIM USER MANUAL	  by Bram Moolenaar
+		     VIM USER MANUAL	by Bram Moolenaar
 
 
 			      Add new menus

--- a/runtime/doc/usr_43.txt
+++ b/runtime/doc/usr_43.txt
@@ -1,7 +1,7 @@
 *usr_43.txt*	For Vim version 9.1.  Last change: 2025 Oct 26
 
 
-		     VIM USER MANUAL	  by Bram Moolenaar
+		     VIM USER MANUAL	by Bram Moolenaar
 
 
 			       Using filetypes

--- a/runtime/doc/usr_44.txt
+++ b/runtime/doc/usr_44.txt
@@ -1,7 +1,7 @@
 *usr_44.txt*	For Vim version 9.1.  Last change: 2025 Oct 26
 
 
-		     VIM USER MANUAL	  by Bram Moolenaar
+		     VIM USER MANUAL	by Bram Moolenaar
 
 
 			 Your own syntax highlighted

--- a/runtime/doc/usr_45.txt
+++ b/runtime/doc/usr_45.txt
@@ -1,7 +1,7 @@
 *usr_45.txt*	For Vim version 9.1.  Last change: 2025 Oct 26
 
 
-		     VIM USER MANUAL	  by Bram Moolenaar
+		     VIM USER MANUAL	by Bram Moolenaar
 
 
 			Select your language (locale)

--- a/runtime/doc/usr_50.txt
+++ b/runtime/doc/usr_50.txt
@@ -1,7 +1,7 @@
 *usr_50.txt*	For Vim version 9.1.  Last change: 2025 Oct 26
 
 
-		     VIM USER MANUAL	  by Bram Moolenaar
+		     VIM USER MANUAL	by Bram Moolenaar
 
 
 			 Advanced Vim script writing

--- a/runtime/doc/usr_51.txt
+++ b/runtime/doc/usr_51.txt
@@ -1,7 +1,7 @@
 *usr_51.txt*	For Vim version 9.1.  Last change: 2025 Oct 26
 
 
-		     VIM USER MANUAL	  by Bram Moolenaar
+		     VIM USER MANUAL	by Bram Moolenaar
 
 
 			      Write plugins

--- a/runtime/doc/usr_52.txt
+++ b/runtime/doc/usr_52.txt
@@ -1,7 +1,7 @@
 *usr_52.txt*	For Vim version 9.1.  Last change: 2025 Oct 26
 
 
-		     VIM USER MANUAL	  by Bram Moolenaar
+		     VIM USER MANUAL	by Bram Moolenaar
 
 
 		       Write larger plugins

--- a/runtime/doc/usr_90.txt
+++ b/runtime/doc/usr_90.txt
@@ -1,7 +1,7 @@
 *usr_90.txt*	For Vim version 9.1.  Last change: 2025 Oct 26
 
 
-		     VIM USER MANUAL	  by Bram Moolenaar
+		     VIM USER MANUAL	by Bram Moolenaar
 
 
 				Installing Vim

--- a/runtime/doc/usr_toc.txt
+++ b/runtime/doc/usr_toc.txt
@@ -1,7 +1,7 @@
 *usr_toc.txt*	For Vim version 9.1.  Last change: 2025 Oct 26
 
 
-		     VIM USER MANUAL	  by Bram Moolenaar
+		     VIM USER MANUAL	by Bram Moolenaar
 
 
 			      Table Of Contents		*user-manual* *usr*

--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -1,7 +1,7 @@
-*various.txt*   For Vim version 9.1.  Last change: 2025 Oct 26
+*various.txt*	For Vim version 9.1.  Last change: 2025 Oct 26
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 Various commands					*various*

--- a/runtime/doc/version4.txt
+++ b/runtime/doc/version4.txt
@@ -1,7 +1,7 @@
-*version4.txt*  For Vim version 9.1.  Last change: 2025 Aug 06
+*version4.txt*	For Vim version 9.1.  Last change: 2025 Aug 06
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 This document lists the incompatible differences between Vim 3.0 and Vim 4.0.

--- a/runtime/doc/version5.txt
+++ b/runtime/doc/version5.txt
@@ -1,7 +1,7 @@
-*version5.txt*  For Vim version 9.1.  Last change: 2025 Oct 26
+*version5.txt*	For Vim version 9.1.  Last change: 2025 Oct 26
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 Welcome to Vim Version 5.0!

--- a/runtime/doc/version6.txt
+++ b/runtime/doc/version6.txt
@@ -1,7 +1,7 @@
-*version6.txt*  For Vim version 9.1.  Last change: 2025 Jul 22
+*version6.txt*	For Vim version 9.1.  Last change: 2025 Jul 22
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 Welcome to Vim Version 6.0!  A large number of features has been added.  This

--- a/runtime/doc/version7.txt
+++ b/runtime/doc/version7.txt
@@ -1,7 +1,7 @@
-*version7.txt*  For Vim version 9.1.  Last change: 2025 Oct 26
+*version7.txt*	For Vim version 9.1.  Last change: 2025 Oct 26
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 					*vim7* *version-7.0* *version7.0*

--- a/runtime/doc/version8.txt
+++ b/runtime/doc/version8.txt
@@ -1,7 +1,7 @@
-*version8.txt*  For Vim version 9.1.  Last change: 2025 Jul 21
+*version8.txt*	For Vim version 9.1.  Last change: 2025 Jul 21
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 				*vim8* *vim-8* *version-8.0* *version8.0*

--- a/runtime/doc/version9.txt
+++ b/runtime/doc/version9.txt
@@ -1,7 +1,7 @@
-*version9.txt*  For Vim version 9.1.  Last change: 2025 Nov 01
+*version9.txt*	For Vim version 9.1.  Last change: 2025 Nov 01
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 				*vim-9.0* *vim-9* *version-9.0* *version9.0*

--- a/runtime/doc/vi_diff.txt
+++ b/runtime/doc/vi_diff.txt
@@ -1,7 +1,7 @@
-*vi_diff.txt*   For Vim version 9.1.  Last change: 2025 Oct 12
+*vi_diff.txt*	For Vim version 9.1.  Last change: 2025 Oct 12
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 Differences between Vim and Vi				*vi-differences*

--- a/runtime/doc/vietnamese.txt
+++ b/runtime/doc/vietnamese.txt
@@ -1,7 +1,7 @@
-*vietnamese.txt*   For Vim version 9.1.  Last change: 2025 Aug 06
+*vietnamese.txt* For Vim version 9.1.  Last change: 2025 Aug 06
 
 
-		  VIM REFERENCE MANUAL    by Phạm Bình An
+		  VIM REFERENCE MANUAL	  by Phạm Bình An
 
 
 Vietnamese language support in Vim		*vietnamese* *Vietnamese*

--- a/runtime/doc/visual.txt
+++ b/runtime/doc/visual.txt
@@ -1,7 +1,7 @@
-*visual.txt*    For Vim version 9.1.  Last change: 2025 Oct 12
+*visual.txt*	For Vim version 9.1.  Last change: 2025 Oct 12
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 Visual mode				*Visual* *Visual-mode* *visual-mode*

--- a/runtime/doc/wayland.txt
+++ b/runtime/doc/wayland.txt
@@ -1,7 +1,7 @@
-*wayland.txt*   For Vim version 9.1.  Last change: 2025 Nov 01
+*wayland.txt*	For Vim version 9.1.  Last change: 2025 Nov 01
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 Wayland Protocol Support				*wayland*

--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -1,7 +1,7 @@
-*windows.txt*   For Vim version 9.1.  Last change: 2025 Oct 26
+*windows.txt*	For Vim version 9.1.  Last change: 2025 Oct 26
 
 
-		  VIM REFERENCE MANUAL    by Bram Moolenaar
+		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
 Editing with multiple windows and buffers.		*windows* *buffers*

--- a/runtime/doc/workshop.txt
+++ b/runtime/doc/workshop.txt
@@ -1,7 +1,7 @@
-*workshop.txt*  For Vim version 9.1.  Last change: 2019 Jan 17
+*workshop.txt*	For Vim version 9.1.  Last change: 2019 Jan 17
 
 
-		  VIM REFERENCE MANUAL    by Gordon Prieur
+		  VIM REFERENCE MANUAL	  by Gordon Prieur
 
 
 Sun Visual WorkShop Features			*workshop* *workshop-support*


### PR DESCRIPTION
- :retab! line 1 and line 4 (main page heading).
- Use four columns whitespace before "by [Author]" in the user manual heading to match the reference manual formatting.
- double space headings.

