### PR TITLE
Wrong display with 'smoothscroll' when FEAT_DIFF is disabled

### DIFF
--- a/src/drawscreen.c
+++ b/src/drawscreen.c
@@ -1919,13 +1919,8 @@ win_update(win_T *wp)
 		    // Correct the first entry for filler lines at the top
 		    // when it won't get updated below.
 		    if (wp->w_p_diff && bot_start > 0)
-		    {
-			int n = plines_win_nofill(wp, wp->w_topline, FALSE)
-			      + wp->w_topfill - adjust_plines_for_skipcol(wp);
-			if (n > wp->w_height)
-			    n = wp->w_height;
-			wp->w_lines[0].wl_size = n;
-		    }
+			wp->w_lines[0].wl_size = plines_correct_topline(wp,
+							  wp->w_topline, TRUE);
 #endif
 		}
 	    }
@@ -2342,21 +2337,7 @@ win_update(win_T *wp)
 			    ++new_rows;
 			else
 #endif
-			{
-#ifdef FEAT_DIFF
-			    if (l == wp->w_topline)
-			    {
-				int n = plines_win_nofill(wp, l, FALSE)
-								+ wp->w_topfill;
-				n -= adjust_plines_for_skipcol(wp);
-				if (n > wp->w_height)
-				    n = wp->w_height;
-				new_rows += n;
-			    }
-			    else
-#endif
-				new_rows += plines_win(wp, l, TRUE);
-			}
+			    new_rows += plines_correct_topline(wp, l, TRUE);
 			++j;
 			if (new_rows > wp->w_height - row - 2)
 			{

--- a/src/move.c
+++ b/src/move.c
@@ -39,7 +39,7 @@ static void botline_forw(lineoff_T *lp);
 /*
  * Get the number of screen lines skipped with "wp->w_skipcol".
  */
-    int
+    static int
 adjust_plines_for_skipcol(win_T *wp)
 {
     if (wp->w_skipcol == 0)
@@ -58,7 +58,7 @@ adjust_plines_for_skipcol(win_T *wp)
  * whether it is the first line, whether w_skipcol is non-zero and limiting to
  * the window height.
  */
-    static int
+    int
 plines_correct_topline(win_T *wp, linenr_T lnum, int limit_winheight)
 {
     int n;

--- a/src/proto/move.pro
+++ b/src/proto/move.pro
@@ -1,5 +1,5 @@
 /* move.c */
-int adjust_plines_for_skipcol(win_T *wp);
+int plines_correct_topline(win_T *wp, linenr_T lnum, int limit_winheight);
 void set_valid_virtcol(win_T *wp, colnr_T vcol);
 int sms_marker_overlap(win_T *wp, int extra2);
 void update_topline_redraw(void);

--- a/src/testdir/test_scroll_opt.vim
+++ b/src/testdir/test_scroll_opt.vim
@@ -277,6 +277,7 @@ endfunc
 
 func Test_smoothscroll_diff_mode()
   CheckScreendump
+  CheckFeature diff
 
   let lines =<< trim END
       vim9script
@@ -303,6 +304,7 @@ endfunc
 
 func Test_smoothscroll_diff_change_line_default()
   CheckScreendump
+  CheckFeature diff
 
   " Uses the new diffopt default with indent-heuristic and inline:char
   let lines =<< trim END
@@ -334,6 +336,7 @@ endfunc
 
 func Test_smoothscroll_diff_change_line()
   CheckScreendump
+  CheckFeature diff
 
   " Uses the old diffopt default
   let lines =<< trim END


### PR DESCRIPTION
Problem:  Wrong display with 'smoothscroll' when FEAT_DIFF is disabled.
Solution: Use plines_correct_topline().