### PR TITLE
rust.vim: stop setting formatprg to rustfmt.

### DIFF
--- a/runtime/autoload/rustfmt.vim
+++ b/runtime/autoload/rustfmt.vim
@@ -1,8 +1,5 @@
 " Author: Stephen Sugden <stephen@stephensugden.com>
 " Last Modified: 2023-09-11
-" Last Change:
-" 2025 Mar 31 by Vim project (rename s:RustfmtConfigOptions())
-" 2025 Jul 14 by Vim project (don't parse rustfmt version automatically #17745)
 "
 " Adapted from https://github.com/fatih/vim-go
 " For bugs, patches and license go to https://github.com/rust-lang/rust.vim
@@ -68,13 +65,7 @@ function! s:RustfmtWriteMode()
     endif
 endfunction
 
-function! rustfmt#RustfmtConfigOptions()
-    let default = '--edition 2018'
-
-    if !get(g:, 'rustfmt_find_toml', 0)
-        return default
-    endif
-
+function! s:RustfmtConfigOptions()
     let l:rustfmt_toml = findfile('rustfmt.toml', expand('%:p:h') . ';')
     if l:rustfmt_toml !=# ''
         return '--config-path '.shellescape(fnamemodify(l:rustfmt_toml, ":p"))
@@ -97,7 +88,7 @@ function! s:RustfmtCommandRange(filename, line1, line2)
 
     let l:arg = {"file": shellescape(a:filename), "range": [a:line1, a:line2]}
     let l:write_mode = s:RustfmtWriteMode()
-    let l:rustfmt_config = rustfmt#RustfmtConfigOptions()
+    let l:rustfmt_config = s:RustfmtConfigOptions()
 
     " FIXME: When --file-lines gets to be stable, add version range checking
     " accordingly.
@@ -112,7 +103,7 @@ endfunction
 
 function! s:RustfmtCommand()
     let write_mode = g:rustfmt_emit_files ? '--emit=stdout' : '--write-mode=display'
-    let config = rustfmt#RustfmtConfigOptions()
+    let config = s:RustfmtConfigOptions()
     return join([g:rustfmt_command, write_mode, config, g:rustfmt_options])
 endfunction
 

--- a/runtime/ftplugin/rust.vim
+++ b/runtime/ftplugin/rust.vim
@@ -3,7 +3,6 @@
 " Maintainer:	Chris Morgan <me@chrismorgan.info>
 " Last Change:	2024 Mar 17
 "		2024 May 23 by Riley Bruins <ribru17@gmail.com ('commentstring')
-"		2025 Mar 31 by Vim project (set 'formatprg' option)
 " For bugs, patches and license go to https://github.com/rust-lang/rust.vim
 
 if exists("b:did_ftplugin")
@@ -57,19 +56,6 @@ setlocal include=\\v^\\s*(pub\\s+)?use\\s+\\zs(\\f\|:)+
 setlocal includeexpr=rust#IncludeExpr(v:fname)
 
 setlocal suffixesadd=.rs
-
-if executable(get(g:, 'rustfmt_command', 'rustfmt'))
-    if get(g:, "rustfmt_fail_silently", 0)
-        augroup rust.vim.FailSilently
-            autocmd! * <buffer>
-            autocmd ShellFilterPost <buffer> if v:shell_error | execute 'echom "shell filter returned error " . v:shell_error . ", undoing changes"' | undo | endif
-        augroup END
-    endif
-
-    let &l:formatprg = get(g:, 'rustfmt_command', 'rustfmt') . ' ' .
-                \ get(g:, 'rustfmt_options', '') . ' ' .
-                \ rustfmt#RustfmtConfigOptions()
-endif
 
 if exists("g:ftplugin_rust_source_path")
     let &l:path=g:ftplugin_rust_source_path . ',' . &l:path
@@ -163,7 +149,7 @@ endif
 
 let b:undo_ftplugin = "
             \ compiler make |
-            \ setlocal formatoptions< comments< commentstring< include< includeexpr< suffixesadd< formatprg<
+            \ setlocal formatoptions< comments< commentstring< include< includeexpr< suffixesadd<
             \|if exists('b:rust_set_style')
                 \|setlocal tabstop< shiftwidth< softtabstop< expandtab< textwidth<
                 \|endif


### PR DESCRIPTION
This reverts commit 4ac995bf9366c6624a0724d19b2226f4c95694b3.

This was added in #16807, with no explanation for why it was necessary beyond "it's an example of an idea". It completely breaks `gq` for me—rustfmt doesn't reflow comments so is not an appropriate tool here! Beyond that, formatting a selection with rustfmt treats that selection as if it were an entire file, throwing away any indentation.

For example, the commit causes `gq` to turn this:

```rust
pub fn foo() {
    // blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah
}
```

into this:

```rust
pub fn foo() {
// blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah
}

```

which is totally wrong. In contrast, if I clear `formatprg` then `gq` does the right thing again:

```rust
pub fn foo() {
    // blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah
    // blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah
    // blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah
    // blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah
    // blah blah blah blah blah blah
}
```