### PR TITLE
fix: Sometimes an allocation error occurs when `complete_info()`

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -4235,7 +4235,7 @@ get_complete_info(list_T *what_list, dict_T *retdict)
 	int	len = compl_ins_end_col - curwin->w_cursor.col;
 
 	ret = dict_add_string_len(retdict, "preinserted_text",
-		(len > 0) ? line + curwin->w_cursor.col : (char_u *)"", len);
+		(len > 0) ? line + curwin->w_cursor.col : (char_u *)"", (len > 0) ? len : 0);
     }
 
     if (ret == OK && (what_flag & (CI_WHAT_ITEMS | CI_WHAT_SELECTED

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -571,6 +571,10 @@ func Test_completefunc_info()
   new
   set completeopt=menuone
   set completefunc=CompleteTest
+    " Can be called outside of ins-completion
+  call feedkeys("i\<C-X>\<C-U>\<C-Y>\<C-R>\<C-R>=string(complete_info())\<CR>\<ESC>", "tx")
+  call assert_equal("matched{'preinserted_text': '', 'pum_visible': 0, 'mode': '', 'selected': -1, 'items': []}", getline(1))
+  %d
   call feedkeys("i\<C-X>\<C-U>\<C-R>\<C-R>=string(complete_info())\<CR>\<ESC>", "tx")
   call assert_equal("matched{'preinserted_text': '', 'pum_visible': 1, 'mode': 'function', 'selected': 0, 'items': [{'word': 'matched', 'menu': '', 'user_data': '', 'info': '', 'kind': '', 'abbr': ''}]}", getline(1))
   %d


### PR DESCRIPTION
# Problem

Occurs an allocation error when calls `complete_info()` outside of ins_completion.

# Solution

Round length below zero at get preinserted text.

# Reproduce Step

1. Place following script `vimrc`

```
nnoremap a ihoge<Cmd>call complete_info()<CR>
```

2. `vim -Nu vimrc`

3. Press `a`

4. Display `E342: Out of memory!  (allocating 18446744073709551614 bytes)`