### PR TITLE
Deferring a lambda function without specifying arguments crashes Vim

### DIFF
--- a/src/testdir/test_vim9_script.vim
+++ b/src/testdir/test_vim9_script.vim
@@ -5343,6 +5343,18 @@ def Test_defer_lambda_func()
     defcompile
   END
   v9.CheckScriptFailure(lines, 'E1028: Compiling :def function failed', 1)
+
+  # Error: lambda without arguments
+  lines =<< trim END
+    vim9script
+    def Foo()
+      defer () => {
+      }
+      assert_report("shouldn't reach here")
+    enddef
+    defcompile
+  END
+  v9.CheckScriptFailure(lines, 'E107: Missing parentheses: ', 1)
 enddef
 
 " Test for using an non-existing type in a "for" statement.

--- a/src/vim9cmds.c
+++ b/src/vim9cmds.c
@@ -2047,7 +2047,12 @@ compile_defer(char_u *arg_start, cctx_T *cctx)
 	// a lambda function
 	if (compile_lambda(&arg, cctx) != OK)
 	    return NULL;
-	paren = arg;
+	paren = vim_strchr(arg, '(');
+	if (paren == NULL)
+	{
+	    semsg(_(e_missing_parenthesis_str), arg);
+	    return NULL;
+	}
     }
     else
     {


### PR DESCRIPTION

If there are no arguments specified after a deferred lambda function, give an error message.