### PR TITLE
fix(normal): make "g<End>" move to last non-blank char in visual mode

### DIFF
--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -807,7 +807,8 @@ tag		char	      note action in Normal mode	~
 |g@|		g@{motion}	   call 'operatorfunc'
 |g~|		g~{motion}	2  swap case for Nmove text
 |g<Down>|	g<Down>		1  same as "gj"
-|g<End>|	g<End>		1  same as "g$"
+|g<End>|	g<End>		1  same as "g$" but go to the rightmost
+				   non-blank character instead
 |g<Home>|	g<Home>		1  same as "g0"
 |g<LeftMouse>|	g<LeftMouse>	   same as <C-LeftMouse>
 		g<MiddleMouse>	   same as <C-MiddleMouse>

--- a/src/normal.c
+++ b/src/normal.c
@@ -5934,15 +5934,9 @@ nv_g_dollar_cmd(cmdarg_T *cap)
     }
     if (flag)
     {
-	char_u	*ptr = ml_get_curline();
-
-	// In Visual mode we may end up after the line.
-	if (curwin->w_cursor.col > 0 && ptr[curwin->w_cursor.col] == NUL)
-	     --curwin->w_cursor.col;
-
 	do
 	    i = gchar_cursor();
-	while (VIM_ISWHITE(i) && oneleft() == OK);
+	while (IS_WHITE_OR_NUL(i) && oneleft() == OK);
 	curwin->w_valid &= ~VALID_WCOL;
     }
 }

--- a/src/normal.c
+++ b/src/normal.c
@@ -5934,6 +5934,12 @@ nv_g_dollar_cmd(cmdarg_T *cap)
     }
     if (flag)
     {
+	char_u	*ptr = ml_get_curline();
+
+	// In Visual mode we may end up after the line.
+	if (curwin->w_cursor.col > 0 && ptr[curwin->w_cursor.col] == NUL)
+	     --curwin->w_cursor.col;
+
 	do
 	    i = gchar_cursor();
 	while (VIM_ISWHITE(i) && oneleft() == OK);

--- a/src/testdir/test_normal.vim
+++ b/src/testdir/test_normal.vim
@@ -4201,6 +4201,11 @@ func Test_normal33_g_cmd_nonblank()
   call assert_equal(80, col("'>"))
   exe "normal 0$bvg\<End>y"
   call assert_equal(71, col("'>"))
+  setlocal nowrap virtualedit=all
+  exe "normal 0$\<C-v>llg\<End>y"
+  call assert_equal(71, col("'<"))
+  exe "normal 0$llvg\<End>y"
+  call assert_equal(71, col("'<"))
   bw!
 endfunc
 

--- a/src/testdir/test_normal.vim
+++ b/src/testdir/test_normal.vim
@@ -4195,6 +4195,12 @@ func Test_normal33_g_cmd_nonblank()
   call assert_equal(20, col('.'))
   exe "normal 0g\<kEnd>"
   call assert_equal(11, col('.'))
+
+  " Test visual mode at end of line
+  normal 0$bvg$y
+  call assert_equal(80, col("'>"))
+  exe "normal 0$bvg\<End>y"
+  call assert_equal(71, col("'>"))
   bw!
 endfunc
 


### PR DESCRIPTION
Problem:  In visual mode, `g<End>` does not move to the last non-blank character when the end of a line is on the same line as the cursor.
Solution: Move the cursor back by one position if it lands after the line.

Fixes: https://github.com/vim/vim/issues/18657