### PR TITLE
Fix escaping in Windows shell command for tombi

### DIFF
--- a/runtime/compiler/tombi.vim
+++ b/runtime/compiler/tombi.vim
@@ -44,7 +44,7 @@ if s:tombi_nocolor
     if &shell =~# '\v<%(cmd|cmd)>'
       CompilerSet makeprg=set\ NO_COLOR=1\ &&\ tombi\ lint
     elseif &shell =~# '\v<%(powershell|pwsh)>'
-      CompilerSet makeprg=$env:NO_COLOR="1";\ tombi\ lint
+      CompilerSet makeprg=$env:NO_COLOR=\"1\";\ tombi\ lint
     else
       echoerr "tombi compiler: Unsupported shell for Windows"
     endif


### PR DESCRIPTION
As observed by @dkearns at https://github.com/vim/vim/pull/18590#pullrequestreview-3392293015