### PR TITLE
%P in 'statusline' doesn't behave as documented

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -5430,7 +5430,7 @@ get_rel_pos(
     char tmp[8];
     // localized percentage value
     vim_snprintf(tmp, sizeof(tmp), _("%d%%"), perc);
-    return (int)vim_snprintf_safelen((char *)buf, buflen, _("%2s"), tmp);
+    return (int)vim_snprintf_safelen((char *)buf, buflen, _("%3s"), tmp);
 }
 
 /*

--- a/src/testdir/test_statusline.vim
+++ b/src/testdir/test_statusline.vim
@@ -168,9 +168,16 @@ func Test_statusline()
   call assert_match('^0,Top\s*$', s:get_statusline())
   norm G
   call assert_match('^100,Bot\s*$', s:get_statusline())
-  9000
-  " Don't check the exact percentage as it depends on the window size
-  call assert_match('^90,\(Top\|Bot\|\d\+%\)\s*$', s:get_statusline())
+  " The exact percentage depends on the window height, so create a window with
+  " known height.
+  9000 | botright 10split | setlocal scrolloff=0 | normal! zb
+  call assert_match('^90,89%\s*$', s:get_statusline())
+  normal! zt
+  call assert_match('^90,90%\s*$', s:get_statusline())
+  " %P should result in a string with 3 in length when not translated.
+  normal! 500zb
+  call assert_match('^5, 4%\s*$', s:get_statusline())
+  close
 
   " %q: "[Quickfix List]", "[Location List]" or empty.
   set statusline=%q


### PR DESCRIPTION
Problem:  %P in 'statusline' doesn't behave as documented
          (after 9.1.1479).
Solution: Make the percentage 3-chars wide when not translated.

fixes: #18669
