### PR TITLE
Recognize `.applescript` files as AppleScript

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -1659,6 +1659,7 @@ const ft_from_ext = {
   # XA65 MOS6510 cross assembler
   "a65": "a65",
   # Applescript
+  "applescript": "applescript",
   "scpt": "applescript",
   # Applix ELF
   "am": "elf",

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -114,7 +114,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     apachestyle: ['/etc/proftpd/file.config,/etc/proftpd/conf.file/file', '/etc/proftpd/conf.file/file', '/etc/proftpd/file.conf', '/etc/proftpd/file.conf-file',
       'any/etc/proftpd/conf.file/file', 'any/etc/proftpd/file.conf', 'any/etc/proftpd/file.conf-file', 'proftpd.conf', 'proftpd.conf-file'],
     apkbuild: ['APKBUILD'],
-    applescript: ['file.scpt'],
+    applescript: ['file.scpt', 'file.applescript'],
     aptconf: ['apt.conf', '/.aptitude/config', 'any/.aptitude/config'],
     arch: ['.arch-inventory', '=tagging-method'],
     arduino: ['file.ino', 'file.pde'],


### PR DESCRIPTION
`.applescript` is also a widely used extension for AppleScript, see [wiki](https://en.wikipedia.org/wiki/AppleScript)