### PR TITLE
runtime(netrw): fix NetrwChgPerm for files not in cwd

### DIFF
--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -4211,11 +4211,12 @@ function s:NetrwChgPerm(islocal,curdir)
     call inputsave()
     let newperm= input("Enter new permission: ")
     call inputrestore()
-    let chgperm= substitute(g:netrw_chgperm,'\<FILENAME\>',netrw#os#Escape(expand("<cfile>")),'')
+    let fullpath = fnamemodify(netrw#fs#PathJoin(a:curdir, expand("<cfile>")), ':p')
+    let chgperm= substitute(g:netrw_chgperm,'\<FILENAME\>',netrw#os#Escape(fullpath),'')
     let chgperm= substitute(chgperm,'\<PERM\>',netrw#os#Escape(newperm),'')
     call system(chgperm)
     if v:shell_error != 0
-        NetrwKeepj call netrw#ErrorMsg(1,"changing permission on file<".expand("<cfile>")."> seems to have failed",75)
+        NetrwKeepj call netrw#msg#Notify('WARNING', printf('changing permission on file<%s> seems to have failed', fullpath))
     endif
     if a:islocal
         NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
@@ -4591,7 +4592,7 @@ function s:NetrwServerEdit(islocal,fname)
         endif
 
     else
-        call netrw#ErrorMsg(s:ERROR,"you need a gui-capable vim and client-server to use <ctrl-r>",98)
+        call netrw#msg#Notify('ERROR', 'you need a gui-capable vim and client-server to use <ctrl-r>')
     endif
 
 endfunction


### PR DESCRIPTION
Problem:
Changing permissions fail when using `gp` if the file under the cursor is not in the current working directory.

Solution:
Use the already available `a:curdir` argument and prepend it to the `<cfile>`, so that the path of the file is correct.

This commit also refactors some leftover `netrw#ErrorMsg` to `netrw#msg#Notify` (the main refactoring was done in f5e3b5c04f85b0f69cd2aae81e4938cfb191a790).