### PR TITLE
runtime(sml): Add ftplugin file for SML

### DIFF
--- a/.github/MAINTAINERS
+++ b/.github/MAINTAINERS
@@ -286,6 +286,7 @@ runtime/ftplugin/sed.vim				@dkearns
 runtime/ftplugin/sh.vim					@dkearns
 runtime/ftplugin/shaderslang.vim			@mTvare6
 runtime/ftplugin/slint.vim				@ribru17
+runtime/ftplugin/sml.vim				@tocariimaa
 runtime/ftplugin/snakemake.vim				@ribru17
 runtime/ftplugin/solidity.vim				@coti-z
 runtime/ftplugin/solution.vim				@dkearns

--- a/runtime/ftplugin/sml.vim
+++ b/runtime/ftplugin/sml.vim
@@ -19,7 +19,7 @@ setlocal commentstring=(*\ %s\ *)
 setlocal comments=sr:(*,mb:*,ex:*)
 
 if exists('loaded_matchit')
-  let b:math_ignorecase = 0
+  let b:match_ignorecase = 0
   let b:match_words = '\<\%(abstype\|let\|local\|sig\|struct\)\>:\<\%(in\|with\)\>:\<end\>'
   let b:undo_ftplugin ..= ' | unlet! b:match_ignorecase b:match_words'
 endif

--- a/runtime/ftplugin/sml.vim
+++ b/runtime/ftplugin/sml.vim
@@ -2,7 +2,7 @@
 " Language: 		SML
 " Filenames:		*.sml *.sig
 " Maintainer: 		tocariimaa <tocariimaa@firemail.cc>
-" Last Change:		2025-10-02
+" Last Change:		2025-10-03
 
 if exists('b:did_ftplugin')
   finish
@@ -19,6 +19,10 @@ setlocal formatoptions+=cqort
 if has('comments')
   setlocal commentstring=(*\ %s\ *)
   setlocal comments=sr:(*,mb:*,ex:*)
+endif
+
+if exists('loaded_matchit')
+  let b:match_words = '\<let\|local\|sig\|struct\|with\>:\<end\>'
 endif
 
 let &cpo = s:cpo_save

--- a/runtime/ftplugin/sml.vim
+++ b/runtime/ftplugin/sml.vim
@@ -2,7 +2,7 @@
 " Language: 		SML
 " Filenames:		*.sml *.sig
 " Maintainer: 		tocariimaa <tocariimaa@firemail.cc>
-" Last Change:		2025-10-03
+" Last Change:		2025 Nov 04
 
 if exists('b:did_ftplugin')
   finish
@@ -14,15 +14,25 @@ set cpo&vim
 
 let b:undo_ftplugin = 'setl com< cms< fo<'
 
-setlocal formatoptions+=cqort
-
-if has('comments')
-  setlocal commentstring=(*\ %s\ *)
-  setlocal comments=sr:(*,mb:*,ex:*)
-endif
+setlocal formatoptions+=croql formatoptions-=t
+setlocal commentstring=(*\ %s\ *)
+setlocal comments=sr:(*,mb:*,ex:*)
 
 if exists('loaded_matchit')
-  let b:match_words = '\<let\|local\|sig\|struct\|with\>:\<end\>'
+  let b:math_ignorecase = 0
+  let b:match_words = '\<\%(abstype\|let\|local\|sig\|struct\)\>:\<\%(in\|with\)\>:\<end\>'
+  let b:undo_ftplugin ..= ' | unlet! b:match_ignorecase b:match_words'
+endif
+
+if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
+  let b:browsefilter = "SML Source Files (*.sml)\t*.sml\n" ..
+                     \ "SML Signature Files (*.sig)\t*.sig\n"
+  if has("win32")
+    let b:browsefilter ..= "All Files (*.*)\t*\n"
+  else
+    let b:browsefilter ..= "All Files (*)\t*\n"
+  endif
+  let b:undo_ftplugin ..= " | unlet! b:browsefilter"
 endif
 
 let &cpo = s:cpo_save

--- a/runtime/ftplugin/sml.vim
+++ b/runtime/ftplugin/sml.vim
@@ -1,0 +1,17 @@
+" Vim filetype plugin file
+" Language: 		SML
+" Maintainer: 		tocariimaa <tocariimaa@firemail.cc>
+" Last Change:		2025-10-02
+
+if exists('b:did_ftplugin')
+  finish
+endif
+let b:did_ftplugin = 1
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+setlocal commentstring=(*\ %s\ *)
+
+let &cpo = s:cpo_save
+unlet s:cpo_save

--- a/runtime/ftplugin/sml.vim
+++ b/runtime/ftplugin/sml.vim
@@ -1,5 +1,6 @@
 " Vim filetype plugin file
 " Language: 		SML
+" Filenames:		*.sml *.sig
 " Maintainer: 		tocariimaa <tocariimaa@firemail.cc>
 " Last Change:		2025-10-02
 
@@ -11,7 +12,14 @@ let b:did_ftplugin = 1
 let s:cpo_save = &cpo
 set cpo&vim
 
-setlocal commentstring=(*\ %s\ *)
+let b:undo_ftplugin = 'setl com< cms< fo<'
+
+setlocal formatoptions+=cqort
+
+if has('comments')
+  setlocal commentstring=(*\ %s\ *)
+  setlocal comments=sr:(*,mb:*,ex:*)
+endif
 
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/runtime/indent/sml.vim
+++ b/runtime/indent/sml.vim
@@ -29,12 +29,6 @@ setlocal shiftwidth=2
 
 let b:undo_indent = "setl et< inde< indk< lisp< si< sw< tw<"
 
-" Comment formatting
-if (has("comments"))
-  set comments=sr:(*,mb:*,ex:*)
-  set fo=cqort
-endif
-
 " Only define the function once.
 "if exists("*GetSMLIndent")
 "finish


### PR DESCRIPTION
Added a ftplugin file for Standard ML. For consistency I also moved the `comments` and `formatoptions` options from the indent file to the ftplugin file.