### PR TITLE
Fix building on Mac OS X 10.6 with MacPorts

### DIFF
--- a/src/os_macosx.m
+++ b/src/os_macosx.m
@@ -386,13 +386,7 @@ timer_delete(timer_t timerid)
 
 #ifdef FEAT_SOUND
 
-// If building on 10.6 with a newer version of clang through MacPorts,
-// use older syntax by avoiding generics and subscripting in this section.
-#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
-static NSMutableDictionary<NSNumber*, NSSound*> *sounds_list = nil;
-#else
 static NSMutableDictionary *sounds_list = nil;
-#endif
 
 /// A delegate for handling when a sound has stopped playing, in
 /// order to clean up the sound and to send a callback.
@@ -469,17 +463,9 @@ sound_mch_play(const char_u* sound_name, long sound_id, soundcb_T *callback, boo
 
 	if (sounds_list == nil)
 	{
-	    #if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
-	    sounds_list = [[NSMutableDictionary<NSNumber*, NSSound*> alloc] init];
-	    #else
 	    sounds_list = [[NSMutableDictionary alloc] init];
-	    #endif
 	}
-	#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
-	sounds_list[[NSNumber numberWithLong:sound_id]] = sound;
-	#else
 	[sounds_list setObject:sound forKey:[NSNumber numberWithLong:sound_id]];
-	#endif
 
 	// Make a delegate to handle when the sound stops. No need to call
 	// autorelease because NSSound only holds a weak reference to it.
@@ -496,11 +482,7 @@ sound_mch_stop(long sound_id)
 {
     @autoreleasepool
     {
-	#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
-	NSSound *sound = sounds_list[[NSNumber numberWithLong:sound_id]];
-	#else
 	NSSound *sound = [sounds_list objectForKey:[NSNumber numberWithLong:sound_id]];
-	#endif
 	if (sound != nil)
 	{
 	    // Stop the sound. No need to release it because the delegate will do


### PR DESCRIPTION
Closes #17678. The original author of sound support on Mac OS (#11274) wrote some checks that would skip the sound feature from being built if the older, stock version of clang was used on Snow Leopard. However, if MacPorts is used to build on 10.6 with a newer version of clang, it fails because of the use of generics and subscripting.

This change takes this case into consideration, and allows vim +huge +sound to build on 10.6 using MacPorts by utilizing the older style of Objective-C syntax.