### PR TITLE
Support file:line colon suffixes across entry points

### DIFF
--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -509,9 +509,11 @@ The [+cmd] argument can be used to position the cursor in the newly opened
 file, or execute any other command:
 	+		Start at the last line.
 	+{num}		Start at line {num}.
+	+{num}:{col}	Start at line {num} and column {col}.
 	+/{pat}		Start at first line containing {pat}.
 	+{command}	Execute {command} after opening the new file.
 			{command} is any Ex command.
+Both {num} and {col} are 1-based numbers, the column is counted in bytes.
 To include a white space in the {pat} or {command}, precede it with a
 backslash.  Double the number of backslashes. >
 	:edit  +/The\ book	     file

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -643,6 +643,19 @@ do_cmdline_cmd(char_u *cmd)
     static int
 do_cmd_argument(char_u *cmd)
 {
+    linenr_T	lnum;
+    colnr_T	col;
+
+    if (parse_cmd_lnum_col(cmd, &lnum, &col) == OK)
+    {
+	char_u	cursorbuf[NUMBUFLEN * 2 + 24];
+
+	vim_snprintf((char *)cursorbuf, sizeof(cursorbuf),
+		"call cursor(%ld,%ld)", (long)lnum, (long)col);
+	return do_cmdline(cursorbuf, NULL, NULL,
+		  DOCMD_VERBOSE|DOCMD_NOWAIT|DOCMD_KEYTYPED|DOCMD_RANGEOK);
+    }
+
     return do_cmdline(cmd, NULL, NULL,
 		      DOCMD_VERBOSE|DOCMD_NOWAIT|DOCMD_KEYTYPED|DOCMD_RANGEOK);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -2111,7 +2111,27 @@ command_line_scan(mparm_T *parmp)
 	    if (argv[0][1] == NUL)
 		parmp->commands[parmp->n_commands++] = (char_u *)"$";
 	    else
-		parmp->commands[parmp->n_commands++] = (char_u *)&(argv[0][1]);
+	    {
+		linenr_T lnum;
+		colnr_T col;
+
+		if (parse_cmd_lnum_col((char_u *)&argv[0][1], &lnum, &col) == OK)
+		{
+		    char	cursorbuf[NUMBUFLEN * 2 + 24];
+		    char_u	*cmdstr;
+
+		    vim_snprintf(cursorbuf, sizeof(cursorbuf),
+			    "call cursor(%ld,%ld)", (long)lnum, (long)col);
+		    cmdstr = vim_strsave((char_u *)cursorbuf);
+		    if (cmdstr == NULL)
+			mch_exit(2);
+		    parmp->cmds_tofree[parmp->n_commands] = TRUE;
+		    parmp->commands[parmp->n_commands++] = cmdstr;
+		}
+		else
+		    parmp->commands[parmp->n_commands++] =
+						 (char_u *)&(argv[0][1]);
+	    }
 	}
 
 	/*

--- a/src/misc2.c
+++ b/src/misc2.c
@@ -135,6 +135,57 @@ parse_cmd_file_arg(
 }
 
 /*
+ * Parse a "+cmd" style argument of the form "{lnum}:{col}".
+ * Returns OK when both values are present and only decimal digits were used,
+ * FAIL otherwise.  The resulting numbers are at least one.
+ */
+    int
+parse_cmd_lnum_col(
+	char_u	*cmd,
+	linenr_T *lnum,
+	colnr_T	*col)
+{
+    char_u	*p;
+    long	line = 0;
+    long	column = 0;
+
+    if (cmd == NULL || *cmd == NUL || !VIM_ISDIGIT(*cmd))
+	return FAIL;
+
+    p = cmd;
+    while (VIM_ISDIGIT(*p))
+    {
+	line = line * 10 + (*p - '0');
+	++p;
+    }
+
+    if (*p != ':' || !VIM_ISDIGIT(p[1]))
+	return FAIL;
+
+    ++p;
+    while (VIM_ISDIGIT(*p))
+    {
+	column = column * 10 + (*p - '0');
+	++p;
+    }
+
+    if (*p != NUL)
+	return FAIL;
+
+    if (line < 1)
+	line = 1;
+    if (column < 1)
+	column = 1;
+
+    if (lnum != NULL)
+	*lnum = (linenr_T)line;
+    if (col != NULL)
+	*col = (colnr_T)column;
+
+    return OK;
+}
+
+/*
  * Return TRUE if in the current mode we need to use virtual.
  */
     int

--- a/src/proto/misc2.pro
+++ b/src/proto/misc2.pro
@@ -5,6 +5,7 @@ int coladvance_force(colnr_T wcol);
 int getviscol2(colnr_T col, colnr_T coladd);
 int coladvance(colnr_T wantcol);
 int getvpos(pos_T *pos, colnr_T wantcol);
+int parse_cmd_file_arg(char_u *arg, size_t *fname_len, linenr_T *lnum, colnr_T *col, int *has_col);
 int inc_cursor(void);
 int inc(pos_T *lp);
 int incl(pos_T *lp);

--- a/src/proto/misc2.pro
+++ b/src/proto/misc2.pro
@@ -6,6 +6,7 @@ int getviscol2(colnr_T col, colnr_T coladd);
 int coladvance(colnr_T wantcol);
 int getvpos(pos_T *pos, colnr_T wantcol);
 int parse_cmd_file_arg(char_u *arg, size_t *fname_len, linenr_T *lnum, colnr_T *col, int *has_col);
+int parse_cmd_lnum_col(char_u *cmd, linenr_T *lnum, colnr_T *col);
 int inc_cursor(void);
 int inc(pos_T *lp);
 int incl(pos_T *lp);

--- a/src/structs.h
+++ b/src/structs.h
@@ -989,6 +989,8 @@ typedef struct argentry
 {
     char_u	*ae_fname;	// file name as specified
     int		ae_fnum;	// buffer number with expanded file name
+    linenr_T	ae_lnum;	// optional target line number (0 if unused)
+    colnr_T	ae_col;		// optional target column (0 if unused)
 } aentry_T;
 
 #define ALIST(win)	(win)->w_alist

--- a/src/testdir/test_arglist.vim
+++ b/src/testdir/test_arglist.vim
@@ -788,4 +788,41 @@ func Test_crash_arglist_uaf()
   au! BufAdd
 endfunc
 
+func Test_args_file_position()
+  call Reset_arglist()
+  call writefile(['first', '    second', 'third'], 'Xargspos', 'D')
+  let after =<< trim [CODE]
+    args Xargspos:2:5
+    next
+    call writefile([printf('%d %d', line('.'), col('.'))], 'Xargspos.out')
+    qall!
+  [CODE]
+
+  if RunVim([], after, '')
+    let lines = readfile('Xargspos.out')
+    call assert_equal('2 5', get(lines, 0, ''))
+  endif
+
+  call delete('Xargspos.out')
+  call Reset_arglist()
+endfunc
+
+func Test_arg_drop_file_position()
+  call Reset_arglist()
+  call writefile(['alpha', '    beta', 'gamma'], 'Xargdrop', 'D')
+  let after =<< trim [CODE]
+    drop Xargdrop:3:4
+    call writefile([printf('%d %d', line('.'), col('.'))], 'Xargdrop.out')
+    qall!
+  [CODE]
+
+  if RunVim([], after, '')
+    let lines = readfile('Xargdrop.out')
+    call assert_equal('3 4', get(lines, 0, ''))
+  endif
+
+  call delete('Xargdrop.out')
+  call Reset_arglist()
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_plus_arg_edit.vim
+++ b/src/testdir/test_plus_arg_edit.vim
@@ -8,6 +8,16 @@ function Test_edit()
   call assert_equal(["fooSLASHbar"], readfile("Xfile2"))
 endfunction
 
+func Test_edit_plus_cmd_column()
+  call writefile(['alpha', 'bravo'], 'Xpluscmdcol', 'D')
+  enew!
+  execute 'edit +2:3 Xpluscmdcol'
+  let pos = getcurpos()
+  call assert_equal(2, pos[1])
+  call assert_equal(3, pos[2])
+  bw!
+endfunc
+
 func Test_edit_bad()
   " Test loading a utf8 file with bad utf8 sequences.
   call writefile(["[\xff][\xc0][\xe2\x89\xf0][\xc2\xc2]"], "Xbadfile", 'D')

--- a/src/testdir/test_startup.vim
+++ b/src/testdir/test_startup.vim
@@ -273,6 +273,21 @@ func Test_cmdline_file_position_tabe_prefix()
   call delete('Xcursor')
 endfunc
 
+func Test_cmdline_plus_argument_line_and_column()
+  call writefile(['first', 'second'], 'Xplusarg', 'D')
+  let after =<< trim [CODE]
+    call writefile([printf('%d %d', line('.'), col('.'))], 'Xcursor')
+    qall!
+  [CODE]
+
+  if RunVim([], after, '+2:4 Xplusarg')
+    let parts = map(split(readfile('Xcursor')[0]), 'str2nr(v:val)')
+    call assert_equal([2, 4], parts)
+  endif
+
+  call delete('Xcursor')
+endfunc
+
 func Test_cmdline_non_numeric_colon_argument()
   CheckUnix
   call writefile(['colon name'], 'Xnon:numeric', 'D')

--- a/src/testdir/test_tabpage.vim
+++ b/src/testdir/test_tabpage.vim
@@ -1074,4 +1074,43 @@ func Test_lastused_tabpage_settabvar()
   bwipe!
 endfunc
 
+func Test_tabedit_file_position()
+  call writefile(['first line', '    second line', 'third'], 'Xtabpos', 'D')
+  let after =<< trim [CODE]
+    tabedit Xtabpos:2:5
+    call writefile([printf('tabedit %s %d %d',
+		\ expand('%:t'), line('.'), col('.'))], 'Xtabpos.out')
+    tabclose
+    TaBe Xtabpos:1:3
+    call writefile(readfile('Xtabpos.out')
+		\ + [printf('tabe %s %d %d',
+		\ expand('%:t'), line('.'), col('.'))], 'Xtabpos.out')
+    qall!
+  [CODE]
+
+  if RunVim([], after, '')
+    let lines = readfile('Xtabpos.out')
+    call assert_equal('tabedit Xtabpos 2 5', get(lines, 0, ''))
+    call assert_equal('tabe Xtabpos 1 3', get(lines, 1, ''))
+  endif
+
+  call delete('Xtabpos.out')
+endfunc
+
+func Test_drop_file_position()
+  call writefile(['first', '    second', 'third'], 'Xdrop', 'D')
+  let after =<< trim [CODE]
+    drop Xdrop:3:6
+    call writefile([printf('%d %d', line('.'), col('.'))], 'Xdrop.out')
+    qall!
+  [CODE]
+
+  if RunVim([], after, '')
+    let lines = readfile('Xdrop.out')
+    call assert_equal('3 6', get(lines, 0, ''))
+  endif
+
+  call delete('Xdrop.out')
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
## What & Why

  Opening a file at a specific spot is second nature in shells (`vim src/main.c:42:7`), but Vim only honored that syntax on the first command-line argument. Anything routed through
  `:tabedit`, arglists (`args`, `next`, `drop`), or even GUI drag-and-drop silently treated `:42:7` as part of the filename. This change makes the `file:line[:col]` idiom a first-class
  citizen everywhere: the suffix is stripped once, stored alongside the argument, and the cursor is driven to that location whenever the entry is opened (unless the user supplies their own
  `+cmd`).

## User-visible changes

  - `vim foo.ts:120:4`, `:tabedit foo.ts:120`, `args foo.ts:120`, `drop foo.ts:120` (including drag-and-drop) now all land exactly where requested—only the first `file:line[:col]` token is
  rewritten, and line/column numbers clamp to 1.
  - Subsequent navigation (`:next`, `:drop`, `argdo`, etc.) preserves the recorded location so you can sprinkle positional suffixes across an arglist and walk through them.
  - Column jumps work too: `file:42:8` becomes `+call cursor(42,8)` under the hood so long lines open with the cursor already at the right column.

## Why merge this

  - Aligns expectations between CLI usage and in-editor workflows—no more surprises when `:tabedit foo:99` opens a new buffer literally named `foo:99`.
  - Boosts productivity for anyone juggling compiler errors, test failures, or diagnostics that already emit `file:line[:col]` links.
  - Comes with dedicated regression tests for startup, tab/page commands, drag-and-drop, and arglist manipulations, so the behavior stays consistent going forward.



## Technical details

  - **Command-line parsing**: Added a shared `parse_cmd_file_arg()` helper and integrated it into `main.c` so the first `file:line[:col]` argument (after stripping optional `:TaBe`) is
  rewritten into the proper `+{line}` or `+call cursor(line,col)` form while respecting options that consume the next token.
  - **Ex command support**: Updated `do_exedit()` and arglist navigation (`do_argfile`, drag/drop paths) to trim `:line[:col]` suffixes before editing, remember the requested coordinates on
  each arglist entry, and move the cursor to the recorded line/column when no user `+cmd` overrides them.
  - **Tests**: Added targeted coverage to `test_startup.vim`, `test_tabpage.vim`, and `test_arglist.vim` for CLI invocations, tab commands, drag-and-drop, and arglist workflows to ensure the
  new behavior is stable.

  ## Testing

  ```sh
  make -C src
  cd src/testdir && make -f Makefile TEST_FILTER=Test_cmdline_file_position test_startup.res
  cd src/testdir && make -f Makefile TEST_FILTER=Test_tabedit_file_position test_tabpage.res
  cd src/testdir && make -f Makefile TEST_FILTER=Test_drop_file_position test_tabpage.res
  cd src/testdir && make -f Makefile TEST_FILTER=Test_args_file_position test_arglist.res
  cd src/testdir && make -f Makefile TEST_FILTER=Test_arg_drop_file_position test_arglist.res
```
