### PR TITLE
runtime(sml): fix number regex

### DIFF
--- a/runtime/syntax/sml.vim
+++ b/runtime/syntax/sml.vim
@@ -4,7 +4,8 @@
 " Maintainer:   Markus Mottl <markus.mottl@gmail.com>
 " Previous Maintainer: Fabrizio Zeno Cornelli
 "				<zeno@filibusta.crema.unimi.it> (invalid)
-" Last Change:  2022 Apr 01
+" Last Change:  2025 Nov 07
+"               2022 Apr 01
 "               2015 Aug 31 - Fixed opening of modules (Ramana Kumar)
 "               2006 Oct 23 - Fixed character highlighting bug (MM)
 

--- a/runtime/syntax/sml.vim
+++ b/runtime/syntax/sml.vim
@@ -153,9 +153,11 @@ syn match    smlKeyChar      ";"
 syn match    smlKeyChar      "\*"
 syn match    smlKeyChar      "="
 
-syn match    smlNumber        "\<\~\=\%(0w\)\=\d\+\>"
-syn match    smlNumber        "\<\~\=0w\=x\x\+\>"
-syn match    smlReal          "\<\~\=\d\+\.\d*\([eE][-+]\=\d\+\)\=[fl]\=\>"
+syn match    smlNumber        "\~\=\<\d\+\>"
+syn match    smlNumber        "\~\=\<0x\x\+\>"
+syn match    smlWord          "\<0w\d\+\>"
+syn match    smlWord          "\<0wx\x\+\>"
+syn match    smlReal          "\~\=\<\d\+\.\d\+\%([eE]\~\=\d\+\)\=\>"
 
 " Synchronization
 syn sync minlines=20
@@ -209,6 +211,7 @@ hi def link smlOperator     Keyword
 hi def link smlBoolean      Boolean
 hi def link smlCharacter    Character
 hi def link smlNumber       Number
+hi def link smlWord         Number
 hi def link smlReal         Float
 hi def link smlString       String
 hi def link smlType         Type

--- a/runtime/syntax/sml.vim
+++ b/runtime/syntax/sml.vim
@@ -153,7 +153,7 @@ syn match    smlKeyChar      ";"
 syn match    smlKeyChar      "\*"
 syn match    smlKeyChar      "="
 
-syn match    smlNumber        "\<\~\=\(0w\)\=\d\+\>"
+syn match    smlNumber        "\<\~\=\%(0w\)\=\d\+\>"
 syn match    smlNumber        "\<\~\=0w\=x\x\+\>"
 syn match    smlReal          "\<\~\=\d\+\.\d*\([eE][-+]\=\d\+\)\=[fl]\=\>"
 

--- a/runtime/syntax/sml.vim
+++ b/runtime/syntax/sml.vim
@@ -152,9 +152,9 @@ syn match    smlKeyChar      ";"
 syn match    smlKeyChar      "\*"
 syn match    smlKeyChar      "="
 
-syn match    smlNumber        "\<-\=\d\+\>"
-syn match    smlNumber        "\<-\=0[x|X]\x\+\>"
-syn match    smlReal          "\<-\=\d\+\.\d*\([eE][-+]\=\d\+\)\=[fl]\=\>"
+syn match    smlNumber        "\<\~\=\(0w\)\=\d\+\>"
+syn match    smlNumber        "\<\~\=0w\=x\x\+\>"
+syn match    smlReal          "\<\~\=\d\+\.\d*\([eE][-+]\=\d\+\)\=[fl]\=\>"
 
 " Synchronization
 syn sync minlines=20


### PR DESCRIPTION
Problem: the regex for number literals is wrong, first it uses `-` for negative numbers instead of `~`; second, it allows `0X` as the hexadecimal literal prefix (SML only supports using `0x`); and third, it doesn't recognize word literals (like `0w1234` or `0wx2fe`).

Solution: correct the regex.