### PR TITLE
runtime(filetype): recognize more Ruby files

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -2571,6 +2571,8 @@ const ft_from_ext = {
   "builder": "ruby",
   "rxml": "ruby",
   "rjs": "ruby",
+  # Sorbet (Ruby typechecker)
+  "rbi": "ruby",
   # Rust
   "rs": "rust",
   # S-lang
@@ -2999,6 +3001,8 @@ const ft_from_name = {
   "apt.conf": "aptconf",
   # BIND zone
   "named.root": "bindzone",
+  # Brewfile (uses Ruby syntax)
+  "Brewfile": "ruby",
   # Busted (Lua unit testing framework - configuration files)
   ".busted": "lua",
   # Bun history

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -695,7 +695,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     rrst: ['file.rrst', 'file.srst'],
     rst: ['file.rst'],
     rtf: ['file.rtf'],
-    ruby: ['.irbrc', 'irbrc', '.irb_history', 'irb_history', 'file.rb', 'file.rbw', 'file.gemspec', 'file.ru', 'Gemfile', 'file.builder', 'file.rxml', 'file.rjs', 'file.rant', 'file.rake', 'rakefile', 'Rakefile', 'rantfile', 'Rantfile', 'rakefile-file', 'Rakefile-file', 'Puppetfile', 'Vagrantfile'],
+    ruby: ['.irbrc', 'irbrc', '.irb_history', 'irb_history', 'file.rb', 'file.rbi', 'file.rbw', 'file.gemspec', 'file.ru', 'Gemfile', 'file.builder', 'file.rxml', 'file.rjs', 'file.rant', 'file.rake', 'rakefile', 'Rakefile', 'rantfile', 'Rantfile', 'rakefile-file', 'Rakefile-file', 'Puppetfile', 'Vagrantfile', 'Brewfile'],
     rust: ['file.rs'],
     sage: ['file.sage'],
     salt: ['file.sls'],


### PR DESCRIPTION
`rbi` is a file extension used by Sorbet, typechecker for Ruby: https://sorbet.org/docs/rbi

`Brewfile` is a bundler file for Homebrew package manager: https://docs.brew.sh/Brew-Bundle-and-Brewfile