### PR TITLE
Add support for mouse buttons 8 and 9 to terminals with xterm-like mouse support

### DIFF
--- a/runtime/doc/term.txt
+++ b/runtime/doc/term.txt
@@ -1167,7 +1167,8 @@ Mouse clicks can be mapped.  The codes for mouse clicks are:
 
 The X1 and X2 buttons refer to the extra buttons found on some mice.  The
 'Microsoft Explorer' mouse has these buttons available to the right thumb.
-Currently X1 and X2 only work on Win32 and X11 environments.
+Currently X1 and X2 only work on Win32 and X11 environments, and in terminals
+with xterm-like mouse support.
 
 Examples: >
 	:noremap <MiddleMouse> <LeftMouse><MiddleMouse>

--- a/src/mouse.c
+++ b/src/mouse.c
@@ -2316,6 +2316,10 @@ check_termcode_mouse(
 	 *	   0x23 = any button release
 	 *	   0x60 = button 4 down (scroll wheel down)
 	 *	   0x61 = button 5 down (scroll wheel up)
+	 *	   0x62 = button 6 down (scroll wheel left)
+	 *	   0x63 = button 7 down (scroll wheel right)
+	 *	   0xa0 = button 8 down (backward button)
+	 *	   0xa1 = button 9 down (forward button)
 	 *	add 0x04 for SHIFT
 	 *	add 0x08 for ALT
 	 *	add 0x10 for CTRL
@@ -2470,7 +2474,7 @@ check_termcode_mouse(
 	 * Linux console with GPM and the MS-DOS or Win32 console
 	 * (multi-clicks use >= 0x60).
 	 */
-	if (mouse_code >= MOUSEWHEEL_LOW
+	if (mouse_code >= MOUSEWHEEL_LOW && mouse_code < MOUSESIDEBUTTONS_LOW
 #  ifdef FEAT_GUI
 		&& !gui.in_use
 #  endif
@@ -2993,7 +2997,11 @@ check_termcode_mouse(
 	held_button = MOUSE_RELEASE;
     }
     else
+    {
+	if (use_xterm_mouse() && orig_mouse_code >= MOUSESIDEBUTTONS_LOW)
+	    current_button = (current_button) ? MOUSE_X2 : MOUSE_X1;
 	key_name[1] = get_pseudo_mouse_code(current_button, is_click, is_drag);
+    }
 
 
     // Make sure the mouse position is valid.  Some terminals may return weird

--- a/src/mouse.c
+++ b/src/mouse.c
@@ -2998,8 +2998,10 @@ check_termcode_mouse(
     }
     else
     {
+#if defined(UNIX)
 	if (use_xterm_mouse() && orig_mouse_code >= MOUSESIDEBUTTONS_LOW)
 	    current_button = (current_button) ? MOUSE_X2 : MOUSE_X1;
+#endif
 	key_name[1] = get_pseudo_mouse_code(current_button, is_click, is_drag);
     }
 

--- a/src/testdir/test_termcodes.vim
+++ b/src/testdir/test_termcodes.vim
@@ -1641,6 +1641,64 @@ func Test_mouse_termcodes()
   %bw!
 endfunc
 
+" Test buttons 8 and 9 for xterm-like terminal mouse support
+func Test_term_mouse_side_buttons()
+  new
+  let save_mouse = &mouse
+  let save_term = &term
+  let save_ttymouse = &ttymouse
+  call test_override('no_query_mouse', 1)
+  set mouse=a term=xterm
+  call WaitForResponses()
+
+  for ttymouse_val in g:Ttymouse_values
+    let msg = 'ttymouse=' .. ttymouse_val
+    exe 'set ttymouse=' .. ttymouse_val
+
+    let mouse_codes = [
+          \ ["<X1Mouse>", TerminalEscapeCode(128, 1, 1, 'M')],
+          \ ["<X1Drag>", TerminalEscapeCode(128+32, 1, 1, 'M')],
+          \ ["<X2Mouse>", TerminalEscapeCode(129, 1, 1, 'M')],
+          \ ["<X2Drag>", TerminalEscapeCode(129+32, 1, 1, 'M')],
+          \ ["<S-X1Mouse>", TerminalEscapeCode(128+4, 1, 1, 'M')],
+          \ ["<S-X2Mouse>", TerminalEscapeCode(129+4, 1, 1, 'M')],
+          \ ["<M-X1Mouse>", TerminalEscapeCode(128+8, 1, 1, 'M')],
+          \ ["<M-X2Mouse>", TerminalEscapeCode(129+8, 1, 1, 'M')],
+          \ ["<C-X1Mouse>", TerminalEscapeCode(128+16, 1, 1, 'M')],
+          \ ["<C-X2Mouse>", TerminalEscapeCode(129+16, 1, 1, 'M')],
+          \ ]
+
+    for [outstr, code] in mouse_codes
+      exe "normal ggC\<C-K>" . code
+      " normal ggD
+      " call feedkeys("i\<C-K>" . code, 'Lx!')
+      call assert_equal(outstr, getline(1), msg)
+    endfor
+  endfor
+
+  " ttymouse_val 'sgr'
+  let msg = 'ttymouse=sgr'
+  exe 'set ttymouse=sgr'
+
+  let mouse_codes = [
+        \ ["<X1Mouse>", TerminalEscapeCode(128, 1, 1, 'M')],
+        \ ["<X1Release>", TerminalEscapeCode(128, 1, 1, 'm')],
+        \ ["<X2Mouse>", TerminalEscapeCode(129, 1, 1, 'M')],
+        \ ["<X2Release>", TerminalEscapeCode(129, 1, 1, 'm')],
+        \ ]
+
+  for [outstr, code] in mouse_codes
+    exe "normal ggC\<C-K>" . code
+    call assert_equal(outstr, getline(1), msg)
+  endfor
+
+  let &mouse = save_mouse
+  let &term = save_term
+  let &ttymouse = save_ttymouse
+  call test_override('no_query_mouse', 0)
+  bwipe!
+endfunc
+
 " This only checks if the sequence is recognized.
 " This must be after other tests, because it has side effects to xterm
 " properties.

--- a/src/vim.h
+++ b/src/vim.h
@@ -2095,6 +2095,9 @@ typedef int sock_T;
 // Lowest button code for using the mouse wheel (xterm only)
 #define MOUSEWHEEL_LOW		0x60
 
+// Lowest button code for extra mouse buttons 8-11
+#define MOUSESIDEBUTTONS_LOW		0xa0
+
 #define MOUSE_CLICK_MASK	0x03
 
 #define NUM_MOUSE_CLICKS(code) \


### PR DESCRIPTION
Add support for mouse buttons 8 and 9 to terminals with xterm-like mouse support (xterm, xterm2, sgr, urxvt).

This adds support for:
- `<X1Mouse>`
- `<X2Mouse>`
- `<X1Release>`
- `<X2Release>`
- `<X1Drag>`
- `<X2Drag>`
including control, meta and shift modifiers.

Button 8 corresponds to `X1`, button 9 to `X2`.

Adds tests for these newly supported buttons, existing tests continue working.

Adds documentation mentioning the support.