### PR TITLE
tests: test_crash.vim times out in CI ASAN builds

### DIFF
--- a/src/testdir/test_crash.vim
+++ b/src/testdir/test_crash.vim
@@ -6,7 +6,12 @@ CheckScreendump
 " Run the command in terminal and wait for it to complete via notification
 func s:RunCommandAndWait(buf, cmd)
   call term_sendkeys(a:buf, a:cmd .. "; printf '" .. TermNotifyParentCmd(v:false) .. "'\<cr>")
-  call WaitForChildNotification()
+  if ValgrindOrAsan()
+    " test times out on ASAN CI builds
+    call WaitForChildNotification(10000)
+  else
+    call WaitForChildNotification()
+  endif
 endfunc
 
 func Test_crash1()


### PR DESCRIPTION
Problem:  tests: test_crash.vim times out in CI ASAN builds
Solution: Increase timeout