### PR TITLE
runtime(hog): set undo_ftplugin correctly

### DIFF
--- a/runtime/ftplugin/hog.vim
+++ b/runtime/ftplugin/hog.vim
@@ -8,7 +8,7 @@ if exists("b:did_ftplugin")
 endif
 let b:did_ftplugin = 1
 
-let s:undo_ftplugin = "setl fo< com< cms< def< inc<"
+let b:undo_ftplugin = "setl fo< com< cms< def< inc<"
 
 let s:cpo_save = &cpo
 set cpo&vim
@@ -19,8 +19,8 @@ setlocal commentstring=\c#\ %s
 setlocal define=\c^\s\{-}var
 setlocal include=\c^\s\{-}include
 
-" Move around configurations 
-let s:hog_keyword_match = '\c^\s*\<\(preprocessor\\|config\\|output\\|include\\|ipvar\\|portvar\\|var\\|dynamicpreprocessor\\|' . 
+" Move around configurations
+let s:hog_keyword_match = '\c^\s*\<\(preprocessor\\|config\\|output\\|include\\|ipvar\\|portvar\\|var\\|dynamicpreprocessor\\|' .
                         \ 'dynamicengine\\|dynamicdetection\\|activate\\|alert\\|drop\\|block\\|dynamic\\|log\\|pass\\|reject\\|sdrop\\|sblock\)\>'
 
 exec "nnoremap <buffer><silent> ]] :call search('" . s:hog_keyword_match . "', 'W' )<CR>"
@@ -28,9 +28,9 @@ exec "nnoremap <buffer><silent> [[ :call search('" . s:hog_keyword_match . "', '
 
 if exists("loaded_matchit")
     let b:match_words =
-                  \ '^\s*\<\%(preprocessor\|config\|output\|include\|ipvar\|portvar' . 
-                  \ '\|var\|dynamicpreprocessor\|dynamicengine\|dynamicdetection' . 
-                  \ '\|activate\|alert\|drop\|block\|dynamic\|log\|pass\|reject' . 
+                  \ '^\s*\<\%(preprocessor\|config\|output\|include\|ipvar\|portvar' .
+                  \ '\|var\|dynamicpreprocessor\|dynamicengine\|dynamicdetection' .
+                  \ '\|activate\|alert\|drop\|block\|dynamic\|log\|pass\|reject' .
                   \ '\|sdrop\|sblock\>\):$,\::\,:;'
     let b:match_skip = 'r:\\.\{-}$\|^\s*#.\{-}$\|^\s*$'
 endif


### PR DESCRIPTION
I happen to be working with hledger CSV `.rules` lately, which are being
detected as `filetype=hog`, so I noticed when `:setf conf` did something weird
with `commentstring`. Make this buffer-local like it should be.
