### PR TITLE
runtime(erlang): recognize -if/-elif as erlangPreCondit

### DIFF
--- a/runtime/syntax/erlang.vim
+++ b/runtime/syntax/erlang.vim
@@ -3,7 +3,7 @@
 " Maintainer:   Csaba Hoch <csaba.hoch@gmail.com>
 " Contributor:  Adam Rutkowski <hq@mtod.org>
 "               Johannes Christ <jc@jchri.st>
-" Last Update:  2025-Jul-06
+" Last Update:  2025-Nov-12
 " License:      Vim license
 " URL:          https://github.com/vim-erlang/vim-erlang-runtime
 
@@ -217,7 +217,7 @@ syn match erlangInnerDocAttribute '^\s*-\%(\s\|\n\|%.*\n\)*\%(moduledoc\|doc\)\>
 syn match erlangInclude   '^\s*-\%(\s\|\n\|%.*\n\)*\%(include\|include_lib\)\>' contains=erlangComment
 syn match erlangRecordDef '^\s*-\%(\s\|\n\|%.*\n\)*record\>' contains=erlangComment
 syn match erlangDefine    '^\s*-\%(\s\|\n\|%.*\n\)*\%(define\|undef\)\>' contains=erlangComment
-syn match erlangPreCondit '^\s*-\%(\s\|\n\|%.*\n\)*\%(ifdef\|ifndef\|else\|endif\)\>' contains=erlangComment
+syn match erlangPreCondit '^\s*-\%(\s\|\n\|%.*\n\)*\%(ifdef\|ifndef\|else\|if\|elif\|endif\)\>' contains=erlangComment
 syn match erlangType      '^\s*-\%(\s\|\n\|%.*\n\)*\%(spec\|type\|opaque\|nominal\|callback\)\>' contains=erlangComment
 
 " Keywords


### PR DESCRIPTION
The `-if(Condition)`/`-elif(Condition)` are compiler macros that evaluate the following lines only if `Condition` evaluates to `true`.  This patch enables syntax highlighting for these macros.

https://www.erlang.org/doc/system/macros.html#conditional-compilation