### PR TITLE
Make 'commentstring' available in all builds

### DIFF
--- a/runtime/doc/version9.txt
+++ b/runtime/doc/version9.txt
@@ -41692,6 +41692,8 @@ Completion: ~
 - 'smartcase' applies to completion filtering
 
 Options: ~
+- 'commentstring' is now available in all builds and no longer requires the
+  |+folding| feature
 - the default for 'commentstring' contains whitespace padding to have
   automatic comments look nicer |comment-install|
 - 'completeopt' is now a |global-local| option.

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -2476,9 +2476,7 @@ free_buf_options(
     ga_clear(&buf->b_kmap_ga);
 #endif
     clear_string_option(&buf->b_p_com);
-#ifdef FEAT_FOLDING
     clear_string_option(&buf->b_p_cms);
-#endif
     clear_string_option(&buf->b_p_nf);
 #ifdef FEAT_SYN_HL
     clear_string_option(&buf->b_p_syn);

--- a/src/errors.h
+++ b/src/errors.h
@@ -1364,9 +1364,9 @@ EXTERN char e_illegal_character_after_chr[]
 #ifdef FEAT_FOLDING
 EXTERN char e_comma_required[]
 	INIT(= N_("E536: Comma required"));
+#endif
 EXTERN char e_commentstring_must_be_empty_or_contain_str[]
 	INIT(= N_("E537: 'commentstring' must be empty or contain %s"));
-#endif
 EXTERN char e_pattern_found_in_every_line_str[]
 	INIT(= N_("E538: Pattern found in every line: %s"));
 EXTERN char e_illegal_character_str[]

--- a/src/option.c
+++ b/src/option.c
@@ -6866,9 +6866,7 @@ get_varp(struct vimoption *p)
 	case PV_CINSD:	return (char_u *)&(curbuf->b_p_cinsd);
 	case PV_CINW:	return (char_u *)&(curbuf->b_p_cinw);
 	case PV_COM:	return (char_u *)&(curbuf->b_p_com);
-#ifdef FEAT_FOLDING
 	case PV_CMS:	return (char_u *)&(curbuf->b_p_cms);
-#endif
 	case PV_CPT:	return (char_u *)&(curbuf->b_p_cpt);
 #ifdef BACKSLASH_IN_FILENAME
 	case PV_CSL:	return (char_u *)&(curbuf->b_p_csl);
@@ -7457,10 +7455,8 @@ buf_copy_options(buf_T *buf, int flags)
 	    COPY_OPT_SCTX(buf, BV_SN);
 	    buf->b_p_com = vim_strsave(p_com);
 	    COPY_OPT_SCTX(buf, BV_COM);
-#ifdef FEAT_FOLDING
 	    buf->b_p_cms = vim_strsave(p_cms);
 	    COPY_OPT_SCTX(buf, BV_CMS);
-#endif
 	    buf->b_p_fo = vim_strsave(p_fo);
 	    COPY_OPT_SCTX(buf, BV_FO);
 	    buf->b_p_flp = vim_strsave(p_flp);

--- a/src/option.h
+++ b/src/option.h
@@ -510,9 +510,7 @@ EXTERN char_u	*p_cb;		// 'clipboard'
 EXTERN char_u	*p_cpm;		// 'clipmethod'
 #endif
 EXTERN long	p_ch;		// 'cmdheight'
-#ifdef FEAT_FOLDING
 EXTERN char_u	*p_cms;		// 'commentstring'
-#endif
 EXTERN char_u	*p_cpt;		// 'complete'
 EXTERN long	p_cto;		// 'completetimeout'
 #if defined(FEAT_GUI_DIALOG) || defined(FEAT_CON_DIALOG)
@@ -1191,9 +1189,7 @@ enum
     , BV_CINSD
     , BV_CINW
     , BV_CM
-#ifdef FEAT_FOLDING
     , BV_CMS
-#endif
     , BV_COM
     , BV_COT
     , BV_CPT

--- a/src/optiondefs.h
+++ b/src/optiondefs.h
@@ -48,9 +48,7 @@
 #define PV_CINSD	OPT_BUF(BV_CINSD)
 #define PV_CINW		OPT_BUF(BV_CINW)
 #define PV_CM		OPT_BOTH(OPT_BUF(BV_CM))
-#ifdef FEAT_FOLDING
-# define PV_CMS		OPT_BUF(BV_CMS)
-#endif
+#define PV_CMS		OPT_BUF(BV_CMS)
 #define PV_COM		OPT_BUF(BV_COM)
 #define PV_COT		OPT_BOTH(OPT_BUF(BV_COT))
 #define PV_CPT		OPT_BUF(BV_CPT)
@@ -671,13 +669,8 @@ static struct vimoption options[] =
 				(char_u *)0L}
 			    SCTX_INIT},
     {"commentstring", "cms", P_STRING|P_ALLOCED|P_VI_DEF,
-#ifdef FEAT_FOLDING
 			    (char_u *)&p_cms, PV_CMS, did_set_commentstring, NULL,
 			    {(char_u *)"/* %s */", (char_u *)0L}
-#else
-			    (char_u *)NULL, PV_NONE, NULL, NULL,
-			    {(char_u *)0L, (char_u *)0L}
-#endif
 			    SCTX_INIT},
 			    // P_PRI_MKRC isn't needed here, optval_default()
 			    // always returns TRUE for 'compatible'

--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -307,9 +307,7 @@ check_buf_options(buf_T *buf)
     check_string_option(&buf->b_p_flp);
     check_string_option(&buf->b_p_isk);
     check_string_option(&buf->b_p_com);
-#ifdef FEAT_FOLDING
     check_string_option(&buf->b_p_cms);
-#endif
     check_string_option(&buf->b_p_nf);
     check_string_option(&buf->b_p_qe);
 #ifdef FEAT_SYN_HL
@@ -1581,7 +1579,6 @@ did_set_comments(optset_T *args)
     return errmsg;
 }
 
-#if defined(FEAT_FOLDING)
 /*
  * The 'commentstring' option is changed.
  */
@@ -1595,7 +1592,6 @@ did_set_commentstring(optset_T *args)
 
     return NULL;
 }
-#endif
 
 /*
  * Check if value for 'complete' is valid when 'complete' option is changed.

--- a/src/structs.h
+++ b/src/structs.h
@@ -3312,9 +3312,7 @@ struct file_buffer
     char_u	*b_p_cinsd;	// 'cinscopedecls'
     char_u	*b_p_cinw;	// 'cinwords'
     char_u	*b_p_com;	// 'comments'
-#ifdef FEAT_FOLDING
     char_u	*b_p_cms;	// 'commentstring'
-#endif
     char_u	*b_p_cot;	// 'completeopt' local value
     unsigned	b_cot_flags;	// flags for 'completeopt'
     char_u	*b_p_cpt;	// 'complete'


### PR DESCRIPTION
Problem:  'commentstring' requires the +folding feature but is used in contexts other than folding.
Solution: Remove the +folding feature guards from 'commentstring' and make it available in all builds.