### PR TITLE
WinEnter autocommand may confuse Vim when closing tabpage

### DIFF
--- a/src/testdir/test_autocmd.vim
+++ b/src/testdir/test_autocmd.vim
@@ -5537,4 +5537,27 @@ func Test_VimResized_and_window_width_not_equalized()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_win_tabclose_autocmd()
+
+  defer CleanUpTestAuGroup()
+  new
+  augroup testing
+    au WinClosed * wincmd p
+  augroup END
+
+  tabnew
+  new
+  new
+
+  call assert_equal(2, tabpagenr('$'))
+  try
+    tabclose
+  catch
+    " should not happen
+    call assert_report("closing tabpage failed")
+  endtry
+  call assert_equal(1, tabpagenr('$'))
+  bw!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/window.c
+++ b/src/window.c
@@ -4403,6 +4403,7 @@ close_others(
 {
     win_T	*wp;
     win_T	*nextwp;
+    win_T	*old_curwin = curwin;
     int		r;
 
     if (one_window())
@@ -4416,6 +4417,14 @@ close_others(
     for (wp = firstwin; win_valid(wp); wp = nextwp)
     {
 	nextwp = wp->w_next;
+
+	// autocommands messed this one up
+	if (old_curwin != curwin && win_valid(old_curwin))
+	{
+	    curwin = old_curwin;
+	    curbuf = curwin->w_buffer;
+	}
+
 	if (wp == curwin)		// don't close current window
 	    continue;
 


### PR DESCRIPTION
Problem:  WinEnter autocommand may confuse Vim when closing tabpage
Solution: Verify that curwin did not change in close_others()

related: #18722