### PR TITLE
Error message with :unlet! and non-existing dictionary item

### DIFF
--- a/src/evalvars.c
+++ b/src/evalvars.c
@@ -2022,7 +2022,7 @@ ex_let_one(
     void
 ex_unlet(exarg_T *eap)
 {
-    ex_unletlock(eap, eap->arg, 0, 0, do_unlet_var, NULL);
+    ex_unletlock(eap, eap->arg, 0, eap->forceit ? GLV_QUIET : 0, do_unlet_var, NULL);
 }
 
 /*

--- a/src/testdir/test_expr.vim
+++ b/src/testdir/test_expr.vim
@@ -1114,4 +1114,17 @@ func Test_bitwise_shift()
   call assert_equal(64, MultBy2_A()(32))
 endfunc
 
+func Test_unlet_nonexisting_key()
+  let g:base = {}
+  call assert_fails(':unlet g:base["foobar"]', 'E716:')
+
+  try
+    unlet! g:base["foobar"]
+  catch
+    call assert_false(1, "no error when unletting non-existing dict key")
+  endtry
+  unlet g:base
+
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_expr.vim
+++ b/src/testdir/test_expr.vim
@@ -1121,7 +1121,7 @@ func Test_unlet_nonexisting_key()
   try
     unlet! g:base["foobar"]
   catch
-    call assert_false(1, "no error when unletting non-existing dict key")
+    call assert_report("error when unletting non-existing dict key")
   endtry
   unlet g:base
 


### PR DESCRIPTION
Problem:  Error message with :unlet! and non-existing dictionary item
Solution: Set GLV_QUIET when using unlet with bang attribute

fixes: #18516