### PR TITLE
runtime(netrw): wipes unnamed buffers

### DIFF
--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -13,6 +13,7 @@
 " 2025 Oct 26 by Vim Project fix parsing of remote user names #18611
 " 2025 Oct 27 by Vim Project align comment after #18611
 " 2025 Nov 01 by Vim Project fix NetrwChgPerm #18674
+" 2025 Nov 13 by Vim Project don't wipe unnamed buffers #18740
 " Copyright:  Copyright (C) 2016 Charles E. Campbell {{{1
 "             Permission is hereby granted to use and distribute this code,
 "             with or without modifications, provided that this copyright
@@ -8315,7 +8316,7 @@ function netrw#LocalBrowseCheck(dirname)
         let ibuf    = 1
         let buflast = bufnr("$")
         while ibuf <= buflast
-            if bufwinnr(ibuf) == -1 && isdirectory(s:NetrwFile(bufname(ibuf)))
+            if bufwinnr(ibuf) == -1 && !empty(bufname(ibuf)) && isdirectory(s:NetrwFile(bufname(ibuf)))
                 exe "sil! keepj keepalt ".ibuf."bw!"
             endif
             let ibuf= ibuf + 1

--- a/src/testdir/test_plugin_netrw.vim
+++ b/src/testdir/test_plugin_netrw.vim
@@ -104,7 +104,7 @@ func Test_netrw_parse_ssh_config_entries()
 endfunction
 
 "username containing special-chars"
-func Test_netrw_parse_special_char_user ()
+func Test_netrw_parse_special_char_user()
   call s:setup()
   let result = TestNetrwCaptureRemotePath('scp://user-01@localhost:2222/test.txt')
   call assert_equal(result.method, 'scp')
@@ -113,4 +113,20 @@ func Test_netrw_parse_special_char_user ()
   call assert_equal(result.port, '2222')
   call assert_equal(result.path, 'test.txt')
   call s:cleanup()
+endfunction
+
+func Test_netrw_wipe_empty_buffer_fastpath()
+  let g:netrw_fastbrowse=0
+  packadd netrw
+  call setline(1, 'foobar')
+  let  bufnr = bufnr('%')
+  tabnew
+  Explore
+  call search('README.txt', 'W')
+  exe ":norm \<cr>"
+  call assert_equal(4, bufnr('$'))
+  call assert_true(bufexists(bufnr))
+  bw
+
+  unlet! netrw_fastbrowse
 endfunction


### PR DESCRIPTION
Problem:  LocalBrowseCheck() wipes unnamed buffers
Solution: Check that bufname() is not empty

fixes: #18740