### PR TITLE
fix(tutor): escape tutor filename

### DIFF
--- a/runtime/autoload/tutor.vim
+++ b/runtime/autoload/tutor.vim
@@ -211,7 +211,7 @@ function! tutor#TutorCmd(tutor_name)
     endif
 
     call tutor#SetupVim()
-    exe "drop ".l:to_open
+    exe "drop ".fnameescape(l:to_open)
     call tutor#EnableInteractive(v:true)
 endfunction
 


### PR DESCRIPTION
Since NeoVim is installed in `Program Files` directory by default, path to tutor filename must be quoted before passing to `:drop`.

This is backport of https://github.com/neovim/neovim/pull/36544.