### PR TITLE
feat: add Arabic-QWERTY and two Persian keymaps

### DIFF
--- a/runtime/keymap/arabic-qwerty.vim
+++ b/runtime/keymap/arabic-qwerty.vim
@@ -1,0 +1,90 @@
+scriptencoding utf-8
+
+" Arabic phonetic keyboard from http://arabic.omaralzabir.com/
+" at https://github.com/suryaya/Arabic-Phonetic-Keyboard-Linux
+" See also https://r.nf/r/learn_arabic/comments/etj8x4/i_made_an_arabic_phonetic_keyboard_for_linux/
+
+
+" Use this short name in the status line.
+let b:keymap_name = "ara"
+
+loadkeymap
+
+1 ١ " Arabic_1
+2 ٢ " Arabic_2
+3 ٣ " Arabic_3
+4 ۴ " Farsi_4
+5 ۵ " Farsi_5
+6 ۶ " Farsi_6
+7 ٧ " Arabic_7
+8 ٨ " Arabic_8
+9 ٩ " Arabic_9
+0 ۰ " Farsi_0
+" -
+" =
+
+q ق " Arabic_qaf
+Q ئ
+w و
+W ؤ
+e ع " Arabic_ain
+E  ٰ
+r ر " Arabic_ra
+R  ٓ
+t ت " Arabic_teh
+T ط " Arabic_tah
+y ى " Arabic_yeh
+u  َ
+U  ً
+i  ِ
+I  ٍ
+o  ُ
+O  ٌ
+p ٱ
+p آ
+" [
+" ]
+
+a ا " Arabic_alef
+A أ " Arabic_maddaonalef
+s س " Arabic_seen
+S ش " Arabic_sheen
+
+d د " Arabic_dal
+D ض
+f ف " Arabic_feh
+F ق
+g ء
+G غ
+h ه " Arabic_heh
+H ح " Arabic_hah
+j ذ
+J ج
+k ك
+K خ
+l ل " Arabic_lam
+L إ
+; ؛ " Arabic_semicolon
+" '
+" \"
+
+z ز " Arabic_zeh
+Z ظ " Arabic_zah
+x ث
+X ة
+c ص
+C  ٔ
+v  ْ
+V  ّ
+b ب " Arabic_beh
+B ﻵ
+n ن " Arabic_noon
+N  ٕ
+m م " Arabic_meem
+" M '
+" , '
+" . 
+" >
+" /
+? ؟
+

--- a/runtime/keymap/persian-banan.vim
+++ b/runtime/keymap/persian-banan.vim
@@ -1,0 +1,92 @@
+scriptencoding utf-8
+
+" Adapted from http://www.persoarabic.org/content/generated/doc.free/mohsen/PLPC/120036/current/accessPage/index.html#farsi-transliterate-bananPersianInputMethod
+
+" Use this short name in the status line.
+let b:keymap_name = "per"
+
+loadkeymap
+
+1 ١ " Arabic_1
+2 ٢ " Arabic_2
+3 ٣ " Arabic_3
+4 ۴ " Farsi_4
+5 ۵ " Farsi_5
+6 ۶ " Farsi_6
+7 ٧ " Arabic_7
+8 ٨ " Arabic_8
+9 ٩ " Arabic_9
+0 ۰ " Farsi_0
+" -
+" =
+
+gh ق " Arabic_qaf
+Q ق " Arabic_qaf
+q غ " Arabic_ghain
+G غ " Arabic_ghain
+" w ش " Arabic_sheen
+" e ع " Arabic_ain
+w ع " Arabic_ain
+r ر " Arabic_ra
+t ت " Arabic_teh
+tt ت " Arabic_teh
+T ط " Arabic_tah
+y ى " Farsi_yeh
+i ى " Farsi_yeh
+I ئ " Farsi_yeh with Hamza
+u و " Arabic_waw
+v و " Arabic_waw
+V ؤ " Arabic_waw  with Hamza
+" o و " Arabic_waw
+p پ " Arabic_peh
+" [
+" ]
+
+a ا " Arabic_alef
+A آ " Arabic_maddaonalef
+s س " Arabic_seen
+ss س " Arabic_seen
+S ص " Arabic_sad
+" <M-s> ش " Arabic_sheen
+sh ش " Arabic_sheen
+
+d د " Arabic_dal
+" D ذ " Arabic_zal
+f ف " Arabic_feh
+g گ " Farsi_gaf
+gg گ " Farsi_gaf
+h ه " Arabic_heh
+hh ه " Arabic_heh
+H ح " Arabic_hah
+j ج " Arabic_jeem
+" J ژ  " Farsi_jeh
+k ک " Arabic_keheh
+kk ک " Arabic_keheh
+l ل " Arabic_lam
+; ؛ " Arabic_semicolon
+' ، " Arabic_comma
+\" ” " quoted_bl
+
+z ز " Arabic_zain
+zz ز " Arabic_zain
+Z ذ " Arabic_thal
+zh ژ  " Farsi_jeh
+" <m-z> ظ " Arabic_zah
+kh خ " Arabic_khah
+" x خ " Arabic_khah
+x ض " Arabic_zad
+X ظ " Arabic_zah
+c ث " Arabic_theh
+cc ث " Arabic_theh
+ch چ " Arabic_tcheh
+C چ " Arabic_tcheh
+v و " Arabic_waw
+" V   " Arabic_hamza
+b ب " Arabic_beh
+n ن " Arabic_noon
+m م " Arabic_meem
+, ,
+" .
+" /
+? ؟
+

--- a/runtime/keymap/persian-qwerty.vim
+++ b/runtime/keymap/persian-qwerty.vim
@@ -1,0 +1,78 @@
+scriptencoding utf-8
+
+" Adapted from https://github.com/gpuminingir/Farsi-Phonetic-Keyboard-Linux/blob/main/ubuntu_ir_keyboardlaout_qwerty
+" to fit https://www.jahanshiri.ir/keyboard/phonetic/en/ .
+" See also https://www.facebook.com/PersianPhoneticKeyboardLayout/
+
+" Use this short name in the status line.
+let b:keymap_name = "per"
+
+loadkeymap
+
+1 ١ " Arabic_1
+2 ٢ " Arabic_2
+3 ٣ " Arabic_3
+4 ۴ " Farsi_4
+5 ۵ " Farsi_5
+6 ۶ " Farsi_6
+7 ٧ " Arabic_7
+8 ٨ " Arabic_8
+9 ٩ " Arabic_9
+0 ۰ " Farsi_0
+" -
+" =
+
+q ق " Arabic_qaf
+Q غ " Arabic_ghain
+w ش " Arabic_sheen
+e ع " Arabic_ain
+r ر " Arabic_ra
+t ت " Arabic_teh
+T ط " Arabic_tah
+y ى " Farsi_yeh
+i ى " Farsi_yeh
+I ئ " Farsi_yeh with Hamza
+u و " Arabic_waw
+o و " Arabic_waw
+p پ " Arabic_peh
+" [
+" ]
+
+a ا " Arabic_alef
+A آ " Arabic_maddaonalef
+s س " Arabic_seen
+S ص " Arabic_sad
+<M-s> ش " Arabic_sheen
+
+d د " Arabic_dal
+D ذ " Arabic_thal
+f ف " Arabic_feh
+g گ " Farsi_gaf
+G غ " Arabic_ghain
+h ه " Arabic_heh
+H ح " Arabic_hah
+j ج " Arabic_jeem
+J ژ  " Farsi_jeh
+k ک " Arabic_kaf
+l ل " Arabic_lam
+; ؛ " Arabic_semicolon
+' ، " Arabic_comma
+\" ” " quoted_bl
+
+z ز " Arabic_zeh
+Z ض " Arabic_zad
+<m-z> ظ " Arabic_zah
+x خ " Arabic_khah
+X ظ " Arabic_zah
+c ث " Arabic_theh
+C چ " Arabic_tcheh
+v و " Arabic_waw
+V ؤ " Arabic_waw  with Hamza
+b ب " Arabic_beh
+n ن " Arabic_noon
+m م " Arabic_meem
+, ,
+" .
+" /
+? ؟
+


### PR DESCRIPTION
Could be of use to other Vim users also less acquainted with the Arabic alphabet, but rather non-standard and niche