### PR TITLE
Remove 'go+=C' Prior to Vim 9.2

### DIFF
--- a/runtime/doc/gui_w32.txt
+++ b/runtime/doc/gui_w32.txt
@@ -491,16 +491,14 @@ VIM_KEYCODE_TRANS_STRATEGY can be set to the desired value ("experimental" or
 
 Title Bar						*gui-w32-title-bar*
 
-Starting with Windows 11, you can customize the gVim title bar (also known as
-the caption bar) by enabling the |'go-C'| option.
+Starting with Windows 11, you can customize the gVim title bar.
 
-Once enabled, the appearance is controlled by two highlighting groups:
+The appearance is controlled by two highlighting groups:
 1. |hl-TitleBar|   -- Sets the color of the title bar for the active window.
 2. |hl-TitleBarNC| -- Sets the color of the title bar for inactive windows.
 
-To use the system's default title bar colors, set highlighting groups to
-`NONE`: >
-
+To use default title bar colors, set highlighting groups to `NONE` (default):
+>
 	hi TitleBar guibg=NONE guifg=NONE
 	hi TitleBarNC guibg=NONE guifg=NONE
 <

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4527,10 +4527,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 								*'go-c'*
 	  'c'	Use console dialogs instead of popup dialogs for simple
 		choices.
-								*'go-C'*
-	  'C'	Use |hl-TitleBar| and |hl-TitleBarNC| if available.
-		Currently only works for MS-Window GUI.
-		See |gui-w32-title-bar| for details.
 								*'go-d'*
 	  'd'	Use dark theme variant if available.  Currently only works for
 		GTK+ GUI.

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -355,7 +355,6 @@ $quote	eval.txt	/*$quote*
 'go'	options.txt	/*'go'*
 'go-!'	options.txt	/*'go-!'*
 'go-A'	options.txt	/*'go-A'*
-'go-C'	options.txt	/*'go-C'*
 'go-F'	options.txt	/*'go-F'*
 'go-L'	options.txt	/*'go-L'*
 'go-M'	options.txt	/*'go-M'*

--- a/runtime/doc/version9.txt
+++ b/runtime/doc/version9.txt
@@ -41715,8 +41715,6 @@ Options: ~
 - Setting 'nowrap' in a modeline could cause long lines to be hidden
   off-screen.  To make this visible, the listchars "extend" suboption is set
   to ">" by default, indicating text that extends beyond the window width.
-- 'guioptions': New value |'go-C'| to style the title/caption bar on Windows 11
-  (see also the below platform specific change).
 - 'completepopup': Add more values to style popup windows.
 
 Ex commands: ~

--- a/src/gui.c
+++ b/src/gui.c
@@ -3564,11 +3564,6 @@ gui_init_which_components(char_u *oldval UNUSED)
 	    case GO_GREY:
 		// make menu's have grey items, ignored here
 		break;
-#ifdef FEAT_GUI_MSWIN
-	    case GO_TITLEBAR:
-		using_titlebar = TRUE;
-		break;
-#endif
 #ifdef FEAT_TOOLBAR
 	    case GO_TOOLBAR:
 		using_toolbar = TRUE;

--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -1563,7 +1563,6 @@ extern BOOL win11_or_later; // this is in os_win32.c
 /*
  * Set TitleBar's color. Handle hl-TitleBar and hl-TitleBarNC.
  *
- * Only enabled when 'guioptions' has 'C'.
  * if "TitleBar guibg=NONE guifg=NONE" reset the window back to using the
  * system's default behavior for the border color.
  */
@@ -1573,27 +1572,23 @@ gui_mch_set_titlebar_colors(void)
     if (pDwmSetWindowAttribute == NULL || !win11_or_later)
 	return;
 
-    guicolor_T captionColor = 0xFFFFFFFF;
-    guicolor_T textColor = 0xFFFFFFFF;
+    guicolor_T captionColor, textColor;
 
-    if (vim_strchr(p_go, GO_TITLEBAR) != NULL)
+    if (gui.in_focus)
     {
-	if (gui.in_focus)
-	{
-	    captionColor = gui.title_bg_pixel;
-	    textColor = gui.title_fg_pixel;
-	}
-	else
-	{
-	    captionColor = gui.titlenc_bg_pixel;
-	    textColor = gui.titlenc_fg_pixel;
-	}
-
-	if (captionColor == INVALCOLOR)
-	    captionColor = 0xFFFFFFFF;
-	if (textColor == INVALCOLOR)
-	    textColor = 0xFFFFFFFF;
+	captionColor = gui.title_bg_pixel;
+	textColor = gui.title_fg_pixel;
     }
+    else
+    {
+	captionColor = gui.titlenc_bg_pixel;
+	textColor = gui.titlenc_fg_pixel;
+    }
+
+    if (captionColor == INVALCOLOR)
+	captionColor = 0xFFFFFFFF;
+    if (textColor == INVALCOLOR)
+	textColor = 0xFFFFFFFF;
 
     pDwmSetWindowAttribute(s_hwnd, DWMWA_CAPTION_COLOR,
 	    &captionColor, sizeof(captionColor));

--- a/src/highlight.c
+++ b/src/highlight.c
@@ -257,7 +257,7 @@ static char *(highlight_init_both[]) = {
     "lCursor guibg=fg guifg=bg", // should be different, but what?
 #endif
 #ifdef FEAT_GUI_MSWIN
-    "TitleBar guibg=bg guifg=fg",
+    "TitleBar guibg=NONE guifg=NONE",
     "TitleBarNC guibg=NONE guifg=NONE",
 #endif
     "default link QuickFixLine Search",

--- a/src/option.h
+++ b/src/option.h
@@ -288,7 +288,6 @@ typedef enum {
 #define GO_ASELML	'A'		// autoselect modeless selection
 #define GO_BOT		'b'		// use bottom scrollbar
 #define GO_CONDIALOG	'c'		// use console dialog
-#define GO_TITLEBAR	'C'		// use 'hl-TitleBar'
 #define GO_DARKTHEME	'd'		// use dark theme variant
 #define GO_TABLINE	'e'		// may show tabline
 #define GO_FORG		'f'		// start GUI in foreground
@@ -309,7 +308,7 @@ typedef enum {
 #define GO_VERTICAL	'v'		// arrange dialog buttons vertically
 #define GO_KEEPWINSIZE	'k'		// keep GUI window size
 // all possible flags for 'go'
-#define GO_ALL		"!aAbcCdefFghilLmMpPrRtTvk"
+#define GO_ALL		"!aAbcdefFghilLmMpPrRtTvk"
 
 // flags for 'comments' option
 #define COM_NEST	'n'		// comments strings nest

--- a/src/testdir/test_gui.vim
+++ b/src/testdir/test_gui.vim
@@ -664,13 +664,6 @@ func Test_set_guioptions()
     set guioptions&
     call assert_equal('egmrLtT', &guioptions)
 
-    set guioptions+=C
-    exec 'sleep' . duration
-    call assert_equal('egmrLtTC', &guioptions)
-    set guioptions-=C
-    exec 'sleep' . duration
-    call assert_equal('egmrLtT', &guioptions)
-
   else
     " Default Value
     set guioptions&


### PR DESCRIPTION
I initially used the guioption flag to restrict this feature because
earlier implementations could not undo its effect on the titlebar.
However, guioption has now become obsolete, since the default
'hl-titlebar' does not affect the behavior of the default titlebar.
Therefore, I propose removing this redundant option before all changes
are finalized.

Rationale:

> New features are accepted only within a development cycle, but not
> within the stability period.  During the cycle, new features may be
> developed and are allowed to change, but they must be settled before
> the cycle closes.

Change:

Remove guioption+=C
Default hi TitleBar guibg=NONE guifg=NONE

Signed-off-by: Mao-Yining <mao.yining@outlook.com>
