### PR TITLE
runtime:compiler:fix: set errorformat where missing

### DIFF
--- a/runtime/compiler/rime_deployer.vim
+++ b/runtime/compiler/rime_deployer.vim
@@ -3,6 +3,7 @@
 " Maintainer:           Wu, Zhenyu <wuzhenyu@ustc.edu>
 " URL:                  https://rime.im
 " Latest Revision:      2024-04-09
+" Last Change:          2025 Nov 16 by The Vim Project (set errorformat)
 
 if exists('b:current_compiler')
   finish
@@ -25,6 +26,8 @@ for s:shared_data_dir in ['/sdcard/rime-data', '/run/current-system/sw/share/rim
 endfor
 execute 'CompilerSet makeprg=rime_deployer\ --build\ %:p:h:S\' s:shared_data_dir
 unlet s:prefix s:shared_data_dir
+" CompilerSet errorformat=%f:%l:%c:\ %m,%f:%l:\ %m
+CompilerSet errorformat&
 
 let &cpoptions = s:save_cpoptions
 unlet s:save_cpoptions

--- a/runtime/compiler/vimdoc.vim
+++ b/runtime/compiler/vimdoc.vim
@@ -2,6 +2,7 @@
 " Language:             vimdoc
 " Maintainer:           Wu, Zhenyu <wuzhenyu@ustc.edu>
 " Latest Revision:      2024-04-13
+" Last Change: 2025 Nov 16 by The Vim Project (set errorformat)
 "
 " If you can not find 'vimdoc' in the package manager of your distribution e.g
 " 'pip', then you may need to build it from its source.
@@ -15,6 +16,8 @@ let s:save_cpoptions = &cpoptions
 set cpoptions&vim
 
 CompilerSet makeprg=vimdoc
+" CompilerSet errorformat=%f:%l:%c:\ %m,%f:%l:\ %m
+CompilerSet errorformat&
 
 let &cpoptions = s:save_cpoptions
 unlet s:save_cpoptions

--- a/runtime/compiler/yamllint.vim
+++ b/runtime/compiler/yamllint.vim
@@ -3,6 +3,7 @@
 " Maintainer:  Romain Lafourcade <romainlafourcade@gmail.com>
 " Last Change: 2021 July 21
 "		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
+"              2025 Nov 16 by The Vim Project (set errorformat)
 
 if exists("current_compiler")
     finish
@@ -10,4 +11,7 @@ endif
 let current_compiler = "yamllint"
 
 CompilerSet makeprg=yamllint\ -f\ parsable
+" CompilerSet errorformat=%f:%l:%c:\ [%t%*[^]]]\ %m,%f:%l:%c:\ [%*[^]]]\ %m
+CompilerSet errorformat&
+
 

--- a/runtime/compiler/zig_build_exe.vim
+++ b/runtime/compiler/zig_build_exe.vim
@@ -1,7 +1,7 @@
 " Vim compiler file
 " Compiler: Zig Compiler (zig build-exe)
 " Upstream: https://github.com/ziglang/zig.vim
-" Last Change: 2024 Apr 05 by The Vim Project (removed :CompilerSet definition)
+" Last Change: 2025 Nov 16 by The Vim Project (set errorformat)
 
 if exists('current_compiler')
   finish
@@ -12,11 +12,9 @@ let current_compiler = 'zig_build_exe'
 let s:save_cpo = &cpo
 set cpo&vim
 
-if has('patch-7.4.191')
-  CompilerSet makeprg=zig\ build-exe\ \%:S\ \$* 
-else
-  CompilerSet makeprg=zig\ build-exe\ \"%\"\ \$* 
-endif
+CompilerSet makeprg=zig\ build-exe\ \%:S\ \$* 
+" CompilerSet errorformat=%f:%l:%c: %t%*[^:]: %m, %f:%l:%c: %m, %f:%l: %m
+CompilerSet errorformat&
 
 let &cpo = s:save_cpo
 unlet s:save_cpo

--- a/runtime/compiler/zig_test.vim
+++ b/runtime/compiler/zig_test.vim
@@ -1,7 +1,7 @@
 " Vim compiler file
 " Compiler: Zig Compiler (zig test)
 " Upstream: https://github.com/ziglang/zig.vim
-" Last Change: 2024 Apr 05 by The Vim Project (removed :CompilerSet definition)
+" Last Change: 2025 Nov 16 by The Vim Project (set errorformat)
 
 if exists('current_compiler')
   finish
@@ -12,11 +12,9 @@ let current_compiler = 'zig_test'
 let s:save_cpo = &cpo
 set cpo&vim
 
-if has('patch-7.4.191')
-  CompilerSet makeprg=zig\ test\ \%:S\ \$* 
-else
-  CompilerSet makeprg=zig\ test\ \"%\"\ \$* 
-endif
+CompilerSet makeprg=zig\ test\ \%:S\ \$* 
+" CompilerSet errorformat=%f:%l:%c: %t%*[^:]: %m, %f:%l:%c: %m, %f:%l: %m
+CompilerSet errorformat&
 
 let &cpo = s:save_cpo
 unlet s:save_cpo


### PR DESCRIPTION
As a matter of caution it sets it to the default gcc errorformat

	errorformat=%*[^"]"%f"%*\D%l: %m,"%f"%*\D%l: %m,%-Gg%\?make[%*\d]: *** [%f:%l:%m,%-Gg%\?make: *** [%f:%l:%m,%-G%f:%l: (Each undeclared identifier is reported only once,%-G%f:%l: for each function it appears in.),%-GIn file included from %f:%l:%c:,%-GIn file included from %f:%l:%c\,,%-GIn file included from %f:%l:%c,%-GIn file included from %f:%l,%-G%*[ ]from %f:%l:%c,%-G%*[ ]from %f:%l:,%-G%*[ ]from %f:%l\,,%-G%*[ ]from %f:%l,%f:%l:%c:%m,%f(%l):%m,%f:%l:%m,"%f"\, line %l%*\D%c%*[^ ] %m,%D%*\a[%*\d]: Entering directory %*[`']%f',%X%*\a[%*\d]: Leaving directory %*[`']%f',%D%*\a: Entering directory %*[`']%f',%X%*\a: Leaving directory %*[`']%f',%DMaking %*\a in %f,%f|%l| %m

so that the compiler keeps working after switching to others.

While likely only a subset is needed; such a subset has been proposed in a commented errorformat;
checked to work for yamllint but ran out of steam for other compilers;
pinging maintainers @romainl and @wuzhenyu and @andrewrk / @techatrix