### PR TITLE
runtime:compiler:feat: use npx for compilers when package.json exists

### DIFF
--- a/runtime/compiler/biome.vim
+++ b/runtime/compiler/biome.vim
@@ -2,14 +2,18 @@
 " Compiler:     Biome (= linter for JavaScript, TypeScript, JSX, TSX, JSON,
 "               JSONC, HTML, Vue, Svelte, Astro, CSS, GraphQL and GritQL files)
 " Maintainer:   @Konfekt
-" Last Change:  2025 Nov 12
+" Last Change:  2025 Nov 16
 if exists("current_compiler") | finish | endif
 let current_compiler = "biome"
 
 let s:cpo_save = &cpo
 set cpo&vim
 
-exe 'CompilerSet makeprg=' .. escape('biome check --linter-enabled=true --formatter-enabled=false --assist-enabled=false --reporter=github '
+" CompilerSet makeprg=biome
+" CompilerSet makeprg=npx\ biome
+exe 'CompilerSet makeprg=' .. escape(
+			\ empty(findfile('package.json', '.;')) ? 'biome' : 'npx @biomejs/biome'
+			\ .. ' check --linter-enabled=true --formatter-enabled=false --assist-enabled=false --reporter=github '
       \ .. get(b:, 'biome_makeprg_params', get(g:, 'biome_makeprg_params', '')), ' \|"')
 
 CompilerSet errorformat=::%trror%.%#file=%f\\,line=%l\\,%.%#col=%c\\,%.%#::%m

--- a/runtime/compiler/csslint.vim
+++ b/runtime/compiler/csslint.vim
@@ -3,11 +3,16 @@
 " Maintainer:	Daniel Moch <daniel@danielmoch.com>
 " Last Change:	2016 May 21
 "		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
+"               2025 Nov 16 by The Vim Project (check if in webdev repo)
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "csslint"
 
-CompilerSet makeprg=csslint\ --format=compact
+if empty(findfile('package.json', '.;'))
+  CompilerSet makeprg=csslint\ --format=compact
+else
+  CompilerSet makeprg=npx\ csslint\ --format=compact
+endif
 CompilerSet errorformat=%-G,%-G%f:\ lint\ free!,%f:\ line\ %l\\,\ col\ %c\\,\ %trror\ -\ %m,%f:\ line\ %l\\,\ col\ %c\\,\ %tarning\ -\ %m,%f:\ line\ %l\\,\ col\ %c\\,\ %m

--- a/runtime/compiler/eslint.vim
+++ b/runtime/compiler/eslint.vim
@@ -2,11 +2,16 @@
 " Compiler:    ESLint for JavaScript
 " Maintainer:  Romain Lafourcade <romainlafourcade@gmail.com>
 " Last Change: 2024 Nov 30
+"              2025 Nov 16 by The Vim Project (check if in webdev repo)
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "eslint"
 
-CompilerSet makeprg=npx\ eslint\ --format\ stylish
+if empty(findfile('package.json', '.;'))
+  CompilerSet makeprg=eslint\ --format\ stylish
+else
+  CompilerSet makeprg=npx\ eslint\ --format\ stylish
+endif
 CompilerSet errorformat=%-P%f,\%\\s%#%l:%c\ %#\ %trror\ \ %m,\%\\s%#%l:%c\ %#\ %tarning\ \ %m,\%-Q,\%-G%.%#,

--- a/runtime/compiler/jest.vim
+++ b/runtime/compiler/jest.vim
@@ -2,6 +2,7 @@
 " Compiler:	Jest
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:	2024 Apr 03
+" Last Change:  2025 Nov 16 by The Vim Project (check if in webdev repo)
 
 if exists("current_compiler")
   finish
@@ -13,7 +14,11 @@ set cpo&vim
 
 " CompilerSet makeprg=npx\ --no-install\ jest\ --no-colors
 
-CompilerSet makeprg=jest\ --no-colors
+if empty(findfile('package.json', '.;'))
+  CompilerSet makeprg=jest\ --no-colors
+else
+  CompilerSet makeprg=npx\ jest\ --no-colors
+endif
 CompilerSet errorformat=%-A\ \ ●\ Console,
 		       \%E\ \ ●\ %m,
 		       \%Z\ %\\{4}%.%#Error:\ %f:\ %m\ (%l:%c):%\\=,

--- a/runtime/compiler/jshint.vim
+++ b/runtime/compiler/jshint.vim
@@ -2,6 +2,7 @@
 " Compiler:	JSHint
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:	2024 Apr 03
+" Last Change:  2025 Nov 16 by The Vim Project (check if in webdev repo)
 
 if exists("current_compiler")
   finish
@@ -13,7 +14,11 @@ set cpo&vim
 
 " CompilerSet makeprg=npx\ jshint\ --verbose
 
-CompilerSet makeprg=jshint\ --verbose
+if empty(findfile('package.json', '.;'))
+  CompilerSet makeprg=jshint\ --verbose
+else
+  CompilerSet makeprg=npx\ jshint\ --verbose
+endif
 CompilerSet errorformat=%f:\ line\ %l\\,\ col\ %c\\,\ %m\ (%t%n),
 		       \%-G%.%#
 

--- a/runtime/compiler/jsonlint.vim
+++ b/runtime/compiler/jsonlint.vim
@@ -2,6 +2,7 @@
 " Compiler:	JSON Lint
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:	2024 Apr 03
+" Last Change:  2025 Nov 16 by The Vim Project (check if in webdev repo)
 
 if exists("current_compiler")
   finish
@@ -13,7 +14,11 @@ set cpo&vim
 
 " CompilerSet makeprg=npx\ jsonlint\ --compact\ --quiet
 
-CompilerSet makeprg=jsonlint\ --compact\ --quiet
+if empty(findfile('package.json', '.;'))
+  CompilerSet makeprg=jsonlint\ --compact\ --quiet
+else
+  CompilerSet makeprg=npx\ jsonlint\ --compact\ --quiet
+endif
 CompilerSet errorformat=%f:\ line\ %l\\,\ col\ %c\\,\ found:\ %m,
 		       \%-G%.%#
 

--- a/runtime/compiler/sass.vim
+++ b/runtime/compiler/sass.vim
@@ -3,6 +3,7 @@
 " Maintainer:	Tim Pope <vimNOSPAM@tpope.org>
 " Last Change:	2016 Aug 29
 "		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
+"               2025 Nov 16 by The Vim Project (check if in webdev repo)
 
 if exists("current_compiler")
   finish
@@ -12,7 +13,11 @@ let current_compiler = "sass"
 let s:cpo_save = &cpo
 set cpo-=C
 
-CompilerSet makeprg=sass
+if empty(findfile('package.json', '.;'))
+  CompilerSet makeprg=sass
+else
+  CompilerSet makeprg=npx\ sass
+endif
 
 CompilerSet errorformat=
       \%f:%l:%m\ (Sass::Syntax%trror),

--- a/runtime/compiler/standard.vim
+++ b/runtime/compiler/standard.vim
@@ -3,11 +3,16 @@
 " Maintainer:  Romain Lafourcade <romainlafourcade@gmail.com>
 " Last Change: 2020 August 20
 "		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
+"               2025 Nov 16 by The Vim Project (check if in webdev repo)
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "standard"
 
-CompilerSet makeprg=npx\ standard
+if empty(findfile('package.json', '.;'))
+  CompilerSet makeprg=standard
+else
+  CompilerSet makeprg=npx\ standard
+endif
 CompilerSet errorformat=%f:%l:%c:\ %m,%-G%.%#

--- a/runtime/compiler/stylelint.vim
+++ b/runtime/compiler/stylelint.vim
@@ -2,6 +2,7 @@
 " Compiler:	Stylelint
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:	2024 Apr 03
+"               2025 Nov 16 by The Vim Project (check if in webdev repo)
 
 if exists("current_compiler")
   finish
@@ -13,7 +14,11 @@ set cpo&vim
 
 " CompilerSet makeprg=npx\ stylelint\ --formatter\ compact
 
-CompilerSet makeprg=stylelint\ --formatter\ compact
+if empty(findfile('package.json', '.;'))
+  CompilerSet makeprg=stylelint\ --formatter\ compact
+else
+  CompilerSet makeprg=npx\ stylelint\ --formatter\ compact
+endif
 CompilerSet errorformat=%f:\ line\ %l\\,\ col\ %c\\,\ %trror\ -\ %m,
 		       \%f:\ line\ %l\\,\ col\ %c\\,\ %tarning\ -\ %m,
 		       \%-G%.%#

--- a/runtime/compiler/svelte-check.vim
+++ b/runtime/compiler/svelte-check.vim
@@ -1,12 +1,16 @@
 " Vim compiler file
 " Compiler:	svelte-check
 " Maintainer:	@Konfekt
-" Last Change:	2025 Feb 27
+" Last Change:	2025 Nov 16
 
 if exists("current_compiler") | finish | endif
 let current_compiler = "svelte-check"
 
-CompilerSet makeprg=npx\ svelte-check\ --output\ machine
+if empty(findfile('package.json', '.;'))
+  CompilerSet makeprg=svelte-check\ --output\ machine
+else
+  CompilerSet makeprg=npx\ svelte-check\ --output\ machine
+endif
 CompilerSet errorformat=%*\\d\ %t%*\\a\ \"%f\"\ %l:%c\ \"%m\",
 CompilerSet errorformat+=%-G%*\\d\ START\ %.%#,
 CompilerSet errorformat+=%-G%*\\d\ COMPLETED\ %.%#,

--- a/runtime/compiler/ts-node.vim
+++ b/runtime/compiler/ts-node.vim
@@ -2,6 +2,7 @@
 " Compiler:	TypeScript Runner
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:	2024 Apr 03
+"               2025 Nov 16 by The Vim Project (check if in webdev repo)
 
 if exists("current_compiler")
   finish
@@ -13,7 +14,11 @@ set cpo&vim
 
 " CompilerSet makeprg=npx\ ts-node
 
-CompilerSet makeprg=ts-node
+if empty(findfile('package.json', '.;'))
+  CompilerSet makeprg=ts-node
+else
+  CompilerSet makeprg=npx\ ts-node
+endif
 CompilerSet errorformat=%f\ %#(%l\\,%c):\ %trror\ TS%n:\ %m,
 		       \%E%f:%l,
 		       \%+Z%\\w%\\+Error:\ %.%#,

--- a/runtime/compiler/tsc.vim
+++ b/runtime/compiler/tsc.vim
@@ -3,6 +3,7 @@
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:	2024 Apr 03
 "		2025 Mar 11 by The Vim Project (add comment for Dispatch, add tsc_makeprg variable)
+"               2025 Nov 16 by The Vim Project (check if in webdev repo)
 
 if exists("current_compiler")
   finish
@@ -14,7 +15,7 @@ set cpo&vim
 
 " CompilerSet makeprg=tsc
 " CompilerSet makeprg=npx\ tsc
-execute $'CompilerSet makeprg={escape(get(b:, 'tsc_makeprg', get(g:, 'tsc_makeprg', 'tsc')), ' \|"')}'
+execute $'CompilerSet makeprg={escape((empty(findfile('package.json', '.;')) ? '' : 'npx ') .. get(b:, 'tsc_makeprg', get(g:, 'tsc_makeprg', 'tsc')), ' \|"')}'
 CompilerSet errorformat=%f\ %#(%l\\,%c):\ %trror\ TS%n:\ %m,
 		       \%trror\ TS%n:\ %m,
 		       \%-G%.%#

--- a/runtime/compiler/typedoc.vim
+++ b/runtime/compiler/typedoc.vim
@@ -2,6 +2,7 @@
 " Compiler:	TypeDoc
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:	2024 Apr 03
+"               2025 Nov 16 by The Vim Project (check if in webdev repo)
 
 if exists("current_compiler")
   finish
@@ -13,7 +14,11 @@ set cpo&vim
 
 " CompilerSet makeprg=npx\ typedoc
 
-CompilerSet makeprg=typedoc
+if empty(findfile('package.json', '.;'))
+  CompilerSet makeprg=typedoc
+else
+  CompilerSet makeprg=npx\ typedoc
+endif
 CompilerSet errorformat=%EError:\ %f(%l),
 		       \%WWarning:\ %f(%l),
 		       \%+IDocumentation\ generated\ at\ %f,

--- a/runtime/compiler/xo.vim
+++ b/runtime/compiler/xo.vim
@@ -2,6 +2,7 @@
 " Compiler:	XO
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:	2024 Apr 03
+"               2025 Nov 16 by The Vim Project (check if in webdev repo)
 
 if exists("current_compiler")
   finish
@@ -13,7 +14,11 @@ set cpo&vim
 
 " CompilerSet makeprg=npx\ xo\ --reporter\ compact
 
-CompilerSet makeprg=xo\ --reporter\ compact
+if empty(findfile('package.json', '.;'))
+  CompilerSet makeprg=xo\ --reporter\ compact
+else
+  CompilerSet makeprg=npx\ xo\ --reporter\ compact
+endif
 CompilerSet errorformat=%f:\ line\ %l\\,\ col\ %c\\,\ %trror\ %m,
 		       \%f:\ line\ %l\\,\ col\ %c\\,\ %tarning\ %m,
 		       \%-G%.%#


### PR DESCRIPTION
webdev compilers are often used inside a webdev repo with deps installed by `npm i` and tooling aligned to it;
take care of this inside Vim as well

pinging maintainers @djmoch, @dkearns, @romainl, @tpope, ... in the hope to not have omitted anyone