### PR TITLE
Fix: Issue #18752: crash in fuzzy sort

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -5710,11 +5710,14 @@ ins_compl_get_exp(pos_T *ini)
     }
     may_trigger_modechanged();
 
-    if (is_nearest_active() && !ins_compl_has_preinsert())
-	sort_compl_match_list(cp_compare_nearest);
+    if (match_count > 0)
+    {
+	if (is_nearest_active() && !ins_compl_has_preinsert())
+	    sort_compl_match_list(cp_compare_nearest);
 
-    if ((get_cot_flags() & COT_FUZZY) && ins_compl_leader_len() > 0)
-	ins_compl_fuzzy_sort();
+	if ((get_cot_flags() & COT_FUZZY) && ins_compl_leader_len() > 0)
+	    ins_compl_fuzzy_sort();
+    }
 
     return match_count;
 }

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -3705,6 +3705,22 @@ func Test_complete_fuzzy_collect()
   set completeopt& cfc& cpt&
 endfunc
 
+" Issue #18752
+func Test_complete_fuzzy_collect_multiwin()
+  new
+  set completefuzzycollect=keyword,files,whole_line
+  set completeopt=fuzzy
+
+  vnew
+  call setline(1, ["completeness,", "compatibility", "Composite", "Omnipotent"])
+  wincmd p
+  call feedkeys("Somp\<C-P>\<Esc>0", 'tx!')
+  call assert_equal('Omnipotent', getline('.'))
+
+  bw!
+  set completeopt& cfc&
+endfunc
+
 func Test_cfc_with_longest()
   new
   set completefuzzycollect=keyword,files,whole_line


### PR DESCRIPTION
Fixes https://github.com/vim/vim/issues/18752

Bug fix: When completion candidates are gathered from a different window, and when completing `<c-p>`, linked list should be sorted only after all items are collected.