### PR TITLE
Fix @. let assignment error

### DIFF
--- a/src/evalvars.c
+++ b/src/evalvars.c
@@ -1088,8 +1088,6 @@ ex_let(exarg_T *eap)
     argend = skip_var_list(arg, TRUE, &var_count, &semicolon, FALSE);
     if (argend == NULL)
 	return;
-    if (argend > arg && argend[-1] == '.')  // for var.='str'
-	--argend;
     expr = skipwhite(argend);
     concat = expr[0] == '.'
 	&& ((expr[1] == '=' && in_old_script(2))

--- a/src/testdir/test_registers.vim
+++ b/src/testdir/test_registers.vim
@@ -1260,4 +1260,11 @@ func Test_insert_small_delete_linewise()
   bwipe!
 endfunc
 
+func Test_writing_readonly_regs()
+  call assert_fails('let @. = "foo"', 'E354:')
+  call assert_fails('let @% = "foo"', 'E354:')
+  call assert_fails('let @: = "foo"', 'E354:')
+  call assert_fails('let @~ = "foo"', 'E354:')
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_vim9_expr.vim
+++ b/src/testdir/test_vim9_expr.vim
@@ -3352,7 +3352,7 @@ def Test_expr9_register()
   END
   v9.CheckDefAndScriptSuccess(lines)
 
-  v9.CheckDefAndScriptFailure(["@. = 'yes'"], ['E354:', 'E488:'], 1)
+  v9.CheckDefAndScriptFailure(["@. = 'yes'"], 'E354:', 1)
 enddef
 
 " This is slow when run under valgrind.


### PR DESCRIPTION
Problem:  When assigning to @. in a :let command an incorrect "E15" error is emitted.
Solution: Emit the correct "E354" error.

It appears that the code deleted in this commit was added to work around
a limitation in the returned value from `find_name_end()` that no longer
exists.

See commit 76b92b2830841fd4e05006cc3cad1d8f0bc8101b (tag: v7.0b).

There's some similar issues with Vim9 compilation of register assignments but these have a different cause so I'll create a separate PR to fix those. 
