### PR TITLE
runtime(i3config): add `all` option for popup_during_fullscreen

### DIFF
--- a/runtime/syntax/i3config.vim
+++ b/runtime/syntax/i3config.vim
@@ -313,7 +313,7 @@ hi def link i3ConfigClientOpts                      i3ConfigOption
 hi def link i3ConfigFocusFollowsMouseOpts           i3ConfigOption
 hi def link i3ConfigMouseWarpingOpts                i3ConfigOption
 hi def link i3ConfigPopupFullscreenOpts             i3ConfigOption
-hi def link i3ConfigPopupFullscreenOptsExtra        i3ConfigOption
+hi def link i3ConfigPopupFullscreenOptsExtra        i3ConfigPopupFullscreenOpts
 hi def link i3ConfigFocusWrappingOpts               i3ConfigOption
 hi def link i3ConfigTimeUnit                        i3ConfigNumber
 hi def link i3ConfigFocusOnActivationOpts           i3ConfigOption

--- a/runtime/syntax/i3config.vim
+++ b/runtime/syntax/i3config.vim
@@ -3,7 +3,7 @@
 " Original Author: Josef Litos (JosefLitos/i3config.vim)
 " Maintainer: Quentin Hibon (github user hiqua)
 " Version: 1.2.5
-" Last Change: 2025-11-17
+" Last Change: 2025-11-24
 
 " References:
 " http://i3wm.org/docs/userguide.html#configuring
@@ -150,8 +150,10 @@ syn keyword i3ConfigMouseWarpingOpts output container none contained
 syn keyword i3ConfigKeyword mouse_warping contained skipwhite nextgroup=i3ConfigMouseWarpingOpts
 
 " 4.26 Popups while fullscreen
-syn keyword i3ConfigPopupFullscreenOpts smart ignore leave_fullscreen all contained
-syn keyword i3ConfigKeyword popup_during_fullscreen contained skipwhite nextgroup=i3ConfigPopupFullscreenOpts
+syn keyword i3ConfigPopupFullscreenShared smart ignore leave_fullscreen contained
+syn keyword i3ConfigPopupFullscreenExtra all contained
+syn cluster i3ConfigPopupFullscreenOpts contains=i3ConfigPopupFullscreenShared,i3ConfigPopupFullscreenExtra
+syn keyword i3ConfigKeyword popup_during_fullscreen contained skipwhite nextgroup=@i3ConfigPopupFullscreenOpts
 
 " 4.27 Focus wrapping
 syn keyword i3ConfigFocusWrappingOpts force workspace contained

--- a/runtime/syntax/i3config.vim
+++ b/runtime/syntax/i3config.vim
@@ -2,8 +2,8 @@
 " Language: i3 config file
 " Original Author: Josef Litos (JosefLitos/i3config.vim)
 " Maintainer: Quentin Hibon (github user hiqua)
-" Version: 1.2.4
-" Last Change: 2024-05-24
+" Version: 1.2.5
+" Last Change: 2025-11-17
 
 " References:
 " http://i3wm.org/docs/userguide.html#configuring
@@ -150,7 +150,7 @@ syn keyword i3ConfigMouseWarpingOpts output container none contained
 syn keyword i3ConfigKeyword mouse_warping contained skipwhite nextgroup=i3ConfigMouseWarpingOpts
 
 " 4.26 Popups while fullscreen
-syn keyword i3ConfigPopupFullscreenOpts smart ignore leave_fullscreen contained
+syn keyword i3ConfigPopupFullscreenOpts smart ignore leave_fullscreen all contained
 syn keyword i3ConfigKeyword popup_during_fullscreen contained skipwhite nextgroup=i3ConfigPopupFullscreenOpts
 
 " 4.27 Focus wrapping

--- a/runtime/syntax/i3config.vim
+++ b/runtime/syntax/i3config.vim
@@ -150,9 +150,9 @@ syn keyword i3ConfigMouseWarpingOpts output container none contained
 syn keyword i3ConfigKeyword mouse_warping contained skipwhite nextgroup=i3ConfigMouseWarpingOpts
 
 " 4.26 Popups while fullscreen
-syn keyword i3ConfigPopupFullscreenShared smart ignore leave_fullscreen contained
-syn keyword i3ConfigPopupFullscreenExtra all contained
-syn cluster i3ConfigPopupFullscreenOpts contains=i3ConfigPopupFullscreenShared,i3ConfigPopupFullscreenExtra
+syn keyword i3ConfigPopupFullscreenOpts smart ignore leave_fullscreen contained
+syn keyword i3ConfigPopupFullscreenOptsExtra all contained
+syn cluster i3ConfigPopupFullscreenOpts contains=i3ConfigPopupFullscreenOpts,i3ConfigPopupFullscreenOptsExtra
 syn keyword i3ConfigKeyword popup_during_fullscreen contained skipwhite nextgroup=@i3ConfigPopupFullscreenOpts
 
 " 4.27 Focus wrapping
@@ -313,6 +313,7 @@ hi def link i3ConfigClientOpts                      i3ConfigOption
 hi def link i3ConfigFocusFollowsMouseOpts           i3ConfigOption
 hi def link i3ConfigMouseWarpingOpts                i3ConfigOption
 hi def link i3ConfigPopupFullscreenOpts             i3ConfigOption
+hi def link i3ConfigPopupFullscreenOptsExtra        i3ConfigOption
 hi def link i3ConfigFocusWrappingOpts               i3ConfigOption
 hi def link i3ConfigTimeUnit                        i3ConfigNumber
 hi def link i3ConfigFocusOnActivationOpts           i3ConfigOption

--- a/runtime/syntax/i3config.vim
+++ b/runtime/syntax/i3config.vim
@@ -1,6 +1,6 @@
 " Vim syntax file
 " Language: i3 config file
-" Original Author: Josef Litos (JosefLitos/i3config.vim)
+" Original Author: Josef Litos (litoj/i3config.vim)
 " Maintainer: Quentin Hibon (github user hiqua)
 " Version: 1.2.5
 " Last Change: 2025-11-24

--- a/runtime/syntax/swayconfig.vim
+++ b/runtime/syntax/swayconfig.vim
@@ -2,8 +2,8 @@
 " Language: sway config file
 " Original Author: Josef Litos (JosefLitos/i3config.vim)
 " Maintainer: James Eapen <james.eapen@vai.org>
-" Version: 1.2.4
-" Last Change: 2024 Oct 17
+" Version: 1.2.5
+" Last Change: 2025 Nov 24
 " 2025 Sep 23 by Vim Project update swayconfig syntax #18293
 
 " References:
@@ -21,6 +21,9 @@ endif
 syn cluster i3ConfigCommand contains=i3ConfigCommand,i3ConfigAction,i3ConfigActionKeyword,@i3ConfigValue,i3ConfigColor,i3ConfigKeyword
 
 runtime! syntax/i3config.vim
+
+" In sway, popup_during_fullscreen does not have options like all option.
+syn cluster i3ConfigPopupFullscreenOpts remove=i3ConfigPopupFullscreenExtra
 
 " Sway extensions to i3
 syn keyword i3ConfigActionKeyword opacity urgent shortcuts_inhibitor splitv splith splitt contained contained skipwhite nextgroup=i3ConfigOption

--- a/runtime/syntax/swayconfig.vim
+++ b/runtime/syntax/swayconfig.vim
@@ -23,7 +23,7 @@ syn cluster i3ConfigCommand contains=i3ConfigCommand,i3ConfigAction,i3ConfigActi
 runtime! syntax/i3config.vim
 
 " In sway, popup_during_fullscreen does not have options like all option.
-syn cluster i3ConfigPopupFullscreenOpts remove=i3ConfigPopupFullscreenExtra
+syn cluster i3ConfigPopupFullscreenOpts remove=i3ConfigPopupFullscreenOptsExtra
 
 " Sway extensions to i3
 syn keyword i3ConfigActionKeyword opacity urgent shortcuts_inhibitor splitv splith splitt contained contained skipwhite nextgroup=i3ConfigOption

--- a/runtime/syntax/swayconfig.vim
+++ b/runtime/syntax/swayconfig.vim
@@ -1,8 +1,8 @@
 " Vim syntax file
 " Language: sway config file
-" Original Author: Josef Litos (JosefLitos/i3config.vim)
+" Original Author: Josef Litos (litoj/i3config.vim)
 " Maintainer: James Eapen <james.eapen@vai.org>
-" Version: 1.2.5
+" Version: 1.2.6
 " Last Change: 2025 Nov 24
 " 2025 Sep 23 by Vim Project update swayconfig syntax #18293
 


### PR DESCRIPTION
It seems like since i3 version 4.24, popup_during_fullscreen has new option `all`.

So add `all` option for popup_during_fullscreen to prevent `all` option highlighted as error.

Reference:
https://i3wm.org/docs/userguide.html#_popups_during_fullscreen_mode