### PR TITLE
Wrong virtcol('$') with virtual text at EOL

### DIFF
--- a/src/charset.c
+++ b/src/charset.c
@@ -1702,8 +1702,7 @@ getvcol(
 	    {
 		incr = 1;	// NUL at end of line only takes one column
 #ifdef FEAT_PROP_POPUP
-		if (cts.cts_cur_text_width > 0)
-		    incr = cts.cts_cur_text_width;
+		incr += cts.cts_cur_text_width;
 		on_NUL = TRUE;
 #endif
 		break;

--- a/src/testdir/test_textprop.vim
+++ b/src/testdir/test_textprop.vim
@@ -4403,6 +4403,22 @@ func Test_text_eol_long_wrap_smoothscroll()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_text_eol_virtcol()
+  new
+  call prop_type_add('test', #{highlight: 'ErrorMsg'})
+  call setline(1, repeat(['1234567890'], 6))
+
+  for [ln, tx] in [[2, 'a'], [3, 'ab'], [4, 'abc'], [5, 'abcd'], [6, 'αβγ口']]
+    let co = col([ln, '$'])
+    call assert_equal(11, virtcol([ln, '$']))
+    call prop_add(ln, co, #{type: 'test', text: tx})
+    call assert_equal(11 + strwidth(tx), virtcol([ln, '$']))
+  endfor
+
+  bwipe!
+  call prop_type_delete('test')
+endfunc
+
 func Test_text_below_nowrap()
   CheckScreendump
   CheckRunVimInTerminal


### PR DESCRIPTION
Problem:  Wrong virtcol('$') with virtual text at EOL.
Solution: Also add 1 to end virtcol when there is virtual text.

fixes: #18761
