### PR TITLE
runtime(netrw): Fix reading files via scp using the default client on Windows

### DIFF
--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -1701,10 +1701,10 @@ function netrw#NetRead(mode,...)
             else
                 let useport= ""
             endif
-            " 'C' in 'C:\path\to\file' is handled as hostname on windows.
+            " Using UNC notation in windows to get a unix like path.
             " This is workaround to avoid mis-handle windows local-path:
             if g:netrw_scp_cmd =~ '^scp' && has("win32")
-                let tmpfile_get = substitute(tr(tmpfile, '\', '/'), '^\(\a\):[/\\]\(.*\)$', '/\1/\2', '')
+                let tmpfile_get = substitute(tr(tmpfile, '\', '/'), '^\(\a\):[/\\]\(.*\)$', '//' .. $COMPUTERNAME .. '/\1$/\2', '')
             else
                 let tmpfile_get = tmpfile
             endif


### PR DESCRIPTION
On Windows the temporary files are translated to a UNC-like notation which is not valid. For example:
```cmd
C:\Users\JohnDoe\AppData\Local\Temp\VEAAE6E.tmp
```
is turned into:
```cmd
/C/Users/JohnDoe/AppData/Local/Temp/VEAAE6E.tmp
```
which Windows default shell (`cmd.exe`) cannot handle.
The fix translates into actual UNC notation which the shell can handle:
```cmd
//COMPUTERNAME/C$/Users/JohnDoe/AppData/Local/Temp/VEAAE6E.tmp
```
a reproducer here: [before patch](https://github.com/MiguelBarro/setpwsh/actions/runs/19447596174/job/55645572664) and [after patch](https://github.com/MiguelBarro/setpwsh/actions/runs/19447709288/job/55647957009).