### PR TITLE
runtime(haskell): allow spaces in backticked operators

### DIFF
--- a/runtime/syntax/haskell.vim
+++ b/runtime/syntax/haskell.vim
@@ -46,8 +46,8 @@ syn match VarId "\(\<[A-Z][a-zA-Z0-9_']*\.\)*\<[a-z][a-zA-Z0-9_']*\>" contains=@
 " others are variables (e.g. functions).
 syn match hsVarSym "\(\<[A-Z][a-zA-Z0-9_']*\.\)\=[-!#$%&\*\+/<=>\?@\\^|~.][-!#$%&\*\+/<=>\?@\\^|~:.]*"
 syn match hsConSym "\(\<[A-Z][a-zA-Z0-9_']*\.\)\=:[-!#$%&\*\+./<=>\?@\\^|~:]*"
-syn match hsVarSym "`\(\<[A-Z][a-zA-Z0-9_']*\.\)\=[a-z][a-zA-Z0-9_']*`"
-syn match hsConSym "`\(\<[A-Z][a-zA-Z0-9_']*\.\)\=[A-Z][a-zA-Z0-9_']*`"
+syn match hsVarSym "` *\(\<[A-Z][a-zA-Z0-9_']*\.\)\=[a-z][a-zA-Z0-9_']* *`"
+syn match hsConSym "` *\(\<[A-Z][a-zA-Z0-9_']*\.\)\=[A-Z][a-zA-Z0-9_']* *`"
 
 " (Non-qualified) identifiers which start with # are labels
 syn match hsLabel "#[a-z][a-zA-Z0-9_']*\>"


### PR DESCRIPTION
This formatting (although rare) is actually accepted by GHC and the standard, but vim does not highlight it. This patch adds the simplest possible regex to support the behavior.

Inconveniently, this might trigger weird formatting on lines that contain errors, e.g. if the first backtick is removed from:

    a `b` c `d` e

then `c` is going to be marked as an operator, which seems weird but is valid.