### PR TITLE
runtime/doc/vim9.txt Section 3

### DIFF
--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -6816,6 +6816,7 @@ conversion-server	mbyte.txt	/*conversion-server*
 convert-to-HTML	syntax.txt	/*convert-to-HTML*
 convert-to-XHTML	syntax.txt	/*convert-to-XHTML*
 convert-to-XML	syntax.txt	/*convert-to-XML*
+convert_:function_to_:def	vim9.txt	/*convert_:function_to_:def*
 convert_legacy_function_to_vim9	vim9.txt	/*convert_legacy_function_to_vim9*
 copy()	builtin.txt	/*copy()*
 copy-diffs	diff.txt	/*copy-diffs*

--- a/runtime/doc/vim9.txt
+++ b/runtime/doc/vim9.txt
@@ -1,4 +1,4 @@
-*vim9.txt*	For Vim version 9.1.  Last change: 2025 Nov 11
+*vim9.txt*	For Vim version 9.1.  Last change: 2025 Nov 27
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -1252,44 +1252,11 @@ Using ++var or --var in an expression is not supported yet.
 			  vim9script
 			  def F_1073()
 			  enddef
-			  def F_1073()  # E1073: Name already defined
+			  def F_1073() # E1073: Name already defined: <SNR>...
 			  enddef
 <				 			*E1011*
 			The {name} must be less than 100 bytes long.
 
-							*E1003* *E1027* *E1096*
-			The type of value used with `:return` must match
-			{return-type}.  When {return-type} is omitted or is
-			"void" the function is not allowed to return
-			anything.  Examples: >vim9
-
-			  vim9script
-			  def F_1003(): bool
-			      return  # E1003: Missing return value
-			  enddef
-			  F_1003()
-< >vim9
-			  vim9script
-			  def F_1027(): bool
-			      echo false  # E1027: Missing return statement
-			  enddef
-			  F_1027()
-< >vim9
-			  vim9script
-			  def F_1096(): void
-			      return false  # E1096: Returning a value ...
-			  enddef
-			  F_1096()
-<							*E1056* *E1059*
-			The type cannot be omitted if the colon heralding it
-			is included.  The colon also cannot be preceded by
-			white space.  Examples: >vim
-
-			  def F_1056():
-			  enddef  # E1056: Expected a type
-			  def F_1059() : bool
-			  enddef  # E1059: No white space allowed before colon
-<
 							*E1077*
 			{arguments} is a sequence of zero or more argument
 			declarations.  There are three forms:
@@ -1300,7 +1267,8 @@ Using ++var or --var in an expression is not supported yet.
 			declaration must provide a type.  Example: >vim9
 
 			  vim9script
-			  def F_1077(x): void  # E1077: Missing argument type
+			  def F_1077(x): void
+			      # E1077: Missing argument type for x
 			  enddef
 <
 			For the second form, because the declaration does not
@@ -1324,9 +1292,44 @@ Using ++var or --var in an expression is not supported yet.
 
 			  vim9script
 			  def F_1123(a: number, b: number): void
-			      echo max(a b)  # E1123: Missing comma
+			      echo max(a b)
+			      # E1123: Missing comma before argument: b)
 			  enddef
 			  F_1123(1, 2)
+<							*E1003* *E1027* *E1096*
+			The type of value used with `:return` must match
+			{return-type}.  When {return-type} is omitted or is
+			"void" the function is not allowed to return
+			anything.  Examples: >vim9
+
+			  vim9script
+			  def F_1003(): bool
+			      return  # E1003: Missing return value
+			  enddef
+			  F_1003()
+< >vim9
+			  vim9script
+			  def F_1027(): bool
+			      echo false  # E1027: Missing return statement
+			  enddef
+			  F_1027()
+< >vim9
+			  vim9script
+			  def F_1096(): void
+			      return false  # E1096: Returning a value ...
+			  enddef
+			  F_1096()
+<							*E1056* *E1059*
+			When ": {return-type}" is specified, {return-type}
+			cannot be omitted (leaving a hanging colon).  The ": "
+			also cannot be preceded by white space.  Examples: >vim
+
+			  def F_1056():
+                              # E1056: Expected a type:
+			  enddef
+			  def F_1059() : bool
+                              # E1059: No white space allowed before colon:...
+			  enddef
 <
 			The function will be compiled into instructions when
 			called or when either `:defcompile` or `:disassemble` is
@@ -1354,7 +1357,8 @@ Using ++var or --var in an expression is not supported yet.
 < >vim9
 			  vim9script
 			  def Func()
-			      def! InnerFunc()  # E1117: Cannot use ! ...
+			      def! InnerFunc()
+			          # E1117: Cannot use ! with nested :def
 			      enddef
 			  enddef
 			  Func()
@@ -1366,7 +1370,8 @@ Using ++var or --var in an expression is not supported yet.
 			  vim9script
 			  def F_1084(): void
 			  enddef
-			  delfunction! F_1084  # E1084: Cannot delete Vim9 ...
+			  delfunction! F_1084
+			  # E1084: Cannot delete Vim9 script function F_1084
 <
 			Note: The generic error *E1028* ("Compiling :def
 			function failed") indicates an undeterminable error
@@ -1380,11 +1385,13 @@ Using ++var or --var in an expression is not supported yet.
 
 			  vim9script
 			  def MyFunc()
-			  echo 'Do Something' | enddef # E1057: Missing enddef
+			  echo 'Do Something' | enddef
+			  # E1057: Missing :enddef
 < >vim9
 			  vim9script
 			  def F_1173()
-			  enddef echo "X"  # E1173: Text found after enddef...
+			  enddef echo 'X'
+			  # E1173: Text found after enddef: echo 'X'
 < >vim9
 			  vim9script
 			  def F_1152()
@@ -1409,9 +1416,9 @@ For example: >vim9
 	        # echo duo  # This would be E1001 (Variable not found: duo)
 	    endif
 	enddef
-	var unus = 1
+	var unus: number = 1
 	MyVim9def()         # MyVim9def is compiled ("duo" does not exist yet)
-	var duo = 2
+	var duo: number = 2
 <
 If the script the `:def` function is defined in is legacy Vim script,
 script-local variables may be accessed with or without the "s:" prefix.
@@ -1445,9 +1452,10 @@ in a legacy function with the "s:" prefix.  For example: >vim9
 
 	vim9script
 	function F_1269()
-	    let s:wishful_thinking = v:true
+	    let s:i_wish = v:true
 	endfunction
-	F_1269()  # E1269: Cannot create a Vim9 script variable in a function
+	F_1269()
+	# E1269: Cannot create a Vim9 script variable in a function: s:i_wish
 <
 						*:defc* *:defcompile*
 :defc[ompile]		Compile functions and classes (|class-compile|)
@@ -1600,7 +1608,7 @@ function to define it: >vim9
 
 	vim9script
 	def GetClosure(i: number): func
-	    var infunc = i
+	    var infunc: number = i
 	    return (): number => infunc
 	enddef
 	var flist: list<func>
@@ -1626,7 +1634,7 @@ the original context where the closure was defined.  For example: >vim9
 	vim9script
 	def F_1248(): void
 	    var n: number
-	    var F = () => {
+	    var F: func = () => {
 	        n += 1
 	    }
 	    try
@@ -1643,7 +1651,7 @@ the variable "n" is used after the `:endfor`, that is an |E121| error: >vim9
 
 	vim9script
 	for n in range(3)
-	    var nr = n
+	    var nr: number = n
 	    timer_start(1000 * n, (_) => {
 	        echowindow nr
 	    })
@@ -1722,14 +1730,16 @@ Calling a :def function in an expr option ~
 							*expr-option-function*
 The value of a few options, such as 'foldexpr', is an expression that is
 evaluated to get a value.  The evaluation can have quite a bit of overhead.
-One way to minimize the overhead, and also to keep the option value very
-simple, is to define a compiled function and set the option to call it
-without arguments.  For example: >vim9
+One way to minimize the overhead, and also to keep the option value simple,
+is to define a compiled function and set the option to call it without
+arguments.  For example: >vim9
 
 	vim9script
 	def MyFoldFunc(): string
-	    return getline(v:lnum) =~ '^\d\%x2E\s\S' &&
-	           getline(v:lnum + 1)->empty() ? '>1' : '1'
+	    # This matches start of line (^), followed by a digit, a full stop
+	    # a space or tab, an uppercase character, with an empty next line
+	    return getline(v:lnum) =~ '^[[:digit:]]\.[[:blank:]][[:upper:]]'
+	        && getline(v:lnum + 1)->empty() ? '>1' : '1'
 	enddef
 	set foldexpr=MyFoldFunc()
 	set foldmethod=expr
@@ -2236,7 +2246,7 @@ in Vim9 script.
   - Using an empty string in an argument that requires a non-empty string: >vim9
 
 	echo exepath('')
-	vim9cmd echo exepath('')  # E1175: Non-empty string required for arg
+	vim9cmd echo exepath('') # E1175: Non-empty string required for arg...
 <
   - Not using a number when it is required: >vim
 

--- a/runtime/doc/vim9.txt
+++ b/runtime/doc/vim9.txt
@@ -232,7 +232,7 @@ You can call a legacy dict function though: >
 	  var d = {func: Legacy, value: 'text'}
 	  d.func()
 	enddef
-<						*E1096* *E1174* *E1175*
+
 The argument types and return type need to be specified.  The "any" type can
 be used, type checking will then be done at runtime, like with legacy
 functions.
@@ -275,7 +275,7 @@ script "export" needs to be used for those to be used elsewhere. >
 	def ThisFunction()          # script-local
 	def g:ThatFunction()        # global
 	export def Function()       # for import and import autoload
-<						*E1058* *E1075*
+<						*E1075*
 When using `:function` or `:def` to specify a nested function inside a `:def`
 function and no namespace was given, this nested function is local to the code
 block it is defined in.  It cannot be used in `function()` with a string
@@ -1236,69 +1236,237 @@ subtracting one: >
 
 Using ++var or --var in an expression is not supported yet.
 
+
 ==============================================================================
 
 3. New style functions					*fast-functions*
 
-							*:def* *E1028*
+							*:def*
 :def[!] {name}([arguments])[: {return-type}]
 			Define a new function by the name {name}.  The body of
 			the function follows in the next lines, until the
-			matching `:enddef`. *E1073*
-							*E1011*
+			matching `:enddef`.
+							*E1073*
+			The {name} cannot be reused at the script-local level: >vim9
+
+			  vim9script
+			  def F_1073()
+			  enddef
+			  def F_1073()  # E1073: Name already defined
+			  enddef
+<				 			*E1011*
 			The {name} must be less than 100 bytes long.
-					*E1003* *E1027* *E1056* *E1059*
+
+							*E1003* *E1027* *E1096*
 			The type of value used with `:return` must match
 			{return-type}.  When {return-type} is omitted or is
-			"void" the function is not expected to return
-			anything.
-							*E1077* *E1123*
+			"void" the function is not allowed to return
+			anything.  Examples: >vim9
+
+			  vim9script
+			  def F_1003(): bool
+			      return  # E1003: Missing return value
+			  enddef
+			  F_1003()
+< >vim9
+			  vim9script
+			  def F_1027(): bool
+			      echo false  # E1027: Missing return statement
+			  enddef
+			  F_1027()
+< >vim9
+			  vim9script
+			  def F_1096(): void
+			      return false  # E1096: Returning a value ...
+			  enddef
+			  F_1096()
+<							*E1056* *E1059*
+			The type cannot be omitted if the colon heralding it
+			is included.  The colon also cannot be preceded by
+			white space.  Examples: >vim
+
+			  def F_1056():
+			  enddef  # E1056: Expected a type
+			  def F_1059() : bool
+			  enddef  # E1059: No white space allowed before colon
+<
+							*E1077*
 			{arguments} is a sequence of zero or more argument
 			declarations.  There are three forms:
 				{name}: {type}
 				{name} = {value}
 				{name}: {type} = {value}
-			The first form is a mandatory argument, the caller
-			must always provide them.
-			The second and third form are optional arguments.
-			When the caller omits an argument the {value} is used.
+			The first form is a mandatory argument.  So, the
+			declaration must provide a type.  Example: >vim9
 
+			  vim9script
+			  def F_1077(x): void  # E1077: Missing argument type
+			  enddef
+<
+			For the second form, because the declaration does not
+			specify it, Vim infers the type.  For both second and
+			third forms, a default {value} applies when the
+			caller omits it.  Examples: >vim9
+
+			  vim9script
+			  def SecondForm(arg = "Hi"): void
+			      echo $'2. arg is a "{arg->typename()}" type ' ..
+			           $'and the default value of arg is "{arg}"'
+			  enddef
+			  SecondForm()
+			  def ThirdForm(arg2: number = 9): void
+			      echo $'3. default value of arg2 is {arg2}'
+			  enddef
+			  ThirdForm()
+<							*E1123*
+			Arguments in a builtin function called in a `:def`
+			function must have commas between arguments: >vim9
+
+			  vim9script
+			  def F_1123(a: number, b: number): void
+			      echo max(a b)  # E1123: Missing comma
+			  enddef
+			  F_1123(1, 2)
+<
 			The function will be compiled into instructions when
-			called, or when `:disassemble` or `:defcompile` is
-			used.  Syntax and type errors will be produced at that
-			time.
+			called or when either `:defcompile` or `:disassemble` is
+			used.  (For an example, see |:disassemble|.)  Syntax
+			and type errors will be produced at that time.
 
+							*E1058*
 			It is possible to nest `:def` inside another `:def` or
-			`:function` up to about 50 levels deep.
+			`:function` only up to 49 levels deep.  At 50 or more
+			levels, it is a |E1058| error.
+
 							*E1117*
-			[!] is used as with `:function`.  Note that
-			script-local functions cannot be deleted or redefined
-			later in Vim9 script.  They can only be removed by
-			reloading the same script.
+			[!] is allowed only in legacy Vim script because it
+			permits function redefinition (as with `:function`!).
+			In Vim9 script, ! is not allowed because script-local
+			functions cannot be deleted or redefined, though they
+			can be removed by reloading the script.  Also, nested
+			functions cannot use ! for redefinition.  Examples: >vim
+
+			  " Legacy Vim script :def! example
+			  def! LegacyFunc()
+			      echo "def! is allowed in a legacy Vim script"
+			  enddef
+			  call LegacyFunc()
+< >vim9
+			  vim9script
+			  def Func()
+			      def! InnerFunc()  # E1117: Cannot use ! ...
+			      enddef
+			  enddef
+			  Func()
+< >vim9
+			  vim9script
+			  def! F_477(): void  # E477: No ! allowed
+			  enddef
+< >vim9
+			  vim9script
+			  def F_1084(): void
+			  enddef
+			  delfunction! F_1084  # E1084: Cannot delete Vim9 ...
+<
+			Note: The generic error *E1028* ("Compiling :def
+			function failed") indicates an undeterminable error
+			during compilation.  If reproducible, it may be
+			reported at https://github.com/vim/vim/issues as
+			it could represent a gap in Vim's error reporting.
 
 					*:enddef* *E1057* *E1152* *E1173*
-:enddef			End of a function defined with `:def`. It should be on
-			a line by its own.
+:enddef			End of a function defined with `:def`.  It should be on
+			a line by itself.  Examples: >vim9
 
+			  vim9script
+			  def MyFunc()
+			  echo 'Do Something' | enddef # E1057: Missing enddef
+< >vim9
+			  vim9script
+			  def F_1173()
+			  enddef echo "X"  # E1173: Text found after enddef...
+< >vim9
+			  vim9script
+			  def F_1152()
+			      function X()
+			      enddef  # E1152: Mismatched enddef
+			  enddef
+<
 You may also find this wiki useful.  It was written by an early adopter of
 Vim9 script: https://github.com/lacygoill/wiki/blob/master/vim/vim9.md
 
-If the script the function is defined in is Vim9 script, then script-local
-variables can be accessed without the "s:" prefix.  They must be defined
-before the function is compiled.  If the script the function is defined in is
-legacy script, then script-local variables must be accessed with the "s:"
-prefix if they do not exist at the time of compiling.
-							*E1269*
-Script-local variables in a |Vim9| script must be declared at the script
-level.  They cannot be created in a function, also not in a legacy function.
+If the script the `:def` function is defined in is Vim9 script, script-local
+variables must be accessed without using the "s:" prefix.  They must be
+defined before the function is compiled and there is no way to avoid errors
+(e.g., by using |exists()|) to conditionally skip undeclared variables.
+For example: >vim9
 
+	vim9script
+	def MyVim9def()
+	    echo unus       # Echoes 1
+	    # echo s:unus   # This would be E1268 (Cannot use s: in Vim9)
+	    if exists('duo')
+	        # echo duo  # This would be E1001 (Variable not found: duo)
+	    endif
+	enddef
+	var unus = 1
+	MyVim9def()         # MyVim9def is compiled ("duo" does not exist yet)
+	var duo = 2
+<
+If the script the `:def` function is defined in is legacy Vim script,
+script-local variables may be accessed with or without the "s:" prefix.
+However, using "s:" may defer variable resolution to runtime, avoiding
+compilation errors for variables that may not exist yet, as this example
+explains: >vim
+
+	" legacy Vim script
+	def! MyLegacyDef(): void
+	    echo [unus, s:unus]   # Echoes [1, 1]
+	    # (If uncommented) First sourcing of 'echo s:duo' is E121 and
+	    # causes a compilation error; subsequent sourcing echoes 2:
+	    # echo s:duo
+	    if exists("s:duo")
+	        # First sourcing: skips echo; subsequent sourcing: echoes 2
+	        echo s:duo
+	    endif
+	    if exists("duo")
+	        # (If uncommented) First sourcing of 'echo duo' is E1001 and
+	        # causes a compilation error; subsequent sourcing echoes 2:
+	        # echo duo
+	    endif
+	enddef
+	let s:unus = 1
+	call MyLegacyDef()  " Calls MyLegacyDef() and compiles if not already
+	let s:duo = 2
+<							*E1269*
+Script-local variables in a Vim9 script must be declared at the script
+level.  They cannot be created in a `:def` function and may not be declared
+in a legacy function with the "s:" prefix.  For example: >vim9
+
+	vim9script
+	function F_1269()
+	    let s:wishful_thinking = v:true
+	endfunction
+	F_1269()  # E1269: Cannot create a Vim9 script variable in a function
+<
 						*:defc* *:defcompile*
 :defc[ompile]		Compile functions and classes (|class-compile|)
 			defined in the current script that were not compiled
 			yet.  This will report any errors found during
 			compilation.
 
-:defc[ompile] MyClass	Compile all methods in a class. |class-compile|
+			Example: When the three lines (up to and including
+			`enddef`) are sourced, there is no error because the
+			Vim9 `:def` function is not compiled.  However, if all
+			four lines are sourced, compilation fails: >vim9
+
+			  vim9script
+			  def F_1027(): string
+			  enddef
+			  defcompile F_1027  # E1027: Missing return statement
+
+:defc[ompile] MyClass	Compile all methods in a class.  (See |:disassemble|
+			for an example.)
 
 :defc[ompile] {func}
 :defc[ompile] debug {func}
@@ -1306,16 +1474,36 @@ level.  They cannot be created in a function, also not in a legacy function.
 			Compile function {func}, if needed.  Use "debug" and
 			"profile" to specify the compilation mode.
 			This will report any errors found during compilation.
-			{func} call also be "ClassName.functionName" to
+			{func} can also be "ClassName.functionName" to
 			compile a function or method in a class.
-			{func} call also be "ClassName" to compile all
+			{func} can also be "ClassName" to compile all
 			functions and methods in a class.
 
 						*:disa* *:disassemble*
 :disa[ssemble] {func}	Show the instructions generated for {func}.
-			This is for debugging and testing. *E1061*
-			Note that for command line completion of {func} you
-			can prepend "s:" to find script-local functions.
+			This is for debugging and testing.
+			If {func} is not found, error *E1061* occurs.
+			{func} can also be "ClassName.functionName" to
+			disassemble a function in a class.
+			The following example demonstrates using `:defcompile`
+			with a |class| and `:disassemble` with a
+			"ClassName.functionName" (positioning the cursor on
+			the last line of the visually sourced script): >vim9
+
+			  vim9script
+			  class Line
+			      var lnum: number
+			      def new(this.lnum)
+			      enddef
+			      def SetLnum()
+			          cursor(this.lnum, 52)
+			      enddef
+			  endclass
+			  defcompile Line
+			  disassemble Line.SetLnum
+			  var vlast: Line = Line.new(line("'>"))
+			  vlast.SetLnum()  # Cursor is positioned here->_
+<			
 
 :disa[ssemble] profile {func}
 			Like `:disassemble` but with the instructions used for
@@ -1325,156 +1513,232 @@ level.  They cannot be created in a function, also not in a legacy function.
 			Like `:disassemble` but with the instructions used for
 			debugging.
 
+  Note: For command line completion of {func}, script-local functions
+	are shown with their <SNR>.  Depending on options, including
+	|wildmenumode()|, completion may work with "s:", "<S", or the function
+	name directly.  (For example, in Vim started with |-u| NONE, ":disa s:"
+	and |c_CTRL-E| lists script-local function names.)
+
+
 Limitations ~
 
-Local variables will not be visible to string evaluation.  For example: >
-	def MapList(): list<string>
-	  var list = ['aa', 'bb', 'cc', 'dd']
-	  return range(1, 2)->map('list[v:val]')
-	enddef
+Variables local to `:def` functions are not visible to string evaluation.
+The following example shows that the script-local constant "SCRIPT_LOCAL" is
+visible whereas the function-local constant "DEF_LOCAL" is not: >vim9
 
+	vim9script
+	const SCRIPT_LOCAL = ['A', 'script-local', 'list']
+	def MapList(scope: string): list<string>
+	    const DEF_LOCAL: list<string> = ['A', 'def-local', 'list']
+	    if scope == 'script local'
+	        return [1]->map('SCRIPT_LOCAL[v:val]')
+	    else
+	        return [1]->map('DEF_LOCAL[v:val]')
+	    endif
+	enddef
+	echo 'script local'->MapList()	# Echoes ['script-local']
+	echo 'def local'->MapList()	# E121: Undefined variable: DEF_LOCAL
+<
 The map argument is a string expression, which is evaluated without the
-function scope.  Instead, use a lambda: >
+function scope.  Instead, in Vim9 script, use a lambda: >vim9
+
+	vim9script
 	def MapList(): list<string>
-	  var list = ['aa', 'bb', 'cc', 'dd']
-	  return range(1, 2)->map((_, v) => list[v])
+	    const DEF_LOCAL: list<string> = ['A', 'def-local', 'list']
+	    return [1]->map((_, v) => DEF_LOCAL[v])
 	enddef
+	echo MapList()			# Echoes ['def-local']
+<
+For commands that are not compiled, such as `:edit`, |backtick-expansion| can
+be used and it can use the local scope.  Example: >vim9
 
-For commands that are not compiled, such as `:edit`, backtick expansion can be
-used and it can use the local scope.  Example: >
-	def Replace()
-	  var fname = 'blah.txt'
-	  edit `=fname`
+	vim9script
+	def EditNewBlah()
+	    var fname: string = 'blah.txt'
+	    split
+	    edit `=fname`
 	enddef
+	EditNewBlah()  # A new split is created as buffer 'blah.txt'
+<
+Closures defined in a loop can either share a variable or each have their own
+copy, depending on where the variable is declared.  With a variable declared
+outside the loop, all closures reference the same shared variable.
+The following example demonstrates the consequences, with the "outloop"
+variable existing only once: >vim9
 
-Closures defined in a loop will share the same context.  For example: >
+	vim9script
 	var flist: list<func>
-	for i in range(5)
-	  var inloop = i
-	  flist[i] = () => inloop
-	endfor
-	echo range(5)->map((i, _) => flist[i]())
-	# Result: [4, 4, 4, 4, 4]
+	def ClosureEg(n: number): void
+	    var outloop: number = 0  # outloop is declared outside the loop!
+	    for i in range(n)
+	        outloop = i
+	        flist[i] = (): number => outloop  # Closures ref the same var
+	    endfor
+	    echo range(n)->map((i, _) => flist[i]())
+	enddef
+	ClosureEg(4)  # Echoes [3, 3, 3, 3]
+<
+All closures put in the list refer to the same instance, which, in the end,
+is 3.
+
+However, when the variable is declared inside the loop, each closure gets its
+own copy, as shown in this example: >vim9
+
+	vim9script
+	var flist: list<func>
+	def ClosureEg(n: number): void
+	    for i in range(n)
+	        var inloop: number = i  # inloop is declared inside the loop
+	        flist[i] = (): number => inloop  # Closures ref each inloop
+	    endfor
+	    echo range(n)->map((i, _) => flist[i]())
+	enddef
+	ClosureEg(4)  # Echoes [0, 1, 2, 3]
+
+Another way to have a separate context for each closure is to call a
+function to define it: >vim9
+
+	vim9script
+	def GetClosure(i: number): func
+	    var infunc = i
+	    return (): number => infunc
+	enddef
+	var flist: list<func>
+	def ClosureEg(n: number): void
+	    for i in range(n)
+	        flist[i] = GetClosure(i)
+	    endfor
+	    echo range(n)->map((i, _) => flist[i]())
+	enddef
+	ClosureEg(4)  # Echoes [0, 1, 2, 3]
 <							*E1271*
 A closure must be compiled in the context that it is defined in, so that
-variables in that context can be found.  This mostly happens correctly, except
-when a function is marked for debugging with `:breakadd` after it was compiled.
-Make sure to define the breakpoint before compiling the outer function.
+variables in that context can be found.  This mostly happens correctly,
+except when a function is marked for debugging with `:breakadd` after it was
+compiled.  Make sure to define the breakpoint before compiling the outer
+function.
+							*E1248*
+In some situations, such as when a Vim9 closure which captures local variables
+is converted to a string and then executed, an error occurs.  This happens
+because the string execution context cannot access the local variables from
+the original context where the closure was defined.  For example: >vim9
 
-The "inloop" variable will exist only once, all closures put in the list refer
-to the same instance, which in the end will have the value 4.  This is
-efficient, also when looping many times.  If you do want a separate context
-for each closure, call a function to define it: >
-	def GetClosure(i: number): func
-	  var infunc = i
-	  return () => infunc
+	vim9script
+	def F_1248(): void
+	    var n: number
+	    var F = () => {
+	        n += 1
+	    }
+	    try
+	        execute printf("call %s()", F)
+	    catch
+	        echo v:exception
+	    endtry
 	enddef
+	F_1248()  # Vim(call):E1248: Closure called from invalid context
 
-	var flist: list<func>
-	for i in range(5)
-	  flist[i] = GetClosure(i)
+In Vim9 script, a loop variable is invalid after the loop is closed.
+For example, this timer will echo 0 to 2 on separate lines.  However, if
+the variable "n" is used after the `:endfor`, that is an |E121| error: >vim9
+
+	vim9script
+	for n in range(3)
+	    var nr = n
+	    timer_start(1000 * n, (_) => {
+	        echowindow nr
+	    })
 	endfor
-	echo range(5)->map((i, _) => flist[i]())
-	# Result: [0, 1, 2, 3, 4]
-
-In some situations, especially when calling a Vim9 closure from legacy
-context, the evaluation will fail.  *E1248*
-
-Note that at the script level the loop variable will be invalid after the
-loop, also when used in a closure that is called later, e.g. with a timer.
-This will generate error |E1302|: >
-	for n in range(4)
-	    timer_start(500 * n, (_) => {
-	          echowin n
-	       })
-	endfor
-
-You need to use a block and define a variable there, and use that one in the
-closure: >
-	for n in range(4)
-	{
-	   var nr = n
-	   timer_start(500 * n, (_) => {
-	          echowin nr
-	      })
-	}
-	endfor
-
-Using `:echowindow` is useful in a timer, the messages go into a popup and will
-not interfere with what the user is doing when it triggers.
+	try
+	    echowindow n
+	catch
+	    echo v:exception
+	endtry
+<
+	  Note: Using `:echowindow` is useful in a timer because messages go
+		into a popup and will not interfere with what the user is
+		doing when it triggers.
 
 
-Converting a function from legacy to Vim9 ~
+Converting a :function to a :def~
 					*convert_legacy_function_to_vim9*
-These are the most changes that need to be made to convert a legacy function
-to a Vim9 function:
+					*convert_:function_to_:def*
+There are many changes that need to be made to convert a `:function` to
+a `:def` function.  The following are some of them:
 
+- Change `let` used to declare variables to one of `var`, `const`, or `final`,
+  and remove the "s:" from each |script-variable|.
 - Change `func` or `function` to `def`.
 - Change `endfunc` or `endfunction` to `enddef`.
-- Add types to the function arguments.
-- If the function returns something, add the return type.
-- Change comments to start with # instead of ".
+- Add the applicable type (or "any") to each function argument.
+- Remove "a:" from each |function-argument|.
+- Remove inapplicable options such as |func-range|, |func-abort|, |func-dict|,
+  and |func-closure|.
+- If the function returns something, add the return type.  (Ideally, add
+  "void" if it does not return anything.)
+- Remove line continuation backslashes from places they are not required.
+- Remove `let` for assigning values to |g:|, |b:|, |w:|, |t:|, or |l:| variables.
+- Rewrite |lambda| expressions in Vim9 script syntax (see |vim9-lambda|).
+- Change comments to start with # (preceded by white space) instead of ".
+- Insert white space in expressions where required (see |vim9-white-space|).
+- Change "." used for string concatenation to " .. ".  (Alternatively, use
+  an |interpolated-string|.)
 
-  For example, a legacy function: >
-	func MyFunc(text)
-	  " function body
-	endfunc
-<  Becomes: >
-	def MyFunc(text: string): number
-	  # function body
+The following legacy Vim script and Vim9 script examples demonstrate all
+those differences.  First, legacy Vim script: >vim
+
+	let s:lnum=0
+	function Leg8(arg) abort
+	    let l:pre=['Result',
+	      \': ']
+	    let b:arg=a:arg
+	    let s:lnum+=2
+	    let b:arg*=4
+	    let l:result={pre->join(pre,'')}(l:pre)
+	    return l:result.(b:arg+s:lnum)"no space before comment
+	endfunction
+	call Leg8(10)->popup_notification(#{time: 3000})" Pops up 'Result: 42'
+
+The equivalent in Vim9 script: >vim9
+
+	vim9script
+	var lnum: number
+	def Vim9(arg: number): string
+	    final pre = ['Result',
+	      ': ']
+	    b:arg = arg
+	    lnum += 2
+	    b:arg *= 4
+	    const RESULT: string = ((lpre) => join(lpre, ''))(pre)
+	    return RESULT .. (b:arg + lnum) # space required before # comment
 	enddef
+	Vim9(10)->popup_notification({time: 3000}) # Pops up 'Result: 42'
 
-- Remove "a:" used for arguments. E.g.: >
-	return len(a:text)
-<  Becomes: >
-	return len(text)
-
-- Change `let` used to declare a variable to `var`.
-- Remove `let` used to assign a value to a variable.  This is for local
-  variables already declared and b: w: g: and t: variables.
-
-  For example, legacy function: >
-	  let lnum = 1
-	  let lnum += 3
-	  let b:result = 42
-<  Becomes: >
-	  var lnum = 1
-	  lnum += 3
-	  b:result = 42
-
-- Insert white space in expressions where needed.
-- Change "." used for concatenation to "..".
-
-  For example, legacy function: >
-	  echo line(1).line(2)
-<  Becomes: >
-	  echo line(1) .. line(2)
-
-- line continuation does not always require a backslash: >
-	echo ['one',
-		\ 'two',
-		\ 'three'
-		\ ]
-<  Becomes: >
-	echo ['one',
-		'two',
-		'three'
-		]
+<	Note: This example also demonstrates (outside the `:def` function):
+		- Removing "#" from the legacy |#{}| - see |vim9-literal-dict|
+		- Omitting `:call` (allowed, though unnecessary in Vim9 script)
 
 
-Calling a function in an expr option ~
+Calling a :def function in an expr option ~
 							*expr-option-function*
 The value of a few options, such as 'foldexpr', is an expression that is
 evaluated to get a value.  The evaluation can have quite a bit of overhead.
 One way to minimize the overhead, and also to keep the option value very
 simple, is to define a compiled function and set the option to call it
-without arguments.  Example: >
+without arguments.  For example: >vim9
+
 	vim9script
-	def MyFoldFunc(): any
-	   ... compute fold level for line v:lnum
-	   return level
+	def MyFoldFunc(): string
+	    return getline(v:lnum) =~ '^\d\%x2E\s\S' &&
+	           getline(v:lnum + 1)->empty() ? '>1' : '1'
 	enddef
-	set foldexpr=s:MyFoldFunc()
+	set foldexpr=MyFoldFunc()
+	set foldmethod=expr
+	norm! zM
+<
+  Warning: This script creates and applies folds at the "Heading 1" level of
+	   this vim9.txt help buffer.  (You can use |zR|, in Normal mode, to
+	   open all the folds after sourcing the script.)
+
 
 ==============================================================================
 
@@ -1927,8 +2191,8 @@ dictionary when it is required: >vim
 	echo [8, 9]->keys()
 	vim9cmd echo [8, 9]->keys()	 # E1206: Dictionary required
 <
-						*E1023* *E1024* *E1029*
-						*E1030* *E1210* *E1212*
+						*E1023* *E1024* *E1029* *E1030*
+						*E1174* *E1175* *E1210* *E1212*
 However, sometimes there will be an error in Vim9 script, which breaks
 backwards compatibility.  The following examples illustrate various places
 this happens.  The legacy Vim script behavior, which does not fail, is shown
@@ -1963,6 +2227,16 @@ in Vim9 script.
 
 	let b:l = [42] | unlet b:l['#'] | echo b:l
 	vim9cmd b:l = [42] | vim9cmd unlet b:l['#']  # E1030: Using a string...
+<
+  - Not using a string where an argument requires a string: >vim9
+
+	echo substitute('Hallo', 'a', 'e', v:true)
+	vim9cmd echo substitute('Hallo', 'a', 'e', true)  # E1174: String...
+<
+  - Using an empty string in an argument that requires a non-empty string: >vim9
+
+	echo exepath('')
+	vim9cmd echo exepath('')  # E1175: Non-empty string required for arg
 <
   - Not using a number when it is required: >vim
 


### PR DESCRIPTION
# vim9.txt - Section 3 - rewrite &#x2F; enhancements

Locations of changes are indicated by reference to **&#x2A;tag&#x2A;** in the updated file.

## 3. New style functions

**&#x2A;:def&#x2A;**

- The tag `*E1028*` is relocated to the end of the `:def` passage as a `Note`.

**&#x2A;E1073&#x2A;**

- The tag is separated from `matching :enddef. *E1073*` because it is a distinct error.  An example is provided too.

**&#x2A;E1003&#x2A; &#x2A;E1027&#x2A; &#x2A;E1096&#x2A;**

- The tags `*E1003*` and `*E1027*` relate to the paragraph that follows and are retained here.  They now include examples of the errors.  Joining them is tag `*E1096*` (relocated from Section 2), which is specific to the second sentence, so is better located here.  It also shows it&#x2019;s not only &#x201C;not expected&#x201D;, it&#x2019;s _not allowed_ (i.e., to return a value).

**&#x2A;E1056&#x2A; &#x2A;E1059&#x2A;**

- These tags are separated from the current help&#x2019;s `*E1003*` and `*E1027*` because they do not relate to the explanation of what is in the paragraph that follows.  The new paragraph explains what is relevant to these tags, i.e., either absence of a type following the colon in a declaration (`E1056`) or including white space before the colon (`E1059`).  The latter is useful particularly &#x2013; it is not solely relevant to `:def` functions.  (Note: As `:def` functions can be used in Vim script and Vim9 script _and_ these two examples error identically in both, the `vim9script` command is neither needed nor used in the two examples.)

**&#x2A;E1077&#x2A;**

- The tag `*E1123*` is separated and relocated because it does not relate to the content that is explained in the paragraph about the &#x201C;three forms&#x201D; of argument declarations.
- &#x201C;The first form...&#x201D;, is made more direct.  An example of error `E1077` is provided too.
- &#x201C;The second and third forms are explained in more detail, especially noting Vim infers the type when using the second form.  An example shows how both the second and third type work in practice.

**&#x2A;E1123&#x2A;**

- It is arguable whether this relocated tag (currently together with `E1077`) and its content, which now includes an example of error `E1123`, should be located under `:def`.  It is not exclusively related to a `:def` (and, if the equivalent to what is shown in the example is done in legacy Vim script, there is an error, albeit a different one: `E116`).  It is also relevant to enums with missing commas, so perhaps the tag and example(s) could be relocated either to `eval.txt` (where tag `*E116*` is located) with cross references to:
  * a sentence in `:def`, and
  * `vim9class.txt`, maybe with an example like the following:
```
	vim9script
	# This is an E1123 error in an enum, "Missing comma before argument: : 1"
	enum E
	    one : 1
	endenum
```
- &#x201C;(For an example, see |:disassemble|.)&#x201D; is added as a cross reference to the paragraph starting, &#x201C;The function will be compiled into instructions...&#x201D;.

**&#x2A;E1058&#x2A;**

- The tag `*E1058*` is relocated from Section 2 because it is specifically related to nesting (`Function nesting too deep`).  So, it makes more sense having it here rather than where it is presently.
- Testing shows specifically it works fine to precisely 49 levels deep.  At 50 levels, or more, Vim errors with `E1058`, so it seems better to say that rather than, &#x201C;about 50 levels deep&#x201D;.

**&#x2A;E1117&#x2A;**

- &#x201C;[!] is used as with `:function`.&#x201D; feels a bit misleading.  It is allowed, like `function!`, in legacy Vim script.  An example is provided.  It is not allowed in Vim9 script either at the script-local level or nested in a `:def` function.  So, that's made clearer.
- Examples of the various Vim9 script `:def!` and `:delfunction` errors (`E1084` and `E477`) are provided, along with `E1117`, which is specific to nested `:def` usage.

**&#x2A;E1028&#x2A;**

- The tag `*E1028*` is relocated here.  From considering `src/errors.h`, `src/vim9compile.c`, and issue [13729](https://github.com/vim/vim/pull/13729), it appears this should be a rarely occurring error.  So, a `Note: ` seems a better way to treat it (rather than prioritising it by locating it along with the prime tag, `*:def*`.

**&#x2A;:enddef&#x2A;**

- &#x201C;a line by its own&#x201D; is changed to, &#x201C;a line by itself&#x201D;.  Examples of `E1057`, `E1173`, and `E1152` are provided.<br/>
(It is not stated, but `enddef` does not need to be standalone &#x2014; e.g., it may be followed by, ` | echo "Another command"`.  So, saying, &#x201C;should be&#x201D;, is correct rather than &#x201C;must&#x201D;.)
- The paragraph &#x201C;If the script the function is defined in is Vim9 script, ...&#x201D;, is separated from the legacy Vim script content and now includes an example.  The current help stated script-local variables &#x201C;can be accessed without the "s:" prefix&#x201D;, which is not precise.  They _must_ be accessed without the "s:" prefix.  So, **Vim9 script**, `:def` functions:
  1. Must use non-prefixed script-local variables (using "s:" produces `E1268`)
  2. Require all variables to exist at compile time (missing variables produce `E1001`, _even if they are conditionally checked with_ `exists()`)

  The new example demonstrates both requirements.
- The (now separated) paragraph regarding legacy Vim script has `:def` added before `function` for clarity.  The key differences in **legacy Vim script** `:def` functions are explained and demonstrated, i.e.:
  1. May use _either_ "s:" prefixed _or_ non-prefixed script-local variables provided the variables exist at compile time
  2. An "s:" prefixed variable may be used when it does not exist yet, when referenced conditionally, using `exists()` in the example, thereby deferring variable resolution to runtime, allowing the `:def` function to compile successfully even though the variable does not exist yet.
  3. Using non-prefixed variables requires they exist at compile time (otherwise `E1001` occurs).  That cannot be avoided like it can be using "s:" (as noted in point 2).

**&#x2A;E1269&#x2A;**

- The paragraph, &#x201C;Script-local variables in a Vim9 script must be declared...&#x201D;, goes further.  Now it shows there is no workaround by trying to use a "s:" prefixed variable in a legacy function, demonstrating the `E1269` error.

**&#x2A;:defc&#x2A;** **&#x2A;:defcompile&#x2A;**

- There was no example for `:defcompile`.  Although mostly[?] used for testing, providing an example makes the concept obvious - i.e., there is no error until the `:def` function is compiled.
- Two corrections of &#x201C;call&#x201D; to &#x201C;can&#x201D; (`{func} can also be "Class...`).

**&#x2A;:disa&#x2A;** **&#x2A;:disassemble&#x2A;**

- The cause of error `*E1061*` is made a separate sentence without an example (being clear as-is).
- &#x201C;{func} can also be "ClassName.functionName"...&#x201D;, is applicable to `:disassemble` too, so it is included.
- An example is added.  It demonstrates several things, and particularly:
  1. `:defcompile` with a class;
  2. `:disassemble` with a ClassName.functionName.
- The `Note`, which was only provided with `:disa[ssemble]`, is updated and relocated to the end of the passage containing all the `{func}` references; it relates generally to `:defcompile {func}`, `:disassemble {func}` and the other variants.  Further, completion with "s:" may not work with all users&#x2019; setups, so the note is distinguished, now saying what should be observed in all instances (i.e., `<SNR>`), though the ":s" point is retained in a qualified form.  Testing included using `vim -u NONE` and `:disa s:`, CTRL-E, which does command line completion of script-local `:def` functions.  However, `:call {func}`<kbd>Tab</kbd> may be what other users could use.  Others could just use `:call <S`<kbd>Tab</kbd>, and so on.  To illustrate:

<center><img src="https://i.postimg.cc/hjBCsMYg/Screenshot2025-11-19-071703.png" width="300" alt="vim -u NONE then :disa s:<CTRL-E>" />&#xA0; and &#xA0;<img src="https://i.postimg.cc/0NYg96R1/Screenshot2025-11-19-072951.png" alt="vim then :disa My<Tab>" width="300" /></center>

### Limitations

- Present tense is used and the example is  extended to show a script-local variable working and the function-local variable failing.  This is useful because, if using string evaluation is still wanted, providing the information about it remaining a valid feature is helpful.
- The Vim9 lambda example is conceptually the same, though it is updated to be similar/connect to the preceding example.
- The current backtick expansion example is made complete.  Now it creates a new split with a buffer named `blah.txt`.  The hot-link to `|backtick-expansion|` is added to facilitate jumping to the details.
- &#x201C;Closures defined in a loop...&#x201D;: The current documentation is brief and it divided the examples of the variable defined outside the loop versus within.  With the examples now following on, it should be clearer for readers to grasp this important distinction.  The explanations are more detailed and clearer.  The &#x201C;separate context&#x201D; example is largely retained as-is (aside from being made complete).

**&#x2A;E1271&#x2A;** 

- This is relocated to following the closures examples.  [_No changes have been made otherwise, but could/should an example be provided for this?_]

**&#x2A;E1248&#x2A;** 

- The tag is relocated to precede the paragraph, which is expanded.  The point is not so much, &#x201C;when calling a Vim9 closure from legacy context, the evaluation will fail&#x201D; - rather, it appears to be particularly in a string execution context (at least in terms of `E1248`, specifically).  So, the paragraph is revised and an example provided demonstrating the error.  Interestingly, while testing how to create an example of this I found the following interesting behaviour using `null_list` versus empty list, `[]`:
```
	vim9script
	def F_Inc(): void
	    var n: number
	    var F = () => {
	        n += 1
	    }
	    F() | echo n                     #     Echoes 1
	    call F() | echo n                #     Echoes 2
	    call(F, []) | echo n             #     Echoes 3
	    call(F, null_list) | echo n      # >>> Echoes 3 - unexpected? <<<
	enddef
	F_Inc()
```
&#xA0; _Is this an intentional or unintentional null&#x5F;&lt;type&gt; anomaly?_

In the current help (line 1383), there is this:
> "**Note** that at the script level the loop variable will be invalid after the loop, also when used in a closure that is called later...."

This is followed by an erroring example and a 'correct' example, is preceded by:
> "You need to use a block and define a variable there...."

- The issue with that content is that most of what is noted is not applicable _today_.  This is supported by the closure of [Issue 11094](https://github.com/vim/vim/issues/11094).  Examples of closures failing (the ones I copied and ran, at least) do not produce errors today - it is reproduced, below.  This part of the help looks like a point-in-time historic warning.  It has been reworked now only to only address the key point about a `for` loop&#x2019;s  variable being inaccessible after the loop closes, with a working example.  (Also, the example has been made to `echowindow` only 0 to 2, reducing the likelihood of the timer results not appearing in numeric order.)
```
vim9script
# Current help: "This will generate error |E1302|:" > [No, it doesn't]
	for n in range(4)
	    timer_start(500 * n, (_) => {
	          echowin n
	       })
	endfor
```

### Converting a :function to a :def

- The heading is changed from, &#x201C;Converting a function from legacy to Vim9&#x201D; because `function` is ambiguous and, at any rate, the point is literally converting a `:function`, which may be used in _either_ legacy Vim script _or_ Vim9 script, to a `:def` function, which may be used in either too.
- The tag, `**convert_legacy_function_to_vim9**` is retained (_though it could be deleted, perhaps?&#xA0; It is not linked-to from elsewhere_), and the more specific tag, `**convert_:function_to_:def**`, is added.
- The list of &#x201C;changes that need to be made to convert&#x201D; a `:function` to a `:def` is expanded and enhanced.&#xA0; The examples (now consolidated into one `:function` and one `:def`) is extreme, really stressing the differences.  The `:function` minimizes spaces wherever possible, using space-less '.' concatenation, etc.  This revised passage, which is the same number of lines as the current less detailed one, should be more helpful for readers.  It is more comprehensive, efficient, and contained.

### Calling a :def function in an expr option

- The current `'foldexpr'` example is:
  * incomplete, and
  * has an "s:" prefixed variable, which would be an error in Vim9 script.

  Nonetheless, it was on the right track to illustrate using a `:def` in an expression.  The example provided now is complete.&#xA0; Because it creates folds when sourced, a warning has been added for the unwary and/or those unsure how to undo the folding after sourcing the script.  [_It creates, and applies, folds at "Heading 1" level, so, "1. What is Vim9 script?" through "8. Rationale"_]

<hr/>

***Miscellaneous***

The tags `*E1174*` and `*E1175*` and related examples are relocated to Section 4&#x2019;s collection of things that are errors in Vim9 script but not errors in legacy Vim script.