### PR TITLE
feat: clipboard provider

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -5332,10 +5332,10 @@ buffer text, see |textlock|.
 
 						*clipboard-providers-available*
 The "available" callback is optional, does not take any arguments and should
-return a |boolean|, which tells Vim if it is available for use.  If it is not,
-then Vim skips over it and tries the next 'clipmethod' item.  If the
-"available" callback is not provided, Vim assumes the provider is always
-available for use (true).
+return a |boolean| or non-zero number, which tells Vim if it is available
+for use.  If it is not, then Vim skips over it and tries the next 'clipmethod'
+value.  If the "available" callback is not provided, Vim assumes the provider
+is always available for use (true).
 
 						*clipboard-providers-paste*
 The "paste" callback takes the following arguments in the following order:

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -5297,11 +5297,11 @@ check if the "+" is available for use, it can be checked with: >
 	if has('unnamedplus')
 <
 						*clipboard-providers-clipmethod*
-To integrate with the Vim's actual clipboard functionality, the 'clipmethod'
-option is used on all platforms.  The names of clipboard providers should be
-put inside the option, and if Vim chooses it, then it overrides the "+" and
-"*" registers.  Note that the "+" and "*" will not be saved in the viminfo at
-all.
+To integrate the providers with Vim's clipboard functionality, the
+'clipmethod' option is used on all platforms.  The names of clipboard
+providers should be put inside the option, and if Vim chooses it, then it
+overrides the "+" and "*" registers.  Note that the "+" and "*" will not be
+saved in the viminfo at all.
 
 						*clipboard-providers-define*
 To define a clipboard provider, the |v:clipproviders| vim variable is used. It
@@ -5323,8 +5323,8 @@ another |dict| declaring the "available", "copy", and "paste" callbacks: >vim
 Each callback can either be a name of a function in a string, a |Funcref|, or
 a |lambda| expression.
 
-If a callback except the "available" callback is not provided, then when Vim
-tries to call it, nothing is done.
+With the exception of the "available" callback if a callback is not provided,
+Vim will not invoke anything, and this is not an error.
 
 						*clipboard-providers-textlock*
 In both the "paste" and "copy" callbacks, it is not allowed to change the
@@ -5343,12 +5343,8 @@ The "paste" callback takes the following arguments in the following order:
 
 It should return a |list| or |tuple| containing the following elements in
 order:
-	1. Register type conforming to |setreg()|
+	1. Register type (and optional width) conforming to |setreg()|
 	2. A |list| of strings to return to Vim, each representing a line.
-
-The first element (the register type), may also have a special value of
-"pass".  In that case, Vim does nothing to the register, meaning the current
-contents become unchanged.
 
 						*clipboard-providers-copy*
 The "copy" callback returns nothing and takes the following arguments in the

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -38,7 +38,7 @@ a remark is given.
 12. The sandbox			|eval-sandbox|
 13. Textlock			|textlock|
 14. Vim script library		|vim-script-library|
-14. Clipboard providers		|clipboard-providers|
+15. Clipboard providers		|clipboard-providers|
 
 Testing support is documented in |testing.txt|.
 Profiling is documented at |profiling|.
@@ -2249,9 +2249,8 @@ v:clipmethod	The current method of accessing the clipboard that is being
 			none		The above methods are unavailable or
 					cannot be used.
 		If it is set to a value not in the above list, then a
-		clipboard provider with the given name is being used and
-		overriding the clipboard functionality.  See 'clipmethod' for
-		more details.
+		clipboard provider with the given name is being used for the
+		clipboard functionality.  See 'clipmethod' for more details.
 
 					*v:clipproviders*
 v:clipproviders
@@ -5278,16 +5277,18 @@ Usage: >vim
 ==============================================================================
 15. Clipboard providers				*clipboard-providers*
 
-The clipboard provider feature allows the "+" and "*" registers to be
-overrided by custom Vimscript functions.  There can be multiple providers, and
-Vim chooses which one to use based on 'clipmethod'.  Despite the name, it does
-not use the 'clipboard' option and should be treated separate from the
-clipboard functionality.  It essentially overrides the existing behaviour of
-the clipboard registers.
+The clipboard provider feature allows the "+" |quoteplus| and "*" |quotestar|
+registers to be overridden by custom Vimscript functions.  There can be
+multiple providers, and Vim chooses which one to use based on 'clipmethod'.
+Despite the name, it does not use the 'clipboard' option and should be treated
+separate from the clipboard functionality.  It essentially overrides the
+existing behaviour of the clipboard registers.
 
 						*clipboard-providers-no-clipboard*
 If the |+clipboard| feature is not enabled, then the "+" and "*" registers
-will not be enabled/available unless |v:clipmethod| is set to a provider.
+will not be enabled/available unless |v:clipmethod| is set to a provider.  If
+it is set to a provider, then the clipboard registers will be exposed despite
+not having the |+clipboard| feature.
 
 						*clipboard-providers-plus*
 If on a platform that only has the "*" register, then the "+" register will
@@ -5303,18 +5304,18 @@ put inside the option, and if Vim chooses it, then it overrides the "+" and
 all.
 
 						*clipboard-providers-define*
-To defined a clipboard provider, the |v:clipproviders| vim variable is used.
-It is a |dict| where each key is the clipboard provider name, and the value is
-another |dict| declaring the 'available", "copy", and "paste" callbacks: >vim
+To define a clipboard provider, the |v:clipproviders| vim variable is used. It
+is a |dict| where each key is the clipboard provider name, and the value is
+another |dict| declaring the "available", "copy", and "paste" callbacks: >vim
 	let v:clipproviders["myprovider"] = {
-	    \ "available": Available,
+	    \ "available": function("Available"),
 	    \ "paste": {
 	    \     "+": function("Paste"),
 	    \     "*": function("Paste")
 	    \	},
 	    \ "copy": {
-	    \     "+": function("Paste"),
-	    \     "*": function("Paste")
+	    \     "+": function("Copy"),
+	    \     "*": function("Copy")
 	    \	}
 	    \ }
 	set clipmethod^=myprovider
@@ -5330,7 +5331,7 @@ In both the "paste" and "copy" callbacks, it is not allowed to change the
 buffer text, see |textlock|.
 
 						*clipboard-providers-available*
-The "available" is an optional callback does not take any arguments and should
+The "available" callback is optional, does not take any arguments and should
 return a |boolean|, which tells Vim if it is available for use.  If it is not,
 then Vim skips over it and tries the next 'clipmethod' item.  If the
 "available" callback is not provided, Vim assumes the provider is always

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -5285,15 +5285,14 @@ not use the 'clipboard' option and should be treated separate from the
 clipboard functionality.  It essentially overrides the existing behaviour of
 the clipboard registers.
 
+						*clipboard-providers-no-clipboard*
+If the |+clipboard| feature is not enabled, then the "+" and "*" registers
+will not be enabled/available unless |v:clipmethod| is set to a provider.
+
 						*clipboard-providers-plus*
-If the clipboard feature is enabled, then Vim exposes the "+" register for
-use.  However if on a platform such as Windows or MacOS that does not have a
-separate "+" register normally, such behaviour will stay the same.  Instead
-when |v:clipmethod| is set to a provider, then the "+" register becomes
-available, but once |v:clipmethod| is "none", the "+' register becomes
-unavailable for use, and will point to the "*" register.  If on X11/Wayland
-systems, then the "+" register will always be available for use. If you want
-to check if the "+" is available for use, it can be checked with: >
+If on a platform that only has the "*" register, then the "+" register will
+only be available when |v:clipmethod| is set to a provider.  If you want to
+check if the "+" is available for use, it can be checked with: >
 	if has('unnamedplus')
 <
 						*clipboard-providers-clipmethod*
@@ -5306,9 +5305,7 @@ all.
 						*clipboard-providers-define*
 To defined a clipboard provider, the |v:clipproviders| vim variable is used.
 It is a |dict| where each key is the clipboard provider name, and the value is
-another |dict| declaring the 'available", "copy", and "paste" callbacks.  For
-example, see below to know how these callbacks work: >vim
-
+another |dict| declaring the 'available", "copy", and "paste" callbacks: >vim
 	let v:clipproviders["myprovider"] = {
 	    \ "available": Available,
 	    \ "paste": {
@@ -5327,6 +5324,10 @@ a |lambda| expression.
 
 If a callback except the "available" callback is not provided, then when Vim
 tries to call it, nothing is done.
+
+						*clipboard-providers-textlock*
+In both the "paste" and "copy" callbacks, it is not allowed to change the
+buffer text, see |textlock|.
 
 						*clipboard-providers-available*
 The "available" is an optional callback does not take any arguments and should

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2248,10 +2248,10 @@ v:clipmethod	The current method of accessing the clipboard that is being
 			x11		X11 selections are being used.
 			none		The above methods are unavailable or
 					cannot be used.
-			*		A clipboard provider is being used and
-					overriding the existing clipboard
-					functionality.
-		See 'clipmethod' for more details.
+		If it is set to a value not in the above list, then a
+		clipboard provider with the given name is being used and
+		overriding the clipboard functionality.  See 'clipmethod' for
+		more details.
 
 					*v:clipproviders*
 v:clipproviders

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -38,6 +38,7 @@ a remark is given.
 12. The sandbox			|eval-sandbox|
 13. Textlock			|textlock|
 14. Vim script library		|vim-script-library|
+14. Clipboard providers		|clipboard-providers|
 
 Testing support is documented in |testing.txt|.
 Profiling is documented at |profiling|.
@@ -2247,6 +2248,9 @@ v:clipmethod	The current method of accessing the clipboard that is being
 			x11		X11 selections are being used.
 			none		The above methods are unavailable or
 					cannot be used.
+			*		A clipboard provider is being used and
+					overriding the existing clipboard
+					functionality.
 		See 'clipmethod' for more details.
 
 					*v:cmdarg* *cmdarg-variable*
@@ -5266,5 +5270,110 @@ Usage: >vim
 	:call dist#vim9#Launch(<args>)
 	:Launch <app> <args>.
 <
+==============================================================================
+15. Clipboard providers				*clipboard-providers*
 
+The clipboard provider feature allows the "+" and "*" registers to be
+overrided by custom Vimscript functions.  There can be multiple providers, and
+Vim chooses which one to use based on 'clipmethod'.  Despite the name, it does
+not use the 'clipboard' option and should be treated separate from the
+clipboard functionality.  It essentially overrides the existing behaviour of
+the clipboard registers.
+
+						*clipboard-providers-plus*
+If the clipboard feature is enabled, then Vim exposes the "+" register for
+use.  However if on a platform such as Windows or MacOS that does not have a
+separate "+" register normally, such behaviour will stay the same.  Instead
+when |v:clipmethod| is set to a provider, then the "+" register becomes
+available, but once |v:clipmethod| is "none", the "+' register becomes
+unavailable for use, and will point to the "*" register.  If on X11/Wayland
+systems, then the "+" register will always be available for use.
+
+						*clipboard-providers-clipmethod*
+To integrate with the Vim's actual clipboard functionality, the 'clipmethod'
+option is used on all platforms.  The names of clipboard providers should be
+put inside the option, and if Vim chooses it, then it overrides the "+" and
+"*" registers.  Note that the "+" and "*" will not be saved in the viminfo at
+all.
+
+						*clipboard-providers-define*
+To defined a clipboard provider, the |v:clipproviders| vim variable is used.
+It is a |dict| where each key is the clipboard provider name, and the value is
+another |dict| declaring the 'available", "copy", and "paste" callbacks.  For
+example, see below to know how these callbacks work: >vim
+
+	let v:clipproviders["myprovider"] = {
+	    \ "available": Available,
+	    \ "paste": {
+	    \     "+": function("Paste"),
+	    \     "*": function("Paste")
+	    \	},
+	    \ "copy": {
+	    \     "+": function("Paste"),
+	    \     "*": function("Paste")
+	    \	}
+	    \ }
+	set clipmethod^=myprovider
+<
+Each callback can either be a name of a function in a string, a |Funcref|, or
+a |lambda| expression.
+
+If a callback except the "available" callback is not provided, then when Vim
+tries to call it, nothing is done.
+
+						*clipboard-providers-available*
+The "available" is an optional callback does not take any arguments and should
+return a |bool|, which tells Vim if it is available for use.  If it is not,
+then Vim skips over it and tries the next 'clipmethod' item.  If the
+"available" callback is not provided, Vim assumes the provider is always
+available for use (true).
+
+						*clipboard-providers-paste*
+The "paste" callback takes the following arguments in the following order:
+	1. Name of the register being accessed, either "+" or "*".
+
+It should return a |list| or |tuple| containing the following elements in
+order:
+	1. Register type conforming to |setreg()|
+	2. A |list| of strings to return to Vim, each representing a line.
+
+The first element (the register type), may also have a special value of
+"pass".  In that case, Vim does nothing to the register, meaning the current
+contents become unchanged.
+
+						*clipboard-providers-copy*
+The "copy" callback returns nothing and takes the following arguments in the
+following order:
+	1. Name of the register being accessed, either "+" or "*".
+	2. Register type conforming to |getregtype()|
+	3. List of strings to use, each representing a line.
+
+Below is a sample script that makes use of the clipboard provider feature: >vim
+	func Available()
+	    return v:true
+	endfunc
+
+	func Copy(reg, type, str)
+	    echom "Register: " .. a:reg
+	    echom "Register type: " .. a:type
+	    echom "Contents: " .. string(a:str)
+	endfunc
+
+	func Paste(reg)
+	    return ("b40", ["this", "is", "the", a:reg, "register!"])
+	endfunc
+
+	let v:clipproviders["test"] = {
+	    \ "available": function("Available"),
+	    \ "copy": {
+	    \     "+": function("Copy"),
+	    \     "*": function("Copy")
+	    \	},
+	    \ "paste": {
+	    \     "+": function("Paste"),
+	    \     "*": function("Paste")
+	    \	}
+	    \ }
+	set clipmethod^=test
+<
  vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2253,6 +2253,11 @@ v:clipmethod	The current method of accessing the clipboard that is being
 					functionality.
 		See 'clipmethod' for more details.
 
+					*v:clipproviders*
+v:clipproviders
+		A dictionary containing clipboard providers, see
+		|clipboard-providers| for more information.
+
 					*v:cmdarg* *cmdarg-variable*
 v:cmdarg	This variable is used for two purposes:
 		1. The extra arguments given to a file read/write command.
@@ -5325,7 +5330,7 @@ tries to call it, nothing is done.
 
 						*clipboard-providers-available*
 The "available" is an optional callback does not take any arguments and should
-return a |bool|, which tells Vim if it is available for use.  If it is not,
+return a |boolean|, which tells Vim if it is available for use.  If it is not,
 then Vim skips over it and tries the next 'clipmethod' item.  If the
 "available" callback is not provided, Vim assumes the provider is always
 available for use (true).

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -5287,8 +5287,10 @@ separate "+" register normally, such behaviour will stay the same.  Instead
 when |v:clipmethod| is set to a provider, then the "+" register becomes
 available, but once |v:clipmethod| is "none", the "+' register becomes
 unavailable for use, and will point to the "*" register.  If on X11/Wayland
-systems, then the "+" register will always be available for use.
-
+systems, then the "+" register will always be available for use. If you want
+to check if the "+" is available for use, it can be checked with: >
+	if has('unnamedplus')
+<
 						*clipboard-providers-clipmethod*
 To integrate with the Vim's actual clipboard functionality, the 'clipmethod'
 option is used on all platforms.  The names of clipboard providers should be

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1915,8 +1915,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 			{only when the |+xterm_clipboard|, |+wayland_clipboard|,
 			or |+eval| features are included}
 	Specifies which method of accessing the system clipboard (or clipboard
-	provider) is used, depending on which method works first or is
-	available.  Supported methods are:
+	provider) is used.  Methods are tried in the order given; the first
+	working method is used.  Supported methods are:
 		wayland		Wayland selections
 		x11		X11 selections
 		<name>		Use a clipboard provider with the given name

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1912,18 +1912,22 @@ A jump table for the options with a short description can be found at |Q_op|.
 				 for VMS: "x11",
 				 otherwise: "")
 			global
-			{only when the |+xterm_clipboard| or
-			|+wayland_clipboard| features are included}
-	Specifies which method of accessing the system clipboard is used,
-	depending on which method works first or is available.  Supported
-	methods are:
+			{only when the |+xterm_clipboard|, |+wayland_clipboard|,
+			or |+eval| features are included}
+	Specifies which method of accessing the system clipboard (or clipboard
+	provider) is used, depending on which method works first or is
+	available.  Supported methods are:
 		wayland		Wayland selections
 		x11		X11 selections
+		*		Clipboard provider name
 
 	Note: This option is ignored when either the GUI is running or if Vim
 	is run on a system without Wayland or X11 support, such as Windows or
-	macOS.  The GUI or system way of accessing the clipboard is always
-	used instead.
+	macOS.  The GUI or system way of accessing the clipboard is used
+	instead, meaning |v:clipmethod| will be set to "none".  The
+	exception to this is the |clipboard-providers| feature, in which if
+	a clipboard provider is being used, then it will override the existing
+	clipboard functionality.
 
 	The option value is a list of comma separated items.  The list is
 	parsed left to right in order, and the first method that Vim

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1919,7 +1919,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	available.  Supported methods are:
 		wayland		Wayland selections
 		x11		X11 selections
-		*		Clipboard provider name
+		<name>		Use a clipboard provider with the given name
 
 	Note: This option is ignored when either the GUI is running or if Vim
 	is run on a system without Wayland or X11 support, such as Windows or

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -1409,6 +1409,7 @@ $quote	eval.txt	/*$quote*
 +cindent	various.txt	/*+cindent*
 +clientserver	various.txt	/*+clientserver*
 +clipboard	various.txt	/*+clipboard*
++clipboard_provider	various.txt	/*+clipboard_provider*
 +clipboard_working	various.txt	/*+clipboard_working*
 +cmd	editing.txt	/*+cmd*
 +cmdline_compl	various.txt	/*+cmdline_compl*

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -6697,8 +6697,10 @@ clipboard-providers-available	eval.txt	/*clipboard-providers-available*
 clipboard-providers-clipmethod	eval.txt	/*clipboard-providers-clipmethod*
 clipboard-providers-copy	eval.txt	/*clipboard-providers-copy*
 clipboard-providers-define	eval.txt	/*clipboard-providers-define*
+clipboard-providers-no-clipboard	eval.txt	/*clipboard-providers-no-clipboard*
 clipboard-providers-paste	eval.txt	/*clipboard-providers-paste*
 clipboard-providers-plus	eval.txt	/*clipboard-providers-plus*
+clipboard-providers-textlock	eval.txt	/*clipboard-providers-textlock*
 clipboard-unnamed	options.txt	/*clipboard-unnamed*
 clipboard-unnamedplus	options.txt	/*clipboard-unnamedplus*
 clojure-indent	indent.txt	/*clojure-indent*
@@ -11265,6 +11267,7 @@ v:char	eval.txt	/*v:char*
 v:charconvert_from	eval.txt	/*v:charconvert_from*
 v:charconvert_to	eval.txt	/*v:charconvert_to*
 v:clipmethod	eval.txt	/*v:clipmethod*
+v:clipproviders	eval.txt	/*v:clipproviders*
 v:cmdarg	eval.txt	/*v:cmdarg*
 v:cmdbang	eval.txt	/*v:cmdbang*
 v:collate	eval.txt	/*v:collate*

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -6692,6 +6692,13 @@ clipboard-autoselectml	options.txt	/*clipboard-autoselectml*
 clipboard-autoselectplus	options.txt	/*clipboard-autoselectplus*
 clipboard-exclude	options.txt	/*clipboard-exclude*
 clipboard-html	options.txt	/*clipboard-html*
+clipboard-providers	eval.txt	/*clipboard-providers*
+clipboard-providers-available	eval.txt	/*clipboard-providers-available*
+clipboard-providers-clipmethod	eval.txt	/*clipboard-providers-clipmethod*
+clipboard-providers-copy	eval.txt	/*clipboard-providers-copy*
+clipboard-providers-define	eval.txt	/*clipboard-providers-define*
+clipboard-providers-paste	eval.txt	/*clipboard-providers-paste*
+clipboard-providers-plus	eval.txt	/*clipboard-providers-plus*
 clipboard-unnamed	options.txt	/*clipboard-unnamed*
 clipboard-unnamedplus	options.txt	/*clipboard-unnamedplus*
 clojure-indent	indent.txt	/*clojure-indent*

--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -379,6 +379,7 @@ T  *+cindent*		'cindent', C indenting; Always enabled
 N  *+clientserver*	Unix and Win32: Remote invocation |clientserver|
    *+clipboard*		|clipboard| support compiled-in
    *+clipboard_working*	|clipboard| support compiled-in and working
+   *+clipboard_provider*  |clipboard-providers| support compiled-in
 T  *+cmdline_compl*	command line completion |cmdline-completion|
 T  *+cmdline_hist*	command line history |cmdline-history|
 T  *+cmdline_info*	'showcmd' and 'ruler'; Always enabled since

--- a/src/clipboard.c
+++ b/src/clipboard.c
@@ -3951,7 +3951,7 @@ exit:
 void
 call_clip_provider_request(char_u *reg)
 {
-    if (clip_provider == NULL)
+    if (clipmethod != CLIPMETHOD_PROVIDER)
 	return;
 
     clip_provider_request_selection(reg, clip_provider);
@@ -3960,7 +3960,7 @@ call_clip_provider_request(char_u *reg)
 void
 call_clip_provider_set(char_u *reg)
 {
-    if (clip_provider == NULL)
+    if (clipmethod != CLIPMETHOD_PROVIDER)
 	return;
 
     clip_provider_set_selection(reg, clip_provider);

--- a/src/clipboard.c
+++ b/src/clipboard.c
@@ -3671,7 +3671,7 @@ clip_provider_is_available(char_u *provider)
     if (dict_get_tv(provider_tv.vval.v_dict, "available", &func_tv) == FAIL)
     {
 	clear_tv(&provider_tv);
-	// If "available" functon not specified assume always TRUE
+	// If "available" function not specified assume always TRUE
 	return 1;
     }
 
@@ -3698,7 +3698,7 @@ fail:
 }
 
 /*
- * Get the specified callback "function" from the provider dictionary of for
+ * Get the specified callback "function" from the provider dictionary for
  * register "reg".
  */
     static int
@@ -3974,7 +3974,7 @@ exit:
 }
 
 // Used to stop calling the provider callback every time there is an update.
-// This prevents unessecary calls when accessing the provider often in an
+// This prevents unnecessary calls when accessing the provider often in an
 // interval.
 //
 // If -1 then allow provider callback to be called then set to zero. Default

--- a/src/clipboard.c
+++ b/src/clipboard.c
@@ -4048,4 +4048,3 @@ void dec_clip_provider(void)
 }
 
 #endif // defined(FEAT_EVAL) && defined(HAVE_CLIPMETHOD)
-

--- a/src/clipboard.c
+++ b/src/clipboard.c
@@ -3553,11 +3553,13 @@ choose_clipmethod(void)
     if (method == CLIPMETHOD_FAIL)
 	return e_invalid_argument;
 
+#ifdef FEAT_EVAL
     if (method != CLIPMETHOD_PROVIDER)
     {
 	vim_free(clip_provider);
 	clip_provider = NULL;
     }
+#endif
 
 // If GUI is running or we are not on a system with Wayland or X11, then always
 // return CLIPMETHOD_NONE. System or GUI clipboard handling always overrides.

--- a/src/clipboard.c
+++ b/src/clipboard.c
@@ -3887,9 +3887,6 @@ clip_provider_paste(char_u *reg, char_u *provider)
     else
 	goto exit;
 
-    // If reg_type is "pass", then don't do anything and use the previous
-    // register contents
-    if (STRCMP(reg_type, "pass") != 0)
     {
 	char_u		yank_type = MAUTO;
 	long		block_len = -1;

--- a/src/clipboard.c
+++ b/src/clipboard.c
@@ -3656,7 +3656,7 @@ ex_clipreset(exarg_T *eap UNUSED)
     static int
 clip_provider_is_available(char_u *provider)
 {
-    dict_T	*providers = get_vim_var_dict(VV_CLIPBOARDS);
+    dict_T	*providers = get_vim_var_dict(VV_CLIPPROVIDERS);
     typval_T	provider_tv = {0};
     callback_T	callback = {0};
     typval_T	rettv = {0};
@@ -3708,7 +3708,7 @@ clip_provider_get_callback(
 	char_u *function,
 	callback_T *callback)
 {
-    dict_T	*providers = get_vim_var_dict(VV_CLIPBOARDS);
+    dict_T	*providers = get_vim_var_dict(VV_CLIPPROVIDERS);
     typval_T	provider_tv;
     typval_T	action_tv;
     typval_T	func_tv;

--- a/src/clipboard.c
+++ b/src/clipboard.c
@@ -3907,7 +3907,7 @@ clip_provider_paste(char_u *reg, char_u *provider)
 	// pointers to allocated copies.
 	lstval = ALLOC_MULT(char_u *, (len + 1) * 2);
 	if (lstval == NULL)
-	    return;
+	    goto exit;
 	curval = lstval;
 	allocval = lstval + len + 2;
 	curallocval = allocval;

--- a/src/clipboard.c
+++ b/src/clipboard.c
@@ -3935,7 +3935,7 @@ clip_provider_paste(char_u *reg, char_u *provider)
 	str_to_reg(y_ptr,
 		yank_type,
 		(char_u *)contents,
-		STRLEN(contents),
+		(long)STRLEN(contents),
 		block_len,
 		TRUE);
 

--- a/src/clipboard.c
+++ b/src/clipboard.c
@@ -3494,7 +3494,6 @@ get_clipmethod(char_u *str)
 		clip_provider = vim_strsave(buf);
 		if (clip_provider == NULL)
 		    goto fail;
-		*plus = *star = TRUE;
 	    }
 	    else if (r == -1)
 #endif

--- a/src/clipboard.c
+++ b/src/clipboard.c
@@ -9,7 +9,7 @@
 
 /*
  * clipboard.c: Functions to handle the clipboard. Additionally contains the
- *		clipboard provider code, which is separate from the main 
+ *		clipboard provider code, which is separate from the main
  *		clipboard code.
  */
 
@@ -3486,7 +3486,7 @@ get_clipmethod(char_u *str)
 #ifdef FEAT_EVAL
 	    // Check if name matches a clipboard provider
 	    int r = clip_provider_is_available(buf);
-	    
+
 	    if (r == 1)
 	    {
 		method = CLIPMETHOD_PROVIDER;

--- a/src/clipboard.c
+++ b/src/clipboard.c
@@ -3415,6 +3415,9 @@ clip_wl_owner_exists(Clipboard_T *cbd)
 
 #endif // FEAT_WAYLAND_CLIPBOARD
 
+#endif // FEAT_CLIPBOARD
+
+#ifdef ADD_CLIPMETHOD
 
 /*
  * Returns the first method for accessing the clipboard that is available/works,
@@ -3603,4 +3606,10 @@ ex_clipreset(exarg_T *eap UNUSED)
 		clipmethod_to_str(clipmethod));
 }
 
-#endif // FEAT_CLIPBOARD
+#endif // ADD_CLIPMETHOD
+
+#ifdef FEAT_EVAL
+
+
+
+#endif // FEAT_EVAL

--- a/src/clipboard.c
+++ b/src/clipboard.c
@@ -3490,6 +3490,7 @@ get_clipmethod(char_u *str)
 	    if (r == 1)
 	    {
 		method = CLIPMETHOD_PROVIDER;
+		vim_free(clip_provider);
 		clip_provider = vim_strsave(buf);
 		if (clip_provider == NULL)
 		    goto fail;
@@ -3552,14 +3553,6 @@ choose_clipmethod(void)
 
     if (method == CLIPMETHOD_FAIL)
 	return e_invalid_argument;
-
-#ifdef FEAT_EVAL
-    if (method != CLIPMETHOD_PROVIDER)
-    {
-	vim_free(clip_provider);
-	clip_provider = NULL;
-    }
-#endif
 
 // If GUI is running or we are not on a system with Wayland or X11, then always
 // return CLIPMETHOD_NONE. System or GUI clipboard handling always overrides.
@@ -3766,7 +3759,7 @@ clip_provider_get_callback(
 }
 
     static void
-clip_provider_set_selection(char_u *reg, char_u *provider)
+clip_provider_copy(char_u *reg, char_u *provider)
 {
     callback_T	callback;
     typval_T	rettv;
@@ -3845,7 +3838,7 @@ clip_provider_set_selection(char_u *reg, char_u *provider)
 }
 
     static void
-clip_provider_request_selection(char_u *reg, char_u *provider)
+clip_provider_paste(char_u *reg, char_u *provider)
 {
     callback_T	callback;
     typval_T	argvars[2];
@@ -3956,7 +3949,7 @@ call_clip_provider_request(char_u *reg)
     if (clipmethod != CLIPMETHOD_PROVIDER)
 	return;
 
-    clip_provider_request_selection(reg, clip_provider);
+    clip_provider_paste(reg, clip_provider);
 }
 
 void
@@ -3965,7 +3958,8 @@ call_clip_provider_set(char_u *reg)
     if (clipmethod != CLIPMETHOD_PROVIDER)
 	return;
 
-    clip_provider_set_selection(reg, clip_provider);
+    clip_provider_copy(reg, clip_provider);
 }
 
-#endif // FEAT_EVAL
+#endif // defined(FEAT_EVAL) && defined(HAVE_CLIPMETHOD)
+

--- a/src/clipboard.c
+++ b/src/clipboard.c
@@ -4041,9 +4041,9 @@ void dec_clip_provider(void)
     plus_pause_count = plus_pause_count == -1 ? -1 : plus_pause_count - 1;
     star_pause_count = star_pause_count == -1 ? -1 : star_pause_count - 1;
 
-    if (plus_pause_count == 0)
+    if (plus_pause_count == 0 || plus_pause_count == -1)
 	plus_pause_count = -2;
-    if (star_pause_count == 0)
+    if (star_pause_count == 0 || star_pause_count == -1)
 	star_pause_count = -2;
 }
 

--- a/src/clipboard.c
+++ b/src/clipboard.c
@@ -3556,9 +3556,10 @@ choose_clipmethod(void)
 
 // If GUI is running or we are not on a system with Wayland or X11, then always
 // return CLIPMETHOD_NONE. System or GUI clipboard handling always overrides.
+// This is unless a provider is being used.
 #if defined(FEAT_XCLIPBOARD) || defined(FEAT_WAYLAND_CLIPBOARD)
 # if defined(FEAT_GUI)
-    if (gui.in_use)
+    if (method != CLIPMETHOD_PROVIDER && gui.in_use)
     {
 #  ifdef FEAT_WAYLAND
 	// We only interact with Wayland for the clipboard, we can just deinit
@@ -3572,7 +3573,7 @@ choose_clipmethod(void)
 # endif
 #else
     // If on a system like windows or macos, then clipmethod is irrelevant, we
-    // use their way of accessing the clipboard. THis is unless we are using the
+    // use their way of accessing the clipboard. This is unless we are using the
     // clipboard provider
 #if defined(FEAT_EVAL) && defined(HAVE_CLIPMETHOD)
     if (method != CLIPMETHOD_PROVIDER)

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -7565,14 +7565,6 @@ f_has(typval_T *argvars, typval_T *rettv)
 		0
 #endif
 		},
-	{"unnamedplus",
-#if defined(FEAT_CLIPBOARD) && (defined(FEAT_X11) \
-	|| defined(FEAT_WAYLAND_CLIPBOARD))
-		1
-#else
-		0
-#endif
-		},
 	{"user-commands", 1},    // was accidentally included in 5.4
 	{"user_commands", 1},
 	{"vartabs",
@@ -7918,7 +7910,27 @@ f_has(typval_T *argvars, typval_T *rettv)
 	{
 	    x = TRUE;
 #ifdef FEAT_CLIPBOARD
-	    n = clip_star.available;
+	    n = clipmethod == CLIPMETHOD_PROVIDER ? TRUE : clip_star.available;
+#endif
+	}
+	else if (STRICMP(name, "unnamedplus") == 0)
+	{
+	    x = TRUE;
+#ifdef FEAT_CLIPBOARD
+	    // The + register is available when clipmethod is set to a provider,
+	    // but becomes unavailable if on a platform that doesn't support it
+	    // and clipmethod is "none".
+	    // (Windows, MacOS).
+# if defined(FEAT_X11) || defined(FEAT_WAYLAND_CLIPBOARD)
+	    n = TRUE;
+# elif defined(FEAT_EVAL)
+	    if (clipmethod == CLIPMETHOD_PROVIDER)
+		n = TRUE;
+	    else
+		n = FALSE;
+# else
+	    n = FALSE;
+# endif
 #endif
 	}
     }

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -6868,6 +6868,13 @@ f_has(typval_T *argvars, typval_T *rettv)
 		0
 #endif
 		},
+	{"clipboard_provider",
+#ifdef FEAT_CLIPBOARD_PROVIDER
+		1
+#else
+		0
+#endif
+		},
 	{"cmdline_compl", 1},
 	{"cmdline_hist", 1},
 	{"cmdwin", 1},

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -11493,7 +11493,7 @@ f_setpos(typval_T *argvars, typval_T *rettv)
 /*
  * Translate a register type string to the yank type and block length
  */
-    static int
+    int
 get_yank_type(char_u **pp, char_u *yank_type, long *block_len)
 {
     char_u *stropt = *pp;

--- a/src/evalvars.c
+++ b/src/evalvars.c
@@ -168,6 +168,7 @@ static struct vimvar
     {VV_NAME("termda1",		 VAR_STRING), NULL, VV_RO},
     {VV_NAME("termosc",	 VAR_STRING), NULL, VV_RO},
     {VV_NAME("vim_did_init",	 VAR_NUMBER), NULL, VV_RO},
+    {VV_NAME("clipboards",	 VAR_DICT), NULL, VV_RO},
 };
 
 // shorthand

--- a/src/evalvars.c
+++ b/src/evalvars.c
@@ -168,7 +168,7 @@ static struct vimvar
     {VV_NAME("termda1",		 VAR_STRING), NULL, VV_RO},
     {VV_NAME("termosc",	 VAR_STRING), NULL, VV_RO},
     {VV_NAME("vim_did_init",	 VAR_NUMBER), NULL, VV_RO},
-    {VV_NAME("clipboards",	 VAR_DICT), NULL, VV_RO},
+    {VV_NAME("clipproviders",	 VAR_DICT), NULL, VV_RO},
 };
 
 // shorthand

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -5489,7 +5489,7 @@ ex_global(exarg_T *eap)
 	}
 	else
 	{
-#if defined(FEAT_EVAL) && defined(HAVE_CLIPMETHOD)
+#ifdef FEAT_CLIPBOARD_PROVIDER
 	    inc_clip_provider();
 #endif
 #ifdef FEAT_CLIPBOARD
@@ -5499,7 +5499,7 @@ ex_global(exarg_T *eap)
 #ifdef FEAT_CLIPBOARD
 	    end_global_changes();
 #endif
-#if defined(FEAT_EVAL) && defined(HAVE_CLIPMETHOD)
+#ifdef FEAT_CLIPBOARD_PROVIDER
 	    dec_clip_provider();
 #endif
 	}

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -5489,12 +5489,18 @@ ex_global(exarg_T *eap)
 	}
 	else
 	{
+#if defined(FEAT_EVAL) && defined(HAVE_CLIPMETHOD)
+	    inc_clip_provider();
+#endif
 #ifdef FEAT_CLIPBOARD
 	    start_global_changes();
 #endif
 	    global_exe(cmd);
 #ifdef FEAT_CLIPBOARD
 	    end_global_changes();
+#endif
+#if defined(FEAT_EVAL) && defined(HAVE_CLIPMETHOD)
+	    dec_clip_provider();
 #endif
 	}
 

--- a/src/ex_cmds2.c
+++ b/src/ex_cmds2.c
@@ -536,7 +536,7 @@ ex_listdo(exarg_T *eap)
 #ifdef FEAT_CLIPBOARD
     start_global_changes();
 #endif
-#if defined(FEAT_EVAL) && defined(HAVE_CLIPMETHOD)
+#ifdef FEAT_CLIPBOARD_PROVIDER
     inc_clip_provider();
 #endif
 
@@ -763,7 +763,7 @@ ex_listdo(exarg_T *eap)
 #ifdef FEAT_CLIPBOARD
     end_global_changes();
 #endif
-#if defined(FEAT_EVAL) && defined(HAVE_CLIPMETHOD)
+#ifdef FEAT_CLIPBOARD_PROVIDER
     dec_clip_provider();
 #endif
 }

--- a/src/ex_cmds2.c
+++ b/src/ex_cmds2.c
@@ -536,6 +536,9 @@ ex_listdo(exarg_T *eap)
 #ifdef FEAT_CLIPBOARD
     start_global_changes();
 #endif
+#if defined(FEAT_EVAL) && defined(HAVE_CLIPMETHOD)
+    inc_clip_provider();
+#endif
 
     if (eap->cmdidx == CMD_windo
 	    || eap->cmdidx == CMD_tabdo
@@ -759,6 +762,9 @@ ex_listdo(exarg_T *eap)
 #endif
 #ifdef FEAT_CLIPBOARD
     end_global_changes();
+#endif
+#if defined(FEAT_EVAL) && defined(HAVE_CLIPMETHOD)
+    dec_clip_provider();
 #endif
 }
 

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -2372,7 +2372,7 @@ do_one_cmd(
 	    && (!IS_USER_CMDIDX(ea.cmdidx) || *ea.arg != '=')
 	    && !((ea.argt & EX_COUNT) && VIM_ISDIGIT(*ea.arg)))
     {
-#if !defined(FEAT_CLIPBOARD) && !defined(FEAT_EVAL) && !defined(HAVE_CLIPMETHOD)
+#if !defined(FEAT_CLIPBOARD) && !defined(FEAT_CLIPBOARD_PROVIDER)
 	// check these explicitly for a more specific error message
 	if (*ea.arg == '*' || *ea.arg == '+')
 	{
@@ -10404,7 +10404,7 @@ ex_folddo(exarg_T *eap)
 # ifdef FEAT_CLIPBOARD
     start_global_changes();
 # endif
-#if defined(FEAT_EVAL) && defined(HAVE_CLIPMETHOD)
+#ifdef FEAT_CLIPBOARD_PROVIDER
     inc_clip_provider();
 #endif
 
@@ -10419,7 +10419,7 @@ ex_folddo(exarg_T *eap)
 # ifdef FEAT_CLIPBOARD
     end_global_changes();
 # endif
-#if defined(FEAT_EVAL) && defined(HAVE_CLIPMETHOD)
+#ifdef FEAT_CLIPBOARD_PROVIDER
     dec_clip_provider();
 #endif
 }

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -2372,7 +2372,7 @@ do_one_cmd(
 	    && (!IS_USER_CMDIDX(ea.cmdidx) || *ea.arg != '=')
 	    && !((ea.argt & EX_COUNT) && VIM_ISDIGIT(*ea.arg)))
     {
-#ifndef FEAT_CLIPBOARD
+#if !defined(FEAT_CLIPBOARD) && !defined(FEAT_EVAL) && !defined(HAVE_CLIPMETHOD)
 	// check these explicitly for a more specific error message
 	if (*ea.arg == '*' || *ea.arg == '+')
 	{
@@ -10404,6 +10404,9 @@ ex_folddo(exarg_T *eap)
 # ifdef FEAT_CLIPBOARD
     start_global_changes();
 # endif
+#if defined(FEAT_EVAL) && defined(HAVE_CLIPMETHOD)
+    inc_clip_provider();
+#endif
 
     // First set the marks for all lines closed/open.
     for (lnum = eap->line1; lnum <= eap->line2; ++lnum)
@@ -10416,6 +10419,9 @@ ex_folddo(exarg_T *eap)
 # ifdef FEAT_CLIPBOARD
     end_global_changes();
 # endif
+#if defined(FEAT_EVAL) && defined(HAVE_CLIPMETHOD)
+    dec_clip_provider();
+#endif
 }
 #endif
 

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -375,7 +375,7 @@ static void	ex_folddo(exarg_T *eap);
 #if !defined(FEAT_WAYLAND)
 # define ex_wlrestore		ex_ni
 #endif
-#if !defined(FEAT_CLIPBOARD)
+#if !defined(HAVE_CLIPMETHOD)
 # define ex_clipreset		ex_ni
 #endif
 #if !defined(FEAT_PROP_POPUP)

--- a/src/feature.h
+++ b/src/feature.h
@@ -924,7 +924,7 @@
     && defined(HAVE_WAYLAND) && defined(WANT_WAYLAND)
 # define FEAT_WAYLAND_CLIPBOARD
 # ifndef FEAT_CLIPBOARD
-#  define FEAT_CLIPBOARD
+#  define FEAT_CLIPBOARD 
 # endif
 #endif
 
@@ -944,8 +944,8 @@
 
 // The clipboard provider feature uses clipmethod as well but should be separate
 // from the clipboard code.
-#if defined(FEAT_CLIPBOARD)
-#define ADD_CLIPMETHOD
+#if defined(FEAT_CLIPBOARD) || defined(FEAT_EVAL)
+#define HAVE_CLIPMETHOD
 #endif
 
 #if defined(FEAT_GUI_MSWIN)

--- a/src/feature.h
+++ b/src/feature.h
@@ -942,6 +942,12 @@
 # define FEAT_DND
 #endif
 
+// The clipboard provider feature uses clipmethod as well but should be separate
+// from the clipboard code.
+#if defined(FEAT_CLIPBOARD)
+#define ADD_CLIPMETHOD
+#endif
+
 #if defined(FEAT_GUI_MSWIN)
 # define MSWIN_FIND_REPLACE	// include code for find/replace dialog
 # define MSWIN_FR_BUFSIZE 256

--- a/src/feature.h
+++ b/src/feature.h
@@ -924,7 +924,7 @@
     && defined(HAVE_WAYLAND) && defined(WANT_WAYLAND)
 # define FEAT_WAYLAND_CLIPBOARD
 # ifndef FEAT_CLIPBOARD
-#  define FEAT_CLIPBOARD 
+#  define FEAT_CLIPBOARD
 # endif
 #endif
 

--- a/src/feature.h
+++ b/src/feature.h
@@ -942,12 +942,6 @@
 # define FEAT_DND
 #endif
 
-// The clipboard provider feature uses clipmethod as well but should be separate
-// from the clipboard code.
-#if defined(FEAT_CLIPBOARD) || defined(FEAT_EVAL)
-#define HAVE_CLIPMETHOD
-#endif
-
 #if defined(FEAT_GUI_MSWIN)
 # define MSWIN_FIND_REPLACE	// include code for find/replace dialog
 # define MSWIN_FR_BUFSIZE 256

--- a/src/globals.h
+++ b/src/globals.h
@@ -994,8 +994,7 @@ EXTERN int	clip_unnamed_saved INIT(= 0);
 #endif
 
 #if defined(FEAT_EVAL) && defined(HAVE_CLIPMETHOD)
-EXTERN char_u	*clip_provider INIT(= NULL); // NULL when clipmethod is not set
-					     // to CLIPMETHOD_PROVIDER
+EXTERN char_u	*clip_provider INIT(= NULL);
 #endif
 
 

--- a/src/globals.h
+++ b/src/globals.h
@@ -993,6 +993,12 @@ EXTERN regprog_T *clip_exclude_prog INIT(= NULL);
 EXTERN int	clip_unnamed_saved INIT(= 0);
 #endif
 
+#if defined(FEAT_EVAL) && defined(HAVE_CLIPMETHOD)
+EXTERN char_u	*clip_provider INIT(= NULL); // NULL when clipmethod is not set
+					     // to CLIPMETHOD_PROVIDER
+#endif
+
+
 /*
  * All regular windows are linked in a list. "firstwin" points to the first
  * entry, "lastwin" to the last entry (can be the same as firstwin) and
@@ -2070,7 +2076,7 @@ EXTERN int	p_tgc_set INIT(= FALSE);
 // If we've already warned about missing/unavailable clipboard
 EXTERN bool did_warn_clipboard INIT(= FALSE);
 
-#ifdef FEAT_CLIPBOARD
+#ifdef HAVE_CLIPMETHOD
 EXTERN clipmethod_T clipmethod INIT(= CLIPMETHOD_NONE);
 #endif
 

--- a/src/globals.h
+++ b/src/globals.h
@@ -993,7 +993,7 @@ EXTERN regprog_T *clip_exclude_prog INIT(= NULL);
 EXTERN int	clip_unnamed_saved INIT(= 0);
 #endif
 
-#if defined(FEAT_EVAL) && defined(HAVE_CLIPMETHOD)
+#ifdef FEAT_CLIPBOARD_PROVIDER
 EXTERN char_u	*clip_provider INIT(= NULL);
 #endif
 

--- a/src/gui.c
+++ b/src/gui.c
@@ -147,8 +147,10 @@ gui_start(char_u *arg UNUSED)
 #endif
     }
     else
+#ifdef HAVE_CLIPMETHOD
 	// Reset clipmethod to CLIPMETHOD_NONE
 	choose_clipmethod();
+#endif
 
 #ifdef FEAT_SOCKETSERVER
     // Install socket server listening socket if we are running it

--- a/src/gui.c
+++ b/src/gui.c
@@ -146,8 +146,8 @@ gui_start(char_u *arg UNUSED)
 	    emsg(msg);
 #endif
     }
-    else
 #ifdef HAVE_CLIPMETHOD
+    else
 	// Reset clipmethod to CLIPMETHOD_NONE
 	choose_clipmethod();
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -704,7 +704,7 @@ vim_main2(void)
     }
 #endif
 
-#ifdef FEAT_CLIPBOARD
+#ifdef HAVE_CLIPMETHOD
     choose_clipmethod();
 #endif
 

--- a/src/option.h
+++ b/src/option.h
@@ -507,6 +507,8 @@ EXTERN char_u	*p_cedit;	// 'cedit'
 EXTERN long	p_cwh;		// 'cmdwinheight'
 #ifdef FEAT_CLIPBOARD
 EXTERN char_u	*p_cb;		// 'clipboard'
+#endif
+#ifdef HAVE_CLIPMETHOD
 EXTERN char_u	*p_cpm;		// 'clipmethod'
 #endif
 EXTERN long	p_ch;		// 'cmdheight'

--- a/src/optiondefs.h
+++ b/src/optiondefs.h
@@ -634,8 +634,10 @@ static struct vimoption options[] =
     {"clipmethod", "cpm",   P_STRING|P_VI_DEF|P_ONECOMMA|P_NODUP,
 #ifdef HAVE_CLIPMETHOD
 			    (char_u *)&p_cpm, PV_NONE, did_set_clipmethod, expand_set_clipmethod,
-# if defined(FEAT_WAYLAND_CLIPBOARD) || defined(FEAT_XCLIPBOARD)
+# ifdef UNIX
 			    {(char_u *)"wayland,x11", (char_u *)0L}
+# elif defined(VMS)
+			    {(char_u *)"x11", (char_u *)0L}
 # else
 			    {(char_u *)"", (char_u *)0L}
 # endif

--- a/src/optiondefs.h
+++ b/src/optiondefs.h
@@ -632,12 +632,10 @@ static struct vimoption options[] =
 #endif
 			    SCTX_INIT},
     {"clipmethod", "cpm",   P_STRING|P_VI_DEF|P_ONECOMMA|P_NODUP,
-#ifdef FEAT_CLIPBOARD
+#ifdef HAVE_CLIPMETHOD
 			    (char_u *)&p_cpm, PV_NONE, did_set_clipmethod, expand_set_clipmethod,
-# ifdef UNIX
+# if defined(FEAT_WAYLAND_CLIPBOARD) || defined(FEAT_XCLIPBOARD)
 			    {(char_u *)"wayland,x11", (char_u *)0L}
-# elif defined(VMS)
-			    {(char_u *)"x11", (char_u *)0L}
 # else
 			    {(char_u *)"", (char_u *)0L}
 # endif

--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -1435,6 +1435,9 @@ expand_set_clipmethod(optexpand_T *args, int *numMatches, char_u ***matches)
 #endif
     values = ALLOC_MULT(char *, count + 1); // Add NULL terminator too
 
+    if (values == NULL)
+	return FAIL;
+
 #ifdef FEAT_WAYLAND_CLIPBOARD
     values[pos++] = "wayland";
 #endif

--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -44,6 +44,8 @@ static char *(p_ff_values[]) = {FF_UNIX, FF_DOS, FF_MAC, NULL};
 #ifdef FEAT_CLIPBOARD
 // Note: Keep this in sync with did_set_clipboard()
 static char *(p_cb_values[]) = {"unnamed", "unnamedplus", "autoselect", "autoselectplus", "autoselectml", "html", "exclude:", NULL};
+#endif
+#ifdef HAVE_CLIPMETHOD
 // Note: Keep this in sync with get_clipmethod()
 static char *(p_cpm_values[]) = {"wayland", "x11", NULL};
 #endif
@@ -1402,7 +1404,9 @@ expand_set_clipboard(optexpand_T *args, int *numMatches, char_u ***matches)
 	    numMatches,
 	    matches);
 }
+#endif
 
+#ifdef HAVE_CLIPMETHOD
     char *
 did_set_clipmethod(optset_T *args UNUSED)
 {

--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -45,10 +45,6 @@ static char *(p_ff_values[]) = {FF_UNIX, FF_DOS, FF_MAC, NULL};
 // Note: Keep this in sync with did_set_clipboard()
 static char *(p_cb_values[]) = {"unnamed", "unnamedplus", "autoselect", "autoselectplus", "autoselectml", "html", "exclude:", NULL};
 #endif
-#ifdef HAVE_CLIPMETHOD
-// Note: Keep this in sync with get_clipmethod()
-static char *(p_cpm_values[]) = {"wayland", "x11", NULL};
-#endif
 #ifdef FEAT_CRYPT
 static char *(p_cm_values[]) = {"zip", "blowfish", "blowfish2",
  # ifdef FEAT_SODIUM
@@ -1416,12 +1412,58 @@ did_set_clipmethod(optset_T *args UNUSED)
     int
 expand_set_clipmethod(optexpand_T *args, int *numMatches, char_u ***matches)
 {
-    return expand_set_opt_string(
+    // We want to expand using the predefined clipmethod values + clipboard
+    // provider names.
+    int		result;
+    char	**values;
+    int		count, pos = 0, start = 0;
+#ifdef FEAT_EVAL
+    dict_T	*providers = get_vim_var_dict(VV_CLIPPROVIDERS);
+#else
+    dict_T	*providers = NULL;
+#endif
+    hashtab_T	*ht = providers == NULL ? NULL : &providers->dv_hashtab;
+
+    count = (ht == NULL ? 0 : ht->ht_used);
+#ifdef FEAT_WAYLAND_CLIPBOARD
+    count++;
+    start++;
+#endif
+#ifdef FEAT_XCLIPBOARD
+    count++;
+    start++;
+#endif
+    values = ALLOC_MULT(char *, count + 1); // Add NULL terminator too
+
+#ifdef FEAT_WAYLAND_CLIPBOARD
+    values[pos++] = "wayland";
+#endif
+#ifdef FEAT_XCLIPBOARD
+    values[pos++] = "x11";
+#endif
+
+    if (ht != NULL)
+	for (long_u i = 0; i < ht->ht_mask + 1; i++)
+	{
+	    hashitem_T	*hi = ht->ht_array + i;
+
+	    if (!HASHITEM_EMPTY(hi))
+		values[pos++] = (char *)vim_strsave(hi->hi_key);
+	}
+    values[pos++] = NULL;
+
+    result = expand_set_opt_string(
 	    args,
-	    p_cpm_values,
-	    ARRAY_LENGTH(p_cpm_values) - 1,
+	    values,
+	    count,
 	    numMatches,
 	    matches);
+
+    for (int i = start; i < count; i++)
+	vim_free(values[i]);
+    vim_free(values);
+
+    return result;
 }
 #endif
 

--- a/src/proto/clipboard.pro
+++ b/src/proto/clipboard.pro
@@ -40,4 +40,6 @@ void clip_uninit_wayland(void);
 int clip_reset_wayland(void);
 char *choose_clipmethod(void);
 void ex_clipreset(exarg_T *eap);
+void call_clip_provider_request(char_u *reg);
+void call_clip_provider_set(char_u *reg);
 /* vim: set ft=c : */

--- a/src/proto/clipboard.pro
+++ b/src/proto/clipboard.pro
@@ -40,6 +40,8 @@ void clip_uninit_wayland(void);
 int clip_reset_wayland(void);
 char *choose_clipmethod(void);
 void ex_clipreset(exarg_T *eap);
-void call_clip_provider_request(char_u *reg);
-void call_clip_provider_set(char_u *reg);
+void call_clip_provider_request(int reg);
+void call_clip_provider_set(int reg);
+void inc_clip_provider(void);
+void dec_clip_provider(void);
 /* vim: set ft=c : */

--- a/src/proto/evalfunc.pro
+++ b/src/proto/evalfunc.pro
@@ -28,4 +28,5 @@ void f_len(typval_T *argvars, typval_T *rettv);
 void mzscheme_call_vim(char_u *name, typval_T *args, typval_T *rettv);
 void range_list_materialize(list_T *list);
 long do_searchpair(char_u *spat, char_u *mpat, char_u *epat, int dir, typval_T *skip, int flags, pos_T *match_pos, linenr_T lnum_stop, long time_limit);
+int get_yank_type(char_u **pp, char_u *yank_type, long *block_len);
 /* vim: set ft=c : */

--- a/src/register.c
+++ b/src/register.c
@@ -2436,7 +2436,13 @@ get_register_name(int num)
 #if defined(FEAT_CLIPBOARD) || (defined(HAVE_CLIPMETHOD) && defined(FEAT_EVAL))
     else if (num == STAR_REGISTER)
 	return '*';
-    else if (num == REAL_PLUS_REGISTER)
+    // If there is only one clipboard, we only want the plus register to point
+    // to the star register if the clipboard provider is not being used. If the
+    // clipboard provider is being used, then both registers should be available
+    // no matter the plaform
+    else if (clipmethod == CLIPMETHOD_PROVIDER && num == REAL_PLUS_REGISTER)
+	return '+';
+    else if (clipmethod != CLIPMETHOD_PROVIDER && num == PLUS_REGISTER)
 	return '+';
 #endif
     else
@@ -2492,13 +2498,8 @@ ex_display(exarg_T *eap)
 	}
 	if (arg != NULL && vim_strchr(arg, name) == NULL
 #ifdef ONE_CLIPBOARD
-	    // Star register and plus register contain the same thing. Unless
-	    // clipmethod is provider.
-		&&
-#if defined(FEAT_EVAL) && defined(HAVE_CLIPMETHOD)
-		clipmethod != CLIPMETHOD_PROVIDER &&
-#endif
-		(name != '*' || vim_strchr(arg, '+' == NULL))
+		// Star register and plus register contain the same thing.
+		&& (name != '*' || vim_strchr(arg, '+') == NULL)
 #endif
 		)
 	    continue;	    // did not ask for this register

--- a/src/register.c
+++ b/src/register.c
@@ -46,7 +46,7 @@ get_y_regs(void)
 }
 #endif
 
-#if defined(FEAT_CLIPBOARD) || (defined(FEAT_EVAL) && defined(HAVE_CLIPMETHOD))
+#if defined(FEAT_CLIPBOARD) || defined(FEAT_CLIPBOARD_PROVIDER)
     yankreg_T *
 get_y_register(int reg)
 {
@@ -194,7 +194,7 @@ valid_yank_reg(
 			    // always exist.
 	    || regname == '*'
 	    || regname == '+'
-#elif defined(HAVE_CLIPMETHOD) && defined(FEAT_EVAL)
+#elif defined(FEAT_CLIPBOARD_PROVIDER)
 	    || ( // If -clipboard, then these registers only exist when
 		 // clipmethod is set to provider.
 	     clipmethod == CLIPMETHOD_PROVIDER && (
@@ -264,7 +264,7 @@ get_yank_register(int regname, int writing)
     // When clipboard is not available, use register 0 instead of '+'
     else if (clip_plus.available && regname == '+')
     {
-#if defined(FEAT_EVAL) && defined(HAVE_CLIPMETHOD)
+#ifdef FEAT_CLIPBOARD_PROVIDER
 	// We want to use the actual + register, since PLUS_REGISTER may be
 	// pointing to STAR_REGISTER.
 	if (clipmethod == CLIPMETHOD_PROVIDER)
@@ -274,7 +274,7 @@ get_yank_register(int regname, int writing)
 	    i = PLUS_REGISTER;
 	ret = TRUE;
     }
-#elif defined(FEAT_EVAL) && defined(HAVE_CLIPMETHOD)
+#elif defined(FEAT_CLIPBOARD_PROVIDER)
     else if (regname == '*')
     {
 	i = STAR_REGISTER;
@@ -310,7 +310,7 @@ get_register(
     yankreg_T	*reg;
     int		i;
 
-#if defined(FEAT_EVAL) && defined(HAVE_CLIPMETHOD)
+#ifdef FEAT_CLIPBOARD_PROVIDER
     call_clip_provider_request(name);
 #endif
 #ifdef FEAT_CLIPBOARD
@@ -647,7 +647,7 @@ do_execreg(
     }
     execreg_lastc = regname;
 
-#if defined(FEAT_EVAL) && defined(HAVE_CLIPMETHOD)
+#ifdef FEAT_CLIPBOARD_PROVIDER
     call_clip_provider_request(regname);
 #endif
 #ifdef FEAT_CLIPBOARD
@@ -859,7 +859,7 @@ insert_reg(
     if (regname != NUL && !valid_yank_reg(regname, FALSE))
 	return FAIL;
 
-#if defined(FEAT_EVAL) && defined(HAVE_CLIPMETHOD)
+#ifdef FEAT_CLIPBOARD_PROVIDER
     call_clip_provider_request(regname);
 #endif
 #ifdef FEAT_CLIPBOARD
@@ -1419,7 +1419,7 @@ op_yank(oparg_T *oap, int deleting, int mess)
 	    decl(&curbuf->b_op_end);
     }
 
-#if defined(FEAT_EVAL) && defined(HAVE_CLIPMETHOD)
+#ifdef FEAT_CLIPBOARD_PROVIDER
     if (curr == &y_regs[REAL_PLUS_REGISTER])
 	call_clip_provider_set('+');
     else if (curr == &y_regs[STAR_REGISTER])
@@ -1585,7 +1585,7 @@ do_put(
     pos_T	orig_end = curbuf->b_op_end;
     unsigned int cur_ve_flags = get_ve_flags();
 
-#if defined(FEAT_EVAL) && defined(HAVE_CLIPMETHOD)
+#ifdef FEAT_CLIPBOARD_PROVIDER
     call_clip_provider_request(regname);
 #endif
 #ifdef FEAT_CLIPBOARD
@@ -2383,7 +2383,7 @@ get_register_name(int num)
 	return num + '0';
     else if (num == DELETION_REGISTER)
 	return '-';
-#if defined(FEAT_CLIPBOARD) || (defined(HAVE_CLIPMETHOD) && defined(FEAT_EVAL))
+#if defined(FEAT_CLIPBOARD) || defined(FEAT_CLIPBOARD_PROVIDER)
     else if (num == STAR_REGISTER)
 	return '*';
     // If there is only one clipboard, we only want the plus register to point
@@ -2431,7 +2431,7 @@ ex_display(exarg_T *eap)
 	arg = NULL;
     attr = HL_ATTR(HLF_8);
 
-#if defined(FEAT_EVAL) && defined(HAVE_CLIPMETHOD)
+#ifdef FEAT_CLIPBOARD_PROVIDER
     inc_clip_provider();
 #endif
 
@@ -2454,8 +2454,7 @@ ex_display(exarg_T *eap)
 		)
 	    continue;	    // did not ask for this register
 
-
-#if defined(FEAT_EVAL) && defined(HAVE_CLIPMETHOD)
+#ifdef FEAT_CLIPBOARD_PROVIDER
 	call_clip_provider_request(name);
 #endif
 #ifdef FEAT_CLIPBOARD
@@ -2588,7 +2587,7 @@ ex_display(exarg_T *eap)
     }
 #endif
 
-#if defined(FEAT_EVAL) && defined(HAVE_CLIPMETHOD)
+#ifdef FEAT_CLIPBOARD_PROVIDER
     dec_clip_provider();
 #endif
 }
@@ -2663,7 +2662,7 @@ get_reg_type(int regname, long *reglen)
 	    return MCHAR;
     }
 
-#if defined(FEAT_EVAL) && defined(HAVE_CLIPMETHOD)
+#ifdef FEAT_CLIPBOARD_PROVIDER
     call_clip_provider_request(regname);
 #endif
 # ifdef FEAT_CLIPBOARD
@@ -2746,7 +2745,7 @@ get_reg_contents(int regname, int flags)
     if (regname != NUL && !valid_yank_reg(regname, FALSE))
 	return NULL;
 
-#if defined(FEAT_EVAL) && defined(HAVE_CLIPMETHOD)
+#ifdef FEAT_CLIPBOARD_PROVIDER
     call_clip_provider_request(regname);
 #endif
 # ifdef FEAT_CLIPBOARD
@@ -2917,7 +2916,7 @@ write_reg_contents_lst(
 
     finish_write_reg(name, old_y_previous, old_y_current);
 
-#if defined(FEAT_EVAL) && defined(HAVE_CLIPMETHOD)
+#ifdef FEAT_CLIPBOARD_PROVIDER
     call_clip_provider_set(name);
 #endif
 }
@@ -2995,7 +2994,7 @@ write_reg_contents_ex(
 
     finish_write_reg(name, old_y_previous, old_y_current);
 
-#if defined(FEAT_EVAL) && defined(HAVE_CLIPMETHOD)
+#ifdef FEAT_CLIPBOARD_PROVIDER
     call_clip_provider_set(name);
 #endif
 }

--- a/src/register.c
+++ b/src/register.c
@@ -2685,8 +2685,15 @@ get_reg_type(int regname, long *reglen)
 	    return MCHAR;
     }
 
+#if defined(FEAT_EVAL) && defined(HAVE_CLIPMETHOD)
+    if (regname == '+')
+	call_clip_provider_request((char_u *)"+");
+    else if (regname == '*')
+	call_clip_provider_request((char_u *)"*");
+#endif
 # ifdef FEAT_CLIPBOARD
-    regname = may_get_selection(regname);
+    if (clipmethod != CLIPMETHOD_PROVIDER)
+	regname = may_get_selection(regname);
 # endif
 
     if (regname != NUL && !valid_yank_reg(regname, FALSE))

--- a/src/register.c
+++ b/src/register.c
@@ -194,7 +194,7 @@ valid_yank_reg(
 			    // always exist.
 	    || regname == '*'
 	    || regname == '+'
-#elif  defined(HAVE_CLIPMETHOD) && defined(FEAT_EVAL)
+#elif defined(HAVE_CLIPMETHOD) && defined(FEAT_EVAL)
 	    || ( // If -clipboard, then these registers only exist when
 		 // clipmethod is set to provider.
 	     clipmethod == CLIPMETHOD_PROVIDER && (
@@ -311,10 +311,7 @@ get_register(
     int		i;
 
 #if defined(FEAT_EVAL) && defined(HAVE_CLIPMETHOD)
-    if (name == '+')
-	call_clip_provider_request((char_u *)"+");
-    else if (name == '*')
-	call_clip_provider_request((char_u *)"*");
+    call_clip_provider_request(name);
 #endif
 #ifdef FEAT_CLIPBOARD
     if (clipmethod != CLIPMETHOD_PROVIDER)
@@ -651,10 +648,7 @@ do_execreg(
     execreg_lastc = regname;
 
 #if defined(FEAT_EVAL) && defined(HAVE_CLIPMETHOD)
-    if (regname == '+')
-	call_clip_provider_request((char_u *)"+");
-    else if (regname == '*')
-	call_clip_provider_request((char_u *)"*");
+    call_clip_provider_request(regname);
 #endif
 #ifdef FEAT_CLIPBOARD
     if (clipmethod != CLIPMETHOD_PROVIDER)
@@ -866,10 +860,7 @@ insert_reg(
 	return FAIL;
 
 #if defined(FEAT_EVAL) && defined(HAVE_CLIPMETHOD)
-    if (regname == '+')
-	call_clip_provider_request((char_u *)"+");
-    else if (regname == '*')
-	call_clip_provider_request((char_u *)"*");
+    call_clip_provider_request(regname);
 #endif
 #ifdef FEAT_CLIPBOARD
     if (clipmethod != CLIPMETHOD_PROVIDER)
@@ -1465,9 +1456,9 @@ op_yank(oparg_T *oap, int deleting, int mess)
 
 #if defined(FEAT_EVAL) && defined(HAVE_CLIPMETHOD)
     if (curr == &y_regs[REAL_PLUS_REGISTER])
-	call_clip_provider_set((char_u *)"+");
+	call_clip_provider_set('+');
     else if (curr == &y_regs[STAR_REGISTER])
-	call_clip_provider_set((char_u *)"*");
+	call_clip_provider_set('*');
 #endif
 
 #ifdef FEAT_CLIPBOARD
@@ -1645,10 +1636,7 @@ do_put(
     unsigned int cur_ve_flags = get_ve_flags();
 
 #if defined(FEAT_EVAL) && defined(HAVE_CLIPMETHOD)
-    if (regname == '+')
-	call_clip_provider_request((char_u *)"+");
-    else if (regname == '*')
-	call_clip_provider_request((char_u *)"*");
+    call_clip_provider_request(regname);
 #endif
 #ifdef FEAT_CLIPBOARD
     if (clipmethod != CLIPMETHOD_PROVIDER)
@@ -2487,6 +2475,10 @@ ex_display(exarg_T *eap)
 	arg = NULL;
     attr = HL_ATTR(HLF_8);
 
+#if defined(FEAT_EVAL) && defined(HAVE_CLIPMETHOD)
+    inc_clip_provider();
+#endif
+
     // Highlight title
     msg_puts_title(_("\nType Name Content"));
     for (i = -1; i < NUM_REGISTERS && !got_int; ++i)
@@ -2506,17 +2498,14 @@ ex_display(exarg_T *eap)
 #if defined(FEAT_EVAL) && defined(HAVE_CLIPMETHOD)
 		clipmethod != CLIPMETHOD_PROVIDER &&
 #endif
-		(name != '*' || vim_strchr(arg, '+') == NULL)
+		(name != '*' || vim_strchr(arg, '+' == NULL))
 #endif
 		)
 	    continue;	    // did not ask for this register
 
 
 #if defined(FEAT_EVAL) && defined(HAVE_CLIPMETHOD)
-	if (name == '+')
-	    call_clip_provider_request((char_u *)"+");
-	else if (name == '*')
-	    call_clip_provider_request((char_u *)"*");
+	call_clip_provider_request(name);
 #endif
 #ifdef FEAT_CLIPBOARD
 	if (clipmethod != CLIPMETHOD_PROVIDER)
@@ -2647,6 +2636,10 @@ ex_display(exarg_T *eap)
 	dis_msg(expr_line, FALSE);
     }
 #endif
+
+#if defined(FEAT_EVAL) && defined(HAVE_CLIPMETHOD)
+    dec_clip_provider();
+#endif
 }
 
 /*
@@ -2720,10 +2713,7 @@ get_reg_type(int regname, long *reglen)
     }
 
 #if defined(FEAT_EVAL) && defined(HAVE_CLIPMETHOD)
-    if (regname == '+')
-	call_clip_provider_request((char_u *)"+");
-    else if (regname == '*')
-	call_clip_provider_request((char_u *)"*");
+    call_clip_provider_request(regname);
 #endif
 # ifdef FEAT_CLIPBOARD
     if (clipmethod != CLIPMETHOD_PROVIDER)
@@ -2806,10 +2796,7 @@ get_reg_contents(int regname, int flags)
 	return NULL;
 
 #if defined(FEAT_EVAL) && defined(HAVE_CLIPMETHOD)
-    if (regname == '+')
-	call_clip_provider_request((char_u *)"+");
-    else if (regname == '*')
-	call_clip_provider_request((char_u *)"*");
+    call_clip_provider_request(regname);
 #endif
 # ifdef FEAT_CLIPBOARD
     if (clipmethod != CLIPMETHOD_PROVIDER)
@@ -2980,10 +2967,7 @@ write_reg_contents_lst(
     finish_write_reg(name, old_y_previous, old_y_current);
 
 #if defined(FEAT_EVAL) && defined(HAVE_CLIPMETHOD)
-    if (name == '+')
-	call_clip_provider_set((char_u *)"+");
-    else if (name == '*')
-	call_clip_provider_set((char_u *)"*");
+    call_clip_provider_set(name);
 #endif
 }
 
@@ -3061,10 +3045,7 @@ write_reg_contents_ex(
     finish_write_reg(name, old_y_previous, old_y_current);
 
 #if defined(FEAT_EVAL) && defined(HAVE_CLIPMETHOD)
-    if (name == '+')
-	call_clip_provider_set((char_u *)"+");
-    else if (name == '*')
-	call_clip_provider_set((char_u *)"*");
+    call_clip_provider_set(name);
 #endif
 }
 #endif	// FEAT_EVAL

--- a/src/register.c
+++ b/src/register.c
@@ -2389,7 +2389,7 @@ get_register_name(int num)
     // If there is only one clipboard, we only want the plus register to point
     // to the star register if the clipboard provider is not being used. If the
     // clipboard provider is being used, then both registers should be available
-    // no matter the plaform
+    // no matter the platform
     else if (clipmethod == CLIPMETHOD_PROVIDER && num == REAL_PLUS_REGISTER)
 	return '+';
     else if (clipmethod != CLIPMETHOD_PROVIDER && num == PLUS_REGISTER)

--- a/src/register.c
+++ b/src/register.c
@@ -190,11 +190,13 @@ valid_yank_reg(
 	    || regname == '"'
 	    || regname == '-'
 	    || regname == '_'
-#if defined(FEAT_CLIPBOARD)
+#if defined(FEAT_CLIPBOARD) // If +clipboard is enabled, then these registers
+			    // always exist.
 	    || regname == '*'
 	    || regname == '+'
 #elif  defined(HAVE_CLIPMETHOD) && defined(FEAT_EVAL)
-	    || (
+	    || ( // If -clipboard, then these registers only exist when
+		 // clipmethod is set to provider.
 	     clipmethod == CLIPMETHOD_PROVIDER && (
 		 regname == '*'
 		 || regname == '+'

--- a/src/register.c
+++ b/src/register.c
@@ -1419,41 +1419,6 @@ op_yank(oparg_T *oap, int deleting, int mess)
 	    decl(&curbuf->b_op_end);
     }
 
-#ifdef FEAT_CLIPBOARD
-    // If we were yanking to the '*' register, send result to clipboard.
-    // If no register was specified, and "unnamed" in 'clipboard', make a copy
-    // to the '*' register.
-    if (clip_star.available
-	    && (curr == &(y_regs[STAR_REGISTER])
-		|| (!deleting && oap->regname == 0
-		   && ((clip_unnamed | clip_unnamed_saved) & CLIP_UNNAMED))))
-    {
-	if (curr != &(y_regs[STAR_REGISTER]))
-	    // Copy the text from register 0 to the clipboard register.
-	    copy_yank_reg(&(y_regs[STAR_REGISTER]));
-
-	clip_own_selection(&clip_star);
-	clip_gen_set_selection(&clip_star);
-    }
-
-# if defined(FEAT_X11) || defined(FEAT_WAYLAND_CLIPBOARD)
-    // If we were yanking to the '+' register, send result to selection.
-    if (clip_plus.available
-	    && (curr == &(y_regs[PLUS_REGISTER])
-		|| (!deleting && oap->regname == 0
-		  && ((clip_unnamed | clip_unnamed_saved) &
-							  CLIP_UNNAMED_PLUS))))
-    {
-	if (curr != &(y_regs[PLUS_REGISTER]))
-	    // Copy the text from register 0 to the clipboard register.
-	    copy_yank_reg(&(y_regs[PLUS_REGISTER]));
-
-	clip_own_selection(&clip_plus);
-	clip_gen_set_selection(&clip_plus);
-    }
-# endif
-#endif
-
 #if defined(FEAT_EVAL) && defined(HAVE_CLIPMETHOD)
     if (curr == &y_regs[REAL_PLUS_REGISTER])
 	call_clip_provider_set('+');
@@ -1462,56 +1427,41 @@ op_yank(oparg_T *oap, int deleting, int mess)
 #endif
 
 #ifdef FEAT_CLIPBOARD
-    // If we were yanking to the '*' register, send result to clipboard.
-    // If no register was specified, and "unnamed" in 'clipboard', make a copy
-    // to the '*' register.
-    if (clipmethod != CLIPMETHOD_PROVIDER && clip_star.available
-	    && (curr == &(y_regs[STAR_REGISTER])
-		|| (!deleting && oap->regname == 0
-		    && ((clip_unnamed | clip_unnamed_saved) & CLIP_UNNAMED))))
+    if (clipmethod != CLIPMETHOD_PROVIDER)
     {
-	if (curr != &(y_regs[STAR_REGISTER]))
-	    // Copy the text from register 0 to the clipboard register.
-	    copy_yank_reg(&(y_regs[STAR_REGISTER]));
-
-	clip_own_selection(&clip_star);
-	clip_gen_set_selection(&clip_star);
-# if defined(FEAT_X11) || defined(FEAT_WAYLAND_CLIPBOARD)
-	did_star = TRUE;
-# endif
-    }
-
-# if defined(FEAT_X11) || defined(FEAT_WAYLAND_CLIPBOARD)
-    // If we were yanking to the '+' register, send result to selection.
-    // Also copy to the '*' register, in case auto-select is off.  But not when
-    // 'clipboard' has "unnamedplus" and not "unnamed"; and not when
-    // deleting and both "unnamedplus" and "unnamed".
-    if (clipmethod != CLIPMETHOD_PROVIDER && clip_plus.available
-	    && (curr == &(y_regs[PLUS_REGISTER])
-		|| (!deleting && oap->regname == 0
-		    && ((clip_unnamed | clip_unnamed_saved) &
-							    CLIP_UNNAMED_PLUS))))
-    {
-	if (curr != &(y_regs[PLUS_REGISTER]))
-	    // Copy the text from register 0 to the clipboard register.
-	    copy_yank_reg(&(y_regs[PLUS_REGISTER]));
-
-	clip_own_selection(&clip_plus);
-	clip_gen_set_selection(&clip_plus);
-	if (!clip_isautosel_star()
-		&& !clip_isautosel_plus()
-		&& !((clip_unnamed | clip_unnamed_saved) == CLIP_UNNAMED_PLUS)
-		&& !(deleting && (clip_unnamed | clip_unnamed_saved)
-					== (CLIP_UNNAMED | CLIP_UNNAMED_PLUS))
-		&& !did_star
-		&& curr == &(y_regs[PLUS_REGISTER]))
+	// If we were yanking to the '*' register, send result to clipboard. If
+	// no register was specified, and "unnamed" in 'clipboard', make a copy
+	// to the '*' register.
+	if (clip_star.available
+		&& (curr == &(y_regs[STAR_REGISTER])
+		    || (!deleting && oap->regname == 0
+			&& ((clip_unnamed | clip_unnamed_saved) & CLIP_UNNAMED))))
 	{
-	    copy_yank_reg(&(y_regs[STAR_REGISTER]));
+	    if (curr != &(y_regs[STAR_REGISTER]))
+		// Copy the text from register 0 to the clipboard register.
+		copy_yank_reg(&(y_regs[STAR_REGISTER]));
+
 	    clip_own_selection(&clip_star);
 	    clip_gen_set_selection(&clip_star);
 	}
-    }
+
+# if defined(FEAT_X11) || defined(FEAT_WAYLAND_CLIPBOARD)
+	// If we were yanking to the '+' register, send result to selection.
+	if (clip_plus.available
+		&& (curr == &(y_regs[PLUS_REGISTER])
+		    || (!deleting && oap->regname == 0
+			&& ((clip_unnamed | clip_unnamed_saved) &
+			    CLIP_UNNAMED_PLUS))))
+	{
+	    if (curr != &(y_regs[PLUS_REGISTER]))
+		// Copy the text from register 0 to the clipboard register.
+		copy_yank_reg(&(y_regs[PLUS_REGISTER]));
+
+	    clip_own_selection(&clip_plus);
+	    clip_gen_set_selection(&clip_plus);
+	}
 # endif
+    }
 #endif
 
 #if defined(FEAT_EVAL)

--- a/src/register.c
+++ b/src/register.c
@@ -266,14 +266,12 @@ get_yank_register(int regname, int writing)
 	    i = PLUS_REGISTER;
 	ret = TRUE;
     }
-#else
-    // When selection is not available, use register 0 instead of '*'
+#elif defined(FEAT_EVAL) && defined(HAVE_CLIPMETHOD)
     else if (regname == '*')
     {
 	i = STAR_REGISTER;
 	ret = TRUE;
     }
-    // When clipboard is not available, use register 0 instead of '+'
     else if (regname == '+')
     {
 	i = REAL_PLUS_REGISTER;

--- a/src/register.c
+++ b/src/register.c
@@ -190,9 +190,15 @@ valid_yank_reg(
 	    || regname == '"'
 	    || regname == '-'
 	    || regname == '_'
-#if defined(FEAT_CLIPBOARD) || (defined(HAVE_CLIPMETHOD) && defined(FEAT_EVAL))
+#if defined(FEAT_CLIPBOARD)
 	    || regname == '*'
 	    || regname == '+'
+#elif  defined(HAVE_CLIPMETHOD) && defined(FEAT_EVAL)
+	    || (
+	     clipmethod == CLIPMETHOD_PROVIDER && (
+		 regname == '*'
+		 || regname == '+'
+	    ))
 #endif
 #ifdef FEAT_DND
 	    || (!writing && regname == '~')
@@ -1618,9 +1624,9 @@ do_put(
 	call_clip_provider_request((char_u *)"+");
     else if (regname == '*')
 	call_clip_provider_request((char_u *)"*");
-    if (clipmethod != CLIPMETHOD_PROVIDER)
 #endif
 #ifdef FEAT_CLIPBOARD
+    if (clipmethod != CLIPMETHOD_PROVIDER)
     {
 	// Adjust register name for "unnamed" in 'clipboard'.
 	adjust_clip_reg(&regname);
@@ -2761,9 +2767,9 @@ get_reg_contents(int regname, int flags)
 	call_clip_provider_request((char_u *)"+");
     else if (regname == '*')
 	call_clip_provider_request((char_u *)"*");
-    if (clipmethod != CLIPMETHOD_PROVIDER)
 #endif
 # ifdef FEAT_CLIPBOARD
+    if (clipmethod != CLIPMETHOD_PROVIDER)
 	regname = may_get_selection(regname);
 # endif
 

--- a/src/structs.h
+++ b/src/structs.h
@@ -4897,8 +4897,10 @@ typedef enum {
 #  define NUM_REGISTERS		(PLUS_REGISTER + 1)
 # endif
 #else
-# ifdef STAR_REGISTER
-# define NUM_REGISTERS		REAL_PLUS_REGISTER + 1
+# ifdef HAVE_CLIPMETHOD
+#  define NUM_REGISTERS		REAL_PLUS_REGISTER + 1
+# else
+#  define NUM_REGISTERS		37
 # endif
 #endif
 

--- a/src/structs.h
+++ b/src/structs.h
@@ -4902,7 +4902,7 @@ typedef enum {
 # endif
 #else
 # ifdef HAVE_CLIPMETHOD
-#  define NUM_REGISTERS		REAL_PLUS_REGISTER + 1
+#  define NUM_REGISTERS		(REAL_PLUS_REGISTER + 1)
 # else
 #  define NUM_REGISTERS		37
 # endif

--- a/src/structs.h
+++ b/src/structs.h
@@ -4896,7 +4896,7 @@ typedef enum {
 # ifdef FEAT_DND
 #  define NUM_REGISTERS		(TILDE_REGISTER + 1)
 # else
-#  define NUM_REGISTERS		(PLUS_REGISTER + 1)
+#  define NUM_REGISTERS		(REAL_PLUS_REGISTER + 1)
 # endif
 #else
 # ifdef HAVE_CLIPMETHOD

--- a/src/structs.h
+++ b/src/structs.h
@@ -4882,6 +4882,8 @@ typedef enum {
 #  else
 #   define PLUS_REGISTER	STAR_REGISTER	    // there is only one
 #   ifdef FEAT_EVAL
+// If there is only star register, we want the clipboard provider to use the +
+// register instead for clipboard provider functionality.
 #    define REAL_PLUS_REGISTER	38
 #   endif
 #  endif

--- a/src/structs.h
+++ b/src/structs.h
@@ -4885,6 +4885,8 @@ typedef enum {
 // Make it so that if clipmethod is "none", the plus register is not available,
 // but if clipmethod is a provider, then expose the plus register for use.
 #    define REAL_PLUS_REGISTER	38
+#   else
+#    define REAL_PLUS_REGISTER	STAR_REGISTER
 #   endif
 #  endif
 #endif

--- a/src/structs.h
+++ b/src/structs.h
@@ -4882,8 +4882,8 @@ typedef enum {
 #  else
 #   define PLUS_REGISTER	STAR_REGISTER	    // there is only one
 #   ifdef FEAT_EVAL
-// If there is only star register, we want the clipboard provider to use the +
-// register instead for clipboard provider functionality.
+// Make it so that if clipmethod is "none", the plus register is not available,
+// but if clipmethod is a provider, then expose the plus register for use.
 #    define REAL_PLUS_REGISTER	38
 #   endif
 #  endif

--- a/src/structs.h
+++ b/src/structs.h
@@ -4874,12 +4874,16 @@ typedef enum {
 
 // Symbolic names for some registers.
 #define DELETION_REGISTER	36
-#ifdef FEAT_CLIPBOARD
+#if defined(FEAT_CLIPBOARD) || defined(HAVE_CLIPMETHOD)
 # define STAR_REGISTER		37
 #  if defined(FEAT_X11) || defined(FEAT_WAYLAND)
 #   define PLUS_REGISTER	38
+#   define REAL_PLUS_REGISTER	PLUS_REGISTER
 #  else
 #   define PLUS_REGISTER	STAR_REGISTER	    // there is only one
+#   ifdef FEAT_EVAL
+#    define REAL_PLUS_REGISTER	38
+#   endif
 #  endif
 #endif
 #ifdef FEAT_DND
@@ -4893,7 +4897,9 @@ typedef enum {
 #  define NUM_REGISTERS		(PLUS_REGISTER + 1)
 # endif
 #else
-# define NUM_REGISTERS		37
+# ifdef STAR_REGISTER
+# define NUM_REGISTERS		REAL_PLUS_REGISTER + 1
+# endif
 #endif
 
 // structure used by block_prep, op_delete and op_yank for blockwise operators

--- a/src/testdir/test_clipmethod.vim
+++ b/src/testdir/test_clipmethod.vim
@@ -217,10 +217,6 @@ func Test_clipmethod_provider()
   clipreset
   call assert_equal("none", v:clipmethod)
 
-  let g:b_available = 0
-  clipreset
-  call assert_equal("none", v:clipmethod)
-
   let g:a_available = 1
   let g:b_available = 1
   clipreset

--- a/src/testdir/test_clipmethod.vim
+++ b/src/testdir/test_clipmethod.vim
@@ -3,21 +3,26 @@
 source util/window_manager.vim
 
 CheckFeature clipboard_working
-CheckFeature xterm_clipboard
-CheckFeature wayland_clipboard
-CheckUnix
 
 " Test if no available clipmethod sets v:clipmethod to none and deinits clipboard
 func Test_no_clipmethod_sets_v_clipmethod_none()
+  CheckFeature xterm_clipboard
+  CheckFeature wayland_clipboard
+  CheckUnix
   CheckNotGui
 
   set clipmethod=
   call assert_equal("none", v:clipmethod)
   call assert_equal(0, has('clipboard_working'))
+
+  set clipmethod&
 endfunc
 
 " Test if method chosen is in line with clipmethod order
 func Test_clipmethod_order()
+  CheckFeature xterm_clipboard
+  CheckFeature wayland_clipboard
+  CheckUnix
   CheckNotGui
 
   set cpm=wayland,x11
@@ -60,6 +65,8 @@ func Test_clipmethod_order()
   call assert_equal("wayland", v:clipmethod)
 
   call EndWaylandCompositor(l:wayland_display)
+
+  set clipmethod&
 endfunc
 
 " Test if clipmethod is set to 'none' when gui is started
@@ -83,6 +90,9 @@ endfunc
 
 " Test if :clipreset switches methods when current one doesn't work
 func Test_clipreset_switches()
+  CheckFeature xterm_clipboard
+  CheckFeature wayland_clipboard
+  CheckUnix
   CheckNotGui
   CheckFeature clientserver
   CheckXServer
@@ -171,6 +181,52 @@ func Test_clipreset_switches()
     " existing, this why WaitForAssert() is used.
     call WaitForAssert({-> assert_equal(['SUCCESS'], readfile('Xtest'))}, 1000)
   endif
+
+  set clipmethod&
+endfunc
+
+func s:AAvailable()
+  return g:a_available
+endfunc
+
+func s:BAvailable()
+  return g:b_available
+endfunc
+
+" Test clipmethod when using provider
+func Test_clipmethod_provider()
+  CheckFeature clipboard_provider
+
+  let v:clipproviders["a"] = {
+        \ "available": function("s:AAvailable"),
+        \ }
+  let v:clipproviders["b"] = {
+        \ "available": function("s:BAvailable"),
+        \ }
+  let g:a_available = 1
+  let g:b_available = 1
+
+  set clipmethod=a,b
+  call assert_equal("a", v:clipmethod)
+
+  let g:a_available = 0
+  clipreset
+  call assert_equal("b", v:clipmethod)
+
+  let g:b_available = 0
+  clipreset
+  call assert_equal("none", v:clipmethod)
+
+  let g:b_available = 0
+  clipreset
+  call assert_equal("none", v:clipmethod)
+
+  let g:a_available = 1
+  let g:b_available = 1
+  clipreset
+  call assert_equal("a", v:clipmethod)
+
+  set clipmethod&
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_eval_stuff.vim
+++ b/src/testdir/test_eval_stuff.vim
@@ -880,6 +880,7 @@ endfunc
 " star register like normal.
 func Test_clipboard_provider_registers()
   CheckNotFeature unnamedplus
+  CheckFeature clipboard_working
 
   let v:clipproviders["test"] = {}
   set clipmethod=test

--- a/src/testdir/test_eval_stuff.vim
+++ b/src/testdir/test_eval_stuff.vim
@@ -852,6 +852,20 @@ func Test_clipboard_provider_paste()
   call assert_equal(["a", "list", "+"], getreg("+", 1, 1))
   call assert_equal(["a", "list", "*"], getreg("*", 1, 1))
 
+  " Test put
+  new
+
+  let g:vim_paste = "tuple"
+  put! *
+
+  call assert_equal(["a", "tuple", "*"], getline(1, 3))
+
+  put +
+
+  call assert_equal(["a", "tuple", "+"], getline(4, 6))
+
+  bw!
+
   set clipmethod&
 endfunc
 
@@ -897,6 +911,25 @@ func Test_clipboard_provider_copy()
   call assert_equal(["hello", "world!"], g:vim_copy.lines)
   call assert_equal("40", g:vim_copy.type)
 
+  " Test yanking
+  new
+
+  call setline(1, "TESTING")
+  yank *
+
+  call assert_equal("*",g:vim_copy.reg)
+  call assert_equal(["TESTING"], g:vim_copy.lines)
+  call assert_equal("V", g:vim_copy.type)
+
+  call setline(1, "TESTING2")
+  yank +
+
+  call assert_equal("+",g:vim_copy.reg)
+  call assert_equal(["TESTING2"], g:vim_copy.lines)
+  call assert_equal("V", g:vim_copy.type)
+
+  bw!
+
   set clipmethod&
 endfunc
 
@@ -904,7 +937,7 @@ endfunc
 " and that the clipboard provider feature exposes the + register only when
 " clipmethod is set to a provider. If not, then the plus register points to the
 " star register like normal.
-func Test_clipboard_provider_registers()
+func Test_clipboard_provider_no_unamedplus()
   CheckNotFeature unnamedplus
   CheckFeature clipboard_working
 
@@ -973,6 +1006,7 @@ func Test_clipboard_provider_sys_clipboard()
         \       '*': function("s:Copy")
         \   }
         \ }
+
   call setreg("*", "hello world from the * register!", "c")
   call assert_equal("hello world from the * register!", getreg("*"))
   call setreg("+", "hello world from the + register!", "c")
@@ -985,6 +1019,19 @@ func Test_clipboard_provider_sys_clipboard()
   call setreg("*", "hello world!", "c")
   call assert_equal(["a", "tuple", "*"], getreg("*", 1, 1))
   call assert_equal(["a", "tuple", "+"], getreg("+", 1, 1))
+
+  new
+  call setline(1, "TESTING")
+  yank *
+
+  call assert_equal("*",g:vim_copy.reg)
+  call assert_equal(["TESTING"], g:vim_copy.lines)
+  call assert_equal("V", g:vim_copy.type)
+
+  put *
+
+  call assert_equal(["TESTING", "a", "tuple", "*"], getline(1, 4))
+  bw!
 
   set clipmethod&
 

--- a/src/testdir/test_eval_stuff.vim
+++ b/src/testdir/test_eval_stuff.vim
@@ -798,7 +798,7 @@ func Test_clipboard_provider_available()
   clipreset
   call assert_notequal("test", v:clipmethod)
 
-  " Invalud return value
+  " Invalid return value
   let g:vim_cp_available = "invalid"
   call assert_fails('set clipmethod=test', "E474:")
   call assert_notequal("test", v:clipmethod)

--- a/src/testdir/test_eval_stuff.vim
+++ b/src/testdir/test_eval_stuff.vim
@@ -752,9 +752,6 @@ func s:Paste(reg)
   elseif l:t == "invalid2"
     return ("c", ["test", [1, 2]])
 
-  elseif l:t == "pass"
-    return ("pass", [])
-
   elseif l:t == "count"
     let g:vim_paste_count[a:reg] += 1
     return ("c", ["hello"])
@@ -843,14 +840,6 @@ func Test_clipboard_provider_paste()
   let g:vim_paste = "invalid2"
   call assert_fails('call getreg("+", 1, 1)', "E730:")
   call assert_fails('call getreg("*", 1, 1)', "E730:")
-
-  " Check if special "pass" regtype works properly
-  let g:vim_paste = "list"
-  call getreg("+", 1, 1)
-  call getreg("*", 1, 1)
-  let g:vim_paste = "pass"
-  call assert_equal(["a", "list", "+"], getreg("+", 1, 1))
-  call assert_equal(["a", "list", "*"], getreg("*", 1, 1))
 
   " Test put
   new

--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -526,7 +526,7 @@ func Test_set_completion_string_values()
     call assert_match('unnamed', getcompletion('set clipboard=', 'cmdline')[1])
   endif
   if exists('+clipmethod')
-    if has('unix') || has('vms')
+    if has('wayland_clipboard') || has('xterm_clipboard')
       call assert_match('wayland', getcompletion('set clipmethod=', 'cmdline')[1])
     else
       call assert_match('wayland', getcompletion('set clipmethod=', 'cmdline')[0])

--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -522,15 +522,21 @@ func Test_set_completion_string_values()
   call assert_equal('unload', getcompletion('set bufhidden=', 'cmdline')[1])
   call assert_equal('nowrite', getcompletion('set buftype=', 'cmdline')[1])
   call assert_equal('internal', getcompletion('set casemap=', 'cmdline')[1])
-  if exists('+clipboard')
+  if has('clipboard')
     call assert_match('unnamed', getcompletion('set clipboard=', 'cmdline')[1])
   endif
-  if exists('+clipmethod')
-    if has('wayland_clipboard') || has('xterm_clipboard')
-      call assert_match('wayland', getcompletion('set clipmethod=', 'cmdline')[1])
-    else
-      call assert_match('wayland', getcompletion('set clipmethod=', 'cmdline')[0])
-    endif
+  if has('wayland_clipboard')
+    call assert_match('wayland', getcompletion('set clipmethod=w', 'cmdline')[0])
+  endif
+  if has('xterm_clipboard')
+    call assert_match('x11', getcompletion('set clipmethod=x', 'cmdline')[0])
+  endif
+  if has('eval')
+    let v:clipproviders["first"] = {}
+    let v:clipproviders["second"] = {}
+
+    call assert_match('first', getcompletion('set clipmethod=f', 'cmdline')[0])
+    call assert_match('second', getcompletion('set clipmethod=s', 'cmdline')[0])
   endif
   call assert_equal('.', getcompletion('set complete=', 'cmdline')[1])
   call assert_equal('menu', getcompletion('set completeopt=', 'cmdline')[1])

--- a/src/version.c
+++ b/src/version.c
@@ -156,7 +156,7 @@ static char *(features[]) =
 #else
 	"-clipboard",
 #endif
-#ifdef FEAT_CLIPBOARD
+#ifdef FEAT_CLIPBOARD_PROVIDER
 	"+clipboard_provider",
 #else
 	"-clipboard_provider",

--- a/src/version.c
+++ b/src/version.c
@@ -156,6 +156,11 @@ static char *(features[]) =
 #else
 	"-clipboard",
 #endif
+#ifdef FEAT_CLIPBOARD
+	"+clipboard_provider",
+#else
+	"-clipboard_provider",
+#endif
 	"+cmdline_compl",
 	"+cmdline_hist",
 	"+cmdline_info",

--- a/src/vim.h
+++ b/src/vim.h
@@ -2260,7 +2260,8 @@ typedef int sock_T;
 #define VV_TERMDA1 114
 #define VV_TERMOSC 115
 #define VV_VIM_DID_INIT		116
-#define VV_LEN		117	// number of v: vars
+#define VV_CLIPBOARDS 117
+#define VV_LEN		118	// number of v: vars
 
 // used for v_number in VAR_BOOL and VAR_SPECIAL
 #define VVAL_FALSE	0L	// VAR_BOOL
@@ -2292,6 +2293,16 @@ typedef int sock_T;
 
 #define TABSTOP_MAX 9999
 
+#ifdef HAVE_CLIPMETHOD
+typedef enum {
+    CLIPMETHOD_FAIL,
+    CLIPMETHOD_NONE,
+    CLIPMETHOD_WAYLAND,
+    CLIPMETHOD_X11,
+    CLIPMETHOD_PROVIDER
+} clipmethod_T;
+#endif
+
 #ifdef FEAT_CLIPBOARD
 
 // VIM_ATOM_NAME is the older Vim-specific selection type for X11.  Still
@@ -2314,13 +2325,6 @@ typedef int sock_T;
 #   define WM_OLE (WM_APP+0)
 #  endif
 # endif
-
-typedef enum {
-    CLIPMETHOD_FAIL,
-    CLIPMETHOD_NONE,
-    CLIPMETHOD_WAYLAND,
-    CLIPMETHOD_X11,
-} clipmethod_T;
 
 // Info about selected text
 typedef struct

--- a/src/vim.h
+++ b/src/vim.h
@@ -2045,7 +2045,11 @@ typedef int sock_T;
 // The clipboard provider feature uses clipmethod as well but should be separate
 // from the clipboard code.
 #if defined(FEAT_CLIPBOARD) || defined(FEAT_EVAL)
-#define HAVE_CLIPMETHOD
+# define HAVE_CLIPMETHOD
+#endif
+
+#if defined(HAVE_CLIPMETHOD) && defined(FEAT_EVAL)
+# define FEAT_CLIPBOARD_PROVIDER
 #endif
 
 // Include option.h before structs.h, because the number of window-local and

--- a/src/vim.h
+++ b/src/vim.h
@@ -2266,7 +2266,7 @@ typedef int sock_T;
 #define VV_TERMDA1 114
 #define VV_TERMOSC 115
 #define VV_VIM_DID_INIT		116
-#define VV_CLIPBOARDS 117
+#define VV_CLIPPROVIDERS 117
 #define VV_LEN		118	// number of v: vars
 
 // used for v_number in VAR_BOOL and VAR_SPECIAL

--- a/src/vim.h
+++ b/src/vim.h
@@ -2042,6 +2042,12 @@ typedef __int64 sock_T;
 typedef int sock_T;
 #endif
 
+// The clipboard provider feature uses clipmethod as well but should be separate
+// from the clipboard code.
+#if defined(FEAT_CLIPBOARD) || defined(FEAT_EVAL)
+#define HAVE_CLIPMETHOD
+#endif
+
 // Include option.h before structs.h, because the number of window-local and
 // buffer-local options is used there.
 #include "option.h"	// options and default values

--- a/src/viminfo.c
+++ b/src/viminfo.c
@@ -1907,7 +1907,7 @@ write_viminfo_registers(FILE *fp)
 
     for (i = 0; i < NUM_REGISTERS; i++)
     {
-#if defined(FEAT_CLIPBOARD) || (defined(FEAT_EVAL) && defined(HAVE_CLIPMETHOD))
+#if defined(FEAT_CLIPBOARD) || defined(FEAT_CLIPBOARD_PROVIDER)
 	// Skip '*'/'+' register, we don't want them back next time
 	if (i == STAR_REGISTER || i == PLUS_REGISTER || i == REAL_PLUS_REGISTER)
 	    continue;

--- a/src/viminfo.c
+++ b/src/viminfo.c
@@ -1907,7 +1907,7 @@ write_viminfo_registers(FILE *fp)
 
     for (i = 0; i < NUM_REGISTERS; i++)
     {
-#ifdef FEAT_CLIPBOARD
+#if defined(FEAT_CLIPBOARD) || (defined(FEAT_EVAL) && defined(HAVE_CLIPMETHOD))
 	// Skip '*'/'+' register, we don't want them back next time
 	if (i == STAR_REGISTER || i == PLUS_REGISTER)
 	    continue;

--- a/src/viminfo.c
+++ b/src/viminfo.c
@@ -1909,7 +1909,7 @@ write_viminfo_registers(FILE *fp)
     {
 #if defined(FEAT_CLIPBOARD) || (defined(FEAT_EVAL) && defined(HAVE_CLIPMETHOD))
 	// Skip '*'/'+' register, we don't want them back next time
-	if (i == STAR_REGISTER || i == PLUS_REGISTER)
+	if (i == STAR_REGISTER || i == PLUS_REGISTER || i == REAL_PLUS_REGISTER)
 	    continue;
 #endif
 #ifdef FEAT_DND


### PR DESCRIPTION
Another try on the clipboard provider feature. The problem with the previous PR was that it tried fitting the clipboard provider code under `FEAT_CLIPBOARD`, which did not play out well.

In this PR, because the clipboard provider feature requires `clipmethod`, `clipmethod` is put under `HAVE_CLIPMETHOD`. The clipboard provider code is completely separate from the clipboard code, falling under `FEAT_EVAL` (though its in the same file).

This works for me under Windows 11 + Linux (without `+clipboard` and with `+clipboard`) without breaking the existing clipboard functionality. Couldn't find a way to compile Vim in Windows without clipboard support however.

Regarding what to do on platforms not Wayland/X11 based, which only have the star register, that behaviour stays the same. However, when clipmethod is a provider instead of "none", then both the star and plus registers become available for use. In both cases they are not saved in the viminfo file.

There are no weird "gui" or "other" values possible for v:clipmethod, the clipmethod option is still primarily for Wayland and X11, but has extended use for the clipboard provider feature.

Here is a sample script:
```vim
vim9script

def Available(): bool
    return true
enddef

def Set(reg: string, type: string, str: list<string>): void
    echom str
enddef

def Get(reg: string): tuple<string, list<string>>
    return ("l", ["hello"])
enddef

v:clipproviders["test"] = {
    "available": Available,
    "copy": {
        "+": Set,
        "*": Set
    },
    "paste": {
        "+": Get,
        "*": Get
    }
}

set clipmethod=test
```

I believe this resolves #17690 as well