### PR TITLE
Fix #18498: Remove 'completefuzzycollect' option

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -137,11 +137,8 @@ static compl_T    *compl_shown_match = NULL;
 static compl_T    *compl_old_match = NULL;
 
 // list used to store the compl_T which have the max score
-// used for completefuzzycollect
 static compl_T	  **compl_best_matches = NULL;
 static int	  compl_num_bests = 0;
-// inserted a longest when completefuzzycollect enabled
-static int	  compl_cfc_longest_ins = FALSE;
 
 // After using a cursor key <Enter> selects a match in the popup menu,
 // otherwise it inserts a line break.
@@ -2273,7 +2270,6 @@ ins_compl_clear(void)
 {
     compl_cont_status = 0;
     compl_started = FALSE;
-    compl_cfc_longest_ins = FALSE;
     compl_matches = 0;
     compl_selected_item = -1;
     compl_ins_end_col = 0;
@@ -4712,7 +4708,6 @@ fuzzy_longest_match(void)
     if (prefix != NULL)
     {
 	ins_compl_longest_insert(prefix);
-	compl_cfc_longest_ins = TRUE;
 	vim_free(prefix);
     }
 

--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -990,9 +990,8 @@ ins_compl_add(
 	current = compl_first_match->cp_next;
 	prev = compl_first_match;
 	inserted = FALSE;
-	// The direction is ignored when using longest and
-	// completefuzzycollect, because matches are inserted
-	// and sorted by score.
+	// The direction is ignored when using longest and fuzzy match, because
+	// matches are inserted and sorted by score.
 	while (current != NULL && current != compl_first_match)
 	{
 	    if (current->cp_score < score)

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -381,8 +381,8 @@ func Test_CompleteDone_vevent_keys()
   call assert_equal('foo_test', g:complete_word)
   call assert_equal('files', g:complete_type)
 
-  call writefile(['hello help'], 'test_case.txt', 'D')
-  set dictionary=test_case.txt
+  call writefile(['hello help'], 'Xtest_case.txt', 'D')
+  set dictionary=Xtest_case.txt
   call feedkeys("ggdGSh\<C-X>\<C-K>\<C-Y>\<Esc>", 'tx')
   call assert_equal('hello', g:complete_word)
   call assert_equal('dictionary', g:complete_type)
@@ -3533,6 +3533,7 @@ func Test_complete_opt_fuzzy()
   call feedkeys("i\<C-R>=CompAnother()\<CR>\<C-P>\<C-P>", 'tx')
   call assert_equal("for", g:abbr)
 
+  %d
   set cot=menu,fuzzy
   call feedkeys("Sblue\<CR>bar\<CR>b\<C-X>\<C-P>\<C-Y>\<ESC>", 'tx')
   call assert_equal('blue', getline('.'))
@@ -3565,7 +3566,7 @@ func Test_complete_opt_fuzzy()
   " Issue 18488: sort after collection when "fuzzy" (unless "nosort")
   %d
   set completeopt&
-  set completeopt+=fuzzy,noselect completefuzzycollect=keyword
+  set completeopt+=fuzzy,noselect
   func! PrintMenuWords()
     let info = complete_info(["items"])
     call map(info.items, {_, v -> v.word})
@@ -3578,7 +3579,7 @@ func Test_complete_opt_fuzzy()
   " clean up
   set omnifunc=
   bw!
-  set complete& completeopt& completefuzzycollect&
+  set complete& completeopt&
   autocmd! AAAAA_Group
   augroup! AAAAA_Group
   delfunc OnPumChange
@@ -3592,7 +3593,7 @@ endfunc
 
 func Test_complete_fuzzy_collect()
   new
-  set completefuzzycollect=keyword,files,whole_line
+  set completeopt+=fuzzy
   call setline(1, ['hello help hero h'])
   " Use "!" flag of feedkeys() so that ex_normal_busy is not set and
   " ins_compl_check_keys() is not skipped.
@@ -3670,7 +3671,7 @@ func Test_complete_fuzzy_collect()
   call assert_equal('no one can save me but you', getline('.'))
 
   " issue #15526
-  set completeopt=menuone,menu,noselect
+  set completeopt=menuone,menu,noselect,fuzzy
   call setline(1, ['Text', 'ToText', ''])
   call cursor(3, 1)
   call feedkeys("STe\<C-X>\<C-N>x\<CR>\<Esc>0", 'tx!')
@@ -3683,8 +3684,8 @@ func Test_complete_fuzzy_collect()
   call assert_equal('completefuzzycollect', getline(line('.') - 1))
 
   " keywords in 'dictonary'
-  call writefile(['hello', 'think'], 'test_dict.txt', 'D')
-  set dict=test_dict.txt
+  call writefile(['hello', 'think'], 'Xtest_dict.txt', 'D')
+  set dict=Xtest_dict.txt
   call feedkeys("Sh\<C-X>\<C-K>\<C-N>\<CR>\<Esc>0", 'tx!')
   call assert_equal('hello', getline(line('.') - 1))
   call feedkeys("Sh\<C-X>\<C-K>\<C-N>\<C-N>\<CR>\<Esc>0", 'tx!')
@@ -3699,16 +3700,26 @@ func Test_complete_fuzzy_collect()
   call feedkeys("Gofuzzy\<C-X>\<C-N>\<C-N>\<C-N>\<C-Y>\<Esc>0", 'tx!')
   call assert_equal('fuzzycollect', getline('.'))
 
+  " when 'fuzzy' is not set, and 'infercase' and 'ignorecase' are set, then
+  " uppercase completes from lowercase words in dictonary
+  set completeopt&
+  set infercase ignorecase
+  call writefile(['hello'], 'Xtest_case.txt', 'D')
+  set dictionary=Xtest_case.txt
+  call feedkeys("ggdGSH\<C-X>\<C-K>\<C-Y>\<Esc>", 'tx')
+  call assert_equal('Hello', getline('.'))
+  call feedkeys("ggdGSHE\<C-X>\<C-K>\<C-Y>\<Esc>", 'tx')
+  call assert_equal('HELLO', getline('.'))
+
   bw!
   bw!
   set dict&
-  set completeopt& cfc& cpt&
+  set completeopt& cpt& ignorecase& infercase&
 endfunc
 
 " Issue #18752
 func Test_complete_fuzzy_collect_multiwin()
   new
-  set completefuzzycollect=keyword,files,whole_line
   set completeopt=fuzzy
 
   vnew
@@ -3718,12 +3729,11 @@ func Test_complete_fuzzy_collect_multiwin()
   call assert_equal('Omnipotent', getline('.'))
 
   bw!
-  set completeopt& cfc&
+  set completeopt&
 endfunc
 
 func Test_cfc_with_longest()
   new
-  set completefuzzycollect=keyword,files,whole_line
   set completeopt=menu,menuone,longest,fuzzy
 
   " keyword
@@ -3807,7 +3817,6 @@ func Test_cfc_with_longest()
 
   bw!
   set completeopt&
-  set completefuzzycollect&
 endfunc
 
 func Test_completefuzzycollect_with_completeslash()
@@ -3817,7 +3826,7 @@ func Test_completefuzzycollect_with_completeslash()
   let orig_shellslash = &shellslash
   set cpt&
   new
-  set completefuzzycollect=files
+  set completeopt+=fuzzy
   set noshellslash
 
   " Test with completeslash unset
@@ -3839,7 +3848,6 @@ func Test_completefuzzycollect_with_completeslash()
   " Reset and clean up
   let &shellslash = orig_shellslash
   set completeslash=
-  set completefuzzycollect&
   %bw!
 endfunc
 

--- a/src/testdir/test_popup.vim
+++ b/src/testdir/test_popup.vim
@@ -1531,8 +1531,7 @@ endfunc
 func Test_pum_completefuzzycollect()
   CheckScreendump
   let lines =<< trim END
-    set completefuzzycollect=keyword,files
-    set completeopt=menu,menuone
+    set completeopt=menu,menuone,fuzzy
   END
   call writefile(lines, 'Xscript', 'D')
   let  buf = RunVimInTerminal('-S Xscript', {})


### PR DESCRIPTION
Fixes https://github.com/vim/vim/issues/18498

@chrisbra please merge your [changes](https://github.com/chrisbra/vim/commit/d4bad16ebc18c6a8807979d8aa0394a550f4703c#diff-07fd0fae719ed025bdbf970fc5e54df565983e2b9a2ec872062e5592a35633d9) into this before you merge to master.