### PR TITLE
xdiff: Fix Coverity warning with MAX_CNT/UINT_MAX usage

### DIFF
--- a/src/xdiff/xhistogram.c
+++ b/src/xdiff/xhistogram.c
@@ -122,7 +122,7 @@ static int scanA(struct histindex *index, int line1, int count1)
 				NEXT_PTR(index, ptr) = rec->ptr;
 				rec->ptr = ptr;
 				/* cap rec->cnt at MAX_CNT */
-				rec->cnt = XDL_MIN(MAX_CNT, rec->cnt + 1);
+				rec->cnt = (rec->cnt < MAX_CNT) ? rec->cnt + 1 : rec->cnt;
 				LINE_MAP(index, ptr) = rec;
 				goto continue_scan;
 			}


### PR DESCRIPTION
In the recent xdiff upstream sync (#18765), MAX_CNT in xhistogram was switched back to using UINT_MAX to match upstream. This exposed an issue in xdiff that using using min() to compare against the max integer will not work as the number will just overflow. Switch the check to be done in a saturating add that respects integer overflow.