### PR TITLE
runtime:compiler:feat: unify node-based makeprgs

### DIFF
--- a/runtime/compiler/biome.vim
+++ b/runtime/compiler/biome.vim
@@ -11,14 +11,12 @@ set cpo&vim
 
 " CompilerSet makeprg=biome
 " CompilerSet makeprg=npx\ biome
-if !empty(escape(get(b:, 'biome_makeprg', get(g:, 'biome_makeprg', ''))))
-  execute $'CompilerSet makeprg={escape(get(b:, 'biome_makeprg', get(g:, 'biome_makeprg', 'biome')), ' \|"')}'
-else
-  exe 'CompilerSet makeprg=' .. escape(
-			\ get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' @biomejs/biome'
-			\ .. ' check --linter-enabled=true --formatter-enabled=false --assist-enabled=false --reporter=github '
-      \ .. get(b:, 'biome_makeprg_params', get(g:, 'biome_makeprg_params', '')), ' \|"')
-endif
+exe 'CompilerSet makeprg=' .. escape(
+                      \ (!empty(get(b:, 'biome_makeprg', get(g:, 'biome_makeprg', ''))) ?
+                      \   get(b:, 'biome_makeprg', get(g:, 'biome_makeprg', '')) :
+		      \   (get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' @biomejs/biome'))
+		      \ .. ' check --linter-enabled=true --formatter-enabled=false --assist-enabled=false --reporter=github '
+                      \ .. get(b:, 'biome_makeprg_params', get(g:, 'biome_makeprg_params', '')), ' \|"')
 
 CompilerSet errorformat=::%trror%.%#file=%f\\,line=%l\\,%.%#col=%c\\,%.%#::%m
 CompilerSet errorformat+=::%tarning%.%#file=%f\\,line=%l\\,%.%#col=%c\\,%.%#::%m

--- a/runtime/compiler/biome.vim
+++ b/runtime/compiler/biome.vim
@@ -11,10 +11,14 @@ set cpo&vim
 
 " CompilerSet makeprg=biome
 " CompilerSet makeprg=npx\ biome
-exe 'CompilerSet makeprg=' .. escape(
+if !empty(escape(get(b:, 'biome_makeprg', get(g:, 'biome_makeprg', ''))))
+  execute $'CompilerSet makeprg={escape(get(b:, 'biome_makeprg', get(g:, 'biome_makeprg', 'biome')), ' \|"')}'
+else
+  exe 'CompilerSet makeprg=' .. escape(
 			\ get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' @biomejs/biome'
 			\ .. ' check --linter-enabled=true --formatter-enabled=false --assist-enabled=false --reporter=github '
       \ .. get(b:, 'biome_makeprg_params', get(g:, 'biome_makeprg_params', '')), ' \|"')
+endif
 
 CompilerSet errorformat=::%trror%.%#file=%f\\,line=%l\\,%.%#col=%c\\,%.%#::%m
 CompilerSet errorformat+=::%tarning%.%#file=%f\\,line=%l\\,%.%#col=%c\\,%.%#::%m

--- a/runtime/compiler/biome.vim
+++ b/runtime/compiler/biome.vim
@@ -2,14 +2,18 @@
 " Compiler:     Biome (= linter for JavaScript, TypeScript, JSX, TSX, JSON,
 "               JSONC, HTML, Vue, Svelte, Astro, CSS, GraphQL and GritQL files)
 " Maintainer:   @Konfekt
-" Last Change:  2025 Nov 12
+" Last Change:  2025 Nov 16
 if exists("current_compiler") | finish | endif
 let current_compiler = "biome"
 
 let s:cpo_save = &cpo
 set cpo&vim
 
-exe 'CompilerSet makeprg=' .. escape('biome check --linter-enabled=true --formatter-enabled=false --assist-enabled=false --reporter=github '
+" CompilerSet makeprg=biome
+" CompilerSet makeprg=npx\ biome
+exe 'CompilerSet makeprg=' .. escape(
+			\ get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' @biomejs/biome'
+			\ .. ' check --linter-enabled=true --formatter-enabled=false --assist-enabled=false --reporter=github '
       \ .. get(b:, 'biome_makeprg_params', get(g:, 'biome_makeprg_params', '')), ' \|"')
 
 CompilerSet errorformat=::%trror%.%#file=%f\\,line=%l\\,%.%#col=%c\\,%.%#::%m

--- a/runtime/compiler/biome.vim
+++ b/runtime/compiler/biome.vim
@@ -14,7 +14,7 @@ set cpo&vim
 exe 'CompilerSet makeprg=' .. escape(
                       \ (!empty(get(b:, 'biome_makeprg', get(g:, 'biome_makeprg', ''))) ?
                       \   get(b:, 'biome_makeprg', get(g:, 'biome_makeprg', '')) :
-		      \   (get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' @biomejs/biome'))
+		      \   (get(b:, 'javascript_node_makeprg', get(g:, 'javascript_node_makeprg', 'npx')) .. ' @biomejs/biome'))
 		      \ .. ' check --linter-enabled=true --formatter-enabled=false --assist-enabled=false --reporter=github '
                       \ .. get(b:, 'biome_makeprg_params', get(g:, 'biome_makeprg_params', '')), ' \|"')
 

--- a/runtime/compiler/biome.vim
+++ b/runtime/compiler/biome.vim
@@ -14,8 +14,8 @@ set cpo&vim
 exe 'CompilerSet makeprg=' .. escape(
                       \ (!empty(get(b:, 'biome_makeprg', get(g:, 'biome_makeprg', ''))) ?
                       \   get(b:, 'biome_makeprg', get(g:, 'biome_makeprg', '')) :
-		      \   (get(b:, 'javascript_node_makeprg', get(g:, 'javascript_node_makeprg', 'npx')) .. ' @biomejs/biome'))
-		      \ .. ' check --linter-enabled=true --formatter-enabled=false --assist-enabled=false --reporter=github '
+                      \   (get(b:, 'javascript_node_makeprg', get(g:, 'javascript_node_makeprg', 'npx')) .. ' @biomejs/biome'))
+                      \ .. ' check --linter-enabled=true --formatter-enabled=false --assist-enabled=false --reporter=github '
                       \ .. get(b:, 'biome_makeprg_params', get(g:, 'biome_makeprg_params', '')), ' \|"')
 
 CompilerSet errorformat=::%trror%.%#file=%f\\,line=%l\\,%.%#col=%c\\,%.%#::%m

--- a/runtime/compiler/csslint.vim
+++ b/runtime/compiler/csslint.vim
@@ -15,7 +15,7 @@ let current_compiler = "csslint"
 exe 'CompilerSet makeprg=' .. escape(
                       \ (!empty(get(b:, 'csslint_makeprg', get(g:, 'csslint_makeprg', ''))) ?
                       \   get(b:, 'csslint_makeprg', get(g:, 'csslint_makeprg', '')) :
-		      \   (get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' csslint'))
+		      \   (get(b:, 'javascript_node_makeprg', get(g:, 'javascript_node_makeprg', 'npx')) .. ' csslint'))
 		      \ .. ' --format=compact ' ..
                       \ get(b:, 'csslint_makeprg_params', get(g:, 'csslint_makeprg_params', '')), ' \|"')
 

--- a/runtime/compiler/csslint.vim
+++ b/runtime/compiler/csslint.vim
@@ -12,13 +12,11 @@ let current_compiler = "csslint"
 
 " CompilerSet makeprg=csslint
 " CompilerSet makeprg=npx\ csslint
-if !empty(escape(get(b:, 'csslint_makeprg', get(g:, 'csslint_makeprg', ''))))
-  execute $'CompilerSet makeprg={escape(get(b:, 'csslint_makeprg', get(g:, 'csslint_makeprg', 'csslint')), ' \|"')}'
-else
-  exe 'CompilerSet makeprg=' .. escape(
-			\ get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' csslint' ..
-			\ ' --format=compact ' ..
-                        \ get(b:, 'csslint_makeprg_params', get(g:, 'csslint_makeprg_params', '')), ' \|"')
-endif
+exe 'CompilerSet makeprg=' .. escape(
+                      \ (!empty(get(b:, 'csslint_makeprg', get(g:, 'csslint_makeprg', ''))) ?
+                      \   get(b:, 'csslint_makeprg', get(g:, 'csslint_makeprg', '')) :
+		      \   (get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' csslint'))
+		      \ .. ' --format=compact ' ..
+                      \ get(b:, 'csslint_makeprg_params', get(g:, 'csslint_makeprg_params', '')), ' \|"')
 
 CompilerSet errorformat=%-G,%-G%f:\ lint\ free!,%f:\ line\ %l\\,\ col\ %c\\,\ %trror\ -\ %m,%f:\ line\ %l\\,\ col\ %c\\,\ %tarning\ -\ %m,%f:\ line\ %l\\,\ col\ %c\\,\ %m

--- a/runtime/compiler/csslint.vim
+++ b/runtime/compiler/csslint.vim
@@ -12,9 +12,13 @@ let current_compiler = "csslint"
 
 " CompilerSet makeprg=csslint
 " CompilerSet makeprg=npx\ csslint
-exe 'CompilerSet makeprg=' .. escape(
+if !empty(escape(get(b:, 'csslint_makeprg', get(g:, 'csslint_makeprg', ''))))
+  execute $'CompilerSet makeprg={escape(get(b:, 'csslint_makeprg', get(g:, 'csslint_makeprg', 'csslint')), ' \|"')}'
+else
+  exe 'CompilerSet makeprg=' .. escape(
 			\ get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' csslint' ..
 			\ ' --format=compact ' ..
                         \ get(b:, 'csslint_makeprg_params', get(g:, 'csslint_makeprg_params', '')), ' \|"')
+endif
 
 CompilerSet errorformat=%-G,%-G%f:\ lint\ free!,%f:\ line\ %l\\,\ col\ %c\\,\ %trror\ -\ %m,%f:\ line\ %l\\,\ col\ %c\\,\ %tarning\ -\ %m,%f:\ line\ %l\\,\ col\ %c\\,\ %m

--- a/runtime/compiler/csslint.vim
+++ b/runtime/compiler/csslint.vim
@@ -3,11 +3,18 @@
 " Maintainer:	Daniel Moch <daniel@danielmoch.com>
 " Last Change:	2016 May 21
 "		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
+"               2025 Nov 22 by The Vim Project (default to npx)
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "csslint"
 
-CompilerSet makeprg=csslint\ --format=compact
+" CompilerSet makeprg=csslint
+" CompilerSet makeprg=npx\ csslint
+exe 'CompilerSet makeprg=' .. escape(
+			\ get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' csslint' ..
+			\ ' --format=compact ' ..
+                        \ get(b:, 'csslint_makeprg_params', get(g:, 'csslint_makeprg_params', '')), ' \|"')
+
 CompilerSet errorformat=%-G,%-G%f:\ lint\ free!,%f:\ line\ %l\\,\ col\ %c\\,\ %trror\ -\ %m,%f:\ line\ %l\\,\ col\ %c\\,\ %tarning\ -\ %m,%f:\ line\ %l\\,\ col\ %c\\,\ %m

--- a/runtime/compiler/csslint.vim
+++ b/runtime/compiler/csslint.vim
@@ -1,9 +1,10 @@
 " Vim compiler file
-" Compiler:     csslint for CSS
-" Maintainer:   Daniel Moch <daniel@danielmoch.com>
-" Last Change:  2016 May 21
-"               2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
-"               2025 Nov 22 by The Vim Project (default to npx)
+" Compiler:             csslint for CSS
+" Previous Maintainer:  Daniel Moch <daniel@danielmoch.com>
+" Last Change:          2016 May 21
+"                       2024 Apr 03 by The Vim Project (removed :CompilerSet
+"                       definition)
+"                       2025 Nov 22 by The Vim Project (default to npx)
 
 if exists("current_compiler")
   finish

--- a/runtime/compiler/csslint.vim
+++ b/runtime/compiler/csslint.vim
@@ -1,8 +1,8 @@
 " Vim compiler file
-" Compiler:	csslint for CSS
-" Maintainer:	Daniel Moch <daniel@danielmoch.com>
-" Last Change:	2016 May 21
-"		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
+" Compiler:     csslint for CSS
+" Maintainer:   Daniel Moch <daniel@danielmoch.com>
+" Last Change:  2016 May 21
+"               2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 "               2025 Nov 22 by The Vim Project (default to npx)
 
 if exists("current_compiler")
@@ -15,8 +15,8 @@ let current_compiler = "csslint"
 exe 'CompilerSet makeprg=' .. escape(
                       \ (!empty(get(b:, 'csslint_makeprg', get(g:, 'csslint_makeprg', ''))) ?
                       \   get(b:, 'csslint_makeprg', get(g:, 'csslint_makeprg', '')) :
-		      \   (get(b:, 'javascript_node_makeprg', get(g:, 'javascript_node_makeprg', 'npx')) .. ' csslint'))
-		      \ .. ' --format=compact ' ..
+                      \   (get(b:, 'javascript_node_makeprg', get(g:, 'javascript_node_makeprg', 'npx')) .. ' csslint'))
+                      \ .. ' --format=compact ' ..
                       \ get(b:, 'csslint_makeprg_params', get(g:, 'csslint_makeprg_params', '')), ' \|"')
 
 CompilerSet errorformat=%-G,%-G%f:\ lint\ free!,%f:\ line\ %l\\,\ col\ %c\\,\ %trror\ -\ %m,%f:\ line\ %l\\,\ col\ %c\\,\ %tarning\ -\ %m,%f:\ line\ %l\\,\ col\ %c\\,\ %m

--- a/runtime/compiler/eslint.vim
+++ b/runtime/compiler/eslint.vim
@@ -14,7 +14,7 @@ let current_compiler = "eslint"
 exe 'CompilerSet makeprg=' .. escape(
 			\ (!empty(get(b:, 'eslint_makeprg', get(g:, 'eslint_makeprg', ''))) ?
 			\   get(b:, 'eslint_makeprg', get(g:, 'eslint_makeprg', '')) :
-			\   (get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' eslint'))
+			\   (get(b:, 'javascript_node_makeprg', get(g:, 'javascript_node_makeprg', 'npx')) .. ' eslint'))
 			\ .. ' --format stylish ' ..
                         \ get(b:, 'eslint_makeprg_params', get(g:, 'eslint_makeprg_params', '')), ' \|"')
 CompilerSet errorformat=%-P%f,\%\\s%#%l:%c\ %#\ %trror\ \ %m,\%\\s%#%l:%c\ %#\ %tarning\ \ %m,\%-Q,\%-G%.%#,

--- a/runtime/compiler/eslint.vim
+++ b/runtime/compiler/eslint.vim
@@ -11,12 +11,10 @@ let current_compiler = "eslint"
 
 " CompilerSet makeprg=eslint
 " CompilerSet makeprg=npx\ eslint
-if !empty(escape(get(b:, 'eslint_makeprg', get(g:, 'eslint_makeprg', ''))))
-  execute $'CompilerSet makeprg={escape(get(b:, 'eslint_makeprg', get(g:, 'eslint_makeprg', 'eslint')), ' \|"')}'
-else
-  exe 'CompilerSet makeprg=' .. escape(
-			\ get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' eslint' ..
-			\ ' --format stylish ' ..
+exe 'CompilerSet makeprg=' .. escape(
+			\ (!empty(get(b:, 'eslint_makeprg', get(g:, 'eslint_makeprg', ''))) ?
+			\   get(b:, 'eslint_makeprg', get(g:, 'eslint_makeprg', '')) :
+			\   (get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' eslint'))
+			\ .. ' --format stylish ' ..
                         \ get(b:, 'eslint_makeprg_params', get(g:, 'eslint_makeprg_params', '')), ' \|"')
-endif
 CompilerSet errorformat=%-P%f,\%\\s%#%l:%c\ %#\ %trror\ \ %m,\%\\s%#%l:%c\ %#\ %tarning\ \ %m,\%-Q,\%-G%.%#,

--- a/runtime/compiler/eslint.vim
+++ b/runtime/compiler/eslint.vim
@@ -11,8 +11,12 @@ let current_compiler = "eslint"
 
 " CompilerSet makeprg=eslint
 " CompilerSet makeprg=npx\ eslint
-exe 'CompilerSet makeprg=' .. escape(
+if !empty(escape(get(b:, 'eslint_makeprg', get(g:, 'eslint_makeprg', ''))))
+  execute $'CompilerSet makeprg={escape(get(b:, 'eslint_makeprg', get(g:, 'eslint_makeprg', 'eslint')), ' \|"')}'
+else
+  exe 'CompilerSet makeprg=' .. escape(
 			\ get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' eslint' ..
 			\ ' --format stylish ' ..
                         \ get(b:, 'eslint_makeprg_params', get(g:, 'eslint_makeprg_params', '')), ' \|"')
+endif
 CompilerSet errorformat=%-P%f,\%\\s%#%l:%c\ %#\ %trror\ \ %m,\%\\s%#%l:%c\ %#\ %tarning\ \ %m,\%-Q,\%-G%.%#,

--- a/runtime/compiler/eslint.vim
+++ b/runtime/compiler/eslint.vim
@@ -2,11 +2,17 @@
 " Compiler:    ESLint for JavaScript
 " Maintainer:  Romain Lafourcade <romainlafourcade@gmail.com>
 " Last Change: 2024 Nov 30
+"              2025 Nov 22 by The Vim Project (default to npx)
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "eslint"
 
-CompilerSet makeprg=npx\ eslint\ --format\ stylish
+" CompilerSet makeprg=eslint
+" CompilerSet makeprg=npx\ eslint
+exe 'CompilerSet makeprg=' .. escape(
+			\ get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' eslint' ..
+			\ ' --format stylish ' ..
+                        \ get(b:, 'eslint_makeprg_params', get(g:, 'eslint_makeprg_params', '')), ' \|"')
 CompilerSet errorformat=%-P%f,\%\\s%#%l:%c\ %#\ %trror\ \ %m,\%\\s%#%l:%c\ %#\ %tarning\ \ %m,\%-Q,\%-G%.%#,

--- a/runtime/compiler/eslint.vim
+++ b/runtime/compiler/eslint.vim
@@ -12,9 +12,9 @@ let current_compiler = "eslint"
 " CompilerSet makeprg=eslint
 " CompilerSet makeprg=npx\ eslint
 exe 'CompilerSet makeprg=' .. escape(
-			\ (!empty(get(b:, 'eslint_makeprg', get(g:, 'eslint_makeprg', ''))) ?
-			\   get(b:, 'eslint_makeprg', get(g:, 'eslint_makeprg', '')) :
-			\   (get(b:, 'javascript_node_makeprg', get(g:, 'javascript_node_makeprg', 'npx')) .. ' eslint'))
-			\ .. ' --format stylish ' ..
+                        \ (!empty(get(b:, 'eslint_makeprg', get(g:, 'eslint_makeprg', ''))) ?
+                        \   get(b:, 'eslint_makeprg', get(g:, 'eslint_makeprg', '')) :
+                        \   (get(b:, 'javascript_node_makeprg', get(g:, 'javascript_node_makeprg', 'npx')) .. ' eslint'))
+                        \ .. ' --format stylish ' ..
                         \ get(b:, 'eslint_makeprg_params', get(g:, 'eslint_makeprg_params', '')), ' \|"')
 CompilerSet errorformat=%-P%f,\%\\s%#%l:%c\ %#\ %trror\ \ %m,\%\\s%#%l:%c\ %#\ %tarning\ \ %m,\%-Q,\%-G%.%#,

--- a/runtime/compiler/jest.vim
+++ b/runtime/compiler/jest.vim
@@ -2,6 +2,7 @@
 " Compiler:	Jest
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:	2024 Apr 03
+" Last Change:  2025 Nov 22 by The Vim Project (default to npx)
 
 if exists("current_compiler")
   finish
@@ -13,7 +14,12 @@ set cpo&vim
 
 " CompilerSet makeprg=npx\ --no-install\ jest\ --no-colors
 
-CompilerSet makeprg=jest\ --no-colors
+" CompilerSet makeprg=jest
+" CompilerSet makeprg=npx\ jest
+exe 'CompilerSet makeprg=' .. escape(
+			\ get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' jest' ..
+			\ ' --no-colors ' ..
+                        \ get(b:, 'jest_makeprg_params', get(g:, 'jest_makeprg_params', '')), ' \|"')
 CompilerSet errorformat=%-A\ \ ●\ Console,
 		       \%E\ \ ●\ %m,
 		       \%Z\ %\\{4}%.%#Error:\ %f:\ %m\ (%l:%c):%\\=,

--- a/runtime/compiler/jest.vim
+++ b/runtime/compiler/jest.vim
@@ -19,7 +19,7 @@ set cpo&vim
 exe 'CompilerSet makeprg=' .. escape(
 			\ (!empty(get(b:, 'jest_makeprg', get(g:, 'jest_makeprg', ''))) ?
 			\   get(b:, 'jest_makeprg', get(g:, 'jest_makeprg', '')) :
-			\   (get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' jest'))
+			\   (get(b:, 'javascript_node_makeprg', get(g:, 'javascript_node_makeprg', 'npx')) .. ' jest'))
 			\ .. ' --no-colors ' ..
                         \ get(b:, 'jest_makeprg_params', get(g:, 'jest_makeprg_params', '')), ' \|"')
 CompilerSet errorformat=%-A\ \ ●\ Console,

--- a/runtime/compiler/jest.vim
+++ b/runtime/compiler/jest.vim
@@ -23,14 +23,14 @@ exe 'CompilerSet makeprg=' .. escape(
                         \ .. ' --no-colors ' ..
                         \ get(b:, 'jest_makeprg_params', get(g:, 'jest_makeprg_params', '')), ' \|"')
 CompilerSet errorformat=%-A\ \ ●\ Console,
-                       \%E\ \ ●\ %m,
-                       \%Z\ %\\{4}%.%#Error:\ %f:\ %m\ (%l:%c):%\\=,
-                       \%Z\ %\\{6}at\ %\\S%#\ (%f:%l:%c),
-                       \%Z\ %\\{6}at\ %\\S%#\ %f:%l:%c,
-                       \%+C\ %\\{4}%\\w%.%#,
-                       \%+C\ %\\{4}%[-+]%.%#,
-                       \%-C%.%#,
-                       \%-G%.%#
+		       \%E\ \ ●\ %m,
+		       \%Z\ %\\{4}%.%#Error:\ %f:\ %m\ (%l:%c):%\\=,
+		       \%Z\ %\\{6}at\ %\\S%#\ (%f:%l:%c),
+		       \%Z\ %\\{6}at\ %\\S%#\ %f:%l:%c,
+		       \%+C\ %\\{4}%\\w%.%#,
+		       \%+C\ %\\{4}%[-+]%.%#,
+		       \%-C%.%#,
+		       \%-G%.%#
 
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/runtime/compiler/jest.vim
+++ b/runtime/compiler/jest.vim
@@ -16,14 +16,12 @@ set cpo&vim
 
 " CompilerSet makeprg=jest
 " CompilerSet makeprg=npx\ jest
-if !empty(escape(get(b:, 'jest_makeprg', get(g:, 'jest_makeprg', ''))))
-  execute $'CompilerSet makeprg={escape(get(b:, 'jest_makeprg', get(g:, 'jest_makeprg', 'jest')), ' \|"')}'
-else
-  exe 'CompilerSet makeprg=' .. escape(
-			\ get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' jest' ..
-			\ ' --no-colors ' ..
+exe 'CompilerSet makeprg=' .. escape(
+			\ (!empty(get(b:, 'jest_makeprg', get(g:, 'jest_makeprg', ''))) ?
+			\   get(b:, 'jest_makeprg', get(g:, 'jest_makeprg', '')) :
+			\   (get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' jest'))
+			\ .. ' --no-colors ' ..
                         \ get(b:, 'jest_makeprg_params', get(g:, 'jest_makeprg_params', '')), ' \|"')
-endif
 CompilerSet errorformat=%-A\ \ ●\ Console,
 		       \%E\ \ ●\ %m,
 		       \%Z\ %\\{4}%.%#Error:\ %f:\ %m\ (%l:%c):%\\=,

--- a/runtime/compiler/jest.vim
+++ b/runtime/compiler/jest.vim
@@ -1,7 +1,7 @@
 " Vim compiler file
-" Compiler:	Jest
-" Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2024 Apr 03
+" Compiler:     Jest
+" Maintainer:   Doug Kearns <dougkearns@gmail.com>
+" Last Change:  2024 Apr 03
 " Last Change:  2025 Nov 22 by The Vim Project (default to npx)
 
 if exists("current_compiler")
@@ -17,20 +17,20 @@ set cpo&vim
 " CompilerSet makeprg=jest
 " CompilerSet makeprg=npx\ jest
 exe 'CompilerSet makeprg=' .. escape(
-			\ (!empty(get(b:, 'jest_makeprg', get(g:, 'jest_makeprg', ''))) ?
-			\   get(b:, 'jest_makeprg', get(g:, 'jest_makeprg', '')) :
-			\   (get(b:, 'javascript_node_makeprg', get(g:, 'javascript_node_makeprg', 'npx')) .. ' jest'))
-			\ .. ' --no-colors ' ..
+                        \ (!empty(get(b:, 'jest_makeprg', get(g:, 'jest_makeprg', ''))) ?
+                        \   get(b:, 'jest_makeprg', get(g:, 'jest_makeprg', '')) :
+                        \   (get(b:, 'javascript_node_makeprg', get(g:, 'javascript_node_makeprg', 'npx')) .. ' jest'))
+                        \ .. ' --no-colors ' ..
                         \ get(b:, 'jest_makeprg_params', get(g:, 'jest_makeprg_params', '')), ' \|"')
 CompilerSet errorformat=%-A\ \ ●\ Console,
-		       \%E\ \ ●\ %m,
-		       \%Z\ %\\{4}%.%#Error:\ %f:\ %m\ (%l:%c):%\\=,
-		       \%Z\ %\\{6}at\ %\\S%#\ (%f:%l:%c),
-		       \%Z\ %\\{6}at\ %\\S%#\ %f:%l:%c,
-		       \%+C\ %\\{4}%\\w%.%#,
-		       \%+C\ %\\{4}%[-+]%.%#,
-		       \%-C%.%#,
-		       \%-G%.%#
+                       \%E\ \ ●\ %m,
+                       \%Z\ %\\{4}%.%#Error:\ %f:\ %m\ (%l:%c):%\\=,
+                       \%Z\ %\\{6}at\ %\\S%#\ (%f:%l:%c),
+                       \%Z\ %\\{6}at\ %\\S%#\ %f:%l:%c,
+                       \%+C\ %\\{4}%\\w%.%#,
+                       \%+C\ %\\{4}%[-+]%.%#,
+                       \%-C%.%#,
+                       \%-G%.%#
 
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/runtime/compiler/jest.vim
+++ b/runtime/compiler/jest.vim
@@ -16,10 +16,14 @@ set cpo&vim
 
 " CompilerSet makeprg=jest
 " CompilerSet makeprg=npx\ jest
-exe 'CompilerSet makeprg=' .. escape(
+if !empty(escape(get(b:, 'jest_makeprg', get(g:, 'jest_makeprg', ''))))
+  execute $'CompilerSet makeprg={escape(get(b:, 'jest_makeprg', get(g:, 'jest_makeprg', 'jest')), ' \|"')}'
+else
+  exe 'CompilerSet makeprg=' .. escape(
 			\ get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' jest' ..
 			\ ' --no-colors ' ..
                         \ get(b:, 'jest_makeprg_params', get(g:, 'jest_makeprg_params', '')), ' \|"')
+endif
 CompilerSet errorformat=%-A\ \ ●\ Console,
 		       \%E\ \ ●\ %m,
 		       \%Z\ %\\{4}%.%#Error:\ %f:\ %m\ (%l:%c):%\\=,

--- a/runtime/compiler/jshint.vim
+++ b/runtime/compiler/jshint.vim
@@ -2,6 +2,7 @@
 " Compiler:	JSHint
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:	2024 Apr 03
+" Last Change:  2025 Nov 22 by The Vim Project (default to npx)
 
 if exists("current_compiler")
   finish
@@ -13,7 +14,12 @@ set cpo&vim
 
 " CompilerSet makeprg=npx\ jshint\ --verbose
 
-CompilerSet makeprg=jshint\ --verbose
+" CompilerSet makeprg=jshint
+" CompilerSet makeprg=npx\ jshint
+exe 'CompilerSet makeprg=' .. escape(
+			\ get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' jshint' ..
+			\ ' --verbose ' ..
+                        \ get(b:, 'jshint_makeprg_params', get(g:, 'jshint_makeprg_params', '')), ' \|"')
 CompilerSet errorformat=%f:\ line\ %l\\,\ col\ %c\\,\ %m\ (%t%n),
 		       \%-G%.%#
 

--- a/runtime/compiler/jshint.vim
+++ b/runtime/compiler/jshint.vim
@@ -16,14 +16,12 @@ set cpo&vim
 
 " CompilerSet makeprg=jshint
 " CompilerSet makeprg=npx\ jshint
-if !empty(escape(get(b:, 'jshint_makeprg', get(g:, 'jshint_makeprg', ''))))
-  execute $'CompilerSet makeprg={escape(get(b:, 'jshint_makeprg', get(g:, 'jshint_makeprg', 'jshint')), ' \|"')}'
-else
-  exe 'CompilerSet makeprg=' .. escape(
-			\ get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' jshint' ..
-			\ ' --verbose ' ..
+exe 'CompilerSet makeprg=' .. escape(
+			\ (!empty(get(b:, 'jshint_makeprg', get(g:, 'jshint_makeprg', ''))) ?
+			\   get(b:, 'jshint_makeprg', get(g:, 'jshint_makeprg', '')) :
+			\   (get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' jshint'))
+			\ .. ' --verbose ' ..
                         \ get(b:, 'jshint_makeprg_params', get(g:, 'jshint_makeprg_params', '')), ' \|"')
-endif
 CompilerSet errorformat=%f:\ line\ %l\\,\ col\ %c\\,\ %m\ (%t%n),
 		       \%-G%.%#
 

--- a/runtime/compiler/jshint.vim
+++ b/runtime/compiler/jshint.vim
@@ -19,7 +19,7 @@ set cpo&vim
 exe 'CompilerSet makeprg=' .. escape(
 			\ (!empty(get(b:, 'jshint_makeprg', get(g:, 'jshint_makeprg', ''))) ?
 			\   get(b:, 'jshint_makeprg', get(g:, 'jshint_makeprg', '')) :
-			\   (get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' jshint'))
+			\   (get(b:, 'javascript_node_makeprg', get(g:, 'javascript_node_makeprg', 'npx')) .. ' jshint'))
 			\ .. ' --verbose ' ..
                         \ get(b:, 'jshint_makeprg_params', get(g:, 'jshint_makeprg_params', '')), ' \|"')
 CompilerSet errorformat=%f:\ line\ %l\\,\ col\ %c\\,\ %m\ (%t%n),

--- a/runtime/compiler/jshint.vim
+++ b/runtime/compiler/jshint.vim
@@ -16,10 +16,14 @@ set cpo&vim
 
 " CompilerSet makeprg=jshint
 " CompilerSet makeprg=npx\ jshint
-exe 'CompilerSet makeprg=' .. escape(
+if !empty(escape(get(b:, 'jshint_makeprg', get(g:, 'jshint_makeprg', ''))))
+  execute $'CompilerSet makeprg={escape(get(b:, 'jshint_makeprg', get(g:, 'jshint_makeprg', 'jshint')), ' \|"')}'
+else
+  exe 'CompilerSet makeprg=' .. escape(
 			\ get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' jshint' ..
 			\ ' --verbose ' ..
                         \ get(b:, 'jshint_makeprg_params', get(g:, 'jshint_makeprg_params', '')), ' \|"')
+endif
 CompilerSet errorformat=%f:\ line\ %l\\,\ col\ %c\\,\ %m\ (%t%n),
 		       \%-G%.%#
 

--- a/runtime/compiler/jshint.vim
+++ b/runtime/compiler/jshint.vim
@@ -1,7 +1,7 @@
 " Vim compiler file
-" Compiler:	JSHint
-" Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2024 Apr 03
+" Compiler:     JSHint
+" Maintainer:   Doug Kearns <dougkearns@gmail.com>
+" Last Change:  2024 Apr 03
 " Last Change:  2025 Nov 22 by The Vim Project (default to npx)
 
 if exists("current_compiler")
@@ -17,13 +17,13 @@ set cpo&vim
 " CompilerSet makeprg=jshint
 " CompilerSet makeprg=npx\ jshint
 exe 'CompilerSet makeprg=' .. escape(
-			\ (!empty(get(b:, 'jshint_makeprg', get(g:, 'jshint_makeprg', ''))) ?
-			\   get(b:, 'jshint_makeprg', get(g:, 'jshint_makeprg', '')) :
-			\   (get(b:, 'javascript_node_makeprg', get(g:, 'javascript_node_makeprg', 'npx')) .. ' jshint'))
-			\ .. ' --verbose ' ..
+                        \ (!empty(get(b:, 'jshint_makeprg', get(g:, 'jshint_makeprg', ''))) ?
+                        \   get(b:, 'jshint_makeprg', get(g:, 'jshint_makeprg', '')) :
+                        \   (get(b:, 'javascript_node_makeprg', get(g:, 'javascript_node_makeprg', 'npx')) .. ' jshint'))
+                        \ .. ' --verbose ' ..
                         \ get(b:, 'jshint_makeprg_params', get(g:, 'jshint_makeprg_params', '')), ' \|"')
 CompilerSet errorformat=%f:\ line\ %l\\,\ col\ %c\\,\ %m\ (%t%n),
-		       \%-G%.%#
+                       \%-G%.%#
 
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/runtime/compiler/jsonlint.vim
+++ b/runtime/compiler/jsonlint.vim
@@ -19,7 +19,7 @@ set cpo&vim
 exe 'CompilerSet makeprg=' .. escape(
 			\ (!empty(get(b:, 'jsonlint_makeprg', get(g:, 'jsonlint_makeprg', ''))) ?
 			\   get(b:, 'jsonlint_makeprg', get(g:, 'jsonlint_makeprg', '')) :
-			\   (get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' jsonlint'))
+			\   (get(b:, 'javascript_node_makeprg', get(g:, 'javascript_node_makeprg', 'npx')) .. ' jsonlint'))
 			\ .. ' --compact --quiet ' ..
                         \ get(b:, 'jsonlint_makeprg_params', get(g:, 'jsonlint_makeprg_params', '')), ' \|"')
 CompilerSet errorformat=%f:\ line\ %l\\,\ col\ %c\\,\ found:\ %m,

--- a/runtime/compiler/jsonlint.vim
+++ b/runtime/compiler/jsonlint.vim
@@ -16,14 +16,12 @@ set cpo&vim
 
 " CompilerSet makeprg=jsonlint
 " CompilerSet makeprg=npx\ jsonlint
-if !empty(escape(get(b:, 'jsonlint_makeprg', get(g:, 'jsonlint_makeprg', ''))))
-  execute $'CompilerSet makeprg={escape(get(b:, 'jsonlint_makeprg', get(g:, 'jsonlint_makeprg', 'jsonlint')), ' \|"')}'
-else
-  exe 'CompilerSet makeprg=' .. escape(
-			\ get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' jsonlint' ..
-			\ ' --compact --quiet ' ..
+exe 'CompilerSet makeprg=' .. escape(
+			\ (!empty(get(b:, 'jsonlint_makeprg', get(g:, 'jsonlint_makeprg', ''))) ?
+			\   get(b:, 'jsonlint_makeprg', get(g:, 'jsonlint_makeprg', '')) :
+			\   (get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' jsonlint'))
+			\ .. ' --compact --quiet ' ..
                         \ get(b:, 'jsonlint_makeprg_params', get(g:, 'jsonlint_makeprg_params', '')), ' \|"')
-endif
 CompilerSet errorformat=%f:\ line\ %l\\,\ col\ %c\\,\ found:\ %m,
 		       \%-G%.%#
 

--- a/runtime/compiler/jsonlint.vim
+++ b/runtime/compiler/jsonlint.vim
@@ -16,10 +16,14 @@ set cpo&vim
 
 " CompilerSet makeprg=jsonlint
 " CompilerSet makeprg=npx\ jsonlint
-exe 'CompilerSet makeprg=' .. escape(
+if !empty(escape(get(b:, 'jsonlint_makeprg', get(g:, 'jsonlint_makeprg', ''))))
+  execute $'CompilerSet makeprg={escape(get(b:, 'jsonlint_makeprg', get(g:, 'jsonlint_makeprg', 'jsonlint')), ' \|"')}'
+else
+  exe 'CompilerSet makeprg=' .. escape(
 			\ get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' jsonlint' ..
 			\ ' --compact --quiet ' ..
                         \ get(b:, 'jsonlint_makeprg_params', get(g:, 'jsonlint_makeprg_params', '')), ' \|"')
+endif
 CompilerSet errorformat=%f:\ line\ %l\\,\ col\ %c\\,\ found:\ %m,
 		       \%-G%.%#
 

--- a/runtime/compiler/jsonlint.vim
+++ b/runtime/compiler/jsonlint.vim
@@ -1,7 +1,7 @@
 " Vim compiler file
-" Compiler:	JSON Lint
-" Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2024 Apr 03
+" Compiler:     JSON Lint
+" Maintainer:   Doug Kearns <dougkearns@gmail.com>
+" Last Change:  2024 Apr 03
 " Last Change:  2025 Nov 22 by The Vim Project (default to npx)
 
 if exists("current_compiler")
@@ -17,13 +17,13 @@ set cpo&vim
 " CompilerSet makeprg=jsonlint
 " CompilerSet makeprg=npx\ jsonlint
 exe 'CompilerSet makeprg=' .. escape(
-			\ (!empty(get(b:, 'jsonlint_makeprg', get(g:, 'jsonlint_makeprg', ''))) ?
-			\   get(b:, 'jsonlint_makeprg', get(g:, 'jsonlint_makeprg', '')) :
-			\   (get(b:, 'javascript_node_makeprg', get(g:, 'javascript_node_makeprg', 'npx')) .. ' jsonlint'))
-			\ .. ' --compact --quiet ' ..
+                        \ (!empty(get(b:, 'jsonlint_makeprg', get(g:, 'jsonlint_makeprg', ''))) ?
+                        \   get(b:, 'jsonlint_makeprg', get(g:, 'jsonlint_makeprg', '')) :
+                        \   (get(b:, 'javascript_node_makeprg', get(g:, 'javascript_node_makeprg', 'npx')) .. ' jsonlint'))
+                        \ .. ' --compact --quiet ' ..
                         \ get(b:, 'jsonlint_makeprg_params', get(g:, 'jsonlint_makeprg_params', '')), ' \|"')
 CompilerSet errorformat=%f:\ line\ %l\\,\ col\ %c\\,\ found:\ %m,
-		       \%-G%.%#
+                       \%-G%.%#
 
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/runtime/compiler/jsonlint.vim
+++ b/runtime/compiler/jsonlint.vim
@@ -2,6 +2,7 @@
 " Compiler:	JSON Lint
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:	2024 Apr 03
+" Last Change:  2025 Nov 22 by The Vim Project (default to npx)
 
 if exists("current_compiler")
   finish
@@ -13,7 +14,12 @@ set cpo&vim
 
 " CompilerSet makeprg=npx\ jsonlint\ --compact\ --quiet
 
-CompilerSet makeprg=jsonlint\ --compact\ --quiet
+" CompilerSet makeprg=jsonlint
+" CompilerSet makeprg=npx\ jsonlint
+exe 'CompilerSet makeprg=' .. escape(
+			\ get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' jsonlint' ..
+			\ ' --compact --quiet ' ..
+                        \ get(b:, 'jsonlint_makeprg_params', get(g:, 'jsonlint_makeprg_params', '')), ' \|"')
 CompilerSet errorformat=%f:\ line\ %l\\,\ col\ %c\\,\ found:\ %m,
 		       \%-G%.%#
 

--- a/runtime/compiler/pylint.vim
+++ b/runtime/compiler/pylint.vim
@@ -1,9 +1,9 @@
 " Vim compiler file
-" Compiler:     Pylint for Python
-" Maintainer:   Daniel Moch <daniel@danielmoch.com>
-" Last Change:  2024 Nov 07 by The Vim Project (added params variable)
-"		2024 Nov 19 by the Vim Project (properly escape makeprg setting)
-"		2025 Nov 06 by the Vim Project (do not set buffer-local makeprg)
+" Compiler:             Pylint for Python
+" Previous Maintainer:  Daniel Moch <daniel@danielmoch.com>
+" Last Change:          2024 Nov 07 by The Vim Project (added params variable)
+"		        2024 Nov 19 by the Vim Project (properly escape makeprg setting)
+"		        2025 Nov 06 by the Vim Project (do not set buffer-local makeprg)
 
 if exists("current_compiler") | finish | endif
 let current_compiler = "pylint"

--- a/runtime/compiler/sass.vim
+++ b/runtime/compiler/sass.vim
@@ -3,6 +3,7 @@
 " Maintainer:	Tim Pope <vimNOSPAM@tpope.org>
 " Last Change:	2016 Aug 29
 "		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
+"               2025 Nov 22 by The Vim Project (default to npx)
 
 if exists("current_compiler")
   finish
@@ -12,7 +13,12 @@ let current_compiler = "sass"
 let s:cpo_save = &cpo
 set cpo-=C
 
-CompilerSet makeprg=sass
+" CompilerSet makeprg=sass
+" CompilerSet makeprg=npx\ sass
+exe 'CompilerSet makeprg=' .. escape(
+			\ get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' sass' ..
+			\ ' ' ..
+                        \ get(b:, 'sass_makeprg_params', get(g:, 'sass_makeprg_params', '')), ' \|"')
 
 CompilerSet errorformat=
       \%f:%l:%m\ (Sass::Syntax%trror),

--- a/runtime/compiler/sass.vim
+++ b/runtime/compiler/sass.vim
@@ -15,14 +15,12 @@ set cpo-=C
 
 " CompilerSet makeprg=sass
 " CompilerSet makeprg=npx\ sass
-if !empty(escape(get(b:, 'sass_makeprg', get(g:, 'sass_makeprg', ''))))
-  execute $'CompilerSet makeprg={escape(get(b:, 'sass_makeprg', get(g:, 'sass_makeprg', 'sass')), ' \|"')}'
-else
-  exe 'CompilerSet makeprg=' .. escape(
-			\ get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' sass' ..
-			\ ' ' ..
+exe 'CompilerSet makeprg=' .. escape(
+			\ (!empty(get(b:, 'sass_makeprg', get(g:, 'sass_makeprg', ''))) ?
+			\   get(b:, 'sass_makeprg', get(g:, 'sass_makeprg', '')) :
+			\   (get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' sass'))
+			\ .. ' ' ..
                         \ get(b:, 'sass_makeprg_params', get(g:, 'sass_makeprg_params', '')), ' \|"')
-endif
 
 CompilerSet errorformat=
       \%f:%l:%m\ (Sass::Syntax%trror),

--- a/runtime/compiler/sass.vim
+++ b/runtime/compiler/sass.vim
@@ -18,7 +18,7 @@ set cpo-=C
 exe 'CompilerSet makeprg=' .. escape(
 			\ (!empty(get(b:, 'sass_makeprg', get(g:, 'sass_makeprg', ''))) ?
 			\   get(b:, 'sass_makeprg', get(g:, 'sass_makeprg', '')) :
-			\   (get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' sass'))
+			\   (get(b:, 'javascript_node_makeprg', get(g:, 'javascript_node_makeprg', 'npx')) .. ' sass'))
 			\ .. ' ' ..
                         \ get(b:, 'sass_makeprg_params', get(g:, 'sass_makeprg_params', '')), ' \|"')
 

--- a/runtime/compiler/sass.vim
+++ b/runtime/compiler/sass.vim
@@ -15,10 +15,14 @@ set cpo-=C
 
 " CompilerSet makeprg=sass
 " CompilerSet makeprg=npx\ sass
-exe 'CompilerSet makeprg=' .. escape(
+if !empty(escape(get(b:, 'sass_makeprg', get(g:, 'sass_makeprg', ''))))
+  execute $'CompilerSet makeprg={escape(get(b:, 'sass_makeprg', get(g:, 'sass_makeprg', 'sass')), ' \|"')}'
+else
+  exe 'CompilerSet makeprg=' .. escape(
 			\ get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' sass' ..
 			\ ' ' ..
                         \ get(b:, 'sass_makeprg_params', get(g:, 'sass_makeprg_params', '')), ' \|"')
+endif
 
 CompilerSet errorformat=
       \%f:%l:%m\ (Sass::Syntax%trror),

--- a/runtime/compiler/sass.vim
+++ b/runtime/compiler/sass.vim
@@ -1,8 +1,8 @@
 " Vim compiler file
-" Compiler:	Sass
-" Maintainer:	Tim Pope <vimNOSPAM@tpope.org>
-" Last Change:	2016 Aug 29
-"		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
+" Compiler:     Sass
+" Maintainer:   Tim Pope <vimNOSPAM@tpope.org>
+" Last Change:  2016 Aug 29
+"               2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 "               2025 Nov 22 by The Vim Project (default to npx)
 
 if exists("current_compiler")
@@ -16,10 +16,10 @@ set cpo-=C
 " CompilerSet makeprg=sass
 " CompilerSet makeprg=npx\ sass
 exe 'CompilerSet makeprg=' .. escape(
-			\ (!empty(get(b:, 'sass_makeprg', get(g:, 'sass_makeprg', ''))) ?
-			\   get(b:, 'sass_makeprg', get(g:, 'sass_makeprg', '')) :
-			\   (get(b:, 'javascript_node_makeprg', get(g:, 'javascript_node_makeprg', 'npx')) .. ' sass'))
-			\ .. ' ' ..
+                        \ (!empty(get(b:, 'sass_makeprg', get(g:, 'sass_makeprg', ''))) ?
+                        \   get(b:, 'sass_makeprg', get(g:, 'sass_makeprg', '')) :
+                        \   (get(b:, 'javascript_node_makeprg', get(g:, 'javascript_node_makeprg', 'npx')) .. ' sass'))
+                        \ .. ' ' ..
                         \ get(b:, 'sass_makeprg_params', get(g:, 'sass_makeprg_params', '')), ' \|"')
 
 CompilerSet errorformat=

--- a/runtime/compiler/standard.vim
+++ b/runtime/compiler/standard.vim
@@ -12,8 +12,12 @@ let current_compiler = "standard"
 
 " CompilerSet makeprg=standard
 " CompilerSet makeprg=npx\ standard
-exe 'CompilerSet makeprg=' .. escape(
+if !empty(escape(get(b:, 'standard_makeprg', get(g:, 'standard_makeprg', ''))))
+  execute $'CompilerSet makeprg={escape(get(b:, 'standard_makeprg', get(g:, 'standard_makeprg', 'standard')), ' \|"')}'
+else
+  exe 'CompilerSet makeprg=' .. escape(
 			\ get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' standard' ..
 			\ ' ' ..
                         \ get(b:, 'standard_makeprg_params', get(g:, 'standard_makeprg_params', '')), ' \|"')
+endif
 CompilerSet errorformat=%f:%l:%c:\ %m,%-G%.%#

--- a/runtime/compiler/standard.vim
+++ b/runtime/compiler/standard.vim
@@ -2,7 +2,7 @@
 " Compiler:    Standard for JavaScript
 " Maintainer:  Romain Lafourcade <romainlafourcade@gmail.com>
 " Last Change: 2020 August 20
-"		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
+"               2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 "               2025 Nov 22 by The Vim Project (default to npx)
 
 if exists("current_compiler")
@@ -13,9 +13,9 @@ let current_compiler = "standard"
 " CompilerSet makeprg=standard
 " CompilerSet makeprg=npx\ standard
 exe 'CompilerSet makeprg=' .. escape(
-			\ (!empty(get(b:, 'standard_makeprg', get(g:, 'standard_makeprg', ''))) ?
-			\   get(b:, 'standard_makeprg', get(g:, 'standard_makeprg', '')) :
-			\   (get(b:, 'javascript_node_makeprg', get(g:, 'javascript_node_makeprg', 'npx')) .. ' standard'))
-			\ .. ' ' ..
+                        \ (!empty(get(b:, 'standard_makeprg', get(g:, 'standard_makeprg', ''))) ?
+                        \   get(b:, 'standard_makeprg', get(g:, 'standard_makeprg', '')) :
+                        \   (get(b:, 'javascript_node_makeprg', get(g:, 'javascript_node_makeprg', 'npx')) .. ' standard'))
+                        \ .. ' ' ..
                         \ get(b:, 'standard_makeprg_params', get(g:, 'standard_makeprg_params', '')), ' \|"')
 CompilerSet errorformat=%f:%l:%c:\ %m,%-G%.%#

--- a/runtime/compiler/standard.vim
+++ b/runtime/compiler/standard.vim
@@ -12,12 +12,10 @@ let current_compiler = "standard"
 
 " CompilerSet makeprg=standard
 " CompilerSet makeprg=npx\ standard
-if !empty(escape(get(b:, 'standard_makeprg', get(g:, 'standard_makeprg', ''))))
-  execute $'CompilerSet makeprg={escape(get(b:, 'standard_makeprg', get(g:, 'standard_makeprg', 'standard')), ' \|"')}'
-else
-  exe 'CompilerSet makeprg=' .. escape(
-			\ get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' standard' ..
-			\ ' ' ..
+exe 'CompilerSet makeprg=' .. escape(
+			\ (!empty(get(b:, 'standard_makeprg', get(g:, 'standard_makeprg', ''))) ?
+			\   get(b:, 'standard_makeprg', get(g:, 'standard_makeprg', '')) :
+			\   (get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' standard'))
+			\ .. ' ' ..
                         \ get(b:, 'standard_makeprg_params', get(g:, 'standard_makeprg_params', '')), ' \|"')
-endif
 CompilerSet errorformat=%f:%l:%c:\ %m,%-G%.%#

--- a/runtime/compiler/standard.vim
+++ b/runtime/compiler/standard.vim
@@ -3,11 +3,17 @@
 " Maintainer:  Romain Lafourcade <romainlafourcade@gmail.com>
 " Last Change: 2020 August 20
 "		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
+"               2025 Nov 22 by The Vim Project (default to npx)
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "standard"
 
-CompilerSet makeprg=npx\ standard
+" CompilerSet makeprg=standard
+" CompilerSet makeprg=npx\ standard
+exe 'CompilerSet makeprg=' .. escape(
+			\ get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' standard' ..
+			\ ' ' ..
+                        \ get(b:, 'standard_makeprg_params', get(g:, 'standard_makeprg_params', '')), ' \|"')
 CompilerSet errorformat=%f:%l:%c:\ %m,%-G%.%#

--- a/runtime/compiler/standard.vim
+++ b/runtime/compiler/standard.vim
@@ -15,7 +15,7 @@ let current_compiler = "standard"
 exe 'CompilerSet makeprg=' .. escape(
 			\ (!empty(get(b:, 'standard_makeprg', get(g:, 'standard_makeprg', ''))) ?
 			\   get(b:, 'standard_makeprg', get(g:, 'standard_makeprg', '')) :
-			\   (get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' standard'))
+			\   (get(b:, 'javascript_node_makeprg', get(g:, 'javascript_node_makeprg', 'npx')) .. ' standard'))
 			\ .. ' ' ..
                         \ get(b:, 'standard_makeprg_params', get(g:, 'standard_makeprg_params', '')), ' \|"')
 CompilerSet errorformat=%f:%l:%c:\ %m,%-G%.%#

--- a/runtime/compiler/stylelint.vim
+++ b/runtime/compiler/stylelint.vim
@@ -16,10 +16,14 @@ set cpo&vim
 
 " CompilerSet makeprg=stylelint
 " CompilerSet makeprg=npx\ stylelint
-exe 'CompilerSet makeprg=' .. escape(
+if !empty(escape(get(b:, 'stylelint_makeprg', get(g:, 'stylelint_makeprg', ''))))
+  execute $'CompilerSet makeprg={escape(get(b:, 'stylelint_makeprg', get(g:, 'stylelint_makeprg', 'stylelint')), ' \|"')}'
+else
+  exe 'CompilerSet makeprg=' .. escape(
 			\ get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' stylelint' ..
 			\ ' --formatter compact ' ..
                         \ get(b:, 'stylelint_makeprg_params', get(g:, 'stylelint_makeprg_params', '')), ' \|"')
+endif
 CompilerSet errorformat=%f:\ line\ %l\\,\ col\ %c\\,\ %trror\ -\ %m,
 		       \%f:\ line\ %l\\,\ col\ %c\\,\ %tarning\ -\ %m,
 		       \%-G%.%#

--- a/runtime/compiler/stylelint.vim
+++ b/runtime/compiler/stylelint.vim
@@ -16,14 +16,12 @@ set cpo&vim
 
 " CompilerSet makeprg=stylelint
 " CompilerSet makeprg=npx\ stylelint
-if !empty(escape(get(b:, 'stylelint_makeprg', get(g:, 'stylelint_makeprg', ''))))
-  execute $'CompilerSet makeprg={escape(get(b:, 'stylelint_makeprg', get(g:, 'stylelint_makeprg', 'stylelint')), ' \|"')}'
-else
-  exe 'CompilerSet makeprg=' .. escape(
-			\ get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' stylelint' ..
-			\ ' --formatter compact ' ..
+exe 'CompilerSet makeprg=' .. escape(
+			\ (!empty(get(b:, 'stylelint_makeprg', get(g:, 'stylelint_makeprg', ''))) ?
+			\   get(b:, 'stylelint_makeprg', get(g:, 'stylelint_makeprg', '')) :
+			\   (get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' stylelint'))
+			\ .. ' --formatter compact ' ..
                         \ get(b:, 'stylelint_makeprg_params', get(g:, 'stylelint_makeprg_params', '')), ' \|"')
-endif
 CompilerSet errorformat=%f:\ line\ %l\\,\ col\ %c\\,\ %trror\ -\ %m,
 		       \%f:\ line\ %l\\,\ col\ %c\\,\ %tarning\ -\ %m,
 		       \%-G%.%#

--- a/runtime/compiler/stylelint.vim
+++ b/runtime/compiler/stylelint.vim
@@ -1,7 +1,7 @@
 " Vim compiler file
-" Compiler:	Stylelint
-" Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2024 Apr 03
+" Compiler:     Stylelint
+" Maintainer:   Doug Kearns <dougkearns@gmail.com>
+" Last Change:  2024 Apr 03
 "               2025 Nov 22 by The Vim Project (default to npx)
 
 if exists("current_compiler")
@@ -17,14 +17,14 @@ set cpo&vim
 " CompilerSet makeprg=stylelint
 " CompilerSet makeprg=npx\ stylelint
 exe 'CompilerSet makeprg=' .. escape(
-			\ (!empty(get(b:, 'stylelint_makeprg', get(g:, 'stylelint_makeprg', ''))) ?
-			\   get(b:, 'stylelint_makeprg', get(g:, 'stylelint_makeprg', '')) :
-			\   (get(b:, 'javascript_node_makeprg', get(g:, 'javascript_node_makeprg', 'npx')) .. ' stylelint'))
-			\ .. ' --formatter compact ' ..
+                        \ (!empty(get(b:, 'stylelint_makeprg', get(g:, 'stylelint_makeprg', ''))) ?
+                        \   get(b:, 'stylelint_makeprg', get(g:, 'stylelint_makeprg', '')) :
+                        \   (get(b:, 'javascript_node_makeprg', get(g:, 'javascript_node_makeprg', 'npx')) .. ' stylelint'))
+                        \ .. ' --formatter compact ' ..
                         \ get(b:, 'stylelint_makeprg_params', get(g:, 'stylelint_makeprg_params', '')), ' \|"')
 CompilerSet errorformat=%f:\ line\ %l\\,\ col\ %c\\,\ %trror\ -\ %m,
-		       \%f:\ line\ %l\\,\ col\ %c\\,\ %tarning\ -\ %m,
-		       \%-G%.%#
+                       \%f:\ line\ %l\\,\ col\ %c\\,\ %tarning\ -\ %m,
+                       \%-G%.%#
 
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/runtime/compiler/stylelint.vim
+++ b/runtime/compiler/stylelint.vim
@@ -19,7 +19,7 @@ set cpo&vim
 exe 'CompilerSet makeprg=' .. escape(
 			\ (!empty(get(b:, 'stylelint_makeprg', get(g:, 'stylelint_makeprg', ''))) ?
 			\   get(b:, 'stylelint_makeprg', get(g:, 'stylelint_makeprg', '')) :
-			\   (get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' stylelint'))
+			\   (get(b:, 'javascript_node_makeprg', get(g:, 'javascript_node_makeprg', 'npx')) .. ' stylelint'))
 			\ .. ' --formatter compact ' ..
                         \ get(b:, 'stylelint_makeprg_params', get(g:, 'stylelint_makeprg_params', '')), ' \|"')
 CompilerSet errorformat=%f:\ line\ %l\\,\ col\ %c\\,\ %trror\ -\ %m,

--- a/runtime/compiler/stylelint.vim
+++ b/runtime/compiler/stylelint.vim
@@ -2,6 +2,7 @@
 " Compiler:	Stylelint
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:	2024 Apr 03
+"               2025 Nov 22 by The Vim Project (default to npx)
 
 if exists("current_compiler")
   finish
@@ -13,7 +14,12 @@ set cpo&vim
 
 " CompilerSet makeprg=npx\ stylelint\ --formatter\ compact
 
-CompilerSet makeprg=stylelint\ --formatter\ compact
+" CompilerSet makeprg=stylelint
+" CompilerSet makeprg=npx\ stylelint
+exe 'CompilerSet makeprg=' .. escape(
+			\ get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' stylelint' ..
+			\ ' --formatter compact ' ..
+                        \ get(b:, 'stylelint_makeprg_params', get(g:, 'stylelint_makeprg_params', '')), ' \|"')
 CompilerSet errorformat=%f:\ line\ %l\\,\ col\ %c\\,\ %trror\ -\ %m,
 		       \%f:\ line\ %l\\,\ col\ %c\\,\ %tarning\ -\ %m,
 		       \%-G%.%#

--- a/runtime/compiler/svelte-check.vim
+++ b/runtime/compiler/svelte-check.vim
@@ -8,10 +8,14 @@ let current_compiler = "svelte-check"
 
 " CompilerSet makeprg=svelte-check
 " CompilerSet makeprg=npx\ svelte-check
-exe 'CompilerSet makeprg=' .. escape(
+if !empty(escape(get(b:, 'svelte_check_makeprg', get(g:, 'svelte_check_makeprg', ''))))
+  execute $'CompilerSet makeprg={escape(get(b:, 'svelte_check_makeprg', get(g:, 'svelte_check_makeprg', 'svelte-check')), ' \|"')}'
+else
+  exe 'CompilerSet makeprg=' .. escape(
 			\ get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' svelte-check' ..
 			\ ' --output machine ' ..
                         \ get(b:, 'svelte_check_makeprg_params', get(g:, 'svelte_check_makeprg_params', '')), ' \|"')
+endif
 CompilerSet errorformat=%*\\d\ %t%*\\a\ \"%f\"\ %l:%c\ \"%m\",
 CompilerSet errorformat+=%-G%*\\d\ START\ %.%#,
 CompilerSet errorformat+=%-G%*\\d\ COMPLETED\ %.%#,

--- a/runtime/compiler/svelte-check.vim
+++ b/runtime/compiler/svelte-check.vim
@@ -1,7 +1,7 @@
 " Vim compiler file
-" Compiler:	svelte-check
-" Maintainer:	@Konfekt
-" Last Change:	2025 Nov 16
+" Compiler:     svelte-check
+" Maintainer:   @Konfekt
+" Last Change:  2025 Nov 16
 
 if exists("current_compiler") | finish | endif
 let current_compiler = "svelte-check"
@@ -9,10 +9,10 @@ let current_compiler = "svelte-check"
 " CompilerSet makeprg=svelte-check
 " CompilerSet makeprg=npx\ svelte-check
 exe 'CompilerSet makeprg=' .. escape(
-			\ (!empty(get(b:, 'svelte_check_makeprg', get(g:, 'svelte_check_makeprg', ''))) ?
-			\   get(b:, 'svelte_check_makeprg', get(g:, 'svelte_check_makeprg', '')) :
-			\   (get(b:, 'javascript_node_makeprg', get(g:, 'javascript_node_makeprg', 'npx')) .. ' svelte-check'))
-			\ .. ' --output machine ' ..
+                        \ (!empty(get(b:, 'svelte_check_makeprg', get(g:, 'svelte_check_makeprg', ''))) ?
+                        \   get(b:, 'svelte_check_makeprg', get(g:, 'svelte_check_makeprg', '')) :
+                        \   (get(b:, 'javascript_node_makeprg', get(g:, 'javascript_node_makeprg', 'npx')) .. ' svelte-check'))
+                        \ .. ' --output machine ' ..
                         \ get(b:, 'svelte_check_makeprg_params', get(g:, 'svelte_check_makeprg_params', '')), ' \|"')
 CompilerSet errorformat=%*\\d\ %t%*\\a\ \"%f\"\ %l:%c\ \"%m\",
 CompilerSet errorformat+=%-G%*\\d\ START\ %.%#,

--- a/runtime/compiler/svelte-check.vim
+++ b/runtime/compiler/svelte-check.vim
@@ -8,14 +8,12 @@ let current_compiler = "svelte-check"
 
 " CompilerSet makeprg=svelte-check
 " CompilerSet makeprg=npx\ svelte-check
-if !empty(escape(get(b:, 'svelte_check_makeprg', get(g:, 'svelte_check_makeprg', ''))))
-  execute $'CompilerSet makeprg={escape(get(b:, 'svelte_check_makeprg', get(g:, 'svelte_check_makeprg', 'svelte-check')), ' \|"')}'
-else
-  exe 'CompilerSet makeprg=' .. escape(
-			\ get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' svelte-check' ..
-			\ ' --output machine ' ..
+exe 'CompilerSet makeprg=' .. escape(
+			\ (!empty(get(b:, 'svelte_check_makeprg', get(g:, 'svelte_check_makeprg', ''))) ?
+			\   get(b:, 'svelte_check_makeprg', get(g:, 'svelte_check_makeprg', '')) :
+			\   (get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' svelte-check'))
+			\ .. ' --output machine ' ..
                         \ get(b:, 'svelte_check_makeprg_params', get(g:, 'svelte_check_makeprg_params', '')), ' \|"')
-endif
 CompilerSet errorformat=%*\\d\ %t%*\\a\ \"%f\"\ %l:%c\ \"%m\",
 CompilerSet errorformat+=%-G%*\\d\ START\ %.%#,
 CompilerSet errorformat+=%-G%*\\d\ COMPLETED\ %.%#,

--- a/runtime/compiler/svelte-check.vim
+++ b/runtime/compiler/svelte-check.vim
@@ -1,12 +1,17 @@
 " Vim compiler file
 " Compiler:	svelte-check
 " Maintainer:	@Konfekt
-" Last Change:	2025 Feb 27
+" Last Change:	2025 Nov 16
 
 if exists("current_compiler") | finish | endif
 let current_compiler = "svelte-check"
 
-CompilerSet makeprg=npx\ svelte-check\ --output\ machine
+" CompilerSet makeprg=svelte-check
+" CompilerSet makeprg=npx\ svelte-check
+exe 'CompilerSet makeprg=' .. escape(
+			\ get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' svelte-check' ..
+			\ ' --output machine ' ..
+                        \ get(b:, 'svelte_check_makeprg_params', get(g:, 'svelte_check_makeprg_params', '')), ' \|"')
 CompilerSet errorformat=%*\\d\ %t%*\\a\ \"%f\"\ %l:%c\ \"%m\",
 CompilerSet errorformat+=%-G%*\\d\ START\ %.%#,
 CompilerSet errorformat+=%-G%*\\d\ COMPLETED\ %.%#,

--- a/runtime/compiler/svelte-check.vim
+++ b/runtime/compiler/svelte-check.vim
@@ -11,7 +11,7 @@ let current_compiler = "svelte-check"
 exe 'CompilerSet makeprg=' .. escape(
 			\ (!empty(get(b:, 'svelte_check_makeprg', get(g:, 'svelte_check_makeprg', ''))) ?
 			\   get(b:, 'svelte_check_makeprg', get(g:, 'svelte_check_makeprg', '')) :
-			\   (get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' svelte-check'))
+			\   (get(b:, 'javascript_node_makeprg', get(g:, 'javascript_node_makeprg', 'npx')) .. ' svelte-check'))
 			\ .. ' --output machine ' ..
                         \ get(b:, 'svelte_check_makeprg_params', get(g:, 'svelte_check_makeprg_params', '')), ' \|"')
 CompilerSet errorformat=%*\\d\ %t%*\\a\ \"%f\"\ %l:%c\ \"%m\",

--- a/runtime/compiler/ts-node.vim
+++ b/runtime/compiler/ts-node.vim
@@ -14,10 +14,14 @@ set cpo&vim
 
 " CompilerSet makeprg=ts-node
 " CompilerSet makeprg=npx\ ts-node
-exe 'CompilerSet makeprg=' .. escape(
+if !empty(escape(get(b:, 'ts_node_makeprg', get(g:, 'ts_node_makeprg', ''))))
+  execute $'CompilerSet makeprg={escape(get(b:, 'ts_node_makeprg', get(g:, 'ts_node_makeprg', 'ts-node')), ' \|"')}'
+else
+  exe 'CompilerSet makeprg=' .. escape(
 			\ get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' ts-node' ..
 			\ ' ' ..
                         \ get(b:, 'ts_node_makeprg_params', get(g:, 'ts_node_makeprg_params', '')), ' \|"')
+endif
 CompilerSet errorformat=%f\ %#(%l\\,%c):\ %trror\ TS%n:\ %m,
 		       \%E%f:%l,
 		       \%+Z%\\w%\\+Error:\ %.%#,

--- a/runtime/compiler/ts-node.vim
+++ b/runtime/compiler/ts-node.vim
@@ -1,7 +1,7 @@
 " Vim compiler file
-" Compiler:	TypeScript Runner
-" Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2024 Apr 03
+" Compiler:     TypeScript Runner
+" Maintainer:   Doug Kearns <dougkearns@gmail.com>
+" Last Change:  2024 Apr 03
 "               2025 Nov 22 by The Vim Project (default to npx)
 
 if exists("current_compiler")
@@ -15,17 +15,17 @@ set cpo&vim
 " CompilerSet makeprg=ts-node
 " CompilerSet makeprg=npx\ ts-node
 exe 'CompilerSet makeprg=' .. escape(
-			\ (!empty(get(b:, 'ts_node_makeprg', get(g:, 'ts_node_makeprg', ''))) ?
-			\   get(b:, 'ts_node_makeprg', get(g:, 'ts_node_makeprg', '')) :
-			\   (get(b:, 'javascript_node_makeprg', get(g:, 'javascript_node_makeprg', 'npx')) .. ' ts-node'))
-			\ .. ' ' ..
+                        \ (!empty(get(b:, 'ts_node_makeprg', get(g:, 'ts_node_makeprg', ''))) ?
+                        \   get(b:, 'ts_node_makeprg', get(g:, 'ts_node_makeprg', '')) :
+                        \   (get(b:, 'javascript_node_makeprg', get(g:, 'javascript_node_makeprg', 'npx')) .. ' ts-node'))
+                        \ .. ' ' ..
                         \ get(b:, 'ts_node_makeprg_params', get(g:, 'ts_node_makeprg_params', '')), ' \|"')
 CompilerSet errorformat=%f\ %#(%l\\,%c):\ %trror\ TS%n:\ %m,
-		       \%E%f:%l,
-		       \%+Z%\\w%\\+Error:\ %.%#,
-		       \%C%p^%\\+,
-		       \%C%.%#,
-		       \%-G%.%#
+                       \%E%f:%l,
+                       \%+Z%\\w%\\+Error:\ %.%#,
+                       \%C%p^%\\+,
+                       \%C%.%#,
+                       \%-G%.%#
 
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/runtime/compiler/ts-node.vim
+++ b/runtime/compiler/ts-node.vim
@@ -17,7 +17,7 @@ set cpo&vim
 exe 'CompilerSet makeprg=' .. escape(
 			\ (!empty(get(b:, 'ts_node_makeprg', get(g:, 'ts_node_makeprg', ''))) ?
 			\   get(b:, 'ts_node_makeprg', get(g:, 'ts_node_makeprg', '')) :
-			\   (get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' ts-node'))
+			\   (get(b:, 'javascript_node_makeprg', get(g:, 'javascript_node_makeprg', 'npx')) .. ' ts-node'))
 			\ .. ' ' ..
                         \ get(b:, 'ts_node_makeprg_params', get(g:, 'ts_node_makeprg_params', '')), ' \|"')
 CompilerSet errorformat=%f\ %#(%l\\,%c):\ %trror\ TS%n:\ %m,

--- a/runtime/compiler/ts-node.vim
+++ b/runtime/compiler/ts-node.vim
@@ -14,14 +14,12 @@ set cpo&vim
 
 " CompilerSet makeprg=ts-node
 " CompilerSet makeprg=npx\ ts-node
-if !empty(escape(get(b:, 'ts_node_makeprg', get(g:, 'ts_node_makeprg', ''))))
-  execute $'CompilerSet makeprg={escape(get(b:, 'ts_node_makeprg', get(g:, 'ts_node_makeprg', 'ts-node')), ' \|"')}'
-else
-  exe 'CompilerSet makeprg=' .. escape(
-			\ get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' ts-node' ..
-			\ ' ' ..
+exe 'CompilerSet makeprg=' .. escape(
+			\ (!empty(get(b:, 'ts_node_makeprg', get(g:, 'ts_node_makeprg', ''))) ?
+			\   get(b:, 'ts_node_makeprg', get(g:, 'ts_node_makeprg', '')) :
+			\   (get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' ts-node'))
+			\ .. ' ' ..
                         \ get(b:, 'ts_node_makeprg_params', get(g:, 'ts_node_makeprg_params', '')), ' \|"')
-endif
 CompilerSet errorformat=%f\ %#(%l\\,%c):\ %trror\ TS%n:\ %m,
 		       \%E%f:%l,
 		       \%+Z%\\w%\\+Error:\ %.%#,

--- a/runtime/compiler/ts-node.vim
+++ b/runtime/compiler/ts-node.vim
@@ -21,11 +21,11 @@ exe 'CompilerSet makeprg=' .. escape(
                         \ .. ' ' ..
                         \ get(b:, 'ts_node_makeprg_params', get(g:, 'ts_node_makeprg_params', '')), ' \|"')
 CompilerSet errorformat=%f\ %#(%l\\,%c):\ %trror\ TS%n:\ %m,
-                       \%E%f:%l,
-                       \%+Z%\\w%\\+Error:\ %.%#,
-                       \%C%p^%\\+,
-                       \%C%.%#,
-                       \%-G%.%#
+		       \%E%f:%l,
+		       \%+Z%\\w%\\+Error:\ %.%#,
+		       \%C%p^%\\+,
+		       \%C%.%#,
+		       \%-G%.%#
 
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/runtime/compiler/ts-node.vim
+++ b/runtime/compiler/ts-node.vim
@@ -2,6 +2,7 @@
 " Compiler:	TypeScript Runner
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:	2024 Apr 03
+"               2025 Nov 22 by The Vim Project (default to npx)
 
 if exists("current_compiler")
   finish
@@ -11,9 +12,12 @@ let current_compiler = "node"
 let s:cpo_save = &cpo
 set cpo&vim
 
+" CompilerSet makeprg=ts-node
 " CompilerSet makeprg=npx\ ts-node
-
-CompilerSet makeprg=ts-node
+exe 'CompilerSet makeprg=' .. escape(
+			\ get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' ts-node' ..
+			\ ' ' ..
+                        \ get(b:, 'ts_node_makeprg_params', get(g:, 'ts_node_makeprg_params', '')), ' \|"')
 CompilerSet errorformat=%f\ %#(%l\\,%c):\ %trror\ TS%n:\ %m,
 		       \%E%f:%l,
 		       \%+Z%\\w%\\+Error:\ %.%#,

--- a/runtime/compiler/tsc.vim
+++ b/runtime/compiler/tsc.vim
@@ -18,7 +18,7 @@ set cpo&vim
 exe 'CompilerSet makeprg=' .. escape(
 			\ (!empty(get(b:, 'tsc_makeprg', get(g:, 'tsc_makeprg', ''))) ?
 			\   get(b:, 'tsc_makeprg', get(g:, 'tsc_makeprg', '')) :
-			\   get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' tsc')
+			\   get(b:, 'javascript_node_makeprg', get(g:, 'javascript_node_makeprg', 'npx')) .. ' tsc')
 			\ .. ' ' ..
                         \ get(b:, 'tsc_makeprg_params', get(g:, 'tsc_makeprg_params', '')), ' \|"')
 

--- a/runtime/compiler/tsc.vim
+++ b/runtime/compiler/tsc.vim
@@ -3,6 +3,7 @@
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:	2024 Apr 03
 "		2025 Mar 11 by The Vim Project (add comment for Dispatch, add tsc_makeprg variable)
+"               2025 Nov 22 by The Vim Project (default to npx)
 
 if exists("current_compiler")
   finish
@@ -14,7 +15,15 @@ set cpo&vim
 
 " CompilerSet makeprg=tsc
 " CompilerSet makeprg=npx\ tsc
-execute $'CompilerSet makeprg={escape(get(b:, 'tsc_makeprg', get(g:, 'tsc_makeprg', 'tsc')), ' \|"')}'
+if !empty(escape(get(b:, 'tsc_makeprg', get(g:, 'tsc_makeprg', ''))))
+  execute $'CompilerSet makeprg={escape(get(b:, 'tsc_makeprg', get(g:, 'tsc_makeprg', 'tsc')), ' \|"')}'
+else
+  exe 'CompilerSet makeprg=' .. escape(
+			\ get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' tsc' ..
+			\ ' ' ..
+                        \ get(b:, 'tsc_makeprg_params', get(g:, 'tsc_makeprg_params', '')), ' \|"')
+endif
+
 CompilerSet errorformat=%f\ %#(%l\\,%c):\ %trror\ TS%n:\ %m,
 		       \%trror\ TS%n:\ %m,
 		       \%-G%.%#

--- a/runtime/compiler/tsc.vim
+++ b/runtime/compiler/tsc.vim
@@ -15,14 +15,12 @@ set cpo&vim
 
 " CompilerSet makeprg=tsc
 " CompilerSet makeprg=npx\ tsc
-if !empty(escape(get(b:, 'tsc_makeprg', get(g:, 'tsc_makeprg', ''))))
-  execute $'CompilerSet makeprg={escape(get(b:, 'tsc_makeprg', get(g:, 'tsc_makeprg', 'tsc')), ' \|"')}'
-else
-  exe 'CompilerSet makeprg=' .. escape(
-			\ get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' tsc' ..
-			\ ' ' ..
+exe 'CompilerSet makeprg=' .. escape(
+			\ (!empty(get(b:, 'tsc_makeprg', get(g:, 'tsc_makeprg', ''))) ?
+			\   get(b:, 'tsc_makeprg', get(g:, 'tsc_makeprg', '')) :
+			\   get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' tsc')
+			\ .. ' ' ..
                         \ get(b:, 'tsc_makeprg_params', get(g:, 'tsc_makeprg_params', '')), ' \|"')
-endif
 
 CompilerSet errorformat=%f\ %#(%l\\,%c):\ %trror\ TS%n:\ %m,
 		       \%trror\ TS%n:\ %m,

--- a/runtime/compiler/tsc.vim
+++ b/runtime/compiler/tsc.vim
@@ -1,8 +1,8 @@
 " Vim compiler file
-" Compiler:	TypeScript Compiler
-" Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2024 Apr 03
-"		2025 Mar 11 by The Vim Project (add comment for Dispatch, add tsc_makeprg variable)
+" Compiler:     TypeScript Compiler
+" Maintainer:   Doug Kearns <dougkearns@gmail.com>
+" Last Change:  2024 Apr 03
+"               2025 Mar 11 by The Vim Project (add comment for Dispatch, add tsc_makeprg variable)
 "               2025 Nov 22 by The Vim Project (default to npx)
 
 if exists("current_compiler")
@@ -16,15 +16,15 @@ set cpo&vim
 " CompilerSet makeprg=tsc
 " CompilerSet makeprg=npx\ tsc
 exe 'CompilerSet makeprg=' .. escape(
-			\ (!empty(get(b:, 'tsc_makeprg', get(g:, 'tsc_makeprg', ''))) ?
-			\   get(b:, 'tsc_makeprg', get(g:, 'tsc_makeprg', '')) :
-			\   get(b:, 'javascript_node_makeprg', get(g:, 'javascript_node_makeprg', 'npx')) .. ' tsc')
-			\ .. ' ' ..
+                        \ (!empty(get(b:, 'tsc_makeprg', get(g:, 'tsc_makeprg', ''))) ?
+                        \   get(b:, 'tsc_makeprg', get(g:, 'tsc_makeprg', '')) :
+                        \   get(b:, 'javascript_node_makeprg', get(g:, 'javascript_node_makeprg', 'npx')) .. ' tsc')
+                        \ .. ' ' ..
                         \ get(b:, 'tsc_makeprg_params', get(g:, 'tsc_makeprg_params', '')), ' \|"')
 
 CompilerSet errorformat=%f\ %#(%l\\,%c):\ %trror\ TS%n:\ %m,
-		       \%trror\ TS%n:\ %m,
-		       \%-G%.%#
+                       \%trror\ TS%n:\ %m,
+                       \%-G%.%#
 
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/runtime/compiler/tsc.vim
+++ b/runtime/compiler/tsc.vim
@@ -23,8 +23,8 @@ exe 'CompilerSet makeprg=' .. escape(
                         \ get(b:, 'tsc_makeprg_params', get(g:, 'tsc_makeprg_params', '')), ' \|"')
 
 CompilerSet errorformat=%f\ %#(%l\\,%c):\ %trror\ TS%n:\ %m,
-                       \%trror\ TS%n:\ %m,
-                       \%-G%.%#
+		       \%trror\ TS%n:\ %m,
+		       \%-G%.%#
 
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/runtime/compiler/typedoc.vim
+++ b/runtime/compiler/typedoc.vim
@@ -16,14 +16,12 @@ set cpo&vim
 
 " CompilerSet makeprg=typedoc
 " CompilerSet makeprg=npx\ typedoc
-if !empty(escape(get(b:, 'typedoc_makeprg', get(g:, 'typedoc_makeprg', ''))))
-  execute $'CompilerSet makeprg={escape(get(b:, 'typedoc_makeprg', get(g:, 'typedoc_makeprg', 'typedoc')), ' \|"')}'
-else
-  exe 'CompilerSet makeprg=' .. escape(
-			\ get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' typedoc' ..
-			\ ' ' ..
+exe 'CompilerSet makeprg=' .. escape(
+			\ (!empty(get(b:, 'typedoc_makeprg', get(g:, 'typedoc_makeprg', ''))) ?
+			\   get(b:, 'typedoc_makeprg', get(g:, 'typedoc_makeprg', '')) :
+			\   (get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' typedoc'))
+			\ .. ' ' ..
                         \ get(b:, 'typedoc_makeprg_params', get(g:, 'typedoc_makeprg_params', '')), ' \|"')
-endif
 CompilerSet errorformat=%EError:\ %f(%l),
 		       \%WWarning:\ %f(%l),
 		       \%+IDocumentation\ generated\ at\ %f,

--- a/runtime/compiler/typedoc.vim
+++ b/runtime/compiler/typedoc.vim
@@ -2,6 +2,7 @@
 " Compiler:	TypeDoc
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:	2024 Apr 03
+"               2025 Nov 22 by The Vim Project (default to npx)
 
 if exists("current_compiler")
   finish
@@ -13,7 +14,12 @@ set cpo&vim
 
 " CompilerSet makeprg=npx\ typedoc
 
-CompilerSet makeprg=typedoc
+" CompilerSet makeprg=typedoc
+" CompilerSet makeprg=npx\ typedoc
+exe 'CompilerSet makeprg=' .. escape(
+			\ get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' typedoc' ..
+			\ ' ' ..
+                        \ get(b:, 'typedoc_makeprg_params', get(g:, 'typedoc_makeprg_params', '')), ' \|"')
 CompilerSet errorformat=%EError:\ %f(%l),
 		       \%WWarning:\ %f(%l),
 		       \%+IDocumentation\ generated\ at\ %f,

--- a/runtime/compiler/typedoc.vim
+++ b/runtime/compiler/typedoc.vim
@@ -16,10 +16,14 @@ set cpo&vim
 
 " CompilerSet makeprg=typedoc
 " CompilerSet makeprg=npx\ typedoc
-exe 'CompilerSet makeprg=' .. escape(
+if !empty(escape(get(b:, 'typedoc_makeprg', get(g:, 'typedoc_makeprg', ''))))
+  execute $'CompilerSet makeprg={escape(get(b:, 'typedoc_makeprg', get(g:, 'typedoc_makeprg', 'typedoc')), ' \|"')}'
+else
+  exe 'CompilerSet makeprg=' .. escape(
 			\ get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' typedoc' ..
 			\ ' ' ..
                         \ get(b:, 'typedoc_makeprg_params', get(g:, 'typedoc_makeprg_params', '')), ' \|"')
+endif
 CompilerSet errorformat=%EError:\ %f(%l),
 		       \%WWarning:\ %f(%l),
 		       \%+IDocumentation\ generated\ at\ %f,

--- a/runtime/compiler/typedoc.vim
+++ b/runtime/compiler/typedoc.vim
@@ -1,7 +1,7 @@
 " Vim compiler file
-" Compiler:	TypeDoc
-" Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2024 Apr 03
+" Compiler:     TypeDoc
+" Maintainer:   Doug Kearns <dougkearns@gmail.com>
+" Last Change:  2024 Apr 03
 "               2025 Nov 22 by The Vim Project (default to npx)
 
 if exists("current_compiler")
@@ -17,16 +17,16 @@ set cpo&vim
 " CompilerSet makeprg=typedoc
 " CompilerSet makeprg=npx\ typedoc
 exe 'CompilerSet makeprg=' .. escape(
-			\ (!empty(get(b:, 'typedoc_makeprg', get(g:, 'typedoc_makeprg', ''))) ?
-			\   get(b:, 'typedoc_makeprg', get(g:, 'typedoc_makeprg', '')) :
-			\   (get(b:, 'javascript_node_makeprg', get(g:, 'javascript_node_makeprg', 'npx')) .. ' typedoc'))
-			\ .. ' ' ..
+                        \ (!empty(get(b:, 'typedoc_makeprg', get(g:, 'typedoc_makeprg', ''))) ?
+                        \   get(b:, 'typedoc_makeprg', get(g:, 'typedoc_makeprg', '')) :
+                        \   (get(b:, 'javascript_node_makeprg', get(g:, 'javascript_node_makeprg', 'npx')) .. ' typedoc'))
+                        \ .. ' ' ..
                         \ get(b:, 'typedoc_makeprg_params', get(g:, 'typedoc_makeprg_params', '')), ' \|"')
 CompilerSet errorformat=%EError:\ %f(%l),
-		       \%WWarning:\ %f(%l),
-		       \%+IDocumentation\ generated\ at\ %f,
-		       \%Z\ %m,
-		       \%-G%.%#
+                       \%WWarning:\ %f(%l),
+                       \%+IDocumentation\ generated\ at\ %f,
+                       \%Z\ %m,
+                       \%-G%.%#
 
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/runtime/compiler/typedoc.vim
+++ b/runtime/compiler/typedoc.vim
@@ -23,10 +23,10 @@ exe 'CompilerSet makeprg=' .. escape(
                         \ .. ' ' ..
                         \ get(b:, 'typedoc_makeprg_params', get(g:, 'typedoc_makeprg_params', '')), ' \|"')
 CompilerSet errorformat=%EError:\ %f(%l),
-                       \%WWarning:\ %f(%l),
-                       \%+IDocumentation\ generated\ at\ %f,
-                       \%Z\ %m,
-                       \%-G%.%#
+		       \%WWarning:\ %f(%l),
+		       \%+IDocumentation\ generated\ at\ %f,
+		       \%Z\ %m,
+		       \%-G%.%#
 
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/runtime/compiler/typedoc.vim
+++ b/runtime/compiler/typedoc.vim
@@ -19,7 +19,7 @@ set cpo&vim
 exe 'CompilerSet makeprg=' .. escape(
 			\ (!empty(get(b:, 'typedoc_makeprg', get(g:, 'typedoc_makeprg', ''))) ?
 			\   get(b:, 'typedoc_makeprg', get(g:, 'typedoc_makeprg', '')) :
-			\   (get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' typedoc'))
+			\   (get(b:, 'javascript_node_makeprg', get(g:, 'javascript_node_makeprg', 'npx')) .. ' typedoc'))
 			\ .. ' ' ..
                         \ get(b:, 'typedoc_makeprg_params', get(g:, 'typedoc_makeprg_params', '')), ' \|"')
 CompilerSet errorformat=%EError:\ %f(%l),

--- a/runtime/compiler/xo.vim
+++ b/runtime/compiler/xo.vim
@@ -21,8 +21,8 @@ exe 'CompilerSet makeprg=' .. escape(
                         \ .. ' --reporter compact ' ..
                         \ get(b:, 'xo_makeprg_params', get(g:, 'xo_makeprg_params', '')), ' \|"')
 CompilerSet errorformat=%f:\ line\ %l\\,\ col\ %c\\,\ %trror\ %m,
-                       \%f:\ line\ %l\\,\ col\ %c\\,\ %tarning\ %m,
-                       \%-G%.%#
+		       \%f:\ line\ %l\\,\ col\ %c\\,\ %tarning\ %m,
+		       \%-G%.%#
 
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/runtime/compiler/xo.vim
+++ b/runtime/compiler/xo.vim
@@ -14,10 +14,14 @@ set cpo&vim
 
 " CompilerSet makeprg=xo
 " CompilerSet makeprg=npx\ xo
-exe 'CompilerSet makeprg=' .. escape(
+if !empty(escape(get(b:, 'xo_makeprg', get(g:, 'xo_makeprg', ''))))
+  execute $'CompilerSet makeprg={escape(get(b:, 'xo_makeprg', get(g:, 'xo_makeprg', 'xo')), ' \|"')}'
+else
+  exe 'CompilerSet makeprg=' .. escape(
 			\ get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' xo' ..
 			\ ' --reporter compact ' ..
                         \ get(b:, 'xo_makeprg_params', get(g:, 'xo_makeprg_params', '')), ' \|"')
+endif
 CompilerSet errorformat=%f:\ line\ %l\\,\ col\ %c\\,\ %trror\ %m,
 		       \%f:\ line\ %l\\,\ col\ %c\\,\ %tarning\ %m,
 		       \%-G%.%#

--- a/runtime/compiler/xo.vim
+++ b/runtime/compiler/xo.vim
@@ -1,7 +1,7 @@
 " Vim compiler file
-" Compiler:	XO
-" Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2024 Apr 03
+" Compiler:     XO
+" Maintainer:   Doug Kearns <dougkearns@gmail.com>
+" Last Change:  2024 Apr 03
 "               2025 Nov 22 by The Vim Project (default to npx)
 
 if exists("current_compiler")
@@ -15,14 +15,14 @@ set cpo&vim
 " CompilerSet makeprg=xo
 " CompilerSet makeprg=npx\ xo
 exe 'CompilerSet makeprg=' .. escape(
-			\ (!empty(get(b:, 'xo_makeprg', get(g:, 'xo_makeprg', ''))) ?
-			\   get(b:, 'xo_makeprg', get(g:, 'xo_makeprg', '')) :
-			\   (get(b:, 'javascript_node_makeprg', get(g:, 'javascript_node_makeprg', 'npx')) .. ' xo'))
-			\ .. ' --reporter compact ' ..
+                        \ (!empty(get(b:, 'xo_makeprg', get(g:, 'xo_makeprg', ''))) ?
+                        \   get(b:, 'xo_makeprg', get(g:, 'xo_makeprg', '')) :
+                        \   (get(b:, 'javascript_node_makeprg', get(g:, 'javascript_node_makeprg', 'npx')) .. ' xo'))
+                        \ .. ' --reporter compact ' ..
                         \ get(b:, 'xo_makeprg_params', get(g:, 'xo_makeprg_params', '')), ' \|"')
 CompilerSet errorformat=%f:\ line\ %l\\,\ col\ %c\\,\ %trror\ %m,
-		       \%f:\ line\ %l\\,\ col\ %c\\,\ %tarning\ %m,
-		       \%-G%.%#
+                       \%f:\ line\ %l\\,\ col\ %c\\,\ %tarning\ %m,
+                       \%-G%.%#
 
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/runtime/compiler/xo.vim
+++ b/runtime/compiler/xo.vim
@@ -17,7 +17,7 @@ set cpo&vim
 exe 'CompilerSet makeprg=' .. escape(
 			\ (!empty(get(b:, 'xo_makeprg', get(g:, 'xo_makeprg', ''))) ?
 			\   get(b:, 'xo_makeprg', get(g:, 'xo_makeprg', '')) :
-			\   (get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' xo'))
+			\   (get(b:, 'javascript_node_makeprg', get(g:, 'javascript_node_makeprg', 'npx')) .. ' xo'))
 			\ .. ' --reporter compact ' ..
                         \ get(b:, 'xo_makeprg_params', get(g:, 'xo_makeprg_params', '')), ' \|"')
 CompilerSet errorformat=%f:\ line\ %l\\,\ col\ %c\\,\ %trror\ %m,

--- a/runtime/compiler/xo.vim
+++ b/runtime/compiler/xo.vim
@@ -14,14 +14,12 @@ set cpo&vim
 
 " CompilerSet makeprg=xo
 " CompilerSet makeprg=npx\ xo
-if !empty(escape(get(b:, 'xo_makeprg', get(g:, 'xo_makeprg', ''))))
-  execute $'CompilerSet makeprg={escape(get(b:, 'xo_makeprg', get(g:, 'xo_makeprg', 'xo')), ' \|"')}'
-else
-  exe 'CompilerSet makeprg=' .. escape(
-			\ get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' xo' ..
-			\ ' --reporter compact ' ..
+exe 'CompilerSet makeprg=' .. escape(
+			\ (!empty(get(b:, 'xo_makeprg', get(g:, 'xo_makeprg', ''))) ?
+			\   get(b:, 'xo_makeprg', get(g:, 'xo_makeprg', '')) :
+			\   (get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' xo'))
+			\ .. ' --reporter compact ' ..
                         \ get(b:, 'xo_makeprg_params', get(g:, 'xo_makeprg_params', '')), ' \|"')
-endif
 CompilerSet errorformat=%f:\ line\ %l\\,\ col\ %c\\,\ %trror\ %m,
 		       \%f:\ line\ %l\\,\ col\ %c\\,\ %tarning\ %m,
 		       \%-G%.%#

--- a/runtime/compiler/xo.vim
+++ b/runtime/compiler/xo.vim
@@ -2,6 +2,7 @@
 " Compiler:	XO
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:	2024 Apr 03
+"               2025 Nov 22 by The Vim Project (default to npx)
 
 if exists("current_compiler")
   finish
@@ -11,9 +12,12 @@ let current_compiler = "xo"
 let s:cpo_save = &cpo
 set cpo&vim
 
-" CompilerSet makeprg=npx\ xo\ --reporter\ compact
-
-CompilerSet makeprg=xo\ --reporter\ compact
+" CompilerSet makeprg=xo
+" CompilerSet makeprg=npx\ xo
+exe 'CompilerSet makeprg=' .. escape(
+			\ get(b:, 'node_makeprg', get(g:, 'node_makeprg', 'npx')) .. ' xo' ..
+			\ ' --reporter compact ' ..
+                        \ get(b:, 'xo_makeprg_params', get(g:, 'xo_makeprg_params', '')), ' \|"')
 CompilerSet errorformat=%f:\ line\ %l\\,\ col\ %c\\,\ %trror\ %m,
 		       \%f:\ line\ %l\\,\ col\ %c\\,\ %tarning\ %m,
 		       \%-G%.%#

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -1292,7 +1292,7 @@ b/g:biome_makeprg variable.  For example: >
 	let b:biome_makeprg = "biome"
 
 Otherwise assumes installation by npm and run using npx. Adjust
-'b/g:node_makeprg' as needed to use, for example, pnpm/yarn dlx instead.
+'b/g:javascript_javascript_node_makeprg' as needed to use, for example, pnpm/yarn dlx instead.
 Compiler options can be added to 'makeprg' by setting the
 b/g:biome_makeprg_params variable.  For example (global default is ""): >
 
@@ -1760,7 +1760,7 @@ b/g:tsc_makeprg variable.  For example: >
 	let b:tsc_makeprg = "npx tsc --noEmit"
 
 Otherwise assumes installation by npm and run using npx.  Adjust
-'b/g:node_makeprg' as needed to use, for example, pnpm/yarn dlx instead.
+'b/g:javascript_javascript_node_makeprg' as needed to use, for example, pnpm/yarn dlx instead.
 
 Compiler options can then be added to 'makeprg' by setting the
 b/g:tsc_makeprg_params variable.  For example: >

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -1286,9 +1286,14 @@ BIOME				      *compiler-biome* *quickfix-biome*
 Biome check lints JavaScript, TypeScript, JSX, TSX, JSON, JSONC, HTML, Vue,
 Svelte, Astro, CSS, GraphQL and GritQL files.
 
-Assumes installation by npm and run using npx.  Adjust 'b/g:node_makeprg'
-as needed to use, for example, pnpm/yarn dlx instead.
-Commonly used compiler options can be added to 'makeprg' by setting the
+The executable and compiler options can be added to 'makeprg' by setting the
+b/g:biome_makeprg variable.  For example: >
+
+	let b:biome_makeprg = "biome"
+
+Otherwise assumes installation by npm and run using npx. Adjust
+'b/g:node_makeprg' as needed to use, for example, pnpm/yarn dlx instead.
+Compiler options can be added to 'makeprg' by setting the
 b/g:biome_makeprg_params variable.  For example (global default is ""): >
 
   let b:biome_makeprg_params = "--diagnostic-level=error --staged"
@@ -1749,9 +1754,15 @@ tombi linter.
 
 TSC COMPILER						*compiler-tsc*
 
-Assumes installation by npm and run using npx.  Adjust 'b/g:node_makeprg'
-as needed to use, for example, pnpm/yarn dlx instead.
-Compiler options can be added to 'makeprg' by setting the
+The executable and compiler options can be added to 'makeprg' by setting the
+b/g:tsc_makeprg variable.  For example: >
+
+	let b:tsc_makeprg = "npx tsc --noEmit"
+
+Otherwise assumes installation by npm and run using npx.  Adjust
+'b/g:node_makeprg' as needed to use, for example, pnpm/yarn dlx instead.
+
+Compiler options can then be added to 'makeprg' by setting the
 b/g:tsc_makeprg_params variable.  For example: >
 
 	let b:tsc_makeprg_params = "--noEmit"

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -1286,6 +1286,8 @@ BIOME				      *compiler-biome* *quickfix-biome*
 Biome check lints JavaScript, TypeScript, JSX, TSX, JSON, JSONC, HTML, Vue,
 Svelte, Astro, CSS, GraphQL and GritQL files.
 
+Assumes installation by npm and run using npx.  Adjust 'b/g:node_makeprg'
+as needed to use, for example, pnpm/yarn dlx instead.
 Commonly used compiler options can be added to 'makeprg' by setting the
 b/g:biome_makeprg_params variable.  For example (global default is ""): >
 
@@ -1747,10 +1749,12 @@ tombi linter.
 
 TSC COMPILER						*compiler-tsc*
 
-The executable and compiler options can be added to 'makeprg' by setting the
-b/g:tsc_makeprg variable.  For example: >
+Assumes installation by npm and run using npx.  Adjust 'b/g:node_makeprg'
+as needed to use, for example, pnpm/yarn dlx instead.
+Compiler options can be added to 'makeprg' by setting the
+b/g:tsc_makeprg_params variable.  For example: >
 
-	let b:tsc_makeprg = "npx tsc --noEmit"
+	let b:tsc_makeprg_params = "--noEmit"
 
 TYPST COMPILER						*compiler-typst*
 


### PR DESCRIPTION
Follow-up to closed https://github.com/vim/vim/pull/18755 
Now defaults to `npx` as suggested by @romainl and @dkearns ;  let the user optionally change it by `b/g:node_makeprg` and documented where documentation existed; @dkearns 's `b/g:tsc_makeprg` kept for backwards compatibility; would that be acceptable, @djmoch  ?