### PR TITLE
Fix Vim9 read-only register assignment compilation

### DIFF
--- a/src/testdir/test_vim9_assign.vim
+++ b/src/testdir/test_vim9_assign.vim
@@ -1592,12 +1592,17 @@ def Test_assignment_failure()
   v9.CheckDefFailure(['var $VAR = 5'], 'E1016: Cannot declare an environment variable:')
   v9.CheckScriptFailure(['vim9script', 'var $ENV = "xxx"'], 'E1016:')
 
+  # read-only registers
+  v9.CheckDefAndScriptFailure(['var @. = 5'], ['E354:', 'E1066:'], 1)
+  v9.CheckDefAndScriptFailure(['var @. = 5'], ['E354:', 'E1066:'], 1)
+  v9.CheckDefAndScriptFailure(['var @% = 5'], ['E354:', 'E1066:'], 1)
+  v9.CheckDefAndScriptFailure(['var @: = 5'], ['E354:', 'E1066:'], 1)
   if has('dnd')
-    v9.CheckDefFailure(['var @~ = 5'], 'E1066:')
+    v9.CheckDefAndScriptFailure(['var @~ = 5'], ['E354:', 'E1066:'], 1)
   else
-    v9.CheckDefFailure(['var @~ = 5'], 'E354:')
-    v9.CheckDefFailure(['@~ = 5'], 'E354:')
+    v9.CheckDefAndScriptFailure(['var @~ = 5'], ['E354:', 'E1066:'], 1)
   endif
+
   v9.CheckDefFailure(['var @a = 5'], 'E1066:')
   v9.CheckDefFailure(['var @/ = "x"'], 'E1066:')
   v9.CheckScriptFailure(['vim9script', 'var @a = "abc"'], 'E1066:')

--- a/src/testdir/test_vim9_expr.vim
+++ b/src/testdir/test_vim9_expr.vim
@@ -3352,7 +3352,11 @@ def Test_expr9_register()
   END
   v9.CheckDefAndScriptSuccess(lines)
 
+  # read-only registers
   v9.CheckDefAndScriptFailure(["@. = 'yes'"], 'E354:', 1)
+  v9.CheckDefAndScriptFailure(["@% = 'yes'"], 'E354:', 1)
+  v9.CheckDefAndScriptFailure(["@: = 'yes'"], 'E354:', 1)
+  v9.CheckDefAndScriptFailure(["@~ = 'yes'"], 'E354:', 1)
 enddef
 
 " This is slow when run under valgrind.

--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -1464,7 +1464,9 @@ vim9_declare_error(char_u *name)
     static int
 valid_dest_reg(int name)
 {
-    if ((name == '@' || valid_yank_reg(name, FALSE)) && name != '.')
+    if (name == '@')
+       name = '"';
+    if (name == '/' || name == '=' || valid_yank_reg(name, TRUE))
 	return TRUE;
     emsg_invreg(name);
     return FAIL;


### PR DESCRIPTION
Problem:  Assignment to read-only registers @: and @% is allowed during
          compilation.
Solution: Abort compilation and emit an E354 error when assigning to
          these registers.

Fix the E354 error emitted when attempting to declare @: with :var so
that it references the correct register, @:,  rather than the garbage
string "^@".

