### PR TITLE
Disable fuzzy sorting for the spell completion candidates

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -5710,7 +5710,7 @@ ins_compl_get_exp(pos_T *ini)
     }
     may_trigger_modechanged();
 
-    if (match_count > 0)
+    if (match_count > 0 && !ctrl_x_mode_spell())
     {
 	if (is_nearest_active() && !ins_compl_has_preinsert())
 	    sort_compl_match_list(cp_compare_nearest);

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -1320,6 +1320,23 @@ func Test_complete_wholeline()
   bw!
 endfunc
 
+" Test for using CTRL-X CTRL-S to complete spell suggestions
+func Test_complete_spell()
+  new
+  setlocal spell
+  " without fuzzy
+  call setline(1, 'The rigth thing')
+  exe "normal! A\<C-X>\<C-S>"
+  call assert_equal('The right thing', getline(1))
+  %d
+  " with fuzzy
+  setlocal completeopt+=fuzzy
+  call setline(1, 'The rigth thing')
+  exe "normal! A\<C-X>\<C-S>"
+  call assert_equal('The right thing', getline(1))
+  bw!
+endfunc
+
 " Test insert completion with 'cindent' (adjust the indent)
 func Test_complete_with_cindent()
   new


### PR DESCRIPTION
Disable fuzzy sort for the spell completion.

In general it should not have effect there as completion candidates are pre-sorted in the right order.

Fixes #18800 

@girishji if you have time, could you pls check if there is a better way to do so.