### PR TITLE
Fix Makefile highlighting when parentheses are used inside quotes

### DIFF
--- a/runtime/syntax/make.vim
+++ b/runtime/syntax/make.vim
@@ -45,15 +45,15 @@ syn match makeIdent	"^ *[^:#= \t]*\s*::="me=e-3
 syn match makeIdent	"^ *[^:#= \t]*\s*="me=e-1
 syn match makeIdent	"%"
 if get(b:, 'make_flavor', s:make_flavor) == 'microsoft'
-  syn region makeIdent	start="\$(" end=")" contains=makeStatement,makeIdent
-  syn region makeIdent	start="\${" end="}" contains=makeStatement,makeIdent
-  syn region makeIdent	start="\$\$(" end=")" containedin=makeDefine contains=makeStatement,makeIdent
-  syn region makeIdent	start="\$\${" end="}" containedin=makeDefine contains=makeStatement,makeIdent
+  syn region makeIdent	start="\$(" end=")" contains=makeStatement,makeIdent,makeDString,makeSString
+  syn region makeIdent	start="\${" end="}" contains=makeStatement,makeIdent,makeDString,makeSString
+  syn region makeIdent	start="\$\$(" end=")" containedin=makeDefine contains=makeStatement,makeIdent,makeDString,makeSString
+  syn region makeIdent	start="\$\${" end="}" containedin=makeDefine contains=makeStatement,makeIdent,makeDString,makeSString
 else
-  syn region makeIdent	start="\$(" skip="\\)\|\\\\" end=")" contains=makeStatement,makeIdent
-  syn region makeIdent	start="\${" skip="\\}\|\\\\" end="}" contains=makeStatement,makeIdent
-  syn region makeIdent	start="\$\$(" skip="\\)\|\\\\" end=")" containedin=makeDefine contains=makeStatement,makeIdent
-  syn region makeIdent	start="\$\${" skip="\\}\|\\\\" end="}" containedin=makeDefine contains=makeStatement,makeIdent
+  syn region makeIdent	start="\$(" skip="\\)\|\\\\" end=")" contains=makeStatement,makeIdent,makeDString,makeSString
+  syn region makeIdent	start="\${" skip="\\}\|\\\\" end="}" contains=makeStatement,makeIdent,makeDString,makeSString
+  syn region makeIdent	start="\$\$(" skip="\\)\|\\\\" end=")" containedin=makeDefine contains=makeStatement,makeIdent,makeDString,makeSString
+  syn region makeIdent	start="\$\${" skip="\\}\|\\\\" end="}" containedin=makeDefine contains=makeStatement,makeIdent,makeDString,makeSString
 endif
 
 " Makefile.in variables


### PR DESCRIPTION
Problem:  Makefile syntax highlighting incorrectly ends function calls
          when encountering ')' inside double or single quoted strings,
          causing incorrect highlighting for the remainder of the line.

Solution: Add makeDString and makeSString to the contains list for
          makeIdent regions. This allows strings to be recognized inside
          variable references and function calls.

Fixes: #18687

I have created this commit message following the style used in
recent commits. Feel free to let me know if that has to be
changed, and I will do so. 