### PR TITLE
runtime(erlang): recognize .xrl (leex) files

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -1921,6 +1921,7 @@ const ft_from_ext = {
   # ERicsson LANGuage; Yaws is erlang too
   "erl": "erlang",
   "hrl": "erlang",
+  "xrl": "erlang",
   "yaws": "erlang",
   # Elm
   "elm": "elm",

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -275,7 +275,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     elsa: ['file.lc'],
     elvish: ['file.elv'],
     epuppet: ['file.epp'],
-    erlang: ['file.erl', 'file.hrl', 'file.yaws'],
+    erlang: ['file.erl', 'file.hrl', 'file.xrl', 'file.yaws'],
     eruby: ['file.erb', 'file.rhtml'],
     esdl: ['file.esdl'],
     esmtprc: ['anyesmtprc', 'esmtprc', 'some-esmtprc'],


### PR DESCRIPTION
leex is the Erlang lexer framework. Its input files are named with the .xrl extension and contain Erlang syntax.

https://www.erlang.org/doc/apps/parsetools/leex.html