### PR TITLE
fix Test_matchfuzzy_initialized

### DIFF
--- a/src/testdir/test_matchfuzzy.vim
+++ b/src/testdir/test_matchfuzzy.vim
@@ -305,6 +305,13 @@ func Test_matchfuzzy_initialized()
   let job = term_getjob(buf)
   if job_status(job) == "run"
     call job_stop(job, "int")
+    " The search might or might not have been completed. If the search is
+    " finished and Vim receives a SIGINT, then that will trigger a message
+    " next time Vim is active:
+    "   Type  :qa  and press <Enter> to exit Vim
+    " If we do not send something here to trigger displaying the message, before
+    " TermWait(), then the exit sequence sent afterward does not work.
+    call term_sendkeys(buf, "\<C-O>")
     call TermWait(buf, 50)
   endif
 

--- a/src/testdir/test_matchfuzzy.vim
+++ b/src/testdir/test_matchfuzzy.vim
@@ -300,7 +300,9 @@ func Test_matchfuzzy_initialized()
 
   let buf = RunVimInTerminal('-u NONE -X -Z', {})
   call term_sendkeys(buf, ":source XTest_matchfuzzy\n")
-  call TermWait(buf, 2000)
+  " Use term_wait directly rather than the TermWait wrapper; otherwise,
+  " retries become very slow.
+  call term_wait(buf, 2000)
 
   let job = term_getjob(buf)
   if job_status(job) == "run"


### PR DESCRIPTION
The first patch fixes https://github.com/vim/vim/issues/18821. This is a best-effort fix: I don't understand the problem absolutely 100%, but I think the fix still works.

The second patch makes the test not get very slow when retried. Trying to debug the test for the previous issue took longer because the test was so slow.

Thanks,
Corey