### PR TITLE
Fix comment for reverting C comment strings

### DIFF
--- a/runtime/defaults.vim
+++ b/runtime/defaults.vim
@@ -136,7 +136,7 @@ if &t_Co > 2 || has("gui_running")
   syntax on
 
   " I like highlighting strings inside C comments.
-  " Revert with ":unlet c_comment_strings".
+  " Revert with ":unlet g:c_comment_strings".
   let c_comment_strings=1
 endif
 


### PR DESCRIPTION
Add `g:` so example works in vim9script as well (errors without it).