### PR TITLE
Clarification in listener_add docs.

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -6773,9 +6773,10 @@ listener_add({callback} [, {buf} [, {unbuffered}]])	*listener_add()*
 		The entries are in the order the changes were made, thus the
 		most recent change is at the end.
 
-		Because of the third trigger reason for triggering a callback
-		listed above, the line numbers passed to the callback are not
-		guaranteed to be valid.  If this is a problem then make
+		Because of the third reason for triggering a callback listed
+		above, the line numbers passed to the callback are not
+		guaranteed to be valid. In particular, the end value can be
+		greater than line('$') + 1. If this is a problem then make
 		{unbuffered} |TRUE|.
 
 		When {unbuffered} is |TRUE| the {callback} is invoked for every


### PR DESCRIPTION
Make it clear that the overall end value can be greter than line('$') + 1.

closes: #18664