### PR TITLE
do not copy writes to the '+' register to the '*' register

### DIFF
--- a/src/register.c
+++ b/src/register.c
@@ -1171,9 +1171,6 @@ op_yank(oparg_T *oap, int deleting, int mess)
     linenr_T		yankendlnum = oap->end.lnum;
     char_u		*pnew;
     struct block_def	bd;
-#if defined(FEAT_CLIPBOARD) && (defined(FEAT_X11) || defined(FEAT_WAYLAND_CLIPBOARD))
-    int			did_star = FALSE;
-#endif
 
 				    // check for read-only register
     if (oap->regname != 0 && !valid_yank_reg(oap->regname, TRUE))
@@ -1397,16 +1394,10 @@ op_yank(oparg_T *oap, int deleting, int mess)
 
 	clip_own_selection(&clip_star);
 	clip_gen_set_selection(&clip_star);
-# if defined(FEAT_X11) || defined(FEAT_WAYLAND_CLIPBOARD)
-	did_star = TRUE;
-# endif
     }
 
 # if defined(FEAT_X11) || defined(FEAT_WAYLAND_CLIPBOARD)
     // If we were yanking to the '+' register, send result to selection.
-    // Also copy to the '*' register, in case auto-select is off.  But not when
-    // 'clipboard' has "unnamedplus" and not "unnamed"; and not when
-    // deleting and both "unnamedplus" and "unnamed".
     if (clip_plus.available
 	    && (curr == &(y_regs[PLUS_REGISTER])
 		|| (!deleting && oap->regname == 0
@@ -1419,18 +1410,6 @@ op_yank(oparg_T *oap, int deleting, int mess)
 
 	clip_own_selection(&clip_plus);
 	clip_gen_set_selection(&clip_plus);
-	if (!clip_isautosel_star()
-		&& !clip_isautosel_plus()
-		&& !((clip_unnamed | clip_unnamed_saved) == CLIP_UNNAMED_PLUS)
-		&& !(deleting && (clip_unnamed | clip_unnamed_saved)
-					 == (CLIP_UNNAMED | CLIP_UNNAMED_PLUS))
-		&& !did_star
-		&& curr == &(y_regs[PLUS_REGISTER]))
-	{
-	    copy_yank_reg(&(y_regs[STAR_REGISTER]));
-	    clip_own_selection(&clip_star);
-	    clip_gen_set_selection(&clip_star);
-	}
     }
 # endif
 #endif

--- a/src/testdir/test_registers.vim
+++ b/src/testdir/test_registers.vim
@@ -520,6 +520,38 @@ func Test_clipboard_regs()
   bwipe!
 endfunc
 
+" When clipboard registers (* and +) are supported, check that they are
+" independent for direct writes.
+func Test_clipboard_regs_separate()
+  CheckNotGui
+  CheckFeature clipboard_working
+  CheckTwoClipboards
+
+  new
+  call setline(1, ['foo'])
+
+  " Check that various clipboard options do not result in one register
+  " affecting the other.
+  for clip in ['', 'autoselect', 'unnamed', 'unnamedplus']
+    :execute 'set clipboard=' . clip
+    " check that * does not affect +
+    let @* = 'xxx'
+    let @+ = 'xxx'
+    :normal "*yw
+    call assert_equal('foo', getreg('*'))
+    call assert_equal('xxx', getreg('+'))
+
+    " check that + does not affect *
+    let @* = 'xxx'
+    :normal "+yw
+    call assert_equal('foo', getreg('+'))
+    call assert_equal('xxx', getreg('*'))
+  endfor
+
+  set clipboard&vim
+  bwipe!
+endfunc
+
 " Test unnamed for both clipboard registers (* and +)
 func Test_clipboard_regs_both_unnamed()
   CheckNotGui


### PR DESCRIPTION
Before this change, writes to '+' get copied to '\*', but only under certain conditions. By default, this does not happen, because clipboard autoselect is enabled. Disabling autoselect (an option which should only apply to visual mode) results in normal-mode writes such as "+yy also going to the '\*' register.

This behavior is undocumented and untested; remove the behavior in order to make Vim's handling of these two registers be consistent.

fixes: #18830