### PR TITLE
runtime(erlang): recognize more Erlang filenames

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -3072,6 +3072,8 @@ const ft_from_name = {
   ".editorconfig": "editorconfig",
   # Elinks configuration
   "elinks.conf": "elinks",
+  # Erlang
+  "rebar.config": "erlang",
   # Exim
   "exim.conf": "exim",
   # Exports

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -428,7 +428,7 @@ au BufNewFile,BufRead *.e,*.E			call dist#ft#FTe()
 au BufNewFile,BufRead filter-rules		setf elmfilt
 
 " Erlang
-au BufNewFile,BufRead *.app.src,rebar.config	setf erlang
+au BufNewFile,BufRead *.app.src			setf erlang
 
 " ESMTP rc file
 au BufNewFile,BufRead *esmtprc			setf esmtprc

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -427,6 +427,9 @@ au BufNewFile,BufRead *.e,*.E			call dist#ft#FTe()
 " Elm Filter Rules file
 au BufNewFile,BufRead filter-rules		setf elmfilt
 
+" Erlang
+au BufNewFile,BufRead *.app.src,rebar.config	setf erlang
+
 " ESMTP rc file
 au BufNewFile,BufRead *esmtprc			setf esmtprc
 

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -275,7 +275,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     elsa: ['file.lc'],
     elvish: ['file.elv'],
     epuppet: ['file.epp'],
-    erlang: ['file.erl', 'file.hrl', 'file.yaws'],
+    erlang: ['file.erl', 'file.hrl', 'file.yaws', 'file.app.src', 'rebar.config'],
     eruby: ['file.erb', 'file.rhtml'],
     esdl: ['file.esdl'],
     esmtprc: ['anyesmtprc', 'esmtprc', 'some-esmtprc'],


### PR DESCRIPTION
*.app.src files contain Erlang application definitions. (There are also *.app files, which are similar but more often build artifacts, and that file extension is too ambiguous to be recognized by default.) https://www.erlang.org/doc/system/applications.html

Rebar is the Erlang build tool. rebar.config uses Erlang syntax. https://rebar3.org/docs/configuration/configuration/