### PR TITLE
feat: add fullscreen mode support for Windows GUI

### DIFF
--- a/runtime/doc/gui_w32.txt
+++ b/runtime/doc/gui_w32.txt
@@ -504,4 +504,25 @@ To use the system's default title bar colors, set highlighting groups to
 	hi TitleBar guibg=NONE guifg=NONE
 	hi TitleBarNC guibg=NONE guifg=NONE
 <
+
+Full Screen						*gui-w32-fullscreen*
+
+To enable fullscreen mode in the Windows GUI version of Vim, add the 's' flag
+to the 'guioptions' setting.
+
+For convenience, you can define a command or mapping to toggle fullscreen mode:
+>
+	command! ToggleFullscreen {
+		if &guioptions =~# 's'
+			set guioptions-=s
+		else
+			set guioptions+=s
+		endif
+	}
+
+	map <expr> <F11> &go =~# 's' ? ":se go-=s<CR>" : ":se go+=s<CR>"
+
+The fullscreen mode will occupy the entire screen area while hiding window
+decorations such as the title bar and borders.
+
  vim:tw=78:sw=4:ts=8:noet:ft=help:norl:

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4572,6 +4572,12 @@ A jump table for the options with a short description can be found at |Q_op|.
 								*'go-T'*
 	  'T'	Include Toolbar.  Currently only in Win32, GTK+, Motif and
 		Photon GUIs.
+								*'go-s'*
+	  's'	Enable fullscreen mode.  Currently only supported in the
+		MS-Windows GUI version.  When set, the window will occupy the
+		entire screen and remove window decorations.  Define custom
+		mappings to toggle this mode conveniently.  For detailed usage
+		instructions, see |gui-w32-fullscreen|.
 								*'go-r'*
 	  'r'	Right-hand scrollbar is always present.
 								*'go-R'*

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -377,6 +377,7 @@ $quote	eval.txt	/*$quote*
 'go-m'	options.txt	/*'go-m'*
 'go-p'	options.txt	/*'go-p'*
 'go-r'	options.txt	/*'go-r'*
+'go-s'	options.txt	/*'go-s'*
 'go-t'	options.txt	/*'go-t'*
 'go-v'	options.txt	/*'go-v'*
 'gp'	options.txt	/*'gp'*
@@ -8248,6 +8249,7 @@ gui-vert-scroll	gui.txt	/*gui-vert-scroll*
 gui-w32	gui_w32.txt	/*gui-w32*
 gui-w32-cmdargs	gui_w32.txt	/*gui-w32-cmdargs*
 gui-w32-dialogs	gui_w32.txt	/*gui-w32-dialogs*
+gui-w32-fullscreen	gui_w32.txt	/*gui-w32-fullscreen*
 gui-w32-printing	gui_w32.txt	/*gui-w32-printing*
 gui-w32-start	gui_w32.txt	/*gui-w32-start*
 gui-w32-title-bar	gui_w32.txt	/*gui-w32-title-bar*

--- a/runtime/doc/version9.txt
+++ b/runtime/doc/version9.txt
@@ -41724,6 +41724,8 @@ Options: ~
   (see also the below platform specific change).
 - 'guioptions': Support darkmode on MS-Windows for menu and title bar using
   |'go-d'| (see also the below platform specific change).
+- 'guioptions': New value |'go-s'| to support fullscreen on MS-Windows GUI
+  (see also the below platform specific change).
 - 'completepopup': Add more values to style popup windows.
 
 Ex commands: ~
@@ -41768,6 +41770,7 @@ Platform specific ~
 - MS-Windows: Vim no longer searches the current directory for
   executables when running external commands; prefix a relative or absolute
   path if you want the old behavior |$NoDefaultCurrentDirectoryInExePath|.
+- MS-Windows: New value |'go-s'| to support fullscreen on MS-Windows GUI
 
 - macOS: increase default scheduler priority to TASK_DEFAULT_APPLICATION.
 

--- a/src/gui.c
+++ b/src/gui.c
@@ -158,6 +158,12 @@ gui_start(char_u *arg UNUSED)
 	gui_gtk_init_socket_server();
 #endif
 
+#ifdef FEAT_GUI_MSWIN
+    // Enable fullscreen mode
+    if (vim_strchr(p_go, GO_FULLSCREEN) != NULL)
+       gui_mch_set_fullscreen(TRUE);
+#endif
+
     vim_free(old_term);
 
     // If the GUI started successfully, trigger the GUIEnter event, otherwise
@@ -3498,6 +3504,9 @@ gui_init_which_components(char_u *oldval UNUSED)
 #ifdef FEAT_GUI_MSWIN
     static int	prev_titlebar = FALSE;
     int		using_titlebar = FALSE;
+
+    static int	prev_fullscreen = FALSE;
+    int		using_fullscreen = FALSE;
 #endif
 #if defined(FEAT_MENU)
     static int	prev_tearoff = -1;
@@ -3572,6 +3581,9 @@ gui_init_which_components(char_u *oldval UNUSED)
 	    case GO_TITLEBAR:
 		using_titlebar = TRUE;
 		break;
+	    case GO_FULLSCREEN:
+		using_fullscreen = TRUE;
+		break;
 #endif
 #ifdef FEAT_TOOLBAR
 	    case GO_TOOLBAR:
@@ -3599,6 +3611,12 @@ gui_init_which_components(char_u *oldval UNUSED)
     {
 	gui_mch_set_titlebar_colors();
 	prev_titlebar = using_titlebar;
+    }
+
+    if (using_fullscreen != prev_fullscreen)
+    {
+	gui_mch_set_fullscreen(using_fullscreen);
+	prev_fullscreen = using_fullscreen;
     }
 #endif
 

--- a/src/option.h
+++ b/src/option.h
@@ -303,13 +303,14 @@ typedef enum {
 #define GO_ASELPLUS	'P'		// autoselectPlus
 #define GO_RIGHT	'r'		// use right scrollbar
 #define GO_VRIGHT	'R'		// right scrollbar with vert split
+#define GO_FULLSCREEN	's'		// enter fullscreen
 #define GO_TEAROFF	't'		// add tear-off menu items
 #define GO_TOOLBAR	'T'		// add toolbar
 #define GO_FOOTER	'F'		// add footer
 #define GO_VERTICAL	'v'		// arrange dialog buttons vertically
 #define GO_KEEPWINSIZE	'k'		// keep GUI window size
 // all possible flags for 'go'
-#define GO_ALL		"!aAbcCdefFghilLmMpPrRtTvk"
+#define GO_ALL		"!aAbcCdefFghilLmMpPrRstTvk"
 
 // flags for 'comments' option
 #define COM_NEST	'n'		// comments strings nest

--- a/src/proto/gui_w32.pro
+++ b/src/proto/gui_w32.pro
@@ -44,6 +44,7 @@ int gui_mch_showing_tabline(void);
 void gui_mch_update_tabline(void);
 void gui_mch_set_curtab(int nr);
 void gui_mch_set_dark_theme(int dark);
+void gui_mch_set_fullscreen(int flag);
 void ex_simalt(exarg_T *eap);
 void gui_mch_find_dialog(exarg_T *eap);
 void gui_mch_replace_dialog(exarg_T *eap);

--- a/src/testdir/test_gui.vim
+++ b/src/testdir/test_gui.vim
@@ -664,10 +664,10 @@ func Test_set_guioptions()
     set guioptions&
     call assert_equal('egmrLtT', &guioptions)
 
-    set guioptions+=C
+    set guioptions+=s
     exec 'sleep' . duration
-    call assert_equal('egmrLtTC', &guioptions)
-    set guioptions-=C
+    call assert_equal('egmrLtTs', &guioptions)
+    set guioptions-=s
     exec 'sleep' . duration
     call assert_equal('egmrLtT', &guioptions)
 


### PR DESCRIPTION
- Implement fullscreen mode controlled by the 'go-s' flag in 'guioptions'
- Note: 'go-s' flag cannot be set prior to window initialization due to
  timing constraints in the GUI loading process
- Update documentation with usage examples and platform-specific details
- But version9.txt has not been written yet.

See :help 'go-s' and :help gui-w32-fullscreen for complete documentation.

Signed-off-by: Mao-Yining <mao.yining@outlook.com>
