### PR TITLE
Add `status_height` to the dict items returned by `getwininfo()`

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -5343,9 +5343,13 @@ getwininfo([{winid}])					*getwininfo()*
 					{only with the +quickfix feature}
 			quickfix	1 if quickfix or location list window
 					{only with the +quickfix feature}
+			status_height	status lines height (0 or 1)
+			tabnr		tab page number
 			terminal	1 if a terminal window
 					{only with the +terminal feature}
-			tabnr		tab page number
+			textoff		number of columns occupied by any
+					'foldcolumn', 'signcolumn' and line
+					number in front of the text
 			topline		first displayed buffer line
 			variables	a reference to the dictionary with
 					window-local variables
@@ -5354,9 +5358,6 @@ getwininfo([{winid}])					*getwininfo()*
 					otherwise
 			wincol		leftmost screen column of the window;
 					"col" from |win_screenpos()|
-			textoff		number of columns occupied by any
-					'foldcolumn', 'signcolumn' and line
-					number in front of the text
 			winid		|window-ID|
 			winnr		window number
 			winrow		topmost screen line of the window;

--- a/src/evalwindow.c
+++ b/src/evalwindow.c
@@ -416,6 +416,7 @@ get_win_info(win_T *wp, short tpnr, short winnr)
     dict_add_number(dict, "winnr", winnr);
     dict_add_number(dict, "winid", wp->w_id);
     dict_add_number(dict, "height", wp->w_height);
+    dict_add_number(dict, "status_height", wp->w_status_height);
     dict_add_number(dict, "winrow", wp->w_winrow + 1);
     dict_add_number(dict, "topline", wp->w_topline);
     dict_add_number(dict, "botline", wp->w_botline - 1);

--- a/src/testdir/test_bufwintabinfo.vim
+++ b/src/testdir/test_bufwintabinfo.vim
@@ -204,4 +204,26 @@ func Test_getwininfo_au()
   bwipe!
 endfunc
 
+func Test_getwininfo_status_height()
+  set laststatus=0
+  vsplit
+  let info = getwininfo(win_getid())[0]
+  call assert_equal(0, info.status_height)
+
+  set laststatus=2
+  let info = getwininfo(win_getid())[0]
+  call assert_equal(1, info.status_height)
+
+  set laststatus=1
+  only
+  let info = getwininfo(win_getid())[0]
+  call assert_equal(0, info.status_height)
+  vsplit
+  let info = getwininfo(win_getid())[0]
+  call assert_equal(1, info.status_height)
+
+  set laststatus&vim
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
I think it's strange that this hasn't existed until now.

(In addition, the order of items in the `getwininfo()` documentation has been changed to alphabetical order)