### PR TITLE
runtime(erlang): Improve application resource file detection

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -3,7 +3,7 @@ vim9script
 # Vim functions for file type detection
 #
 # Maintainer:		The Vim Project <https://github.com/vim/vim>
-# Last Change:		2025 Nov 30
+# Last Change:		2025 Dec 07
 # Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 # These functions are moved here from runtime/filetype.vim to make startup
@@ -27,6 +27,28 @@ export def Check_inp()
       n += 1
     endwhile
   endif
+enddef
+
+# Erlang Application Resource Files (*.app.src is matched by extension)
+# See: https://erlang.org/doc/system/applications
+export def FTapp()
+  if exists("g:filetype_app")
+    exe "setf " .. g:filetype_app
+    return
+  endif
+  const pat = '^\s*{\s*application\s*,\s*\(''\=\)' .. expand("%:t:r:r") .. '\1\s*,'
+  var line: string
+  for lnum in range(1, min([line("$"), 100]))
+    line = getline(lnum)
+    # skip Erlang comments, might be something else
+    if line =~ '^\s*%' || line =~ '^\s*$'
+      continue
+    elseif line =~ '^\s*{' &&
+	getline(lnum, lnum + 9)->filter((_, v) => v !~ '^\s*%')->join(' ') =~# pat
+      setf erlang
+    endif
+    return
+  endfor
 enddef
 
 # This function checks for the kind of assembly that is wanted by the user, or

--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -138,6 +138,7 @@ what kind of file it is.  This doesn't always work.  A number of global
 variables can be used to overrule the filetype used for certain extensions:
 
 	file name	variable ~
+	*.app		g:filetype_app
 	*.asa		g:filetype_asa		|ft-aspperl-syntax|
 						|ft-aspvbs-syntax|
 	*.asm		g:asmsyntax		|ft-asm-syntax|

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -427,8 +427,9 @@ au BufNewFile,BufRead *.e,*.E			call dist#ft#FTe()
 " Elm Filter Rules file
 au BufNewFile,BufRead filter-rules		setf elmfilt
 
-" Erlang
+" Erlang Application Resource Files
 au BufNewFile,BufRead *.app.src			setf erlang
+au BufNewFile,BufRead *.app			call dist#ft#FTapp()
 
 " ESMTP rc file
 au BufNewFile,BufRead *esmtprc			setf esmtprc

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -3248,4 +3248,34 @@ func Test_m4_format()
   filetype off
 endfunc
 
+" Erlang Application Resource File
+func Test_app_file()
+  filetype on
+
+  call writefile(['% line comment', '{application, xfile1,'], 'xfile1.app', 'D')
+  split xfile1.app
+  call assert_equal('erlang', &filetype)
+  bwipe!
+
+  call writefile(['% line comment', "{application, 'Xfile2',"], 'Xfile2.app', 'D')
+  split Xfile2.app
+  call assert_equal('erlang', &filetype)
+  bwipe!
+
+  call writefile([' % line comment',
+        \ ' ',
+        \ ' % line comment',
+        \ ' { ',
+        \ ' % line comment ',
+        \ ' application , ',
+        \ ' % line comment ',
+        \ ' xfile3 , '],
+        \ 'xfile3.app', 'D')
+  split xfile3.app
+  call assert_equal('erlang', &filetype)
+  bwipe!
+
+  filetype off
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Add content-based filetype detection for application resource files matching extension `*.app` or `*.app.src`.

Related: #18835

@jparise @hcs42, does this make sense?  Those extensions are generic and the content appears easy to match.

I don't know a lick of Erlang so I may be missing something...or everything.
