### PR TITLE
feat: tag jump support vertical split

### DIFF
--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -880,6 +880,18 @@ the buffer.  The result is that all buffers will use the 'encoding' encoding
 		Does ":tag[!] [tagname]" and splits the window for the found
 		tag.  See also |:tag|.
 
+CTRL-W [						*CTRL-W_[*
+		Vertical split current window in two.  Use identifier under
+		cursor as a tag and jump to it in the new window.  The
+		position of the new window depends on the value of
+		'splitright'. In Visual mode uses the Visually selected
+		text as a tag. Make new window N high.
+							*CTRL-W_g[*
+CTRL-W g [	Like |CTRL-W_]|, but vertical split current window in two.
+		Use identifier under cursor as a tag and perform ":tselect"
+		on it in the new window. In Visual mode uses the
+		Visually selected text as a tag. Make new window N high.
+
 CTRL-W ]					*CTRL-W_]* *CTRL-W_CTRL-]*
 CTRL-W CTRL-]	Split current window in two.  Use identifier under cursor as a
 		tag and jump to it in the new upper window.

--- a/src/normal.c
+++ b/src/normal.c
@@ -3414,6 +3414,7 @@ nv_K_getcmd(
 /*
  * Handle the commands that use the word under the cursor.
  * [g] CTRL-]	:ta to current identifier
+ * [g] CTRL-[	:ta to current identifier
  * [g] 'K'	run program for current identifier
  * [g] '*'	/ to current identifier or string
  * [g] '#'	? to current identifier or string
@@ -3437,7 +3438,7 @@ nv_ident(cmdarg_T *cap)
     int		tag_cmd = FALSE;
     char_u	*aux_ptr;
 
-    if (cap->cmdchar == 'g')	// "g*", "g#", "g]" and "gCTRL-]"
+    if (cap->cmdchar == 'g')	// "g*", "g#", "g]", "g[" and "gCTRL-]"
     {
 	cmdchar = cap->nchar;
 	g_cmd = TRUE;
@@ -3513,6 +3514,7 @@ nv_ident(cmdarg_T *cap)
 	    break;
 
 	case ']':
+	case '[':
 	    tag_cmd = TRUE;
 #ifdef FEAT_CSCOPE
 	    if (p_cst)

--- a/src/testdir/test_tagjump.vim
+++ b/src/testdir/test_tagjump.vim
@@ -1670,4 +1670,77 @@ func Test_tag_excmd_with_number_vim9script()
   bwipe!
 endfunc
 
+func Test_tag_jump_split()
+  call writefile(["!_TAG_FILE_ENCODING\tutf-8\t//",
+        \ "second\tXtpfile1\t2",
+        \ "third\tXtpfile1\t3",],
+        \ 'Xtags', 'D')
+  call writefile(['first', 'second', 'third'], 'Xtpfile1', 'D')
+  set tags=Xtags
+  let cwin = win_getid()
+  edit Xtpfile1
+  " vertical split at the left
+  call cursor(3, 1)
+  wincmd [
+  let new_win = win_getid()
+  call assert_equal(1, new_win > cwin)
+  call assert_equal(1, winwidth(new_win) < &columns)
+  call assert_equal(1, getwininfo(new_win)[0]['wincol'] == 1)
+
+  " vertical split at the right
+  wincmd p
+  only
+  set splitright
+  wincmd [
+  let new_win = win_getid()
+  call assert_equal(1, new_win > cwin)
+  call assert_equal(1, winwidth(new_win) < &columns)
+  call assert_equal(1, getwininfo(new_win)[0]['wincol'] > 1)
+
+  " vertical split with tselect
+  wincmd p
+  only
+  call feedkeys(":\<C-u>wincmd g[\<CR>1\<CR>", 'xt')
+  let new_win = win_getid()
+  call assert_equal(1, new_win > cwin)
+  call assert_equal(1, winwidth(new_win) < &columns)
+  call assert_equal(1, getwininfo(new_win)[0]['wincol'] > 1)
+
+  " split horizontally at the top
+  wincmd p
+  only
+  call feedkeys(":\<C-u>wincmd g]\<CR>1\<CR>", 'xt')
+  let new_win = win_getid()
+  call assert_equal(1, new_win > cwin)
+  call assert_equal(1, getwininfo(cwin)[0]['winrow'] > 1)
+
+  " split horizontally with tselect
+  wincmd p
+  only
+  wincmd ]
+  let new_win = win_getid()
+  call assert_equal(1, new_win > cwin)
+  call assert_equal(1, getwininfo(cwin)[0]['winrow'] > 1)
+
+  " split horizontally at the below
+  set splitbelow
+  wincmd p
+  only
+  wincmd ]
+  let new_win = win_getid()
+  call assert_equal(1, new_win > cwin)
+  call assert_equal(1, getwininfo(new_win)[0]['winrow'] > 1)
+
+  wincmd p
+  only
+  call feedkeys(":\<C-u>wincmd g]\<CR>1\<CR>", 'xt')
+  let new_win = win_getid()
+  call assert_equal(1, new_win > cwin)
+  call assert_equal(1, getwininfo(new_win)[0]['winrow'] > 1)
+
+  set tags&
+  set splitright&
+  set splitbelow&
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem: Tag jump currently only works with horizontal splits, not vertical splits.

Solution: Add support for vertical splits using `wincmd [` or `<C-w>(g)[`

Most modern desktop monitors are quite large. With only horizontal splits, screen space isn’t fully utilized. Vertical splits could be more useful.