### PR TITLE
syntax(i3config+swayconfig): identifier + output option matcher style cleanup

### DIFF
--- a/runtime/syntax/i3config.vim
+++ b/runtime/syntax/i3config.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language: i3 config file
 " Original Author: Josef Litos (litoj/i3config.vim)
-" Maintainer: Quentin Hibon (github user hiqua)
+" Maintainer: Josef Litos (litoj)
 " Version: 1.2.7
 " Last Change: 2025-12-02
 

--- a/runtime/syntax/i3config.vim
+++ b/runtime/syntax/i3config.vim
@@ -2,6 +2,7 @@
 " Language: i3 config file
 " Original Author: Josef Litos (litoj/i3config.vim)
 " Maintainer: Josef Litos (litoj)
+" Previous maintainer: Quentin Hibon (github user hiqua)
 " Version: 1.2.7
 " Last Change: 2025-12-02
 

--- a/runtime/syntax/i3config.vim
+++ b/runtime/syntax/i3config.vim
@@ -2,8 +2,8 @@
 " Language: i3 config file
 " Original Author: Josef Litos (litoj/i3config.vim)
 " Maintainer: Quentin Hibon (github user hiqua)
-" Version: 1.2.5
-" Last Change: 2025-11-24
+" Version: 1.2.7
+" Last Change: 2025-12-02
 
 " References:
 " http://i3wm.org/docs/userguide.html#configuring
@@ -51,8 +51,8 @@ syn match i3ConfigComment /#.*$/ contained contains=i3ConfigTodo
 " 4.3 Fonts
 syn match i3ConfigFontSize / \d\+\(px\)\?$/ contained
 syn match i3ConfigColonOperator /:/ contained
-syn match i3ConfigFontNamespace /pango:/ contained contains=i3ConfigColonOperator
-syn region i3ConfigParamLine matchgroup=i3ConfigKeyword start=/font / skip=/\\$/ end=/$/ contained contains=i3ConfigFontNamespace,i3ConfigFontSize,i3ConfigSeparator keepend containedin=i3ConfigBarBlock
+syn match i3ConfigFontNamespace /\(pango\|xft\):/ contained contains=i3ConfigColonOperator
+syn region i3ConfigFont matchgroup=i3ConfigKeyword start=/font / skip=/\\$/ end=/$/ contained contains=i3ConfigFontNamespace,i3ConfigFontSize,i3ConfigSeparator keepend
 
 " 4.4-4.5 Keyboard/Mouse bindings
 syn match i3ConfigBindArgument /--\(release\|border\|whole-window\|exclude-titlebar\) / contained nextgroup=i3ConfigBindArgument,i3ConfigBindCombo
@@ -64,7 +64,9 @@ syn region i3ConfigBind start=/\zs/ skip=/\\$/ end=/$/ contained contains=@i3Con
 syn keyword i3ConfigBindKeyword bindsym bindcode contained skipwhite nextgroup=i3ConfigBindArgument,i3ConfigBindCombo
 
 " 4.6 Binding modes
-syn region i3ConfigModeBlock matchgroup=i3ConfigKeyword start=/mode\ze\( --pango_markup\)\? \([^'" {]\+\|'[^']\+'\|".\+"\)\s\+{$/ end=/^}\zs$/ contained contains=i3ConfigShParam,@i3ConfigStrVar,i3ConfigBindKeyword,i3ConfigComment,i3ConfigParen fold keepend extend
+syn region i3ConfigModeBlock matchgroup=i3ConfigParen start=/{$/ end=/^\s*}$/ contained contains=i3ConfigComment,i3ConfigBindKeyword fold keepend
+syn match i3ConfigModeIdent /[^ ,;]\+/ contained contains=@i3ConfigStrVar extend skipwhite nextgroup=i3ConfigModeBlock
+syn match i3ConfigKeyword /mode\( --pango_markup\)\?/ contained contains=i3ConfigShParam skipwhite nextgroup=i3ConfigModeIdent
 
 " 4.7 Floating modifier
 syn match i3ConfigKeyword /floating_modifier [$A-Z][0-9A-Za-z]*$/ contained contains=i3ConfigVariable,i3ConfigBindModkey
@@ -120,17 +122,15 @@ syn region i3ConfigKeyword start=/assign / end=/$/ contained contains=i3ConfigAs
 syn region i3ConfigShCommand matchgroup=i3ConfigShDelim start=/\$(/ end=/)/ contained contains=i3ConfigExecAction,i3ConfigShCommand,i3ConfigShDelim,i3ConfigShOper,i3ConfigShParam,i3ConfigString,i3ConfigNumber,i3ConfigVariable extend
 syn match  i3ConfigShDelim /[[\]{}();`]\+/ contained
 syn match  i3ConfigShOper /[<>&|+=~^*!.?]\+/ contained
-syn match i3ConfigShParam /\<-[A-Za-z-][0-9A-Za-z_-]*\>/ contained
-syn cluster i3ConfigSh contains=@i3ConfigIdent,i3ConfigShOper,i3ConfigShDelim,i3ConfigShParam,i3ConfigShCommand
+syn match i3ConfigShParam /\s\zs-[A-Za-z-][0-9A-Za-z_-]*\>/ contained
+syn cluster i3ConfigSh contains=@i3ConfigIdent,i3ConfigShOper,i3ConfigShDelim,i3ConfigShParam,i3ConfigShCommand,i3ConfigComment
 syn region i3ConfigExec start=/ \ze[^{]/ skip=/\\$/ end=/$/ contained contains=i3ConfigExecAction,@i3ConfigSh keepend
 syn keyword i3ConfigKeyword exec_always exec contained nextgroup=i3ConfigExec
 
 " 4.21 Workspaces per output
-syn match i3ConfigOutputIdent /[^'",; ]\+/ contained contains=@i3ConfigIdent,i3ConfigColonOperator skipwhite nextgroup=i3ConfigOutputIdent
-syn region i3ConfigOutputIdent start=/['"]/ end=/\ze/ contained contains=@i3ConfigIdent skipwhite nextgroup=i3ConfigOutputIdent
+syn match i3ConfigOutputIdent /[^ ,;]\+/ contained contains=@i3ConfigIdent,i3ConfigColonOperator skipwhite nextgroup=i3ConfigOutputIdent extend
 syn keyword i3ConfigOutput output contained skipwhite nextgroup=i3ConfigOutputIdent
-syn match i3ConfigWorkspaceIdent /[^'",; ]\+/ contained contains=@i3ConfigIdent skipwhite nextgroup=i3ConfigGaps,i3ConfigOutput
-syn region i3ConfigWorkspaceIdent start=/['"]/ end=/\ze/ contained contains=@i3ConfigIdent skipwhite nextgroup=i3ConfigGaps,i3ConfigOutput
+syn match i3ConfigWorkspaceIdent /[^ ,;]\+/ contained contains=@i3ConfigIdent skipwhite nextgroup=i3ConfigGaps,i3ConfigOutput extend
 syn keyword i3ConfigKeyword workspace contained skipwhite nextgroup=i3ConfigWorkspaceIdent
 
 " 4.22 Changing colors
@@ -191,7 +191,9 @@ syn keyword i3ConfigBarOpts modifier contained skipwhite nextgroup=i3ConfigBindC
 syn keyword i3ConfigBarOpts i3bar_command status_command workspace_command contained skipwhite nextgroup=@i3ConfigSh
 syn keyword i3ConfigBarOpts mode hidden_state id position output tray_output tray_padding separator_symbol workspace_buttons workspace_min_width strip_workspace_numbers strip_workspace_name binding_mode_indicator padding contained skipwhite nextgroup=i3ConfigBarOptVals,@i3ConfigValue,i3ConfigShOper
 syn keyword i3ConfigBarOptVals dock hide invisible show none top bottom primary nonprimary contained
-syn region i3ConfigBarBlock matchgroup=i3ConfigKeyword start=/bar\ze {$/ end=/^\s*}\zs$/ contained contains=i3ConfigBarOpts,i3ConfigComment,i3ConfigParen,i3ConfigBindKeyword,i3ConfigColorsBlock fold keepend extend
+
+syn region i3ConfigBarBlock matchgroup=i3ConfigParen start=/ {$/ end=/^\s*}$/ contained contains=i3ConfigBarOpts,i3ConfigComment,i3ConfigBindKeyword,i3ConfigColorsBlock,i3ConfigFont fold keepend
+syn keyword i3ConfigKeyword bar contained nextgroup=i3ConfigBarBlock
 
 " 5.16 Color block
 syn match i3ConfigColorSeq /#[0-9A-Fa-f]\{3,8}\|\$[0-9A-Za-z_:|[\]-]\+/ contained contains=@i3ConfigColVar skipwhite nextgroup=i3ConfigColorSeq
@@ -262,9 +264,9 @@ syn match i3ConfigMarkOpt /--\(add\|replace\)\( --toggle\)\?/ contained contains
 syn keyword i3ConfigActionKeyword mark contained skipwhite nextgroup=i3ConfigMarkOpt,i3ConfigOutputIdent
 
 " Commands usable for direct config calls - for enforcing start of line for Commands
-syn match i3ConfigTopLevelDirective /^\s*/ nextgroup=i3ConfigComment,i3ConfigKeyword,i3ConfigCommand,i3ConfigBindKeyword,i3ConfigParamLine,i3ConfigModeBlock,i3ConfigBarBlock,i3ConfigError
+syn match i3ConfigTopLevelDirective /^\s*/ nextgroup=i3ConfigComment,i3ConfigKeyword,i3ConfigCommand,i3ConfigBindKeyword,i3ConfigParamLine,i3ConfigFont,i3ConfigError
 
-" Commands useable in keybinds
+" Commands usable in keybinds
 syn keyword i3ConfigActionKeyword mode append_layout kill open fullscreen sticky split floating swap unmark title_window_icon title_format border restart reload exit scratchpad nop bar contained skipwhite nextgroup=i3ConfigOption,@i3ConfigValue
 syn keyword i3ConfigOption default enable disable toggle key restore current horizontal vertical auto none normal pixel show container with id con_id padding hidden_state hide dock invisible contained skipwhite nextgroup=i3ConfigOption,@i3ConfigValue
 " Commands usable at runtime (outside loading config)
@@ -283,15 +285,18 @@ hi def link i3ConfigBoolean                         Boolean
 hi def link i3ConfigString                          String
 hi def link i3ConfigColor                           Constant
 hi def link i3ConfigNumber                          Number
+hi def link i3ConfigIdent                           Identifier
 hi def link i3ConfigComment                         Comment
 hi def link i3ConfigColonOperator                   i3ConfigOperator
 hi def link i3ConfigFontNamespace                   i3ConfigOption
 hi def link i3ConfigFontSize                        i3ConfigNumber
+hi def link i3ConfigFont                            i3ConfigParamLine
 hi def link i3ConfigBindArgument                    i3ConfigShParam
 hi def link i3ConfigBindModifier                    i3ConfigOperator
 hi def link i3ConfigBindModkey                      Special
 hi def link i3ConfigBindCombo                       SpecialChar
 hi def link i3ConfigBindKeyword                     i3ConfigKeyword
+hi def link i3ConfigModeIdent                       i3ConfigIdent
 hi def link i3ConfigSizeSpecial                     i3ConfigOperator
 hi def link i3ConfigOrientationOpts                 i3ConfigOption
 hi def link i3ConfigWorkspaceLayoutOpts             i3ConfigOption
@@ -305,9 +310,9 @@ hi def link i3ConfigShParam                         PreProc
 hi def link i3ConfigShDelim                         Delimiter
 hi def link i3ConfigShOper                          Operator
 hi def link i3ConfigShCommand                       Normal
-hi def link i3ConfigOutputIdent                     i3ConfigParamLine
+hi def link i3ConfigOutputIdent                     i3ConfigIdent
 hi def link i3ConfigOutput                          i3ConfigMoveType
-hi def link i3ConfigWorkspaceIdent                  i3ConfigParamLine
+hi def link i3ConfigWorkspaceIdent                  i3ConfigIdent
 hi def link i3ConfigDotOperator                     i3ConfigOperator
 hi def link i3ConfigClientOpts                      i3ConfigOption
 hi def link i3ConfigFocusFollowsMouseOpts           i3ConfigOption
@@ -343,6 +348,7 @@ hi def link i3ConfigResizeExtra                     i3ConfigOption
 hi def link i3ConfigResizeDir                       i3ConfigOption
 hi def link i3ConfigResizeType                      i3ConfigOption
 hi def link i3ConfigMark                            i3ConfigCommand
+hi def link i3ConfigMarkOpt                         i3ConfigOption
 hi def link i3ConfigActionKeyword                   i3ConfigCommand
 hi def link i3ConfigOption                          Type
 

--- a/runtime/syntax/swayconfig.vim
+++ b/runtime/syntax/swayconfig.vim
@@ -2,9 +2,8 @@
 " Language: sway config file
 " Original Author: Josef Litos (litoj/i3config.vim)
 " Maintainer: James Eapen <james.eapen@vai.org>
-" Version: 1.2.6
-" Last Change: 2025 Nov 24
-" 2025 Sep 23 by Vim Project update swayconfig syntax #18293
+" Version: 1.2.7
+" Last Change: 2025-12-02
 
 " References:
 " http://i3wm.org/docs/userguide.html#configuring
@@ -40,6 +39,7 @@ syn region i3ConfigBindCombo matchgroup=i3ConfigParen start=/{$/ end=/^\s*}$/ co
 " hack for blocks with start outside parsing range
 syn region swayConfigBlockOrphan start=/^\s\+\(--[a-z-]\+ \)*\([$A-Z][$0-9A-Za-z_+]\+\|[a-z]\) [a-z[]/ skip=/\\$\|$\n^\s*}$/ end=/$/ contains=i3ConfigBindArgument,i3ConfigBindCombo,i3ConfigParen keepend extend
 
+" Note: braces highlighted by @i3ConfigSh already
 syn region i3ConfigExec start=/ {$/ end=/^\s*}$/ contained contains=i3ConfigExecAction,@i3ConfigSh,i3ConfigComment fold keepend extend
 
 syn keyword swayConfigFloatingModifierOpts normal inverse none contained
@@ -47,6 +47,10 @@ syn match i3ConfigKeyword /floating_modifier \(none\|[$A-Z][0-9A-Za-z]\+ \(norma
 
 syn match swayConfigI3Param /--i3/ contains=i3ConfigShParam skipwhite nextgroup=i3ConfigEdgeOpts
 syn keyword i3ConfigKeyword hide_edge_borders contained skipwhite nextgroup=swayConfigI3Param,i3ConfigEdgeOpts
+
+" accept bar ids in the form: bar <id> { ... }
+syn match swayConfigBarIdent /[^{ ,;]\+/ contained contains=@i3ConfigStrVar skipwhite nextgroup=i3ConfigBarBlock
+syn keyword i3ConfigKeyword bar contained skipwhite nextgroup=swayConfigBarIdent,i3ConfigBarBlock
 
 syn keyword i3ConfigBarOpts swaybar_command contained skipwhite nextgroup=@i3ConfigSh
 syn region i3ConfigBarOpts matchgroup=i3ConfigBarOpts start=/gaps/ end=/$/ contained contains=@i3ConfigNumVar
@@ -65,8 +69,7 @@ syn keyword swayConfigInhibitOpts focus fullscreen open none visible contained
 syn keyword i3ConfigActionKeyword inhibit_idle contained skipwhite nextgroup=swayConfigInhibitOpts
 
 " Primary selection
-" Allow tearing
-syn keyword i3ConfigKeyword primary_selection allow_tearing contained skipwhite nextgroup=i3ConfigBoolean
+syn keyword i3ConfigKeyword primary_selection contained skipwhite nextgroup=i3ConfigBoolean
 
 " Swaybg command
 " Swaynag command
@@ -112,43 +115,46 @@ syn match swayConfigInputAngle /\(3[0-5][0-9]\|[1-2]\?[0-9]\{1,2\}\)\(\.[0-9]\+\
 syn keyword swayConfigInputOpts rotation_angle contained skipwhite nextgroup=swayConfigInputAngle
 
 syn region swayConfigInput start=/\s/ skip=/\\$/ end=/\ze[,;]\|$/ contained contains=swayConfigInputOpts,@i3ConfigValue keepend
-syn region swayConfigInput matchgroup=i3ConfigParen start=/ {$/ end=/^\s*}$/ contained contains=swayConfigInputOpts,@i3ConfigValue,i3ConfigComment keepend extend
-syn keyword swayConfigInputType touchpad pointer keyboard touch tablet_tool tablet_pad switch contained nextgroup=swayConfigInput
-syn match swayConfigInputIdent /type:!\?/ contained contains=swayConfigDeviceOper nextgroup=swayConfigInputType
-syn match swayConfigInputIdent /[^t '"]\S*/ contained contains=i3ConfigOutputIdent nextgroup=swayConfigInput
-syn region swayConfigInputIdent start=/['"]/ end=/\ze/ contained contains=i3ConfigOutputIdent nextgroup=swayConfigInput
-syn keyword i3ConfigKeyword input contained skipwhite nextgroup=swayConfigInputIdent
+syn region swayConfigInput matchgroup=i3ConfigParen start=/ {$/ end=/^\s*}$/ contained contains=swayConfigInputOpts,@i3ConfigValue,i3ConfigComment keepend
+syn keyword swayConfigInputType touchpad pointer keyboard touch tablet_tool tablet_pad switch contained skipwhite nextgroup=swayConfigInput
+syn match swayConfigInputTypeIdent /type:!\?/ contained contains=swayConfigDeviceOper skipwhite nextgroup=swayConfigInputType
+syn match swayConfigInputIdent /[^t ,;][^ ,;]*/ contained contains=@i3ConfigStrVar skipwhite nextgroup=swayConfigInput extend
+syn keyword i3ConfigKeyword input contained skipwhite nextgroup=swayConfigInputTypeIdent,swayConfigInputIdent
 
 " Seat
 syn keyword swayConfigSeatOpts cursor fallback hide_cursor keyboard_grouping shortcuts_inhibitor pointer_constraint xcursor_theme contained skipwhite nextgroup=swayConfigSeatOptVals,@i3ConfigValue
-syn match swayConfigInputTypeSeq / \w\+/ contained contains=swayConfigInputType nextgroup=swayConfigInputTypeSeq,swayConfigSeatOpts
+syn match swayConfigInputTypeSeq / \w\+/ contained contains=swayConfigInputType skipwhite nextgroup=swayConfigInputTypeSeq,swayConfigSeatOpts
 syn keyword swayConfigSeatOpts idle_inhibit idle_wake contained nextgroup=swayConfigInputTypeSeq
 syn keyword swayConfigSeatOpts attach contained skipwhite nextgroup=swayConfigSeatIdent
 syn match swayConfigSeatOptVals /when-typing/ contained skipwhite nextgroup=swayConfigSeatOptVals
 syn keyword swayConfigSeatOptVals move set press release none smart activate deactivate toggle escape enable disable contained skipwhite nextgroup=swayConfigSeatOpts
 syn region swayConfigSeat start=/\s/ skip=/\\$/ end=/\ze[,;]\|$/ contained contains=swayConfigSeatOpts,@i3ConfigValue keepend
-syn region swayConfigSeat matchgroup=i3ConfigParen start=/ {$/ end=/^\s*}$/ contained contains=swayConfigSeatOpts,@i3ConfigValue,i3ConfigComment keepend extend
-syn match swayConfigSeatIdent /[^ ]\+/ contained contains=i3ConfigOutputIdent skipwhite nextgroup=swayConfigSeat
+syn region swayConfigSeat matchgroup=i3ConfigParen start=/ {$/ end=/^\s*}$/ contained contains=swayConfigSeatOpts,@i3ConfigValue,i3ConfigComment keepend
+syn match swayConfigSeatIdent /[^ ,;]\+/ contained contains=@i3ConfigStrVar nextgroup=swayConfigSeat extend
 syn keyword i3ConfigKeyword seat contained skipwhite nextgroup=swayConfigSeatIdent
 
 " Output monitors
-syn keyword swayConfigOutputOpts mode resolution res modeline position pos scale scale_filter subpixel transform disable enable power dpms max_render_time adaptive_sync render_bit_depth color_profile allow_tearing contained skipwhite nextgroup=swayConfigOutputOptVals,@i3ConfigValue,swayConfigOutputMode
-syn keyword swayConfigOutputOptVals linear nearest smart rgb bgr vrgb vbgr none clockwise anticlockwise toggle srgb icc contained skipwhite nextgroup=swayConfigOutputOptVals,@i3ConfigValue,i3ConfigShOper
+syn keyword swayConfigOutputOpts mode resolution res modeline position pos scale scale_filter subpixel transform disable enable toggle power dpms max_render_time adaptive_sync render_bit_depth color_profile allow_tearing contained skipwhite nextgroup=swayConfigOutputOptVals,@i3ConfigValue,swayConfigOutputMode
+syn keyword swayConfigOutputOptVals linear nearest smart rgb bgr vrgb vbgr none toggle srgb contained skipwhite nextgroup=swayConfigOutputOptVals,@i3ConfigValue
 syn keyword swayConfigOutputBgVals solid_color fill stretch fit center tile contained skipwhite nextgroup=@i3ConfigColVar
-syn match swayConfigOutputBg /[#$]\S\+ solid_color/ contained contains=@i3ConfigColVar,swayConfigOutputBgVals
-syn match swayConfigOutputBg /[^b# '"]\S*/ contained contains=i3ConfigShOper skipwhite nextgroup=swayConfigOutputBgVals
-syn region swayConfigOutputBg start=/['"]/ end=/\ze/ contained contains=@i3ConfigIdent skipwhite nextgroup=swayConfigOutputBgVals
+syn match swayConfigOutputBg /[#$]\S\+ solid_color/ contained contains=@i3ConfigColVar,swayConfigOutputBgVals skipwhite nextgroup=swayConfigOutputOpts
+syn match swayConfigOutputBg /[^b# ,;][^ ,;]*/ contained contains=@i3ConfigStrVar skipwhite nextgroup=swayConfigOutputBgVals extend
 syn keyword swayConfigOutputOpts bg background contained skipwhite nextgroup=swayConfigOutputBg
 syn match swayConfigOutputFPS /@[0-9.]\+Hz/ contained skipwhite nextgroup=swayConfigOutputOpts
 syn match swayConfigOutputMode /\(--custom \)\?[0-9]\+x[0-9]\+/ contained contains=i3ConfigShParam skipwhite nextgroup=swayConfigOutputFPS,swayConfigOutputOpts
-syn match swayConfigOutputOptVals /\(flipped-\)\?\(90\|180\|270\)\|flipped\|normal/ contained contains=i3ConfigNumber skipwhite nextgroup=swayConfigOutputOptsVals
+" clockwise and anticlockwise are relative -> only as bindings / user actions - not in config setup
+syn match swayConfigOutputOptVals /\(\(flipped-\)\?\(90\|180\|270\)\|flipped\|normal\)\( \(anti\)\?clockwise\)\?/ contained contains=i3ConfigNumber skipwhite nextgroup=swayConfigOutputOpts
+syn match swayConfigOutputICCPath /\S\+/ contained contains=@i3ConfigStrVar skipwhite nextgroup=swayConfigOutputOpts extend
+syn keyword swayConfigOutputOptVals icc contained skipwhite nextgroup=swayConfigOutputICCPath
 syn region swayConfigOutput start=/\s/ skip=/\\$/ end=/\ze[,;]\|$/ contained contains=swayConfigOutputOpts,@i3ConfigValue keepend
-syn region swayConfigOutput matchgroup=i3ConfigParen start=/ {$/ end=/^\s*}$/ contained contains=swayConfigOutputOpts,@i3ConfigValue,i3ConfigComment keepend extend
-syn match swayConfigOutputIdent /[^ ]\+/ contained contains=i3ConfigOutputIdent skipwhite nextgroup=swayConfigOutput
+syn region swayConfigOutput matchgroup=i3ConfigParen start=/ {$/ end=/^\s*}$/ contained contains=swayConfigOutputOpts,@i3ConfigValue,i3ConfigComment keepend
+syn match swayConfigOutputIdent /[^ ,;]\+/ contained contains=@i3ConfigIdent skipwhite nextgroup=swayConfigOutput extend
 syn keyword i3ConfigKeyword output contained skipwhite nextgroup=swayConfigOutputIdent
+syn keyword i3ConfigActionKeyword output contained skipwhite nextgroup=swayConfigOutputIdent
 
 " Define the highlighting.
 hi def link swayConfigFloatingModifierOpts   i3ConfigOption
+hi def link swayConfigBarIdent               i3ConfigIdent
 hi def link swayConfigXOpt                   i3ConfigOption
 hi def link swayConfigInhibitOpts            i3ConfigOption
 hi def link swayConfigBindswitchArgument     i3ConfigBindArgument
@@ -159,7 +165,8 @@ hi def link swayConfigBindgestureType        i3ConfigMoveType
 hi def link swayConfigBindgestureDir         i3ConfigMoveDir
 hi def link swayConfigDeviceOper             i3ConfigOperator
 hi def link swayConfigInputType              i3ConfigMoveType
-hi def link swayConfigInputIdent             i3ConfigMoveDir
+hi def link swayConfigInputTypeIdent         i3ConfigMoveDir
+hi def link swayConfigInputIdent             i3ConfigIdent
 hi def link swayConfigInputOptVals           i3ConfigShParam
 hi def link swayConfigInputOpts              i3ConfigOption
 hi def link swayConfigInputAngle             i3ConfigNumber
@@ -168,10 +175,14 @@ hi def link swayConfigXkbOptsPair            i3ConfigShParam
 hi def link swayConfigXkbLayout              i3ConfigParamLine
 hi def link swayConfigSeatOptVals            swayConfigInputOptVals
 hi def link swayConfigSeatOpts               swayConfigInputOpts
+hi def link swayConfigSeatIdent              i3ConfigIdent
 hi def link swayConfigOutputOptVals          swayConfigInputOptVals
 hi def link swayConfigOutputBgVals           swayConfigInputOptVals
+hi def link swayConfigOutputBg               i3ConfigString
+hi def link swayConfigOutputICCPath          i3ConfigString
 hi def link swayConfigOutputOpts             swayConfigInputOpts
 hi def link swayConfigOutputFPS              Constant
 hi def link swayConfigOutputMode             i3ConfigNumber
+hi def link swayConfigOutputIdent            i3ConfigIdent
 
 let b:current_syntax = "swayconfig"


### PR DESCRIPTION
- cleanup of PR for tearing (#18293) and cleanup of other output options
  - removed `allow_tearing` from global keywords (it's only an output option)
  - moved `...clockwise` directives from general to transform options
  - separated `icc` highlight to correctly detect and highlight paths
  - updated output bg to use the same approach as `icc` for file path highlighting
- updated all identifier-matchers to the same design
  - complex (`"string"`) or referenced (`$var`) identifiers always included
    - `extend` fixes string matches to recognize there was some text already matched (otherwise errors as it thinks it was an empty space)
    - string matches skip spaces first and thereby extend the match over spaces - we can drop space parsing from the identifier match itself
  - one-word identifiers get highlighted with the respective identifier highlight group
    - therefore `OutputIdent` mostly removed since it was misused for setting the highlight, not parsing
  - all identifiers now stop before the `,;` command separators
- added support for bar identifiers in swayconfig (and supporting bar matcher restructure in i3config)
  - separate fonts group now added to the block top-down-style; no `containedin`
  - updated implementation of #18814
    - as already mentioned: fonts have their own group, bar ID added only for sway
- separated input _type_ and _device name_ highlights
- added missing highlight defaults for mark options
- removed `extend` from block commands that cannot be in another block

(Syntax tested with <https://github.com/litoj/i3config.vim/blob/master/test.swayconfig#L222>)

Ping @jamespeapen @hiqua 