### PR TITLE
runtime/doc/vim9.txt Section 1

### DIFF
--- a/runtime/doc/vim9.txt
+++ b/runtime/doc/vim9.txt
@@ -1,4 +1,4 @@
-*vim9.txt*	For Vim version 9.1.  Last change: 2025 Nov 30
+*vim9.txt*	For Vim version 9.1.  Last change: 2025 Dec 03
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -64,7 +64,7 @@ dictionary adds quite a lot of overhead.  In a Vim9 function this dictionary
 is not available.  Other differences are more subtle, such as how errors are
 handled.
 
-The Vim9 script syntax and semantics are used in:
+Vim9 script syntax, semantics, and behavior apply in:
 - a function defined with the `:def` command
 - a script file where the first command is `vim9script`
 - an autocommand defined in the context of the above
@@ -78,18 +78,72 @@ Vim9 script and legacy Vim script can be mixed.  There is no requirement to
 rewrite old scripts, they keep working as before.  You may want to use a few
 `:def` functions for code that needs to be fast.
 
-:vim9[cmd] {cmd}				*:vim9* *:vim9cmd* *E1164*
-		Evaluate and execute {cmd} using Vim9 script syntax and
-		semantics.  Useful when typing a command and in a legacy
-		script or function.
+:vim9[cmd] {cmd}				*:vim9* *:vim9cmd*
+		Evaluate and execute {cmd} using Vim9 script syntax,
+		semantics, and behavior.  Useful when typing a command,
+		in a `:function`, or a legacy Vim script.
 
-:leg[acy] {cmd}					*:leg* *:legacy* *E1189* *E1234*
-		Evaluate and execute {cmd} using legacy script syntax and
-		semantics.  Only useful in a Vim9 script or a :def function.
-		Note that {cmd} cannot use local variables, since it is parsed
-		with legacy expression syntax.
+		The following short example shows how a legacy Vim script
+		command and a :vim9cmd (so Vim9 script context) may appear
+		similar, though may differ not just syntactically, but also
+		semantically and behaviorally. >vim
 
-See some examples of Vim9 script at |52.6|.
+		  call popup_notification('entrée'[5:]
+		    \ ->str2list()->string(), #{time: 7000})
+		  vim9cmd popup_notification('entrée'[5 :]
+		      ->str2list()->string(), {time: 7000})
+<
+		 Notes: 1) The reason for the different output is Vim9 script
+			   uses character indexing whereas legacy Vim script
+			   uses byte indexing - see |vim9-string-index|.
+			2) Syntax is different too.  In Vim9 script:
+			  - The space in "[5 :]" is mandatory (see
+			    |vim9-white-space|).
+			  - Line continuation with "\" is not required.
+			  - The "#" (to avoid putting quotes around dictionary
+			    keys) is neither required nor allowed - see |#{}|.
+
+						*E1164*
+		`:vim9cmd` cannot stand alone; it must be followed by a command.
+
+:leg[acy] {cmd}					*:leg* *:legacy*
+		Evaluate and execute {cmd} using legacy Vim script syntax,
+		semantics, and behavior.  It is only applicable in a Vim9
+		script or a `:def` function.  Using an equivalent script to
+		the one, above (see its notes for why the output differs): >vim9
+
+		  vim9script
+		  # Legacy context - so, this creates a popup with [769, 101]
+		  legacy call popup_notification('entrée'[5:]
+		    \ ->str2list()->string(), #{time: 7000})
+		  # Vim9 script context - so, this creates a pop up with [101]
+		  popup_notification('entrée'[5 :]
+		      ->str2list()->string(), {time: 7000})
+<
+		Vim9 script script-local variables may be used by prefixing
+		"s:", like in legacy Vim script.  This example shows the
+		difference in syntax: "k" for the script-local variable in
+		Vim9 script, "s:k" in the legacy Vim script context. >vim9
+
+		  vim9script
+		  var k: string = "Okay"
+		  echo k
+		  legacy echo s:k
+<						*E1189*
+		Using `:legacy` is not allowed in compiled Vim9 script
+		control flow contexts. For example: >vim9
+
+		  vim9script
+		  def F_1189()
+		    if v:version == 900
+		    # E1189: Cannot use :legacy with this command: endif
+		    legacy endif
+		  enddef
+		  F_1189()
+<						*E1234*
+		`:legacy` cannot stand alone; it must be followed by a command.
+
+
 ==============================================================================
 
 2. Differences from legacy Vim script			*vim9-differences*


### PR DESCRIPTION
# vim9.txt - Section 1 - rewrite &#x2F; enhancements

Locations of changes are indicated by reference to **&#x2A;tag&#x2A;** in the updated file.

## 1. What is Vim9 script?

- The paragraph starting, “Vim9 script syntax ...”, is updated to include “behavior”.  That is because some things operate/behave differently too.  So, it is not just a matter of syntax and semantics differing.
- [_Not changed:_]
  - The sentence, “When using `:function`”, is not quite the whole story - e.g., behaviour may differ too.  It would be too early (and dilute the point about `scriptversion`) for an example, though a variant of the example now provided at `:vim9[cmd]` would demonstrate that it is not just a matter of syntax:

    ```
    vim9script
    function Elegacy()
        echo 'é'[0]
    endfunction
    def Enine(): void
        echo 'é'[0]
    enddef
    Elegacy()  # Echos byte <c3>
    Enine()    # Echos é
    ```

  - The `scriptversion` point is a bit inconsistent in using the word, “highest”, noting that `eval.txt` says explicitly:

    > When using a legacy function, defined with &#x60;:function&#x60;, in |Vim9| script then scriptversion 4 is used.”

    (It is probably of little consequence with, I'm guessing, most of those reading `vim9.txt` not wanting to use legacy Vim script anyway, and even fewer wanting to use a `scriptversion` other than the latest.)

**&#x2A;:vim9&#x2A; &#x2A;:vim9cmd&#x2A;**

- The tag `*E1164*` is relocated later (with an example).
- The paragraph is extended to stress that behaviour is relevant too.
- An example and explanation demonstrates the points, i.e., just a few lines show important differences in syntax, semantics, and behaviour.
  It _could_ also include this explanation (in the first note):

  ```
  In the first popup notification, the result is "[769, 101]", being the
  second byte of the penultimate character, "é" - itself made up of "e" and a
  combining acute accent (U+0301, decimal 769) - and the last character, "e"
  (U+0065, decimal 101).  The second popup notification returns "[101]"
  because the sixth character in the string is the "e" (i.e., at the end
  of the word, "entrée".
  ```
  That has not been provided.  I think that may be too much / dilute the other the points.

**&#x2A;E1164&#x2A;**

- This is separated because it is specific to using `:vim9[cmd]` without any following command.

**&#x2A;:leg&#x2A; &#x2A;:legacy&#x2A;**

- Tags `*E1189*` and `*E1234*` are relocated later because they are caused by very specific things (which deserve distinct, explicit explanations).
- The first two sentences have similar adjustments as the one relating to `:vim9cmd`.  The example, which is the Vim9 script equivalent to the example preceding it, is similarly brief.
- The Note, “cannot use local variables”, is amended.  That is because `:legacy` _can_ utilise Vim9 script-local variables by prefixing "s:", just like in a legacy Vim script.  So, the paragraph replaces the Note, and now focuses on what you _can_ do.

**&#x2A;E1189&#x2A;**

- This is explained, along with an example.  The current help is silent on what the error is caused by, which is not very helpful.

**&#x2A;E1234&#x2A;**

- Like `*E1164*`, for a standalone `vim9cmd`, this is explained separately, though should hopefully be sufficiently obvious to not require an example. <br/>[_Amusingly,_ `vim9cmd legacy` _standalone is also an `E1189` error, also showing that they can be “stacked”, though it is better not to go there!_ – `vim9cmd legacy vim9cmd legacy vim9cmd echo "hi"` _anyone?_]
- “See some examples...”, now is redundant.  `vim9.txt` - aside from Section 2 - now has lots of complete, sourceable examples.  (Section 2 is all that is left to update once this PR has been merged.)