### PR TITLE
:0tab behaves like :tab for :stag when 'swb' contains "newtab"

### DIFF
--- a/src/tag.c
+++ b/src/tag.c
@@ -3855,7 +3855,7 @@ jumpto_tag(
 	    // split window.
 	    cmdmod.cmod_split |= WSP_VERT;
 
-	if (swb_flags & SWB_NEWTAB)
+	if ((swb_flags & SWB_NEWTAB) && cmdmod.cmod_tab == 0)
 	    // If 'switchbuf' contains 'newtab', then use a new tabpage
 	    cmdmod.cmod_tab = tabpage_index(curtab) + 1;
 

--- a/src/testdir/test_tagjump.vim
+++ b/src/testdir/test_tagjump.vim
@@ -162,7 +162,12 @@ func Test_tagjump_switchbuf()
   call assert_equal(2, tabpagenr('$'))
   call assert_equal(2, tabpagenr())
   call assert_equal(2, line('.'))
+  0tab stag third
+  call assert_equal(3, tabpagenr('$'))
+  call assert_equal(1, tabpagenr())
+  call assert_equal(3, line('.'))
 
+  tabclose!
   tabclose!
   enew | only
   set tags&


### PR DESCRIPTION
Problem:  :0tab behaves like :tab for :stag when 'switchbuf' contains
          "newtab" (after 9.1.1949).
Solution: Don't override cmod_tab if it's already non-zero.
