### PR TITLE
Sorting a list of large numbers (> 32 bits) using a function with sort() doesn't work

### DIFF
--- a/src/list.c
+++ b/src/list.c
@@ -2083,11 +2083,10 @@ item_compare2(const void *s1, const void *s2)
 	res = ITEM_COMPARE_FAIL;
     else
     {
-	res = (int)tv_get_number_chk(&rettv, &sortinfo->item_compare_func_err);
-	if (res > 0)
-	    res = 1;
-	else if (res < 0)
-	    res = -1;
+	varnumber_T	n;
+
+	n = tv_get_number_chk(&rettv, &sortinfo->item_compare_func_err);
+	res = (n > 0) ? 1 : (n < 0) ? -1 : 0;
     }
     if (sortinfo->item_compare_func_err)
 	res = ITEM_COMPARE_FAIL;  // return value has wrong type

--- a/src/testdir/test_sort.vim
+++ b/src/testdir/test_sort.vim
@@ -1,5 +1,7 @@
 " Tests for the "sort()" function and for the ":sort" command.
 
+import './util/vim9.vim' as v9
+
 func Compare1(a, b) abort
   call sort(range(3), 'Compare2')
   return a:a - a:b
@@ -1555,6 +1557,32 @@ func Test_sort_using_dict_func()
   let d = #{order: 'reverse'}
   call assert_equal([3, 2, 1], sort([2, 1, 3], 'DictSort', d))
   delfunc DictSort
+endfunc
+
+" Test for using sort() function with a funcref and large numbers
+func Test_sort_funcref_with_large_number()
+  let lines =<< trim END
+    call assert_equal(
+        \ [
+        \  (188325333471071, 188931909913550),
+        \  (229539777187355, 229539777187355),
+        \  (245727634348687, 249469249579525),
+        \  (264028451845520, 265514296554744),
+        \  (375117820166731, 378942174241518),
+        \  (487766135067138, 491977135306566),
+        \  (535474757750378, 535849288071548)
+        \ ],
+        \ [
+        \  (229539777187355, 229539777187355),
+        \  (487766135067138, 491977135306566),
+        \  (188325333471071, 188931909913550),
+        \  (264028451845520, 265514296554744),
+        \  (245727634348687, 249469249579525),
+        \  (375117820166731, 378942174241518),
+        \  (535474757750378, 535849288071548)
+        \ ]->sort(LSTART a, b LMIDDLE a[0] - b[0] LEND))
+  END
+  call v9.CheckSourceLegacyAndVim9Success(lines)
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION

Don't truncate the return value of tv_get_number_chk().