### PR TITLE
When setting a byte in a blob, check for valid values

### DIFF
--- a/src/errors.h
+++ b/src/errors.h
@@ -3181,7 +3181,7 @@ EXTERN char e_no_such_user_defined_command_in_current_buffer_str[]
 EXTERN char e_blob_required_for_argument_nr[]
 	INIT(= N_("E1238: Blob required for argument %d"));
 EXTERN char e_invalid_value_for_blob_nr[]
-	INIT(= N_("E1239: Invalid value for blob: %d"));
+	INIT(= N_("E1239: Invalid value for blob: 0x%lX"));
 #endif
 EXTERN char e_resulting_text_too_long[]
 	INIT(= N_("E1240: Resulting text too long"));

--- a/src/eval.c
+++ b/src/eval.c
@@ -2363,7 +2363,7 @@ set_var_lval(
 
 	if (lp->ll_blob != NULL)
 	{
-	    int	    error = FALSE, val;
+	    int	    error = FALSE;
 
 	    if (op != NULL && *op != '=')
 	    {
@@ -2384,9 +2384,14 @@ set_var_lval(
 	    }
 	    else
 	    {
-		val = (int)tv_get_number_chk(rettv, &error);
+		varnumber_T	val = tv_get_number_chk(rettv, &error);
 		if (!error)
-		    blob_set_append(lp->ll_blob, lp->ll_n1, val);
+		{
+		    if (val < 0 || val > 255)
+			semsg(_(e_invalid_value_for_blob_nr), val);
+		    else
+			blob_set_append(lp->ll_blob, lp->ll_n1, val);
+		}
 	    }
 	}
 	else if (op != NULL && *op != '=')

--- a/src/testdir/test_blob.vim
+++ b/src/testdir/test_blob.vim
@@ -882,7 +882,7 @@ func Test_blob_byte_set_invalid_value()
     VAR b = 0zD0C3E4E18E1B
     LET b[0] = 229539777187355
   END
-  call v9.CheckSourceLegacyAndVim9Failure(lines, 'E1239: Invalid value for blob: 0xD0C3E4E18E1B')
+  call v9.CheckSourceLegacyAndVim9Failure(lines, 'E1239: Invalid value for blob:')
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_blob.vim
+++ b/src/testdir/test_blob.vim
@@ -876,4 +876,13 @@ func Test_blob_items()
   call v9.CheckSourceLegacyAndVim9Success(lines)
 endfunc
 
+" Test for setting a byte in a blob with invalid value
+func Test_blob_byte_set_invalid_value()
+  let lines =<< trim END
+    VAR b = 0zD0C3E4E18E1B
+    LET b[0] = 229539777187355
+  END
+  call v9.CheckSourceLegacyAndVim9Failure(lines, 'E1239: Invalid value for blob: 0xD0C3E4E18E1B')
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/vim9execute.c
+++ b/src/vim9execute.c
@@ -2526,6 +2526,11 @@ execute_storeindex(isn_T *iptr, ectx_T *ectx)
 	    nr = tv_get_number_chk(tv, &error);
 	    if (error)
 		return FAIL;
+	    if (nr < 0 || nr > 255)
+	    {
+		semsg(_(e_invalid_value_for_blob_nr), nr);
+		return FAIL;
+	    }
 	    blob_set_append(blob, lidx, nr);
 	}
 	else if (dest_type == VAR_CLASS || dest_type == VAR_OBJECT)


### PR DESCRIPTION

Don't truncate the return value of tv_get_number_chk().