### PR TITLE
fix(gui_w32): gui_mch_set_titlebar_colors() was excessively called

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -3494,7 +3494,7 @@ gui_init_which_components(char_u *oldval UNUSED)
     int		using_tabline;
 #endif
 #ifdef FEAT_GUI_MSWIN
-    static int	prev_titlebar = -1;
+    static int	prev_titlebar = FALSE;
     int		using_titlebar = FALSE;
 #endif
 #if defined(FEAT_MENU)


### PR DESCRIPTION
Problem: gui_mch_set_titlebar_colors() don't need to be called when
'go+=C' is not set.

Solution: let it's default setting is not to be enabled

Signed-off-by: Mao-Yining <mao.yining@outlook.com>
