### PR TITLE
feat: support dark mode on MS-Windows

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4526,7 +4526,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 		See |gui-w32-title-bar| for details.
 								*'go-d'*
 	  'd'	Use dark theme variant if available.  Currently only works for
-		GTK+ GUI.
+		Win32 and GTK+ GUI.
 								*'go-e'*
 	  'e'	Add tab pages when indicated with 'showtabline'.
 		'guitablabel' can be used to change the text in the labels.

--- a/runtime/doc/todo.txt
+++ b/runtime/doc/todo.txt
@@ -309,8 +309,6 @@ Problem with Visual highlight when 'linebreak' and 'showbreak' are set.
 GUI Scroll test fails on FreeBSD when using Motif.  See FIXME in
 Test_scrollbars in src/test_gui.vim
 
-Support dark mode for MS-Windows: #12282
-
 Remote command escapes single quote with backslash, should be doubling the
 single quote in vim_strsave_escaped_ext()  #12202.
 

--- a/src/feature.h
+++ b/src/feature.h
@@ -508,7 +508,7 @@
 /*
  * GUI dark theme variant
  */
-#if defined(FEAT_GUI_GTK) && defined(USE_GTK3)
+#if (defined(FEAT_GUI_GTK) && defined(USE_GTK3)) || defined(FEAT_GUI_MSWIN)
 # define FEAT_GUI_DARKTHEME
 #endif
 

--- a/src/gui.c
+++ b/src/gui.c
@@ -3480,7 +3480,7 @@ static int	prev_which_scrollbars[3];
 gui_init_which_components(char_u *oldval UNUSED)
 {
 #ifdef FEAT_GUI_DARKTHEME
-    static int	prev_dark_theme = -1;
+    static int	prev_dark_theme = FALSE;
     int		using_dark_theme = FALSE;
 #endif
 #ifdef FEAT_MENU

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -161,7 +161,7 @@ static int suppress_winsize = 1;	// don't fiddle with console
 static WCHAR *exe_pathw = NULL;
 
 static BOOL win8_or_later = FALSE;
-static BOOL win10_22H2_or_later = FALSE;
+BOOL win10_22H2_or_later = FALSE;
 BOOL win11_or_later = FALSE; // used in gui_mch_set_titlebar_colors(void)
 
 #if !defined(FEAT_GUI_MSWIN) || defined(VIMDLL)

--- a/src/proto/gui_w32.pro
+++ b/src/proto/gui_w32.pro
@@ -43,6 +43,7 @@ void gui_mch_show_tabline(int showit);
 int gui_mch_showing_tabline(void);
 void gui_mch_update_tabline(void);
 void gui_mch_set_curtab(int nr);
+void gui_mch_set_dark_theme(int dark);
 void ex_simalt(exarg_T *eap);
 void gui_mch_find_dialog(exarg_T *eap);
 void gui_mch_replace_dialog(exarg_T *eap);

--- a/src/testdir/test_gui.vim
+++ b/src/testdir/test_gui.vim
@@ -671,6 +671,13 @@ func Test_set_guioptions()
     exec 'sleep' . duration
     call assert_equal('egmrLtT', &guioptions)
 
+    set guioptions+=d
+    exec 'sleep' . duration
+    call assert_equal('egmrLtTd', &guioptions)
+    set guioptions-=d
+    exec 'sleep' . duration
+    call assert_equal('egmrLtT', &guioptions)
+
   else
     " Default Value
     set guioptions&


### PR DESCRIPTION
Problem:  dark mode for MS-Windows is not supported.
Solution: Inplement the 'd' flag in 'guioptions' on MS-Windows.

Support the most basic dark mode function. Similar to #12282. But not consider any complicate extra-setting yet.