### PR TITLE
Update FreeBSD version in Cirrus CI configuration

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -16,7 +16,7 @@ freebsd_task:
     - ./configure --with-features=${FEATURES}
     - make -j${NPROC}
   test_script:
-    - sed -i 's/term_wait(10)/term_wait(50)/' src/testdir/util/term_util.vim
+    - sed -i '' 's/term_wait(10)/term_wait(50)/' src/testdir/util/term_util.vim
     - src/vim --version
       # run tests as user "cirrus" instead of root
     - pw useradd cirrus -m

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -13,10 +13,10 @@ freebsd_task:
     - pkg install -y gettext
   build_script:
     - NPROC=$(getconf _NPROCESSORS_ONLN)
-    - ./configure --with-features=${FEATURES} --with-vterm=builtin
+    - ./configure --with-features=${FEATURES}
     - make -j${NPROC}
   test_script:
-    - export TERM=xterm-256color
+    - sed -i '' 's/term_wait(10)/term_wait(50)/' src/testdir/term_util.vim
     - src/vim --version
       # run tests as user "cirrus" instead of root
     - pw useradd cirrus -m

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -16,7 +16,7 @@ freebsd_task:
     - ./configure --with-features=${FEATURES}
     - make -j${NPROC}
   test_script:
-    - sed -i '' 's/term_wait(10)/term_wait(50)/' src/testdir/term_util.vim
+    - sed -i 's/term_wait(10)/term_wait(50)/' src/testdir/util/term_util.vim
     - src/vim --version
       # run tests as user "cirrus" instead of root
     - pw useradd cirrus -m

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -16,6 +16,7 @@ freebsd_task:
     - ./configure --with-features=${FEATURES} --with-vterm=builtin
     - make -j${NPROC}
   test_script:
+    - export TERM=xterm-256color
     - src/vim --version
       # run tests as user "cirrus" instead of root
     - pw useradd cirrus -m

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -13,7 +13,7 @@ freebsd_task:
     - pkg install -y gettext
   build_script:
     - NPROC=$(getconf _NPROCESSORS_ONLN)
-    - ./configure --with-features=${FEATURES}
+    - ./configure --with-features=${FEATURES} --with-vterm=builtin
     - make -j${NPROC}
   test_script:
     - src/vim --version

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,9 +5,9 @@ env:
 freebsd_task:
   name: FreeBSD
   matrix:
-    - name: FreeBSD 14.3
+    - name: FreeBSD 15.0
       freebsd_instance:
-        image_family: freebsd-14-3
+        image_family: freebsd-15-0-amd64-zfs
   timeout_in: 20m
   install_script:
     - pkg install -y gettext


### PR DESCRIPTION
Image names are update:
- https://cirrus-ci.org/guide/FreeBSD/#list-of-available-image-families

Freebsd 14.3 Ends in 6 months and 3 weeks
(30 Jun 2026)