### PR TITLE
[more prompt] Don't Start Recording After The More Prompt

### DIFF
--- a/src/message.c
+++ b/src/message.c
@@ -1414,7 +1414,8 @@ wait_return(int redraw)
 	    if (c == K_LEFTMOUSE || c == K_MIDDLEMOUSE || c == K_RIGHTMOUSE
 					|| c == K_X1MOUSE || c == K_X2MOUSE)
 		(void)jump_to_mouse(MOUSE_SETPOS, NULL, 0);
-	    else if (vim_strchr((char_u *)"\r\n ", c) == NULL && c != Ctrl_C)
+	    else if (vim_strchr((char_u *)"\r\n ", c) == NULL && c != Ctrl_C
+		    && c != 'q')
 	    {
 		// Put the character back in the typeahead buffer.  Don't use
 		// the stuff buffer, because lmaps wouldn't work.

--- a/src/testdir/test_messages.vim
+++ b/src/testdir/test_messages.vim
@@ -340,6 +340,25 @@ func Test_message_more()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_message_more_recording()
+  CheckRunVimInTerminal
+  let buf = RunVimInTerminal('', {'rows': 6})
+  call term_sendkeys(buf, ":call setline(1, range(1, 100))\n")
+  call term_sendkeys(buf, ":%p\n")
+  call WaitForAssert({-> assert_equal('-- More --', term_getline(buf, 6))})
+  call term_sendkeys(buf, 'G')
+  call WaitForAssert({-> assert_equal('Press ENTER or type command to continue', term_getline(buf, 6))})
+
+  " Hitting 'q' at the end of the more prompt should not start recording
+  call term_sendkeys(buf, 'q')
+  call WaitForAssert({-> assert_equal(5, term_getcursor(buf)[0])})
+  " Hitting 'k' now should move the cursor up instead of recording keys
+  call term_sendkeys(buf, 'k')
+  call WaitForAssert({-> assert_equal(4, term_getcursor(buf)[0])})
+
+  call StopVimInTerminal(buf)
+endfunc
+
 " Test more-prompt scrollback
 func Test_message_more_scrollback()
   CheckScreendump


### PR DESCRIPTION
## Problem

When exiting at the end of the more prompt (at the "hit enter" prompt) \
by hitting `q` the "recording" mode will be started.

## Solution

Don't add the `q` command to the "typeahead buffer" \
in the function `wait_return`.

## Rationale

You can exit the more prompt at any situation by hitting the `q` key.\
When you quit the more prompt at the beginning or somewhere in the middle \
recording is not started and you can continue working normally.\
At the end of the more prompt you have to remember you are at the end and \
hit ENTER instead of `q`.\
This is not a very intuitive workflow.\
Pagers (like `less` or `bat`) usually can be closed by hitting `q` so \
at least for me this is the most intuitive way to close the more prompt.

So pressing `q` should behave exactly like it does when at the start or the \
middle or a more prompt.\


Closes: #2589