### PR TITLE
rust.vim: use textwidth=100 for the Rust recommended style

### DIFF
--- a/runtime/doc/ft_rust.txt
+++ b/runtime/doc/ft_rust.txt
@@ -60,8 +60,8 @@ g:rust_conceal_pub~
                                                      *g:rust_recommended_style*
 g:rust_recommended_style~
         Set this option to enable vim indentation and textwidth settings to
-        conform to style conventions of the rust standard library (i.e. use 4
-        spaces for indents and sets 'textwidth' to 99). This option is enabled
+        conform to style conventions of the Rust style guide (i.e. use 4
+        spaces for indents and set 'textwidth' to 100). This option is enabled
 	by default. To disable it: >
 	    let g:rust_recommended_style = 0
 <

--- a/runtime/ftplugin/rust.vim
+++ b/runtime/ftplugin/rust.vim
@@ -49,7 +49,7 @@ setlocal smartindent nocindent
 if get(g:, 'rust_recommended_style', 1)
     let b:rust_set_style = 1
     setlocal shiftwidth=4 softtabstop=4 expandtab
-    setlocal textwidth=99
+    setlocal textwidth=100
 endif
 
 setlocal include=\\v^\\s*(pub\\s+)?use\\s+\\zs(\\f\|:)+


### PR DESCRIPTION
The help text here said 99 was the recommended style for the standard library, but I can't find a citation for this anywhere. In contrast the Rust Style Guide hosted on rust-lang.org [says](https://doc.rust-lang.org/stable/style-guide/#indentation-and-line-width) the maximum line width is 100, and rustfmt [agrees](https://github.com/rust-lang/rust/blob/37aa2135b5d0936bd13aa699d941aaa94fbaa645/src/tools/rustfmt/src/config/options.rs#L570).

Having the two disagree causes an annoying off-by-one error in vim: if you configure vim to highlight too-long lines then it will occasionally complain about a line that rustfmt refuses to fix.