### PR TITLE
runtime(doc): Rename NoDefaultCurrentDirectoryInExePath tag

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -1,4 +1,4 @@
-*builtin.txt*	For Vim version 9.1.  Last change: 2025 Dec 06
+*builtin.txt*	For Vim version 9.1.  Last change: 2025 Dec 10
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -2715,13 +2715,14 @@ executable({expr})					*executable()*
 		On MS-Windows an executable in the same directory as the Vim
 		executable is always found.  Since this directory is added to
 		$PATH it should also work to execute it |win32-PATH|.
-					*NoDefaultCurrentDirectoryInExePath*
+					*$NoDefaultCurrentDirectoryInExePath*
 		On MS-Windows when using cmd.exe as 'shell' an executable in
 		Vim's current working directory is also normally found, which
 		can be disabled by setting the
 		`$NoDefaultCurrentDirectoryInExePath` environment variable.
-		This is always done when executing external commands using
-		e.g. |:!|, |:make|, |system()| for security reasons.
+		This variable is always set by Vim when executing external
+		commands (e.g., via |:!|, |:make|, or |system()|) for security
+		reasons.
 
 		The result is a Number:
 			1	exists

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -9,6 +9,7 @@ $HOME-windows	options.txt	/*$HOME-windows*
 $MYGVIMRC	gui.txt	/*$MYGVIMRC*
 $MYVIMDIR	starting.txt	/*$MYVIMDIR*
 $MYVIMRC	starting.txt	/*$MYVIMRC*
+$NoDefaultCurrentDirectoryInExePath	builtin.txt	/*$NoDefaultCurrentDirectoryInExePath*
 $VIM	starting.txt	/*$VIM*
 $VIM-use	version5.txt	/*$VIM-use*
 $VIMRUNTIME	starting.txt	/*$VIMRUNTIME*
@@ -5777,7 +5778,6 @@ Neovim	intro.txt	/*Neovim*
 NetBSD-backspace	options.txt	/*NetBSD-backspace*
 NetBeans	netbeans.txt	/*NetBeans*
 NetUserPass()	pi_netrw.txt	/*NetUserPass()*
-NoDefaultCurrentDirectoryInExePath	builtin.txt	/*NoDefaultCurrentDirectoryInExePath*
 None	eval.txt	/*None*
 Normal	intro.txt	/*Normal*
 Normal-mode	intro.txt	/*Normal-mode*

--- a/runtime/doc/version9.txt
+++ b/runtime/doc/version9.txt
@@ -41759,7 +41759,7 @@ Platform specific ~
   highlighting group |gui-w32-title-bar|.
 - MS-Windows: Vim no longer searches the current directory for
   executables when running external commands; use a relative or absolute path
-  if you want the previous behavior |NoDefaultCurrentDirectoryInExePath|.
+  if you want the previous behavior |$NoDefaultCurrentDirectoryInExePath|.
 - macOS: increase default scheduler priority to TASK_DEFAULT_APPLICATION.
 
 Others: ~


### PR DESCRIPTION
- Add leading "$" to match other environment variable tags.
- Clarify :help $NoDefaultCurrentDirectoryInExePath.

