### PR TITLE
fix: avoid unloading buffer while being saved

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -516,6 +516,10 @@ can_unload_buffer(buf_T *buf)
 		break;
 	    }
     }
+    // Don't unload the buffer while it's still being saved
+    if (can_unload && buf->b_saving)
+	can_unload = false;
+
     if (!can_unload)
     {
 	char_u *fname = buf->b_fname != NULL ? buf->b_fname : buf->b_ffname;

--- a/src/testdir/test_buffer.vim
+++ b/src/testdir/test_buffer.vim
@@ -226,6 +226,13 @@ func Test_buffer_error()
   %bwipe
 endfunc
 
+func Test_bwipe_during_save()
+  set charconvert=execute('%bw!')
+  call assert_fails('write ++enc=lmao boom', 'E937:')
+
+  %bwipe
+endfunc
+
 " Test for the status messages displayed when unloading, deleting or wiping
 " out buffers
 func Test_buffer_statusmsg()


### PR DESCRIPTION
Problem: Crashes when a buffer gets deleted inside charconvert during save.

Solution: Add a `b_saving` check in `can_unload_buffer()` so we don’t try to unload a buffer while it’s still being saved.