### PR TITLE
fix: adjust visual col after block insert

### DIFF
--- a/src/ops.c
+++ b/src/ops.c
@@ -754,6 +754,11 @@ block_insert(
 	    // the insert in the first line.
 	    curbuf->b_op_end.lnum = oap->end.lnum;
 	    curbuf->b_op_end.col = offset;
+	    if (curbuf->b_visual.vi_end.coladd)
+	    {
+		curbuf->b_visual.vi_end.col += curbuf->b_visual.vi_end.coladd;
+		curbuf->b_visual.vi_end.coladd = 0;
+	    }
 	}
     } // for all lnum
 

--- a/src/testdir/test_visual.vim
+++ b/src/testdir/test_visual.vim
@@ -2824,6 +2824,7 @@ endfunc
 
 " Test visual block pos update after block insert and gv
 func Test_visual_block_pos_update()
+  new
   set virtualedit=block
   call setline(1, ['aacccc', 'bb'])
   exe "norm! e\<C-v>jAa\<Esc>gv"

--- a/src/testdir/test_visual.vim
+++ b/src/testdir/test_visual.vim
@@ -2822,4 +2822,16 @@ func Test_visual_pos_buffer_heap_overflow()
   bw! Xa Xb
 endfunc
 
+" Test visual block pos update after block insert and gv
+func Test_visual_block_pos_update()
+  set virtualedit=block
+  call setline(1, ['aacccc', 'bb'])
+  exe "norm! e\<C-v>jAa\<Esc>gv"
+  call assert_equal([[0, 1, 6, 0], [0 , 2, 6, 0]], [getpos("v"), getpos(".")])
+  normal! kj
+  call assert_equal([[0, 1, 6, 0], [0 , 2, 6, 0]], [getpos("v"), getpos(".")])
+  set virtualedit=
+  bw!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem: getpos('.') in visual mode return wrong value after block
insert

Solution: adjust b_visual.vi_end after block insert

Fix https://github.com/vim/vim/issues/18900
