### PR TITLE
fix: vim.eval() truncate 64-bit number to 32-bit on Windows

### DIFF
--- a/src/if_py_both.h
+++ b/src/if_py_both.h
@@ -1039,7 +1039,7 @@ VimToPython(typval_T *our_tv, int depth, PyObject *lookup_dict)
 	char buf[NUMBUFLEN];
 
 	// For backwards compatibility numbers are stored as strings.
-	sprintf(buf, "%ld", (long)our_tv->vval.v_number);
+	sprintf(buf, "%lld", (long long)our_tv->vval.v_number);
 	ret = PyString_FromString((char *)buf);
     }
     else if (our_tv->v_type == VAR_FLOAT)

--- a/src/testdir/test_python3.vim
+++ b/src/testdir/test_python3.vim
@@ -305,7 +305,12 @@ endfunc
 
 " Test vim.eval() with various types.
 func Test_python3_vim_eval()
-  call assert_equal("\n8",             execute('py3 print(vim.eval("3+5"))'))
+  call assert_equal("\n2061300532912", execute('py3 print(vim.eval("2061300532912"))'))
+  call assert_equal("\n9223372036854775807", execute('py3 print(vim.eval("9223372036854775807"))'))
+  call assert_equal("\n-9223372036854775807",execute('py3 print(vim.eval("-9223372036854775807"))'))
+  call assert_equal("\n2147483648",  execute('py3 print(vim.eval("2147483648"))'))
+  call assert_equal("\n-2147483649", execute('py3 print(vim.eval("-2147483649"))'))
+  call assert_equal("\n8",           execute('py3 print(vim.eval("3+5"))'))
   call assert_equal("\n3.140000",    execute('py3 print(vim.eval("1.01+2.13"))'))
   call assert_equal("\n0.000000",    execute('py3 print(vim.eval("0.0/(1.0/0.0)"))'))
   call assert_equal("\n0.000000",    execute('py3 print(vim.eval("0.0/(1.0/0.0)"))'))


### PR DESCRIPTION
Fix: #18899