### PR TITLE
tests: missing cleanup in Test_bwipe_during_save()

### DIFF
--- a/src/testdir/test_buffer.vim
+++ b/src/testdir/test_buffer.vim
@@ -230,6 +230,7 @@ func Test_bwipe_during_save()
   set charconvert=execute('%bw!')
   call assert_fails('write ++enc=lmao boom', 'E937:')
 
+  set charconvert&
   %bwipe
 endfunc
 


### PR DESCRIPTION
Problem:  tests: missing cleanup in Test_bwipe_during_save().
Solution: Reset &charconvert.
