### PR TITLE
Clipboard provider fixes

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -5343,7 +5343,8 @@ The "paste" callback takes the following arguments in the following order:
 
 It should return a |list| or |tuple| containing the following elements in
 order:
-	1. Register type (and optional width) conforming to |setreg()|
+	1. Register type (and optional width) conforming to |setreg()|.  If it
+	   is an empty string, then the type is automatically chosen.
 	2. A |list| of strings to return to Vim, each representing a line.
 
 						*clipboard-providers-copy*

--- a/src/clipboard.c
+++ b/src/clipboard.c
@@ -3934,8 +3934,8 @@ clip_provider_paste(char_u *reg, char_u *provider)
 	}
 	*curval++ = NULL;
 
-	if (STRLEN(reg_type) <= 0
-		|| get_yank_type(&reg_type, &yank_type, &block_len) == FAIL)
+	if (*reg_type != NUL && (STRLEN(reg_type) <= 0
+		|| get_yank_type(&reg_type, &yank_type, &block_len) == FAIL))
 	{
 	    emsg(e_invalid_argument);
 	    goto free_lstval;
@@ -3977,7 +3977,7 @@ exit:
 // This prevents unnecessary calls when accessing the provider often in an
 // interval.
 //
-// If -1 then allow provider callback to be called then set to zero. Default
+// If -1 then allow provider callback to be called then set to one. Default
 // value (is allowed) is -2.
 static int star_pause_count = -2, plus_pause_count = -2;
 
@@ -4031,15 +4031,19 @@ call_clip_provider_set(int reg)
     void
 inc_clip_provider(void)
 {
-    plus_pause_count = plus_pause_count == -2 ? -1 : plus_pause_count + 1;
-    star_pause_count = star_pause_count == -2 ? -1 : star_pause_count + 1;
+    plus_pause_count = (plus_pause_count == -2
+	|| plus_pause_count == -1) ? -1 : plus_pause_count + 1;
+    star_pause_count = (star_pause_count == -2
+	|| star_pause_count == -1) ? -1 : star_pause_count + 1;
 }
 
     void
 dec_clip_provider(void)
 {
-    plus_pause_count = plus_pause_count == -1 ? -1 : plus_pause_count - 1;
-    star_pause_count = star_pause_count == -1 ? -1 : star_pause_count - 1;
+    if (plus_pause_count != -2)
+	plus_pause_count = plus_pause_count == -1 ? -1 : plus_pause_count - 1;
+    if (star_pause_count != -2)
+	star_pause_count = star_pause_count == -1 ? -1 : star_pause_count - 1;
 
     if (plus_pause_count == 0 || plus_pause_count == -1)
 	plus_pause_count = -2;

--- a/src/register.c
+++ b/src/register.c
@@ -1420,6 +1420,7 @@ op_yank(oparg_T *oap, int deleting, int mess)
     }
 
 #ifdef FEAT_CLIPBOARD_PROVIDER
+    inc_clip_provider();
     if (curr == &y_regs[REAL_PLUS_REGISTER])
 	call_clip_provider_set('+');
     else if (curr == &y_regs[STAR_REGISTER])
@@ -1467,6 +1468,9 @@ op_yank(oparg_T *oap, int deleting, int mess)
 #if defined(FEAT_EVAL)
     if (!deleting && has_textyankpost())
 	yank_do_autocmd(oap, y_current);
+#endif
+#ifdef FEAT_CLIPBOARD_PROVIDER
+    dec_clip_provider();
 #endif
     return OK;
 


### PR DESCRIPTION
- allow empty register type for paste function to mean automatic
- fix internal inc_clip_provider() and dec_clip_provider() functions not setting the pause count correctly
- don't call paste function when yanking