### PR TITLE
Tweak documentation

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2389,7 +2389,7 @@ v:echospace	Number of screen cells that can be used for an `:echo` message
 		available above the last line.
 
 					*v:errmsg* *errmsg-variable*
-v:errmsg	Last error message that occurred (not neccessarily displayed).
+v:errmsg	Last error message that occurred (not necessarily displayed).
 		It's allowed to set this variable.  Example: >
 	:let v:errmsg = ""
 	:silent! next
@@ -3841,7 +3841,7 @@ text...
 			when the screen is redrawn.
 
 					*:echow* *:echowin* *:echowindow*
-:[N]echow[indow] {expr1} ..
+:[N]echow[indow] {expr1} ...
 			Like |:echomsg| but when the messages popup window is
 			available the message is displayed there.  This means
 			it will show for three seconds and avoid a

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4527,11 +4527,11 @@ A jump table for the options with a short description can be found at |Q_op|.
 		choices.
 								*'go-C'*
 	  'C'	Use |hl-TitleBar| and |hl-TitleBarNC| if available.
-		Currently only works for MS-Window GUI.
+		Currently only works for MS-Windows GUI.
 		See |gui-w32-title-bar| for details.
 								*'go-d'*
 	  'd'	Use dark theme variant if available.  Currently only works for
-		Win32 and GTK+ GUI.
+		MS-Windows and GTK+ GUI.
 								*'go-e'*
 	  'e'	Add tab pages when indicated with 'showtabline'.
 		'guitablabel' can be used to change the text in the labels.


### PR DESCRIPTION
eval.txt
- Fix typo.
- One more `.`.

options.txt
- The notation is unified to `MS-Windows`.