### PR TITLE
Remove agide.org link pointing to unrelated site

### DIFF
--- a/runtime/doc/develop.txt
+++ b/runtime/doc/develop.txt
@@ -153,7 +153,7 @@ VIM IS... NOT						*design-not*
   everything but the kitchen sink, but some people say that you can clean one
   with it.  ;-)"
   To use Vim with gdb see |terminal-debugger|.  Other (older) tools can be
-  found at http://www.agide.org (link seems dead)  and http://clewn.sf.net.
+  found at http://clewn.sf.net.
 - Vim is not a fancy GUI editor that tries to look nice at the cost of
   being less consistent over all platforms.  But functional GUI features are
   welcomed.


### PR DESCRIPTION
The agide.org domain no longer hosts Vim-related tools and now points to unrelated content (an AI news site). Remove this reference from the documentation to avoid confusion.
