### PR TITLE
filetype: add N-Quads filetype

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -2371,6 +2371,8 @@ const ft_from_ext = {
   "norg": "norg",
   # Novell netware batch files
   "ncf": "ncf",
+  # N-Quads
+  "nq": "nq",
   # Not Quite C
   "nqc": "nqc",
   # NSE - Nmap Script Engine - uses Lua syntax

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -578,6 +578,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     ninja: ['file.ninja'],
     nix: ['file.nix'],
     norg: ['file.norg'],
+    nq: ['file.nq']
     nqc: ['file.nqc'],
     nroff: ['file.tr', 'file.nr', 'file.roff', 'file.tmac', 'tmac.file'],
     nsis: ['file.nsi', 'file.nsh'],


### PR DESCRIPTION
The N-Quads file type is specified here: https://www.w3.org/TR/n-quads/