### PR TITLE
Use struct string_T to store field class_name in struct class_T

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -1156,7 +1156,7 @@ fill_lval_from_lval_root(lval_T *lp, lval_root_T *lr)
 		lp->ll_tv = &lp->ll_class->class_members_tv[m_idx];
 #ifdef LOG_LOCKVAR
 		ch_log(NULL, "LKVAR:    ... class member %s.%s",
-					lp->ll_class->class_name, lp->ll_name);
+					lp->ll_class->class_name.string, lp->ll_name);
 #endif
 		return;
 	    }
@@ -1205,7 +1205,7 @@ get_lval_check_access(
 		{
 		    if (om->ocm_type->tt_type == VAR_OBJECT)
 			semsg(_(e_enumvalue_str_cannot_be_modified),
-				cl->class_name, om->ocm_name);
+				cl->class_name.string, om->ocm_name);
 		    else
 			msg = e_variable_is_not_writable_str;
 		}
@@ -6230,7 +6230,7 @@ method_tv2string(typval_T *tv, char_u **tofree, int echo_style)
 
     size_t len = vim_snprintf((char *)buf, sizeof(buf), "<SNR>%d_%s.%s",
 			   pt->pt_func->uf_script_ctx.sc_sid,
-			   pt->pt_func->uf_class->class_name,
+			   pt->pt_func->uf_class->class_name.string,
 			   pt->pt_func->uf_name);
     if (len >= sizeof(buf))
     {
@@ -6493,31 +6493,29 @@ class_tv2string(typval_T *tv, char_u **tofree)
     char_u	*r = NULL;
     size_t	rsize;
     class_T	*cl = tv->vval.v_class;
-    char_u	*class_name = (char_u *)"[unknown]";
-    size_t	class_namelen = 9;
-    char	*s = "class";
-    size_t	slen = 5;
+    string_T	class_name = {(char_u *)"[unknown]", 9};
+    string_T	s = {(char_u *)"class", 5};
 
     if (cl != NULL)
     {
-	class_name = cl->class_name;
-	class_namelen = STRLEN(cl->class_name);
+	class_name.string = cl->class_name.string;
+	class_name.length = cl->class_name.length;
 	if (IS_INTERFACE(cl))
 	{
-	    s = "interface";
-	    slen = 9;
+	    s.string = (char_u *)"interface";
+	    s.length = 9;
 	}
 	else if (IS_ENUM(cl))
 	{
-	    s = "enum";
-	    slen = 4;
+	    s.string = (char_u *)"enum";
+	    s.length = 4;
 	}
     }
 
-    rsize = slen + 1 + class_namelen + 1;
+    rsize = s.length + 1 + class_name.length + 1;
     r = *tofree = alloc(rsize);
     if (r != NULL)
-	vim_snprintf((char *)r, rsize, "%s %s", s, (char *)class_name);
+	vim_snprintf((char *)r, rsize, "%s %s", s.string, (char *)class_name.string);
 
     return r;
 }
@@ -6550,11 +6548,11 @@ object_tv2string(
     else if (copyID != 0 && obj->obj_copyID == copyID
 	    && obj->obj_class->class_obj_member_count != 0)
     {
-	size_t n = 25 + STRLEN((char *)obj->obj_class->class_name);
+	size_t n = 25 + obj->obj_class->class_name.length;
 	r = alloc(n);
 	if (r != NULL)
 	    (void)vim_snprintf((char *)r, n, "object of %s {...}",
-						obj->obj_class->class_name);
+						obj->obj_class->class_name.string);
 	*tofree = r;
     }
     else

--- a/src/evalvars.c
+++ b/src/evalvars.c
@@ -2258,7 +2258,7 @@ report_lockvar_member(char *msg, lval_T *lp)
     int did_alloc = FALSE;
     char_u *vname = (char_u *)"";
     char_u *class_name = lp->ll_class != NULL
-				    ? lp->ll_class->class_name : (char_u *)"";
+				    ? lp->ll_class->class_name.string : (char_u *)"";
     if (lp->ll_name != NULL)
     {
 	if (lp->ll_name_end == NULL)

--- a/src/structs.h
+++ b/src/structs.h
@@ -1606,7 +1606,7 @@ struct itf2class_S {
 // Also used for an interface (class_flags has CLASS_INTERFACE).
 struct class_S
 {
-    char_u	*class_name;		// allocated
+    string_T	class_name;		// allocated
     int		class_flags;		// CLASS_ flags
 
     int		class_refcount;

--- a/src/typval.c
+++ b/src/typval.c
@@ -283,7 +283,7 @@ tv_get_bool_or_number_chk(
 		{
 		    class_T *cl = varp->vval.v_object->obj_class;
 		    if (cl != NULL && IS_ENUM(cl))
-			semsg(_(e_using_enum_str_as_number), cl->class_name);
+			semsg(_(e_using_enum_str_as_number), cl->class_name.string);
 		    else
 			emsg(_(e_using_object_as_number));
 		}
@@ -1248,7 +1248,7 @@ tv_get_string_buf_chk_strict(typval_T *varp, char_u *buf, int strict)
 		{
 		    class_T *cl = varp->vval.v_object->obj_class;
 		    if (cl != NULL && IS_ENUM(cl))
-			semsg(_(e_using_enum_str_as_string), cl->class_name);
+			semsg(_(e_using_enum_str_as_string), cl->class_name.string);
 		    else
 			emsg(_(e_using_object_as_string));
 		}

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -4524,7 +4524,8 @@ trans_function_name_ext(
 	else if (lv.ll_tv->v_type == VAR_CLASS
 					     && lv.ll_tv->vval.v_class != NULL)
 	{
-	    name = vim_strsave(lv.ll_tv->vval.v_class->class_name);
+	    name = vim_strnsave(lv.ll_tv->vval.v_class->class_name.string,
+		lv.ll_tv->vval.v_class->class_name.length);
 	    *pp = end;
 	}
 	else if (lv.ll_tv->v_type == VAR_PARTIAL
@@ -5955,7 +5956,7 @@ defcompile_function(ufunc_T *ufunc, class_T *cl)
 	(void)compile_def_function(ufunc, FALSE, compile_type, NULL);
     else
 	smsg(_("Function %s%s%s does not need compiling"),
-				cl != NULL ? cl->class_name : (char_u *)"",
+				cl != NULL ? cl->class_name.string : (char_u *)"",
 				cl != NULL ? (char_u *)"." : (char_u *)"",
 				ufunc->uf_name);
 }

--- a/src/vim9cmds.c
+++ b/src/vim9cmds.c
@@ -248,8 +248,8 @@ compile_lock_unlock(
 		if (*end != '.' && *end != '[')
 		{
 		    // Push the class of the bare class variable name
-		    name = cl->class_name;
-		    len = (int)STRLEN(name);
+		    name = cl->class_name.string;
+		    len = (int)cl->class_name.length;
 #ifdef LOG_LOCKVAR
 		    ch_log(NULL, "LKVAR:    ... cctx_class_member: name %s",
 			   name);

--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -1627,7 +1627,7 @@ lhs_class_member_modifiable(lhs_T *lhs, char_u	*var_start, cctx_T *cctx)
 
     if (IS_ENUM(cl))
     {
-	semsg(_(e_enumvalue_str_cannot_be_modified), cl->class_name,
+	semsg(_(e_enumvalue_str_cannot_be_modified), cl->class_name.string,
 		m->ocm_name);
 	return FALSE;
     }
@@ -1758,7 +1758,7 @@ compile_lhs_class_variable(
 	// A class variable can be accessed without the class name
 	// only inside a class.
 	semsg(_(e_class_variable_str_accessible_only_inside_class_str),
-		lhs->lhs_name, defcl->class_name);
+		lhs->lhs_name, defcl->class_name.string);
 	return FAIL;
     }
 
@@ -2055,7 +2055,7 @@ compile_lhs_set_oc_member_type(
 	if (!inside_class(cctx, cl))
 	{
 	    semsg(_(e_enumvalue_str_cannot_be_modified),
-		    cl->class_name, m->ocm_name);
+		    cl->class_name.string, m->ocm_name);
 	    return FAIL;
 	}
 	if (lhs->lhs_type->tt_type == VAR_OBJECT &&
@@ -2064,7 +2064,7 @@ compile_lhs_set_oc_member_type(
 	    char *msg = lhs->lhs_member_idx == 0 ?
 		e_enum_str_name_cannot_be_modified :
 		e_enum_str_ordinal_cannot_be_modified;
-	    semsg(_(msg), cl->class_name);
+	    semsg(_(msg), cl->class_name.string);
 	    return FAIL;
 	}
     }

--- a/src/vim9execute.c
+++ b/src/vim9execute.c
@@ -3345,7 +3345,7 @@ var_any_get_oc_member(class_T *current_class, isn_T *iptr, typval_T *tv)
 	    msg = e_variable_not_found_on_object_str_str;
 	else
 	    msg = e_class_variable_str_not_found_in_class_str;
-	semsg(_(msg), iptr->isn_arg.string, tv_cl->class_name);
+	semsg(_(msg), iptr->isn_arg.string, tv_cl->class_name.string);
 	return FAIL;
     }
 
@@ -7069,7 +7069,7 @@ list_instructions(char *pfx, isn_T *instr, int instr_count, ufunc_T *ufunc)
 	{
 	    case ISN_CONSTRUCT:
 		smsg("%s%4d NEW %s size %d", pfx, current,
-			iptr->isn_arg.construct.construct_class->class_name,
+			iptr->isn_arg.construct.construct_class->class_name.string,
 				  (int)iptr->isn_arg.construct.construct_size);
 		break;
 	    case ISN_EXEC:
@@ -7381,7 +7381,7 @@ list_instructions(char *pfx, isn_T *instr, int instr_count, ufunc_T *ufunc)
 		    smsg("%s%4d %s CLASSMEMBER %s.%s", pfx, current,
 			    iptr->isn_type == ISN_LOAD_CLASSMEMBER
 							    ? "LOAD" : "STORE",
-			    cl->class_name, ocm->ocm_name);
+			    cl->class_name.string, ocm->ocm_name);
 		}
 		break;
 
@@ -7436,7 +7436,7 @@ list_instructions(char *pfx, isn_T *instr, int instr_count, ufunc_T *ufunc)
 	    case ISN_PUSHCLASS:
 		smsg("%s%4d PUSHCLASS %s", pfx, current,
 			iptr->isn_arg.classarg == NULL ? "null"
-				 : (char *)iptr->isn_arg.classarg->class_name);
+				 : (char *)iptr->isn_arg.classarg->class_name.string);
 		break;
 	    case ISN_PUSHEXC:
 		smsg("%s%4d PUSH v:exception", pfx, current);
@@ -7508,7 +7508,7 @@ list_instructions(char *pfx, isn_T *instr, int instr_count, ufunc_T *ufunc)
 		    cmfunc_T	*mfunc = iptr->isn_arg.mfunc;
 
 		    smsg("%s%4d METHODCALL %s.%s(argc %d)", pfx, current,
-			    mfunc->cmf_itf->class_name,
+			    mfunc->cmf_itf->class_name.string,
 			    mfunc->cmf_itf->class_obj_methods[
 						      mfunc->cmf_idx]->uf_name,
 			    mfunc->cmf_argcount);
@@ -7563,7 +7563,7 @@ list_instructions(char *pfx, isn_T *instr, int instr_count, ufunc_T *ufunc)
 		    if (extra != NULL && extra->fre_class != NULL)
 		    {
 			smsg("%s%4d FUNCREF %s.%s", pfx, current,
-					   extra->fre_class->class_name, name);
+					   extra->fre_class->class_name.string, name);
 		    }
 		    else if (extra == NULL
 				     || extra->fre_loopvar_info.lvi_depth == 0)
@@ -7853,7 +7853,7 @@ list_instructions(char *pfx, isn_T *instr, int instr_count, ufunc_T *ufunc)
 	    case ISN_GET_ITF_MEMBER: smsg("%s%4d ITF_MEMBER %d on %s",
 			     pfx, current,
 			     (int)iptr->isn_arg.classmember.cm_idx,
-			     iptr->isn_arg.classmember.cm_class->class_name);
+			     iptr->isn_arg.classmember.cm_class->class_name.string);
 				     break;
 	    case ISN_STORE_THIS: smsg("%s%4d STORE_THIS %d", pfx, current,
 					     (int)iptr->isn_arg.number); break;

--- a/src/vim9expr.c
+++ b/src/vim9expr.c
@@ -496,7 +496,7 @@ compile_class_object_index(cctx_T *cctx, char_u **arg, type_T *type)
 	    // Trying to invoke an abstract method in a super class is not
 	    // allowed.
 	    semsg(_(e_abstract_method_str_direct), ufunc->uf_name,
-		    ufunc->uf_defclass->class_name);
+		    ufunc->uf_defclass->class_name.string);
 	    goto done;
 	}
 
@@ -1052,7 +1052,7 @@ compile_load(
 		else
 		{
 		    semsg(_(e_class_variable_str_accessible_only_inside_class_str),
-			    name, cl->class_name);
+			    name, cl->class_name.string);
 		    res = FAIL;
 		}
 	    }
@@ -1511,7 +1511,7 @@ compile_call(
 	    else
 	    {
 		semsg(_(e_class_method_str_accessible_only_inside_class_str),
-			name, cl->class_name);
+			name, cl->class_name.string);
 		res = FAIL;
 	    }
 	    goto theend;

--- a/src/vim9type.c
+++ b/src/vim9type.c
@@ -2848,7 +2848,7 @@ check_type_is_value(type_T *type)
 	case VAR_CLASS:
 	    if (type->tt_class != NULL && IS_ENUM(type->tt_class))
 		semsg(_(e_using_enum_as_value_str),
-			type->tt_class->class_name);
+			type->tt_class->class_name.string);
 	    else
 		semsg(_(e_using_class_as_value_str),
 			type->tt_class == NULL ? (char_u *)""

--- a/src/vim9type.c
+++ b/src/vim9type.c
@@ -2626,23 +2626,27 @@ failed:
     static char *
 type_name_class_or_obj(char *name, type_T *type, char **tofree)
 {
-    char_u *class_name;
+    string_T	class_name;
 
     if (type->tt_class != NULL)
     {
-	class_name = type->tt_class->class_name;
+	class_name.string = type->tt_class->class_name.string;
+	class_name.length = type->tt_class->class_name.length;
 	if (IS_ENUM(type->tt_class))
 	    name = "enum";
     }
     else
-	class_name = (char_u *)"any";
+    {
+	class_name.string = (char_u *)"any";
+	class_name.length = 3;
+    }
 
-    size_t len = STRLEN(name) + STRLEN(class_name) + 3;
+    size_t len = STRLEN(name) + class_name.length + 3;
     *tofree = alloc(len);
     if (*tofree == NULL)
 	return name;
 
-    vim_snprintf(*tofree, len, "%s<%s>", name, class_name);
+    vim_snprintf(*tofree, len, "%s<%s>", name, class_name.string);
     return *tofree;
 }
 
@@ -2812,7 +2816,7 @@ check_typval_is_value(typval_T *tv)
 	    {
 		class_T *cl = tv->vval.v_class;
 		char_u *class_name = (cl == NULL) ? (char_u *)""
-							: cl->class_name;
+							: cl->class_name.string;
 		if (cl != NULL && IS_ENUM(cl))
 		    semsg(_(e_using_enum_as_value_str), class_name);
 		else
@@ -2848,7 +2852,7 @@ check_type_is_value(type_T *type)
 	    else
 		semsg(_(e_using_class_as_value_str),
 			type->tt_class == NULL ? (char_u *)""
-			: type->tt_class->class_name);
+			: type->tt_class->class_name.string);
 	    return FAIL;
 
 	case VAR_TYPEALIAS:


### PR DESCRIPTION
Use struct `string_T` to store field `class_name` in struct `class_T`.

This means we can just use the `.length` field in struct `string_T` instead of measuring it.

In addition:
1. In `eval.c` use `string_T` to store `class_name` and `s` in function `class_tv2string()`.
2. In `vim9type.c` change some calls from `ga_concat()` to `ga_concat_len()` where the length is known.
3. In `vim9class.c` remove unused struct definition `oc_newmember_S`.
	Change some calls from `ga_concat()` to `ga_concat_len()` where the length is known.
4. In `scriptfile.c` use `string_T` to store `type_name`, `class_name` and `es_name` in function `estack_sfile()`.
	In function `estack_sfile()` simplify construction of the grow array `ga` to make it more closely match how .
	Change some calls from `ga_concat()` to `ga_concat_len()` where the length is known.

Cheers
John