### PR TITLE
Fixed unexpected stop when generating opt_test.vim

### DIFF
--- a/src/testdir/Make_ming.mak
+++ b/src/testdir/Make_ming.mak
@@ -88,6 +88,7 @@ clean:
 	-@if exist starttime $(DEL) starttime
 	-@if exist benchmark.out del benchmark.out
 	-@if exist opt_test.vim $(DEL) opt_test.vim
+	-@if exist gen_opt_test.log $(DEL) gen_opt_test.log
 	-@if exist guidialog $(DEL) guidialog
 	-@if exist guidialogfile $(DEL) guidialogfile
 
@@ -159,8 +160,8 @@ test_gui_init.res: test_gui_init.vim
 
 opt_test.vim: util/gen_opt_test.vim ../optiondefs.h ../../runtime/doc/options.txt
 	$(VIMPROG) -e -s -u NONE $(COMMON_ARGS) --nofork -S $^
-	@if test -f test.log; then \
-		cat test.log; \
+	@if test -f gen_opt_test.log; then \
+		cat gen_opt_test.log; \
 		exit 1; \
 	fi
 

--- a/src/testdir/Make_mvc.mak
+++ b/src/testdir/Make_mvc.mak
@@ -87,6 +87,7 @@ clean:
 	- if exist starttime $(RM) starttime
 	- if exist benchmark.out $(RM) benchmark.out
 	- if exist opt_test.vim $(RM) opt_test.vim
+	- if exist gen_opt_test.log $(RM) gen_opt_test.log
 	- if exist guidialog $(RM) guidialog
 	- if exist guidialogfile $(RM) guidialogfile
 
@@ -160,7 +161,7 @@ test_gui_init.res: test_gui_init.vim
 opt_test.vim: util/gen_opt_test.vim ../optiondefs.h \
 		../../runtime/doc/options.txt
 	$(VIMPROG) -e -s -u NONE $(COMMON_ARGS) --nofork -S $**
-	@ if exist test.log ( type test.log & exit /b 1 )
+	@ if exist gen_opt_test.log ( type gen_opt_test.log & exit /b 1 )
 
 test_bench_regexp.res: test_bench_regexp.vim
 	- if exist benchmark.out $(RM) benchmark.out

--- a/src/testdir/Makefile
+++ b/src/testdir/Makefile
@@ -94,6 +94,7 @@ RUN_VIMPROG = VIMRUNTIME=$(SCRIPTSOURCE) $(VALGRIND) $(VIMPROG) -f $(GUI_FLAG) -
 clean:
 	-rm -rf *.out *.failed *.res *.rej *.orig XfakeHOME Xdir1 Xfind failed
 	-rm -f opt_test.vim test_result.log $(CLEANUP_FILES)
+	-rm -f gen_opt_test.log
 	-rm -rf $(RM_ON_RUN) $(RM_ON_START)
 	-rm -f valgrind.*
 	-rm -f asan.* asan_test_*
@@ -188,8 +189,8 @@ opt_test.vim: $(GEN_OPT_DEPS)
 	else \
 		$(VIMPROG) -e -s -u NONE $(NO_INITS) --nofork --gui-dialog-file guidialog -S $(GEN_OPT_DEPS) ; \
 	fi
-	@if test -f test.log; then \
-		cat test.log; \
+	@if test -f gen_opt_test.log; then \
+		cat gen_opt_test.log; \
 		exit 1; \
 	fi
 

--- a/src/testdir/util/gen_opt_test.vim
+++ b/src/testdir/util/gen_opt_test.vim
@@ -515,7 +515,7 @@ catch
   " Append errors to test.log
   let error = $'Error: {v:exception} in {v:throwpoint}'
   echoc error
-  split test.log
+  split gen_opt_test.log
   call append('$', error)
   write
 endtry


### PR DESCRIPTION
Problem: When running newtests, it may unexpectedly stop just before test_options_all.

Cause: When generating the opt_test.vim file for test_options_all, the failure is judged by the existence of test.log. Therefore, if a test performed before test_options_all fails and test.log is created, it is mistakenly thought that the generation of opt_tet.vim has failed, and the test process stops there.

Solution: Changed the filename created when utils/gen_opt_test.vim fails from test.log to gen_opt_test.log, so that it can be detected independently from other test failures.