### PR TITLE
Fix ANSI colors in terminal on Windows

### DIFF
--- a/src/term.c
+++ b/src/term.c
@@ -7642,7 +7642,7 @@ static const char_u ansi_table[16][3] = {
 
 # if defined(MSWIN)
 // Mapping between cterm indices < 16 and their counterpart in the ANSI palette.
-static const char_u cterm_ansi_idx[] = {
+const char_u cterm_ansi_idx[] = {
     0, 4, 2, 6, 1, 5, 3, 7, 8, 12, 10, 14, 9, 13, 11, 15
 };
 # endif

--- a/src/termdefs.h
+++ b/src/termdefs.h
@@ -233,3 +233,8 @@ typedef enum {
     TMODE_RAW,	    // terminal mode for Normal and Insert mode
     TMODE_UNKNOWN   // after executing a shell
 } tmode_T;
+
+#if defined(MSWIN)
+// Mapping between cterm indices < 16 and their counterpart in the ANSI palette.
+extern const char_u cterm_ansi_idx[];
+#endif

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -3042,9 +3042,8 @@ color2index(VTermColor *color, int fg, int *boldp)
 	{
 	    uint8_t index = color->index;
 #ifdef MSWIN
-	    if (index < 16) {
+	    if (index < 16)
 		index = ansi_to_cterm_nr16[index];
-	    }
 #endif
 	    return index + 1;
 	}

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -3013,12 +3013,6 @@ may_toggle_cursor(term_T *term)
 	cursor_off();
 }
 
-#ifdef MSWIN
-static const uint8_t ansi_to_cterm_nr16[] = {
-    0, 4, 2, 6, 1, 5, 3, 7, 8, 12, 10, 14, 9, 13, 11, 15
-};
-#endif
-
 /*
  * Reverse engineer the RGB value into a cterm color index.
  * First color is 1.  Return 0 if no match found (default color).
@@ -3042,8 +3036,14 @@ color2index(VTermColor *color, int fg, int *boldp)
 	{
 	    uint8_t index = color->index;
 #ifdef MSWIN
+	    // Convert ANSI palette to cterm color index.
+	    // cterm_ansi_idx is a table for the reverse conversion from cterm
+	    // color index to ANSI palette. However, the current table can
+	    // be used for this conversion as well.
+	    // Note: If the contents of cterm_ansi_idx change in the future, a
+	    // different table may be needed for this purpose.
 	    if (index < 16)
-		index = ansi_to_cterm_nr16[index];
+		index = cterm_ansi_idx[index];
 #endif
 	    return index + 1;
 	}


### PR DESCRIPTION
Problem: ANSI escape colors are not displayed correctly in nontermguicolors in vim (cli) on Windows. The red and blue channels seem to be swapped.

[A file used for testing: ansi.txt](https://github.com/user-attachments/files/24166088/ansi.txt)

Result image before applying this change:
<img width="348" height="518" alt="Result image before applying this change" src="https://github.com/user-attachments/assets/88d47c22-f9c1-4865-953d-f3a8ab414509" />
(Please ignore translated messages)

Result image after applying this change:
<img width="339" height="529" alt="Result image after applying this change" src="https://github.com/user-attachments/assets/b9ed7f83-d6df-4606-8c1a-6924ac099a8d" />



Cause: When converting VTerm ANSI index colors to cterm colors in terminal.c, the Windows case equivalent to NR-16 (:help cterm-colors) is ignored.

Solution: Created and used a table to convert ANSI indexed colors to cterm's NR-16 representation (Windows only). This table corresponds to the inverse conversion of cterm_ansi_idx in term.c. The values in both tables are exactly the same, but the meanings are opposite, so they are separate tables.