### PR TITLE
assert_equal() prepends unnecessary ':' when typed

### DIFF
--- a/src/scriptfile.c
+++ b/src/scriptfile.c
@@ -226,7 +226,7 @@ estack_sfile(estack_arg_T which UNUSED)
 	    ga_concat_len(&ga, type_name.string, type_name.length);
 	    // For class methods prepend "<class name>." to the function name.
 	    if (*class_name.string != NUL)
-		ga.ga_len += vim_snprintf_safelen(
+		ga.ga_len += (int)vim_snprintf_safelen(
 		    (char *)ga.ga_data + ga.ga_len,
 		    len - (size_t)ga.ga_len,
 		    "<SNR>%d_%s.",
@@ -236,7 +236,7 @@ estack_sfile(estack_arg_T which UNUSED)
 	    // For the bottom entry of <sfile>: do not add the line number, it is used in
 	    // <slnum>.  Also leave it out when the number is not set.
 	    if (lnum != 0)
-		ga.ga_len += vim_snprintf_safelen(
+		ga.ga_len += (int)vim_snprintf_safelen(
 		    (char *)ga.ga_data + ga.ga_len,
 		    len - (size_t)ga.ga_len,
 		    "[%ld]",
@@ -246,7 +246,9 @@ estack_sfile(estack_arg_T which UNUSED)
 	}
     }
 
-    ga_append(&ga, NUL);
+    // Only NUL-terminate when not returning NULL.
+    if (ga.ga_data != NULL)
+	ga_append(&ga, NUL);
     return (char_u *)ga.ga_data;
 #endif
 }

--- a/src/testdir/test_assert.vim
+++ b/src/testdir/test_assert.vim
@@ -381,6 +381,19 @@ func Test_assert_fails_in_timer()
   call StopVimInTerminal(buf)
 endfunc
 
+" Check that a typed assert_equal() doesn't prepend an unnecessary ':'.
+func Test_assert_equal_typed()
+  let after =<< trim END
+    call feedkeys(":call assert_equal(0, 1)\<CR>", 't')
+    call feedkeys(":call writefile(v:errors, 'Xerrors')\<CR>", 't')
+    call feedkeys(":qa!\<CR>", 't')
+  END
+  call assert_equal(1, RunVim([], after, ''))
+  call assert_equal(['Expected 0 but got 1'], readfile('Xerrors'))
+
+  call delete('Xerrors')
+endfunc
+
 func Test_assert_beeps()
   new
   call assert_equal(0, assert_beeps('normal h'))


### PR DESCRIPTION
Problem:  assert_equal() prepends unnecessary ':' when typed
          (after 9.0.1758).
Solution: Don't change a NULL stacktrace to an empty string.
