### PR TITLE
Move target greedy match after $() to avoid region matching overflow

### DIFF
--- a/runtime/syntax/make.vim
+++ b/runtime/syntax/make.vim
@@ -40,10 +40,6 @@ syn match makeIdent	"\$\$\w*"
 syn match makeIdent	"\$\$\$\$\w*" containedin=makeDefine
 syn match makeIdent	"\$[^({]"
 syn match makeIdent	"\$\$[^({]" containedin=makeDefine
-syn match makeIdent	"^ *[^:#= \t]*\s*[:+?!*]="me=e-2
-syn match makeIdent	"^ *[^:#= \t]*\s*::="me=e-3
-syn match makeIdent	"^ *[^:#= \t]*\s*="me=e-1
-syn match makeIdent	"%"
 if get(b:, 'make_flavor', s:make_flavor) == 'microsoft'
   syn region makeIdent	start="\$(" end=")" contains=makeStatement,makeIdent
   syn region makeIdent	start="\${" end="}" contains=makeStatement,makeIdent
@@ -55,6 +51,10 @@ else
   syn region makeIdent	start="\$\$(" skip="\\)\|\\\\" end=")" containedin=makeDefine contains=makeStatement,makeIdent
   syn region makeIdent	start="\$\${" skip="\\}\|\\\\" end="}" containedin=makeDefine contains=makeStatement,makeIdent
 endif
+syn match makeIdent	"^ *[^:#= \t]*\s*[:+?!*]="me=e-2
+syn match makeIdent	"^ *[^:#= \t]*\s*::="me=e-3
+syn match makeIdent	"^ *[^:#= \t]*\s*="me=e-1
+syn match makeIdent	"%"
 
 " Makefile.in variables
 syn match makeConfig "@[A-Za-z0-9_]\+@"


### PR DESCRIPTION
Partially revert 2a33b499a3d7f46dc307234847a6562cef6cf1d8, where all syn match makeIdent are moved before syn region makeIdent to match $() (reason: see https://github.com/vim/vim/pull/18403#issuecomment-3341161566)

However this results in https://github.com/vim/vim/issues/18890 , because lines like
`$(a) =`
will first start a region search beginning with `$(` but then the whole target including `)` will be matched by `syn match makeIdent "^ *[^:#= \t]*\s*="me=e-1`
which leaves the region search for the never-found `)` and let the region matching overflow.

Same for

`$(a) ::`
`$(a) +=`

The solution is to move those greedy target match back, so they take priority and prevents region match from happening.

Closes: https://github.com/vim/vim/issues/18890