### PR TITLE
test_sound.vim fails on Windows

### DIFF
--- a/src/testdir/test_sound.vim
+++ b/src/testdir/test_sound.vim
@@ -33,9 +33,14 @@ func Test_play_event()
 endfunc
 
 func Test_play_silent()
+  if has('win32') && !has('gui_running')
+    throw 'Skipped: Playing file with callback is not supported on Windows, non-GUI'
+  endif
+
   let fname = fnamemodify('silent.wav', '%p')
   let g:playcallback_count = 0
   let g:result = -1
+  let g:id = 0
 
   " play without callback
   let id1 = sound_playfile(fname)


### PR DESCRIPTION
Problem: tests: test_sound.vim fails when run locally on Windows

Cause: There are two causes.

First. The global variable g:id is undefined, causing an undefined reference. Due to the execution order of test cases, g:id is defined in Test_play_event. However, on Windows, this test is skipped, so g:id is not defined. It is referenced in Test_play_silent's WaitForAssert without being defined, resulting in an undefined error.

Solution: Define g:id at the beginning of Test_play_silent.

Second. In the non-GUI Windows version of vim, there is no message loop, so the callback when play file sound ends does not occur, and Test_play_silent's WaitForAssert times out and fails. In CI, sound_playfile() returns 0, so Test_play_silent is skipped. The reason for this is unknown, but it may be because CI is running on Windows Server or something like that.

Solution: Skip Test_play_silent in Windows non-GUI environments.