### PR TITLE
Fix heap buffer overflow when in COMPAREANY instruction

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1349,7 +1349,13 @@ To compare Funcrefs to see if they refer to the same function, ignoring bound
 Dictionary and arguments, use |get()| to get the function name: >
 	if get(Part1, 'name') == get(Part2, 'name')
 	   " Part1 and Part2 refer to the same function
-<							*E1037*
+<
+							*E1572*
+An |Object| can only be compared with an |Object| and only "equal", "not
+equal", "is" and "isnot" can be used.  Note that an |Enum| is also a type of
+|Object|, and the same rules apply to it as well.
+
+							*E1037*
 Using "is" or "isnot" with a |List|, |Tuple|, |Dictionary| or |Blob| checks
 whether the expressions are referring to the same |List|, |Tuple|,
 |Dictionary| or |Blob| instance.  A copy of a |List| or |Tuple| is different

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1350,7 +1350,7 @@ Dictionary and arguments, use |get()| to get the function name: >
 	if get(Part1, 'name') == get(Part2, 'name')
 	   " Part1 and Part2 refer to the same function
 <
-							*E1572*
+							*E1437*
 An |Object| can only be compared with an |Object| and only "equal", "not
 equal", "is" and "isnot" can be used.  Note that an |Enum| is also a type of
 |Object|, and the same rules apply to it as well.

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -4757,6 +4757,7 @@ E1569	builtin.txt	/*E1569*
 E157	sign.txt	/*E157*
 E1570	builtin.txt	/*E1570*
 E1571	builtin.txt	/*E1571*
+E1572	eval.txt	/*E1572*
 E158	sign.txt	/*E158*
 E159	sign.txt	/*E159*
 E16	cmdline.txt	/*E16*

--- a/src/errors.h
+++ b/src/errors.h
@@ -3631,8 +3631,10 @@ EXTERN char e_enum_can_only_be_used_in_script[]
 	INIT(= N_("E1435: Enum can only be used in a script"));
 EXTERN char e_interface_can_only_be_used_in_script[]
 	INIT(= N_("E1436: Interface can only be used in a script"));
+EXTERN char e_can_only_compare_object_with_object[]
+	INIT(= N_("E1437: Can only compare Object with Object"));
 #endif
-// E1437 - E1499 unused (reserved for Vim9 class support)
+// E1438 - E1499 unused (reserved for Vim9 class support)
 EXTERN char e_cannot_mix_positional_and_non_positional_str[]
 	INIT(= N_("E1500: Cannot mix positional and non-positional arguments: %s"));
 EXTERN char e_fmt_arg_nr_unused_str[]

--- a/src/testdir/test_vim9_class.vim
+++ b/src/testdir/test_vim9_class.vim
@@ -13008,6 +13008,29 @@ def Test_object_any_type()
     x['a'] = {}
   END
   v9.CheckSourceDefAndScriptFailure(lines, ['E1012: Type mismatch; expected object<any> but got dict<any>', 'E1012: Type mismatch; expected object<any> but got dict<any>'])
+
+  # Error if comparing object with non object when using COMPAREANY instruction
+  lines =<< trim END
+    vim9script
+
+    enum DirectiveType
+        Unknown,
+        Set
+    endenum
+
+    type PatternSteps = list<any>
+    type Directive = tuple<DirectiveType, PatternSteps>
+
+    def Test(): void
+        var directive: Directive = (DirectiveType.Unknown, ["eq", 1, "hello"])
+
+        if directive[0] == "test"
+        endif
+    enddef
+
+    Test()
+  END
+  v9.CheckSourceFailure(lines, 'E1437: Can only compare Object with Object', 3)
 enddef
 
 " Test for object<{class}> type

--- a/src/typval.c
+++ b/src/typval.c
@@ -1887,6 +1887,11 @@ typval_compare_object(
 	*res = obj1 == obj2 ? res_match : !res_match;
 	return OK;
     }
+    else if (tv1->v_type != tv2->v_type)
+    {
+	emsg(_(e_can_only_compare_object_with_object));
+	return FAIL;
+    }
 
     *res = object_equal(obj1, obj2, ic) ? res_match : !res_match;
     return OK;


### PR DESCRIPTION
Reproduce:
1. Compile with ASAN
2. Run this script:
```vim
vim9script

enum DirectiveType
    Unknown,
    Set
endenum

type PatternSteps = list<any>
type Directive = tuple<DirectiveType, PatternSteps>

def g:Test(): void
    var directives: list<list<Directive>>

    directives[0] = [(DirectiveType.Unknown, ["eq", 1, "hello"])]

    for directive: Directive in directives[0]
        if directive[0] == 'set!'
        endif
    endfor
enddef
```

A heap buffer overflow will occur because object_equal() attempts to compare a VAR_OBJECT typval_T with a non VAR_OBJECT typval_T.