### PR TITLE
Skip term_gettty() test when using compty on Windows

### DIFF
--- a/src/testdir/test_vim9_builtin.vim
+++ b/src/testdir/test_vim9_builtin.vim
@@ -4766,6 +4766,9 @@ def Test_term_gettty()
     CheckFeature terminal
   else
     var buf = g:Run_shell_in_terminal({})
+    if has('win32') && buf->term_getjob()->job_info()['tty_type'] == 'conpty'
+      throw 'Skipped: When using conpty, term_gettty() always returns an empty string.'
+    endif
     term_gettty(buf, true)->assert_notequal('')
     g:StopShellInTerminal(buf)
   endif


### PR DESCRIPTION
Problem: tests: `Test_term_gettty()` fails when using conpty on Windows. CI uses winpty, so this test passes.

Solution: Skip the test `Test_term_gettty()`. Since conpty communicates via anonymous pipes, there is no name that can be obtained with `term_gettty()`.

---

For references:

Places where anonymous pipes are created and used:
https://github.com/vim/vim/blob/ca12f62d0a6a49db0e1956c5c217e7e00e0366c7/src/terminal.c#L7083-L7091