### PR TITLE
runtime(compiler): Match gcc.vim make error format

### DIFF
--- a/runtime/compiler/gcc.vim
+++ b/runtime/compiler/gcc.vim
@@ -16,6 +16,7 @@ let s:cpo_save = &cpo
 set cpo&vim
 
 CompilerSet errorformat=
+      \make:\ ***\ [%f:%l:\ %m,
       \%*[^\"]\"%f\"%*\\D%l:%c:\ %m,
       \%*[^\"]\"%f\"%*\\D%l:\ %m,
       \\"%f\"%*\\D%l:%c:\ %m,


### PR DESCRIPTION
Problem:  gcc.vim interprets "make: *** [Makefile" in the error message
          "make: *** [Makefile:2: all] Error 1" as a valid filename.
Solution: Add pattern to extract the filename correctly. Note that this
	  doesn't remove the dangling "]" from the output ("all]").