### PR TITLE
runtime(rustc): improve rust errorformat

### DIFF
--- a/runtime/compiler/rustc.vim
+++ b/runtime/compiler/rustc.vim
@@ -29,8 +29,10 @@ CompilerSet errorformat=
             \%Eerror:\ %m,
             \%Eerror[E%n]:\ %m,
             \%Wwarning:\ %m,
+            \%Wwarning[E%n]:\ %m,
             \%Inote:\ %m,
             \%C\ %#-->\ %f:%l:%c,
+            \%C\ %#╭▸\ %f:%l:%c,
             \%E\ \ left:%m,%C\ right:%m\ %f:%l:%c,%Z
 
 " Old errorformat (before nightly 2016/08/10)


### PR DESCRIPTION
This commit adds match patterns for:
- warnings with error codes (warning[E0123]: foobar)
- valid nightly unicode entries