### PR TITLE
tests: not enough tests for :setlocal omnifunc

### DIFF
--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -2428,32 +2428,49 @@ func Test_completefunc_callback()
     bw!
 
     #" :setlocal and :setglobal
-    set completefunc&
+    set complete=F completefunc&
     setlocal completefunc=function('g:CompleteFunc1',\ [22])
     call setline(1, 'sun')
     LET g:CompleteFunc1Args = []
     call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
     call assert_equal([[22, 1, ''], [22, 0, 'sun']], g:CompleteFunc1Args)
+    LET g:CompleteFunc1Args = []
+    call feedkeys("A\<C-N>\<Esc>", 'x')
+    call assert_equal([[22, 1, ''], [22, 0, 'sun']], g:CompleteFunc1Args)
     new
     call setline(1, 'sun')
     LET g:CompleteFunc1Args = []
     call assert_fails('call feedkeys("A\<C-X>\<C-U>\<Esc>", "x")', 'E764:')
     call assert_equal([], g:CompleteFunc1Args)
+    LET g:CompleteFunc1Args = []
+    call feedkeys("A\<C-N>\<Esc>", 'x')
+    call assert_equal([], g:CompleteFunc1Args)
     bw!
     setglobal completefunc=function('g:CompleteFunc1',\ [23])
     call setline(1, 'sun')
-    call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
-    call assert_equal([[22, 1, ''], [22, 0, 'sun']], g:CompleteFunc1Args)
-    new
-    call setline(1, 'sun')
     LET g:CompleteFunc1Args = []
     call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
-    call assert_equal([[23, 1, ''], [23, 0, 'sun']], g:CompleteFunc1Args)
+    call assert_equal([[22, 1, ''], [22, 0, 'sun']], g:CompleteFunc1Args)
+    LET g:CompleteFunc1Args = []
+    call feedkeys("A\<C-N>\<Esc>", 'x')
+    call assert_equal([[22, 1, ''], [22, 0, 'sun']], g:CompleteFunc1Args)
     setlocal completefunc&
     call setline(1, 'sun')
     LET g:CompleteFunc1Args = []
     call assert_fails('call feedkeys("A\<C-X>\<C-U>\<Esc>", "x")', 'E764:')
     call assert_equal([], g:CompleteFunc1Args)
+    LET g:CompleteFunc1Args = []
+    call feedkeys("A\<C-N>\<Esc>", 'x')
+    call assert_equal([], g:CompleteFunc1Args)
+    new
+    call setline(1, 'sun')
+    LET g:CompleteFunc1Args = []
+    call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
+    call assert_equal([[23, 1, ''], [23, 0, 'sun']], g:CompleteFunc1Args)
+    LET g:CompleteFunc1Args = []
+    call feedkeys("A\<C-N>\<Esc>", 'x')
+    call assert_equal([[23, 1, ''], [23, 0, 'sun']], g:CompleteFunc1Args)
+    set complete& completefunc&
     :%bw!
   END
   call v9.CheckLegacyAndVim9Success(lines)
@@ -2731,32 +2748,49 @@ func Test_omnifunc_callback()
     bw!
 
     #" :setlocal and :setglobal
-    set omnifunc&
+    set complete=o omnifunc&
     setlocal omnifunc=function('g:OmniFunc1',\ [22])
     call setline(1, 'sun')
     LET g:OmniFunc1Args = []
     call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
     call assert_equal([[22, 1, ''], [22, 0, 'sun']], g:OmniFunc1Args)
+    LET g:OmniFunc1Args = []
+    call feedkeys("A\<C-N>\<Esc>", 'x')
+    call assert_equal([[22, 1, ''], [22, 0, 'sun']], g:OmniFunc1Args)
     new
     call setline(1, 'sun')
     LET g:OmniFunc1Args = []
     call assert_fails('call feedkeys("A\<C-X>\<C-O>\<Esc>", "x")', 'E764:')
     call assert_equal([], g:OmniFunc1Args)
+    LET g:OmniFunc1Args = []
+    call feedkeys("A\<C-N>\<Esc>", 'x')
+    call assert_equal([], g:OmniFunc1Args)
     bw!
     setglobal omnifunc=function('g:OmniFunc1',\ [23])
     call setline(1, 'sun')
-    call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
-    call assert_equal([[22, 1, ''], [22, 0, 'sun']], g:OmniFunc1Args)
-    new
-    call setline(1, 'sun')
     LET g:OmniFunc1Args = []
     call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
-    call assert_equal([[23, 1, ''], [23, 0, 'sun']], g:OmniFunc1Args)
+    call assert_equal([[22, 1, ''], [22, 0, 'sun']], g:OmniFunc1Args)
+    LET g:OmniFunc1Args = []
+    call feedkeys("A\<C-N>\<Esc>", 'x')
+    call assert_equal([[22, 1, ''], [22, 0, 'sun']], g:OmniFunc1Args)
     setlocal omnifunc&
     call setline(1, 'sun')
     LET g:OmniFunc1Args = []
     call assert_fails('call feedkeys("A\<C-X>\<C-O>\<Esc>", "x")', 'E764:')
     call assert_equal([], g:OmniFunc1Args)
+    LET g:OmniFunc1Args = []
+    call feedkeys("A\<C-N>\<Esc>", 'x')
+    call assert_equal([], g:OmniFunc1Args)
+    new
+    call setline(1, 'sun')
+    LET g:OmniFunc1Args = []
+    call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
+    call assert_equal([[23, 1, ''], [23, 0, 'sun']], g:OmniFunc1Args)
+    LET g:OmniFunc1Args = []
+    call feedkeys("A\<C-N>\<Esc>", 'x')
+    call assert_equal([[23, 1, ''], [23, 0, 'sun']], g:OmniFunc1Args)
+    set complete& omnifunc&
     :%bw!
   END
   call v9.CheckLegacyAndVim9Success(lines)

--- a/src/testdir/test_tagfunc.vim
+++ b/src/testdir/test_tagfunc.vim
@@ -275,16 +275,17 @@ func Test_tagfunc_callback()
     call assert_equal([], g:TagFunc1Args)
     bw!
     setglobal tagfunc=function('g:TagFunc1',\ [23])
+    LET g:TagFunc1Args = []
     call assert_fails("tag a22", 'E433:')
     call assert_equal([22, 'a22', '', {}], g:TagFunc1Args)
-    new
-    LET g:TagFunc1Args = []
-    call assert_fails("tag a23", 'E433:')
-    call assert_equal([23, 'a23', '', {}], g:TagFunc1Args)
     setlocal tagfunc&
     LET g:TagFunc1Args = []
     call assert_fails("tag a23", 'E433:')
     call assert_equal([], g:TagFunc1Args)
+    new
+    LET g:TagFunc1Args = []
+    call assert_fails("tag a23", 'E433:')
+    call assert_equal([23, 'a23', '', {}], g:TagFunc1Args)
     :%bw!
   END
   call v9.CheckLegacyAndVim9Success(lines)


### PR DESCRIPTION
Problem:  Not enough tests for :setlocal omnifunc (after 9.1.1991).
Solution: Move the last :new after :setlocal. Also test with 'complete'.
