### PR TITLE
vim:runtime:compiler:t'y: add compiler file for Ty type checker

### DIFF
--- a/runtime/compiler/ty.vim
+++ b/runtime/compiler/ty.vim
@@ -1,0 +1,19 @@
+" Vim compiler file
+" Compiler:     Ty (Python Type Checker)
+" Maintainer:   @konfekt
+" Last Change:  2024 Dec 18
+
+if exists("current_compiler") | finish | endif
+let current_compiler = "ty"
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+" CompilerSet makeprg=ty
+exe 'CompilerSet makeprg=' ..  escape(
+        \ get(b:, 'ty_makeprg', get(g:, 'ty_makeprg', 'ty --no-progress --color=never'))
+        \ ..' check --output-format=concise', ' \|"')
+CompilerSet errorformat=%f:%l:%c:\ %m,%f:%l:\ %m,%f:%l:%c\ -\ %m,%f:
+
+let &cpo = s:cpo_save
+unlet s:cpo_save

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -1654,6 +1654,15 @@ b/g:mypy_makeprg_params variable.  For example: >
 
 The global default is "--strict --ignore-missing-imports".
 
+TY TYPE CHECKER					*compiler-ty*
+
+Commonly used compiler options and executable can be set by the
+b/g:ty_makeprg variable.  For example: >
+
+	let b:ty_makeprg = "uv run ty"
+
+The global default is "ty --no-progress --color=never".
+
 RUFF LINTER						*compiler-ruff*
 
 Commonly used compiler options can be added to 'makeprg' by setting the

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -6778,6 +6778,7 @@ compiler-spotbugs	quickfix.txt	/*compiler-spotbugs*
 compiler-tex	quickfix.txt	/*compiler-tex*
 compiler-tombi	quickfix.txt	/*compiler-tombi*
 compiler-tsc	quickfix.txt	/*compiler-tsc*
+compiler-ty	quickfix.txt	/*compiler-ty*
 compiler-typst	quickfix.txt	/*compiler-typst*
 compiler-vaxada	ft_ada.txt	/*compiler-vaxada*
 compl-current	insert.txt	/*compl-current*


### PR DESCRIPTION
This allows for setting the executable and possible parameters as they might differ in different projects as in other compiler files; see ongoing discussion in https://github.com/vim/vim/pull/18798 and at other places though if preference should rather be given to forking runtime files by the user and barring such customization by user variables to avoid global variable name clashes