### PR TITLE
fix(quickfix): restore correct window when closing quickfix

### DIFF
--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -4612,6 +4612,12 @@ qf_open_new_cwindow(qf_info_T *qi, int height)
     if (cmdmod.cmod_split == 0)
 	flags = WSP_BELOW;
     flags |= WSP_NEWLOC;
+
+    // Create a snapshot for quickfix window (not for location list)
+    // so that when closing it, we can restore to the previous window
+    if (IS_QF_STACK(qi))
+	flags |= WSP_QUICKFIX;
+
     if (win_split(height, flags) == FAIL)
 	return FAIL;		// not enough room for window
     RESET_BINDING(curwin);

--- a/src/structs.h
+++ b/src/structs.h
@@ -3693,9 +3693,10 @@ typedef void diffline_T;
 typedef void diffline_change_T;
 #endif
 
-#define SNAP_HELP_IDX	0
-#define SNAP_AUCMD_IDX	1
-#define SNAP_COUNT	2
+#define SNAP_HELP_IDX	    0
+#define SNAP_AUCMD_IDX	    1
+#define SNAP_QUICKFIX_IDX   2
+#define SNAP_COUNT	    3
 
 /*
  * Tab pages point to the top frame of each tab page.

--- a/src/testdir/test_quickfix.vim
+++ b/src/testdir/test_quickfix.vim
@@ -6958,4 +6958,15 @@ func Test_vimgrep_dummy_buffer_keep()
   %bw!
 endfunc
 
+func Test_quickfix_restore_current_win()
+  let curwin = win_getid()
+  vsplit Xb
+  wincmd p
+  botright copen
+  cclose
+
+  call assert_equal(curwin, win_getid())
+  bw! Xb
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/vim.h
+++ b/src/vim.h
@@ -1314,6 +1314,7 @@ extern int (*dyn_libintl_wputenv)(const wchar_t *envstring);
 #define WSP_ABOVE	0x80	// put new window above/left
 #define WSP_NEWLOC	0x100	// don't copy location list
 #define WSP_FORCE_ROOM	0x200	// ignore "not enough room" errors
+#define WSP_QUICKFIX	0x400	// creating the quickfix window
 
 /*
  * arguments for gui_set_shellsize()


### PR DESCRIPTION
Problem:
After `botright copen` and close this quikfix window, cursor ends up in the wrong window. The problem is fr_child always points to the first (leftmost for FR_ROW, topmost for FR_COL) child frame. When do :vsplit, the new window is created on the left, and frame_insert() updates the parent's fr_child to point to this new left window.

Solution:
Same as help windows - snapshot before open, restore when close.