### PR TITLE
Use string_T to store ocm_name

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -1205,7 +1205,7 @@ get_lval_check_access(
 		{
 		    if (om->ocm_type->tt_type == VAR_OBJECT)
 			semsg(_(e_enumvalue_str_cannot_be_modified),
-				cl->class_name.string, om->ocm_name);
+				cl->class_name.string, om->ocm_name.string);
 		    else
 			msg = e_variable_is_not_writable_str;
 		}
@@ -1218,7 +1218,7 @@ get_lval_check_access(
     }
     if (msg != NULL)
     {
-	emsg_var_cl_define(msg, om->ocm_name, 0, cl);
+	emsg_var_cl_define(msg, om->ocm_name.string, 0, cl);
 	return FAIL;
     }
     return OK;

--- a/src/structs.h
+++ b/src/structs.h
@@ -1580,7 +1580,7 @@ typedef enum {
  * Entry for an object or class member variable.
  */
 typedef struct {
-    char_u	*ocm_name;	// allocated
+    string_T	ocm_name;	// allocated
     omacc_T	ocm_access;
     type_T	*ocm_type;
     int		ocm_flags;

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -563,7 +563,7 @@ parse_argument_types(
 			{
 			    if (obj_members != NULL
 				    && STRCMP(aname,
-					obj_members[om].ocm_name) == 0)
+					obj_members[om].ocm_name.string) == 0)
 			    {
 				type = obj_members[om].ocm_type;
 				break;

--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -1628,7 +1628,7 @@ lhs_class_member_modifiable(lhs_T *lhs, char_u	*var_start, cctx_T *cctx)
     if (IS_ENUM(cl))
     {
 	semsg(_(e_enumvalue_str_cannot_be_modified), cl->class_name.string,
-		m->ocm_name);
+		m->ocm_name.string);
 	return FALSE;
     }
 
@@ -1643,7 +1643,7 @@ lhs_class_member_modifiable(lhs_T *lhs, char_u	*var_start, cctx_T *cctx)
 	char *msg = (m->ocm_access == VIM_ACCESS_PRIVATE)
 				? e_cannot_access_protected_variable_str
 				: e_variable_is_not_writable_str;
-	emsg_var_cl_define(msg, m->ocm_name, 0, cl);
+	emsg_var_cl_define(msg, m->ocm_name.string, 0, cl);
 	return FALSE;
     }
 
@@ -2055,7 +2055,7 @@ compile_lhs_set_oc_member_type(
 	if (!inside_class(cctx, cl))
 	{
 	    semsg(_(e_enumvalue_str_cannot_be_modified),
-		    cl->class_name.string, m->ocm_name);
+		    cl->class_name.string, m->ocm_name.string);
 	    return FAIL;
 	}
 	if (lhs->lhs_type->tt_type == VAR_OBJECT &&
@@ -2080,7 +2080,7 @@ compile_lhs_set_oc_member_type(
 	char *msg = (m->ocm_access == VIM_ACCESS_PRIVATE)
 	    ? e_cannot_access_protected_variable_str
 	    : e_variable_is_not_writable_str;
-	emsg_var_cl_define(msg, m->ocm_name, 0, cl);
+	emsg_var_cl_define(msg, m->ocm_name.string, 0, cl);
 	return FAIL;
     }
 
@@ -4118,7 +4118,7 @@ obj_constructor_prologue(ufunc_T *ufunc, cctx_T *cctx)
 		// determined at run time.  Add a runtime type check.
 		where_T	where = WHERE_INIT;
 		where.wt_kind = WT_MEMBER;
-		where.wt_func_name = (char *)m->ocm_name;
+		where.wt_func_name = (char *)m->ocm_name.string;
 		if (need_type_where(type, m->ocm_type, FALSE, -1,
 					where, cctx, FALSE, FALSE) == FAIL)
 		    return FAIL;

--- a/src/vim9execute.c
+++ b/src/vim9execute.c
@@ -2391,7 +2391,7 @@ execute_storeindex(isn_T *iptr, ectx_T *ectx)
 			char *msg = (m->ocm_access == VIM_ACCESS_PRIVATE)
 			    ? e_cannot_access_protected_variable_str
 			    : e_variable_is_not_writable_str;
-			emsg_var_cl_define(msg, m->ocm_name, 0, cl);
+			emsg_var_cl_define(msg, m->ocm_name.string, 0, cl);
 			status = FAIL;
 		    }
 		    // Fail if the variable is a const or final or the type
@@ -6145,7 +6145,7 @@ exec_instructions(ectx_T *ectx)
 			ocmember_T *m = &obj->obj_class->class_obj_members[idx];
 			SOURCING_LNUM = iptr->isn_lnum;
 			semsg(_(e_uninitialized_object_var_reference),
-				m->ocm_name);
+				m->ocm_name.string);
 			goto on_error;
 		    }
 		    copy_tv(mtv, tv);
@@ -7381,7 +7381,7 @@ list_instructions(char *pfx, isn_T *instr, int instr_count, ufunc_T *ufunc)
 		    smsg("%s%4d %s CLASSMEMBER %s.%s", pfx, current,
 			    iptr->isn_type == ISN_LOAD_CLASSMEMBER
 							    ? "LOAD" : "STORE",
-			    cl->class_name.string, ocm->ocm_name);
+			    cl->class_name.string, ocm->ocm_name.string);
 		}
 		break;
 

--- a/src/vim9expr.c
+++ b/src/vim9expr.c
@@ -551,7 +551,7 @@ compile_class_object_index(cctx_T *cctx, char_u **arg, type_T *type)
 	    if (*name == '_' && !inside_class(cctx, cl))
 	    {
 		emsg_var_cl_define(e_cannot_access_protected_variable_str,
-							m->ocm_name, 0, cl);
+							m->ocm_name.string, 0, cl);
 		goto done;
 	    }
 
@@ -596,7 +596,7 @@ compile_class_object_index(cctx_T *cctx, char_u **arg, type_T *type)
 	    if (*name == '_' && cctx->ctx_ufunc->uf_class != cl)
 	    {
 		emsg_var_cl_define(e_cannot_access_protected_variable_str,
-							m->ocm_name, 0, cl);
+							m->ocm_name.string, 0, cl);
 		goto done;
 	    }
 


### PR DESCRIPTION
Use struct `string_T` to store field `ocn_name` in struct `ocmember_T`.

This means we can use the `.length` field in struct `string_T`.

In addition in `vim9class.c`:
1: change some calls from `ga_concat()` to `ga_concat_len()` where the length is known.
2: in `ex_class()` remove unneeded variable `name`.
3. in `intf_method_present()` remove unneeded variable `cl_name`.
4: in `update_member_method_lookup_table()` move some assignments from inner loops into outer loops.
5: in `member_lookup()` remove unneeded `else`.
6: in `is_duplicate_variable()` and `is_duplicate_enum()` rearrange the string comparisons to first check the lengths match.

Cheers
John