### PR TITLE
refactor(vim9): use 'start' open urls on win32

### DIFF
--- a/runtime/autoload/dist/vim9.vim
+++ b/runtime/autoload/dist/vim9.vim
@@ -66,9 +66,13 @@ if has('unix')
   endif
 elseif has('win32')
   export def Launch(args: string)
-    const shell = (&shell =~? '\<cmd\.exe\>') ? '' : 'cmd.exe /c'
-    const quotes = empty(shell) ? '' : '""'
-    execute $'silent ! {shell} start {quotes} /b {args} {Redir()}' | redraw!
+    try
+      execute ':silent !start' args | redraw!
+    catch /^Vim(!):E371:/
+      echohl ErrorMsg
+      echom "dist#vim9#Launch(): can not start" args
+      echohl None
+    endtry
   enddef
 else
   export def Launch(dummy: string)
@@ -81,7 +85,10 @@ var os_viewer = null_string
 if has('win32unix')
   # (cyg)start suffices
   os_viewer = ''
-# Windows / WSL
+# Windows
+elseif has('win32')
+  os_viewer = '' # Use :!start
+# WSL
 elseif executable('explorer.exe')
   os_viewer = 'explorer.exe'
 # Linux / BSD

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -5231,7 +5231,7 @@ $VIMRUNTIME/plugin/openPlugin.vim
 dist#vim9#Open(file: string) ~
 
 Opens `path` with the system default handler (macOS `open`, Windows
-`explorer.exe`, Linux `xdg-open`, …).  If the variable |g:Openprg| exists the
+`start`, Linux `xdg-open`, …).  If the variable |g:Openprg| exists the
 string specified in the variable is used instead.
 
 The |:Open| user command uses file completion for its argument.


### PR DESCRIPTION
- Use `:!start` directly, discard the using of `explorer.exe`.
- Update the document in `eval.txt`.

Currently, on Windows, explorer.exe is used to open files, URLs, etc. However, this approach has several issues:

1. No error reporting: If an invalid input is provided, it simply opens an Explorer window at the homepage without indicating an error.
2. Bad process management: For unknown reasons, an explorer.exe process sometimes remains running in the background after opening a file.
3. Poor performance: On my machine, opening a file takes over one second, which is unusually slow.

Since I do not currently have WSL available, I do not change the behavior in WSL. Nevertheless, I believe explorer.exe can be removed entirely.