### PR TITLE
windows: GLVS plugin fails with wget.exe with PowerShell

### DIFF
--- a/runtime/autoload/getscript.vim
+++ b/runtime/autoload/getscript.vim
@@ -58,7 +58,10 @@ endif
 
 " wget vs curl {{{2
 if !exists("g:GetLatestVimScripts_wget")
- if executable("wget")
+ if executable("wget.exe")
+  " enforce extension: windows powershell desktop version has a wget alias that hides wget.exe
+  let g:GetLatestVimScripts_wget= "wget.exe"
+ elseif executable("wget")
   let g:GetLatestVimScripts_wget= "wget"
  elseif executable("curl.exe")
   " enforce extension: windows powershell desktop version has a curl alias that hides curl.exe
@@ -73,7 +76,7 @@ endif
 
 " options that wget and curl require:
 if !exists("g:GetLatestVimScripts_options")
- if g:GetLatestVimScripts_wget == "wget"
+ if g:GetLatestVimScripts_wget =~ "wget"
   let g:GetLatestVimScripts_options= "-q -O"
  elseif g:GetLatestVimScripts_wget =~ "curl"
   let g:GetLatestVimScripts_options= "-s -o"


### PR DESCRIPTION
Problem: Only Windows: The GLVS plugin fails in a PowerShell Desktop if wget.exe is installed. The PowerShell Desktop has an alias called wget which hides wget.exe.

Solution: Forces .exe extension if wget.exe is available.

---

Note: The same measure has already been taken for curl.exe, and this will now be taken for wget.exe as well.