### PR TITLE
Add out-of-memory checks

### DIFF
--- a/src/vim9class.c
+++ b/src/vim9class.c
@@ -179,7 +179,10 @@ add_member(
     m->ocm_name.length = (size_t)(varname_end - varname);
     m->ocm_name.string = vim_strnsave(varname, m->ocm_name.length);
     if (m->ocm_name.string == NULL)
+    {
 	m->ocm_name.length = 0;
+	return FAIL;
+    }
     m->ocm_access = has_public ? VIM_ACCESS_ALL
 		      : *varname == '_' ? VIM_ACCESS_PRIVATE : VIM_ACCESS_READ;
     if (has_final)
@@ -230,7 +233,10 @@ add_members_to_class(
 	*m = parent_members[i];
 	m->ocm_name.string = vim_strnsave(m->ocm_name.string, m->ocm_name.length);
 	if (m->ocm_name.string == NULL)
+	{
 	    m->ocm_name.length = 0;
+	    return FAIL;
+	}
 	if (m->ocm_init != NULL)
 	    m->ocm_init = vim_strsave(m->ocm_init);
     }


### PR DESCRIPTION
Based on AI feedback, in `vim9class.c` add out-of-memory checks to functions `add_member()` and `add_members_to_class()`.

Cheers
John