### PR TITLE
runtime(filetype): bpftrace hashbang not recognized

### DIFF
--- a/runtime/autoload/dist/script.vim
+++ b/runtime/autoload/dist/script.vim
@@ -233,6 +233,10 @@ export def Exe2filetype(name: string, line1: string): string
   elseif name =~ '^execlineb\>'
     return 'execline'
 
+    # Bpftrace
+  elseif name =~ '^bpftrace\>'
+    return 'bpftrace'
+
     # Vim
   elseif name =~ '^vim\>'
     return 'vim'

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -1095,6 +1095,7 @@ def s:GetScriptChecks(): dict<list<list<string>>>
             ['#!/path/regina']],
     janet:  [['#!/path/janet']],
     dart:   [['#!/path/dart']],
+    bpftrace:  [['#!/path/bpftrace']],
     vim:    [['#!/path/vim']],
   }
 enddef


### PR DESCRIPTION
Problem:    bpftrace files are not recognized from the hashbang line.
Solution:   Add a hashbang check.