### PR TITLE
runtime(filetype): Add file type for the Hylo language

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -2118,6 +2118,8 @@ const ft_from_ext = {
   "tmpl": "template",
   # Hurl
   "hurl": "hurl",
+  # Hylo
+  "hylo": "hylo",
   # Hyper Builder
   "hb": "hb",
   # Httest

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -381,6 +381,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     http: ['file.http'],
     hurl: ['file.hurl'],
     hy: ['file.hy', '.hy-history'],
+    hylo: ['file.hylo'],
     hyprlang: ['hyprlock.conf', 'hyprland.conf', 'hypridle.conf', 'hyprpaper.conf', '/hypr/foo.conf'],
     i3config: ['/home/user/.i3/config', '/home/user/.config/i3/config', '/etc/i3/config', '/etc/xdg/i3/config'],
     ibasic: ['file.iba', 'file.ibi'],


### PR DESCRIPTION
I added file type detection for the Hylo language.

For reference, see the Hylo language's website at https://hylo-lang.org/, and the merged PR at https://github.com/neovim/nvim-lspconfig/pull/4237/changes.