### PR TITLE
tests: Be sure to delete the "Xm4" test directory

### DIFF
--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -3233,9 +3233,9 @@ endfunc
 func Test_m4_format()
   filetype on
 
-  call mkdir('Xm4', 'D')
+  call mkdir('Xm4', 'R')
   cd Xm4
-  call writefile([''], 'alocal.m4', 'D')
+  call writefile([''], 'alocal.m4')
   split alocal.m4
   call assert_equal('m4', &filetype)
   bwipe!


### PR DESCRIPTION
Problem: tests: The "Xm4" directory remains after running test_filetype.vim.

Test_m4_format in test_filetype.vim creates the "Xm4" directory with the 'D' flag. Then it creates two files in the "Xm4" directory. One of them, "alocal.m4," was created with the 'D' flag, so it will disappear after the test is complete. However, the other, "configure.ac," was created without any flags, so it will remain even after the test is complete. Because the parent directory "Xm4" was created with the 'D' flag, the latter "configure.ac" remains and is not empty, so it will not be deleted.

Solution: The 'R' flag is now used when creating the "Xm4" directory.

This forces the directory to be deleted regardless of its contents. As a result,flags for two files "alocal.m4" and "configure.ac" created in the directory are no longer needed, so they have been deleted.