### PR TITLE
runtime(ftplugin): set different formatoptions for bpftrace

### DIFF
--- a/runtime/ftplugin/bpftrace.vim
+++ b/runtime/ftplugin/bpftrace.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin
 " Language:     bpftrace
 " Maintainer:	Stanislaw Gruszka <stf_xl@wp.pl>
-" Last Change:	2025 Dec 05
+" Last Change:	2025 Dec 23
 
 if exists('b:did_ftplugin')
   finish
@@ -11,4 +11,6 @@ let b:did_ftplugin = 1
 setlocal comments=sO:*\ -,mO:*\ \ ,exO:*/,s1:/*,mb:*,ex:*/,://
 setlocal commentstring=//\ %s
 
-let b:undo_ftplugin = "setlocal comments< commentstring<"
+setlocal formatoptions-=t formatoptions+=croql
+
+let b:undo_ftplugin = "setlocal comments< commentstring< formatoptions<"


### PR DESCRIPTION
Problem:  No default indention and formatting when editing bpftrace files.
 Solution: Set smartindent and formatoptions in bpftrace ftplugin, they
          work very well for bpftrace code, we do not need any custom
          indent script.