### PR TITLE
Display conpty terminal process failure message

### DIFF
--- a/src/terminal.c
+++ b/src/terminal.c
@@ -7048,6 +7048,7 @@ conpty_term_and_job_init(
     HANDLE	    o_theirs = NULL;
     HANDLE	    i_ours = NULL;
     HANDLE	    o_ours = NULL;
+    char	    *errmsg = NULL;
 
     ga_init2(&ga_cmd, sizeof(char*), 20);
     ga_init2(&ga_env, sizeof(char*), 20);
@@ -7149,7 +7150,10 @@ conpty_term_and_job_init(
 	    | CREATE_SUSPENDED | CREATE_DEFAULT_ERROR_MODE,
 	    env_wchar, cwd_wchar,
 	    &term->tl_siex.StartupInfo, &proc_info))
+    {
+	errmsg = GetWin32Error();
 	goto failed;
+    }
 
     CloseHandle(i_theirs);
     CloseHandle(o_theirs);
@@ -7257,6 +7261,9 @@ failed:
     if (term->tl_conpty != NULL)
 	pClosePseudoConsole(term->tl_conpty);
     term->tl_conpty = NULL;
+    // Propagate errors that occur in CreateProcess
+    if (errmsg)
+	semsg("CreateProcess failed: %s", errmsg);
     return FAIL;
 }
 

--- a/src/testdir/test_terminal3.vim
+++ b/src/testdir/test_terminal3.vim
@@ -46,9 +46,11 @@ func Test_terminal_shell_option()
     " the %PATH%, "term dir" succeeds unintentionally.  Use dir.com instead.
     try
       term dir.com /b runtest.vim
-      call WaitForAssert({-> assert_match('job failed', term_getline(bufnr(), 1))})
-    catch /CreateProcess/
-      " ignore
+      throw 'dir.com without a shell must fail, so you will never get here'
+    catch /CreateProcess failed/
+      " ignore:
+      " winpty simply fails with "CreateProcess failed".
+      " compty fails with "CreateProcess failed: {localized failure reason}".
     endtry
     bwipe!
 


### PR DESCRIPTION
Problem: When opening a conpty terminal, if process startup fails, it will silently exit.  As a result, the Test_terminal_shell_option in test_terminal3.vim failed in conpty.

In a winpty terminal, the winpty-provided error message "CreateProcess failed" was displayed.  The test is designed to catch this error as an exception.

Solution: Conpty now displays error messages in the same way as winpty.

In addition, since the GetWin32Error() function can obtain more detailed error messages, the format has been changed to "CreateProcess failed: {localized message from the OS}" for conpty.

Also, since the GetWin32Error() function returns errors in ACP (Active Code Page) encoding, these have been converted to Vim's internal encoding, enc.  This will prevent messages from being garbled in Japanese environments, etc.  The output of this function was basically used by the semsg() function in other places, so this change also fixes potential similar garbled characters.

The test now errors out immediately in places where it is expected not to be reached, and comments have been added about the expected content of the winpty and conpty error messages.