### PR TITLE
fix adjust_clip_reg in register.c when using clipboard provider feature with unnamed/unnamedplus flags in 'clipboard' option

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1823,7 +1823,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	prepend, e.g.: >
 		set clipboard^=unnamed
 <	When using the GUI see |'go-A'|.
-	When using the |clipboard-providers| feature, only the "unamed" and
+	When using the |clipboard-providers| feature, only the "unnamed" and
 	"unnamedplus" features will be recognized  If compiled without the
 	|+clipboard| feature but compiled with the |+clipboard_provider|
 	feature, then they will be the only values allowed and the other

--- a/src/clipboard.c
+++ b/src/clipboard.c
@@ -3534,7 +3534,7 @@ adjust_clip_reg(int *rp)
 #ifdef FEAT_CLIPBOARD_PROVIDER
     if (clipmethod == CLIPMETHOD_PROVIDER)
     {
-	if (clip_unnamed != 0)
+	if (*rp == 0 && clip_unnamed != 0)
 	    *rp = ((clip_unnamed & CLIP_UNNAMED_PLUS)) ? '+' : '*';
 	return;
     }


### PR DESCRIPTION
fixes #18988 and #18983

Also fixes a small typo in options.txt