### PR TITLE
Fix blob2str stopping after an empty line

### DIFF
--- a/src/strings.c
+++ b/src/strings.c
@@ -1234,6 +1234,8 @@ blob_from_string(char_u *str, blob_T *blob)
  * Return a string created from the bytes in blob starting at "start_idx".
  * A NL character in the blob indicates end of string.
  * A NUL character in the blob is translated to a NL.
+ * If a newline is followed by another newline (empty line), then an empty
+ * allocated string is returned and "start_idx" is moved forward by one byte.
  * On return, "start_idx" points to next byte to process in blob.
  */
     static char_u *
@@ -1265,6 +1267,8 @@ string_from_blob(blob_T *blob, long *start_idx)
 
     if (str_ga.ga_data != NULL)
 	ret_str = vim_strnsave(str_ga.ga_data, str_ga.ga_len);
+    else
+	ret_str = vim_strsave((char_u *)"");
     *start_idx = idx;
 
     ga_clear(&str_ga);

--- a/src/testdir/test_blob.vim
+++ b/src/testdir/test_blob.vim
@@ -885,4 +885,17 @@ func Test_blob_byte_set_invalid_value()
   call v9.CheckSourceLegacyAndVim9Failure(lines, 'E1239: Invalid value for blob:')
 endfunc
 
+" Test when converting a blob to a string, and there is an empty line (newline
+" followed directly by another newline).
+func Test_blob2str_empty_line()
+  let stuff =<< trim END
+  Hello
+
+  World!
+  END
+
+  let b = str2blob(stuff)
+  call assert_equal(['Hello', '', 'World!'], blob2str(b))
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Before, if a blob that represented a string with an empty line (ex. "\n\n..."), then everything after the newline would be ignored