### PR TITLE
cindent: fix aligning else at if do if while else

### DIFF
--- a/src/testdir/test_cindent.vim
+++ b/src/testdir/test_cindent.vim
@@ -1111,6 +1111,27 @@ def Test_cindent_1()
   b;
   }
 
+  void func() {
+  if (0)
+  do
+  if (0);
+  while (0);
+  else;
+  }
+
+  void func() {
+  if (0)
+  do
+  if (0)
+  do
+  if (0)
+  a();
+  while (0);
+  while (0);
+  else
+  a();
+  }
+
   /* end of AUTO */
   [CODE]
 
@@ -2091,6 +2112,27 @@ def Test_cindent_1()
   void foo() {
   	float a[5],
   		  b;
+  }
+
+  void func() {
+  	if (0)
+  		do
+  			if (0);
+  		while (0);
+  	else;
+  }
+
+  void func() {
+  	if (0)
+  		do
+  			if (0)
+  				do
+  					if (0)
+  						a();
+  				while (0);
+  		while (0);
+  	else
+  		a();
   }
 
   /* end of AUTO */


### PR DESCRIPTION
Problem:
At "if(0) do if(0); while(0); else", else should be aligned with outer if, but is aligned with inner if.

Solution:
In function find_match, ignore "if" and "else" inside a do-while loop, when looking for "if".