### PR TITLE
runtime(termdebug): fix vim9 condition

### DIFF
--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -454,7 +454,7 @@ def GetRemotePtyCmd(gdb_cmd: list<string>): list<string>
         term_cmd = gdb_cmd[0 : gdb_pos - 1]
         # roundtrip to check if socat is available on the remote side
         silent call system(join(term_cmd, ' ') .. ' socat -h')
-        if v:shell_error
+        if v:shell_error != 0
           Echowarn('Install socat on the remote machine for a program window better experience')
         else
           # create a devoted tty slave device and link to stdin/stdout


### PR DESCRIPTION
This fix references https://github.com/vim/vim/pull/18429
In vim9 the condition:
https://github.com/vim/vim/blob/20064150169a94380abef37d3966c864531d1d92/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim#L457-L459
is wrong because only the integers `0` and `1` are valid booleans.
`v:shell_error` may not be `1` (`sh` like shells return `1` on failure but `powershell` returns `127` and breaks the script).