### PR TITLE
fix: ignore 'Found' messages in ruff and ty compiler files

### DIFF
--- a/runtime/compiler/ruff.vim
+++ b/runtime/compiler/ruff.vim
@@ -1,7 +1,7 @@
 " Vim compiler file
 " Compiler:     Ruff (Python linter)
 " Maintainer:   @pbnj-dragon
-" Last Change:  2024 Nov 07
+" Last Change:  2024 Dec 24 by the Vim Project (mute Found messages)
 "		2024 Nov 19 by the Vim Project (properly escape makeprg setting)
 "		2025 Nov 06 by the Vim Project (do not set buffer-local makeprg)
 
@@ -16,6 +16,7 @@ exe 'CompilerSet makeprg=' .. escape('ruff check --output-format=concise '
         \ ..get(b:, 'ruff_makeprg_params', get(g:, 'ruff_makeprg_params', '--preview')),
         \ ' \|"')
 CompilerSet errorformat=%f:%l:%c:\ %m,%f:%l:\ %m,%f:%l:%c\ -\ %m,%f:
+CompilerSet errorformat+=%-GFound\ %.%#
 
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/runtime/compiler/ty.vim
+++ b/runtime/compiler/ty.vim
@@ -1,7 +1,7 @@
 " Vim compiler file
 " Compiler:     Ty (Python Type Checker)
 " Maintainer:   @konfekt
-" Last Change:  2024 Dec 18
+" Last Change:  2024 Dec 24
 
 if exists("current_compiler") | finish | endif
 let current_compiler = "ty"
@@ -11,9 +11,10 @@ set cpo&vim
 
 " CompilerSet makeprg=ty
 exe 'CompilerSet makeprg=' ..  escape(
-        \ get(b:, 'ty_makeprg', get(g:, 'ty_makeprg', 'ty --no-progress --color=never'))
-        \ ..' check --output-format=concise', ' \|"')
+        \ get(b:, 'ty_makeprg', get(g:, 'ty_makeprg', 'ty check --no-progress --color=never'))
+        \ ..' --output-format=concise', ' \|"')
 CompilerSet errorformat=%f:%l:%c:\ %m,%f:%l:\ %m,%f:%l:%c\ -\ %m,%f:
+CompilerSet errorformat+=%-GFound\ %.%#
 
 let &cpo = s:cpo_save
 unlet s:cpo_save


### PR DESCRIPTION
I am sorry, there was a typo in `ty.vim`, mixing the order of arguments; also suppress status messages from quickfix