### PR TITLE
runtime(netrw): Fix reading UNC paths on windows

### DIFF
--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -3234,7 +3234,7 @@ function s:NetrwFile(fname)
             let b:netrw_curdir= getcwd()
         endif
 
-        if !exists("g:netrw_cygwin") && has("win32")
+        if !g:netrw_cygwin && has("win32")
             if fname =~ '^\' || fname =~ '^\a:\'
                 " windows, but full path given
                 let ret= fname


### PR DESCRIPTION
Problem:
When Vim is launched with a UNC directory, netrw treats it as a relative path and compose it again.

Solution:
This is due to `exists("g:netrw_cygwin")` always being true. We can directly use `g:netrw_cygwin`.

Reproduction step:
1. launch PowerShell.
2. `cd \\localhost\C$`
3. `vim .`
4. Shows only empty content instead of file list on `C:` drive.