### PR TITLE
Avoid using C++ keyword `class` as member variable name

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -131,7 +131,7 @@ fill_evalarg_from_eap(evalarg_T *evalarg, exarg_T *eap, int skip)
 	evalarg->eval_getline = eap->ea_getline;
 	evalarg->eval_cookie = eap->cookie;
     }
-    evalarg->eval_class = eap->class;
+    evalarg->eval_class = eap->ea_class;
 }
 
 /*

--- a/src/ex_cmds.h
+++ b/src/ex_cmds.h
@@ -1973,7 +1973,7 @@ struct exarg
     void	*cookie;	// argument for getline()
 #ifdef FEAT_EVAL
     cstack_T	*cstack;	// condition stack for ":if" etc.
-    class_T	*class;		// Name of class being defined. Used by :class
+    class_T	*ea_class;		// Name of class being defined. Used by :class
 				// and :enum commands.
 #endif
 };

--- a/src/vim9class.c
+++ b/src/vim9class.c
@@ -2122,7 +2122,7 @@ early_ret:
     cl->class_object_type.tt_type = VAR_OBJECT;
     cl->class_object_type.tt_class = cl;
 
-    eap->class = cl;
+    eap->ea_class = cl;
 
     // Add the class to the script-local variables.
     // TODO: handle other context, e.g. in a function


### PR DESCRIPTION
Problem:  A recent commit introduced a member variable named `class` in
          the `exarg` structure, which conflicts with the C++ keyword
          `class`. This causes compilation issues on Windows when VIM
          is compiled with OLE enabled, as "if_ole.cpp" cannot compile
          due to the keyword conflict.

Solution: Rename the member variable of `exarg` from `class` to `cclass`.