### PR TITLE
fsync option cannot be set per buffer

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4269,7 +4269,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 					*'fsync'* *'fs'* *'nofsync'* *'nofs'*
 'fsync' 'fs'		boolean	(default on)
-			global
+			global or local to buffer |global-local|
 	When on, the library function fsync() will be called after writing a
 	file.  This will flush a file to disk, ensuring that it is safely
 	written even on filesystems which do metadata-only journaling.  This

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -2537,6 +2537,9 @@ free_buf_options(
     clear_string_option(&buf->b_p_qe);
     buf->b_p_ac = -1;
     buf->b_p_ar = -1;
+#ifdef HAVE_FSYNC
+    buf->b_p_fs = -1;
+#endif
     buf->b_p_ul = NO_LOCAL_UNDOLEVEL;
     clear_string_option(&buf->b_p_lw);
     clear_string_option(&buf->b_p_bkc);

--- a/src/bufwrite.c
+++ b/src/bufwrite.c
@@ -2199,7 +2199,8 @@ restore_backup:
 	// For a device do try the fsync() but don't complain if it does not
 	// work (could be a pipe).
 	// If the 'fsync' option is FALSE, don't fsync().  Useful for laptops.
-	if (p_fs && vim_fsync(fd) != 0 && !device)
+	if ((buf->b_p_fs >= 0 ? buf->b_p_fs : p_fs) && vim_fsync(fd) != 0
+		&& !device)
 	{
 	    errmsg = (char_u *)_(e_fsync_failed);
 	    end = 0;

--- a/src/option.c
+++ b/src/option.c
@@ -698,6 +698,9 @@ set_init_1(int clean_arg)
     curbuf->b_p_initialized = TRUE;
     curbuf->b_p_ac = -1;
     curbuf->b_p_ar = -1;	// no local 'autoread' value
+#ifdef HAVE_FSYNC
+    curbuf->b_p_fs = -1;	// no local 'fsync' value
+#endif
     curbuf->b_p_ul = NO_LOCAL_UNDOLEVEL;
     check_buf_options(curbuf);
     check_win_options(curwin);
@@ -2216,6 +2219,10 @@ do_set_option_bool(
 	    value = -1;
 	else if ((int *)varp == &curbuf->b_p_ac && opt_flags == OPT_LOCAL)
 	    value = -1;
+#ifdef HAVE_FSYNC
+	else if ((int *)varp == &curbuf->b_p_fs && opt_flags == OPT_LOCAL)
+	    value = -1;
+#endif
 	else
 	    value = *(int *)get_varp_scope(&(options[opt_idx]), OPT_GLOBAL);
     }
@@ -6479,6 +6486,11 @@ unset_global_local_option(char_u *name, void *from)
 	case PV_AR:
 	    buf->b_p_ar = -1;
 	    break;
+#ifdef HAVE_FSYNC
+	case PV_FS:
+	    buf->b_p_fs = -1;
+	    break;
+#endif
 	case PV_BKC:
 	    clear_string_option(&buf->b_p_bkc);
 	    buf->b_bkc_flags = 0;
@@ -6613,6 +6625,9 @@ get_varp_scope(struct vimoption *p, int scope)
 	switch ((int)p->indir)
 	{
 	    case PV_FP:   return (char_u *)&(curbuf->b_p_fp);
+#ifdef HAVE_FSYNC
+	    case PV_FS:	return (char_u *)&(curbuf->b_p_fs);
+#endif
 #ifdef FEAT_EVAL
 	    case PV_FFU: return (char_u *)&(curbuf->b_p_ffu);
 #endif
@@ -6737,6 +6752,10 @@ get_varp(struct vimoption *p)
 #endif
 	case PV_FP:	return *curbuf->b_p_fp != NUL
 				    ? (char_u *)&(curbuf->b_p_fp) : p->var;
+#ifdef HAVE_FSYNC
+	case PV_FS:	return curbuf->b_p_fs >= 0
+				    ? (char_u *)&(curbuf->b_p_fs) : p->var;
+#endif
 #ifdef FEAT_EVAL
 	case PV_FFU:	return *curbuf->b_p_ffu != NUL
 				    ? (char_u *)&(curbuf->b_p_ffu) : p->var;
@@ -7540,6 +7559,9 @@ buf_copy_options(buf_T *buf, int flags)
 	    // are not copied, start using the global value
 	    buf->b_p_ac = -1;
 	    buf->b_p_ar = -1;
+#ifdef HAVE_FSYNC
+	    buf->b_p_fs = -1;
+#endif
 	    buf->b_p_ul = NO_LOCAL_UNDOLEVEL;
 	    buf->b_p_bkc = empty_option;
 	    buf->b_bkc_flags = 0;

--- a/src/option.h
+++ b/src/option.h
@@ -1224,6 +1224,9 @@ enum
     , BV_FF
     , BV_FLP
     , BV_FO
+#ifdef HAVE_FSYNC
+    , BV_FS
+#endif
     , BV_FT
     , BV_IMI
     , BV_IMS

--- a/src/optiondefs.h
+++ b/src/optiondefs.h
@@ -82,6 +82,9 @@
 #define PV_FF		OPT_BUF(BV_FF)
 #define PV_FLP		OPT_BUF(BV_FLP)
 #define PV_FO		OPT_BUF(BV_FO)
+#ifdef HAVE_FSYNC
+# define PV_FS		OPT_BOTH(OPT_BUF(BV_FS))
+#endif
 #define PV_FT		OPT_BUF(BV_FT)
 #define PV_IMI		OPT_BUF(BV_IMI)
 #define PV_IMS		OPT_BUF(BV_IMS)
@@ -1172,7 +1175,7 @@ static struct vimoption options[] =
 			    {(char_u *)"", (char_u *)0L} SCTX_INIT},
     {"fsync",       "fs",   P_BOOL|P_SECURE|P_VI_DEF,
 #ifdef HAVE_FSYNC
-			    (char_u *)&p_fs, PV_NONE, NULL, NULL,
+			    (char_u *)&p_fs, PV_FS, NULL, NULL,
 			    {(char_u *)TRUE, (char_u *)0L}
 #else
 			    (char_u *)NULL, PV_NONE, NULL, NULL,

--- a/src/structs.h
+++ b/src/structs.h
@@ -3377,6 +3377,9 @@ struct file_buffer
     char_u	*b_p_fex;	// 'formatexpr'
     long_u	b_p_fex_flags;	// flags for 'formatexpr'
 #endif
+#ifdef HAVE_FSYNC
+    int		b_p_fs;		// 'fsync'
+#endif
 #ifdef FEAT_CRYPT
     char_u	*b_p_key;	// 'key'
 #endif

--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -1681,25 +1681,34 @@ endfunc
 
 " Test for setting boolean global-local option value
 func Test_set_boolean_global_local_option()
-  setglobal autoread
-  setlocal noautoread
+  CheckUnix
+
+  setglobal autoread fsync
+  setlocal noautoread nofsync
   call assert_equal(1, &g:autoread)
   call assert_equal(0, &l:autoread)
   call assert_equal(0, &autoread)
+  call assert_equal(1, &g:fsync)
+  call assert_equal(0, &l:fsync)
+  call assert_equal(0, &fsync)
 
   " :set {option}< set the effective value of {option} to its global value.
-  set autoread<
+  set autoread< fsync<
   call assert_equal(1, &l:autoread)
   call assert_equal(1, &autoread)
+  call assert_equal(1, &l:fsync)
+  call assert_equal(1, &fsync)
 
   " :setlocal {option}< removes the local value, so that the global value will be used.
-  setglobal noautoread
-  setlocal autoread
-  setlocal autoread<
+  setglobal noautoread nofsync
+  setlocal autoread fsync
+  setlocal autoread< fsync<
   call assert_equal(-1, &l:autoread)
   call assert_equal(0, &autoread)
+  call assert_equal(-1, &l:fsync)
+  call assert_equal(0, &fsync)
 
-  set autoread&
+  set autoread& fsync&
 endfunc
 
 func Test_set_in_sandbox()

--- a/src/undo.c
+++ b/src/undo.c
@@ -1774,7 +1774,8 @@ u_write_undo(
 #endif
 
 #if defined(UNIX) && defined(HAVE_FSYNC)
-    if (p_fs && fflush(fp) == 0 && vim_fsync(fd) != 0)
+    if ((buf->b_p_fs >= 0 ? buf->b_p_fs : p_fs) && fflush(fp) == 0
+	    && vim_fsync(fd) != 0)
 	write_ok = FALSE;
 #endif
 


### PR DESCRIPTION
Problem:  'fsync' option is global, cannot be customized per buffer
Solution: Make 'fsync' can local to buffer

relate https://github.com/neovim/neovim/issues/36936