### PR TITLE
Use-after-free in alist_add()

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -75,6 +75,7 @@ static garray_T buf_reuse = GA_EMPTY;	// file numbers to recycle
     static void
 trigger_undo_ftplugin(buf_T *buf, win_T *win)
 {
+    int win_was_locked = win->w_locked;
     window_layout_lock();
     buf->b_locked++;
     win->w_locked = TRUE;
@@ -82,7 +83,7 @@ trigger_undo_ftplugin(buf_T *buf, win_T *win)
     do_cmdline_cmd((char_u*)"if exists('b:undo_ftplugin') | :legacy :exe \
 	    b:undo_ftplugin | endif");
     buf->b_locked--;
-    win->w_locked = FALSE;
+    win->w_locked = win_was_locked;
     window_layout_unlock();
 }
 

--- a/src/testdir/test_arglist.vim
+++ b/src/testdir/test_arglist.vim
@@ -772,7 +772,6 @@ func Test_crash_arglist_uaf()
   "%argdelete
   new one
   au BufAdd XUAFlocal :bw
-  "call assert_fails(':arglocal XUAFlocal', 'E163:')
   arglocal XUAFlocal
   au! BufAdd
   bw! XUAFlocal
@@ -785,6 +784,17 @@ func Test_crash_arglist_uaf()
   bw! XUAFlocal2
   bw! two
 
+  au! BufAdd
+endfunc
+
+" This was using freed memory again
+func Test_crash_arglist_uaf2()
+  new
+  au BufAdd XUAFlocal :bw
+  arglocal XUAFlocal
+  redraw!
+  put ='abc'
+  2#
   au! BufAdd
 endfunc
 


### PR DESCRIPTION
Problem:  A BufAdd autocommand may cause alist_add() to use freed
          memory, this is caused by the w_locked variable unset too
          early.
Solution: in trigger_undo_ftplugin() only set w_locked to false, if it
          was false when calling the function.