### PR TITLE
runtime(bpftrace): add indention settings

### DIFF
--- a/.github/MAINTAINERS
+++ b/.github/MAINTAINERS
@@ -336,6 +336,7 @@ runtime/import/dist/vimhighlight.vim			@lacygoill
 runtime/indent/arduino.vim				@k-takata
 runtime/indent/astro.vim				@wuelnerdotexe
 runtime/indent/basic.vim				@dkearns
+runtime/indent/bpftrace.vim				@sgruszka
 runtime/indent/bst.vim					@tpope
 runtime/indent/cdl.vim					@dkearns
 runtime/indent/chatito.vim				@ObserverOfTime

--- a/runtime/indent/bpftrace.vim
+++ b/runtime/indent/bpftrace.vim
@@ -1,0 +1,19 @@
+" Vim indent file
+" Language:     bpftrace
+" Author:       Stanislaw Gruszka <stf_xl@wp.pl>
+" Last Change:  2025 Dec 27
+
+" Only load this indent file when no other was loaded.
+if exists("b:did_indent")
+    finish
+endif
+let b:did_indent = 1
+
+setlocal noautoindent nosmartindent
+
+setlocal cindent
+setlocal cinoptions=+0,(0,[0,Ws,J1,j1,m1,>s
+setlocal cinkeys=0{,0},!^F,o,O,#0
+setlocal cinwords=
+
+let b:undo_indent = "setlocal autoindent< smartindent< cindent< cinoptions< cinkeys< cinwords<"


### PR DESCRIPTION
Problem:  No indention support when editing bpftrace files.
Solution: Add indention settings based on cindent with custom options.