### PR TITLE
tests: Fix flaky Test_terminal_cwd in ConPTY

### DIFF
--- a/src/structs.h
+++ b/src/structs.h
@@ -2716,8 +2716,14 @@ struct channel_S {
 				// reference, the job refers to the channel.
     int		ch_job_killed;	// TRUE when there was a job and it was killed
 				// or we know it died.
-    int		ch_anonymous_pipe;  // ConPTY
-    int		ch_killing;	    // TerminateJobObject() was called
+    int		ch_anonymous_pipe;  // Indicates that anonymous pipes are being
+				    // used for communication in the Windows
+				    // ConPTY terminal.
+    int		ch_killing;	    // Indicates that the job associated with
+				    // the channel is terminating.  It becomes
+				    // TRUE when TerminateJobObject() was
+				    // called or the process associated with
+				    // the job had exited (only ConPTY).
 
     int		ch_refcount;	// reference count
     int		ch_copyID;


### PR DESCRIPTION
Problem: tests: Test_terminal_cwd in test_terminal.vim fails flaky in the Windows ConPTY terminal.

Processes that terminate too quickly in the ConPTY terminal cause Vim to miss their final output.

In my environment, the probability of the "cmd /D /c cd" used in Test_terminal_cwd occurring is about 1/4.  For a simple statically linked Hello World, the probability of it occurring is about 3/4.

Solution: In ConPTY, the timeout is extended to 1msec when reading a channel associated with a job that is about to finish.  This allows Vim to read the last output of a process in a pseudo console.

In investigating this issue, I added comments to explain my understanding of two poorly explained fields in the channel structure.