### PR TITLE
Make conpty default on Windows 11

### DIFF
--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -8574,7 +8574,7 @@ mch_setenv(char *var, char *value, int x UNUSED)
  */
 #define CONPTY_STABLE_BUILD	    MAKE_VER(10, 0, 22000)
 // Notes:
-// Win 10 22H2 Final is build 19045, it's conpty is widely used.
+// Win 10 22H2 Final is build 19045, its conpty is widely used.
 // Strangely, 19045 is newer but is a lower build number than the 2020 insider
 // preview which had a build 19587.  And, not sure how stable that was?
 // Win Server 2022 (May 10, 2022) is build 20348, its conpty is widely used.

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -8570,9 +8570,9 @@ mch_setenv(char *var, char *value, int x UNUSED)
 #define CONPTY_INSIDER_BUILD	    MAKE_VER(10, 0, 18995)
 
 /*
- * Not stable now.
+ * Make conpty default on Windows 11
  */
-#define CONPTY_STABLE_BUILD	    MAKE_VER(10, 0, 32767)  // T.B.D.
+#define CONPTY_STABLE_BUILD	    MAKE_VER(10, 0, 22000)
 // Notes:
 // Win 10 22H2 Final is build 19045, it's conpty is widely used.
 // Strangely, 19045 is newer but is a lower build number than the 2020 insider


### PR DESCRIPTION
Conpty was first introduced in 2018, and it's stable on Windows 11 now.

fix #19033 