### PR TITLE
Allow using class members from lambda inside a object method

### DIFF
--- a/src/testdir/test_vim9_class.vim
+++ b/src/testdir/test_vim9_class.vim
@@ -11832,4 +11832,41 @@ func Test_class_selfref_gc()
   call v9.CheckSourceSuccess(lines)
 endfunc
 
+" Test if class members can be accessed via a lambda inside a object/class
+" method.
+func Test_class_member_lambda()
+  let lines =<< trim END
+    vim9script
+    class A
+      static var regular: string
+      static var _protected: string
+
+      static def RegularMethod(): string
+        return A.regular
+      enddef
+
+      static def _ProtectedMethod(): string
+        return A._protected
+      enddef
+
+      def new()
+        var FuncA: func = () => {
+          A.regular = "regular"
+          assert_equal("regular", A.RegularMethod())
+        }
+        var FuncB: func = () => {
+          A._protected = "protected"
+          assert_equal("protected", A._ProtectedMethod())
+        }
+
+        FuncA()
+        FuncB()
+      enddef
+    endclass
+
+    A.new()
+  END
+  call v9.CheckSourceSuccess(lines)
+endfunc
+
 " vim: ts=8 sw=2 sts=2 expandtab tw=80 fdm=marker

--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -2075,7 +2075,7 @@ compile_lhs_set_oc_member_type(
     // only inside the class where it is defined.
     if ((m->ocm_access != VIM_ACCESS_ALL) &&
 	    ((is_object && !inside_class(cctx, cl))
-	     || (!is_object && cctx->ctx_ufunc->uf_class != cl)))
+	     || (!is_object && cctx->ctx_ufunc->uf_defclass != cl)))
     {
 	char *msg = (m->ocm_access == VIM_ACCESS_PRIVATE)
 	    ? e_cannot_access_protected_variable_str

--- a/src/vim9expr.c
+++ b/src/vim9expr.c
@@ -508,7 +508,7 @@ compile_class_object_index(cctx_T *cctx, char_u **arg, type_T *type)
 		((type->tt_type == VAR_OBJECT
 		  && !inside_class_hierarchy(cctx, cl))
 		 || (type->tt_type == VAR_CLASS
-		     && cctx->ctx_ufunc->uf_class != cl)))
+		     && cctx->ctx_ufunc->uf_defclass != cl)))
 	{
 	    semsg(_(e_cannot_access_protected_method_str), name);
 	    goto done;


### PR DESCRIPTION
Before this wouldn't work:
```vim
vim9script

class A
    static var value: string

    static def _Method(): void
        echom A.value
    enddef

    def new()
        var Something: func = () => {
            A.value = "hey"
            A._Method()
        }

        Something()
    enddef
endclass

var obj: object<A> = A.new()
```