### PR TITLE
runtime(rust): fix indentation after nested array literal

### DIFF
--- a/runtime/indent/rust.vim
+++ b/runtime/indent/rust.vim
@@ -195,6 +195,22 @@ function GetRustIndent(lnum)
         endif
     endif
 
+    " Prevent cindent from becoming confused when pairing square brackets, as
+    " in
+    "
+    " let arr = [[u8; 4]; 2] = [
+    "     [0; 4],
+    "     [1, 3, 5, 9],
+    " ];
+    "     | ← indentation placed here
+    "
+    " for which it calculates too much indentation in the line following the
+    " close of the array.
+    if prevline =~# '^\s*\]' && l:last_prevline_character ==# ';'
+                \ && line !~# '^\s*}'
+        return indent(prevlinenum)
+    endif
+
     if l:last_prevline_character ==# ","
                 \ && s:get_line_trimmed(a:lnum) !~# '^\s*[\[\]{})]'
                 \ && prevline !~# '^\s*fn\s'

--- a/runtime/indent/testdir/rust.in
+++ b/runtime/indent/testdir/rust.in
@@ -15,6 +15,21 @@ fn main() {
 	Ok(file) => file,
     };
 
+    // Start doing nothing forever
+    loop {
+        let arr1 = [[u8; 4]; 2] = [
+            [0; 4],
+            [1, 3, 5, 9],
+        ];
+        }
+
+    // Plan for a future that will never come
+    let arr2 = [[u8; 4]; 2] = [
+        [1; 4],
+        [2, 4, 6, 8],
+    ];
+        let arr2_ref = &arr2;
+
     // Read the file contents into a string, returns `io::Result<usize>`
     let mut s = String::new();
         match file.read_to_string(&mut s) {

--- a/runtime/indent/testdir/rust.ok
+++ b/runtime/indent/testdir/rust.ok
@@ -15,6 +15,21 @@ fn main() {
         Ok(file) => file,
     };
 
+    // Start doing nothing forever
+    loop {
+        let arr1 = [[u8; 4]; 2] = [
+            [0; 4],
+            [1, 3, 5, 9],
+        ];
+    }
+
+    // Plan for a future that will never come
+    let arr2 = [[u8; 4]; 2] = [
+        [1; 4],
+        [2, 4, 6, 8],
+    ];
+    let arr2_ref = &arr2;
+
     // Read the file contents into a string, returns `io::Result<usize>`
     let mut s = String::new();
     match file.read_to_string(&mut s) {


### PR DESCRIPTION
Adding one more special case for an instance where cindent doesn't quite get it right. Fixes #18974.