### PR TITLE
Add compiling with clang as default.

### DIFF
--- a/bin/compile.sh
+++ b/bin/compile.sh
@@ -1,11 +1,13 @@
-#!/usr/bin/env fish
+#!/bin/sh
 # Compiles the program with clang.
 
-cd (status dirname)/..
+cd $(dirname "$0")/../
 
-export CC=clang
+CC=clang
+
+export CC_OVERRIDE=$CC
 ./configure
 
 cd src/
 make
-cd -
+cd - 2 > /dev/null

--- a/bin/compile.sh
+++ b/bin/compile.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env fish
+# Compiles the program with clang.
+
+cd (status dirname)/..
+
+export CC=clang
+./configure
+
+cd src/
+make
+cd -

--- a/src/Makefile
+++ b/src/Makefile
@@ -254,7 +254,7 @@
 #DO NOT CHANGE the next line, we need it for configure to find the compiler
 #instead of using the default from the "make" program.
 #Use a line further down to change the value for CC.
-CC=
+CC=clang
 
 # Change and use these defines if configure cannot find your Motif stuff.
 # Unfortunately there is no "standard" location for Motif. {{{
@@ -580,7 +580,7 @@ CClink = $(CC)
 # again.
 #CC = cc
 #CC = gcc
-#CC = clang
+CC = clang
 
 # COMPILER FLAGS - change as you please. Either before running {{{1
 # configure or afterwards. For examples see below.

--- a/src/Makefile
+++ b/src/Makefile
@@ -250,11 +250,10 @@
 #      "sudo fixPrecomps".  Also see CONF_OPT_DARWIN below.
 # }}}
 
-
 #DO NOT CHANGE the next line, we need it for configure to find the compiler
 #instead of using the default from the "make" program.
 #Use a line further down to change the value for CC.
-CC=clang
+CC=
 
 # Change and use these defines if configure cannot find your Motif stuff.
 # Unfortunately there is no "standard" location for Motif. {{{
@@ -580,7 +579,8 @@ CClink = $(CC)
 # again.
 #CC = cc
 #CC = gcc
-CC = clang
+#CC = clang
+#CC = $(CC_OVERRIDE)
 
 # COMPILER FLAGS - change as you please. Either before running {{{1
 # configure or afterwards. For examples see below.


### PR DESCRIPTION
Hello,

I just tried compiling `vim` with `clang`.
It is not stright forward.
Thought it should work like this:

```sh
gh repo clone vim/vim
cd ./vim/src/
CC=clang make
sudo make install
```

I added a script and modified `Makefile`, but in the end would like a simplier solution to use a different compiler.