### PR TITLE
Removed auto-set current buffer name as title if no title is provided

### DIFF
--- a/runtime/compiler/pandoc.vim
+++ b/runtime/compiler/pandoc.vim
@@ -52,8 +52,6 @@ endfunction
 
 execute 'CompilerSet makeprg=pandoc'..escape(
     \ ' --standalone'..
-    \ (s:PandocFiletype(&filetype) ==# 'markdown' && (getline(1) =~# '^%\s\+\S\+' || (search('^title:\s\+\S\+', 'cnw') > 0)) ?
-    \ '' : ' --metadata title=%:t:r:S')..
     \ ' '..s:PandocLang()..
     \ ' --from='..s:PandocFiletype(&filetype)..
     \ ' '..get(b:, 'pandoc_compiler_args', get(g:, 'pandoc_compiler_args', ''))..


### PR DESCRIPTION
@Konfekt 

Problem: It is often desirable to have a rendered document without any title, but the current version of the compiler force the title to be the filename of the current buffer if the title is left empty. 
Having the opportunity of rendering a document without any title without returning errors or warnings is consistent with newer versions of pandoc. 

Solution: prevent forcing a title if no title is specified. 

Related: https://github.com/vim/vim/issues/16643 , https://github.com/Konfekt/vim-compilers/issues/10 

