### PR TITLE
fix(undo): don't override saved cursor position

### DIFF
--- a/src/testdir/test_undo.vim
+++ b/src/testdir/test_undo.vim
@@ -913,5 +913,16 @@ func Test_load_existing_undofile()
   bw!
 endfunc
 
+func Test_correctly_restore_cursor_position_after_undo()
+  CheckFeature persistent_undo
+  sp samples/test_undo.txt
+
+  3 | exe "norm! gqk" | undojoin | 1 delete
+  call assert_equal(1, line('.'))
+  norm! u
+  call assert_equal(3, line('.'))
+  bw!
+endfunc
+
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/undo.c
+++ b/src/undo.c
@@ -2721,7 +2721,6 @@ u_undoredo(int undo)
 
 	// Decide about the cursor position, depending on what text changed.
 	// Don't set it yet, it may be invalid if lines are going to be added.
-	if (top < newlnum)
 	{
 	    // If the saved cursor is somewhere in this undo block, move it to
 	    // the remembered position.  Makes "gwap" put the cursor back
@@ -2730,9 +2729,12 @@ u_undoredo(int undo)
 	    if (lnum >= top && lnum <= top + newsize + 1)
 	    {
 		new_curpos = curhead->uh_cursor;
-		newlnum = new_curpos.lnum - 1;
+
+		// We don't want other entries to override saved cursor
+		// position.
+		newlnum = -1;
 	    }
-	    else
+	    else if (top < newlnum)
 	    {
 		// Use the first line that actually changed.  Avoids that
 		// undoing auto-formatting puts the cursor in the previous


### PR DESCRIPTION
When an undo has multiple entries where the one of them is in saved cursor position, but the top one is not, then the cursor jumps to the top one instead of the saved cursor position.

Example: with file content `a\n\nb\nc\nd` , run `:4|call execute("norm! gqap") | undojoin | 1delete`