### PR TITLE
Mac: Build failure with Mac OS X 10.6

### DIFF
--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -3681,8 +3681,10 @@ mch_early_init(void)
      * threads’ quality of service classes clamped.
      */
 #ifdef MACOS_X
+# ifdef MAC_OS_X_VERSION_10_7
     integer_t policy = TASK_DEFAULT_APPLICATION;
     task_policy_set(mach_task_self(), TASK_CATEGORY_POLICY, &policy, 1);
+# endif
 #endif
 }
 


### PR DESCRIPTION
Problem:  Mac: Build failure with Mac OS X 10.6
          (Sergey Fedorov, after: v9.1.1748)
Solution: Add ifdefs MAC_OS_X_VERSION_10_7 around the code that sets the
          scheduler priority.

related: #18120
fixes:   #19044