### PR TITLE
runtime(filetype): recognize Kos files

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -2234,6 +2234,8 @@ const ft_from_ext = {
   "k": "kwt",
   # Kivy
   "kv": "kivy",
+  # Kos
+  "kos": "kos",
   # Kotlin
   "kt": "kotlin",
   "ktm": "kotlin",

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -432,6 +432,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     kitty: ['kitty.conf', '~/.config/kitty/colorscheme.conf'],
     kivy: ['file.kv'],
     kix: ['file.kix'],
+    kos: ['file.kos'],
     kotlin: ['file.kt', 'file.ktm', 'file.kts'],
     krl: ['file.sub', 'file.Sub', 'file.SUB'],
     kscript: ['file.ks'],


### PR DESCRIPTION
Add the `kos` extension for the Kos programming language.

Reference:
https://github.com/kos-lang/kos