### PR TITLE
gq with 'formatprg' fails on an empty buffer 

### DIFF
--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -1516,8 +1516,9 @@ do_filter(
 	     */
 	    curwin->w_cursor.lnum = line1;
 	    del_lines(linecount, TRUE);
-	    curbuf->b_op_start.lnum -= linecount;	// adjust '[
-	    curbuf->b_op_end.lnum -= linecount;		// adjust ']
+	    // adjust '[ and ']
+	    curbuf->b_op_start.lnum = MAX(curbuf->b_op_start.lnum - linecount, 1);
+	    curbuf->b_op_end.lnum = MAX(curbuf->b_op_end.lnum - linecount, 1);
 	    write_lnum_adjust(-linecount);		// adjust last line
 							// for next write
 #ifdef FEAT_FOLDING

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -1516,8 +1516,18 @@ do_filter(
 	     */
 	    curwin->w_cursor.lnum = line1;
 	    del_lines(linecount, TRUE);
-	    curbuf->b_op_start.lnum -= linecount;	// adjust '[
-	    curbuf->b_op_end.lnum -= linecount;		// adjust ']
+	    if (read_linecount == 0)
+	    {
+		// no filter output: clamp '[ and '] to a valid line
+		curbuf->b_op_start.lnum = curbuf->b_op_end.lnum =
+					MIN(line1, curbuf->b_ml.ml_line_count);
+		curbuf->b_op_start.col = curbuf->b_op_end.col = 0;
+	    }
+	    else
+	    {
+		curbuf->b_op_start.lnum -= linecount;	// adjust '[
+		curbuf->b_op_end.lnum -= linecount;	// adjust ']
+	    }
 	    write_lnum_adjust(-linecount);		// adjust last line
 							// for next write
 #ifdef FEAT_FOLDING

--- a/src/testdir/test_marks.vim
+++ b/src/testdir/test_marks.vim
@@ -322,5 +322,24 @@ func Test_jump_mark_autocmd()
   bwipe!
 endfunc
 
+func Test_mark_formatprg_on_empty()
+  new
+  if has('win32')
+    setl formatprg=more
+  else
+    setl formatprg=cat
+  endif
+  call assert_equal([0, 0], [line("'["), col("'[")])
+  call assert_equal([0, 0], [line("']"), col("']")])
+  try
+    norm! gqG
+  catch
+    call assert_report("gqG on empty buffer should not fail")
+  endtry
+  call assert_true(empty(v:errmsg))
+  call assert_equal([1, 1], [line("'["), col("'[")])
+  call assert_equal([1, 1], [line("']"), col("']")])
+  bwipe!
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_marks.vim
+++ b/src/testdir/test_marks.vim
@@ -329,5 +329,26 @@ func Test_jump_mark_autocmd()
   bwipe!
 endfunc
 
+func Test_mark_formatprg_on_empty()
+  new
+  if has('win32')
+    setl formatprg=more
+  else
+    setl formatprg=cat
+  endif
+  call assert_equal([0, 0], [line("'["), col("'[")])
+  call assert_equal([0, 0], [line("']"), col("']")])
+  let v:errmsg = ''
+  try
+    norm! gqG
+  catch
+    call assert_report('gqG on empty buffer should not fail: ' .. v:exception)
+  endtry
+  call assert_true(empty(v:errmsg))
+  " col() is 1-based, so 1 == first column (:marks shows it as 0)
+  call assert_equal([1, 1], [line("'["), col("'[")])
+  call assert_equal([1, 1], [line("']"), col("']")])
+  bwipe!
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  gq (and other filters) on an empty buffer fail with
          "E20: Mark not set": when the filter produces no output,
          do_filter() still subtracts the line count from '[ and '],
          pushing '] to line 0.
Solution: when the filter produces no output, put '[ and '] on a valid
          line instead of subtracting past line 1.

related https://github.com/neovim/neovim/issues/30593