### PR TITLE
#18002 wayland gtk redraw slow on msg_scroll_up; `:highlight`, `:syntax list`, `:version`

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -211,7 +211,6 @@ gui_attempt_start(void)
 	if (gui_get_x11_windis(&x11_window, &x11_display) == OK)
 	    set_vim_var_nr(VV_WINDOWID, (long)x11_window);
 # endif
-
 	// Display error messages in a dialog now.
 	display_errors();
     }
@@ -484,6 +483,9 @@ gui_init_check(void)
     result = OK;
 #else
 # ifdef FEAT_GUI_GTK
+#  ifdef GDK_WINDOWING_WAYLAND
+    gui.is_wayland = FALSE;
+#  endif
     /*
      * Note: Don't call gtk_init_check() before fork, it will be called after
      * the fork. When calling it before fork, it make vim hang for a while.

--- a/src/gui.h
+++ b/src/gui.h
@@ -389,6 +389,9 @@ typedef struct Gui
     char_u	*browse_fname;	    // file name from filedlg
 
     guint32	event_time;
+# ifdef GDK_WINDOWING_WAYLAND
+    _Bool	is_wayland;           // active gdk backend in gtk is wayland
+# endif
 #endif	// FEAT_GUI_GTK
 
 #if defined(FEAT_GUI_GTK) || defined(FEAT_GUI_MSWIN)

--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -6726,7 +6726,14 @@ gui_mch_wait_for_chars(long wtime)
 	 * situations, sort of race condition).
 	 */
 	if (!input_available())
-	    g_main_context_iteration(NULL, TRUE);
+	{
+#ifdef GDK_WINDOWING_WAYLAND
+	    if (gui.is_wayland)
+		g_main_context_iteration(NULL, FALSE);
+	    else
+#endif
+		g_main_context_iteration(NULL, TRUE);
+	}
 
 	// Got char, return immediately
 	if (input_available())

--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -6622,6 +6622,11 @@ gui_mch_draw_part_cursor(int w, int h, guicolor_T color)
     void
 gui_mch_update(void)
 {
+#ifdef GDK_WINDOWING_WAYLAND
+    // avoid early redraws; compositor does redraw
+    if (gui.is_wayland)
+       return;
+#endif
     int cnt = 0;	// prevent endless loop
     while (g_main_context_pending(NULL) && !vim_is_input_buf_full()
 								&& ++cnt < 100)


### PR DESCRIPTION
Closes: https://github.com/vim/vim/issues/18002

Since `patch 9.1.1585: Wayland: gvim still needs GVIM_ENABLE_WAYLAND`,
the message window has been slow at drawing especially `:version` and
`:highlight`, `:syntax list` and more.

Since wayland redraws entire screen between updates (*contrary to X11*),
there are without a doubt- many more gains in perf in other paths not
discovered. This explains the old condition for preventing wayland becoming default.

The slowdown is easily reproduced on;
- Fullscreen
- Fractionally scaled
- Vertical HiDPI displays
- 100+ lines

**Solution**

**1**. 68528ad4dfc4f2645cda4fa0d6d4d3a03da629f1 prerequisite: `gui.is_wayland` reliable way to detect wayland at runtime.


**2**. b542ec0535632ffd5d4de87bf57247dbe816c9cd don't pump event loop 
* X11 solution to avoid partial redraws
* wayland has opposite effect; causing partial redraws during scrolling, black regions


**Result**: faster redraw, fully drawn frames at all times on wayland ( [0:26](https://youtu.be/L1LplVAsZ3g?t=26) when scrolling down you see it clearly, half the file is not visible.)

**3**. 0d1ac2a746c419a56d040199668f4b75640ff6ff reduce massive allocs on HiDPi, fractionally scaled screens. 
* best compromise in lack of a full, tedious refactor of all immediate drawers such as `message.c` and `term.c`
* Use CAIRO_OPERATOR_SOURCE to overwrite instead of blend, which is much faster.
* Reuse scroll source region for dest scroll region
* Fast scroll-up path
* Remove `cairo_(pop/push)_group` and `cairo_clip` preventing the massive allocs on fractionally scaled wayland. Due to GTK3 scaling up to 2x then downsampling to fractionally scaled (e.g. `1.5`) - which is *easily* a 50MB operation on every trigger due to this very reason.

**Result**: scrolling is more efficient, allocs reduced


**4**. 55011087b7e9d987b05716b667c8fff93231acf0 don't block for input 
* wayland redraw/keyboard input does not compete

**Result**: 222x faster keyboard input (*4mil to 18k cost*) measured in cachegrind.


I consider third change best possible current minimal compromise of a potentially *long and complex refactoring* of all drawing code.

This PR does not only improve the original issue;
* drawing
* input delay
on wayland is overall improved - for input delay alone its 222 times faster, 50MB allocs are gone.

`:highlight`, `:syntax list` or `for l in range(1,99) | echomsg l | endfor` is still not instant (*but close*). Will continue experimenting - I have something half-working for messages.

The speed at which `:highlight` or `:messages` draws initially is reduced a lot due to change 2, 4 - likewise pgdn / scroll down is significantly faster.

**Video** (3840x2160, 1.5 scale, 99 lines)
Before: https://www.youtube.com/watch?v=L1LplVAsZ3g
After: https://www.youtube.com/shorts/AZUWKEOByqk