### PR TITLE
Use-after-free in winframe_remove()

### DIFF
--- a/src/diff.c
+++ b/src/diff.c
@@ -898,6 +898,13 @@ diff_write(buf_T *buf, diffin_T *din, linenr_T start, linenr_T end)
     if (din->din_fname == NULL)
 	return diff_write_buffer(buf, din, start, end);
 
+    // Writing the diff buffers may trigger changes in the window structure
+    // via aucmd_prepbuf()/aucmd_restbuf() commands.
+    // This may cause recursively calling winframe_remove() which is not safe and causes
+    // use after free, so let's stop it here.
+    if (frames_locked())
+	return FAIL;
+
     if (end < 0)
 	end = buf->b_ml.ml_line_count;
 

--- a/src/proto/window.pro
+++ b/src/proto/window.pro
@@ -1,6 +1,7 @@
 /* window.c */
 void window_layout_lock(void);
 void window_layout_unlock(void);
+int frames_locked(void);
 int window_layout_locked(enum CMD_index cmd);
 int check_can_set_curbuf_disabled(void);
 int check_can_set_curbuf_forceit(int forceit);

--- a/src/testdir/test_diffmode.vim
+++ b/src/testdir/test_diffmode.vim
@@ -3566,4 +3566,36 @@ func Test_diff_add_prop_in_autocmd()
   call StopVimInTerminal(buf)
 endfunc
 
+" this was causing a use-after-free by callig winframe_remove() rerursively
+func Test_diffexpr_wipe_buffers()
+  CheckRunVimInTerminal
+
+  let lines =<< trim END
+    def DiffFuncExpr()
+      var in: list<string> = readfile(v:fname_in)
+      var new = readfile(v:fname_new)
+      var out: string = diff(in, new)
+      writefile(split(out, "n"), v:fname_out)
+    enddef
+
+    new
+    vnew
+    set diffexpr=DiffFuncExpr()
+    wincmd l
+    new
+    cal setline(1,range(20))
+    wind difft
+    wincm w
+    hid
+    %bw!
+  END
+  call writefile(lines, 'Xtest_diffexpr_wipe', 'D')
+
+  let buf = RunVimInTerminal('Xtest_diffexpr_wipe', {})
+  call term_sendkeys(buf, ":so\<CR>")
+  call WaitForAssert({-> assert_match('4 buffers wiped out', term_getline(buf, 20))})
+
+  call StopVimInTerminal(buf)
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/window.c
+++ b/src/window.c
@@ -90,6 +90,10 @@ static int split_disallowed = 0;
 // autocommands mess up the window structure.
 static int close_disallowed = 0;
 
+// When non-zero changing the window frame structure is forbidden.  Used
+// to avoid that winframe_remove() is called recursively
+static int frame_locked = 0;
+
 /*
  * Disallow changing the window layout (split window, close window, move
  * window).  Resizing is still allowed.
@@ -109,6 +113,12 @@ window_layout_unlock(void)
 {
     --split_disallowed;
     --close_disallowed;
+}
+
+    int
+frames_locked(void)
+{
+    return frame_locked;
 }
 
 /*
@@ -3577,6 +3587,8 @@ winframe_remove(
     if (tp == NULL ? ONE_WINDOW : tp->tp_firstwin == tp->tp_lastwin)
 	return NULL;
 
+    frame_locked++;
+
     // Save the position of the containing frame (which will also contain the
     // altframe) before we remove anything, to recompute window positions later.
     wp = frame2win(frp_close->fr_parent);
@@ -3681,6 +3693,8 @@ winframe_remove(
 	frame_flatten(frp2);
     else
 	*unflat_altfr = frp2;
+
+    frame_locked--;
 
     return wp;
 }


### PR DESCRIPTION
Problem:  Use-after-free in winframe_remove
Solution: Set window_layout_locked() inside winframe_remove()
          and check that writing diff files is disallowed when the
          window layout is locked

ping @ychin as we discussed this issue recently. Thanks 🙏