### PR TITLE
Vim9: fix unexpected E1209 error

### DIFF
--- a/src/testdir/test_vim9_builtin.vim
+++ b/src/testdir/test_vim9_builtin.vim
@@ -804,6 +804,10 @@ def Test_col()
   v9.CheckSourceDefAndScriptFailure(['col(true)'], ['E1013: Argument 1: type mismatch, expected string but got bool', 'E1222: String or List required for argument 1'])
   v9.CheckSourceDefAndScriptFailure(['col(".", [])'], ['E1013: Argument 2: type mismatch, expected number but got list<any>', 'E1210: Number required for argument 2'])
   v9.CheckSourceDefExecAndScriptFailure(['col("")'], 'E1209: Invalid value for a line number')
+  v9.CheckSourceDefExecAndScriptFailure(['col(".1")'], 'E1209: Invalid value for a line number')
+  v9.CheckSourceDefAndScriptSuccess(['col(".")'])
+  v9.CheckSourceDefExecAndScriptFailure(['col("'a1")'], 'E1209: Invalid value for a line number')
+  v9.CheckSourceDefAndScriptSuccess(['col("'a")'])
   bw!
 enddef
 

--- a/src/testdir/test_vim9_builtin.vim
+++ b/src/testdir/test_vim9_builtin.vim
@@ -806,8 +806,8 @@ def Test_col()
   v9.CheckSourceDefExecAndScriptFailure(['col("")'], 'E1209: Invalid value for a line number')
   v9.CheckSourceDefExecAndScriptFailure(['col(".1")'], 'E1209: Invalid value for a line number')
   v9.CheckSourceDefAndScriptSuccess(['col(".")'])
-  v9.CheckSourceDefExecAndScriptFailure(['col("'a1")'], 'E1209: Invalid value for a line number')
-  v9.CheckSourceDefAndScriptSuccess(['col("'a")'])
+  v9.CheckSourceDefExecAndScriptFailure(['col("\''a1")'], 'E1209: Invalid value for a line number')
+  v9.CheckSourceDefAndScriptSuccess(['col("\''a")'])
   bw!
 enddef
 


### PR DESCRIPTION
New Year :tada:

Related: #8536 ([8.2.3144](https://github.com/vim/vim/commit/0f1227f7d5a3e368f61d396c1640088c079fef91))

```
$ LANG=C vim --cmd "vim9cmd echo getline('.')"
Error detected while processing pre-vimrc command line:
E1209: Invalid value for a line number: "."
Press ENTER or type command to continue
```

`echo getline('.')` is a valid Vim9 script, so shouldn't it display an error?
(The buffer has not yet been created?)