### PR TITLE
Make vim compile without the linebreak option

### DIFF
--- a/src/charset.c
+++ b/src/charset.c
@@ -1523,8 +1523,8 @@ win_lbr_chartabsize(
 #  ifdef FEAT_PROP_POPUP
     size += cts->cts_first_char;
 #  endif
-    return size;
 # endif
+    return size;
 #endif
 }
 

--- a/src/charset.c
+++ b/src/charset.c
@@ -773,7 +773,7 @@ chartabsize(char_u *p, colnr_T col)
     RET_WIN_BUF_CHARTABSIZE(curwin, curbuf, p, col)
 }
 
-#if defined(FEAT_LINEBREAK)
+#if defined(FEAT_LINEBREAK) || defined(FEAT_PROP_POPUP)
     int
 win_chartabsize(win_T *wp, char_u *p, colnr_T col)
 {
@@ -1226,11 +1226,11 @@ win_lbr_chartabsize(
     win_T	*wp = cts->cts_win;
 #if defined(FEAT_PROP_POPUP) || defined(FEAT_LINEBREAK)
     char_u	*line = cts->cts_line; // start of the line
+    int		size;
 #endif
     char_u	*s = cts->cts_ptr;
     colnr_T	vcol = cts->cts_vcol;
 #ifdef FEAT_LINEBREAK
-    int		size;
     int		mb_added = 0;
     int		n;
     char_u	*sbr;

--- a/src/charset.c
+++ b/src/charset.c
@@ -1348,12 +1348,10 @@ win_lbr_chartabsize(
 			size += tab_size;
 		    }
 #  endif
-#  ifdef FEAT_PROP_POPUP
 		    if (tp->tp_col == MAXCOL && (tp->tp_flags
 				& (TP_FLAG_ALIGN_ABOVE | TP_FLAG_ALIGN_BELOW)))
 			// count extra line for property above/below
 			++cts->cts_prop_lines;
-#  endif
 		}
 	    }
 	    if (tp->tp_col != MAXCOL && tp->tp_col - 1 > col)

--- a/src/charset.c
+++ b/src/charset.c
@@ -1283,7 +1283,9 @@ win_lbr_chartabsize(
 # ifdef FEAT_PROP_POPUP
     if (cts->cts_has_prop_with_text)
     {
+#  ifdef FEAT_LINEBREAK
 	int	    tab_size = size;
+#  endif
 	int	    charlen = *s == NUL ? 1 : mb_ptr2len(s);
 	int	    i;
 	int	    col = (int)(s - line);

--- a/src/charset.c
+++ b/src/charset.c
@@ -773,7 +773,7 @@ chartabsize(char_u *p, colnr_T col)
     RET_WIN_BUF_CHARTABSIZE(curwin, curbuf, p, col)
 }
 
-#if defined(FEAT_LINEBREAK)
+#if defined(FEAT_LINEBREAK) || defined(FEAT_PROP_POPUP)
     int
 win_chartabsize(win_T *wp, char_u *p, colnr_T col)
 {
@@ -1265,11 +1265,11 @@ win_lbr_chartabsize(
 #if defined(FEAT_LINEBREAK) || defined(FEAT_PROP_POPUP)
     int has_lcs_eol = wp->w_p_list && wp->w_lcs_chars.eol != NUL;
 
-# ifdef FEAT_LINEBREAK
     /*
      * First get the normal size, without 'linebreak' or text properties
      */
     size = win_chartabsize(wp, s, vcol);
+# ifdef FEAT_LINEBREAK
     if (*s == NUL)
     {
 	// 1 cell for EOL list char (if present), as opposed to the two cell ^@

--- a/src/charset.c
+++ b/src/charset.c
@@ -773,7 +773,7 @@ chartabsize(char_u *p, colnr_T col)
     RET_WIN_BUF_CHARTABSIZE(curwin, curbuf, p, col)
 }
 
-#if defined(FEAT_LINEBREAK) || defined(FEAT_PROP_POPUP)
+#if defined(FEAT_LINEBREAK)
     int
 win_chartabsize(win_T *wp, char_u *p, colnr_T col)
 {
@@ -1265,6 +1265,7 @@ win_lbr_chartabsize(
 #if defined(FEAT_LINEBREAK) || defined(FEAT_PROP_POPUP)
     int has_lcs_eol = wp->w_p_list && wp->w_lcs_chars.eol != NUL;
 
+# ifdef FEAT_LINEBREAK
     /*
      * First get the normal size, without 'linebreak' or text properties
      */
@@ -1275,7 +1276,7 @@ win_lbr_chartabsize(
 	// for a NUL character in the text.
 	size = has_lcs_eol ? 1 : 0;
     }
-# ifdef FEAT_LINEBREAK
+
     int is_doublewidth = has_mbyte && size == 2 && MB_BYTE2LEN(*s) > 1;
 # endif
 
@@ -1338,6 +1339,7 @@ win_lbr_chartabsize(
 		    else
 			size += cells;
 		    cts->cts_start_incl = tp->tp_flags & TP_FLAG_START_INCL;
+#  ifdef FEAT_LINEBREAK
 		    if (*s == TAB)
 		    {
 			// tab size changes because of the inserted text
@@ -1345,10 +1347,13 @@ win_lbr_chartabsize(
 			tab_size = win_chartabsize(wp, s, vcol + size);
 			size += tab_size;
 		    }
+#  endif
+#  ifdef FEAT_PROP_POPUP
 		    if (tp->tp_col == MAXCOL && (tp->tp_flags
 				& (TP_FLAG_ALIGN_ABOVE | TP_FLAG_ALIGN_BELOW)))
 			// count extra line for property above/below
 			++cts->cts_prop_lines;
+#  endif
 		}
 	    }
 	    if (tp->tp_col != MAXCOL && tp->tp_col - 1 > col)

--- a/src/drawline.c
+++ b/src/drawline.c
@@ -2775,9 +2775,9 @@ win_line(
 		}
 
 		wlv.extra_for_textprop = FALSE;
-#ifdef FEAT_LINEBREAK
+# ifdef FEAT_LINEBREAK
 		in_linebreak = FALSE;
-#endif
+# endif
 	    }
 #endif
 	}

--- a/src/drawline.c
+++ b/src/drawline.c
@@ -1755,7 +1755,7 @@ win_line(
     }
 #endif
 
-#if defined(FEAT_LINEBREAK) || defined(FEAT_PROP_POPUP)
+#if defined(FEAT_LINEBREAK) && defined(FEAT_PROP_POPUP)
     colnr_T vcol_first_char = 0;
     if (wp->w_p_lbr && number_only == 0)
     {
@@ -2775,7 +2775,9 @@ win_line(
 		}
 
 		wlv.extra_for_textprop = FALSE;
+#ifdef FEAT_LINEBREAK
 		in_linebreak = FALSE;
+#endif
 	    }
 #endif
 	}

--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -4035,6 +4035,7 @@ did_set_signcolumn(optset_T *args)
 {
     char_u	**varp = (char_u **)args->os_varp;
 
+#if defined(FEAT_LINEBREAK)
     if (check_opt_strings(*varp, p_scl_values, FALSE) != OK)
 	return e_invalid_argument;
     // When changing the 'signcolumn' to or from 'number', recompute the
@@ -4043,6 +4044,7 @@ did_set_signcolumn(optset_T *args)
 		|| (*curwin->w_p_scl == 'n' && *(curwin->w_p_scl + 1) =='u'))
 	    && (curwin->w_p_nu || curwin->w_p_rnu))
 	curwin->w_nrwidth_line_count = 0;
+#endif
 
     return NULL;
 }

--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -4037,14 +4037,12 @@ did_set_signcolumn(optset_T *args)
 
     if (check_opt_strings(*varp, p_scl_values, FALSE) != OK)
 	return e_invalid_argument;
-#if defined(FEAT_LINEBREAK)
     // When changing the 'signcolumn' to or from 'number', recompute the
     // width of the number column if 'number' or 'relativenumber' is set.
     if (((*args->os_oldval.string == 'n' && args->os_oldval.string[1] == 'u')
 		|| (*curwin->w_p_scl == 'n' && *(curwin->w_p_scl + 1) =='u'))
 	    && (curwin->w_p_nu || curwin->w_p_rnu))
 	curwin->w_nrwidth_line_count = 0;
-#endif
 
     return NULL;
 }

--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -4037,12 +4037,14 @@ did_set_signcolumn(optset_T *args)
 
     if (check_opt_strings(*varp, p_scl_values, FALSE) != OK)
 	return e_invalid_argument;
+#if defined(FEAT_LINEBREAK)
     // When changing the 'signcolumn' to or from 'number', recompute the
     // width of the number column if 'number' or 'relativenumber' is set.
     if (((*args->os_oldval.string == 'n' && args->os_oldval.string[1] == 'u')
 		|| (*curwin->w_p_scl == 'n' && *(curwin->w_p_scl + 1) =='u'))
 	    && (curwin->w_p_nu || curwin->w_p_rnu))
 	curwin->w_nrwidth_line_count = 0;
+#endif
 
     return NULL;
 }

--- a/src/sign.c
+++ b/src/sign.c
@@ -1159,6 +1159,7 @@ sign_list_by_name(char_u *name)
 static void
 may_force_numberwidth_recompute(buf_T *buf, int unplace)
 {
+# if defined(FEAT_LINEBREAK)
     tabpage_T *tp = NULL;
     win_T *wp = NULL;
 
@@ -1169,6 +1170,7 @@ may_force_numberwidth_recompute(buf_T *buf, int unplace)
             (*wp->w_p_scl == 'n' && *(wp->w_p_scl + 1) == 'u'))
             wp->w_nrwidth_line_count = 0;
     }
+# endif
 }
 
 /*

--- a/src/structs.h
+++ b/src/structs.h
@@ -4309,7 +4309,7 @@ struct window_S
 #endif
     linenr_T	w_nrwidth_line_count;	// line count when ml_nrwidth_width
 					// was computed.
-#if defined(FEAT_LINEBREAK)
+#ifdef FEAT_LINEBREAK
     long	w_nuw_cached;		// 'numberwidth' option cached
 #endif
     int		w_nrwidth_width;	// nr of chars to print line count.

--- a/src/structs.h
+++ b/src/structs.h
@@ -4307,12 +4307,9 @@ struct window_S
 #ifdef FEAT_GUI
     scrollbar_T	w_scrollbars[2];	// vert. Scrollbars for this window
 #endif
-#ifdef FEAT_LINEBREAK
     linenr_T	w_nrwidth_line_count;	// line count when ml_nrwidth_width
-					// was computed.
     long	w_nuw_cached;		// 'numberwidth' option cached
     int		w_nrwidth_width;	// nr of chars to print line count.
-#endif
 
 #ifdef FEAT_QUICKFIX
     qf_info_T	*w_llist;		// Location list for this window

--- a/src/structs.h
+++ b/src/structs.h
@@ -4309,8 +4309,10 @@ struct window_S
 #endif
     linenr_T	w_nrwidth_line_count;	// line count when ml_nrwidth_width
 					// was computed.
-    long	w_nuw_cached;		// 'numberwidth' option cached
     int		w_nrwidth_width;	// nr of chars to print line count.
+#if defined(FEAT_LINEBREAK)
+    long	w_nuw_cached;		// 'numberwidth' option cached
+#endif
 
 #ifdef FEAT_QUICKFIX
     qf_info_T	*w_llist;		// Location list for this window

--- a/src/structs.h
+++ b/src/structs.h
@@ -4309,10 +4309,10 @@ struct window_S
 #endif
     linenr_T	w_nrwidth_line_count;	// line count when ml_nrwidth_width
 					// was computed.
-    int		w_nrwidth_width;	// nr of chars to print line count.
 #if defined(FEAT_LINEBREAK)
     long	w_nuw_cached;		// 'numberwidth' option cached
 #endif
+    int		w_nrwidth_width;	// nr of chars to print line count.
 
 #ifdef FEAT_QUICKFIX
     qf_info_T	*w_llist;		// Location list for this window

--- a/src/structs.h
+++ b/src/structs.h
@@ -4307,12 +4307,12 @@ struct window_S
 #ifdef FEAT_GUI
     scrollbar_T	w_scrollbars[2];	// vert. Scrollbars for this window
 #endif
+#ifdef FEAT_LINEBREAK
     linenr_T	w_nrwidth_line_count;	// line count when ml_nrwidth_width
 					// was computed.
-#ifdef FEAT_LINEBREAK
     long	w_nuw_cached;		// 'numberwidth' option cached
-#endif
     int		w_nrwidth_width;	// nr of chars to print line count.
+#endif
 
 #ifdef FEAT_QUICKFIX
     qf_info_T	*w_llist;		// Location list for this window

--- a/src/structs.h
+++ b/src/structs.h
@@ -4308,6 +4308,7 @@ struct window_S
     scrollbar_T	w_scrollbars[2];	// vert. Scrollbars for this window
 #endif
     linenr_T	w_nrwidth_line_count;	// line count when ml_nrwidth_width
+					// was computed.
     long	w_nuw_cached;		// 'numberwidth' option cached
     int		w_nrwidth_width;	// nr of chars to print line count.
 


### PR DESCRIPTION
When compiling with all features except for linebreak, there were some
compiler errors. By slightly modifying some preprocessor conditions,
compiling without the linebreak feature should work as expected.