### PR TITLE
clarify visual mark behavior in getpos() and setpos()

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -4881,7 +4881,7 @@ getpos({expr})						*getpos()*
 
 		The visual marks '< and '> refer to the beginning and end of
 		the visual selection relative to the buffer. Note that this
-		differs from |setpos()|, where they are reltaive to the cursor.
+		differs from |setpos()|, where they are relative to the cursor.
 
 		Note that for '< and '> Visual mode matters: when it is "V"
 		(visual line mode) the column of '< is zero and the column of

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -4881,7 +4881,7 @@ getpos({expr})						*getpos()*
 
 		The visual marks '< and '> refer to the beginning and end of
 		the visual selection relative to the buffer. Note that this
-		differs from |setpos()| where they are reltaive to the cursor.
+		differs from |setpos()|, where they are reltaive to the cursor.
 
 		Note that for '< and '> Visual mode matters: when it is "V"
 		(visual line mode) the column of '< is zero and the column of
@@ -10162,7 +10162,7 @@ setpos({expr}, {list})					*setpos()*
 
 		The visual marks '< and '> refer to the beginning and end of
 		the visual selection relative to the cursor. Note that this
-		differs from |setpos()| where they are reltaive to the buffer.
+		differs from |getpos()|, where they are relative to the buffer.
 
 		Returns 0 when the position could be set, -1 otherwise.
 		An error message is given if {expr} is invalid.

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -4879,6 +4879,10 @@ getpos({expr})						*getpos()*
 		within the line.  To get the character position in the line,
 		use |getcharpos()|.
 
+		The visual marks '< and '> refer to the beginning and end of
+		the visual selection relative to the buffer. Note that this
+		differs from |setpos()| where they are reltaive to the cursor.
+
 		Note that for '< and '> Visual mode matters: when it is "V"
 		(visual line mode) the column of '< is zero and the column of
 		'> is a large number equal to |v:maxcol|.
@@ -10155,6 +10159,10 @@ setpos({expr}, {list})					*setpos()*
 		Note that for '< and '> changing the line number may result in
 		the marks to be effectively be swapped, so that '< is always
 		before '>.
+
+		The visual marks '< and '> refer to the beginning and end of
+		the visual selection relative to the cursor. Note that this
+		differs from |setpos()| where they are reltaive to the buffer.
 
 		Returns 0 when the position could be set, -1 otherwise.
 		An error message is given if {expr} is invalid.

--- a/src/mark.c
+++ b/src/mark.c
@@ -96,10 +96,16 @@ setmark_pos(int c, pos_T *pos, int fnum)
 
     if (c == '<' || c == '>')
     {
-	if (c == '<')
-	    buf->b_visual.vi_start = *pos;
+	pos_T	*startp = &buf->b_visual.vi_start;
+	pos_T	*endp = &buf->b_visual.vi_end;
+
+	// Apply the same logic as in getmark_buf_fnum() to handle reversed
+	// visual selections consistently.
+	if (((c == '<') == LT_POS(*startp, *endp) || endp->lnum == 0)
+							  && startp->lnum != 0)
+	    *startp = *pos;
 	else
-	    buf->b_visual.vi_end = *pos;
+	    *endp = *pos;
 	if (buf->b_visual.vi_mode == NUL)
 	    // Visual_mode has not yet been set, use a sane default.
 	    buf->b_visual.vi_mode = 'v';

--- a/src/mark.c
+++ b/src/mark.c
@@ -96,16 +96,10 @@ setmark_pos(int c, pos_T *pos, int fnum)
 
     if (c == '<' || c == '>')
     {
-	pos_T	*startp = &buf->b_visual.vi_start;
-	pos_T	*endp = &buf->b_visual.vi_end;
-
-	// Apply the same logic as in getmark_buf_fnum() to handle reversed
-	// visual selections consistently.
-	if (((c == '<') == LT_POS(*startp, *endp) || endp->lnum == 0)
-							  && startp->lnum != 0)
-	    *startp = *pos;
+	if (c == '<')
+	    buf->b_visual.vi_start = *pos;
 	else
-	    *endp = *pos;
+	    buf->b_visual.vi_end = *pos;
 	if (buf->b_visual.vi_mode == NUL)
 	    // Visual_mode has not yet been set, use a sane default.
 	    buf->b_visual.vi_mode = 'v';


### PR DESCRIPTION
Addresses issue #19049.

## Problem

When a visual selection is reversed (the cursor is at the start of the selection), `getpos()` and `setpos()` operate inconsistently on the visual marks `'<` and `'>`.

When `setmark_pos()` in `src/mark.c` sets visual marks, it assigns to `vi_start` or `vi_end` without checking their relative order. This is in contrast to `getmark_buf_fnum()` which returns based on relative order.

## Solution

~~This patch applies the logic found in `getmark_buf_fnum()` to `setmark_pos()` so that vim function `setpos()` updates the leftmost/rightmost marks on `'<` and `'>` respectively.~~

Likely too many downstream breaks would result from ensuring consistency, instead clarify behavior in docs.