### PR TITLE
When adding a new item at the end of a list in vim9script, use the proper item type

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -467,7 +467,13 @@ Changing the order of items in a list: >
 	:call reverse(list)		" reverse the order of items
 	:call uniq(sort(list))		" sort and remove duplicates
 
-
+In a Vim9 script or a def method, a new item can be appended to a List by
+using the list length as the index: >
+    vim9script
+    var l: list<string>
+    l[0] = 'a'
+    l[1] = 'b'
+<
 For loop ~
 
 The |:for| loop executes commands for each item in a List, Tuple, String or

--- a/src/eval.c
+++ b/src/eval.c
@@ -2470,6 +2470,18 @@ set_var_lval(
 							      NULL, 0) == FAIL)
 	    return;
 
+	// If the lval is a List and the type of the list is not yet set,
+	// then set the item type from the declared type of the variable.
+	if (in_vim9script() && rettv->v_type == VAR_LIST
+				&& rettv->vval.v_list != NULL
+				&& rettv->vval.v_list->lv_type == NULL)
+	{
+	    if (lp->ll_tv->v_type == VAR_LIST
+		    && lp->ll_tv->vval.v_list != NULL
+		    && lp->ll_tv->vval.v_list->lv_type != NULL)
+		set_tv_type(rettv, lp->ll_tv->vval.v_list->lv_type);
+	}
+
 	if (lp->ll_newkey != NULL)
 	{
 	    if (op != NULL && *op != '=')

--- a/src/proto/vim9class.pro
+++ b/src/proto/vim9class.pro
@@ -22,6 +22,7 @@ ufunc_T *method_lookup(class_T *cl, vartype_T v_type, char_u *name, size_t namel
 int inside_class(cctx_T *cctx_arg, class_T *cl);
 int oc_var_check_ro(class_T *cl, ocmember_T *m);
 void obj_lock_const_vars(object_T *obj);
+object_T *alloc_object(class_T *cl);
 void copy_object(typval_T *from, typval_T *to);
 void copy_class(typval_T *from, typval_T *to);
 void class_unref(class_T *cl);

--- a/src/vim9execute.c
+++ b/src/vim9execute.c
@@ -3708,19 +3708,8 @@ exec_instructions(ectx_T *ectx)
 		// "this" is always the local variable at index zero
 		tv = STACK_TV_VAR(0);
 		tv->v_type = VAR_OBJECT;
-		tv->vval.v_object = alloc_clear(
-				       iptr->isn_arg.construct.construct_size);
-		tv->vval.v_object->obj_class =
-				       iptr->isn_arg.construct.construct_class;
-		++tv->vval.v_object->obj_class->class_refcount;
-		tv->vval.v_object->obj_refcount = 1;
-		object_created(tv->vval.v_object);
-
-		// When creating an enum value object, initialize the name and
-		// ordinal object variables.
-		class_T *en = tv->vval.v_object->obj_class;
-		if (IS_ENUM(en))
-		    enum_set_internal_obj_vars(en, tv->vval.v_object);
+		tv->vval.v_object =
+		    alloc_object(iptr->isn_arg.construct.construct_class);
 		break;
 
 	    // execute Ex command line


### PR DESCRIPTION
In a Vim9 script, a new item can be appended to a list by using the list length
as the index. When doing this, Vim initially adds a number as the new item.
This led to the type error reported in #19045. Instead of using a number as the
new item, this change creates a new item based on the proper type before
adding it to the list.

Fixes the issue reported in #19045.