### PR TITLE
tests: make Test_cd_completion more robust on Windows

### DIFF
--- a/src/testdir/test_cd.vim
+++ b/src/testdir/test_cd.vim
@@ -224,15 +224,43 @@ func Test_cd_completion()
 
   if has('win32')
     " Test Windows absolute path completion
+
+    let saved_cwd = getcwd()
+
     " Retrieve a suitable dir in the current drive
-    let dir = readdir('/', 'isdirectory("/" .. v:val) && len(v:val) > 2')[-1]
+    for d in readdir('/', 'isdirectory("/" .. v:val) && len(v:val) > 2')
+      " Paths containing '$' such as "$RECYCLE.BIN" are skipped because
+      " they are considered environment variables and completion does not
+      " work.
+      if d =~ '\V$'
+        continue
+      endif
+      " Skip directories that we don't have permission to "cd" into by
+      " actually "cd"ing into them and making sure they don't fail.
+      " Directory "System Volume Information" is an example of this.
+      try
+        call chdir('/' .. d)
+        let dir = d
+        " Yay! We found a suitable dir!
+        break
+      catch /:E472:/
+        " Just skip directories where "cd" fails
+        continue
+      finally
+        call chdir(saved_cwd)
+      endtry
+    endfor
+    if !exists('l:dir')
+      throw 'Skipped: no testable directories found in the current drive root'
+    endif
+
     " Get partial path
     let partial = dir[0:-2]
-    " Get the current drive letter
-    let old = chdir('/' . dir)
+    " Get the current drive letter and full path of the target dir
+    call chdir('/' . dir)
     let full = getcwd()
     let drive = full[0]
-    call chdir(old)
+    call chdir(saved_cwd)
 
     for cmd in ['cd', 'chdir', 'lcd', 'lchdir', 'tcd', 'tchdir']
       for sep in [ '/', '\']


### PR DESCRIPTION
Problem: tests: Test_cd_completion() may fail depending on the contents of the root directory of the current drive on Windows.

readdir() may return a directory that cannot "cd" to, causing this test to fail. An example of such a directory is "System Volume Information" which only admin can "cd" to.

Solution: When determining the directory to use for testing, use the directory that we actually "cd" to successfully.

In addition, directories with '$' in their names are also excluded, as they are considered environment variables during completion and do not work as expected. Example: "$RECYCLE.BIN"