### PR TITLE
windows: Use absolute path for find.exe

### DIFF
--- a/src/auto/nmake/tools.mak
+++ b/src/auto/nmake/tools.mak
@@ -23,7 +23,7 @@ PSFLAGS = -NoLogo -NoProfile -Command
 !ERROR The PowerShell program version 3.0 or higher is required for work.
 !ENDIF
 
-!IF ![echo $(COMSPEC) | 1> nul find "cmd.exe"]
+!IF ![echo $(COMSPEC) | 1> nul $(SYSTEMROOT)\System32\find.exe "cmd.exe"]
 CMD = $(COMSPEC)
 !ELSE
 CMD = $(SYSTEMROOT)\System32\cmd.exe


### PR DESCRIPTION
Problem: If another find.exe derived from findutils is installed on Windows, unintended behavior will occur. If MSYS2 is installed and prioritized over the system path, the find.exe derived from findutils will be launched during build, resulting in an unintended warning message.

Solution: Specify the absolute path including SYSTEMROOT to launch find.exe.