### PR TITLE
Force LF line endings in old test .ok files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,12 @@
 src/testdir/test42.in diff
 
+# The old test .ok files are expected to use LF line endings, even on Windows.
+# In src/testdir/Make_mvc.mak and src/testdir/Make_ming.mak, the test result
+# files are converted to LF line endings before being compared.  Therefore, if
+# the .ok files' line endings are not specified and are converted to CRLF,
+# those tests will always fail.
+src/testdir/test*.ok text eol=lf
+
 # `vim.pot` is updated every time any of the *.c files are modified.  And as it
 # contains line numbers for strings from *.c files, inserting a line into a
 # single .c file may cause many lines in the `vim.pot` file to be updated.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -536,8 +536,6 @@ jobs:
           # Show Windows version
           cmd /c ver
 
-          git config --global core.autocrlf input
-
           if ${{ matrix.arch == 'x64' }}; then
             cygreg=registry
             pyreg=


### PR DESCRIPTION
Problem: When running tests on a source tree checked out with git for Windows, the old tests fail.

The Git for Windows installer installs git with core.autocrlf=true by default.  If you check out, build, and run tests using such a git, the old test .ok files will likely fail because they use CRLF line endings. Tests on Windows assume that .ok files use LF line endings, and appropriately convert the line endings of related files.  This assumption breaks down when .ok files use CRLF.

Solution: Force LF line endings for old test .ok files in the .gitattributes file.  Related to that, we've stopped explicitly specifying line endings when checking out in CI.