### PR TITLE
style: Normalise strcmp usage

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -1277,7 +1277,7 @@ channel_open_func(typval_T *argvars)
 	return NULL;
     }
 
-    if (!STRNCMP(address, "unix:", 5))
+    if (STRNCMP(address, "unix:", 5) == 0)
     {
 	is_unix = TRUE;
 	address += 5;

--- a/src/channel.c
+++ b/src/channel.c
@@ -1308,7 +1308,7 @@ channel_parse_socketserver_address(
     if (*address == NUL)
 	goto fail;
 
-    if (!STRNCMP(address, "unix:", 5))
+    if (STRNCMP(address, "unix:", 5) == 0)
     {
 	*unix_path = vim_strsave(address + 5);
 	return OK;
@@ -1361,7 +1361,7 @@ channel_open_func(typval_T *argvars)
 	return NULL;
     }
 
-    if (!STRNCMP(address, "unix:", 5))
+    if (STRNCMP(address, "unix:", 5) == 0)
     {
 	is_unix = TRUE;
 	address += 5;
@@ -1458,7 +1458,7 @@ channel_listen_func(typval_T *argvars)
 	return NULL;
     }
 
-    if (!STRNCMP(arg, "unix:", 5))
+    if (STRNCMP(arg, "unix:", 5) == 0)
     {
 	is_unix = TRUE;
 	arg += 5;

--- a/src/cindent.c
+++ b/src/cindent.c
@@ -748,7 +748,7 @@ cin_is_compound_init(char_u *s)
     {
 	if (*p == '=')
 	    p = r = cin_skipcomment(p + 1);
-	else if (!STRNCMP(p, "return", 6) && !vim_isIDc(p[6])
+	else if (STRNCMP(p, "return", 6) == 0 && !vim_isIDc(p[6])
 		&& (p == s || (p > s && !vim_isIDc(p[-1]))))
 	    p = r = cin_skipcomment(p + 6);
 	else
@@ -1424,19 +1424,19 @@ cin_is_if_for_while_before_offset(char_u *line, int *poffset)
 	--offset;
 
     offset -= 1;
-    if (!STRNCMP(line + offset, "if", 2))
+    if (STRNCMP(line + offset, "if", 2) == 0)
 	goto probablyFound;
 
     if (offset >= 1)
     {
 	offset -= 1;
-	if (!STRNCMP(line + offset, "for", 3))
+	if (STRNCMP(line + offset, "for", 3) == 0)
 	    goto probablyFound;
 
 	if (offset >= 2)
 	{
 	    offset -= 2;
-	    if (!STRNCMP(line + offset, "while", 5))
+	    if (STRNCMP(line + offset, "while", 5) == 0)
 		goto probablyFound;
 	}
     }

--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -8775,11 +8775,11 @@ gui_mch_register_sign(char_u *signfile)
     {
 	int do_load = 1;
 
-	if (!STRICMP(ext, ".bmp"))
+	if (STRICMP(ext, ".bmp") == 0)
 	    sign.uType =  IMAGE_BITMAP;
-	else if (!STRICMP(ext, ".ico"))
+	else if (STRICMP(ext, ".ico") == 0)
 	    sign.uType =  IMAGE_ICON;
-	else if (!STRICMP(ext, ".cur") || !STRICMP(ext, ".ani"))
+	else if (STRICMP(ext, ".cur") == 0 || STRICMP(ext, ".ani") == 0)
 	    sign.uType =  IMAGE_CURSOR;
 	else
 	    do_load = 0;
@@ -8789,7 +8789,7 @@ gui_mch_register_sign(char_u *signfile)
 		    gui.char_width * 2, gui.char_height,
 		    LR_LOADFROMFILE | LR_CREATEDIBSECTION);
 # ifdef FEAT_XPM_W32
-	if (!STRICMP(ext, ".xpm"))
+	if (STRICMP(ext, ".xpm") == 0)
 	{
 	    sign.uType = IMAGE_XPM;
 	    LoadXpmImage((char *)signfile, (HBITMAP *)&sign.hImage,

--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -9113,11 +9113,11 @@ gui_mch_register_sign(char_u *signfile)
     {
 	int do_load = 1;
 
-	if (!STRICMP(ext, ".bmp"))
+	if (STRICMP(ext, ".bmp") == 0)
 	    sign.uType =  IMAGE_BITMAP;
-	else if (!STRICMP(ext, ".ico"))
+	else if (STRICMP(ext, ".ico") == 0)
 	    sign.uType =  IMAGE_ICON;
-	else if (!STRICMP(ext, ".cur") || !STRICMP(ext, ".ani"))
+	else if (STRICMP(ext, ".cur") == 0 || STRICMP(ext, ".ani") == 0)
 	    sign.uType =  IMAGE_CURSOR;
 	else
 	    do_load = 0;
@@ -9127,7 +9127,7 @@ gui_mch_register_sign(char_u *signfile)
 		    gui.char_width * 2, gui.char_height,
 		    LR_LOADFROMFILE | LR_CREATEDIBSECTION);
 # ifdef FEAT_XPM_W32
-	if (!STRICMP(ext, ".xpm"))
+	if (STRICMP(ext, ".xpm") == 0)
 	{
 	    sign.uType = IMAGE_XPM;
 	    LoadXpmImage((char *)signfile, (HBITMAP *)&sign.hImage,

--- a/src/hardcopy.c
+++ b/src/hardcopy.c
@@ -1948,7 +1948,7 @@ prt_open_resource(struct prt_ps_resource_S *resource)
 prt_check_resource(struct prt_ps_resource_S *resource, char_u *version)
 {
     // Version number m.n should match, the revision number does not matter
-    if (STRNCMP(resource->version, version, STRLEN(version)))
+    if (STRNCMP(resource->version, version, STRLEN(version)) != 0)
     {
 	semsg(_(e_str_resource_file_has_wrong_version),
 		resource->name);

--- a/src/hardcopy.c
+++ b/src/hardcopy.c
@@ -1959,7 +1959,7 @@ prt_open_resource(struct prt_ps_resource_S *resource)
 prt_check_resource(struct prt_ps_resource_S *resource, char_u *version)
 {
     // Version number m.n should match, the revision number does not matter
-    if (STRNCMP(resource->version, version, STRLEN(version)))
+    if (STRNCMP(resource->version, version, STRLEN(version)) != 0)
     {
 	semsg(_(e_str_resource_file_has_wrong_version),
 		resource->name);

--- a/src/map.c
+++ b/src/map.c
@@ -1544,7 +1544,7 @@ ExpandMappings(
 
 	while (ptr2 < ptr3)
 	{
-	    if (STRCMP(*ptr1, *ptr2))
+	    if (STRCMP(*ptr1, *ptr2) != 0)
 		*++ptr1 = *ptr2++;
 	    else
 	    {
@@ -1685,7 +1685,7 @@ check_abbr(
 	    // find entries with right mode and keys
 	    match =    (mp->m_mode & State)
 		    && qlen == len
-		    && !STRNCMP(q, ptr, (size_t)len);
+		    && STRNCMP(q, ptr, (size_t)len) == 0;
 	    if (q != mp->m_keys)
 		vim_free(q);
 	    if (match)

--- a/src/map.c
+++ b/src/map.c
@@ -1548,7 +1548,7 @@ ExpandMappings(
 
 	while (ptr2 < ptr3)
 	{
-	    if (STRCMP(*ptr1, *ptr2))
+	    if (STRCMP(*ptr1, *ptr2) != 0)
 		*++ptr1 = *ptr2++;
 	    else
 	    {
@@ -1689,7 +1689,7 @@ check_abbr(
 	    // find entries with right mode and keys
 	    match =    (mp->m_mode & State)
 		    && qlen == len
-		    && !STRNCMP(q, ptr, (size_t)len);
+		    && STRNCMP(q, ptr, (size_t)len) == 0;
 	    if (q != mp->m_keys)
 		vim_free(q);
 	    if (match)

--- a/src/message.c
+++ b/src/message.c
@@ -174,7 +174,7 @@ msg_attr_keep(
 	    || (*s != '<'
 		&& last_msg_hist != NULL
 		&& last_msg_hist->msg != NULL
-		&& STRCMP(s, last_msg_hist->msg)))
+		&& STRCMP(s, last_msg_hist->msg) != 0))
 	add_msg_hist((char_u *)s, -1, attr);
 
 #ifdef FEAT_EVAL

--- a/src/misc1.c
+++ b/src/misc1.c
@@ -316,7 +316,7 @@ get_last_leader_offset(char_u *line, char_u **flags)
 		for (off = (len2 > i ? i : len2); off > 0 && off + len1 > len2;)
 		{
 		    --off;
-		    if (!STRNCMP(string + off, com_leader, len2 - off))
+		    if (STRNCMP(string + off, com_leader, len2 - off) == 0)
 		    {
 			if (i - off < lower_check_bound)
 			    lower_check_bound = i - off;

--- a/src/search.c
+++ b/src/search.c
@@ -3728,9 +3728,9 @@ search_line:
 		    // compare the first "len" chars from "ptr"
 		    startp = skipwhite(p);
 		    if (p_ic)
-			matched = !MB_STRNICMP(startp, ptr, len);
+			matched = MB_STRNICMP(startp, ptr, len) == 0;
 		    else
-			matched = !STRNCMP(startp, ptr, len);
+			matched = STRNCMP(startp, ptr, len) == 0;
 		    if (matched && define_matched && whole
 						  && vim_iswordc(startp[len]))
 			matched = FALSE;

--- a/src/search.c
+++ b/src/search.c
@@ -3816,9 +3816,9 @@ search_line:
 		    // compare the first "len" chars from "ptr"
 		    startp = skipwhite(p);
 		    if (p_ic)
-			matched = !MB_STRNICMP(startp, ptr, len);
+			matched = MB_STRNICMP(startp, ptr, len) == 0;
 		    else
-			matched = !STRNCMP(startp, ptr, len);
+			matched = STRNCMP(startp, ptr, len) == 0;
 		    if (matched && define_matched && whole
 						  && vim_iswordc(startp[len]))
 			matched = FALSE;

--- a/src/tag.c
+++ b/src/tag.c
@@ -1533,23 +1533,23 @@ find_tagfunc_tags(
 		continue;
 
 	    len += (int)STRLEN(tv->vval.v_string) + 1;   // Space for "\tVALUE"
-	    if (!STRCMP(dict_key, "name"))
+	    if (STRCMP(dict_key, "name") == 0)
 	    {
 		res_name = tv->vval.v_string;
 		continue;
 	    }
-	    if (!STRCMP(dict_key, "filename"))
+	    if (STRCMP(dict_key, "filename") == 0)
 	    {
 		res_fname = tv->vval.v_string;
 		continue;
 	    }
-	    if (!STRCMP(dict_key, "cmd"))
+	    if (STRCMP(dict_key, "cmd") == 0)
 	    {
 		res_cmd = tv->vval.v_string;
 		continue;
 	    }
 	    has_extra = 1;
-	    if (!STRCMP(dict_key, "kind"))
+	    if (STRCMP(dict_key, "kind") == 0)
 	    {
 		res_kind = tv->vval.v_string;
 		continue;
@@ -1615,13 +1615,13 @@ find_tagfunc_tags(
 		    if (tv->v_type != VAR_STRING || tv->vval.v_string == NULL)
 			continue;
 
-		    if (!STRCMP(dict_key, "name"))
+		    if (STRCMP(dict_key, "name") == 0)
 			continue;
-		    if (!STRCMP(dict_key, "filename"))
+		    if (STRCMP(dict_key, "filename") == 0)
 			continue;
-		    if (!STRCMP(dict_key, "cmd"))
+		    if (STRCMP(dict_key, "cmd") == 0)
 			continue;
-		    if (!STRCMP(dict_key, "kind"))
+		    if (STRCMP(dict_key, "kind") == 0)
 			continue;
 
 		    *p++ = TAB;

--- a/src/tag.c
+++ b/src/tag.c
@@ -1535,23 +1535,23 @@ find_tagfunc_tags(
 		continue;
 
 	    len += (int)STRLEN(tv->vval.v_string) + 1;   // Space for "\tVALUE"
-	    if (!STRCMP(dict_key, "name"))
+	    if (STRCMP(dict_key, "name") == 0)
 	    {
 		res_name = tv->vval.v_string;
 		continue;
 	    }
-	    if (!STRCMP(dict_key, "filename"))
+	    if (STRCMP(dict_key, "filename") == 0)
 	    {
 		res_fname = tv->vval.v_string;
 		continue;
 	    }
-	    if (!STRCMP(dict_key, "cmd"))
+	    if (STRCMP(dict_key, "cmd") == 0)
 	    {
 		res_cmd = tv->vval.v_string;
 		continue;
 	    }
 	    has_extra = 1;
-	    if (!STRCMP(dict_key, "kind"))
+	    if (STRCMP(dict_key, "kind") == 0)
 	    {
 		res_kind = tv->vval.v_string;
 		continue;
@@ -1617,13 +1617,13 @@ find_tagfunc_tags(
 		    if (tv->v_type != VAR_STRING || tv->vval.v_string == NULL)
 			continue;
 
-		    if (!STRCMP(dict_key, "name"))
+		    if (STRCMP(dict_key, "name") == 0)
 			continue;
-		    if (!STRCMP(dict_key, "filename"))
+		    if (STRCMP(dict_key, "filename") == 0)
 			continue;
-		    if (!STRCMP(dict_key, "cmd"))
+		    if (STRCMP(dict_key, "cmd") == 0)
 			continue;
-		    if (!STRCMP(dict_key, "kind"))
+		    if (STRCMP(dict_key, "kind") == 0)
 			continue;
 
 		    *p++ = TAB;


### PR DESCRIPTION
Always explicitly test the return value with `strcmp`, matching the dominant style.
