### PR TITLE
runtime(filetype): support .rasinc extension for Rofi stylesheet

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -3009,6 +3009,7 @@ const ft_from_ext = {
   "usd": "usd",
   # Rofi stylesheet
   "rasi": "rasi",
+  "rasinc": "rasi",
   # Zsh module
   # mdd: https://github.com/zsh-users/zsh/blob/57248b88830ce56adc243a40c7773fb3825cab34/Etc/zsh-development-guide#L285-L288
   # mdh, pro: https://github.com/zsh-users/zsh/blob/57248b88830ce56adc243a40c7773fb3825cab34/Etc/zsh-development-guide#L268-L271

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -673,7 +673,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     raku: ['file.pm6', 'file.p6', 'file.t6', 'file.pod6', 'file.raku', 'file.rakumod', 'file.rakudoc', 'file.rakutest'],
     raml: ['file.raml'],
     rapid: ['file.sysx', 'file.Sysx', 'file.SysX', 'file.SYSx', 'file.SYSX', 'file.modx', 'file.Modx', 'file.ModX', 'file.MODx', 'file.MODX'],
-    rasi: ['file.rasi'],
+    rasi: ['file.rasi', 'file.rasinc'],
     ratpoison: ['.ratpoisonrc', 'ratpoisonrc'],
     rbs: ['file.rbs'],
     rc: ['file.rc', 'file.rch'],


### PR DESCRIPTION
The file extension is used for Rofi's dynamic theme fragments, introduced in version [1.7.6](https://github.com/davatorium/rofi/releases/tag/1.7.6).

Ref: https://github.com/davatorium/rofi/blob/next/doc/rofi-theme.5.markdown#file-extension