### PR TITLE
runtime(filetype): recognize Djot files

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -1917,6 +1917,9 @@ const ft_from_ext = {
   # Diff files
   "diff": "diff",
   "rej": "diff",
+  # Djot
+  "dj": "djot",
+  "djot": "djot",
   # DOT
   "dot": "dot",
   "gv": "dot",

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -242,6 +242,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     dictdconf: ['dictd.conf', 'dictdfile.conf', 'dictd-file.conf'],
     diff: ['file.diff', 'file.rej'],
     dircolors: ['.dir_colors', '.dircolors', '/etc/DIR_COLORS', 'any/etc/DIR_COLORS'],
+    djot: ['file.dj', 'file.djot'],
     dnsmasq: ['/etc/dnsmasq.conf', '/etc/dnsmasq.d/file', 'any/etc/dnsmasq.conf', 'any/etc/dnsmasq.d/file'],
     dockerfile: ['Containerfile', 'Dockerfile', 'dockerfile', 'file.Dockerfile', 'file.dockerfile', 'Dockerfile.debian', 'Containerfile.something'],
     dosbatch: ['file.bat'],


### PR DESCRIPTION
This PR reintroduces Djot filetype detection from https://github.com/vim/vim/pull/14963.

Ref: https://djot.net/