### PR TITLE
runtime: Remove 'formatprg' from ftplugins

### DIFF
--- a/runtime/ftplugin/gleam.vim
+++ b/runtime/ftplugin/gleam.vim
@@ -4,6 +4,7 @@
 " Previous Maintainer: Trilowy (https://github.com/trilowy)
 " Based On:            https://github.com/gleam-lang/gleam.vim
 " Last Change:         2025 Apr 21
+"                      2026 Feb 13 by Vim Project (remove 'formatprg' #19108)
 
 if exists('b:did_ftplugin')
   finish
@@ -12,9 +13,8 @@ let b:did_ftplugin = 1
 
 setlocal comments=:////,:///,://
 setlocal commentstring=//\ %s
-setlocal formatprg=gleam\ format\ --stdin
 setlocal suffixesadd=.gleam
-let b:undo_ftplugin = "setlocal com< cms< fp< sua<"
+let b:undo_ftplugin = "setlocal com< cms< sua<"
 
 if get(g:, "gleam_recommended_style", 1)
   setlocal expandtab

--- a/runtime/ftplugin/go.vim
+++ b/runtime/ftplugin/go.vim
@@ -8,6 +8,7 @@
 " 2025 Apr 16 by Vim Project (set 'cpoptions' for line continuation, #17121)
 " 2025 Jul 02 by Vim Project (add section movement mappings #17641)
 " 2025 Jul 05 by Vim Project (update b:undo_ftplugin #17664)
+" 2026 Feb 13 by Vim Project (remove formatprg #19108)
 
 if exists('b:did_ftplugin')
   finish
@@ -18,7 +19,6 @@ let s:cpo_save = &cpo
 set cpo&vim
 
 setlocal formatoptions-=t
-setlocal formatprg=gofmt
 
 setlocal comments=s1:/*,mb:*,ex:*/,://
 setlocal commentstring=//\ %s
@@ -26,7 +26,7 @@ setlocal keywordprg=:GoKeywordPrg
 
 command! -buffer -nargs=* GoKeywordPrg call s:GoKeywordPrg()
 
-let b:undo_ftplugin = 'setl fo< com< cms< fp< kp<'
+let b:undo_ftplugin = 'setl fo< com< cms< kp<'
                   \ . '| delcommand -buffer GoKeywordPrg'
 
 if get(g:, 'go_recommended_style', 1)


### PR DESCRIPTION
Effective use of 'formatprg' requires both an understanding of the
specific capabilities of the formatting tool and Vim's formatting
commands.  This is overly burdensome for some users.

Rather than address each complaint on a filetype by filetype basis,
remove 'formatprg' settings from all ftplugins.

It is expected that formatter plugins will be available in the near
future as a better solution. See #17145 (Add "formatter" feature using
"compiler" as a template).

Note: 'formatprg' will be removed from older ftplugins after the release
of Vim 9.2. The setting was added to the go and gleam ftplugins during
the current development cycle and have not been included in a Vim
release.

See: #18650 (rust.vim: stop setting formatprg to rustfmt)

