### PR TITLE
socketserver fixes/changes

### DIFF
--- a/Filelist
+++ b/Filelist
@@ -248,6 +248,7 @@ SRC_ALL =	\
 		src/testdir/util/view_util.vim \
 		src/testdir/util/vim9.vim \
 		src/testdir/util/window_manager.vim \
+		src/testdir/util/socketserver.vim \
 		src/testdir/viewdumps.vim \
 		src/proto.h \
 		src/protodef.h \

--- a/src/auto/configure
+++ b/src/auto/configure
@@ -9088,26 +9088,22 @@ then :
 else case e in #(
   e) if test "x$features" = xtiny
 then :
-  enable_socketserver=no_auto
+  enable_socketserver=no_msg
 			 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: cannot use socketserver with tiny features" >&5
 printf "%s\n" "cannot use socketserver with tiny features" >&6; }
 else case e in #(
-  e) enable_socketserver=auto ;;
+  e) enable_socketserver=yes ;;
 esac
 fi ;;
 esac
 fi
+
 
 if test "$enable_socketserver" = "yes"; then
   printf "%s\n" "#define WANT_SOCKETSERVER 1" >>confdefs.h
 
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 printf "%s\n" "yes" >&6; }
-elif test "$enable_socketserver" = "auto"; then
-  printf "%s\n" "#define MAYBE_SOCKETSERVER 1" >>confdefs.h
-
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: auto" >&5
-printf "%s\n" "auto" >&6; }
 elif test "$enable_socketserver" = "no"; then
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
 printf "%s\n" "no" >&6; }
@@ -14538,18 +14534,18 @@ then :
 fi
 if test "$enable_largefile,$enable_year2038" != no,no
 then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CPPFLAGS option for large files" >&5
-printf %s "checking for $CPPFLAGS option for large files... " >&6; }
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CC option to enable large file support" >&5
+printf %s "checking for $CC option to enable large file support... " >&6; }
 if test ${ac_cv_sys_largefile_opts+y}
 then :
   printf %s "(cached) " >&6
 else case e in #(
-  e) ac_save_CPPFLAGS=$CPPFLAGS
+  e) ac_save_CC="$CC"
   ac_opt_found=no
-  for ac_opt in "none needed" "-D_FILE_OFFSET_BITS=64" "-D_LARGE_FILES=1"; do
+  for ac_opt in "none needed" "-D_FILE_OFFSET_BITS=64" "-D_LARGE_FILES=1" "-n32"; do
     if test x"$ac_opt" != x"none needed"
 then :
-  CPPFLAGS="$ac_save_CPPFLAGS $ac_opt"
+  CC="$ac_save_CC $ac_opt"
 fi
     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -14578,12 +14574,12 @@ then :
   if test x"$ac_opt" = x"none needed"
 then :
   # GNU/Linux s390x and alpha need _FILE_OFFSET_BITS=64 for wide ino_t.
-	 CPPFLAGS="$CPPFLAGS -DFTYPE=ino_t"
+	 CC="$CC -DFTYPE=ino_t"
 	 if ac_fn_c_try_compile "$LINENO"
 then :
 
 else case e in #(
-  e) CPPFLAGS="$CPPFLAGS -D_FILE_OFFSET_BITS=64"
+  e) CC="$CC -D_FILE_OFFSET_BITS=64"
 	    if ac_fn_c_try_compile "$LINENO"
 then :
   ac_opt='-D_FILE_OFFSET_BITS=64'
@@ -14599,7 +14595,7 @@ fi
 rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
     test $ac_opt_found = no || break
   done
-  CPPFLAGS=$ac_save_CPPFLAGS
+  CC="$ac_save_CC"
 
   test $ac_opt_found = yes || ac_cv_sys_largefile_opts="support not detected" ;;
 esac
@@ -14623,14 +14619,16 @@ printf "%s\n" "#define _FILE_OFFSET_BITS 64" >>confdefs.h
 
 printf "%s\n" "#define _LARGE_FILES 1" >>confdefs.h
  ;; #(
+  "-n32") :
+    CC="$CC -n32" ;; #(
   *) :
     as_fn_error $? "internal error: bad value for \$ac_cv_sys_largefile_opts" "$LINENO" 5 ;;
 esac
 
 if test "$enable_year2038" != no
 then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CPPFLAGS option for timestamps after 2038" >&5
-printf %s "checking for $CPPFLAGS option for timestamps after 2038... " >&6; }
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CC option for timestamps after 2038" >&5
+printf %s "checking for $CC option for timestamps after 2038... " >&6; }
 if test ${ac_cv_sys_year2038_opts+y}
 then :
   printf %s "(cached) " >&6

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -412,9 +412,6 @@
 /* Define if you want to use sockets for clientserver communication. */
 #undef WANT_SOCKETSERVER
 
-/* Define if you want to use sockets for clientserver communication if it makes sense. */
-#undef MAYBE_SOCKETSERVER
-
 /* Define if you want to include fontset support. */
 #undef FEAT_XFONTSET
 

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -2368,15 +2368,13 @@ AC_ARG_ENABLE(socketserver,
 	[  --enable-socketserver Use sockets for clientserver communication.],
 	[enable_socketserver=$enableval],
 	AS_IF([test "x$features" = xtiny],
-			[enable_socketserver=no_auto
+			[enable_socketserver=no_msg
 			 AC_MSG_RESULT([cannot use socketserver with tiny features])],
-			[enable_socketserver=auto]))
+			[enable_socketserver=yes]))
+
 if test "$enable_socketserver" = "yes"; then
   AC_DEFINE(WANT_SOCKETSERVER)
   AC_MSG_RESULT([yes])
-elif test "$enable_socketserver" = "auto"; then
-  AC_DEFINE(MAYBE_SOCKETSERVER)
-  AC_MSG_RESULT([auto])
 elif test "$enable_socketserver" = "no"; then
   AC_MSG_RESULT([no])
 fi

--- a/src/feature.h
+++ b/src/feature.h
@@ -955,8 +955,7 @@
 /*
  * +socketserver	 Use UNIX domain sockets for clientserver communication
  */
-#if defined(UNIX) && (defined(WANT_SOCKETSERVER) || \
-	(defined(MAYBE_SOCKETSERVER) && !defined(HAVE_X11)))
+#if defined(UNIX) && defined(WANT_SOCKETSERVER)
 #define FEAT_SOCKETSERVER
 #endif
 

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -9416,10 +9416,19 @@ socket_server_list_sockets(void)
 	    buf.length = vim_snprintf_safelen((char *)buf.string, sizeof(addr.sun_path),
 		"%s/%s", path.string, dp->d_name);
 
-	    // Try sending an ALIVE command. This is more assuring than a
-	    // simple connect, and *also seems to make tests less flaky*.
-	    if (!socket_server_check_alive(buf.string))
-		continue;
+	    // Don't want to send to ourselves, but we do want to list our
+	    // server name.
+	    if (STRCMP(socket_server_path, buf.string) != 0)
+	    {
+
+		// Try sending an ALIVE command. This is more assuring than a
+		// simple connect, and *also seems to make tests less flaky*.
+		//
+		// We could also use a lock file which may be better, but this
+		// has worked fine so far... - 64bitman
+		if (!socket_server_check_alive(buf.string))
+		    continue;
+	    }
 
 	    ga_concat_len(&str, (char_u *)dp->d_name, buf.length - (path.length + 1));
 	    ga_append(&str, '\n');

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -9417,8 +9417,9 @@ socket_server_list_sockets(void)
 		"%s/%s", path.string, dp->d_name);
 
 	    // Don't want to send to ourselves, but we do want to list our
-	    // server name.
-	    if (STRCMP(socket_server_path, buf.string) != 0)
+	    // server name (if we are a server).
+	    if (socket_server_path == NULL
+		    || STRCMP(socket_server_path, buf.string) != 0)
 	    {
 
 		// Try sending an ALIVE command. This is more assuring than a

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -157,7 +157,6 @@ Display	    *x11_display = NULL;
 
 static int	socket_server_fd = -1;
 static char_u	*socket_server_path = NULL;
-static char_u	*socket_server_name; // Pointer to socket_server_path
 
 typedef enum {
     SS_MSG_TYPE_ENCODING    = 'e',  // Encoding of message.
@@ -9315,7 +9314,6 @@ socket_server_init(char_u *name)
     }
 
     serverName = vim_strsave(socket_server_path);
-    socket_server_name = vim_strrchr(socket_server_path, '/') + 1;
 #ifdef FEAT_EVAL
     set_vim_var_string(VV_SEND_SERVER, serverName, -1);
 #endif
@@ -9351,7 +9349,6 @@ socket_server_uninit(void)
 	mch_remove(socket_server_path);
 	vim_free(socket_server_path);
 	socket_server_path = NULL;
-	socket_server_name = NULL;
     }
 #ifdef FEAT_GUI_GTK
     if (gui.in_use)
@@ -9410,14 +9407,6 @@ socket_server_list_sockets(void)
 	if (dirp == NULL)
 	    continue;
 
-	// Don't want to send to ourselves, but we do want to list our
-	// server name (if we are a server).
-	if (socket_server_name != NULL)
-	{
-	    ga_concat(&str, socket_server_name);
-	    ga_append(&str, '\n');
-	}
-
 	// Loop through directory
 	while ((dp = readdir(dirp)) != NULL)
 	{
@@ -9427,17 +9416,19 @@ socket_server_list_sockets(void)
 	    buf.length = vim_snprintf_safelen((char *)buf.string, sizeof(addr.sun_path),
 		"%s/%s", path.string, dp->d_name);
 
-	    if (socket_server_path != NULL
-		    && STRCMP(socket_server_path, buf.string) == 0)
-		continue;
-
-	    // Try sending an ALIVE command. This is more assuring than a
-	    // simple connect, and *also seems to make tests less flaky*.
-	    //
-	    // We could also use a lock file which may be better, but this
-	    // has worked fine so far... - 64bitman
-	    if (!socket_server_check_alive(buf.string))
-		continue;
+	    // Don't want to send to ourselves, but we do want to list our
+	    // server name (if we are a server).
+	    if (socket_server_path == NULL
+		    || STRCMP(socket_server_path, buf.string) != 0)
+	    {
+		// Try sending an ALIVE command. This is more assuring than a
+		// simple connect, and *also seems to make tests less flaky*.
+		//
+		// We could also use a lock file which may be better, but this
+		// has worked fine so far... - 64bitman
+		if (!socket_server_check_alive(buf.string))
+		    continue;
+	    }
 
 	    ga_concat_len(&str, (char_u *)dp->d_name, buf.length - (path.length + 1));
 	    ga_append(&str, '\n');

--- a/src/testdir/test_clientserver.vim
+++ b/src/testdir/test_clientserver.vim
@@ -205,6 +205,7 @@ endfunc
 func Test_client_server_stopinsert()
   " test does not work on MS-Windows
   CheckNotMSWindows
+  CheckNotMac
   let g:test_is_flaky = 1
   let cmd = GetVimCommand()
   if cmd == ''
@@ -229,8 +230,8 @@ func Test_client_server_stopinsert()
 
   call remote_expr(name, 'execute("stopinsert")')
 
-  call assert_equal('n', name->remote_expr("mode(1)"))
-  call assert_equal('13', name->remote_expr("col('.')"))
+  call WaitForAssert({-> assert_equal('n', name->remote_expr("mode(1)"))})
+  cal WaitForAssert({-> assert_equal('13', name->remote_expr("col('.')"))})
 
   eval name->remote_send(":qa!\<CR>")
   try
@@ -283,7 +284,7 @@ func Test_client_server_x11_and_socket_server()
 endfunc
 
 " Test if socket server works in the GUI
-func Test_client_socket_server_server_gui()
+func Test_client_server_socket_server_gui()
   CheckNotMSWindows
   CheckFeature socketserver
   CheckFeature gui_gtk

--- a/src/testdir/test_clientserver.vim
+++ b/src/testdir/test_clientserver.vim
@@ -12,7 +12,7 @@ source util/shared.vim
 
 " Unlike X11, we need the socket server running if we want to send commands to
 " a server via sockets.
-CheckSocketServer
+RunSocketServer
 
 func Check_X11_Connection()
   if has('x11')

--- a/src/testdir/test_remote.vim
+++ b/src/testdir/test_remote.vim
@@ -131,4 +131,19 @@ func Test_remote_servername_shellslash()
   close
 endfunc
 
+" Test if serverlist() lists itself.
+func Test_remote_servername_itself()
+  let lines =<< trim END
+    call writefile([serverlist()], "XTest")
+  END
+  defer delete("XTest")
+  call writefile(lines, 'XRemote.vim', 'D')
+  let buf = RunVimInTerminal('--servername XVIMTEST -S XRemote.vim', {'rows': 8})
+  call TermWait(buf)
+
+  call WaitForAssert({-> assert_match("XVIMTEST", readfile("XTest")[0])})
+
+  call StopVimInTerminal(buf)
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_remote.vim
+++ b/src/testdir/test_remote.vim
@@ -16,9 +16,16 @@ func Verify_remote_feature_works()
   let buf = RunVimInTerminal('--servername XVIMTEST', {'rows': 8})
   call TermWait(buf)
 
-  if match(serverlist(), "XVIMTEST") == -1
-    call StopVimInTerminal(buf)
-    throw s:skip
+  " For some reason when the socket server is being used, the terminal Vim never
+  " receives the `:w! XVimRemoteTest.txt` command from term_sendkeys.
+  if has('socketserver') && !has('X11')
+    if match(serverlist(), "XVIMTEST") == -1
+      call StopVimInTerminal(buf)
+      throw s:skip
+    endif
+
+    let s:remote = 1
+    return
   endif
 
   let cmd = GetVimCommandCleanTerm() .. '--serverlist'

--- a/src/testdir/test_remote.vim
+++ b/src/testdir/test_remote.vim
@@ -16,16 +16,9 @@ func Verify_remote_feature_works()
   let buf = RunVimInTerminal('--servername XVIMTEST', {'rows': 8})
   call TermWait(buf)
 
-  " For some reason when the socket server is being used, the terminal Vim never
-  " receives the `:w! XVimRemoteTest.txt` command from term_sendkeys.
-  if has('socketserver') && !has('X11')
-    if match(serverlist(), "XVIMTEST") == -1
-      call StopVimInTerminal(buf)
-      throw s:skip
-    endif
-
-    let s:remote = 1
-    return
+  if match(serverlist(), "XVIMTEST") == -1
+    call StopVimInTerminal(buf)
+    throw s:skip
   endif
 
   let cmd = GetVimCommandCleanTerm() .. '--serverlist'

--- a/src/testdir/test_vim9_builtin.vim
+++ b/src/testdir/test_vim9_builtin.vim
@@ -1,10 +1,8 @@
 " Test using builtin functions in the Vim9 script language.
 
 source util/screendump.vim
+source util/socketserver.vim
 import './util/vim9.vim' as v9
-
-" Socket backend for remote functions require the socket server to be running
-CheckSocketServer
 
 " Test for passing too many or too few arguments to builtin functions
 func Test_internalfunc_arg_error()
@@ -3527,12 +3525,17 @@ enddef
 
 def Test_remote_expr()
   CheckFeature clientserver
-  CheckEnv DISPLAY
+  TrySocketServer
+
+  if !g:socketserver_only
+    CheckEnv DISPLAY
+  endif
   v9.CheckSourceDefAndScriptFailure(['remote_expr(1, "b")'], ['E1013: Argument 1: type mismatch, expected string but got number', 'E1174: String required for argument 1'])
   v9.CheckSourceDefAndScriptFailure(['remote_expr("a", 2)'], ['E1013: Argument 2: type mismatch, expected string but got number', 'E1174: String required for argument 2'])
   v9.CheckSourceDefAndScriptFailure(['remote_expr("a", "b", 3)'], ['E1013: Argument 3: type mismatch, expected string but got number', 'E1174: String required for argument 3'])
   v9.CheckSourceDefAndScriptFailure(['remote_expr("a", "b", "c", "d")'], ['E1013: Argument 4: type mismatch, expected number but got string', 'E1210: Number required for argument 4'])
-  v9.CheckSourceDefExecAndScriptFailure(['remote_expr("", "")'], 'E241: Unable to send to ')
+
+    v9.CheckSourceDefExecAndScriptFailure(['remote_expr("", "")'], 'E241: Unable to send to ')
 enddef
 
 def Test_remote_foreground()
@@ -3548,7 +3551,10 @@ enddef
 
 def Test_remote_peek()
   CheckFeature clientserver
-  CheckEnv DISPLAY
+  TrySocketServer
+  if !g:socketserver_only
+    CheckEnv DISPLAY
+  endif
   v9.CheckSourceDefAndScriptFailure(['remote_peek(0z10)'], ['E1013: Argument 1: type mismatch, expected string but got blob', 'E1174: String required for argument 1'])
   v9.CheckSourceDefAndScriptFailure(['remote_peek("a5b6c7", [1])'], ['E1013: Argument 2: type mismatch, expected string but got list<number>', 'E1174: String required for argument 2'])
   v9.CheckSourceDefExecAndScriptFailure(['remote_peek("")'], 'E573: Invalid server id used')
@@ -3564,7 +3570,10 @@ enddef
 
 def Test_remote_send()
   CheckFeature clientserver
-  CheckEnv DISPLAY
+  TrySocketServer
+  if !g:socketserver_only
+    CheckEnv DISPLAY
+  endif
   v9.CheckSourceDefAndScriptFailure(['remote_send(1, "b")'], ['E1013: Argument 1: type mismatch, expected string but got number', 'E1174: String required for argument 1'])
   v9.CheckSourceDefAndScriptFailure(['remote_send("a", 2)'], ['E1013: Argument 2: type mismatch, expected string but got number', 'E1174: String required for argument 2'])
   v9.CheckSourceDefAndScriptFailure(['remote_send("a", "b", 3)'], ['E1013: Argument 3: type mismatch, expected string but got number', 'E1174: String required for argument 3'])
@@ -3573,7 +3582,10 @@ enddef
 
 def Test_remote_startserver()
   CheckFeature clientserver
-  CheckEnv DISPLAY
+  TrySocketServer
+  if !g:socketserver_only
+    CheckEnv DISPLAY
+  endif
   v9.CheckSourceDefAndScriptFailure(['remote_startserver({})'], ['E1013: Argument 1: type mismatch, expected string but got dict<any>', 'E1174: String required for argument 1'])
 enddef
 

--- a/src/testdir/util/check.vim
+++ b/src/testdir/util/check.vim
@@ -329,12 +329,12 @@ func CheckGithubActions()
   endif
 endfunc
 
-command CheckSocketServer call CheckSocketServer()
-func CheckSocketServer()
-  if v:servername == ""
+command RunSocketServer call RunSocketServer()
+func RunSocketServer()
+  if has("socketserver") && v:servername == ""
     try
       call remote_startserver('VIMSOCKETSERVERTEST')
-    catch /^Vim\%((\a\+)\)\=:E240:/ " not possible to start a remote server
+    catch " not possible to start a remote server
       throw 'Skipped: Cannot start remote server'
     endtry
   endif

--- a/src/testdir/util/socketserver.vim
+++ b/src/testdir/util/socketserver.vim
@@ -1,0 +1,17 @@
+" Check if only the socketserver backend is available for clientserver (only on
+" Unix), and set g:socketserver_only to v:true along with starting the
+" socketserver.
+command TrySocketServer call TrySocketServer()
+func TrySocketServer()
+  if has("socketserver") && !has("x11")
+    let g:socketserver_only = v:true
+
+    if v:servername == ""
+      call remote_startserver('VIMSOCKETSERVERTEST')
+    endif
+  else
+      let g:socketserver_only = v:false
+    endif
+endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
- don't poll current vim instance when using serverlist()
- however list the current vim instance in serverlist() (to match X11 behaviour)
- don't make X11 feature disable socketserver feature: Not sure why I originally did this but it doesn't make much sense looking at it now.