### PR TITLE
Fix shadow warning

### DIFF
--- a/src/menu.c
+++ b/src/menu.c
@@ -721,19 +721,19 @@ add_menu_path(
 		if (tearpath != NULL)
 		{
 		    char_u  *s;
-		    int	    idx;
+		    int	    len;
 
 		    STRCPY(tearpath, menu_path);
-		    idx = (int)(next_name - path_name - 1);
-		    for (s = tearpath; *s && s < tearpath + idx; MB_PTR_ADV(s))
+		    len = (int)(next_name - path_name - 1);
+		    for (s = tearpath; *s && s < tearpath + len; MB_PTR_ADV(s))
 		    {
 			if ((*s == '\\' || *s == Ctrl_V) && s[1])
 			{
-			    ++idx;
+			    ++len;
 			    ++s;
 			}
 		    }
-		    tearpath[idx] = NUL;
+		    tearpath[len] = NUL;
 		    gui_add_tearoff(tearpath, pri_tab, pri_idx);
 		    vim_free(tearpath);
 		}


### PR DESCRIPTION
This PR fixes this clang 21.1.8 warning:

```c
clang -c -I. -Iproto -DWIN32 -DWINVER=0x0A00 -D_WIN32_WINNT=0x0A00 -DFEAT_HUGE -DHAVE_PATHDEF -DHAVE_STDINT_H -D__USE_MINGW_ANSI_STDIO -pipe -Wall -Wshadow -O3 -fomit-frame-pointer -DFEAT_JOB_CHANNEL -DFEAT_IPV6 -DFEAT_NETBEANS_INTG -DFEAT_GUI_MSWIN -DFEAT_CLIPBOARD menu.c -o gobjx86-64/menu.o
menu.c:724:15: warning: declaration shadows a local variable [-Wshadow]
  724 |                     int     idx;
      |                             ^
menu.c:500:10: note: previous declaration is here
  500 |     int         idx;
      |                 ^
1 warning generated.
```

Cheers
John