### PR TITLE
:wqall! doesn't close a terminal buffer like :qall! does

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -49,7 +49,6 @@ static int	append_arg_number(win_T *wp, char_u *buf, size_t buflen, int add_file
 static void	free_buffer(buf_T *);
 static void	free_buffer_stuff(buf_T *buf, int free_options);
 static int	bt_nofileread(buf_T *buf);
-static void	no_write_message_buf(buf_T *buf);
 static int	do_buffer_ext(int action, int start, int dir, int count, int flags);
 
 #ifdef UNIX
@@ -2079,8 +2078,8 @@ do_autochdir(void)
 }
 #endif
 
-    static void
-no_write_message_buf(buf_T *buf UNUSED)
+    void
+no_write_message_buf(buf_T *buf)
 {
 #ifdef FEAT_TERMINAL
     if (term_job_running(buf->b_term))

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -2509,9 +2509,9 @@ do_wqall(exarg_T *eap)
     FOR_ALL_BUFFERS(buf)
     {
 #ifdef FEAT_TERMINAL
-	if (exiting && term_job_running(buf->b_term))
+	if (exiting && !eap->forceit && term_job_running(buf->b_term))
 	{
-	    no_write_message_nobang(buf);
+	    no_write_message_buf(buf);
 	    ++error;
 	}
 	else

--- a/src/proto/buffer.pro
+++ b/src/proto/buffer.pro
@@ -15,6 +15,7 @@ int do_buffer(int action, int start, int dir, int count, int forceit);
 char *do_bufdel(int command, char_u *arg, int addr_count, int start_bnr, int end_bnr, int forceit);
 void set_curbuf(buf_T *buf, int action);
 void do_autochdir(void);
+void no_write_message_buf(buf_T *buf);
 void no_write_message(void);
 void no_write_message_nobang(buf_T *buf);
 int curbuf_reusable(void);

--- a/src/testdir/test_terminal.vim
+++ b/src/testdir/test_terminal.vim
@@ -1368,7 +1368,7 @@ func Test_terminal_qall_kill_func()
 endfunc
 
 " Run Vim, start a terminal in that Vim without the kill argument,
-" check that :qall does not exit, :qall! does.
+" check that :qall does not exit.
 func Test_terminal_qall_exit()
   let after =<< trim [CODE]
     term
@@ -1388,6 +1388,28 @@ func Test_terminal_qall_exit()
   endif
   call assert_equal("done", readfile("Xdone")[0])
   call delete("Xdone")
+endfunc
+
+" :qall! and :wqall! should exit when there is a terminal buffer.
+func Test_terminal_qall_wqall_bang_exit()
+  for cmd in ['qall!', 'wqall!']
+    let after =<< trim eval [CODE]
+      term
+      let buf = bufnr("%")
+      while term_getline(buf, 1) =~ "^\\s*$"
+        sleep 10m
+      endwhile
+      set nomore
+      au VimLeavePre * call writefile(["done"], "Xdone")
+      {cmd}
+    [CODE]
+
+    if !RunVim([], after, '')
+      continue
+    endif
+    call assert_equal("done", readfile("Xdone")[0])
+    call delete("Xdone")
+  endfor
 endfunc
 
 " Run Vim in a terminal, then start a terminal in that Vim without a kill


### PR DESCRIPTION
Problem:  :wqall! doesn't close a terminal buffer like :qall! does
          (after 8.0.1525).
Solution: Check eap->forceit.

Ref https://github.com/vim/vim/issues/2654#issuecomment-366803932

realted: #2654
related: neovim/neovim#14061
