### PR TITLE
CI: build failure in if_perl.xs

### DIFF
--- a/ci/config.mk.sed
+++ b/ci/config.mk.sed
@@ -1,3 +1,3 @@
 /^CFLAGS[[:blank:]]*=/s/$/ -Wall -Wextra -Wshadow -Wstrict-prototypes -Wmissing-prototypes -Werror -Wno-deprecated-declarations/
-/^PERL_CFLAGS_EXTRA[[:blank:]]*=/s/$/ -Wno-error=unused-function -Wno-shadow/
+/^PERL_CFLAGS_EXTRA[[:blank:]]*=/s/$/ -Wno-error=unused-function -Wno-strict-prototypes -Wno-shadow/
 /^RUBY_CFLAGS_EXTRA[[:blank:]]*=/s/$/ -Wno-error=unused-parameter -Wno-strict-prototypes/


### PR DESCRIPTION
Problem:  CI: build failure in if_perl.xs.
Solution: Add -Wno-strict-prototypes to PERL_CFLAGS_EXTRA.
