### PR TITLE
Incorrect YAML object indentation in array #18943

### DIFF
--- a/runtime/indent/yaml.vim
+++ b/runtime/indent/yaml.vim
@@ -114,7 +114,13 @@ function GetYAMLIndent(lnum)
         "
         " - |-
         "     Block scalar without indentation indicator
-        return previndent+shiftwidth()
+        if prevline =~# '^\s*-\s.*:$'
+            " Special case: list item with mapping key (- key:)
+            " Need to account for the "- " prefix
+            return previndent + 2 + shiftwidth()
+        else
+            return previndent+shiftwidth()
+        endif
     elseif prevline =~# '\v[:-]\ [|>]%(\d+[+\-]?|[+\-]?\d+)%(\#.*|\s*)$'
         " - |+2
         "   block scalar with indentation indicator
@@ -136,7 +142,10 @@ function GetYAMLIndent(lnum)
         let prevmapline = s:FindPrevLEIndentedLineMatchingRegex(a:lnum,
                     \                                           s:mapkeyregex)
         if getline(prevmapline) =~# '^\s*- '
-            return indent(prevmapline) + 2
+            " Previous mapping key is in a list item (- key:)
+            " The key effectively starts at indent + 2 (after "- ")
+            " Content under it should be indented relative to the key position
+            return indent(prevmapline) + 2 + shiftwidth()
         else
             return indent(prevmapline)
         endif

--- a/src/testdir/test_indent.vim
+++ b/src/testdir/test_indent.vim
@@ -384,4 +384,40 @@ func Test_mouse_shape_indent_norm_with_gq()
   call delete('Xmouseshapes')
 endfunc
 
+" Test for YAML indentation with list items containing mapping keys
+func Test_yaml_indent_list_with_mapping()
+  new
+  setl sw=2
+  " Ensure the yaml indent file can be loaded fresh
+  if exists('*GetYAMLIndent')
+    delfunction GetYAMLIndent
+  endif
+  runtime! indent/yaml.vim
+
+  " Test case: list items with mapping keys should preserve correct indentation
+  " when using =G (re-indent entire file)
+  call setline(1, [
+        \ 'list:',
+        \ '  - element1:',
+        \ '      foo: bar',
+        \ '  - element2:',
+        \ '      foo: bar'
+        \ ])
+
+  " Apply =G to re-indent the entire file
+  normal! gg=G
+
+  " Verify that indentation is preserved correctly
+  " Content under '- element1:' should be at indent 6 (not 4)
+  call assert_equal([
+        \ 'list:',
+        \ '  - element1:',
+        \ '      foo: bar',
+        \ '  - element2:',
+        \ '      foo: bar'
+        \ ], getline(1, '$'))
+
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Fixes #18943

The code was generated with help from AI, and the comments are exclusively AI generated
This PR fixes incorrect YAML indentation when objects are nested inside arrays.

**Problem:**
When using `=G` to re-indent YAML files, content under mapping keys inside list items was incorrectly indented.

**Example:**
```yaml
list:
  - element1:
      foo: bar  # Should be at column 6, was being changed to column 4
```

**Solution:**
The indent function now accounts for the `- ` prefix when calculating indent for content under list item mapping keys. Content under `- element1:` is now correctly indented to `indent(list_item) + 2 + shiftwidth` instead of just `indent(list_item) + shiftwidth`.