### PR TITLE
docs: some improvement

### DIFF
--- a/runtime/doc/popup.txt
+++ b/runtime/doc/popup.txt
@@ -4,7 +4,7 @@
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
-Displaying text in a floating window.	*popup* *popup-window* *popupwin*
+Displaying text in a popup window.	*popup* *popup-window* *popupwin*
 
 
 1. Introduction			|popup-intro|

--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -1263,7 +1263,7 @@ Alternatively, press "s" to swap the first and second dump.  Do this several
 times so that you can spot the difference in the context of the text.
 
 ==============================================================================
-6. Debugging	*terminal-debug* *terminal-debugger* *package-termdebug*
+6. Debugging	*terminal-debug* *terminal-debugger* *package-termdebug* *termdebug*
 
 The Terminal debugging plugin can be used to debug a program with gdb and view
 the source code in a Vim window.  Since this is completely contained inside


### PR DESCRIPTION
Problem:
- When I type `:h termdebug`, I will expect to see the introduction of the termdebug plugin. But instead, it shows me document of `termdebug_wide`, and I have to scroll up quite much to find the introduction.
- `:h popup` says `floating-window`? Why? As I have tried both features (of Vim and Neovim), I think they are _very different_ things, even more different than job features in Vim and Neovim.

Solution:
- In `:h terminal.txt`, add tag `*termdebug*` to the introduction of termdebug plugin.
- In `:h popup.txt`, "floating window" -> "popup window".