### PR TITLE
use-after-free with 'qftf' wiping buffer

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -6973,8 +6973,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	|lambda| or a |Funcref|.  See |option-value-function| for more
 	information.
 
-	It is not allowed to change the window layout or wipe buffers when
-	using this function.
+	It is not allowed to change text or jump to another window while
+	evaluating 'qftf' |textlock|.
 
 	This option cannot be set from a |modeline| or in the |sandbox|, for
 	security reasons.

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -6973,6 +6973,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 	|lambda| or a |Funcref|.  See |option-value-function| for more
 	information.
 
+	It is not allowed to change the window layout or wipe buffers when
+	using this function.
+
 	This option cannot be set from a |modeline| or in the |sandbox|, for
 	security reasons.
 

--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -5097,9 +5097,7 @@ call_qftf_func(qf_list_T *qfl, int qf_winid, long start_idx, long end_idx)
 	args[0].vval.v_dict = d;
 
 	qftf_list = NULL;
-	window_layout_lock();
-	curwin->w_locked = TRUE;
-	curbuf->b_locked = TRUE;
+	textlock++;
 	if (call_callback(cb, 0, &rettv, 1, args) != FAIL)
 	{
 	    if (rettv.v_type == VAR_LIST)
@@ -5109,9 +5107,7 @@ call_qftf_func(qf_list_T *qfl, int qf_winid, long start_idx, long end_idx)
 	    }
 	    clear_tv(&rettv);
 	}
-	curbuf->b_locked = FALSE;
-	curwin->w_locked = FALSE;
-	window_layout_unlock();
+	textlock--;
 	dict_unref(d);
     }
 

--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -5097,6 +5097,9 @@ call_qftf_func(qf_list_T *qfl, int qf_winid, long start_idx, long end_idx)
 	args[0].vval.v_dict = d;
 
 	qftf_list = NULL;
+	window_layout_lock();
+	curwin->w_locked = TRUE;
+	curbuf->b_locked = TRUE;
 	if (call_callback(cb, 0, &rettv, 1, args) != FAIL)
 	{
 	    if (rettv.v_type == VAR_LIST)
@@ -5106,6 +5109,9 @@ call_qftf_func(qf_list_T *qfl, int qf_winid, long start_idx, long end_idx)
 	    }
 	    clear_tv(&rettv);
 	}
+	curbuf->b_locked = FALSE;
+	curwin->w_locked = FALSE;
+	window_layout_unlock();
 	dict_unref(d);
     }
 

--- a/src/testdir/test_quickfix.vim
+++ b/src/testdir/test_quickfix.vim
@@ -6979,7 +6979,7 @@ func Test_quickfixtextfunc_wipes_buffer()
     set quickfixtextfunc=QFexpr
     lad "['0:4:e']"
     lw
-  catch /^Vim\%((\S\+)\)\=:E937:/
+  catch /^Vim\%((\S\+)\)\=:E565:/
     let g:crash='caught'
   endtry
   " close location list window

--- a/src/testdir/test_quickfix.vim
+++ b/src/testdir/test_quickfix.vim
@@ -6969,4 +6969,27 @@ func Test_quickfix_restore_current_win()
   bw! Xb
 endfunc
 
+func Test_quickfixtextfunc_wipes_buffer()
+  let g:crash=""
+  new
+  fu QFexpr(dummy)
+    bw
+  endfu
+  try
+    set quickfixtextfunc=QFexpr
+    lad "['0:4:e']"
+    lw
+  catch /^Vim\%((\S\+)\)\=:E937:/
+    let g:crash='caught'
+  endtry
+  " close location list window
+  bw
+  delfunc QFexpr
+  set quickfixtextfunc=
+  call assert_equal('caught', g:crash)
+  unlet g:crash
+  " close the newly opened window
+  bw
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  use-after-free with 'qftf' wiping buffer
Solution: Forbid changing the window layout or wiping the buffers.