### PR TITLE
runtime(sieve): preserve existing line endings

### DIFF
--- a/runtime/ftplugin/sieve.vim
+++ b/runtime/ftplugin/sieve.vim
@@ -2,7 +2,7 @@
 " Language:             Sieve filtering language input file
 " Maintainer:           This runtime file is looking for a new maintainer.
 " Previous Maintainer:  Nikolai Weibull <now@bitwi.se>
-" Latest Revision:      2025 Feb 20
+" Latest Revision:      2026 Jan 09
 
 if exists("b:did_ftplugin")
   finish
@@ -16,4 +16,7 @@ setlocal formatoptions-=t formatoptions+=croql
 
 " https://datatracker.ietf.org/doc/html/rfc5228#section-2.2 says
 " "newlines (CRLF, never just CR or LF)"
-setlocal fileformat=dos
+" Use CRLF for new files only; preserve existing line endings
+if expand('%:p') !=# '' && !filereadable(expand('%:p'))
+  setlocal fileformat=dos
+endif


### PR DESCRIPTION
## Problem

Commit 3cb4148 set `fileformat=dos` in the sieve ftplugin to comply with RFC 5228. However, this unconditionally converts existing files with LF line endings to CRLF on save, causing:

- Version control issues (entire file appears changed in diffs)
- Broken workflows where sieve files are stored with unix line endings

## Solution

Only set `fileformat=dos` for new files that don't exist on disk yet.

Note: Using `setlocal fileformats=dos,unix` would be simpler, but `fileformats` is a global-only option, so it cannot be set per-buffer in an ftplugin.

```vim
if expand('%:p') !=# '' && !filereadable(expand('%:p'))
  setlocal fileformat=dos
endif
```

This:
- Sets CRLF for new files (satisfies RFC 5228)
- Preserves existing line endings when editing files
- Leaves unnamed buffers unchanged

## Rationale

Dovecot Pigeonhole (the main sieve implementation) has explicitly accepted LF line endings since 2008. From `src/lib-sieve/sieve-lexer.c` ([commit 97b967b5, line 461](https://github.com/dovecot/pigeonhole/commit/97b967b568031ea30cedfbced686858e08250c1a#diff-447c41970379d807c54e7baca21a299dd130e1a0e54078844bd67edd5996b1d4R461-R463)):

```c
/* Loose LF is allowed (non-standard) and converted to CRLF */
case '\n':
    str_append(str, "\r\n");
```

This behavior has remained unchanged for almost 18 years.

## Testing

| Scenario | Before (3cb4148) | After (this PR) |
|----------|------------------|-----------------|
| New file | CRLF | CRLF |
| Existing LF file | CRLF (converts) | LF (preserved) |
| Unnamed buffer | CRLF | unchanged |

Tested manually with vim 9.1 and nvim 0.11.5 by editing new files, existing LF/CRLF files, and unnamed buffers.

---

This PR was written and tested with assistance from Claude Code 2.1.2 (Claude Opus 4.5).