### PR TITLE
tests: MINGW test fails midway and stops

### DIFF
--- a/src/testdir/Make_ming.mak
+++ b/src/testdir/Make_ming.mak
@@ -160,10 +160,7 @@ test_gui_init.res: test_gui_init.vim
 
 opt_test.vim: util/gen_opt_test.vim ../optiondefs.h ../../runtime/doc/options.txt
 	$(VIMPROG) -e -s -u NONE $(COMMON_ARGS) --nofork -S $^
-	@if test -f gen_opt_test.log; then \
-		cat gen_opt_test.log; \
-		exit 1; \
-	fi
+	@if exist gen_opt_test.log ( type gen_opt_test.log & exit /b 1 )
 
 test_bench_regexp.res: test_bench_regexp.vim
 	-$(DEL) benchmark.out


### PR DESCRIPTION
Problem: tests: When running the MINGW test, an error occurs after generating opt_test.vim.

The recipe section of src/testdir/Make_ming.mak must be written in cmd.exe syntax.  This is because "SHELL = cmd.exe" is specified at the beginning.  However, the error detection in the opt_test.vim recipe is written in UNXI syntax, which caused the error.

Solution: Rewrite the error detection in cmd.exe syntax.