### PR TITLE
runtime(rst): set suffixesadd for rst

### DIFF
--- a/runtime/ftplugin/rst.vim
+++ b/runtime/ftplugin/rst.vim
@@ -23,6 +23,7 @@ let b:undo_ftplugin = "setlocal comments< commentstring< expandtab< formatoption
 
 setlocal comments=fb:.. commentstring=..\ %s expandtab
 setlocal formatoptions+=tcroql
+setlocal suffixesadd=.rst
 
 " reStructuredText standard recommends that tabs be expanded to 8 spaces
 " The choice of 3-space indentation is to provide slightly better support for


### PR DESCRIPTION
Add .rst to suffixesadd. This allows gf and similar commands to work for
rst documentation such as in the linux kernel Documentation.

Signed-off-by: Anakin Childerhose <anakin@childerhose.ca>
