### PR TITLE
docs(if_pyth): clarify vim.eval behavior with Vim special variables

### DIFF
--- a/runtime/doc/if_pyth.txt
+++ b/runtime/doc/if_pyth.txt
@@ -183,9 +183,11 @@ vim.eval(str)						*python-eval*
 	Evaluates the expression str using the vim internal expression
 	evaluator (see |expression|).  Returns the expression result as:
 	- a string if the Vim expression evaluates to a string or number
-	- a list if the Vim expression evaluates to a Vim list
-	- a tuple if the Vim expression evaluates to a Vim tuple
-	- a dictionary if the Vim expression evaluates to a Vim dictionary
+	- a list if the Vim expression evaluates to a Vim |list|
+	- a tuple if the Vim expression evaluates to a Vim |tuple|
+	- a dictionary if the Vim expression evaluates to a Vim |dict|
+	- a boolean if Vim exression evaluates to |v:true| or |v:false|
+	- `None` if Vim expression evaluates to |v:null| or |v:none|
 	Dictionaries, lists and tuples are recursively expanded.
 	Examples: >
 	    :" value of the 'textwidth' option


### PR DESCRIPTION
Problem:
- The behavior of vim.eval with Vim special variables is not clearly documented. It is (partly) the reason why Nvim Python's vim.eval gives different output when evaluating `v:true` and `v:false`
https://github.com/neovim/pynvim/blob/fdaae821a9df8574c4429d0e87fa43eef08f01aa/README.md?plain=1#L66-L67

Solution:
- Clearly document it.