### PR TITLE
Removed unnecessary "#ifdef FEAT_GUI".

### DIFF
--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -4848,7 +4848,6 @@ mch_system_classic(char *cmd, int options)
 
     // Wait for the command to terminate before continuing
     {
-# ifdef FEAT_GUI
 	int	    delay = 1;
 
 	// Keep updating the window while waiting for the shell to finish.
@@ -4872,9 +4871,6 @@ mch_system_classic(char *cmd, int options)
 	    if (delay < 50)
 		delay += 10;
 	}
-# else
-	WaitForSingleObject(pi.hProcess, INFINITE);
-# endif
 
 	// Get the command exit code
 	GetExitCodeProcess(pi.hProcess, &ret);


### PR DESCRIPTION
Problem: "#ifdef FEAT_GUI" exists within "ifdef FEAT_GUI_MSWIN", which is confusing when reading the code.  FEAT_GUI is always defined if FEAT_GUI_MSWIN is defined (see vim.h).  Therefore, this check and the else block are unnecessary.

Solution: Removed unnecessary "#ifdef FEAT_GUI".