### PR TITLE
Try to process WM_SETFOCUS event soon

### DIFF
--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -4886,6 +4886,10 @@ mch_system_classic(char *cmd, int options)
 
     // Try to get input focus back.  Doesn't always work though.
     PostMessage(hwnd, WM_SETFOCUS, 0, 0);
+    // To increase the chances that WM_SETFOCUS will work, run the message loop
+    // here.  In addition, it prevents problems caused by delayed WM_SETFOCUS
+    // processing.
+    gui_mch_update();
 
     return ret;
 }


### PR DESCRIPTION
Problem: In gvim on Windows, a certain problem can occur when the WM_SETFOCUS event sent after an external command is not processed immediately.

The problem is that Test_normal11_showcmd may fail when running the test_normal.vim test.  Investigation revealed that the trigger was an external command executed in the previous test,
Test_mouse_shape_after_failed_change, when two tests were executed consecutively.  In gvim on Windows, a WM_SETFOCUS event will be sent when an external command finishes executing.  This WM_SETFOCUS event is not processed immediately, but rather by redraw, which is expected to update showcmd. Because it is queued in typebuf at this time, clear_showcmd(), which expects typebuf to be empty, cannot update showcmd.

Solution: After posting WM_SETFOCUS, run the message loop to process it as quickly as possible.

Also added a test that simulates the above problem.