### PR TITLE
csh: Support negated if in matchit

### DIFF
--- a/runtime/ftplugin/csh.vim
+++ b/runtime/ftplugin/csh.vim
@@ -31,7 +31,7 @@ let b:undo_ftplugin = "setlocal com< cms< fo<"
 if exists("loaded_matchit") && !exists("b:match_words")
   let s:line_start = '\%(^\s*\)\@<='
   let b:match_words =
-	\ s:line_start .. 'if\s*(.*)\s*then\>:' ..
+	\ s:line_start .. 'if\s*!\?\s*(.*)\s*then\>:' ..
 	\   s:line_start .. 'else\s\+if\s*(.*)\s*then\>:' .. s:line_start .. 'else\>:' ..
 	\   s:line_start .. 'endif\>,' ..
 	\ s:line_start .. '\%(\<foreach\s\+\h\w*\|while\)\s*(:' ..


### PR DESCRIPTION
Currently, the matchit configuration chokes on valid syntax like:

```csh
if !(true) then
   true
endif
```

Make sure the negation syntax is supported.

Ping @dkearns