### PR TITLE
runtime: enable localization of messages for ConTeXt, METAFONT and MetaPost

### DIFF
--- a/runtime/autoload/typeset.vim
+++ b/runtime/autoload/typeset.vim
@@ -15,15 +15,15 @@ def Echo(msg: string, mode: string, label: string)
   echohl None
 enddef
 
-def EchoMsg(msg: string, label = 'Notice')
+def EchoMsg(msg: string, label = gettext('Notice'))
   Echo(msg, 'ModeMsg', label)
 enddef
 
-def EchoWarn(msg: string, label = 'Warning')
+def EchoWarn(msg: string, label = gettext('Warning'))
   Echo(msg, 'WarningMsg', label)
 enddef
 
-def EchoErr(msg: string, label = 'Error')
+def EchoErr(msg: string, label = gettext('Error'))
   Echo(msg, 'ErrorMsg', label)
 enddef
 # }}}
@@ -54,7 +54,7 @@ enddef
 def ProcessOutput(qfid: number, wd: string, efm: string, ch: channel, msg: string)
   # Make sure the quickfix list still exists
   if getqflist({'id': qfid}).id != qfid
-    EchoErr("Quickfix list not found, stopping the job")
+    EchoErr(gettext("Quickfix list not found, stopping the job"))
     job_stop(ch_getjob(ch))
     return
   endif
@@ -74,13 +74,13 @@ def ExitCb(label: string, jobid: job, exitStatus: number)
 
   if exitStatus == 0
     botright cwindow
-    EchoMsg('Success!', label)
+    EchoMsg(gettext('Success!'), label)
   elseif exitStatus < 0
-    EchoWarn('Job terminated', label)
+    EchoWarn(gettext('Job terminated'), label)
   else
     botright copen
     wincmd p
-    EchoWarn('There are errors.', label)
+    EchoWarn(gettext('There are errors.'), label)
   endif
 enddef
 # }}}
@@ -207,12 +207,13 @@ export def Typeset(
   var qfid = NewQuickfixList(fp)
 
   if qfid == -1
-    EchoErr('Could not create quickfix list', label)
+    EchoErr(gettext('Could not create quickfix list'), label)
     return false
   endif
 
   if !filereadable(fp)
-    EchoErr($'File not readable: {fp}', label)
+    var msg = gettext('File not readable:')
+    EchoErr($'{msg} {fp}', label)
     return false
   endif
 
@@ -226,19 +227,20 @@ export def Typeset(
   })
 
   if job_status(jobid) ==# "fail"
-    EchoErr("Failed to start job", label)
+    EchoErr(gettext("Failed to start job"), label)
     return false
   endif
 
   AddJob(label, jobid)
 
-  EchoMsg('Typesetting...', label)
+  EchoMsg(gettext('Typesetting...'), label)
 
   return true
 enddef
 
 export def JobStatus(label: string)
-  EchoMsg($'Jobs still running: {len(GetRunningJobs(label))}', label)
+  var msg = gettext('Jobs still running:')
+  EchoMsg($'{msg} {len(GetRunningJobs(label))}', label)
 enddef
 
 export def StopJobs(label: string)
@@ -246,7 +248,7 @@ export def StopJobs(label: string)
     job_stop(job)
   endfor
 
-  EchoMsg('Done.', label)
+  EchoMsg(gettext('Done.'), label)
 enddef
 
 # Typeset the specified buffer
@@ -264,12 +266,12 @@ export def TypesetBuffer(
     name: string,
     Cmd: func(string): list<string>,
     env = {},
-    label = 'Typeset'
+    label = gettext('Typeset')
     ): bool
   var bufname = bufname(name)
 
   if empty(bufname)
-    EchoErr('Please save the buffer first.', label)
+    EchoErr(gettext('Please save the buffer first.'), label)
     return false
   endif
 

--- a/src/po/Make_all.mak
+++ b/src/po/Make_all.mak
@@ -190,10 +190,12 @@ CHECKFILES = \
 
 PO_VIM_INPUTLIST = \
 	../../runtime/optwin.vim \
+	../../runtime/autoload/typeset.vim \
 	../../runtime/defaults.vim
 
 PO_VIM_JSLIST = \
 	optwin.js \
+	typeset.js \
 	defaults.js
 
 # Arguments for xgettext to pick up messages to translate from the source code.


### PR DESCRIPTION
This will enable localization of the messages that are displayed by the ConTeXt support script.
It will add 13 short new strings to all existing languages.

I have discussed this with the maintainer of these files, @lifepillar and he suggested me to propose the change. He will later pull from here.