### PR TITLE
Memory leak when skipping invalid literal dict

### DIFF
--- a/src/dict.c
+++ b/src/dict.c
@@ -1038,17 +1038,13 @@ eval_dict(char_u **arg, typval_T *rettv, evalarg_T *evalarg, int literal)
 	*arg = skipwhite_and_linebreak(*arg + 1, evalarg);
 	if (eval1(arg, &tv, evalarg) == FAIL)	// recursive!
 	{
-	    if (evaluate)
-		clear_tv(&tvkey);
+	    clear_tv(&tvkey);
 	    goto failret;
 	}
 	if (check_typval_is_value(&tv) == FAIL)
 	{
-	    if (evaluate)
-	    {
-		clear_tv(&tvkey);
-		clear_tv(&tv);
-	    }
+	    clear_tv(&tvkey);
+	    clear_tv(&tv);
 	    goto failret;
 	}
 	if (evaluate)

--- a/src/testdir/test_listdict.vim
+++ b/src/testdir/test_listdict.vim
@@ -575,6 +575,8 @@ func Test_dict_literal_keys()
   " why *{} cannot be used for a literal dictionary
   let blue = 'blue'
   call assert_equal('6', trim(execute('echo 2 *{blue: 3}.blue')))
+
+  call assert_fails('eval 1 || #{a:', 'E15:') " used to leak
 endfunc
 
 " Nasty: deepcopy() dict that refers to itself (fails when noref used)


### PR DESCRIPTION
Problem: memory leak when not evaluating (just parsing) invalid literal dict.
Solution: always clear the key's typval.

Though "check_typval_is_value(&tv) == FAIL && !evaluate" is maybe never true, also always clear tvs if check_typval_is_value fails; at worst this would be a no-op as their initial types are VAR_UNKNOWN.