### PR TITLE
runtime(yaml) fix indentation

### DIFF
--- a/runtime/indent/testdir/yaml.in
+++ b/runtime/indent/testdir/yaml.in
@@ -26,3 +26,14 @@ list:
   - element2:
       foo: bar
 # END_INDENT
+
+# START_INDENT
+- name: test playbook
+  hosts: localhost
+  gather_facts: false
+
+  tasks:
+    - name: hello world
+      ansible.builtin.debug:
+        msg: "hello world"
+# END_INDENT

--- a/runtime/indent/testdir/yaml.ok
+++ b/runtime/indent/testdir/yaml.ok
@@ -26,3 +26,14 @@ list:
   - element2:
       foo: bar
 # END_INDENT
+
+# START_INDENT
+- name: test playbook
+  hosts: localhost
+  gather_facts: false
+
+  tasks:
+    - name: hello world
+      ansible.builtin.debug:
+        msg: "hello world"
+# END_INDENT

--- a/runtime/indent/yaml.vim
+++ b/runtime/indent/yaml.vim
@@ -146,7 +146,7 @@ function GetYAMLIndent(lnum)
             " Previous mapping key is in a list item (- key:)
             " The key effectively starts at indent + 2 (after "- ")
             " Content under it should be indented relative to the key position
-            return indent(prevmapline) + 2 + shiftwidth()
+            return indent(prevmapline) + 2
         else
             return indent(prevmapline)
         endif


### PR DESCRIPTION
#### Problem

The indentation of Ansible Playbooks gets messed up after gg=G.

#### Solution

Remove one shiftwidth() that seems to be misplaced.

#### Rationale

After commit 9179ddc I noticed some undesired behavior when editing Ansible Playbooks.\
The indentation of correctly indented playbooks that pass `yamllint` will end up misformatted after a `gg=G`.\
This also causes some issues when using the plugin https://github.com/pearofducks/ansible-vim which relies on the yaml indentation.