### PR TITLE
Prevent overwriting editing keys with keypad keys

### DIFF
--- a/src/term.c
+++ b/src/term.c
@@ -7387,6 +7387,14 @@ got_code_from_term(char_u *code, int len)
 							     name[0], name[1]);
 # endif
 		}
+		else if (i >= 0 && name[0] == 'K' && VIM_ISDIGIT(name[1]))
+		{
+		    // Would replace existing entry with keypad key - skip.
+# ifdef FEAT_EVAL
+		    ch_log(NULL, "got_code_from_term(): Skipping entry %c%c in favor of %c%c with matching keys %s",
+			    name[0], name[1], termcodes[i].name[0], termcodes[i].name[1], str);
+# endif
+		}
 		else
 		{
 		    if (i >= 0)

--- a/src/testdir/test_termcodes.vim
+++ b/src/testdir/test_termcodes.vim
@@ -2776,6 +2776,29 @@ func Test_home_key_works()
   let &t_@7 = save_end
 endfunc
 
+func Test_avoid_keypad_if_ambiguous()
+  new
+  call feedkeys("\<Esc>P1+r6b68=1B4F48\<Esc>\\", 't') " kh <Home>
+  call feedkeys("\<Esc>P1+r4b31=1B4F48\<Esc>\\", 't') " K1 <kHome>
+  call feedkeys("i\<C-K>\<Esc>OH\<CR>\<Esc>", 't')
+  call feedkeys("\<Esc>P1+r4037=1B4F46\<Esc>\\", 't') " @7 <End>
+  call feedkeys("\<Esc>P1+r4b34=1B4F46\<Esc>\\", 't') " K4 <kEnd>
+  call feedkeys("i\<C-K>\<Esc>OF\<CR>\<Esc>", 't')
+  call feedkeys("\<Esc>P1+r6b50=1B5B357E\<Esc>\\", 't') " kP <PageUp>
+  call feedkeys("\<Esc>P1+r4b33=1B5B357E\<Esc>\\", 't') " K3 <kPageUp>
+  call feedkeys("i\<C-K>\<Esc>[5~\<CR>\<Esc>", 't')
+  call feedkeys("\<Esc>P1+r6b4e=1B5B367E\<Esc>\\", 't') " kN <PageDown>
+  call feedkeys("\<Esc>P1+r4b35=1B5B367E\<Esc>\\", 't') " K5 <kPageDown>
+  call feedkeys("i\<C-K>\<Esc>[6~\<CR>\<Esc>", 'tx')
+  call assert_equal([
+        \ '<Home>',
+        \ '<End>',
+        \ '<PageUp>',
+        \ '<PageDown>',
+        \ ''], getline(1, '$'))
+  bwipe!
+endfunc
+
 func Test_terminal_builtin_without_gui()
   CheckNotMSWindows
 


### PR DESCRIPTION
Suggested fix for #17331, alternative to #19145. In principle there is no conflict with the other fix.

An advantage of this fix over #19145 is that it doesn't rely on the builtin `<xHome>`. Instead, vim will associate the correct termcode with `<Home>`.

The test fails because `<PageUp>` and `<PageDown>` are still not fixed. Fixing those requires improving `find_term_bykeys` to recognize that `^[[5;*~` is a match for `^[[5~`. If the maintainers are interested I can try doing such an improvement and un-draft this PR.