### PR TITLE
bt_quickfix() is slow

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -5946,7 +5946,7 @@ bt_normal(buf_T *buf)
 bt_quickfix(buf_T *buf UNUSED)
 {
 #ifdef FEAT_QUICKFIX
-    return buf != NULL && buf_valid(buf) && buf->b_p_bt[0] == 'q';
+    return buf != NULL && buf->b_p_bt[0] == 'q';
 #else
     return FALSE;
 #endif


### PR DESCRIPTION
Problem:  In order to prevent a use-after-free, bt_quickfix() added a
          call to buf_valid(), which slows it down, because Vim has to
          loop through many buffers all the time (v9.0.1859)
Solution: Patch v9.0.2010 fixed a similar problem, so that the call to
          buf_valid() is no longer required (zeertzjq)

fixes: #19169