### PR TITLE
Redundant NULL checks in find_pattern_in_path()

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -3496,7 +3496,7 @@ find_pattern_in_path(
 	    char_u *p_fname = (curr_fname == curbuf->b_fname)
 					      ? curbuf->b_ffname : curr_fname;
 
-	    if (inc_opt != NULL && strstr((char *)inc_opt, "\\zs") != NULL)
+	    if (strstr((char *)inc_opt, "\\zs") != NULL)
 		// Use text from '\zs' to '\ze' (or end) of 'include'.
 		new_fname = find_file_name_in_path(incl_regmatch.startp[0],
 		       (int)(incl_regmatch.endp[0] - incl_regmatch.startp[0]),
@@ -3578,8 +3578,7 @@ find_pattern_in_path(
 			 * Isolate the file name.
 			 * Include the surrounding "" or <> if present.
 			 */
-			if (inc_opt != NULL
-				   && strstr((char *)inc_opt, "\\zs") != NULL)
+			if (strstr((char *)inc_opt, "\\zs") != NULL)
 			{
 			    // pattern contains \zs, use the match
 			    p = incl_regmatch.startp[0];

--- a/src/testdir/test_diffmode.vim
+++ b/src/testdir/test_diffmode.vim
@@ -3566,7 +3566,7 @@ func Test_diff_add_prop_in_autocmd()
   call StopVimInTerminal(buf)
 endfunc
 
-" this was causing a use-after-free by callig winframe_remove() rerursively
+" this was causing a use-after-free by calling winframe_remove() recursively
 func Test_diffexpr_wipe_buffers()
   CheckRunVimInTerminal
 


### PR DESCRIPTION
Problem:  Redundant NULL checks in find_pattern_in_path().
Solution: Remove the NULL checks.

After assigning to inc_opt on line 3461, it's dereferenced immediately,
and not assigned another value afterwards, so checking for NULL after
line 3462 is redundant.
