### PR TITLE
Last buffer not freed with EXITFREE

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -777,17 +777,22 @@ aucmd_abort:
     // Autocommands may have opened or closed windows for this buffer.
     // Decrement the count for the close we do here.
     // Don't decrement b_nwindows if the buffer wasn't displayed in any window
-    // before calling buf_freeall(),
+    // before calling buf_freeall().
     if (nwindows > 0 && buf->b_nwindows > 0)
 	--buf->b_nwindows;
 
     /*
      * Remove the buffer from the list.
      * Do not wipe out the buffer if it is used in a window, or if autocommands
-     * wiped out all other buffers.
+     * wiped out all other buffers (unless when inside free_all_mem() where all
+     * buffers need to be freed and autocommands are blocked).
      */
     if (wipe_buf && buf->b_nwindows <= 0
-			    && (buf->b_prev != NULL || buf->b_next != NULL))
+			    && (buf->b_prev != NULL || buf->b_next != NULL
+#if defined(EXITFREE)
+				|| entered_free_all_mem
+#endif
+				))
     {
 	tabpage_T	*tp;
 	win_T		*wp;


### PR DESCRIPTION
Problem:  Last buffer not freed with EXITFREE (after 9.1.2087).
Solution: Free the last buffer when inside free_all_mem().

This isn't really a memory leak, as the last buffer's memory is still
reachable via pointers like firstbuf and lastbuf. But it's possible that
this may cause false ASAN warnings in the future, which is what EXITFREE
is supposed to prevent.
