### PR TITLE
Add .roto filetype for Roto

### DIFF
--- a/.github/MAINTAINERS
+++ b/.github/MAINTAINERS
@@ -289,6 +289,7 @@ runtime/ftplugin/readline.vim				@dkearns
 runtime/ftplugin/remind.vim				@joereynolds
 runtime/ftplugin/rescript.vim				@ribru17
 runtime/ftplugin/routeros.vim				@zainin
+runtime/ftplugin/roto.vim				@bsamseth
 runtime/ftplugin/rst.vim				@marshallward
 runtime/ftplugin/ruby.vim				@tpope @dkearns
 runtime/ftplugin/rust.vim				@lilyball

--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -2594,6 +2594,8 @@ const ft_from_ext = {
   "roc": "roc",
   # RON (Rusty Object Notation)
   "ron": "ron",
+  # Roto
+  "roto": "roto",
   # MikroTik RouterOS script
   "rsc": "routeros",
   # Rpcgen

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -974,6 +974,9 @@ au BufNewFile,BufRead [rR]antfile,*.rant,[rR]akefile,*.rake	setf ruby
 " Rust
 au BufNewFile,BufRead Cargo.lock,*/.cargo/config,*/.cargo/credentials	setf toml
 
+" Roto
+au BufNewFile,BufRead *.roto			setf roto
+
 " Sather, TI linear assembly
 au BufNewFile,BufRead *.sa			call dist#ft#FTsa()
 

--- a/runtime/ftplugin/roto.vim
+++ b/runtime/ftplugin/roto.vim
@@ -1,0 +1,15 @@
+" Roto filetype plugin file
+" Language: Roto
+" Maintainer: Bendik Samseth <bendik@samseth.me>
+" Latest Revision: 2026-01-16
+
+if exists("b:did_ftplugin")
+  finish
+endif
+let b:did_ftplugin = 1
+
+setlocal comments=:#
+setlocal commentstring=#\ %s
+
+let b:undo_ftplugin = "setl com< cms<"
+

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -699,6 +699,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     robots: ['robots.txt'],
     roc: ['file.roc'],
     ron: ['file.ron'],
+    roto: ['file.roto'],
     routeros: ['file.rsc'],
     rpcgen: ['file.x'],
     rpgle: ['file.rpgle', 'file.rpgleinc'],


### PR DESCRIPTION
This is only meant to provide minimal filetype recognition as the first step to get some level of editor support for the language. It can be extended once the language has a (more) stable syntax.

See https://github.com/NLnetLabs/roto.

Note: I have no affiliation with NLnetLabs, I simply would like to improve the editor support in order to make it easier to use.

Note 2: I have tried to figure out all the places where I should make changes. If I've missed something I'm happy to update the PR.