### PR TITLE
runtime(doc): fix return type in getqflist() and getloclist()

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -4727,7 +4727,7 @@ getloclist({nr} [, {what}])				*getloclist()*
 			:echo getloclist(3, {'all': 0})
 			:echo getloclist(5, {'filewinid': 0})
 <
-		Return type: list<dict<any>> or list<any>
+		Return type: list<dict<any>> or dict<any>
 
 
 getmarklist([{buf}])					*getmarklist()*
@@ -5008,7 +5008,7 @@ getqflist([{what}])					*getqflist()*
 			:echo getqflist({'nr': 2, 'title': 1})
 			:echo getqflist({'lines' : ["F1:10:L10"]})
 <
-		Return type: list<dict<any>> or list<any>
+		Return type: list<dict<any>> or dict<any>
 
 
 getreg([{regname} [, 1 [, {list}]]])			*getreg()*


### PR DESCRIPTION
Problem: `call getqflist({})` will return `{}`.
Solution: fix it in the document.

Does `[]` is `list<dict<any>>`? Or these should be `list<dict<any>> or list<any> or dict<any>`? If it is, please directly modify the document.