### PR TITLE
Tweak documentation style in {ft_context,terminal}.txt

### DIFF
--- a/runtime/doc/ft_context.txt
+++ b/runtime/doc/ft_context.txt
@@ -117,7 +117,7 @@ and this option is not set, standard `make` is used. If this option is set,
 <
 NOTE: before using |:make|, ensure that the working directory of the buffer is
 set to the directory of the file you want to typeset. Additionally, be aware
-that |:make| searches for `mtxrun in $PATH.
+that |:make| searches for `mtxrun` in $PATH.
 
 					*'g:context_extra_options'*
 A list of additional options to pass to `mtxrun`.

--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -1263,7 +1263,8 @@ Alternatively, press "s" to swap the first and second dump.  Do this several
 times so that you can spot the difference in the context of the text.
 
 ==============================================================================
-6. Debugging	*terminal-debug* *terminal-debugger* *package-termdebug* *termdebug*
+6. Debugging				*terminal-debug* *terminal-debugger*
+					*package-termdebug* *termdebug*
 
 The Terminal debugging plugin can be used to debug a program with gdb and view
 the source code in a Vim window.  Since this is completely contained inside


### PR DESCRIPTION
ft_context.txt
- Forgot the backtick.

terminal.txt
- Over 80 columns.