### PR TITLE
Add dockercompose filetype

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -273,6 +273,10 @@ au BufNewFile,BufRead *.cpy
 	\   setf cobol |
 	\ endif
 
+" Dockercompose
+au BufNewFile,BufRead docker-compose.yaml,docker-compose.yml setf dockercompose
+au BufNewFile,BufRead docker-compose.yaml,docker-compose.yml set syntax=yaml
+
 " Dockerfile; Podman uses the same syntax with name Containerfile
 " Also see Dockerfile.* below.
 au BufNewFile,BufRead Containerfile,Dockerfile,dockerfile,*.[dD]ockerfile	setf dockerfile

--- a/runtime/ftplugin/dockercompose.vim
+++ b/runtime/ftplugin/dockercompose.vim
@@ -1,0 +1,40 @@
+" Vim filetype plugin file
+" Language:             Docker compose files
+" Maintainer:           Jan Claußen <jan.claussen10@web.de>
+" Last Change:          2026 Jan 17
+
+if exists("b:did_ftplugin")
+  finish
+endif
+let b:did_ftplugin = 1
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+let b:undo_ftplugin = "setl com< cms< et< fo<"
+
+setlocal comments=:# commentstring=#\ %s expandtab
+setlocal formatoptions-=t formatoptions+=croql
+
+if get(g:, "yaml_recommended_style",1)
+  let b:undo_ftplugin ..= " sw< sts<"
+  setlocal shiftwidth=2 softtabstop=2
+endif
+
+" rime input method engine(https://rime.im/)
+" uses `*.custom.yaml` as its config files
+if expand('%:r:e') ==# 'custom'
+  " `__include` command in `*.custom.yaml`
+  " see: https://github.com/rime/home/wiki/Configuration#%E5%8C%85%E5%90%AB
+  setlocal include=__include:\\s*
+  let b:undo_ftplugin ..= " inc<"
+
+  if !exists('current_compiler')
+    compiler rime_deployer
+    let b:undo_ftplugin ..= " | compiler make"
+  endif
+endif
+
+
+let &cpo = s:cpo_save
+unlet s:cpo_save


### PR DESCRIPTION
This is needed for the [docker-language-server](https://github.com/docker/docker-language-server), which I just submitted a fix for in yegappan/lsp

https://github.com/yegappan/lsp/pull/744

Having a dockercompose filetype would make the language server configuration much easier

```vimscript
let docker_ls =
			\ #{name: 'docker-language-server',
			\   path: 'docker-language-server',
			\   args: ['start', '--stdio'],
			\   filetype: ['dockerfile', 'dockercompose']
			\ }
```

Not sure if this is the right way though. Syntax should stay yaml, so I just copied the `ftplugin/yaml.vim` over to `ftplugin/dockercompse.vim` and add `set syntax=yaml`. Only the extra filetype is needed to not start the server in all yaml files. Maybe it can be mapped to yaml somehow?