### PR TITLE
Changed one old menu item name to a new one

### DIFF
--- a/runtime/menu.vim
+++ b/runtime/menu.vim
@@ -84,7 +84,7 @@ an <silent> 9999.40 &Help.&Find\.\.\.	:call <SID>Helpfind()<CR>
 an 9999.45 &Help.-sep1-			<Nop>
 an 9999.50 &Help.&Credits		:help credits<CR>
 an 9999.60 &Help.Co&pying		:help copying<CR>
-an 9999.70 &Help.&Sponsor	  :help sponsor<CR>
+an 9999.70 &Help.&Sponsor	  	:help sponsor<CR>
 an 9999.70 &Help.O&rphans		:help kcc<CR>
 an 9999.75 &Help.-sep2-			<Nop>
 an 9999.80 &Help.&Version		:version<CR>
@@ -98,7 +98,7 @@ if exists(':tlmenu')
   tlnoremenu 9999.45 &Help.-sep1-			<Nop>
   tlnoremenu 9999.50 &Help.&Credits			<C-W>:help credits<CR>
   tlnoremenu 9999.60 &Help.Co&pying			<C-W>:help copying<CR>
-  tlnoremenu 9999.70 &Help.&Sponsor/Register		<C-W>:help sponsor<CR>
+  tlnoremenu 9999.70 &Help.&Sponsor			<C-W>:help sponsor<CR>
   tlnoremenu 9999.70 &Help.O&rphans			<C-W>:help kcc<CR>
   tlnoremenu 9999.75 &Help.-sep2-			<Nop>
   tlnoremenu 9999.80 &Help.&Version			<C-W>:version<CR>


### PR DESCRIPTION
Problem: There is an unavailable "Sponsor/Register" item in the Help menu.

The item names of tlmenu, which are only valid in terminal mode, were not updated, so unnecessary items that were unavailable were displayed.

This item is also very confusing when creating menu translations.

Solution: The item name has been unified to "Sponsor".

In addition, the indentation of an item with the same name in the regular menu has been corrected.