### PR TITLE
MS-Windows: Ruby interface not work correctly

### DIFF
--- a/src/if_ruby.c
+++ b/src/if_ruby.c
@@ -179,6 +179,9 @@
 #ifdef HAVE_DUP
 # undef HAVE_DUP
 #endif
+#ifdef HAVE_FSYNC
+# undef HAVE_FSYNC
+#endif
 
 // Avoid redefining TRUE/FALSE in vterm.h.
 #ifdef TRUE


### PR DESCRIPTION
Problem:  Ruby headers define HAVE_FSYNC, which leaks into Vim sources
          on Windows and changes conditional compilation of buf_T. This
          causes struct layout mismatches in if_ruby.c and results in a
          different offset for the b_p_bl property, making Vim::Buffer
          access fail.
Solution: Undefine HAVE_FSYNC after including the Ruby headers.

related: #19019