### PR TITLE
feat(filetype): add razor filetype for .cshtml and .razor

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -2559,6 +2559,9 @@ const ft_from_ext = {
   "rakumod": "raku",
   "rakudoc": "raku",
   "rakutest": "raku",
+  # Razor
+  "cshtml": "razor",
+  "razor": "razor",
   # Renderman Interface Bytestream
   "rib": "rib",
   # Rego Policy Language

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -535,7 +535,6 @@ au BufNewFile,BufRead init.trans,*/etc/translate-shell,.trans	setf clojure
 
 " HTML (.stm for server side, .shtml is server-side or superhtml)
 au BufNewFile,BufRead *.html,*.htm,*.shtml,*.stm  call dist#ft#FThtml()
-au BufNewFile,BufRead *.cshtml			setf html
 
 " Host config
 au BufNewFile,BufRead */etc/host.conf		setf hostconf

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -378,7 +378,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     hostconf: ['/etc/host.conf', 'any/etc/host.conf'],
     hostsaccess: ['/etc/hosts.allow', '/etc/hosts.deny', 'any/etc/hosts.allow', 'any/etc/hosts.deny'],
     # file.component.html should be HTML, not Angular, see #13594
-    html: ['file.html', 'file.htm', 'file.cshtml', 'file.component.html'],
+    html: ['file.html', 'file.htm', 'file.component.html'],
     htmlm4: ['file.html.m4'],
     httest: ['file.htt', 'file.htb'],
     http: ['file.http'],
@@ -678,6 +678,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     rapid: ['file.sysx', 'file.Sysx', 'file.SysX', 'file.SYSx', 'file.SYSX', 'file.modx', 'file.Modx', 'file.ModX', 'file.MODx', 'file.MODX'],
     rasi: ['file.rasi', 'file.rasinc'],
     ratpoison: ['.ratpoisonrc', 'ratpoisonrc'],
+    razor: ['file.cshtml', 'file.razor'],
     rbs: ['file.rbs'],
     rc: ['file.rc', 'file.rch'],
     rcs: ['file,v'],


### PR DESCRIPTION
cshtml/razor is not html and is its own markup language

https://learn.microsoft.com/en-us/aspnet/core/mvc/views/razor?view=aspnetcore-10.0

>Files containing Razor generally have a .cshtml file extension. Razor is also found in [Razor component](https://learn.microsoft.com/en-us/aspnet/core/blazor/components/?view=aspnetcore-10.0) files (.razor). Razor syntax is similar to the templating engines of various JavaScript single-page application (SPA) frameworks, such as Angular, React, VueJs, and Svelte.