### PR TITLE
Add termcap entries for kitty color detection

### DIFF
--- a/src/term.c
+++ b/src/term.c
@@ -641,6 +641,12 @@ static tcap_entry_T builtin_kitty[] = {
     // have been used.
     {(int)KS_CTE,	"\033[>4;m\033[=0;1u"},
 
+    // t_RF request terminal foreground color
+    {(int)KS_RFG,	"\033]10;?\033\\"},
+
+    // t_RB request terminal background color
+    {(int)KS_RBG,	"\033]11;?\033\\"},
+
     {(int)KS_NAME,	NULL}  // end marker
 };
 


### PR DESCRIPTION
Problem: Kitty incorrectly guessued background/foreground terminal colors
Solution: Add missing termcap entries

[source](https://sw.kovidgoyal.net/kitty/faq/#using-a-color-theme-with-a-background-color-does-not-work-well-in-vim)