### PR TITLE
Crash with 'wildmenu' when typing Ctrl-Y after Ctrl-A

### DIFF
--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -1994,7 +1994,7 @@ getcmdline_int(
 
 	int key_is_wc = (c == p_wc && KeyTyped) || c == p_wcm;
 	if ((cmdline_pum_active() || wild_menu_showing || did_wild_list)
-		&& !key_is_wc)
+		&& !key_is_wc && xpc.xp_numfiles > 0)
 	{
 	    // Ctrl-Y: Accept the current selection and close the popup menu.
 	    // Ctrl-E: cancel the cmdline popup menu and return the original

--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -162,6 +162,16 @@ func Test_complete_wildmenu()
   call feedkeys(":sign un zz\<Left>\<Left>\<Left>\<Tab>\<Tab>\<C-Y> yy\<C-B>\"\<CR>", 'tx')
   call assert_equal('"sign unplace yy zz', @:)
 
+  " This used to crash
+  call feedkeys(":sign un\<Tab>\<S-Tab>\<C-A>\<C-Y>\<C-B>\"\<CR>", 'tx')
+  " Ctrl-Y is inserted literally like before 9.1.1714
+  call assert_equal("\"sign undefine unplace\<C-Y>", @:)
+  " Also test Ctrl-Y after Ctrl-A with selected item (the result is the same)
+  call feedkeys(":sign un\<Tab>\<C-A>\<C-Y>\<C-B>\"\<CR>", 'tx')
+  call assert_equal("\"sign undefine unplace\<C-Y>", @:)
+  call feedkeys(":sign un\<Tab>\<Tab>\<C-A>\<C-Y>\<C-B>\"\<CR>", 'tx')
+  call assert_equal("\"sign undefine unplace\<C-Y>", @:)
+
   " cleanup
   %bwipe
   set nowildmenu


### PR DESCRIPTION
Problem:  Crash with 'wildmenu' when typing Ctrl-Y after Ctrl-A
          (after 9.1.1714) (fizz-is-on-the-way).
Solution: Check if there are matches before applying one.
