### PR TITLE
:wqall! doesn't quit when using :quit in BufWritePost

### DIFF
--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -2498,6 +2498,7 @@ do_wqall(exarg_T *eap)
     buf_T	*buf;
     int		error = 0;
     int		save_forceit = eap->forceit;
+    int		save_exiting = exiting;
 
     if (eap->cmdidx == CMD_xall || eap->cmdidx == CMD_wqall)
     {
@@ -2564,7 +2565,7 @@ do_wqall(exarg_T *eap)
     {
 	if (!error)
 	    getout(0);		// exit Vim
-	not_exiting();
+	not_exiting(save_exiting);
     }
 }
 

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -6062,9 +6062,9 @@ ex_highlight(exarg_T *eap)
  * (because of an error).  May need to restore the terminal mode.
  */
     void
-not_exiting(void)
+not_exiting(int save_exiting)
 {
-    exiting = FALSE;
+    exiting = save_exiting;
     settmode(TMODE_RAW);
 }
 
@@ -6139,6 +6139,7 @@ ex_quit(exarg_T *eap)
     netbeansForcedQuit = eap->forceit;
 #endif
 
+    int save_exiting = exiting;
     /*
      * If there is only one relevant window we will exit.
      */
@@ -6151,7 +6152,7 @@ ex_quit(exarg_T *eap)
 	    || check_more(TRUE, eap->forceit) == FAIL
 	    || (only_one_window() && check_changed_any(eap->forceit, TRUE)))
     {
-	not_exiting();
+	not_exiting(save_exiting);
     }
     else
     {
@@ -6163,7 +6164,7 @@ ex_quit(exarg_T *eap)
 	// :h|wincmd w|q      - quit
 	if (only_one_window() && (ONE_WINDOW || eap->addr_count == 0))
 	    getout(0);
-	not_exiting();
+	not_exiting(save_exiting);
 #ifdef FEAT_GUI
 	need_mouse_correct = TRUE;
 #endif
@@ -6219,10 +6220,11 @@ ex_quit_all(exarg_T *eap)
 {
     if (before_quit_all(eap) == FAIL)
 	return;
+    int save_exiting = exiting;
     exiting = TRUE;
     if (eap->forceit || !check_changed_any(FALSE, FALSE))
 	getout(0);
-    not_exiting();
+    not_exiting(save_exiting);
 }
 
 /*
@@ -6725,6 +6727,7 @@ ex_exit(exarg_T *eap)
 	return;
     }
 
+    int save_exiting = exiting;
     /*
      * we plan to exit if there is only one relevant window
      */
@@ -6739,13 +6742,13 @@ ex_exit(exarg_T *eap)
 	    || check_more(TRUE, eap->forceit) == FAIL
 	    || (only_one_window() && check_changed_any(eap->forceit, FALSE)))
     {
-	not_exiting();
+	not_exiting(save_exiting);
     }
     else
     {
 	if (only_one_window())	    // quit last window, exit Vim
 	    getout(0);
-	not_exiting();
+	not_exiting(save_exiting);
 #ifdef FEAT_GUI
 	need_mouse_correct = TRUE;
 #endif

--- a/src/proto/ex_docmd.pro
+++ b/src/proto/ex_docmd.pro
@@ -38,7 +38,7 @@ char_u *find_nextcmd(char_u *p);
 char_u *check_nextcmd(char_u *p);
 void set_nextcmd(exarg_T *eap, char_u *arg);
 char_u *get_command_name(expand_T *xp, int idx);
-void not_exiting(void);
+void not_exiting(int save_exiting);
 int before_quit_autocmds(win_T *wp, int quit_all, int forceit);
 void ex_quit(exarg_T *eap);
 int before_quit_all(exarg_T *eap);

--- a/src/testdir/test_exit.vim
+++ b/src/testdir/test_exit.vim
@@ -90,6 +90,20 @@ func Test_exiting()
     call assert_equal(['QuitPre', 'ExitPre'], readfile('Xtestout'))
   endif
   call delete('Xtestout')
+
+  " Test using :quit in BufWritePost during :wqall
+  let after =<< trim [CODE]
+    botright new Xwritebuf
+    call setline(1, 'SHOULD BE WRITTEN')
+    autocmd BufWritePost Xwritebuf 1quit
+    wqall
+    call setline(1, 'NOT REACHED') | write | qall
+  [CODE]
+
+  if RunVim([], after, '')
+    call assert_equal(['SHOULD BE WRITTEN'], readfile('Xwritebuf'))
+  endif
+  call delete('Xwritebuf')
 endfunc
 
 " Test for getting the Vim exit code from v:exiting


### PR DESCRIPTION
Problem:  :wqall! doesn't quit when using :quit in BufWritePost
          (after 8.0.1190).
Solution: Restore old value of "exiting" when calling not_exiting()
          instead of always resetting it to FALSE.

related: #2205
