### PR TITLE
Class, enum and typealias cannot be used with the falsy operator

### DIFF
--- a/src/testdir/test_vim9_expr.vim
+++ b/src/testdir/test_vim9_expr.vim
@@ -263,6 +263,67 @@ def Test_expr1_falsy()
   END
   v9.CheckSourceScriptSuccess(lines)
 
+  # class cannot be used with the falsy operator
+  lines =<< trim END
+    vim9script
+    class A
+    endclass
+    echo A ?? 'falsy'
+  END
+  v9.CheckSourceScriptFailure(lines, 'E1405: Class "A" cannot be used as a value')
+
+  lines =<< trim END
+    vim9script
+    class B
+    endclass
+    echo !B
+  END
+  v9.CheckSourceScriptFailure(lines, 'E1405: Class "B" cannot be used as a value')
+
+  lines =<< trim END
+    vim9script
+    echo null_class ?? 'falsy'
+  END
+  v9.CheckSourceScriptFailure(lines, 'E1405: Class "" cannot be used as a value')
+
+  lines =<< trim END
+    vim9script
+    echo !null_class
+  END
+  v9.CheckSourceScriptFailure(lines, 'E1405: Class "" cannot be used as a value')
+
+  # enum cannot be used with the falsy operator
+  lines =<< trim END
+    vim9script
+    enum E1
+    endenum
+    echo E1 ?? 'falsy'
+  END
+  v9.CheckSourceScriptFailure(lines, 'E1421: Enum "E1" cannot be used as a value')
+
+  lines =<< trim END
+    vim9script
+    enum E2
+    endenum
+    echo !E2
+  END
+  v9.CheckSourceScriptFailure(lines, 'E1421: Enum "E2" cannot be used as a value')
+
+  # typealias cannot be used with the falsy operator
+  lines =<< trim END
+    vim9script
+    type T1 = list<bool>
+    echo T1 ?? 'falsy'
+  END
+  v9.CheckSourceScriptFailure(lines, 'E1403: Type alias "T1" cannot be used as a value')
+
+  lines =<< trim END
+    vim9script
+    type T2 = list<bool>
+    echo !T2
+  END
+  v9.CheckSourceScriptFailure(lines, 'E1403: Type alias "T2" cannot be used as a value')
+
   var msg = "White space required before and after '??'"
   call v9.CheckDefAndScriptFailure(["var x = 1?? 'one' : 'two'"], msg, 1)
   call v9.CheckDefAndScriptFailure(["var x = 1 ??'one' : 'two'"], msg, 1)

--- a/src/vim9execute.c
+++ b/src/vim9execute.c
@@ -8131,12 +8131,15 @@ tv2bool(typval_T *tv)
 	case VAR_OBJECT:
 	    return tv->vval.v_object != NULL;
 
+	case VAR_CLASS:
+	case VAR_TYPEALIAS:
+	    check_typval_is_value(tv);
+	    break;
+
 	case VAR_UNKNOWN:
 	case VAR_ANY:
 	case VAR_VOID:
 	case VAR_INSTR:
-	case VAR_CLASS:
-	case VAR_TYPEALIAS:
 	    break;
     }
     return FALSE;


### PR DESCRIPTION
Class, enum and typealias cannot be used as values.  Display an error when these are used with the falsy operator.