### PR TITLE
filetype: tiltfiles are not recognized

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -530,6 +530,10 @@ au BufNewFile,BufRead *.persistentmodels	setf haskellpersistent
 " Tilde (must be before HTML)
 au BufNewFile,BufRead *.t.html			setf tilde
 
+" Tiltfile
+" Also see Tiltfile.* below.
+au BufNewFile,BufRead Tiltfile,tiltfile,*.[tT]iltfile	setf tiltfile
+
 " Translate shell
 au BufNewFile,BufRead init.trans,*/etc/translate-shell,.trans	setf clojure
 
@@ -1547,6 +1551,9 @@ au BufNewFile,BufRead .tcshrc*	call dist#ft#SetFileTypeShell("tcsh")
 
 " csh scripts ending in a star
 au BufNewFile,BufRead .login*,.cshrc*  call dist#ft#CSH()
+
+" Tiltfile
+au BufNewFile,BufRead Tiltfile.*	call s:StarSetf('tiltfile')
 
 " tmux configuration with arbitrary extension
 au BufNewFile,BufRead {.,}tmux*.conf*		call s:StarSetf('tmux')

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -888,6 +888,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     tidy: ['.tidyrc', 'tidyrc', 'tidy.conf'],
     tiger: ['file.tig'],
     tilde: ['file.t.html'],
+    tiltfile: ['Tiltfile', 'tiltfile', 'file.Tiltfile', 'file.tiltfile', 'Tiltfile.debian'],
     tla: ['file.tla'],
     tli: ['file.tli'],
     tmux: ['tmuxfile.conf', '.tmuxfile.conf', '.tmux-file.conf', '.tmux.conf', 'tmux-file.conf', 'tmux.conf', 'tmux.conf.local'],


### PR DESCRIPTION
Fixes #19214 

This should take care of recognizing the file type.
I'd like to also assing the syntax to match starlark but it seems like there's no starlark syntax. Bazel also uses starlark but there seems to be a dedicated syntax for bazel files. Maybe that syntax should be renamed to starlark and both bazel and tilt files should be set with that syntax but that would be a bigger change and should be done separately, if at all.