### PR TITLE
runtime(c): change 'keywordprg' for gui

### DIFF
--- a/runtime/ftplugin/c.vim
+++ b/runtime/ftplugin/c.vim
@@ -16,7 +16,7 @@ let b:did_ftplugin = 1
 let s:cpo_save = &cpo
 set cpo-=C
 
-let b:undo_ftplugin = "setl fo< com< ofu< cms< def< inc< kp< | if has('vms') | setl isk< | endif"
+let b:undo_ftplugin = "setl fo< com< ofu< cms< def< inc< | if has('vms') | setl isk< | endif"
 
 " Set 'formatoptions' to break comment lines but not other lines,
 " and insert the comment leader when hitting <CR> or using "o".
@@ -40,13 +40,21 @@ if has("vms")
   setlocal iskeyword+=$
 endif
 
-" Use :Man for a nicer manual that also works in GUI
-runtime ftplugin/man.vim
+" Use terminal window for gui
+if has('gui_running')
+  setlocal keywordprg=:CKeywordPrg
 
-if exists(":Man") == 2
-  setlocal keywordprg=:Man\ -s2,3
-else
-  setlocal keywordprg=man\ -s2,3
+  command! -buffer -nargs=1 -count CKeywordPrg call s:CKeywordPrg(<q-args>, <count>)
+
+  function! s:CKeywordPrg(arg, count) abort
+    if a:count > 0
+      exe printf('term ++close man -s %d %s', a:count, a:arg)
+    else
+      exe printf('term ++close man %s', a:arg)
+    endif
+  endfunction
+
+  let b:undo_ftplugin .= ' | setl pa< | sil! delc -buffer CKeywordPrg | sil! delf s:CKeywordPrg'
 endif
 
 " When the matchit plugin is loaded, this makes the % command skip parens and

--- a/runtime/ftplugin/c.vim
+++ b/runtime/ftplugin/c.vim
@@ -41,7 +41,7 @@ if has("vms")
 endif
 
 " Use terminal window for gui
-if has('gui_running')
+if has('gui_running') && has('terminal')
   setlocal keywordprg=:CKeywordPrg
 
   command! -buffer -nargs=1 -count CKeywordPrg call s:CKeywordPrg(<q-args>, <count>)

--- a/runtime/ftplugin/c.vim
+++ b/runtime/ftplugin/c.vim
@@ -41,7 +41,7 @@ if has("vms")
 endif
 
 " Use terminal window for gui
-if has('gui_running') && has('terminal')
+if has('gui_running') && exists(':terminal') == 2
   setlocal keywordprg=:CKeywordPrg
 
   command! -buffer -nargs=1 -count CKeywordPrg call s:CKeywordPrg(<q-args>, <count>)
@@ -54,7 +54,7 @@ if has('gui_running') && has('terminal')
     endif
   endfunction
 
-  let b:undo_ftplugin .= ' | setl pa< | sil! delc -buffer CKeywordPrg | sil! delf s:CKeywordPrg'
+  let b:undo_ftplugin .= ' | setl kp< | sil! delc -buffer CKeywordPrg'
 endif
 
 " When the matchit plugin is loaded, this makes the % command skip parens and

--- a/runtime/ftplugin/c.vim
+++ b/runtime/ftplugin/c.vim
@@ -16,7 +16,7 @@ let b:did_ftplugin = 1
 let s:cpo_save = &cpo
 set cpo-=C
 
-let b:undo_ftplugin = "setl fo< com< ofu< cms< def< inc< | if has('vms') | setl isk< | endif"
+let b:undo_ftplugin = "setl fo< com< ofu< cms< def< inc< kp< | if has('vms') | setl isk< | endif"
 
 " Set 'formatoptions' to break comment lines but not other lines,
 " and insert the comment leader when hitting <CR> or using "o".
@@ -38,6 +38,15 @@ setlocal comments=sO:*\ -,mO:*\ \ ,exO:*/,s1:/*,mb:*,ex:*/,:///,://
 " In VMS C keywords contain '$' characters.
 if has("vms")
   setlocal iskeyword+=$
+endif
+
+" Use :Man for a nicer manual that also works in GUI
+runtime ftplugin/man.vim
+
+if exists(":Man") == 2
+  setlocal keywordprg=:Man\ -s2,3
+else
+  setlocal keywordprg=man\ -s2,3
 endif
 
 " When the matchit plugin is loaded, this makes the % command skip parens and


### PR DESCRIPTION
This is mostly useful for the gui since `:!man` in the builtin terminal is unusable. Maybe it should be done only when the gui is running? Although I think also terminal users would prefer the `man.vim` plugin

I also added an option to `man` to only search in relevant sections, for example `man -s2,3 open` opens the man page for the syscall instead of the user program with the same name.  