### PR TITLE
Make the line break code of ja.sjis.po the same as ja.po

### DIFF
--- a/src/po/sjiscorr.c
+++ b/src/po/sjiscorr.c
@@ -1,16 +1,27 @@
-/*
- * Simplistic program to correct SJIS inside strings.  When a trail byte is a
- * backslash it needs to be doubled.
- * Public domain.
- */
+// Simplistic program to correct SJIS inside strings.  When a trail byte is a
+// backslash it needs to be doubled.
+// Public domain.
+
 #include <stdio.h>
 #include <string.h>
+
+#ifdef _WIN32
+#	include <fcntl.h>
+#	include <io.h>
+#endif
 
 	int
 main(int argc, char **argv)
 {
 	char buffer[BUFSIZ];
 	char *p;
+
+	// Windows only: put standard input and output into binary mode so that the
+	// line endings in the output match those in the input.
+#ifdef _WIN32
+	_setmode(_fileno(stdin), _O_BINARY);
+	_setmode(_fileno(stdout), _O_BINARY);
+#endif
 
 	while (fgets(buffer, BUFSIZ, stdin) != NULL)
 	{
@@ -22,11 +33,10 @@ main(int argc, char **argv)
 				fputs("charset=CP932", stdout);
 				p += 12;
 			}
-			else if (strncmp(p, "# Original translations", 23) == 0)
+			else if (strncmp(p, "# Original translations.", 24) == 0)
 			{
+				p += 24 - 1; // subtracting 1 by considering "p++" in the loop.
 				fputs("# Generated from ja.po, DO NOT EDIT.", stdout);
-				while (p[1] != '\n')
-					++p;
 			}
 			else if (*(unsigned char *)p == 0x81 && p[1] == '_')
 			{
@@ -46,3 +56,5 @@ main(int argc, char **argv)
 		}
 	}
 }
+
+// vim:set ts=4 sts=4 sw=4 noet:


### PR DESCRIPTION
Problem: Depending on the worker's environment, the line endings in ja.sjis.po may differ from those in the source ja.po.

This occurs when using MINGW gcc on Windows and git with autocrlf=false. In this case, the line endings in ja.po are LF, but because sjiscorr compiled with MINGW gcc uses text mode for standard input and output, the line endings in the output ja.sjis.po will be CRLF.

This mismatch in line endings confuses git, causing large differences to occur when updating.

Solution: By setting standard input and output to binary mode, the line endings for input and output will match.

In addition, the comment style has been changed to // to match the rest of Vim's code.