### PR TITLE
Improved src/po/check.vim to be faster and show errors

### DIFF
--- a/src/po/Makefile
+++ b/src/po/Makefile
@@ -42,7 +42,7 @@ converted: $(MOCONVERTED)
 .po.ck:
 	$(VIMPROG) -u NONE --noplugins -e -s -X --cmd "set enc=utf-8" \
 		-S check.vim -c "if error == 0 | q | else | num 2 | cq | endif" \
-		$< >/dev/null
+		$<
 	touch $@
 
 check: $(CHECKFILES)

--- a/src/po/check.vim
+++ b/src/po/check.vim
@@ -22,7 +22,7 @@ set nowrapscan
 func! GetMline()
   let idline = substitute(getline('.'), '"\(.*\)"$', '\1', '')
   while line('.') < line('$')
-    +
+    silent +
     let line = getline('.')
     if line[0] != '"'
       break
@@ -60,8 +60,8 @@ endfunc
 
 " Start at the first "msgid" line.
 let wsv = winsaveview()
-1
-keeppatterns /^msgid\>
+silent 1
+silent keeppatterns /^msgid\>
 
 " When an error is detected this is set to the line number.
 " Note: this is used in the Makefile.
@@ -154,7 +154,7 @@ endwhile
 " - msgstr "E123 ..."     missing colon
 " - msgstr "..."          missing error code
 "
-1
+silent 1
 if search('msgid "\("\n"\)\?\([EW][0-9]\+:\).*\nmsgstr "\("\n"\)\?[^"]\@=\2\@!') > 0
   echomsg 'Mismatching error/warning code in line ' . line('.')
   if error == 0
@@ -164,8 +164,8 @@ endif
 
 " Check that the \n at the end of the msgid line is also present in the msgstr
 " line.  Skip over the header.
-1
-keeppatterns /^"MIME-Version:
+silent 1
+silent keeppatterns /^"MIME-Version:
 while 1
   let lnum = search('^msgid\>')
   if lnum <= 0
@@ -191,8 +191,8 @@ endwhile
 " final '""', '\n"', ' "' '/"' '."' '-"' are OK
 " Beware, it can give false positives if the message is split
 " in the middle of a word
-1
-keeppatterns /^"MIME-Version:
+silent 1
+silent keeppatterns /^"MIME-Version:
 while 1
   let lnum = search('^msgid\>')
   if lnum <= 0
@@ -259,7 +259,7 @@ if executable("msgfmt")
 endif
 
 " Check that the plural form is properly initialized
-1
+silent 1
 let plural = search('^msgid_plural ', 'n')
 if (plural && search('^"Plural-Forms: ', 'n') == 0) || (plural && search('^msgstr\[0\] ".\+"', 'n') != plural + 1)
   if search('^"Plural-Forms: ', 'n') == 0


### PR DESCRIPTION
Problem: When checking a .po file (make -C src/po check), errors are not displayed.

This is because the output of check.vim is redirected to /dev/null. However, if you stop the redirection, check.vim generates a lot of output and becomes very slow.

Solution: Adding "silent" to some normal commands in check.vim suppresses unnecessary output.

When these commands are run in ex mode, they output the contents of the line the cursor is pointing to.  This caused a lot of output.