### PR TITLE
tests: Test_foldtextresult_rightleft() does not restore 'columns'

### DIFF
--- a/src/testdir/test_fold.vim
+++ b/src/testdir/test_fold.vim
@@ -1504,6 +1504,7 @@ endfunc
 func Test_foldtextresult_rightleft()
   CheckFeature rightleft
 
+  let save_columns = &columns
   new
   set columns=70
   setlocal rightleft
@@ -1519,6 +1520,7 @@ func Test_foldtextresult_rightleft()
   call assert_equal('+--  2 lines: ' .. multibyte, foldtextresult(1))
 
   bw!
+  let &columns = save_columns
 endfunc
 
 " Test for merging two recursive folds when an intermediate line with no fold


### PR DESCRIPTION
Problem:  Test_foldtextresult_rightleft() does not restore 'columns'.
Solution: Save and restore the value of 'columns'.