### PR TITLE
Avoid double slash in path concatenation for create_readdirex_item

### DIFF
--- a/src/fileio.c
+++ b/src/fileio.c
@@ -4822,7 +4822,7 @@ create_readdirex_item(char_u *path, char_u *name)
 {
     dict_T	*item;
     char	*p;
-    size_t	len;
+    size_t	pathlen, len;
     stat_T	st;
     int		ret, link = FALSE;
     varnumber_T	size;
@@ -4836,11 +4836,15 @@ create_readdirex_item(char_u *path, char_u *name)
 	return NULL;
     item->dv_refcount++;
 
-    len = STRLEN(path) + 1 + STRLEN(name) + 1;
+    pathlen = STRLEN(path);
+    len = pathlen + 1 + STRLEN(name) + 1;
     p = alloc(len);
     if (p == NULL)
 	goto theend;
-    vim_snprintf(p, len, "%s/%s", path, name);
+    if (pathlen > 0 && path[pathlen - 1] == '/')
+	vim_snprintf(p, len, "%s%s", path, name);
+    else
+	vim_snprintf(p, len, "%s/%s", path, name);
     ret = mch_lstat(p, &st);
     if (ret >= 0 && S_ISLNK(st.st_mode))
     {


### PR DESCRIPTION
Fixing https://github.com/vim/vim/issues/19188

On Cygwin and MSYS2, `//` has a special meaning: it is treated as a prefix for accessing network computers.
For example, `//wsl$/` is used to access WSL.

In the current Vim implementation, the directory path passed to `readdirex()` and the file name found during traversal are concatenated using `"/"`.
When the directory path already ends with `/`, this results in paths like:

```
"/" + "/" + "$Recycle.Bin"
```

which produces a `//`-prefixed path. Such paths are interpreted as network paths, so Vim ends up trying to retrieve the file size of a network computer named `$Recycle.Bin`, which is not intended.

From a correctness perspective on Windows, file size retrieval should be skipped for paths of the following forms:

```
 //host
 //host/share
```

However, as a first step, we should avoid generating `//` paths caused by redundant `/` concatenation in the first place.
The patch below addresses this by preventing unnecessary `/` insertion when constructing paths.

