### PR TITLE
runtime(doc): Fix erroneous *roff syntax examples

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -2712,10 +2712,10 @@ package, arrange for files to be recognized as groff input (see
 GNU troff differs from older AT&T n/troff programs (that you may still find in
 Solaris or Plan 9) by extending the *roff language syntax.  For example, in
 AT&T troff, you access the count of years since 1900 with the escape sequence
-\(yr.  In groff you can do the same, which it recognizes for compatibility, or
-use groff's extended syntax, \[yr].  AT&T troff documented the yr register as
-storing the "last two digits of current year", but had a Y2K problem; in
-groff, you can access the Gregorian year correctly: \[year].  In groff, font,
+\n(yr.  In groff you can do the same, which it recognizes for compatibility,
+or use groff's extended syntax, \n[yr].  AT&T troff documented the yr register
+as storing the "last two digits of current year", but had a Y2K problem; in
+groff, you can access the Gregorian year correctly: \n[year].  In groff, font,
 register, macro, string, and request names can exceed two characters; for
 example, with groff's mm package, the control lines ".VERBON" and ".VERBOFF"
 call macros of those names to bracket displays of "verbatim" content.


### PR DESCRIPTION
Problem dates back at least to commit 071d4279d6, Vim 7.0001 (2004).

The examples shown were of special character interpolation syntax, not ("number") register interpolation syntax.

Sources:
* https://www.gnu.org/software/groff/manual/groff.html.node/Built_002din-Registers.html
* https://github.com/mamccollum/troff-resources/blob/main/cstr-54.pdf