### PR TITLE
Prevent guioptions=aP and guioptions=aAP from copying to * register

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4515,8 +4515,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 		by a yank or delete operation for the "* register.
 		The same applies to the modeless selection.
 								*'go-P'*
-	  'P'	Like autoselect but using the "+ register instead of the "*
-		register.
+	  'P'	Like autoselect but only copy to the "+ register instead of
+		the "* register.
 								*'go-A'*
 	  'A'	Autoselect for the modeless selection.  Like 'a', but only
 		applies to the modeless selection.

--- a/src/clipboard.c
+++ b/src/clipboard.c
@@ -452,11 +452,12 @@ clip_auto_select(void)
     int
 clip_isautosel_star(void)
 {
-    return (
-# ifdef FEAT_GUI
-	    gui.in_use ? (vim_strchr(p_go, GO_ASEL) != NULL) :
-# endif
-	    clip_autoselect_star);
+#ifdef FEAT_GUI
+    if (gui.in_use)
+	return vim_strchr(p_go, GO_ASEL) != NULL
+	    && vim_strchr(p_go, GO_ASELPLUS) == NULL;
+#endif
+    return clip_autoselect_star;
 }
 
 /*
@@ -466,11 +467,11 @@ clip_isautosel_star(void)
     int
 clip_isautosel_plus(void)
 {
-    return (
-# ifdef FEAT_GUI
-	    gui.in_use ? (vim_strchr(p_go, GO_ASELPLUS) != NULL) :
-# endif
-	    clip_autoselect_plus);
+#ifdef FEAT_GUI
+    if (gui.in_use)
+	return vim_strchr(p_go, GO_ASELPLUS) != NULL;
+#endif
+    return clip_autoselect_plus;
 }
 
 

--- a/src/testdir/test_gui.vim
+++ b/src/testdir/test_gui.vim
@@ -1827,4 +1827,38 @@ func Test_Buffers_Menu()
   %bw!
 endfunc
 
+" Test if 'guioptions=a' only copies to the primary selection and
+" 'guioptions=aP' only copies to the regular selection.
+func Test_guioptions_clipboard()
+  CheckX11BasedGui
+
+  set mouse=
+  let save_guioptions = &guioptions
+  set guioptions=a
+
+  let @+ = ""
+  let @* = ""
+
+  call setline(1, ['one two three', 'four five six'])
+  call cursor(1, 1)
+  call feedkeys("\<Esc>vee\<Esc>", "Lx!")
+
+  call assert_equal("one two", @*)
+  call assert_equal("", @+)
+
+  set guioptions=aP
+
+  let @+ = ""
+  let @* = ""
+
+  call cursor(1, 1)
+  call feedkeys("\<Esc>veee\<Esc>", "Lx!")
+
+  call assert_equal("one two three", @+)
+  call assert_equal("", @*)
+
+  set mouse&
+  let &guioptions = save_guioptions
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Fixes #19187