### PR TITLE
Fix blob2str() with UTF-16 encodings

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -1391,6 +1391,8 @@ blob2str({blob} [, {options}])				*blob2str()*
 <
 		Return type: list<string>
 
+		If `iconv` is not available, the encoding conversion will fail
+		silently, and the original, unconverted text will be returned.
 
 browse({save}, {title}, {initdir}, {default})		*browse()*
 		Put up a file requester.  This only works when "has("browse")"

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -1391,8 +1391,8 @@ blob2str({blob} [, {options}])				*blob2str()*
 <
 		Return type: list<string>
 
-		If `iconv` is not available, the encoding conversion will fail
-		silently, and the original, unconverted text will be returned.
+		If `iconv` is not available and the encoding cannot be converted
+		using built-in conversions, an error will be reported.
 
 browse({save}, {title}, {initdir}, {default})		*browse()*
 		Put up a file requester.  This only works when "has("browse")"

--- a/src/mbyte.c
+++ b/src/mbyte.c
@@ -5160,14 +5160,8 @@ convert_setup_ext(
 
     from_prop = enc_canon_props(from);
     to_prop = enc_canon_props(to);
-    if (from_unicode_is_utf8)
-	from_is_utf8 = from_prop == ENC_UNICODE;  // Only exact UTF-8, not UTF-16 etc
-    else
-	from_is_utf8 = from_prop == ENC_UNICODE;
-    if (to_unicode_is_utf8)
-	to_is_utf8 = to_prop == ENC_UNICODE;  // Only exact UTF-8, not UTF-16 etc
-    else
-	to_is_utf8 = to_prop == ENC_UNICODE;
+    from_is_utf8 = from_prop == ENC_UNICODE;
+    to_is_utf8 = to_prop == ENC_UNICODE;
 
     if ((from_prop & ENC_LATIN1) && to_is_utf8)
     {

--- a/src/mbyte.c
+++ b/src/mbyte.c
@@ -5160,8 +5160,14 @@ convert_setup_ext(
 
     from_prop = enc_canon_props(from);
     to_prop = enc_canon_props(to);
-    from_is_utf8 = from_prop == ENC_UNICODE;
-    to_is_utf8 = to_prop == ENC_UNICODE;
+    if (from_unicode_is_utf8)
+	from_is_utf8 = from_prop & ENC_UNICODE;
+    else
+	from_is_utf8 = from_prop == ENC_UNICODE;
+    if (to_unicode_is_utf8)
+	to_is_utf8 = to_prop & ENC_UNICODE;
+    else
+	to_is_utf8 = to_prop == ENC_UNICODE;
 
     if ((from_prop & ENC_LATIN1) && to_is_utf8)
     {

--- a/src/mbyte.c
+++ b/src/mbyte.c
@@ -5161,11 +5161,11 @@ convert_setup_ext(
     from_prop = enc_canon_props(from);
     to_prop = enc_canon_props(to);
     if (from_unicode_is_utf8)
-	from_is_utf8 = from_prop & ENC_UNICODE;
+	from_is_utf8 = from_prop == ENC_UNICODE;  // Only exact UTF-8, not UTF-16 etc
     else
 	from_is_utf8 = from_prop == ENC_UNICODE;
     if (to_unicode_is_utf8)
-	to_is_utf8 = to_prop & ENC_UNICODE;
+	to_is_utf8 = to_prop == ENC_UNICODE;  // Only exact UTF-8, not UTF-16 etc
     else
 	to_is_utf8 = to_prop == ENC_UNICODE;
 

--- a/src/strings.c
+++ b/src/strings.c
@@ -1450,7 +1450,7 @@ f_blob2str(typval_T *argvars, typval_T *rettv)
 	    if (from_encoding != NULL)
 	    {
 		// Use raw encoding name for convert_string to preserve encoding details
-		converted_str = convert_string(str, 
+		converted_str = convert_string(str,
 			from_encoding_raw ? from_encoding_raw : from_encoding, p_enc);
 		vim_free(str);
 		if (converted_str == NULL)

--- a/src/strings.c
+++ b/src/strings.c
@@ -1431,7 +1431,9 @@ f_blob2str(typval_T *argvars, typval_T *rettv)
     }
 
     // Special handling for UTF-16/UCS-2/UTF-32/UCS-4 encodings: convert entire blob before splitting by newlines
-    int from_prop = enc_canon_props(from_encoding);
+    int from_prop = 0;
+    if (from_encoding != NULL)
+	from_prop = enc_canon_props(from_encoding);
     if (from_encoding != NULL && (from_prop & (ENC_2BYTE | ENC_4BYTE | ENC_2WORD)))
     {
 	// Build a temporary buffer from the blob as a whole

--- a/src/strings.c
+++ b/src/strings.c
@@ -1350,7 +1350,12 @@ append_converted_string_to_list(
 		    vim_free(converted);
 		    return; // Stop processing
 		}
-		list_append_string(list, line, -1);
+		if (list_append_string(list, line, -1) == NULL)
+		{
+		    vim_free(line);
+		    vim_free(converted);
+		    return; // Stop processing on append failure
+		}
 		vim_free(line);
 	    }
 	    else

--- a/src/strings.c
+++ b/src/strings.c
@@ -1364,8 +1364,7 @@ f_blob2str(typval_T *argvars, typval_T *rettv)
     if (from_encoding != NULL && STRCMP(from_encoding, "none") == 0)
     {
 	validate_utf8 = FALSE;
-	vim_free(from_encoding);
-	from_encoding = NULL;
+	VIM_CLEAR(from_encoding);
 	VIM_CLEAR(from_encoding_raw);
     }
 

--- a/src/strings.c
+++ b/src/strings.c
@@ -1318,18 +1318,18 @@ f_blob2str(typval_T *argvars, typval_T *rettv)
 		if (from_encoding_raw != NULL)
 		{
 		    char_u *s = enc_skipped;
-		    char_u *d = from_encoding_raw;
+		    char_u *pe = from_encoding_raw;
 
 		    // Convert to lowercase and replace '_' with '-'
 		    while (*s != NUL)
 		    {
 			if (*s == '_')
-			    *d++ = '-';
+			    *pe++ = '-';
 			else
-			    *d++ = TOLOWER_ASC(*s);
+			    *pe++ = TOLOWER_ASC(*s);
 			++s;
 		    }
-		    *d = NUL;
+		    *pe = NUL;
 
 		    // Add hyphen before digit: "ucs2be" -> "ucs-2be", "utf16le" -> "utf-16le"
 		    char_u *p = from_encoding_raw;

--- a/src/strings.c
+++ b/src/strings.c
@@ -1353,6 +1353,13 @@ append_converted_string_to_list(
 		list_append_string(list, line, -1);
 		vim_free(line);
 	    }
+	    else
+	    {
+		// Allocation failure: report error and stop processing
+		semsg(_(e_out_of_memory));
+		vim_free(converted);
+		return;
+	    }
 
 	    if (*p == NL)
 		p++;

--- a/src/strings.c
+++ b/src/strings.c
@@ -1353,8 +1353,7 @@ f_blob2str(typval_T *argvars, typval_T *rettv)
 	validate_utf8 = FALSE;
 	vim_free(from_encoding);
 	from_encoding = NULL;
-	vim_free(from_encoding_raw);
-	from_encoding_raw = NULL;
+	VIM_CLEAR(from_encoding_raw);
     }
 
     // Special handling for UTF-16/UCS-2/UTF-32/UCS-4 encodings: convert entire blob before splitting by newlines
@@ -1381,7 +1380,7 @@ f_blob2str(typval_T *argvars, typval_T *rettv)
 	vimconv_T vimconv;
 	vimconv.vc_type = CONV_NONE;
 	// Use raw encoding name for iconv to preserve endianness (utf-16be vs utf-16)
-	if (convert_setup(&vimconv, from_encoding_raw ? from_encoding_raw : from_encoding, p_enc) == FAIL)
+	if (convert_setup_ext(&vimconv, from_encoding_raw ? from_encoding_raw : from_encoding, FALSE, p_enc, FALSE) == FAIL)
 	{
 	    ga_clear(&blob_ga);
 	    semsg(_(e_str_encoding_from_failed), from_encoding);

--- a/src/strings.c
+++ b/src/strings.c
@@ -1416,6 +1416,12 @@ f_blob2str(typval_T *argvars, typval_T *rettv)
 		// For iconv, preserve the endianness suffix by creating a normalized
 		// version with hyphens: "ucs2be" -> "ucs-2be", "utf16le" -> "utf-16le"
 		from_encoding_raw = normalize_encoding_name(enc_skipped);
+		if (from_encoding_raw == NULL)
+		{
+		    emsg(_(e_outofmem));
+		    VIM_CLEAR(from_encoding);
+		    return;
+		}
 	    }
 	}
     }

--- a/src/strings.c
+++ b/src/strings.c
@@ -1439,7 +1439,7 @@ f_blob2str(typval_T *argvars, typval_T *rettv)
 	// Build a temporary buffer from the blob as a whole
 	// Don't use string_from_blob() because it treats NUL as line separator
 	garray_T blob_ga;
-	int nul_size = (from_prop & (ENC_4BYTE)) ? 4 : 2;
+	int nul_size = (from_prop & ENC_4BYTE) ? 4 : 2;
 	ga_init2(&blob_ga, 1, blen + nul_size);
 	for (long i = 0; i < blen; i++)
 	    ga_append(&blob_ga, (int)(unsigned char)blob_get(blob, i));

--- a/src/strings.c
+++ b/src/strings.c
@@ -1350,7 +1350,7 @@ append_converted_string_to_list(
 		    vim_free(converted);
 		    return; // Stop processing
 		}
-		if (list_append_string(list, line, -1) == NULL)
+		if (list_append_string(list, line, -1) == FAIL)
 		{
 		    vim_free(line);
 		    vim_free(converted);
@@ -1361,7 +1361,7 @@ append_converted_string_to_list(
 	    else
 	    {
 		// Allocation failure: report error and stop processing
-		semsg(_(e_out_of_memory));
+		emsg(_(e_out_of_memory));
 		vim_free(converted);
 		return;
 	    }
@@ -1430,7 +1430,7 @@ f_blob2str(typval_T *argvars, typval_T *rettv)
 		from_encoding_raw = normalize_encoding_name(enc_skipped);
 		if (from_encoding_raw == NULL)
 		{
-		    emsg(_(e_outofmem));
+		    emsg(_(e_out_of_memory));
 		    VIM_CLEAR(from_encoding);
 		    return;
 		}

--- a/src/testdir/test_blob.vim
+++ b/src/testdir/test_blob.vim
@@ -898,4 +898,44 @@ func Test_blob2str_empty_line()
   call assert_equal(['Hello', '', 'World!'], blob2str(b))
 endfunc
 
+func Test_blob2str_multi_byte_encodings()
+  " UTF-16LE: "Hello" = 48 00 65 00 6C 00 6C 00 6F 00
+  call assert_equal(['Hello'], blob2str(0z480065006C006C006F00, {'encoding': 'utf-16le'}))
+  call assert_equal(['Hello'], blob2str(0z480065006C006C006F00, {'encoding': 'utf16le'}))
+
+  " UTF-16BE: "Hello" = 00 48 00 65 00 6C 00 6C 00 6F
+  call assert_equal(['Hello'], blob2str(0z00480065006C006C006F, {'encoding': 'utf-16be'}))
+  call assert_equal(['Hello'], blob2str(0z00480065006C006C006F, {'encoding': 'utf16be'}))
+
+  " UCS-2LE: "Hello" = 48 00 65 00 6C 00 6C 00 6F 00
+  call assert_equal(['Hello'], blob2str(0z480065006C006C006F00, {'encoding': 'ucs-2le'}))
+  call assert_equal(['Hello'], blob2str(0z480065006C006C006F00, {'encoding': 'ucs2le'}))
+
+  " UCS-2BE: "Hello" = 00 48 00 65 00 6C 00 6C 00 6F
+  call assert_equal(['Hello'], blob2str(0z00480065006C006C006F, {'encoding': 'ucs-2be'}))
+  call assert_equal(['Hello'], blob2str(0z00480065006C006C006F, {'encoding': 'ucs2be'}))
+
+  " UTF-32LE: "Hi" = 48 00 00 00 69 00 00 00
+  call assert_equal(['Hi'], blob2str(0z4800000069000000, {'encoding': 'utf-32le'}))
+  call assert_equal(['Hi'], blob2str(0z4800000069000000, {'encoding': 'utf32le'}))
+
+  " UTF-32BE: "Hi" = 00 00 00 48 00 00 00 69
+  call assert_equal(['Hi'], blob2str(0z0000004800000069, {'encoding': 'utf-32be'}))
+  call assert_equal(['Hi'], blob2str(0z0000004800000069, {'encoding': 'utf32be'}))
+
+  " UCS-4LE: "Hi" = 48 00 00 00 69 00 00 00
+  call assert_equal(['Hi'], blob2str(0z4800000069000000, {'encoding': 'ucs-4le'}))
+  call assert_equal(['Hi'], blob2str(0z4800000069000000, {'encoding': 'ucs4le'}))
+
+  " UCS-4BE: "Hi" = 00 00 00 48 00 00 00 69
+  call assert_equal(['Hi'], blob2str(0z0000004800000069, {'encoding': 'ucs-4be'}))
+  call assert_equal(['Hi'], blob2str(0z0000004800000069, {'encoding': 'ucs4be'}))
+
+  " UTF-16LE with newlines: "Hi\nBye" = 48 00 69 00 0A 00 42 00 79 00 65 00
+  call assert_equal(['Hi', 'Bye'], blob2str(0z48006900.0A004200.79006500, {'encoding': 'utf-16le'}))
+
+  " UTF-32LE with newlines: "A\nB" = 41 00 00 00 0A 00 00 00 42 00 00 00
+  call assert_equal(['A', 'B'], blob2str(0z41000000.0A000000.42000000, {'encoding': 'utf-32le'}))
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -4556,6 +4556,13 @@ func Test_blob2str()
     call assert_fails("call blob2str(0z6162, [])", 'E1206: Dictionary required for argument 2')
     call assert_fails("call blob2str(0z6162, {'encoding': []})", 'E730: Using a List as a String')
     call assert_fails("call blob2str(0z6162, {'encoding': 'ab12xy'})", 'E1515: Unable to convert from ''ab12xy'' encoding')
+
+    #" UTF-16LE encoding
+    call assert_equal(['Hello'], blob2str(0z480065006C006C006F00, {'encoding': 'utf-16le'}))
+    call assert_equal(['Hello'], blob2str(0z480065006C006C006F00, {'encoding': 'utf16le'}))
+    #" UCS-2LE encoding
+    call assert_equal(['Hello'], blob2str(0z480065006C006C006F00, {'encoding': 'ucs-2le'}))
+    call assert_equal(['Hello'], blob2str(0z480065006C006C006F00, {'encoding': 'ucs2le'}))
   END
   call v9.CheckLegacyAndVim9Success(lines)
 endfunc


### PR DESCRIPTION
`blob2str()` function did not properly handle UTF-16/UCS-2/UTF-32/UCS-4 encodings with endianness suffixes (e.g., `utf-16le`, `utf-16be`, `ucs-2le`). The encoding name was canonicalized too aggressively, losing the endianness information needed by iconv.

This pull-request include few fixes.

- Preserve the raw encoding name with endianness suffix for iconv calls
- Normalize encoding names properly: `"ucs2be"` → `"ucs-2be"`, `"utf16le"` → `"utf-16le"`
- For multi-byte encodings (UTF-16/32, UCS-2/4), convert the entire blob first, then split by newlines

I considered using `enc_canonize()`, but it converts BE encodings to canonical names without the endianness suffix (e.g., `"utf16be"` → `"utf-16"`, `"ucs2be"` → `"ucs-2"`), which loses the information needed by iconv.

`convert_string()` cannot handle UTF-16 because it uses `string_convert()` which expects NUL-terminated strings. UTF-16 contains `0x00` bytes within characters (e.g., "H" = `0x48 0x00`), causing premature termination. Therefore, for UTF-16/32 encodings, the fix uses `string_convert_ext()` with an explicit input length to convert the entire blob at once.

The code appends two NUL bytes (`ga_append(&blob_ga, NUL)` twice) because UTF-16 requires a 2-byte NUL terminator (`0x00 0x00`), not a single-byte NUL.


- src/strings.c: Add `from_encoding_raw` to preserve endianness, special handling for UTF-16/32 and UCS-2/4
- src/mbyte.c: Fix `convert_setup_ext()` to use `== ENC_UNICODE` instead of `& ENC_UNICODE`. The bitwise AND was incorrectly treating UTF-16/UCS-2 (which have `ENC_UNICODE + ENC_2BYTE` etc.) as UTF-8, causing iconv setup to be skipped.

Closes https://github.com/vim/vim/issues/19198
