### PR TITLE
runtime(filetype): NetLinx

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -2373,6 +2373,9 @@ const ft_from_ext = {
   # N1QL
   "n1ql": "n1ql",
   "nql": "n1ql",
+  # NetLinx
+  "axs": "netlinx",
+  "axi": "netlinx",
   # Nickel
   "ncl": "nickel",
   # Nim file

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -578,6 +578,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     ncf: ['file.ncf'],
     neomuttlog: ['/home/user/.neomuttdebug1'],
     neomuttrc: ['Neomuttrc', '.neomuttrc', '.neomuttrc-file', '/.neomutt/neomuttrc', '/.neomutt/neomuttrc-file', 'Neomuttrc', 'Neomuttrc-file', 'any/.neomutt/neomuttrc', 'any/.neomutt/neomuttrc-file', 'neomuttrc', 'neomuttrc-file' ],
+    netlinx: ['file.axs', 'file.axi'],
     netrc: ['.netrc'],
     nginx: ['file.nginx', 'nginxfile.conf', 'filenginx.conf', 'any/etc/nginx/file', 'any/usr/local/nginx/conf/file', 'any/nginx/file.conf'],
     nickel: ['file.ncl'],


### PR DESCRIPTION
Adds support for detection of NetLinx source (`*.axs`) and include (`*.axi`) files.

Language spec: https://www.amx.com/en/site_elements/amx-language-reference-guide-netlinx-programming-language

Linguist reference: https://github.com/github-linguist/linguist/blob/e51c227048a02a8a1b0fae6e72214e7c5f327c73/lib/linguist/languages.yml#L4992-L5000

