### PR TITLE
runtime(rustfmt): Recover accidentally deleted code.

### DIFF
--- a/runtime/autoload/rustfmt.vim
+++ b/runtime/autoload/rustfmt.vim
@@ -69,6 +69,12 @@ function! s:RustfmtWriteMode()
 endfunction
 
 function! s:RustfmtConfigOptions()
+    let default = '--edition 2018'
+
+    if !get(g:, 'rustfmt_find_toml', 0)
+        return default
+    endif
+
     let l:rustfmt_toml = findfile('rustfmt.toml', expand('%:p:h') . ';')
     if l:rustfmt_toml !=# ''
         return '--config-path '.shellescape(fnamemodify(l:rustfmt_toml, ":p"))


### PR DESCRIPTION
':RustFmt' will report this error.

```vim
Error detected while processing function rustfmt#Format[1]..<SNR>111_RustfmtCommand[2]..<SNR>111_RustfmtConfigOptions:
line   12:
E121: Undefined variable: default
rust.vim: was not able to parse rustfmt messages. Here is the raw output:

Unrecognized option: 'write-mode'
Error detected while processing function rustfmt#Format[1]..<SNR>111_RunRustfmt:
line  104:
E776: No location list
Press ENTER or type command to continue
```

<img width="2220" height="649" alt="image" src="https://github.com/user-attachments/assets/f7c5b1f8-93ae-4435-b1ff-82c906a0e96a" />

I search in blame and found 'default'  variable was removed in this pr https://github.com/vim/vim/pull/18650,  IMO this part of the code wouldn't affect the original meaning this pr, so i added it back.
