### PR TITLE
respect lpDx advance widths in DirectX rendering

### DIFF
--- a/src/gui_dwrite.cpp
+++ b/src/gui_dwrite.cpp
@@ -21,7 +21,6 @@
 #include <windows.h>
 #include <crtdbg.h>
 #include <assert.h>
-#include <stdio.h>
 #include <math.h>
 #include <d2d1.h>
 #include <d2d1helper.h>


### PR DESCRIPTION
## Problem

When using DirectX rendering (`set renderoptions=type:directx`), character positions can become misaligned with what Vim expects.

<img width="1185" height="487" alt="image" src="https://github.com/user-attachments/assets/0eae488b-13fb-4f22-b2ca-f20c84b4e5f8" />

## Cause

The Win32 GUI computes advance widths for each character as the `lpDx` array and passes it to `DWriteContext::DrawText()`. These values represent the "correct" character positions as determined by Vim, based on `wcwidth()` and `gui.char_width`.

However, `lpDx` was not passed through `TextRendererContext` to `AdjustedGlyphRun`. As a result, the DirectX side ignored `lpDx` and computed advance widths independently using `adjustToCell()` based on font metrics.

In short: "`lpDx` was passed but never used."

This caused a mismatch: Vim manages cursor positions and redraw regions based on `lpDx`, but DirectX rendered characters based on font metrics. For fonts where glyph widths differ from Vim's cell width (e.g., UbuntuMono), characters would progressively drift out of alignment.

## Solution

Pass `lpDx` through `TextRendererContext` to `AdjustedGlyphRun`, and use the advance widths provided by Vim instead of computing them from font metrics.

<img width="1185" height="692" alt="image" src="https://github.com/user-attachments/assets/30204fdd-4c75-4322-8da5-4d8f47669d49" />
