### PR TITLE
runtime(haskellcomplete): fix undefined buffer variable.

### DIFF
--- a/runtime/autoload/haskellcomplete.vim
+++ b/runtime/autoload/haskellcomplete.vim
@@ -15,12 +15,6 @@
 "   https://downloads.haskell.org/~ghc/8.4.3/docs/html/users_guide/flags.html
 
 
-
-" Available completions
-let b:completingLangExtension = 0
-let b:completingOptionsGHC    = 0
-let b:completingModule        = 0
-
 function! haskellcomplete#Complete(findstart, base)
     if a:findstart
         let l:line = getline('.')
@@ -52,7 +46,7 @@ function! haskellcomplete#Complete(findstart, base)
         return start
     endif
 
-    if b:completingLangExtension
+    if get(b:, 'completingLangExtension', 0)
         if a:base ==? ""
             " Return all possible Lang extensions
             return s:langExtensions
@@ -68,7 +62,7 @@ function! haskellcomplete#Complete(findstart, base)
         endif
 
 
-    elseif b:completingOptionsGHC
+    elseif get(b:, 'completingOptionsGHC', 0)
         if a:base ==? ""
             " Return all possible GHC options
             return s:optionsGHC
@@ -84,7 +78,7 @@ function! haskellcomplete#Complete(findstart, base)
         endif
 
 
-    elseif b:completingModule
+    elseif get(b:, 'completingModule', 0)
         if a:base ==? ""
             " Return all possible modules
             return s:commonModules


### PR DESCRIPTION
When you edit one .hs file and use omnifunc completion, and opening another .hs file and using omnifunc completion will be report this error.
<img width="563" height="74" alt="image" src="https://github.com/user-attachments/assets/bc97d574-1ce5-4293-bc8a-22aa63e26898" />

The .vim in runtimepath 'autoload' just source once and then caches it. So, these top-level buffer variables undefined in another buffer.