### PR TITLE
Vim9: No errors about if syntax inside def

### DIFF
--- a/src/testdir/test_vim9_script.vim
+++ b/src/testdir/test_vim9_script.vim
@@ -2002,7 +2002,7 @@ def Test_if_elseif_else_fails()
       else
       endif
   END
-  v9.CheckDefFailure(lines, 'E583:')
+  v9.CheckSourceDefFailure(lines, 'E583:')
 
   lines =<< trim END
       var a = 3
@@ -2012,7 +2012,7 @@ def Test_if_elseif_else_fails()
       else
       endif
   END
-  v9.CheckDefFailure(lines, 'E584:')
+  v9.CheckSourceDefFailure(lines, 'E584:')
 
   lines =<< trim END
       var cond = true

--- a/src/testdir/test_vim9_script.vim
+++ b/src/testdir/test_vim9_script.vim
@@ -1995,6 +1995,25 @@ def Test_if_elseif_else_fails()
   END
   v9.CheckDefFailure(lines, 'E488:')
 
+
+  lines =<< trim END
+      if true
+      else
+      else
+      endif
+  END
+  v9.CheckDefFailure(lines, 'E583:')
+
+  lines =<< trim END
+      var a = 3
+      if a == 2
+      else
+      elseif true
+      else
+      endif
+  END
+  v9.CheckDefFailure(lines, 'E584:')
+
   lines =<< trim END
       var cond = true
       if cond

--- a/src/vim9cmds.c
+++ b/src/vim9cmds.c
@@ -596,6 +596,11 @@ compile_elseif(char_u *arg, cctx_T *cctx)
 	emsg(_(e_elseif_without_if));
 	return NULL;
     }
+    if (scope->se_u.se_if.is_seen_else)
+    {
+	emsg(_(e_elseif_after_else));
+	return NULL;
+    }
     unwind_locals(cctx, scope->se_local_count, TRUE);
     if (!cctx->ctx_had_return && !cctx->ctx_had_throw)
 	// the previous if block didn't end in a "return" or a "throw"
@@ -743,6 +748,11 @@ compile_else(char_u *arg, cctx_T *cctx)
     if (scope == NULL || scope->se_type != IF_SCOPE)
     {
 	emsg(_(e_else_without_if));
+	return NULL;
+    }
+    if (scope->se_u.se_if.is_seen_else)
+    {
+	emsg(_(e_multiple_else));
 	return NULL;
     }
     unwind_locals(cctx, scope->se_local_count, TRUE);


### PR DESCRIPTION
### Case 1

- "E584: :elseif after :else" does not occur. SEGF almost always occurs
```vim
def Aaa()
    var a = 3
    if a == 2
    else
    elseif true
    else
    endif
enddef
```

### Case 2

- "E583: Multiple :else" does not occur.
```vim
def Aaa()
    if true
    else
    else
    endif
enddef
```

Note:
This issue is reported by @todashuta at vim-jp/issue https://github.com/vim-jp/issues/issues/1455 (Note: Japanese lang.)