### PR TITLE
Fix Rust indentation when a string literal contains "if"

### DIFF
--- a/runtime/indent/rust.vim
+++ b/runtime/indent/rust.vim
@@ -141,14 +141,15 @@ function GetRustIndent(lnum)
     if l:standalone_open || l:standalone_close || l:standalone_where
         let l:orig_line = line('.')
         let l:orig_col = col('.')
-        while 1
+        " Limit to 10 iterations as a failsafe against endless looping.
+        for l:i in range(10)
             " ToDo: we can search for more items than 'fn' and 'if'.
             let [l:found_line, l:col, l:submatch] =
                         \ searchpos('\<\(fn\|if\)\>', 'bWp')
             if l:found_line ==# 0 || !s:is_string_comment(l:found_line, l:col)
                 break
             endif
-        endwhile
+        endfor
         call cursor(l:orig_line, l:orig_col)
         if l:found_line !=# 0
             " Now we count the number of '{' and '}' in between the match

--- a/runtime/indent/rust.vim
+++ b/runtime/indent/rust.vim
@@ -139,9 +139,17 @@ function GetRustIndent(lnum)
     let l:standalone_close = line =~# '\V\^\s\*}\s\*\$'
     let l:standalone_where = line =~# '\V\^\s\*where\s\*\$'
     if l:standalone_open || l:standalone_close || l:standalone_where
-        " ToDo: we can search for more items than 'fn' and 'if'.
-        let [l:found_line, l:col, l:submatch] =
-                    \ searchpos('\<\(fn\)\|\(if\)\>', 'bnWp')
+        let l:orig_line = line('.')
+        let l:orig_col = col('.')
+        while 1
+            " ToDo: we can search for more items than 'fn' and 'if'.
+            let [l:found_line, l:col, l:submatch] =
+                        \ searchpos('\<\(fn\|if\)\>', 'bWp')
+            if l:found_line ==# 0 || !s:is_string_comment(l:found_line, l:col)
+                break
+            endif
+        endwhile
+        call cursor(l:orig_line, l:orig_col)
         if l:found_line !=# 0
             " Now we count the number of '{' and '}' in between the match
             " locations and the current line (there is probably a better

--- a/runtime/indent/rust.vim
+++ b/runtime/indent/rust.vim
@@ -141,15 +141,21 @@ function GetRustIndent(lnum)
     if l:standalone_open || l:standalone_close || l:standalone_where
         let l:orig_line = line('.')
         let l:orig_col = col('.')
-        " Limit to 10 iterations as a failsafe against endless looping.
-        for l:i in range(10)
+        let l:i = 0
+        while 1
             " ToDo: we can search for more items than 'fn' and 'if'.
             let [l:found_line, l:col, l:submatch] =
                         \ searchpos('\<\(fn\|if\)\>', 'bWp')
             if l:found_line ==# 0 || !s:is_string_comment(l:found_line, l:col)
                 break
             endif
-        endfor
+            let l:i += 1
+            " Limit to 10 iterations as a failsafe against endless looping.
+            if l:i >= 10
+                let l:found_line = 0
+                break
+            endif
+        endwhile
         call cursor(l:orig_line, l:orig_col)
         if l:found_line !=# 0
             " Now we count the number of '{' and '}' in between the match

--- a/runtime/indent/testdir/rust.in
+++ b/runtime/indent/testdir/rust.in
@@ -40,3 +40,11 @@ fn main() {
     // file goes out of scope, and the "hello.txt" file gets closed
 }
 // END_INDENT
+
+// START_INDENT
+let x = "
+            if fn motif
+            ";
+            struct X {
+                        }
+// END_INDENT

--- a/runtime/indent/testdir/rust.ok
+++ b/runtime/indent/testdir/rust.ok
@@ -40,3 +40,11 @@ fn main() {
     // file goes out of scope, and the "hello.txt" file gets closed
 }
 // END_INDENT
+
+// START_INDENT
+let x = "
+            if fn motif
+            ";
+            struct X {
+}
+// END_INDENT


### PR DESCRIPTION
indent/rust.vim behaves incorrectly when a string literal contains the substring "if".

For example, in this code:

```rust
let x = "
            motif
";
struct X {
            }
```

indent/rust.vim thinks that the closing "}" should line up with "motif".

This patch fixes the issue by checking whether the "if" is in a string literal or comment before considering it to be a match for a subsequent brace (and also by requiring it to start on a word boundary).