### PR TITLE
runtime: remove myself as maintainer of make syntax

### DIFF
--- a/.github/MAINTAINERS
+++ b/.github/MAINTAINERS
@@ -586,7 +586,6 @@ runtime/syntax/m17ndb.vim				@dseomn
 runtime/syntax/m3build.vim				@dkearns
 runtime/syntax/m3quake.vim				@dkearns
 runtime/syntax/mailcap.vim				@dkearns
-runtime/syntax/make.vim					@rohieb
 runtime/syntax/mallard.vim				@jhradilek
 runtime/syntax/markdown.vim				@tpope
 runtime/syntax/mbsync.vim				@fymyte

--- a/runtime/syntax/make.vim
+++ b/runtime/syntax/make.vim
@@ -1,7 +1,6 @@
 " Vim syntax file
 " Language:	Makefile
-" Maintainer:	Roland Hieber <rohieb+vim-iR0jGdkV@rohieb.name>, <https://github.com/rohieb>
-" Previous Maintainer:	Claudio Fleiner <claudio@fleiner.com>
+" Previous Maintainer:	Claudio Fleiner <claudio@fleiner.com>, Roland Hieber <https://github.com/rohieb>
 " URL:		https://github.com/vim/vim/blob/master/runtime/syntax/make.vim
 " Last Change:	2022 Nov 06
 " 2025 Apr 15 by Vim project: rework Make flavor detection (#17089)


### PR DESCRIPTION
Sadly I'm not using Makefiles as much these days as I would like, and I feel like I cannot contribute enough time and expertise in the foreseeable future to continue maintainership.