### PR TITLE
runtime(doc): Hyperlink some List references

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -1338,8 +1338,8 @@ bindtextdomain({package}, {path})			*bindtextdomain()*
 
 
 blob2list({blob})					*blob2list()*
-		Return a List containing the number value of each byte in Blob
-		{blob}.  Examples: >
+		Return a |List| containing the number value of each byte in
+		|Blob| {blob}.  Examples: >
 			blob2list(0z0102.0304)	returns [1, 2, 3, 4]
 			blob2list(0z)		returns []
 <		Returns an empty List on error.  |list2blob()| does the
@@ -1352,7 +1352,7 @@ blob2list({blob})					*blob2list()*
 
 
 blob2str({blob} [, {options}])				*blob2str()*
-		Return a List of Strings in the current 'encoding' by
+		Return a |List| of |String|s in the current 'encoding' by
 		converting the bytes in {blob} into characters.
 
 		Each <NL> byte in the blob is interpreted as the end of a
@@ -2440,7 +2440,7 @@ diff({fromlist}, {tolist} [, {options}])		*diff()*
 							*E106*
 		The optional "output" item in {options} specifies the returned
 		diff format.  The following values are supported:
-		    indices	Return a List of the starting and ending
+		    indices	Return a |List| of the starting and ending
 				indices and a count of the strings in each
 				diff hunk.
 		    unified	Return the unified diff output as a String.
@@ -2565,9 +2565,10 @@ digraph_get({chars})					*digraph_get()* *E1214*
 
 
 digraph_getlist([{listall}])				*digraph_getlist()*
-		Return a list of digraphs.  If the {listall} argument is given
-		and it is TRUE, return all digraphs, including the default
-		digraphs.  Otherwise, return only user-defined digraphs.
+		Return a |List| of digraphs.  If the {listall} argument is
+		given and it is TRUE, return all digraphs, including the
+		default digraphs.  Otherwise, return only user-defined
+		digraphs.
 
 		The characters will be converted from Unicode to 'encoding'
 		when needed.  This does require the conservation to be
@@ -4347,9 +4348,9 @@ getcmdwintype()						*getcmdwintype()*
 
 
 getcompletion({pat}, {type} [, {filtered}])		*getcompletion()*
-		Return a list of command-line completion matches.  The String
-		{type} argument specifies what for.  The following completion
-		types are supported:
+		Return a |List| of command-line completion matches.  The
+		String {type} argument specifies what for.  The following
+		completion types are supported:
 
 		arglist		file names in argument list
 		augroup		autocmd groups
@@ -4889,7 +4890,7 @@ getpos({expr})						*getpos()*
 		'> is a large number equal to |v:maxcol|.
 		A very large column number equal to |v:maxcol| can be returned,
 		in which case it means "after the end of the line".
-		If {expr} is invalid, returns a list with all zeros.
+		If {expr} is invalid, returns a |List| with all zeros.
 
 		This can be used to save and restore the position of a mark: >
 			let save_a_mark = getpos("'a")
@@ -5075,7 +5076,7 @@ getreginfo([{regname}])					*getreginfo()*
 
 
 getregion({pos1}, {pos2} [, {opts}])			*getregion()*
-		Returns the list of strings from {pos1} to {pos2} from a
+		Returns the |List| of strings from {pos1} to {pos2} from a
 		buffer.
 
 		{pos1} and {pos2} must both be |List|s with four numbers.
@@ -5135,7 +5136,7 @@ getregion({pos1}, {pos2} [, {opts}])			*getregion()*
 
 
 getregionpos({pos1}, {pos2} [, {opts}])			*getregionpos()*
-		Same as |getregion()|, but returns a list of positions
+		Same as |getregion()|, but returns a |List| of positions
 		describing the buffer text segments bound by {pos1} and
 		{pos2}.
 		The segments are a pair of positions for every line: >
@@ -5822,8 +5823,8 @@ hlexists({name})					*hlexists()*
 
 
 hlget([{name} [, {resolve}]])				*hlget()*
-		Returns a List of all the highlight group attributes.  If the
-		optional {name} is specified, then returns a List with only
+		Returns a |List| of all the highlight group attributes.  If the
+		optional {name} is specified, then returns a |List| with only
 		the attributes of the specified highlight group.  Returns an
 		empty List if the highlight group {name} is not present.
 
@@ -8672,7 +8673,7 @@ readblob({fname} [, {offset} [, {size}]])		*readblob()*
 
 
 readdir({directory} [, {expr} [, {dict}]])		*readdir()*
-		Return a list with file and directory names in {directory}.
+		Return a |List| with file and directory names in {directory}.
 		You can also use |glob()| if you don't need to do complicated
 		things, such as limiting the number of matches.
 		The list will be sorted (case sensitive), see the {dict}
@@ -8732,7 +8733,7 @@ readdir({directory} [, {expr} [, {dict}]])		*readdir()*
 
 readdirex({directory} [, {expr} [, {dict}]])		*readdirex()*
 		Extended version of |readdir()|.
-		Return a list of Dictionaries with file and directory
+		Return a |List| of |Dictionaries| with file and directory
 		information in {directory}.
 		This is useful if you want to get the attributes of file and
 		directory at the same time as getting a list of a directory.
@@ -9813,7 +9814,7 @@ server2client({clientid}, {string})			*server2client()*
 
 
 serverlist()						*serverlist()*
-		Return a list of available server names, one per line.
+		Return a |List| of available server names, one per line.
 		When there are no servers or the information is not available
 		an empty string is returned.  See also |clientserver|.
 		{only available when compiled with the |+clientserver| feature}
@@ -11014,8 +11015,8 @@ str2float({string} [, {quoted}])			*str2float()*
 
 
 str2list({string} [, {utf8}])				*str2list()*
-		Return a list containing the number values which represent
-		each character in String {string}.  Examples: >
+		Return a |List| containing the number values which represent
+		each character in |String| {string}.  Examples: >
 			str2list(" ")		returns [32]
 			str2list("ABC")		returns [65, 66, 67]
 <		|list2str()| does the opposite.
@@ -11493,7 +11494,7 @@ substitute({string}, {pat}, {sub}, {flags})		*substitute()*
 
 
 swapfilelist()						*swapfilelist()*
-		Returns a list of swap file names, like what "vim -r" shows.
+		Returns a |List| of swap file names, like what "vim -r" shows.
 		See the |-r| command argument.  The 'directory' option is used
 		for the directories to inspect.  If you only want to get a
 		list of swap files in the current directory then temporarily
@@ -11977,7 +11978,7 @@ test_ functions are documented here: |test-functions-details|
 
 
 timer_info([{id}])					*timer_info()*
-		Return a list with information about timers.
+		Return a |List| with information about timers.
 		When {id} is given only information about this timer is
 		returned.  When timer {id} does not exist an empty list is
 		returned.
@@ -12665,8 +12666,8 @@ win_gotoid({expr})					*win_gotoid()*
 
 
 win_id2tabwin({expr})					*win_id2tabwin()*
-		Return a list with the tab number and window number of window
-		with ID {expr}: [tabnr, winnr].
+		Return a |List| with the tab number and window number of
+		window with ID {expr}: [tabnr, winnr].
 		Return [0, 0] if the window cannot be found.
 
 		Can also be used as a |method|: >

--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -1203,7 +1203,7 @@ On the second invocation the arguments are:
    a:base	the text with which matches should match; the text that was
 		located in the first call (can be empty)
 
-The function must return a List with the matching words.  These matches
+The function must return a |List| with the matching words.  These matches
 usually include the "a:base" text.  When there are no matches return an empty
 List.  Note that the cursor may have moved since the first invocation, the
 text may have been changed.

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3947,7 +3947,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	|String| and is the |:find| command argument.  The second argument is
 	a |Boolean| and is set to |v:true| when the function is called to get
 	a List of command-line completion matches for the |:find| command.
-	The function should return a List of strings.
+	The function should return a |List| of strings.
 
 	The function is called only once per |:find| command invocation.
 	The function can process all the directories specified in 'path'.
@@ -8880,7 +8880,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 			feature}
 	This option specifies a function to be used to perform tag searches
 	(including |taglist()|).
-	The function gets the tag pattern and should return a List of matching
+	The function gets the tag pattern and should return a |List| of matching
 	tags.  See |tag-function| for an explanation of how to write the
 	function and an example.  The value can be the name of a function, a
 	|lambda| or a |Funcref|.  See |option-value-function| for more

--- a/runtime/doc/popup.txt
+++ b/runtime/doc/popup.txt
@@ -474,7 +474,7 @@ popup_hide({id})						*popup_hide()*
 
 
 popup_list()						 *popup_list()*
-		Return a List with the |window-ID| of all existing popups.
+		Return a |List| with the |window-ID| of all existing popups.
 
 		Return type: list<number> or list<any>
 

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -2403,7 +2403,7 @@ a common parent directory.
 
 The displayed text can be customized by setting the 'quickfixtextfunc' option
 to a Vim function.  This function will be called with a dict argument and
-should return a List of strings to be displayed in the quickfix or location
+should return a |List| of strings to be displayed in the quickfix or location
 list window.  The dict argument will have the following fields:
 
     quickfix	set to 1 when called for a quickfix list and 0 when called for

--- a/runtime/doc/sign.txt
+++ b/runtime/doc/sign.txt
@@ -423,7 +423,7 @@ sign_define({list})
 		and a "name" item for the sign name.
 
 		Returns 0 on success and -1 on failure.  When the one argument
-		{list} is used, then returns a List of values one for each
+		{list} is used, then returns a |List| of values one for each
 		defined sign.
 
 		Examples: >
@@ -487,7 +487,7 @@ sign_getdefined([{name}])				*sign_getdefined()*
 
 
 sign_getplaced([{buf} [, {dict}]])			*sign_getplaced()*
-		Return a list of signs placed in a buffer or all the buffers.
+		Return a |List| of signs placed in a buffer or all the buffers.
 		This is similar to the |:sign-place-list| command.
 
 		If the optional buffer name {buf} is specified, then only the
@@ -659,7 +659,7 @@ sign_placelist({list})				*sign_placelist()*
 		If {id} refers to an existing sign, then the existing sign is
 		modified to use the specified {name} and/or {priority}.
 
-		Returns a List of sign identifiers.  If failed to place a
+		Returns a |List| of sign identifiers.  If failed to place a
 		sign, the corresponding list item is set to -1.
 
 		Examples: >
@@ -703,7 +703,7 @@ sign_undefine({list})
 		signs.  Each list item is the name of a sign.
 
 		Returns 0 on success and -1 on failure.  For the one argument
-		{list} call, returns a list of values one for each undefined
+		{list} call, returns a |List| of values one for each undefined
 		sign.
 
 		Examples: >
@@ -787,7 +787,7 @@ sign_unplacelist({list})				*sign_unplacelist()*
 		    id		sign identifier.  If not specified, then all
 				the signs in the specified group are removed.
 
-		Returns a List where an entry is set to 0 if the corresponding
+		Returns a |List| where an entry is set to 0 if the corresponding
 		sign was successfully removed or -1 on failure.
 
 		Example: >

--- a/runtime/doc/tagsrch.txt
+++ b/runtime/doc/tagsrch.txt
@@ -924,7 +924,7 @@ Note that when 'tagfunc' is set, the priority of the tags described in
 |tag-priority| does not apply.  Instead, the priority is exactly as the
 ordering of the elements in the list returned by the function.
 								*E987*
-The function should return a List of Dict entries.  Each Dict must at least
+The function should return a |List| of |Dict| entries.  Each Dict must at least
 include the following entries and each value must be a string:
 	name		Name of the tag.
 	filename	Name of the file where the tag is defined.  It is

--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -610,7 +610,7 @@ term_getaltscreen({buf})				*term_getaltscreen()*
 
 term_getansicolors({buf})				*term_getansicolors()*
 		Get the ANSI color palette in use by terminal {buf}.
-		Returns a List of length 16 where each element is a String
+		Returns a |List| of length 16 where each element is a String
 		representing a color in hexadecimal "#rrggbb" format.
 		Also see |term_setansicolors()| and |g:terminal_ansi_colors|.
 		If neither was used returns the default colors.
@@ -642,7 +642,7 @@ term_getattr({attr}, {what})				*term_getattr()*
 
 
 term_getcursor({buf})					*term_getcursor()*
-		Get the cursor position of terminal {buf}.  Returns a list
+		Get the cursor position of terminal {buf}.  Returns a |List|
 		with two numbers and a dictionary: [row, col, dict].
 
 		"row" and "col" are one based, the first screen cell is row
@@ -714,7 +714,7 @@ term_getscrolled({buf})					*term_getscrolled()*
 
 
 term_getsize({buf})					*term_getsize()*
-		Get the size of terminal {buf}.  Returns a list with two
+		Get the size of terminal {buf}.  Returns a |List| with two
 		numbers: [rows, cols].  This is the size of the terminal, not
 		the window containing the terminal.
 
@@ -775,7 +775,7 @@ term_gettty({buf} [, {input}])				*term_gettty()*
 
 
 term_list()						*term_list()*
-		Return a list with the buffer numbers of all buffers for
+		Return a |List| with the buffer numbers of all buffers for
 		terminal windows.
 
 		Return type: list<number> or list<any>
@@ -789,7 +789,7 @@ term_scrape({buf}, {row})				*term_scrape()*
 		line is used.  When {row} is invalid an empty string is
 		returned.
 
-		Return a List containing a Dict for each screen cell:
+		Return a |List| containing a |Dict| for each screen cell:
 		    "chars"	character(s) at the cell
 		    "fg"	foreground color as #rrggbb
 		    "bg"	background color as #rrggbb

--- a/runtime/doc/textprop.txt
+++ b/runtime/doc/textprop.txt
@@ -320,7 +320,7 @@ prop_find({props} [, {direction}])			*prop_find()*
 
 
 prop_list({lnum} [, {props}])				*prop_list()*
-		Returns a List with all the text properties in line {lnum}.
+		Returns a |List| with all the text properties in line {lnum}.
 
 		The following optional items are supported in {props}:
 		   bufnr	use this buffer instead of the current buffer
@@ -497,7 +497,7 @@ prop_type_get({name} [, {props}])			*prop_type_get()*
 
 
 prop_type_list([{props}])				*prop_type_list()*
-		Returns a list with all property type names.
+		Returns a |List| with all property type names.
 
 		{props} can contain a "bufnr" item.  When it is given, use
 		this buffer instead of the global property types.


### PR DESCRIPTION
Link "List" more consistently in phrases like "Return a list..." in builtin function descriptions.

This is intentionally limited in scope for review purposes, as requested.
