### PR TITLE
helpcurwin - fix E121 (and autoload relative path)

### DIFF
--- a/runtime/pack/dist/opt/helpcurwin/plugin/helpcurwin.vim
+++ b/runtime/pack/dist/opt/helpcurwin/plugin/helpcurwin.vim
@@ -3,15 +3,9 @@ vim9script
 # Open Vim help on {subject} in the current window (rather than a new split)
 #
 # Maintainer:   The Vim Project <https://github.com/vim/vim>
-# Last change:  2025 Dec 02
+# Last change:  2026 Jan 29
 
-# Exit when the helpcurwin plugin is loaded already
-if exists('g:loaded_helpcurwin')
-  finish
-endif
-g:loaded_helpcurwin = true
-
-import autoload 'helpcurwin.vim'
+import autoload '../autoload/helpcurwin.vim'
 
 command -bar -nargs=? -complete=help HelpCurwin helpcurwin.Open(<q-args>)
 


### PR DESCRIPTION
- I'd not noticed the E121 when using `:HelpCurwin` until I pointed to `/pack/dist/opt/helpcurwin`.
- This fixes the E121 by removing the `g:loaded_helpcurwin` check. There are other ways, though this looks the most aligned to the other `opt` Vim9 script plugins.
- Incidental: the autoload is also relative now ("By using relative paths loading can be much faster for an import inside of a package")