### PR TITLE
Fix wide character display with popups

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -586,6 +586,9 @@ screen_line(
 	// Do not redraw if under the popup menu.
 	if (redraw_this && skip_for_popup(row, col + coloff))
 	    redraw_this = FALSE;
+	// Also skip the second cell for double-width characters.
+	if (redraw_this && char_cells == 2 && skip_for_popup(row, col + coloff + 1))
+	    redraw_this = FALSE;
 
 	if (redraw_this)
 	{

--- a/src/screen.c
+++ b/src/screen.c
@@ -586,36 +586,6 @@ screen_line(
 	// Do not redraw if under the popup menu.
 	if (redraw_this && skip_for_popup(row, col + coloff))
 	    redraw_this = FALSE;
-#ifdef FEAT_PROP_POPUP
-	// For wide characters, if any part is blocked by a popup, clear both
-	// cells to avoid garbage showing through transparent popups.
-	if (char_cells == 2)
-	{
-	    int skip_second = skip_for_popup(row, col + coloff + 1);
-
-	    if (!redraw_this || skip_second)
-	    {
-		// Clear both cells in ScreenLines
-		ScreenLines[off_to] = ' ';
-		ScreenLines[off_to + 1] = ' ';
-		if (enc_utf8)
-		{
-		    ScreenLinesUC[off_to] = 0;
-		    ScreenLinesUC[off_to + 1] = 0;
-		}
-		ScreenAttrs[off_to] = 0;
-		ScreenAttrs[off_to + 1] = 0;
-
-		// Draw the cells that are not blocked
-		if (redraw_this)
-		    screen_char(off_to, row, col + coloff);
-		if (!skip_second)
-		    screen_char(off_to + 1, row, col + coloff + 1);
-
-		redraw_this = FALSE;
-	    }
-	}
-#endif
 
 	if (redraw_this)
 	{

--- a/src/screen.c
+++ b/src/screen.c
@@ -586,6 +586,36 @@ screen_line(
 	// Do not redraw if under the popup menu.
 	if (redraw_this && skip_for_popup(row, col + coloff))
 	    redraw_this = FALSE;
+#ifdef FEAT_PROP_POPUP
+	// For wide characters, if any part is blocked by a popup, clear both
+	// cells to avoid garbage showing through transparent popups.
+	if (char_cells == 2)
+	{
+	    int skip_second = skip_for_popup(row, col + coloff + 1);
+
+	    if (!redraw_this || skip_second)
+	    {
+		// Clear both cells in ScreenLines
+		ScreenLines[off_to] = ' ';
+		ScreenLines[off_to + 1] = ' ';
+		if (enc_utf8)
+		{
+		    ScreenLinesUC[off_to] = 0;
+		    ScreenLinesUC[off_to + 1] = 0;
+		}
+		ScreenAttrs[off_to] = 0;
+		ScreenAttrs[off_to + 1] = 0;
+
+		// Draw the cells that are not blocked
+		if (redraw_this)
+		    screen_char(off_to, row, col + coloff);
+		if (!skip_second)
+		    screen_char(off_to + 1, row, col + coloff + 1);
+
+		redraw_this = FALSE;
+	    }
+	}
+#endif
 
 	if (redraw_this)
 	{


### PR DESCRIPTION
## Problem

When a popup window partially overlaps a wide character (e.g., Japanese characters):

1. **Truncated display**: If only the right half of a wide character is visible, the character was displayed with its right half cut off, violating Vim's rule that "wide characters with only half visible should not be shown at all."

2. **Garbage display**: Old character data remained in the screen buffer and was visible through the popup, appearing as garbage.

## Reproduction

```vim
call setline(1, 'This is line 1')
call setline(2, 'あいうえお')
call setline(3, '        かきくけこ')
hi MyPopup guibg=darkblue guifg=white
call popup_create(['FOO  BAR'], #{
\ line: 1,
\ col: 2,
\ minwidth: 15,
\ minheight: 3,
\ highlight: 'MyPopup',
\})
```

**Before**: The first character "あ" in line 2 shows only its left half (truncated). When adding spaces to line 3, garbage appears where the right half of "け" would be.

**After**: Characters are completely hidden when partially overlapped, and no garbage appears.

<img width="382" height="153" alt="image" src="https://github.com/user-attachments/assets/bafaf41e-6ac3-47a7-b964-ae5f68017bba" />

Left half of あ must not be shown.

<img width="405" height="170" alt="image" src="https://github.com/user-attachments/assets/b83999f6-0e79-40f9-b255-b5535cd77dfe" />

Right half of "け" must be shown as a space.

## Solution

In `screen.c`, when rendering wide characters that are partially blocked by a popup:
- Clear both cells of the wide character in `ScreenLines` to prevent garbage
- Only draw the cells that are not blocked by the popup
- Skip drawing the entire wide character (set `redraw_this = FALSE`)
