### PR TITLE
feat: support shorthands :py=, :py3=, :pyx= to print Python expressions

### DIFF
--- a/runtime/doc/if_pyth.txt
+++ b/runtime/doc/if_pyth.txt
@@ -37,6 +37,10 @@ anymore.
 			Execute Python statement {stmt}.  A simple check if
 			the `:python` command is working: >
 				:python print "Hello"
+<
+			If {stmt} starts with "=" the rest of the chunk is
+			evaluated as an expression and printed. `:python
+			=expr` is equivalent to `:python print(expr)`
 
 :[range]py[thon] << [trim] [{endmarker}]
 {script}
@@ -63,7 +67,7 @@ Example: >
 	endfunction
 
 To see what version of Python you have: >
-	:python print(sys.version)
+	:python =sys.version
 
 There is no need to import sys, it's done by default.
 
@@ -841,7 +845,7 @@ the DLL from the registry, Vim will search the latest version of Python.
 <
 	To see what version of Python you have: >
 		:py3 import sys
-		:py3 print(sys.version)
+		:py3 =sys.version
 <							*:py3file*
 :[range]py3f[ile] {file}
 	The `:py3file` command works similar to `:pyfile`.
@@ -969,7 +973,7 @@ if the `:pyx` command is working: >
 
 To see what version of Python is being used: >
 	:pyx import sys
-	:pyx print(sys.version)
+	:pyx =sys.version
 <
 					*:pyxfile* *python_x-special-comments*
 The `:pyxfile` command works similar to `:pyfile`.  However you can add one of

--- a/src/if_py_both.h
+++ b/src/if_py_both.h
@@ -6601,6 +6601,32 @@ run_eval(const char *cmd, dict_T *locals, void *arg
     PyErr_Clear();
 }
 
+    static void
+DoPyCommand(const char *cmd, dict_T *locals, rangeinitializer init_range, runner run, void *arg);
+
+    static void
+exec_py_cmd(char_u *script, exarg_T *eap)
+{
+    char_u *cmd = script == NULL ? eap->arg : script;
+    char_u *tofree = NULL;
+
+    if (script == NULL && cmd[0] == '=')
+    {
+	// ":py =expr" runs "print(expr)"
+	size_t  len = 7 + STRLEN(cmd + 1) + 1;
+	tofree = alloc(len);
+
+	if (tofree != NULL)
+	{
+	    vim_snprintf((char *)tofree, len, "print(%s)", cmd + 1);
+	    cmd = tofree;
+	}
+    }
+
+    DoPyCommand((const char *)cmd, NULL, init_range_cmd, (runner)run_cmd, (void *)eap);
+    vim_free(tofree);
+}
+
     static int
 set_ref_in_py(const int copyID)
 {

--- a/src/if_python.c
+++ b/src/if_python.c
@@ -1100,31 +1100,30 @@ ex_python(exarg_T *eap)
 	if (p_pyx == 0)
 	    p_pyx = 2;
 
-	if (script == NULL && cmd[0] == '=')
-	{
-	    // ":py =expr" runs "print(expr)"
-	    size_t  len = 7 + STRLEN(cmd + 1) + 1;
-	    char    *tofree = alloc(len);
+        char_u  *cmd = script == NULL ? eap->arg : script;
+        char_u  *tofree = NULL;
 
-	    if (tofree != NULL)
-	    {
-		vim_snprintf(tofree, len, "print(%s)", cmd + 1);
-		DoPyCommand(tofree,
-			NULL,
-			init_range_cmd,
-			(runner) run_cmd,
-			(void *) eap);
-		vim_free(tofree);
-	    }
-	}
-	else
-	{
-	    DoPyCommand(cmd,
-		    NULL,
-		    init_range_cmd,
-		    (runner) run_cmd,
-		    (void *) eap);
-	}
+        if (p_pyx == 0)
+            p_pyx = 2;
+
+        if (script == NULL && cmd[0] == '=')
+        {
+            // ":py =expr" runs "print(expr)"
+            size_t  len = 7 + STRLEN(cmd + 1) + 1;
+            char_u  *tofree = alloc(len);
+
+            if (tofree != NULL)
+            {
+                vim_snprintf(tofree, len, "print(%s)", cmd + 1);
+                cmd = tofree;
+            }
+        }
+        DoPyCommand(cmd,
+                NULL,
+                init_range_cmd,
+                (runner) run_cmd,
+                (void *) eap);
+        vim_free(tofree);
     }
     vim_free(script);
 }

--- a/src/if_python.c
+++ b/src/if_python.c
@@ -1095,35 +1095,10 @@ ex_python(exarg_T *eap)
     script = script_get(eap, eap->arg);
     if (!eap->skip)
     {
-	char *cmd = script == NULL ? (char *) eap->arg : (char *) script;
-
 	if (p_pyx == 0)
 	    p_pyx = 2;
 
-        char_u  *cmd = script == NULL ? eap->arg : script;
-        char_u  *tofree = NULL;
-
-        if (p_pyx == 0)
-            p_pyx = 2;
-
-        if (script == NULL && cmd[0] == '=')
-        {
-            // ":py =expr" runs "print(expr)"
-            size_t  len = 7 + STRLEN(cmd + 1) + 1;
-            char_u  *tofree = alloc(len);
-
-            if (tofree != NULL)
-            {
-                vim_snprintf(tofree, len, "print(%s)", cmd + 1);
-                cmd = tofree;
-            }
-        }
-        DoPyCommand(cmd,
-                NULL,
-                init_range_cmd,
-                (runner) run_cmd,
-                (void *) eap);
-        vim_free(tofree);
+	exec_py_cmd(script, eap);
     }
     vim_free(script);
 }

--- a/src/if_python.c
+++ b/src/if_python.c
@@ -1095,14 +1095,36 @@ ex_python(exarg_T *eap)
     script = script_get(eap, eap->arg);
     if (!eap->skip)
     {
+	char *cmd = script == NULL ? (char *) eap->arg : (char *) script;
+
 	if (p_pyx == 0)
 	    p_pyx = 2;
 
-	DoPyCommand(script == NULL ? (char *) eap->arg : (char *) script,
-		NULL,
-		init_range_cmd,
-		(runner) run_cmd,
-		(void *) eap);
+	if (script == NULL && cmd[0] == '=')
+	{
+	    // ":py =expr" runs "print(expr)"
+	    size_t  len = 7 + STRLEN(cmd + 1) + 1;
+	    char    *tofree = alloc(len);
+
+	    if (tofree != NULL)
+	    {
+		vim_snprintf(tofree, len, "print(%s)", cmd + 1);
+		DoPyCommand(tofree,
+			NULL,
+			init_range_cmd,
+			(runner) run_cmd,
+			(void *) eap);
+		vim_free(tofree);
+	    }
+	}
+	else
+	{
+	    DoPyCommand(cmd,
+		    NULL,
+		    init_range_cmd,
+		    (runner) run_cmd,
+		    (void *) eap);
+	}
     }
     vim_free(script);
 }

--- a/src/if_python3.c
+++ b/src/if_python3.c
@@ -1517,14 +1517,36 @@ ex_py3(exarg_T *eap)
     script = script_get(eap, eap->arg);
     if (!eap->skip)
     {
+	char *cmd = script == NULL ? (char *) eap->arg : (char *) script;
+
 	if (p_pyx == 0)
 	    p_pyx = 3;
 
-	DoPyCommand(script == NULL ? (char *) eap->arg : (char *) script,
-		NULL,
-		init_range_cmd,
-		(runner) run_cmd,
-		(void *) eap);
+	if (script == NULL && cmd[0] == '=')
+	{
+	    // ":py3 =expr" runs "print(expr)"
+	    size_t  len = 7 + STRLEN(cmd + 1) + 1;
+	    char    *tofree = alloc(len);
+
+	    if (tofree != NULL)
+	    {
+		vim_snprintf(tofree, len, "print(%s)", cmd + 1);
+		DoPyCommand(tofree,
+			NULL,
+			init_range_cmd,
+			(runner) run_cmd,
+			(void *) eap);
+		vim_free(tofree);
+	    }
+	}
+	else
+	{
+	    DoPyCommand(cmd,
+		    NULL,
+		    init_range_cmd,
+		    (runner) run_cmd,
+		    (void *) eap);
+	}
     }
     vim_free(script);
 }

--- a/src/if_python3.c
+++ b/src/if_python3.c
@@ -1517,36 +1517,10 @@ ex_py3(exarg_T *eap)
     script = script_get(eap, eap->arg);
     if (!eap->skip)
     {
-	char *cmd = script == NULL ? (char *) eap->arg : (char *) script;
-
 	if (p_pyx == 0)
 	    p_pyx = 3;
 
-	if (script == NULL && cmd[0] == '=')
-	{
-	    // ":py3 =expr" runs "print(expr)"
-	    size_t  len = 7 + STRLEN(cmd + 1) + 1;
-	    char    *tofree = alloc(len);
-
-	    if (tofree != NULL)
-	    {
-		vim_snprintf(tofree, len, "print(%s)", cmd + 1);
-		DoPyCommand(tofree,
-			NULL,
-			init_range_cmd,
-			(runner) run_cmd,
-			(void *) eap);
-		vim_free(tofree);
-	    }
-	}
-	else
-	{
-	    DoPyCommand(cmd,
-		    NULL,
-		    init_range_cmd,
-		    (runner) run_cmd,
-		    (void *) eap);
-	}
+	exec_py_cmd(script, eap);
     }
     vim_free(script);
 }

--- a/src/testdir/test_python2.vim
+++ b/src/testdir/test_python2.vim
@@ -53,6 +53,16 @@ func Test_AAA_python_setup()
   EOF
 endfunc
 
+" Test command :py= and variants
+func Test_python_ex_eval()
+  " python 2 tests are flaky, probably because of the softspace thing, so
+  " we'll use `trim()` to remove any spurious whitespace.
+  call assert_equal("10", trim(execute('python =10')))
+  call assert_equal("20", trim(execute('python=   20     ')))
+  call assert_equal("30", trim(execute('py=    30     ')))
+  call assert_equal("40", trim(execute('py=40')))
+endfunc
+
 func Test_pydo()
   new
 

--- a/src/testdir/test_python3.vim
+++ b/src/testdir/test_python3.vim
@@ -303,6 +303,21 @@ func Test_unicode()
   set encoding=utf8
 endfunc
 
+" Test command :py3= and variants
+func Test_python3_ex_eval()
+  call assert_equal("\n10", execute('python3 =10'))
+  call assert_equal("\n20", execute('python3=   20     '))
+  call assert_equal("\n30", execute('py3=    30     '))
+  call assert_equal("\n40", execute('py3=40'))
+
+  " On syntax error or evaluation error, stacktrace information is printed
+  call assert_fails('py3= 1/0', 'Traceback (most recent call last):')
+
+  python3 def raise_error(): raise RuntimeError("oops")
+  call assert_fails('python3 =print("nooo", raise_error())', 'Traceback (most recent call last):')
+  call assert_notmatch("nooo", execute(':messages'))
+endfunc
+
 " Test vim.eval() with various types.
 func Test_python3_vim_eval()
   call assert_equal("\n2061300532912", execute('py3 print(vim.eval("2061300532912"))'))


### PR DESCRIPTION
Neovim supports shorthands :py=, :py3=, :pyx= to evaluate and print Python expressions (they also have :lua= to print Lua expression btw) https://github.com/neovim/pynvim/blob/a06146fe412b63eb0462d714b3b67f8431110f66/pynvim/plugin/script_host.py#L81-L96

I think it is very convenient for quick evaluation of Python expressions, as the number of keystroke is now similar to printing Vimscript expression (`:echo vimexpr` vs `:py3= py3expr`) , and you will worry less about forgetting to close parenthesis, so I port them to Vim's Python interface.