### PR TITLE
test: make :lang test pass on OpenBSD

### DIFF
--- a/src/testdir/test_excmd.vim
+++ b/src/testdir/test_excmd.vim
@@ -236,8 +236,15 @@ endfunc
 func Test_language_cmd()
   CheckFeature multi_lang
 
-  call assert_fails('language ctype non_existing_lang', 'E197:')
-  call assert_fails('language time non_existing_lang', 'E197:')
+  " OpenBSD allows nearly arbitrary locale names, since it largely ignores them
+  " (see setlocale(3)). One useful exception for this test is that in doesn't
+  " allow names containing dots unless they end in '.UTF-8'.
+  "
+  " Windows also allows nonsensical locale names, though it seems to reject
+  " names with multiple underscores (possibly expecting 'language_region', but
+  " not 'language_region_additional').
+  call assert_fails('language ctype non_existing_lang.bad', 'E197:')
+  call assert_fails('language time non_existing_lang.bad', 'E197:')
 endfunc
 
 " Test for the :confirm command dialog


### PR DESCRIPTION
Problem: Test_language_cmd fails on OpenBSD because the test uses an invalid locale name and expects the command to produce an error. OpenBSD accepts (almost) any locale name as valid by design, so the :lang command succeeds and the test fails.

Solution: Slightly update the "bad" locale name to make it something that OpenBSD considers invalid by adding a dot (but not ending with ".UTF-8"). Maintain the original two underscores in the name because that ensures Windows will also see it as invalid.