### PR TITLE
Fix crash on completion when using tagfunc

### DIFF
--- a/src/tag.c
+++ b/src/tag.c
@@ -1460,7 +1460,7 @@ find_tagfunc_tags(
     // create 'info' dict argument
     if ((d = dict_alloc_lock(VAR_FIXED)) == NULL)
 	return FAIL;
-    if (tag->user_data != NULL)
+    if (!(flags & TAG_INS_COMP) && tag->user_data != NULL)
 	dict_add_string(d, "user_data", tag->user_data);
     if (buf_ffname != NULL)
 	dict_add_string(d, "buf_ffname", buf_ffname);


### PR DESCRIPTION
do not add the user_data to the 'info' dictionary when called for insert mode completion (the TAG_INS_COMP flag is set). Completion should not depend on the state of a previous tag jump.

Fixes: #19255