### PR TITLE
Fix blob2str() when a blob ends with 0x0A

### DIFF
--- a/src/strings.c
+++ b/src/strings.c
@@ -1359,6 +1359,10 @@ f_blob2str(typval_T *argvars, typval_T *rettv)
 	    break;
     }
 
+    // If the blob ends with a newline, we need to add another empty string.
+    if (blen > 0 && blob_get(blob, blen - 1) == NL)
+	list_append_string(rettv->vval.v_list, (char_u *)"", 0);
+
 done:
     vim_free(from_encoding);
 }

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -4512,6 +4512,7 @@ func Test_blob2str()
     call assert_equal(["ab"], blob2str(0z6162))
     call assert_equal(["a\nb"], blob2str(0z610062))
     call assert_equal(["ab", "cd"], blob2str(0z61620A6364))
+    call assert_equal(["ab", "cd", ""], blob2str(0z61620A63640A))
 
     call assert_equal(["«»"], blob2str(0zC2ABC2BB))
     call assert_equal(["ŝş"], blob2str(0zC59DC59F))


### PR DESCRIPTION
`blob2str()` doesn't restore a tail of new line.

```vim
let original_str = "foo\nbar\n"
let b = str2blob(original_str->split("\n", 1))
call assert_equal(0z666F6F0A.6261720A, b)  " OK
let restored_str = blob2str(b)->join("\n")
call assert_equal(original_str, restored_str)  " Fail
```