### PR TITLE
vim9: make float negation consistent between compiled and interpreted code

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -5415,14 +5415,9 @@ eval9_leader(
 		}
 		if (rettv->v_type == VAR_FLOAT)
 		{
-		    if (vim9script)
-		    {
-			rettv->v_type = VAR_BOOL;
-			val = f == 0.0 ? VVAL_TRUE : VVAL_FALSE;
-			type = VAR_BOOL;
-		    }
-		    else
-			f = !f;
+		    rettv->v_type = VAR_BOOL;
+		    val = f == 0.0 ? VVAL_TRUE : VVAL_FALSE;
+		    type = VAR_BOOL;
 		}
 		else
 		{

--- a/src/eval.c
+++ b/src/eval.c
@@ -5419,6 +5419,7 @@ eval9_leader(
 		    {
 			rettv->v_type = VAR_BOOL;
 			val = f == 0.0 ? VVAL_TRUE : VVAL_FALSE;
+			type = VAR_BOOL;
 		    }
 		    else
 			f = !f;

--- a/src/testdir/test_vim9_expr.vim
+++ b/src/testdir/test_vim9_expr.vim
@@ -4117,6 +4117,11 @@ def Test_expr9_not()
 
       assert_equal(false, ![1, 2, 3]->reverse())
       assert_equal(true, ![]->reverse())
+
+      # float
+      assert_equal(true, !0.0)
+      assert_equal(false, !1.0)
+      assert_equal(false, !25.678)
   END
   v9.CheckDefAndScriptSuccess(lines)
 enddef

--- a/src/testdir/test_vimscript.vim
+++ b/src/testdir/test_vimscript.vim
@@ -7086,7 +7086,11 @@ func Test_compound_assignment_operators()
     call assert_fails('let x %= 0.5', 'E734:')
     call assert_fails('let x .= "f"', 'E734:')
     let x = !3.14
-    call assert_equal(0.0, x)
+    call assert_equal(0, x)
+    call assert_equal(1, !!1.0)
+    let x = !0.0
+    call assert_equal(1, x)
+    call assert_equal(0, !!0.0)
 
     " integer and float operations
     let x = 1


### PR DESCRIPTION
This PR aligns the behavior of float negation in :def functions with Vim9 script level.
In a legacy script, !0.0 returns 1 and !1.0 returns 0.

Fix the issue reported in #19282.