### PR TITLE
extend  syntax for quickfix

### DIFF
--- a/runtime/syntax/qf.vim
+++ b/runtime/syntax/qf.vim
@@ -18,9 +18,8 @@ syn match	qfText		".*"	 contained
 syn match	qfError		"error"	  contained
 syn match	qfWarning	"warning" contained
 syn match	qfNote		"note"    contained
-syn match	qfHint		"hint"    contained
 syn match	qfInfo		"info"    contained
-syn cluster	qfType		contains=qfError,qfWarning,qfNote,qfHint,qfInfo
+syn cluster	qfType		contains=qfError,qfWarning,qfNote,qfInfo
 
 
 " The default highlighting.
@@ -31,6 +30,10 @@ hi def link qfSeparator2	Delimiter
 hi def link qfText		Normal
 
 hi def link qfError		Error
+"hi def link qfError		DiagnosticError
+hi def link qfWarning		DiagnosticWarn
+hi def link qfNote		DiagnosticHint
+hi def link qfInfo		DiagnosticInfo
 
 let b:current_syntax = "qf"
 

--- a/runtime/syntax/qf.vim
+++ b/runtime/syntax/qf.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:		Quickfix window
 " Maintainer:		The Vim Project <https://github.com/vim/vim>
-" Last Change:		2025 Feb 07
+" Last Change:		2026 Jan 31
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Quit when a syntax file was already loaded
@@ -15,8 +15,13 @@ syn match	qfLineNr	"[^|]*"	 contained nextgroup=qfSeparator2 contains=@qfType
 syn match	qfSeparator2	"|"	 contained nextgroup=qfText
 syn match	qfText		".*"	 contained
 
-syn match	qfError		"error"	 contained
-syn cluster	qfType	contains=qfError
+syn match	qfError		"error"	  contained
+syn match	qfWarning	"warning" contained
+syn match	qfNote		"note"    contained
+syn match	qfHint		"hint"    contained
+syn match	qfInfo		"info"    contained
+syn cluster	qfType	contains=qfError,qfWarning,qfNote,qfHint,qfInfo
+
 
 " The default highlighting.
 hi def link qfFileName		Directory

--- a/runtime/syntax/qf.vim
+++ b/runtime/syntax/qf.vim
@@ -20,7 +20,7 @@ syn match	qfWarning	"warning" contained
 syn match	qfNote		"note"    contained
 syn match	qfHint		"hint"    contained
 syn match	qfInfo		"info"    contained
-syn cluster	qfType	contains=qfError,qfWarning,qfNote,qfHint,qfInfo
+syn cluster	qfType		contains=qfError,qfWarning,qfNote,qfHint,qfInfo
 
 
 " The default highlighting.

--- a/runtime/syntax/qf.vim
+++ b/runtime/syntax/qf.vim
@@ -28,12 +28,8 @@ hi def link qfLineNr		LineNr
 hi def link qfSeparator1	Delimiter
 hi def link qfSeparator2	Delimiter
 hi def link qfText		Normal
-
 hi def link qfError		Error
-"hi def link qfError		DiagnosticError
-hi def link qfWarning		DiagnosticWarn
-hi def link qfNote		DiagnosticHint
-hi def link qfInfo		DiagnosticInfo
+
 
 let b:current_syntax = "qf"
 


### PR DESCRIPTION
If you are using quickfix for diagnostic messages in neovim via `vim.diagnostic.setqflist()`, only entries with severity error are highlighted. 

I've added additional captures for severity types, which can be highlighted separately in the colorscheme if needed.
- qfError
- qfWarning
- qfNote
- qfHint
- qfInfo

The default vim highlighting is unchanged. 


**example:**
<img width="1744" height="242" alt="Screenshot_20260131_121139-1" src="https://github.com/user-attachments/assets/164320ff-ea47-4514-862c-be4a4af8c5d0" />





