### PR TITLE
Fix DirectX font size to match GDI by implementing proper clipping

### DIFF
--- a/src/gui_dwrite.cpp
+++ b/src/gui_dwrite.cpp
@@ -820,9 +820,6 @@ DWriteContext::CreateTextFormatFromLOGFONT(const LOGFONTW &logFont,
 	    fontSize = fontSize * float(fontMetrics.designUnitsPerEm)
 		/ float(fontMetrics.ascent + fontMetrics.descent);
 	}
-
-	// Scale by ascent ratio to match GDI rendering size
-	fontSize = ceil(fontSize * float(fontMetrics.ascent) / float(fontMetrics.designUnitsPerEm));
     }
 
     // The text format includes a locale name. Ideally, this would be the
@@ -1055,6 +1052,15 @@ DWriteContext::DrawText(const WCHAR *text, int len,
 
     SetDrawingMode(DM_DIRECTX);
 
+    // Apply clipping if ETO_CLIPPED is specified
+    if ((fuOptions & ETO_CLIPPED) && lprc != NULL)
+    {
+	mRT->PushAxisAlignedClip(
+	    D2D1::RectF(FLOAT(lprc->left), FLOAT(lprc->top),
+			FLOAT(lprc->right), FLOAT(lprc->bottom)),
+	    D2D1_ANTIALIAS_MODE_ALIASED);
+    }
+
     hr = mDWriteFactory->CreateTextLayout(text, len, mTextFormat,
 	    FLOAT(w), FLOAT(h), &textLayout);
 
@@ -1080,6 +1086,11 @@ DWriteContext::DrawText(const WCHAR *text, int len,
     }
 
     SafeRelease(&textLayout);
+
+    if ((fuOptions & ETO_CLIPPED) && lprc != NULL)
+    {
+	mRT->PopAxisAlignedClip();
+    }
 }
 
     void

--- a/src/gui_dwrite.cpp
+++ b/src/gui_dwrite.cpp
@@ -1088,9 +1088,7 @@ DWriteContext::DrawText(const WCHAR *text, int len,
     SafeRelease(&textLayout);
 
     if ((fuOptions & ETO_CLIPPED) && lprc != NULL)
-    {
 	mRT->PopAxisAlignedClip();
-    }
 }
 
     void


### PR DESCRIPTION
After the DirectX rendering improvements in patch 9.1.2125 (commit b39b065d6), users reported that fonts rendered with DirectX (`set renderoptions=type:directx`) appeared smaller than the same fonts rendered with GDI.

## Root Cause

**The original DirectX implementation (before patch 9.1.2125) had a clipping issue**: The `ETO_CLIPPED` flag and clipping rectangle (`lprc`) passed from the GDI layer were not being respected. Without proper clipping, glyphs would extend beyond cell boundaries, causing rendering artifacts (visual "garbage") above and below the text cells.

In patch 9.1.2125, to work around this long-standing clipping issue (#19254), the font size was intentionally reduced by scaling to only the ascent height:

```cpp
fontSize = ceil(fontSize * float(fontMetrics.ascent) / float(fontMetrics.designUnitsPerEm));
```

This prevented glyphs from overflowing their cells, but it also made the fonts appear smaller than their GDI counterparts—typically about 13% smaller (e.g., 13px instead of 15px for an 11pt font).

## Solution

Instead of reducing the font size to avoid overflow, this patch fixes the root cause by implementing proper clipping support:

1. **Removed the ascent ratio scaling** - Font size now matches GDI rendering
2. **Implemented ETO_CLIPPED support** - Added `PushAxisAlignedClip()` and `PopAxisAlignedClip()` calls in `DWriteContext::DrawText()` to respect the clipping rectangle

With proper clipping in place, glyphs are prevented from rendering outside their cell boundaries, eliminating the need to artificially reduce the font size.

closes: #19254
