### PR TITLE
runtime(doc): Improve the description at :help :cwindow

### DIFF
--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -625,6 +625,11 @@ can go back to the unfiltered list using the |:colder|/|:lolder| command.
 			errors.  If the window is already open and there are
 			no recognized errors, close the window.
 
+			When opening the window and [height] is given, the
+			window becomes that high (if there is room).  When
+			[height] is omitted the window is made ten lines high.
+
+
 							*:lw* *:lwindow*
 :lw[indow] [height]	Same as ":cwindow", except use the window showing the
 			location list for the current window.


### PR DESCRIPTION
Describe the "height" argument when opening the quickfix window.

See: #19302 ("[cl]window" has different behaviour from "[cl]open" about their argument [height])
