### PR TITLE
runtime(ruby): Update for Vim 9.2 release

### DIFF
--- a/runtime/compiler/eruby.vim
+++ b/runtime/compiler/eruby.vim
@@ -2,7 +2,6 @@
 " Language:		eRuby
 " Maintainer:		Doug Kearns <dougkearns@gmail.com>
 " URL:			https://github.com/vim-ruby/vim-ruby
-" Release Coordinator:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:		2024 Apr 03
 
 if exists("current_compiler")

--- a/runtime/compiler/rake.vim
+++ b/runtime/compiler/rake.vim
@@ -2,7 +2,6 @@
 " Language:		Rake
 " Maintainer:		Tim Pope <vimNOSPAM@tpope.org>
 " URL:			https://github.com/vim-ruby/vim-ruby
-" Release Coordinator:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:		2018 Mar 02
 "			2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 

--- a/runtime/compiler/rspec.vim
+++ b/runtime/compiler/rspec.vim
@@ -2,7 +2,6 @@
 " Language:		RSpec
 " Maintainer:		Tim Pope <vimNOSPAM@tpope.org>
 " URL:			https://github.com/vim-ruby/vim-ruby
-" Release Coordinator:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:		2018 Aug 07
 "			2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 

--- a/runtime/compiler/ruby.vim
+++ b/runtime/compiler/ruby.vim
@@ -3,7 +3,6 @@
 " Function:		Syntax check and/or error reporting
 " Maintainer:		Tim Pope <vimNOSPAM@tpope.org>
 " URL:			https://github.com/vim-ruby/vim-ruby
-" Release Coordinator:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:		2019 Jan 06
 "			2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 

--- a/runtime/compiler/rubyunit.vim
+++ b/runtime/compiler/rubyunit.vim
@@ -2,7 +2,6 @@
 " Language:		Test::Unit - Ruby Unit Testing Framework
 " Maintainer:		Doug Kearns <dougkearns@gmail.com>
 " URL:			https://github.com/vim-ruby/vim-ruby
-" Release Coordinator:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:		2014 Mar 23
 "			2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
 

--- a/runtime/ftplugin/eruby.vim
+++ b/runtime/ftplugin/eruby.vim
@@ -2,7 +2,6 @@
 " Language:		eRuby
 " Maintainer:		Tim Pope <vimNOSPAM@tpope.org>
 " URL:			https://github.com/vim-ruby/vim-ruby
-" Release Coordinator:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:		2022 May 15
 "			2024 Jan 14 by Vim Project (browsefilter)
 "			2024 May 23 by Riley Bruins <ribru17@gmail.com> ('commentstring')

--- a/runtime/indent/eruby.vim
+++ b/runtime/indent/eruby.vim
@@ -2,7 +2,6 @@
 " Language:		eRuby
 " Maintainer:		Tim Pope <vimNOSPAM@tpope.org>
 " URL:			https://github.com/vim-ruby/vim-ruby
-" Release Coordinator:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:		2019 Jan 06
 
 if exists("b:did_indent")

--- a/runtime/indent/ruby.vim
+++ b/runtime/indent/ruby.vim
@@ -3,8 +3,7 @@
 " Maintainer:		Andrew Radev <andrey.radev@gmail.com>
 " Previous Maintainer:	Nikolai Weibull <now at bitwi.se>
 " URL:			https://github.com/vim-ruby/vim-ruby
-" Release Coordinator:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:		2022 Jun 30
+" Last Change:		2023 Dec 22
 
 " 0. Initialization {{{1
 " =================
@@ -93,7 +92,14 @@ let s:ruby_indent_keywords =
       \    '\<\%(if\|for\|while\|until\|case\|unless\|begin\):\@!\>'
 
 " Def without an end clause: def method_call(...) = <expression>
-let s:ruby_endless_def = '\<def\s\+\%(\k\+\.\)\=\k\+[!?]\=\%((.*)\|\s\)\s*='
+let s:ruby_endless_def =
+      \ '\<def\s\+\%(\k\+\.\)\=\%(\k\+[=!?]\=\|' .
+      \ '[-+*/%&^<>~!]\|' .
+      \ '\*\*\|>>\|<<\|' .
+      \ '===\?\|\!=\|=\~\|\!\~\|' .
+      \ '<=>\|<=\|>=\|' .
+      \ '[-+!\~]@\|\[\]' .
+      \ '\)\%((.*)\|\s\)\s*='
 
 " Regex used for words that, at the start of a line, remove a level of indent.
 let s:ruby_deindent_keywords =

--- a/runtime/syntax/eruby.vim
+++ b/runtime/syntax/eruby.vim
@@ -2,7 +2,6 @@
 " Language:		eRuby
 " Maintainer:		Tim Pope <vimNOSPAM@tpope.org>
 " URL:			https://github.com/vim-ruby/vim-ruby
-" Release Coordinator:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:		2022 Mar 18
 
 if exists("b:current_syntax")

--- a/runtime/syntax/ruby.vim
+++ b/runtime/syntax/ruby.vim
@@ -2,7 +2,6 @@
 " Language:		Ruby
 " Maintainer:		Doug Kearns <dougkearns@gmail.com>
 " URL:			https://github.com/vim-ruby/vim-ruby
-" Release Coordinator:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:		2023 Mar 16
 " ----------------------------------------------------------------------------
 "


### PR DESCRIPTION
We have our own indent and syntax tests, I'm not sure there's too much to be gained by converting them for inclusion in Vim's tests.
