### PR TITLE
Fix buf_check_timestamp heap UAF

### DIFF
--- a/src/fileio.c
+++ b/src/fileio.c
@@ -4480,7 +4480,7 @@ buf_check_timestamp(
 	// Reload the buffer.
 	buf_reload(buf, orig_mode, reload == RELOAD_DETECT);
 #ifdef FEAT_PERSISTENT_UNDO
-	if (buf->b_p_udf && buf->b_ffname != NULL)
+	if (bufref_valid(&bufref) && buf->b_p_udf && buf->b_ffname != NULL)
 	{
 	    char_u	    hash[UNDO_HASH_SIZE];
 	    buf_T	    *save_curbuf = curbuf;

--- a/src/testdir/test_filechanged.vim
+++ b/src/testdir/test_filechanged.vim
@@ -279,4 +279,27 @@ func Test_FileChangedShell_newbuf()
   au! testnewbuf
 endfunc
 
+func Test_file_changed_wipeout()
+  call writefile(['foo'], 'Xchanged_bw', 'D')
+  edit Xchanged_bw
+  augroup FileChangedWipeout
+    autocmd FileChangedShell * ++once let v:fcs_choice = 'reload'
+    autocmd BufReadPost * ++once %bw!
+  augroup END
+
+  " Need to wait until the timestamp would change.
+  if has('nanotime')
+    sleep 10m
+  else
+    sleep 2
+  endif
+  call writefile(['bar'], 'Xchanged_bw')
+  call assert_equal(1, bufexists('Xchanged_bw'))
+  checktime " used to be a heap UAF
+  call assert_equal(0, bufexists('Xchanged_bw'))
+
+  au! FileChangedWipeout
+  %bw!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem: heap UAF if autocommands from reloading a file changed outside of Vim wipe its buffer.

Solution: validate the bufref after buf_reload.