### PR TITLE
Fix for :VimKeywordPrg when syntax does not match

### DIFF
--- a/runtime/ftplugin/vim.vim
+++ b/runtime/ftplugin/vim.vim
@@ -89,7 +89,9 @@ if !exists("*" .. expand("<SID>") .. "Help")
       endif
     endif
 
-    if pre =~# '^\s*:\=$' || pre =~# '\%(\\\||\)\@<!|\s*:\=$'
+    if stridx(post, '(') == 0
+      return topic .. '()'
+    elseif pre =~# '^\s*:\=$' || pre =~# '\%(\\\||\)\@<!|\s*:\=$'
       return ':' .. topic
     elseif pre =~# '\<v:$'
       return 'v:' .. topic


### PR DESCRIPTION
When using vim9-syntax plugin, `:VimKeywordPrg` does not lookup functions correctly, as it relies solely on syntax names to find the help topic.

The syntax keyword used for builtin functions is `vi9FuncNameBuiltin` in vim9-syntax plugin, not `vimFuncName` expected by `:VimKeywordPrg`, so the fallback rules apply, and there is no fallback rule for function calls.

Fix by just checking if the first char after topic is '(', and if so assume help topic is a function.

cc @Konfekt 

Related to: https://github.com/lacygoill/vim9-syntax/issues/14