### PR TITLE
translation(sv): Fix typo, update tutor1 to v1.7, add tutor2

### DIFF
--- a/runtime/doc/help.svx
+++ b/runtime/doc/help.svx
@@ -1,10 +1,10 @@
 *help.svx*	För Vim version 9.1.       Senaste ändring: 2025 Nov 01
 
 			VIM - Huvudsaklig hjälpfil
-									           k
-         Flytta runt:  Använd markörtangenterna, eller "h" för att gå vänster,   h   l
-		       "j" för att gå neråt, "k" för att gå uppåt, "l" för höger.  j
-Stänga detta fönster:  Använd ":q<Enter>".
+									     k
+      Flytta runt:  Använd markörknapparna, eller "h" vänster,	       h   l
+		    "j" ner, "k" upp, "l" höger.				 j
+ Stäng detta fönster:  Använd ":q<Enter>".
 	 Avsluta Vim:  Använd ":qa!<Enter>" (var försiktig, alla ändring
                        förloras!).
 
@@ -237,7 +237,7 @@ Standardtillägg ~
 |pi_gzip.txt|      Läser och skriv komprimerade filer
 |pi_logipat.txt|   Logiska operatorer på mönster
 |pi_netrw.txt|     Läser och skriver filer över ett nätverk
-|pi_paren.txt|     Markera matchande paranteser
+|pi_paren.txt|     Markera matchande parenteser
 |pi_spec.txt|      Filtypstillägg för att jobba med rpm-specfiler
 |pi_tar.txt|       Tar-filsutforskare
 |pi_tutor.txt|     Interaktiv handledning för Vim

--- a/runtime/tutor/tutor1.sv
+++ b/runtime/tutor/tutor1.sv
@@ -1,24 +1,25 @@
 ===============================================================================
-= V ä l k o m m e n  t i l l  h a n d l e d n i n g e n  i  V i m  - Ver. 1.5 =
+= V ä l k o m m e n  t i l l  V I M - h a n d l e d n i n g e n  - Ver. 1.7  =
+===============================================================================
+=			    K A P I T E L   E T T			      =
 ===============================================================================
 
      Vim är en väldigt kraftfull redigerare som har många kommandon, alltför
      många att förklara i en handledning som denna. Den här handledningen är
-     gjord för att förklara tillräckligt många kommandon så att du enkelt ska
+     gjord för att beskriva tillräckligt många kommandon så att du enkelt ska
      kunna använda Vim som en redigerare för alla ändamål.
-
-     Den beräknade tiden för att slutföra denna handledning är 25-30 minuter,
+     Den beräknade tiden för att slutföra denna handledning är 30 minuter,
      beroende på hur mycket tid som läggs ned på experimentering.
 
+     OBSERVERA:
      Kommandona i lektionerna kommer att modifiera texten. Gör en kopia av den
-     här filen att öva på (om du startade "vimtutor är det här redan en kopia).
+     här filen att öva på (om du startade "vimtutor" är det här redan en kopia).
 
      Det är viktigt att komma ihåg att den här handledningen är konstruerad
      att lära vid användning. Det betyder att du måste köra kommandona för att
      lära dig dem ordentligt. Om du bara läser texten så kommer du att glömma
      kommandona!
-
-     Försäkra dig nu om att din Caps-Lock tangent INTE är aktiv och tryck på
+     Försäkra dig nu om att din Caps-Lock-tangent INTE är aktiv och tryck på
      j-tangenten tillräckligt många gånger för att förflytta markören så att
      Lektion 1.1.1 fyller skärmen helt.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -27,59 +28,58 @@
 
    ** För att flytta markören, tryck på tangenterna h,j,k,l som indikerat. **
 	     ^
-	     k		Tips:
-       < h	 l >	h-tangenten är till vänster och flyttar till vänster.
-	     j		l-tangenten är till höger och flyttar till höger.
-	     v		j-tangenten ser ut som en pil ned.
+	     k		Tips:  h-tangenten är till vänster och flyttar vänster.
+       < h	 l >	       l-tangenten är till höger och flyttar höger.
+	     j		       j-tangenten ser ut som en pil ned.
+	     v
   1. Flytta runt markören på skärmen tills du känner dig bekväm.
 
-  2. Håll ned tangenten pil ned (j) tills att den repeterar.
----> Nu vet du hur du tar dig till nästa lektion.
+  2. Håll ned tangenten (j) tills den repeterar.
+     Nu vet du hur du tar dig till nästa lektion.
 
-  3. Flytta till Lektion 1.1.2, med hjälp av ned tangenten.
+  3. Flytta till Lektion 1.1.2, med hjälp av ned-tangenten.
 
-Notera: Om du är osäker på någonting du skrev, tryck <ESC> för att placera dig
-	dig i Normal-läge. Skriv sedan om kommandot.
+NOTERA: Om du är osäker på någonting du skrev, tryck <ESC> för att placera
+	dig i Normalläge. Skriv sedan om kommandot du ville använda.
 
-Notera: Piltangenterna borde också fungera.  Men om du använder hjkl så kommer
-	du att kunna flytta omkring mycket snabbare, när du väl vant dig vid
-	det.
+NOTERA: Piltangenterna borde också fungera. Men om du använder hjkl så kommer
+	du att kunna flytta runt mycket snabbare, när du väl vant dig vid det.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-		     Lektion 1.1.2: STARTA OCH AVSLUTA VIM
+			    Lektion 1.1.2: AVSLUTA VIM
 
 
   !! NOTERA: Innan du utför någon av punkterna nedan, läs hela lektionen!!
 
-  1. Tryck <ESC>-tangenten (för att se till att du är i Normal-läge).
+  1. Tryck <ESC>-tangenten (för att se till att du är i Normalläge).
 
-  2. Skriv:			:q! <ENTER>.
+  2. Skriv:	:q! <ENTER>.
+     Detta avslutar redigeraren UTAN att spara några ändringar.
 
----> Detta avslutar redigeraren UTAN att spara några ändringar du gjort.
-     Om du vill spara ändringarna och avsluta skriv:
-				:wq  <ENTER>
+  3. Kom tillbaka hit genom att köra kommandot som tog dig till den här
+     handledningen. Det kan vara:  vimtutor <ENTER>
 
-  3. När du ser skal-prompten, skriv kommandot som tog dig in i den här
-     handledningen.  Det kan vara:	vimtutor <ENTER>
-     Normalt vill du använda:		vim tutor <ENTER>
+  4. Om du har memorerat dessa steg och känner dig säker, kör steg 1 till 3
+     för att avsluta och starta om redigeraren.
 
----> 'vim' betyder öppna redigeraren vim, 'tutor' är filen du vill redigera.
+NOTERA: :q! <ENTER> kastar alla ändringar du gjort. Om några lektioner lär
+	du dig hur du sparar ändringar till en fil.
 
-  4. Om du har memorerat dessa steg och känner dig självsäker, kör då stegen
-     1 till 3 för att avsluta och starta om redigeraren. Flytta sedan ned
-     markören till Lektion 1.1.3.
+  5. Flytta ned markören till Lektion 1.1.3.
+
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-		     Lektion 1.1.3: TEXT REDIGERING - BORTTAGNING
+		     Lektion 1.1.3: TEXTREDIGERING - BORTTAGNING
 
 
-** När du är i Normal-läge tryck  x  för att ta bort tecknet under markören. **
+	   ** Tryck  x  för att ta bort tecknet under markören. **
 
-  1. Flytta markören till raden nedan med markeringen --->.
+  1. Flytta markören till raden nedan markerad med --->.
 
   2. För att rätta felen, flytta markören tills den står på tecknet som ska
-     tas bort. fix the errors, move the cursor until it is on top of the
+     tas bort.
 
-  3. Tryck på	x-tangenten för att ta bort det felaktiga tecknet.
+  3. Tryck på  x-tangenten för att ta bort det oönskade tecknet.
 
   4. Upprepa steg 2 till 4 tills meningen är korrekt.
 
@@ -87,338 +87,426 @@ Notera: Piltangenterna borde också fungera.  Men om du använder hjkl så komme
 
   5. Nu när raden är korrekt, gå till Lektion 1.1.4.
 
-NOTERA: När du går igenom den här handledningen, försök inte att memorera, lär
+NOTERA: När du går igenom den här handledningen, försök inte memorera, lär
 	genom användning.
 
 
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-		     Lektion 1.1.4: TEXT REDIGERING - INFOGNING
+		      Lektion 1.1.4: TEXTREDIGERING - INFOGNING
 
 
-	 ** När du är i Normal-läge tryck  i  för att infoga text. **
+		    ** Tryck  i  för att infoga text. **
 
-  1. Flytta markören till den första raden nedan med markeringen --->.
+  1. Flytta markören till första raden nedan markerad med --->.
 
-  2. För att göra den första raden likadan som den andra, flytta markören till
-     det första tecknet EFTER där text ska infogas.
+  2. För att göra första raden likadan som den andra, flytta markören till
+     tecknet FÖRE vilket texten ska infogas.
 
-  3. Tryck  i  och skriv in det som saknas.
+  3. Tryck  i  och skriv in de nödvändiga tilläggen.
 
-  4. När du rättat ett fel tryck <ESC> för att återgå till Normal-läge.
+  4. När varje fel är rättat, tryck <ESC> för att återgå till Normalläge.
      Upprepa steg 2 till 4 för att rätta meningen.
 
----> Det sakns här .
+---> Det saknas lit från den här .
 ---> Det saknas lite text från den här raden.
 
-  5. När du känner dig bekväm med att infoga text, gå till sammanfattningen
-     nedan.
+  5. När du känner dig bekväm med att infoga text, gå till Lektion 1.1.5.
 
 
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-			       LEKTION 1.1 SAMMANFATTNING
+		     Lektion 1.1.5: TEXTREDIGERING - LÄGGA TILL
 
 
-  1. Markören flyttas genom att använda piltangenterna eller hjkl-tangenterna.
+		    ** Tryck  A  för att lägga till text. **
+
+  1. Flytta markören till första raden nedan markerad med --->.
+     Det spelar ingen roll på vilket tecken markören är på den raden.
+
+  2. Tryck  A  och skriv in de nödvändiga tilläggen.
+
+  3. När texten har lagts till, tryck <ESC> för att återgå till Normalläge.
+
+  4. Flytta markören till den andra raden markerad ---> och upprepa
+     steg 2 och 3 för att rätta denna mening.
+
+---> Det saknas lite text från de
+     Det saknas lite text från den här raden.
+---> Det saknas också lite tex
+     Det saknas också lite text här.
+
+  5. När du känner dig bekväm med att lägga till text, gå till Lektion 1.1.6.
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+		     Lektion 1.1.6: REDIGERA EN FIL
+
+
+		    ** Använd  :wq  för att spara en fil och avsluta. **
+
+  !! NOTERA: Innan du utför någon av punkterna nedan, läs hela lektionen!!
+
+  1.  Om du har tillgång till en annan terminal, gör följande där.
+      Annars, avsluta denna handledning som i Lektion 1.1.2:  :q!
+
+  2. Vid skalprompten, skriv detta kommando:  vim fil.txt <ENTER>
+     'vim' är kommandot för att starta Vim-redigeraren, 'fil.txt' är namnet på
+     filen du vill redigera. Använd ett namn på en fil som du kan ändra.
+
+  3. Infoga och ta bort text som du lärt dig i tidigare lektioner.
+
+  4. Spara filen med ändringar och avsluta Vim med:  :wq <ENTER>
+
+  5. Om du avslutade vimtutor i steg 1, starta om vimtutor och flytta ned till
+     följande sammanfattning.
+
+  6. Efter att ha läst stegen ovan och förstått dem: gör det.
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+			       Lektion 1.1 SAMMANFATTNING
+
+
+  1. Markören flyttas med antingen piltangenterna eller hjkl-tangenterna.
 	 h (vänster)	j (ned)       k (upp)	    l (höger)
 
-  2. För att starta Vim (från %-prompten) skriv:  vim FILNAMN <ENTER>
+  2. För att starta Vim från skalprompten, skriv:  vim FILNAMN <ENTER>
 
-  3. För att avsluta Vim skriv:  <ESC>  :q!  <ENTER>  för att kasta ändringar.
-		   ELLER skriv:  <ESC>	:wq  <ENTER>  för att spara ändringar.
+  3. För att avsluta Vim, skriv:   <ESC>   :q!	<ENTER>  för att kasta ändringar.
+	     ELLER skriv:	   <ESC>   :wq	<ENTER>  för att spara ändringar.
 
-  4. För att ta bort tecknet under markören i Normal-läge skriv:  x
+  4. För att ta bort tecknet vid markören, skriv:  x
 
-  5. För att infoga text vid markören i Normal-läge skriv:
-	 i     skriv in text	<ESC>
+  5. För att infoga eller lägga till text, skriv:
+	 i   skriv infogad text   <ESC>		infoga före markören
+	 A   skriv tillagd text   <ESC>         lägg till efter raden
 
-NOTERA: Genom att trycka <ESC> kommer du att placeras i Normal-läge eller
-	avbryta ett delvis färdigskrivet kommando.
+NOTERA: Att trycka <ESC> placerar dig i Normalläge eller avbryter ett
+	oönskat och delvis slutfört kommando.
 
 Fortsätt nu med Lektion 1.2.
-
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 			Lektion 1.2.1: BORTTAGNINGSKOMMANDON
 
 
-	    ** Skriv  dw  för att radera till slutet av ett ord. **
+		       ** Skriv  dw  för att ta bort ett ord. **
 
-  1. Tryck  <ESC>  för att försäkra dig om att du är i Normal-läge.
+  1. Tryck  <ESC>  för att se till att du är i Normalläge.
 
-  2. Flytta markören till raden nedan markerad --->.
+  2. Flytta markören till raden nedan markerad med --->.
 
-  3. Flytta markören till början av ett ord som måste raderas.
+  3. Flytta markören till början av ett ord som behöver tas bort.
 
-  4. Skriv   dw	 för att radera ordet.
+  4. Skriv   dw	 för att få ordet att försvinna.
 
-  NOTERA: Bokstäverna dw kommer att synas på den sista raden på skärmen när
-	du skriver dem. Om du skrev något fel, tryck  <ESC>  och börja om.
+NOTERA: Bokstaven  d  kommer att synas på sista raden på skärmen när du
+	skriver den. Vim väntar på att du ska skriva  w . Om du ser ett annat
+	tecken än  d  skrev du fel; tryck <ESC> och börja om.
 
----> Det är ett några ord roliga att som inte hör hemma i den här meningen.
+---> Det finns a några ord kul som inte hör hemma papper i den här meningen.
 
-  5. Upprepa stegen 3 och 4 tills meningen är korrekt och gå till Lektion 1.2.2.
-
+  5. Upprepa steg 3 och 4 tills meningen är korrekt och gå till Lektion 1.2.2.
 
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 		      Lektion 1.2.2: FLER BORTTAGNINGSKOMMANDON
 
 
-	   ** Skriv  d$	för att radera till slutet på raden. **
+	   ** Skriv  d$  för att ta bort till slutet av raden. **
 
-  1. Tryck  <ESC>  för att försäkra dig om att du är i Normal-läge.
+  1. Tryck  <ESC>  för att se till att du är i Normalläge.
 
-  2. Flytta markören till raden nedan markerad --->.
+  2. Flytta markören till raden nedan markerad med --->.
 
-  3. Flytta markören till slutet på den rätta raden (EFTER den första . ).
+  3. Flytta markören till slutet av den korrekta raden (EFTER den första . ).
 
-  4. Skriv    d$    för att radera till slutet på raden.
+  4. Skriv    d$    för att ta bort till slutet av raden.
 
----> Någon skrev slutet på den här raden två gånger. den här raden två gånger.
+---> Någon skrev slutet av denna rad två gånger. slutet av denna rad två gånger.
 
 
-  5. Gå vidare till Lektion 1.2.3 för att förstå vad det är som händer.
+  5. Gå vidare till Lektion 1.2.3 för att förstå vad som händer.
+
+
+
+
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+		     Lektion 1.2.3: OM OPERATORER OCH RÖRELSER
+
+
+  Många kommandon som ändrar text är gjorda av en operator och en rörelse.
+  Formatet för ett borttagningskommando med  d  borttagningsoperatorn är:
+
+  	d   rörelse
+
+  Där:
+    d      - är borttagningsoperatorn.
+    rörelse - är vad operatorn ska operera på (listad nedan).
+
+  En kort lista med rörelser:
+    w - till början av nästa ord, EXKLUSIVE dess första tecken.
+    e - till slutet av nuvarande ord, INKLUSIVE det sista tecknet.
+    $ - till slutet av raden, INKLUSIVE det sista tecknet.
+
+  Alltså kommer  de  att ta bort från markören till slutet av ordet.
+
+NOTERA: Att bara trycka rörelsen i Normalläge utan operator kommer att flytta
+	markören som specificerat.
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+		     Lektion 1.2.4: ANVÄNDA ANTAL FÖR EN RÖRELSE
+
+
+   ** Att skriva ett nummer före en rörelse repeterar den så många gånger. **
+
+  1. Flytta markören till början av raden nedan markerad med --->.
+
+  2. Skriv  2w  för att flytta markören två ord framåt.
+
+  3. Skriv  3e  för att flytta markören till slutet av det tredje ordet framåt.
+
+  4. Skriv  0  (noll) för att flytta till början av raden.
+
+  5. Upprepa steg 2 och 3 med olika nummer.
+
+---> Detta är bara en rad med ord som du kan flytta runt i.
+
+  6. Gå vidare till Lektion 1.2.5.
+
+
+
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+		     Lektion 1.2.5: ANVÄNDA ANTAL FÖR ATT TA BORT MER
+
+
+   ** Att skriva ett nummer med en operator repeterar den så många gånger. **
+
+  I kombinationen av borttagningsoperatorn och en rörelse nämnd ovan kan du
+  infoga ett antal före rörelsen för att ta bort mer:
+	 d   antal   rörelse
+
+  1. Flytta markören till det första VERSALA ordet på raden markerad med --->.
+
+  2. Skriv  d2w  för att ta bort de två VERSALA orden.
+
+  3. Upprepa steg 1 och 2 med olika antal för att ta bort de efterföljande
+     VERSALA orden med ett kommando.
+
+--->  denna ABC DE rad FGHI JK LMN OP av ord är Q RS TUV städad.
 
 
 
 
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-		     Lesson 1.2.3: KOMMANDON OCH OBJEKT
+			 Lektion 1.2.6: OPERERA PÅ RADER
 
 
-  Syntaxen för  d  raderingskommandot är följande:
+		   ** Skriv  dd   för att ta bort en hel rad. **
 
-	 [nummer]   d	objekt	    ELLER	     d	 [nummer]   objekt
-  Var:
-    nummer - är antalet upprepningar av kommandot (valfritt, standard=1).
-    d - är kommandot för att radera.
-    objekt - är vad kommandot kommer att operera på (listade nedan).
-
-  En kort lista över objekt:
-    w - från markören till slutet av ordet, inklusive blanksteget.
-    e - från markören till slutet av ordet, EJ inklusive blanksteget.
-    $ - från markören till slutet på raden.
-
-NOTERA:  För den äventyrslystne, genom att bara trycka på objektet i
-	 Normal-läge (utan kommando) så kommer markören att flyttas som
-	 angivet i objektlistan.
-
-
-
-
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-		Lektion 1.2.4: ETT UNDANTAG TILL 'KOMMANDO-OBJEKT'
-
-
-	       ** Skriv	 dd   för att radera hela raden. **
-
-  På grund av hur vanligt det är att ta bort hela rader, valde upphovsmannen
-  till Vi att det skulle vara enklare att bara trycka d två gånger i rad för
-  att ta bort en rad.
+  På grund av hur vanligt det är att ta bort hela rader, beslutade Vis
+  konstruktörer att det skulle vara enklare att bara skriva två d för att
+  ta bort en rad.
 
   1. Flytta markören till den andra raden i frasen nedan.
-  2. Skriv  dd  för att radera raden.
+  2. Skriv  dd  för att ta bort raden.
   3. Flytta nu till den fjärde raden.
-  4. Skriv   2dd   (kom ihåg:  nummer-kommando-objekt) för att radera de två
-     raderna.
+  4. Skriv   2dd   för att ta bort två rader.
 
-      1)  Roses are red,
-      2)  Mud is fun,
-      3)  Violets are blue,
-      4)  I have a car,
-      5)  Clocks tell time,
-      6)  Sugar is sweet
-      7)  And so are you.
+--->  1)  Rosor är röda,
+--->  2)  Lera är kul,
+--->  3)  Violer är blå,
+--->  4)  Jag har en bil,
+--->  5)  Klockor visar tid,
+--->  6)  Socker är sött
+--->  7)  Och det är du med.
 
-
+Att dubbla för att operera på en rad fungerar också för operatorer nämnda nedan.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-			 Lektion 1.2.5: ÅNGRA-KOMMANDOT
+			 Lektion 1.2.7: ÅNGRA-KOMMANDOT
 
 
-** Skriv  u för att ångra det senaste kommandona,  U för att fixa en hel rad. **
+   ** Tryck  u  för att ångra senaste kommandot,  U  för att fixa en hel rad. **
 
-  1. Flytta markören till slutet av raden nedan markerad ---> och placera den
-     på det första felet.
-  2. Skriv  x  för att radera den första felaktiga tecknet.
-  3. Skriv nu  u  för att ångra det senaste körda kommandot.
-  4. Rätta den här gången alla felen på raden med  x-kommandot.
-  5. Skriv nu  U  för att återställa raden till dess ursprungliga utseende.
-  6. Skriv nu  u  några gånger för att ångra  U  och tidigare kommandon.
-  7. Tryck nu CTRL-R (håll inne CTRL samtidigt som du trycker R) några gånger
-     för att upprepa kommandona (ångra ångringarna).
+  1. Flytta markören till raden nedan markerad ---> och placera den på det
+     första felet.
+  2. Skriv  x  för att ta bort det första oönskade tecknet.
+  3. Skriv nu  u  för att ångra det senast körda kommandot.
+  4. Denna gång, rätta alla fel på raden med  x  kommandot.
+  5. Skriv nu ett stort  U  för att återställa raden till dess ursprungliga tillstånd.
+  6. Skriv nu  u  några gånger för att ångra  U  och föregående kommandon.
+  7. Tryck nu CTRL-R (håll CTRL nedtryckt medan du trycker R) några gånger
+     för att göra om kommandona (ångra ångringarna).
 
----> Fiixa felen ppå deen häär meningen och återskapa dem med ångra.
+---> Rätta feelen på dennna rad ochh ersätt dem meed ångra.
 
-  8. Det här är väldigt användbara kommandon.  Gå nu vidare till
-     Lektion 1.2 Sammanfattning.
+  8. Dessa är mycket användbara kommandon. Gå nu vidare till Lektion 1.2 Sammanfattning.
 
 
 
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-			       LEKTION 1.2 SAMMANFATTNING
+			       Lektion 1.2 SAMMANFATTNING
 
+  1. För att ta bort från markören till nästa ord, skriv:       dw
+  2. För att ta bort från markören till slutet av ordet, skriv: de
+  3. För att ta bort från markören till slutet av raden, skriv: d$
+  4. För att ta bort en hel rad, skriv:                         dd
 
-  1. För att radera från markören till slutet av ett ord skriv:    dw
-
-  2. För att radera från markören till slutet av en rad skriv:    d$
-
-  3. För att radera en hel rad skriv:    dd
-
-  4. Syntaxen för ett kommando i Normal-läge är:
-
-       [nummer]   kommando   objekt   ELLER   kommando   [nummer]   objekt
+  5. För att repetera en rörelse, sätt ett nummer före den:   2w
+  6. Formatet för ett ändringskommando är:
+               operator   [antal]   rörelse
      där:
-       nummer - är hur många gånger kommandot kommandot ska repeteras
-       kommando - är vad som ska göras, t.ex.  d  för att radera
-       objekt - är vad kommandot ska operera på, som t.ex.  w (ord),
-		$ (till slutet av raden), etc.
+       operator - är vad som ska göras, såsom  d  för ta bort
+       [antal]  - är ett valfritt antal för att repetera rörelsen
+       rörelse  - rör sig över texten att operera på, såsom  w (ord),
+		  e (slut på ord),  $ (slut på rad), osv.
 
-  5. För att ångra tidigare kommandon, skriv:  u (litet u)
-     För att ångra alla tidigare ändringar på en rad skriv:  U (stort U)
-     För att ångra ångringar tryck:  CTRL-R
+  7. För att flytta till början av raden, använd noll:  0
+
+  8. För att ångra tidigare handlingar, skriv:         u  (litet u)
+     För att ångra alla ändringar på en rad, skriv:    U  (stort U)
+     För att ångra ångringarna, skriv:                 CTRL-R
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 			 Lektion 1.3.1: KLISTRA IN-KOMMANDOT
 
 
-   ** Skriv  p  för att klistra in den senaste raderingen efter markören. **
+       ** Skriv  p  för att klistra in tidigare borttagen text efter markören. **
 
-  1. Flytta markören till den första raden i listan nedan.
+  1. Flytta markören till den första raden nedan markerad med --->.
 
-  2. Skriv  dd  för att radera raden och lagra den i Vims buffert.
+  2. Skriv  dd  för att ta bort raden och lagra den i ett Vim-register.
 
-  3. Flytta markören till raden OVANFÖR där den raderade raden borde vara.
+  3. Flytta markören till rad c), OVANFÖR där den borttagna raden ska vara.
 
-  4. När du är i Normal-läge, skriv    p	 för att byta ut raden.
+  4. Skriv   p   för att lägga raden under markören.
 
-  5. Repetera stegen 2 till 4 för att klistra in alla rader i rätt ordning.
+  5. Upprepa steg 2 till 4 för att lägga alla rader i korrekt ordning.
 
-     d) Kan du lära dig också?
-     b) Violetter är blå,
-     c) Intelligens fås genom lärdom,
-     a) Rosor är röda,
-
-
-
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-		       Lesson 1.3.2: ERSÄTT-KOMMANDOT
-
-
-  ** Skriv  r  och ett tecken för att ersätta tecknet under markören. **
-
-  1. Flytta markören till den första raden nedan markerad --->.
-
-  2. Flytta markören så att den står på det första felet.
-
-  3. Skriv   r	och sedan det tecken som borde ersätta felet.
-
-  4. Repetera steg 2 och 3 tills den första raden är korrekt.
-
---->  När drn här ruden skrevs, trickte någon på fil knappar!
---->  När den här raden skrevs, tryckte någon på fel knappar!
-
-  5. Gå nu vidare till Lektion 1.3.2.
-
-NOTERA: Kom ihåg att du skall lära dig genom användning, inte genom memorering.
+---> d) Kan du också lära dig?
+---> b) Violer är blå,
+---> c) Intelligens är lärt,
+---> a) Rosor är röda,
 
 
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-			Lektion 1.3.3: ÄNDRA-KOMMANDOT
+		       Lektion 1.3.2: ERSÄTT-KOMMANDOT
 
 
-	   ** För att ändra en del eller ett helt ord, skriv  cw . **
+       ** Skriv  rx  för att ersätta tecknet vid markören med  x . **
 
-  1. Flytta markören till den första redan nedan markerad --->.
+  1. Flytta markören till den första raden nedan markerad med --->.
 
-  2. Placera markören på d i rdrtn.
+  2. Flytta markören så att den är ovanpå det första felet.
 
-  3. Skriv  cw  och det rätta ordet (i det här fallet, skriv "aden".)
+  3. Skriv   r	och sedan tecknet som borde vara där.
 
-  4. Tryck <ESC> och flytta markören till nästa fel (det första tecknet som
-     ska ändras.)
+  4. Upprepa steg 2 och 3 tills den första raden är lika som den andra.
 
-  5. Repetera steg 3 och 4 tills den första raden är likadan som den andra.
+--->  Näe danne rad skrevs in, tryckte någpn några felaktiga tangenter!
+--->  När denna rad skrevs in, tryckte någon några felaktiga tangenter!
 
----> Den här rdrtn har några otf som brhotrt ändras mrf ändra-komjendit.
----> Den här raden har några ord som behöver ändras med ändra-kommandot.
+  5. Gå nu vidare till Lektion 1.3.3.
 
-Notera att  cw  inte bara ändrar ordet, utan även placerar dig i infogningsläge.
+NOTERA: Kom ihåg att du bör lära dig genom att göra, inte genom att memorera.
 
+
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+			Lektion 1.3.3: ÄNDRA-OPERATORN
+
+
+	   ** För att ändra till slutet av ett ord, skriv  ce . **
+
+  1. Flytta markören till den första raden nedan markerad med --->.
+
+  2. Placera markören på  u  i  kubw.
+
+  3. Skriv  ce  och det korrekta ordet (i detta fall, skriv  ine ).
+
+  4. Tryck <ESC> och flytta till nästa tecken som behöver ändras.
+
+  5. Upprepa steg 3 och 4 tills den första meningen är likadan som den andra.
+
+---> Denna kubw har några otf som mfpr ändras anef ändra-operatorn.
+---> Denna rad har några ord som behöver ändras med ändra-operatorn.
+
+Observera att  ce  tar bort ordet och placerar dig i Infogningsläge.
+               cc  gör samma sak för hela raden.
 
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 		       Lektion 1.3.4: FLER ÄNDRINGAR MED c
 
 
-     ** Ändra-kommandot används på samma objekt som radera. **
+     ** Ändra-operatorn används med samma rörelser som borttagning. **
 
-  1. Ändra-kommandot fungerar på samma sätt som radera. Syntaxen är:
+  1. Ändra-operatorn fungerar på samma sätt som borttagning. Formatet är:
 
-       [nummer]   c   objekt	   ELLER	    c	[nummer]   objekt
+         c    [antal]   rörelse
 
-  2. Objekten är också de samma, som t.ex.   w (ord), $ (slutet av raden), etc.
+  2. Rörelserna är desamma, såsom   w (ord) och  $ (slutet av raden).
 
-  3. Flytta till den första raden nedan markerad -->.
+  3. Flytta markören till den första raden nedan markerad med --->.
 
   4. Flytta markören till det första felet.
 
-  5. Skriv  c$  för att göra resten av raden likadan som den andra och tryck
-     <ESC>.
+  5. Skriv  c$  och skriv resten av raden som den andra och tryck <ESC>.
 
----> Slutet på den här raden behöver hjälp med att få den att likna den andra.
----> Slutet på den här raden behöver rättas till med  c$-kommandot.
+---> Slutet av denna rad behöver hjälp för att bli som den andra.
+---> Slutet av denna rad behöver rättas med c$ kommandot.
+
+NOTERA: Du kan använda Backsteg-tangenten för att rätta misstag när du skriver.
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+			       Lektion 1.3 SAMMANFATTNING
+
+
+  1. För att klistra tillbaka text som just tagits bort, skriv   p . Detta
+     lägger den borttagna texten EFTER markören (om en rad togs bort hamnar
+     den på raden under markören).
+
+  2. För att ersätta tecknet under markören, skriv   r   och sedan tecknet
+     du vill ha där.
+
+  3. Ändra-operatorn låter dig ändra från markören till dit rörelsen tar dig.
+     T.ex. Skriv  ce  för att ändra från markören till slutet av ordet,
+     c$  för att ändra till slutet av raden.
+
+  4. Formatet för ändra är:
+
+	 c   [antal]   rörelse
+
+Gå nu vidare till nästa lektion.
 
 
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-			       LEKTION 1.3 SAMMANFATTNING
+		  Lektion 1.4.1: MARKÖRPOSITION OCH FILSTATUS
 
+  ** Skriv CTRL-G för att visa din position i filen och filstatus.
+     Skriv  G  för att flytta till en rad i filen. **
 
-  1. För att ersätta text som redan har blivit raderad, skriv   p .
-     Detta klistrar in den raderade texten EFTER markören (om en rad raderades
-     kommer den att hamna på raden under markören.
+  NOTERA: Läs hela denna lektion innan du utför något av stegen!!
 
-  2. För att ersätta tecknet under markören, skriv   r   och sedan tecknet som
-     kommer att ersätta orginalet.
+  1. Håll ned Ctrl-tangenten och tryck  g . Vi kallar detta CTRL-G.
+     Ett meddelande kommer att visas längst ned på sidan med filnamnet och
+     positionen i filen. Kom ihåg radnumret för Steg 3.
 
-  3. Ändra-kommandot låter dig ändra det angivna objektet från markören till
-     slutet på objektet. eg. Skriv  cw  för att ändra från markören till slutet
-     på ordet, c$	för att ändra till slutet på en rad.
+NOTERA: Du kanske ser markörpositionen i nedre högra hörnet av skärmen.
+	Detta händer när 'ruler'-alternativet är satt (se  :help 'ruler'  )
 
-  4. Syntaxen för ändra-kommandot är:
+  2. Tryck  G  för att flytta dig till botten av filen.
+     Skriv  gg  för att flytta dig till början av filen.
 
-	 [nummer]   c	objekt	      ELLER	c   [nummer]   objekt
+  3. Skriv numret på raden du var på och sedan  G . Detta tar dig tillbaka
+     till raden du var på när du först tryckte CTRL-G.
 
-Gå nu till nästa lektion.
-
-
-
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-		     Lektion 1.4.1: POSITION OCH FILSTATUS
-
-
-  ** Tryck CTRL-g för att visa din position i filen och filstatusen.
-     Tryck SHIFT-G för att flytta till en rad i filen. **
-
-  Notera: Läsa hela den lektion innan du utför något av stegen!!
-
-  1. Håll ned Ctrl-tangenten och tryck  g . En statusrad med filnamn och raden
-     du befinner dig på kommer att synas. Kom ihåg radnummret till Steg 3.
-
-  2. Tryck shift-G för att flytta markören till slutet på filen.
-
-  3. Skriv in nummret på raden du var på och tryck sedan shift-G. Detta kommer
-     att ta dig tillbaka till raden du var på när du först tryckte Ctrl-g.
-     (När du skriver in nummren, kommer de INTE att visas på skärmen.)
-
-  4. Om du känner dig säker på det här, utför steg 1 till 3.
-
-
+  4. Om du känner dig säker på detta, utför steg 1 till 3.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 			Lektion 1.4.2: SÖK-KOMMANDOT
@@ -426,232 +514,234 @@ Gå nu till nästa lektion.
 
      ** Skriv  /  följt av en fras för att söka efter frasen. **
 
-  1. I Normal-läge skriv /-tecknet. Notera att det och markören blir synlig
-     längst ned på skärmen precis som med :-kommandot.
+  1. I Normalläge, skriv  /  tecknet. Lägg märke till att det och markören
+     visas längst ned på skärmen som med  :  kommandot.
 
-  2. Skriv nu "feeel" <ENTER>. Det här är ordet du vill söka efter.
+  2. Skriv nu 'feeeel' <ENTER>. Detta är ordet du vill söka efter.
 
-  3. För att söka efter samma fras igen, tryck helt enkelt  n .
-     För att söka efter samma fras igen i motsatt riktning, tryck  Shift-N .
+  3. För att söka efter samma fras igen, skriv helt enkelt  n .
+     För att söka efter samma fras i motsatt riktning, skriv  N .
 
-  4. Om du vill söka efter en fras bakåt i filen, använd kommandot  ?  istället
-     för /.
+  4. För att söka efter en fras baklänges, använd  ?  istället för  / .
 
----> "feeel" är inte rätt sätt att stava fel: feeel är ett fel.
+  5. För att gå tillbaka dit du kom ifrån, tryck  CTRL-O  (håll Ctrl nedtryckt
+     medan du trycker bokstaven o). Upprepa för att gå längre tillbaka. CTRL-I
+     går framåt.
 
-Notera: När sökningen når slutet på filen kommer den att fortsätta vid början.
+---> "feeeel" är inte hur man stavar feel; feeeel är ett fel.
 
-
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-		   Lektion 1.4.3: SÖKNING EFTER MATCHANDE PARENTESER
-
-
-	      ** Skriv  %  för att hitta en matchande ),], or } . **
-
-  1. Placera markören på någon av (, [, or { på raden nedan markerad --->.
-
-  2. Skriv nu %-tecknet.
-
-  3. Markören borde vara på den matchande parentesen eller hakparentesen.
-
-  4. Skriv  %  för att flytta markören tillbaka till den första hakparentesen
-     (med matchning).
-
----> Det ( här är en testrad med (, [ ] och { } i den. ))
-
-Notera: Det här är väldigt användbart vid avlusning av ett program med icke
-	matchande parenteser!
-
-
-
-
-
+NOTERA: När sökningen når slutet av filen fortsätter den från början, såvida
+	inte 'wrapscan'-alternativet har återställts.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-		      Lektion 1.4.4: ETT SÄTT ATT ÄNDRA FEL
+		   Lektion 1.4.3: SÖKA MATCHANDE PARENTESER
 
 
-	** Skriv  :s/gammalt/nytt/g  för att ersätta "gammalt" med "nytt". **
+	      ** Skriv  %  för att hitta en matchande ), ] eller }. **
 
-  1. Flytta markören till raden nedan markerad --->.
+  1. Placera markören på någon (, [ eller { på raden nedan markerad med --->.
 
-  2. Skriv  :s/denn/den <ENTER> . Notera att det här kommandot bara ändrar den
-     första förekomsten på raden.
+  2. Skriv nu  %  tecknet.
 
-  3. Skriv nu	 :s/denn/den/g	   vilket betyder ersätt globalt på raden.
-     Det ändrar alla förekomster på raden.
+  3. Markören kommer att flytta till den matchande parentesen eller hakparentesen.
 
----> denn bästa tiden att se blommor blomma är denn på våren.
+  4. Skriv  %  för att flytta markören till den andra matchande parentesen.
 
-  4. För att ändra alla förekomster av en teckensträng mellan två rader,
-     skriv  :#,#s/gammalt/nytt/g    där #,# är de två radernas radnummer.
-     Skriv  :%s/gammtl/nytt/g    för att ändra varje förekomst i hela filen.
+  5. Flytta markören till en annan (, ), [, ], { eller } och se vad  %  gör.
 
+---> Detta ( är en testrad med (, [ ] och { } i den. ))
+
+
+NOTERA: Detta är väldigt användbart vid felsökning av ett program med
+	omatchade parenteser!
 
 
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-			       LEKTION 1.4 SAMMANFATTNING
+		      Lektion 1.4.4: ERSÄTT-KOMMANDOT
 
 
-  1. Ctrl-g  visar din position i filen och filstatusen.
-     Shift-G  flyttar till slutet av filen. Ett radnummer följt  Shift-G
-     flyttar till det radnummret.
+	** Skriv  :s/gammalt/nytt/g  för att ersätta 'gammalt' med 'nytt'. **
 
-  2. Skriver man  /	följt av en fras söks det FRAMMÅT efter frasen.
-     Skriver man  ?	följt av en fras söks det BAKÅT efter frasen.
-     Efter en sökning skriv  n  för att hitta nästa förekomst i samma riktning
-     eller  Shift-N  för att söka i den motsatta riktningen.
+  1. Flytta markören till raden nedan markerad med --->.
 
-  3. Skriver man  %	när markören är på ett  (,),[,],{, eller }  hittas dess
+  2. Skriv  :s/denn/den/ <ENTER> . Notera att detta kommando bara ändrar den
+     första förekomsten av "denn" på raden.
+
+  3. Skriv nu  :s/denn/den/g . Att lägga till  g  flaggan betyder att ersätta
+     globalt på raden, och ändrar alla förekomster av "denn" på raden.
+
+---> denn bästa tiden att se denn blomman är under denn sommarn.
+
+  4. För att ändra varje förekomst av en teckensträng mellan två rader,
+     skriv  :#,#s/gammalt/nytt/g  där #,# är radnumren på de två raderna för
+			         intervallet där ersättningen ska göras.
+     Skriv  :%s/gammalt/nytt/g  för att ändra varje förekomst i hela filen.
+     Skriv  :%s/gammalt/nytt/gc för att hitta varje förekomst i hela filen,
+			         med en prompt om du vill ersätta eller inte.
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+			       Lektion 1.4 SAMMANFATTNING
+
+
+  1. CTRL-G  visar din position i filen och filstatus.
+	     G  flyttar till slutet av filen.
+     antal  G  flyttar till det radnumret.
+	    gg  flyttar till första raden.
+
+  2. Att skriva  /  följt av en fras söker FRAMÅT efter frasen.
+     Att skriva  ?  följt av en fras söker BAKÅT efter frasen.
+     Efter en sökning, skriv  n  för att hitta nästa förekomst i samma
+     riktning eller  N  för att söka i motsatt riktning.
+     CTRL-O tar dig tillbaka till äldre positioner, CTRL-I till nyare positioner.
+
+  3. Att skriva  %  medan markören är på en (, ), [, ], { eller } hittar dess
      matchande par.
 
-  4. För att ersätta den första gammalt med nytt på en rad skriv  :s/gammlt/nytt
-     För att ersätta alla gammlt med nytt på en rad skriv  :s/gammlt/nytt/g
-     För att ersätta fraser mellan rad # och rad # skriv  :#,#s/gammlt/nytt/g
-     För att ersätta alla förekomster i filen skriv  :%s/gammlt/nytt/g
-     För att bekräfta varje gång lägg till "c"  :%s/gammlt/nytt/gc
-
+  4. För att ersätta ny för den första gammalt på en rad, skriv    :s/gammalt/nytt
+     För att ersätta ny för alla gammalt på en rad, skriv          :s/gammalt/nytt/g
+     För att ersätta fraser mellan två radnummer, skriv            :#,#s/gammalt/nytt/g
+     För att ersätta alla förekomster i filen, skriv               :%s/gammalt/nytt/g
+     För att få fråga om bekräftelse varje gång, lägg till 'c'     :%s/gammalt/nytt/gc
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 		Lektion 1.5.1: HUR MAN KÖR ETT EXTERNT KOMMANDO
 
 
-   ** Skriv  :!	följt av ett externt kommando för att köra det kommandot. **
+   ** Skriv  :!  följt av ett externt kommando för att köra det kommandot. **
 
-  1. Skriv det välbekanta kommandot	:  för att placera markören längst ned
-     på skärmen på skärmen. Detta låter dig skriva in ett kommando.
+  1. Skriv det välbekanta kommandot  :  för att placera markören längst ned
+     på skärmen. Detta låter dig skriva ett kommandorads-kommando.
 
-  2. Skriv nu  !  (utropstecken).  Detta låter dig köra ett godtyckligt externt
-     skalkommando.
+  2. Skriv nu  !  (utropstecken). Detta låter dig köra vilket externt
+     skalkommando som helst.
 
-  3. Som ett exempel skriv   ls   efter ! och tryck sedan <ENTER>. Detta kommer
-     att visa dig en listning av din katalog, precis som om du kört det vid
-     skalprompten. Använd  :!dir  om ls inte fungerar.
+  3. Som ett exempel, skriv   ls   efter ! och tryck sedan <ENTER>. Detta
+     kommer att visa dig en lista över din katalog, precis som om du var vid
+     en skalprompt. Eller använd  :!dir  om  ls  inte fungerar.
 
-Notera:  Det är möjligt att köra vilket externt kommando som helst på det här
-	 sättet.
+NOTERA: Det är möjligt att köra vilket externt kommando som helst på detta sätt,
+	också med argument.
 
-Notera:  Alla  :-kommandon måste avslutas med att trycka på <ENTER>
-
-
+NOTERA: Alla  :  kommandon måste avslutas genom att trycka <ENTER>
+	Från och med nu nämner vi inte alltid det.
 
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 		      Lektion 1.5.2: MER OM ATT SPARA FILER
 
 
-     ** För att spara ändringar gjorda i en fil, skriv  :w FILNAMN. **
+	** För att spara ändringarna i filen, skriv  :w FILNAMN . **
 
-  1. Skriv  :!dir  eller  :!ls  för att få en listning av din katalog.
-     Du vet redan att du måste trycka <ENTER> efter det här.
+  1. Skriv  :!ls  eller  :!dir  för att få en lista över din katalog.
+     Du vet redan att du måste trycka <ENTER> efter detta.
 
-  2. Välj ett filnamn som inte redan existerar, som t.ex. TEST.
+  2. Välj ett filnamn som inte finns ännu, såsom TEST.
 
-  3. Skriv nu:	 :w TEST   (där TEST är filnamnet du valt.)
+  3. Skriv nu:	 :w TEST   (där TEST är filnamnet du valde.)
 
-  4. Det här sparar hela filen	(Vim handledningen)  under namnet TEST.
-     För att verifiera detta, skriv    :!dir   igen för att se din katalog
+  4. Detta sparar hela filen (Vim Tutor) under namnet TEST.
+     För att verifiera detta, skriv   :!ls   eller  :!dir  igen för att se
+     din katalog.
 
-Notera: Om du skulle avsluta Vim och sedan öppna igen med filnamnet TEST så
-	skulle filen vara en exakt kopia av handledningen när du sparade den.
+NOTERA: Om du skulle avsluta Vim och starta igen med  vim TEST , skulle filen
+	vara en exakt kopia av handledningen när du sparade den.
 
-  5. Ta nu bort filen genom att skriva (MS-DOS):  :!del TEST
-				   eller (Unix):  :!rm TEST
-
-
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-		    Lektion 1.5.3: ETT SELEKTIVT SPARA-KOMMANDO
-
-
-	** För att spara en del av en fil, skriv   :#,# w FILNAMN **
-
-  1. Ännu en gång, skriv  :!dir  eller  :!ls  för att få en listning av din
-     katalog och välj ett passande filnamn som t.ex. TEST.
-
-  2. Flytta markören högst upp på den här sidan och tryck  Ctrl-g  för att få
-     reda på radnumret på den raden. KOM IHÅG DET NUMMRET!
-
-  3. Flytta nu längst ned på sidan och skriv  Ctrl-g igen.
-     KOM IHÅG DET RADNUMMRET OCKSÅ!
-
-  4. För att BARA spara en sektion till en fil, skriv   :#,# w TEST
-     där #,# är de två nummren du kom ihåg (toppen, botten) och TEST är
-     ditt filnamn.
-
-  5. Ännu en gång, kolla så att filen är där med  :!dir  men radera den INTE.
-
-
+  5. Ta nu bort filen genom att skriva (MS-DOS):    :!del TEST
+				   eller (Unix):    :!rm TEST
 
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-		   Lektion 1.5.4: TA EMOT OCH FÖRENA FILER
+		    Lektion 1.5.3: VÄLJA TEXT ATT SPARA
 
 
-       ** För att infoga innehållet av en fil, skriv   :r FILNAMN **
+	** För att spara del av filen, skriv  v  rörelse  :w FILNAMN **
 
-  1. Skriv   :!dir   för att försäkra dig om att TEST-filen från tidigare
-     fortfarande är kvar.
+  1. Flytta markören till denna rad.
 
-  2. Placera markören högst upp på den här sidan.
+  2. Tryck  v  och flytta markören till det femte objektet nedan. Lägg märke
+     till att texten markeras.
 
-NOTERA:  Efter att du kört Steg 3 kommer du att se Lektion 1.5.3.
-	 Flytta då NED till den här lektionen igen.
+  3. Tryck  :  tecknet. Längst ned på skärmen visas  :'<,'>  .
 
-  3. Ta nu emot din TEST-fil med kommandot   :r TEST   där TEST är namnet på
-     filen.
+  4. Skriv  w TEST  , där TEST är ett filnamn som inte finns ännu. Verifiera
+     att du ser  :'<,'>w TEST  innan du trycker <ENTER>.
 
-NOTERA:  Filen du tar emot placeras där markören är placerad.
+  5. Vim kommer att skriva de markerade raderna till filen TEST. Använd  :!ls
+     eller  :!dir  för att se den. Ta inte bort den ännu! Vi kommer att
+     använda den i nästa lektion.
 
-  4. För att verifiera att filen togs emot, gå tillbaka och notera att det nu
-     finns två kopior av Lektion 1.5.3, orginalet och filversionen.
+NOTERA: Att trycka  v  startar Visuell markering. Du kan flytta markören runt
+	för att göra markeringen större eller mindre. Sedan kan du använda en
+	operator för att göra något med texten. Till exempel,  d  tar bort texten.
 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+		   Lektion 1.5.4: HÄMTA OCH SAMMANFOGA FILER
+
+
+       ** För att infoga innehållet av en fil, skriv  :r FILNAMN  **
+
+  1. Placera markören precis ovanför denna rad.
+
+NOTERA: Efter att ha kört Steg 2 kommer du att se text från Lektion 1.5.3.
+	Flytta sedan NED för att se denna lektion igen.
+
+  2. Hämta nu din TEST-fil med kommandot   :r TEST   där TEST är namnet på
+     filen du använde.
+     Filen du hämtar placeras under markörens rad.
+
+  3. För att verifiera att en fil hämtades, flytta markören tillbaka och lägg
+     märke till att det nu finns två kopior av Lektion 1.5.3, originalet och
+     filversionen.
+
+NOTERA: Du kan också läsa utdata från ett externt kommando. Till exempel,
+	:r !ls  läser utdata från ls kommandot och lägger det under markören.
 
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-			       LEKTION 1.5 SAMMANFATTNING
+			       Lektion 1.5 SAMMANFATTNING
 
 
   1.  :!kommando  kör ett externt kommando.
 
       Några användbara exempel är:
 	 (MS-DOS)	  (Unix)
-	  :!dir		   :!ls		  -  visar en kataloglistning.
-	  :!del FILNAMN    :!rm FILNAMN   -  tar bort filen FILNAMN.
+	  :!dir		   :!ls		   -  visar en kataloglista.
+	  :!del FILNAMN	   :!rm FILNAMN    -  tar bort filen FILNAMN.
 
-  2.  :w FILNAMN  sparar den aktuella Vim-filen med namnet FILNAMN.
+  2.  :w FILNAMN  sparar nuvarande Vim-fil till disk med namnet FILNAMN.
 
-  3.  :#,#w FILNAMN  sparar raderna # till #  i filen FILNAMN.
+  3.  v  rörelse  :w FILNAMN  sparar de Visuellt markerade raderna i filen
+      FILNAMN.
 
-  4.  :r FILNAMN  tar emot filen FILNAMN och infogar den i den aktuella filen
-      efter markören.
+  4.  :r FILNAMN  hämtar diskfilen FILNAMN och lägger den under markörens
+      position.
 
-
-
-
+  5.  :r !ls  läser utdata från ls kommandot och lägger det under markörens
+      position.
 
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-			 Lektion 1.6.1: ÖPPNA-KOMMANDOT
+			Lektion 1.6.1: ÖPPNA-KOMMANDOT
 
 
- ** Skriv  o  för att öppna en rad under markören och placera dig i
-    Infoga-läge. **
+	   ** Skriv  o  för att öppna en rad under markören
+	      och placera dig i Infogningsläge. **
 
-  1. Flytta markören till raden nedan markerad --->.
+  1. Flytta markören till raden nedan markerad med --->.
 
-  2. Skriv  o (litet o) för att öppna upp en rad NEDANFÖR markören och placera
-     dig i Infoga-mode.
+  2. Skriv det lilla  o  för att öppna en rad UNDER markören och placera dig
+     i Infogningsläge.
 
   3. Kopiera nu raden markerad ---> och tryck <ESC> för att avsluta
-     Infoga-läget.
+     Infogningsläge.
 
----> Efter du skrivit  o  placerad markören på en öppen rad i Infoga-läge.
+---> När du har tryckt  o  placeras markören på den öppna raden i Infogningsläge.
 
-  4. För att öppna upp en rad OVANFÖR markören, skriv ett stort  O , istället
-     för ett litet  o. Pröva detta på raden nedan.
-Öppna upp en rad ovanför denna genom att trycka Shift-O när markören står här.
+  4. För att öppna en rad OVANFÖR markören, skriv helt enkelt ett stort  O ,
+     istället för ett litet  o . Prova detta på raden nedan.
 
+---> Öppna en rad ovanför denna genom att skriva O medan markören är på denna rad.
 
 
 
@@ -660,171 +750,190 @@ NOTERA:  Filen du tar emot placeras där markören är placerad.
 			Lektion 1.6.2: LÄGG TILL-KOMMANDOT
 
 
-	     ** Skriv  a  för att infoga text EFTER markören. **
+	    ** Skriv  a  för att infoga text EFTER markören. **
 
-  1. Flytta markören till slutet av den första raden nedan markerad ---> genom
-     att skriv  $	i Normal-läge.
+  1. Flytta markören till början av raden nedan markerad med --->.
 
-  2. Skriv ett  a  (litet a) för att lägga till text EFTER tecknet under
-     markören.  (Stort  A  lägger till i slutet av raden.)
+  2. Tryck  e  tills markören är på slutet av  ra .
 
-Notera: Detta undviker att behöva skriva  i , det sista tecknet, texten att
-	infoga, <ESC>, högerpil, och slutligen, x, bara för att lägga till i
-	slutet på en rad!
+  3. Skriv ett  a  (litet) för att lägga till text EFTER markören.
 
-  3. Gör nu färdigt den första raden. Notera också att lägga till är likadant
-      som Infoga-läge, enda skillnaden är positionen där texten blir infogad.
+  4. Slutför ordet som på raden under det. Tryck <ESC> för att avsluta
+     Infogningsläge.
 
----> Här kan du träna
----> Här kan du träna på att lägga till text i slutet på en rad.
+  5. Använd  e  för att flytta till nästa ofullständiga ord och upprepa
+     steg 3 och 4.
 
+---> Denna ra låter dig öv på att läg till te i en rad.
+---> Denna rad låter dig öva på att lägga till text i en rad.
 
+NOTERA: a, i och A går alla till samma Infogningsläge, den enda skillnaden är
+	var tecknen infogas.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-		    Lektion 1.6.3: EN ANNAN VERSION AV ERSÄTT
+		    Lektion 1.6.3: ETT ANNAT SÄTT ATT ERSÄTTA
 
 
       ** Skriv ett stort  R  för att ersätta fler än ett tecken. **
 
-  1. Flytta markören till den första raden nedan markerad --->.
+  1. Flytta markören till den första raden nedan markerad med --->. Flytta
+     markören till början av det första  xxx .
 
-  2. Placera markören vid början av det första ordet som är annorlunda jämfört
-     med den andra raden markerad ---> (ordet "sista").
+  2. Tryck nu  R  och skriv numret nedan det på den andra raden, så att det
+     ersätter xxx .
 
-  3. Skriv nu  R  och ersätt resten av texten på den första raden genom att
-     skriva över den gamla texten så att den första raden blir likadan som
-     den andra.
+  3. Tryck <ESC> för att lämna Ersättningsläge. Lägg märke till att resten
+     av raden förblir oförändrad.
 
----> För att få den första raden lika som den sista, använd tangenterna.
----> För att få den första raden lika som den andra, skriv R och den nya texten.
+  4. Upprepa stegen för att ersätta det återstående xxx .
 
-  4. Notera att när du trycker <ESC> för att avsluta, så blir eventuell
-     oförändrad text kvar.
+---> Att lägga 123 till xxx ger dig xxx.
+---> Att lägga 123 till 456 ger dig 579.
 
-
-
-
+NOTERA: Ersättningsläge är som Infogningsläge, men varje skrivet tecken tar
+	bort ett existerande tecken.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-			    Lektion 1.6.4: SÄTT FLAGGOR
+		    Lektion 1.6.4: KOPIERA OCH KLISTRA IN TEXT
 
-  ** Sätt en flagga så att en sökning eller ersättning ignorerar storlek **
 
-  1. Sök efter "ignore" genom att skriva:
-     /ignore
-     Repetera flera gånger genom att trycka på n-tangenten
+  ** Använd  y  operatorn för att kopiera text och  p  för att klistra in den **
 
-  2. Sätt 'ic' (Ignore Case) flaggan genom att skriva:
-     :set ic
+  1. Gå till raden nedan markerad med ---> och placera markören efter "a)".
 
-  3. Sök nu efter "ignore" igen genom att trycka: n
-     Repeat search several more times by hitting the n key
+  2. Starta Visuellt läge med  v  och flytta markören till precis före "första".
 
-  4. Sätt 'hlsearch' and 'incsearch' flaggorna:
-     :set hls is
+  3. Skriv  y  för att kopiera (yank) den markerade texten.
 
-  5. Skriv nu in sök-kommandot igen, och se vad som händer:
-     /ignore
+  4. Flytta markören till slutet av nästa rad:  j$
 
-  6. För att ta bort framhävningen av träffar, skriv
-     :nohlsearch
+  5. Skriv  p  för att klistra in texten. Skriv sedan:  ett andra <ESC> .
+
+  6. Använd Visuellt läge för att markera " objekt.", kopiera det med  y ,
+     flytta till slutet av nästa rad med  j$  och klistra in texten där med  p .
+
+--->  a) detta är det första objektet.
+      b)
+
+NOTERA: du kan också använda  y  som en operator;  yw  kopierar ett ord.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-			       LEKTION 1.6 SAMMANFATTNING
+		    Lektion 1.6.5: STÄLLA IN ALTERNATIV
 
 
-  1. Genom att skriva  o  öpnnas en rad NEDANFÖR markören och markören placeras
-     på den öppna raden i Infoga-läge.
-     Genom att skriva ett stort  O  öppnas raden OVANFÖR raden som markören är
-     på.
+  ** Ställ in ett alternativ så sökningar och ersättningar ignorerar skiftläge **
 
-  2. Skriv ett  a  för att infoga text EFTER tecknet som markören står på.
-     Genom att skriva ett stort  A  läggs text automatiskt till i slutet på
-     raden.
+  1. Sök efter 'ignorera' genom att skriva:   /ignorera <ENTER>
+     Upprepa flera gånger genom att trycka  n  tangenten.
 
-  3. Genom att skriva ett stort  R  hamnar du i Ersätt-läge till  <ESC>  trycks
-     för att avsluta.
+  2. Ställ in 'ic' (Ignorera skiftläge) alternativet genom att skriva:  :set ic
 
-  4. Genom att skriva ":set xxx" sätts flaggan "xxx"
+  3. Sök nu efter 'ignorera' igen genom att trycka  n
+     Lägg märke till att Ignorera och IGNORERA nu också hittas.
 
+  4. Ställ in 'hlsearch' och 'incsearch' alternativen:  :set hls is
 
+  5. Skriv nu in sökkommandot igen och se vad som händer:  /ignorera <ENTER>
 
+  6. För att inaktivera skiftlägeskänslighet, skriv:  :set noic
 
+NOTERA: För att ta bort markeringen av träffar, skriv:   :nohlsearch
+NOTERA: Om du vill ignorera skiftläge för bara en sökning, använd  \c
+	i frasen:  /ignorera\c  <ENTER>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+			       Lektion 1.6 SAMMANFATTNING
 
+  1. Skriv  o  för att öppna en rad UNDER markören och starta Infogningsläge.
+     Skriv  O  för att öppna en rad OVANFÖR markören.
 
+  2. Skriv  a  för att infoga text EFTER markören.
+     Skriv  A  för att infoga text efter slutet av raden.
 
+  3. Det stora  e  kommandot flyttar till slutet av ett ord.
 
+  4. Operatorn  y  kopierar text,  p  klistrar in den.
+
+  5. Att skriva ett stort  R  startar Ersättningsläge tills  <ESC>  trycks.
+
+  6. Att skriva ":set xxx" ställer in alternativet "xxx". Några alternativ är:
+  	'ic' 'ignorecase'	ignorera versaler/gemener vid sökning
+	'is' 'incsearch'	visa delmatchningar för en sökfras
+	'hls' 'hlsearch'	markera alla matchande fraser
+     Du kan använda antingen det långa eller korta alternativnamnet.
+
+  7. Sätt "no" före ett alternativnamn för att stänga av det:  :set noic
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-		       LEKTION 1.7: ON-LINE HJÄLP-KOMMANDON
+			      Lektion 1.7: ONLINE-HJÄLP
 
 
-		      ** Använd on-line hjälpsystemet **
+		       ** Använd online-hjälpsystemet **
 
-  Vim har ett omfattande on-line hjälpsystem. För att komma igång pröva ett av
-  dessa tre:
-	- tryck <HELP> tangenten (om du har någon)
-	- tryck <F1> tangenten (om du har någon)
+  Vim har ett omfattande online-hjälpsystem. För att komma igång, prova en
+  av dessa tre:
+	- tryck <HJÄLP>-tangenten (om du har en)
+	- tryck <F1>-tangenten (om du har en)
 	- skriv   :help <ENTER>
 
-  Skriv   :q <ENTER>   för att stränga hjälpfönstret.
+  Läs texten i hjälpfönstret för att ta reda på hur hjälpen fungerar.
+  Skriv  CTRL-W CTRL-W   för att hoppa från ett fönster till ett annat.
+  Skriv    :q <ENTER>    för att stänga hjälpfönstret.
 
-  Du kan hitta hjälp om nästan allting, genom att ge ett argument till
-  ":help" kommandot. Pröva dessa (glöm inte att trycka <ENTER>):
+  Du kan hitta hjälp om nästan allt genom att ge ett argument till
+  ":help"-kommandot.  Prova dessa (glöm inte att trycka <ENTER>):
 
 	:help w
-	:help c_<T
+	:help c_CTRL-D
 	:help insert-index
 	:help user-manual
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+			  Lektion 1.8: SKAPA ETT STARTSKRIPT
 
+			  ** Aktivera Vim-funktioner **
+
+  Vim har många fler funktioner än Vi, men de flesta är inaktiverade som
+  standard. För att börja använda fler funktioner behöver du skapa en
+  "vimrc"-fil.
+
+  1. Börja redigera "vimrc"-filen. Detta beror på ditt system:
+	:e ~/.vimrc		för Unix
+	:e ~/_vimrc		för MS-Windows
+
+  2. Läs nu in exempel-"vimrc"-filens innehåll:
+	:r $VIMRUNTIME/vimrc_example.vim
+
+  3. Skriv filen med:
+	:w
+
+  Nästa gång du startar Vim kommer den att använda syntaxmarkering.
+  Du kan lägga till alla dina föredragna inställningar i denna "vimrc"-fil.
+  För mer information, skriv  :help vimrc-intro
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-		       LEKTION 1.8: SKAPA ETT UPPSTARTSSKRIPT
+			       Lektion 1.9: SLUTSATS
 
-			  ** Aktivera Vim- funktioner **
+  Detta var tänkt att ge en kort översikt av Vim-redigeraren, precis tillräckligt
+  för att du ska kunna använda redigeraren ganska enkelt. Det är långt ifrån
+  komplett eftersom Vim har många många fler kommandon. Läs användarhandboken
+  härnäst: ":help user-manual".
 
-  Vim har många fler funktioner än Vi, men de flesta av dem är inaktiverade som
-  standard. För att börja använda fler funktioner måste du skapa en "vimrc"-fil.
-
-  1. Börja redigera "vimrc"-filen, detta beror på ditt system:
-	:edit ~/.vimrc		för Unix
-	:edit ~/_vimrc		för MS-Windows
-
-  2. Läs nu texten i exempel "vimrc"-filen:
-
-	:read $VIMRUNTIME/vimrc_example.vim
-
-  3. Spara filen med:
-
-	:write
-
-  Nästa gång du startar Vim kommer den att använda syntaxframhävning.
-  Du kan lägga till alla inställningar du föredrar till den här "vimrc"-filen.
-
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-  Detta avslutar handledningen i Vim. Den var avsedd att ge en kort översikt av
-  redigeraren Vim, bara tillräckligt för att du ska kunna använda redigeraren
-  relativt enkelt. Den är långt ifrån komplett eftersom Vim har många många fler
-  kommandon. Läs användarmanualen härnäst: ":help user-manual".
-
-  För vidare läsning rekommenderas den här boken:
+  För vidare läsning och studier rekommenderas denna bok:
 	Vim - Vi Improved - av Steve Oualline
-	Förlag: New Riders
-  Den första boken som är endast behandlar Vim. Speciellt användbar för
-  nybörjare. Det finns många exempel och bilder.
+	Förläggare: New Riders
+  Den första boken helt tillägnad Vim. Särskilt användbar för nybörjare.
+  Det finns många exempel och bilder.
   Se https://iccf-holland.org/click5.html
 
-  Den här boken är äldre och behandlar mer Vi än Vim, men rekommenderas också:
+  Denna äldre bok handlar mer om Vi än Vim, men rekommenderas också:
 	Learning the Vi Editor - av Linda Lamb
-	Förlag: O'Reilly & Associates Inc.
-  Det är en bra bok för att lära sig nästan allt som du vill kunna göra med Vi.
+	Förläggare: O'Reilly & Associates Inc.
+  Det är en bra bok för att lära sig nästan allt du vill göra med Vi.
   Den sjätte upplagan inkluderar också information om Vim.
 
-  Den här handledningen är skriven av Michael C. Pierce och Robert K. Ware,
-  Colorado School of Mines med idéer från Charles Smith,
+  Denna handledning skrevs av Michael C. Pierce och Robert K. Ware,
+  Colorado School of Mines med idéer av Charles Smith,
   Colorado State University.  E-post: bware@mines.colorado.edu.
 
   Modifierad för Vim av Bram Moolenaar.
-  Översatt av Johan Svedberg <johan@svedberg.com>
+  Svensk översättning av Johan Svedberg och Daniel Nylander.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/runtime/tutor/tutor2.sv
+++ b/runtime/tutor/tutor2.sv
@@ -1,0 +1,294 @@
+===============================================================================
+=    V ä l k o m m e n   t i l l   V I M - h a n d l e d n i n g e n          =
+=                              -   Version 1.7                                =
+===============================================================================
+=			    K A P I T E L   T V Å			      =
+===============================================================================
+
+     Hic Sunt Dracones: om detta är din första kontakt med Vim och du
+     avsåg att börja med introduktionskapitlet, skriv vänligen
+     :q!<ENTER> och kör vimtutor för kapitel 1 istället.
+
+     Den ungefärliga tiden för att slutföra detta kapitel är 8-10 minuter,
+     beroende på hur mycket tid som läggs på experimentering.
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+		     Lektion 2.1.1: BEMÄSTRA TEXTOBJEKT
+
+   ** Arbeta på logiska textblock med precision med hjälp av textobjekt **
+
+  1. Öva på ordoperationer:
+     - Placera markören på valfritt ord i raden nedan
+     - Skriv  diw  för att radera INRE ord (ord utan omgivande mellanslag)
+     - Skriv  daw  för att radera ETT ORD (inklusive efterföljande mellanslag)
+     - Prova med andra operatorer:  ciw  (ändra),  yiw  (kopiera),  gqiw  (formatera)
+
+---> Öva på: "Vims", (text_objekt), och 'kraftfulla' ord här.
+
+  2. Arbeta med innehåll inom parenteser:
+     - Placera markören inuti något () {} [] <> par nedan
+     - Skriv  di(  eller  dib  (radera inuti parentes)
+     - Skriv  da(  eller  dab  (radera runt parenteser)
+     - Prova samma med  i"/a"  för citattecken,  it/at  för HTML/XML-taggar
+
+---> Testfall: {klamrar}, [hakparenteser], <vinkelparenteser>, och "citerade" objekt.
+
+  3. Stycke- och meningsmanipulering:
+     - Använd  dip  för att radera inre stycke (markören var som helst i stycket)
+     - Använd  vap  för att visuellt markera hela stycket
+     - Prova  das  för att radera en mening (fungerar mellan .!? skiljetecken)
+
+  4. Avancerade kombinationer:
+     - ciwnew<ESC>    - Ändra nuvarande ord till "new"
+     - ciw"<CTRL-R>-"<ESC> - Omslut nuvarande ord med citattecken
+     - gUit           - Gör HTML-tagginnehåll till versaler
+     - va"p           - Markera citerad text och klistra över den
+
+---> Slutövning: (Ändra "denna" text) genom att [tillämpa {olika} operationer]<
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+		     Lektion 2.1.2: NAMNGIVNA REGISTER
+
+
+         ** Lagra två kopierade ord samtidigt och klistra sedan in dem **
+
+  1. Flytta markören till raden nedan markerad --->
+
+  2. Navigera till valfri punkt på ordet 'Edward' och skriv   "ayiw
+
+MINNESREGEL: till register(") namngivet (a) (y)ank (kopiera) (i)nre (w)ord (ord)
+
+  3. Navigera framåt till ordet 'kaka' (fk eller 3fc eller $2b eller /ka<ENTER>)
+     och skriv   "byiw
+
+  4. Navigera till valfri punkt på ordet 'Vince' och skriv   ciw<CTRL-R>a<ESC>
+
+MINNESREGEL: (c)hange (ändra) (i)nre (w)ord (ord) med <innehåll från (r)egister> namngivet (a)
+
+  5. Navigera till valfri punkt på ordet 'tårta' och skriv   ciw<CTRL-R>b<ESC>
+
+--->  a) Edward kommer hädanefter att ansvara för kaka-ransonerna
+      b) I denna egenskap kommer Vince ha ensam tårta-beslutanderätt
+
+OBS: Radering fungerar också till register, dvs. "sdiw raderar ordet under
+     markören till register s.
+
+REFERENS: 	Register 	:h registers
+		Namngivna register :h quotea
+		Förflyttning 	:h motion.txt<ENTER> /inner<ENTER>
+		CTRL-R		:h insert<ENTER> /CTRL-R<ENTER>
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+		     Lektion 2.1.3: UTTRYCKSREGISTRET
+
+
+	     ** Infoga resultat av beräkningar direkt **
+
+  1. Flytta markören till raden nedan markerad --->
+
+  2. Navigera till valfri punkt på det angivna numret
+
+  3. Skriv ciw<CTRL-R> följt av  =60*60*24<ENTER>
+
+  4. På nästa rad, gå in i infogningsläge och lägg till dagens datum med 
+     <CTRL-R> följt av  =system('date')<ENTER>
+
+OBS: Alla anrop till system är OS-beroende, t.ex. på Windows använd 
+      system('date /t')   eller  :r!date /t
+
+---> Jag har glömt det exakta antalet sekunder på en dag, är det 84600?
+     Dagens datum är: 
+
+OBS: samma sak kan uppnås med :pu=system('date')
+      eller, med färre tangenttryckningar :r!date
+
+REFERENS: 	Uttrycksregister 	:h quote=
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+		     Lektion 2.1.4: NUMRERADE REGISTER
+
+
+	** Tryck  yy och dd för att se deras effekt på registren **
+
+  1. Flytta markören till raden nedan markerad --->
+
+  2. Kopiera noll-raden, sedan inspektera register med  :reg<ENTER>
+
+  3. Radera rad 0. med "cdd, sedan inspektera register
+     (Var förväntar du dig att rad 0 ska vara?)
+
+  4. Fortsätt radera varje efterföljande rad, inspektera :reg medan du gör det
+
+OBS: Du bör märka att gamla helradsraderingar flyttas nedåt i listan
+      när nya helradsraderingar läggs till
+
+  5. Nu (p)asta följande register i ordning; c, 7, 4, 8, 2. dvs. "7p
+
+---> 0. Detta
+     9. vinglar
+     8. hemliga
+     7. är
+     6. på
+     5. axel
+     4. ett
+     3. krig
+     2. meddelande
+     1. hyllning
+
+OBS: Helradsraderingar (dd) lever mycket längre i de numrerade registren
+      än helradskopieringar, eller raderingar med mindre förflyttningar
+
+REFERENS: 	Numrerade register 	:h quote0
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+		     Lektion 2.1.5: SPECIALREGISTER
+
+ ** Använd systemets urklipp och svarta hålet för avancerad redigering **
+
+ Obs: Urklippsanvändning kräver X11/Wayland-bibliotek på Linux-system OCH
+      en Vim byggd med "+clipboard" (vanligtvis en Huge-byggning). Kontrollera med
+      ":version"  och ":echo has('clipboard_working')"
+
+  1. Urklippsregister  +  och  *  :
+     - "+y  - Kopiera till systemets urklipp (t.ex. "+yy för nuvarande rad)
+     - "+p  - Klistra in från systemets urklipp
+     - "* är primärmarkering på X11 (mittenklick), "+ är urklipp
+
+---> Prova: "+yy sedan klistra in i ett annat program med Ctrl-V eller Cmd+V
+
+  2. Svarta hålet-register  _  kastar text:
+     - "_daw  - Radera ord utan att spara till något register
+     - Användbart när du inte vill skriva över ditt standard " register
+     - Observera att detta använder "ett Ord" textobjekt, introducerat i en
+       tidigare lektion
+     - "_dd   - Radera rad utan att spara
+     - "_dap  - Radera stycke utan att spara
+     - Kombinera med antal: 3"_dw
+
+---> Öva: "_diw på valfritt ord för att radera det utan att påverka kopieringshistorik
+
+  3. Kombinera med visuella markeringar:
+     - Markera text med V sedan "+y
+     - För att klistra in från urklipp i infogningsläge: <CTRL-R>+
+     - Prova att öppna ett annat program och klistra in från urklipp
+
+  4. Kom ihåg:
+     - Urklippsregister fungerar mellan olika Vim-instanser
+     - Urklippsregister fungerar inte alltid
+     - Svarta hålet förhindrar oavsiktlig registerskrivning
+     - Standard " register är fortfarande tillgängligt för normal kopiering/inklistring
+     - Namngivna register (a-z) förblir privata för varje Vim-session
+
+  5. Urklippsfelsökning:
+     - Kontrollera stöd med :echo has('clipboard_working')
+     - 1 betyder tillgängligt, 0 betyder inte inkompilerat
+     - På Linux kan vim-gtk eller vim-x11 paket behövas
+       (kontrollera :version utdata)
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+		     Lektion 2.1.6: SKÖNHETEN MED MARKERINGAR
+
+	           ** Kodapans aritmetik-undvikande **
+
+OBS: ett vanligt problem vid kodning är att flytta runt stora kodblock.
+      Följande teknik hjälper till att undvika radnummerberäkningar associerade
+      med operationer som   "a147d   eller   :945,1091d a   eller ännu värre att använda
+      i<CTRL-R> följt av   =1091-945<ENTER>   först
+
+  1. Flytta markören till raden nedan markerad --->
+
+  2. Gå till första raden av funktionen och markera den med   ma
+
+OBS: exakt position på raden är INTE viktigt!
+
+  3. Navigera till slutet av raden och sedan slutet av kodblocket 
+     med   $%
+
+  4. Radera blocket till register a med   "ad'a
+
+MINNESREGEL: till register(") namngivet (a) lägg (d)eletionen (raderingen) från markören till
+          RADEN som innehåller markering(') (a)
+
+  5. Klistra in blocket mellan BBB och CCC   "ap
+
+OBS: öva denna operation flera gånger för att bli flytande   ma$%"ad'a
+
+---> AAA
+     function detBlevStortSnabbt() {
+       if ( nagotArSant ) {
+         gorDet()
+       }
+       // vår funktions taxonomi har ändrats och den
+       // är inte längre alfabetiskt logisk på sin nuvarande plats
+
+       // tänk dig hundratals rader kod
+
+       // naivt kunde du navigera till början och slutet och spela in eller
+       // komma ihåg varje radnummer
+     }
+     BBB
+     CCC
+
+OBS: markeringar och register delar inte namnrymd, därför är register a
+      helt oberoende av markering a. Detta gäller inte register och
+      makron.
+
+REFERENS: 	Markeringar 	:h marks
+		Markeringsförflyttningar :h mark-motions  (skillnad mellan ' och `)
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+		     Lektion 2.1 SAMMANFATTNING
+
+  1. Textobjekt ger precisionsredigering:
+     - iw/aw - inre/runt ord
+     - i[/a[ - inre/runt hakparentes
+     - i"/a" - inre/runt citattecken
+     - it/at - inre/runt tagg
+     - ip/ap - inre/runt stycke
+     - is/as - inre/runt mening
+
+  2. För att lagra (kopiera, radera) text till, och hämta (klistra in) från, totalt
+     26 register (a-z) 
+  3. Kopiera ett helt ord från var som helst inom ett ord:   yiw
+  4. Ändra ett helt ord från var som helst inom ett ord:   ciw
+  5. Infoga text direkt från register i infogningsläge:   <CTRL-R>a
+
+  6. Infoga resultat av enkla aritmetiska operationer: <CTRL-R> följt av
+     =60*60<ENTER>
+     i infogningsläge
+  7. Infoga resultat av systemanrop: <CTRL-R> följt av
+     =system('ls -1')<ENTER>
+     i infogningsläge
+
+  8. Inspektera register med   :reg
+  9. Lär dig slutdestinationen för helradsraderingar: dd i de numrerade
+     registren, dvs. fallande från register 1 - 9. Uppskatta att hel-
+     radsraderingar bevaras längre i de numrerade registren än någon
+     annan operation
+ 10. Lär dig slutdestinationen för alla kopieringar i de numrerade registren och
+     hur flyktiga de är
+
+ 11. Placera markeringar från kommandoläge   m[a-zA-Z0-9]
+ 12. Flytta radvis till en markering med   '
+
+ 13. Specialregister:
+     - "+/"*  - Systemets urklipp (OS-beroende)
+     - "_     - Svarta hålet (kasta raderad/kopierad text)
+     - "=     - Uttrycksregister
+     - "-     - Register för små raderingar
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  Detta avslutar kapitel två av Vim-handledningen. Det är ett pågående arbete.
+
+  Detta kapitel skrevs av Paul D. Parker och Christian Brabandt.
+  Svensk översättning av Daniel Nylander.
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Swedish Translation Updates

Follow-up fixes and improvements from PR #18849.

### 🐛 Bug Fixes

**help.svx:**
- Fixed typo: `paranteser` → `parenteser` (line 240)
- Fixed navigation block being too wide (h j k l section)

### ✨ New Content

**tutor1.sv** - Updated from v1.5 to v1.7:
- Added 14 missing lessons (1.1.5, 1.1.6, 1.2.3-1.2.5, 1.3.2, 1.5.3, 1.6.x, 1.7, 1.8, 1.9)
- Added all summary sections
- Now matches English tutor structure

**tutor2.sv** - New translation (294 lines):
- Text objects (iw, aw, i[, a[, it, at, ip, ap, is, as)
- Named registers (a-z)
- Expression register (=)
- Numbered registers (0-9)
- Special registers (+, *, _, -)
- Marks and mark motions

### 📊 Statistics

| File | Lines | Status |
|------|-------|--------|
| help.svx | 264 | Fixed |
| tutor1.sv | 939 | Updated to v1.7 |
| tutor2.sv | 294 | New |

### ✅ Verified
- All encodings correct (UTF-8 for tutor, Latin-1 for help.svx)
- Line lengths ≤80 chars
- Swedish characters (åäöÅÄÖ) working

---
Original translation by Johan Svedberg.
Updates by Daniel Nylander.