### PR TITLE
runtime(doc): fix pattern problem in cmdline.txt

### DIFF
--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -1381,10 +1381,10 @@ Example: >
 	:au CmdwinLeave :  let &cpt = b:cpt_save
 This sets 'complete' to use completion in the current window for |i_CTRL-N|.
 Another example: >
-	:au CmdwinEnter [/\?]  startinsert
+	:au CmdwinEnter [\/\?]  startinsert
 This will make Vim start in Insert mode in the command-line window.
-Note: The "?" needs to be escaped, as this is a |file-pattern|.  See also
-|cmdline-autocompletion|.
+Note: The "\" and "?" needs to be escaped, as this is a |file-pattern|.
+See also |cmdline-autocompletion|.
 
 						*cmdwin-char*
 The character used for the pattern indicates the type of command-line:


### PR DESCRIPTION
Problem: These examples are wrong.
Solution: use right examples.

Seems CmdwinEnter's pattern doesn't follow file-pattern.

@girishji Since you changed this line before, could you please check whether
this work on your machine?
