### PR TITLE
runtime(context): fix issue with SyncTeX and update command

### DIFF
--- a/runtime/autoload/context.vim
+++ b/runtime/autoload/context.vim
@@ -3,13 +3,13 @@ vim9script
 # Language:           ConTeXt typesetting engine
 # Maintainer:         Nicola Vitacolonna <nvitacolonna@gmail.com>
 # Former Maintainers: Nikolai Weibull <now@bitwi.se>
-# Latest Revision:    2026 Jan 10
+# Latest Revision:    2026 Feb 03
 
 # Typesetting {{{
 import autoload './typeset.vim'
 
 export def ConTeXtCmd(path: string): list<string>
-  var cmd = ['mtxrun', '--script', 'context', '--nonstopmode', '--autogenerate']
+  var cmd = ['mtxrun', '--script', 'context', '--paranoid', '--autogenerate']
   if !empty(get(g:, 'context_extra_options', ''))
     cmd += g:context_extra_options
   endif

--- a/runtime/autoload/typeset.vim
+++ b/runtime/autoload/typeset.vim
@@ -2,7 +2,7 @@ vim9script
 
 # Language:           Generic TeX typesetting engine
 # Maintainer:         Nicola Vitacolonna <nvitacolonna@gmail.com>
-# Latest Revision:    2026 Jan 10
+# Latest Revision:    2026 Feb 03
 
 # Constants and helpers {{{
 const SLASH = !exists("+shellslash") || &shellslash ? '/' : '\'
@@ -203,6 +203,7 @@ export def Typeset(
     env:   dict<string> = {}
     ): bool
   var fp   = fnamemodify(path, ':p')
+  var name = fnamemodify(fp, ':t')
   var wd   = fnamemodify(fp, ':h')
   var qfid = NewQuickfixList(fp)
 
@@ -216,7 +217,11 @@ export def Typeset(
     return false
   endif
 
-  var jobid = job_start(Cmd(path), {
+  # Make sure to pass only the base name of the path to Cmd as this usually
+  # works better with TeX commands (note that the command is executed inside
+  # the file's directory). For instance, ConTeXt writes the path in .synctex
+  # files, and full paths break syncing from the editor to the viewer.
+  var jobid = job_start(Cmd(name), {
     env: env,
     cwd: wd,
     in_io: "null",


### PR DESCRIPTION
Remove `--nonstopmode` because (a) ConTeXt always stops anyway, and (b) `--nonstopmode` disables SyncTeX unconditionally. Add `--paranoid`, which prevents the command to descend to `..` and `../..`.

Pass the typesetting command only the name of the input file rather than its full path, as this is more compatible with ConTeXt's syncing mechanism.