### PR TITLE
Improve handling of overlong single lines

### DIFF
--- a/src/fileio.c
+++ b/src/fileio.c
@@ -1170,7 +1170,12 @@ retry:
 	}
 
 	// Protect against the argument of lalloc() going negative.
-	if (size < 0 || size + linerest + 1 < 0 || linerest >= MAXCOL)
+	// Also split lines that are too long for colnr_T.  After this check
+	// passes, we read up to 'size' more bytes.  We must ensure that even
+	// after that read, the line length won't exceed MAXCOL - 1 (because
+	// we add 1 for the NUL when casting to colnr_T).  If this check fires,
+	// we insert a synthetic newline immediately, so linerest doesn't grow.
+	if (size < 0 || size + linerest + 1 < 0 || linerest >= MAXCOL - size)
 	{
 	    ++split;
 	    *ptr = NL;		    // split line by inserting a NL

--- a/src/memline.c
+++ b/src/memline.c
@@ -2941,7 +2941,7 @@ ml_append_int(
     int		line_count;	// number of indexes in current block
     int		offset;
     int		from, to;
-    int		space_needed;	// space needed for new line
+    long	space_needed;	// space needed for new line
     int		page_size;
     int		page_count;
     int		db_idx;		// index for lnum in data block
@@ -3018,7 +3018,7 @@ ml_append_int(
  * - not appending to the last line in the file
  * insert in front of the next block.
  */
-    if ((int)dp->db_free < space_needed && db_idx == line_count - 1
+    if ((long)dp->db_free < space_needed && db_idx == line_count - 1
 					    && lnum < buf->b_ml.ml_line_count)
     {
 	/*
@@ -3041,7 +3041,7 @@ ml_append_int(
 
     ++buf->b_ml.ml_line_count;
 
-    if ((int)dp->db_free >= space_needed)	// enough room in data block
+    if ((long)dp->db_free >= space_needed)	// enough room in data block
     {
 	/*
 	 * Insert the new line in an existing data block, or in the data block
@@ -3142,7 +3142,7 @@ ml_append_int(
 		data_moved = ((dp->db_index[db_idx]) & DB_INDEX_MASK) -
 							    dp->db_txt_start;
 		total_moved = data_moved + lines_moved * INDEX_SIZE;
-		if ((int)dp->db_free + total_moved >= space_needed)
+		if ((long)dp->db_free + total_moved >= space_needed)
 		{
 		    in_left = TRUE;	// put new line in left block
 		    space_needed = total_moved;


### PR DESCRIPTION
Problem:  reading files with very long lines crashes Vim 
Solution: break long lines, use (long) instead of (int) to handle 
               the line length so that it doesn't overflow

fixes:   #17935
related: #18953

Note: I used Claude to help with this.