### PR TITLE
runtime(tar): force wrapping on search()

### DIFF
--- a/runtime/autoload/tar.vim
+++ b/runtime/autoload/tar.vim
@@ -226,7 +226,7 @@ fun! tar#Browse(tarfile)
 
   " remove tar: Removing leading '/' from member names
   " Note: the message could be localized
-  if search('^tar: ') > 0 || search(g:tar_leading_pat) > 0
+  if search('^tar: ', 'w') > 0 || search(g:tar_leading_pat, 'w') > 0
     call append(3,'" Note: Path Traversal Attack detected!')
     let b:leading_slash = 1
     " remove the message output

--- a/src/testdir/test_plugin_tar.vim
+++ b/src/testdir/test_plugin_tar.vim
@@ -126,3 +126,24 @@ def g:Test_tar_evil()
 
   bw!
 enddef
+
+def g:Test_tar_path_traversal_with_nowrapscan()
+  CopyFile("evil.tar")
+  defer delete("X.tar")
+  # Make sure we still find the tar warning (or leading slashes) even when
+  # wrapscan is off
+  set nowrapscan
+  e X.tar
+
+  ### Check header
+  assert_match('^" tar\.vim version v\d\+', getline(1))
+  assert_match('^" Browsing tarfile .*/X.tar', getline(2))
+  assert_match('^" Select a file with cursor and press ENTER, "x" to extract a file', getline(3))
+  assert_match('^" Note: Path Traversal Attack detected', getline(4))
+  assert_match('^$', getline(5))
+  assert_match('/etc/ax-pwn', getline(6))
+
+  assert_equal(1, b:leading_slash)
+
+  bw!
+enddef


### PR DESCRIPTION
Problem: search() is used to check for the message from tar that indicates leading slashes found in the tar archive, or to check for the leading slashes themselves. However, if 'nowrapscan' is in effect these searches are limited to the last line and don't find any results. This causes the warning message from tar to be seen in the buffer, the "Path Traversal Attack Detected" message to be omitted, and editing actions can fail. This can be seen, for example, when editing src/testdir/samples/evil.tar.

Solution: Use the 'w' flag for search().