### PR TITLE
Terminal doesn't handle split UTF-8 sequence after ASCII

### DIFF
--- a/src/libvterm/src/state.c
+++ b/src/libvterm/src/state.c
@@ -297,6 +297,8 @@ static int on_text(const char bytes[], size_t len, void *user)
     !(bytes[eaten] & 0x80) ? &state->encoding[state->gl_set] :
     state->vt->mode.utf8   ? &state->encoding_utf8 :
                              &state->encoding[state->gr_set];
+  if (encoding->enc == state->encoding_utf8.enc)
+    encoding = &state->encoding_utf8;  // Only use one UTF-8 encoding state.
 
   (*encoding->enc->decode)(encoding->enc, encoding->data,
       codepoints, &npoints, state->gsingle_set ? 1 : (int)maxpoints,

--- a/src/libvterm/t/14state_encoding.test
+++ b/src/libvterm/t/14state_encoding.test
@@ -103,3 +103,12 @@ PUSH "AB\xc4\x88D"
   putglyph 0x0042 1 0,1
   putglyph 0x0108 1 0,2
   putglyph 0x0044 1 0,3
+
+!Split UTF-8 after US-ASCII
+RESET
+PUSH "AB\xc4"
+  putglyph 0x0041 1 0,0
+  putglyph 0x0042 1 0,1
+PUSH "\x88D"
+  putglyph 0x0108 1 0,2
+  putglyph 0x0044 1 0,3


### PR DESCRIPTION
Problem:  Terminal doesn't handle split UTF-8 sequence after ASCII.
Solution: Only use one UTF-8 encoding state per vterm state.

fixes: #16559
