### PR TITLE
Another case of buffer overflow with 'helpfile'

### DIFF
--- a/src/tag.c
+++ b/src/tag.c
@@ -3347,7 +3347,7 @@ get_tagfname(
 	    if (tnp->tn_hf_idx > tag_fnames.ga_len || *p_hf == NUL)
 		return FAIL;
 	    ++tnp->tn_hf_idx;
-	    vim_strncpy(buf, p_hf, MAXPATHL - 1);
+	    vim_strncpy(buf, p_hf, MAXPATHL - STRLEN_LITERAL("tags") - 1);
 	    STRCPY(gettail(buf), "tags");
 #ifdef BACKSLASH_IN_FILENAME
 	    slash_adjust(buf);

--- a/src/testdir/test_help.vim
+++ b/src/testdir/test_help.vim
@@ -281,6 +281,11 @@ func Test_helpfile_overflow()
   let &helpfile = repeat('A', 5000)
   help
   helpclose
+  for i in range(4089, 4096)
+    let &helpfile = repeat('A', i) .. '/A'
+    help
+    helpclose
+  endfor
   let &helpfile = _helpfile
 endfunc
 


### PR DESCRIPTION
Problem:  Another case of buffer overflow with 'helpfile'.
Solution: Leave room for "tags" in the buffer.
