### PR TITLE
Editable dot register

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -10336,8 +10336,8 @@ setreg({regname}, {value} [, {options}])		*setreg()*
 
 							*E883*
 		Note: you may not use |List| containing more than one item to
-		      set search and expression registers.  Lists containing
-		      no items act like empty strings.
+		      set search and expression and dot registers.  Lists
+		      containing no items act like empty strings.
 
 		Examples: >
 			:call setreg(v:register, @*)

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -10310,9 +10310,13 @@ setqflist({list} [, {action} [, {what}]])		*setqflist()*
 
 setreg({regname}, {value} [, {options}])		*setreg()*
 		Set the register {regname} to {value}.
-		If {regname} is "" or "@", the unnamed register '"' is used.
+		If {regname} is "" or "@" or ".", the unnamed register '"' is
+		used.
 		The {regname} argument is a string.  In |Vim9-script|
 		{regname} must be one character.
+		The dot register '.' can now be set to customize the repeat
+		command.  The value should be a string representing the
+		insert command and text.
 
 		{value} may be any value returned by |getreg()| or
 		|getreginfo()|, including a |List| or |Dict|.
@@ -10344,8 +10348,21 @@ setreg({regname}, {value} [, {options}])		*setreg()*
 			:call setreg('*', @%, 'ac')
 			:call setreg('a', "1\n2\n3", 'b5')
 			:call setreg('"', { 'points_to': 'a'})
+<
+		Examples for dot register (experimental): >
+			" Set simple text (uses 'a' mode)
+			:call setreg('.', 'iHello')
 
-<		This example shows using the functions to save and restore a
+			" Works with direct assignment too
+			:let @. = 'oNew line'
+
+			" Concatenate
+			:let @. .= ' more text'
+<
+		Note: The exact behavior of the dot register is subject
+		to change.  See |dot-register-writable|.
+
+		This example shows using the functions to save and restore a
 		register: >
 			:let var_a = getreginfo()
 			:call setreg('a', var_a)

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -10310,8 +10310,7 @@ setqflist({list} [, {action} [, {what}]])		*setqflist()*
 
 setreg({regname}, {value} [, {options}])		*setreg()*
 		Set the register {regname} to {value}.
-		If {regname} is "" or "@" or ".", the unnamed register '"' is
-		used.
+		If {regname} is "" or "@", the unnamed register '"' is used.
 		The {regname} argument is a string.  In |Vim9-script|
 		{regname} must be one character.
 		The dot register '.' can now be set to customize the repeat

--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -45,19 +45,29 @@ of area is used, see |visual-repeat|.
 						*dot-register-writable*
 Writable dot register					*@.*
 
-The dot register can now be written to customize repeat behavior.  This is
-an EXPERIMENTAL feature and the behavior may change in future versions.
+The dot register stores a COMMAND sequence, not just text.  This is
+consistent with how |:normal| works.  The first character is interpreted
+as an insert mode command if it is one of [iaoOIAcsSC].
 
-Currently, if the first character is one of [iaoOIAcsSC] followed by more
-characters, it is treated as an insert command.  Otherwise, the text is
-treated as if entered with the 'a' command.
+Examples: >
+	:let @. = 'itext'    " Execute 'i' command, then insert 'text'
+	:let @. = 'oLine'    " Execute 'o' command, then insert 'Line'
+	:let @. = 'cw'       " Execute 'cw' command (change word)
+	:let @. = 'i'        " Execute 'i' command (enter insert mode)
 
-Examples: >vim
-	:let @. = 'itext'    " insert mode with 'i' command
-	:let @. = 'text'     " append mode (treated as 'atext')
-	:let @. = 'i'        " single char 'i' (not treated as command)
+	" To insert the literal character 'i', use:
+	:let @. = 'ai'       " Execute 'a' command, then insert 'i'
+
+	" Characters that are NOT insert commands are treated as text:
+	:let @. = 'x'        " Insert 'x' (not a valid insert command)
+	:let @. = 'text'     " Insert 'text' with implicit 'a'
 <
-This feature is designed to replace the need for plugins like vim-repeat.
+This is consistent with |:normal| which also requires an insert command
+to enter insert mode: >
+    :normal itext        " Not: ':normal text'
+<
+The dot register represents the LAST CHANGE, which is a command sequence,
+not just text.  See |.| for more information.
 
 ==============================================================================
 2. Multiple repeats					*multi-repeat*

--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -42,6 +42,22 @@ of area is used, see |visual-repeat|.
 			{not available when compiled without the
 			|+cmdline_hist| feature}
 
+						*dot-register-writable*
+Writable dot register					*@.*
+
+The dot register can now be written to customize repeat behavior.  This is
+an EXPERIMENTAL feature and the behavior may change in future versions.
+
+Currently, if the first character is one of [iaoOIAcsSC] followed by more
+characters, it is treated as an insert command.  Otherwise, the text is
+treated as if entered with the 'a' command.
+
+Examples: >vim
+	:let @. = 'itext'    " insert mode with 'i' command
+	:let @. = 'text'     " append mode (treated as 'atext')
+	:let @. = 'i'        " single char 'i' (not treated as command)
+<
+This feature is designed to replace the need for plugins like vim-repeat.
 
 ==============================================================================
 2. Multiple repeats					*multi-repeat*

--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -47,28 +47,28 @@ Writable dot register					*@.*
 
 The dot register stores a COMMAND sequence, not just text.  This is
 consistent with how |:normal| works.  The first character is interpreted
-as an insert mode command if it is one of [iaoOIAcsSC].
+as an insert mode command if it is one of [iaoOIAcsSC].  For other
+characters, the string is executed as a normal mode command sequence.
 
 Examples: >
 	:let @. = 'itext'    " Execute 'i' command, then insert 'text'
 	:let @. = 'oLine'    " Execute 'o' command, then insert 'Line'
-	:let @. = 'cw'       " Execute 'cw' command (change word)
+	:let @. = 'cwnew'    " Execute 'cw' command, then insert 'new'
 	:let @. = 'i'        " Execute 'i' command (enter insert mode)
+	:let @. = 'dd'       " Execute 'dd' command (delete line)
+	:let @. = '3x'       " Execute '3x' command (delete 3 chars)
 
 	" To insert the literal character 'i', use:
 	:let @. = 'ai'       " Execute 'a' command, then insert 'i'
-
-	" Characters that are NOT insert commands are treated as text:
-	:let @. = 'x'        " Insert 'x' (not a valid insert command)
-	:let @. = 'text'     " Insert 'text' with implicit 'a'
 <
+Note: The string is executed as-is.  If it does not represent a valid
+command sequence, the behavior is undefined.  Users are responsible for
+providing valid commands.
+
 This is consistent with |:normal| which also requires an insert command
 to enter insert mode: >
     :normal itext        " Not: ':normal text'
 <
-The dot register represents the LAST CHANGE, which is a command sequence,
-not just text.  See |.| for more information.
-
 ==============================================================================
 2. Multiple repeats					*multi-repeat*
 

--- a/src/edit.c
+++ b/src/edit.c
@@ -2670,6 +2670,44 @@ set_last_insert(int c)
     last_insert_skip = 0;
 }
 
+/*
+ * Set the last inserted text to str.
+ */
+    void
+set_last_insert_str(char_u	*str)
+{
+    char_u  *s;
+    char_u  *p;
+    int     c;
+    size_t  len = str ? STRLEN(str) : 0;
+
+    vim_free(last_insert.string);
+    last_insert.string = alloc(len * MB_MAXBYTES + 5);
+    if (last_insert.string == NULL)
+    {
+	last_insert.length = 0;
+	return;
+    }
+
+    s = last_insert.string;
+    if (str != NULL)
+    {
+	for (p = str; *p != NUL; MB_PTR_ADV(p))
+	{
+	    c = mb_ptr2char(p);
+	    // Use the CTRL-V only when entering a special char
+	    if (c < ' ' || c == DEL)
+		*s++ = Ctrl_V;
+	    s = add_char2buf(c, s);
+	}
+    }
+
+    *s++ = ESC;
+    *s = NUL;
+    last_insert.length = (size_t)(s - last_insert.string);
+    last_insert_skip = 0;
+}
+
 #if defined(EXITFREE)
     void
 free_last_insert(void)

--- a/src/edit.c
+++ b/src/edit.c
@@ -2706,6 +2706,10 @@ set_last_insert_str(char_u	*str)
     *s = NUL;
     last_insert.length = (size_t)(s - last_insert.string);
     last_insert_skip = 0;
+
+    // Change redo buff
+    ResetRedobuff();
+    AppendToRedobuffLit(s, -1);
 }
 
 #if defined(EXITFREE)

--- a/src/edit.c
+++ b/src/edit.c
@@ -2709,7 +2709,7 @@ set_last_insert_str(char_u	*str)
 
     // Change redo buff
     ResetRedobuff();
-    AppendToRedobuffLit(s, -1);
+    AppendToRedobuffLit(str, -1);
 }
 
 #if defined(EXITFREE)

--- a/src/edit.c
+++ b/src/edit.c
@@ -2682,7 +2682,7 @@ set_last_insert_str(char_u	*str)
     size_t  len = str ? STRLEN(str) : 0;
 
     vim_free(last_insert.string);
-    last_insert.string = alloc(len * MB_MAXBYTES + 5);
+    last_insert.string = alloc(len * 3 + 5);
     if (last_insert.string == NULL)
     {
 	last_insert.length = 0;
@@ -2709,7 +2709,7 @@ set_last_insert_str(char_u	*str)
 
     // Change redo buff
     ResetRedobuff();
-    AppendToRedobuffLit(str, -1);
+    stuffReadbuff(str);
 }
 
 #if defined(EXITFREE)

--- a/src/edit.c
+++ b/src/edit.c
@@ -2704,7 +2704,7 @@ set_last_insert_str(char_u *str)
 	if (first_char == 'i' || first_char == 'a' || first_char == 'o' ||
 	    first_char == 'O' || first_char == 'I' || first_char == 'A' ||
 	    first_char == 'c' || first_char == 's' || first_char == 'C' ||
-            first_char == 'S')
+	    first_char == 'S')
 	{
 	    has_command = TRUE;
 	    MB_PTR_ADV(p);  // Skip the command character

--- a/src/edit.c
+++ b/src/edit.c
@@ -2760,6 +2760,8 @@ set_last_insert_str(char_u *str)
 	}
 	else
 	{
+	    // Not an insert command - pass through as-is
+	    // This allows commands like 'dd', 'yy', 'x', etc.
 	    for (p = str; *p != NUL; )
 		AppendCharToRedobuff(mb_cptr2char_adv(&p));
 	}

--- a/src/edit.c
+++ b/src/edit.c
@@ -2672,6 +2672,14 @@ set_last_insert(int c)
 
 /*
  * Set the last inserted text to str.
+ * EXPERIMENTAL: This is used for writable dot register feature.
+ * The behavior may change in future versions.
+ *
+ * If the first character is an insert command (i, a, o, etc.) and there
+ * are more characters following it, the first char is treated as the
+ * command and the rest as text to insert.
+ *
+ * TODO: Consider alternative approaches for command specification.
  */
     void
 set_last_insert_str(char_u *str)

--- a/src/edit.c
+++ b/src/edit.c
@@ -2730,6 +2730,11 @@ set_last_insert_str(char_u *str)
     // Update redo buffer for . command
     // Use the approach from spellsuggest.c
     ResetRedobuff();
+
+    // Skip the next restore
+    // NOTE: Used after executing autocommands and user functions.
+    skipRestoreRedobuff();
+
     if (str != NULL && *str != NUL)
     {
 	if (has_command)

--- a/src/edit.c
+++ b/src/edit.c
@@ -2672,14 +2672,18 @@ set_last_insert(int c)
 
 /*
  * Set the last inserted text to str.
- * EXPERIMENTAL: This is used for writable dot register feature.
- * The behavior may change in future versions.
  *
- * If the first character is an insert command (i, a, o, etc.) and there
- * are more characters following it, the first char is treated as the
- * command and the rest as text to insert.
+ * This is used for writable dot register feature.
  *
- * TODO: Consider alternative approaches for command specification.
+ * The string represents a COMMAND sequence, similar to :normal.
+ * If the first character is a valid insert mode command [iaoOIAcsSC],
+ * it is treated as the command and the rest as text to insert.
+ * Otherwise, the entire string is treated as text with implicit 'a' command.
+ *
+ * Examples:
+ *   "itext"  -> i command + "text"
+ *   "i"      -> i command (no text)
+ *   "text"   -> a command + "text" (implicit, 't' is not an insert command)
  */
     void
 set_last_insert_str(char_u *str)
@@ -2699,15 +2703,15 @@ set_last_insert_str(char_u *str)
 	return;
     }
 
-    // Parse the input string to separate the command (i, a, o, etc.) from the
-    // text
+    // Parse the input string to separate the command (i, a, o, etc.) from
+    // the text.  The first character is checked to see if it's a valid
+    // insert mode command.
     s = last_insert.string;
     p = str;
     text_start = str;
 
     // Check if the first character is an insert mode command
-    // For single character strings, treat as literal text (not a command)
-    if (str != NULL && str[0] != NUL && str[1] != NUL)
+    if (str != NULL && *str != NUL)
     {
 	int first_char = *p;
 	// Check if it's a valid insert command character

--- a/src/edit.c
+++ b/src/edit.c
@@ -2706,19 +2706,22 @@ set_last_insert_str(char_u *str)
     text_start = str;
 
     // Check if the first character is an insert mode command
-    if (str != NULL && *str != NUL)
+    // For single character strings, treat as literal text (not a command)
+    if (str != NULL && str[0] != NUL && str[1] != NUL)
     {
 	int first_char = *p;
-	if (first_char == 'i' || first_char == 'a' || first_char == 'o' ||
-	    first_char == 'O' || first_char == 'I' || first_char == 'A' ||
-	    first_char == 'c' || first_char == 's' || first_char == 'C' ||
-	    first_char == 'S')
+	// Check if it's a valid insert command character
+	if (vim_strchr((char_u *)"iaoOIAcsSC", first_char) != NULL)
 	{
 	    has_command = TRUE;
 	    MB_PTR_ADV(p);  // Skip the command character
 	    text_start = p;
 	}
+    }
 
+    // Copy the text part to last_insert.string
+    if (text_start != NULL && *text_start != NUL)
+    {
 	// Copy the text part to last_insert.string
 	for (; *p != NUL; MB_PTR_ADV(p))
 	{

--- a/src/getchar.c
+++ b/src/getchar.c
@@ -53,6 +53,8 @@ static int typedchars_pos = 0;
  */
 static int	block_redo = FALSE;
 
+static int	skip_restore_redo = FALSE;
+
 static int	KeyNoremap = 0;	    // remapping flags
 
 /*
@@ -558,6 +560,7 @@ saveRedobuff(save_redo_T *save_redo)
     char_u	*s;
     size_t	slen;
 
+    skip_restore_redo = FALSE;
     save_redo->sr_redobuff = redobuff;
     redobuff.bh_first.b_next = NULL;
     save_redo->sr_old_redobuff = old_redobuff;
@@ -579,10 +582,23 @@ saveRedobuff(save_redo_T *save_redo)
     void
 restoreRedobuff(save_redo_T *save_redo)
 {
+    if (skip_restore_redo) {
+	return;
+    }
+
     free_buff(&redobuff);
     redobuff = save_redo->sr_redobuff;
     free_buff(&old_redobuff);
     old_redobuff = save_redo->sr_old_redobuff;
+}
+
+/*
+ * Skip restoreRedobuff() until saveRedobuff().
+ */
+    void
+skipRestoreRedobuff()
+{
+    skip_restore_redo = TRUE;
 }
 
 /*

--- a/src/getchar.c
+++ b/src/getchar.c
@@ -54,6 +54,7 @@ static int typedchars_pos = 0;
 static int	block_redo = FALSE;
 
 static int	skip_restore_redo = FALSE;
+static int	skip_restore_redo_cnt = 0;
 
 static int	KeyNoremap = 0;	    // remapping flags
 
@@ -560,7 +561,7 @@ saveRedobuff(save_redo_T *save_redo)
     char_u	*s;
     size_t	slen;
 
-    skip_restore_redo = FALSE;
+    skip_restore_redo_cnt++;
     save_redo->sr_redobuff = redobuff;
     redobuff.bh_first.b_next = NULL;
     save_redo->sr_old_redobuff = old_redobuff;
@@ -582,7 +583,11 @@ saveRedobuff(save_redo_T *save_redo)
     void
 restoreRedobuff(save_redo_T *save_redo)
 {
-    if (skip_restore_redo) {
+    skip_restore_redo_cnt--;
+    if (skip_restore_redo)
+    {
+	if (skip_restore_redo_cnt <= 0)
+	    skip_restore_redo = FALSE;
 	return;
     }
 

--- a/src/getchar.c
+++ b/src/getchar.c
@@ -601,7 +601,7 @@ restoreRedobuff(save_redo_T *save_redo)
  * Skip restoreRedobuff() until saveRedobuff().
  */
     void
-skipRestoreRedobuff()
+skipRestoreRedobuff(void)
 {
     skip_restore_redo = TRUE;
 }

--- a/src/proto/edit.pro
+++ b/src/proto/edit.pro
@@ -14,6 +14,7 @@ void insertchar(int c, int flags, int second_indent);
 void start_arrow(pos_T *end_insert_pos);
 int stop_arrow(void);
 void set_last_insert(int c);
+void set_last_insert_str(char_u *str);
 void free_last_insert(void);
 char_u *add_char2buf(int c, char_u *s);
 void beginline(int flags);

--- a/src/proto/getchar.pro
+++ b/src/proto/getchar.pro
@@ -9,7 +9,7 @@ void ResetRedobuff(void);
 void CancelRedo(void);
 void saveRedobuff(save_redo_T *save_redo);
 void restoreRedobuff(save_redo_T *save_redo);
-void skipRestoreRedobuff();
+void skipRestoreRedobuff(void);
 void AppendToRedobuff(char_u *s);
 void AppendToRedobuffLit(char_u *str, int len);
 void AppendToRedobuffSpec(char_u *s);

--- a/src/proto/getchar.pro
+++ b/src/proto/getchar.pro
@@ -9,6 +9,7 @@ void ResetRedobuff(void);
 void CancelRedo(void);
 void saveRedobuff(save_redo_T *save_redo);
 void restoreRedobuff(save_redo_T *save_redo);
+void skipRestoreRedobuff();
 void AppendToRedobuff(char_u *s);
 void AppendToRedobuffLit(char_u *str, int len);
 void AppendToRedobuffSpec(char_u *s);

--- a/src/register.c
+++ b/src/register.c
@@ -186,6 +186,7 @@ valid_yank_reg(
 				    "/.%:"
 #endif
 					, regname) != NULL)
+	    || regname == '.'
 	    || regname == '#'
 	    || regname == '"'
 	    || regname == '-'

--- a/src/register.c
+++ b/src/register.c
@@ -2909,7 +2909,7 @@ write_reg_contents_lst(
 {
     yankreg_T  *old_y_previous, *old_y_current;
 
-    if (name == '/' || name == '=')
+    if (name == '/' || name == '=' || name == '.')
     {
 	char_u	*s;
 
@@ -2963,6 +2963,13 @@ write_reg_contents_ex(
     if (name == '/')
     {
 	set_last_search_pat(str, RE_SEARCH, TRUE, TRUE);
+	return;
+    }
+
+    // Special case: '.' dot repeat register
+    if (name == '.')
+    {
+	set_last_insert_str(str);
 	return;
     }
 

--- a/src/register.c
+++ b/src/register.c
@@ -2970,10 +2970,7 @@ write_reg_contents_ex(
     // Special case: '.' dot repeat register
     if (name == '.')
     {
-	ResetRedobuff();
-	stuffReadbuff(str);
-	// TODO: set_last_insert_str() does not work well...
-	//set_last_insert_str(str);
+	set_last_insert_str(str);
 	return;
     }
 

--- a/src/register.c
+++ b/src/register.c
@@ -2970,7 +2970,9 @@ write_reg_contents_ex(
     // Special case: '.' dot repeat register
     if (name == '.')
     {
-	ins_typebuf(str, REMAP_NONE, 0, TRUE, FALSE);
+	ResetRedobuff();
+	stuffReadbuff(str);
+	// TODO: set_last_insert_str() does not work well...
 	//set_last_insert_str(str);
 	return;
     }

--- a/src/register.c
+++ b/src/register.c
@@ -2970,7 +2970,12 @@ write_reg_contents_ex(
     // Special case: '.' dot repeat register
     if (name == '.')
     {
-	set_last_insert_str(str);
+	char_u *p = vim_strnsave(str, (size_t)len);
+	if (p != NULL)
+	{
+	    set_last_insert_str(p);
+	    vim_free(p);
+	}
 	return;
     }
 

--- a/src/register.c
+++ b/src/register.c
@@ -2970,7 +2970,8 @@ write_reg_contents_ex(
     // Special case: '.' dot repeat register
     if (name == '.')
     {
-	set_last_insert_str(str);
+	ins_typebuf(str, REMAP_NONE, 0, TRUE, FALSE);
+	//set_last_insert_str(str);
 	return;
     }
 

--- a/src/testdir/test_registers.vim
+++ b/src/testdir/test_registers.vim
@@ -1300,8 +1300,13 @@ endfunc
 
 func Test_write_dot_register()
   let save_dot = getreg('.')
+
   call setreg('.', 'foobar')
   call assert_equal('foobar', getreg('.'))
+
+  let @. .= 'baz'
+  call assert_equal('foobarbaz', getreg('.'))
+
   call setreg('.', save_dot)
   call assert_equal(save_dot, getreg('.'))
 endfunc

--- a/src/testdir/test_registers.vim
+++ b/src/testdir/test_registers.vim
@@ -1302,15 +1302,15 @@ func Test_write_dot_register()
 
   " Basic functionality
   call setreg('.', 'itext')
-  call assert_equal('itext', getreg('.'))
+  call assert_equal('text', getreg('.'))
 
   " Direct assignment
   let @. = 'abc'
-  call assert_equal('abc', getreg('.'))
+  call assert_equal('bc', getreg('.'))
 
   " Concatenation
   let @. .= 'def'
-  call assert_equal('abcdef', getreg('.'))
+  call assert_equal('bcdef', getreg('.'))
 
   " Single character edge case
   let @. = 'i'
@@ -1318,7 +1318,7 @@ func Test_write_dot_register()
 
   " Multibyte support
   let @. = 'i日本語'
-  call assert_equal('i日本語', getreg('.'))
+  call assert_equal('日本語', getreg('.'))
 
   " Empty string
   let @. = ''

--- a/src/testdir/test_registers.vim
+++ b/src/testdir/test_registers.vim
@@ -345,7 +345,6 @@ func Test_get_register()
   call assert_equal('', getreg('_'))
   call assert_beeps('normal ":yy')
   call assert_beeps('normal "%yy')
-  call assert_beeps('normal ".yy')
 
   call assert_equal('', getreg("\<C-F>"))
   call assert_equal('', getreg("\<C-W>"))
@@ -1299,16 +1298,11 @@ func Test_writing_readonly_regs()
 endfunc
 
 func Test_write_dot_register()
-  let save_dot = getreg('.')
-
   call setreg('.', 'foobar')
   call assert_equal('foobar', getreg('.'))
 
   let @. .= 'baz'
   call assert_equal('foobarbaz', getreg('.'))
-
-  call setreg('.', save_dot)
-  call assert_equal(save_dot, getreg('.'))
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_registers.vim
+++ b/src/testdir/test_registers.vim
@@ -1293,7 +1293,6 @@ func Test_insert_small_delete_linewise()
 endfunc
 
 func Test_writing_readonly_regs()
-  call assert_fails('let @. = "foo"', 'E354:')
   call assert_fails('let @% = "foo"', 'E354:')
   call assert_fails('let @: = "foo"', 'E354:')
   call assert_fails('let @~ = "foo"', 'E354:')

--- a/src/testdir/test_registers.vim
+++ b/src/testdir/test_registers.vim
@@ -1300,17 +1300,31 @@ endfunc
 func Test_write_dot_register()
   new
 
-  call setreg('.', 'foobar')
-  call assert_equal('foobar', getreg('.'))
+  " Basic functionality
+  call setreg('.', 'itext')
+  call assert_equal('itext', getreg('.'))
 
-  let @. .= 'baz'
-  call assert_equal('foobarbaz', getreg('.'))
+  " Direct assignment
+  let @. = 'abc'
+  call assert_equal('abc', getreg('.'))
 
-  " . command test.
-  let @. = 'abb'
-  normal! .
+  " Concatenation
+  let @. .= 'def'
+  call assert_equal('abcdef', getreg('.'))
 
-  call assert_equal(['bb'], getline(1, '$'))
+  " Single character edge case
+  let @. = 'i'
+  call assert_equal('i', getreg('.'))
+
+  " Multibyte support
+  let @. = 'i日本語'
+  call assert_equal('i日本語', getreg('.'))
+
+  " Empty string
+  let @. = ''
+  call assert_equal('', getreg('.'))
+
+  " TODO: Add more behavioral tests once spec is finalized
 
   bwipe!
 endfunc

--- a/src/testdir/test_registers.vim
+++ b/src/testdir/test_registers.vim
@@ -1299,4 +1299,12 @@ func Test_writing_readonly_regs()
   call assert_fails('let @~ = "foo"', 'E354:')
 endfunc
 
+func Test_write_dot_register()
+  let save_dot = getreg('.')
+  call setreg('.', 'foobar')
+  call assert_equal('foobar', getreg('.'))
+  call setreg('.', save_dot)
+  call assert_equal(save_dot, getreg('.'))
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_registers.vim
+++ b/src/testdir/test_registers.vim
@@ -1298,11 +1298,21 @@ func Test_writing_readonly_regs()
 endfunc
 
 func Test_write_dot_register()
+  new
+
   call setreg('.', 'foobar')
   call assert_equal('foobar', getreg('.'))
 
   let @. .= 'baz'
   call assert_equal('foobarbaz', getreg('.'))
+
+  " . command test.
+  let @. = 'abb'
+  normal! .
+
+  call assert_equal(['bb'], getline(1, '$'))
+
+  bwipe!
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_registers.vim
+++ b/src/testdir/test_registers.vim
@@ -1399,11 +1399,12 @@ func Test_write_dot_register()
   normal! .
   call assert_equal(['---'], getline(1, '$'))
 
-  " Test 9: Implicit 'a' command (no insert command character)
+  " Test 9: Non-insert mode command (dd)
   %delete _
-  let @. = 'test'
+  call setline(1, ['line1', 'line2', 'line3'])
+  let @. = 'dd'
   normal! .
-  call assert_equal([''], getline(1, '$'))
+  call assert_equal(['line2', 'line3'], getline(1, '$'))
 
   " Test 10: Single command character with no text
   %delete _
@@ -1460,6 +1461,21 @@ func Test_write_dot_register()
   let @. = 'Sreplaced'
   normal! j.
   call assert_equal(['line1', 'replaced'], getline(1, '$'))
+
+  " Test 18: Character deletion command
+  %delete _
+  call setline(1, 'abcdef')
+  normal! 0
+  let @. = '3x'
+  normal! .
+  call assert_equal(['def'], getline(1, '$'))
+
+  " Test 19: Yank and paste (non-destructive command)
+  %delete _
+  call setline(1, 'test')
+  let @. = 'yypP'
+  normal! .
+  call assert_equal(['test', 'test', 'test'], getline(1, '$'))
 
   bwipe!
 endfunc

--- a/src/testdir/test_vim9_assign.vim
+++ b/src/testdir/test_vim9_assign.vim
@@ -1593,8 +1593,6 @@ def Test_assignment_failure()
   v9.CheckScriptFailure(['vim9script', 'var $ENV = "xxx"'], 'E1016:')
 
   # read-only registers
-  v9.CheckDefAndScriptFailure(['var @. = 5'], ['E354:', 'E1066:'], 1)
-  v9.CheckDefAndScriptFailure(['var @. = 5'], ['E354:', 'E1066:'], 1)
   v9.CheckDefAndScriptFailure(['var @% = 5'], ['E354:', 'E1066:'], 1)
   v9.CheckDefAndScriptFailure(['var @: = 5'], ['E354:', 'E1066:'], 1)
   if has('dnd')

--- a/src/testdir/test_vim9_expr.vim
+++ b/src/testdir/test_vim9_expr.vim
@@ -3630,7 +3630,6 @@ def Test_expr9_register()
   v9.CheckDefAndScriptSuccess(lines)
 
   # read-only registers
-  v9.CheckDefAndScriptFailure(["@. = 'yes'"], 'E354:', 1)
   v9.CheckDefAndScriptFailure(["@% = 'yes'"], 'E354:', 1)
   v9.CheckDefAndScriptFailure(["@: = 'yes'"], 'E354:', 1)
   v9.CheckDefAndScriptFailure(["@~ = 'yes'"], 'E354:', 1)


### PR DESCRIPTION
https://github.com/neovim/neovim/issues/33030

Current dot register is not editable.

https://github.com/tpope/vim-repeat plugin already exists.  But when using this plugin, users must install `repeat.vim` and there are side effects such as changing the mappings to custom ones. Therefore, I adopted an approach of modifying the core functionality to make the dot register changeable from scripts.

## Design Decisions

This PR makes the dot register writable, enabling customization of the repeat 
command behavior without requiring external plugins like vim-repeat.

### Command Interpretation (Finalized)

The dot register represents a **command sequence**, not just text. This is 
consistent with how `:normal` works and the fundamental nature of the dot 
command (`.`), which repeats the last *change* (an operation), not just text.

**Implementation**:
- If the first character is `[iaoOIAcsSC]`, it's treated as an insert mode command
- The remaining characters (if any) are treated as the text to insert
- If the first character is NOT an insert command, the string is executed as a normal mode command sequence
- This is consistent with `:normal` behavior - no implicit commands are added

**Examples**:
```vim
" Insert mode commands
let @. = 'iHello'   " → i command + 'Hello'
let @. = 'i'        " → i command (no text)
let @. = 'oLine'    " → o command + 'Line'
let @. = 'ai'       " → a command + 'i' (to insert literal 'i')

" Normal mode commands
let @. = 'dd'       " → delete line
let @. = '3x'       " → delete 3 characters
let @. = 'yy'       " → yank line
```

**Note**: The string is executed as-is, similar to `:normal`. Users are 
responsible for providing valid command sequences.