### PR TITLE
BUG: win_execute() clobbers :lcd override of 'autochdir'

### DIFF
--- a/src/evalwindow.c
+++ b/src/evalwindow.c
@@ -771,7 +771,10 @@ f_win_execute(typval_T *argvars, typval_T *rettv)
     restore_win_noblock(&switchwin, TRUE);
 # ifdef FEAT_AUTOCHDIR
     if (apply_acd)
+    {
+	vim_free(save_sfname);
 	do_autochdir();
+    }
     else
 # endif
 	if (cwd_status == OK)
@@ -780,6 +783,7 @@ f_win_execute(typval_T *argvars, typval_T *rettv)
 # ifdef FEAT_AUTOCHDIR
 	    if (save_sfname != NULL)
 	    {
+		vim_free(curbuf->b_sfname);
 		curbuf->b_sfname = save_sfname;
 		curbuf->b_fname = curbuf->b_sfname;
 	    }

--- a/src/evalwindow.c
+++ b/src/evalwindow.c
@@ -732,7 +732,7 @@ f_win_execute(typval_T *argvars, typval_T *rettv)
 # ifdef FEAT_AUTOCHDIR
     char_u	autocwd[MAXPATHL];
     int	apply_acd = FALSE;
-    char_u	*save_sfname;
+    char_u	*save_sfname = NULL;
 # endif
 
     // Getting and setting directory can be slow on some systems, only do

--- a/src/testdir/test_cd.vim
+++ b/src/testdir/test_cd.vim
@@ -189,6 +189,27 @@ func Test_lcd_split()
   quit!
 endfunc
 
+" Test that a temporary override of 'autochdir' via :lcd isn't clobbered by win_execute() in a split window.
+func Test_lcd_win_execute()
+  CheckOption autochdir
+
+  let startdir = getcwd()
+  call mkdir('Xsubdir', 'R')
+  call test_autochdir()
+  set autochdir
+  edit Xsubdir/file
+  call assert_match('testdir.Xsubdir.file$', expand('%:p'))
+  split
+  lcd ..
+  call assert_match('testdir.Xsubdir.file$', expand('%:p'))
+  call win_execute(win_getid(2), "")
+  call assert_match('testdir.Xsubdir.file$', expand('%:p'))
+
+  set noautochdir
+  bwipe!
+  call chdir(startdir)
+endfunc
+
 func Test_cd_from_non_existing_dir()
   CheckNotMSWindows
 


### PR DESCRIPTION
This problem has been in Vim since the introduction of `win_execute()`, but it's only encountered when 'autochdir' is set (which most users don't) and you do a local override of the working directory. Unfortunately, I've been encountering that frequently, because my configuration switches to the parent directory for editing Git commit messages (so I can directly reference files from the project root instead of the useless `.git/` subdir where the message is created in), and I use several custom completions that inspect other buffers via `win_execute()`. If you `:wq` after a completion, the `COMMIT_EDITMSG` file is written to the project root, and the Git command aborts or uses stale data! I've finally dug into this, and found a simple fix for this cornercase, that I've successfully been using for the past week.

The problem is caused by a bad interaction of the 'autochdir' behavior, overriding of the current directory via `:lchdir`, and the temporary window switching done by `win_execute()`, manifesting when e.g. a custom completion inspects other buffers.

1. In the initial state after the `:lcd ..` we have `curbuf->b_fname = "Xsubdir/file"`.
2. `do_autochdir()` is invoked, temporarily undoing the `:lcd ..`, changing back into the `Xsubdir/` subdirectory.
3. `win_execute()` switches windows, triggering `win_enter_ext()` → `win_fix_current_dir()` → `shorten_fnames(TRUE)`
4. `shorten_fnames()` processes *all* buffers
5. `shorten_buf_fname()` makes the filename relative to the current (wrong) directory; `b_fname` becomes `file` instead of `Xsubdir/file`
6. Directory restoration correctly restores working directory via `mch_chdir()` (skipping a second `do_autochdir()` invocation because `apply_acd` is `FALSE`), but `b_fname` remains corrupted, with the `Xsubdir/` part missing.
7. `expand('%:p')` (and commands like `:write`) continue to use the corrupted filename, resolving to a wrong path that's missing the `Xsubdir/` part.

To fix the problem the short filename is saved if its in effect (i.e. pointed to by `curbuf->b_fname`) and 'autochdir' happened. It's then restored in case of a local cwd override. The conditions limit this workaround to when 'autochdir' is active *and* overridden by a `:lchdir`.

The added test reproduces the problem and verifies the fix with a minimal setup using just one buffer and two split windows.
