### PR TITLE
runtime(doc): Add Swedish to help-translated list

### DIFF
--- a/runtime/doc/helphelp.txt
+++ b/runtime/doc/helphelp.txt
@@ -326,6 +326,7 @@ At this moment translations are available for:
 	Japanese - multiple authors
 	Polish   - translated by Mikolaj Machowski
 	Russian  - translated by Vassily Ragosin
+	Swedish  - translated by Daniel Nylander
 See the Vim website to find them: http://www.vim.org/translations.php
 
 A set of translated help files consists of these files:


### PR DESCRIPTION
Add Swedish translation to the list of available translations in helphelp.txt.

Swedish Vim documentation is available at:
https://github.com/yeager/vimdoc-sv

Currently includes:
- help.svx - Main help file

Translated by Daniel Nylander.

Related: #19321