### PR TITLE
[documentation] clarify term_cols allowed range

### DIFF
--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -525,10 +525,12 @@ term_dumpdiff({filename}, {filename} [, {options}])
 				     of the first file name.
 		   "term_rows"	     vertical size to use for the terminal,
 				     instead of using 'termwinsize', but
-				     respecting the minimal size
+				     respecting the minimal size; valid range
+				     is from 0 to 1000
 		   "term_cols"	     horizontal size to use for the terminal,
 				     instead of using 'termwinsize', but
-				     respecting the minimal size
+				     respecting the minimal size; valid range
+				     is from 0 to 1000
 		   "vertical"	     split the window vertically
 		   "curwin"	     use the current window, do not split the
 				     window; fails if the current buffer
@@ -951,9 +953,10 @@ term_start({cmd} [, {options}])			*term_start()*
 				     of the command name.
 		   "term_rows"	     vertical size to use for the terminal,
 				     instead of using 'termwinsize'; valid
-				     range is from zero to 1000
+				     range is from 0 to 1000
 		   "term_cols"	     horizontal size to use for the terminal,
-				     instead of using 'termwinsize'
+				     instead of using 'termwinsize'; valid
+				     range is from 0 to 1000
 		   "vertical"	     split the window vertically; note that
 				     other window position can be defined with
 				     command modifiers, such as |:belowright|.


### PR DESCRIPTION
Patch 9.0.1527 (related issue: vim/vim#12362) introduced range checking for `term_cols` parameter of the various terminal related functions, but did not update the documentation. This is the fix, hopefully I found everything that mentions is. Also improve the style for `term_rows` to match.

Code reference ( https://github.com/vim/vim/blob/master/src/job.c#L456 ):
````        if (opt->jo_term_cols < 0 || opt->jo_term_cols > 1000)````

NOTE: Such "random" constants dropped in the middle of the codebase should be avoided...
It may be worth moving such constrains in a separate header. It will be great if documentation can also refer to it, but that will mean we'll need a doc-processor in the pipe.

Issue #7285 is related to the original patch, may be time to close it since we currently hard-code a limit of 1000.