### PR TITLE
test: Update tests for OpenBSD

### DIFF
--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -3106,7 +3106,8 @@ func Test_readdirex_sort()
 
   " 6) Collation de_DE
   " Switch locale, this may not work on the CI system, if the locale isn't
-  " available
+  " available. Doesn't work on OpenBSD, which has minimal locale support.
+  CheckNotOpenBSD
   try
     lang collate de_DE
     let files = readdirex('Xsortdir2', 1, #{sort: 'collate'})->map({-> v:val.name})

--- a/src/testdir/test_startup.vim
+++ b/src/testdir/test_startup.vim
@@ -832,6 +832,9 @@ func Test_stdin_no_newline()
   CheckScreendump
   CheckUnix
   CheckExecutable bash
+  " For some reason bash doesn't exit at the end of the test on FreeBSD &
+  " OpenBSD.
+  CheckNotBSD
 
   let $PS1 = 'TEST_PROMPT> '
   let buf = RunVimInTerminal('', #{rows: 20, cmd: 'bash --noprofile --norc'})

--- a/src/testdir/test_startup_utf8.vim
+++ b/src/testdir/test_startup_utf8.vim
@@ -60,6 +60,8 @@ endfunc
 
 func Test_detect_fifo()
   CheckUnix
+  " On OpenBSD /dev/fd/n files are character special, not FIFO
+  CheckNotOpenBSD
   " Using bash/zsh's process substitution.
   if executable('bash')
     set shell=bash

--- a/src/testdir/util/check.vim
+++ b/src/testdir/util/check.vim
@@ -115,6 +115,17 @@ func CheckNotBSD()
   endif
 endfunc
 
+" Command to check for not running on OpenBSD
+command CheckNotOpenBSD call CheckNotOpenBSD()
+func CheckNotOpenBSD()
+  if has('bsd')
+    let uname = trim(system('uname'))
+    if uname == 'OpenBSD'
+      throw 'Skipped: does not work on OpenBSD'
+    endif
+  endif
+endfunc
+
 " Command to check for not running on a MacOS
 command CheckNotMac call CheckNotMac()
 func CheckNotMac()


### PR DESCRIPTION
Problem: Some tests are not valid on OpenBSD.

Solution: Add CheckNotOpenBSD, use it to skip certain tests.

Details:

Test_readdirex_sort performs locale-dependent sorting. OpenBSD has minimal locale support.

Test_stdin_no_newline hangs on OpenBSD and FreeBSD. I don't know exactly why, but it may be due to bash not exiting at the end of the test. This is skipped in the FreeBSD CI runs because bash is not installed.

Test_detect_fifo uses /dev/fd/ files (via process substitution) as FIFOs. On OpenBSD the files in /dev/fd are not FIFOs.