### PR TITLE
nginx syntax: highlight Lua in set_by_lua_block

### DIFF
--- a/runtime/syntax/nginx.vim
+++ b/runtime/syntax/nginx.vim
@@ -2302,7 +2302,7 @@ let b:current_syntax = "nginx"
 " Enable nested LUA syntax highlighting
 unlet b:current_syntax
 syn include @LUA syntax/lua.vim
-syn region ngxLua start=+^\s*\w\+_by_lua_block\s*{+ end=+}+me=s-1 contains=ngxBlock,@LUA
+syn region ngxLua start=+^\s*\w\+_by_lua_block\s*\(\$\w\+\s*\)\?{+ end=+}+me=s-1 contains=ngxBlock,@LUA
 let b:current_syntax = "nginx"
 
 


### PR DESCRIPTION
The `set_by_lua_block` (see [docs](https://openresty-reference.readthedocs.io/en/latest/Directives/#set_by_lua_block)) directive of the Lua module takes an additional variable as an argument which currently breaks the detection of inline Lua blocks. For example:

```nginx
set_by_lua_block $myvar {
    return tonumber(ngx.var.myothervar)-1
}
```

This PR adjusts the corresponding regex to allow a parameter on all `*_by_luck_block` directives.