### PR TITLE
fix: Handle mouse scroll events for popup windows on MS-Windows

### DIFF
--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -4742,7 +4742,6 @@ _OnMouseWheel(HWND hwnd UNUSED, WPARAM wParam, LPARAM lParam, int horizontal)
 	update_screen(0);
 	setcursor();
 	out_flush();
-	return;
     }
 #endif
 

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -1507,7 +1507,6 @@ decode_mouse_wheel(MOUSE_EVENT_RECORD *pmer)
 	update_screen(0);
 	setcursor();
 	out_flush();
-	return;
     }
 # endif
     mouse_col = g_xMouse;


### PR DESCRIPTION
Ensure mouse wheel events on popup windows are properly processed by
sending the corresponding key messages. Previously, early returns
prevented normal event flow, causing popup windows to ignore scroll
input.

Closes: #19353
