### PR TITLE
runtime: add Swedish (sv.UTF-8) documentation entries to Make_all.mak

### DIFF
--- a/runtime/doc/Make_all.mak
+++ b/runtime/doc/Make_all.mak
@@ -339,6 +339,11 @@ CONVERTED = \
 	vimdiff-ru.UTF-8.1 \
 	vimtutor-ru.UTF-8.1 \
 	xxd-ru.UTF-8.1 \
+	vim-sv.UTF-8.1 \
+	evim-sv.UTF-8.1 \
+	vimdiff-sv.UTF-8.1 \
+	vimtutor-sv.UTF-8.1 \
+	xxd-sv.UTF-8.1 \
 	vim-tr.UTF-8.1 \
 	evim-tr.UTF-8.1 \
 	vimdiff-tr.UTF-8.1 \


### PR DESCRIPTION
Swedish (sv.UTF-8) Vim documentation translations by Daniel Nylander exist in the repository, but the corresponding entries are missing from `runtime/doc/Make_all.mak`. This causes the Swedish man pages not to be built and installed.

This patch adds the following Swedish entries to the `CONVERTED` list:
- `vim-sv.UTF-8.1`
- `evim-sv.UTF-8.1`
- `vimdiff-sv.UTF-8.1`
- `vimtutor-sv.UTF-8.1`
- `xxd-sv.UTF-8.1`

Thanks to 毛逸宁 for reporting this issue.