### PR TITLE
Fix `gf` in Vim script

### DIFF
--- a/runtime/autoload/vimgoto.vim
+++ b/runtime/autoload/vimgoto.vim
@@ -41,9 +41,9 @@ export def Find(editcmd: string) #{{{2
     if stridx(curfunc, '#') >= 0
         var parts = split(curfunc, '#')
         var path = $"autoload/{join(parts[0 : -2], '/')}.vim"
-        var resolved_path = globpath(&runtimepath, path)
+        var resolved_path = globpath(&runtimepath, path, 1, 1)
 
-        if resolved_path != ''
+        if !resolved_path->empty()
             var function_pattern: string = $'^\s*\%(:\s*\)\=fun\%[ction]!\=\s\+\zs{curfunc}('
             resolved_path->Open(editcmd, function_pattern)
         endif


### PR DESCRIPTION
Problem: `gf` in Vim script fails if multiple target files exist.
Solution: Use globpath() which returns an array.

In a Vim script, `gf` on `some#func()` will jump to `autoload/some.vim`. In this case, if there are multiple `autoload/foo.vim`s in 'runtimepath', `globpath(&runtimepath, path)` will return multiple paths, separated by newlines.
As a result, the second and subsequent paths will be executed as commands in `autoload/vimgoto.vim:195`, causing an error. This change fixes this issue by making the result of `globpath()` an array.