### PR TITLE
feat(filetype): Add cel

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -1832,6 +1832,8 @@ const ft_from_ext = {
   "tlh": "cpp",
   # Cascading Style Sheets
   "css": "css",
+  # Common Expression Language (CEL) - https://cel.dev
+  "cel": "cel",
   # Century Term Command Scripts (*.cmd too)
   "con": "cterm",
   # ChordPro

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -171,6 +171,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     cdrdaoconf: ['/etc/cdrdao.conf', '/etc/defaults/cdrdao', '/etc/default/cdrdao', '.cdrdao', 'any/etc/cdrdao.conf', 'any/etc/default/cdrdao', 'any/etc/defaults/cdrdao'],
     cdrtoc: ['file.toc'],
     cedar: ['file.cedar'],
+    cel: ['file.cel'],
     cf: ['file.cfm', 'file.cfi', 'file.cfc'],
     cfengine: ['cfengine.conf'],
     cfg: ['file.hgrc', 'filehgrc', 'hgrc', 'some-hgrc'],


### PR DESCRIPTION
Generally CEL is an embedded language in other filetypes (protobuf, markdown documentation), but is occasionally in a separate file.

e.g.:
* https://github.com/google/cel-java/blob/e36c49febc36bcb16ef4f07274fcc8873c1eee59/testing/src/test/resources/expressions/coverage_test_case/simple_expression.cel
* https://github.com/elastic/mito/blob/d0d2dbabae5c563dd943c61fd52992acb655942d/example.cel