### PR TITLE
Update the sed patterns in installman.sh

### DIFF
--- a/src/installman.sh
+++ b/src/installman.sh
@@ -52,6 +52,8 @@ if test $what = "install"; then
    if test -r $helpsource/vim$langadd.1; then
       echo installing $destdir/$exename.1
       LC_ALL=C sed -e s+/usr/local/lib/vim+$vimloc+ \
+	      -e s+'/usr/local/share/vim/vim??'+$vimloc+ \
+	      -e s+/usr/local/share/vim+$vimloc+ \
 	      -e s+$vimloc/doc+$helpsubloc+ \
 	      -e s+$vimloc/print+$printsubloc+ \
 	      -e s+$vimloc/syntax+$synsubloc+ \
@@ -63,7 +65,6 @@ if test $what = "install"; then
 	      -e s+$vimloc/filetype.vim+$scriptloc/filetype.vim+ \
 	      -e s+$vimloc/scripts.vim+$scriptloc/scripts.vim+ \
 	      -e s+$vimloc/optwin.vim+$scriptloc/optwin.vim+ \
-	      -e 's+$vimloc/\*.ps+$scriptloc/\*.ps+' \
 	      $helpsource/vim$langadd.1 > $destdir/$exename.1
       chmod $manmod $destdir/$exename.1
    fi
@@ -72,6 +73,7 @@ if test $what = "install"; then
    if test -r $helpsource/vimtutor$langadd.1; then
       echo installing $destdir/$exename""tutor.1
       LC_ALL=C sed -e s+/usr/local/lib/vim+$vimloc+ \
+	      -e s+'/usr/local/share/vim/vim??'+$vimloc+ \
 	      -e s+$vimloc/tutor+$tutorsubloc+ \
 	      $helpsource/vimtutor$langadd.1 > $destdir/$exename""tutor.1
       chmod $manmod $destdir/$exename""tutor.1
@@ -88,6 +90,7 @@ if test $what = "install"; then
    if test -r $helpsource/evim$langadd.1; then
       echo installing $destdir/$evimname.1
       LC_ALL=C sed -e s+/usr/local/lib/vim+$vimloc+ \
+	      -e s+'/usr/local/share/vim/vim??'+$vimloc+ \
 	      -e s+$vimloc/evim.vim+$scriptloc/evim.vim+ \
 	      $helpsource/evim$langadd.1 > $destdir/$evimname.1
       chmod $manmod $destdir/$evimname.1


### PR DESCRIPTION
In commit ce6fe84db21f we changed '/usr/local/lib' to '/usr/local/share' but the `installman.sh` script was not updated accordingly.
As a result, the file paths in vim(1) are not really accurate anymore. E.g. for Arch Linux:
https://man.archlinux.org/man/vim.1#FILES

We can see the correct file paths in the French translation:
https://man.archlinux.org/man/vim.1.fr#FICHIERS
