### PR TITLE
Update syntax for Django.

### DIFF
--- a/runtime/syntax/django.vim
+++ b/runtime/syntax/django.vim
@@ -32,6 +32,7 @@ syn keyword djangoStatement contained get_current_language trans noop blocktrans
 syn keyword djangoStatement contained endblocktrans get_available_languages
 syn keyword djangoStatement contained get_current_language_bidi plural
 syn keyword djangoStatement contained translate blocktranslate endblocktranslate
+syn keyword djangoStatement contained partialdef endpartialdef partial
 
 " Django templete built-in filters
 syn keyword djangoFilter contained add addslashes capfirst center cut date


### PR DESCRIPTION
Added tags: 'partialdef', 'endpartialdef', 'partial'.
Refernece: [Template Reference: partial](https://docs.djangoproject.com/en/6.0/ref/templates/builtins/#partial)((introduced in Django 6.0) and 'filter'.