### PR TITLE
/runtime/doc/usr_22.txt various corrections

### DIFF
--- a/runtime/doc/usr_22.txt
+++ b/runtime/doc/usr_22.txt
@@ -1,4 +1,4 @@
-*usr_22.txt*	For Vim version 9.1.  Last change: 2025 Nov 09
+*usr_22.txt*	For Vim version 9.1.  Last change: 2026 Feb 13
 
 
 		     VIM USER MANUAL	by Bram Moolenaar
@@ -33,7 +33,7 @@ with the contents of the directory.  It looks like this (slightly cleaned up
 so that it fits within 78 chars): >
 
   " ==========================================================================
-  " Netrw Directory Listing                                       (netrw v180)
+  " Netrw Directory Listing                                       (netrw v184)
   "   /path/to/vim/runtime/doc
   "   Sorted by      name
   "   Sort sequence: [\/]$,*,\(\.bak\|\~\|\.o\|\.h\|\.info\|\.swp\)[*@]\=$
@@ -51,15 +51,12 @@ so that it fits within 78 chars): >
 
 You can see these items:
 
-1.  The name of the browsing tool and its version number
-2.  The name of the browsing directory
-3.  The method of sorting (may be by name, time, or size)
-4.  How names are to be sorted (directories first, then *.h files,
-    *.c files, etc)
-5.  How to get help (use the <F1> key), and an abbreviated listing
-    of available commands
-6.  A listing of files, including "../", which allows one to list
-    the parent directory.
+1. The name of the browsing tool and its version number
+2. The name of the browsing directory
+3. The method of sorting (may be by name, time, or size)
+4. How names are to be sorted (directories first, then by extension, etc.)
+5. How to get help (the <F1> key), and an abridged list of available commands
+6. A listing of files, including "../" (it will list the parent directory).
 
 If you have syntax highlighting enabled, the different parts are highlighted
 so as to make it easier to spot them.
@@ -76,76 +73,66 @@ higher.  Pressing "-" does the same thing, without the need to move to the
 "../" item first.
 
 You can press <F1> to get help on the things you can do in the netrw file
-browser.  This is what you get: >
-
-    9. Directory Browsing	 netrw-browse   netrw-dir   netrw-list   netrw-help
-
-    MAPS								 netrw-maps
-	 <F1>.............Help.......................................|netrw-help|
-	 <cr>.............Browsing...................................|netrw-cr|
-	 <del>............Deleting Files or Directories..............|netrw-delete|
-	 -................Going Up...................................|netrw--|
-	 a................Hiding Files or Directories................|netrw-a|
-	 mb...............Bookmarking a Directory....................|netrw-mb|
-	 gb...............Changing to a Bookmarked Directory.........|netrw-gb|
-	 cd...............Make Browsing Directory The Current Dir....|netrw-c|
-	 d................Make A New Directory.......................|netrw-d|
-	 D................Deleting Files or Directories..............|netrw-D|
-	 <c-h>............Edit File/Directory Hiding List............|netrw-ctrl-h|
-	 i................Change Listing Style.......................|netrw-i|
-	 <c-l>............Refreshing the Listing.....................|netrw-ctrl-l|
-	 o................Browsing with a Horizontal Split...........|netrw-o|
-	 p................Use Preview Window.........................|netrw-p|
-	 P................Edit in Previous Window....................|netrw-p|
-	 q................Listing Bookmarks and History..............|netrw-qb|
-	 r................Reversing Sorting Order....................|netrw-r|
-<	(etc)
-
+browser.  This is what you get:
+>
+ QUICK HELP						netrw-quickhelp
+                       (Use ctrl-] to select a topic)
+	Intro to Browsing...............................netrw-intro-browse
+	  Quick Reference: Maps.........................netrw-quickmap
+	  Quick Reference: Commands.....................netrw-browse-cmds
+<
 The <F1> key thus brings you to a netrw directory browsing contents help page.
 It's a regular help page; use the usual |CTRL-]| to jump to tagged help items
-and |CTRL-O| to jump back.
+and |CTRL-O| to jump back.  So, if you CTRL-] on |netrw-quickmap| you will
+jump to this:
+>
+				netrw-quickmap  netrw-quickmaps
+ QUICK REFERENCE: MAPS				netrw-browse-maps
 
-To select files for display and editing: (with the cursor is atop a filename)
+	  ---			-----------------			----
+	  Map			Quick Explanation			Link
+	  ---			-----------------			----
+	 <F1>	Causes Netrw to issue help
+	 <cr>	Netrw will enter the directory or read the file      netrw-cr
+	 <del>	Netrw will attempt to remove the file/directory      netrw-del
+<	 (etc.)
 
-	<enter>		Open the file in the current window.	   |netrw-cr|
-	o		Horizontally split window and display file |netrw-o|
-	v		Vertically split window and display file   |netrw-v|
-	p		Use the |preview-window|		   |netrw-p|
-	P		Edit in the previous window		   |netrw-P|
-	t		Open file in a new tab			   |netrw-t|
-
+To select files for display and editing (with the cursor atop a filename):
+>
+	   o	Enter the file/directory under the cursor in a new   netrw-o
+		browser window.  A horizontal split is used.
+	   O	Obtain a file specified by cursor                    netrw-O
+	   p	Preview the file                                     netrw-p
+	   P	Browse in the previously used window                 netrw-P
+	   v	Enter the file/directory under the cursor in a new   netrw-v
+		browser window.  A vertical split is used.
+<
 The following normal-mode commands may be used to control the browser display:
-
-	i		Controls listing style (thin, long, wide, and tree).
-			The long listing includes size and date information.
-	s		Repeatedly pressing s will change the way the files
-			are sorted; one may sort on name, modification time,
-			or size.
-	r		Reverse the sorting order.
-
+>
+	   i	Cycle between thin, long, wide, and tree listings    netrw-i
+	   r	Reverse sorting order                                netrw-r
+	   s	Select sorting style: by name, time, or file size    netrw-s
+<
 As a sampling of extra normal-mode commands:
-
-	cd		Change Vim's notion of the current directory to be
-			the same as the browser directory.  (see
-			|g:netrw_keepdir| to control this, too)
-	R		Rename the file or directory under the cursor; a
-			prompt will be issued for the new name.
-	D		Delete the file or directory under the cursor; a
-			confirmation request will be issued.
-	mb gb		Make bookmark/goto bookmark
-
-
+>
+	   cd	Make browsing directory the current directory        netrw-cd
+	   D	Attempt to remove the file(s)/directory(ies)         netrw-D
+	   gb	Go to previous bookmarked directory                  netrw-gb
+	   mb	Bookmark current directory                           netrw-mb
+	   R	Rename the designated file(s)/directory(ies)         netrw-R
+<
 One may also use command mode; again, just a sampling:
-
-	:Explore [directory]	Browse specified/current directory
-	:NetrwSettings		A comprehensive list of your current netrw
-				settings with help linkage.
-
-The netrw browser is not limited to just your local machine; one may use
-urls such as:    (that trailing / is important)
+>
+     :Explore[!]  [dir] Explore directory of current file......netrw-explore
+     :Hexplore[!] [dir] Horizontal Split & Explore.............netrw-explore
+<
+The netrw browser is not limited to just your local machine; one may use URLs
+such as: >
 
 	:Explore ftp://somehost/path/to/dir/
 	:e scp://somehost/path/to/dir/
+<
+	Note: The trailing "/" is important.
 
 See |netrw-browse| for more.
 
@@ -219,8 +206,8 @@ TAB LOCAL DIRECTORY
 
 When you open a new tab page, it uses the directory of the window in the
 previous tab page from which the new tab page was opened.  You can change the
-directory of the current tab page using the `:tcd` command.  All the windows in
-a tab page share this directory except for windows with a window-local
+directory of the current tab page using the `:tcd` command.  All the windows
+in a tab page share this directory except for windows with a window-local
 directory.  Any new windows opened in this tab page will use this directory as
 the current working directory.  Using a `:cd` command in a tab page will not
 change the working directory of tab pages which have a tab local directory.
@@ -318,13 +305,13 @@ without making sure you have saved all the buffers.
 
 INACTIVE BUFFERS
 
-   When a buffer has been used once, Vim remembers some information about it.
+When a buffer has been used once, Vim remembers some information about it.
 When it is not displayed in a window and it is not hidden, it is still in the
 buffer list.  This is called an inactive buffer.  Overview:
 
-   Active		Appears in a window, text loaded.
-   Hidden		Not in a window, text loaded.
-   Inactive		Not in a window, no text loaded.
+	Active		Appears in a window, text loaded.
+	Hidden		Not in a window, text loaded.
+	Inactive	Not in a window, no text loaded.
 
 The inactive buffers are remembered, because Vim keeps information about them,
 like marks.  And remembering the file name is useful too, so that you can see
@@ -404,12 +391,11 @@ will be closed.  If you delete the current buffer, the current window will be
 closed.  If it was the last window, Vim will find another buffer to edit.  You
 can't be editing nothing!
 
-	Note:
-	Even after removing the buffer with ":bdelete" Vim still remembers it.
-	It's actually made "unlisted", it no longer appears in the list from
-	":buffers".  The ":buffers!" command will list unlisted buffers (yes,
-	Vim can do the impossible).  To really make Vim forget about a buffer,
-	use ":bwipe".  Also see the 'buflisted' option.
+	Note: Even after removing the buffer with ":bdelete" Vim still
+	remembers it.  It's actually made "unlisted", it no longer appears in
+	the list from ":buffers".  The ":buffers!" command will list unlisted
+	buffers (yes, Vim can do the impossible).  To really make Vim forget
+	about a buffer, use ":bwipe".  Also see the 'buflisted' option.
 
 ==============================================================================
 


### PR DESCRIPTION
Various fixes and improvements, including:

- Lines exceeding 78 display characters now are within the limit
- Updated outdated netrw help content with correctly quoted content from pi_netrw.txt
- Replace paraphrased content with correctly quoted content (e.g., "mb gb		Make bookmark/goto bookmark")
- Incidental/collateral things like netrw version in example listing from v180 to v184
- Better/fixed wording, e.g., "abridged" rather than "abbreviated", "URLs" not "urls", and removing "is" from "with the cursor is atop a filename", and
- Reflow Note block to follow standard help style.