### PR TITLE
Corrects the covergroup matchit pattern in systemverilog ftplugin

### DIFF
--- a/runtime/ftplugin/systemverilog.vim
+++ b/runtime/ftplugin/systemverilog.vim
@@ -32,7 +32,7 @@ if exists("loaded_matchit")
     \ '\<checker\>:\<endchecker\>,' .
     \ '\<class\>:\<endclass\>,' .
     \ '\<clocking\>:\<endclocking\>,' .
-    \ '\<group\>:\<endgroup\>,' .
+    \ '\<covergroup\>:\<endgroup\>,' .
     \ '\<interface\>:\<endinterface\>,' .
     \ '\<package\>:\<endpackage\>,' .
     \ '\<program\>:\<endprogram\>,' .


### PR DESCRIPTION
A covergroup start with the covergroup keyword and ends with the endgroup keyword. group is not even a reserved keyword in systemverilog.

https://www.chipverify.com/systemverilog/systemverilog-covergroup-coverpoint#covergroup https://github.com/MikePopoloski/slang/blob/master/docs/grammar.md#covergroup_declaration