### PR TITLE
Fix typos in markdown documents

### DIFF
--- a/README_VIM9.md
+++ b/README_VIM9.md
@@ -28,7 +28,7 @@ way:
 * Local variables are not available in an l: dictionary.
 * A few more things that slow us down, such as exception handling details.
 
-I Implemented a "proof of concept" and measured the time to run a simple
+I implemented a "proof of concept" and measured the time to run a simple
 for loop with an addition (Justin used this example in his presentation,
 full code is below):
 
@@ -224,7 +224,7 @@ Eventually this will lead to Vim 9!
 
 ## Code for sum time measurements
 
-Vim was build with -O2.
+Vim was built with -O2.
 
 ``` vim
 func VimOld()

--- a/runtime/pack/dist/opt/netrw/README.md
+++ b/runtime/pack/dist/opt/netrw/README.md
@@ -30,7 +30,7 @@ Changes made to `autoload/netrw.vim`:
 - 2024 May 13 by Vim Project: prefer scp over pscp
 - 2024 Jun 04 by Vim Project: set bufhidden if buffer changed, nohidden is set and buffer shall be switched (#14915)
 - 2024 Jun 13 by Vim Project: glob() on Windows fails when a directory name contains [] (#14952)
-- 2024 Jun 23 by Vim Project: save ad restore registers when liststyle = WIDELIST (#15077, #15114)
+- 2024 Jun 23 by Vim Project: save and restore registers when liststyle = WIDELIST (#15077, #15114)
 - 2024 Jul 22 by Vim Project: avoid endless recursion (#15318)
 - 2024 Jul 23 by Vim Project: escape filename before trying to delete it (#15330)
 - 2024 Jul 30 by Vim Project: handle mark-copy to same target directory (#12112)
@@ -505,7 +505,7 @@ General changes made to netrw:
 		Dec 24, 2013	* (esquifit) asked that netrw allow the
 				  /cygdrive prefix be a user-alterable
 				  parameter.
-		Jan 02, 2014	* Fixed a problem with netrw-based ballon
+		Jan 02, 2014	* Fixed a problem with netrw-based balloon
 				  evaluation (ie. netrw#NetrwBaloonHelp()
 				  not having been loaded error messages)
 		Jan 03, 2014	* Fixed a problem with tree listings

--- a/runtime/syntax/generator/README.md
+++ b/runtime/syntax/generator/README.md
@@ -3,7 +3,7 @@
 This directory contains a Vim script generator, that will parse the Vim source file and
 generate a vim.vim syntax file.
 
-Files in this directory where copied from https://github.com/vim-jp/syntax-vim-ex/
+Files in this directory were copied from https://github.com/vim-jp/syntax-vim-ex/
 and included here on Feb, 13th, 2024 for the Vim Project.
 
 - Maintainer: Hirohito Higashi


### PR DESCRIPTION
## Summary

Fix a few spelling mistakes across markdown files:

- `README_VIM9.md`: "I Implemented" -> "I implemented", "was build" -> "was built"
- `runtime/syntax/generator/README.md`: "where copied" -> "were copied"
- `runtime/pack/dist/opt/netrw/README.md`: "save ad restore" -> "save and restore", "ballon" -> "balloon"