### PR TITLE
cindent: fix comment lines which start like a label

### DIFF
--- a/src/cindent.c
+++ b/src/cindent.c
@@ -652,6 +652,9 @@ cin_islabel(void)		// XXX
     if (!cin_islabel_skip(&s))
 	return FALSE;
 
+    if (ind_find_start_CORS(NULL))
+	return FALSE; // Don't accept a label in a comment or a raw string.
+
     // Only accept a label if the previous line is terminated or is a case
     // label.
     pos_T	cursor_save;

--- a/src/testdir/test_cindent.vim
+++ b/src/testdir/test_cindent.vim
@@ -1132,6 +1132,12 @@ def Test_cindent_1()
   a();
   }
 
+  void func() {
+  /* aaaaaa
+  bbbbb:
+  ccccccc */
+  }
+
   /* end of AUTO */
   [CODE]
 
@@ -2133,6 +2139,12 @@ def Test_cindent_1()
   		while (0);
   	else
   		a();
+  }
+
+  void func() {
+  	/* aaaaaa
+  	   bbbbb:
+  	   ccccccc */
   }
 
   /* end of AUTO */


### PR DESCRIPTION
Problem: Comment lines which start like a label are recognized as a label and indented based on that.

Solution Check if the position is in a comment after recognizing a label in cin_islabel.