### PR TITLE
runtime(hare): update for Hare 0.26.0

### DIFF
--- a/runtime/syntax/hare.vim
+++ b/runtime/syntax/hare.vim
@@ -101,10 +101,10 @@ syn match hareTypedefEquals '=' contained nextgroup=@hareType skipempty skipwhit
 
 # Attributes {{{3
 syn keyword hareAttribute @init @fini @test
-syn keyword hareAttribute @offset nextgroup=hareAttributeParens skipempty skipwhite
 syn keyword hareAttribute @packed
 syn keyword hareAttribute @symbol nextgroup=hareAttributeParens skipempty skipwhite
 syn keyword hareAttribute @threadlocal
+syn keyword hareAttribute @undefined
 
 # Match the parens following attributes.
 syn region hareAttributeParens matchgroup=hareParen start='(' end=')' contained contains=TOP transparent


### PR DESCRIPTION
I have not updated the "last change" header at the top of the syntax file, as the *upstream* repository was last modified on February 1st still. I'm not sure if the same date should be used here, or if it would be better to list the date of this downstream commit instead.