### PR TITLE
Problem:  tests: Test_popup_setbuf fails

### DIFF
--- a/src/testdir/dumps/Test_popup_setbuf_04.vim
+++ b/src/testdir/dumps/Test_popup_setbuf_04.vim
@@ -1,2 +1,4 @@
 " replace Last Change Header in help.txt
 :1s/|L|a|s|t| |c|h|a|n|g|e|:| |\d|\d|\d|\d| |\w|\w|\w| |\d|\d|/|L|a|s|t| |c|h|a|n|g|e|:| |2|0|2|4| |M|a|y| |2|7|/ge
+" replace Version number in help.txt
+:1s/|v|e|r|s|i|o|n| |\(\d|\)\+\.|\d|\.|/|v|e|r|s|i|o|n| |9|.|1|.|/ge

--- a/src/testdir/dumps/Test_popup_setbuf_05.vim
+++ b/src/testdir/dumps/Test_popup_setbuf_05.vim
@@ -1,2 +1,4 @@
 " replace Last Change Header in help.txt
 :1s/|L|a|s|t| |c|h|a|n|g|e|:| |\d|\d|\d|\d| |\w|\w|\w| |\d|\d|/|L|a|s|t| |c|h|a|n|g|e|:| |2|0|2|4| |M|a|y| |2|7|/ge
+" replace Version number in help.txt
+:1s/|v|e|r|s|i|o|n| |\(\d|\)\+\.|\d|\.|/|v|e|r|s|i|o|n| |9|.|1|.|/ge

--- a/src/testdir/dumps/Test_popup_setbuf_06.vim
+++ b/src/testdir/dumps/Test_popup_setbuf_06.vim
@@ -1,2 +1,4 @@
 " replace Last Change Header in help.txt
 :1s/|L|a|s|t| |c|h|a|n|g|e|:| |\d|\d|\d|\d| |\w|\w|\w| |\d|\d|/|L|a|s|t| |c|h|a|n|g|e|:| |2|0|2|4| |M|a|y| |2|7|/ge
+" replace Version number in help.txt
+:1s/|v|e|r|s|i|o|n| |\(\d|\)\+\.|\d|\.|/|v|e|r|s|i|o|n| |9|.|1|.|/ge


### PR DESCRIPTION
Problem:  tests: Test_popup_setbuf fails, because the dump file contains
          a reference to Vim version 9.1 (after v9.2.0000)
Solution: Replace Version number by 9.1 always