### PR TITLE
Still buffer overflow.

### DIFF
--- a/src/netbeans.c
+++ b/src/netbeans.c
@@ -2319,9 +2319,9 @@ special_keys(char_u *args)
 	    tok++;
 	}
 
-	if (strlen(tok) + i < KEYBUFLEN)
+	if (strlen(tok) + i + 1 <= KEYBUFLEN)
 	{
-	    strcpy(&keybuf[i], tok);
+	    vim_strncpy((char_u *)&keybuf[i], (char_u *)tok, KEYBUFLEN - i - 1);
 	    vim_snprintf(cmdbuf, sizeof(cmdbuf),
 				 "<silent><%s> :nbkey %s<CR>", keybuf, keybuf);
 	    do_map(MAPTYPE_MAP, (char_u *)cmdbuf, MODE_NORMAL, FALSE);


### PR DESCRIPTION
@chrisbra I suspect this fix does not fully resolve the issue.

https://github.com/vim/vim/commit/c5f312aad8e4179e437f81ad39a860cd0ef11970#diff-012c27cfc933c3fb6030c48e84f44e5cd2706af0b1ac94631f6a5d31b13170b0R2322

- `keybuf[KEYBUFLEN]` is a fixed-size buffer of 64 bytes (KEYBUFLEN = 64)
- `strlen(tok)` returns the string length (NUL terminator **not** included)
- `i` is the number of characters already written to keybuf

After copying, we need 1 additional byte for the NUL terminator (`\0`). And the original check `strlen(tok) + i < 64` only checked up to 63 bytes.