### PR TITLE
Use single target to generate wayland protocol files

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1607,7 +1607,10 @@ EXTRA_SRC = if_lua.c if_mzsch.c auto/if_perl.c \
 	    gui_beval.c netbeans.c job.c channel.c \
 	    $(GRESOURCE_SRC)
 
-$(WAYLAND_SRC):
+$(WAYLAND_SRC): genwaylandproto
+
+.PHONY: genwaylandproto
+genwaylandproto:
 	cd auto/wayland; $(MAKE)
 
 # Needed for parallel jobs to work


### PR DESCRIPTION
$(WAYLAND_SRC) contains up to 4 files which, given right timing and parallelization level, can spawn 4 independent `make` processes during parallel build. Each process generates same set of files intermittently leading to inconsistent results. Instead use one common target each source file depends on.

Fixes #19419