### PR TITLE
defaults.vim: add XDG support

### DIFF
--- a/runtime/defaults.vim
+++ b/runtime/defaults.vim
@@ -155,3 +155,25 @@ if has('langmap') && exists('+langremap')
   " compatible).
   set nolangremap
 endif
+
+
+" XDG Base Directory support
+" https://jorenar.com/blog/vim-xdg
+
+if empty($XDG_DATA_HOME)   | let $XDG_DATA_HOME   = $HOME."/.local/share" | endif
+if empty($XDG_STATE_HOME)  | let $XDG_STATE_HOME  = $HOME."/.local/state" | endif
+
+" set runtimepath+=$XDG_DATA_HOME/vim
+
+set packpath^=$XDG_DATA_HOME/vim
+"   set packpath+=$XDG_DATA_HOME/vim/after
+
+"   set backupdir=$XDG_STATE_HOME/vim/backup | call mkdir(&backupdir, 'p', 0700)
+"   set directory=$XDG_STATE_HOME/vim/swap   | call mkdir(&directory, 'p', 0700)
+"   set viewdir=$XDG_STATE_HOME/vim/view     | call mkdir(&viewdir,   'p', 0700)
+"   set undodir=$XDG_STATE_HOME/vim/undo     | call mkdir(&undodir,   'p', 0700)
+set viminfofile=$XDG_STATE_HOME/vim/viminfo
+
+" let g:netrw_home = $XDG_DATA_HOME."/vim"
+" call mkdir($XDG_DATA_HOME."/vim/spell", 'p', 0700)
+call mkdir($XDG_STATE_HOME."/vim", 'p', 0700)

--- a/runtime/defaults.vim
+++ b/runtime/defaults.vim
@@ -156,23 +156,5 @@ if has('langmap') && exists('+langremap')
   set nolangremap
 endif
 
-
 " XDG Base Directory support
-
-if empty($XDG_CONFIG_HOME) | let $XDG_CONFIG_HOME = $HOME."/.config"      | endif
-if empty($XDG_DATA_HOME)   | let $XDG_DATA_HOME   = $HOME."/.local/share" | endif
-if empty($XDG_STATE_HOME)  | let $XDG_STATE_HOME  = $HOME."/.local/state" | endif
-
-set packpath^=$XDG_DATA_HOME/vim
-set packpath+=$XDG_DATA_HOME/vim/after
-
-if isdirectory(expand($XDG_CONFIG_HOME."/vim"))
-  set viminfofile=$XDG_STATE_HOME/vim/viminfo | call mkdir($XDG_STATE_HOME."/vim", 'p', 0700)
-  " set backupdir=$XDG_STATE_HOME/vim/backup | call mkdir(&backupdir, 'p', 0700)
-  " set directory=$XDG_STATE_HOME/vim/swap   | call mkdir(&directory, 'p', 0700)
-  " set viewdir=$XDG_STATE_HOME/vim/view     | call mkdir(&viewdir,   'p', 0700)
-  " set undodir=$XDG_STATE_HOME/vim/undo     | call mkdir(&undodir,   'p', 0700)
-
-  " let g:netrw_home = $XDG_DATA_HOME."/vim"
-  " call mkdir($XDG_DATA_HOME."/vim/spell", 'p', 0700)
-endif
+source $VIMRUNTIME/xdg.vim

--- a/runtime/defaults.vim
+++ b/runtime/defaults.vim
@@ -158,22 +158,21 @@ endif
 
 
 " XDG Base Directory support
-" https://jorenar.com/blog/vim-xdg
 
+if empty($XDG_CONFIG_HOME) | let $XDG_CONFIG_HOME = $HOME."/.config"      | endif
 if empty($XDG_DATA_HOME)   | let $XDG_DATA_HOME   = $HOME."/.local/share" | endif
 if empty($XDG_STATE_HOME)  | let $XDG_STATE_HOME  = $HOME."/.local/state" | endif
 
-" set runtimepath+=$XDG_DATA_HOME/vim
-
 set packpath^=$XDG_DATA_HOME/vim
-"   set packpath+=$XDG_DATA_HOME/vim/after
+set packpath+=$XDG_DATA_HOME/vim/after
 
-"   set backupdir=$XDG_STATE_HOME/vim/backup | call mkdir(&backupdir, 'p', 0700)
-"   set directory=$XDG_STATE_HOME/vim/swap   | call mkdir(&directory, 'p', 0700)
-"   set viewdir=$XDG_STATE_HOME/vim/view     | call mkdir(&viewdir,   'p', 0700)
-"   set undodir=$XDG_STATE_HOME/vim/undo     | call mkdir(&undodir,   'p', 0700)
-set viminfofile=$XDG_STATE_HOME/vim/viminfo
+if isdirectory(expand($XDG_CONFIG_HOME."/vim"))
+  set viminfofile=$XDG_STATE_HOME/vim/viminfo | call mkdir($XDG_STATE_HOME."/vim", 'p', 0700)
+  " set backupdir=$XDG_STATE_HOME/vim/backup | call mkdir(&backupdir, 'p', 0700)
+  " set directory=$XDG_STATE_HOME/vim/swap   | call mkdir(&directory, 'p', 0700)
+  " set viewdir=$XDG_STATE_HOME/vim/view     | call mkdir(&viewdir,   'p', 0700)
+  " set undodir=$XDG_STATE_HOME/vim/undo     | call mkdir(&undodir,   'p', 0700)
 
-" let g:netrw_home = $XDG_DATA_HOME."/vim"
-" call mkdir($XDG_DATA_HOME."/vim/spell", 'p', 0700)
-call mkdir($XDG_STATE_HOME."/vim", 'p', 0700)
+  " let g:netrw_home = $XDG_DATA_HOME."/vim"
+  " call mkdir($XDG_DATA_HOME."/vim/spell", 'p', 0700)
+endif

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -1125,8 +1125,8 @@ This is not an exhaustive list of those directories:
   `$XDG_DATA_HOME`	$HOME/.local/share	Persistent data files
   `$XDG_STATE_HOME`	$HOME/.local/state	State data files
 
-Vim will only use the `$XDG_CONFIG_HOME` directory, the others are not
-(yet) used for its various configuration and state files.
+Vim itself will only use the `$XDG_CONFIG_HOME` directory, some of the others
+are supported in |defaults.vim|, see the script for details.
 
 							*xdg-vimrc*
 Vim, on Unix systems, will look at `$XDG_CONFIG_HOME/vim/vimrc` for its

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -1126,7 +1126,7 @@ This is not an exhaustive list of those directories:
   `$XDG_STATE_HOME`	$HOME/.local/state	State data files
 
 Vim itself will only use the `$XDG_CONFIG_HOME` directory, some of the others
-are supported in |defaults.vim|, see the script for details.
+are supported in $VIMRUNTIME/xdg.vim, see the script for details.
 
 							*xdg-vimrc*
 Vim, on Unix systems, will look at `$XDG_CONFIG_HOME/vim/vimrc` for its

--- a/runtime/xdg.vim
+++ b/runtime/xdg.vim
@@ -9,6 +9,8 @@ set packpath+=$XDG_DATA_HOME/vim/after
 
 if isdirectory(expand($XDG_CONFIG_HOME."/vim"))
   set viminfofile=$XDG_STATE_HOME/vim/viminfo | call mkdir($XDG_STATE_HOME."/vim", 'p', 0700)
+
+  " These options are not essential for XDG, but you might want to set them:
   " set backupdir=$XDG_STATE_HOME/vim/backup// | call mkdir(&backupdir, 'p', 0700)
   " set directory=$XDG_STATE_HOME/vim/swap   | call mkdir(&directory, 'p', 0700)
   " set viewdir=$XDG_STATE_HOME/vim/view     | call mkdir(&viewdir,   'p', 0700)

--- a/runtime/xdg.vim
+++ b/runtime/xdg.vim
@@ -1,0 +1,19 @@
+" XDG Base Directory support
+
+if empty($XDG_CONFIG_HOME) | let $XDG_CONFIG_HOME = $HOME."/.config"      | endif
+if empty($XDG_DATA_HOME)   | let $XDG_DATA_HOME   = $HOME."/.local/share" | endif
+if empty($XDG_STATE_HOME)  | let $XDG_STATE_HOME  = $HOME."/.local/state" | endif
+
+set packpath^=$XDG_DATA_HOME/vim
+set packpath+=$XDG_DATA_HOME/vim/after
+
+if isdirectory(expand($XDG_CONFIG_HOME."/vim"))
+  set viminfofile=$XDG_STATE_HOME/vim/viminfo | call mkdir($XDG_STATE_HOME."/vim", 'p', 0700)
+  " set backupdir=$XDG_STATE_HOME/vim/backup | call mkdir(&backupdir, 'p', 0700)
+  " set directory=$XDG_STATE_HOME/vim/swap   | call mkdir(&directory, 'p', 0700)
+  " set viewdir=$XDG_STATE_HOME/vim/view     | call mkdir(&viewdir,   'p', 0700)
+  " set undodir=$XDG_STATE_HOME/vim/undo     | call mkdir(&undodir,   'p', 0700)
+
+  " let g:netrw_home = $XDG_DATA_HOME."/vim"
+  " call mkdir($XDG_DATA_HOME."/vim/spell", 'p', 0700)
+endif

--- a/runtime/xdg.vim
+++ b/runtime/xdg.vim
@@ -9,7 +9,7 @@ set packpath+=$XDG_DATA_HOME/vim/after
 
 if isdirectory(expand($XDG_CONFIG_HOME."/vim"))
   set viminfofile=$XDG_STATE_HOME/vim/viminfo | call mkdir($XDG_STATE_HOME."/vim", 'p', 0700)
-  " set backupdir=$XDG_STATE_HOME/vim/backup | call mkdir(&backupdir, 'p', 0700)
+  " set backupdir=$XDG_STATE_HOME/vim/backup// | call mkdir(&backupdir, 'p', 0700)
   " set directory=$XDG_STATE_HOME/vim/swap   | call mkdir(&directory, 'p', 0700)
   " set viewdir=$XDG_STATE_HOME/vim/view     | call mkdir(&viewdir,   'p', 0700)
   " set undodir=$XDG_STATE_HOME/vim/undo     | call mkdir(&undodir,   'p', 0700)


### PR DESCRIPTION
If the system has XDG basedirs for Vim already, do support them.

Fixes #19399 