### PR TITLE
More use ga_concat_len() where the length is known

### DIFF
--- a/src/clientserver.c
+++ b/src/clientserver.c
@@ -677,13 +677,13 @@ build_drop_cmd(
     string_T	cdp;
     char_u	*cwd;
     // reset wildignore temporarily
-#define STRING_INIT(s) \
+# define STRING_INIT(s) \
     {(char_u *)(s), STRLEN_LITERAL(s)}
     const string_T wig[] = {
 	STRING_INIT("<CR><C-\\><C-N>:let g:_wig=&wig|set wig="),
 	STRING_INIT("<C-\\><C-N>:let &wig=g:_wig|unlet g:_wig<CR>")
     };
-#undef STRING_INIT
+# undef STRING_INIT
 
     if (filec > 0 && filev[0][0] == '+')
     {

--- a/src/clientserver.c
+++ b/src/clientserver.c
@@ -674,12 +674,16 @@ build_drop_cmd(
     int		i;
     char_u	*inicmd = NULL;
     char_u	*p;
-    char_u	*cdp;
+    string_T	cdp;
     char_u	*cwd;
     // reset wildignore temporarily
-    const char *wig[] =
-    { "<CR><C-\\><C-N>:let g:_wig=&wig|set wig=",
-      "<C-\\><C-N>:let &wig=g:_wig|unlet g:_wig<CR>"};
+#define STRING_INIT(s) \
+    {(char_u *)(s), STRLEN_LITERAL(s)}
+    const string_T wig[] = {
+	STRING_INIT("<CR><C-\\><C-N>:let g:_wig=&wig|set wig="),
+	STRING_INIT("<C-\\><C-N>:let &wig=g:_wig|unlet g:_wig<CR>")
+    };
+#undef STRING_INIT
 
     if (filec > 0 && filev[0][0] == '+')
     {
@@ -700,7 +704,7 @@ build_drop_cmd(
 	vim_free(cwd);
 	return NULL;
     }
-    cdp = vim_strsave_escaped_ext(cwd,
+    cdp.string = vim_strsave_escaped_ext(cwd,
 # ifdef BACKSLASH_IN_FILENAME
 	    (char_u *)"",  // rem_backslash() will tell what chars to escape
 # else
@@ -708,20 +712,21 @@ build_drop_cmd(
 # endif
 	    '\\', TRUE);
     vim_free(cwd);
-    if (cdp == NULL)
+    if (cdp.string == NULL)
 	return NULL;
+    cdp.length = STRLEN(cdp.string);
     ga_init2(&ga, 1, 100);
-    ga_concat(&ga, (char_u *)"<C-\\><C-N>:cd ");
-    ga_concat(&ga, cdp);
+    ga_concat_len(&ga, (char_u *)"<C-\\><C-N>:cd ", 14);
+    ga_concat_len(&ga, cdp.string, cdp.length);
     // reset wildignorecase temporarily
-    ga_concat(&ga, (char_u *)wig[0]);
+    ga_concat_len(&ga, (char_u *)wig[0].string, wig[0].length);
 
     // Call inputsave() so that a prompt for an encryption key works.
-    ga_concat(&ga, (char_u *)
-	    "<CR><C-\\><C-N>:if exists('*inputsave')|call inputsave()|endif|");
+    ga_concat_len(&ga, (char_u *)
+	    "<CR><C-\\><C-N>:if exists('*inputsave')|call inputsave()|endif|", 62);
     if (tabs)
-	ga_concat(&ga, (char_u *)"tab ");
-    ga_concat(&ga, (char_u *)"drop");
+	ga_concat_len(&ga, (char_u *)"tab ", 4);
+    ga_concat_len(&ga, (char_u *)"drop", 4);
     for (i = 0; i < filec; i++)
     {
 	// On Unix the shell has already expanded the wildcards, don't want to
@@ -739,16 +744,16 @@ build_drop_cmd(
 	    vim_free(ga.ga_data);
 	    return NULL;
 	}
-	ga_concat(&ga, (char_u *)" ");
+	ga_concat_len(&ga, (char_u *)" ", 1);
 	ga_concat(&ga, p);
 	vim_free(p);
     }
-    ga_concat(&ga, (char_u *)
-		  "|if exists('*inputrestore')|call inputrestore()|endif<CR>");
+    ga_concat_len(&ga, (char_u *)
+		  "|if exists('*inputrestore')|call inputrestore()|endif<CR>", 57);
 
     // The :drop commands goes to Insert mode when 'insertmode' is set, use
     // CTRL-\ CTRL-N again.
-    ga_concat(&ga, (char_u *)"<C-\\><C-N>");
+    ga_concat_len(&ga, (char_u *)"<C-\\><C-N>", 10);
 
     // Switch back to the correct current directory (prior to temporary path
     // switch) unless 'autochdir' is set, in which case it will already be
@@ -761,34 +766,34 @@ build_drop_cmd(
     //      cd -
     //    endif
     //  endif
-    ga_concat(&ga, (char_u *)":if !exists('+acd')||!&acd|if haslocaldir()|");
+    ga_concat_len(&ga, (char_u *)":if !exists('+acd')||!&acd|if haslocaldir()|", 44);
 # ifdef MSWIN
     // in case :set shellslash is set, need to normalize the directory separators
     // '/' is not valid in a filename so replacing '/' by '\\' should be safe
-    ga_concat(&ga, (char_u *)"cd -|lcd -|elseif getcwd()->tr('/','\\') ==# '");
+    ga_concat_len(&ga, (char_u *)"cd -|lcd -|elseif getcwd()->tr('/','\\') ==# '", 45);
 # else
-    ga_concat(&ga, (char_u *)"cd -|lcd -|elseif getcwd() ==# '");
+    ga_concat_len(&ga, (char_u *)"cd -|lcd -|elseif getcwd() ==# '", 32);
 # endif
-    ga_concat(&ga, cdp);
-    ga_concat(&ga, (char_u *)"'|cd -|endif|endif<CR>");
-    vim_free(cdp);
+    ga_concat_len(&ga, cdp.string, cdp.length);
+    ga_concat_len(&ga, (char_u *)"'|cd -|endif|endif<CR>", 22);
+    vim_free(cdp.string);
     // reset wildignorecase
-    ga_concat(&ga, (char_u *)wig[1]);
+    ga_concat_len(&ga, (char_u *)wig[1].string, wig[1].length);
 
     if (sendReply)
-	ga_concat(&ga, (char_u *)":call SetupRemoteReplies()<CR>");
-    ga_concat(&ga, (char_u *)":");
+	ga_concat_len(&ga, (char_u *)":call SetupRemoteReplies()<CR>", 29);
+    ga_concat_len(&ga, (char_u *)":", 1);
     if (inicmd != NULL)
     {
 	// Can't use <CR> after "inicmd", because a "startinsert" would cause
 	// the following commands to be inserted as text.  Use a "|",
 	// hopefully "inicmd" does allow this...
 	ga_concat(&ga, inicmd);
-	ga_concat(&ga, (char_u *)"|");
+	ga_concat_len(&ga, (char_u *)"|", 1);
     }
     // Bring the window to the foreground, goto Insert mode when 'im' set and
     // clear command line.
-    ga_concat(&ga, (char_u *)"cal foreground()|if &im|star|en|redr|f<CR>");
+    ga_concat_len(&ga, (char_u *)"cal foreground()|if &im|star|en|redr|f<CR>", 42);
     ga_append(&ga, NUL);
     return ga.ga_data;
 }

--- a/src/clientserver.c
+++ b/src/clientserver.c
@@ -716,17 +716,16 @@ build_drop_cmd(
 	return NULL;
     cdp.length = STRLEN(cdp.string);
     ga_init2(&ga, 1, 100);
-    ga_concat_len(&ga, (char_u *)"<C-\\><C-N>:cd ", 14);
+    GA_CONCAT_LITERAL(&ga, "<C-\\><C-N>:cd ");
     ga_concat_len(&ga, cdp.string, cdp.length);
     // reset wildignorecase temporarily
-    ga_concat_len(&ga, (char_u *)wig[0].string, wig[0].length);
+    ga_concat_len(&ga, wig[0].string, wig[0].length);
 
     // Call inputsave() so that a prompt for an encryption key works.
-    ga_concat_len(&ga, (char_u *)
-	    "<CR><C-\\><C-N>:if exists('*inputsave')|call inputsave()|endif|", 62);
+    GA_CONCAT_LITERAL(&ga, "<CR><C-\\><C-N>:if exists('*inputsave')|call inputsave()|endif|");
     if (tabs)
 	ga_concat_len(&ga, (char_u *)"tab ", 4);
-    ga_concat_len(&ga, (char_u *)"drop", 4);
+    GA_CONCAT_LITERAL(&ga, "drop");
     for (i = 0; i < filec; i++)
     {
 	// On Unix the shell has already expanded the wildcards, don't want to
@@ -744,16 +743,15 @@ build_drop_cmd(
 	    vim_free(ga.ga_data);
 	    return NULL;
 	}
-	ga_concat_len(&ga, (char_u *)" ", 1);
+	GA_CONCAT_LITERAL(&ga, " ");
 	ga_concat(&ga, p);
 	vim_free(p);
     }
-    ga_concat_len(&ga, (char_u *)
-		  "|if exists('*inputrestore')|call inputrestore()|endif<CR>", 57);
+    GA_CONCAT_LITERAL(&ga, "|if exists('*inputrestore')|call inputrestore()|endif<CR>");
 
     // The :drop commands goes to Insert mode when 'insertmode' is set, use
     // CTRL-\ CTRL-N again.
-    ga_concat_len(&ga, (char_u *)"<C-\\><C-N>", 10);
+    GA_CONCAT_LITERAL(&ga, "<C-\\><C-N>");
 
     // Switch back to the correct current directory (prior to temporary path
     // switch) unless 'autochdir' is set, in which case it will already be
@@ -766,34 +764,34 @@ build_drop_cmd(
     //      cd -
     //    endif
     //  endif
-    ga_concat_len(&ga, (char_u *)":if !exists('+acd')||!&acd|if haslocaldir()|", 44);
+    GA_CONCAT_LITERAL(&ga, ":if !exists('+acd')||!&acd|if haslocaldir()|");
 # ifdef MSWIN
     // in case :set shellslash is set, need to normalize the directory separators
     // '/' is not valid in a filename so replacing '/' by '\\' should be safe
-    ga_concat_len(&ga, (char_u *)"cd -|lcd -|elseif getcwd()->tr('/','\\') ==# '", 45);
+    GA_CONCAT_LITERAL(&ga, "cd -|lcd -|elseif getcwd()->tr('/','\\') ==# '");
 # else
-    ga_concat_len(&ga, (char_u *)"cd -|lcd -|elseif getcwd() ==# '", 32);
+    GA_CONCAT_LITERAL(&ga, "cd -|lcd -|elseif getcwd() ==# '");
 # endif
     ga_concat_len(&ga, cdp.string, cdp.length);
-    ga_concat_len(&ga, (char_u *)"'|cd -|endif|endif<CR>", 22);
+    GA_CONCAT_LITERAL(&ga, "'|cd -|endif|endif<CR>");
     vim_free(cdp.string);
     // reset wildignorecase
-    ga_concat_len(&ga, (char_u *)wig[1].string, wig[1].length);
+    ga_concat_len(&ga, wig[1].string, wig[1].length);
 
     if (sendReply)
-	ga_concat_len(&ga, (char_u *)":call SetupRemoteReplies()<CR>", 29);
-    ga_concat_len(&ga, (char_u *)":", 1);
+	GA_CONCAT_LITERAL(&ga, ":call SetupRemoteReplies()<CR>");
+    GA_CONCAT_LITERAL(&ga, ":");
     if (inicmd != NULL)
     {
 	// Can't use <CR> after "inicmd", because a "startinsert" would cause
 	// the following commands to be inserted as text.  Use a "|",
 	// hopefully "inicmd" does allow this...
 	ga_concat(&ga, inicmd);
-	ga_concat_len(&ga, (char_u *)"|", 1);
+	GA_CONCAT_LITERAL(&ga, "|");
     }
     // Bring the window to the foreground, goto Insert mode when 'im' set and
     // clear command line.
-    ga_concat_len(&ga, (char_u *)"cal foreground()|if &im|star|en|redr|f<CR>", 42);
+    GA_CONCAT_LITERAL(&ga, "cal foreground()|if &im|star|en|redr|f<CR>");
     ga_append(&ga, NUL);
     return ga.ga_data;
 }

--- a/src/clientserver.c
+++ b/src/clientserver.c
@@ -724,7 +724,7 @@ build_drop_cmd(
     // Call inputsave() so that a prompt for an encryption key works.
     GA_CONCAT_LITERAL(&ga, "<CR><C-\\><C-N>:if exists('*inputsave')|call inputsave()|endif|");
     if (tabs)
-	ga_concat_len(&ga, (char_u *)"tab ", 4);
+	GA_CONCAT_LITERAL(&ga, "tab ");
     GA_CONCAT_LITERAL(&ga, "drop");
     for (i = 0; i < filec; i++)
     {

--- a/src/json.c
+++ b/src/json.c
@@ -96,6 +96,7 @@ json_encode_lsp_msg(typval_T *val)
 {
     garray_T	ga;
     garray_T	lspga;
+    size_t	IObufflen;
 
     ga_init2(&ga, 1, 4000);
     if (json_encode_gap(&ga, val, 0) == FAIL)
@@ -104,10 +105,10 @@ json_encode_lsp_msg(typval_T *val)
 
     ga_init2(&lspga, 1, 4000);
     // Header according to LSP specification.
-    vim_snprintf((char *)IObuff, IOSIZE,
+    IObufflen = vim_snprintf_safelen((char *)IObuff, IOSIZE,
 	    "Content-Length: %u\r\n\r\n",
 	    ga.ga_len - 1);
-    ga_concat(&lspga, IObuff);
+    ga_concat_len(&lspga, IObuff, IObufflen);
     ga_concat_len(&lspga, ga.ga_data, ga.ga_len);
     ga_clear(&ga);
     return lspga.ga_data;
@@ -145,7 +146,7 @@ write_string(garray_T *gap, char_u *str)
 
     if (res == NULL)
     {
-	ga_concat(gap, (char_u *)"\"\"");
+	ga_concat_len(gap, (char_u *)"\"\"", 2);
 	return;
     }
 
@@ -199,16 +200,21 @@ write_string(garray_T *gap, char_u *str)
 		    ga_append(gap, c);
 		    break;
 		default:
-		    vim_snprintf((char *)numbuf, NUMBUFLEN, "\\u%04lx",
-								      (long)c);
-		    ga_concat(gap, numbuf);
+		{
+		    size_t  numbuflen;
+
+		    numbuflen = vim_snprintf_safelen((char *)numbuf,
+			sizeof(numbuf), "\\u%04lx", (long)c);
+		    ga_concat_len(gap, numbuf, numbuflen);
+		}
 	    }
 
 	    res += 1;
 	}
 	else
 	{
-	    int l = utf_ptr2len(res);
+	    int	    l = utf_ptr2len(res);
+	    size_t  numbuflen;
 
 	    if (l > 1)
 	    {
@@ -222,8 +228,9 @@ write_string(garray_T *gap, char_u *str)
 		ga_concat_len(gap, from, res - from);
 	    from = res + 1;
 
-	    numbuf[utf_char2bytes(0xFFFD, numbuf)] = NUL;
-	    ga_concat(gap, numbuf);
+	    numbuflen = utf_char2bytes(0xFFFD, numbuf);
+	    numbuf[numbuflen] = NUL;
+	    ga_concat_len(gap, numbuf, numbuflen);
 
 	    res += l;
 	}
@@ -276,8 +283,8 @@ json_encode_item(garray_T *gap, typval_T *val, int copyID, int options)
 	case VAR_BOOL:
 	    switch ((long)val->vval.v_number)
 	    {
-		case VVAL_FALSE: ga_concat(gap, (char_u *)"false"); break;
-		case VVAL_TRUE: ga_concat(gap, (char_u *)"true"); break;
+		case VVAL_FALSE: ga_concat_len(gap, (char_u *)"false", 5); break;
+		case VVAL_TRUE: ga_concat_len(gap, (char_u *)"true", 4); break;
 	    }
 	    break;
 
@@ -289,14 +296,18 @@ json_encode_item(garray_T *gap, typval_T *val, int copyID, int options)
 				    // empty item
 				    break;
 				// FALLTHROUGH
-		case VVAL_NULL: ga_concat(gap, (char_u *)"null"); break;
+		case VVAL_NULL: ga_concat_len(gap, (char_u *)"null", 4); break;
 	    }
 	    break;
 
 	case VAR_NUMBER:
-	    vim_snprintf((char *)numbuf, NUMBUFLEN, "%lld",
-					      (varnumber_T)val->vval.v_number);
-	    ga_concat(gap, numbuf);
+	    {
+		size_t  numbuflen;
+
+		numbuflen = vim_snprintf_safelen((char *)numbuf, sizeof(numbuf),
+		    "%lld", (varnumber_T)val->vval.v_number);
+		ga_concat_len(gap, numbuf, numbuflen);
+	    }
 	    break;
 
 	case VAR_STRING:
@@ -318,17 +329,19 @@ json_encode_item(garray_T *gap, typval_T *val, int copyID, int options)
 	case VAR_BLOB:
 	    b = val->vval.v_blob;
 	    if (b == NULL || b->bv_ga.ga_len == 0)
-		ga_concat(gap, (char_u *)"[]");
+		ga_concat_len(gap, (char_u *)"[]", 2);
 	    else
 	    {
 		ga_append(gap, '[');
 		for (i = 0; i < b->bv_ga.ga_len; i++)
 		{
+		    size_t  numbuflen;
+
 		    if (i > 0)
-			ga_concat(gap, (char_u *)",");
-		    vim_snprintf((char *)numbuf, NUMBUFLEN, "%d",
-			    blob_get(b, i));
-		    ga_concat(gap, numbuf);
+			ga_concat_len(gap, (char_u *)",", 1);
+		    numbuflen = vim_snprintf_safelen((char *)numbuf, sizeof(numbuf),
+			"%d", blob_get(b, i));
+		    ga_concat_len(gap, numbuf, numbuflen);
 		}
 		ga_append(gap, ']');
 	    }
@@ -337,11 +350,11 @@ json_encode_item(garray_T *gap, typval_T *val, int copyID, int options)
 	case VAR_LIST:
 	    l = val->vval.v_list;
 	    if (l == NULL)
-		ga_concat(gap, (char_u *)"[]");
+		ga_concat_len(gap, (char_u *)"[]", 2);
 	    else
 	    {
 		if (l->lv_copyID == copyID)
-		    ga_concat(gap, (char_u *)"[]");
+		    ga_concat_len(gap, (char_u *)"[]", 2);
 		else
 		{
 		    listitem_T	*li;
@@ -373,11 +386,11 @@ json_encode_item(garray_T *gap, typval_T *val, int copyID, int options)
 	case VAR_TUPLE:
 	    tuple = val->vval.v_tuple;
 	    if (tuple == NULL)
-		ga_concat(gap, (char_u *)"[]");
+		ga_concat_len(gap, (char_u *)"[]", 2);
 	    else
 	    {
 		if (tuple->tv_copyID == copyID)
-		    ga_concat(gap, (char_u *)"[]");
+		    ga_concat_len(gap, (char_u *)"[]", 2);
 		else
 		{
 		    int		len = TUPLE_LEN(tuple);
@@ -409,11 +422,11 @@ json_encode_item(garray_T *gap, typval_T *val, int copyID, int options)
 	case VAR_DICT:
 	    d = val->vval.v_dict;
 	    if (d == NULL)
-		ga_concat(gap, (char_u *)"{}");
+		ga_concat_len(gap, (char_u *)"{}", 2);
 	    else
 	    {
 		if (d->dv_copyID == copyID)
-		    ga_concat(gap, (char_u *)"{}");
+		    ga_concat_len(gap, (char_u *)"{}", 2);
 		else
 		{
 		    int		first = TRUE;
@@ -451,20 +464,22 @@ json_encode_item(garray_T *gap, typval_T *val, int copyID, int options)
 	case VAR_FLOAT:
 #if defined(HAVE_MATH_H)
 	    if (isnan(val->vval.v_float))
-		ga_concat(gap, (char_u *)"NaN");
+		ga_concat_len(gap, (char_u *)"NaN", 3);
 	    else if (isinf(val->vval.v_float))
 	    {
 		if (val->vval.v_float < 0.0)
-		    ga_concat(gap, (char_u *)"-Infinity");
+		    ga_concat_len(gap, (char_u *)"-Infinity", 9);
 		else
-		    ga_concat(gap, (char_u *)"Infinity");
+		    ga_concat_len(gap, (char_u *)"Infinity", 8);
 	    }
 	    else
 #endif
 	    {
-		vim_snprintf((char *)numbuf, NUMBUFLEN, "%g",
-							   val->vval.v_float);
-		ga_concat(gap, numbuf);
+		size_t	numbuflen;
+
+		numbuflen = vim_snprintf_safelen((char *)numbuf, sizeof(numbuf),
+		    "%g", val->vval.v_float);
+		ga_concat_len(gap, numbuf, numbuflen);
 	    }
 	    break;
 	case VAR_UNKNOWN:
@@ -612,9 +627,11 @@ json_decode_string(js_read_T *reader, typval_T *res, int quote)
 		    if (res != NULL)
 		    {
 			char_u	buf[NUMBUFLEN];
+			size_t	buflen;
 
-			buf[utf_char2bytes((int)nr, buf)] = NUL;
-			ga_concat(&ga, buf);
+			buflen = utf_char2bytes((int)nr, buf);
+			buf[buflen] = NUL;
+			ga_concat_len(&ga, buf, buflen);
 		    }
 		    break;
 		default:

--- a/src/json.c
+++ b/src/json.c
@@ -146,7 +146,7 @@ write_string(garray_T *gap, char_u *str)
 
     if (res == NULL)
     {
-	ga_concat_len(gap, (char_u *)"\"\"", 2);
+	GA_CONCAT_LITERAL(gap, "\"\"");
 	return;
     }
 
@@ -283,8 +283,8 @@ json_encode_item(garray_T *gap, typval_T *val, int copyID, int options)
 	case VAR_BOOL:
 	    switch ((long)val->vval.v_number)
 	    {
-		case VVAL_FALSE: ga_concat_len(gap, (char_u *)"false", 5); break;
-		case VVAL_TRUE: ga_concat_len(gap, (char_u *)"true", 4); break;
+		case VVAL_FALSE: GA_CONCAT_LITERAL(gap, "false"); break;
+		case VVAL_TRUE: GA_CONCAT_LITERAL(gap, "true"); break;
 	    }
 	    break;
 
@@ -296,7 +296,7 @@ json_encode_item(garray_T *gap, typval_T *val, int copyID, int options)
 				    // empty item
 				    break;
 				// FALLTHROUGH
-		case VVAL_NULL: ga_concat_len(gap, (char_u *)"null", 4); break;
+		case VVAL_NULL: GA_CONCAT_LITERAL(gap, "null"); break;
 	    }
 	    break;
 
@@ -329,7 +329,7 @@ json_encode_item(garray_T *gap, typval_T *val, int copyID, int options)
 	case VAR_BLOB:
 	    b = val->vval.v_blob;
 	    if (b == NULL || b->bv_ga.ga_len == 0)
-		ga_concat_len(gap, (char_u *)"[]", 2);
+		GA_CONCAT_LITERAL(gap, "[]");
 	    else
 	    {
 		ga_append(gap, '[');
@@ -338,7 +338,7 @@ json_encode_item(garray_T *gap, typval_T *val, int copyID, int options)
 		    size_t  numbuflen;
 
 		    if (i > 0)
-			ga_concat_len(gap, (char_u *)",", 1);
+			GA_CONCAT_LITERAL(gap, ",");
 		    numbuflen = vim_snprintf_safelen((char *)numbuf, sizeof(numbuf),
 			"%d", blob_get(b, i));
 		    ga_concat_len(gap, numbuf, numbuflen);
@@ -350,11 +350,11 @@ json_encode_item(garray_T *gap, typval_T *val, int copyID, int options)
 	case VAR_LIST:
 	    l = val->vval.v_list;
 	    if (l == NULL)
-		ga_concat_len(gap, (char_u *)"[]", 2);
+		GA_CONCAT_LITERAL(gap, "[]");
 	    else
 	    {
 		if (l->lv_copyID == copyID)
-		    ga_concat_len(gap, (char_u *)"[]", 2);
+		    GA_CONCAT_LITERAL(gap, "[]");
 		else
 		{
 		    listitem_T	*li;
@@ -386,11 +386,11 @@ json_encode_item(garray_T *gap, typval_T *val, int copyID, int options)
 	case VAR_TUPLE:
 	    tuple = val->vval.v_tuple;
 	    if (tuple == NULL)
-		ga_concat_len(gap, (char_u *)"[]", 2);
+		GA_CONCAT_LITERAL(gap, "[]");
 	    else
 	    {
 		if (tuple->tv_copyID == copyID)
-		    ga_concat_len(gap, (char_u *)"[]", 2);
+		    GA_CONCAT_LITERAL(gap, "[]");
 		else
 		{
 		    int		len = TUPLE_LEN(tuple);
@@ -422,11 +422,11 @@ json_encode_item(garray_T *gap, typval_T *val, int copyID, int options)
 	case VAR_DICT:
 	    d = val->vval.v_dict;
 	    if (d == NULL)
-		ga_concat_len(gap, (char_u *)"{}", 2);
+		GA_CONCAT_LITERAL(gap, "{}");
 	    else
 	    {
 		if (d->dv_copyID == copyID)
-		    ga_concat_len(gap, (char_u *)"{}", 2);
+		    GA_CONCAT_LITERAL(gap, "{}");
 		else
 		{
 		    int		first = TRUE;
@@ -464,13 +464,13 @@ json_encode_item(garray_T *gap, typval_T *val, int copyID, int options)
 	case VAR_FLOAT:
 #if defined(HAVE_MATH_H)
 	    if (isnan(val->vval.v_float))
-		ga_concat_len(gap, (char_u *)"NaN", 3);
+		GA_CONCAT_LITERAL(gap, "NaN");
 	    else if (isinf(val->vval.v_float))
 	    {
 		if (val->vval.v_float < 0.0)
-		    ga_concat_len(gap, (char_u *)"-Infinity", 9);
+		    GA_CONCAT_LITERAL(gap, "-Infinity");
 		else
-		    ga_concat_len(gap, (char_u *)"Infinity", 8);
+		    GA_CONCAT_LITERAL(gap, "Infinity");
 	    }
 	    else
 #endif

--- a/src/macros.h
+++ b/src/macros.h
@@ -424,6 +424,7 @@
 #define GA_GROW_FAILS(gap, n) unlikely((((gap)->ga_maxlen - (gap)->ga_len < (n)) ? ga_grow_inner((gap), (n)) : OK) == FAIL)
 // Inlined version of ga_grow() with optimized condition that it succeeds.
 #define GA_GROW_OK(gap, n) likely((((gap)->ga_maxlen - (gap)->ga_len < (n)) ? ga_grow_inner((gap), (n)) : OK) == OK)
+#define GA_CONCAT_LITERAL(gap, s) (ga_concat_len((gap), (char_u *)(s), STRLEN_LITERAL(s)))
 
 #ifndef MIN
 # define MIN(a, b) ((a) < (b) ? (a) : (b))

--- a/src/macros.h
+++ b/src/macros.h
@@ -424,7 +424,7 @@
 #define GA_GROW_FAILS(gap, n) unlikely((((gap)->ga_maxlen - (gap)->ga_len < (n)) ? ga_grow_inner((gap), (n)) : OK) == FAIL)
 // Inlined version of ga_grow() with optimized condition that it succeeds.
 #define GA_GROW_OK(gap, n) likely((((gap)->ga_maxlen - (gap)->ga_len < (n)) ? ga_grow_inner((gap), (n)) : OK) == OK)
-#define GA_CONCAT_LITERAL(gap, s) (ga_concat_len((gap), (char_u *)(s), STRLEN_LITERAL(s)))
+#define GA_CONCAT_LITERAL(gap, s) ga_concat_len((gap), (char_u *)(s), STRLEN_LITERAL(s))
 
 #ifndef MIN
 # define MIN(a, b) ((a) < (b) ? (a) : (b))

--- a/src/testing.c
+++ b/src/testing.c
@@ -28,7 +28,7 @@ prepare_assert_error(garray_T *gap)
     {
 	ga_concat(gap, sname);
 	if (SOURCING_LNUM > 0)
-	    ga_concat_len(gap, (char_u *)" ", 1);
+	    GA_CONCAT_LITERAL(gap, " ");
     }
     if (SOURCING_LNUM > 0)
     {
@@ -39,7 +39,7 @@ prepare_assert_error(garray_T *gap)
 	ga_concat_len(gap, (char_u *)buf, buflen);
     }
     if (sname != NULL || SOURCING_LNUM > 0)
-	ga_concat_len(gap, (char_u *)": ", 2);
+	GA_CONCAT_LITERAL(gap, ": ");
     vim_free(sname);
 }
 
@@ -62,13 +62,13 @@ ga_concat_esc(garray_T *gap, char_u *p, int clen)
 
     switch (*p)
     {
-	case BS: ga_concat_len(gap, (char_u *)"\\b", 2); break;
-	case ESC: ga_concat_len(gap, (char_u *)"\\e", 2); break;
-	case FF: ga_concat_len(gap, (char_u *)"\\f", 2); break;
-	case NL: ga_concat_len(gap, (char_u *)"\\n", 2); break;
-	case TAB: ga_concat_len(gap, (char_u *)"\\t", 2); break;
-	case CAR: ga_concat_len(gap, (char_u *)"\\r", 2); break;
-	case '\\': ga_concat_len(gap, (char_u *)"\\\\", 2); break;
+	case BS: GA_CONCAT_LITERAL(gap, "\\b"); break;
+	case ESC: GA_CONCAT_LITERAL(gap, "\\e"); break;
+	case FF: GA_CONCAT_LITERAL(gap, "\\f"); break;
+	case NL: GA_CONCAT_LITERAL(gap, "\\n"); break;
+	case TAB: GA_CONCAT_LITERAL(gap, "\\t"); break;
+	case CAR: GA_CONCAT_LITERAL(gap, "\\r"); break;
+	case '\\': GA_CONCAT_LITERAL(gap, "\\\\"); break;
 	default:
 	   if (*p < ' ' || *p == 0x7f)
 	   {
@@ -101,7 +101,7 @@ ga_concat_shorten_esc(garray_T *gap, char_u *str)
 
     if (str == NULL)
     {
-	ga_concat_len(gap, (char_u *)"NULL", 4);
+	GA_CONCAT_LITERAL(gap, "NULL");
 	return;
     }
 
@@ -118,13 +118,13 @@ ga_concat_shorten_esc(garray_T *gap, char_u *str)
 	}
 	if (same_len > 20)
 	{
-	    ga_concat_len(gap, (char_u *)"\\[", 2);
+	    GA_CONCAT_LITERAL(gap, "\\[");
 	    ga_concat_esc(gap, p, clen);
-	    ga_concat_len(gap, (char_u *)" occurs ", 8);
+	    GA_CONCAT_LITERAL(gap, " occurs ");
 	    buflen = vim_snprintf_safelen((char *)buf, sizeof(buf),
 		"%d", same_len);
 	    ga_concat_len(gap, buf, buflen);
-	    ga_concat_len(gap, (char_u *)" times]", 7);
+	    GA_CONCAT_LITERAL(gap, " times]");
 	    p = s;
 	}
 	else
@@ -161,15 +161,15 @@ fill_assert_error(
     {
 	ga_concat(gap, echo_string(opt_msg_tv, &tofree, numbuf, 0));
 	vim_free(tofree);
-	ga_concat_len(gap, (char_u *)": ", 2);
+	GA_CONCAT_LITERAL(gap, ": ");
     }
 
     if (atype == ASSERT_MATCH || atype == ASSERT_NOTMATCH)
-	ga_concat_len(gap, (char_u *)"Pattern ", 8);
+	GA_CONCAT_LITERAL(gap, "Pattern ");
     else if (atype == ASSERT_NOTEQUAL)
-	ga_concat_len(gap, (char_u *)"Expected not equal to ", 22);
+	GA_CONCAT_LITERAL(gap, "Expected not equal to ");
     else
-	ga_concat_len(gap, (char_u *)"Expected ", 9);
+	GA_CONCAT_LITERAL(gap, "Expected ");
     if (exp_str == NULL)
     {
 	// When comparing dictionaries, drop the items that are equal, so that
@@ -234,19 +234,19 @@ fill_assert_error(
     else
     {
 	if (atype == ASSERT_FAILS)
-	    ga_concat_len(gap, (char_u *)"'", 1);
+	    GA_CONCAT_LITERAL(gap, "'");
 	ga_concat_shorten_esc(gap, exp_str);
 	if (atype == ASSERT_FAILS)
-	    ga_concat_len(gap, (char_u *)"'", 1);
+	    GA_CONCAT_LITERAL(gap, "'");
     }
     if (atype != ASSERT_NOTEQUAL)
     {
 	if (atype == ASSERT_MATCH)
-	    ga_concat_len(gap, (char_u *)" does not match ", 16);
+	    GA_CONCAT_LITERAL(gap, " does not match ");
 	else if (atype == ASSERT_NOTMATCH)
-	    ga_concat_len(gap, (char_u *)" does match ", 12);
+	    GA_CONCAT_LITERAL(gap, " does match ");
 	else
-	    ga_concat_len(gap, (char_u *)" but got ", 9);
+	    GA_CONCAT_LITERAL(gap, " but got ");
 	ga_concat_shorten_esc(gap, tv2string(got_tv, &tofree, numbuf, 0));
 	vim_free(tofree);
 
@@ -376,9 +376,9 @@ assert_beeps(typval_T *argvars, int no_beep)
     {
 	prepare_assert_error(&ga);
 	if (no_beep)
-	    ga_concat_len(&ga, (char_u *)"command did beep: ", 18);
+	    GA_CONCAT_LITERAL(&ga, "command did beep: ");
 	else
-	    ga_concat_len(&ga, (char_u *)"command did not beep: ", 22);
+	    GA_CONCAT_LITERAL(&ga, "command did not beep: ");
 	ga_concat(&ga, cmd);
 	assert_error(&ga);
 	ga_clear(&ga);
@@ -523,21 +523,21 @@ assert_equalfile(typval_T *argvars)
 
 	    ga_concat(&ga, echo_string(&argvars[2], &tofree, numbuf, 0));
 	    vim_free(tofree);
-	    ga_concat_len(&ga, (char_u *)": ", 2);
+	    GA_CONCAT_LITERAL(&ga, ": ");
 	}
 	ga_concat_len(&ga, IObuff, IObufflen);
 	if (lineidx > 0)
 	{
 	    line1[lineidx] = NUL;
 	    line2[lineidx] = NUL;
-	    ga_concat_len(&ga, (char_u *)" after \"", 8);
+	    GA_CONCAT_LITERAL(&ga, " after \"");
 	    ga_concat_len(&ga, (char_u *)line1, lineidx);
 	    if (STRCMP(line1, line2) != 0)
 	    {
-		ga_concat_len(&ga, (char_u *)"\" vs \"", 6);
+		GA_CONCAT_LITERAL(&ga, "\" vs \"");
 		ga_concat_len(&ga, (char_u *)line2, lineidx);
 	    }
-	    ga_concat_len(&ga, (char_u *)"\"", 1);
+	    GA_CONCAT_LITERAL(&ga, "\"");
 	}
 	assert_error(&ga);
 	ga_clear(&ga);
@@ -589,7 +589,7 @@ f_assert_exception(typval_T *argvars, typval_T *rettv)
     if (*get_vim_var_str(VV_EXCEPTION) == NUL)
     {
 	prepare_assert_error(&ga);
-	ga_concat_len(&ga, (char_u *)"v:exception is not set", 22);
+	GA_CONCAT_LITERAL(&ga, "v:exception is not set");
 	assert_error(&ga);
 	ga_clear(&ga);
 	rettv->vval.v_number = 1;
@@ -643,7 +643,7 @@ f_assert_fails(typval_T *argvars, typval_T *rettv)
     if (called_emsg == called_emsg_before)
     {
 	prepare_assert_error(&ga);
-	ga_concat_len(&ga, (char_u *)"command did not fail: ", 22);
+	GA_CONCAT_LITERAL(&ga, "command did not fail: ");
 	assert_append_cmd_or_arg(&ga, argvars, cmd);
 	assert_error(&ga);
 	ga_clear(&ga);
@@ -762,7 +762,7 @@ f_assert_fails(typval_T *argvars, typval_T *rettv)
 	    }
 	    fill_assert_error(&ga, &argvars[2], expected_str,
 			&argvars[error_found_index], &actual_tv, ASSERT_FAILS);
-	    ga_concat_len(&ga, (char_u *)": ", 2);
+	    GA_CONCAT_LITERAL(&ga, ": ");
 	    assert_append_cmd_or_arg(&ga, argvars, cmd);
 	    assert_error(&ga);
 	    ga_clear(&ga);

--- a/src/testing.c
+++ b/src/testing.c
@@ -21,7 +21,6 @@
     static void
 prepare_assert_error(garray_T *gap)
 {
-    char    buf[NUMBUFLEN];
     char_u  *sname = estack_sfile(ESTACK_NONE);
 
     ga_init2(gap, 1, 100);
@@ -29,15 +28,18 @@ prepare_assert_error(garray_T *gap)
     {
 	ga_concat(gap, sname);
 	if (SOURCING_LNUM > 0)
-	    ga_concat(gap, (char_u *)" ");
+	    ga_concat_len(gap, (char_u *)" ", 1);
     }
     if (SOURCING_LNUM > 0)
     {
-	sprintf(buf, "line %ld", (long)SOURCING_LNUM);
-	ga_concat(gap, (char_u *)buf);
+	char    buf[NUMBUFLEN];
+	size_t	buflen;
+
+	buflen = vim_snprintf_safelen(buf, sizeof(buf), "line %ld", (long)SOURCING_LNUM);
+	ga_concat_len(gap, (char_u *)buf, buflen);
     }
     if (sname != NULL || SOURCING_LNUM > 0)
-	ga_concat(gap, (char_u *)": ");
+	ga_concat_len(gap, (char_u *)": ", 2);
     vim_free(sname);
 }
 
@@ -54,28 +56,31 @@ ga_concat_esc(garray_T *gap, char_u *p, int clen)
     {
 	mch_memmove(buf, p, clen);
 	buf[clen] = NUL;
-	ga_concat(gap, buf);
+	ga_concat_len(gap, buf, clen);
 	return;
     }
 
     switch (*p)
     {
-	case BS: ga_concat(gap, (char_u *)"\\b"); break;
-	case ESC: ga_concat(gap, (char_u *)"\\e"); break;
-	case FF: ga_concat(gap, (char_u *)"\\f"); break;
-	case NL: ga_concat(gap, (char_u *)"\\n"); break;
-	case TAB: ga_concat(gap, (char_u *)"\\t"); break;
-	case CAR: ga_concat(gap, (char_u *)"\\r"); break;
-	case '\\': ga_concat(gap, (char_u *)"\\\\"); break;
+	case BS: ga_concat_len(gap, (char_u *)"\\b", 2); break;
+	case ESC: ga_concat_len(gap, (char_u *)"\\e", 2); break;
+	case FF: ga_concat_len(gap, (char_u *)"\\f", 2); break;
+	case NL: ga_concat_len(gap, (char_u *)"\\n", 2); break;
+	case TAB: ga_concat_len(gap, (char_u *)"\\t", 2); break;
+	case CAR: ga_concat_len(gap, (char_u *)"\\r", 2); break;
+	case '\\': ga_concat_len(gap, (char_u *)"\\\\", 2); break;
 	default:
-		   if (*p < ' ' || *p == 0x7f)
-		   {
-		       vim_snprintf((char *)buf, NUMBUFLEN, "\\x%02x", *p);
-		       ga_concat(gap, buf);
-		   }
-		   else
-		       ga_append(gap, *p);
-		   break;
+	   if (*p < ' ' || *p == 0x7f)
+	   {
+		size_t	buflen;
+
+		buflen = vim_snprintf_safelen((char *)buf, sizeof(buf),
+		    "\\x%02x", *p);
+		ga_concat_len(gap, buf, buflen);
+	   }
+	   else
+	       ga_append(gap, *p);
+	   break;
     }
 }
 
@@ -91,11 +96,12 @@ ga_concat_shorten_esc(garray_T *gap, char_u *str)
     int	    c;
     int	    clen;
     char_u  buf[NUMBUFLEN];
+    size_t  buflen;
     int	    same_len;
 
     if (str == NULL)
     {
-	ga_concat(gap, (char_u *)"NULL");
+	ga_concat_len(gap, (char_u *)"NULL", 4);
 	return;
     }
 
@@ -112,12 +118,13 @@ ga_concat_shorten_esc(garray_T *gap, char_u *str)
 	}
 	if (same_len > 20)
 	{
-	    ga_concat(gap, (char_u *)"\\[");
+	    ga_concat_len(gap, (char_u *)"\\[", 2);
 	    ga_concat_esc(gap, p, clen);
-	    ga_concat(gap, (char_u *)" occurs ");
-	    vim_snprintf((char *)buf, NUMBUFLEN, "%d", same_len);
-	    ga_concat(gap, buf);
-	    ga_concat(gap, (char_u *)" times]");
+	    ga_concat_len(gap, (char_u *)" occurs ", 8);
+	    buflen = vim_snprintf_safelen((char *)buf, sizeof(buf),
+		"%d", same_len);
+	    ga_concat_len(gap, buf, buflen);
+	    ga_concat_len(gap, (char_u *)" times]", 7);
 	    p = s;
 	}
 	else
@@ -154,15 +161,15 @@ fill_assert_error(
     {
 	ga_concat(gap, echo_string(opt_msg_tv, &tofree, numbuf, 0));
 	vim_free(tofree);
-	ga_concat(gap, (char_u *)": ");
+	ga_concat_len(gap, (char_u *)": ", 2);
     }
 
     if (atype == ASSERT_MATCH || atype == ASSERT_NOTMATCH)
-	ga_concat(gap, (char_u *)"Pattern ");
+	ga_concat_len(gap, (char_u *)"Pattern ", 8);
     else if (atype == ASSERT_NOTEQUAL)
-	ga_concat(gap, (char_u *)"Expected not equal to ");
+	ga_concat_len(gap, (char_u *)"Expected not equal to ", 22);
     else
-	ga_concat(gap, (char_u *)"Expected ");
+	ga_concat_len(gap, (char_u *)"Expected ", 9);
     if (exp_str == NULL)
     {
 	// When comparing dictionaries, drop the items that are equal, so that
@@ -227,29 +234,30 @@ fill_assert_error(
     else
     {
 	if (atype == ASSERT_FAILS)
-	    ga_concat(gap, (char_u *)"'");
+	    ga_concat_len(gap, (char_u *)"'", 1);
 	ga_concat_shorten_esc(gap, exp_str);
 	if (atype == ASSERT_FAILS)
-	    ga_concat(gap, (char_u *)"'");
+	    ga_concat_len(gap, (char_u *)"'", 1);
     }
     if (atype != ASSERT_NOTEQUAL)
     {
 	if (atype == ASSERT_MATCH)
-	    ga_concat(gap, (char_u *)" does not match ");
+	    ga_concat_len(gap, (char_u *)" does not match ", 16);
 	else if (atype == ASSERT_NOTMATCH)
-	    ga_concat(gap, (char_u *)" does match ");
+	    ga_concat_len(gap, (char_u *)" does match ", 12);
 	else
-	    ga_concat(gap, (char_u *)" but got ");
+	    ga_concat_len(gap, (char_u *)" but got ", 9);
 	ga_concat_shorten_esc(gap, tv2string(got_tv, &tofree, numbuf, 0));
 	vim_free(tofree);
 
 	if (omitted != 0)
 	{
-	    char buf[100];
+	    char    buf[100];
+	    size_t  buflen;
 
-	    vim_snprintf(buf, 100, " - %d equal item%s omitted",
-					     omitted, omitted == 1 ? "" : "s");
-	    ga_concat(gap, (char_u *)buf);
+	    buflen = vim_snprintf_safelen(buf, sizeof(buf),
+		" - %d equal item%s omitted", omitted, omitted == 1 ? "" : "s");
+	    ga_concat_len(gap, (char_u *)buf, buflen);
 	}
     }
 
@@ -368,9 +376,9 @@ assert_beeps(typval_T *argvars, int no_beep)
     {
 	prepare_assert_error(&ga);
 	if (no_beep)
-	    ga_concat(&ga, (char_u *)"command did beep: ");
+	    ga_concat_len(&ga, (char_u *)"command did beep: ", 18);
 	else
-	    ga_concat(&ga, (char_u *)"command did not beep: ");
+	    ga_concat_len(&ga, (char_u *)"command did not beep: ", 22);
 	ga_concat(&ga, cmd);
 	assert_error(&ga);
 	ga_clear(&ga);
@@ -427,16 +435,18 @@ assert_equalfile(typval_T *argvars)
     char	line1[200];
     char	line2[200];
     int		lineidx = 0;
+    size_t	IObufflen;
 
     if (fname1 == NULL || fname2 == NULL)
 	return 0;
 
     IObuff[0] = NUL;
+    IObufflen = 0;
     fd1 = mch_fopen((char *)fname1, READBIN);
     if (fd1 == NULL)
     {
-	vim_snprintf((char *)IObuff, IOSIZE, (char *)e_cant_read_file_str,
-								       fname1);
+	IObufflen = vim_snprintf_safelen((char *)IObuff, IOSIZE,
+	    (char *)e_cant_read_file_str, fname1);
     }
     else
     {
@@ -444,8 +454,8 @@ assert_equalfile(typval_T *argvars)
 	if (fd2 == NULL)
 	{
 	    fclose(fd1);
-	    vim_snprintf((char *)IObuff, IOSIZE, (char *)e_cant_read_file_str,
-								       fname2);
+	    IObufflen = vim_snprintf_safelen((char *)IObuff, IOSIZE,
+		(char *)e_cant_read_file_str, fname2);
 	}
 	else
 	{
@@ -460,12 +470,16 @@ assert_equalfile(typval_T *argvars)
 		if (c1 == EOF)
 		{
 		    if (c2 != EOF)
+		    {
 			STRCPY(IObuff, "first file is shorter");
+			IObufflen = 21;
+		    }
 		    break;
 		}
 		else if (c2 == EOF)
 		{
 		    STRCPY(IObuff, "second file is shorter");
+		    IObufflen = 22;
 		    break;
 		}
 		else
@@ -475,9 +489,8 @@ assert_equalfile(typval_T *argvars)
 		    ++lineidx;
 		    if (c1 != c2)
 		    {
-			vim_snprintf((char *)IObuff, IOSIZE,
-					    "difference at byte %ld, line %ld",
-							     count, linecount);
+			IObufflen = vim_snprintf_safelen((char *)IObuff, IOSIZE,
+			    "difference at byte %ld, line %ld", count, linecount);
 			break;
 		    }
 		}
@@ -499,7 +512,7 @@ assert_equalfile(typval_T *argvars)
 	}
     }
 
-    if (IObuff[0] != NUL)
+    if (IObufflen > 0)
     {
 	garray_T	ga;
 	prepare_assert_error(&ga);
@@ -510,21 +523,21 @@ assert_equalfile(typval_T *argvars)
 
 	    ga_concat(&ga, echo_string(&argvars[2], &tofree, numbuf, 0));
 	    vim_free(tofree);
-	    ga_concat(&ga, (char_u *)": ");
+	    ga_concat_len(&ga, (char_u *)": ", 2);
 	}
-	ga_concat(&ga, IObuff);
+	ga_concat_len(&ga, IObuff, IObufflen);
 	if (lineidx > 0)
 	{
 	    line1[lineidx] = NUL;
 	    line2[lineidx] = NUL;
-	    ga_concat(&ga, (char_u *)" after \"");
-	    ga_concat(&ga, (char_u *)line1);
+	    ga_concat_len(&ga, (char_u *)" after \"", 8);
+	    ga_concat_len(&ga, (char_u *)line1, lineidx);
 	    if (STRCMP(line1, line2) != 0)
 	    {
-		ga_concat(&ga, (char_u *)"\" vs \"");
-		ga_concat(&ga, (char_u *)line2);
+		ga_concat_len(&ga, (char_u *)"\" vs \"", 6);
+		ga_concat_len(&ga, (char_u *)line2, lineidx);
 	    }
-	    ga_concat(&ga, (char_u *)"\"");
+	    ga_concat_len(&ga, (char_u *)"\"", 1);
 	}
 	assert_error(&ga);
 	ga_clear(&ga);
@@ -576,7 +589,7 @@ f_assert_exception(typval_T *argvars, typval_T *rettv)
     if (*get_vim_var_str(VV_EXCEPTION) == NUL)
     {
 	prepare_assert_error(&ga);
-	ga_concat(&ga, (char_u *)"v:exception is not set");
+	ga_concat_len(&ga, (char_u *)"v:exception is not set", 22);
 	assert_error(&ga);
 	ga_clear(&ga);
 	rettv->vval.v_number = 1;
@@ -630,7 +643,7 @@ f_assert_fails(typval_T *argvars, typval_T *rettv)
     if (called_emsg == called_emsg_before)
     {
 	prepare_assert_error(&ga);
-	ga_concat(&ga, (char_u *)"command did not fail: ");
+	ga_concat_len(&ga, (char_u *)"command did not fail: ", 22);
 	assert_append_cmd_or_arg(&ga, argvars, cmd);
 	assert_error(&ga);
 	ga_clear(&ga);
@@ -749,7 +762,7 @@ f_assert_fails(typval_T *argvars, typval_T *rettv)
 	    }
 	    fill_assert_error(&ga, &argvars[2], expected_str,
 			&argvars[error_found_index], &actual_tv, ASSERT_FAILS);
-	    ga_concat(&ga, (char_u *)": ");
+	    ga_concat_len(&ga, (char_u *)": ", 2);
 	    assert_append_cmd_or_arg(&ga, argvars, cmd);
 	    assert_error(&ga);
 	    ga_clear(&ga);

--- a/src/vim.h
+++ b/src/vim.h
@@ -3092,4 +3092,6 @@ long elapsed(DWORD start_tick);
 #define CF_INTERFACE	2	// inside an interface
 #define CF_ABSTRACT_METHOD	4	// inside an abstract class
 
+#define GA_CONCAT_LITERAL(gap, s) (ga_concat_len((gap), (char_u *)(s), STRLEN_LITERAL(s)))
+
 #endif // VIM__H

--- a/src/vim.h
+++ b/src/vim.h
@@ -3092,6 +3092,4 @@ long elapsed(DWORD start_tick);
 #define CF_INTERFACE	2	// inside an interface
 #define CF_ABSTRACT_METHOD	4	// inside an abstract class
 
-#define GA_CONCAT_LITERAL(gap, s) (ga_concat_len((gap), (char_u *)(s), STRLEN_LITERAL(s)))
-
 #endif // VIM__H


### PR DESCRIPTION
This PR changes some more calls in various source files from `ga_concat()` to `ga_concat_len()` where the length is known or can be calculated.

In addition:
In `clientserver.c`, in function `build_drop_cmd()` use a `string_T` for the strings `cdp` and `wig` for use in `ga_concat_len()`.
In list.c, in function `list_join_inner()` use a `string_T` for the string `s` for use in `ga_concat_len()`. Also, change local struct `join_T` to use `string_T`.

Cheers
John