### PR TITLE
starting.txt: fix XDG runtimepath typo

### DIFF
--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -1140,7 +1140,7 @@ and `~/.vim/vimrc` file.
 When the |xdg-vimrc| is used the 'runtimepath' and 'packpath' options will be
 modified accordingly to respect the |xdg-base-dir|: >
 
-    "$XDG_CONFIG_HOME/vim,$VIMRUNTIME,/after,$XDG_CONFIG_HOME/vim/after"
+    "$XDG_CONFIG_HOME/vim,$VIM/vimfiles,$VIMRUNTIME,$VIM/vimfiles/after,$XDG_CONFIG_HOME/vim/after"
 <
 
 Avoiding trojan horses ~


### PR DESCRIPTION
Looks like a typo: there is no `/after` directory.