### PR TITLE
Fix OSC sequence handling

### DIFF
--- a/src/proto/term.pro
+++ b/src/proto/term.pro
@@ -84,6 +84,7 @@ void set_mouse_topline(win_T *wp);
 int is_mouse_topline(win_T *wp);
 int put_string_in_typebuf(int offset, int slen, char_u *string, int new_slen, char_u *buf, int bufsize, int *buflen);
 int decode_modifiers(int n);
+bool in_osc_sequence(void);
 int check_termcode(int max_offset, char_u *buf, int bufsize, int *buflen);
 void term_get_fg_color(char_u *r, char_u *g, char_u *b);
 void term_get_bg_color(char_u *r, char_u *g, char_u *b);

--- a/src/term.c
+++ b/src/term.c
@@ -5900,9 +5900,17 @@ check_for_color_response(char_u *resp, int len)
 static oscstate_T osc_state;
 
 /*
- * Handles any OSC sequence and places the result in "v:termosc". Note that the
- * OSC identifier and terminator character(s) will not be placed in the final
- * result. Returns OK on success and FAIL on failure.
+ * Return true if currently receiving an OSC response.
+ */
+bool
+in_osc_sequence(void)
+{
+    return osc_state.processing;
+}
+
+/*
+ * Handles any OSC sequence and places the result in "v:termosc". Returns OK on
+ * success and FAIL on failure.
  */
     static int
 handle_osc(char_u *tp, int len, char_u *key_name, int *slen)


### PR DESCRIPTION
Fixes #19426. I could not find a way to create a regression test for this, as this seems to somewhat be an edge case unfortunately. I believe it has to do something with `ins_typebuf()` and `was_safe` in main.c being TRUE, considering this log message:
```
  0.015400331 : SafeState: back to waiting, triggering SafeStateAgain
  0.015776467 : raw key input: "ff/ffff" <----- part of OSC sequence
  0.015784193 : SafeState: reset: ins_typebuf() <-- Possibly culprit
  0.015828314 : raw terminal output: "[?25l[52;1H[K[52;1H:call <SNR>16_NextPage()
"
  0.015957537 : raw terminal output: "[?25h[?25l[52;1H[K[52;1H:redraw
"
  0.015982502 : raw terminal output: "[139C1,1[11CAll"
  0.015994138 : raw terminal output: "[?25h[?25l[52;1H[K[52;1H:file
"
  0.016029627 : raw terminal output: ""[No Name]" [readonly] 1 line --100%--"
  0.016034533 : raw key input: "\" <--- End of OSC sequence

```
I have managed to create an environment like the one above without the safe state reset, and the issue does not appear.