### PR TITLE
runtime(c): Add special characters to cOperator

### DIFF
--- a/runtime/syntax/c.vim
+++ b/runtime/syntax/c.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:		C
 " Maintainer:		The Vim Project <https://github.com/vim/vim>
-" Last Change:		2026 Jan 13
+" Last Change:		2026 Feb 17
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Quit when a (custom) syntax file was already loaded
@@ -271,6 +271,7 @@ syn match	cCommentError	display "\*/"
 syn match	cCommentStartError display "/\*"me=e-1 contained
 syn match	cWrongComTail	display "\*/"
 
+syn match	cOperator	'[.,;?:+\-*/%&|^~<>!=]'
 syn keyword	cOperator	sizeof
 if exists("c_gnu")
   syn keyword	cType		__label__ __complex__


### PR DESCRIPTION
@brammool

This PR has a goal to highlight, of a clear way, what are identifiers, and what are operators.

Without this, snippets of code can become hard to read/understand (because all it is white), like this below:

```
Foo *foo = newFoo( &bar );
foo->value = (++(foo->origin)) & FOO_MASK;
foo->type = (~(foo->value)) / FOO_TOTAL_TYPES;
foo->info.state = foo->info.type = OS == WIN ? ENABLE : DISABLE;
foo->level %= (foo->info.state == ENABLE ? ENABLE_LEVEL : DISABLE_LEVEL);
foo->method = foo->origin.methods[ DEF_MET * (++(foo->level)) ];
```