### PR TITLE
Wrong shortened buffer name after :cd with duplicate slashes

### DIFF
--- a/src/fileio.c
+++ b/src/fileio.c
@@ -3457,7 +3457,9 @@ shorten_fname(char_u *full_path, char_u *dir_name)
 #endif
 	{
 	    if (vim_ispathsep(*p))
-		++p;
+		do
+		    ++p;
+		while (vim_ispathsep_nocolon(*p));
 #ifndef VMS   // the path separator is always part of the path
 	    else
 		p = NULL;

--- a/src/testdir/test_cd.vim
+++ b/src/testdir/test_cd.vim
@@ -409,4 +409,15 @@ func Test_cd_symlinks()
   call chdir(savedir)
 endfunc
 
+func Test_cd_shorten_bufname_with_duplicate_slashes()
+  let savedir = getcwd()
+  call mkdir('Xexistingdir', 'R')
+  new Xexistingdir//foo/bar
+  cd Xexistingdir
+  call assert_equal('foo/bar', bufname('%'))
+
+  call chdir(savedir)
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  Wrong shortened buffer name after :cd with duplicate slashes.
Solution: Skip over multiple consecutive path separators.

related: neovim/neovim#37080
