### PR TITLE
insexpand: filter non-prefix fuzzy omnifunc matches when leader is NULL

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -1520,13 +1520,29 @@ get_leader_for_startcol(compl_T *match, int cached)
 	return NULL;
     }
 
-    if (cpt_sources_array == NULL || compl_leader.string == NULL)
+    if (cpt_sources_array == NULL)
 	goto theend;
 
     int	cpt_idx = match->cp_cpt_source_idx;
-    if (cpt_idx < 0 || compl_col <= 0)
+    if (cpt_idx < 0)
 	goto theend;
     int	startcol = cpt_sources_array[cpt_idx].cs_startcol;
+
+    if (compl_leader.string == NULL)
+    {
+	// When leader is not set (e.g. 'autocomplete' first fires before
+	// compl_leader is initialised), fall back to compl_orig_text for
+	// matches starting at or after compl_col.  Matches starting before
+	// compl_col carry pre-compl_col text and must not be compared with
+	// compl_orig_text, so return &compl_leader (NULL string) to signal
+	// "pass through" (no prefix filter).
+	if (startcol < 0 || startcol >= compl_col)
+	    return &compl_orig_text;
+	return &compl_leader;  // pass through (startcol < compl_col)
+    }
+
+    if (compl_col <= 0)
+	goto theend;
 
     if (startcol >= 0 && startcol < compl_col)
     {

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -5486,10 +5486,13 @@ func Test_autocomplete_trigger()
   call assert_equal(['fooze', 'faberge'], b:matches->mapnew('v:val.word'))
 
   " Test 9: Trigger autocomplete immediately upon entering Insert mode
+  " 'faberge' is filtered out because it doesn't start with the current prefix
+  " 'foo'; non-prefix omnifunc matches are excluded from the PUM when leader
+  " is NULL (compl_orig_text is used as a fallback filter).
   call feedkeys("Sprefix->foo\<Esc>a\<F2>\<Esc>0", 'tx!')
-  call assert_equal(['foobar', 'fooze', 'faberge'], b:matches->mapnew('v:val.word'))
+  call assert_equal(['foobar', 'fooze'], b:matches->mapnew('v:val.word'))
   call feedkeys("Sprefix->fooxx\<Esc>hcw\<F2>\<Esc>0", 'tx!')
-  call assert_equal(['foobar', 'fooze', 'faberge'], b:matches->mapnew('v:val.word'))
+  call assert_equal(['foobar', 'fooze'], b:matches->mapnew('v:val.word'))
 
   bw!
   call test_override("char_avail", 0)
@@ -6194,6 +6197,47 @@ func Test_helptags_autocomplete_timeout()
   call test_override("char_avail", 0)
   set autocomplete& completeopt& complete&
   bw!
+endfunc
+
+func Test_autocomplete_preinsert_null_leader()
+  " Test that non-prefix matches from omnifunc are filtered when leader is NULL.
+  " When autocomplete first fires, compl_leader is NULL.  Previously the prefix
+  " filter was bypassed, allowing non-prefix fuzzy matches to be incorrectly
+  " shown in the PUM and preinserted.
+  func NonPrefixOmni(findstart, base)
+    if a:findstart
+      return col(".") - 1
+    endif
+    " Return "key" (doesn't start with 'y') and "yellow" (starts with 'y').
+    " Simulates what a fuzzy omnifunc returns (e.g. vimcomplete#Complete with
+    " wildoptions=fuzzy).
+    return ["key", "yellow"]
+  endfunc
+
+  call test_override("char_avail", 1)
+  new
+  set omnifunc=NonPrefixOmni complete=o
+  set completeopt=preinsert autocomplete
+
+  func GetState()
+    let g:line = getline('.')
+    let g:col = col('.')
+    let g:matches = complete_info(['matches']).matches->mapnew('v:val.word')
+  endfunc
+  inoremap <buffer> <F5> <C-R>=GetState()<CR>
+
+  " Type 'y': "key" should be filtered out (doesn't start with 'y'),
+  " "yellow" should be the only PUM entry and preinserted with cursor after 'y'.
+  call feedkeys("iy\<F5>\<C-E>\<Esc>", 'tx')
+  call assert_equal("yellow", g:line)
+  call assert_equal(2, g:col)
+  call assert_equal(['yellow'], g:matches)
+
+  bw!
+  set omnifunc& complete& completeopt& autocomplete&
+  call test_override("char_avail", 0)
+  delfunc NonPrefixOmni
+  delfunc GetState
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab nofoldenable


### PR DESCRIPTION
Fixes: #19328

When 'autocomplete' first fires, compl_leader is NULL because ins_compl_start() has not set it yet.  This caused the prefix filter in ins_compl_build_pum(), find_next_completion_match() and find_common_prefix() to be bypassed, allowing non-prefix fuzzy omnifunc matches to appear in the PUM and be preinserted.

Extend get_leader_for_startcol() to fall back to compl_orig_text when compl_leader.string is NULL: if the match's cpt source startcol is less than compl_col the match includes pre-compl_col text, so return &compl_leader (NULL string) to signal "pass through"; otherwise return &compl_orig_text so callers filter by the original text.  The compl_col <= 0 guard is kept only for the prepend-text path to avoid it interfering with the NULL-leader fallback when compl_col is zero.

With this change all callers of get_leader_for_startcol() automatically receive the correct filter string without additional helpers.

Also update Test_autocomplete_trigger Test 9 to reflect the new behavior: 'faberge' is no longer shown when completing 'foo' because it does not start with the current prefix.

Add Test_autocomplete_preinsert_null_leader() to verify that only prefix-matching candidates appear in the PUM and are preinserted.