### PR TITLE
Revert "perf(gtk-wayland): don't block input loop"

### DIFF
--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -6728,14 +6728,7 @@ gui_mch_wait_for_chars(long wtime)
 	 * situations, sort of race condition).
 	 */
 	if (!input_available())
-	{
-#ifdef GDK_WINDOWING_WAYLAND
-	    if (gui.is_wayland)
-		g_main_context_iteration(NULL, FALSE);
-	    else
-#endif
-		g_main_context_iteration(NULL, TRUE);
-	}
+	    g_main_context_iteration(NULL, TRUE);
 
 	// Got char, return immediately
 	if (input_available())


### PR DESCRIPTION
This reverts commit 55011087b7e9d987b05716b667c8fff93231acf0.

Need a bit more time to investigate this.

Bug: #19448