### PR TITLE
runtime(progress): Use setlocal for expandtab

### DIFF
--- a/runtime/syntax/progress.vim
+++ b/runtime/syntax/progress.vim
@@ -9,7 +9,7 @@
 " 			Chris Ruprecht		<chrisSPAXY@ruprecht.org>
 "			Mikhail Kuperblum	<mikhailSPAXY@whasup.com>
 "			John Florian		<jflorianSPAXY@voyager.net>
-" Last Change:		Jul 23 2024
+" Last Change:		Feb 18 2026
 
 " quit when a syntax file was already loaded
 if exists("b:current_syntax")
@@ -22,7 +22,7 @@ set cpo&vim
 setlocal iskeyword=@,48-57,_,-,!,#,$,%
 
 " The Progress editor doesn't cope with tabs very well.
-set expandtab
+setlocal expandtab
 
 syn case ignore
 


### PR DESCRIPTION
The Progress syntax file gained `set expandtab` in 4c3f536f4 (updated for version 7.0d01, 2006-04-11). The Progress language itself doesn't distinguish between tabs and spaces for indentation, so this seems like something that should be left to user preference; but the setting is accompanied by the comment "The Progress editor doesn't cope with tabs very well", so there may be reason to keep it.

However, using `set` means that any new buffers created after editing a Progress file will also have `expandtab` turned on, which is likely contrary to a user's expectations. We should use `setlocal` instead to avoid this.