### PR TITLE
matchadd() conceal may use unrelated syntax cchar

### DIFF
--- a/Filelist
+++ b/Filelist
@@ -878,6 +878,7 @@ RT_SCRIPTS =	\
 		runtime/delmenu.vim \
 		runtime/synmenu.vim \
 		runtime/makemenu.vim \
+		runtime/xdg.vim \
 		runtime/autoload/*.vim \
 		runtime/autoload/README.txt \
 		runtime/autoload/cargo/*.vim \

--- a/src/drawline.c
+++ b/src/drawline.c
@@ -3626,11 +3626,11 @@ win_line(
 		&& !(lnum_in_visual_area
 				    && vim_strchr(wp->w_p_cocu, 'v') == NULL))
 	    {
+		int syntax_conceal = (syntax_flags & HL_CONCEAL) != 0;
 		wlv.char_attr = conceal_attr;
-		if (((prev_syntax_id != syntax_seqnr
-					   && (syntax_flags & HL_CONCEAL) != 0)
+		if (((prev_syntax_id != syntax_seqnr && syntax_conceal)
 			    || has_match_conc > 1)
-			&& (syn_get_sub_char() != NUL
+			&& ((syntax_conceal && syn_get_sub_char() != NUL)
 				|| (has_match_conc && match_conc)
 				|| wp->w_p_cole == 1)
 			&& wp->w_p_cole != 3)
@@ -3639,7 +3639,7 @@ win_line(
 		    // character.
 		    if (has_match_conc && match_conc)
 			c = match_conc;
-		    else if (syn_get_sub_char() != NUL)
+		    else if (syntax_conceal && syn_get_sub_char() != NUL)
 			c = syn_get_sub_char();
 		    else if (wp->w_lcs_chars.conceal != NUL)
 			c = wp->w_lcs_chars.conceal;

--- a/src/testdir/test_matchadd_conceal.vim
+++ b/src/testdir/test_matchadd_conceal.vim
@@ -202,6 +202,29 @@ func Test_syn_and_match_conceal()
   call assert_equal(screenattr(lnum, 2), screenattr(lnum, 18))
   call assert_notequal(screenattr(lnum, 18), screenattr(lnum, 19))
 
+  5new | setlocal conceallevel=2 concealcursor=n
+  redraw!
+  call assert_equal(expect, Screenline(6 + lnum))
+
+  " Syntax conceal shouldn't interfere with matchadd() in another buffer.
+  call setline(1, 'foo bar baz')
+  call matchadd('Conceal', 'bar')
+  redraw!
+  call assert_equal('foo  baz', Screenline(1))
+  call assert_equal(expect, Screenline(6 + lnum))
+
+  " Syntax conceal shouldn't interfere with matchadd() in the same buffer.
+  syntax match MyOtherConceal /foo/ conceal cchar=!
+  redraw!
+  call assert_equal('!  baz', Screenline(1))
+  call assert_equal(expect, Screenline(6 + lnum))
+
+  syntax clear
+  redraw!
+  call assert_equal('foo  baz', Screenline(1))
+  call assert_equal(expect, Screenline(6 + lnum))
+  bwipe!
+
   "             123456789012345678
   let expect = '# ThisXis a Test'
   syntax clear MyConceal


### PR DESCRIPTION
Problem:  matchadd() conceal may use unrelated syntax cchar.
Solution: Only use syntax cchar when syntax_flags has HL_CONCEAL.
