### PR TITLE
runtime(less.sh): Fix reading from stdin.

### DIFF
--- a/runtime/macros/less.sh
+++ b/runtime/macros/less.sh
@@ -9,7 +9,8 @@ fi
 
 if [ -t 1 ]; then
   [ $# -eq 0 ] && set -- "-"
-  exec vim --cmd 'let no_plugin_maps=1' -c 'runtime! macros/less.vim' --not-a-term -- "$@"
+  [ "$*" != "-" ] && set -- -- "$@"
+  exec vim --cmd 'let no_plugin_maps=1' -c 'runtime! macros/less.vim' --not-a-term "$@"
 else  # Output is not a terminal.
   exec cat -- "$@"
 fi


### PR DESCRIPTION
Problem: less.sh can't read from stdin; it will try to read from a file named "-" instead (after 515da6ecdb).

Solution: Do not prepend "-" with "--" in the arguments list for vim.

The following were checked manually and worked as expected:
```
    echo Test | less.sh
    echo Test | less.sh -
    less.sh some_file
    less.sh --cmd some_file  # vim will try to load "--cmd" and "some_file".
    less.sh                  # script outputs "No input."
    # All of the above repeated with the output piped to 'cat'.
```

Note: before this patch `echo Test | less.sh` would appear to fail silently. (less.vim would output `Skipping non-existing file -` but vim would exit before a user could read it.)