### PR TITLE
Fix CI error caused by Filelist

### DIFF
--- a/Filelist
+++ b/Filelist
@@ -862,7 +862,8 @@ RT_ALL =	\
 		runtime/pack/dist/opt/osc52/plugin/osc52.vim \
 		runtime/pack/dist/opt/osc52/autoload/osc52.vim \
 		runtime/pack/dist/opt/osc52/doc/osc52.txt \
-		runtime/pack/dist/opt/osc52/doc/tags
+		runtime/pack/dist/opt/osc52/doc/tags \
+		runtime/xdg.vim
 
 # Runtime files for all distributions without CR/LF translation.
 RT_ALL_BIN =	\


### PR DESCRIPTION
This issue has been occurring since [patch 9.2.0019](https://github.com/vim/vim/commit/4f04efb760af4f51975091ace7605c3dbd01d0c9).

https://github.com/vim/vim/actions/runs/22171369708/job/64109800322

<img width="612" height="480" alt="image" src="https://github.com/user-attachments/assets/94bffa01-3f24-48f0-8573-d58698664a70" />
