### PR TITLE
Vim can use bool/true/false (after v9.2.0010)

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -484,7 +484,7 @@ gui_init_check(void)
 #else
 # ifdef FEAT_GUI_GTK
 #  ifdef GDK_WINDOWING_WAYLAND
-    gui.is_wayland = FALSE;
+    gui.is_wayland = false;
 #  endif
     /*
      * Note: Don't call gtk_init_check() before fork, it will be called after

--- a/src/gui.h
+++ b/src/gui.h
@@ -390,7 +390,7 @@ typedef struct Gui
 
     guint32	event_time;
 # ifdef GDK_WINDOWING_WAYLAND
-    _Bool	is_wayland;           // active gdk backend in gtk is wayland
+    bool	is_wayland;	    // active gdk backend in gtk is wayland
 # endif
 #endif	// FEAT_GUI_GTK
 

--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -4006,7 +4006,7 @@ gui_mch_init(void)
 #ifdef GDK_WINDOWING_WAYLAND
     GdkDisplay *d = gdk_display_get_default();
     if (GDK_IS_WAYLAND_DISPLAY(d))
-	gui.is_wayland = TRUE;
+	gui.is_wayland = true;
 #endif
 
     // Determine which events we will filter.


### PR DESCRIPTION
Vim can use bool since [9.1.1584](https://github.com/vim/vim/commit/5608f3dc938c258f7a8b71f52a1e70c24e3906c0).

true/false for bool.
TRUE/FALSE for int.

(CC: @dezza)