### PR TITLE
Fix Issue #19329: Remove preinserted text during register content insertion

### DIFF
--- a/src/register.c
+++ b/src/register.c
@@ -1616,6 +1616,9 @@ do_put(
 	(void)may_get_selection(regname);
 #endif
 
+    // Remove any preinserted text (issue #19329)
+    if (ins_compl_preinsert_effect())
+	ins_compl_delete();
 
     curbuf->b_op_start = curwin->w_cursor;	// default for '[ mark
     curbuf->b_op_end = curwin->w_cursor;	// default for '] mark

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -6265,4 +6265,26 @@ func Test_autocomplete_preinsert_null_leader()
   delfunc GetState
 endfunc
 
+" Issue #19329: When register contents are inserted, remove preinserted text
+func Test_ins_register_preinsert_autocomplete()
+  func TestOmni(findstart, base)
+    if a:findstart
+      return col(".") - 1
+    endif
+    return ["foo", "foobar"]
+  endfunc
+
+  call test_override("char_avail", 1)
+  new
+  set omnifunc=TestOmni complete^=o
+  set completeopt=preinsert autocomplete
+
+  call feedkeys("ifoo \<C-R>\<C-P>=\"xyz\"\<CR>\<Esc>", 'tx')
+  call assert_equal("foo xyz", getline('.'))
+  bw!
+  set omnifunc& complete& completeopt& autocomplete&
+  call test_override("char_avail", 0)
+  delfunc TestOmni
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab nofoldenable


### PR DESCRIPTION
preinsert has no meaning after contents of a register are inserted.

fixes https://github.com/vim/vim/issues/19329

