### PR TITLE
runtime(netrw): Fix reading UNC paths on windows

### DIFF
--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -3239,7 +3239,7 @@ function s:NetrwFile(fname)
         endif
 
         if !g:netrw_cygwin && has("win32")
-            if fname =~ '^\' || fname =~ '^\a:\'
+            if isabsolutepath(fname)
                 " windows, but full path given
                 let ret= fname
             else

--- a/src/testdir/test_plugin_netrw.vim
+++ b/src/testdir/test_plugin_netrw.vim
@@ -113,7 +113,6 @@ function Test_NetrwMarkFileCopy_SameDir(dir = $HOME, symlink = 0) abort
     endif
 endfunction
 
-
 " Test file copy operations via s:NetrwMarkFileMove()
 function Test_NetrwMarkFileMove(source_dir, target_dir, marked_files) abort
     " set up
@@ -126,6 +125,12 @@ function Test_NetrwMarkFileMove(source_dir, target_dir, marked_files) abort
     call s:NetrwMarkFileMove(1)
     " wipe out the test buffer
     bw
+endfunction
+
+" Test how netrw fixes paths according with settings
+" (g:netrw_keepdir, g:netrw_cygwin, tree style ...)
+function Test_NetrwFile(fname) abort
+    return s:NetrwFile(a:fname)
 endfunction
 
 " }}}
@@ -301,6 +306,30 @@ func Test_netrw_wipe_empty_buffer_fastpath()
   bw
 
   unlet! netrw_fastbrowse
+endfunction
+
+" Test UNC paths on windows
+func Test_netrw_check_UNC_paths()
+  CheckMSWindows
+
+  let test_paths = [
+  \ '\\Server2\Share\Test\Foo.txt',
+  \ '//Server2/Share/Test/Foo.txt',
+  \ '\\Server2\Share\Test\',
+  \ '//Server2/Share/Test/',
+  \ '\\wsl.localhost\Ubuntu\home\user\_vimrc',
+  \ '//wsl.localhost/Ubuntu/home/user/_vimrc',
+  \ '\\wsl.localhost\Ubuntu\home\user',
+  \ '//wsl.localhost/Ubuntu/home/user']
+
+  " The paths must be interpreted as absolute ones
+  for path in test_paths
+    call assert_equal(
+    \   path,
+    \   Test_NetrwFile(path),
+    \   $"UNC path: {path} missinterpreted")
+  endfor
+
 endfunction
 
 " ---------------------------------


### PR DESCRIPTION
The [previous fix](https://github.com/vim/vim/pull/19015) was not complete.
Now the following code is executed to retrieve the absolute path:
```c++
           if fname =~ '^\' || fname =~ '^\a:\'
                " windows, but full path given
                let ret= fname
            else
                " windows, relative path given
                let ret= netrw#fs#ComposePath(b:netrw_curdir,fname)
            endif
```
But the condition doesn't cover all posible UNC paths (like `//localhost/C$/Windows`).
It is better to rely on [isabsolutepath()](https://vimhelp.org/builtin.txt.html#isabsolutepath%28%29) that handles [UNC properly](https://github.com/vim/vim/pull/17829).