### PR TITLE
potential integer underflow in screen_line()

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -840,7 +840,7 @@ skip_opacity:
 #ifdef FEAT_GUI
 		&& !gui.in_use
 #endif
-		&& col + coloff > 0)
+		&& col + coloff > 0 && off_to > 0)
 	{
 	    if (ScreenAttrs[off_to] == ScreenAttrs[off_to - 1])
 	    {


### PR DESCRIPTION
Problem:  In screen_line(), there is a potential integer underflow when
          accessing ScreenAttrs[off_to - 1] if off_to is zero.
          (Coverity CID 1681430, after v9.2.0017)
Solution: Add a check to ensure off_to > 0 before accessing the
          previous attribute index.

related: #19272