### PR TITLE
Revert "perf(gtk-wayland): avoid early redraws; compositor does redraw"

### DIFF
--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -6624,11 +6624,6 @@ gui_mch_draw_part_cursor(int w, int h, guicolor_T color)
     void
 gui_mch_update(void)
 {
-#ifdef GDK_WINDOWING_WAYLAND
-    // avoid early redraws; compositor does redraw
-    if (gui.is_wayland)
-       return;
-#endif
     int cnt = 0;	// prevent endless loop
     while (g_main_context_pending(NULL) && !vim_is_input_buf_full()
 								&& ++cnt < 100)


### PR DESCRIPTION
Bug: #19481

This reverts commit b542ec0535632ffd5d4de87bf57247dbe816c9cd.