### PR TITLE
Pass string length to list_append_string() where it is known

### DIFF
--- a/src/clipboard.c
+++ b/src/clipboard.c
@@ -3838,7 +3838,8 @@ clip_provider_copy(char_u *reg, char_u *provider)
     }
 
     for (int i = 0; i < y_ptr->y_size; i++)
-	if (list_append_string(list, y_ptr->y_array[i].string, -1) == FAIL)
+	if (list_append_string(list, y_ptr->y_array[i].string,
+	    (int)y_ptr->y_array[i].length) == FAIL)
 	{
 	    free_callback(&callback);
 	    list_unref(list);

--- a/src/evalbuffer.c
+++ b/src/evalbuffer.c
@@ -801,19 +801,12 @@ get_buffer_lines(
 
     if (!retlist)
     {
-	string_T    s;
-
 	if (start >= 1 && start <= buf->b_ml.ml_line_count)
-	{
-	    s.string = ml_get_buf(buf, start, FALSE);
-	    s.length = ml_get_buf_len(buf, start);
-	}
+	    rettv->vval.v_string =
+		vim_strnsave(ml_get_buf(buf, start, FALSE),
+		ml_get_buf_len(buf, start));
 	else
-	{
-	    s.string = (char_u *)"";
-	    s.length = 0;
-	}
-	rettv->vval.v_string = vim_strnsave(s.string, s.length);
+	    rettv->vval.v_string = vim_strnsave((char_u *)"", 0);
     }
     else
     {

--- a/src/evalbuffer.c
+++ b/src/evalbuffer.c
@@ -785,8 +785,6 @@ get_buffer_lines(
     int		retlist,
     typval_T	*rettv)
 {
-    char_u	*p;
-
     if (retlist)
     {
 	if (rettv_list_alloc(rettv) == FAIL)
@@ -803,11 +801,19 @@ get_buffer_lines(
 
     if (!retlist)
     {
+	string_T    s;
+
 	if (start >= 1 && start <= buf->b_ml.ml_line_count)
-	    p = ml_get_buf(buf, start, FALSE);
+	{
+	    s.string = ml_get_buf(buf, start, FALSE);
+	    s.length = ml_get_buf_len(buf, start);
+	}
 	else
-	    p = (char_u *)"";
-	rettv->vval.v_string = vim_strsave(p);
+	{
+	    s.string = (char_u *)"";
+	    s.length = 0;
+	}
+	rettv->vval.v_string = vim_strnsave(s.string, s.length);
     }
     else
     {
@@ -820,14 +826,11 @@ get_buffer_lines(
 	    end = buf->b_ml.ml_line_count;
 	while (start <= end)
 	{
-	    string_T	s;
-
-	    s.string = ml_get_buf(buf, start, FALSE);
-	    s.length = ml_get_buf_len(buf, start);
-	    ++start;
-	    if (list_append_string(rettv->vval.v_list, s.string,
-		(int)s.length) == FAIL)
+	    if (list_append_string(rettv->vval.v_list,
+		ml_get_buf(buf, start, FALSE),
+		(int)ml_get_buf_len(buf, start)) == FAIL)
 		break;
+	    ++start;
 	}
     }
 }

--- a/src/evalbuffer.c
+++ b/src/evalbuffer.c
@@ -819,9 +819,16 @@ get_buffer_lines(
 	if (end > buf->b_ml.ml_line_count)
 	    end = buf->b_ml.ml_line_count;
 	while (start <= end)
-	    if (list_append_string(rettv->vval.v_list,
-				 ml_get_buf(buf, start++, FALSE), -1) == FAIL)
+	{
+	    string_T	s;
+
+	    s.string = ml_get_buf(buf, start, FALSE);
+	    s.length = ml_get_buf_len(buf, start);
+	    ++start;
+	    if (list_append_string(rettv->vval.v_list, s.string,
+		(int)s.length) == FAIL)
 		break;
+	}
     }
 }
 

--- a/src/evalbuffer.c
+++ b/src/evalbuffer.c
@@ -804,7 +804,7 @@ get_buffer_lines(
 	if (start >= 1 && start <= buf->b_ml.ml_line_count)
 	    rettv->vval.v_string =
 		vim_strnsave(ml_get_buf(buf, start, FALSE),
-		ml_get_buf_len(buf, start));
+		    ml_get_buf_len(buf, start));
 	else
 	    rettv->vval.v_string = vim_strnsave((char_u *)"", 0);
     }

--- a/src/evalwindow.c
+++ b/src/evalwindow.c
@@ -293,14 +293,16 @@ get_framelayout(frame_T *fr, list_T *l, int outer)
     {
 	if (fr->fr_win != NULL)
 	{
-	    list_append_string(fr_list, (char_u *)"leaf", -1);
+	    list_append_string(fr_list, (char_u *)"leaf", STRLEN_LITERAL("leaf"));
 	    list_append_number(fr_list, fr->fr_win->w_id);
 	}
     }
     else
     {
-	list_append_string(fr_list,
-	     fr->fr_layout == FR_ROW ?  (char_u *)"row" : (char_u *)"col", -1);
+	if (fr->fr_layout == FR_ROW)
+	    list_append_string(fr_list, (char_u *)"row", STRLEN_LITERAL("row"));
+	else
+	    list_append_string(fr_list, (char_u *)"col", STRLEN_LITERAL("col"));
 
 	win_list = list_alloc();
 	if (win_list == NULL)

--- a/src/register.c
+++ b/src/register.c
@@ -1097,7 +1097,7 @@ yank_do_autocmd(oparg_T *oap, yankreg_T *reg)
 
     // yanked text contents
     for (n = 0; n < reg->y_size; n++)
-	list_append_string(list, reg->y_array[n].string, -1);
+	list_append_string(list, reg->y_array[n].string, (int)reg->y_array[n].length);
     list->lv_lock = VAR_FIXED;
     (void)dict_add_list(v_event, "regcontents", list);
 
@@ -2793,17 +2793,17 @@ get_reg_contents(int regname, int flags)
     if (flags & GREG_LIST)
     {
 	list_T	*list = list_alloc();
-	int	error = FALSE;
 
 	if (list == NULL)
 	    return NULL;
 	for (i = 0; i < y_current->y_size; ++i)
-	    if (list_append_string(list, y_current->y_array[i].string, -1) == FAIL)
-		error = TRUE;
-	if (error)
 	{
-	    list_free(list);
-	    return NULL;
+	    if (list_append_string(list, y_current->y_array[i].string,
+		(int)y_current->y_array[i].length) == FAIL)
+	    {
+		list_free(list);
+		return NULL;
+	    }
 	}
 	return (char_u *)list;
     }

--- a/src/strings.c
+++ b/src/strings.c
@@ -1280,7 +1280,7 @@ string_from_blob(blob_T *blob, long *start_idx, string_T *ret)
     }
     else
     {
-	ret->string = vim_strnsave((char_u *)"", 0);
+	ret->string = vim_strsave((char_u *)"");
 	ret->length = 0;
     }
     *start_idx = idx;

--- a/src/strings.c
+++ b/src/strings.c
@@ -1197,22 +1197,31 @@ f_charidx(typval_T *argvars, typval_T *rettv)
 /*
  * Convert the string "str", from encoding "from" to encoding "to".
  */
-    static char_u *
-convert_string(char_u *str, char_u *from, char_u *to)
+    static int
+convert_string(string_T *str, char_u *from, char_u *to, string_T *ret)
 {
     vimconv_T	vimconv;
 
     vimconv.vc_type = CONV_NONE;
     if (convert_setup(&vimconv, from, to) == FAIL)
-	return NULL;
+	return FAIL;
     vimconv.vc_fail = TRUE;
     if (vimconv.vc_type == CONV_NONE)
-	str = vim_strsave(str);
+    {
+	ret->string = vim_strnsave(str->string, str->length);
+	if (ret->string == NULL)
+	    ret->length = 0;
+	else
+	    ret->length = str->length;
+    }
     else
-	str = string_convert(&vimconv, str, NULL);
+    {
+	ret->length = str->length;
+	ret->string = string_convert(&vimconv, str->string, (int *)&ret->length);
+    }
     convert_setup(&vimconv, NULL, NULL);
 
-    return str;
+    return (ret->string == NULL) ? FAIL : OK;
 }
 
 /*
@@ -1238,13 +1247,12 @@ blob_from_string(char_u *str, blob_T *blob)
  * allocated string is returned and "start_idx" is moved forward by one byte.
  * On return, "start_idx" points to next byte to process in blob.
  */
-    static char_u *
-string_from_blob(blob_T *blob, long *start_idx)
+    static int
+string_from_blob(blob_T *blob, long *start_idx, string_T *ret)
 {
     garray_T	str_ga;
     long	blen;
     int		idx;
-    char_u	*ret_str = NULL;
 
     ga_init2(&str_ga, sizeof(char), 80);
 
@@ -1266,13 +1274,19 @@ string_from_blob(blob_T *blob, long *start_idx)
     }
 
     if (str_ga.ga_data != NULL)
-	ret_str = vim_strnsave(str_ga.ga_data, str_ga.ga_len);
+    {
+	ret->string = vim_strnsave(str_ga.ga_data, str_ga.ga_len);
+	ret->length = str_ga.ga_len;
+    }
     else
-	ret_str = vim_strsave((char_u *)"");
+    {
+	ret->string = vim_strnsave((char_u *)"", 0);
+	ret->length = 0;
+    }
     *start_idx = idx;
 
     ga_clear(&str_ga);
-    return ret_str;
+    return (ret->string == NULL) ? FAIL : OK;
 }
 
 /*
@@ -1320,56 +1334,57 @@ normalize_encoding_name(char_u *enc_skipped)
  */
     static void
 append_converted_string_to_list(
-	char_u *converted,
+	string_T *converted,
 	int validate_utf8,
 	list_T *list,
 	char_u *from_encoding)
 {
-    if (converted != NULL)
+    if (converted->string != NULL)
     {
 	// After conversion, the output is a valid UTF-8 string (NUL-terminated)
-	int converted_len = (int)STRLEN(converted);
-
 	// Split by newlines and add to list
-	char_u *p = converted;
-	char_u *end = converted + converted_len;
+	char_u *p = converted->string;
+	char_u *end = converted->string + converted->length;
 	while (p < end)
 	{
-	    char_u *line_start = p;
+	    string_T	line;
+	    char_u	*line_start = p;
+
 	    while (p < end && *p != NL)
 		p++;
 
 	    // Add this line to the result list
-	    char_u *line = vim_strnsave(line_start, p - line_start);
-	    if (line != NULL)
+	    line.length = (size_t)(p - line_start);
+	    line.string = vim_strnsave(line_start, line.length);
+	    if (line.string != NULL)
 	    {
-		if (validate_utf8 && !utf_valid_string(line, NULL))
+		if (validate_utf8 && !utf_valid_string(line.string, NULL))
 		{
-		    vim_free(line);
+		    vim_free(line.string);
 		    semsg(_(e_str_encoding_from_failed), p_enc);
-		    vim_free(converted);
+		    vim_free(converted->string);
 		    return; // Stop processing
 		}
-		if (list_append_string(list, line, -1) == FAIL)
+		if (list_append_string(list, line.string, (int)line.length) == FAIL)
 		{
-		    vim_free(line);
-		    vim_free(converted);
+		    vim_free(line.string);
+		    vim_free(converted->string);
 		    return; // Stop processing on append failure
 		}
-		vim_free(line);
+		vim_free(line.string);
 	    }
 	    else
 	    {
 		// Allocation failure: report error and stop processing
 		emsg(_(e_out_of_memory));
-		vim_free(converted);
+		vim_free(converted->string);
 		return;
 	    }
 
 	    if (*p == NL)
 		p++;
 	}
-	vim_free(converted);
+	vim_free(converted->string);
     }
     else
     {
@@ -1378,17 +1393,17 @@ append_converted_string_to_list(
 }
 
     static int
-append_validated_line_to_list(char_u *line, int validate_utf8, list_T *list)
+append_validated_line_to_list(string_T *line, int validate_utf8, list_T *list)
 {
-    if (validate_utf8 && !utf_valid_string(line, NULL))
+    if (validate_utf8 && !utf_valid_string(line->string, NULL))
     {
 	semsg(_(e_str_encoding_from_failed), p_enc);
-	vim_free(line);
+	vim_free(line->string);
 	return FAIL;
     }
 
-    int ret = list_append_string(list, line, -1);
-    vim_free(line);
+    int ret = list_append_string(list, line->string, (int)line->length);
+    vim_free(line->string);
     return ret;
 }
 
@@ -1477,12 +1492,16 @@ f_blob2str(typval_T *argvars, typval_T *rettv)
 	    goto done;
 	}
 	vimconv.vc_fail = TRUE;
+
 	// Use string_convert_ext with explicit input length
-	int inlen = blen;
-	char_u *converted = string_convert_ext(&vimconv, (char_u *)blob_ga.ga_data, &inlen, NULL);
+	string_T    converted;
+
+	converted.length = blen;
+	converted.string =
+	    string_convert_ext(&vimconv, (char_u *)blob_ga.ga_data, (int *)&converted.length, NULL);
 	convert_setup(&vimconv, NULL, NULL);
 	ga_clear(&blob_ga);
-	append_converted_string_to_list(converted, validate_utf8, rettv->vval.v_list, from_encoding);
+	append_converted_string_to_list(&converted, validate_utf8, rettv->vval.v_list, from_encoding);
     }
     else
     {
@@ -1490,27 +1509,29 @@ f_blob2str(typval_T *argvars, typval_T *rettv)
 	idx = 0;
 	while (idx < blen)
 	{
-	    char_u	*str;
+	    string_T	str;
 
-	    str = string_from_blob(blob, &idx);
-	    if (str == NULL)
+	    if (string_from_blob(blob, &idx, &str) != OK)
 		break;
 
 	    if (from_encoding != NULL)
 	    {
 		// from_encoding_raw is guaranteed non-NULL whenever from_encoding != NULL
-		char_u *converted = convert_string(str, from_encoding_raw, p_enc);
-		vim_free(str);
-		str = converted;
+		int	    res;
+		string_T    converted;
+
+		res = convert_string(&str, from_encoding_raw, p_enc, &converted);
+		vim_free(str.string);
+		if (res != OK)
+		{
+		    semsg(_(e_str_encoding_from_failed), from_encoding);
+		    goto done;
+		}
+		str.string = converted.string;
+		str.length = converted.length;
 	    }
 
-	    if (str == NULL)
-	    {
-		semsg(_(e_str_encoding_from_failed), from_encoding);
-		goto done;
-	    }
-
-	    if (append_validated_line_to_list(str, validate_utf8, rettv->vval.v_list) == FAIL)
+	    if (append_validated_line_to_list(&str, validate_utf8, rettv->vval.v_list) == FAIL)
 		goto done;
 	}
     }
@@ -1564,29 +1585,39 @@ f_str2blob(typval_T *argvars, typval_T *rettv)
 	if (li->li_tv.v_type != VAR_STRING)
 	    continue;
 
-	char_u	*str = li->li_tv.vval.v_string;
+	string_T    str = {li->li_tv.vval.v_string, 0};
 
-	if (str == NULL)
-	    str = (char_u *)"";
+	if (str.string == NULL)
+	{
+	    str.string = (char_u *)"";
+	    str.length = 0;
+	}
+	else
+	    str.length = STRLEN(str.string);
 
 	if (to_encoding != NULL)
 	{
-	    str = convert_string(str, p_enc, to_encoding);
-	    if (str == NULL)
+	    int		res;
+	    string_T	converted;
+
+	    res = convert_string(&str, p_enc, to_encoding, &converted);
+	    if (res != OK)
 	    {
 		semsg(_(e_str_encoding_to_failed), to_encoding);
 		goto done;
 	    }
+	    str.string = converted.string;
+	    str.length = converted.length;
 	}
 
 	if (li != list->lv_first)
 	    // Each list string item is separated by a newline in the blob
 	    ga_append(&blob->bv_ga, NL);
 
-	blob_from_string(str, blob);
+	blob_from_string(str.string, blob);
 
 	if (to_encoding != NULL)
-	    vim_free(str);
+	    vim_free(str.string);
     }
 
 done:

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -6704,10 +6704,12 @@ f_term_getansicolors(typval_T *argvars, typval_T *rettv)
     state = vterm_obtain_state(term->tl_vterm);
     for (index = 0; index < 16; index++)
     {
+	size_t	hexbuflen;
+
 	vterm_state_get_palette_color(state, index, &color);
-	sprintf((char *)hexbuf, "#%02x%02x%02x",
-		color.red, color.green, color.blue);
-	if (list_append_string(list, hexbuf, 7) == FAIL)
+	hexbuflen = vim_snprintf_safelen((char *)hexbuf, sizeof(hexbuf),
+	    "#%02x%02x%02x", color.red, color.green, color.blue);
+	if (list_append_string(list, hexbuf, (int)hexbuflen) == FAIL)
 	    return;
     }
 }


### PR DESCRIPTION
This PR refactors some source files to pass string length to function `list_append_string()` where it is known or can be calculated simply.

In addition:
In `evalfunc.c`:
	refactor function `block_def2str()` to accept a `string_T` to return the resulting string and to drop local variables.
	refactor function `f_getregion()` to restructure the logic within the `for` loop and to use a `string_T` to store string `akt`.
In `register.c`:
	refactor function `get_reg_contents()` to exit the first `for` loop if the call to `list_append_string()` fails which means we can remove local variable `error`.
In `strings.c`:
	refactor function `convert_string()` to accept a `string_T` and another `string_T` to return the resulting string.
	refactor function `string_from_blob()` to accept a `string_T` to return the resulting string.
	refactor function `append_converted_string_to_list()` to accept argument `converted` as a `string_T`.
	refactor function `append_validated_line_to_list()` to accept argument `line` as a `string_T`.
<edit>
In `evalbuffer.c`:
        refactor function `get_buffer_lines()` to call `vim_strnsave()` instead of `vim_strsave()`.
</edit>

Cheers
John