### PR TITLE
fix: typename() returns wrong type for lists/dicts/tuples with shared references

### DIFF
--- a/src/testdir/test_tuple.vim
+++ b/src/testdir/test_tuple.vim
@@ -2238,6 +2238,14 @@ func Test_tuple_typename()
   END
   call v9.CheckSourceDefAndScriptSuccess(lines)
 
+  " Shared (non-circular) references must not be treated as circular.
+  " repeat() makes all elements point to the same inner tuple object.
+  let lines =<< trim END
+    call assert_equal('tuple<tuple<number, number>, tuple<number, number>, tuple<number, number>>', ((1, 2),)->repeat(3)->typename())
+    call assert_equal('list<tuple<number, number>>', [(1, 2)]->repeat(3)->typename())
+  END
+  call v9.CheckSourceLegacyAndVim9Success(lines)
+
   " When a tuple item is used in a "for" loop, the type is tuple<any>
   let lines =<< trim END
     vim9script

--- a/src/testdir/test_vim9_builtin.vim
+++ b/src/testdir/test_vim9_builtin.vim
@@ -4983,6 +4983,22 @@ def Test_typename()
   endif
   var l: list<func(list<number>): any> = [function('min')]
   assert_equal('list<func(list<number>): any>', typename(l))
+
+  # Check that circular list/dict references don't cause infinite recursion.
+  # Use legacy script where lv_type is not set so the copyID mechanism is used.
+  v9.CheckSourceLegacySuccess([
+        'let circ_l = []',
+        'call add(circ_l, circ_l)',
+        "call assert_equal('list<list<any>>', typename(circ_l))",
+        'let circ_d = {}',
+        "let circ_d['self'] = circ_d",
+        "call assert_equal('dict<dict<any>>', typename(circ_d))",
+  ])
+
+  # Shared (non-circular) references must not be treated as circular.
+  # repeat() makes all elements point to the same inner list/dict object.
+  assert_equal('list<list<string>>', [[" "]]->repeat(3)->typename())
+  assert_equal('list<dict<number>>', [{'a': 1}]->repeat(3)->typename())
 enddef
 
 def Test_undofile()

--- a/src/vim9type.c
+++ b/src/vim9type.c
@@ -612,6 +612,10 @@ list_typval2type(typval_T *tv, int copyID, garray_T *type_gap, int flags)
 	common_type(typval2type(&li->li_tv, copyID, type_gap, TVTT_DO_MEMBER),
 					member_type, &member_type, type_gap);
 
+    // Reset copyID so that a shared reference to this list (not a circular
+    // reference) can be processed again to get the correct type.
+    l->lv_copyID = 0;
+
     return get_list_type(member_type, type_gap);
 }
 
@@ -661,6 +665,9 @@ tuple_typval2type(typval_T *tv, int copyID, garray_T *type_gap, int flags)
 	if (ga_grow(&tuple_types_ga, 1) == FAIL)
 	{
 	    ga_clear(&tuple_types_ga);
+	    // Reset copyID so that a shared reference to this tuple can be
+	    // processed again.
+	    tuple->tv_copyID = 0;
 	    return NULL;
 	}
 	((type_T **)tuple_types_ga.ga_data)[tuple_types_ga.ga_len] = type;
@@ -669,6 +676,10 @@ tuple_typval2type(typval_T *tv, int copyID, garray_T *type_gap, int flags)
 
     type_T *tuple_type = get_tuple_type(&tuple_types_ga, type_gap);
     ga_clear(&tuple_types_ga);
+
+    // Reset copyID so that a shared reference to this tuple (not a circular
+    // reference) can be processed again to get the correct type.
+    tuple->tv_copyID = 0;
 
     return tuple_type;
 }
@@ -715,6 +726,10 @@ dict_typval2type(typval_T *tv, int copyID, garray_T *type_gap, int flags)
     while (dict_iterate_next(&iter, &value) != NULL)
 	common_type(typval2type(value, copyID, type_gap, TVTT_DO_MEMBER),
 					member_type, &member_type, type_gap);
+
+    // Reset copyID so that a shared reference to this dict (not a circular
+    // reference) can be processed again to get the correct type.
+    d->dv_copyID = 0;
 
     return get_dict_type(member_type, type_gap);
 }


### PR DESCRIPTION
Fixes: #19490

### Problem

`typename()` incorrectly returned list<any> for the member type when a container
held multiple references to the same inner object. For example:

```vim
echo [[" "]]->repeat(3)->typename()   " returned list<list<any>>, expected list<list<string>>
```

`repeat()` makes all elements point to the same inner list/dict/tuple object
(shallow copy via copy_tv()). During type inference, list_typval2type(),
dict_typval2type(), and tuple_typval2type() use a copyID to guard against
infinite recursion on circular references. However, they never cleared the
copyID after finishing, so when the same object was encountered again as a
sibling element (a shared reference, not a circular one), it was mistakenly
treated as a circular reference and t_list_any / t_dict_any / t_tuple_any was
returned.

### Solution

Reset lv_copyID / dv_copyID / tv_copyID to 0 after all members have been
processed in each of the three functions. The circular reference guard still
works correctly because the copyID is set before processing members and only
cleared after — so any re-entrant call on the same object during its own
traversal is still detected and short-circuits with t_*_any.