### PR TITLE
GTK: force X11 backend when Wayland support is not compiled in

### DIFF
--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -1720,6 +1720,13 @@ gui_mch_init_check(void)
     }
 #endif
 
+#if GTK_CHECK_VERSION(3,10,0) && !defined(HAVE_WAYLAND)
+    // Without Wayland display protocol support compiled in, force the X11 GDK
+    // backend to avoid display issues when running under a Wayland compositor
+    // (e.g., cmdline bottom half hidden in tiny builds, see patch 9.1.1585).
+    gdk_set_allowed_backends("x11");
+#endif
+
 #ifdef FEAT_GUI_GNOME
     if (gtk_socket_id == 0)
 	using_gnome = 1;


### PR DESCRIPTION
Fixes: #19483

Problem:
Running gvim with a tiny build under a Wayland compositor hides the bottom
half of the command line.

Solution:
When Wayland display protocol support is not compiled in (HAVE_WAYLAND not
defined), force the X11 GDK backend to avoid display issues.  This restores
the gdk_set_allowed_backends("x11") call that was removed by patch [9.1.1585](https://github.com/vim/vim/commit/48a3b146b49d508f1d592974105c690b7af62ea8).
but only for builds without Wayland support (e.g. tiny builds, see patch [9.1.1565](https://github.com/vim/vim/commit/f412241fcdf93107353d75c99adcc4c0bc900656)).