### PR TITLE
Fix: memory leak in exe_newdict

### DIFF
--- a/src/vim9execute.c
+++ b/src/vim9execute.c
@@ -290,6 +290,7 @@ exe_newdict(int count, ectx_T *ectx)
 	    if (dict_add(dict, item) == FAIL)
 	    {
 		// can this ever happen?
+		dictitem_free(item);
 		dict_unref(dict);
 		return FAIL;
 	    }


### PR DESCRIPTION
## Fix memory leak in `exe_newdict()` in `src/vim9execute.c`

## Problem

In `exe_newdict()`, a `dictitem_T *item` is allocated and later inserted into a dictionary (line **279**):

```c
item = dictitem_alloc(key);
```

If `dict_add(dict, item)` returns `FAIL`, the function returns early after calling `dict_unref(dict)` (line **290-295**):

```c
if (dict_add(dict, item) == FAIL)
{
    // can this ever happen?
    dict_unref(dict);
    return FAIL;
}
```

On this failure path, `item` has not been inserted into `dict`, so `dict_unref(dict)` does not free it. As a result, `item` is leaked.

## Solution

Free `item` before returning when `dict_add()` fails. The fix is included in this commit.