### PR TITLE
Fix memory leak in `type_name_list_or_dict()` in `src/vim9type.c`

### DIFF
--- a/src/vim9type.c
+++ b/src/vim9type.c
@@ -2573,7 +2573,10 @@ type_name_list_or_dict(char *name, type_T *type, char **tofree)
     size_t len = STRLEN(name) + STRLEN(member_name) + 3;
     *tofree = alloc(len);
     if (*tofree == NULL)
+    {
+	vim_free(member_free);
 	return name;
+    }
 
     vim_snprintf(*tofree, len, "%s<%s>", name, member_name);
     vim_free(member_free);


### PR DESCRIPTION
### Problem

In `type_name_list_or_dict()`, the function calls `type_name()` to obtain the member type name (lines **2568–2571**):

```c
if (type->tt_member->tt_type == VAR_UNKNOWN)
    member_name = type_name(&t_any, &member_free);
else
    member_name = type_name(type->tt_member, &member_free);
```

If `type_name()` allocates memory for the returned string, it stores the allocated pointer in `member_free`, which must be freed by the caller.

Later, `type_name_list_or_dict()` allocates `*tofree` (lines **2574–2576**):

```c
*tofree = alloc(len);
if (*tofree == NULL)
    return name;
```

If `alloc(len)` fails, the function returns early without freeing `member_free`, resulting in a memory leak on the out-of-memory path.

Under normal execution, `member_free` is freed before returning (lines **2579–2580**):

```c
vim_free(member_free);
return *tofree;
```

However, this cleanup is skipped when the allocation of `*tofree` fails.

### Solution

Free `member_free` before returning when `alloc(len)` fails. The fix is included in this commit.