### PR TITLE
fix: popupwin flickering and extra transparency (after v9.2.0016)

### DIFF
--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -4128,9 +4128,10 @@ may_update_popup_mask(int type)
 	height = popup_height(wp);
 	popup_update_mask(wp, width, height);
 
-	// Popup with opacitys do not block lower layers from drawing,
-	// so they don't participate in the popup_mask.
-	if (wp->w_popup_flags & POPF_OPACITY)
+	// Popup with partial transparency do not block lower layers from
+	// drawing, so they don't participate in the popup_mask.
+	// Fully opaque popups (blend == 0) still block lower layers.
+	if ((wp->w_popup_flags & POPF_OPACITY) && wp->w_popup_blend > 0)
 	    continue;
 
 	for (line = wp->w_winrow;
@@ -4343,7 +4344,8 @@ update_popups(void (*win_update)(win_T *wp))
 	screen_zindex = wp->w_zindex;
 
 	// Set popup with opacity context for screen drawing.
-	if (wp->w_popup_flags & POPF_OPACITY)
+	// Only enable transparency rendering when blend > 0 (not fully opaque).
+	if ((wp->w_popup_flags & POPF_OPACITY) && wp->w_popup_blend > 0)
 	    screen_opacity_popup = wp;
 	else
 	    screen_opacity_popup = NULL;

--- a/src/testdir/dumps/Test_popupwin_opacity_100_blocks_bg.dump
+++ b/src/testdir/dumps/Test_popupwin_opacity_100_blocks_bg.dump
@@ -1,0 +1,10 @@
+>b+0&#ffffff0|a|c|k|g|r|o|u|n|d| |t|e|x|t| |h|e|r|e| @54
+|P+0#0000001#ffd7ff255|O|P|U|P| |L|I|N|E| |1| @7| +0#0000000#ffffff0@54
+|P+0#0000001#ffd7ff255|O|P|U|P| |L|I|N|E| |2| @7| +0#0000000#ffffff0@54
+|b|a|c|k|g|r|o|u|n|d| |t|e|x|t| |h|e|r|e| @54
+|b|a|c|k|g|r|o|u|n|d| |t|e|x|t| |h|e|r|e| @54
+|b|a|c|k|g|r|o|u|n|d| |t|e|x|t| |h|e|r|e| @54
+|b|a|c|k|g|r|o|u|n|d| |t|e|x|t| |h|e|r|e| @54
+|b|a|c|k|g|r|o|u|n|d| |t|e|x|t| |h|e|r|e| @54
+|b|a|c|k|g|r|o|u|n|d| |t|e|x|t| |h|e|r|e| @54
+@57|1|,|1| @10|T|o|p| 

--- a/src/testdir/test_popupwin.vim
+++ b/src/testdir/test_popupwin.vim
@@ -4813,6 +4813,23 @@ func Test_popup_opacity_highlight()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_popup_opacity_100_blocks_background()
+  CheckScreendump
+
+  " opacity:100 (fully opaque, blend==0) popup should block background content.
+  " Before the fix, POPF_OPACITY caused the popup to be excluded from
+  " popup_mask even with blend==0, making background show through.
+  let lines =<< trim END
+    call setline(1, repeat(['background text here'], 10))
+    call popup_create(['POPUP LINE 1', 'POPUP LINE 2'],
+        \ #{line: 2, col: 1, minwidth: 20, opacity: 100})
+  END
+  call writefile(lines, 'XtestPopupOpaque100', 'D')
+  let buf = RunVimInTerminal('-S XtestPopupOpaque100', #{rows: 10})
+  call VerifyScreenDump(buf, 'Test_popupwin_opacity_100_blocks_bg', {})
+  call StopVimInTerminal(buf)
+endfunc
+
 func Test_popup_getwininfo_tabnr()
   tab split
   let winid1 = popup_create('sup', #{tabpage: 1})


### PR DESCRIPTION
Fixes: #19510
Fixes: #19499

Two bugs fixed.

- When screen_opacity_popup is set, background save, restore, and blending processes are run every frame in screen.c. With opacity 100 (fully opaque), these processes were run even though they were unnecessary, causing flickering.

- The POPF_OPACITY flag was set even when opacity was 100 (fully opaque), so registration to popup_mask was skipped, allowing the underlying buffer to show through.