### PR TITLE
Fix memory leak in `invoke_sync_listeners()` in `src/change.c`

### DIFF
--- a/src/change.c
+++ b/src/change.c
@@ -557,7 +557,10 @@ invoke_sync_listeners(
 
     dict = dict_alloc();
     if (dict == NULL)
+    {
+	list_unref(recorded_changes);
 	return;
+    }
 
     dict_add_number(dict, "lnum", (varnumber_T)start);
     dict_add_number(dict, "end", (varnumber_T)end);


### PR DESCRIPTION
### Problem

In `invoke_sync_listeners()`, a list is allocated to store change details (line **552**):

```c
recorded_changes = list_alloc();
```

Later, a dictionary is allocated. However, if `dict_alloc()` fails, the function returns early without releasing `recorded_changes`. As a result, the allocated list is leaked. (lines **558–560**):

```c
dict = dict_alloc();
if (dict == NULL)
    return;
```

Under normal execution, `recorded_changes` is released at the end of the function (line **571**):

```c
list_unref(recorded_changes);
```

However, this cleanup is skipped when `dict_alloc()` fails.

### Solution

Release `recorded_changes` before returning when `dict_alloc()` fails. The fix is included in this commit.