### PR TITLE
Fix memory leak in `build_drop_cmd()` in `src/clientserver.c`

### DIFF
--- a/src/clientserver.c
+++ b/src/clientserver.c
@@ -740,6 +740,7 @@ build_drop_cmd(
 		);
 	if (p == NULL)
 	{
+	    vim_free(cdp.string);
 	    vim_free(ga.ga_data);
 	    return NULL;
 	}


### PR DESCRIPTION
### Problem

In `build_drop_cmd()`, the escaped current directory string is allocated and stored in `cdp.string` (line **707-716**):

```c
cdp.string = vim_strsave_escaped_ext(cwd, ...);
...
if (cdp.string == NULL)
    return NULL;
```

Later, inside the loop, if `vim_strsave_escaped()` fails, the function returns early (line **734-745**):

```c
p = vim_strsave_escaped((char_u *)filev[i], ...);
if (p == NULL)
{
    vim_free(ga.ga_data);
    return NULL;
}
```

On this early-return path, `cdp.string` has not been freed yet (it is only freed near the end of the function via `vim_free(cdp.string);`). As a result, `cdp.string` is leaked when `vim_strsave_escaped()` returns `NULL`.

### Solution

Free `cdp.string` before returning on the `p == NULL` failure path. The fix is included in this commit.