### PR TITLE
Fix memory leak in `dict_extend_func()` in `src/dict.c`

### DIFF
--- a/src/dict.c
+++ b/src/dict.c
@@ -1370,7 +1370,11 @@ dict_extend_func(
 
     if (type != NULL && check_typval_arg_type(type, &argvars[1],
 							 func_name, 2) == FAIL)
+    {
+	if (is_new)
+	    dict_unref(d1);
 	return;
+    }
     dict_extend(d1, d2, action, func_name);
 
     if (is_new)


### PR DESCRIPTION
### Problem

In `dict_extend_func()`, when `is_new` is true, the function creates a copy of the first dictionary (line **1338-1343**):

```c
if (is_new)
{
    d1 = dict_copy(d1, FALSE, TRUE, get_copyID());
    if (d1 == NULL)
        return;
}
```

Later, if `type != NULL` and `check_typval_arg_type()` fails, the function returns early (line **1371-1373**):

```c
if (type != NULL && check_typval_arg_type(type, &argvars[1],
							 func_name, 2) == FAIL)
	return;
```

On this return path, the copied dictionary `d1` is not released when `is_new` is true, resulting in a memory leak.

### Solution

When `is_new` is true, `type` is not `NULL`, and `check_typval_arg_type()` fails, the copied dictionary should be released before returning. The fix is included in this commit.