### PR TITLE
Vim9: fix E933 on re-source by using ISN_UCALL for script-local def calls inside lambda

### DIFF
--- a/src/vim9instr.c
+++ b/src/vim9instr.c
@@ -1910,6 +1910,23 @@ generate_BLOBAPPEND(cctx_T *cctx)
 }
 
 /*
+ * get the instruction type for a function call: ISN_METHODCALL, ISN_DCALL, or
+ * ISN_UCALL.
+ */
+    static isntype_T
+isn_get_calltype(
+	cctx_T	    *cctx,
+	ufunc_T	    *ufunc,
+	class_T	    *cl)
+{
+    return cl != NULL ? ISN_METHODCALL
+	: (ufunc->uf_def_status != UF_NOT_COMPILED
+		&& ((cctx->ctx_ufunc->uf_flags & FC_LAMBDA) == 0
+		    || ufunc->uf_name[0] != K_SPECIAL))
+	? ISN_DCALL : ISN_UCALL;
+}
+
+/*
  * Generate an ISN_DCALL, ISN_UCALL or ISN_METHODCALL instruction.
  * When calling a method on an object, of which we know the interface only,
  * then "cl" is the interface and "mi" the method index on the interface.
@@ -1996,11 +2013,7 @@ generate_CALL(
 	return FAIL;
     }
 
-    if ((isn = generate_instr(cctx, cl != NULL ? ISN_METHODCALL
-			  : (ufunc->uf_def_status != UF_NOT_COMPILED
-			     && ((cctx->ctx_ufunc->uf_flags & FC_LAMBDA) == 0
-				 || ufunc->uf_name[0] != K_SPECIAL))
-					     ? ISN_DCALL : ISN_UCALL)) == NULL)
+    if ((isn = generate_instr(cctx, isn_get_calltype(cctx, ufunc, cl))) == NULL)
 	return FAIL;
     if (cl != NULL /* isn->isn_type == ISN_METHODCALL */)
     {

--- a/src/vim9instr.c
+++ b/src/vim9instr.c
@@ -1997,7 +1997,9 @@ generate_CALL(
     }
 
     if ((isn = generate_instr(cctx, cl != NULL ? ISN_METHODCALL
-			  : ufunc->uf_def_status != UF_NOT_COMPILED
+			  : (ufunc->uf_def_status != UF_NOT_COMPILED
+			     && ((cctx->ctx_ufunc->uf_flags & FC_LAMBDA) == 0
+				 || ufunc->uf_name[0] != K_SPECIAL))
 					     ? ISN_DCALL : ISN_UCALL)) == NULL)
 	return FAIL;
     if (cl != NULL /* isn->isn_type == ISN_METHODCALL */)


### PR DESCRIPTION
Fixes: #19509

When a Vim9 script is sourced twice, a lambda inside an autocommand that calls a
script-local def function fails with E933 "Function was deleted".

### The error sequence is:

  1. First `:source`: script-local `def F()` is compiled and gets dfunc_idx=N.
  2. The autocommand registers `timer_start(0, (_) => F())`.
  3. The lambda is compiled: `generate_CALL` picks `ISN_DCALL` because `F` is
     already compiled, and stores dfunc_idx=N in the instruction.
  4. The autocommand fires (e.g. `CmdlineLeave`) before the second `:source`.
     The timer is now pending with the compiled lambda holding ISN_DCALL/idx=N.
  5. Second `:source`: `delete_script_functions()` deletes the old `F`
     (df_deleted = TRUE) and the new `F` is compiled as dfunc_idx=N+1.
  6. The 0ms timer fires: ISN_DCALL looks up dfunc_idx=N, finds
     `df_deleted == TRUE`, and raises E933.

### Solution

  In `generate_CALL`, when the call is inside a lambda (`FC_LAMBDA`) and the
  callee is a script-local function (`uf_name[0] == K_SPECIAL`), emit
  `ISN_UCALL` instead of `ISN_DCALL`.
  `ISN_UCALL` stores the function name and resolves it at call time, so after
  re-sourcing it finds the new `F` via its `<SNR>N_F` key in `func_hashtab`.

### Note

  Global def functions are unaffected by `delete_script_functions` and continue
  to use the faster `ISN_DCALL`.