### PR TITLE
runtime(env): add ftplugin for env filetype

### DIFF
--- a/runtime/ftplugin/env.vim
+++ b/runtime/ftplugin/env.vim
@@ -1,0 +1,19 @@
+" Vim filetype plugin file
+" Language:    env
+" Maintainer:  This runtime file is looking for a new maintainer.
+" Last Change: 2026 Feb 27
+
+if exists("b:did_ftplugin")
+  finish
+endif
+let b:did_ftplugin = 1
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+let b:undo_ftplugin = "setl com< cms< fo<"
+
+setlocal comments=b:# commentstring=#\ %s formatoptions-=t formatoptions+=croql
+
+let &cpo = s:cpo_save
+unlet s:cpo_save


### PR DESCRIPTION
## Summary

Add `runtime/ftplugin/env.vim` to set `commentstring`, `comments`, and `formatoptions` for the `env` filetype.

## Problem

#19260 (patch 9.2.0033) introduced a dedicated `env` filetype for `.env` files, which were previously detected as `sh`. A syntax file was added but no ftplugin, leaving `commentstring` empty. This breaks commenting (e.g. `gc` in Neovim, or any plugin relying on `commentstring`).

## Changes

Sets `comments=b:#`, `commentstring=#\ %s`, and `formatoptions-=t formatoptions+=croql`, matching the options `.env` files previously inherited from the `sh` ftplugin.