### PR TITLE
Failed "z=" changing 'nospell'

### DIFF
--- a/src/spellsuggest.c
+++ b/src/spellsuggest.c
@@ -463,7 +463,7 @@ spell_check_sps(void)
     void
 spell_suggest(int count)
 {
-    char_u	*line;
+    char_u	*line = NULL;
     pos_T	prev_cursor = curwin->w_cursor;
     char_u	wcopy[MAXWLEN + 2];
     char_u	*p;
@@ -488,7 +488,7 @@ spell_suggest(int count)
     if (*curwin->w_s->b_p_spl == NUL)
     {
 	emsg(_(e_spell_checking_is_not_possible));
-	return;
+	goto skip;
     }
 
     if (VIsual_active)
@@ -498,7 +498,7 @@ spell_suggest(int count)
 	if (curwin->w_cursor.lnum != VIsual.lnum)
 	{
 	    vim_beep(BO_SPELL);
-	    return;
+	    goto skip;
 	}
 	badlen = (int)curwin->w_cursor.col - (int)VIsual.col;
 	if (badlen < 0)
@@ -518,11 +518,11 @@ spell_suggest(int count)
 	// No bad word or it starts after the cursor: use the word under the
 	// cursor.
 	curwin->w_cursor = prev_cursor;
-	line = ml_get_curline();
-	p = line + curwin->w_cursor.col;
+	char_u *curline = ml_get_curline();
+	p = curline + curwin->w_cursor.col;
 	// Backup to before start of word.
-	while (p > line && spell_iswordp_nmw(p, curwin))
-	    MB_PTR_BACK(line, p);
+	while (p > curline && spell_iswordp_nmw(p, curwin))
+	    MB_PTR_BACK(curline, p);
 	// Forward to start of word.
 	while (*p != NUL && !spell_iswordp_nmw(p, curwin))
 	    MB_PTR_ADV(p);
@@ -530,9 +530,9 @@ spell_suggest(int count)
 	if (!spell_iswordp_nmw(p, curwin))		// No word found.
 	{
 	    beep_flush();
-	    return;
+	    goto skip;
 	}
-	curwin->w_cursor.col = (colnr_T)(p - line);
+	curwin->w_cursor.col = (colnr_T)(p - curline);
     }
 
     // Get the word and its length.

--- a/src/testdir/test_spell.vim
+++ b/src/testdir/test_spell.vim
@@ -1567,4 +1567,18 @@ let g:test_data_aff_sal = [
       \"SAL Z                    S",
       \ ]
 
+func Test_suggest_spell_restore()
+  norm! z=
+  call assert_equal(0, &spell)
+  set spelllang=
+  sil! norm! z=
+  call assert_equal(0, &spell)
+  set spelllang=en
+  call setline(1, ['1','2'])
+  norm! vjz=
+  call assert_equal(0, &spell)
+  set spelllang&
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_spell_utf8.vim
+++ b/src/testdir/test_spell_utf8.vim
@@ -808,13 +808,14 @@ endfunc
 
 func Test_check_empty_line()
   " This was using freed memory
+  set spell
   enew
   spellgood! ﬂ
   norm z=
   norm yy
   sil! norm P]svc
   norm P]s
-
+  set spell&
   bwipe!
 endfunc
 


### PR DESCRIPTION
Problem:  When z= fails due to no word being found, 'spelllang' being
          unset or a multiline visual selection, 'nospell' is not
          restored.
Solution: Jump to where the user configured value of 'spell' is restored
          instead of returning early.

Ref https://github.com/neovim/neovim/issues/38094