### PR TITLE
runtime(julia): Update julia ftplugin commentstring

### DIFF
--- a/runtime/ftplugin/julia.vim
+++ b/runtime/ftplugin/julia.vim
@@ -3,7 +3,7 @@
 " Maintainer:	Carlo Baldassi <carlobaldassi@gmail.com>
 " Homepage:	https://github.com/JuliaEditorSupport/julia-vim
 " Last Change:	2021 Aug 04
-" 2025 Dec 9 sync with upstream repo #18894
+" 2026 Feb 27 sync with upstream repo
 
 if exists("b:did_ftplugin")
   finish
@@ -16,7 +16,7 @@ set cpo&vim
 setlocal include=^\\s*\\%(reload\\\|include\\)\\>
 setlocal suffixesadd=.jl
 setlocal comments=:#
-setlocal commentstring=#=%s=#
+setlocal commentstring=#\ %s
 setlocal cinoptions+=#1
 setlocal define=^\\s*macro\\>
 setlocal fo-=t fo+=croql


### PR DESCRIPTION
The upstream Julia ftplugin recently changed `commentstring` to the single line variant: JuliaEditorSupport/julia-vim@edd3512. This patch effectively reverts the change to this line from #18894.

I assume staying in sync with upstream is sufficient cause to adopt this. In case it's not, see JuliaEditorSupport/julia-vim#198 for the upstream discussion. I can also personally attest to the new/old multi-line `commentstring` being quite disruptive since I received the #18894 patch. It's rarely used and does not play well with standard tooling such as JuliaFormatter.jl.