### PR TITLE
Fix memory leak in `eval_dict()` in `src/dict.c`

### DIFF
--- a/src/dict.c
+++ b/src/dict.c
@@ -994,7 +994,7 @@ eval_dict(char_u **arg, typval_T *rettv, evalarg_T *evalarg, int literal)
 		{
 		    emsg(_(e_missing_matching_bracket_after_dict_key));
 		    clear_tv(&tvkey);
-		    return FAIL;
+		    goto failret;
 		}
 		++*arg;
 	    }


### PR DESCRIPTION
### Problem

In `eval_dict()`, the dictionary `d` is allocated when `evaluate` is true (lines **958–963**):

```c
if (evaluate)
{
    d = dict_alloc();
    if (d == NULL)
        return FAIL;
}
```

Later, when parsing a Vim9 dictionary key written in bracket form (`[key]`), the code reports an error if the closing `]` is missing and returns early (lines **993–998**):

```c
if (**arg != ']')
{
    emsg(_(e_missing_matching_bracket_after_dict_key));
    clear_tv(&tvkey);
    return FAIL;
}
```

 Returning directly bypasses the shared cleanup in the `failret:` block, where `d` is freed. This results in a memory leak on this error path.

### Solution

Replace the direct `return FAIL;` with `goto failret;` so that the existing cleanup logic is executed. The fix is included in this commit.