### PR TITLE
netrw: patch 9.2.0073 should take into account a possible port number

### DIFF
--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -2592,7 +2592,8 @@ endfunction
 
 " s:NetrwValidateHostname:  Validate that the hostname is valid {{{2
 " Input:
-"   hostname, may include an optional username, e.g. user@hostname
+"   hostname, may include an optional username and port number, e.g.
+"       user@hostname:port
 "   allow a alphanumeric hostname or an IPv(4/6) address
 " Output:
 "  true if g:netrw_machine is valid according to RFC1123 #Section 2
@@ -2601,17 +2602,19 @@ function s:NetrwValidateHostname(hostname)
   let user_pat = '\%([a-zA-Z0-9._-]\+@\)\?'
   " Hostname: 1-64 chars, alphanumeric/dots/hyphens.
   " No underscores. No leading/trailing dots/hyphens.
-  let host_pat = '[a-zA-Z0-9]\%([-a-zA-Z0-9.]{,62}[a-zA-Z0-9]\)\?$'
+  let host_pat = '[a-zA-Z0-9]\%([-a-zA-Z0-9.]\{0,62}[a-zA-Z0-9]\)\?'
+  " Port: 16 bit unsigned integer
+  let port_pat = '\%(:\d\{1,5\}\)\?$'
 
   " IPv4: 1-3 digits separated by dots
-  let ipv4_pat = '\%(\d\{1,3}\.\)\{3\}\d\{1,3\}$'
+  let ipv4_pat = '\%(\d\{1,3}\.\)\{3\}\d\{1,3\}'
 
   " IPv6: Hex, colons, and optional brackets
-  let ipv6_pat = '\[\?\%([a-fA-F0-9:]\{2,}\)\+\]\?$'
+  let ipv6_pat = '\[\?\%([a-fA-F0-9:]\{2,}\)\+\]\?'
 
-  return a:hostname =~? '^'.user_pat.host_pat ||
-       \ a:hostname =~? '^'.user_pat.ipv4_pat ||
-       \ a:hostname =~? '^'.user_pat.ipv6_pat
+  return a:hostname =~? '^'.user_pat.host_pat.port_pat ||
+       \ a:hostname =~? '^'.user_pat.ipv4_pat.port_pat ||
+       \ a:hostname =~? '^'.user_pat.ipv6_pat.port_pat
 endfunction
 
 " NetUserPass: set username and password for subsequent ftp transfer {{{2

--- a/src/testdir/test_plugin_netrw.vim
+++ b/src/testdir/test_plugin_netrw.vim
@@ -133,6 +133,11 @@ function Test_NetrwFile(fname) abort
     return s:NetrwFile(a:fname)
 endfunction
 
+" Test hostname validation
+function Test_NetrwValidateHostname(hostname) abort
+    return s:NetrwValidateHostname(a:hostname)
+endfunction
+
 " }}}
 END
 
@@ -564,6 +569,30 @@ func Test_netrw_reject_evil_hostname()
   let msg = execute(':e scp://x;touch RCE;x/dir/')
   let msg = split(msg, "\n")[-1]
   call assert_match('Rejecting invalid hostname', msg)
-endfunction
+endfunc
+
+func Test_netrw_hostname()
+  let valid_hostnames = [
+  \   'localhost',
+  \   '127.0.0.1',
+  \   '::1',
+  \   '0:0:0:0:0:0:0:1',
+  \   'user@localhost',
+  \   'usuario@127.0.0.1',
+  \   'utilisateur@::1',
+  \   'benutzer@0:0:0:0:0:0:0:1',
+  \   'localhost:22',
+  \   '127.0.0.1:80',
+  \   '[::1]:443',
+  \   '[0:0:0:0:0:0:0:1]:5432',
+  \   'user@localhost:22',
+  \   'usuario@127.0.0.1:80',
+  \   'utilisateur@[::1]:443',
+  \   'benutzer@[0:0:0:0:0:0:0:1]:5432']
+
+  for hostname in valid_hostnames
+    call assert_true(Test_NetrwValidateHostname(hostname), $"Valid hostname {hostname} was rejected")
+  endfor
+endfunc
 
 " vim:ts=8 sts=2 sw=2 et


### PR DESCRIPTION
https://github.com/vim/vim/blob/4e5b9e31cb7484ad156fba995fdce3c9b075b5fd/runtime/pack/dist/opt/netrw/autoload/netrw.vim#L1531-L1544

The port number may appear at the end of the hostname in several protocols: cadaver, ftp, rsync, scp & sftp.