### PR TITLE
feat: add 'termsync' setting

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -9096,6 +9096,19 @@ A jump table for the options with a short description can be found at |Q_op|.
 <
 	NOTE: This option is reset when 'compatible' is set.
 
+						*'termsync'* *'tsy'*
+'termsync' 'tsy'	boolean (default off)
+			global
+	If the host terminal supports it, buffer all screen updates made
+	during a redraw cycle so that each screen is displayed in the terminal
+	all at once.  This can prevent tearing or flickering when the terminal
+	updates faster than Vim can redraw.  If the host terminal does not
+	support it or if Vim is running graphically, then this option does
+	nothing.
+
+	Vim may set this option automatically at startup time when Vim is
+	compiled with the |+termresponse| feature.
+
 						*'termwinkey'* *'twk'*
 'termwinkey' 'twk'	string	(default "")
 			local to window

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -1235,6 +1235,7 @@ $quote	eval.txt	/*$quote*
 'termbidi'	options.txt	/*'termbidi'*
 'termencoding'	options.txt	/*'termencoding'*
 'termguicolors'	options.txt	/*'termguicolors'*
+'termsync'	options.txt	/*'termsync'*
 'termwinkey'	options.txt	/*'termwinkey'*
 'termwinscroll'	options.txt	/*'termwinscroll'*
 'termwinsize'	options.txt	/*'termwinsize'*
@@ -1270,6 +1271,7 @@ $quote	eval.txt	/*$quote*
 'tsl'	options.txt	/*'tsl'*
 'tsr'	options.txt	/*'tsr'*
 'tsrfu'	options.txt	/*'tsrfu'*
+'tsy'	options.txt	/*'tsy'*
 'ttimeout'	options.txt	/*'ttimeout'*
 'ttimeoutlen'	options.txt	/*'ttimeoutlen'*
 'ttm'	options.txt	/*'ttm'*

--- a/runtime/doc/term.txt
+++ b/runtime/doc/term.txt
@@ -510,6 +510,10 @@ Added by Vim (there are no standard codes for these):
 		|xterm-focus-event|
 	t_fd	disable focus-event tracking			*t_fd* *'t_fd'*
 		|xterm-focus-event|
+	t_BS	begin synchronized update			*t_BS* *'t_BS'*
+		see 'termsync'
+	t_ES	end synchronized update				*t_ES* *'t_ES'*
+		see 'termsync'
 
 Some codes have a start, middle and end part.  The start and end are defined
 by the termcap option, the middle part is text.
@@ -527,6 +531,11 @@ t_SH must take one argument:
 
 t_RS is sent only if the response to t_RV has been received.  It is not used
 on Mac OS when Terminal.app could be recognized from the termresponse.
+
+The t_BS and t_ES are not stored in the termcap, but are instead set to the
+following default values on startup:
+	t_BS		"\033[?2026h"
+	t_ES		"\033[?2026l"
 
 							*mouse-reporting*
 Many terminals can report mouse clicks and some can report mouse movement and

--- a/src/drawscreen.c
+++ b/src/drawscreen.c
@@ -160,6 +160,8 @@ update_screen(int type_arg)
     }
     updating_screen = TRUE;
 
+    term_set_sync_output(TERM_SYNC_OUTPUT_ENABLE);
+
 #ifdef FEAT_PROP_POPUP
     // Update popup_mask if needed.  This may set w_redraw_top and w_redraw_bot
     // in some windows.
@@ -433,6 +435,8 @@ update_screen(int type_arg)
     invoke_redraw_listener_start_or_end(false);
     redraw_listener_cleanup();
 #endif
+
+    term_set_sync_output(TERM_SYNC_OUTPUT_DISABLE);
 
     return OK;
 }

--- a/src/getchar.c
+++ b/src/getchar.c
@@ -1725,6 +1725,9 @@ using_script(void)
     void
 before_blocking(void)
 {
+    // Tell terminal to flush screen contents before blocking
+    term_set_sync_output(TERM_SYNC_OUTPUT_FLUSH);
+
     updatescript(0);
 #ifdef FEAT_EVAL
     if (may_garbage_collect)

--- a/src/gui.c
+++ b/src/gui.c
@@ -148,8 +148,11 @@ gui_start(char_u *arg UNUSED)
     }
 #ifdef HAVE_CLIPMETHOD
     else
+    {
 	// Reset clipmethod to CLIPMETHOD_NONE
 	choose_clipmethod();
+	term_set_sync_output(TERM_SYNC_OUTPUT_OFF);
+    }
 #endif
 
 #if defined(FEAT_SOCKETSERVER) && defined(FEAT_GUI_GTK)

--- a/src/main.c
+++ b/src/main.c
@@ -892,6 +892,8 @@ vim_main2(void)
     may_req_termresponse();
 
     may_req_bg_color();
+
+    may_req_sync_output();
 # endif
 
     // start in insert mode
@@ -1854,6 +1856,8 @@ getout(int exitval)
 #ifdef MSWIN
     free_cmd_argsW();
 #endif
+
+    term_set_sync_output(TERM_SYNC_OUTPUT_OFF);
 
     mch_exit(exitval);
 }

--- a/src/option.c
+++ b/src/option.c
@@ -4409,6 +4409,14 @@ did_set_termguicolors(optset_T *args UNUSED)
 }
 #endif
 
+    char *
+did_set_termsync(optset_T *args UNUSED)
+{
+    if (!p_tsy)
+	term_set_sync_output(TERM_SYNC_OUTPUT_OFF);
+    return NULL;
+}
+
 #if defined(FEAT_TERMINAL)
 /*
  * Process the updated 'termwinscroll' option value.

--- a/src/option.h
+++ b/src/option.h
@@ -1035,6 +1035,7 @@ EXTERN char_u	*p_tenc;	// 'termencoding'
 #ifdef FEAT_TERMGUICOLORS
 EXTERN int	p_tgc;		// 'termguicolors'
 #endif
+EXTERN int	p_tsy;		// 'termsync'
 #ifdef FEAT_TERMINAL
 EXTERN long	p_twsl;		// 'termwinscroll'
 #endif

--- a/src/optiondefs.h
+++ b/src/optiondefs.h
@@ -2661,6 +2661,9 @@ static struct vimoption options[] =
 			    {(char_u *)FALSE, (char_u *)FALSE}
 #endif
 			    SCTX_INIT},
+    {"termsync", "tsy",	    P_BOOL|P_VI_DEF,
+			    (char_u *)&p_tsy, PV_NONE, did_set_termsync, NULL,
+			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},
     {"termwinkey", "twk",   P_STRING|P_ALLOCED|P_RWIN|P_VI_DEF,
 #ifdef FEAT_TERMINAL
 			    (char_u *)VAR_WIN, PV_TWK, did_set_termwinkey, NULL,
@@ -3161,6 +3164,8 @@ static struct vimoption options[] =
     p_term("t_8b", T_8B)
     p_term("t_8u", T_8U)
     p_term("t_xo", T_XON)
+    p_term("t_BS", T_BSU)
+    p_term("t_ES", T_ESU)
 
 // terminal key codes are not in here
 

--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -4456,6 +4456,9 @@ did_set_term_option(optset_T *args)
 	    out_str(T_BE);
     }
 
+    if (varp == &T_BSU || varp == &T_ESU)
+	term_set_sync_output(TERM_SYNC_OUTPUT_OFF);
+
     return NULL;
 }
 

--- a/src/proto/option.pro
+++ b/src/proto/option.pro
@@ -72,6 +72,7 @@ char *did_set_smoothscroll(optset_T *args);
 char *did_set_spell(optset_T *args);
 char *did_set_swapfile(optset_T *args);
 char *did_set_termguicolors(optset_T *args);
+char *did_set_termsync(optset_T *args);
 char *did_set_termwinscroll(optset_T *args);
 char *did_set_terse(optset_T *args);
 char *did_set_textauto(optset_T *args);

--- a/src/proto/term.pro
+++ b/src/proto/term.pro
@@ -96,4 +96,6 @@ void swap_tcap(void);
 void ansi_color2rgb(int nr, char_u *r, char_u *g, char_u *b, char_u *ansi_idx);
 void cterm_color2rgb(int nr, char_u *r, char_u *g, char_u *b, char_u *ansi_idx);
 int term_replace_keycodes(char_u *ta_buf, int ta_len, int len_arg);
+void may_req_sync_output(void);
+void term_set_sync_output(int flags);
 /* vim: set ft=c : */

--- a/src/structs.h
+++ b/src/structs.h
@@ -5329,3 +5329,12 @@ typedef enum {
 
 # endif
 #endif
+
+// Used in term_set_sync_output()
+typedef enum
+{
+    TERM_SYNC_OUTPUT_ENABLE = 1 << 0,
+    TERM_SYNC_OUTPUT_DISABLE = 1 << 1,
+    TERM_SYNC_OUTPUT_OFF = 1 << 2,
+    TERM_SYNC_OUTPUT_FLUSH = 1 << 3,
+} term_sync_output_T;

--- a/src/term.c
+++ b/src/term.c
@@ -130,6 +130,9 @@ static termrequest_T u7_status = TERMREQUEST_INIT;
 // Request xterm compatibility check:
 static termrequest_T xcc_status = TERMREQUEST_INIT;
 
+// Request synchronized output report
+static termrequest_T sync_output_status = TERMREQUEST_INIT;
+
 #ifdef FEAT_TERMRESPONSE
 # ifdef FEAT_TERMINAL
 // Request foreground color report:
@@ -165,6 +168,7 @@ static termrequest_T *all_termrequests[] = {
     &rbm_status,
     &rcs_status,
     &winpos_status,
+    &sync_output_status,
     NULL
 };
 
@@ -223,6 +227,24 @@ static int initial_cursor_shape_blink = FALSE;
 // The blink flag from the blinking-cursor mode response
 static int initial_cursor_blink = FALSE;
 #endif
+
+// 0	Mode is not recognized	not supported
+//
+// 1	Set			supported and screen updates are not shown to
+//				the user until mode is disabled
+//
+// 2	Reset			supported and screen updates are shown as usual
+//				(e.g. as soon as they arrive)
+//
+// 3	Permanently set		undefined
+//
+// 4	Permanently reset	not supported
+//
+static int sync_output_setting = 0;
+
+// > 0: Currently batching output
+// == 0: No synchronized output
+static int sync_output_state = 0;
 
 /*
  * The builtin termcap entries.
@@ -2184,6 +2206,14 @@ set_termname(char_u *term)
     if (strstr((char *)term, "kitty") != NULL
 					   && (T_CRV == NULL || *T_CRV == NUL))
 	T_CRV = (char_u *)"\033[>c";
+
+    // These are the DECSET/DECRESET codes for synchronized output. iTerm
+    // supports another way, but this is the de facto standard terminal codes
+    // that are used (from what I can tell - 64bitman).
+    if (T_BSU == NULL || T_BSU == empty_option)
+	T_BSU = (char_u *)"\033[?2026h";
+    if (T_ESU == NULL || T_ESU == empty_option)
+	T_ESU = (char_u *)"\033[?2026l";
 
 #ifdef UNIX
 /*
@@ -5564,6 +5594,8 @@ handle_csi_function_key(
  *
  * - DA1 query response: {lead}?...;c
  *
+ * - DEC mode 2026 response (synchronized output): {lead}?2026;{mode}$y
+ *
  * Return 0 for no match, -1 for partial match, > 0 for full match.
  */
     static int
@@ -5690,6 +5722,28 @@ handle_csi(
 
 	key_name[0] = (int)KS_EXTRA;
 	key_name[1] = (int)KE_IGNORE;
+    }
+
+    // DEC 2026 mode response (for 'termsync' option)
+    else if (first == '?' && trail == 'y' && argc == 2 && arg[0] == 2026)
+    {
+	int setting = arg[1];
+
+	*slen = csi_len;
+	key_name[0] = (int)KS_EXTRA;
+	key_name[1] = (int)KE_IGNORE;
+
+	if (setting >= 0 && setting <= 4)
+	{
+	    sync_output_setting = setting;
+	    LOG_TRN("Received DEC 2026 mode: %s", tp);
+	    sync_output_status.tr_progress = STATUS_GOT;
+
+	    set_option_value_give_err((char_u *)"termsync",
+		    setting == 1 || setting == 2, NULL, 0);
+	}
+	else
+	    LOG_TRN("Unknown synchronized output setting %d", setting);
     }
 
     // Version string: Eat it when there is at least one digit and
@@ -7797,4 +7851,95 @@ term_replace_keycodes(char_u *ta_buf, int ta_len, int len_arg)
 	    i += (*mb_ptr2len_len)(ta_buf + i, ta_len + len - i) - 1;
     }
     return len;
+}
+
+#ifdef FEAT_TERMRESPONSE
+/*
+ * Query the setting for DEC mode 2026 (synchronized output) from the terminal.
+ */
+    void
+may_req_sync_output(void)
+{
+    if (can_get_termresponse() && starting == 0
+	    && sync_output_status.tr_progress == STATUS_GET)
+    {
+	MAY_WANT_TO_LOG_THIS;
+	LOG_TR1("Sending synchronized output request");
+
+	out_str((char_u *)"\033[?2026$p");
+	termrequest_sent(&sync_output_status);
+
+	// check for the characters now, otherwise they might be eaten by
+	// get_keystroke()
+	out_flush();
+	(void)vpeekc_nomap();
+    }
+
+}
+#endif
+
+/*
+ * Enable or disable synchronized output if possible. Specification can be found
+ * here:
+ * https://github.com/contour-terminal/vt-extensions/blob/master/synchronized-output.md
+ */
+    void
+term_set_sync_output(int flags)
+{
+    bool    allowed;
+    char_u  *str;
+#ifdef FEAT_GUI
+    bool    in_gui = gui.in_use;
+#else
+    bool    in_gui = false;
+#endif
+
+    allowed = p_tsy && (sync_output_setting == 1 || sync_output_setting == 2);
+
+    if (flags & TERM_SYNC_OUTPUT_FLUSH)
+    {
+	// Tell terminal to display screen contents
+	if (allowed && !in_gui && sync_output_state > 0)
+	{
+	    out_str((char_u *)T_ESU);
+	    out_str((char_u *)T_BSU);
+	}
+	return;
+    }
+
+    // Forcibly turn off synchronized output (e.g. 'notermsync')
+    if (flags & TERM_SYNC_OUTPUT_OFF)
+    {
+	if (sync_output_state > 0)
+	{
+	    out_str((char_u *)T_ESU);
+	    sync_output_state = 0;
+	}
+	return;
+    }
+
+    if (!allowed || in_gui || *T_BSU == NUL || *T_ESU == NUL)
+	return;
+
+    // Only enable if we aren't already, and only disable if we have reached
+    // zero.
+    if (flags & TERM_SYNC_OUTPUT_ENABLE)
+    {
+	if (sync_output_state++ > 0)
+	    return;
+	str = T_BSU;
+    }
+    else if (flags & TERM_SYNC_OUTPUT_DISABLE)
+    {
+	if (sync_output_state == 0 || --sync_output_state > 0)
+	    return;
+	str = T_ESU;
+    }
+    else
+    {
+	siemsg("Unknown sync output value %d", flags);
+	return;
+    }
+
+    out_str((char_u *)str);
 }

--- a/src/termdefs.h
+++ b/src/termdefs.h
@@ -116,10 +116,12 @@ enum SpecialKey
     KS_FD,	// disable focus event tracking
     KS_FE,	// enable focus event tracking
     KS_CF,	// set terminal alternate font
-    KS_XON	// terminal uses xon/xoff handshaking
+    KS_XON,	// terminal uses xon/xoff handshaking
+    KS_BSU,	// begin synchronized update
+    KS_ESU	// end synchronized update
 };
 
-#define KS_LAST	    KS_XON
+#define KS_LAST	    KS_ESU
 
 /*
  * the terminal capabilities are stored in this array
@@ -226,6 +228,8 @@ extern char_u *(term_strings[]);    // current terminal strings
 #define T_FD	(TERM_STR(KS_FD))	// disable focus event tracking
 #define T_FE	(TERM_STR(KS_FE))	// enable focus event tracking
 #define T_XON	(TERM_STR(KS_XON))	// terminal uses xon/xoff handshaking
+#define T_BSU	(TERM_STR(KS_BSU))	// begin synchronized update
+#define T_ESU	(TERM_STR(KS_ESU))	// end synchronized update
 
 typedef enum {
     TMODE_COOK,	    // terminal mode for external cmds and Ex mode

--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -318,7 +318,7 @@ func Test_set_completion()
 
   " Expand abbreviation of options.
   call feedkeys(":set ts\<C-A>\<C-B>\"\<CR>", 'tx')
-  call assert_equal('"set tabstop thesaurus thesaurusfunc ttyscroll', @:)
+  call assert_equal('"set tabstop termsync thesaurus thesaurusfunc ttyscroll', @:)
 
   " Expand current value
   call feedkeys(":set suffixes=\<C-A>\<C-B>\"\<CR>", 'tx')


### PR DESCRIPTION
Same as Neovim's `termsync` option. Surprised this wasn't already added, considering how simple it was to implement (unless I'm missing something) and it reduces flickering greatly for me on my machine.

Here's a before and after comparsion:

https://github.com/user-attachments/assets/fb45ab56-b3a8-491b-b589-3c818fa6cd25