### PR TITLE
runtime(osc52): Omit paste capability from the osc52 provider when g:osc52_disable_paste is enabled

### DIFF
--- a/runtime/pack/dist/opt/osc52/doc/osc52.txt
+++ b/runtime/pack/dist/opt/osc52/doc/osc52.txt
@@ -62,9 +62,10 @@ setting |g:osc52_force_avail| to true.
 
                                                         *g:osc52_disable_paste*
 If your terminal does not support pasting via OSC 52, or has it disabled, then
-it is a good idea to set g:osc52_disable_paste to TRUE.  This will cause an
-empty string to be returned when Vim attempts to query the osc52.vim provider,
-instead of doing a blocking wait, as said in |osc52-support|.
+it is a good idea to set g:osc52_disable_paste to TRUE.  This will register
+only the "copy" method for the osc52.vim clipboard provider, so Vim will not
+attempt an OSC 52 paste query and avoids the blocking wait described in
+|osc52-support|.
 
 ==============================================================================
 vim:tw=78:ts=8:fo=tcq2:ft=help:

--- a/runtime/pack/dist/opt/osc52/plugin/osc52.vim
+++ b/runtime/pack/dist/opt/osc52/plugin/osc52.vim
@@ -11,17 +11,24 @@ endif
 
 import autoload "../autoload/osc52.vim" as osc
 
-v:clipproviders["osc52"] = {
+var provider: dict<any> = {
   "available": osc.Available,
-  "paste": {
-    "*": osc.Paste,
-    "+": osc.Paste
-  },
   "copy": {
     "*": osc.Copy,
     "+": osc.Copy
   },
 }
+
+if !get(g:, 'osc52_disable_paste', 0)
+  provider->extend({
+    "paste": {
+      "*": osc.Paste,
+      "+": osc.Paste
+    }
+  })
+endif
+
+v:clipproviders["osc52"] = provider
 
 def SendDA1(): void
   if !has("gui_running") && !get(g:, 'osc52_force_avail', 0)


### PR DESCRIPTION
## Summary

On terminals without OSC 52 paste support, setting g:osc52_disable_paste = v:true previously made the + and * registers appear empty. This PR fixes that by making the osc52 provider capabilities conditional (omit "paste" when disabled) and updates the documentation to match.

## Background

Some terminals do not support OSC 52 paste, so paste is disabled using g:osc52_disable_paste = v:true.
However, with the previous behavior, enabling this setting caused the + and * registers to be treated as empty.
This PR addresses the issue by revisiting the provider definition when g:osc52_disable_paste is enabled.

## Changes

- plugin/osc52.vim
    - Add "paste" only when g:osc52_disable_paste is false
    - When true, register only "available" and "copy"
- doc/osc52.txt
    - Update the description of g:osc52_disable_paste
    - Revise the behavior description to match the implementation

## Expected Benefits

- Avoid unnecessary OSC 52 paste queries on terminals that do not support paste
- Prevent the +/* registers from being treated as empty even when g:osc52_disable_paste is enabled

## Reference

#18983