### PR TITLE
control flow commands using '|' fail inside a {} block

### DIFF
--- a/src/ex_eval.c
+++ b/src/ex_eval.c
@@ -1601,6 +1601,28 @@ inside_block(exarg_T *eap)
     cstack_T	*cstack = eap->cstack;
     int		i;
 
+    // Control flow commands handle '|' themselves and must not be treated
+    // as if inside a block even when they are - otherwise '|' separators
+    // in "try | catch | endtry" etc. would not be recognized.
+    switch (eap->cmdidx)
+    {
+	case CMD_if:
+	case CMD_elseif:
+	case CMD_else:
+	case CMD_endif:
+	case CMD_while:
+	case CMD_endwhile:
+	case CMD_for:
+	case CMD_endfor:
+	case CMD_try:
+	case CMD_catch:
+	case CMD_finally:
+	case CMD_endtry:
+	    return FALSE;
+	default:
+	    break;
+    }
+
     for (i = 0; i <= cstack->cs_idx; ++i)
 	if (cstack->cs_flags[i] & CSF_BLOCK)
 	    return TRUE;

--- a/src/testdir/test_trycatch.vim
+++ b/src/testdir/test_trycatch.vim
@@ -2375,5 +2375,31 @@ func Test_leave_block_in_endtry_not_called()
   endtry
 endfunc
 
+" Ensure | inside_block is correctly executed "{{{1
+func Test_try_endtry_inside_block()
+  let lines =<< trim END
+    vim9script
+
+    augroup testing
+      au User myusertest {
+        try
+          echoerr 'try'
+        catch
+        endtry
+        g:reached_after_endtry = 1
+      }
+    augroup end
+    doautocmd User myusertest
+  END
+  call writefile(lines, 'XtestInsideBlock', 'D')
+  source XtestInsideBlock
+  call assert_equal(1, g:reached_after_endtry)
+  unlet! g:reached_after_endtry
+  augroup testing
+    au!
+  augroup END
+  augroup! testing
+endfunc
+
 " Modeline								    {{{1
 " vim: ts=8 sw=2 sts=2 expandtab tw=80 fdm=marker


### PR DESCRIPTION
Problem:  inside_block() iterates through all cstack levels
          and returns TRUE when a CSF_BLOCK frame is found.  For control
          flow commands this causes '|' to no longer be
          recognised as a command separator, breaking
          "try | silent cmd | catch | endtry"
          (Martin Tournoij, after v9.2.0072).
Solution: Return FALSE from inside_block() for control flow commands
          that handle '|' themselves, so they always use '|' as
          separator regardless of block nesting.

fixes:  #19535

supported by AI claude.