### PR TITLE
Tweak doc style in options.txt

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5813,9 +5813,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 			Like |lcs-tab|, but only for leading tabs.  When
 			omitted, the "tab" setting is used for leading tabs.
 			|lcs-tab| must also be set for this to work. *E1572*
-			You can combine it with "tab:", for example:
-			`:set listchars=tab:>-,leadtab:.\ `
-			This shows leading tabs as periods(.) and other tabs
+			You can combine it with "tab:", for example: >
+				:set listchars=tab:>-,leadtab:.\ 
+<			This shows leading tabs as periods(.) and other tabs
 			as ">--".
 							*lcs-trail*
 	  trail:c	Character to show for trailing spaces.  When omitted,


### PR DESCRIPTION
The example was not highlighted, so I fixed it to the same format as `lcs-leadtab`.