### PR TITLE
"leadtab" behavior inconsistent on line with only TABs

### DIFF
--- a/src/drawline.c
+++ b/src/drawline.c
@@ -3267,7 +3267,7 @@ win_line(
 
 		    // check if leadtab is set in 'listchars'
 		    if (wp->w_p_list && wp->w_lcs_chars.leadtab1 != NUL &&
-			(leadcol == 0 || ptr < line + leadcol))
+							  ptr < line + leadcol)
 		    {
 			lcs_tab1 = wp->w_lcs_chars.leadtab1;
 			lcs_tab2 = wp->w_lcs_chars.leadtab2;

--- a/src/testdir/test_listchars.vim
+++ b/src/testdir/test_listchars.vim
@@ -151,6 +151,21 @@ func Test_listchars()
   call Check_listchars(expected, 5, -1, 6)
   call assert_equal(expected, split(execute("%list"), "\n"))
 
+  " In a line with only spaces, they aren't considered leading even if "trail"
+  " isn't set.
+  set listchars-=trail:<
+  let expected = [
+	      \ '>>>>ffffxxxx$',
+	      \ '>>>>>>>>>>gg$',
+	      \ 'hxxxxxxxxxxx$',
+	      \ 'xxxxxxxxxxxx$',
+	      \ '>>>>0xx0xxxx$',
+	      \ '$'
+	      \ ]
+  call Check_listchars(expected, 6)
+  call Check_listchars(expected, 5, -1, 6)
+  call assert_equal(expected, split(execute("%list"), "\n"))
+
   " Test multispace
   normal ggdG
   set listchars&
@@ -161,6 +176,7 @@ func Test_listchars()
 	      \ '    ffff    ',
 	      \ '  i i     gg',
 	      \ ' h          ',
+	      \ '            ',
 	      \ '          j ',
 	      \ '    0  0    ',
 	      \ ])
@@ -169,12 +185,13 @@ func Test_listchars()
 	      \ 'yYzZffffyYzZ$',
 	      \ 'yYi iyYzZygg$',
 	      \ ' hyYzZyYzZyY$',
+	      \ 'yYzZyYzZyYzZ$',
 	      \ 'yYzZyYzZyYj $',
 	      \ 'yYzZ0yY0yYzZ$',
 	      \ '$'
 	      \ ]
-  call Check_listchars(expected, 6)
-  call Check_listchars(expected, 5, -1, 6)
+  call Check_listchars(expected, 7)
+  call Check_listchars(expected, 6, -1, 6)
   call assert_equal(expected, split(execute("%list"), "\n"))
 
   " Test leadmultispace + multispace
@@ -187,6 +204,7 @@ func Test_listchars()
 	      \ '    ffff    ',
 	      \ '  i i     gg',
 	      \ ' h          ',
+	      \ '            ',
 	      \ '          j ',
 	      \ '    0  0    ',
 	      \ ])
@@ -195,16 +213,17 @@ func Test_listchars()
 	      \ '.-+*ffffyYzZ$',
 	      \ '.-i iSyYzZgg$',
 	      \ ' hyYzZyYzZyY$',
+	      \ 'yYzZyYzZyYzZ$',
 	      \ '.-+*.-+*.-j $',
 	      \ '.-+*0yY0yYzZ$',
 	      \ '$'
 	      \ ]
   call assert_equal('eol:$,multispace:yYzZ,nbsp:S,leadmultispace:.-+*', &listchars)
-  call Check_listchars(expected, 6)
-  call Check_listchars(expected, 5, -1, 1)
-  call Check_listchars(expected, 5, -1, 2)
-  call Check_listchars(expected, 5, -1, 3)
-  call Check_listchars(expected, 5, -1, 6)
+  call Check_listchars(expected, 7)
+  call Check_listchars(expected, 6, -1, 1)
+  call Check_listchars(expected, 6, -1, 2)
+  call Check_listchars(expected, 6, -1, 3)
+  call Check_listchars(expected, 6, -1, 6)
   call assert_equal(expected, split(execute("%list"), "\n"))
 
   " Test leadmultispace without multispace
@@ -217,6 +236,7 @@ func Test_listchars()
 	      \ '    ffff    ',
 	      \ '  i i     gg',
 	      \ ' h          ',
+	      \ '            ',
 	      \ '          j ',
 	      \ '    0  0    ',
 	      \ ])
@@ -225,16 +245,17 @@ func Test_listchars()
 	      \ '.-+*ffff>>>>$',
 	      \ '.-i+i+++++gg$',
 	      \ '+h>>>>>>>>>>$',
+	      \ '>>>>>>>>>>>>$',
 	      \ '.-+*.-+*.-j>$',
 	      \ '.-+*0++0>>>>$',
 	      \ '$'
 	      \ ]
   call assert_equal('eol:$,nbsp:S,leadmultispace:.-+*,space:+,trail:>,eol:$', &listchars)
-  call Check_listchars(expected, 6)
-  call Check_listchars(expected, 5, -1, 1)
-  call Check_listchars(expected, 5, -1, 2)
-  call Check_listchars(expected, 5, -1, 3)
-  call Check_listchars(expected, 5, -1, 6)
+  call Check_listchars(expected, 7)
+  call Check_listchars(expected, 6, -1, 1)
+  call Check_listchars(expected, 6, -1, 2)
+  call Check_listchars(expected, 6, -1, 3)
+  call Check_listchars(expected, 6, -1, 6)
   call assert_equal(expected, split(execute("%list"), "\n"))
 
   " Test leadmultispace only
@@ -247,6 +268,7 @@ func Test_listchars()
 	      \ '    ffff    ',
 	      \ '  i i     gg',
 	      \ ' h          ',
+	      \ '            ',
 	      \ '          j ',
 	      \ '    0  0    ',
 	      \ ])
@@ -255,12 +277,13 @@ func Test_listchars()
 	      \ '.-+*ffff    ',
 	      \ '.-i i     gg',
 	      \ ' h          ',
+	      \ '            ',
 	      \ '.-+*.-+*.-j ',
 	      \ '.-+*0  0    ',
 	      \ ' '
 	      \ ]
   call assert_equal('leadmultispace:.-+*', &listchars)
-  call Check_listchars(expected, 5, 12)
+  call Check_listchars(expected, 6, 12)
   call assert_equal(expected, split(execute("%list"), "\n"))
 
   " Changing the value of 'ambiwidth' twice shouldn't cause double-free when
@@ -279,6 +302,7 @@ func Test_listchars()
 	      \ '    ffff    ',
 	      \ '  i i     gg',
 	      \ ' h          ',
+	      \ '            ',
 	      \ '          j ',
 	      \ '    0  0    ',
 	      \ ])
@@ -287,16 +311,17 @@ func Test_listchars()
 	      \ '.-+*ffff----$',
 	      \ '.-i-i-----gg$',
 	      \ '<h----------$',
+	      \ '------------$',
 	      \ '.-+*.-+*.-j-$',
 	      \ '.-+*0--0----$',
 	      \ '$'
 	      \ ]
   call assert_equal('eol:$,lead:<,space:-,leadmultispace:.-+*', &listchars)
-  call Check_listchars(expected, 6)
-  call Check_listchars(expected, 5, -1, 1)
-  call Check_listchars(expected, 5, -1, 2)
-  call Check_listchars(expected, 5, -1, 3)
-  call Check_listchars(expected, 5, -1, 6)
+  call Check_listchars(expected, 7)
+  call Check_listchars(expected, 6, -1, 1)
+  call Check_listchars(expected, 6, -1, 2)
+  call Check_listchars(expected, 6, -1, 3)
+  call Check_listchars(expected, 6, -1, 6)
   call assert_equal(expected, split(execute("%list"), "\n"))
 
   " the last occurrence of 'multispace:' is used
@@ -308,13 +333,14 @@ func Test_listchars()
 	      \ 'XyYXffffXyYX$',
 	      \ 'XyixiXyYXygg$',
 	      \ 'xhXyYXyYXyYX$',
+	      \ 'XyYXyYXyYXyY$',
 	      \ 'XyYXyYXyYXjx$',
 	      \ 'XyYX0Xy0XyYX$',
 	      \ '$'
 	      \ ]
   call assert_equal('eol:$,multispace:yYzZ,space:x,multispace:XyY', &listchars)
-  call Check_listchars(expected, 6)
-  call Check_listchars(expected, 5, -1, 6)
+  call Check_listchars(expected, 7)
+  call Check_listchars(expected, 6, -1, 6)
   call assert_equal(expected, split(execute("%list"), "\n"))
 
   set listchars+=lead:>,trail:<
@@ -323,12 +349,13 @@ func Test_listchars()
 	      \ '>>>>ffff<<<<$',
 	      \ '>>ixiXyYXygg$',
 	      \ '>h<<<<<<<<<<$',
+	      \ '<<<<<<<<<<<<$',
 	      \ '>>>>>>>>>>j<$',
 	      \ '>>>>0Xy0<<<<$',
 	      \ '$'
 	      \ ]
-  call Check_listchars(expected, 6)
-  call Check_listchars(expected, 5, -1, 6)
+  call Check_listchars(expected, 7)
+  call Check_listchars(expected, 6, -1, 6)
   call assert_equal(expected, split(execute("%list"), "\n"))
 
   " removing 'multispace:'
@@ -339,12 +366,13 @@ func Test_listchars()
 	      \ '>>>>ffff<<<<$',
 	      \ '>>ixixxxxxgg$',
 	      \ '>h<<<<<<<<<<$',
+	      \ '<<<<<<<<<<<<$',
 	      \ '>>>>>>>>>>j<$',
 	      \ '>>>>0xx0<<<<$',
 	      \ '$'
 	      \ ]
-  call Check_listchars(expected, 6)
-  call Check_listchars(expected, 5, -1, 6)
+  call Check_listchars(expected, 7)
+  call Check_listchars(expected, 6, -1, 6)
   call assert_equal(expected, split(execute("%list"), "\n"))
 
   " Test leadtab basic functionality
@@ -392,19 +420,22 @@ func Test_listchars()
   call Check_listchars(expected, 1, 12)
 
   " Test leadtab vs tab distinction (leading vs non-leading)
+  " In a line with only tabs, they aren't considered leading.
   normal ggdG
   set listchars=tab:>-,leadtab:+*
   call append(0, [
         \ "\tleading",
         \ "text\tnot leading",
-        \ "\t\tmultiple leading"
+        \ "\t\tmultiple leading",
+        \ "\t\t"
         \ ])
   let expected = [
         \ '+*******leading                 ',
         \ 'text>---not leading             ',
-        \ '+*******+*******multiple leading'
+        \ '+*******+*******multiple leading',
+        \ '>------->-------                '
         \ ]
-  call Check_listchars(expected, 3, 32)
+  call Check_listchars(expected, 4, 32)
 
   " Test leadtab with trail and space
   normal ggdG


### PR DESCRIPTION
Problem:  "leadtab" behavior inconsistent on line with only TABs
          (after 9.2.0088).
Solution: Don't consider those as leading TABs. Also add more tests for
          existing behavior of "lead" and "leadmultispace".
