### PR TITLE
Memory leak in qf_push_dir()

### DIFF
--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -2841,7 +2841,7 @@ qf_push_dir(char_u *dirbuf, struct dir_stack_T **stackptr, int is_file_stack)
 		(*stackptr)->dirname = dirname;
 		break;
 	    }
-
+	    vim_free(dirname);
 	    ds_new = ds_new->next;
 	}
 


### PR DESCRIPTION
Problem:  Memory leak in qf_push_dir() (after v9.2.0091)
Problem:  free dirname, if it is not a directory.