### PR TITLE
Push winhighlight override in more places

### DIFF
--- a/src/drawscreen.c
+++ b/src/drawscreen.c
@@ -634,7 +634,6 @@ redraw_custom_statusline(win_T *wp)
     void
 showruler(int always)
 {
-    bool override_success;
     if (!always && !redrawing())
 	return;
     if (pum_visible())
@@ -643,15 +642,12 @@ showruler(int always)
 	curwin->w_redr_status = TRUE;
 	return;
     }
-    override_success = push_highlight_overrides(curwin->w_hl, curwin->w_hl_len);
 #if defined(FEAT_STL_OPT)
     if ((*p_stl != NUL || *curwin->w_p_stl != NUL) && curwin->w_status_height)
 	redraw_custom_statusline(curwin);
     else
 #endif
 	win_redr_ruler(curwin, always, FALSE);
-    if (override_success)
-	pop_highlight_overrides();
 
     if (need_maketitle
 #ifdef FEAT_STL_OPT
@@ -744,6 +740,8 @@ win_redr_ruler(win_T *wp, int always, int ignore_pum)
 	int	this_ru_col;
 	int	n1;			    // scratch value
 	int	n2;			    // scratch value
+	bool	override_success =
+	    push_highlight_overrides(wp->w_hl, wp->w_hl_len);
 
 	cursor_off();
 	if (wp->w_status_height)
@@ -849,6 +847,9 @@ win_redr_ruler(win_T *wp, int always, int ignore_pum)
 #ifdef FEAT_DIFF
 	wp->w_ru_topfill = wp->w_topfill;
 #endif
+
+	if (override_success)
+	    pop_highlight_overrides();
     }
 }
 
@@ -1029,6 +1030,8 @@ redraw_win_toolbar(win_T *wp)
     int		col = 0;
     int		next_col;
     int		off = (int)(current_ScreenLine - ScreenLines);
+    bool	override_success =
+	push_highlight_overrides(wp->w_hl, wp->w_hl_len);
     int		fill_attr = syn_name2attr((char_u *)"ToolbarLine");
     int		button_attr = syn_name2attr((char_u *)"ToolbarButton");
 
@@ -1080,6 +1083,9 @@ redraw_win_toolbar(win_T *wp)
 
     screen_line(wp, wp->w_winrow, wp->w_wincol, wp->w_width,
 							  wp->w_width, -1, 0);
+
+    if (override_success)
+	pop_highlight_overrides();
 }
 #endif
 
@@ -1518,6 +1524,7 @@ win_update(win_T *wp)
 #if defined(FEAT_SYN_HL) || defined(FEAT_SEARCH_EXTRA)
     int		save_got_int;
 #endif
+    bool	override_success;
 
 #if defined(FEAT_SEARCH_EXTRA) || defined(FEAT_CLIPBOARD)
     // This needs to be done only for the first window when update_screen() is
@@ -1567,6 +1574,9 @@ win_update(win_T *wp)
 	return;
     }
 
+    override_success = push_highlight_overrides(wp->w_hl, wp->w_hl_len);
+
+
 #ifdef FEAT_TERMINAL
     // If this window contains a terminal, redraw works completely differently.
     if (term_do_update_window(wp))
@@ -1578,6 +1588,8 @@ win_update(win_T *wp)
 	    redraw_win_toolbar(wp);
 # endif
 	wp->w_redr_type = 0;
+	if (override_success)
+	    pop_highlight_overrides();
 	return;
     }
 #endif
@@ -2850,6 +2862,9 @@ win_update(win_T *wp)
     if (!got_int)
 	got_int = save_got_int;
 #endif
+
+    if (override_success)
+	pop_highlight_overrides();
 }
 
 #if defined(FEAT_NETBEANS_INTG) || defined(FEAT_GUI)

--- a/src/highlight.c
+++ b/src/highlight.c
@@ -184,11 +184,11 @@ typedef struct
 typedef struct hl_overrides_S hl_overrides_T;
 struct hl_overrides_S
 {
-    hl_override_T   *arr;
+    hl_override_T   *arr;   // May be NULL if "arr" was freed
     int		    len;
-    hl_overrides_T  *next; // Used to handle recursive calls
+    hl_overrides_T  *next;  // Used to handle recursive calls
 
-    int attr[HLF_COUNT]; // highlight_attr[] before being updated.
+    int attr[HLF_COUNT];    // highlight_attr[] before being updated.
 };
 
 static hl_overrides_T *overrides = NULL;
@@ -5473,6 +5473,25 @@ update_highlight_overrides(hl_override_T *old, hl_override_T *hl_new, int newlen
 	{
 	    set->arr = hl_new;
 	    set->len = newlen;
+	    break;
+	}
+    }
+}
+
+/*
+ * If "arr" is in the highlight overrides list, then mark it as invalid.
+ */
+    void
+remove_highlight_overrides(hl_override_T *arr)
+{
+    if (arr == NULL || overrides == NULL)
+	return;
+
+    for (hl_overrides_T *set = overrides; set != NULL; set = set->next)
+    {
+	if (set->arr == arr)
+	{
+	    set->arr = NULL;
 	    break;
 	}
     }

--- a/src/proto/highlight.pro
+++ b/src/proto/highlight.pro
@@ -49,6 +49,7 @@ void free_highlight_fonts(void);
 void f_hlget(typval_T *argvars, typval_T *rettv);
 void f_hlset(typval_T *argvars, typval_T *rettv);
 void update_highlight_overrides(hl_override_T *old, hl_override_T *hl_new, int newlen);
+void remove_highlight_overrides(hl_override_T *arr);
 bool push_highlight_overrides(hl_override_T *arr, int len);
 void pop_highlight_overrides(void);
 char *update_winhighlight(win_T *wp, char_u *opt);

--- a/src/screen.c
+++ b/src/screen.c
@@ -117,7 +117,9 @@ conceal_check_cursor_line(int was_concealed)
     int
 get_win_attr(win_T *wp)
 {
-    int win_attr = wp->w_hlfwin_id;
+    int	    win_attr = wp->w_hlfwin_id;
+    bool    override_success =
+	push_highlight_overrides(wp->w_hl, wp->w_hl_len);
 
     if (win_attr != 0)
     {
@@ -135,6 +137,9 @@ get_win_attr(win_T *wp)
 	    win_attr = HL_ATTR(HLF_PNI);    // Pmenu
     }
 #endif
+
+    if (override_success)
+	pop_highlight_overrides();
     return win_attr;
 }
 
@@ -190,6 +195,8 @@ win_draw_end(
     int		n = 0;
     int		attr = HL_ATTR(hl);
     int		win_attr = get_win_attr(wp);
+    bool	override_success =
+	push_highlight_overrides(wp->w_hl, wp->w_hl_len);
 
     attr = hl_combine_attr(win_attr, attr);
 
@@ -232,6 +239,9 @@ win_draw_end(
     }
 
     set_empty_rows(wp, row);
+
+    if (override_success)
+	pop_highlight_overrides();
 }
 
 #if defined(FEAT_FOLDING)
@@ -489,6 +499,8 @@ screen_line(
     int		    clear_next = FALSE;
     int		    char_cells;		// 1: normal char
 					// 2: occupies two display cells
+    bool	    override_success =
+	push_highlight_overrides(wp->w_hl, wp->w_hl_len);
 
     // Check for illegal row and col, just in case.
     if (row >= Rows)
@@ -1061,6 +1073,9 @@ skip_opacity:
 	else
 	    LineWraps[row] = FALSE;
     }
+
+    if (override_success)
+	pop_highlight_overrides();
 }
 
 #if defined(FEAT_RIGHTLEFT)
@@ -1212,6 +1227,7 @@ win_redr_custom(
     stl_hlrec_T *tabtab;
     win_T	*ewp;
     int		p_crb_save;
+    bool	override_success = false;
 
     // There is a tiny chance that this gets called recursively: When
     // redrawing a status line triggers redrawing the ruler or tabline.
@@ -1234,6 +1250,8 @@ win_redr_custom(
     }
     else
     {
+	override_success = push_highlight_overrides(wp->w_hl, wp->w_hl_len);
+
 	row = statusline_row(wp);
 	fillchar = fillchar_status(&attr, wp);
 	int in_status_line = wp->w_status_height != 0;
@@ -1387,6 +1405,8 @@ win_redr_custom(
     }
 
 theend:
+    if (override_success)
+	pop_highlight_overrides();
     entered = FALSE;
 }
 
@@ -4773,7 +4793,9 @@ get_trans_bufname(buf_T *buf)
     int
 fillchar_status(int *attr, win_T *wp)
 {
-    int fill;
+    int	    fill;
+    bool    override_success =
+	push_highlight_overrides(wp->w_hl, wp->w_hl_len);
 
 #ifdef FEAT_TERMINAL
     if (bt_terminal(wp->w_buffer))
@@ -4801,6 +4823,9 @@ fillchar_status(int *attr, win_T *wp)
 	*attr = HL_ATTR(HLF_SNC);
 	fill = wp->w_fill_chars.stlnc;
     }
+
+    if (override_success)
+	pop_highlight_overrides();
     return fill;
 }
 
@@ -4811,7 +4836,12 @@ fillchar_status(int *attr, win_T *wp)
     int
 fillchar_vsep(int *attr, win_T *wp)
 {
+    bool override_success =
+	push_highlight_overrides(wp->w_hl, wp->w_hl_len);
     *attr = HL_ATTR(HLF_C);
+    if (override_success)
+	pop_highlight_overrides();
+
     if (*attr == 0 && wp->w_fill_chars.vert == ' ')
 	return '|';
     else

--- a/src/window.c
+++ b/src/window.c
@@ -5986,6 +5986,7 @@ win_free(
     ruby_window_free(wp);
 #endif
 
+    remove_highlight_overrides(wp->w_hl);
     vim_free(wp->w_hl);
 
     clear_winopt(&wp->w_onebuf_opt);


### PR DESCRIPTION
Might be a bit excessive, but better to be safe. Shouldn't have any impact on performance due to this if statement in `push_highlight_override()`:
```c
    if (arr == NULL || (overrides != NULL && overrides->arr == arr))
	return false;
```

Also fix a possible use after free situtation