### PR TITLE
Avoid using C++ keyword `new` as function parameter name

### DIFF
--- a/src/highlight.c
+++ b/src/highlight.c
@@ -5457,11 +5457,11 @@ f_hlset(typval_T *argvars, typval_T *rettv)
 #endif
 
 /*
- * If "old" is in the override stack, then update it to "new". Does not free
+ * If "old" is in the override stack, then update it to "hl_new". Does not free
  * "old".
  */
     void
-update_highlight_overrides(hl_override_T *old, hl_override_T *new, int newlen)
+update_highlight_overrides(hl_override_T *old, hl_override_T *hl_new, int newlen)
 {
     if (old == NULL)
 	return;
@@ -5470,7 +5470,7 @@ update_highlight_overrides(hl_override_T *old, hl_override_T *new, int newlen)
     {
 	if (set->arr == old)
 	{
-	    set->arr = new;
+	    set->arr = hl_new;
 	    set->len = newlen;
 	    break;
 	}

--- a/src/proto/highlight.pro
+++ b/src/proto/highlight.pro
@@ -48,7 +48,7 @@ int expand_highlight_group(char_u *pat, expand_T *xp, regmatch_T *rmp, char_u **
 void free_highlight_fonts(void);
 void f_hlget(typval_T *argvars, typval_T *rettv);
 void f_hlset(typval_T *argvars, typval_T *rettv);
-void update_highlight_overrides(hl_override_T *old, hl_override_T *new, int newlen);
+void update_highlight_overrides(hl_override_T *old, hl_override_T *hl_new, int newlen);
 bool push_highlight_overrides(hl_override_T *arr, int len);
 void pop_highlight_overrides(void);
 char *update_winhighlight(win_T *wp, char_u *opt);


### PR DESCRIPTION
Problem:
A recent commit introduced a new function named `update_highlight_overrides()` in `highlight.pro` and `highlight.c`, one of the parameter names conflicts with the C++ keyword `new`. This causes compilation issues on Windows when VIM is compiled with OLE enabled, as "if_ole.cpp" cannot compile due to the conflict (after v9.2.0093).

Solution:
Rename the parameter name of `update_highlight_overrides()` from `new` to `hl_new`.
