### PR TITLE
Fix: missing FEAT_MENU guard for w_winbar_height in window.c (after v9.2.0083)

### DIFF
--- a/src/window.c
+++ b/src/window.c
@@ -7657,22 +7657,21 @@ frame_change_statusline_height_rec(frame_T *frp, bool actual_change)
 
 	if (wp->w_height > 0 && wp->w_status_height > 0)
 	{
+	    int win_free_height = frp->fr_height - WINBAR_HEIGHT(wp);
+
 	    if (actual_change)
 	    {
 		wp->w_status_height = stlo_mh;
-		if (wp->w_status_height > frp->fr_height - wp->w_winbar_height
-			- p_wmh)
+		if (wp->w_status_height > win_free_height - p_wmh)
 		{
-		    wp->w_status_height = frp->fr_height - wp->w_winbar_height
-			- p_wmh;
+		    wp->w_status_height = win_free_height - p_wmh;
 		}
-		win_new_height(wp, frp->fr_height - wp->w_status_height
-			- wp->w_winbar_height);
+		win_new_height(wp, win_free_height - wp->w_status_height);
 	    }
 	    else
 	    {
-		if (frp->fr_height - wp->w_winbar_height - p_wmh < stlh_effort)
-		    stlh_effort = frp->fr_height - wp->w_winbar_height - p_wmh;
+		if (win_free_height - p_wmh < stlh_effort)
+		    stlh_effort = win_free_height - p_wmh;
 	    }
 	}
     }


### PR DESCRIPTION
Fixes: #19556 

I worked around the issue by using the WINBAR_HEIGHT() macro instead of using the FEAT_MENU guard.