### PR TITLE
Remove VIM_BACKTICK

### DIFF
--- a/src/feature.h
+++ b/src/feature.h
@@ -170,10 +170,6 @@
 # define FEAT_KEYMAP
 #endif
 
-#ifdef FEAT_NORMAL
-# define VIM_BACKTICK		// internal backtick expansion
-#endif
-
 /*
  * +linebreak		'showbreak', 'breakat' and 'linebreak' options.
  *			Also 'numberwidth'.

--- a/src/filepath.c
+++ b/src/filepath.c
@@ -3429,8 +3429,6 @@ match_suffix(char_u *fname)
     return (setsuflen != 0);
 }
 
-#ifdef VIM_BACKTICK
-
 /*
  * Return TRUE if we can expand this backtick thing here.
  */
@@ -3497,7 +3495,6 @@ expand_backtick(
     vim_free(buffer);
     return cnt;
 }
-#endif // VIM_BACKTICK
 
 #if defined(MSWIN)
 /*
@@ -4105,9 +4102,7 @@ gen_expand_wildcards(
     for (i = 0; i < num_pat; i++)
     {
 	if (has_special_wildchar(pat[i])
-# ifdef VIM_BACKTICK
 		&& !(vim_backtick(pat[i]) && pat[i][1] == '=')
-# endif
 	   )
 	    return mch_expand_wildcards(num_pat, pat, num_file, file, flags);
     }
@@ -4125,7 +4120,6 @@ gen_expand_wildcards(
 	add_pat = -1;
 	p = pat[i];
 
-#ifdef VIM_BACKTICK
 	if (vim_backtick(p))
 	{
 	    add_pat = expand_backtick(&ga, p, flags);
@@ -4133,7 +4127,6 @@ gen_expand_wildcards(
 		retval = FAIL;
 	}
 	else
-#endif
 	{
 	    /*
 	     * First expand environment variables, "~/" and "~user/".

--- a/src/misc1.c
+++ b/src/misc1.c
@@ -2388,8 +2388,7 @@ veryfast_breakcheck(void)
 }
 #endif
 
-#if defined(VIM_BACKTICK) || defined(FEAT_EVAL) \
-	|| (defined(HAVE_LOCALE_H) || defined(X_LOCALE))
+#if defined(FEAT_EVAL) || (defined(HAVE_LOCALE_H) || defined(X_LOCALE))
 
 # ifndef SEEK_SET
 #  define SEEK_SET 0

--- a/src/os_amiga.c
+++ b/src/os_amiga.c
@@ -1683,13 +1683,7 @@ mch_has_wildcard(char_u *p)
 	if (*p == '\\' && p[1] != NUL)
 	    ++p;
 	else
-	    if (vim_strchr((char_u *)
-#ifdef VIM_BACKTICK
-				    "*?[(#$`"
-#else
-				    "*?[(#$"
-#endif
-						, *p) != NULL
+	    if (vim_strchr((char_u *)"*?[(#$`", *p) != NULL
 		    || (*p == '~' && p[1] != NUL))
 		return TRUE;
     }

--- a/src/os_mswin.c
+++ b/src/os_mswin.c
@@ -635,13 +635,7 @@ mch_has_wildcard(char_u *p)
 {
     for ( ; *p; MB_PTR_ADV(p))
     {
-	if (vim_strchr((char_u *)
-#ifdef VIM_BACKTICK
-				    "?*$[`"
-#else
-				    "?*$["
-#endif
-						, *p) != NULL
+	if (vim_strchr((char_u *)"?*$[`", *p) != NULL
 		|| (*p == '~' && p[1] != NUL))
 	    return TRUE;
     }


### PR DESCRIPTION
This would only be unset on the tiny build, but all the cases of #ifdef VIM_BACKTICK are in features already excluded in the tiny build, so effectively it doesn't really seem to do anything.

The byte size doesn't increase; before (--with-features=tiny):

	1,724,264 │ 13:43 │ /tmp/vim-sz-before/tiny-O2
	1,484,552 │ 13:44 │ /tmp/vim-sz-before/tiny-Os

After, exactly the same size:

	1,724,264 │ 13:55 │ /tmp/vim-sz-after/tiny-O2
	1,484,552 │ 13:55 │ /tmp/vim-sz-after/tiny-Os

Saves a few #ifdefs.