### PR TITLE
Fix memory leak in `heredoc_get()` in `src/evalvars.c`

### DIFF
--- a/src/evalvars.c
+++ b/src/evalvars.c
@@ -949,6 +949,7 @@ heredoc_get(exarg_T *eap, char_u *cmd, int script_get, int vim9compile)
 	    {
 		vim_free(theline);
 		vim_free(text_indent);
+		list_free(l);
 		return FAIL;
 	    }
 	    count++;


### PR DESCRIPTION
### Problem

In `heredoc_get()`, a list is allocated to store heredoc lines (lines **871–873**):

```c
l = list_alloc();
if (l == NULL)
    return NULL;
```

Later, when `vim9compile` is enabled, if `compile_all_expr_in_str()` fails the function returns early (lines **948–953**):

```c
if (compile_all_expr_in_str(str, evalstr, cctx) == FAIL)
{
    vim_free(theline);
    vim_free(text_indent);
    return FAIL;
}
```

On this early-return path, the allocated list `l` is not freed, resulting in a memory leak.

### Solution

Free `l` before returning when `compile_all_expr_in_str()` fails. The fix is included in this commit.