### PR TITLE
Fix memory leak in `expand_findfunc()` in `src/ex_docmd.c`

### DIFF
--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -7080,11 +7080,17 @@ expand_findfunc(char_u *pat, char_u ***files, int *numMatches)
 
     len = list_len(l);
     if (len == 0)	    // empty List
+    {
+	list_free(l);
 	return FAIL;
+    }
 
     *files = ALLOC_MULT(char_u *, len);
     if (*files == NULL)
+    {
+	list_free(l);
 	return FAIL;
+    }
 
     // Copy all the List items
     listitem_T *li;


### PR DESCRIPTION
### Problem

In `expand_findfunc()`, the list `l` is allocated by `call_findfunc()` (lines **7076–7079**):

```c
l = call_findfunc(pat, VVAL_TRUE);

if (l == NULL)
    return FAIL;
```

However, there are early-return paths after `l` is allocated (lines **7081–7087**):

```c
len = list_len(l);
if (len == 0)        // empty List
    return FAIL;

*files = ALLOC_MULT(char_u *, len);
if (*files == NULL)
    return FAIL;
```

On these failure paths, `l` is not freed. Since `list_free(l)` is only called on the success path near the end of the function, `l` is leaked when returning early.

### Solution

Free `l` before returning on error paths. The fix is included in this commit.