### PR TITLE
Fix memory leak in `list_extend_func()` in `src/list.c`

### DIFF
--- a/src/list.c
+++ b/src/list.c
@@ -3025,8 +3025,7 @@ list_extend_func(
 	{
 	    before = (long)tv_get_number_chk(&argvars[2], &error);
 	    if (error)
-		return;		// type error; errmsg already given
-
+		goto cleanup;		// type error; errmsg already given
 	    if (before == l1->lv_len)
 		item = NULL;
 	    else
@@ -3035,7 +3034,7 @@ list_extend_func(
 		if (item == NULL)
 		{
 		    semsg(_(e_list_index_out_of_range_nr), before);
-		    return;
+		    goto cleanup;
 		}
 	    }
 	}
@@ -3043,7 +3042,7 @@ list_extend_func(
 	    item = NULL;
 	if (type != NULL && check_typval_arg_type(
 		    type, &argvars[1], func_name, 2) == FAIL)
-	    return;
+	    goto cleanup;
 	list_extend(l1, l2, item);
 
 	if (is_new)
@@ -3054,6 +3053,11 @@ list_extend_func(
 	}
 	else
 	    copy_tv(&argvars[0], rettv);
+	return;
+
+cleanup:
+	if (is_new)
+	    list_unref(l1);
     }
 }
 


### PR DESCRIPTION
### Problem

In `list_extend_func()`, when `is_new` is true, a new list is created using `list_copy()` (lines **3017–3022**):

```c
if (is_new)
{
    l1 = list_copy(l1, FALSE, TRUE, get_copyID());
    if (l1 == NULL)
        return;
}
```

After this allocation, several error paths may return early:

- When the third argument has a type error (lines **3026–3028**):
```c
before = (long)tv_get_number_chk(&argvars[2], &error);
if (error)
    return;  // type error; errmsg already given
```

- When `list_find()` fails (lines **3034–3039**):
```c
item = list_find(l1, before);
if (item == NULL)
{
    semsg(_(e_list_index_out_of_range_nr), before);
    return;
}
```

- When `check_typval_arg_type()` fails (lines **3044–3046**):
```c
if (type != NULL && check_typval_arg_type(
        type, &argvars[1], func_name, 2) == FAIL)
    return;
```

If `is_new` is true, `l1` refers to the newly allocated list. Returning early without releasing it causes the copied list to leak.

### Solution

Release the copied list before returning on these error paths when `is_new` is true. The fix is included in this commit.