### PR TITLE
Avoid redundant ptr2len() call in byteidx() and utf16idx()

### DIFF
--- a/src/strings.c
+++ b/src/strings.c
@@ -1107,8 +1107,10 @@ byteidx_common(typval_T *argvars, typval_T *rettv, int comp)
 	    int c = (clen > 1) ? utf_ptr2char(t) : *t;
 	    if (c > 0xFFFF)
 		idx--;
+	    if (idx > 0)
+		t += clen;
 	}
-	if (idx > 0)
+	else if (idx > 0)
 	    t += ptr2len(t);
     }
     rettv->vval.v_number = (varnumber_T)(t - str);
@@ -2243,7 +2245,7 @@ f_utf16idx(typval_T *argvars, typval_T *rettv)
 	int c = (clen > 1) ? utf_ptr2char(p) : *p;
 	if (c > 0xFFFF)
 	    len++;
-	p += ptr2len(p);
+	p += clen;
 	if (charidx)
 	    idx--;
     }


### PR DESCRIPTION
byteidx() with utf16 flag and utf16idx() call ptr2len() twice per loop iteration: once to check for surrogate pairs and once to advance the pointer. Reuse the result from the first call.

### Benchmark

100,000 iterations, mixed ASCII/CJK/emoji strings:

| | short (48B) | long (303B) | vlong (2903B) |
|---|---|---|---|
| **byteidx** before | 0.2734s | 0.3263s | 1.0804s |
| **byteidx** after | 0.2522s | 0.2938s | 0.7150s |
| speedup | 1.08x | 1.11x | **1.51x** |
| **utf16idx** before | 0.2190s | 0.3164s | 1.5950s |
| **utf16idx** after | 0.2298s | 0.2898s | 1.0019s |
| speedup | ~1.0x | 1.09x | **1.59x** |