### PR TITLE
tests: Skip wayland tests when X11 is not available or $XDG_RUNTIME_D…

### DIFF
--- a/src/testdir/test_wayland.vim
+++ b/src/testdir/test_wayland.vim
@@ -6,6 +6,7 @@ CheckUnix
 CheckFeature job
 CheckWaylandCompositor
 CheckNotGui
+CheckEnv XDG_RUNTIME_DIR
 
 if !executable('wl-paste') || !executable('wl-copy')
   throw "Skipped: wl-clipboard is not available"
@@ -57,6 +58,10 @@ endfunc
 
 func s:CheckClientserver()
   CheckFeature clientserver
+
+  if has('x11')
+      CheckEnv DISPLAY
+  endif
 
   if has('socketserver') && !has('x11')
     if v:servername == ""


### PR DESCRIPTION
…IR is not defined

It throws a lot of errors when running the test suite when neither X11 nor Wayland is possible

```
14 FAILED:
command line..script /home/chrisbra/code/vim-src/src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_no_wayland_connect_cmd_flag[9]..WaitForAssert[2]..<SNR>4_WaitForCommon[11]..<lambda>4 line 1: Pattern 'WLFLAGVIMTEST' does not match ''
Caught exception in Test_no_wayland_connect_cmd_flag(): Vim(let):E240: No connection to the X server @ command line..script /home/chrisbra/code/vim-src/src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_no_wayland_connect_cmd_flag[11]..WaitForAssert[2]..<SNR>4_WaitForCommon[11]..<lambda>5, line 1
Found errors in Test_wayland_autoselect_works():
command line..script /home/chrisbra/code/vim-src/src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_wayland_autoselect_works[23]..WaitForAssert[2]..<SNR>4_WaitForCommon[11]..<lambda>7 line 1: Pattern 'WLVIMTEST' does not match ''
Caught exception in Test_wayland_autoselect_works(): Vim(call):E240: No connection to the X server @ command line..script /home/chrisbra/code/vim-src/src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_wayland_autoselect_works, line 25
Found errors in Test_wayland_bad_environment():
command line..script /home/chrisbra/code/vim-src/src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_wayland_bad_environment[17]..WaitForAssert[2]..<SNR>4_WaitForCommon[11]..<lambda>9 line 1: Pattern 'WLVIMTEST' does not match ''
Caught exception in Test_wayland_bad_environment(): Vim(let):E240: No connection to the X server @ command line..script /home/chrisbra/code/vim-src/src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_wayland_bad_environment[19]..WaitForAssert[2]..<SNR>4_WaitForCommon[11]..<lambda>10, line 1
Found errors in Test_wayland_become_inactive():
command line..script /home/chrisbra/code/vim-src/src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_wayland_become_inactive[12]..WaitForAssert[2]..<SNR>4_WaitForCommon[11]..<lambda>12 line 1: Pattern 'WLLOSEVIMTEST' does not match ''
Caught exception in Test_wayland_become_inactive(): Vim(call):E240: No connection to the X server @ command line..script /home/chrisbra/code/vim-src/src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_wayland_become_inactive, line 14
Found errors in Test_wayland_handle_large_data():
command line..script /home/chrisbra/code/vim-src/src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_wayland_handle_large_data line 9: Expected '\[c occurs 1000000 times]' but got ''
command line..script /home/chrisbra/code/vim-src/src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_wayland_handle_large_data line 13: Expected '\[c occurs 1000000 times]' but got 'error: XDG_RUNTIME_DIR is invalid or not set in the environment.\nFailed to connect to a Wayland server: No such file or directory\nNote: WAYLAND_DISPLAY is set to wayland-0\nNote: XDG_RUNTIME_DIR is unset\n'
Found errors in Test_wayland_lost_selection():
command line..script /home/chrisbra/code/vim-src/src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_wayland_lost_selection line 6: Expected 'regular' but got 'primary'
command line..script /home/chrisbra/code/vim-src/src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_wayland_lost_selection line 12: Expected 'overwrite' but got 'primary'
command line..script /home/chrisbra/code/vim-src/src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_wayland_lost_selection line 13: Expected 'overwrite' but got 'primary'
command line..script /home/chrisbra/code/vim-src/src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_wayland_lost_selection line 18: Expected 'regular' but got 'primary'
Found errors in Test_wayland_mime_types_correct():
command line..script /home/chrisbra/code/vim-src/src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_wayland_mime_types_correct line 18: 'error: XDG_RUNTIME_DIR is invalid or not set in the environment.' is not a supported mime type
command line..script /home/chrisbra/code/vim-src/src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_wayland_mime_types_correct line 18: 'Failed to connect to a Wayland server: No such file or directory' is not a supported mime type
command line..script /home/chrisbra/code/vim-src/src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_wayland_mime_types_correct line 18: 'Note: WAYLAND_DISPLAY is set to wayland-0' is not a supported mime type
command line..script /home/chrisbra/code/vim-src/src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_wayland_mime_types_correct line 18: 'Note: XDG_RUNTIME_DIR is unset' is not a supported mime type
command line..script /home/chrisbra/code/vim-src/src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_wayland_mime_types_correct line 26: 'error: XDG_RUNTIME_DIR is invalid or not set in the environment.' is not a supported mime type
command line..script /home/chrisbra/code/vim-src/src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_wayland_mime_types_correct line 26: 'Failed to connect to a Wayland server: No such file or directory' is not a supported mime type
command line..script /home/chrisbra/code/vim-src/src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_wayland_mime_types_correct line 26: 'Note: WAYLAND_DISPLAY is set to wayland-0' is not a supported mime type
command line..script /home/chrisbra/code/vim-src/src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_wayland_mime_types_correct line 26: 'Note: XDG_RUNTIME_DIR is unset' is not a supported mime type
Found errors in Test_wayland_no_mime_types_supported():
command line..script /home/chrisbra/code/vim-src/src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_wayland_no_mime_types_supported line 4: Expected 'tester' but got 'text'
command line..script /home/chrisbra/code/vim-src/src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_wayland_no_mime_types_supported line 7: Expected '' but got 'text'
command line..script /home/chrisbra/code/vim-src/src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_wayland_no_mime_types_supported line 8: command did not fail: put +
Found errors in Test_wayland_paste():
command line..script /home/chrisbra/code/vim-src/src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_wayland_paste line 9: Expected 'TESTING' but got 'text'
command line..script /home/chrisbra/code/vim-src/src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_wayland_paste line 14: Expected ['LINE1', 'LINE2', 'LINE3'] but got ['text']
command line..script /home/chrisbra/code/vim-src/src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_wayland_paste line 23: Expected 'TESTING' but got 'text'
command line..script /home/chrisbra/code/vim-src/src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_wayland_paste line 28: Expected ['LINE1', 'LINE2', 'LINE3'] but got ['text']
command line..script /home/chrisbra/code/vim-src/src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_wayland_paste line 34: command did not fail: put +
Found errors in Test_wayland_paste_vim_format_correct():
command line..script /home/chrisbra/code/vim-src/src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_wayland_paste_vim_format_correct line 17: Expected '^@text' but got 'error: XDG_RUNTIME_DIR is invalid or not set in the environment.\nFailed to connect to a Wayland server: No such file or directory\nNote: WAYLAND_DISPLAY is set to wayland-0\nNote: XDG_RUNTIME_DIR is unset\n'
command line..script /home/chrisbra/code/vim-src/src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_wayland_paste_vim_format_correct line 19: Expected '^@utf-8^@text' but got 'error: XDG_RUNTIME_DIR is invalid or not set in the environment.\nFailed to connect to a Wayland server: No such file or directory\nNote: WAYLAND_DISPLAY is set to wayland-0\nNote: XDG_RUNTIME_DIR is unset\n'
command line..script /home/chrisbra/code/vim-src/src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_wayland_paste_vim_format_correct line 22: Expected '^Atext\n' but got 'error: XDG_RUNTIME_DIR is invalid or not set in the environment.\nFailed to connect to a Wayland server: No such file or directory\nNote: WAYLAND_DISPLAY is set to wayland-0\nNote: XDG_RUNTIME_DIR is unset\n'
command line..script /home/chrisbra/code/vim-src/src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_wayland_paste_vim_format_correct line 24: Expected '^Autf-8^@text\n' but got 'error: XDG_RUNTIME_DIR is invalid or not set in the environment.\nFailed to connect to a Wayland server: No such file or directory\nNote: WAYLAND_DISPLAY is set to wayland-0\nNote: XDG_RUNTIME_DIR is unset\n'
command line..script /home/chrisbra/code/vim-src/src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_wayland_paste_vim_format_correct line 27: Expected '^Btext\n' but got 'error: XDG_RUNTIME_DIR is invalid or not set in the environment.\nFailed to connect to a Wayland server: No such file or directory\nNote: WAYLAND_DISPLAY is set to wayland-0\nNote: XDG_RUNTIME_DIR is unset\n'
command line..script /home/chrisbra/code/vim-src/src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_wayland_paste_vim_format_correct line 29: Expected '^Butf-8^@text\n' but got 'error: XDG_RUNTIME_DIR is invalid or not set in the environment.\nFailed to connect to a Wayland server: No such file or directory\nNote: WAYLAND_DISPLAY is set to wayland-0\nNote: XDG_RUNTIME_DIR is unset\n'
command line..script /home/chrisbra/code/vim-src/src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_wayland_paste_vim_format_correct line 33: Expected '^@text' but got 'error: XDG_RUNTIME_DIR is invalid or not set in the environment.\nFailed to connect to a Wayland server: No such file or directory\nNote: WAYLAND_DISPLAY is set to wayland-0\nNote: XDG_RUNTIME_DIR is unset\n'
command line..script /home/chrisbra/code/vim-src/src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_wayland_paste_vim_format_correct line 35: Expected '^@utf-8^@text' but got 'error: XDG_RUNTIME_DIR is invalid or not set in the environment.\nFailed to connect to a Wayland server: No such file or directory\nNote: WAYLAND_DISPLAY is set to wayland-0\nNote: XDG_RUNTIME_DIR is unset\n'
command line..script /home/chrisbra/code/vim-src/src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_wayland_paste_vim_format_correct line 38: Expected '^Atext\n' but got 'error: XDG_RUNTIME_DIR is invalid or not set in the environment.\nFailed to connect to a Wayland server: No such file or directory\nNote: WAYLAND_DISPLAY is set to wayland-0\nNote: XDG_RUNTIME_DIR is unset\n'
command line..script /home/chrisbra/code/vim-src/src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_wayland_paste_vim_format_correct line 40: Expected '^Autf-8^@text\n' but got 'error: XDG_RUNTIME_DIR is invalid or not set in the environment.\nFailed to connect to a Wayland server: No such file or directory\nNote: WAYLAND_DISPLAY is set to wayland-0\nNote: XDG_RUNTIME_DIR is unset\n'
command line..script /home/chrisbra/code/vim-src/src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_wayland_paste_vim_format_correct line 43: Expected '^Btext\n' but got 'error: XDG_RUNTIME_DIR is invalid or not set in the environment.\nFailed to connect to a Wayland server: No such file or directory\nNote: WAYLAND_DISPLAY is set to wayland-0\nNote: XDG_RUNTIME_DIR is unset\n'
command line..script /home/chrisbra/code/vim-src/src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_wayland_paste_vim_format_correct line 45: Expected '^Butf-8^@text\n' but got 'error: XDG_RUNTIME_DIR is invalid or not set in the environment.\nFailed to connect to a Wayland server: No such file or directory\nNote: WAYLAND_DISPLAY is set to wayland-0\nNote: XDG_RUNTIME_DIR is unset\n'
Found errors in Test_wayland_plus_star_not_same():
command line..script /home/chrisbra/code/vim-src/src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_wayland_plus_star_not_same line 7: Expected not equal to 'text'
command line..script /home/chrisbra/code/vim-src/src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_wayland_plus_star_not_same line 13: Expected not equal to 'error: XDG_RUNTIME_DIR is invalid or not set in the environment.\nFailed to connect to a Wayland server: No such file or directory\nNote: WAYLAND_DISPLAY is set to wayland-0\nNote: XDG_RUNTIME_DIR is unset\n'
Found errors in Test_wayland_seat():
command line..script /home/chrisbra/code/vim-src/src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_wayland_seat line 8: Expected 'TESTING' but got 'PRIMARY'
command line..script /home/chrisbra/code/vim-src/src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_wayland_seat line 12: Expected '' but got 'PRIMARY'
command line..script /home/chrisbra/code/vim-src/src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_wayland_seat line 16: Expected '' but got 'PRIMARY'
command line..script /home/chrisbra/code/vim-src/src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_wayland_seat line 20: Expected 'TESTING' but got 'PRIMARY'
Found errors in Test_wayland_startup():
command line..script /home/chrisbra/code/vim-src/src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_wayland_startup[9]..WaitForAssert[2]..<SNR>4_WaitForCommon[11]..<lambda>18 line 1: Pattern 'WLVIMTEST' does not match ''
Caught exception in Test_wayland_startup(): Vim(let):E240: No connection to the X server @ command line..script /home/chrisbra/code/vim-src/src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_wayland_startup[11]..WaitForAssert[2]..<SNR>4_WaitForCommon[11]..<lambda>19, line 1
Found errors in Test_wayland_yank():
command line..script /home/chrisbra/code/vim-src/src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_wayland_yank line 8: Expected 'testing\n' but got 'error: XDG_RUNTIME_DIR is invalid or not set in the environment.\nFailed to connect to a Wayland server: No such file or directory\nNote: WAYLAND_DISPLAY is set to wayland-0\nNote: XDG_RUNTIME_DIR is unset\n'
command line..script /home/chrisbra/code/vim-src/src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_wayland_yank line 14: Expected 'testing\ntesting2\ntesting3\n' but got 'error: XDG_RUNTIME_DIR is invalid or not set in the environment.\nFailed to connect to a Wayland server: No such file or directory\nNote: WAYLAND_DISPLAY is set to wayland-0\nNote: XDG_RUNTIME_DIR is unset\n'
command line..script /home/chrisbra/code/vim-src/src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_wayland_yank line 24: Expected 'testing\n' but got 'error: XDG_RUNTIME_DIR is invalid or not set in the environment.\nFailed to connect to a Wayland server: No such file or directory\nNote: WAYLAND_DISPLAY is set to wayland-0\nNote: XDG_RUNTIME_DIR is unset\n'
command line..script /home/chrisbra/code/vim-src/src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_wayland_yank line 30: Expected 'testing\ntesting2\ntesting3\n' but got 'error: XDG_RUNTIME_DIR is invalid or not set in the environment.\nFailed to connect to a Wayland server: No such file or directory\nNote: WAYLAND_DISPLAY is set to wayland-0\nNote: XDG_RUNTIME_DIR is unset\n'
SKIPPED Test_wayland_connection_lost(): Error: Wayland compositor exited when starting up
SKIPPED Test_wayland_focus_steal(): seat does not have keyboard
SKIPPED Test_wayland_lost_selection_focus_steal(): seat does not have keyboard
SKIPPED Test_wayland_wlrestore(): Error: Wayland compositor exited when starting up
```