### PR TITLE
Fix incorrect stdout redirection to Visual Studio Output window in ConPTY terminal

### DIFF
--- a/src/terminal.c
+++ b/src/terminal.c
@@ -7134,6 +7134,15 @@ conpty_term_and_job_init(
 
     term->tl_siex.StartupInfo.cb = sizeof(term->tl_siex);
 
+    // Explicitly invalidate std handles to prevent inheritance of
+    // the debugger's stdout (e.g., in Visual Studio debugging sessions),
+    // which could cause job output to go to the debugger instead of
+    // the intended ConPTY, even with bInheritHandles set to FALSE in CreateProcess.
+    term->tl_siex.StartupInfo.dwFlags = STARTF_USESTDHANDLES;
+    term->tl_siex.StartupInfo.hStdInput = INVALID_HANDLE_VALUE;
+    term->tl_siex.StartupInfo.hStdOutput = INVALID_HANDLE_VALUE;
+    term->tl_siex.StartupInfo.hStdError = INVALID_HANDLE_VALUE;
+
     // Set up pipe inheritance safely: Vista or later.
     pInitializeProcThreadAttributeList(NULL, 1, 0, &breq);
     term->tl_siex.lpAttributeList = alloc(breq);


### PR DESCRIPTION
When launching GVim from within Visual Studio and opening a ConPTY-based terminal, the standard output of the terminal is incorrectly redirected to the Visual Studio Output window instead of the terminal itself.

<img width="1920" height="1040" alt="untitled" src="https://github.com/user-attachments/assets/916ac590-c52e-4ea3-b8fd-d9b21e86e9f1" />

This PR addresses the issue by specifying `STARTF_USESTDHANDLES` in `StartupInfo` and explicitly setting the standard input/output/error handles to `INVALID_HANDLE_VALUE`.

While I couldn't find any official Microsoft documentation explicitly covering this behavior, I've verified that several major terminal emulators (Windows Terminal, Alacritty, and WezTerm) use this same approach to handle similar cases.