### PR TITLE
runtime(toml): fix highlights of dates and escapes

### DIFF
--- a/runtime/syntax/toml.vim
+++ b/runtime/syntax/toml.vim
@@ -9,7 +9,8 @@ if exists('b:current_syntax')
   finish
 endif
 
-syn match tomlEscape /\\[btnfr"/\\]/ display contained
+syn match tomlEscape /\\[betnfr"/\\]/ display contained
+syn match tomlEscape /\\x\x\{2}/ contained
 syn match tomlEscape /\\u\x\{4}/ contained
 syn match tomlEscape /\\U\x\{8}/ contained
 syn match tomlLineEscape /\\$/ contained
@@ -37,8 +38,8 @@ syn match tomlBoolean /\<\%(true\|false\)\>/ display
 
 " https://tools.ietf.org/html/rfc3339
 syn match tomlDate /\d\{4\}-\d\{2\}-\d\{2\}/ display
-syn match tomlDate /\d\{2\}:\d\{2\}:\d\{2\}\%(\.\d\+\)\?/ display
-syn match tomlDate /\d\{4\}-\d\{2\}-\d\{2\}[T ]\d\{2\}:\d\{2\}:\d\{2\}\%(\.\d\+\)\?\%(Z\|[+-]\d\{2\}:\d\{2\}\)\?/ display
+syn match tomlDate /\d\{2\}:\d\{2\}\%(:\d\{2\}\%(\.\d\+\)\?\)\?/ display
+syn match tomlDate /\d\{4\}-\d\{2\}-\d\{2\}[Tt ]\d\{2\}:\d\{2\}\%(:\d\{2\}\%(\.\d\+\)\?\)\?\%([Zz]\|[+-]\d\{2\}:\d\{2\}\)\?/ display
 
 syn match tomlDotInKey /\v[^.]+\zs\./ contained display
 syn match tomlKey /\v(^|[{,])\s*\zs[[:alnum:]._-]+\ze\s*\=/ contains=tomlDotInKey display


### PR DESCRIPTION
From upstream:
https://github.com/cespare/vim-toml/pull/69
https://github.com/cespare/vim-toml/pull/70