### PR TITLE
fix(textformat): don't swallow "space" with auto-formatting enabled

### DIFF
--- a/src/testdir/test_textformat.vim
+++ b/src/testdir/test_textformat.vim
@@ -1155,6 +1155,32 @@ func Test_fo_a_w()
   %bw!
 endfunc
 
+" Test that auto-format ('a' flag) preserves spaces typed in the middle of a line
+func Test_fo_a_midline_space()
+  new
+  let lines = [
+    \ 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa it but',
+    \ 'Lorem Ipsum is simply dummy text of the printing and typesetting dasddd',
+    \ 'industry.',
+    \ ]
+  call setline(1, lines)
+  set fo=ta tw=70
+
+  " Prevent INPUT_BUFLEN batching so auto_format runs between keystrokes
+  autocmd InsertCharPre * " nothing
+
+  " Position at 't' of 'it' (col 68) and type space then Z
+  call cursor(1, 68)
+  call feedkeys("a Z\<Esc>", 'xt')
+
+  " The space between 'it' and 'Z' must be preserved
+  call assert_match('it Z', getline(1))
+
+  autocmd! InsertCharPre
+  set fo& tw&
+  bw!
+endfunc
+
 " Test for formatting lines using gq in visual mode
 func Test_visual_gq_format()
   new

--- a/src/textformat.c
+++ b/src/textformat.c
@@ -703,6 +703,24 @@ auto_format(
 	curwin->w_cursor = pos;
     }
 
+    // Also skip formatting when the user just typed whitespace in the
+    // middle of the line.  Reformatting would join all paragraph lines and
+    // re-wrap, consuming the space at the line break point via
+    // OPENLINE_DELSPACES.  By deferring, the next non-whitespace character
+    // will be inserted adjacent to the space, keeping it protected from
+    // being consumed at a line break.  auto_format() will then reformat
+    // properly on the next keystroke.
+    if (*old != NUL && !trailblank && !wasatend && pos.col > 0
+	    && (State & MODE_INSERT))
+    {
+	char_u *line = ml_get_curline();
+	if (WHITECHAR(line[pos.col - 1]))
+	{
+	    curwin->w_cursor = pos;
+	    return;
+	}
+    }
+
     // With the 'c' flag in 'formatoptions' and 't' missing: only format
     // comments.
     if (has_format_option(FO_WRAP_COMS) && !has_format_option(FO_WRAP)


### PR DESCRIPTION
Problem: With auto paragraph formatting enabled, when a user makes an attempt to add a new word before the end of a line and with the following space bringing the line with over 'textwidth', the space ends up just getting swallowed by the editor, which is utterly confusing behavior.

Solution: Detect such a constellation and correct the behavior.