### PR TITLE
Add support for in-band window resize events

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -9096,6 +9096,24 @@ A jump table for the options with a short description can be found at |Q_op|.
 <
 	NOTE: This option is reset when 'compatible' is set.
 
+						*'termresize* *'trz'*
+'termresize' 'trz'	number	(default "")
+			global
+			{only available in Unix, does not work in the GUI}
+	Determines the method to use for detecting window resize events,
+	possible values are:
+	    "sigwinch":	    Use the SIGWINCH signal.
+	    "inband":	    Receive resize events from the terminal via escape
+			    sequences (recommended if supported by terminal).
+	    "":		    Automatically choose depending on terminal.
+
+	The SIGWINCH handler is always available.  If set to "inband" and the
+	terminal does not support in-band window resize events, then the
+	SIGWINCH handler will be used instead as a fallback.  If set to ""
+	(empty option), then "inband" will be used if Vim detects that the
+	terminal supports it, otherwise "sigwinch".
+
+
 						*'termsync'* *'tsy'*
 'termsync' 'tsy'	boolean (default off)
 			global

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -1237,6 +1237,7 @@ $quote	eval.txt	/*$quote*
 'termbidi'	options.txt	/*'termbidi'*
 'termencoding'	options.txt	/*'termencoding'*
 'termguicolors'	options.txt	/*'termguicolors'*
+'termresize	options.txt	/*'termresize*
 'termsync'	options.txt	/*'termsync'*
 'termwinkey'	options.txt	/*'termwinkey'*
 'termwinscroll'	options.txt	/*'termwinscroll'*
@@ -1269,6 +1270,7 @@ $quote	eval.txt	/*$quote*
 'tplo'	options.txt	/*'tplo'*
 'tpm'	options.txt	/*'tpm'*
 'tr'	options.txt	/*'tr'*
+'trz'	options.txt	/*'trz'*
 'ts'	options.txt	/*'ts'*
 'tsl'	options.txt	/*'tsl'*
 'tsr'	options.txt	/*'tsr'*

--- a/runtime/optwin.vim
+++ b/runtime/optwin.vim
@@ -385,6 +385,10 @@ call <SID>AddOption("window", gettext("number of lines to scroll for CTRL-F and 
 call append("$", " \tset window=" . &window)
 call <SID>AddOption("lazyredraw", gettext("don't redraw while executing macros"))
 call <SID>BinOptionG("lz", &lz)
+if has("unix")
+  call <SID>AddOption("termresize", gettext("configure method of receiving terminal size changes"))
+  call <SID>BinOptionG("trz", &trz)
+endif
 call <SID>AddOption("termsync", gettext("enable terminal sync mode"))
 call <SID>BinOptionG("tsy", &tsy)
 if has("reltime")

--- a/src/gui.c
+++ b/src/gui.c
@@ -78,6 +78,9 @@ gui_start(char_u *arg UNUSED)
 	cursor_on();			// needed for ":gui" in .vimrc
     full_screen = FALSE;
 
+    // If GUI fails to start, then we will recover afterwards
+    term_disable_dec();
+
 #ifdef GUI_MAY_FORK
     ++recursive;
     /*
@@ -141,6 +144,9 @@ gui_start(char_u *arg UNUSED)
 	termcapinit(old_term);
 	settmode(TMODE_RAW);		// restart RAW mode
 	set_title_defaults();		// set 'title' and 'icon' again
+#ifdef UNIX
+	term_set_win_resize(true);
+#endif
 #if defined(GUI_MAY_SPAWN) && defined(EXPERIMENTAL_GUI_CMD)
 	if (msg != NULL)
 	    emsg(msg);
@@ -148,11 +154,8 @@ gui_start(char_u *arg UNUSED)
     }
 #ifdef HAVE_CLIPMETHOD
     else
-    {
 	// Reset clipmethod to CLIPMETHOD_NONE
 	choose_clipmethod();
-	term_set_sync_output(TERM_SYNC_OUTPUT_OFF);
-    }
 #endif
 
 #if defined(FEAT_SOCKETSERVER) && defined(FEAT_GUI_GTK)

--- a/src/main.c
+++ b/src/main.c
@@ -893,7 +893,7 @@ vim_main2(void)
 
     may_req_bg_color();
 
-    may_req_sync_output();
+    may_req_dec_setting();
 # endif
 
     // start in insert mode
@@ -1857,7 +1857,7 @@ getout(int exitval)
     free_cmd_argsW();
 #endif
 
-    term_set_sync_output(TERM_SYNC_OUTPUT_OFF);
+    term_disable_dec();
 
     mch_exit(exitval);
 }

--- a/src/option.h
+++ b/src/option.h
@@ -1035,6 +1035,9 @@ EXTERN char_u	*p_tenc;	// 'termencoding'
 #ifdef FEAT_TERMGUICOLORS
 EXTERN int	p_tgc;		// 'termguicolors'
 #endif
+#ifdef UNIX
+EXTERN char_u	*p_trz;		// 'termresize'
+#endif
 EXTERN int	p_tsy;		// 'termsync'
 #ifdef FEAT_TERMINAL
 EXTERN long	p_twsl;		// 'termwinscroll'

--- a/src/optiondefs.h
+++ b/src/optiondefs.h
@@ -2661,6 +2661,15 @@ static struct vimoption options[] =
 			    {(char_u *)FALSE, (char_u *)FALSE}
 #endif
 			    SCTX_INIT},
+    {"termresize", "trz", P_STRING|P_VI_DEF,
+#ifdef UNIX
+			    (char_u *)&p_trz, PV_NONE, did_set_termresize, expand_set_termresize,
+			    {(char_u *)"", (char_u *)0}
+#else
+			    (char_u *)NULL, PV_NONE, NULL, NULL,
+			    {(char_u *)NULL, (char_u *)0L}
+#endif
+			    SCTX_INIT},
     {"termsync", "tsy",	    P_BOOL|P_VI_DEF,
 			    (char_u *)&p_tsy, PV_NONE, did_set_termsync, NULL,
 			    {(char_u *)FALSE, (char_u *)0L} SCTX_INIT},

--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -150,6 +150,9 @@ static char *(p_csl_values[]) = {"slash", "backslash", NULL};
 #ifdef FEAT_SIGNS
 static char *(p_scl_values[]) = {"yes", "no", "auto", "number", NULL};
 #endif
+#ifdef UNIX
+static char *(p_trz_values[]) = {"inband", "sigwinch", "", NULL};
+#endif
 #if defined(MSWIN) && defined(FEAT_TERMINAL)
 static char *(p_twt_values[]) = {"winpty", "conpty", "", NULL};
 #endif
@@ -4464,6 +4467,37 @@ did_set_term_option(optset_T *args)
 
     return NULL;
 }
+
+
+#ifdef UNIX
+/*
+ * The 'termresize' option is changed.
+ */
+    char *
+did_set_termresize(optset_T *args UNUSED)
+{
+    // If empty or "inband", then attempt to enable in-band resize events.
+    if (*p_trz == NUL || STRCMP(p_trz, "inband") == 0)
+	term_set_win_resize(true);
+    else if (STRCMP(p_trz, "sigwinch") == 0)
+	term_set_win_resize(false);
+    else
+	return e_invalid_argument;
+
+    return NULL;
+}
+
+    int
+expand_set_termresize(optexpand_T *args, int *numMatches, char_u ***matches)
+{
+    return expand_set_opt_string(
+	    args,
+	    p_trz_values,
+	    ARRAY_LENGTH(p_trz_values) - 1,
+	    numMatches,
+	    matches);
+}
+#endif
 
 #if defined(FEAT_TERMINAL)
 /*

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -1570,6 +1570,14 @@ mch_init(void)
 #endif
 }
 
+    void
+set_sigwinch_handler(void)
+{
+#if defined(SIGWINCH)
+    mch_signal(SIGWINCH, sig_winch);
+#endif
+}
+
     static void
 set_signals(void)
 {

--- a/src/proto/optionstr.pro
+++ b/src/proto/optionstr.pro
@@ -180,6 +180,8 @@ char *did_set_tagcase(optset_T *args);
 int expand_set_tagcase(optexpand_T *args, int *numMatches, char_u ***matches);
 char *did_set_term(optset_T *args);
 char *did_set_term_option(optset_T *args);
+char *did_set_termresize(optset_T *args);
+int expand_set_termresize(optexpand_T *args, int *numMatches, char_u ***matches);
 char *did_set_termwinkey(optset_T *args);
 char *did_set_termwinsize(optset_T *args);
 char *did_set_termwintype(optset_T *args);

--- a/src/proto/os_unix.pro
+++ b/src/proto/os_unix.pro
@@ -10,6 +10,7 @@ void mch_delay(long msec, int flags);
 int mch_stackcheck(char *p);
 void mch_suspend(void);
 void mch_init(void);
+void set_sigwinch_handler(void);
 void reset_signals(void);
 int vim_handle_signal(int sig);
 int mch_check_win(int argc, char **argv);

--- a/src/proto/term.pro
+++ b/src/proto/term.pro
@@ -96,6 +96,8 @@ void swap_tcap(void);
 void ansi_color2rgb(int nr, char_u *r, char_u *g, char_u *b, char_u *ansi_idx);
 void cterm_color2rgb(int nr, char_u *r, char_u *g, char_u *b, char_u *ansi_idx);
 int term_replace_keycodes(char_u *ta_buf, int ta_len, int len_arg);
-void may_req_sync_output(void);
+void may_req_dec_setting(void);
+void term_disable_dec(void);
+void term_set_win_resize(bool state);
 void term_set_sync_output(int flags);
 /* vim: set ft=c : */

--- a/src/term.c
+++ b/src/term.c
@@ -133,6 +133,11 @@ static termrequest_T xcc_status = TERMREQUEST_INIT;
 // Request synchronized output report
 static termrequest_T sync_output_status = TERMREQUEST_INIT;
 
+#ifdef UNIX
+// Request in-band window resize events report
+static termrequest_T win_resize_status = TERMREQUEST_INIT;
+#endif
+
 #ifdef FEAT_TERMRESPONSE
 # ifdef FEAT_TERMINAL
 // Request foreground color report:
@@ -169,6 +174,9 @@ static termrequest_T *all_termrequests[] = {
     &rcs_status,
     &winpos_status,
     &sync_output_status,
+# ifdef UNIX
+    &win_resize_status,
+# endif
     NULL
 };
 
@@ -245,6 +253,13 @@ static int sync_output_setting = 0;
 // > 0: Currently batching output
 // == 0: No synchronized output
 static int sync_output_state = 0;
+
+#ifdef UNIX
+// DEC mode 2048 (in-band window resize events)
+// https://gist.github.com/rockorager/e695fb2924d36b2bcf1fff4a3704bd83
+static int win_resize_setting = 0;
+static bool win_resize_enabled = false;
+#endif
 
 /*
  * The builtin termcap entries.
@@ -5594,7 +5609,7 @@ handle_csi_function_key(
  *
  * - DA1 query response: {lead}?...;c
  *
- * - DEC mode 2026 response (synchronized output): {lead}?2026;{mode}$y
+ * - DECRPM response: {lead}?2026;{mode}$y
  *
  * Return 0 for no match, -1 for partial match, > 0 for full match.
  */
@@ -5724,8 +5739,9 @@ handle_csi(
 	key_name[1] = (int)KE_IGNORE;
     }
 
-    // DEC 2026 mode response (for 'termsync' option)
-    else if (first == '?' && trail == 'y' && argc == 2 && arg[0] == 2026)
+    // DECRPM mode 2026 or 2048.
+    else if (first == '?' && trail == 'y' && argc == 2
+	    && (arg[0] == 2026 || arg[0] == 2048))
     {
 	int setting = arg[1];
 
@@ -5735,16 +5751,43 @@ handle_csi(
 
 	if (setting >= 0 && setting <= 4)
 	{
-	    sync_output_setting = setting;
-	    LOG_TRN("Received DEC 2026 mode: %s", tp);
-	    sync_output_status.tr_progress = STATUS_GOT;
+	    LOG_TRN("Received DECRPM mode %d: %s", arg[0], tp);
 
-	    set_option_value_give_err((char_u *)"termsync",
-		    setting == 1 || setting == 2, NULL, 0);
+	    switch (arg[0])
+	    {
+		case 2026:
+		    sync_output_setting = setting;
+		    sync_output_status.tr_progress = STATUS_GOT;
+		    set_option_value_give_err((char_u *)"termsync",
+			    setting == 1 || setting == 2, NULL, 0);
+		    break;
+#ifdef UNIX
+		case 2048:
+		    win_resize_status.tr_progress = STATUS_GOT;
+		    win_resize_setting = setting;
+
+		    term_set_win_resize(true);
+		    break;
+#endif
+	    }
 	}
 	else
-	    LOG_TRN("Unknown synchronized output setting %d", setting);
+	    LOG_TRN("Unknown DECRPM mode %d setting %d", arg[0], setting);
     }
+
+#ifdef UNIX
+    // In-band window resize event
+    else if (win_resize_enabled && argc >= 3 && arg[0] == 48)
+    {
+	int height = arg[1], width = arg[2];
+
+	*slen = csi_len;
+	key_name[0] = (int)KS_EXTRA;
+	key_name[1] = (int)KE_IGNORE;
+
+	set_shellsize(width, height, true);
+    }
+#endif
 
     // Version string: Eat it when there is at least one digit and
     // it ends in 'c'
@@ -7855,26 +7898,107 @@ term_replace_keycodes(char_u *ta_buf, int ta_len, int len_arg)
 
 #ifdef FEAT_TERMRESPONSE
 /*
- * Query the setting for DEC mode 2026 (synchronized output) from the terminal.
+ * Query the setting for the following DEC modes from the terminal:
+ * - DEC mode 2026 (synchronized output)
+ * - DEC mode 2048 (window resize events)
  */
     void
-may_req_sync_output(void)
+may_req_dec_setting(void)
 {
-    if (can_get_termresponse() && starting == 0
-	    && sync_output_status.tr_progress == STATUS_GET)
+    if (can_get_termresponse() && starting == 0)
     {
-	MAY_WANT_TO_LOG_THIS;
-	LOG_TR1("Sending synchronized output request");
+	bool didit = false;
 
-	out_str((char_u *)"\033[?2026$p");
-	termrequest_sent(&sync_output_status);
+	if (sync_output_status.tr_progress == STATUS_GET)
+	{
+	    MAY_WANT_TO_LOG_THIS;
+	    LOG_TR1("Sending synchronized output request");
 
-	// check for the characters now, otherwise they might be eaten by
-	// get_keystroke()
-	out_flush();
-	(void)vpeekc_nomap();
+	    out_str((char_u *)"\033[?2026$p");
+	    termrequest_sent(&sync_output_status);
+	    didit = true;
+	}
+
+# ifdef UNIX
+	if (win_resize_status.tr_progress == STATUS_GET)
+	{
+	    MAY_WANT_TO_LOG_THIS;
+	    LOG_TR1("Sending in-band window resize events request");
+
+	    out_str((char_u *)"\033[?2048$p");
+	    termrequest_sent(&win_resize_status);
+	    didit = true;
+	}
+# endif
+
+	if (didit)
+	{
+	    // check for the characters now, otherwise they might be eaten by
+	    // get_keystroke()
+	    out_flush();
+	    (void)vpeekc_nomap();
+	}
     }
+}
+#endif
 
+/*
+ * Should be called when cleaning up terminal state.
+ */
+    void
+term_disable_dec(void)
+{
+    term_set_sync_output(TERM_SYNC_OUTPUT_OFF);
+#ifdef UNIX
+    term_set_win_resize(false);
+#endif
+    // Make sure to always flush the output buffer, because this may be called
+    // before starting the GUI
+    out_flush();
+}
+
+#ifdef UNIX
+/*
+ * Enable or disable receiving in-band window resize events from the terminal.
+ * If "state" is true, then if the terminal supports DEC mode 2048 and
+ * 'termresize' is "" or "inband", then enable it and disable the SIGWINCH
+ * signal handling. Otherwise disable the mode if it is enabled and reinstall
+ * the SIGWINCH handler.
+ */
+    void
+term_set_win_resize(bool state)
+{
+# ifdef FEAT_GUI
+    bool    in_gui = gui.in_use;
+# else
+    bool    in_gui = false;
+# endif
+
+    if (state && in_gui)
+	return;
+
+    if (!state || win_resize_setting == 0 || win_resize_setting == 4)
+    {
+	// Make sure it update internal window size if DEC mode 2048 is
+	// unavailable now.
+	if (win_resize_enabled)
+	{
+	    set_shellsize(0, 0, false);
+	    set_sigwinch_handler();
+	    out_str((char_u *)"\033[?2048l");
+	}
+	win_resize_enabled = false;
+    }
+    else if ((*p_trz == NUL || STRCMP(p_trz, "inband") == 0)
+	    && !win_resize_enabled)
+    {
+	if (win_resize_setting == 2)
+	    out_str((char_u *)"\033[?2048h");
+# ifdef SIGWINCH
+	mch_signal(SIGWINCH, SIG_DFL);
+# endif
+	win_resize_enabled = true;
+    }
 }
 #endif
 

--- a/src/testdir/test_termcodes.vim
+++ b/src/testdir/test_termcodes.vim
@@ -2966,4 +2966,73 @@ func Test_term_rgb_response()
   set t_RF= t_RB=
 endfunc
 
+" Test in-band window resize events (DEC mode 2048).
+" https://gist.github.com/rockorager/e695fb2924d36b2bcf1fff4a3704bd83
+func Test_term_win_resize()
+  CheckRunVimInTerminal
+
+  let lines =<< trim END
+  vim9script
+
+  autocmd VimResized * writefile([$"{&lines} {&columns}"], "XTestWinResizeResult")
+  END
+  call writefile(lines, 'XTestWinResize', 'D')
+  defer delete("XTestWinResizeResult")
+
+  let buf = RunVimInTerminal('-S XTestWinResize', #{rows: 15, cols: 20})
+
+  " Send status report
+  call term_sendkeys(buf, "\<Esc>[?2048;1$y")
+  call TermWait(buf)
+
+  " Resize to 50 rows 100 cols
+  call term_sendkeys(buf, "\<Esc>[48;50;100;0;0t")
+  call TermWait(buf)
+
+  call WaitForAssert({-> assert_equal(["50 100"], readfile("XTestWinResizeResult"))})
+
+  " SIGWINCH handler should be uninstalled
+  call job_stop(term_getjob(buf), 28)
+  call TermWait(buf)
+
+  call WaitForAssert({-> assert_equal(["50 100"], readfile("XTestWinResizeResult"))})
+
+  " SIGWINCH handler should be reinstalled again
+  call term_sendkeys(buf, "\<Esc>:set termresize=sigwinch\<CR>")
+  call TermWait(buf)
+
+  call WaitForAssert({-> assert_equal(["15 20"], readfile("XTestWinResizeResult"))})
+
+  call term_sendkeys(buf, "\<Esc>:set termresize=\<CR>")
+  call TermWait(buf)
+
+  call term_sendkeys(buf, "\<Esc>[48;50;30;0;0t")
+  call TermWait(buf)
+
+  call WaitForAssert({-> assert_equal(["50 30"], readfile("XTestWinResizeResult"))})
+
+  " Simulate no support for in-band window resize
+  call term_sendkeys(buf, "\<Esc>[?2048;0$y")
+  call TermWait(buf)
+
+  " Should reinstall SIGWINCH handler
+  call WaitForAssert({-> assert_equal(["15 20"], readfile("XTestWinResizeResult"))})
+
+  call term_setsize(buf, 5, 20)
+  call TermWait(buf)
+  call WaitForAssert({-> assert_equal(["5 20"], readfile("XTestWinResizeResult"))})
+
+  " Setting 'termresize' to "inband" should do nothing if support is not
+  " detected from terminal.
+  call term_sendkeys(buf, "\<Esc>:set termresize=inband\<CR>")
+  call TermWait(buf)
+
+  call term_sendkeys(buf, "\<Esc>[48;50;100;0;0t")
+  call TermWait(buf)
+
+  call WaitForAssert({-> assert_equal(["5 20"], readfile("XTestWinResizeResult"))})
+
+  call StopVimInTerminal(buf)
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/util/gen_opt_test.vim
+++ b/src/testdir/util/gen_opt_test.vim
@@ -389,6 +389,13 @@ if !has('clipboard')
 	\ ]
 endif
 
+if has('unix')
+  let test_values['termresize'] = [
+	\ ['', 'sigwinch', 'inband'],
+	\ ['xxx', 'sig']
+	\ ]
+endif
+
 " Two lists with values: values that pre- and post-processing in test.
 " Clear out t_WS: we don't want to resize the actual terminal.
 let test_prepost = {


### PR DESCRIPTION
Alternative to SIGWINCH on Unix: https://gist.github.com/rockorager/e695fb2924d36b2bcf1fff4a3704bd83. It is trivial to implement, and a good amount of terminals support it.