### PR TITLE
fix(popupwin): handle opacity=0 as fully transparent

### DIFF
--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -785,7 +785,13 @@ apply_general_options(win_T *wp, dict_T *dict)
     if (di != NULL)
     {
 	nr = dict_get_number(dict, "opacity");
-	if (nr > 0 && nr < 100)
+	if (nr == 0)
+	{
+	    // Fully transparent
+	    wp->w_popup_flags |= POPF_OPACITY;
+	    wp->w_popup_blend = 100;
+	}
+	else if (nr > 0 && nr < 100)
 	{
 	    // opacity: 1-99, partially transparent
 	    // Convert to blend (0=opaque, 100=transparent)

--- a/src/testdir/dumps/Test_popupwin_opacity_zero_01.dump
+++ b/src/testdir/dumps/Test_popupwin_opacity_zero_01.dump
@@ -1,0 +1,10 @@
+>b+0&#ffffff0|a|c|k|g|r|o|u|n|d| |t|e|x|t| |h|e|r|e| @54
+|b|a|c|k|g|r|o|u|n|d| |t|e|x|t| |h|e|r|e| @54
+|b|a|c|k|g|r|o|u|n|d| |t|e|x|t| |h|e|r|e| @54
+|b|a|c|k|g|r|o|u|n|d| |t|e|x|t| |h|e|r|e| @54
+|b|a|c|k|g|r|o|u|n|d| |t|e|x|t| |h|e|r|e| @54
+|o|p|a|c|i|t|y|u|n|d|0|t|e|x|t| |h|e|r|e| @54
+|b|a|c|k|g|r|o|u|n|d| |t|e|x|t| |h|e|r|e| @54
+|b|a|c|k|g|r|o|u|n|d| |t|e|x|t| |h|e|r|e| @54
+|b|a|c|k|g|r|o|u|n|d| |t|e|x|t| |h|e|r|e| @54
+@57|1|,|1| @10|T|o|p| 

--- a/src/testdir/dumps/Test_popupwin_opacity_zero_02.dump
+++ b/src/testdir/dumps/Test_popupwin_opacity_zero_02.dump
@@ -1,0 +1,10 @@
+>b+0&#ffffff0|a|c|k|g|r|o|u|n|d| |t|e|x|t| |h|e|r|e| @54
+|b|a|c|k|g|r|o|u|n|d| |t|e|x|t| |h|e|r|e| @54
+|b|a|c|k|g|r|o|u|n|d| |t|e|x|t| |h|e|r|e| @54
+|b|a|c|k|g|r|o|u|n|d| |t|e|x|t| |h|e|r|e| @54
+|b|a|c|k|g|r|o|u|n|d| |t|e|x|t| |h|e|r|e| @54
+|o|p|a|c|i|t|y|u|n|d|0|t|e|x|t| |h|e|r|e| @54
+|b|a|c|k|g|r|o|u|n|d| |t|e|x|t| |h|e|r|e| @54
+|b|a|c|k|g|r|o|u|n|d| |t|e|x|t| |h|e|r|e| @54
+|b|a|c|k|g|r|o|u|n|d| |t|e|x|t| |h|e|r|e| @54
+|0| @55|1|,|1| @10|T|o|p| 

--- a/src/testdir/test_popupwin.vim
+++ b/src/testdir/test_popupwin.vim
@@ -4835,6 +4835,33 @@ func Test_popup_opacity_100_blocks_background()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_popup_opacity_zero()
+  CheckScreendump
+
+  let lines =<< trim END
+    call setline(1, repeat(['background text here'], 10))
+    hi PopupTest guibg=blue guifg=white
+    hi Normal guibg=black guifg=white
+
+    " opacity=0: fully transparent, only text visible
+    let g:pop_id = popup_create('opacity   0', {
+        \ 'line': 6, 'col': 1,
+        \ 'highlight': 'PopupTest',
+        \ 'opacity': 0,
+        \ })
+  END
+
+  call writefile(lines, 'XtestPopupOpacityZero', 'D')
+  let buf = RunVimInTerminal('-S XtestPopupOpacityZero', #{rows: 10})
+  call VerifyScreenDump(buf, 'Test_popupwin_opacity_zero_01', {})
+
+  call TermWait(buf, 50)
+  call term_sendkeys(buf, ":echo popup_getoptions(g:pop_id)['opacity']\<CR>")
+  call VerifyScreenDump(buf, 'Test_popupwin_opacity_zero_02', {})
+
+  call StopVimInTerminal(buf)
+endfunc
+
 func Test_popup_getwininfo_tabnr()
   tab split
   let winid1 = popup_create('sup', #{tabpage: 1})


### PR DESCRIPTION
Problem: Setting opacity=0 falls through to the else branch, leaving the popup fully opaque instead of fully transparent. 

Solution: Add an explicit check for opacity=0 and set blend to 100.