### PR TITLE
Initialize w_hl in win_init functions

### DIFF
--- a/src/window.c
+++ b/src/window.c
@@ -1565,6 +1565,7 @@ win_init(win_T *newp, win_T *oldp, int flags UNUSED)
     newp->w_wrow = oldp->w_wrow;
     newp->w_fraction = oldp->w_fraction;
     newp->w_prev_fraction_row = oldp->w_prev_fraction_row;
+    newp->w_hl = NULL;
     copy_jumplist(oldp, newp);
 #ifdef FEAT_QUICKFIX
     if (flags & WSP_NEWLOC)
@@ -2521,6 +2522,7 @@ win_init_empty(win_T *wp)
     wp->w_prev_pcmark.lnum = 0;
     wp->w_prev_pcmark.col = 0;
     wp->w_topline = 1;
+    wp->w_hl = NULL;
 #ifdef FEAT_DIFF
     wp->w_topfill = 0;
 #endif


### PR DESCRIPTION
I have been experiencing this crash in Vim:
```
                  Stack trace of thread 27520:
                  #0  0x00007fdae17b34db kill (libc.so.6 + 0x3e4db)
                  #1  0x0000561c45a0551d may_core_dump (/usr/bin/vim + 0x22851d)
                  #2  0x0000561c45ba892a getout (/usr/bin/vim + 0x3cb92a)
                  #3  0x00007fdae17b32d0 n/a (libc.so.6 + 0x3e2d0)
                  #4  0x0000561c4596c96e set_highlight_attr (/usr/bin/vim + 0x18f96e)
                  #5  0x0000561c4596cd2c push_highlight_overrides (/usr/bin/vim + 0x18fd2c)
                  #6  0x0000561c45a6f9da draw_tabline (/usr/bin/vim + 0x2929da)
                  #7  0x0000561c458a92a0 update_screen (/usr/bin/vim + 0xcc2a0)
                  #8  0x0000561c458ac34c redraw_after_callback (/usr/bin/vim + 0xcf34c)
                  #9  0x0000561c45b8f271 write_to_term (/usr/bin/vim + 0x3b2271)
                  #10 0x0000561c45b93143 channel_parse_messages (/usr/bin/vim + 0x3b6143)
                  #11 0x0000561c4595ef30 parse_queued_messages (/usr/bin/vim + 0x181f30)
                  #12 0x0000561c45b023c5 inchar_loop (/usr/bin/vim + 0x3253c5)
                  #13 0x0000561c4595f7d8 inchar (/usr/bin/vim + 0x1827d8)
                  #14 0x0000561c4596258d vgetorpeek (/usr/bin/vim + 0x18558d)
                  #15 0x0000561c45964e2c vgetc (/usr/bin/vim + 0x187e2c)
                  #16 0x0000561c45ad5fe2 term_vgetc (/usr/bin/vim + 0x2f8fe2)
                  #17 0x0000561c45ae21ef terminal_loop.constprop.0 (/usr/bin/vim + 0x3051ef)
                  #18 0x0000561c45ba7ffd main_loop (/usr/bin/vim + 0x3caffd)
                  #19 0x0000561c45bac03f vim_main2 (/usr/bin/vim + 0x3cf03f)
                  #20 0x00007fdae179c6c1 n/a (libc.so.6 + 0x276c1)
                  #21 0x00007fdae179c7f9 __libc_start_main (libc.so.6 + 0x277f9)
                  #22 0x0000561c4584ae25 _start (/usr/bin/vim + 0x6de25)

                  Stack trace of thread 27529:
                  #0  0x00007fdae1813f32 n/a (libc.so.6 + 0x9ef32)
                  #1  0x00007fdae180839c n/a (libc.so.6 + 0x9339c)
                  #2  0x00007fdae18083e4 n/a (libc.so.6 + 0x933e4)
                  #3  0x00007fdae17b3e95 __sigtimedwait (libc.so.6 + 0x3ee95)
                  #4  0x00007fdae1817873 n/a (libc.so.6 + 0xa2873)
                  #5  0x00007fdae180b97a n/a (libc.so.6 + 0x9697a)
                  #6  0x00007fdae188f2bc n/a (libc.so.6 + 0x11a2bc)
                  ELF object binary architecture: AMD x86-64
```

Debugging the coredump, it seems that `wp->w_hl` address was corrupted or uninitialized. I only encountered this crash while using termdebug, but I couldn't find an explicit way to reproduce unfortunately.