### PR TITLE
fix intro.txt document about Neovim

### DIFF
--- a/runtime/doc/intro.txt
+++ b/runtime/doc/intro.txt
@@ -313,11 +313,11 @@ Elvis	Another Vi clone, made by Steve Kirkendall.  Very compact but isn't
 	as flexible as Vim.  Development has stalled, Elvis has left the
 	building!  Source code is freely available.
 							*Neovim*
-Neovim	A Vim clone.  Forked the Vim source in 2014 and went a different way.
-	Very much bound to github and has many more dependencies, making
-	development more complex and limiting portability.  Code has been
-	refactored, resulting in patches not being exchangeable with Vim.
-	Supports a remote GUI and integration with scripting languages.
+Neovim	A fork of Vim source from 2014 that went a different way. Very much
+	bound to GitHub and has many more dependencies, making development
+	more complex and limiting portability. Code has been refactored,
+	resulting in patches not being exchangeable with Vim. Supports remote
+	UIs and first-class Lua scripting.
 
 ==============================================================================
 4. Notation						*notation*

--- a/runtime/doc/intro.txt
+++ b/runtime/doc/intro.txt
@@ -313,10 +313,10 @@ Elvis	Another Vi clone, made by Steve Kirkendall.  Very compact but isn't
 	as flexible as Vim.  Development has stalled, Elvis has left the
 	building!  Source code is freely available.
 							*Neovim*
-Neovim	A fork of Vim source from 2014 that went a different way. Very much
+Neovim	A fork of Vim source from 2014 that went a different way.  Very much
 	bound to GitHub and has many more dependencies, making development
-	more complex and limiting portability. Code has been refactored,
-	resulting in patches not being exchangeable with Vim. Supports remote
+	more complex and limiting portability.  Code has been refactored,
+	resulting in patches not being exchangeable with Vim.  Supports remote
 	UIs and first-class Lua scripting.
 
 ==============================================================================


### PR DESCRIPTION
Just to fix some phrases:
- "A Vim clone". Neovim document says that it is not a clone, but just a fork https://neovim.io/doc/user/nvim/#nvim
- "Supports a remote GUI". Neovim supports any UI (both GUI and TUI) that implements its UI protocol, so "a" is not correct
- "Integration with scripting languages". This is true, but it is also true to Vim (which supports 8 scripting languages AFAIK), so this probably doesn't need to be said in this document. Instead, what makes Neovim unique in this "scripting languages" aspect is its first class support for Lua

I also doubt about "making development more complex", but I am not sure, so I'll leave it as-is. Perhaps @zeertzjq and @glepnir who have had many direct contributions to both Vim and Neovim will have better comments