### PR TITLE
memory leak in w_hl when reusing a popup window

### DIFF
--- a/src/window.c
+++ b/src/window.c
@@ -2522,6 +2522,8 @@ win_init_empty(win_T *wp)
     wp->w_prev_pcmark.lnum = 0;
     wp->w_prev_pcmark.col = 0;
     wp->w_topline = 1;
+    // in case it was already set
+    vim_free(wp->w_hl);
     wp->w_hl = NULL;
 #ifdef FEAT_DIFF
     wp->w_topfill = 0;


### PR DESCRIPTION
Problem:  When a popup info window is reused, win_init_empty() resets
          w_hl to NULL without freeing the previously allocated value,
          causing a memory leak (after v9.2.0113)
Solution: Free w_hl before resetting it to NULL in win_init_empty().