### PR TITLE
tests: test_normal fails

### DIFF
--- a/src/testdir/test_normal.vim
+++ b/src/testdir/test_normal.vim
@@ -4389,6 +4389,9 @@ func Test_pos_percentage_in_turkish_locale()
   CheckRunVimInTerminal
   CheckNotMac
   defer execute(':lang C')
+  if !filereadable('../po/tr.mo')
+        throw 'Skipped: tr.mo not built, run make in src/po first'
+  endif
 
   try
     let dir = expand('$VIMRUNTIME/lang/tr/')
@@ -4398,7 +4401,7 @@ func Test_pos_percentage_in_turkish_locale()
     call mkdir(target, '')
     call filecopy(tr, target .. 'vim.mo')
     lang tr_TR.UTF-8
-    let buf = RunVimInTerminal('', {'rows': 5})
+    let buf = RunVimInTerminal('', {'rows': 5, 'cols': 40})
     call term_sendkeys(buf, ":lang tr_TR.UTF-8\<cr>")
     call term_sendkeys(buf, ":put =range(1,40)\<cr>")
     call term_sendkeys(buf, ":5\<cr>")


### PR DESCRIPTION
Problem:  tests: test_normal fails
Solution: Ensure the terminal width is 40 columns and also
          check for existence of the tr.mo file