### PR TITLE
Fix memory leak and don't initialize to w_hl to NULL in win_init_empty()

### DIFF
--- a/src/window.c
+++ b/src/window.c
@@ -1565,7 +1565,11 @@ win_init(win_T *newp, win_T *oldp, int flags UNUSED)
     newp->w_wrow = oldp->w_wrow;
     newp->w_fraction = oldp->w_fraction;
     newp->w_prev_fraction_row = oldp->w_prev_fraction_row;
-    newp->w_hl = NULL;
+
+    // Not sure if this is needed, but be safe
+    remove_highlight_overrides(newp->w_hl);
+    VIM_CLEAR(newp->w_hl);
+
     copy_jumplist(oldp, newp);
 #ifdef FEAT_QUICKFIX
     if (flags & WSP_NEWLOC)
@@ -2522,7 +2526,6 @@ win_init_empty(win_T *wp)
     wp->w_prev_pcmark.lnum = 0;
     wp->w_prev_pcmark.col = 0;
     wp->w_topline = 1;
-    VIM_CLEAR(wp->w_hl);
 #ifdef FEAT_DIFF
     wp->w_topfill = 0;
 #endif


### PR DESCRIPTION
- By setting `w_hl` to NULL in `win_init_empty()`, switching to a new file (e.g. `:e file`) will clear all window local highlights for the window.

- Fix memory leak found in ASAN CI test