### PR TITLE
test_recover: Skip Test_recover_corrupted_swap_file1 on big-endian systems

### DIFF
--- a/src/testdir/test_recover.vim
+++ b/src/testdir/test_recover.vim
@@ -1,5 +1,21 @@
 " Test :recover
 
+func SetUp()
+  edit XSetUp
+  preserve
+  let sn = swapname('')
+  let b = readblob(sn)
+  bw!
+
+  " Not all fields are written in a system-independent manner.  Detect whether
+  " the test is running on a little or big-endian system.
+  " The B0_MAGIC_LONG field may be 32-bit or 64-bit, depending on the system,
+  " even though the value stored is only 32-bits.  Therefore, need to check
+  " both the high and low 32-bits to compute these values.
+  let s:little_endian = (b[1008:1011] == 0z33323130) || (b[1012:1015] == 0z33323130)
+  let s:system_64bit = s:little_endian ? (b[1012:1015] == 0z00000000) : (b[1008:1011] == 0z00000000)
+endfunc
+
 func Test_recover_root_dir()
   " This used to access invalid memory.
   split Xtest
@@ -199,17 +215,8 @@ func Test_recover_corrupted_swap_file()
   let save_b = copy(b)
   bw!
 
-  " Not all fields are written in a system-independent manner.  Detect whether
-  " the test is running on a little or big-endian system, so the correct
-  " corruption values can be set.
-  " The B0_MAGIC_LONG field may be 32-bit or 64-bit, depending on the system,
-  " even though the value stored is only 32-bits.  Therefore, need to check
-  " both the high and low 32-bits to compute these values.
-  let little_endian = (b[1008:1011] == 0z33323130) || (b[1012:1015] == 0z33323130)
-  let system_64bit = little_endian ? (b[1012:1015] == 0z00000000) : (b[1008:1011] == 0z00000000)
-
   " clear the B0_MAGIC_LONG field
-  if system_64bit
+  if s:system_64bit
     let b[1008:1015] = 0z00000000.00000000
   else
     let b[1008:1011] = 0z00000000
@@ -259,10 +266,10 @@ func Test_recover_corrupted_swap_file()
 
   " set the block number in a pointer entry to a negative number
   let b = copy(save_b)
-  if system_64bit
-    let b[4104:4111] = little_endian ? 0z00000000.00000080 : 0z80000000.00000000
+  if s:system_64bit
+    let b[4104:4111] = s:little_endian ? 0z00000000.00000080 : 0z80000000.00000000
   else
-    let b[4104:4107] = little_endian ? 0z00000080 : 0z80000000
+    let b[4104:4107] = s:little_endian ? 0z00000080 : 0z80000000
   endif
   call writefile(b, sn)
   call assert_fails('recover Xfile1', 'E312:')
@@ -281,7 +288,7 @@ func Test_recover_corrupted_swap_file()
 
   " set the number of lines in the data block to zero
   let b = copy(save_b)
-  if system_64bit
+  if s:system_64bit
     let b[8208:8215] = 0z00000000.00000000
   else
     let b[8208:8211] = 0z00000000
@@ -295,7 +302,7 @@ func Test_recover_corrupted_swap_file()
 
   " set the number of lines in the data block to a large value
   let b = copy(save_b)
-  if system_64bit
+  if s:system_64bit
     let b[8208:8215] = 0z00FFFFFF.FFFFFF00
   else
     let b[8208:8211] = 0z00FFFF00
@@ -310,7 +317,7 @@ func Test_recover_corrupted_swap_file()
 
   " use an invalid text start for the lines in a data block
   let b = copy(save_b)
-  if system_64bit
+  if s:system_64bit
     let b[8216:8219] = 0z00000000
   else
     let b[8212:8215] = 0z00000000
@@ -323,7 +330,7 @@ func Test_recover_corrupted_swap_file()
 
   " use an incorrect text end (db_txt_end) for the data block
   let b = copy(save_b)
-  let b[8204:8207] = little_endian ? 0z80000000 : 0z00000080
+  let b[8204:8207] = s:little_endian ? 0z80000000 : 0z00000080
   call writefile(b, sn)
   call assert_fails('recover Xfile1', 'E312:')
   call assert_equal('Xfile1', @%)
@@ -475,8 +482,8 @@ endfunc
 func Test_recover_corrupted_swap_file1()
   CheckUnix
   " only works correctly on 64bit Unix systems:
-  if v:sizeoflong != 8 || !has('unix')
-    throw 'Skipped: Corrupt Swap file sample requires a 64bit Unix build'
+  if !(s:system_64bit && s:little_endian && has('unix'))
+    throw 'Skipped: Corrupt Swap file sample requires a little-endian 64bit Unix build'
   endif
   " Test 1: Heap buffer-overflow
   new


### PR DESCRIPTION
The POC files were generated on 64-bit little-endian systems and
therefore are not portable to any other system type.

Extract the 64-bit / endianness detection from Test_recover_corrupted_swap_file
into a SetUp function and use that data to determine if the test should
be run.