### PR TITLE
feat(has): add support for 'android' and 'termux' feature flags

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -13104,6 +13104,7 @@ acl			Compiled with |ACL| support.
 all_builtin_terms	Compiled with all builtin terminals enabled. (always
 			true)
 amiga			Amiga version of Vim.
+android			Android version of Vim. *android*
 arabic			Compiled with Arabic support |Arabic|.
 arp			Compiled with ARP support (Amiga).
 autocmd			Compiled with autocommand support. (always true)
@@ -13274,6 +13275,7 @@ termguicolors		Compiled with true color in terminal support.
 terminal		Compiled with |terminal| support.
 terminfo		Compiled with terminfo instead of termcap.
 termresponse		Compiled with support for |t_RV| and |v:termresponse|.
+termux			Termux version of Vim. *termux*
 textobjects		Compiled with support for |text-objects|.
 textprop		Compiled with support for |text-properties|.
 tgetent			Compiled with tgetent support, able to use a termcap

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -6227,6 +6227,7 @@ alt-input	debugger.txt	/*alt-input*
 alternate-file	editing.txt	/*alternate-file*
 amiga-window	starting.txt	/*amiga-window*
 and()	builtin.txt	/*and()*
+android	builtin.txt	/*android*
 anonymous-function	eval.txt	/*anonymous-function*
 ant.vim	syntax.txt	/*ant.vim*
 ap	motion.txt	/*ap*
@@ -11077,6 +11078,7 @@ termresponse-variable	eval.txt	/*termresponse-variable*
 termrfgresp-variable	eval.txt	/*termrfgresp-variable*
 termstyleresp-variable	eval.txt	/*termstyleresp-variable*
 termu7resp-variable	eval.txt	/*termu7resp-variable*
+termux	builtin.txt	/*termux*
 ternary	eval.txt	/*ternary*
 test-functions	usr_41.txt	/*test-functions*
 test-functions-details	testing.txt	/*test-functions-details*

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -6674,6 +6674,13 @@ f_has(typval_T *argvars, typval_T *rettv)
 		0
 #endif
 		},
+	{"android",
+#ifdef __ANDROID__
+		1
+#else
+		0
+#endif
+		},
 	{"arp",
 #if defined(AMIGA) && defined(FEAT_ARP)
 		1
@@ -6753,6 +6760,13 @@ f_has(typval_T *argvars, typval_T *rettv)
 		},
 	{"sun",
 #ifdef SUN_SYSTEM
+		1
+#else
+		0
+#endif
+		},
+	{"termux",
+#ifdef __TERMUX__
 		1
 #else
 		0


### PR DESCRIPTION
## Problem: 
The 'android' and 'termux' feature flags have been shipped in Termux's downstream `vim`/`vim-gtk` package for 5+ years but were never properly documented in the downstream patch.

## Solution: 
Upstream the 'android' and 'termux' feature flags into Vim as decoupled feature flags, this enables the 'android' feature in particular to be available independently of the 'termux' feature for builds of Vim against the Android NDK, but not including the Termux NDK patchset.

<h1><em></em></h1> <!-- thin separator -->

### Additional context:
This PR is an upstreaming effort based on an existing downstream patch for Vim in Termux.
https://github.com/termux/termux-packages/blob/4f5d80b/packages/vim/src-evalfunc.c.patch

- After discussion with @justinmk in my inital downstream PR for Termux,
https://github.com/termux/termux-packages/pull/28681#discussion_r2908450273
he mentioned this patch could be added directly to upstream Vim.

> [!NOTE]
> - An equivalent PR has been submitted by me to Neovim to upstream the `neovim` equivalent of this downstream patch as well.
> Neovim PR: neovim/neovim#38218

I have added two additional authors to the attached commit:
@shadmansaleh as the author of the original downstream patch for Termux's Vim/Vim-GTK package, which this PR is based on.
and @lethal-lisa who initially made me aware of the lack of documentation and helped with research for the revised patch.

<h1><em></em></h1> <!-- thin separator -->

This is my first time making a pull request to Vim, I have tried to the best of my ability to follow all contribution guidelines, if I've goofed up significantly anywhere or missed something please let me know and I'll get that resolved as soon as I can.