### PR TITLE
Fix memory leak in `netbeans_file_activated()` in `src/netbeans.c`

### DIFF
--- a/src/netbeans.c
+++ b/src/netbeans.c
@@ -2603,8 +2603,13 @@ netbeans_file_activated(buf_T *bufp)
 	return;
 
     q = nb_quote(bufp->b_ffname);
-    if (q == NULL || bp == NULL)
+    if (q == NULL)
 	return;
+    if (bp == NULL)
+    {
+	vim_free(q);
+	return;
+    }
 
     vim_snprintf(buffer, sizeof(buffer),  "%d:fileOpened=%d \"%s\" %s %s\n",
 	    bufno,


### PR DESCRIPTION
### Problem

In `netbeans_file_activated()`, the string `q` is allocated by `nb_quote()` (line **2605**):

```c
q = nb_quote(bufp->b_ffname);
```

Immediately afterwards, the function may return early if either `q` is `NULL` or `bp` is `NULL` (lines **2606-2607**):

```c
if (q == NULL || bp == NULL)
	return;
```

If `q` is successfully allocated but `bp` is `NULL`, the function returns without freeing `q`, resulting in a memory leak.

### Solution

Free `q` before returning when `bp` is `NULL`. The fix is included in this commit.