### PR TITLE
Fix memory leak in `socket_server_send_reply()` in `src/os_unix.c`

### DIFF
--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -9778,6 +9778,7 @@ socket_server_send_reply(char_u *client, char_u *str)
 	    socket_server_write(socket_fd, final, sz, 1000) == FAIL)
     {
 	socket_server_free_cmd(&cmd);
+	vim_free(final);
 	close(socket_fd);
 	return FAIL;
     }


### PR DESCRIPTION
### Problem

In `socket_server_send_reply()`, the buffer `final` is allocated by `socket_server_encode_cmd()` (line **9775**):

```c
final = socket_server_encode_cmd(&cmd, &sz);
```

The function then checks whether `final` is `NULL` or whether `socket_server_write()` fails (lines **9777-9783**):

```c
if (final == NULL ||
	    socket_server_write(socket_fd, final, sz, 1000) == FAIL)
{
	socket_server_free_cmd(&cmd);
	close(socket_fd);
	return FAIL;
}
```

If `final` is successfully allocated but `socket_server_write()` fails, the function returns without freeing `final`. Since `vim_free(final)` is only called on the success path later in the function, this results in a memory leak.

Note that `socket_server_write()` does not free the buffer passed to it, so the caller must release `final` when the write fails.

### Solution

Free `final` before returning on this error path. Calling `vim_free(final)` is safe even when `final == NULL`, since `vim_free()` checks for `NULL` before calling `free()`. The fix is included in this commit.