### PR TITLE
Fix memory leak in `eval_tuple()` in `src/tuple.c`

### DIFF
--- a/src/tuple.c
+++ b/src/tuple.c
@@ -517,7 +517,7 @@ eval_tuple(char_u **arg, typval_T *rettv, evalarg_T *evalarg, int do_error)
 	{
 	    // Add the first item to the tuple from "rettv"
 	    if (tuple_append_tv(tuple, rettv) == FAIL)
-		return FAIL;
+		goto failret;
 	    // The first item in "rettv" is added to the tuple.  Set the rettv
 	    // type to unknown, so that the caller doesn't free it.
 	    rettv->v_type = VAR_UNKNOWN;


### PR DESCRIPTION
### Problem

In `eval_tuple()`, when `evaluate` is true, a tuple is allocated (lines **512–514**):

```c
tuple = tuple_alloc();
if (tuple == NULL)
    return FAIL;
```

If `rettv->v_type != VAR_UNKNOWN`, the first item is appended to the tuple (lines **519–520**):

```c
if (tuple_append_tv(tuple, rettv) == FAIL)
    return FAIL;
```

If `tuple_append_tv()` fails, the function returns early without freeing the previously allocated `tuple`, resulting in a memory leak.

### Solution

Route this error path through `failret:` so that the existing cleanup logic frees `tuple` before returning. The fix is included in this commit.