### PR TITLE
Fix memory leak in `add_interface_from_super_class()` in `src/vim9class.c`

### DIFF
--- a/src/vim9class.c
+++ b/src/vim9class.c
@@ -918,7 +918,7 @@ add_interface_from_super_class(
 	return FALSE;
 
     if (ga_grow(impl_gap, 1) == FAIL)
-	return FALSE;
+	goto fail;
 
     char_u **intf_names = (char_u **)impl_gap->ga_data;
     intf_names[impl_gap->ga_len] = intf_name;
@@ -926,7 +926,10 @@ add_interface_from_super_class(
 
     // Add the interface class to "intf_classes_gap"
     if (ga_grow(intf_classes_gap, 1) == FAIL)
-	return FALSE;
+    {
+	--impl_gap->ga_len;
+	goto fail;
+    }
 
     class_T **intf_classes = (class_T **)intf_classes_gap->ga_data;
     intf_classes[intf_classes_gap->ga_len] = ifcl;
@@ -934,6 +937,9 @@ add_interface_from_super_class(
     ++ifcl->class_refcount;
 
     return TRUE;
+fail:
+    vim_free(intf_name);
+    return FALSE;
 }
 
 /*


### PR DESCRIPTION
### Problem

In `add_interface_from_super_class()`, the interface name `intf_name` is allocated using `vim_strnsave()` (lines **916–918**):
``` c
intf_name = vim_strnsave(ifcl->class_name.string, ifcl->class_name.length);
if (intf_name == NULL)
    return FALSE;
```
1. The function then attempts to grow the destination arrays. If `ga_grow(impl_gap, 1)` fails, the function returns without freeing `intf_name`, resulting in a memory leak (lines **920–921**):
    ``` c
    if (ga_grow(impl_gap, 1) == FAIL)
        return FALSE;
    ```
2. A second failure path exists after `intf_name` has already been inserted into `impl_gap`. If `ga_grow(intf_classes_gap, 1)` fails, the function also returns immediately (lines **928–929**):
    ``` c
    if (ga_grow(intf_classes_gap, 1) == FAIL)
        return FALSE;
    ```
   At this point `intf_name` has already been stored in `impl_gap` and `impl_gap->ga_len` has been incremented. Returning directly leaves a dangling entry in the array and also leaks the allocated `intf_name`.

### Solution

Free `intf_name` before returning on these error paths. Additionally, for the second failure path, decrement `impl_gap->ga_len` to roll back the partially appended entry before freeing `intf_name`. The fix is included in this commit. 

If the maintainers prefer not to use `goto` for this cleanup, please let me know and I can adjust the patch. Also, if a different label name (e.g., `cleanup` instead of `fail`) is preferred to match the project's style, I can update it accordingly. Thanks!