### PR TITLE
filetype: Tiltfile files are not recognized correctly

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -170,7 +170,8 @@ au BufNewFile,BufRead *.bb,*.bbappend,*.bbclass,*/build/conf/*.conf,*/meta{-*,}/
 au BufNewFile,BufRead */etc/blkid.tab,*/etc/blkid.tab.old   setf xml
 
 " Bazel (https://bazel.build) and Buck2 (https://buck2.build/)
-au BufNewFile,BufRead *.bzl,*.bxl,*.bazel,WORKSPACE,WORKSPACE.bzlmod	setf bzl
+" Tiltfiles (https://tilt.dev) are also written in starlark
+au BufNewFile,BufRead *.bzl,*.bxl,*.bazel,Tiltfile,WORKSPACE,WORKSPACE.bzlmod	setf bzl
 if has("fname_case")
   " There is another check for BUILD and BUCK further below.
   au BufNewFile,BufRead *.BUILD,BUILD,BUCK		setf bzl

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -154,7 +154,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     brightscript: ['file.brs'],
     bsdl: ['file.bsd', 'file.bsdl'],
     bst: ['file.bst'],
-    bzl: ['file.bazel', 'file.bzl', 'file.bxl', 'WORKSPACE', 'WORKSPACE.bzlmod'],
+    bzl: ['file.bazel', 'file.bzl', 'file.bxl', 'Tiltfile', 'WORKSPACE', 'WORKSPACE.bzlmod'],
     bzr: ['bzr_log.any', 'bzr_log.file'],
     c: ['enlightenment/file.cfg', 'file.qc', 'file.c', 'some-enlightenment/file.cfg', 'file.mdh', 'file.epro'],
     c3: ['file.c3', 'file.c3i', 'file.c3t'],


### PR DESCRIPTION
Problem:  filetype: Tiltfiles are not recognized as bzl
Solution: Detect Tiltfiles files as Starlark/bzl filetype
      (Christian Heusel).

Reference:
- https://docs.tilt.dev/tiltfile_concepts.html#execution-model

Signed-off-by: Christian Heusel <christian@heusel.eu>
