### PR TITLE
dict: speed up dict_find key copy

### DIFF
--- a/src/dict.c
+++ b/src/dict.c
@@ -668,7 +668,8 @@ dict_find(dict_T *d, char_u *key, int len)
     else
     {
 	// Avoid a malloc/free by using buf[].
-	vim_strncpy(buf, key, len);
+	mch_memmove(buf, key, (size_t)len);
+	buf[len] = NUL;
 	akey = buf;
     }
 


### PR DESCRIPTION
Replace `vim_strncpy()` with `mch_memmove()` + NUL termination in `dict_find()` to avoid the per-byte NUL-padding overhead of `vim_strncpy()`.

| Operation | Before | After | Change |
|---|---|---|---|
| short key lookup | 1.5883s | 1.5761s | (noise) |
| long key lookup | 1.7802s | 1.6616s | **-7%** |
| `has_key()` | 1.9650s | 1.8474s | **-6%** |
