### PR TITLE
Cache string segments lengths in function exe_concat().

### DIFF
--- a/src/vim9execute.c
+++ b/src/vim9execute.c
@@ -172,7 +172,7 @@ exe_concat(int count, ectx_T *ectx)
 	    segment->length = 0;    // Ensure clean state for the second pass
     }
 
-    if (ga_grow(&ga, len + 1) == FAIL)
+    if (ga_grow(&ga, (int)len + 1) == FAIL)
     {
 	if (string_segment_tab != fixed_string_segment_tab)
 	    vim_free(string_segment_tab);

--- a/src/vim9execute.c
+++ b/src/vim9execute.c
@@ -133,18 +133,20 @@ ufunc_argcount(ufunc_T *ufunc)
 exe_concat(int count, ectx_T *ectx)
 {
     int		idx;
-    int		len = 0;
+    size_t	len = 0;
     garray_T	ga;
-#define NR_ROWS_SIZE_TAB 10
     typedef struct
     {
 	typval_T    *tv;
 	size_t	    length;
     } string_segment_T;
-    string_segment_T	fixed_string_segment_tab[NR_ROWS_SIZE_TAB];
+    enum
+    {
+	STRING_SEGMENT_CACHE_SIZE = 10
+    };
+    string_segment_T	fixed_string_segment_tab[STRING_SEGMENT_CACHE_SIZE];
     string_segment_T	*string_segment_tab = &fixed_string_segment_tab[0];	// an array of cached typevals and lengths
     string_segment_T    *segment;
-#undef NR_ROWS_SIZE_TAB
 
     if (count > (int)ARRAY_LENGTH(fixed_string_segment_tab))
     {
@@ -164,8 +166,10 @@ exe_concat(int count, ectx_T *ectx)
 	if (segment->tv->vval.v_string != NULL)
 	{
 	    segment->length = STRLEN(segment->tv->vval.v_string);
-	    len += (int)segment->length;
+	    len += segment->length;
 	}
+	else
+	    segment->length = 0;    // Ensure clean state for the second pass
     }
 
     if (ga_grow(&ga, len + 1) == FAIL)
@@ -178,8 +182,7 @@ exe_concat(int count, ectx_T *ectx)
     for (idx = 0; idx < count; ++idx)
     {
 	segment = &string_segment_tab[idx];
-	if (segment->tv->vval.v_string != NULL)
-	    ga_concat_len(&ga, segment->tv->vval.v_string, (int)segment->length);
+	ga_concat_len(&ga, segment->tv->vval.v_string, segment->length);
 	clear_tv(segment->tv);
     }
 

--- a/src/vim9execute.c
+++ b/src/vim9execute.c
@@ -144,6 +144,7 @@ exe_concat(int count, ectx_T *ectx)
     string_segment_T	fixed_string_segment_tab[NR_ROWS_SIZE_TAB];
     string_segment_T	*string_segment_tab = &fixed_string_segment_tab[0];	// an array of cached typevals and lengths
     string_segment_T    *segment;
+#undef NR_ROWS_SIZE_TAB
 
     if (count > (int)ARRAY_LENGTH(fixed_string_segment_tab))
     {

--- a/src/vim9execute.c
+++ b/src/vim9execute.c
@@ -134,27 +134,52 @@ exe_concat(int count, ectx_T *ectx)
 {
     int		idx;
     int		len = 0;
-    typval_T	*tv;
     garray_T	ga;
+#define NR_ROWS_SIZE_TAB 10
+    typedef struct
+    {
+	typval_T    *tv;
+	size_t	    length;
+    } string_segment_T;
+    string_segment_T	fixed_string_segment_tab[NR_ROWS_SIZE_TAB];
+    string_segment_T	*string_segment_tab = &fixed_string_segment_tab[0];	// an array of cached typevals and lengths
+    string_segment_T    *segment;
+
+    if (count > (int)ARRAY_LENGTH(fixed_string_segment_tab))
+    {
+	// make an array big enough to store the length of each string segment
+	string_segment_tab = ALLOC_MULT(string_segment_T, count);
+	if (string_segment_tab == NULL)
+	    return FAIL;
+    }
 
     ga_init2(&ga, sizeof(char), 1);
     // Preallocate enough space for the whole string to avoid having to grow
     // and copy.
     for (idx = 0; idx < count; ++idx)
     {
-	tv = STACK_TV_BOT(idx - count);
-	if (tv->vval.v_string != NULL)
-	    len += (int)STRLEN(tv->vval.v_string);
+	segment = &string_segment_tab[idx];
+	segment->tv = STACK_TV_BOT(idx - count);
+	if (segment->tv->vval.v_string != NULL)
+	{
+	    segment->length = STRLEN(segment->tv->vval.v_string);
+	    len += (int)segment->length;
+	}
     }
 
     if (ga_grow(&ga, len + 1) == FAIL)
+    {
+	if (string_segment_tab != fixed_string_segment_tab)
+	    vim_free(string_segment_tab);
 	return FAIL;
+    }
 
     for (idx = 0; idx < count; ++idx)
     {
-	tv = STACK_TV_BOT(idx - count);
-	ga_concat(&ga, tv->vval.v_string);
-	clear_tv(tv);
+	segment = &string_segment_tab[idx];
+	if (segment->tv->vval.v_string != NULL)
+	    ga_concat_len(&ga, segment->tv->vval.v_string, (int)segment->length);
+	clear_tv(segment->tv);
     }
 
     // add a terminating NUL
@@ -162,6 +187,9 @@ exe_concat(int count, ectx_T *ectx)
 
     ectx->ec_stack.ga_len -= count - 1;
     STACK_TV_BOT(-1)->vval.v_string = ga.ga_data;
+
+    if (string_segment_tab != fixed_string_segment_tab)
+	vim_free(string_segment_tab);
 
     return OK;
 }


### PR DESCRIPTION
Function `exe_concat()` uses two `for` loops: the first calculates the total length of the target string; the second actually builds the target string. Both of these loops call `STRLEN()` (the first by explicitly calling `STRLEN()` and the second indirectly via a call to `ga_concat()`).

Running the test suite on my test machine (archlinux) showed function `exe_concat()` was called 39,227 times. `STRLEN()` was called 82,902 times:
	* 82,902 explicit calls in the first `for` loop, and
	* 82,902 implicit calls (as part of `ga_concat()`) in the second `for` loop.
The most times it was called as 8.

This PR uses an array to cache the results of the first `for` loop's `STRLEN()` calls, which is then used in the second `for` loop by changing the call to `ga_concat()` to `ga_concat_len()`.

Cheers
John