### PR TITLE
Coverity: Dead code warning

### DIFF
--- a/src/term.c
+++ b/src/term.c
@@ -7970,12 +7970,10 @@ term_set_win_resize(bool state)
 {
 # ifdef FEAT_GUI
     bool    in_gui = gui.in_use;
-# else
-    bool    in_gui = false;
-# endif
 
     if (state && in_gui)
 	return;
+# endif
 
     if (!state || win_resize_setting == 0 || win_resize_setting == 4)
     {


### PR DESCRIPTION
Problem:  Coverity: Dead code warning for expressions in non-gui builds
          (after v9.2.0139)
Solution: add ifdef FEAT_GUI

CID 1685426