### PR TITLE
Vim9: segfault when unletting an imported variable

### DIFF
--- a/src/evalvars.c
+++ b/src/evalvars.c
@@ -2150,9 +2150,14 @@ do_unlet_var(
     else if (lp->ll_list != NULL)
 	// unlet a List item.
 	listitem_remove(lp->ll_list, lp->ll_li);
-    else
+    else if (lp->ll_dict != NULL)
 	// unlet a Dictionary item.
 	dictitem_remove(lp->ll_dict, lp->ll_di, "unlet");
+    else
+    {
+	semsg(_(e_cannot_unlet_imported_item_str), lp->ll_name);
+	return FAIL;
+    }
 
     return ret;
 }

--- a/src/testdir/test_vim9_assign.vim
+++ b/src/testdir/test_vim9_assign.vim
@@ -2869,6 +2869,26 @@ def Test_unlet()
   END
   v9.CheckScriptFailure(lines, 'E1260:', 1)
 
+  # unlet imported item at script level
+  lines =<< trim END
+    vim9script
+    import './XunletExport.vim' as exp
+    unlet exp.svar
+  END
+  v9.CheckScriptFailure(lines, 'E1260:', 3)
+
+  # unlet imported item in legacy function
+  lines =<< trim END
+    vim9script
+    import './XunletExport.vim' as exp
+    function F()
+      unlet exp.svar
+    endfunction
+    call F()
+  END
+  # error in line 1 of the F()
+  v9.CheckScriptFailure(lines, 'E1260:', 1)
+
   $ENVVAR = 'foobar'
   assert_equal('foobar', $ENVVAR)
   unlet $ENVVAR


### PR DESCRIPTION
Problem:  do_unlet_var() unconditionally calls dictitem_remove() in its
          final else branch, but for imported items lp->ll_dict is NULL,
          causing a segfault (Peter Kenny)
Solution: Add a NULL check and return E1260 instead.

Affects :unlet at vim9script level and inside legacy :function. The :def case already worked (handled in vim9cmds.c).

fixes: #19637