### PR TITLE
if_lua: runtime error with lua 5.5

### DIFF
--- a/src/if_lua.c
+++ b/src/if_lua.c
@@ -2431,8 +2431,7 @@ luaV_pushversion(lua_State *L)
     "    -- Note: ignores trailing item without trailing `;`. Not using something\n"\
     "    -- simpler in order to preserve empty items (stand for default path).\n"\
     "    local orig = {}\n"\
-    "    for s in orig_str:gmatch('[^;]*;') do\n"\
-    "      s = s:sub(1, -2)  -- Strip trailing semicolon\n"\
+    "    for s in orig_str:gmatch('([^;]*);') do\n"\
     "      orig[#orig + 1] = s\n"\
     "    end\n"\
     "    if key == 'path' then\n"\


### PR DESCRIPTION
Problem:  Lua 5.5 makes for-loop control variables read-only.
          The path-parsing logic in if_lua.c attempts to modify the
          loop variable 's', causing the script to fail during
          runtime initialization (Binbin Qian)
Solution: Use a Lua capture group in gmatch() to extract the path
          without the semicolon, avoiding the need to re-assign
          to the loop variable.

fixes: #19639

supported by AI claude.