### PR TITLE
Ensure VisualNOS is only used under X11; fall back to Visual otherwise.

### DIFF
--- a/src/drawline.c
+++ b/src/drawline.c
@@ -1462,10 +1462,11 @@ win_line(
 		area_highlighting = TRUE;
 		vi_attr = HL_ATTR(HLF_V);
 #if defined(FEAT_CLIPBOARD) && defined(FEAT_X11)
-		if ((clip_star.available && !clip_star.owned
-						      && clip_isautosel_star())
-			|| (clip_plus.available && !clip_plus.owned
-						     && clip_isautosel_plus()))
+		if (xterm_dpy
+			&& ((clip_star.available && !clip_star.owned
+						    && clip_isautosel_star())
+			    || (clip_plus.available && !clip_plus.owned
+						    && clip_isautosel_plus())))
 		    vi_attr = HL_ATTR(HLF_VNC);
 #endif
 	    }

--- a/src/testdir/test_visual.vim
+++ b/src/testdir/test_visual.vim
@@ -1618,6 +1618,40 @@ func Test_visual_hl_with_showbreak()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_visual_highlight_when_using_a_clipboard_provider()
+  " The test assumes different screen attributes will be used for Visual and for VisualNOS.
+  CheckFeature clipboard_provider
+  if exists('$DISPLAY')
+     throw 'Skipped: requires non-X11 setup ($DISPLAY must be empty)'
+  endif
+
+  func s:get_attr_for_first_char_in_buf()
+    let pos = screenpos(win_getid(), 1, 1)
+    call assert_true(pos.row > 0 && pos.col > 0)
+    redraw
+    return screenattr(pos.row, pos.col)
+  endfunc
+
+  new +0put='X'
+  call matchadd('Visual', '.')
+  const Visual_attr = s:get_attr_for_first_char_in_buf()
+  call clearmatches()
+
+  normal! V$
+
+  let v:clipproviders['custom'] = {}
+  set clipmethod=custom
+  " The following assert originally failed; VisualNOS, not Visual, was used.
+  call assert_equal(Visual_attr, s:get_attr_for_first_char_in_buf())
+
+  set clipmethod=
+  call assert_equal(Visual_attr, s:get_attr_for_first_char_in_buf())
+
+  unlet v:clipproviders['custom']
+  set clipmethod&
+  bwipe!
+endfunc
+
 func Test_Visual_r_CTRL_C()
   new
   " visual r_cmd


### PR DESCRIPTION
Problem: Vim could use the VisualNOS highlight group when not connected to an X server.
Solution: Always highlight visual selections with Visual when not connected to an X server.

When Vim is running with X11 support it chooses between the Visual and VisualNOS highlight groups for a visual selection based on whether it believes it owns the X selection. According to :help hl-VisualNOS, VisualNOS should only be used by the X11 GUI or when using the xterm-clipboard feature, however, prior to this commit Vim could choose VisualNOS when a clipboard provider was used, even when Vim was not connected to an X server.

I first noticed the issue after running:
`:packadd osc52 | set clipmethod=osc52`

I wrote the following test case. The test is effective if my shell's DISPLAY variable has been unset. I did not work out how to make the test work if the Vim instance running the test had connected to an X server (as then it may then use VisualNOS instead of Visual for highlighting the visual selection).
```
func Test_visual_highlight_when_using_a_clipboard_provider()
  " The test assumes different screen attributes will be used for Visual and for VisualNOS.
  CheckFeature clipboard_provider

  func s:get_attr_for_first_char_in_buf()
    let pos = screenpos(win_getid(), 1, 1)
    call assert_true(pos.row > 0 && pos.col > 0)
    redraw
    return screenattr(pos.row, pos.col)
  endfunc

  new +0put='X'
  call matchadd('Visual', '.')
  const Visual_attr = s:get_attr_for_first_char_in_buf()
  call clearmatches()

  normal! V$

  let v:clipproviders['custom'] = {}
  set clipmethod=custom
  " The following assert originally failed; VisualNOS, not Visual, was used.
  call assert_equal(Visual_attr, s:get_attr_for_first_char_in_buf())

  set clipmethod=
  call assert_equal(Visual_attr, s:get_attr_for_first_char_in_buf())

  unlet v:clipproviders['custom']
  set clipmethod&
  bwipe!
endfunc
```
