### PR TITLE
Allow virtual text to overlay buffer text

### DIFF
--- a/src/charset.c
+++ b/src/charset.c
@@ -1304,6 +1304,11 @@ win_lbr_chartabsize(
 	    textprop_T	*tp = cts->cts_text_props + i;
 	    int		col_off = win_col_off(wp);
 
+	    // If virtual text is set to overlay, then don't skip over the
+	    // virtual text.
+	    if (tp->tp_flags & TP_FLAG_OVERLAY)
+		continue;
+
 	    // Watch out for the text being deleted.  "cts_text_props" is a
 	    // copy, the text prop may actually have been removed from the line.
 	    if (tp->tp_id < 0

--- a/src/charset.c
+++ b/src/charset.c
@@ -1304,8 +1304,7 @@ win_lbr_chartabsize(
 	    textprop_T	*tp = cts->cts_text_props + i;
 	    int		col_off = win_col_off(wp);
 
-	    // If virtual text is set to overlay, then don't skip over the
-	    // virtual text.
+	    // Skip overlay virtual text
 	    if (tp->tp_flags & TP_FLAG_OVERLAY)
 		continue;
 

--- a/src/drawline.c
+++ b/src/drawline.c
@@ -146,7 +146,6 @@ typedef struct {
 #endif
 #ifdef FEAT_PROP_POPUP
     int		text_prop_above_count;
-    int		overlay_fill;
 #endif
 
     // TRUE when 'cursorlineopt' has "screenline" and cursor is in this line
@@ -165,6 +164,12 @@ typedef struct {
     int		c_final;	// final char, mandatory if set
     int		extra_for_textprop; // n_extra set for textprop
     int		start_extra_for_textprop; // extra_for_textprop was just set
+#ifdef FEAT_PROP_POPUP
+    int		n_overlay;
+    char_u	*p_overlay;
+    int		overlay_attr;
+    int		overlay_remaining;
+#endif
 
     // saved "extra" items for when draw_state becomes WL_LINE (again)
     int		saved_n_extra;
@@ -1144,34 +1149,6 @@ apply_cursorline_highlight(
 }
 #endif
 
-#ifdef FEAT_PROP_POPUP
-/*
- *
- */
-    static int
-calculate_overlay(win_T *wp, winlinevars_T *wlv, char_u **ptr, char_u *line)
-{
-    chartabsize_T   cts;
-    int		    cells; // Amount of cells that the entire overlay covers
-
-    cells = mb_string2cells(wlv->p_extra, wlv->n_extra);
-
-    while (cells > 0)
-    {
-	int ptr_cells; // Number of cells that the current "ptr" char covers
-
-	init_chartabsize_arg(&cts, wp, 0, wlv->vcol, line, *ptr);
-	ptr_cells = win_lbr_chartabsize(&cts, NULL);
-	clear_chartabsize_arg(&cts);
-
-	cells -= ptr_cells;
-	MB_PTR_ADV(*ptr);
-    }
-
-    return abs(cells);
-}
-#endif
-
 /*
  * Display line "lnum" of window "wp" on the screen.
  * Start at row "startrow", stop when "endrow" is reached.
@@ -1198,8 +1175,6 @@ win_line(
     long	vcol_prev = -1;		// "wlv.vcol" of previous character
     char_u	*line;			// current line
     char_u	*ptr;			// current position in "line"
-    char_u	*ptr_raw;		// Actual position excluding overlay
-					// text.
     int		in_curline = wp == curwin && lnum == curwin->w_cursor.lnum;
 
 #ifdef FEAT_PROP_POPUP
@@ -1259,6 +1234,8 @@ win_line(
     int		text_prop_flags = 0;
     int		text_prop_above = FALSE;  // first doing virtual text above
     int		text_prop_follows = FALSE;  // another text prop to display
+    int		text_prop_col = 0;	// First column of overlay virtual text
+    int		text_prop_len = 0;	// Length of overlay virtual text
     int		saved_search_attr = 0;	// search_attr to be used when n_extra
 					// goes to zero
     int		saved_area_attr = 0;	// idem for area_attr
@@ -1346,6 +1323,11 @@ win_line(
 #else
 # define VCOL_HLC (wlv.vcol - wlv.vcol_off_tp)
 #endif
+#ifdef FEAT_PROP_POPUP
+    bool	last_overlay	= false; // If current char was the last overlay
+					 // char.
+    int		lock_charattr	= 0; // Don't change char_attr if > 0;
+#endif
 
     if (startrow > endrow)		// past the end already!
 	return startrow;
@@ -1360,9 +1342,6 @@ win_line(
     wlv.tocol = MAXCOL;
 #ifdef FEAT_LINEBREAK
     wlv.vcol_sbr = -1;
-#endif
-#ifdef FEAT_PROP_POPUP
-    wlv.overlay_fill = 0;
 #endif
 
     if (number_only == 0)
@@ -1633,7 +1612,6 @@ win_line(
 
 	// If current line is empty, check first word in next line for capital.
 	ptr = skipwhite(line);
-	ptr_raw = ptr;
 	if (*ptr == NUL)
 	{
 	    spv->spv_cap_col = 0;
@@ -2131,14 +2109,30 @@ win_line(
 	    if (text_props != NULL)
 	    {
 		int pi;
-		int bcol = (int)(ptr_raw - line);
+		int bcol = (int)(ptr - line);
 
-		if (wlv.n_extra > 0
+	 	if ((wlv.n_extra > 0
 # ifdef FEAT_LINEBREAK
 			&& !in_linebreak
 # endif
+		    )
+#ifdef FEAT_PROP_POPUP
+			|| wlv.overlay_remaining > 0
+#endif
 			)
 		    --bcol;  // still working on the previous char, e.g. Tab
+
+		// Last overlay character is not able to fully cover the actual
+		// character (e.g. double width or tab). If so then pad with '>'
+		// chars.
+		if (wlv.overlay_remaining > 0 && wlv.n_overlay == 0)
+		{
+		    wlv.n_extra = wlv.overlay_remaining;
+		    wlv.c_extra = '>';
+		    wlv.char_attr = HL_ATTR(HLF_AT);
+		    lock_charattr = wlv.n_extra;
+		    wlv.overlay_remaining = 0;
+		}
 
 		// Check if any active property ends.
 		for (pi = 0; pi < text_props_active; ++pi)
@@ -2160,18 +2154,14 @@ win_line(
 
 			--text_props_active;
 			--pi;
+
+			text_prop_col = 0;
+			text_prop_len = 0;
 # ifdef FEAT_LINEBREAK
 			// not exactly right but should work in most cases
 			if (in_linebreak && syntax_attr == text_prop_attr_comb)
 			    syntax_attr = 0;
 # endif
-#ifdef FEAT_PROP_POPUP
-			if (tp->tp_flags & TP_FLAG_OVERLAY)
-			{
-			    wlv.c_extra = '>';
-			    wlv.n_extra = wlv.overlay_fill;
-			}
-#endif
 		    }
 		}
 
@@ -2254,6 +2244,9 @@ win_line(
 			if (pt != NULL
 				&& (pt->pt_hl_id > 0 || tp->tp_id < 0)
 				&& tp->tp_id != -MAXCOL
+				&& tp->tp_col != text_prop_col
+				&& (!(tp->tp_flags & TP_FLAG_OVERLAY)
+				    || bcol >= text_prop_col +text_prop_len)
 				&& !(tp->tp_id < 0
 				    && !wp->w_p_wrap
 				    && (tp->tp_flags & (TP_FLAG_ALIGN_RIGHT
@@ -2301,10 +2294,25 @@ win_line(
 							& TP_FLAG_ALIGN_ABOVE);
 			int	    bail_out = FALSE;
 
+			text_prop_col = tp->tp_col;
+			text_prop_len = tp->tp_len;
+
 			// reset the ID in the copy to avoid it being used
 			// again
 			tp->tp_id = -MAXCOL;
 
+#if defined(FEAT_PROP_POPUP)
+			if (p != NULL && tp->tp_flags & TP_FLAG_OVERLAY)
+			{
+			    wlv.p_overlay = p;
+			    wlv.n_overlay = STRLEN(p);
+			    wlv.overlay_attr = hl_combine_attr(wlv.win_attr,
+				    used_attr);
+			    wlv.c_extra = NUL;
+			    wlv.c_final = NUL;
+			}
+			else
+#endif
 			if (p != NULL)
 			{
 			    int	    right = (tp->tp_flags
@@ -2333,14 +2341,6 @@ win_line(
 			    if (*ptr == NUL)
 				// don't combine char attr after EOL
 				text_prop_flags &= ~PT_FLAG_COMBINE;
-#if defined(FEAT_PROP_POPUP)
-			    if (tp->tp_flags & TP_FLAG_OVERLAY)
-			    {
-				ptr_raw = ptr;
-                                wlv.overlay_fill =
-				    calculate_overlay(wp, &wlv, &ptr, line);
-			    }
-#endif
 # ifdef FEAT_LINEBREAK
 			    if (text_prop_no_showbreak(tp))
 			    {
@@ -2649,61 +2649,69 @@ win_line(
 # endif
 #endif
 
-	    // Decide which of the highlight attributes to use.
-	    attr_pri = TRUE;
+	    if (lock_charattr == 0)
+	    {
+		// Decide which of the highlight attributes to use.
+		attr_pri = TRUE;
 #ifdef LINE_ATTR
-	    if (area_attr != 0)
-	    {
-		wlv.char_attr = hl_combine_attr(wlv.line_attr, area_attr);
-		if (!highlight_match)
-		    // let search highlight show in Visual area if possible
-		    wlv.char_attr = hl_combine_attr(search_attr, wlv.char_attr);
+		if (area_attr != 0)
+		{
+		    wlv.char_attr = hl_combine_attr(wlv.line_attr, area_attr);
+		    if (!highlight_match)
+			// let search highlight show in Visual area if possible
+			wlv.char_attr =
+			    hl_combine_attr(search_attr, wlv.char_attr);
 # ifdef FEAT_SYN_HL
-		wlv.char_attr = hl_combine_attr(syntax_attr, wlv.char_attr);
+		    wlv.char_attr = hl_combine_attr(syntax_attr, wlv.char_attr);
 # endif
-	    }
-	    else if (search_attr != 0)
-	    {
-		wlv.char_attr = hl_combine_attr(wlv.line_attr, search_attr);
+		}
+		else if (search_attr != 0)
+		{
+		    wlv.char_attr = hl_combine_attr(wlv.line_attr, search_attr);
 # ifdef FEAT_SYN_HL
-		wlv.char_attr = hl_combine_attr(syntax_attr, wlv.char_attr);
+		    wlv.char_attr = hl_combine_attr(syntax_attr, wlv.char_attr);
 # endif
-	    }
-	    else if (wlv.line_attr != 0
-		    && ((wlv.fromcol == -10 && wlv.tocol == MAXCOL)
-			      || wlv.vcol < wlv.fromcol
-			      || vcol_prev < fromcol_prev
-			      || wlv.vcol >= wlv.tocol))
-	    {
-		// Use wlv.line_attr when not in the Visual or 'incsearch' area
-		// (area_attr may be 0 when "noinvcur" is set).
+		}
+		else if (wlv.line_attr != 0
+			&& ((wlv.fromcol == -10 && wlv.tocol == MAXCOL)
+			    || wlv.vcol < wlv.fromcol
+			    || vcol_prev < fromcol_prev
+			    || wlv.vcol >= wlv.tocol))
+		{
+		    // Use wlv.line_attr when not in the Visual or 'incsearch'
+		    // area (area_attr may be 0 when "noinvcur" is set).
 # ifdef FEAT_SYN_HL
-		wlv.char_attr = hl_combine_attr(syntax_attr, wlv.line_attr);
+		    wlv.char_attr = hl_combine_attr(syntax_attr, wlv.line_attr);
 # else
-		wlv.char_attr = wlv.line_attr;
+		    wlv.char_attr = wlv.line_attr;
 # endif
-		attr_pri = FALSE;
-	    }
+		    attr_pri = FALSE;
+		}
 #else
-	    if (area_attr != 0)
-		wlv.char_attr = area_attr;
-	    else if (search_attr != 0)
-		wlv.char_attr = search_attr;
+		if (area_attr != 0)
+		    wlv.char_attr = area_attr;
+		else if (search_attr != 0)
+		    wlv.char_attr = search_attr;
 #endif
-	    else
-	    {
-		attr_pri = FALSE;
+		else
+		{
+		    attr_pri = FALSE;
 #ifdef FEAT_SYN_HL
-		wlv.char_attr = syntax_attr;
+		    wlv.char_attr = syntax_attr;
 #else
-		wlv.char_attr = 0;
+		    wlv.char_attr = 0;
+#endif
+		}
+#ifdef FEAT_PROP_POPUP
+		// override with text property highlight when "override" is TRUE
+		if (text_prop_type != NULL
+			&& (text_prop_flags & PT_FLAG_OVERRIDE))
+		    wlv.char_attr =
+			hl_combine_attr(wlv.char_attr, text_prop_attr);
 #endif
 	    }
-#ifdef FEAT_PROP_POPUP
-	    // override with text property highlight when "override" is TRUE
-	    if (text_prop_type != NULL && (text_prop_flags & PT_FLAG_OVERRIDE))
-		wlv.char_attr = hl_combine_attr(wlv.char_attr, text_prop_attr);
-#endif
+	    else
+		lock_charattr--;
 	}
 
 	// combine attribute with HLF_WIN
@@ -2715,6 +2723,7 @@ win_line(
 		wlv.char_attr = hl_combine_attr(wlv.win_attr, wlv.char_attr);
 	}
 
+
 	// Get the next character to put on the screen.
 
 	// The "p_extra" points to the extra stuff that is inserted to
@@ -2724,8 +2733,17 @@ win_line(
 	// "p_extra" must end in a NUL to avoid mb_ptr2len() reads past
 	// "p_extra[n_extra]".
 	// For the '$' of the 'list' option, n_extra == 1, p_extra == "".
-	if (wlv.n_extra > 0)
+	if (wlv.n_extra > 0 || wlv.n_overlay > 0)
 	{
+#ifdef FEAT_PROP_POPUP
+	    // Extra text always overrides overlay
+	    char_u  **p = wlv.n_extra > 0 ? &wlv.p_extra : &wlv.p_overlay;
+	    int	    *n = wlv.n_extra > 0 ? &wlv.n_extra : &wlv.n_overlay;
+#else
+	    char_u  **p = &wlv.p_extra;
+	    int	    *n = &wlv.n_extra;
+#endif
+
 	    if (wlv.c_extra != NUL || (wlv.n_extra == 1 && wlv.c_final != NUL))
 	    {
 		c = (wlv.n_extra == 1 && wlv.c_final != NUL)
@@ -2742,7 +2760,8 @@ win_line(
 	    }
 	    else
 	    {
-		c = *wlv.p_extra;
+
+		c = **p;
 		if (has_mbyte)
 		{
 		    mb_c = c;
@@ -2750,13 +2769,13 @@ win_line(
 		    {
 			// If the UTF-8 character is more than one byte:
 			// Decode it into "mb_c".
-			mb_l = utfc_ptr2len(wlv.p_extra);
+			mb_l = utfc_ptr2len(*p);
 			mb_utf8 = FALSE;
-			if (mb_l > wlv.n_extra)
+			if (mb_l > *n)
 			    mb_l = 1;
 			else if (mb_l > 1)
 			{
-			    mb_c = utfc_ptr2char(wlv.p_extra, u8cc);
+			    mb_c = utfc_ptr2char(*p, u8cc);
 			    mb_utf8 = TRUE;
 			    c = 0xc0;
 			}
@@ -2765,10 +2784,10 @@ win_line(
 		    {
 			// if this is a DBCS character, put it in "mb_c"
 			mb_l = MB_BYTE2LEN(c);
-			if (mb_l >= wlv.n_extra)
+			if (mb_l >= *n)
 			    mb_l = 1;
 			else if (mb_l > 1)
-			    mb_c = (c << 8) + wlv.p_extra[1];
+			    mb_c = (c << 8) + (*p)[1];
 		    }
 		    if (mb_l == 0)  // at the NUL at end-of-line
 			mb_l = 1;
@@ -2796,21 +2815,21 @@ win_line(
 
 			// put the pointer back to output the double-width
 			// character at the start of the next line.
-			++wlv.n_extra;
-			--wlv.p_extra;
+			++(*n);
+			--(*p);
 		    }
 		    else
 		    {
-			wlv.n_extra -= mb_l - 1;
-			wlv.p_extra += mb_l - 1;
+			(*n) -= mb_l - 1;
+			(*p) += mb_l - 1;
 		    }
 		}
-		++wlv.p_extra;
+		++(*p);
 	    }
 
-	    --wlv.n_extra;
+	    --(*n);
 #if defined(FEAT_PROP_POPUP)
-	    if (wlv.n_extra <= 0)
+	    if (n == &wlv.n_extra && wlv.n_extra <= 0)
 	    {
 		// Only restore search_attr and area_attr after "n_extra" in
 		// the next screen line is also done.
@@ -2831,6 +2850,51 @@ win_line(
 # ifdef FEAT_LINEBREAK
 		in_linebreak = FALSE;
 # endif
+	    }
+
+	    if (n == &wlv.n_overlay)
+	    {
+		int covered = 0;
+
+		if (wlv.overlay_remaining == 0)
+		{
+		    chartabsize_T cts;
+
+		    init_chartabsize_arg(&cts, wp, 0, wlv.col, line, ptr);
+		    covered = win_lbr_chartabsize(&cts, NULL);
+		    wlv.overlay_remaining = covered;
+
+		    clear_chartabsize_arg(&cts);
+		    MB_PTR_ADV(ptr);
+		}
+		if (wlv.overlay_remaining > 0)
+		    wlv.overlay_remaining -= mb_char2cells(mb_c);
+
+		// If negative, then it means that the overlay char covers more
+		// than one character. To handle this, increment ptr until it
+		// advances to a char that is not covered by the overlay char.
+		while (wlv.overlay_remaining < 0)
+		{
+		    chartabsize_T   cts;
+		    int		    len;
+
+		    init_chartabsize_arg(&cts, wp, 0, wlv.col + covered,
+								line, ptr);
+		    len = win_lbr_chartabsize(&cts, NULL);
+		    clear_chartabsize_arg(&cts);
+
+		    if (len == 0)
+		    {
+			iemsg("virtual text: size in cells is zero?");
+			break;
+		    }
+
+		    wlv.overlay_remaining += len;
+		    covered += len;
+		    MB_PTR_ADV(ptr);
+		}
+
+		last_overlay = wlv.n_overlay == 0;
 	    }
 #endif
 	}
@@ -3817,6 +3881,21 @@ win_line(
 	    }
 #endif
 	}
+
+#ifdef FEAT_PROP_POPUP
+	// Highlighting from overlay virtual text is always applied
+	if (wlv.draw_state == WL_LINE && (wlv.n_overlay > 0 || last_overlay))
+	{
+	    last_overlay = false;
+#ifdef LINE_ATTR
+	    if (wlv.line_attr)
+		wlv.char_attr = hl_combine_attr(wlv.line_attr, wlv.overlay_attr);
+	    else
+#endif
+		wlv.char_attr = wlv.overlay_attr;
+	}
+#endif
+
 
 #if defined(FEAT_XIM) && defined(FEAT_GUI_GTK)
 	// XIM don't send preedit_start and preedit_end, but they send

--- a/src/drawline.c
+++ b/src/drawline.c
@@ -146,7 +146,7 @@ typedef struct {
 #endif
 #ifdef FEAT_PROP_POPUP
     int		text_prop_above_count;
-    bool	overlay;
+    int		overlay_fill;
 #endif
 
     // TRUE when 'cursorlineopt' has "screenline" and cursor is in this line
@@ -1144,6 +1144,34 @@ apply_cursorline_highlight(
 }
 #endif
 
+#ifdef FEAT_PROP_POPUP
+/*
+ *
+ */
+    static int
+calculate_overlay(win_T *wp, winlinevars_T *wlv, char_u **ptr, char_u *line)
+{
+    chartabsize_T   cts;
+    int		    cells; // Amount of cells that the entire overlay covers
+
+    cells = mb_string2cells(wlv->p_extra, wlv->n_extra);
+
+    while (cells > 0)
+    {
+	int ptr_cells; // Number of cells that the current "ptr" char covers
+
+	init_chartabsize_arg(&cts, wp, 0, wlv->vcol, line, *ptr);
+	ptr_cells = win_lbr_chartabsize(&cts, NULL);
+	clear_chartabsize_arg(&cts);
+
+	cells -= ptr_cells;
+	MB_PTR_ADV(*ptr);
+    }
+
+    return abs(cells);
+}
+#endif
+
 /*
  * Display line "lnum" of window "wp" on the screen.
  * Start at row "startrow", stop when "endrow" is reached.
@@ -1170,6 +1198,8 @@ win_line(
     long	vcol_prev = -1;		// "wlv.vcol" of previous character
     char_u	*line;			// current line
     char_u	*ptr;			// current position in "line"
+    char_u	*ptr_raw;		// Actual position excluding overlay
+					// text.
     int		in_curline = wp == curwin && lnum == curwin->w_cursor.lnum;
 
 #ifdef FEAT_PROP_POPUP
@@ -1316,10 +1346,6 @@ win_line(
 #else
 # define VCOL_HLC (wlv.vcol - wlv.vcol_off_tp)
 #endif
-#ifdef FEAT_PROP_POPUP
-    int		overlay_gap = 0;
-    bool	overlay_gap_is_tab = false;
-#endif
 
     if (startrow > endrow)		// past the end already!
 	return startrow;
@@ -1334,6 +1360,9 @@ win_line(
     wlv.tocol = MAXCOL;
 #ifdef FEAT_LINEBREAK
     wlv.vcol_sbr = -1;
+#endif
+#ifdef FEAT_PROP_POPUP
+    wlv.overlay_fill = 0;
 #endif
 
     if (number_only == 0)
@@ -1604,6 +1633,7 @@ win_line(
 
 	// If current line is empty, check first word in next line for capital.
 	ptr = skipwhite(line);
+	ptr_raw = ptr;
 	if (*ptr == NUL)
 	{
 	    spv->spv_cap_col = 0;
@@ -2101,7 +2131,7 @@ win_line(
 	    if (text_props != NULL)
 	    {
 		int pi;
-		int bcol = (int)(ptr - line);
+		int bcol = (int)(ptr_raw - line);
 
 		if (wlv.n_extra > 0
 # ifdef FEAT_LINEBREAK
@@ -2127,6 +2157,7 @@ win_line(
 					text_prop_idxs + pi + 1,
 					sizeof(int)
 					     * (text_props_active - (pi + 1)));
+
 			--text_props_active;
 			--pi;
 # ifdef FEAT_LINEBREAK
@@ -2134,6 +2165,13 @@ win_line(
 			if (in_linebreak && syntax_attr == text_prop_attr_comb)
 			    syntax_attr = 0;
 # endif
+#ifdef FEAT_PROP_POPUP
+			if (tp->tp_flags & TP_FLAG_OVERLAY)
+			{
+			    wlv.c_extra = '>';
+			    wlv.n_extra = wlv.overlay_fill;
+			}
+#endif
 		    }
 		}
 
@@ -2284,12 +2322,6 @@ win_line(
 			    wlv.p_extra = p;
 			    wlv.c_extra = NUL;
 			    wlv.c_final = NUL;
-
-#if defined(FEAT_PROP_POPUP)
-			    if (tp->tp_flags & TP_FLAG_OVERLAY)
-				wlv.overlay = true;
-#endif
-
 			    wlv.n_extra = (int)STRLEN(p);
 			    wlv.extra_for_textprop = TRUE;
 			    wlv.start_extra_for_textprop = TRUE;
@@ -2301,6 +2333,14 @@ win_line(
 			    if (*ptr == NUL)
 				// don't combine char attr after EOL
 				text_prop_flags &= ~PT_FLAG_COMBINE;
+#if defined(FEAT_PROP_POPUP)
+			    if (tp->tp_flags & TP_FLAG_OVERLAY)
+			    {
+				ptr_raw = ptr;
+                                wlv.overlay_fill =
+				    calculate_overlay(wp, &wlv, &ptr, line);
+			    }
+#endif
 # ifdef FEAT_LINEBREAK
 			    if (text_prop_no_showbreak(tp))
 			    {
@@ -2702,10 +2742,6 @@ win_line(
 	    }
 	    else
 	    {
-#ifdef FEAT_PROP_POPUP
-		bool nofit = false;
-#endif
-
 		c = *wlv.p_extra;
 		if (has_mbyte)
 		{
@@ -2762,7 +2798,6 @@ win_line(
 			// character at the start of the next line.
 			++wlv.n_extra;
 			--wlv.p_extra;
-			nofit = true;
 		    }
 		    else
 		    {
@@ -2771,79 +2806,6 @@ win_line(
 		    }
 		}
 		++wlv.p_extra;
-
-#if defined(FEAT_PROP_POPUP)
-		if (wlv.overlay && wlv.draw_state == WL_LINE && !nofit)
-		{
-		    chartabsize_T   cts;
-		    int		    ptr_len;
-		    int		    extra_len;
-
-		    init_chartabsize_arg(&cts, wp, 0, wlv.vcol, line, ptr);
-		    ptr_len = win_lbr_chartabsize(&cts, NULL);
-		    clear_chartabsize_arg(&cts);
-		    extra_len = mb_char2cells(mb_c);
-
-		    if (overlay_gap > 0)
-		    {
-			// Overlay character is not able to cover the buffer
-			// character:
-			//
-			// extra -> OVERLAY TEXT
-			// ptr   -> hel<>lo wol<>
-			//             __	_
-			//
-			// To handle this, don't advance "ptr", only advance
-			// until we cover the buffer character fully.
-			overlay_gap--;
-		    }
-		    else if (overlay_gap == 0)
-		    {
-			overlay_gap = ptr_len - extra_len;
-
-			if (*ptr == TAB)
-			    overlay_gap_is_tab = true;
-
-			// Advance ptr to next character
-			MB_PTR_ADV(ptr);
-
-			if (overlay_gap < 0)
-			{
-			    // Overlay character covers the buffer character,
-			    // and the next characters as well:
-			    //
-			    // <>: char that takes up multiple cells
-			    //
-			    // extra -> OVERLAY TEXT<><-->
-			    // ptr	 -> abc efg hijk lmno
-			    //                      __  __
-			    //
-			    // To handle this, advance ptr until the next ptr
-			    // char is after or at the end of the wide overlay
-			    // char.
-			    int accumulated = 0;
-
-			    do
-			    {
-				int len;
-
-				init_chartabsize_arg(&cts, wp, 0,
-					wlv.vcol + accumulated + 1, line, ptr);
-				len = win_lbr_chartabsize(&cts, NULL);
-				clear_chartabsize_arg(&cts);
-
-				accumulated += len;
-				MB_PTR_ADV(ptr);
-			    }
-			    while (accumulated <= extra_len);
-
-			    // Possible to have over go past the wide char
-			    // because of alignment.
-			    overlay_gap = accumulated - extra_len;
-			}
-		    }
-		}
-#endif
 	    }
 
 	    --wlv.n_extra;
@@ -4370,24 +4332,6 @@ win_line(
 	    skipped_cells = 0;
 	}
 
-#if defined(FEAT_PROP_POPUP)
-	if (wlv.overlay && wlv.n_extra == 0 && wlv.draw_state == WL_LINE)
-	{
-	    wlv.overlay = false;
-
-	    if (overlay_gap > 0)
-	    {
-		// Last overlay character cannot cover the buffer character it
-		// is on top of fully. Therefore add '>' if not tab, otherwise
-		// spaces.
-		wlv.c_extra = overlay_gap_is_tab ? ' ' : '>';
-		wlv.n_extra = overlay_gap;
-		overlay_gap = 0;
-		overlay_gap_is_tab = false;
-	    }
-	}
-#endif
-
 	// Only advance the "wlv.vcol" when after the 'number' or
 	// 'relativenumber' column.
 	if (wlv.draw_state > WL_NR
@@ -4407,11 +4351,7 @@ win_line(
 	    wlv.char_attr = saved_attr3;
 
 	// restore attributes after last 'listchars' or 'number' char
-	if (
-#ifdef FEAT_PROP_POPUP
-		!wlv.overlay &&
-#endif
-		n_attr > 0 && wlv.draw_state == WL_LINE
+	if (n_attr > 0 && wlv.draw_state == WL_LINE
 				      && wlv.n_attr_skip == 0 && --n_attr == 0)
 	    wlv.char_attr = saved_attr2;
 	if (wlv.n_attr_skip > 0)

--- a/src/drawline.c
+++ b/src/drawline.c
@@ -146,6 +146,7 @@ typedef struct {
 #endif
 #ifdef FEAT_PROP_POPUP
     int		text_prop_above_count;
+    bool	overlay;
 #endif
 
     // TRUE when 'cursorlineopt' has "screenline" and cursor is in this line
@@ -175,9 +176,6 @@ typedef struct {
     int		saved_c_extra;
     int		saved_c_final;
     int		saved_char_attr;
-    bool	saved_overlay;
-    bool	saved_overlay_indicator;
-    int		saved_overlay_n_chars;
 
     char_u	extra[NUMBUFLEN + MB_MAXBYTES];
 				// "%ld " and 'fdc' must fit in here, as well
@@ -195,11 +193,6 @@ typedef struct {
      // do consider wrapping in linebreak mode only after encountering
      // a non whitespace char
     int		need_lbr;
-#endif
-#ifdef FEAT_PROP_POPUP
-    bool	overlay;
-    bool	overlay_indicator;
-    int		overlay_n_chars;
 #endif
 } winlinevars_T;
 
@@ -1075,12 +1068,6 @@ win_line_start(win_T *wp UNUSED, winlinevars_T *wlv, int save_extra)
 	wlv->saved_extra_for_textprop = wlv->extra_for_textprop;
 	wlv->saved_c_extra = wlv->c_extra;
 	wlv->saved_c_final = wlv->c_final;
-#ifdef FEAT_PROP_POPUP
-	wlv->saved_overlay = wlv->overlay;
-	wlv->saved_overlay_indicator = wlv->overlay_indicator;
-	wlv->saved_overlay_n_chars = wlv->overlay_n_chars;
-
-#endif
 #ifdef FEAT_LINEBREAK
 	wlv->need_lbr = TRUE;
 #endif
@@ -1122,11 +1109,6 @@ win_line_continue(winlinevars_T *wlv)
 	wlv->n_attr_skip = wlv->saved_n_attr_skip;
 	wlv->extra_for_textprop = wlv->saved_extra_for_textprop;
 	wlv->char_attr = wlv->saved_char_attr;
-#ifdef FEAT_PROP_POPUP
-	wlv->overlay = wlv->saved_overlay;
-	wlv->overlay_indicator = wlv->saved_overlay_indicator;
-	wlv->overlay_n_chars = wlv->saved_overlay_n_chars;
-#endif
     }
     else
 	wlv->char_attr = wlv->win_attr;
@@ -1334,6 +1316,10 @@ win_line(
 #else
 # define VCOL_HLC (wlv.vcol - wlv.vcol_off_tp)
 #endif
+#ifdef FEAT_PROP_POPUP
+    int		overlay_gap = 0;
+    bool	overlay_gap_is_tab = false;
+#endif
 
     if (startrow > endrow)		// past the end already!
 	return startrow;
@@ -1348,11 +1334,6 @@ win_line(
     wlv.tocol = MAXCOL;
 #ifdef FEAT_LINEBREAK
     wlv.vcol_sbr = -1;
-#endif
-#ifdef FEAT_PROP_POPUP
-    wlv.overlay = false;
-    wlv.overlay_indicator = false;
-    wlv.overlay_indicator = 0;
 #endif
 
     if (number_only == 0)
@@ -2126,7 +2107,7 @@ win_line(
 # ifdef FEAT_LINEBREAK
 			&& !in_linebreak
 # endif
-			&& !wlv.overlay)
+			)
 		    --bcol;  // still working on the previous char, e.g. Tab
 
 		// Check if any active property ends.
@@ -2148,9 +2129,6 @@ win_line(
 					     * (text_props_active - (pi + 1)));
 			--text_props_active;
 			--pi;
-
-			if (tp->tp_flags & TP_FLAG_OVERLAY)
-			    wlv.overlay = false;
 # ifdef FEAT_LINEBREAK
 			// not exactly right but should work in most cases
 			if (in_linebreak && syntax_attr == text_prop_attr_comb)
@@ -2164,16 +2142,14 @@ win_line(
 		    // not on the next char yet, don't start another prop
 		    --bcol;
 # endif
-		// Add any text property that starts in this column.
+
+		// Add any text property that that this column is within.
 		while (text_prop_next < text_prop_count)
 		{
 		    int active;
 		    textprop_T *tp = &text_props[text_prop_next];
 
-		    if (tp->tp_flags & TP_FLAG_OVERLAY
-			    && tp->tp_col - 1 == bcol)
-			active = true;
-		    else if (tp->tp_col == MAXCOL)
+		    if (tp->tp_col == MAXCOL)
 		    {
 			if (bcol == 0 && (tp->tp_flags & TP_FLAG_ALIGN_ABOVE))
 			    active = TRUE;
@@ -2213,8 +2189,7 @@ win_line(
 		    text_prop_id = 0;
 		    reset_extra_attr = FALSE;
 		}
-		if (text_props_active > 0
-			&& (wlv.n_extra == 0 || wlv.overlay))
+		if (text_props_active > 0 && wlv.n_extra == 0)
 		{
 		    int	used_tpi = -1;
 		    int	used_attr = 0;
@@ -2309,18 +2284,15 @@ win_line(
 			    wlv.p_extra = p;
 			    wlv.c_extra = NUL;
 			    wlv.c_final = NUL;
-			    wlv.n_extra = (int)STRLEN(p);
+
+#if defined(FEAT_PROP_POPUP)
 			    if (tp->tp_flags & TP_FLAG_OVERLAY)
-				// No need to set extra_for_textprop, as we
-				// basically just replacing the underlying
-				// character.
 				wlv.overlay = true;
-			    else
-			    {
-				wlv.extra_for_textprop = TRUE;
-				wlv.start_extra_for_textprop = TRUE;
-				wlv.overlay = false;
-			    }
+#endif
+
+			    wlv.n_extra = (int)STRLEN(p);
+			    wlv.extra_for_textprop = TRUE;
+			    wlv.start_extra_for_textprop = TRUE;
 			    wlv.extra_attr = hl_combine_attr(wlv.win_attr,
 								    used_attr);
 			    n_attr = mb_charlen(p);
@@ -2705,36 +2677,6 @@ win_line(
 
 	// Get the next character to put on the screen.
 
-#ifdef FEAT_PROP_POPUP
-	// "overlay_indicator" is set when there is a double width character
-	// that cannot be fully covered by the overlay text. In this case, just
-	// use '>' to indicate the absent cell.
-	if (wlv.overlay_indicator)
-	{
-	    wlv.overlay_indicator = false;
-
-	    c = '>';
-	    mb_c = c;
-	    mb_l = 1;
-	    mb_utf8 = FALSE;
-	    multi_attr = HL_ATTR(HLF_AT);
-# ifdef FEAT_SYN_HL
-	    if (wlv.cul_attr)
-		multi_attr = hl_combine_attr(multi_attr, wlv.cul_attr);
-# endif
-	    multi_attr = hl_combine_attr(wlv.win_attr, multi_attr);
-
-	    if (wlv.overlay_n_chars != 0)
-	    {
-		// Must advance across the final character, where one
-		// overlay char + '>' char is overlayed upon.
-		MB_PTR_ADV(ptr);
-		wlv.overlay_n_chars = 0;
-	    }
-	}
-	else
-#endif
-
 	// The "p_extra" points to the extra stuff that is inserted to
 	// represent special characters (non-printable stuff) and other
 	// things.  When all characters are the same, c_extra is used.
@@ -2760,6 +2702,10 @@ win_line(
 	    }
 	    else
 	    {
+#ifdef FEAT_PROP_POPUP
+		bool nofit = false;
+#endif
+
 		c = *wlv.p_extra;
 		if (has_mbyte)
 		{
@@ -2816,6 +2762,7 @@ win_line(
 			// character at the start of the next line.
 			++wlv.n_extra;
 			--wlv.p_extra;
+			nofit = true;
 		    }
 		    else
 		    {
@@ -2824,32 +2771,80 @@ win_line(
 		    }
 		}
 		++wlv.p_extra;
-	    }
-#ifdef FEAT_PROP_POPUP
-	    if (wlv.overlay && *ptr != NUL)
-	    {
-		if (wlv.overlay_n_chars > 0)
-		    // Need to overlay the entire double width character
-		    wlv.overlay_n_chars--;
-		else
-		{
-		    wlv.overlay_n_chars = (*mb_ptr2cells)(ptr);
 
-		    if (wlv.n_extra < wlv.overlay_n_chars)
-			// Overlay text cannot cover the double width char, must
-			// add a '>'.
-			wlv.overlay_indicator = true;
-		    else
+#if defined(FEAT_PROP_POPUP)
+		if (wlv.overlay && wlv.draw_state == WL_LINE && !nofit)
+		{
+		    chartabsize_T   cts;
+		    int		    ptr_len;
+		    int		    extra_len;
+
+		    init_chartabsize_arg(&cts, wp, 0, wlv.vcol, line, ptr);
+		    ptr_len = win_lbr_chartabsize(&cts, NULL);
+		    clear_chartabsize_arg(&cts);
+		    extra_len = mb_char2cells(mb_c);
+
+		    if (overlay_gap > 0)
 		    {
-			// Advance across character and consume one char from
-			// it, since the current character is the overlay
-			// character.
+			// Overlay character is not able to cover the buffer
+			// character:
+			//
+			// extra -> OVERLAY TEXT
+			// ptr   -> hel<>lo wol<>
+			//             __	_
+			//
+			// To handle this, don't advance "ptr", only advance
+			// until we cover the buffer character fully.
+			overlay_gap--;
+		    }
+		    else if (overlay_gap == 0)
+		    {
+			overlay_gap = ptr_len - extra_len;
+
+			if (*ptr == TAB)
+			    overlay_gap_is_tab = true;
+
+			// Advance ptr to next character
 			MB_PTR_ADV(ptr);
-			wlv.overlay_n_chars--;
+
+			if (overlay_gap < 0)
+			{
+			    // Overlay character covers the buffer character,
+			    // and the next characters as well:
+			    //
+			    // <>: char that takes up multiple cells
+			    //
+			    // extra -> OVERLAY TEXT<><-->
+			    // ptr	 -> abc efg hijk lmno
+			    //                      __  __
+			    //
+			    // To handle this, advance ptr until the next ptr
+			    // char is after or at the end of the wide overlay
+			    // char.
+			    int accumulated = 0;
+
+			    do
+			    {
+				int len;
+
+				init_chartabsize_arg(&cts, wp, 0,
+					wlv.vcol + accumulated + 1, line, ptr);
+				len = win_lbr_chartabsize(&cts, NULL);
+				clear_chartabsize_arg(&cts);
+
+				accumulated += len;
+				MB_PTR_ADV(ptr);
+			    }
+			    while (accumulated <= extra_len);
+
+			    // Possible to have over go past the wide char
+			    // because of alignment.
+			    overlay_gap = accumulated - extra_len;
+			}
 		    }
 		}
-	    }
 #endif
+	    }
 
 	    --wlv.n_extra;
 #if defined(FEAT_PROP_POPUP)
@@ -4369,16 +4364,29 @@ win_line(
 	else
 	    --skip_cells;
 
-#ifdef FEAT_PROP_POPUP
-	if (wlv.overlay && wlv.n_extra == 0)
-	    wlv.overlay = false;
-#endif
-
 	if (wlv.draw_state > WL_NR && skipped_cells > 0)
 	{
 	    wlv.vcol += skipped_cells;
 	    skipped_cells = 0;
 	}
+
+#if defined(FEAT_PROP_POPUP)
+	if (wlv.overlay && wlv.n_extra == 0 && wlv.draw_state == WL_LINE)
+	{
+	    wlv.overlay = false;
+
+	    if (overlay_gap > 0)
+	    {
+		// Last overlay character cannot cover the buffer character it
+		// is on top of fully. Therefore add '>' if not tab, otherwise
+		// spaces.
+		wlv.c_extra = overlay_gap_is_tab ? ' ' : '>';
+		wlv.n_extra = overlay_gap;
+		overlay_gap = 0;
+		overlay_gap_is_tab = false;
+	    }
+	}
+#endif
 
 	// Only advance the "wlv.vcol" when after the 'number' or
 	// 'relativenumber' column.
@@ -4399,7 +4407,11 @@ win_line(
 	    wlv.char_attr = saved_attr3;
 
 	// restore attributes after last 'listchars' or 'number' char
-	if (n_attr > 0 && wlv.draw_state == WL_LINE
+	if (
+#ifdef FEAT_PROP_POPUP
+		!wlv.overlay &&
+#endif
+		n_attr > 0 && wlv.draw_state == WL_LINE
 				      && wlv.n_attr_skip == 0 && --n_attr == 0)
 	    wlv.char_attr = saved_attr2;
 	if (wlv.n_attr_skip > 0)

--- a/src/drawline.c
+++ b/src/drawline.c
@@ -175,6 +175,9 @@ typedef struct {
     int		saved_c_extra;
     int		saved_c_final;
     int		saved_char_attr;
+    bool	saved_overlay;
+    bool	saved_overlay_indicator;
+    int		saved_overlay_n_chars;
 
     char_u	extra[NUMBUFLEN + MB_MAXBYTES];
 				// "%ld " and 'fdc' must fit in here, as well
@@ -192,6 +195,11 @@ typedef struct {
      // do consider wrapping in linebreak mode only after encountering
      // a non whitespace char
     int		need_lbr;
+#endif
+#ifdef FEAT_PROP_POPUP
+    bool	overlay;
+    bool	overlay_indicator;
+    int		overlay_n_chars;
 #endif
 } winlinevars_T;
 
@@ -1067,6 +1075,11 @@ win_line_start(win_T *wp UNUSED, winlinevars_T *wlv, int save_extra)
 	wlv->saved_extra_for_textprop = wlv->extra_for_textprop;
 	wlv->saved_c_extra = wlv->c_extra;
 	wlv->saved_c_final = wlv->c_final;
+#ifdef FEAT_PROP_POPUP
+	wlv->saved_overlay = wlv->overlay;
+	wlv->saved_overlay_indicator = wlv->overlay_indicator;
+	wlv->saved_overlay_n_chars = wlv->overlay_n_chars;
+#endif
 #ifdef FEAT_LINEBREAK
 	wlv->need_lbr = TRUE;
 #endif
@@ -1108,6 +1121,11 @@ win_line_continue(winlinevars_T *wlv)
 	wlv->n_attr_skip = wlv->saved_n_attr_skip;
 	wlv->extra_for_textprop = wlv->saved_extra_for_textprop;
 	wlv->char_attr = wlv->saved_char_attr;
+#ifdef FEAT_PROP_POPUP
+	wlv->overlay = wlv->saved_overlay;
+	wlv->overlay_indicator = wlv->saved_overlay_indicator;
+	wlv->overlay_n_chars = wlv->saved_overlay_n_chars;
+#endif
     }
     else
 	wlv->char_attr = wlv->win_attr;
@@ -1329,6 +1347,11 @@ win_line(
     wlv.tocol = MAXCOL;
 #ifdef FEAT_LINEBREAK
     wlv.vcol_sbr = -1;
+#endif
+#ifdef FEAT_PROP_POPUP
+    wlv.overlay = false;
+    wlv.overlay_indicator = false;
+    wlv.overlay_indicator = 0;
 #endif
 
     if (number_only == 0)
@@ -2278,8 +2301,16 @@ win_line(
 			    wlv.c_extra = NUL;
 			    wlv.c_final = NUL;
 			    wlv.n_extra = (int)STRLEN(p);
-			    wlv.extra_for_textprop = TRUE;
-			    wlv.start_extra_for_textprop = TRUE;
+			    if (tp->tp_flags & TP_FLAG_OVERLAY)
+				// No need to set extra_for_textprop, as we
+				// basically just replacing the underlying
+				// character.
+				wlv.overlay = true;
+			    else
+			    {
+				wlv.extra_for_textprop = TRUE;
+				wlv.start_extra_for_textprop = TRUE;
+			    }
 			    wlv.extra_attr = hl_combine_attr(wlv.win_attr,
 								    used_attr);
 			    n_attr = mb_charlen(p);
@@ -2664,6 +2695,36 @@ win_line(
 
 	// Get the next character to put on the screen.
 
+#ifdef FEAT_PROP_POPUP
+	// "overlay_indicator" is set when there is a double width character
+	// that cannot be fully covered by the overlay text. In this case, just
+	// use '>' to indicate the absent cell.
+	if (wlv.overlay_indicator)
+	{
+	    wlv.overlay_indicator = false;
+
+	    c = '>';
+	    mb_c = c;
+	    mb_l = 1;
+	    mb_utf8 = FALSE;
+	    multi_attr = HL_ATTR(HLF_AT);
+# ifdef FEAT_SYN_HL
+	    if (wlv.cul_attr)
+		multi_attr = hl_combine_attr(multi_attr, wlv.cul_attr);
+# endif
+	    multi_attr = hl_combine_attr(wlv.win_attr, multi_attr);
+
+	    if (wlv.overlay_n_chars != 0)
+	    {
+		// Must advance across the final character, where one
+		// overlay char + '>' char is overlayed upon.
+		MB_PTR_ADV(ptr);
+		wlv.overlay_n_chars = 0;
+	    }
+	}
+	else
+#endif
+
 	// The "p_extra" points to the extra stuff that is inserted to
 	// represent special characters (non-printable stuff) and other
 	// things.  When all characters are the same, c_extra is used.
@@ -2754,6 +2815,32 @@ win_line(
 		}
 		++wlv.p_extra;
 	    }
+#ifdef FEAT_PROP_POPUP
+	    if (wlv.overlay && *ptr != NUL)
+	    {
+		if (wlv.overlay_n_chars > 0)
+		    // Need to overlay the entire double width character
+		    wlv.overlay_n_chars--;
+		else
+		{
+		    wlv.overlay_n_chars = (*mb_ptr2cells)(ptr);
+
+		    if (wlv.n_extra < wlv.overlay_n_chars)
+			// Overlay text cannot cover the double width char, must
+			// add a '>'.
+			wlv.overlay_indicator = true;
+		    else
+		    {
+			// Advance across character and consume one char from
+			// it, since the current character is the overlay
+			// character.
+			MB_PTR_ADV(ptr);
+			wlv.overlay_n_chars--;
+		    }
+		}
+	    }
+#endif
+
 	    --wlv.n_extra;
 #if defined(FEAT_PROP_POPUP)
 	    if (wlv.n_extra <= 0)
@@ -4271,6 +4358,11 @@ win_line(
 #endif // FEAT_CONCEAL
 	else
 	    --skip_cells;
+
+#ifdef FEAT_PROP_POPUP
+	if (wlv.overlay && wlv.n_extra == 0)
+	    wlv.overlay = false;
+#endif
 
 	if (wlv.draw_state > WL_NR && skipped_cells > 0)
 	{

--- a/src/drawline.c
+++ b/src/drawline.c
@@ -1079,6 +1079,7 @@ win_line_start(win_T *wp UNUSED, winlinevars_T *wlv, int save_extra)
 	wlv->saved_overlay = wlv->overlay;
 	wlv->saved_overlay_indicator = wlv->overlay_indicator;
 	wlv->saved_overlay_n_chars = wlv->overlay_n_chars;
+
 #endif
 #ifdef FEAT_LINEBREAK
 	wlv->need_lbr = TRUE;
@@ -2125,7 +2126,7 @@ win_line(
 # ifdef FEAT_LINEBREAK
 			&& !in_linebreak
 # endif
-			)
+			&& !wlv.overlay)
 		    --bcol;  // still working on the previous char, e.g. Tab
 
 		// Check if any active property ends.
@@ -2134,9 +2135,9 @@ win_line(
 		    int		tpi = text_prop_idxs[pi];
 		    textprop_T  *tp = &text_props[tpi];
 
-		    // An inline property ends when after the start column plus
-		    // length. An "above" property ends when used and n_extra
-		    // is zero.
+		    // An inline/overlay property ends when after the start
+		    // column plus length. An "above" property ends when used
+		    // and n_extra is zero.
 		    if ((tp->tp_col != MAXCOL
 				       && bcol >= tp->tp_col - 1 + tp->tp_len))
 		    {
@@ -2147,6 +2148,9 @@ win_line(
 					     * (text_props_active - (pi + 1)));
 			--text_props_active;
 			--pi;
+
+			if (tp->tp_flags & TP_FLAG_OVERLAY)
+			    wlv.overlay = false;
 # ifdef FEAT_LINEBREAK
 			// not exactly right but should work in most cases
 			if (in_linebreak && syntax_attr == text_prop_attr_comb)
@@ -2165,7 +2169,11 @@ win_line(
 		{
 		    int active;
 		    textprop_T *tp = &text_props[text_prop_next];
-		    if (tp->tp_col == MAXCOL)
+
+		    if (tp->tp_flags & TP_FLAG_OVERLAY
+			    && tp->tp_col - 1 == bcol)
+			active = true;
+		    else if (tp->tp_col == MAXCOL)
 		    {
 			if (bcol == 0 && (tp->tp_flags & TP_FLAG_ALIGN_ABOVE))
 			    active = TRUE;
@@ -2173,8 +2181,8 @@ win_line(
 			    break;
 			else
 			{
-			    // With 'nowrap' and not in the first screen line only "below"
-			    // text prop can show.
+			    // With 'nowrap' and not in the first screen line
+			    // only "below" text prop can show.
 			    active = wp->w_p_wrap
 				  || wlv.row == startrow
 				  || (tp->tp_flags & TP_FLAG_ALIGN_BELOW);
@@ -2205,11 +2213,12 @@ win_line(
 		    text_prop_id = 0;
 		    reset_extra_attr = FALSE;
 		}
-		if (text_props_active > 0 && wlv.n_extra == 0)
+		if (text_props_active > 0
+			&& (wlv.n_extra == 0 || wlv.overlay))
 		{
-		    int used_tpi = -1;
-		    int used_attr = 0;
-		    int other_tpi = -1;
+		    int	used_tpi = -1;
+		    int	used_attr = 0;
+		    int	other_tpi = -1;
 
 		    text_prop_above = FALSE;
 		    text_prop_follows = FALSE;
@@ -2310,6 +2319,7 @@ win_line(
 			    {
 				wlv.extra_for_textprop = TRUE;
 				wlv.start_extra_for_textprop = TRUE;
+				wlv.overlay = false;
 			    }
 			    wlv.extra_attr = hl_combine_attr(wlv.win_attr,
 								    used_attr);

--- a/src/structs.h
+++ b/src/structs.h
@@ -911,6 +911,7 @@ typedef struct textprop_S
 #define TP_FLAG_WRAP		0x080	// virtual text wraps - when missing
 					// text is truncated
 #define TP_FLAG_START_INCL	0x100	// "start_incl" copied from proptype
+#define TP_FLAG_OVERLAY		0x200	// virtual text overlays actual text
 
 #define PROP_TEXT_MIN_CELLS	4	// minimum number of cells to use for
 					// the text, even when truncating

--- a/src/structs.h
+++ b/src/structs.h
@@ -892,8 +892,7 @@ typedef struct textprop_S
 {
     colnr_T	tp_col;		// start column (one based, in bytes)
     colnr_T	tp_len;		// length in bytes, when tp_id is negative used
-				// for left padding plus one. If overlay, then
-				// length of text.
+				// for left padding plus one.
     int		tp_id;		// identifier
     int		tp_type;	// property type
     int		tp_flags;	// TP_FLAG_ values

--- a/src/structs.h
+++ b/src/structs.h
@@ -892,7 +892,8 @@ typedef struct textprop_S
 {
     colnr_T	tp_col;		// start column (one based, in bytes)
     colnr_T	tp_len;		// length in bytes, when tp_id is negative used
-				// for left padding plus one
+				// for left padding plus one. If overlay, then
+				// length of text.
     int		tp_id;		// identifier
     int		tp_type;	// property type
     int		tp_flags;	// TP_FLAG_ values

--- a/src/textprop.c
+++ b/src/textprop.c
@@ -255,12 +255,12 @@ prop_add_one(
 	    length = end_col - col;
 	else
 	    length = (int)textlen - col + 1;
-	if (length > (long)textlen)
+	if (length > (long)textlen || text_flags & TP_FLAG_OVERLAY)
 	    length = (int)textlen;	// can include the end-of-line
 	if (length < 0)
 	    length = 0;		// zero-width property
 
-	if (text_arg != NULL)
+	if (text_arg != NULL && !(text_flags & TP_FLAG_OVERLAY))
 	{
 	    length = 1;		// text is placed on one character
 	    if (col == 0)

--- a/src/textprop.c
+++ b/src/textprop.c
@@ -539,7 +539,7 @@ prop_add_common(
 
 	    if (p == NULL)
 		goto theend;
-	    if (start_col != 0)
+	    if (start_col != 0 && STRCMP(p, "overlay") != 0)
 	    {
 		emsg(_(e_can_only_use_text_align_when_column_is_zero));
 		goto theend;
@@ -550,6 +550,8 @@ prop_add_common(
 		flags |= TP_FLAG_ALIGN_ABOVE;
 	    else if (STRCMP(p, "below") == 0)
 		flags |= TP_FLAG_ALIGN_BELOW;
+	    else if (STRCMP(p, "overlay") == 0)
+		flags |= TP_FLAG_OVERLAY;
 	    else if (STRCMP(p, "after") != 0)
 	    {
 		semsg(_(e_invalid_value_for_argument_str_str), "text_align", p);

--- a/src/textprop.c
+++ b/src/textprop.c
@@ -262,13 +262,20 @@ prop_add_one(
 
 	if (text_arg != NULL)
 	{
-	    length = 1;		// text is placed on one character
-	    if (col == 0)
+	    if (text_flags & TP_FLAG_OVERLAY)
+		// We set tp_len to the length of the overlay text. This is
+		// required so we know where the text proprty ends when drawing.
+		length = STRLEN(text_arg);
+	    else
 	    {
-		col = MAXCOL;	// before or after the line
-		if ((text_flags & TP_FLAG_ALIGN_ABOVE) == 0)
-		    sort_col = MAXCOL;
-		length += text_padding_left;
+		length = 1;		// text is placed on one character
+		if (col == 0)
+		{
+		    col = MAXCOL;	// before or after the line
+		    if ((text_flags & TP_FLAG_ALIGN_ABOVE) == 0)
+			sort_col = MAXCOL;
+		    length += text_padding_left;
+		}
 	    }
 	}
 

--- a/src/textprop.c
+++ b/src/textprop.c
@@ -255,12 +255,12 @@ prop_add_one(
 	    length = end_col - col;
 	else
 	    length = (int)textlen - col + 1;
-	if (length > (long)textlen || text_flags & TP_FLAG_OVERLAY)
+	if (length > (long)textlen)
 	    length = (int)textlen;	// can include the end-of-line
 	if (length < 0)
 	    length = 0;		// zero-width property
 
-	if (text_arg != NULL && !(text_flags & TP_FLAG_OVERLAY))
+	if (text_arg != NULL)
 	{
 	    length = 1;		// text is placed on one character
 	    if (col == 0)


### PR DESCRIPTION
Fixes #15007

Should work correctly with multibyte and double width characters. If the overlay text can't fully cover a double width character, then a '>' will be substituted in.

If the overlay is placed over double-width characters, then the cursor will appear to skip some characters. I initially thought this was a bug, however it seems like Neovim has the same behaviour. Thinking about it more, it makes sense.

Here is a demo program to test
```vim
vim9script

prop_type_add("Test", {highlight: "ErrorMsg"})

command -nargs=0 Prop {
    prop_add(line('.'), col('.'), {type: "Test", text: "ABC", text_align: "overlay"})
}

command -nargs=0 Clear prop_clear(line('.'))

noremap <leader>pp <cmd>Prop<cr>
noremap <leader>pc <cmd>Clear<cr>
```