### PR TITLE
fix: flush output buffer before ending synchronized update

### DIFF
--- a/src/term.c
+++ b/src/term.c
@@ -8056,6 +8056,11 @@ term_set_sync_output(int flags)
     {
 	if (sync_output_state == 0 || --sync_output_state > 0)
 	    return;
+	// Flush the output buffer before ending the sync batch so that
+	// all drawing output is sent to the terminal within the
+	// BSU..ESU window.  Without this, the drawing data remaining in
+	// out_buf would be sent after ESU, outside the sync batch.
+	out_flush();
 	str = T_ESU;
     }
     else


### PR DESCRIPTION
`term_set_sync_output()` sends ESU directly via `ui_write()` / `mch_write()`, but drawing data sits in `out_buf` and is only sent later by `out_flush()`. This means the drawing data ends up after ESU, outside the BSU..ESU window.

Flush `out_buf` before sending ESU so that all drawing output stays within the synchronized update batch.