### PR TITLE
strings: speed up blob_from_string() by using bulk copy

### DIFF
--- a/src/strings.c
+++ b/src/strings.c
@@ -1232,13 +1232,20 @@ convert_string(string_T *str, char_u *from, char_u *to, string_T *ret)
     static void
 blob_from_string(char_u *str, blob_T *blob)
 {
-    char_u  *p;
+    int	    len = (int)STRLEN(str);
+    char_u  *dest;
 
-    for (p = str; *p != NUL; ++p)
-    {
-	// Translate newlines in the string to NUL character
-	ga_append(&blob->bv_ga, (*p == NL) ? NUL : (int)*p);
-    }
+    if (len == 0)
+	return;
+    if (ga_grow(&blob->bv_ga, len) == FAIL)
+	return;
+    dest = (char_u *)blob->bv_ga.ga_data + blob->bv_ga.ga_len;
+    mch_memmove(dest, str, (size_t)len);
+    // Translate newlines in the string to NUL characters
+    for (int i = 0; i < len; ++i)
+	if (dest[i] == NL)
+	    dest[i] = NUL;
+    blob->bv_ga.ga_len += len;
 }
 
 /*


### PR DESCRIPTION
Replace byte-at-a-time ga_append() loop in blob_from_string() with
a single ga_grow() + mch_memmove(), then translate NL→NUL in-place.

str2blob() with 50 iterations:

| Case | Before | After | Speedup |
|---|---|---|---|
| 10,000 x 500 bytes | 0.466s | 0.173s | 2.7x |
| 100 x 50,000 bytes | 0.469s | 0.168s | 2.8x |
| 100,000 x 10 bytes | 0.043s | 0.031s | 1.4x |