### PR TITLE
feat: objectscript detection for .cls files

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -195,6 +195,7 @@ export def FTcl()
   endif
 enddef
 
+# Determines whether a *.cls file is ObjectScript, TeX, Rexx, Visual Basic, or Smalltalk.
 export def FTcls()
   if exists("g:filetype_cls")
     exe "setf " .. g:filetype_cls
@@ -211,9 +212,6 @@ export def FTcls()
   endif
 
   var nonblank1 = getline(nextnonblank(1))
-
-  # ObjectScript class files can start with Import/Include/IncludeGenerator.
-  # Skip those declarations and inspect the next relevant line.
   var lnum = nextnonblank(1)
   while lnum > 0 && lnum <= line("$")
     var line = getline(lnum)

--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -211,7 +211,23 @@ export def FTcls()
   endif
 
   var nonblank1 = getline(nextnonblank(1))
-  if nonblank1 =~ '^\v%(\%|\\)'
+
+  # ObjectScript class files can start with Import/Include/IncludeGenerator.
+  # Skip those declarations and inspect the next relevant line.
+  var lnum = nextnonblank(1)
+  while lnum > 0 && lnum <= line("$")
+    var line = getline(lnum)
+    if line =~? '^\s*\%(import\|include\|includegenerator\)\>'
+      lnum = nextnonblank(lnum + 1)
+    else
+      nonblank1 = line
+      break
+    endif
+  endwhile
+
+  if nonblank1 =~? '^\s*class\>\s\+[%A-Za-z][%A-Za-z0-9_.]*\%(\s\+extends\>\|\s*\[\|\s*{\|$\)'
+    setf objectscript
+  elseif nonblank1 =~ '^\v%(\%|\\)'
     setf tex
   elseif nonblank1 =~ '^\s*\%(/\*\|::\w\)'
     setf rexx

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1054,7 +1054,7 @@ au BufNewFile,BufRead *.scm,*.ss,*.sld,*.stsg,*/supertux2/config,.lips_repl_hist
 " SiSU
 au BufNewFile,BufRead *.sst.meta,*.-sst.meta,*._sst.meta setf sisu
 
-" Smalltalk (and Rexx, TeX, and Visual Basic)
+" Smalltalk (and ObjectScript, Rexx, TeX, and Visual Basic)
 au BufNewFile,BufRead *.cls			call dist#ft#FTcls()
 
 " SMIL or XML

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -2564,6 +2564,39 @@ func Test_cls_file()
   bwipe!
   unlet g:filetype_cls
 
+  let g:filetype_cls = 'objectscript'
+  split Xfile.cls
+  call assert_equal('objectscript', &filetype)
+  bwipe!
+  unlet g:filetype_cls
+
+  " ObjectScript
+
+  call writefile(['Class User.Person Extends (%Persistent, %Populate)'], 'Xfile.cls')
+  split Xfile.cls
+  call assert_equal('objectscript', &filetype)
+  bwipe!
+
+  call writefile(['Import MyApp.Utils', 'Class User.Person Extends %Persistent'], 'Xfile.cls')
+  split Xfile.cls
+  call assert_equal('objectscript', &filetype)
+  bwipe!
+
+  call writefile(['Include MyMacros', 'Class User.Person Extends %Persistent'], 'Xfile.cls')
+  split Xfile.cls
+  call assert_equal('objectscript', &filetype)
+  bwipe!
+
+  call writefile(['IncludeGenerator MyGen', 'Class User.Person Extends %Persistent'], 'Xfile.cls')
+  split Xfile.cls
+  call assert_equal('objectscript', &filetype)
+  bwipe!
+
+  call writefile(['Import MyApp.Utils', 'Include MyMacros', 'IncludeGenerator MyGen', 'Class User.Person Extends %Persistent'], 'Xfile.cls')
+  split Xfile.cls
+  call assert_equal('objectscript', &filetype)
+  bwipe!
+
   " TeX
 
   call writefile(['%'], 'Xfile.cls')


### PR DESCRIPTION
## Summary
Extends `*.cls` filetype detection to recognize [ObjectScript](https://docs.intersystems.com/latest/csp/docbook/DocBook.UI.Page.cls?KEY=GCOS_intro) class files. 

## Problem
`*.cls` files are currently detected as Smalltalk/TeX/Rexx/Visual Basic, but ObjectScript class files also use `.cls`.

## Solution
Updated `runtime/autoload/dist/ft.vim` (`FTcls()`):
- preserve existing `g:filetype_cls` override and existing Rexx/VB/TeX behavior
- detect ObjectScript class headers (`Class ...`)
- skip ObjectScript import/include/includegenerator lines before `Class`

## Tests
Extended `Test_cls_file()` in `src/testdir/test_filetype.vim` with ObjectScript cases:
- direct `Class ...`
- `Import`/`Include`/`IncludeGenerator` + `Class ...`
- `g:filetype_cls='objectscript'` override
- Verified existing `.cls` cases continue to resolve to the same filetypes.