### PR TITLE
Fix race condition in popup window being freed

### DIFF
--- a/src/highlight.c
+++ b/src/highlight.c
@@ -5758,6 +5758,9 @@ update_winhighlight(win_T *wp, char_u *opt)
     if (arr == NULL && err != NULL)
 	return err;
 
+    if (arr == NULL && wp->w_hl == NULL)
+	return NULL;
+
     update_highlight_overrides(wp->w_hl, arr, num);
 
     vim_free(wp->w_hl);

--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -3283,6 +3283,12 @@ popup_close_tabpage(tabpage_T *tp, int id, int force)
 		}
 		back_to_prevwin(wp);
 	    }
+
+	    // Set curwin for tabpage to a valid window, in case we try
+	    // accessing it later.
+	    if (tp->tp_curwin == wp)
+		tp->tp_curwin = tp->tp_firstwin;
+
 	    if (prev == NULL)
 		*root = wp->w_next;
 	    else


### PR DESCRIPTION
Should fix #19650

I found a way to reproduce it and managed to get an ASAN log:
```
=================================================================
==157354==ERROR: AddressSanitizer: heap-use-after-free on address 0x7e33f4270e90 at pc 0x559ef4289613 bp 0x7fffff63c900 sp 0x7fffff63c8f0
READ of size 4 at 0x7e33f4270e90 thread T0
    #0 0x559ef4289612 in draw_tabline /srv/git/vim/src/screen.c:4702
    #1 0x559ef3ae3382 in update_screen /srv/git/vim/src/drawscreen.c:284
    #2 0x559ef48cffe5 in main_loop /srv/git/vim/src/main.c:1529
    #3 0x559ef48ce7b9 in vim_main2 /srv/git/vim/src/main.c:979
    #4 0x559ef48cdbac in main /srv/git/vim/src/main.c:453
    #5 0x7fe3f4a366c0  (/usr/lib/libc.so.6+0x276c0) (BuildId: 7a8d41a2df4fde040b4c6ac2832311ab645a1e41)
    #6 0x7fe3f4a367f8 in __libc_start_main (/usr/lib/libc.so.6+0x277f8) (BuildId: 7a8d41a2df4fde040b4c6ac2832311ab645a1e41)
    #7 0x559ef3927824 in _start (/srv/git/vim/src/vim+0x1921824) (BuildId: 080d135e75b6c6d0a38f2d833149dcb1474f180a)

0x7e33f4270e90 is located 9616 bytes inside of 9624-byte region [0x7e33f426e900,0x7e33f4270e98)
freed by thread T0 here:
    #0 0x7fe3f571f79d  (/usr/lib/libasan.so.8+0x11f79d) (BuildId: 0b96d08695bbce2da9d4770c29ad2e72fb536f47)
    #1 0x559ef39288cd in vim_free /srv/git/vim/src/alloc.c:616
    #2 0x559ef478691b in win_free /srv/git/vim/src/window.c:6128
    #3 0x559ef4786d42 in win_free_popup /srv/git/vim/src/window.c:6164
    #4 0x559ef410a2b1 in popup_free /srv/git/vim/src/popupwin.c:3189
    #5 0x559ef410ac50 in popup_close_tabpage /srv/git/vim/src/popupwin.c:3294
    #6 0x559ef410a883 in popup_close /srv/git/vim/src/popupwin.c:3259
    #7 0x559ef4106654 in popup_close_and_callback /srv/git/vim/src/popupwin.c:2740
    #8 0x559ef4106774 in popup_close_with_retval /srv/git/vim/src/popupwin.c:2751
    #9 0x559ef4114b9f in popup_check_cursor_pos /srv/git/vim/src/popupwin.c:4076
    #10 0x559ef48cf733 in main_loop /srv/git/vim/src/main.c:1432
    #11 0x559ef48ce7b9 in vim_main2 /srv/git/vim/src/main.c:979
    #12 0x559ef48cdbac in main /srv/git/vim/src/main.c:453
    #13 0x7fe3f4a366c0  (/usr/lib/libc.so.6+0x276c0) (BuildId: 7a8d41a2df4fde040b4c6ac2832311ab645a1e41)
    #14 0x7fe3f4a367f8 in __libc_start_main (/usr/lib/libc.so.6+0x277f8) (BuildId: 7a8d41a2df4fde040b4c6ac2832311ab645a1e41)
    #15 0x559ef3927824 in _start (/srv/git/vim/src/vim+0x1921824) (BuildId: 080d135e75b6c6d0a38f2d833149dcb1474f180a)

previously allocated by thread T0 here:
    #0 0x7fe3f5720cb5 in malloc (/usr/lib/libasan.so.8+0x120cb5) (BuildId: 0b96d08695bbce2da9d4770c29ad2e72fb536f47)
    #1 0x559ef3927cd0 in lalloc /srv/git/vim/src/alloc.c:246
    #2 0x559ef3927b43 in alloc_clear /srv/git/vim/src/alloc.c:177
    #3 0x559ef47843e8 in win_alloc /srv/git/vim/src/window.c:5901
    #4 0x559ef477b099 in win_alloc_popup_win /srv/git/vim/src/window.c:4620
    #5 0x559ef4101d98 in popup_create /srv/git/vim/src/popupwin.c:2349
    #6 0x559ef41059f6 in f_popup_atcursor /srv/git/vim/src/popupwin.c:2627
    #7 0x559ef3b960de in call_internal_func_by_idx /srv/git/vim/src/evalfunc.c:3511
    #8 0x559ef464e6b8 in call_bfunc /srv/git/vim/src/vim9execute.c:1388
    #9 0x559ef467f953 in exec_instructions /srv/git/vim/src/vim9execute.c:4869
    #10 0x559ef46a1a14 in call_def_function /srv/git/vim/src/vim9execute.c:6871
    #11 0x559ef458cd5c in call_user_func /srv/git/vim/src/userfunc.c:3050
    #12 0x559ef4592e29 in call_user_func_check /srv/git/vim/src/userfunc.c:3485
    #13 0x559ef4598831 in call_func /srv/git/vim/src/userfunc.c:4158
    #14 0x559ef4595966 in call_callback /srv/git/vim/src/userfunc.c:3818
    #15 0x559ef4857522 in invoke_callback /srv/git/vim/src/channel.c:2111
    #16 0x559ef4861d45 in invoke_one_time_callback /srv/git/vim/src/channel.c:3092
    #17 0x559ef4865646 in may_invoke_callback /srv/git/vim/src/channel.c:3453
    #18 0x559ef4872c5e in channel_parse_messages /srv/git/vim/src/channel.c:5407
    #19 0x559ef3d8b3a0 in parse_queued_messages /srv/git/vim/src/getchar.c:2653
    #20 0x559ef452f656 in inchar_loop /srv/git/vim/src/ui.c:298
    #21 0x559ef40a3d88 in mch_inchar /srv/git/vim/src/os_unix.c:591
    #22 0x559ef452f442 in ui_inchar /srv/git/vim/src/ui.c:232
    #23 0x559ef3d98219 in inchar /srv/git/vim/src/getchar.c:4124
    #24 0x559ef3d96f28 in vgetorpeek /srv/git/vim/src/getchar.c:3909
    #25 0x559ef3d86c0f in vgetc /srv/git/vim/src/getchar.c:1954
    #26 0x559ef3d88bff in safe_vgetc /srv/git/vim/src/getchar.c:2291
    #27 0x559ef3f9b6f7 in normal_cmd /srv/git/vim/src/normal.c:767
    #28 0x559ef48d033f in main_loop /srv/git/vim/src/main.c:1641
    #29 0x559ef48ce7b9 in vim_main2 /srv/git/vim/src/main.c:979

SUMMARY: AddressSanitizer: heap-use-after-free /srv/git/vim/src/screen.c:4702 in draw_tabline
Shadow bytes around the buggy address:
  0x7e33f4270c00: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x7e33f4270c80: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x7e33f4270d00: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x7e33f4270d80: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x7e33f4270e00: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
=>0x7e33f4270e80: fd fd[fd]fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x7e33f4270f00: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x7e33f4270f80: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x7e33f4271000: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x7e33f4271080: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x7e33f4271100: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==157354==ABORTING
```

It looks like the popup window is being freed but is still set in the tabpage, then later the winhighlight logic tries accessing the window which is now a dangling pointer.

It seems that this only occurs with popup windows with certain settings, however I am not very familiar with popup windows unfortunately. A way to reproduce this is using yegappan's lsp plugin, and make :LspHover show popups. Then open vim, create a new separate tabpage, do a split, then try doing :LspHover on something, causing the popup to show. 