### PR TITLE
tests: unnecessary CheckRunVimInTerminal

### DIFF
--- a/src/testdir/test_quickfix.vim
+++ b/src/testdir/test_quickfix.vim
@@ -6993,7 +6993,6 @@ func Test_quickfixtextfunc_wipes_buffer()
 endfunc
 
 func Test_quickfix_longline_noeol()
-  CheckRunVimInTerminal
   let qf = 'Xquickfix'
   let args = $"-q {qf}"
   let after =<< trim [CODE]


### PR DESCRIPTION
Problem:  tests: unnecessary CheckRunVimInTerminal.
Solution: Remove it.
