### PR TITLE
Fix invalid pointer casting in string_convert() arguments

### DIFF
--- a/src/os_mac_conv.c
+++ b/src/os_mac_conv.c
@@ -354,7 +354,9 @@ mac_utf16_to_enc(
 	}
 	else
 	{
-	    result = string_convert(&conv, utf8_str, (int *)&utf8_len);
+	    int len = utf8_len
+	    result = string_convert(&conv, utf8_str, &len);
+	    utf8_len = len;
 	    vim_free(utf8_str);
 	}
 

--- a/src/strings.c
+++ b/src/strings.c
@@ -1218,8 +1218,9 @@ convert_string(string_T *str, char_u *from, char_u *to, string_T *ret)
     }
     else
     {
-	ret->length = str->length;
-	ret->string = string_convert(&vimconv, str->string, (int *)&ret->length);
+	int len = str->length;
+	ret->string = string_convert(&vimconv, str->string, &len);
+	ret->length = len;
     }
     convert_setup(&vimconv, NULL, NULL);
 
@@ -1505,9 +1506,10 @@ f_blob2str(typval_T *argvars, typval_T *rettv)
 	// Use string_convert_ext with explicit input length
 	string_T    converted;
 
-	converted.length = blen;
+	int len = blen;
 	converted.string =
-	    string_convert_ext(&vimconv, (char_u *)blob_ga.ga_data, (int *)&converted.length, NULL);
+	    string_convert_ext(&vimconv, (char_u *)blob_ga.ga_data, &len, NULL);
+	converted.length = len;
 	convert_setup(&vimconv, NULL, NULL);
 	ga_clear(&blob_ga);
 	append_converted_string_to_list(&converted, validate_utf8, rettv->vval.v_list, from_encoding);


### PR DESCRIPTION
string_convert()/string_convert_ext() accept an "int *lenp" parameter,
however a few call sites were taking the address of a possibly larger
type (long, size_t) and casting it as an int * when calling these
functions.

On big-endian platforms, this passes the (likely) zeroed high bytes of
the known length through to string_convert(). This indicates it received
an empty string and returns an allocated empty string rather than
converting the input. This is exhibited by test failures like

	From test_blob.vim:
	Found errors in Test_blob2str_multi_byte_encodings():
	command line..script src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_blob2str_multi_byte_encodings line 2: Expected ['Hello'] but got ['']
	command line..script src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_blob2str_multi_byte_encodings line 3: Expected ['Hello'] but got ['']
	command line..script srctestdir/runtest.vim[636]..function RunTheTest[63]..Test_blob2str_multi_byte_encodings line 6: Expected ['Hello'] but got ['']

Instead, use a temporary local int variable as the in/out variable for
string_convert() and assign the result back to the larger typed length
variable post-conversion.