### PR TITLE
Motif detection broken on aarch64

### DIFF
--- a/src/auto/configure
+++ b/src/auto/configure
@@ -11417,7 +11417,7 @@ printf "%s\n" "no" >&6; }
 
                     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for location of Motif GUI libs" >&5
 printf %s "checking for location of Motif GUI libs... " >&6; }
-    gui_libs="`echo $x_libraries|sed 's%/^/^/*$%%'` `echo "$gui_XXX" | sed s/XXX/lib/g` /usr/lib64 /usr/lib/i386-linux-gnu /usr/lib/x86_64-linux-gnu `echo "$GUI_INC_LOC" | sed s/include/lib/` $GUI_LIB_LOC"
+    gui_libs="`echo $x_libraries|sed 's%/^/^/*$%%'` `echo "$gui_XXX" | sed s/XXX/lib/g` /usr/lib64 /usr/lib/i386-linux-gnu /usr/lib/aarch64-linux-gnu /usr/lib/x86_64-linux-gnu `echo "$GUI_INC_LOC" | sed s/include/lib/` $GUI_LIB_LOC"
     GUI_LIB_LOC=
     for try in $gui_libs; do
       for libtry in "$try"/libXm.a "$try"/libXm.dll.a "$try"/libXm.so* "$try"/libXm.sl "$try"/libXm.dylib; do
@@ -11430,6 +11430,7 @@ printf %s "checking for location of Motif GUI libs... " >&6; }
                   if test "$GUI_LIB_LOC" = /usr/lib \
 	   -o "$GUI_LIB_LOC" = /usr/lib64 \
 	   -o "$GUI_LIB_LOC" = /usr/lib/i386-linux-gnu \
+	   -o "$GUI_LIB_LOC" = /usr/lib/aarch64-linux-gnu \
 	   -o "$GUI_LIB_LOC" = /usr/lib/x86_64-linux-gnu; then
 	GUI_LIB_LOC=
 	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: in default path" >&5

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -3144,7 +3144,7 @@ if test -z "$SKIP_MOTIF"; then
     dnl Cygwin uses the .dll.a extension.
     dnl OpenSUSE appears to use /usr/lib64.
     AC_MSG_CHECKING(for location of Motif GUI libs)
-    gui_libs="`echo $x_libraries|sed 's%/[^/][^/]*$%%'` `echo "$gui_XXX" | sed s/XXX/lib/g` /usr/lib64 /usr/lib/i386-linux-gnu /usr/lib/x86_64-linux-gnu `echo "$GUI_INC_LOC" | sed s/include/lib/` $GUI_LIB_LOC"
+    gui_libs="`echo $x_libraries|sed 's%/[^/][^/]*$%%'` `echo "$gui_XXX" | sed s/XXX/lib/g` /usr/lib64 /usr/lib/i386-linux-gnu /usr/lib/aarch64-linux-gnu /usr/lib/x86_64-linux-gnu `echo "$GUI_INC_LOC" | sed s/include/lib/` $GUI_LIB_LOC"
     GUI_LIB_LOC=
     for try in $gui_libs; do
       for libtry in "$try"/libXm.a "$try"/libXm.dll.a "$try"/libXm.so* "$try"/libXm.sl "$try"/libXm.dylib; do
@@ -3159,6 +3159,7 @@ if test -z "$SKIP_MOTIF"; then
       if test "$GUI_LIB_LOC" = /usr/lib \
 	   -o "$GUI_LIB_LOC" = /usr/lib64 \
 	   -o "$GUI_LIB_LOC" = /usr/lib/i386-linux-gnu \
+	   -o "$GUI_LIB_LOC" = /usr/lib/aarch64-linux-gnu \
 	   -o "$GUI_LIB_LOC" = /usr/lib/x86_64-linux-gnu; then
 	GUI_LIB_LOC=
 	AC_MSG_RESULT(in default path)


### PR DESCRIPTION
Problem:  Motif libraries are not found on aarch64 (ARM64) systems.
          The configure script does not look in the multiarch path
          /usr/lib/aarch64-linux-gnu.
Solution: Add the aarch64-linux-gnu path to the Motif library search
          logic in configure.ac.

I noticed that the configure script did not pick up the motif libraries on my Debian machine when trying to inspect the issue Tony mentioned. @jamessan not sure how you build the motif gui on Debian, but does that change make sense for you?