### PR TITLE
Fix translation for 'paste' in zh_CN.UTF-8.po

### DIFF
--- a/src/po/zh_CN.UTF-8.po
+++ b/src/po/zh_CN.UTF-8.po
@@ -2729,7 +2729,7 @@ msgid " Arabic"
 msgstr " Arabic"
 
 msgid " (paste)"
-msgstr " (粘帖)"
+msgstr " (粘贴)"
 
 msgid " VISUAL"
 msgstr " 可视"


### PR DESCRIPTION
Corrected the translation for 'paste' from '粘帖' to '粘贴'.

Explanation: In Chinese, the correct term for the computer action "paste" is 粘贴 (zhān tiē). The original translation used 粘帖, which contains a very common typo. The second character was mistakenly written as 帖 (which means a note or invitation) instead of the correct character 贴 (which means to stick or paste).