### PR TITLE
fix(channel): fix ch_listen() issues on Windows

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -1440,7 +1440,7 @@ channel_listen_func(typval_T *argvars)
 	    return NULL;
 	}
 	port = strtol((char *)(p + 1), &rest, 10);
-	if (port <= 0 || port >= 65536 || *rest != NUL)
+	if (port < 0 || port >= 65536 || *rest != NUL)
 	{
 	    semsg(_(e_invalid_argument_str), address);
 	    return NULL;
@@ -1459,7 +1459,7 @@ channel_listen_func(typval_T *argvars)
 	    return NULL;
 	}
 	port = strtol((char *)(p + 1), &rest, 10);
-	if (port <= 0 || port >= 65536 || *rest != NUL)
+	if (port < 0 || port >= 65536 || *rest != NUL)
 	{
 	    semsg(_(e_invalid_argument_str), address);
 	    return NULL;
@@ -1511,6 +1511,10 @@ channel_listen(
     int			val = 1;
     channel_T		*channel;
 
+#ifdef MSWIN
+    channel_init_winsock();
+#endif
+
     channel = add_channel();
     if (channel == NULL)
     {
@@ -1555,7 +1559,7 @@ channel_listen(
     }
 
 #ifdef MSWIN
-    if (setsockopt(sd, SOL_SOCKET, SO_REUSEADDR,
+    if (setsockopt(sd, SOL_SOCKET, SO_EXCLUSIVEADDRUSE,
 				    (const char *)&val, sizeof(val)) < 0)
 #else
     if (setsockopt(sd, SOL_SOCKET, SO_REUSEADDR,
@@ -1589,6 +1593,16 @@ channel_listen(
 	sock_close(sd);
 	channel_free(channel);
 	return NULL;
+    }
+
+    // When port 0 was specified, retrieve the actual port assigned by the OS.
+    if (port_in == 0)
+    {
+	struct sockaddr_in	addr;
+	socklen_t		addr_len = sizeof(addr);
+
+	if (getsockname(sd, (struct sockaddr *)&addr, &addr_len) == 0)
+	    port_in = ntohs(addr.sin_port);
     }
 
     channel->ch_listen = TRUE;

--- a/src/testdir/test_channel.vim
+++ b/src/testdir/test_channel.vim
@@ -2798,8 +2798,11 @@ func Test_listen_invalid_address()
     " port number too large
     call assert_fails("call ch_listen('localhost:99999')", 'E475:')
 
-    " port number zero
-    call assert_fails("call ch_listen('localhost:0')", 'E475:')
+    " port number zero should let the OS assign an available port
+    let ch = ch_listen('localhost:0')
+    call assert_equal('open', ch_status(ch))
+    call assert_notequal(0, ch_info(ch).port)
+    call ch_close(ch)
 
     " port number negative
     call assert_fails("call ch_listen('localhost:-1')", 'E475:')


### PR DESCRIPTION
- Call channel_init_winsock() in channel_listen() so ch_listen() works without a prior ch_open() call
- Use SO_EXCLUSIVEADDRUSE instead of SO_REUSEADDR on Windows to prevent multiple processes from binding to the same port
- Allow port 0 to let the OS assign an available port, and retrieve the actual port with getsockname()

closes #19231

🤖 Generated with [Claude Code](https://claude.com/claude-code)