### PR TITLE
Fix screen flash on startup with 'termguicolors' and 'visualbell' on Win32

### DIFF
--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -7496,17 +7496,22 @@ notsgr:
 	}
 	else if (s[0] == ESC && len >= 3-1 && s[1] == '[')
 	{
-	    int l = 2;
-
-	    if (SAFE_isdigit(s[l]))
-		l++;
-	    if (s[l] == ' ' && s[l + 1] == 'q')
+	    // When USE_VTP is active, CSI sequences written through
+	    // write_chars() are interpreted by the console's VTP parser,
+	    // generating responses (e.g. DECRQM) that end up in the
+	    // input buffer as unwanted keystrokes.  Discard them.
+	    if (USE_VTP)
 	    {
-		// DECSCUSR (cursor style) sequences
-		if (vtp_working)
-		    vtp_printf("%.*s", l + 2, s);   // Pass through
-		s += l + 2;
-		len -= l + 1;
+		int l = 2;
+
+		// skip parameter and intermediate bytes (0x20-0x3F)
+		while (s + l < end && s[l] >= 0x20 && s[l] <= 0x3F)
+		    l++;
+		// skip the final byte (0x40-0x7E)
+		if (s + l < end && s[l] >= 0x40 && s[l] <= 0x7E)
+		    l++;
+		len -= l - 1;
+		s += l;
 	    }
 	}
 	else


### PR DESCRIPTION
When both `set visualbell` and `set termguicolors` are in vimrc, the screen flashes on startup in the Windows console.

When `USE_VTP` is active (`termguicolors` or 256 colors), `write_chars()` uses `WriteConsoleW()` which feeds into the console's VTP parser. CSI sequences such as DECRQM queries (`\033[?2026$p`) written through `mch_write()` are passed character-by-character to `write_chars()`, but the console's VTP parser still assembles them into complete sequences and generates responses. The DECRQM response (`\033[?2026;2$y`) ends up in the input buffer and its leading ESC is interpreted as an ESC keypress in Normal mode, triggering a beep — visible as a screen flash when `visualbell` is set.

Fix by discarding CSI sequences in `mch_write()` when `USE_VTP` is active, since the console cannot properly return their responses through Vim's input handling.

related: #11532