### PR TITLE
Fix missing semicolon in os_mac_conv.c introduced by patch 9.2.0168

### DIFF
--- a/src/os_mac_conv.c
+++ b/src/os_mac_conv.c
@@ -354,7 +354,7 @@ mac_utf16_to_enc(
 	}
 	else
 	{
-	    int len = utf8_len
+	    int len = utf8_len;
 	    result = string_convert(&conv, utf8_str, &len);
 	    utf8_len = len;
 	    vim_free(utf8_str);


### PR DESCRIPTION
patch 9.2.0168 (b00f441e6) introduced a missing semicolon in os_mac_conv.c line 357, breaking the macOS CI build.

I don't have a macOS machine to verify, but the fix should be obvious — just a missing `;` after `int len = utf8_len`.