### PR TITLE
Run check_restricted() in diff_file() before call_shell()

### DIFF
--- a/src/diff.c
+++ b/src/diff.c
@@ -1371,6 +1371,9 @@ diff_file(diffio_T *dio)
     if (dio->dio_internal)
 	return diff_file_internal(dio);
 
+    if (check_restricted())
+	return FAIL;
+
     len = STRLEN(tmp_orig) + STRLEN(tmp_new)
 				+ STRLEN(tmp_diff) + STRLEN(p_srr) + 27;
     cmd = alloc(len);

--- a/src/testdir/test_restricted.vim
+++ b/src/testdir/test_restricted.vim
@@ -115,4 +115,27 @@ func Test_restricted_mode()
   call delete('Xresult')
 endfunc
 
+" Test that external diff is blocked in restricted mode.
+" Using :diffupdate with 'diffopt' excluding "internal" would call an external
+" diff program via call_shell(), which must be blocked.
+func Test_restricted_diff()
+  let lines =<< trim END
+    set diffopt=filler
+    call writefile(['line1', 'line2'], 'Xrfile1', 'D')
+    call writefile(['line1', 'line3'], 'Xrfile2', 'D')
+    edit Xrfile1
+    diffthis
+    split Xrfile2
+    diffthis
+    call assert_fails('diffupdate', 'E145:')
+    call writefile(v:errors, 'Xresult')
+    qa!
+  END
+  call writefile(lines, 'Xrestricteddiff', 'D')
+  if RunVim([], [], '-Z --clean -S Xrestricteddiff')
+    call assert_equal([], readfile('Xresult'))
+  endif
+  call delete('Xresult')
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
To prevent restricted Vim escape.