### PR TITLE
Disallow settings variables in ex_let_env() when in restricted mode

### DIFF
--- a/src/evalvars.c
+++ b/src/evalvars.c
@@ -1712,7 +1712,7 @@ ex_let_env(
 	else if (endchars != NULL
 			      && vim_strchr(endchars, *skipwhite(arg)) == NULL)
 	    emsg(_(e_unexpected_characters_in_let));
-	else if (!check_secure())
+	else if (!check_secure() && !check_restricted())
 	{
 	    char_u	*tofree = NULL;
 	    int		c1 = name[len];


### PR DESCRIPTION
Related issue: #13394