### PR TITLE
Fix DirectWrite glyph pixel spillover leaving artifacts

### DIFF
--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -6670,6 +6670,16 @@ gui_mch_draw_string(
 	    pcliprect = &rc;
 	    foptions = ETO_CLIPPED;
 	}
+#ifdef FEAT_DIRECTX
+	// DirectWrite anti-aliasing can extend glyph pixels beyond cell
+	// boundaries, leaving artifacts when adjacent cells are not
+	// redrawn.  Clip to the cell rect to prevent this.
+	else if (IS_ENABLE_DIRECTX())
+	{
+	    pcliprect = &rc;
+	    foptions = ETO_CLIPPED;
+	}
+#endif
     }
     SetTextColor(s_hdc, gui.currFgColor);
     SelectFont(s_hdc, gui.currFont);


### PR DESCRIPTION
When using DirectWrite rendering, glyph pixels rendered by anti-aliasing can extend beyond cell boundaries. When adjacent cells are later redrawn without the overflowing cell being redrawn at the same time, the spillover pixels remain on screen as visual artifacts.

This is reproducible with plugins that rapidly create and destroy popup windows with `opacity: 0` (e.g., cursor animation plugins), but the root cause is general to DirectWrite rendering.

GDI rendering does not exhibit this issue. The artifacts can be cleared with `CTRL-L` (full screen redraw).

The fix clips DirectWrite text rendering to the cell rectangle by setting `ETO_CLIPPED`, matching the existing behavior already used for cursor drawing.

Trying with https://github.com/mattn/vim-smear-cursor/

Before

https://github.com/user-attachments/assets/7dc9dfe2-e6e5-4d59-ba8f-f1ed4227e4fc

After


https://github.com/user-attachments/assets/f11937d3-cbc7-4694-be35-e7d10c3da8d3


