### PR TITLE
Fix #19717

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -6984,7 +6984,9 @@ var2fpos(
 	if (name[1] == '0')		// "w0": first visible line
 	{
 #ifdef FEAT_TERMINAL
-	    if (bt_terminal(curwin->w_buffer) && curwin->w_buffer->b_term != NULL)
+	    if (bt_terminal(curwin->w_buffer)
+				    && curwin->w_buffer->b_term != NULL
+				    && !term_in_normal_mode(curwin->w_buffer))
 		may_move_terminal_to_buffer(curwin->w_buffer->b_term, TRUE);
 #endif
 	    update_topline();
@@ -6996,7 +6998,9 @@ var2fpos(
 	else if (name[1] == '$')	// "w$": last visible line
 	{
 #ifdef FEAT_TERMINAL
-	    if (bt_terminal(curwin->w_buffer) && curwin->w_buffer->b_term != NULL)
+	    if (bt_terminal(curwin->w_buffer)
+				    && curwin->w_buffer->b_term != NULL
+				    && !term_in_normal_mode(curwin->w_buffer))
 		may_move_terminal_to_buffer(curwin->w_buffer->b_term, TRUE);
 #endif
 	    validate_botline();

--- a/src/misc1.c
+++ b/src/misc1.c
@@ -772,7 +772,7 @@ get_mode(char_u *buf)
 	    buf[i++] = restart_edit;
 	}
 # ifdef FEAT_TERMINAL
-	else if (term_in_normal_mode())
+	else if (term_in_normal_mode(curbuf))
 	    buf[i++] = 't';
 # endif
     }

--- a/src/normal.c
+++ b/src/normal.c
@@ -6985,7 +6985,7 @@ nv_edit(cmdarg_T *cap)
     if (VIsual_active && (cap->cmdchar == 'A' || cap->cmdchar == 'I'))
     {
 #ifdef FEAT_TERMINAL
-	if (term_in_normal_mode())
+	if (term_in_normal_mode(curbuf))
 	{
 	    end_visual_mode();
 	    clearop(cap->oap);
@@ -7003,7 +7003,7 @@ nv_edit(cmdarg_T *cap)
 	nv_object(cap);
     }
 #ifdef FEAT_TERMINAL
-    else if (term_in_normal_mode())
+    else if (term_in_normal_mode(curbuf))
     {
 	clearop(cap->oap);
 	term_enter_job_mode();

--- a/src/option.c
+++ b/src/option.c
@@ -3854,7 +3854,7 @@ did_set_modifiable(optset_T *args UNUSED)
 
 #ifdef FEAT_TERMINAL
     // Cannot set 'modifiable' when in Terminal mode.
-    if (curbuf->b_p_ma && (term_in_normal_mode() || (bt_terminal(curbuf)
+    if (curbuf->b_p_ma && (term_in_normal_mode(curbuf) || (bt_terminal(curbuf)
 		    && curbuf->b_term != NULL && !term_is_finished(curbuf))))
     {
 	curbuf->b_p_ma = FALSE;

--- a/src/proto/terminal.pro
+++ b/src/proto/terminal.pro
@@ -15,7 +15,7 @@ int term_confirm_stop(buf_T *buf);
 int term_try_stop_job(buf_T *buf);
 void may_move_terminal_to_buffer(term_T *term, int redraw);
 int term_check_timers(int next_due_arg, proftime_T *now);
-int term_in_normal_mode(void);
+int term_in_normal_mode(buf_T *buf);
 void term_enter_job_mode(void);
 void check_no_reduce_keys(void);
 int send_keys_to_term(term_T *term, int c, int modmask, int typed);

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -2302,9 +2302,9 @@ term_enter_normal_mode(void)
  * Terminal-Normal mode.
  */
     int
-term_in_normal_mode(void)
+term_in_normal_mode(buf_T *buf)
 {
-    term_T *term = curbuf->b_term;
+    term_T *term = buf->b_term;
 
     return term != NULL && term->tl_normal_mode;
 }

--- a/src/testdir/test_terminal3.vim
+++ b/src/testdir/test_terminal3.vim
@@ -1202,6 +1202,14 @@ func Test_term_getpos()
   call assert_equal(13, str2nr(result[1]) - str2nr(result[0]))
   call assert_true(str2nr(result[0]) > 1)
 
+  " Regression: line('w0') and line('w$') must not move cursor position
+  call term_sendkeys(buf, "gg")
+  call term_sendkeys(buf, ":call line('w0')\<cr>")
+  call term_sendkeys(buf, ":call line('w$')\<cr>")
+  call term_wait(buf)
+  call WaitForAssert({-> assert_match("for i in", term_getline(buf, 1))})
+  call WaitForAssert({-> assert_match("line12", term_getline(buf, 13))})
+
   call StopVimInTerminal(buf)
   " this crashed
   new


### PR DESCRIPTION
Fix #19717

* change not to call `may_move_terminal_to_buffer` at termianl-normal mode in `var2fpos`