### PR TITLE
Use the return value of copy_option_part()

### DIFF
--- a/src/bufwrite.c
+++ b/src/bufwrite.c
@@ -1346,7 +1346,7 @@ buf_write(
 	    {
 #if defined(UNIX) || defined(MSWIN)
 		char_u	*p;
-		size_t	copybuf_len;
+		int	copybuf_len;
 #endif
 
 #ifdef UNIX
@@ -1357,7 +1357,7 @@ buf_write(
 
 		// Isolate one directory name, using an entry in 'bdir'.
 #if defined(UNIX) || defined(MSWIN)
-		copybuf_len = (size_t)
+		copybuf_len =
 #else
 		(void)
 #endif
@@ -1578,9 +1578,9 @@ buf_write(
 	    {
 		// Isolate one directory name and make the backup file name.
 #if defined(UNIX) || defined(MSWIN)
-		size_t	IObufflen;
+		int	IObufflen;
 
-		IObufflen = (size_t)
+		IObufflen =
 #else
 		(void)
 #endif

--- a/src/bufwrite.c
+++ b/src/bufwrite.c
@@ -1314,14 +1314,11 @@ buf_write(
 		&& (fd = mch_open((char *)fname, O_RDONLY | O_EXTRA, 0)) >= 0)
 	{
 	    int		bfd;
-	    char_u	*copybuf, *wp;
+	    char_u	*copybuf;
 	    int		some_error = FALSE;
 	    stat_T	st_new;
 	    char_u	*dirp;
 	    char_u	*rootname;
-#if defined(UNIX) || defined(MSWIN)
-	    char_u      *p;
-#endif
 #if defined(UNIX)
 	    int		did_set_shortname;
 	    mode_t	umask_save;
@@ -1347,6 +1344,11 @@ buf_write(
 	    dirp = p_bdir;
 	    while (*dirp)
 	    {
+#if defined(UNIX) || defined(MSWIN)
+		char_u	*p;
+		size_t	copybuf_len;
+#endif
+
 #ifdef UNIX
 		st_new.st_ino = 0;
 		st_new.st_dev = 0;
@@ -1354,10 +1356,15 @@ buf_write(
 #endif
 
 		// Isolate one directory name, using an entry in 'bdir'.
-		(void)copy_option_part(&dirp, copybuf, WRITEBUFSIZE, ",");
+#if defined(UNIX) || defined(MSWIN)
+		copybuf_len = (size_t)
+#else
+		(void)
+#endif
+		    copy_option_part(&dirp, copybuf, WRITEBUFSIZE, ",");
 
 #if defined(UNIX) || defined(MSWIN)
-		p = copybuf + STRLEN(copybuf);
+		p = copybuf + copybuf_len;
 		if (after_pathsep(copybuf, p) && p[-1] == p[-2])
 		    // Ends with '//', use full path
 		    if ((p = make_percent_swname(copybuf, p, fname)) != NULL)
@@ -1423,6 +1430,8 @@ buf_write(
 			// Change one character, just before the extension.
 			if (!p_bk)
 			{
+			    char_u	*wp;
+
 			    wp = backup + STRLEN(backup) - 1
 							 - STRLEN(backup_ext);
 			    if (wp < backup)	// empty file name ???
@@ -1568,10 +1577,17 @@ buf_write(
 	    while (*dirp)
 	    {
 		// Isolate one directory name and make the backup file name.
-		(void)copy_option_part(&dirp, IObuff, IOSIZE, ",");
+#if defined(UNIX) || defined(MSWIN)
+		size_t	IObufflen;
+
+		IObufflen = (size_t)
+#else
+		(void)
+#endif
+		    copy_option_part(&dirp, IObuff, IOSIZE, ",");
 
 #if defined(UNIX) || defined(MSWIN)
-		p = IObuff + STRLEN(IObuff);
+		p = IObuff + IObufflen;
 		if (after_pathsep(IObuff, p) && p[-1] == p[-2])
 		    // path ends with '//', use full path
 		    if ((p = make_percent_swname(IObuff, p, fname)) != NULL)

--- a/src/bufwrite.c
+++ b/src/bufwrite.c
@@ -1344,10 +1344,8 @@ buf_write(
 	    dirp = p_bdir;
 	    while (*dirp)
 	    {
-#if defined(UNIX) || defined(MSWIN)
-		char_u	*p;
-		int	copybuf_len;
-#endif
+		char_u	*p UNUSED;
+		int	copybuf_len UNUSED;
 
 #ifdef UNIX
 		st_new.st_ino = 0;
@@ -1356,12 +1354,7 @@ buf_write(
 #endif
 
 		// Isolate one directory name, using an entry in 'bdir'.
-#if defined(UNIX) || defined(MSWIN)
-		copybuf_len =
-#else
-		(void)
-#endif
-		    copy_option_part(&dirp, copybuf, WRITEBUFSIZE, ",");
+		copybuf_len = copy_option_part(&dirp, copybuf, WRITEBUFSIZE, ",");
 
 #if defined(UNIX) || defined(MSWIN)
 		p = copybuf + copybuf_len;
@@ -1576,15 +1569,10 @@ buf_write(
 	    dirp = p_bdir;
 	    while (*dirp)
 	    {
-		// Isolate one directory name and make the backup file name.
-#if defined(UNIX) || defined(MSWIN)
-		int	IObufflen;
+		int IObufflen UNUSED;
 
-		IObufflen =
-#else
-		(void)
-#endif
-		    copy_option_part(&dirp, IObuff, IOSIZE, ",");
+		// Isolate one directory name and make the backup file name.
+		IObufflen = copy_option_part(&dirp, IObuff, IOSIZE, ",");
 
 #if defined(UNIX) || defined(MSWIN)
 		p = IObuff + IObufflen;

--- a/src/change.c
+++ b/src/change.c
@@ -1894,6 +1894,7 @@ open_line(
 	char_u	*lead_repl = NULL;	    // replaces comment leader
 	int	lead_repl_len = 0;	    // length of *lead_repl
 	char_u	lead_middle[COM_MAX_LEN];   // middle-comment string
+	int	lead_middle_len;	    // length of the lead_middle
 	char_u	lead_end[COM_MAX_LEN];	    // end-comment string
 	char_u	*comment_end = NULL;	    // where lead_end has been found
 	int	extra_space = FALSE;	    // append extra space
@@ -1934,7 +1935,7 @@ open_line(
 			require_blank = TRUE;
 		    ++p;
 		}
-		(void)copy_option_part(&p, lead_middle, COM_MAX_LEN, ",");
+		lead_middle_len = copy_option_part(&p, lead_middle, COM_MAX_LEN, ",");
 
 		while (*p && p[-1] != ':')	// find end of end flags
 		{
@@ -1967,7 +1968,7 @@ open_line(
 		    if (current_flag == COM_START)
 		    {
 			lead_repl = lead_middle;
-			lead_repl_len = (int)STRLEN(lead_middle);
+			lead_repl_len = lead_middle_len;
 		    }
 
 		    // If we have hit RETURN immediately after the start

--- a/src/cindent.c
+++ b/src/cindent.c
@@ -2280,6 +2280,7 @@ get_c_indent(void)
 	char_u	lead_start[COM_MAX_LEN];	// start-comment string
 	char_u	lead_middle[COM_MAX_LEN];	// middle-comment string
 	char_u	lead_end[COM_MAX_LEN];		// end-comment string
+	int	lead_end_len;
 	char_u	*p;
 	int	start_align = 0;
 	int	start_off = 0;
@@ -2312,25 +2313,25 @@ get_c_indent(void)
 
 	    if (*p == ':')
 		++p;
-	    (void)copy_option_part(&p, lead_end, COM_MAX_LEN, ",");
+	    lead_end_len = copy_option_part(&p, lead_end, COM_MAX_LEN, ",");
 	    if (what == COM_START)
 	    {
 		STRCPY(lead_start, lead_end);
-		lead_start_len = (int)STRLEN(lead_start);
+		lead_start_len = lead_end_len;
 		start_off = off;
 		start_align = align;
 	    }
 	    else if (what == COM_MIDDLE)
 	    {
 		STRCPY(lead_middle, lead_end);
-		lead_middle_len = (int)STRLEN(lead_middle);
+		lead_middle_len = lead_end_len;
 	    }
 	    else if (what == COM_END)
 	    {
 		// If our line starts with the middle comment string, line it
 		// up with the comment opener per the 'comments' option.
 		if (STRNCMP(theline, lead_middle, lead_middle_len) == 0
-			&& STRNCMP(theline, lead_end, STRLEN(lead_end)) != 0)
+			&& STRNCMP(theline, lead_end, lead_end_len) != 0)
 		{
 		    done = TRUE;
 		    if (curwin->w_cursor.lnum > 1)
@@ -2366,7 +2367,7 @@ get_c_indent(void)
 		// If our line starts with the end comment string, line it up
 		// with the middle comment
 		if (STRNCMP(theline, lead_middle, lead_middle_len) != 0
-			&& STRNCMP(theline, lead_end, STRLEN(lead_end)) == 0)
+			&& STRNCMP(theline, lead_end, lead_end_len) == 0)
 		{
 		    amount = get_indent_lnum(curwin->w_cursor.lnum - 1);
 								     // XXX

--- a/src/help.c
+++ b/src/help.c
@@ -775,7 +775,9 @@ fix_help_buffer(void)
 	    p = p_rtp;
 	    while (*p != NUL)
 	    {
-		copy_option_part(&p, NameBuff, MAXPATHL, ",");
+		size_t	NameBufflen;
+
+		NameBufflen = (size_t)copy_option_part(&p, NameBuff, MAXPATHL, ",");
 		mustfree = FALSE;
 		rt = vim_getenv((char_u *)"VIMRUNTIME", &mustfree);
 		if (rt != NULL &&
@@ -790,11 +792,15 @@ fix_help_buffer(void)
 		    char_u	*cp;
 
 		    // Find all "doc/ *.txt" files in this directory.
-		    add_pathsep(NameBuff);
+		    if (*NameBuff != NUL && !after_pathsep(NameBuff, NameBuff + NameBufflen))
+		    {
+			STRCPY(NameBuff + NameBufflen, PATHSEPSTR);
+			NameBufflen += STRLEN_LITERAL(PATHSEPSTR);
+		    }
 #ifdef FEAT_MULTI_LANG
-		    STRCAT(NameBuff, "doc/*.??[tx]");
+		    STRCPY(NameBuff + NameBufflen, "doc/*.??[tx]");
 #else
-		    STRCAT(NameBuff, "doc/*.txt");
+		    STRCPY(NameBuff + NameBufflen, "doc/*.txt");
 #endif
 		    if (gen_expand_wildcards(1, &NameBuff, &fcount,
 					 &fnames, EW_FILE|EW_SILENT) == OK

--- a/src/help.c
+++ b/src/help.c
@@ -775,9 +775,9 @@ fix_help_buffer(void)
 	    p = p_rtp;
 	    while (*p != NUL)
 	    {
-		size_t	NameBufflen;
+		int NameBufflen;
 
-		NameBufflen = (size_t)copy_option_part(&p, NameBuff, MAXPATHL, ",");
+		NameBufflen = copy_option_part(&p, NameBuff, MAXPATHL, ",");
 		mustfree = FALSE;
 		rt = vim_getenv((char_u *)"VIMRUNTIME", &mustfree);
 		if (rt != NULL &&

--- a/src/memline.c
+++ b/src/memline.c
@@ -1945,7 +1945,7 @@ recover_names(
 #ifdef VMS
 		names[0] = vim_strnsave((char_u *)"*_sw%", STRLEN_LITERAL("*_sw%"));
 #else
-		names[0] = vim_strnsave((char_u *)"*.sw?", STRLEN_LITERAL("*_sw?"));
+		names[0] = vim_strnsave((char_u *)"*.sw?", STRLEN_LITERAL("*.sw?"));
 #endif
 #if defined(UNIX) || defined(MSWIN)
 		// For Unix names starting with a dot are special.  MS-Windows

--- a/src/memline.c
+++ b/src/memline.c
@@ -1898,7 +1898,7 @@ recover_names(
     int		file_count = 0;
     char_u	**files;
     char_u	*dirp;
-    char_u	*dir_name;
+    string_T	dir_name;
     char_u	*fname_res = NULL;
 #ifdef HAVE_READLINK
     char_u	fname_buf[MAXPATHL];
@@ -1927,35 +1927,35 @@ recover_names(
      * Do the loop for every directory in 'directory'.
      * First allocate some memory to put the directory name in.
      */
-    dir_name = alloc(STRLEN(p_dir) + 1);
+    dir_name.string = alloc(STRLEN(p_dir) + 1);
     dirp = p_dir;
-    while (dir_name != NULL && *dirp)
+    while (dir_name.string != NULL && *dirp)
     {
 	/*
 	 * Isolate a directory name from *dirp and put it in dir_name (we know
 	 * it is large enough, so use 31000 for length).
 	 * Advance dirp to next directory name.
 	 */
-	(void)copy_option_part(&dirp, dir_name, 31000, ",");
+	dir_name.length = (size_t)copy_option_part(&dirp, dir_name.string, 31000, ",");
 
-	if (dir_name[0] == '.' && dir_name[1] == NUL)	// check current dir
+	if (dir_name.string[0] == '.' && dir_name.string[1] == NUL)	// check current dir
 	{
 	    if (fname == NULL)
 	    {
 #ifdef VMS
-		names[0] = vim_strsave((char_u *)"*_sw%");
+		names[0] = vim_strnsave((char_u *)"*_sw%", STRLEN_LITERAL("*_sw%"));
 #else
-		names[0] = vim_strsave((char_u *)"*.sw?");
+		names[0] = vim_strnsave((char_u *)"*.sw?", STRLEN_LITERAL("*_sw?"));
 #endif
 #if defined(UNIX) || defined(MSWIN)
 		// For Unix names starting with a dot are special.  MS-Windows
 		// supports this too, on some file systems.
-		names[1] = vim_strsave((char_u *)".*.sw?");
-		names[2] = vim_strsave((char_u *)".sw?");
+		names[1] = vim_strnsave((char_u *)".*.sw?", STRLEN_LITERAL(".*.sw?$"));
+		names[2] = vim_strnsave((char_u *)".sw?", STRLEN_LITERAL(".sw?"));
 		num_names = 3;
 #else
 # ifdef VMS
-		names[1] = vim_strsave((char_u *)".*_sw%");
+		names[1] = vim_strnsave((char_u *)".*_sw%", STRLEN_LITERAL(".*_sw%"));
 		num_names = 2;
 # else
 		num_names = 1;
@@ -1970,19 +1970,19 @@ recover_names(
 	    if (fname == NULL)
 	    {
 #ifdef VMS
-		names[0] = concat_fnames(dir_name, (char_u *)"*_sw%", TRUE);
+		names[0] = concat_fnames(dir_name.string, (char_u *)"*_sw%", TRUE);
 #else
-		names[0] = concat_fnames(dir_name, (char_u *)"*.sw?", TRUE);
+		names[0] = concat_fnames(dir_name.string, (char_u *)"*.sw?", TRUE);
 #endif
 #if defined(UNIX) || defined(MSWIN)
 		// For Unix names starting with a dot are special.  MS-Windows
 		// supports this too, on some file systems.
-		names[1] = concat_fnames(dir_name, (char_u *)".*.sw?", TRUE);
-		names[2] = concat_fnames(dir_name, (char_u *)".sw?", TRUE);
+		names[1] = concat_fnames(dir_name.string, (char_u *)".*.sw?", TRUE);
+		names[2] = concat_fnames(dir_name.string, (char_u *)".sw?", TRUE);
 		num_names = 3;
 #else
 # ifdef VMS
-		names[1] = concat_fnames(dir_name, (char_u *)".*_sw%", TRUE);
+		names[1] = concat_fnames(dir_name.string, (char_u *)".*_sw%", TRUE);
 		num_names = 2;
 # else
 		num_names = 1;
@@ -1992,19 +1992,17 @@ recover_names(
 	    else
 	    {
 #if defined(UNIX) || defined(MSWIN)
-		int	len = (int)STRLEN(dir_name);
-
-		p = dir_name + len;
-		if (after_pathsep(dir_name, p) && len > 1 && p[-1] == p[-2])
+		p = dir_name.string + dir_name.length;
+		if (after_pathsep(dir_name.string, p) && dir_name.length > 1 && p[-1] == p[-2])
 		{
 		    // Ends with '//', Use Full path for swap name
-		    tail = make_percent_swname(dir_name, p, fname_res);
+		    tail = make_percent_swname(dir_name.string, p, fname_res);
 		}
 		else
 #endif
 		{
 		    tail = gettail(fname_res);
-		    tail = concat_fnames(dir_name, tail, TRUE);
+		    tail = concat_fnames(dir_name.string, tail, TRUE);
 		}
 		if (tail == NULL)
 		    num_names = 0;
@@ -2101,7 +2099,7 @@ recover_names(
 	}
 	else if (do_list)
 	{
-	    if (dir_name[0] == '.' && dir_name[1] == NUL)
+	    if (dir_name.string[0] == '.' && dir_name.string[1] == NUL)
 	    {
 		if (fname == NULL)
 		    msg_puts(_("   In current directory:\n"));
@@ -2111,7 +2109,7 @@ recover_names(
 	    else
 	    {
 		msg_puts(_("   In directory "));
-		msg_home_replace(dir_name);
+		msg_home_replace(dir_name.string);
 		msg_puts(":\n");
 	    }
 
@@ -2136,7 +2134,7 @@ recover_names(
 	{
 	    for (int i = 0; i < num_files; ++i)
 	    {
-		char_u *name = concat_fnames(dir_name, files[i], TRUE);
+		char_u *name = concat_fnames(dir_name.string, files[i], TRUE);
 		if (name != NULL)
 		{
 		    list_append_string(ret_list, name, -1);
@@ -2153,7 +2151,7 @@ recover_names(
 	if (num_files > 0)
 	    FreeWild(num_files, files);
     }
-    vim_free(dir_name);
+    vim_free(dir_name.string);
     return file_count;
 }
 

--- a/src/memline.c
+++ b/src/memline.c
@@ -1950,7 +1950,7 @@ recover_names(
 #if defined(UNIX) || defined(MSWIN)
 		// For Unix names starting with a dot are special.  MS-Windows
 		// supports this too, on some file systems.
-		names[1] = vim_strnsave((char_u *)".*.sw?", STRLEN_LITERAL(".*.sw?$"));
+		names[1] = vim_strnsave((char_u *)".*.sw?", STRLEN_LITERAL(".*.sw?"));
 		names[2] = vim_strnsave((char_u *)".sw?", STRLEN_LITERAL(".sw?"));
 		num_names = 3;
 #else

--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -5514,27 +5514,29 @@ export_myvimdir(void)
     int		dofree = FALSE;
     char_u	*p;
     char_u	*q = p_rtp;
-    char_u	*buf = alloc(MAXPATHL);
+    string_T	buf;
 
-    if (buf == NULL)
+    buf.string = alloc(MAXPATHL);
+    if (buf.string == NULL)
 	return;
 
-    (void)copy_option_part(&q, buf, MAXPATHL, ",");
+    buf.length = (size_t)copy_option_part(&q, buf.string, MAXPATHL, ",");
 
     p = vim_getenv((char_u *)"MYVIMDIR", &dofree);
 
-    if (p == NULL || STRCMP(p, buf) != 0)
+    if (p == NULL || STRCMP(p, buf.string) != 0)
     {
-	add_pathsep(buf);
+	if (*buf.string != NUL && !after_pathsep(buf.string, buf.string + buf.length))
+	    STRCPY(buf.string + buf.length, PATHSEPSTR);
 #ifdef MSWIN
 	// normalize path separators
-	for (q = buf; *q != NUL; q++)
+	for (q = buf.string; *q != NUL; q++)
 	    if (*q == '/')
 		*q = '\\';
 #endif
-	vim_setenv((char_u *)"MYVIMDIR", buf);
+	vim_setenv((char_u *)"MYVIMDIR", buf.string);
     }
     if (dofree)
 	vim_free(p);
-    vim_free(buf);
+    vim_free(buf.string);
 }

--- a/src/scriptfile.c
+++ b/src/scriptfile.c
@@ -590,10 +590,8 @@ do_in_path(
     void	*cookie)
 {
     char_u	*rtp;
-    char_u	*np;
-    char_u	*buf;
+    string_T	buf;
     char_u	*rtp_copy;
-    char_u	*tail;
     int		num_files;
     char_u	**files;
     int		i;
@@ -609,36 +607,42 @@ do_in_path(
     // Make a copy of 'runtimepath'.  Invoking the callback may change the
     // value.
     rtp_copy = vim_strsave(path);
-    buf = alloc(MAXPATHL);
-    if (buf != NULL && rtp_copy != NULL)
+    buf.string = alloc(MAXPATHL);
+    if (buf.string != NULL && rtp_copy != NULL)
     {
-	if (p_verbose > 10 && name != NULL)
+	size_t	prefixlen = 0;
+	size_t	namelen = 0;
+
+	if (name != NULL)
 	{
-	    verbose_enter();
-	    if (*prefix != NUL)
-		smsg(_("Searching for \"%s\" under \"%s\" in \"%s\""),
-					   (char *)name, prefix, (char *)path);
-	    else
-		smsg(_("Searching for \"%s\" in \"%s\""),
-						   (char *)name, (char *)path);
-	    verbose_leave();
+	    prefixlen = STRLEN(prefix);
+	    namelen = STRLEN(name);
+
+	    if (p_verbose > 10)
+	    {
+		verbose_enter();
+		if (*prefix != NUL)
+		    smsg(_("Searching for \"%s\" under \"%s\" in \"%s\""),
+					       (char *)name, prefix, (char *)path);
+		else
+		    smsg(_("Searching for \"%s\" in \"%s\""),
+						       (char *)name, (char *)path);
+		verbose_leave();
+	    }
 	}
 
 	// Loop over all entries in 'runtimepath'.
 	rtp = rtp_copy;
 	while (*rtp != NUL && ((flags & DIP_ALL) || !did_one))
 	{
-	    size_t buflen;
-
 	    // Copy the path from 'runtimepath' to buf[].
-	    copy_option_part(&rtp, buf, MAXPATHL, ",");
-	    buflen = STRLEN(buf);
+	    buf.length = (size_t)copy_option_part(&rtp, buf.string, MAXPATHL, ",");
 
 	    // Skip after or non-after directories.
 	    if (flags & (DIP_NOAFTER | DIP_AFTER))
 	    {
-		int is_after = buflen >= 5
-				     && STRCMP(buf + buflen - 5, "after") == 0;
+		int is_after = buf.length >= 5
+		    && STRCMP(buf.string + buf.length - 5, "after") == 0;
 
 		if ((is_after && (flags & DIP_NOAFTER))
 			|| (!is_after && (flags & DIP_AFTER)))
@@ -647,33 +651,42 @@ do_in_path(
 
 	    if (name == NULL)
 	    {
-		(*callback)(buf, (void *) &cookie);
+		(*callback)(buf.string, (void *)&cookie);
 		if (!did_one)
 		    did_one = (cookie == NULL);
 	    }
-	    else if (buflen + 2 + STRLEN(prefix) + STRLEN(name) < MAXPATHL)
+	    else if (buf.length + 2 + prefixlen + namelen < MAXPATHL)
 	    {
-		add_pathsep(buf);
-		STRCAT(buf, prefix);
-		tail = buf + STRLEN(buf);
+		char_u	*np;
+		char_u	*tail;
+
+		if (*buf.string != NUL
+		    && !after_pathsep(buf.string, buf.string + buf.length))
+		{
+		    STRCPY(buf.string + buf.length, PATHSEPSTR);
+		    buf.length += STRLEN_LITERAL(PATHSEPSTR);
+		}
+		STRCPY(buf.string + buf.length, prefix);
+		buf.length += prefixlen;
+		tail = buf.string + buf.length;
 
 		// Loop over all patterns in "name"
 		np = name;
 		while (*np != NUL && ((flags & DIP_ALL) || !did_one))
 		{
 		    // Append the pattern from "name" to buf[].
-		    copy_option_part(&np, tail, (int)(MAXPATHL - (tail - buf)),
+		    copy_option_part(&np, tail, (int)(MAXPATHL - (tail - buf.string)),
 								       "\t ");
 
 		    if (p_verbose > 10)
 		    {
 			verbose_enter();
-			smsg(_("Searching for \"%s\""), buf);
+			smsg(_("Searching for \"%s\""), buf.string);
 			verbose_leave();
 		    }
 
 		    // Expand wildcards, invoke the callback for each match.
-		    if (gen_expand_wildcards(1, &buf, &num_files, &files,
+		    if (gen_expand_wildcards(1, &buf.string, &num_files, &files,
 				  (flags & DIP_DIR) ? EW_DIR : EW_FILE) == OK)
 		    {
 			for (i = 0; i < num_files; ++i)
@@ -689,7 +702,7 @@ do_in_path(
 	    }
 	}
     }
-    vim_free(buf);
+    vim_free(buf.string);
     vim_free(rtp_copy);
     if (!did_one && name != NULL)
     {
@@ -838,7 +851,7 @@ add_pack_dir_to_rtp(char_u *fname)
     char_u  *after_insp = NULL;
     char_u  *ffname = NULL;
     size_t  fname_len;
-    char_u  *buf = NULL;
+    string_T	buf = {NULL, 0};
     char_u  *rtp_ffname;
     int	    match;
     int	    retval = FAIL;
@@ -865,17 +878,17 @@ add_pack_dir_to_rtp(char_u *fname)
     // Find "ffname" in "p_rtp", ignoring '/' vs '\' differences.
     // Also stop at the first "after" directory.
     fname_len = STRLEN(ffname);
-    buf = alloc(MAXPATHL);
-    if (buf == NULL)
+    buf.string = alloc(MAXPATHL);
+    if (buf.string == NULL)
 	goto theend;
     for (entry = p_rtp; *entry != NUL; )
     {
 	char_u *cur_entry = entry;
 
-	copy_option_part(&entry, buf, MAXPATHL, ",");
+	buf.length = (size_t)copy_option_part(&entry, buf.string, MAXPATHL, ",");
 
-	if ((p = (char_u *)strstr((char *)buf, "after")) != NULL
-		&& p > buf
+	if ((p = (char_u *)strstr((char *)buf.string, "after")) != NULL
+		&& p > buf.string
 		&& vim_ispathsep(p[-1])
 		&& (vim_ispathsep(p[5]) || p[5] == NUL || p[5] == ','))
 	{
@@ -889,8 +902,9 @@ add_pack_dir_to_rtp(char_u *fname)
 
 	if (insp == NULL)
 	{
-	    add_pathsep(buf);
-	    rtp_ffname = fix_fname(buf);
+	    if (*buf.string != NUL && !after_pathsep(buf.string, buf.string + buf.length))
+		STRCPY(buf.string + buf.length, PATHSEPSTR);
+	    rtp_ffname = fix_fname(buf.string);
 	    if (rtp_ffname == NULL)
 		goto theend;
 	    match = vim_fnamencmp(rtp_ffname, ffname, fname_len) == 0;
@@ -961,7 +975,7 @@ add_pack_dir_to_rtp(char_u *fname)
     retval = OK;
 
 theend:
-    vim_free(buf);
+    vim_free(buf.string);
     vim_free(ffname);
     vim_free(afterdir);
     return retval;

--- a/src/spell.c
+++ b/src/spell.c
@@ -2100,9 +2100,8 @@ parse_spelllang(win_T *wp)
     for (splp = spl_copy; *splp != NUL; )
     {
 	// Get one language name.
-	copy_option_part(&splp, lang, MAXWLEN, ",");
+	len = copy_option_part(&splp, lang, MAXWLEN, ",");
 	region = NULL;
-	len = (int)STRLEN(lang);
 
 	if (!valid_spelllang(lang))
 	    continue;
@@ -2248,8 +2247,8 @@ parse_spelllang(win_T *wp)
 	else
 	{
 	    // One entry in 'spellfile'.
-	    copy_option_part(&spf, spf_name, MAXPATHL - 4, ",");
-	    STRCAT(spf_name, ".spl");
+	    len = copy_option_part(&spf, spf_name, MAXPATHL - 4, ",");
+	    STRCPY(spf_name + len, ".spl");
 
 	    // If it was already found above then skip it.
 	    for (c = 0; c < ga.ga_len; ++c)

--- a/src/spellfile.c
+++ b/src/spellfile.c
@@ -6377,8 +6377,7 @@ spell_add_word(
     static void
 init_spellfile(void)
 {
-    char_u	*buf;
-    int		l;
+    string_T	buf;
     char_u	*fname;
     char_u	*rtp;
     char_u	*lend;
@@ -6388,9 +6387,11 @@ init_spellfile(void)
     if (*curwin->w_s->b_p_spl == NUL || curwin->w_s->b_langp.ga_len <= 0)
 	return;
 
-    buf = alloc(MAXPATHL);
-    if (buf == NULL)
+    buf.string = alloc(MAXPATHL);
+    if (buf.string == NULL)
 	return;
+
+    buf.length = 0;
 
     // Find the end of the language name.  Exclude the region.  If there
     // is a path separator remember the start of the tail.
@@ -6410,51 +6411,51 @@ init_spellfile(void)
 	if (aspath)
 	    // Use directory of an entry with path, e.g., for
 	    // "/dir/lg.utf-8.spl" use "/dir".
-	    vim_strncpy(buf, curbuf->b_s.b_p_spl,
+	    vim_strncpy(buf.string, curbuf->b_s.b_p_spl,
 		    lstart - curbuf->b_s.b_p_spl - 1);
 	else
 	    // Copy the path from 'runtimepath' to buf[].
-	    copy_option_part(&rtp, buf, MAXPATHL, ",");
-	if (filewritable(buf) == 2)
+	    buf.length = (size_t)copy_option_part(&rtp, buf.string, MAXPATHL, ",");
+	if (filewritable(buf.string) == 2)
 	{
 	    // Use the first language name from 'spelllang' and the
 	    // encoding used in the first loaded .spl file.
 	    if (aspath)
-		vim_strncpy(buf, curbuf->b_s.b_p_spl,
-			lend - curbuf->b_s.b_p_spl);
+	    {
+		buf.length = (size_t)(lend - curbuf->b_s.b_p_spl);
+		vim_strncpy(buf.string, curbuf->b_s.b_p_spl, buf.length);
+	    }
 	    else
 	    {
 		// Create the "spell" directory if it doesn't exist yet.
-		l = (int)STRLEN(buf);
-		vim_snprintf((char *)buf + l, MAXPATHL - l, "/spell");
-		if (filewritable(buf) != 2)
+		buf.length += vim_snprintf_safelen((char *)buf.string + buf.length,
+		    MAXPATHL - buf.length, "/spell");
+		if (filewritable(buf.string) != 2)
 		{
-		    if (vim_mkdir(buf, 0755) != 0)
+		    if (vim_mkdir(buf.string, 0755) != 0)
 		    {
-			vim_free(buf);
+			vim_free(buf.string);
 			return;
 		    }
 		}
 
-		l = (int)STRLEN(buf);
-		vim_snprintf((char *)buf + l, MAXPATHL - l,
-			"/%.*s", (int)(lend - lstart), lstart);
+		buf.length += vim_snprintf_safelen((char *)buf.string + buf.length,
+		    MAXPATHL - buf.length, "/%.*s", (int)(lend - lstart), lstart);
 	    }
-	    l = (int)STRLEN(buf);
 	    fname = LANGP_ENTRY(curwin->w_s->b_langp, 0)
 		->lp_slang->sl_fname;
-	    vim_snprintf((char *)buf + l, MAXPATHL - l, ".%s.add",
-		    fname != NULL
-		    && strstr((char *)gettail(fname), ".ascii.") != NULL
+	    vim_snprintf((char *)buf.string + buf.length, MAXPATHL - buf.length,
+		".%s.add",
+		fname != NULL && strstr((char *)gettail(fname), ".ascii.") != NULL
 		    ? (char_u *)"ascii" : spell_enc());
 	    set_option_value_give_err((char_u *)"spellfile",
-		    0L, buf, OPT_LOCAL);
+		    0L, buf.string, OPT_LOCAL);
 	    break;
 	}
 	aspath = FALSE;
     }
 
-    vim_free(buf);
+    vim_free(buf.string);
 }
 
 

--- a/src/viminfo.c
+++ b/src/viminfo.c
@@ -386,19 +386,18 @@ removable(char_u *name)
 {
     char_u  *p;
     char_u  part[51];
+    size_t  part_len;
     int	    retval = FALSE;
-    size_t  n;
 
     name = home_replace_save(NULL, name);
     if (name == NULL)
 	return FALSE;
     for (p = p_viminfo; *p; )
     {
-	copy_option_part(&p, part, 51, ", ");
+	part_len = (size_t)copy_option_part(&p, part, sizeof(part), ", ");
 	if (part[0] == 'r')
 	{
-	    n = STRLEN(part + 1);
-	    if (MB_STRNICMP(part + 1, name, n) == 0)
+	    if (MB_STRNICMP(part + 1, name, part_len - 1) == 0)
 	    {
 		retval = TRUE;
 		break;

--- a/src/viminfo.c
+++ b/src/viminfo.c
@@ -386,7 +386,7 @@ removable(char_u *name)
 {
     char_u  *p;
     char_u  part[51];
-    size_t  part_len;
+    int	    part_len;
     int	    retval = FALSE;
 
     name = home_replace_save(NULL, name);
@@ -394,7 +394,7 @@ removable(char_u *name)
 	return FALSE;
     for (p = p_viminfo; *p; )
     {
-	part_len = (size_t)copy_option_part(&p, part, sizeof(part), ", ");
+	part_len = copy_option_part(&p, part, sizeof(part), ", ");
 	if (part[0] == 'r')
 	{
 	    if (MB_STRNICMP(part + 1, name, part_len - 1) == 0)


### PR DESCRIPTION
This PR refactors some source files to use the return value of `copy_option_part()`.

In addition:
In `memline.c`:
->In function `recover_names()`:
->->Replace calls to `vim_strsave()` with `vim_strnsave()` for the literal strings.
->->Use a `string_T` to store local variable `buf`.
In `bufwrite.c`:
->In function `buf_write()`, move variable `wp` to where it is used.
In `help.c`:
->In function `fix_help_buffer()`, replace call to `add_pathsep()` with `after_pathsep()`.
In `optionstr.c`:
->In function `export_myvimdir()`:
->->Use a `string_T` to store local variable `buf`.
->->Replace call to `add_pathsep()` with `after_pathsep()`.
In `scriptfile.c`:
->In function `do_in_path()`:
->->Use a `string_T` to store local variable `buf`.
->->Measure the lengths of `prefix` and `name` once before the `while` loop.
->->Replace call to `add_pathsep()` with `after_pathsep()`.*
->->Move some variables closer to where they are used.
In `spellfile.c`:
-> In function `init_spellfile()`:
->->Use a `string_T` to store local variable `buf`.

Cheers
John