### PR TITLE
heap buffer overflow with long generic function name

### DIFF
--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -5434,9 +5434,13 @@ common_function(typval_T *argvars, typval_T *rettv, int is_funcref)
 	    else
 	    {
 		// generic function
-		STRCPY(IObuff, name);
-		STRCAT(IObuff, start_bracket);
-		rettv->vval.v_string = vim_strsave(IObuff);
+		size_t len = STRLEN(name) + STRLEN(start_bracket);
+		rettv->vval.v_string = alloc(len + 1);
+		if (rettv->vval.v_string != NULL)
+		{
+		    STRCPY(rettv->vval.v_string, name);
+		    STRCAT(rettv->vval.v_string, start_bracket);
+		}
 		vim_free(name);
 	    }
 	}

--- a/src/testdir/test_vimscript.vim
+++ b/src/testdir/test_vimscript.vim
@@ -7689,6 +7689,19 @@ func Test_catch_pattern_trailing_chars()
   bw!
 endfunc
 
+" Test for long gerneric type name {{{1
+func Test_function_long_generic_name()
+  func TestFunc()
+    return
+  endfunc
+
+  let name = 'TestFunc<' .. repeat('T', 1100) .. '>'
+
+  call function(name)
+  call funcref(name)
+  delfunc TestFunc
+endfunc
+
 "-------------------------------------------------------------------------------
 " Modelines								    {{{1
 " vim: ts=8 sw=2 sts=2 expandtab tw=80 fdm=marker


### PR DESCRIPTION
Problem:    Using a long generic function name may cause a heap buffer
            overflow in common_function().
Solution:   Allocate memory for the full name instead of using IObuff.
            (Kaixuan Li)