### PR TITLE
Fix TabPageIdxs buffer overflow when drawing custom tabline

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -1439,6 +1439,9 @@ win_redr_custom(
     if (wp == NULL)
     {
 	// Fill the TabPageIdxs[] array for clicking in the tab pagesline.
+	int end_col = firstwin->w_wincol + topframe->fr_width;
+	if (end_col > Columns)
+	    end_col = Columns;
 	col = firstwin->w_wincol;
 	len = 0;
 	p = buf;
@@ -1446,12 +1449,14 @@ win_redr_custom(
 	for (n = 0; tabtab[n].start != NULL; n++)
 	{
 	    len += vim_strnsize(p, (int)(tabtab[n].start - p));
-	    while (col < len)
+	    while (col < len && col < end_col)
 		TabPageIdxs[col++] = fillchar;
+	    if (col >= end_col)
+		break;
 	    p = tabtab[n].start;
 	    fillchar = tabtab[n].userhl;
 	}
-	while (col < firstwin->w_wincol + topframe->fr_width)
+	while (col < end_col)
 	    TabPageIdxs[col++] = fillchar;
     }
 

--- a/src/testdir/test_tabline.vim
+++ b/src/testdir/test_tabline.vim
@@ -158,6 +158,20 @@ func Test_mouse_click_in_tab()
   call RunVim([], [], "-e -s -S Xclickscript -c qa")
 endfunc
 
+func Test_tabline_TabPageIdxs_overflow()
+  " Regression: TabPageIdxs[] overflow when closing a tab with custom
+  " 'tabline' and showtabpanel=1 (firstwin->w_wincol + topframe->fr_width
+  " could exceed Columns).
+  CheckFeature tabpanel
+  let before = [
+      \ 'set showtabpanel=1',
+      \ 'set tabline=foo',
+      \ 'call feedkeys(":qa!\<CR>")',
+      \ ]
+  call RunVim(before, [], '-p Xtabline_overflow_a Xtabline_overflow_b')
+  call assert_equal(0, v:shell_error, 'Vim subprocess must not crash (TabPageIdxs overflow)')
+endfunc
+
 func Test_tabline_showcmd()
   CheckScreendump
 


### PR DESCRIPTION
## Reproduction

Use an **ASan build** to reliably observe the crash (a normal build may not crash even though the out-of-bounds write occurs).

```bash
# Build with FEAT_TABPANEL and ASan.
CFLAGS="-fsanitize=address" LDFLAGS="-fsanitize=address" ./configure --with-features=huge && make
```

```bash
# With showtabpanel=1 and a custom tabline, opening 2 tabs.
# (The `-n` option is not necessary, but without it, swap files will remain.)
vim -u NONE -n --cmd 'set tabline=xxx showtabpanel=1' -p a.txt b.txt
```

An ASan build reports a heap-buffer-overflow immediately. A normal build may not crash, but the out-of-bounds write (UB) still occurs.

## Cause

In `win_redr_custom(NULL)` (custom 'tabline' drawing), `TabPageIdxs[]` is filled from `firstwin->w_wincol` through `firstwin->w_wincol + topframe->fr_width - 1`.  
`TabPageIdxs` is allocated with only **Columns** elements in `screenalloc()`, so a buffer overflow happens when `firstwin->w_wincol + topframe->fr_width > Columns`.  
Example: with showtabpanel=1, tab panel width 20, fr_width=80, Columns=80 → col runs 20..99, so indices 80..99 are out of bounds.

## Fix

Cap the write range with `end_col = min(firstwin->w_wincol + topframe->fr_width, Columns)` so that all writes to TabPageIdxs stay within `col < end_col` (screen.c).

Finally: I used AI to work on this PR.