### PR TITLE
use redraw_as_cleared() instead of screenclear() to avoid flicker

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -3819,7 +3819,7 @@ win_do_lines(
 	    && wp->w_width == topframe->fr_width)
     {
 	if (!no_win_do_lines_ins)
-	    screenclear();	    // will set wp->w_lines_valid to 0
+	    redraw_as_cleared();    // don't clear the screen to avoid flicker
 	return FAIL;
     }
 


### PR DESCRIPTION
The flicker is caused by `screenclear()` in `win_do_lines()` (screen.c). When the scroll amount is large (`Rows - line_count < 5`) and the window spans the full width, `screenclear()` clears the entire terminal screen before redrawing all lines. The blank screen is visible as flicker. This is why the flickering occurs during scrolling.

With a vertical split, `wp->w_width != topframe->fr_width`, so this condition (screen.c:3803) is skipped and the scroll region path is used instead, which shifts content in-place without blanking.

The fix is to replace `screenclear()` with `redraw_as_cleared()`. `screenclear()` both invalidates the internal `ScreenLines[]` buffer and sends `T_CL` to clear the terminal. `redraw_as_cleared()` only invalidates the buffer. Since this path returns FAIL, the caller redraws all lines via `win_line()` which overwrites each character in place, so the screen is never blank.

closes #18972