### PR TITLE
docs(if_pyth): fix 'exression' typo

### DIFF
--- a/runtime/doc/if_pyth.txt
+++ b/runtime/doc/if_pyth.txt
@@ -186,7 +186,7 @@ vim.eval(str)						*python-eval*
 	- a list if the Vim expression evaluates to a Vim |list|
 	- a tuple if the Vim expression evaluates to a Vim |tuple|
 	- a dictionary if the Vim expression evaluates to a Vim |dict|
-	- a boolean if Vim exression evaluates to |v:true| or |v:false|
+	- a boolean if Vim expression evaluates to |v:true| or |v:false|
 	- `None` if Vim expression evaluates to |v:null| or |v:none|
 	Dictionaries, lists and tuples are recursively expanded.
 	Examples: >


### PR DESCRIPTION
I ran [typos](https://github.com/crate-ci/typos) on every helpfile and this was the only typo I saw!

## Problem

`runtime/doc/if_pyth.txt` contains a typo: `exression` instead of `expression`.

## Solution

Fix the spelling.