### PR TITLE
Tabpanel: frame width not updated for existing tab pages

### DIFF
--- a/src/testdir/test_tabpanel.vim
+++ b/src/testdir/test_tabpanel.vim
@@ -849,4 +849,27 @@ function Test_tabpanel_with_cmdline_no_pum()
   call StopVimInTerminal(buf)
 endfunc
 
+" When showtabpanel=1 and a second tab is opened, all existing tab pages must
+" have their frame width updated, not just the newly created one.
+function Test_tabpanel_showtabpanel_via_cmd_arg()
+  let tpl_width = 20  " default tpl_columns
+  set showtabpanel=1 noruler
+
+  " With one tab the tabpanel is hidden; no width reduction yet.
+  tabfirst
+  call assert_equal(&columns, winwidth(0))
+
+  " Opening a second tab makes the tabpanel visible; the first tab page must
+  " also get its frame width reduced.
+  tabnew
+  tabfirst
+  call assert_equal(&columns - tpl_width, winwidth(0),
+        \ 'first tab width after tabnew')
+  call assert_equal(tpl_width + 1, win_screenpos(0)[1],
+        \ 'first tab wincol after tabnew')
+
+  tabonly
+  set showtabpanel& noruler&
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/window.c
+++ b/src/window.c
@@ -4884,7 +4884,21 @@ win_new_tabpage(int after)
 #endif
 #if defined(FEAT_TABPANEL)
 	if (prev_columns != COLUMNS_WITHOUT_TPL())
+	{
+	    tabpage_T	*tp2;
+	    int		w = COLUMNS_WITHOUT_TPL();
+
 	    shell_new_columns();
+	    // shell_new_columns() only updates the current tab page; fix up
+	    // all others.
+	    FOR_ALL_TABPAGES(tp2)
+		if (tp2 != curtab)
+		{
+		    frame_new_width(tp2->tp_topframe, w, FALSE, TRUE);
+		    if (!frame_check_width(tp2->tp_topframe, w))
+			frame_new_width(tp2->tp_topframe, w, FALSE, FALSE);
+		}
+	}
 #endif
 	redraw_all_later(UPD_NOT_VALID);
 	apply_autocmds(EVENT_WINNEW, NULL, NULL, FALSE, curbuf);


### PR DESCRIPTION
```
  Problem:  When 'showtabpanel' is set before any window exists (e.g. via
            --cmd) and multiple tab pages are opened with -p, the tabpanel
            appears when the second tab page is created.  At that point
            shell_new_columns() only updates the current (new) tab page's
            frame width; existing tab pages retain the wrong width.
  Solution: After calling shell_new_columns() in win_new_tabpage(), iterate
            all other tab pages and update their frame widths with
            frame_new_width().
```

Related: #19730 (Address the underlying cause of this issue)