### PR TITLE
Fix excessive scroll-up with guioptions+=! and ConPTY

### DIFF
--- a/src/terminal.c
+++ b/src/terminal.c
@@ -4008,6 +4008,9 @@ update_system_term(term_T *term)
     screen = vterm_obtain_screen(term->tl_vterm);
 
     // Scroll up to make more room for terminal lines if needed.
+    // Use the cursor position to determine how much to scroll, because
+    // ConPTY may damage all rows on initialization even when most are
+    // empty, which would cause unnecessary scrolling.
     while (term->tl_toprow > 0
 		  && (Rows - term->tl_toprow) < term->tl_cursor_pos.row + 1)
     {

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -4009,7 +4009,7 @@ update_system_term(term_T *term)
 
     // Scroll up to make more room for terminal lines if needed.
     while (term->tl_toprow > 0
-			  && (Rows - term->tl_toprow) < term->tl_dirty_row_end)
+		  && (Rows - term->tl_toprow) < term->tl_cursor_pos.row + 1)
     {
 	int save_p_more = p_more;
 

--- a/src/testdir/test_gui.vim
+++ b/src/testdir/test_gui.vim
@@ -965,6 +965,7 @@ endfunc
 " which previously caused the entire screen to scroll up.
 func Test_gui_system_term_scroll()
   CheckFeature terminal
+  CheckFeature conpty
   let save_guioptions = &guioptions
   set guioptions+=!
 

--- a/src/testdir/test_gui.vim
+++ b/src/testdir/test_gui.vim
@@ -972,20 +972,22 @@ func Test_gui_system_term_scroll()
   call setline(1, repeat(['AAAA'], &lines + 5))
   redraw
 
-  " Timer fires during wait_return after the command finishes.
-  " Record screen row 1 then dismiss the prompt.
+  " Timer fires during terminal_loop to check the screen while the command
+  " is still running.  Row 1 should still show buffer content if scrolling
+  " is correct.
   let g:system_term_row1 = ''
   func s:CheckScroll(timer)
     let g:system_term_row1 = screenstring(1, 1)
-    call feedkeys("\<CR>", 't')
   endfunc
-  call timer_start(1000, function('s:CheckScroll'))
+  call timer_start(200, function('s:CheckScroll'))
 
-  " Run a short command.
+  " Use a command that runs long enough for the timer to fire during
+  " terminal_loop.  wait_return() returns immediately when sourcing a script,
+  " so the timer must fire before the command finishes.
   if has('win32')
-    !echo test_output
+    !ping -n 2 127.0.0.1 > nul
   else
-    !echo test_output
+    !sleep 1
   endif
 
   " With the ConPTY scroll bug, the screen scrolled up entirely and row 1

--- a/src/testdir/test_gui.vim
+++ b/src/testdir/test_gui.vim
@@ -960,6 +960,44 @@ func Test_gui_run_cmd_in_terminal()
   let &guioptions = save_guioptions
 endfunc
 
+" Test that :! with guioptions+=! doesn't scroll more than necessary.
+" With ConPTY on Windows 11, the terminal may damage all rows on init,
+" which previously caused the entire screen to scroll up.
+func Test_gui_system_term_scroll()
+  CheckFeature terminal
+  let save_guioptions = &guioptions
+  set guioptions+=!
+
+  enew
+  call setline(1, repeat(['AAAA'], &lines + 5))
+  redraw
+
+  " Timer fires during wait_return after the command finishes.
+  " Record screen row 1 then dismiss the prompt.
+  let g:system_term_row1 = ''
+  func s:CheckScroll(timer)
+    let g:system_term_row1 = screenstring(1, 1)
+    call feedkeys("\<CR>", 't')
+  endfunc
+  call timer_start(1000, function('s:CheckScroll'))
+
+  " Run a short command.
+  if has('win32')
+    !echo test_output
+  else
+    !echo test_output
+  endif
+
+  " With the ConPTY scroll bug, the screen scrolled up entirely and row 1
+  " became blank.  With the fix, only the output lines scroll and the buffer
+  " content remains visible near the top of the screen.
+  call assert_equal('A', g:system_term_row1)
+
+  %bwipe!
+  delfunc s:CheckScroll
+  let &guioptions = save_guioptions
+endfunc
+
 func Test_gui_recursive_mapping()
   nmap ' <C-W>
   nmap <C-W>a :let didit = 1<CR>


### PR DESCRIPTION
patch 9.2.0048 (71cc1b12) made ConPTY the default on Windows 11. Since then, running `:!cmd` (e.g. `:!git diff`) with `guioptions+=!` scrolls the screen up by the entire window height, instead of scrolling up only as many lines as the command actually outputs.

The cause is that ConPTY damages (marks dirty) all terminal rows on initialization, even rows that are still empty. This makes `tl_dirty_row_end` equal to `Rows`, so the scroll-up loop in `update_system_term()` keeps scrolling until `tl_toprow` reaches 0.

The fix uses the terminal cursor position (`tl_cursor_pos.row + 1`) instead of `tl_dirty_row_end` for the scroll calculation. The cursor position reflects where content has actually been written, so scrolling is limited to the lines that have real output.


before
<img width="1044" height="822" alt="image" src="https://github.com/user-attachments/assets/be7cfa8e-29df-48dc-acf2-9f2fa0b7dbd6" />

after
<img width="1044" height="822" alt="image" src="https://github.com/user-attachments/assets/e606b67e-3fff-43b4-a001-8b8f7c2dbd6a" />
