### PR TITLE
Fix setcmdline() freeze during wildmenu completion

### DIFF
--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -1857,6 +1857,8 @@ getcmdline_int(
 	int	prev_cmdpos = ccline.cmdpos;
 	int	skip_pum_redraw = FALSE;
 
+	VIM_CLEAR(prev_cmdbuff);
+
 	redir_off = TRUE;	// Don't redirect the typed command.
 				// Repeated, because a ":redir" inside
 				// completion may switch it on.
@@ -1878,7 +1880,6 @@ getcmdline_int(
 	// Trigger SafeState if nothing is pending.
 	may_trigger_safestate(xpc.xp_numfiles <= 0);
 
-	VIM_CLEAR(prev_cmdbuff);
 	if (ccline.cmdbuff != NULL)
 	{
 	    prev_cmdbuff = vim_strsave(ccline.cmdbuff);

--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -1681,7 +1681,7 @@ getcmdline_int(
     int		cmdline_type;
     int		wild_type = 0;
     int		event_cmdlineleavepre_triggered = FALSE;
-    int		cmdbuff_was_replaced = FALSE;
+    char_u	*prev_cmdbuff = NULL;
     int		did_hist_navigate = FALSE;
 
     // one recursion level deeper
@@ -1878,6 +1878,14 @@ getcmdline_int(
 	// Trigger SafeState if nothing is pending.
 	may_trigger_safestate(xpc.xp_numfiles <= 0);
 
+	VIM_CLEAR(prev_cmdbuff);
+	if (ccline.cmdbuff != NULL)
+	{
+	    prev_cmdbuff = vim_strsave(ccline.cmdbuff);
+	    if (prev_cmdbuff == NULL)
+		goto returncmd;
+	}
+
 	// Defer screen update to avoid pum flicker during wildtrigger()
 	if (c == K_WILD && firstc != '@')
 	    skip_pum_redraw = TRUE;
@@ -1893,9 +1901,7 @@ getcmdline_int(
 	// If the cmdline was replaced externally (e.g. by setcmdline()
 	// during an <expr> mapping), clean up the wildmenu completion
 	// state to avoid using stale completion data.
-	cmdbuff_was_replaced = ccline.cmdbuff_replaced;
-	ccline.cmdbuff_replaced = FALSE;
-	if (cmdbuff_was_replaced && xpc.xp_numfiles > 0)
+	if (ccline.cmdbuff_replaced && xpc.xp_numfiles > 0)
 	{
 	    if (cmdline_pum_active())
 		cmdline_pum_remove(&ccline, FALSE);
@@ -1905,6 +1911,7 @@ getcmdline_int(
 	    wim_index = 0;
 	    wildmenu_cleanup(&ccline);
 	}
+	ccline.cmdbuff_replaced = FALSE;
 
 	// Skip wildmenu during history navigation via Up/Down keys
 	if (c == K_WILD && did_hist_navigate)
@@ -2667,7 +2674,8 @@ cmdline_changed:
 	// Trigger CmdlineChanged autocommands.
 	if (trigger_cmdlinechanged
 		&& (ccline.cmdpos != prev_cmdpos
-		    || cmdbuff_was_replaced))
+		    || (prev_cmdbuff != NULL &&
+			STRCMP(prev_cmdbuff, ccline.cmdbuff) != 0)))
 	    trigger_cmd_autocmd(cmdline_type, EVENT_CMDLINECHANGED);
 
 	// Trigger CursorMovedC autocommands.
@@ -2790,6 +2798,7 @@ theend:
 	else
 	    ccline.cmdbuff = NULL;
 
+	vim_free(prev_cmdbuff);
 	return p;
     }
 }

--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -1681,7 +1681,7 @@ getcmdline_int(
     int		cmdline_type;
     int		wild_type = 0;
     int		event_cmdlineleavepre_triggered = FALSE;
-    char_u	*prev_cmdbuff = NULL;
+    int		cmdbuff_was_replaced = FALSE;
     int		did_hist_navigate = FALSE;
 
     // one recursion level deeper
@@ -1857,8 +1857,6 @@ getcmdline_int(
 	int	prev_cmdpos = ccline.cmdpos;
 	int	skip_pum_redraw = FALSE;
 
-	VIM_CLEAR(prev_cmdbuff);
-
 	redir_off = TRUE;	// Don't redirect the typed command.
 				// Repeated, because a ":redir" inside
 				// completion may switch it on.
@@ -1880,13 +1878,6 @@ getcmdline_int(
 	// Trigger SafeState if nothing is pending.
 	may_trigger_safestate(xpc.xp_numfiles <= 0);
 
-	if (ccline.cmdbuff != NULL)
-	{
-	    prev_cmdbuff = vim_strsave(ccline.cmdbuff);
-	    if (prev_cmdbuff == NULL)
-		goto returncmd;
-	}
-
 	// Defer screen update to avoid pum flicker during wildtrigger()
 	if (c == K_WILD && firstc != '@')
 	    skip_pum_redraw = TRUE;
@@ -1898,6 +1889,22 @@ getcmdline_int(
 	    cursorcmd();		// set the cursor on the right spot
 	    c = safe_vgetc();
 	} while (c == K_IGNORE || c == K_NOP);
+
+	// If the cmdline was replaced externally (e.g. by setcmdline()
+	// during an <expr> mapping), clean up the wildmenu completion
+	// state to avoid using stale completion data.
+	cmdbuff_was_replaced = ccline.cmdbuff_replaced;
+	ccline.cmdbuff_replaced = FALSE;
+	if (cmdbuff_was_replaced && xpc.xp_numfiles > 0)
+	{
+	    if (cmdline_pum_active())
+		cmdline_pum_remove(&ccline, FALSE);
+	    (void)ExpandOne(&xpc, NULL, NULL, 0, WILD_FREE);
+	    did_wild_list = FALSE;
+	    xpc.xp_context = EXPAND_NOTHING;
+	    wim_index = 0;
+	    wildmenu_cleanup(&ccline);
+	}
 
 	// Skip wildmenu during history navigation via Up/Down keys
 	if (c == K_WILD && did_hist_navigate)
@@ -2660,8 +2667,7 @@ cmdline_changed:
 	// Trigger CmdlineChanged autocommands.
 	if (trigger_cmdlinechanged
 		&& (ccline.cmdpos != prev_cmdpos
-		    || (prev_cmdbuff != NULL &&
-			STRCMP(prev_cmdbuff, ccline.cmdbuff) != 0)))
+		    || cmdbuff_was_replaced))
 	    trigger_cmd_autocmd(cmdline_type, EVENT_CMDLINECHANGED);
 
 	// Trigger CursorMovedC autocommands.
@@ -2784,7 +2790,6 @@ theend:
 	else
 	    ccline.cmdbuff = NULL;
 
-	vim_free(prev_cmdbuff);
 	return p;
     }
 }
@@ -4518,6 +4523,7 @@ set_cmdline_str(char_u *str, int pos)
 
     p->cmdpos = pos < 0 || pos > p->cmdlen ? p->cmdlen : pos;
     new_cmdpos = p->cmdpos;
+    p->cmdbuff_replaced = TRUE;
 
     redrawcmd();
 

--- a/src/structs.h
+++ b/src/structs.h
@@ -716,6 +716,8 @@ typedef struct
     char_u	*xp_arg;	// user-defined expansion arg
     int		input_fn;	// when TRUE Invoked for input() function
 #endif
+    int		cmdbuff_replaced; // when TRUE cmdline was replaced externally
+				  // (e.g. by setcmdline())
 } cmdline_info_T;
 
 /*

--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -4488,6 +4488,22 @@ func Test_setcmdline()
   call feedkeys(":a\<CR>", 'tx')
   call assert_equal('let foo=0', @:)
   cunmap a
+
+  " setcmdline() during wildmenu completion should not freeze.
+  " Stripping completion state when cmdline was replaced externally.
+  set wildmenu
+  call mkdir('Xsetcmdlinedir', 'pR')
+  call writefile([], 'Xsetcmdlinedir/Xfile1')
+  func g:SetCmdLineEmpty()
+    call setcmdline('', 1)
+    return "\<Left>"
+  endfunc
+  cnoremap <expr> a g:SetCmdLineEmpty()
+  call feedkeys(":e Xsetcmdlinedir/\<Tab>a\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"', @:)
+  cunmap a
+  delfunc g:SetCmdLineEmpty
+  set nowildmenu
 endfunc
 
 func Test_rulerformat_position()

--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -4494,6 +4494,7 @@ func Test_setcmdline()
   set wildmenu
   call mkdir('Xsetcmdlinedir', 'pR')
   call writefile([], 'Xsetcmdlinedir/Xfile1')
+  call writefile([], 'Xsetcmdlinedir/Xfile2')
   func g:SetCmdLineEmpty()
     call setcmdline('', 1)
     return "\<Left>"


### PR DESCRIPTION
Add a `cmdbuff_replaced` flag to `cmdline_info_T`, set by `set_cmdline_str()`. After `safe_vgetc()`, if the flag is set and wildmenu completion is active, clean up the stale completion state to prevent the freeze.

Closes #19742