### PR TITLE
Add an option to end output with terminating null

### DIFF
--- a/src/testdir/test_xxd.vim
+++ b/src/testdir/test_xxd.vim
@@ -284,6 +284,37 @@ func Test_xxd()
 
   call assert_equal(expected, getline(1,'$'), s:Mess(s:test))
 
+  " Test 20: Print C include with terminating null
+  let s:test += 1
+  call writefile(['TESTabcd09'], 'XXDfile')
+  %d
+  exe '0r! ' . s:xxd_cmd . ' -i -t XXDfile'
+  $d
+  let expected =<< trim [CODE]
+    unsigned char XXDfile[] = {
+      0x54, 0x45, 0x53, 0x54, 0x61, 0x62, 0x63, 0x64, 0x30, 0x39, 0x0a, 0x00
+    };
+    unsigned int XXDfile_len = 11;
+  [CODE]
+
+  call assert_equal(expected, getline(1,'$'), s:Mess(s:test))
+
+  " Test 21: Print C include in binary format
+  let s:test += 1
+  call writefile(['TESTabcd09'], 'XXDfile')
+  %d
+  exe '0r! ' . s:xxd_cmd . ' -i -b -t XXDfile'
+  $d
+  let expected =<< trim [CODE]
+    unsigned char XXDfile[] = {
+      0b01010100, 0b01000101, 0b01010011, 0b01010100, 0b01100001, 0b01100010,
+      0b01100011, 0b01100100, 0b00110000, 0b00111001, 0b00001010, 0b00000000
+    };
+    unsigned int XXDfile_len = 11;
+  [CODE]
+
+  call assert_equal(expected, getline(1,'$'), s:Mess(s:test))
+
 
   %d
   bwipe!

--- a/src/xxd/xxd.c
+++ b/src/xxd/xxd.c
@@ -285,7 +285,7 @@ exit_with_usage(void)
 		  "    -g bytes    number of octets per group in normal output. Default 2 (-e: 4).\n"
 		  "    -h          print this summary.\n"
 		  "    -i          output in C include file style.\n"
-		  "    -t          fill terminating zero in C include output (-i).\n"
+		  "    -t          append terminating zero to C include output (-i).\n"
 		  "    -l len      stop after <len> octets.\n"
 		  "    -n name     set the variable name used in C include output (-i).\n"
 		  "    -o off      add <off> to the displayed file position.\n"
@@ -1072,7 +1072,7 @@ main(int argc, char *argv[])
 	}
 
       p = 0;
-      while ((length < 0 || p < length) && ((c = getc_or_die(fp)) != EOF) || termination)
+      while ((length < 0 || p < length) && (((c = getc_or_die(fp)) != EOF) || termination))
 	{
 	  if (c == EOF)
 	    {

--- a/src/xxd/xxd.c
+++ b/src/xxd/xxd.c
@@ -285,6 +285,7 @@ exit_with_usage(void)
 		  "    -g bytes    number of octets per group in normal output. Default 2 (-e: 4).\n"
 		  "    -h          print this summary.\n"
 		  "    -i          output in C include file style.\n"
+		  "    -t          fill terminating zero in C include output (-i).\n"
 		  "    -l len      stop after <len> octets.\n"
 		  "    -n name     set the variable name used in C include output (-i).\n"
 		  "    -o off      add <off> to the displayed file position.\n"
@@ -735,6 +736,7 @@ main(int argc, char *argv[])
   int cols = 0, colsgiven = 0, nonzero = 0, autoskip = 0, hextype = HEX_NORMAL;
   int capitalize = 0, decimal_offset = 0;
   int ebcdic = 0;
+  int termination = 0;
   int octspergrp = -1;	/* number of octets grouped in output */
   int grplen;		/* total chars per octet group excluding colors */
   long length = -1, n = 0, seekoff = 0;
@@ -784,6 +786,7 @@ main(int argc, char *argv[])
       else if (!STRNCMP(pp, "-d", 2)) decimal_offset = 1;
       else if (!STRNCMP(pp, "-r", 2)) revert++;
       else if (!STRNCMP(pp, "-E", 2)) ebcdic++;
+      else if (!STRNCMP(pp, "-t", 2)) termination++;
       else if (!STRNCMP(pp, "-v", 2))
 	{
 	  fprintf(stderr, "%s%s\n", version, osver);
@@ -1069,8 +1072,13 @@ main(int argc, char *argv[])
 	}
 
       p = 0;
-      while ((length < 0 || p < length) && (c = getc_or_die(fp)) != EOF)
+      while ((length < 0 || p < length) && ((c = getc_or_die(fp)) != EOF) || termination)
 	{
+	  if (c == EOF)
+	    {
+	      c = 0;
+	      termination = -1;
+	    }
 	  if (hextype & HEX_BITS)
 	    {
 	      if (p == 0)
@@ -1090,6 +1098,11 @@ main(int argc, char *argv[])
 	      FPRINTF_OR_DIE((fpo, (hexx == hexxa) ? "%s0x%02x" : "%s0X%02X",
 		(p % cols) ? ", " : (!p ? "  " : ",\n  "), c));
 	      p++;
+	    }
+	  if (termination == -1)
+	    {
+	      --p;
+	      break ;
 	    }
 	}
 


### PR DESCRIPTION
Implements #14409 as a `-t` option that only has an effect when the `-i` option is used.