### PR TITLE
Add newline ("\n") to SHELL_SPECIAL

### DIFF
--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -7075,7 +7075,7 @@ mch_expandpath(
 #  define SEEK_END 2
 # endif
 
-# define SHELL_SPECIAL (char_u *)"\t \"&'$;<>()\\|"
+# define SHELL_SPECIAL (char_u *)"\t \"&'$;<>()\\|\n"
 
     int
 mch_expand_wildcards(


### PR DESCRIPTION
`glob()` function can be used to run shell commands by using newline as a command separator. It goes through `f_glob()` -> `ExpandOne()` -> `ExpandOne_start()` -> `ExpandFromContext()` -> `expand_wildcards()` -> `gen_expand_wildcards()` -> `mch_expand_wildcards()` -> `call_shell()`

Example: `:call glob("$NON_EXISTENT\n/tmp/test.sh\n")`