### PR TITLE
CI: bump actions/upload-artifact to v7

### DIFF
--- a/.github/actions/test_artifacts/action.yml
+++ b/.github/actions/test_artifacts/action.yml
@@ -27,7 +27,7 @@ runs:
         # set as the "result".
         result-encoding: string
     - name: Upload failed tests
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         # Name of the artifact to upload.
         name: ${{ format('GH-{0}-{1}-{2}-{3}-{4}-failed-tests',

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -776,7 +776,7 @@ jobs:
       #    copy src\vim*.dll artifacts
       #
       #- name: Upload Artifact
-      #  uses: actions/upload-artifact@v1
+      #  uses: actions/upload-artifact@v7
       #  with:
       #    name: vim${{ matrix.bits }}-${{ matrix.toolchain }}
       #    path: ./artifacts


### PR DESCRIPTION
To resolve CI warnings `Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/upload-artifact@v4`.

