### PR TITLE
Fix DEC responses appearing on screen

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -893,6 +893,9 @@ vim_main2(void)
 
     may_req_bg_color();
 # endif
+    // Same reason for termresponse, don't want the terminal sending out the
+    // DECRPM response after Vim has exited.
+    send_decrqm_modes();
 
     // start in insert mode
     if (p_im)

--- a/src/proto/term.pro
+++ b/src/proto/term.pro
@@ -96,6 +96,7 @@ void swap_tcap(void);
 void ansi_color2rgb(int nr, char_u *r, char_u *g, char_u *b, char_u *ansi_idx);
 void cterm_color2rgb(int nr, char_u *r, char_u *g, char_u *b, char_u *ansi_idx);
 int term_replace_keycodes(char_u *ta_buf, int ta_len, int len_arg);
+void send_decrqm_modes(void);
 void term_disable_dec(void);
 void term_set_win_resize(bool state);
 void term_set_sync_output(int flags);

--- a/src/term.c
+++ b/src/term.c
@@ -4051,16 +4051,6 @@ starttermcap(void)
 	out_str(T_FE);
 #endif
 
-    if (cur_tmode == TMODE_RAW)
-    {
-	// Request setting of relevant DEC modes via DECRQM
-	for (int i = 0; i < (int)ARRAY_LENGTH(dec_modes); i++)
-	{
-	    vim_snprintf((char *)IObuff, IOSIZE, "\033[?%d$p", dec_modes[i]);
-	    out_str(IObuff);
-	}
-    }
-
     out_flush();
     termcap_active = TRUE;
     screen_start();			// don't know where cursor is now
@@ -7979,6 +7969,23 @@ term_replace_keycodes(char_u *ta_buf, int ta_len, int len_arg)
 	    i += (*mb_ptr2len_len)(ta_buf + i, ta_len + len - i) - 1;
     }
     return len;
+}
+
+/*
+ * Query the settings for the DEC modes we support
+ */
+    void
+send_decrqm_modes(void)
+{
+    if (termcap_active && cur_tmode == TMODE_RAW)
+    {
+	// Request setting of relevant DEC modes via DECRQM
+	for (int i = 0; i < (int)ARRAY_LENGTH(dec_modes); i++)
+	{
+	    vim_snprintf((char *)IObuff, IOSIZE, "\033[?%d$p", dec_modes[i]);
+	    out_str(IObuff);
+	}
+    }
 }
 
 /*


### PR DESCRIPTION
I think the main problem is that we send the DECRQM escape codes too soon, it is possible that Vim may exit before the responses are sent out by the terminal, and they will appear on screen.