### PR TITLE
filetype: recognize wireguard config

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1571,6 +1571,9 @@ au BufNewFile,BufRead *vimrc*			call s:StarSetf('vim')
 " Subversion commit file
 au BufNewFile,BufRead svn-commit*.tmp		setf svn
 
+" Wireguard config
+au BufNewFile,BufRead */etc/wireguard/*.conf    setf dosini
+
 " X resources file
 au BufNewFile,BufRead Xresources*,*/app-defaults/*,*/Xresources/* call s:StarSetf('xdefaults')
 

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -256,6 +256,7 @@ def s:GetFilenameChecks(): dict<list<string>>
              'psprint.conf', 'sofficerc', 'any/.config/lxqt/globalkeyshortcuts.conf', 'any/.config/screengrab/screengrab.conf',
              'any/.local/share/flatpak/repo/config',
              '.alsoftrc', 'alsoft.conf', 'alsoft.ini', 'alsoftrc.sample',
+             '/etc/wireguard/wg0.conf',
              '.notmuch-config', '.notmuch-config.myprofile',
              '~/.config/notmuch/myprofile/config'] + WhenConfigHome('$XDG_CONFIG_HOME/notmuch/myprofile/config'),
     dot: ['file.dot', 'file.gv'],


### PR DESCRIPTION
Problem: filetype: wireguard config file is not recognized

Solution: Detect /etc/wireguard/*.conf files as dosini filetype