### PR TITLE
Correct visual selection highlighting in X11 GUI. (Problem since 9.2.0158.)

### DIFF
--- a/src/drawline.c
+++ b/src/drawline.c
@@ -1462,10 +1462,7 @@ win_line(
 		area_highlighting = TRUE;
 		vi_attr = HL_ATTR(HLF_V);
 #if defined(FEAT_CLIPBOARD) && defined(FEAT_X11)
-		if (
-# ifdef FEAT_XCLIPBOARD
-			xterm_dpy &&
-# endif
+		if (X_DISPLAY &&
 			((clip_star.available && !clip_star.owned
 						    && clip_isautosel_star())
 			    || (clip_plus.available && !clip_plus.owned

--- a/src/vim.h
+++ b/src/vim.h
@@ -2690,8 +2690,10 @@ typedef int (*opt_expand_cb_T)(optexpand_T *args, int *numMatches, char_u ***mat
 #  else
 #   define X_DISPLAY	gui.dpy
 #  endif
-# else
+# elif defined(FEAT_XCLIPBOARD)
 #  define X_DISPLAY	xterm_dpy
+# else
+#  define X_DISPLAY	(Display *)NULL
 # endif
 #endif
 

--- a/src/vim.h
+++ b/src/vim.h
@@ -2683,18 +2683,16 @@ typedef int (*opt_expand_cb_T)(optexpand_T *args, int *numMatches, char_u ***mat
 # else
 #  define X_DISPLAY	(gui.in_use ? gui.dpy : xterm_dpy)
 # endif
-#else
-# ifdef FEAT_GUI
-#  ifdef FEAT_GUI_GTK
-#   define X_DISPLAY	((gui.in_use) ? gui_mch_get_display() : (Display *)NULL)
-#  else
-#   define X_DISPLAY	gui.dpy
-#  endif
-# elif defined(FEAT_XCLIPBOARD)
-#  define X_DISPLAY	xterm_dpy
+#elif defined(FEAT_GUI)
+# ifdef FEAT_GUI_GTK
+#  define X_DISPLAY	((gui.in_use) ? gui_mch_get_display() : (Display *)NULL)
 # else
-#  define X_DISPLAY	(Display *)NULL
+#  define X_DISPLAY	gui.dpy
 # endif
+#elif defined(FEAT_XCLIPBOARD)
+# define X_DISPLAY	xterm_dpy
+#else
+# define X_DISPLAY	(Display *)NULL
 #endif
 
 #ifdef FEAT_GUI_GTK


### PR DESCRIPTION
_From the first commit message:_

Problem: The check for whether an X connection was opened was incorrect in 9.2.0158.
Solution: Use X_DISPLAY instead of xterm_dpy.

Note: xterm_dpy would be NULL if Vim was started in GUI mode.

Previously, starting two instances of gvim that use GTK3 with:
  `GDK_BACKEND=x11 gvim`
and making a visual selection in both would leave both selections highlighted with the `Visual` highlight group. Now, when the second selection is made the first selection will be highlighted with `VisualNOS`.