### PR TITLE
fix: gvim freezes on second :hardcopy on MS-Windows

### DIFF
--- a/src/os_mswin.c
+++ b/src/os_mswin.c
@@ -1192,8 +1192,6 @@ AbortProc(HDC hdcPrn UNUSED, int iCode UNUSED)
     return !*bUserAbort;
 }
 
-# if !defined(FEAT_GUI) || defined(VIMDLL)
-
     static UINT_PTR CALLBACK
 PrintHookProc(
 	HWND hDlg,	// handle to dialog box
@@ -1246,7 +1244,6 @@ PrintHookProc(
 
     return FALSE;
 }
-# endif
 
     void
 mch_print_cleanup(void)
@@ -1262,7 +1259,7 @@ mch_print_cleanup(void)
 
     if (prt_dlg.hDC != NULL)
 	DeleteDC(prt_dlg.hDC);
-    if (!*bUserAbort)
+    if (!*bUserAbort && hDlgPrint != NULL)
 	SendMessage(hDlgPrint, WM_COMMAND, 0, 0);
 }
 
@@ -1400,18 +1397,11 @@ mch_print_init(prt_settings_T *psettings, char_u *jobname, int forceit)
 	prt_dlg.hDevMode = stored_dm;
 	prt_dlg.hDevNames = stored_devn;
 	prt_dlg.lCustData = stored_nCopies; // work around bug in print dialog
-# if !defined(FEAT_GUI) || defined(VIMDLL)
-#  ifdef VIMDLL
-	if (!gui.in_use)
-#  endif
-	{
-	    /*
-	     * Use hook to prevent console window being sent to back
-	     */
-	    prt_dlg.lpfnPrintHook = PrintHookProc;
-	    prt_dlg.Flags |= PD_ENABLEPRINTHOOK;
-	}
-# endif
+	/*
+	 * Use hook to prevent print dialog being sent to back.
+	 */
+	prt_dlg.lpfnPrintHook = PrintHookProc;
+	prt_dlg.Flags |= PD_ENABLEPRINTHOOK;
 	prt_dlg.Flags |= stored_nFlags;
     }
 
@@ -1628,7 +1618,7 @@ mch_print_begin(prt_settings_T *psettings)
 mch_print_end(prt_settings_T *psettings UNUSED)
 {
     EndDoc(prt_dlg.hDC);
-    if (!*bUserAbort)
+    if (!*bUserAbort && hDlgPrint != NULL)
 	SendMessage(hDlgPrint, WM_COMMAND, 0, 0);
 }
 


### PR DESCRIPTION
Enable PrintHookProc for GUI mode so that the print dialog is brought to the foreground via BringWindowToTop/SetForegroundWindow. Without the hook, the second PrintDlgW() modal dialog appears behind gvim due to Windows foreground lock timeout, making gvim unresponsive.

Also add NULL checks for hDlgPrint in SendMessage calls.

closes #19715