### PR TITLE
fix: restore DECSCUSR pass-through in VTP mode

### DIFF
--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -7443,7 +7443,9 @@ notsgr:
 	    // When USE_VTP is active, CSI sequences written through
 	    // write_chars() are interpreted by the console's VTP parser,
 	    // generating responses (e.g. DECRQM) that end up in the
-	    // input buffer as unwanted keystrokes.  Discard them.
+	    // input buffer as unwanted keystrokes.  Parse the sequence
+	    // and only pass through known safe ones (e.g. DECSCUSR for
+	    // cursor shape), discard the rest.
 	    if (USE_VTP)
 	    {
 		int l = 2;
@@ -7453,7 +7455,12 @@ notsgr:
 		    l++;
 		// skip the final byte (0x40-0x7E)
 		if (s + l < end && s[l] >= 0x40 && s[l] <= 0x7E)
+		{
+		    // DECSCUSR (cursor style): pass through to terminal
+		    if (s[l] == 'q')
+			vtp_printf("%.*s", l + 1, s);
 		    l++;
+		}
 		len -= l - 1;
 		s += l;
 	    }


### PR DESCRIPTION
Patch 9.2.0184 discards all CSI sequences in mch_write() when VTP is active to prevent unwanted DECRQM responses. However, this also removed the existing DECSCUSR pass-through, breaking cursor shape changes (t_SI/t_SR/t_EI) on Windows Terminal.

Restore vtp_printf() pass-through for DECSCUSR (final byte 'q') while continuing to discard other CSI sequences.

related #19694
related #11532
closes #19750