### PR TITLE
filetype: cps files are not recognized

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -1789,6 +1789,8 @@ const ft_from_ext = {
   "cairo": "cairo",
   # Cap'n Proto
   "capnp": "capnp",
+  # Common Package Specification
+  "cps": "json",
   # C#
   "cs": "cs",
   "csx": "cs",

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -418,7 +418,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     jovial: ['file.jov', 'file.j73', 'file.jovial'],
     jproperties: ['file.properties', 'file.properties_xx', 'file.properties_xx_xx', 'some.properties_xx_xx_file', 'org.eclipse.xyz.prefs'],
     jq: ['file.jq'],
-    json: ['file.json', 'file.jsonp', 'file.json-patch', 'file.geojson', 'file.webmanifest', 'Pipfile.lock', 'file.ipynb', 'file.jupyterlab-settings',
+    json: ['file.json', 'file.jsonp', 'file.json-patch', 'file.geojson', 'file.webmanifest', 'Pipfile.lock', 'file.ipynb', 'file.jupyterlab-settings', 'file.cps',
     '.prettierrc', '.firebaserc', '.stylelintrc', '.lintstagedrc', 'file.slnf', 'file.sublime-project', 'file.sublime-settings', 'file.sublime-workspace',
     'file.bd', 'file.bda', 'file.xci', 'flake.lock', 'pack.mcmeta', 'deno.lock', '.swcrc', 'composer.lock', 'symfony.lock'],
     json5: ['file.json5'],


### PR DESCRIPTION
Problem: filetype: cps (Common Package Specification) files are not recognized as json
Solution: Detect *.cps files as json filetype

Reference:
- https://github.com/cps-org/cps
- https://cps-org.github.io/cps/