### PR TITLE
Call stack string can get corrupted

### DIFF
--- a/src/scriptfile.c
+++ b/src/scriptfile.c
@@ -230,7 +230,7 @@ estack_sfile(estack_arg_T which UNUSED)
 	    {
 		added = vim_snprintf_safelen(
 		    (char *)ga.ga_data + ga.ga_len,
-		    len - (size_t)ga.ga_len,
+		    ga.ga_maxlen - ga.ga_len,
 		    "<SNR>%d_%s.",
 		    entry->es_info.ufunc->uf_script_ctx.sc_sid,
 		    class_name.string);
@@ -244,7 +244,7 @@ estack_sfile(estack_arg_T which UNUSED)
 	    {
 		added = vim_snprintf_safelen(
 		    (char *)ga.ga_data + ga.ga_len,
-		    len - (size_t)ga.ga_len,
+		    ga.ga_maxlen - ga.ga_len,
 		    "[%ld]",
 		    lnum);
 

--- a/src/testdir/test_vim9_script.vim
+++ b/src/testdir/test_vim9_script.vim
@@ -5791,4 +5791,38 @@ def Test_substitute_cmd()
   source Xvim9lines
 enddef
 
+def Test_call_stack_string()
+  CheckScreendump
+  var lines =<< trim END
+    vim9script
+
+    def CheckStack(stack: string, expected: string)
+      const caller = stack->split('\.\.')[-1]->substitute('\[\d\+\]', '', '')
+      if caller !~ expected
+        throw 'fail'
+      endif
+    enddef
+
+    class C
+      static def ClassMethodX()
+        CheckStack(expand('<stack>'), '_C.ClassMethodX$')
+      enddef
+    endclass
+
+    def NormalFuncX()
+      CheckStack(expand('<stack>'), '_NormalFuncX$')
+    enddef
+
+    # creating function names of various lengths till the name in call stack is corrupt
+    for i in range(1, 20)
+      const name = 'Wrapper' .. repeat('A', i) .. 'func'
+      execute "def g:" .. name .. "(id: any)\n  NormalFuncX()\n  C.ClassMethodX()\nenddef"
+      execute "timer_start(0, g:" .. name .. ")"
+    endfor
+  END
+  writefile(lines, 'XTest_call_stack_string', 'D')
+  var buf = g:RunVimInTerminal('-S XTest_call_stack_string', {'rows': 20})
+  g:StopVimInTerminal(buf)
+enddef
+
 " vim: ts=8 sw=2 sts=2 expandtab tw=80 fdm=marker


### PR DESCRIPTION
Problem: calculated remaining capacity for call stack string can underflow
Solution: calculate capacity against maximum capacity

Introduced in 2019321e0be320183afa47b7ea979dc4fc3984a0