### PR TITLE
runtime: add filetype detection for Concerto (.cto)

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -273,6 +273,9 @@ au BufNewFile,BufRead *.cpy
 	\   setf cobol |
 	\ endif
 
+" Concerto
+au BufNewFile,BufRead *.cto			setf concerto
+
 " Dockerfile; Podman uses the same syntax with name Containerfile
 " Also see Dockerfile.* below.
 au BufNewFile,BufRead Containerfile,Dockerfile,dockerfile,*.[dD]ockerfile	setf dockerfile

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -194,6 +194,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     coco: ['file.atg'],
     codeowners: ['CODEOWNERS'],
     conaryrecipe: ['file.recipe'],
+    concerto: ['file.cto'],
     conf: ['auto.master', 'file.conf', 'texdoc.cnf', '.x11vncrc', '.chktexrc', '.ripgreprc', 'ripgreprc', 'file.ctags'],
     config: ['/etc/hostname.file', 'any/etc/hostname.file', 'configure.in', 'configure.ac', 'file.at', 'aclocal.m4'],
     confini: ['pacman.conf', 'paru.conf', 'mpv.conf', 'any/.aws/config', 'any/.aws/credentials', 'any/.aws/cli/alias', 'file.nmconnection',


### PR DESCRIPTION
Add filetype detection for the Concerto Modelling Language (`.cto` files).

[Concerto](https://concerto.accordproject.org) is a schema/modelling language by the [Accord Project](https://accordproject.org) for defining data models used in smart legal contracts and business networks. It has an active open-source ecosystem with a tree-sitter grammar, CLI tooling, and editor integrations under development.

**Changes:**
- `runtime/filetype.vim`: detect `*.cto` files as filetype `concerto`
- `src/testdir/test_filetype.vim`: add test entry

**Example `.cto` file:**
```
namespace org.acme.hr@1.0.0

concept Employee identified by employeeId {
  o String employeeId
  o String firstName
  o DateTime startDate
}

enum Department {
  o ENGINEERING
  o MARKETING
}
```

**References:**
- Language spec: https://concerto.accordproject.org
- Tree-sitter grammar: https://github.com/accordproject/concerto-tree-sitter
- Accord Project: https://accordproject.org