### PR TITLE
fix: redraw adjacent cells for DirectWrite subpixel rendering spill

### DIFF
--- a/src/gui.h
+++ b/src/gui.h
@@ -260,6 +260,9 @@ typedef struct Gui
     int		left_sbar_x;	    // Calculated x coord for left scrollbar
     int		right_sbar_x;	    // Calculated x coord for right scrollbar
     int         force_redraw;       // Force a redraw even e.g. not resized
+#ifdef FEAT_DIRECTX
+    int		directx_enabled;    // DirectX (DirectWrite) rendering active
+#endif
 
 #ifdef FEAT_MENU
 # ifndef FEAT_GUI_GTK

--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -242,6 +242,7 @@ gui_mch_set_rendering_options(char_u *s)
 	}
     }
     s_directx_enabled = dx_enable;
+    gui.directx_enabled = IS_ENABLE_DIRECTX();
 
     return OK;
 # else

--- a/src/screen.c
+++ b/src/screen.c
@@ -920,6 +920,14 @@ skip_opacity:
 	    // redraw that one if this one changed, no matter attributes.
 	    if (gui.in_use && changed_this)
 		redraw_next = TRUE;
+# ifdef FEAT_DIRECTX
+	    // DirectWrite subpixel rendering (especially with CFF/OTF
+	    // fonts) can extend pixels beyond cell boundaries to the
+	    // left.  Redraw the current character if the previous one
+	    // changed.
+	    if (gui.directx_enabled && changed_this)
+		redraw_this = TRUE;
+# endif
 #endif
 
 	    ScreenAttrs[off_to] = ScreenAttrs[off_from];
@@ -1731,6 +1739,12 @@ screen_puts_len(
 		if (n & HL_BOLD)
 		    force_redraw_next = TRUE;
 	    }
+#endif
+#ifdef FEAT_DIRECTX
+	    // DirectWrite subpixel rendering can extend pixels beyond
+	    // cell boundaries.  Redraw the next character too.
+	    if (gui.directx_enabled && need_redraw)
+		force_redraw_next = TRUE;
 #endif
 	    // When at the end of the text and overwriting a two-cell
 	    // character with a one-cell character, need to clear the next
@@ -2663,6 +2677,12 @@ skip_opacity_fill:
 			force_next = FALSE;
 		}
 #endif // FEAT_GUI || defined(UNIX)
+#ifdef FEAT_DIRECTX
+		// DirectWrite subpixel rendering can extend pixels
+		// beyond cell boundaries.  Redraw the next character.
+		if (gui.directx_enabled)
+		    force_next = TRUE;
+#endif
 		ScreenLines[off] = c;
 		if (enc_utf8)
 		{


### PR DESCRIPTION
DirectWrite subpixel rendering (especially with CFF/OTF fonts) can extend glyph pixels beyond cell boundaries. Vim already handles the forward direction (redraw the next character when the current one changes) for MS-Windows antialiasing, but the backward direction was missing.

This adds a `gui.directx_enabled` flag accessible from screen.c and extends the existing spill-over handling to also redraw the current character when the previous one changed, and force redraw of adjacent characters in the `screen_puts_len()` and `screen_fill()` paths.

closes #19586