### PR TITLE
Since 9.2.0200, several tests fail in the Windows CUI.

### DIFF
--- a/src/term.c
+++ b/src/term.c
@@ -7985,6 +7985,7 @@ send_decrqm_modes(void)
 	    vim_snprintf((char *)IObuff, IOSIZE, "\033[?%d$p", dec_modes[i]);
 	    out_str(IObuff);
 	}
+	out_flush();
     }
 }
 


### PR DESCRIPTION
Problem:

The Windows CUI actively buffers transmissions to terms. Patch 0200 changed the timing of DECRQM transmissions, and out_flush() is no longer called after transmission. Therefore, actual term initialization does not occur until the buffer is flushed, causing the following tests to fail:

- test_autocmd.vim - Test_Changed_FirstTime()
- test_mapping.vim - Test_error_in_map_expr()
- test_messages.vim - Test_mode_message_at_leaving_insert_with_esc_mapped()
- test_search.vim - Test_search_cmdline_incsearch_highlight_attr()

The failures since version 200 can be confirmed in the following CI jobs.

- 9.2.0200 https://github.com/vim/vim/actions/runs/23312934497
    - https://github.com/vim/vim/actions/runs/23312934497/job/67804736843
    - https://github.com/vim/vim/actions/runs/23312934497/job/67804736752
    - https://github.com/vim/vim/actions/runs/23312934497/job/67804736735
- 9.2.0199 https://github.com/vim/vim/actions/runs/23311871938 The above test can be confirmed to be successful.

Solution:

After sending DECRQM in send_decrqm_modes(), explicitly call out_flush() to ensure terminal initialization.

---

cf. https://github.com/vim/vim/commit/1da42ee2710c7d3413e0656cbbc9067f23390615 (9.2.0200)