### PR TITLE
Fix flaky Test_gui_system_term_scroll()

### DIFF
--- a/src/testdir/test_gui.vim
+++ b/src/testdir/test_gui.vim
@@ -973,31 +973,18 @@ func Test_gui_system_term_scroll()
   call setline(1, repeat(['AAAA'], &lines + 5))
   redraw
 
-  " Timer fires during terminal_loop to check the screen while the command
-  " is still running.  Row 1 should still show buffer content if scrolling
-  " is correct.
-  let g:system_term_row1 = ''
-  func s:CheckScroll(timer)
-    let g:system_term_row1 = screenstring(1, 1)
-  endfunc
-  call timer_start(200, function('s:CheckScroll'))
-
-  " Use a command that runs long enough for the timer to fire during
-  " terminal_loop.  wait_return() returns immediately when sourcing a script,
-  " so the timer must fire before the command finishes.
   if has('win32')
-    !ping -n 2 127.0.0.1 > nul
+    !echo.
   else
-    !sleep 1
+    !echo
   endif
 
   " With the ConPTY scroll bug, the screen scrolled up entirely and row 1
   " became blank.  With the fix, only the output lines scroll and the buffer
   " content remains visible near the top of the screen.
-  call assert_equal('A', g:system_term_row1)
+  call assert_equal('A', screenstring(1, 1))
 
   %bwipe!
-  delfunc s:CheckScroll
   let &guioptions = save_guioptions
 endfunc
 


### PR DESCRIPTION
Remove timer-based screen check and use a simple command instead of ping.
The timer could fire before ConPTY initialization was complete, causing screenstring() to return an empty string.
Check screenstring() directly after the command finishes instead.