### PR TITLE
Fix segfault when using a partial or lambda as a clipboard provider callback.

### DIFF
--- a/src/clipboard.c
+++ b/src/clipboard.c
@@ -3778,7 +3778,8 @@ clip_provider_get_callback(
 
     // func_tv owns the function name, so we must make a copy for the callback
     set_callback(callback, &cb);
-    free_callback(&cb);
+    if (cb.cb_free_name)
+	vim_free(cb.cb_name);
     clear_tv(&func_tv);
     return OK;
 }

--- a/src/testdir/test_eval_stuff.vim
+++ b/src/testdir/test_eval_stuff.vim
@@ -866,10 +866,14 @@ endfunc
 func Test_clipboard_provider_copy()
   CheckFeature clipboard_provider
 
+  function s:copy_cb_to_test_partial(_, reg, type, str)
+    call s:Copy(a:reg, a:type, a:str)
+  endfunction
+
   let v:clipproviders["test"] = {
         \ "copy": {
         \       '+': function("s:Copy"),
-        \       '*': function("s:Copy")
+        \       '*': function("s:copy_cb_to_test_partial", [""])
         \   }
         \ }
   set clipmethod=test


### PR DESCRIPTION
Problem: cb_partial member freed prematurely on calling a clipboard provider callback.
Solution: Don't call free_callback() from clip_provider_get_callback().