### PR TITLE
fix(win32): clamp version components to prevent overflow

### DIFF
--- a/src/os_mswin.c
+++ b/src/os_mswin.c
@@ -127,9 +127,9 @@ win_version_init(void)
 
     osver.dwOSVersionInfoSize = sizeof(OSVERSIONINFOW);
     pRtlGetVersion(&osver);
-    win_version =
-	MAKE_VER(osver.dwMajorVersion, osver.dwMinorVersion,
-		 osver.dwBuildNumber);
+    win_version = MAKE_VER(min(osver.dwMajorVersion, 0xFF),
+	    min(osver.dwMinorVersion, 0xFF),
+	    min(osver.dwBuildNumber, 0xFFFF));
 }
 
 /*

--- a/src/os_win32.h
+++ b/src/os_win32.h
@@ -227,4 +227,4 @@ Trace(char *pszFormat, ...);
 
 // Windows Version
 #define MAKE_VER(major, minor, build) \
-    ((((major) & 0xFF) << 24) | (((minor) & 0xFF) << 16) | ((build) & 0x7FFF))
+    (((major) << 24) | ((minor) << 16) | (build))


### PR DESCRIPTION
The version components (major, minor, build) from RtlGetVersion are now
clamped to their maximum bit widths (8 bits, 8 bits, 15 bits) before
being packed into a 32-bit integer. This prevents overflow when storing
unexpectedly large values.

This fixes a regression introduced in patch 9.2.0206 where the previous
clamping logic was accidentally removed.

The MAKE_VER macro is simplified by removing bit masks, as clamping is
now done at the call site, making the macro clearer and reducing
redundant masking.
