### PR TITLE
runtime(compiler): add just compiler plugin

### DIFF
--- a/.github/MAINTAINERS
+++ b/.github/MAINTAINERS
@@ -80,6 +80,7 @@ runtime/compiler/jjs.vim				@dkearns
 runtime/compiler/jq.vim					@vito-c
 runtime/compiler/jshint.vim				@dkearns
 runtime/compiler/jsonlint.vim				@dkearns
+runtime/compiler/just.vim				@Alarcritty
 runtime/compiler/make.vim				@Konfekt
 runtime/compiler/mypy.vim				@Konfekt
 runtime/compiler/pandoc.vim				@Konfekt

--- a/runtime/compiler/just.vim
+++ b/runtime/compiler/just.vim
@@ -11,7 +11,7 @@ let current_compiler = "just"
 let s:cpo_save = &cpo
 set cpo-=C
 
-CompilerSet makeprg=just\ $*
+CompilerSet makeprg=just
 
 CompilerSet errorformat=
       \%Eerror:\ %m,

--- a/runtime/compiler/just.vim
+++ b/runtime/compiler/just.vim
@@ -1,0 +1,23 @@
+" Vim compiler file
+" Compiler:	Just
+" Maintainer:	Alarcritty
+" Last Change:	2026 Mar 20
+
+if exists("current_compiler")
+  finish
+endif
+let current_compiler = "just"
+
+let s:cpo_save = &cpo
+set cpo-=C
+
+CompilerSet makeprg=just\ $*
+
+CompilerSet errorformat=
+      \%Eerror:\ %m,
+      \%C%\\s%#——▶\ %f:%l:%c,
+      \%-C%.%#,
+      \%-G%.%#
+
+let &cpo = s:cpo_save
+unlet s:cpo_save

--- a/src/testdir/test_compiler.vim
+++ b/src/testdir/test_compiler.vim
@@ -739,7 +739,7 @@ func Test_compiler_just()
 
   compiler just
   call assert_equal('just', b:current_compiler)
-  call assert_match('^just\s', &makeprg)
+  call assert_equal('just', &makeprg)
   let verbose_efm = execute('verbose set efm')
   call assert_match('Last set from .*[/\\]compiler[/\\]just.vim ', verbose_efm)
 

--- a/src/testdir/test_compiler.vim
+++ b/src/testdir/test_compiler.vim
@@ -734,4 +734,35 @@ func Test_compiler_spotbugs_properties()
   let &shellslash = save_shellslash
 endfunc
 
+func Test_compiler_just()
+  CheckFeature quickfix
+
+  compiler just
+  call assert_equal('just', b:current_compiler)
+  call assert_match('^just\s', &makeprg)
+  let verbose_efm = execute('verbose set efm')
+  call assert_match('Last set from .*[/\\]compiler[/\\]just.vim ', verbose_efm)
+
+  " Test that the errorformat can parse just error output
+  let lines =<< trim END
+    error: Variable `name` not defined
+      ——▶ justfile:2:15
+       │
+     2 │   echo {{name}}
+       │          ^^^^
+  END
+  call writefile(lines, 'Xjusterr.txt')
+  cgetfile Xjusterr.txt
+  let l = getqflist()
+  call assert_equal(1, len(l))
+  call assert_equal('E', l[0].type)
+  call assert_equal('Variable `name` not defined', l[0].text)
+  call assert_equal(2, l[0].lnum)
+  call assert_equal(15, l[0].col)
+
+  call setqflist([])
+  call delete('Xjusterr.txt')
+  compiler make
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
 Problem:
  The `just` command runner (https://github.com/casey/just) is not
  recognized as a compiler. `:compiler just` fails with E666.

  Solution:
  Add `runtime/compiler/just.vim` with `makeprg=just $*` and a custom
  errorformat that parses just's multi-line error output into quickfix
  entries with file, line, column, and message.
  Add a test in `src/testdir/test_compiler.vim`.
  Update `.github/MAINTAINERS`.