### PR TITLE
"zb" scrolls incorrectly with cursor on fold

### DIFF
--- a/src/move.c
+++ b/src/move.c
@@ -2570,8 +2570,12 @@ scroll_cursor_bot(int min_scroll, int set_topbot)
     if (set_topbot)
     {
 	used = 0;
-	curwin->w_botline = cln + 1;
-	loff.lnum = cln + 1;
+	linenr_T cln_last = cln;
+#ifdef FEAT_FOLDING
+	(void)hasFolding(cln, NULL, &cln_last);
+#endif
+	curwin->w_botline = cln_last + 1;
+	loff.lnum = cln_last + 1;
 #ifdef FEAT_DIFF
 	loff.fill = 0;
 #endif

--- a/src/testdir/test_normal.vim
+++ b/src/testdir/test_normal.vim
@@ -4269,6 +4269,20 @@ func Test_single_line_filler_zb()
   bw!
 endfunc
 
+" Test for zb with fewer buffer lines than window height, non-zero 'scrolloff'
+" and cursor on fold.
+func Test_zb_with_cursor_on_fold()
+  15new
+  call setline(1, range(1, 5) + ['', 'foo{{{', 'bar}}}', '', 'baz'])
+  setlocal foldmethod=marker scrolloff=1
+  call assert_equal(8, foldclosedend(7))
+  call cursor(7, 1)
+  normal! zb
+  call assert_equal(1, line('w0'))
+
+  bwipe!
+endfunc
+
 " Test for Ctrl-U not getting stuck at end of buffer with 'scrolloff'.
 func Test_halfpage_scrolloff_eob()
   set scrolloff=5


### PR DESCRIPTION
Problem:  "zb" scrolls incorrectly with cursor on fold.
Solution: Set w_botline to the line below the fold.

related: neovim/neovim#38413
