### PR TITLE
Make it configurable MODIFIED_BY etc. in Cygwin and MinGW

### DIFF
--- a/src/Make_cyg_ming.mak
+++ b/src/Make_cyg_ming.mak
@@ -27,6 +27,13 @@
 # Maintained by Ron Aaron <ronaharon@yahoo.com> et al.
 # Last Update: 2025 May 14.
 
+# If you want to build some optional features without modifying the source, you
+# can set EXTRA_DEFINES on the command line. Here's an example of setting
+# MODIFIED_BY:
+#
+#	mingw-make -f Make_ming.mvc \
+#	  'EXTRA_DEFINES=-DMODIFIED_BY=\"yourmail@example.com\"'
+
 #>>>>> choose options:
 # FEATURES=[TINY | NORMAL | HUGE]
 # Set to TINY to make a minimal version (no optional features).
@@ -536,7 +543,8 @@ endif # RUBY
 # Any other defines can be included here.
 DEF_GUI=-DFEAT_GUI_MSWIN -DFEAT_CLIPBOARD
 DEFINES=-DWIN32 -DWINVER=$(WINVER) -D_WIN32_WINNT=$(WINVER) \
-	-DHAVE_PATHDEF -DFEAT_$(FEATURES) -DHAVE_STDINT_H
+	-DHAVE_PATHDEF -DFEAT_$(FEATURES) -DHAVE_STDINT_H \
+	$(EXTRA_DEFINES)
 
 #>>>>> end of choices
 ###########################################################################


### PR DESCRIPTION
Problem:
In Cygwin and MinGW, options like MODIFIED_BY cannot be set. MSVC (Make_mvc.mak) allows you to build optional features without modifying the source code by specifying DEFINES in the nmake options. However, this is not the case in Make_cyg_ming.mak.

cf. https://github.com/vim/vim/blob/8e0483c2f484c2d99b99f0672eed6e726dceea6f/src/Make_mvc.mak#L161-L163

Solution:
Since DEFINES is used in many places, we will provide EXTRA_DEFINES assuming that the user will define it. By adding this to DEFINES, it will be possible to specify it in the same way as in MSVC.