### PR TITLE
Strip OSC 8 hyperlink sequences in manpager plugin

### DIFF
--- a/runtime/plugin/manpager.vim
+++ b/runtime/plugin/manpager.vim
@@ -32,6 +32,9 @@ function s:ManPager()
   " Remove ansi sequences
   exe 'silent! keepj keepp %s/\v\e\[%(%(\d;)?\d{1,2})?[mK]//e' .. (&gdefault ? '' : 'g')
 
+  " Remove OSC 8 hyperlink sequences: \e]8;;...\e\ or \e]8;;...\a
+  exe 'silent! keepj keepp %s/\v\e\]8;[^\a\e]*%(\a|\e\\)//e' .. (&gdefault ? '' : 'g')
+
   " Remove empty lines above the header
   call cursor(1, 1)
   let n = search(".*(.*)", "c")


### PR DESCRIPTION
Strip OSC 8 hyperlink sequences in the manpager plugin.

Some man pages (e.g. coreutils) include OSC 8 escape sequences for terminal hyperlinks. The `:Man` command avoids this by setting `GROFF_NO_SGR=1`, but the manpager plugin receives already-formatted output from stdin and only strips CSI sequences, leaving OSC 8 sequences visible as raw text.

I considered adding clickable hyperlink support, but that would require significant changes, so this PR simply strips the sequences for now.

Closes #19726