### PR TITLE
Problem: AROS/MorphOS/AmigaOS tiny/small link error

### DIFF
--- a/src/os_amiga.h
+++ b/src/os_amiga.h
@@ -20,6 +20,7 @@
 # if defined(AZTEC_C) || defined(__amigaos4__)
 #  define HAVE_STAT_H
 # endif
+# define HAVE_LOCALE_H
 # define HAVE_STDLIB_H
 # define HAVE_STRING_H
 # define HAVE_FCNTL_H


### PR DESCRIPTION
Solution: Include get_cmd_output by defining HAVE_LOCALE_H