### PR TITLE
Wks filetype addition

### DIFF
--- a/.github/MAINTAINERS
+++ b/.github/MAINTAINERS
@@ -711,6 +711,7 @@ runtime/syntax/vroom.vim				@dbarnett
 runtime/syntax/wdl.vim					@zenmatic
 runtime/syntax/wget.vim					@dkearns
 runtime/syntax/wget2.vim				@dkearns
+runtime/syntax/wks.vim					@anakin4747
 runtime/syntax/xbl.vim					@dkearns
 runtime/syntax/xcompose.vim				@ObserverOfTime
 runtime/syntax/xml.vim					@chrisbra

--- a/.github/MAINTAINERS
+++ b/.github/MAINTAINERS
@@ -350,6 +350,7 @@ runtime/ftplugin/vdf.vim				@ObserverOfTime
 runtime/ftplugin/vim.vim				@dkearns
 runtime/ftplugin/wget.vim				@dkearns
 runtime/ftplugin/wget2.vim				@dkearns
+runtime/ftplugin/wks.vim				@anakin4747
 runtime/ftplugin/xcompose.vim				@ObserverOfTime
 runtime/ftplugin/xml.vim				@chrisbra
 runtime/ftplugin/xs.vim					@petdance

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1,7 +1,7 @@
 " Vim support file to detect file types
 "
 " Maintainer:		The Vim Project <https://github.com/vim/vim>
-" Last Change:		2026 Mar 19
+" Last Change:		2026 Mar 23
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " If the filetype can be detected from extension or file name(the final path component),
@@ -885,6 +885,9 @@ au BufNewFile,BufRead requires/*.txt		setf requirements
 
 " Pkl
 au BufNewFile,BufRead *.pkl,*.pcf,pkl-lsp://*	setf pkl
+
+" WIC kickstarter files
+au BufNewFile,BufRead *.wks,*.wks.in,*.wks.inc	setf wks
 
 " Povray, Pascal, PHP or assembly
 au BufNewFile,BufRead *.inc			call dist#ft#FTinc()

--- a/runtime/ftplugin/wks.vim
+++ b/runtime/ftplugin/wks.vim
@@ -1,0 +1,14 @@
+" Vim filetype plugin file
+" Language:	OpenEmbedded Image Creator (WIC) Kickstarter files wks
+" Maintainer:	Anakin Childerhose <anakin@childerhose.ca>
+" Last Change:	2026 Mar 23
+
+if exists("b:did_ftplugin")
+  finish
+endif
+let b:did_ftplugin = 1
+
+setlocal comments=:#
+setlocal commentstring=#\ %s
+
+let b:undo_ftplugin = 'setlocal com< cms<'

--- a/runtime/syntax/wks.vim
+++ b/runtime/syntax/wks.vim
@@ -1,0 +1,29 @@
+" Vim syntax file
+" Language:	OpenEmbedded Image Creator (WIC) Kickstarter files wks
+" Maintainer:	Anakin Childerhose <anakin@childerhose.ca>
+" Last Change:	2026 Mar 23
+
+if exists("b:current_syntax")
+  finish
+endif
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+syn case match
+
+syn match wksComment "#.*$"
+syn match wksCommand "\<bootloader\>"
+syn match wksCommand "\<\(part\|partition\)\>" skipwhite nextgroup=wksMountPoint
+syn match wksMountPoint "\(/[^ \t]*\|swap\)" contained
+
+syn match wksOption "--[a-zA-Z_-]\+"
+
+hi def link wksComment    Comment
+hi def link wksCommand    Statement
+hi def link wksMountPoint Identifier
+hi def link wksOption     Special
+
+let b:current_syntax = "wks"
+let &cpo = s:cpo_save
+unlet s:cpo_save

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -964,6 +964,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     wgsl: ['file.wgsl'],
     winbatch: ['file.wbt'],
     wit: ['file.wit'],
+    wks: ['file.wks', 'file.wks.in', 'file.wks.inc'],
     wml: ['file.wml'],
     wsh: ['file.wsf', 'file.wsc'],
     wsml: ['file.wsml'],


### PR DESCRIPTION
Add syntax and ftplugin files for the OpenEmbedded image creator kickstarter files `wks` used in OpenEmbedded and Yocto projects for describing the partition and bootloader layout of embedded Linux devices.