### PR TITLE
fix flaky Test_close_lambda by waiting for channel close

### DIFF
--- a/src/testdir/test_channel.vim
+++ b/src/testdir/test_channel.vim
@@ -1475,6 +1475,9 @@ func Ch_close_handle(port)
   let s:channelfd = ch_open(s:address(a:port), s:chopt)
   call ch_sendexpr(s:channelfd, "test", {'callback': function('Ch_CloseHandler')})
   call WaitForAssert({-> assert_equal('what?', g:Ch_unletResponse)})
+  " Wait for the channel to be fully closed, so that the callback does not
+  " fire during the next test.
+  call WaitForAssert({-> assert_equal('closed', ch_status(s:channelfd))})
 endfunc
 
 func Test_close_handle()


### PR DESCRIPTION
`Test_close_lambda` was flaky on CI. The root cause was `Ch_close_handle()` returning before the channel was fully closed. `Ch_CloseHandler` could then fire during the next test's `GetPort()` sleep loop, triggering E906.

Fixed by adding `WaitForAssert()` to wait for `ch_status()` to become `'closed'` before returning from `Ch_close_handle()`.