### PR TITLE
Fix "-- VISUAL --" not shown when terminal responses are pending

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -4422,12 +4422,14 @@ screen_del_lines(
     int
 skip_showmode(void)
 {
-    // Call char_avail() only when we are going to show something, because it
-    // takes a bit of time.  redrawing() may also call char_avail().
+    // Check the stuff buffer and typeahead buffer for pending characters,
+    // instead of char_avail() which also reads raw terminal input and may pick
+    // up terminal response sequences (e.g. t_RV response), falsely preventing
+    // the mode from being shown.
     if (global_busy
 	    || msg_silent != 0
 	    || !redrawing()
-	    || (char_avail() && !KeyTyped))
+	    || ((!stuff_empty() || typebuf.tb_len > 0) && !KeyTyped))
     {
 	redraw_mode = TRUE;		// show mode later
 	return TRUE;

--- a/src/screen.c
+++ b/src/screen.c
@@ -4417,19 +4417,20 @@ screen_del_lines(
 
 /*
  * Return TRUE when postponing displaying the mode message: when not redrawing
- * or inside a mapping.
+ * or inside a mapping or a script.
  */
     int
 skip_showmode(void)
 {
-    // Check the stuff buffer and typeahead buffer for pending characters,
-    // instead of char_avail() which also reads raw terminal input and may pick
-    // up terminal response sequences (e.g. t_RV response), falsely preventing
-    // the mode from being shown.
+    // Check the stuff buffer, typeahead buffer and script input for pending
+    // characters, instead of char_avail() which also reads raw terminal input
+    // and may pick up terminal response sequences (e.g. t_RV response),
+    // falsely preventing the mode from being shown.
     if (global_busy
 	    || msg_silent != 0
 	    || !redrawing()
-	    || ((!stuff_empty() || typebuf.tb_len > 0 || using_script()) && !KeyTyped))
+	    || ((!stuff_empty() || typebuf.tb_len > 0 || using_script())
+		&& !KeyTyped))
     {
 	redraw_mode = TRUE;		// show mode later
 	return TRUE;

--- a/src/screen.c
+++ b/src/screen.c
@@ -4429,7 +4429,7 @@ skip_showmode(void)
     if (global_busy
 	    || msg_silent != 0
 	    || !redrawing()
-	    || ((!stuff_empty() || typebuf.tb_len > 0) && !KeyTyped))
+	    || ((!stuff_empty() || typebuf.tb_len > 0 || using_script()) && !KeyTyped))
     {
 	redraw_mode = TRUE;		// show mode later
 	return TRUE;


### PR DESCRIPTION
When starting Vim with a script that enters Visual mode (e.g. "vim -S script.vim"), the "-- VISUAL --" mode message sometimes doesn't appear. This happens because skip_showmode() calls char_avail(), which reads raw terminal input and picks up terminal response escape sequences (e.g. t_RV response). Combined with !KeyTyped (which is TRUE after script execution), this causes skip_showmode() to return TRUE, preventing the mode from being displayed.

Fix this by checking only the stuff buffer and typeahead buffer for pending characters, instead of char_avail() which also reads raw terminal input. This way, terminal response sequences no longer interfere with mode display.

closes: #16620