### PR TITLE
Fix fileinfo not shown after :bd of last listed buffer

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -1323,6 +1323,9 @@ empty_curbuf(
 	close_buffer(NULL, buf, action, FALSE, FALSE);
     if (!close_others)
 	need_fileinfo = FALSE;
+    else if (retval == OK && !shortmess(SHM_FILEINFO))
+	// do_ecmd() does not display file info for a new empty buffer.
+	need_fileinfo = TRUE;
     return retval;
 }
 

--- a/src/testdir/test_messages.vim
+++ b/src/testdir/test_messages.vim
@@ -811,4 +811,28 @@ func Test_long_formatprg_no_hit_enter()
   call StopVimInTerminal(buf)
 endfunc
 
+" Test that fileinfo is shown after deleting the last listed buffer with :bd
+func Test_fileinfo_after_last_bd()
+  CheckRunVimInTerminal
+
+  let content =<< trim END
+    set shortmess-=F
+    edit xxx
+    edit yyy
+  END
+
+  call writefile(content, 'Xtest_fileinfo_last_bd', 'D')
+  let buf = RunVimInTerminal('-S Xtest_fileinfo_last_bd', #{rows: 10})
+  call WaitForAssert({-> assert_match('^"yyy" \[New\]', term_getline(buf, 10))})
+
+  call term_sendkeys(buf, ":bd\<CR>")
+  call WaitForAssert({-> assert_match('^"xxx" \[New\]', term_getline(buf, 10))})
+
+  call term_sendkeys(buf, ":bd\<CR>")
+  call WaitForAssert({-> assert_match('^\"\[No Name\]\" --No lines in buffer--', term_getline(buf, 10))})
+
+  " clean up
+  call StopVimInTerminal(buf)
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
When deleting the last listed buffer with :bd, the new empty buffer's
file info (e.g. "[No Name]" --No lines in buffer--) was not displayed.
do_ecmd() only calls fileinfo() for existing buffers (oldbuf), not for
newly created empty buffers.

Set need_fileinfo in empty_curbuf() so the file info is displayed after
redraw.

Fixes: #548