### PR TITLE
feat: objectscript routine detection for .mac, .int, and .inc files

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -11,20 +11,10 @@ vim9script
 
 var prolog_pattern = '^\s*\(:-\|%\+\(\s\|$\)\|\/\*\)\|\.\s*$'
 
-def IsObjectScriptRoutine(maxlines: number): bool
-  var lnum = nextnonblank(1)
-  while lnum > 0 && lnum <= min([line("$"), maxlines])
-    var line = getline(lnum)
-    if lnum == 1
-      line = substitute(line, '^\ufeff', '', '')
-    endif
-    if line =~? '^\s*\%(import\|include\|includegenerator\)\>'
-      lnum = nextnonblank(lnum + 1)
-      continue
-    endif
-    return line =~? '^\s*routine\>\s\+[%A-Za-z][%A-Za-z0-9_.]*\%(\s*\[\|\s*;\|$\)'
-  endwhile
-  return false
+def IsObjectScriptRoutine(): bool
+  var line1 = getline(1)
+  line1 = substitute(line1, '^\ufeff', '', '')
+  return line1 =~? '^\s*routine\>\s\+[%A-Za-z][%A-Za-z0-9_.]*\%(\s*\[\|\s*;\|$\)'
 enddef
 
 export def Check_inp()
@@ -95,7 +85,7 @@ export def FTmac()
   if exists("g:filetype_mac")
     exe "setf " .. g:filetype_mac
   else
-    if IsObjectScriptRoutine(20)
+    if IsObjectScriptRoutine()
       setf objectscript_routine
     else
       FTasm()
@@ -899,7 +889,7 @@ export def FTinc()
   if exists("g:filetype_inc")
     exe "setf " .. g:filetype_inc
   else
-    if IsObjectScriptRoutine(20)
+    if IsObjectScriptRoutine()
       setf objectscript_routine
       return
     endif
@@ -975,7 +965,7 @@ enddef
 export def FTint()
   if exists("g:filetype_int")
     exe "setf " .. g:filetype_int
-  elseif IsObjectScriptRoutine(20)
+  elseif IsObjectScriptRoutine()
     setf objectscript_routine
   else
     setf hex

--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -92,10 +92,14 @@ export def FTasm()
 enddef
 
 export def FTmac()
-  if IsObjectScriptRoutine(20)
-    setf objectscript_routine
+  if exists("g:filetype_mac")
+    exe "setf " .. g:filetype_mac
   else
-    FTasm()
+    if IsObjectScriptRoutine(20)
+      setf objectscript_routine
+    else
+      FTasm()
+    endif
   endif
 enddef
 

--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -973,7 +973,9 @@ export def FTi()
 enddef
 
 export def FTint()
-  if IsObjectScriptRoutine(20)
+  if exists("g:filetype_int")
+    exe "setf " .. g:filetype_int
+  elseif IsObjectScriptRoutine(20)
     setf objectscript_routine
   else
     setf hex

--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -11,6 +11,22 @@ vim9script
 
 var prolog_pattern = '^\s*\(:-\|%\+\(\s\|$\)\|\/\*\)\|\.\s*$'
 
+def IsObjectScriptRoutine(maxlines: number): bool
+  var lnum = nextnonblank(1)
+  while lnum > 0 && lnum <= min([line("$"), maxlines])
+    var line = getline(lnum)
+    if lnum == 1
+      line = substitute(line, '^\ufeff', '', '')
+    endif
+    if line =~? '^\s*\%(import\|include\|includegenerator\)\>'
+      lnum = nextnonblank(lnum + 1)
+      continue
+    endif
+    return line =~? '^\s*routine\>\s\+[%A-Za-z][%A-Za-z0-9_.]*\%(\s*\[\|\s*;\|$\)'
+  endwhile
+  return false
+enddef
+
 export def Check_inp()
   if getline(1) =~ '%%'
     setf tex
@@ -73,6 +89,14 @@ export def FTasm()
   endif
 
   exe "setf " .. fnameescape(b:asmsyntax)
+enddef
+
+export def FTmac()
+  if IsObjectScriptRoutine(20)
+    setf objectscript_routine
+  else
+    FTasm()
+  endif
 enddef
 
 export def FTasmsyntax()
@@ -871,6 +895,10 @@ export def FTinc()
   if exists("g:filetype_inc")
     exe "setf " .. g:filetype_inc
   else
+    if IsObjectScriptRoutine(20)
+      setf objectscript_routine
+      return
+    endif
     for lnum in range(1, min([line("$"), 20]))
       var line = getline(lnum)
       if line =~? "perlscript"
@@ -938,6 +966,14 @@ export def FTi()
     lnum += 1
   endwhile
   setf progress
+enddef
+
+export def FTint()
+  if IsObjectScriptRoutine(20)
+    setf objectscript_routine
+  else
+    setf hex
+  endif
 enddef
 
 var ft_pascal_comments = '^\s*\%({\|(\*\|//\)'

--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -161,6 +161,7 @@ variables can be used to overrule the filetype used for certain extensions:
 						|ft-cpp-syntax|
 	*.i		g:filetype_i		|ft-progress-syntax|
 	*.inc		g:filetype_inc
+	*.int		g:filetype_int
 	*.lsl		g:filetype_lsl
 	*.m		g:filetype_m		|ft-mathematica-syntax|
 	*.mac		g:filetype_mac

--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -163,6 +163,7 @@ variables can be used to overrule the filetype used for certain extensions:
 	*.inc		g:filetype_inc
 	*.lsl		g:filetype_lsl
 	*.m		g:filetype_m		|ft-mathematica-syntax|
+	*.mac		g:filetype_mac
 	*[mM]makefile,*.mk,*.mak,[mM]akefile*
 			g:make_flavor		|ft-make-syntax|
 	*.markdown,*.mdown,*.mkd,*.mkdn,*.mdwn,*.md

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -119,10 +119,13 @@ au BufNewFile,BufRead */boot/grub/menu.lst,*/boot/grub/grub.conf,*/etc/grub.conf
 " *.mc omitted - used by dist#ft#McSetf()
 au BufNewFile,BufRead *.demo,*.dm{1,2,3,t},*.wxm,maxima-init.mac setf maxima
 
+" ObjectScript routine or assembly
+au BufNewFile,BufRead *.mac			call dist#ft#FTmac()
+
 " Assembly (all kinds)
 " *.lst is not pure assembly, it has two extra columns (address, byte codes)
 " *.[sS], *.[aA] usually Assembly - GNU
-au BufNewFile,BufRead *.asm,*.[sS],*.[aA],*.mac,*.lst	call dist#ft#FTasm()
+au BufNewFile,BufRead *.asm,*.[sS],*.[aA],*.lst	call dist#ft#FTasm()
 
 " BASIC or Visual Basic
 au BufNewFile,BufRead *.bas			call dist#ft#FTbas()
@@ -571,6 +574,9 @@ au BufNewFile,BufRead *.pro			call dist#ft#ProtoCheck('idlang')
 
 " Initng
 au BufNewFile,BufRead */etc/initng/*/*.i,*.ii	setf initng
+
+" Intel HEX or ObjectScript routine
+au BufNewFile,BufRead *.int			call dist#ft#FTint()
 
 " Innovation Data Processing
 au BufNewFile,BufRead upstream.dat\c,upstream.*.dat\c,*.upstream.dat\c	setf upstreamdat

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -2902,6 +2902,12 @@ func Test_mac_file()
   call assert_equal('objectscript_routine', &filetype)
   bwipe!
 
+  let g:filetype_mac = 'foo'
+  split Xfile.mac
+  call assert_equal('foo', &filetype)
+  bwipe!
+  unlet g:filetype_mac
+
   filetype off
 endfunc
 

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -2884,6 +2884,12 @@ func Test_int_file()
   call assert_equal('objectscript_routine', &filetype)
   bwipe!
 
+  let g:filetype_int = 'foo'
+  split Xfile.int
+  call assert_equal('foo', &filetype)
+  bwipe!
+  unlet g:filetype_int
+
   filetype off
 endfunc
 

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -2778,6 +2778,12 @@ func Test_inc_file()
   call assert_equal('pov', &filetype)
   bwipe!
 
+  " ObjectScript routine
+  call writefile(['ROUTINE Sample [Type=INC]'], 'Xfile.inc', 'D')
+  split Xfile.inc
+  call assert_equal('objectscript_routine', &filetype)
+  bwipe!
+
   let g:filetype_inc = 'foo'
   split Xfile.inc
   call assert_equal('foo', &filetype)
@@ -2858,6 +2864,42 @@ func Test_inc_file()
   call writefile(['asmsyntax=foo'], 'Xfile.inc')
   split Xfile.inc
   call assert_equal('foo', &filetype)
+  bwipe!
+
+  filetype off
+endfunc
+
+func Test_int_file()
+  filetype on
+
+  " Intel HEX
+  call writefile([':10010000214601360121470136007EFE09D2190140'], 'Xfile.int', 'D')
+  split Xfile.int
+  call assert_equal('hex', &filetype)
+  bwipe!
+
+  " ObjectScript routine
+  call writefile(['ROUTINE Sample [Type=INT]'], 'Xfile.int', 'D')
+  split Xfile.int
+  call assert_equal('objectscript_routine', &filetype)
+  bwipe!
+
+  filetype off
+endfunc
+
+func Test_mac_file()
+  filetype on
+
+  " Assembly
+  call writefile(['looks like asm'], 'Xfile.mac', 'D')
+  split Xfile.mac
+  call assert_equal('asm', &filetype)
+  bwipe!
+
+  " ObjectScript routine
+  call writefile(['ROUTINE Sample [Type=MAC]'], 'Xfile.mac', 'D')
+  split Xfile.mac
+  call assert_equal('objectscript_routine', &filetype)
   bwipe!
 
   filetype off


### PR DESCRIPTION
## Summary
Extends `*.inc`,`*.mac`,`*.int` filetype detection to recognize [ObjectScript Routines](https://docs.intersystems.com/latest/csp/docbook/DocBook.UI.Page.cls?KEY=GORIENT_ch_intro#GORIENT_intro_routines).

## Problem
`*.mac`, `*.int`,`*.inc`, files currently don't detect ObjectScript Routines.

## Solution
- Updated `runtime/filetype.vim`
  - route `*.mac` to `dist#ft#FTmac()`
  - route `*.int` to `dist#ft#FTint()`
- Updated `runtime/autoload/dist/ft.vim` (`FTmac()`,`FTinc()`,FTinc()):
  - add objectscript routine (`IsObjectScriptRoutine()`) (checks for routine header in first line)
  - preserve existing fallback behavior
  - add overrule options for int and mac : "g:filetype_int" and "g:filetype_mac"

## Tests
Extended `src/testdir/test_filetype.vim` with routine detection coverage:

- `Test_inc_file()`
  - add `ROUTINE ...` case -> `objectscript_routine`
  - keep existing `.inc` behavior checks unchanged
- `Test_int_file()`
  - Intel HEX case remains `hex`
  - add `ROUTINE ...` case -> `objectscript_routine`
- `Test_mac_file()`
  - asm-like case remains `asm`
  - add `ROUTINE ...` case -> `objectscript_routine`