### PR TITLE
fix(manpager): use \x07 instead of \a for BEL in OSC 8 regex

### DIFF
--- a/runtime/plugin/manpager.vim
+++ b/runtime/plugin/manpager.vim
@@ -33,8 +33,8 @@ function s:ManPager()
   " Remove ansi sequences
   exe 'silent! keepj keepp %s/\v\e\[%(%(\d;)?\d{1,2})?[mK]//e' .. (&gdefault ? '' : 'g')
 
-  " Remove OSC 8 hyperlink sequences: \e]8;;...\e\ or \e]8;;...\a
-  exe 'silent! keepj keepp %s/\v\e\]8;[^\a\e]*%(\a|\e\\)//e' .. (&gdefault ? '' : 'g')
+  " Remove OSC 8 hyperlink sequences: \e]8;;...\e\ or \e]8;;...<BEL>
+  exe 'silent! keepj keepp %s/\v\e\]8;[^\x07\e]*%(%x07|\e\\)//e' .. (&gdefault ? '' : 'g')
 
   " Remove empty lines above the header
   call cursor(1, 1)


### PR DESCRIPTION
Fix the OSC 8 hyperlink stripping regex in manpager plugin. `\a` in Vim's regex matches `[A-Za-z]`, not the BEL character (0x07), which caused man page content to be incorrectly removed. Use `\x07` / `%x07` instead.

Closes #19794