### PR TITLE
xxd: fix auto color detection for output file and TERM

### DIFF
--- a/src/testdir/test_xxd.vim
+++ b/src/testdir/test_xxd.vim
@@ -758,4 +758,68 @@ func Test_xxd_null_dereference()
   bw!
 endfunc
 
+func Test_xxd_color_outfile_no_color()
+  CheckUnix
+
+  " When output goes to a file (two-argument form), auto color should be
+  " disabled and produce the same result as redirect to file.
+  let input = 'Xxd_color_input'
+  let outfile = 'Xxd_color_outfile'
+  let outredir = 'Xxd_color_outredir'
+
+  call writefile([repeat('A', 100)], input)
+
+  " Two-argument form: xxd infile outfile
+  silent exe '!' . s:xxd_cmd . ' ' . input . ' ' . outfile
+
+  " Redirect form: xxd infile > outfile
+  silent exe '!' . s:xxd_cmd . ' ' . input . ' > ' . outredir
+
+  call assert_equal(readfile(outredir), readfile(outfile))
+
+  call delete(input)
+  call delete(outfile)
+  call delete(outredir)
+endfunc
+
+func Test_xxd_color_term_dumb()
+  CheckUnix
+
+  " When TERM is 'dumb', auto color should be disabled.
+  let input = 'Xxd_term_input'
+  let outfile = 'Xxd_term_outfile'
+
+  call writefile([repeat('A', 100)], input)
+
+  silent exe '!' . 'TERM=dumb ' . s:xxd_cmd . ' ' . input . ' > ' . outfile
+  let result = readfile(outfile)
+  " Output should not contain escape sequences
+  for line in result
+    call assert_equal(-1, stridx(line, "\e"), 'Unexpected color escape in: ' . line)
+  endfor
+
+  call delete(input)
+  call delete(outfile)
+endfunc
+
+func Test_xxd_color_term_unset()
+  CheckUnix
+
+  " When TERM is not set, auto color should be disabled.
+  let input = 'Xxd_unset_input'
+  let outfile = 'Xxd_unset_outfile'
+
+  call writefile([repeat('A', 100)], input)
+
+  silent exe '!' . 'env -u TERM ' . s:xxd_cmd . ' ' . input . ' > ' . outfile
+  let result = readfile(outfile)
+  " Output should not contain escape sequences
+  for line in result
+    call assert_equal(-1, stridx(line, "\e"), 'Unexpected color escape in: ' . line)
+  endfor
+
+  call delete(input)
+  call delete(outfile)
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/xxd/xxd.c
+++ b/src/xxd/xxd.c
@@ -723,7 +723,16 @@ enable_color(void)
   mode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
   return (int)SetConsoleMode(out, mode);
 #elif defined(UNIX)
-  return isatty(STDOUT_FILENO);
+  char *term;
+
+  if (!isatty(STDOUT_FILENO))
+    return 0;
+
+  term = getenv("TERM");
+  if (term == NULL || *term == '\0' || !strcmp(term, "dumb"))
+    return 0;
+
+  return 1;
 #else
   return 0;
 #endif
@@ -748,6 +757,7 @@ main(int argc, char *argv[])
   char *varname = NULL;
   int addrlen = 9;
   int color = 0;
+  int color_forced = 0;	/* set when -R always is used */
   char *no_color;
   char cur_color = 0;
 
@@ -920,6 +930,7 @@ main(int argc, char *argv[])
 	    {
 	      (void)enable_color();
 	      color = 1;
+	      color_forced = 1;
 	    }
 	  else if (!STRNCMP(pw, "never", 5))
 	    color = 0;
@@ -1018,6 +1029,10 @@ main(int argc, char *argv[])
 	  return 3;
 	}
       rewind(fpo);
+
+      /* Disable auto color when writing to a file. */
+      if (!color_forced)
+	color = 0;
     }
 
   if (revert)


### PR DESCRIPTION
- Disable auto color when output goes to a file (two-argument form)
- Check TERM variable: disable color when unset, empty or "dumb"
- Add color_forced flag to preserve -R always behavior
- Add tests for the new behavior

fixes: #19790