### PR TITLE
Fix: memory leak in `globpath` in `src/cmdexpand.c`

### DIFF
--- a/src/cmdexpand.c
+++ b/src/cmdexpand.c
@@ -4219,6 +4219,11 @@ globpath(
 			++ga->ga_len;
 		    }
 		}
+		else
+		{
+		    FreeWild(num_p, p);
+		    p = NULL;
+		}
 		vim_free(p);
 	    }
 	}


### PR DESCRIPTION
## Problem

In `globpath()` located in `src/cmdexpand.c`, `ExpandFromContext()` is called at line **4208** to expand file matches, allocating an array `p` of `num_p` dynamically allocated strings:

```c
if (ExpandFromContext(&xpc, buf, &p, &num_p,
                 WILD_SILENT|expand_options) != FAIL && num_p > 0)
{
    ExpandEscape(&xpc, buf, num_p, p, WILD_SILENT|expand_options);

    if (ga_grow(ga, num_p) == OK)
    {
        // take over the pointers and put them in "ga"
        for (int i = 0; i < num_p; ++i)
        {
            ((char_u **)ga->ga_data)[ga->ga_len] = p[i];
            ++ga->ga_len;
        }
    }
    vim_free(p);
}
```

When `ga_grow(ga, num_p)` succeeds, the individual `p[i]` pointers are transferred into `ga`, which takes ownership. However, when `ga_grow()` returns `FAIL`, the code skips the transfer loop and only calls `vim_free(p)`, this frees the pointer array itself but not the individually allocated strings `p[0]..p[num_p-1]` returned by `ExpandFromContext()`, resulting in a memory leak.

## Solution

Free all individually allocated strings when `ga_grow()` fails by calling `FreeWild(num_p, p)`, which frees both the individual entries and the array. Then set `p = NULL` so the subsequent `vim_free(p)` is a harmless no-op. The fix is included in this commit.
