### PR TITLE
Fix: memory leak in `eval8` in `src/eval.c`

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -4856,9 +4856,9 @@ eval8(
 
     res = eval9(arg, rettv, evalarg, want_string);
 
-    if (want_type != NULL && evaluate)
+    if (want_type != NULL)
     {
-	if (res == OK)
+	if (evaluate && res == OK)
 	{
 	    type_T *actual = typval2type(rettv, get_copyID(), &type_list,
 							       TVTT_DO_MEMBER);


### PR DESCRIPTION
## Problem

In `eval8()` located in `src/eval.c`, `parse_type()` is called at line 4837 to parse a `<type>` cast in Vim9 script, allocating type objects into `type_list`:

```c
want_type = parse_type(arg, &type_list, NULL, NULL, TRUE);
```

The cleanup call `clear_type_list(&type_list)` at line 4887 is only reached when `want_type != NULL && evaluate`:

```c
if (want_type != NULL && evaluate)
{
    if (res == OK)
    {
        // ... type checking logic ...
    }
    clear_type_list(&type_list);
}
```

When `want_type != NULL` but `evaluate` is false (the expression is being parsed but not evaluated), the entire block is skipped and `clear_type_list()` is never called. The types allocated by `parse_type()` into `type_list` are leaked.

## Solution

Change the outer condition from `want_type != NULL && evaluate` to just `want_type != NULL`, so that `clear_type_list(&type_list)` is always called when types were allocated. The `evaluate` check is moved inward to guard only the type-checking logic that depends on it. The fix is included in this commit.
