### PR TITLE
Fix: memory leak in `change_indent` in `src/indent.c`

### DIFF
--- a/src/indent.c
+++ b/src/indent.c
@@ -1513,7 +1513,10 @@ change_indent(
 	// Save new line
 	new_line = vim_strnsave(ml_get_curline(), ml_get_curline_len());
 	if (new_line == NULL)
+	{
+	    vim_free(orig_line);
 	    return;
+	}
 
 	// We only put back the new line up to the cursor
 	new_line[curwin->w_cursor.col] = NUL;


### PR DESCRIPTION
## Problem

In `change_indent()` located in `src/indent.c`, when in `VREPLACE` mode, `orig_line` is allocated at line **1336** via `vim_strnsave()` to save the original line content:

```c
if (State & VREPLACE_FLAG)
{
    orig_line = vim_strnsave(ml_get_curline(), ml_get_curline_len());
    orig_col = curwin->w_cursor.col;
}
```

Later, at line **1514**, `new_line` is allocated. If that allocation fails, the function returns immediately without freeing `orig_line`:

```c
new_line = vim_strnsave(ml_get_curline(), ml_get_curline_len());
if (new_line == NULL)
    return;       // orig_line is leaked
```

On the success path, `orig_line` is passed to `ml_replace()` with `copy=FALSE`, which consumes it (transfers ownership to the memline). But on this failure path, ownership was never transferred, so `orig_line` leaks.

## Solution

Free `orig_line` before returning when `new_line` allocation fails. The fix is included in the commit.