### PR TITLE
Fix: memory leak in `check_for_cryptkey` in `src/fileio.c`

### DIFF
--- a/src/fileio.c
+++ b/src/fileio.c
@@ -3074,8 +3074,12 @@ check_for_cryptkey(
 
 	    header_len = crypt_get_header_len(method);
 	    if (*sizep < header_len)
+	    {
 		// invalid header, buffer can't be encrypted
+		if (cryptkey != curbuf->b_p_key)
+		    vim_free(cryptkey);
 		return NULL;
+	    }
 
 	    curbuf->b_cryptstate = crypt_create_from_header(
 							method, cryptkey, ptr);


### PR DESCRIPTION
## Problem

In `check_for_cryptkey()` located in `src/fileio.c`, when the encryption header is invalid (`*sizep < header_len`), the function returns NULL at line **3078** without freeing `cryptkey`:

```c
cryptkey = crypt_get_key(newfile, FALSE);
...
if (cryptkey != NULL)
{
    int header_len;

    header_len = crypt_get_header_len(method);
    if (*sizep < header_len)
        // invalid header, buffer can't be encrypted
        return NULL;          // cryptkey is leaked
```

When `newfile` is FALSE, `crypt_get_key()` returns a freshly allocated key (not stored in `curbuf->b_p_key`). On this early return, that allocation is leaked.

## Solution

Free `cryptkey` before returning NULL when the header is invalid, but only when it's not pointing to `curbuf->b_p_key`. This matches the same guard used at line **3064** for the empty-key case. The fix is included in the commit.
