### PR TITLE
virtual text property IDs are not recycled after deletion

### DIFF
--- a/src/testdir/test_textprop.vim
+++ b/src/testdir/test_textprop.vim
@@ -4907,4 +4907,45 @@ func Test_textprop_materialize_list()
 	call assert_equal([], prop_list(1, #{ids: 3->range()}))
 endfunc
 
+func Test_textprop_virtual_text_id_recycle()
+  new
+  call setline(1, ['one', 'two', 'three'])
+
+  call prop_type_add('comment', {'highlight': 'Directory'})
+  let id_a = prop_add(1, 0, {'type': 'comment', 'text': '<text-a>'})
+  let id_b = prop_add(2, 0, {'type': 'comment', 'text': '<text-b>'})
+  let id_c = prop_add(3, 0, {'type': 'comment', 'text': '<text-c>'})
+
+  " Remove and re-add individually: IDs should be recycled
+  call prop_remove({'type': 'comment'}, 1)
+  let new_id_a = prop_add(1, 0, {'type': 'comment', 'text': '<text-a>'})
+  call assert_equal(id_a, new_id_a)
+
+  call prop_remove({'type': 'comment'}, 2)
+  let new_id_b = prop_add(2, 0, {'type': 'comment', 'text': '<text-b>'})
+  call assert_equal(id_b, new_id_b)
+
+  " Remove multiple then re-add in the same order: IDs should be recycled
+  call prop_remove({'type': 'comment'}, 1)
+  call prop_remove({'type': 'comment'}, 2)
+  let new_id_a = prop_add(1, 0, {'type': 'comment', 'text': '<text-a>'})
+  let new_id_b = prop_add(2, 0, {'type': 'comment', 'text': '<text-b>'})
+  call assert_equal(id_a, new_id_a)
+  call assert_equal(id_b, new_id_b)
+
+  " Verify text content is correct after recycling
+  let props1 = prop_list(1)
+  call assert_equal('<text-a>', props1[0].text)
+  let props2 = prop_list(2)
+  call assert_equal('<text-b>', props2[0].text)
+  let props3 = prop_list(3)
+  call assert_equal('<text-c>', props3[0].text)
+
+  call prop_remove({'type': 'comment'}, 1)
+  call prop_remove({'type': 'comment'}, 2)
+  call prop_remove({'type': 'comment'}, 3)
+  call prop_type_delete('comment')
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/textprop.c
+++ b/src/textprop.c
@@ -212,15 +212,22 @@ prop_add_one(
     {
 	garray_T    *gap = &buf->b_textprop_text;
 	char_u	    *p;
+	int	    ga_idx = -id - 1;
 
-	// double check we got the right ID
-	if (-id - 1 != gap->ga_len)
-	    iemsg("text prop ID mismatch");
-	if (gap->ga_growsize == 0)
-	    ga_init2(gap, sizeof(char *), 50);
-	if (ga_grow(gap, 1) == FAIL)
-	    goto theend;
-	((char_u **)gap->ga_data)[gap->ga_len++] = text;
+	// Recycle deleted entries
+	if (ga_idx < gap->ga_len && gap->ga_len > 0)
+	    ((char_u **)gap->ga_data)[ga_idx] = text;
+	else
+	{
+	    // double check we got the right ID
+	    if (ga_idx != gap->ga_len)
+		iemsg("text prop ID mismatch");
+	    if (gap->ga_growsize == 0)
+		ga_init2(gap, sizeof(char *), 50);
+	    if (ga_grow(gap, 1) == FAIL)
+		goto theend;
+	    ((char_u **)gap->ga_data)[gap->ga_len++] = text;
+	}
 
 	// change any control character (Tab, Newline, etc.) to a Space to make
 	// it simpler to compute the size
@@ -430,8 +437,17 @@ f_prop_add_list(typval_T *argvars, typval_T *rettv UNUSED)
     static int
 get_textprop_id(buf_T *buf)
 {
-    // TODO: recycle deleted entries
-    return -(buf->b_textprop_text.ga_len + 1);
+    garray_T	*gap = &buf->b_textprop_text;
+    char_u	**entries = (char_u **)gap->ga_data;
+
+    // Recycle deleted entries
+    for (int i = 0; i < gap->ga_len; i++)
+    {
+	if (entries[i] == NULL)
+	    return -(i + 1);
+    }
+
+    return -(gap->ga_len + 1);
 }
 
 /*


### PR DESCRIPTION
Problem:  Virtual text property IDs are not recycled after deletion,
          causing b_textprop_text growarray to grow indefinitely when
          properties are repeatedly added and removed.

Solution: Scan for NULL entries in b_textprop_text to find reusable IDs
          in get_textprop_id(), and reuse existing slots in
          prop_add_one() when a recycled ID is returned.

Fixes: #19681