### PR TITLE
tests: Test_popup_opacity_vsplit() fails with large terminal

### DIFF
--- a/src/normal.c
+++ b/src/normal.c
@@ -1616,7 +1616,8 @@ clear_showcmd(void)
     if (!p_sc)
 	return;
 
-    if (VIsual_active && !char_avail())
+    if (VIsual_active
+	&& stuff_empty() && typebuf.tb_len == 0 && !using_script())
     {
 	int		cursor_bot = LT_POS(VIsual, curwin->w_cursor);
 	long		lines;

--- a/src/testdir/dumps/Test_popupwin_opacity_vsplit_1.dump
+++ b/src/testdir/dumps/Test_popupwin_opacity_vsplit_1.dump
@@ -1,12 +1,12 @@
->r+0&#ffffff0|i|g|h|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @12||+1&&|l+0&&|e|f|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @10
-|r|i|g|h|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @12||+1&&|l+0&&|e|f|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @10
-|r|i|g|h|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @1|o|p|a|c|i|t|y| |o|v|e|r+1&&|l+0&&|v|s|p|l|i|t|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @10
-|r|i|g|h|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @12||+1&&|l+0&&|e|f|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @10
-|r|i|g|h|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @12||+1&&|l+0&&|e|f|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @10
-|r|i|g|h|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @12||+1&&|l+0&&|e|f|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @10
-|r|i|g|h|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @12||+1&&|l+0&&|e|f|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @10
-|r|i|g|h|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @12||+1&&|l+0&&|e|f|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @10
-|r|i|g|h|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @12||+1&&|l+0&&|e|f|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @10
-|r|i|g|h|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @12||+1&&|l+0&&|e|f|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @10
-|[+3&&|N|o| |N|a|m|e|]| |[|+|]| @8|1|,|1| @11|A|l@1| |[+1&&|N|o| |N|a|m|e|]| |[|+|]| @5|1|,|1| @11|A|l@1
-| +0&&@77
+>r+0&#ffffff0|i|g|h|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @2||+1&&|l+0&&|e|f|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @2
+|r|i|g|h|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @2||+1&&|l+0&&|e|f|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @2
+|r|i|g|h|t| |w|i|n|d|o|w| |t|e|x|t| |o+0#ffffff255#000045255|p|a|c|i|t|y|x+0#8080c5255&|o+0#ffffff255&|v|e|r||+1#8080c5255&|v+0#ffffff255&|s|p|l|i|t|i+0#8080c5255&|n|d|o|w| |t+0#0000000#ffffff0|e|x|t| |h|e|r|e| |x@3| @2
+|r|i|g|h|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @2||+1&&|l+0&&|e|f|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @2
+|r|i|g|h|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @2||+1&&|l+0&&|e|f|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @2
+|r|i|g|h|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @2||+1&&|l+0&&|e|f|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @2
+|r|i|g|h|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @2||+1&&|l+0&&|e|f|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @2
+|r|i|g|h|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @2||+1&&|l+0&&|e|f|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @2
+|r|i|g|h|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @2||+1&&|l+0&&|e|f|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @2
+|r|i|g|h|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @2||+1&&|l+0&&|e|f|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @2
+|[+3&&|N|o| |N|a|m|e|]| |[|+|]| @1|1|,|1| @8|A|l@1| |[+1&&|N|o| |N|a|m|e|]| |[|+|]| @1|1|,|1| @7|A|l@1
+| +0&&@59

--- a/src/testdir/dumps/Test_popupwin_opacity_vsplit_2.dump
+++ b/src/testdir/dumps/Test_popupwin_opacity_vsplit_2.dump
@@ -1,12 +1,12 @@
-|r+0&#ffffff0|i|g|h|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @12||+1&&|l+0&&|e|f|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @10
-|r|i|g|h|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @12||+1&&|l+0&&|e|f|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @10
-|r|i|g|h|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @1|o|p|a|c|i|t|y| |o|v|e|r+1&&|l+0&&|v|s|p|l|i|t|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @10
-|r|i|g|h|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @12||+1&&|l+0&&|e|f|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @10
-|r|i|g|h|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @12||+1&&|l+0&&|e|f|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @10
->r|i|g|h|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @12||+1&&|l+0&&|e|f|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @10
-|r|i|g|h|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @12||+1&&|l+0&&|e|f|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @10
-|r|i|g|h|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @12||+1&&|l+0&&|e|f|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @10
-|r|i|g|h|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @12||+1&&|l+0&&|e|f|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @10
-|r|i|g|h|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @12||+1&&|l+0&&|e|f|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @10
-|[+3&&|N|o| |N|a|m|e|]| |[|+|]| @8|6|,|1| @11|A|l@1| |[+1&&|N|o| |N|a|m|e|]| |[|+|]| @5|1|,|1| @11|A|l@1
-| +0&&@77
+|r+0&#ffffff0|i|g|h|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @2||+1&&|l+0&&|e|f|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @2
+|r|i|g|h|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @2||+1&&|l+0&&|e|f|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @2
+|r|i|g|h|t| |w|i|n|d|o|w| |t|e|x|t| |o+0#ffffff255#000045255|p|a|c|i|t|y|x+0#8080c5255&|o+0#ffffff255&|v|e|r||+1#8080c5255&|v+0#ffffff255&|s|p|l|i|t|i+0#8080c5255&|n|d|o|w| |t+0#0000000#ffffff0|e|x|t| |h|e|r|e| |x@3| @2
+|r|i|g|h|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @2||+1&&|l+0&&|e|f|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @2
+|r|i|g|h|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @2||+1&&|l+0&&|e|f|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @2
+>r|i|g|h|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @2||+1&&|l+0&&|e|f|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @2
+|r|i|g|h|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @2||+1&&|l+0&&|e|f|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @2
+|r|i|g|h|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @2||+1&&|l+0&&|e|f|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @2
+|r|i|g|h|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @2||+1&&|l+0&&|e|f|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @2
+|r|i|g|h|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @2||+1&&|l+0&&|e|f|t| |w|i|n|d|o|w| |t|e|x|t| |h|e|r|e| |x@3| @2
+|[+3&&|N|o| |N|a|m|e|]| |[|+|]| @1|6|,|1| @8|A|l@1| |[+1&&|N|o| |N|a|m|e|]| |[|+|]| @1|1|,|1| @7|A|l@1
+| +0&&@59

--- a/src/testdir/test_popupwin.vim
+++ b/src/testdir/test_popupwin.vim
@@ -5029,13 +5029,14 @@ func Test_popup_opacity_vsplit()
   " Opacity popup spanning a vertical split should redraw both windows
   " underneath, not just the left one (blend accumulation bug).
   let lines =<< trim END
+    set termguicolors
     call setline(1, repeat(['left window text here xxxx'], 10))
     vnew
     call setline(1, repeat(['right window text here xxxx'], 10))
     wincmd h
     hi PopupColor guibg=darkblue guifg=white
     let g:pop_id = popup_create(['opacity over vsplit'], #{
-        \ line: 3, col: 30,
+        \ line: 3, col: 19,
         \ minwidth: 25,
         \ highlight: 'PopupColor',
         \ opacity: 50,
@@ -5043,7 +5044,7 @@ func Test_popup_opacity_vsplit()
         \})
   END
   call writefile(lines, 'XtestPopupOpacityVsplit', 'D')
-  let buf = RunVimInTerminal('-S XtestPopupOpacityVsplit', #{rows: 12, cols: 80})
+  let buf = RunVimInTerminal('-S XtestPopupOpacityVsplit', #{rows: 12, cols: 60})
   call VerifyScreenDump(buf, 'Test_popupwin_opacity_vsplit_1', {})
 
   " Move cursor multiple times to trigger redraws; without the fix the

--- a/src/testdir/test_visual.vim
+++ b/src/testdir/test_visual.vim
@@ -1634,7 +1634,6 @@ func Test_visual_block_hl_with_autoselect()
   call writefile(lines, 'XTest_visual_block_autoselect', 'D')
 
   let buf = RunVimInTerminal('-S XTest_visual_block_autoselect', {'rows': 10})
-  call TermWait(buf, 50)
   call VerifyScreenDump(buf, 'Test_visual_block_hl_with_autoselect_1', {})
   call term_sendkeys(buf, 'l')
   call VerifyScreenDump(buf, 'Test_visual_block_hl_with_autoselect_2', {})

--- a/src/testdir/test_visual.vim
+++ b/src/testdir/test_visual.vim
@@ -1634,7 +1634,7 @@ func Test_visual_block_hl_with_autoselect()
   call writefile(lines, 'XTest_visual_block_autoselect', 'D')
 
   let buf = RunVimInTerminal('-S XTest_visual_block_autoselect', {'rows': 10})
-  call TermWait(buf)
+  call TermWait(buf, 50)
   call VerifyScreenDump(buf, 'Test_visual_block_hl_with_autoselect_1', {})
   call term_sendkeys(buf, 'l')
   call VerifyScreenDump(buf, 'Test_visual_block_hl_with_autoselect_2', {})


### PR DESCRIPTION
Problem:  tests: Test_popup_opacity_vsplit() fails with large terminal
          (after v9.2.0230)
Solution: Reduce terminal window size to 60, force termguicolors to make
          the opacity visible