### PR TITLE
fix: system() List arg link error without FEAT_JOB_CHANNEL

### DIFF
--- a/src/misc2.c
+++ b/src/misc2.c
@@ -3095,7 +3095,9 @@ build_argv_from_string(char_u *cmd, char ***argv, int *argc)
     return OK;
 }
 
-# if defined(FEAT_JOB_CHANNEL)
+#endif
+
+#if defined(FEAT_EVAL)
 /*
  * Build "argv[argc]" from the list "l".
  * "argv[argc]" is set to NULL;
@@ -3130,7 +3132,6 @@ build_argv_from_list(list_T *l, char ***argv, int *argc)
     (*argv)[*argc] = NULL;
     return OK;
 }
-# endif
 #endif
 
 /*

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -5960,7 +5960,9 @@ create_pipe_pair(HANDLE handles[2])
     return TRUE;
 }
 
-# if defined(FEAT_EVAL)
+#endif // FEAT_JOB_CHANNEL
+
+#if defined(FEAT_EVAL)
 /*
  * Execute "argv" directly without the shell and return the output.
  * Used by system() and systemlist() when the command is a List.
@@ -6171,8 +6173,9 @@ done:
 	CloseHandle(hChildStdinRd);
     return buffer;
 }
-# endif
+#endif // FEAT_EVAL
 
+#if defined(FEAT_JOB_CHANNEL)
     void
 mch_job_start(char *cmd, job_T *job, jobopt_T *options)
 {


### PR DESCRIPTION
Move build_argv_from_list() and mch_get_cmd_output_direct() out of FEAT_JOB_CHANNEL preprocessor guards so that system() with a List argument (patch 9.2.0250) builds correctly in configurations that have FEAT_EVAL but not FEAT_JOB_CHANNEL (e.g. FEAT_NORMAL without GUI on Windows).

Thanks to John Marriott (@basilisk0315) for reporting and providing initial patches.
https://github.com/vim/vim/commit/30f012d8bcf3d1cb19410ab8ca20523b1716539d#commitcomment-160237498