### PR TITLE
Fix: memory leak in `call_oc_method` in `src/vim9class.c`

### DIFF
--- a/src/vim9class.c
+++ b/src/vim9class.c
@@ -3099,7 +3099,11 @@ call_oc_method(
     char_u *argp = name_end;
     int ret = get_func_arguments(&argp, evalarg, 0, argvars, &argcount, FALSE);
     if (ret == FAIL)
+    {
+	while (--argcount >= 0)
+	    clear_tv(&argvars[argcount]);
 	return FAIL;
+    }
 
     funcexe_T funcexe;
     CLEAR_FIELD(funcexe);


### PR DESCRIPTION
## Problem

In `call_oc_method()` located in `src/vim9class.c`, `get_func_arguments()` is called at line **3100** to parse and evaluate function arguments into `argvars[]`. When `get_func_arguments()` fails, it may have already populated `argvars[0..argcount-1]` with evaluated arguments that own allocated memory (e.g., strings, lists, dicts).

The function returns FAIL immediately without cleaning up these arguments:

```c
int ret = get_func_arguments(&argp, evalarg, 0, argvars, &argcount, FALSE);
if (ret == FAIL)
    return FAIL;       // argvars[0..argcount-1] leaked
```

The cleanup loop at lines **3126-3127** is only reached on the success path:

```c
for (int idx = 0; idx < argcount; ++idx)
    clear_tv(&argvars[idx]);
```

Other callers of `get_func_arguments()` (e.g., `get_func_tv()` in `src/userfunc.c:2209-2210`) correctly clean up `argvars` on both success and failure paths.

## Solution

Clean up the already-parsed arguments before returning FAIL, matching the pattern used in `get_func_tv()`. The fix is included in the commit.
