### PR TITLE
fix(tabpanel): prevent flicker when scrolling edit buffer

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -3845,6 +3845,13 @@ win_do_lines(
     if (!no_win_do_lines_ins)
 	clear_cmdline = TRUE;
 
+#if defined(FEAT_TABPANEL)
+    // Terminal scroll operations affect the full screen width, which would
+    // corrupt the vertical tabpanel area and cause flicker.
+    if (tabpanel_width() > 0)
+	return FAIL;
+#endif
+
     /*
      * If the terminal can set a scroll region, use that.
      * Always do this in a vertically split window.  This will redraw from


### PR DESCRIPTION
When a vertical tabpanel is visible, terminal scroll operations in win_do_lines() affect the full screen width, corrupting the tabpanel area momentarily. The tabpanel is then redrawn via redraw_tabpanel, causing visible flicker.
Return FAIL from win_do_lines() when tabpanel_width() > 0 to force line-by-line redraw instead, analogous to the existing popup_visible check. The check is placed after clear_cmdline is set to ensure the command line is properly cleared during scroll.