### PR TITLE
Allow defining dictionary function with bracket key that is not a valid identifier

### DIFF
--- a/src/testdir/test_user_func.vim
+++ b/src/testdir/test_user_func.vim
@@ -584,6 +584,18 @@ func Test_func_dict()
   call assert_fails('call mydict.nonexist()', 'E716:')
 endfunc
 
+func Test_func_dict_bracket_key()
+  " Dictionary function can be defined with bracket notation using a key
+  " that does not follow function naming rules (e.g. containing a hyphen).
+  let obj = {}
+  function obj['foo-bar']() dict
+    return self.value
+  endfunction
+  let obj.value = 42
+  call assert_equal(42, obj['foo-bar']())
+  call assert_equal(42, call(obj['foo-bar'], []))
+endfunc
+
 func Test_func_range()
   new
   call setline(1, range(1, 8))

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -5253,33 +5253,40 @@ define_function(
 	    char_u  *name_base = arg;
 	    int	    i;
 
-	    if (*arg == K_SPECIAL)
+	    // When defining a dictionary function with bracket notation
+	    // (e.g. obj['foo-bar']()), the key is a dictionary key and is not
+	    // required to follow function naming rules.  Skip the identifier
+	    // check in that case.
+	    if (arg != fudi.fd_newkey)
 	    {
-		name_base = vim_strchr(arg, '_');
-		if (name_base == NULL)
-		    name_base = arg + 3;
-		else
-		    ++name_base;
-	    }
-	    for (i = 0; name_base[i] != NUL && (i == 0
-					? eval_isnamec1(name_base[i])
-					: eval_isnamec(name_base[i])); ++i)
-		;
-	    if (name_base[i] != NUL)
-	    {
-		emsg_funcname(e_invalid_argument_str, arg);
-		goto ret_free;
-	    }
+		if (*arg == K_SPECIAL)
+		{
+		    name_base = vim_strchr(arg, '_');
+		    if (name_base == NULL)
+			name_base = arg + 3;
+		    else
+			++name_base;
+		}
+		for (i = 0; name_base[i] != NUL && (i == 0
+					    ? eval_isnamec1(name_base[i])
+					    : eval_isnamec(name_base[i])); ++i)
+		    ;
+		if (name_base[i] != NUL)
+		{
+		    emsg_funcname(e_invalid_argument_str, arg);
+		    goto ret_free;
+		}
 
-	    // In Vim9 script a function cannot have the same name as a
-	    // variable.
-	    if (vim9script && *arg == K_SPECIAL
-		&& eval_variable(name_base, i, 0, NULL,
-		    NULL, EVAL_VAR_NOAUTOLOAD + EVAL_VAR_IMPORT
+		// In Vim9 script a function cannot have the same name as a
+		// variable.
+		if (vim9script && *arg == K_SPECIAL
+		    && eval_variable(name_base, i, 0, NULL,
+			NULL, EVAL_VAR_NOAUTOLOAD + EVAL_VAR_IMPORT
 						     + EVAL_VAR_NO_FUNC) == OK)
-	    {
-		semsg(_(e_redefining_script_item_str), name_base);
-		goto ret_free;
+		{
+		    semsg(_(e_redefining_script_item_str), name_base);
+		    goto ret_free;
+		}
 	    }
 	}
 	// Disallow using the g: dict.


### PR DESCRIPTION
## Problem

In Vim script, a dictionary function can be defined as:

- `function obj.func()` (dot notation)
- `function obj['func']()` (bracket notation)

When using bracket notation, the expression inside `[]` was required to match function naming rules (identifier: letters, digits, underscore). So for example:

```vim
function obj['foo-bar']() dict
  return self.x
endfunction
```

failed with `E475: Invalid argument`.

However, once a dictionary function exists, it can be assigned and called with any key:

- `let obj['foo-bar'] = obj.func` works
- `call obj['foo-bar']()` works

So only the definition was incorrectly restricted.

This PR resolves this issue and brings consistency to the behavior.
This change may also be useful when creating DSLs in Vim script, for example.

## Cause

In `userfunc.c`, when handling `:function name(...)` or `:function dict[key](...)`, the code validated the name with `eval_isnamec1` / `eval_isnamec`. For the bracket form, the key (e.g. `'foo-bar'`) is stored in `fudi.fd_newkey`. That key was validated as if it were a function name, even though it is just a dictionary key. Dictionary keys in Vim are arbitrary strings.

## Solution

When the "name" being checked is `fudi.fd_newkey` (i.e. we are defining a dictionary function with bracket notation), skip the identifier check. The key is a dictionary key and does not need to follow function naming rules.

## Others

I was helped by AI for this work.
