### PR TITLE
Store virtual text in ref-counted vtext_T to fix undo/redo

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -696,9 +696,9 @@ LINT_OPTIONS = -beprxzF
 # $ export ASAN_OPTIONS="print_stacktrace=1 log_path=asan"
 # $ export LSAN_OPTIONS="suppressions=`pwd`/testdir/lsan-suppress.txt"
 # When running tests output can be found in testdir/asan.*
-SANITIZER_CFLAGS = -g -O0 -fsanitize-recover=all \
-		   -fsanitize=address -fsanitize=undefined \
-		   -fno-omit-frame-pointer
+#SANITIZER_CFLAGS = -g -O0 -fsanitize-recover=all \
+#		   -fsanitize=address -fsanitize=undefined \
+#		   -fno-omit-frame-pointer
 
 # Similarly when compiling with clang and using ubsan.
 # $ export UBSAN_OPTIONS="print_stacktrace=1 log_path=ubsan"
@@ -713,7 +713,7 @@ SANITIZER_LIBS = $(SANITIZER_CFLAGS)
 # Configuration is in the .ccmalloc or ~/.ccmalloc file.
 # Doesn't work very well, since memory linked to from global variables
 # (in libraries) is also marked as leaked memory.
-LEAK_CFLAGS = -DEXITFREE
+#LEAK_CFLAGS = -DEXITFREE
 #LEAK_LIBS = -lccmalloc
 
 # Uncomment this line to have Vim call abort() when an internal error is

--- a/src/Makefile
+++ b/src/Makefile
@@ -696,9 +696,9 @@ LINT_OPTIONS = -beprxzF
 # $ export ASAN_OPTIONS="print_stacktrace=1 log_path=asan"
 # $ export LSAN_OPTIONS="suppressions=`pwd`/testdir/lsan-suppress.txt"
 # When running tests output can be found in testdir/asan.*
-#SANITIZER_CFLAGS = -g -O0 -fsanitize-recover=all \
-#		   -fsanitize=address -fsanitize=undefined \
-#		   -fno-omit-frame-pointer
+SANITIZER_CFLAGS = -g -O0 -fsanitize-recover=all \
+		   -fsanitize=address -fsanitize=undefined \
+		   -fno-omit-frame-pointer
 
 # Similarly when compiling with clang and using ubsan.
 # $ export UBSAN_OPTIONS="print_stacktrace=1 log_path=ubsan"
@@ -713,7 +713,7 @@ SANITIZER_LIBS = $(SANITIZER_CFLAGS)
 # Configuration is in the .ccmalloc or ~/.ccmalloc file.
 # Doesn't work very well, since memory linked to from global variables
 # (in libraries) is also marked as leaked memory.
-#LEAK_CFLAGS = -DEXITFREE
+LEAK_CFLAGS = -DEXITFREE
 #LEAK_LIBS = -lccmalloc
 
 # Uncomment this line to have Vim call abort() when an internal error is

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -967,44 +967,12 @@ buf_freeall(buf_T *buf, int flags)
 #ifdef FEAT_TCL
     tcl_buffer_free(buf);
 #endif
-#ifdef FEAT_PROP_POPUP
-    // Unref virtual text in memline and clear the pointers to NULL.
-    // This must be done before u_clearallandblockfree() because undo
-    // entries contain byte-copies of the same tp_vtext pointers.
-    // Clearing to NULL ensures u_unref_vtext() will skip them.
-    if (buf->b_has_textprop && buf->b_ml.ml_mfp != NULL)
-    {
-	linenr_T    lnum;
-
-	for (lnum = 1; lnum <= buf->b_ml.ml_line_count; ++lnum)
-	{
-	    char_u  *props;
-	    int	    count = get_text_props(buf, lnum, &props, TRUE);
-	    int	    i;
-
-	    for (i = 0; i < count; ++i)
-	    {
-		textprop_T prop;
-
-		mch_memmove(&prop, props + i * sizeof(textprop_T),
-							sizeof(textprop_T));
-		if (prop.tp_vtext != NULL)
-		{
-		    vtext_unref(prop.tp_vtext);
-		    prop.tp_vtext = NULL;
-		    mch_memmove(props + i * sizeof(textprop_T),
-					    &prop, sizeof(textprop_T));
-		}
-	    }
-	}
-    }
-#endif
+    ml_close(buf, TRUE);	    // close and delete the memline/memfile
+    buf->b_ml.ml_line_count = 0;    // no lines in buffer
     if ((flags & BFA_KEEP_UNDO) == 0)
 	// free the memory allocated for undo
 	// and reset all undo information
 	u_clearallandblockfree(buf);
-    ml_close(buf, TRUE);	    // close and delete the memline/memfile
-    buf->b_ml.ml_line_count = 0;    // no lines in buffer
 #ifdef FEAT_SYN_HL
     syntax_clear(&buf->b_s);	    // reset syntax info
 #endif
@@ -1149,7 +1117,28 @@ free_buffer_stuff(
     netbeans_file_killed(buf);
 #endif
 #ifdef FEAT_PROP_POPUP
-    // Virtual text is unreferenced in buf_freeall() before undo cleanup.
+    // Unref virtual text in all lines before freeing the buffer.
+    if (buf->b_has_textprop && buf->b_ml.ml_mfp != NULL)
+    {
+	linenr_T    lnum;
+
+	for (lnum = 1; lnum <= buf->b_ml.ml_line_count; ++lnum)
+	{
+	    char_u  *props;
+	    int	    count = get_text_props(buf, lnum, &props, FALSE);
+	    int	    i;
+
+	    for (i = 0; i < count; ++i)
+	    {
+		textprop_T  prop;
+
+		mch_memmove(&prop, props + i * sizeof(textprop_T),
+						       sizeof(textprop_T));
+		if (prop.tp_vtext != NULL)
+		    vtext_unref(prop.tp_vtext);
+	    }
+	}
+    }
 #endif
     map_clear_mode(buf, MAP_ALL_MODES, TRUE, FALSE);  // clear local mappings
     map_clear_mode(buf, MAP_ALL_MODES, TRUE, TRUE);   // clear local abbrevs

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -1117,7 +1117,7 @@ free_buffer_stuff(
     netbeans_file_killed(buf);
 #endif
 #ifdef FEAT_PROP_POPUP
-    ga_clear_strings(&buf->b_textprop_text);
+    // Virtual text is managed via tp_vtext with reference counting.
 #endif
     map_clear_mode(buf, MAP_ALL_MODES, TRUE, FALSE);  // clear local mappings
     map_clear_mode(buf, MAP_ALL_MODES, TRUE, TRUE);   // clear local abbrevs

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -967,12 +967,44 @@ buf_freeall(buf_T *buf, int flags)
 #ifdef FEAT_TCL
     tcl_buffer_free(buf);
 #endif
-    ml_close(buf, TRUE);	    // close and delete the memline/memfile
-    buf->b_ml.ml_line_count = 0;    // no lines in buffer
+#ifdef FEAT_PROP_POPUP
+    // Unref virtual text in memline and clear the pointers to NULL.
+    // This must be done before u_clearallandblockfree() because undo
+    // entries contain byte-copies of the same tp_vtext pointers.
+    // Clearing to NULL ensures u_unref_vtext() will skip them.
+    if (buf->b_has_textprop && buf->b_ml.ml_mfp != NULL)
+    {
+	linenr_T    lnum;
+
+	for (lnum = 1; lnum <= buf->b_ml.ml_line_count; ++lnum)
+	{
+	    char_u  *props;
+	    int	    count = get_text_props(buf, lnum, &props, TRUE);
+	    int	    i;
+
+	    for (i = 0; i < count; ++i)
+	    {
+		textprop_T prop;
+
+		mch_memmove(&prop, props + i * sizeof(textprop_T),
+							sizeof(textprop_T));
+		if (prop.tp_vtext != NULL)
+		{
+		    vtext_unref(prop.tp_vtext);
+		    prop.tp_vtext = NULL;
+		    mch_memmove(props + i * sizeof(textprop_T),
+					    &prop, sizeof(textprop_T));
+		}
+	    }
+	}
+    }
+#endif
     if ((flags & BFA_KEEP_UNDO) == 0)
 	// free the memory allocated for undo
 	// and reset all undo information
 	u_clearallandblockfree(buf);
+    ml_close(buf, TRUE);	    // close and delete the memline/memfile
+    buf->b_ml.ml_line_count = 0;    // no lines in buffer
 #ifdef FEAT_SYN_HL
     syntax_clear(&buf->b_s);	    // reset syntax info
 #endif
@@ -1117,28 +1149,7 @@ free_buffer_stuff(
     netbeans_file_killed(buf);
 #endif
 #ifdef FEAT_PROP_POPUP
-    // Unref virtual text in all lines before freeing the buffer.
-    if (buf->b_has_textprop && buf->b_ml.ml_mfp != NULL)
-    {
-	linenr_T    lnum;
-
-	for (lnum = 1; lnum <= buf->b_ml.ml_line_count; ++lnum)
-	{
-	    char_u  *props;
-	    int	    count = get_text_props(buf, lnum, &props, FALSE);
-	    int	    i;
-
-	    for (i = 0; i < count; ++i)
-	    {
-		textprop_T  prop;
-
-		mch_memmove(&prop, props + i * sizeof(textprop_T),
-						       sizeof(textprop_T));
-		if (prop.tp_vtext != NULL)
-		    vtext_unref(prop.tp_vtext);
-	    }
-	}
-    }
+    // Virtual text is unreferenced in buf_freeall() before undo cleanup.
 #endif
     map_clear_mode(buf, MAP_ALL_MODES, TRUE, FALSE);  // clear local mappings
     map_clear_mode(buf, MAP_ALL_MODES, TRUE, TRUE);   // clear local abbrevs

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -1117,7 +1117,28 @@ free_buffer_stuff(
     netbeans_file_killed(buf);
 #endif
 #ifdef FEAT_PROP_POPUP
-    // Virtual text is managed via tp_vtext with reference counting.
+    // Unref virtual text in all lines before freeing the buffer.
+    if (buf->b_has_textprop && buf->b_ml.ml_mfp != NULL)
+    {
+	linenr_T    lnum;
+
+	for (lnum = 1; lnum <= buf->b_ml.ml_line_count; ++lnum)
+	{
+	    char_u  *props;
+	    int	    count = get_text_props(buf, lnum, &props, FALSE);
+	    int	    i;
+
+	    for (i = 0; i < count; ++i)
+	    {
+		textprop_T  prop;
+
+		mch_memmove(&prop, props + i * sizeof(textprop_T),
+						       sizeof(textprop_T));
+		if (prop.tp_vtext != NULL)
+		    vtext_unref(prop.tp_vtext);
+	    }
+	}
+    }
 #endif
     map_clear_mode(buf, MAP_ALL_MODES, TRUE, FALSE);  // clear local mappings
     map_clear_mode(buf, MAP_ALL_MODES, TRUE, TRUE);   // clear local abbrevs

--- a/src/charset.c
+++ b/src/charset.c
@@ -1289,7 +1289,6 @@ win_lbr_chartabsize(
 	int	    charlen = *s == NUL ? 1 : mb_ptr2len(s);
 	int	    i;
 	int	    col = (int)(s - line);
-	garray_T    *gap = &wp->w_buffer->b_textprop_text;
 
 	// The "$" for 'list' mode will go between the EOL and
 	// the text prop, account for that.
@@ -1307,15 +1306,15 @@ win_lbr_chartabsize(
 	    // Watch out for the text being deleted.  "cts_text_props" is a
 	    // copy, the text prop may actually have been removed from the line.
 	    if (tp->tp_id < 0
+		    && tp->tp_vtext != NULL
 		    && ((tp->tp_col - 1 >= col
 					     && tp->tp_col - 1 < col + charlen)
 		       || (tp->tp_col == MAXCOL
 			   && ((tp->tp_flags & TP_FLAG_ALIGN_ABOVE)
 				? col == 0
-				: s[0] == NUL && cts->cts_with_trailing)))
-		    && -tp->tp_id - 1 < gap->ga_len)
+				: s[0] == NUL && cts->cts_with_trailing))))
 	    {
-		char_u *p = ((char_u **)gap->ga_data)[-tp->tp_id - 1];
+		char_u *p = tp->tp_vtext->vt_text;
 
 		if (p != NULL)
 		{

--- a/src/drawline.c
+++ b/src/drawline.c
@@ -2246,13 +2246,10 @@ win_line(
 			}
 		    }
 		    if (text_prop_id < 0 && used_tpi >= 0
-			    && -text_prop_id
-				      <= wp->w_buffer->b_textprop_text.ga_len)
+				 && text_props[used_tpi].tp_vtext != NULL)
 		    {
 			textprop_T  *tp = &text_props[used_tpi];
-			char_u	    *p = ((char_u **)wp->w_buffer
-						   ->b_textprop_text.ga_data)[
-							   -text_prop_id - 1];
+			char_u	    *p = tp->tp_vtext->vt_text;
 			int	    above = (tp->tp_flags
 							& TP_FLAG_ALIGN_ABOVE);
 			int	    bail_out = FALSE;

--- a/src/memline.c
+++ b/src/memline.c
@@ -3891,13 +3891,6 @@ ml_delete_int(buf_T *buf, linenr_T lnum, int flags)
 	if (!(flags & (ML_DEL_UNDO | ML_DEL_NOPROP)) && textprop_len > 0)
 	    textprop_save = vim_memsave((char_u *)dp + line_start + textlen,
 								 textprop_len);
-
-	// Do NOT unref vtext for ML_DEL_UNDO.  u_save_line()
-	// incremented the refcount to account for the undo copy;
-	// that increment also covers the memline reference being
-	// destroyed here.  The old undo data will be re-inserted
-	// into the memline via ml_append_flags(ML_APPEND_UNDO),
-	// which transfers ownership without changing the refcount.
     }
 #endif
 

--- a/src/memline.c
+++ b/src/memline.c
@@ -3993,6 +3993,20 @@ theend:
 	if (lnum <= buf->b_ml.ml_line_count)
 	    adjust_text_props_for_delete(buf, lnum, textprop_save,
 						     (int)textprop_len, FALSE);
+
+	// Unref virtual text in the deleted line's properties.
+	{
+	    int done;
+
+	    for (done = 0; done < (int)textprop_len; done += sizeof(textprop_T))
+	    {
+		textprop_T prop;
+
+		mch_memmove(&prop, textprop_save + done, sizeof(textprop_T));
+		if (prop.tp_vtext != NULL)
+		    vtext_unref(prop.tp_vtext);
+	    }
+	}
     }
     vim_free(textprop_save);
 #endif

--- a/src/memline.c
+++ b/src/memline.c
@@ -3891,6 +3891,13 @@ ml_delete_int(buf_T *buf, linenr_T lnum, int flags)
 	if (!(flags & (ML_DEL_UNDO | ML_DEL_NOPROP)) && textprop_len > 0)
 	    textprop_save = vim_memsave((char_u *)dp + line_start + textlen,
 								 textprop_len);
+
+	// Do NOT unref vtext for ML_DEL_UNDO.  u_save_line()
+	// incremented the refcount to account for the undo copy;
+	// that increment also covers the memline reference being
+	// destroyed here.  The old undo data will be re-inserted
+	// into the memline via ml_append_flags(ML_APPEND_UNDO),
+	// which transfers ownership without changing the refcount.
     }
 #endif
 

--- a/src/proto/textprop.pro
+++ b/src/proto/textprop.pro
@@ -1,4 +1,7 @@
 /* textprop.c */
+vtext_T *vtext_alloc(char_u *text);
+void vtext_ref(vtext_T *vt);
+void vtext_unref(vtext_T *vt);
 int find_prop_type_id(char_u *name, buf_T *buf);
 void f_prop_add(typval_T *argvars, typval_T *rettv);
 void f_prop_add_list(typval_T *argvars, typval_T *rettv);

--- a/src/structs.h
+++ b/src/structs.h
@@ -890,6 +890,13 @@ typedef struct memline
  * When stored in memline they are after the text, ml_line_len is larger than
  * STRLEN(ml_line_ptr) + 1.
  */
+// Reference-counted virtual text string.
+typedef struct vtext_S
+{
+    int		vt_refcount;	// reference count; free when it reaches zero
+    char_u	vt_text[];	// NUL-terminated text (flexible array member)
+} vtext_T;
+
 typedef struct textprop_S
 {
     colnr_T	tp_col;		// start column (one based, in bytes)
@@ -900,6 +907,7 @@ typedef struct textprop_S
     int		tp_flags;	// TP_FLAG_ values
     int		tp_padleft;	// left padding between text line and virtual
 				// text
+    vtext_T	*tp_vtext;	// virtual text (ref-counted), or NULL
 } textprop_T;
 
 #define TP_FLAG_CONT_NEXT	0x1	// property continues in next line
@@ -3550,7 +3558,8 @@ struct file_buffer
     int		b_has_textprop;	// TRUE when text props were added
     hashtab_T	*b_proptypes;	// text property types local to buffer
     proptype_T	**b_proparray;	// entries of b_proptypes sorted on tp_id
-    garray_T	b_textprop_text; // stores text for props, index by (-id - 1)
+    int		b_textprop_next_vt_id;	// next virtual text property ID
+					// (decremented for each new one)
 #endif
 
 #if defined(FEAT_BEVAL) && defined(FEAT_EVAL)

--- a/src/testdir/Make_all.mak
+++ b/src/testdir/Make_all.mak
@@ -336,6 +336,7 @@ NEW_TESTS = \
 	test_textformat \
 	test_textobjects \
 	test_textprop \
+	test_textprop2 \
 	test_timers \
 	test_true_false \
 	test_trycatch \
@@ -599,6 +600,7 @@ NEW_TESTS_RES = \
 	test_textformat.res \
 	test_textobjects.res \
 	test_textprop.res \
+	test_textprop2.res \
 	test_timers.res \
 	test_true_false.res \
 	test_trycatch.res \

--- a/src/testdir/test_textprop.vim
+++ b/src/testdir/test_textprop.vim
@@ -3979,11 +3979,11 @@ func Test_removed_prop_with_text_cleans_up_array()
   let id2 = prop_add(1, 10, #{type: 'some', text: "HERE"})
   call assert_equal(-2, id2)
 
-  " removing the props resets the index
+  " IDs are not recycled; new IDs keep decreasing.
   call prop_remove(#{id: id1})
   call prop_remove(#{id: id2})
   let id1 = prop_add(1, 5, #{type: 'some', text: "SOME"})
-  call assert_equal(-1, id1)
+  call assert_equal(-3, id1)
 
   call prop_type_delete('some')
   bwipe!
@@ -4905,6 +4905,71 @@ func Test_textprop_materialize_list()
 	call assert_equal([], prop_list(1, #{ids: ids}))
 
 	call assert_equal([], prop_list(1, #{ids: 3->range()}))
+endfunc
+
+func Test_textprop_virtual_text_id_and_undo()
+  new
+  call setline(1, ['one', 'two', 'three'])
+
+  call prop_type_add('comment', {'highlight': 'Directory'})
+
+  " IDs are unique and monotonically decreasing.
+  let id_a = prop_add(1, 0, {'type': 'comment', 'text': '<text-a>'})
+  let id_b = prop_add(2, 0, {'type': 'comment', 'text': '<text-b>'})
+  call assert_equal(-1, id_a)
+  call assert_equal(-2, id_b)
+
+  " After remove + re-add, a new ID is assigned (no recycling).
+  call prop_remove({'type': 'comment'}, 1)
+  let id_a2 = prop_add(1, 0, {'type': 'comment', 'text': '<text-a2>'})
+  call assert_equal(-3, id_a2)
+
+  " Make three text edits with different virtual text at each stage.
+  " edit1: text="one!", vtext='<text-a2>'
+  set undolevels&
+  exe "normal! 1GA!\<Esc>"
+
+  " edit2: text="one!!", vtext='<EDIT2>'
+  set undolevels&
+  call prop_remove({'type': 'comment'}, 1)
+  call prop_add(1, 0, {'type': 'comment', 'text': '<EDIT2>'})
+  exe "normal! 1GA!\<Esc>"
+
+  " edit3: text="one!!?", vtext='<EDIT3>'
+  set undolevels&
+  call prop_remove({'type': 'comment'}, 1)
+  call prop_add(1, 0, {'type': 'comment', 'text': '<EDIT3>'})
+  exe "normal! 1GA?\<Esc>"
+
+  " undo x3, redo x2, undo x1
+  undo
+  call assert_equal('one!!', getline(1), 'undo1: text')
+  call assert_equal('<EDIT3>', prop_list(1)[0].text, 'undo1: vtext')
+
+  undo
+  call assert_equal('one!', getline(1), 'undo2: text')
+  call assert_equal('<EDIT2>', prop_list(1)[0].text, 'undo2: vtext')
+
+  undo
+  call assert_equal('one', getline(1), 'undo3: text')
+  call assert_equal('<text-a2>', prop_list(1)[0].text, 'undo3: vtext')
+
+  redo
+  call assert_equal('one!', getline(1), 'redo1: text')
+  call assert_equal('<EDIT2>', prop_list(1)[0].text, 'redo1: vtext')
+
+  redo
+  call assert_equal('one!!', getline(1), 'redo2: text')
+  call assert_equal('<EDIT3>', prop_list(1)[0].text, 'redo2: vtext')
+
+  undo
+  call assert_equal('one!', getline(1), 'undo4: text')
+  call assert_equal('<EDIT2>', prop_list(1)[0].text, 'undo4: vtext')
+
+  call prop_remove({'type': 'comment'}, 1)
+  call prop_remove({'type': 'comment'}, 2)
+  call prop_type_delete('comment')
+  bwipe!
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_textprop2.vim
+++ b/src/testdir/test_textprop2.vim
@@ -1,0 +1,421 @@
+" Additional tests for defining text property types and adding text properties
+" to the buffer.
+
+CheckFeature textprop
+
+source util/screendump.vim
+
+" Find a property of a given type on a given line.
+func s:PropForType(lnum, type_name)
+  for p in prop_list(a:lnum)
+    if p['type'] == a:type_name
+      return p
+    endif
+  endfor
+  return {}
+endfunc
+
+" Clean up property types and wipe buffer.
+func s:CleanupPropTypes(types)
+  for name in a:types
+    call prop_type_delete(name)
+  endfor
+  bwipe!
+endfunc
+
+" Set up buffer content and properties used by multiple tests.
+"
+" Properties:
+"   type '1': line 2 col 2 -> line 4 col 9  (multiline highlight)
+"   type '2': line 2 col 3 -> line 2 col 7  (single line highlight)
+"   type '2': line 3 col 3 -> line 3 col 8  (single line highlight)
+"   type '2': line 4 col 3 -> line 4 col 9  (single line highlight)
+"   type '3': line 2 col 5 -> line 4 col 9  (multiline highlight)
+func s:Setup_multiline_props_1()
+  new
+  call setline(1, ['Line1', 'Line.2', 'Line..3', 'Line...4'])
+  call prop_type_add('1', {'highlight': 'DiffAdd'})
+  call prop_type_add('2', {'highlight': 'DiffChange'})
+  call prop_type_add('3', {'highlight': 'DiffDelete'})
+  call prop_add(2, 2, {'type': '1', 'id': 42, 'end_lnum': 4, 'end_col': 9})
+  call prop_add(2, 3, {'type': '2', 'id': 42, 'end_lnum': 2, 'end_col': 7})
+  call prop_add(3, 3, {'type': '2', 'id': 42, 'end_lnum': 3, 'end_col': 8})
+  call prop_add(4, 3, {'type': '2', 'id': 42, 'end_lnum': 4, 'end_col': 9})
+  call prop_add(2, 5, {'type': '3', 'id': 42, 'end_lnum': 4, 'end_col': 9})
+
+  " Sanity check.
+  call assert_equal(4, line('$'))
+  call assert_equal(0, len(prop_list(1)))
+  call assert_equal(3, len(prop_list(2)))
+  call assert_equal(3, len(prop_list(3)))
+  call assert_equal(3, len(prop_list(4)))
+endfunc
+
+" Set up buffer with a multiline property spanning line 1 col 4 -> line 3 col 4.
+func s:Setup_start_end_prop()
+  new
+  call setline(1, ['Line.1', 'Line..2', 'Line...3', 'Line....4'])
+  call prop_type_add('1', {'highlight': 'DiffAdd'})
+  call prop_add(1, 4, {'type': '1', 'id': 42, 'end_lnum': 3, 'end_col': 4})
+endfunc
+
+" The substitute command should adjust marks when one or more whole lines are
+" deleted.
+" func Test_subst_adjusts_marks()
+"   " Buffer: 4 lines with a single multiline property spanning all lines.
+"   " type '1': line 1 col 1 -> line 4 col 10
+"   func DoEditAndCheck(edit, expected_marks, expected_nlines) closure
+"     new
+"     call setline(1, ['Line.1', 'Line..2', 'Line...3', 'Line....4'])
+"     call prop_type_add('1', {'highlight': 'DiffAdd'})
+"     call prop_add(1, 1, {'type': '1', 'id': 42, 'end_lnum': 4, 'end_col': 10})
+"     call setpos("'a", [0, 1, 1])
+"     call setpos("'b", [0, 2, 1])
+"     call setpos("'c", [0, 3, 1])
+"     call setpos("'d", [0, 4, 1])
+"     set undolevels&
+"     let msg = printf('Edit command = "%s"', a:edit)
+"
+"     execute a:edit
+"
+"     call assert_equal(a:expected_nlines, line('$'), msg)
+"     call assert_equal(a:expected_marks[0], getpos("'a"), msg .. ', mark a')
+"     call assert_equal(a:expected_marks[1], getpos("'b"), msg .. ', mark b')
+"     call assert_equal(a:expected_marks[2], getpos("'c"), msg .. ', mark c')
+"     call assert_equal(a:expected_marks[3], getpos("'d"), msg .. ', mark d')
+"
+"     " Undo and verify original state is restored.
+"     :undo
+"     call assert_equal(4, line('$'), msg .. ', post-undo')
+"     call assert_equal('Line.1', getline(1), msg .. ', post-undo line 1')
+"     call assert_equal([0, 1, 1, 0], getpos("'a"), msg .. ', post-undo mark a')
+"     call assert_equal([0, 2, 1, 0], getpos("'b"), msg .. ', post-undo mark b')
+"     call assert_equal([0, 3, 1, 0], getpos("'c"), msg .. ', post-undo mark c')
+"     call assert_equal([0, 4, 1, 0], getpos("'d"), msg .. ', post-undo mark d')
+"
+"     call prop_type_delete('1')
+"     bwipe!
+"   endfunc
+"
+"   " Delete line 1.
+"   let expected = [[0, 0, 0, 0], [0, 1, 1, 0], [0, 2, 1, 0], [0, 3, 1, 0]]
+"   for edit in [':1 substitute/Line.1\n//', ':1 delete', 'normal 1GVx']
+"     call DoEditAndCheck(edit, expected, 3)
+"   endfor
+"   return
+"
+"   " NOTE: The tests below are disabled in the original too (after 'return').
+"   " Delete line 2.
+"   let expected = [[0, 1, 1, 0], [0, 0, 0, 0], [0, 2, 1, 0], [0, 3, 1, 0]]
+"   for edit in [':2 substitute/Line..2\n//', ':1 substitute/\nLine..2//',
+"       \ '2: delete', 'normal 2GVx']
+"     call DoEditAndCheck(edit, expected, 3)
+"   endfor
+"
+"   " Delete line 4.
+"   let expected = [[0, 1, 1, 0], [0, 2, 1, 0], [0, 3, 1, 0], [0, 0, 0, 0]]
+"   for edit in [':3 substitute/\nLine....4//', '4: delete', 'normal 4GVx']
+"     call DoEditAndCheck(edit, expected, 3)
+"   endfor
+"
+"   " Delete lines 2-3.
+"   let expected = [[0, 1, 1, 0], [0, 0, 0, 0], [0, 0, 0, 0], [0, 2, 1, 0]]
+"   for edit in [':2,3 substitute/Line.*[23]\n//',
+"       \ ':2,3 substitute/\%(Line[.]*[23]\n\)*',
+"       \ '2,3: delete', 'normal 2GVjx']
+"     call DoEditAndCheck(edit, expected, 2)
+"   endfor
+"
+"   " Delete lines 1-3.
+"   let expected = [[0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0], [0, 1, 1, 0]]
+"   for edit in [':1,$ substitute/Line.*[123]\n//',
+"       \ ':1,$ substitute/\%(Line[.]*[123]\n\)*',
+"       \ '1,3: delete', 'normal 1GVjjx']
+"     call DoEditAndCheck(edit, expected, 1)
+"   endfor
+"
+"   " Delete all lines.
+"   let expected = [[0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]]
+"   for edit in [':1,$ substitute/Line.*[1234]\n//',
+"       \ ':1,$ substitute/\%(Line[.]*[1234]\n\)*//',
+"       \ '1,4: delete', 'normal 1GVjjjx']
+"     call DoEditAndCheck(edit, expected, 1)
+"   endfor
+"
+"   " Delete lines 3-4.
+"   let expected = [[0, 1, 1, 0], [0, 2, 1, 0], [0, 0, 0, 0], [0, 0, 0, 0]]
+"   for edit in [':2,$ substitute/\n\%(Line.*[34]\n\?\)*//',
+"       \ '3,4: delete', 'normal 3GVjx']
+"     call DoEditAndCheck(edit, expected, 2)
+"   endfor
+"
+"   " Delete lines 2-4.
+"   let expected = [[0, 1, 1, 0], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]]
+"   for edit in [':1,$ substitute/\n\%(Line.*[234]\n\?\)*//',
+"       \ '2,4: delete', 'normal 2GVjjx']
+"     call DoEditAndCheck(edit, expected, 1)
+"   endfor
+" endfunc
+
+" The substitute command should correctly drop floating, virtual
+" properties when lines are deleted.
+" func Test_multiline_substitute_del_lines_drops_virt_text_props()
+"   " Helper to set up the buffer with virtual text properties.
+"   " When a:virt_k_col is 1, 'virt-k' is at line 1 col 1 (floating);
+"   " when 4, it is at line 1 col 4 (inline).
+"   func SetupVirtProps(virt_k_col)
+"     new
+"     call setline(1, ['Line.1', 'Line..2', 'Line...3', 'Line....4'])
+"     call prop_type_add('1', {'highlight': 'DiffAdd'})
+"     call prop_type_add('2', {'highlight': 'DiffChange', 'end_incl': 1})
+"     call prop_type_add('3', {'highlight': 'DiffDelete'})
+"     call prop_type_add('4', {'highlight': 'DiffText'})
+"     call prop_type_add('7', {'highlight': 'WarningMsg'})
+"     call prop_type_add('8', {'highlight': 'Directory'})
+"     " Floating virtual text.
+"     call prop_add(1, 0, {'type': '1', 'text': 'virt-a', 'text_align': 'right'})
+"     call prop_add(1, 0, {'type': '2', 'text': 'virt-b', 'text_align': 'right'})
+"     call prop_add(2, 0, {'type': '3', 'text': 'virt-c', 'text_align': 'right'})
+"     call prop_add(2, 0, {'type': '4', 'text': 'virt-d', 'text_align': 'right'})
+"     call prop_add(3, 0, {'type': '4', 'text': 'virt-e', 'text_align': 'right'})
+"     call prop_add(4, 0, {'type': '3', 'text': 'virt-g', 'text_align': 'right'})
+"     call prop_add(4, 0, {'type': '7', 'text': 'virt-h', 'text_align': 'right'})
+"     " Inline virtual text.
+"     call prop_add(1, a:virt_k_col, {'type': '8', 'text': 'virt-k'})
+"     " Highlight property spanning lines 1-4.
+"     call prop_add(1, 1, {'type': '2', 'id': 42, 'end_lnum': 4, 'end_col': 4})
+"     call prop_add(4, 4, {'type': '3', 'id': 42, 'end_lnum': 4, 'end_col': 7})
+"   endfunc
+"
+"   " Join lines 1-2.
+"   call SetupVirtProps(1)
+"   1,2 substitute /e.1\nL/e.1 L/
+"   call assert_equal(3, line('$'))
+"   call assert_equal('Line.1 Line..2', getline(1))
+"   call assert_equal(4, len(prop_list(1)))
+"   call s:CleanupPropTypes(['1', '2', '3', '4', '7', '8'])
+"
+"   " Join lines 1-3.
+"   call SetupVirtProps(1)
+"   1,3 substitute /e.1\nLine..2\nL/e.1 L/
+"   call assert_equal(2, line('$'))
+"   call assert_equal('Line.1 Line...3', getline(1))
+"   call assert_equal(3, len(prop_list(1)))
+"   call s:CleanupPropTypes(['1', '2', '3', '4', '7', '8'])
+"
+"   " Join lines 1-4.
+"   call SetupVirtProps(1)
+"   1,4 substitute /e.1\nLine..2\nLine...3\nL/e.1 L/
+"   call assert_equal(1, line('$'))
+"   call assert_equal('Line.1 Line....4', getline(1))
+"   call assert_equal(5, len(prop_list(1)))
+"   call s:CleanupPropTypes(['1', '2', '3', '4', '7', '8'])
+"
+"   " Second variant: inline virtual text at col 4.
+"   call SetupVirtProps(4)
+"   1,2 substitute /e.1\nL/e.1 L/
+"   call assert_equal(3, line('$'))
+"   call assert_equal(4, len(prop_list(1)))
+"   call s:CleanupPropTypes(['1', '2', '3', '4', '7', '8'])
+" endfunc
+
+" Deletion of text starting a multiline property should adjust next line.
+" func Test_text_deletion_of_start_to_eol_adjusts_multiline_property()
+"   " Partial delete: property is shortened but not removed.
+"   call s:Setup_start_end_prop()
+"   normal 1G03l2x
+"   call assert_equal('Lin1', getline(1))
+"   call assert_equal(1, len(prop_list(1)))
+"   call assert_equal(2, prop_list(1)[0]['length'])
+"   call prop_type_delete('1')
+"   bwipe!
+"
+"   " Full delete of start: property should be removed from line 1.
+"   for edit in ['normal 1G03ld$', 'normal 1G03l3x',
+"       \ 'normal 1G03lv  x', '1 substitute /e.1//']
+"     call s:Setup_start_end_prop()
+"     execute edit
+"     let msg = printf('op="%s"', edit)
+"     call assert_equal([], prop_list(1), msg)
+"     call prop_type_delete('1')
+"     bwipe!
+"   endfor
+" endfunc
+
+" Deletion of text ending a multiline property should adjust previous line.
+" func Test_text_deletion_of_end_to_sol_adjusts_multiline_property()
+"   " Partial delete: property end is adjusted but not removed.
+"   call s:Setup_start_end_prop()
+"   normal 3G02x
+"   call assert_equal('ne...3', getline(3))
+"   call assert_equal(1, len(prop_list(3)))
+"   call assert_equal(0, prop_list(3)[0]['start'])
+"   call prop_type_delete('1')
+"   bwipe!
+"
+"   " Full delete of ending portion: property should be removed from line 3.
+"   for edit in ['normal 3G03x', 'normal 3G0v  x', '3 substitute /Lin//']
+"     call s:Setup_start_end_prop()
+"     execute edit
+"     let msg = printf('op="%s"', edit)
+"     call assert_equal([], prop_list(3), msg)
+"     call prop_type_delete('1')
+"     bwipe!
+"   endfor
+" endfunc
+
+" Inline text properties should be removed when surrounding text is removed.
+" func Test_text_deletion_removes_inline_virtual_text()
+"   func SetupVirtText(start_incl, end_incl)
+"     new
+"     call setline(1, ['The line with properties....'])
+"     let opts = {'highlight': 'DiffChange'}
+"     if a:start_incl
+"       let opts['start_incl'] = 1
+"     endif
+"     if a:end_incl
+"       let opts['end_incl'] = 1
+"     endif
+"     call prop_type_add('2', opts)
+"     call prop_add(1, 7, {'type': '2', 'text': 'xxx'})
+"   endfunc
+"
+"   " Test all combinations of start_incl/end_incl.
+"   for [si, ei] in [[0, 0], [1, 0], [0, 1], [1, 1]]
+"     " Deletion of one char before virtual text: property stays.
+"     for edit in ['normal 1G05lx', '1 substitute /i//', 'normal 1G05lvx']
+"       call SetupVirtText(si, ei)
+"       execute edit
+"       let msg = printf('si=%d ei=%d op="%s"', si, ei, edit)
+"       call assert_equal(1, len(prop_list(1)), msg)
+"       call assert_equal(6, prop_list(1)[0]['col'], msg)
+"       call prop_type_delete('2')
+"       bwipe!
+"     endfor
+"
+"     " Deletion of one char after virtual text: property stays.
+"     for edit in ['normal 1G06lx', '1 substitute /n//', 'normal 1G06lvx']
+"       call SetupVirtText(si, ei)
+"       execute edit
+"       let msg = printf('si=%d ei=%d op="%s"', si, ei, edit)
+"       call assert_equal(1, len(prop_list(1)), msg)
+"       call assert_equal(7, prop_list(1)[0]['col'], msg)
+"       call prop_type_delete('2')
+"       bwipe!
+"     endfor
+"
+"     " Deletion of both chars around virtual text: property is removed.
+"     for edit in ['normal 1G05l2x', '1 substitute /in//', 'normal 1G05lv x']
+"       call SetupVirtText(si, ei)
+"       execute edit
+"       let msg = printf('si=%d ei=%d op="%s"', si, ei, edit)
+"       call assert_equal([], prop_list(1), msg)
+"       call prop_type_delete('2')
+"       bwipe!
+"     endfor
+"   endfor
+" endfunc
+
+" Removing a multiline property from the last line should fix the property
+" on the penultimate line.
+" func Test_multiline_prop_partial_remove_last_using_remove()
+"   call s:Setup_multiline_props_1()
+"
+"   call prop_remove({'type': '3'}, 4)
+"   call assert_equal(1, s:PropForType(3, '3')['end'])
+"
+"   call s:CleanupPropTypes(['1', '2', '3'])
+" endfunc
+
+" Removing a multiline property from the penultimate line should fix the
+" properties on the previous and last lines.
+" func Test_multiline_prop_partial_remove_penultimate_using_remove()
+"   call s:Setup_multiline_props_1()
+"
+"   call prop_remove({'type': '3'}, 3)
+"   call assert_equal(1, s:PropForType(2, '3')['end'])
+"   call assert_equal(1, s:PropForType(4, '3')['start'])
+"
+"   call s:CleanupPropTypes(['1', '2', '3'])
+" endfunc
+
+" Removing all properties from the first line should fix the properties
+" on the second line.
+" func Test_multiline_prop_partial_remove_first_using_clear()
+"   call s:Setup_multiline_props_1()
+"
+"   call prop_clear(2)
+"   call assert_equal(1, s:PropForType(3, '3')['start'])
+"   call assert_equal(1, s:PropForType(3, '1')['start'])
+"
+"   call s:CleanupPropTypes(['1', '2', '3'])
+" endfunc
+
+" Removing all multiline properties from the last line should fix the
+" properties on the penultimate line.
+" func Test_multiline_prop_partial_remove_last_using_clear()
+"   call s:Setup_multiline_props_1()
+"
+"   call prop_clear(4)
+"   call assert_equal(1, s:PropForType(3, '3')['end'])
+"   call assert_equal(1, s:PropForType(3, '1')['end'])
+"
+"   call s:CleanupPropTypes(['1', '2', '3'])
+" endfunc
+
+" Removing all multiline properties from the penultimate line should fix the
+" properties on the previous and last lines.
+" func Test_multiline_prop_partial_remove_penultimate_using_clear()
+"   call s:Setup_multiline_props_1()
+"
+"   call prop_clear(3)
+"   call assert_equal(1, s:PropForType(2, '3')['end'])
+"   call assert_equal(1, s:PropForType(4, '3')['start'])
+"   call assert_equal(1, s:PropForType(2, '1')['end'])
+"   call assert_equal(1, s:PropForType(4, '1')['start'])
+"
+"   call s:CleanupPropTypes(['1', '2', '3'])
+" endfunc
+
+" Deleting the first line with multiline properties should fix the properties
+" on the second line.
+func Test_multiline_prop_delete_first_line()
+  call s:Setup_multiline_props_1()
+
+  :2 delete
+  call assert_equal(3, line('$'))
+  call assert_equal(1, s:PropForType(2, '1')['start'])
+  call assert_equal(1, s:PropForType(2, '3')['start'])
+
+  call s:CleanupPropTypes(['1', '2', '3'])
+endfunc
+
+" Deleting the last line with multiline properties should fix the properties
+" on the penultimate line.
+func Test_multiline_prop_delete_last_line()
+  call s:Setup_multiline_props_1()
+
+  :4 delete
+  call assert_equal(3, line('$'))
+  call assert_equal(1, s:PropForType(3, '1')['end'])
+  call assert_equal(1, s:PropForType(3, '3')['end'])
+
+  call s:CleanupPropTypes(['1', '2', '3'])
+endfunc
+
+" Deleting the penultimate line with multiline properties should keep
+" the properties spanning lines.
+func Test_multiline_prop_delete_penultimate_line()
+  call s:Setup_multiline_props_1()
+
+  :3 delete
+  call assert_equal(3, line('$'))
+  call assert_equal(0, s:PropForType(2, '1')['end'])
+  call assert_equal(0, s:PropForType(2, '3')['end'])
+  call assert_equal(0, s:PropForType(3, '1')['start'])
+  call assert_equal(0, s:PropForType(3, '3')['start'])
+
+  call s:CleanupPropTypes(['1', '2', '3'])
+endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/src/textprop.c
+++ b/src/textprop.c
@@ -1114,7 +1114,24 @@ f_prop_clear(typval_T *argvars, typval_T *rettv UNUSED)
 	len = ml_get_buf_len(buf, lnum) + 1;
 	if ((size_t)buf->b_ml.ml_line_len > len)
 	{
+	    char_u  *props;
+	    int	    propcount;
+	    int	    i;
+
+	    // Unref virtual text before clearing properties.
+	    propcount = get_text_props(buf, lnum, &props, FALSE);
+	    for (i = 0; i < propcount; ++i)
+	    {
+		textprop_T  prop;
+
+		mch_memmove(&prop, props + i * sizeof(textprop_T),
+						       sizeof(textprop_T));
+		if (prop.tp_vtext != NULL)
+		    vtext_unref(prop.tp_vtext);
+	    }
+
 	    did_clear = TRUE;
+	    text = ml_get_buf(buf, lnum, FALSE);
 	    if (!(buf->b_ml.ml_flags & ML_LINE_DIRTY))
 	    {
 		char_u *newtext = vim_strsave(text);
@@ -2282,7 +2299,11 @@ adjust_prop_columns(
 		proplen = get_text_props(curbuf, lnum, &props, TRUE);
 	}
 	if (res.can_drop)
+	{
+	    if (prop.tp_vtext != NULL)
+		vtext_unref(prop.tp_vtext);
 	    continue; // Drop this text property
+	}
 	mch_memmove(props + wi * sizeof(textprop_T), &prop, sizeof(textprop_T));
 	++wi;
     }

--- a/src/textprop.c
+++ b/src/textprop.c
@@ -16,6 +16,45 @@
 #if defined(FEAT_PROP_POPUP)
 
 /*
+ * Allocate a reference-counted virtual text string.
+ * The returned vtext_T has refcount 1.
+ */
+    vtext_T *
+vtext_alloc(char_u *text)
+{
+    size_t  len = STRLEN(text) + 1;
+    vtext_T *vt = alloc(offsetof(vtext_T, vt_text) + len);
+
+    if (vt != NULL)
+    {
+	vt->vt_refcount = 1;
+	mch_memmove(vt->vt_text, text, len);
+    }
+    return vt;
+}
+
+/*
+ * Increment the reference count of a vtext_T.
+ */
+    void
+vtext_ref(vtext_T *vt)
+{
+    if (vt != NULL)
+	++vt->vt_refcount;
+}
+
+/*
+ * Decrement the reference count of a vtext_T.
+ * Free it when the count reaches zero.
+ */
+    void
+vtext_unref(vtext_T *vt)
+{
+    if (vt != NULL && --vt->vt_refcount <= 0)
+	vim_free(vt);
+}
+
+/*
  * In a hashtable item "hi_key" points to "pt_name" in a proptype_T.
  * This avoids adding a pointer to the hashtable item.
  * PT2HIKEY() converts a proptype pointer to a hashitem key pointer.
@@ -210,24 +249,13 @@ prop_add_one(
 
     if (text != NULL)
     {
-	garray_T    *gap = &buf->b_textprop_text;
 	char_u	    *p;
-
-	// double check we got the right ID
-	if (-id - 1 != gap->ga_len)
-	    iemsg("text prop ID mismatch");
-	if (gap->ga_growsize == 0)
-	    ga_init2(gap, sizeof(char *), 50);
-	if (ga_grow(gap, 1) == FAIL)
-	    goto theend;
-	((char_u **)gap->ga_data)[gap->ga_len++] = text;
 
 	// change any control character (Tab, Newline, etc.) to a Space to make
 	// it simpler to compute the size
 	for (p = text; *p != NUL; MB_PTR_ADV(p))
 	    if (*p < ' ')
 		*p = ' ';
-	text = NULL;
     }
 
     for (lnum = start_lnum; lnum <= end_lnum; ++lnum)
@@ -309,6 +337,7 @@ prop_add_one(
 			    | ((type->pt_flags & PT_FLAG_INS_START_INCL)
 						     ? TP_FLAG_START_INCL : 0);
 	tmp_prop.tp_padleft = text_padding_left;
+	tmp_prop.tp_vtext = (text_arg != NULL) ? vtext_alloc(text_arg) : NULL;
 	mch_memmove(newprops + i * sizeof(textprop_T), &tmp_prop,
 							   sizeof(textprop_T));
 
@@ -430,8 +459,7 @@ f_prop_add_list(typval_T *argvars, typval_T *rettv UNUSED)
     static int
 get_textprop_id(buf_T *buf)
 {
-    // TODO: recycle deleted entries
-    return -(buf->b_textprop_text.ga_len + 1);
+    return --buf->b_textprop_next_vt_id;
 }
 
 /*
@@ -966,11 +994,7 @@ prop_fill_dict(dict_T *dict, textprop_T *prop, buf_T *buf)
 {
     proptype_T *pt;
     int buflocal = TRUE;
-    // A negative tp_id normally means a virtual text property, but a user
-    // may set a negative id for a regular property when no virtual text
-    // properties exist.  Guard against that by checking the index is valid.
-    int virtualtext_prop = prop->tp_id < 0
-			   && -prop->tp_id - 1 < buf->b_textprop_text.ga_len;
+    int virtualtext_prop = prop->tp_id < 0 && prop->tp_vtext != NULL;
 
     dict_add_number(dict, "col", (prop->tp_col == MAXCOL) ? 0 : prop->tp_col);
     if (!virtualtext_prop)
@@ -998,12 +1022,7 @@ prop_fill_dict(dict_T *dict, textprop_T *prop, buf_T *buf)
     if (virtualtext_prop)
     {
 	// virtual text property
-	garray_T    *gap = &buf->b_textprop_text;
-	char_u	    *text;
-
-	// negate the property id to get the string index
-	text = ((char_u **)gap->ga_data)[-prop->tp_id - 1];
-	dict_add_string(dict, "text", text);
+	dict_add_string(dict, "text", prop->tp_vtext->vt_text);
 
 	// text_align
 	char_u	    *text_align = NULL;
@@ -1739,19 +1758,8 @@ f_prop_remove(typval_T *argvars, typval_T *rettv)
 		    buf->b_ml.ml_line_len -= sizeof(textprop_T);
 		    --idx;
 
-		    if (textprop.tp_id < 0)
-		    {
-			garray_T    *gap = &buf->b_textprop_text;
-			int	    ii = -textprop.tp_id - 1;
-
-			// negative ID: property with text - free the text
-			if (ii < gap->ga_len)
-			{
-			    char_u **p = ((char_u **)gap->ga_data) + ii;
-			    VIM_CLEAR(*p);
-			    did_remove_text = TRUE;
-			}
-		    }
+		    if (textprop.tp_vtext != NULL)
+			vtext_unref(textprop.tp_vtext);
 
 		    if (first_changed == 0)
 			first_changed = lnum;
@@ -1769,16 +1777,6 @@ f_prop_remove(typval_T *argvars, typval_T *rettv)
 	changed_line_display_buf(buf);
 	changed_lines_buf(buf, first_changed, last_changed + 1, 0);
 	redraw_buf_later(buf, UPD_VALID);
-    }
-
-    if (did_remove_text)
-    {
-	garray_T    *gap = &buf->b_textprop_text;
-
-	// Reduce the growarray size for NULL pointers at the end.
-	while (gap->ga_len > 0
-			 && ((char_u **)gap->ga_data)[gap->ga_len - 1] == NULL)
-	    --gap->ga_len;
     }
 
 cleanup_prop_remove:

--- a/src/textprop.c
+++ b/src/textprop.c
@@ -1598,7 +1598,6 @@ f_prop_remove(typval_T *argvars, typval_T *rettv)
     int		*type_ids = NULL;   // array, for a list of "types", allocated
     int		num_type_ids = 0;   // number of elements in "type_ids"
     int		both;
-    int		did_remove_text = FALSE;
 
     rettv->vval.v_number = 0;
 

--- a/src/undo.c
+++ b/src/undo.c
@@ -454,7 +454,14 @@ u_unref_vtext(undoline_T *ul)
 	mch_memmove(&prop, text_start + i * sizeof(textprop_T),
 						      sizeof(textprop_T));
 	if (prop.tp_id < 0 && prop.tp_vtext != NULL)
+	{
 	    vtext_unref(prop.tp_vtext);
+	    // Clear the pointer so that if another undo entry has a
+	    // byte-copy of the same textprop, it won't double-free.
+	    prop.tp_vtext = NULL;
+	    mch_memmove(text_start + i * sizeof(textprop_T),
+					    &prop, sizeof(textprop_T));
+	}
     }
 }
 #endif

--- a/src/undo.c
+++ b/src/undo.c
@@ -454,14 +454,7 @@ u_unref_vtext(undoline_T *ul)
 	mch_memmove(&prop, text_start + i * sizeof(textprop_T),
 						      sizeof(textprop_T));
 	if (prop.tp_id < 0 && prop.tp_vtext != NULL)
-	{
 	    vtext_unref(prop.tp_vtext);
-	    // Clear the pointer so that if another undo entry has a
-	    // byte-copy of the same textprop, it won't double-free.
-	    prop.tp_vtext = NULL;
-	    mch_memmove(text_start + i * sizeof(textprop_T),
-					    &prop, sizeof(textprop_T));
-	}
     }
 }
 #endif

--- a/src/undo.c
+++ b/src/undo.c
@@ -110,6 +110,10 @@ static void u_freeheader(buf_T *buf, u_header_T *uhp, u_header_T **uhpp);
 static void u_freebranch(buf_T *buf, u_header_T *uhp, u_header_T **uhpp);
 static void u_freeentries(buf_T *buf, u_header_T *uhp, u_header_T **uhpp);
 static void u_freeentry(u_entry_T *, long);
+#ifdef FEAT_PROP_POPUP
+static void u_ref_vtext(undoline_T *ul);
+static void u_unref_vtext(undoline_T *ul);
+#endif
 #ifdef FEAT_PERSISTENT_UNDO
 # ifdef FEAT_CRYPT
 static int undo_flush(bufinfo_T *bi);
@@ -374,7 +378,12 @@ u_save_line(undoline_T *ul, linenr_T lnum)
 	ul->ul_len = curbuf->b_ml.ml_line_len;
 	ul->ul_line = vim_memsave(line, ul->ul_len);
     }
-    return ul->ul_line == NULL ? FAIL : OK;
+    if (ul->ul_line == NULL)
+	return FAIL;
+#ifdef FEAT_PROP_POPUP
+    u_ref_vtext(ul);
+#endif
+    return OK;
 }
 
 #ifdef FEAT_PROP_POPUP
@@ -397,6 +406,56 @@ has_prop_w_flags(linenr_T lnum, int flags)
 	    return TRUE;
     }
     return FALSE;
+}
+
+/*
+ * Increment refcount for all virtual text properties in undoline "ul".
+ */
+    static void
+u_ref_vtext(undoline_T *ul)
+{
+    char_u	*text_start;
+    int		proplen;
+    int		i;
+
+    if (ul->ul_line == NULL || ul->ul_len <= ul->ul_textlen + 1)
+	return;
+    text_start = ul->ul_line + ul->ul_textlen + 1;
+    proplen = (int)((ul->ul_len - ul->ul_textlen - 1) / sizeof(textprop_T));
+    for (i = 0; i < proplen; ++i)
+    {
+	textprop_T prop;
+
+	mch_memmove(&prop, text_start + i * sizeof(textprop_T),
+						      sizeof(textprop_T));
+	if (prop.tp_id < 0 && prop.tp_vtext != NULL)
+	    vtext_ref(prop.tp_vtext);
+    }
+}
+
+/*
+ * Decrement refcount for all virtual text properties in undoline "ul".
+ */
+    static void
+u_unref_vtext(undoline_T *ul)
+{
+    char_u	*text_start;
+    int		proplen;
+    int		i;
+
+    if (ul->ul_line == NULL || ul->ul_len <= ul->ul_textlen + 1)
+	return;
+    text_start = ul->ul_line + ul->ul_textlen + 1;
+    proplen = (int)((ul->ul_len - ul->ul_textlen - 1) / sizeof(textprop_T));
+    for (i = 0; i < proplen; ++i)
+    {
+	textprop_T prop;
+
+	mch_memmove(&prop, text_start + i * sizeof(textprop_T),
+						      sizeof(textprop_T));
+	if (prop.tp_id < 0 && prop.tp_vtext != NULL)
+	    vtext_unref(prop.tp_vtext);
+    }
 }
 #endif
 
@@ -2816,6 +2875,8 @@ u_undoredo(int undo)
 		else
 		    ml_append_flags(lnum, uep->ue_array[i].ul_line,
 			     (colnr_T)uep->ue_array[i].ul_len, ML_APPEND_UNDO);
+		// Don't unref vtexts here: ownership of the tp_vtext
+		// pointers transfers from the undo entry to the memline.
 		vim_free(uep->ue_array[i].ul_line);
 	    }
 	    vim_free((char_u *)uep->ue_array);
@@ -3461,7 +3522,13 @@ u_freeentries(
 u_freeentry(u_entry_T *uep, long n)
 {
     while (n > 0)
-	vim_free(uep->ue_array[--n].ul_line);
+    {
+	--n;
+#ifdef FEAT_PROP_POPUP
+	u_unref_vtext(&uep->ue_array[n]);
+#endif
+	vim_free(uep->ue_array[n].ul_line);
+    }
     vim_free((char_u *)uep->ue_array);
 #ifdef U_DEBUG
     uep->ue_magic = 0;
@@ -3492,6 +3559,9 @@ u_blockfree(buf_T *buf)
 {
     while (buf->b_u_oldhead != NULL)
 	u_freeheader(buf, buf->b_u_oldhead, NULL);
+#ifdef FEAT_PROP_POPUP
+    u_unref_vtext(&buf->b_u_line_ptr);
+#endif
     vim_free(buf->b_u_line_ptr.ul_line);
 }
 
@@ -3537,7 +3607,9 @@ u_clearline(void)
 {
     if (curbuf->b_u_line_ptr.ul_line == NULL)
 	return;
-
+#ifdef FEAT_PROP_POPUP
+    u_unref_vtext(&curbuf->b_u_line_ptr);
+#endif
     VIM_CLEAR(curbuf->b_u_line_ptr.ul_line);
     curbuf->b_u_line_ptr.ul_len = 0;
     curbuf->b_u_line_ptr.ul_textlen = 0;


### PR DESCRIPTION
Problem:  Virtual text stored in b_textprop_text is not part of the
          undo/redo mechanism, causing text mismatch after undo when
          IDs are recycled.  The b_textprop_text growarray also grows
          indefinitely with repeated add/remove.

Solution: Add vtext_T with reference counting and store the pointer
          directly in textprop_T.tp_vtext.  Remove b_textprop_text.
          Increment refcount when saving lines for undo, decrement
          when undo entries are freed.  Virtual text memory is now
          managed per-property and freed when refcount reaches zero.

Fixes: #19680
Fixes: #19681

Related: #19685 (Since the original PR is no longer being updated due to various reasons, I am taking over the work in this PR.)
Note:
- The original PR also embedded the virtual text into the memline, but because the changes were extensive and had a wide-ranging impact, this PR uses the allocation + refcount method.
- The original PR is enormous, so we're splitting it into three parts. This is the first of them.