### PR TITLE
Cannot disable kitty keyboard protocol in vim :terminal

### DIFF
--- a/src/libvterm/src/state.c
+++ b/src/libvterm/src/state.c
@@ -983,6 +983,7 @@ static int on_csi(const char *leader, const long args[], int argcount, const cha
     switch(leader[0]) {
     case '?':
     case '>':
+    case '<':
       leader_byte = leader[0];
       break;
     default:

--- a/src/testdir/test_terminal.vim
+++ b/src/testdir/test_terminal.vim
@@ -2441,4 +2441,14 @@ func Test_term_TextChangedT_close()
   augroup END
 endfunc
 
+func Test_terminal_disable_kitty_keyboard()
+  CheckRunVimInTerminal
+  let cmd = ['sh', '-c', 'printf ''\033[>1u\033[?u\033[<u\033[?u''; sleep 1']
+  let buf = term_start(cmd)
+  let job = term_getjob(buf)
+  call WaitForAssert({-> assert_equal('dead', job_status(job))})
+  call WaitForAssert({-> assert_equal('^[[?1u^[[?0u', term_getline(buf, 1))})
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
In patch v9.0.0930 the kitty keyboard protocol was added to libvterm. But the
CSI sequence that disables this protocol is not handled correctly, and this
leaves the terminal window in a broken state. Here are the steps to reproduce:

1. `vim --clean`
2. `:terminal<CR>`
3. In the terminal window shell, enable and then disable kitty keyboard protocol:
 `$ printf '\x1b[>1u\x1b[<u'`
4. Try to use some shell key combination like `<C-r>`, `<C-d>` or `<C-e>` etc. They won't work because kitty keyboard is not disabled.
