### PR TITLE
Change some tests to avoid trailing whitespace.

### DIFF
--- a/src/testdir/test_conceal.vim
+++ b/src/testdir/test_conceal.vim
@@ -148,7 +148,7 @@ func Test_conceal_with_cursorcolumn()
           \ "three |hidden| three three three three three three three three"]
     call setline(1, lines)
     set wrap linebreak
-    set showbreak=\ >>>\ 
+    let &showbreak = ' >>> '
     syntax match test /|hidden|/ conceal
     set conceallevel=2
     set concealcursor=

--- a/src/testdir/test_display.vim
+++ b/src/testdir/test_display.vim
@@ -342,7 +342,7 @@ func Test_eob_fillchars()
   set fillchars=eob:+
   redraw
   call assert_equal('+', Screenline(2))
-  set fillchars=eob:\ 
+  let &fillchars = 'eob: '
   redraw
   call assert_equal(' ', nr2char(screenchar(2, 1)))
   set fillchars&
@@ -413,7 +413,7 @@ func Test_fold_fillchars()
   call assert_equal(expected, lines)
 
   " check setting foldinner
-  set fillchars+=foldinner:\ 
+  let &fillchars = &fillchars .. ',foldinner: '
   let lines = ScreenLines([1, 6], 22)
   let expected = [
         \ ' one                  ',

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -3311,7 +3311,9 @@ endfunc
 func Test_ins_complete_end_of_line()
   " this was reading past the end of the line
   new
-  norm 8oý 
+  " Note that the 'space' at the end of the expression below is a non-breaking
+  " space, U+00a0.
+  execute "norm 8oý "
   sil! norm o
 
   bwipe!

--- a/src/testdir/test_listchars.vim
+++ b/src/testdir/test_listchars.vim
@@ -411,7 +411,7 @@ func Test_listchars()
 
   " Test leadtab with pipe character
   normal ggdG
-  set listchars=tab:>-,leadtab:\|\ 
+  let &listchars = 'tab:>-,leadtab:| '
   call append(0, ["\ttext"])
   let expected = ['|       text']
   call Check_listchars(expected, 1, 12)
@@ -419,7 +419,7 @@ func Test_listchars()
 
   " Test leadtab with unicode bar
   normal ggdG
-  set listchars=tab:>-,leadtab:│\ 
+  let &listchars = 'tab:>-,leadtab:│ '
   call append(0, ["\ttext"])
   let expected = ['│       text']
   call Check_listchars(expected, 1, 12)

--- a/src/testdir/test_normal.vim
+++ b/src/testdir/test_normal.vim
@@ -4420,6 +4420,7 @@ endfunc
 "
 " The problem occurred because WM_SETFOCUS was processed slowly, and typebuf
 " was not empty when it should have been.
+" TODO: Is this test flaky?
 func Test_win32_gui_setfocus_prevent_showcmd()
   if !has('win32') || !has('gui_running')
     throw 'Skipped: Windows GUI regression test'

--- a/src/testdir/test_popupwin.vim
+++ b/src/testdir/test_popupwin.vim
@@ -1165,7 +1165,7 @@ func Test_popup_with_showbreak()
   CheckScreendump
 
   let lines =<< trim END
-	 set showbreak=>>\ 
+	 let &showbreak ='>> '
 	 call setline(1, range(1, 20))
 	 let winid = popup_dialog(
 	   \ 'a long line here that wraps',

--- a/src/testdir/test_scroll_opt.vim
+++ b/src/testdir/test_scroll_opt.vim
@@ -517,7 +517,8 @@ func Test_smoothscroll_long_line_showbreak()
       vim9script
       # a line that spans four screen lines
       setline(1, 'with lots of text in one line '->repeat(6))
-      set smoothscroll scrolloff=0 showbreak=+++\ 
+      set smoothscroll scrolloff=0
+      &showbreak = '+++ '
   END
   call writefile(lines, 'XSmoothLongShowbreak', 'D')
   let buf = RunVimInTerminal('-S XSmoothLongShowbreak', #{rows: 6, cols: 40})

--- a/src/testdir/test_signs.vim
+++ b/src/testdir/test_signs.vim
@@ -165,7 +165,9 @@ func Test_sign()
 
   sign define Sign5 text=X\  linehl=Comment
   sign undefine Sign5
-  sign define Sign5 linehl=Comment text=X\ 
+  " The use of execute in the next line is just to ensure the space for
+  " the text value is obvious and does not get accidently deleted.
+  execute "sign define Sign5 linehl=Comment text=X\ "
   sign undefine Sign5
 
   " define sign with backslash

--- a/src/testdir/test_textprop.vim
+++ b/src/testdir/test_textprop.vim
@@ -3606,7 +3606,7 @@ func Test_props_with_text_below_nowrap()
       vim9script
       edit foobar
       set nowrap
-      set showbreak=+++\ 
+      set showbreak=+++
       setline(1, ['onasdf asdf asdf sdf df asdf asdf e asdf asdf asdf asdf asd fas df', 'two'])
       prop_type_add('test', {highlight: 'Special'})
       prop_add(1, 0, {
@@ -4273,7 +4273,7 @@ func Test_text_after_wrap_showbreak()
     set shiftwidth=4
 
     set breakindent
-    set showbreak=>\ 
+    let &showbreak = '> '
     set breakindentopt=shift:2,min:64
 
     call setline(1, ['        " 1234567890', 'foo', 'bar'])


### PR DESCRIPTION
Some tests currently rely on trailing whitespace at the end of lines, escaped with '\'. I have demonstrated in another PR, such spaces can be inadvertently removed and this is difficult to spot.