### PR TITLE
fix hlset() failure with attribute values containing spaces

### DIFF
--- a/src/highlight.c
+++ b/src/highlight.c
@@ -5309,7 +5309,23 @@ add_attr_and_value(char_u *dptr, char_u *attr, int attrlen, char_u *value)
 	return dptr;
 
     vallen = STRLEN(value);
-    if (dptr + attrlen + vallen + 1 < hlsetBuf + HLSETBUFSZ)
+    // When the value contains a space and the attribute has an "=" (i.e. it
+    // is a key=value pair), surround the value with single quotes so that
+    // do_highlight() can parse it correctly.
+    if (vim_strchr(value, ' ') != NULL && vim_strchr(attr, '=') != NULL)
+    {
+	if (dptr + attrlen + vallen + 3 < hlsetBuf + HLSETBUFSZ)
+	{
+	    STRCPY(dptr, attr);
+	    dptr += attrlen;
+	    *dptr++ = '\'';
+	    STRCPY(dptr, value);
+	    dptr += vallen;
+	    *dptr++ = '\'';
+	    *dptr = NUL;
+	}
+    }
+    else if (dptr + attrlen + vallen + 1 < hlsetBuf + HLSETBUFSZ)
     {
 	STRCPY(dptr, attr);
 	dptr += attrlen;

--- a/src/testdir/test_highlight.vim
+++ b/src/testdir/test_highlight.vim
@@ -1142,17 +1142,9 @@ endfunc
 
 " Test for the hlset() function
 func Test_hlset()
-  " FIXME: With GVim, _current_ test cases that are run before this one may
-  "	influence the result of calling "hlset(hlget())", depending on what
-  "	"&guifont" is set to.  For example, introduce SetUp() as follows:
-  "
-  " if CanRunVimInTerminal() && has('gui_running') && has('gui_gtk')
-  "   def SetUp()
-  "     set guifont=Monospace\ 10
-  "   enddef
-  " endif
-  "
-  "	and see "E416: Missing equal sign: ... line 4" for this test case.
+  " Note: hlset() now correctly handles attribute values containing spaces
+  " by quoting them, so hlset(hlget()) works even with font names like
+  " "Monospace 10".
   let lines =<< trim END
     call assert_equal(0, hlset(test_null_list()))
     call assert_equal(0, hlset([]))
@@ -1353,6 +1345,15 @@ func Test_hlset()
   call hlset([{'name': 'hlg11', 'stop': ''}])
   call hlset([{'name': 'hlg11', 'term': {}}])
   call assert_true(hlget('hlg11')[0].cleared)
+
+  " Test that hlset() handles attribute values containing spaces
+  call hlset([{'name': 'hlg12', 'guifg': 'light blue'}])
+  call assert_equal('light blue', hlget('hlg12')[0].guifg)
+  call hlset([{'name': 'hlg12', 'guibg': 'dark red'}])
+  call assert_equal('dark red', hlget('hlg12')[0].guibg)
+  call hlset([{'name': 'hlg12', 'guisp': 'sea green'}])
+  call assert_equal('sea green', hlget('hlg12')[0].guisp)
+  highlight clear hlg12
 endfunc
 
 " Test for the 'winhighlight' option


### PR DESCRIPTION
hlset(hlget('Normal')) fails with E416 when a highlight attribute value contains spaces (e.g. font name "Monospace 10"). hlg_add_or_update() builds a string like "font=Monospace 10" and passes it to do_highlight(), whose parser splits on whitespace and treats "10" as a separate key without "=".

Fix by quoting values with single quotes (e.g. font='Monospace 10') when the value contains spaces and the attribute is a key=value pair. do_highlight() already supports single-quoted values.