### PR TITLE
Fix changed_lines arguments in blockwise paste

### DIFF
--- a/src/register.c
+++ b/src/register.c
@@ -2021,7 +2021,7 @@ do_put(
 		curwin->w_cursor.col += bd.startspaces;
 	}
 
-	changed_lines(lnum, 0, curwin->w_cursor.lnum, nr_lines);
+	changed_lines(lnum, 0, curwin->w_cursor.lnum - nr_lines, nr_lines);
 
 	// Set '[ mark.
 	curbuf->b_op_start = curwin->w_cursor;

--- a/src/testdir/test_listener.vim
+++ b/src/testdir/test_listener.vim
@@ -782,4 +782,23 @@ func Test_redraw_listener_partial()
   call redraw_listener_add(#{on_start: function("s:OnRedraw", [1])})
 endfunc
 
+func Test_listener_blockwise_paste()
+  new
+  call setline(1, ['1', '2', '3'])
+  let s:list = []
+  let id = listener_add('s:StoreListArgs')
+
+  " yank a blockwise selection and paste at the end of the buffer, which
+  " appends new lines
+  call feedkeys("1G0\<C-v>2jyGp", 'xt')
+  call listener_flush()
+  " the listener should report correct lnume (before the change) and added
+  call assert_equal(3, s:start)
+  call assert_equal(4, s:end)
+  call assert_equal(2, s:added)
+
+  call listener_remove(id)
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
## Summary

When doing a blockwise paste beyond the end of the buffer, `changed_lines()` is called with an incorrect `lnume` argument. The third argument `curwin->w_cursor.lnum` includes the newly appended lines, but `lnume` should be "the first line below the changed lines BEFORE the change."

This fix subtracts `nr_lines` (the number of appended lines) from `curwin->w_cursor.lnum`, as suggested by @brammool in #6660.

Port of neovim/neovim#12733. Fixes #6660.

## Changes

- `src/register.c`: Fix the third argument to `changed_lines()` in blockwise paste from `curwin->w_cursor.lnum` to `curwin->w_cursor.lnum - nr_lines`
- `src/testdir/test_listener.vim`: Add `Test_listener_blockwise_paste()` to verify the listener receives correct `start`, `end`, and `added` values when doing a blockwise paste that appends lines beyond the buffer end