### PR TITLE
fix(terminal): avoid redundant gui_mch_flush() in conpty terminal

### DIFF
--- a/src/terminal.c
+++ b/src/terminal.c
@@ -3326,7 +3326,9 @@ handle_movecursor(
 	    position_cursor(wp, &pos);
     }
     if (term->tl_buffer == curbuf && !term->tl_normal_mode)
-	update_cursor(term, term->tl_cursor_visible);
+	// Don't redraw here, it will be done after
+	// vterm_input_write() is finished.
+	update_cursor(term, FALSE);
 
     return 1;
 }
@@ -4956,6 +4958,7 @@ create_vterm(term_T *term, int rows, int cols)
     }
 
     vterm_screen_set_callbacks(screen, &screen_callbacks, term);
+    vterm_screen_set_damage_merge(screen, VTERM_DAMAGE_SCROLL);
     // TODO: depends on 'encoding'.
     vterm_set_utf8(vterm, 1);
 


### PR DESCRIPTION
handle_movecursor callback was calling update_cursor() with redraw=TRUE on every cursor move inside vterm_input_write(). This triggered gui_mch_flush() (GdiFlush + DWriteContext_Flush) and TextChangedT autocmd for each cursor move. ConPTY output contains ~17 cursor positioning sequences per 4KB chunk, each flush taking ~5ms, resulting in 80-110ms per chunk.

Fix by passing FALSE to update_cursor() in handle_movecursor since write_to_term() already calls update_cursor() with proper redraw after vterm_input_write() finishes.

Also set vterm_screen_set_damage_merge() to VTERM_DAMAGE_SCROLL so that damage callbacks are buffered until vterm_screen_flush_damage() instead of being emitted per cell.

vterm_input_write profiling (per 4KB chunk):

| | Before | After | Improvement |
|---|---|---|---|
| vterm_input_write | 80-110ms | 0.7-1.1ms | ~100x |

Benchmark: 24-line :terminal running `dir /s C:\Windows\System32`:

| | Before | After | Improvement |
|---|---|---|---|
| vim.exe (TUI) | 18.73s | 18.55s | (noise) |
| gvim.exe (GUI) | 68.77s | 9.24s | -87% |

Closes #19845