### PR TITLE
fix(win32): prevent typeahead buffer overflow during mouse drag

### DIFF
--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -2424,10 +2424,11 @@ mch_inchar(
 # endif
 
     // Keep looping until there is something in the typeahead buffer and more
-    // to get and still room in the buffer (up to two bytes for a char and
-    // three bytes for a modifier).
+    // to get and still room in the buffer.  A mouse event uses up to
+    // 10 bytes: 3 (modifier) + 3 (scroll event) + 4 (coordinates), and a
+    // keyboard input uses up to 7 bytes: 3 (modifier) + 4 (UTF-8 char).
     while ((typeaheadlen == 0 || WaitForChar(0L, FALSE))
-			  && typeaheadlen + 5 + TYPEAHEADSPACE <= TYPEAHEADLEN)
+			  && typeaheadlen + 10 + TYPEAHEADSPACE <= TYPEAHEADLEN)
     {
 	if (typebuf_changed(tb_change_cnt))
 	{


### PR DESCRIPTION
The typeahead buffer guard in mch_inchar() only reserved 5 bytes per loop iteration, but a mouse event writes up to 7 bytes (3 header + 4 coordinates) and a scroll event with modifiers writes up to 10 bytes. When dragging the status line quickly on Windows console, 3+ mouse events could queue up in a single loop pass and overflow the 20-byte static buffer, corrupting adjacent memory. This caused garbage bytes to be fed into the input stream, triggering unintended commands such as Ctrl-Z (suspend).
The bug has existed since Vim 7.0001 but was not visible on the legacy console where ReadConsole properly skipped MOUSE_EVENT records. With ConPTY (Windows Terminal), the corruption becomes visible.
Change the guard from 5 to 10 to match the actual worst-case write size.