### PR TITLE
feat: auto-save before :term when 'autowrite' is set

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1031,7 +1031,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 			global
 	Write the contents of the file, if it has been modified, on each
 	`:next`, `:rewind`, `:last`, `:first`, `:previous`, `:stop`,
-	`:suspend`, `:tag`, `:!`, `:make`, CTRL-] and CTRL-^ command; and when
+	`:suspend`, `:tag`, `:!`, `:make`, `:terminal`, CTRL-] and CTRL-^ command; and when
 	a `:buffer`, CTRL-O, CTRL-I, '{A-Z0-9}, or `{A-Z0-9} command takes one
 	to another file.
 	A buffer is not written if it becomes hidden, e.g. when 'bufhidden' is

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -810,6 +810,11 @@ ex_terminal(exarg_T *eap)
     int		opt_shell = FALSE;
     char_u	*cmd;
     char_u	*tofree = NULL;
+    int	        scroll_save = msg_scroll;
+
+    msg_scroll = FALSE;	    // don't scroll here
+    autowrite_all();
+    msg_scroll = scroll_save;
 
     init_job_options(&opt);
 

--- a/src/testdir/test_terminal3.vim
+++ b/src/testdir/test_terminal3.vim
@@ -1218,4 +1218,15 @@ func Test_term_getpos()
   bw
 endfunc
 
+func Test_term_autowrite()
+  set autowrite
+  new termautowritetestfile
+  call setline(1, 'test content')
+  term echo "test"
+  call assert_equal(['test content'], readfile('termautowritetestfile'))
+  call delete('termautowritetestfile')
+  bwipe!
+  set noautowrite
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
This feature makes sense to add because the use case of the `:term` command is very similar to `:!` or `:make`, both of which automatically write all modified buffers when the `autowrite` option is set.

Existing autocmd mechanisms such as `autocmd TerminalOpen * wa` cannot properly fulfill this need, as they save files only after the terminal has started.

Moreover, this change is very small and minimally invasive.