### PR TITLE
runtime(doc): adjust :h 'autowrite' and :h 'autowriteall'

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1,4 +1,4 @@
-*options.txt*	For Vim version 9.2.  Last change: 2026 Apr 01
+*options.txt*	For Vim version 9.2.  Last change: 2026 Apr 03
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -1030,10 +1030,10 @@ A jump table for the options with a short description can be found at |Q_op|.
 'autowrite' 'aw'	boolean	(default off)
 			global
 	Write the contents of the file, if it has been modified, on each
-	`:next`, `:rewind`, `:last`, `:first`, `:previous`, `:stop`,
-	`:suspend`, `:tag`, `:!`, `:make`, `:terminal`, CTRL-] and CTRL-^ command; and when
-	a `:buffer`, CTRL-O, CTRL-I, '{A-Z0-9}, or `{A-Z0-9} command takes one
-	to another file.
+	`:next`, `:rewind`, `:last`, `:first`, `:previous`, `:tag`, `:stop`,
+	`:suspend`, `:!`, `:make`, `:terminal`, CTRL-] or CTRL-^ command; and
+	when a `:buffer`, CTRL-O, CTRL-I, '{A-Z0-9}, or `{A-Z0-9} command
+	switches to another file.
 	A buffer is not written if it becomes hidden, e.g. when 'bufhidden' is
 	set to "hide" and `:next` is used.
 	Note that for some commands the 'autowrite' option is not used, see
@@ -1047,8 +1047,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 			 *'autowriteall'* *'awa'* *'noautowriteall'* *'noawa'*
 'autowriteall' 'awa'	boolean	(default off)
 			global
-	Like 'autowrite', but also used for commands ":edit", ":enew",
-	":quit", ":qall", ":exit", ":xit", ":recover" and closing the Vim
+	Like 'autowrite', but also used for commands `:edit`, `:enew`,
+	`:quit`, `:qall`, `:exit`, `:xit`, `:recover` and closing the Vim
 	window.
 	Setting this option also implies that Vim behaves like 'autowrite' has
 	been set.


### PR DESCRIPTION
- Don't go over 78 columns.
- Change the first "and" to "or", as "or" is used below.
- Change "takes one" to "switches", as "one" may be mistaken as
  referring to the command instead of the user.
- Use backticks in :h 'autowriteall' like in :h 'autowrite'.
