### PR TITLE
patch for listchars not using highlight groups in selection

### DIFF
--- a/src/drawline.c
+++ b/src/drawline.c
@@ -3743,19 +3743,31 @@ win_line(
 	// highlighting, unless text property overrides.
 	// Don't use "wlv.extra_attr" until wlv.n_attr_skip is zero.
 	if (wlv.n_attr_skip == 0 && n_attr > 0
-		&& wlv.draw_state == WL_LINE
-		&& (!attr_pri
+		&& wlv.draw_state == WL_LINE)
+	{
+	    if (!attr_pri
 #ifdef FEAT_PROP_POPUP
 		    || (text_prop_flags & PT_FLAG_OVERRIDE)
 #endif
-		   ))
-	{
+		   )
+	    {
 #ifdef LINE_ATTR
-	    if (wlv.line_attr)
-		wlv.char_attr = hl_combine_attr(wlv.line_attr, wlv.extra_attr);
-	    else
+		if (wlv.line_attr)
+		    wlv.char_attr = hl_combine_attr(wlv.line_attr, wlv.extra_attr);
+		else
 #endif
-		wlv.char_attr = wlv.extra_attr;
+		    wlv.char_attr = wlv.extra_attr;
+	    }
+	    else
+	    {
+#ifdef LINE_ATTR
+		if (wlv.line_attr)
+		    wlv.char_attr = hl_combine_attr(wlv.line_attr,
+				hl_combine_attr(wlv.extra_attr, wlv.char_attr));
+		else
+#endif
+		    wlv.char_attr = hl_combine_attr(wlv.extra_attr, wlv.char_attr);
+	    }
 #ifdef FEAT_PROP_POPUP
 	    if (reset_extra_attr)
 	    {


### PR DESCRIPTION
Problem:  When text with 'leadmultispace' (or other listchars whitespace
          characters) is visually selected, the listchar characters do not
          render with their designated highlight group (Whitespace/NonText).
          They inherit the syntax color of surrounding text instead.
Solution: In win_line(), when attr_pri is set (Visual selection active),
          combine extra_attr with char_attr using hl_combine_attr() instead
          of skipping the assignment entirely.
fixes: #19872
```
pwd
/Users/dipayandutta/Developer/vim-official

cat /tmp/repro.vim
─────┬────────────────────────────────────────────────────────────────────────────────────
     │ File: /tmp/repro.vim
─────┼────────────────────────────────────────────────────────────────────────────────────
   1 │ set nocompatible
   2 │ set list
   3 │ set listchars=leadmultispace:\|\ \ \ <----------
   4 │ set expandtab tabstop=4 shiftwidth=4
   5 │ highlight Whitespace ctermfg=1
   6 │ highlight Visual ctermbg=4
─────┴────────────────────────────────────────────────────────────────────────────────────


 cat /tmp/testfile.py
─────┬────────────────────────────────────────────────────────────────────────────────────
     │ File: /tmp/testfile.py
─────┼────────────────────────────────────────────────────────────────────────────────────
   1 │ def foo():
   2 │     if True:
   3 │         pass
─────┴───────────────────
```

src/vim -u /tmp/repro.vim /tmp/testfile.py
<img width="1456" height="368" alt="image" src="https://github.com/user-attachments/assets/40d481f9-0d8e-4097-99a6-e2a18d5843aa" />

