### PR TITLE
runtime(jjdescription): improve status line highlighting and add support for renames

### DIFF
--- a/runtime/syntax/jjdescription.vim
+++ b/runtime/syntax/jjdescription.vim
@@ -11,8 +11,9 @@ endif
 syn match jjAdded "^JJ:\s\+\zsA\s.*" contained
 syn match jjRemoved "^JJ:\s\+\zsD\s.*" contained
 syn match jjChanged "^JJ:\s\+\zsM\s.*" contained
+syn match jjRenamed "^JJ:\s\+\zsR\s.*" contained
 
-syn region jjComment start="^JJ:" end="$" contains=jjAdded,jjRemoved,jjChanged
+syn region jjComment start="^JJ:" end="$" contains=jjAdded,jjRemoved,jjChanged,jjRenamed
 
 syn include @jjCommitDiff syntax/diff.vim
 syn region jjCommitDiff start=/\%(^diff --\%(git\|cc\|combined\) \)\@=/ end=/^\%(diff --\|$\|@@\@!\|[^[:alnum:]\ +-]\S\@!\)\@=/ fold contains=@jjCommitDiff
@@ -21,5 +22,6 @@ hi def link jjComment Comment
 hi def link jjAdded Added
 hi def link jjRemoved Removed
 hi def link jjChanged Changed
+hi def link jjRenamed Changed
 
 let b:current_syntax = 'jjdescription'

--- a/runtime/syntax/jjdescription.vim
+++ b/runtime/syntax/jjdescription.vim
@@ -8,9 +8,9 @@ if exists('b:current_syntax')
   finish
 endif
 
-syn match jjAdded "A .*" contained
-syn match jjRemoved "D .*" contained
-syn match jjChanged "M .*" contained
+syn match jjAdded "^JJ:\s\+\zsA\s.*" contained
+syn match jjRemoved "^JJ:\s\+\zsD\s.*" contained
+syn match jjChanged "^JJ:\s\+\zsM\s.*" contained
 
 syn region jjComment start="^JJ:" end="$" contains=jjAdded,jjRemoved,jjChanged
 


### PR DESCRIPTION
The regex for highlighting `jj` status lines was a bit too broad, frequently highlighting lines that weren't actually status lines in my commit descriptions. I've made the regex a bit more strict to prevent this.

I also added support for highlighting renamed files (these lines look like `R {old.txt => new.txt}`).