### PR TITLE
Remove unnecessary (int) casts before alloc() calls

### DIFF
--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -42,7 +42,7 @@ static void	set_cmdspos(void);
 static void	set_cmdspos_cursor(void);
 static void	correct_cmdspos(int idx, int cells);
 static void	dealloc_cmdbuff(void);
-static void	alloc_cmdbuff(int len);
+static void	alloc_cmdbuff(size_t len);
 static void	draw_cmdline(int start, int len);
 static void	save_cmdline(cmdline_info_T *ccp);
 static void	restore_cmdline(cmdline_info_T *ccp);
@@ -1537,7 +1537,7 @@ cmdline_browse_history(
 		}
 		if (i == 0)
 		{
-		    alloc_cmdbuff((int)len);
+		    alloc_cmdbuff(len);
 		    if (ccline.cmdbuff == NULL)
 		    {
 			res = GOTO_NORMAL_MODE;
@@ -1550,7 +1550,7 @@ cmdline_browse_history(
 	}
 	else
 	{
-	    alloc_cmdbuff((int)plen);
+	    alloc_cmdbuff(plen);
 	    if (ccline.cmdbuff == NULL)
 	    {
 		res = GOTO_NORMAL_MODE;
@@ -3491,7 +3491,7 @@ dealloc_cmdbuff(void)
  * Assigns the new buffer to ccline.cmdbuff and ccline.cmdbufflen.
  */
     static void
-alloc_cmdbuff(int len)
+alloc_cmdbuff(size_t len)
 {
     /*
      * give some extra space to avoid having to allocate all the time
@@ -3502,7 +3502,7 @@ alloc_cmdbuff(int len)
 	len += 20;
 
     ccline.cmdbuff = alloc(len);    // caller should check for out-of-memory
-    ccline.cmdbufflen = len;
+    ccline.cmdbufflen = (int)len;
 }
 
 /*

--- a/src/memline.c
+++ b/src/memline.c
@@ -3674,7 +3674,7 @@ ml_replace_len(
 	    size_t textproplen = curbuf->b_ml.ml_line_len - oldtextlen;
 
 	    // Need to copy over text properties, stored after the text.
-	    newline = alloc(len + (int)textproplen);
+	    newline = alloc(len + textproplen);
 	    if (newline != NULL)
 	    {
 		mch_memmove(newline, line, len);

--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -5896,7 +5896,7 @@ popup_set_title(win_T *wp)
 
     vim_free(wp->w_popup_title);
     len = STRLEN(wp->w_buffer->b_fname) + 3;
-    wp->w_popup_title = alloc((int)len);
+    wp->w_popup_title = alloc(len);
     if (wp->w_popup_title != NULL)
 	vim_snprintf((char *)wp->w_popup_title, len, " %s ",
 		wp->w_buffer->b_fname);

--- a/src/session.c
+++ b/src/session.c
@@ -1099,7 +1099,7 @@ write_session_file(char_u *filename)
     escaped_filename = vim_strsave_escaped(filename, escape_chars);
     if (escaped_filename == NULL)
 	return FALSE;
-    mksession_cmdline = alloc(10 + (int)STRLEN(escaped_filename) + 1);
+    mksession_cmdline = alloc(10 + STRLEN(escaped_filename) + 1);
     if (mksession_cmdline == NULL)
     {
 	vim_free(escaped_filename);

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -5697,7 +5697,7 @@ get_separator(int text_width, char_u *fname)
     int	    i;
     size_t  off;
 
-    textline = alloc(width + (int)STRLEN(fname) + 1);
+    textline = alloc(width + STRLEN(fname) + 1);
     if (textline == NULL)
 	return NULL;
 

--- a/src/vim9expr.c
+++ b/src/vim9expr.c
@@ -3355,7 +3355,7 @@ compile_expr6(char_u **arg, cctx_T *cctx, ppconst_T *ppconst)
 		char_u *s2 = tv2->vval.v_string;
 		size_t len1 = STRLEN(s1);
 
-		tv1->vval.v_string = alloc((int)(len1 + STRLEN(s2) + 1));
+		tv1->vval.v_string = alloc(len1 + STRLEN(s2) + 1);
 		if (tv1->vval.v_string == NULL)
 		{
 		    clear_ppconst(ppconst);


### PR DESCRIPTION
alloc() already accepts size_t, so (int) casts on size_t values are redundant and could theoretically cause truncation on values > INT_MAX. Remove the casts and change alloc_cmdbuff() and list_alloc_with_items() signatures from int to size_t to match.

Closes #19888