### PR TITLE
test(netrw): skip pipe injection test on Windows

### DIFF
--- a/src/testdir/test_plugin_netrw.vim
+++ b/src/testdir/test_plugin_netrw.vim
@@ -596,6 +596,7 @@ func Test_netrw_hostname()
 endfunc
 
 func Test_netrw_FileUrlEdit_pipe_injection()
+  CheckUnix
   CheckExecutable id
   let fname = 'Xtestfile'
   let url = 'file:///tmp/file.md%7C!id>'..fname


### PR DESCRIPTION
Skip `Test_netrw_FileUrlEdit_pipe_injection` on Windows with `CheckUnix`.
The test fails with E303 because `|` is not a valid filename character on Windows.
Since the pipe character cannot appear in a Windows filename, the command injection vector does not apply.

Introduced in https://github.com/vim/vim/commit/3e60f03d94

cc @chrisbra