### PR TITLE
test(viminfo): catch E342 in length overflow test

### DIFF
--- a/src/testdir/test_viminfo.vim
+++ b/src/testdir/test_viminfo.vim
@@ -1385,8 +1385,13 @@ func Test_viminfo_len_overflow()
         \ '|<CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
         \ '|<DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD'], viminfo_file, 'b')
 
-  " Should not crash or cause memory errors
-  exe 'rviminfo! ' .. viminfo_file
+  " Should not crash or cause memory errors.
+  " E342 (out of memory) may be thrown depending on the platform's memory
+  " allocation behavior, which is an acceptable outcome.
+  try
+    exe 'rviminfo! ' .. viminfo_file
+  catch /E342/
+  endtry
 
   let &viminfofile = _viminfofile
 endfunc


### PR DESCRIPTION
Test_viminfo_len_overflow tries to allocate ~4GB, which may throw E342
(out of memory) depending on the platform's memory allocation behavior.
This is an acceptable outcome since the test's purpose is to verify
that Vim does not crash on a crafted viminfo entry.

Introduced in b2e55ed1d

cc @chrisbra