### PR TITLE
Remove more unnecessary (int) casts before alloc() calls

### DIFF
--- a/src/netbeans.c
+++ b/src/netbeans.c
@@ -937,7 +937,7 @@ nb_partialremove(linenr_T lnum, colnr_T first, colnr_T last)
 	return;
     if (lastbyte >= oldlen)
 	lastbyte = oldlen - 1;
-    newtext = alloc(oldlen - (int)(lastbyte - first));
+    newtext = alloc(oldlen - (lastbyte - first));
     if (newtext == NULL)
 	return;
 

--- a/src/vim9script.c
+++ b/src/vim9script.c
@@ -460,7 +460,7 @@ handle_import(
 	{
 	    // Relative to current script: "./name.vim", "../../name.vim".
 	    len = STRLEN(si->sn_name) - STRLEN(tail) + STRLEN(tv.vval.v_string) + 2;
-	    from_name = alloc((int)len);
+	    from_name = alloc(len);
 	    if (from_name == NULL)
 		goto erret;
 	    vim_strncpy(from_name, si->sn_name, tail - si->sn_name);
@@ -485,7 +485,7 @@ handle_import(
 	char_u	    *from_name;
 
 	// Find file in "autoload" subdirs in 'runtimepath'.
-	from_name = alloc((int)len);
+	from_name = alloc(len);
 	if (from_name == NULL)
 	    goto erret;
 	vim_snprintf((char *)from_name, len, "autoload/%s", tv.vval.v_string);
@@ -512,7 +512,7 @@ handle_import(
 	char_u	    *from_name;
 
 	// Find file in "import" subdirs in 'runtimepath'.
-	from_name = alloc((int)len);
+	from_name = alloc(len);
 	if (from_name == NULL)
 	    goto erret;
 	vim_snprintf((char *)from_name, len, "import/%s", tv.vval.v_string);


### PR DESCRIPTION
Follow-up to patch 9.2.0283. Remove remaining `(int)` casts before `alloc()` in `vim9script.c` and `netbeans.c`.

- `vim9script.c` (3 locations): lengths derived from `STRLEN()` on file paths, bounded by `PATH_MAX`. The `(int)` cast is unnecessary but not a security issue in practice.
- `netbeans.c` (1 location): all operands (`oldlen`, `lastbyte`, `first`) are already `int`/`colnr_T` (= `int`), so the `(int)` cast is purely redundant — no truncation can occur here.

Relates to #19888