### PR TITLE
libvterm: signed integer overflow parsing long CSI arguments

### DIFF
--- a/src/libvterm/src/parser.c
+++ b/src/libvterm/src/parser.c
@@ -232,8 +232,10 @@ size_t vterm_input_write(VTerm *vt, const char *bytes, size_t len)
       if(c >= '0' && c <= '9') {
         if(vt->parser.v.csi.args[vt->parser.v.csi.argi] == CSI_ARG_MISSING)
           vt->parser.v.csi.args[vt->parser.v.csi.argi] = 0;
-        vt->parser.v.csi.args[vt->parser.v.csi.argi] *= 10;
-        vt->parser.v.csi.args[vt->parser.v.csi.argi] += c - '0';
+        if(vt->parser.v.csi.args[vt->parser.v.csi.argi] < (CSI_ARG_MISSING - 9) / 10) {
+          vt->parser.v.csi.args[vt->parser.v.csi.argi] *= 10;
+          vt->parser.v.csi.args[vt->parser.v.csi.argi] += c - '0';
+        }
         break;
       }
       if(c == ':') {


### PR DESCRIPTION
Problem:  Accumulating CSI argument digits without an upper bound causes
          signed integer overflow when the argument exceeds LONG_MAX.
Solution: Skip further digit accumulation once the value would overflow
          LONG_MAX.

Supported by AI