### PR TITLE
:syn sync grouphere may go beyond end of line

### DIFF
--- a/src/syntax.c
+++ b/src/syntax.c
@@ -595,7 +595,7 @@ syn_sync(
     int		found_flags = 0;
     int		found_match_idx = 0;
     linenr_T	found_current_lnum = 0;
-    int		found_current_col= 0;
+    int		found_current_col = 0;
     lpos_T	found_m_endpos;
     colnr_T	prev_current_col;
 
@@ -817,6 +817,8 @@ syn_sync(
 		 */
 		if (found_flags & HL_SYNC_HERE)
 		{
+		    current_lnum = found_m_endpos.lnum;
+		    current_col = found_m_endpos.col;
 		    if (current_state.ga_len)
 		    {
 			cur_si = &CUR_STATE(current_state.ga_len - 1);
@@ -825,8 +827,6 @@ syn_sync(
 			update_si_end(cur_si, (int)current_col, TRUE);
 			check_keepend();
 		    }
-		    current_col = found_m_endpos.col;
-		    current_lnum = found_m_endpos.lnum;
 		    (void)syn_finish_line(FALSE);
 		    ++current_lnum;
 		}

--- a/src/testdir/test_syntax.vim
+++ b/src/testdir/test_syntax.vim
@@ -988,5 +988,30 @@ func Test_WinEnter_synstack_synID()
   bw!
 endfunc
 
+" This was going beyond the end of the "foo" line
+func Test_syn_sync_grouphere_shorter_next_line()
+  let lines =<< trim END
+    if [[ "$var1" == 1 ]]; then
+      foo
+    else
+      bar
+    fi
+  END
+  let lines = ['a']->repeat(50) + lines + ['a']->repeat(28 + winheight(0))
+
+  new
+  call setline(1, lines)
+  syn region shIf transparent
+        \ start="\<if\_s" skip=+-fi\>+ end="\<;\_s*then\>" end="\<fi\>"
+  syn sync minlines=20 maxlines=40
+  syn sync match shIfSync grouphere shIf "\<if\>"
+  redraw!
+
+  normal! G
+  " Should not go beyond end of line
+  redraw!
+
+  bw!
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  :syn sync grouphere may go beyond end of line.
Solution: Start searching for the end of region at the end of match
          instead of a possibly invalid position.
