### PR TITLE
Add const qualifier to static table data

### DIFF
--- a/src/crypt.c
+++ b/src/crypt.c
@@ -342,7 +342,7 @@ sodium_enabled(int verbose)
 #endif
 
 #define CRYPT_MAGIC_LEN	12	// cannot change
-static char	crypt_magic_head[] = "VimCrypt~";
+static const char crypt_magic_head[] = "VimCrypt~";
 
 /*
  * Return int value for crypt method name.

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -2734,7 +2734,7 @@ ex_errmsg(char *msg, char_u *arg)
  * The "+" string used in place of an empty command in Ex mode.
  * This string is used in pointer comparison.
  */
-static char exmode_plus[] = "+";
+static const char exmode_plus[] = "+";
 
 /*
  * Handle a range without a command.

--- a/src/hardcopy.c
+++ b/src/hardcopy.c
@@ -1394,7 +1394,7 @@ static int prt_use_courier;
 static int prt_in_ascii;
 static int prt_half_width;
 static char *prt_ascii_encoding;
-static char_u prt_hexchar[] = "0123456789abcdef";
+static const char_u prt_hexchar[] = "0123456789abcdef";
 
     static void
 prt_write_file_raw_len(char_u *buffer, int bytes)

--- a/src/memline.c
+++ b/src/memline.c
@@ -69,7 +69,7 @@ typedef struct pointer_entry	PTR_EN;	    // block/line-count pair
 #define BLOCK0_ID1_C4  's'		    // block 0 id 1 'cm' 4
 
 #if defined(FEAT_CRYPT)
-static int id1_codes[] = {
+static const int id1_codes[] = {
     BLOCK0_ID1_C0,  // CRYPT_M_ZIP
     BLOCK0_ID1_C1,  // CRYPT_M_BF
     BLOCK0_ID1_C2,  // CRYPT_M_BF2

--- a/src/pty.c
+++ b/src/pty.c
@@ -354,15 +354,15 @@ mch_openpty(char **ttyn)
 #ifndef PTY_DONE
 
 # ifdef hpux
-static char PtyProto[] = "/dev/ptym/ptyXY";
-static char TtyProto[] = "/dev/pty/ttyXY";
+static const char PtyProto[] = "/dev/ptym/ptyXY";
+static const char TtyProto[] = "/dev/pty/ttyXY";
 # else
 #  ifdef __HAIKU__
-static char PtyProto[] = "/dev/pt/XY";
-static char TtyProto[] = "/dev/tt/XY";
+static const char PtyProto[] = "/dev/pt/XY";
+static const char TtyProto[] = "/dev/tt/XY";
 #  else
-static char PtyProto[] = "/dev/ptyXY";
-static char TtyProto[] = "/dev/ttyXY";
+static const char PtyProto[] = "/dev/ptyXY";
+static const char TtyProto[] = "/dev/ttyXY";
 #  endif
 # endif
 

--- a/src/regexp.c
+++ b/src/regexp.c
@@ -377,7 +377,7 @@ static int	reg_strict;	// "[abc" is illegal
  */
 
 // META[] is used often enough to justify turning it into a table.
-static char_u META_flags[] = {
+static const char_u META_flags[] = {
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 //		   %  &     (  )  *  +	      .
@@ -2908,7 +2908,7 @@ static regengine_T nfa_regengine =
 static int regexp_engine = 0;
 
 #ifdef DEBUG
-static char_u regname[][30] = {
+static const char_u regname[][30] = {
 		    "AUTOMATIC Regexp Engine",
 		    "BACKTRACKING Regexp Engine",
 		    "NFA Regexp Engine"

--- a/src/regexp_bt.c
+++ b/src/regexp_bt.c
@@ -253,7 +253,7 @@ static int	one_exactly = FALSE;	// only do one char for EXACTLY
 
 // When making changes to classchars also change nfa_classcodes.
 static char_u	*classchars = (char_u *)".iIkKfFpPsSdDxXoOwWhHaAlLuU";
-static int	classcodes[] = {
+static const int classcodes[] = {
     ANY, IDENT, SIDENT, KWORD, SKWORD,
     FNAME, SFNAME, PRINT, SPRINT,
     WHITE, NWHITE, DIGIT, NDIGIT,

--- a/src/regexp_nfa.c
+++ b/src/regexp_nfa.c
@@ -233,7 +233,7 @@ enum
 };
 
 // Keep in sync with classchars.
-static int nfa_classcodes[] = {
+static const int nfa_classcodes[] = {
     NFA_ANY, NFA_IDENT, NFA_SIDENT, NFA_KWORD,NFA_SKWORD,
     NFA_FNAME, NFA_SFNAME, NFA_PRINT, NFA_SPRINT,
     NFA_WHITE, NFA_NWHITE, NFA_DIGIT, NFA_NDIGIT,

--- a/src/term.c
+++ b/src/term.c
@@ -689,7 +689,7 @@ static tcap_entry_T builtin_sync_output[] = {
 /*
  * List of DECRQM modes that Vim supports
  */
-static int dec_modes[] = {
+static const int dec_modes[] = {
     2026,   // Synchronized output
 #ifdef UNIX
     2048    // In-band terminal resize events
@@ -7827,11 +7827,11 @@ swap_tcap(void)
 
 
 #if (defined(MSWIN) && (!defined(FEAT_GUI_MSWIN) || defined(VIMDLL))) || defined(FEAT_TERMINAL)
-static int cube_value[] = {
+static const int cube_value[] = {
     0x00, 0x5F, 0x87, 0xAF, 0xD7, 0xFF
 };
 
-static int grey_ramp[] = {
+static const int grey_ramp[] = {
     0x08, 0x12, 0x1C, 0x26, 0x30, 0x3A, 0x44, 0x4E, 0x58, 0x62, 0x6C, 0x76,
     0x80, 0x8A, 0x94, 0x9E, 0xA8, 0xB2, 0xBC, 0xC6, 0xD0, 0xDA, 0xE4, 0xEE
 };


### PR DESCRIPTION
Several static arrays that are never modified at runtime were missing the const qualifier.
Add const to move them from .data to .rodata section.