### PR TITLE
Reduce startup termcode and UTF-8 scanning work

### DIFF
--- a/src/strings.c
+++ b/src/strings.c
@@ -626,6 +626,8 @@ vim_strchr(char_u *string, int c)
     int		b;
 
     p = string;
+    if (enc_utf8 && c > 0 && c < 0x80)
+	return vim_strbyte(string, c);
     if (enc_utf8 && c >= 0x80)
     {
 	while (*p != NUL)

--- a/src/term.c
+++ b/src/term.c
@@ -7209,6 +7209,13 @@ find_term_bykeys(char_u *src, int *matchlen)
     int         slen, modslen;
     int         thislen;
 
+    // Most input bytes cannot start a terminal code.  Reuse the same leader
+    // table as check_termcode() to avoid scanning termcodes[] unnecessarily.
+    if (need_gather)
+	gather_termleader();
+    if (*src == NUL || vim_strchr(termleader, *src) == NULL)
+	return -1;
+
     // find longest match
     // borrows part of check_termcode
     for (i = 0; i < tc_len; ++i)


### PR DESCRIPTION
This reduces some repeated startup work in `find_term_bykeys()` and `vim_strchr()`.

Compared with `master` on normal startup (`./vim -c 'qa!'`):

| Benchmark | master | branch | delta |
|:--|--:|--:|--:|
| Callgrind `Ir` | 788,506,178 | 574,678,633 | -27.12% |
| Hyperfine wall-clock | 2.156 s ± 0.018 s | 2.153 s ± 0.037 s | no meaningful change |

This lowers CPU work in the startup path, but startup time itself stays about the same here because terminal I/O and other external costs still dominate.