### PR TITLE
libvterm: avoid CSI argument overflow

### DIFF
--- a/src/libvterm/src/parser.c
+++ b/src/libvterm/src/parser.c
@@ -230,12 +230,16 @@ size_t vterm_input_write(VTerm *vt, const char *bytes, size_t len)
     case CSI_ARGS:
       /* Numerical value of argument */
       if(c >= '0' && c <= '9') {
-        if(vt->parser.v.csi.args[vt->parser.v.csi.argi] == CSI_ARG_MISSING)
-          vt->parser.v.csi.args[vt->parser.v.csi.argi] = 0;
-        if(vt->parser.v.csi.args[vt->parser.v.csi.argi] < (CSI_ARG_MISSING - 9) / 10) {
-          vt->parser.v.csi.args[vt->parser.v.csi.argi] *= 10;
-          vt->parser.v.csi.args[vt->parser.v.csi.argi] += c - '0';
-        }
+        long arg_max = CSI_ARG_MISSING - 1;
+        long *arg = &vt->parser.v.csi.args[vt->parser.v.csi.argi];
+        int digit = c - '0';
+
+        if(*arg == CSI_ARG_MISSING)
+          *arg = 0;
+        if(*arg > (arg_max - digit) / 10)
+          *arg = arg_max;
+        else
+          *arg = *arg * 10 + digit;
         break;
       }
       if(c == ':') {

--- a/src/testdir/test_terminal3.vim
+++ b/src/testdir/test_terminal3.vim
@@ -1232,8 +1232,9 @@ endfunc
 " Test that CSI sequences with more than CSI_ARGS_MAX arguments do not crash
 func Test_terminal_csi_args_overflow()
   CheckExecutable printf
-  let buf = term_start([&shell, &shellcmdflag,
-        \ 'printf "\033[' . repeat('1;', 49) . '1m"'])
+  let seq = "\033[" .. repeat('1;', 49) .. '1m'
+  let seq ..= "\033[1111111111111111111m"
+  let buf = term_start([&shell, &shellcmdflag, 'printf "' .. seq .. '"'])
 
   " If we get here without a crash, the fix works
   call assert_equal('running', term_getstatus(buf))


### PR DESCRIPTION
Clamp oversized CSI numeric arguments before multiplying by 10 so libvterm does not overflow while parsing long digit sequences.

The failing linux (huge, clang, asan, 5.1) job hit UBSan in libvterm/src/parser.c when a terminal test fed a very large CSI argument and the parser evaluated 1111111111111111111 * 10 in a signed long.

This also extends the terminal test to cover both too many CSI arguments and an oversized numeric argument.