### PR TITLE
Add out-of-memory check to may_get_cmd_block()

### DIFF
--- a/src/usercmd.c
+++ b/src/usercmd.c
@@ -1240,6 +1240,8 @@ may_get_cmd_block(exarg_T *eap, char_u *p, char_u **tofree, int *flags)
 	    }
 	vim_free(line);
 	retp = *tofree = ga_concat_strings(&ga, "\n");
+	if (retp == NULL)
+	    retp = p;
 	ga_clear_strings(&ga);
 	*flags |= UC_VIM9;
     }


### PR DESCRIPTION
This PR adds an out-of-memory check to `may_get_cmd_block()`.

Function `ga_concat_strings()` returns `NULL` on an out-of-memory condition.

Function `may_get_cmd_block()` calls `ga_concat_strings()` and passes it's return value unchecked to it's caller.
When called from function `do_autocmd()`, this return value is then passed unchecked to `expand_sfile()` which calls `STRLEN()` on it.
When called from function `ex_command()`, this return value is then passed unchecked, via `uc_add_command()`, to `replace_termcodes()` which calls `STRLEN()` on it.

Obviously, both of which will result in attempting to deference a potentially `NULL` pointer.

This PR changes function `may_get_cmd_block()` to check the result of `ga_concat_strings()` and returns it's input value `p` on a `NULL` result, just like the function does if `ga_copy_string()` fails.

Cheers
John