### PR TITLE
Redundant and incorrect integer pointer casts in drawline.c

### DIFF
--- a/src/drawline.c
+++ b/src/drawline.c
@@ -1418,8 +1418,7 @@ win_line(
 			wlv.fromcol = 0;
 		    else
 		    {
-			getvvcol(wp, top, (colnr_T *)&wlv.fromcol,
-								NULL, NULL, 0);
+			getvvcol(wp, top, &wlv.fromcol, NULL, NULL, 0);
 			if (gchar_pos(top) == NUL)
 			    wlv.tocol = wlv.fromcol + 1;
 		    }
@@ -1437,12 +1436,10 @@ win_line(
 		    {
 			pos = *bot;
 			if (*p_sel == 'e')
-			    getvvcol(wp, &pos, (colnr_T *)&wlv.tocol,
-								NULL, NULL, 0);
+			    getvvcol(wp, &pos, &wlv.tocol, NULL, NULL, 0);
 			else
 			{
-			    getvvcol(wp, &pos, NULL, NULL,
-						     (colnr_T *)&wlv.tocol, 0);
+			    getvvcol(wp, &pos, NULL, NULL, &wlv.tocol, 0);
 			    ++wlv.tocol;
 			}
 		    }
@@ -1481,14 +1478,14 @@ win_line(
 	{
 	    if (lnum == curwin->w_cursor.lnum)
 		getvcol(curwin, &(curwin->w_cursor),
-				       (colnr_T *)&wlv.fromcol, NULL, NULL, 0);
+						&wlv.fromcol, NULL, NULL, 0);
 	    else
 		wlv.fromcol = 0;
 	    if (lnum == curwin->w_cursor.lnum + search_match_lines)
 	    {
 		pos.lnum = lnum;
 		pos.col = search_match_endcol;
-		getvcol(curwin, &pos, (colnr_T *)&wlv.tocol, NULL, NULL, 0);
+		getvcol(curwin, &pos, &wlv.tocol, NULL, NULL, 0);
 	    }
 	    else
 		wlv.tocol = MAXCOL;

--- a/src/ops.c
+++ b/src/ops.c
@@ -2620,7 +2620,7 @@ charwise_block_prep(
 	startcol = start.col;
 	if (virtual_op)
 	{
-	    getvcol(curwin, &start, &cs, NULL, &ce, false);
+	    getvcol(curwin, &start, &cs, NULL, &ce, 0);
 	    if (ce != cs && start.coladd > 0)
 	    {
 		// Part of a tab selected -- but don't
@@ -2639,7 +2639,7 @@ charwise_block_prep(
 	endcol = end.col;
 	if (virtual_op)
 	{
-	    getvcol(curwin, &end, &cs, NULL, &ce, false);
+	    getvcol(curwin, &end, &cs, NULL, &ce, 0);
 	    if (p[endcol] == NUL || (cs + end.coladd < ce
 			// Don't add space for double-wide
 			// char; endcol will be on last byte


### PR DESCRIPTION
Problem:  Currently `colnr_T` and `int` and the same type, so casting
          `int *` to `colnr_T *` is redundant. Additionally, even if
          they are changed to different types in the future, these casts
          are incorrect as they won't work on big-endian platforms.
Solution: Remove the casts. Also fix two cases of passing false instead
          of 0 to an integer argument.

related: #19672
