### PR TITLE
:packadd may lead to heap-buffer-overflow

### DIFF
--- a/src/scriptfile.c
+++ b/src/scriptfile.c
@@ -885,7 +885,7 @@ add_pack_dir_to_rtp(char_u *fname)
 	buf.length = (size_t)copy_option_part(&entry, buf.string, MAXPATHL, ",");
 
 	// keep track of p_rtp length as we go to make the STRLEN() below have less work to do
-	p_rtp_len += (*(p_rtp + buf.length) == ',') ? buf.length + 1 : buf.length;
+	p_rtp_len += (*(cur_entry + buf.length) == ',') ? buf.length + 1 : buf.length;
 
 	if ((p = (char_u *)strstr((char *)buf.string, "after")) != NULL
 		&& p > buf.string

--- a/src/testdir/test_packadd.vim
+++ b/src/testdir/test_packadd.vim
@@ -26,6 +26,13 @@ func Test_packadd()
   " plugdir should be inserted before plugdir/after
   call assert_match('^nosuchdir,' . s:plugdir . ',', &rtp)
 
+  " This used to cause heep-buffer-overflow
+  " All existing entries in 'rtp' have the same length here
+  let &rtp = 'Xfoodir,Xbardir,Xbazdir'
+  packadd mytest
+  " plugdir should be inserted after the existing directories
+  call assert_match('^Xfoodir,Xbardir,Xbazdir,' .. s:plugdir .. ',', &rtp)
+
   set rtp&
   let rtp = &rtp
   filetype on


### PR DESCRIPTION
Problem:  :packadd may lead to heap-buffer-overflow when all entries in
          'runtimepath' have the same length (after 9.2.0291).
Solution: Check for comma after current entry properly.
