### PR TITLE
Vim9: Fix void function return value inconsistent between script and :def

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -82,7 +82,7 @@ browsedir({title}, {initdir})	String	put up a directory requester
 bufadd({name})			Number	add a buffer to the buffer list
 bufexists({buf})		Number	|TRUE| if buffer {buf} exists
 buflisted({buf})		Number	|TRUE| if buffer {buf} is listed
-bufload({buf})			Number	load buffer {buf} if not loaded yet
+bufload({buf})			none	load buffer {buf} if not loaded yet
 bufloaded({buf})		Number	|TRUE| if buffer {buf} is loaded
 bufname([{buf}])		String	name of the buffer {buf}
 bufnr([{buf} [, {create}]])	Number	number of the buffer {buf}
@@ -1500,7 +1500,7 @@ bufload({buf})						*bufload()*
 		Can also be used as a |method|: >
 			eval 'somename'->bufload()
 <
-		Return type: |Number|
+		Return type: void
 
 
 bufloaded({buf})					*bufloaded()*

--- a/runtime/doc/channel.txt
+++ b/runtime/doc/channel.txt
@@ -736,7 +736,7 @@ ch_logfile({fname} [, {mode}])					*ch_logfile()*
 		Can also be used as a |method|: >
 			'logfile'->ch_logfile('w')
 <
-		Return type: |Number|
+		Return type: void
 
 ch_open({address} [, {options}])				*ch_open()*
 		Open a channel to {address}.  See |channel|.

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -3499,6 +3499,8 @@ call_internal_func(
 	return FCERR_OTHER;
     argvars[argcount].v_type = VAR_UNKNOWN;
     global_functions[i].f_func(argvars, rettv);
+    if (in_vim9script() && global_functions[i].f_retfunc == ret_void)
+	rettv->v_type = VAR_VOID;
     return FCERR_NONE;
 }
 
@@ -3509,6 +3511,8 @@ call_internal_func_by_idx(
 	typval_T    *rettv)
 {
     global_functions[idx].f_func(argvars, rettv);
+    if (in_vim9script() && global_functions[idx].f_retfunc == ret_void)
+	rettv->v_type = VAR_VOID;
 }
 
 /*

--- a/src/testdir/test_vim9_builtin.vim
+++ b/src/testdir/test_vim9_builtin.vim
@@ -4089,8 +4089,8 @@ enddef
 
 def Test_setenv()
   v9.CheckSourceDefAndScriptFailure(['setenv(1, 2)'], ['E1013: Argument 1: type mismatch, expected string but got number', 'E1174: String required for argument 1'])
-  assert_equal(0, setenv('', ''))
-  assert_equal(0, setenv('', v:null))
+  setenv('', '')
+  setenv('', v:null)
 enddef
 
 def Test_setfperm()
@@ -4939,7 +4939,7 @@ enddef
 
 def Test_timer_stop()
   v9.CheckSourceDefAndScriptFailure(['timer_stop("x")'], ['E1013: Argument 1: type mismatch, expected number but got string', 'E1210: Number required for argument 1'])
-  assert_equal(0, timer_stop(100))
+  timer_stop(100)
 enddef
 
 def Test_tolower()

--- a/src/testdir/test_vim9_func.vim
+++ b/src/testdir/test_vim9_func.vim
@@ -5002,6 +5002,41 @@ def Test_void_method_chain()
     defcompile TestFunc
   END
   v9.CheckScriptFailure(lines, 'E1031: Cannot use void value')
+
+  #### Case 4: Script-level and :def should behave the same ####
+  # script-level: void built-in assigned to variable
+  lines =<< trim END
+    vim9script
+    var x = bufload('')
+  END
+  v9.CheckScriptFailure(lines, 'E1031: Cannot use void value')
+
+  # inside def: same error
+  lines =<< trim END
+    vim9script
+    def TestFunc()
+      var x = bufload('')
+    enddef
+    TestFunc()
+  END
+  v9.CheckScriptFailure(lines, 'E1031: Cannot use void value')
+
+  # script-level: echo void built-in
+  lines =<< trim END
+    vim9script
+    echo bufload('')
+  END
+  v9.CheckScriptFailure(lines, 'E1186: Expression does not result in a value: bufload(')
+
+  # inside def: compile-time error
+  lines =<< trim END
+    vim9script
+    def TestFunc()
+      echo bufload('')
+    enddef
+    TestFunc()
+  END
+  v9.CheckScriptFailure(lines, 'E1186: Expression does not result in a value: bufload(')
 enddef
 
 " vim: ts=8 sw=2 sts=2 expandtab tw=80 fdm=marker


### PR DESCRIPTION
In Vim9 script, calling a void built-in function (e.g. bufload()) at the script level did not set rettv to VAR_VOID, making it appear to return 0. Inside :def it correctly returned VAR_VOID and raised E1031.  Set rettv to VAR_VOID after calling a ret_void built-in function in Vim9 script so the behavior is consistent.

Also fix the documentation for bufload() and ch_logfile() to correctly state that the return type is void.

Related: https://github.com/vim/vim/pull/19912#discussion_r3036268822

Note:
Regarding the discussion at https://github.com/vim/vim/pull/19912#discussion_r3036277259, I will submit a separate PR for it.