### PR TITLE
Fix return type mismatches between evalfunc.c and documentation

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -120,7 +120,7 @@ ch_readraw({handle} [, {options}])
 ch_sendexpr({handle}, {expr} [, {options}])
 				any	send {expr} over JSON {handle}
 ch_sendraw({handle}, {expr} [, {options}])
-				any	send {expr} over raw {handle}
+				none	send {expr} over raw {handle}
 ch_setoptions({handle}, {options})
 				none	set options for {handle}
 ch_status({handle} [, {options}])
@@ -192,7 +192,7 @@ extendnew({expr1}, {expr2} [, {expr3}])
 				List/Dict
 					like |extend()| but creates a new List
 					or Dictionary
-feedkeys({string} [, {mode}])	Number	add key sequence to typeahead buffer
+feedkeys({string} [, {mode}])	none	add key sequence to typeahead buffer
 filecopy({from}, {to})		Number	|TRUE| if copying file {from} to {to}
 					worked
 filereadable({file})		Number	|TRUE| if {file} is a readable file
@@ -219,7 +219,7 @@ foldtext()			String	line displayed for closed fold
 foldtextresult({lnum})		String	text for closed fold at {lnum}
 foreach({expr1}, {expr2})	List/Tuple/Dict/Blob/String
 					for each item in {expr1} call {expr2}
-foreground()			Number	bring the Vim window to the foreground
+foreground()			none	bring the Vim window to the foreground
 fullcommand({name} [, {vim9}])	String	get full command from {name}
 funcref({name} [, {arglist}] [, {dict}])
 				Funcref	reference to function {name}
@@ -391,7 +391,7 @@ list2tuple({list})		Tuple	turn {list} of items into a tuple
 listener_add({callback} [, {buf} [, {unbuffered}]])
 				Number	add a callback to listen to changes
 listener_flush([{buf}])		none	invoke listener callbacks
-listener_remove({id})		none	remove a listener callback
+listener_remove({id})		Number	remove a listener callback
 localtime()			Number	current time
 log({expr})			Float	natural logarithm (base e) of {expr}
 log10({expr})			Float	logarithm of Float {expr} to base 10
@@ -486,7 +486,7 @@ prompt_setinterrupt({buf}, {text})
 				none	set prompt interrupt function
 prompt_setprompt({buf}, {text}) none	set prompt text
 prop_add({lnum}, {col}, {props})
-				none	add one text property
+				Number	add one text property
 prop_add_list({props}, [[{lnum}, {col}, {end-lnum}, {end-col}], ...])
 				none	add multiple text properties
 prop_clear({lnum} [, {lnum-end} [, {props}]])
@@ -581,7 +581,7 @@ setbufvar({buf}, {varname}, {val})
 				none	set {varname} in buffer {buf} to {val}
 setcellwidths({list})		none	set character cell width overrides
 setcharpos({expr}, {list})	Number	set the {expr} position to {list}
-setcharsearch({dict})		Dict	set character search from {dict}
+setcharsearch({dict})		none	set character search from {dict}
 setcmdline({str} [, {pos}])	Number	set command-line
 setcmdpos({pos})		Number	set cursor position in command-line
 setcursorcharpos({list})	Number	move cursor to position in {list}
@@ -699,8 +699,7 @@ synconcealed({lnum}, {col})	List	info about concealing
 synstack({lnum}, {col})		List	stack of syntax IDs at {lnum} and
 					{col}
 system({expr} [, {input}])	String	output of shell command/filter {expr}
-systemlist({expr} [, {input}])
-				List	output of shell command/filter {expr}
+systemlist({expr} [, {input}])	List	output of shell command/filter {expr}
 tabpagebuflist([{arg}])		List	list of buffer numbers in tab page
 tabpagenr([{arg}])		Number	number of current or last tab page
 tabpagewinnr({tabarg} [, {arg}])
@@ -739,7 +738,7 @@ term_setrestore({buf}, {command})
 term_setsize({buf}, {rows}, {cols})
 				none	set the size of a terminal
 term_start({cmd} [, {options}])	Number	open a terminal window and run a job
-term_wait({buf} [, {time}])	Number  wait for screen to be updated
+term_wait({buf} [, {time}])	none    wait for screen to be updated
 terminalprops()			Dict	properties of the terminal
 test_alloc_fail({id}, {countdown}, {repeat})
 				none	make memory allocation fail
@@ -768,7 +767,7 @@ test_setmouse({row}, {col})	none	set the mouse position for testing
 test_settime({expr})		none	set current time for testing
 test_srand_seed([{seed}])	none	set seed for testing srand()
 test_unknown()			any	unknown value for testing
-test_void()			any	void value for testing
+test_void()			none	void value for testing
 timer_info([{id}])		List	information about timers
 timer_pause({id}, {pause})	none	pause or unpause a timer
 timer_start({time}, {callback} [, {options}])
@@ -803,7 +802,7 @@ virtcol2col({winid}, {lnum}, {col})
 				Number  byte index of a character on screen
 visualmode([{expr}])		String	last visual mode used
 wildmenumode()			Number	whether 'wildmenu' mode is active
-wildtrigger()			Number	start wildcard expansion
+wildtrigger()			none	start wildcard expansion
 win_execute({id}, {command} [, {silent}])
 				String	execute {command} in window {id}
 win_findbuf({bufnr})		List	find windows containing {bufnr}
@@ -1273,7 +1272,7 @@ balloon_show({expr})					*balloon_show()*
 		{only available when compiled with the |+balloon_eval| or
 		|+balloon_eval_term| feature}
 
-		Return type: |Number|
+		Return type: void
 
 
 balloon_split({msg})					*balloon_split()*
@@ -1895,7 +1894,7 @@ clearmatches([{win}])					*clearmatches()*
 		Can also be used as a |method|: >
 			GetWin()->clearmatches()
 <
-		Return type: |Number|
+		Return type: void
 
 
 cmdcomplete_info()					*cmdcomplete_info()*
@@ -2015,7 +2014,7 @@ complete({startcol}, {matches})				*complete()* *E785*
 		second argument: >
 			GetMatches()->complete(col('.'))
 <
-		Return type: |Number|
+		Return type: void
 
 
 complete_add({expr})					*complete_add()*
@@ -2659,7 +2658,7 @@ echoraw({string})					*echoraw()*
 			call echoraw(&t_TI)
 <		Use with care, you can mess up the terminal this way.
 
-		Return type: |Number|
+		Return type: void
 
 
 empty({expr})						*empty()*
@@ -2702,7 +2701,7 @@ err_teapot([{expr}])					*err_teapot()*
 		indicating that coffee is temporarily not available.
 		If {expr} is present it must be a String.
 
-		Return type: |Number|
+		Return type: void
 
 
 escape({string}, {chars})				*escape()*
@@ -3219,7 +3218,7 @@ feedkeys({string} [, {mode}])				*feedkeys()*
 		Can also be used as a |method|: >
 			GetInput()->feedkeys()
 <
-		Return type: |Number|
+		Return type: void
 
 
 filecopy({from}, {to})					*filecopy()*
@@ -3656,7 +3655,7 @@ foreground()						*foreground()*
 		allow a window to bring itself to the foreground.  Use
 		|remote_foreground()| instead.
 
-		Return type: |Number|
+		Return type: void
 		{only in the Win32, Motif and GTK GUI versions and the
 		Win32 console version}
 
@@ -3808,7 +3807,7 @@ garbagecollect([{atexit}])				*garbagecollect()*
 		type a character.  To force garbage collection immediately use
 		|test_garbagecollect_now()|.
 
-		Return type: |String|
+		Return type: void
 
 
 get({list}, {idx} [, {default}])			*get()* *get()-list*
@@ -6877,7 +6876,7 @@ listener_flush([{buf}])					*listener_flush()*
 		Can also be used as a |method|: >
 			GetBuffer()->listener_flush()
 <
-		Return type: |Number|
+		Return type: void
 
 
 listener_remove({id})					*listener_remove()*
@@ -7221,7 +7220,7 @@ mapset({dict})
 			    mapset(d)
 			endfor
 <
-		Return type: |Number|
+		Return type: void
 
 
 match({expr}, {pat} [, {start} [, {count}]])		*match()*
@@ -8484,8 +8483,10 @@ prompt_setcallback({buf}, {expr})			*prompt_setcallback()*
 
 <		Can also be used as a |method|: >
 			GetBuffer()->prompt_setcallback(callback)
+<
+		Return type: void
 
-<		{only available when compiled with the |+channel| feature}
+		{only available when compiled with the |+channel| feature}
 
 prompt_setinterrupt({buf}, {expr})			*prompt_setinterrupt()*
 		Set a callback for buffer {buf} to {expr}.  When {expr} is an
@@ -8499,7 +8500,7 @@ prompt_setinterrupt({buf}, {expr})			*prompt_setinterrupt()*
 		Can also be used as a |method|: >
 			GetBuffer()->prompt_setinterrupt(callback)
 <
-		Return type: |Number|
+		Return type: void
 
 		{only available when compiled with the |+channel| feature}
 
@@ -8513,7 +8514,7 @@ prompt_setprompt({buf}, {text})				*prompt_setprompt()*
 		Can also be used as a |method|: >
 			GetBuffer()->prompt_setprompt('command: ')
 <
-		Return type: |Number|
+		Return type: void
 
 		{only available when compiled with the |+channel| feature}
 
@@ -8876,7 +8877,7 @@ redraw_listener_remove({id})			*redraw_listener_remove()*
 		Can also be used as a |method|: >
 			GetRedrawListenerId()->redraw_listener_remove()
 <
-		Return type: |Number|
+		Return type: void
 
 
 reduce({object}, {func} [, {initial}])			*reduce()* *E998*
@@ -9132,7 +9133,7 @@ remote_startserver({name})		*remote_startserver()* *E941* *E942*
 		Can also be used as a |method|: >
 			ServerName()->remote_startserver()
 <
-		Return type: |Number|
+		Return type: void
 
 		{only available when compiled with the |+clientserver| feature}
 
@@ -9880,7 +9881,7 @@ setbufvar({buf}, {varname}, {val})			*setbufvar()*
 		third argument: >
 			GetValue()->setbufvar(buf, varname)
 <
-		Return type: |Number|
+		Return type: void
 
 
 setcellwidths({list})					*setcellwidths()*
@@ -9917,7 +9918,7 @@ setcellwidths({list})					*setcellwidths()*
 		match with what Vim knows about each emoji.  If it doesn't
 		look right you need to adjust the {list} argument.
 
-		Return type: |Number|
+		Return type: void
 
 
 setcharpos({expr}, {list})				*setcharpos()*
@@ -9960,7 +9961,7 @@ setcharsearch({dict})					*setcharsearch()*
 		Can also be used as a |method|: >
 			SavedSearch()->setcharsearch()
 <
-		Return type: dict<any>
+		Return type: void
 
 
 setcmdline({str} [, {pos}])				*setcmdline()*
@@ -10027,7 +10028,7 @@ setenv({name}, {val})					*setenv()*
 		second argument: >
 			GetPath()->setenv('PATH')
 <
-		Return type: |Number|
+		Return type: void
 
 
 setfperm({fname}, {mode})				*setfperm()* *chmod*
@@ -10386,7 +10387,7 @@ settabvar({tabnr}, {varname}, {val})			*settabvar()*
 		third argument: >
 			GetValue()->settabvar(tab, name)
 <
-		Return type: |Number|
+		Return type: void
 
 
 settabwinvar({tabnr}, {winnr}, {varname}, {val})	*settabwinvar()*
@@ -10411,7 +10412,7 @@ settabwinvar({tabnr}, {winnr}, {varname}, {val})	*settabwinvar()*
 		fourth argument: >
 			GetValue()->settabwinvar(tab, winnr, name)
 <
-		Return type: |Number|
+		Return type: void
 
 
 settagstack({nr}, {dict} [, {action}])			*settagstack()*
@@ -10464,7 +10465,7 @@ setwinvar({winnr}, {varname}, {val})			*setwinvar()*
 		third argument: >
 			GetValue()->setwinvar(winnr, name)
 <
-		Return type: |Number|
+		Return type: void
 
 
 sha256({expr})						*sha256()*
@@ -10704,7 +10705,7 @@ sound_clear()						*sound_clear()*
 		On some Linux systems you may need the libcanberra-pulse
 		package, otherwise sound may not stop.
 
-		Return type: |Number|
+		Return type: void
 
 		{only available when compiled with the |+sound| feature}
 
@@ -10774,7 +10775,7 @@ sound_stop({id})					*sound_stop()*
 		Can also be used as a |method|: >
 			soundid->sound_stop()
 <
-		Return type: |Number|
+		Return type: void
 
 		{only available when compiled with the |+sound| feature}
 
@@ -12059,7 +12060,7 @@ timer_pause({timer}, {paused})				*timer_pause()*
 		Can also be used as a |method|: >
 			GetTimer()->timer_pause(1)
 <
-		Return type: |Number|
+		Return type: void
 
 		{only available when compiled with the |+timers| feature}
 
@@ -12119,7 +12120,7 @@ timer_stop({timer})					*timer_stop()*
 		Can also be used as a |method|: >
 			GetTimer()->timer_stop()
 <
-		Return type: |Number|
+		Return type: void
 
 		{only available when compiled with the |+timers| feature}
 
@@ -12129,7 +12130,7 @@ timer_stopall()						*timer_stopall()*
 		invoked.  Useful if a timer is misbehaving.  If there are no
 		timers there is no error.
 
-		Return type: |Number|
+		Return type: void
 
 		{only available when compiled with the |+timers| feature}
 
@@ -12619,7 +12620,7 @@ wildtrigger()						*wildtrigger()*
 
 		Return value is always 0.
 
-		Return type: |Number|
+		Return type: void
 
 
 win_execute({id}, {command} [, {silent}])		*win_execute()*
@@ -12971,7 +12972,7 @@ winrestview({dict})					*winrestview()*
 		Can also be used as a |method|: >
 			GetView()->winrestview()
 <
-		Return type: |Number|
+		Return type: void
 
 
 winsaveview()						*winsaveview()*

--- a/runtime/doc/channel.txt
+++ b/runtime/doc/channel.txt
@@ -549,7 +549,7 @@ ch_close({handle})						*ch_close()*
 		Can also be used as a |method|: >
 			GetChannel()->ch_close()
 <
-		Return type: |Number|
+		Return type: void
 
 ch_close_in({handle})						*ch_close_in()*
 		Close the "in" part of {handle}.  See |channel-close-in|.
@@ -559,7 +559,7 @@ ch_close_in({handle})						*ch_close_in()*
 		Can also be used as a |method|: >
 			GetChannel()->ch_close_in()
 <
-		Return type: |Number|
+		Return type: void
 
 
 ch_evalexpr({handle}, {expr} [, {options}])			*ch_evalexpr()*
@@ -708,7 +708,7 @@ ch_log({msg} [, {handle}])					*ch_log()*
 		Can also be used as a |method|: >
 			'did something'->ch_log()
 <
-		Return type: dict<any>
+		Return type: void
 
 ch_logfile({fname} [, {mode}])					*ch_logfile()*
 		Start logging channel activity to {fname}.
@@ -825,7 +825,7 @@ ch_sendraw({handle}, {expr} [, {options}])		*ch_sendraw()*
 		Can also be used as a |method|: >
 			GetChannel()->ch_sendraw(rawexpr)
 <
-		Return type: dict<any> or |String|
+		Return type: void
 
 ch_setoptions({handle}, {options})			*ch_setoptions()*
 		Set options on {handle}:
@@ -844,7 +844,7 @@ ch_setoptions({handle}, {options})			*ch_setoptions()*
 		Can also be used as a |method|: >
 			GetChannel()->ch_setoptions(options)
 <
-		Return type: |Number|
+		Return type: void
 
 ch_status({handle} [, {options}])				*ch_status()*
 		Return the status of {handle}:
@@ -1038,7 +1038,7 @@ job_setoptions({job}, {options})			*job_setoptions()*
 		Can also be used as a |method|: >
 			GetJob()->job_setoptions(options)
 <
-		Return type: |Number|
+		Return type: void
 
 
 job_start({command} [, {options}])			*job_start()*

--- a/runtime/doc/popup.txt
+++ b/runtime/doc/popup.txt
@@ -254,7 +254,7 @@ popup_clear([{force}])
 		when it is the current window.  If a terminal is running in a
 		popup it is killed.
 
-		Return type: |Number|
+		Return type: void
 
 
 popup_close({id} [, {result}])				*popup_close()*
@@ -269,7 +269,7 @@ popup_close({id} [, {result}])				*popup_close()*
 		Can also be used as a |method|: >
 			GetPopup()->popup_close()
 <
-		Return type: |Number|
+		Return type: void
 
 
 popup_create({what}, {options})				*popup_create()*
@@ -471,7 +471,7 @@ popup_hide({id})						*popup_hide()*
 		Can also be used as a |method|: >
 			GetPopup()->popup_hide()
 <
-		Return type: |Number|
+		Return type: void
 
 
 popup_list()						 *popup_list()*
@@ -542,7 +542,7 @@ popup_move({id}, {options})					*popup_move()*
 		Can also be used as a |method|: >
 			GetPopup()->popup_move(options)
 <
-		Return type: |Number|
+		Return type: void
 
 
 popup_notification({what}, {options})			 *popup_notification()*
@@ -624,7 +624,7 @@ popup_setoptions({id}, {options})			*popup_setoptions()*
 		Can also be used as a |method|: >
 			GetPopup()->popup_setoptions(options)
 <
-		Return type: |Number|
+		Return type: void
 
 
 popup_settext({id}, {text})				*popup_settext()*
@@ -636,7 +636,7 @@ popup_settext({id}, {text})				*popup_settext()*
 		Can also be used as a |method|: >
 			GetPopup()->popup_settext('hello')
 <
-		Return type: |Number|
+		Return type: void
 
 
 popup_show({id})						*popup_show()*

--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -596,7 +596,7 @@ term_dumpwrite({buf}, {filename} [, {options}])		*term_dumpwrite()*
 		name: >
 			GetFilename()->term_dumpwrite(bufnr)
 <
-		Return type: |Number|
+		Return type: void
 
 
 term_getaltscreen({buf})				*term_getaltscreen()*
@@ -817,7 +817,7 @@ term_sendkeys({buf}, {keys})				*term_sendkeys()*
 		Can also be used as a |method|: >
 			GetBufnr()->term_sendkeys(keys)
 <
-		Return type: |Number|
+		Return type: void
 
 
 term_setansicolors({buf}, {colors})			*term_setansicolors()*
@@ -852,7 +852,7 @@ term_setansicolors({buf}, {colors})			*term_setansicolors()*
 		Can also be used as a |method|: >
 			GetBufnr()->term_setansicolors(colors)
 <
-		Return type: |Number|
+		Return type: void
 
 		{only available with GUI enabled and/or the |+termguicolors|
 		feature}
@@ -870,7 +870,7 @@ term_setapi({buf}, {expr})				*term_setapi()*
 		When used as a method the base is used for {buf}: >
 			GetBufnr()->term_setapi({expr})
 <
-		Return type: |Number|
+		Return type: void
 
 
 term_setkill({buf}, {how})				*term_setkill()*
@@ -888,7 +888,7 @@ term_setkill({buf}, {how})				*term_setkill()*
 		Can also be used as a |method|: >
 			GetBufnr()->term_setkill(how)
 <
-		Return type: |Number|
+		Return type: void
 
 
 term_setrestore({buf}, {command})			*term_setrestore()*
@@ -903,7 +903,7 @@ term_setrestore({buf}, {command})			*term_setrestore()*
 		Can also be used as a |method|: >
 			GetBufnr()->term_setrestore(command)
 <
-		Return type: |Number|
+		Return type: void
 
 
 term_setsize({buf}, {rows}, {cols})		*term_setsize()* *E955*
@@ -919,7 +919,7 @@ term_setsize({buf}, {rows}, {cols})		*term_setsize()* *E955*
 		Can also be used as a |method|: >
 			GetBufnr()->term_setsize(rows, cols)
 <
-		Return type: |Number|
+		Return type: void
 
 
 term_start({cmd} [, {options}])			*term_start()*
@@ -1027,7 +1027,7 @@ term_wait({buf} [, {time}])					*term_wait()*
 		Can also be used as a |method|: >
 			GetBufnr()->term_wait()
 <
-		Return type: |Number|
+		Return type: void
 
 ==============================================================================
 3. Terminal communication			 *terminal-communication*

--- a/runtime/doc/testing.txt
+++ b/runtime/doc/testing.txt
@@ -46,14 +46,14 @@ test_alloc_fail({id}, {countdown}, {repeat})		*test_alloc_fail()*
 		Can also be used as a |method|: >
 			GetAllocId()->test_alloc_fail()
 <
-		Return type: |Number|
+		Return type: void
 
 
 test_autochdir()					*test_autochdir()*
 		Set a flag to enable the effect of 'autochdir' before Vim
 		startup has finished.
 
-		Return type: |Number|
+		Return type: void
 
 
 test_feedinput({string})				*test_feedinput()*
@@ -64,7 +64,7 @@ test_feedinput({string})				*test_feedinput()*
 		Can also be used as a |method|: >
 			GetText()->test_feedinput()
 <
-		Return type: |Number|
+		Return type: void
 
 
 test_garbagecollect_now()			 *test_garbagecollect_now()*
@@ -75,13 +75,13 @@ test_garbagecollect_now()			 *test_garbagecollect_now()*
 		This will not work when called from a :def function, because
 		variables on the stack will be freed.
 
-		Return type: |Number|
+		Return type: void
 
 test_garbagecollect_soon()			 *test_garbagecollect_soon()*
 		Set the flag to call the garbagecollector as if in the main
 		loop.  Only to be used in tests.
 
-		Return type: |Number|
+		Return type: void
 
 test_getvalue({name})					*test_getvalue()*
 		Get the value of an internal variable.  These values for
@@ -237,7 +237,7 @@ test_ignore_error({expr})			 *test_ignore_error()*
 		Can also be used as a |method|: >
 			GetErrorText()->test_ignore_error()
 <
-		Return type: |Number|
+		Return type: void
 
 test_mswin_event({event}, {args})		*test_mswin_event()*
 		Generate a low-level MS-Windows {event} with arguments {args}
@@ -381,7 +381,7 @@ test_option_not_set({name})				*test_option_not_set()*
 		Can also be used as a |method|: >
 			GetOptionName()->test_option_not_set()
 <
-		Return type: |Number|
+		Return type: void
 
 test_override({name}, {val})				*test_override()*
 		Overrides certain parts of Vim's internal processing to be
@@ -438,7 +438,7 @@ test_override({name}, {val})				*test_override()*
 <		Can also be used as a |method|: >
 			GetOverrideVal()-> test_override('starting')
 <
-		Return type: |Number|
+		Return type: void
 
 test_refcount({expr})					*test_refcount()*
 		Return the reference count of {expr}.  When {expr} is of a
@@ -457,7 +457,7 @@ test_setmouse({row}, {col})				*test_setmouse()*
 			call test_setmouse(4, 20)
 			call feedkeys("\<LeftMouse>", "xt")
 <
-		Return type: |Number|
+		Return type: void
 
 
 test_settime({expr})					*test_settime()*
@@ -472,13 +472,13 @@ test_settime({expr})					*test_settime()*
 		Can also be used as a |method|: >
 			GetTime()->test_settime()
 <
-		Return type: |Number|
+		Return type: void
 
 test_srand_seed([{seed}])				*test_srand_seed()*
 		When {seed} is given this sets the seed value used by
 		`srand()`.  When omitted the test seed is removed.
 
-		Return type: |Number|
+		Return type: void
 
 test_unknown()						*test_unknown()*
 		Return a value with unknown type.  Only useful for testing.

--- a/runtime/doc/textprop.txt
+++ b/runtime/doc/textprop.txt
@@ -270,6 +270,8 @@ prop_add_list({props}, [{item}, ...])			*prop_add_list()*
 <
 		Can also be used as a |method|: >
 			GetProp()->prop_add_list([[1, 1, 1, 2], [1, 4, 1, 8]])
+<
+		Return type: void
 
 
 prop_clear({lnum} [, {lnum-end} [, {props}]])		*prop_clear()*
@@ -283,7 +285,7 @@ prop_clear({lnum} [, {lnum-end} [, {props}]])		*prop_clear()*
 		Can also be used as a |method|: >
 			GetLnum()->prop_clear()
 <
-		Return type: |Number|
+		Return type: void
 
 
 prop_find({props} [, {direction}])			*prop_find()*
@@ -444,7 +446,7 @@ prop_type_add({name}, {props})		*prop_type_add()* *E969* *E970*
 		Can also be used as a |method|: >
 			GetPropName()->prop_type_add(props)
 <
-		Return type: |Number|
+		Return type: void
 
 
 prop_type_change({name}, {props})			*prop_type_change()*
@@ -455,7 +457,7 @@ prop_type_change({name}, {props})			*prop_type_change()*
 		Can also be used as a |method|: >
 			GetPropName()->prop_type_change(props)
 <
-		Return type: |Number|
+		Return type: void
 
 
 prop_type_delete({name} [, {props}])			*prop_type_delete()*
@@ -472,7 +474,7 @@ prop_type_delete({name} [, {props}])			*prop_type_delete()*
 		Can also be used as a |method|: >
 			GetPropName()->prop_type_delete()
 <
-		Return type: |Number|
+		Return type: void
 
 
 prop_type_get({name} [, {props}])			*prop_type_get()*

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -2184,7 +2184,7 @@ static const funcentry_T global_functions[] =
     {"environ",		0, 0, 0,	    NULL,
 			ret_dict_string,    f_environ},
     {"err_teapot",	0, 1, 0,	    NULL,
-			ret_number_bool,    f_err_teapot},
+			ret_void,	    f_err_teapot},
     {"escape",		2, 2, FEARG_1,	    arg2_string,
 			ret_string,	    f_escape},
     {"eval",		1, 1, FEARG_1,	    arg1_string,


### PR DESCRIPTION
- Fix summary table in builtin.txt: feedkeys, foreground, setcharsearch, term_wait, test_void, wildtrigger, ch_sendraw from non-none to none; listener_remove and prop_add from none to Number
- Fix err_teapot in evalfunc.c: ret_number_bool to ret_void
- Fix "Return type:" in detailed doc sections (64 functions across builtin.txt, channel.txt, terminal.txt, popup.txt, testing.txt, textprop.txt) from wrong types to void
- Add missing "Return type: void" for prompt_setcallback and prop_add_list

Related: https://github.com/vim/vim/pull/19912#discussion_r3036277259