### PR TITLE
tests: test for 9.2.0285 doesn't always fail without the fix

### DIFF
--- a/src/testdir/test_syntax.vim
+++ b/src/testdir/test_syntax.vim
@@ -997,9 +997,9 @@ func Test_syn_sync_grouphere_shorter_next_line()
       bar
     fi
   END
-  let lines = ['a']->repeat(50) + lines + ['a']->repeat(28 + winheight(0))
+  let lines = ['a']->repeat(50) + lines + ['a']->repeat(48)
 
-  new
+  20new
   call setline(1, lines)
   syn region shIf transparent
         \ start="\<if\_s" skip=+-fi\>+ end="\<;\_s*then\>" end="\<fi\>"


### PR DESCRIPTION
Problem:  When the terminal is very large, test for 9.2.0285 doesn't
          trigger an ASAN error without the fix.
Solution: Use a window with fixed height.
