### PR TITLE
tests: zip plugin tests don't check for warning message properly

### DIFF
--- a/src/testdir/test_plugin_zip.vim
+++ b/src/testdir/test_plugin_zip.vim
@@ -257,6 +257,7 @@ def g:Test_zip_fname_evil_path()
   # needed for writing the zip file
   CheckExecutable zip
 
+  messages clear
   CopyZipFile("evil.zip")
   defer delete("X.zip")
   e X.zip
@@ -280,6 +281,7 @@ def g:Test_zip_fname_evil_path2()
   # needed for writing the zip file
   CheckExecutable zip
 
+  messages clear
   CopyZipFile("evil.zip")
   defer delete("X.zip")
   e X.zip
@@ -302,6 +304,7 @@ def g:Test_zip_fname_evil_path3()
   # needed for writing the zip file
   CheckExecutable zip
 
+  messages clear
   CopyZipFile("evil.zip")
   defer delete("X.zip")
   e X.zip


### PR DESCRIPTION
Problem:  zip plugin tests may match messages from previous test cases
          when checking for warning message.
Solution: Clear messages at the start of these tests.
