### PR TITLE
runtime(vim9): Fix dist#vim9#Open() spaced paths and SIGPIPE crashes

### DIFF
--- a/runtime/autoload/dist/vim9.vim
+++ b/runtime/autoload/dist/vim9.vim
@@ -62,7 +62,7 @@ if has('unix')
     export def Launch(args: string)
       # Use job_start, because using !xdg-open is known not to work with zsh
       # ignore signals on exit
-      job_start(split(args), {'stoponexit': ''})
+      job_start(['sh', '-c', args], {'stoponexit': '', 'in_io': 'null', 'out_io': 'null', 'err_io': 'null'})
     enddef
   endif
 elseif has('win32')
@@ -139,13 +139,7 @@ export def Open(file: string)
     setlocal shell&
     defer setbufvar('%', '&shell', shell)
   endif
-  if has('unix') && !has('win32unix') && !exists('$WSL_DISTRO_NAME')
-    # Linux: using job_start, so do not use shellescape.
-    Launch($"{Viewer()} {file}")
-  else
-    # Windows/WSL/Cygwin: NEEDS shellescape because Launch uses '!'
-    Launch($"{Viewer()} {shellescape(file, 1)}")
-  endif
+  Launch($"{Viewer()} {shellescape(file, 1)}")
 enddef
 
 # Uncomment this line to check for compilation errors early


### PR DESCRIPTION
Problem:    dist#vim9#Open() fails to open files with spaces on Linux
            because Launch() splits the command string. Also,
            background GUI viewers (e.g., xdg-open) crash with SIGPIPE
            when Vim destroys the default job_start() IO pipes.

Solution:   Use job_start() with 'sh -c' to let the POSIX shell parse
            the shellescaped quotes safely. Set 'in_io', 'out_io', and
            'err_io' to 'null' to completely detach the background
            process and prevent pipe crashes. Unify the Launch()
            execution block across all operating systems.

closes: #19916