### PR TITLE
Fix bug in zstd archive extraction.

### DIFF
--- a/runtime/autoload/tar.vim
+++ b/runtime/autoload/tar.vim
@@ -687,7 +687,7 @@ fun! tar#Extract()
    endif
 
   elseif filereadable(tarbase.".tzst")
-   let extractcmd= substitute(extractcmd,"-","--zstd","")
+   let extractcmd= substitute(extractcmd,"-","--zstd -","")
    call system(extractcmd." ".shellescape(tarbase).".tzst ".shellescape(fname))
    if v:shell_error != 0
     call s:Msg('tar#Extract', 'error', $"{extractcmd} {tarbase}.tzst {fname}: failed!")
@@ -696,7 +696,7 @@ fun! tar#Extract()
    endif
 
   elseif filereadable(tarbase.".tar.zst")
-   let extractcmd= substitute(extractcmd,"-","--zstd","")
+   let extractcmd= substitute(extractcmd,"-","--zstd -","")
    call system(extractcmd." ".shellescape(tarbase).".tar.zst ".shellescape(fname))
    if v:shell_error != 0
     call s:Msg('tar#Extract', 'error', $"{extractcmd} {tarbase}.tar.zst {fname}: failed!")

--- a/runtime/autoload/tar.vim
+++ b/runtime/autoload/tar.vim
@@ -611,117 +611,120 @@ fun! tar#Extract()
    return
   endif
 
-  let tarball = expand("%")
-  let tarbase = substitute(tarball,'\..*$','','')
-
   let extractcmd= s:WinPath(g:tar_extractcmd)
-  if filereadable(tarbase.".tar")
-   call system(extractcmd." ".shellescape(tarbase).".tar ".shellescape(fname))
+  let tarball = expand("%")
+  if !filereadable(tarball)
+   let &report= repkeep
+   return
+  endif
+
+  if tarball =~# "\.tar$"
+   call system(extractcmd." ".shellescape(tarball)." ".shellescape(fname))
    if v:shell_error != 0
-    call s:Msg('tar#Extract', 'error', $"{extractcmd} {tarbase}.tar {fname}: failed!")
+    call s:Msg('tar#Extract', 'error', $"{extractcmd} {tarball} {fname}: failed!")
    else
     echo "***note*** successfully extracted ". fname
    endif
 
-  elseif filereadable(tarbase.".tgz")
+  elseif tarball =~# "\.tgz$"
    let extractcmd= substitute(extractcmd,"-","-z","")
-   call system(extractcmd." ".shellescape(tarbase).".tgz ".shellescape(fname))
+   call system(extractcmd." ".shellescape(tarball)." ".shellescape(fname))
    if v:shell_error != 0
-    call s:Msg('tar#Extract', 'error', $"{extractcmd} {tarbase}.tgz {fname}: failed!")
+    call s:Msg('tar#Extract', 'error', $"{extractcmd} {tarball} {fname}: failed!")
    else
     echo "***note*** successfully extracted ".fname
    endif
 
-  elseif filereadable(tarbase.".tar.gz")
+  elseif tarball =~# "\.tar\.gz$"
    let extractcmd= substitute(extractcmd,"-","-z","")
-   call system(extractcmd." ".shellescape(tarbase).".tar.gz ".shellescape(fname))
+   call system(extractcmd." ".shellescape(tarball)." ".shellescape(fname))
    if v:shell_error != 0
-    call s:Msg('tar#Extract', 'error', $"{extractcmd} {tarbase}.tar.gz {fname}: failed!")
+    call s:Msg('tar#Extract', 'error', $"{extractcmd} {tarball} {fname}: failed!")
    else
     echo "***note*** successfully extracted ".fname
    endif
 
-  elseif filereadable(tarbase.".tbz")
+  elseif tarball =~# "\.tbz$"
    let extractcmd= substitute(extractcmd,"-","-j","")
-   call system(extractcmd." ".shellescape(tarbase).".tbz ".shellescape(fname))
+   call system(extractcmd." ".shellescape(tarball)." ".shellescape(fname))
    if v:shell_error != 0
-    call s:Msg('tar#Extract', 'error', $"{extractcmd} {tarbase}.tbz {fname}: failed!")
+    call s:Msg('tar#Extract', 'error', $"{extractcmd} {tarball} {fname}: failed!")
    else
     echo "***note*** successfully extracted ".fname
    endif
 
-  elseif filereadable(tarbase.".tar.bz2")
+  elseif tarball =~# "\.tar\.bz2$"
    let extractcmd= substitute(extractcmd,"-","-j","")
-   call system(extractcmd." ".shellescape(tarbase).".tar.bz2 ".shellescape(fname))
+   call system(extractcmd." ".shellescape(tarball)." ".shellescape(fname))
    if v:shell_error != 0
-    call s:Msg('tar#Extract', 'error', $"{extractcmd} {tarbase}.tar.bz2 {fname}: failed!")
+    call s:Msg('tar#Extract', 'error', $"{extractcmd} {tarball} {fname}: failed!")
    else
     echo "***note*** successfully extracted ".fname
    endif
 
-  elseif filereadable(tarbase.".tar.bz3")
+  elseif tarball =~# "\.tar\.bz3$"
    let extractcmd= substitute(extractcmd,"-","-j","")
-   call system(extractcmd." ".shellescape(tarbase).".tar.bz3 ".shellescape(fname))
+   call system(extractcmd." ".shellescape(tarball)." ".shellescape(fname))
    if v:shell_error != 0
-    call s:Msg('tar#Extract', 'error', $"{extractcmd} {tarbase}.tar.bz3 {fname}: failed!")
+    call s:Msg('tar#Extract', 'error', $"{extractcmd} {tarball} {fname}: failed!")
    else
     echo "***note*** successfully extracted ".fname
    endif
 
-  elseif filereadable(tarbase.".txz")
+  elseif tarball =~# "\.txz$"
    let extractcmd= substitute(extractcmd,"-","-J","")
-   call system(extractcmd." ".shellescape(tarbase).".txz ".shellescape(fname))
+   call system(extractcmd." ".shellescape(tarball)." ".shellescape(fname))
    if v:shell_error != 0
-    call s:Msg('tar#Extract', 'error', $"{extractcmd} {tarbase}.txz {fname}: failed!")
+    call s:Msg('tar#Extract', 'error', $"{extractcmd} {tarball} {fname}: failed!")
    else
     echo "***note*** successfully extracted ".fname
    endif
 
-  elseif filereadable(tarbase.".tar.xz")
+  elseif tarball =~# "\.tar\.xz$"
    let extractcmd= substitute(extractcmd,"-","-J","")
-   call system(extractcmd." ".shellescape(tarbase).".tar.xz ".shellescape(fname))
+   call system(extractcmd." ".shellescape(tarball)." ".shellescape(fname))
    if v:shell_error != 0
-    call s:Msg('tar#Extract', 'error', $"{extractcmd} {tarbase}.tar.xz {fname}: failed!")
+    call s:Msg('tar#Extract', 'error', $"{extractcmd} {tarball} {fname}: failed!")
    else
     echo "***note*** successfully extracted ".fname
    endif
 
-  elseif filereadable(tarbase.".tzst")
+  elseif tarball =~# "\.tzst$"
    let extractcmd= substitute(extractcmd,"-","--zstd -","")
-   call system(extractcmd." ".shellescape(tarbase).".tzst ".shellescape(fname))
+   call system(extractcmd." ".shellescape(tarball)." ".shellescape(fname))
    if v:shell_error != 0
-    call s:Msg('tar#Extract', 'error', $"{extractcmd} {tarbase}.tzst {fname}: failed!")
+    call s:Msg('tar#Extract', 'error', $"{extractcmd} {tarball} {fname}: failed!")
    else
     echo "***note*** successfully extracted ".fname
    endif
 
-  elseif filereadable(tarbase.".tar.zst")
+  elseif tarball =~# "\.tar\.zst$"
    let extractcmd= substitute(extractcmd,"-","--zstd -","")
-   call system(extractcmd." ".shellescape(tarbase).".tar.zst ".shellescape(fname))
+   call system(extractcmd." ".shellescape(tarball)." ".shellescape(fname))
    if v:shell_error != 0
-    call s:Msg('tar#Extract', 'error', $"{extractcmd} {tarbase}.tar.zst {fname}: failed!")
+    call s:Msg('tar#Extract', 'error', $"{extractcmd} {tarball} {fname}: failed!")
    else
     echo "***note*** successfully extracted ".fname
    endif
 
-  elseif filereadable(tarbase.".tlz4")
+  elseif tarball =~# "\.tlz4$"
    if has("linux")
     let extractcmd= substitute(extractcmd,"-","-I lz4 -","")
    endif
-   call system(extractcmd." ".shellescape(tarbase).".tlz4 ".shellescape(fname))
+   call system(extractcmd." ".shellescape(tarball)." ".shellescape(fname))
    if v:shell_error != 0
-    call s:Msg('tar#Extract', 'error', $"{extractcmd} {tarbase}.tlz4 {fname}: failed!")
+    call s:Msg('tar#Extract', 'error', $"{extractcmd} {tarball} {fname}: failed!")
    else
     echo "***note*** successfully extracted ".fname
    endif
 
-  elseif filereadable(tarbase.".tar.lz4")
+  elseif tarball =~# "\.tar\.lz4$"
    if has("linux")
     let extractcmd= substitute(extractcmd,"-","-I lz4 -","")
    endif
-   call system(extractcmd." ".shellescape(tarbase).".tar.lz4 ".shellescape(fname))
+   call system(extractcmd." ".shellescape(tarball)." ".shellescape(fname))
    if v:shell_error != 0
-    call s:Msg('tar#Extract', 'error', $"{extractcmd} {tarbase}.tar.lz4 {fname}: failed!")
+    call s:Msg('tar#Extract', 'error', $"{extractcmd} {tarball} {fname}: failed!")
    else
     echo "***note*** successfully extracted ".fname
    endif

--- a/src/testdir/test_plugin_tar.vim
+++ b/src/testdir/test_plugin_tar.vim
@@ -263,3 +263,53 @@ def g:Test_extraction()
     bw!
   endfor
 enddef
+
+def g:Test_extract_with_dotted_dir()
+  delete('X.txt')
+  writefile(['when they kiss they spit white noise'], 'X.txt')
+
+  var dirname = tempname()
+  mkdir(dirname, 'R')
+  dirname = dirname .. '/foo.bar'
+  mkdir(dirname, 'R')
+  var tarpath = dirname .. '/Xarchive.tar.gz'
+  system('tar -czf ' .. tarpath .. ' X.txt')
+  assert_true(filereadable(tarpath))
+  assert_equal(0, v:shell_error)
+
+  delete('X.txt')
+  defer delete(tarpath)
+
+  execute 'e ' .. tarpath
+  assert_match('X.txt', getline(5))
+  :5
+  normal x
+  assert_true(filereadable('X.txt'))
+  assert_equal(['when they kiss they spit white noise'], readfile('X.txt'))
+  delete('X.txt')
+  bw!
+enddef
+
+def g:Test_extract_with_dotted_filename()
+  delete('X.txt')
+  writefile(['holiday inn'], 'X.txt')
+
+  var dirname = tempname()
+  mkdir(dirname, 'R')
+  var tarpath = dirname .. '/Xarchive.foo.tar.gz'
+  system('tar -czf ' .. tarpath .. ' X.txt')
+  assert_true(filereadable(tarpath))
+  assert_equal(0, v:shell_error)
+
+  delete('X.txt')
+  defer delete(tarpath)
+
+  execute 'e ' .. tarpath
+  assert_match('X.txt', getline(5))
+  :5
+  normal x
+  assert_true(filereadable('X.txt'))
+  assert_equal(['holiday inn'], readfile('X.txt'))
+  delete('X.txt')
+  bw!
+enddef

--- a/src/testdir/test_plugin_tar.vim
+++ b/src/testdir/test_plugin_tar.vim
@@ -148,56 +148,118 @@ def g:Test_tar_path_traversal_with_nowrapscan()
   bw!
 enddef
 
-def g:Test_tar_lz4_extract()
-  CheckExecutable lz4
-
-  delete('X.txt')
-  delete('Xarchive.tar')
-  delete('Xarchive.tar.lz4')
-  call writefile(['hello'], 'X.txt')
-  call system('tar -cf Xarchive.tar X.txt')
+def CreateTar(archivename: string, content: string, outputdir: string)
+  var tempdir = tempname()
+  mkdir(tempdir, 'R')
+  call writefile([content], tempdir .. '/X.txt')
+  assert_true(filereadable(tempdir .. '/X.txt'))
+  call system('tar -C ' .. tempdir .. ' -cf ' .. outputdir .. '/' .. archivename .. ' X.txt')
   assert_equal(0, v:shell_error)
-
-  call system('lz4 -z Xarchive.tar Xarchive.tar.lz4')
-  assert_equal(0, v:shell_error)
-
-  delete('X.txt')
-  delete('Xarchive.tar')
-  defer delete('Xarchive.tar.lz4')
-
-  e Xarchive.tar.lz4
-  assert_match('X.txt', getline(5))
-  :5
-  normal x
-  assert_true(filereadable('X.txt'))
-  assert_equal(['hello'], readfile('X.txt'))
-  delete('X.txt')
-  bw!
 enddef
 
-def g:Test_tlz4_extract()
-  CheckExecutable lz4
-
-  delete('X.txt')
-  delete('Xarchive.tar')
-  delete('Xarchive.tlz4')
-  call writefile(['goodbye'], 'X.txt')
-  call system('tar -cf Xarchive.tar X.txt')
+def CreateTgz(archivename: string, content: string, outputdir: string)
+  var tempdir = tempname()
+  mkdir(tempdir, 'R')
+  call writefile([content], tempdir .. '/X.txt')
+  assert_true(filereadable(tempdir .. '/X.txt'))
+  call system('tar -C ' .. tempdir .. ' -czf ' .. outputdir .. '/' .. archivename .. ' X.txt')
   assert_equal(0, v:shell_error)
+enddef
 
-  call system('lz4 -z Xarchive.tar Xarchive.tlz4')
+def CreateTbz(archivename: string, content: string, outputdir: string)
+  var tempdir = tempname()
+  mkdir(tempdir, 'R')
+  call writefile([content], tempdir .. '/X.txt')
+  assert_true(filereadable(tempdir .. '/X.txt'))
+  call system('tar -C ' .. tempdir .. ' -cjf ' .. outputdir .. '/' .. archivename .. ' X.txt')
   assert_equal(0, v:shell_error)
+enddef
 
-  delete('X.txt')
-  delete('Xarchive.tar')
-  defer delete('Xarchive.tlz4')
+def CreateTxz(archivename: string, content: string, outputdir: string)
+  var tempdir = tempname()
+  mkdir(tempdir, 'R')
+  call writefile([content], tempdir .. '/X.txt')
+  assert_true(filereadable(tempdir .. '/X.txt'))
+  call system('tar -C ' .. tempdir .. ' -cJf ' .. outputdir .. '/' .. archivename .. ' X.txt')
+  assert_equal(0, v:shell_error)
+enddef
 
-  e Xarchive.tlz4
-  assert_match('X.txt', getline(5))
-  :5
-  normal x
-  assert_true(filereadable('X.txt'))
-  assert_equal(['goodbye'], readfile('X.txt'))
-  delete('X.txt')
-  bw!
+def CreateTzst(archivename: string, content: string, outputdir: string)
+  var tempdir = tempname()
+  mkdir(tempdir, 'R')
+  call writefile([content], tempdir .. '/X.txt')
+  assert_true(filereadable(tempdir .. '/X.txt'))
+  call system('tar --zstd -C ' .. tempdir .. ' -cf ' .. outputdir .. '/' .. archivename .. ' X.txt')
+  assert_equal(0, v:shell_error)
+enddef
+
+def CreateTlz4(archivename: string, content: string, outputdir: string)
+  var tempdir = tempname()
+  mkdir(tempdir, 'R')
+  call writefile([content], tempdir .. '/X.txt')
+  assert_true(filereadable(tempdir .. '/X.txt'))
+  call system('tar -C ' .. tempdir .. ' -cf ' .. tempdir .. '/Xarchive.tar X.txt')
+  assert_equal(0, v:shell_error)
+  assert_true(filereadable(tempdir .. '/Xarchive.tar'))
+  call system('lz4 -z ' .. tempdir .. '/Xarchive.tar ' .. outputdir .. '/' .. archivename)
+  assert_equal(0, v:shell_error)
+enddef
+
+# XXX: Add test for .tar.bz3
+def g:Test_extraction()
+  var control = [
+    {create: CreateTar,
+     archive: 'Xarchive.tar'},
+    {create: CreateTgz,
+     archive: 'Xarchive.tgz'},
+    {create: CreateTgz,
+     archive: 'Xarchive.tar.gz'},
+    {create: CreateTbz,
+     archive: 'Xarchive.tbz'},
+    {create: CreateTbz,
+     archive: 'Xarchive.tar.bz2'},
+    {create: CreateTxz,
+     archive: 'Xarchive.txz'},
+    {create: CreateTxz,
+     archive: 'Xarchive.tar.xz'},
+  ]
+
+  if executable('lz4') == 1
+    control->add({
+      create: CreateTlz4,
+      archive: 'Xarchive.tar.lz4'
+    })
+    control->add({
+      create: CreateTlz4,
+      archive: 'Xarchive.tlz4'
+    })
+  endif
+  if executable('zstd') == 1
+    control->add({
+      create: CreateTzst,
+      archive: 'Xarchive.tar.zst'
+    })
+    control->add({
+      create: CreateTzst,
+      archive: 'Xarchive.tzst'
+    })
+  endif
+
+  for c in control
+    var dir = tempname()
+    mkdir(dir, 'R')
+    call(c.create, [c.archive, 'hello', dir])
+
+    delete('X.txt')
+    execute 'edit ' .. dir .. '/' .. c.archive
+    assert_match('X.txt', getline(5), 'line 5 wrong in archive: ' .. c.archive)
+    :5
+    normal x
+    assert_equal(0, v:shell_error, 'vshell error not 0')
+    assert_true(filereadable('X.txt'), 'X.txt not readable for archive: ' .. c.archive)
+    assert_equal(['hello'], readfile('X.txt'), 'X.txt wrong contents for archive: ' .. c.archive)
+    delete('X.txt')
+    delete(dir .. '/' .. c.archive)
+    bw!
+  endfor
 enddef


### PR DESCRIPTION
There are two commits in this PR.  I think they should remain separate
to make things clear in posterity.  Both fix issues with the extraction logic in the tar plugin.

(1) The tar.vim plugin allows vim to read and manipulate zstd archives,
but it had a bug that caused extraction attempts to fail. Specifically,
if the archive has a .tar.zst or .tzst extension, then the code was
generating invalid extraction commands that looked like this:

  tar --zstdpxf foo.tar.zst foo

When they should be like this:

  tar --zstd -pxf foo.tar.zst foo

This patch changes the flag manipulation logic so that --zstd isn't glued to pxf.

(2)     Make tar extraction work when paths have dots.

    tar#Extract was getting the extensionless basename by
    stripping away everything starting with the leftmost
    dot.  So if a directory had a dot or the file had an
    'extra' dot then the code did the wrong thing.  For
    example, if it was given:

      /tmp/foo.bar/baz.tar.gz

    Then it would treat /tmp/foo as the extensionless
    basename, but it actually should have grabbed:

      /tmp/foo.bar/baz

    This patch fixes the issue by instead looking at the
    rightmost dot(s).
