### PR TITLE
0x9b byte not unescaped in <Cmd> mapping

### DIFF
--- a/src/getchar.c
+++ b/src/getchar.c
@@ -4283,6 +4283,13 @@ getcmdkeycmd(
 	    // to a single Esc here.
 	    if (c1 == K_ESC)
 		c1 = ESC;
+
+#ifdef FEAT_GUI
+	    // Translate K_CSI to CSI.  The special key is only used to
+	    // avoid it being recognized as the start of a special key.
+	    if (c1 == K_CSI)
+		c1 = CSI;
+#endif
 	}
 
 	if (got_int)

--- a/src/testdir/test_mapping.vim
+++ b/src/testdir/test_mapping.vim
@@ -1124,7 +1124,11 @@ func Test_map_cmdkey()
   call setline(1, ['some short lines', 'of test text'])
   call feedkeys(":bar\<F2>x\<C-B>\"\r", 'xt')
   call assert_equal('"barx', @:)
-  unmap! <F2>
+
+  " test for chars with 0x80 or 0x9b bytes
+  map <F2> <Cmd>let x = '洛固四最倒倀'<CR>
+  call feedkeys("\<F2>", 'xt')
+  call assert_equal('洛固四最倒倀', x)
 
   " test for calling a <SID> function
   let lines =<< trim END
@@ -1137,7 +1141,10 @@ func Test_map_cmdkey()
   source Xscript
   call feedkeys("\<F2>", 'xt')
   call assert_equal(32, g:x)
+  unlet g:x
 
+  unmap <F2>
+  unmap! <F2>
   unmap <F3>
   unmap! <F3>
   %bw!


### PR DESCRIPTION
Problem:  0x9b byte not unescaped in \<Cmd\> mapping.
Solution: Translate K_CSI to CSI like what is done in vgetc().

fixes: #19936
