### PR TITLE
runtime(help): support highlighting groups in translated syntax doc

### DIFF
--- a/runtime/syntax/help.vim
+++ b/runtime/syntax/help.vim
@@ -306,7 +306,7 @@ hi def link helpDiffAdded	Added
 hi def link helpDiffChanged	Changed
 hi def link helpDiffRemoved	Removed
 
-if has('textprop') && expand('%:p') =~ '[/\\]doc[/\\]syntax.txt'
+if has('textprop') && expand('%:p') =~? '[/\\]doc[/\\]syntax.\(txt\|\a\ax\)$'
   " highlight groups with their respective color
   import 'dist/vimhelp.vim'
   call vimhelp.HighlightGroups()


### PR DESCRIPTION
The pattern for detecting `*/doc/syntax.txt` was not matching translated documents like `*/doc/syntax.jax`.
Also use case-insensitive matching for case-insensitive file systems.