### PR TITLE
tests: some patterns in tar and zip plugin tests not strict enough

### DIFF
--- a/src/testdir/test_plugin_tar.vim
+++ b/src/testdir/test_plugin_tar.vim
@@ -22,8 +22,8 @@ def g:Test_tar_basic()
   assert_match('^" Browsing tarfile .*/X.tar', getline(2))
   assert_match('^" Select a file with cursor and press ENTER, "x" to extract a file', getline(3))
   assert_match('^$', getline(4))
-  assert_match('testtar/', getline(5))
-  assert_match('testtar/file1.txt', getline(6))
+  assert_equal('testtar/', getline(5))
+  assert_equal('testtar/file1.txt', getline(6))
 
   ### Check ENTER on header
   :1
@@ -78,7 +78,7 @@ def g:Test_tar_evil()
   assert_match('^" Select a file with cursor and press ENTER, "x" to extract a file', getline(3))
   assert_match('^" Note: Path Traversal Attack detected', getline(4))
   assert_match('^$', getline(5))
-  assert_match('/etc/ax-pwn', getline(6))
+  assert_equal('/etc/ax-pwn', getline(6))
 
   ### Check ENTER on header
   :1
@@ -141,7 +141,7 @@ def g:Test_tar_path_traversal_with_nowrapscan()
   assert_match('^" Select a file with cursor and press ENTER, "x" to extract a file', getline(3))
   assert_match('^" Note: Path Traversal Attack detected', getline(4))
   assert_match('^$', getline(5))
-  assert_match('/etc/ax-pwn', getline(6))
+  assert_equal('/etc/ax-pwn', getline(6))
 
   assert_equal(1, b:leading_slash)
 
@@ -252,7 +252,7 @@ def g:Test_extraction()
 
     delete('X.txt')
     execute 'edit ' .. dir .. '/' .. c.archive
-    assert_match('X.txt', getline(5), 'line 5 wrong in archive: ' .. c.archive)
+    assert_equal('X.txt', getline(5), 'line 5 wrong in archive: ' .. c.archive)
     :5
     normal x
     assert_equal(0, v:shell_error, 'vshell error not 0')
@@ -281,7 +281,7 @@ def g:Test_extract_with_dotted_dir()
   defer delete(tarpath)
 
   execute 'e ' .. tarpath
-  assert_match('X.txt', getline(5))
+  assert_equal('X.txt', getline(5))
   :5
   normal x
   assert_true(filereadable('X.txt'))
@@ -305,7 +305,7 @@ def g:Test_extract_with_dotted_filename()
   defer delete(tarpath)
 
   execute 'e ' .. tarpath
-  assert_match('X.txt', getline(5))
+  assert_equal('X.txt', getline(5))
   :5
   normal x
   assert_true(filereadable('X.txt'))

--- a/src/testdir/test_plugin_zip.vim
+++ b/src/testdir/test_plugin_zip.vim
@@ -22,7 +22,7 @@ def g:Test_zip_basic()
 
   ### Check header
   assert_match('^" zip\.vim version v\d\+', getline(1))
-  assert_match('^" Browsing zipfile .*/X.zip', getline(2))
+  assert_match('^" Browsing zipfile .*/X\.zip', getline(2))
   assert_match('^" Select a file with cursor and press ENTER', getline(3))
   assert_match('^$', getline(4))
 
@@ -43,7 +43,7 @@ def g:Test_zip_basic()
   :1
   search('file.txt')
   exe ":normal \<cr>"
-  assert_match('zipfile://.*/X.zip::Xzip/file.txt', @%)
+  assert_match('zipfile://.*/X\.zip::Xzip/file\.txt', @%)
   assert_equal('one', getline(1))
 
   ### Check editing file
@@ -68,7 +68,7 @@ def g:Test_zip_basic()
   assert_true(filereadable("Xzip/file.txt"))
 
   ## Check not overwriting existing file
-  assert_match('<Xzip/file.txt> .* not overwriting!', execute("normal x"))
+  assert_match('<Xzip/file\.txt> .* not overwriting!', execute("normal x"))
 
   delete("Xzip", "rf")
 
@@ -118,7 +118,7 @@ def g:Test_zip_basic()
   ### Check when "zip" report failure
   if executable("false")
     g:zip_zipcmd = "false"
-    assert_match('sorry, unable to update .*/X.zip with Xzip/file.txt',
+    assert_match('sorry, unable to update .*/X\.zip with Xzip/file\.txt',
                   execute("write"))
   endif
   bw!|bw
@@ -189,7 +189,7 @@ def g:Test_zip_glob_fname()
   fname = 'a[a].txt'
   search('\V' .. fname)
   exe ":normal \<cr>"
-  assert_match('zipfile://.*/X.zip::zipglob/a\[a\].txt', @%)
+  assert_match('zipfile://.*/X\.zip::zipglob/a\[a\]\.txt', @%)
   assert_equal('a test file with []', getline(1))
   bw
 
@@ -198,7 +198,7 @@ def g:Test_zip_glob_fname()
   fname = 'a*.txt'
   search('\V' .. fname)
   exe ":normal \<cr>"
-  assert_match('zipfile://.*/X.zip::zipglob/a\*.txt', @%)
+  assert_match('zipfile://.*/X\.zip::zipglob/a\*\.txt', @%)
   assert_equal('a test file with a*', getline(1))
   bw
 
@@ -207,7 +207,7 @@ def g:Test_zip_glob_fname()
   fname = 'a?.txt'
   search('\V' .. fname)
   exe ":normal \<cr>"
-  assert_match('zipfile://.*/X.zip::zipglob/a?.txt', @%)
+  assert_match('zipfile://.*/X\.zip::zipglob/a?\.txt', @%)
   assert_equal('a test file with a?', getline(1))
   bw
 
@@ -216,7 +216,7 @@ def g:Test_zip_glob_fname()
   fname = 'a\.txt'
   search('\V' .. escape(fname, '\\'))
   exe ":normal \<cr>"
-  assert_match('zipfile://.*/X.zip::zipglob/a\\.txt', @%)
+  assert_match('zipfile://.*/X\.zip::zipglob/a\\\.txt', @%)
   assert_equal('a test file with a\', getline(1))
   bw
 
@@ -225,7 +225,7 @@ def g:Test_zip_glob_fname()
   fname = 'a\\.txt'
   search('\V' .. escape(fname, '\\'))
   exe ":normal \<cr>"
-  assert_match('zipfile://.*/X.zip::zipglob/a\\\\.txt', @%)
+  assert_match('zipfile://.*/X\.zip::zipglob/a\\\\\.txt', @%)
   assert_equal('a test file with a double \', getline(1))
   bw
 


### PR DESCRIPTION
Problem:  Some patterns in tar and zip plugin tests not strict enough.
Solution: Use assert_equal() for lines that should match exactly. Match
          a literal dot properly.
