### PR TITLE
Add out-of-memory check to register.c

### DIFF
--- a/src/register.c
+++ b/src/register.c
@@ -352,6 +352,16 @@ get_register(
 	    {
 		reg->y_array[i].string = vim_strnsave(y_current->y_array[i].string,
 					    y_current->y_array[i].length);
+		if (reg->y_array[i].string == NULL)
+		{
+		    // The allocation failed so clean up and exit
+		    while (--i >= 0)
+			vim_free(reg->y_array[i].string);
+		    vim_free(reg->y_array);
+		    vim_free(reg);
+		    return (void *)NULL;
+		}
+
 		reg->y_array[i].length = y_current->y_array[i].length;
 	    }
 	}


### PR DESCRIPTION
This PR adds a check for an out-of-memory condition to function `get_register()` in `register.c`.

If such a condition is detected, free all the allocated memory and exit.

Cheers
John