### PR TITLE
Fix invalid pointer cast in list_slice_or_index()

### DIFF
--- a/src/list.c
+++ b/src/list.c
@@ -1368,7 +1368,8 @@ list_slice_or_index(
     {
 	// copy the item to "var1" to avoid that freeing the list makes it
 	// invalid.
-	listitem_T *li = check_range_index_one(list, (long *)&n1, TRUE, TRUE);
+	long index = n1;
+	listitem_T *li = check_range_index_one(list, &index, TRUE, TRUE);
 	if (li == NULL)
 	    return FAIL;
 	copy_tv(&li->li_tv, &var1);


### PR DESCRIPTION
`check_range_index_one()` expects a `long *` parameter, but `n1` is a
`varnumber_T`. On big-endian platforms where long is not 64-bit, casting
the `varnumber_T *` to `long *` passes a pointer to the wrong bytes.

Use a local long variable and pass that pointer to `check_range_index_one()`.

Validated on 32-bit powerpc, s390x, and x86.

Closes: #19798