### PR TITLE
Wrap pum_redraw() in synchronized output to avoid flicker

### DIFF
--- a/src/popupmenu.c
+++ b/src/popupmenu.c
@@ -953,6 +953,10 @@ pum_redraw(void)
     // Use current window for highlight overrides when using 'winhighlight'
     override_success = push_highlight_overrides(curwin->w_hl, curwin->w_hl_len);
 
+    // Batch the underlying screen update and the pum drawing into a single
+    // synchronized output frame to avoid flicker.
+    term_set_sync_output(TERM_SYNC_OUTPUT_ENABLE);
+
     hlf_T	hlfsNorm[3];
     hlf_T	hlfsSel[3];
     // "word"/"abbr"
@@ -1187,6 +1191,8 @@ pum_redraw(void)
 
     if (override_success)
 	pop_highlight_overrides();
+
+    term_set_sync_output(TERM_SYNC_OUTPUT_DISABLE);
 }
 
 #if defined(FEAT_PROP_POPUP) && defined(FEAT_QUICKFIX)


### PR DESCRIPTION
pum_redraw() calls update_screen(0) internally, which flushes at its BSU/ESU boundary. The popup cells are drawn after that flush, so the terminal briefly shows the screen with the pum area cleared. Bracket pum_redraw() in TERM_SYNC_OUTPUT_ENABLE/DISABLE so the whole frame is delivered atomically.