### PR TITLE
feat(mouse): change Alt+click/drag to reset selection origin

### DIFF
--- a/runtime/doc/term.txt
+++ b/runtime/doc/term.txt
@@ -1067,7 +1067,8 @@ Normal Mode:
 event	      position	   selection	  change  action	~
 	       cursor			  window		~
 <S-LeftMouse>	yes	start or extend (1) no
-<A-LeftMouse>   yes start or extend blockw. no		      *<A-LeftMouse>*
+<A-LeftMouse>   yes	end		    no		      *<A-LeftMouse>*
+<A-LeftDrag>    yes start or extend blockw. no		      *<A-LeftDrag>*
 <RightMouse>	no	popup menu	    no
 
 Insert or Replace Mode:

--- a/src/mouse.c
+++ b/src/mouse.c
@@ -704,8 +704,7 @@ do_mouse(
 	    return FALSE;
 #endif
 	}
-	if (which_button == MOUSE_LEFT
-				&& (mod_mask & (MOD_MASK_SHIFT|MOD_MASK_ALT)))
+	if (which_button == MOUSE_LEFT && (mod_mask & MOD_MASK_SHIFT))
 	{
 	    which_button = MOUSE_RIGHT;
 	    mod_mask &= ~MOD_MASK_SHIFT;

--- a/src/testdir/test_termcodes.vim
+++ b/src/testdir/test_termcodes.vim
@@ -1042,22 +1042,47 @@ func Test_mouse_alt_leftclick()
   call WaitForResponses()
 
   new
-  call setline(1, 'one (two) three')
 
   for ttymouse_val in g:Ttymouse_values
     let msg = 'ttymouse=' .. ttymouse_val
     exe 'set ttymouse=' .. ttymouse_val
+    call setline(1, repeat([repeat('-', 7)], 7))
 
-    " Left click with the Alt modifier key should extend the selection in
-    " blockwise visual mode.
-    let @" = ''
-    call MouseLeftClick(1, 3)
-    call MouseLeftRelease(1, 3)
-    call MouseAltLeftClick(1, 11)
-    call MouseLeftRelease(1, 11)
+    " Left click with the Alt modifier key should not start blockwise visual
+    " mode without dragging.
+    call MouseAltLeftClick(1, 1)
+    call MouseLeftRelease(1, 1)
+    call assert_equal("n", mode(), msg)
+
+    " Left click and drag with the Alt modifier key should enter blockwise
+    " visual mode and expand new selection.
+    call MouseAltLeftClick(2, 2)
+    call MouseAltLeftDrag(5, 5)
+    call MouseLeftRelease(5, 5)
+    norm! r1gv
     call assert_equal("\<C-V>", mode(), msg)
-    normal! y
-    call assert_equal('e (two) t', @")
+    call assert_equal(['-------',
+          \            '-1111--',
+          \            '-1111--',
+          \            '-1111--',
+          \            '-1111--',
+          \            '-------',
+          \            '-------'], getline(1, '$'), msg)
+
+    " Left click and drag with the Alt modifier key in a new location should
+    " reset the selection anchor and not expand the existing selection.
+    call MouseAltLeftClick(6, 6)
+    call MouseAltLeftDrag(3, 3)
+    call MouseLeftRelease(3, 3)
+    norm! r2gv
+    call assert_equal("\<C-V>", mode(), msg)
+    call assert_equal(['-------',
+          \            '-1111--',
+          \            '-12222-',
+          \            '-12222-',
+          \            '-12222-',
+          \            '--2222-',
+          \            '-------'], getline(1, '$'), msg)
   endfor
 
   let &mouse = save_mouse

--- a/src/testdir/util/mouse.vim
+++ b/src/testdir/util/mouse.vim
@@ -265,6 +265,24 @@ func MouseLeftDrag(row, col)
   endif
 endfunc
 
+func MouseAltLeftDragCode(row, col)
+  let alt = 0x8
+  if &ttymouse ==# 'dec'
+    return DecEscapeCode(1, 4, a:row, a:col)
+  else
+    return TerminalEscapeCode(0x20 + alt, a:row, a:col, 'M')
+  endif
+endfunc
+
+func MouseAltLeftDrag(row, col)
+  if has('win32')
+    call MSWinMouseEvent(s:MOUSE_CODE.BTN_LEFT, a:row, a:col, 1, 0,
+                                                       \ s:MOUSE_CODE.MOD_ALT)
+  else
+    call feedkeys(MouseAltLeftDragCode(a:row, a:col), 'Lx!')
+  endif
+endfunc
+
 func MouseWheelUpCode(row, col)
   return TerminalEscapeCode(0x40, a:row, a:col, 'M')
 endfunc


### PR DESCRIPTION
Hi! I previously proposed a similar change in Neovim (neovim/neovim#38943), but it wasn’t accepted there. I’m opening it here as it may be more appropriate for Vim itself.

Happy to adjust or drop this if it doesn’t align with Vim’s intended behavior. I'll leave another description below.

## Problem
Alt+click/drag in Visual Block mode expands the selection relative to the furthest corner of the existing block, rather than the position where the drag started.

## Solution
Update the selection anchor to the position of the initial click, so that dragging behaves consistently with standard mouse-based visual selections (left-click/drag).

The current behavioris from https://github.com/vim/vim/commit/6496966ad1f64e6cb421adaec99143789de805c5 for reference.

| Before | After |
| :---: | :---: |
| <img src="https://github.com/user-attachments/assets/48750544-b87d-4701-bb7d-6c4484b8cafb" width="360"/> | <img src="https://github.com/user-attachments/assets/c2ce5ecc-56d8-45be-9b1d-59aa51f370dd" width="360"/> |