### PR TITLE
patch 9.2.XXXX: potential buffer underrun when setting statusline like option

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -5028,7 +5028,7 @@ build_stl_str_hl_local(
 	    if (*s != '}')	// missing '}' or out of space
 		break;
 	    s++;
-	    if (reevaluate)
+	    if (reevaluate && p > out)
 		p[-1] = NUL; // remove the % at the end of %{% expr %}
 	    else
 		*p = NUL;

--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -5390,4 +5390,14 @@ func Test_breaklist_args_fails()
   call assert_fails(':breaklist extra', 'E488:')
 endfunc
 
+func Test_rulerformat_empty()
+  set ruler rulerformat=%!'%{}%'
+  try
+    redraw
+  catch
+  endtry
+  set ruler&
+  set rulerformat&
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -870,9 +870,6 @@ func Test_set_option_errors()
   call assert_fails('set commentstring=x', 'E537:')
   call assert_fails('let &commentstring = "x"', 'E537:')
   call assert_fails('set complete=x', 'E539:')
-  call assert_fails('set rulerformat=%-', 'E539:')
-  call assert_fails('set rulerformat=%(', 'E542:')
-  call assert_fails('set rulerformat=%15(%%', 'E542:')
 
   " Test for 'statusline' errors
   call assert_fails('set statusline=%$', 'E539:')
@@ -889,6 +886,11 @@ func Test_set_option_errors()
   call assert_fails('set tabline=%{%}', 'E539:')
   call assert_fails('set tabline=%(', 'E542:')
   call assert_fails('set tabline=%)', 'E542:')
+
+  " Test for 'rulerformat' errors
+  call assert_fails('set rulerformat=%-', 'E539:')
+  call assert_fails('set rulerformat=%(', 'E542:')
+  call assert_fails('set rulerformat=%15(%%', 'E542:')
 
   if has('cursorshape')
     " This invalid value for 'guicursor' used to cause Vim to crash.

--- a/src/testdir/test_statusline.vim
+++ b/src/testdir/test_statusline.vim
@@ -930,4 +930,14 @@ func Test_tabline_click_handler()
   endif
 endfunc
 
+func Test_statusline_empty()
+  set laststatus=2 statusline=%!'%{}%'
+  try
+  redraw!
+  catch
+  endtry
+  set laststatus&
+  set statusline&
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_tabline.vim
+++ b/src/testdir/test_tabline.vim
@@ -250,4 +250,14 @@ func Test_tabline_mouse_enable()
   endfor
 endfunc
 
+func Test_tabline_empty()
+  set showtabline=2 tabline=%!'%{}%'
+  try
+    redraw!
+  catch
+  endtry
+  set showtabline&
+  set tabline&
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_tabpanel.vim
+++ b/src/testdir/test_tabpanel.vim
@@ -923,4 +923,14 @@ func Test_tabpanel_variable_height()
   %bwipeout!
 endfunc
 
+func Test_tabpanel_empty()
+  set showtabpanel=2 tabpanel=%!'%{}%'
+  try
+  redraw!
+  catch
+  endtry
+  set showtabpanel&
+  set tabpanel&
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  potential buffer underrun when settings statusline like option
          (q1uf3ng)
Solution: Validate that p > out before accessing p[-1], validate
          the result of %! expression evaluation with check_stl_option()