### PR TITLE
Accept a script local variable in a function which overrides a previous block-scope variable

### DIFF
--- a/src/testdir/test_vim9_script.vim
+++ b/src/testdir/test_vim9_script.vim
@@ -5759,6 +5759,28 @@ def Test_multikey_dict_in_block()
   unlet g:TestDict
 enddef
 
+" Test for overriding a block level variable with a new script level variable
+" and referring to it in a function.
+def Test_block_var_override_with_script_var()
+  var lines =<< trim END
+    vim9script
+
+    if true
+      var lines = ['a']
+      lines->filter((_, _) => true)
+    endif
+
+    var lines = []
+
+    def Fx()
+      lines->add('b')
+    enddef
+    Fx()
+    assert_equal(['b'], lines)
+  END
+  v9.CheckSourceSuccess(lines)
+enddef
+
 " Test for using the type() function with void
 def Test_type_func_with_void()
   var lines =<< trim END

--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -253,6 +253,11 @@ find_script_var(char_u *name, size_t len, cctx_T *cctx, cstack_T *cstack)
     {
 	int idx;
 
+	if (ufunc->uf_block_depth == 0 && sav->sav_block_id == 0)
+	    // If the function was defined at the script level (not inside a
+	    // block), script-scope variables are always visible.
+	    return sav;
+
 	// Go over the blocks that this function was defined in.  If the
 	// variable block ID matches it was visible to the function.
 	for (idx = 0; idx < ufunc->uf_block_depth; ++idx)


### PR DESCRIPTION
When a function is defined at the top level of a script, it should be able to see
script-local variables defined at that same level.

The find_script_var() function was missing a check for the case where uf_block_depth
is zero. Added a check to ensure sav_block_id == 0 is accepted as visible when the 
function is not inside a nested block.

Fixes the issue reported in #19959.