### PR TITLE
Wrong autoformatting with 'autocomplete'

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -2956,7 +2956,7 @@ ins_compl_stop(int c, int prev_mode, int retval)
 	    want_cindent = FALSE;	// don't do it again
 	}
     }
-    else
+    else if (!compl_autocomplete || compl_used_match)
     {
 	int prev_col = curwin->w_cursor.col;
 

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -6289,4 +6289,20 @@ func Test_ins_register_preinsert_autocomplete()
   delfunc TestOmni
 endfunc
 
+func Test_autocomplete_with_auto_format()
+  call test_override("char_avail", 1)
+  new
+  setlocal formatoptions=tcq textwidth=9 autocomplete noautoindent
+  call feedkeys("ia b c d\<Esc>ie f g\<Esc>", 'tx')
+  call assert_equal(['a b c e f', 'gd'], getline(1, '$'))
+
+  %delete
+  setlocal autoindent
+  call feedkeys("ia b c d\<Esc>ie f g\<Esc>", 'tx')
+  call assert_equal(['a b c e f', 'gd'], getline(1, '$'))
+
+  bw!
+  call test_override("char_avail", 0)
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab nofoldenable


### PR DESCRIPTION
Problem:  Wrong autoformatting with 'autocomplete'.
Solution: Don't trigger autoformatting when ending autocompletion
          without selecting an item.

fixes: #19954
