### PR TITLE
fix(test_clientserver): Wait for argc() before checking argv()

### DIFF
--- a/src/testdir/test_clientserver.vim
+++ b/src/testdir/test_clientserver.vim
@@ -145,6 +145,7 @@ func Test_client_server()
 
     " Edit multiple files using --remote
     call system(cmd .. ' --remote Xclientfile1 Xclientfile2 Xclientfile3')
+    call WaitForAssert({-> assert_equal('3', remote_expr(name, 'argc()'))})
     call assert_match(".*Xclientfile1\n.*Xclientfile2\n.*Xclientfile3\n", remote_expr(name, 'argv()'))
     eval name->remote_send(":%bw!\<CR>")
 


### PR DESCRIPTION
On slower systems, the argv() check may run before the server has
populated the arg list.

Add a wait for argc() to be 3 to be more tolerant of such systems