### PR TITLE
Optimize repeat() string copying

### DIFF
--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -10581,7 +10581,7 @@ repeat_string(typval_T *str_tv, int n, typval_T *rettv)
     int		slen;
     int		len;
     char_u	*r;
-    int		i;
+    int		done;
 
     p = tv_get_string(str_tv);
     rettv->v_type = VAR_STRING;
@@ -10596,8 +10596,17 @@ repeat_string(typval_T *str_tv, int n, typval_T *rettv)
     if (r == NULL)
 	return;
 
-    for (i = 0; i < n; i++)
-	mch_memmove(r + i * slen, p, (size_t)slen);
+    mch_memmove(r, p, (size_t)slen);
+    done = slen;
+    while (done < len)
+    {
+	int copy_len = done;
+
+	if (copy_len > len - done)
+	    copy_len = len - done;
+	mch_memmove(r + done, r, (size_t)copy_len);
+	done += copy_len;
+    }
     r[len] = NUL;
 
     rettv->vval.v_string = r;


### PR DESCRIPTION
This changes string handling in `repeat()` to copy the initial chunk once and then grow the result by copying from the already-built output buffer. That reduces the number of `memmove()` calls for larger repeat counts while preserving behavior.

Benchmark (best of 3 runs, iterations bumped so each case takes ~1s or more):

| Case | Before | After | Change |
| --- | ---: | ---: | ---: |
| `repeat('ab', 64)` (1,000,000 iters) | 1.845 s | 1.687 s | 1.09x faster |
| `repeat(long, 8)` (1,000,000 iters) | 1.799 s | 1.754 s | 1.03x faster |
| `repeat('ab', 1024)` (500,000 iters) | 2.375 s | 0.878 s | 2.70x faster |
| `repeat(huge, 32)` (200,000 iters) | 1.020 s | 1.114 s | 0.92x (slower) |

`long` is `repeat('abcdefg', 100)` (700 bytes) and `huge` is `repeat('abcdefg', 1000)` (7000 bytes).

The `huge, 32` case regresses because with a large source and small repeat count, the doubling strategy ends up copying more total bytes than the original per-chunk loop, and the `memmove()` call overhead it saves is already small relative to the payload.

Validated with `make -j4 vim` and local `repeat()` smoke checks.