### PR TITLE
runtime(tar): add path traversal checks to tar#Extract()

### DIFF
--- a/runtime/autoload/tar.vim
+++ b/runtime/autoload/tar.vim
@@ -612,6 +612,24 @@ fun! tar#Extract()
    let &report= repkeep
    return
   endif
+  if fname =~ '^[.]\?[.]/' || simplify(fname) =~ '\.\.[/\\]'
+   call s:Msg('tar#Extract', 'error', "Path Traversal Attack detected, not extracting!")
+   let &report= repkeep
+   return
+  endif
+  if has("unix")
+   if fname =~ '^/'
+    call s:Msg('tar#Extract', 'error', "Path Traversal Attack detected, not extracting!")
+    let &report= repkeep
+    return
+   endif
+  else
+   if fname =~ '^\%(\a:[\\/]\|[\\/]\)'
+    call s:Msg('tar#Extract', 'error', "Path Traversal Attack detected, not extracting!")
+    let &report= repkeep
+    return
+   endif
+  endif
 
   let extractcmd= s:WinPath(g:tar_extractcmd)
   let tarball = expand("%")


### PR DESCRIPTION
tar#Extract() has no check for ../ or absolute paths. zip#Extract()
was patched for this recently, tar#Extract() was not.

Add the same checks: ../ relative traversal, leading slash on Unix,
drive letter and leading slash/backslash on Windows.