### PR TITLE
runtime(vimball): block Windows drive letter paths

### DIFF
--- a/runtime/autoload/vimball.vim
+++ b/runtime/autoload/vimball.vim
@@ -8,6 +8,7 @@
 "   2025 Feb 28 by Vim Project: add support for bzip3 (#16755)
 "   2026 Apr 05 by Vim Project: Detect path traversal attacks
 "   2026 Apr 09 by Vim Project: Detect more path traversal attacks
+"   2026 Apr 16 by Vim Project: Block Windows drive letter paths
 " Copyright: (c) 2004-2011 by Charles E. Campbell
 "            The VIM LICENSE applies to Vimball.vim, and Vimball.txt
 "            (see |copyright|) except use "Vimball" instead of "Vim".
@@ -230,8 +231,11 @@ fun! vimball#Vimball(really,...)
    let fsize   = substitute(getline(linenr+1),'^\(\d\+\).\{-}$','\1','')+0
    let fenc    = substitute(getline(linenr+1),'^\d\+\s*\(\S\{-}\)$','\1','')
    let filecnt = filecnt + 1
-   " Do not allow a leading / or .. anywhere in the file name
-   if fname =~ '\.\.' || fname =~ '^/'
+   " Do not allow a leading /, .. anywhere, or a Windows drive letter
+   " (e.g. C:/foo) in the file name.  Backslashes were already converted
+   " to forward slashes above, so this also catches \\server\share UNC
+   " paths via the leading-slash check.
+   if fname =~ '\.\.' || fname =~ '^/' || fname =~ '^\a:'
      echomsg "(Vimball) Path Traversal Attack detected, aborting..."
      exe "tabn ".curtabnr
      bw! Vimball

--- a/src/testdir/test_plugin_vimball.vim
+++ b/src/testdir/test_plugin_vimball.vim
@@ -95,6 +95,5 @@ func Test_vimball_path_traversal_drive_letter()
 
   let mess = execute(':mess')->split('\n')[-1]
   call assert_match('(Vimball) Path Traversal Attack detected, aborting\.\.\.', mess)
-  call assert_false(isdirectory('C:'))
   call s:teardown()
 endfunc

--- a/src/testdir/test_plugin_vimball.vim
+++ b/src/testdir/test_plugin_vimball.vim
@@ -83,3 +83,18 @@ func Test_vimball_path_traversal()
   call assert_false(filereadable('../XVimball/Xtest.txt'))
   call s:teardown()
 endfunc
+
+func Test_vimball_path_traversal_drive_letter()
+  call s:Mkvimball()
+  call delete('XVimball', 'rf')
+  sp Xtest.vmb
+  " try to write to a Windows-style absolute path with a drive letter
+  4s#XVimball#C:/&#
+  so %
+  call feedkeys("\<cr>", "it")
+
+  let mess = execute(':mess')->split('\n')[-1]
+  call assert_match('(Vimball) Path Traversal Attack detected, aborting\.\.\.', mess)
+  call assert_false(isdirectory('C:'))
+  call s:teardown()
+endfunc


### PR DESCRIPTION
The path traversal check in `vimball#Vimball()` rejected leading `/` and embedded `..`, but did not reject file names starting with a Windows drive letter (e.g. `C:/foo`). Backslashes are normalized to forward slashes earlier, so UNC paths are caught by the leading-slash check, but absolute drive-letter paths slipped through and could write outside of `g:vimball_home` on Windows.

Add a `^\a:` check next to the existing `^/` check, and cover it with a new test (verified on Linux and Windows MinGW).