### PR TITLE
Vim9: Missing check_secure() when executing ISN_STOREENV instruction

### DIFF
--- a/src/testdir/test_restricted.vim
+++ b/src/testdir/test_restricted.vim
@@ -220,4 +220,49 @@ func Test_restricted_cscope()
   call delete('XResult_cscope')
 endfunc
 
+func Test_vim9_storeenv_sandbox()
+  let lines =<< trim END
+    vim9script
+
+    function g:LegacySetEnv()
+      let $VIM_SANDBOX_TEST = 'legacy'
+    endfunc
+
+    def Vim9SetEnv()
+      $VIM_SANDBOX_TEST = 'vim9_bypass'
+    enddef
+
+    # Legacy path should be blocked by check_secure()
+    var legacy_blocked = false
+    try
+      legacy sandbox call LegacySetEnv()
+    catch /E48/
+      legacy_blocked = true
+    endtry
+    assert_true(legacy_blocked, 'legacy $ENV assignment should be blocked in sandbox')
+    assert_false(exists('$VIM_SANDBOX_TEST'))
+
+    # Vim9 path should also be blocked by check_secure()
+    var vim9_blocked = false
+    try
+      sandbox Vim9SetEnv()
+    catch /E48/
+      vim9_blocked = true
+    endtry
+    assert_true(vim9_blocked, 'Vim9 ISN_STOREENV should be blocked in sandbox')
+    assert_false(exists('$VIM_SANDBOX_TEST'))
+    writefile([
+    legacy_blocked,
+    vim9_blocked,
+    string(v:errors)], 'XResult_storeenv')
+    qa
+  END
+  call writefile(lines, 'Xtest_storeenv_sandbox.vim', 'D')
+  let expected = ['true', 'true', '[]']
+  if RunVim([], [], '-u NONE -N -i NONE --not-a-term -S Xtest_storeenv_sandbox.vim')
+    call assert_equal(expected, readfile('XResult_storeenv'))
+  endif
+  call delete('XResult_storeenv')
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/vim9execute.c
+++ b/src/vim9execute.c
@@ -4472,7 +4472,7 @@ exec_instructions(ectx_T *ectx)
 
 	    // store $ENV
 	    case ISN_STOREENV:
-		if (check_restricted())
+		if (check_secure() || check_restricted())
 		    goto theend;
 		--ectx->ec_stack.ga_len;
 		tv = STACK_TV_BOT(0);


### PR DESCRIPTION
Problem:  Vim9: Missing check_secure() when executing ISN_STOREENV
          instruction (Andrej Tomči)
Solution: Add check_secure(), add test