### PR TITLE
Update statements and filters for Django syntax file.

### DIFF
--- a/runtime/syntax/django.vim
+++ b/runtime/syntax/django.vim
@@ -31,7 +31,7 @@ syn keyword djangoStatement contained openbrace closebrace opencomment
 syn keyword djangoStatement contained closecomment widthratio url with endwith
 syn keyword djangoStatement contained get_current_language trans noop blocktrans
 syn keyword djangoStatement contained endblocktrans get_available_languages
-syn keyword djangoStatement contained get_current_language_bidi plural
+syn keyword djangoStatement contained get_current_language_bidi get_language_info plural
 syn keyword djangoStatement contained translate blocktranslate endblocktranslate
 syn keyword djangoStatement contained partialdef endpartialdef partial
 syn keyword djangoStatement contained querystring lorem verbatim

--- a/runtime/syntax/django.vim
+++ b/runtime/syntax/django.vim
@@ -34,6 +34,7 @@ syn keyword djangoStatement contained endblocktrans get_available_languages
 syn keyword djangoStatement contained get_current_language_bidi plural
 syn keyword djangoStatement contained translate blocktranslate endblocktranslate
 syn keyword djangoStatement contained partialdef endpartialdef partial
+syn keyword djangoStatement contained querystring lorem verbatim
 
 " Django templete built-in filters
 syn keyword djangoFilter contained add addslashes capfirst center cut date
@@ -48,6 +49,7 @@ syn keyword djangoFilter contained safe safeseq stringformat striptags
 syn keyword djangoFilter contained time timesince timeuntil title truncatechars
 syn keyword djangoFilter contained truncatewords truncatewords_html unordered_list upper urlencode
 syn keyword djangoFilter contained urlize urlizetrunc wordcount wordwrap yesno
+syn keyword djangoFilter contained force_escape iriencode json_script truncatechars_html
 
 " Keywords to highlight within comments
 syn keyword djangoTodo contained TODO FIXME XXX

--- a/runtime/syntax/django.vim
+++ b/runtime/syntax/django.vim
@@ -22,15 +22,13 @@ syn keyword djangoStatement contained autoescape csrf_token empty
 syn keyword djangoStatement contained and as block endblock by cycle debug else elif
 syn keyword djangoStatement contained extends filter endfilter firstof for
 syn keyword djangoStatement contained endfor if endif ifchanged endifchanged
-syn keyword djangoStatement contained ifequal endifequal ifnotequal
-syn keyword djangoStatement contained endifnotequal in include load not now or
-syn keyword djangoStatement contained parsed regroup reversed spaceless
-syn keyword djangoStatement contained endspaceless ssi templatetag openblock
+syn keyword djangoStatement contained in include load not now
+syn keyword djangoStatement contained regroup reversed spaceless
+syn keyword djangoStatement contained endspaceless templatetag openblock
 syn keyword djangoStatement contained closeblock openvariable closevariable
-syn keyword djangoStatement contained openbrace closebrace opencomment
+syn keyword djangoStatement contained openbrace closebrace opencomment or
 syn keyword djangoStatement contained closecomment widthratio url with endwith
-syn keyword djangoStatement contained get_current_language trans noop blocktrans
-syn keyword djangoStatement contained endblocktrans get_available_languages
+syn keyword djangoStatement contained get_current_language noop get_available_languages
 syn keyword djangoStatement contained get_current_language_bidi get_language_info plural
 syn keyword djangoStatement contained translate blocktranslate endblocktranslate
 syn keyword djangoStatement contained partialdef endpartialdef partial
@@ -40,7 +38,7 @@ syn keyword djangoStatement contained querystring lorem verbatim
 syn keyword djangoFilter contained add addslashes capfirst center cut date
 syn keyword djangoFilter contained default default_if_none dictsort
 syn keyword djangoFilter contained dictsortreversed divisibleby escape escapejs
-syn keyword djangoFilter contained filesizeformat first fix_ampersands
+syn keyword djangoFilter contained filesizeformat first
 syn keyword djangoFilter contained floatformat get_digit join last length length_is
 syn keyword djangoFilter contained linebreaks linebreaksbr linenumbers ljust
 syn keyword djangoFilter contained lower make_list phone2numeric pluralize


### PR DESCRIPTION
# Update statements and filters.

## Add missing statements and filters.

djangoStatement:

- `querystring`: Added in version Django 5.2.
- `lorem`: Added in version Django 1.8.
- `verbatim`: Added in version Django 1.10.
- `get_language_info`: Was added in version Django 1.8.

djangoFilter:

- `force_escape`: Added in version Django 1.8.
- `iriencode`: Added in version Django 1.8.
- `json_script`: Added in version 2.1.
- `truncatechars_html`: Added in version 1.7.

## Removed unsupported template statements and filters by current LTS.

djangoStatement:

- `ifequal`: Depricated version 4.0.
- `endifequal`: Depricated version 4.0.
- `ifnotequal`: Depricated version 4.0.
- `endifnotequal`: Depricated version 4.0.
- `parsed`: No details found.
- `trans`: Renamed to `translate` in version 4.0.
- `blocktrans`: Renamed to `blocktranslate` in version 4.0.
- `endblocktrans`: Renamed to `endblocktranslate` in version 4.0.

djangoFilter:

- `fix_ampersands`: Removed in version 1.8.
- `length_is`: Removed in version 5.1.

## Sources.

- [Current LTS is version 5.2](https://www.djangoproject.com/download/#supported-versions).
- [Documentation template builtins LTS 5.2](https://docs.djangoproject.com/en/5.2/ref/templates/builtins/#truncatechars-html).
- [Documentation template builtins 6](https://docs.djangoproject.com/en/6.0/ref/templates/builtins).
- [Django Deprecation Timeline](https://docs.djangoproject.com/en/6.0/internals/deprecation)