### PR TITLE
runtime(vim9): remove extra escaping in Open

### DIFF
--- a/runtime/autoload/dist/vim9.vim
+++ b/runtime/autoload/dist/vim9.vim
@@ -139,7 +139,11 @@ export def Open(file: string)
     setlocal shell&
     defer setbufvar('%', '&shell', shell)
   endif
-  Launch($"{Viewer()} {shellescape(file, 1)}")
+  if has('unix') && !has('win32unix') && !exists('$WSL_DISTRO_NAME')
+    Launch($"{Viewer()} {shellescape(file)}")
+  else
+    Launch($"{Viewer()} {shellescape(file, 1)}")
+  endif
 enddef
 
 # Uncomment this line to check for compilation errors early


### PR DESCRIPTION
Before 71fd19d7ac9e83bf63d7bad337f43cd830a5b5bd this function went
through a `:!` command on all platforms, so it needed special escaping for `#` and
others. After that commit it doesn't go through that path on unix
platforms. Then with 48581f2ba96550f5499cc322647b2ff1df5ad4ed this
escaping was re-added on unix since it goes through
`sh -c`, but it should not have the extra escaping specific to `:!`.

Specifically my original broken command is:

```
PATH=/usr/bin:/bin VIMRUNTIME=~/dev/vim/runtime ./src/vim -u NONE -c 'call dist#vim9#Open("https://github.com/keith/dotfiles/blob/7bce9f5c697df6a549cf97bf5606d8b639e5bf5a/vimrc#L19")'
```

Where the `#L19` ends up being opened as `%5C#L19`. But I verified this
case still works as well:

```
PATH=/usr/bin:/bin VIMRUNTIME=~/dev/vim/runtime ./src/vim -u NONE -c 'call dist#vim9#Open("foo bar.txt")'
```

Which is what would otherwise break if we weren't doing any shell
escaping on unix.
