### PR TITLE
fix: typo in stop, OOB in prefix, asymmetric pending loop

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -3032,7 +3032,7 @@ ins_compl_stop(int c, int prev_mode, int retval)
     }
     compl_autocomplete = FALSE;
     compl_from_nonkeyword = FALSE;
-    compl_best_matches = 0;
+    compl_num_bests = 0;
     compl_ins_end_col = 0;
 
     if (c == Ctrl_C && cmdwin_type != 0)
@@ -5777,7 +5777,8 @@ find_common_prefix(size_t *prefix_len, int curbuf_only)
 	    }
 
 	    if (!match_limit_exceeded && (!curbuf_only
-			|| cpt_sources_array[cur_source].cs_flag == '.'))
+			|| (cur_source != -1
+			    && cpt_sources_array[cur_source].cs_flag == '.')))
 	    {
 		if (first == NULL && STRNCMP(ins_compl_leader(),
 			    compl->cp_str.string, ins_compl_leader_len()) == 0)
@@ -6058,7 +6059,7 @@ find_next_completion_match(
 		    compl_shown_match = compl_shown_match->cp_next;
 		    --compl_pending;
 		}
-		if (compl_pending < 0 && compl_shown_match->cp_prev != NULL)
+		else if (compl_pending < 0 && compl_shown_match->cp_prev != NULL)
 		{
 		    compl_shown_match = compl_shown_match->cp_prev;
 		    ++compl_pending;


### PR DESCRIPTION
Problem:
1. ins_compl_stop sets compl_best_matches = 0, but that's a pointer. Meant to reset the counter compl_num_bests.
2. find_common_prefix reads cpt_sources_array[cur_source] without checking cur_source != -1. OOB when it's -1.
3. find_next_completion_match: second `if` in the pending loop should be `else if`. Forward paging only moves one step per call.

Solution:
1. Reset compl_num_bests instead.
2. Add the -1 guard.
3. Change `if` to `else if`.