### PR TITLE
refactor: change boolean gui_T members from int/char to bool

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -198,7 +198,7 @@ gui_attempt_start(void)
     static int recursive = 0;
 
     ++recursive;
-    gui.starting = TRUE;
+    gui.starting = true;
 
 #ifdef FEAT_GUI_GTK
     gui.event_time = GDK_CURRENT_TIME;
@@ -388,8 +388,8 @@ gui_read_child_pipe(int fd)
     void
 gui_prepare(int *argc, char **argv)
 {
-    gui.in_use = FALSE;		    // No GUI yet (maybe later)
-    gui.starting = FALSE;	    // No GUI yet (maybe later)
+    gui.in_use = false;		    // No GUI yet (maybe later)
+    gui.starting = false;	    // No GUI yet (maybe later)
     gui_mch_prepare(argc, argv);
 }
 
@@ -412,17 +412,17 @@ gui_init_check(void)
     }
 
     gui.shell_created = false;
-    gui.dying = FALSE;
-    gui.in_focus = TRUE;		// so the guicursor setting works
+    gui.dying = false;
+    gui.in_focus = true;		// so the guicursor setting works
     gui.dragged_sb = SBAR_NONE;
     gui.dragged_wp = NULL;
-    gui.pointer_hidden = FALSE;
+    gui.pointer_hidden = false;
     gui.col = 0;
     gui.row = 0;
     gui.num_cols = Columns;
     gui.num_rows = Rows;
 
-    gui.cursor_is_valid = FALSE;
+    gui.cursor_is_valid = false;
     gui.scroll_region_top = 0;
     gui.scroll_region_bot = Rows - 1;
     gui.scroll_region_left = 0;
@@ -457,7 +457,7 @@ gui_init_check(void)
     gui.menu_font = NOFONT;
 #  endif
 # endif
-    gui.menu_is_active = TRUE;	    // default: include menu
+    gui.menu_is_active = true;	    // default: include menu
 # ifndef FEAT_GUI_GTK
     gui.menu_height = MENU_DEFAULT_HEIGHT;
     gui.menu_width = 0;
@@ -674,7 +674,7 @@ gui_init(void)
     /*
      * Create the GUI shell.
      */
-    gui.in_use = TRUE;		// Must be set after menus have been set up
+    gui.in_use = true;		// Must be set after menus have been set up
     if (gui_mch_init() == FAIL)
 	goto error;
 
@@ -780,9 +780,11 @@ gui_init(void)
 	// It was still there to make F10 work.
 	if (vim_strchr(p_go, GO_MENUS) == NULL)
 	{
-	    --gui.starting;
+	    bool save_starting = gui.starting;
+
+	    gui.starting = false;
 	    gui_mch_enable_menu(FALSE);
-	    ++gui.starting;
+	    gui.starting = save_starting;
 	    gui_mch_update();
 	}
 # endif
@@ -855,7 +857,7 @@ error2:
 #endif
 
 error:
-    gui.in_use = FALSE;
+    gui.in_use = false;
     clip_init(FALSE);
 }
 
@@ -866,7 +868,7 @@ gui_exit(int rc)
     // don't free the fonts, it leads to a BUS error
     // richard@whitequeen.com Jul 99
     free_highlight_fonts();
-    gui.in_use = FALSE;
+    gui.in_use = false;
     gui_mch_exit(rc);
 }
 
@@ -1163,7 +1165,7 @@ gui_check_pos(void)
     if (gui.col >= screen_Columns)
 	gui.col = screen_Columns - 1;
     if (gui.cursor_row >= screen_Rows || gui.cursor_col >= screen_Columns)
-	gui.cursor_is_valid = FALSE;
+	gui.cursor_is_valid = false;
 }
 
 /*
@@ -1229,7 +1231,7 @@ gui_update_cursor(
     if (gui.row >= screen_Rows || gui.col >= screen_Columns)
 	return;
 
-    gui.cursor_is_valid = TRUE;
+    gui.cursor_is_valid = true;
 
     /*
      * How the cursor is drawn depends on the current mode.
@@ -1850,7 +1852,7 @@ gui_clear_block(
     // Invalidate cursor if it was in this block
     if (       gui.cursor_row >= row1 && gui.cursor_row <= row2
 	    && gui.cursor_col >= col1 && gui.cursor_col <= col2)
-	gui.cursor_is_valid = FALSE;
+	gui.cursor_is_valid = false;
 }
 
 /*
@@ -1922,7 +1924,7 @@ gui_write(
 		case 'C':	// Clear screen
 		    clip_scroll_selection(9999);
 		    gui_mch_clear_all();
-		    gui.cursor_is_valid = FALSE;
+		    gui.cursor_is_valid = false;
 		    force_scrollbar = TRUE;
 		    break;
 		case 'M':	// Move cursor
@@ -2691,7 +2693,7 @@ gui_outstr_nowrap(
 	if (gui.cursor_row == gui.row
 		&& gui.cursor_col >= col
 		&& gui.cursor_col < col + len)
-	    gui.cursor_is_valid = FALSE;
+	    gui.cursor_is_valid = false;
     }
 
 #ifdef FEAT_SIGN_ICONS
@@ -2731,7 +2733,7 @@ gui_undraw_cursor(void)
 
     // Cursor_is_valid is reset when the cursor is undrawn, also reset it
     // here in case it wasn't needed to undraw it.
-    gui.cursor_is_valid = FALSE;
+    gui.cursor_is_valid = false;
 }
 
     void
@@ -2943,7 +2945,7 @@ gui_delete_lines(int row, int count)
 		&& gui.cursor_col <= gui.scroll_region_right)
 	{
 	    if (gui.cursor_row < row + count)
-		gui.cursor_is_valid = FALSE;
+		gui.cursor_is_valid = false;
 	    else if (gui.cursor_row <= gui.scroll_region_bot)
 		gui.cursor_row -= count;
 	}
@@ -2971,7 +2973,7 @@ gui_insert_lines(int row, int count)
 	    if (gui.cursor_row <= gui.scroll_region_bot - count)
 		gui.cursor_row += count;
 	    else if (gui.cursor_row <= gui.scroll_region_bot)
-		gui.cursor_is_valid = FALSE;
+		gui.cursor_is_valid = false;
 	}
     }
 }
@@ -3545,30 +3547,30 @@ gui_init_which_components(char_u *oldval UNUSED)
 	    p_go = temp;
 	}
     }
-    gui.menu_is_active = FALSE;
+    gui.menu_is_active = false;
 #endif
 
     for (i = 0; i < 3; i++)
-	gui.which_scrollbars[i] = FALSE;
+	gui.which_scrollbars[i] = false;
     for (p = p_go; *p; p++)
 	switch (*p)
 	{
 	    case GO_LEFT:
-		gui.which_scrollbars[SBAR_LEFT] = TRUE;
+		gui.which_scrollbars[SBAR_LEFT] = true;
 		break;
 	    case GO_RIGHT:
-		gui.which_scrollbars[SBAR_RIGHT] = TRUE;
+		gui.which_scrollbars[SBAR_RIGHT] = true;
 		break;
 	    case GO_VLEFT:
 		if (win_hasvertsplit())
-		    gui.which_scrollbars[SBAR_LEFT] = TRUE;
+		    gui.which_scrollbars[SBAR_LEFT] = true;
 		break;
 	    case GO_VRIGHT:
 		if (win_hasvertsplit())
-		    gui.which_scrollbars[SBAR_RIGHT] = TRUE;
+		    gui.which_scrollbars[SBAR_RIGHT] = true;
 		break;
 	    case GO_BOT:
-		gui.which_scrollbars[SBAR_BOTTOM] = TRUE;
+		gui.which_scrollbars[SBAR_BOTTOM] = true;
 		break;
 #ifdef FEAT_GUI_DARKTHEME
 	    case GO_DARKTHEME:
@@ -3577,7 +3579,7 @@ gui_init_which_components(char_u *oldval UNUSED)
 #endif
 #ifdef FEAT_MENU
 	    case GO_MENUS:
-		gui.menu_is_active = TRUE;
+		gui.menu_is_active = true;
 		break;
 #endif
 	    case GO_GREY:

--- a/src/gui.h
+++ b/src/gui.h
@@ -231,23 +231,23 @@ typedef long	    guicolor_T;	// handle for a GUI color; for X11 this should
 
 typedef struct Gui
 {
-    int		in_focus;	    // Vim has input focus
-    int		in_use;		    // Is the GUI being used?
-    int		starting;	    // GUI will start in a little while
+    bool	in_focus;	    // Vim has input focus
+    bool	in_use;		    // Is the GUI being used?
+    bool	starting;	    // GUI will start in a little while
     bool	shell_created;	    // Has the shell been created yet?
-    int		dying;		    // Is vim dying? Then output to terminal
-    int		dofork;		    // Use fork() when GUI is starting
+    bool	dying;		    // Is vim dying? Then output to terminal
+    bool	dofork;		    // Use fork() when GUI is starting
 #ifdef GUI_MAY_SPAWN
-    int		dospawn;	    // Use spawn() when GUI is starting
+    bool	dospawn;	    // Use spawn() when GUI is starting
 #endif
     int		dragged_sb;	    // Which scrollbar being dragged, if any?
     win_T	*dragged_wp;	    // Which WIN's sb being dragged, if any?
-    int		pointer_hidden;	    // Is the mouse pointer hidden?
+    bool	pointer_hidden;	    // Is the mouse pointer hidden?
     int		col;		    // Current cursor column in GUI display
     int		row;		    // Current cursor row in GUI display
     int		cursor_col;	    // Physical cursor column in GUI display
     int		cursor_row;	    // Physical cursor row in GUI display
-    char	cursor_is_valid;    // There is a cursor at cursor_row/col
+    bool	cursor_is_valid;    // There is a cursor at cursor_row/col
     int		num_cols;	    // Number of columns
     int		num_rows;	    // Number of rows
     int		scroll_region_top;  // Top (first) line of scroll region
@@ -259,9 +259,9 @@ typedef struct Gui
     int		scrollbar_height;   // Height of horizontal scrollbar
     int		left_sbar_x;	    // Calculated x coord for left scrollbar
     int		right_sbar_x;	    // Calculated x coord for right scrollbar
-    int         force_redraw;       // Force a redraw even e.g. not resized
+    bool	force_redraw;       // Force a redraw even e.g. not resized
 #ifdef FEAT_DIRECTX
-    int		directx_enabled;    // DirectX (DirectWrite) rendering active
+    bool	directx_enabled;    // DirectX (DirectWrite) rendering active
 #endif
 
 #ifdef FEAT_MENU
@@ -269,11 +269,11 @@ typedef struct Gui
     int		menu_height;	    // Height of the menu bar
     int		menu_width;	    // Width of the menu bar
 # endif
-    char	menu_is_active;	    // TRUE if menu is present
+    bool	menu_is_active;	    // true if menu is present
 #endif
 
     scrollbar_T bottom_sbar;	    // Bottom scrollbar
-    int		which_scrollbars[3];// Which scrollbar boxes are active?
+    bool	which_scrollbars[3];// Which scrollbar boxes are active?
     int		prev_wrap;	    // For updating the horizontal scrollbar
     int		char_width;	    // Width of char cell in pixels
     int		char_height;	    // Height of char cell in pixels, includes
@@ -288,7 +288,7 @@ typedef struct Gui
     GuiFont	ital_font;	    // Italic font
     GuiFont	boldital_font;	    // Bold-Italic font
 #else
-    int		font_can_bold;	    // Whether norm_font supports bold weight.
+    bool	font_can_bold;	    // Whether norm_font supports bold weight.
 				    // The styled font variants are not used.
 #endif
 

--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -675,7 +675,7 @@ gui_mch_prepare(int *argc, char **argv)
 		    break;
 #ifdef FEAT_NETBEANS_INTG
 		case ARG_NETBEANS:
-		    gui.dofork = FALSE; // don't fork() when starting GUI
+		    gui.dofork = false; // don't fork() when starting GUI
 		    netbeansArg = argv[i];
 		    break;
 #endif
@@ -689,7 +689,7 @@ gui_mch_prepare(int *argc, char **argv)
 	// Only when the GUI can start.
 	if ((option->flags & ARG_NEEDS_GUI)
 				      && gui_mch_early_init_check(FALSE) == OK)
-	    gui.starting = TRUE;
+	    gui.starting = true;
 
 	if (option->flags & ARG_KEEP)
 	    ++i;
@@ -1710,7 +1710,7 @@ gui_mch_early_init_check(int give_message)
     q = mch_getenv((char_u *)"WAYLAND_DISPLAY");
     if ((p == NULL || *p == NUL) && (q == NULL || *q == NUL))
     {
-	gui.dying = TRUE;
+	gui.dying = true;
 	if (give_message)
 	    emsg(_((char *)e_cannot_open_display));
 	return FAIL;
@@ -1751,7 +1751,7 @@ gui_mch_init_check(void)
     // Don't use gtk_init() or gnome_init(), it exits on failure.
     if (!gtk_init_check(&gui_argc, &gui_argv))
     {
-	gui.dying = TRUE;
+	gui.dying = true;
 	emsg(_((char *)e_cannot_open_display));
 	return FAIL;
     }
@@ -4224,7 +4224,7 @@ gui_mch_init(void)
 		     G_CALLBACK(scroll_event), NULL);
 
     // Pretend we don't have input focus, we will get an event if we do.
-    gui.in_focus = FALSE;
+    gui.in_focus = false;
 
     // Handle changes to the "Xft/DPI" setting.
     {
@@ -5299,7 +5299,7 @@ get_styled_font_variants(void)
     PangoFont		    *plain_font;
     PangoFont		    *bold_font;
 
-    gui.font_can_bold = FALSE;
+    gui.font_can_bold = false;
 
     plain_font = pango_context_load_font(gui.text_context, gui.norm_font);
 

--- a/src/gui_motif.c
+++ b/src/gui_motif.c
@@ -578,7 +578,7 @@ gui_x11_create_widgets(void)
     gui_x11_callbacks(textArea, vimForm);
 
     // Pretend we don't have input focus, we will get an event if we do.
-    gui.in_focus = FALSE;
+    gui.in_focus = false;
 }
 
 /*

--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -3731,7 +3731,7 @@ gui_mch_delete_lines(
     // scrolling such that the cursor ends up in the top-left character on
     // the screen...   But why?  (Webb)
     // It's probably fixed by disabling drawing the cursor while scrolling.
-    // gui.cursor_is_valid = FALSE;
+    // gui.cursor_is_valid = false;
 
     gui_clear_block(gui.scroll_region_bot - num_lines + 1,
 						       gui.scroll_region_left,

--- a/src/gui_x11.c
+++ b/src/gui_x11.c
@@ -1146,7 +1146,7 @@ gui_mch_prepare(int *argc, char **argv)
 #ifdef FEAT_NETBEANS_INTG
 	    if (strncmp("-nb", argv[arg], 3) == 0)
 	{
-	    gui.dofork = FALSE;	// don't fork() when starting GUI
+	    gui.dofork = false;	// don't fork() when starting GUI
 	    netbeansArg = argv[arg];
 	    mch_memmove(&argv[arg], &argv[arg + 1],
 					    (--*argc - arg) * sizeof(char *));
@@ -1197,7 +1197,7 @@ gui_mch_init_check(void)
 #endif
     if (app_context == NULL || gui.dpy == NULL)
     {
-	gui.dying = TRUE;
+	gui.dying = true;
 	emsg(_(e_cannot_open_display));
 	return FAIL;
     }

--- a/src/main.c
+++ b/src/main.c
@@ -198,7 +198,7 @@ main
     // Check if the current executable file is for the GUI subsystem.
     gui.starting = mch_is_gui_executable();
 #  elif defined(FEAT_GUI_MSWIN)
-    gui.starting = TRUE;
+    gui.starting = true;
 #  endif
 
 #  ifdef FEAT_CLIENTSERVER
@@ -228,7 +228,7 @@ main
      * :gui.
      */
 #  ifdef ALWAYS_USE_GUI
-    gui.starting = TRUE;
+    gui.starting = true;
 #  else
 #   if defined(FEAT_GUI_X11) || defined(FEAT_GUI_GTK)
     /*
@@ -239,7 +239,7 @@ main
     {
 	if (gui_init_check() == FAIL)
 	{
-	    gui.starting = FALSE;
+	    gui.starting = false;
 
 	    // When running "evim" or "gvim -y" we need the menus, exit if we
 	    // don't have them.
@@ -1038,7 +1038,7 @@ common_init_2(mparm_T *paramp)
 #endif
 
 #ifdef FEAT_GUI
-    gui.dofork = TRUE;		    // default is to use fork()
+    gui.dofork = true;		    // default is to use fork()
 #endif
 
     /*
@@ -1910,7 +1910,7 @@ early_arg_scan(mparm_T *parmp UNUSED)
 #  ifdef FEAT_GUI
 	    if (strstr(argv[i], "-wait") != 0)
 		// don't fork() when starting the GUI to edit files ourself
-		gui.dofork = FALSE;
+		gui.dofork = false;
 #  endif
 	}
 #  if defined(FEAT_X11) && defined(FEAT_SOCKETSERVER)
@@ -2027,7 +2027,7 @@ parse_command_name(mparm_T *parmp)
 		|| TOLOWER_ASC(initstr[1]) == 'g'))
     {
 # ifdef FEAT_GUI
-	gui.starting = TRUE;
+	gui.starting = true;
 # endif
 	parmp->evim_mode = TRUE;
 	++initstr;
@@ -2041,12 +2041,12 @@ parse_command_name(mparm_T *parmp)
 	++initstr;
 # endif
 # ifdef GUI_MAY_SPAWN
-	gui.dospawn = FALSE;	// No need to spawn a new process.
+	gui.dospawn = false;	// No need to spawn a new process.
 # endif
     }
 # ifdef GUI_MAY_SPAWN
     else
-	gui.dospawn = TRUE;	// Not "gvim". Need to spawn gvim.exe.
+	gui.dospawn = true;	// Not "gvim". Need to spawn gvim.exe.
 # endif
 
 
@@ -2189,7 +2189,7 @@ command_line_scan(mparm_T *parmp)
 		    cmdline_width = Columns = 80;   // need to init Columns
 		    info_message = TRUE; // use mch_msg(), not mch_errmsg()
 # if defined(FEAT_GUI) && !defined(ALWAYS_USE_GUI) && !defined(VIMDLL)
-		    gui.starting = FALSE; // not starting GUI, will exit
+		    gui.starting = false; // not starting GUI, will exit
 # endif
 		    list_version();
 		    msg_putchar('\n');
@@ -2215,7 +2215,7 @@ command_line_scan(mparm_T *parmp)
 		else if (STRNICMP(argv[0] + argv_idx, "nofork", 6) == 0)
 		{
 # ifdef FEAT_GUI
-		    gui.dofork = FALSE;	// don't fork() when starting GUI
+		    gui.dofork = false;	// don't fork() when starting GUI
 # endif
 		}
 		else if (STRNICMP(argv[0] + argv_idx, "noplugin", 8) == 0)
@@ -2327,7 +2327,7 @@ command_line_scan(mparm_T *parmp)
 	    case 'f':		// "-f"  GUI: run in foreground.  Amiga: open
 				// window directly, not with newcli
 # ifdef FEAT_GUI
-		gui.dofork = FALSE;	// don't fork() when starting GUI
+		gui.dofork = false;	// don't fork() when starting GUI
 # endif
 		break;
 
@@ -2344,7 +2344,7 @@ command_line_scan(mparm_T *parmp)
 	    case 'h':		// "-h" give help message
 # ifdef FEAT_GUI_GNOME
 		// Tell usage() to exit for "gvim".
-		gui.starting = FALSE;
+		gui.starting = false;
 # endif
 		usage();
 		break;
@@ -2374,7 +2374,7 @@ command_line_scan(mparm_T *parmp)
 
 	    case 'y':		// "-y"  easy mode
 # ifdef FEAT_GUI
-		gui.starting = TRUE;	// start GUI a bit later
+		gui.starting = true;	// start GUI a bit later
 # endif
 		parmp->evim_mode = TRUE;
 		break;
@@ -2504,7 +2504,7 @@ command_line_scan(mparm_T *parmp)
 	    case 'v':		// "-v"  Vi-mode (as if called "vi")
 		exmode_active = 0;
 # if defined(FEAT_GUI) && !defined(VIMDLL)
-		gui.starting = FALSE;	// don't start GUI
+		gui.starting = false;	// don't start GUI
 # endif
 		break;
 
@@ -2694,7 +2694,7 @@ scripterror:
 		     */
 # ifdef FEAT_GUI
 		    if (term_is_gui((char_u *)argv[0]))
-			gui.starting = TRUE;	// start GUI a bit later
+			gui.starting = true;	// start GUI a bit later
 		    else
 # endif
 			parmp->term = (char_u *)argv[0];
@@ -3508,7 +3508,7 @@ source_startup_scripts(mparm_T *parmp)
 main_start_gui(void)
 {
 # ifdef FEAT_GUI
-    gui.starting = TRUE;	// start GUI a bit later
+    gui.starting = true;	// start GUI a bit later
 # else
     mch_errmsg(_(e_gui_cannot_be_used_not_enabled_at_compile_time));
     mch_errmsg("\n");
@@ -3595,7 +3595,7 @@ mainerr(
     gui.in_use = mch_is_gui_executable();
 #endif
 #ifdef FEAT_GUI_MSWIN
-    gui.starting = FALSE;   // Needed to show as error.
+    gui.starting = false;   // Needed to show as error.
 #endif
 
     init_longVersion();
@@ -3822,7 +3822,7 @@ usage(void)
     if (gui.starting)
     {
 	mch_msg("\n");
-	gui.dofork = FALSE;
+	gui.dofork = false;
     }
     else
 # endif

--- a/src/misc1.c
+++ b/src/misc1.c
@@ -2284,7 +2284,7 @@ prepare_to_exit(void)
 #ifdef FEAT_GUI
     if (gui.in_use)
     {
-	gui.dying = TRUE;
+	gui.dying = true;
 	out_trash();	// trash any pending output
     }
     else


### PR DESCRIPTION
Problem:
Several gui_T fields are declared as "int" or "char" but are used strictly as
boolean flags with TRUE/FALSE values.  The integer types obscure the boolean
intent and are wider than needed.

Solution:
Change the following gui_T members to bool (stdbool.h) and update their
assignments from TRUE/FALSE to true/false accordingly.

- int -> bool (11 members):
  in_focus, in_use, starting, dying, dofork, dospawn, pointer_hidden,
  force_redraw, directx_enabled, font_can_bold, which_scrollbars[3]

- char -> bool (2 members):
  cursor_is_valid, menu_is_active

No existing code compares these members against TRUE/FALSE explicitly
(e.g. "== TRUE"), so only plain assignments are affected.

gui_init() used counter-style "--gui.starting" / "++gui.starting" to
temporarily clear the flag across a call to gui_mch_enable_menu().  With
gui.starting now bool this triggers -Werror=bool-operation, so replace it with
an explicit save/restore.

X11 Bool members (rsrc_rev_video, color_approx) are intentionally left
unchanged: rsrc_rev_video is registered as an X Toolkit resource with XtRBool /
sizeof(Bool) and must keep the int-sized X11 Bool type.