### PR TITLE
refactor(gui): remove dead color_approx flag and unreachable warning

### DIFF
--- a/src/errors.h
+++ b/src/errors.h
@@ -1138,10 +1138,7 @@ EXTERN char e_cant_find_postscript_resource_file_str_ps[]
 EXTERN char e_cant_read_postscript_resource_file_str[]
 	INIT(= N_("E457: Can't read PostScript resource file \"%s\""));
 #endif
-#ifdef FEAT_GUI_X11
-EXTERN char e_cannot_allocate_colormap_entry_some_colors_may_be_incorrect[]
-	INIT(= N_("E458: Cannot allocate colormap entry, some colors may be incorrect"));
-#endif
+// E458 unused
 #if defined(UNIX) || defined(FEAT_SESSION)
 EXTERN char e_cannot_go_back_to_previous_directory[]
 	INIT(= N_("E459: Cannot go back to previous directory"));

--- a/src/ex_eval.c
+++ b/src/ex_eval.c
@@ -275,7 +275,7 @@ cause_errthrow(
 		    {
 			char	    *tmsg;
 
-			// Skip the extra "Vim " prefix for message "E458".
+			// Skip the extra "Vim " prefix for message "E457".
 			tmsg = elem->msg;
 			if (STRNCMP(tmsg, "Vim E", 5) == 0
 				&& VIM_ISDIGIT(tmsg[5])

--- a/src/gui.h
+++ b/src/gui.h
@@ -341,7 +341,6 @@ typedef struct Gui
     Bool	rsrc_rev_video;	    // Use reverse video?
 
     char_u	*geom;		    // Geometry, eg "80x24"
-    Bool	color_approx;	    // Some color was approximated
 #endif
 
 #ifdef FEAT_GUI_GTK

--- a/src/gui_x11.c
+++ b/src/gui_x11.c
@@ -1419,9 +1419,6 @@ gui_mch_init(void)
 #endif
     }
 
-    if (gui.color_approx)
-	emsg(_(e_cannot_allocate_colormap_entry_some_colors_may_be_incorrect));
-
 #ifdef FEAT_BEVAL_GUI
     gui_init_tooltip_font();
 #endif


### PR DESCRIPTION
Problem:
gui.color_approx in gui_T has not been assigned anywhere since patch 7.4.2094 ("The color allocation in X11 is overly complicated", 2016), which dropped the single "gui.color_approx = TRUE;" site.  Because the member is zero-initialized and never written, the check "if (gui.color_approx)" in gui_mch_init() is always false and the "E458: Cannot allocate colormap entry, ..." warning can never be emitted.

Solution:
Remove the struct member and the unreachable branch.  The E458 error definition is removed but a "// E458 unused" marker is left in place so the number is not reused by future changes.  Update the example error code "E458" in the ex_eval.c comment to "E457" accordingly.