### PR TITLE
refactor: change boolean win_T members from int/char to bool

### DIFF
--- a/src/arglist.c
+++ b/src/arglist.c
@@ -541,7 +541,7 @@ check_arg_idx(win_T *win)
     {
 	// We are not editing the current entry in the argument list.
 	// Set "arg_had_last" if we are editing the last one.
-	win->w_arg_idx_invalid = TRUE;
+	win->w_arg_idx_invalid = true;
 	if (win->w_arg_idx != WARGCOUNT(win) - 1
 		&& arg_had_last == FALSE
 		&& ALIST(win) == &global_alist
@@ -557,7 +557,7 @@ check_arg_idx(win_T *win)
     {
 	// We are editing the current entry in the argument list.
 	// Set "arg_had_last" if it's also the last one
-	win->w_arg_idx_invalid = FALSE;
+	win->w_arg_idx_invalid = false;
 	if (win->w_arg_idx == WARGCOUNT(win) - 1
 					      && win->w_alist == &global_alist)
 	    arg_had_last = TRUE;

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -2001,8 +2001,8 @@ enter_buffer(buf_T *buf)
     curwin->w_cursor.lnum = 1;
     curwin->w_cursor.col = 0;
     curwin->w_cursor.coladd = 0;
-    curwin->w_set_curswant = TRUE;
-    curwin->w_topline_was_set = FALSE;
+    curwin->w_set_curswant = true;
+    curwin->w_topline_was_set = false;
 
     // mark cursor position as being invalid
     curwin->w_valid = 0;
@@ -2625,7 +2625,7 @@ buflist_getfile(
 	    curwin->w_cursor.col = col;
 	    check_cursor_col();
 	    curwin->w_cursor.coladd = 0;
-	    curwin->w_set_curswant = TRUE;
+	    curwin->w_set_curswant = true;
 	}
 	retval = OK;
     }
@@ -2655,7 +2655,7 @@ buflist_getfpos(void)
 	curwin->w_cursor.col = fpos->col;
 	check_cursor_col();
 	curwin->w_cursor.coladd = 0;
-	curwin->w_set_curswant = TRUE;
+	curwin->w_set_curswant = true;
     }
 }
 
@@ -3344,7 +3344,7 @@ get_winopts(buf_T *buf)
 #endif
 #ifdef FEAT_FOLDING
 	curwin->w_fold_manual = wp->w_fold_manual;
-	curwin->w_foldinvalid = TRUE;
+	curwin->w_foldinvalid = true;
 	cloneFoldGrowArray(&wp->w_folds, &curwin->w_folds);
 #endif
     }
@@ -3354,7 +3354,7 @@ get_winopts(buf_T *buf)
 	copy_winopt(&wip->wi_opt, &curwin->w_onebuf_opt);
 #ifdef FEAT_FOLDING
 	curwin->w_fold_manual = wip->wi_fold_manual;
-	curwin->w_foldinvalid = TRUE;
+	curwin->w_foldinvalid = true;
 	cloneFoldGrowArray(&wip->wi_folds, &curwin->w_folds);
 #endif
     }

--- a/src/diff.c
+++ b/src/diff.c
@@ -2747,11 +2747,11 @@ diff_set_topline(win_T *fromwin, win_T *towin)
     }
 
     // safety check (if diff info gets outdated strange things may happen)
-    towin->w_botfill = FALSE;
+    towin->w_botfill = false;
     if (towin->w_topline > towin->w_buffer->b_ml.ml_line_count)
     {
 	towin->w_topline = towin->w_buffer->b_ml.ml_line_count;
-	towin->w_botfill = TRUE;
+	towin->w_botfill = true;
     }
     if (towin->w_topline < 1)
     {

--- a/src/drawline.c
+++ b/src/drawline.c
@@ -4034,7 +4034,7 @@ win_line(
 		    curwin->w_cline_row = startrow;
 		    curwin->w_cline_height = wlv.row - startrow;
 #ifdef FEAT_FOLDING
-		    curwin->w_cline_folded = FALSE;
+		    curwin->w_cline_folded = false;
 #endif
 		    curwin->w_valid |= (VALID_CHEIGHT|VALID_CROW);
 		}

--- a/src/drawscreen.c
+++ b/src/drawscreen.c
@@ -212,7 +212,7 @@ update_screen(int type_arg)
 			    wp->w_redr_type = UPD_NOT_VALID;
 			    if (W_WINROW(wp) + wp->w_height
 					 + wp->w_status_height <= msg_scrolled)
-				wp->w_redr_status = TRUE;
+				wp->w_redr_status = true;
 			}
 		    }
 		}
@@ -489,7 +489,7 @@ win_redr_status(win_T *wp, int ignore_pum UNUSED)
 
     row = statusline_row(wp);
 
-    wp->w_redr_status = FALSE;
+    wp->w_redr_status = false;
     if (wp->w_status_height == 0)
     {
 	// no status line, can only be last window
@@ -501,7 +501,7 @@ win_redr_status(win_T *wp, int ignore_pum UNUSED)
 	    || (!ignore_pum && pum_visible()))
     {
 	// Don't redraw right now, do it later.
-	wp->w_redr_status = TRUE;
+	wp->w_redr_status = true;
     }
 #ifdef FEAT_STL_OPT
     else if (*p_stl != NUL || *wp->w_p_stl != NUL)
@@ -653,7 +653,7 @@ showruler(int always)
     if (pum_visible())
     {
 	// Don't redraw right now, do it later.
-	curwin->w_redr_status = TRUE;
+	curwin->w_redr_status = true;
 	return;
     }
 #if defined(FEAT_STL_OPT)
@@ -1442,7 +1442,7 @@ fold_line(
     {
 	curwin->w_cline_row = row;
 	curwin->w_cline_height = 1;
-	curwin->w_cline_folded = TRUE;
+	curwin->w_cline_folded = true;
 	curwin->w_valid |= (VALID_CHEIGHT|VALID_CROW);
     }
 
@@ -1563,7 +1563,7 @@ win_update(win_T *wp)
 
     if (type == UPD_NOT_VALID)
     {
-	wp->w_redr_status = TRUE;
+	wp->w_redr_status = true;
 	wp->w_lines_valid = 0;
     }
 
@@ -3370,7 +3370,7 @@ redraw_buf_and_status_later(buf_T *buf, int type)
 	if (wp->w_buffer == buf)
 	{
 	    redraw_win_later(wp, type);
-	    wp->w_redr_status = TRUE;
+	    wp->w_redr_status = true;
 	}
     }
 }
@@ -3387,7 +3387,7 @@ status_redraw_all(void)
     FOR_ALL_WINDOWS(wp)
 	if (wp->w_status_height)
 	{
-	    wp->w_redr_status = TRUE;
+	    wp->w_redr_status = true;
 	    redraw_later(UPD_VALID);
 	}
 }
@@ -3403,7 +3403,7 @@ status_redraw_curbuf(void)
     FOR_ALL_WINDOWS(wp)
 	if (wp->w_status_height != 0 && wp->w_buffer == curbuf)
 	{
-	    wp->w_redr_status = TRUE;
+	    wp->w_redr_status = true;
 	    redraw_later(UPD_VALID);
 	}
 }
@@ -3447,7 +3447,7 @@ redraw_statuslines(void)
 win_redraw_last_status(frame_T *frp)
 {
     if (frp->fr_layout == FR_LEAF)
-	frp->fr_win->w_redr_status = TRUE;
+	frp->fr_win->w_redr_status = true;
     else if (frp->fr_layout == FR_ROW)
     {
 	FOR_ALL_FRAMES(frp, frp->fr_child)

--- a/src/edit.c
+++ b/src/edit.c
@@ -468,7 +468,7 @@ edit(
 
 	// set curwin->w_curswant for next K_DOWN or K_UP
 	if (!arrow_used)
-	    curwin->w_set_curswant = TRUE;
+	    curwin->w_set_curswant = true;
 
 	// If there is no typeahead may check for timestamps (e.g., for when a
 	// menu invoked a shell command).
@@ -2740,7 +2740,7 @@ beginline(int flags)
 			       && !((flags & BL_FIX) && ptr[1] == NUL); ++ptr)
 		++curwin->w_cursor.col;
 	}
-	curwin->w_set_curswant = TRUE;
+	curwin->w_set_curswant = true;
     }
     adjust_skipcol();
 }
@@ -2768,7 +2768,7 @@ oneright(void)
 	coladvance(getviscol() + ((*ptr != TAB
 					  && vim_isprintc((*mb_ptr2char)(ptr)))
 		    ? ptr2cells(ptr) : 1));
-	curwin->w_set_curswant = TRUE;
+	curwin->w_set_curswant = true;
 	// Return OK if the cursor moved, FAIL otherwise (at window edge).
 	return (prevpos.col != curwin->w_cursor.col
 		    || prevpos.coladd != curwin->w_cursor.coladd) ? OK : FAIL;
@@ -2789,7 +2789,7 @@ oneright(void)
 	return FAIL;
     curwin->w_cursor.col += l;
 
-    curwin->w_set_curswant = TRUE;
+    curwin->w_set_curswant = true;
     adjust_skipcol();
     return OK;
 }
@@ -2836,7 +2836,7 @@ oneleft(void)
 		curwin->w_cursor.coladd = 0;
 	}
 
-	curwin->w_set_curswant = TRUE;
+	curwin->w_set_curswant = true;
 	adjust_skipcol();
 	return OK;
     }
@@ -2844,7 +2844,7 @@ oneleft(void)
     if (curwin->w_cursor.col == 0)
 	return FAIL;
 
-    curwin->w_set_curswant = TRUE;
+    curwin->w_set_curswant = true;
     --curwin->w_cursor.col;
 
     // if the character on the left of the current cursor is a multi-byte
@@ -3791,7 +3791,7 @@ ins_esc(
     // When an autoindent was removed, curswant stays after the
     // indent
     if (restart_edit == NUL && (colnr_T)temp == curwin->w_cursor.col)
-	curwin->w_set_curswant = TRUE;
+	curwin->w_set_curswant = true;
 
     // Remember the last Insert position in the '^ mark.
     if ((cmdmod.cmod_flags & CMOD_KEEPJUMPS) == 0)
@@ -4740,7 +4740,7 @@ ins_left(void)
 	start_arrow(&tpos);
 	--(curwin->w_cursor.lnum);
 	coladvance((colnr_T)MAXCOL);
-	curwin->w_set_curswant = TRUE;	// so we stay at the end
+	curwin->w_set_curswant = true;	// so we stay at the end
     }
     else
 	vim_beep(BO_CRSR);
@@ -4800,7 +4800,7 @@ ins_s_left(void)
 	if (!end_change)
 	    AppendCharToRedobuff(K_S_LEFT);
 	(void)bck_word(1L, FALSE, FALSE);
-	curwin->w_set_curswant = TRUE;
+	curwin->w_set_curswant = true;
     }
     else
 	vim_beep(BO_CRSR);
@@ -4822,7 +4822,7 @@ ins_right(void)
 	start_arrow_with_change(&curwin->w_cursor, end_change);
 	if (!end_change)
 	    AppendCharToRedobuff(K_RIGHT);
-	curwin->w_set_curswant = TRUE;
+	curwin->w_set_curswant = true;
 	if (virtual_active())
 	    oneright();
 	else
@@ -4845,7 +4845,7 @@ ins_right(void)
 	    && curwin->w_cursor.lnum < curbuf->b_ml.ml_line_count)
     {
 	start_arrow(&curwin->w_cursor);
-	curwin->w_set_curswant = TRUE;
+	curwin->w_set_curswant = true;
 	++curwin->w_cursor.lnum;
 	curwin->w_cursor.col = 0;
     }
@@ -4870,7 +4870,7 @@ ins_s_right(void)
 	if (!end_change)
 	    AppendCharToRedobuff(K_S_RIGHT);
 	(void)fwd_word(1L, FALSE, 0);
-	curwin->w_set_curswant = TRUE;
+	curwin->w_set_curswant = true;
     }
     else
 	vim_beep(BO_CRSR);

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -10851,7 +10851,7 @@ search_cmn(typval_T *argvars, pos_T *match_pos, int *flagsp)
     if (flags & SP_NOMOVE)
 	curwin->w_cursor = save_cursor;
     else
-	curwin->w_set_curswant = TRUE;
+	curwin->w_set_curswant = true;
 theend:
     p_ws = save_p_ws;
 
@@ -11443,7 +11443,7 @@ set_position(typval_T *argvars, typval_T *rettv, int charpos)
 	if (curswant >= 0)
 	{
 	    curwin->w_curswant = curswant - 1;
-	    curwin->w_set_curswant = FALSE;
+	    curwin->w_set_curswant = false;
 	}
 	check_cursor();
 	rettv->vval.v_number = 0;
@@ -11994,7 +11994,7 @@ f_spellbadword(typval_T *argvars UNUSED, typval_T *rettv)
 	if (len != 0)
 	{
 	    word = ml_get_cursor();
-	    curwin->w_set_curswant = TRUE;
+	    curwin->w_set_curswant = true;
 	}
     }
     else if (*curbuf->b_s.b_p_spl != NUL)

--- a/src/evalwindow.c
+++ b/src/evalwindow.c
@@ -794,7 +794,7 @@ f_win_execute(typval_T *argvars, typval_T *rettv)
 
     // Update the status line if the cursor moved.
     if (win_valid(wp) && !EQUAL_POS(curpos, wp->w_cursor))
-	wp->w_redr_status = TRUE;
+	wp->w_redr_status = true;
 
     // In case the command moved the cursor or changed the Visual area,
     // check it is valid.
@@ -1256,7 +1256,7 @@ f_winrestview(typval_T *argvars, typval_T *rettv UNUSED)
     if (dict_has_key(dict, "curswant"))
     {
 	curwin->w_curswant = (colnr_T)dict_get_number(dict, "curswant");
-	curwin->w_set_curswant = FALSE;
+	curwin->w_set_curswant = false;
     }
 
     if (dict_has_key(dict, "topline"))

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -3430,7 +3430,7 @@ do_ecmd(
 		curwin->w_cursor.col = solcol;
 		check_cursor_col();
 		curwin->w_cursor.coladd = 0;
-		curwin->w_set_curswant = TRUE;
+		curwin->w_set_curswant = true;
 	    }
 	    else
 		beginline(BL_SOL | BL_FIX);

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -7917,7 +7917,7 @@ ex_syncbind(exarg_T *eap UNUSED)
 	    curwin->w_scbind_pos = topline;
 	    redraw_later(UPD_VALID);
 	    cursor_correct();
-	    curwin->w_redr_status = TRUE;
+	    curwin->w_redr_status = true;
 	}
     }
     curwin = save_curwin;

--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -584,7 +584,7 @@ may_do_incsearch_highlighting(
 
     // May redraw the status line to show the cursor position.
     if (p_ru && curwin->w_status_height > 0)
-	curwin->w_redr_status = TRUE;
+	curwin->w_redr_status = true;
 
     update_screen(UPD_SOME_VALID);
     highlight_match = FALSE;
@@ -1829,7 +1829,7 @@ getcmdline_int(
 	FOR_ALL_WINDOWS(wp)
 	    if (*p_stl != NUL || *wp->w_p_stl != NUL)
 	    {
-		wp->w_redr_status = TRUE;
+		wp->w_redr_status = true;
 		found_one = TRUE;
 	    }
 

--- a/src/fold.c
+++ b/src/fold.c
@@ -501,7 +501,7 @@ newFoldLevelWin(win_T *wp)
 	fp = (fold_T *)wp->w_folds.ga_data;
 	for (i = 0; i < wp->w_folds.ga_len; ++i)
 	    fp[i].fd_flags = FD_LEVEL;
-	wp->w_fold_manual = FALSE;
+	wp->w_fold_manual = false;
     }
     changed_window_setting_win(wp);
 }
@@ -692,7 +692,7 @@ foldCreate(linenr_T start, linenr_T end)
     if (use_level && !closed && level < curwin->w_p_fdl)
 	closeFold(start, 1L);
     if (!use_level)
-	curwin->w_fold_manual = TRUE;
+	curwin->w_fold_manual = true;
     fp->fd_flags = FD_CLOSED;
     fp->fd_small = MAYBE;
 
@@ -805,7 +805,7 @@ deleteFold(
 clearFolding(win_T *win)
 {
     deleteFoldRecurse(&win->w_folds);
-    win->w_foldinvalid = FALSE;
+    win->w_foldinvalid = false;
 }
 
 // foldUpdate() {{{2
@@ -875,7 +875,7 @@ foldUpdate(win_T *wp, linenr_T top, linenr_T bot)
     void
 foldUpdateAll(win_T *win)
 {
-    win->w_foldinvalid = TRUE;
+    win->w_foldinvalid = true;
     redraw_win_later(win, UPD_NOT_VALID);
 }
 
@@ -1219,7 +1219,7 @@ checkupdate(win_T *wp)
 	return;
 
     foldUpdate(wp, (linenr_T)1, (linenr_T)MAXLNUM); // will update all
-    wp->w_foldinvalid = FALSE;
+    wp->w_foldinvalid = false;
 }
 
 // setFoldRepeat() {{{2
@@ -1387,7 +1387,7 @@ setManualFoldWin(
 	    found->fd_flags = FD_CLOSED;
 	    done |= DONE_ACTION;
 	}
-	wp->w_fold_manual = TRUE;
+	wp->w_fold_manual = true;
 	if (done & DONE_ACTION)
 	    changed_window_setting_win(wp);
 	done |= DONE_FOLD;
@@ -2177,7 +2177,7 @@ foldUpdateIEMS(win_T *wp, linenr_T top, linenr_T bot)
 	// Need to update all folds.
 	top = 1;
 	bot = wp->w_buffer->b_ml.ml_line_count;
-	wp->w_foldinvalid = FALSE;
+	wp->w_foldinvalid = false;
 
 	// Mark all folds as maybe-small.
 	setSmallMaybe(&wp->w_folds);
@@ -2679,14 +2679,14 @@ foldUpdateIEMSRecurse(
 		    // The first fold depends on the containing fold.
 		    if (topflags == FD_OPEN)
 		    {
-			flp->wp->w_fold_manual = TRUE;
+			flp->wp->w_fold_manual = true;
 			fp->fd_flags = FD_OPEN;
 		    }
 		    else if (i <= 0)
 		    {
 			fp->fd_flags = topflags;
 			if (topflags != FD_LEVEL)
-			    flp->wp->w_fold_manual = TRUE;
+			    flp->wp->w_fold_manual = true;
 		    }
 		    else
 			fp->fd_flags = (fp - 1)->fd_flags;

--- a/src/if_lua.c
+++ b/src/if_lua.c
@@ -1687,7 +1687,7 @@ luaV_window_newindex(lua_State *L)
 	luaV_checksandbox(L);
 # endif
 	w->w_cursor.col = v - 1;
-	w->w_set_curswant = TRUE;
+	w->w_set_curswant = true;
 	update_screen(UPD_VALID);
     }
     else if (strncmp(s, "width", 5) == 0)

--- a/src/if_mzsch.c
+++ b/src/if_mzsch.c
@@ -2128,7 +2128,7 @@ set_cursor(void *data, int argc, Scheme_Object **argv)
 
     win->win->w_cursor.lnum = lnum;
     win->win->w_cursor.col = col;
-    win->win->w_set_curswant = TRUE;
+    win->win->w_set_curswant = true;
     update_screen(UPD_VALID);
 
     raise_if_error();

--- a/src/if_ruby.c
+++ b/src/if_ruby.c
@@ -1692,7 +1692,7 @@ window_set_cursor(VALUE self, VALUE pos)
     col = RARRAY_PTR(pos)[1];
     win->w_cursor.lnum = NUM2LONG(lnum);
     win->w_cursor.col = NUM2UINT(col);
-    win->w_set_curswant = TRUE;
+    win->w_set_curswant = true;
     check_cursor();		    // put cursor on an existing line
     update_screen(UPD_NOT_VALID);
     return Qnil;

--- a/src/if_tcl.c
+++ b/src/if_tcl.c
@@ -1103,7 +1103,7 @@ winselfcmd(
 	    // TODO: should check column
 	    win->w_cursor.lnum = val1;
 	    win->w_cursor.col = col2vim(val2);
-	    win->w_set_curswant = TRUE;
+	    win->w_set_curswant = true;
 	    flags |= FL_UPDATE_SCREEN;
 	    break;
 

--- a/src/indent.c
+++ b/src/indent.c
@@ -1454,7 +1454,7 @@ change_indent(
 	curwin->w_cursor.col = 0;
     else
 	curwin->w_cursor.col = (colnr_T)new_cursor_col;
-    curwin->w_set_curswant = TRUE;
+    curwin->w_set_curswant = true;
     changed_cline_bef_curs();
 
     // May have to adjust the start of the insert.

--- a/src/memline.c
+++ b/src/memline.c
@@ -6234,7 +6234,7 @@ goto_byte(long cnt)
 	curwin->w_cursor.lnum = lnum;
 	curwin->w_cursor.col = (colnr_T)boff;
 	curwin->w_cursor.coladd = 0;
-	curwin->w_set_curswant = TRUE;
+	curwin->w_set_curswant = true;
     }
     check_cursor();
 

--- a/src/misc1.c
+++ b/src/misc1.c
@@ -621,7 +621,7 @@ check_status(buf_T *buf)
     FOR_ALL_WINDOWS(wp)
 	if (wp->w_buffer == buf && wp->w_status_height)
 	{
-	    wp->w_redr_status = TRUE;
+	    wp->w_redr_status = true;
 	    set_must_redraw(UPD_VALID);
 	}
 }

--- a/src/misc2.c
+++ b/src/misc2.c
@@ -719,7 +719,7 @@ set_leftcol(colnr_T leftcol)
     }
 
     if (retval)
-	curwin->w_set_curswant = TRUE;
+	curwin->w_set_curswant = true;
     redraw_later(UPD_NOT_VALID);
     return retval;
 }

--- a/src/mouse.c
+++ b/src/mouse.c
@@ -1123,7 +1123,7 @@ do_mouse(
 		    find_end_of_word(&curwin->w_cursor);
 		}
 	    }
-	    curwin->w_set_curswant = TRUE;
+	    curwin->w_set_curswant = true;
 	}
 	if (is_click)
 	    redraw_curbuf_later(UPD_INVERTED);	// update the inversion
@@ -1329,7 +1329,7 @@ ins_mousescroll(int dir)
     int did_scroll = (orig_topline != curwin->w_topline
 		   || orig_leftcol != curwin->w_leftcol);
 
-    curwin->w_redr_status = TRUE;
+    curwin->w_redr_status = true;
     curwin = old_curwin;
     curbuf = curwin->w_buffer;
 
@@ -2346,7 +2346,7 @@ retnomove:
     }
 
     curwin->w_curswant = col;
-    curwin->w_set_curswant = FALSE;	// May still have been TRUE
+    curwin->w_set_curswant = false;	// May still have been TRUE
     if (coladvance(col) == FAIL)	// Mouse click beyond end of line
     {
 	if (inclusive != NULL)
@@ -2436,7 +2436,7 @@ nv_mousescroll(cmdarg_T *cap)
     // Call the common mouse scroll function shared with other modes.
     do_mousescroll(cap);
 
-    curwin->w_redr_status = TRUE;
+    curwin->w_redr_status = true;
     curwin = old_curwin;
     curbuf = curwin->w_buffer;
 }

--- a/src/move.c
+++ b/src/move.c
@@ -650,7 +650,7 @@ update_curswant_force(void)
 	- curwin->w_virtcol_first_char
 #endif
 	;
-    curwin->w_set_curswant = FALSE;
+    curwin->w_set_curswant = false;
 }
 
 /*
@@ -766,7 +766,7 @@ set_topline(win_T *wp, linenr_T lnum)
     if (wp->w_botline > wp->w_buffer->b_ml.ml_line_count + 1)
 	wp->w_botline = wp->w_buffer->b_ml.ml_line_count + 1;
     wp->w_topline = lnum;
-    wp->w_topline_was_set = TRUE;
+    wp->w_topline_was_set = true;
 #ifdef FEAT_DIFF
     if (lnum != prev_topline)
 	// Keep the filler lines when the topline didn't change.
@@ -3044,7 +3044,7 @@ scroll_cursor_halfway(int atend, int prefer_above)
 #ifdef FEAT_DIFF
     curwin->w_topfill = topfill;
     if (old_topline > curwin->w_topline + curwin->w_height)
-	curwin->w_botfill = FALSE;
+	curwin->w_botfill = false;
     check_topfill(curwin, FALSE);
 #endif
     curwin->w_valid &= ~(VALID_WROW|VALID_CROW|VALID_BOTLINE|VALID_BOTLINE_AP);
@@ -3458,7 +3458,7 @@ do_check_cursorbind(void)
 	    // Only scroll when 'scrollbind' hasn't done this.
 	    if (!curwin->w_p_scb)
 		update_topline();
-	    curwin->w_redr_status = TRUE;
+	    curwin->w_redr_status = true;
 	}
     }
 

--- a/src/normal.c
+++ b/src/normal.c
@@ -1845,7 +1845,7 @@ display_showcmd(void)
     if (*p_sloc == 's')
     {
 	if (showcmd_is_clear)
-	    curwin->w_redr_status = TRUE;
+	    curwin->w_redr_status = true;
 	else
 	    win_redr_status(curwin, FALSE);
     }
@@ -1998,7 +1998,7 @@ check_scrollbind(linenr_T topline_diff, long leftcol_diff)
 
 	    redraw_later(UPD_VALID);
 	    cursor_correct();
-	    curwin->w_redr_status = TRUE;
+	    curwin->w_redr_status = true;
 	}
 
 	// do the horizontal scroll
@@ -2314,7 +2314,7 @@ find_decl(
     }
     else
     {
-	curwin->w_set_curswant = TRUE;
+	curwin->w_set_curswant = true;
 	// "n" searches forward now
 	reset_search_dir();
     }
@@ -2923,14 +2923,14 @@ nv_zet(cmdarg_T *cap)
 
 		// "zx": re-apply 'foldlevel' and open folds at the cursor
     case 'x':	curwin->w_p_fen = TRUE;
-		curwin->w_foldinvalid = TRUE;	// recompute folds
+		curwin->w_foldinvalid = true;	// recompute folds
 		newFoldLevel();			// update right now
 		foldOpenCursor();
 		break;
 
 		// "zX": undo manual opens/closes, re-apply 'foldlevel'
     case 'X':	curwin->w_p_fen = TRUE;
-		curwin->w_foldinvalid = TRUE;	// recompute folds
+		curwin->w_foldinvalid = true;	// recompute folds
 		old_fdl = -1;			// force an update
 		break;
 
@@ -3875,7 +3875,7 @@ nv_right(cmdarg_T *cap)
 		    ++curwin->w_cursor.lnum;
 		    curwin->w_cursor.col = 0;
 		    curwin->w_cursor.coladd = 0;
-		    curwin->w_set_curswant = TRUE;
+		    curwin->w_set_curswant = true;
 		    cap->oap->inclusive = FALSE;
 		}
 		continue;
@@ -3895,7 +3895,7 @@ nv_right(cmdarg_T *cap)
 	}
 	else if (past_line)
 	{
-	    curwin->w_set_curswant = TRUE;
+	    curwin->w_set_curswant = true;
 	    if (virtual_active())
 		oneright();
 	    else
@@ -3953,7 +3953,7 @@ nv_left(cmdarg_T *cap)
 	    {
 		--(curwin->w_cursor.lnum);
 		coladvance((colnr_T)MAXCOL);
-		curwin->w_set_curswant = TRUE;
+		curwin->w_set_curswant = true;
 
 		// When the NL before the first char has to be deleted we
 		// put the cursor on the NUL after the previous line.
@@ -4222,7 +4222,7 @@ normal_search(
     cap->oap->motion_type = MCHAR;
     cap->oap->inclusive = FALSE;
     cap->oap->use_reg_one = TRUE;
-    curwin->w_set_curswant = TRUE;
+    curwin->w_set_curswant = true;
 
     CLEAR_FIELD(sia);
     i = do_search(cap->oap, dir, dir, pat, patlen, cap->count1,
@@ -4289,7 +4289,7 @@ nv_csearch(cmdarg_T *cap)
 	return;
     }
 
-    curwin->w_set_curswant = TRUE;
+    curwin->w_set_curswant = true;
     // Include a Tab for "tx" and for "dfx".
     if (gchar_cursor() == TAB && virtual_active() && cap->arg == FORWARD
 	    && (t_cmd || cap->oap->op_type != OP_NOP))
@@ -4431,7 +4431,7 @@ nv_bracket_block(cmdarg_T *cap, pos_T *old_pos)
     {
 	setpcmark();
 	curwin->w_cursor = *pos;
-	curwin->w_set_curswant = TRUE;
+	curwin->w_set_curswant = true;
 #ifdef FEAT_FOLDING
 	if ((fdo_flags & FDO_BLOCK) && KeyTyped
 		&& cap->oap->op_type == OP_NOP)
@@ -4495,7 +4495,7 @@ nv_brackets(cmdarg_T *cap)
 		(linenr_T)MAXLNUM,
 		FALSE, FALSE);
 	    vim_free(ptr);
-	    curwin->w_set_curswant = TRUE;
+	    curwin->w_set_curswant = true;
 	}
     }
     else
@@ -4520,7 +4520,7 @@ nv_brackets(cmdarg_T *cap)
 	else
 	    flag = '}';		    // "][" or "[]"
 
-	curwin->w_set_curswant = TRUE;
+	curwin->w_set_curswant = true;
 	// Imitate strange Vi behaviour: When using "]]" with an operator
 	// we also stop at '}'.
 	if (!findpar(&cap->oap->inclusive, cap->arg, cap->count1, flag,
@@ -4605,7 +4605,7 @@ nv_brackets(cmdarg_T *cap)
 		break;
 	    }
 	    else
-		curwin->w_set_curswant = TRUE;
+		curwin->w_set_curswant = true;
 # ifdef FEAT_FOLDING
 	if (cap->oap->op_type == OP_NOP && (fdo_flags & FDO_SEARCH) && KeyTyped)
 	    foldOpenCursor();
@@ -4665,7 +4665,7 @@ nv_percent(cmdarg_T *cap)
 	{
 	    setpcmark();
 	    curwin->w_cursor = *pos;
-	    curwin->w_set_curswant = TRUE;
+	    curwin->w_set_curswant = true;
 	    curwin->w_cursor.coladd = 0;
 	    adjust_for_sel(cap);
 	}
@@ -4690,7 +4690,7 @@ nv_brace(cmdarg_T *cap)
     cap->oap->use_reg_one = TRUE;
     // The motion used to be inclusive for "(", but that is not what Vi does.
     cap->oap->inclusive = FALSE;
-    curwin->w_set_curswant = TRUE;
+    curwin->w_set_curswant = true;
 
     if (findsent(cap->arg, cap->count1) == FAIL)
     {
@@ -4730,7 +4730,7 @@ nv_findpar(cmdarg_T *cap)
     cap->oap->motion_type = MCHAR;
     cap->oap->inclusive = FALSE;
     cap->oap->use_reg_one = TRUE;
-    curwin->w_set_curswant = TRUE;
+    curwin->w_set_curswant = true;
     if (!findpar(&cap->oap->inclusive, cap->arg, cap->count1, NUL, FALSE))
     {
 	clearopbeep(cap->oap);
@@ -4778,7 +4778,7 @@ nv_kundo(cmdarg_T *cap)
     }
 #endif
     u_undo((int)cap->count1);
-    curwin->w_set_curswant = TRUE;
+    curwin->w_set_curswant = true;
 }
 
 /*
@@ -4983,7 +4983,7 @@ nv_replace(cmdarg_T *cap)
 	if (has_mbyte)
 	    mb_adjust_cursor();
 	curbuf->b_op_end = curwin->w_cursor;
-	curwin->w_set_curswant = TRUE;
+	curwin->w_set_curswant = true;
 	set_last_insert(cap->nchar);
     }
 }
@@ -5033,7 +5033,7 @@ v_swap_corners(int cmdchar)
 	old_cursor = curwin->w_cursor;
 	curwin->w_cursor = VIsual;
 	VIsual = old_cursor;
-	curwin->w_set_curswant = TRUE;
+	curwin->w_set_curswant = true;
     }
 }
 
@@ -5187,7 +5187,7 @@ n_swapchar(cmdarg_T *cap)
 
 
     check_cursor();
-    curwin->w_set_curswant = TRUE;
+    curwin->w_set_curswant = true;
     if (did_change)
     {
 	changed_lines(startpos.lnum, startpos.col, curwin->w_cursor.lnum + 1,
@@ -5224,7 +5224,7 @@ nv_cursormark(cmdarg_T *cap, int flag, pos_T *pos)
     if (cap->cmdchar == '`')
 	cap->oap->use_reg_one = TRUE;
     cap->oap->inclusive = FALSE;		// ignored if not MCHAR
-    curwin->w_set_curswant = TRUE;
+    curwin->w_set_curswant = true;
 }
 
 /*
@@ -5411,7 +5411,7 @@ nv_pcmark(cmdarg_T *cap)
 	pos = movemark((int)cap->count1);
     if (pos == (pos_T *)-1)		// jump to other file
     {
-	curwin->w_set_curswant = TRUE;
+	curwin->w_set_curswant = true;
 	check_cursor();
     }
     else if (pos != NULL)		    // can jump
@@ -5551,7 +5551,7 @@ nv_visual(cmdarg_T *cap)
 		coladvance(curwin->w_curswant);
 	    }
 	    else
-		curwin->w_set_curswant = TRUE;
+		curwin->w_set_curswant = true;
 	    redraw_curbuf_later(UPD_INVERTED);	// show the inversion
 	}
 	else
@@ -5813,7 +5813,7 @@ nv_g_home_m_cmd(cmdarg_T *cap)
 	while (VIM_ISWHITE(i) && oneright() == OK);
 	curwin->w_valid &= ~VALID_WCOL;
     }
-    curwin->w_set_curswant = TRUE;
+    curwin->w_set_curswant = true;
 #ifdef FEAT_FOLDING
     if (hasAnyFolding(curwin))
     {
@@ -5854,7 +5854,7 @@ nv_g_underscore_cmd(cmdarg_T *cap)
     while (curwin->w_cursor.col > 0
 	    && VIM_ISWHITE(ptr[curwin->w_cursor.col]))
 	--curwin->w_cursor.col;
-    curwin->w_set_curswant = TRUE;
+    curwin->w_set_curswant = true;
     adjust_for_sel(cap);
 }
 
@@ -6103,7 +6103,7 @@ nv_g_cmd(cmdarg_T *cap)
 		coladvance((colnr_T)(i * cap->count0 / 100));
 	    else
 		coladvance((colnr_T)(i / 2));
-	    curwin->w_set_curswant = TRUE;
+	    curwin->w_set_curswant = true;
 	}
 	break;
 
@@ -6135,7 +6135,7 @@ nv_g_cmd(cmdarg_T *cap)
     case 'e':
     case 'E':
 	oap->motion_type = MCHAR;
-	curwin->w_set_curswant = TRUE;
+	curwin->w_set_curswant = true;
 	oap->inclusive = TRUE;
 	if (bckend_word(cap->count1, cap->nchar == 'E', FALSE) == FAIL)
 	    clearopbeep(oap);
@@ -6409,7 +6409,7 @@ nv_redo_or_register(cmdarg_T *cap)
 	return;
 
     u_redo((int)cap->count1);
-    curwin->w_set_curswant = TRUE;
+    curwin->w_set_curswant = true;
 }
 
 /*
@@ -6432,7 +6432,7 @@ nv_Undo(cmdarg_T *cap)
 	return;
 
     u_undoline();
-    curwin->w_set_curswant = TRUE;
+    curwin->w_set_curswant = true;
 }
 
 /*
@@ -6569,7 +6569,7 @@ nv_pipe(cmdarg_T *cap)
 	curwin->w_curswant = 0;
     // keep curswant at the column where we wanted to go, not where
     // we ended; differs if line is too short
-    curwin->w_set_curswant = FALSE;
+    curwin->w_set_curswant = false;
 }
 
 /*
@@ -6581,7 +6581,7 @@ nv_bck_word(cmdarg_T *cap)
 {
     cap->oap->motion_type = MCHAR;
     cap->oap->inclusive = FALSE;
-    curwin->w_set_curswant = TRUE;
+    curwin->w_set_curswant = true;
     if (bck_word(cap->count1, cap->arg, FALSE) == FAIL)
 	clearopbeep(cap->oap);
 #ifdef FEAT_FOLDING
@@ -6651,7 +6651,7 @@ nv_wordcmd(cmdarg_T *cap)
     }
 
     cap->oap->motion_type = MCHAR;
-    curwin->w_set_curswant = TRUE;
+    curwin->w_set_curswant = true;
     if (word_end)
 	n = end_word(cap->count1, cap->arg, flag, FALSE);
     else
@@ -6931,7 +6931,7 @@ nv_esc(cmdarg_T *cap)
     {
 	end_visual_mode();	// stop Visual
 	check_cursor_col();	// make sure cursor is not beyond EOL
-	curwin->w_set_curswant = TRUE;
+	curwin->w_set_curswant = true;
 	redraw_curbuf_later(UPD_INVERTED);
     }
     else if (no_reason)
@@ -6957,7 +6957,7 @@ nv_esc(cmdarg_T *cap)
     void
 set_cursor_for_append_to_line(void)
 {
-    curwin->w_set_curswant = TRUE;
+    curwin->w_set_curswant = true;
     if (get_ve_flags() == VE_ALL)
     {
 	int save_State = State;
@@ -7242,7 +7242,7 @@ nv_object(
     if (flag == FAIL)
 	clearopbeep(cap->oap);
     adjust_cursor_col();
-    curwin->w_set_curswant = TRUE;
+    curwin->w_set_curswant = true;
 }
 
 /*

--- a/src/ops.c
+++ b/src/ops.c
@@ -1719,7 +1719,7 @@ op_insert(oparg_T *oap, long count1)
 	if (oap->block_mode && curwin->w_cursor.coladd == 0)
 	{
 	    // Move the cursor to the character right of the block.
-	    curwin->w_set_curswant = TRUE;
+	    curwin->w_set_curswant = true;
 	    while (*ml_get_cursor() != NUL
 		    && (curwin->w_cursor.col < bd.textcol + bd.textlen))
 		++curwin->w_cursor.col;
@@ -2390,7 +2390,7 @@ do_join(
     check_cursor_col();
 
     curwin->w_cursor.coladd = 0;
-    curwin->w_set_curswant = TRUE;
+    curwin->w_set_curswant = true;
 
 theend:
     vim_free(spaces);
@@ -3273,7 +3273,7 @@ theend:
     if (visual)
 	curwin->w_cursor = save_cursor;
     else if (did_change)
-	curwin->w_set_curswant = TRUE;
+	curwin->w_set_curswant = true;
     else if (virtual_active())
 	curwin->w_cursor.coladd = save_coladd;
 
@@ -4270,7 +4270,7 @@ do_pending_operator(cmdarg_T *cap, int old_col, int gui_yank)
 	    if (l > 1)
 		oap->end.col += l - 1;
 	}
-	curwin->w_set_curswant = TRUE;
+	curwin->w_set_curswant = true;
 
 	// oap->empty is set when start and end are the same.  The inclusive
 	// flag affects this too, unless yanking and the end is on a NUL.

--- a/src/option.c
+++ b/src/option.c
@@ -5283,7 +5283,7 @@ set_bool_option(
     if (curwin->w_curswant != MAXCOL
 		     && (options[opt_idx].flags & (P_CURSWANT | P_RALL)) != 0
 				   && (options[opt_idx].flags & P_HLONLY) == 0)
-	curwin->w_set_curswant = TRUE;
+	curwin->w_set_curswant = true;
 
     if ((opt_flags & OPT_NO_REDRAW) == 0)
 	check_redraw(options[opt_idx].flags);
@@ -5523,7 +5523,7 @@ set_num_option(
     if (curwin->w_curswant != MAXCOL
 		     && (options[opt_idx].flags & (P_CURSWANT | P_RALL)) != 0
 				   && (options[opt_idx].flags & P_HLONLY) == 0)
-	curwin->w_set_curswant = TRUE;
+	curwin->w_set_curswant = true;
 
     if ((opt_flags & OPT_NO_REDRAW) == 0)
 	check_redraw(options[opt_idx].flags);

--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -1416,7 +1416,7 @@ did_set_buftype(optset_T *args UNUSED)
 
     if (curwin->w_status_height)
     {
-	curwin->w_redr_status = TRUE;
+	curwin->w_redr_status = true;
 	redraw_later(UPD_VALID);
     }
     curbuf->b_help = (curbuf->b_p_bt[0] == 'h');
@@ -5553,7 +5553,7 @@ did_set_string_option(
     if (curwin->w_curswant != MAXCOL
 		   && (get_option_flags(opt_idx) & (P_CURSWANT | P_RALL)) != 0
 				&& (get_option_flags(opt_idx) & P_HLONLY) == 0)
-	curwin->w_set_curswant = TRUE;
+	curwin->w_set_curswant = true;
 
     if ((opt_flags & OPT_NO_REDRAW) == 0)
     {

--- a/src/popupmenu.c
+++ b/src/popupmenu.c
@@ -1483,7 +1483,7 @@ pum_set_selected(int n, int repeat UNUSED)
 			// window is not resized, skip the preview window's
 			// status line redrawing.
 			if (ins_compl_active() && !resized)
-			    curwin->w_redr_status = FALSE;
+			    curwin->w_redr_status = false;
 
 			// Return cursor to where we were
 			validate_cursor();
@@ -1513,7 +1513,7 @@ pum_set_selected(int n, int repeat UNUSED)
 			// StatusLineNC for a moment and cause flicker.
 			pum_will_redraw = !resized;
 			save_redr_status = curwin_save->w_redr_status;
-			curwin_save->w_redr_status = FALSE;
+			curwin_save->w_redr_status = false;
 			update_screen(0);
 			pum_pretend_not_visible = FALSE;
 			pum_will_redraw = FALSE;

--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -880,7 +880,7 @@ apply_general_options(win_T *wp, dict_T *dict)
 	    int		i;
 
 	    CHECK_LIST_MATERIALIZE(list);
-	    wp->w_border_highlight_isset = TRUE;
+	    wp->w_border_highlight_isset = true;
 	    // Clear all highlights if list is empty
 	    if (list->lv_len == 0)
 	    {
@@ -1566,7 +1566,7 @@ popup_adjust_position(win_T *wp)
     if (wp->w_buffer->b_term != NULL && !term_is_finished(wp->w_buffer))
 	// Terminal window with running job never has a scrollbar, adjusts to
 	// window height.
-	wp->w_has_scrollbar = FALSE;
+	wp->w_has_scrollbar = false;
 #endif
     maxwidth_no_scrollbar = maxwidth;
     if (wp->w_has_scrollbar)
@@ -1736,7 +1736,7 @@ popup_adjust_position(win_T *wp)
 	if (wp->w_buffer->b_term == NULL || term_is_finished(wp->w_buffer))
 #endif
 	{
-	    wp->w_has_scrollbar = TRUE;
+	    wp->w_has_scrollbar = true;
 	    if (width_with_scrollbar > 0)
 		wp->w_width = width_with_scrollbar;
 	}
@@ -3385,7 +3385,7 @@ redraw_under_popup_area(int winrow, int wincol, int height, int width, int lefto
 		    redrawWinline(twp, lnum);
 		}
 		else if (line_cp == twp->w_height)
-		    twp->w_redr_status = TRUE;
+		    twp->w_redr_status = true;
 	    }
 	}
     }
@@ -4419,7 +4419,7 @@ redraw_win_under_opacity_popup(win_T *wp)
 		else if (line_cp == twp->w_height)
 		    // Status bar line: mark for redraw to prevent
 		    // opacity blend accumulation.
-		    twp->w_redr_status = TRUE;
+		    twp->w_redr_status = true;
 	    }
 	}
     }
@@ -4703,7 +4703,7 @@ may_update_popup_mask(int type)
 
 				if (line_cp >= wp->w_height)
 				    // In (or below) status line
-				    wp->w_redr_status = TRUE;
+				    wp->w_redr_status = true;
 				else
 				{
 				    // compute the position in the buffer line

--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -3649,7 +3649,7 @@ qf_jump_goto_line(
 		coladvance(qf_col - 1);
 	    else
 		curwin->w_cursor.col = qf_col - 1;
-	    curwin->w_set_curswant = TRUE;
+	    curwin->w_set_curswant = true;
 	    check_cursor();
 	}
 	else
@@ -4768,7 +4768,7 @@ qf_win_goto(win_T *win, linenr_T lnum)
     curwin->w_curswant = 0;
     update_topline();		// scroll to show the line
     redraw_later(UPD_VALID);
-    curwin->w_redr_status = TRUE;	// update ruler
+    curwin->w_redr_status = true;	// update ruler
     curwin = old_curwin;
     curbuf = curwin->w_buffer;
 }

--- a/src/register.c
+++ b/src/register.c
@@ -2375,7 +2375,7 @@ error:
     }
 
     msgmore(nr_lines);
-    curwin->w_set_curswant = TRUE;
+    curwin->w_set_curswant = true;
 
     // Make sure the cursor is not after the NUL.
     int len = ml_get_curline_len();

--- a/src/screen.c
+++ b/src/screen.c
@@ -3870,7 +3870,7 @@ win_ins_lines(
      */
     if (!did_delete)
     {
-	wp->w_redr_status = TRUE;
+	wp->w_redr_status = true;
 	redraw_cmdline = TRUE;
 	nextrow = W_WINROW(wp) + wp->w_height + wp->w_status_height;
 	lastrow = nextrow + line_count;
@@ -3886,7 +3886,7 @@ win_ins_lines(
 	// deletion will have messed up other windows
 	if (did_delete)
 	{
-	    wp->w_redr_status = TRUE;
+	    wp->w_redr_status = true;
 	    win_rest_invalid(W_NEXT(wp));
 	}
 	return FAIL;
@@ -3936,7 +3936,7 @@ win_del_lines(
 	if (screen_ins_lines(0, W_WINROW(wp) + wp->w_height - line_count,
 			      line_count, (int)Rows, clear_attr, NULL) == FAIL)
 	{
-	    wp->w_redr_status = TRUE;
+	    wp->w_redr_status = true;
 	    win_rest_invalid(wp->w_next);
 	}
     }
@@ -4052,7 +4052,7 @@ win_rest_invalid(win_T *wp)
     while (wp != NULL)
     {
 	redraw_win_later(wp, UPD_NOT_VALID);
-	wp->w_redr_status = TRUE;
+	wp->w_redr_status = true;
 	wp = wp->w_next;
     }
     redraw_cmdline = TRUE;

--- a/src/search.c
+++ b/src/search.c
@@ -1713,7 +1713,7 @@ do_search(
     if (options & SEARCH_MARK)
 	setpcmark();
     curwin->w_cursor = pos;
-    curwin->w_set_curswant = TRUE;
+    curwin->w_set_curswant = true;
 
 end_do_search:
     if ((options & SEARCH_KEEP) || (cmdmod.cmod_flags & CMOD_KEEPPATTERNS))
@@ -3958,7 +3958,7 @@ search_line:
 		if (action != ACTION_SHOW)
 		{
 		    curwin->w_cursor.col = (colnr_T)(startp - line);
-		    curwin->w_set_curswant = TRUE;
+		    curwin->w_set_curswant = true;
 		}
 
 # if defined(FEAT_QUICKFIX)

--- a/src/structs.h
+++ b/src/structs.h
@@ -4062,7 +4062,7 @@ struct window_S
 				    // used to try to stay in the same column
 				    // for up/down cursor motions.
 
-    int		w_set_curswant;	    // If set, then update w_curswant the next
+    bool	w_set_curswant;	    // If set, then update w_curswant the next
 				    // time through cursupdate() to the
 				    // current virtual column
 
@@ -4093,7 +4093,7 @@ struct window_S
      */
     linenr_T	w_topline;	    // buffer line number of the line at the
 				    // top of the window
-    char	w_topline_was_set;  // flag set to TRUE when topline is set,
+    bool	w_topline_was_set;  // flag set to true when topline is set,
 				    // e.g. by winrestview()
 
     linenr_T	w_botline;	    // number of the line below the bottom of
@@ -4102,9 +4102,9 @@ struct window_S
 #ifdef FEAT_DIFF
     int		w_topfill;	    // number of filler lines above w_topline
     int		w_old_topfill;	    // w_topfill at last redraw
-    int		w_botfill;	    // TRUE when filler lines are actually
+    bool	w_botfill;	    // true when filler lines are actually
 				    // below w_topline (at end of file)
-    int		w_old_botfill;	    // w_botfill at last redraw
+    bool	w_old_botfill;	    // w_botfill at last redraw
 #endif
     colnr_T	w_leftcol;	    // screen column number of the left most
 				    // character in the window; used when
@@ -4151,7 +4151,7 @@ struct window_S
     int		w_vsep_width;	    // Number of separator columns (0 or 1).
 
     pos_save_T	w_save_cursor;	    // backup of cursor pos and topline
-    int		w_do_win_fix_cursor;// if TRUE cursor may be invalid
+    bool	w_do_win_fix_cursor;// if true cursor may be invalid
 
 #ifdef FEAT_PROP_POPUP
     int		w_popup_flags;	    // POPF_ values
@@ -4159,7 +4159,7 @@ struct window_S
     int		w_popup_handled;    // POPUP_HANDLE[0-9] flags
     char_u	*w_popup_title;
     poppos_T	w_popup_pos;
-    int		w_popup_fixed;	    // do not shift popup to fit on screen
+    bool	w_popup_fixed;	    // do not shift popup to fit on screen
     int		w_popup_prop_type;  // when not zero: textprop type ID
     win_T	*w_popup_prop_win;  // window to search for textprop
     int		w_popup_prop_id;    // when not zero: textprop ID
@@ -4173,13 +4173,13 @@ struct window_S
     int		w_wantcol;	    // "col" for popup window
     int		w_firstline;	    // "firstline" for popup window
     int		w_want_scrollbar;   // when zero don't use a scrollbar
-    int		w_has_scrollbar;    // 1 if scrollbar displayed, 0 otherwise
+    bool	w_has_scrollbar;    // true if scrollbar displayed
     char_u	*w_scrollbar_highlight; // "scrollbarhighlight"
     char_u	*w_thumb_highlight; // "thumbhighlight"
     int		w_popup_padding[4]; // popup padding top/right/bot/left
     int		w_popup_border[4];  // popup border top/right/bot/left
     char_u	*w_border_highlight[4];  // popup border highlight
-    int		w_border_highlight_isset; // borderhighlight was explicitly set
+    bool	w_border_highlight_isset; // borderhighlight was explicitly set
     int		w_border_char[8];   // popup border characters
     int		w_popup_shadow;     // popup shadow (right and bottom edges)
 
@@ -4246,7 +4246,7 @@ struct window_S
      */
     int		w_cline_height;	    // current size of cursor line
 #ifdef FEAT_FOLDING
-    int		w_cline_folded;	    // cursor line is folded
+    bool	w_cline_folded;	    // cursor line is folded
 #endif
 
     int		w_cline_row;	    // starting row of the cursor line
@@ -4285,9 +4285,9 @@ struct window_S
 
 #ifdef FEAT_FOLDING
     garray_T	w_folds;	    // array of nested folds
-    char	w_fold_manual;	    // when TRUE: some folds are opened/closed
+    bool	w_fold_manual;	    // when true: some folds are opened/closed
 				    // manually
-    char	w_foldinvalid;	    // when TRUE: folding needs to be
+    bool	w_foldinvalid;	    // when true: folding needs to be
 				    // recomputed
 #endif
 #ifdef FEAT_LINEBREAK
@@ -4307,7 +4307,7 @@ struct window_S
 				    // w_redr_type is UPD_REDRAW_TOP
     linenr_T	w_redraw_top;	    // when != 0: first line needing redraw
     linenr_T	w_redraw_bot;	    // when != 0: last line needing redraw
-    int		w_redr_status;	    // if TRUE status line must be redrawn
+    bool	w_redr_status;	    // if true status line must be redrawn
 
     // remember what is shown in the ruler for this window (if 'ruler' set)
     pos_T	w_ru_cursor;	    // cursor position shown in ruler
@@ -4317,14 +4317,14 @@ struct window_S
 #ifdef FEAT_DIFF
     int		w_ru_topfill;	    // topfill shown in ruler
 #endif
-    char	w_ru_empty;	    // TRUE if ruler shows 0-1 (empty line)
+    bool	w_ru_empty;	    // true if ruler shows 0-1 (empty line)
 
     int		w_alt_fnum;	    // alternate file (for # and CTRL-^)
 
     alist_T	*w_alist;	    // pointer to arglist for this window
     int		w_arg_idx;	    // current index in argument list (can be
 				    // out of range!)
-    int		w_arg_idx_invalid;  // editing another file than w_arg_idx
+    bool	w_arg_idx_invalid;  // editing another file than w_arg_idx
 
     char_u	*w_localdir;	    // absolute path of local directory or
 				    // NULL

--- a/src/tag.c
+++ b/src/tag.c
@@ -476,7 +476,7 @@ do_tag(
 		    curwin->w_cursor.lnum = saved_fmark.mark.lnum;
 		}
 		curwin->w_cursor.col = saved_fmark.mark.col;
-		curwin->w_set_curswant = TRUE;
+		curwin->w_set_curswant = true;
 		check_cursor();
 #ifdef FEAT_FOLDING
 		if ((fdo_flags & FDO_TAG) && old_KeyTyped)
@@ -3898,7 +3898,7 @@ jumpto_tag(
 
     if (GETFILE_SUCCESS(getfile_result))	// got to the right file
     {
-	curwin->w_set_curswant = TRUE;
+	curwin->w_set_curswant = true;
 	postponed_split = 0;
 
 	save_magic_overruled = magic_overruled;

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -2464,7 +2464,7 @@ term_enter_normal_mode(void)
     check_cursor();
     if (coladvance(col) == FAIL)
 	coladvance(MAXCOL);
-    curwin->w_set_curswant = TRUE;
+    curwin->w_set_curswant = true;
     curwin->w_topline = term->tl_buffer_scrolled + 1;
 }
 
@@ -3562,7 +3562,7 @@ handle_settermprop(
 	    if (term == curbuf->b_term)
 	    {
 		maketitle();
-		curwin->w_redr_status = TRUE;
+		curwin->w_redr_status = true;
 	    }
 	    break;
 

--- a/src/window.c
+++ b/src/window.c
@@ -724,7 +724,7 @@ wingotofile:
 			Prenum1, ACTION_SPLIT, (linenr_T)1, (linenr_T)MAXLNUM,
 			FALSE, FALSE);
 		vim_free(ptr);
-		curwin->w_set_curswant = TRUE;
+		curwin->w_set_curswant = true;
 		break;
 #endif
 
@@ -5777,7 +5777,7 @@ win_enter_ext(win_T *wp, int flags)
     if (curwin_invalid == 0)
     {
 	prevwin = curwin;	// remember for CTRL-W p
-	curwin->w_redr_status = TRUE;
+	curwin->w_redr_status = true;
     }
     curwin = wp;
     curbuf = wp->w_buffer;
@@ -5818,7 +5818,7 @@ win_enter_ext(win_T *wp, int flags)
     }
 
     maketitle();
-    curwin->w_redr_status = TRUE;
+    curwin->w_redr_status = true;
 #ifdef FEAT_TERMINAL
     if (bt_terminal(curwin->w_buffer))
 	// terminal is likely in another mode
@@ -5831,7 +5831,7 @@ win_enter_ext(win_T *wp, int flags)
     {
 	win_T *ww;
 	FOR_ALL_WINDOWS(ww)
-	    ww->w_redr_status = TRUE;
+	    ww->w_redr_status = true;
     }
 #if defined(FEAT_TABPANEL)
     redraw_tabpanel = TRUE;
@@ -6513,7 +6513,7 @@ frame_comp_pos(frame_T *topfrp, int *row, int *col)
 	    wp->w_winrow = *row;
 	    wp->w_wincol = *col;
 	    redraw_win_later(wp, UPD_NOT_VALID);
-	    wp->w_redr_status = TRUE;
+	    wp->w_redr_status = true;
 	}
 	// WinBar will not show if the window height is zero
 	h = VISIBLE_HEIGHT(wp) + wp->w_status_height;
@@ -7257,7 +7257,7 @@ win_fix_scroll(int resize)
 	{
 	    // Cursor position in this window may now be invalid.  It is kept
 	    // potentially invalid until the window is made the current window.
-	    wp->w_do_win_fix_cursor = TRUE;
+	    wp->w_do_win_fix_cursor = true;
 
 	    // If window has moved update botline to keep the same screenlines.
 	    if (*p_spk == 's' && wp->w_winrow != wp->w_prev_winrow
@@ -7315,7 +7315,7 @@ win_fix_cursor(int normal)
 	    || wp->w_buffer->b_ml.ml_line_count < wp->w_height)
 	return;
 
-    wp->w_do_win_fix_cursor = FALSE;
+    wp->w_do_win_fix_cursor = false;
     // Determine valid cursor range.
     long so = MIN(wp->w_height / 2, get_scrolloff_value());
     linenr_T lnum = wp->w_cursor.lnum;
@@ -7385,7 +7385,7 @@ win_new_height(win_T *wp, int height)
     }
 
     wp->w_height = height;
-    wp->w_redr_status = TRUE;
+    wp->w_redr_status = true;
     win_comp_scroll(wp);
 
     // There is no point in adjusting the scroll position when exiting.  Some
@@ -7531,7 +7531,7 @@ win_new_width(win_T *wp, int width)
 	curs_columns(TRUE);	// validate w_wrow
 
     redraw_win_later(wp, UPD_NOT_VALID);
-    wp->w_redr_status = TRUE;
+    wp->w_redr_status = true;
 }
 
     void


### PR DESCRIPTION
Problem:
Several win_T fields are declared as "int" or "char" but are used strictly as boolean flags with TRUE/FALSE values.  The integer types obscure the boolean intent and are wider than needed.

Solution:
Change the following win_T members to bool (stdbool.h) and update their assignments from TRUE/FALSE to true/false accordingly.

- int -> bool (10 members): w_set_curswant, w_botfill, w_old_botfill, w_do_win_fix_cursor, w_popup_fixed, w_border_highlight_isset, w_cline_folded, w_redr_status, w_arg_idx_invalid, w_has_scrollbar

- char -> bool (4 members): w_topline_was_set, w_ru_empty, w_fold_manual, w_foldinvalid

No existing code compares these members against TRUE/FALSE explicitly or uses ++/-- / bitwise ops on them, so only plain assignments are affected.

Excluded: w_locked (recursion counter with ++/--), w_want_scrollbar (may hold -1 from dict_get_bool), w_winbar_height (used in arithmetic and exposed as number via getwininfo()).