### PR TITLE
vim9: fix g: variable lookup shadowed by script-local function

### DIFF
--- a/src/testdir/test_vim9_script.vim
+++ b/src/testdir/test_vim9_script.vim
@@ -5847,4 +5847,90 @@ def Test_call_stack_string()
   g:StopVimInTerminal(buf)
 enddef
 
+def Test_g_variable_not_shadowed_by_function()
+  var lines =<< trim END
+    vim9script
+    g:F = 1
+    def F()
+      return 2
+    enddef
+    def Check()
+      var x = g:F
+      assert_equal(1, x)
+    enddef
+    Check()
+  END
+  v9.CheckScriptSuccess(lines)
+enddef
+
+" Test g: variable shadowed by script-local function in various expression contexts.
+def Test_g_variable_shadow_multi_context()
+  var lines =<< trim END
+    vim9script
+    g:F = 1
+    def F(): number
+      return 2
+    enddef
+
+    # 1. Assignment to local
+    def AssignCheck()
+      var x = g:F
+      assert_equal(1, x)
+    enddef
+
+    # 2. Function argument
+    def ArgCheck(val: number): number
+      return val * 10
+    enddef
+    def CallArg()
+      assert_equal(10, ArgCheck(g:F))
+    enddef
+
+    # 3. Return value
+    def ReturnCheck(): number
+      return g:F
+    enddef
+
+    # 4. Binary operation
+    def BinaryCheck(): number
+      return g:F + 5
+    enddef
+
+    # 5. List literal element
+    def ListCheck(): list<number>
+      return [g:F, 2, 3]
+    enddef
+
+    # 6. Dict literal value
+    def DictCheck(): dict<number>
+      return {val: g:F}
+    enddef
+
+    # 7. Conditional expression
+    def CondCheck(): string
+      return g:F == 1 ? 'yes' : 'no'
+    enddef
+
+    # 8. Loop condition (only evaluated once but still loads)
+    def LoopCheck(): number
+      var i = 0
+      while i < g:F
+        i += 1
+      endwhile
+      return i
+    enddef
+
+    AssignCheck()
+    CallArg()
+    assert_equal(1, ReturnCheck())
+    assert_equal(6, BinaryCheck())
+    assert_equal([1, 2, 3], ListCheck())
+    assert_equal({val: 1}, DictCheck())
+    assert_equal('yes', CondCheck())
+    assert_equal(1, LoopCheck())
+  END
+  v9.CheckScriptSuccess(lines)
+  unlet g:F
+enddef
+
 " vim: ts=8 sw=2 sts=2 expandtab tw=80 fdm=marker

--- a/src/vim9expr.c
+++ b/src/vim9expr.c
@@ -946,7 +946,7 @@ compile_load(
 		case 'g': if (vim_strchr(name, AUTOLOAD_CHAR) == NULL)
 			  {
 			      if (is_expr && ASCII_ISUPPER(*name)
-				       && (find_func(name, FALSE) != NULL
+				       && (find_func(name, TRUE) != NULL
 					   || gfatab.gfat_args.ga_len > 0))
 				  res = generate_funcref(cctx, name, &gfatab,
 								TRUE);


### PR DESCRIPTION
Fixes #20009.