### PR TITLE
fix(smoothscroll): crash when resizing to textoff with showbreak

### DIFF
--- a/src/charset.c
+++ b/src/charset.c
@@ -1468,7 +1468,8 @@ win_lbr_chartabsize(
 
 		if (max_head_vcol == 0 || vcol + size + added < max_head_vcol)
 		    head += cnt * head_mid;
-		else if (max_head_vcol > vcol + head_prev + prev_rem)
+		else if (width2 > 0
+			   && max_head_vcol > vcol + head_prev + prev_rem)
 		    head += (max_head_vcol - (vcol + head_prev + prev_rem)
 					     + width2 - 1) / width2 * head_mid;
 		else if (max_head_vcol < 0)

--- a/src/testdir/test_crash.vim
+++ b/src/testdir/test_crash.vim
@@ -261,6 +261,55 @@ func TearDown()
   call delete('Untitled')
 endfunc
 
+" Resizing to "textoff" after 'smoothscroll' skips part of a wrapped line must
+" not crash.
+func Test_crash_textoff_showbreak()
+  CheckOption smoothscroll
+
+  let donefile = 'XTest_crash_textoff_showbreak_done'
+  let lines =<< trim END
+    set noswapfile
+
+    set scrolloff=0
+    set lines=12 columns=40
+
+    call setline(1, 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
+    set number wrap smoothscroll showbreak=>
+    vsplit
+
+    let textoff = getwininfo(win_getid())[0].textoff
+    execute "normal! 0\<C-E>"
+    redraw
+    execute 'vertical resize' textoff
+    redraw
+    call writefile(['done'], 'XTest_crash_textoff_showbreak_done')
+  END
+  call writefile(lines, 'XTest_crash_textoff_showbreak', 'D')
+  call delete(donefile)
+
+  let buf = 0
+  try
+    let buf = term_start([GetVimProg(), '--clean'], #{term_rows: 24, term_cols: 80})
+    call TermWait(buf, 200)
+    call term_sendkeys(buf, ":source XTest_crash_textoff_showbreak\<CR>")
+    call WaitFor({-> filereadable(donefile)
+          \ || term_getstatus(buf) !=# 'running'}, 1000)
+
+    let status = term_getstatus(buf)
+    call assert_equal('running', status)
+    call assert_true(filereadable(donefile))
+  finally
+    if buf > 0 && bufexists(buf)
+      if term_getstatus(buf) ==# 'running'
+        call StopVimInTerminal(buf)
+      else
+        exe buf .. 'bwipe!'
+      endif
+    endif
+    call delete(donefile)
+  endtry
+endfunc
+
 func Test_crash_bufwrite()
   let lines =<< trim END
     w! ++enc=ucs4 Xoutput


### PR DESCRIPTION
## Minimal repro

`repro-textoff-showbreak.vim`
```vim
set noswapfile

set scrolloff=0
set lines=12 columns=40

call setline(1, 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
set number wrap smoothscroll showbreak=>
vsplit

let textoff = getwininfo(win_getid())[0].textoff
execute "normal! 0\<C-E>"
redraw
execute 'vertical resize' textoff
redraw
```

```
vim --clean
:source repro-textoff-showbreak.vim
```

## Problem

In the above scenario:
- the window is wrapped
- `showbreak` contributes head width on continuation lines
- `smoothscroll` has moved the viewport into a nonzero `skipcol` state
- resizing the window to `textoff` leaves continuation lines with zero text width

The redraw path still enters the partial `max_head_vcol` calculation and does:

```c
head += (max_head_vcol - (vcol + head_prev + prev_rem)
         + width2 - 1) / width2 * head_mid;
```

but here `width2 == 0`, so redraw crashes with a divide-by-zero.

## Solution

Skip that partial head calculation when the wrapped continuation width
is zero, matching the other width2 guards in charset.c.

## AI assistance

AI-assisted: Codex

This bug was found by Codex when I instructed it to chase down a different redraw problem I was experiencing in neovim. The patch is also generated by Codex.
