### PR TITLE
runtime(netrw): expand ~ in :Explore on Windows

### DIFF
--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -530,8 +530,8 @@ function netrw#Explore(indx,dosplit,style,...)
   NetrwKeepj norm! 0
 
   if a:0 > 0
-    if a:1 =~ '^\~' && (has("unix") || g:netrw_cygwin)
-      let dirname= simplify(substitute(a:1,'\~',expand("$HOME"),''))
+    if a:1 =~ '^\~' && (has("unix") || has("win32") || g:netrw_cygwin)
+      let dirname= simplify(substitute(a:1,'^\~',escape(expand("$HOME"),'\&~'),''))
     elseif a:1 == '.'
       let dirname= simplify(exists("b:netrw_curdir")? b:netrw_curdir : getcwd())
       if dirname !~ '/$'


### PR DESCRIPTION
On Windows, `:Explore ~` did nothing because tilde expansion in `netrw#Explore()` was gated to Unix/Cygwin. Adding `has("win32")` alone is not enough: `substitute()` treats backslashes in the replacement as case modifiers (e.g. `\U`), so a `$HOME` like `C:\Users\name` gets mangled. Anchor the pattern to the start and escape `\`, `&`, `~` in the replacement.

Fixes #20003