### PR TITLE
insexpand: avoid flicker when updating pum in place

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -1828,8 +1828,9 @@ ins_compl_show_pum(void)
     if (!pum_wanted() || !pum_enough_matches())
 	return;
 
-    // Update the screen later, before drawing the popup menu over it.
-    pum_call_update_screen();
+    // Avoid redrawing the screen under a pum that stays in place.
+    if (!pum_redraw_in_same_position())
+	pum_call_update_screen();
 
     if (compl_match_array == NULL)
 	// Need to build the popup menu list.


### PR DESCRIPTION
When the popup menu is already visible, ins_compl_show_pum() still calls pum_call_update_screen() whenever the completion list is updated. For asynchronous completion sources such as vim-lsp, asyncomplete.vim, and asyncomplete-lsp.vim, candidates may be appended while the popup menu stays in the same position. In that case Vim redraws the screen behind the popup menu even though only the menu contents changed, which makes the screen flicker.

This change skips the screen update when the popup menu can be redrawn in place, and only redraws the popup menu itself. Cases where the popup menu needs to move keep the existing behavior.

Tests: make insexpand.o, make -C testdir test_ins_complete.res