### PR TITLE
refactor: use bool type for internal flags in buf_T

### DIFF
--- a/src/autocmd.c
+++ b/src/autocmd.c
@@ -2366,7 +2366,7 @@ apply_autocmds_group(
 
     // Remember that FileType was triggered.  Used for did_filetype().
     if (event == EVENT_FILETYPE)
-	curbuf->b_did_filetype = TRUE;
+	curbuf->b_did_filetype = true;
 
     tail = gettail(fname);
 
@@ -2475,7 +2475,7 @@ apply_autocmds_group(
 	restore_search_patterns();
 	if (did_save_redobuff)
 	    restoreRedobuff(&save_redo);
-	curbuf->b_did_filetype = FALSE;
+	curbuf->b_did_filetype = false;
 	while (au_pending_free_buf != NULL)
 	{
 	    buf_T *b = au_pending_free_buf->b_next;
@@ -2517,7 +2517,7 @@ BYPASS_AU:
 	aubuflocal_remove(buf);
 
     if (retval == OK && event == EVENT_FILETYPE)
-	curbuf->b_au_did_filetype = TRUE;
+	curbuf->b_au_did_filetype = true;
 
     return retval;
 }

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -259,7 +259,7 @@ open_buffer(
     // The autocommands in readfile() may change the buffer, but only AFTER
     // reading the file.
     set_bufref(&old_curbuf, curbuf);
-    curbuf->b_modified_was_set = FALSE;
+    curbuf->b_modified_was_set = false;
 
     // mark cursor position as being invalid
     curwin->w_valid = 0;
@@ -278,7 +278,7 @@ open_buffer(
     {
 	int old_msg_silent = msg_silent;
 #ifdef UNIX
-	int save_bin = curbuf->b_p_bin;
+	int	save_bin = curbuf->b_p_bin;
 	int perm;
 #endif
 #ifdef FEAT_NETBEANS_INTG
@@ -824,7 +824,7 @@ aucmd_abort:
 	    buf->b_flags = BF_CHECK_RO | BF_NEVERLOADED;
 
 	    // Init the options when loaded again.
-	    buf->b_p_initialized = FALSE;
+	    buf->b_p_initialized = false;
 	}
 	buf_clear_file(buf);
 	if (del_buf)
@@ -847,7 +847,7 @@ buf_clear_file(buf_T *buf)
 {
     buf->b_ml.ml_line_count = 1;
     unchanged(buf, TRUE, TRUE);
-    buf->b_shortname = FALSE;
+    buf->b_shortname = false;
     buf->b_p_eof = FALSE;
     buf->b_start_eof = FALSE;
     buf->b_p_eol = TRUE;
@@ -2014,7 +2014,7 @@ enter_buffer(buf_T *buf)
 	// ":ball" used in an autocommand.  If there already is a filetype we
 	// might prefer to keep it.
 	if (*curbuf->b_p_ft == NUL)
-	    curbuf->b_did_filetype = FALSE;
+	    curbuf->b_did_filetype = false;
 
 	open_buffer(FALSE, NULL, 0);
     }
@@ -2294,7 +2294,7 @@ buflist_new(
 	free_buffer_stuff(buf, FALSE);	// delete local variables et al.
 
 	// Init the options.
-	buf->b_p_initialized = FALSE;
+	buf->b_p_initialized = false;
 	buf_copy_options(buf, BCO_ENTER);
 
 #ifdef FEAT_KEYMAP
@@ -2374,15 +2374,15 @@ buflist_new(
     buf->b_fname = buf->b_sfname;
 #ifdef UNIX
     if (st.st_dev == (dev_T)-1)
-	buf->b_dev_valid = FALSE;
+	buf->b_dev_valid = false;
     else
     {
-	buf->b_dev_valid = TRUE;
+	buf->b_dev_valid = true;
 	buf->b_dev = st.st_dev;
 	buf->b_ino = st.st_ino;
     }
 #endif
-    buf->b_u_synced = TRUE;
+    buf->b_u_synced = true;
     buf->b_flags = BF_CHECK_RO | BF_NEVERLOADED;
     if (flags & BLN_DUMMY)
 	buf->b_flags |= BF_DUMMY;
@@ -3671,16 +3671,16 @@ setfname(
     buf->b_fname = buf->b_sfname;
 #ifdef UNIX
     if (st.st_dev == (dev_T)-1)
-	buf->b_dev_valid = FALSE;
+	buf->b_dev_valid = false;
     else
     {
-	buf->b_dev_valid = TRUE;
+	buf->b_dev_valid = true;
 	buf->b_dev = st.st_dev;
 	buf->b_ino = st.st_ino;
     }
 #endif
 
-    buf->b_shortname = FALSE;
+    buf->b_shortname = false;
 
     buf_name_changed(buf);
     return OK;
@@ -3894,12 +3894,12 @@ buf_setino(buf_T *buf)
 
     if (buf->b_fname != NULL && mch_stat((char *)buf->b_fname, &st) >= 0)
     {
-	buf->b_dev_valid = TRUE;
+	buf->b_dev_valid = true;
 	buf->b_dev = st.st_dev;
 	buf->b_ino = st.st_ino;
     }
     else
-	buf->b_dev_valid = FALSE;
+	buf->b_dev_valid = false;
 }
 
 /*

--- a/src/bufwrite.c
+++ b/src/bufwrite.c
@@ -1160,7 +1160,7 @@ buf_write(
     got_int = FALSE;
 
     // Mark the buffer as 'being saved' to prevent changed buffer warnings
-    buf->b_saving = TRUE;
+    buf->b_saving = true;
 
     // If we are not appending or filtering, the file exists, and the
     // 'writebackup', 'backup' or 'patchmode' option is set, need a backup.
@@ -1407,13 +1407,13 @@ buf_write(
 			    // may try again with 'shortname' set
 			    if (!(buf->b_shortname || buf->b_p_sn))
 			    {
-				buf->b_shortname = TRUE;
+				buf->b_shortname = true;
 				did_set_shortname = TRUE;
 				continue;
 			    }
 				// setting shortname didn't help
 			    if (did_set_shortname)
-				buf->b_shortname = FALSE;
+				buf->b_shortname = false;
 			    break;
 			}
 #endif
@@ -2543,7 +2543,7 @@ fail:
 nofail:
 
     // Done saving, we accept changed buffer warnings again
-    buf->b_saving = FALSE;
+    buf->b_saving = false;
 
     vim_free(backup);
     if (buffer != smallbuf)
@@ -2661,7 +2661,7 @@ nofail:
 #ifdef FEAT_VIMINFO
     // Make sure marks will be written out to the viminfo file later, even when
     // the file is new.
-    curbuf->b_marks_read = TRUE;
+    curbuf->b_marks_read = true;
 #endif
 
     got_int |= prev_got_int;

--- a/src/change.c
+++ b/src/change.c
@@ -61,7 +61,7 @@ change_warning(int col)
 	out_flush();
 	ui_delay(1002L, TRUE); // give the user time to think about it
     }
-    curbuf->b_did_warn = TRUE;
+    curbuf->b_did_warn = true;
     redraw_cmdline = FALSE;	// don't redraw and erase the message
     if (msg_row < Rows - 1)
 	showmode();
@@ -702,7 +702,7 @@ changed_common(
 		// This is the first of a new sequence of undo-able changes
 		// and it's at some distance of the last change.  Use a new
 		// position in the changelist.
-		curbuf->b_new_change = FALSE;
+		curbuf->b_new_change = false;
 
 		if (curbuf->b_changelistlen == JUMPLISTSIZE)
 		{
@@ -897,7 +897,7 @@ changedOneline(buf_T *buf, linenr_T lnum)
     else
     {
 	// set the area that must be redisplayed to one line
-	buf->b_mod_set = TRUE;
+	buf->b_mod_set = true;
 	buf->b_mod_top = lnum;
 	buf->b_mod_bot = lnum + 1;
 	buf->b_mod_xlines = 0;
@@ -1035,7 +1035,7 @@ changed_lines_buf(
     else
     {
 	// set the area that must be redisplayed
-	buf->b_mod_set = TRUE;
+	buf->b_mod_set = true;
 	buf->b_mod_top = lnum;
 	buf->b_mod_bot = lnume + xtra;
 	buf->b_mod_xlines = xtra;

--- a/src/channel.c
+++ b/src/channel.c
@@ -1754,7 +1754,7 @@ channel_set_job(channel_T *channel, job_T *job, jobopt_T *options)
 	{
 	    // Special mode: send last-but-one line when appending a line
 	    // to the buffer.
-	    in_part->ch_bufref.br_buf->b_write_to_channel = TRUE;
+	    in_part->ch_bufref.br_buf->b_write_to_channel = true;
 	    in_part->ch_buf_append = TRUE;
 	    in_part->ch_buf_top =
 		in_part->ch_bufref.br_buf->b_ml.ml_line_count + 1;
@@ -2054,7 +2054,7 @@ channel_write_new_lines(buf_T *buf)
 	}
     }
     if (!found_one)
-	buf->b_write_to_channel = FALSE;
+	buf->b_write_to_channel = false;
 }
 
 /*
@@ -3069,7 +3069,7 @@ append_to_buffer(
 {
     aco_save_T	aco;
     linenr_T    lnum = buffer->b_ml.ml_line_count;
-    int		save_write_to = buffer->b_write_to_channel;
+    bool	save_write_to = buffer->b_write_to_channel;
     chanpart_T  *ch_part = &channel->ch_part[part];
     int		save_p_ma = buffer->b_p_ma;
     int		empty = (buffer->b_ml.ml_flags & ML_EMPTY) ? 1 : 0;
@@ -3089,7 +3089,7 @@ append_to_buffer(
     if (save_write_to)
     {
 	--lnum;
-	buffer->b_write_to_channel = FALSE;
+	buffer->b_write_to_channel = false;
     }
 
     // Append to the buffer
@@ -3168,7 +3168,7 @@ append_to_buffer(
 
 	// Find channels reading from this buffer and adjust their
 	// next-to-read line number.
-	buffer->b_write_to_channel = TRUE;
+	buffer->b_write_to_channel = true;
 	FOR_ALL_CHANNELS(ch)
 	{
 	    chanpart_T  *in_part = &ch->ch_part[PART_IN];

--- a/src/diff.c
+++ b/src/diff.c
@@ -820,7 +820,7 @@ diff_write_buffer(buf_T *buf, diffin_T *din, linenr_T start, linenr_T end)
 	// Allocating memory failed.  This can happen, because we try to read
 	// the whole buffer text into memory.  Set the failed flag, the diff
 	// will be retried with external diff.  The flag is never reset.
-	buf->b_diff_failed = TRUE;
+	buf->b_diff_failed = true;
 	if (p_verbose > 0)
 	{
 	    verbose_enter();

--- a/src/drawscreen.c
+++ b/src/drawscreen.c
@@ -384,7 +384,7 @@ update_screen(int type_arg)
     // Reset b_mod_set flags.  Going through all windows is probably faster
     // than going through all buffers (there could be many buffers).
     FOR_ALL_WINDOWS(wp)
-	wp->w_buffer->b_mod_set = FALSE;
+	wp->w_buffer->b_mod_set = false;
 
 #ifdef FEAT_PROP_POPUP
     // Display popup windows on top of the windows and command line.
@@ -2846,13 +2846,13 @@ win_update(win_T *wp)
 	    if (wp->w_redr_type != 0)
 	    {
 		// Don't update for changes in buffer again.
-		i = curbuf->b_mod_set;
-		curbuf->b_mod_set = FALSE;
+		bool b = curbuf->b_mod_set;
+		curbuf->b_mod_set = false;
 		j = curbuf->b_mod_xlines;
 		curbuf->b_mod_xlines = 0;
 		curs_columns(TRUE);
 		win_update(curwin);
-		curbuf->b_mod_set = i;
+		curbuf->b_mod_set = b;
 		curbuf->b_mod_xlines = j;
 	    }
 	    // Other windows might have w_redr_type raised in update_topline().

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -3205,7 +3205,7 @@ do_ecmd(
     // Since we are starting to edit a file, consider the filetype to be
     // unset.  Helps for when an autocommand changes files and expects syntax
     // highlighting to work in the other file.
-    curbuf->b_did_filetype = FALSE;
+    curbuf->b_did_filetype = false;
 
 /*
  * other_file	oldbuf

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -10368,7 +10368,7 @@ ex_setfiletype(exarg_T *eap)
 
     set_option_value_give_err((char_u *)"filetype", 0L, arg, OPT_LOCAL);
     if (arg != eap->arg)
-	curbuf->b_did_filetype = FALSE;
+	curbuf->b_did_filetype = false;
 }
 
     static void

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -236,7 +236,7 @@ readfile(
 #endif
     size_t	fnamelen = 0;
 
-    curbuf->b_au_did_filetype = FALSE; // reset before triggering any autocommands
+    curbuf->b_au_did_filetype = false; // reset before triggering any autocommands
 
     curbuf->b_no_eol_lnum = 0;	// in case it was set by the previous read
 
@@ -4664,7 +4664,7 @@ buf_reload(buf_T *buf, int orig_mode, int reload_options)
 	    int old_msg_silent = msg_silent;
 
 	    curbuf->b_flags |= BF_CHECK_RO;	// check for RO again
-	    curbuf->b_keep_filetype = TRUE;	// don't detect 'filetype'
+	    curbuf->b_keep_filetype = true;	// don't detect 'filetype'
 
 	    if (shortmess(SHM_FILEINFO))
 		msg_silent = 1;
@@ -4721,7 +4721,7 @@ buf_reload(buf_T *buf, int orig_mode, int reload_options)
 	curwin->w_cursor = old_cursor;
 	check_cursor();
 	update_topline();
-	curbuf->b_keep_filetype = FALSE;
+	curbuf->b_keep_filetype = false;
 #ifdef FEAT_FOLDING
 	{
 	    win_T	*wp;

--- a/src/help.c
+++ b/src/help.c
@@ -634,7 +634,7 @@ prepare_help_buffer(void)
 {
     char_u	*p;
 
-    curbuf->b_help = TRUE;
+    curbuf->b_help = true;
 #ifdef FEAT_QUICKFIX
     set_string_option_direct((char_u *)"buftype", -1,
 				     (char_u *)"help", OPT_FREE|OPT_LOCAL, 0);

--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -5402,7 +5402,7 @@ ins_compl_get_exp(pos_T *ini)
 	buf_T *buf;
 
 	FOR_ALL_BUFFERS(buf)
-	    buf->b_scanned = 0;
+	    buf->b_scanned = false;
 	if (!st_cleared)
 	{
 	    CLEAR_FIELD(st);
@@ -5526,7 +5526,7 @@ ins_compl_get_exp(pos_T *ini)
 	{
 	    // Mark a buffer scanned when it has been scanned completely
 	    if (buf_valid(st.ins_buf) && (type == 0 || type == CTRL_X_PATH_PATTERNS))
-		st.ins_buf->b_scanned = TRUE;
+		st.ins_buf->b_scanned = true;
 
 	    compl_started = FALSE;
 	}

--- a/src/memline.c
+++ b/src/memline.c
@@ -305,9 +305,9 @@ ml_open(buf_T *buf)
      * When 'updatecount' is non-zero swap file may be opened later.
      */
     if (p_uc && buf->b_p_swf)
-	buf->b_may_swap = TRUE;
+	buf->b_may_swap = true;
     else
-	buf->b_may_swap = FALSE;
+	buf->b_may_swap = false;
 
     /*
      * Open the memfile.  No swap file is created yet.
@@ -793,7 +793,7 @@ ml_open_file(buf_T *buf)
 	fname = vim_tempname('s', FALSE);
 	if (fname != NULL)
 	    (void)mf_open_file(mfp, fname);	// consumes fname!
-	buf->b_may_swap = FALSE;
+	buf->b_may_swap = false;
 	return;
     }
 #endif
@@ -851,7 +851,7 @@ ml_open_file(buf_T *buf)
     }
 
     // don't try to open a swap file again
-    buf->b_may_swap = FALSE;
+    buf->b_may_swap = false;
 }
 
 /*
@@ -2442,9 +2442,9 @@ recov_file_names(char_u **names, char_u *path, int prepend_dot)
     char_u	*p;
     int		i;
 #ifndef MSWIN
-    int	    shortname = curbuf->b_shortname;
+    bool    shortname = curbuf->b_shortname;
 
-    curbuf->b_shortname = FALSE;
+    curbuf->b_shortname = false;
 #endif
     string_T	ret;
 
@@ -2493,7 +2493,7 @@ recov_file_names(char_u **names, char_u *path, int prepend_dot)
     /*
      * Also try with 'shortname' set, in case the file is on a DOS filesystem.
      */
-    curbuf->b_shortname = TRUE;
+    curbuf->b_shortname = true;
 # ifdef VMS
     names[num_names] = modname(path, (char_u *)"_sw%", FALSE);
 # else
@@ -5108,7 +5108,7 @@ findswapname(
 		    vim_free(fname2);
 		    if (same)
 		    {
-			buf->b_shortname = TRUE;
+			buf->b_shortname = true;
 			vim_free(fname);
 			fname = makeswapname(buf_fname, buf->b_ffname,
 							       buf, dir_name);
@@ -5178,7 +5178,7 @@ findswapname(
 		fname[n - 1] = 'p';
 		if (r >= 0)		    // "file.swx" seems to exist
 		{
-		    buf->b_shortname = TRUE;
+		    buf->b_shortname = true;
 		    vim_free(fname);
 		    fname = makeswapname(buf_fname, buf->b_ffname,
 							       buf, dir_name);

--- a/src/netbeans.c
+++ b/src/netbeans.c
@@ -486,7 +486,7 @@ nb_parse_cmd(char_u *cmd)
 	buf_T	*buf;
 
 	FOR_ALL_BUFFERS(buf)
-	    buf->b_has_sign_column = FALSE;
+	    buf->b_has_sign_column = false;
 
 	// The IDE is breaking the connection.
 	netbeans_close();
@@ -595,8 +595,8 @@ nb_free(void)
 	vim_free(buf.signmap);
 	if (buf.bufp != NULL && buf_valid(buf.bufp))
 	{
-	    buf.bufp->b_netbeans_file = FALSE;
-	    buf.bufp->b_was_netbeans_file = FALSE;
+	    buf.bufp->b_netbeans_file = false;
+	    buf.bufp->b_was_netbeans_file = false;
 	}
     }
     VIM_CLEAR(buf_list);
@@ -2211,11 +2211,11 @@ nb_do_cmd(
 	    }
 	    if (*args == 'T')
 	    {
-		buf->bufp->b_netbeans_file = TRUE;
-		buf->bufp->b_was_netbeans_file = TRUE;
+		buf->bufp->b_netbeans_file = true;
+		buf->bufp->b_was_netbeans_file = true;
 	    }
 	    else
-		buf->bufp->b_netbeans_file = FALSE;
+		buf->bufp->b_netbeans_file = false;
 // =====================================================================
 	}
 	else if (streq((char *)cmd, "specialKeys"))

--- a/src/option.c
+++ b/src/option.c
@@ -696,7 +696,7 @@ set_init_1(int clean_arg)
 	set_option_value_give_err((char_u *)"bg", 0L, (char_u *)"dark", 0);
 #endif
 
-    curbuf->b_p_initialized = TRUE;
+    curbuf->b_p_initialized = true;
     curbuf->b_p_ac = -1;
     curbuf->b_p_ar = -1;	// no local 'autoread' value
 #ifdef HAVE_FSYNC
@@ -4177,7 +4177,7 @@ did_set_modified(optset_T *args)
     if (!args->os_newval.boolean)
 	save_file_ff(curbuf);	// Buffer is unchanged
     redraw_titles();
-    curbuf->b_modified_was_set = args->os_newval.boolean;
+    curbuf->b_modified_was_set = !!args->os_newval.boolean;
     return NULL;
 }
 
@@ -4481,7 +4481,7 @@ did_set_readonly(optset_T *args)
 
     // when 'readonly' is set may give W10 again
     if (curbuf->b_p_ro)
-	curbuf->b_did_warn = FALSE;
+	curbuf->b_did_warn = false;
 
     redraw_titles();
 
@@ -7998,7 +7998,7 @@ buf_copy_options(buf_T *buf, int flags)
 		else
 		    buf->b_p_vts_array = NULL;
 #endif
-		buf->b_help = FALSE;
+		buf->b_help = false;
 		if (buf->b_p_bt[0] == 'h')
 		    clear_string_option(&buf->b_p_bt);
 		buf->b_p_ma = p_ma;
@@ -8009,7 +8009,7 @@ buf_copy_options(buf_T *buf, int flags)
 	// When the options should be copied (ignoring BCO_ALWAYS), set the
 	// flag that indicates that the options have been initialized.
 	if (should_copy)
-	    buf->b_p_initialized = TRUE;
+	    buf->b_p_initialized = true;
     }
 
     check_buf_options(buf);	    // make sure we don't have NULLs

--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -5365,7 +5365,7 @@ do_filetype_autocmd(char_u **varp, int opt_flags, int value_changed)
     secure = 0;
 
     ++ft_recursive;
-    curbuf->b_did_filetype = TRUE;
+    curbuf->b_did_filetype = true;
     // Only pass TRUE for "force" when the value changed or not
     // used recursively, to avoid endless recurrence.
     apply_autocmds(EVENT_FILETYPE, curbuf->b_p_ft, curbuf->b_fname,

--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -2395,7 +2395,7 @@ popup_create(typval_T *argvars, typval_T *rettv, create_type_T type)
 	buf->b_locked = TRUE;	// prevent deleting the buffer
 
 	// Avoid that 'buftype' is reset when this buffer is entered.
-	buf->b_p_initialized = TRUE;
+	buf->b_p_initialized = true;
     }
     wp->w_p_wrap = TRUE;	// 'wrap' is default on
     wp->w_p_so = 0;		// 'scrolloff' zero

--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -5271,12 +5271,12 @@ qf_fill_buffer(qf_list_T *qfl, buf_T *buf, qfline_T *old_last, int qf_winid)
 						0L, (char_u *)"qf", OPT_LOCAL);
 	curbuf->b_p_ma = FALSE;
 
-	curbuf->b_keep_filetype = TRUE;	// don't detect 'filetype'
+	curbuf->b_keep_filetype = true;	// don't detect 'filetype'
 	apply_autocmds(EVENT_BUFREADPOST, (char_u *)"quickfix", NULL,
 							       FALSE, curbuf);
 	apply_autocmds(EVENT_BUFWINENTER, (char_u *)"quickfix", NULL,
 							       FALSE, curbuf);
-	curbuf->b_keep_filetype = FALSE;
+	curbuf->b_keep_filetype = false;
 	--curbuf_lock;
 
 	// make sure it will be redrawn

--- a/src/sign.c
+++ b/src/sign.c
@@ -254,7 +254,7 @@ insert_sign(buf_T *buf, // buffer to store sign in
         buf->b_signlist = newsign;
 # ifdef FEAT_NETBEANS_INTG
         if (netbeans_active())
-            buf->b_has_sign_column = TRUE;
+            buf->b_has_sign_column = true;
 # endif
     }
     else

--- a/src/spell.c
+++ b/src/spell.c
@@ -2589,7 +2589,7 @@ open_spellbuf(void)
     if (buf == NULL)
 	return NULL;
 
-    buf->b_spell = TRUE;
+    buf->b_spell = true;
     buf->b_p_swf = TRUE;	// may create a swap file
 #ifdef FEAT_CRYPT
     buf->b_p_key = empty_option;

--- a/src/structs.h
+++ b/src/structs.h
@@ -3233,7 +3233,7 @@ struct file_buffer
 				// b_sfname
 
 #ifdef UNIX
-    int		b_dev_valid;	// TRUE when b_dev has a valid number
+    bool	b_dev_valid;	// true when b_dev has a valid number
     dev_t	b_dev;		// device number
     ino_t	b_ino;		// inode number
 #endif
@@ -3259,14 +3259,14 @@ struct file_buffer
     varnumber_T	b_last_changedtick_pum; // b:changedtick for TextChangedP
     varnumber_T	b_last_changedtick_i;   // b:changedtick for TextChangedI
 
-    int		b_saving;	// Set to TRUE if we are in the middle of
+    bool	b_saving;	// Set to true if we are in the middle of
 				// saving the buffer.
 
     /*
      * Changes to a buffer require updating of the display.  To minimize the
      * work, remember changes made and update everything at once.
      */
-    int		b_mod_set;	// TRUE when there are changes since the last
+    bool	b_mod_set;	// true when there are changes since the last
 				// time the display was updated
     linenr_T	b_mod_top;	// topmost lnum that was changed
     linenr_T	b_mod_bot;	// lnum below last changed line, AFTER the
@@ -3305,7 +3305,7 @@ struct file_buffer
      */
     pos_T	b_changelist[JUMPLISTSIZE];
     int		b_changelistlen;	// number of active entries
-    int		b_new_change;		// set by u_savecommon()
+    bool	b_new_change;		// set in u_savecommon()
 
     /*
      * Character table, only used in charset.c for 'iskeyword'
@@ -3327,12 +3327,12 @@ struct file_buffer
     pos_T	b_op_end;
 
 #ifdef FEAT_VIMINFO
-    int		b_marks_read;	// Have we read viminfo marks yet?
+    bool	b_marks_read;	// Have we read viminfo marks yet?
 #endif
 
-    int		b_modified_was_set;	// did ":set modified"
-    int		b_did_filetype;		// FileType event found
-    int		b_keep_filetype;	// value for did_filetype when starting
+    bool	b_modified_was_set;	// did ":set modified"
+    bool	b_did_filetype;		// FileType event found
+    bool	b_keep_filetype;	// value for did_filetype when starting
 					// to execute autocommands
 
     // Set by the apply_autocmds_group function if the given event is equal to
@@ -3341,7 +3341,7 @@ struct file_buffer
     //
     // Relying on this value requires one to reset it prior calling
     // apply_autocmds_group().
-    int		b_au_did_filetype;
+    bool	b_au_did_filetype;
 
     /*
      * The following only used in undo.c.
@@ -3351,7 +3351,7 @@ struct file_buffer
 				// if b_u_curhead is not NULL
     u_header_T	*b_u_curhead;	// pointer to current header
     int		b_u_numhead;	// current number of headers
-    int		b_u_synced;	// entry lists are synced
+    bool	b_u_synced;	// entry lists are synced
     long	b_u_seq_last;	// last used undo sequence number
     long	b_u_save_nr_last; // counter for last file write
     long	b_u_seq_cur;	// uh_seq of header below which we are now
@@ -3365,7 +3365,7 @@ struct file_buffer
     linenr_T	b_u_line_lnum;	// line number of line in u_line
     colnr_T	b_u_line_colnr;	// optional column number
 
-    int		b_scanned;	// ^N/^P have scanned this buffer
+    bool	b_scanned;	// ^N/^P have scanned this buffer
 
     // flags for use of ":lmap" and IM control
     long	b_p_iminsert;	// input mode for insert
@@ -3388,7 +3388,7 @@ struct file_buffer
      * They are here because their value depends on the type of file
      * or contents of the file being edited.
      */
-    int		b_p_initialized;	// set when options initialized
+    bool	b_p_initialized;	// set when options initialized
 
 #ifdef FEAT_EVAL
     sctx_T	b_p_script_ctx[BV_COUNT]; // SCTXs for buffer-local options
@@ -3611,7 +3611,7 @@ struct file_buffer
     list_T	*b_recorded_changes;
 #endif
 #ifdef FEAT_PROP_POPUP
-    int		b_has_textprop;	// TRUE when text props were added
+    bool	b_has_textprop;	// true when text props were added
     hashtab_T	*b_proptypes;	// text property types local to buffer
     proptype_T	**b_proparray;	// entries of b_proptypes sorted on tp_id
 #endif
@@ -3627,23 +3627,23 @@ struct file_buffer
     // When a buffer is created, it starts without a swap file.  b_may_swap is
     // then set to indicate that a swap file may be opened later.  It is reset
     // if a swap file could not be opened.
-    int		b_may_swap;
-    int		b_did_warn;	// Set to 1 if user has been warned on first
+    bool	b_may_swap;
+    bool	b_did_warn;	// Set to true if user has been warned on first
 				// change of a read-only file
 
     // Two special kinds of buffers:
     // help buffer  - used for help files, won't use a swap file.
     // spell buffer - used for spell info, never displayed and doesn't have a
     //		      file name.
-    int		b_help;		// TRUE for help file buffer (when set b_p_bt
+    bool	b_help;		// true for help file buffer (when set b_p_bt
 				// is "help")
 #ifdef FEAT_SPELL
-    int		b_spell;	// TRUE for a spell file buffer, most fields
+    bool	b_spell;	// true for a spell file buffer, most fields
 				// are not used!  Use the B_SPELL macro to
 				// access b_spell without #ifdef.
 #endif
 
-    int		b_shortname;	// this file has an 8.3 file name
+    bool	b_shortname;	// this file has an 8.3 file name
 
 #ifdef FEAT_JOB_CHANNEL
     char_u	*b_prompt_text;		// set by prompt_setprompt()
@@ -3685,18 +3685,18 @@ struct file_buffer
 #ifdef FEAT_SIGNS
     sign_entry_T *b_signlist;	   // list of placed signs
 # ifdef FEAT_NETBEANS_INTG
-    int		b_has_sign_column; // Flag that is set when a first sign is
+    bool	b_has_sign_column; // Flag that is set when a first sign is
 				   // added and remains set until the end of
 				   // the netbeans session.
 # endif
 #endif
 
 #ifdef FEAT_NETBEANS_INTG
-    int		b_netbeans_file;    // TRUE when buffer is owned by NetBeans
-    int		b_was_netbeans_file;// TRUE if b_netbeans_file was once set
+    bool	b_netbeans_file;    // true when buffer is owned by NetBeans
+    bool	b_was_netbeans_file;// true if b_netbeans_file was once set
 #endif
 #ifdef FEAT_JOB_CHANNEL
-    int		b_write_to_channel; // TRUE when appended lines are written to
+    bool	b_write_to_channel; // true when appended lines are written to
 				    // a channel.
 #endif
 
@@ -3711,7 +3711,7 @@ struct file_buffer
 				// window.
 #endif
 #ifdef FEAT_DIFF
-    int		b_diff_failed;	// internal diff failed for this buffer
+    bool	b_diff_failed;	// internal diff failed for this buffer
 #endif
 }; // file_buffer
 

--- a/src/tag.c
+++ b/src/tag.c
@@ -3080,7 +3080,7 @@ find_tags(
 
     int		save_emsg_off;
 
-    int		help_save;
+    bool	help_save;
 #ifdef FEAT_MULTI_LANG
     int		i;
     char_u	*saved_pat = NULL;		// copy of pat[]
@@ -3122,13 +3122,13 @@ find_tags(
      * Initialize a few variables
      */
     if (st.help_only)				// want tags from help file
-	curbuf->b_help = TRUE;			// will be restored later
+	curbuf->b_help = true;			// will be restored later
 #ifdef FEAT_CSCOPE
     else if (use_cscope)
     {
 	// Make sure we don't mix help and cscope, confuses Coverity.
 	st.help_only = FALSE;
-	curbuf->b_help = FALSE;
+	curbuf->b_help = false;
     }
 #endif
 

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -646,7 +646,7 @@ term_start(
     set_string_option_direct((char_u *)"buftype", -1,
 				  (char_u *)"terminal", OPT_FREE|OPT_LOCAL, 0);
     // Avoid that 'buftype' is reset when this buffer is entered.
-    curbuf->b_p_initialized = TRUE;
+    curbuf->b_p_initialized = true;
 
     // Mark the buffer as not modifiable. It can only be made modifiable after
     // the job finished.

--- a/src/textprop.c
+++ b/src/textprop.c
@@ -965,7 +965,7 @@ f_prop_add_list(typval_T *argvars, typval_T *rettv UNUSED)
     // This must be done _before_ we start adding properties because property
     // changes trigger buffer (memline) reorganisation, which needs this flag
     // to be correctly set.
-    buf->b_has_textprop = TRUE;  // this is never reset
+    buf->b_has_textprop = true;  // this is never reset
     FOR_ALL_LIST_ITEMS(argvars[1].vval.v_list, li)
     {
 	if (li->li_tv.v_type != VAR_LIST || li->li_tv.vval.v_list == NULL)
@@ -1187,7 +1187,7 @@ prop_add_common(
     // This must be done _before_ we add the property because property changes
     // trigger buffer (memline) reorganisation, which needs this flag to be
     // correctly set.
-    buf->b_has_textprop = TRUE;  // this is never reset
+    buf->b_has_textprop = true;  // this is never reset
 
     prop_add_one(buf, type_name, id, text, text_padding_left, flags,
 				    start_lnum, end_lnum, start_col, end_col);

--- a/src/undo.c
+++ b/src/undo.c
@@ -495,12 +495,12 @@ u_savecommon(
     size = bot - top - 1;
 
     /*
-     * If curbuf->b_u_synced == TRUE make a new header.
+     * If curbuf->b_u_synced is true make a new header.
      */
     if (curbuf->b_u_synced)
     {
 	// Need to create new entry in b_changelist.
-	curbuf->b_new_change = TRUE;
+	curbuf->b_new_change = true;
 
 	if (get_undolevel() >= 0)
 	{
@@ -559,7 +559,7 @@ u_savecommon(
 	{
 	    if (old_curhead != NULL)
 		u_freebranch(curbuf, old_curhead, NULL);
-	    curbuf->b_u_synced = FALSE;
+	    curbuf->b_u_synced = false;
 	    return OK;
 	}
 
@@ -653,7 +653,7 @@ u_savecommon(
 			// entry now.  Following deleted/inserted lines go to
 			// the re-used entry.
 			u_getbot();
-			curbuf->b_u_synced = FALSE;
+			curbuf->b_u_synced = false;
 
 			// Move the found entry to become the last entry.  The
 			// order of undo/redo doesn't matter for the entries
@@ -740,7 +740,7 @@ u_savecommon(
 	uep->ue_array = NULL;
     uep->ue_next = curbuf->b_u_newhead->uh_entry;
     curbuf->b_u_newhead->uh_entry = uep;
-    curbuf->b_u_synced = FALSE;
+    curbuf->b_u_synced = false;
     undo_undoes = FALSE;
 
 #ifdef U_DEBUG
@@ -2146,7 +2146,7 @@ u_read_undo(char_u *name, char_u *hash, char_u *orig_name UNUSED)
     curbuf->b_u_save_nr_last = last_save_nr;
     curbuf->b_u_save_nr_cur = last_save_nr;
 
-    curbuf->b_u_synced = TRUE;
+    curbuf->b_u_synced = true;
     vim_free(uhp_table);
 
 # ifdef U_DEBUG
@@ -2199,7 +2199,7 @@ u_undo(int count)
      * original vi. If this happens twice in one macro the result will not
      * be compatible.
      */
-    if (curbuf->b_u_synced == FALSE)
+    if (!curbuf->b_u_synced)
     {
 	u_sync(TRUE);
 	count = 1;
@@ -2333,7 +2333,7 @@ undo_time(
     }
 
     // First make sure the current undoable change is synced.
-    if (curbuf->b_u_synced == FALSE)
+    if (!curbuf->b_u_synced)
 	u_sync(TRUE);
 
     u_newcount = 0;
@@ -3078,7 +3078,7 @@ u_sync(
 	return;		    // XIM is busy, don't break an undo sequence
 #endif
     if (get_undolevel() < 0)
-	curbuf->b_u_synced = TRUE;  // no entries, nothing to do
+	curbuf->b_u_synced = true;  // no entries, nothing to do
     else
     {
 	u_getbot();		    // compute ue_bot of previous u_save
@@ -3215,7 +3215,7 @@ ex_undojoin(exarg_T *eap UNUSED)
 	return;		    // no entries, nothing to do
     else
 	// Append next change to the last entry
-	curbuf->b_u_synced = FALSE;
+	curbuf->b_u_synced = false;
 }
 
 /*
@@ -3226,7 +3226,7 @@ ex_undojoin(exarg_T *eap UNUSED)
 u_unchanged(buf_T *buf)
 {
     u_unch_branch(buf->b_u_oldhead);
-    buf->b_did_warn = FALSE;
+    buf->b_did_warn = false;
 }
 
 /*
@@ -3319,7 +3319,7 @@ u_get_headentry(void)
 
 /*
  * u_getbot(): compute the line number of the previous u_save
- *		It is called only when b_u_synced is FALSE.
+ *		It is called only when b_u_synced is false.
  */
     static void
 u_getbot(void)
@@ -3353,7 +3353,7 @@ u_getbot(void)
 	curbuf->b_u_newhead->uh_getbot_entry = NULL;
     }
 
-    curbuf->b_u_synced = TRUE;
+    curbuf->b_u_synced = true;
 }
 
 /*
@@ -3480,7 +3480,7 @@ u_freeentry(u_entry_T *uep, long n)
 u_clearall(buf_T *buf)
 {
     buf->b_u_newhead = buf->b_u_oldhead = buf->b_u_curhead = NULL;
-    buf->b_u_synced = TRUE;
+    buf->b_u_synced = true;
     buf->b_u_numhead = 0;
     buf->b_u_line_ptr.ul_line = NULL;
     buf->b_u_line_ptr.ul_len = 0;

--- a/src/viminfo.c
+++ b/src/viminfo.c
@@ -2533,7 +2533,7 @@ check_marks_read(void)
 
     // Always set b_marks_read; needed when 'viminfo' is changed to include
     // the ' parameter after opening a buffer.
-    curbuf->b_marks_read = TRUE;
+    curbuf->b_marks_read = true;
 }
 
     static int


### PR DESCRIPTION
Change the type of 23 internal state flag fields in buf_T from int to bool for improved type clarity and code readability.

These fields are pure boolean flags that are never accessed via the option system's varp (which uses *(int *)varp = value), never compared with int fields holding non-0/1 values, and never use tristate values.

Converted fields:
- State flags: b_dev_valid, b_saving, b_mod_set, b_new_change, b_marks_read, b_modified_was_set, b_did_filetype, b_keep_filetype, b_au_did_filetype, b_u_synced, b_scanned, b_p_initialized
- Characteristic flags: b_has_textprop, b_may_swap, b_did_warn, b_help, b_spell, b_shortname, b_has_sign_column, b_netbeans_file, b_was_netbeans_file, b_write_to_channel, b_diff_failed

All TRUE/FALSE assignments to these fields have been updated to true/false accordingly. The type of temporary save variables (e.g. help_save in tag.c) has also been adjusted to bool.

Option value fields (b_p_XXX) are kept as int because they are accessed via the option system and some use tristate (-1) semantics. Fields compared with int option values (b_start_eof, b_start_eol, b_start_bomb) are also kept as int to preserve comparison integrity.