### PR TITLE
runtime(help): make help omnifunc global

### DIFF
--- a/runtime/ftplugin/help.vim
+++ b/runtime/ftplugin/help.vim
@@ -17,14 +17,14 @@ let b:undo_ftplugin = "setl isk< fo< tw< cole< cocu< keywordprg< omnifunc< comme
 
 setl comments= cms=
 
-setlocal formatoptions+=tcroql textwidth=78 keywordprg=:help omnifunc=s:HelpComplete
+setlocal formatoptions+=tcroql textwidth=78 keywordprg=:help omnifunc=HelpComplete
 let &l:iskeyword='!-~,^*,^|,^",192-255'
 if has("conceal")
   setlocal cole=2 cocu=nc
 endif
 
-if !exists('*s:HelpComplete')
-  func s:HelpComplete(findstart, base)
+if !exists('HelpComplete')
+  func HelpComplete(findstart, base)
     if a:findstart
       let colnr = col('.') - 1 " Get the column number before the cursor
       let line = getline('.')


### PR DESCRIPTION
Problem:

- The omnifunc for help tags completion is script local making it hard to use by plugins.
  - see: https://github.com/saghen/blink.cmp/pull/2498

Solution:

- Make the function referenced by the omnifunc global.
