### PR TITLE
refactor: add STR_LITERAL_SET() macro for string_T literal assignment

### DIFF
--- a/src/autocmd.c
+++ b/src/autocmd.c
@@ -3444,10 +3444,7 @@ f_autocmd_get(typval_T *argvars, typval_T *rettv)
 
 	    group_name.string = get_augroup_name(NULL, ap->group);
 	    if (group_name.string == NULL)
-	    {
-		group_name.string = (char_u *)"";
-		group_name.length = 0;
-	    }
+		STR_LITERAL_SET(group_name, "");
 	    else
 		group_name.length = STRLEN(group_name.string);
 

--- a/src/channel.c
+++ b/src/channel.c
@@ -3677,52 +3677,36 @@ channel_part_info(channel_T *channel, dict_T *dict, char *name, ch_part_T part)
 
     STRCPY(namebuf + tail, "status");
     if (chanpart->ch_fd != INVALID_FD)
-    {
-	s.string = (char_u *)"open";
-	s.length = STRLEN_LITERAL("open");
-    }
+	STR_LITERAL_SET(s, "open");
     else if (channel_has_readahead(channel, part))
-    {
-	s.string = (char_u *)"buffered";
-	s.length = STRLEN_LITERAL("buffered");
-    }
+	STR_LITERAL_SET(s, "buffered");
     else
-    {
-	s.string = (char_u *)"closed";
-	s.length = STRLEN_LITERAL("closed");
-    }
+	STR_LITERAL_SET(s, "closed");
     dict_add_string_len(dict, namebuf, s.string, (int)s.length);
 
     STRCPY(namebuf + tail, "mode");
     switch (chanpart->ch_mode)
     {
 	case CH_MODE_NL:
-	    s.string = (char_u *)"NL";
-	    s.length = STRLEN_LITERAL("NL");
+	    STR_LITERAL_SET(s, "NL");
 	    break;
 	case CH_MODE_RAW:
-	    s.string = (char_u *)"RAW";
-	    s.length = STRLEN_LITERAL("RAW");
+	    STR_LITERAL_SET(s, "RAW");
 	    break;
 	case CH_MODE_JSON:
-	    s.string = (char_u *)"JSON";
-	    s.length = STRLEN_LITERAL("JSON");
+	    STR_LITERAL_SET(s, "JSON");
 	    break;
 	case CH_MODE_JS:
-	    s.string = (char_u *)"JS";
-	    s.length = STRLEN_LITERAL("JS");
+	    STR_LITERAL_SET(s, "JS");
 	    break;
 	case CH_MODE_LSP:
-	    s.string = (char_u *)"LSP";
-	    s.length = STRLEN_LITERAL("LSP");
+	    STR_LITERAL_SET(s, "LSP");
 	    break;
 	case CH_MODE_DAP:
-	    s.string = (char_u *)"DAP";
-	    s.length = STRLEN_LITERAL("DAP");
+	    STR_LITERAL_SET(s, "DAP");
 	    break;
 	default:
-	    s.string = (char_u *)"";
-	    s.length = 0;
+	    STR_LITERAL_SET(s, "");
 	    break;
     }
     dict_add_string_len(dict, namebuf, s.string, (int)s.length);

--- a/src/eval.c
+++ b/src/eval.c
@@ -6579,15 +6579,9 @@ class_tv2string(typval_T *tv, char_u **tofree)
 	class_name.string = cl->class_name.string;
 	class_name.length = cl->class_name.length;
 	if (IS_INTERFACE(cl))
-	{
-	    s.string = (char_u *)"interface";
-	    s.length = 9;
-	}
+	    STR_LITERAL_SET(s, "interface");
 	else if (IS_ENUM(cl))
-	{
-	    s.string = (char_u *)"enum";
-	    s.length = 4;
-	}
+	    STR_LITERAL_SET(s, "enum");
     }
 
     rsize = s.length + 1 + class_name.length + 1;

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -4945,10 +4945,7 @@ create_readdirex_item(char_u *path, char_u *name)
 	link = TRUE;
 	ret = mch_stat(p, &st);
 	if (ret < 0)
-	{
-	    q.string = (char_u *)"link";
-	    q.length = STRLEN_LITERAL("link");
-	}
+	    STR_LITERAL_SET(q, "link");
     }
     vim_free(p);
 
@@ -4971,15 +4968,9 @@ create_readdirex_item(char_u *path, char_u *name)
 	if (link)
 	{
 	    if (S_ISDIR(st.st_mode))
-	    {
-		q.string = (char_u *)"linkd";
-		q.length = STRLEN_LITERAL("linkd");
-	    }
+		STR_LITERAL_SET(q, "linkd");
 	    else
-	    {
-		q.string = (char_u *)"link";
-		q.length = STRLEN_LITERAL("link");
-	    }
+		STR_LITERAL_SET(q, "link");
 	}
 	else
 	{
@@ -4993,10 +4984,7 @@ create_readdirex_item(char_u *path, char_u *name)
 
 	pw = getpwuid(st.st_uid);
 	if (pw == NULL)
-	{
-	    q.string = (char_u *)"";
-	    q.length = 0;
-	}
+	    STR_LITERAL_SET(q, "");
 	else
 	{
 	    q.string = (char_u *)pw->pw_name;
@@ -5007,10 +4995,7 @@ create_readdirex_item(char_u *path, char_u *name)
 #  if !defined(VMS) || (defined(VMS) && defined(HAVE_XOS_R_H))
 	gr = getgrgid(st.st_gid);
 	if (gr == NULL)
-	{
-	    q.string = (char_u *)"";
-	    q.length = 0;
-	}
+	    STR_LITERAL_SET(q, "");
 	else
 	{
 	    q.string = (char_u *)gr->gr_name;

--- a/src/macros.h
+++ b/src/macros.h
@@ -376,6 +376,12 @@
 #define STR_LITERAL_INIT(s) \
     {(char_u *)(s), STRLEN_LITERAL(s)}
 
+#define STR_LITERAL_SET(str, s) \
+    do { \
+	(str).string = (char_u *)(s); \
+	(str).length = STRLEN_LITERAL(s); \
+    } while (0)
+
 // Whether a command index indicates a user command.
 #define IS_USER_CMDIDX(idx) ((int)(idx) < 0)
 

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -2730,10 +2730,7 @@ executable_exists(
     {
 	pathext.string = mch_getenv("PATHEXT");
 	if (pathext.string == NULL)
-	{
-	    pathext.string = (char_u *)".com;.exe;.bat;.cmd";
-	    pathext.length = 19;
-	}
+	    STR_LITERAL_SET(pathext, ".com;.exe;.bat;.cmd");
 	else
 	    pathext.length = STRLEN(pathext.string);
 
@@ -2774,10 +2771,7 @@ executable_exists(
 
     // Prepend single "." to pathext, it means no extension added.
     if (pathext.string == NULL)
-    {
-	pathext.string = (char_u *)".";
-	pathext.length = 1;
-    }
+	STR_LITERAL_SET(pathext, ".");
     else if (noext == TRUE)
     {
 	char_u  *tmp;
@@ -2828,10 +2822,7 @@ executable_exists(
      * is an executable file.
      */
     if (pathbuf.string == NULL)
-    {
-	pathbuf.string = (char_u *)".";
-	pathbuf.length = 1;
-    }
+	STR_LITERAL_SET(pathbuf, ".");
     p = pathbuf.string;
     while (*p)
     {

--- a/src/scriptfile.c
+++ b/src/scriptfile.c
@@ -199,12 +199,10 @@ estack_sfile(estack_arg_T which UNUSED)
 		switch (entry->es_type)
 		{
 		    case ETYPE_SCRIPT:
-			type_name.string = (char_u *)"script ";
-			type_name.length = 7;
+			STR_LITERAL_SET(type_name, "script ");
 			break;
 		    case ETYPE_UFUNC:
-			type_name.string = (char_u *)"function ";
-			type_name.length = 9;
+			STR_LITERAL_SET(type_name, "function ");
 			break;
 		    default:
 			break;

--- a/src/strings.c
+++ b/src/strings.c
@@ -1601,10 +1601,7 @@ f_str2blob(typval_T *argvars, typval_T *rettv)
 	string_T    str = {li->li_tv.vval.v_string, 0};
 
 	if (str.string == NULL)
-	{
-	    str.string = (char_u *)"";
-	    str.length = 0;
-	}
+	    STR_LITERAL_SET(str, "");
 	else
 	    str.length = STRLEN(str.string);
 

--- a/src/textprop.c
+++ b/src/textprop.c
@@ -1734,20 +1734,11 @@ prop_fill_dict(dict_T *dict, textprop_T *prop, buf_T *buf)
 
 	// text_align
 	if (prop->tp_flags & TP_FLAG_ALIGN_RIGHT)
-	{
-	    text_align.string = (char_u *)"right";
-	    text_align.length = STRLEN_LITERAL("right");
-	}
+	    STR_LITERAL_SET(text_align, "right");
 	else if (prop->tp_flags & TP_FLAG_ALIGN_ABOVE)
-	{
-	    text_align.string = (char_u *)"above";
-	    text_align.length = STRLEN_LITERAL("above");
-	}
+	    STR_LITERAL_SET(text_align, "above");
 	else if (prop->tp_flags & TP_FLAG_ALIGN_BELOW)
-	{
-	    text_align.string = (char_u *)"below";
-	    text_align.length = STRLEN_LITERAL("below");
-	}
+	    STR_LITERAL_SET(text_align, "below");
 	if (text_align.string != NULL)
 	    dict_add_string_len(dict, "text_align",
 		text_align.string, (int)text_align.length);

--- a/src/vim9type.c
+++ b/src/vim9type.c
@@ -2658,10 +2658,7 @@ type_name_class_or_obj(char *name, type_T *type, char **tofree)
 	    name = "enum";
     }
     else
-    {
-	class_name.string = (char_u *)"any";
-	class_name.length = 3;
-    }
+	STR_LITERAL_SET(class_name, "any");
 
     size_t len = STRLEN(name) + class_name.length + 3;
     *tofree = alloc(len);
@@ -2695,10 +2692,7 @@ type_name_func(type_T *type, char **tofree)
 	string_T    arg_type;
 
 	if (type->tt_args == NULL)
-	{
-	    arg_type.string = (char_u *)"[unknown]";
-	    arg_type.length = 9;
-	}
+	    STR_LITERAL_SET(arg_type, "[unknown]");
 	else
 	{
 	    arg_type.string = (char_u *)type_name(type->tt_args[i], &arg_free);


### PR DESCRIPTION
Previously, assigning a string literal to a string_T variable required two lines that repeated the literal:

    s.string = (char_u *)"open";
    s.length = STRLEN_LITERAL("open");

Writing the literal twice is error-prone -- a typo in one of them leaves the pointer and the cached length out of sync.

Add a STR_LITERAL_SET() macro in macros.h so that the assignment can be written in one statement with the literal appearing only once:

    STR_LITERAL_SET(s, "open");

Replace all occurrences of the two-line pattern across the codebase with the new macro.

No functional change.

---

Note:

Initially, I considered defining the `STR_LITERAL_SET()` macro like this:
```c
#define STR_LITERAL_SET(str, s) \
    (str) = (string_T){ .string = (char_u *)(s), .length = STRLEN_LITERAL(s)}
```
or alternatively, making the `STR_LITERAL_INIT()` macro from PR #20023 generic for common use:
```c
#define STR_LITERAL_INIT(s) \
    (string_T){ .string = (char_u *)(s), .length = STRLEN_LITERAL(s)}
```
However, I decided on the current definition to account for compilers that might not support designated initializers.

---

(Cc: @basilisk0315 )