### PR TITLE
Integer overflow with "ze" and large 'sidescrolloff'

### DIFF
--- a/src/move.c
+++ b/src/move.c
@@ -1184,9 +1184,9 @@ curwin_col_off2(void)
 curs_columns(
     int		may_scroll)	// when TRUE, may scroll horizontally
 {
-    int		diff;
+    long	diff;
     int		extra;		// offset for first screen line
-    int		off_left, off_right;
+    long	off_left, off_right;
     int		n;
     int		p_lines;
     int		width1;		// text width for first screen line
@@ -1306,13 +1306,12 @@ curs_columns(
 #endif
 	/*
 	 * If Cursor is left of the screen, scroll rightwards.
-	 * If Cursor is right of the screen, scroll leftwards
+	 * If Cursor is right of the screen, scroll leftwards.
 	 * If we get closer to the edge than 'sidescrolloff', scroll a little
-	 * extra
+	 * extra.
 	 */
-	off_left = (int)startcol - (int)curwin->w_leftcol - siso;
-	off_right = (int)endcol - (int)(curwin->w_leftcol + curwin->w_width
-								- siso) + 1;
+	off_left = startcol - curwin->w_leftcol - siso;
+	off_right = endcol - curwin->w_leftcol - (curwin->w_width - siso) + 1;
 	if (off_left < 0 || off_right > 0)
 	{
 	    if (off_left < 0)
@@ -1329,9 +1328,9 @@ curs_columns(
 		if (diff < p_ss)
 		    diff = p_ss;
 		if (off_left < 0)
-		    new_leftcol = curwin->w_leftcol - diff;
+		    new_leftcol = curwin->w_leftcol - (int)diff;
 		else
-		    new_leftcol = curwin->w_leftcol + diff;
+		    new_leftcol = curwin->w_leftcol + (int)diff;
 	    }
 	    if (new_leftcol < 0)
 		new_leftcol = 0;

--- a/src/normal.c
+++ b/src/normal.c
@@ -2791,8 +2791,10 @@ nv_zet(cmdarg_T *cap)
 		    n = curwin->w_width - curwin_col_off();
 		    if ((long)col + siso < n)
 			col = 0;
+		    else if (siso - n < INT_MAX - col)
+			col = (int)(col + siso - n + 1);
 		    else
-			col = col + siso - n + 1;
+			col = INT_MAX;
 		    if (curwin->w_leftcol != col)
 		    {
 			curwin->w_leftcol = col;

--- a/src/testdir/test_normal.vim
+++ b/src/testdir/test_normal.vim
@@ -1196,6 +1196,31 @@ func Test_normal17_z_scroll_hor2()
   bw!
 endfunc
 
+func Test_large_sidescrolloff_no_overflow()
+  10new
+  20vsp
+  setlocal nowrap sidescrolloff=2147483647
+  call setline(1, repeat('a', 40))
+
+  normal! $
+  redraw!
+  call assert_equal(29, winsaveview().leftcol)
+
+  normal! zs
+  redraw!
+  call assert_equal(29, winsaveview().leftcol)
+
+  normal! ze
+  redraw!
+  call assert_equal(29, winsaveview().leftcol)
+
+  normal! 0
+  redraw!
+  call assert_equal(0, winsaveview().leftcol)
+
+  bw!
+endfunc
+
 " Test for commands that scroll the window horizontally. Test with folds.
 "   H, M, L, CTRL-E, CTRL-Y, CTRL-U, CTRL-D, PageUp, PageDown commands
 func Test_vert_scroll_cmds()


### PR DESCRIPTION
Problem:  Integer overflow with large 'sidescrolloff'.
Solution: Check for overflow to avoid negative w_leftcol.
