### PR TITLE
fix(edit): stale Insstart after <Cmd> cursor move breaks undo

### DIFF
--- a/src/edit.c
+++ b/src/edit.c
@@ -2502,7 +2502,12 @@ stop_arrow(void)
     else if (ins_need_undo)
     {
 	if (u_save_cursor() == OK)
+	{
+	    // A command or event may have moved the cursor after syncing undo.
+	    Insstart = curwin->w_cursor;
+	    Insstart_textlen = (colnr_T)linetabsize_str(ml_get_curline());
 	    ins_need_undo = FALSE;
+	}
     }
 
 #ifdef FEAT_FOLDING

--- a/src/testdir/test_undo.vim
+++ b/src/testdir/test_undo.vim
@@ -924,5 +924,19 @@ func Test_restore_cursor_position_after_undo()
   bw!
 endfunc
 
+func Test_undo_line_backspace_after_insert_cmd_cursor_movement()
+  new
+  setlocal backspace=eol undolevels=100
+  call setline(1, ['', '', 'abc', 'def'])
+  call cursor(4, 1)
+
+  let v:errmsg = ''
+  call feedkeys("i\<Cmd>setlocal undolevels=101 | call cursor(3, 1)\<CR>"
+        \ .. "\<BS>\<BS>\<Esc>u", 'xt')
+
+  call assert_equal('', v:errmsg)
+  call assert_equal(['', '', 'abc', 'def'], getline(1, '$'))
+  bwipe!
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:
A `<Cmd>` command executed from Insert mode can sync undo and move the cursor before the next edit. stop_arrow() saved the new cursor line for undo, but left Insstart at the previous insertion point. A line-start backspace could then delete lines above the saved line without saving the joined range, leaving a pending undo entry whose bottom resolved above its top and and raising E340.

Solution:
Update Insstart and Insstart_textlen after the pending undo save so the next edit starts from the command-updated cursor position.

AI-assisted: Codex

I gave Codex the bug described at https://github.com/L3MON4D3/LuaSnip/issues/1248, and it found this (different) bug and the patch. 