### PR TITLE
filetype: some some Beancount files are not recognized

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -1798,6 +1798,7 @@ const ft_from_ext = {
   # BDF font
   "bdf": "bdf",
   # Beancount
+  "bean": "beancount",
   "beancount": "beancount",
   # BibTeX bibliography database file
   "bib": "bib",

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -138,7 +138,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     bass: ['file.bass'],
     bc: ['file.bc'],
     bdf: ['file.bdf'],
-    beancount: ['file.beancount'],
+    beancount: ['file.beancount', 'file.bean'],
     bib: ['file.bib'],
     bicep: ['file.bicep'],
     bicep-params: ['file.bicepparam'],


### PR DESCRIPTION
Problem:    Not all Beancount files are recognized.
Solution:   Add additional file extensions