### PR TITLE
DECRQM still leaves stray "pp" on Apple Terminal.app after 9.2.0387

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -892,10 +892,6 @@ vim_main2(void)
     may_req_termresponse();
 
     may_req_bg_color();
-
-    // Same reason as for termresponse: don't want the terminal sending out
-    // the DECRPM response after Vim has exited.
-    may_req_decrqm();
 # endif
 
     // start in insert mode

--- a/src/proto/term.pro
+++ b/src/proto/term.pro
@@ -60,7 +60,6 @@ void stoptermcap(void);
 void may_req_termresponse(void);
 void check_terminal_behavior(void);
 void may_req_bg_color(void);
-void may_req_decrqm(void);
 int swapping_screen(void);
 void scroll_start(void);
 void cursor_on_force(void);

--- a/src/term.c
+++ b/src/term.c
@@ -4312,36 +4312,6 @@ may_req_bg_color(void)
     }
 }
 
-/*
- * Query the settings for the DEC modes we support via DECRQM.
- * Only sent once, and only when the terminal is known not to dislike it
- * (i.e. TPR_DECRQM is TPR_YES, or still TPR_UNKNOWN when the version response
- * has not yet been received).
- * The DECRPM responses are caught in handle_csi().
- */
-    void
-may_req_decrqm(void)
-{
-    if (decrqm_status.tr_progress == STATUS_GET
-	    && term_props[TPR_DECRQM].tpr_status != TPR_NO
-	    && can_get_termresponse()
-	    && starting == 0)
-    {
-	MAY_WANT_TO_LOG_THIS;
-	LOG_TR1("Sending DECRQM requests");
-	for (int i = 0; i < (int)ARRAY_LENGTH(dec_modes); i++)
-	{
-	    vim_snprintf((char *)IObuff, IOSIZE, "\033[?%d$p", dec_modes[i]);
-	    out_str(IObuff);
-	}
-	termrequest_sent(&decrqm_status);
-	// check for the characters now, otherwise they might be eaten by
-	// get_keystroke()
-	out_flush();
-	(void)vpeekc_nomap();
-    }
-}
-
 #endif
 
 /*
@@ -5395,6 +5365,23 @@ handle_version_response(int first, int *arg, int argc, char_u *tp)
 	    LOG_TR1("Sending cursor blink mode request");
 	    out_str(T_CRC);
 	    termrequest_sent(&rbm_status);
+	    need_flush = TRUE;
+	}
+
+	// Only request DEC modes via DECRQM when the terminal is known to
+	// handle it.  Not for Apple Terminal.app or GNU screen, they echo
+	// the trailing "p" to the screen.  See issue #19852.
+	if (decrqm_status.tr_progress == STATUS_GET
+		&& term_props[TPR_DECRQM].tpr_status == TPR_YES)
+	{
+	    MAY_WANT_TO_LOG_THIS;
+	    LOG_TR1("Sending DECRQM requests");
+	    for (int i = 0; i < (int)ARRAY_LENGTH(dec_modes); i++)
+	    {
+		vim_snprintf((char *)IObuff, IOSIZE, "\033[?%d$p", dec_modes[i]);
+		out_str(IObuff);
+	    }
+	    termrequest_sent(&decrqm_status);
 	    need_flush = TRUE;
 	}
 


### PR DESCRIPTION
DECRQM still leaves stray "pp" on Apple Terminal.app after 9.2.0387

Problem:  After 9.2.0387, DECRQM was still sent to Apple Terminal.app
          before its DA2 reply was processed, leaving a literal "pp"
          on screen.  may_req_decrqm() was called from vim_main2()
          right after may_req_termresponse(), at which point
          term_props[TPR_DECRQM].tpr_status was still TPR_UNKNOWN, so
          the `!= TPR_NO` guard let the request through.

Solution: Send DECRQM from handle_version_response() once
          term_props[TPR_DECRQM].tpr_status == TPR_YES, the same
          pattern already used for t_RS (TPR_CURSOR_STYLE) and t_RC
          (TPR_CURSOR_BLINK), which deliberately wait for the DA2
          reply to avoid the same echo-on-screen issue on Apple
          Terminal.app and Gnome terminal.  Drop the now-unused
          may_req_decrqm() helper and its call site in vim_main2().

fixes: #19852
related: #19938