### PR TITLE
Scrolling with 'splitkeep' when changing 'cmdheight'

### DIFF
--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -4384,6 +4384,11 @@ expand_set_spellsuggest(optexpand_T *args, int *numMatches, char_u ***matches)
     char *
 did_set_splitkeep(optset_T *args UNUSED)
 {
+    win_T	*wp;
+    tabpage_T	*tp;
+    FOR_ALL_TAB_WINDOWS(tp, wp) {
+	wp->w_prev_height = wp->w_height;
+    }
     return did_set_opt_strings(p_spk, p_spk_values, FALSE);
 }
 

--- a/src/testdir/test_window_cmd.vim
+++ b/src/testdir/test_window_cmd.vim
@@ -1992,6 +1992,16 @@ func Test_splitkeep_screen_cursor_pos()
   set splitkeep&
 endfunc
 
+func Test_splitkeep_cmdheight()
+  set splitkeep=screen
+  call setline(1, range(&lines))
+  norm! G
+  set cmdheight=2
+  call assert_equal(&lines - 1, line('.'))
+  %bwipeout!
+  set splitkeep& cmdheight&
+endfunc
+
 func Test_splitkeep_cursor()
   CheckScreendump
   let lines =<< trim END

--- a/src/window.c
+++ b/src/window.c
@@ -7588,6 +7588,7 @@ command_height(void)
     }
     if (p_ch < old_p_ch && command_frame_height && frp != NULL)
 	frame_add_height(frp, (int)(old_p_ch - p_ch));
+    win_fix_scroll(true);
 
     // Recompute window positions.
     win_comp_pos();


### PR DESCRIPTION
Problem:  Cursor is not adjusted when 'cmdheight' is changed to cover
          the cursor with 'splitkeep' ~= "cursor".
Solution: Handle window resize for 'splitkeep' after changing 'cmdheight'.
          Ensure previous window height is set when changing 'splitkeep'.