### PR TITLE
Do not open a new tab page on double-click in the tabpanel

### DIFF
--- a/runtime/doc/tabpage.txt
+++ b/runtime/doc/tabpage.txt
@@ -513,6 +513,16 @@ The scrollbar uses the |hl-PmenuSbar| highlight group for the track and
 The scroll offset is remembered across redraws but is reset when "scroll" or
 "scrollbar" is toggled off and back on.
 
+MOUSE CLICKS IN THE TABPANEL:				*tabpanel-mouse*
+
+A left click on a row in the tabpanel selects the tab page that the row
+belongs to.  Unlike the tabline, a double click in the tabpanel does *not*
+open a new, empty tab page; it is treated the same as a single click.
+
+For finer-grained control, the 'tabpanel' value may contain |%[FuncName]|
+click regions.  Clicks on those regions are dispatched to the callback
+function instead of falling through to tab selection.
+
 ==============================================================================
 6. Setting 'guitablabel'				*setting-guitablabel*
 

--- a/src/mouse.c
+++ b/src/mouse.c
@@ -591,9 +591,13 @@ do_mouse(
 	    c1 = tp_label.nr;
 	    if (c1 >= 0)
 	    {
-		if ((mod_mask & MOD_MASK_MULTI_CLICK) == MOD_MASK_2CLICK)
+		if ((mod_mask & MOD_MASK_MULTI_CLICK) == MOD_MASK_2CLICK
+						    && !tp_label.is_panel)
 		{
-		    // double click opens new page
+		    // Double-click on the tabline opens a new, empty tab page.
+		    // The tabpanel has no "empty area" (every row maps to a tab)
+		    // and this behavior is not documented for tabpanel, so fall
+		    // through to the regular tab-switch path there.
 		    end_visual_mode_keep_button();
 		    tabpage_new();
 		    tabpage_move(c1 == 0 ? 9999 : c1 - 1);


### PR DESCRIPTION
The tabpanel click handler inherited the tabline behavior of spawning a new, empty tab page on double-click. Unlike the tabline, the tabpanel has no "empty area" — every row maps to some tab — so this fires on any double-click inside the tabpanel and can generate stray empty tabs. The behavior is also not documented for the tabpanel (the author confirmed it was an unintentional copy from the tabline path).

Gate the new-tab branch on `!tp_label.is_panel` so the tabpanel falls through to the regular tab-switch path. The tabline behavior is unchanged. Added a `*tabpanel-mouse*` note to `runtime/doc/tabpage.txt` describing the behavior.