### PR TITLE
fix GVim does not lose selection ownership and does not use VisualNOS when it should

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4810,7 +4810,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 			    windows
 	|hl-Visual|	 v  Visual mode
 	|hl-VisualNOS|	 V  Visual mode when Vim is "Not Owning the
-			    Selection" Only X11 Gui's |gui-x11|,
+			    Selection" Only X11 or Wayland GUI's |gui-x11|,
 			    |xterm-clipboard| and |wayland-selections|
 	|hl-WarningMsg|	 w  warning messages
 	|hl-WildMenu|	 W  wildcard matches displayed for 'wildmenu'

--- a/src/drawline.c
+++ b/src/drawline.c
@@ -1464,7 +1464,7 @@ win_line(
 	    {
 		area_highlighting = TRUE;
 		vi_attr = HL_ATTR(HLF_V);
-#if defined(FEAT_CLIPBOARD) && defined(FEAT_X11)
+#if defined(FEAT_CLIPBOARD)
 		if ((clipmethod != CLIPMETHOD_PROVIDER) &&
 			((clip_star.available && !clip_star.owned
 						    && clip_isautosel_star())

--- a/src/drawline.c
+++ b/src/drawline.c
@@ -1465,7 +1465,7 @@ win_line(
 		area_highlighting = TRUE;
 		vi_attr = HL_ATTR(HLF_V);
 #if defined(FEAT_CLIPBOARD) && defined(FEAT_X11)
-		if (X_DISPLAY &&
+		if ((clipmethod != CLIPMETHOD_PROVIDER) &&
 			((clip_star.available && !clip_star.owned
 						    && clip_isautosel_star())
 			    || (clip_plus.available && !clip_plus.owned


### PR DESCRIPTION
fixes #19914.

I don't really know what condition is better to put here, but since the patch introduced this issue (#19659) is about clipboard provider, I think this is good enough?