### PR TITLE
test: ignore user files during Test_backupskip

### DIFF
--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -1185,7 +1185,7 @@ func Test_backupskip()
       qall
   [CODE]
   call writefile(after, 'Xafter', 'D')
-  let cmd = GetVimProg() . ' --not-a-term -S Xafter --cmd "set enc=utf8"'
+  let cmd = GetVimProg() . ' --clean --not-a-term -S Xafter --cmd "set enc=utf8"'
 
   let saveenv = {}
   for var in ['TMPDIR', 'TMP', 'TEMP']
@@ -1193,9 +1193,9 @@ func Test_backupskip()
     call setenv(var, '/duplicate/path')
   endfor
 
-  " unset $HOME, so that it won't try to read init files
+  " set $HOME='', so that Vim won't try to read init files
   let saveenv['HOME'] = getenv("HOME")
-  call setenv('HOME', v:null)
+  call setenv('HOME', '')
   exe 'silent !' . cmd
   call assert_equal(['errors:'], readfile('Xtestout'))
 


### PR DESCRIPTION
Even though we unset HOME, we can see via scriptnames that user files are still sourced! One of my installed plugins warns when not compiled with +python3, so this test has a "press Enter" prompt.

Use `--clean` like most other GetVimProg()'s do to fix it. Some tests use `system()` instead, but that turns this test into a failure rather than passing; I'm not sure why other tests don't suffer from this.

To prove to ourselves, we can use code like this:

    diff --git i/src/testdir/test_options.vim w/src/testdir/test_options.vim
    index a408e20e1..044364a54 100644
    --- i/src/testdir/test_options.vim
    +++ w/src/testdir/test_options.vim
    @@ -1179,6 +1179,7 @@ func Test_backupskip()
       " P_NODUP).  Run this in a separate instance and write v:errors in a file,
       " so that we see what happens on startup.
       let after =<< trim [CODE]
    +      call writefile([execute('scriptnames')], 'foo')
           let bsklist = split(&backupskip, ',')
           call assert_equal(uniq(copy(bsklist)), bsklist)
           call writefile(['errors:'] + v:errors, 'Xtestout')
    @@ -1196,7 +1197,7 @@ func Test_backupskip()
       " unset $HOME, so that it won't try to read init files
       let saveenv['HOME'] = getenv("HOME")
       call setenv('HOME', v:null)
    -  exe 'silent !' . cmd
    +  exe 'silent !' . cmd .. ' --cmd "echo &rtp"'
       call assert_equal(['errors:'], readfile('Xtestout'))

       " restore environment variables

Here, that causes "foo" to include a bunch of files under ~/.vim. I'm not sure why this happens, but lets paper over it for the test.

We can also tell that (orthogonal to --clean) setting HOME='' works too. Let's do that in addition since unsetting HOME isn't quite enough.

---

This fixes a test oddity for me, but I can't explain why it happens here and not elsewhere. Better explanations welcome!