### PR TITLE
xxd: use %lu for unsigned long in decimal offset output

### DIFF
--- a/src/testdir/test_xxd.vim
+++ b/src/testdir/test_xxd.vim
@@ -476,7 +476,7 @@ func Test_xxd_buffer_overflow()
   endif
   new
   let input = repeat('A', 256)
-  call writefile(['-9223372036854775808: ' . repeat("\e[1;32m41\e[0m ", 256) . ' ' . "\e[1;32m" . repeat('A', 256) . "\e[0m"], 'Xxdexpected', 'D')
+  call writefile(['9223372036854775808: ' . repeat("\e[1;32m41\e[0m ", 256) . ' ' . "\e[1;32m" . repeat('A', 256) . "\e[0m"], 'Xxdexpected', 'D')
   exe 'r! printf ' . input . '| ' . s:xxd_cmd . ' -Ralways -g1 -c256 -d -o 9223372036854775808 > Xxdout'
   call assert_equalfile('Xxdexpected', 'Xxdout')
   call delete('Xxdout')

--- a/src/xxd/xxd.c
+++ b/src/xxd/xxd.c
@@ -1172,7 +1172,7 @@ main(int argc, char *argv[])
     {
       if (p == 0)
 	{
-	  addrlen = sprintf(l, decimal_offset ? "%08ld:" : "%08lx:",
+	  addrlen = sprintf(l, decimal_offset ? "%08lu:" : "%08lx:",
 				  ((unsigned long)(n + seekoff + displayoff)));
 	  for (c = addrlen; c < LLEN_NO_COLOR; l[c++] = ' ')
 	    ;


### PR DESCRIPTION
The decimal offset (`-d`) used `%ld` with an `unsigned long` value, so offsets above `LONG_MAX` were printed as negative numbers. Use `%lu` instead.

```
$ printf 'AB' | ./xxd -d -o 9223372036854775808
-9223372036854775808: 4142                                     AB
```