### PR TITLE
Add tabpanel_getinfo() and tabpanel_scroll()

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -11891,7 +11891,6 @@ tabpanel_getinfo()					*tabpanel_getinfo()*
 		tabpanel (see |tabpanel|).  The dictionary has these keys:
 			align		"left" or "right"
 			columns		width in screen columns
-			scroll		|TRUE| if 'tabpanelopt' contains "scroll"
 			scrollbar	|TRUE| if a scrollbar is shown
 			offset		current scroll offset in rows
 			total		total number of rows rendered
@@ -11913,10 +11912,10 @@ tabpanel_scroll({n} [, {opts}])				*tabpanel_scroll()*
 		instead of a delta.
 
 		Returns |TRUE| if the scroll offset changed, |FALSE|
-		otherwise (for example when 'tabpanelopt' does not contain
-		"scroll", or the offset is already at the requested value).
+		otherwise (for example when the tabpanel is not shown, or
+		the offset is already at the requested value).
 
-		Return type: |Number|
+		Return type: |vim9-boolean|
 
 
 tagfiles()						*tagfiles()*

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -706,7 +706,7 @@ tabpagenr([{arg}])		Number	number of current or last tab page
 tabpagewinnr({tabarg} [, {arg}])
 				Number	number of current window in tab page
 tabpanel_getinfo()		Dict	get current state of the tabpanel
-tabpanel_scroll({n} [, {opts}])	Number	scroll the tabpanel
+tabpanel_scroll({n} [, {opts}])	Bool	scroll the tabpanel
 tagfiles()			List	tags files used
 taglist({expr} [, {filename}])	List	list of tags matching {expr}
 tan({expr})			Float	tangent of {expr}

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -705,6 +705,8 @@ tabpagebuflist([{arg}])		List	list of buffer numbers in tab page
 tabpagenr([{arg}])		Number	number of current or last tab page
 tabpagewinnr({tabarg} [, {arg}])
 				Number	number of current window in tab page
+tabpanel_getinfo()		Dict	get current state of the tabpanel
+tabpanel_scroll({n} [, {opts}])	Number	scroll the tabpanel
 tagfiles()			List	tags files used
 taglist({expr} [, {filename}])	List	list of tags matching {expr}
 tan({expr})			Float	tangent of {expr}
@@ -11881,6 +11883,39 @@ tabpagewinnr({tabarg} [, {arg}])			*tabpagewinnr()*
 		Can also be used as a |method|: >
 			GetTabpage()->tabpagewinnr()
 <
+		Return type: |Number|
+
+
+tabpanel_getinfo()					*tabpanel_getinfo()*
+		Return a |Dictionary| describing the current state of the
+		tabpanel (see |tabpanel|).  The dictionary has these keys:
+			align		"left" or "right"
+			columns		width in screen columns
+			scroll		|TRUE| if 'tabpanelopt' contains "scroll"
+			scrollbar	|TRUE| if a scrollbar is shown
+			offset		current scroll offset in rows
+			total		total number of rows rendered
+			max_offset	largest valid value for "offset"
+
+		The "total" and "max_offset" values are only accurate after
+		the tabpanel has been drawn at least once.
+
+		Return type: dict<any>
+
+
+tabpanel_scroll({n} [, {opts}])				*tabpanel_scroll()*
+		Scroll the tabpanel by {n} rows.  Positive values scroll down
+		(later tabs become visible), negative values scroll up.  The
+		new offset is clamped to the valid range.
+
+		When {opts} is a |Dictionary| and its "absolute" entry is
+		|TRUE|, {n} is used as the new absolute scroll offset
+		instead of a delta.
+
+		Returns |TRUE| if the scroll offset changed, |FALSE|
+		otherwise (for example when 'tabpanelopt' does not contain
+		"scroll", or the offset is already at the requested value).
+
 		Return type: |Number|
 
 

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -1081,6 +1081,8 @@ Buffers, windows and the argument list:
 	tabpagebuflist()	return List of buffers in a tab page
 	tabpagenr()		get the number of a tab page
 	tabpagewinnr()		like winnr() for a specified tab page
+	tabpanel_getinfo()	get current state of the tabpanel
+	tabpanel_scroll()	scroll the tabpanel
 	winnr()			get the window number for the current window
 	bufwinid()		get the window ID of a specific buffer
 	bufwinnr()		get the window number of a specific buffer

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -1934,6 +1934,11 @@ typedef struct
 #else
 # define TERM_FUNC(name) NULL
 #endif
+#ifdef FEAT_TABPANEL
+# define TABPANEL_FUNC(name) name
+#else
+# define TABPANEL_FUNC(name) NULL
+#endif
 
 static const funcentry_T global_functions[] =
 {
@@ -2991,6 +2996,10 @@ static const funcentry_T global_functions[] =
 			ret_number,	    f_tabpagenr},
     {"tabpagewinnr",	1, 2, FEARG_1,	    arg2_number_string,
 			ret_number,	    f_tabpagewinnr},
+    {"tabpanel_getinfo", 0, 0, 0,	    NULL,
+			ret_dict_any,	    TABPANEL_FUNC(f_tabpanel_getinfo)},
+    {"tabpanel_scroll",	1, 2, FEARG_1,	    arg2_number_dict_any,
+			ret_bool,	    TABPANEL_FUNC(f_tabpanel_scroll)},
     {"tagfiles",	0, 0, 0,	    NULL,
 			ret_list_string,    f_tagfiles},
     {"taglist",		1, 2, FEARG_1,	    arg2_string,

--- a/src/proto/tabpanel.pro
+++ b/src/proto/tabpanel.pro
@@ -9,4 +9,7 @@ bool mouse_on_tabpanel(void);
 bool mouse_on_tabpanel_scrollbar(void);
 bool tabpanel_drag_scrollbar(int screen_row);
 bool tabpanel_scroll(int dir, int count);
+bool tabpanel_set_offset(int offset);
+void f_tabpanel_getinfo(typval_T *argvars, typval_T *rettv);
+void f_tabpanel_scroll(typval_T *argvars, typval_T *rettv);
 /* vim: set ft=c : */

--- a/src/tabpanel.c
+++ b/src/tabpanel.c
@@ -913,4 +913,103 @@ tabpanel_scroll(int dir, int count)
     return true;
 }
 
+/*
+ * Set the tabpanel scroll offset to "offset" (clamped to the valid range).
+ * Returns true if the offset changed and a redraw was scheduled.
+ */
+    bool
+tabpanel_set_offset(int offset)
+{
+    int max_offset;
+
+    if (tabpanel_width() == 0)
+	return false;
+
+    max_offset = tpl_total_rows - Rows;
+    if (max_offset < 0)
+	max_offset = 0;
+
+    if (offset < 0)
+	offset = 0;
+    if (offset > max_offset)
+	offset = max_offset;
+    if (offset == tpl_scroll_offset)
+	return false;
+
+    tpl_scroll_offset = offset;
+    redraw_tabpanel = TRUE;
+    return true;
+}
+
+/*
+ * "tabpanel_getinfo()" function
+ */
+    void
+f_tabpanel_getinfo(typval_T *argvars UNUSED, typval_T *rettv)
+{
+    dict_T	*d;
+    int		max_offset;
+
+    if (rettv_dict_alloc(rettv) == FAIL)
+	return;
+    d = rettv->vval.v_dict;
+
+    max_offset = tpl_total_rows - Rows;
+    if (max_offset < 0)
+	max_offset = 0;
+
+    dict_add_string(d, "align",
+	    (char_u *)(tpl_align == ALIGN_RIGHT ? "right" : "left"));
+    dict_add_number(d, "columns", tabpanel_width());
+    dict_add_bool(d, "scroll", tpl_scroll);
+    dict_add_bool(d, "scrollbar", tpl_scrollbar);
+    dict_add_number(d, "offset", tpl_scroll_offset);
+    dict_add_number(d, "total", tpl_total_rows);
+    dict_add_number(d, "max_offset", max_offset);
+}
+
+/*
+ * "tabpanel_scroll()" function
+ */
+    void
+f_tabpanel_scroll(typval_T *argvars, typval_T *rettv)
+{
+    varnumber_T	n;
+    int		absolute = 0;
+    bool	changed;
+
+    rettv->v_type = VAR_BOOL;
+    rettv->vval.v_number = VVAL_FALSE;
+
+    if (in_vim9script()
+	    && (check_for_number_arg(argvars, 0) == FAIL
+		|| check_for_opt_dict_arg(argvars, 1) == FAIL))
+	return;
+
+    n = tv_get_number_chk(&argvars[0], NULL);
+    if (argvars[1].v_type != VAR_UNKNOWN)
+    {
+	if (argvars[1].v_type != VAR_DICT || argvars[1].vval.v_dict == NULL)
+	{
+	    emsg(_(e_dictionary_required));
+	    return;
+	}
+	absolute = dict_get_bool(argvars[1].vval.v_dict, "absolute", FALSE);
+    }
+
+    // Clamp to int range to avoid signed overflow when casting and negating.
+    if (n > INT_MAX)
+	n = INT_MAX;
+    else if (n < -INT_MAX)
+	n = -INT_MAX;
+
+    if (absolute)
+	changed = tabpanel_set_offset((int)n);
+    else
+	changed = tabpanel_scroll(n >= 0 ? 1 : -1,
+				  (int)(n >= 0 ? n : -n));
+
+    rettv->vval.v_number = changed ? VVAL_TRUE : VVAL_FALSE;
+}
+
 #endif // FEAT_TABPANEL

--- a/src/tabpanel.c
+++ b/src/tabpanel.c
@@ -961,7 +961,6 @@ f_tabpanel_getinfo(typval_T *argvars UNUSED, typval_T *rettv)
     dict_add_string(d, "align",
 	    (char_u *)(tpl_align == ALIGN_RIGHT ? "right" : "left"));
     dict_add_number(d, "columns", tabpanel_width());
-    dict_add_bool(d, "scroll", tpl_scroll);
     dict_add_bool(d, "scrollbar", tpl_scrollbar);
     dict_add_number(d, "offset", tpl_scroll_offset);
     dict_add_number(d, "total", tpl_total_rows);

--- a/src/testdir/test_tabpanel.vim
+++ b/src/testdir/test_tabpanel.vim
@@ -1129,4 +1129,58 @@ func Test_tabpanel_empty()
   set tabpanel&
 endfunc
 
+func Test_tabpanel_getinfo_and_scroll()
+  set showtabpanel=2 tabpanelopt=scroll,columns:20
+  for i in range(40)
+    tabnew
+  endfor
+  redraw
+
+  let info = tabpanel_getinfo()
+  call assert_equal('left', info.align)
+  call assert_equal(20, info.columns)
+  call assert_true(info.scroll)
+  call assert_equal(0, info.offset)
+  call assert_true(info.total > 0)
+  call assert_true(info.max_offset >= 0)
+
+  " relative scroll down
+  if info.max_offset > 0
+    call assert_true(tabpanel_scroll(1))
+    redraw
+    call assert_equal(1, tabpanel_getinfo().offset)
+  endif
+
+  " relative scroll up, clamped at 0
+  call tabpanel_scroll(-10)
+  redraw
+  call assert_equal(0, tabpanel_getinfo().offset)
+
+  " absolute set
+  let max = tabpanel_getinfo().max_offset
+  if max > 0
+    call tabpanel_scroll(max, #{absolute: 1})
+    redraw
+    call assert_equal(max, tabpanel_getinfo().offset)
+  endif
+
+  " clamp past the end
+  call tabpanel_scroll(99999, #{absolute: 1})
+  redraw
+  call assert_equal(max, tabpanel_getinfo().offset)
+
+  " clamp negative absolute
+  call tabpanel_scroll(-5, #{absolute: 1})
+  redraw
+  call assert_equal(0, tabpanel_getinfo().offset)
+
+  " no change returns false
+  call assert_false(tabpanel_scroll(0, #{absolute: 1}))
+  call assert_false(tabpanel_scroll(-1))
+
+  set showtabpanel& tabpanelopt&
+  tabonly!
+  %bwipeout!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_tabpanel.vim
+++ b/src/testdir/test_tabpanel.vim
@@ -1130,57 +1130,80 @@ func Test_tabpanel_empty()
 endfunc
 
 func Test_tabpanel_getinfo_and_scroll()
-  set showtabpanel=2 tabpanelopt=scroll,columns:20
-  for i in range(40)
-    tabnew
+  CheckScreendump
+
+  let lines =<< trim END
+    set showtabpanel=2 tabpanelopt=columns:20
+    set showtabline=0
+    for i in range(40)
+      tabnew
+    endfor
+    tabfirst
+    redraw
+    func WriteResult(label)
+      call writefile([a:label, string(tabpanel_getinfo())], 'Xresult', 'a')
+    endfunc
+    call delete('Xresult')
+    call WriteResult('initial')
+    let g:r1 = tabpanel_scroll(1)
+    redraw
+    call WriteResult('after_scroll_1')
+    call tabpanel_scroll(-10)
+    redraw
+    call WriteResult('after_scroll_minus10')
+    let g:max = tabpanel_getinfo().max_offset
+    call tabpanel_scroll(g:max, #{absolute: 1})
+    redraw
+    call WriteResult('after_abs_max')
+    call tabpanel_scroll(99999, #{absolute: 1})
+    redraw
+    call WriteResult('after_abs_overflow')
+    call tabpanel_scroll(-5, #{absolute: 1})
+    redraw
+    call WriteResult('after_abs_negative')
+    let g:r_zero = tabpanel_scroll(0, #{absolute: 1})
+    let g:r_neg_at_zero = tabpanel_scroll(-1)
+    call writefile([
+          \ 'r1=' .. g:r1,
+          \ 'max=' .. g:max,
+          \ 'r_zero=' .. g:r_zero,
+          \ 'r_neg_at_zero=' .. g:r_neg_at_zero,
+          \ ], 'Xflags')
+  END
+  call writefile(lines, 'XTest_tabpanel_getinfo', 'D')
+
+  let buf = RunVimInTerminal('-S XTest_tabpanel_getinfo', {'rows': 10, 'cols': 45})
+  call WaitForAssert({-> assert_true(filereadable('Xflags'))})
+  call StopVimInTerminal(buf)
+
+  let results = readfile('Xresult')
+  let flags = readfile('Xflags')
+  call delete('Xresult')
+  call delete('Xflags')
+
+  " Parse [label, dict] pairs.
+  let info = {}
+  for i in range(0, len(results) - 1, 2)
+    let info[results[i]] = eval(results[i + 1])
   endfor
-  redraw
 
-  let info = tabpanel_getinfo()
-  call assert_equal('left', info.align)
-  call assert_equal(20, info.columns)
-  call assert_true(info.scroll)
-  call assert_equal(0, info.offset)
-  call assert_true(info.total > 0)
-  call assert_true(info.max_offset >= 0)
+  call assert_equal('left', info.initial.align)
+  call assert_equal(20, info.initial.columns)
+  call assert_false(has_key(info.initial, 'scroll'))
+  call assert_equal(0, info.initial.offset)
+  call assert_true(info.initial.total > 0)
+  call assert_true(info.initial.max_offset > 0)
 
-  " relative scroll down
-  if info.max_offset > 0
-    call assert_true(tabpanel_scroll(1))
-    redraw
-    call assert_equal(1, tabpanel_getinfo().offset)
-  endif
+  call assert_equal(1, info.after_scroll_1.offset)
+  call assert_equal(0, info.after_scroll_minus10.offset)
 
-  " relative scroll up, clamped at 0
-  call tabpanel_scroll(-10)
-  redraw
-  call assert_equal(0, tabpanel_getinfo().offset)
+  let max = info.initial.max_offset
+  call assert_equal(max, info.after_abs_max.offset)
+  call assert_equal(max, info.after_abs_overflow.offset)
+  call assert_equal(0, info.after_abs_negative.offset)
 
-  " absolute set
-  let max = tabpanel_getinfo().max_offset
-  if max > 0
-    call tabpanel_scroll(max, #{absolute: 1})
-    redraw
-    call assert_equal(max, tabpanel_getinfo().offset)
-  endif
-
-  " clamp past the end
-  call tabpanel_scroll(99999, #{absolute: 1})
-  redraw
-  call assert_equal(max, tabpanel_getinfo().offset)
-
-  " clamp negative absolute
-  call tabpanel_scroll(-5, #{absolute: 1})
-  redraw
-  call assert_equal(0, tabpanel_getinfo().offset)
-
-  " no change returns false
-  call assert_false(tabpanel_scroll(0, #{absolute: 1}))
-  call assert_false(tabpanel_scroll(-1))
-
-  set showtabpanel& tabpanelopt&
-  tabonly!
-  %bwipeout!
+  call assert_equal(['r1=v:true', 'max=' .. max,
+        \ 'r_zero=v:false', 'r_neg_at_zero=v:false'], flags)
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Expose the tabpanel scroll state to Vim script.

- `tabpanel_getinfo()` returns a dict with `align`, `columns`, `scrollbar`, `offset`, `total`, `max_offset`.
- `tabpanel_scroll({n})` scrolls by `n` rows (positive down, negative up). With `{absolute: v:true}` the argument becomes the new offset instead of a delta. The offset is clamped to the valid range; returns true when it actually changes.