### PR TITLE
Make_cyg_ming.mak: support system libXpm layout (include/X11/)

### DIFF
--- a/src/Make_cyg_ming.mak
+++ b/src/Make_cyg_ming.mak
@@ -744,7 +744,7 @@ XPM = no
  endif
  ifdef XPM
   ifneq ($(XPM),no)
-CFLAGS += -DFEAT_XPM_W32 -I $(XPM)/include -I $(XPM)/../include
+CFLAGS += -DFEAT_XPM_W32 -I $(XPM)/include -I $(XPM)/include/X11 -I $(XPM)/../include
   endif
  endif
 


### PR DESCRIPTION
The bundled libXpm.a under src/xpm/ is a pre-built static library from 2013 and only links against the legacy MSVCRT MinGW runtime. When building with the modern MSYS2 UCRT64 toolchain it fails with `undefined reference to __imp___iob_func`.

```
C:/msys64/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/15.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: xpm/x64/lib/libXpm.a(RdFToI.o):RdFToI.c:(.text+0xf2): undefined reference to `__imp___iob_func'
C:/msys64/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/15.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: xpm/x64/lib/libXpm.a(RdFToI.o):RdFToI.c:(.text+0x12f): undefined reference to `__imp___iob_func'
collect2.exe: error: ld returned 1 exit status
mingw32-make: *** [Make_cyg_ming.mak:1197: gvim.exe] Error 1
```

Pointing `XPM` at a system prefix (e.g. `XPM=c:/msys64/ucrt64`) lets the build pick up `mingw-w64-ucrt-x86_64-xpm-nox` instead, but `xpm.h` and `simx.h` live under `include/X11/` in that layout so the existing `-I` flags don't find them.

This adds `-I $(XPM)/include/X11` to the XPM CFLAGS. The bundled layout still works (the new `-I` just points at a non-existent directory in that case).