### PR TITLE
VisualNOS not used when Wayland selection ownership lost

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -6141,7 +6141,8 @@ TitleBarNC	Title bar for inactive Gui's window.
 Visual		Visual mode selection.
 							*hl-VisualNOS*
 VisualNOS	Visual mode selection when vim is "Not Owning the Selection".
-		Only X11 Gui's |gui-x11| and |xterm-clipboard| supports this.
+		Only X11 Gui's |gui-x11|, |xterm-clipboard| and |wayland-selections|
+		supports this.
 							*hl-WarningMsg*
 WarningMsg	Warning messages.
 							*hl-WildMenu*

--- a/src/drawline.c
+++ b/src/drawline.c
@@ -1465,11 +1465,10 @@ win_line(
 		area_highlighting = TRUE;
 		vi_attr = HL_ATTR(HLF_V);
 #if defined(FEAT_CLIPBOARD) && defined(FEAT_X11)
-		if (X_DISPLAY &&
-			((clip_star.available && !clip_star.owned
+		if ((clip_star.available && !clip_star.owned
 						    && clip_isautosel_star())
-			    || (clip_plus.available && !clip_plus.owned
-						    && clip_isautosel_plus())))
+			|| (clip_plus.available && !clip_plus.owned
+						    && clip_isautosel_plus()))
 		    vi_attr = HL_ATTR(HLF_VNC);
 #endif
 	    }

--- a/src/drawline.c
+++ b/src/drawline.c
@@ -1464,7 +1464,7 @@ win_line(
 	    {
 		area_highlighting = TRUE;
 		vi_attr = HL_ATTR(HLF_V);
-#if defined(FEAT_CLIPBOARD) && defined(FEAT_X11)
+#if defined(FEAT_CLIPBOARD) && (defined(FEAT_X11) || defined(FEAT_WAYLAND_CLIPBOARD))
 		if ((clip_star.available && !clip_star.owned
 						    && clip_isautosel_star())
 			|| (clip_plus.available && !clip_plus.owned


### PR DESCRIPTION
Problem: VisualNOS not used when Wayland selection ownership lost (lilydjwg)
Solution: Don't require X_DISPLAY != NULL to use VisualNOS (Shane Harper).

fixes: #19914
related: #19812, #19659