### PR TITLE
patch 9.2.xxx: tags: when jumping to tags, will open URLs

### DIFF
--- a/runtime/doc/tagsrch.txt
+++ b/runtime/doc/tagsrch.txt
@@ -579,6 +579,9 @@ ctags).
 		have an absolute or relative path.  It may contain environment
 		variables and wildcards (although the use of wildcards is
 		doubtful).  It cannot contain a <Tab>.
+								*E1576*
+		Using a remote file via network protocol (e.g. using
+		http://remote/file.txt) is not allowed.
 {tagaddress}	The Ex command that positions the cursor on the tag.  It can
 		be any Ex command, although restrictions apply (see
 		|tag-security|).  Posix only allows line numbers and search

--- a/src/errors.h
+++ b/src/errors.h
@@ -3809,3 +3809,5 @@ EXTERN char e_gethostbyname_in_channel_listen[]
 EXTERN char e_cannot_create_pipes[]
 	INIT(= N_("E1575: Cannot create pipes"));
 #endif
+EXTERN char e_tag_file_entry_must_not_be_url[]
+	INIT(= N_("E1576: Tag file entry must not be a URL"));

--- a/src/tag.c
+++ b/src/tag.c
@@ -4135,6 +4135,15 @@ expand_tag_fname(char_u *fname, char_u *tag_fname, int expand)
     char_u	*expanded_fname = NULL;
     expand_T	xpc;
 
+    // Refuse to follow URLs from tag files.  Tag entries are expected
+    // to reference local source files; a URL would otherwise be passed
+    // to netrw and trigger a network request.
+    if (path_with_url(fname))
+    {
+       emsg(_(e_tag_file_entry_must_not_be_url));
+       return NULL;
+    }
+
     /*
      * Expand file name (for environment variables) when needed.
      * Disallow backticks, they could execute arbitrary shell

--- a/src/testdir/test_tagjump.vim
+++ b/src/testdir/test_tagjump.vim
@@ -1715,4 +1715,15 @@ func Test_tag_backtick_filename_not_expanded()
   bwipe!
 endfunc
 
+func Test_tagjump_refuse_url()
+  call writefile([
+        \ "XTagURL\thttp://127.0.0.1:1/$XTAG_SECRET/file.c\t/^int main"
+        \ ], 'Xtags', 'D')
+  let save_tags = &tags
+  set tags=Xtags
+
+  call assert_fails('tag XTagURL', 'E1576:')
+  let &tags = save_tags
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  tags: when jumping to tags, will open URLs
          (Srinivas Piskala Ganesh Babu)
Solution: Disallow trying to open remote files.

Supported by AI