### PR TITLE
patch 9.2.xxxx: redraw_listener_add function does not check secure flag

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -1,4 +1,4 @@
-*builtin.txt*	For Vim version 9.2.  Last change: 2026 Apr 21
+*builtin.txt*	For Vim version 9.2.  Last change: 2026 Apr 25
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -6863,6 +6863,8 @@ listener_add({callback} [, {buf} [, {unbuffered}]])	*listener_add()*
 		second argument: >
 			GetBuffer()->listener_add(callback)
 <
+		This function is not available in the |sandbox|.
+
 		Return type: |Number|
 
 
@@ -6877,6 +6879,8 @@ listener_flush([{buf}])					*listener_flush()*
 		Can also be used as a |method|: >
 			GetBuffer()->listener_flush()
 <
+		This function is not available in the |sandbox|.
+
 		Return type: void
 
 
@@ -6888,6 +6892,8 @@ listener_remove({id})					*listener_remove()*
 		Can also be used as a |method|: >
 			GetListenerId()->listener_remove()
 <
+		This function is not available in the |sandbox|.
+
 		Return type: |Number|
 
 
@@ -8867,6 +8873,8 @@ redraw_listener_add({opts})				*redraw_listener_add()*
 		Can also be used as a |method|: >
 			GetOpts()->redraw_listener_add()
 <
+		This function is not available in the |sandbox|.
+
 		Return type: |Number|
 
 

--- a/runtime/doc/tabpage.txt
+++ b/runtime/doc/tabpage.txt
@@ -1,4 +1,4 @@
-*tabpage.txt*	For Vim version 9.2.  Last change: 2026 Apr 21
+*tabpage.txt*	For Vim version 9.2.  Last change: 2026 Apr 25
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -484,15 +484,15 @@ groups: |hl-TabPanel| |hl-TabPanelSel| |hl-TabPanelFill|
 
 SCROLLING IN THE TABPANEL:				*tabpanel-scroll*
 
-When the total height of the tab list exceeds the visible screen height, the
-tabpanel by default displays the "page" that contains the current tab and
-offers no way to view tabs outside that page.
+When the total height of the tab page list exceeds the visible screen height,
+the tabpanel by default displays the "page" that contains the current tab page
+and offers no way to view tab pages outside that page.
 
 To make the tabpanel scrollable, add "scroll" to 'tabpanelopt': >
 	:set tabpanelopt+=scroll
 
 With "scroll" enabled, mouse wheel events over the tabpanel area scroll the
-tab list up or down.  The scroll step follows the 'mousescroll' setting.
+tab page list up or down.  The scroll step follows the 'mousescroll' setting.
 Wheel events inside the tabpanel area are consumed by the tabpanel and do not
 trigger |<ScrollWheelUp>| or |<ScrollWheelDown>| mappings.
 

--- a/runtime/doc/version9.txt
+++ b/runtime/doc/version9.txt
@@ -1,4 +1,4 @@
-*version9.txt*	For Vim version 9.2.  Last change: 2026 Apr 21
+*version9.txt*	For Vim version 9.2.  Last change: 2026 Apr 25
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -52616,9 +52616,8 @@ Other ~
 - Allow mouse clickable regions in the 'statusline', 'tabline' and the
   'tabpanel' using the |stl-%[FuncName]| atom.
 - Enable reflow support in the |:terminal|.
-- Added "scroll" and "scrollbar" sub-options to 'tabpanelopt' so the
-  tabpanel can scroll when the tab list exceeds the visible screen
-  height.
+- Added "scroll" and "scrollbar" sub-options to 'tabpanelopt' so the tabpanel
+  can scroll when the tab page list exceeds the visible screen height.
 
 Platform specific ~
 -----------------

--- a/src/drawscreen.c
+++ b/src/drawscreen.c
@@ -3506,6 +3506,9 @@ f_redraw_listener_add(typval_T *argvars, typval_T *rettv)
     bool		got_one = false;
     static int		id;
 
+    if (check_secure())
+	return;
+
     if (redraw_cb_in_progress)
     {
 	emsg(_(e_cannot_add_redraw_listener_in_listener_callback));

--- a/src/testdir/test_listener.vim
+++ b/src/testdir/test_listener.vim
@@ -801,4 +801,15 @@ func Test_listener_blockwise_paste()
   bwipe!
 endfunc
 
+func Test_listener_add_in_sandbox()
+  call assert_fails(
+    \ 'sandbox call redraw_listener_add({"on_start": function("tr")})',
+    \ 'E48:')
+  call assert_fails(
+    \ 'sandbox call listener_add({"on_start": function("tr")})',
+    \ 'E48:')
+  call assert_fails('sandbox call listener_flush()', 'E48:')
+  call assert_fails('sandbox call listener_remove(1)', 'E48:')
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  redraw_listener_add function does not check secure flag
          (Srinivas Piskala Ganesh Babu)
Solution: Call check_secure(). Add tests and update documenation also
          for the change from v9.2.0317