### PR TITLE
Apply pumopt opacity to wildmenu pum

### DIFF
--- a/src/cmdexpand.c
+++ b/src/cmdexpand.c
@@ -436,7 +436,7 @@ cmdline_pum_create(
     void
 cmdline_pum_display(void)
 {
-    if (!pum_redraw_in_same_position())
+    if (p_po > 0 && p_po < 100 && !pum_redraw_in_same_position())
 	pum_call_update_screen();
     pum_display(compl_match_array, compl_match_arraysize, compl_selected);
 }

--- a/src/cmdexpand.c
+++ b/src/cmdexpand.c
@@ -436,6 +436,8 @@ cmdline_pum_create(
     void
 cmdline_pum_display(void)
 {
+    if (!pum_redraw_in_same_position())
+	pum_call_update_screen();
     pum_display(compl_match_array, compl_match_arraysize, compl_selected);
 }
 

--- a/src/popupmenu.c
+++ b/src/popupmenu.c
@@ -1617,8 +1617,12 @@ pum_visible(void)
     static int
 pum_in_same_position(void)
 {
+    int	    row = (State & MODE_CMDLINE)
+			? cmdline_row
+			: curwin->w_wrow + W_WINROW(curwin);
+
     return pum_window != curwin
-	    || (pum_win_row == curwin->w_wrow + W_WINROW(curwin)
+	    || (pum_win_row == row
 		&& pum_win_height == curwin->w_height
 		&& pum_win_col == curwin->w_wincol
 		&& pum_win_width == curwin->w_width);


### PR DESCRIPTION
Call pum_call_update_screen() in cmdline_pum_display() so that the opacity setting in 'pumopt' takes effect for the popup menu shown when 'wildoptions' contains "pum". Other 'pumopt' suboptions (height/width/border/shadow/margin) already apply via the shared pum_display() path; only opacity required this extra hook.

Follow-up commit fixes a flicker the first commit exposed: pum_in_same_position() compared pum_win_row against the cursor's screen row, which never matches for cmdline pum (whose pum_win_row is cmdline_row). pum_may_redraw() therefore always took the undisplay+display path, freeing the saved opacity background each cycle and producing a solid-then-blended flicker on every screen update. Compare against cmdline_row in MODE_CMDLINE so the cmdline pum is recognized as in the same position and the cached background survives.

No regression test for the flicker: it only shows up when something keeps triggering update_screen (autocmds, async callbacks, etc.) in a live session, and in the test harness the screen stabilizes before the alternation can be observed.