### PR TITLE
runtime(help): fix wrong check for existing HelpComplete function

### DIFF
--- a/runtime/ftplugin/help.vim
+++ b/runtime/ftplugin/help.vim
@@ -24,7 +24,7 @@ if has("conceal")
   setlocal cole=2 cocu=nc
 endif
 
-if !exists('HelpComplete')
+if !exists('*HelpComplete')
   func HelpComplete(findstart, base)
     if a:findstart
       let colnr = col('.') - 1 " Get the column number before the cursor


### PR DESCRIPTION
To check for an existing HelpComplete function, exists('*HelpComplete')
should be used, as exists('HelpComplete') still returns 0 after sourcing
the ftplugin.
