### PR TITLE
test: stabilize Test_error_callback_terminal on macOS

### DIFF
--- a/src/testdir/test_channel.vim
+++ b/src/testdir/test_channel.vim
@@ -2922,11 +2922,11 @@ func Test_error_callback_terminal()
   call assert_equal('RAW', dict.err_mode)
   call assert_equal('pipe', dict.err_io)
   call term_sendkeys(buf, "XXXX\<cr>")
-  call term_wait(buf)
+  " term_wait() does not wait for the err_io 'pipe' callback to fire, so use
+  " WaitForAssert() to poll until sh has written the error message.
+  call WaitForAssert({-> assert_match('sh:.*XXXX:.*not found', g:error)}, 5000)
   call term_sendkeys(buf, "exit\<cr>")
-  call term_wait(buf)
-  call assert_match('XXX.*exit', g:out)
-  call assert_match('sh:.*XXXX:.*not found', g:error)
+  call WaitForAssert({-> assert_match('XXX.*exit', g:out)}, 5000)
 
   delfunc s:Out
   delfunc s:Err


### PR DESCRIPTION
`Test_error_callback_terminal()` flakes on macOS because `term_wait()` only waits for terminal screen updates and does not guarantee that the `err_io: 'pipe'` callback has fired. The `assert_match()` against `g:error` then runs before sh has written `sh: XXXX: not found` to the stderr pipe and fails with `Pattern '...' does not match ''`.

Replace `term_wait()` + `assert_match()` with `WaitForAssert()` so each assertion polls until the callback delivers the expected output, and defer sending `exit` until the stderr message has been seen so the write isn't lost to the exit race.

This is currently blocking unrelated PRs from passing macOS CI, e.g. https://github.com/vim/vim/actions/runs/24954898306/job/73071340924?pr=20042