### PR TITLE
runtime(typst): Improve ftplugin

### DIFF
--- a/.github/MAINTAINERS
+++ b/.github/MAINTAINERS
@@ -706,7 +706,7 @@ runtime/syntax/tt2html.vim				@petdance
 runtime/syntax/tt2js.vim				@petdance
 runtime/syntax/typescript.vim				@HerringtonDarkholme @rhysd
 runtime/syntax/typescriptreact.vim			@HerringtonDarkholme @rhysd
-runtime/syntax/typst.vim				@gpanders
+runtime/syntax/typst.vim				@habamax
 runtime/syntax/shared/typescriptcommon.vim		@HerringtonDarkholme @rhysd
 runtime/syntax/unison.vim				@chuwy
 runtime/syntax/vdf.vim					@ObserverOfTime

--- a/.github/MAINTAINERS
+++ b/.github/MAINTAINERS
@@ -350,6 +350,7 @@ runtime/ftplugin/tt2html.vim				@petdance
 runtime/ftplugin/twig.vim				@ribru17
 runtime/ftplugin/typescript.vim				@dkearns
 runtime/ftplugin/typescriptreact.vim			@dkearns
+runtime/ftplugin/typst.vim				@habamax
 runtime/ftplugin/uc.vim					@ribru17
 runtime/ftplugin/unison.vim				@chuwy
 runtime/ftplugin/v.vim					@ribru17
@@ -726,7 +727,7 @@ runtime/syntax/tt2html.vim				@petdance
 runtime/syntax/tt2js.vim				@petdance
 runtime/syntax/typescript.vim				@HerringtonDarkholme @rhysd
 runtime/syntax/typescriptreact.vim			@HerringtonDarkholme @rhysd
-runtime/syntax/typst.vim				@gpanders
+runtime/syntax/typst.vim				@habamax
 runtime/syntax/shared/typescriptcommon.vim		@HerringtonDarkholme @rhysd
 runtime/syntax/unison.vim				@chuwy
 runtime/syntax/vdf.vim					@ObserverOfTime

--- a/runtime/autoload/typst.vim
+++ b/runtime/autoload/typst.vim
@@ -1,79 +1,79 @@
-" Language:    Typst
+" Language:             Typst
+" Maintainer:           Maxim Kim <habamax@gmail.com>
 " Previous Maintainer:  Luca Saccarola <github.e41mv@aleeas.com>
-" Maintainer: This runtime file is looking for a new maintainer.
-" Last Change: 2025 Aug 05
-" Based on:    https://github.com/kaarmu/typst.vim
+" Last Change:          2026 Jun 29
+" Based on the plugin at https://github.com/kaarmu/typst.vim
 
 function! typst#indentexpr() abort
-    let l:lnum = v:lnum
-    let s:sw = shiftwidth()
+  let l:lnum = v:lnum
+  let s:sw = shiftwidth()
 
-    let [l:plnum, l:pline] = s:get_prev_nonblank(l:lnum - 1)
-    if l:plnum == 0 | return 0 | endif
+  let [l:plnum, l:pline] = s:get_prev_nonblank(l:lnum - 1)
+  if l:plnum == 0 | return 0 | endif
 
-    let l:line = getline(l:lnum)
-    let l:ind = indent(l:plnum)
+  let l:line = getline(l:lnum)
+  let l:ind = indent(l:plnum)
 
-    let l:synname = synIDattr(synID(l:lnum, 1, 1), 'name')
+  let l:synname = synIDattr(synID(l:lnum, 1, 1), 'name')
 
-    " Use last indent for block comments
-    if l:synname == 'typstCommentBlock'
-        return l:ind
-    " do not change the indents of bullet lists
-    elseif l:synname == 'typstMarkupBulletList'
-        return indent(a:lnum)
-    endif
-
-    if l:pline =~ '\v[{[(]\s*$'
-        let l:ind += s:sw
-    endif
-
-    if l:line =~ '\v^\s*[}\])]'
-        let l:ind -= s:sw
-    endif
-
+  " Use last indent for block comments
+  if l:synname == 'typstCommentBlock'
     return l:ind
+  " do not change the indents of bullet lists
+  elseif l:synname == 'typstMarkupBulletList'
+    return indent(a:lnum)
+  endif
+
+  if l:pline =~ '\v[{[(]\s*$'
+    let l:ind += s:sw
+  endif
+
+  if l:line =~ '\v^\s*[}\])]'
+    let l:ind -= s:sw
+  endif
+
+  return l:ind
 endfunction
 
-function typst#foldexpr()
-    let line = getline(v:lnum)
+function! typst#foldexpr()
+  let line = getline(v:lnum)
 
-    " Whenever the user wants to fold nested headers under the parent
-    let nested = get(g:, "typst_foldnested", 1)
+  " Whenever the user wants to fold nested headers under the parent
+  let nested = get(g:, "typst_foldnested", 1)
 
-    " Regular headers
-    let depth = match(line, '\(^=\+\)\@<=\( .*$\)\@=')
+  " Regular headers
+  let depth = match(line, '\(^=\+\)\@<=\( .*$\)\@=')
 
-    " Do not fold nested regular headers
-    if depth > 1 && !nested
-        let depth = 1
+  " Do not fold nested regular headers
+  if depth > 1 && !nested
+    let depth = 1
+  endif
+
+  if depth > 0
+    " check syntax, it should be typstMarkupHeading
+    let syncode = synstack(v:lnum, 1)
+    if len(syncode) > 0 && synIDattr(syncode[0], 'name') ==# 'typstMarkupHeading'
+      return ">" .. depth
     endif
+  endif
 
-    if depth > 0
-        " check syntax, it should be typstMarkupHeading
-        let syncode = synstack(v:lnum, 1)
-        if len(syncode) > 0 && synIDattr(syncode[0], 'name') ==# 'typstMarkupHeading'
-            return ">" . depth
-        endif
-    endif
-
-    return "="
+  return "="
 endfunction
 
 " Gets the previous non-blank line that is not a comment.
 function! s:get_prev_nonblank(lnum) abort
-    let l:lnum = prevnonblank(a:lnum)
+  let l:lnum = prevnonblank(a:lnum)
+  let l:line = getline(l:lnum)
+
+  while l:lnum > 0 && l:line =~ '^\s*//'
+    let l:lnum = prevnonblank(l:lnum - 1)
     let l:line = getline(l:lnum)
+  endwhile
 
-    while l:lnum > 0 && l:line =~ '^\s*//'
-        let l:lnum = prevnonblank(l:lnum - 1)
-        let l:line = getline(l:lnum)
-    endwhile
-
-    return [l:lnum, s:remove_comments(l:line)]
+  return [l:lnum, s:remove_comments(l:line)]
 endfunction
 
 " Removes comments from the given line.
 function! s:remove_comments(line) abort
-    return substitute(a:line, '\s*//.*', '', '')
+  return substitute(a:line, '\s*//.*', '', '')
 endfunction

--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -1057,6 +1057,13 @@ Currently no other formats are recognized.
 
 TYPST							*ft-typst-plugin*
 
+						   *g:typst_recommended_style*
+By default, the Typst filetype plugin enables the following options: >
+	setlocal expandtab shiftwidth=2 softtabstop=2
+
+To disable this, set the following variable: >
+	let g:typst_recommended_style = 0
+<
 							*g:typst_conceal*
 When |TRUE| the Typst filetype plugin will set the 'conceallevel' option to 2.
 

--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -1134,6 +1134,13 @@ Currently no other formats are recognized.
 
 TYPST							*ft-typst-plugin*
 
+						   *g:typst_recommended_style*
+By default, the Typst filetype plugin enables the following options: >
+	setlocal expandtab shiftwidth=2 softtabstop=2
+
+To disable this, set the following variable: >
+	let g:typst_recommended_style = 0
+<
 							*g:typst_conceal*
 When |TRUE| the Typst filetype plugin will set the 'conceallevel' option to 2.
 

--- a/runtime/ftplugin/typst.vim
+++ b/runtime/ftplugin/typst.vim
@@ -3,10 +3,10 @@
 " Previous Maintainer:  Gregory Anders
 "                       Luca Saccarola <github.e41mv@aleeas.com>
 " Maintainer:  This runtime file is looking for a new maintainer.
-" Last Change: 2025 Aug 05
+" Last Change: 2026 Apr 26
 " Based on:    https://github.com/kaarmu/typst.vim
 
-if exists('b:did_ftplugin')
+if exists("b:did_ftplugin")
   finish
 endif
 let b:did_ftplugin = 1
@@ -20,20 +20,37 @@ setlocal formatlistpat=^\\s*\\d\\+[\\]:.)}\\t\ ]\\s*
 setlocal formatlistpat+=\\\|^\\s*[-+/\]\\s\\+
 setlocal suffixesadd=.typ
 
-let b:undo_ftplugin = 'setl cms< com< fo< flp< sua<'
+let b:undo_ftplugin = "setl cms< com< fo< flp< sua<"
 
-if get(g:, 'typst_conceal', 0)
+if get(g:, "typst_conceal", 0)
   setlocal conceallevel=2
-  let b:undo_ftplugin .= ' cole<'
+  let b:undo_ftplugin ..= " cole<"
 endif
 
-if has("folding") && get(g:, 'typst_folding', 0)
-    setlocal foldexpr=typst#foldexpr()
-    setlocal foldmethod=expr
-    let b:undo_ftplugin .= "|setl foldexpr< foldmethod<"
+if get(g:, "typst_recommended_style", 1)
+  setlocal expandtab
+  setlocal softtabstop=2
+  setlocal shiftwidth=2
+  let b:undo_ftplugin ..= " | setl et< sts< sw<"
 endif
 
-if !exists('current_compiler')
+if has("folding") && get(g:, "typst_folding", 0)
+  setlocal foldexpr=typst#foldexpr()
+  setlocal foldmethod=expr
+  let b:undo_ftplugin ..= " | setl foldexpr< foldmethod<"
+endif
+
+if !exists("current_compiler")
   compiler typst
-  let b:undo_ftplugin ..= "| compiler make"
+  let b:undo_ftplugin ..= " | compiler make"
+endif
+
+if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
+  let  b:browsefilter = "Typst Markup file (*.typ)\t*.typ\n"
+  if has("win32")
+    let b:browsefilter ..= "All Files (*.*)\t*\n"
+  else
+    let b:browsefilter ..= "All Files (*)\t*\n"
+  endif
+  let b:undo_ftplugin ..= " | unlet! b:browsefilter"
 endif

--- a/runtime/ftplugin/typst.vim
+++ b/runtime/ftplugin/typst.vim
@@ -1,12 +1,12 @@
 " Vim filetype plugin file
-" Language:    Typst
-" Previous Maintainer:  Gregory Anders
+" Language:             Typst
+" Maintainer:           Maxim Kim <habamax@gmail.com>
+" Previous Maintainers: Gregory Anders
 "                       Luca Saccarola <github.e41mv@aleeas.com>
-" Maintainer:  This runtime file is looking for a new maintainer.
-" Last Change: 2025 Aug 05
-" Based on:    https://github.com/kaarmu/typst.vim
+" Last Change:          2026 Jun 29
+" Based on the ftplugin from https://github.com/kaarmu/typst.vim
 
-if exists('b:did_ftplugin')
+if exists("b:did_ftplugin")
   finish
 endif
 let b:did_ftplugin = 1
@@ -20,20 +20,38 @@ setlocal formatlistpat=^\\s*\\d\\+[\\]:.)}\\t\ ]\\s*
 setlocal formatlistpat+=\\\|^\\s*[-+/\]\\s\\+
 setlocal suffixesadd=.typ
 
-let b:undo_ftplugin = 'setl cms< com< fo< flp< sua<'
+let b:undo_ftplugin = "setl cms< com< fo< flp< sua<"
 
-if get(g:, 'typst_conceal', 0)
+if get(g:, "typst_conceal", 0)
   setlocal conceallevel=2
-  let b:undo_ftplugin .= ' cole<'
+  let b:undo_ftplugin ..= " cole<"
 endif
 
-if has("folding") && get(g:, 'typst_folding', 0)
-    setlocal foldexpr=typst#foldexpr()
-    setlocal foldmethod=expr
-    let b:undo_ftplugin .= "|setl foldexpr< foldmethod<"
+if get(g:, 'typst_recommended_style',
+      \ get(g:, 'filetype_recommended_style', 1))
+  setlocal expandtab
+  setlocal softtabstop=2
+  setlocal shiftwidth=2
+  let b:undo_ftplugin ..= " | setl et< sts< sw<"
 endif
 
-if !exists('current_compiler')
+if has("folding") && get(g:, "typst_folding", 0)
+  setlocal foldexpr=typst#foldexpr()
+  setlocal foldmethod=expr
+  let b:undo_ftplugin ..= " | setl foldexpr< foldmethod<"
+endif
+
+if !exists("current_compiler")
   compiler typst
-  let b:undo_ftplugin ..= "| compiler make"
+  let b:undo_ftplugin ..= " | compiler make"
+endif
+
+if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
+  let  b:browsefilter = "Typst Markup file (*.typ)\t*.typ\n"
+  if has("win32")
+    let b:browsefilter ..= "All Files (*.*)\t*\n"
+  else
+    let b:browsefilter ..= "All Files (*)\t*\n"
+  endif
+  let b:undo_ftplugin ..= " | unlet! b:browsefilter"
 endif

--- a/runtime/indent/typst.vim
+++ b/runtime/indent/typst.vim
@@ -3,18 +3,15 @@
 " Previous Maintainer:  Gregory Anders
 "                       Luca Saccarola <github.e41mv@aleeas.com>
 " Maintainer:  This runtime file is looking for a new maintainer.
-" Last Change: 2025 Aug 05
+" Last Change: 2026 Apr 26
 " Based on:    https://github.com/kaarmu/typst.vim
 
-if exists('b:did_indent')
+if exists("b:did_indent")
   finish
 endif
 let b:did_indent = 1
 
-setlocal expandtab
-setlocal softtabstop=2
-setlocal shiftwidth=2
 setlocal autoindent
 setlocal indentexpr=typst#indentexpr()
 
-let b:undo_indent = 'setl et< sts< sw< ai< inde<'
+let b:undo_indent = "setl ai< inde<"

--- a/runtime/indent/typst.vim
+++ b/runtime/indent/typst.vim
@@ -1,20 +1,17 @@
 " Vim indent file
-" Language:    Typst
+" Language:             Typst
+" Maintainer:           Maxim Kim <habamax@gmail.com>
 " Previous Maintainer:  Gregory Anders
 "                       Luca Saccarola <github.e41mv@aleeas.com>
-" Maintainer:  This runtime file is looking for a new maintainer.
-" Last Change: 2025 Aug 05
-" Based on:    https://github.com/kaarmu/typst.vim
+" Last Change:          2026 Jun 29
+" Based on the indent plugin from https://github.com/kaarmu/typst.vim
 
-if exists('b:did_indent')
+if exists("b:did_indent")
   finish
 endif
 let b:did_indent = 1
 
-setlocal expandtab
-setlocal softtabstop=2
-setlocal shiftwidth=2
 setlocal autoindent
 setlocal indentexpr=typst#indentexpr()
 
-let b:undo_indent = 'setl et< sts< sw< ai< inde<'
+let b:undo_indent = "setl ai< inde<"

--- a/runtime/syntax/typst.vim
+++ b/runtime/syntax/typst.vim
@@ -1,9 +1,8 @@
 " Vim syntax file
-" Previous Maintainer:  Luca Saccarola <github.e41mv@aleeas.com>
-" Maintainer:  This runtime file is looking for a new maintainer.
+" Maintainer:  Maxim Kim <habamax@gmail.com>
 " Language:    Typst
-" Based On:    https://github.com/kaarmu/typst.vim
-" Last Change: 2025 Aug 05
+" Last Change: 2026 Mar 05
+" Based on the syntax file from https://github.com/kaarmu/typst.vim
 
 if exists('b:current_syntax')
     finish
@@ -12,293 +11,276 @@ endif
 let s:cpo_save = &cpo
 set cpo&vim
 
-syntax sync fromstart
 syntax spell toplevel
+syntax sync minlines=300
 
-" Common {{{1
-syntax cluster typstCommon
-    \ contains=@typstComment
-
-" Common > Comment {{{2
 syntax cluster typstComment
-    \ contains=typstCommentBlock,typstCommentLine
+      \ contains=typstCommentBlock,typstCommentLine
 syntax region typstCommentBlock
-    \ start="/\*" end="\*/" keepend
-    \ contains=typstCommentTodo,@Spell
+      \ start="/\*" end="\*/" keepend
+      \ contains=typstCommentTodo,@Spell
 syntax match typstCommentLine
-    \ #//.*#
-    \ contains=typstCommentTodo,@Spell
+      \ #//.*#
+      \ contains=typstCommentTodo,@Spell
 syntax keyword typstCommentTodo
-    \ contained
-    \ TODO FIXME XXX TBD
+      \ contained
+      \ TODO FIXME XXX TBD
 
 
-" Code {{{1
 syntax cluster typstCode
-    \ contains=@typstCommon
-            \ ,@typstCodeKeywords
-            \ ,@typstCodeConstants
-            \ ,@typstCodeIdentifiers
-            \ ,@typstCodeFunctions
-            \ ,@typstCodeParens
+      \ contains=@typstComment
+      \ ,@typstCodeKeywords
+      \ ,@typstCodeConstants
+      \ ,@typstCodeIdentifiers
+      \ ,@typstCodeFunctions
+      \ ,@typstCodeParens
 
-" Code > Keywords {{{2
 syntax cluster typstCodeKeywords
-    \ contains=typstCodeConditional
-            \ ,typstCodeRepeat
-            \ ,typstCodeKeyword
-            \ ,typstCodeStatement
+      \ contains=typstCodeConditional
+      \ ,typstCodeRepeat
+      \ ,typstCodeKeyword
+      \ ,typstCodeStatement
 syntax keyword typstCodeConditional
-    \ contained
-    \ if else
+      \ contained
+      \ if else
 syntax keyword typstCodeRepeat
-    \ contained
-    \ while for
+      \ contained
+      \ while for
 syntax keyword typstCodeKeyword
-    \ contained
-    \ not in and or return
+      \ contained
+      \ not in and or return
 syntax region typstCodeStatement
-    \ contained
-    \ matchgroup=typstCodeStatementWord start=/\v(let|set|import|include)>/
-    \ matchgroup=Noise end=/\v%(;|$)/
-    \ contains=@typstCode
+      \ contained
+      \ matchgroup=typstCodeStatementWord start=/\v(let|set|import|include)>/
+      \ matchgroup=NONE end=/\v%(;|$)/
+      \ contains=@typstCode
 syntax region typstCodeStatement
-    \ contained
-    \ matchgroup=typstCodeStatementWord start=/show/
-    \ matchgroup=Noise end=/\v%(:|$)/ keepend
-    \ contains=@typstCode
-    \ skipwhite nextgroup=@typstCode,typstCodeShowRocket
+      \ contained
+      \ matchgroup=typstCodeStatementWord start=/show/
+      \ matchgroup=NONE end=/\v%(:|$)/ keepend
+      \ contains=@typstCode
+      \ skipwhite nextgroup=@typstCode,typstCodeShowRocket
 syntax match typstCodeShowRocket
-    \ contained
-    \ /.*=>/
-    \ contains=@typstCode
-    \ skipwhite nextgroup=@typstCode
+      \ contained
+      \ /.*=>/
+      \ contains=@typstCode
+      \ skipwhite nextgroup=@typstCode
 
-" Code > Identifiers {{{2
 syntax cluster typstCodeIdentifiers
-    \ contains=typstCodeIdentifier
-            \ ,typstCodeFieldAccess
+      \ contains=typstCodeIdentifier
+      \ ,typstCodeFieldAccess
 syntax match typstCodeIdentifier
-    \ contained
-    \ /\v\w\k*>(<%(let|set|show|import|include))@<![\.\[\(]@!/
+      \ contained
+      \ /\v\w\k*>(<%(let|set|show|import|include))@<![\.\[\(]@!/
 syntax match typstCodeFieldAccess
-    \ contained
-    \ /\v\w\k*>(<%(let|set|show|import|include))@<!\.[\[\(]@!/
-    \ nextgroup=typstCodeFieldAccess,typstCodeFunction
+      \ contained
+      \ /\v\w\k*>(<%(let|set|show|import|include))@<!\.[\[\(]@!/
+      \ nextgroup=typstCodeFieldAccess,typstCodeFunction
 
-" Code > Functions {{{2
 syntax cluster typstCodeFunctions
-    \ contains=typstCodeFunction
+      \ contains=typstCodeFunction
 syntax match typstCodeFunction
-    \ contained
-    \ /\v\w\k*>(<%(let|set|show|import|include))@<![\(\[]@=/
-    \ nextgroup=typstCodeFunctionArgument
+      \ contained
+      \ /\v\w\k*>(<%(let|set|show|import|include))@<![\(\[]@=/
+      \ nextgroup=typstCodeFunctionArgument
 syntax match typstCodeFunctionArgument
-    \ contained
-    \ /\v%(%(\(.{-}\)|\[.{-}\]|\{.{-}\}))*/ transparent
-    \ contains=@typstCode
+      \ contained
+      \ /\v%(%(\(.{-}\)|\[.{-}\]|\{.{-}\}))*/ transparent
+      \ contains=@typstCode
 
-" Code > Constants {{{2
 syntax cluster typstCodeConstants
-    \ contains=typstCodeConstant
-            \ ,typstCodeNumberInteger
-            \ ,typstCodeNumberFloat
-            \ ,typstCodeNumberLength
-            \ ,typstCodeNumberAngle
-            \ ,typstCodeNumberRatio
-            \ ,typstCodeNumberFraction
-            \ ,typstCodeString
-            \ ,typstCodeLabel
+      \ contains=typstCodeConstant
+      \ ,typstCodeNumberInteger
+      \ ,typstCodeNumberFloat
+      \ ,typstCodeNumberLength
+      \ ,typstCodeNumberAngle
+      \ ,typstCodeNumberRatio
+      \ ,typstCodeNumberFraction
+      \ ,typstCodeString
+      \ ,typstCodeLabel
 syntax match typstCodeConstant
-    \ contained
-    \ /\v<%(none|auto|true|false)-@!>/
+      \ contained
+      \ /\v<%(none|auto|true|false)-@!>/
 syntax match typstCodeNumberInteger
-    \ contained
-    \ /\v<\d+>/
+      \ contained
+      \ /\v<\d+>/
 
 syntax match typstCodeNumberFloat
-    \ contained
-    \ /\v<\d+\.\d*>/
+      \ contained
+      \ /\v<\d+\.\d*>/
 syntax match typstCodeNumberLength
-    \ contained
-    \ /\v<\d+(\.\d*)?(pt|mm|cm|in|em)>/
+      \ contained
+      \ /\v<\d+(\.\d*)?(pt|mm|cm|in|em)>/
 syntax match typstCodeNumberAngle
-    \ contained
-    \ /\v<\d+(\.\d*)?(deg|rad)>/
+      \ contained
+      \ /\v<\d+(\.\d*)?(deg|rad)>/
 syntax match typstCodeNumberRatio
-    \ contained
-    \ /\v<\d+(\.\d*)?\%/
+      \ contained
+      \ /\v<\d+(\.\d*)?\%/
 syntax match typstCodeNumberFraction
-    \ contained
-    \ /\v<\d+(\.\d*)?fr>/
+      \ contained
+      \ /\v<\d+(\.\d*)?fr>/
 syntax region typstCodeString
-    \ contained
-    \ start=/"/ skip=/\v\\\\|\\"/ end=/"/
-    \ contains=@Spell
+      \ contained
+      \ start=/"/ skip=/\v\\\\|\\"/ end=/"/
+      \ contains=@Spell
 syntax match typstCodeLabel
-    \ contained
-    \ /\v\<\K%(\k*-*)*\>/
+      \ contained
+      \ /\v\<\K%(\k*-*)*\>/
 
-" Code > Parens {{{2
 syntax cluster typstCodeParens
-    \ contains=typstCodeParen
-            \ ,typstCodeBrace
-            \ ,typstCodeBracket
-            \ ,typstCodeDollar
-            \ ,typstMarkupRawInline
-            \ ,typstMarkupRawBlock
+      \ contains=typstCodeParen
+      \ ,typstCodeBrace
+      \ ,typstCodeBracket
+      \ ,typstCodeDollar
+      \ ,typstMarkupRawInline
+      \ ,typstMarkupRawBlock
 syntax region typstCodeParen
-    \ contained
-    \ matchgroup=Noise start=/(/ end=/)/
-    \ contains=@typstCode
+      \ contained
+      \ matchgroup=NONE start=/(/ end=/)/
+      \ contains=@typstCode
 syntax region typstCodeBrace
-    \ contained
-    \ matchgroup=Noise start=/{/ end=/}/
-    \ contains=@typstCode
+      \ contained
+      \ matchgroup=NONE start=/{/ end=/}/
+      \ contains=@typstCode
 syntax region typstCodeBracket
-    \ contained
-    \ matchgroup=Noise start=/\[/ end=/\]/
-    \ contains=@typstMarkup
+      \ contained
+      \ matchgroup=NONE start=/\[/ end=/\]/
+      \ contains=@typstMarkup
 syntax region typstCodeDollar
-    \ contained
-    \ matchgroup=Number start=/\\\@<!\$/ end=/\\\@<!\$/
-    \ contains=@typstMath
+      \ contained
+      \ matchgroup=Number start=/\\\@<!\$/ end=/\\\@<!\$/
+      \ contains=@typstMath
 
 
-" Hashtag {{{1
 syntax cluster typstHashtag
-    \ contains=@typstHashtagKeywords
-            \ ,@typstHashtagConstants
-            \ ,@typstHashtagIdentifiers
-            \ ,@typstHashtagFunctions
-            \ ,@typstHashtagParens
+      \ contains=@typstHashtagKeywords
+      \ ,@typstHashtagConstants
+      \ ,@typstHashtagIdentifiers
+      \ ,@typstHashtagFunctions
+      \ ,@typstHashtagParens
 
-" Hashtag > Keywords {{{2
 syntax cluster typstHashtagKeywords
-    \ contains=typstHashtagConditional
-            \ ,typstHashtagRepeat
-            \ ,typstHashtagKeywords
-            \ ,typstHashtagStatement
+      \ contains=typstHashtagConditional
+      \ ,typstHashtagRepeat
+      \ ,typstHashtagKeywords
+      \ ,typstHashtagStatement
 
-" syntax match typstHashtagControlFlowError
-"     \ /\v#%(if|while|for)>-@!.{-}$\_.{-}%(\{|\[|\()/
 syntax match typstHashtagControlFlow
-    \ /\v#%(if|while|for)>.{-}\ze%(\{|\[|\()/
-    \ contains=typstHashtagConditional,typstHashtagRepeat
-    \ nextgroup=@typstCode
+      \ /\v#%(if|while|for)>.{-}\ze%(\{|\[|\()/
+      \ contains=typstHashtagConditional,typstHashtagRepeat
+      \ nextgroup=@typstCode
 syntax region typstHashtagConditional
-    \ contained
-    \ start=/\v#if>/ end=/\v\ze(\{|\[)/
-    \ contains=@typstCode
+      \ contained
+      \ start=/\v#if>/ end=/\v\ze(\{|\[)/
+      \ contains=@typstCode
 syntax region typstHashtagRepeat
-    \ contained
-    \ start=/\v#(while|for)>/ end=/\v\ze(\{|\[)/
-    \ contains=@typstCode
+      \ contained
+      \ start=/\v#(while|for)>/ end=/\v\ze(\{|\[)/
+      \ contains=@typstCode
 syntax match typstHashtagKeyword
-    \ /\v#(return)>/
-    \ skipwhite nextgroup=@typstCode
+      \ /\v#(return)>/
+      \ skipwhite nextgroup=@typstCode
 syntax region typstHashtagStatement
-    \ matchgroup=typstHashtagStatementWord start=/\v#(let|set|import|include)>/
-    \ matchgroup=Noise end=/\v%(;|$)/
-    \ contains=@typstCode
+      \ matchgroup=typstHashtagStatementWord start=/\v#(let|set|import|include)>/
+      \ matchgroup=NONE end=/\v%(;|$)/
+      \ contains=@typstCode
 syntax region typstHashtagStatement
-    \ matchgroup=typstHashtagStatementWord start=/#show/
-    \ matchgroup=Noise end=/\v%(:|$)/ keepend
-    \ contains=@typstCode
-    \ skipwhite nextgroup=@typstCode,typstCodeShowRocket
+      \ matchgroup=typstHashtagStatementWord start=/#show/
+      \ matchgroup=NONE end=/\v%(:|$)/ keepend
+      \ contains=@typstCode
+      \ skipwhite nextgroup=@typstCode,typstCodeShowRocket
 
-" Hashtag > Constants {{{2
 syntax cluster typstHashtagConstants
-    \ contains=typstHashtagConstant
+      \ contains=typstHashtagConstant
 syntax match typstHashtagConstant
-    \ /\v#(none|auto|true|false)>/
+      \ /\v#(none|auto|true|false)>/
 
-" Hashtag > Identifiers {{{2
 syntax cluster typstHashtagIdentifiers
-    \ contains=typstHashtagIdentifier
-            \ ,typstHashtagFieldAccess
+      \ contains=typstHashtagIdentifier
+      \ ,typstHashtagFieldAccess
 syntax match typstHashtagIdentifier
-    \ /\v#\w\k*>(<%(let|set|show|import|include))@<![\.\[\(]@!/
+      \ /\v#\w\k*>(<%(let|set|show|import|include))@<![\.\[\(]@!/
 syntax match typstHashtagFieldAccess
-    \ /\v#\w\k*>(<%(let|set|show|import|include))@<!\.[\[\(]@!/
-    \ nextgroup=typstCodeFieldAccess,typstCodeFunction
+      \ /\v#\w\k*>(<%(let|set|show|import|include))@<!\.[\[\(]@!/
+      \ nextgroup=typstCodeFieldAccess,typstCodeFunction
 
-" Hashtag > Functions {{{2
 syntax cluster typstHashtagFunctions
-    \ contains=typstHashtagFunction
+      \ contains=typstHashtagFunction
 syntax match typstHashtagFunction
-    \ /\v#\w\k*>(<%(let|set|show|import|include))@<![\(\[]@=/
-    \ nextgroup=typstCodeFunctionArgument
+      \ /\v#\w\k*>(<%(let|set|show|import|include))@<![\(\[]@=/
+      \ nextgroup=typstCodeFunctionArgument
 
-" Hashtag > Parens {{{2
 syntax cluster typstHashtagParens
-    \ contains=typstHashtagParen
-            \ ,typstHashtagBrace
-            \ ,typstHashtagBracket
-            \ ,typstHashtagDollar
+      \ contains=typstHashtagParen
+      \ ,typstHashtagBrace
+      \ ,typstHashtagBracket
+      \ ,typstHashtagDollar
 syntax region typstHashtagParen
-    \ matchgroup=Noise start=/#(/ end=/)/
-    \ contains=@typstCode
+      \ start=/#(/ end=/)/
+      \ contains=@typstCode
 syntax region typstHashtagBrace
-    \ matchgroup=Noise start=/#{/ end=/}/
-    \ contains=@typstCode
+      \ start=/#{/ end=/}/
+      \ contains=@typstCode
 syntax region typstHashtagBracket
-    \ matchgroup=Noise start=/#\[/ end=/\]/
-    \ contains=@typstMarkup
+      \ start=/#\[/ end=/\]/
+      \ contains=@typstMarkup
 syntax region typstHashtagDollar
-    \ matchgroup=Noise start=/#\$/ end=/\\\@<!\$/
-    \ contains=@typstMath
+      \ start=/#\$/ end=/\\\@<!\$/
+      \ contains=@typstMath
 
 
-" Markup {{{1
 syntax cluster typstMarkup
-    \ contains=@typstCommon
-            \ ,@Spell
-            \ ,@typstHashtag
-            \ ,@typstMarkupText
-            \ ,@typstMarkupParens
+      \ contains=@typstComment
+      \ ,@Spell
+      \ ,@typstHashtag
+      \ ,@typstMarkupText
+      \ ,@typstMarkupParens
 
-" Markup > Text {{{2
 syntax cluster typstMarkupText
-    \ contains=typstMarkupRawInline
-            \ ,typstMarkupRawBlock
-            \ ,typstMarkupLabel
-            \ ,typstMarkupReference
-            \ ,typstMarkupUrl
-            \ ,typstMarkupHeading
-            \ ,typstMarkupBulletList
-            \ ,typstMarkupEnumList
-            \ ,typstMarkupTermList
-            \ ,typstMarkupBold
-            \ ,typstMarkupItalic
-            \ ,typstMarkupLinebreak
-            \ ,typstMarkupNonbreakingSpace
-            \ ,typstMarkupShy
-            \ ,typstMarkupDash
-            \ ,typstMarkupEllipsis
+      \ contains=typstMarkupRawInline
+      \ ,typstMarkupRawBlock
+      \ ,typstMarkupLabel
+      \ ,typstMarkupReference
+      \ ,typstMarkupUrl
+      \ ,typstMarkupHeading
+      \ ,typstMarkupBulletList
+      \ ,typstMarkupEnumList
+      \ ,typstMarkupTermList
+      \ ,typstMarkupBold
+      \ ,typstMarkupItalic
+      \ ,typstMarkupLinebreak
+      \ ,typstMarkupNonbreakingSpace
+      \ ,typstMarkupShy
+      \ ,typstMarkupDash
+      \ ,typstMarkupEllipsis
 
-" Raw Text
-syntax match typstMarkupRawInline
-    \ /`.\{-}`/
+syntax region typstMarkupRawInline
+      \ matchgroup=typstMarkupRawInlineDelimiter
+      \ start=+\%(^\|[[:space:]-:/]\)\@1<=`[^`]\@1=+
+      \ skip=/\\`/
+      \ end=+`+
+
 syntax region typstMarkupRawBlock
-    \ matchgroup=Macro start=/```\w*/
-    \ matchgroup=Macro end=/```/ keepend
+      \ matchgroup=Macro start=/```\w*/
+      \ matchgroup=Macro end=/```/ keepend
 syntax region typstMarkupCodeBlockTypst
-    \ matchgroup=Macro start=/```typst/
-    \ matchgroup=Macro end=/```/ contains=@typstCode keepend
-    \ concealends
+      \ matchgroup=Macro start=/```typst/
+      \ matchgroup=Macro end=/```/ contains=@typstCode keepend
+      \ concealends
 
 for s:name in get(g:, 'typst_embedded_languages', [])
     let s:include = ['syntax include'
                 \   ,'@typstEmbedded_'..s:name
                 \   ,'syntax/'..s:name..'.vim']
     let s:rule = ['syn region'
-                \,s:name
-                \,'matchgroup=Macro'
-                \,'start=/```'..s:name..'\>/ end=/```/' 
-                \,'contains=@typstEmbedded_'..s:name 
-                \,'keepend'
-                \,'concealends']
+                \ ,"typstMarkupRawBlock_"..s:name
+                \ ,'matchgroup=Macro'
+                \ ,'start=/```'..s:name..'\>/ end=/```/' 
+                \ ,'contains=@typstEmbedded_'..s:name 
+                \ ,'keepend'
+                \ ,'concealends']
+
     execute 'silent! ' .. join(s:include, ' ')
     unlet! b:current_syntax
     execute join(s:rule, ' ')
@@ -306,174 +288,152 @@ endfor
 
 " Label & Reference
 syntax match typstMarkupLabel
-    \ /\v\<\K%(\k*-*)*\>/
+      \ /\v\<\K%(\k*-*)*\>/
 syntax match typstMarkupReference
-    \ /\v\@\K%(\k*-*)*/
+      \ /\v\@\K%(\k*-*)*/
 
-" URL
 syntax match typstMarkupUrl
-    \ #\v\w+://\S*#
+      \ #\v\w+://\S*#
 
-" Heading
-syntax match typstMarkupHeading
-    \ /^\s*\zs=\{1,6}\s.*$/
-    \ contains=typstMarkupLabel,@Spell
+syntax region typstMarkupHeading
+      \ matchgroup=typstMarkupHeadingDelimiter
+      \ start=/^\s*\zs=\{1,6}\s/
+      \ end=/$/ keepend oneline
+      \ contains=typstMarkupLabel,@Spell
 
-" Lists
 syntax match typstMarkupBulletList
-    \ /\v^\s*-\s+/
+      \ /\v^\s*-\s+/
 syntax match typstMarkupEnumList
-    \ /\v^\s*(\+|\d+\.)\s+/
+      \ /\v^\s*(\+|\d+\.)\s+/
 syntax region typstMarkupTermList
-    \ oneline start=/\v^\s*\/\s/ end=/:/
-    \ contains=@typstMarkup
+      \ matchgroup=typstMarkupTermListDelimiter
+      \ start=/\v^\s*\/\s/
+      \ skip=/\\:/
+      \ end=/:/
+      \ oneline contains=@typstMarkup
 
-" Bold & Italic
-syntax match typstMarkupBold
-    \ /\v(\w|\\)@1<!\*\S@=.{-}(\n.{-1,})*\S@1<=\\@1<!\*/
-    \ contains=typstMarkupBoldRegion
-syntax match typstMarkupItalic
-    \ /\v(\w|\\)@1<!_\S@=.{-}(\n.{-1,})*\S@1<=\\@1<!_/
-    \ contains=typstMarkupItalicRegion
-syntax match typstMarkupBoldItalic
-    \ contained
-    \ /\v(\w|\\)@1<![_\*]\S@=.{-}(\n.{-1,})*\S@1<=\\@1<!\2/
-    \ contains=typstMarkupBoldRegion,typstMarkupItalicRegion
-syntax region typstMarkupBoldRegion
-    \ contained
-    \ transparent matchgroup=typstMarkupBold
-    \ start=/\(^\|[^0-9a-zA-Z]\)\@<=\*/ end=/\*\($\|[^0-9a-zA-Z]\)\@=/
-    \ concealends contains=typstMarkupBoldItalic,typstMarkupLabel,@Spell
-syntax region typstMarkupItalicRegion
-    \ contained
-    \ transparent matchgroup=typstMarkupItalic
-    \ start=/\(^\|[^0-9a-zA-Z]\)\@<=_/ end=/_\($\|[^0-9a-zA-Z]\)\@=/
-    \ concealends contains=typstMarkupBoldItalic,typstMarkupLabel,@Spell
+syn region typstMarkupBold
+      \ start=+\%(^\|[[:space:]-:/]\)\@1<=\*[^*]\@1=+
+      \ skip=+\\\*+
+      \ end=+\*\($\|[[:space:]-.,:;!?"'/\\>)\]}]\)\@1=+
+      \ concealends contains=typstMarkupLabel,@Spell
+syn region typstMarkupItalic
+      \ start=+\%(^\|[[:space:]-:/]\)\@1<=_[^_]\@1=+
+      \ skip=+\\_+
+      \ end=+_\($\|[[:space:]-.,:;!?"'/\\>)\]}]\)\@1=+
+      \ concealends contains=typstMarkupLabel,@Spell
+syn region typstMarkupBoldItalic
+      \ start=+\%(^\|[[:space:]-:/]\)\@1<=\*_[^*_]\@1=+
+      \ skip=+\\\*_+
+      \ end=+_\*\($\|[[:space:]-.,:;!?"'/\\>)\]}]\)\@1=+
+      \ concealends contains=typstMarkupLabel,@Spell
+syn region typstMarkupBoldItalic
+      \ start=+\%(^\|[[:space:]-:/]\)\@1<=_\*[^*_]\@1=+
+      \ skip=+\\_\*+
+      \ end=+\*_\($\|[[:space:]-.,:;!?"'/\\>)\]}]\)\@1=+
+      \ concealends contains=typstMarkupLabel,@Spell
 
-" Linebreak & Special Whitespace
 syntax match typstMarkupLinebreak
-    \ /\\\\/
+      \ /\%([^\\]\|^\)\@1<=\\\%(\s\|$\)/
 syntax match typstMarkupNonbreakingSpace
-    \ /\~/
+      \ /\~/
 syntax match typstMarkupShy
-    \ /-?/
+      \ /-?/
 
-" Special Symbols
 syntax match typstMarkupDash
-    \ /-\{2,3}/
+      \ /-\{2,3}/
 syntax match typstMarkupEllipsis
-    \ /\.\.\./
+      \ /\.\.\./
 
-" Markup > Parens {{{2
 syntax cluster typstMarkupParens
-    \ contains=typstMarkupBracket
-            \ ,typstMarkupDollar
+      \ contains=typstMarkupBracket
+      \ ,typstMarkupMath
 syntax region typstMarkupBracket
-    \ matchgroup=Noise start=/\[/ end=/\]/
-    \ contains=@typstMarkup
-syntax region typstMarkupDollar
-    \ matchgroup=Special start=/\\\@<!\$/ end=/\\\@<!\$/
-    \ contains=@typstMath
+      \ start=/\[/ end=/\]/
+      \ contains=@typstMarkup
+syntax region typstMarkupMath
+      \ matchgroup=typstMarkupDollar start=/\\\@<!\$/ end=/\\\@<!\$/
+      \ contains=@typstMath
 
 
-" Math {{{1
+" Math
 syntax cluster typstMath
-    \ contains=@typstCommon
-            \ ,@typstHashtag
-            \ ,typstMathIdentifier
-            \ ,typstMathFunction
-            \ ,typstMathNumber
-            \ ,typstMathSymbol
-            \ ,typstMathBold
-            \ ,typstMathScripts
-            \ ,typstMathQuote
+      \ contains=@typstComment
+      \ ,@typstHashtag
+      \ ,typstMathIdentifier
+      \ ,typstMathFunction
+      \ ,typstMathNumber
+      \ ,typstMathSymbol
+      \ ,typstMathBold
+      \ ,typstMathScripts
+      \ ,typstMathQuote
 
 syntax match typstMathIdentifier
-    \ /\a\a\+/
-    \ contained
+      \ /\a\a\+/
+      \ contained
 syntax match typstMathFunction
-    \ /\a\a\+\ze(/
-    \ contained
+      \ /\a\a\+\ze(/
+      \ contained
 syntax match typstMathNumber
-    \ /\<\d\+\>/
-    \ contained
+      \ /\<\d\+\>/
+      \ contained
 syntax region typstMathQuote
-    \ matchgroup=String start=/"/ skip=/\\"/ end=/"/
-    \ contained
+      \ matchgroup=String start=/"/ skip=/\\"/ end=/"/
+      \ contained
 
-" Math > Linked groups {{{2
-highlight default link typstMathIdentifier          Identifier
-highlight default link typstMathFunction            Statement
-highlight default link typstMathNumber              Number
-highlight default link typstMathSymbol              Statement
-
-" Highlighting {{{1
-
-" Highlighting > Linked groups {{{2
-highlight default link typstCommentBlock            Comment
-highlight default link typstCommentLine             Comment
-highlight default link typstCommentTodo             Todo
-highlight default link typstCodeConditional         Conditional
-highlight default link typstCodeRepeat              Repeat
-highlight default link typstCodeKeyword             Keyword
-highlight default link typstCodeConstant            Constant
-highlight default link typstCodeNumberInteger       Number
-highlight default link typstCodeNumberFloat         Number
-highlight default link typstCodeNumberLength        Number
-highlight default link typstCodeNumberAngle         Number
-highlight default link typstCodeNumberRatio         Number
-highlight default link typstCodeNumberFraction      Number
-highlight default link typstCodeString              String
-highlight default link typstCodeLabel               Structure
-highlight default link typstCodeStatementWord       Statement
-highlight default link typstCodeIdentifier          Identifier
-highlight default link typstCodeFieldAccess         Identifier
-highlight default link typstCodeFunction            Function
-highlight default link typstCodeParen               Noise
-highlight default link typstCodeBrace               Noise
-highlight default link typstCodeBracket             Noise
-highlight default link typstCodeDollar              Noise
-" highlight default link typstHashtagControlFlowError Error
-highlight default link typstHashtagConditional      Conditional
-highlight default link typstHashtagRepeat           Repeat
-highlight default link typstHashtagKeyword          Keyword
-highlight default link typstHashtagConstant         Constant
-highlight default link typstHashtagStatementWord    Statement
-highlight default link typstHashtagIdentifier       Identifier
-highlight default link typstHashtagFieldAccess      Identifier
-highlight default link typstHashtagFunction         Function
-highlight default link typstHashtagParen            Noise
-highlight default link typstHashtagBrace            Noise
-highlight default link typstHashtagBracket          Noise
-highlight default link typstHashtagDollar           Noise
-highlight default link typstMarkupRawInline         Macro
-highlight default link typstMarkupRawBlock          Macro
-highlight default link typstMarkupLabel             Structure
-highlight default link typstMarkupReference         Structure
-highlight default link typstMarkupBulletList        Structure
-" highlight default link typstMarkupItalicError       Error
-" highlight default link typstMarkupBoldError         Error
-highlight default link typstMarkupEnumList          Structure
-highlight default link typstMarkupLinebreak         Structure
-highlight default link typstMarkupNonbreakingSpace  Structure
-highlight default link typstMarkupShy               Structure
-highlight default link typstMarkupDash              Structure
-highlight default link typstMarkupEllipsis          Structure
-highlight default link typstMarkupTermList          Structure
-highlight default link typstMarkupDollar            Noise
-
-" Highlighting > Custom Styling {{{2
-highlight! Conceal ctermfg=NONE ctermbg=NONE guifg=NONE guibg=NONE
-
-highlight default typstMarkupHeading                    term=underline,bold     cterm=underline,bold    gui=underline,bold
-highlight default typstMarkupUrl                        term=underline          cterm=underline         gui=underline
-highlight default typstMarkupBold                       term=bold               cterm=bold              gui=bold
-highlight default typstMarkupItalic                     term=italic             cterm=italic            gui=italic
-highlight default typstMarkupBoldItalic                 term=bold,italic        cterm=bold,italic       gui=bold,italic
+hi def link typstMathIdentifier Identifier
+hi def link typstMathFunction Statement
+hi def link typstMathNumber Number
+hi def link typstMathSymbol Statement
+hi def link typstCommentBlock Comment
+hi def link typstCommentLine Comment
+hi def link typstCommentTodo Todo
+hi def link typstCodeConditional Conditional
+hi def link typstCodeRepeat Repeat
+hi def link typstCodeKeyword Keyword
+hi def link typstCodeConstant Constant
+hi def link typstCodeNumberInteger Number
+hi def link typstCodeNumberFloat Number
+hi def link typstCodeNumberLength Number
+hi def link typstCodeNumberAngle Number
+hi def link typstCodeNumberRatio Number
+hi def link typstCodeNumberFraction Number
+hi def link typstCodeString String
+hi def link typstCodeLabel Structure
+hi def link typstCodeStatementWord Statement
+hi def link typstCodeIdentifier Identifier
+hi def link typstCodeFieldAccess Identifier
+hi def link typstCodeFunction Function
+hi def link typstHashtagConditional Conditional
+hi def link typstHashtagRepeat Repeat
+hi def link typstHashtagKeyword Keyword
+hi def link typstHashtagConstant Constant
+hi def link typstHashtagStatementWord Statement
+hi def link typstHashtagIdentifier Identifier
+hi def link typstHashtagFieldAccess Identifier
+hi def link typstHashtagFunction Function
+hi def link typstMarkupRawInlineDelimiter Special
+hi def link typstMarkupRawBlock Special
+hi def link typstMarkupDollar Special
+hi def link typstMarkupLabel PreProc
+hi def link typstMarkupReference Special
+hi def link typstMarkupBulletList PreProc
+hi def link typstMarkupEnumList PreProc
+hi def link typstMarkupLinebreak Special
+hi def link typstMarkupNonbreakingSpace Special
+hi def link typstMarkupShy Special
+hi def link typstMarkupDash Special
+hi def link typstMarkupEllipsis Special
+hi def link typstMarkupTermList Bold
+hi def link typstMarkupTermListDelimiter PreProc
+hi def link typstMarkupHeading Title
+hi def link typstMarkupHeadingDelimiter Type
+hi def link typstMarkupUrl Underlined
+hi def link typstMarkupBold Bold
+hi def link typstMarkupItalic Italic
+hi def link typstMarkupBoldItalic BoldItalic
 
 let b:current_syntax = 'typst'
 
 let &cpo = s:cpo_save
 unlet s:cpo_save
-
-" }}}1

--- a/runtime/syntax/typst.vim
+++ b/runtime/syntax/typst.vim
@@ -1,9 +1,8 @@
 " Vim syntax file
-" Previous Maintainer:  Luca Saccarola <github.e41mv@aleeas.com>
-" Maintainer:  This runtime file is looking for a new maintainer.
+" Maintainer:  Maxim Kim <habamax@gmail.com>
 " Language:    Typst
-" Based On:    https://github.com/kaarmu/typst.vim
-" Last Change: 2025 Aug 05
+" Last Change: 2026 Jun 30
+" Based on the syntax file from https://github.com/kaarmu/typst.vim
 
 if exists('b:current_syntax')
     finish
@@ -12,293 +11,175 @@ endif
 let s:cpo_save = &cpo
 set cpo&vim
 
-syntax sync fromstart
 syntax spell toplevel
+syntax sync minlines=300
+syntax iskeyword @,48-57,192-255,_,-
 
-" Common {{{1
-syntax cluster typstCommon
-    \ contains=@typstComment
+syntax cluster typstExpr
+      \ contains=typstExprCodeBlock
+      \ ,typstExprFunc
+      \ ,typstExprContentBlock
+      \ ,typstExprBraces
+      \ ,typstExprColon
+      \ ,typstExprDot
+      \ ,typstExprCommand
+      \ ,@typstExprConstants
+      \ ,typstExprVar
+      \ ,typstExprOpSym
+      \ ,typstExprOp
+      \ ,@typstComment
 
-" Common > Comment {{{2
-syntax cluster typstComment
-    \ contains=typstCommentBlock,typstCommentLine
-syntax region typstCommentBlock
-    \ start="/\*" end="\*/" keepend
-    \ contains=typstCommentTodo,@Spell
-syntax match typstCommentLine
-    \ #//.*#
-    \ contains=typstCommentTodo,@Spell
-syntax keyword typstCommentTodo
-    \ contained
-    \ TODO FIXME XXX TBD
+syntax match typstExprStart /#/ nextgroup=@typstExpr,typstExprBareVar
+syntax match typstExprDot /\./
+      \ contained
+      \ nextgroup=@typstExpr
 
+syntax match typstExprColon /:/
+      \ skipwhite
+      \ contained
+      \ nextgroup=@typstExpr
 
-" Code {{{1
-syntax cluster typstCode
-    \ contains=@typstCommon
-            \ ,@typstCodeKeywords
-            \ ,@typstCodeConstants
-            \ ,@typstCodeIdentifiers
-            \ ,@typstCodeFunctions
-            \ ,@typstCodeParens
+syntax match typstExprVar /\k\+/
+      \ skipwhite
+      \ contained
+      \ nextgroup=typstExprOp,typstExprOpSym,@typstExpr
 
-" Code > Keywords {{{2
-syntax cluster typstCodeKeywords
-    \ contains=typstCodeConditional
-            \ ,typstCodeRepeat
-            \ ,typstCodeKeyword
-            \ ,typstCodeStatement
-syntax keyword typstCodeConditional
-    \ contained
-    \ if else
-syntax keyword typstCodeRepeat
-    \ contained
-    \ while for
-syntax keyword typstCodeKeyword
-    \ contained
-    \ not in and or return
-syntax region typstCodeStatement
-    \ contained
-    \ matchgroup=typstCodeStatementWord start=/\v(let|set|import|include)>/
-    \ matchgroup=Noise end=/\v%(;|$)/
-    \ contains=@typstCode
-syntax region typstCodeStatement
-    \ contained
-    \ matchgroup=typstCodeStatementWord start=/show/
-    \ matchgroup=Noise end=/\v%(:|$)/ keepend
-    \ contains=@typstCode
-    \ skipwhite nextgroup=@typstCode,typstCodeShowRocket
-syntax match typstCodeShowRocket
-    \ contained
-    \ /.*=>/
-    \ contains=@typstCode
-    \ skipwhite nextgroup=@typstCode
+syntax region typstExprBraces
+      \ skipwhite
+      \ contained
+      \ contains=@typstExpr,typstMarkupMath
+      \ nextgroup=typstExprOp,typstExprOpSym,@typstExpr
+      \ start=/(/
+      \ end=/)/
 
-" Code > Identifiers {{{2
-syntax cluster typstCodeIdentifiers
-    \ contains=typstCodeIdentifier
-            \ ,typstCodeFieldAccess
-syntax match typstCodeIdentifier
-    \ contained
-    \ /\v\w\k*>(<%(let|set|show|import|include))@<![\.\[\(]@!/
-syntax match typstCodeFieldAccess
-    \ contained
-    \ /\v\w\k*>(<%(let|set|show|import|include))@<!\.[\[\(]@!/
-    \ nextgroup=typstCodeFieldAccess,typstCodeFunction
+syntax match typstExprOpSym /\%(=[=>]\)\|\%([-+*/<>!=]=\)\|[<=>\-+*/]/
+      \ skipwhite
+      \ contained
+      \ nextgroup=typstExprFunc,@typstExpr
 
-" Code > Functions {{{2
-syntax cluster typstCodeFunctions
-    \ contains=typstCodeFunction
-syntax match typstCodeFunction
-    \ contained
-    \ /\v\w\k*>(<%(let|set|show|import|include))@<![\(\[]@=/
-    \ nextgroup=typstCodeFunctionArgument
-syntax match typstCodeFunctionArgument
-    \ contained
-    \ /\v%(%(\(.{-}\)|\[.{-}\]|\{.{-}\}))*/ transparent
-    \ contains=@typstCode
+syntax match typstExprOp /in\>\|and\>\|or\>\|\%(not\%(\s\+in\>\)\?\)/
+      \ skipwhite skipempty
+      \ contained
+      \ nextgroup=@typstExpr
 
-" Code > Constants {{{2
-syntax cluster typstCodeConstants
-    \ contains=typstCodeConstant
-            \ ,typstCodeNumberInteger
-            \ ,typstCodeNumberFloat
-            \ ,typstCodeNumberLength
-            \ ,typstCodeNumberAngle
-            \ ,typstCodeNumberRatio
-            \ ,typstCodeNumberFraction
-            \ ,typstCodeString
-            \ ,typstCodeLabel
-syntax match typstCodeConstant
-    \ contained
-    \ /\v<%(none|auto|true|false)-@!>/
-syntax match typstCodeNumberInteger
-    \ contained
-    \ /\v<\d+>/
+syntax match typstExprBareVar /\k\+/ skipwhite contained
 
-syntax match typstCodeNumberFloat
-    \ contained
-    \ /\v<\d+\.\d*>/
-syntax match typstCodeNumberLength
-    \ contained
-    \ /\v<\d+(\.\d*)?(pt|mm|cm|in|em)>/
-syntax match typstCodeNumberAngle
-    \ contained
-    \ /\v<\d+(\.\d*)?(deg|rad)>/
-syntax match typstCodeNumberRatio
-    \ contained
-    \ /\v<\d+(\.\d*)?\%/
-syntax match typstCodeNumberFraction
-    \ contained
-    \ /\v<\d+(\.\d*)?fr>/
-syntax region typstCodeString
-    \ contained
-    \ start=/"/ skip=/\v\\\\|\\"/ end=/"/
-    \ contains=@Spell
-syntax match typstCodeLabel
-    \ contained
-    \ /\v\<\K%(\k*-*)*\>/
+syntax match typstExprCommand
+      \ /let\|set\|while\|for\|if\|else\|show\|import\|include\|context\|return/
+      \ skipwhite skipempty
+      \ contained
+      \ nextgroup=@typstExpr
 
-" Code > Parens {{{2
-syntax cluster typstCodeParens
-    \ contains=typstCodeParen
-            \ ,typstCodeBrace
-            \ ,typstCodeBracket
-            \ ,typstCodeDollar
-            \ ,typstMarkupRawInline
-            \ ,typstMarkupRawBlock
-syntax region typstCodeParen
-    \ contained
-    \ matchgroup=Noise start=/(/ end=/)/
-    \ contains=@typstCode
-syntax region typstCodeBrace
-    \ contained
-    \ matchgroup=Noise start=/{/ end=/}/
-    \ contains=@typstCode
-syntax region typstCodeBracket
-    \ contained
-    \ matchgroup=Noise start=/\[/ end=/\]/
-    \ contains=@typstMarkup
-syntax region typstCodeDollar
-    \ contained
-    \ matchgroup=Number start=/\\\@<!\$/ end=/\\\@<!\$/
-    \ contains=@typstMath
+syntax region typstExprCodeBlock
+      \ skipwhite
+      \ contained
+      \ contains=@typstExpr
+      \ start=/{/
+      \ end=/}/
+
+syntax region typstExprContentBlock
+      \ skipwhite
+      \ contained
+      \ extend
+      \ contains=@typstMarkup,typstExprStart,typstMarkupMath
+      \ nextgroup=@typstExpr
+      \ matchgroup=NONE
+      \ start=/\[/
+      \ end=/\]/
+
+syntax match typstExprFunc
+      \ skipwhite
+      \ contained
+      \ contains=typstExprDot
+      \ nextgroup=typstExprBraces,typstExprContentBlock,@typstExpr
+      \ /\k\+\%(\.\k\+\)*[[(]\@=/
+
+syntax cluster typstExprConstants
+      \ contains=typstExprConstant
+      \ ,typstExprNumber
+      \ ,typstExprString
+      \ ,typstExprLabel
+
+syntax match typstExprConstant
+      \ contained
+      \ /\v<%(none|auto|true|false)-@!>/
+
+syntax region typstExprString
+      \ contained
+      \ start=/"/ skip=/\v\\\\|\\"/ end=/"/
+      \ contains=@Spell
+syntax match typstExprNumber
+      \ skipwhite
+      \ contained
+      \ nextgroup=typstExprNumberType,typstExprOp,typstExprOpSym,@typstExpr
+      \ /\v<\d+%(\.\d+)?/
+syntax match typstExprNumberType
+      \ contained
+      \ nextgroup=typstExprOp,typstExprOpSym,@typstExpr
+      \ /\v%(pt|mm|cm|in|em|deg|rad|\%|fr)>?/
+
+syntax match typstExprLabel
+      \ contained
+      \ /\v\<\K%(\k*-*)*\>/
+
+syntax region typstMarkupDollar
+      \ matchgroup=typstMarkupDollar start=/\\\@1<!\$/ end=/\\\@1<!\$/
+      \ contains=@typstMath
 
 
-" Hashtag {{{1
-syntax cluster typstHashtag
-    \ contains=@typstHashtagKeywords
-            \ ,@typstHashtagConstants
-            \ ,@typstHashtagIdentifiers
-            \ ,@typstHashtagFunctions
-            \ ,@typstHashtagParens
-
-" Hashtag > Keywords {{{2
-syntax cluster typstHashtagKeywords
-    \ contains=typstHashtagConditional
-            \ ,typstHashtagRepeat
-            \ ,typstHashtagKeywords
-            \ ,typstHashtagStatement
-
-" syntax match typstHashtagControlFlowError
-"     \ /\v#%(if|while|for)>-@!.{-}$\_.{-}%(\{|\[|\()/
-syntax match typstHashtagControlFlow
-    \ /\v#%(if|while|for)>.{-}\ze%(\{|\[|\()/
-    \ contains=typstHashtagConditional,typstHashtagRepeat
-    \ nextgroup=@typstCode
-syntax region typstHashtagConditional
-    \ contained
-    \ start=/\v#if>/ end=/\v\ze(\{|\[)/
-    \ contains=@typstCode
-syntax region typstHashtagRepeat
-    \ contained
-    \ start=/\v#(while|for)>/ end=/\v\ze(\{|\[)/
-    \ contains=@typstCode
-syntax match typstHashtagKeyword
-    \ /\v#(return)>/
-    \ skipwhite nextgroup=@typstCode
-syntax region typstHashtagStatement
-    \ matchgroup=typstHashtagStatementWord start=/\v#(let|set|import|include)>/
-    \ matchgroup=Noise end=/\v%(;|$)/
-    \ contains=@typstCode
-syntax region typstHashtagStatement
-    \ matchgroup=typstHashtagStatementWord start=/#show/
-    \ matchgroup=Noise end=/\v%(:|$)/ keepend
-    \ contains=@typstCode
-    \ skipwhite nextgroup=@typstCode,typstCodeShowRocket
-
-" Hashtag > Constants {{{2
-syntax cluster typstHashtagConstants
-    \ contains=typstHashtagConstant
-syntax match typstHashtagConstant
-    \ /\v#(none|auto|true|false)>/
-
-" Hashtag > Identifiers {{{2
-syntax cluster typstHashtagIdentifiers
-    \ contains=typstHashtagIdentifier
-            \ ,typstHashtagFieldAccess
-syntax match typstHashtagIdentifier
-    \ /\v#\w\k*>(<%(let|set|show|import|include))@<![\.\[\(]@!/
-syntax match typstHashtagFieldAccess
-    \ /\v#\w\k*>(<%(let|set|show|import|include))@<!\.[\[\(]@!/
-    \ nextgroup=typstCodeFieldAccess,typstCodeFunction
-
-" Hashtag > Functions {{{2
-syntax cluster typstHashtagFunctions
-    \ contains=typstHashtagFunction
-syntax match typstHashtagFunction
-    \ /\v#\w\k*>(<%(let|set|show|import|include))@<![\(\[]@=/
-    \ nextgroup=typstCodeFunctionArgument
-
-" Hashtag > Parens {{{2
-syntax cluster typstHashtagParens
-    \ contains=typstHashtagParen
-            \ ,typstHashtagBrace
-            \ ,typstHashtagBracket
-            \ ,typstHashtagDollar
-syntax region typstHashtagParen
-    \ matchgroup=Noise start=/#(/ end=/)/
-    \ contains=@typstCode
-syntax region typstHashtagBrace
-    \ matchgroup=Noise start=/#{/ end=/}/
-    \ contains=@typstCode
-syntax region typstHashtagBracket
-    \ matchgroup=Noise start=/#\[/ end=/\]/
-    \ contains=@typstMarkup
-syntax region typstHashtagDollar
-    \ matchgroup=Noise start=/#\$/ end=/\\\@<!\$/
-    \ contains=@typstMath
-
-
-" Markup {{{1
 syntax cluster typstMarkup
-    \ contains=@typstCommon
-            \ ,@Spell
-            \ ,@typstHashtag
-            \ ,@typstMarkupText
-            \ ,@typstMarkupParens
+      \ contains=typstMarkupRawInline
+      \ ,typstMarkupRawBlock
+      \ ,typstMarkupLabel
+      \ ,typstMarkupReference
+      \ ,typstMarkupUrl
+      \ ,typstMarkupHeading
+      \ ,typstMarkupBulletList
+      \ ,typstMarkupEnumList
+      \ ,typstMarkupTermList
+      \ ,typstMarkupBold
+      \ ,typstMarkupItalic
+      \ ,typstMarkupBoldItalic
+      \ ,typstMarkupBackslash
+      \ ,typstMarkupLinebreak
+      \ ,typstMarkupNonbreakingSpace
+      \ ,@typstMarkupDollar
+      \ ,typstMarkupShy
+      \ ,typstMarkupDash
+      \ ,typstMarkupEllipsis
+      \ ,typstMarkupBackslash
+      \ ,typstMarkupEscape
 
-" Markup > Text {{{2
-syntax cluster typstMarkupText
-    \ contains=typstMarkupRawInline
-            \ ,typstMarkupRawBlock
-            \ ,typstMarkupLabel
-            \ ,typstMarkupReference
-            \ ,typstMarkupUrl
-            \ ,typstMarkupHeading
-            \ ,typstMarkupBulletList
-            \ ,typstMarkupEnumList
-            \ ,typstMarkupTermList
-            \ ,typstMarkupBold
-            \ ,typstMarkupItalic
-            \ ,typstMarkupLinebreak
-            \ ,typstMarkupNonbreakingSpace
-            \ ,typstMarkupShy
-            \ ,typstMarkupDash
-            \ ,typstMarkupEllipsis
+syntax region typstMarkupRawInline
+      \ matchgroup=typstMarkupRawDelimiter
+      \ start=+\%(^\|[[:space:]-:/]\)\@1<=`[^`]\@1=+
+      \ skip=/\\`/
+      \ end=+`+
 
-" Raw Text
-syntax match typstMarkupRawInline
-    \ /`.\{-}`/
 syntax region typstMarkupRawBlock
-    \ matchgroup=Macro start=/```\w*/
-    \ matchgroup=Macro end=/```/ keepend
+      \ matchgroup=typstMarkupRawDelimiter
+      \ start=/```\w*/
+      \ end=/```/
+      \ keepend
 syntax region typstMarkupCodeBlockTypst
-    \ matchgroup=Macro start=/```typst/
-    \ matchgroup=Macro end=/```/ contains=@typstCode keepend
-    \ concealends
+      \ matchgroup=typstMarkupRawDelimiter
+      \ start=/```typst/
+      \ end=/```/
+      \ contains=@typstCode
+      \ keepend
 
 for s:name in get(g:, 'typst_embedded_languages', [])
     let s:include = ['syntax include'
                 \   ,'@typstEmbedded_'..s:name
                 \   ,'syntax/'..s:name..'.vim']
     let s:rule = ['syn region'
-                \,s:name
-                \,'matchgroup=Macro'
-                \,'start=/```'..s:name..'\>/ end=/```/' 
-                \,'contains=@typstEmbedded_'..s:name 
-                \,'keepend'
-                \,'concealends']
+                \ ,"typstMarkupRawBlock_"..s:name
+                \ ,'matchgroup=typstMarkupRawDelimiter'
+                \ ,'start=/```'..s:name..'\>/ end=/```/' 
+                \ ,'contains=@typstEmbedded_'..s:name 
+                \ ,'keepend'
+                \ ,'concealends']
+
     execute 'silent! ' .. join(s:include, ' ')
     unlet! b:current_syntax
     execute join(s:rule, ' ')
@@ -306,174 +187,145 @@ endfor
 
 " Label & Reference
 syntax match typstMarkupLabel
-    \ /\v\<\K%(\k*-*)*\>/
+      \ /\v\<\K%(\k*-*)*\>/
 syntax match typstMarkupReference
-    \ /\v\@\K%(\k*-*)*/
+      \ /\v\@\K%(\k*-*)*/
 
-" URL
 syntax match typstMarkupUrl
-    \ #\v\w+://\S*#
+      \ #\v\w+://\S*#
 
-" Heading
-syntax match typstMarkupHeading
-    \ /^\s*\zs=\{1,6}\s.*$/
-    \ contains=typstMarkupLabel,@Spell
+syntax region typstMarkupHeading
+      \ matchgroup=typstMarkupHeadingDelimiter
+      \ start=/^\s*\zs=\{1,6}\s/
+      \ end=/$/ keepend oneline
+      \ contains=typstMarkupLabel,@Spell
 
-" Lists
 syntax match typstMarkupBulletList
-    \ /\v^\s*-\s+/
+      \ /\v^\s*-\s+/
 syntax match typstMarkupEnumList
-    \ /\v^\s*(\+|\d+\.)\s+/
+      \ /\v^\s*(\+|\d+\.)\s+/
 syntax region typstMarkupTermList
-    \ oneline start=/\v^\s*\/\s/ end=/:/
-    \ contains=@typstMarkup
+      \ matchgroup=typstMarkupTermListDelimiter
+      \ start=/\v^\s*\/\s/
+      \ skip=/\\:/
+      \ end=/:/
+      \ oneline contains=@typstMarkup
 
-" Bold & Italic
-syntax match typstMarkupBold
-    \ /\v(\w|\\)@1<!\*\S@=.{-}(\n.{-1,})*\S@1<=\\@1<!\*/
-    \ contains=typstMarkupBoldRegion
-syntax match typstMarkupItalic
-    \ /\v(\w|\\)@1<!_\S@=.{-}(\n.{-1,})*\S@1<=\\@1<!_/
-    \ contains=typstMarkupItalicRegion
-syntax match typstMarkupBoldItalic
-    \ contained
-    \ /\v(\w|\\)@1<![_\*]\S@=.{-}(\n.{-1,})*\S@1<=\\@1<!\2/
-    \ contains=typstMarkupBoldRegion,typstMarkupItalicRegion
-syntax region typstMarkupBoldRegion
-    \ contained
-    \ transparent matchgroup=typstMarkupBold
-    \ start=/\(^\|[^0-9a-zA-Z]\)\@<=\*/ end=/\*\($\|[^0-9a-zA-Z]\)\@=/
-    \ concealends contains=typstMarkupBoldItalic,typstMarkupLabel,@Spell
-syntax region typstMarkupItalicRegion
-    \ contained
-    \ transparent matchgroup=typstMarkupItalic
-    \ start=/\(^\|[^0-9a-zA-Z]\)\@<=_/ end=/_\($\|[^0-9a-zA-Z]\)\@=/
-    \ concealends contains=typstMarkupBoldItalic,typstMarkupLabel,@Spell
+syn region typstMarkupBold
+      \ start=+\%(^\|[\[[:space:]-:/]\)\@1<=\*[^*]\@1=+
+      \ skip=+\\\*+
+      \ end=+\*\($\|[[:space:]-.,:;!?"'/\\>)\]}]\)\@1=+
+      \ concealends contains=typstMarkupLabel,@Spell
+syn region typstMarkupItalic
+      \ start=+\%(^\|[\[[:space:]-:/]\)\@1<=_[^_]\@1=+
+      \ skip=+\\_+
+      \ end=+_\($\|[[:space:]-.,:;!?"'/\\>)\]}]\)\@1=+
+      \ concealends contains=typstMarkupLabel,@Spell
+syn region typstMarkupBoldItalic
+      \ start=+\%(^\|[\[[:space:]-:/]\)\@1<=\*_[^*_]\@1=+
+      \ skip=+\\\*_+
+      \ end=+_\*\($\|[[:space:]-.,:;!?"'/\\>)\]}]\)\@1=+
+      \ concealends contains=typstMarkupLabel,@Spell
+syn region typstMarkupBoldItalic
+      \ start=+\%(^\|[[:space:]-:/]\)\@1<=_\*[^*_]\@1=+
+      \ skip=+\\_\*+
+      \ end=+\*_\($\|[[:space:]-.,:;!?"'/\\>)\]}]\)\@1=+
+      \ concealends contains=typstMarkupLabel,@Spell
 
-" Linebreak & Special Whitespace
-syntax match typstMarkupLinebreak
-    \ /\\\\/
-syntax match typstMarkupNonbreakingSpace
-    \ /\~/
-syntax match typstMarkupShy
-    \ /-?/
+syntax match typstMarkupBackslash /\\\\/
+syntax match typstMarkupLinebreak /\\\%(\s\|$\)/
+syntax match typstMarkupNonbreakingSpace /\~/
+syntax match typstMarkupShy /-?/
+syntax match typstMarkupDash /-\{2,3}/
+syntax match typstMarkupEllipsis /\.\.\./
+syntax match typstMarkupEscape /\\./
 
-" Special Symbols
-syntax match typstMarkupDash
-    \ /-\{2,3}/
-syntax match typstMarkupEllipsis
-    \ /\.\.\./
+syntax region typstMarkupMath
+      \ matchgroup=typstMarkupDollar start=/\\\@1<!\$/ end=/\\\@1<!\$/
+      \ contains=@typstMath
 
-" Markup > Parens {{{2
-syntax cluster typstMarkupParens
-    \ contains=typstMarkupBracket
-            \ ,typstMarkupDollar
-syntax region typstMarkupBracket
-    \ matchgroup=Noise start=/\[/ end=/\]/
-    \ contains=@typstMarkup
-syntax region typstMarkupDollar
-    \ matchgroup=Special start=/\\\@<!\$/ end=/\\\@<!\$/
-    \ contains=@typstMath
-
-
-" Math {{{1
+" Math
 syntax cluster typstMath
-    \ contains=@typstCommon
-            \ ,@typstHashtag
-            \ ,typstMathIdentifier
-            \ ,typstMathFunction
-            \ ,typstMathNumber
-            \ ,typstMathSymbol
-            \ ,typstMathBold
-            \ ,typstMathScripts
-            \ ,typstMathQuote
+      \ contains=@typstHashtag
+      \ ,typstMathIdentifier
+      \ ,typstMathFunction
+      \ ,typstMathNumber
+      \ ,typstMathSymbol
+      \ ,typstMathBold
+      \ ,typstMathScripts
+      \ ,typstMathQuote
+      \ ,@typstComment
 
 syntax match typstMathIdentifier
-    \ /\a\a\+/
-    \ contained
+      \ /\a\a\+/
+      \ contained
 syntax match typstMathFunction
-    \ /\a\a\+\ze(/
-    \ contained
+      \ /\a\a\+\ze(/
+      \ contained
 syntax match typstMathNumber
-    \ /\<\d\+\>/
-    \ contained
+      \ contained
+      \ /\v\d+%(\.\d+)?/
 syntax region typstMathQuote
-    \ matchgroup=String start=/"/ skip=/\\"/ end=/"/
-    \ contained
+      \ matchgroup=String start=/"/ skip=/\\"/ end=/"/
+      \ contained
 
-" Math > Linked groups {{{2
-highlight default link typstMathIdentifier          Identifier
-highlight default link typstMathFunction            Statement
-highlight default link typstMathNumber              Number
-highlight default link typstMathSymbol              Statement
 
-" Highlighting {{{1
+syntax cluster typstComment
+      \ contains=typstCommentBlock,typstCommentLine
+syntax region typstCommentBlock
+      \ start="/\*" end="\*/" keepend
+      \ contains=typstCommentTodo,@Spell
+syntax match typstCommentLine
+      \ #//.*#
+      \ contains=typstCommentTodo,@Spell
+syntax keyword typstCommentTodo
+      \ contained
+      \ TODO FIXME XXX TBD
 
-" Highlighting > Linked groups {{{2
-highlight default link typstCommentBlock            Comment
-highlight default link typstCommentLine             Comment
-highlight default link typstCommentTodo             Todo
-highlight default link typstCodeConditional         Conditional
-highlight default link typstCodeRepeat              Repeat
-highlight default link typstCodeKeyword             Keyword
-highlight default link typstCodeConstant            Constant
-highlight default link typstCodeNumberInteger       Number
-highlight default link typstCodeNumberFloat         Number
-highlight default link typstCodeNumberLength        Number
-highlight default link typstCodeNumberAngle         Number
-highlight default link typstCodeNumberRatio         Number
-highlight default link typstCodeNumberFraction      Number
-highlight default link typstCodeString              String
-highlight default link typstCodeLabel               Structure
-highlight default link typstCodeStatementWord       Statement
-highlight default link typstCodeIdentifier          Identifier
-highlight default link typstCodeFieldAccess         Identifier
-highlight default link typstCodeFunction            Function
-highlight default link typstCodeParen               Noise
-highlight default link typstCodeBrace               Noise
-highlight default link typstCodeBracket             Noise
-highlight default link typstCodeDollar              Noise
-" highlight default link typstHashtagControlFlowError Error
-highlight default link typstHashtagConditional      Conditional
-highlight default link typstHashtagRepeat           Repeat
-highlight default link typstHashtagKeyword          Keyword
-highlight default link typstHashtagConstant         Constant
-highlight default link typstHashtagStatementWord    Statement
-highlight default link typstHashtagIdentifier       Identifier
-highlight default link typstHashtagFieldAccess      Identifier
-highlight default link typstHashtagFunction         Function
-highlight default link typstHashtagParen            Noise
-highlight default link typstHashtagBrace            Noise
-highlight default link typstHashtagBracket          Noise
-highlight default link typstHashtagDollar           Noise
-highlight default link typstMarkupRawInline         Macro
-highlight default link typstMarkupRawBlock          Macro
-highlight default link typstMarkupLabel             Structure
-highlight default link typstMarkupReference         Structure
-highlight default link typstMarkupBulletList        Structure
-" highlight default link typstMarkupItalicError       Error
-" highlight default link typstMarkupBoldError         Error
-highlight default link typstMarkupEnumList          Structure
-highlight default link typstMarkupLinebreak         Structure
-highlight default link typstMarkupNonbreakingSpace  Structure
-highlight default link typstMarkupShy               Structure
-highlight default link typstMarkupDash              Structure
-highlight default link typstMarkupEllipsis          Structure
-highlight default link typstMarkupTermList          Structure
-highlight default link typstMarkupDollar            Noise
+hi def link typstCommentBlock Comment
+hi def link typstCommentLine Comment
+hi def link typstCommentTodo Todo
 
-" Highlighting > Custom Styling {{{2
-highlight! Conceal ctermfg=NONE ctermbg=NONE guifg=NONE guibg=NONE
+hi def link typstMathIdentifier Identifier
+hi def link typstMathFunction Statement
+hi def link typstMathNumber Number
+hi def link typstMathSymbol Statement
 
-highlight default typstMarkupHeading                    term=underline,bold     cterm=underline,bold    gui=underline,bold
-highlight default typstMarkupUrl                        term=underline          cterm=underline         gui=underline
-highlight default typstMarkupBold                       term=bold               cterm=bold              gui=bold
-highlight default typstMarkupItalic                     term=italic             cterm=italic            gui=italic
-highlight default typstMarkupBoldItalic                 term=bold,italic        cterm=bold,italic       gui=bold,italic
+hi def link typstExprStart Special
+hi def link typstExprOp Statement
+hi def link typstExprBareVar Identifier
+hi def link typstExprEmbeddedBareVar Identifier
+hi def link typstExprFunc Function
+hi def link typstExprCommand Statement
+hi def link typstExprConstant Constant
+hi def link typstExprNumber Number
+hi def link typstExprNumberType Constant
+hi def link typstExprString String
+hi def link typstExprLabel Structure
+
+hi def link typstMarkupRawInline PreProc
+hi def link typstMarkupRawDelimiter Special
+hi def link typstMarkupRawBlock PreProc
+hi def link typstMarkupDollar Special
+hi def link typstMarkupLabel PreProc
+hi def link typstMarkupReference Special
+hi def link typstMarkupBulletList PreProc
+hi def link typstMarkupEnumList PreProc
+hi def link typstMarkupLinebreak Special
+hi def link typstMarkupNonbreakingSpace Special
+hi def link typstMarkupShy Special
+hi def link typstMarkupDash Special
+hi def link typstMarkupEllipsis Special
+hi def link typstMarkupTermList Bold
+hi def link typstMarkupTermListDelimiter PreProc
+hi def link typstMarkupHeading Title
+hi def link typstMarkupHeadingDelimiter Type
+hi def link typstMarkupUrl Underlined
+hi def link typstMarkupBold Bold
+hi def link typstMarkupItalic Italic
+hi def link typstMarkupBoldItalic BoldItalic
 
 let b:current_syntax = 'typst'
 
 let &cpo = s:cpo_save
 unlet s:cpo_save
-
-" }}}1


### PR DESCRIPTION
- Move whitespace formatting settings from the indent to the filetype plugin behind a `typst_recommended_style` config option.
- Set browsefilter

Related: #20036

