### PR TITLE
test suite races when run with parallel make

### DIFF
--- a/src/testdir/Makefile
+++ b/src/testdir/Makefile
@@ -2,6 +2,11 @@
 # Makefile to run all tests for Vim
 #
 
+# The old-style tests (*.in) use shared filenames in the working directory
+# (test.ok, test.out, X*, viminfo), so running them in parallel causes races
+# and spurious failures.
+.NOTPARALLEL:
+
 # Use console or GUI.
 VIMPROG = ../vim
 XXDPROG = ../xxd/xxd


### PR DESCRIPTION
Problem:  Running "make test" with -jN causes spurious failures because
          the old-style tests share filenames (test.ok, test.out, X*,
          viminfo) in the working directory.
Solution: Add .NOTPARALLEL to the testdir Makefile to prevent parallel
          execution of tests (Jesse Rosenstock).

Co-authored-by: Gemini