### PR TITLE
channel: add 'blob' mode so callbacks receive binary data as Blob

### DIFF
--- a/runtime/doc/channel.txt
+++ b/runtime/doc/channel.txt
@@ -170,6 +170,7 @@ unreachable on the network.
 	"js"   - Use JS (JavaScript) encoding, more efficient than JSON.
 	"nl"   - Use messages that end in a NL character
 	"raw"  - Use raw messages
+	"blob" - Use raw messages and pass callback data as a |Blob|
 	"lsp"  - Use language server protocol encoding
 	"dap"  - Use debug adapter protocol encoding
 						*channel-callback* *E921*
@@ -189,6 +190,8 @@ unreachable on the network.
 		excluding the NL.
 		When "mode" is "raw" the "msg" argument is the whole message
 		as a string.
+		When "mode" is "blob" the "msg" argument is the whole message
+		as a |Blob|.
 
 		For all callbacks: Use |function()| to bind it to arguments
 		and/or a Dictionary.  Or use the form "dict.function" to bind

--- a/src/channel.c
+++ b/src/channel.c
@@ -1372,8 +1372,7 @@ channel_open_func(typval_T *argvars)
     opt.jo_timeout = 2000;
     if (get_job_options(&argvars[1], &opt,
 	    JO_MODE_ALL + JO_CB_ALL + JO_TIMEOUT_ALL
-		+ (is_unix? 0 : JO_WAITTIME),
-	    0) == FAIL)
+		+ (is_unix? 0 : JO_WAITTIME), 0) == FAIL)
 	goto theend;
     if (opt.jo_timeout < 0)
     {

--- a/src/channel.c
+++ b/src/channel.c
@@ -5868,8 +5868,7 @@ f_ch_setoptions(typval_T *argvars, typval_T *rettv UNUSED)
 	return;
     clear_job_options(&opt);
     if (get_job_options(&argvars[1], &opt,
-			    JO_CB_ALL + JO_TIMEOUT_ALL + JO_MODE_ALL,
-			    0) == OK)
+			    JO_CB_ALL + JO_TIMEOUT_ALL + JO_MODE_ALL, 0) == OK)
 	channel_set_options(channel, &opt);
     free_job_options(&opt);
 }

--- a/src/channel.c
+++ b/src/channel.c
@@ -4634,7 +4634,7 @@ common_channel_read(typval_T *argvars, typval_T *rettv, int raw, int blob)
     if (opt.jo_set & JO_TIMEOUT)
 	timeout = opt.jo_timeout;
 
-    if (blob)
+    if (blob || mode == CH_MODE_BLOB)
     {
 	int	    outlen = 0;
 	char_u  *p = channel_read_block(channel, part,
@@ -4657,8 +4657,7 @@ common_channel_read(typval_T *argvars, typval_T *rettv, int raw, int blob)
 	    vim_free(p);
 	}
     }
-    else if (raw || mode == CH_MODE_RAW || mode == CH_MODE_BLOB
-	    || mode == CH_MODE_NL)
+    else if (raw || mode == CH_MODE_RAW || mode == CH_MODE_NL)
 	rettv->vval.v_string = channel_read_block(channel, part,
 		timeout, raw, NULL);
     else
@@ -5043,7 +5042,7 @@ ch_expr_common(typval_T *argvars, typval_T *rettv, int eval)
     if (ch_mode == CH_MODE_RAW || ch_mode == CH_MODE_BLOB
 	    || ch_mode == CH_MODE_NL)
     {
-	emsg(_(e_cannot_use_evalexpr_sendexpr_with_raw_or_nl_channel));
+	emsg(_(e_cannot_use_evalexpr_sendexpr_with_raw_nl_or_blob_channel));
 	return;
     }
 

--- a/src/channel.c
+++ b/src/channel.c
@@ -1372,7 +1372,8 @@ channel_open_func(typval_T *argvars)
     opt.jo_timeout = 2000;
     if (get_job_options(&argvars[1], &opt,
 	    JO_MODE_ALL + JO_CB_ALL + JO_TIMEOUT_ALL
-		+ (is_unix? 0 : JO_WAITTIME), 0) == FAIL)
+		+ (is_unix? 0 : JO_WAITTIME),
+	    0) == FAIL)
 	goto theend;
     if (opt.jo_timeout < 0)
     {
@@ -1440,7 +1441,8 @@ channel_listen_func(typval_T *argvars)
     opt.jo_mode = CH_MODE_JSON;
     opt.jo_timeout = 2000;
     if (get_job_options(&argvars[1], &opt,
-	    JO_MODE_ALL + JO_CB_ALL + JO_TIMEOUT_ALL, 0) == FAIL)
+	    JO_MODE_ALL + JO_CB_ALL + JO_TIMEOUT_ALL,
+	    0) == FAIL)
 	goto theend;
     if (opt.jo_timeout < 0)
     {
@@ -3213,6 +3215,7 @@ channel_use_json_head(channel_T *channel, ch_part_T part)
 may_invoke_callback(channel_T *channel, ch_part_T part)
 {
     char_u	*msg = NULL;
+    blob_T	*blob = NULL;
     typval_T	*listtv = NULL;
     typval_T	argv[CH_JSON_MAX_ARGS];
     int		seq_nr = -1;
@@ -3224,6 +3227,7 @@ may_invoke_callback(channel_T *channel, ch_part_T part)
     buf_T	*buffer = NULL;
     char_u	*p;
     int		called_otc;		// one time callbackup
+    int		raw_len = 0;
 
     if (channel->ch_nb_close_cb != NULL)
 	// this channel is handled elsewhere (netbeans)
@@ -3384,15 +3388,42 @@ may_invoke_callback(channel_T *channel, ch_part_T part)
 	{
 	    // For a raw channel we don't know where the message ends, just
 	    // get everything we have.
-	    // Convert NUL to NL, the internal representation.
-	    msg = channel_get_all(channel, part, NULL);
+	    raw_len = 0;
+	    msg = channel_get_all(channel, part,
+			ch_mode == CH_MODE_BLOB ? &raw_len : NULL);
 	}
 
 	if (msg == NULL)
 	    return FALSE; // out of memory (and avoids Coverity warning)
 
-	argv[1].v_type = VAR_STRING;
-	argv[1].vval.v_string = msg;
+	if (ch_mode == CH_MODE_BLOB)
+	{
+	    blob = blob_alloc();
+	    if (blob == NULL)
+	    {
+		vim_free(msg);
+		return FALSE;
+	    }
+	    if (ga_grow(&blob->bv_ga, raw_len) == FAIL)
+	    {
+		blob_free(blob);
+		vim_free(msg);
+		return FALSE;
+	    }
+	    if (raw_len > 0)
+	    {
+		mch_memmove(blob->bv_ga.ga_data, msg, (size_t)raw_len);
+		blob->bv_ga.ga_len = raw_len;
+	    }
+	    argv[1].v_type = VAR_BLOB;
+	    argv[1].vval.v_blob = blob;
+	    ++blob->bv_refcount;
+	}
+	else
+	{
+	    argv[1].v_type = VAR_STRING;
+	    argv[1].vval.v_string = msg;
+	}
     }
 
     called_otc = FALSE;
@@ -3519,6 +3550,8 @@ may_invoke_callback(channel_T *channel, ch_part_T part)
 
     if (listtv != NULL)
 	free_tv(listtv);
+    if (blob != NULL)
+	blob_unref(blob);
     vim_free(msg);
 
     return TRUE;
@@ -3653,6 +3686,9 @@ channel_part_info(channel_T *channel, dict_T *dict, char *name, ch_part_T part)
 	    break;
 	case CH_MODE_RAW:
 	    STR_LITERAL_SET(s, "RAW");
+	    break;
+	case CH_MODE_BLOB:
+	    STR_LITERAL_SET(s, "BLOB");
 	    break;
 	case CH_MODE_JSON:
 	    STR_LITERAL_SET(s, "JSON");
@@ -4317,14 +4353,16 @@ channel_read_block(
     readq_T	*node;
 
     ch_log(channel, "Blocking %s read, timeout: %d msec",
-				  mode == CH_MODE_RAW ? "RAW" : "NL", timeout);
+				  mode == CH_MODE_RAW ? "RAW"
+				: mode == CH_MODE_BLOB ? "BLOB" : "NL", timeout);
 
     while (TRUE)
     {
 	node = channel_peek(channel, part);
 	if (node != NULL)
 	{
-	    if (mode == CH_MODE_RAW || (mode == CH_MODE_NL
+	    if (mode == CH_MODE_RAW || mode == CH_MODE_BLOB
+		    || (mode == CH_MODE_NL
 					   && channel_first_nl(node) != NULL))
 		// got a complete message
 		break;
@@ -4348,7 +4386,7 @@ channel_read_block(
     }
 
     // We have a complete message now.
-    if (mode == CH_MODE_RAW || outlen != NULL)
+    if (mode == CH_MODE_RAW || mode == CH_MODE_BLOB || outlen != NULL)
     {
 	msg = channel_get_all(channel, part, outlen);
     }
@@ -4384,7 +4422,8 @@ channel_read_block(
 	}
     }
     if (ch_log_active())
-	ch_log(channel, "Returning %d bytes", (int)STRLEN(msg));
+	ch_log(channel, "Returning %d bytes",
+		outlen != NULL ? *outlen : (int)STRLEN(msg));
     return msg;
 }
 
@@ -4618,7 +4657,8 @@ common_channel_read(typval_T *argvars, typval_T *rettv, int raw, int blob)
 	    vim_free(p);
 	}
     }
-    else if (raw || mode == CH_MODE_RAW || mode == CH_MODE_NL)
+    else if (raw || mode == CH_MODE_RAW || mode == CH_MODE_BLOB
+	    || mode == CH_MODE_NL)
 	rettv->vval.v_string = channel_read_block(channel, part,
 		timeout, raw, NULL);
     else
@@ -5000,7 +5040,8 @@ ch_expr_common(typval_T *argvars, typval_T *rettv, int eval)
     part_send = channel_part_send(channel);
 
     ch_mode = channel_get_mode(channel, part_send);
-    if (ch_mode == CH_MODE_RAW || ch_mode == CH_MODE_NL)
+    if (ch_mode == CH_MODE_RAW || ch_mode == CH_MODE_BLOB
+	    || ch_mode == CH_MODE_NL)
     {
 	emsg(_(e_cannot_use_evalexpr_sendexpr_with_raw_or_nl_channel));
 	return;
@@ -5830,7 +5871,8 @@ f_ch_setoptions(typval_T *argvars, typval_T *rettv UNUSED)
 	return;
     clear_job_options(&opt);
     if (get_job_options(&argvars[1], &opt,
-			    JO_CB_ALL + JO_TIMEOUT_ALL + JO_MODE_ALL, 0) == OK)
+			    JO_CB_ALL + JO_TIMEOUT_ALL + JO_MODE_ALL,
+			    0) == OK)
 	channel_set_options(channel, &opt);
     free_job_options(&opt);
 }

--- a/src/channel.c
+++ b/src/channel.c
@@ -1440,8 +1440,7 @@ channel_listen_func(typval_T *argvars)
     opt.jo_mode = CH_MODE_JSON;
     opt.jo_timeout = 2000;
     if (get_job_options(&argvars[1], &opt,
-	    JO_MODE_ALL + JO_CB_ALL + JO_TIMEOUT_ALL,
-	    0) == FAIL)
+	    JO_MODE_ALL + JO_CB_ALL + JO_TIMEOUT_ALL, 0) == FAIL)
 	goto theend;
     if (opt.jo_timeout < 0)
     {

--- a/src/errors.h
+++ b/src/errors.h
@@ -2377,8 +2377,8 @@ EXTERN char e_using_job_as_number[]
 	INIT(= N_("E910: Using a Job as a Number"));
 EXTERN char e_using_job_as_float[]
 	INIT(= N_("E911: Using a Job as a Float"));
-EXTERN char e_cannot_use_evalexpr_sendexpr_with_raw_or_nl_channel[]
-	INIT(= N_("E912: Cannot use ch_evalexpr()/ch_sendexpr() with a raw or nl channel"));
+EXTERN char e_cannot_use_evalexpr_sendexpr_with_raw_nl_or_blob_channel[]
+	INIT(= N_("E912: Cannot use ch_evalexpr()/ch_sendexpr() with a raw, nl or blob channel"));
 EXTERN char e_using_channel_as_number[]
 	INIT(= N_("E913: Using a Channel as a Number"));
 EXTERN char e_using_channel_as_float[]

--- a/src/job.c
+++ b/src/job.c
@@ -27,6 +27,8 @@ handle_mode(typval_T *item, jobopt_T *opt, ch_mode_T *modep, int jo)
 	*modep = CH_MODE_NL;
     else if (STRCMP(val, "raw") == 0)
 	*modep = CH_MODE_RAW;
+    else if (STRCMP(val, "blob") == 0)
+	*modep = CH_MODE_BLOB;
     else if (STRCMP(val, "js") == 0)
 	*modep = CH_MODE_JS;
     else if (STRCMP(val, "json") == 0)
@@ -1324,7 +1326,8 @@ job_start(
 	if (get_job_options(&argvars[1], &opt,
 		    JO_MODE_ALL + JO_CB_ALL + JO_TIMEOUT_ALL + JO_STOPONEXIT
 			 + JO_EXIT_CB + JO_OUT_IO + JO_BLOCK_WRITE,
-		     JO2_ENV + JO2_CWD) == FAIL)
+		     JO2_ENV + JO2_CWD)
+								      == FAIL)
 	    goto theend;
     }
 

--- a/src/job.c
+++ b/src/job.c
@@ -1326,8 +1326,7 @@ job_start(
 	if (get_job_options(&argvars[1], &opt,
 		    JO_MODE_ALL + JO_CB_ALL + JO_TIMEOUT_ALL + JO_STOPONEXIT
 			 + JO_EXIT_CB + JO_OUT_IO + JO_BLOCK_WRITE,
-		     JO2_ENV + JO2_CWD)
-								      == FAIL)
+		     JO2_ENV + JO2_CWD) == FAIL)
 	    goto theend;
     }
 

--- a/src/structs.h
+++ b/src/structs.h
@@ -2671,6 +2671,7 @@ typedef enum
 {
     CH_MODE_NL = 0,
     CH_MODE_RAW,
+    CH_MODE_BLOB,
     CH_MODE_JSON,
     CH_MODE_JS,
     CH_MODE_LSP,	// Language Server Protocol (http + json)

--- a/src/testdir/test_channel.vim
+++ b/src/testdir/test_channel.vim
@@ -1411,6 +1411,7 @@ func Test_out_cb_blob_mode()
   finally
     call job_stop(job)
     delfunc OutBlobCb
+    unlet g:Ch_blob_bytes
   endtry
 endfunc
 

--- a/src/testdir/test_channel.vim
+++ b/src/testdir/test_channel.vim
@@ -1390,6 +1390,30 @@ func Test_out_cb_lambda()
   endtry
 endfunc
 
+func Test_out_cb_blob_mode()
+  let g:Ch_blob_bytes = []
+  func OutBlobCb(chan, msg)
+    call assert_equal(v:t_blob, type(a:msg))
+    let g:Ch_blob_bytes += blob2list(a:msg)
+  endfunc
+
+  let cmd = [s:python, '-c',
+        \ 'import sys,time;'
+        \ .. 'sys.stdout.buffer.write(bytes([0, 1, 2, 10, 255]));'
+        \ .. 'sys.stdout.flush();'
+        \ .. 'time.sleep(0.1)']
+  let job = job_start(cmd, #{
+        \ out_mode: 'blob',
+        \ out_cb: 'OutBlobCb',
+        \ })
+  try
+    call WaitForAssert({-> assert_equal([0, 1, 2, 10, 255], g:Ch_blob_bytes)})
+  finally
+    call job_stop(job)
+    delfunc OutBlobCb
+  endtry
+endfunc
+
 func Test_close_and_exit_cb()
   let g:test_is_flaky = 1
   let g:retdict = {'ret': {}}

--- a/src/testdir/test_channel.vim
+++ b/src/testdir/test_channel.vim
@@ -1415,6 +1415,39 @@ func Test_out_cb_blob_mode()
   endtry
 endfunc
 
+func Test_pty_out_cb_blob_mode()
+  CheckUnix
+
+  let g:Ch_blob_bytes = []
+  func PtyBlobCb(chan, msg)
+    call assert_equal(v:t_blob, type(a:msg))
+    let g:Ch_blob_bytes += blob2list(a:msg)
+  endfunc
+
+  " Put the pty in raw mode so the line discipline does not translate LF
+  " to CRLF or strip NUL bytes, then write bytes that include NULs on
+  " both sides of an embedded LF.
+  let cmd = [s:python, '-c',
+        \ 'import os,sys,time;'
+        \ .. 'os.system("stty raw -echo");'
+        \ .. 'sys.stdout.buffer.write(bytes([65, 0, 66, 10, 67, 0, 68]));'
+        \ .. 'sys.stdout.flush();'
+        \ .. 'time.sleep(0.1)']
+  let job = job_start(cmd, #{
+        \ pty: 1,
+        \ out_mode: 'blob',
+        \ out_cb: 'PtyBlobCb',
+        \ })
+  try
+    call WaitForAssert({-> assert_equal(
+          \ [65, 0, 66, 10, 67, 0, 68], g:Ch_blob_bytes)})
+  finally
+    call job_stop(job)
+    delfunc PtyBlobCb
+    unlet g:Ch_blob_bytes
+  endtry
+endfunc
+
 func Test_close_and_exit_cb()
   let g:test_is_flaky = 1
   let g:retdict = {'ret': {}}


### PR DESCRIPTION
Raw channel callbacks always receive a String, which truncates binary data at NUL bytes. Add a `blob` mode for `mode` / `out_mode` / `err_mode` so the callback's `msg` argument is delivered as a |Blob|, preserving all bytes including 0x00.

Closes #10500