### PR TITLE
Fix vsep flicker behind the popup menu when navigating with C-N/C-P

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -445,6 +445,20 @@ skip_for_popup(int row, int col)
 #endif
 	    )
 	return TRUE;
+    // Also skip when the pum is visible and the cell is geometrically under
+    // it, regardless of pum_will_redraw.  This protects against background
+    // draws (e.g. vsep at cursor row, status line) that are not part of a
+    // pum_redraw cycle.  The pum's own draw uses screen_zindex ==
+    // POPUPMENU_ZINDEX, so this check excludes it.
+#ifdef FEAT_PROP_POPUP
+    if (screen_zindex < POPUPMENU_ZINDEX
+	    && pum_visible()
+	    && pum_under_menu(row, col, FALSE))
+	return TRUE;
+#else
+    if (pum_visible() && pum_under_menu(row, col, FALSE))
+	return TRUE;
+#endif
 #ifdef FEAT_PROP_POPUP
     if (blocked_by_popup(row, col))
 	return TRUE;

--- a/src/screen.c
+++ b/src/screen.c
@@ -445,18 +445,19 @@ skip_for_popup(int row, int col)
 #endif
 	    )
 	return TRUE;
-    // Also skip when the pum is visible and the cell is geometrically under
-    // it, regardless of pum_will_redraw.  This protects against background
-    // draws (e.g. vsep at cursor row, status line) that are not part of a
-    // pum_redraw cycle.  The pum's own draw uses screen_zindex ==
-    // POPUPMENU_ZINDEX, so this check excludes it.
+    // Protect cells under the pum from background draws (vsep, status line).
+    // Excluded for wildmenu pum (MODE_CMDLINE): pum_row can be stale while
+    // the cmdline grows.
 #ifdef FEAT_PROP_POPUP
     if (screen_zindex < POPUPMENU_ZINDEX
 	    && pum_visible()
+	    && (State & MODE_CMDLINE) == 0
 	    && pum_under_menu(row, col, FALSE))
 	return TRUE;
 #else
-    if (pum_visible() && pum_under_menu(row, col, FALSE))
+    if (pum_visible()
+	    && (State & MODE_CMDLINE) == 0
+	    && pum_under_menu(row, col, FALSE))
 	return TRUE;
 #endif
 #ifdef FEAT_PROP_POPUP


### PR DESCRIPTION
Fix vsep flicker behind the popup menu when navigating with C-N/C-P

In a vertical split where the insert-mode popup menu overlaps the vertical separator, pressing C-N/C-P made the vsep briefly bleed through the pum and flicker.

skip_for_popup() only skipped pum-covered cells when pum_will_redraw was set, which is true only inside pum_redraw()'s own update_screen() call. Background paths (vsep at cursor row, status line, redraw_vseps, idle ins_redraw) could therefore write into cells that are geometrically under the pum. Also skip when the pum is visible and the current draw is not the pum itself (screen_zindex < POPUPMENU_ZINDEX); the pum's own draw uses screen_zindex == POPUPMENU_ZINDEX and is excluded by the strict-less-than check.

The wildmenu pum (MODE_CMDLINE) is excluded from the new check: pum_row can be stale while the cmdline grows on <C-N>, which would otherwise protect cells that now belong to the expanded cmdline (regression in Test_long_line_noselect).

Before

https://github.com/user-attachments/assets/61c70537-0a65-445c-9214-3a84f22592c5

After

https://github.com/user-attachments/assets/9c05d315-a064-4129-84c4-7fc74d8a4b35