### PR TITLE
test suite is slow because it cannot run in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
 
       - name: Test
         timeout-minutes: 20
-        run: make ${SHADOWOPT} ${TEST}
+        run: make -j$(getconf _NPROCESSORS_ONLN) ${SHADOWOPT} ${TEST}
 
       # Enable to debug failing tests live and ssh into the CI runners
       # - name: Setup tmate session
@@ -326,7 +326,7 @@ jobs:
       - name: Test
         timeout-minutes: 25
         run: |
-          make ${TEST}
+          make -j${NPROC} ${TEST}
 
       - name: Upload failed test artifacts
         if: ${{ !cancelled() }}

--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,8 @@ src/testdir/viminfo
 src/testdir/opt_test.vim
 src/testdir/failed
 src/testdir/starttime
+src/testdir/workdir/
+src/testdir/XfakeHOME/
 runtime/indent/testdir/*.out
 runtime/indent/testdir/*.fail
 src/memfile_test

--- a/Filelist
+++ b/Filelist
@@ -538,6 +538,7 @@ SRC_UNIX =	\
 		src/proto/pty.pro \
 		src/pty.c \
 		src/testdir/Makefile \
+		src/testdir/setup_workdir.sh \
 		src/testdir/util/unix.vim \
 		src/toolcheck \
 		src/vim_icon.xbm \

--- a/src/testdir/Makefile
+++ b/src/testdir/Makefile
@@ -1,11 +1,18 @@
 #
 # Makefile to run all tests for Vim
 #
-
-# The old-style tests (*.in) use shared filenames in the working directory
-# (test.ok, test.out, X*, viminfo), so running them in parallel causes races
-# and spurious failures.
-.NOTPARALLEL:
+# Tests run in per-test isolated working directories under workdir/ so that
+# they can execute in parallel without racing on shared temp files.  The
+# layout for each test is a symlink tree that preserves relative-path depth:
+#
+#   workdir/                     symlinks to vim root (runtime/, ...)
+#   workdir/$test/               symlinks to src/ contents
+#   workdir/$test/testdir/       symlinks to testdir/ contents, test cwd
+#
+# Tests cd into workdir/$test/testdir/ so '../' resolves to src/ and
+# '../../' resolves to the vim root, matching the real directory layout.
+# The nolog target creates the level-1 (vim root) symlinks once; the
+# setup_workdir.sh script creates per-test levels 2 and 3.
 
 # Use console or GUI.
 VIMPROG = ../vim
@@ -39,17 +46,62 @@ test_options_all.res: opt_test.vim
 
 .SUFFIXES: .in .out .res .vim
 
-nongui:	nolog tinytests newtests report
+# Ordering: nolog must run before any tests, report must run after all tests.
+# The individual tests within tinytests/newtests can run in parallel.
+#
+# We use recursive make to enforce sequencing (nolog → tests → report)
+# without GNU order-only prerequisites.  Each @$(MAKE) line completes
+# before the next starts; the middle one inherits -j for parallelism.
+nongui:
+	@$(MAKE) nolog
+	@$(MAKE) tinytests newtests
+	@$(MAKE) report
 
-gui:	nolog tinytests newtests report
+gui:
+	@$(MAKE) nolog
+	@$(MAKE) tinytests newtests
+	@$(MAKE) report
 
-tiny:	nolog tinytests report
+tiny:
+	@$(MAKE) nolog
+	@$(MAKE) tinytests
+	@$(MAKE) report_tiny
 
 benchmark: $(SCRIPTS_BENCH)
 
+# Assumes nolog and tinytests have already run (called via recursive
+# make from the tiny target above).  Do not invoke directly.
+report_tiny:
+	@# Collect per-test failure logs.
+	@/bin/sh -c 'cat workdir/*/test.log > test.log 2>/dev/null || true'
+	@/bin/sh -c "if test -s test.log; \
+		then cp test.log test_result.log; \
+		else echo No failures reported > test_result.log; \
+		fi"
+	@rm -f starttime
+	@echo
+	@echo 'Test results:'
+	@cat test_result.log
+	@/bin/sh -c "if test -s test.log; \
+		then echo TEST FAILURE; exit 1; \
+		else echo ALL DONE; \
+		fi"
+
+# Assumes nolog, tinytests, and newtests have already run (called via
+# recursive make from nongui/gui above).  Do not invoke directly.
 report:
+	@# Collect per-test output from workdirs.
+	@/bin/sh -c 'cat workdir/*/testdir/messages > messages 2>/dev/null || true'
+	@/bin/sh -c 'cat workdir/*/testdir/test.log > test.log 2>/dev/null || true'
+	@# Collect per-test failed screendump directories so they are
+	@# available in the usual testdir/failed/ location for debugging.
+	@/bin/sh -c 'for d in workdir/*/testdir/failed; do \
+		test -d "$$d" || continue; \
+		mkdir -p failed; \
+		cp -r "$$d"/* failed/ 2>/dev/null; \
+	done || true'
 	@# without the +eval feature test_result.log is a copy of test.log
-	@/bin/sh -c "if test -f test.log; \
+	@/bin/sh -c "if test -s test.log; \
 		then cp test.log test_result.log; \
 		else echo No failures reported > test_result.log; \
 		fi"
@@ -58,7 +110,7 @@ report:
 	@echo
 	@echo 'Test results:'
 	@cat test_result.log
-	@/bin/sh -c "if test -f test.log; \
+	@/bin/sh -c "if test -s test.log; \
 		then echo TEST FAILURE; exit 1; \
 		else echo ALL DONE; \
 		fi"
@@ -73,33 +125,31 @@ $(SCRIPTS_TINY_OUT) $(NEW_TESTS_RES): $(VIMPROG)
 # 	make test_largefile
 $(NEW_TESTS):
 	rm -f $@.res $(CLEANUP_FILES)
+	@$(MAKE) nolog
 	@MAKEFLAGS=--no-print-directory $(MAKE) -f Makefile $@.res VIMPROG=$(VIMPROG) XXDPROG=$(XXDPROG) SCRIPTSOURCE=$(SCRIPTSOURCE)
-	@cat messages
-	@if test -f test.log; then \
-		exit 1; \
-	fi
+	@/bin/sh -c 'cat workdir/*/messages 2>/dev/null || true'
+	@/bin/sh -c 'if cat workdir/*/test.log 2>/dev/null; then exit 1; fi'
 
 codestyle:
 	rm -f test_codestyle.res $(CLEANUP_FILES)
+	@$(MAKE) nolog
 	@MAKEFLAGS=--no-print-directory $(MAKE) -f Makefile test_codestyle.res VIMPROG=$(VIMPROG) XXDPROG=$(XXDPROG) SCRIPTSOURCE=$(SCRIPTSOURCE)
-	@cat messages
-	@if test -f test.log; then \
-		exit 1; \
-	fi
+	@/bin/sh -c 'cat workdir/*/messages 2>/dev/null || true'
+	@/bin/sh -c 'if cat workdir/*/test.log 2>/dev/null; then exit 1; fi'
 
 # Run only tests specific for Vim9 script
 test_vim9:
 	rm -f test_vim9_*.res $(CLEANUP_FILES)
+	@$(MAKE) nolog
 	@MAKEFLAGS=--no-print-directory $(MAKE) -f Makefile $(TEST_VIM9_RES) VIMPROG=$(VIMPROG) XXDPROG=$(XXDPROG) SCRIPTSOURCE=$(SCRIPTSOURCE)
-	@cat messages
+	@/bin/sh -c 'cat workdir/*/messages > messages 2>/dev/null || true'
+	@/bin/sh -c 'cat workdir/*/test.log > test.log 2>/dev/null || true'
 	@rm -f starttime
 	@MAKEFLAGS=--no-print-directory $(MAKE) -f Makefile report VIMPROG=$(VIMPROG) XXDPROG=$(XXDPROG) SCRIPTSOURCE=$(SCRIPTSOURCE)
 	@if test -f test.log; then \
 		exit 1; \
 	fi
 
-RM_ON_RUN = test.out X* viminfo
-RM_ON_START = test.ok benchmark.out
 RUN_VIMPROG = VIMRUNTIME=$(SCRIPTSOURCE) $(VALGRIND) $(VIMPROG) -f $(GUI_FLAG) -u util/unix.vim $(NO_INITS) -s dotest.in
 
 # Delete files that may interfere with running tests.  This includes some files
@@ -108,10 +158,11 @@ clean:
 	-rm -rf *.out *.failed *.res *.rej *.orig XfakeHOME Xdir1 Xfind failed
 	-rm -f opt_test.vim test_result.log $(CLEANUP_FILES)
 	-rm -f gen_opt_test.log
-	-rm -rf $(RM_ON_RUN) $(RM_ON_START)
+	-rm -rf test.out test.ok benchmark.out X* viminfo
 	-rm -f valgrind.*
 	-rm -f asan.* asan_test_*
 	-rm -f guidialog guidialogfile
+	-rm -rf workdir
 
 # Delete the files produced by benchmarking, so they can run again.
 benchmarkclean:
@@ -119,36 +170,57 @@ benchmarkclean:
 
 nolog:
 	-rm -f test_result.log $(CLEANUP_FILES)
+	-rm -rf workdir
+	@# Level 1: vim root (runtime/, etc.) for ../../ references.
+	@# Created here once, not per-test in setup_workdir.sh, because
+	@# ln -s follows existing symlinks to directories: if workdir/runtime
+	@# already exists as a symlink, "ln -s .../runtime workdir/runtime"
+	@# creates runtime/runtime inside the real runtime/ dir.  Neither
+	@# ln -sf nor rm+ln nor test -L guards fix this under make -j
+	@# (ln -sf and bare ln -s both follow; rm+ln races).  Running the
+	@# loop once here, serially before any tests start, avoids the issue.
+	@TESTDIR=`pwd`; mkdir -p workdir; \
+	for f in "$$TESTDIR"/../../*; do \
+		b=$$(basename "$$f"); \
+		case "$$b" in src) continue;; esac; \
+		ln -s "$$f" workdir/"$$b" 2>/dev/null || true; \
+	done
+	@# Record the start time once so parallel tests don't race on it.
+	@date +%s > starttime
 
 
 # Tiny tests.  Works even without the +eval feature.
 tinytests: $(SCRIPTS_TINY_OUT)
 
+# Each old-style test runs in its own workdir to avoid races on shared
+# filenames (test.ok, test.out, X*, viminfo).
 .in.out:
-	-rm -rf $*.failed test.ok $(RM_ON_RUN)
-	cp $*.ok test.ok
+	-rm -rf $*.failed workdir/$*
+	@sh setup_workdir.sh $*
+	cp $*.ok workdir/$*/testdir/test.ok
 	@# Sleep a moment to avoid that the xterm title is messed up.
 	@# 200 msec is sufficient, but only modern sleep supports a fraction of
 	@# a second, fall back to a second if it fails.
 	@-/bin/sh -c "sleep .2 > /dev/null 2>&1 || sleep 1"
+	@TESTDIR=`pwd`; \
 	if test -n "$${ASAN_OPTIONS}"; then \
-		ASAN_OPTIONS="$${ASAN_OPTIONS}_$*" UBSAN_OPTIONS="$${UBSAN_OPTIONS}_$*" $(RUN_VIMPROG) $*.in $(REDIR_TEST_TO_NULL) ; \
+		cd workdir/$*/testdir && ASAN_OPTIONS="$${ASAN_OPTIONS}_$*" UBSAN_OPTIONS="$${UBSAN_OPTIONS}_$*" VIMRUNTIME=$$TESTDIR/$(SCRIPTSOURCE) $(VALGRIND) $$TESTDIR/$(VIMPROG) -f $(GUI_FLAG) -u $$TESTDIR/util/unix.vim $(NO_INITS) -s $$TESTDIR/dotest.in $$TESTDIR/$*.in $(REDIR_TEST_TO_NULL) ; \
 	else \
-		$(RUN_VIMPROG) $*.in $(REDIR_TEST_TO_NULL) ; \
+		cd workdir/$*/testdir && VIMRUNTIME=$$TESTDIR/$(SCRIPTSOURCE) $(VALGRIND) $$TESTDIR/$(VIMPROG) -f $(GUI_FLAG) -u $$TESTDIR/util/unix.vim $(NO_INITS) -s $$TESTDIR/dotest.in $$TESTDIR/$*.in $(REDIR_TEST_TO_NULL) ; \
 	fi
 
 	@# Check if the test.out file matches test.ok.
-	@/bin/sh -c "if test -f test.out; then \
-		  if diff test.out $*.ok; \
-		  then mv -f test.out $*.out; \
-		  else echo $* FAILED >>test.log; mv -f test.out $*.failed; \
+	@/bin/sh -c "if test -f workdir/$*/testdir/test.out; then \
+		  if diff workdir/$*/testdir/test.out $*.ok; \
+		  then mv -f workdir/$*/testdir/test.out $*.out; \
+		  else echo $* FAILED >>workdir/$*/test.log; mv -f workdir/$*/testdir/test.out $*.failed; \
 		  fi \
-		else echo $* NO OUTPUT >>test.log; \
+		else echo $* NO OUTPUT >>workdir/$*/test.log; \
 		fi"
-	@/bin/sh -c "if test -f valgrind; then\
-		  mv -f valgrind valgrind.$*; \
+	@/bin/sh -c "if test -f workdir/$*/testdir/valgrind; then\
+		  mv -f workdir/$*/testdir/valgrind valgrind.$*; \
 		fi"
-	-rm -rf X* test.ok viminfo
+	-rm -rf workdir/$*/testdir/X* workdir/$*/testdir/test.ok workdir/$*/testdir/viminfo
 
 
 # New style of tests uses Vim script with assert calls.  These are easier
@@ -157,42 +229,49 @@ tinytests: $(SCRIPTS_TINY_OUT)
 # Add --gui-dialog-file to avoid getting stuck in a dialog.
 RUN_VIMTEST = VIMRUNTIME=$(SCRIPTSOURCE) $(VALGRIND) $(VIMPROG) -f $(GUI_FLAG) -u util/unix.vim --gui-dialog-file guidialog
 
-newtests: newtestssilent
-	@/bin/sh -c "if test -f messages; then cat messages; fi"
+newtests: $(NEW_TESTS_RES)
 
-newtestssilent: $(NEW_TESTS_RES)
-
-
+# Each new-style test runs with TEST_WORKDIR set so that runtest.vim
+# creates temp files in an isolated directory.
 .vim.res:
-	@echo "$(VIMPROG)" > vimcmd
-	@echo "$(RUN_VIMTEST)" >> vimcmd
+	@sh setup_workdir.sh $*
+	@TESTDIR=`pwd`; \
+	echo "$$TESTDIR/$(VIMPROG)" > workdir/$*/testdir/vimcmd; \
+	echo "VIMRUNTIME=$$TESTDIR/$(SCRIPTSOURCE) $(VALGRIND) $$TESTDIR/$(VIMPROG) -f $(GUI_FLAG) -u $$TESTDIR/util/unix.vim --gui-dialog-file guidialog" >> workdir/$*/testdir/vimcmd
+	@TESTDIR=`pwd`; \
 	if test -n "$${ASAN_OPTIONS}"; then \
-		ASAN_OPTIONS="$${ASAN_OPTIONS}_$*" UBSAN_OPTIONS="$${UBSAN_OPTIONS}_$*" $(RUN_VIMTEST) $(NO_INITS) -S runtest.vim $*.vim $(REDIR_TEST_TO_NULL) ; \
+		ASAN_OPTIONS="$${ASAN_OPTIONS}_$*" UBSAN_OPTIONS="$${UBSAN_OPTIONS}_$*" TEST_WORKDIR=$$TESTDIR/workdir/$*/testdir $(RUN_VIMTEST) $(NO_INITS) -S runtest.vim $*.vim $(REDIR_TEST_TO_NULL) ; \
 	else \
-		$(RUN_VIMTEST) $(NO_INITS) -S runtest.vim $*.vim $(REDIR_TEST_TO_NULL) ; \
+		TEST_WORKDIR=$$TESTDIR/workdir/$*/testdir $(RUN_VIMTEST) $(NO_INITS) -S runtest.vim $*.vim $(REDIR_TEST_TO_NULL) ; \
 	fi
-	@rm vimcmd
+	@rm -f workdir/$*/testdir/vimcmd
 
 test_gui.res: test_gui.vim
-	@echo "$(VIMPROG)" > vimcmd
-	@echo "$(RUN_GVIMTEST)" >> vimcmd
+	@sh setup_workdir.sh $*
+	@TESTDIR=`pwd`; \
+	echo "$$TESTDIR/$(VIMPROG)" > workdir/$*/testdir/vimcmd; \
+	echo "$(RUN_GVIMTEST)" >> workdir/$*/testdir/vimcmd
+	@TESTDIR=`pwd`; \
 	if test -n "$${ASAN_OPTIONS}"; then \
-		ASAN_OPTIONS="$${ASAN_OPTIONS}_$*" UBSAN_OPTIONS="$${UBSAN_OPTIONS}_$*" $(RUN_VIMTEST) -u NONE $(NO_INITS) -S runtest.vim $< ; \
+		ASAN_OPTIONS="$${ASAN_OPTIONS}_$*" UBSAN_OPTIONS="$${UBSAN_OPTIONS}_$*" TEST_WORKDIR=$$TESTDIR/workdir/$*/testdir $(RUN_VIMTEST) -u NONE $(NO_INITS) -S runtest.vim $< ; \
 	else \
-		$(RUN_VIMTEST) -u NONE $(NO_INITS) -S runtest.vim $< ; \
+		TEST_WORKDIR=$$TESTDIR/workdir/$*/testdir $(RUN_VIMTEST) -u NONE $(NO_INITS) -S runtest.vim $< ; \
 	fi
 
-	@rm vimcmd
+	@rm -f workdir/$*/testdir/vimcmd
 
 test_gui_init.res: test_gui_init.vim
-	@echo "$(VIMPROG)" > vimcmd
-	@echo "$(RUN_GVIMTEST_WITH_GVIMRC)" >> vimcmd
+	@sh setup_workdir.sh $*
+	@TESTDIR=`pwd`; \
+	echo "$$TESTDIR/$(VIMPROG)" > workdir/$*/testdir/vimcmd; \
+	echo "$(RUN_GVIMTEST_WITH_GVIMRC)" >> workdir/$*/testdir/vimcmd
+	@TESTDIR=`pwd`; \
 	if test -n "$${ASAN_OPTIONS}"; then \
-		ASAN_OPTIONS="$${ASAN_OPTIONS}_$*" UBSAN_OPTIONS="$${UBSAN_OPTIONS}_$*" $(RUN_VIMTEST) -u util/gui_preinit.vim -U util/gui_init.vim $(NO_PLUGINS) -S runtest.vim $< ; \
+		ASAN_OPTIONS="$${ASAN_OPTIONS}_$*" UBSAN_OPTIONS="$${UBSAN_OPTIONS}_$*" TEST_WORKDIR=$$TESTDIR/workdir/$*/testdir $(RUN_VIMTEST) -u util/gui_preinit.vim -U util/gui_init.vim $(NO_PLUGINS) -S runtest.vim $< ; \
 	else \
-		$(RUN_VIMTEST) -u util/gui_preinit.vim -U util/gui_init.vim $(NO_PLUGINS) -S runtest.vim $< ; \
+		TEST_WORKDIR=$$TESTDIR/workdir/$*/testdir $(RUN_VIMTEST) -u util/gui_preinit.vim -U util/gui_init.vim $(NO_PLUGINS) -S runtest.vim $< ; \
 	fi
-	@rm vimcmd
+	@rm -f workdir/$*/testdir/vimcmd
 
 GEN_OPT_DEPS = util/gen_opt_test.vim ../optiondefs.h ../../runtime/doc/options.txt
 
@@ -208,21 +287,24 @@ opt_test.vim: $(GEN_OPT_DEPS)
 	fi
 
 test_xxd.res:
+	@sh setup_workdir.sh $*
+	@TESTDIR=`pwd`; \
 	if test -n "$${ASAN_OPTIONS}"; then \
-		XXD=$(XXDPROG); export XXD; ASAN_OPTIONS="$${ASAN_OPTIONS}_$*" UBSAN_OPTIONS="$${UBSAN_OPTIONS}_$*" $(RUN_VIMTEST) $(NO_INITS) -S runtest.vim test_xxd.vim ; \
+		XXD=$(XXDPROG); export XXD; ASAN_OPTIONS="$${ASAN_OPTIONS}_$*" UBSAN_OPTIONS="$${UBSAN_OPTIONS}_$*" TEST_WORKDIR=$$TESTDIR/workdir/$*/testdir $(RUN_VIMTEST) $(NO_INITS) -S runtest.vim test_xxd.vim ; \
 	else \
-		XXD=$(XXDPROG); export XXD; $(RUN_VIMTEST) $(NO_INITS) -S runtest.vim test_xxd.vim ; \
+		XXD=$(XXDPROG); export XXD; TEST_WORKDIR=$$TESTDIR/workdir/$*/testdir $(RUN_VIMTEST) $(NO_INITS) -S runtest.vim test_xxd.vim ; \
 	fi
 
 test_bench_regexp.res: test_bench_regexp.vim
-	-rm -rf benchmark.out $(RM_ON_RUN)
+	@sh setup_workdir.sh $*
 	@# Sleep a moment to avoid that the xterm title is messed up.
 	@# 200 msec is sufficient, but only modern sleep supports a fraction of
 	@# a second, fall back to a second if it fails.
 	@-/bin/sh -c "sleep .2 > /dev/null 2>&1 || sleep 1"
+	@TESTDIR=`pwd`; \
 	if test -n "$${ASAN_OPTIONS}"; then \
-		ASAN_OPTIONS="$${ASAN_OPTIONS}_$*" UBSAN_OPTIONS="$${UBSAN_OPTIONS}_$*" $(RUN_VIMTEST) $(NO_INITS) -S runtest.vim $*.vim $(REDIR_TEST_TO_NULL) ; \
+		ASAN_OPTIONS="$${ASAN_OPTIONS}_$*" UBSAN_OPTIONS="$${UBSAN_OPTIONS}_$*" TEST_WORKDIR=$$TESTDIR/workdir/$*/testdir $(RUN_VIMTEST) $(NO_INITS) -S runtest.vim $*.vim $(REDIR_TEST_TO_NULL) ; \
 	else \
-		$(RUN_VIMTEST) $(NO_INITS) -S runtest.vim $*.vim $(REDIR_TEST_TO_NULL) ; \
+		TEST_WORKDIR=$$TESTDIR/workdir/$*/testdir $(RUN_VIMTEST) $(NO_INITS) -S runtest.vim $*.vim $(REDIR_TEST_TO_NULL) ; \
 	fi
-	@/bin/sh -c "if test -f benchmark.out; then cat benchmark.out; fi"
+	@/bin/sh -c "if test -f workdir/$*/testdir/benchmark.out; then cat workdir/$*/testdir/benchmark.out; fi"

--- a/src/testdir/runtest.vim
+++ b/src/testdir/runtest.vim
@@ -84,16 +84,21 @@ if &lines < 24 || &columns < 80
   qa!
 endif
 
+" g:testdir is the directory containing the test scripts and utilities.
+" When running in a workdir ($TEST_WORKDIR), this is needed to locate
+" resources like dumps/ and samples/.
+let g:testdir = getcwd()
+
 if has('reltime')
   let s:run_start_time = reltime()
 
-  if !filereadable('starttime')
-    " first test, store the overall test starting time
-    let s:test_start_time = localtime()
-    call writefile([string(s:test_start_time)], 'starttime')
+  let s:starttime_file = g:testdir .. '/starttime'
+  if filereadable(s:starttime_file)
+    let s:test_start_time = readfile(s:starttime_file)[0]->str2nr()
   else
-    " second or later test, read the overall test starting time
-    let s:test_start_time = readfile('starttime')[0]->str2nr()
+    " Fallback if starttime was not created by the Makefile (e.g. when
+    " running runtest.vim manually).
+    let s:test_start_time = localtime()
   endif
 endif
 
@@ -551,7 +556,8 @@ endfunc
 
 " Source the test script.  First grab the file name, in case the script
 " navigates away.  g:testname can be used by the tests.
-let g:testname = expand('%')
+" Use the absolute path so the .res file is created in testdir, not workdir.
+let g:testname = expand('%:p')
 let s:done = 0
 let s:fail = 0
 let s:fail_expected = 0
@@ -559,6 +565,9 @@ let s:errors = []
 let s:errors_expected = []
 let s:messages = []
 let s:skipped = []
+
+" Source the test file while cwd is still testdir, so that source
+" commands for utility scripts (screendump.vim, etc.) resolve correctly.
 if expand('%') =~ 'test_vimscript.vim'
   " this test has intentional errors, don't use try/catch.
   source %
@@ -572,6 +581,15 @@ else
     let s:fail += 1
     call add(s:errors, 'Caught exception: ' . v:exception . ' @ ' . v:throwpoint)
   endtry
+endif
+
+" If $TEST_WORKDIR is set, cd into it so that temp files (X*, test.log,
+" messages) are isolated per-test.  This must happen after sourcing the
+" test file (which may source utility scripts via relative paths) but
+" before running Test_ functions (which create temp files).
+if $TEST_WORKDIR != ''
+  let s:abs_workdir = fnamemodify($TEST_WORKDIR, ':p')
+  exe 'cd' fnameescape(s:abs_workdir)
 endif
 
 " Delete the .res file, it may change behavior for completion

--- a/src/testdir/setup_workdir.sh
+++ b/src/testdir/setup_workdir.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+# Create a per-test workdir with symlinks to shared resources.
+#
+# The layout mirrors the real directory tree so that relative paths work:
+#   workdir/$test/         - mimics src/     (has src/* symlinks)
+#   workdir/$test/testdir/ - mimics testdir/ (has testdir/* symlinks)
+#
+# Tests cd into workdir/$test/testdir/ so '../' = src/, '../../' = vim root.
+#
+# Level-1 symlinks (workdir/runtime, etc.) are created once by the nolog
+# Makefile target; this script creates only levels 2 and 3 per test.
+#
+# Usage: setup_workdir.sh <testname>
+
+testname=$1
+if [ -z "$testname" ]; then
+    echo "Usage: setup_workdir.sh <testname>" >&2
+    exit 1
+fi
+
+# Compute the absolute path to testdir from this script's location.
+TESTDIR=$(cd "$(dirname "$0")" && pwd)
+
+mkdir -p workdir/"$testname"/testdir
+
+# Level 2: src/ contents into workdir/$test/ for ../ references.
+for f in "$TESTDIR"/../*; do
+    case "$(basename "$f")" in testdir) continue;; esac
+    rm -f workdir/"$testname"/"$(basename "$f")" 2>/dev/null
+    ln -s "$f" workdir/"$testname"/"$(basename "$f")" 2>/dev/null || true
+done
+
+# Level 3: testdir/ contents into workdir/$test/testdir/.
+for f in "$TESTDIR"/*; do
+    case "$(basename "$f")" in workdir) continue;; esac
+    rm -f workdir/"$testname"/testdir/"$(basename "$f")" 2>/dev/null
+    ln -s "$f" workdir/"$testname"/testdir/"$(basename "$f")" 2>/dev/null || true
+done

--- a/src/testdir/test_python3.vim
+++ b/src/testdir/test_python3.vim
@@ -2908,11 +2908,22 @@ func Test_python3_chdir()
     os.chdir('..')
     path = fnamemodify('.', ':p:h:t')
     if path != b'src' and path != b'src2':
-      # Running tests from a shadow directory, so move up another level
-      # This will result in @% looking like shadow/testdir/Xp3cdfile, hence the
-      # slicing to remove the leading path and path separator
+      # Running tests from a shadow directory or workdir, so move up
+      # another level.
+      # This will result in @% looking like shadow/testdir/Xp3cdfile, hence
+      # the slicing to remove the leading path and path separator.
       os.chdir('..')
-      cb.append(str(fnamemodify('.', ':p:h:t')))
+      parent = fnamemodify('.', ':p:h:t')
+      if parent == b'workdir':
+        # Per-test workdir (make -j): real src/ is two levels above
+        # workdir/.  Navigate there for the directory name, then return
+        # so that @% is read from the right level.
+        os.chdir('../..')
+        cb.append(str(fnamemodify('.', ':p:h:t').replace(b'src2', b'src')))
+        os.chdir('testdir/workdir')
+      else:
+        cb.append(str(parent))
+      del parent
       cb.append(vim.eval('@%')[len(path)+1:].replace(os.path.sep, '/'))
       os.chdir(path)
     else:

--- a/src/testdir/test_stacktrace.vim
+++ b/src/testdir/test_stacktrace.vim
@@ -6,11 +6,11 @@ let s:thisfile = expand('%:p')
 let s:testdir = s:thisfile->fnamemodify(':h')
 
 func Filepath(name)
-  return s:testdir .. '/' .. a:name
+  return getcwd() .. '/' .. a:name
 endfunc
 
 func AssertStacktrace(expect, actual)
-  call assert_equal(Filepath('runtest.vim'), a:actual[0]['filepath'])
+  call assert_equal(s:testdir .. '/runtest.vim', a:actual[0]['filepath'])
   call assert_equal(a:expect, a:actual[-len(a:expect):])
 endfunc
 

--- a/src/testdir/util/shared.vim
+++ b/src/testdir/util/shared.vim
@@ -302,6 +302,10 @@ func s:GetJustBuildVimExe()
     endif
     return '..\vim.exe'
   endif
+  " Use g:testdir if available, so this works from a workdir too.
+  if exists('g:testdir')
+    return g:testdir .. '/../vim'
+  endif
   return '../vim'
 endfunc
 
@@ -309,8 +313,12 @@ endfunc
 " The Makefile writes it as the first line in the "vimcmd" file.
 " Falls back to the Vim executable in the src directory.
 func GetVimProg()
+  " When running in a workdir, look for vimcmd there first, then in testdir.
   if filereadable('vimcmd')
     return readfile('vimcmd')[0]
+  endif
+  if exists('g:testdir') && filereadable(g:testdir .. '/vimcmd')
+    return readfile(g:testdir .. '/vimcmd')[0]
   endif
   echo 'Cannot read the "vimcmd" file, falling back to ../vim.'
 
@@ -326,6 +334,8 @@ let g:valgrind_cnt = 1
 func GetVimCommand(...)
   if filereadable('vimcmd')
     let lines = readfile('vimcmd')
+  elseif exists('g:testdir') && filereadable(g:testdir .. '/vimcmd')
+    let lines = readfile(g:testdir .. '/vimcmd')
   else
     echo 'Cannot read the "vimcmd" file, falling back to ../vim.'
     let lines = [s:GetJustBuildVimExe()]


### PR DESCRIPTION
Problem:  The test suite takes over 17 minutes serially and cannot
          be run with make -j because tests share the testdir/
          working directory and create temporary files with
          well-known names (X*, test.log, messages, vimcmd).
Solution: Create per-test isolated working directories under
          workdir/ using symlink trees that mirror the real
          directory layout, keeping temp files isolated while
          preserving all relative path assumptions.
          (Jesse Rosenstock)

Each test runs in workdir/$test/testdir/ where the symlink tree preserves relative-path depth: ../ resolves to src/ contents and ../../ resolves to the vim root.  The layout is:

  workdir/                     symlinks to vim root (runtime/, ...)
  workdir/$test/               symlinks to src/ contents
  workdir/$test/testdir/       symlinks to testdir/ contents, test cwd

Level-1 symlinks are created once in the nolog target rather than per-test, because ln -s follows existing symlinks to directories (creating e.g. runtime/runtime in the repo root) and there is no race-free way to create them from parallel test processes.  A setup_workdir.sh POSIX shell script creates the per-test levels 2 and 3.

The Makefile avoids GNU Make extensions to stay POSIX-compatible: setup_workdir.sh replaces a define/call macro, shell TESTDIR=`pwd` replaces $(CURDIR), and recursive $(MAKE) replaces order-only prerequisites (|).

The test_stacktrace.vim Filepath() function is updated to use getcwd() for Xscript files since they are created in the workdir cwd, while runtest.vim is resolved from the original testdir.

An alternative approach would eliminate the symlink tree entirely by rewriting all ~127 relative path references (../ and ../../) across 35 test files to use absolute paths via g:testdir.  This was rejected because: (1) it touches many files unrelated to the parallelism fix, creating review noise and merge conflicts; (2) tab-completion and fnamemodify tests genuinely test relative path resolution against real directory structure, requiring per-test fixture directories anyway; (3) future test authors must remember to avoid ../ in favor of g:testdir, an easy regression with no enforcement mechanism; and (4) the symlink approach preserves the natural relative-path idiom that existing tests use, keeping the diff focused on infrastructure.

On a 48-core machine, wall clock time drops from 17m32s to ~50s.

This supersedes 6146f33 / #20082 (patch 9.2.0410: test suite races when run with parallel make) which added .NOTPARALLEL as a workaround for the same race conditions.

related: #20082