### PR TITLE
popupwin: accept opacity: in completepopup/previewpopup

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2393,6 +2393,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 		close		show close button: "on" (default) or "off"
 		height		maximum height of the popup
 		highlight	popup highlight group (default: PmenuSel)
+		opacity		opacity percentage 0-100 (default 100, fully
+				opaque).  When less than 100, content beneath
+				the popup shows through.
 		resize		show resize handle: "on" (default) or "off"
 		shadow		"off" (default) or "on" using |hl-PmenuShadow|
 		width		maximum width of the popup
@@ -2400,6 +2403,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	Example: >
 		:set completepopup=height:10,border:single,highlight:InfoPopup
 		:set completepopup=width:60,border:custom:─;│;─;│;┌;┐;┘;└
+		:set completepopup=border:round,opacity:80
 <
 	When "align" is set to "item", the popup is positioned near the
 	selected item and moves as the selection changes.

--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -960,6 +960,9 @@ settings.  The option is a comma-separated list of values:
 			the value is "on", it must be set after border.
 	height		maximum height of the popup
 	highlight	highlight group of the popup (default is Pmenu)
+	opacity		opacity percentage 0-100 (default 100, fully opaque).
+			When less than 100, content beneath the popup shows
+			through.
 	resize		show resize handle: "on" (default) or "off"
 	shadow		"off" (default) or "on" using |hl-PmenuShadow|
 	width		maximum width of the popup
@@ -968,6 +971,7 @@ Example: >
 	:set previewpopup=height:10,width:60
 	:set previewpopup=border:single,borderhilight:PmenuBorder
 	:set previewpopup=border:custom:─;│;─;│;┌;┐;┘;└
+	:set previewpopup=border:round,opacity:80
 
 A few peculiarities:
 - If the file is in a buffer already, it will be re-used.  This will allow for

--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -73,11 +73,11 @@ static char *(p_kpc_protocol_values[]) = {"none", "mok2", "kitty", NULL};
 #ifdef FEAT_PROP_POPUP
 // Note: Keep this in sync with parse_popup_option()
 static char *(p_popup_cpp_option_values[]) = {"align:", "border:",
-    "borderhighlight:", "close:", "height:", "highlight:", "resize:",
-    "shadow:", "width:", NULL};
+    "borderhighlight:", "close:", "height:", "highlight:", "opacity:",
+    "resize:", "shadow:", "width:", NULL};
 static char *(p_popup_pvp_option_values[]) = {"border:",
-    "borderhighlight:", "close:", "height:", "highlight:", "resize:",
-    "shadow:", "width:", NULL};
+    "borderhighlight:", "close:", "height:", "highlight:", "opacity:",
+    "resize:", "shadow:", "width:", NULL};
 static char *(p_popup_option_on_off_values[]) = {"on", "off", NULL};
 static char *(p_popup_cpp_border_values[]) = {"single", "double", "round",
     "ascii", "on", "off", "custom:", NULL};

--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -2161,6 +2161,29 @@ parse_popup_option(win_T *wp, int is_preview)
 	    if (wp != NULL && menu)
 		wp->w_popup_flags |= POPF_INFO_MENU;
 	}
+	else if (STRNCMP(s, "opacity:", 8) == 0)
+	{
+	    if (dig != p || x < 0 || x > 100)
+		return FAIL;
+	    if (wp != NULL)
+	    {
+		if (x == 0)
+		{
+		    wp->w_popup_flags |= POPF_OPACITY;
+		    wp->w_popup_blend = 100;
+		}
+		else if (x < 100)
+		{
+		    wp->w_popup_flags |= POPF_OPACITY;
+		    wp->w_popup_blend = 100 - x;
+		}
+		else
+		{
+		    wp->w_popup_flags &= ~POPF_OPACITY;
+		    wp->w_popup_blend = 0;
+		}
+	    }
+	}
 	else
 	    return FAIL;
     }

--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -2167,21 +2167,11 @@ parse_popup_option(win_T *wp, int is_preview)
 		return FAIL;
 	    if (wp != NULL)
 	    {
-		if (x == 0)
-		{
+		if (x < 100)
 		    wp->w_popup_flags |= POPF_OPACITY;
-		    wp->w_popup_blend = 100;
-		}
-		else if (x < 100)
-		{
-		    wp->w_popup_flags |= POPF_OPACITY;
-		    wp->w_popup_blend = 100 - x;
-		}
 		else
-		{
 		    wp->w_popup_flags &= ~POPF_OPACITY;
-		    wp->w_popup_blend = 0;
-		}
+		wp->w_popup_blend = 100 - x;
 	    }
 	}
 	else

--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -674,8 +674,10 @@ func Test_set_completion_string_values()
   set completepopup=border:on,opacity:100
   call assert_fails('set completepopup=opacity:101', 'E474:')
   call assert_fails('set completepopup=opacity:abc', 'E474:')
+  call assert_fails('set completepopup=opacity:-10', 'E474:')
   set previewpopup=opacity:30
   call assert_fails('set previewpopup=opacity:200', 'E474:')
+  call assert_fails('set previewpopup=opacity:-10', 'E474:')
 
   set previewpopup& completepopup&
 

--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -663,6 +663,20 @@ func Test_set_completion_string_values()
   call feedkeys(":set completepopup=height:10,align:\<Tab>\<C-B>\"\<CR>", 'xt')
   call assert_equal('"set completepopup=height:10,align:item', @:)
   call assert_equal([], getcompletion('set completepopup=bogusname:', 'cmdline'))
+
+  " opacity: numeric, 0..100 only
+  call assert_true(index(getcompletion('set completepopup=', 'cmdline'),
+        \ 'opacity:') >= 0)
+  call assert_true(index(getcompletion('set previewpopup=', 'cmdline'),
+        \ 'opacity:') >= 0)
+  set completepopup=border:on,opacity:0
+  set completepopup=border:on,opacity:50
+  set completepopup=border:on,opacity:100
+  call assert_fails('set completepopup=opacity:101', 'E474:')
+  call assert_fails('set completepopup=opacity:abc', 'E474:')
+  set previewpopup=opacity:30
+  call assert_fails('set previewpopup=opacity:200', 'E474:')
+
   set previewpopup& completepopup&
 
   " diffopt: special handling of algorithm:<alg_list> and inline:<inline_type>


### PR DESCRIPTION
`popup_create()` already supports an `opacity` field, and `'pumopt'` exposes `opacity:` for the popup menu, but the same key was not accepted by `'completepopup'` and `'previewpopup'`. Setting `:set completepopup=border:on,opacity:50` therefore failed with `E474`.