### PR TITLE
cmdexpand: allow dict items in customlist completion

### DIFF
--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -1693,7 +1693,17 @@ For the "custom" argument, the function should return the completion
 candidates one per line in a newline separated string.
 							*E1303*
 For the "customlist" argument, the function should return the completion
-candidates as a Vim List.  Non-string items in the list are ignored.
+candidates as a Vim List.  Each item may be either a string or a |Dictionary|.
+A Dictionary item may have the following keys:
+	word	(required) the completion text
+	kind	short kind text (one or two characters), shown in the popup
+		menu when 'wildoptions' contains "pum"
+	menu	extra text shown after the match in the popup menu
+	info	long description shown in the info popup; the |+popup| feature
+		is required to display it
+Items that are neither a string nor a Dictionary, and Dictionary items without
+a "word" key, are ignored.  When 'wildoptions' does not contain "pum", only
+"word" is shown.
 
 The function arguments are:
 	ArgLead		the leading portion of the argument currently being

--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -1695,7 +1695,11 @@ candidates one per line in a newline separated string.
 For the "customlist" argument, the function should return the completion
 candidates as a Vim List.  Each item may be either a string or a |Dictionary|.
 A Dictionary item may have the following keys:
-	word	(required) the completion text
+	word	(required) the text inserted into the command line when the
+		item is selected
+	abbr	alternative text shown in the popup menu in place of "word",
+		when 'wildoptions' contains "pum"; useful when the inserted
+		text and the displayed text should differ
 	kind	short kind text (one or two characters), shown in the popup
 		menu when 'wildoptions' contains "pum"
 	menu	extra text shown after the match in the popup menu

--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -1703,8 +1703,8 @@ A Dictionary item may have the following keys:
 	kind	short kind text (one or two characters), shown in the popup
 		menu when 'wildoptions' contains "pum"
 	menu	extra text shown after the match in the popup menu
-	info	long description shown in the info popup; the |+popup| feature
-		is required to display it
+	info	long description shown in the info popup; the |+popupwin|
+		feature is required to display it
 Items that are neither a string nor a Dictionary, and Dictionary items without
 a "word" key, are ignored.  When 'wildoptions' does not contain "pum", only
 "word" is shown.

--- a/src/cmdexpand.c
+++ b/src/cmdexpand.c
@@ -412,7 +412,10 @@ cmdline_pum_create(
     compl_match_arraysize = numMatches;
     for (int i = 0; i < numMatches; i++)
     {
-	compl_match_array[i].pum_text = SHOW_MATCH(i);
+	compl_match_array[i].pum_text = (xp->xp_files_abbr != NULL
+				    && xp->xp_files_abbr[i] != NULL)
+					? xp->xp_files_abbr[i]
+					: SHOW_MATCH(i);
 	compl_match_array[i].pum_info = xp->xp_files_info != NULL
 					    ? xp->xp_files_info[i] : NULL;
 	compl_match_array[i].pum_extra = xp->xp_files_menu != NULL
@@ -1189,6 +1192,11 @@ ExpandCleanup(expand_T *xp)
 {
     if (xp->xp_numfiles >= 0)
     {
+	if (xp->xp_files_abbr != NULL)
+	{
+	    FreeWild(xp->xp_numfiles, xp->xp_files_abbr);
+	    xp->xp_files_abbr = NULL;
+	}
 	if (xp->xp_files_kind != NULL)
 	{
 	    FreeWild(xp->xp_numfiles, xp->xp_files_kind);
@@ -1442,6 +1450,11 @@ showmatches(
     if (xp->xp_numfiles == -1)
     {
 	FreeWild(numMatches, matches);
+	if (xp->xp_files_abbr != NULL)
+	{
+	    FreeWild(numMatches, xp->xp_files_abbr);
+	    xp->xp_files_abbr = NULL;
+	}
 	if (xp->xp_files_kind != NULL)
 	{
 	    FreeWild(numMatches, xp->xp_files_kind);
@@ -4157,6 +4170,7 @@ ExpandUserList(
     list_T      *retlist;
     listitem_T	*li;
     garray_T	ga;
+    garray_T	ga_abbr;
     garray_T	ga_kind;
     garray_T	ga_menu;
     garray_T	ga_info;
@@ -4170,6 +4184,7 @@ ExpandUserList(
 	return FAIL;
 
     ga_init2(&ga, sizeof(char *), 3);
+    ga_init2(&ga_abbr, sizeof(char *), 3);
     ga_init2(&ga_kind, sizeof(char *), 3);
     ga_init2(&ga_menu, sizeof(char *), 3);
     ga_init2(&ga_info, sizeof(char *), 3);
@@ -4177,6 +4192,7 @@ ExpandUserList(
     FOR_ALL_LIST_ITEMS(retlist, li)
     {
 	char_u	*p = NULL;
+	char_u	*abbr = NULL;
 	char_u	*kind = NULL;
 	char_u	*menu = NULL;
 	char_u	*info = NULL;
@@ -4196,10 +4212,11 @@ ExpandUserList(
 	    if (word == NULL)
 		continue;  // "word" is required
 	    p = vim_strsave(word);
+	    abbr = dict_get_string(d, "abbr", TRUE);
 	    kind = dict_get_string(d, "kind", TRUE);
 	    menu = dict_get_string(d, "menu", TRUE);
 	    info = dict_get_string(d, "info", TRUE);
-	    if (kind != NULL || menu != NULL || info != NULL)
+	    if (abbr != NULL || kind != NULL || menu != NULL || info != NULL)
 		have_extra = TRUE;
 	}
 	else
@@ -4209,11 +4226,13 @@ ExpandUserList(
 	    break;
 
 	if (ga_grow(&ga, 1) == FAIL
+		|| ga_grow(&ga_abbr, 1) == FAIL
 		|| ga_grow(&ga_kind, 1) == FAIL
 		|| ga_grow(&ga_menu, 1) == FAIL
 		|| ga_grow(&ga_info, 1) == FAIL)
 	{
 	    vim_free(p);
+	    vim_free(abbr);
 	    vim_free(kind);
 	    vim_free(menu);
 	    vim_free(info);
@@ -4221,6 +4240,7 @@ ExpandUserList(
 	}
 
 	((char_u **)ga.ga_data)[ga.ga_len++] = p;
+	((char_u **)ga_abbr.ga_data)[ga_abbr.ga_len++] = abbr;
 	((char_u **)ga_kind.ga_data)[ga_kind.ga_len++] = kind;
 	((char_u **)ga_menu.ga_data)[ga_menu.ga_len++] = menu;
 	((char_u **)ga_info.ga_data)[ga_info.ga_len++] = info;
@@ -4231,6 +4251,7 @@ ExpandUserList(
     *numMatches = ga.ga_len;
     if (have_extra && ga.ga_len > 0)
     {
+	xp->xp_files_abbr = (char_u **)ga_abbr.ga_data;
 	xp->xp_files_kind = (char_u **)ga_kind.ga_data;
 	xp->xp_files_menu = (char_u **)ga_menu.ga_data;
 	xp->xp_files_info = (char_u **)ga_info.ga_data;
@@ -4238,6 +4259,9 @@ ExpandUserList(
     else
     {
 	// No extra info collected; free the placeholder NULL entries.
+	for (i = 0; i < ga_abbr.ga_len; i++)
+	    vim_free(((char_u **)ga_abbr.ga_data)[i]);
+	vim_free(ga_abbr.ga_data);
 	for (i = 0; i < ga_kind.ga_len; i++)
 	    vim_free(((char_u **)ga_kind.ga_data)[i]);
 	vim_free(ga_kind.ga_data);

--- a/src/cmdexpand.c
+++ b/src/cmdexpand.c
@@ -1091,6 +1091,26 @@ ExpandOne(
     if (xp->xp_numfiles != -1 && mode != WILD_ALL && mode != WILD_LONGEST)
     {
 	FreeWild(xp->xp_numfiles, xp->xp_files);
+	if (xp->xp_files_abbr != NULL)
+	{
+	    FreeWild(xp->xp_numfiles, xp->xp_files_abbr);
+	    xp->xp_files_abbr = NULL;
+	}
+	if (xp->xp_files_kind != NULL)
+	{
+	    FreeWild(xp->xp_numfiles, xp->xp_files_kind);
+	    xp->xp_files_kind = NULL;
+	}
+	if (xp->xp_files_menu != NULL)
+	{
+	    FreeWild(xp->xp_numfiles, xp->xp_files_menu);
+	    xp->xp_files_menu = NULL;
+	}
+	if (xp->xp_files_info != NULL)
+	{
+	    FreeWild(xp->xp_numfiles, xp->xp_files_info);
+	    xp->xp_files_info = NULL;
+	}
 	xp->xp_numfiles = -1;
 	VIM_CLEAR(xp->xp_orig);
 

--- a/src/cmdexpand.c
+++ b/src/cmdexpand.c
@@ -413,9 +413,12 @@ cmdline_pum_create(
     for (int i = 0; i < numMatches; i++)
     {
 	compl_match_array[i].pum_text = SHOW_MATCH(i);
-	compl_match_array[i].pum_info = NULL;
-	compl_match_array[i].pum_extra = NULL;
-	compl_match_array[i].pum_kind = NULL;
+	compl_match_array[i].pum_info = xp->xp_files_info != NULL
+					    ? xp->xp_files_info[i] : NULL;
+	compl_match_array[i].pum_extra = xp->xp_files_menu != NULL
+					    ? xp->xp_files_menu[i] : NULL;
+	compl_match_array[i].pum_kind = xp->xp_files_kind != NULL
+					    ? xp->xp_files_kind[i] : NULL;
 	compl_match_array[i].pum_user_abbr_hlattr = -1;
 	compl_match_array[i].pum_user_kind_hlattr = -1;
     }
@@ -1186,6 +1189,21 @@ ExpandCleanup(expand_T *xp)
 {
     if (xp->xp_numfiles >= 0)
     {
+	if (xp->xp_files_kind != NULL)
+	{
+	    FreeWild(xp->xp_numfiles, xp->xp_files_kind);
+	    xp->xp_files_kind = NULL;
+	}
+	if (xp->xp_files_menu != NULL)
+	{
+	    FreeWild(xp->xp_numfiles, xp->xp_files_menu);
+	    xp->xp_files_menu = NULL;
+	}
+	if (xp->xp_files_info != NULL)
+	{
+	    FreeWild(xp->xp_numfiles, xp->xp_files_info);
+	    xp->xp_files_info = NULL;
+	}
 	FreeWild(xp->xp_numfiles, xp->xp_files);
 	xp->xp_numfiles = -1;
     }
@@ -1422,7 +1440,24 @@ showmatches(
     }
 
     if (xp->xp_numfiles == -1)
+    {
 	FreeWild(numMatches, matches);
+	if (xp->xp_files_kind != NULL)
+	{
+	    FreeWild(numMatches, xp->xp_files_kind);
+	    xp->xp_files_kind = NULL;
+	}
+	if (xp->xp_files_menu != NULL)
+	{
+	    FreeWild(numMatches, xp->xp_files_menu);
+	    xp->xp_files_menu = NULL;
+	}
+	if (xp->xp_files_info != NULL)
+	{
+	    FreeWild(numMatches, xp->xp_files_info);
+	    xp->xp_files_info = NULL;
+	}
+    }
 
     return EXPAND_OK;
 }
@@ -4122,6 +4157,11 @@ ExpandUserList(
     list_T      *retlist;
     listitem_T	*li;
     garray_T	ga;
+    garray_T	ga_kind;
+    garray_T	ga_menu;
+    garray_T	ga_info;
+    int		have_extra = FALSE;
+    int		i;
 
     *matches = NULL;
     *numMatches = 0;
@@ -4130,31 +4170,84 @@ ExpandUserList(
 	return FAIL;
 
     ga_init2(&ga, sizeof(char *), 3);
+    ga_init2(&ga_kind, sizeof(char *), 3);
+    ga_init2(&ga_menu, sizeof(char *), 3);
+    ga_init2(&ga_info, sizeof(char *), 3);
     // Loop over the items in the list.
     FOR_ALL_LIST_ITEMS(retlist, li)
     {
-	char_u	*p;
+	char_u	*p = NULL;
+	char_u	*kind = NULL;
+	char_u	*menu = NULL;
+	char_u	*info = NULL;
 
-	if (li->li_tv.v_type != VAR_STRING || li->li_tv.vval.v_string == NULL)
-	    continue;  // Skip non-string items and empty strings
+	if (li->li_tv.v_type == VAR_STRING)
+	{
+	    if (li->li_tv.vval.v_string == NULL)
+		continue;  // Skip empty strings
+	    p = vim_strsave(li->li_tv.vval.v_string);
+	}
+	else if (li->li_tv.v_type == VAR_DICT
+				    && li->li_tv.vval.v_dict != NULL)
+	{
+	    dict_T	*d = li->li_tv.vval.v_dict;
+	    char_u	*word = dict_get_string(d, "word", FALSE);
 
-	p = vim_strsave(li->li_tv.vval.v_string);
+	    if (word == NULL)
+		continue;  // "word" is required
+	    p = vim_strsave(word);
+	    kind = dict_get_string(d, "kind", TRUE);
+	    menu = dict_get_string(d, "menu", TRUE);
+	    info = dict_get_string(d, "info", TRUE);
+	    if (kind != NULL || menu != NULL || info != NULL)
+		have_extra = TRUE;
+	}
+	else
+	    continue;  // Skip other types
+
 	if (p == NULL)
 	    break;
 
-	if (ga_grow(&ga, 1) == FAIL)
+	if (ga_grow(&ga, 1) == FAIL
+		|| ga_grow(&ga_kind, 1) == FAIL
+		|| ga_grow(&ga_menu, 1) == FAIL
+		|| ga_grow(&ga_info, 1) == FAIL)
 	{
 	    vim_free(p);
+	    vim_free(kind);
+	    vim_free(menu);
+	    vim_free(info);
 	    break;
 	}
 
-	((char_u **)ga.ga_data)[ga.ga_len] = p;
-	++ga.ga_len;
+	((char_u **)ga.ga_data)[ga.ga_len++] = p;
+	((char_u **)ga_kind.ga_data)[ga_kind.ga_len++] = kind;
+	((char_u **)ga_menu.ga_data)[ga_menu.ga_len++] = menu;
+	((char_u **)ga_info.ga_data)[ga_info.ga_len++] = info;
     }
     list_unref(retlist);
 
     *matches = ga.ga_data;
     *numMatches = ga.ga_len;
+    if (have_extra && ga.ga_len > 0)
+    {
+	xp->xp_files_kind = (char_u **)ga_kind.ga_data;
+	xp->xp_files_menu = (char_u **)ga_menu.ga_data;
+	xp->xp_files_info = (char_u **)ga_info.ga_data;
+    }
+    else
+    {
+	// No extra info collected; free the placeholder NULL entries.
+	for (i = 0; i < ga_kind.ga_len; i++)
+	    vim_free(((char_u **)ga_kind.ga_data)[i]);
+	vim_free(ga_kind.ga_data);
+	for (i = 0; i < ga_menu.ga_len; i++)
+	    vim_free(((char_u **)ga_menu.ga_data)[i]);
+	vim_free(ga_menu.ga_data);
+	for (i = 0; i < ga_info.ga_len; i++)
+	    vim_free(((char_u **)ga_info.ga_data)[i]);
+	vim_free(ga_info.ga_data);
+    }
     return OK;
 }
 #endif

--- a/src/cmdexpand.c
+++ b/src/cmdexpand.c
@@ -1025,6 +1025,31 @@ find_longest_match(expand_T *xp, int options)
     return ss;
 }
 
+    static void
+free_xp_files_extra(expand_T *xp, int numfiles)
+{
+    if (xp->xp_files_abbr != NULL)
+    {
+	FreeWild(numfiles, xp->xp_files_abbr);
+	xp->xp_files_abbr = NULL;
+    }
+    if (xp->xp_files_kind != NULL)
+    {
+	FreeWild(numfiles, xp->xp_files_kind);
+	xp->xp_files_kind = NULL;
+    }
+    if (xp->xp_files_menu != NULL)
+    {
+	FreeWild(numfiles, xp->xp_files_menu);
+	xp->xp_files_menu = NULL;
+    }
+    if (xp->xp_files_info != NULL)
+    {
+	FreeWild(numfiles, xp->xp_files_info);
+	xp->xp_files_info = NULL;
+    }
+}
+
 /*
  * Do wildcard expansion on the string "str".
  * Chars that should not be expanded must be preceded with a backslash.
@@ -1091,26 +1116,7 @@ ExpandOne(
     if (xp->xp_numfiles != -1 && mode != WILD_ALL && mode != WILD_LONGEST)
     {
 	FreeWild(xp->xp_numfiles, xp->xp_files);
-	if (xp->xp_files_abbr != NULL)
-	{
-	    FreeWild(xp->xp_numfiles, xp->xp_files_abbr);
-	    xp->xp_files_abbr = NULL;
-	}
-	if (xp->xp_files_kind != NULL)
-	{
-	    FreeWild(xp->xp_numfiles, xp->xp_files_kind);
-	    xp->xp_files_kind = NULL;
-	}
-	if (xp->xp_files_menu != NULL)
-	{
-	    FreeWild(xp->xp_numfiles, xp->xp_files_menu);
-	    xp->xp_files_menu = NULL;
-	}
-	if (xp->xp_files_info != NULL)
-	{
-	    FreeWild(xp->xp_numfiles, xp->xp_files_info);
-	    xp->xp_files_info = NULL;
-	}
+	free_xp_files_extra(xp, xp->xp_numfiles);
 	xp->xp_numfiles = -1;
 	VIM_CLEAR(xp->xp_orig);
 
@@ -1212,26 +1218,7 @@ ExpandCleanup(expand_T *xp)
 {
     if (xp->xp_numfiles >= 0)
     {
-	if (xp->xp_files_abbr != NULL)
-	{
-	    FreeWild(xp->xp_numfiles, xp->xp_files_abbr);
-	    xp->xp_files_abbr = NULL;
-	}
-	if (xp->xp_files_kind != NULL)
-	{
-	    FreeWild(xp->xp_numfiles, xp->xp_files_kind);
-	    xp->xp_files_kind = NULL;
-	}
-	if (xp->xp_files_menu != NULL)
-	{
-	    FreeWild(xp->xp_numfiles, xp->xp_files_menu);
-	    xp->xp_files_menu = NULL;
-	}
-	if (xp->xp_files_info != NULL)
-	{
-	    FreeWild(xp->xp_numfiles, xp->xp_files_info);
-	    xp->xp_files_info = NULL;
-	}
+	free_xp_files_extra(xp, xp->xp_numfiles);
 	FreeWild(xp->xp_numfiles, xp->xp_files);
 	xp->xp_numfiles = -1;
     }
@@ -1470,26 +1457,7 @@ showmatches(
     if (xp->xp_numfiles == -1)
     {
 	FreeWild(numMatches, matches);
-	if (xp->xp_files_abbr != NULL)
-	{
-	    FreeWild(numMatches, xp->xp_files_abbr);
-	    xp->xp_files_abbr = NULL;
-	}
-	if (xp->xp_files_kind != NULL)
-	{
-	    FreeWild(numMatches, xp->xp_files_kind);
-	    xp->xp_files_kind = NULL;
-	}
-	if (xp->xp_files_menu != NULL)
-	{
-	    FreeWild(numMatches, xp->xp_files_menu);
-	    xp->xp_files_menu = NULL;
-	}
-	if (xp->xp_files_info != NULL)
-	{
-	    FreeWild(numMatches, xp->xp_files_info);
-	    xp->xp_files_info = NULL;
-	}
+	free_xp_files_extra(xp, numMatches);
     }
 
     return EXPAND_OK;
@@ -4242,10 +4210,8 @@ ExpandUserList(
 	else
 	    continue;  // Skip other types
 
-	if (p == NULL)
-	    break;
-
-	if (ga_grow(&ga, 1) == FAIL
+	if (p == NULL
+		|| ga_grow(&ga, 1) == FAIL
 		|| ga_grow(&ga_abbr, 1) == FAIL
 		|| ga_grow(&ga_kind, 1) == FAIL
 		|| ga_grow(&ga_menu, 1) == FAIL

--- a/src/structs.h
+++ b/src/structs.h
@@ -678,6 +678,14 @@ typedef struct expand
     int		xp_selected;		// selected index in completion
     char_u	*xp_orig;		// originally expanded string
     char_u	**xp_files;		// list of files
+    char_u	**xp_files_kind;	// optional parallel array of "kind"
+					// strings; NULL if unused
+    char_u	**xp_files_menu;	// optional parallel array of "menu"
+					// strings (shown after the match);
+					// NULL if unused
+    char_u	**xp_files_info;	// optional parallel array of "info"
+					// strings (shown in info popup);
+					// NULL if unused
     char_u	*xp_line;		// text being completed
 #define EXPAND_BUF_LEN 256
     char_u	xp_buf[EXPAND_BUF_LEN];	// buffer for returned match

--- a/src/structs.h
+++ b/src/structs.h
@@ -678,6 +678,9 @@ typedef struct expand
     int		xp_selected;		// selected index in completion
     char_u	*xp_orig;		// originally expanded string
     char_u	**xp_files;		// list of files
+    char_u	**xp_files_abbr;	// optional parallel array of display
+					// strings (override xp_files for the
+					// pum text); NULL if unused
     char_u	**xp_files_kind;	// optional parallel array of "kind"
 					// strings; NULL if unused
     char_u	**xp_files_menu;	// optional parallel array of "menu"

--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -4624,9 +4624,21 @@ func Test_customlist_dict_completion()
   call feedkeys(":DictCmd a\<Tab>\<C-B>\"\<CR>", 'xt')
   call assert_equal('"DictCmd apple', @:)
 
+  " "abbr" overrides display only; "word" is what gets inserted.
+  func DictCompAbbr(A, L, P)
+    return [{'word': 'apple', 'abbr': 'APPLE🍎'}]
+  endfunc
+  call assert_equal(['apple'],
+        \ getcompletion('', 'customlist,DictCompAbbr'))
+  command -nargs=1 -complete=customlist,DictCompAbbr DictAbbrCmd echo <q-args>
+  call feedkeys(":DictAbbrCmd \<Tab>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"DictAbbrCmd apple', @:)
+
+  delcommand DictAbbrCmd
   delcommand DictCmd
   delfunc DictComp
   delfunc DictCompMissingWord
+  delfunc DictCompAbbr
 endfunc
 
 func Test_custom_completion_with_glob()

--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -4594,6 +4594,41 @@ func Test_custom_completion()
   delfunc Check_customlist_completion
 endfunc
 
+" Test that 'customlist' completion accepts dict items with extra info
+" (kind/menu/info) for display in the popup menu, and that string items still
+" work in the same list.
+func Test_customlist_dict_completion()
+  func DictComp(A, L, P)
+    return [
+          \ {'word': 'apple',  'kind': 'f', 'menu': 'fruit',     'info': 'A red fruit'},
+          \ {'word': 'banana', 'kind': 'f', 'menu': 'fruit',     'info': 'A yellow fruit'},
+          \ {'word': 'carrot', 'kind': 'v', 'menu': 'vegetable', 'info': 'An orange vegetable'},
+          \ 'plain',
+          \ ]
+  endfunc
+  command -nargs=1 -complete=customlist,DictComp DictCmd echo <q-args>
+
+  " getcompletion() returns only the "word" of each item; string items pass
+  " through unchanged.
+  call assert_equal(['apple', 'banana', 'carrot', 'plain'],
+        \ getcompletion('', 'customlist,DictComp'))
+
+  " Items missing a "word" key are silently skipped.
+  func DictCompMissingWord(A, L, P)
+    return [{'kind': 'x'}, {'word': 'ok'}]
+  endfunc
+  call assert_equal(['ok'],
+        \ getcompletion('', 'customlist,DictCompMissingWord'))
+
+  " Tab completion still selects the word.
+  call feedkeys(":DictCmd a\<Tab>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"DictCmd apple', @:)
+
+  delcommand DictCmd
+  delfunc DictComp
+  delfunc DictCompMissingWord
+endfunc
+
 func Test_custom_completion_with_glob()
   func TestGlobComplete(A, L, P)
     return split(glob('Xglob*'), "\n")


### PR DESCRIPTION
Extend `customlist` completion so each returned list item may be a Dict with `word` (required) plus optional `abbr`, `kind`, `menu`, and `info` keys, surfaced through the cmdline pum the same way `complete()` does in insert mode. String items keep working as before.


https://github.com/user-attachments/assets/8a042d8e-35b5-4b0c-98ab-c83f2abb9885

