### PR TITLE
Add 'shortmess' option to hide undo/redo messages

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -8044,6 +8044,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 		search count statistics.  The maximum limit can be set with
 		the 'maxsearchcount' option, see also |searchcount()|
 		function.
+	  u	don't give |:undo|,|:redo| messages; for example,	*shm-u*
+		"1 line less; before #1  1 second ago", "Already at oldest
+		change" or "Already at newest change"
 
 	This gives you the opportunity to avoid that a change between buffers
 	requires you to hit <Enter>, but still gives as useful a message as

--- a/src/option.h
+++ b/src/option.h
@@ -277,8 +277,9 @@ typedef enum {
 #define SHM_RECORDING	'q'		// short recording message
 #define SHM_FILEINFO	'F'		// no file info messages
 #define SHM_SEARCHCOUNT  'S'		// no search stats: '[1/10]'
+#define SHM_UNDO	'u'		// undo messages
 #define SHM_POSIX       "AS"		// POSIX value
-#define SHM_ALL		"rmfixlnwaWtToOsAIcCqFS" // all possible flags for 'shm'
+#define SHM_ALL		"rmfixlnwaWtToOsAIcCqFSu" // all possible flags for 'shm'
 #define SHM_LEN		30		// max length of all flags together
 					// plus a NUL character
 

--- a/src/testdir/test_messages.vim
+++ b/src/testdir/test_messages.vim
@@ -837,4 +837,37 @@ func Test_fileinfo_after_last_bd()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_undo_messages()
+  enew
+
+  " Normal undo/redo messages
+  redir => result
+  call setline(1, 'foo')
+  undo
+  undo
+  redo
+  redo
+  redir END
+  let msg_list = split(result, "\n")
+  call assert_match("^1 line less; before #1", msg_list[0])
+  call assert_equal("Already at oldest change", msg_list[1])
+  call assert_match("^1 more line; after #1", msg_list[2])
+  call assert_equal("Already at newest change", msg_list[3])
+
+  " Ignore undo/redo messages
+  redir => result
+  set shortmess+=u
+  call setline(1, 'foo')
+  undo
+  undo
+  redo
+  redo
+  redir END
+  let msg_list = split(result, "\n")
+  call assert_equal([], msg_list)
+
+  bwipe!
+  set shortmess&
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/undo.c
+++ b/src/undo.c
@@ -2262,7 +2262,8 @@ u_doit(int startcount)
 		beep_flush();
 		if (count == startcount - 1)
 		{
-		    msg(_("Already at oldest change"));
+		    if (!shortmess(SHM_UNDO))
+			msg(_("Already at oldest change"));
 		    return;
 		}
 		break;
@@ -2277,7 +2278,8 @@ u_doit(int startcount)
 		beep_flush();	// nothing to redo
 		if (count == startcount - 1)
 		{
-		    msg(_("Already at newest change"));
+		    if (!shortmess(SHM_UNDO))
+			msg(_("Already at newest change"));
 		    return;
 		}
 		break;
@@ -2530,10 +2532,12 @@ undo_time(
 
 	if (closest == closest_start)
 	{
-	    if (step < 0)
-		msg(_("Already at oldest change"));
-	    else
-		msg(_("Already at newest change"));
+	    if (!shortmess(SHM_UNDO)) {
+		if (step < 0)
+		    msg(_("Already at oldest change"));
+		else
+		    msg(_("Already at newest change"));
+	    }
 	    return;
 	}
 
@@ -2996,7 +3000,8 @@ u_undo_end(
 #endif
 
     if (global_busy	    // no messages now, wait until global is finished
-	    || !messaging())  // 'lazyredraw' set, don't do messages now
+	    || !messaging() // 'lazyredraw' set, don't do messages now
+            || shortmess(SHM_UNDO))
 	return;
 
     if (curbuf->b_ml.ml_flags & ML_EMPTY)

--- a/src/undo.c
+++ b/src/undo.c
@@ -3001,7 +3001,7 @@ u_undo_end(
 
     if (global_busy	    // no messages now, wait until global is finished
 	    || !messaging() // 'lazyredraw' set, don't do messages now
-            || shortmess(SHM_UNDO))
+	    || shortmess(SHM_UNDO))
 	return;
 
     if (curbuf->b_ml.ml_flags & ML_EMPTY)

--- a/src/undo.c
+++ b/src/undo.c
@@ -2532,7 +2532,8 @@ undo_time(
 
 	if (closest == closest_start)
 	{
-	    if (!shortmess(SHM_UNDO)) {
+	    if (!shortmess(SHM_UNDO))
+	    {
 		if (step < 0)
 		    msg(_("Already at oldest change"));
 		else


### PR DESCRIPTION
#20049 

I have added `u` to `shortmess` option.

It disables undo/redo messages.