### PR TITLE
blob: speed up parsing of 0z... blob literals

### DIFF
--- a/src/blob.c
+++ b/src/blob.c
@@ -333,23 +333,31 @@ string2blob(char_u *str)
 {
     blob_T  *blob = blob_alloc();
     char_u  *s = str;
+    char_u  *dst;
+    int	    max_bytes;
 
     if (blob == NULL)
 	return NULL;
     if (s[0] != '0' || (s[1] != 'z' && s[1] != 'Z'))
 	goto failed;
     s += 2;
+    // Upper bound on the number of bytes: every two hex chars become one byte.
+    max_bytes = (int)(STRLEN(s) / 2);
+    if (max_bytes > 0 && ga_grow(&blob->bv_ga, max_bytes) == FAIL)
+	goto failed;
+    dst = (char_u *)blob->bv_ga.ga_data;
     while (vim_isxdigit(*s))
     {
 	if (!vim_isxdigit(s[1]))
 	    goto failed;
-	ga_append(&blob->bv_ga, (hex2nr(s[0]) << 4) + hex2nr(s[1]));
+	*dst++ = (hex2nr(s[0]) << 4) + hex2nr(s[1]);
 	s += 2;
 	if (*s == '.' && vim_isxdigit(s[1]))
 	    ++s;
     }
     if (*skipwhite(s) != NUL)
 	goto failed;  // text after final digit
+    blob->bv_ga.ga_len = (int)(dst - (char_u *)blob->bv_ga.ga_data);
 
     ++blob->bv_refcount;
     return blob;

--- a/src/typval.c
+++ b/src/typval.c
@@ -2438,11 +2438,27 @@ eval_number(
     if (**arg == '0' && ((*arg)[1] == 'z' || (*arg)[1] == 'Z'))
     {
 	char_u  *bp;
+	char_u  *dst = NULL;
 	blob_T  *blob = NULL;  // init for gcc
 
 	// Blob constant: 0z0123456789abcdef
 	if (evaluate)
+	{
 	    blob = blob_alloc();
+	    if (blob != NULL)
+	    {
+		// Upper bound on the number of bytes: every two hex chars
+		// in the rest of the input become one byte.
+		int max_bytes = (int)(STRLEN(*arg + 2) / 2);
+		if (max_bytes > 0
+			&& ga_grow(&blob->bv_ga, max_bytes) == FAIL)
+		{
+		    VIM_CLEAR(blob);
+		    return FAIL;
+		}
+		dst = (char_u *)blob->bv_ga.ga_data;
+	    }
+	}
 	for (bp = *arg + 2; vim_isxdigit(bp[0]); bp += 2)
 	{
 	    if (!vim_isxdigit(bp[1]))
@@ -2456,13 +2472,15 @@ eval_number(
 		return FAIL;
 	    }
 	    if (blob != NULL)
-		ga_append(&blob->bv_ga,
-			     (hex2nr(*bp) << 4) + hex2nr(*(bp+1)));
+		*dst++ = (hex2nr(*bp) << 4) + hex2nr(*(bp + 1));
 	    if (bp[2] == '.' && vim_isxdigit(bp[3]))
 		++bp;
 	}
 	if (blob != NULL)
+	{
+	    blob->bv_ga.ga_len = (int)(dst - (char_u *)blob->bv_ga.ga_data);
 	    rettv_blob_set(rettv, blob);
+	}
 	*arg = bp;
     }
     else


### PR DESCRIPTION
Parsing a `0z...` blob literal calls `ga_append()` per byte, which makes a non-inlined function call into `ga_grow()` for a one-byte capacity check on every byte. For large blob literals consumed via `eval()` or read from a viminfo file, that overhead dominates.

Estimate the byte count up front from the remaining input length (every two hex chars become one byte), `ga_grow()` once, and write each parsed byte directly through a local `char_u *`. Same fix in `eval_number()` (`typval.c`) and `string2blob()` (`blob.c`).

Benchmark: `eval('0z' .. repeat('ab', 4194304))`, 5 iterations, total seconds, median of 3 runs:

| | Before | After | Speedup |
|---|---:|---:|---:|
| plain (no separators)        | 0.128 | 0.114 | 1.12x |
| dotted (`.` every 4 bytes)   | 0.134 | 0.123 | 1.10x |

`make test_blob`, `test_eval_stuff`, `test_viminfo` all pass.