### PR TITLE
testdir: fix flaky Test_shortmess_F3() on MS-Windows

### DIFF
--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -1450,7 +1450,7 @@ func Test_shortmess_F3()
   if has('nanotime')
     sleep 10m
   else
-    sleep 2
+    sleep 3
   endif
   call writefile(['bar'], 'X_dummy')
   bprev
@@ -1460,7 +1460,7 @@ func Test_shortmess_F3()
   if has('nanotime')
     sleep 10m
   else
-    sleep 2
+    sleep 3
   endif
   call writefile(['baz'], 'X_dummy')
   checktime


### PR DESCRIPTION
On MS-Windows `time_differs()` in `fileio.c` treats the file mtime as unchanged unless `st_mtime` differs by more than 1 second (to tolerate FAT-style 2-second roundoff). When `Test_shortmess_F3()` runs without `nanotime` it relies on a 2-second sleep between two `writefile()` calls, but if the two writes happen to straddle a single second boundary (e.g. first write at 100.999s rounds to 100, second at 102.001s rounds to 102, but a slightly different alignment yields 100 and 101), the integer second difference is exactly 1 and `time_differs()` returns false, so `checktime` does not reload the buffer.

Bumping the sleep to 3 seconds makes the integer mtime difference always greater than 1 regardless of alignment.

Observed in https://github.com/vim/vim/actions/runs/25237179105/job/74005748453 on the `windows (NORMAL, mingw, no, yes, x64)` job.