### PR TITLE
win32: skip mch_update_cursor() in cursor_visible() for vtp mode

### DIFF
--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -7104,9 +7104,19 @@ cursor_visible(BOOL fVisible)
     s_cursor_visible = fVisible;
 
     if (vtp_working)
+    {
+	// In vtp mode, visibility is controlled solely by DECTCEM.  Skip
+	// mch_update_cursor() since shape is independent of visibility and
+	// re-emitting DECSCUSR can cause the terminal to briefly redisplay
+	// the cursor while a redraw is in progress.
 	vtp_printf("\033[?25%c", fVisible ? 'h' : 'l');
+	return;
+    }
 
 # ifdef MCH_CURSOR_SHAPE
+    // Non-vtp Windows console: SetConsoleCursorInfo() consults
+    // s_cursor_visible inside mch_set_cursor_shape(), so the call is needed
+    // to apply the new visibility.
     mch_update_cursor();
 # endif
 }


### PR DESCRIPTION
In vtp (ConPTY) mode the cursor visibility is already controlled by DECTCEM, but cursor_visible() then calls mch_update_cursor() which re-emits DECSCUSR on every visibility toggle. The shape is independent of visibility, so this write is redundant; some terminals interpret the trailing DECSCUSR as a cue to redisplay the cursor, which can show up as a brief flash during a line redraw bracketed by cursor_off()/cursor_on(). Skip the call in vtp mode while keeping the non-vtp path unchanged (SetConsoleCursorInfo() there still needs to consult s_cursor_visible).