### PR TITLE
runtime(netrw): fix off-by-one bug in "Unmark all" mapping

### DIFF
--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -6348,7 +6348,7 @@ function s:NetrwUnMarkFile(islocal)
     endif
 
     let ibuf= 1
-    while ibuf < bufnr("$")
+    while ibuf <= bufnr("$")
         if exists("s:netrwmarkfilelist_".ibuf)
             unlet s:netrwmarkfilelist_{ibuf}
             unlet s:netrwmarkfilemtch_{ibuf}

--- a/src/testdir/test_plugin_netrw.vim
+++ b/src/testdir/test_plugin_netrw.vim
@@ -138,6 +138,33 @@ function Test_NetrwValidateHostname(hostname) abort
     return s:NetrwValidateHostname(a:hostname)
 endfunction
 
+" Test unmarking all files via s:NetrwUnMarkFile()
+function Test_NetrwUnMarkFile()
+    " set up: init global and buffer-local mark lists
+    new
+
+    " initializing the global mark list, the loop handles the buffer-local
+    let s:netrwmarkfilelist = ['test_file']
+
+    " making sure every buffer has a mark list and match pattern
+    let ibuf = 1
+    while ibuf <= bufnr('$')
+        let s:netrwmarkfilelist_{ibuf} = ['test_mark']
+        let s:netrwmarkfilemtch_{ibuf} = 'test_mark'
+        let ibuf = ibuf + 1
+    endwhile
+
+    call s:NetrwUnMarkFile(1)
+
+    call assert_false(exists('s:netrwmarkfilelist'), 'Global list should be wiped')
+    call assert_false(exists('s:netrwmarkfilelist_' . bufnr('$')), 'Last buffer-local list should be wiped')
+    call assert_false(exists('s:netrwmarkfilemtch_' . bufnr('$')), 'Last buffer-local match str should be wiped')
+    call assert_false(exists('s:netrwmarkfilelist_1'), 'First buffer-local list should be wiped')
+    call assert_false(exists('s:netrwmarkfilemtch_1'), 'First buffer-local match str should be wiped')
+
+    " wipe out the test buffer
+    bw
+endfunction
 " }}}
 END
 
@@ -643,6 +670,10 @@ func Test_netrw_Home_tilde()
   Explore ~
   call assert_match('Netrw Directory Listing', getline(2))
   bw!
+endfunc
+
+func Test_netrw_unmark_all()
+  call Test_NetrwUnMarkFile()
 endfunc
 
 " vim:ts=8 sts=2 sw=2 et


### PR DESCRIPTION
`s:NetrwUnMarkFile: called via mu map; unmarks *all* marked files, both global and buffer-local`

When the function loops through buffers to clear `s:netrwmarkfilelist_#` and `s:netrwmarkfilemtch_#`, it skips the last one at `bufnr('$')`, messing up mark highlights and causing other functions that operate on those arrays (like delete or rename) to target stale marked files.

The `bufnr()` help page says that `bufnr("$")` returns the highest buffer number of existing buffers, so `while ibuf < bufnr("$")` does not clear the last buffer-local arrays.

To reproduce:
- Just opening a fresh Vim and running `:Ex` opens a netrw buffer at the highest number. Then, typing `mu` after marking some files triggers the mark highlight bug, and finally typing `D` would act like calling the delete function against the previous marked files, as the buffer-local arrays where not touched by `s:NetrwUnMarkFile`.