### PR TITLE
termdebug tests race on breakpoint sign placement

### DIFF
--- a/src/testdir/test_plugin_termdebug.vim
+++ b/src/testdir/test_plugin_termdebug.vim
@@ -162,10 +162,10 @@ func Test_termdebug_basic()
   Break 9
   call term_wait(gdb_buf)
   redraw!
-  call assert_equal([
+  call WaitForAssert({-> assert_equal([
         \ {'lnum': 9, 'id': 1014, 'name': 'debugBreakpoint1.0',
         \  'priority': 110, 'group': 'TermDebug'}],
-        \ sign_getplaced('', #{group: 'TermDebug'})[0].signs)
+        \ sign_getplaced('', #{group: 'TermDebug'})[0].signs)})
   Run
   call term_wait(gdb_buf, 400)
   redraw!
@@ -324,12 +324,12 @@ func Test_termdebug_tbreak()
   call term_wait(gdb_buf)
   redraw!
   " both temporary and normal breakpoint signs were displayed...
-  call assert_equal([
+  call WaitForAssert({-> assert_equal([
         \ {'lnum': temp_bp_line, 'id': 1014, 'name': 'debugBreakpoint1.0',
         \  'priority': 110, 'group': 'TermDebug'},
         \ {'lnum': bp_line, 'id': 2014, 'name': 'debugBreakpoint2.0',
         \  'priority': 110, 'group': 'TermDebug'}],
-        \ sign_getplaced('', #{group: 'TermDebug'})[0].signs)
+        \ sign_getplaced('', #{group: 'TermDebug'})[0].signs)})
 
   Run
   call term_wait(gdb_buf, 400)
@@ -717,10 +717,10 @@ func Test_termdebug_toggle_break()
 
   call term_wait(gdb_buf)
   redraw!
-  call assert_equal([
+  call WaitForAssert({-> assert_equal([
         \ {'lnum': bp_line, 'id': 1014, 'name': 'debugBreakpoint1.0',
         \  'priority': 110, 'group': 'TermDebug'}],
-        \ sign_getplaced('', #{group: 'TermDebug'})[0].signs)
+        \ sign_getplaced('', #{group: 'TermDebug'})[0].signs)})
 
   RunOrContinue
   call term_wait(gdb_buf, 400)


### PR DESCRIPTION
Problem:  Test_termdebug_tbreak(), Test_termdebug_basic(), and
          Test_termdebug_toggle_break() use synchronous assert_equal()
          to check breakpoint signs immediately after sending commands
          to gdb.  On slow CI (ASAN, ARM64, macOS) gdb may not have
          processed the response yet, causing the sign to be missing.
Solution: Wrap the three assertions in WaitForAssert() to poll until
          the signs are placed, matching the pattern already used by
          the other assertions in the same tests.
          (Jesse Rosenstock)

Co-authored-by: Gemini