### PR TITLE
fix: correct typos in comments, docs, and file headers

### DIFF
--- a/runtime/doc/ft_mp.txt
+++ b/runtime/doc/ft_mp.txt
@@ -25,7 +25,7 @@ MetaPost documents, including syntax coloring, indentation, and completion.
 Defining indentation rules for METAFONT and MetaPost code is tricky and
 somewhat subjective, because the syntax is quite liberal. The plugin uses some
 heuristics that work well most of the time, but in particular cases you may
-want to to override the automatic rules, so that the manually defined
+want to override the automatic rules, so that the manually defined
 indentation is preserved by commands like `gg=G`.
 
 This can be achieved by appending `%>`, `%<`, `%=` or `%!` to a line to

--- a/runtime/ftplugin/ptx.vim
+++ b/runtime/ftplugin/ptx.vim
@@ -1,5 +1,5 @@
 " Vim filetype plugin file
-" Language:	Nvidia PTX (Parellel Thread Execution)
+" Language:	Nvidia PTX (Parallel Thread Execution)
 " Maintainer:	Yinzuo Jiang <jiangyinzuo@foxmail.com>
 " Last Change:	2024-12-05
 

--- a/runtime/ftplugin/readline.vim
+++ b/runtime/ftplugin/readline.vim
@@ -26,7 +26,7 @@ if exists("loaded_matchit") && !exists("b:match_words")
 endif
 
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
-  let b:browsefilter = "Readline Intialization Files (inputrc, .inputrc)\tinputrc;*.inputrc\n"
+  let b:browsefilter = "Readline Initialization Files (inputrc, .inputrc)\tinputrc;*.inputrc\n"
   if has("win32")
     let b:browsefilter ..= "All Files (*.*)\t*\n"
   else

--- a/runtime/indent/cdl.vim
+++ b/runtime/indent/cdl.vim
@@ -71,7 +71,7 @@ fun! CdlGetIndent(lnum)
   " One 'closing' element at the beginning of the line has already reduced the
   " indent, but 'else', 'elseif' & 'then' increment it for the next line.
   " '=' at the beginning already has the right indent (increased for
-  " asignments).
+  " assignments).
   let f = -1
   let inicio = matchend(line, '^\c\s*\(else\a*\|then\|endif\|/[*/]\|[);={]\)')
   if inicio > 0

--- a/runtime/indent/javascriptreact.vim
+++ b/runtime/indent/javascriptreact.vim
@@ -1,2 +1,2 @@
-" Placeholder for backwards compatilibity: .jsx used to stand for JavaScript.
+" Placeholder for backwards compatibility: .jsx used to stand for JavaScript.
 runtime! indent/javascript.vim

--- a/runtime/indent/rust.vim
+++ b/runtime/indent/rust.vim
@@ -4,7 +4,7 @@
 " Last Change:      2023-09-11
 " 2024 Jul 04 by Vim Project: use shiftwidth() instead of hard-coding shifted values #15138
 " 2025 Dec 29 by Vim Project: clean up
-" 2025 Dec 31 by Vim Project: correcly indent after nested array literal #19042
+" 2025 Dec 31 by Vim Project: correctly indent after nested array literal #19042
 " 2026 Jan 28 by Vim Project: fix indentation when a string literal contains 'if' #19265
 
 " For bugs, patches and license go to https://github.com/rust-lang/rust.vim

--- a/runtime/indent/sh.vim
+++ b/runtime/indent/sh.vim
@@ -233,7 +233,7 @@ function! s:is_array(line)
 endfunction
 
 function! s:is_in_block(line)
-  " checks whether a:line is whithin a 
+  " checks whether a:line is within a
   " block e.g. a shell function
   " foo() {
   " ..

--- a/runtime/indent/stylus.vim
+++ b/runtime/indent/stylus.vim
@@ -97,7 +97,7 @@ function! GetStylusIndent()
   let line     = substitute(getline(lnum),'[\s()]\+$','','')  " get last line strip ending whitespace
   let cline    = substitute(substitute(getline(v:lnum),'\s\+$','',''),'^\s\+','','')  " get current line, trimmed
   let lastcol  = strlen(line)  " get last col in prev line
-  let line     = substitute(line,'^\s\+','','')  " then remove preceeding whitespace
+  let line     = substitute(line,'^\s\+','','')  " then remove preceding whitespace
   let indent   = indent(lnum)  " get indent on prev line
   let cindent  = indent(v:lnum)  " get indent on current line
   let increase = indent + &sw  " increase indent by the shift width

--- a/runtime/indent/typescriptreact.vim
+++ b/runtime/indent/typescriptreact.vim
@@ -1,2 +1,2 @@
-" Placeholder for backwards compatilibity: .tsx used to stand for TypeScript.
+" Placeholder for backwards compatibility: .tsx used to stand for TypeScript.
 runtime! indent/typescript.vim

--- a/src/normal.c
+++ b/src/normal.c
@@ -6513,7 +6513,7 @@ set_op_var(int optype)
 /*
  * Handle linewise operator "dd", "yy", etc.
  *
- * "_" is is a strange motion command that helps make operators more logical.
+ * "_" is a strange motion command that helps make operators more logical.
  * It is actually implemented, but not documented in the real Vi.  This motion
  * command actually refers to "the current line".  Commands like "dd" and "yy"
  * are really an alternate form of "d_" and "y_".  It does accept a count, so

--- a/src/vim9cmds.c
+++ b/src/vim9cmds.c
@@ -215,7 +215,7 @@ compile_lock_unlock(
 	// These checks are reminiscent of the variable_exists function.
 	// But most of the matches require special handling.
 
-	// If bare name is is locally accessible, except for local var,
+	// If bare name is locally accessible, except for local var,
 	// then put it on the stack to use with ISN_LOCKUNLOCK.
 	// This could be v.memb, v[idx_key]; bare class variable,
 	// function arg. The item on the stack, will be passed


### PR DESCRIPTION
Fix several typos found across source comments, documentation, indent plugins, and filetype plugin headers

Changes:
- src/normal.c, src/vim9cmds.c: remove duplicate words ("is is")
- runtime/doc/ft_mp.txt: remove duplicate word ("to to")
- runtime/indent/: fix asignments, compatilibity, correcly, whithin, preceeding in comments
- runtime/ftplugin/ptx.vim: Parellel → Parallel
- runtime/ftplugin/readline.vim: Intialization → Initialization