### PR TITLE
 Cannot set 'path' option via modeline

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1,4 +1,4 @@
-*options.txt*	For Vim version 9.2.  Last change: 2026 May 03
+*options.txt*	For Vim version 9.2.  Last change: 2026 May 04
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -6798,9 +6798,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 		:let &path = &path .. "," .. substitute($INCL, ';', ',', 'g')
 <	Replace the ';' with a ':' or whatever separator is used.  Note that
 	this doesn't work when $INCL contains a comma or white space.
-
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
 
 						*'perldll'*
 'perldll'		string	(default depends on the build)

--- a/src/optiondefs.h
+++ b/src/optiondefs.h
@@ -1958,7 +1958,7 @@ static struct vimoption options[] =
 			    (char_u *)&p_pm, PV_NONE,
 			    did_set_backupext_or_patchmode, NULL,
 			    {(char_u *)"", (char_u *)0L} SCTX_INIT},
-    {"path",	    "pa",   P_STRING|P_EXPAND|P_VI_DEF|P_SECURE|P_COMMA|P_NODUP,
+    {"path",	    "pa",   P_STRING|P_EXPAND|P_VI_DEF|P_COMMA|P_NODUP,
 			    (char_u *)&p_path, PV_PATH, NULL, NULL,
 			    {
 #if defined(AMIGA) || defined(MSWIN)

--- a/src/testdir/test_find_complete.vim
+++ b/src/testdir/test_find_complete.vim
@@ -165,9 +165,15 @@ endfunc
 func Test_find_completion_backtick_in_path()
   CheckUnix
   CheckExecutable id
+  set nomodelinestrict modeline
 
+  let lines =<< trim END
+    // vim: set path+=`id>Xrce_marker` :
+  END
+
+  call writefile(lines, 'Xpoc.c', 'D')
   new Xpoc.c
-  setl path+=`id>Xrce_marker`
+  call assert_match('`id>Xrce_marker`', &path)
   " Triggering completion must not execute the backtick command.
   call getcompletion('', 'file_in_path')
   call assert_false(filereadable('Xrce_marker'))
@@ -176,6 +182,7 @@ func Test_find_completion_backtick_in_path()
 
   bwipe!
   call delete('Xrce_marker')
+  set modelinestrict& modeline&
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_modeline.vim
+++ b/src/testdir/test_modeline.vim
@@ -665,18 +665,4 @@ func Test_modeline_strict_cannot_be_set_from_modeline()
   let &modeline = modeline
 endfunc
 
-" Verify that backticks in 'path' set from a modeline are not executed
-func Test_path_modeline()
-  let lines =<< trim END
-    // vim: set path+=foobar :
-  END
-  call writefile(lines, 'Xpoc.c', 'D')
-
-  set nomodelinestrict modeline
-  call assert_fails('split Xpoc.c', 'E520:')
-
-  bwipe!
-  set modelinestrict& modeline&
-endfunc
-
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  Cannot set 'path' option via modeline (zeertzjq, after v9.2.0435)
Solution: Revert the part that disallows setting 'path' via modeline