### PR TITLE
Fix comment in getchar.c

### DIFF
--- a/src/getchar.c
+++ b/src/getchar.c
@@ -2205,7 +2205,7 @@ vgetc(void)
 
 #ifdef FEAT_EVAL
 /*
- * Handle the InsertCharPre autocommand.
+ * Handle the KeyInputPre autocommand.
  * "c" is the character that was typed.
  * Return new input character.
  */


### PR DESCRIPTION
The comment for `do_key_input_pre()` function says that it handles the InsertCharPre autocommand, but what it actually handles is the KeyInputPre autocommand.  This PR corrects the comment.

P.S. This PR only has a really really small change without any effect on Vim's behavior, so feel free to include this change in another patch and no credit is necessary ;)