### PR TITLE
runtime(netrw): fix bookmark path expansion for marked files

### DIFF
--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -8989,11 +8989,10 @@ function s:MakeBookmark(fname)
     if index(g:netrw_bookmarklist,a:fname) == -1
         " curdir not currently in g:netrw_bookmarklist, so include it
         if isdirectory(s:NetrwFile(a:fname)) && a:fname !~ '/$'
-            call add(g:netrw_bookmarklist,a:fname.'/')
-        elseif a:fname !~ '/'
-            call add(g:netrw_bookmarklist,getcwd()."/".a:fname)
+            " Directory without a trailing slash
+            call add(g:netrw_bookmarklist, s:NetrwFile(a:fname) . '/')
         else
-            call add(g:netrw_bookmarklist,a:fname)
+            call add(g:netrw_bookmarklist, s:NetrwFile(a:fname))
         endif
         call sort(g:netrw_bookmarklist)
     endif

--- a/src/testdir/test_plugin_netrw.vim
+++ b/src/testdir/test_plugin_netrw.vim
@@ -165,6 +165,13 @@ function Test_NetrwUnMarkFile()
     " wipe out the test buffer
     bw
 endfunction
+
+function Test_MakeBookmark(netrw_curdir, fname)
+  new
+  let b:netrw_curdir = a:netrw_curdir
+  call s:MakeBookmark(a:fname)
+  bw
+endfunction
 " }}}
 END
 
@@ -674,6 +681,40 @@ endfunc
 
 func Test_netrw_unmark_all()
   call Test_NetrwUnMarkFile()
+endfunc
+
+" Creating a bookmark from a marked file should use b:netrw_curdir as head directory
+func Test_netrw_bookmark_marked_file()
+  let save_keepdir = g:netrw_keepdir
+  let save_workdir = getcwd()
+  let save_bookmarklist = exists('g:netrw_bookmarklist') ? g:netrw_bookmarklist : v:null
+
+  " Make sure Vim's working directory diverge from Netrw's
+  let g:netrw_keepdir = 1
+  let g:netrw_bookmarklist = []
+  let test_workdir = 'Xtest_workdir'
+  let test_netrw_curdir = test_workdir . '/Xtest_netrw_curdir'
+  call mkdir(test_netrw_curdir, 'p')
+  call writefile([], test_netrw_curdir . '/test_file')
+
+  execute 'cd ' . test_workdir
+  call Test_MakeBookmark(test_netrw_curdir, 'test_file')
+
+  call assert_equal(1, len(g:netrw_bookmarklist))
+  call assert_match(test_netrw_curdir . '/test_file', g:netrw_bookmarklist[0])
+
+  " Tear down
+  execute 'cd ' . save_workdir
+  call delete(test_workdir, 'rf')
+
+  let g:netrw_keepdir = save_keepdir
+  if save_bookmarklist is v:null
+    unlet g:netrw_bookmarklist
+  else
+    let g:netrw_bookmarklist = save_bookmarklist
+  endif
+
+  bw!
 endfunc
 
 " vim:ts=8 sts=2 sw=2 et


### PR DESCRIPTION
Problem:  the `g:netrw_keepdir=1` (default) setting lets Vim and Netrw have their own current directories. When creating a bookmark from a marked file while these directories are out of sync, results in a bookmark with the wrong path, as the `s:MakeBookmark()` function incorrectly appends the marked file tail to `getcwd()`.
Solution: replace the `getcwd()` logic with a call to the `s:NetrwFile()`, which "ensures that netrw's idea of the current directory is used" for the given file path.

The fix also makes that bookmarking `../` or `./` correctly expands to their expected absolute paths, rather than saving the literal dots to the bookmark list.

fixes #10481