### PR TITLE
did_set_shellpipe_redir() in wrong file

### DIFF
--- a/src/cmdexpand.c
+++ b/src/cmdexpand.c
@@ -4183,7 +4183,7 @@ expand_process_user_list(
 	{
 	    if (tv->vval.v_string == NULL)
 		continue;  // Skip NULL strings
-	    p = vim_strsave(li->li_tv.vval.v_string);
+	    p = vim_strsave(tv->vval.v_string);
 	}
 	else if (tv->v_type == VAR_DICT && tv->vval.v_dict != NULL)
 	{

--- a/src/option.c
+++ b/src/option.c
@@ -4527,44 +4527,6 @@ did_set_maxsearchcount(optset_T *args UNUSED)
 #undef MAX_SEARCH_COUNT
 }
 
-/*
- * Validate 'shellpipe'/'shellredir' option.
- */
-    char *
-did_set_shellpipe_redir(optset_T *args)
-{
-    char_u	*p;
-    bool	seen = false;
-
-    for (p = args->os_newval.string; *p != NUL; ++p)
-    {
-	if (*p != '%')
-	    continue;
-
-	if (p[1] == NUL)
-	    return e_invalid_format_string_single_percent_s;
-
-	if (p[1] == '%')
-	{
-	    ++p;    // skip second %
-	    continue;
-	}
-
-	if (p[1] == 's')
-	{
-	    if (seen)
-		return e_invalid_format_string_single_percent_s;
-
-	    seen = true;
-	    ++p;    // consume 's'
-	    continue;
-	}
-	return e_invalid_format_string_single_percent_s;
-    }
-    return NULL;
-}
-
-
 #if defined(BACKSLASH_IN_FILENAME)
 /*
  * Process the updated 'shellslash' option value.

--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -4180,6 +4180,43 @@ expand_set_sessionoptions(
 #endif
 
 /*
+ * Validate 'shellpipe'/'shellredir' option.
+ */
+    char *
+did_set_shellpipe_redir(optset_T *args)
+{
+    char_u	*p;
+    bool	seen = false;
+
+    for (p = args->os_newval.string; *p != NUL; ++p)
+    {
+	if (*p != '%')
+	    continue;
+
+	if (p[1] == NUL)
+	    return e_invalid_format_string_single_percent_s;
+
+	if (p[1] == '%')
+	{
+	    ++p;    // skip second %
+	    continue;
+	}
+
+	if (p[1] == 's')
+	{
+	    if (seen)
+		return e_invalid_format_string_single_percent_s;
+
+	    seen = true;
+	    ++p;    // consume 's'
+	    continue;
+	}
+	return e_invalid_format_string_single_percent_s;
+    }
+    return NULL;
+}
+
+/*
  * The 'shortmess' option is changed.
  */
     char *

--- a/src/proto/option.pro
+++ b/src/proto/option.pro
@@ -65,7 +65,6 @@ char *did_set_pyxversion(optset_T *args);
 char *did_set_readonly(optset_T *args);
 char *did_set_scrollbind(optset_T *args);
 char *did_set_maxsearchcount(optset_T *args);
-char *did_set_shellpipe_redir(optset_T *args);
 char *did_set_shellslash(optset_T *args);
 char *did_set_shiftwidth_tabstop(optset_T *args);
 char *did_set_showtabline(optset_T *args);

--- a/src/proto/optionstr.pro
+++ b/src/proto/optionstr.pro
@@ -152,6 +152,7 @@ char *did_set_selectmode(optset_T *args);
 int expand_set_selectmode(optexpand_T *args, int *numMatches, char_u ***matches);
 char *did_set_sessionoptions(optset_T *args);
 int expand_set_sessionoptions(optexpand_T *args, int *numMatches, char_u ***matches);
+char *did_set_shellpipe_redir(optset_T *args);
 char *did_set_shortmess(optset_T *args);
 int expand_set_shortmess(optexpand_T *args, int *numMatches, char_u ***matches);
 char *did_set_showbreak(optset_T *args);


### PR DESCRIPTION
Problem:  did_set_shellpipe_redir() is a callback for a string option,
          but is not in optionstr.c (after 9.2.0458).
Solution: Move it to optionstr.c. Also add missing change from patch
          9.2.0455.
