### PR TITLE
patch 9.2.XXXX: modeline: foldmarker cannot be set with modelinestrict

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -6216,6 +6216,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 		'filetype'
 		'foldcolumn'
 		'foldenable'
+		'foldmarker'
 		'foldmethod'
 		'modifiable'
 		'readonly'

--- a/src/option.c
+++ b/src/option.c
@@ -1554,6 +1554,7 @@ static char *modeline_whitelist[] =
     "filetype",
     "foldcolumn",
     "foldenable",
+    "foldmarker",
     "foldmethod",
     "modifiable",
     "readonly",

--- a/src/testdir/test_modeline.vim
+++ b/src/testdir/test_modeline.vim
@@ -563,11 +563,12 @@ func Test_modeline_strict_allowed()
   set modeline modelinestrict
 
   " Whitelisted options should work
-  call writefile(['vim: set ts=2 sw=4 et :'], 'Xmodeline_strict', 'D')
+  call writefile(['vim: set ts=2 sw=4 et foldmarker=[,]:'], 'Xmodeline_strict', 'D')
   split Xmodeline_strict
   call assert_equal(2, &ts)
   call assert_equal(4, &sw)
   call assert_equal(1, &et)
+  call assert_equal('[,]', &foldmarker)
   bwipe!
 
   " 'filetype' should work


### PR DESCRIPTION
Problem:  modeline: foldmarker cannot be set with modelinestrict
          (after v9.2.0350)
Solution: Add foldmarker option to the whitelist

fixes: #20028