### PR TITLE
Not able to use legacy expression evaluation in a vim9script insert-mode map

### DIFF
--- a/src/map.c
+++ b/src/map.c
@@ -277,6 +277,8 @@ map_add(
     else
     {
 	mp->m_script_ctx = current_sctx;
+	if (cmdmod.cmod_flags & CMOD_LEGACY)
+	    mp->m_script_ctx.sc_version = 1;
 	mp->m_script_ctx.sc_lnum += SOURCING_LNUM;
     }
 #endif
@@ -871,6 +873,8 @@ do_map(
 #ifdef FEAT_EVAL
 				    mp->m_expr = expr;
 				    mp->m_script_ctx = current_sctx;
+				    if (cmdmod.cmod_flags & CMOD_LEGACY)
+					mp->m_script_ctx.sc_version = 1;
 				    mp->m_script_ctx.sc_lnum += SOURCING_LNUM;
 #endif
 				    mp_result[keyround - 1] = mp;
@@ -1822,11 +1826,10 @@ eval_map_expr(
     save_cursor = curwin->w_cursor;
     save_msg_col = msg_col;
     save_msg_row = msg_row;
+
+    current_sctx.sc_version = mp->m_script_ctx.sc_version;
     if (mp->m_script_ctx.sc_version == SCRIPT_VERSION_VIM9)
-    {
 	current_sctx.sc_sid = mp->m_script_ctx.sc_sid;
-	current_sctx.sc_version = SCRIPT_VERSION_VIM9;
-    }
 
     // Note: the evaluation may make "mp" invalid.
     p = eval_to_string(expr, FALSE, FALSE);

--- a/src/testdir/test_vim9_cmd.vim
+++ b/src/testdir/test_vim9_cmd.vim
@@ -2145,5 +2145,16 @@ def Test_syntax_enable_clear()
   syntax clear
 enddef
 
+" Test for using legacy expression evaluation in a vim9script map
+def Test_map_legacy_expr()
+  var lines =<< trim END
+    legacy inoremap <expr> <F2> 'hello' . 'world'
+    new
+    feedkeys("a\<F2>", 'xt')
+    assert_equal(['helloworld'], getline(1, '$'))
+    bw!
+  END
+  v9.CheckDefAndScriptSuccess(lines)
+enddef
 
 " vim: ts=8 sw=2 sts=2 expandtab tw=80 fdm=marker


### PR DESCRIPTION

When the `legacy` command modifier is used with an insert mode map in a vim9 script, treat the map as defined in a legacy script.

Fixes #20176.