### PR TITLE
Win32: W/A for assert error on GUI

### DIFF
--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -8100,7 +8100,8 @@ mch_fopen(const char *name, const char *mode)
     vim_free(wm);
 
 #if defined(DEBUG) && _MSC_VER >= 1400
-    _set_fmode(oldMode);
+    if (oldMode != 0)
+	_set_fmode(oldMode);
 #endif
     return f;
 }


### PR DESCRIPTION
If Vim is built with debug mode, gvim causes an assertion error and stops working when running on Visual Studio Debugger.
Stop calling _set_fmode() if not needed.