### PR TITLE
runtime(sh): treat 'name=()' as array assignment, not a function

### DIFF
--- a/runtime/syntax/sh.vim
+++ b/runtime/syntax/sh.vim
@@ -25,6 +25,7 @@
 "		2026 Mar 23 improve matching of function definitions #19638
 "		2026 Apr 02 improve matching of function definitions #19849
 "		2026 Apr 19 improve detection of special variables #20016
+"		2026 May 10 exclude '=' from bash function-name candidates #20183
 " }}}
 " Version:		208
 " Former URL:		http://www.drchip.org/astronaut/vim/index.html#SYNTAX_SH
@@ -667,12 +668,12 @@ ShFoldFunctions syn region shFunctionSubSh	matchgroup=shFunctionSubShRegion star
 
 if exists("b:is_bash")
     syn keyword shFunctionKey coproc
-    syn match shFunctionCmdOne	"\%#=1^\s*\zs\%(\%(\<\k\+\|[^()<>|&$;\t ]\+\)\+\)\@>\s*()\ze\_s*\%(\%(for\|case\|select\|if\|while\|until\)\>\|\[\[\s\|((\)"	skipwhite skipnl nextgroup=@shFunctionCmds
-    syn match shFunctionCmdTwo	"\%#=1\%(\%(\<\k\+\>\|[^()<>|&$;\t ]\+\)\+\)\@>\ze\s*\%(()\ze\)\=\_s*\%(\<\%(for\|case\|select\|if\|while\|until\)\>\|\[\[\s\|((\)"	contained skipwhite skipnl nextgroup=@shFunctionCmds
-    syn match shFunctionOne	"\%#=1^\s*\zs\%(\%(\<\k\+\|[^()<>|&$;\t ]\+\)\+\)\@>\s*()\ze\_s*{"	skipwhite skipnl nextgroup=shFunctionExpr
-    syn match shFunctionTwo	"\%#=1\%(\%(\<\k\+\|[^()<>|&$;\t ]\+\)\+\)\@>\ze\s*\%(()\ze\)\=\_s*{"	contained skipwhite skipnl nextgroup=shFunctionExpr
-    syn match shFunctionThree	"\%#=1^\s*\zs\%(\%(\<\k\+\|[^()<>|&$;\t ]\+\)\+\)\@>\s*()\ze\_s*((\@!"	skipwhite skipnl nextgroup=shFunctionSubSh
-    syn match shFunctionFour	"\%#=1\%(\%(\<\k\+\|[^()<>|&$;\t ]\+\)\+\)\@>\ze\s*\%(\%(()\ze\)\=\)\@>\_s*((\@!"	contained skipwhite skipnl nextgroup=shFunctionSubSh
+    syn match shFunctionCmdOne	"\%#=1^\s*\zs\%(\%(\<\k\+\|[^()<>|&$;=\t ]\+\)\+\)\@>\s*()\ze\_s*\%(\%(for\|case\|select\|if\|while\|until\)\>\|\[\[\s\|((\)"	skipwhite skipnl nextgroup=@shFunctionCmds
+    syn match shFunctionCmdTwo	"\%#=1\%(\%(\<\k\+\>\|[^()<>|&$;=\t ]\+\)\+\)\@>\ze\s*\%(()\ze\)\=\_s*\%(\<\%(for\|case\|select\|if\|while\|until\)\>\|\[\[\s\|((\)"	contained skipwhite skipnl nextgroup=@shFunctionCmds
+    syn match shFunctionOne	"\%#=1^\s*\zs\%(\%(\<\k\+\|[^()<>|&$;=\t ]\+\)\+\)\@>\s*()\ze\_s*{"	skipwhite skipnl nextgroup=shFunctionExpr
+    syn match shFunctionTwo	"\%#=1\%(\%(\<\k\+\|[^()<>|&$;=\t ]\+\)\+\)\@>\ze\s*\%(()\ze\)\=\_s*{"	contained skipwhite skipnl nextgroup=shFunctionExpr
+    syn match shFunctionThree	"\%#=1^\s*\zs\%(\%(\<\k\+\|[^()<>|&$;=\t ]\+\)\+\)\@>\s*()\ze\_s*((\@!"	skipwhite skipnl nextgroup=shFunctionSubSh
+    syn match shFunctionFour	"\%#=1\%(\%(\<\k\+\|[^()<>|&$;=\t ]\+\)\+\)\@>\ze\s*\%(\%(()\ze\)\=\)\@>\_s*((\@!"	contained skipwhite skipnl nextgroup=shFunctionSubSh
 elseif exists("b:is_ksh88")
     " AT&T ksh88
     syn match shFunctionCmdOne	"^\s*\zs\h\w*\s*()\ze\_s*\%(\%(for\|case\|select\|if\|while\|until\)\>\|\[\[\s\|((\)"	skipwhite skipnl nextgroup=@shFunctionCmds


### PR DESCRIPTION
Fixes the case from #20183 where the second of two consecutive empty-array assignments was highlighted as if it were a function definition:

```sh
#!/bin/bash
array_a=()
array_b=()
if :; then :; fi
```

`array_a=()` highlights as `shVariable`+`shVarAssign`+`shShellVariables` but `array_b=()` was matched by `shFunctionCmdOne` because the line `array_b=()\nif :; then :; fi` satisfies the bash function-command head pattern: a candidate name, optional whitespace, `()`, then `\_s*` followed by one of `for|case|select|if|while|until|[[|((`.

The candidate-name alternation is `\%(\<\k\+\|[^()<>|&\$;\t ]\+\)\+`. The negated class allows `=`, so `array_b=` is accepted as a function-name run, `()` follows, and the next line starts with `if`. The first row escapes only because the next non-blank token there is `array_b`, which is not in the lookahead set.

The bisect referenced in the issue (`12f6f205521`) wrapped these patterns in `\%(...\)\@>` and pinned the old engine. The candidate-name class itself dates back further; the regression-tagged commit changed visible group attribution which made the symptom obvious.

## Fix

Exclude `=` from the negated character class in the six bash patterns (`shFunctionCmdOne/Two`, `shFunctionOne/Two/Three/Four`). bash function names cannot contain `=` anyway, since the parser would otherwise split the token into `name` and `=value` for an assignment.

## Verification

Before:
```
3:1 a  shFunctionCmdOne
3:2 r  shFunctionCmdOne
...
3:9 (  shFunctionCmdOne
3:10 ) shFunctionCmdOne
```

After:
```
3:1 a  shVariable
3:2 r  shVariable
...
3:8 =  shVarAssign
3:9 (  shShellVariables
3:10 ) shShellVariables
```

Both `array_a=()` and `array_b=()` now highlight identically.

Tested manually against:
- the reporter's exact reproducer
- regular function definitions: `my_fn() { ... }` (still `shFunctionOne`)
- weird names: `weird-name() { ... }` (still `shFunctionOne`)
- command-head bodies: `my_cmd_fn() if true; then echo a; fi` (still `shFunctionCmdOne`)
- multiple consecutive `name=()` lines preceding `if`/`case`/`while` (all now `shVariable`)

`runtime/syntax/testdir/input/sh_functions_bash.sh` does not currently cover empty-array assignments. Happy to add a case with regenerated screendumps if preferred, or leave it for a follow-up.

Closes #20183