### PR TITLE
Initialise di_key at compile time

### DIFF
--- a/src/evalvars.c
+++ b/src/evalvars.c
@@ -37,7 +37,7 @@ static hashtab_T	compat_hashtab;
 #define VV_RO		2	// read-only
 #define VV_RO_SBX	4	// read-only in the sandbox
 
-#define VV_NAME(s, t)	s, {{t, 0, {0}}, 0, {0}}
+#define VV_NAME(s, t)	s, {{t, 0, {0}}, 0, {s}}
 
 typedef struct vimvar vimvar_T;
 
@@ -216,12 +216,6 @@ evalvars_init(void)
     for (i = 0; i < VV_LEN; ++i)
     {
 	p = &vimvars[i];
-	if (STRLEN(p->vv_name) > DICTITEM16_KEY_LEN)
-	{
-	    iemsg("Name too long, increase size of dictitem16_T");
-	    getout(1);
-	}
-	STRCPY(p->vv_di.di_key, p->vv_name);
 	if (p->vv_flags & VV_RO)
 	    p->vv_di.di_flags = DI_FLAGS_RO | DI_FLAGS_FIX;
 	else if (p->vv_flags & VV_RO_SBX)


### PR DESCRIPTION
This PR initialises the `di_key` struct member (in struct `dictitem16_T` which itself is inside `struct vimvar`) at compile time.

This means we can drop the length test and the string copy in `evalvars_init()`. The compiler will truncate the string if it is too long and will give a warning if `-Wexcess-initializers` is set like so (from clang 22.1.4):
``` bash
evalvars.c:54:14: warning: initializer-string for char array is too long [-Wexcess-initializers]
   54 |     {VV_NAME("count0000000000000000",            VAR_NUMBER), NULL, VV_COMPAT+VV_RO},
      |              ^~~~~~~~~~~~~~~~~~~~~~~
1 warning generated.
````


Cheers
John