### PR TITLE
Fix manpage typo in description of '--ttyfail'

### DIFF
--- a/runtime/doc/vim.1
+++ b/runtime/doc/vim.1
@@ -515,7 +515,7 @@ GTK GUI only: Use the GtkPlug mechanism to run gVim in another window.
 During startup write timing messages to the file {fname}.
 .TP
 \-\-ttyfail
-When stdin or stdout is not a a terminal (tty) then exit right away.
+When stdin or stdout is not a terminal (tty) then exit right away.
 .TP
 \-\-version
 Print version information and exit.

--- a/runtime/doc/vim.man
+++ b/runtime/doc/vim.man
@@ -396,7 +396,7 @@ OPTIONS
        --startuptime {file}
                    During startup write timing messages to the file {fname}.
 
-       --ttyfail   When  stdin  or  stdout is not a a terminal (tty) then exit
+       --ttyfail   When  stdin  or  stdout is not a terminal (tty) then exit
                    right away.
 
        --version   Print version information and exit.


### PR DESCRIPTION
This seems to have been accidentally introduced in ce6fe84db21f00fd30b226200dbb02709514871a.