### PR TITLE
popup: keep wincol stable when textprop scrolls above host top

### DIFF
--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -1482,11 +1482,15 @@ popup_geom_restore(win_T *wp, popup_geom_save_T *sv)
 
 /*
  * Compute a screen row for a textprop that has scrolled above the host
- * window's top.  textpos2screenpos() cannot return a row above topline, so we
- * probe at topline to fill the screen_{scol,ccol,ecol} column mapping, then
- * extrapolate a (possibly-negative) row by counting how many buffer lines lie
- * between the prop and topline.  The popup_topoff clip path then turns the
+ * window's top.  textpos2screenpos() cannot return a row above topline, so
+ * compute the virtual column directly from the prop's *own* line and then
+ * extrapolate a (possibly-negative) row by counting how many buffer lines
+ * lie between the prop and topline.  The popup_topoff clip path turns the
  * negative row into a top-clip animation as the prop rolls off the top edge.
+ *
+ * Probing at topline with the prop's tp_col would inherit topline's tab
+ * stops / multi-byte widths, so the popup's wincol would jitter every time
+ * a wider/narrower line scrolled into the topmost position.
  */
     static void
 popup_screenpos_above_top(
@@ -1499,10 +1503,16 @@ popup_screenpos_above_top(
 	int	    *screen_ecol)
 {
     pos_T   probe = *pos;
+    colnr_T scol = 0, ccol = 0, ecol = 0;
+    int	    coloff;
 
-    probe.lnum = prop_win->w_topline;
-    textpos2screenpos(prop_win, &probe,
-			    screen_row, screen_scol, screen_ccol, screen_ecol);
+    probe.lnum = prop_lnum;
+    getvcol(prop_win, &probe, &scol, &ccol, &ecol, 0);
+    coloff = (int)win_col_off(prop_win) - (int)prop_win->w_leftcol
+					+ prop_win->w_wincol + 1;
+    *screen_scol = (int)scol + coloff;
+    *screen_ccol = (int)ccol + coloff;
+    *screen_ecol = (int)ecol + coloff;
     *screen_row = prop_win->w_winrow + 1
 				 - (int)(prop_win->w_topline - prop_lnum);
 }


### PR DESCRIPTION
Follow-up to v9.2.0469 (clipwindow).  popup_screenpos_above_top() probed textpos2screenpos() at prop_win->w_topline using the prop's own tp_col, so the returned screen_scol picked up topline's tab stops and multi-byte widths instead of the prop's actual line.  Once the textprop scrolled above the host's top, the popup's wincol jittered left/right every time a wider or narrower line rotated into the topmost slot.

Compute the virtual column from the prop's actual line via getvcol() and translate it through prop_win's win_col_off / leftcol / wincol; row extrapolation from topline is unchanged.

Repro: drop a textprop in a buffer whose nearby lines mix tabs / multi-byte characters / plain ASCII, attach a clipwindow popup, :sp :sp, then scroll past the prop.  Without the fix, popup_getpos().col oscillates between several values matching the topline content cycle; with the fix it stays put.