### PR TITLE
popup: leftover content after popup_free under layout change

### DIFF
--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -3512,10 +3512,38 @@ f_popup_close(typval_T *argvars, typval_T *rettv UNUSED)
 	popup_close_and_callback(wp, &argvars[1]);
 }
 
+/*
+ * Clear popup_mask entries for the cells covered by "wp" so that
+ * screen_fill / screen_puts calls made before the next update_screen()
+ * (e.g. msg_clr_eos triggered by a status message) are not silently
+ * dropped by skip_for_popup().  Without this the popup's chars survive
+ * on screen until may_update_popup_mask() runs and the affected cells
+ * happen to be redrawn.
+ */
+    static void
+popup_clear_mask_for(win_T *wp)
+{
+    int r, c;
+    int row_start, col_start, row_end, col_end;
+
+    if (popup_mask == NULL || !popup_visible)
+	return;
+
+    row_start = MAX(wp->w_winrow, 0);
+    col_start = MAX(wp->w_wincol, 0);
+    row_end = MIN(wp->w_winrow + popup_height(wp), (int)screen_Rows);
+    col_end = MIN(wp->w_wincol + popup_width(wp), (int)screen_Columns);
+
+    for (r = row_start; r < row_end; ++r)
+	for (c = col_start; c < col_end; ++c)
+	    popup_mask[r * screen_Columns + c] = 0;
+}
+
     void
 popup_hide(win_T *wp)
 {
     popup_area_T	old_area;
+    int			was_visible = (wp->w_popup_flags & POPF_HIDDEN) == 0;
 
 #ifdef FEAT_TERMINAL
     if (error_if_term_popup_window())
@@ -3530,6 +3558,9 @@ popup_hide(win_T *wp)
     // Do not decrement b_nwindows, we still reference the buffer.
     if (wp->w_winrow + popup_height(wp) >= cmdline_row)
 	clear_cmdline = TRUE;
+
+    if (was_visible)
+	popup_clear_mask_for(wp);
 
     if (old_area.active)
 	popup_redraw_exposed_area(&old_area);
@@ -3715,6 +3746,7 @@ f_popup_setbuf(typval_T *argvars, typval_T *rettv UNUSED)
 popup_free(win_T *wp)
 {
     popup_area_T	old_area;
+    int			was_visible = (wp->w_popup_flags & POPF_HIDDEN) == 0;
 
     popup_save_area(wp, &old_area);
 
@@ -3722,6 +3754,9 @@ popup_free(win_T *wp)
     wp->w_buffer->b_locked = FALSE;
     if (wp->w_winrow + popup_height(wp) >= cmdline_row)
 	clear_cmdline = TRUE;
+
+    if (was_visible)
+	popup_clear_mask_for(wp);
 
     popup_redraw_exposed_area(&old_area);
 

--- a/src/testdir/test_popupwin.vim
+++ b/src/testdir/test_popupwin.vim
@@ -5408,4 +5408,52 @@ func Test_popupwin_close_status_redraw()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_popupwin_close_copen_redraw()
+  CheckMSWindows
+  CheckFeature quickfix
+
+  func! s:OpenPopup()
+    call popup_create(repeat(['ZZZZZZZZZ'], 10), #{
+          \ pos: 'botright',
+          \ col: &columns,
+          \ line: &lines,
+          \ filter: function('s:PopupFilter'),
+          \ })
+  endfunc
+  func! s:PopupFilter(winid, key)
+    if a:key ==# 'q'
+      call popup_close(a:winid)
+      copen
+    endif
+    return 1
+  endfunc
+
+  enew!
+  call setline(1, range(1, 30))
+  call setqflist(map(range(1, 20),
+        \ {_, v -> {'bufnr': bufnr('%'), 'lnum': v, 'col': 1, 'text': 'item ' .. v}}))
+
+  call s:OpenPopup()
+  redraw
+  call feedkeys('q', 'xt')
+  redraw
+  cclose
+  redraw
+
+  call s:OpenPopup()
+  redraw
+  call feedkeys('q', 'xt')
+  redraw
+
+  for row in range(&lines - 9, &lines)
+    let line = join(map(range(1, &columns), 'screenstring(row, v:val)'), '')
+    call assert_notmatch('Z', line)
+  endfor
+
+  cclose
+  bwipe!
+  delfunc s:OpenPopup
+  delfunc s:PopupFilter
+endfunc
+
 " vim: shiftwidth=2 sts=2


### PR DESCRIPTION
When a visible popup is freed, popup_redraw_exposed_area is a no-op for non-opacity popups, and the diff-based popup_mask cleanup in may_update_popup_mask() cannot reach cells under it once the popup is gone. A follow-up command that changes the layout (such as copen invoked from the popup's filter) then leaves stale popup content on screen. Force the exposed-area redraw whenever the popup was visible by reusing the existing popup_area_T helpers; the post-free redraw_all_later / popup_mask_refresh path stays gated on opacity as before.

Closes #20178