### PR TITLE
Allow user commands to handle completion argument as a whole (add -nargs=_ command argument)

### DIFF
--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -1608,14 +1608,21 @@ Arguments are considered to be separated by (unescaped) spaces or tabs in this
 context, except when there is one argument, then the white space is part of
 the argument. The difference between the "-nargs=1" and "-nargs=_": >
 
-	func MyCommandComplete(ArgLead, CmdLine, CursorPos)
-	  return ["one value", "two values", "three values"]->matchfuzzy(a:ArgLead)
+	func MyComplete(ArgLead, CmdLine, CursorPos)
+	  return ["one value", "two values", "three values"]
+		\->matchfuzzy(a:ArgLead)
 	endfunc
-	:command -nargs=1 -complete=customlist,MyCommandComplete MyCommand1 echo <q-args>
-	:command -nargs=_ -complete=customlist,MyCommandComplete MyCommand2 echo <q-args>
+	:command -nargs=1 -complete=customlist,MyComplete MyCmd1 echo <q-args>
+	:command -nargs=_ -complete=customlist,MyComplete MyCmd2 echo <q-args>
 
-Completing ":MyCommand1 two va<tab>" will complete with "MyCommand1 two one value".
-Completing ":MyCommand2 two va<tab>" will complete with "MyCommand2 two values".
+Completing ":MyCmd1 two va<tab>" will complete with: >
+
+	:MyCmd1 two one value
+
+Completing ":MyCmd2 two va<tab>" will complete with: >
+
+	:MyCmd2 two values
+
 
 Note that arguments are used as text, not as expressions.  Specifically,
 "s:var" will use the script-local variable in the script where the command was

--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -1593,7 +1593,12 @@ reported if any are supplied).  However, it is possible to specify that the
 command can take arguments, using the -nargs attribute.  Valid cases are:
 
 	-nargs=0    No arguments are allowed (the default)
-	-nargs=1    Exactly one argument is required, it includes spaces
+	-nargs=1    Exactly one argument is required, it includes spaces,
+		    however completion treets white spaces as argument
+		    separation
+	-nargs=_    Exactly one argument is required, it includes spaces
+		    and completion treats white spaces as part of the
+		    argument
 	-nargs=*    Any number of arguments are allowed (0, 1, or many),
 		    separated by white space
 	-nargs=?    0 or 1 arguments are allowed
@@ -1601,7 +1606,16 @@ command can take arguments, using the -nargs attribute.  Valid cases are:
 
 Arguments are considered to be separated by (unescaped) spaces or tabs in this
 context, except when there is one argument, then the white space is part of
-the argument.
+the argument. The difference between the "-nargs=1" and "-nargs=_": >
+
+	func MyCommandComplete(ArgLead, CmdLine, CursorPos)
+	  return ["one value", "two values", "three values"]->matchfuzzy(a:ArgLead)
+	endfunc
+	:command -nargs=1 -complete=customlist,MyCommandComplete MyCommand1 echo <q-args>
+	:command -nargs=_ -complete=customlist,MyCommandComplete MyCommand2 echo <q-args>
+
+Completing ":MyCommand1 two va<tab>" will complete with "MyCommand1 two one value".
+Completing ":MyCommand2 two va<tab>" will complete with "MyCommand2 two values".
 
 Note that arguments are used as text, not as expressions.  Specifically,
 "s:var" will use the script-local variable in the script where the command was

--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -1593,12 +1593,10 @@ reported if any are supplied).  However, it is possible to specify that the
 command can take arguments, using the -nargs attribute.  Valid cases are:
 
 	-nargs=0    No arguments are allowed (the default)
-	-nargs=1    Exactly one argument is required, it includes spaces,
-		    however completion treets white spaces as argument
-		    separation
-	-nargs=_    Exactly one argument is required, it includes spaces
-		    and completion treats white spaces as part of the
-		    argument
+	-nargs=1    Exactly one argument is required, it includes spaces;
+		    completion treets white spaces as argument separation
+	-nargs=_    Exactly one argument is required, it includes spaces;
+		    completion treats white spaces as part of the argument
 	-nargs=*    Any number of arguments are allowed (0, 1, or many),
 		    separated by white space
 	-nargs=?    0 or 1 arguments are allowed

--- a/src/ex_cmds.h
+++ b/src/ex_cmds.h
@@ -31,7 +31,8 @@
 #define EX_BANG		0x002	// allow a ! after the command name
 #define EX_EXTRA	0x004	// allow extra args after command name
 #define EX_XFILE	0x008	// expand wildcards in extra part
-#define EX_NOSPC	0x010	// no spaces allowed in the extra part
+#define EX_NOSPC	0x010	// extra part is a single argument (no split on
+				// whitespace)
 #define	EX_DFLALL	0x020	// default file range is 1,$
 #define EX_WHOLEFOLD	0x040	// extend range to include whole fold also
 				// when less than two numbers given
@@ -60,7 +61,7 @@
 #define EX_EXPR_ARG    0x8000000  // argument is an expression
 #define EX_WHOLE      0x10000000  // command name cannot be shortened in Vim9
 #define EX_EXPORT     0x20000000  // command can be used after :export
-#define EX_ARGSPACE   0x40000000  // allow spaces in user command with -nargs=_
+#define EX_ARGSPACE   0x40000000  // completion: keep spaces in arg lead
 
 #define EX_FILES (EX_XFILE | EX_EXTRA)	// multiple extra files allowed
 #define EX_FILE1 (EX_FILES | EX_NOSPC)	// 1 file, defaults to current file

--- a/src/ex_cmds.h
+++ b/src/ex_cmds.h
@@ -60,6 +60,7 @@
 #define EX_EXPR_ARG    0x8000000  // argument is an expression
 #define EX_WHOLE      0x10000000  // command name cannot be shortened in Vim9
 #define EX_EXPORT     0x20000000  // command can be used after :export
+#define EX_ARGSPACE   0x40000000  // allow spaces in user command with -nargs=_
 
 #define EX_FILES (EX_XFILE | EX_EXTRA)	// multiple extra files allowed
 #define EX_FILE1 (EX_FILES | EX_NOSPC)	// 1 file, defaults to current file

--- a/src/testdir/test_usercommands.vim
+++ b/src/testdir/test_usercommands.vim
@@ -363,6 +363,14 @@ func CustomCompleteList(A, L, P)
   return [ "Monday", "Tuesday", "Wednesday", {}, test_null_string()]
 endfunc
 
+func CustomCompleteListWithSpaces(A, L, P)
+  return [ "Monday Here", "Tuesday There", "Wednesday OK", {}, test_null_string()]
+endfunc
+
+func CustomCompleteListFuzzy(A, L, P)
+  return [ "Monday Here", "Tuesday There", "Wednesday OK", {}, test_null_string()]->matchfuzzy(a:A)
+endfunc
+
 func Test_CmdCompletion()
   call feedkeys(":com -\<C-A>\<C-B>\"\<CR>", 'tx')
   call assert_equal('"com -addr bang bar buffer complete count keepscript nargs range register', @:)
@@ -371,7 +379,7 @@ func Test_CmdCompletion()
   call assert_equal('"com -nargs=0 -addr bang bar buffer complete count keepscript nargs range register', @:)
 
   call feedkeys(":com -nargs=\<C-A>\<C-B>\"\<CR>", 'tx')
-  call assert_equal('"com -nargs=* + 0 1 ?', @:)
+  call assert_equal('"com -nargs=* + 0 1 ? _', @:)
 
   call feedkeys(":com -addr=\<C-A>\<C-B>\"\<CR>", 'tx')
   call assert_equal('"com -addr=arguments buffers lines loaded_buffers other quickfix tabs windows', @:)
@@ -476,6 +484,14 @@ func Test_CmdCompletion()
   com! -nargs=? -complete=customlist,CustomCompleteList DoCmd :
   call feedkeys(":DoCmd \<C-A>\<C-B>\"\<CR>", 'tx')
   call assert_equal('"DoCmd Monday Tuesday Wednesday', @:)
+
+  com! -nargs=_ -complete=customlist,CustomCompleteListWithSpaces DoCmd :
+  call feedkeys(":DoCmd \<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"DoCmd Monday Here Tuesday There Wednesday OK', @:)
+
+  com! -nargs=_ -complete=customlist,CustomCompleteListFuzzy DoCmd :
+  call feedkeys(":DoCmd mo he\<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"DoCmd Monday Here', @:)
 
   com! -nargs=+ -complete=custom,CustomCompleteList DoCmd :
   call assert_fails("call feedkeys(':DoCmd \<C-D>', 'tx')", 'E730:')

--- a/src/testdir/test_usercommands.vim
+++ b/src/testdir/test_usercommands.vim
@@ -339,6 +339,9 @@ func Test_CmdErrors()
   com! -nargs=1 DoCmd :
   call assert_fails('DoCmd', 'E471:')
 
+  com! -nargs=_ DoCmd :
+  call assert_fails('DoCmd', 'E471:')
+
   com! -nargs=+ DoCmd :
   call assert_fails('DoCmd', 'E471:')
 
@@ -426,7 +429,15 @@ func Test_CmdCompletion()
   call feedkeys(":DoCmd \<C-A>\<C-B>\"\<CR>", 'tx')
   call assert_equal('"DoCmd mswin xterm', @:)
 
+  com! -nargs=_ -complete=behave DoCmd :
+  call feedkeys(":DoCmd \<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"DoCmd mswin xterm', @:)
+
   com! -nargs=1 -complete=retab DoCmd :
+  call feedkeys(":DoCmd \<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"DoCmd -indentonly', @:)
+
+  com! -nargs=_ -complete=retab DoCmd :
   call feedkeys(":DoCmd \<C-A>\<C-B>\"\<CR>", 'tx')
   call assert_equal('"DoCmd -indentonly', @:)
 
@@ -435,8 +446,21 @@ func Test_CmdCompletion()
   call feedkeys(":DoCmd READM\<Tab>\<C-B>\"\<CR>", 'tx')
   call assert_equal('"DoCmd README.txt', @:)
 
+  com! -nargs=_ -complete=file DoCmd :
+  call feedkeys(":DoCmd READM\<Tab>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"DoCmd README.txt', @:)
+
   " Test for buffer name completion
   com! -nargs=1 -complete=buffer DoCmd :
+  let bnum = bufadd('BufForUserCmd')
+  call setbufvar(bnum, '&buflisted', 1)
+  call feedkeys(":DoCmd BufFor\<Tab>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"DoCmd BufForUserCmd', @:)
+  bwipe BufForUserCmd
+  call feedkeys(":DoCmd BufFor\<Tab>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"DoCmd BufFor', @:)
+
+  com! -nargs=_ -complete=buffer DoCmd :
   let bnum = bufadd('BufForUserCmd')
   call setbufvar(bnum, '&buflisted', 1)
   call feedkeys(":DoCmd BufFor\<Tab>\<C-B>\"\<CR>", 'tx')
@@ -614,6 +638,10 @@ func Test_command_list()
   call assert_equal("\n    Name              Args Address Complete    Definition"
         \        .. "\n    DoCmd             1            arglist     :",
         \           execute('command DoCmd'))
+  command! -nargs=_ -complete=arglist DoCmd :
+  call assert_equal("\n    Name              Args Address Complete    Definition"
+        \        .. "\n    DoCmd             _            arglist     :",
+        \           execute('command DoCmd'))
   command! -nargs=* -complete=augroup DoCmd :
   call assert_equal("\n    Name              Args Address Complete    Definition"
         \        .. "\n    DoCmd             *            augroup     :",
@@ -635,6 +663,10 @@ func Test_command_list()
   command! -nargs=1 DoCmd :
   call assert_equal("\n    Name              Args Address Complete    Definition"
         \        .. "\n    DoCmd             1                        :",
+        \           execute('command DoCmd'))
+  command! -nargs=_ DoCmd :
+  call assert_equal("\n    Name              Args Address Complete    Definition"
+        \        .. "\n    DoCmd             _                        :",
         \           execute('command DoCmd'))
   command! -nargs=* DoCmd :
   call assert_equal("\n    Name              Args Address Complete    Definition"

--- a/src/testdir/test_usercommands.vim
+++ b/src/testdir/test_usercommands.vim
@@ -595,6 +595,27 @@ func Test_addr_all()
   delcommand DoSomething
 endfunc
 
+func Test_nargs_underscore_fargs()
+  " -nargs=_ must behave like -nargs=1 for <f-args>/<q-args>:
+  " the whole argument is one token, whitespace is part of it.
+  let g:res = []
+  com! -nargs=1 DoCmd1 call add(g:res, [<f-args>])
+  com! -nargs=_ DoCmdU call add(g:res, [<f-args>])
+  DoCmd1 a b c
+  DoCmdU a b c
+  call assert_equal([['a b c'], ['a b c']], g:res)
+
+  let g:res = []
+  com! -nargs=_ DoCmdQ call add(g:res, <q-args>)
+  DoCmdQ a b c
+  call assert_equal(['a b c'], g:res)
+
+  delcom DoCmd1
+  delcom DoCmdU
+  delcom DoCmdQ
+  unlet g:res
+endfunc
+
 func Test_command_list()
   command! DoCmd :
   call assert_equal("\n    Name              Args Address Complete    Definition"

--- a/src/usercmd.c
+++ b/src/usercmd.c
@@ -650,7 +650,7 @@ uc_list(char_u *name, size_t name_len)
 		case (EX_EXTRA|EX_NOSPC):	IObuff[len++] = '?'; break;
 		case (EX_EXTRA|EX_NEEDARG):	IObuff[len++] = '+'; break;
 		case (EX_EXTRA|EX_NOSPC|EX_NEEDARG): IObuff[len++] = '1'; break;
-		case (EX_EXTRA|EX_NEEDARG|EX_ARGSPACE): IObuff[len++] = '_'; break;
+		case (EX_EXTRA|EX_NOSPC|EX_NEEDARG|EX_ARGSPACE): IObuff[len++] = '_'; break;
 	    }
 
 	    do
@@ -980,7 +980,7 @@ uc_scan_attr(
 		else if (*val == '+')
 		    *argt |= (EX_EXTRA | EX_NEEDARG);
 		else if (*val == '_')
-		    *argt |= (EX_EXTRA | EX_NEEDARG | EX_ARGSPACE);
+		    *argt |= (EX_EXTRA | EX_NOSPC | EX_NEEDARG | EX_ARGSPACE);
 		else
 		    goto wrong_nargs;
 	    }

--- a/src/usercmd.c
+++ b/src/usercmd.c
@@ -344,15 +344,18 @@ set_context_in_user_cmdarg(
 	return set_context_in_map_cmd(xp, (char_u *)"map", arg, forceit, FALSE,
 							FALSE, CMD_map);
     // Find start of last argument.
-    p = arg;
-    while (*p)
+    if (!(argt & EX_ARGSPACE))
     {
-	if (*p == ' ')
-	    // argument starts after a space
-	    arg = p + 1;
-	else if (*p == '\\' && *(p + 1) != NUL)
-	    ++p; // skip over escaped character
-	MB_PTR_ADV(p);
+	p = arg;
+	while (*p)
+	{
+	    if (*p == ' ')
+		// argument starts after a space
+		arg = p + 1;
+	    else if (*p == '\\' && *(p + 1) != NUL)
+		++p; // skip over escaped character
+	    MB_PTR_ADV(p);
+	}
     }
     xp->xp_pattern = arg;
     xp->xp_context = context;
@@ -975,6 +978,8 @@ uc_scan_attr(
 		    *argt |= (EX_EXTRA | EX_NOSPC);
 		else if (*val == '+')
 		    *argt |= (EX_EXTRA | EX_NEEDARG);
+		else if (*val == '_')
+		    *argt |= (EX_EXTRA | EX_NEEDARG | EX_ARGSPACE);
 		else
 		    goto wrong_nargs;
 	    }

--- a/src/usercmd.c
+++ b/src/usercmd.c
@@ -454,7 +454,7 @@ get_user_cmd_flags(expand_T *xp UNUSED, int idx)
     char_u *
 get_user_cmd_nargs(expand_T *xp UNUSED, int idx)
 {
-    static char *user_cmd_nargs[] = {"0", "1", "*", "?", "+"};
+    static char *user_cmd_nargs[] = {"0", "1", "_", "*", "?", "+"};
 
     if (idx < 0 || idx >= (int)ARRAY_LENGTH(user_cmd_nargs))
 	return NULL;
@@ -643,13 +643,14 @@ uc_list(char_u *name, size_t name_len)
 	    len = 0;
 
 	    // Arguments
-	    switch ((int)(a & (EX_EXTRA|EX_NOSPC|EX_NEEDARG)))
+	    switch ((int)(a & (EX_EXTRA|EX_NOSPC|EX_NEEDARG|EX_ARGSPACE)))
 	    {
 		case 0:				IObuff[len++] = '0'; break;
 		case (EX_EXTRA):		IObuff[len++] = '*'; break;
 		case (EX_EXTRA|EX_NOSPC):	IObuff[len++] = '?'; break;
 		case (EX_EXTRA|EX_NEEDARG):	IObuff[len++] = '+'; break;
 		case (EX_EXTRA|EX_NOSPC|EX_NEEDARG): IObuff[len++] = '1'; break;
+		case (EX_EXTRA|EX_NEEDARG|EX_ARGSPACE): IObuff[len++] = '_'; break;
 	    }
 
 	    do


### PR DESCRIPTION
Problem: User commands with a single argument can't complete argument with unescaped spaces.

Solution: Add -nargs=_ command argument to not split command argument on white spaces for the completion purposes.

The difference between the `-nargs=1` and `-nargs=_`:

	func MyComplete(ArgLead, CmdLine, CursorPos)
	  return ["one value", "two values", "three values"]->matchfuzzy(a:ArgLead)
	endfunc
	:command -nargs=1 -complete=customlist,MyComplete MyCmd1 echo <q-args>
	:command -nargs=_ -complete=customlist,MyComplete MyCmd2 echo <q-args>

Completing `:MyCmd1 two va<tab>` will complete with:

	:MyCmd1 two one value

Completing `:MyCmd2 two va<tab>` will complete with:

	:MyCmd2 two values

Relates 
- #20102
- #19294