### PR TITLE
Pasting ". register without autocommands breaks TextPut*

### DIFF
--- a/src/register.c
+++ b/src/register.c
@@ -1736,7 +1736,8 @@ do_put(
 	    stuffcharReadbuff(VIsual_mode);
 
 #ifdef FEAT_EVAL
-	if (has_textputpre() || has_textputpost())
+	bool has_textput_events = has_textputpre() || has_textputpost();
+	if (has_textput_events)
 	    add_last_insert++;
 #endif
 
@@ -1748,11 +1749,10 @@ do_put(
 	// TextPutPost after TextPutPre.
 	if (has_textputpre())
 	    put_do_autocmd('.', NULL, NULL, false, dir);
-
 	if (has_textputpost())
 	    put_do_autocmd('.', NULL, NULL, true, dir);
 
-	if (--add_last_insert == 0)
+	if (has_textput_events && --add_last_insert == 0)
 	    ga_clear(&last_insert_ga);
 #endif
 

--- a/src/testdir/test_autocmd.vim
+++ b/src/testdir/test_autocmd.vim
@@ -6069,22 +6069,27 @@ func Test_TextPutX()
   au! TextPutPre
   let g:pre_event = []
 
-  " Test that recursive ". register calls have the same contents for post and
-  " pre
-  au TextPutPre * put . | let g:pre_event = copy(v:event)
-  au TextPutPost * let g:post_event = copy(v:event)
+  for round in range(2)
+    " Recursive ". register calls have the same contents for post and pre.
+    au TextPutPre * put . | let g:pre_event = copy(v:event)
+    au TextPutPost * let g:post_event = copy(v:event)
 
-  call feedkeys("iinserted\<Esc>", 'x')
-  norm! ".p
+    call feedkeys("iinserted\<Esc>", 'x')
+    norm! ".p
 
-  call assert_equal(
-        \ #{regcontents: ["inserted"], regname: '.',
-        \ operator: 'p', regtype: 'v', visual: v:false},
-        \ g:pre_event)
-  call assert_equal(g:pre_event, g:post_event)
+    call assert_equal(
+          \ #{regcontents: ["inserted"], regname: '.',
+          \ operator: 'p', regtype: 'v', visual: v:false},
+          \ g:pre_event)
+    call assert_equal(g:pre_event, g:post_event)
 
-  au! TextPutPre
-  au! TextPutPost
+    au! TextPutPre
+    au! TextPutPost
+
+    " Pasting ". register without TextPutPre/TextPutPost autocommands should
+    " not interfere with these autocommands in the next round.
+    norm! ".p
+  endfor
 
   unlet g:post_event
   unlet g:pre_event


### PR DESCRIPTION
Problem:  Pasting ". register without TextPut* autocommands breaks
          subsequent TextPut* autocommands (after 9.2.0470).
Solution: Only decrement add_last_insert if it has been incremented.