### PR TITLE
runtime(netrw): normalize bookmark paths to prevent duplicates

### DIFF
--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -8979,21 +8979,30 @@ function s:MakeSshCmd(sshcmd)
     return sshcmd
 endfunction
 
-" s:MakeBookmark: enters a bookmark into Netrw's bookmark system   {{{2
+" s:MakeBookmark: enters a bookmark into Netrw's bookmark system {{{2
+" Note that bookmark paths should always be absolute.
 function s:MakeBookmark(fname)
 
     if !exists("g:netrw_bookmarklist")
-        let g:netrw_bookmarklist= []
+        let g:netrw_bookmarklist = []
     endif
 
-    if index(g:netrw_bookmarklist,a:fname) == -1
-        " curdir not currently in g:netrw_bookmarklist, so include it
-        if isdirectory(s:NetrwFile(a:fname)) && a:fname !~ '/$'
-            " Directory without a trailing slash
-            call add(g:netrw_bookmarklist, s:NetrwFile(a:fname) . '/')
-        else
-            call add(g:netrw_bookmarklist, s:NetrwFile(a:fname))
-        endif
+    " Normalize path to prevent duplicate entries
+    let bookmark_path = netrw#fs#AbsPath(s:NetrwFile(a:fname))
+    let ignore_case = 0
+    if has('win32')
+        let bookmark_path = substitute(bookmark_path, '\\', '/', 'ge')
+        let ignore_case = 1
+    endif
+    let bookmark_path = simplify(bookmark_path)
+
+    if isdirectory(bookmark_path) && bookmark_path !~ '/$'
+        let bookmark_path .= '/'
+    endif
+
+    if index(g:netrw_bookmarklist, bookmark_path, 0, ignore_case) == -1
+        " Not currently in the bookmarks list, so include it
+        call add(g:netrw_bookmarklist, bookmark_path)
         call sort(g:netrw_bookmarklist)
     endif
 

--- a/src/testdir/test_plugin_netrw.vim
+++ b/src/testdir/test_plugin_netrw.vim
@@ -692,7 +692,7 @@ func Test_netrw_bookmark_marked_file()
   " Make sure Vim's working directory diverge from Netrw's
   let g:netrw_keepdir = 1
   let g:netrw_bookmarklist = []
-  let test_workdir = 'Xtest_workdir'
+  let test_workdir = getcwd() . '/Xtest_workdir'
   let test_netrw_curdir = test_workdir . '/Xtest_netrw_curdir'
   call mkdir(test_netrw_curdir, 'p')
   call writefile([], test_netrw_curdir . '/test_file')
@@ -700,8 +700,16 @@ func Test_netrw_bookmark_marked_file()
   execute 'cd ' . test_workdir
   call Test_MakeBookmark(test_netrw_curdir, 'test_file')
 
+  " Bookmark paths should be absolute and normalized to prevent duplicates on win32
+  let expected_path = netrw#fs#AbsPath(test_netrw_curdir . '/test_file')
+  if has('win32')
+    let expected_path = substitute(expected_path, '\\', '/', 'ge')
+  endif
+  let expected_path = simplify(expected_path)
+
   call assert_equal(1, len(g:netrw_bookmarklist))
-  call assert_match(test_netrw_curdir . '/test_file', g:netrw_bookmarklist[0])
+  call assert_equal(expected_path, g:netrw_bookmarklist[0])
+  call assert_true(isabsolutepath(g:netrw_bookmarklist[0]), 'Bookmark paths should be absolute')
 
   " Tear down
   execute 'cd ' . save_workdir


### PR DESCRIPTION
Problem: the bookmarks list can have duplicate entries, more often in win32 (due to mixed slashes and capitalization) and when g:netrw_keepdir=0 (which could introduce relative paths). Duplicate entries could be: 
`C:\foo\BAR\baz.file`
`c:\foo\bar\baz.file`
`c:/foo\BAR/baz.file`
`BAR/baz.file`

Solution: normalize the paths and make sure they are always absolute.