### PR TITLE
runtime(compiler): set zig errorformat

### DIFF
--- a/runtime/compiler/zig.vim
+++ b/runtime/compiler/zig.vim
@@ -17,7 +17,27 @@ else
     CompilerSet makeprg=zig\ \$*\ \"%\"
 endif
 
-" TODO: improve errorformat as needed.
+CompilerSet errorformat=
+            \%-G,
+            \%-G\ %#+-\ %.%#,
+            \%-Ginstall,
+            \%-Ginstall\ transitive\ failure,
+            \%-Grun,
+            \%-Grun\ transitive\ failure,
+            \%-Gtest,
+            \%-Gtest\ transitive\ failure,
+            \%-Gfailed\ command:\ %.%#,
+            \%-Gerror:\ %*\\d\ compilation\ errors,
+            \%-GBuild\ Summary:\ %.%#,
+            \%-Gerror:\ the\ following\ build\ command\ failed\ with\ exit\ code\ %*\\d:,
+            \%-G.zig-cache%.%#,
+            \%E%f:%l:%c:\ error:\ %m,
+            \%I%f:%l:%c:\ note:\ %m
+
+" zig has no warnings, but zig cc and zig c++ do
+CompilerSet errorformat+=
+            \%W%f:%l:%c:\ warning:\ %m,
+            \%-G%*\\d\ warnings\ generated.
 
 let &cpo = s:save_cpo
 unlet s:save_cpo

--- a/runtime/compiler/zig_build.vim
+++ b/runtime/compiler/zig_build.vim
@@ -18,8 +18,6 @@ else
 	CompilerSet makeprg=zig\ build\ $*
 endif
 
-" TODO: anything to add to errorformat for zig build specifically?
-
 let &cpo = s:save_cpo
 unlet s:save_cpo
 " vim: tabstop=8 shiftwidth=4 softtabstop=4 expandtab

--- a/runtime/compiler/zig_cc.vim
+++ b/runtime/compiler/zig_cc.vim
@@ -1,18 +1,17 @@
 " Vim compiler file
-" Compiler: Zig Compiler (zig build-exe)
-" Upstream: https://github.com/ziglang/zig.vim
+" Compiler: Zig Compiler (zig cc)
 " Last Change: 2025 Nov 16 by The Vim Project (set errorformat)
 
 if exists('current_compiler')
   finish
 endif
 runtime compiler/zig.vim
-let current_compiler = 'zig_build_exe'
+let current_compiler = 'zig_cc'
 
 let s:save_cpo = &cpo
 set cpo&vim
 
-CompilerSet makeprg=zig\ build-exe\ \%:S\ \$*
+CompilerSet makeprg=zig\ cc\ \%:S\ \$*
 
 let &cpo = s:save_cpo
 unlet s:save_cpo

--- a/runtime/compiler/zig_test.vim
+++ b/runtime/compiler/zig_test.vim
@@ -13,8 +13,6 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 CompilerSet makeprg=zig\ test\ \%:S\ \$*
-" CompilerSet errorformat=%f:%l:%c: %t%*[^:]: %m, %f:%l:%c: %m, %f:%l: %m
-CompilerSet errorformat&
 
 let &cpo = s:save_cpo
 unlet s:save_cpo


### PR DESCRIPTION
compiler output is filtered rather aggressively. i may have gone overboard; if so, please let me know