### PR TITLE
viminfo: avoid signed int overflow in register array growth

### DIFF
--- a/src/viminfo.c
+++ b/src/viminfo.c
@@ -1706,7 +1706,7 @@ read_viminfo_register(vir_T *virp, int force)
 	    if (size == limit)
 	    {
 		string_T *new_array = (string_T *)
-					   alloc(limit * 2 * sizeof(string_T));
+				    alloc((size_t)limit * 2 * sizeof(string_T));
 
 		if (new_array == NULL)
 		{


### PR DESCRIPTION
The size expression `limit * 2 * sizeof(string_T)` in read_viminfo_register() performs the multiplication in `int` and can overflow signed once `limit` passes `INT_MAX / 2`. Cast `limit` to `size_t` before multiplying so the computation stays unsigned.

This is defensive only — reaching this path requires a register consuming many gigabytes, at which point the preceding allocations would already be failing — but the int-overflow itself is undefined behavior, so worth closing.