### PR TITLE
fix(fuzzy): prevent crash on long multi-word patterns

### DIFF
--- a/src/fuzzy.c
+++ b/src/fuzzy.c
@@ -85,6 +85,7 @@ fuzzy_match(
     int		complete = FALSE;
     int		score = 0;
     int		numMatches = 0;
+    int		pat_chars = 0;
     score_t	fzy_score;
 
     *outScore = 0;
@@ -118,6 +119,17 @@ fuzzy_match(
 		complete = TRUE;
 	    *p = NUL;
 	}
+	// match_positions() always writes pat_chars entries,
+	// so bail if they won't fit.
+	pat_chars = MB_CHARLEN(pat);
+	if (pat_chars > maxMatches)
+	    pat_chars = maxMatches;
+	if (numMatches > maxMatches - pat_chars)
+	{
+	    numMatches = 0;
+	    *outScore = FUZZY_SCORE_NONE;
+	    break;
+	}
 
 	score = FUZZY_SCORE_NONE;
 	if (has_match(pat, str))
@@ -143,7 +155,7 @@ fuzzy_match(
 	else
 	    *outScore += score;
 
-	numMatches += MB_CHARLEN(pat);
+	numMatches += pat_chars;
 
 	if (complete || numMatches >= maxMatches)
 	    break;

--- a/src/testdir/test_matchfuzzy.vim
+++ b/src/testdir/test_matchfuzzy.vim
@@ -322,4 +322,13 @@ func Test_matchfuzzy_initialized()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_matchfuzzy_long_multiword_no_overflow()
+  let word = repeat('a', 100)
+  let pat_ok = repeat(word . ' ', 9) . word
+  call assert_equal([word], matchfuzzy([word], pat_ok))
+
+  let pat_overflow = repeat(word . ' ', 14) . word
+  call assert_equal([[], [], []], matchfuzzypos([word], pat_overflow))
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:
fuzzy_match checked maxMatches too late. Long multi-word patterns could write past matches[FUZZY_MATCH_MAX_LEN] in fuzzy_match_in_list.

Solution:
Clamp pat_chars to maxMatches and stop before calling match_positions when the buffer is full.