### PR TITLE
Resolve FIXME related to comparison operators runtime/syntax/django.vim.

### DIFF
--- a/runtime/syntax/django.vim
+++ b/runtime/syntax/django.vim
@@ -32,6 +32,8 @@ syn keyword djangoStatement contained get_current_language_bidi get_language_inf
 syn keyword djangoStatement contained translate blocktranslate endblocktranslate
 syn keyword djangoStatement contained partialdef endpartialdef partial
 syn keyword djangoStatement contained querystring lorem verbatim localize endlocalize
+syn keyword djangoStatement contained localtime endlocaltime timezone endtimezone
+syn keyword djangoStatement contained get_current_timezone
 
 " Django templete built-in filters
 syn keyword djangoFilter contained add addslashes capfirst center cut date
@@ -47,7 +49,7 @@ syn keyword djangoFilter contained time timesince timeuntil title truncatechars
 syn keyword djangoFilter contained truncatewords truncatewords_html unordered_list upper urlencode
 syn keyword djangoFilter contained urlize urlizetrunc wordcount wordwrap yesno
 syn keyword djangoFilter contained force_escape iriencode json_script truncatechars_html
-syn keyword djangoFilter contained localize unlocalize
+syn keyword djangoFilter contained localize unlocalize localtime utc timezone
 
 " Keywords to highlight within comments
 syn keyword djangoTodo contained TODO FIXME XXX

--- a/runtime/syntax/django.vim
+++ b/runtime/syntax/django.vim
@@ -18,8 +18,6 @@ syn match djangoError "%}\|}}\|#}"
 " Django template built-in tags and parameters
 " 'comment' doesn't appear here because it gets special treatment
 syn keyword djangoStatement contained autoescape csrf_token empty
-" FIXME ==, !=, <, >, <=, and >= should be djangoStatements:
-" syn keyword djangoStatement contained == != < > <= >=
 syn keyword djangoStatement contained and as block endblock by cycle debug else elif
 syn keyword djangoStatement contained extends filter endfilter firstof for
 syn keyword djangoStatement contained endfor if endif ifchanged endifchanged
@@ -68,6 +66,9 @@ syn region djangoVarBlock start="{{" end="}}" contains=djangoFilter,djangoArgume
 syn region djangoComment start="{%\s*comment\(\s\+.\{-}\)\?%}" end="{%\s*endcomment\s*%}" contains=djangoTodo
 syn region djangoComBlock start="{#" end="#}" contains=djangoTodo
 
+" March comparison operators within Django statements.
+syn match djangoOperator /==\|!=\| < \| > \|<=\|>=/ contained containedin=djangoTagBlock,djangoVarBlock
+
 " Define the default highlighting.
 " Only when an item doesn't have highlighting yet
 
@@ -82,6 +83,7 @@ hi def link djangoError Error
 hi def link djangoComment Comment
 hi def link djangoComBlock Comment
 hi def link djangoTodo Todo
+hi def link djangoOperator Operator
 
 
 let b:current_syntax = "django"

--- a/runtime/syntax/django.vim
+++ b/runtime/syntax/django.vim
@@ -66,7 +66,7 @@ syn region djangoVarBlock start="{{" end="}}" contains=djangoFilter,djangoArgume
 syn region djangoComment start="{%\s*comment\(\s\+.\{-}\)\?%}" end="{%\s*endcomment\s*%}" contains=djangoTodo
 syn region djangoComBlock start="{#" end="#}" contains=djangoTodo
 
-" March comparison operators within Django statements.
+" Match comparison operators within Django statements.
 syn match djangoOperator /==\|!=\| < \| > \|<=\|>=/ contained containedin=djangoTagBlock,djangoVarBlock
 
 " Define the default highlighting.

--- a/runtime/syntax/django.vim
+++ b/runtime/syntax/django.vim
@@ -31,7 +31,7 @@ syn keyword djangoStatement contained get_current_language noop get_available_la
 syn keyword djangoStatement contained get_current_language_bidi get_language_info plural
 syn keyword djangoStatement contained translate blocktranslate endblocktranslate
 syn keyword djangoStatement contained partialdef endpartialdef partial
-syn keyword djangoStatement contained querystring lorem verbatim
+syn keyword djangoStatement contained querystring lorem verbatim localize endlocalize
 
 " Django templete built-in filters
 syn keyword djangoFilter contained add addslashes capfirst center cut date
@@ -47,6 +47,7 @@ syn keyword djangoFilter contained time timesince timeuntil title truncatechars
 syn keyword djangoFilter contained truncatewords truncatewords_html unordered_list upper urlencode
 syn keyword djangoFilter contained urlize urlizetrunc wordcount wordwrap yesno
 syn keyword djangoFilter contained force_escape iriencode json_script truncatechars_html
+syn keyword djangoFilter contained localize unlocalize
 
 " Keywords to highlight within comments
 syn keyword djangoTodo contained TODO FIXME XXX


### PR DESCRIPTION
Summary: Add highlight of comparison operators resolving FIXME left by maintainer.

How it works: By creating a the variable ‘djangoOperator’ with the regex and defining to only highlight when enclosed within ‘djangoTag’ and ‘djangoVarBlock’ the highlight works as expected.

Note: Note even though the maintainer had left the note “FIXME ==, !=, <, >, <=, and >= should be djangoStatements” the results do work as I think he intended even though the variable ‘djangoOperator’ had to be created to achieve the result. By doing it this way the highlight process does not get confused depending on the spacing of the comparison operator. Example: `{{ x==10 }}` and `{{ x == 10 }}` work as expected.