### PR TITLE
filetype: Missing overrule variable for Objective-C++ detection

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -3,7 +3,7 @@ vim9script
 # Vim functions for file type detection
 #
 # Maintainer:		The Vim Project <https://github.com/vim/vim>
-# Last Change:		2026 Apr 23
+# Last Change:		2026 May 14
 # Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 # These functions are moved here from runtime/filetype.vim to make startup
@@ -798,6 +798,11 @@ export def FTnroff(): number
 enddef
 
 export def FTmm()
+  if exists("g:filetype_mm")
+    exe "setf " .. g:filetype_mm
+    return
+  endif
+
   var n = 1
   while n < 20
     if getline(n) =~ '^\s*\(#\s*\(include\|import\)\>\|@import\>\|/\*\)'

--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -1,4 +1,4 @@
-*filetype.txt*	For Vim version 9.2.  Last change: 2026 Apr 13
+*filetype.txt*	For Vim version 9.2.  Last change: 2026 May 14
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -164,6 +164,7 @@ variables can be used to overrule the filetype used for certain extensions:
 	*.int		g:filetype_int
 	*.lsl		g:filetype_lsl
 	*.m		g:filetype_m		|ft-mathematica-syntax|
+	*.mm		g:filetype_mm
 	*.mac		g:filetype_mac
 	*[mM]makefile,*.mk,*.mak,[mM]akefile*
 			g:make_flavor		|ft-make-syntax|


### PR DESCRIPTION
Problem:  filetype: Missing overrule variable for Objective-C++ detection
Solution: Add g:filetype_mm to overrule content detection of `*.mm` files.

