### PR TITLE
Resolve FIXME of comparrison operators + localization tags syntax/dja…

### DIFF
--- a/runtime/syntax/django.vim
+++ b/runtime/syntax/django.vim
@@ -18,8 +18,6 @@ syn match djangoError "%}\|}}\|#}"
 " Django template built-in tags and parameters
 " 'comment' doesn't appear here because it gets special treatment
 syn keyword djangoStatement contained autoescape csrf_token empty
-" FIXME ==, !=, <, >, <=, and >= should be djangoStatements:
-" syn keyword djangoStatement contained == != < > <= >=
 syn keyword djangoStatement contained and as block endblock by cycle debug else elif
 syn keyword djangoStatement contained extends filter endfilter firstof for
 syn keyword djangoStatement contained endfor if endif ifchanged endifchanged
@@ -33,7 +31,9 @@ syn keyword djangoStatement contained get_current_language noop get_available_la
 syn keyword djangoStatement contained get_current_language_bidi get_language_info plural
 syn keyword djangoStatement contained translate blocktranslate endblocktranslate
 syn keyword djangoStatement contained partialdef endpartialdef partial
-syn keyword djangoStatement contained querystring lorem verbatim
+syn keyword djangoStatement contained querystring lorem verbatim localize endlocalize
+syn keyword djangoStatement contained localtime endlocaltime timezone endtimezone
+syn keyword djangoStatement contained get_current_timezone
 
 " Django templete built-in filters
 syn keyword djangoFilter contained add addslashes capfirst center cut date
@@ -49,6 +49,7 @@ syn keyword djangoFilter contained time timesince timeuntil title truncatechars
 syn keyword djangoFilter contained truncatewords truncatewords_html unordered_list upper urlencode
 syn keyword djangoFilter contained urlize urlizetrunc wordcount wordwrap yesno
 syn keyword djangoFilter contained force_escape iriencode json_script truncatechars_html
+syn keyword djangoFilter contained localize unlocalize localtime utc timezone
 
 " Keywords to highlight within comments
 syn keyword djangoTodo contained TODO FIXME XXX
@@ -68,6 +69,9 @@ syn region djangoVarBlock start="{{" end="}}" contains=djangoFilter,djangoArgume
 syn region djangoComment start="{%\s*comment\(\s\+.\{-}\)\?%}" end="{%\s*endcomment\s*%}" contains=djangoTodo
 syn region djangoComBlock start="{#" end="#}" contains=djangoTodo
 
+" Match comparison operators within Django statements.
+syn match djangoOperator "==\|!=\|<=\|>=\|<\|>" contained containedin=djangoTagBlock
+
 " Define the default highlighting.
 " Only when an item doesn't have highlighting yet
 
@@ -82,6 +86,7 @@ hi def link djangoError Error
 hi def link djangoComment Comment
 hi def link djangoComBlock Comment
 hi def link djangoTodo Todo
+hi def link djangoOperator Operator
 
 
 let b:current_syntax = "django"


### PR DESCRIPTION
**Resolve FIXME related to comparison operators syntax/django.vim.**

Summary: Add highlight of comparison operators resolving FIXME left by maintainer.

How it works: By creating a the variable ‘djangoOperator’ with the regex and defining to only highlight when enclosed within ‘djangoTag’ and ‘djangoVarBlock’ the highlight works as expected.

> Note 1: Order matters in the REGEX. Complex operators like `>=` must precede `>` to work as expected. Otherwise the simpler operator will be resolved and the extra character will be ignored.

> Note 2: Even though the maintainer had left the note “FIXME ==, !=, <, >, <=, and >= should be djangoStatements” the results do work as I think he intended even though the variable ‘djangoOperator’ had to be created to achieve the result. By doing it this way the highlight process does not get confused depending on the spacing of the comparison operator. Example: {{ x>=10 }} and {{ x >= 10 }} work as expected.

**Add tags related to localization.**

Documentation source:

- [Controlling localization in templates](https://docs.djangoproject.com/en/5.2/topics/i18n/formatting/#controlling-localization-in-templates)