### PR TITLE
tests(commondumps): Use character counts when marking columns

### DIFF
--- a/src/testdir/commondumps.vim
+++ b/src/testdir/commondumps.vim
@@ -10,7 +10,7 @@ enddef
 def TryChangingLastJumpMark(marks: dict<list<number>>)
   const pos: list<number> = get(marks, line('.'), [])
   if !empty(pos)
-    setpos("'`", pos)
+    setcharpos("'`", pos)
   endif
 enddef
 
@@ -56,7 +56,7 @@ def FoldAndMarkDumpDiffParts(letters: list<string>)
 	var marks: dict<list<number>> = {}
 	for idx in range(parts[1]->len())
 	  if !empty(letters)
-	    setpos(("'" .. remove(letters, 0)), parts[1][idx])
+	    setcharpos(("'" .. remove(letters, 0)), parts[1][idx])
 	  endif
 	  # Point "bs" to "cs", "cs" to "as", "as" to "cs".
 	  marks[parts[1][idx][1]] = parts[2][idx]


### PR DESCRIPTION
Continue using `strwidth` when calculating the position of  
a column of interest, and start using `setcharpos` when  
marking a line of interest so that paired-up marks remain  
aligned columnwise across all three parts generated by  
`term_dumpdiff`, especially when multibyte characters are  
written in the line before the marked column.
