### PR TITLE
runtime(mbsync): Properly handle values for the "Sync" keyword

### DIFF
--- a/runtime/syntax/mbsync.vim
+++ b/runtime/syntax/mbsync.vim
@@ -132,7 +132,28 @@ syn match mbsCConfStPattern       '^Patterns\?\s\+\ze.*$'     contains=mbsCConfI
 syn match mbsCConfStMaxSize       '^MaxSize\s\+\ze.*$'        contains=mbsCConfItemK contained nextgroup=mbsSize transparent
 syn match mbsCConfStMaxMessages   '^MaxMessages\s\+\ze.*$'    contains=mbsCConfItemK contained nextgroup=mbsNumber transparent
 syn match mbsCConfStExpireUnread  '^ExpireUnread\s\+\ze.*$'   contains=mbsCConfItemK contained nextgroup=mbsBool transparent
-syn match mbsCConfSyncOpt 'None\|All\|\%(\s\+\%(Pull\|Push\|New\|ReNew\|Delete\|Flags\)\)\+' display contained
+" Properly matching mbsCConfSyncOpt:
+"
+" None is a special case. From mbsync's man page:
+"   "None may not be combined with any other operation."
+" Once "None" is out of the way, first try to match operations, including:
+"   - New, Old, Upgrade, Gone, Flags
+"   - ReNew (deprecated synonym for Upgrade)
+"   - Delete (deprecated synonym for Gone)
+"   - All and Full, since they can be combined with other flags
+" Then try to match the "second style" (as defined by mbsync's man page),
+" which is a concatenation of direction Flags (Pull/Push) and of the
+" operations seen above (New, Old, Upgrade/Renew, Gone/Delete, Flags, Full).
+" Note that while "PullFull" exists, "PullAll" is not handled by mbsync's
+" parser.
+" Last but not least, match "\s+%(All of the above, except None) as multiple
+" operations may be given to Sync.
+syn match mbsCConfSyncOpt /\v(
+  \None
+  \|%(Pull|Push|New|Old|Upgrade|ReNew|Gone|Delete|Flags|Full|All
+    \|%(Pull|Push)%(New|Old|Upgrade|ReNew|Gone|Delete|Flags|Full))
+  \%(\s+%(Pull|Push|New|Old|Upgrade|ReNew|Gone|Delete|Flags|Full|All
+        \|%(Pull|Push)%(New|Old|Upgrade|ReNew|Gone|Delete|Flags|Full)))*)$/ display contained
 syn match mbsCConfStSync          '^Sync\s\+\ze.*$'           contains=mbsCConfItemK contained nextgroup=mbsCConfSyncOpt transparent
 syn keyword mbsCConfManipOpt  None Far Near Both contained
 syn match mbsCConfStCreate        '^Create\s\+\ze.*$'         contains=mbsCConfItemK contained nextgroup=mbsCConfManipOpt transparent


### PR DESCRIPTION
This has been manually tested with my personal mbsync configuration and
with the following test file:

    $ cat test.mbsyncrc
    Channel Foo
    # None may not be combined with other operations
    Sync None
    Sync None New
    # First form
    Sync Pull
    Sync Push
    Sync New
    Sync Old
    Sync Upgrade
    Sync ReNew
    Sync Gone
    Sync Delete
    Sync Flags
    Sync Invalid
    # Second form
    Sync PullNew
    Sync PullOld
    Sync PullUpgrade
    Sync PullReNew
    Sync PullGone
    Sync PullDelete
    Sync PullFlags
    Sync PullFull
    Sync PullAll
    Sync PullInvalid
    Sync PushNew
    Sync PushOld
    Sync PushUpgrade
    Sync PushReNew
    Sync PushGone
    Sync PushDelete
    Sync PushFlags
    Sync PushFull
    Sync PushAll
    Sync PushInvalid
    Sync NewInvalid
    # Multiple operations
    Sync New Upgrade Gone Flags
    # Mix of the two styles (an example from the mbsync manpage)
    Sync PullNew PullGone Push
    # Syntaxically correct, though they will raise a warning in mbsync:
    Sync PullNew Pull
    Sync PullNew Gone Push
