### PR TITLE
Add to doc need for "libwayland-dev" for clipboard on env with only Wayland.

### DIFF
--- a/src/INSTALL
+++ b/src/INSTALL
@@ -61,6 +61,10 @@ To build Vim on Ubuntu from scratch on a clean system using git:
 	% sudo apt install libxt-dev
 	% make reconfig
 
+	Add Wayland clipboard support:
+	% sudo apt install libwayland-dev
+	% make reconfig
+
 	Add GUI support:
 	% sudo apt install libgtk-3-dev
 	% make reconfig


### PR DESCRIPTION
In GNU/Linux distributions without X11 and only depending on the [Wayland](https://wayland.freedesktop.org/docs/html/) Composer as a display server I could not find official documentation on how to compile VIM with clipbloard support.

> This will become more relevant as common GNU/Linux distributions transition to Wayland only environments. (sources and articles bellow)

The library [libwayland](https://packages.debian.org/sid/libwayland-dev) provides the development headers for the Wayland libraries.


Sources.

- [Gnome Blog: X11 Session Removal FAQ 2025-06-23.](https://blogs.gnome.org/alatiera/2025/06/23/x11-session-removal-faq/)
- [KDE Blog: Going all-in on a Wayland future 2025-11-26.](https://blogs.kde.org/2025/11/26/going-all-in-on-a-wayland-future/)
- [Gnome Blog: An update on the X11 GNOME Session Removal 2025-06-08.](https://blogs.gnome.org/alatiera/2025/06/08/the-x11-session-removal/)
- [Wayland Documentation.](https://wayland.freedesktop.org/docs/html/)

Articles.

- [It’s Foss: No More Xorg! Fedora 43 Will Be Wayland-only 2025-05-21.](https://itsfoss.com/news/fedora-43-wayland-only/)
- [How-To-Geek: The writing is on the wall for X11 on Linux, here's what is replacing it 2025-12-29.](https://www.howtogeek.com/x11-is-going-away-on-linux-heres-how-to-prepare/)
- [Dev.To: GNOME 50 Removes X11: What It Means for Linux Users 2026-03-16.](https://dev.to/the_nazar/gnome-50-removes-x11-what-it-means-for-linux-users-1ike)
- [LinuxSecurity.com: GNOME 50: Wayland-Only Brings Enhanced Security and Isolation](https://linuxsecurity.com/news/desktop-security/gnome-50-wayland-linux-security)
- [XDA Developers: KDE is finally killing X11, and I'm not as sad as I thought I'd be 2026-05-14](https://www.xda-developers.com/kde-dropping-x11-support/)
- [Desde Linux: The depreciation of X11 in Fedora continues and in Fedora 41 the Gnome session in X11 will disappear.](https://blog.desdelinux.net/en/The-depreciation-of-x11-in-fedora-continues-and-in-fedora-41-the-gnome-session-in-x11-will-disappear/)
