### PR TITLE
runtime(html): Anchor ng-template and ng-content for htmlangular detection

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -3,7 +3,7 @@ vim9script
 # Vim functions for file type detection
 #
 # Maintainer:		The Vim Project <https://github.com/vim/vim>
-# Last Change:		2026 May 16
+# Last Change:		2026 May 18
 # Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 # These functions are moved here from runtime/filetype.vim to make startup
@@ -547,7 +547,7 @@ export def FThtml()
 
   while n < 40 && n <= line("$")
     # Check for Angular
-    if getline(n) =~ '@\(if\|for\|defer\|switch\)\|\*\(ngIf\|ngFor\|ngSwitch\|ngTemplateOutlet\)\|ng-template\|ng-content'
+    if getline(n) =~ '@\(if\|for\|defer\|switch\)\|\*\(ngIf\|ngFor\|ngSwitch\|ngTemplateOutlet\)\|\<ng-template\|\<ng-content'
       setf htmlangular
       return
     endif

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -1888,6 +1888,27 @@ func Test_html_file()
   call assert_equal('htmlangular', &filetype)
   bwipe!
 
+  " HTML Angular ng-template element
+  let content = ['<ng-template let-foo>{{ foo }}</ng-template>']
+  call writefile(content, 'Xfile.html', 'D')
+  split Xfile.html
+  call assert_equal('htmlangular', &filetype)
+  bwipe!
+
+  " HTML Angular ng-content element
+  let content = ['<div><ng-content select="[item]"></ng-content></div>']
+  call writefile(content, 'Xfile.html', 'D')
+  split Xfile.html
+  call assert_equal('htmlangular', &filetype)
+  bwipe!
+
+  " Word containing 'ng-template' as a suffix must not trigger htmlangular
+  let content = ['<div class="song-template">', '  <h1>Not Angular</h1>', '</div>']
+  call writefile(content, 'Xfile.html', 'D')
+  split Xfile.html
+  call assert_equal('html', &filetype)
+  bwipe!
+
   " Django Template
   let content = ['{% if foobar %}',
       \ '    <ul>',


### PR DESCRIPTION
Prevent false-positive htmlangular detection on words containing `ng-template` or `ng-content` as a substring (e.g. `song-template`, `sing-content`). Anchor both branches with `\<` to require a word start, matching the `\<DTD\s\+XHTML\s` idiom used five lines below at `runtime/autoload/dist/ft.vim:555`.

Stash-bisect against the unmodified runtime:

```
<div class="song-template">x</div>   filetype=htmlangular   (false positive)
<div class="sing-content">x</div>    filetype=htmlangular   (false positive)
```

With the fix applied:

```
<ng-template let-foo></ng-template>           filetype=htmlangular   (preserved)
<div><ng-content select="[i]"></ng-content>   filetype=htmlangular   (preserved)
<div class="song-template">x</div>            filetype=html          (fixed)
<div class="sing-content">x</div>             filetype=html          (fixed)
<!DOCTYPE html><html></html>                  filetype=html          (preserved)
```

Three new asserts added to `Test_html_file` for the two `<ng-…>` element openings (positive cases) and the `song-template` substring (negative case).

Reported in neovim/neovim#39778.

This contribution was prepared with AI assistance.