### PR TITLE
runtime(doc): fix GTK4 package name in src/INSTALL

### DIFF
--- a/src/INSTALL
+++ b/src/INSTALL
@@ -70,7 +70,9 @@ To build Vim on Ubuntu from scratch on a clean system using git:
 	% make reconfig
 
 	Add GUI (GTK4) support:
-	% sudo apt install libgtk-3-dev
+	% sudo apt install libgtk-4-dev
+	(GTK4 is not the default; configure with
+	 --enable-gui=gtk4 to select it.)
 	% make reconfig
 
 	Add Python 3 support:


### PR DESCRIPTION
The GTK4 section in src/INSTALL pointed at libgtk-3-dev, which is the GTK3 package. Use libgtk-4-dev and add a short note that GTK4 is not the default and needs --enable-gui=gtk4.

Reported in https://github.com/vim/vim/commit/da5ebe71cbf56a89796000fa1aa92f6a76acf4c7#commitcomment-185900906