### PR TITLE
runtime(context): Correct whitespace error in Log()'s 'edit' command

### DIFF
--- a/runtime/autoload/context.vim
+++ b/runtime/autoload/context.vim
@@ -3,9 +3,7 @@ vim9script
 # Language:           ConTeXt typesetting engine
 # Maintainer:         Nicola Vitacolonna <nvitacolonna@gmail.com>
 # Former Maintainers: Nikolai Weibull <now@bitwi.se>
-# Latest Revision:    2026 Feb 03
-# Last Change:
-# 2026 Mar 30 by Vim project: Use fnameescape for the Log command
+# Latest Revision:    2026 May 20
 
 # Typesetting {{{
 import autoload './typeset.vim'
@@ -35,7 +33,7 @@ export def Log(bufname: string)
   var logpath = typeset.LogPath(bufname)
 
   if filereadable(logpath)
-    execute 'edit' .. fnameescape(typeset.LogPath(bufname))
+    execute 'edit' fnameescape(typeset.LogPath(bufname))
     return
   endif
 

--- a/runtime/autoload/typeset.vim
+++ b/runtime/autoload/typeset.vim
@@ -2,10 +2,7 @@ vim9script
 
 # Language:           Generic TeX typesetting engine
 # Maintainer:         Nicola Vitacolonna <nvitacolonna@gmail.com>
-# Latest Revision:    2026 Feb 19
-# Last Change:
-# 2026 Mar 30 by Vim project: Use fnameescape for the ProcessOutput command
-# 2026 May 19 by Vim project: missing space in :lcd command #20244
+# Latest Revision:    2026 May 20
 
 # Constants and helpers {{{
 const SLASH = !exists("+shellslash") || &shellslash ? '/' : '\'


### PR DESCRIPTION
Following up on https://github.com/vim/vim/issues/20242, this PR fixes a similar regression in `runtime/autoload/context.vim`.

I take the opportunity to remind people that for issues in filetype plugins it is a good idea to notify a plugin's maintainer instead of opening an issue directly in Vim's repo. By doing so the maintainer is informed and can take care of the fix, lifting the burden from Vim's developers. Contact information can be found in the affected runtime scripts.