### PR TITLE
configure: allow GTK4 build without X11

### DIFF
--- a/src/auto/configure
+++ b/src/auto/configure
@@ -5193,7 +5193,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.beam \
 
             CPPFLAGS="$CPPFLAGS -DMACOS_X_DARWIN"
 
-               if test -z "$with_x" -a "X$enable_gui" != Xmotif -a "X$enable_gui" != Xgtk2 -a "X$enable_gui" != Xgtk3; then
+               if test -z "$with_x" -a "X$enable_gui" != Xmotif -a "X$enable_gui" != Xgtk2 -a "X$enable_gui" != Xgtk3 -a "X$enable_gui" != Xgtk4; then
       with_x=no
      fi
   fi
@@ -10469,7 +10469,7 @@ if test "x$with_x" = xno -a "x$with_x_arg" = xyes; then
     as_fn_error $? "could not configure X" "$LINENO" 5
 fi
 
-test "x$with_x" = xno -a "x$HAIKU" != "xyes" -a "x$MACOS_X" != "xyes" -a "x$QNX" != "xyes" && enable_gui=no
+test "x$with_x" = xno -a "x$HAIKU" != "xyes" -a "x$MACOS_X" != "xyes" -a "x$QNX" != "xyes" -a "x$enable_gui" != xgtk4 && enable_gui=no
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking --enable-gui argument" >&5
 printf %s "checking --enable-gui argument... " >&6; }

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -330,7 +330,7 @@ if test "$vim_cv_uname_output" = Darwin; then
 
      dnl Assume we don't want X11 unless it was specifically asked for
      dnl (--with-x) or Motif or GTK GUI is used.
-     if test -z "$with_x" -a "X$enable_gui" != Xmotif -a "X$enable_gui" != Xgtk2 -a "X$enable_gui" != Xgtk3; then
+     if test -z "$with_x" -a "X$enable_gui" != Xmotif -a "X$enable_gui" != Xgtk2 -a "X$enable_gui" != Xgtk3 -a "X$enable_gui" != Xgtk4; then
       with_x=no
      fi
   fi
@@ -2609,7 +2609,7 @@ if test "x$with_x" = xno -a "x$with_x_arg" = xyes; then
     AC_MSG_ERROR([could not configure X])
 fi
 
-test "x$with_x" = xno -a "x$HAIKU" != "xyes" -a "x$MACOS_X" != "xyes" -a "x$QNX" != "xyes" && enable_gui=no
+test "x$with_x" = xno -a "x$HAIKU" != "xyes" -a "x$MACOS_X" != "xyes" -a "x$QNX" != "xyes" -a "x$enable_gui" != xgtk4 && enable_gui=no
 
 AC_MSG_CHECKING(--enable-gui argument)
 AC_ARG_ENABLE(gui,


### PR DESCRIPTION
GTK4 does not use X11 APIs directly; the X11 backend is loaded by GTK4 at runtime as a dependency of GTK4 itself. Currently configure forces a hard X11 dependency for any GUI build, so passing `--enable-gui=gtk4` on a system without X11 development headers ends up disabling the GUI entirely.

This change adds `gtk4` as an exception in two places where X11 is treated as mandatory for GUI builds:

- In the Darwin block, where the `with_x=no` default is suppressed for Motif/GTK2/GTK3 — GTK4 is added so that an explicit `--enable-gui=gtk4` is treated consistently with the other GTK toolkits.
- In the post-X11-detection guard that forces `enable_gui=no` when `with_x=no`, so a failed X11 probe no longer disables GUI when the user has explicitly requested GTK4.

X11 detection is still attempted (so the build continues to pick up X11 when available) but its failure is no longer fatal for an explicit GTK4 build.