### PR TITLE
Refactor event_nr2name() to return a string_T *

### DIFF
--- a/src/autocmd.c
+++ b/src/autocmd.c
@@ -261,7 +261,7 @@ static int current_augroup = AUGROUP_DEFAULT;
 static int au_need_clean = FALSE;   // need to delete marked patterns
 
 static event_T event_name2nr(char_u *start, char_u **end);
-static char_u *event_nr2name(event_T event);
+static string_T *event_nr2name(event_T event);
 static int au_get_grouparg(char_u **argp);
 static int do_autocmd_event(event_T event, char_u *pat, int once, int nested, char_u *cmd, int forceit, int group, int flags);
 static int apply_autocmds_group(event_T event, char_u *fname, char_u *fname_io, int force, int group, buf_T *buf, exarg_T *eap);
@@ -305,6 +305,8 @@ show_autocmd(AutoPat *ap, event_T event)
 	goto theend;
     if (event != last_event || ap->group != last_group)
     {
+	string_T    *event_name;
+
 	if (ap->group != AUGROUP_DEFAULT)
 	{
 	    if (AUGROUP_NAME(ap->group) == NULL)
@@ -313,7 +315,8 @@ show_autocmd(AutoPat *ap, event_T event)
 		msg_puts_attr((char *)AUGROUP_NAME(ap->group), HL_ATTR(HLF_T));
 	    msg_puts("  ");
 	}
-	msg_puts_attr((char *)event_nr2name(event), HL_ATTR(HLF_T));
+	event_name = event_nr2name(event);
+	msg_puts_attr((char *)event_name->string, HL_ATTR(HLF_T));
 	last_event = event;
 	last_group = ap->group;
 	msg_putchar('\n');
@@ -485,9 +488,12 @@ aubuflocal_remove(buf_T *buf)
 		au_remove_pat(ap);
 		if (p_verbose >= 6)
 		{
+		    string_T	*event_name;
+
 		    verbose_enter();
+		    event_name = event_nr2name(event);
 		    smsg(_("auto-removing autocommand: %s <buffer=%d>"),
-					   event_nr2name(event), buf->b_fnum);
+				       event_name->string, buf->b_fnum);
 		    verbose_leave();
 		}
 	    }
@@ -710,13 +716,14 @@ event_name2nr(char_u *start, char_u **end)
 /*
  * Return the name for event "event".
  */
-    static char_u *
+    static string_T *
 event_nr2name(event_T event)
 {
     int	    i;
-#define CACHE_SIZE 12
+    enum {CACHE_SIZE = 12};
     static int cache_tab[CACHE_SIZE];
     static int cache_last_index = -1;
+    static string_T unknown = STR_LITERAL_INIT("Unknown");
 
     if (cache_last_index < 0)
     {
@@ -731,7 +738,7 @@ event_nr2name(event_T event)
     for (i = cache_last_index; cache_tab[i] >= 0; )
     {
 	if ((event_T)abs(event_tab[cache_tab[i]].key) == event)
-	    return event_tab[cache_tab[i]].value.string;
+	    return &event_tab[cache_tab[i]].value;
 
 	if (i == 0)
 	    i = CACHE_SIZE - 1;
@@ -755,12 +762,11 @@ event_nr2name(event_T event)
 	    else
 		++cache_last_index;
 	    cache_tab[cache_last_index] = i;
-	    break;
+	    return &event_tab[i].value;
 	}
     }
 
-    return (i == NUM_EVENTS) ? (char_u *)"Unknown" :
-						    event_tab[i].value.string;
+    return &unknown;
 }
 
 /*
@@ -2630,8 +2636,6 @@ auto_next_pat(
 {
     AutoPat	*ap;
     AutoCmd	*cp;
-    char_u	*name;
-    char	*s;
     estack_T	*entry;
     char_u	*namep;
 
@@ -2657,12 +2661,15 @@ auto_next_pat(
 				      apc->sfname, apc->tail, ap->allow_dirs))
 		    : ap->buflocal_nr == apc->arg_bufnr)
 	    {
-		name = event_nr2name(apc->event);
-		s = _("%s Autocommands for \"%s\"");
-		namep = alloc(STRLEN(s) + STRLEN(name) + ap->patlen + 1);
+		string_T    *event_name;
+		char	    *fmt;
+
+		event_name = event_nr2name(apc->event);
+		fmt = _("%s Autocommands for \"%s\"");
+		namep = alloc(STRLEN(fmt) + event_name->length + ap->patlen + 1);
 		if (namep != NULL)
 		{
-		    sprintf((char *)namep, s, (char *)name, (char *)ap->pat);
+		    sprintf((char *)namep, fmt, (char *)event_name->string, (char *)ap->pat);
 		    if (p_verbose >= 8)
 		    {
 			verbose_enter();
@@ -3364,7 +3371,6 @@ f_autocmd_get(typval_T *argvars, typval_T *rettv)
     AutoCmd	*ac;
     list_T	*event_list;
     dict_T	*event_dict;
-    string_T	event_name = {NULL, 0};
     char_u	*pat = NULL;
     char_u	*name = NULL;
     int		group = AUGROUP_ALL;
@@ -3443,11 +3449,12 @@ f_autocmd_get(typval_T *argvars, typval_T *rettv)
     for (event = (event_T)0; (int)event < NUM_EVENTS;
 	    event = (event_T)((int)event + 1))
     {
+	string_T    *event_name;
+
 	if (event_arg != NUM_EVENTS && event != event_arg)
 	    continue;
 
-	event_name.string = event_nr2name(event);
-	event_name.length = STRLEN(event_name.string);
+	event_name = event_nr2name(event);
 
 	// iterate through all the patterns for this autocmd event
 	FOR_ALL_AUTOCMD_PATTERNS(event, ap)
@@ -3482,7 +3489,7 @@ f_autocmd_get(typval_T *argvars, typval_T *rettv)
 		}
 
 		if (dict_add_string_len(event_dict, "event",
-			event_name.string, (int)event_name.length) == FAIL
+			event_name->string, (int)event_name->length) == FAIL
 			|| dict_add_string_len(event_dict, "group",
 			    group_name.string, (int)group_name.length) == FAIL
 			|| (ap->buflocal_nr != 0

--- a/src/autocmd.c
+++ b/src/autocmd.c
@@ -2635,9 +2635,7 @@ auto_next_pat(
     int		stop_at_last)	    // stop when 'last' flag is set
 {
     AutoPat	*ap;
-    AutoCmd	*cp;
     estack_T	*entry;
-    char_u	*namep;
 
     entry = ((estack_T *)exestack.ga_data) + exestack.ga_len - 1;
 
@@ -2663,6 +2661,8 @@ auto_next_pat(
 	    {
 		string_T    *event_name;
 		char	    *fmt;
+		char_u	    *namep;
+		AutoCmd	    *cp;
 
 		event_name = event_nr2name(apc->event);
 		fmt = _("%s Autocommands for \"%s\"");


### PR DESCRIPTION
This PR refactors `event_nr2name()` to return a `string_T *`.

We do this so we can use the length instead of having to measure it.

In addition:
->change the `define` to an `enum`.
->In function `auto_next_pat()`, move some variables closer to where they are used. Rename `s` to `fmt` along the way.

Cheers
John