### PR TITLE
cmdline: complete user :K* via ":k..." when 'ignorecase'

### DIFF
--- a/src/cmdexpand.c
+++ b/src/cmdexpand.c
@@ -1761,7 +1761,8 @@ set_cmd_index(char_u *cmd, exarg_T *eap, expand_T *xp, int *complp)
     // - the 'k' command can directly be followed by any character, but do
     // accept "keepmarks", "keepalt" and "keepjumps". Bypass also when
     // 'ignorecase' is set so a lowercase ":kz" still completes a user
-    // command like :Kz (#20241), and for fuzzy matching as before.
+    // command like :Kz (#20241), and for fuzzy matching as that can find
+    // matches anywhere in the command name.
     // - the 's' command can be followed directly by 'c', 'g', 'i', 'I' or 'r'
     if (!fuzzy && !p_ic && (*cmd == 'k' && cmd[1] != 'e'))
     {

--- a/src/cmdexpand.c
+++ b/src/cmdexpand.c
@@ -1759,11 +1759,11 @@ set_cmd_index(char_u *cmd, exarg_T *eap, expand_T *xp, int *complp)
     // Isolate the command and search for it in the command table.
     // Exceptions:
     // - the 'k' command can directly be followed by any character, but do
-    // accept "keepmarks", "keepalt" and "keepjumps". As fuzzy matching can
-    // find matches anywhere in the command name, do this only for command
-    // expansion based on regular expression and not for fuzzy matching.
+    // accept "keepmarks", "keepalt" and "keepjumps". Bypass also when
+    // 'ignorecase' is set so a lowercase ":kz" still completes a user
+    // command like :Kz (#20241), and for fuzzy matching as before.
     // - the 's' command can be followed directly by 'c', 'g', 'i', 'I' or 'r'
-    if (!fuzzy && (*cmd == 'k' && cmd[1] != 'e'))
+    if (!fuzzy && !p_ic && (*cmd == 'k' && cmd[1] != 'e'))
     {
 	eap->cmdidx = CMD_k;
 	p = cmd + 1;

--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -4095,6 +4095,27 @@ func Test_fuzzy_completion_cmd_k()
   set wildoptions&
 endfunc
 
+" Issue #20241: with 'ignorecase', a lowercase "k"-prefixed input should
+" still complete a user command starting with "K".
+func Test_cmdline_complete_user_cmd_k_with_ignorecase()
+  command! Kz echo "hello"
+  command! Gz echo "here"
+
+  set noignorecase
+  call assert_equal([], getcompletion('kz', 'cmdline'))
+  call assert_equal([], getcompletion('gz', 'cmdline'))
+  call assert_equal(['Kz'], getcompletion('Kz', 'cmdline'))
+  call assert_equal(['Gz'], getcompletion('Gz', 'cmdline'))
+
+  set ignorecase
+  call assert_equal(['Kz'], getcompletion('kz', 'cmdline'))
+  call assert_equal(['Gz'], getcompletion('gz', 'cmdline'))
+
+  set ignorecase&
+  delcommand Kz
+  delcommand Gz
+endfunc
+
 " Test for fuzzy completion for user defined custom completion function
 func Test_fuzzy_completion_custom_func()
   func Tcompl(a, c, p)


### PR DESCRIPTION
With 'ignorecase' set, `:gz<Tab>` completes to a user command `:Gz`, but `:kz<Tab>` does not reach a user command `:Kz`. This is because `set_cmd_index()` short-circuits any `:k<X>` as `:k {X}` (the mark argument) before command-name expansion runs.

Skip the short-circuit when `p_ic` is set so the input flows through the normal command-name expansion path. Default behaviour (`noignorecase`) is unchanged, so `Test_cmdline_complete_various` and `Test_fuzzy_completion_cmd_k` still pass.

A regression test is added that covers both `noignorecase` and `ignorecase`.

Fixes #20241