### PR TITLE
runtime(doc): fix a typo in :map-local

### DIFF
--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -208,7 +208,7 @@ be effective in the current buffer only.  Example: >
 Then you can map ",w" to something else in another buffer: >
 	:map <buffer>  ,w  /[#&!]<CR>
 The local buffer mappings are used before the global ones.  See <nowait> below
-to make a short local mapping not taking effect when a longer global one
+to make a short local mapping taking effect when a longer global one
 exists.
 The "<buffer>" argument can also be used to clear mappings: >
 	:unmap <buffer> ,w


### PR DESCRIPTION
Problem: found a typo in `:h map-local`, which makes that section of document unfriendly for careful readers.
Solution: fix the target sentence.

Ref: https://vi.stackexchange.com/q/48667.