### PR TITLE
Update foldcolumn overflow logic

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -300,14 +300,15 @@ fill_foldcolumn(
 	if (win_foldinfo.fi_lnum == lnum
 		&& first_level + i >= win_foldinfo.fi_low_level)
 	    symbol = wp->w_fill_chars.foldopen;
-	else if (first_level == 1)
-	    symbol = wp->w_fill_chars.foldsep;
-	else if (wp->w_fill_chars.foldinner != NUL)
-	    symbol = wp->w_fill_chars.foldinner;
-	else if (first_level + i <= 9)
-	    symbol = '0' + first_level + i;
+	else if (i == 0 && first_level > 1)
+	    if (wp->w_fill_chars.foldinner != NUL)
+		symbol = wp->w_fill_chars.foldinner;
+	    else if (first_level <= 9)
+		symbol = '0' + first_level;
+	    else
+		symbol = '>';
 	else
-	    symbol = '>';
+	    symbol = wp->w_fill_chars.foldsep;
 
 	len = utf_char2bytes(symbol, &p[byte_counter]);
 	byte_counter += len;

--- a/src/testdir/test_display.vim
+++ b/src/testdir/test_display.vim
@@ -462,6 +462,31 @@ func Test_fold_fillchars()
         \ ]
   call assert_equal(expected, lines)
 
+  " check fdc >= 3
+  normal! 4ggzo
+  set fdc=3 foldmethod=manual
+  let lines = ScreenLines([1, 6], 26)
+  let expected = [
+        \ '   one                  ',
+        \ '▼          two          ',
+        \ '‖          two          ',
+        \ '‖▼                 three',
+        \ '‖‖                 three',
+        \ '   four                 ',
+        \ ]
+
+  normal! 3ggzf2j
+  let lines = ScreenLines([1, 6], 26)
+  let expected = [
+        \ '   one                  ',
+        \ '▼          two          ',
+        \ '‖▼         two          ',
+        \ '2▼                 three',
+        \ '2‖                 three',
+        \ '   four                 ',
+        \ ]
+
+
   %bw!
   set fillchars& fdc& foldmethod& foldenable&
 endfunc

--- a/src/testdir/test_fold.vim
+++ b/src/testdir/test_fold.vim
@@ -1228,7 +1228,7 @@ func s:mbyte_fillchar_tests(fo, fc, fs)
         \ a:fo .. '  one    ',
         \ a:fs .. a:fo .. ' two    ',
         \ '2' .. a:fo .. ' three  ',
-        \ '23 four   ',
+        \ '2' .. a:fs .. ' four   ',
         \ a:fs .. a:fs .. ' five   ',
         \ a:fs .. '  six    ',
         \ ], ScreenLines([1, 6], 10))
@@ -1283,7 +1283,7 @@ func s:mbyte_fillchar_tests(fo, fc, fs)
         \ a:fo .. '      1 one  ',
         \ a:fs .. a:fo .. '     2 two  ',
         \ '2' .. a:fo .. ' ->  3 three',
-        \ '23     4 four ',
+        \ '2' .. a:fs ..     '     4 four ',
         \ a:fs .. a:fs .. '     5 five ',
         \ a:fs .. '      6 six  '
         \ ], ScreenLines([1, 6], 14))
@@ -1298,7 +1298,7 @@ func s:mbyte_fillchar_tests(fo, fc, fs)
           \  strcharpart(lines[1], strchars(lines[1]) - 10, 10))
     call assert_equal('t 3  >- ' .. a:fo .. '2',
           \  strcharpart(lines[2], strchars(lines[2]) - 10, 10))
-    call assert_equal('f 4     32',
+    call assert_equal('f 4     ' .. a:fs .. '2',
           \  strcharpart(lines[3], strchars(lines[3]) - 10, 10))
     call assert_equal('f 5     ' .. a:fs .. a:fs,
           \  strcharpart(lines[4], strchars(lines[4]) - 10, 10))
@@ -1313,20 +1313,20 @@ func s:mbyte_fillchar_tests(fo, fc, fs)
 
   " Add a test with more than 9 folds (and then delete some folds)
   normal zE
-  for i in range(1, 10)
+  for i in range(1, 11)
     normal zfGzo
   endfor
   normal zR
   call assert_equal([
         \ a:fo .. a:fo .. ' one ',
-        \ '9> two '
+        \ '>' .. a:fs .. ' two '
         \ ], ScreenLines([1, 2], 7))
   normal 1Gzd
   call assert_equal([
         \ a:fo .. a:fo .. ' one ',
-        \ '89 two '
+        \ '9' .. a:fs .. ' two '
         \ ], ScreenLines([1, 2], 7))
-  normal 1Gzdzdzdzdzdzdzd
+  normal 1Gzdzdzdzdzdzdzdzd
   call assert_equal([
         \ a:fo .. a:fo .. ' one ',
         \ a:fs .. a:fs .. ' two '


### PR DESCRIPTION
See https://github.com/neovim/neovim/issues/39916 and my comment (https://github.com/neovim/neovim/issues/39916#issuecomment-4508460763). This PR implements the 2nd solution.

Current `foldcolumn` behavior when `fdc=3`:

```
-  line 1
|- line 2
2- line 3
23 line 4
```

Proposed behavior:

```
-  line 1
|- line 2
2- line 3
2| line 4
```

And with `fdc=4`:

```
-   line 1
|-  line 2
||- line 3
2|- line 4
2|| line 5
```

On lines where we can't draw all the fold levels, this would turn the first column into a spill indicator. Thus `2|` would mean there are two fold levels that are "collapsed".

IMO this is a better use of the limited space than always displaying `[n-1][n]`, and is a bit clearer visually.