### PR TITLE
runtime(debversions): Add stonking (26.10) as Ubuntu release name

### DIFF
--- a/runtime/syntax/shared/debversions.vim
+++ b/runtime/syntax/shared/debversions.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:     Debian version information
 " Maintainer:   Debian Vim Maintainers
-" Last Change:  2026 Jan 01
+" Last Change:  2026 May 21
 " URL: https://salsa.debian.org/vim-team/vim-debian/blob/main/syntax/shared/debversions.vim
 
 let s:cpo = &cpo
@@ -12,7 +12,7 @@ let g:debSharedSupportedVersions = [
       \ 'oldstable', 'stable', 'testing', 'unstable', 'experimental', 'sid', 'rc-buggy',
       \ 'bookworm', 'trixie', 'forky', 'duke',
       \
-      \ 'jammy', 'noble', 'questing', 'resolute',
+      \ 'jammy', 'noble', 'questing', 'resolute', 'stonking',
       \ 'devel'
       \ ]
 " Historic version names, no longer under standard support


### PR DESCRIPTION
https://documentation.ubuntu.com/release-notes/26.10/schedule/

Unsure if this needs to go though vim-debian on Salsa first.