### PR TITLE
tests: add a test for wrong shellescape() command in combination with :!

### DIFF
--- a/src/testdir/test_codestyle.vim
+++ b/src/testdir/test_codestyle.vim
@@ -195,4 +195,27 @@ def Test_indent_of_source_files()
   endfor
 enddef
 
+def Test_runtime_wrong_shellescape()
+  # Check that shellescape() is called with the {special} argument (a second,
+  # non-zero argument) when its result is used in a ":!" ex command.
+  # This could cause code injection!
+  var pattern = '\<shellescape(\%([^,()]\|([^()]*)\)\+)'
+
+  var q = "['" .. '"]'
+  var bang_exe = '\<\%(exe\%[cute]\|sil\%[ent]\)\>.*' .. q .. '[^"' .. "']*!"
+
+  var skip = 'getline(".") !~ ' .. string(bang_exe)
+    .. ' || getline(".") =~ ' .. string('\<system\%(list\)\=(')
+    .. ' || getline(".") =~ ' .. string('^\s*"')
+
+  for fpath in glob('../../runtime/**/*.vim', 0, 1)
+    g:ignoreSwapExists = 'e'
+    exe 'edit ' .. fpath
+    PerformCheck(fpath, pattern,
+      'shellescape() without {special} flag used in ":!" command', skip)
+  endfor
+
+  :%bwipe!
+enddef
+
 " vim: shiftwidth=2 sts=2 expandtab nofoldenable


### PR DESCRIPTION
This has lead to a few security relevant issues, so add a test that checks all runtime files for any ! followed by a shellescape() that does not use the {special} arg.

related: Commit: 3fb5e58fbc63d86a3e65f1a141b0d67af2 (patch 9.2.0479:
         [security]: runtime(tar): command injection in tar plugin)

Supported by AI