### PR TITLE
configure: skip X11 dependency checks for GTK4 builds

### DIFF
--- a/src/auto/configure
+++ b/src/auto/configure
@@ -9296,8 +9296,11 @@ CPPFLAGS=$cppflags_save
 CFLAGS=$cflags_save
 fi
 
+if test "x$enable_gui" = "xgtk4"; then
+  with_x=no
+fi
 test -z "$with_x" && with_x=yes
-test "${enable_gui-yes}" != no -a "x$MACOS_X" != "xyes" -a "x$QNX" != "xyes" && with_x=yes
+test "${enable_gui-yes}" != no -a "x$MACOS_X" != "xyes" -a "x$QNX" != "xyes" -a "x$enable_gui" != "xgtk4" && with_x=yes
 if test "$with_x" = no; then
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: defaulting to: don't HAVE_X11" >&5
 printf "%s\n" "defaulting to: don't HAVE_X11" >&6; }
@@ -10465,7 +10468,7 @@ printf "%s\n" "#define SIZEOF_WCHAR_T $ac_cv_sizeof_wchar_t" >>confdefs.h
   fi
 fi
 
-if test "x$with_x" = xno -a "x$with_x_arg" = xyes; then
+if test "x$with_x" = xno -a "x$with_x_arg" = xyes -a "x$enable_gui" != "xgtk4"; then
     as_fn_error $? "could not configure X" "$LINENO" 5
 fi
 
@@ -11921,7 +11924,7 @@ printf "%s\n" "$NARROW_PROTO" >&6; }
 
 fi
 
-if test "$enable_xsmp" = "yes"; then
+if test "$enable_xsmp" = "yes" -a "x$with_x" != "xno"; then
   cppflags_save=$CPPFLAGS
   CPPFLAGS="$CPPFLAGS $X_CFLAGS"
   ac_fn_c_check_header_compile "$LINENO" "X11/SM/SMlib.h" "ac_cv_header_X11_SM_SMlib_h" "$ac_includes_default"

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -2489,8 +2489,15 @@ CPPFLAGS=$cppflags_save
 CFLAGS=$cflags_save
 fi
 
+dnl GTK4 does not use X11 APIs directly, so skip X11 detection entirely.
+dnl This avoids pulling libICE/libSM/libX11/libXt into build dependencies
+dnl for GTK4-only builds, even when --with-x=yes is passed (e.g. by a
+dnl distro's default packaging script).
+if test "x$enable_gui" = "xgtk4"; then
+  with_x=no
+fi
 test -z "$with_x" && with_x=yes
-test "${enable_gui-yes}" != no -a "x$MACOS_X" != "xyes" -a "x$QNX" != "xyes" && with_x=yes
+test "${enable_gui-yes}" != no -a "x$MACOS_X" != "xyes" -a "x$QNX" != "xyes" -a "x$enable_gui" != "xgtk4" && with_x=yes
 if test "$with_x" = no; then
   AC_MSG_RESULT(defaulting to: don't HAVE_X11)
 else
@@ -2605,7 +2612,8 @@ else
 fi
 
 dnl Check if --with-x was given but it doesn't work.
-if test "x$with_x" = xno -a "x$with_x_arg" = xyes; then
+dnl GTK4 always forces with_x=no above, so don't treat that as a failure.
+if test "x$with_x" = xno -a "x$with_x_arg" = xyes -a "x$enable_gui" != "xgtk4"; then
     AC_MSG_ERROR([could not configure X])
 fi
 
@@ -3275,8 +3283,9 @@ EOF
 fi
 
 dnl Look for XSMP support - but don't necessarily restrict it to X11 GUIs
-dnl use the X11 include path
-if test "$enable_xsmp" = "yes"; then
+dnl use the X11 include path.  Skip when X11 is not in use; USE_XSMP itself
+dnl requires HAVE_X11, so the header check would be wasted otherwise.
+if test "$enable_xsmp" = "yes" -a "x$with_x" != "xno"; then
   cppflags_save=$CPPFLAGS
   CPPFLAGS="$CPPFLAGS $X_CFLAGS"
   AC_CHECK_HEADERS(X11/SM/SMlib.h)


### PR DESCRIPTION
GTK4 does not use X11 APIs directly; its X11 backend is loaded at runtime. Force with_x=no when --enable-gui=gtk4 so configure does not probe for libICE/libSM/libX11/libXt/libXdmcp/libXpm, avoiding packagers pulling those into build dependencies. Also skip the XSMP X11/SM/SMlib.h header check when X11 is disabled, since USE_XSMP itself requires HAVE_X11.

Closes #20268