### PR TITLE
virtualedit=insert doesn't work during change operation

### DIFF
--- a/src/misc2.c
+++ b/src/misc2.c
@@ -24,15 +24,16 @@ virtual_active(void)
 {
     unsigned int cur_ve_flags = get_ve_flags();
 
+    if (cur_ve_flags == VE_ALL
+	    || ((cur_ve_flags & VE_INSERT) && (State & MODE_INSERT)))
+	return TRUE;
+
     // While an operator is being executed we return "virtual_op", because
     // VIsual_active has already been reset, thus we can't check for "block"
     // being used.
     if (virtual_op != MAYBE)
 	return virtual_op;
-    return (cur_ve_flags == VE_ALL
-	    || ((cur_ve_flags & VE_BLOCK) && VIsual_active
-						      && VIsual_mode == Ctrl_V)
-	    || ((cur_ve_flags & VE_INSERT) && (State & MODE_INSERT)));
+    return (cur_ve_flags & VE_BLOCK) && VIsual_active && VIsual_mode == Ctrl_V;
 }
 
 /*

--- a/src/testdir/test_virtualedit.vim
+++ b/src/testdir/test_virtualedit.vim
@@ -753,4 +753,39 @@ func Test_virtualedit_getpos_stable_past_eol_after_visual()
   bwipe!
 endfunc
 
+func Test_virtualedit_insert()
+  new
+  set virtualedit=insert
+
+  call feedkeys("ifoobar\<Right>\<Right>\<Right>\<Right>baz\<Esc>", 'tnix')
+  call assert_equal('foobar    baz', getline(1))
+
+  call feedkeys("ccFOOBAR\<Right>\<Right>\<Right>\<Right>BAZ\<Esc>", 'tnix')
+  call assert_equal('FOOBAR    BAZ', getline(1))
+
+  set virtualedit&
+  bwipe!
+endfunc
+
+func Test_set_virtualedit_on_mode_change()
+  new
+  set virtualedit=all
+  augroup testing
+    au ModeChanged n:* set virtualedit=onemore
+    au ModeChanged *:n set virtualedit=all
+    au ModeChanged i:* call cursor(getpos("'^")[1:])
+  augroup END
+
+  call feedkeys("ilkj\<Esc>", 'tnix')
+  call assert_equal([0, 1, 4, 0], getpos('.'))
+
+  call feedkeys("cclkj\<Esc>", 'tnix')
+  call assert_equal([0, 1, 4, 0], getpos('.'))
+
+  au! testing ModeChanged
+  augroup! testing
+  set virtualedit&
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  virtualedit=insert doesn't work during change operation
          (after 6.1.014).
Solution: Make virtual_op only affect virtualedit=block.

related: neovim/neovim#35391
