### PR TITLE
Support fullscreen (guioptions+=s) for GTK

### DIFF
--- a/runtime/doc/gui.txt
+++ b/runtime/doc/gui.txt
@@ -1254,6 +1254,32 @@ A recommended Japanese font is MS Mincho.  You can find info here:
 https://learn.microsoft.com/en-us/typography/font-list/ms-mincho
 It should be distributed with Windows.
 
+
+Full Screen						*gui-fullscreen*
+
+Fullscreen mode is currently only supported in the Windows and GTK GUI
+versions of Vim.
+
+To enable fullscreen mode in the GUI version of Vim, add the 's' flag
+to the 'guioptions' setting.
+
+For convenience, you can define a command or mapping to toggle fullscreen
+mode:
+>
+	command ToggleFullscreen {
+	  if &guioptions =~# 's'
+	    set guioptions-=s
+	  else
+	    set guioptions+=s
+	  endif
+	}
+
+	map <expr> <F11> &go =~# 's' ? ":se go-=s<CR>" : ":se go+=s<CR>"
+
+The fullscreen mode will occupy the entire screen area while hiding window
+decorations such as the title bar and borders.
+
+
 ==============================================================================
 8. Shell Commands					*gui-shell*
 

--- a/runtime/doc/gui_w32.txt
+++ b/runtime/doc/gui_w32.txt
@@ -505,25 +505,4 @@ To use the system's default title bar colors, set highlighting groups to
 	hi TitleBarNC guibg=NONE guifg=NONE
 <
 
-Full Screen						*gui-w32-fullscreen*
-
-To enable fullscreen mode in the Windows GUI version of Vim, add the 's' flag
-to the 'guioptions' setting.
-
-For convenience, you can define a command or mapping to toggle fullscreen
-mode:
->
-	command ToggleFullscreen {
-	  if &guioptions =~# 's'
-	    set guioptions-=s
-	  else
-	    set guioptions+=s
-	  endif
-	}
-
-	map <expr> <F11> &go =~# 's' ? ":se go-=s<CR>" : ":se go+=s<CR>"
-
-The fullscreen mode will occupy the entire screen area while hiding window
-decorations such as the title bar and borders.
-
  vim:tw=78:sw=4:ts=8:noet:ft=help:norl:

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4613,10 +4613,10 @@ A jump table for the options with a short description can be found at |Q_op|.
 		Photon GUIs.
 								*'go-s'*
 	  's'	Enable fullscreen mode.  Currently only supported in the
-		MS-Windows GUI version.  When set, the window will occupy the
-		entire screen and remove window decorations.  Define custom
-		mappings to toggle this mode conveniently.  For detailed usage
-		instructions, see |gui-w32-fullscreen|.
+		MS-Windows and GTK GUI version.  When set, the window will
+		occupy the entire screen and remove window decorations.
+		Define custom mappings to toggle this mode conveniently.
+		For detailed usage instructions, see |gui-fullscreen|.
 								*'go-r'*
 	  'r'	Right-hand scrollbar is always present.
 								*'go-R'*

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -8257,6 +8257,7 @@ gui-font	gui.txt	/*gui-font*
 gui-fontwide	gui.txt	/*gui-fontwide*
 gui-footer	debugger.txt	/*gui-footer*
 gui-fork	gui_x11.txt	/*gui-fork*
+gui-fullscreen	gui.txt	/*gui-fullscreen*
 gui-functions	usr_41.txt	/*gui-functions*
 gui-gnome	gui_x11.txt	/*gui-gnome*
 gui-gnome-session	gui_x11.txt	/*gui-gnome-session*
@@ -8286,7 +8287,6 @@ gui-vert-scroll	gui.txt	/*gui-vert-scroll*
 gui-w32	gui_w32.txt	/*gui-w32*
 gui-w32-cmdargs	gui_w32.txt	/*gui-w32-cmdargs*
 gui-w32-dialogs	gui_w32.txt	/*gui-w32-dialogs*
-gui-w32-fullscreen	gui_w32.txt	/*gui-w32-fullscreen*
 gui-w32-printing	gui_w32.txt	/*gui-w32-printing*
 gui-w32-start	gui_w32.txt	/*gui-w32-start*
 gui-w32-title-bar	gui_w32.txt	/*gui-w32-title-bar*

--- a/src/gui.c
+++ b/src/gui.c
@@ -158,7 +158,7 @@ gui_start(char_u *arg UNUSED)
 	choose_clipmethod();
 #endif
 
-#ifdef FEAT_GUI_MSWIN
+#if defined(FEAT_GUI_MSWIN) || defined(FEAT_GUI_GTK)
     // Enable fullscreen mode
     if (vim_strchr(p_go, GO_FULLSCREEN) != NULL)
        gui_mch_set_fullscreen(TRUE);
@@ -3512,7 +3512,9 @@ gui_init_which_components(char_u *oldval UNUSED)
 #ifdef FEAT_GUI_MSWIN
     static int	prev_titlebar = FALSE;
     int		using_titlebar = FALSE;
+#endif
 
+#if defined(FEAT_GUI_MSWIN) || defined(FEAT_GUI_GTK)
     static int	prev_fullscreen = FALSE;
     int		using_fullscreen = FALSE;
 #endif
@@ -3589,6 +3591,8 @@ gui_init_which_components(char_u *oldval UNUSED)
 	    case GO_TITLEBAR:
 		using_titlebar = TRUE;
 		break;
+#endif
+#if defined(FEAT_GUI_MSWIN) || defined(FEAT_GUI_GTK)
 	    case GO_FULLSCREEN:
 		using_fullscreen = TRUE;
 		break;
@@ -3620,7 +3624,9 @@ gui_init_which_components(char_u *oldval UNUSED)
 	gui_mch_set_titlebar_colors();
 	prev_titlebar = using_titlebar;
     }
+#endif
 
+#if defined(FEAT_GUI_MSWIN) || defined(FEAT_GUI_GTK)
     if (using_fullscreen != prev_fullscreen)
     {
 	gui_mch_set_fullscreen(using_fullscreen);

--- a/src/gui_gtk.c
+++ b/src/gui_gtk.c
@@ -2611,3 +2611,12 @@ recent_func_log_func(const gchar *log_domain UNUSED,
     // http://bugzilla.gnome.org/show_bug.cgi?id=664587
 }
 #endif
+
+    void
+gui_mch_set_fullscreen(int flag)
+{
+    if (flag)
+	gtk_window_fullscreen(GTK_WINDOW(gui.mainwin));
+    else
+	gtk_window_unfullscreen(GTK_WINDOW(gui.mainwin));
+}

--- a/src/gui_gtk4.c
+++ b/src/gui_gtk4.c
@@ -280,6 +280,7 @@ static gboolean drop_cb(GtkDropTarget *target, const GValue *value, double x, do
 #endif
 static void mainwin_destroy_cb(GObject *object, gpointer data);
 static gboolean delete_event_cb(GtkWindow *window, gpointer data);
+static void mainwin_fullscreened_cb(GObject *obj, GParamSpec *pspec, gpointer user_data);
 static void drawarea_realize_cb(GtkWidget *widget, gpointer data);
 static void drawarea_unrealize_cb(GtkWidget *widget, gpointer data);
 static void drawarea_resize_cb(GtkDrawingArea *area, int width, int height, gpointer data);
@@ -449,6 +450,8 @@ gui_mch_init(void)
 
     g_signal_connect(G_OBJECT(gui.mainwin), "close-request",
 		     G_CALLBACK(delete_event_cb), NULL);
+    g_signal_connect(G_OBJECT(gui.mainwin), "notify::fullscreened",
+		     G_CALLBACK(mainwin_fullscreened_cb), NULL);
 
     // A vertical box holds the menubar, toolbar and main text window.
     vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
@@ -745,6 +748,26 @@ gui_mch_unmaximize(void)
 {
     if (gui.mainwin != NULL)
 	gtk_window_unmaximize(GTK_WINDOW(gui.mainwin));
+}
+
+    void
+gui_mch_set_fullscreen(int flag)
+{
+    if (gui.mainwin == NULL)
+	return;
+    if (flag)
+	gtk_window_fullscreen(GTK_WINDOW(gui.mainwin));
+    else
+	gtk_window_unfullscreen(GTK_WINDOW(gui.mainwin));
+}
+
+    static void
+mainwin_fullscreened_cb(GObject *obj,
+	GParamSpec *pspec UNUSED, gpointer user_data UNUSED)
+{
+    // Force a redraw of the drawing area when entering fullscreen mode.
+    if (gtk_window_is_fullscreen(GTK_WINDOW(obj)))
+	gui_focus_change(TRUE);
 }
 
 /*

--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -2850,6 +2850,18 @@ mainwin_screen_changed_cb(GtkWidget  *widget,
     }
 }
 
+    static gboolean
+mainwin_state_event_cb(GtkWidget *widget UNUSED,
+		       GdkEventWindowState *event,
+		       gpointer user_data UNUSED)
+{
+    if (event->new_window_state & GDK_WINDOW_STATE_FULLSCREEN)
+	// To redraw the text area when switching to fullscreen mode, we will
+	// reuse the `gui_focus_change` method.
+	gui_focus_change(TRUE);
+    return FALSE;
+}
+
 /*
  * After the drawing area comes up, we calculate all colors and create the
  * dummy blank cursor.
@@ -3825,6 +3837,9 @@ gui_mch_init(void)
 
     g_signal_connect(G_OBJECT(gui.mainwin), "screen-changed",
 		     G_CALLBACK(&mainwin_screen_changed_cb), NULL);
+
+    g_signal_connect(G_OBJECT(gui.mainwin), "window-state-event",
+		     G_CALLBACK(&mainwin_state_event_cb), NULL);
 
     gui.accel_group = gtk_accel_group_new();
     gtk_window_add_accel_group(GTK_WINDOW(gui.mainwin), gui.accel_group);

--- a/src/proto/gui_gtk.pro
+++ b/src/proto/gui_gtk.pro
@@ -21,4 +21,5 @@ void gui_make_popup(char_u *path_name, int mouse_pos);
 void gui_mch_find_dialog(exarg_T *eap);
 void gui_mch_replace_dialog(exarg_T *eap);
 void ex_helpfind(exarg_T *eap);
+void gui_mch_set_fullscreen(int flag);
 /* vim: set ft=c : */

--- a/src/proto/gui_gtk4.pro
+++ b/src/proto/gui_gtk4.pro
@@ -16,6 +16,7 @@ int gui_mch_get_winpos(int *x, int *y);
 void gui_mch_set_winpos(int x, int y);
 int gui_mch_maximized(void);
 void gui_mch_unmaximize(void);
+void gui_mch_set_fullscreen(int flag);
 void gui_mch_newfont(void);
 void gui_mch_settitle(char_u *title, char_u *icon);
 void gui_mch_set_shellsize(int width, int height, int min_width, int min_height, int base_width, int base_height, int direction);


### PR DESCRIPTION
- Add codes for GTK
- Update documents
    - The explanation about fullscreen mode has been moved to gui.txt.
    - Added information to the description of the `-s` flag in `guioptions`, stating that it can also be used with GTK.
    - Regenerate runtime/doc/tags