### PR TITLE
Disallow setting the quickfixtextfunc option from the sandbox

### DIFF
--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -8173,12 +8173,15 @@ qf_setprop_curidx(qf_info_T *qi, qf_list_T *qfl, dictitem_T *di)
 }
 
 /*
- * Set the current index in the specified quickfix list
+ * Set the 'quickfixtextfunc' in the specified quickfix/location list
  */
     static int
 qf_setprop_qftf(qf_info_T *qi UNUSED, qf_list_T *qfl, dictitem_T *di)
 {
     callback_T	cb;
+
+    if (check_restricted() || check_secure())
+	return FAIL;
 
     free_callback(&qfl->qf_qftf_cb);
     cb = get_callback(&di->di_tv);

--- a/src/testdir/test_quickfix.vim
+++ b/src/testdir/test_quickfix.vim
@@ -7040,7 +7040,7 @@ func Xtest_set_qftf_in_sandbox(cchar)
 
   let g:caught_exception = v:false
   try
-    sandbox call setqflist([], 'a', #{quickfixtextfunc: 'g:Qftf_Fn'})
+    sandbox call g:Xsetlist([], 'a', #{quickfixtextfunc: 'g:Qftf_Fn'})
   catch /E48:/
     let g:caught_exception = v:true
   endtry

--- a/src/testdir/test_quickfix.vim
+++ b/src/testdir/test_quickfix.vim
@@ -7028,4 +7028,38 @@ func Test_efm_overlongline()
   call setqflist([], 'f')
 endfunc
 
+func Xtest_set_qftf_in_sandbox(cchar)
+  call s:setup_commands(a:cchar)
+
+  call g:Xsetlist([{'filename': 'test.c', 'lnum': 1, 'text': 'trigger'}])
+  let g:qftf_fn_called = v:false
+  func Qftf_Fn(d)
+    let g:qftf_fn_called = v:true
+    return []
+  endfunc
+
+  let g:caught_exception = v:false
+  try
+    sandbox call setqflist([], 'a', #{quickfixtextfunc: 'g:Qftf_Fn'})
+  catch /E48:/
+    let g:caught_exception = v:true
+  endtry
+  copen
+  cclose
+
+  call assert_equal(v:true, g:caught_exception)
+  call assert_equal(v:false, g:qftf_fn_called)
+
+  delfunc Qftf_Fn
+  unlet g:caught_exception
+  unlet g:qftf_fn_called
+  %bw!
+endfunc
+
+" Test for setting the 'quickfixtextfunc' in a sandbox
+func Test_set_qftf_in_sandbox()
+  call Xtest_set_qftf_in_sandbox('c')
+  call Xtest_set_qftf_in_sandbox('l')
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION

Fix the security vulnerability reported in GHSA-6mwv-8vj2-jfrp.