### PR TITLE
patch 9.2.xxxx: Setting quickfixtextfunc does not check for secure mode

### DIFF
--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -8180,6 +8180,9 @@ qf_setprop_qftf(qf_info_T *qi UNUSED, qf_list_T *qfl, dictitem_T *di)
 {
     callback_T	cb;
 
+   if (check_secure())
+	return FAIL;
+
     free_callback(&qfl->qf_qftf_cb);
     cb = get_callback(&di->di_tv);
     if (cb.cb_name == NULL || *cb.cb_name == NUL)

--- a/src/testdir/test_quickfix.vim
+++ b/src/testdir/test_quickfix.vim
@@ -7028,4 +7028,17 @@ func Test_efm_overlongline()
   call setqflist([], 'f')
 endfunc
 
+" Setting 'quickfixtextfunc' via setqflist()/setloclist() registers a
+" callback that fires later outside the sandbox, so the registration
+" itself must be blocked when in the sandbox.
+func Test_setqflist_qftf_sandbox()
+  call setqflist([{'filename': 'F1', 'lnum': 1, 'text': 'x'}])
+  let qfid = getqflist({'id': 0}).id
+  call assert_fails("sandbox call setqflist([], 'a', {'id': qfid, 'quickfixtextfunc': 'tr'})", 'E48:')
+  new
+  call assert_fails("sandbox call setloclist(0, [], 'a', {'quickfixtextfunc': 'tr'})", 'E48:')
+  bwipe!
+  call setqflist([], 'f')
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  Setting quickfixtextfunc can register callback in sandbox
Solution: Add check_secure() to qf_setprop_qftf() (tacdm)