### PR TITLE
Add out-of-memory checks to ex_substitute()

### DIFF
--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -4144,6 +4144,8 @@ ex_substitute(exarg_T *eap)
 	pat = NULL;		// search_regcomp() will use previous pattern
 	patlen = 0;
 	sub = vim_strsave(old_sub);
+	if (sub == NULL)
+	    return;
 
 	// Vi compatibility quirk: repeating with ":s" keeps the cursor in the
 	// last column after using "$".

--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -5003,6 +5003,12 @@ ex_substitute(exarg_T *eap)
 		    vim_free(sub_firstline);
 		    sub_firstline = vim_strnsave(ml_get(sub_firstlnum),
 						    ml_get_len(sub_firstlnum));
+		    if (sub_firstline == NULL)
+		    {
+			vim_free(new_start);
+			goto outofmem;
+		    }
+
 		    // When going beyond the last line, stop substituting.
 		    if (sub_firstlnum <= line2)
 			do_again = TRUE;
@@ -5019,6 +5025,11 @@ ex_substitute(exarg_T *eap)
 		    // less than what it ought to be.
 		    vim_free(sub_firstline);
 		    sub_firstline = vim_strsave((char_u *)"");
+		    if (sub_firstline == NULL)
+		    {
+			vim_free(new_start);
+			goto outofmem;
+		    }
 		    copycol = 0;
 		}
 


### PR DESCRIPTION
This PR adds a couple of out-of-memory checks in `ex_substitute()`.

Cheers
John