### PR TITLE
spell: memory leak in spell_read_dic()

### DIFF
--- a/src/spellfile.c
+++ b/src/spellfile.c
@@ -3704,6 +3704,7 @@ spell_read_dic(spellinfo_T *spin, char_u *fname, afffile_T *affile)
 								      == FAIL)
 		{
 		    retval = FAIL;
+		    vim_free(pc);
 		    break;
 		}
 		pfxlen = totlen;
@@ -3717,6 +3718,7 @@ spell_read_dic(spellinfo_T *spin, char_u *fname, afffile_T *affile)
 								      == FAIL)
 		{
 		    retval = FAIL;
+		    vim_free(pc);
 		    break;
 		}
 	    }


### PR DESCRIPTION
Problem:  spell: memory leak in spell_read_dic() (after 9.2.0524).
Solution: Free "pc" before breaking out of the loop.
