### PR TITLE
runtime(html): b:match_words for html must use whole tag

### DIFF
--- a/runtime/ftplugin/html.vim
+++ b/runtime/ftplugin/html.vim
@@ -41,7 +41,7 @@ if exists("loaded_matchit") && !exists("b:match_words")
 	\	      '<:>,' ..
 	\	      '<\@<=[ou]l\>[^>]*\%(>\|$\):<\@<=li\>:<\@<=/[ou]l>,' ..
 	\	      '<\@<=dl\>[^>]*\%(>\|$\):<\@<=d[td]\>:<\@<=/dl>,' ..
-	\	      '<\@<=\([^/!][^ \t>]*\)[^>]*\%(>\|$\):<\@<=/\1>'
+	\	      '<\@<=\([^/!][^ \t>]*\)\%([ \t]\|>\|$\):<\@<=/\1>'
   let b:html_set_match_words = 1
   let b:undo_ftplugin ..= " | unlet! b:match_ignorecase b:match_words b:html_set_match_words"
 endif


### PR DESCRIPTION
`b:match_words` which contains patterns used by `matchit` plugin to find tag's counterpath, is fixed so that matching happens using the whole tag, not just its first letter.

Also, it allows to find matching tag in case if there are spaces or attributes after tag name.

This MR addresses https://github.com/chrisbra/matchit/issues/51