### PR TITLE
Cannot keep leading whitespace in %{} statusline expr

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -8667,7 +8667,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	{ NF  Evaluate expression between '%{' and '}' and substitute result.
 	      Note that there is no '%' before the closing '}'.  The
 	      expression cannot contain a '}' character, call a function to
-	      work around that.  See |stl-%{| below.
+	      work around that.  See |stl-%{| below.  Use '%0{' to insert the
+	      result verbatim.
 	{% -  This is almost same as { except the result of the expression is
 	      re-evaluated as a statusline format string.  Thus if the
 	      return value of expr contains % items they will get expanded.
@@ -8794,6 +8795,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	A result of all digits is regarded a number for display purposes.
 	Otherwise the result is taken as flag text and applied to the rules
 	described above.
+	With %0{ neither applies: the result is inserted as a literal string.
 
 	Watch out for errors in expressions.  They may render Vim unusable!
 	If you are stuck, hold down ':' or 'Q' to get a prompt, then quit and

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -5041,7 +5041,8 @@ build_stl_str_hl_local(
 
 	    if (reevaluate)
 		s++;
-	    itemisflag = TRUE;
+	    // %0{} keeps the result verbatim
+	    itemisflag = zeropad ? FALSE : TRUE;
 	    t = p;
 	    while ((*s != '}' || (reevaluate && s[-1] != '%'))
 					  && *s != NUL && p + 1 < out + outlen)
@@ -5078,7 +5079,7 @@ build_stl_str_hl_local(
 	    do_unlet((char_u *)"g:actual_curbuf", TRUE);
 	    do_unlet((char_u *)"g:actual_curwin", TRUE);
 
-	    if (str != NULL && *str != NUL)
+	    if (!zeropad && str != NULL && *str != NUL)
 	    {
 		if (*skipdigits(str) == NUL)
 		{

--- a/src/testdir/test_statusline.vim
+++ b/src/testdir/test_statusline.vim
@@ -282,6 +282,16 @@ func Test_statusline()
   call assert_match('^vimLineComment\s*$', s:get_statusline())
   syntax off
 
+  " %0{: result of expression is inserted verbatim
+  set statusline=%{'\ x'}
+  call assert_match('^x\s*$', s:get_statusline())
+  set statusline=%0{'\ x'}
+  call assert_match('^ x\s*$', s:get_statusline())
+  set statusline=%{'000'}
+  call assert_match('^0\s*$', s:get_statusline())
+  set statusline=%0{'000'}
+  call assert_match('^000\s*$', s:get_statusline())
+
   "%{%expr%}: evaluates expressions present in result of expr
   func! Inner_eval()
     return '%n some other text'


### PR DESCRIPTION
Problem:
A leading space in the result of a %{} item is sometimes stripped, and an all-digit result is converted to a number.

Solution:
Add %0{} which inserts the expression result verbatim.

Fix #3898 