### PR TITLE
GTK4: fix shell resize and font-change redraw

### DIFF
--- a/src/gui_gtk4.c
+++ b/src/gui_gtk4.c
@@ -765,6 +765,16 @@ gui_mch_settitle(char_u *title, char_u *icon UNUSED)
 }
 
 static int in_set_shellsize = FALSE;
+static guint clear_drawarea_size_request_id = 0;
+
+    static gboolean
+clear_drawarea_size_request_cb(gpointer data UNUSED)
+{
+    clear_drawarea_size_request_id = 0;
+    if (gui.drawarea != NULL)
+	gtk_widget_set_size_request(gui.drawarea, -1, -1);
+    return G_SOURCE_REMOVE;
+}
 
     void
 gui_mch_set_shellsize(int width, int height,
@@ -772,9 +782,24 @@ gui_mch_set_shellsize(int width, int height,
 	int base_width UNUSED, int base_height UNUSED,
 	int direction UNUSED)
 {
-    width += get_menu_tool_width();
-    height += get_menu_tool_height();
-    gtk_window_set_default_size(GTK_WINDOW(gui.mainwin), width, height);
+    int total_width = width + get_menu_tool_width();
+    int total_height = height + get_menu_tool_height();
+
+    gtk_window_set_default_size(GTK_WINDOW(gui.mainwin),
+	    total_width, total_height);
+
+    // gtk_window_set_default_size() alone only takes effect at first show;
+    // some window managers (e.g. xfwm4 on X11) ignore subsequent updates
+    // because gui.drawarea has no natural size to drive a grow. Push the
+    // window via a temporary size request on the drawing area, then clear
+    // it on idle so the user can still shrink the window manually.
+    if (gui.drawarea != NULL && gtk_widget_get_realized(gui.mainwin))
+    {
+	gtk_widget_set_size_request(gui.drawarea, width, height);
+	if (clear_drawarea_size_request_id == 0)
+	    clear_drawarea_size_request_id =
+		g_idle_add(clear_drawarea_size_request_cb, NULL);
+    }
 }
 
     void
@@ -1906,7 +1931,10 @@ drawarea_resize_cb(GtkDrawingArea *area UNUSED, int width, int height,
     cairo_paint(cr);
     cairo_destroy(cr);
 
-    // Notify Vim about the new size - this will cause a full redraw
+    // Notify Vim about the new size. Force a redraw even if Rows/Columns
+    // don't change (e.g. font change keeps the cell count): the surface
+    // was just wiped and would otherwise stay blank.
+    gui.force_redraw = TRUE;
     gui_resize_shell(width, height);
 }
 


### PR DESCRIPTION
GTK4 builds did not honor `set lines=...` / `set columns=...` after the window was realized, and font changes left the editor blank until forced refresh.

Two related issues in `src/gui_gtk4.c`:

1. `gui_mch_set_shellsize()` only called `gtk_window_set_default_size()`. In GTK4 that mostly affects the initial show; once realized, window managers such as xfwm4 on X11 ignore further updates because `gui.drawarea` has no natural size to drive a grow. Push the requested size with a temporary `gtk_widget_set_size_request()` on the drawing area, then clear it on idle so the user can still shrink the window manually.

2. After the drawing area is resized, `drawarea_resize_cb()` destroys and recreates the backing cairo surface filled with the background color. The follow-up `gui_resize_shell()` skips `shell_resized()` when Rows/Columns are unchanged (typical for font changes that keep the same cell count), so the fresh surface stayed blank. Set `gui.force_redraw` before calling `gui_resize_shell()` to guarantee a full redraw.

Fixes #20307