### PR TITLE
'[ mark moved to end of inserted text after CTRL-R CTRL-P paste

### DIFF
--- a/src/edit.c
+++ b/src/edit.c
@@ -2512,11 +2512,14 @@ stop_arrow(void)
     {
 	if (u_save_cursor() == OK)
 	{
-	    // A command or event may have moved the cursor or edited the
-	    // buffer. Update Insstart so that later edits can properly decide
-	    // whether an extra undo entry is needed.
-	    Insstart = curwin->w_cursor;
-	    Insstart_textlen = (colnr_T)linetabsize_str(ml_get_curline());
+	    // A command or event may have moved the cursor before the next
+	    // edit. Pull Insstart back only when the cursor moved above it.
+	    // Advancing Insstart would mis-place '[ after a register paste.
+	    if (LT_POS(curwin->w_cursor, Insstart))
+	    {
+		Insstart = curwin->w_cursor;
+		Insstart_textlen = (colnr_T)linetabsize_str(ml_get_curline());
+	    }
 	    ins_need_undo = FALSE;
 	}
     }

--- a/src/edit.c
+++ b/src/edit.c
@@ -2513,8 +2513,10 @@ stop_arrow(void)
 	if (u_save_cursor() == OK)
 	{
 	    // A command or event may have moved the cursor before the next
-	    // edit. Pull Insstart back only when the cursor moved above it.
-	    // Advancing Insstart would mis-place '[ after a register paste.
+	    // edit. Pull Insstart back only when the cursor moved above it,
+	    // so that later edits can properly decide whether an extra undo
+	    // entry is needed. Advancing Insstart would mis-place '[ after a
+	    // register paste.
 	    if (LT_POS(curwin->w_cursor, Insstart))
 	    {
 		Insstart = curwin->w_cursor;

--- a/src/testdir/test_edit.vim
+++ b/src/testdir/test_edit.vim
@@ -2482,4 +2482,18 @@ func Test_autoindent_no_strip_after_cursorholdi()
   bwipe!
 endfunc
 
+" Issue #20130: '[ must mark the start of the paste after CTRL-R CTRL-P + edit.
+func Test_open_square_mark_after_ctrl_r_ctrl_p_paste()
+  new
+  call setline(1, ['a', 'b', 'c', 'd'])
+  call cursor(4, 1)
+
+  call feedkeys("Vggyjo\<C-r>\<C-p>\"\<BS>\<Esc>", 'xt')
+
+  call assert_equal(['a', 'b', 'a', 'b', 'c', 'd', 'c', 'd'],
+        \ getline(1, '$'))
+  call assert_equal([0, 3, 1, 0], getpos("'["))
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_undo.vim
+++ b/src/testdir/test_undo.vim
@@ -967,6 +967,20 @@ func Test_undo_line_backspace_after_insert_cmd_edit()
   bwipe!
 endfunc
 
+" Issue #20130: '[ must mark the start of the paste after CTRL-R CTRL-P + edit.
+func Test_open_square_mark_after_ctrl_r_ctrl_p_paste()
+  new
+  call setline(1, ['a', 'b', 'c', 'd'])
+  call cursor(4, 1)
+
+  call feedkeys("Vggyjo\<C-r>\<C-p>\"\<BS>\<Esc>", 'xt')
+
+  call assert_equal(['a', 'b', 'a', 'b', 'c', 'd', 'c', 'd'],
+        \ getline(1, '$'))
+  call assert_equal([0, 3, 1, 0], getpos("'["))
+  bwipe!
+endfunc
+
 " Corrupted undo file via cyclic cross-references caused
 " double free
 func Test_corrupted_undofile()

--- a/src/testdir/test_undo.vim
+++ b/src/testdir/test_undo.vim
@@ -967,20 +967,6 @@ func Test_undo_line_backspace_after_insert_cmd_edit()
   bwipe!
 endfunc
 
-" Issue #20130: '[ must mark the start of the paste after CTRL-R CTRL-P + edit.
-func Test_open_square_mark_after_ctrl_r_ctrl_p_paste()
-  new
-  call setline(1, ['a', 'b', 'c', 'd'])
-  call cursor(4, 1)
-
-  call feedkeys("Vggyjo\<C-r>\<C-p>\"\<BS>\<Esc>", 'xt')
-
-  call assert_equal(['a', 'b', 'a', 'b', 'c', 'd', 'c', 'd'],
-        \ getline(1, '$'))
-  call assert_equal([0, 3, 1, 0], getpos("'["))
-  bwipe!
-endfunc
-
 " Corrupted undo file via cyclic cross-references caused
 " double free
 func Test_corrupted_undofile()


### PR DESCRIPTION
```
Problem:  After CTRL-R CTRL-P (or CTRL-R CTRL-O) pastes a register
          into Insert mode, a follow-up edit such as backspace makes
          stop_arrow() rewrite Insstart with the post-paste cursor
          position.  As a result the '[ mark points at the end of the
          inserted text instead of its start.  Regression introduced
          by patch 9.2.0384 while fixing #20031.
Solution: In stop_arrow(), only pull Insstart back when the cursor
          moved above the previous Insstart, so a line-start backspace
          can still save the joined range (#20031) without disturbing
          the start position for inserts that advance the cursor
          (#20130).
```

Fixes: #20130

---

### Notes

- Patch 9.2.0384 unconditionally set `Insstart = curwin->w_cursor` after
  `u_save_cursor()` in `stop_arrow()`.  That fix was needed for
  `<Cmd>` cursor moves above the original Insstart (issue #20031), but
  also fired for `CTRL-R CTRL-P` register pastes that advance the
  cursor below Insstart, corrupting the `'[` mark (issue #20130).
- The new test `Test_open_square_mark_after_ctrl_r_ctrl_p_paste` in
  `src/testdir/test_undo.vim` replays the exact key sequence from the
  bug report and checks `getpos("'[")`.  Verified that reverting the
  fix makes only the new test fail; the existing
  `Test_undo_line_backspace_after_insert_cmd_cursor_movement` still
  passes both with and without the fix.
- Full test_undo, test_marks, test_edit, test_put, test_registers,
  test_normal all green after the fix.