### PR TITLE
GTK4: fix scrollbar widgets not appearing

### DIFF
--- a/src/gui_gtk4.c
+++ b/src/gui_gtk4.c
@@ -3715,10 +3715,10 @@ gui_mch_set_scrollbar_thumb(scrollbar_T *sb, long val, long size, long max)
 
     if (sb->id == NULL)
 	return;
-    if (!GTK_IS_WIDGET(sb->id) || !GTK_IS_RANGE(sb->id))
+    if (!GTK_IS_WIDGET(sb->id) || !GTK_IS_SCROLLBAR(sb->id))
 	return;
 
-    adj = gtk_range_get_adjustment(GTK_RANGE(sb->id));
+    adj = gtk_scrollbar_get_adjustment(GTK_SCROLLBAR(sb->id));
     gtk_adjustment_set_lower(adj, 0.0);
     gtk_adjustment_set_upper(adj, (gdouble)max + 1);
     gtk_adjustment_set_value(adj, (gdouble)val);
@@ -3784,9 +3784,9 @@ gui_mch_create_scrollbar(scrollbar_T *sb, int orient)
     else
 	sb->id = gtk_scrollbar_new(GTK_ORIENTATION_VERTICAL, NULL);
 
-    if (sb->id != NULL && GTK_IS_RANGE(sb->id))
+    if (sb->id != NULL && GTK_IS_SCROLLBAR(sb->id))
     {
-	GtkAdjustment *adj = gtk_range_get_adjustment(GTK_RANGE(sb->id));
+	GtkAdjustment *adj = gtk_scrollbar_get_adjustment(GTK_SCROLLBAR(sb->id));
 
 	gtk_widget_set_visible(sb->id, FALSE);
 	gui_gtk_form_put(GTK_FORM(gui.formwin), sb->id, 0, 0);

--- a/src/gui_gtk4.c
+++ b/src/gui_gtk4.c
@@ -488,8 +488,8 @@ gui_mch_init(void)
     gui.formwin = gui_gtk_form_new();
     gtk_widget_set_name(gui.formwin, "vim-gtk-form");
     // formwin is overlaid on top of drawarea for scrollbar positioning.
-    // Disable input targeting so mouse events pass through to drawarea.
-    gtk_widget_set_can_target(gui.formwin, FALSE);
+    // GtkForm's contains() returns FALSE so empty-area clicks fall through
+    // to the drawarea, while the scrollbar children still receive events.
 
     // The drawing area for the editor content.
     // Placed in an overlay so it fills the formwin, with scrollbars on top.

--- a/src/gui_gtk4_f.c
+++ b/src/gui_gtk4_f.c
@@ -36,6 +36,7 @@ static void form_measure(GtkWidget *widget, GtkOrientation orientation,
 static void form_size_allocate(GtkWidget *widget, int width, int height,
 	int baseline);
 static void form_snapshot(GtkWidget *widget, GtkSnapshot *snapshot);
+static gboolean form_contains(GtkWidget *widget, double x, double y);
 static void form_dispose(GObject *object);
 static void form_position_child(GtkForm *form, GtkFormChild *child,
 	gboolean force_allocate);
@@ -173,6 +174,7 @@ gui_gtk_form_class_init(GtkFormClass *klass)
     widget_class->measure = form_measure;
     widget_class->size_allocate = form_size_allocate;
     widget_class->snapshot = form_snapshot;
+    widget_class->contains = form_contains;
 }
 
     static void
@@ -263,6 +265,14 @@ form_snapshot(GtkWidget *widget, GtkSnapshot *snapshot)
 		&& gtk_widget_get_parent(child->widget) == widget)
 	    gtk_widget_snapshot_child(widget, child->widget, snapshot);
     }
+}
+
+// Make the form itself input-transparent so clicks on its empty area fall
+// through to the drawarea below, while the scrollbar children stay pickable.
+    static gboolean
+form_contains(GtkWidget *widget UNUSED, double x UNUSED, double y UNUSED)
+{
+    return FALSE;
 }
 
     static void


### PR DESCRIPTION
In GTK4 GtkScrollbar derives from GtkWidget directly, not from GtkRange as in GTK3. The GTK_IS_RANGE check after gtk_scrollbar_new() always returned FALSE, so gui_gtk_form_put() was skipped and the scrollbar was never parented to formwin; `set guioptions+=rlRL` reserved space but rendered nothing. Switch to GTK_IS_SCROLLBAR and gtk_scrollbar_get_adjustment().

Fixes #20307