### PR TITLE
GTK4: fix blank window after sub-cell resize

### DIFF
--- a/src/gui_gtk4.c
+++ b/src/gui_gtk4.c
@@ -1894,6 +1894,7 @@ drawarea_resize_cb(GtkDrawingArea *area UNUSED, int width, int height,
 	gpointer data UNUSED)
 {
     cairo_t *cr;
+    cairo_surface_t *old_surface;
     int	    scale = get_drawarea_scale();
 
     if (width <= 0 || height <= 0)
@@ -1906,22 +1907,38 @@ drawarea_resize_cb(GtkDrawingArea *area UNUSED, int width, int height,
 
 	if (sw == width && sh == height)
 	    return;
-
-	cairo_surface_destroy(gui.surface);
     }
 
-    // Create a fresh surface filled with the background color.
-    // Do not copy old surface content: gui_resize_shell() will trigger
-    // a full redraw, and stale content (e.g. intro screen text) would
-    // otherwise remain as ghost artifacts.
+    // Create a new surface filled with the background color, then
+    // preserve the old contents on top. If the follow-up redraw is
+    // delayed (e.g. when this callback fires while Vim is waiting in
+    // gui_mch_wait_for_chars()), the user keeps seeing the previous
+    // frame instead of a blank window.
+    old_surface = gui.surface;
     gui.surface = create_backing_surface(width, height);
-    cr = cairo_create(gui.surface);
-    set_cairo_source_from_pixel(cr, gui.back_pixel);
-    cairo_paint(cr);
-    cairo_destroy(cr);
+    if (gui.surface != NULL)
+    {
+	cr = cairo_create(gui.surface);
+	set_cairo_source_from_pixel(cr, gui.back_pixel);
+	cairo_paint(cr);
+	if (old_surface != NULL)
+	{
+	    cairo_set_source_surface(cr, old_surface, 0, 0);
+	    cairo_paint(cr);
+	}
+	cairo_destroy(cr);
+    }
+    if (old_surface != NULL)
+	cairo_surface_destroy(old_surface);
 
-    // Notify Vim about the new size - this will cause a full redraw
+    // Force shell_resized() to run even when Rows/Columns are unchanged
+    // (a sub-cell pixel resize). Also queue a full redraw so the surface
+    // is repainted once Vim returns from waiting for input, even if
+    // set_shellsize_inner() bails out because updating_screen is set.
+    gui.force_redraw = TRUE;
     gui_resize_shell(width, height);
+    if (gui.in_use)
+	redraw_all_later(UPD_CLEAR);
 }
 
     static void

--- a/src/gui_gtk4.c
+++ b/src/gui_gtk4.c
@@ -1889,56 +1889,94 @@ drawarea_unrealize_cb(GtkWidget *widget UNUSED, gpointer data UNUSED)
     }
 }
 
+// Debounced resize: drawarea_resize_cb only resizes the backing surface
+// (preserving old content) and (re)arms a short timeout. The actual
+// gui_resize_shell() runs from drawarea_resize_apply_cb once the user has
+// stopped dragging for ~100 ms, by which time no input is pending and
+// update_screen() will not bail in screenclear()'s wake.
+static guint drawarea_resize_timeout_id = 0;
+static int drawarea_resize_pending_w = 0;
+static int drawarea_resize_pending_h = 0;
+
+    static gboolean
+drawarea_resize_apply_cb(gpointer data UNUSED)
+{
+    int width = drawarea_resize_pending_w;
+    int height = drawarea_resize_pending_h;
+
+    drawarea_resize_timeout_id = 0;
+
+    if (width <= 0 || height <= 0)
+	return G_SOURCE_REMOVE;
+    if (updating_screen)
+    {
+	drawarea_resize_timeout_id = g_timeout_add(50,
+		drawarea_resize_apply_cb, NULL);
+	return G_SOURCE_REMOVE;
+    }
+
+    gui.force_redraw = TRUE;
+    gui_resize_shell(width, height);
+    if (gui.in_use)
+	redraw_all_later(UPD_CLEAR);
+    return G_SOURCE_REMOVE;
+}
+
     static void
 drawarea_resize_cb(GtkDrawingArea *area UNUSED, int width, int height,
 	gpointer data UNUSED)
 {
     cairo_t *cr;
     cairo_surface_t *old_surface;
-    int	    scale = get_drawarea_scale();
+    int scale = get_drawarea_scale();
 
     if (width <= 0 || height <= 0)
 	return;
 
+    drawarea_resize_pending_w = width;
+    drawarea_resize_pending_h = height;
+
+    // Keep the backing surface in sync with the drawing area so GTK keeps
+    // showing the previous frame. Re-creating it preserves the old
+    // contents.
     if (gui.surface != NULL)
     {
 	int sw = cairo_image_surface_get_width(gui.surface) / scale;
 	int sh = cairo_image_surface_get_height(gui.surface) / scale;
-
-	if (sw == width && sh == height)
-	    return;
-    }
-
-    // Create a new surface filled with the background color, then
-    // preserve the old contents on top. If the follow-up redraw is
-    // delayed (e.g. when this callback fires while Vim is waiting in
-    // gui_mch_wait_for_chars()), the user keeps seeing the previous
-    // frame instead of a blank window.
-    old_surface = gui.surface;
-    gui.surface = create_backing_surface(width, height);
-    if (gui.surface != NULL)
-    {
-	cr = cairo_create(gui.surface);
-	set_cairo_source_from_pixel(cr, gui.back_pixel);
-	cairo_paint(cr);
-	if (old_surface != NULL)
+	if (sw != width || sh != height)
 	{
-	    cairo_set_source_surface(cr, old_surface, 0, 0);
-	    cairo_paint(cr);
+	    old_surface = gui.surface;
+	    gui.surface = create_backing_surface(width, height);
+	    if (gui.surface != NULL)
+	    {
+		cr = cairo_create(gui.surface);
+		set_cairo_source_from_pixel(cr, gui.back_pixel);
+		cairo_paint(cr);
+		cairo_set_source_surface(cr, old_surface, 0, 0);
+		cairo_paint(cr);
+		cairo_destroy(cr);
+	    }
+	    cairo_surface_destroy(old_surface);
 	}
-	cairo_destroy(cr);
     }
-    if (old_surface != NULL)
-	cairo_surface_destroy(old_surface);
+    else
+    {
+	gui.surface = create_backing_surface(width, height);
+	if (gui.surface != NULL)
+	{
+	    cr = cairo_create(gui.surface);
+	    set_cairo_source_from_pixel(cr, gui.back_pixel);
+	    cairo_paint(cr);
+	    cairo_destroy(cr);
+	}
+    }
 
-    // Force shell_resized() to run even when Rows/Columns are unchanged
-    // (a sub-cell pixel resize). Also queue a full redraw so the surface
-    // is repainted once Vim returns from waiting for input, even if
-    // set_shellsize_inner() bails out because updating_screen is set.
-    gui.force_redraw = TRUE;
-    gui_resize_shell(width, height);
-    if (gui.in_use)
-	redraw_all_later(UPD_CLEAR);
+    // Debounce: (re)arm the apply timeout, so gui_resize_shell() only
+    // runs once the resize stream settles.
+    if (drawarea_resize_timeout_id != 0)
+	g_source_remove(drawarea_resize_timeout_id);
+    drawarea_resize_timeout_id = g_timeout_add(100,
+	    drawarea_resize_apply_cb, NULL);
 }
 
     static void
@@ -3843,21 +3881,11 @@ gui_mch_set_text_area_pos(int x, int y, int w, int h)
     // form_size_allocate which gives drawarea the formwin's full size.
     gui_gtk_form_move(GTK_FORM(gui.formwin), gui.drawarea, x, y);
 
-    // Update surface to match new text area size
-    if (w > 0 && h > 0)
-    {
-	int scale = get_drawarea_scale();
-
-	if (gui.surface != NULL)
-	{
-	    int sw = cairo_image_surface_get_width(gui.surface) / scale;
-	    int sh = cairo_image_surface_get_height(gui.surface) / scale;
-	    if (sw == w && sh == h)
-		return;
-	    cairo_surface_destroy(gui.surface);
-	}
-	gui.surface = create_backing_surface(w, h);
-    }
+    // Surface sizing is owned by drawarea_resize_cb; don't recreate it
+    // here. Recreating on every text-area change wiped any preserved
+    // content whenever a sub-cell resize shifted the cell grid, and
+    // update_screen() may bail (char_avail()) during a drag and leave
+    // the fresh surface blank.
 }
 
 /*


### PR DESCRIPTION
On resize, drawarea_resize_cb() recreated the cairo backing surface and called gui_resize_shell() synchronously. Two issues conspired to leave the window blank after a drag:

- `gui_mch_set_text_area_pos()` destroyed `gui.surface` and created a fresh one whenever the text-area dimensions changed (i.e. on every cell-grid change during a drag). Any preserved content from `drawarea_resize_cb()` was thrown away after each sub-cell resize, which is why the redraw only looked correct when the window pixel size happened to be an exact character-cell multiple.
- During an active drag, `update_screen()` returns early because `redrawing()` sees pending mouse input via `char_avail()`. The synchronous `gui_resize_shell()` call therefore wiped the surface in `screenclear()` but never repainted it.

The fix:
- In `drawarea_resize_cb()`, keep the backing surface in sync with the drawing area and preserve old contents.
- Stop touching the surface in `gui_mch_set_text_area_pos()`; sizing is owned by the resize callback.
- Debounce `gui_resize_shell()` 100 ms after the last resize event so it runs only once the drag stream settles and `update_screen()` can actually paint.

Refs #20307