### PR TITLE
CI: Win32: Fix Test_cd_completion

### DIFF
--- a/src/testdir/test_cd.vim
+++ b/src/testdir/test_cd.vim
@@ -263,7 +263,7 @@ func Test_cd_completion()
         let dir = d
         " Yay! We found a suitable dir!
         break
-      catch /:E472:/
+      catch /:\(E472\|E344\):/
         " Just skip directories where "cd" fails
         continue
       finally


### PR DESCRIPTION
Sometimes, Test_cd_completion fails with E344:
https://github.com/vim/vim-win32-installer/issues/446#issuecomment-4526975345

Actually, it raises E344 then E472.  Catch E344 also.