### PR TITLE
Win32: W/A for flaky mouse test

### DIFF
--- a/src/testdir/test_mswin_event.vim
+++ b/src/testdir/test_mswin_event.vim
@@ -704,6 +704,10 @@ func Test_mswin_event_mouse()
   CheckMSWindows
   new
 
+  if !has('gui_running')
+    let g:test_is_flaky = 1
+  endif
+
   set mousemodel=extend
   call test_override('no_query_mouse', 1)
   call WaitForResponses()


### PR DESCRIPTION
Test_mswin_event_mouse is flaky in console:
https://github.com/vim/vim-win32-installer/issues/446#issuecomment-4538212367

Mark it as flaky.