### PR TITLE
Cursor wrong after autoindent strip is skipped

### DIFF
--- a/src/edit.c
+++ b/src/edit.c
@@ -2657,6 +2657,11 @@ stop_insert(
 		if (VIsual_active)
 		    check_visual_pos();
 	    }
+	    else
+	    {
+		// Non-whitespace follows, keep original cursor.
+		curwin->w_cursor = tpos;
+	    }
 	}
     }
     did_ai = FALSE;

--- a/src/testdir/test_edit.vim
+++ b/src/testdir/test_edit.vim
@@ -2496,4 +2496,22 @@ func Test_open_square_mark_after_ctrl_r_ctrl_p_paste()
   bwipe!
 endfunc
 
+func Test_autoindent_no_strip_cross_line()
+  new
+  setlocal autoindent
+  inoremap <buffer> <F3> {}<Left><CR><Cmd>normal! ==<CR><Up><End><CR>
+
+  call setline(1, '')
+  call feedkeys("i\<F3>\<Esc>", 'tx')
+
+  call assert_equal('{', getline(1))
+  call assert_equal('', getline(2))
+  call assert_equal('}', getline(3))
+  call assert_equal([0, 2, 1, 0], getpos('.'))
+
+  " Overwrite @. register with simple content to avoid affecting later tests.
+  call feedkeys("Go\<Esc>", 'tnix')
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:
cursor lands on the wrong line when a <Cmd>
mapping or autocmd modifies lines during insert and the strip is skipped.

Solution:
Restore cursor to tpos when skipwhite skips the strip, instead of leaving it at end_insert_pos.

cc @kristijanhusak
