### PR TITLE
Enhance BitBake inc file tests and detection rules

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -920,7 +920,7 @@ export def FTinc()
       elseif line =~ '^\s*\%({\|(\*\)' || line =~? ft_pascal_keywords
         setf pascal
         return
-      elseif line =~# '\<\%(require\|inherit\)\>' || line =~# '[A-Z][A-Za-z0-9_:${}/]*\(\[[A-Za-z0-9_:/]\+\]\)*\s\+\%(??\|[?:+.]\)\?=.\? '
+      elseif line =~# '^\s*\<\%(require\|inherit\)\>' || line =~# '^\s*[A-Z][A-Za-z0-9_:${}/]*\%(\[[A-Za-z0-9_:/]\+\]\)*\s\+\%(??=\|[?:+.]=\|=[+.]\?\)\s\+'
         setf bitbake
         return
       endif

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -2894,6 +2894,11 @@ func Test_inc_file()
   call assert_equal('bitbake', &filetype)
   bwipe!
 
+  call writefile(['MACHINE ?= "qemu"'], 'Xfile.inc')
+  split Xfile.inc
+  call assert_equal('bitbake', &filetype)
+  bwipe!
+
   call writefile(['MACHINE ??= "qemu"'], 'Xfile.inc')
   split Xfile.inc
   call assert_equal('bitbake', &filetype)

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -2831,7 +2831,13 @@ endfunc
 func Test_inc_file()
   filetype on
 
+  " pov
   call writefile(['this is the fallback'], 'Xfile.inc', 'D')
+  split Xfile.inc
+  call assert_equal('pov', &filetype)
+  bwipe!
+
+  call writefile(['!Comment with formular a = b/c'], 'Xfile.inc')
   split Xfile.inc
   call assert_equal('pov', &filetype)
   bwipe!


### PR DESCRIPTION
Add a test case which covers BitBake inc files with weak variable assignment using ?= operator.

Add an additional test case for pov inc files, which makes sure we don't inadvertently match to BitBake.

Be more strict when detecting BitBake inc files. In particular, only match include keywords and variable assignments at the beginning of a line (excluding whitespace).

Use non-capturing groups to slightly improve performance.

Use regex or-operators to exactly match BitBake assignment operators. The previous expression would falsely match

    FOO .=. "bar"

, which is not valid BitBake syntax. The new capturing group is more specific and matches only valid assignments.

fixes https://github.com/vim/vim/issues/20288