### PR TITLE
Vim9: wrong error when redeclaring a typed variable

### DIFF
--- a/src/testdir/test_vim9_assign.vim
+++ b/src/testdir/test_vim9_assign.vim
@@ -3131,6 +3131,28 @@ def Test_type_specification_in_assignment()
     Foo()
   END
   v9.CheckSourceFailure(lines, "E476: Invalid command: MyVar: string = 'abc'", 1)
+
+  # redeclare an existing def local variable with a type
+  lines =<< trim END
+    vim9script
+    def Foo()
+      var n: number = 10
+      var n: number = 20
+    enddef
+    Foo()
+  END
+  v9.CheckSourceFailure(lines, 'E1017: Variable already declared: n', 2)
+
+  # redeclare an existing def local constant with a type
+  lines =<< trim END
+    vim9script
+    def Foo()
+      const x: number = 1
+      const x: number = 2
+    enddef
+    Foo()
+  END
+  v9.CheckSourceFailure(lines, 'E1017: Variable already declared: x', 2)
 enddef
 
 let g:someVar = 'X'

--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -1949,7 +1949,8 @@ compile_lhs_var_dest(
     int		cmdidx,
     char_u	*var_start,
     char_u	*var_end,
-    int		is_decl)
+    int		is_decl,
+    int		has_cmd)	// "var" before "var_start"
 {
     int	    declare_error = FALSE;
 
@@ -2004,8 +2005,8 @@ compile_lhs_var_dest(
 		char_u *p = skipwhite(lhs->lhs_end);
 		if (p[0] == '.' && p[1] == '=')
 		    emsg(_(e_dot_equal_not_supported_with_script_version_two));
-		else if (p[0] == ':')
-		    // type specified in a non-var assignment
+		else if (p[0] == ':' && !has_cmd)
+		    // type specified in an assignment without "var"
 		    semsg(_(e_trailing_characters_str), p);
 		else
 		    semsg(_(e_variable_already_declared_str), lhs->lhs_name);
@@ -2309,7 +2310,7 @@ compile_lhs(
     {
 	// compile the LHS destination
 	if (compile_lhs_var_dest(cctx, lhs, cmdidx, var_start, var_end,
-							is_decl) == FAIL)
+						is_decl, has_cmd) == FAIL)
 	    return FAIL;
     }
 


### PR DESCRIPTION
```
Problem:  In a :def function, redeclaring an existing variable with a
          type annotation (e.g. "var x: number = 1" used twice) reports
          "E488: Trailing characters" instead of the expected
          "E1017: Variable already declared".
Solution: Report E1017 when the redeclaration uses a "var", "final" or
          "const" command; keep E488 only for a type specified in an
          assignment that has no declaration keyword.
```

fixes: #20337