### PR TITLE
Fix GTK4 menu memory leak

### DIFF
--- a/src/menu.c
+++ b/src/menu.c
@@ -1074,6 +1074,10 @@ free_menu(vimmenu_T **menup)
     // Also may rebuild a tearoff'ed menu
     if (gui.in_use)
 	gui_mch_destroy_menu(menu);
+# ifdef USE_GTK4
+    // GTK4 uses "menu->label" for action name
+    vim_free((char_u *)menu->label);
+# endif
 #endif
 
     // Don't change *menup until after calling gui_mch_destroy_menu(). The


### PR DESCRIPTION
```
=================================================================
==159845==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 1760 byte(s) in 220 object(s) allocated from:
    #0 0x7f731b12c161 in malloc (/usr/lib/libasan.so.8+0x12c161) (BuildId: ee5fbab73143ab257a66a33afe0f038a4af7a74e)
    #1 0x55e93a967050 in lalloc /srv/git/vim/src/alloc.c:246
    #2 0x55e93a966e26 in alloc /srv/git/vim/src/alloc.c:151
    #3 0x55e93b44b39b in vim_strsave /srv/git/vim/src/strings.c:27
    #4 0x55e93b89d26e in gui_mch_add_menu_item /srv/git/vim/src/gui_gtk4.c:3952
    #5 0x55e93af73488 in add_menu_path /srv/git/vim/src/menu.c:690
    #6 0x55e93af712ab in ex_menu /srv/git/vim/src/menu.c:405
    #7 0x55e93aca7777 in do_one_cmd /srv/git/vim/src/ex_docmd.c:2629
    #8 0x55e93ac9a5a9 in do_cmdline /srv/git/vim/src/ex_docmd.c:1041
    #9 0x55e93ac98109 in do_cmdline_cmd /srv/git/vim/src/ex_docmd.c:635
    #10 0x55e93b721562 in exec_instructions /srv/git/vim/src/vim9execute.c:4090
    #11 0x55e93b752ab6 in call_def_function /srv/git/vim/src/vim9execute.c:6926
    #12 0x55e93b63c93d in call_user_func /srv/git/vim/src/userfunc.c:3055
    #13 0x55e93b642a91 in call_user_func_check /srv/git/vim/src/userfunc.c:3492
    #14 0x55e93b648499 in call_func /srv/git/vim/src/userfunc.c:4165
    #15 0x55e93b634518 in get_func_tv /srv/git/vim/src/userfunc.c:2190
    #16 0x55e93b65f130 in ex_call_inner /srv/git/vim/src/userfunc.c:6525
    #17 0x55e93b6622dd in ex_call /srv/git/vim/src/userfunc.c:6883
    #18 0x55e93aca7777 in do_one_cmd /srv/git/vim/src/ex_docmd.c:2629
    #19 0x55e93ac9a5a9 in do_cmdline /srv/git/vim/src/ex_docmd.c:1041
    #20 0x55e93a9902b3 in apply_autocmds_group /srv/git/vim/src/autocmd.c:2447
    #21 0x55e93a98d87d in apply_autocmds /srv/git/vim/src/autocmd.c:1858
    #22 0x55e93b053eea in nv_cursorhold /srv/git/vim/src/normal.c:7584
    #23 0x55e93b006f40 in normal_cmd /srv/git/vim/src/normal.c:955
    #24 0x55e93b9db951 in main_loop /srv/git/vim/src/main.c:1639
    #25 0x55e93b9d9bea in vim_main2 /srv/git/vim/src/main.c:977
    #26 0x55e93b9d8b74 in main /srv/git/vim/src/main.c:453
    #27 0x7f7318e27740  (/usr/lib/libc.so.6+0x27740) (BuildId: 020d6f7c33b2413f4fe10814c4729dce1387f049)
    #28 0x7f7318e27878 in __libc_start_main (/usr/lib/libc.so.6+0x27878) (BuildId: 020d6f7c33b2413f4fe10814c4729dce1387f049)
    #29 0x55e93a966ba4 in _start (/srv/git/vim/src/vim+0x1a53ba4) (BuildId: f0c2b30d48c056f1f57ce8c3efe4880cb6c31cb6)

Direct leak of 1001 byte(s) in 138 object(s) allocated from:
    #0 0x7f731b12c161 in malloc (/usr/lib/libasan.so.8+0x12c161) (BuildId: ee5fbab73143ab257a66a33afe0f038a4af7a74e)
    #1 0x55e93a967050 in lalloc /srv/git/vim/src/alloc.c:246
    #2 0x55e93a966e26 in alloc /srv/git/vim/src/alloc.c:151
    #3 0x55e93b44b39b in vim_strsave /srv/git/vim/src/strings.c:27
    #4 0x55e93b89d26e in gui_mch_add_menu_item /srv/git/vim/src/gui_gtk4.c:3952
    #5 0x55e93af7cf66 in gui_create_initial_menus /srv/git/vim/src/menu.c:2076
    #6 0x55e93af7cf53 in gui_create_initial_menus /srv/git/vim/src/menu.c:2073
    #7 0x55e93b867349 in gui_init /srv/git/vim/src/gui.c:722
    #8 0x55e93b4f2f07 in set_termname /srv/git/vim/src/term.c:2188
    #9 0x55e93b4f52ba in termcapinit /srv/git/vim/src/term.c:2815
    #10 0x55e93b86576c in gui_attempt_start /srv/git/vim/src/gui.c:201
    #11 0x55e93b8654b2 in gui_start /srv/git/vim/src/gui.c:130
    #12 0x55e93b9d8db9 in vim_main2 /srv/git/vim/src/main.c:587
    #13 0x55e93b9d8b74 in main /srv/git/vim/src/main.c:453
    #14 0x7f7318e27740  (/usr/lib/libc.so.6+0x27740) (BuildId: 020d6f7c33b2413f4fe10814c4729dce1387f049)
    #15 0x7f7318e27878 in __libc_start_main (/usr/lib/libc.so.6+0x27878) (BuildId: 020d6f7c33b2413f4fe10814c4729dce1387f049)
    #16 0x55e93a966ba4 in _start (/srv/git/vim/src/vim+0x1a53ba4) (BuildId: f0c2b30d48c056f1f57ce8c3efe4880cb6c31cb6)

Direct leak of 429 byte(s) in 54 object(s) allocated from:
    #0 0x7f731b12c161 in malloc (/usr/lib/libasan.so.8+0x12c161) (BuildId: ee5fbab73143ab257a66a33afe0f038a4af7a74e)
    #1 0x55e93a967050 in lalloc /srv/git/vim/src/alloc.c:246
    #2 0x55e93a966e26 in alloc /srv/git/vim/src/alloc.c:151
    #3 0x55e93b44b39b in vim_strsave /srv/git/vim/src/strings.c:27
    #4 0x55e93b89d26e in gui_mch_add_menu_item /srv/git/vim/src/gui_gtk4.c:3952
    #5 0x55e93af7cf66 in gui_create_initial_menus /srv/git/vim/src/menu.c:2076
    #6 0x55e93af7cf53 in gui_create_initial_menus /srv/git/vim/src/menu.c:2073
    #7 0x55e93af7cf53 in gui_create_initial_menus /srv/git/vim/src/menu.c:2073
    #8 0x55e93b867349 in gui_init /srv/git/vim/src/gui.c:722
    #9 0x55e93b4f2f07 in set_termname /srv/git/vim/src/term.c:2188
    #10 0x55e93b4f52ba in termcapinit /srv/git/vim/src/term.c:2815
    #11 0x55e93b86576c in gui_attempt_start /srv/git/vim/src/gui.c:201
    #12 0x55e93b8654b2 in gui_start /srv/git/vim/src/gui.c:130
    #13 0x55e93b9d8db9 in vim_main2 /srv/git/vim/src/main.c:587
    #14 0x55e93b9d8b74 in main /srv/git/vim/src/main.c:453
    #15 0x7f7318e27740  (/usr/lib/libc.so.6+0x27740) (BuildId: 020d6f7c33b2413f4fe10814c4729dce1387f049)
    #16 0x7f7318e27878 in __libc_start_main (/usr/lib/libc.so.6+0x27878) (BuildId: 020d6f7c33b2413f4fe10814c4729dce1387f049)
    #17 0x55e93a966ba4 in _start (/srv/git/vim/src/vim+0x1a53ba4) (BuildId: f0c2b30d48c056f1f57ce8c3efe4880cb6c31cb6)

Direct leak of 308 byte(s) in 39 object(s) allocated from:
    #0 0x7f731b12c161 in malloc (/usr/lib/libasan.so.8+0x12c161) (BuildId: ee5fbab73143ab257a66a33afe0f038a4af7a74e)
    #1 0x55e93a967050 in lalloc /srv/git/vim/src/alloc.c:246
    #2 0x55e93a966e26 in alloc /srv/git/vim/src/alloc.c:151
    #3 0x55e93b44b39b in vim_strsave /srv/git/vim/src/strings.c:27
    #4 0x55e93b89d26e in gui_mch_add_menu_item /srv/git/vim/src/gui_gtk4.c:3952
    #5 0x55e93af7cf66 in gui_create_initial_menus /srv/git/vim/src/menu.c:2076
    #6 0x55e93af7cf53 in gui_create_initial_menus /srv/git/vim/src/menu.c:2073
    #7 0x55e93af7cf53 in gui_create_initial_menus /srv/git/vim/src/menu.c:2073
    #8 0x55e93af7cf53 in gui_create_initial_menus /srv/git/vim/src/menu.c:2073
    #9 0x55e93b867349 in gui_init /srv/git/vim/src/gui.c:722
    #10 0x55e93b4f2f07 in set_termname /srv/git/vim/src/term.c:2188
    #11 0x55e93b4f52ba in termcapinit /srv/git/vim/src/term.c:2815
    #12 0x55e93b86576c in gui_attempt_start /srv/git/vim/src/gui.c:201
    #13 0x55e93b8654b2 in gui_start /srv/git/vim/src/gui.c:130
    #14 0x55e93b9d8db9 in vim_main2 /srv/git/vim/src/main.c:587
    #15 0x55e93b9d8b74 in main /srv/git/vim/src/main.c:453
    #16 0x7f7318e27740  (/usr/lib/libc.so.6+0x27740) (BuildId: 020d6f7c33b2413f4fe10814c4729dce1387f049)
    #17 0x7f7318e27878 in __libc_start_main (/usr/lib/libc.so.6+0x27878) (BuildId: 020d6f7c33b2413f4fe10814c4729dce1387f049)
    #18 0x55e93a966ba4 in _start (/srv/git/vim/src/vim+0x1a53ba4) (BuildId: f0c2b30d48c056f1f57ce8c3efe4880cb6c31cb6)

Direct leak of 184 byte(s) in 23 object(s) allocated from:
    #0 0x7f731b12c161 in malloc (/usr/lib/libasan.so.8+0x12c161) (BuildId: ee5fbab73143ab257a66a33afe0f038a4af7a74e)
    #1 0x55e93a967050 in lalloc /srv/git/vim/src/alloc.c:246
    #2 0x55e93a966e26 in alloc /srv/git/vim/src/alloc.c:151
    #3 0x55e93b44b39b in vim_strsave /srv/git/vim/src/strings.c:27
    #4 0x55e93b89d26e in gui_mch_add_menu_item /srv/git/vim/src/gui_gtk4.c:3952
    #5 0x55e93af73488 in add_menu_path /srv/git/vim/src/menu.c:690
    #6 0x55e93af712ab in ex_menu /srv/git/vim/src/menu.c:405
    #7 0x55e93aca7777 in do_one_cmd /srv/git/vim/src/ex_docmd.c:2629
    #8 0x55e93ac9a5a9 in do_cmdline /srv/git/vim/src/ex_docmd.c:1041
    #9 0x55e93b32938a in do_source_ext /srv/git/vim/src/scriptfile.c:1948
    #10 0x55e93b32b278 in do_source /srv/git/vim/src/scriptfile.c:2094
    #11 0x55e93b320132 in source_all_matches /srv/git/vim/src/scriptfile.c:828
    #12 0x55e93b321baa in load_pack_plugin /srv/git/vim/src/scriptfile.c:1012
    #13 0x55e93b321ecc in add_pack_plugin /srv/git/vim/src/scriptfile.c:1070
    #14 0x55e93b31f781 in do_in_path /srv/git/vim/src/scriptfile.c:692
    #15 0x55e93b32240c in ex_packadd /srv/git/vim/src/scriptfile.c:1137
    #16 0x55e93aca7777 in do_one_cmd /srv/git/vim/src/ex_docmd.c:2629
    #17 0x55e93ac9a5a9 in do_cmdline /srv/git/vim/src/ex_docmd.c:1041
    #18 0x55e93b7071e9 in exec_command /srv/git/vim/src/vim9execute.c:2188
    #19 0x55e93b71cc69 in exec_instructions /srv/git/vim/src/vim9execute.c:3765
    #20 0x55e93b752ab6 in call_def_function /srv/git/vim/src/vim9execute.c:6926
    #21 0x55e93b63c93d in call_user_func /srv/git/vim/src/userfunc.c:3055
    #22 0x55e93b642a91 in call_user_func_check /srv/git/vim/src/userfunc.c:3492
    #23 0x55e93b648499 in call_func /srv/git/vim/src/userfunc.c:4165
    #24 0x55e93b634518 in get_func_tv /srv/git/vim/src/userfunc.c:2190
    #25 0x55e93abb23ad in call_func_rettv /srv/git/vim/src/eval.c:5563
    #26 0x55e93abc2ce8 in handle_subscript /srv/git/vim/src/eval.c:7542
    #27 0x55e93abb0fba in eval9 /srv/git/vim/src/eval.c:5400
    #28 0x55e93abad03e in eval8 /srv/git/vim/src/eval.c:4857
    #29 0x55e93ababce4 in eval7 /srv/git/vim/src/eval.c:4755

Direct leak of 48 byte(s) in 6 object(s) allocated from:
    #0 0x7f731b12c161 in malloc (/usr/lib/libasan.so.8+0x12c161) (BuildId: ee5fbab73143ab257a66a33afe0f038a4af7a74e)
    #1 0x55e93a967050 in lalloc /srv/git/vim/src/alloc.c:246
    #2 0x55e93a966e26 in alloc /srv/git/vim/src/alloc.c:151
    #3 0x55e93b44b39b in vim_strsave /srv/git/vim/src/strings.c:27
    #4 0x55e93b89d26e in gui_mch_add_menu_item /srv/git/vim/src/gui_gtk4.c:3952
    #5 0x55e93af73488 in add_menu_path /srv/git/vim/src/menu.c:690
    #6 0x55e93af712ab in ex_menu /srv/git/vim/src/menu.c:405
    #7 0x55e93aca7777 in do_one_cmd /srv/git/vim/src/ex_docmd.c:2629
    #8 0x55e93ac9a5a9 in do_cmdline /srv/git/vim/src/ex_docmd.c:1041
    #9 0x55e93ac98109 in do_cmdline_cmd /srv/git/vim/src/ex_docmd.c:635
    #10 0x55e93b721562 in exec_instructions /srv/git/vim/src/vim9execute.c:4090
    #11 0x55e93b752ab6 in call_def_function /srv/git/vim/src/vim9execute.c:6926
    #12 0x55e93b63c93d in call_user_func /srv/git/vim/src/userfunc.c:3055
    #13 0x55e93b642a91 in call_user_func_check /srv/git/vim/src/userfunc.c:3492
    #14 0x55e93b648499 in call_func /srv/git/vim/src/userfunc.c:4165
    #15 0x55e93b634518 in get_func_tv /srv/git/vim/src/userfunc.c:2190
    #16 0x55e93b65f130 in ex_call_inner /srv/git/vim/src/userfunc.c:6525
    #17 0x55e93b6622dd in ex_call /srv/git/vim/src/userfunc.c:6883
    #18 0x55e93aca7777 in do_one_cmd /srv/git/vim/src/ex_docmd.c:2629
    #19 0x55e93ac9a5a9 in do_cmdline /srv/git/vim/src/ex_docmd.c:1041
    #20 0x55e93a9902b3 in apply_autocmds_group /srv/git/vim/src/autocmd.c:2447
    #21 0x55e93a98d87d in apply_autocmds /srv/git/vim/src/autocmd.c:1858
    #22 0x55e93b9d98cd in vim_main2 /srv/git/vim/src/main.c:904
    #23 0x55e93b9d8b74 in main /srv/git/vim/src/main.c:453
    #24 0x7f7318e27740  (/usr/lib/libc.so.6+0x27740) (BuildId: 020d6f7c33b2413f4fe10814c4729dce1387f049)
    #25 0x7f7318e27878 in __libc_start_main (/usr/lib/libc.so.6+0x27878) (BuildId: 020d6f7c33b2413f4fe10814c4729dce1387f049)
    #26 0x55e93a966ba4 in _start (/srv/git/vim/src/vim+0x1a53ba4) (BuildId: f0c2b30d48c056f1f57ce8c3efe4880cb6c31cb6)

Direct leak of 8 byte(s) in 1 object(s) allocated from:
    #0 0x7f731b12c161 in malloc (/usr/lib/libasan.so.8+0x12c161) (BuildId: ee5fbab73143ab257a66a33afe0f038a4af7a74e)
    #1 0x55e93a967050 in lalloc /srv/git/vim/src/alloc.c:246
    #2 0x55e93a966e26 in alloc /srv/git/vim/src/alloc.c:151
    #3 0x55e93b44b39b in vim_strsave /srv/git/vim/src/strings.c:27
    #4 0x55e93b89d26e in gui_mch_add_menu_item /srv/git/vim/src/gui_gtk4.c:3952
    #5 0x55e93af73488 in add_menu_path /srv/git/vim/src/menu.c:690
    #6 0x55e93af712ab in ex_menu /srv/git/vim/src/menu.c:405
    #7 0x55e93aca7777 in do_one_cmd /srv/git/vim/src/ex_docmd.c:2629
    #8 0x55e93ac9a5a9 in do_cmdline /srv/git/vim/src/ex_docmd.c:1041
    #9 0x55e93b7071e9 in exec_command /srv/git/vim/src/vim9execute.c:2188
    #10 0x55e93b71cc69 in exec_instructions /srv/git/vim/src/vim9execute.c:3765
    #11 0x55e93b752ab6 in call_def_function /srv/git/vim/src/vim9execute.c:6926
    #12 0x55e93b63c93d in call_user_func /srv/git/vim/src/userfunc.c:3055
    #13 0x55e93b642a91 in call_user_func_check /srv/git/vim/src/userfunc.c:3492
    #14 0x55e93b648499 in call_func /srv/git/vim/src/userfunc.c:4165
    #15 0x55e93b634518 in get_func_tv /srv/git/vim/src/userfunc.c:2190
    #16 0x55e93b65f130 in ex_call_inner /srv/git/vim/src/userfunc.c:6525
    #17 0x55e93b6622dd in ex_call /srv/git/vim/src/userfunc.c:6883
    #18 0x55e93aca7777 in do_one_cmd /srv/git/vim/src/ex_docmd.c:2629
    #19 0x55e93ac9a5a9 in do_cmdline /srv/git/vim/src/ex_docmd.c:1041
    #20 0x55e93a9902b3 in apply_autocmds_group /srv/git/vim/src/autocmd.c:2447
    #21 0x55e93a98d87d in apply_autocmds /srv/git/vim/src/autocmd.c:1858
    #22 0x55e93b053eea in nv_cursorhold /srv/git/vim/src/normal.c:7584
    #23 0x55e93b006f40 in normal_cmd /srv/git/vim/src/normal.c:955
    #24 0x55e93b9db951 in main_loop /srv/git/vim/src/main.c:1639
    #25 0x55e93b9d9bea in vim_main2 /srv/git/vim/src/main.c:977
    #26 0x55e93b9d8b74 in main /srv/git/vim/src/main.c:453
    #27 0x7f7318e27740  (/usr/lib/libc.so.6+0x27740) (BuildId: 020d6f7c33b2413f4fe10814c4729dce1387f049)
    #28 0x7f7318e27878 in __libc_start_main (/usr/lib/libc.so.6+0x27878) (BuildId: 020d6f7c33b2413f4fe10814c4729dce1387f049)
    #29 0x55e93a966ba4 in _start (/srv/git/vim/src/vim+0x1a53ba4) (BuildId: f0c2b30d48c056f1f57ce8c3efe4880cb6c31cb6)

SUMMARY: AddressSanitizer: 3738 byte(s) leaked in 481 allocation(s).
```