### PR TITLE
fix(gtk3-wayland): crash right mouse-button tabline

### DIFF
--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -3479,15 +3479,15 @@ on_tabline_menu(GtkWidget *widget, GdkEvent *event)
 	{
 # if GTK_CHECK_VERSION(3,22,2)
 #  ifdef GDK_WINDOWING_WAYLAND
-    if (gui.is_wayland)
-    {
-      int x2, y2;
-      gui_gtk_get_pointer(gui.mainwin, &x2, &y2, NULL);
-      gtk_menu_popup_at_rect(GTK_MENU(widget),
-          gtk_widget_get_window(gui.mainwin), &(GdkRectangle){x2, y2, 1, 1},
-          GDK_GRAVITY_SOUTH_WEST, GDK_GRAVITY_NORTH_WEST, NULL);
-    }
-    else
+	    if (gui.is_wayland)
+	    {
+		int x2, y2;
+		gui_gtk_get_pointer(gui.mainwin, &x2, &y2, NULL);
+		gtk_menu_popup_at_rect(GTK_MENU(widget),
+			gtk_widget_get_window(gui.mainwin), &(GdkRectangle){x2, y2, 1, 1},
+			GDK_GRAVITY_SOUTH_WEST, GDK_GRAVITY_NORTH_WEST, NULL);
+	    }
+	    else
 #  endif
 	    gtk_menu_popup_at_pointer(GTK_MENU(widget), event);
 # else

--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -3478,6 +3478,17 @@ on_tabline_menu(GtkWidget *widget, GdkEvent *event)
 	if (bevent->button == 3)
 	{
 # if GTK_CHECK_VERSION(3,22,2)
+#  ifdef GDK_WINDOWING_WAYLAND
+    if (gui.is_wayland)
+    {
+      int x, y;
+      gui_gtk_get_pointer(gui.mainwin, &x, &y, NULL);
+      gtk_menu_popup_at_rect(GTK_MENU(widget),
+          gtk_widget_get_window(gui.mainwin), &(GdkRectangle){x, y, 1, 1},
+          GDK_GRAVITY_SOUTH_WEST, GDK_GRAVITY_NORTH_WEST, NULL);
+    }
+    else
+#  endif
 	    gtk_menu_popup_at_pointer(GTK_MENU(widget), event);
 # else
 	    gtk_menu_popup(GTK_MENU(widget), NULL, NULL, NULL, NULL,

--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -3481,10 +3481,10 @@ on_tabline_menu(GtkWidget *widget, GdkEvent *event)
 #  ifdef GDK_WINDOWING_WAYLAND
     if (gui.is_wayland)
     {
-      int x, y;
-      gui_gtk_get_pointer(gui.mainwin, &x, &y, NULL);
+      int x2, y2;
+      gui_gtk_get_pointer(gui.mainwin, &x2, &y2, NULL);
       gtk_menu_popup_at_rect(GTK_MENU(widget),
-          gtk_widget_get_window(gui.mainwin), &(GdkRectangle){x, y, 1, 1},
+          gtk_widget_get_window(gui.mainwin), &(GdkRectangle){x2, y2, 1, 1},
           GDK_GRAVITY_SOUTH_WEST, GDK_GRAVITY_NORTH_WEST, NULL);
     }
     else


### PR DESCRIPTION
GtkNotebook (tabline) is a windowless container widget causing a nullptr deref inside `gdk_window_get_effective_parent()` as Wayland lacks a surface to anchor to.

Thus use `gui.mainwin` and get coords. This also solves wrong placement of mousemenu when right-clicking over mid-way on a tab.

Closes: #18864