### PR TITLE
filetype: SGF files are not recognized

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -3390,6 +3390,8 @@ const ft_from_name = {
   # Screen RC
   ".screenrc": "screen",
   "screenrc": "screen",
+  # SGF, Smart Game Format
+  "sgf": "sgf",
   # skhd (simple hotkey daemon for macOS)
   ".skhdrc": "skhd",
   "skhdrc": "skhd",

--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -2715,6 +2715,8 @@ const ft_from_ext = {
   "mill": "scala",
   # SBT - Scala Build Tool
   "sbt": "sbt",
+  # SGF, Smart Game Format
+  "sgf": "sgf",
   # Slang Shading Language
   "slang": "shaderslang",
   # Slint
@@ -3390,8 +3392,6 @@ const ft_from_name = {
   # Screen RC
   ".screenrc": "screen",
   "screenrc": "screen",
-  # SGF, Smart Game Format
-  "sgf": "sgf",
   # skhd (simple hotkey daemon for macOS)
   ".skhdrc": "skhd",
   "skhdrc": "skhd",

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1013,6 +1013,9 @@ au BufNewFile,BufRead */etc/slp.spi		setf slpspi
 " Setserial config
 au BufNewFile,BufRead */etc/serial.conf		setf setserial
 
+" SGF, Smart Game Format
+au BufNewFile,BufRead *.sgf		setf sgf
+
 " SGML
 au BufNewFile,BufRead *.sgm,*.sgml
 	\ if getline(1).getline(2).getline(3).getline(4).getline(5) =~? 'linuxdoc' |

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1013,9 +1013,6 @@ au BufNewFile,BufRead */etc/slp.spi		setf slpspi
 " Setserial config
 au BufNewFile,BufRead */etc/serial.conf		setf setserial
 
-" SGF, Smart Game Format
-au BufNewFile,BufRead *.sgf		setf sgf
-
 " SGML
 au BufNewFile,BufRead *.sgm,*.sgml
 	\ if getline(1).getline(2).getline(3).getline(4).getline(5) =~? 'linuxdoc' |

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -740,6 +740,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     services: ['/etc/services', 'any/etc/services'],
     setserial: ['/etc/serial.conf', 'any/etc/serial.conf'],
     sexplib: ['file.sexp'],
+    sgf: ['file.sgf'],
     sh: ['.bashrc', '.bash_profile', '.bash-profile', '.bash_logout', '.bash-logout', '.bash_aliases', '.bash-aliases', '.bash_history', '.bash-history',
          '/tmp/bash-fc-3Ozjlw', '/tmp/bash-fc.3Ozjlw', 'PKGBUILD', 'file.bash', '/usr/share/doc/bash-completion/filter.sh',
          '/etc/udev/cdsymlinks.conf', 'any/etc/udev/cdsymlinks.conf', 'file.bats', '.ash_history', 'any/etc/neofetch/config.conf', '.xprofile',


### PR DESCRIPTION
Add filetype for the [SGF](https://www.red-bean.com/sgf/index.html). The format is widely used across Go servers, game databases, study tools, and editors, and .sgf files are the common interchange format for sharing and reviewing Go games.