### PR TITLE
filetype: Popcap Reanimation files are not recognized

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -3368,6 +3368,8 @@ const ft_from_name = {
   ".Rprofile": "r",
   "Rprofile": "r",
   "Rprofile.site": "r",
+  # Popcap Reanimation files
+  "reanim": "xml",
   # Resolv.conf
   "resolv.conf": "resolv",
   # Robots.txt

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -984,7 +984,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     xml: ['/etc/blkid.tab', '/etc/blkid.tab.old', 'file.xmi', 'file.csproj', 'file.csproj.user', 'file.fsproj', 'file.fsproj.user', 'file.vbproj', 'file.vbproj.user', 'file.ui',
           'file.tpm', '/etc/xdg/menus/file.menu', 'fglrxrc', 'file.xlf', 'file.xliff', 'file.xul', 'file.wsdl', 'file.wpl', 'any/etc/blkid.tab', 'any/etc/blkid.tab.old',
           'any/etc/xdg/menus/file.menu', 'file.atom', 'file.rss', 'file.cdxml', 'file.psc1', 'file.mpd', 'fonts.conf', 'file.xcu', 'file.xlb', 'file.xlc', 'file.xba', 'file.xpr',
-          'file.xpfm', 'file.spfm', 'file.bxml', 'file.mmi', 'file.slnx', 'Directory.Packages.props', 'Directory.Build.targets', 'Directory.Build.props'],
+          'file.xpfm', 'file.spfm', 'file.bxml', 'file.mmi', 'file.slnx', 'Directory.Packages.props', 'Directory.Build.targets', 'Directory.Build.props', 'file.reanim'],
     xmodmap: ['anyXmodmap', 'Xmodmap', 'some-Xmodmap', 'some-xmodmap', 'some-xmodmap-file', 'xmodmap', 'xmodmap-file'],
     xpm: ['file.xpm'],
     xpm2: ['file.xpm2'],


### PR DESCRIPTION
Problem: Popcap Reanimation files are not recognized
Solution: recognize Popcap Reanimation files as xml filetype

E.g.: `~/.config/io.github.wszqkzqk/PvZPortable/main/reanim/Z.reanim`:

```xml
<fps>12</fps>
<track>
<name>z1</name>
<t><x>-5.3</x><y>-5.2</y><sx>0.117</sx><sy>0.117</sy><a>0.00</a><i>IMAGE_REANIM_Z</i></t>
<t><x>-4.4</x><y>-7.4</y><sx>0.196</sx><sy>0.196</sy><a>0.50</a></t>
<t><x>-3.5</x><y>-9.6</y><sx>0.275</sx><sy>0.275</sy><a>1.00</a></t>
<t><x>-0.0</x><y>-14.3</y><kx>5.0</kx><ky>5.0</ky><sx>0.334</sx><sy>0.334</sy></t>
<t><x>3.5</x><y>-19.0</y><kx>10.0</kx><ky>10.0</ky><sx>0.393</sx><sy>0.393</sy></t>
<t><x>-0.5</x><y>-24.2</y><kx>5.0</kx><ky>5.0</ky><sx>0.422</sx><sy>0.422</sy></t>
<t><x>-4.9</x><y>-29.4</y><kx>0.0</kx><ky>0.0</ky><sx>0.452</sx><sy>0.452</sy></t>
```
