### PR TITLE
configure: GTK4 build requires GTK >= 4.10

### DIFF
--- a/src/auto/configure
+++ b/src/auto/configure
@@ -10853,7 +10853,7 @@ printf "%s\n" "gtk test disabled" >&6; }
 
   if test "x$PKG_CONFIG" != "xno"; then
 
-      min_gtk_version="4.0.0"
+      min_gtk_version="4.10.0"
 
     if test "$PKG_CONFIG" != "no"; then
     case $min_gtk_version in #(

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -2986,7 +2986,7 @@ if test -z "$SKIP_GTK4"; then
   fi
 
   if test "x$PKG_CONFIG" != "xno"; then
-    AM_PATH_GTK(4.0.0,
+    AM_PATH_GTK(4.10.0,
 		[GUI_LIB_LOC="$GTK_LIBDIR"
 		 GTK_LIBNAME="$GTK_LIBS"
 		 GUI_INC_LOC="$GTK_CPPFLAGS"])


### PR DESCRIPTION
The GTK4 GUI uses GtkFontDialog, GtkFileDialog and GtkAlertDialog, which were all introduced in GTK 4.10. configure.ac still required only 4.0.0, so on systems with older GTK4 (e.g. Debian Bookworm with GTK 4.8) configure succeeds and the build later fails in gui_gtk4.c. Bump the minimum to 4.10.0 so the failure surfaces at configure time.

Fixes #20340