### PR TITLE
scrolljump ignored when scrolling up

### DIFF
--- a/src/move.c
+++ b/src/move.c
@@ -431,22 +431,15 @@ update_topline(void)
 	    // If we weren't very close to begin with, we scroll to put the
 	    // cursor in the middle of the window.  Otherwise put the cursor
 	    // near the top of the window.
-	    if (n >= halfheight)
-	    {
-		if (eof_pressure)
-		    scroll_cursor_halfway(TRUE, TRUE);
-		else
-		    scroll_cursor_halfway(FALSE, FALSE);
-	    }
+	    int min_scroll = scrolljump_value();
+	    if (eof_pressure)
+		scroll_cursor_halfway(TRUE, TRUE);
+	    else if (n >= halfheight && min_scroll < halfheight)
+		scroll_cursor_halfway(FALSE, FALSE);
 	    else
 	    {
-		if (eof_pressure)
-		    scroll_cursor_halfway(TRUE, TRUE);
-		else
-		{
-		    scroll_cursor_top(scrolljump_value(), FALSE);
-		    check_botline = TRUE;
-		}
+		scroll_cursor_top(min_scroll, FALSE);
+		check_botline = TRUE;
 	    }
 	}
 

--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -2472,6 +2472,13 @@ func Test_opt_scrolljump()
          \            'topline':5, 'coladd':0, 'skipcol':0, 'curswant':0},
          \           winsaveview())
 
+  norm! 100Gzt
+  set scrolljump=-100
+  norm! 20k
+  call assert_equal({'lnum':80, 'leftcol':0, 'col':0, 'topfill':0,
+        \            'topline':71, 'coladd':0, 'skipcol':0, 'curswant':0},
+        \           winsaveview())
+
   set scrolljump&
   bw
 endfunc


### PR DESCRIPTION
Problem:
sj=-100 only scrolls half a page going up, but works fine going down. update_topline always falls back to
scroll_cursor_halfway when the cursor is far above topline.

Solution:
Only center when sj is smaller than half the window. Otherwise call scroll_cursor_top like the downward path does.

Fix #1527 