### PR TITLE
runtime(pilrc): fix typo country names in pilrcCountry syntax list

### DIFF
--- a/runtime/syntax/pilrc.vim
+++ b/runtime/syntax/pilrc.vim
@@ -72,7 +72,7 @@ syn keyword pilrcType WARNING WEEKSTARTDAY
 
 " Country
 syn keyword pilrcCountry Australia Austria Belgium Brazil Canada Denmark
-syn keyword pilrcCountry Finland France Germany HongKong Iceland Indian
+syn keyword pilrcCountry Finland France Germany HongKong Iceland India
 syn keyword pilrcCountry Indonesia Ireland Italy Japan Korea Luxembourg Malaysia
 syn keyword pilrcCountry Mexico Netherlands NewZealand Norway Philippines
 syn keyword pilrcCountry RepChina Singapore Spain Sweden Switzerland Thailand


### PR DESCRIPTION
Corrected "Indian" to "India" for accurate naming.

Refer to http://www.fifi.org/doc/pilrc/html/manual.html#lang_graffitiinputarea