### PR TITLE
[Runtime]: Detect Kawasaki robots AS files

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -3,7 +3,7 @@ vim9script
 # Vim functions for file type detection
 #
 # Maintainer:		The Vim Project <https://github.com/vim/vim>
-# Last Change:		2026 May 28
+# Last Change:		2026 May 29
 # Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 # These functions are moved here from runtime/filetype.vim to make startup
@@ -61,6 +61,21 @@ export def FTapp()
     endif
     return
   endfor
+enddef
+
+# This function checks for Kawasaki robots AS file or atlas file type.
+export def FTas()
+  if exists("g:filetype_as")
+    exe "setf " .. g:filetype_as
+    return
+  endif
+  for lnum in range(1, min([line("$"), 30]))
+    if getline(lnum) =~ '^\.NETCONF'
+      setf kawasaki_as
+      return
+    endif
+  endfor
+  setf atlas
 enddef
 
 # This function checks for the kind of assembly that is wanted by the user, or
@@ -1771,7 +1786,6 @@ const ft_from_ext = {
   "astro": "astro",
   # Atlas
   "atl": "atlas",
-  "as": "atlas",
   # Atom is based on XML
   "atom": "xml",
   # Authzed
@@ -2300,6 +2314,8 @@ const ft_from_ext = {
   # KAREL
   "kl": "karel",
   "KL": "karel",
+  # Kawasaki AS
+  "pg": "kawasaki_as",
   # KDL
   "kdl": "kdl",
   # KerML

--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -1,4 +1,4 @@
-*filetype.txt*	For Vim version 9.2.  Last change: 2026 May 16
+*filetype.txt*	For Vim version 9.2.  Last change: 2026 May 29
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -139,6 +139,7 @@ variables can be used to overrule the filetype used for certain extensions:
 
 	file name	variable ~
 	*.app		g:filetype_app
+	*.as		g:filetype_as
 	*.asa		g:filetype_asa		|ft-aspperl-syntax|
 						|ft-aspvbs-syntax|
 	*.asm		g:asmsyntax		|ft-asm-syntax|

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1,7 +1,7 @@
 " Vim support file to detect file types
 "
 " Maintainer:		The Vim Project <https://github.com/vim/vim>
-" Last Change:		2026 Apr 20
+" Last Change:		2026 May 29
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " If the filetype can be detected from extension or file name(the final path component),
@@ -90,6 +90,9 @@ au BufNewFile,BufRead */.aptitude/config       setf aptconf
 
 " Arch Inventory file
 au BufNewFile,BufRead .arch-inventory,=tagging-method	setf arch
+
+" atlas or kawasaki_as
+au BufNewFile,BufRead *.as call dist#ft#FTas()
 
 " Active Server Pages (with Visual Basic Script)
 au BufNewFile,BufRead *.asa


### PR DESCRIPTION
In Kawasaki robots (https://kawasakirobotics.com/products-robots/) AS language

*.pg is the extention for a program file and
*.as is for a complete backup.

	modified:   runtime/autoload/dist/ft.vim
	modified:   runtime/doc/filetype.txt
	modified:   runtime/filetype.vim