### PR TITLE
perf: syntax highlighting skips patterns that cannot match a line

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -6616,5 +6616,44 @@ literal text specify the size of that text (in bytes):
 		many places.
 "<\@1<=span"	Matches the same, but only tries one byte before "span".
 
+						*:syntax-prefilter*
+To avoid wasted work Vim uses a "required-byte" prefilter.  When a syntax
+pattern is defined, Vim works out which bytes must appear in any text the
+pattern can match.  Before trying the pattern on a line it checks the line for
+those bytes and skips the pattern when one of them is missing, without running
+the regexp engine at all.  This is why including literal text, as above,
+helps: it gives the prefilter something to key on.
+
+This only makes highlighting faster, it never changes the result.  The
+highlighting is the same whether a pattern is skipped or not.
+
+The prefilter applies only to the patterns of |:syn-match| and |:syn-region|
+items.  It does not affect matching functions such as |match()|, |search()| or
+|substitute()|.
+
+The analysis is deliberately careful: it speeds up only the patterns it can
+analyse with certainty and does nothing for the rest.  Which patterns benefit
+therefore depends on how a pattern is written; two patterns that match the
+same text are not necessarily optimized the same way.  There is no option to
+configure this and nothing to tune.
+
+Because a skipped pattern is not tried, it is not counted in a |:syntime|
+report for the lines where it was skipped, and may be absent from the report
+entirely if it was skipped on every line that was redrawn.
+
+If you suspect the prefilter causes wrong highlighting, you can turn it off to
+check, with |test_override()|: >
+	:call test_override('syn_prefilter', 1)
+	:syntax sync fromstart
+	:redraw!
+<Switch it back on again, together with any other overrides, with: >
+	:call test_override('ALL', 0)
+<If the highlighting changes when the prefilter is off, that is a bug worth
+reporting; the result is meant to be identical either way.
+
+Vim's own test suite guards this in src/testdir/test_syntax.vim: it highlights
+several buffers with the prefilter on and off and checks that the result is
+identical, so an analysis bug that wrongly skips a pattern is caught.
+
 
  vim:tw=78:sw=4:ts=8:noet:ft=help:norl:

--- a/runtime/doc/testing.txt
+++ b/runtime/doc/testing.txt
@@ -409,6 +409,8 @@ test_override({name}, {val})				*test_override()*
 		redraw       disable the redrawing() function.
 		redraw_flag  ignore the RedrawingDisabled flag.
 		starting     reset the "starting" variable, see below.
+		syn_prefilter	disable the syntax highlighting required-byte
+				prefilter, so all patterns are tried.
 		syn_idlist_cache	disable the cache for resolving
 					syntax "contains"/cluster lists.
 		term_props   reset all terminal properties when the version

--- a/src/globals.h
+++ b/src/globals.h
@@ -2007,6 +2007,7 @@ EXTERN int  disable_char_avail_for_testing INIT(= FALSE);
 EXTERN int  disable_redraw_for_testing INIT(= FALSE);
 EXTERN int  ignore_redraw_flag_for_testing INIT(= FALSE);
 EXTERN int  nfa_fail_for_testing INIT(= FALSE);
+EXTERN int  disable_syn_prefilter_for_testing INIT(= FALSE);
 EXTERN int  disable_syn_idlist_cache_for_testing INIT(= FALSE);
 EXTERN int  no_query_mouse_for_testing INIT(= FALSE);
 EXTERN int  ui_delay_for_testing INIT(= 0);

--- a/src/proto/regexp.pro
+++ b/src/proto/regexp.pro
@@ -7,6 +7,7 @@ int re_multiline(regprog_T *prog);
 char_u *skip_regexp(char_u *startp, int delim, int magic);
 char_u *skip_regexp_err(char_u *startp, int delim, int magic);
 char_u *skip_regexp_ex(char_u *startp, int dirc, int magic, char_u **newp, int *dropped, magic_T *magic_val);
+int regpat_get_brace_limits(char_u **pp, long *minval, long *maxval);
 reg_extmatch_T *ref_extmatch(reg_extmatch_T *em);
 void unref_extmatch(reg_extmatch_T *em);
 char_u *regtilde(char_u *source, int magic);

--- a/src/regexp.c
+++ b/src/regexp.c
@@ -676,6 +676,65 @@ skip_regexp_ex(
 }
 
 /*
+ * regpat_get_brace_limits - Parse the "{n,m}" limits of a "\{...}" multi,
+ * starting at "*pp" (just after "\{").  Like the skip_regexp() helpers above
+ * this works on the pattern *syntax* and is independent of any compiled
+ * program, so it can be shared by the regexp engine and by other consumers of
+ * the pattern.
+ *
+ * If the first character is '-', the range is reversed.  A missing minval
+ * defaults to zero, a missing maxval to a very big number.  The values are
+ * normalised the same way the engine uses them.  On success "*pp" is left on
+ * the closing "}" and OK is returned; FAIL is returned when the limits are not
+ * well-formed.
+ */
+    int
+regpat_get_brace_limits(char_u **pp, long *minval, long *maxval)
+{
+    char_u	*p = *pp;
+    int		reverse = FALSE;
+    char_u	*first_char;
+    long	tmp;
+
+    if (*p == '-')
+    {
+	// Starts with '-', so reverse the range later
+	++p;
+	reverse = TRUE;
+    }
+    first_char = p;
+    *minval = getdigits(&p);
+    if (*p == ',')		    // There is a comma
+    {
+	if (vim_isdigit(*++p))
+	    *maxval = getdigits(&p);
+	else
+	    *maxval = MAX_LIMIT;
+    }
+    else if (VIM_ISDIGIT(*first_char))
+	*maxval = *minval;	    // It was \{n} or \{-n}
+    else
+	*maxval = MAX_LIMIT;	    // It was \{} or \{-}
+    if (*p == '\\')
+	++p;			    // Allow either \{...} or \{...\}
+    if (*p != '}')
+	return FAIL;
+
+    /*
+     * Reverse the range if there was a '-', or make sure it is in the right
+     * order otherwise.
+     */
+    if ((!reverse && *minval > *maxval) || (reverse && *minval < *maxval))
+    {
+	tmp = *minval;
+	*minval = *maxval;
+	*maxval = tmp;
+    }
+    *pp = p;			    // left on the "}"
+    return OK;
+}
+
+/*
  * Functions for getting characters from the regexp input.
  */
 static int	prevchr_len;	// byte length of previous char
@@ -1059,53 +1118,15 @@ getoctchrs(void)
 }
 
 /*
- * read_limits - Read two integers to be taken as a minimum and maximum.
- * If the first character is '-', then the range is reversed.
- * Should end with 'end'.  If minval is missing, zero is default, if maxval is
- * missing, a very big number is the default.
+ * read_limits - Read the "{n,m}" limits for the regexp engine, advancing
+ * "regparse" past the closing "}".
  */
     static int
 read_limits(long *minval, long *maxval)
 {
-    int		reverse = FALSE;
-    char_u	*first_char;
-    long	tmp;
-
-    if (*regparse == '-')
-    {
-	// Starts with '-', so reverse the range later
-	regparse++;
-	reverse = TRUE;
-    }
-    first_char = regparse;
-    *minval = getdigits(&regparse);
-    if (*regparse == ',')	    // There is a comma
-    {
-	if (vim_isdigit(*++regparse))
-	    *maxval = getdigits(&regparse);
-	else
-	    *maxval = MAX_LIMIT;
-    }
-    else if (VIM_ISDIGIT(*first_char))
-	*maxval = *minval;	    // It was \{n} or \{-n}
-    else
-	*maxval = MAX_LIMIT;	    // It was \{} or \{-}
-    if (*regparse == '\\')
-	regparse++;	// Allow either \{...} or \{...\}
-    if (*regparse != '}')
+    if (!regpat_get_brace_limits(&regparse, minval, maxval))
 	EMSG2_RET_FAIL(_(e_syntax_error_in_str_curlies),
 						       reg_magic == MAGIC_ALL);
-
-    /*
-     * Reverse the range if there was a '-', or make sure it is in the right
-     * order otherwise.
-     */
-    if ((!reverse && *minval > *maxval) || (reverse && *minval < *maxval))
-    {
-	tmp = *minval;
-	*minval = *maxval;
-	*maxval = tmp;
-    }
     skipchr();		// let's be friends with the lexer again
     return OK;
 }

--- a/src/syntax.c
+++ b/src/syntax.c
@@ -53,6 +53,8 @@ typedef struct syn_pattern
     int		 sp_cchar;		// conceal substitute character
 #endif
     int		 sp_ic;			// ignore-case flag for sp_prog
+    bool	 sp_filter_active;	// true when sp_req is usable
+    char_u	 sp_req[32];		// bitset: bytes that must occur in line
     int		 sp_sync_idx;		// sync item index (syncing only)
     int		 sp_line_id;		// ID of last line where tried
     int		 sp_startcol;		// next match in sp_line_id line
@@ -76,6 +78,11 @@ typedef struct syn_pattern
 #define SPTYPE_END	3	// match a regexp, end of item
 #define SPTYPE_SKIP	4	// match a regexp, skip within item
 
+// Required-byte prefilter: a 256-bit set (32 bytes) used to cheaply reject
+// syntax patterns that provably cannot match anywhere in the current line,
+// avoiding a full syn_regexec() call.  See syn_compute_required_bytes().
+#define SYN_BSET_SIZE	32
+#define SYN_BSET_ADD(set, b)	((set)[((b) & 0xff) >> 3] |= (1 << ((b) & 7)))
 
 #define SYN_ITEMS(buf)	((synpat_T *)((buf)->b_syn_patterns.ga_data))
 
@@ -343,9 +350,14 @@ static int syn_check_cluster(char_u *pp, int len);
 static int syn_add_cluster(char_u *name);
 static void init_syn_patterns(void);
 static char_u *get_syn_pattern(char_u *arg, synpat_T *ci);
+static void syn_compute_required_bytes(synpat_T *ci);
+static bool syn_line_cannot_match(synpat_T *spp);
 static int get_id_list(char_u **arg, int keylen, short **list, int skip);
 static void syn_combine_list(short **clstr1, short **clstr2, int list_op);
 static void idl_cache_clear(synblock_T *block);
+
+// Bitset of bytes present in the current line, for the required-byte prefilter.
+static char_u current_line_bset[SYN_BSET_SIZE];
 
 /*
  * Start the syntax recognition for a line.  This function is normally called
@@ -901,6 +913,11 @@ syn_start_line(void)
 {
     current_finished = FALSE;
     current_col = 0;
+
+    // Build the byte set of this line for the required-byte prefilter.
+    CLEAR_FIELD(current_line_bset);
+    for (char_u *p = syn_getcurline(); *p != NUL; ++p)
+	SYN_BSET_ADD(current_line_bset, *p);
 
     /*
      * Need to update the end of a start/skip/end that continues from the
@@ -1958,6 +1975,17 @@ syn_current_attr(
 				    && spp->sp_startcol >= next_match_col)
 				continue;
 			    spp->sp_line_id = current_line_id;
+
+			    // Required-byte prefilter.  Can be disabled with
+			    // test_override('syn_prefilter', 1) to verify it
+			    // does not change the result.
+			    if (spp->sp_filter_active
+				    && !disable_syn_prefilter_for_testing
+				    && syn_line_cannot_match(spp))
+			    {
+				spp->sp_startcol = MAXCOL;
+				continue;
+			    }
 
 			    lc_col = current_col - spp->sp_offsets[SPO_LC_OFF];
 			    if (lc_col < 0)
@@ -5625,6 +5653,413 @@ init_syn_patterns(void)
     curwin->w_s->b_syn_patterns.ga_growsize = 10;
 }
 
+    static void
+syn_bset_or(char_u *dst, char_u *src)
+{
+    for (int i = 0; i < SYN_BSET_SIZE; ++i)
+	dst[i] |= src[i];
+}
+
+    static void
+syn_bset_and(char_u *dst, char_u *src)
+{
+    for (int i = 0; i < SYN_BSET_SIZE; ++i)
+	dst[i] &= src[i];
+}
+
+/*
+ * Recursive-descent analysis of a syntax pattern (magic mode) to derive a
+ * required-byte prefilter.  syn_fa_T holds "req", the bytes mandatory in every
+ * match (intersection across branches, union along a concatenation), and
+ * "bail", set when an unsupported construct is found.
+ *
+ * The filter must only speed things up, never change the highlighting: a byte
+ * is added to req only when it must literally occur, and any construct that is
+ * not obviously sound bails out so the pattern is always tried.  When in doubt,
+ * bail.
+ */
+#define SYN_FA_MAXDEPTH 10
+
+typedef struct
+{
+    char_u	req[SYN_BSET_SIZE];
+    bool	bail;
+} syn_fa_T;
+
+static char_u *syn_fa_alt(char_u *p, int ic, int depth, syn_fa_T *out);
+static char_u *syn_fa_concat(char_u *p, int ic, int depth, syn_fa_T *out);
+
+/*
+ * Add the literal character at "p" (single or multibyte) to the required-byte
+ * set and return its byte length.  Under ignore case a different-case form may
+ * match instead, so the bytes are only required when the character has no case
+ * variants.
+ */
+    static int
+syn_fa_add_literal(char_u *p, int ic, syn_fa_T *out)
+{
+    int		len = (*mb_ptr2len)(p);
+    bool	add;
+
+    if (!ic)
+	add = true;
+    else if (len == 1)
+	add = TOUPPER_LOC(*p) == TOLOWER_LOC(*p);
+    else if (enc_utf8)
+    {
+	int	c = utf_ptr2char(p);
+
+	add = utf_fold(c) == c;
+    }
+    else
+	add = false;		// DBCS + ignore case: invariance unknown
+    if (add)
+	for (int i = 0; i < len; ++i)
+	    SYN_BSET_ADD(out->req, p[i]);
+    return len;
+}
+
+/*
+ * Parse one atom (without its trailing quantifier) starting at "p".
+ */
+    static char_u *
+syn_fa_atom(char_u *p, int ic, int depth, syn_fa_T *out)
+{
+    CLEAR_FIELD(out->req);
+    out->bail = false;
+
+    // group: \(...\) or \%(...\)
+    if (*p == '\\' && (p[1] == '(' || (p[1] == '%' && p[2] == '(')))
+    {
+	if (depth >= SYN_FA_MAXDEPTH)
+	{
+	    out->bail = true;
+	    return p;
+	}
+	p += (p[1] == '%') ? 3 : 2;
+	p = syn_fa_alt(p, ic, depth + 1, out);
+	if (out->bail)
+	    return p;
+	if (*p == '\\' && p[1] == ')')
+	    return p + 2;
+	out->bail = true;		// malformed
+	return p;
+    }
+    // other \%... constructs: not supported
+    if (*p == '\\' && p[1] == '%')
+    {
+	out->bail = true;
+	return p;
+    }
+
+    // zero-width anchors: no byte required
+    if (*p == '^' || *p == '$')
+	return p + 1;
+    if (*p == '\\' && (p[1] == '<' || p[1] == '>'))
+	return p + 2;
+    if (*p == '\\' && p[1] == 'z' && (p[2] == 's' || p[2] == 'e'))
+	return p + 3;
+
+    // any character: no specific byte required
+    if (*p == '.' || *p == '~')
+	return p + 1;
+
+    // bracket [...]: matches one of a set, no single byte required
+    if (*p == '[')
+    {
+	char_u	*q = p + 1;
+
+	if (*q == '^')
+	    ++q;
+	if (*q == ']')
+	    ++q;
+	while (*q != NUL && *q != ']')
+	{
+	    if (*q == '[' && (q[1] == ':' || q[1] == '.' || q[1] == '='))
+	    {
+		out->bail = true;
+		return p;
+	    }
+	    // backslash escapes inside [...] are too varied to model soundly
+	    if (*q == '\\')
+	    {
+		out->bail = true;
+		return p;
+	    }
+	    if (*q >= 0x80)
+	    {
+		out->bail = true;
+		return p;
+	    }
+	    if (q[1] == '-' && q[2] != NUL && q[2] != ']')
+	    {
+		int	c1 = *q;
+		int	c2 = q[2];
+
+		if (c2 == '\\' || c2 >= 0x80 || c2 < c1)
+		{
+		    out->bail = true;
+		    return p;
+		}
+		q += 3;
+	    }
+	    else
+		++q;
+	}
+	if (*q != ']')
+	{
+	    out->bail = true;
+	    return p;
+	}
+	return q + 1;
+    }
+
+    // backslash escape: class, control char, operator or literal punctuation
+    if (*p == '\\' && p[1] != NUL)
+    {
+	int	c = p[1];
+	int	lit;
+
+	switch (c)
+	{
+	    case '(': case ')': case '|': case '&': case '@':
+	    case '{': case '%': case 'z': case 'n': case '_':
+	    case 'v': case 'm': case 'M':
+	    case 'Z':
+	    case '1': case '2': case '3': case '4': case '5':
+	    case '6': case '7': case '8': case '9':
+		// operators, flags, \n, \_x, backrefs: not modeled
+		out->bail = true;
+		return p;
+	    case 'c': case 'C':
+		// case toggle: zero-width, already applied to "ic" globally
+		return p + 2;
+	    case 'V':
+		// very nomagic: every following byte is literal until the next
+		// backslash.  A "\|", "\&" or "\)" there is a branch/group
+		// boundary handled by the caller; any other escape introduces
+		// constructs not modeled here, so bail.
+		{
+		    char_u  *q = p + 2;
+
+		    while (*q != NUL && *q != '\\')
+			q += syn_fa_add_literal(q, ic, out);
+		    if (*q == '\\'
+			    && q[1] != '|' && q[1] != '&' && q[1] != ')')
+		    {
+			out->bail = true;
+			return p;
+		    }
+		    return q;
+		}
+	    case 't': lit = TAB; break;
+	    case 'r': lit = CAR; break;
+	    case 'e': lit = ESC; break;
+	    case 'b': lit = BS; break;
+	    default:
+		// character classes (\d \s \w ...): a byte is required here,
+		// but the exact set is not modeled, so add nothing
+		if (vim_strchr((char_u *)"adfhiklopsuwxADFHIKLOPSUWX", c)
+								       != NULL)
+		{
+		    return p + 2;
+		}
+		// other alphanumeric escapes are reserved for special use; bail
+		if (ASCII_ISALPHA(c) || VIM_ISDIGIT(c))
+		{
+		    out->bail = true;
+		    return p;
+		}
+		lit = c;		// escaped literal punctuation
+		break;
+	}
+	if (!ic || TOUPPER_LOC(lit) == TOLOWER_LOC(lit))
+	    SYN_BSET_ADD(out->req, lit);
+	return p + 2;
+    }
+
+    // a plain or multibyte literal: all of its bytes are required
+    return p + syn_fa_add_literal(p, ic, out);
+}
+
+/*
+ * Parse a concatenation of atoms until "\|", "\&", "\)" or end of pattern.
+ */
+    static char_u *
+syn_fa_concat(char_u *p, int ic, int depth, syn_fa_T *out)
+{
+    CLEAR_FIELD(out->req);
+    out->bail = false;
+
+    while (*p != NUL
+	    && !(*p == '\\' && (p[1] == '|' || p[1] == '&' || p[1] == ')')))
+    {
+	syn_fa_T    item;
+	bool	    optional = false;
+
+	p = syn_fa_atom(p, ic, depth, &item);
+	if (item.bail)
+	{
+	    out->bail = true;
+	    return p;
+	}
+
+	if (*p == '\\' && p[1] == '@')
+	{
+	    out->bail = true;		// look-around assertion
+	    return p;
+	}
+	if (*p == '*')
+	{
+	    optional = true;
+	    ++p;
+	}
+	else if (*p == '\\' && (p[1] == '=' || p[1] == '?'))
+	{
+	    optional = true;
+	    p += 2;
+	}
+	else if (*p == '\\' && p[1] == '+')
+	    p += 2;			// one or more: still mandatory
+	else if (*p == '\\' && p[1] == '{')
+	{
+	    char_u  *q = p + 2;
+	    long    lo, hi;
+
+	    // \{n,m} repeat: reuse the shared pattern-grammar parser so the
+	    // same normalisation (defaults and reversal) applies.  The atom is
+	    // optional when it can occur zero times, i.e. the smaller bound
+	    // is zero; otherwise it is mandatory like "\+".
+	    if (!regpat_get_brace_limits(&q, &lo, &hi))
+	    {
+		out->bail = true;	// malformed
+		return p;
+	    }
+	    p = q + 1;			// past the "}"
+	    if ((lo < hi ? lo : hi) == 0)
+		optional = true;
+	}
+
+	// a mandatory atom: its required bytes must occur
+	if (!optional)
+	    syn_bset_or(out->req, item.req);
+    }
+
+    return p;
+}
+
+/*
+ * Parse an alternation of branches separated by "\|".
+ */
+    static char_u *
+syn_fa_alt(char_u *p, int ic, int depth, syn_fa_T *out)
+{
+    syn_fa_T	branch;
+    bool	first = true;
+
+    CLEAR_FIELD(out->req);
+    out->bail = false;
+
+    for (;;)
+    {
+	p = syn_fa_concat(p, ic, depth, &branch);
+	if (branch.bail)
+	{
+	    out->bail = true;
+	    return p;
+	}
+	if (first)
+	{
+	    mch_memmove(out->req, branch.req, SYN_BSET_SIZE);
+	    first = false;
+	}
+	else
+	    syn_bset_and(out->req, branch.req);	// required bytes: intersection
+	if (*p == '\\' && p[1] == '|')
+	{
+	    p += 2;
+	    continue;
+	}
+	if (*p == '\\' && p[1] == '&')
+	{
+	    out->bail = true;		// "\&" concat operator: not supported
+	    return p;
+	}
+	break;
+    }
+    return p;
+}
+
+/*
+ * Analyze "ci->sp_pattern" and store a conservative required-byte prefilter in
+ * sp_req.  On any unsupported construct the analysis bails out, leaving
+ * sp_filter_active false so the pattern is always tried.
+ */
+    static void
+syn_compute_required_bytes(synpat_T *ci)
+{
+    syn_fa_T	res;
+    bool	have_req = false;
+
+    ci->sp_filter_active = false;
+    CLEAR_FIELD(ci->sp_req);
+
+    if (ci->sp_pattern == NULL || *ci->sp_pattern == NUL)
+	return;
+
+    // "\c" / "\C" anywhere force case (in)sensitivity for the whole pattern;
+    // "\c" wins over "\C", matching how the engine resolves the flags.  Scan
+    // by escape pairs so an escaped backslash is not mistaken for a toggle.
+    int		ic = ci->sp_ic;
+    bool	saw_ci = false, saw_cs = false;
+    for (char_u *s = ci->sp_pattern; *s != NUL; )
+	if (s[0] == '\\' && s[1] != NUL)
+	{
+	    if (s[1] == 'c')
+		saw_ci = true;
+	    else if (s[1] == 'C')
+		saw_cs = true;
+	    s += 2;
+	}
+	else
+	    s += (*mb_ptr2len)(s);	// skip a whole char (DBCS 0x5C safe)
+    if (saw_ci)
+	ic = TRUE;
+    else if (saw_cs)
+	ic = FALSE;
+
+    (void)syn_fa_alt(ci->sp_pattern, ic, 0, &res);
+    if (res.bail)
+	return;
+
+    for (int i = 0; i < SYN_BSET_SIZE; ++i)
+	if (res.req[i])
+	{
+	    have_req = true;
+	    break;
+	}
+    if (!have_req)
+	return;
+
+    mch_memmove(ci->sp_req, res.req, SYN_BSET_SIZE);
+    ci->sp_filter_active = true;
+}
+
+/*
+ * Return true when "spp" provably cannot match anywhere in the current line,
+ * based on the required-byte prefilter and current_line_bset.
+ */
+    static bool
+syn_line_cannot_match(synpat_T *spp)
+{
+    // A byte that must occur is absent from the line: cannot match.
+    for (int i = 0; i < SYN_BSET_SIZE; ++i)
+	if (spp->sp_req[i] & ~current_line_bset[i])
+	    return true;
+
+    return false;
+}
+
 /*
  * Get one pattern for a ":syntax match" or ":syntax region" command.
  * Stores the pattern and program in a synpat_T.
@@ -5661,6 +6096,7 @@ get_syn_pattern(char_u *arg, synpat_T *ci)
     if (ci->sp_prog == NULL)
 	return NULL;
     ci->sp_ic = curwin->w_s->b_syn_ic;
+    syn_compute_required_bytes(ci);
 #ifdef FEAT_PROFILE
     syn_clear_time(&ci->sp_time);
 #endif

--- a/src/testdir/test_syntax.vim
+++ b/src/testdir/test_syntax.vim
@@ -114,7 +114,12 @@ func Test_syntime()
 
   view ../memfile_test.c
   setfiletype cpp
-  redraw
+  " Highlight the whole buffer, not just the visible screen: the first lines
+  " hold no numeric literal, so the required-byte prefilter would skip cppNumber
+  " there and it would be missing from the report.
+  for lnum in range(1, line('$'))
+    call synID(lnum, max([1, len(getline(lnum))]), 1)
+  endfor
   let a = execute('syntime report')
   call assert_match('^  TOTAL *COUNT *MATCH *SLOWEST *AVERAGE *NAME *PATTERN', a)
   call assert_match(' \d*\.\d* \+[^0]\d* .* cppRawString ', a)
@@ -689,6 +694,7 @@ func Test_syn_zsub()
   bw!
 endfunc
 
+" Collect the syntax id name of every cell of a freshly highlighted buffer.
 func s:SynDumpBuffer(ft, lines)
   new
   syntax on
@@ -702,6 +708,210 @@ func s:SynDumpBuffer(ft, lines)
   endfor
   bwipe!
   return result
+endfunc
+
+func s:SynDumpCustomSyntax(lines, syncmds)
+  new
+  syntax clear
+  for cmd in a:syncmds
+    execute cmd
+  endfor
+  call setline(1, a:lines)
+  let result = []
+  for lnum in range(1, line('$'))
+    for col in range(1, max([1, len(getline(lnum))]))
+      call add(result, synIDattr(synID(lnum, col, 1), 'name'))
+    endfor
+  endfor
+  bwipe!
+  return result
+endfunc
+
+" The internal required-byte prefilter skips patterns that cannot match in a
+" line.  It must never skip a pattern that can match: each item below is checked
+" on a line where it does match, exercising alternation, a group, an inline \c
+" flag, a leading class, a look-around and a hex class.
+func Test_syntax_required_byte_prefilter()
+  new
+  syntax clear
+  syntax case match
+
+  syntax match Tier1 "ab\|cd"
+  syntax match Tier2 "\%(foo\|bar\)baz"
+  syntax match Tier3 "\cWORD"
+  syntax match Tier4 "[Uu]niq"
+  syntax match Tier5 "\\\@<!|tag|"
+  syntax match Tier6 "0[xX]\x\+"
+  " a multibyte literal: all of its bytes are required, so it must be tried on
+  " a line containing the character
+  let mb = nr2char(0xe9)	" 'e' with acute accent
+  execute 'syntax match Tier7 "x' .. mb .. 'y"'
+
+  call setline(1, ['cd', 'barbaz', 'word', 'uniq', '|tag|', '0XAB',
+        \ 'x' .. mb .. 'y'])
+
+  call assert_equal('Tier1', synIDattr(synID(1, 1, 1), 'name'))
+  call assert_equal('Tier2', synIDattr(synID(2, 1, 1), 'name'))
+  call assert_equal('Tier3', synIDattr(synID(3, 1, 1), 'name'))
+  call assert_equal('Tier4', synIDattr(synID(4, 1, 1), 'name'))
+  call assert_equal('Tier5', synIDattr(synID(5, 1, 1), 'name'))
+  call assert_equal('Tier6', synIDattr(synID(6, 1, 1), 'name'))
+  call assert_equal('Tier7', synIDattr(synID(7, 1, 1), 'name'))
+
+  syntax clear
+  bwipe!
+endfunc
+
+" The required-byte prefilter is a speed optimization only: highlighting must be
+" identical whether it is active or not.  Compare the full-buffer synID()
+" output with the prefilter on (default) and forced off across several
+" filetypes, so a future analyzer bug that wrongly skips a pattern is caught.
+func Test_syntax_prefilter_unchanged()
+  let samples = {
+        \ 'c': ['#define M 0x1F', "char c = '\\n';", 'int i = 42; // x', 'L"wide"'],
+        \ 'vim': ['func <SID>Foo() abort', '  let x = 0z1f2e', 'endfunc', '" a'],
+        \ 'python': ['def f(x): return 0xAB', 'a = "s" + r"\d+"  # c'],
+        \ 'sh': ['for i in $(seq 1 3); do echo "v=${i}"; done'],
+        \ }
+  for ft in sort(keys(samples))
+    call test_override('syn_prefilter', 0)
+    let on = s:SynDumpBuffer(ft, samples[ft])
+    call test_override('syn_prefilter', 1)
+    let off = s:SynDumpBuffer(ft, samples[ft])
+    call test_override('ALL', 0)
+    call assert_equal(off, on, 'filetype ' .. ft)
+  endfor
+endfunc
+
+func Test_syntax_prefilter_classes()
+  " The required-byte prefilter analyzer does not enumerate any character
+  " class's byte set: every class (\a \d \f \h \i \k \l \o \p \s \u \w \x and
+  " their negated/uppercase forms) is consuming but requires no specific byte.
+  " It bails on unknown escapes (e.g. \g) and treats an escaped punctuation as
+  " a literal.  It also bails on backslash escapes inside a [...] collection
+  " (\t \e \r \b \n, the numeric \d \o \x \u \U forms, and "\s" meaning
+  " backslash-or-s), which it cannot model soundly.
+  " Highlighting must be identical with the prefilter on and off for each.
+  let cases = [
+        \ ['\i\+', 'abc_123'],
+        \ ['\k\+', 'word42'],
+        \ ['\f\+', 'a/b.c'],
+        \ ['\p\+', 'hello!'],
+        \ ['\I\+', 'name'],
+        \ ['\D\+', 'xyz.'],
+        \ ['\W\+', '!!!'],
+        \ ['\S\+', 'foo'],
+        \ ['\g\+', 'gggg'],
+        \ ['a\.b', 'a.b'],
+        \ ['[\t]x', "\tx"],
+        \ ['[\d65]x', 'Ax'],
+        \ ['[\s]x', "\\x"],
+        \ ]
+  for [pat, line] in cases
+    let cmds = ['syntax match Special /' .. escape(pat, '/') .. '/']
+    call test_override('syn_prefilter', 0)
+    let on = s:SynDumpCustomSyntax([line], cmds)
+    call test_override('syn_prefilter', 1)
+    let off = s:SynDumpCustomSyntax([line], cmds)
+    call test_override('ALL', 0)
+    call assert_equal(off, on, 'pattern ' .. pat)
+  endfor
+endfunc
+
+func Test_syntax_prefilter_quantifiers()
+  " The analyzer models the \{n,m} repeat with the shared brace-limit parser:
+  " the atom is optional when the smaller bound is zero, mandatory otherwise.
+  " The bound syntax has subtle corners (Vim silently swaps out-of-order bounds
+  " so \{42,0} acts like \{0,42}, \{} means *, a leading "-" is non-greedy).
+  " The optional cases below lack the quantified byte, where a wrong "mandatory"
+  " guess would drop the highlight; the last cases supply it for the mandatory
+  " path.  Highlighting must be identical with the prefilter on and off for
+  " every form.
+  let cases = [
+        \ ['x\{42,0}zap', 'zap'],
+        \ ['x\{-42,0}zap', 'zap'],
+        \ ['x\{0,3}zap', 'zap'],
+        \ ['x\{,3}zap', 'zap'],
+        \ ['x\{}zap', 'zap'],
+        \ ['x\{0}zap', 'zap'],
+        \ ['x\{2,3}zap', 'zap'],
+        \ ['x\{2,3}zap', 'xxzap'],
+        \ ['x\{3,}zap', 'xxxzap'],
+        \ ]
+  for [pat, line] in cases
+    let cmds = ['syntax match Special /' .. escape(pat, '/') .. '/']
+    call test_override('syn_prefilter', 0)
+    let on = s:SynDumpCustomSyntax([line], cmds)
+    call test_override('syn_prefilter', 1)
+    let off = s:SynDumpCustomSyntax([line], cmds)
+    call test_override('ALL', 0)
+    call assert_equal(off, on, 'pattern ' .. pat .. ' on ' .. line)
+  endfor
+endfunc
+
+func Test_syntax_prefilter_multibyte()
+  " A multibyte literal contributes all of its bytes to the required-byte set,
+  " so a line lacking the character is skipped.  Under ":syn case ignore" the
+  " bytes are only required when the character has no case variants (e.g. CJK
+  " is invariant, Greek is not).  Highlighting must be identical with the
+  " prefilter on and off for every case.
+  let cases = [
+        \ ['あいう', 'xあいうy', 'match'],
+        \ ['あいう', 'no match here', 'match'],
+        \ ['日本語', 'コード 日本語 test', 'match'],
+        \ ['café', 'a café here', 'match'],
+        \ ['café', 'plain ascii only', 'match'],
+        \ ['あ', 'aaa', 'match'],
+        \ ['あいう', 'xあいうy', 'ignore'],
+        \ ['あいう', 'no match here', 'ignore'],
+        \ ['Ωμέγα', 'has ωμέγα lower', 'ignore'],
+        \ ['Ωμέγα', 'unrelated text', 'ignore'],
+        \ ]
+  for [pat, line, casing] in cases
+    let cmds = ['syntax case ' .. casing,
+          \ 'syntax match Special /' .. escape(pat, '/') .. '/']
+    call test_override('syn_prefilter', 0)
+    let on = s:SynDumpCustomSyntax([line], cmds)
+    call test_override('syn_prefilter', 1)
+    let off = s:SynDumpCustomSyntax([line], cmds)
+    call test_override('ALL', 0)
+    call assert_equal(off, on, 'pattern ' .. pat .. ' on ' .. line)
+  endfor
+endfunc
+
+func Test_syntax_prefilter_case_and_verynomagic()
+  " "\c"/"\C" anywhere force the case behavior for the whole pattern, and "\V"
+  " (very nomagic) makes every following byte literal until a backslash.  Each
+  " line is chosen so a wrong analysis would drop a real highlight or keep a
+  " skipped one.  Highlighting must be identical with the prefilter on and off.
+  let cases = [
+        \ ['\cWORD', 'has word here', 'match'],
+        \ ['\cWORD', 'nothing here', 'match'],
+        \ ['\CFOO', 'has FOO here', 'match'],
+        \ ['\CFOO', 'has foo here', 'match'],
+        \ ['foo\cbar', 'x FOObar y', 'match'],
+        \ ['\Va.c', 'xx a.c yy', 'match'],
+        \ ['\Va.c', 'xx axc yy', 'match'],
+        \ ['\Vfoo|bar', 'a foo|bar b', 'match'],
+        \ ['\Vfoo|bar', 'a foo bar b', 'match'],
+        \ ['\Vfoo\|bar', 'only bar here', 'match'],
+        \ ['\Vfoo\?', 'fo here', 'match'],
+        \ ['\Vab\{0,2}c', 'ac here', 'match'],
+        \ ['\Vあ.い', 'xあ.いx', 'match'],
+        \ ['\c\Vfoo', 'a FOO b', 'match'],
+        \ ['\CFOO', 'has FOO here', 'ignore'],
+        \ ['\CFOO', 'has foo here', 'ignore'],
+        \ ]
+  for [pat, line, casing] in cases
+    let cmds = ['syntax case ' .. casing,
+          \ 'syntax match Special /' .. escape(pat, '/') .. '/']
+    call test_override('syn_prefilter', 0)
+    let on = s:SynDumpCustomSyntax([line], cmds)
+    call test_override('syn_prefilter', 1)
+    let off = s:SynDumpCustomSyntax([line], cmds)
+    call test_override('ALL', 0)
+    call assert_equal(off, on, 'pattern ' .. pat .. ' on ' .. line)
+  endfor
 endfunc
 
 " The in_id_list() cache is a speed optimization only: highlighting must be

--- a/src/testing.c
+++ b/src/testing.c
@@ -1055,6 +1055,8 @@ f_test_override(typval_T *argvars, typval_T *rettv UNUSED)
     }
     else if (STRCMP(name, (char_u *)"nfa_fail") == 0)
 	nfa_fail_for_testing = val;
+    else if (STRCMP(name, (char_u *)"syn_prefilter") == 0)
+	disable_syn_prefilter_for_testing = val;
     else if (STRCMP(name, (char_u *)"syn_idlist_cache") == 0)
 	disable_syn_idlist_cache_for_testing = val;
     else if (STRCMP(name, (char_u *)"no_query_mouse") == 0)
@@ -1083,6 +1085,7 @@ f_test_override(typval_T *argvars, typval_T *rettv UNUSED)
 	disable_redraw_for_testing = FALSE;
 	ignore_redraw_flag_for_testing = FALSE;
 	nfa_fail_for_testing = FALSE;
+	disable_syn_prefilter_for_testing = FALSE;
 	disable_syn_idlist_cache_for_testing = FALSE;
 	no_query_mouse_for_testing = FALSE;
 	ui_delay_for_testing = 0;


### PR DESCRIPTION
```
Problem:  Every syntax pattern is run against every line, including lines
          that obviously cannot match it.
Solution: For each pattern derive the set of bytes that must occur in any
          match, and skip the pattern on a line missing one of them without
          running the regexp engine.
```

The analysis is deliberately conservative: it bails on any construct it cannot
model soundly, so a pattern is only ever skipped when it genuinely cannot match
the line. Coverage includes:

- plain and multibyte literals — a multibyte character contributes all of its
  bytes to the required set; under `:syn case ignore` only when the character
  has no case variant
- the `\{n,m}` repeat, reusing the regexp engine's brace-limit parser so the
  same normalization (defaults and out-of-order reversal) applies
- the `\c` / `\C` case flags and `\V` very-nomagic literal runs
- alternation, groups, character classes, anchors and look-around — the
  constructs that cannot be modeled soundly bail rather than guess

Highlighting is identical whether the prefilter runs or not. This can be
verified at runtime with `test_override('syn_prefilter', 1)`, and is locked
down by an on/off equivalence regression test in `src/testdir/test_syntax.vim`
that highlights several buffers both ways and asserts the `synID()` output
matches — so an analyzer bug that wrongly skips a pattern is caught in CI. The
feature is documented under `:syntax-prefilter`.

Skipped patterns are not run, so they no longer appear in a `:syntime` report
for the lines where they were skipped; this is the only observable difference.