### PR TITLE
Vim9: :call and :delfunction reject dict member funcref with E1017

### DIFF
--- a/src/testdir/test_vim9_cmd.vim
+++ b/src/testdir/test_vim9_cmd.vim
@@ -2178,4 +2178,23 @@ def Test_call_dict_funcref()
   v9.CheckScriptSuccess(lines)
 enddef
 
+" :delfunction on a funcref stored in a dict member used to fail with E1017 in
+" Vim9 script for the same reason as :call.
+def Test_delfunction_dict_funcref()
+  var lines =<< trim END
+      vim9script
+      func g:LegacyFunc()
+      endfunc
+      var d: dict<any> = {}
+      d.key = g:LegacyFunc
+      d['k2'] = g:LegacyFunc
+      delfunction d.key
+      assert_false(has_key(d, 'key'))
+      delfunction d['k2']
+      assert_false(has_key(d, 'k2'))
+      delfunction g:LegacyFunc
+  END
+  v9.CheckScriptSuccess(lines)
+enddef
+
 " vim: ts=8 sw=2 sts=2 expandtab tw=80 fdm=marker


### PR DESCRIPTION
Problem: In Vim9 script, ":call d.key()" and ":delfunction d.key" fail with "E1017: Variable already declared" when d is an existing dictionary.  This is because trans_function_name_ext() forwards no GLV_NO_DECL hint to get_lval(), which then treats the dict subscript as a re-declaration of "d".  The same holds for the bracket form "d['key']".  :call is documented as supported in Vim9 script (vim9.txt "Omitting :call and :eval"), and is required after a range, so this is a genuine bug.

Solution: Pass TFN_NO_DECL from ex_call() and ex_delfunction() so that get_lval() does not flag the existing variable as a re-declaration.  This is the smallest change that fixes the bug while leaving other callers of trans_function_name_ext() (notably the function-definition paths) unchanged.

Add a regression test in test_vim9_cmd.vim.

update:

Patch 9.2.0572 fixed ":call d.key()" and ":delfunction d.key" failing
with E1017 in Vim9 script, but only the :call form was covered by a
regression test.  Add Test_delfunction_dict_funcref to exercise both
"delfunction d.key" and "delfunction d['k2']".

This PR is powered by Claude Code.