### PR TITLE
userfunc: avoid leaving broken dict entry when vim_strnsave() fails

### DIFF
--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -5612,18 +5612,27 @@ define_function(
 
 	if (fudi.fd_dict != NULL)
 	{
+	    char_u *func_name = vim_strnsave(name, namelen);
+
+	    if (func_name == NULL)
+	    {
+		VIM_CLEAR(fp);
+		goto erret;
+	    }
 	    if (fudi.fd_di == NULL)
 	    {
 		// add new dict entry
 		fudi.fd_di = dictitem_alloc(fudi.fd_newkey);
 		if (fudi.fd_di == NULL)
 		{
+		    vim_free(func_name);
 		    VIM_CLEAR(fp);
 		    goto erret;
 		}
 		if (dict_add(fudi.fd_dict, fudi.fd_di) == FAIL)
 		{
 		    vim_free(fudi.fd_di);
+		    vim_free(func_name);
 		    VIM_CLEAR(fp);
 		    goto erret;
 		}
@@ -5632,7 +5641,7 @@ define_function(
 		// overwrite existing dict entry
 		clear_tv(&fudi.fd_di->di_tv);
 	    fudi.fd_di->di_tv.v_type = VAR_FUNC;
-	    fudi.fd_di->di_tv.vval.v_string = vim_strnsave(name, namelen);
+	    fudi.fd_di->di_tv.vval.v_string = func_name;
 
 	    // behave like "dict" was used
 	    flags |= FC_DICT;


### PR DESCRIPTION
Problem: define_function() builds the dict entry that holds a numbered
funcref name in three steps: dictitem_alloc()/dict_add() add a new entry (or
clear_tv() wipes an existing one), v_type is set to VAR_FUNC, and then
vim_strnsave(name, namelen) duplicates the function name into v_string.  The
vim_strnsave() result is not checked.  On allocation failure, di_tv is left
with v_type == VAR_FUNC and v_string == NULL.  For a newly added entry this
leaves a broken member in the dict; for an existing entry it silently throws
away the funcref the user had previously stored, because clear_tv() already
unref'd the old name before the new allocation was attempted.

Solution: Allocate the new name first, so the dict is not modified at all
when the duplication fails.  Free that allocation along the existing dict
failure paths (dictitem_alloc, dict_add).  The user's previous funcref is
preserved when the new allocation fails, and a partially constructed dict
entry is no longer reachable.

This PR is powered by Claude Code.