### PR TITLE
runtime(sgf): add sgf syntax

### DIFF
--- a/runtime/syntax/sgf.vim
+++ b/runtime/syntax/sgf.vim
@@ -8,11 +8,6 @@ if exists("b:current_syntax")
   finish
 endif
 
-let s:cpo_save = &cpo
-set cpo&vim
-
-syn case match
-
 syn match sgfDelimiter "[();]"
 
 syn keyword sgfMoveProp B W nextgroup=sgfValue skipwhite
@@ -25,8 +20,8 @@ syn keyword sgfCommentProp C nextgroup=sgfCommentValue skipwhite
 syn match sgfProperty "\<[A-Za-z]\+\ze\s*\[" nextgroup=sgfValue skipwhite
 
 syn match sgfEscape "\\." contained
-syn region sgfValue matchgroup=sgfBracket start="\[" end="\]" skip="\\\\\|\\\]" contains=sgfEscape keepend nextgroup=sgfValue skipwhite
-syn region sgfCommentValue matchgroup=sgfBracket start="\[" end="\]" skip="\\\\\|\\\]" contains=sgfEscape,@Spell keepend nextgroup=sgfCommentValue skipwhite
+syn region sgfValue contained matchgroup=sgfBracket start="\[" end="\]" skip="\\\\\|\\\]" contains=sgfEscape keepend nextgroup=sgfValue skipwhite
+syn region sgfCommentValue contained matchgroup=sgfBracket start="\[" end="\]" skip="\\\\\|\\\]" contains=sgfEscape,@Spell keepend nextgroup=sgfCommentValue skipwhite
 
 hi def link sgfDelimiter Delimiter
 hi def link sgfMoveProp Statement
@@ -42,8 +37,5 @@ hi def link sgfValue String
 hi def link sgfCommentValue Comment
 
 let b:current_syntax = "sgf"
-
-let &cpo = s:cpo_save
-unlet s:cpo_save
 
 " vim: ts=8

--- a/runtime/syntax/sgf.vim
+++ b/runtime/syntax/sgf.vim
@@ -1,0 +1,49 @@
+" Vim syntax file
+" Language:	Smart Game Format
+" Maintainer:	Borys Lykah
+" Last Change:	2026 May 30
+
+" Quit when a syntax file was already loaded
+if exists("b:current_syntax")
+  finish
+endif
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+syn case match
+
+syn match sgfDelimiter "[();]"
+
+syn keyword sgfMoveProp B W nextgroup=sgfValue skipwhite
+syn keyword sgfSetupProp AB AE AW PL nextgroup=sgfValue skipwhite
+syn keyword sgfMarkupProp AR CR DD DM FG GB GW HO LB LN MA SL SQ TR UC VW nextgroup=sgfValue skipwhite
+syn keyword sgfRootProp AP CA FF GM ST SZ nextgroup=sgfValue skipwhite
+syn keyword sgfGameInfoProp AN BR BT CP DT EV GC GN HA KM ON OT PB PC PW RE RO RU SO TM US WR WT nextgroup=sgfValue skipwhite
+syn keyword sgfCommentProp C nextgroup=sgfCommentValue skipwhite
+
+syn match sgfProperty "\<[A-Za-z]\+\ze\s*\[" nextgroup=sgfValue skipwhite
+
+syn match sgfEscape "\\." contained
+syn region sgfValue matchgroup=sgfBracket start="\[" end="\]" skip="\\\\\|\\\]" contains=sgfEscape keepend nextgroup=sgfValue skipwhite
+syn region sgfCommentValue matchgroup=sgfBracket start="\[" end="\]" skip="\\\\\|\\\]" contains=sgfEscape,@Spell keepend nextgroup=sgfCommentValue skipwhite
+
+hi def link sgfDelimiter Delimiter
+hi def link sgfMoveProp Statement
+hi def link sgfSetupProp Type
+hi def link sgfMarkupProp Identifier
+hi def link sgfRootProp PreProc
+hi def link sgfGameInfoProp Label
+hi def link sgfCommentProp Comment
+hi def link sgfProperty Identifier
+hi def link sgfBracket Delimiter
+hi def link sgfEscape SpecialChar
+hi def link sgfValue String
+hi def link sgfCommentValue Comment
+
+let b:current_syntax = "sgf"
+
+let &cpo = s:cpo_save
+unlet s:cpo_save
+
+" vim: ts=8


### PR DESCRIPTION
This is a follow-up to #20349 that introduced the SGF filetype.

I've used Codex AI to generate the syntax module, and tested it on the corpus of SGF files. Here is a sample of highlighted SGF:

<img width="810" height="671" alt="image" src="https://github.com/user-attachments/assets/663facbd-f713-4dac-89c0-8f7116d7b960" />
