### PR TITLE
Fix <C-w>f not to duplicate current window if do_ecmd is aborted

### DIFF
--- a/src/testdir/test_window_cmd.vim
+++ b/src/testdir/test_window_cmd.vim
@@ -117,6 +117,40 @@ func Test_window_cmd_wincmd_gf()
   bw!
 endfunc
 
+func Test_abort_in_wincmd_f()
+  let fname = 'test_f.txt'
+  let swp_fname = '.' . fname . '.swp'
+  call writefile([], fname, 'D')
+  call writefile([], swp_fname, 'D')
+  function s:swap_exists_f()
+    let v:swapchoice = s:swap_choice
+  endfunc
+  " Remove the catch-all that runtest.vim adds
+  au! SwapExists
+  augroup test_window_cmd_wincmd_f
+    autocmd!
+    exec "autocmd SwapExists " . fname . " call s:swap_exists_f()"
+  augroup END
+
+  call setline(1, fname)
+  call assert_equal(1, winnr('$'))
+  " (A)bort
+  let s:swap_choice = 'a'
+  try
+    wincmd f
+  catch /^Vim:Interrupt$/
+    " expected interrupt by abort
+  endtry
+  call assert_equal(1, winnr('$'))
+  new | only!
+
+  " See :h W19 for the background of this au!. Ideally other tests
+  " should also follow this.
+  au! test_window_cmd_wincmd_f
+  augroup! test_window_cmd_wincmd_f
+  bw!
+endfunc
+
 func Test_window_quit()
   e Xa
   split Xb

--- a/src/window.c
+++ b/src/window.c
@@ -682,9 +682,21 @@ wingotofile:
 			if (do_ecmd(0, ptr, NULL, NULL, ECMD_LASTL,
 						   ECMD_HIDE, NULL) == FAIL)
 			{
+			    /*
+			     * Note: if FEAT_EVAL is defined and do_ecmd() is aborted resulting
+			     * in got_int be true, win_close() unconditionally fails. In such
+			     * case, the window split for do_ecmd() is left unclosed, i.e. the
+			     * current window is just duplicated. To avoid this, save and load
+			     * got_int value before and after closing the window.
+			     */
+			    sig_atomic_t    old_got_int = got_int;
+			    got_int = FALSE;
+
 			    // Failed to open the file, close the window
 			    // opened for it.
 			    win_close(curwin, FALSE);
+			    got_int = got_int || old_got_int;
+
 			    goto_tabpage_win(oldtab, oldwin);
 			}
 			else


### PR DESCRIPTION
Problem: If got_int is true when win_close() is called, it unexpectedly fails in the branch that detects failure in apply_autocmds(). This causes wingotofile in do_window() to duplicate current window when do_ecmd() is aborted with got_int.

Solution: Fix do_window() to save the got_int value before trying to close the split window.

Steps to reproduce:
 1. run `touch a && touch .a.swp && echo a > b && vim b`
 2. Type `<C-w>f`
 3. In the warning dialogue, type `a` to abort
 4. Current window is duplicated