### PR TITLE
vim9: free nested ufunc when reserve_local() or generate_FUNCREF() fails

### DIFF
--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -1170,9 +1170,15 @@ compile_nested_function(exarg_T *eap, cctx_T *cctx, garray_T *lines_to_free)
 	lvar = reserve_local(cctx, func_name, name_end - name_start,
 					    ASSIGN_CONST, ufunc->uf_func_type);
 	if (lvar == NULL)
+	{
+	    func_ptr_unref(ufunc);
 	    goto theend;
+	}
 	if (generate_FUNCREF(cctx, ufunc, NULL, FALSE, 0, &funcref_isn_idx) == FAIL)
+	{
+	    func_ptr_unref(ufunc);
 	    goto theend;
+	}
 	r = generate_STORE(cctx, ISN_STORE, lvar->lv_idx, NULL);
     }
 


### PR DESCRIPTION
Problem: compile_nested_function() calls define_function() which registers the new ufunc in func_hashtab with uf_refcount = 1.  For a local nested function the caller then reserves a local lvalue and generates a FUNCREF instruction; either step can fail.  When that happens the function jumps to the theend label and leaves the ufunc behind with refcount 1 and no external reference, leaking it for the rest of the Vim session.  This mirrors patch 8.2.3951, which fixed the same leak for the "text after enddef" branch a few lines above.

Solution: Call func_ptr_unref(ufunc) before the goto theend on both failure paths in the local-variable branch.

This PR is powered by Claude Code.