### PR TITLE
popup_create() not blocked in secure/sandbox

### DIFF
--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -2864,6 +2864,9 @@ popup_create(typval_T *argvars, typval_T *rettv, create_type_T type)
     dict_T	*d = NULL;
     int		i;
 
+    if (check_secure())
+	return NULL;
+
     if (argvars != NULL)
     {
 	if (in_vim9script()

--- a/src/testdir/test_popup.vim
+++ b/src/testdir/test_popup.vim
@@ -2628,4 +2628,8 @@ func Test_popup_opacity_move_after_close()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_popup_create_sandbox()
+  call assert_fails('sandbox call popup_create("hello", {})', 'E48:')
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  popup_create() is not gated by check_secure(), unlike the
          similar deferred-callback registrars timer_start() and
          feedkeys().  A popup created with a 'time' and 'callback' (or with
          close/filter callbacks) registers code that runs after the secure/sandbox
          context has been left, which is inconsistent with how
          timer_start() and feedkeys() handle the same situation.
Solution: Call check_secure() at the top of popup_create(), matching the
          timer_start()/feedkeys() pattern.