### PR TITLE
xxd: binary output is not colored with -R

### DIFF
--- a/runtime/doc/xxd.1
+++ b/runtime/doc/xxd.1
@@ -142,9 +142,9 @@ anywhere. Use the combination
 to read a bits dump instead of a hex dump.
 .TP
 .IR \-R " " when
-In the output the hex-value and the value are both colored with the same color
-depending on the hex-value. Mostly helping to differentiate printable and
-non-printable characters.
+In the output both the data column (hex, or bits with \-b) and the character
+column are colored with the same color depending on the byte value. Mostly
+helping to differentiate printable and non-printable characters.
 .I \fIwhen\fP
 is
 .BR never ", " always ", or " auto " (default: auto).

--- a/runtime/doc/xxd.man
+++ b/runtime/doc/xxd.man
@@ -101,11 +101,12 @@ OPTIONS
               instead of a hex dump.
 
        -R when
-              In the output the hex-value and the value are both colored  with
-              the  same  color  depending  on the hex-value. Mostly helping to
-              differentiate printable and non-printable characters.   when  is
-              never,  always, or auto (default: auto).  When the $NO_COLOR en‐
-              vironment variable is set, colorization will be disabled.
+              In the output both the data column (hex, or bits  with  -b)  and
+              the  character  column are colored with the same color depending
+              on the byte value. Mostly helping to differentiate printable and
+              non-printable characters.  when is never, always, or  auto  (de‐
+              fault:  auto).   When the $NO_COLOR environment variable is set,
+              colorization will be disabled.
 
        -seek offset
               When used after -r: revert with <offset> added to file positions

--- a/src/testdir/test_xxd.vim
+++ b/src/testdir/test_xxd.vim
@@ -663,6 +663,22 @@ call writefile(data,'Xinput')
 
 endfunc
 
+func Test_xxd_color_bits()
+  " Binary output (-b) should be colored per byte like the hex output,
+  " see issue #20385.  Bytes cover the white/yellow/green/blue color groups.
+  let s:test = 1
+  call writefile(0z000941FF, 'Xxxdbits')
+
+  %d
+  exe '0r! ' . s:xxd_cmd . ' -b -R always -c 4 Xxxdbits'
+  $d
+  let expected = [
+      \ "00000000: \e[1;37m00000000\e[0m \e[1;33m00001001\e[0m \e[1;32m01000001\e[0m \e[1;34m11111111\e[0m  \e[1;37m.\e[0m\e[1;33m.\e[0m\e[1;32mA\e[0m\e[1;34m.\e[0m"]
+  call assert_equal(expected, getline(1, '$'), s:Mess(s:test))
+
+  call delete('Xxxdbits')
+endfunc
+
 func Test_xxd_color2()
   CheckScreendump
   CheckUnix

--- a/src/xxd/xxd.c
+++ b/src/xxd/xxd.c
@@ -1194,8 +1194,15 @@ main(int argc, char *argv[])
 	}
       else /* hextype == HEX_BITS */
 	{
+	  if (color)
+	    cur_color = get_color_char(e, ebcdic);
+
 	  for (i = 7; i >= 0; i--)
-	    l[c++] = (e & (1 << i)) ? '1' : '0';
+	    {
+	      if (color)
+		colors[c] = cur_color;
+	      l[c++] = (e & (1 << i)) ? '1' : '0';
+	    }
 	}
       if (e)
 	nonzero++;


### PR DESCRIPTION
```
Problem:  With xxd the -R option colors the hex output but leaves the
          binary output produced by -b uncolored.
Solution: Color the binary (bits) output per byte with the same colors as
          the hex output, update the documentation and add a test.
```

fixes: #20385