### PR TITLE
Reset the winfixheight option when a quickfix buffer is deleted from a window

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -736,6 +736,11 @@ aucmd_abort:
 	unblock_autocmds();
     }
 
+    // When a quickfix buffer is deleted from a window, clear the
+    // 'winfixheight' option.
+    if (bt_quickfix(buf) && win_valid && win->w_buffer == buf)
+	win->w_p_wfh = FALSE;
+
     // Remember if the buffer may be hidden soon, or is already hidden.
     hiding_buf = buf->b_nwindows <= 0 || ((win_valid || closed_popup)
 	    && win->w_buffer == buf && buf->b_nwindows == 1);

--- a/src/testdir/test_quickfix.vim
+++ b/src/testdir/test_quickfix.vim
@@ -7090,4 +7090,20 @@ func Test_set_qftf_in_sandbox()
   call Xtest_set_qftf_in_sandbox('l')
 endfunc
 
+" Test for the 'statusline' height remaining at one when the quickfix buffer
+" is wiped out when quickfix window is the only window open.
+func Test_qf_statusline_height()
+  %bw!
+  copen
+  wincmd p
+  let prev_wh = winheight('.')
+  wincmd p
+  only
+  bw!
+  copen
+  wincmd p
+  call assert_equal(prev_wh, winheight('.'))
+  %bw!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION

In a quickfix window, the 'winfixheight' option is automatically set.  When this window is made the only window and the quickfix buffer is deleted/wiped out, the 'winfixheight' option is not cleared.  When another quickfix window is opened now, the statusline height calculation goes wrong.

To address this issue, clear the 'winfixheight' option when the quickfix buffer is removed from a window.

Fixes #3378.