### PR TITLE
indent not ignored in fuzzy wholeline completion

### DIFF
--- a/src/fuzzy.c
+++ b/src/fuzzy.c
@@ -865,11 +865,15 @@ search_for_fuzzy_match(
 		}
 		else
 		{
-		    if (fuzzy_match_str(*ptr, pattern) != FUZZY_SCORE_NONE)
+		    char_u *line = *ptr;
+		    char_u *p = skipwhite(line);
+		    if (fuzzy_match_str(p, pattern) != FUZZY_SCORE_NONE)
 		    {
 			found_new_match = TRUE;
 			*pos = current_pos;
-			*len = (int)ml_get_buf_len(buf, current_pos.lnum);
+			*ptr = p;
+			*len = (int)ml_get_buf_len(buf, current_pos.lnum) -
+								(int)(p - line);
 			break;
 		    }
 		}

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -3696,10 +3696,16 @@ func Test_complete_opt_fuzzy()
   call feedkeys("Goa\<C-P>\<C-Y>\<Esc>", 'tx')
   call assert_equal('aaaa', getline('.'))
 
+  %d
+  set autoindent
+  set completeopt=menuone,fuzzy
+  call feedkeys("A\<TAB>hello world\<CR>word is on fire\<CR>w\<C-X>\<C-L>\<C-Y>", 'tx')
+  call assert_equal("\thello world", getline('.'))
+
   " clean up
   set omnifunc=
   bw!
-  set complete& completeopt&
+  set complete& completeopt& autoindent&
   autocmd! AAAAA_Group
   augroup! AAAAA_Group
   delfunc OnPumChange


### PR DESCRIPTION
Problem:
Indent is not stripped in whole-line completion (CTRL-X CTRL-L).

Solution:
Skip the matched line's indent for whole-line matches in search_for_fuzzy_match.

related: https://github.com/neovim/neovim/issues/40072