### PR TITLE
Fix NULL y_current when emitting TextPut* autocmd

### DIFF
--- a/src/register.c
+++ b/src/register.c
@@ -1190,6 +1190,11 @@ put_do_autocmd(
     if (recursive || regname == '_')
 	return;
 
+    if (regname != '.' && insert == NULL
+	    && reg == NULL)
+	// Can happen when pasting text in normal mode in a terminal buffer
+	return;
+
     v_event = get_v_event(&save_v_event);
 
     list = list_alloc();
@@ -1219,7 +1224,6 @@ put_do_autocmd(
     }
     else
     {
-	assert(reg != NULL);
 	for (n = 0; n < reg->y_size; n++)
 	    list_append_string(list, reg->y_array[n].string,
 		    (int)reg->y_array[n].length);

--- a/src/testdir/test_autocmd.vim
+++ b/src/testdir/test_autocmd.vim
@@ -6094,7 +6094,35 @@ func Test_TextPutX()
   unlet g:post_event
   unlet g:pre_event
   bwipe!
+endfunc
 
+" Test that attempting to put text in normal mode terminal buffer does not
+" result in a crash. This only happens when terminal is only window in tabpage
+" it seems.
+func Test_TextPutPost_term_norm()
+  CheckFeature terminal
+
+  tabnew
+  term ++curwin
+
+  let bnr = bufnr('$')
+  call WaitForAssert({-> assert_equal('running', term_getstatus(bnr))})
+
+  call feedkeys("\<C-\>\<C-N>", 'xt')
+  call WaitForAssert({-> assert_equal('running,normal', term_getstatus(bnr))})
+
+  let err = 0
+
+  try
+    call feedkeys("p", 'xt')
+  catch /^Vim\%((\S\+)\)\=:E21:/
+    let err = 1
+  endtry
+
+  call assert_true(err)
+
+  unlet err
+  bwipe!
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
1. Have a `TextPutPost` autocmd active
2. Open a terminal buffer
3. Go into normal mode
4. Try putting text
5. Assertion failure because "reg" is NULL in `put_do_autocmd()`