### PR TITLE
fix(make): clipboard.o missing WAYLAND C/CPP flags

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -3264,7 +3264,7 @@ objects/clientserver.o: clientserver.c
 	$(CCC) -o $@ clientserver.c
 
 objects/clipboard.o: clipboard.c $(WAYLAND_SRC)
-	$(CCC) -o $@ clipboard.c
+	$(CCC) $(WAYLAND_CFLAGS) $(WAYLAND_CPPFLAGS) -o $@ clipboard.c
 
 objects/cmdexpand.o: cmdexpand.c
 	$(CCC) -o $@ cmdexpand.c


### PR DESCRIPTION
GTK4 skips previously used PRE_DEFS -> GUI_IPATH path adding includes to every line. This caused resurfacing issue from #18051

This ensures consistency across all wayland src files regardless of configuration.