### PR TITLE
Add $VIM_CLIENTSERVER environment variable

### DIFF
--- a/runtime/doc/remote.txt
+++ b/runtime/doc/remote.txt
@@ -80,9 +80,6 @@ The following command line arguments are available:
    --clientserver {method}	Use the specified method {method} as the
 				backend for clientserver functionality.  Can
 				either be "socket", "x11", or "mswin".
-				{only available when compiled with both |+X11|
-				and |+socketserver| features, or
-				|+socketserver| on MS-Windows}
 							    *$VIM_CLIENTSERVER*
 				If the "$VIM_CLIENTSERVER" environment
 				variable is set, then Vim will interpret the
@@ -90,6 +87,9 @@ The following command line arguments are available:
 				If it is set and --clientserver is provided in
 				the command line, then --clientserver takes
 				priority.
+				{only available when compiled with both |+X11|
+				and |+socketserver| features, or
+				|+socketserver| on MS-Windows}
 
 Examples ~
 

--- a/runtime/doc/remote.txt
+++ b/runtime/doc/remote.txt
@@ -83,7 +83,13 @@ The following command line arguments are available:
 				{only available when compiled with both |+X11|
 				and |+socketserver| features, or
 				|+socketserver| on MS-Windows}
-
+							    *$VIM_CLIENTSERVER*
+				If the "$VIM_CLIENTSERVER" environment
+				variable is set, then Vim will interpret the
+				value just like the --clientserver argument.
+				If it is set and --clientserver is provided in
+				the command line, then --clientserver takes
+				priority.
 
 Examples ~
 

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -13,6 +13,7 @@ $NoDefaultCurrentDirectoryInExePath	builtin.txt	/*$NoDefaultCurrentDirectoryInEx
 $VIM	starting.txt	/*$VIM*
 $VIM-use	version5.txt	/*$VIM-use*
 $VIMRUNTIME	starting.txt	/*$VIMRUNTIME*
+$VIM_CLIENTSERVER	remote.txt	/*$VIM_CLIENTSERVER*
 $VIM_POSIX	vi_diff.txt	/*$VIM_POSIX*
 $XDG_CONFIG_HOME	starting.txt	/*$XDG_CONFIG_HOME*
 $quote	eval.txt	/*$quote*

--- a/runtime/doc/vim.1
+++ b/runtime/doc/vim.1
@@ -518,7 +518,9 @@ it is taken as either an absolute, relative or relative path to the socket.
 Use {backend} as the backend for clientserver functionality, either "socket",
 "x11", or "mswin" respectively.  Only available when compiled with both
 socketserver and X11 features present, or if compiled with socketserver on
-MS-Windows.
+MS-Windows. The $VIM_CLIENTSERVER environment variable may also be set which
+will be interpreted in the same way, but the --clientserver argument will always
+take priority.
 .TP
 \-\-socketid {id}
 GTK GUI only: Use the GtkPlug mechanism to run gVim in another window.

--- a/src/clientserver.c
+++ b/src/clientserver.c
@@ -1276,3 +1276,28 @@ f_serverlist(typval_T *argvars UNUSED, typval_T *rettv)
     rettv->vval.v_string = r;
 }
 #endif
+
+#ifdef FEAT_CLIENTSERVER_BACKENDS
+/*
+ * Check the $VIM_CLIENTSERVER environment variable and set the method
+ */
+    void
+check_clientserver_method_env(void)
+{
+    char_u *env = mch_getenv("VIM_CLIENTSERVER");
+
+    if (env == NULL)
+	return;
+
+    if (STRICMP(env, "socket") == 0)
+	clientserver_method = CLIENTSERVER_METHOD_SOCKET;
+# ifdef FEAT_X11
+    else if (STRICMP(env, "x11") == 0)
+	clientserver_method = CLIENTSERVER_METHOD_X11;
+# endif
+# ifdef MSWIN
+    else if (STRICMP(env, "mswin") == 0)
+	clientserver_method = CLIENTSERVER_METHOD_MSWIN;
+# endif
+}
+#endif

--- a/src/main.c
+++ b/src/main.c
@@ -1038,6 +1038,13 @@ common_init_2(mparm_T *paramp)
     gui.dofork = true;		    // default is to use fork()
 #endif
 
+#ifdef FEAT_CLIENTSERVER_BACKENDS
+    /*
+     * Check the $VIM_CLIENTSERVER env before we handle the --clientserver arg
+     */
+    check_clientserver_method_env();
+#endif
+
     /*
      * Do a first scan of the arguments in "argv[]":
      *   -display or --display

--- a/src/proto/clientserver.pro
+++ b/src/proto/clientserver.pro
@@ -13,4 +13,5 @@ void f_remote_send(typval_T *argvars, typval_T *rettv);
 void f_remote_startserver(typval_T *argvars, typval_T *rettv);
 void f_server2client(typval_T *argvars, typval_T *rettv);
 void f_serverlist(typval_T *argvars, typval_T *rettv);
+void check_clientserver_method_env(void);
 /* vim: set ft=c : */

--- a/src/testdir/test_clientserver.vim
+++ b/src/testdir/test_clientserver.vim
@@ -498,6 +498,48 @@ func Test_clientserver_socketserver_invalid_msg()
   call StopVimInTerminal(buf)
 endfunc
 
+" Test that $VIM_CLIENTSERVER env var works properly
+func Test_clientserver_env_method()
+  CheckFeature socketserver
+
+  let g:test_is_flaky = 1
+  let cmd = GetVimCommand()
+
+  if cmd == ''
+    throw 'GetVimCommand() failed'
+  endif
+
+  " Don't use channel:2000, because previous tests use that and it may take a
+  " while for the channel to fully close.
+  let actual = cmd .. ' --servername channel:4000'
+  let $VIM_CLIENTSERVER = 'socket'
+
+  let job = job_start(actual, {'stoponexit': 'kill', 'out_io': 'null'})
+
+  call WaitForAssert({-> assert_equal("run", job_status(job))})
+
+  if !has('win32') || !has('gui_running')
+      call assert_match('channel:4000',
+            \ system(actual .. ' --remote-expr "v:servername"'))
+  endif
+
+  if has('win32')
+    call job_stop(job, 'kill')
+  else
+    call system(actual .. " --remote-expr 'execute(\"qa!\")'")
+  endif
+  unlet $VIM_CLIENTSERVER
+
+  try
+    call WaitForAssert({-> assert_equal("dead", job_status(job))})
+  finally
+    if job_status(job) != 'dead'
+      call assert_report('Server did not exit')
+      call job_stop(job, 'kill')
+    endif
+  endtry
+endfunc
+
 " Uncomment this line to get a debugging log
 " call ch_logfile('channellog', 'w')
 


### PR DESCRIPTION
Useful for people who find needing to add `--clientserver socket` every time annoying, and don't want to compile Vim themselves