### PR TITLE
runtime(doc): improve wordings in :write-plugin

### DIFF
--- a/runtime/doc/usr_51.txt
+++ b/runtime/doc/usr_51.txt
@@ -250,8 +250,8 @@ difference between using <SID> and <Plug>:
 	only conventions to keep the name readable and unlikely to clash with
 	other plugins.  None of them are required: all that matters is that
 	the sequence starts with "<Plug>" and is unique.
-	Note: when <Plug> appears in the {rhs} of a mapping, this part is
-	always applied even if remapping is disallowed. |:nore|
+	When starts the {rhs} of a mapping, the {rhs} is always recursively
+	resolved even if remapping is explicitly disallowed. |:nore|
 
 <SID>	is the script ID, a unique identifier for a script.
 	Internally Vim translates <SID> to "<SNR>123_", where "123" can be any

--- a/runtime/doc/usr_51.txt
+++ b/runtime/doc/usr_51.txt
@@ -250,8 +250,8 @@ difference between using <SID> and <Plug>:
 	only conventions to keep the name readable and unlikely to clash with
 	other plugins.  None of them are required: all that matters is that
 	the sequence starts with "<Plug>" and is unique.
-	When starts the {rhs} of a mapping, the {rhs} is always recursively
-	resolved even if remapping is explicitly disallowed. |:nore|
+	When <Plug> appears in the {rhs} of a mapping, it is always resolved
+	recursively even if remapping is explicitly disallowed. |:nore|
 
 <SID>	is the script ID, a unique identifier for a script.
 	Internally Vim translates <SID> to "<SNR>123_", where "123" can be any

--- a/runtime/doc/usr_51.txt
+++ b/runtime/doc/usr_51.txt
@@ -250,6 +250,8 @@ difference between using <SID> and <Plug>:
 	only conventions to keep the name readable and unlikely to clash with
 	other plugins.  None of them are required: all that matters is that
 	the sequence starts with "<Plug>" and is unique.
+	Note: when <Plug> appears in the {rhs} of a mapping, this part is
+	always applied even if remapping is disallowed. |:nore|
 
 <SID>	is the script ID, a unique identifier for a script.
 	Internally Vim translates <SID> to "<SNR>123_", where "123" can be any
@@ -258,6 +260,8 @@ difference between using <SID> and <Plug>:
 	you use the ":function" command to get a list of functions.  The
 	translation of <SID> in mappings is exactly the same, that's how you
 	can call a script-local function from a mapping.
+	Note: when <SID> appears in the {rhs} of a mapping, you might consider
+	using <script>. |:map-<script>|
 
 
 USER COMMAND
@@ -416,8 +420,8 @@ hasmapto()		Function to test if the user already defined a mapping
 
 map <unique>		Give a warning if a mapping already exists.
 
-noremap <script>	Use only mappings local to the script, not global
-			mappings.
+noremap <script>	Only remap mappings defined in this script that start
+			with <SID>.
 
 exists(":Cmd")		Check if a user command already exists.
 

--- a/runtime/doc/usr_51.txt
+++ b/runtime/doc/usr_51.txt
@@ -250,8 +250,8 @@ difference between using <SID> and <Plug>:
 	only conventions to keep the name readable and unlikely to clash with
 	other plugins.  None of them are required: all that matters is that
 	the sequence starts with "<Plug>" and is unique.
-	When <Plug> appears in the {rhs} of a mapping, it is always resolved
-	recursively even if remapping is explicitly disallowed. |:nore|
+	When starts the {lhs} of a mapping, it is always applied to the {rhs}
+	of another mapping even if remapping is explicitly disallowed. |:nore|
 
 <SID>	is the script ID, a unique identifier for a script.
 	Internally Vim translates <SID> to "<SNR>123_", where "123" can be any

--- a/runtime/doc/usr_51.txt
+++ b/runtime/doc/usr_51.txt
@@ -250,8 +250,9 @@ difference between using <SID> and <Plug>:
 	only conventions to keep the name readable and unlikely to clash with
 	other plugins.  None of them are required: all that matters is that
 	the sequence starts with "<Plug>" and is unique.
-	When starts the {lhs} of a mapping, it is always applied to the {rhs}
-	of another mapping even if remapping is explicitly disallowed. |:nore|
+	A mapping whose {lhs} starts with <Plug> is always applied to the
+	{rhs} of another mapping, even if remapping is explicitly disallowed.
+	|:nore|
 
 <SID>	is the script ID, a unique identifier for a script.
 	Internally Vim translates <SID> to "<SNR>123_", where "123" can be any


### PR DESCRIPTION
Problem: Some important info is missing from `:h write-plugin`.
Solution: Provide more links in appropriate places; also make some text more consistent.

Context:
1. For a beginner, it might not be immediately apparent that `:noremap` will remap `<Plug>...`, which was pointed out by [nickspoons](https://github.com/vim/vim/issues/9789#issuecomment-1042079192) years ago. I also found it confusing when I first learned it from [vi.stackexchange](https://vi.stackexchange.com/a/48675/10189), answered by romainl.
2. For a beginner, it might be confusing on why the same summary item `noremap <script>` is described differently between `:h plugin-special` and `:h ftplugin-special`.