### PR TITLE
Fix saving session with terminal

### DIFF
--- a/src/terminal.c
+++ b/src/terminal.c
@@ -1107,7 +1107,7 @@ term_write_session(FILE *fd, win_T *wp, hashtab_T *terminal_bufs)
 	if (!HASHITEM_EMPTY(entry))
 	{
 	    // we've already opened this terminal buffer
-	    if (fprintf(fd, "execute 'buffer ' . s:term_buf_%d", bufnr) < 0)
+	    if (fprintf(fd, "execute 'buffer ' . term_buf_%d", bufnr) < 0)
 		return FAIL;
 	    return put_eol(fd);
 	}
@@ -1128,7 +1128,7 @@ term_write_session(FILE *fd, win_T *wp, hashtab_T *terminal_bufs)
     if (put_eol(fd) != OK)
 	return FAIL;
 
-    if (fprintf(fd, "let s:term_buf_%d = bufnr()", bufnr) < 0)
+    if (fprintf(fd, "var term_buf_%d: number = bufnr()", bufnr) < 0)
 	return FAIL;
 
     if (terminal_bufs != NULL && wp->w_buffer->b_nwindows > 1)

--- a/src/testdir/test_mksession.vim
+++ b/src/testdir/test_mksession.vim
@@ -581,17 +581,20 @@ func Test_mksession_terminal_shared_windows()
   let lines = readfile('Xtest_mks.out')
   let found_creation = 0
   let found_use = 0
+  let found_var = 0
 
   for line in lines
     if line =~ '^terminal'
       let found_creation = 1
       call assert_match('terminal ++curwin ++cols=\d\+ ++rows=\d\+', line)
-    elseif line =~ "^execute 'buffer ' . s:term_buf_" . term_buf . "$"
+    elseif line =~ $"^var term_buf_{term_buf}: number = bufnr()$"
+      let found_var = 1
+    elseif line =~ "^execute 'buffer ' . term_buf_" . term_buf . "$"
       let found_use = 1
     endif
   endfor
 
-  call assert_true(found_creation && found_use)
+  call assert_true(found_creation && found_use && found_var)
 
   call StopShellInTerminal(term_buf)
   call delete('Xtest_mks.out')


### PR DESCRIPTION
`:mksession` emits vim9script, so `:let` cannot be used