### PR TITLE
Set filetype=sh for xinitrc files

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1038,6 +1038,7 @@ au BufNewFile,BufRead *.decl,*.dcl,*.dec
 " Gentoo ebuilds and Arch Linux PKGBUILDs are actually bash scripts.
 " NOTE: Patterns ending in a star are further down, these have lower priority.
 au BufNewFile,BufRead .bashrc,bashrc,bash.bashrc,.bash[_-]profile,.bash[_-]logout,.bash[_-]aliases,.bash[_-]history,bash-fc[-.],*.ebuild,*.bash,*.eclass,PKGBUILD,*.bats,*.cygport call dist#ft#SetFileTypeSH("bash")
+au BufNewFile,BufRead ~/.x{init,server}rc,/etc/X11/xinit/x{initrc{,.d/*},serverrc} setf sh
 au BufNewFile,BufRead .kshrc,*.ksh call dist#ft#SetFileTypeSH("ksh")
 au BufNewFile,BufRead */etc/profile,.profile,*.sh,*.envrc,.envrc.* call dist#ft#SetFileTypeSH(getline(1))
 " Shell script (Arch Linux) or PHP file (Drupal)


### PR DESCRIPTION
According to [this page](https://wiki.archlinux.org/title/Xinit#Configuration), `~/.xinitrc` is an actual shell script, so I think it should be given `filetype=sh`, whereas currently it is given `filetype=conf` by this line:
https://github.com/vim/vim/blob/f1ed84158ab80240c42c9f2356767cad448ca151/runtime/filetype.vim#L1649

I'm also matching _xinitrc_ files in other locations.