### PR TITLE
runtime(kitty): prevent kittyMapSeq from leaking into subsequent lines

### DIFF
--- a/runtime/syntax/kitty.vim
+++ b/runtime/syntax/kitty.vim
@@ -46,7 +46,7 @@ syn keyword kittyMapName nextgroup=kittyMapValue skipwhite contained map
 syn region kittyMapValue start="\S" skip="[\r\n][ \t]*\\" end="\ze[\r\n]" contains=kittyMapSeq,kittyMapAction contained
 
 syn region kittyMapAction start="\S" skip="[\r\n][ \t]*\\" end="\ze[\r\n]" contains=@kittyPrimitive contained
-syn region kittyMapSeq start="\S" end="\ze\s\|^\ze[ \t]*\\" nextgroup=kittyMapAction,kittyMouseMapType skipwhite contains=kittyCtrl,kittyAlt,kittyShift,kittySuper,kittyAnd,kittyWith,kittyKey contained
+syn region kittyMapSeq start="\S" end="\ze\s\|^\ze[ \t]*\\\|\ze$" nextgroup=kittyMapAction,kittyMouseMapType skipwhite contains=kittyCtrl,kittyAlt,kittyShift,kittySuper,kittyAnd,kittyWith,kittyKey contained
 
 " Mouse shortcut """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " Format: `mouse_map <keys> <type> <grabbed> <action>?`


### PR DESCRIPTION
### Problem

When `kitty_mod` (or a `map` command with no inline action) is defined at the end of a line without a trailing space (for example: `kitty_mod ctrl+shift`), the `kittyMapSeq` region fails to terminate on that line. 

This happens because Vim's `\s` matches spaces and tabs but not newlines, meaning the current ending pattern `end="\ze\s\|^\ze[ \t]*\\"` cannot be triggered at the end of the line. As a result, the region leaks into subsequent lines, corrupting the syntax highlighting of the next `map` definitions (e.g., highlighting `map` as `kittyKey` instead of `kittyMapName`).

### Solution

Added `\|\ze$` to the `end` pattern of `kittyMapSeq`:
```vim
syn region kittyMapSeq start="\S" end="\ze\s\|^\ze[ \t]*\\\|\ze$" ...
```

This allows the region to terminate correctly at the end of the line (zero-width match before `$`) without consuming the newline character, leaving it to be handled by the parent region (like `kittyMod`) to close safely.

### How to reproduce

1. Add the following to `kitty.conf` (ensuring no trailing space at the end of the first line):
   ```ini
   kitty_mod ctrl+shift
   map kitty_mod+enter launch
   ```
2. Without this fix, the `map` on the second line is incorrectly highlighted as `kittyKey` (Special). With this fix, it is correctly highlighted as `kittyMapName` (Function).
