### PR TITLE
Use-after-free with ":wqall" and a running terminal job (after v9.2.0593)

### DIFF
--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -2515,11 +2515,17 @@ do_wqall(exarg_T *eap)
 #ifdef FEAT_TERMINAL
 	if (exiting && !eap->forceit && term_job_running(buf->b_term))
 	{
+	    bufref_T	bufref;
+
+	    set_bufref(&bufref, buf);
 	    if (term_try_stop_job(buf) == FAIL)
 	    {
 		no_write_message_buf(buf);
 		++error;
 	    }
+	    // Stopping the job may have freed the terminal buffer.
+	    else if (!bufref_valid(&bufref))
+		buf = firstbuf;
 	}
 	else
 #endif


### PR DESCRIPTION
```
Problem:  Using ":wqall" with a running terminal buffer can free the
          buffer that is currently being iterated over in the buffer
          list, resulting in a use-after-free.
Solution: After stopping the job, check whether the buffer is still valid
          and restart the iteration from the first buffer if it was freed.
```

related: #20417