### PR TITLE
tests: Test_statusline() is flaky

### DIFF
--- a/src/testdir/test_statusline.vim
+++ b/src/testdir/test_statusline.vim
@@ -14,11 +14,15 @@ func TearDown()
 endfunc
 
 func s:get_statusline()
+  redraw!
   if has('gui_running')
-    redraw!
     sleep 1m
   endif
-  return ScreenLines(&lines - 1, &columns)[0]
+  " Read the screen directly after redraw! instead of going through
+  " ScreenLines(), whose own redraw! may process events and change the window
+  " layout between here and the screenstring() calls.
+  let row = &lines - 1
+  return join(map(range(1, &columns), 'screenstring(row, v:val)'), '')
 endfunc
 
 func StatuslineWithCaughtError()


### PR DESCRIPTION
```
Problem:  Test_statusline() occasionally fails in CI, reading buffer text
          instead of the status line (e.g. '9012...' instead of '57,39').
Solution: In s:get_statusline() redraw unconditionally and read the screen
          cells directly with screenstring(), instead of relying on
          ScreenLines() whose own redraw! can process events and change the
          window layout between the redraw and reading the cells.  This
          matches the already-stable s:Assert_match_statusline() helper in
          test_statuslineopt.vim.
```