### PR TITLE
quickfix: no efficient way to get error type counts

### DIFF
--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -461,6 +461,15 @@ using the |getqflist()| and |getloclist()| functions respectively.  Examples: >
 	echo getqflist({'size' : 1})
 	echo getloclist(5, {'size' : 1})
 <
+							*quickfix-total*
+You can get the count of each error type in a quickfix and a location list
+using the |getqflist()| and |getloclist()| functions respectively.  This
+returns a dictionary where the keys are the type characters and the values are
+the counts.  Empty type characters are returned with an empty string key.
+Examples: >
+	echo getqflist({'total' : 1})
+	echo getloclist(5, {'total' : 1})
+<
 							*quickfix-context*
 Any Vim type can be associated as a context with a quickfix or location list.
 The |setqflist()| and the |setloclist()| functions can be used to associate a
@@ -772,6 +781,9 @@ using these functions are below:
     " get the number of entries in a quickfix list specified by an id
     :echo getqflist({'id' : qfid, 'size' : 0}).size
 
+    " get the count of each error type in a quickfix list specified by an id
+    :echo getqflist({'id' : qfid, 'total' : 0}).total
+
     " get the context of the third quickfix list in the stack
     :echo getqflist({'nr' : 3, 'context' : 0}).context
 
@@ -790,6 +802,9 @@ using these functions are below:
     " parse text from a List of lines and return a quickfix list
     :let myList = ["a.java:10:L10", "b.java:20:L20"]
     :echo getqflist({'lines' : myList}).items
+
+    " parse text from a List of lines and return the type counts
+    :echo getqflist({'lines' : myList, 'total' : 1}).total
 
     " parse text using a custom 'efm' and return a quickfix list
     :echo getqflist({'lines' : ['a.c#10#Line 10'], 'efm':'%f#%l#%m'}).items

--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -81,6 +81,7 @@ typedef struct qf_list_S
     qfline_T	*qf_last;	// pointer to the last error
     qfline_T	*qf_ptr;	// pointer to the current error
     int		qf_count;	// number of errors (0 means empty list)
+    int		qf_type_count[256]; // count of each error type
     int		qf_index;	// current index in the error list
     int		qf_nonevalid;	// TRUE if not a single valid entry found
     int		qf_has_user_data; // TRUE if at least one item has user_data attached
@@ -199,6 +200,8 @@ static void	wipe_dummy_buffer(buf_T *buf, char_u *dirname_start);
 static void	unload_dummy_buffer(buf_T *buf, char_u *dirname_start);
 static qf_info_T *ll_get_or_alloc_list(win_T *);
 static int	entry_is_closer_to_target(qfline_T *entry, qfline_T *other_entry, int target_fnum, int target_lnum, int target_col);
+static int	qf_getprop_keys2flags(dict_T *what, int loclist);
+static int	qf_getprop_total(qf_list_T *qfl, dict_T *retdict);
 
 // Quickfix window check helper macro
 # define IS_QF_WINDOW(wp) (bt_quickfix((wp)->w_buffer) && (wp)->w_llist_ref == NULL)
@@ -2341,10 +2344,15 @@ qf_add_entry(
     qfp->qf_cleared = FALSE;
     *lastp = qfp;
     ++qfl->qf_count;
-    if (qfl->qf_index == 0 && qfp->qf_valid)	// first valid entry
-    {
-	qfl->qf_index = qfl->qf_count;
-	qfl->qf_ptr = qfp;
+    if (qfp->qf_valid) {
+	// first valid entry
+	if (qfl->qf_index == 0)
+	{
+		qfl->qf_index = qfl->qf_count;
+		qfl->qf_ptr = qfp;
+	}
+	// increment the histogram for every valid item
+	qfl->qf_type_count[(char_u)qfp->qf_type]++;
     }
 
     return QF_OK;
@@ -4377,6 +4385,8 @@ qf_free_items(qf_list_T *qfl)
     qfl->qf_multiline = FALSE;
     qfl->qf_multiignore = FALSE;
     qfl->qf_multiscan = FALSE;
+    // reset type counter
+    vim_memset(qfl->qf_type_count, 0, sizeof(qfl->qf_type_count));
 }
 
 /*
@@ -7317,7 +7327,8 @@ enum {
     QF_GETLIST_FILEWINID	= 0x200,
     QF_GETLIST_QFBUFNR	= 0x400,
     QF_GETLIST_QFTF	= 0x800,
-    QF_GETLIST_ALL	= 0xFFF,
+    QF_GETLIST_TOTAL	= 0x1000,
+    QF_GETLIST_ALL	= 0x1FFF,
 };
 
 /*
@@ -7351,6 +7362,9 @@ qf_get_list_from_lines(dict_T *what, dictitem_T *di, dict_T *retdict)
     if (l == NULL)
 	return FAIL;
 
+    int flags = qf_getprop_keys2flags(what, FALSE);
+    status = OK;
+
     qi = qf_alloc_stack(QFLT_INTERNAL, 1);
     if (qi != NULL)
     {
@@ -7358,13 +7372,20 @@ qf_get_list_from_lines(dict_T *what, dictitem_T *di, dict_T *retdict)
 		    TRUE, (linenr_T)0, (linenr_T)0, NULL, NULL) > 0)
 	{
 	    (void)get_errorlist(qi, NULL, 0, 0, l);
+	if ((flags & QF_GETLIST_TOTAL)
+			&& (qf_getprop_total(&qi->qf_lists[0], retdict) == FAIL))
+		status = FAIL;
 	    qf_free(&qi->qf_lists[0]);
 	}
 
 	qf_free_lists(qi);
     }
-    dict_add_list(retdict, "items", l);
-    status = OK;
+
+	if (status == OK)
+	status = dict_add_list(retdict, "items", l);
+
+	if (status == FAIL)
+	list_free(l);
 
     return status;
 }
@@ -7454,6 +7475,9 @@ qf_getprop_keys2flags(dict_T *what, int loclist)
 
     if (dict_has_key(what, "quickfixtextfunc"))
 	flags |= QF_GETLIST_QFTF;
+
+    if (dict_has_key(what, "total"))
+	flags |= QF_GETLIST_TOTAL;
 
     return flags;
 }
@@ -7551,6 +7575,14 @@ qf_getprop_defaults(qf_info_T *qi, int flags, int locstack, dict_T *retdict)
 	status = qf_getprop_qfbufnr(qi, retdict);
     if ((status == OK) && (flags & QF_GETLIST_QFTF))
 	status = dict_add_string_len(retdict, "quickfixtextfunc", (char_u *)"", 0);
+    if ((status == OK) && (flags & QF_GETLIST_TOTAL))
+    {
+	dict_T	*d = dict_alloc();
+	if (d != NULL)
+	    status = dict_add_dict(retdict, "total", d);
+	else
+	    status = FAIL;
+    }
 
     return status;
 }
@@ -7672,6 +7704,42 @@ qf_getprop_qftf(qf_list_T *qfl, dict_T *retdict)
 }
 
 /*
+ * Return the count of each error type in a quickfix/location list.
+ * Returns OK on success and FAIL on failure.
+ */
+    static int
+qf_getprop_total(qf_list_T *qfl, dict_T *retdict)
+{
+    dict_T	*dict;
+    int		i;
+    char	key[2];
+
+    if ((dict = dict_alloc()) == NULL)
+	return FAIL;
+
+    for (i = 0; i < 256; ++i)
+    {
+	if (qfl->qf_type_count[i] > 0)
+	{
+	    if (i == 0)
+		key[0] = NUL;
+	    else
+	    {
+		key[0] = (char)i;
+		key[1] = NUL;
+	    }
+	    if (dict_add_number(dict, key, (long)qfl->qf_type_count[i]) == FAIL)
+	    {
+		dict_unref(dict);
+		return FAIL;
+	    }
+	}
+    }
+
+    return dict_add_dict(retdict, "total", dict);
+}
+
+/*
  * Return quickfix/location list details (title) as a
  * dictionary. 'what' contains the details to return. If 'list_idx' is -1,
  * then current list is used. Otherwise the specified list is used.
@@ -7738,6 +7806,8 @@ qf_get_properties(win_T *wp, dict_T *what, dict_T *retdict)
 	status = qf_getprop_qfbufnr(qi, retdict);
     if ((status == OK) && (flags & QF_GETLIST_QFTF))
 	status = qf_getprop_qftf(qfl, retdict);
+    if ((status == OK) && (flags & QF_GETLIST_TOTAL))
+	status = qf_getprop_total(qfl, retdict);
 
     return status;
 }


### PR DESCRIPTION
Problem:  There is no efficient way to get the count of each error type
          in a quickfix list.  Retrieving this information requires
          iterating over the entire list in script, which is O(N).
Solution: Maintain a type-frequency histogram in 'qf_list_T' and expose
          it via the 'total' key in getqflist() and getloclist().
          (yilisharcs)

Co-authored-by: Gemini 3 Flash

Note: https://github.com/neovim/neovim/pull/40110