### PR TITLE
matchfuzzypos() returns garbage positions for long candidates

### DIFF
--- a/src/fuzzy.c
+++ b/src/fuzzy.c
@@ -135,10 +135,10 @@ fuzzy_match(
 	if (has_match(pat, str))
 	{
 	    fzy_score = match_positions(pat, str, matches + numMatches);
-	    score = (fzy_score == SCORE_MIN) ? INT_MIN + 1
-		: (fzy_score == SCORE_MAX) ? INT_MAX
-		: (fzy_score < 0) ? (int)ceil(fzy_score * SCORE_SCALE - 0.5)
-		: (int)floor(fzy_score * SCORE_SCALE + 0.5);
+	    if (fzy_score != SCORE_MIN)
+		score = (fzy_score == SCORE_MAX) ? INT_MAX
+		    : (fzy_score < 0) ? (int)ceil(fzy_score * SCORE_SCALE - 0.5)
+		    : (int)floor(fzy_score * SCORE_SCALE + 0.5);
 	}
 
 	if (score == FUZZY_SCORE_NONE)

--- a/src/testdir/test_matchfuzzy.vim
+++ b/src/testdir/test_matchfuzzy.vim
@@ -331,4 +331,32 @@ func Test_matchfuzzy_long_multiword_no_overflow()
   call assert_equal([[], [], []], matchfuzzypos([word], pat_overflow))
 endfunc
 
+func Test_matchfuzzy_long_candidate()
+  let str = repeat('a', 1024) .. 'z'
+  call assert_equal([], matchfuzzy([str], 'az'))
+  call assert_equal([[], [], []], matchfuzzypos([str], 'az'))
+
+  call assert_equal([str], matchfuzzy([str], 'a'))
+  let r = matchfuzzypos([str], 'a')
+  call assert_equal([str], r[0])
+  call assert_equal([0], r[1][0])
+
+  let edge = 'a' .. repeat('x', 1022) .. 'a'
+  call assert_equal([edge], matchfuzzy([edge], 'aa'))
+  let e = matchfuzzypos([edge], 'aa')
+  call assert_equal([edge], e[0])
+  call assert_equal([0, 1023], e[1][0])
+endfunc
+
+func Test_matchfuzzy_long_candidate_mbyte()
+  CheckFeature multi_lang
+  let ok = repeat('好', 1023) .. '界'
+  call assert_equal([ok], matchfuzzy([ok], '好界'))
+  call assert_notequal([], matchfuzzypos([ok], '好界')[0])
+
+  let toolong = repeat('好', 1024) .. '界'
+  call assert_equal([], matchfuzzy([toolong], '好界'))
+  call assert_equal([[], [], []], matchfuzzypos([toolong], '好界'))
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  a needle that only matches past char 1024 gives an INT_MIN + 1 score
          with unset positions, e.g. matchfuzzypos([repeat('a',1024)..'z'], 'az').
Solution: drop the candidate when match_positions() returns SCORE_MIN.