### PR TITLE
runtime(xslt,xsd): speed up highlighting by optimizing lookbehinds in patterns

### DIFF
--- a/runtime/syntax/xsd.vim
+++ b/runtime/syntax/xsd.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:	XSD (XML Schema)
 " Maintainer:	Johannes Zellner <johannes@zellner.org>
-" Last Change:	Tue, 27 Apr 2004 14:54:59 CEST
+" Last Change:	21 Jun 2026
 " Filenames:	*.xsd
 " $Id: xsd.vim,v 1.1 2004/06/13 18:20:48 vimboss Exp $
 
@@ -14,48 +14,26 @@ if exists("b:current_syntax")
     finish
 endif
 
-runtime syntax/xml.vim
+runtime! syntax/xml.vim
 
 syn cluster xmlTagHook add=xsdElement
 syn case match
 
-syn match xsdElement '\%(xsd:\)\@<=all'
-syn match xsdElement '\%(xsd:\)\@<=annotation'
-syn match xsdElement '\%(xsd:\)\@<=any'
-syn match xsdElement '\%(xsd:\)\@<=anyAttribute'
-syn match xsdElement '\%(xsd:\)\@<=appInfo'
-syn match xsdElement '\%(xsd:\)\@<=attribute'
-syn match xsdElement '\%(xsd:\)\@<=attributeGroup'
-syn match xsdElement '\%(xsd:\)\@<=choice'
-syn match xsdElement '\%(xsd:\)\@<=complexContent'
-syn match xsdElement '\%(xsd:\)\@<=complexType'
-syn match xsdElement '\%(xsd:\)\@<=documentation'
-syn match xsdElement '\%(xsd:\)\@<=element'
-syn match xsdElement '\%(xsd:\)\@<=enumeration'
-syn match xsdElement '\%(xsd:\)\@<=extension'
-syn match xsdElement '\%(xsd:\)\@<=field'
-syn match xsdElement '\%(xsd:\)\@<=group'
-syn match xsdElement '\%(xsd:\)\@<=import'
-syn match xsdElement '\%(xsd:\)\@<=include'
-syn match xsdElement '\%(xsd:\)\@<=key'
-syn match xsdElement '\%(xsd:\)\@<=keyref'
-syn match xsdElement '\%(xsd:\)\@<=length'
-syn match xsdElement '\%(xsd:\)\@<=list'
-syn match xsdElement '\%(xsd:\)\@<=maxInclusive'
-syn match xsdElement '\%(xsd:\)\@<=maxLength'
-syn match xsdElement '\%(xsd:\)\@<=minInclusive'
-syn match xsdElement '\%(xsd:\)\@<=minLength'
-syn match xsdElement '\%(xsd:\)\@<=pattern'
-syn match xsdElement '\%(xsd:\)\@<=redefine'
-syn match xsdElement '\%(xsd:\)\@<=restriction'
-syn match xsdElement '\%(xsd:\)\@<=schema'
-syn match xsdElement '\%(xsd:\)\@<=selector'
-syn match xsdElement '\%(xsd:\)\@<=sequence'
-syn match xsdElement '\%(xsd:\)\@<=simpleContent'
-syn match xsdElement '\%(xsd:\)\@<=simpleType'
-syn match xsdElement '\%(xsd:\)\@<=union'
-syn match xsdElement '\%(xsd:\)\@<=unique'
+for s:element in [
+    \ 'all', 'annotation', 'any', 'anyAttribute', 'appInfo', 'attribute',
+    \ 'attributeGroup', 'choice', 'complexContent', 'complexType',
+    \ 'documentation', 'element', 'enumeration', 'extension', 'field', 'group',
+    \ 'import', 'include', 'key', 'keyref', 'length', 'list', 'maxInclusive',
+    \ 'maxLength', 'minInclusive', 'minLength', 'pattern', 'redefine',
+    \ 'restriction', 'schema', 'selector', 'sequence', 'simpleContent',
+    \ 'simpleType', 'union', 'unique',
+    \ ]
+    execute 'syn match xsdElement contained /\%#=1\%([</]xsd:\)\@5<=' . s:element . '[^ /!?<>"'']\@!/'
+endfor
+unlet s:element
 
 hi def link xsdElement Statement
+
+let b:current_syntax = 'xsd'
 
 " vim: ts=8

--- a/runtime/syntax/xslt.vim
+++ b/runtime/syntax/xslt.vim
@@ -2,7 +2,7 @@
 " Language:	XSLT
 " Maintainer:   Bogdan Barbu <l4b.bogdan.barbu@gmail.com>
 " Previous Maintainer:	Johannes Zellner <johannes@zellner.org>
-" Last Change:	Fri, 17 Jan 2020 07:15:37 +0200
+" Last Change:	21 Jun 2026
 " Filenames:	*.xsl
 " $Id: xslt.vim,v 1.1 2004/06/13 15:52:10 vimboss Exp $
 
@@ -15,57 +15,28 @@ if exists("b:current_syntax")
     finish
 endif
 
-runtime syntax/xml.vim
+runtime! syntax/xml.vim
 
 syn cluster xmlTagHook add=xslElement
 syn case match
 
-syn match xslElement '\%(xsl:\)\@<=analyze-string'
-syn match xslElement '\%(xsl:\)\@<=apply-imports'
-syn match xslElement '\%(xsl:\)\@<=apply-templates'
-syn match xslElement '\%(xsl:\)\@<=attribute'
-syn match xslElement '\%(xsl:\)\@<=attribute-set'
-syn match xslElement '\%(xsl:\)\@<=call-template'
-syn match xslElement '\%(xsl:\)\@<=character-map'
-syn match xslElement '\%(xsl:\)\@<=choose'
-syn match xslElement '\%(xsl:\)\@<=comment'
-syn match xslElement '\%(xsl:\)\@<=copy'
-syn match xslElement '\%(xsl:\)\@<=copy-of'
-syn match xslElement '\%(xsl:\)\@<=decimal-format'
-syn match xslElement '\%(xsl:\)\@<=document'
-syn match xslElement '\%(xsl:\)\@<=element'
-syn match xslElement '\%(xsl:\)\@<=fallback'
-syn match xslElement '\%(xsl:\)\@<=for-each'
-syn match xslElement '\%(xsl:\)\@<=for-each-group'
-syn match xslElement '\%(xsl:\)\@<=function'
-syn match xslElement '\%(xsl:\)\@<=if'
-syn match xslElement '\%(xsl:\)\@<=include'
-syn match xslElement '\%(xsl:\)\@<=import'
-syn match xslElement '\%(xsl:\)\@<=import-schema'
-syn match xslElement '\%(xsl:\)\@<=key'
-syn match xslElement '\%(xsl:\)\@<=message'
-syn match xslElement '\%(xsl:\)\@<=namespace'
-syn match xslElement '\%(xsl:\)\@<=namespace-alias'
-syn match xslElement '\%(xsl:\)\@<=number'
-syn match xslElement '\%(xsl:\)\@<=otherwise'
-syn match xslElement '\%(xsl:\)\@<=output'
-syn match xslElement '\%(xsl:\)\@<=param'
-syn match xslElement '\%(xsl:\)\@<=perform-sort'
-syn match xslElement '\%(xsl:\)\@<=processing-instruction'
-syn match xslElement '\%(xsl:\)\@<=preserve-space'
-syn match xslElement '\%(xsl:\)\@<=script'
-syn match xslElement '\%(xsl:\)\@<=sequence'
-syn match xslElement '\%(xsl:\)\@<=sort'
-syn match xslElement '\%(xsl:\)\@<=strip-space'
-syn match xslElement '\%(xsl:\)\@<=stylesheet'
-syn match xslElement '\%(xsl:\)\@<=template'
-syn match xslElement '\%(xsl:\)\@<=transform'
-syn match xslElement '\%(xsl:\)\@<=text'
-syn match xslElement '\%(xsl:\)\@<=value-of'
-syn match xslElement '\%(xsl:\)\@<=variable'
-syn match xslElement '\%(xsl:\)\@<=when'
-syn match xslElement '\%(xsl:\)\@<=with-param'
+for s:element in [
+    \ 'analyze-string', 'apply-imports', 'apply-templates', 'attribute',
+    \ 'attribute-set', 'call-template', 'character-map', 'choose', 'comment',
+    \ 'copy', 'copy-of', 'decimal-format', 'document', 'element', 'fallback',
+    \ 'for-each', 'for-each-group', 'function', 'if', 'include', 'import',
+    \ 'import-schema', 'key', 'message', 'namespace', 'namespace-alias',
+    \ 'number', 'otherwise', 'output', 'param', 'perform-sort',
+    \ 'processing-instruction', 'preserve-space', 'script', 'sequence', 'sort',
+    \ 'strip-space', 'stylesheet', 'template', 'transform', 'text', 'value-of',
+    \ 'variable', 'when', 'with-param',
+    \ ]
+    execute 'syn match xslElement contained /\%#=1\%([</]xsl:\)\@5<=' . s:element . '[^ /!?<>"'']\@!/'
+endfor
+unlet s:element
 
 hi def link xslElement Statement
+
+let b:current_syntax = 'xslt'
 
 " vim: ts=8


### PR DESCRIPTION
Scrolling in these filetypes is too slow, so I investigated which syntax patterns were causing the slowdown with `:syntime`. Turns out it was the matching of XSL/XSD-specific tag names was costing way more time than it has to. I fixed this with by using the `lc=...` parameter for the regexes, which makes the syntax engine step a number of characters back before matching the pattern, which in this case is practically equivalent to a lookbehind in front of the pattern. I also made them check the character before the name of the XML namespace which they weren't doing before, so that stuff like `<notxsl:element>...` does not get matched.