### PR TITLE
Mark Test_mswin_event_mouse as flaky

### DIFF
--- a/src/testdir/test_mswin_event.vim
+++ b/src/testdir/test_mswin_event.vim
@@ -704,9 +704,7 @@ func Test_mswin_event_mouse()
   CheckMSWindows
   new
 
-  if !has('gui_running')
-    let g:test_is_flaky = 1
-  endif
+  let g:test_is_flaky = 1
 
   set mousemodel=extend
   call test_override('no_query_mouse', 1)


### PR DESCRIPTION
Test_mswin_event_mouse is also flaky on the GUI:
https://github.com/vim/vim-win32-installer/issues/446#issuecomment-4644444408