### PR TITLE
Fix heap buffer overlow in GUI

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -3378,6 +3378,13 @@ give_up:
     screen_Rows = Rows;
     screen_Columns = Columns;
 
+#ifdef FEAT_GUI
+    // Cursor position may now be out of bounds after resize
+    if (gui.in_use && (gui.cursor_row >= screen_Rows
+		|| gui.cursor_col >= screen_Columns))
+	gui.cursor_is_valid = false;
+#endif
+
     set_must_redraw(UPD_CLEAR);	// need to clear the screen later
     if (doclear)
 	screenclear2(TRUE);


### PR DESCRIPTION
To reproduce (seems to only happen with this specific case?):
```
$ vim -f -g <some file> +'set guiligatures=->' +'set guifont=JetBrains\\ Mono'
=================================================================
==216375==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x7cd532b2c2dc at pc 0x563d775789aa bp 0x7ffeacdb7680 sp 0x7ffeacdb7670
READ of size 4 at 0x7cd532b2c2dc thread T0
    #0 0x563d775789a9 in gui_adjust_undraw_cursor_for_ligatures /srv/git/vim/src/gui.c:1130
    #1 0x563d775810ce in gui_undraw_cursor /srv/git/vim/src/gui.c:2744
    #2 0x563d77730dd4 in msg_scroll_up /srv/git/vim/src/message.c:2821
    #3 0x563d7772ef56 in msg_puts_display /srv/git/vim/src/message.c:2569
    #4 0x563d7772db3c in msg_puts_attr_len /srv/git/vim/src/message.c:2388
    #5 0x563d7772d8b2 in msg_puts_attr /srv/git/vim/src/message.c:2337
    #6 0x563d77727bdd in msg_putchar_attr /srv/git/vim/src/message.c:1650
    #7 0x563d7772786c in msg_putchar /srv/git/vim/src/message.c:1633
    #8 0x563d77727573 in msg_start /srv/git/vim/src/message.c:1602
    #9 0x563d7771e460 in msg_attr_keep /srv/git/vim/src/message.c:187
    #10 0x563d7771e170 in msg_attr /srv/git/vim/src/message.c:139
    #11 0x563d77721216 in msg_source /srv/git/vim/src/message.c:553
    #12 0x563d77722a90 in emsg_core /srv/git/vim/src/message.c:782
    #13 0x563d77722b84 in emsg /srv/git/vim/src/message.c:807
    #14 0x563d76db3e2f in do_set /srv/git/vim/src/option.c:3071
    #15 0x563d76da65e3 in ex_set /srv/git/vim/src/option.c:1426
    #16 0x563d769a5dd9 in do_one_cmd /srv/git/vim/src/ex_docmd.c:2629
    #17 0x563d76998c0b in do_cmdline /srv/git/vim/src/ex_docmd.c:1041
    #18 0x563d7699676b in do_cmdline_cmd /srv/git/vim/src/ex_docmd.c:635
    #19 0x563d7770f937 in exe_commands /srv/git/vim/src/main.c:3318
    #20 0x563d7770030d in vim_main2 /srv/git/vim/src/main.c:866
    #21 0x563d776ff4fe in main /srv/git/vim/src/main.c:453
    #22 0x7fc536427740  (/usr/lib/libc.so.6+0x27740) (BuildId: 020d6f7c33b2413f4fe10814c4729dce1387f049)
    #23 0x7fc536427878 in __libc_start_main (/usr/lib/libc.so.6+0x27878) (BuildId: 020d6f7c33b2413f4fe10814c4729dce1387f049)
    #24 0x563d7665e2d4 in _start (/srv/git/vim/src/vim+0x1a942d4) (BuildId: 00aa31fbb8f040f67292024744933355c63535da)

0x7cd532b2c2dc is located 20 bytes after 200-byte region [0x7cd532b2c200,0x7cd532b2c2c8)
allocated by thread T0 here:
    #0 0x7fc53812c161 in malloc (/usr/lib/libasan.so.8+0x12c161) (BuildId: ee5fbab73143ab257a66a33afe0f038a4af7a74e)
    #1 0x563d7665e780 in lalloc /srv/git/vim/src/alloc.c:246
    #2 0x563d7700f047 in screenalloc /srv/git/vim/src/screen.c:3177
    #3 0x563d7700dd14 in screen_valid /srv/git/vim/src/screen.c:3052
    #4 0x563d77736bf2 in msg_check_screen /srv/git/vim/src/message.c:3841
    #5 0x563d7773317f in msg_use_printf /srv/git/vim/src/message.c:3173
    #6 0x563d7772db0e in msg_puts_attr_len /srv/git/vim/src/message.c:2385
    #7 0x563d7772d8b2 in msg_puts_attr /srv/git/vim/src/message.c:2337
    #8 0x563d77727bdd in msg_putchar_attr /srv/git/vim/src/message.c:1650
    #9 0x563d7772786c in msg_putchar /srv/git/vim/src/message.c:1633
    #10 0x563d77727573 in msg_start /srv/git/vim/src/message.c:1602
    #11 0x563d7771e460 in msg_attr_keep /srv/git/vim/src/message.c:187
    #12 0x563d7771e170 in msg_attr /srv/git/vim/src/message.c:139
    #13 0x563d77721216 in msg_source /srv/git/vim/src/message.c:553
    #14 0x563d77722a90 in emsg_core /srv/git/vim/src/message.c:782
    #15 0x563d77722b84 in emsg /srv/git/vim/src/message.c:807
    #16 0x563d76db3e2f in do_set /srv/git/vim/src/option.c:3071
    #17 0x563d76da65e3 in ex_set /srv/git/vim/src/option.c:1426
    #18 0x563d769a5dd9 in do_one_cmd /srv/git/vim/src/ex_docmd.c:2629
    #19 0x563d76998c0b in do_cmdline /srv/git/vim/src/ex_docmd.c:1041
    #20 0x563d7699676b in do_cmdline_cmd /srv/git/vim/src/ex_docmd.c:635
    #21 0x563d7770f937 in exe_commands /srv/git/vim/src/main.c:3318
    #22 0x563d7770030d in vim_main2 /srv/git/vim/src/main.c:866
    #23 0x563d776ff4fe in main /srv/git/vim/src/main.c:453
    #24 0x7fc536427740  (/usr/lib/libc.so.6+0x27740) (BuildId: 020d6f7c33b2413f4fe10814c4729dce1387f049)
    #25 0x7fc536427878 in __libc_start_main (/usr/lib/libc.so.6+0x27878) (BuildId: 020d6f7c33b2413f4fe10814c4729dce1387f049)
    #26 0x563d7665e2d4 in _start (/srv/git/vim/src/vim+0x1a942d4) (BuildId: 00aa31fbb8f040f67292024744933355c63535da)

SUMMARY: AddressSanitizer: heap-buffer-overflow /srv/git/vim/src/gui.c:1130 in gui_adjust_undraw_cursor_for_ligatures
Shadow bytes around the buggy address:
  0x7cd532b2c000: fd fd fd fd fd fd fd fd fd fd fa fa fa fa fa fa
  0x7cd532b2c080: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
  0x7cd532b2c100: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x7cd532b2c180: fd fd fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x7cd532b2c200: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x7cd532b2c280: 00 00 00 00 00 00 00 00 00 fa fa[fa]fa fa fa fa
  0x7cd532b2c300: fa fa fa fa fa fa fa fa 00 00 00 00 00 00 00 00
  0x7cd532b2c380: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7cd532b2c400: 00 00 00 04 fa fa fa fa fa fa fa fa fa fa fa fa
  0x7cd532b2c480: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x7cd532b2c500: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==216375==ABORTING
```
Fix was created by Claude and reviewed by me