### PR TITLE
Fix `:vim9cmd gui` not sourcing menus.vim

### DIFF
--- a/src/scriptfile.c
+++ b/src/scriptfile.c
@@ -1806,9 +1806,9 @@ do_source_ext(
     sticky_cmdmod_flags = 0;
 
     save_current_sctx = current_sctx;
-    if (cmdmod.cmod_flags & CMOD_VIM9CMD)
-	// When the ":vim9cmd" command modifier is used, source the script as a
-	// Vim9 script.
+    if ((cmdmod.cmod_flags & CMOD_VIM9CMD) && cookie.source_from_buf)
+	// When the ":vim9cmd" command modifier is used, source buffer lines as
+	// Vim9 script
 	current_sctx.sc_version = SCRIPT_VERSION_VIM9;
     else
 	current_sctx.sc_version = 1;  // default script version

--- a/src/testdir/test_gui.vim
+++ b/src/testdir/test_gui.vim
@@ -154,6 +154,24 @@ func Test_quoteplus()
   let @+ = quoteplus_saved
 endfunc
 
+" Test that legacy script menu files are sourced when :gui is executed with
+" the :vim9cmd modifier
+func Test_vim9cmd_gui()
+  CheckX11BasedGui
+
+  let lines =<< trim END
+    " Ignore the "failed to create input context" error.
+    call test_ignore_error("E285")
+    vim9cmd gui -f
+    call writefile([!empty(menu_info("Help"))], "XguimenuOK")
+    qa!
+  END
+  call writefile(lines, 'Xguimenuscript', 'D')
+  call system(GetVimCommand() .. ' --noplugin -S Xguimenuscript')
+  call assert_equal(['1'], readfile('XguimenuOK'))
+  call delete('XguimenuOK')
+endfunc
+
 func Test_gui_read_stdin()
   CheckUnix
 

--- a/src/testdir/test_source.vim
+++ b/src/testdir/test_source.vim
@@ -635,6 +635,22 @@ func Test_source_buffer_vim9()
   %bw!
 endfunc
 
+" Test that the modifier does not override the script type when sourcing files
+" with :vim9cmd and :legacy
+func Test_source_file_ignores_modifiers()
+  let lines = ["let g:legacy_sourced = 42"]
+  call writefile(lines, 'Xsourcelegacy', 'D')
+  vim9cmd source Xsourcelegacy
+  call assert_equal(42, g:legacy_sourced)
+  unlet g:legacy_sourced
+
+  let lines = ["vim9script", "g:vim9_sourced = 42"]
+  call writefile(lines, 'Xsourcevim9', 'D')
+  legacy source Xsourcevim9
+  call assert_equal(42, g:vim9_sourced)
+  unlet g:vim9_sourced
+endfunc
+
 func Test_source_buffer_long_line()
   " This was reading past the end of the line.
   new


### PR DESCRIPTION
Problem: Commands modified by `:vim9cmd` source all scripts as Vim9 script.
Solution: Only source buffer lines as Vim9 via the `:vim9cmd` modifier. When sourcing a file, respect its script type.

This caused `:vim9cmd gui` to launch the GUI without menus as the legacy script menus.vim file failed to load when sourced as Vim9 script.