### PR TITLE
popup_setoptions()/ch_setoptions() does not check secure mode

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -5927,6 +5927,9 @@ f_ch_setoptions(typval_T *argvars, typval_T *rettv UNUSED)
     channel_T	*channel;
     jobopt_T	opt;
 
+    if (check_restricted() || check_secure())
+	return;
+
     if (in_vim9script()
 	    && (check_for_chan_or_job_arg(argvars, 0) == FAIL
 		|| check_for_dict_arg(argvars, 1) == FAIL))

--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -4474,6 +4474,9 @@ f_popup_setoptions(typval_T *argvars, typval_T *rettv UNUSED)
     int		need_redraw = FALSE;
     int		need_reposition = FALSE;
 
+    if (check_secure())
+	return;
+
     if (in_vim9script()
 	    && (check_for_number_arg(argvars, 0) == FAIL
 		|| check_for_dict_arg(argvars, 1) == FAIL))

--- a/src/testdir/test_popup.vim
+++ b/src/testdir/test_popup.vim
@@ -2632,8 +2632,9 @@ func Test_popup_opacity_move_after_close()
   call StopVimInTerminal(buf)
 endfunc
 
-func Test_popup_create_sandbox()
+func Test_popup_sandbox()
   call assert_fails('sandbox call popup_create("hello", {})', 'E48:')
+  call assert_fails('sandbox call popup_setoptions(1, {})', 'E48:')
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_restricted.vim
+++ b/src/testdir/test_restricted.vim
@@ -70,6 +70,7 @@ func Test_restricted_mode()
     if has('channel')
       call assert_fails("call ch_logfile('Xlog')", 'E145:')
       call assert_fails("call ch_open('localhost:8765')", 'E145:')
+      call assert_fails("call ch_setoptions('localhost:8765', {})", 'E145:')
     endif
 
     if has('job')


### PR DESCRIPTION
Problem:  popup_setoptions()/ch_setoptions() does not check secure mode
Solution: Add missing checks for check_restricted()/check_secure()