### PR TITLE
tests: Test_screenpos() is flaky in GUI

### DIFF
--- a/src/testdir/test_cursor_func.vim
+++ b/src/testdir/test_cursor_func.vim
@@ -125,7 +125,7 @@ func Test_screenpos()
   exe "normal G\<C-Y>\<C-Y>"
   redraw
   let winbar_height = get(wininfo, 'winbar', 0)
-  call assert_equal({'row': winrow + wininfo.height - 1 + winbar_height,
+  call assert_equal({'row': winrow + winheight(winid) - 1 + winbar_height,
 	\ 'col': wincol + 7,
 	\ 'curscol': wincol + 7,
 	\ 'endcol': wincol + 7}, winid->screenpos(line('$'), 8))


### PR DESCRIPTION
Problem:  Test_screenpos() fails intermittently in the GUI testgui CI job with "Expected {'row': 22} but got {'row': 23}".  In the GUI, the window height reported by getwininfo() before the final redraw can be stale, so the cached wininfo.height does not match the actual window height when the assertion runs.

Solution: Use winheight(winid) at assertion time so the height reflects the window state after the redraw.

This PR is powered by Claude Code.