### PR TITLE
cindent: closing brace in a line comment affects the next line's indent

### DIFF
--- a/src/cindent.c
+++ b/src/cindent.c
@@ -1217,6 +1217,8 @@ find_last_paren(char_u *l, int start, int end)
     for (i = 0; l[i] != NUL; i++)
     {
 	i = (int)(cin_skipcomment(l + i) - l); // ignore parens in comments
+	if (l[i] == NUL)
+	    break;
 	i = (int)(skip_string(l + i) - l);    // ignore parens in quotes
 	if (l[i] == start)
 	    ++open_count;

--- a/src/testdir/test_cindent.vim
+++ b/src/testdir/test_cindent.vim
@@ -5604,6 +5604,37 @@ def Test_cindent_comment_brackets()
   assert_equal('    arg3);', getline(3))
   bwipe!
 
+  # stray } in a // line comment inside an aggregate (enum/struct) whose
+  # opening brace is at the end of the line must not affect the next member
+  new
+  setl cindent sw=4
+  var code6 =<< trim [CODE]
+  typedef enum {
+      ND_BLOCK,  // { ... }
+      ND_FUNCALL,
+  } NodeKind;
+  [CODE]
+  setline(1, code6)
+  cursor(3, 1)
+  normal ==
+  assert_equal('    ND_FUNCALL,', getline(3))
+  bwipe!
+
+  # same, a struct member with a trailing // } comment
+  new
+  setl cindent sw=4
+  var code7 =<< trim [CODE]
+  struct S {
+      int a;  // }
+      int b;
+  };
+  [CODE]
+  setline(1, code7)
+  cursor(3, 1)
+  normal ==
+  assert_equal('    int b;', getline(3))
+  bwipe!
+
 enddef
 
 


### PR DESCRIPTION
```
Problem:  A '}' inside a // line comment changes the indentation of the
          following line inside an enum or struct (rendcrx).
Solution: Stop scanning the line once a line comment is reached, so a brace
          inside the comment is no longer mistaken for an unmatched brace.
```

fixes: #20455