### PR TITLE
Fix integer overflow in popup image size validation

### DIFF
--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -981,9 +981,11 @@ apply_general_options(win_T *wp, dict_T *dict)
 	{
 	    blob_T  *b = id->di_tv.vval.v_blob;
 	    long     blen = blob_len(b);
-	    int	     has_alpha = (blen == (long)iw * ih * 4);
+	    // 64-bit to avoid iw * ih * 4 overflow on a 32-bit long
+	    varnumber_T	 npixels = (varnumber_T)iw * ih;
+	    int	     has_alpha = (blen == npixels * 4);
 
-	    if (has_alpha || blen == (long)iw * ih * 3)
+	    if (has_alpha || blen == npixels * 3)
 	    {
 		// Detect "same-size image swap": replacing the pixel buffer
 		// without changing the popup's pixel dimensions or pixel


### PR DESCRIPTION
The image size validation computed iw * ih * 4 in a 32-bit long, which overflows on MS-Windows and can wrap to match a short blob, leading to an out-of-bounds read when the pixels are encoded. Compute the size in 64-bit.