### PR TITLE
Fix use-after-free in popup_getoptions() on dict_add() failure

### DIFF
--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -5433,7 +5433,9 @@ f_popup_getoptions(typval_T *argvars, typval_T *rettv)
 		++b->bv_refcount;
 		if (dict_add(idict, item) == FAIL)
 		{
+		    // dictitem_free() already freed the blob
 		    dictitem_free(item);
+		    b = NULL;
 		    ok = FALSE;
 		}
 	    }


### PR DESCRIPTION
When dict_add() fails, dictitem_free() already frees the blob, but the cleanup then reads the freed blob's refcount and could free it again. Clear the pointer after dictitem_free().