### PR TITLE
GvimExt: Support multiple runtime directory structures

### DIFF
--- a/src/GvimExt/Make_ming.mak
+++ b/src/GvimExt/Make_ming.mak
@@ -86,8 +86,8 @@ $(DLL): $(OBJ) $(RES) $(DEFFILE)
 			$(LIBS) \
 		-Wl,-Bstatic $(STATIC_LIBS) -Wl,-Bdynamic
 
-gvimext.o: gvimext.cpp
-	$(CXX) $(CXXFLAGS) -DFEAT_GETTEXT -DWINVER=$(WINVER) -D_WIN32_WINNT=$(WINVER) -c $? -o $@
+gvimext.o: gvimext.cpp gvimext.h ../version.h
+	$(CXX) $(CXXFLAGS) -DFEAT_GETTEXT -DWINVER=$(WINVER) -D_WIN32_WINNT=$(WINVER) -c $< -o $@
 
 $(RES): gvimext_ming.rc
 	$(WINDRES) $(WINDRES_FLAGS) --input-format=rc --output-format=coff -DMING $? -o $@

--- a/src/GvimExt/Make_mvc.mak
+++ b/src/GvimExt/Make_mvc.mak
@@ -50,7 +50,7 @@ CPU = ARM64
 cc = cl
 link = link
 rc = rc
-cflags = -nologo -c
+cflags = -nologo -c -GF
 lflags = -incremental:no -nologo
 rcflags = /r
 olelibsdll = ole32.lib uuid.lib oleaut32.lib user32.lib gdi32.lib advapi32.lib
@@ -84,7 +84,7 @@ gvimext.dll: gvimext.obj gvimext.res
 		-out:$*.dll $** $(olelibsdll) shell32.lib comctl32.lib \
 		-subsystem:$(SUBSYSTEM)
 
-gvimext.obj: gvimext.h
+gvimext.obj: gvimext.h ../version.h
 
 .cpp.obj:
 	$(cc) $(cflags) -DFEAT_GETTEXT $(cvarsmt) $*.cpp

--- a/src/GvimExt/gvimext.cpp
+++ b/src/GvimExt/gvimext.cpp
@@ -994,17 +994,20 @@ BOOL CShellExt::LoadMenuIcon()
     static char *
 searchpath(char *name)
 {
-    static char widename[2 * BUFSIZE];
-    WCHAR location[BUFSIZE + 1];
+    static union {
+	char	location[2 * BUFSIZE];
+	WCHAR	wname[BUFSIZE];
+    };
+    WCHAR wlocation[BUFSIZE + 1];
 
     // There appears to be a bug in FindExecutableA() on Windows NT.
     // Use FindExecutableW() instead...
-    MultiByteToWideChar(CP_ACP, 0, name, -1, (LPWSTR)widename, BUFSIZE);
-    if (FindExecutableW((LPCWSTR)widename, L"", location) > (HINSTANCE)32)
+    MultiByteToWideChar(CP_ACP, 0, name, -1, wname, BUFSIZE);
+    if (FindExecutableW(wname, L"", wlocation) > (HINSTANCE)32)
     {
-	WideCharToMultiByte(CP_ACP, 0, location, -1,
-		(LPSTR)widename, 2 * BUFSIZE, NULL, NULL);
-	return widename;
+	WideCharToMultiByte(CP_ACP, 0, wlocation, -1,
+		location, sizeof(location), NULL, NULL);
+	return location;
     }
     return (char *)"";
 }

--- a/src/GvimExt/gvimext.cpp
+++ b/src/GvimExt/gvimext.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "gvimext.h"
+#include "../version.h"
 
 #define ARRAY_LENGTH(a) (sizeof(a) / sizeof((a)[0]))
 
@@ -52,7 +53,7 @@ UINT cbFiles = 0;
 // Returns the path in name[BUFSIZE].  It's empty when it fails.
 //
     static void
-getGvimName(char *name, int runtime)
+getGvimName(char *name, BOOL runtime)
 {
     HKEY	keyhandle;
     DWORD	hlen;
@@ -102,9 +103,9 @@ getGvimName(char *name, int runtime)
 }
 
     static void
-getGvimInvocation(char *name, int runtime)
+getGvimInvocation(char *name)
 {
-    getGvimName(name, runtime);
+    getGvimName(name, FALSE);
     // avoid that Vim tries to expand wildcards in the file names
     strcat(name, " --literal");
 }
@@ -115,9 +116,18 @@ getGvimInvocationW(wchar_t *nameW)
     char *name;
 
     name = (char *)malloc(BUFSIZE);
-    getGvimInvocation(name, 0);
+    getGvimInvocation(name);
     mbstowcs(nameW, name, BUFSIZE);
     free(name);
+}
+
+    static BOOL
+FileExists(LPCTSTR szPath)
+{
+    DWORD dwAttrib = GetFileAttributes(szPath);
+
+    return (dwAttrib != INVALID_FILE_ATTRIBUTES
+	    && !(dwAttrib & FILE_ATTRIBUTE_DIRECTORY));
 }
 
 //
@@ -130,21 +140,47 @@ getRuntimeDir(char *buf)
 {
     int		idx;
 
-    getGvimName(buf, 1);
-    if (buf[0] != 0)
-    {
-	// When no path found, use the search path to expand it.
-	if (strchr(buf, '/') == NULL && strchr(buf, '\\') == NULL)
-	    strcpy(buf, searchpath(buf));
+    getGvimName(buf, TRUE);
+    if (buf[0] == 0)
+	return;
 
-	// remove "gvim.exe" from the end
-	for (idx = (int)strlen(buf) - 1; idx >= 0; idx--)
-	    if (buf[idx] == '\\' || buf[idx] == '/')
-	    {
-		buf[idx + 1] = 0;
-		break;
-	    }
+    // When no path found, use the search path to expand it.
+    if (strchr(buf, '/') == NULL && strchr(buf, '\\') == NULL)
+	strcpy(buf, searchpath(buf));
+
+    // remove "gvim.exe" from the end
+    for (idx = (int)strlen(buf) - 1; idx >= 0; idx--)
+	if (buf[idx] == '\\' || buf[idx] == '/')
+	{
+	    buf[++idx] = 0;
+	    break;
+	}
+
+    // Check the existence of defaults.vim
+    char *p = buf + idx;
+    strcpy(p, "defaults.vim");
+    if (FileExists(buf))
+    {
+	*p = 0;		// Cut "defaults.vim"
+	return;
     }
+    // Check the existence of vimXX\defaults.vim
+    strcpy(p, VIM_VERSION_NODOT "\\" "defaults.vim");
+    if (FileExists(buf))
+    {
+	p[ARRAY_LENGTH(VIM_VERSION_NODOT)] = 0;	// Cut "defaults.vim"
+	return;
+    }
+    // Check the existence of runtime\defaults.vim
+    strcpy(p, "runtime" "\\" "defaults.vim");
+    if (FileExists(buf))
+    {
+	p[ARRAY_LENGTH("runtime")] = 0;		// Cut "defaults.vim"
+	return;
+    }
+    // Not found
+    buf[0] = 0;
+    return;
 }
 
     WCHAR *
@@ -923,10 +959,10 @@ BOOL CALLBACK CShellExt::EnumWindowsProc(HWND hWnd, LPARAM lParam)
     // No child window ???
     // if (GetParent(hWnd)) return TRUE;
     // Class name should be Vim, if failed to get class name, return
-    if (GetClassName(hWnd, temp, sizeof(temp)) == 0)
+    if (GetClassName(hWnd, temp, ARRAY_LENGTH(temp)) == 0)
 	return TRUE;
     // Compare class name to that of vim, if not, return
-    if (_strnicmp(temp, "vim", sizeof("vim")) != 0)
+    if (_strnicmp(temp, "vim", ARRAY_LENGTH("vim")) != 0)
 	return TRUE;
     // First check if the number of vim instance exceeds MAX_HWND
     CShellExt *cs = (CShellExt*) lParam;
@@ -942,7 +978,7 @@ BOOL CALLBACK CShellExt::EnumWindowsProc(HWND hWnd, LPARAM lParam)
 BOOL CShellExt::LoadMenuIcon()
 {
     char vimExeFile[BUFSIZE];
-    getGvimName(vimExeFile, 1);
+    getGvimName(vimExeFile, TRUE);
     if (vimExeFile[0] == '\0')
 	return FALSE;
     HICON hVimIcon;


### PR DESCRIPTION
Vim itself supports certain runtime directory structures.
However, GvimExt supports only one type of them.

Check three types of runtime directory structures.

1. gvim.exe is in runtimedir.
2. gvim.exe is in the parent of runtimedir.
   runtimedir is "vimXX".
3. gvim.exe is in the parent of runtimedir.
   runtimedir is "runtime".

This is a preparation for https://github.com/vim/vim-win32-installer/issues/356