### PR TITLE
Fix sixel encoder dropping rightmost pixels in a band

### DIFF
--- a/src/sixel.c
+++ b/src/sixel.c
@@ -598,7 +598,8 @@ sixel_encode(image_rgb_T *img)
 		{
 		    if (x < band_state->xmin[pix])
 			band_state->xmin[pix] = x;
-		    band_state->xmax[pix] = x;
+		    if (x > band_state->xmax[pix])
+			band_state->xmax[pix] = x;
 		}
 		band_state->bits[(size_t)pix * width + x] |= rowmask;
 	    }


### PR DESCRIPTION
The sixel encoder tracks the per-band x range of each colour while filling the band bitmask row by row, but xmax was updated with an unconditional assignment, so it ended up holding the rightmost x of the last row containing the colour rather than the maximum across all six rows. Pixels to the right of that were never emitted, and with P2=1 they stay transparent, which shows up as dark gaps along edges of shapes that narrow toward the bottom, for example the lower-right arc of a circle (found via mattn/vim-xeyes, where the right eye's lower-right outline went missing). The fix updates xmax only when the new x is greater, mirroring the existing xmin handling. Verified by capturing the emitted sixel sequences from a pty and decoding them: the previously dropped ring and white pixels on the lower-right are now all present.

Follow-up to 9.2.0612.

Before
<img width="66" height="38" alt="image" src="https://github.com/user-attachments/assets/bc857319-3f39-4698-9b8a-6f3236db8ed3" />

After
<img width="57" height="40" alt="image" src="https://github.com/user-attachments/assets/3bd9f505-a0bc-4354-a92b-debba030c77d" />
