### PR TITLE
fix(test): xxd explicit dash for portability

### DIFF
--- a/src/testdir/test_xxd.vim
+++ b/src/testdir/test_xxd.vim
@@ -712,7 +712,7 @@ func Test_xxd_color2()
 
   let $PS1='$ '
   " This needs dash, plain bashs sh does not seem to work :(
-  let buf = RunVimInTerminal('', #{rows: 20, cmd: 'sh'})
+  let buf = RunVimInTerminal('', #{rows: 20, cmd: 'dash'})
   call term_sendkeys(buf,  s:xxd_cmd .. " -R never  < XXDfile_colors\<cr>")
   call TermWait(buf)
   redraw


### PR DESCRIPTION
Test is already checking for dash executable, but failing on distros not defaulting to /bin/sh as dash.

Explicit dash will make it portable and deterministic.