### PR TITLE
'autoindent' not stripped with virtualedit=onemore

### DIFF
--- a/src/edit.c
+++ b/src/edit.c
@@ -2670,6 +2670,8 @@ stop_insert(
 		curwin->w_cursor.col = strip_col;
 		for (;;)
 		{
+		    if (gchar_cursor() == NUL && curwin->w_cursor.col > 0)
+			--curwin->w_cursor.col;
 		    cc = gchar_cursor();
 		    if (!VIM_ISWHITE(cc))
 			break;

--- a/src/testdir/test_virtualedit.vim
+++ b/src/testdir/test_virtualedit.vim
@@ -788,4 +788,18 @@ func Test_set_virtualedit_on_mode_change()
   bwipe!
 endfunc
 
+func Test_strip_autoindent_with_virtualedit_onemore()
+  new
+  setlocal autoindent virtualedit=onemore
+  call feedkeys("i   x\<CR>\<Esc>", 'tnix')
+  call assert_equal(['   x', ''], getline(1, '$'))
+
+  %delete _
+  setlocal virtualedit&
+  call feedkeys("i   x\<CR>\<Esc>", 'tnix')
+  call assert_equal(['   x', ''], getline(1, '$'))
+
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  'autoindent' not stripped with virtualedit=onemore (after
          9.2.0510).
Solution: Restore the decrement of cursor column when it's on NUL.

fixes: neovim/neovim#40183
