### PR TITLE
runtime(syntax-tests): Rename test files on demand

### DIFF
--- a/runtime/syntax/testdir/README.txt
+++ b/runtime/syntax/testdir/README.txt
@@ -26,9 +26,12 @@ Creating a syntax plugin test
 -----------------------------
 
 Create a source file in the language you want to test in the "input"
-directory.  Use the filetype name as the base and a file name extension
+directory.  Use the filetype name as the base and a filename extension
 matching the filetype.  Let's use Java as an example.  The file would then be
-"input/java.java".
+"input/java.java".  As another example, consider Gitignore.  Since there is no
+established filename extension for this filetype, use the filetype name for
+its base AND filename extension, "input/gitignore.gitignore", as the first
+step.
 
 Make sure to include some interesting constructs with plenty of complicated
 highlighting.  Optionally, pre-configure the testing environment by including
@@ -47,6 +50,10 @@ Continuing the Java example:
 	// VIM_TEST_SETUP let g:java_space_errors = 1
 	// VIM_TEST_SETUP let g:java_minlines = 5
 	class Test { }
+
+Continuing the Gitignore example, give the file a valid name as the last step:
+
+	# VIM_TEST_SETUP call DeferRenamingTestFileTo('.gitignore')
 
 As an alternative, setup commands can be included in an external Vim script
 file in the "input/setup" directory.  This script file must have the same base

--- a/runtime/syntax/testdir/input/setup/java_module_info.vim
+++ b/runtime/syntax/testdir/input/setup/java_module_info.vim
@@ -1,30 +1,3 @@
-vim9script
-
-# Test filenames are required to begin with the filetype name prefix,
-# whereas the name of a Java module declaration must be "module-info".
-const name_a: string = 'input/java_module_info.java'
-const name_b: string = 'input/module-info.java'
-
-def ChangeFilename()
-    exec 'saveas! ' .. name_b
-enddef
-
-def RestoreFilename()
-    exec 'saveas! ' .. name_a
-    delete(name_b)
-enddef
-
-autocmd_add([{
-    replace:	true,
-    group:	'java_syntax_tests',
-    event:	'BufEnter',
-    pattern:	name_a,
-    cmd:	'ChangeFilename()',
-    once:	true,
-}, {
-    group:	'java_syntax_tests',
-    event:	['BufLeave', 'ExitPre'],
-    pattern:	name_b,
-    cmd:	'RestoreFilename()',
-    once:	true,
-}])
+" Test filenames are required to begin with the filetype name prefix,
+" whereas the name of a Java module declaration must be "module-info".
+call DeferRenamingTestFileTo('module-info.java')

--- a/runtime/syntax/testdir/runtest.vim
+++ b/runtime/syntax/testdir/runtest.vim
@@ -253,6 +253,8 @@ func RunTest()
     " Track the cursor progress through a syntax test file so that any
     " degenerate input can be reported.  Each file will have its own cursor.
     let s:cursor = 1
+    " Give a new name to a file-associated buffer on demand.
+    let s:new_fname = ''
 
     " extra info for shell variables
     func ShellInfo()
@@ -294,13 +296,49 @@ func RunTest()
 	exe substitute(getline(lnum), '\C.*\<VIM_TEST_SETUP\>', '', '')
       endfor
       call cursor(1, 1)
+      let [old_name, new_name] = s:ResolveFilenames()
+      call s:ChangeFilenameTo(new_name)
       " BEGIN [runtime/defaults.vim]
       " Also, disable italic highlighting to avoid issues on some terminals.
       set display=lastline ruler scrolloff=5 t_ZH= t_ZR=
       syntax on
       " END [runtime/defaults.vim]
+      call s:RestoreFilename(new_name, old_name)
       redraw!
     endfunc
+
+    def s:ChangeFilenameTo(name: string)
+      if !empty(name)
+	exe 'saveas! ' .. name
+      endif
+    enddef
+
+    def s:RestoreFilename(new_name: string, old_name: string)
+      if !empty(new_name) && !empty(old_name)
+	exe 'saveas! ' .. old_name
+	delete(new_name)
+      endif
+    enddef
+
+    def s:ResolveFilenames(): tuple<string, string>
+      if !empty(new_fname)
+	const old_name: string = fnamemodify(bufname(), ':.')
+	# Get a platform-independent pathname prefix, cf. "expand('%:p:h') .. '/'".
+	const new_name: string = strpart(
+	    old_name,
+	    0,
+	    strridx(old_name, fnamemodify(bufname(), ':t'))) ..
+	  new_fname
+	return (old_name, new_name)
+      else
+	return ("", "")
+      endif
+    enddef
+
+    def DeferRenamingTestFileTo(name: string)
+      # Strip any leading pathname and mask the filenames of '.' and '..'.
+      new_fname = substitute(fnamemodify(name, ':t'), '^\.\.\=$', '', '')
+    enddef
 
     def s:AssertCursorForwardProgress(): bool
       const curnum: number = line('.')


### PR DESCRIPTION
The current scheme for naming syntax plugin tests expects  
a filetype name prefix and an associated filename extension.  
However, many configurational filetypes, e.g. Gitignore,  
lack any established filename extension.  Factor out the  
available file-renaming routine and offer a convenience  
function to work around this limitation.

For example, put in a `VIM_TEST_SETUP` aware context:
```
call DeferRenamingTestFileTo('.gitignore')
```
