### PR TITLE
fix: prevent integer overflow in read_tree_node bounds check

### DIFF
--- a/src/spellfile.c
+++ b/src/spellfile.c
@@ -1670,7 +1670,7 @@ read_tree_node(
     if (len <= 0)
 	return SP_TRUNCERROR;
 
-    if (startidx + len >= maxidx)
+    if (len >= maxidx - startidx)
 	return SP_FORMERROR;
     byts[idx++] = len;
 


### PR DESCRIPTION
The bounds check at spellfile.c:1673 uses signed integer addition which can overflow when startidx approaches INT_MAX, allowing out-of-bounds heap writes.

Replace overflow-prone addition with safe subtraction:
  OLD: if (startidx + len >= maxidx)
  NEW: if (len >= maxidx - startidx)

The subtraction cannot overflow because both operands are valid indices. This maintains the original >= semantics while preventing integer overflow.