### PR TITLE
fix: prevent infinite loop in barline_parse continuation parsing

### DIFF
--- a/src/viminfo.c
+++ b/src/viminfo.c
@@ -1074,9 +1074,9 @@ barline_parse(vir_T *virp, char_u *text, garray_T *values)
 		    // Get length of text, excluding |< and NL chars.
 		    n = STRLEN(virp->vir_line);
 		    while (n > 0 && (virp->vir_line[n - 1] == NL
-				     || virp->vir_line[n - 1] == CAR))
+					 || virp->vir_line[n - 1] == CAR))
 			--n;
-		    if (n <= 2)
+		    if (n < 2)
 		    {
 			// Invalid continuation line: no usable content
 			// between "|<" and the newline.

--- a/src/viminfo.c
+++ b/src/viminfo.c
@@ -1074,8 +1074,15 @@ barline_parse(vir_T *virp, char_u *text, garray_T *values)
 		    // Get length of text, excluding |< and NL chars.
 		    n = STRLEN(virp->vir_line);
 		    while (n > 0 && (virp->vir_line[n - 1] == NL
-					     || virp->vir_line[n - 1] == CAR))
+				     || virp->vir_line[n - 1] == CAR))
 			--n;
+		    if (n <= 2)
+		    {
+			// Invalid continuation line: no usable content
+			// between "|<" and the newline.
+			vim_free(buf);
+			return TRUE;
+		    }
 		    n -= 2;
 		    if (n > todo)
 		    {


### PR DESCRIPTION
When a viminfo continuation line is exactly '|<\n' with no content, n becomes 0 after stripping. The loop 'for (todo = len; todo > 0; todo -= n)' never decrements todo, causing infinite loop until EOF.

Add guard after newline stripping: if n <= 2 (only prefix, no content), abort parsing by freeing buffer and returning TRUE.