### PR TITLE
the % command does not skip parens in comments

### DIFF
--- a/runtime/doc/motion.txt
+++ b/runtime/doc/motion.txt
@@ -1294,9 +1294,13 @@ remembered.
 			quotes).  Note that this works fine for C, but not for
 			Perl, where single quotes are used for strings.
 
-			Nothing special is done for matches in comments.  You
-			can either use the matchit plugin |matchit-install| or
-			put quotes around matches.
+			When in addition 'comments' defines C-style "//" or
+			"/*" comments, parens and braces inside such comments
+			are skipped, like the |=| operator does.  This does
+			not happen when the cursor is inside a comment, so a
+			match inside that comment can still be found.
+			Otherwise you can use the matchit plugin
+			|matchit-install| or put quotes around matches.
 
 			No count is allowed, {count}% jumps to a line {count}
 			percentage down the file |N%|.  Using '%' on

--- a/runtime/doc/version9.txt
+++ b/runtime/doc/version9.txt
@@ -52642,6 +52642,8 @@ Other ~
 - |:command-completion-customlist| can return a list of dictionaries with
   kind/menu/info/abbr for the popup menu.
 - |C-indenting| detects comments better.
+- The |%| command skips parens inside comments when 'comments' defines
+  C-style "//" or "/*" comments.
 - The |package-hlyank| can now optionally highlight the last put region as
   well.
 - New argument handling for user commands |:command-nargs| using the "-nars=_"

--- a/src/normal.c
+++ b/src/normal.c
@@ -4621,6 +4621,30 @@ nv_brackets(cmdarg_T *cap)
 }
 
 /*
+ * Return TRUE when 'comments' defines a C-style line ("//") or block comment.
+ * This is when "%" should skip matching parens in comments, like the "="
+ * operator does.
+ */
+    static bool
+buf_has_cstyle_comments(void)
+{
+    char_u	*list;
+    char_u	part_buf[COM_MAX_LEN];	// buffer for one 'comments' part
+
+    for (list = curbuf->b_p_com; *list; )
+    {
+	char_u	*string;
+
+	(void)copy_option_part(&list, part_buf, COM_MAX_LEN, ",");
+	string = vim_strchr(part_buf, ':');	// flags and comment leader
+	if (string != NULL && string[1] == '/'
+				    && (string[2] == '/' || string[2] == '*'))
+	    return true;
+    }
+    return false;
+}
+
+/*
  * Handle Normal mode "%" command.
  */
     static void
@@ -4659,9 +4683,23 @@ nv_percent(cmdarg_T *cap)
     }
     else		    // "%" : go to matching paren
     {
+	int	flags = 0;
+
+	// Skip matching parens inside C-style comments, like the "=" operator
+	// does, but not when "%" is in 'cpoptions' (Vi-compatible) or the
+	// cursor sits in a line comment (so a match there can still be found).
+	if (vim_strchr(p_cpo, CPO_MATCH) == NULL && buf_has_cstyle_comments())
+	{
+	    int	comment_col = check_linecomment(ml_get_curline());
+
+	    if (comment_col == MAXCOL
+			   || curwin->w_cursor.col < (colnr_T)comment_col)
+		flags = FM_SKIPCOMM;
+	}
+
 	cap->oap->motion_type = MCHAR;
 	cap->oap->use_reg_one = TRUE;
-	if ((pos = findmatch(cap->oap, NUL)) == NULL)
+	if ((pos = findmatchlimit(cap->oap, NUL, flags, 0)) == NULL)
 	    clearopbeep(cap->oap);
 	else
 	{

--- a/src/testdir/test_normal.vim
+++ b/src/testdir/test_normal.vim
@@ -3896,6 +3896,70 @@ func Test_normal_percent_jump()
   bwipe!
 endfunc
 
+" Test that "%" skips parens inside comments when 'comments' defines C-style
+" "//" or "/*" comments.
+func Test_normal_percent_skip_comment()
+  new
+  setlocal comments=s1:/*,mb:*,ex:*/,://
+
+  " Forward: skip a ")" inside a // comment, match the real one.
+  silent! %delete _
+  call setline(1, ['foo(  // )', ');'])
+  call cursor(1, 4)
+  normal %
+  call assert_equal([2, 1], [line('.'), col('.')])
+
+  " Forward: skip a ")" inside a /* */ comment, match the real one.
+  silent! %delete _
+  call setline(1, ['bar( /* ) */ x)'])
+  call cursor(1, 4)
+  normal %
+  call assert_equal([1, 15], [line('.'), col('.')])
+
+  " Backward: skip a "(" inside a // comment, match the real one.
+  silent! %delete _
+  call setline(1, ['( // (', ')'])
+  call cursor(2, 1)
+  normal %
+  call assert_equal([1, 1], [line('.'), col('.')])
+
+  " Cursor inside a // comment: a match inside that comment is still found.
+  silent! %delete _
+  call setline(1, ['x // ( y )'])
+  call cursor(1, 6)
+  normal %
+  call assert_equal([1, 10], [line('.'), col('.')])
+
+  " Cursor inside a /* */ comment: a match inside that comment is still found.
+  silent! %delete _
+  call setline(1, ['/* a ( b ) c */'])
+  call cursor(1, 6)
+  normal %
+  call assert_equal([1, 10], [line('.'), col('.')])
+
+  " When 'comments' has no C-style comments the parens are not skipped.
+  setlocal comments=b:#
+  silent! %delete _
+  call setline(1, ['foo(  // )', ');'])
+  call cursor(1, 4)
+  normal %
+  call assert_equal([1, 10], [line('.'), col('.')])
+
+  " With "%" in 'cpoptions' Vi-compatible matching is used and the parens
+  " inside comments are not skipped.
+  let save_cpo = &cpoptions
+  setlocal comments=s1:/*,mb:*,ex:*/,://
+  set cpoptions+=%
+  silent! %delete _
+  call setline(1, ['foo(  // )', ');'])
+  call cursor(1, 4)
+  normal %
+  call assert_equal([1, 10], [line('.'), col('.')])
+  let &cpoptions = save_cpo
+
+  bwipe!
+endfunc
+
 " Test for << and >> commands to shift text by 'shiftwidth'
 func Test_normal_shift_rightleft()
   new


### PR DESCRIPTION
```
Problem:  The "%" command jumps to parens and braces inside comments,
          unlike the "=" operator (cindent), which ignores them.
Solution: When 'comments' defines C-style comments and "%" is not in
          'cpoptions', skip matching parens inside such comments, except
          when the cursor is inside a comment so a match there can still
          be found.
```

fixes: #20329
related: #20111

---

## Problem

The `%` command jumps to parens and braces inside comments, unlike the `=` operator (cindent), which ignores them. So on code like

```c
foo(  // )
);
```

`%` on the first `(` jumps to the `)` inside the `//` comment instead of the real one on the next line.

## Background

`FM_SKIPCOMM` has been implemented in `findmatchlimit()` since v9.2.0447 (#20111), where it was added so that cindent ignores `{`/`}`/parens inside `//` and `/* */` comments. So the `=` operator already skips comment parens.

The same behavior for `%` was requested afterwards in #20329 and closed with a pointer to the matchit plugin — even though the infrastructure to do it cleanly (`FM_SKIPCOMM`) already existed at that point. So this is not a new matching feature: it is a small, natural application of code that already landed for `=`/cindent, and it makes the two consistent.

## Solution

When `'comments'` defines C-style `//` or `/*` comments and `%` is not in `'cpoptions'`, `nv_percent()` calls `findmatchlimit()` with `FM_SKIPCOMM` instead of `findmatch()`. The rule, matching what a user expects:

- if the paren the cursor acts on is **inside** a comment, jump to its match **inside** that comment (a match there can still be found);
- if it is **outside** a comment, jump to its match, **ignoring** parens inside comments.

The "inside a comment" case is handled naturally: for a line comment the flag is not set when the cursor is past the comment leader, and for a block comment `FM_SKIPCOMM` does not skip the comment the cursor already sits in. Buffers without C-style comments are unaffected, so non-C filetypes keep the current behavior.

## Why gate on `cpo-%`

Skipping parens inside comments is a slightly backwards-incompatible change for anyone who relied on `%` reaching them. Rather than adding a new `'cpoptions'` flag, this reuses the existing `%` flag (`cpo-%`), which already toggles Vi-compatible vs Vim-smart `%` matching: with `%` excluded (the Vim default) `findmatchlimit()` already ignores parens in quotes, recognizes `#if`/`#endif`, and matches `/*` with `*/`. Skipping parens inside comments fits as one more of those. With `%` present in `'cpoptions'` the old Vi-compatible behavior is kept, so the change is opt-out.

## Notes

- Reuses the merged `FM_SKIPCOMM` from #20111 (v9.2.0447); no new matching logic.
- Gated on both `'comments'` (so it only applies to filetypes with C-style comments) and `%` not being in `'cpoptions'` (so Vi-compatible matching keeps the old behavior).
- Tests in `Test_normal_percent_skip_comment` cover forward/backward skipping, cursor inside a `//` and a `/* */` comment, the no-C-style-comments case, and the `cpo+=%` case where parens are not skipped. `make test_normal` passes.
- `motion.txt` documents the new behavior under the `cpo-%` paragraph.