### PR TITLE
Reject illegal characters in dict key names when using dot notation

### DIFF
--- a/src/testdir/test_vim9_expr.vim
+++ b/src/testdir/test_vim9_expr.vim
@@ -3156,6 +3156,10 @@ def Test_expr9_dict()
   v9.CheckDefFailure(['var x = ({'], 'E723:', 2)
   v9.CheckScriptFailure(['vim9script', 'var x = ({'], 'E723:', 2)
   v9.CheckDefExecAndScriptFailure(['{}[getftype("file")]'], 'E716: Key not present in Dictionary: ""', 1)
+
+  # invalid dot notation key name
+  v9.CheckDefAndScriptFailure(['var x = { "a#b": 1 }', 'x.a#b'], ['E488:', 'E716:'], 2)
+  v9.CheckDefAndScriptFailure(['var x = { "a:b": 1 }', 'x.a:b'], ['E488:', 'E716:'], 2)
 enddef
 
 def Test_expr9_dict_vim9script()

--- a/src/vim9expr.c
+++ b/src/vim9expr.c
@@ -2860,9 +2860,8 @@ compile_subscript(
 		    return FAIL;
 		}
 		p = *arg;
-		if (eval_isdictc(*p))
-		    while (eval_isnamec(*p))
-			MB_PTR_ADV(p);
+		while (eval_isdictc(*p))
+		    MB_PTR_ADV(p);
 		if (p == *arg)
 		{
 		    semsg(_(e_syntax_error_at_str), *arg);


### PR DESCRIPTION
Problem:  In a Vim9 function definition, colons and hashes are accepted in a dict key name when using dot notation.
Solution: Restrict dict key names used with dot notaton to alphanumeric and underscore characters, as documented.
