### PR TITLE
0x80 and 0x9b byte not unescaped when checking for valid abbr

### DIFF
--- a/src/map.c
+++ b/src/map.c
@@ -662,18 +662,24 @@ do_map(
 		{
 		    int	first, last;
 		    int	same = -1;
+		    char_u *p_char;
 
-		    first = vim_iswordp(keys);
+		    p = keys;
+		    p_char = mb_unescape(&p);
+		    if (p_char == NULL)
+			p_char = p++;
+		    first = vim_iswordp(p_char);
 		    last = first;
-		    p = keys + (*mb_ptr2len)(keys);
 		    n = 1;
 		    while (p < keys + len)
 		    {
-			++n;			// nr of (multi-byte) chars
-			last = vim_iswordp(p);	// type of last char
+			++n;			     // nr of (multi-byte) chars
+			p_char = mb_unescape(&p);
+			if (p_char == NULL)
+			    p_char = p++;
+			last = vim_iswordp(p_char);  // type of last char
 			if (same == -1 && last != first)
-			    same = n - 1;	// count of same char type
-			p += (*mb_ptr2len)(p);
+			    same = n - 1;	     // count of same char type
 		    }
 		    if (last && n > 2 && same >= 0 && same < n - 1)
 		    {

--- a/src/testdir/test_mapping.vim
+++ b/src/testdir/test_mapping.vim
@@ -5,11 +5,29 @@ import './util/vim9.vim' as v9
 
 func Test_abbreviation()
   new
-  " abbreviation with 0x80 should work
+
+  " abbreviation with 0x80 (full-id)
   inoreab чкпр   vim
   call feedkeys("Goчкпр \<Esc>", "xt")
   call assert_equal('vim ', getline('$'))
   iunab чкпр
+
+  " abbreviation with 0x80 (non-id)
+  inoreab abc⁀ abc^
+  inoreab ⁀ ^
+  call feedkeys("Goabc⁀ def⁀ ⁀ \<Esc>", "xt")
+  call assert_equal('abc^ def⁀ ^ ', getline('$'))
+  iunab abc⁀
+  iunab ⁀
+
+  " abbreviation with 0x9b (non-id)
+  inoreab abc； abc;
+  inoreab ； ;
+  call feedkeys("Goabc； def； ； \<Esc>", "xt")
+  call assert_equal('abc; def； ; ', getline('$'))
+  iunab abc；
+  iunab ；
+
   bwipe!
 endfunc
 


### PR DESCRIPTION
Problem:  0x80 and 0x9b byte not unescaped when check for valid abbr.
Solution: Use mb_unescape().

fixes: #20506
