### PR TITLE
filetype: tf files sometimes incorrectly recognized

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -1498,14 +1498,25 @@ enddef
 
 # Determine if a *.tf file is TF mud client or terraform
 export def FTtf()
-  var numberOfLines = line('$')
-  for i in range(1, numberOfLines)
-    var currentLine = trim(getline(i))
-    var firstCharacter = currentLine[0]
-    if firstCharacter !=? ";" && firstCharacter !=? "/" && firstCharacter !=? ""
-      setf terraform
-      return
+  if exists("g:filetype_tf")
+    exe "setf " .. g:filetype_tf
+    return
+  endif
+
+  var continuation: bool = false
+  for lnum in range(1, min([line("$"), 100]))
+    var line = getline(lnum)
+    # TF supports backslash line continuation, so a continued line may begin
+    # with any character.  Only test the first character of a line that does
+    # not continue a previous one.
+    if !continuation
+      var firstchar = trim(line)[0]
+      if firstchar !=? ";" && firstchar !=? "/" && firstchar !=? ""
+        setf terraform
+        return
+      endif
     endif
+    continuation = line =~ '\\$'
   endfor
   setf tf
 enddef

--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -1,4 +1,4 @@
-*filetype.txt*	For Vim version 9.2.  Last change: 2026 May 29
+*filetype.txt*	For Vim version 9.2.  Last change: 2026 Jun 13
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -183,6 +183,7 @@ variables can be used to overrule the filetype used for certain extensions:
 	*.sys		g:filetype_sys
 	*.sh		g:bash_is_sh		|ft-sh-syntax|
 	*.tex		g:tex_flavor		|ft-tex-plugin|
+	*.tf		g:filetype_tf
 	*.typ		g:filetype_typ
 	*.v		g:filetype_v
 	*.w		g:filetype_w		|ft-cweb-syntax|

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -2546,6 +2546,25 @@ func Test_tf_file_v2()
   call assert_equal('terraform', &filetype)
   bwipe!
 
+  " A backslash continuation line may start with any character
+  let lines =<< trim END
+    /def greet = \
+        plain words that start the continued line
+    ;a comment
+  END
+  call writefile(lines, "Xfile.tf", "D")
+  split Xfile.tf
+  call assert_equal('tf', &filetype)
+  bwipe!
+
+  " The user override wins regardless of content
+  let g:filetype_tf = 'terraform'
+  call writefile([';;; looks like tf'], 'Xfile.tf', 'D')
+  split Xfile.tf
+  call assert_equal('terraform', &filetype)
+  bwipe!
+  unlet g:filetype_tf
+
   filetype off
 endfunc
 


### PR DESCRIPTION
Problem:  filetype: tf files sometimes incorrectly recognized
          (Christian Robinson)
Solution: Add support for g;filetype_tf variable to override detection,
          re-write the filetype detection loop

closes: #PR

Supported by AI