### PR TITLE
perf(gtk3-wayland): CAIRO_CONTENT_COLOR over ALPHA

### DIFF
--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -814,7 +814,7 @@ scale_factor_event(GtkWidget *widget,
     gtk_window_get_size(GTK_WINDOW(gui.mainwin), &w, &h);
     gui.surface = gdk_window_create_similar_surface(
 	    gtk_widget_get_window(widget),
-	    CAIRO_CONTENT_COLOR_ALPHA,
+	    CAIRO_CONTENT_COLOR,
 	    w, h);
 
     int	    usable_height = h;
@@ -2900,7 +2900,7 @@ drawarea_realize_cb(GtkWidget *widget, gpointer data UNUSED)
 #if GTK_CHECK_VERSION(3,0,0)
     gui.surface = gdk_window_create_similar_surface(
 	    gtk_widget_get_window(widget),
-	    CAIRO_CONTENT_COLOR_ALPHA,
+	    CAIRO_CONTENT_COLOR,
 	    gtk_widget_get_allocated_width(widget),
 	    gtk_widget_get_allocated_height(widget));
 #else
@@ -3035,7 +3035,7 @@ drawarea_configure_event_cb(GtkWidget	      *widget,
 
     gui.surface = gdk_window_create_similar_surface(
 	    gtk_widget_get_window(widget),
-	    CAIRO_CONTENT_COLOR_ALPHA,
+	    CAIRO_CONTENT_COLOR,
 	    event->width, event->height);
 
     gtk_widget_queue_draw(widget);


### PR DESCRIPTION
Partially addresses: #18002

Reduces the processing load significantly, since it contains no alpha channel.

https://www.cairographics.org/manual/cairo-cairo-surface-t.html#CAIRO-CONTENT-COLOR-ALPHA:CAPS

Tested on aarch64 with a rpi5 and 4k/hidpi integer scaling.

Slowest gvim I have encountered yet.

Slow symptoms;
* Startup
* Scrolling
* Drawing text
* Loading new buffers

*Note:* Aware we are moving gtk3 into maintenance phase, however I think this will make it usable for longer. The alpha channel is **not** for truecolor text, its for gtk widgets - *we don't support opacity in gtk3 and don't intend to* - so it remains unused.