### PR TITLE
fix(gtk): scrollbar prevents WinScrolled, refocus gui

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -4141,6 +4141,8 @@ gui_drag_scrollbar(scrollbar_T *sb, long value, int still_dragging)
 	// Keep the "dragged_wp" value until after the scrolling, for when the
 	// mouse button is released.  GTK2 doesn't send the button-up event.
 	gui.dragged_wp = NULL;
+	// WinScrolled event
+	gui_focus_change(TRUE);
 #endif
     }
 


### PR DESCRIPTION
`WinScrolled` is one of the latest events Bram did.

I simply think the gui was never considered.

I can't see any reason why the scrollbars in gui should not trigger `WinScrolled`, they follow the window that is focused - which aligns with both function and intention.

Therefore refocus the gui once scrollbar is dragged, which triggers `WinScrolled` timely as gui scrollbar is scrolled - instead of delaying until pressing inside `gui.drawarea` (buffer).

cc @mattn (for gtk4 notes)