### PR TITLE
fix(statusline): prevent various buffer overflows with item groups

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -4864,7 +4864,9 @@ build_stl_str_hl_local(
 		p = p - n + 1;
 
 		// Fill up space left over by half a double-wide char.
-		while (++l < stl_items[stl_groupitem[groupdepth]].stl_minwid)
+		int minwid_fixed = MIN(stl_items[stl_groupitem[groupdepth]].stl_minwid,
+				       stl_items[stl_groupitem[groupdepth]].stl_maxwid);
+		while (++l < minwid_fixed)
 		    MB_CHAR2BYTES(fillchar, p);
 
 		// correct the start of the items for the truncation
@@ -4880,25 +4882,30 @@ build_stl_str_hl_local(
 	    {
 		// fill
 		n = stl_items[stl_groupitem[groupdepth]].stl_minwid;
+		int fillchar_len = MB_CHAR2LEN(fillchar);
 		if (n < 0)
 		{
 		    // fill by appending characters
 		    n = 0 - n;
-		    while (l++ < n && p + 1 < out + outlen)
+		    while (l++ < n && p + fillchar_len < out + outlen)
 			MB_CHAR2BYTES(fillchar, p);
 		}
 		else
 		{
 		    // fill by inserting characters
-		    l = (n - l) * MB_CHAR2LEN(fillchar);
-		    mch_memmove(t + l, t, (size_t)(p - t));
+		    n = n - l;
+		    l = n * fillchar_len;
 		    if (p + l >= out + outlen)
-			l = (long)((out + outlen) - p - 1);
+		    {
+			n = (long)((out + outlen) - p - 1) / fillchar_len;
+			l = n * fillchar_len;
+		    }
+		    mch_memmove(t + l, t, (size_t)(p - t));
 		    p += l;
+		    for ( ; n > 0; n--)
+			MB_CHAR2BYTES(fillchar, t);
 		    for (n = stl_groupitem[groupdepth] + 1; n < curitem; n++)
 			stl_items[n].stl_start += l;
-		    for ( ; l > 0; l--)
-			MB_CHAR2BYTES(fillchar, t);
 		}
 	    }
 	    continue;

--- a/src/testdir/test_statusline.vim
+++ b/src/testdir/test_statusline.vim
@@ -120,10 +120,30 @@ func Test_statusline()
   call assert_match('^    Xstatusline\s*$', s:get_statusline())
   set statusline=%.6(%f%)
   call assert_match('^<sline\s*$', s:get_statusline())
+  set statusline=%.5(1234567%),%2.5(1234567%),%5.5(1234567%),%50.5(1234567%)
+  call assert_match('^<4567,<4567,<4567,<4567\s*$', s:get_statusline())
   set statusline=%14f
   call assert_match('^   Xstatusline\s*$', s:get_statusline())
   set statusline=%.4L
   call assert_match('^10>3\s*$', s:get_statusline())
+  for filler in ['-', '∙']
+    exec 'set fillchars+=stl:'..filler
+    set statusline=%-5(x%),%-5.(x%),%-5.5(x%),%-5.10(x%);
+    call assert_match(substitute('^x____,x____,x____,x____;_*$', '_', filler, 'g'), s:get_statusline())
+    set statusline=%5(x%),%5.(x%),%5.5(x%),%5.10(x%);
+    call assert_match(substitute('^____x,____x,____x,____x;_*$', '_', filler, 'g'), s:get_statusline())
+    set statusline=%.5(12🙂345%),%4.5(12🙂345%),%5.5(12🙂345%),%50.5(12🙂345%);
+    call assert_match(substitute('^<345,<345,<345_,<345_;_*$', '_', filler, 'g'), s:get_statusline())
+  endfor
+  if has('linux')
+    " This assumes MAXPATHL is 4096 bytes.
+    set stl=%{%repeat('x',4096-6)%}%10(X%)
+    set fillchars+=stl:-
+    call assert_match('^<x\+----X$', s:get_statusline())
+    set fillchars+=stl:∙
+    call assert_match('^<x\+∙X$', s:get_statusline())
+  endif
+  set fillchars&
 
   " %h: Help buffer flag, text is "[help]".
   " %H: Help buffer flag, text is ",HLP".


### PR DESCRIPTION
The code that handles item group alignment and truncation contains several bugs that can lead to buffer overflows, mostly related to multibyte or multicell characters. See commit message for details.

The most practically relevant bug is that multibyte `fillchars` write over the contents of right-aligned item groups.
For example:
```sh
vim --clean +"set fillchars+=stl:∙ ls=2 stl=%5(X%)"
```
produces `∙∙∙∙<e2>`, the item group content `X` being lost.

see https://github.com/neovim/neovim/pull/40219