### PR TITLE
GTK4: fix crash in gui_mch_menu_hidden

### DIFF
--- a/src/gui_gtk4.c
+++ b/src/gui_gtk4.c
@@ -2685,7 +2685,9 @@ gui_mch_menu_grey(vimmenu_T *menu, int grey)
     void
 gui_mch_menu_hidden(vimmenu_T *menu, int hidden)
 {
-    if (menu->id == 0)
+    // GMenu-based menu items have no real widget, only the (GtkWidget *)1
+    // marker; they cannot be toggled via the widget API.
+    if (menu->id == NULL || menu->id == (GtkWidget *)1)
 	return;
 
     if (hidden)


### PR DESCRIPTION
GTK4 menu items use the `(GtkWidget *)1` sentinel as their id, but `gui_mch_menu_hidden()` only skipped NULL ids and passed the sentinel to `gtk_widget_get_visible()`, causing a crash (`vim -gf`). Skip the sentinel like `gui_mch_menu_grey()` does.