### PR TITLE
popup image: kitty placement remains after clipwindow scroll-out

### DIFF
--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -2965,6 +2965,25 @@ popup_adjust_position(win_T *wp)
     // leaving stray decorations behind.
     if (popup_compute_clipwindow_offsets(wp))
     {
+	if ((wp->w_popup_flags & POPF_HIDDEN) == 0)
+	{
+#ifdef FEAT_IMAGE_KITTY
+	    // delete the kitty placement before hiding, like popup_hide()
+	    popup_image_clear_kitty(wp);
+#endif
+#ifdef FEAT_IMAGE_GDK
+	    if (gui.in_use)
+		gui_gtk4_remove_image(wp);
+#endif
+#ifdef FEAT_IMAGE
+	    if (wp->w_popup_image_data != NULL)
+	    {
+		redraw_all_later(UPD_NOT_VALID);
+		status_redraw_all();
+		popup_mask_refresh = TRUE;
+	    }
+#endif
+	}
 	popup_hide_for_textprop(wp);
 	return;
     }


### PR DESCRIPTION
A clipwindow popup with an image leaves a stale image on the terminal after it scrolls out of view, when the kitty graphics protocol is used.

popup_adjust_position() hides a popup in two places. The textprop scroll-out path already deletes the kitty placement before hiding, but the path that fires when popup_compute_clipwindow_offsets() reports the popup has fully scrolled past a host edge did not. A kitty placement is drawn above the text layer and persists until it is explicitly deleted (sixel pixels are cleared by the next text overwrite, so sixel is unaffected), so the last partially-clipped image stayed on screen.

Delete the kitty placement (and the GTK4 image) and force a full redraw before hiding, mirroring the textprop scroll-out path.

Fixes #20501