### PR TITLE
Vim aborts at startup when built with the example -O2 CFLAGS

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -597,13 +597,19 @@ CClink = $(CC)
 #CFLAGS = -O -Olimit 2000
 #CFLAGS = -O -FOlimit,2000
 
+# Add $(FORTIFY_CFLAGS) to optimizing example lines below: at higher levels
+# (the compiler default with -O) the buffer overflow check aborts Vim on the
+# "x[1] but actually longer" struct-hack arrays (e.g. dictitem di_key).
+# configure adds this automatically; these examples bypass it.
+FORTIFY_CFLAGS = -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1
+
 # Often used for GCC: mixed optimizing, lot of optimizing, debugging
-#CFLAGS = -g -O2 -fno-strength-reduce -Wall -Wshadow -Wmissing-prototypes
-#CFLAGS = -g -O2 -fno-strength-reduce -Wall -Wmissing-prototypes
+#CFLAGS = -g -O2 -fno-strength-reduce -Wall -Wshadow -Wmissing-prototypes $(FORTIFY_CFLAGS)
+#CFLAGS = -g -O2 -fno-strength-reduce -Wall -Wmissing-prototypes $(FORTIFY_CFLAGS)
 #CFLAGS = -g -Wall -Wmissing-prototypes
-#CFLAGS = -O6 -fno-strength-reduce -Wall -Wshadow -Wmissing-prototypes
+#CFLAGS = -O6 -fno-strength-reduce -Wall -Wshadow -Wmissing-prototypes $(FORTIFY_CFLAGS)
 #CFLAGS = -g -DDEBUG -Wall -Wshadow -Wmissing-prototypes
-#CFLAGS = -g -O2 '-DSTARTUPTIME="vimstartup"' -fno-strength-reduce -Wall -Wmissing-prototypes
+#CFLAGS = -g -O2 '-DSTARTUPTIME="vimstartup"' -fno-strength-reduce -Wall -Wmissing-prototypes $(FORTIFY_CFLAGS)
 
 # Use this with GCC to check for mistakes, unused arguments, etc.
 # Note: If you use -Wextra and get warnings in GTK code about function


### PR DESCRIPTION
```
Problem:  Building with an optimizing example CFLAGS line in src/Makefile
          (which bypasses configure) aborts Vim at startup with a buffer
          overflow, because the compiler then defaults _FORTIFY_SOURCE to
          a level >= 2.
Solution: Define FORTIFY_CFLAGS with -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1
          and reference it from the optimizing example CFLAGS lines, the
          same pin configure already applies; at higher levels the check
          false-positives on the "x[1] but actually longer" struct-hack
          arrays.
```

fixes: #20526