### PR TITLE
feat(register): clear altfile (#) register

### DIFF
--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -1338,6 +1338,7 @@ Contains the |alternate-file| for current window
 This register is writeable and changes which buffer CTRL-^ enters.>
 A String is matched against existing buffer names, like |:buffer|: >
     let @# = 'buffer_name'
+Also supports using |file-pattern|.
 Throws |E86| when the buffer number does not exist.
 Throws |E93| when more than one buffer matches, or |E94| when none match.
 Clear the register with empty String: >

--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -1335,10 +1335,10 @@ and ":put" commands and with CTRL-R.
 							*quote_#* *quote#*
 6. Alternate file register "#
 Contains the |alternate-file| for current window
-This register is writeable and changes which buffer CTRL-^ enters.>
+This register is writeable and changes which buffer CTRL-^ enters.
 A String is matched against existing buffer names, like |:buffer|: >
     let @# = 'buffer_name'
-Also supports using |file-pattern|.
+Also supports using buffer number and |file-pattern|.
 Throws |E86| when the buffer number does not exist.
 Throws |E93| when more than one buffer matches, or |E94| when none match.
 Clear the register with empty String: >

--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -1335,15 +1335,10 @@ and ":put" commands and with CTRL-R.
 							*quote_#* *quote#*
 6. Alternate file register "#
 Contains the |alternate-file| for current window
-This register is writeable and changes which buffer CTRL-^ enters: >
-    let @# = 1
-    ...
-    let altbuf = bufnr(@#)
-Throws |E86| when the buffer number does not exist.
+This register is writeable and changes which buffer CTRL-^ enters.>
 A String is matched against existing buffer names, like |:buffer|: >
     let @# = 'buffer_name'
-Patterns using |file-pattern|: >
-    let @# = '*/dir/{foo,bar}*.vim'
+Throws |E86| when the buffer number does not exist.
 Throws |E93| when more than one buffer matches, or |E94| when none match.
 Clear the register with empty String: >
     let @# = ''

--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -1334,7 +1334,7 @@ and ":put" commands and with CTRL-R.
 		feature}
 							*quote_#* *quote#*
 6. Alternate file register "#
-Contains the |alternate-file| for current window
+Contains the |alternate-file| name for current window
 This register is writeable and changes which buffer CTRL-^ enters.
 A String is matched against existing buffer names, like |:buffer|: >
     let @# = 'buffer_name'

--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -1334,19 +1334,19 @@ and ":put" commands and with CTRL-R.
 		feature}
 							*quote_#* *quote#*
 6. Alternate file register "#
-Contains the name of the alternate file for the current window.  It will
-change how the |CTRL-^| command works.
-This register is writable, mainly to allow for restoring it after a plugin has
-changed it.  It accepts buffer number: >
-    let altbuf = bufnr(@#)
+Contains the |alternate-file| for current window
+This register is writeable and changes which buffer CTRL-^ enters: >
+    let @# = 1
     ...
-    let @# = altbuf
-It will give error |E86| if you pass buffer number and this buffer does not
-exist.
-It can also accept a match with an existing buffer name: >
+    let altbuf = bufnr(@#)
+Throws |E86| when the buffer number does not exist.
+A String is matched against existing buffer names, like |:buffer|: >
     let @# = 'buffer_name'
-Error |E93| if there is more than one buffer matching the given name or |E94|
-if none of buffers matches the given name.
+Patterns using |file-pattern|: >
+    let @# = '*/dir/{foo,bar}*.vim'
+Throws |E93| when more than one buffer matches, or |E94| when none match.
+Clear the register with empty String: >
+    let @# = ''
 
 7. Expression register "=			*quote_=* *quote=* *@=*
 This is not really a register that stores text, but is a way to use an

--- a/src/register.c
+++ b/src/register.c
@@ -3152,6 +3152,12 @@ write_reg_contents_ex(
 
     if (name == '#')
     {
+	if (len == 0)
+	{
+	  curwin->w_alt_fnum = 0; // clear altfile
+	  return;
+	}
+
 	buf_T	*buf;
 
 	if (VIM_ISDIGIT(*str))

--- a/src/testdir/test_registers.vim
+++ b/src/testdir/test_registers.vim
@@ -396,6 +396,8 @@ func Test_set_register()
   call assert_equal('Xfile_alt_1', getreg('#'))
   call setreg('#', b2)
   call assert_equal('Xfile_alt_2', getreg('#'))
+  call setreg('#', '')
+  call assert_equal(getreg('#'), '')
 
   let ab = 'regwrite'
   call setreg('=', '')

--- a/src/testdir/test_registers.vim
+++ b/src/testdir/test_registers.vim
@@ -397,7 +397,10 @@ func Test_set_register()
   call setreg('#', b2)
   call assert_equal('Xfile_alt_2', getreg('#'))
   call setreg('#', '')
-  call assert_equal(getreg('#'), '')
+  call assert_equal('', getreg('#'))
+  call setreg('#', 'alt_1')
+  let @# = ''
+  call assert_equal('', getreg('#'))
 
   let ab = 'regwrite'
   call setreg('=', '')


### PR DESCRIPTION
Any reason why this is not possible?

```vim
:edit test1
:edit test2
" # is set to test1 in test2
:call setreg('#', '')
" E93: More than one match for
:let @# = ''
" E93: More than one match for
:call setreg('#', 0)
" not cleared, but also ambigous if a buffer is indeed called '0'
```

I thought this could be useful if you created a plugin managing altfiles, or if you felt like clearing altfile in a buffer.