### PR TITLE
Tweak some documentation style

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -4044,20 +4044,20 @@ getbufvar({buf}, {varname} [, {def}])			*getbufvar()*
 
 
 getbgcolor()						*getbgcolor()*
-		Returns a |List| describing the current background colour
-		as [red, green, blue], each component in the range 0..255.
+		Returns a |List| describing the current background colour as
+		[red, green, blue], each component in the range 0..255.
 
-		In the GUI (or with 'termguicolors' set) the value comes
-		from the |hl-Normal| highlight group's background.  In a
-		terminal it comes from the OSC 11 response (also available
-		as |v:termrbgresp|).
+		In the GUI (or with 'termguicolors' set) the value comes from
+		the |hl-Normal| highlight group's background.  In a terminal
+		it comes from the OSC 11 response (also available as
+		|v:termrbgresp|).
 		Returns [] when no value is available, e.g. before the
 		terminal has answered the OSC 11 query, or when |hl-Normal|
 		has no background colour set.
 
-		Useful when manually crafting RGB image data and you want
-		to flatten alpha onto the same colour the terminal will
-		actually display behind the image.
+		Useful when manually crafting RGB image data and you want to
+		flatten alpha onto the same colour the terminal will actually
+		display behind the image.
 
 		Return type: list<any>
 

--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -486,59 +486,55 @@ setting: >
 BEANCOUNT						*ft-beancount-plugin*
 
 Beancount omni-completion |compl-omni| is provided by beancountcomplete.vim,
-if enabled with |g:beancount_completion_enable|.
+if enabled with g:beancount_completion_enable.
 
 To enable completion of account names, set: >
 	let g:beancount_completion_enable = 1
-
-< Note enabling this may cause beancount to load additional plugin files.
-Only enable for code you trust.
+<
+Note: Enabling this may cause beancount to load additional plugin files.  Only
+enable for code you trust.
 
 Variables:
-*g:beancount_account_completion*
-			Can be either 'default' or 'chunks'.
+g:beancount_account_completion
+			Specify the completion pattern format for the account
+			name.  Can be either "default" or "chunks".
+			Default value: "default"
 
-			Default value: 'default'
-
-*g:beancount_completion_enable*
+g:beancount_completion_enable
 			Enable omni-completion |compl-omni| for accounts.
-
 			Default value: 0
 
-*g:beancount_detailed_first*
-			If non-zero, accounts higher down the hierarchy will be
-			listed first as completions.
-
+g:beancount_detailed_first
+			If non-zero, accounts higher down the hierarchy will
+			be listed first as completions.
 			Default value: 0
 
-*g:beancount_separator_col*
+g:beancount_separator_col
 			The column that the decimal separator is aligned to.
-
 			Default value: 50
 
-*b:beancount_root*
-			Set the root Beancount file. This is used to gather
+b:beancount_root
+			Set the root Beancount file.  This is used to gather
 			values for the completion.
-			If not set, the current file will be used.
-
-			Default value: not set
+			If not set (default), the current file will be used.
 
 
 Commands:
-:AlignCommodity		Adds spaces between an account and commodity so that the
-			decimal points of the commodities all occur in the column
-			given by |g:beancount_separator_col|.  If an amount has no
-			decimal point, the imaginary decimal point to the right
-			of the least significant digit will align.
+:AlignCommodity		Adds spaces between an account and commodity so that
+			the decimal points of the commodities all occur in the
+			column given by g:beancount_separator_col.  If an
+			amount has no decimal point, the imaginary decimal
+			point to the right of the least significant digit will
+			align.
 
-			The command acts on a range, with the default being the
-			current line. If the cursor happens to be inside that
-			range and to the right of the account name, the cursor
-			will be pushed to the right the appropriate amount, so
-			that it remains on the same character.
+			The command acts on a range, with the default being
+			the current line.  If the cursor happens to be inside
+			that range and to the right of the account name, the
+			cursor will be pushed to the right the appropriate
+			amount, so that it remains on the same character.
 
-			The script assumes the use of spaces for alignment. It
-			does not understand tabs.
+			The script assumes the use of spaces for alignment.
+			It does not understand tabs.
 
 :GetContext		Uses bean-doctor context to display the context of the
 			current line.

--- a/runtime/doc/popup.txt
+++ b/runtime/doc/popup.txt
@@ -1171,16 +1171,16 @@ To make the four corners transparent:
 POPUP IMAGE						*popup-image*
 
 A popup window can render an image instead of (or on top of) text by passing
-an "image" dictionary to |popup_create()| or |popup_setoptions()|.  The
-caller supplies an already-decoded raw pixel buffer and Vim emits it through
+an "image" dictionary to |popup_create()| or |popup_setoptions()|.  The caller
+supplies an already-decoded raw pixel buffer and Vim emits it through
 whichever backend is available at runtime:
 
     sixel   DEC sixel DCS sequence on a sixel-capable terminal.
 	    |+image_sixel|.  Detected automatically; the buffer is also
 	    cropped one cell above the screen edge to avoid sixel-induced
 	    terminal scrolling.
-    kitty   kitty graphics protocol APC sequence on terminals that support
-	    it (kitty, ghostty, WezTerm, Konsole, ...).  |+image_kitty|.
+    kitty   kitty graphics protocol APC sequence on terminals that support it
+	    (kitty, ghostty, WezTerm, Konsole, ...).  |+image_kitty|.
 	    Detected by actively querying the terminal.
     GDI     StretchDIBits onto the GUI canvas on the MS-Windows GUI.
 	    |+image_gdi|.
@@ -1190,9 +1190,9 @@ whichever backend is available at runtime:
 	    rendering (only for GTK 4).	|+image_gdk|
 
 Vim itself does NOT link against libpng, libjpeg, libwebp or any image
-decoder.  Format decoding is left to the caller, who can pipe the file
-through any external tool (GraphicsMagick, ImageMagick, ffmpeg, a custom
-converter, ...) and pass the resulting bytes via a |Blob|.
+decoder.  Format decoding is left to the caller, who can pipe the file through
+any external tool (GraphicsMagick, ImageMagick, ffmpeg, a custom converter,
+...) and pass the resulting bytes via a |Blob|.
 
 The "image" dictionary accepts:
     data	|Blob| of bytes.  Length must equal width*height*3 for RGB,
@@ -1205,9 +1205,9 @@ The popup's cell box is derived from the pixel dimensions and the terminal /
 GUI cell metrics, so the caller does not normally have to set "minwidth" /
 "minheight" / "maxwidth" / "maxheight".
 
-For RGBA buffers that need to blend cleanly into the editor's actual
-backdrop the script can call |getbgcolor()| to obtain the current background
-colour as [r, g, b] and pre-composite anti-aliased edges against it.
+For RGBA buffers that need to blend cleanly into the editor's actual backdrop
+the script can call |getbgcolor()| to obtain the current background colour as
+[r, g, b] and pre-composite anti-aliased edges against it.
 
 Minimal RGB example - a 4x4 red square popped at the cursor: >
 	let pixels = repeat([0xff, 0x00, 0x00], 4 * 4)->list2blob()
@@ -1231,11 +1231,10 @@ raw RGB bytes: >
 	      \ })
 
 The image can be replaced at runtime via |popup_setoptions()|.  When the new
-buffer has the same width and height as the current one the pixels are
-swapped in place, which is fast enough to drive frame-by-frame animation
-from a |timer|.  |popup_getoptions()| returns the same dictionary back; the
-"data" entry is a fresh blob copy independent of the popup's internal
-buffer.
+buffer has the same width and height as the current one the pixels are swapped
+in place, which is fast enough to drive frame-by-frame animation from a
+|timer|.  |popup_getoptions()| returns the same dictionary back; the "data"
+entry is a fresh blob copy independent of the popup's internal buffer.
 
 To remove a previously set image pass an empty dictionary: >
 	call popup_setoptions(winid, #{image: {}})


### PR DESCRIPTION
builtin.txt
popup.txt
- Correcting line breaks (making effective use of 78 columns)

filetype.txt  (in BEANCOUNT section)
- Remove help tags from variable names (since they are in the same section, they can easily be found with `#` or `*`).
- Move the sample highlight closing tag (`<`) to the previous line.
- Add a description for `g:beancount_account_completion`.
- Remove the blank line before "Default value:".
- Fix lines exceeding 78 columns.  (See Note)
- Adhere to the rule of using two spaces after a period at the end of a sentence.  (See Note)

related: #20373
(Cc: @ambroisie @nathangrigg)

---

> [!NOTE]
> Please see `:h help-writing`.
> ```
> (snip)
> STYLE
> (snip)
> 
> Vim help files should be formatted for a 'textwidth' of 78 characters (with
> 'conceal' enabled), so they look good in a typical 80 x 24 terminal window;
> use `:set colorcolumn=+0` as a visual guide.
> 
> Use two spaces between the final dot of a sentence of the first letter of the
> next sentence.  Like this.
> ```