### PR TITLE
GTK4: Update minimum width of form widget

### DIFF
--- a/src/gui_gtk4_f.c
+++ b/src/gui_gtk4_f.c
@@ -271,11 +271,12 @@ vim_form_measure(
     }
     else
     {
-	// Set minimum width of form widget to 10 columns.
+	// Set minimum width of form widget to 20 columns. Any less and the draw
+	// area seems to glitch out...
 	if (minimum != NULL)
-	    *minimum  = gui.char_width * 10;
+	    *minimum  = gui.char_width * 20;
 	if (natural != NULL)
-	    *natural = gui.char_width * 10;
+	    *natural = gui.char_width * 20;
     }
 
     if (minimum_baseline != NULL)


### PR DESCRIPTION
From my testing, 10 columns seems to make the draw area look not render some parts for some reason