### PR TITLE
cannot switch to a buffer with '%' in its name on MS-Windows

### DIFF
--- a/src/testdir/test_buffer.vim
+++ b/src/testdir/test_buffer.vim
@@ -935,4 +935,19 @@ func Test_split_window_in_BufLeave_from_switching_buffer()
   bwipe! Xb
 endfunc
 
+" Switch to a buffer whose name contains '%' via completion (#20529).
+func Test_buffer_switch_to_name_with_percent()
+  CheckMSWindows
+
+  let bufnr = bufadd('Xpercent%name')
+  call setbufvar(bufnr, '&buflisted', 1)
+  call bufload(bufnr)
+  enew
+
+  call feedkeys(":b Xpercent\<Tab>\<CR>", 'xt')
+  call assert_equal(bufnr, bufnr('%'))
+
+  exe 'bwipe! ' .. bufnr
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/vim.h
+++ b/src/vim.h
@@ -343,7 +343,10 @@
 #endif
 #ifdef BACKSLASH_IN_FILENAME
 # define PATH_ESC_CHARS ((char_u *)" \t\n*?[{`%#'\"|!<")
-# define BUFFER_ESC_CHARS ((char_u *)" \t\n*?[`%#'\"|!<")
+// '%' and '#' are not escaped for ":buffer": it has no EX_XFILE, so they are
+// not expanded, and escaping them as "\%"/"\#" breaks buffer name matching
+// when '%'/'#' is in 'isfname' (backslash treated as a path separator).
+# define BUFFER_ESC_CHARS ((char_u *)" \t\n*?[`'\"|!<")
 #else
 # ifdef VMS
     // VMS allows a lot of characters in the file name


### PR DESCRIPTION
```
Problem:  On MS-Windows it is not possible to switch to a buffer by name
          with ":b" (including via command-line completion) when the
          buffer name contains '%'.
Solution: Do not escape '%' and '#' for the ":buffer" command on
          MS-Windows.  Since ":buffer" has no EX_XFILE these are not
          expanded, and escaping them as "\%"/"\#" makes buffer name
          matching fail when '%'/'#' is in 'isfname' (the backslash is
          treated as a path separator).
```

fixes: #20529