### PR TITLE
fix lz4 extraction on non-Linux systems

### DIFF
--- a/runtime/autoload/tar.vim
+++ b/runtime/autoload/tar.vim
@@ -733,8 +733,10 @@ fun! tar#Extract()
   elseif tarball =~# "\.tlz4$"
    if has("linux")
     let extractcmd= substitute(extractcmd,"-","-I lz4 -","")
+    call system(extractcmd." ".shellescape(tarball)." ".g:tar_secure.shellescape(fname))
+   else
+    call system("lz4 --decompress --stdout -- ".shellescape(tarball)." | ".extractcmd." - ".g:tar_secure.shellescape(fname))
    endif
-   call system(extractcmd." ".shellescape(tarball)." ".g:tar_secure.shellescape(fname))
    if v:shell_error != 0
     call s:Msg('tar#Extract', 'error', $"{extractcmd} {tarball} {fname}: failed!")
    else
@@ -744,8 +746,10 @@ fun! tar#Extract()
   elseif tarball =~# "\.tar\.lz4$"
    if has("linux")
     let extractcmd= substitute(extractcmd,"-","-I lz4 -","")
+    call system(extractcmd." ".shellescape(tarball)." ".g:tar_secure.shellescape(fname))
+   else
+    call system("lz4 --decompress --stdout -- ".shellescape(tarball)." | ".extractcmd." - ".g:tar_secure.shellescape(fname))
    endif
-   call system(extractcmd." ".shellescape(tarball)." ".g:tar_secure.shellescape(fname))
    if v:shell_error != 0
     call s:Msg('tar#Extract', 'error', $"{extractcmd} {tarball} {fname}: failed!")
    else


### PR DESCRIPTION
Patch 9.2.0306 fixed malformed lz4 extraction commands by using "tar -I lz4" on Linux and leaving non-Linux tar implementations to auto-detect lz4 input. That still fails on systems where tar does not support either -I lz4 or automatic lz4 decompression, such as Solaris /usr/bin/tar.

Keep the existing Linux path using GNU tar's "-I lz4" support.  For non-Linux systems, use lz4 explicitly to decompress the archive to stdout and feed the resulting tar stream to the configured tar extraction command.  This is the same style tar.vim already used for lz4 archives before patch 9.2.0306.

Follow-up for https://github.com/vim/vim/pull/19925