### PR TITLE
fix DTrace probe highlighting before action blocks

### DIFF
--- a/runtime/syntax/dtrace.vim
+++ b/runtime/syntax/dtrace.vim
@@ -35,8 +35,8 @@ syn match dtraceComment "\%^#!.*-s.*"
 " XXX: This allows a probe description to end with ',', even if it's not
 " followed by another probe.
 " XXX: This doesn't work if followed by a comment.
-let s:oneProbe = '\%(BEGIN\|END\|ERROR\|\S\{-}:\S\{-}:\S\{-}:\S\{-}\)\_s*'
-exec 'syn match dtraceProbe "'.s:oneProbe.'\%(,\_s*'.s:oneProbe.'\)*\ze\_s\%({\|\/[^*]\|\%$\)"'
+let s:oneProbe = '\%(BEGIN\|END\|ERROR\|\S\{-}:\S\{-}:\S\{-}:\S*\)\_s*'
+exec 'syn match dtraceProbe "'.s:oneProbe.'\%(,\_s*'.s:oneProbe.'\)*\ze\_s*\%({\|\/[^*]\|\_s*\S\|\%$\)"'
 
 " Note: We have to be careful to not make this match /* */ comments.
 " Also be careful not to eat `c = a / b; b = a / 2;`. We use the same


### PR DESCRIPTION
Recognize DTrace probe descriptions that are followed immediately by an action block, such as:

    BEGIN{ trace(1); }
    syscall::open:entry{ trace(1); }

The fourth probe field now consumes the remaining non-whitespace text, and the lookahead allows zero or more whitespace before the following token.