### PR TITLE
fix recover test with symlinked samples

### DIFF
--- a/src/testdir/test_recover.vim
+++ b/src/testdir/test_recover.vim
@@ -503,7 +503,9 @@ func Test_recover_corrupted_swap_file1()
   new
   let sample = 'samples/recover-crash1.swp'
   let target = 'Xpoc1.swp'
-  call filecopy(sample, target)
+  " In an out-of-source-tree build the sample may be a symlink, this copies the
+  " data into a real file.
+  call writefile(readblob(sample), target, 'D')
   try
     sil recover! Xpoc1
   catch /^Vim\%((\S\+)\)\=:E1364:/
@@ -517,7 +519,9 @@ func Test_recover_corrupted_swap_file1()
   new
   let sample = 'samples/recover-crash2.swp'
   let target = 'Xpoc2.swp'
-  call filecopy(sample, target)
+  " In an out-of-source-tree build the sample may be a symlink, this copies the
+  " data into a real file.
+  call writefile(readblob(sample), target, 'D')
   try
     sil recover! Xpoc2
   catch /^Vim\%((\S\+)\)\=:E1364:/


### PR DESCRIPTION
Test_recover_corrupted_swap_file1() copies prebuilt corrupt swap samples before recovering them.  In an out-of-source-tree build those sample files may be symlinks into the source tree.  filecopy() preserves symlinks, so the copied target may remain a symlink.  Recovery opens swap files with O_NOFOLLOW, so that copied symlink cannot be opened.  Read the sample as a blob and write it back so the recovery target is a real swap file.