### PR TITLE
GTK4: Fix toolbar

### DIFF
--- a/src/gui_gtk4.c
+++ b/src/gui_gtk4.c
@@ -4666,10 +4666,9 @@ gui_mch_destroy_menu(vimmenu_T *menu)
     // For toolbar buttons and separators, remove from the toolbar box.
     if (menu->id != NULL && menu->id != (GtkWidget *)1)
     {
-	GtkWidget *parent_widget = gtk_widget_get_parent(menu->id);
-
-	if (parent_widget != NULL)
-	    gtk_box_remove(GTK_BOX(parent_widget), menu->id);
+	vim_toolbar_remove(VIM_TOOLBAR(gui.toolbar), menu->id);
+	menu->id = NULL;
+	return;
     }
     menu->id = NULL;
 

--- a/src/gui_gtk4_tb.c
+++ b/src/gui_gtk4_tb.c
@@ -193,6 +193,19 @@ set_button_style(GtkWidget *btn, int style, int iconsize, gboolean invalidate)
 }
 
 /*
+ * Always close overflow popover when button is clicked.
+ */
+    static void
+button_clicked(GtkWidget *widget UNUSED, VimToolbar *self)
+{
+    gtk_menu_button_popdown(GTK_MENU_BUTTON(self->overflow_btn));
+    // Bring focus to drawarea, popping overflow menu down does not change
+    // focus.
+    gtk_widget_grab_focus(gui.drawarea);
+    gui_mch_flush();
+}
+
+/*
  * Add a new toolbar button at the given index and return the widget. "icon" and
  * "text" may be NULL..
  */
@@ -229,6 +242,9 @@ vim_toolbar_insert_button(
     }
 
     set_button_style(btn, self->style, self->iconsize, TRUE);
+
+    g_signal_connect_object(btn, "clicked",
+	    G_CALLBACK(button_clicked), self, G_CONNECT_DEFAULT);
 
     vim_toolbar_insert(self, btn, idx);
     return btn;
@@ -276,6 +292,18 @@ vim_toolbar_set_style(VimToolbar *self, int style, int iconsize)
 	cur_child = gtk_widget_get_next_sibling(cur_child);
     }
     // Sizes may have changed
+    gtk_widget_queue_allocate(GTK_WIDGET(self));
+}
+
+/*
+ * Remove the item from the toolbar.
+ */
+    void
+vim_toolbar_remove(VimToolbar *self, GtkWidget *item)
+{
+    gtk_box_remove(GTK_BOX(self->strip),item);
+    self->items = g_list_remove(self->items, item);
+    g_object_unref(item);
     gtk_widget_queue_allocate(GTK_WIDGET(self));
 }
 

--- a/src/gui_gtk4_tb.c
+++ b/src/gui_gtk4_tb.c
@@ -35,8 +35,8 @@ struct _VimToolbar
 
 G_DEFINE_TYPE(VimToolbar, vim_toolbar, GTK_TYPE_WIDGET)
 
-    static void vim_toolbar_size_allocate(GtkWidget *widget, int width, int height, int baseline);
-    static void vim_toolbar_measure(GtkWidget *widget, GtkOrientation orientation, int for_size, int *minimum, int *natural, int *minimum_baseline, int *natural_baseline);
+static void vim_toolbar_size_allocate(GtkWidget *widget, int width, int height, int baseline);
+static void vim_toolbar_measure(GtkWidget *widget, GtkOrientation orientation, int for_size, int *minimum, int *natural, int *minimum_baseline, int *natural_baseline);
 
     static void
 vim_toolbar_dispose(GObject *object)

--- a/src/gui_gtk4_tb.h
+++ b/src/gui_gtk4_tb.h
@@ -25,6 +25,7 @@ GtkWidget *vim_toolbar_new(void);
 GtkWidget *vim_toolbar_insert_button(VimToolbar *self, GtkWidget *icon, const char *text, int idx);
 GtkWidget *vim_toolbar_insert_separator(VimToolbar *self, int idx);
 void vim_toolbar_set_style(VimToolbar *self, int style, int iconsize);
+void vim_toolbar_remove(VimToolbar *self, GtkWidget *item);
 
 #endif
 


### PR DESCRIPTION
- fix segfault when removing toolbar item
- bring focus to drawarea when button in overflow menu is clicked 