### PR TITLE
skip cd test on Solaris

### DIFF
--- a/src/testdir/test_cd.vim
+++ b/src/testdir/test_cd.vim
@@ -211,6 +211,9 @@ func Test_lcd_win_execute()
 endfunc
 
 func Test_cd_from_non_existing_dir()
+  if has('sun')
+    throw 'Skipped: Solaris does not allow deleting the current working directory'
+  endif
   CheckNotMSWindows
 
   let saveddir = getcwd()


### PR DESCRIPTION
Test_cd_from_non_existing_dir() depends on deleting the current working directory.  Solaris does not allow that, so skip the test there.