### PR TITLE
Several :mksession fixes overlooked in #20152

### DIFF
--- a/src/session.c
+++ b/src/session.c
@@ -1355,12 +1355,12 @@ ex_mkrc(exarg_T	*eap)
 
 			// compare prefixes if available
 			if (si->sn_autoload_prefix != NULL && b_si->sn_autoload_prefix != NULL
-				&& (0 == STRICMP(si->sn_autoload_prefix, b_si->sn_autoload_prefix)))
+				&& (STRCMP(si->sn_autoload_prefix, b_si->sn_autoload_prefix) == 0))
 			    break;
 
 			// otherwise compare tails
 			char_u *b_name = gettail(b_si->sn_name);
-			if (0 == STRICMP(name, b_name))
+			if (STRCMP(name, b_name) == 0)
 			    break;
 		    }
 

--- a/src/session.c
+++ b/src/session.c
@@ -1333,12 +1333,39 @@ ex_mkrc(exarg_T	*eap)
 	    for (sid = 1; sid <= script_items.ga_len; ++sid)
 	    {
 		si = SCRIPT_ITEM(sid);
+
 		// autoload script paths may be absolute, relative to the
 		// current script or relative to a 'runtimepath' directory
-		if ((si->sn_autoload_prefix || si->sn_import_autoload) &&
-		    (fprintf(fd, "import autoload '%s'", si->sn_name) < 0 ||
-			put_eol(fd) == FAIL))
+		if (si->sn_autoload_prefix || si->sn_import_autoload)
+		{
+		    // Check if conflicts with a previous import
+		    int b_sid = sid - 1;
+		    char_u *name = gettail(si->sn_name);
+
+		    for (; b_sid; --b_sid)
+		    {
+			scriptitem_T *b_si = SCRIPT_ITEM(b_sid);
+
+			// only autoload may conflict
+			if (!b_si->sn_autoload_prefix && !b_si->sn_import_autoload)
+			    continue;
+
+			// compare prefixes if available
+			if (si->sn_autoload_prefix != NULL && b_si->sn_autoload_prefix != NULL
+				&& (0 == STRICMP(si->sn_autoload_prefix, b_si->sn_autoload_prefix)))
+			    break;
+
+			// otherwise compare tails
+			char_u *b_name = gettail(b_si->sn_name);
+			if (0 == STRICMP(name, b_name))
+			    break;
+		    }
+
+		    // import the auto script if there are no conflicts
+		    if (fprintf(fd, "%simport autoload '%s'", b_sid ? "# " : "", si->sn_name) < 0 ||
+			put_eol(fd) == FAIL)
 		    failed = TRUE;
+		}
 	    }
 #endif
 	}

--- a/src/session.c
+++ b/src/session.c
@@ -1334,9 +1334,11 @@ ex_mkrc(exarg_T	*eap)
 	    {
 		si = SCRIPT_ITEM(sid);
 
-		// autoload script paths may be absolute, relative to the
+		// Autoload script paths may be absolute, relative to the
 		// current script or relative to a 'runtimepath' directory
-		if (si->sn_autoload_prefix || si->sn_import_autoload)
+		// Ignore if missing
+		if ((si->sn_autoload_prefix || si->sn_import_autoload)
+			&& file_is_readable(si->sn_name))
 		{
 		    // Check if conflicts with a previous import
 		    int b_sid = sid - 1;
@@ -1346,8 +1348,9 @@ ex_mkrc(exarg_T	*eap)
 		    {
 			scriptitem_T *b_si = SCRIPT_ITEM(b_sid);
 
-			// only autoload may conflict
-			if (!b_si->sn_autoload_prefix && !b_si->sn_import_autoload)
+			// Only autoload may conflict. Ignore if missing
+			if ((!b_si->sn_autoload_prefix && !b_si->sn_import_autoload)
+				|| !file_is_readable(b_si->sn_name))
 			    continue;
 
 			// compare prefixes if available

--- a/src/session.c
+++ b/src/session.c
@@ -1333,7 +1333,9 @@ ex_mkrc(exarg_T	*eap)
 	    for (sid = 1; sid <= script_items.ga_len; ++sid)
 	    {
 		si = SCRIPT_ITEM(sid);
-		if (si->sn_autoload_prefix &&
+		// autoload script paths may be absolute, relative to the
+		// current script or relative to a 'runtimepath' directory
+		if ((si->sn_autoload_prefix || si->sn_import_autoload) &&
 		    (fprintf(fd, "import autoload '%s'", si->sn_name) < 0 ||
 			put_eol(fd) == FAIL))
 		    failed = TRUE;

--- a/src/testdir/test_mksession.vim
+++ b/src/testdir/test_mksession.vim
@@ -1395,9 +1395,9 @@ func Test_mksession_vim9_expr_mappings()
   call writefile(test_sources, 'XTest.vim', 'D')
   " spawn a new Vim instance to load the session and execute the mapping
   call system(GetVimCommand('XTest.vim'))
+  defer delete('XDummyOutput')
   call assert_true(filereadable('XDummyOutput'),
         \ 'Expected output file was not created by Vim9 plugin')
-  defer delete('XDummyOutput')
   call assert_equal([ref_txt], readfile('XDummyOutput'))
 
 endfunc
@@ -1461,9 +1461,9 @@ func Test_mksession_legacy_expr_mappings()
   call writefile(test_sources, 'XTest.vim', 'D')
   " spawn a new Vim instance to load the session and execute the mapping
   call system(GetVimCommand('XTest.vim'))
+  defer delete('XDummyOutput')
   call assert_true(filereadable('XDummyOutput'),
         \ 'Expected output file was not created by legacy vim plugin')
-  defer delete('XDummyOutput')
   call assert_equal([ref_txt], readfile('XDummyOutput'))
 
 endfunc
@@ -1722,4 +1722,4 @@ func Test_mksession_vim9_duplicate_import()
 
 endfunc
 
-" " vim: shiftwidth=2 sts=2 expandtab
+" vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_mksession.vim
+++ b/src/testdir/test_mksession.vim
@@ -1395,9 +1395,9 @@ func Test_mksession_vim9_expr_mappings()
   call writefile(test_sources, 'XTest.vim', 'D')
   " spawn a new Vim instance to load the session and execute the mapping
   call system(GetVimCommand('XTest.vim'))
-  defer delete('XDummyOutput')
   call assert_true(filereadable('XDummyOutput'),
         \ 'Expected output file was not created by Vim9 plugin')
+  defer delete('XDummyOutput')
   call assert_equal([ref_txt], readfile('XDummyOutput'))
 
 endfunc
@@ -1461,9 +1461,9 @@ func Test_mksession_legacy_expr_mappings()
   call writefile(test_sources, 'XTest.vim', 'D')
   " spawn a new Vim instance to load the session and execute the mapping
   call system(GetVimCommand('XTest.vim'))
-  defer delete('XDummyOutput')
   call assert_true(filereadable('XDummyOutput'),
         \ 'Expected output file was not created by legacy vim plugin')
+  defer delete('XDummyOutput')
   call assert_equal([ref_txt], readfile('XDummyOutput'))
 
 endfunc
@@ -1607,8 +1607,7 @@ func Test_mksession_vim9_relative_auto_import()
     import autoload './XAuto.vim'
     nnoremap dummy-test <ScriptCmd>XAuto.Test()<CR>
   END
-  call writefile(script_sources, 'XScript.vim')
-  defer delete('XScript.vim')
+  call writefile(script_sources, 'XScript.vim', 'D')
 
   let auto_sources =<< trim END
     vim9script
@@ -1620,8 +1619,7 @@ func Test_mksession_vim9_relative_auto_import()
       writefile([ref_txt], 'XDummyOutput')
     enddef
   END
-  call writefile(auto_sources, 'XAuto.vim')
-  defer delete('XAuto.vim')
+  call writefile(auto_sources, 'XAuto.vim', 'D')
 
   " Source the script
   const ref_txt = 'Hello from vim9 dummy relative auto script!'
@@ -1654,9 +1652,72 @@ func Test_mksession_vim9_relative_auto_import()
   call writefile(test_sources, 'XTest.vim', 'D')
   " spawn a new Vim instance to load the session and execute the mapping
   call system(GetVimCommand('XTest.vim'))
-  defer delete('XDummyOutput')
   call assert_true(filereadable('XDummyOutput'),
         \ 'Expected output file was not created by Vim9 auto script mapping')
+  defer delete('XDummyOutput')
+  call assert_equal([ref_txt], readfile('XDummyOutput'))
+
+endfunc
+
+" Test vim9 script avoid homonimous auto imports
+func Test_mksession_vim9_duplicate_import()
+
+  " Auto script
+  let auto_sources =<< trim END
+    vim9script
+    const ref_txt = 'Hello from a duplicated vim9 script!'
+    export def Test()
+      writefile([ref_txt], 'XDummyOutput')
+    enddef
+  END
+
+  " Dummy vim9 script
+  let script_sources =<< trim END
+    vim9script
+    import autoload './XAuto.vim'
+    nnoremap dummy-test <ScriptCmd>XAuto.Test()<CR>
+  END
+
+  for i in range(1, 5)
+    let dir = $'XDir{i}'
+    call mkdir(dir, 'p')
+    defer delete(dir, 'rf')
+
+    let autofile = dir . '/XAuto.vim'
+    call writefile(auto_sources, autofile, 'D')
+
+    let scriptfile = dir . '/XScript.vim'
+    call writefile(script_sources, scriptfile, 'D')
+    exe "source " . scriptfile
+  endfor
+
+  " Create a session file
+  mksession! XDummySession.vim
+  defer delete('XDummySession.vim')
+  call assert_true(filereadable('XDummySession.vim'), 'Session file was not created')
+
+  " Check there are commented imports in the session file
+  let commented_imports = filter(readfile('XDummySession.vim'),
+  \ {_, v -> v =~ '^# import autoload'})
+  call assert_equal(4, len(commented_imports),
+  \ 'Session file does not contain the expected number of commented imports')
+
+  " Check the session file mappings are operational
+  const ref_txt = 'Hello from a duplicated vim9 script!'
+  let test_sources =<< trim END
+    " Load session
+    source XDummySession.vim
+    " Execute mapping
+    normal dummy-test
+    " on my way
+    cq
+  END
+  call writefile(test_sources, 'XTest.vim', 'D')
+  " spawn a new Vim instance to load the session and execute the mapping
+  call system(GetVimCommand('XTest.vim'))
+  call assert_true(filereadable('XDummyOutput'),
+        \ 'Expected output file was not created by Vim9 auto script mapping')
+  defer delete('XDummyOutput')
   call assert_equal([ref_txt], readfile('XDummyOutput'))
 
 endfunc

--- a/src/testdir/test_mksession.vim
+++ b/src/testdir/test_mksession.vim
@@ -1598,4 +1598,67 @@ func Test_mksession_localmappings()
 
 endfunc
 
-" vim: shiftwidth=2 sts=2 expandtab
+" Test vim9 script relative auto imports (issue #12641)
+func Test_mksession_vim9_relative_auto_import()
+
+  " Dummy vim9 script
+  let script_sources =<< trim END
+    vim9script
+    import autoload './XAuto.vim'
+    nnoremap dummy-test <ScriptCmd>XAuto.Test()<CR>
+  END
+  call writefile(script_sources, 'XScript.vim')
+  defer delete('XScript.vim')
+
+  let auto_sources =<< trim END
+    vim9script
+    const ref_txt = 'Hello from vim9 dummy relative auto script!'
+    export def Test()
+      if !has("gui_running")
+        exe $"echomsg '{ref_txt}'"
+      endif
+      writefile([ref_txt], 'XDummyOutput')
+    enddef
+  END
+  call writefile(auto_sources, 'XAuto.vim')
+  defer delete('XAuto.vim')
+
+  " Source the script
+  const ref_txt = 'Hello from vim9 dummy relative auto script!'
+  source XScript.vim
+
+  " Execute mapping
+  normal dummy-test
+
+  if !has('gui_running')
+    call assert_match(ref_txt, execute('messages'), 'No vim9 auto script XAuto.Test() execution')
+  endif
+  call assert_true(filereadable('XDummyOutput'), 'Output file was not created by Vim9 auto script')
+  call assert_equal([ref_txt], readfile('XDummyOutput'))
+  call delete('XDummyOutput')
+
+  " Create a session file
+  mksession! XDummySession.vim
+  defer delete('XDummySession.vim')
+  call assert_true(filereadable('XDummySession.vim'), 'Session file was not created')
+
+  " Check the session file mappings are operational
+  let test_sources =<< trim END
+    " Load session
+    source XDummySession.vim
+    " Execute mapping
+    normal dummy-test
+    " on my way
+    cq
+  END
+  call writefile(test_sources, 'XTest.vim', 'D')
+  " spawn a new Vim instance to load the session and execute the mapping
+  call system(GetVimCommand('XTest.vim'))
+  defer delete('XDummyOutput')
+  call assert_true(filereadable('XDummyOutput'),
+        \ 'Expected output file was not created by Vim9 auto script mapping')
+  call assert_equal([ref_txt], readfile('XDummyOutput'))
+
+endfunc
+
+" " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Some session fixes missed in https://github.com/vim/vim/pull/20152. The generated session file:
- ignored those imports defined relative to a script or with absolute paths. This fixes https://github.com/vim/vim/issues/12641
- included imports associated to scripts no longer available.
- duplicated script imports if available in several runtime locations, leading to termination errors loading a session.