### PR TITLE
fix(gtk2,3): popup-images not rendering properly, gtk2 build fails

### DIFF
--- a/src/cairo.c
+++ b/src/cairo.c
@@ -185,11 +185,11 @@ cairo_popup_image_paint(
     cairo_surface_t *surface = (cairo_surface_t *)wp->w_popup_image_surface;
 
 
-#if !GTK_CHECK_VERSION(3,0,0)
+# if !GTK_CHECK_VERSION(3,0,0)
     cr = gdk_cairo_create((GdkDrawable *)target);
-#else
+# else
     cr = cairo_create((cairo_surface_t *)target);
-#endif
+# endif
     cairo_set_operator(cr, CAIRO_OPERATOR_OVER);
     // Position the source so its (src_x, src_y) pixel lands at (x, y),
     // then clip to the visible (draw_w x draw_h) rectangle.

--- a/src/cairo.c
+++ b/src/cairo.c
@@ -182,14 +182,21 @@ cairo_popup_image_paint(
 	return;
     if (!cairo_popup_image_ensure(wp))
 	return;
+    cairo_surface_t *surface = (cairo_surface_t *)wp->w_popup_image_surface;
 
+
+#if !GTK_CHECK_VERSION(3,0,0)
+    cr = gdk_cairo_create((GdkDrawable *)target);
+#else
     cr = cairo_create((cairo_surface_t *)target);
+#endif
     cairo_set_operator(cr, CAIRO_OPERATOR_OVER);
     // Position the source so its (src_x, src_y) pixel lands at (x, y),
     // then clip to the visible (draw_w x draw_h) rectangle.
     cairo_set_source_surface(cr,
-	    (cairo_surface_t *)wp->w_popup_image_surface,
+	    surface,
 	    x - src_x, y - src_y);
+
     cairo_rectangle(cr, x, y, draw_w, draw_h);
     cairo_fill(cr);
     cairo_destroy(cr);

--- a/src/gui.c
+++ b/src/gui.c
@@ -1426,6 +1426,9 @@ gui_update_cursor(
 #endif
     }
     gui.highlight_mask = old_hl_mask;
+#if defined(FEAT_IMAGE_CAIRO) && !GTK_CHECK_VERSION(4,0,0)
+    update_popup_images();
+#endif
 }
 
 #if defined(FEAT_MENU)

--- a/src/gui.c
+++ b/src/gui.c
@@ -1355,6 +1355,9 @@ gui_update_cursor(
     if (!gui.in_focus)
     {
 	gui_mch_draw_hollow_cursor(cbg);
+#if defined(FEAT_IMAGE_CAIRO) && !GTK_CHECK_VERSION(4,0,0)
+	update_popup_images();
+#endif
 	return;
     }
 

--- a/src/gui.c
+++ b/src/gui.c
@@ -1355,8 +1355,10 @@ gui_update_cursor(
     if (!gui.in_focus)
     {
 	gui_mch_draw_hollow_cursor(cbg);
-#if defined(FEAT_IMAGE_CAIRO) && !GTK_CHECK_VERSION(4,0,0)
+#if defined(FEAT_GUI_GTK) && defined(FEAT_IMAGE_CAIRO)
+# if !GTK_CHECK_VERSION(4,0,0)
 	update_popup_images();
+# endif
 #endif
 	return;
     }
@@ -1426,8 +1428,10 @@ gui_update_cursor(
 #endif
     }
     gui.highlight_mask = old_hl_mask;
-#if defined(FEAT_IMAGE_CAIRO) && !GTK_CHECK_VERSION(4,0,0)
+#if defined(FEAT_GUI_GTK) && defined(FEAT_IMAGE_CAIRO)
+# if !GTK_CHECK_VERSION(4,0,0)
     update_popup_images();
+# endif
 #endif
 }
 

--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -7035,23 +7035,23 @@ gui_mch_draw_popup_image(
     if (wp->w_popup_image_data == NULL
 	    || wp->w_popup_image_w <= 0 || wp->w_popup_image_h <= 0
 	    || draw_w <= 0 || draw_h <= 0
-#if GTK_CHECK_VERSION(3,0,0)
+# if GTK_CHECK_VERSION(3,0,0)
 	    || gui.surface == NULL
-#endif
+# endif
        )
 	return;
 
     x = FILL_X(col);
     y = FILL_Y(row);
-#if GTK_CHECK_VERSION(3,0,0)
+# if GTK_CHECK_VERSION(3,0,0)
     cairo_popup_image_paint(wp, gui.surface, x, y,
-					    src_x, src_y, draw_w, draw_h);
+	    src_x, src_y, draw_w, draw_h);
     if (gui.drawarea != NULL)
 	gtk_widget_queue_draw_area(gui.drawarea, x, y, draw_w, draw_h);
-#else
+# else
     cairo_popup_image_paint(wp, gui.drawarea->window, x, y,
-					    src_x, src_y, draw_w, draw_h);
-#endif
+	    src_x, src_y, draw_w, draw_h);
+# endif
 }
 #endif // FEAT_IMAGE_CAIRO
 

--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -7035,16 +7035,23 @@ gui_mch_draw_popup_image(
     if (wp->w_popup_image_data == NULL
 	    || wp->w_popup_image_w <= 0 || wp->w_popup_image_h <= 0
 	    || draw_w <= 0 || draw_h <= 0
-	    || gui.surface == NULL)
+#if GTK_CHECK_VERSION(3,0,0)
+	    || gui.surface == NULL
+#endif
+       )
 	return;
 
     x = FILL_X(col);
     y = FILL_Y(row);
+#if GTK_CHECK_VERSION(3,0,0)
     cairo_popup_image_paint(wp, gui.surface, x, y,
 					    src_x, src_y, draw_w, draw_h);
-
     if (gui.drawarea != NULL)
 	gtk_widget_queue_draw_area(gui.drawarea, x, y, draw_w, draw_h);
+#else
+    cairo_popup_image_paint(wp, gui.drawarea->window, x, y,
+					    src_x, src_y, draw_w, draw_h);
+#endif
 }
 #endif // FEAT_IMAGE_CAIRO
 


### PR DESCRIPTION
⚠️
Prerequisite: [vim/vim#20576](https://github.com/vim/vim/pull/20576)
* gtk2 build fails
* popup-images lost when gui is unfocused
* popup-images hidden when cursor is moved over.

**Examples:**

* gtk3
<img width="243" height="286" alt="gtk3" src="https://github.com/user-attachments/assets/03d87123-5212-4421-be38-648bb533db51" />

* gtk2
<img width="201" height="214" alt="gtk2" src="https://github.com/user-attachments/assets/8a367add-e9da-48a2-874e-342b191e3013" />

```vim
let pixels = repeat([0xff, 0x00, 0x00], 4 * 4)->list2blob()
call popup_create('', #{
  \ image: #{ data: pixels, width: 4, height: 4 },
  \ line: 'cursor+1', col: 'cursor',
  \ z-index: 100,
  \ opacity: 0,
  \ })
let png = $'{$HOME}/dice.png'
let dim = split(system('gm identify -format "%w %h" '
  \ .. shellescape(png)))
let [w, h] = [str2nr(dim[0]), str2nr(dim[1])]
call system('gm convert ' .. shellescape(png)
  \ .. ' -depth 8 rgba:/tmp/cat.rgb')
let blob = readblob('/tmp/cat.rgb')
call popup_create('', #{
  \ image: #{ data: blob, width: w, height: h },
  \ line: 1, col: 1, border: [], padding: [0, 0, 0, 0],
  \ opacity: 0,
  \ z-index: 1,
  \ })
```

dice.png
<img width="100" height="75" alt="dice" src="https://github.com/user-attachments/assets/a8bfa1f8-6445-4c0f-ae9a-0f2769366865" />

⚠️
Prerequisite: [vim/vim#20576](https://github.com/vim/vim/pull/20576)

Closes: #20504 