### PR TITLE
skip tempdir deletion test on Solaris

### DIFF
--- a/src/testdir/test_vimscript.vim
+++ b/src/testdir/test_vimscript.vim
@@ -7734,6 +7734,9 @@ func Test_delete_temp_dir()
   " assumes Unix has always flock/dirfd support
   CheckUnix
   CheckNotMac
+  if has('sun')
+    throw 'Skipped: Solaris Vim does not detect deleted tempdir without flock()'
+  endif
   let a = tempname()
   let dir = fnamemodify(a, ':h')
   call delete(dir, 'rf')


### PR DESCRIPTION
Test_delete_temp_dir() assumes Vim can detect when its cached private temp directory has been deleted, which depends on flock/dirfd support.  Solaris does not provide flock(), so Vim keeps using the cached temp directory path after the directory has been deleted.  Skip the test there.

BTW thank you, I have few more patches Solaris was hoarding and will be creating pull requests for those. Anything you don't like I'm more than happy to change or accept that this is not suitable for upstream.

Vlad