### PR TITLE
fix Solaris test assumptions

### DIFF
--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -330,7 +330,7 @@ func Test_strptime()
 
   " Force DST and check that it's considered.
   " MS-Windows CRT tzset() does not parse POSIX TZ strings with DST rules.
-  if !has('win32')
+  if !has('win32') && !has('sun')
     let $TZ = 'WINTER0SUMMER,J1,J365'
     call assert_equal(1484653763 - 3600, strptime('%Y-%m-%d %T', '2017-01-17 11:49:23'))
   endif

--- a/src/testdir/test_gettext_utf8.vim
+++ b/src/testdir/test_gettext_utf8.vim
@@ -16,7 +16,9 @@ func Test_gettext()
       call assert_equal('ОШИБКА: for __PACKAGE__', gettext("ERROR: ", "__PACKAGE__"))
 
       call assert_equal('ОШИБКА: for __PACKAGE__', ngettext("ERROR: ", "ERRORS: ", 1, "__PACKAGE__"))
-      call assert_equal('ОШИБКА: for __PACKAGE__', ngettext("ERROR: ", "ERRORS: ", 2, "__PACKAGE__"))
+      if !has('sun')
+        call assert_equal('ОШИБКА: for __PACKAGE__', ngettext("ERROR: ", "ERRORS: ", 2, "__PACKAGE__"))
+      endif
 
       call assert_equal('%d буфер удалён из памяти for __PACKAGE__', ngettext("%d buffer unloaded", "%d buffers unloaded", 1, "__PACKAGE__"))
       call assert_equal('%d буфера удалено из памяти for __PACKAGE__', ngettext("%d buffer unloaded", "%d buffers unloaded", 2, "__PACKAGE__"))

--- a/src/testdir/test_startup_utf8.vim
+++ b/src/testdir/test_startup_utf8.vim
@@ -78,8 +78,9 @@ func Test_detect_fifo()
 	\ ]
   if RunVim([], after, '<(cat Xtestin_fifo)')
     let lines = readfile('Xtestout')
-    call assert_match('\[fifo\]', lines[0])
-    call assert_match('\[fifo\]', lines[1])
+    let filetype = has('sun') ? '\[character special\]' : '\[fifo\]'
+    call assert_match(filetype, lines[0])
+    call assert_match(filetype, lines[1])
   else
     call assert_equal('', 'RunVim failed.')
   endif

--- a/src/testdir/test_termencoding.vim
+++ b/src/testdir/test_termencoding.vim
@@ -25,7 +25,7 @@ func Test_termencoding_euc_jp()
 	\ 'set termencoding=utf-8',
 	\ 'scriptencoding utf-8',
 	\ 'exe "normal aE83: バッファを作成できないので、他のを使用します...\<Esc>"',
-	\ 'split Xeuc_jp.txt',
+	\ has('sun') ? 'split ++enc=euc-jp Xeuc_jp.txt' : 'split Xeuc_jp.txt',
 	\ ], 'XTest_tenc_euc_jp', 'D')
   let buf = RunVimInTerminal('-S XTest_tenc_euc_jp', {'rows': 10})
   call VerifyScreenDump(buf, 'Test_tenc_euc_jp_01', {})


### PR DESCRIPTION
Several Vim tests assume behavior that is not true for Solaris:

Test_strptime() expects the artificial POSIX DST rule in TZ to be applied, but Solaris strptime() returns the UTC value for that test case.

Test_gettext() checks ngettext() with a singular-only test catalog entry. GNU gettext reuses the singular translation for the Russian plural lookup, but Solaris gettext returns an empty string for that malformed catalog entry.

Test_detect_fifo() reads bash process substitution through /dev/fd, which Solaris reports as character special rather than fifo.

Test_termencoding_euc_jp() writes Xeuc_jp.txt as EUC-JP.  On Solaris, the latin1 fallback in 'fileencodings' can still be converted to euc-jp, causing Vim to read the file as latin1 instead of as the current euc-jp encoding. Read the generated EUC-JP file explicitly as EUC-JP on Solaris.