### PR TITLE
disable keyprotocol query before suspend tests

### DIFF
--- a/src/testdir/test_suspend.vim
+++ b/src/testdir/test_suspend.vim
@@ -30,7 +30,8 @@ func Test_suspend()
 
   call term_sendkeys(buf, v:progpath
         \               . " --clean -X"
-        \               . " -c 'set nu keyprotocol='"
+        \               . " --cmd 'set t_RK= keyprotocol='"
+        \               . " -c 'set nu'"
         \               . " -c 'call setline(1, \"foo\")'"
         \               . " Xfoo\<CR>")
   " Cursor in terminal buffer should be on first line in spawned vim.
@@ -80,7 +81,8 @@ func Test_suspend_autocmd()
 
   call term_sendkeys(buf, v:progpath
         \               . " --clean -X"
-        \               . " -c 'set nu keyprotocol='"
+        \               . " --cmd 'set t_RK= keyprotocol='"
+        \               . " -c 'set nu'"
         \               . " -c 'let g:count = 0'"
         \               . " -c 'au VimSuspend * let g:count += 1'"
         \               . " -c 'au VimResume * let g:count += 1'"


### PR DESCRIPTION
The nested Vim can send a keyprotocol query during startup.  If the terminal response arrives at the wrong time, the nested Vim may not consume it and the response can be written to the inner terminal, leaving characters such as 4;2m after the shell prompt when the test later suspends Vim.

The previous command tried to avoid that with -c 'set keyprotocol=', but -c commands are applied too late.  Use --cmd 'set t_RK= keyprotocol=' so the inner Vim disables the query before startup can send it.