### PR TITLE
use UTF-8 locale for composing terminal test on Solaris

### DIFF
--- a/src/testdir/test_terminal.vim
+++ b/src/testdir/test_terminal.vim
@@ -1150,7 +1150,11 @@ func Test_terminal_composing_unicode()
   endif
 
   enew
-  let buf = term_start(cmd, {'curwin': 1})
+  let term_opts = {'curwin': 1}
+  if has('sun')
+    let term_opts.env = {'LC_ALL': 'C.UTF-8'}
+  endif
+  let buf = term_start(cmd, term_opts)
   let g:job = term_getjob(buf)
   call WaitFor({-> term_getline(buf, 1) !=# ''}, 1000)
 


### PR DESCRIPTION
Test_terminal_composing_unicode() can run its child shell in a locale where readline echoes combining UTF-8 input as octal byte escapes.  Force a UTF-8 locale for the terminal job on Solaris so the test observes the composed input it sends.