### PR TITLE
use Solaris name limit for swap names

### DIFF
--- a/src/os_unix.h
+++ b/src/os_unix.h
@@ -122,6 +122,11 @@ typedef void (*sighandler_T) SIGPROTOARG;
 # define MAXNAMLEN NAME_MAX	    // for Linux before .99p3
 #endif
 
+#if defined(__sun)
+# undef MAXNAMLEN
+# define MAXNAMLEN 255
+#endif
+
 /*
  * Note: if MAXNAMLEN has the wrong value, you will get error messages
  *	 for not being able to open the swap file.


### PR DESCRIPTION
Solaris dirent.h exposes MAXNAMLEN as 512, but the usable value is in param.h. Vim uses MAXNAMLEN to derive BASENAMELEN for generated swap file names, so it tries to rename swap files to overlong components and gets ENAMETOOLONG.

Use the effective Solaris component limit for swap name generation.