### PR TITLE
fix(make): clipboard.o missing WAYLAND C/CPP flags

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -3287,7 +3287,7 @@ objects/clientserver.o: clientserver.c
 	$(CCC) -o $@ clientserver.c
 
 objects/clipboard.o: clipboard.c $(WAYLAND_SRC)
-	$(CCC) -o $@ clipboard.c
+	$(CCC) $(WAYLAND_CFLAGS) $(WAYLAND_CPPFLAGS) -o $@ clipboard.c
 
 objects/cmdexpand.o: cmdexpand.c
 	$(CCC) -o $@ cmdexpand.c


### PR DESCRIPTION
Reopening. 
[20565](https://github.com/vim/vim/pull/20565) depends on this.

We assume the `pkg-config` returned gtk includes will include wayland for `clipboard.c` currently.

(Important caveat: `with-wayland=yes` is actually a *standalone wayland event loop* for terminal vim, unrelated to gui.)

Be explicit ensuring `clipboard.c` always compiles, consistent with the other files.

gtk3 contains ` -I/usr/include/wayland -` since it supports wayland.
```
pkg-config --cflags-only-I gtk+-3.0
-I/usr/include/gtk-3.0 -I/usr/include/pango-1.0 -I/usr/include/cairo -I/usr/include/gdk-pixbuf-2.0 -I/usr/include/glycin-2 -I/usr/include/libseccomp -I/usr/include/at-spi2-atk/2.0 -I/usr/include/at-spi-2.0 -I/usr/include/atk-1.0 -I/usr/include/dbus-1.0 -I/usr/lib64/dbus-1.0/include -I/usr/include/libxkbcommon -I/usr/include/wayland -I/usr/include/fribidi -I/usr/include/libpng16 -I/usr/include/pixman-1 -I/usr/include/harfbuzz -I/usr/include/freetype2 -I/usr/include/gio-unix-2.0 -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/libmount -I/usr/include/blkid
```

gtk2 does not.
```
pkg-config --cflags-only-I gtk+-2.0
-I/usr/include/gtk-2.0 -I/usr/lib64/gtk-2.0/include -I/usr/include/pango-1.0 -I/usr/include/atk-1.0 -I/usr/include/gdk-pixbuf-2.0 -I/usr/include/glycin-2 -I/usr/include/libseccomp -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/fribidi -I/usr/include/cairo -I/usr/include/libpng16 -I/usr/include/pixman-1 -I/usr/include/harfbuzz -I/usr/include/freetype2 -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include
```

(renamed branch and reworded commit so old PR was closed https://github.com/vim/vim/pull/20408)