### PR TITLE
Fix ':delete #' clobbering register "0

### DIFF
--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -1332,10 +1332,11 @@ and ":put" commands and with CTRL-R.
 		the command was executed completely from a mapping.
 		{not available when compiled without the |+cmdline_hist|
 		feature}
-							*quote_#* *quote#*
-6. Alternate file register "#
+
+6. Alternate file register "#			*quote_#* *quote#* *@#*
 Contains the |alternate-file| name for current window
-This register is writeable and changes which buffer CTRL-^ enters.
+This register is writable with `:let` and |setreg()|.  This changes which buffer
+CTRL-^ enters.  You can't yank or delete into this register.
 A String is matched against existing buffer names, like |:buffer|: >
     let @# = 'buffer_name'
 Also supports using buffer number and |file-pattern|.
@@ -1398,11 +1399,12 @@ When writing to this register, nothing happens.  This can be used to delete
 text without affecting the normal registers.  When reading from this register,
 nothing is returned.
 
-10. Last search pattern register	"/		*quote_/* *quote/*
+10. Last search pattern register "/			*quote_/* *quote/*
 Contains the most recent search-pattern.  This is used for "n" and 'hlsearch'.
-It is writable with `:let`, you can change it to have 'hlsearch' highlight
-other matches without actually searching.  You can't yank or delete into this
-register.  The search direction is available in |v:searchforward|.
+This register is writable with `:let` and |setreg()|.  You can change it to have
+'hlsearch' highlight other matches without actually searching.  You can't yank
+or delete into this register.  The search direction is available in
+|v:searchforward|.
 Note that the value is restored when returning from a function
 |function-search-undo|.
 

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -4015,6 +4015,7 @@ $quote	eval.txt	/*$quote*
 ?<CR>	pattern.txt	/*?<CR>*
 ??	eval.txt	/*??*
 @	repeat.txt	/*@*
+@#	change.txt	/*@#*
 @/	change.txt	/*@\/*
 @:	repeat.txt	/*@:*
 @=	change.txt	/*@=*

--- a/src/errors.h
+++ b/src/errors.h
@@ -2287,8 +2287,8 @@ EXTERN char e_line_count_changed_unexpectedly[]
 #ifdef FEAT_EVAL
 EXTERN char e_uniq_compare_function_failed[]
 	INIT(= N_("E882: Uniq compare function failed"));
-EXTERN char e_search_pattern_and_expression_register_may_not_contain_two_or_more_lines[]
-	INIT(= N_("E883: Search pattern and expression register may not contain two or more lines"));
+EXTERN char e_register_char_cannot_contain_multiple_lines[]
+	INIT(= N_("E883: Register '%c' cannot contain multiple lines"));
 EXTERN char e_function_name_cannot_contain_colon_str[]
 	INIT(= N_("E884: Function name cannot contain a colon: %s"));
 #endif

--- a/src/register.c
+++ b/src/register.c
@@ -181,12 +181,11 @@ valid_yank_reg(
     if (       (regname > 0 && ASCII_ISALNUM(regname))
 	    || (!writing && vim_strchr((char_u *)
 #ifdef FEAT_EVAL
-				    "/.%:="
+				    "/#.%:="
 #else
-				    "/.%:"
+				    "/#.%:"
 #endif
 					, regname) != NULL)
-	    || regname == '#'
 	    || regname == '"'
 	    || regname == '-'
 	    || regname == '_'
@@ -3093,7 +3092,7 @@ write_reg_contents_lst(
 {
     yankreg_T  *old_y_previous, *old_y_current;
 
-    if (name == '/' || name == '=')
+    if (name == '/' || name == '=' || name == '#')
     {
 	char_u	*s;
 
@@ -3101,7 +3100,7 @@ write_reg_contents_lst(
 	    s = (char_u *)"";
 	else if (strings[1] != NULL)
 	{
-	    emsg(_(e_search_pattern_and_expression_register_may_not_contain_two_or_more_lines));
+	    semsg(_(e_register_char_cannot_contain_multiple_lines), name);
 	    return;
 	}
 	else

--- a/src/testdir/test_excmd.vim
+++ b/src/testdir/test_excmd.vim
@@ -4,11 +4,24 @@ source util/screendump.vim
 
 func Test_ex_delete()
   new
+
   call setline(1, ['a', 'b', 'c'])
   2
   " :dl is :delete with the "l" flag, not :dlist
   .dl
   call assert_equal(['a', 'c'], getline(1, 2))
+  %delete _
+
+  " :delete # used to clobber "0
+  call setreg('#', '')
+  call setreg('0', '')
+  call setline(1, ['a', 'b', 'c'])
+  call assert_fails("1delete #", 'E488:')
+  call assert_equal(['a', 'b', 'c'], getline(1, '$'))
+  call assert_equal('', getreg('#'))
+  call assert_equal('', getreg('0'))
+
+  bw!
 endfunc
 
 func Test_range_error()

--- a/src/testdir/test_registers.vim
+++ b/src/testdir/test_registers.vim
@@ -415,6 +415,7 @@ func Test_set_register()
   call assert_equal('', @=)
   call assert_fails("call setreg('/', ['a', 'b'])", 'E883:')
   call assert_fails("call setreg('=', ['a', 'b'])", 'E883:')
+  call assert_fails("call setreg('#', ['a', 'b'])", 'E883:')
   call assert_equal(0, setreg('_', ['a', 'b']))
 
   " Test for recording to a invalid register

--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -1481,7 +1481,7 @@ valid_dest_reg(int name)
 {
     if (name == '@')
        name = '"';
-    if (name == '/' || name == '=' || valid_yank_reg(name, TRUE))
+    if (name == '/' || name == '=' || name == '#' || valid_yank_reg(name, TRUE))
 	return TRUE;
     emsg_invreg(name);
     return FAIL;


### PR DESCRIPTION
Problem:  ':delete #' silently fails to update "# and clobbers "0.
Solution: Treat "# like "/, writable only with :let and setreg().

