### PR TITLE
filetype completion mishandles finished sub options

### DIFF
--- a/src/cmdexpand.c
+++ b/src/cmdexpand.c
@@ -2455,13 +2455,13 @@ set_context_in_filetype_cmd(expand_T *xp, char_u *arg)
 
     for (;;)
     {
-	if (STRNCMP(p, "plugin", 6) == 0)
+	if (STRNCMP(p, "plugin", 6) == 0 && VIM_ISWHITE(p[6]))
 	{
 	    val |= EXPAND_FILETYPECMD_PLUGIN;
 	    p = skipwhite(p + 6);
 	    continue;
 	}
-	if (STRNCMP(p, "indent", 6) == 0)
+	if (STRNCMP(p, "indent", 6) == 0 && VIM_ISWHITE(p[6]))
 	{
 	    val |= EXPAND_FILETYPECMD_INDENT;
 	    p = skipwhite(p + 6);

--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -3648,6 +3648,10 @@ func Test_completion_filetypecmd()
   call assert_equal('"filetype off on', @:)
   call feedkeys(":filetype indent of\<C-A>\<C-B>\"\<CR>", 'tx')
   call assert_equal('"filetype indent off', @:)
+  call feedkeys(":filetype plugin\<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"filetype plugin', @:)
+  call feedkeys(":filetype plugin indent\<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"filetype plugin indent', @:)
   set wildoptions&
 endfunc
 


### PR DESCRIPTION
Problem:  ":filetype plugin<Tab>" gives "pluginindent" because a
          sub option before the cursor is treated as already given.
Solution: only skip plugin and indent when followed by white space.