### PR TITLE
Wrong dot-repeat when calling complete() while filtering completion

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -3878,7 +3878,7 @@ set_completion(colnr_T startcol, list_T *list)
     int compl_no_select = (cur_cot_flags & COT_NOSELECT) != 0;
 
     // If already doing completions stop it.
-    if (ctrl_x_mode_not_default())
+    if (compl_started || ctrl_x_mode_not_default())
 	ins_compl_prep(' ');
     ins_compl_clear();
     ins_compl_free();

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -6401,4 +6401,20 @@ func Test_smartcase_longest()
   delfunc TestInner
 endfunc
 
+" Check that calling complete() while filtering Ctrl-N completion doesn't
+" break dot-repeat.
+func Test_call_complete_while_filtering()
+  new
+  setlocal complete=. completeopt=menuone,noselect
+  inoremap <buffer> <F2> <Cmd>call complete(3, ['obar', 'obaz'])<CR>
+  call setline(1, ['foobar', 'foobaz'])
+
+  call feedkeys("Gofo\<C-N>ob\<F2>cd\<Esc>", 'tx')
+  call assert_equal(['foobar', 'foobaz', 'foobcd'], getline(1, '$'))
+  normal! .
+  call assert_equal(['foobar', 'foobaz', 'foobcd', 'foobcd'], getline(1, '$'))
+
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab nofoldenable


### PR DESCRIPTION
Problem:  Wrong dot-repeat when calling complete() while filtering
          Ctrl-N completion.
Solution: Also check compl_started for whether completion is active.

related: neovim/neovim#40346
