### PR TITLE
:windo and :tabdo create an extra window with 'winfixbuf'

### DIFF
--- a/src/ex_cmds2.c
+++ b/src/ex_cmds2.c
@@ -478,7 +478,11 @@ ex_listdo(exarg_T *eap)
     buf_T	*buf = curbuf;
     int		next_fnum = 0;
 
-    if (curwin->w_p_wfb)
+    // ":windo" and ":tabdo" only visit existing windows/tabpages, they don't
+    // change the current window's buffer, so they can't escape a 'winfixbuf'
+    // window (which would create a split).
+    if (curwin->w_p_wfb && eap->cmdidx != CMD_windo &&
+	    eap->cmdidx != CMD_tabdo)
     {
 	if ((eap->cmdidx == CMD_ldo || eap->cmdidx == CMD_lfdo) &&
 		!eap->forceit)

--- a/src/testdir/test_winfixbuf.vim
+++ b/src/testdir/test_winfixbuf.vim
@@ -2857,36 +2857,34 @@ func Test_tNext()
   set tags&
 endfunc
 
-" Call :tabdo and choose the next available 'nowinfixbuf' window.
-func Test_tabdo_choose_available_window()
+" Call :tabdo and stay in the 'winfixbuf' window: it only visits tabpages and
+" doesn't change the current buffer, so it must not switch to another window
+" even when a 'nowinfixbuf' window is available.
+func Test_tabdo_stay_in_winfixbuf_window()
   call s:reset_all_buffers()
 
   let [l:first, _] = s:make_args_list()
 
-  " Make a split window that is 'nowinfixbuf' but make it the second-to-last
-  " window so that :tabdo will first try the 'winfixbuf' window, pass over it,
-  " and prefer the other 'nowinfixbuf' window, instead.
-  "
   " +-------------------+
   " |   'nowinfixbuf'   |
   " +-------------------+
   " |    'winfixbuf'    |  <-- Cursor is here
   " +-------------------+
   split
-  let l:nowinfixbuf_window = win_getid()
   " Move to the 'winfixbuf' window now
   exe "normal \<C-w>j"
   let l:winfixbuf_window = win_getid()
 
   let l:expected_windows = s:get_windows_count()
   tabdo echo ''
-  call assert_equal(l:nowinfixbuf_window, win_getid())
+  call assert_equal(l:winfixbuf_window, win_getid())
   call assert_equal(l:first, bufnr())
   call assert_equal(l:expected_windows, s:get_windows_count())
 endfunc
 
-" Call :tabdo and create a new split window if all available windows are 'winfixbuf'.
-func Test_tabdo_make_new_window()
+" Call :tabdo and do not create a new window even when the only window is
+" 'winfixbuf'.
+func Test_tabdo_no_new_window()
   call s:reset_all_buffers()
 
   let [l:first, _] = s:make_buffers_list()
@@ -2896,11 +2894,9 @@ func Test_tabdo_make_new_window()
   let l:current_windows = s:get_windows_count()
 
   tabdo echo ''
-  call assert_notequal(l:current, win_getid())
+  call assert_equal(l:current, win_getid())
   call assert_equal(l:first, bufnr())
-  exe "normal \<C-w>j"
-  call assert_equal(l:first, bufnr())
-  call assert_equal(l:current_windows + 1, s:get_windows_count())
+  call assert_equal(l:current_windows, s:get_windows_count())
 endfunc
 
 " Fail :tag but :tag! is allowed
@@ -3212,6 +3208,23 @@ func Test_windo()
 
   exe $"windo buffer! {l:current_buffer}"
   call assert_equal(l:current_window, win_getid())
+endfunc
+
+" Call :windo and do not create a new window even when the only window is
+" 'winfixbuf'.
+func Test_windo_no_new_window()
+  call s:reset_all_buffers()
+
+  let [l:first, _] = s:make_buffers_list()
+  exe $"buffer! {l:first}"
+
+  let l:current = win_getid()
+  let l:current_windows = s:get_windows_count()
+
+  windo echo ''
+  call assert_equal(l:current, win_getid())
+  call assert_equal(l:first, bufnr())
+  call assert_equal(l:current_windows, s:get_windows_count())
 endfunc
 
 " Fail :wnext but :wnext! is allowed


### PR DESCRIPTION
Problem:
With 'winfixbuf' set in the current window, `:windo` and `:tabdo` create an
extra split window. For example, `vim --clean` then:

    :set winfixbuf
    :windo echo 'hello'

leaves you with two windows instead of one. This also affects startup
(`vim +'set winfixbuf'`), which is how vim-fugitive users hit it (#14301).

`ex_listdo()` escapes a 'winfixbuf' window up front by splitting a new
'nowinfixbuf' window so buffer-changing commands (`:bufdo`, `:argdo`, `:cdo`,
…) can switch buffers. But `:windo` and `:tabdo` only visit existing
windows/tabpages and never change the current window's buffer, so the escape
is unnecessary and the split is spurious.

Solution:
Skip the 'winfixbuf' escape in `ex_listdo()` for `:windo` and `:tabdo`.

Buffer-changing commands run via `:windo`/`:tabdo` (e.g. `:windo enew`,
`:windo edit foo`, `:windo buffer X`) remain protected: they now fail with
E1513 in a 'winfixbuf' window, exactly as the equivalent single command does
(plain `:enew`/`:edit`/`:buffer` already error with E1513 — they no longer
escape to a split). Non-buffer-changing commands like `:windo echo` are
allowed, which is the goal described in #14301.

Updated test_winfixbuf.vim:
- `Test_tabdo_choose_available_window` -> `Test_tabdo_stay_in_winfixbuf_window`
- `Test_tabdo_make_new_window` -> `Test_tabdo_no_new_window`
- Added `Test_windo_no_new_window`
(`Test_windo` already covers `:windo buffer` -> E1513.)

fixes: #14301
