### PR TITLE
use strtol for getdigits on Solaris

### DIFF
--- a/src/charset.c
+++ b/src/charset.c
@@ -2230,7 +2230,19 @@ getdigits(char_u **pp)
     long	retval;
 
     p = *pp;
+#ifdef __sun
+    errno = 0;
+    retval = strtol((char *)p, NULL, 10);
+    if (errno == ERANGE)
+    {
+	if (*p == '-')
+	    retval = LONG_MIN;
+	else
+	    retval = LONG_MAX;
+    }
+#else
     retval = atol((char *)p);
+#endif
     if (*p == '-')		// skip negative sign
 	++p;
     p = skipdigits(p);		// skip to next non-digit

--- a/src/charset.c
+++ b/src/charset.c
@@ -2262,7 +2262,7 @@ getdigits(char_u **pp)
     long	retval;
 
     p = *pp;
-    retval = atol((char *)p);
+    retval = strtol((char *)p, NULL, 10);
     if (*p == '-')		// skip negative sign
 	++p;
     p = skipdigits(p);		// skip to next non-digit


### PR DESCRIPTION
getdigits() uses atol(), whose overflow behavior is not portable.  On Solaris, overflowing atol() can return a wrapped positive value without ERANGE, so Ex address parsing (like :999999999999999999999print) misses the intended out-of-range condition.  Use strtol() on Solaris and clamp overflow to the same sentinel values expected by callers. This fixes the Test_address_line_overflow() failure in test_excmd.vim.