### PR TITLE
Surprising terminal behavior of title vs. icon

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4948,6 +4948,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 	restored if possible |X11|.  See |X11-icon| for changing the icon on
 	X11.
 	For MS-Windows the icon can be changed, see |windows-icon|.
+	NOTE: Some terminals treat the icon text as an alias for the window
+	title.  On those, setting the icon text may also change the terminal
+	window title; see 'title'.
 
 						*'iconstring'*
 'iconstring'		string	(default "")
@@ -9635,6 +9638,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 	then the WINDOWID environment variable should be inherited and the
 	title of the window should change back to what it should be after
 	exiting Vim.
+	NOTE: Some terminals treat the icon text as an alias for the window
+	title (see 'icon').  On those, the interaction between 'title' and
+	'icon' depend on the specific behavior of the terminal.
 
 								*'titlelen'*
 'titlelen'		number	(default 85)


### PR DESCRIPTION
Document that some terminals sets the 'icon' as window title. Just like
'title' would.  Which can be confusing and need to be documented for both
options.

closes: #20553