### PR TITLE
configure: Actually check whether -lrt is needed for timer_create

### DIFF
--- a/src/auto/configure
+++ b/src/auto/configure
@@ -15078,7 +15078,7 @@ main (void)
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_compile "$LINENO"
+if ac_fn_c_try_link "$LINENO"
 then :
   vim_cv_timer_create=yes
 else case e in #(
@@ -15086,7 +15086,8 @@ else case e in #(
    ;;
 esac
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext ;;
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext conftest.$ac_ext ;;
 esac
 fi
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $vim_cv_timer_create" >&5
@@ -15117,7 +15118,7 @@ main (void)
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_compile "$LINENO"
+if ac_fn_c_try_link "$LINENO"
 then :
   vim_cv_timer_create_with_lrt=yes
 else case e in #(
@@ -15125,7 +15126,8 @@ else case e in #(
      ;;
 esac
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext ;;
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext conftest.$ac_ext ;;
 esac
 fi
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $vim_cv_timer_create_with_lrt" >&5

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -4037,7 +4037,7 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
 
 dnl Check for timer_create. It probably requires the 'rt' library.
 AC_CACHE_CHECK([for timer_create without -lrt], [vim_cv_timer_create], [
-  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
+  AC_LINK_IFELSE([AC_LANG_PROGRAM([
   #include <time.h>
   ], [
     timer_create(CLOCK_MONOTONIC, NULL, NULL);
@@ -4051,7 +4051,7 @@ if test "x$vim_cv_timer_create" = "xno" ; then
   save_LIBS="$LIBS"
   LIBS="$LIBS -lrt"
   AC_CACHE_CHECK([for timer_create with -lrt], [vim_cv_timer_create_with_lrt], [
-    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
+    AC_LINK_IFELSE([AC_LANG_PROGRAM([
     #include <time.h>
     ], [
       timer_create(CLOCK_MONOTONIC, NULL, NULL);


### PR DESCRIPTION
AC_COMPILE_IFELSE won't try to link, so if the function exists in the
system headers, we will always detect that -lrt is not needed, as the
code will compile regardless of linker flags. If not cross-compiling,
the following AC_RUN_IFELSE will end up trying to link, so if -lrt is
needed it will fail to link and we will interpret timer_create as not
working, rather than that we just need to link with -lrt. But when we
are cross-compiling we will skip the AC_RUN_IFELSE and assume that it
works, failing to link when we later build if -lrt is in fact needed.

Fixes: 2cf145b78b88 ("patch 9.1.0837: cross-compiling has some issues")
Signed-off-by: Jessica Clarke <jrtc27@jrtc27.com>
