### PR TITLE
Problem: leak in ins_compl_infercase_gettext() in error case

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -699,6 +699,7 @@ ins_compl_infercase_gettext(
 	    if (ga_grow(&gap, 10) == FAIL)
 	    {
 		ga_clear(&gap);
+		vim_free(wca);
 		return (char_u *)"[failed]";
 	    }
 	    p = (char_u *)gap.ga_data + gap.ga_len;


### PR DESCRIPTION
Problem:  leak in ins_compl_infercase_gettext() in error case
          (Cheng)
Solution: free wca before returning.