### PR TITLE
GTK: Make popup images account for display scaling

### DIFF
--- a/src/cairo.c
+++ b/src/cairo.c
@@ -122,6 +122,7 @@ cairo_popup_image_ensure(win_T *wp)
 	cairo_surface_destroy(surf);
 	return false;
     }
+    cairo_surface_set_device_scale(surf, gui.scale, gui.scale);
     cairo_popup_image_fill_surface(wp, surf);
     wp->w_popup_image_surface = surf;
     return true;
@@ -163,7 +164,8 @@ cairo_popup_image_free(win_T *wp)
  * non-zero offsets to crop the portion that falls outside the host window.
  * Builds the cache on first call.  Caller is responsible for scheduling a
  * redraw of the target's owning widget if needed (e.g.
- * gtk_widget_queue_draw_area on GTK).
+ * gtk_widget_queue_draw_area on GTK). "x" and "y" are assumed to be in logical
+ * pixels, the rest are in physical pixels.
  */
     void
 cairo_popup_image_paint(
@@ -184,6 +186,10 @@ cairo_popup_image_paint(
 	return;
     cairo_surface_t *surface = (cairo_surface_t *)wp->w_popup_image_surface;
 
+    src_x = PHY2LOG((double)src_x);
+    src_y = PHY2LOG((double)src_y);
+    draw_w = PHY2LOG((double)draw_w);
+    draw_h = PHY2LOG((double)draw_h);
 
 # if !GTK_CHECK_VERSION(3,0,0)
     cr = gdk_cairo_create((GdkDrawable *)target);

--- a/src/cairo.c
+++ b/src/cairo.c
@@ -173,10 +173,10 @@ cairo_popup_image_paint(
 	void	*target,
 	int	 x,
 	int	 y,
-	int	 src_x,
-	int	 src_y,
-	int	 draw_w,
-	int	 draw_h)
+	double	 src_x,
+	double	 src_y,
+	double	 draw_w,
+	double	 draw_h)
 {
     cairo_t *cr;
 
@@ -186,10 +186,10 @@ cairo_popup_image_paint(
 	return;
     cairo_surface_t *surface = (cairo_surface_t *)wp->w_popup_image_surface;
 
-    src_x = PHY2LOG((double)src_x);
-    src_y = PHY2LOG((double)src_y);
-    draw_w = PHY2LOG((double)draw_w);
-    draw_h = PHY2LOG((double)draw_h);
+    src_x = PHY2LOG(src_x);
+    src_y = PHY2LOG(src_y);
+    draw_w = PHY2LOG(draw_w);
+    draw_h = PHY2LOG(draw_h);
 
 # if !GTK_CHECK_VERSION(3,0,0)
     cr = gdk_cairo_create((GdkDrawable *)target);

--- a/src/gui.c
+++ b/src/gui.c
@@ -676,7 +676,7 @@ gui_init(void)
      */
     gui.in_use = true;		// Must be set after menus have been set up
 #if defined(FEAT_GUI_GTK) && defined(FEAT_IMAGE)
-    gui.scale = 1; // Default value
+    gui.scale = 1.0; // Default value
 #endif
     if (gui_mch_init() == FAIL)
 	goto error;

--- a/src/gui.c
+++ b/src/gui.c
@@ -675,6 +675,9 @@ gui_init(void)
      * Create the GUI shell.
      */
     gui.in_use = true;		// Must be set after menus have been set up
+#if defined(FEAT_GUI_GTK) && defined(FEAT_IMAGE)
+    gui.scale = 1; // Default value
+#endif
     if (gui_mch_init() == FAIL)
 	goto error;
 

--- a/src/gui.h
+++ b/src/gui.h
@@ -104,8 +104,10 @@ typedef GdkEvent GdkEventKey;	// GTK4: GdkEventKey merged into GdkEvent
 # define Y_2_ROW(y)	(((y) - gui.border_offset) / gui.char_height)
 #endif
 #if defined(FEAT_GUI_GTK) && defined(FEAT_IMAGE)
-# define LOG2PHY(l) ((l) * gui.scale) // Logical pixels to physical pixels
-# define PHY2LOG(p) ((p) / gui.scale) // Physical pixels to logical pixels
+// Logical pixels to physical pixels
+# define LOG2PHY(l) (gui.in_use ? (double)(l) * gui.scale : (l))
+ // Physical pixels to logical pixels
+# define PHY2LOG(p) (gui.in_use ? (double)(p) / gui.scale : (p))
 #else
 # define LOG2PHY(l) (l)
 # define PHY2LOG(p) (p)
@@ -423,7 +425,7 @@ typedef struct Gui
     bool	is_wayland;	    // active gdk backend in gtk is wayland
 # endif
 # ifdef FEAT_IMAGE
-    int		scale;		    // Current scaling
+    double	scale;		    // Current scaling (may be fractional)
 # endif
 #endif	// FEAT_GUI_GTK
 

--- a/src/gui.h
+++ b/src/gui.h
@@ -103,6 +103,13 @@ typedef GdkEvent GdkEventKey;	// GTK4: GdkEventKey merged into GdkEvent
 # define FILL_Y(row)	((row) * gui.char_height + gui.border_offset)
 # define Y_2_ROW(y)	(((y) - gui.border_offset) / gui.char_height)
 #endif
+#if defined(FEAT_GUI_GTK) && defined(FEAT_IMAGE)
+# define LOG2PHY(l) ((l) * gui.scale) // Logical pixels to physical pixels
+# define PHY2LOG(p) ((p) / gui.scale) // Physical pixels to logical pixels
+#else
+# define LOG2PHY(l) (l)
+# define PHY2LOG(p) (p)
+#endif
 
 // Indices for arrays of scrollbars
 #define SBAR_NONE	    (-1)
@@ -414,6 +421,9 @@ typedef struct Gui
     guint32	event_time;
 # ifdef GDK_WINDOWING_WAYLAND
     bool	is_wayland;	    // active gdk backend in gtk is wayland
+# endif
+# ifdef FEAT_IMAGE
+    int		scale;		    // Current scaling
 # endif
 #endif	// FEAT_GUI_GTK
 

--- a/src/gui_gtk4.c
+++ b/src/gui_gtk4.c
@@ -300,9 +300,9 @@ static void mainwin_fullscreened_cb(GObject *obj, GParamSpec *pspec, gpointer us
 static void drawarea_realize_cb(GtkWidget *widget, gpointer data);
 static void drawarea_unrealize_cb(GtkWidget *widget, gpointer data);
 #ifndef USE_GTK4_SNAPSHOT
-static void drawarea_scale_factor_cb(GObject *object, GParamSpec *pspec, gpointer data);
 static cairo_surface_t *create_backing_surface(int width, int height);
 #endif
+static void drawarea_scale_factor_cb(GObject *object, GParamSpec *pspec, gpointer data);
 static void clipboard_changed_cb(GdkClipboard *clipboard, gpointer user_data);
 #ifdef FEAT_MENU
 static void show_menubar_popover(void);
@@ -569,14 +569,16 @@ gui_mch_init(void)
     // Set up drawing.
     gtk_drawing_area_set_draw_func(GTK_DRAWING_AREA(gui.drawarea),
 	    (GtkDrawingAreaDrawFunc)draw_event, NULL, NULL);
-
-    g_signal_connect(G_OBJECT(gui.drawarea), "notify::scale-factor",
-		     G_CALLBACK(drawarea_scale_factor_cb), NULL);
 #endif
     g_signal_connect(G_OBJECT(gui.drawarea), "realize",
 		     G_CALLBACK(drawarea_realize_cb), NULL);
     g_signal_connect(G_OBJECT(gui.drawarea), "unrealize",
 		     G_CALLBACK(drawarea_unrealize_cb), NULL);
+    g_signal_connect(G_OBJECT(gui.drawarea), "notify::scale-factor",
+		     G_CALLBACK(drawarea_scale_factor_cb), NULL);
+#ifdef FEAT_IMAGE
+    gui.scale = gtk_widget_get_scale_factor(gui.drawarea);
+#endif
 
     // Set up event controllers.
     {
@@ -2408,15 +2410,14 @@ gui_gtk4_resize(int width, int height)
 	}
     }
 }
+#endif
 
     static void
 drawarea_scale_factor_cb(GObject *object UNUSED,
 	GParamSpec *pspec UNUSED, gpointer data UNUSED)
 {
+#ifndef USE_GTK4
     int	w, h;
-
-    if (gui.drawarea == NULL)
-	return;
 
     w = gtk_widget_get_width(gui.drawarea);
     h = gtk_widget_get_height(gui.drawarea);
@@ -2437,8 +2438,12 @@ drawarea_scale_factor_cb(GObject *object UNUSED,
     gtk_widget_queue_draw(gui.drawarea);
     if (gui.in_use)
 	redraw_all_later(UPD_CLEAR);
-}
 #endif
+#if defined(FEAT_IMAGE)
+    gui.scale = gtk_widget_get_scale_factor(gui.drawarea);
+    popup_update_scale();
+#endif
+}
 
 typedef enum
 {

--- a/src/gui_gtk4.c
+++ b/src/gui_gtk4.c
@@ -2344,9 +2344,10 @@ drawarea_realize_cb(GtkWidget *widget UNUSED, gpointer data UNUSED)
 	// Use GdkSurface, as that handles fractional scale values.
 	GdkSurface *surface = gtk_native_get_surface(
 		gtk_widget_get_native(gui.drawarea));
+	double old = gui.scale;
 
 	gui.scale = gdk_surface_get_scale(surface);
-	popup_update_scale();
+	popup_update_scale(old);
 	g_signal_connect(G_OBJECT(surface), "notify::scale",
 		G_CALLBACK(scale_factor_cb), NULL);
     }
@@ -2446,8 +2447,12 @@ scale_factor_cb(GdkSurface  *surface,
 	redraw_all_later(UPD_CLEAR);
 #endif
 #if defined(FEAT_IMAGE)
-    gui.scale = gdk_surface_get_scale(surface);
-    popup_update_scale();
+    {
+	double old = gui.scale;
+
+	gui.scale = gdk_surface_get_scale(surface);
+	popup_update_scale(old);
+    }
 #endif
 }
 

--- a/src/gui_gtk4.c
+++ b/src/gui_gtk4.c
@@ -2346,6 +2346,7 @@ drawarea_realize_cb(GtkWidget *widget UNUSED, gpointer data UNUSED)
 		gtk_widget_get_native(gui.drawarea));
 
 	gui.scale = gdk_surface_get_scale(surface);
+	popup_update_scale();
 	g_signal_connect(G_OBJECT(surface), "notify::scale",
 		G_CALLBACK(scale_factor_cb), NULL);
     }

--- a/src/gui_gtk4.c
+++ b/src/gui_gtk4.c
@@ -302,7 +302,7 @@ static void drawarea_unrealize_cb(GtkWidget *widget, gpointer data);
 #ifndef USE_GTK4_SNAPSHOT
 static cairo_surface_t *create_backing_surface(int width, int height);
 #endif
-static void drawarea_scale_factor_cb(GObject *object, GParamSpec *pspec, gpointer data);
+static void scale_factor_cb(GdkSurface *surface, GParamSpec *pspec, void *udata);
 static void clipboard_changed_cb(GdkClipboard *clipboard, gpointer user_data);
 #ifdef FEAT_MENU
 static void show_menubar_popover(void);
@@ -574,11 +574,6 @@ gui_mch_init(void)
 		     G_CALLBACK(drawarea_realize_cb), NULL);
     g_signal_connect(G_OBJECT(gui.drawarea), "unrealize",
 		     G_CALLBACK(drawarea_unrealize_cb), NULL);
-    g_signal_connect(G_OBJECT(gui.drawarea), "notify::scale-factor",
-		     G_CALLBACK(drawarea_scale_factor_cb), NULL);
-#ifdef FEAT_IMAGE
-    gui.scale = gtk_widget_get_scale_factor(gui.drawarea);
-#endif
 
     // Set up event controllers.
     {
@@ -2345,6 +2340,15 @@ drawarea_realize_cb(GtkWidget *widget UNUSED, gpointer data UNUSED)
 	cairo_surface_destroy(gui.surface);
     gui.surface = create_backing_surface(w, h);
 #endif
+    {
+	// Use GdkSurface, as that handles fractional scale values.
+	GdkSurface *surface = gtk_native_get_surface(
+		gtk_widget_get_native(gui.drawarea));
+
+	gui.scale = gdk_surface_get_scale(surface);
+	g_signal_connect(G_OBJECT(surface), "notify::scale",
+		G_CALLBACK(scale_factor_cb), NULL);
+    }
 
     gui_mch_new_colors();
 }
@@ -2413,10 +2417,11 @@ gui_gtk4_resize(int width, int height)
 #endif
 
     static void
-drawarea_scale_factor_cb(GObject *object UNUSED,
-	GParamSpec *pspec UNUSED, gpointer data UNUSED)
+scale_factor_cb(GdkSurface  *surface,
+	GParamSpec	    *pspec UNUSED,
+	void		    *udata UNUSED)
 {
-#ifndef USE_GTK4
+#ifndef USE_GTK4_SNAPSHOT
     int	w, h;
 
     w = gtk_widget_get_width(gui.drawarea);
@@ -2440,7 +2445,7 @@ drawarea_scale_factor_cb(GObject *object UNUSED,
 	redraw_all_later(UPD_CLEAR);
 #endif
 #if defined(FEAT_IMAGE)
-    gui.scale = gtk_widget_get_scale_factor(gui.drawarea);
+    gui.scale = gdk_surface_get_scale(surface);
     popup_update_scale();
 #endif
 }

--- a/src/gui_gtk4_da.c
+++ b/src/gui_gtk4_da.c
@@ -1761,15 +1761,15 @@ vim_draw_area_add_image(
 	GdkTexture  *image,
 	int	    row,
 	int	    col,
-	int	    src_x,
-	int	    src_y,
-	int	    draw_w,
-	int	    draw_h,
+	double	    src_x,
+	double	    src_y,
+	double	    draw_w,
+	double	    draw_h,
 	int	    zindex,
 	int	    id)
 {
     GskRenderNode   *node, *old;
-    int		    w, h;
+    double	    w, h;
     graphene_rect_t clip;
     GList	    *link;
     DrawImage	    *dimg;
@@ -1781,10 +1781,10 @@ vim_draw_area_add_image(
 
     w = PHY2LOG(gdk_texture_get_width(image));
     h = PHY2LOG(gdk_texture_get_height(image));
-    src_x = PHY2LOG((double)src_x);
-    src_y = PHY2LOG((double)src_y);
-    draw_w = PHY2LOG((double)draw_w);
-    draw_h = PHY2LOG((double)draw_h);
+    src_x = PHY2LOG(src_x);
+    src_y = PHY2LOG(src_y);
+    draw_w = PHY2LOG(draw_w);
+    draw_h = PHY2LOG(draw_h);
 
     node = gsk_texture_scale_node_new(image,
 	    &GRAPHENE_RECT_INIT(FILL_X(col) - src_x, FILL_Y(row) - src_y,

--- a/src/gui_gtk4_da.c
+++ b/src/gui_gtk4_da.c
@@ -1752,7 +1752,8 @@ vim_draw_area_queue_image(VimDrawArea *self, GList *link)
  * (src_x, src_y, draw_w, draw_h) describe which pixel sub-rect of the source
  * texture should be drawn. If there is an image that has the same id, then it
  * is re-rendered with the new texture. If zindex of an image changed, then the
- * queue will be updated accordingly.
+ * queue will be updated accordingly. Note that the dimensions/positions are to
+ * be in physical pixels!!!
  */
     void
 vim_draw_area_add_image(
@@ -1778,12 +1779,16 @@ vim_draw_area_add_image(
 		|| col >= self->n_cols))
 	return;
 
-    w = gdk_texture_get_width(image);
-    h = gdk_texture_get_height(image);
+    w = PHY2LOG(gdk_texture_get_width(image));
+    h = PHY2LOG(gdk_texture_get_height(image));
+    src_x = PHY2LOG((double)src_x);
+    src_y = PHY2LOG((double)src_y);
+    draw_w = PHY2LOG((double)draw_w);
+    draw_h = PHY2LOG((double)draw_h);
 
-    node = gsk_texture_node_new(image,
+    node = gsk_texture_scale_node_new(image,
 	    &GRAPHENE_RECT_INIT(FILL_X(col) - src_x, FILL_Y(row) - src_y,
-		w, h));
+		w, h), GSK_SCALING_FILTER_TRILINEAR);
 
     if (node != NULL)
     {

--- a/src/gui_gtk4_da.h
+++ b/src/gui_gtk4_da.h
@@ -34,7 +34,7 @@ void vim_draw_area_add_sign(VimDrawArea *self, GdkTexture *sign, int row, int co
 void vim_draw_area_add_multisign(VimDrawArea *self, cairo_surface_t *surf, int row, int col, int width, int height);
 # endif
 # ifdef FEAT_IMAGE_GDK
-void vim_draw_area_add_image(VimDrawArea *self, GdkTexture *image, int row, int col, int src_x, int src_y, int draw_w, int draw_h, int zindex, int id);
+void vim_draw_area_add_image(VimDrawArea *self, GdkTexture *image, int row, int col, double src_x, double src_y, double draw_w, double draw_h, int zindex, int id);
 void vim_draw_area_remove_image(VimDrawArea *self, int id);
 # endif
 

--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -836,6 +836,10 @@ scale_factor_event(GtkWidget *widget,
     gui.force_redraw = 1;
     gui_resize_shell(w, usable_height);
     gui_gtk_form_thaw(GTK_FORM(gui.formwin));
+#  ifdef FEAT_IMAGE
+    gui.scale = gtk_widget_get_scale_factor(widget);
+    popup_update_scale();
+#  endif
 
     return TRUE;
 }
@@ -4284,6 +4288,10 @@ gui_mch_init(void)
 	g_signal_connect(gtk_settings, "notify::gtk-xft-dpi",
 			   G_CALLBACK(gtk_settings_xft_dpi_changed_cb), NULL);
     }
+
+#ifdef FEAT_IMAGE
+    gui.scale = gtk_widget_get_scale_factor(gui.formwin);
+#endif
 
     return OK;
 }

--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -837,8 +837,12 @@ scale_factor_event(GtkWidget *widget,
     gui_resize_shell(w, usable_height);
     gui_gtk_form_thaw(GTK_FORM(gui.formwin));
 #  ifdef FEAT_IMAGE
-    gui.scale = gtk_widget_get_scale_factor(widget);
-    popup_update_scale();
+    {
+	double old = gui.scale;
+
+	gui.scale = gtk_widget_get_scale_factor(widget);
+	popup_update_scale(old);
+    }
 #  endif
 
     return TRUE;

--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -3016,29 +3016,21 @@ popup_adjust_position(win_T *wp)
  * Should be called when scale factor changes.
  */
     void
-popup_update_scale(void)
+popup_update_scale(double old_scale)
 {
     win_T *wp;
+    double ratio = old_scale / gui.scale;
+
     FOR_ALL_POPUPWINS_IN_TAB(curtab, wp)
     {
 	// If the popup has an image, recalculate its bounding box in cells
 	if (wp->w_popup_image_data != NULL)
 	{
-	    int cx, cy;
-	    int cw, ch;
-
-	    cx = LOG2PHY(gui.char_width);
-	    cy = LOG2PHY(gui.char_height);
-
-	    // Calculate the new cell width and height
-	    cw = (wp->w_popup_image_w + cx - 1) / cx;
-	    ch = (wp->w_popup_image_h + cy - 1) / cy;
-
-	    // Update the window dimensions to fit the image at the new scale
-	    wp->w_minwidth  = cw;
-	    wp->w_maxwidth  = cw;
-	    wp->w_minheight = ch;
-	    wp->w_maxheight = ch;
+	    // Add +0.5 so that it rounds to nearest whole value
+	    wp->w_minwidth  = wp->w_minwidth * ratio + 0.5;
+	    wp->w_maxwidth  = wp->w_maxwidth * ratio + 0.5;
+	    wp->w_minheight = wp->w_minheight * ratio + 0.5;
+	    wp->w_maxheight = wp->w_maxheight * ratio + 0.5;
 	}
 
 	// Reflow the popup layout with the newly calculated limits

--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -3024,7 +3024,7 @@ popup_update_scale(void)
 	// If the popup has an image, recalculate its bounding box in cells
 	if (wp->w_popup_image_data != NULL)
 	{
-	    int cx = 8, cy = 16;
+	    int cx, cy;
 	    int cw, ch;
 
 	    cx = LOG2PHY(gui.char_width);

--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -1110,9 +1110,9 @@ apply_general_options(win_T *wp, dict_T *dict)
 			    if (gui.in_use)
 			    {
 				if (gui.char_width > 0)
-				    cx = gui.char_width;
+				    cx = LOG2PHY(gui.char_width);
 				if (gui.char_height > 0)
-				    cy = gui.char_height;
+				    cy = LOG2PHY(gui.char_height);
 			    }
 			    else
 #  endif
@@ -3010,6 +3010,43 @@ popup_adjust_position(win_T *wp)
 	popup_mask_refresh = TRUE;
     }
 }
+
+#if defined(FEAT_GUI_GTK) && defined(FEAT_IMAGE)
+/*
+ * Should be called when scale factor changes.
+ */
+    void
+popup_update_scale(void)
+{
+    win_T *wp;
+    FOR_ALL_POPUPWINS_IN_TAB(curtab, wp)
+    {
+	// If the popup has an image, recalculate its bounding box in cells
+	if (wp->w_popup_image_data != NULL)
+	{
+	    int cx = 8, cy = 16;
+	    int cw, ch;
+
+	    cx = LOG2PHY(gui.char_width);
+	    cy = LOG2PHY(gui.char_height);
+
+	    // Calculate the new cell width and height
+	    cw = (wp->w_popup_image_w + cx - 1) / cx;
+	    ch = (wp->w_popup_image_h + cy - 1) / cy;
+
+	    // Update the window dimensions to fit the image at the new scale
+	    wp->w_minwidth  = cw;
+	    wp->w_maxwidth  = cw;
+	    wp->w_minheight = ch;
+	    wp->w_maxheight = ch;
+	}
+
+	// Reflow the popup layout with the newly calculated limits
+	popup_adjust_position(wp);
+    }
+    redraw_later(UPD_CLEAR);
+}
+#endif
 
 typedef enum
 {
@@ -6820,9 +6857,13 @@ popup_image_gui_clip(
 	int	*draw_h)
 {
     popup_clip_T    cl;
-    int		    cell_x = gui.char_width > 0 ? gui.char_width : 8;
-    int		    cell_y = gui.char_height > 0 ? gui.char_height : 16;
+    // "gui.char_*" are in logical pixels, must convert to physical first,
+    // because all the other dimensions are in physical pixels.
+    int		    cell_x = LOG2PHY(gui.char_width > 0 ? gui.char_width : 8);
+    int		    cell_y = LOG2PHY(gui.char_height > 0 ? gui.char_height : 16);
     win_T	    *cw;
+    int		    visible_w;
+    int		    visible_h;
 
     popup_compute_clip(wp, &cl);
     *row += cl.clip_top_content;
@@ -6852,6 +6893,18 @@ popup_image_gui_clip(
 	*draw_w = 0;
     if (*draw_h < 0)
 	*draw_h = 0;
+
+    // If image is larger than the actual screen size, then clip it. Maybe best
+    // solution would be to somehow make popup win bigger than the screen size
+    // (as if 'nowrap' is on). However that would require a lot of changes so
+    // just clip the image for now.
+    visible_w = wp->w_width - cl.clip_left_content - cl.clip_right_content;
+    visible_h = wp->w_height - cl.clip_top_content - cl.clip_bot_content;
+
+    if (visible_w > 0)
+	*draw_w = MIN(*draw_w, visible_w * cell_x);
+    if (visible_h > 0)
+	*draw_h = MIN(*draw_h, visible_h * cell_y);
 }
 # endif
 
@@ -7080,12 +7133,12 @@ popup_emit_image(win_T *wp)
     // vim still thinks it is at the image origin, so the relative-move
     // optimisation would otherwise place the cursor on the line just
     // after the image.
-    out_str((char_u *)"\033[?25l");
+    cursor_off();
     term_windgoto(row, col);
     out_str(wp->w_popup_image_seq);
     screen_start();
     setcursor_mayforce(TRUE);
-    out_str((char_u *)"\033[?25h");
+    cursor_on();
     out_flush();
 
     // The sixel bytes just painted over every cell of the emitted rectangle,

--- a/src/proto/cairo.pro
+++ b/src/proto/cairo.pro
@@ -2,5 +2,5 @@
 bool cairo_popup_image_ensure(win_T *wp);
 bool cairo_popup_image_update(win_T *wp);
 void cairo_popup_image_free(win_T *wp);
-void cairo_popup_image_paint(win_T *wp, void *target, int x, int y, int src_x, int src_y, int draw_w, int draw_h);
+void cairo_popup_image_paint(win_T *wp, void *target, int x, int y, double src_x, double src_y, double draw_w, double draw_h);
 /* vim: set ft=c : */

--- a/src/proto/popupwin.pro
+++ b/src/proto/popupwin.pro
@@ -11,6 +11,7 @@ int popup_left_extra(win_T *wp);
 int popup_height(win_T *wp);
 int popup_width(win_T *wp);
 int popup_extra_width(win_T *wp);
+void popup_update_scale(void);
 int parse_previewpopup(win_T *wp);
 int parse_completepopup(win_T *wp);
 void popup_set_wantpos_cursor(win_T *wp, int width, dict_T *d);

--- a/src/proto/popupwin.pro
+++ b/src/proto/popupwin.pro
@@ -11,7 +11,7 @@ int popup_left_extra(win_T *wp);
 int popup_height(win_T *wp);
 int popup_width(win_T *wp);
 int popup_extra_width(win_T *wp);
-void popup_update_scale(void);
+void popup_update_scale(double old_scale);
 int parse_previewpopup(win_T *wp);
 int parse_completepopup(win_T *wp);
 void popup_set_wantpos_cursor(win_T *wp, int width, dict_T *d);


### PR DESCRIPTION
Make popup images account for display scaling in GTK GUI. Unfortunately GTK2 does not seem to have a way to query the scale factor, so this PR does not work for it.

Additionally, clip images if they are bigger than the screen size. Before, if an image was bigger than the screen size, it would go outside the popup window bounds. This fix only applies for the GUI, images in terminal still have this issue, but that requires a more complex change.