### PR TITLE
:syn sync without an argument also lists every syntax cluster

### DIFF
--- a/src/syntax.c
+++ b/src/syntax.c
@@ -3834,9 +3834,22 @@ syn_cmd_list(
 	    msg_puts(_("syncing on C-style comments"));
 	    syn_lines_msg();
 	    syn_match_msg();
-	    return;
 	}
-	else if (!(curwin->w_s->b_syn_sync_flags & SF_MATCH))
+	else if (curwin->w_s->b_syn_sync_flags & SF_MATCH)
+	{
+	    msg_puts_title(_("\n--- Syntax sync items ---"));
+	    if (curwin->w_s->b_syn_sync_minlines > 0
+		|| curwin->w_s->b_syn_sync_maxlines > 0
+		|| curwin->w_s->b_syn_sync_linebreaks > 0)
+	    {
+		msg_puts(_("\nsyncing on items"));
+		syn_lines_msg();
+		syn_match_msg();
+	    }
+	    for (id = 1; id <= highlight_num_groups() && !got_int; ++id)
+		syn_list_one(id, syncing, FALSE);
+	}
+	else
 	{
 	    if (curwin->w_s->b_syn_sync_minlines == 0)
 		msg_puts(_("no syncing"));
@@ -3852,20 +3865,11 @@ syn_cmd_list(
 		}
 		syn_match_msg();
 	    }
-	    return;
 	}
-	msg_puts_title(_("\n--- Syntax sync items ---"));
-	if (curwin->w_s->b_syn_sync_minlines > 0
-		|| curwin->w_s->b_syn_sync_maxlines > 0
-		|| curwin->w_s->b_syn_sync_linebreaks > 0)
-	{
-	    msg_puts(_("\nsyncing on items"));
-	    syn_lines_msg();
-	    syn_match_msg();
-	}
+	return;
     }
-    else
-	msg_puts_title(_("\n--- Syntax items ---"));
+
+    msg_puts_title(_("\n--- Syntax items ---"));
     if (ends_excmd2(eap->cmd, arg))
     {
 	/*

--- a/src/testdir/test_syntax.vim
+++ b/src/testdir/test_syntax.vim
@@ -419,6 +419,24 @@ func Test_syn_sync()
   call assert_match('SyncHere', execute('syntax sync'))
   syn sync clear
   call assert_notmatch('SyncHere', execute('syntax sync'))
+
+  syn sync minlines=10
+  syntax cluster xmlStuff contains=xmlGroup1,xmlGroup2
+  syntax region xmlComment start=/<!--/ end=/-->/ keepend contains=@Spell
+  syntax sync match xmlSync1 grouphere xmlComment /<!--/
+  syntax sync match xmlSync2 groupthere NONE /-->/
+  syntax cluster xmlAll contains=ALL
+  let out = execute('syntax sync')
+  call assert_match('xmlSync1', out)
+  call assert_match('xmlSync2', out)
+  call assert_match('grouphere xmlComment', out)
+  call assert_match('groupthere NONE', out)
+  call assert_notmatch('xmlStuff', out)
+  call assert_notmatch('xmlAll', out)
+  call assert_notmatch('cluster', out)
+  call assert_notmatch('keepend', out)
+  call assert_equal(4, len(split(out, '\n')))
+
   syn clear
 endfunc
 


### PR DESCRIPTION
Problem:  :syn sync without an argument also lists every syntax cluster
Solution: Fix control flow in syn_cmd_list() so that only the syncing
          items are printed when this function gets called by :syn sync.
          (dmitmel)