### PR TITLE
filetype: supertux related files are not recognized correctly

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1062,7 +1062,7 @@ au BufNewFile,BufRead .zshrc,.zshenv,.zlogin,.zlogout,.zcompdump,.zsh_history se
 au BufNewFile,BufRead *.zsh,*.zsh-theme,*.zunit		setf zsh
 
 " Scheme, Supertux configuration, Lips.js history, Guile init file ("racket" patterns are now separate, see above)
-au BufNewFile,BufRead *.scm,*.ss,*.sld,*.stsg,*/supertux2/config,.lips_repl_history,.guile	setf scheme
+au BufNewFile,BufRead *.scm,*.ss,*.sld,*.stwm,*.stl,*.stxt,*.sprite,*.strf,*.satc,*.stcd,*.stf,*.stcp,*.music,*.stsg,*/supertux2/config,supertux2/*/info,.lips_repl_history,.guile	setf scheme
 
 " SiSU
 au BufNewFile,BufRead *.sst.meta,*.-sst.meta,*._sst.meta setf sisu

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -729,7 +729,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     sass: ['file.sass'],
     sbt: ['file.sbt'],
     scala: ['file.scala', 'file.mill'],
-    scheme: ['file.scm', 'file.ss', 'file.sld', 'file.stsg', 'any/local/share/supertux2/config', '.lips_repl_history', '.guile'],
+    scheme: ['file.scm', 'file.ss', 'file.sld', 'file.stwm', 'file.stl', 'file.stxt', 'file.sprite', 'file.strf', 'file.satc', 'file.stcd', 'file.stf', 'file.stcp', 'file.music', 'file.stsg', 'any/local/share/supertux2/config', 'supertux2/levels/world1/info', '.lips_repl_history', '.guile'],
     scilab: ['file.sci', 'file.sce'],
     screen: ['.screenrc', 'screenrc'],
     scss: ['file.scss'],


### PR DESCRIPTION
Problem: supertux related files are not recognized correctly
Solution: recognize supertux related files as scheme

Continue #16287

https://github.com/SuperTux/supertux/wiki/S-Expression

levels:
*.stwm: supertux world map
https://github.com/SuperTux/supertux/wiki/Worldmap-Format
*.stl: supertux level
https://github.com/SuperTux/supertux/wiki/Level-Format

images:
*.sprite: supertux sprite
https://github.com/SuperTux/supertux/wiki/Sprite
*.strf: supertux tileset
https://github.com/SuperTux/supertux/wiki/Tileset
*.satc: supertux autotiles configuration
*.stcd: supertux converter data

font:
*.stf: supetux font

particles:
*.stcp: supertux custom particle

music:
*.music: supertux music

config:
~/.local/share/supertux2/config: supertux config
https://github.com/SuperTux/supertux/wiki/S-Expression#supertux-config-file
*.stsg: supertux save game
