### PR TITLE
CI: Restore Coverity

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,0 +1,85 @@
+name: Coverity
+on:
+  schedule:
+    - cron: '42 0 * * *'  # Run once per day, to avoid Coverity's submission limits
+  workflow_dispatch:
+
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
+jobs:
+  scan:
+    runs-on: ubuntu-24.04
+
+    env:
+      CC: gcc
+      DEBIAN_FRONTEND: noninteractive
+      TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
+
+    steps:
+      - name: Checkout repository from github
+        if: env.TOKEN
+        uses: actions/checkout@v6.0.2
+
+      - name: Download Coverity
+        if: env.TOKEN
+        run: |
+          wget -q https://scan.coverity.com/download/cxx/linux64 --post-data "token=$TOKEN&project=vim" -O coverity_tool.tgz
+          mkdir cov-scan
+          tar ax -f coverity_tool.tgz --strip-components=1 -C cov-scan
+
+      - name: Install packages
+        if: env.TOKEN
+        run: |
+          sudo apt-get update && sudo apt-get install -y \
+            autoconf \
+            gettext \
+            libcanberra-dev \
+            libperl-dev \
+            python3-dev \
+            liblua5.4-dev \
+            lua5.4 \
+            ruby-dev \
+            tcl-dev \
+            libgtk2.0-dev \
+            desktop-file-utils \
+            libtool-bin \
+            libsodium-dev
+
+      - name: Set up environment
+        if: env.TOKEN
+        run: |
+          echo "$(pwd)/cov-scan/bin" >> $GITHUB_PATH
+          (
+          echo "NPROC=$(getconf _NPROCESSORS_ONLN)"
+          echo "CONFOPT=--enable-perlinterp --enable-python3interp --enable-rubyinterp --enable-luainterp --enable-tclinterp"
+          ) >> $GITHUB_ENV
+
+      - name: Configure
+        if: env.TOKEN
+        run: |
+          ./configure --with-features=huge ${CONFOPT} --enable-fail-if-missing
+          # Append various warning flags to CFLAGS.
+          sed -i -f ci/config.mk.sed src/auto/config.mk
+          sed -i -f ci/config.mk.${CC}.sed src/auto/config.mk
+          # -O2 gives false warning and turns it into an error:
+          # warning: function may return address of local variable [-Wreturn-local-addr]
+          sed -i 's/-O2 \?//' src/auto/config.mk
+
+      - name: Build/scan vim
+        if: env.TOKEN
+        run: |
+          cov-build --dir cov-int make -j${NPROC}
+
+      - name: Submit results
+        if: env.TOKEN
+        run: |
+          tar zcf cov-scan.tgz cov-int
+          curl --form token=$TOKEN \
+            --form email=$EMAIL \
+            --form file=@cov-scan.tgz \
+            --form version="$(git rev-parse HEAD)" \
+            --form description="Automatic GHA scan" \
+            'https://scan.coverity.com/builds?project=vim'
+        env:
+          EMAIL: ${{ secrets.COVERITY_SCAN_EMAIL }}

--- a/Filelist
+++ b/Filelist
@@ -14,6 +14,7 @@ SRC_ALL =	\
 		.github/workflows/ci-windows.yml \
 		.github/workflows/ci.yml \
 		.github/workflows/codeql-analysis.yml \
+		.github/workflows/coverity.yml \
 		.github/workflows/link-check.yml \
 		.github/actions/build_vim_on_linux/action.yml \
 		.github/actions/test_artifacts/action.yml \

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Github Build status](https://github.com/vim/vim/workflows/GitHub%20CI/badge.svg)](https://github.com/vim/vim/actions?query=workflow%3A%22GitHub+CI%22)
 [![Coverage Status](https://codecov.io/gh/vim/vim/coverage.svg?branch=master)](https://codecov.io/gh/vim/vim?branch=master)
+[![Coverity Scan](https://scan.coverity.com/projects/241/badge.svg)](https://scan.coverity.com/projects/vim)
 [![Debian CI](https://badges.debian.net/badges/debian/testing/vim/version.svg)](https://buildd.debian.org/vim)
 [![Packages](https://repology.org/badge/tiny-repos/vim.svg)](https://repology.org/metapackage/vim)
 [![Fossies codespell report](https://fossies.org/linux/test/vim-master.tar.gz/codespell.svg)](https://fossies.org/linux/test/vim-master.tar.gz/codespell.html)

--- a/ci/lychee.toml
+++ b/ci/lychee.toml
@@ -26,6 +26,7 @@ exclude = [
   '^file://.*',
   '^https?://(www\.)?badges\.debian\.net/.*$',
   '^https?://(www\.)?repology\.org/.*$',
+  '^https?://scan\.coverity\.com/.*$',
   '^https?://(www\.)?img\.shields\.io/.*$',
   '^https?://(www\.)?fossies\.org/.*$',
   '^https?://(www\.)?adobe\.com.*$',

--- a/runtime/doc/todo.txt
+++ b/runtime/doc/todo.txt
@@ -1,4 +1,4 @@
-*todo.txt*	For Vim version 9.2.  Last change: 2026 Jun 12
+*todo.txt*	For Vim version 9.2.  Last change: 2026 Jun 23
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -1998,6 +1998,9 @@ Dominique can't reproduce it.
 
 ":function f(x) keepjumps" creates a function where every command is executed
 like it has ":keepjumps" before it.
+
+Coverity: Check if there are new reported defects:
+https://scan.coverity.com/projects/241
 
 Problem with editing file in binary mode. (Ingo Krabbe, 2009 Oct 8)
 


### PR DESCRIPTION
I finally got a note that Coverity is online back again.

This partially reverts commit 0abffbff23adc4ae6e3c78af921a8c9a8cb6670f. ("CI: Remove Cirrus CI and Coverity Scan")

related: #20431