### PR TITLE
fix use after free when freeing exit_cb from job on exit

### DIFF
--- a/src/testdir/test_vim9_func.vim
+++ b/src/testdir/test_vim9_func.vim
@@ -2,6 +2,7 @@
 
 import './util/vim9.vim' as v9
 source util/screendump.vim
+source util/shared.vim
 
 func Test_def_basic()
   def SomeFunc(): string
@@ -5043,6 +5044,29 @@ def Test_void_method_chain()
     TestFunc()
   END
   v9.CheckScriptFailure(lines, 'E1186: Expression does not result in a value: bufload(')
+enddef
+
+def Test_term_wait_in_job_exit_cb()
+  CheckUnix
+  CheckFeature terminal
+
+  var cmd = g:GetVimCommand()
+
+  var lines =<< eval trim END
+      var buf: number = term_start(["{cmd}", "+q"], {{}})
+
+      var job: job = term_getjob(buf)
+
+      job_setoptions(job, {{
+      exit_cb: (_, _) => {{
+        term_wait(buf)
+          }}
+      }})
+  END
+
+  # This shouldn't cause an ASAN error immediately, but will result in a use
+  # after free when Vim exits.
+  v9.CheckDefSuccess(lines)
 enddef
 
 " vim: ts=8 sw=2 sts=2 expandtab tw=80 fdm=marker

--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -5238,7 +5238,7 @@ delete_def_function_contents(dfunc_T *dfunc, int mark_deleted)
     void
 unlink_def_function(ufunc_T *ufunc)
 {
-    if (ufunc->uf_dfunc_idx <= 0)
+    if (ufunc->uf_dfunc_idx <= 0 || def_functions.ga_data == NULL)
 	return;
 
     dfunc_T *dfunc = ((dfunc_T *)def_functions.ga_data)


### PR DESCRIPTION
`def_functions` is may already be cleared.
```
Thread 1 "vim" received signal SIGSEGV, Segmentation fault.
0x0000555557c9a0ca in unlink_def_function (ufunc=0x7d7ff2bc7480) at vim9compile.c:5247
5247        if (--dfunc->df_refcount <= 0)
(gdb) bt
#0  0x0000555557c9a0ca in unlink_def_function (ufunc=0x7d7ff2bc7480)
    at vim9compile.c:5247
#1  0x0000555557be7492 in func_clear (fp=0x7d7ff2bc7480, force=0) at userfunc.c:2769
#2  0x0000555557be77d3 in func_clear_free (fp=0x7d7ff2bc7480, force=0)
    at userfunc.c:2804
#3  0x0000555557c0adbd in func_ptr_unref (fp=0x7d7ff2bc7480) at userfunc.c:6389
#4  0x0000555557166ec7 in partial_free (pt=0x7d2ff28dbb00) at eval.c:6158
#5  0x00005555571677a8 in partial_unref (pt=0x7d2ff28dbb00) at eval.c:6199
#6  0x0000555557204522 in free_callback (callback=0x7cbff2801bc0) at evalvars.c:5388
#7  0x0000555557e9d767 in job_free_contents (job=0x7cbff2801b80) at job.c:778
#8  0x0000555557e9de8b in job_free (job=0x7cbff2801b80) at job.c:814
#9  0x0000555557e9dfcb in job_free_all () at job.c:850
#10 0x0000555556f18084 in free_all_mem () at alloc.c:558
#11 0x00005555576b7f14 in mch_exit (r=0) at os_unix.c:3735
#12 0x0000555557f3072c in getout (exitval=0) at main.c:1870
#13 0x00005555572835e5 in ex_quit (eap=0x7bfff1786050) at ex_docmd.c:6174
#14 0x0000555557256c7b in do_one_cmd (cmdlinep=0x7bfff1898830, flags=0, 
    cstack=0x7bfff1898950, fgetline=0x5555572d8629 <getexline>, cookie=0x0)
    at ex_docmd.c:2629
#15 0x0000555557249aad in do_cmdline (cmdline=0x0, 
    fgetline=0x5555572d8629 <getexline>, cookie=0x0, flags=0) at ex_docmd.c:1041
#16 0x00005555575bdad9 in nv_colon (cap=0x7bfff14fe170) at normal.c:3187
#17 0x00005555575a7bf6 in normal_cmd (oap=0x7bfff15cfe30, toplevel=1) at normal.c:955
#18 0x0000555557f2f9c2 in main_loop (cmdwin=0, noexmode=0) at main.c:1646
#19 0x0000555557f2de3c in vim_main2 () at main.c:977
#20 0x0000555557f2d234 in main (argc=2, argv=0x7fffffffdc48) at main.c:453
```