### PR TITLE
Restore terminal window using proportions not exact size

### DIFF
--- a/src/terminal.c
+++ b/src/terminal.c
@@ -1116,11 +1116,14 @@ term_write_session(FILE *fd, win_T *wp, hashtab_T *terminal_bufs)
     // Create the terminal and run the command.  This is not without
     // risk, but let's assume the user only creates a session when this
     // will be OK.
-    if (fprintf(fd, "terminal ++curwin ++cols=%d ++rows=%d ",
-		term->tl_cols, term->tl_rows) < 0)
+    if (fprintf(fd, "exe ':terminal ++curwin"
+		" ++cols=' .. ((&columns * %d + %ld) / %ld)"
+		" .. ' ++rows=' .. ((&lines * %d + %ld) / %ld) ",
+		term->tl_cols, Columns / 2, Columns,
+		term->tl_rows, Rows / 2, Rows) < 0)
 	return FAIL;
 # ifdef MSWIN
-    if (fprintf(fd, "++type=%s ", term->tl_job->jv_tty_type) < 0)
+    if (fprintf(fd, ".. ' ++type=%s' ", term->tl_job->jv_tty_type) < 0)
 	return FAIL;
 # endif
     if (term->tl_command != NULL && fputs((char *)term->tl_command, fd) < 0)

--- a/src/testdir/test_mksession.vim
+++ b/src/testdir/test_mksession.vim
@@ -466,13 +466,13 @@ func Test_mksession_terminal_shell()
   let lines = readfile('Xtest_mks.out')
   let term_cmd = ''
   for line in lines
-    if line =~ '^terminal'
+    if line =~ '^exe '':terminal'
       let term_cmd = line
     elseif line =~ 'badd.*' . &shell
       call assert_report('unexpected shell line: ' . line)
     endif
   endfor
-  call assert_match('terminal ++curwin ++cols=\d\+ ++rows=\d\+\s*.*$', term_cmd)
+  call assert_match('exe '':terminal ++curwin ++cols='' \.\. ((&columns \* \d\+ + \d\+) \/ \d\+) \.\. '' ++rows='' \.\. ((&lines \* \d\+ + \d\+) \/ \d\+)\s.*$', term_cmd)
 
   call StopShellInTerminal(bufnr('%'))
   call delete('Xtest_mks.out')
@@ -486,7 +486,7 @@ func Test_mksession_terminal_no_restore_cmdarg()
   let lines = readfile('Xtest_mks.out')
   let term_cmd = ''
   for line in lines
-    if line =~ '^terminal'
+    if line =~ '^exe '':terminal'
       call assert_report('session must not restore terminal')
     endif
   endfor
@@ -503,7 +503,7 @@ func Test_mksession_terminal_no_restore_funcarg()
   let lines = readfile('Xtest_mks.out')
   let term_cmd = ''
   for line in lines
-    if line =~ '^terminal'
+    if line =~ '^exe '':terminal'
       call assert_report('session must not restore terminal')
     endif
   endfor
@@ -521,7 +521,7 @@ func Test_mksession_terminal_no_restore_func()
   let lines = readfile('Xtest_mks.out')
   let term_cmd = ''
   for line in lines
-    if line =~ '^terminal'
+    if line =~ '^exe '':terminal'
       call assert_report('session must not restore terminal')
     endif
   endfor
@@ -539,7 +539,7 @@ func Test_mksession_terminal_no_ssop()
   let lines = readfile('Xtest_mks.out')
   let term_cmd = ''
   for line in lines
-    if line =~ '^terminal'
+    if line =~ '^exe '':terminal'
       call assert_report('session must not restore terminal')
     endif
   endfor
@@ -559,11 +559,11 @@ func Test_mksession_terminal_restore_other()
   let lines = readfile('Xtest_mks.out')
   let term_cmd = ''
   for line in lines
-    if line =~ '^terminal'
+    if line =~ '^exe '':terminal'
       let term_cmd = line
     endif
   endfor
-  call assert_match('terminal ++curwin ++cols=\d\+ ++rows=\d\+.*other', term_cmd)
+  call assert_match('exe '':terminal ++curwin ++cols='' \.\. ((&columns \* \d\+ + \d\+) \/ \d\+) \.\. '' ++rows='' \.\. ((&lines \* \d\+ + \d\+) \/ \d\+).*other', term_cmd)
 
   call StopShellInTerminal(bufnr('%'))
   call delete('Xtest_mks.out')
@@ -584,9 +584,9 @@ func Test_mksession_terminal_shared_windows()
   let found_var = 0
 
   for line in lines
-    if line =~ '^terminal'
+    if line =~ '^exe '':terminal'
       let found_creation = 1
-      call assert_match('terminal ++curwin ++cols=\d\+ ++rows=\d\+', line)
+      call assert_match('exe '':terminal ++curwin ++cols='' \.\. ((&columns \* \d\+ + \d\+) \/ \d\+) \.\. '' ++rows='' \.\. ((&lines \* \d\+ + \d\+) \/ \d\+)', line)
     elseif line =~ $"^var term_buf_{term_buf}: number = bufnr()$"
       let found_var = 1
     elseif line =~ "^execute 'buffer ' . term_buf_" . term_buf . "$"


### PR DESCRIPTION
Use the same logic that normal windows use for terminal windows, by preserving proportions, not exact size.

Fixes #20622

