### PR TITLE
GTK4: Calculate scrollbar size in gui_mch_enable_scrollbar()

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -1735,11 +1735,6 @@ gui_set_shellsize(
     if (!gui.shell_created)
 	return;
 
-#if defined(FEAT_GUI_GTK) && defined(USE_GTK4)
-    // Get the scrollbar width + height if possible
-    gui_mch_update_scrollbar_size();
-#endif
-
 #if defined(MSWIN) || defined(FEAT_GUI_GTK)
     // If not setting to a user specified size and maximized, calculate the
     // number of characters that fit in the maximized window.

--- a/src/gui_gtk4.c
+++ b/src/gui_gtk4.c
@@ -2767,6 +2767,64 @@ gui_mch_forked(void)
 }
 
 /*
+ * Try getting the actual size of the scrollbar, and update gui.scrollbar_width
+ * and gui.scrollbar_height.
+ */
+    static void
+gui_gtk4_update_scrollbar_size(void)
+{
+    win_T	*wp;
+    int		w = -1, h = -1;
+    GtkWidget	*sbar;
+
+    FOR_ALL_WINDOWS(wp)
+    {
+	sbar = wp->w_scrollbars[SBAR_LEFT].id;
+
+	if (sbar == NULL || !gtk_widget_get_visible(sbar)
+		|| (!gui.which_scrollbars[SBAR_LEFT]
+		    && wp->w_scrollbars[SBAR_RIGHT].id != NULL))
+	    sbar = wp->w_scrollbars[SBAR_RIGHT].id;
+
+	if (sbar != NULL && gtk_widget_get_visible(sbar))
+	{
+	    GtkRequisition  min, nat;
+	    int		    sw;
+
+	    // Use preferred size, since widget may not have its size allocated
+	    // yet.
+	    gtk_widget_get_preferred_size(sbar, &min, &nat);
+	    sw = MAX(min.width, nat.width);
+	    if (sw > 0)
+	    {
+		w = sw;
+		break;
+	    }
+	}
+
+    }
+
+    sbar = gui.bottom_sbar.id;
+    if (sbar != NULL && gtk_widget_get_visible(sbar))
+    {
+	GtkRequisition min, nat;
+	int		    sh;
+
+	gtk_widget_get_preferred_size(sbar, &min, &nat);
+	sh = MAX(min.height, nat.height);
+
+	if (sh > 0)
+	    h = sh;
+    }
+
+    if (w != -1)
+	gui.scrollbar_width = w;
+    if (h != -1)
+	gui.scrollbar_height = h;
+}
+
+
+/*
  * ============================================================
  * Scrollbar
  * ============================================================
@@ -2776,7 +2834,14 @@ gui_mch_forked(void)
 gui_mch_enable_scrollbar(scrollbar_T *sb, int flag)
 {
     if (sb->id != NULL)
+    {
+	gboolean was_visible = gtk_widget_get_visible(sb->id);
+
 	gtk_widget_set_visible(sb->id, flag);
+
+	if (!was_visible && flag)
+	    gui_gtk4_update_scrollbar_size();
+    }
 }
 
 #if defined(FEAT_MENU)
@@ -4654,63 +4719,6 @@ gui_mch_destroy_scrollbar(scrollbar_T *sb)
 	vim_form_remove(VIM_FORM(gui.formwin), sb->id);
 	sb->id = NULL;
     }
-}
-
-/*
- * Try getting the actual size of the scrollbar, and update gui.scrollbar_width
- * and gui.scrollbar_height.
- */
-    void
-gui_mch_update_scrollbar_size(void)
-{
-    win_T	*wp;
-    int		w = -1, h = -1;
-    GtkWidget	*sbar;
-
-    FOR_ALL_WINDOWS(wp)
-    {
-	sbar = wp->w_scrollbars[SBAR_LEFT].id;
-
-	if (sbar == NULL || !gtk_widget_get_visible(sbar)
-		|| (!gui.which_scrollbars[SBAR_LEFT]
-		    && wp->w_scrollbars[SBAR_RIGHT].id != NULL))
-	    sbar = wp->w_scrollbars[SBAR_RIGHT].id;
-
-	if (sbar != NULL && gtk_widget_get_visible(sbar))
-	{
-	    GtkRequisition  min, nat;
-	    int		    sw;
-
-	    // Use preferred size, since widget may not have its size allocated
-	    // yet.
-	    gtk_widget_get_preferred_size(sbar, &min, &nat);
-	    sw = MAX(min.width, nat.width);
-	    if (sw > 0)
-	    {
-		w = sw;
-		break;
-	    }
-	}
-
-    }
-
-    sbar = gui.bottom_sbar.id;
-    if (sbar != NULL && gtk_widget_get_visible(sbar))
-    {
-	GtkRequisition min, nat;
-	int		    sh;
-
-	gtk_widget_get_preferred_size(sbar, &min, &nat);
-	sh = MAX(min.height, nat.height);
-
-	if (sh > 0)
-	    h = sh;
-    }
-
-    if (w != -1)
-	gui.scrollbar_width = w;
-    if (h != -1)
-	gui.scrollbar_height = h;
 }
 
 /*

--- a/src/proto/gui_gtk4.pro
+++ b/src/proto/gui_gtk4.pro
@@ -102,7 +102,6 @@ int gui_mch_get_scrollbar_xpadding(void);
 int gui_mch_get_scrollbar_ypadding(void);
 void gui_mch_create_scrollbar(scrollbar_T *sb, int orient);
 void gui_mch_destroy_scrollbar(scrollbar_T *sb);
-void gui_mch_update_scrollbar_size(void);
 void gui_mch_set_text_area_pos(int x, int y, int w, int h);
 void gui_gtk_calculate_bleed(int width, int height);
 char_u *gui_mch_browse(int saving, char_u *title, char_u *dflt, char_u *ext, char_u *initdir, char_u *filter);


### PR DESCRIPTION
This seems to fix the issue for me of the right scrollbar bounds going off the maximized window on startup.

Before:
<img width="330" height="1814" alt="image" src="https://github.com/user-attachments/assets/a1d9e0ba-d413-4a99-865e-7f02b183d745" />

After:
<img width="330" height="1814" alt="image" src="https://github.com/user-attachments/assets/ce589d86-a5c0-4682-8399-b270cf101f91" />
