### PR TITLE
doc: Add installer updates to version9.txt

### DIFF
--- a/runtime/doc/version9.txt
+++ b/runtime/doc/version9.txt
@@ -52664,6 +52664,13 @@ Platform specific ~
 - support OpenType font features in 'guifont' for DirectWrite (Win32)
 - Include strptime() fallback for MS-Windows
 - Hardware-accelerated rendering for the GTK4 GUI via |gtk4-hwaccel|.
+- The NSIS installer has been reworked:
+  - Support per-user and per-machine install.
+  - Change the install directory structure.
+  - Replace the batch files with the Vim launchers.
+  - Support adding the Vim directory to PATH.
+  - Support selecting install components from the command line options.
+  - Move the source code to the vim/vim-win32-installer repository.
 
 xxd ~
 ---


### PR DESCRIPTION
The NSIS installer has been reworked in https://github.com/vim/vim-win32-installer/pull/457.
Add the updates to version9.txt.