### PR TITLE
% skips parens on continued quoted lines

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -2664,9 +2664,9 @@ findmatchlimit(
 		    do_quotes = 1;
 		    if (start_in_quotes == MAYBE)
 		    {
-			// Do we need to use at_start here?
-			inquote = TRUE;
-			start_in_quotes = TRUE;
+			inquote = at_start;
+			if (inquote)
+			    start_in_quotes = TRUE;
 		    }
 		    else if (backwards)
 			inquote = TRUE;

--- a/src/testdir/test_search.vim
+++ b/src/testdir/test_search.vim
@@ -2166,6 +2166,19 @@ func Test_search_match_paren()
   normal [(
   call assert_equal([1, 4], [line('.'), col('.')])
 
+  call setline(1, ['x" (a "b" )\', '")'])
+  call cursor(1, 4)
+  normal %
+  call assert_equal([1, 11], [line('.'), col('.')])
+  normal %
+  call assert_equal([1, 4], [line('.'), col('.')])
+  call cursor(1, 10)
+  normal [(
+  call assert_equal([1, 4], [line('.'), col('.')])
+  call cursor(1, 4)
+  normal ])
+  call assert_equal([1, 11], [line('.'), col('.')])
+
   " matching parenthesis in 'virtualedit' mode with cursor after the eol
   call setline(1, 'abc(defgh)')
   set virtualedit=all

--- a/src/testdir/test_textobjects.vim
+++ b/src/testdir/test_textobjects.vim
@@ -648,6 +648,16 @@ func Test_textobj_find_paren_forward()
   normal 0di)
   call assert_equal('foo ()', getline(1))
 
+  call setline(1, ['x" (a "b" )\', '")'])
+  call cursor(1, 6)
+  normal va)y
+  call assert_equal('(a "b" )', @")
+
+  call setline(1, ['x" [a "b" ]\', '"]'])
+  call cursor(1, 6)
+  normal va]y
+  call assert_equal('[a "b" ]', @")
+
   bw!
 endfunc
 


### PR DESCRIPTION
related: neovim/neovim#23171

## Problem

The "%" command and bracket/text-object motions can skip the matching paren or bracket on a line with quotes and a trailing backslash.

For example, with the cursor over the letter left of `|`:

```text
x" (|a "b" )\
")
```

From the `(`, `%` and `])` can skip the same-line `)` and use the `)` on the next line instead.

## Solution

Use the quote state at the search start when an odd-quote line is continued with a backslash, instead of always treating the search as starting in quotes.