### PR TITLE
GTK4: queue resize for form widget when not visible

### DIFF
--- a/src/gui_gtk4.c
+++ b/src/gui_gtk4.c
@@ -2825,8 +2825,10 @@ gui_mch_draw_menubar(void)
     void
 gui_mch_show_tabline(int showit)
 {
-    if (gui.tabline != NULL)
-	gtk_widget_set_visible(gui.tabline, showit);
+    if (gui.tabline == NULL)
+	return;
+    gtk_widget_set_visible(gui.tabline, showit);
+    gui_mch_update();
 }
 
     int

--- a/src/gui_gtk4_f.c
+++ b/src/gui_gtk4_f.c
@@ -174,6 +174,8 @@ vim_form_move_resize(
 	gint	    h)
 {
     gtk_widget_set_size_request(widget, w, h);
+    if (!gtk_widget_get_visible(widget))
+	gtk_widget_queue_resize(widget);
     vim_form_move(self, widget, x, y);
 }
 


### PR DESCRIPTION
Seems to fix scrollbar size not being updated when restoring session. Unrelated change: call gui_mch_update() when showing tabline as well, because thats what the GTK3 GUI does

Before (top scrollbar overlaps with bottom one, despite its height request being correct):
<img width="330" height="1814" alt="image" src="https://github.com/user-attachments/assets/c299b3ca-2eac-416d-8676-34490a7b6f99" />

After:
<img width="330" height="1814" alt="image" src="https://github.com/user-attachments/assets/1cc79a69-9603-4b9b-923c-4ce57d23a233" />
