### PR TITLE
syntax: add 'scrollbar-gutter' keyword in CSS

### DIFF
--- a/runtime/syntax/css.vim
+++ b/runtime/syntax/css.vim
@@ -207,6 +207,8 @@ syn match cssBoxProp contained "\<overflow\%(-\%(x\|y\|style\)\)\=\>"
 syn match cssBoxProp contained "\<rotation\%(-point\)\=\>"
 syn keyword cssBoxAttr contained visible hidden scroll auto
 syn match cssBoxAttr contained "\<no-\%(display\|content\)\>"
+syn keyword cssBoxProp contained scrollbar-gutter
+syn keyword cssBoxAttr contained auto stable both-edges
 
 syn keyword cssCascadeProp contained all
 syn keyword cssCascadeAttr contained initial unset revert


### PR DESCRIPTION
This is defined in the 'CSS Overflow Module Level 3' spec[1] and supported by recent versions of all browsers reported by MDN[2]

Link: https://drafts.csswg.org/css-overflow/#scrollbar-gutter-property [1]
Link: https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/scrollbar-gutter#browser_compatibility [2]