### PR TITLE
patch 9.2.NNNN: function pointer passed to STRNCMP() instead of a length

### DIFF
--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -3516,7 +3516,7 @@ expand_set_popupoption(optexpand_T *args, int *numMatches, char_u ***matches,
 	int is_border = xp->xp_pattern - args->oe_set_arg >= border_len &&
 		STRNCMP(xp->xp_pattern - border_len, "border:", border_len) == 0;
 	int is_close = xp->xp_pattern - args->oe_set_arg >= close_len &&
-		STRNCMP(xp->xp_pattern - close_len, "close:", close) == 0;
+		STRNCMP(xp->xp_pattern - close_len, "close:", close_len) == 0;
 	int is_resize = xp->xp_pattern - args->oe_set_arg >= resize_len &&
 		STRNCMP(xp->xp_pattern - resize_len, "resize:", resize_len) == 0;
 	int is_shadow = xp->xp_pattern - args->oe_set_arg >= shadow_len &&

--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -663,6 +663,9 @@ func Test_set_completion_string_values()
   call feedkeys(":set completepopup=height:10,align:\<Tab>\<C-B>\"\<CR>", 'xt')
   call assert_equal('"set completepopup=height:10,align:item', @:)
   call assert_equal([], getcompletion('set completepopup=bogusname:', 'cmdline'))
+  call assert_equal(['on', 'off'], getcompletion('set completepopup=close:', 'cmdline'))
+  call assert_equal(['on', 'off'], getcompletion('set completepopup=close:o', 'cmdline'))
+  call assert_equal(['off'], getcompletion('set previewpopup=close:of', 'cmdline'))
 
   " opacity: numeric, 0..100 only
   call assert_true(index(getcompletion('set completepopup=', 'cmdline'),


### PR DESCRIPTION
Problem:  In the popup 'close' option-value completion check, a function pointer (the address of close()) was passed as STRNCMP()'s third argument instead of the string length.
Solution: Pass the length (close_len). (Shane Harper)

The user-visible effect was negligible: ":set completepopup=close:o\<Tab\>" offered no completions instead of "on" and "off".