### PR TITLE
allow complete_check() interrupt for mapped typed keys

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -6408,9 +6408,10 @@ ins_compl_check_keys(int frequency, int in_compl_func)
 	    c = safe_vgetc();
 	    if (c != K_IGNORE)
 	    {
-		// Don't interrupt completion when the character wasn't typed,
-		// e.g., when doing @q to replay keys.
-		if (c != Ctrl_R && KeyTyped)
+		// Typed keys that get mapped lose KeyTyped. Still let
+		// complete_check() interrupt, except during @r replay.
+		if (c != Ctrl_R && (KeyTyped
+			    || (in_compl_func && reg_executing == 0)))
 		    compl_interrupted = TRUE;
 
 		vungetc(c);

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -6515,4 +6515,32 @@ func Test_call_complete_while_filtering()
   bwipe!
 endfunc
 
+func Test_complete_check_mapped_typed_key()
+  func SlowComplete(findstart, base)
+    if a:findstart
+      return col('.') - 1
+    endif
+    call complete_add('foobar')
+    let g:compl_iterations = 0
+    while !complete_check() && g:compl_iterations < 100
+      let g:compl_iterations += 1
+      sleep 5m
+    endwhile
+    return []
+  endfunc
+
+  new
+  setlocal completefunc=SlowComplete
+  setlocal completeopt=menuone,noselect
+  inoremap <buffer> <Space> <Space><Space>
+
+  let g:compl_iterations = -1
+  call feedkeys("Sfoo\<C-X>\<C-U> \<Esc>", 'tx')
+  call assert_inrange(0, 99, g:compl_iterations)
+
+  bwipe!
+  delfunc SlowComplete
+  unlet g:compl_iterations
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab nofoldenable


### PR DESCRIPTION
Problem: Mapped typed keys didn't interrupt completion because KeyTyped was cleared.
Solution: Also interrupt when in_compl_func and not replaying a register.

Fix #5547