### PR TITLE
refactor comment package to allow simpler tests

### DIFF
--- a/runtime/pack/dist/opt/comment/autoload/comment.vim
+++ b/runtime/pack/dist/opt/comment/autoload/comment.vim
@@ -1,7 +1,7 @@
 vim9script
 
 # Maintainer: Maxim Kim <habamax@gmail.com>
-# Last Update: 2025-06-13
+# Last Update: 2026-06-27
 #
 # Toggle comments
 # Usage:
@@ -11,70 +11,68 @@ vim9script
 #       xnoremap <silent> <expr> gc comment.Toggle()
 #       nnoremap <silent> <expr> gcc comment.Toggle() .. '_'
 #       nnoremap <silent> <expr> gC  comment.Toggle() .. '$'
-export def Toggle(...args: list<string>): string
-    if len(args) == 0
-        &opfunc = matchstr(expand('<stack>'), '[^. ]*\ze[')
-        return 'g@'
-    endif
-    if empty(&cms) || !&ma | return '' | endif
-    var cms = substitute(substitute(&cms, '\S\zs%s\s*', ' %s', ''), '%s\ze\S', '%s ', '')
-    var [lnum1, lnum2] = [line("'["), line("']")]
-    var cms_l = split(escape(cms, '*.\^$['), '\s*%s\s*')
+export def Toggle(): string
+    &opfunc = (_) => {
+      if empty(&cms) || !&ma | return | endif
+      var cms = substitute(substitute(&cms, '\S\zs%s\s*', ' %s', ''), '%s\ze\S', '%s ', '')
+      var [lnum1, lnum2] = [line("'["), line("']")]
+      var cms_l = split(escape(cms, '*.\^$['), '\s*%s\s*')
 
-    var first_col = indent(lnum1)
-    var start_col = getpos("'[")[2] - 1
-    if len(cms_l) == 1 && lnum1 == lnum2 && first_col < start_col
+      var first_col = indent(lnum1)
+      var start_col = getpos("'[")[2] - 1
+      if len(cms_l) == 1 && lnum1 == lnum2 && first_col < start_col
         var line_start = getline(lnum1)[0 : start_col - 1]
         var line_end = getline(lnum1)[start_col : -1]
         line_end = line_end =~ $'\c^\s*{cms_l[0]}' ?
-                    \ substitute(line_end, $'\c^\s*\zs{cms_l[0]}\s\ze\s*', line_end =~ '^\s' ? ' ' : '', '') :
-                    \ printf(substitute(cms, '%s\@!', '%%', ''), line_end)
+              \ substitute(line_end, $'\c^\s*\zs{cms_l[0]}\s\ze\s*', line_end =~ '^\s' ? ' ' : '', '') :
+              \ printf(substitute(cms, '%s\@!', '%%', ''), line_end)
         setline(lnum1, line_start .. line_end)
-        return ''
-    endif
+        return
+      endif
 
-    if len(cms_l) == 0 | return '' | endif
-    if len(cms_l) == 1 | call add(cms_l, '') | endif
-    var comment = false
-    var indent_spaces = false
-    var indent_tabs = false
-    var indent_min = indent(lnum1)
-    var indent_start = matchstr(getline(lnum1), '^\s*')
-    for lnum in range(lnum1, lnum2)
+      if len(cms_l) == 0 | return | endif
+      if len(cms_l) == 1 | call add(cms_l, '') | endif
+      var comment = false
+      var indent_spaces = false
+      var indent_tabs = false
+      var indent_min = indent(lnum1)
+      var indent_start = matchstr(getline(lnum1), '^\s*')
+      for lnum in range(lnum1, lnum2)
         if getline(lnum) =~ '^\s*$' | continue | endif
         var indent_str = matchstr(getline(lnum), '^\s*')
         if indent_min > indent(lnum)
-            indent_min = indent(lnum)
-            indent_start = indent_str
+          indent_min = indent(lnum)
+          indent_start = indent_str
         endif
         indent_spaces = indent_spaces || (stridx(indent_str, ' ') != -1)
         indent_tabs = indent_tabs || (stridx(indent_str, "\t") != -1)
         if getline(lnum) !~ $'\c^\s*{cms_l[0]}.*{cms_l[1]}$'
-            comment = true
+          comment = true
         endif
-    endfor
-    var mixed_indent = indent_spaces && indent_tabs
-    var lines = []
-    var line = ''
-    for lnum in range(lnum1, lnum2)
+      endfor
+      var mixed_indent = indent_spaces && indent_tabs
+      var lines = []
+      var line = ''
+      for lnum in range(lnum1, lnum2)
         if getline(lnum) =~ '^\s*$'
-            line = getline(lnum)
+          line = getline(lnum)
         elseif comment
-            if exists("g:comment_first_col") || exists("b:comment_first_col")
-                line = printf(substitute(cms, '%s\@!', '%%', 'g'), getline(lnum))
-            else
-                # consider different whitespace indenting
-                var indent_current = mixed_indent ? matchstr(getline(lnum), '^\s*') : indent_start
-                line = printf(indent_current .. substitute(cms, '%s\@!', '%%', 'g'),
-                    strpart(getline(lnum), strlen(indent_current)))
-            endif
+          if exists("g:comment_first_col") || exists("b:comment_first_col")
+            line = printf(substitute(cms, '%s\@!', '%%', 'g'), getline(lnum))
+          else
+            # consider different whitespace indenting
+            var indent_current = mixed_indent ? matchstr(getline(lnum), '^\s*') : indent_start
+            line = printf(indent_current .. substitute(cms, '%s\@!', '%%', 'g'),
+              strpart(getline(lnum), strlen(indent_current)))
+          endif
         else
-            line = substitute(getline(lnum), $'\c^\s*\zs{cms_l[0]} \?\| \?{cms_l[1]}$', '', 'g')
+          line = substitute(getline(lnum), $'\c^\s*\zs{cms_l[0]} \?\| \?{cms_l[1]}$', '', 'g')
         endif
         add(lines, line)
-    endfor
-    noautocmd keepjumps setline(lnum1, lines)
-    return ''
+      endfor
+      noautocmd keepjumps setline(lnum1, lines)
+    }
+    return 'g@'
 enddef
 
 

--- a/src/testdir/test_plugin_comment.vim
+++ b/src/testdir/test_plugin_comment.vim
@@ -1,6 +1,7 @@
 " Test for the comment package
 
-CheckRunVimInTerminal
+packadd comment
+
 func Test_basic_comment()
   let lines =<< trim END
     vim9script
@@ -10,18 +11,15 @@ func Test_basic_comment()
     enddef
   END
 
-  let input_file = "test_basic_comment_input.vim"
-  call writefile(lines, input_file, "D")
+  enew
+  call setline(1, lines)
+  filetype plugin on
+  set ft=vim
 
-  let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
-  call term_sendkeys(buf, "gcc")
-  call term_sendkeys(buf, "2jgcip")
-  let output_file = "comment_basic_test.vim"
-  call term_sendkeys(buf, $":w {output_file}\<CR>")
-  defer delete(output_file)
+  normal gcc
+  normal 2jgcip
 
-  call StopVimInTerminal(buf)
-  let result = readfile(output_file)
+  let result = getline(1, '$')
   call assert_equal(["# vim9script", "", "# def Hello()", '#   echo "Hello"', "# enddef"], result)
 endfunc
 
@@ -34,18 +32,15 @@ func Test_basic_uncomment()
     # enddef
   END
 
-  let input_file = "test_basic_uncomment_input.vim"
-  call writefile(lines, input_file, "D")
+  enew
+  call setline(1, lines)
+  filetype plugin on
+  set ft=vim
 
-  let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
-  call term_sendkeys(buf, "gcc")
-  call term_sendkeys(buf, "2jgcip")
-  let output_file = "uncomment_basic_test.vim"
-  call term_sendkeys(buf, $":w {output_file}\<CR>")
-  defer delete(output_file)
+  normal gcc
+  normal 2jgcip
 
-  call StopVimInTerminal(buf)
-  let result = readfile(output_file)
+  let result = getline(1, '$')
   call assert_equal(["# vim9script", "", "def Hello()", '  echo "Hello"', "enddef"], result)
 endfunc
 
@@ -55,17 +50,14 @@ func Test_backward_slash_uncomment()
     .\" .TL Test backward slash uncomment
   END
 
-  let input_file = "Test_backward_slash_uncomment_input.mom"
-  call writefile(lines, input_file, "D")
+  enew
+  call setline(1, lines)
+  filetype plugin on
+  set ft=nroff
 
-  let buf = RunVimInTerminal('-c "packadd comment" -c "set ft=nroff" ' .. input_file, {})
-  call term_sendkeys(buf, "gcc")
-  let output_file = "backward_slash_uncomment_test.mom"
-  call term_sendkeys(buf, $":w {output_file}\<CR>")
-  defer delete(output_file)
+  normal gcc
 
-  call StopVimInTerminal(buf)
-  let result = readfile(output_file)
+  let result = getline(1, '$')
   call assert_equal([".TL Test backward slash uncomment"], result)
 endfunc
 
@@ -74,17 +66,14 @@ func Test_caseinsensitive_uncomment()
       rem echo "Hello"
   END
 
-  let input_file = "test_caseinsensitive_uncomment_input.bat"
-  call writefile(lines, input_file, "D")
+  enew
+  call setline(1, lines)
+  filetype plugin on
+  set ft=dosbatch
 
-  let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
-  call term_sendkeys(buf, "gcc")
-  let output_file = "comment_testinsensitive_uncomment_test.bat"
-  call term_sendkeys(buf, $":w {output_file}\<CR>")
-  defer delete(output_file)
+  normal gcc
 
-  call StopVimInTerminal(buf)
-  let result = readfile(output_file)
+  let result = getline(1, '$')
   call assert_equal(['echo "Hello"'], result)
 endfunc
 
@@ -93,17 +82,14 @@ func Test_bothends_comment()
     int main() {}
   END
 
-  let input_file = "test_bothends_comment_input.c"
-  call writefile(lines, input_file, "D")
+  enew
+  call setline(1, lines)
+  filetype plugin on
+  set ft=c
 
-  let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
-  call term_sendkeys(buf, "gcc")
-  let output_file = "comment_bothends_test.c"
-  call term_sendkeys(buf, $":w {output_file}\<CR>")
-  defer delete(output_file)
+  normal gcc
 
-  call StopVimInTerminal(buf)
-  let result = readfile(output_file)
+  let result = getline(1, '$')
   call assert_equal(["/* int main() {} */"], result)
 endfunc
 
@@ -114,17 +100,14 @@ func Test_bothends_uncomment()
     /* } */
   END
 
-  let input_file = "test_bothends_uncomment_input.c"
-  call writefile(lines, input_file, "D")
+  enew
+  call setline(1, lines)
+  filetype plugin on
+  set ft=c
 
-  let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
-  call term_sendkeys(buf, "gcip")
-  let output_file = "uncomment_bothends_test.c"
-  call term_sendkeys(buf, $":w {output_file}\<CR>")
-  defer delete(output_file)
+  normal gcip
 
-  call StopVimInTerminal(buf)
-  let result = readfile(output_file)
+  let result = getline(1, '$')
   call assert_equal(["int main() {", "  return 0;", "}"], result)
 endfunc
 
@@ -135,17 +118,14 @@ func Test_mixed_comment()
       # print(x*x)
   END
 
-  let input_file = "test_mixed_comment_input.py"
-  call writefile(lines, input_file, "D")
+  enew
+  call setline(1, lines)
+  filetype plugin on
+  set ft=python
 
-  let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
-  call term_sendkeys(buf, "gcG")
-  let output_file = "comment_mixed_test.py"
-  call term_sendkeys(buf, $":w {output_file}\<CR>")
-  defer delete(output_file)
+  normal gcG
 
-  call StopVimInTerminal(buf)
-  let result = readfile(output_file)
+  let result = getline(1, '$')
   call assert_equal(["# for x in range(10):", "#   # print(x)", "#   # print(x*x)"], result)
 endfunc
 
@@ -156,34 +136,28 @@ func Test_mixed_comment2()
       # print(x*x)
   END
 
-  let input_file = "test_mixed_comment_input2.py"
-  call writefile(lines, input_file, "D")
+  enew
+  call setline(1, lines)
+  filetype plugin on
+  set ft=python
 
-  let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
-  call term_sendkeys(buf, "gcG")
-  let output_file = "comment_mixed_test2.py"
-  call term_sendkeys(buf, $":w {output_file}\<CR>")
-  defer delete(output_file)
+  normal gcG
 
-  call StopVimInTerminal(buf)
-  let result = readfile(output_file)
+  let result = getline(1, '$')
   call assert_equal(["# # for x in range(10):", "#   print(x)", "#   # print(x*x)"], result)
 endfunc
 
 func Test_mixed_indent_comment()
   let lines = ["int main() {", "\tif 1 {", "\t  return 0;", "\t}", "    return 1;", "}"]
 
-  let input_file = "test_mixed_indent_comment_input.c"
-  call writefile(lines, input_file, "D")
+  enew
+  call setline(1, lines)
+  filetype plugin on
+  set ft=c
 
-  let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
-  call term_sendkeys(buf, "gcip")
-  let output_file = "comment_mixed_indent_test.c"
-  call term_sendkeys(buf, $":w {output_file}\<CR>")
-  defer delete(output_file)
+  normal gcip
 
-  call StopVimInTerminal(buf)
-  let result = readfile(output_file)
+  let result = getline(1, '$')
   call assert_equal(["/* int main() { */", "\t/* if 1 { */", "\t  /* return 0; */",  "\t/* } */", "    /* return 1; */", "/* } */"], result)
 endfunc
 
@@ -194,17 +168,15 @@ func Test_buffer_first_col_comment()
       pass
   END
 
-  let input_file = "test_first_col_comment_input.py"
-  call writefile(lines, input_file, "D")
+  enew
+  call setline(1, lines)
+  filetype plugin on
+  set ft=python
+  let b:comment_first_col = 1
 
-  let buf = RunVimInTerminal('-c "packadd comment" -c "let b:comment_first_col=1" ' .. input_file, {})
-  call term_sendkeys(buf, "jgcc")
-  let output_file = "comment_first_col_test.py"
-  call term_sendkeys(buf, $":w {output_file}\<CR>")
-  defer delete(output_file)
+  normal jgcc
 
-  call StopVimInTerminal(buf)
-  let result = readfile(output_file)
+  let result = getline(1, '$')
   call assert_equal(["def Hello():", '#   print("Hello")', "  pass"], result)
 endfunc
 
@@ -215,17 +187,17 @@ func Test_global_first_col_comment()
       pass
   END
 
-  let input_file = "test_first_col_comment_input.py"
-  call writefile(lines, input_file, "D")
+  enew
+  call setline(1, lines)
+  filetype plugin on
+  set ft=python
+  let g:comment_first_col = 1
 
-  let buf = RunVimInTerminal('-c "packadd comment" -c "let g:comment_first_col=1" ' .. input_file, {})
-  call term_sendkeys(buf, "jgcj")
-  let output_file = "comment_first_col_test.py"
-  call term_sendkeys(buf, $":w {output_file}\<CR>")
-  defer delete(output_file)
+  normal jgcj
 
-  call StopVimInTerminal(buf)
-  let result = readfile(output_file)
+  unlet g:comment_first_col
+
+  let result = getline(1, '$')
   call assert_equal(["def Hello():", '#   print("Hello")', "#   pass"], result)
 endfunc
 
@@ -243,17 +215,15 @@ func Test_textobj_icomment()
       print(x*x*x*x*x)
   END
 
-  let input_file = "test_textobj_icomment_input.py"
-  call writefile(lines, input_file, "D")
+  enew
+  call setline(1, lines)
+  filetype plugin on
+  syntax on
+  set ft=python
 
-  let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
-  call term_sendkeys(buf, "dic..")
-  let output_file = "comment_textobj_icomment.py"
-  call term_sendkeys(buf, $":w {output_file}\<CR>")
-  defer delete(output_file)
+  normal dic..
 
-  call StopVimInTerminal(buf)
-  let result = readfile(output_file)
+  let result = getline(1, '$')
   call assert_equal(["for x in range(10):", "  print(x) ", "  print(x*x*x*x) ", "  print(x*x*x*x*x) ", "", "  print(x*x*x*x*x)"], result)
 endfunc
 
@@ -271,17 +241,15 @@ func Test_textobj_icomment2()
     }
   END
 
-  let input_file = "test_textobj_icomment2_input.c"
-  call writefile(lines, input_file, "D")
+  enew
+  call setline(1, lines)
+  filetype plugin on
+  syntax on
+  set ft=c
 
-  let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
-  call term_sendkeys(buf, "dic..")
-  let output_file = "comment_textobj_icomment2.c"
-  call term_sendkeys(buf, $":w {output_file}\<CR>")
-  defer delete(output_file)
+  normal dic.
 
-  call StopVimInTerminal(buf)
-  let result = readfile(output_file)
+  let result = getline(1, '$')
   call assert_equal(["#include <stdio.h>", "", "int main() {", "    printf(\"hello\");  printf(\" world\\n\");", "    ", "", "    return 0;", "}"], result)
 endfunc
 
@@ -295,17 +263,15 @@ func Test_textobj_icomment3()
     }
   END
 
-  let input_file = "test_textobj_icomment3_input.c"
-  call writefile(lines, input_file, "D")
+  enew
+  call setline(1, lines)
+  filetype plugin on
+  syntax on
+  set ft=c
 
-  let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
-  call term_sendkeys(buf, "jjjdic")
-  let output_file = "comment_textobj_icomment3.c"
-  call term_sendkeys(buf, $":w {output_file}\<CR>")
-  defer delete(output_file)
+  normal jjjdic
 
-  call StopVimInTerminal(buf)
-  let result = readfile(output_file)
+  let result = getline(1, '$')
   call assert_equal(["#include <stdio.h>", "", "int main() {", "    printf(\"hello\");printf(\" world\\n\");",  "    return 0;", "}"], result)
 endfunc
 
@@ -323,17 +289,15 @@ func Test_textobj_acomment()
       print(x*x*x*x*x)
   END
 
-  let input_file = "test_textobj_acomment_input.py"
-  call writefile(lines, input_file, "D")
+  enew
+  call setline(1, lines)
+  filetype plugin on
+  syntax on
+  set ft=python
 
-  let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
-  call term_sendkeys(buf, "dac..")
-  let output_file = "comment_textobj_acomment.py"
-  call term_sendkeys(buf, $":w {output_file}\<CR>")
-  defer delete(output_file)
+  normal dac..
 
-  call StopVimInTerminal(buf)
-  let result = readfile(output_file)
+  let result = getline(1, '$')
   call assert_equal(["for x in range(10):", "  print(x)", "  print(x*x*x*x)", "  print(x*x*x*x*x)", "", "  print(x*x*x*x*x)"], result)
 endfunc
 
@@ -351,17 +315,15 @@ func Test_textobj_acomment2()
     }
   END
 
-  let input_file = "test_textobj_acomment2_input.c"
-  call writefile(lines, input_file, "D")
+  enew
+  call setline(1, lines)
+  filetype plugin on
+  syntax on
+  set ft=c
 
-  let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
-  call term_sendkeys(buf, "dac.")
-  let output_file = "comment_textobj_acomment2.c"
-  call term_sendkeys(buf, $":w {output_file}\<CR>")
-  defer delete(output_file)
+  normal dac.
 
-  call StopVimInTerminal(buf)
-  let result = readfile(output_file)
+  let result = getline(1, '$')
   call assert_equal(["#include <stdio.h>", "", "int main() {", "    printf(\"hello\");printf(\" world\\n\");", "    return 0;", "}"], result)
 endfunc
 
@@ -375,17 +337,15 @@ func Test_textobj_acomment3()
     }
   END
 
-  let input_file = "test_textobj_acomment3_input.c"
-  call writefile(lines, input_file, "D")
+  enew
+  call setline(1, lines)
+  filetype plugin on
+  syntax on
+  set ft=c
 
-  let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
-  call term_sendkeys(buf, "jjjdac")
-  let output_file = "comment_textobj_acomment3.c"
-  call term_sendkeys(buf, $":w {output_file}\<CR>")
-  defer delete(output_file)
+  normal jjjdac
 
-  call StopVimInTerminal(buf)
-  let result = readfile(output_file)
+  let result = getline(1, '$')
   call assert_equal(["#include <stdio.h>", "", "int main() {", "    printf(\"hello\");printf(\" world\\n\");",  "    return 0;", "}"], result)
 endfunc
 
@@ -396,17 +356,15 @@ func Test_textobj_firstline_comment()
     int main() {}
   END
 
-  let input_file = "test_textobj_firstlinecomment_input.c"
-  call writefile(lines, input_file, "D")
+  enew
+  call setline(1, lines)
+  filetype plugin on
+  syntax on
+  set ft=c
 
-  let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
-  call term_sendkeys(buf, "dac")
-  let output_file = "comment_textobj_firstline_comment.c"
-  call term_sendkeys(buf, $":w {output_file}\<CR>")
-  defer delete(output_file)
+  normal dac
 
-  call StopVimInTerminal(buf)
-  let result = readfile(output_file)
+  let result = getline(1, '$')
   call assert_equal(["int main() {}"], result)
 endfunc
 
@@ -416,17 +374,15 @@ func Test_textobj_noleading_space_comment()
     }/* main end */
   END
 
-  let input_file = "test_textobj_noleading_space_input.c"
-  call writefile(lines, input_file, "D")
+  enew
+  call setline(1, lines)
+  filetype plugin on
+  syntax on
+  set ft=c
 
-  let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
-  call term_sendkeys(buf, "dacdic")
-  let output_file = "comment_textobj_noleading_space_comment.c"
-  call term_sendkeys(buf, $":w {output_file}\<CR>")
-  defer delete(output_file)
+  normal dacdic
 
-  call StopVimInTerminal(buf)
-  let result = readfile(output_file)
+  let result = getline(1, '$')
   call assert_equal(["int main() {", "}"], result)
 endfunc
 
@@ -436,52 +392,46 @@ func Test_textobj_noleading_space_comment2()
     }    /* main end */
   END
 
-  let input_file = "test_textobj_noleading_space_input2.c"
-  call writefile(lines, input_file, "D")
+  enew
+  call setline(1, lines)
+  filetype plugin on
+  syntax on
+  set ft=c
 
-  let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
-  call term_sendkeys(buf, "dac.")
-  let output_file = "comment_textobj_noleading_space_comment2.c"
-  call term_sendkeys(buf, $":w {output_file}\<CR>")
-  defer delete(output_file)
+  normal dac.
 
-  call StopVimInTerminal(buf)
-  let result = readfile(output_file)
+  let result = getline(1, '$')
   call assert_equal(["int main() {", "}"], result)
 endfunc
 
 func Test_textobj_trailing_spaces_comment()
   let lines = ['# print("hello")   ', '# print("world")   ', "#", 'print("!")']
 
-  let input_file = "test_textobj_trailing_spaces_input.py"
-  call writefile(lines, input_file, "D")
+  enew
+  call setline(1, lines)
+  filetype plugin on
+  syntax on
+  set ft=python
 
-  let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
-  call term_sendkeys(buf, "jdac")
-  let output_file = "comment_textobj_trailing_spaces_comment.py"
-  call term_sendkeys(buf, $":w {output_file}\<CR>")
-  defer delete(output_file)
+  normal jdac
 
-  call StopVimInTerminal(buf)
-  let result = readfile(output_file)
+  let result = getline(1, '$')
   call assert_equal(['print("!")'], result)
 endfunc
 
 func Test_textobj_trailing_spaces_last_comment()
   let lines = ['# print("hello")   ', '# print("world")   ', "#", '', '']
 
-  let input_file = "test_textobj_trailing_spaces_last_input.py"
-  call writefile(lines, input_file, "D")
+  enew
+  call setline(1, lines)
+  filetype plugin on
+  syntax on
+  set ft=python
 
-  let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
-  call term_sendkeys(buf, "jdac")
-  let output_file = "comment_textobj_trailing_spaces_last_comment.py"
-  call term_sendkeys(buf, $":w {output_file}\<CR>")
-  defer delete(output_file)
+  normal jdac
 
-  call StopVimInTerminal(buf)
-  let result = readfile(output_file)
-  call assert_equal([], result)
+  let result = getline(1, '$')
+  call assert_equal([''], result)
 endfunc
 
 func Test_textobj_last_line_empty_comment()
@@ -491,18 +441,16 @@ func Test_textobj_last_line_empty_comment()
     #
   END
 
-  let input_file = "test_textobj_last_line_empty_input.py"
-  call writefile(lines, input_file, "D")
+  enew
+  call setline(1, lines)
+  filetype plugin on
+  syntax on
+  set ft=python
 
-  let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
-  call term_sendkeys(buf, "dac")
-  let output_file = "comment_textobj_last_line_empty_comment.py"
-  call term_sendkeys(buf, $":w {output_file}\<CR>")
-  defer delete(output_file)
+  normal dac
 
-  call StopVimInTerminal(buf)
-  let result = readfile(output_file)
-  call assert_equal([], result)
+  let result = getline(1, '$')
+  call assert_equal([''], result)
 endfunc
 
 func Test_textobj_cursor_on_leading_space_comment()
@@ -513,17 +461,15 @@ func Test_textobj_cursor_on_leading_space_comment()
     }
   END
 
-  let input_file = "test_textobj_cursor_on_leading_space_comment_input.c"
-  call writefile(lines, input_file, "D")
+  enew
+  call setline(1, lines)
+  filetype plugin on
+  syntax on
+  set ft=c
 
-  let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
-  call term_sendkeys(buf, "jjdac")
-  let output_file = "comment_textobj_cursor_on_leading_space_comment.c"
-  call term_sendkeys(buf, $":w {output_file}\<CR>")
-  defer delete(output_file)
+  normal jjdac
 
-  call StopVimInTerminal(buf)
-  let result = readfile(output_file)
+  let result = getline(1, '$')
   call assert_equal(["int main() {", "}"], result)
 endfunc
 
@@ -536,17 +482,15 @@ func Test_textobj_conseq_comment()
     }
   END
 
-  let input_file = "test_textobj_conseq_comment_input.c"
-  call writefile(lines, input_file, "D")
+  enew
+  call setline(1, lines)
+  filetype plugin on
+  syntax on
+  set ft=c
 
-  let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
-  call term_sendkeys(buf, "dac")
-  let output_file = "comment_textobj_conseq_comment.c"
-  call term_sendkeys(buf, $":w {output_file}\<CR>")
-  defer delete(output_file)
+  normal dac
 
-  call StopVimInTerminal(buf)
-  let result = readfile(output_file)
+  let result = getline(1, '$')
   call assert_equal(["int main() {", "    printf(\"hello\");", "    printf(\"world\");", "}"], result)
 endfunc
 
@@ -560,17 +504,15 @@ func Test_textobj_conseq_comment2()
     }
   END
 
-  let input_file = "test_textobj_conseq_comment_input2.c"
-  call writefile(lines, input_file, "D")
+  enew
+  call setline(1, lines)
+  filetype plugin on
+  syntax on
+  set ft=c
 
-  let buf = RunVimInTerminal('-c "packadd comment" ' .. input_file, {})
-  call term_sendkeys(buf, "dac")
-  let output_file = "comment_textobj_conseq_comment2.c"
-  call term_sendkeys(buf, $":w {output_file}\<CR>")
-  defer delete(output_file)
+  normal dac
 
-  call StopVimInTerminal(buf)
-  let result = readfile(output_file)
+  let result = getline(1, '$')
   call assert_equal(["int main() {", "    printf(\"hello\");", "", "    // world", "    printf(\"world\");", "}"], result)
 endfunc
 
@@ -579,18 +521,14 @@ func Test_inline_comment()
     echo "Hello" This should be a comment
   END
 
-  let input_file = "test_inline_comment_input.vim"
-  call writefile(lines, input_file, "D")
+  enew
+  call setline(1, lines)
+  filetype plugin on
+  set ft=vim
 
-  let buf = RunVimInTerminal('-c "packadd comment" -c "nnoremap <expr> gC comment#Toggle()..''$''" ' .. input_file, {})
-  call term_sendkeys(buf, "fTgC")
+  normal fTgC
 
-  let output_file = "comment_inline_test.vim"
-  call term_sendkeys(buf, $":w {output_file}\<CR>")
-  defer delete(output_file)
-
-  call StopVimInTerminal(buf)
-  let result = readfile(output_file)
+  let result = getline(1, '$')
   call assert_equal(['echo "Hello" " This should be a comment'], result)
 endfunc
 
@@ -599,18 +537,14 @@ func Test_inline_uncomment()
     echo "Hello" " This should be a comment
   END
 
-  let input_file = "test_inline_uncomment_input.vim"
-  call writefile(lines, input_file, "D")
+  enew
+  call setline(1, lines)
+  filetype plugin on
+  set ft=vim
 
-  let buf = RunVimInTerminal('-c "packadd comment" -c "nnoremap <expr> gC comment#Toggle()..''$''" ' .. input_file, {})
-  call term_sendkeys(buf, '$F"gC')
+  normal $F"gC
 
-  let output_file = "uncomment_inline_test.vim"
-  call term_sendkeys(buf, $":w {output_file}\<CR>")
-  defer delete(output_file)
-
-  call StopVimInTerminal(buf)
-  let result = readfile(output_file)
+  let result = getline(1, '$')
   call assert_equal(['echo "Hello" This should be a comment'], result)
 endfunc
 
@@ -619,17 +553,14 @@ func Test_textobj_selection_exclusive_inline_comment()
     print("Hello") # selection exclusive
   END
 
-  let input_file = "test_selection_exclusive_inline_comment_input.py"
-  call writefile(lines, input_file, "D")
+  enew
+  call setline(1, lines)
+  filetype plugin on
+  syntax on
+  set ft=python
 
-  let buf = RunVimInTerminal('-c "set selection=exclusive" -c "packadd comment" ' .. input_file, {})
-  call term_sendkeys(buf, "dac")
+  normal dac
 
-  let output_file = "test_selection_exclusive_inline_comment.py"
-  call term_sendkeys(buf, $":w {output_file}\<CR>")
-  defer delete(output_file)
-
-  call StopVimInTerminal(buf)
-  let result = readfile(output_file)
+  let result = getline(1, '$')
   call assert_equal(['print("Hello")'], result)
 endfunc


### PR DESCRIPTION
Currently test suite for the comment package uses separate vim in terminal to do tests, which is inefficient and unnecessary complex.

The reason is that `comment.Toggle()` uses `<stack>` to get function name for the `opfunc` and this fools vim's test runner.

- use lambda function for `opfunc` inside `comment.Toggle()`
- simplify tests not to use terminal