### PR TITLE
runtime(vim): Fix heredoc triggering misidentifcation of Vim9 script

### DIFF
--- a/runtime/ftplugin/vim.vim
+++ b/runtime/ftplugin/vim.vim
@@ -6,7 +6,7 @@
 "                    @Konfekt
 "                    @tpope (s:Help())
 "                    @lacygoill
-" Last Change:       2026 May 31
+" Last Change:       2026 Jun 27
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin")
@@ -107,7 +107,7 @@ command! -buffer -nargs=1 VimKeywordPrg :exe 'help' s:Help(<q-args>)
 setlocal keywordprg=:VimKeywordPrg
 
 " Comments starts with # in Vim9 script.  We have to guess which one to use.
-if "\n" .. getline(1, 32)->join("\n") =~# '\n\s*vim9\%[script]\>'
+if "\n" .. getline(1, 32)->join("\n") =~# '\nvim9s\%[cript]\>'
   setlocal commentstring=#\ %s
   " Set 'comments' to format dashed lists in comments, for Vim9 script.
   setlocal com=sO:#\ -,mO:#\ \ ,eO:##,:#\\\ ,:#

--- a/runtime/syntax/generator/vim.vim.base
+++ b/runtime/syntax/generator/vim.vim.base
@@ -2,7 +2,7 @@
 " Language:	   Vim script
 " Maintainer:	   Hirohito Higashi <h.east.727 ATMARK gmail.com>
 "	   Doug Kearns <dougkearns@gmail.com>
-" Last Change:	   2026 Jun 12
+" Last Change:	   2026 Jun 27
 " Former Maintainer: Charles E. Campbell
 
 " DO NOT CHANGE DIRECTLY.
@@ -19,7 +19,7 @@ set cpo&vim
 " Feature testing {{{1
 
 " NOTE: vimsyn_force_vim9 for internal use only
-let s:vim9script = get(b:, "vimsyn_force_vim9", v:false) || "\n" .. getline(1, 32)->join("\n") =~# '\n\s*vim9\%[script]\>'
+let s:vim9script = get(b:, "vimsyn_force_vim9", v:false) || "\n" .. getline(1, 32)->join("\n") =~# '\nvim9s\%[cript]\>'
 
 function s:has(feature)
   return has(a:feature) || index(get(g:, "vimsyn_vim_features", []), a:feature) != -1

--- a/runtime/syntax/vim.vim
+++ b/runtime/syntax/vim.vim
@@ -2,7 +2,7 @@
 " Language:	   Vim script
 " Maintainer:	   Hirohito Higashi <h.east.727 ATMARK gmail.com>
 "	   Doug Kearns <dougkearns@gmail.com>
-" Last Change:	   2026 Jun 12
+" Last Change:	   2026 Jun 27
 " Former Maintainer: Charles E. Campbell
 
 " DO NOT CHANGE DIRECTLY.
@@ -19,7 +19,7 @@ set cpo&vim
 " Feature testing {{{1
 
 " NOTE: vimsyn_force_vim9 for internal use only
-let s:vim9script = get(b:, "vimsyn_force_vim9", v:false) || "\n" .. getline(1, 32)->join("\n") =~# '\n\s*vim9\%[script]\>'
+let s:vim9script = get(b:, "vimsyn_force_vim9", v:false) || "\n" .. getline(1, 32)->join("\n") =~# '\nvim9s\%[cript]\>'
 
 function s:has(feature)
   return has(a:feature) || index(get(g:, "vimsyn_vim_features", []), a:feature) != -1


### PR DESCRIPTION
The following let-heredoc can cause legacy scripts to be misidentified as Vim9 script if it appears early in the file.  Only match :vim9script at the start of a line where it sensibly belongs.

```vim
let x =<< trim LINES
  vim9script
  ...
LINES
```

Fixes #20647 (reported by Maxim Kim).
