### PR TITLE
fix popup_atcursor() closing immediately when the cursor is on white space

### DIFF
--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -233,12 +233,25 @@ set_moved_columns(win_T *wp, int flags)
 {
     char_u	*ptr;
     int		len = find_ident_under_cursor(&ptr, flags | FIND_NOERROR);
+    int		mincol;
 
     if (len <= 0)
 	return;
 
-    wp->w_popup_mincol = (int)(ptr - ml_get_curline());
-    wp->w_popup_maxcol = wp->w_popup_mincol + len - 1;
+    // When the cursor is on white space find_ident_under_cursor() skips
+    // forward to the next word, whose range does not cover the cursor column.
+    // Keep the cursor column then, otherwise popup_check_cursor_pos() would
+    // close the popup right away.
+    mincol = (int)(ptr - ml_get_curline());
+    if (curwin->w_cursor.col < mincol)
+    {
+	wp->w_popup_mincol = curwin->w_cursor.col;
+	wp->w_popup_maxcol = curwin->w_cursor.col;
+	return;
+    }
+
+    wp->w_popup_mincol = mincol;
+    wp->w_popup_maxcol = mincol + len - 1;
 }
 
 /*

--- a/src/testdir/test_popupwin.vim
+++ b/src/testdir/test_popupwin.vim
@@ -2331,6 +2331,20 @@ func Test_popup_moved()
   call assert_equal({}, popup_getpos(winid))
   call popup_clear()
 
+  " On white space find_ident_under_cursor() skips forward to the next word,
+  " whose range does not cover the cursor.  The cursor column must be used so
+  " the popup is not closed right away.
+  exe "normal gg4|"
+  let winid = popup_atcursor('text', {})
+  redraw
+  call assert_equal(1, popup_getpos(winid).visible)
+  call assert_equal([1, 3, 3], popup_getoptions(winid).moved)
+  call feedkeys("i\<Esc>", 'xt')
+  call assert_equal(1, popup_getpos(winid).visible)
+  call feedkeys("$i\<Esc>", 'xt')
+  call assert_equal({}, popup_getpos(winid))
+  call popup_clear()
+
   bwipe!
   call test_override('ALL', 0)
 endfunc


### PR DESCRIPTION
When the cursor is on white space, popup_atcursor() created a popup that was closed immediately, for example when popup_atcursor() is called from another popup's filter that also closes that popup.

The cause is that find_ident_under_cursor() skips forward to the next word when the cursor is on white space, so the stored "moved" column range did not cover the cursor column and popup_check_cursor_pos() closed the popup right away. Keep the cursor column in that case.

Fixes #20652