### PR TITLE
Crash with truncated spellfile

### DIFF
--- a/src/spellfile.c
+++ b/src/spellfile.c
@@ -1178,8 +1178,6 @@ read_sofo_section(FILE *fd, slang_T *slang)
     char_u	*from, *to;
     int		res;
 
-    slang->sl_sofo = TRUE;
-
     // <sofofromlen> <sofofrom>
     from = read_cnt_string(fd, 2, &cnt);
     if (cnt < 0)
@@ -1433,6 +1431,7 @@ set_sofo(slang_T *lp, char_u *from, char_u *to)
 	    return SP_OTHERERROR;
 	vim_memset(gap->ga_data, 0, sizeof(int *) * 256);
 	gap->ga_len = 256;
+	lp->sl_sofo = TRUE;
 
 	// First count the number of items for each list.  Temporarily use
 	// sl_sal_first[] for this.
@@ -1489,6 +1488,7 @@ set_sofo(slang_T *lp, char_u *from, char_u *to)
 	for (i = 0; to[i] != NUL; ++i)
 	    lp->sl_sal_first[from[i]] = to[i];
 	lp->sl_sal.ga_len = 1;		// indicates we have soundfolding
+	lp->sl_sofo = TRUE;
     }
 
     return 0;

--- a/src/testdir/test_spellfile.vim
+++ b/src/testdir/test_spellfile.vim
@@ -1319,4 +1319,31 @@ func Test_soundfold_overflow()
   let &enc = _enc
 endfunc
 
+func Test_spell_sal_sofo_truncated()
+  call mkdir('Xspelldir/spell', 'pR')
+
+  " "VIMspell" <ver=0x32>
+  "   SN_SAL(5)  flags=0 len=7   : <salflags=0><salcount=0,1><a><0><1>a<1>a
+  "   SN_SOFO(6) flags=0 len=0   : truncated, no body -> EOF in reader
+  " (28 bytes total)
+  let bytes = 0z56494d7370656c6c.3205000000000700.000101610161060000.000000
+  call writefile(bytes, 'Xspelldir/spell/Xx.utf-8.spl', 'b')
+
+  let save_rtp = &rtp
+  set rtp=./Xspelldir
+  try
+    set spelllang=Xx
+    silent! set spell
+  catch
+    " an error message is fine; a crash is not
+  endtry
+
+  " Reaching this point means Vim did not crash on the crafted file.
+  call assert_true(v:true)
+
+  set nospell
+  set spelllang&
+  let &rtp = save_rtp
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  Crash when reading truncated spellfile (MarkLee131)
Solution: Set sl_sofo to TRUE in set_sofo() once sl_sal has been
          converted to the soundfold layout.