### PR TITLE
cscope connections leak when growing the array fails

### DIFF
--- a/src/if_cscope.c
+++ b/src/if_cscope.c
@@ -1504,8 +1504,10 @@ cs_insert_filelist(
 	    csinfo = vim_realloc(csinfo, sizeof(csinfo_T)*csinfo_size);
 	    if (csinfo == NULL)
 	    {
-		vim_free(t_csinfo);
-		csinfo_size = 0;
+		// allocation failure, so keep the old infos
+		csinfo = t_csinfo;
+		csinfo_size = i;
+		return -1;
 	    }
 	}
 	if (csinfo == NULL)


### PR DESCRIPTION
Problem:  In cs_insert_filelist() a failed vim_realloc() when growing the
          csinfo[] array frees the array and resets csinfo/csinfo_size,
          discarding the still-open existing connections: their fname,
          ppath and flags are leaked and the cscope child processes are
          orphaned, since cs_end()/cs_reset() can no longer reach them.
          (Ao Xijie)
Solution: On realloc() failure keep the original array, which is still
          valid, and only fail to add the new database.