### PR TITLE
tests: test_popupwin fails with zsh because of the prompt

### DIFF
--- a/src/testdir/test_popupwin.vim
+++ b/src/testdir/test_popupwin.vim
@@ -683,7 +683,7 @@ func Test_popup_drag_termwin()
 	set shell=/bin/sh noruler
 	unlet $PROMPT_COMMAND
 	let $PS1 = 'vim> '
-        terminal ++rows=4
+	terminal ++rows=4
 	$wincmd w
 	let winid = popup_create(['1111', '2222'], #{
 	      \ drag: 1,
@@ -3017,18 +3017,18 @@ func Test_popupwin_terminal_buffer()
   " open help window to test that :help below fails
   help
 
-  let termbuf = term_start(&shell, #{hidden: 1})
+  let env =  {'HOME': '/nonexisting', 'PS1':''}
+  let termbuf = term_start(&shell, #{hidden: 1, env: env})
   let winid = popup_create(termbuf, #{minwidth: 40, minheight: 10, border: []})
   " Wait for shell to start
   call WaitForAssert({-> assert_equal("run", job_status(term_getjob(termbuf)))})
-  " Wait for a prompt (see border char first, then space after prompt)
-  call WaitForAssert({ -> assert_equal(' ', screenstring(screenrow(), screencol() - 1))})
+  call WaitForAssert({-> assert_equal('', term_getline(termbuf, '.'))})
 
   " When typing a character, the cursor is after it.
   call feedkeys("x", 'xt')
   call term_wait(termbuf)
   redraw
-  call WaitForAssert({ -> assert_equal('x', screenstring(screenrow(), screencol() - 1))})
+  call WaitForAssert({-> assert_equal('x', term_getline(termbuf, '.'))})
   call feedkeys("\<BS>", 'xt')
 
   " Check this doesn't crash
@@ -5307,18 +5307,19 @@ func Test_popup_opacity_terminal_no_freeze()
   let g:test_is_flaky = 1
 
   let origwin = win_getid()
-  let termbuf = term_start(&shell, #{hidden: 1})
+  let env =  {'HOME': '/nonexisting', 'PS1':''}
+  let termbuf = term_start(&shell, #{hidden: 1, env: env})
   let winid = popup_create(termbuf, #{minwidth: 40, minheight: 10,
         \ border: [1, 1, 1, 1], opacity: 10})
   call WaitForAssert({-> assert_equal("run", job_status(term_getjob(termbuf)))})
-  call WaitForAssert({-> assert_equal(' ', screenstring(screenrow(), screencol() - 1))})
+  call WaitForAssert({-> assert_equal('', term_getline(termbuf, '.'))})
 
   " Before the fix typing froze Vim: redraw under an opacity popup raised
   " must_redraw every cycle, trapping terminal_loop in its redraw loop.
   call feedkeys('x', 'xt')
   call term_wait(termbuf)
   redraw
-  call WaitForAssert({-> assert_equal('x', screenstring(screenrow(), screencol() - 1))})
+  call WaitForAssert({-> assert_equal('x', term_getline(termbuf, '.'))})
 
   call feedkeys("\<BS>", 'xt')
   call feedkeys("exit\<CR>", 'xt')


### PR DESCRIPTION
Problem:  tests: test_popupwin fails with zsh: it asserts against screen
          cells next to the cursor, which break when zsh draws its own
          prompt.
Solution: Pass an env dict to term_start() clearing $HOME and $PS1
          and assert against term_getline() instead of screenstring().
          While at it fix indentation.