### PR TITLE
'autocompletedelay' interferes with CTRL-G U and i_CTRL-K

### DIFF
--- a/src/edit.c
+++ b/src/edit.c
@@ -1171,6 +1171,9 @@ doESCkey:
 	    break;
 
 	case K_COMPLETE_DELAY:	// 'autocompletedelay' expired
+	    // If CTRL-G U was used apply it to the next typed key.
+	    if (dont_sync_undo == TRUE)
+		dont_sync_undo = MAYBE;
 	    ins_compl_clear_autocomplete_delay();
 	    if (!ins_compl_has_autocomplete() || char_avail()
 		    || curwin->w_cursor.col == 0)

--- a/src/edit.c
+++ b/src/edit.c
@@ -677,6 +677,9 @@ edit(
 
 	// Don't want K_CURSORHOLD for the second key, e.g., after CTRL-V.
 	did_cursorhold = TRUE;
+	if (c != K_CURSORHOLD && c != K_COMPLETE_DELAY)
+	    // Don't want delayed autocompletion from the previous key either.
+	    ins_compl_clear_autocomplete_delay();
 
 #ifdef FEAT_RIGHTLEFT
 	if (p_hkmap && KeyTyped)

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -5976,6 +5976,30 @@ func Test_autocompletedelay()
   call StopVimInTerminal(buf)
 endfunc
 
+func Run_test_autocompletedelay_ctrl_g_U(delay1, delay2)
+  new
+  call setline(1, 'foo bar baz')
+  inoremap <buffer> ( ()<C-g>U
+  set autocomplete autocompletedelay=200
+
+  call timer_start(a:delay1, { -> feedkeys('(', 't') })
+  call timer_start(a:delay2, { -> feedkeys("\<Left>a\<Esc>", 't') })
+  call feedkeys('ob', 'tx!')
+  call assert_equal(['foo bar baz', 'b(a)'], getline(1, '$'))
+  undo
+  call assert_equal(['foo bar baz'], getline(1, '$'))
+
+  set autocomplete& autocompletedelay&
+  bwipe!
+endfunc
+
+func Test_autocompletedelay_ctrl_g_U()
+  " '(' typed after 'autocompletedelay' expires
+  call Run_test_autocompletedelay_ctrl_g_U(250, 500)
+  " '(' typed before 'autocompletedelay' expires
+  call Run_test_autocompletedelay_ctrl_g_U(150, 500)
+endfunc
+
 " Preinsert longest prefix when autocomplete
 func Test_autocomplete_longest()
   func GetLine()

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -6000,6 +6000,27 @@ func Test_autocompletedelay_ctrl_g_U()
   call Run_test_autocompletedelay_ctrl_g_U(150, 500)
 endfunc
 
+func Run_test_autocompletedelay_ctrl_k(delay1, delay2)
+  new
+  call setline(1, 'foo bar baz')
+  set autocomplete autocompletedelay=200
+
+  call timer_start(a:delay1, { -> feedkeys("\<C-K>", 't') })
+  call timer_start(a:delay2, { -> feedkeys(".,\<Esc>", 't') })
+  call feedkeys('ob', 'tx!')
+  call assert_equal(['foo bar baz', 'b…'], getline(1, '$'))
+
+  set autocomplete& autocompletedelay&
+  bwipe!
+endfunc
+
+func Test_autocompletedelay_ctrl_k()
+  " Ctrl-K typed after 'autocompletedelay' expires
+  call Run_test_autocompletedelay_ctrl_k(250, 500)
+  " Ctrl-K typed before 'autocompletedelay' expires
+  call Run_test_autocompletedelay_ctrl_k(150, 500)
+endfunc
+
 " Preinsert longest prefix when autocomplete
 func Test_autocomplete_longest()
   func GetLine()


### PR DESCRIPTION
#### 'autocompletedelay' interferes with CTRL-G U

Problem:  'autocompletedelay' interferes with CTRL-G U (after 9.2.0739).
Solution: Restore the flag for CTRL-G U.

related: #8937


#### 'autocompletedelay' interferes with i_CTRL-K

Problem:  'autocompletedelay' interferes with i_CTRL-K (after 9.2.0739).
Solution: Clear the pending autocompltion from the previous key when a
          new key is typed.
