### PR TITLE
Session with multiple tabpages sets 'winminheight' to 0

### DIFF
--- a/src/session.c
+++ b/src/session.c
@@ -889,9 +889,11 @@ makeopens(
 	    // cursor can be set.  This is done again below.
 	    // winminheight and winminwidth need to be set to avoid an error if
 	    // the user has set winheight or winwidth.
-	    if (put_line(fd, "save_winminheight = &winminheight") == FAIL
-		    || put_line(fd, "save_winminwidth = &winminwidth")
-								       == FAIL)
+	    if (!restore_height_width
+		    && (put_line(fd, "save_winminheight = &winminheight")
+									== FAIL
+			|| put_line(fd, "save_winminwidth = &winminwidth")
+								       == FAIL))
 		goto fail;
 	    if (put_line(fd, "set winminheight=0") == FAIL
 		    || put_line(fd, "set winheight=1") == FAIL

--- a/src/testdir/test_mksession.vim
+++ b/src/testdir/test_mksession.vim
@@ -1074,9 +1074,19 @@ func Test_mksession_winminheight()
     endif
   endfor
   call assert_equal(2, found_restore)
+  " Test with multiple tabpages
+  tab split | split | tab split | split
+  call assert_equal(3, tabpagenr('$'))
+  mksession! Xtest_mks.out
+  tabclose | tabclose | close
+  call assert_equal(1, tabpagenr('$'))
+  set winminheight=2 winminwidth=2
+  source Xtest_mks.out
+  call assert_equal(3, tabpagenr('$'))
+  call assert_equal([2, 2], [&winminheight, &winminwidth])
+  tabclose | tabclose | close
   call delete('Xtest_mks.out')
-  close
-  set sessionoptions&
+  set sessionoptions& winminheight& winminwidth&
 endfunc
 
 " Test for mksession with and without options restores shortmess


### PR DESCRIPTION
Problem:  Session with multiple tabpages sets 'winminheight' to 0.
Solution: Only save 'winminheight' and 'winminwidth' once.

related: #8119
related: neovim/neovim#40493
