### PR TITLE
'autocomplete' behaves inconsistently when recording

### DIFF
--- a/src/getchar.c
+++ b/src/getchar.c
@@ -1379,9 +1379,9 @@ gotchars_add_byte(gotchars_state_T *state, char_u byte)
 		// When receiving a modifier, wait for the modified key.
 		goto ret_false;
 	    c = TO_SPECIAL(state->prev_c, c);
-	    if (c == K_FOCUSGAINED || c == K_FOCUSLOST)
-		// Drop K_FOCUSGAINED and K_FOCUSLOST, they are not useful
-		// in a recording.
+	    // Drop K_FOCUSGAINED, K_FOCUSLOST and K_COMPLETE_DELAY, they are
+	    // not useful in a recording.
+	    if (c == K_FOCUSGAINED || c == K_FOCUSLOST || c == K_COMPLETE_DELAY)
 		state->buflen = 0;
 	}
 	// When receiving a multibyte character, store it until we have all

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -6031,9 +6031,19 @@ func Test_autocompletedelay_no_record()
   let @a = ''
   " Type a char that arms the delay, idle past 'autocompletedelay' so a
   " K_COMPLETE_DELAY would be injected, then end Insert mode and stop recording.
-  call timer_start(200, { -> feedkeys("\<Esc>q", 't') })
+  call timer_start(300, { -> feedkeys("\<Esc>q", 't') })
   call feedkeys("qaSf", 'tx!')
   call assert_equal("Sf\<Esc>", @a)
+
+  " Delayed autocompletion still works when recording.
+  if !has('win32') " FIXME: does not work on Windows
+    call setline(1, 'foobar foofoo')
+    call timer_start(300, { -> feedkeys("\<Down>\<C-Y>\<Esc>q", 't') })
+    call feedkeys("qaof", 'tx!')
+    call assert_equal('foobar', getline('.'))
+    " XXX: This doesn't produce the same result when replaying.
+    call assert_equal("of\<Down>\<C-Y>\<Esc>", @a)
+  endif
 
   set autocomplete& autocompletedelay&
   bwipe!

--- a/src/ui.c
+++ b/src/ui.c
@@ -305,9 +305,9 @@ inchar_loop(
 	// 'autocompletedelay' and 'updatetime' so the delay does not postpone
 	// CursorHold.  Once CursorHold has fired, only the delay is left.
 	// Gate the injection like trigger_cursorhold() so the deferred key
-	// cannot fire while recording or outside Insert mode.
+	// cannot fire while outside Insert mode, but do still fire the key
+	// when recording a register (gotchars_add_byte() will ignore it).
 	bool delay_pending = ins_compl_autocomplete_pending() && p_acl > 0
-		&& reg_recording == 0
 		&& typebuf.tb_len == 0
 		&& !ins_compl_active()
 		&& (get_real_state() & MODE_INSERT) != 0;


### PR DESCRIPTION
Problem:  If 'autocompletedelay' is non-zero, 'autocomplete' doesn't
          work when recording a register (after 9.2.0750).
Solution: Still produce K_COMPLETE_DELAY when recording a register, and
          drop it in gotchars_add_byte() instead.

This patch only changes the behavior when recording a register.
Replaying a register with 'autocomplete' still doesn't fully work
regardless of 'autocompletedelay', as 'autocomplete' isn't triggered
when there is pending input.
