### PR TITLE
:legacy / :vim9cmd: Make flags exclusive

### DIFF
--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -3092,6 +3092,9 @@ parse_command_modifiers(
 				      _(e_legacy_must_be_followed_by_command);
 				return FAIL;
 			    }
+			    // Make sure we do not have both legacy and Vim9
+			    // flags set at the same time.
+			    cmod->cmod_flags &= ~CMOD_VIM9CMD;
 			    cmod->cmod_flags |= CMOD_LEGACY;
 			    continue;
 			}
@@ -3177,6 +3180,9 @@ parse_command_modifiers(
 				      _(e_vim9cmd_must_be_followed_by_command);
 				return FAIL;
 			    }
+			    // Make sure we do not have both legacy and Vim9
+			    // flags set at the same time.
+			    cmod->cmod_flags &= ~CMOD_LEGACY;
 			    cmod->cmod_flags |= CMOD_VIM9CMD;
 			    continue;
 			}

--- a/src/testdir/test_vim9_cmd.vim
+++ b/src/testdir/test_vim9_cmd.vim
@@ -97,6 +97,23 @@ def Test_vim9cmd()
   v9.CheckScriptFailure(lines, 'E1017:')
 enddef
 
+def Test_legacy_vim9cmd_exclusive()
+  # Make sure that only one of the "legacy" or "vim9cmd" prefixes is applied.
+
+  # Invalid as vim9syntax.
+  call assert_fails("legacy vim9cmd echo 'a' . 'b'", 'E15:')
+  call assert_fails("legacy vim9cmd legacy vim9cmd echo 'a' . 'b'", 'E15:')
+
+  # Invalid legacy syntax.
+  call assert_fails("vim9cmd legacy echo (x) => x", 'E121:')
+  call assert_fails("vim9cmd legacy vim9cmd legacy echo (x) => x", 'E121:')
+
+  # Validate legacy/vim9 syntax being used.
+  call assert_equal('ab', trim(execute("vim9cmd legacy echo 'a' . 'b'")))
+  call assert_equal('true',
+    execute('legacy vim9cmd echo type((x) => x) == v:t_func')->trim())
+enddef
+
 def Test_defcompile_fails()
   assert_fails('defcompile NotExists', 'E1061:')
   assert_fails('defcompile debug debug Test_defcompile_fails', 'E488:')


### PR DESCRIPTION
When one of the ":legacy" or ":vim9cmd" prefixes is used, it sets a flag.  As the rest of the code might check either of the flags, setting both could produce confusing results.  It does not make a lot of sense to use both prefixes in the same command.  But just in case it is used, selecting the last prefix seems reasonable.