### PR TITLE
Netrw can't open \

### DIFF
--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -3862,7 +3862,7 @@ function s:NetrwBrowseChgDir(islocal, newdir, cursor, ...)
     endif
 
     " set up o/s-dependent directory recognition pattern
-    let dirpat = has("amiga") ? '[\/:]$' : '[\/]$'
+    let dirpat = has("win32") || has("amiga") ? '[\/:]$' : '[/]$'
 
     if newdir !~ dirpat && !(a:islocal && isdirectory(s:NetrwFile(netrw#fs#ComposePath(dirname, newdir))))
         " ------------------------------


### PR DESCRIPTION
## Problem
netrw is unable to open `\` file.

## Solution
update the regex to allow edit of `\` type file in unix type system from netrw.

## Related Issues
https://github.com/neovim/neovim/issues/15439