### PR TITLE
runtime(autoload/dist): gx may open XQuartz on macOS

### DIFF
--- a/runtime/autoload/dist/vim9.vim
+++ b/runtime/autoload/dist/vim9.vim
@@ -89,15 +89,15 @@ if has('win32unix')
 # Windows
 elseif has('win32')
   os_viewer = '' # Use :!start
+# MacOS
+elseif has('osx')
+  os_viewer = 'open'
 # WSL
 elseif executable('explorer.exe')
   os_viewer = 'explorer.exe'
 # Linux / BSD
 elseif executable('xdg-open')
   os_viewer = 'xdg-open'
-# MacOS
-elseif executable('open')
-  os_viewer = 'open'
 endif
 
 def Viewer(): string


### PR DESCRIPTION
Minor annoyance: I had to install some X11-related stuff in a macOS system, and ended up having `xdg-open` in `PATH`. Therefore, whenever I type `gx`, `xdg-open` is used instead of `open`, which launches XQuartz (macOS implementation of the X Window system). This commit ensures that `open` is used even under such circumstances.