### PR TITLE
If session restored a tiny window, restore fails

### DIFF
--- a/src/session.c
+++ b/src/session.c
@@ -975,9 +975,12 @@ makeopens(
     if (put_line(fd, "endif") == FAIL)
 	goto fail;
 
-    // Re-apply 'winheight' and 'winwidth'.
-    if (fprintf(fd, "set winheight=%ld winwidth=%ld",
-			       p_wh, p_wiw) < 0 || put_eol(fd) == FAIL)
+    // Re-apply 'winheight' and 'winwidth', but honor 'winminheight' and
+    // 'winminwidth' settings we saved from the original user context.
+    if (fprintf(fd, "&winheight = max([%ld, save_winminheight])", p_wh) < 0
+	    || put_eol(fd) == FAIL
+	    || fprintf(fd, "&winwidth = max([%ld, save_winminwidth])", p_wiw) < 0
+	    || put_eol(fd) == FAIL)
 	goto fail;
 
     // Restore 'shortmess'.

--- a/src/testdir/test_mksession.vim
+++ b/src/testdir/test_mksession.vim
@@ -1076,8 +1076,7 @@ endfunc
 
 " Test for mksession without options restores winminheight
 func Test_mksession_winminheight()
-  set winheight=10 winwidth=10 winminheight& winminwidth&
-  defer execute('set winheight& winwidth&')
+  set winheight& winwidth& winminheight& winminwidth&
   set sessionoptions-=options
   defer execute('set sessionoptions&')
   split
@@ -1097,8 +1096,8 @@ func Test_mksession_winminheight()
   mksession! Xtest_mks.out
   tabclose | tabclose | close
   call assert_equal(1, tabpagenr('$'))
-  set winminheight=2 winminwidth=2
-  defer execute('set winminheight& winminwidth&')
+  set winheight=2 winminheight=2 winwidth=2 winminwidth=2
+  defer execute('set winheight& winwidth& winminheight& winminwidth&')
   source Xtest_mks.out
   call assert_equal(3, tabpagenr('$'))
   call assert_equal([2, 2], [&winminheight, &winminwidth])


### PR DESCRIPTION
Problem:  If session restored a tiny window, restore fails
Solution: Extend window sizes to be at least the minimum size during session restore

If session contains a window that is shorter/narrower than the current `&winminheight` and `&winminwidth`, respectively, Vim will fail when assigning original values to the `&winminheight`/`&winminwidth` and the session restore will be slightly incomplete.

It seems reasonable to assume that if the user has selected certain values for these minimum size settings, it is safe to just make the restored windows big enough to match the minimums and continue without producing an error.

This fix allows `Test_mksession_winminheight()` to start with the default values of `&winheight`/`&winwidth` and only change them after the session restore.

---
### Reviewer note.

Due to changes in the same test, it might be easier to wait for #20691 to be merged in first.
I'll resolve the conflicts and will publish this PR again then.