### PR TITLE
tests: Test_fuzzy_completion_bufname_fullpath() creates unnecessary dir

### DIFF
--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -3601,7 +3601,7 @@ endfunc
 func Test_fuzzy_completion_bufname_fullpath()
   CheckUnix
   set wildoptions&
-  call mkdir('Xcmd/Xstate/Xfile.js', 'pR')
+  call mkdir('Xcmd/Xstate', 'pR')
   edit Xcmd/Xstate/Xfile.js
   cd Xcmd/Xstate
   enew


### PR DESCRIPTION
Problem:  tests: Test_fuzzy_completion_bufname_fullpath() creates an
          unnecessary directory with the name of a file.
Solution: Only create the parent directory of the file.
