### PR TITLE
fix(spell): restore spellfile words properly

### DIFF
--- a/runtime/doc/spell.txt
+++ b/runtime/doc/spell.txt
@@ -1,4 +1,4 @@
-*spell.txt*	For Vim version 9.2.  Last change: 2026 May 23
+*spell.txt*	For Vim version 9.2.  Last change: 2026 Jul 23
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -388,9 +388,8 @@ version.
 SPELLFILE CLEANUP					*spellfile-cleanup*
 
 The |zw| command turns existing entries in 'spellfile' into comment lines.
-This avoids having to write a new file every time, but results in the file
-only getting longer, never shorter.  To clean up the comment lines in all
-".add" spell files do this: >
+This results in the file only getting longer, never shorter.  To clean up the
+comment lines in all ".add" spell files do this: >
 	:runtime spell/cleanadd.vim
 
 This deletes all comment lines, except the ones that start with "##".  Use

--- a/src/spellfile.c
+++ b/src/spellfile.c
@@ -6374,11 +6374,17 @@ spell_add_word(
 
     if (what == SPELL_ADD_BAD || undo)
     {
+	garray_T	ga;
+
 	// When the word appears as good word we need to remove that one,
 	// since its flags sort before the one with WF_BANNED.
-	fd = mch_fopen((char *)fname, "r");
+	ga_init2(&ga, sizeof(long), 10);
+	fd = mch_fopen((char *)fname, READBIN);
 	if (fd != NULL)
 	{
+	    char_u	*fbuf = NULL;
+	    long	fsize = 0;
+
 	    while (!vim_fgets(line, MAXWLEN * 2, fd))
 	    {
 		fpos = fpos_next;
@@ -6390,33 +6396,60 @@ spell_add_word(
 			&& STRNCMP(word, line, len) == 0
 			&& (line[len] == '/' || line[len] < ' '))
 		{
-		    // Found duplicate word.  Remove it by writing a '#' at
-		    // the start of the line.  Mixing reading and writing
-		    // doesn't work for all systems, close the file first.
-		    fclose(fd);
-		    fd = mch_fopen((char *)fname, "r+");
-		    if (fd == NULL)
+		    // Remember the start of the line so it can be commented
+		    // out below by inserting a '#', keeping the whole word.
+		    if (ga_grow(&ga, 1) == FAIL)
 			break;
-		    if (fseek(fd, fpos, SEEK_SET) == 0)
-		    {
-			fputc('#', fd);
-			if (undo)
-			{
-			    home_replace(NULL, fname, NameBuff, MAXPATHL, TRUE);
-			    smsg(_("Word '%.*s' removed from %s"),
-							 len, word, NameBuff);
-			}
-		    }
-		    if (fseek(fd, fpos_next, SEEK_SET) != 0)
-		    {
-			PERROR(_("Seek error in spellfile"));
-			break;
-		    }
+		    ((long *)ga.ga_data)[ga.ga_len++] = fpos;
 		}
 	    }
-	    if (fd != NULL)
-		fclose(fd);
+
+	    // Rewrite the file with a '#' inserted at the start of each
+	    // remembered line.  Overwriting the first character in place
+	    // would lose it and the line cannot be grown in place.
+	    if (ga.ga_len > 0
+		    && fseek(fd, 0L, SEEK_END) == 0
+		    && (fsize = ftell(fd)) > 0
+		    && fseek(fd, 0L, SEEK_SET) == 0)
+	    {
+		fbuf = alloc((size_t)fsize);
+		if (fbuf != NULL
+			&& fread(fbuf, 1, (size_t)fsize, fd) < (size_t)fsize)
+		    VIM_CLEAR(fbuf);
+	    }
+	    fclose(fd);
+
+	    if (fbuf != NULL)
+	    {
+		FILE	*wfd = mch_fopen((char *)fname, WRITEBIN);
+
+		if (wfd == NULL)
+		    semsg(_(e_cant_open_file_str), fname);
+		else
+		{
+		    long	prev = 0;
+
+		    for (i = 0; i < ga.ga_len; ++i)
+		    {
+			long	off = ((long *)ga.ga_data)[i];
+
+			fwrite(fbuf + prev, 1, (size_t)(off - prev), wfd);
+			fputc('#', wfd);
+			prev = off;
+		    }
+		    fwrite(fbuf + prev, 1, (size_t)(fsize - prev), wfd);
+		    fclose(wfd);
+		    if (undo)
+		    {
+			home_replace(NULL, fname, NameBuff, MAXPATHL, TRUE);
+			smsg(_("Word '%.*s' removed from %s"),
+			     len, word, NameBuff);
+		    }
+		}
+		vim_free(fbuf);
+	    }
 	}
+	ga_clear(&ga);
     }
 
     if (!undo)

--- a/src/spellfile.c
+++ b/src/spellfile.c
@@ -6308,6 +6308,8 @@ spell_add_word(
     char_u	line[MAXWLEN * 2];
     long	fpos, fpos_next = 0;
     int		i;
+    int		rewrite_failed = FALSE;
+    int		did_change = FALSE;
     size_t	linelen;
     char_u	*spf;
 
@@ -6375,11 +6377,18 @@ spell_add_word(
     if (what == SPELL_ADD_BAD || undo)
     {
 	garray_T	ga;
+	char_u		*write_fname = fname;
+#ifdef HAVE_READLINK
+	char_u		fname_res[MAXPATHL];
+
+	if (resolve_symlink(fname, fname_res) == OK)
+	    write_fname = fname_res;
+#endif
 
 	// When the word appears as good word we need to remove that one,
 	// since its flags sort before the one with WF_BANNED.
 	ga_init2(&ga, sizeof(long), 10);
-	fd = mch_fopen((char *)fname, READBIN);
+	fd = mch_fopen((char *)write_fname, READBIN);
 	if (fd != NULL)
 	{
 	    char_u	*fbuf = NULL;
@@ -6421,38 +6430,122 @@ spell_add_word(
 
 	    if (fbuf != NULL)
 	    {
-		FILE	*wfd = mch_fopen((char *)fname, WRITEBIN);
+		char_u	*tempname;
+		FILE	*wfd = NULL;
+#ifndef VMS
+		int	tempfd;
+#endif
+		int	write_error = FALSE;
+		int	renamed = FALSE;
+		long	perm = mch_getperm(write_fname);
 
+		tempname = buf_modname(FALSE, write_fname,
+#ifdef VMS
+			(char_u *)"-tmp",
+#else
+			(char_u *)".tmp",
+#endif
+			FALSE);
+		if (tempname != NULL)
+		{
+#ifdef VMS
+		    stat_T st;
+
+		    if (mch_stat((char *)tempname, &st) < 0)
+			wfd = mch_fopen((char *)tempname, WRITEBIN);
+#else
+		    tempfd = mch_open((char *)tempname,
+			    O_CREAT | O_EXTRA | O_EXCL | O_WRONLY | O_NOFOLLOW,
+			    (int)((perm & 0777) | 0600));
+		    if (tempfd >= 0)
+		    {
+			wfd = fdopen(tempfd, WRITEBIN);
+			if (wfd == NULL)
+			    close(tempfd);
+		    }
+#endif
+		}
 		if (wfd == NULL)
-		    semsg(_(e_cant_open_file_str), fname);
+		{
+		    semsg(_(e_cant_open_file_str),
+				   tempname == NULL ? write_fname : tempname);
+		    rewrite_failed = TRUE;
+		}
 		else
 		{
-		    long	prev = 0;
+		    long prev = 0;
 
 		    for (i = 0; i < ga.ga_len; ++i)
 		    {
-			long	off = ((long *)ga.ga_data)[i];
+			long off = ((long *)ga.ga_data)[i];
 
-			fwrite(fbuf + prev, 1, (size_t)(off - prev), wfd);
-			fputc('#', wfd);
+			if (fwrite(fbuf + prev, 1, (size_t)(off - prev), wfd)
+						!= (size_t)(off - prev)
+				|| fputc('#', wfd) == EOF)
+			{
+			    write_error = TRUE;
+			    break;
+			}
 			prev = off;
 		    }
-		    fwrite(fbuf + prev, 1, (size_t)(fsize - prev), wfd);
-		    fclose(wfd);
-		    if (undo)
+		    if (!write_error
+			    && fwrite(fbuf + prev, 1, (size_t)(fsize - prev), wfd)
+						!= (size_t)(fsize - prev))
+			write_error = TRUE;
+		    if (fclose(wfd) == EOF)
+			write_error = TRUE;
+
+		    if (!write_error && mch_setperm(tempname, perm) == OK)
 		    {
-			home_replace(NULL, fname, NameBuff, MAXPATHL, TRUE);
-			smsg(_("Word '%.*s' removed from %s"),
-			     len, word, NameBuff);
+#ifdef HAVE_ACL
+			vim_acl_T acl = mch_get_acl(write_fname);
+
+			mch_set_acl(tempname, acl);
+			mch_free_acl(acl);
+#endif
+#if defined(HAVE_SELINUX) || defined(HAVE_SMACK)
+			mch_copy_sec(write_fname, tempname);
+#endif
+#ifdef FEAT_XATTR
+			mch_copy_xattr(write_fname, tempname);
+#endif
+#ifdef MSWIN
+			(void)mch_copy_file_attribute(write_fname, tempname);
+#endif
+			if (vim_rename(tempname, write_fname) == 0)
+			{
+			    renamed = TRUE;
+			    did_change = TRUE;
+			    if (undo)
+			    {
+				home_replace(NULL, fname, NameBuff, MAXPATHL, TRUE);
+				smsg(_("Word '%.*s' removed from %s"),
+					     len, word, NameBuff);
+			    }
+			}
+			else
+			    write_error = TRUE;
+		    }
+		    else
+			write_error = TRUE;
+		    if (write_error)
+		    {
+			semsg(_(e_error_writing_to_str), write_fname);
+			rewrite_failed = TRUE;
 		    }
 		}
+		if (tempname != NULL && !renamed)
+		    mch_remove(tempname);
+		vim_free(tempname);
 		vim_free(fbuf);
 	    }
+	    else if (ga.ga_len > 0)
+		rewrite_failed = TRUE;
 	}
 	ga_clear(&ga);
     }
 
-    if (!undo)
+    if (!undo && !rewrite_failed)
     {
 	fd = mch_fopen((char *)fname, "a");
 	if (fd == NULL && new_spf)
@@ -6487,13 +6580,14 @@ spell_add_word(
 	    else
 		fprintf(fd, "%.*s\n", len, word);
 	    fclose(fd);
+	    did_change = TRUE;
 
 	    home_replace(NULL, fname, NameBuff, MAXPATHL, TRUE);
 	    smsg(_("Word '%.*s' added to %s"), len, word, NameBuff);
 	}
     }
 
-    if (fd != NULL)
+    if (did_change)
     {
 	// Update the .add.spl file.
 	mkspell(1, &fname, FALSE, TRUE, TRUE);

--- a/src/testdir/test_spellfile.vim
+++ b/src/testdir/test_spellfile.vim
@@ -187,8 +187,13 @@ func Test_spell_undo_keeps_word()
 
   " The reported case: add a word, undo it, the word is kept after the '#'.
   spellgood fooee
+  call writefile([], './Xspellundo.add.tmp')
+  call assert_fails('spellundo fooee', 'E484:')
+  call assert_equal(['fooee'], readfile('./Xspellundo.add'))
+  call delete('./Xspellundo.add.tmp')
   spellundo fooee
   call assert_equal(['#fooee'], readfile('./Xspellundo.add'))
+  call assert_equal([], glob('./Xspellundo.add.tmp', FALSE, TRUE))
 
   " A word in the middle of the file: first character kept, neighbours intact.
   call delete('./Xspellundo.add')

--- a/src/testdir/test_spellfile.vim
+++ b/src/testdir/test_spellfile.vim
@@ -41,18 +41,18 @@ func Test_spell_normal()
   norm! ]s
   call assert_equal('2 goood', getline('.'))
   let cnt=readfile('./Xspellfile.add')
-  call assert_equal('#oood', cnt[0])
+  call assert_equal('#goood', cnt[0])
   call assert_equal('goood/!', cnt[1])
 
   " Test for :spellrare
   spellrare rare
   let cnt=readfile('./Xspellfile.add')
-  call assert_equal(['#oood', 'goood/!', 'rare/?'], cnt)
+  call assert_equal(['#goood', 'goood/!', 'rare/?'], cnt)
 
   " Make sure :spellundo works for rare words.
   spellundo rare
   let cnt=readfile('./Xspellfile.add')
-  call assert_equal(['#oood', 'goood/!', '#are/?'], cnt)
+  call assert_equal(['#goood', 'goood/!', '#rare/?'], cnt)
 
   " Test for zg in visual mode
   let a=execute('unsilent :norm! V$zg')
@@ -80,36 +80,36 @@ func Test_spell_normal()
   let a=execute('unsilent norm! V$zW')
   call assert_match("Word '2 goood' added to .*", a)
   let cnt=readfile(fname)
-  call assert_equal('# goood', cnt[0])
+  call assert_equal('#2 goood', cnt[0])
   call assert_equal('2 goood/!', cnt[1])
 
   " Test for zuW
   let a=execute('unsilent norm! V$zuW')
   call assert_match("Word '2 goood' removed from .*", a)
   let cnt=readfile(fname)
-  call assert_equal('# goood', cnt[0])
-  call assert_equal('# goood/!', cnt[1])
+  call assert_equal('#2 goood', cnt[0])
+  call assert_equal('#2 goood/!', cnt[1])
 
   " Test for zuG
   let a=execute('unsilent norm! $zG')
   call assert_match("Word 'goood' added to .*", a)
   let cnt=readfile(fname)
-  call assert_equal('# goood', cnt[0])
-  call assert_equal('# goood/!', cnt[1])
+  call assert_equal('#2 goood', cnt[0])
+  call assert_equal('#2 goood/!', cnt[1])
   call assert_equal('goood', cnt[2])
   let a=execute('unsilent norm! $zuG')
   let cnt=readfile(fname)
   call assert_match("Word 'goood' removed from .*", a)
-  call assert_equal('# goood', cnt[0])
-  call assert_equal('# goood/!', cnt[1])
-  call assert_equal('#oood', cnt[2])
+  call assert_equal('#2 goood', cnt[0])
+  call assert_equal('#2 goood/!', cnt[1])
+  call assert_equal('#goood', cnt[2])
   " word not found in wordlist
   let a=execute('unsilent norm! V$zuG')
   let cnt=readfile(fname)
   call assert_match("", a)
-  call assert_equal('# goood', cnt[0])
-  call assert_equal('# goood/!', cnt[1])
-  call assert_equal('#oood', cnt[2])
+  call assert_equal('#2 goood', cnt[0])
+  call assert_equal('#2 goood/!', cnt[1])
+  call assert_equal('#goood', cnt[2])
 
   " Test for zug
   call delete('./Xspellfile.add')
@@ -120,12 +120,12 @@ func Test_spell_normal()
   let a=execute('unsilent norm! $zug')
   call assert_match("Word 'goood' removed from \./Xspellfile.add", a)
   let cnt=readfile('./Xspellfile.add')
-  call assert_equal('#oood', cnt[0])
+  call assert_equal('#goood', cnt[0])
   " word not in wordlist
   let a=execute('unsilent norm! V$zug')
   call assert_match('', a)
   let cnt=readfile('./Xspellfile.add')
-  call assert_equal('#oood', cnt[0])
+  call assert_equal('#goood', cnt[0])
 
   " Test for zuw
   call delete('./Xspellfile.add')
@@ -136,12 +136,12 @@ func Test_spell_normal()
   let a=execute('unsilent norm! Vzuw')
   call assert_match("Word '2 goood' removed from \./Xspellfile.add", a)
   let cnt=readfile('./Xspellfile.add')
-  call assert_equal('# goood/!', cnt[0])
+  call assert_equal('#2 goood/!', cnt[0])
   " word not in wordlist
   let a=execute('unsilent norm! $zug')
   call assert_match('', a)
   let cnt=readfile('./Xspellfile.add')
-  call assert_equal('# goood/!', cnt[0])
+  call assert_equal('#2 goood/!', cnt[0])
 
   " add second entry to spellfile setting
   set spellfile=./Xspellfile.add,./Xspellfile2.add
@@ -156,11 +156,11 @@ func Test_spell_normal()
   let temp = execute(':spe!0/0')
   call assert_match('Invalid region', temp)
   let spellfile = matchstr(temp, 'Invalid region nr in \zs.*\ze line \d: 0')
-  call assert_equal(['# goood', '# goood/!', '#oood', '0/0'], readfile(spellfile))
+  call assert_equal(['#2 goood', '#2 goood/!', '#goood', '0/0'], readfile(spellfile))
 
   " Test for :spellrare!
   :spellrare! raare
-  call assert_equal(['# goood', '# goood/!', '#oood', '0/0', 'raare/?'], readfile(spellfile))
+  call assert_equal(['#2 goood', '#2 goood/!', '#goood', '0/0', 'raare/?'], readfile(spellfile))
   call delete(spellfile)
 
   " clean up
@@ -178,6 +178,29 @@ func Test_spell_normal()
 
   set spellfile= spell& spelllang&
   bw!
+endfunc
+
+" Undo of adding a word to 'spellfile' keeps the whole word in the comment
+" line instead of overwriting the first character (neovim/neovim#20609).
+func Test_spell_undo_keeps_word()
+  set spellfile=./Xspellundo.add
+
+  " The reported case: add a word, undo it, the word is kept after the '#'.
+  spellgood fooee
+  spellundo fooee
+  call assert_equal(['#fooee'], readfile('./Xspellundo.add'))
+
+  " A word in the middle of the file: first character kept, neighbours intact.
+  call delete('./Xspellundo.add')
+  spellgood oneword
+  spellgood twoword
+  spellgood threeword
+  spellundo twoword
+  call assert_equal(['oneword', '#twoword', 'threeword'], readfile('./Xspellundo.add'))
+
+  call delete('./Xspellundo.add')
+  call delete('./Xspellundo.add.spl')
+  set spellfile=
 endfunc
 
 " Spell file content test. Write 'content' to the spell file prefixed by the


### PR DESCRIPTION
related: neovim/neovim#20609

## Problem

undoing a `'spellfile'` word (`zw`/`zug`/`zuw`/`:spellundo`) comments the entry out by overwriting its first character with `#`, so the record loses that charac
ter. `fooee` becomes `#ooee`.

## Solution

remember the start of each matching line, then rewrite the file inserting `#` before it so the whole word is kept.