### PR TITLE
searchcount() returns wrong cached maxcount

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -3309,7 +3309,7 @@ update_search_stat(
 	stat->cnt = cnt;
 	stat->exact_match = exact_match;
 	stat->incomplete = incomplete;
-	stat->last_maxcount = p_msc;
+	stat->last_maxcount = last_maxcount;
 	return;
     }
     last_maxcount = maxcount;

--- a/src/testdir/test_search.vim
+++ b/src/testdir/test_search.vim
@@ -2457,4 +2457,17 @@ func Test_incsearch_delimiter_ctrlg()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_searchcount_maxcount_cached()
+  new
+  call setline(1, repeat(['foo'], 5))
+  set maxsearchcount=99
+  let @/ = 'foo'
+  call cursor(1, 1)
+  call searchcount(#{recompute: v:true,  maxcount: 3})
+  let r = searchcount(#{recompute: v:false, maxcount: 3})
+  call assert_equal(3, r.maxcount)
+  set maxsearchcount&
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  Cached searchcount() returns 'maxsearchcount' instead of the
          requested maxcount.
Solution: return the remembered last_maxcount.