### PR TITLE
Support Git revision list filetype

### DIFF
--- a/.github/MAINTAINERS
+++ b/.github/MAINTAINERS
@@ -206,6 +206,7 @@ runtime/ftplugin/gitcommit.vim				@tpope
 runtime/ftplugin/gitconfig.vim				@tpope
 runtime/ftplugin/gitignore.vim				@ObserverOfTime
 runtime/ftplugin/gitrebase.vim				@tpope
+runtime/ftplugin/gitrevlist.vim				@fionn
 runtime/ftplugin/gitsendemail.vim			@tpope
 runtime/ftplugin/gleam.vim				@kirillmorozov
 runtime/ftplugin/go.vim					@dbarnett

--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -3264,6 +3264,8 @@ const ft_from_name = {
   "TAG_EDITMSG": "gitcommit",
   "NOTES_EDITMSG": "gitcommit",
   "EDIT_DESCRIPTION": "gitcommit",
+  # Git revision list
+  ".git-blame-ignore-revs": "gitrevlist",
   # gnash(1) configuration files
   "gnashrc": "gnash",
   ".gnashrc": "gnash",

--- a/runtime/ftplugin/gitrevlist.vim
+++ b/runtime/ftplugin/gitrevlist.vim
@@ -1,0 +1,16 @@
+" Vim filetype plugin file
+" Language:     Git revision list
+" Author:       Fionn Fitzmaurice (github.com/fionn)
+" Maintainer:   Fionn Fitzmaurice (github.com/fionn)
+" License:      Vim & Apache 2.0
+
+if exists("b:did_ftplugin")
+    finish
+endif
+let b:did_ftplugin = 1
+
+setlocal comments=:#
+setlocal commentstring=#\ %s
+setlocal keywordprg=git\ show
+
+let b:undo_ftplugin = "setl comments< commentstring< keywordprg<"

--- a/runtime/syntax/gitrevlist.vim
+++ b/runtime/syntax/gitrevlist.vim
@@ -1,0 +1,17 @@
+" Vim syntax file
+" Language:     Git revision list
+" Author:       Fionn Fitzmaurice (github.com/fionn)
+" Maintainer:   Fionn Fitzmaurice (github.com/fionn)
+" License:      Vim & Apache 2.0
+
+if exists("b:current_syntax")
+    finish
+endif
+
+syn match gitrevlistHash "\<\x\{40}\>\|\<\x\{64}\>" contains=@NoSpell nextgroup=gitrevlistComment skipwhite
+syn match gitrevlistComment "#.*$"
+
+hi def link gitrevlistHash Identifier
+hi def link gitrevlistComment Comment
+
+let b:current_syntax = "gitrevlist"

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -337,6 +337,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     gitignore: ['file.git/info/exclude', '.gitignore', '/.config/git/ignore', 'some.git/info/exclude'] + WhenConfigHome('$XDG_CONFIG_HOME/git/ignore') + ['.prettierignore', '.fdignore', '/.config/fd/ignore', '.ignore', '.rgignore', '.dockerignore', '.containerignore', '.npmignore', '.vscodeignore'],
     gitolite: ['gitolite.conf', '/gitolite-admin/conf/file', 'any/gitolite-admin/conf/file'],
     gitrebase: ['git-rebase-todo'],
+    gitrevlist: ['.git-blame-ignore-revs'],
     gitsendemail: ['.gitsendemail.msg.xxxxxx'],
     gkrellmrc: ['gkrellmrc', 'gkrellmrc_x'],
     gleam: ['file.gleam'],


### PR DESCRIPTION
A Git revision list is

> a list of object names (i.e. one unabbreviated SHA-1 per line)..., comments (#), empty lines, and any leading and trailing whitespace are ignored.

(from Git's `fsck.skipList` documentation).

The default output of `git rev-list` will match this. It is also suitable as input to `git blame --ignore-revs-file`.

This adds filetype detection matching `.git-blame-ignore-revs` files, syntax highlighting and basic filetype settings.