### PR TITLE
make(tags): detach from configure

### DIFF
--- a/Filelist
+++ b/Filelist
@@ -34,6 +34,7 @@ SRC_ALL =	\
 		ci/ddebs.list \
 		ci/pinned-pkgs \
 		src/Make_all.mak \
+		src/Make_tags.mak \
 		src/README.md \
 		src/alloc.c \
 		src/alloc.h \

--- a/Makefile
+++ b/Makefile
@@ -30,9 +30,12 @@ first:
 	@echo "If there are problems, cd to the src directory and run make there"
 	cd src && $(MAKE) $@
 
+tags:
+	$(MAKE) -C src/ -f Make_tags.mak tags
+
 # Some make programs use the last target for the $@ default; put the other
 # targets separately to always let $@ expand to "first" by default.
-all install uninstall tools config configure reconfig proto depend lint tags types test scripttests testtiny test_libvterm unittests testclean clean distclean:
+all install uninstall tools config configure reconfig proto depend lint types test scripttests testtiny test_libvterm unittests testclean clean distclean:
 	@if test ! -f src/auto/config.mk; then \
 		cp src/config.mk.dist src/auto/config.mk; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,8 @@ first:
 	@echo "If there are problems, cd to the src directory and run make there"
 	cd src && $(MAKE) $@
 
-tags:
-	$(MAKE) -C src/ -f Make_tags.mak tags
+tags notags:
+	$(MAKE) -C src/ -f Make_tags.mak $@
 
 # Some make programs use the last target for the $@ default; put the other
 # targets separately to always let $@ expand to "first" by default.

--- a/src/Make_all.mak
+++ b/src/Make_all.mak
@@ -1,5 +1,5 @@
 #
-# Common Makefile, defines the list of tests to run and other things.
+# Common Makefile - shared platform independent
 #
 
 # Argument for running ctags.
@@ -8,7 +8,7 @@ TAGS_FILES = \
 	*.cc \
 	*.cpp \
 	*.h \
-	auto/*.c \
+	$(wildcard auto/*.c) \
 	libvterm/src/*.c \
 	libvterm/src/*.h \
 	libvterm/include/*.h \

--- a/src/Make_all.mak
+++ b/src/Make_all.mak
@@ -8,7 +8,7 @@ TAGS_FILES = \
 	*.cc \
 	*.cpp \
 	*.h \
-	$(wildcard auto/*.c) \
+	auto/*.c \
 	libvterm/src/*.c \
 	libvterm/src/*.h \
 	libvterm/include/*.h \

--- a/src/Make_tags.mak
+++ b/src/Make_tags.mak
@@ -4,9 +4,7 @@
 
 include Make_all.mak
 
-ifeq ($(strip $(TAGPRG)),)
-TAGPRG = ctags -I INIT+,INIT2+,INIT3+,INIT4+,INIT5+ --fields=+S -f tags
-endif
+TAGPRG ?= ctags -I INIT+,INIT2+,INIT3+,INIT4+,INIT5+ --fields=+S -f tags
 
 notags:
 	-rm -f tags

--- a/src/Make_tags.mak
+++ b/src/Make_tags.mak
@@ -4,6 +4,7 @@
 
 include Make_all.mak
 
+# Override with `make TAGPRG='...'`
 TAGPRG ?= ctags -I INIT+,INIT2+,INIT3+,INIT4+,INIT5+ --fields=+S -f tags
 
 notags:

--- a/src/Make_tags.mak
+++ b/src/Make_tags.mak
@@ -4,7 +4,7 @@
 
 include Make_all.mak
 
-# Override with `make TAGPRG='...'`
+# Override with `make TAGPRG='...' tags`
 TAGPRG ?= ctags -I INIT+,INIT2+,INIT3+,INIT4+,INIT5+ --fields=+S -f tags
 
 notags:

--- a/src/Make_tags.mak
+++ b/src/Make_tags.mak
@@ -1,0 +1,16 @@
+#
+# tags
+#
+
+include Make_all.mak
+
+ifeq ($(strip $(TAGPRG)),)
+TAGPRG = ctags -I INIT+,INIT2+,INIT3+,INIT4+,INIT5+ --fields=+S -f tags
+endif
+
+notags:
+	-rm -f tags
+
+# You can ignore error messages for missing files.
+tags TAGS: notags
+	$(TAGPRG) $(TAGS_FILES)

--- a/src/Make_tags.mak
+++ b/src/Make_tags.mak
@@ -3,6 +3,7 @@
 #
 
 include Make_all.mak
+-include auto/config.mk
 
 # Override with `make TAGPRG='...' tags`
 TAGPRG ?= ctags -I INIT+,INIT2+,INIT3+,INIT4+,INIT5+ --fields=+S -f tags

--- a/src/Makefile
+++ b/src/Makefile
@@ -2203,7 +2203,7 @@ proto/gui_gtk_gresources.pro: auto/gui_gtk_gresources.c
 notags:
 	$(MAKE) -f Make_tags.mak notags
 
-# Note: tags is made for the currently configured version.
+# Configure sets portable TAGPRG, else modern ctags is used.
 # You can ignore error messages for missing files.
 tags TAGS:
 	$(MAKE) -f Make_tags.mak tags

--- a/src/Makefile
+++ b/src/Makefile
@@ -2205,7 +2205,7 @@ notags:
 
 # Configure sets portable TAGPRG, else modern ctags is used.
 # You can ignore error messages for missing files.
-tags TAGS:
+tags TAGS: notags
 	$(MAKE) -f Make_tags.mak tags
 
 # Build the cscope database.

--- a/src/Makefile
+++ b/src/Makefile
@@ -2201,12 +2201,12 @@ proto/gui_gtk_gresources.pro: auto/gui_gtk_gresources.c
 	fi
 
 notags:
-	-rm -f tags
+	$(MAKE) -f Make_tags.mak notags
 
 # Note: tags is made for the currently configured version.
 # You can ignore error messages for missing files.
-tags TAGS: notags
-	$(TAGPRG) $(TAGS_FILES)
+tags TAGS:
+	$(MAKE) -f Make_tags.mak tags
 
 # Build the cscope database.
 # This may search more files than necessary.


### PR DESCRIPTION
**Problem:**

* `make tags` > `/src/tags` requires `./configure` (slow workflow)

I expect that tags are *available* when opening vim inside the vim src or only require near instant `make tags` command.

**Solution:**

Make it possible to run:
```
make -C src tags # cd src && make tags
```

Separating it cleanly while retaining function makes ctags more accessible.

* Comments explaining new behaviour:
[src/Makefile](https://github.com/dezza/vim/blob/fix-make-ctags-independent/src/Makefile#L2206)
[src/Make_tags.mak](https://github.com/dezza/vim/blob/fix-make-ctags-independent/src/Make_tags.mak#L7)

---

**Q**: Why can't we run `make tags`from `/Makefile` but only from `/src/Makefile` w/o configure?

* Requires significant change. This is least risky compromise, easily documented. See `Q` below for more details.

**Q**: Why `Make_tags.mak` ? `Make_all.mak` contain only `TAGS_FILES=` var, why not reuse and place it here?

* VIM Makefile uses ordering to build. This avoids implementing default target and aims at smallest change - aiming for highest portability.

* `Make_all.mak` is meant as platform-independent file. It was vaguely insinuated in [old comments](https://github.com/vim/vim/blob/master/src/Make_all.mak#L1-L5), but `TAGS_FILES` remains the only variable. However, the same concept lives in `src/testdir/Make_all.mak` - so it is not "*unused*".

I [updated the comment](https://github.com/dezza/vim/blob/fix-make-ctags-independent/src/Make_all.mak#L2) making it clear that `Make_all.mak` is for platform-independent variables and fixtures.

* **Q**: [Makefile:L2206-L2209](https://github.com/vim/vim/blob/master/src/Makefile#L2206-L2209) mentions its for the configured version, _makes sense requiring configure_?

Highly overstated;

`TAGS_FILES` is constant.
`/src/auto/*` only dir populated after configure and tags are still generated for it, if configured.

* **Q**: Fallback if not configured?

Same default of `TAGPRG = ctags -I INIT+,INIT2+,INIT3+,INIT4+,INIT5+ --fields=+S -f tags` for modern universal/exhuberant ctags that `configure.ac` tests first:
[configure.ac:L4609-L4610](https://github.com/vim/vim/blob/master/src/configure.ac#L4609-L4610)

If not sufficient; the solution remains the same:
* configure

The new override saves a configure-step:
* `make TAGPRG='ctags $_new_args_here_ -f tags'`
Thus easy to set once a specific ctags from [configure.ac:L4600-4626](https://github.com/vim/vim/blob/master/src/configure.ac#L4600-L4626), or copy it straight from `src/auto/config.mk` after configure.

---

I'd rather fix this upstream than do hack to circumvent configure. I'm sure it will be appreciated that it is more accessible to newer contributors. I think it turned out proper, aligning with current function.

If it breaks anything, I'm sure we will know fast - but passing CI without much effort here is a good hint its not that significant. For same reason I did the smallest change possible to detach it properly.