### PR TITLE
client-server test fails without X11 server

### DIFF
--- a/src/clientserver.c
+++ b/src/clientserver.c
@@ -1287,6 +1287,8 @@ f_serverlist(typval_T *argvars UNUSED, typval_T *rettv)
 	make_connection();
 	if (X_DISPLAY != NULL)
 	    list = serverGetVimNames(X_DISPLAY);
+	else
+	    list = list_alloc();
     }
 #  endif
 # endif


### PR DESCRIPTION
Problem: When unable to connect to X11, `serverlist({'list':1})` returns a string instead of a list.  This causes Test_remote_serverlist() in test_vim9_builtin.vim to fail.

Solution: Assign a new list even when unable to connect to X11.

---

It is not ideal to have a string returned when a list is expected.
https://github.com/vim/vim/blob/834b8d218f1db92e587ecd449e5ce88b41fbe256/src/testdir/test_vim9_builtin.vim#L3610-L3611
