### PR TITLE
fileio: treat { and } literally when in 'isfname'

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5380,6 +5380,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 				comma, plus <Tab>.
 	See |option-backslash| about including spaces and backslashes.
 
+	If including '{' or '}', |E219| and |E220| won't be thrown.
+
 						*'isident'* *'isi'*
 'isident' 'isi'		string	(default for Win32:
 					   "@,48-57,_,128-167,224-235"

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -5793,6 +5793,7 @@ file_pat_to_reg_pat(
     int		i;
     int		nested = 0;
     int		add_dollar = TRUE;
+    int		brace_is_filename = (vim_isfilec('{') || vim_isfilec('}'));
 
     if (allow_dirs != NULL)
 	*allow_dirs = FALSE;
@@ -5937,11 +5938,21 @@ file_pat_to_reg_pat(
 		break;
 #endif
 	    case '{':
+		if (brace_is_filename)
+		{
+		    reg_pat[i++] = '{';
+		    break;
+		}
 		reg_pat[i++] = '\\';
 		reg_pat[i++] = '(';
 		nested++;
 		break;
 	    case '}':
+		if (brace_is_filename)
+		{
+		    reg_pat[i++] = '}';
+		    break;
+		}
 		reg_pat[i++] = '\\';
 		reg_pat[i++] = ')';
 		--nested;


### PR DESCRIPTION
When 'isfname' contains '{' or '}', treat them as literal filename
characters instead of brace expansion markers. This prevents E554 and
E870 errors on Windows where braces are valid filename characters.

relates: #20392
