### PR TITLE
docs: better way to detect WSL

### DIFF
--- a/runtime/doc/os_win32.txt
+++ b/runtime/doc/os_win32.txt
@@ -48,7 +48,7 @@ For compiling see "src/INSTALLpc.txt".			*win32-compiling*
 							*WSL*
 When using Vim on WSL (Windows Subsystem for Linux) the remarks here do not
 apply, `has('win32')` will return false then.  In case you need to know
-whether Vim is running on WSL you can use `exists('$WSLENV')`.
+whether Vim is running on WSL you can use `exists('$WSL_DISTRO_NAME')`.
 
 ==============================================================================
 1. Known problems					*win32-problems*


### PR DESCRIPTION
Current method can't work in Windows Terminal as far as I know.

This is a way that already had been adopted in `dist/vim9.vim`.
