### PR TITLE
Sort features in :version

### DIFF
--- a/src/version.c
+++ b/src/version.c
@@ -96,6 +96,11 @@ static char *(features[]) =
 #else
 	"-acl",
 #endif
+#ifdef FEAT_ARABIC
+	"+arabic",
+#else
+	"-arabic",
+#endif
 #ifdef AMIGA		// only for Amiga systems
 # ifdef FEAT_ARP
 	"+ARP",
@@ -103,17 +108,12 @@ static char *(features[]) =
 	"-ARP",
 # endif
 #endif
-#ifdef FEAT_ARABIC
-	"+arabic",
+#ifdef FEAT_AUTOCHDIR
+	"+autochdir",
 #else
-	"-arabic",
+	"-autochdir",
 #endif
 	"+autocmd",
-#ifdef FEAT_AUTOCHDIR
-       "+autochdir",
-#else
-       "-autochdir",
-#endif
 #ifdef FEAT_AUTOSERVERNAME
 	"+autoservername",
 #else
@@ -275,6 +275,36 @@ static char *(features[]) =
 #else
 	"-iconv",
 #endif
+#ifdef FEAT_IMAGE
+	"+image",
+#else
+	"-image",
+#endif
+#ifdef FEAT_IMAGE_CAIRO
+	"+image_cairo",
+#else
+	"-image_cairo",
+#endif
+#ifdef FEAT_IMAGE_GDI
+	"+image_gdi",
+#else
+	"-image_gdi",
+#endif
+#ifdef FEAT_IMAGE_GDK
+	"+image_gdk",
+#else
+	"-image_gdk",
+#endif
+#ifdef FEAT_IMAGE_KITTY
+	"+image_kitty",
+#else
+	"-image_kitty",
+#endif
+#ifdef FEAT_IMAGE_SIXEL
+	"+image_sixel",
+#else
+	"-image_sixel",
+#endif
 	"+insert_expand",
 #ifdef FEAT_IPV6
 	"+ipv6",
@@ -336,12 +366,6 @@ static char *(features[]) =
 #endif
 	"+modify_fname",
 	"+mouse",
-#ifdef FEAT_MOUSESHAPE
-	"+mouseshape",
-#else
-	"-mouseshape",
-#endif
-
 #if defined(UNIX) || defined(VMS)
 # ifdef FEAT_MOUSE_DEC
 	"+mouse_dec",
@@ -390,6 +414,11 @@ static char *(features[]) =
 	"-mouse_urxvt",
 # endif
 	"+mouse_xterm",
+#endif
+#ifdef FEAT_MOUSESHAPE
+	"+mouseshape",
+#else
+	"-mouseshape",
 #endif
 
 #ifdef FEAT_MBYTE_IME
@@ -535,36 +564,6 @@ static char *(features[]) =
 #else
 	"-sodium",
 #endif
-#ifdef FEAT_IMAGE
-	"+image",
-#else
-	"-image",
-#endif
-#ifdef FEAT_IMAGE_SIXEL
-	"+image_sixel",
-#else
-	"-image_sixel",
-#endif
-#ifdef FEAT_IMAGE_KITTY
-	"+image_kitty",
-#else
-	"-image_kitty",
-#endif
-#ifdef FEAT_IMAGE_GDI
-	"+image_gdi",
-#else
-	"-image_gdi",
-#endif
-#ifdef FEAT_IMAGE_CAIRO
-	"+image_cairo",
-#else
-	"-image_cairo",
-#endif
-#ifdef FEAT_IMAGE_GDK
-	"+image_gdk",
-#else
-	"-image_gdk",
-#endif
 #ifdef FEAT_SOUND
 	"+sound",
 #else
@@ -600,9 +599,9 @@ static char *(features[]) =
 #else
 	"-tabpanel",
 #endif
+	"-tag_any_white",
 	"+tag_binary",
 	"-tag_old_static",
-	"-tag_any_white",
 #ifdef FEAT_TCL
 # ifdef DYNAMIC_TCL
 	"+tcl/dyn",


### PR DESCRIPTION
Problem: Features in :version are not sorted.

Solution: Sort features case-insensitively.

---

I noticed that `+image` was placed after `+sodium`.
After checking everything, I found a few other items where the order was incorrect, so I fixed those as well.

The indentation for `autochdir` differed from the rest, so I corrected it to match.