### PR TITLE
Skip Test_clientserver_serverlist_list for non-gvim GUI builds

### DIFF
--- a/src/testdir/test_clientserver.vim
+++ b/src/testdir/test_clientserver.vim
@@ -549,6 +549,12 @@ endfunc
 func Test_clientserver_serverlist_list()
   CheckNotGui
 
+  " CheckNotGui has already confirmed gvim is not being used to run this test.
+  " However, if this is a GUI _build_ of vim, then the running Vim process
+  " will already have selected _not_ to use socket clientserver. Therefore, we
+  " either need the ability to use the GUI clientserver or to skip the test.
+  call Check_X11_Connection()
+
   let g:test_is_flaky = 1
   let cmd = GetVimCommand()
 
@@ -567,7 +573,7 @@ func Test_clientserver_serverlist_list()
   call assert_equal('list<string>', typename(serverlist(#{list: v:true})))
   call assert_true(serverlist(#{list: v:true})->index('XVIMTEST') != -1)
 
-  if has('win32') || has('gui_running')
+  if has('win32')
     call job_stop(job, 'kill')
   else
     call system(actual .. " --remote-expr 'execute(\"qa!\")'")


### PR DESCRIPTION
Running a GUI build that cannot access the GUI clientserver will fail
like below

    command line..script /build/package/src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_clientserver_serverlist_list[16]..WaitForAssert[2]..<SNR>4_WaitForCommon[11]..<lambda>23 line 1: Pattern 'XVIMTEST' does not match ''
    command line..script /build/package/src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_clientserver_serverlist_list line 18: Expected 'list<string>' but got 'string'
    Caught exception in Test_clientserver_serverlist_list(): Vim(call):E897: List or Blob required @ command line..script /build/package/src/testdir/runtest.vim[636]..function RunTheTest[63]..Test_clientserver_serverlist_list, line 19