### PR TITLE
cleared last search pattern is restored from viminfo on restart

### DIFF
--- a/src/testdir/test_viminfo.vim
+++ b/src/testdir/test_viminfo.vim
@@ -38,6 +38,18 @@ func Test_viminfo_read_and_write()
   call assert_equal(3, done)
 endfunc
 
+func Test_viminfo_clear_search_pattern()
+  let @/ = 'foobar'
+  wviminfo Xviminfo
+  call assert_notequal(-1, match(readfile('Xviminfo'), 'foobar'))
+
+  let @/ = ''
+  wviminfo Xviminfo
+  call assert_equal(-1, match(readfile('Xviminfo'), 'foobar'))
+
+  call delete('Xviminfo')
+endfunc
+
 func Test_global_vars()
   let g:MY_GLOBAL_STRING = "Vim Editor"
   let g:MY_GLOBAL_NUM = 345

--- a/src/viminfo.c
+++ b/src/viminfo.c
@@ -1476,7 +1476,7 @@ write_viminfo_sub_string(FILE *fp)
  */
 
     static int
-read_viminfo_search_pattern(vir_T *virp, int force)
+read_viminfo_search_pattern(vir_T *virp, int force, int writing)
 {
     char_u	*lp;
     int		idx = -1;
@@ -1543,16 +1543,19 @@ read_viminfo_search_pattern(vir_T *virp, int force)
 									TRUE);
 	    if (val != NULL)
 	    {
-		set_last_search_pat(val, idx, magic, setlast);
-		vim_free(val);
-		spat->no_scs = no_scs;
-		spat->off.line = off_line;
-		spat->off.end = off_end;
-		spat->off.off = off;
+		if (!writing)
+		{
+		    set_last_search_pat(val, idx, magic, setlast);
+		    spat->no_scs = no_scs;
+		    spat->off.line = off_line;
+		    spat->off.end = off_end;
+		    spat->off.off = off;
 #ifdef FEAT_SEARCH_EXTRA
-		if (setlast)
-		    set_no_hlsearch(!hlsearch_on);
+		    if (setlast)
+			set_no_hlsearch(!hlsearch_on);
 #endif
+		}
+		vim_free(val);
 	    }
 	}
     }
@@ -2914,7 +2917,7 @@ read_viminfo_up_to_marks(
 	    case '/':	    // Search string
 	    case '&':	    // Substitute search string
 	    case '~':	    // Last search string, followed by '/' or '&'
-		eof = read_viminfo_search_pattern(virp, forceit);
+		eof = read_viminfo_search_pattern(virp, forceit, writing);
 		break;
 	    case '$':
 		eof = read_viminfo_sub_string(virp, forceit);


### PR DESCRIPTION
## Problem
The last search pattern cannot be permanently cleared: after `:let @/ = ""` the pattern is restored from the viminfo file on the next start.

## Solution

When reading the viminfo file for a merging write, do not restore a search pattern that was cleared in the current session.

Note: this is the simpler of two approaches. Registers and marks merge by
timestamp so the most recent change wins (even across
concurrent Vim instances).

In contrast, the search pattern carries no timestamp in the
viminfo format. Here I chose to let the current session win on write (last writer wins), which fixes clearing across restarts but the semantics are a bit different.

I can add a timestamp-based merge (which would arguably be more correct) but I don't know if the complexity is warranted.

closes #20718