### PR TITLE
fix(gtk): remove type hints

### DIFF
--- a/src/gui_gtk.c
+++ b/src/gui_gtk.c
@@ -1712,8 +1712,6 @@ gui_mch_dialog(int	type,	    // type of dialog
     dialog = create_message_dialog(type, title, message);
     dialoginfo.dialog = GTK_DIALOG(dialog);
     dialog_add_buttons(GTK_DIALOG(dialog), buttons);
-    gtk_window_set_type_hint(GTK_WINDOW(dialog),
-			     GDK_WINDOW_TYPE_HINT_POPUP_MENU);
 
     if (textfield != NULL)
     {


### PR DESCRIPTION
Closes: #17760

It is unclear whether #172 was properly fixed by
https://github.com/vim/vim/pull/16100

Remaining issues on wayland:

* Centering dialog (*hard*)
[Window.get_position](https://docs.gtk.org/gtk3/method.Window.get_position.html):
`The reliability of this function depends on the windowing system currently in use. Some windowing systems, such as Wayland, do not support a global coordinate system, and thus the position of the window will always be (0, 0). Others, like X11, do not have a reliable way to obtain the geometry of the decorations of a window if they are provided by the window manager.
`
Hacks include manual positioning in `realize` event; breaks gtk3 API lifetime of widget and reintroduces focus issue and other issues including significantly increased complexity - also even if a hack works on one desktop/compositor (*kwin does*) doesn't mean it works everywhere. I believe most can live with this minor annoyance of not being equal in position to x11.
Related(issue explained): [[1]](https://hackaday.com/2025/11/11/waylands-never-ending-opposition-to-multi-window-positioning/)

`GTK_WINDOW_POPUP` can't get keybord focus, but allows postioning.

`GTK_DIALOG_MODAL` (*gtk_message_dialog_new* default) grabs input for dialog until `Yes|No|Cancel` is pressed. 

The latter is the better tradeoff, to avoid requiring mouse to interact.

* Find/replace dialog starts maximized , occupying entire `gui.mainwin`

* Other dialogs

@CS-cwhite can you clarify if the issue was fixed for you with your PR or it reappeared? 

5049daf2 
`GDK_WINDOW_TYPE_HINT_POPUP_MENU` is the wrong fix, since it doesn't allow keyboard input #17760

@aswild @nitro322 @gcb welcome to test this PR