### PR TITLE
runtime(netrw): fix E471 when g:netrw_chgwin is one past the last window

### DIFF
--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -3936,7 +3936,7 @@ function s:NetrwBrowseChgDir(islocal, newdir, cursor, ...)
                             let curwin= winnr()
                             exe "NetrwKeepj keepalt ".winnr("$")."wincmd w"
                             vs
-                            exe "NetrwKeepj keepalt ".g:netrw_chgwin."wincmd ".curwin
+                            exe "NetrwKeepj keepalt ".curwin."wincmd w"
                         endif
                         exe "NetrwKeepj keepalt ".g:netrw_chgwin."wincmd w"
                     endif


### PR DESCRIPTION
**Problem**

Opening a file from a netrw listing throws:

```
Error in function <SNR>NN_NetrwBrowseChgDir:
line  120:
E471: Argument required: keepj keepalt 2wincmd 1
```

whenever `g:netrw_chgwin == winnr('$') + 1`. The easiest way to hit it:

1. `:Lexplore` (sets `g:netrw_chgwin = 2`) and open a file
2. Close the Lexplore sidebar (`g:netrw_chgwin` stays `2`)
3. `:Explore` in the remaining single window and press `<CR>` on a file

**Root cause**

In `s:NetrwBrowseChgDir` (runtime/pack/dist/opt/netrw/autoload/netrw.vim:3939), the "make the missing window available" branch builds the return jump as:

```vim
exe "NetrwKeepj keepalt ".g:netrw_chgwin."wincmd ".curwin
```

which concatenates the saved window **number** (`curwin`) where `wincmd` expects its single-letter argument — producing the malformed `2wincmd 1`.

**Fix**

Per the surrounding comment, the intent is to return to the saved window after `vs` creates the missing one; the statement right after the `endif` then performs the actual jump to `g:netrw_chgwin`:

```vim
exe "NetrwKeepj keepalt ".curwin."wincmd w"
```

**Verified** (nvim 0.12.4 with the patched file shadowing the bundled copy, same runtime code): the repro above no longer errors; the selected file opens in window 2 of a fresh vsplit, i.e. the documented `g:netrw_chgwin` behavior.

**Notes**

- The faulty line dates back to at least Vim 9.0 (`runtime/autoload/netrw.vim:4976` at `v9.0.0000`).
- Previously reported against the since-archived netrw repo (saccarosium/netrw.vim#98) and in neovim (neovim/neovim#34169, closed as upstream).