### PR TITLE
winlayout, taglist: unlink GC-chained list/dict on append failure

### DIFF
--- a/src/evalwindow.c
+++ b/src/evalwindow.c
@@ -284,7 +284,7 @@ get_framelayout(frame_T *fr, list_T *l, int outer)
 	    return;
 	if (list_append_list(l, fr_list) == FAIL)
 	{
-	    vim_free(fr_list);
+	    list_free(fr_list);
 	    return;
 	}
     }
@@ -309,7 +309,7 @@ get_framelayout(frame_T *fr, list_T *l, int outer)
 	    return;
 	if (list_append_list(fr_list, win_list) == FAIL)
 	{
-	    vim_free(win_list);
+	    list_free(win_list);
 	    return;
 	}
 

--- a/src/tag.c
+++ b/src/tag.c
@@ -1270,7 +1270,7 @@ add_llist_tags(
 	    continue;
 	if (list_append_dict(list, dict) == FAIL)
 	{
-	    vim_free(dict);
+	    dict_unref(dict);
 	    continue;
 	}
 


### PR DESCRIPTION
get_framelayout() (winlayout()) and add_llist_tags() (taglist()) release a list_alloc()'d list or dict_alloc()'d dict with vim_free() when the append fails. Those objects are linked into the garbage-collection chain, so vim_free() leaves a dangling pointer there, a latent crash during garbage collection. Use list_free() and dict_unref() so the object is unlinked.

related: #20668
