### PR TITLE
getregionpos: fix double-free and unlink lists on alloc failure

### DIFF
--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -6395,37 +6395,27 @@ add_regionpos_range(typval_T *rettv, pos_T p1, pos_T p2)
 
     if (list_append_list(rettv->vval.v_list, l1) == FAIL)
     {
-	vim_free(l1);
+	list_free(l1);
 	return;
     }
 
     l2 = list_alloc();
     if (l2 == NULL)
-    {
-	vim_free(l1);
 	return;
-    }
 
     if (list_append_list(l1, l2) == FAIL)
     {
-	vim_free(l1);
-	vim_free(l2);
+	list_free(l2);
 	return;
     }
 
     l3 = list_alloc();
     if (l3 == NULL)
-    {
-	vim_free(l1);
-	vim_free(l2);
 	return;
-    }
 
     if (list_append_list(l1, l3) == FAIL)
     {
-	vim_free(l1);
-	vim_free(l2);
-	vim_free(l3);
+	list_free(l3);
 	return;
     }
 


### PR DESCRIPTION
add_regionpos_range() freed lists that were already linked into the result list when a later list_alloc() or list_append_list() failed, causing a double-free and use-after-free when the return value was later cleared. Only free lists that were not appended, and free them with list_free() so they are unlinked from the garbage-collection chain.

related: #20668
