### PR TITLE
fix memory leaks on allocation-failure paths

### DIFF
--- a/src/cmdexpand.c
+++ b/src/cmdexpand.c
@@ -5040,6 +5040,8 @@ f_cmdcomplete_info(typval_T *argvars UNUSED, typval_T *rettv)
 	if (li == NULL)
 	    return;
 	ret = dict_add_list(retdict, "matches", li);
+	if (ret == FAIL)
+	    list_unref(li);
 	for (idx = 0; ret == OK && idx < ccline->xpc->xp_numfiles; idx++)
 	    list_append_string(li, ccline->xpc->xp_files[idx], -1);
     }

--- a/src/diff.c
+++ b/src/diff.c
@@ -5140,7 +5140,8 @@ f_diff(typval_T *argvars UNUSED, typval_T *rettv UNUSED)
 	    if (hunk_dict == NULL)
 		goto done;
 
-	    list_append_dict(l, hunk_dict);
+	    if (list_append_dict(l, hunk_dict) == FAIL)
+		dict_unref(hunk_dict);
 	}
     }
     else

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -10569,7 +10569,8 @@ f_getreginfo(typval_T *argvars, typval_T *rettv)
     list = (list_T *)get_reg_contents(regname, GREG_EXPR_SRC | GREG_LIST);
     if (list == NULL)
 	return;
-    (void)dict_add_list(dict, "regcontents", list);
+    if (dict_add_list(dict, "regcontents", list) == FAIL)
+	list_unref(list);
 
     switch (get_reg_type(regname, &reglen))
     {

--- a/src/highlight.c
+++ b/src/highlight.c
@@ -5768,8 +5768,8 @@ f_hlget(typval_T *argvars, typval_T *rettv)
 	if (hlarg == NULL || STRICMP(hlarg, HL_TABLE()[i].sg_name) == 0)
 	{
 	    dict = highlight_get_info(i, resolve_link);
-	    if (dict != NULL)
-		list_append_dict(list, dict);
+	    if (dict != NULL && list_append_dict(list, dict) == FAIL)
+		dict_unref(dict);
 	}
     }
 }

--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -4176,6 +4176,8 @@ get_complete_info(list_T *what_list, dict_T *retdict)
 		return;
 	    ret = dict_add_list(retdict, (has_matches && !has_items)
 						? "matches" : "items", li);
+	    if (ret == FAIL)
+		list_unref(li);
 	}
 	if (ret == OK && what_flag & CI_WHAT_SELECTED)
 	    if (compl_curr_match != NULL && compl_curr_match->cp_number == -1)
@@ -4196,7 +4198,10 @@ get_complete_info(list_T *what_list, dict_T *retdict)
 			    return;
 			ret = list_append_dict(li, di);
 			if (ret != OK)
+			{
+			    dict_unref(di);
 			    return;
+			}
 			fill_complete_info_dict(di, match, has_matches && has_items);
 		    }
 		    if (compl_curr_match != NULL
@@ -4219,6 +4224,8 @@ get_complete_info(list_T *what_list, dict_T *retdict)
 		return;
 	    fill_complete_info_dict(di, compl_curr_match, FALSE);
 	    ret = dict_add_dict(retdict, "completed", di);
+	    if (ret == FAIL)
+		dict_unref(di);
 	}
     }
 }

--- a/src/job.c
+++ b/src/job.c
@@ -1870,7 +1870,11 @@ job_info(job_T *job, dict_T *dict)
     if (l == NULL)
 	return;
 
-    dict_add_list(dict, "cmd", l);
+    if (dict_add_list(dict, "cmd", l) == FAIL)
+    {
+	list_unref(l);
+	return;
+    }
     if (job->jv_argv != NULL)
 	for (i = 0; job->jv_argv[i] != NULL; i++)
 	    list_append_string(l, (char_u *)job->jv_argv[i], -1);

--- a/src/match.c
+++ b/src/match.c
@@ -1035,7 +1035,8 @@ f_getmatches(typval_T *argvars UNUSED, typval_T *rettv UNUSED)
 		    list_append_number(l, (varnumber_T)llpos->len);
 		}
 		sprintf(buf, "pos%d", i + 1);
-		dict_add_list(dict, buf, l);
+		if (dict_add_list(dict, buf, l) == FAIL)
+		    list_unref(l);
 	    }
 	}
 	else
@@ -1056,7 +1057,8 @@ f_getmatches(typval_T *argvars UNUSED, typval_T *rettv UNUSED)
 	    dict_add_string_len(dict, "conceal", (char_u *)&buf, buflen);
 	}
 #  endif
-	list_append_dict(rettv->vval.v_list, dict);
+	if (list_append_dict(rettv->vval.v_list, dict) == FAIL)
+	    dict_unref(dict);
 	cur = cur->mit_next;
     }
 # endif

--- a/src/menu.c
+++ b/src/menu.c
@@ -2862,7 +2862,11 @@ menuitem_getinfo(char_u *menu_name, vimmenu_T *menu, int modes, dict_T *dict)
 	if (l == NULL)
 	    return FAIL;
 
-	dict_add_list(dict, "submenus", l);
+	if (dict_add_list(dict, "submenus", l) == FAIL)
+	{
+	    list_unref(l);
+	    return FAIL;
+	}
 	// get all the children.  Skip PopUp[nvoci].
 	for (topmenu = menu; topmenu != NULL; topmenu = topmenu->next)
 	    if (!menu_is_hidden(topmenu->dname))
@@ -2950,7 +2954,11 @@ menuitem_getinfo(char_u *menu_name, vimmenu_T *menu, int modes, dict_T *dict)
 	if (l == NULL)
 	    return FAIL;
 
-	dict_add_list(dict, "submenus", l);
+	if (dict_add_list(dict, "submenus", l) == FAIL)
+	{
+	    list_unref(l);
+	    return FAIL;
+	}
 	child = menu->children;
 	while (child)
 	{

--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -5344,7 +5344,11 @@ get_padding_border(dict_T *dict, int *array, char *name)
     if (list == NULL)
 	return;
 
-    dict_add_list(dict, name, list);
+    if (dict_add_list(dict, name, list) == FAIL)
+    {
+	list_unref(list);
+	return;
+    }
     if (array[0] != 1 || array[1] != 1 || array[2] != 1 || array[3] != 1)
 	for (i = 0; i < 4; ++i)
 	    list_append_number(list, array[i]);
@@ -5371,7 +5375,11 @@ get_borderhighlight(dict_T *dict, win_T *wp)
     if (list == NULL)
 	return;
 
-    dict_add_list(dict, "borderhighlight", list);
+    if (dict_add_list(dict, "borderhighlight", list) == FAIL)
+    {
+	list_unref(list);
+	return;
+    }
     // When all highlights are NULL (cleared to empty list), return empty list.
     if (i == 4)
 	return;
@@ -5400,7 +5408,11 @@ get_borderchars(dict_T *dict, win_T *wp)
     if (list == NULL)
 	return;
 
-    dict_add_list(dict, "borderchars", list);
+    if (dict_add_list(dict, "borderchars", list) == FAIL)
+    {
+	list_unref(list);
+	return;
+    }
     for (i = 0; i < 8; ++i)
     {
 	len = mb_char2bytes(wp->w_border_char[i], buf);
@@ -5419,16 +5431,24 @@ get_moved_list(dict_T *dict, win_T *wp)
     list = list_alloc();
     if (list != NULL)
     {
-	dict_add_list(dict, "moved", list);
-	list_append_number(list, wp->w_popup_lnum);
-	list_append_number(list, wp->w_popup_mincol);
-	list_append_number(list, wp->w_popup_maxcol);
+	if (dict_add_list(dict, "moved", list) == FAIL)
+	    list_unref(list);
+	else
+	{
+	    list_append_number(list, wp->w_popup_lnum);
+	    list_append_number(list, wp->w_popup_mincol);
+	    list_append_number(list, wp->w_popup_maxcol);
+	}
     }
     list = list_alloc();
     if (list == NULL)
 	return;
 
-    dict_add_list(dict, "mousemoved", list);
+    if (dict_add_list(dict, "mousemoved", list) == FAIL)
+    {
+	list_unref(list);
+	return;
+    }
     list_append_number(list, wp->w_popup_mouse_row);
     list_append_number(list, wp->w_popup_mouse_mincol);
     list_append_number(list, wp->w_popup_mouse_maxcol);

--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -7222,7 +7222,10 @@ get_qfline_items(qfline_T *qfp, list_T *list)
     if ((dict = dict_alloc()) == NULL)
 	return FAIL;
     if (list_append_dict(list, dict) == FAIL)
+    {
+	dict_unref(dict);
 	return FAIL;
+    }
 
     buf[0] = qfp->qf_type;
     buf[1] = NUL;

--- a/src/register.c
+++ b/src/register.c
@@ -1134,7 +1134,8 @@ yank_do_autocmd(oparg_T *oap, yankreg_T *reg)
     for (n = 0; n < reg->y_size; n++)
 	list_append_string(list, reg->y_array[n].string, (int)reg->y_array[n].length);
     list->lv_lock = VAR_FIXED;
-    (void)dict_add_list(v_event, "regcontents", list);
+    if (dict_add_list(v_event, "regcontents", list) == FAIL)
+	list_unref(list);
 
     // register name or empty string for unnamed operation
     buf[0] = (char_u)oap->regname;
@@ -1229,7 +1230,8 @@ put_do_autocmd(
     }
 
     list->lv_lock = VAR_FIXED;
-    (void)dict_add_list(v_event, "regcontents", list);
+    if (dict_add_list(v_event, "regcontents", list) == FAIL)
+	list_unref(list);
 
     // register name or empty string for unnamed operation
     buf[0] = (char_u)regname;

--- a/src/sign.c
+++ b/src/sign.c
@@ -1860,8 +1860,8 @@ get_buffer_signs(buf_T *buf, list_T *l)
     FOR_ALL_SIGNS_IN_BUF(buf, sign)
     {
         dict_T *d = sign_get_info(sign);
-        if (d != NULL)
-            list_append_dict(l, d);
+        if (d != NULL && list_append_dict(l, d) == FAIL)
+            dict_unref(d);
     }
 }
 
@@ -1879,7 +1879,11 @@ sign_get_placed_in_buf(buf_T *buf,
     if (d == NULL)
         return;
 
-    list_append_dict(retlist, d);
+    if (list_append_dict(retlist, d) == FAIL)
+    {
+        dict_unref(d);
+        return;
+    }
 
     dict_add_number(d, "bufnr", (long)buf->b_fnum);
 
@@ -1887,7 +1891,11 @@ sign_get_placed_in_buf(buf_T *buf,
     if (l == NULL)
         return;
 
-    dict_add_list(d, "signs", l);
+    if (dict_add_list(d, "signs", l) == FAIL)
+    {
+        list_unref(l);
+        return;
+    }
 
     sign_entry_T *sign = NULL;
     FOR_ALL_SIGNS_IN_BUF(buf, sign)
@@ -1901,8 +1909,8 @@ sign_get_placed_in_buf(buf_T *buf,
             (lnum == sign->se_lnum && sign_id == sign->se_id))
         {
             dict_T *sdict = sign_get_info(sign);
-            if (sdict != NULL)
-                list_append_dict(l, sdict);
+            if (sdict != NULL && list_append_dict(l, sdict) == FAIL)
+                dict_unref(sdict);
         }
     }
 }

--- a/src/tag.c
+++ b/src/tag.c
@@ -4450,7 +4450,12 @@ get_tags(list_T *list, char_u *pat, char_u *buf_fname)
 	    break;
 	}
 	if (list_append_dict(list, dict) == FAIL)
+	{
 	    ret = FAIL;
+	    dict_unref(dict);
+	    vim_free(matches[i]);
+	    continue;
+	}
 
 	full_fname = tag_full_fname(&tp);
 	if (add_tag_field(dict, "name", tp.tagname, tp.tagname_end) == FAIL
@@ -4564,7 +4569,11 @@ get_tagstack(win_T *wp, dict_T *retdict)
     {
 	if ((d = dict_alloc_id(aid_tagstack_details)) == NULL)
 	    return;
-	list_append_dict(l, d);
+	if (list_append_dict(l, d) == FAIL)
+	{
+	    dict_unref(d);
+	    return;
+	}
 
 	get_tag_details(&wp->w_tagstack[i], d);
     }

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -6435,7 +6435,8 @@ f_term_getcursor(typval_T *argvars, typval_T *rettv)
 	    ? !term->tl_cursor_blink : term->tl_cursor_blink);
     dict_add_number(d, "shape", term->tl_cursor_shape);
     dict_add_string(d, "color", cursor_color_get(term->tl_cursor_color));
-    list_append_dict(l, d);
+    if (list_append_dict(l, d) == FAIL)
+	dict_unref(d);
 }
 
 /*
@@ -6846,7 +6847,11 @@ f_term_scrape(typval_T *argvars, typval_T *rettv)
 	dcell = dict_alloc();
 	if (dcell == NULL)
 	    break;
-	list_append_dict(l, dcell);
+	if (list_append_dict(l, dcell) == FAIL)
+	{
+	    dict_unref(dcell);
+	    break;
+	}
 
 	dict_add_string_len(dcell, "chars", mbs, (int)mbslen);
 

--- a/src/textprop.c
+++ b/src/textprop.c
@@ -2153,7 +2153,8 @@ get_props_in_line(
 	    prop_fill_dict(d, &prop, buf);
 	    if (add_lnum)
 		dict_add_number(d, "lnum", lnum);
-	    list_append_dict(retlist, d);
+	    if (list_append_dict(retlist, d) == FAIL)
+		dict_unref(d);
 	}
     }
 }

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -3997,7 +3997,7 @@ call_func(
 	// could be changed or deleted in the called function.
 	name = len > 0 ? vim_strnsave(funcname, len) : vim_strsave(funcname);
 	if (name == NULL)
-	    return ret;
+	    goto theend;
 
 	fname = fname_trans_sid(name, fname_buf, &tofree, &error);
     }

--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -4319,7 +4319,10 @@ compile_def_function_body(
 	    {
 		line = vim_strsave(line);
 		if (ga_add_string(lines_to_free, line) == FAIL)
+		{
+		    vim_free(line);
 		    return FAIL;
+		}
 	    }
 	}
 

--- a/src/vim9expr.c
+++ b/src/vim9expr.c
@@ -3377,6 +3377,7 @@ compile_expr6(char_u **arg, cctx_T *cctx, ppconst_T *ppconst)
 		tv1->vval.v_string = alloc(len1 + STRLEN(s2) + 1);
 		if (tv1->vval.v_string == NULL)
 		{
+		    vim_free(s1);
 		    clear_ppconst(ppconst);
 		    return FAIL;
 		}


### PR DESCRIPTION
Several functions leaked a freshly allocated object on an allocation-failure path: they ignored the return of list_append_dict() / dict_add_list() / dict_add_dict() (leaking the GC-linked dict or list on OOM), returned past a cleanup label, or dropped a string copy when a grow failed. Each now frees the object on the failure path.

Affected: getqflist, getreginfo, taglist/gettagstack, hlget, prop_list, getmatches, menu_getinfo, popup_getoptions, sign_getplaced, job_info, term_getcursor/term_scrape, diff(), complete_info, cmdcomplete_info, two Vim9 compile paths (constant string concat and ga_add_string), and call_func generic type args.

related: #20668
