### PR TITLE
perf(gtk3): coalesce x11 redraws

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -2797,6 +2797,14 @@ dnl something like that.
 	       sed 's/\([[0-9]]*\)\.\([[0-9]]*\)\.\([[0-9]]*\)/\2/'`
 	     gtk_micro_version=`$PKG_CONFIG --modversion $gtk_pkg_name | \
 	       sed 's/\([[0-9]]*\)\.\([[0-9]]*\)\.\([[0-9]]*\)/\3/'`
+
+       AS_IF([test "x$SKIP_GTK3" != 'xYES' \
+              -a "$gtk_major_version" = 3 \
+              -a "$gtk_minor_version" = 22 \
+              -a "$gtk_micro_version" -ge 2 \
+              -a "$gtk_micro_version" -lt 4],
+       [AC_MSG_FAILURE([GTK versions 3.22.2 and 3.22.3 are not supported])])
+
 	     AC_MSG_RESULT([yes; found version $gtk_major_version.$gtk_minor_version.$gtk_micro_version])
 	   ],
 	   [
@@ -2838,7 +2846,12 @@ dnl something like that.
 # include <stdlib.h>
 # include <stddef.h>
 #endif
-
+#if GTK_MAJOR_VERSION == 3 \
+	&& GTK_MINOR_VERSION == 22 \
+	&& GTK_MICRO_VERSION >= 2 \
+	&& GTK_MICRO_VERSION < 4
+# error GTK version 3.22.2 and 3.22.3 are not supported
+#endif
 int
 main ()
 {
@@ -3051,7 +3064,7 @@ if test -z "$SKIP_GTK2"; then
   if test "x$PKG_CONFIG" != "xno"; then
     dnl First try finding version 2.2.0 or later.  The 2.0.x series has
     dnl problems (bold fonts, --remote doesn't work).
-    AM_PATH_GTK(2.2.0,
+    AM_PATH_GTK(2.4.0,
 		[GUI_LIB_LOC="$GTK_LIBDIR"
 		 GTK_LIBNAME="$GTK_LIBS"
 		 GUI_INC_LOC="$GTK_CPPFLAGS"])

--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -6948,10 +6948,10 @@ gui_mch_flush(void)
 {
     if (gui.mainwin == NULL || !gtk_widget_get_realized(gui.mainwin))
 	return;
-#if GTK_CHECK_VERSION(2,4,0)
+#if !GTK_CHECK_VERSION(3,0,0)
        gdk_display_flush(gtk_widget_get_display(gui.mainwin));
        return;
-#else
+#endif
     if (dirty_rect.active && gui.drawarea != NULL)
     {
 	dirty_rect.active = false;
@@ -6959,7 +6959,6 @@ gui_mch_flush(void)
 		dirty_rect.top, (dirty_rect.right - dirty_rect.left),
 		(dirty_rect.bottom - dirty_rect.top));
     }
-#endif
 }
 
 /*

--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -3008,36 +3008,6 @@ drawarea_configure_event_cb(GtkWidget	      *widget,
     static int cur_height = 0;
 
     g_return_val_if_fail(event
-	    && event->width >= 1 && event->height >= 1, TRUE);
-
-# if GTK_CHECK_VERSION(3,22,2) && !GTK_CHECK_VERSION(3,22,4)
-    // As of 3.22.2, GdkWindows have started distributing configure events to
-    // their "native" children (https://git.gnome.org/browse/gtk+/commit/?h=gtk-3-22&id=12579fe71b3b8f79eb9c1b80e429443bcc437dd0).
-    //
-    // As can be seen from the implementation of move_native_children() and
-    // configure_native_child() in gdkwindow.c, those functions actually
-    // propagate configure events to every child, failing to distinguish
-    // "native" one from non-native one.
-    //
-    // Naturally, configure events propagated to here like that are fallacious
-    // and, as a matter of fact, they trigger a geometric collapse of
-    // gui.drawarea in fullscreen and maximized modes.
-    //
-    // To filter out such nuisance events, we are making use of the fact that
-    // the field send_event of such GdkEventConfigures is set to FALSE in
-    // configure_native_child().
-    //
-    // Obviously, this is a terrible hack making GVim depend on GTK's
-    // implementation details.  Therefore, watch out any relevant internal
-    // changes happening in GTK in the feature (sigh).
-    //
-    // Follow-up
-    // After a few weeks later, the GdkWindow change mentioned above was
-    // reverted (https://git.gnome.org/browse/gtk+/commit/?h=gtk-3-22&id=f70039cb9603a02d2369fec4038abf40a1711155).
-    // The corresponding official release is 3.22.4.
-    if (event->send_event == FALSE)
-	return TRUE;
-# endif
 
     if (event->width == cur_width && event->height == cur_height)
 	return TRUE;
@@ -4433,31 +4403,6 @@ form_configure_event(GtkWidget *widget UNUSED,
     }
     clear_resize_hists();
 #endif
-
-#if GTK_CHECK_VERSION(3,22,2) && !GTK_CHECK_VERSION(3,22,4)
-    // As of 3.22.2, GdkWindows have started distributing configure events to
-    // their "native" children (https://git.gnome.org/browse/gtk+/commit/?h=gtk-3-22&id=12579fe71b3b8f79eb9c1b80e429443bcc437dd0).
-    //
-    // As can be seen from the implementation of move_native_children() and
-    // configure_native_child() in gdkwindow.c, those functions actually
-    // propagate configure events to every child, failing to distinguish
-    // "native" one from non-native one.
-    //
-    // Naturally, configure events propagated to here like that are fallacious
-    // and, as a matter of fact, they trigger a geometric collapse of
-    // gui.formwin.
-    //
-    // To filter out such fallacious events, check if the given event is the
-    // one that was sent out to the right place. Ignore it if not.
-    //
-    // Follow-up
-    // After a few weeks later, the GdkWindow change mentioned above was
-    // reverted (https://git.gnome.org/browse/gtk+/commit/?h=gtk-3-22&id=f70039cb9603a02d2369fec4038abf40a1711155).
-    // The corresponding official release is 3.22.4.
-    if (event->window != gtk_widget_get_window(gui.formwin))
-	return TRUE;
-#endif
-
     // When in a GtkPlug, we can't guarantee valid heights (as a round
     // no. of char-heights), so we have to manually sanitise them.
     // Widths seem to sort themselves out, don't ask me why.

--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -53,7 +53,8 @@
 # include <gnome.h>
 # include "version.h"
 // missing prototype in bonobo-dock-item.h
-extern void bonobo_dock_item_set_behavior(BonoboDockItem *dock_item, BonoboDockItemBehavior beh);
+extern void bonobo_dock_item_set_behavior(BonoboDockItem *dock_item,
+	BonoboDockItemBehavior beh);
 #endif
 
 #if defined(FEAT_GUI_GTK)

--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -2762,9 +2762,12 @@ mainwin_realize(GtkWidget *widget UNUSED, gpointer data UNUSED)
 	     */
 	    GList *icons = NULL;
 
-	    icons = g_list_prepend(icons, pixbuf_new_from_png_data(vim16x16_png, vim16x16_png_len));
-	    icons = g_list_prepend(icons, pixbuf_new_from_png_data(vim32x32_png, vim32x32_png_len));
-	    icons = g_list_prepend(icons, pixbuf_new_from_png_data(vim48x48_png, vim48x48_png_len));
+	    icons = g_list_prepend(icons,
+		    pixbuf_new_from_png_data(vim16x16_png, vim16x16_png_len));
+	    icons = g_list_prepend(icons,
+		    pixbuf_new_from_png_data(vim32x32_png, vim32x32_png_len));
+	    icons = g_list_prepend(icons,
+		    pixbuf_new_from_png_data(vim48x48_png, vim48x48_png_len));
 
 	    gtk_window_set_icon_list(GTK_WINDOW(gui.mainwin), icons);
 	    for (item = icons; item != NULL; iem = item->next)
@@ -2786,7 +2789,8 @@ mainwin_realize(GtkWidget *widget UNUSED, gpointer data UNUSED)
 	setup_save_yourself();
 
 #ifdef FEAT_CLIENTSERVER
-    if (clientserver_method == CLIENTSERVER_METHOD_X11 && gui_mch_get_display())
+    if (clientserver_method == CLIENTSERVER_METHOD_X11
+	    && gui_mch_get_display())
     {
 	if (serverName == NULL && serverDelayedStartName != NULL)
 	{

--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -3745,54 +3745,6 @@ gui_gtk_set_dnd_targets(void)
 		      GDK_ACTION_COPY | GDK_ACTION_MOVE);
 }
 
-#ifdef GDK_WINDOWING_WAYLAND
-static struct {
-    int left;
-    int top;
-    int right;
-    int bottom;
-    bool active;
-} wl_dirty_rect = {0, 0, 0, 0, false};
-
-    static void
-wl_queue_dirty_area(int x, int y, int width, int height)
-{
-    if (!wl_dirty_rect.active)
-    {
-	wl_dirty_rect.left = x;
-	wl_dirty_rect.top = y;
-	wl_dirty_rect.right = x + width;
-	wl_dirty_rect.bottom = y + height;
-	wl_dirty_rect.active = true;
-    }
-    else
-    {
-	// Expand to append further changes
-	if (x < wl_dirty_rect.left)   wl_dirty_rect.left = x;
-	if (y < wl_dirty_rect.top)    wl_dirty_rect.top = y;
-	if (x + width > wl_dirty_rect.right)  wl_dirty_rect.right = x + width;
-	if (y + height > wl_dirty_rect.bottom) wl_dirty_rect.bottom = y + height;
-    }
-}
-
-    static void
-wl_flush(void)
-{
-    if (!wl_dirty_rect.active)
-	return;
-    int draw_x = wl_dirty_rect.left;
-    int draw_y = wl_dirty_rect.top;
-    int draw_w = wl_dirty_rect.right - wl_dirty_rect.left;
-    int draw_h = wl_dirty_rect.bottom - wl_dirty_rect.top;
-
-    if (draw_w > 0 && draw_h > 0)
-    {
-	gtk_widget_queue_draw_area(gui.drawarea, draw_x, draw_y, draw_w, draw_h);
-    }
-    wl_dirty_rect.active = false;
-}
-#endif
-
 /*
  * Initialize the GUI.	Create all the windows, set up all the callbacks etc.
  * Returns OK for success, FAIL when the GUI can't be started.
@@ -6269,20 +6221,39 @@ gui_gtk_draw_string(int row, int col, char_u *s, int len, int flags)
     return len_sum;
 }
 
+#if GTK_CHECK_VERSION(3,0,0)
+static struct {
+    int left;
+    int top;
+    int right;
+    int bottom;
+    bool active;
+} dirty_rect = {0, 0, 0, 0, false};
+
     static void
-queue_draw_area(
-	int	x,
-	int	y,
-	int	width,
-	int	height)
+queue_draw_area(int x, int y, int width, int height)
 {
-#ifdef GDK_WINDOWING_WAYLAND
-    if (gui.is_wayland)
-	wl_queue_dirty_area(x, y, width, height);
+    if (width <= 0 || height <= 0 || gui.drawarea == NULL)
+	return;
+    if (!dirty_rect.active)
+    {
+	dirty_rect.left = x;
+	dirty_rect.top = y;
+	dirty_rect.right = x + width;
+	dirty_rect.bottom = y + height;
+	dirty_rect.active = true;
+	return;
+    }
     else
-#endif
-	gtk_widget_queue_draw_area(gui.drawarea, x, y, width, height);
+    {
+	// Expand to append further changes
+	if (x < dirty_rect.left) dirty_rect.left = x;
+	if (y < dirty_rect.top) dirty_rect.top = y;
+	if (x + width > dirty_rect.right) dirty_rect.right = x + width;
+	if (y + height > dirty_rect.bottom) dirty_rect.bottom = y + height;
+    }
 }
+#endif
 
     int
 gui_gtk_draw_string_ext(
@@ -6680,8 +6651,7 @@ gui_mch_invert_rectangle(int r, int c, int nr, int nc)
 
     cairo_destroy(cr);
 
-    queue_draw_area(rect.x, rect.y,
-	    rect.width, rect.height);
+    queue_draw_area(rect.x, rect.y, rect.width, rect.height);
 #else
     GdkGCValues values;
     GdkGC *invert_gc;
@@ -6834,17 +6804,14 @@ gui_mch_update(void)
 {
     int cnt = 0;	// prevent endless loop
     while (g_main_context_pending(NULL) && !vim_is_input_buf_full()
-								&& ++cnt < 100)
+	    && ++cnt < 100)
     {
-#ifdef GDK_WINDOWING_WAYLAND
-	if (gui.is_wayland)
-	{
-	    int prio = 0;
-	    g_main_context_prepare(NULL, &prio);
-	    // peek internal scheduling of redraw
-	    if (prio == GDK_PRIORITY_REDRAW)
-		gui_may_flush(); // prepares redraw: g_main_context_iteration
-	}
+#if GTK_CHECK_VERSION(3,0,0)
+	int prio = 0;
+	g_main_context_prepare(NULL, &prio);
+	// peek internal scheduling of redraw
+	if (prio == GDK_PRIORITY_REDRAW)
+	    gui_may_flush(); // prepares redraw: g_main_context_iteration
 #endif
 	g_main_context_iteration(NULL, TRUE);
     }
@@ -6979,18 +6946,21 @@ theend:
     void
 gui_mch_flush(void)
 {
-    if (gui.mainwin != NULL && gtk_widget_get_realized(gui.mainwin))
-    {
-#ifdef GDK_WINDOWING_WAYLAND
-	if (gui.is_wayland)
-	    return wl_flush();
-#endif
+    if (gui.mainwin == NULL || !gtk_widget_get_realized(gui.mainwin))
+	return;
 #if GTK_CHECK_VERSION(2,4,0)
-	gdk_display_flush(gtk_widget_get_display(gui.mainwin));
+       gdk_display_flush(gtk_widget_get_display(gui.mainwin));
+       return;
 #else
-	gdk_display_sync(gtk_widget_get_display(gui.mainwin));
-#endif
+    if (dirty_rect.active && gui.drawarea != NULL)
+    {
+	dirty_rect.active = false;
+	gtk_widget_queue_draw_area(gui.drawarea, dirty_rect.left,
+		dirty_rect.top, (dirty_rect.right - dirty_rect.left),
+		(dirty_rect.bottom - dirty_rect.top));
     }
+    gdk_display_sync(gtk_widget_get_display(gui.mainwin));
+#endif
 }
 
 /*
@@ -7042,8 +7012,7 @@ gui_mch_clear_block(int row1arg, int col1arg, int row2arg, int col2arg)
 	cairo_fill(cr);
 	cairo_destroy(cr);
 
-	queue_draw_area(
-		rect.x, rect.y, rect.width, rect.height);
+	queue_draw_area(rect.x, rect.y, rect.width, rect.height);
     }
 #else // !GTK_CHECK_VERSION(3,0,0)
     gdk_gc_set_foreground(gui.text_gc, &color);
@@ -7079,8 +7048,7 @@ gui_gtk_window_clear(GdkWindow *win)
     cairo_fill(cr);
     cairo_destroy(cr);
 
-    queue_draw_area(
-	    rect.x, rect.y, rect.width, rect.height);
+    queue_draw_area(rect.x, rect.y, rect.width, rect.height);
 }
 #else
 # define gui_gtk_window_clear(win)  gdk_window_clear(win)
@@ -7138,8 +7106,7 @@ gui_mch_draw_popup_image(
 # if GTK_CHECK_VERSION(3,0,0)
     cairo_popup_image_paint(wp, gui.surface, x, y,
 	    src_x, src_y, draw_w, draw_h);
-    if (gui.drawarea != NULL)
-	queue_draw_area(x, y, draw_w, draw_h);
+    queue_draw_area(x, y, draw_w, draw_h);
 # else
     cairo_popup_image_paint(wp, gui.drawarea->window, x, y,
 	    src_x, src_y, draw_w, draw_h);

--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -2767,9 +2767,8 @@ mainwin_realize(GtkWidget *widget UNUSED, gpointer data UNUSED)
 	    icons = g_list_prepend(icons, pixbuf_new_from_png_data(vim48x48_png, vim48x48_png_len));
 
 	    gtk_window_set_icon_list(GTK_WINDOW(gui.mainwin), icons);
-
-	    // TODO: is this type cast OK?
-	    g_list_foreach(icons, (GFunc)(void *)&g_object_unref, NULL);
+	    for (item = icons; item != NULL; iem = item->next)
+		g_object_unref(item->data);
 	    g_list_free(icons);
 	}
     }

--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -2761,6 +2761,7 @@ mainwin_realize(GtkWidget *widget UNUSED, gpointer data UNUSED)
 	     * Add an icon to the main window. For fun and convenience of the user.
 	     */
 	    GList *icons = NULL;
+	    GList *item = NULL;
 
 	    icons = g_list_prepend(icons,
 		    pixbuf_new_from_png_data(vim16x16_png, vim16x16_png_len));
@@ -2770,7 +2771,7 @@ mainwin_realize(GtkWidget *widget UNUSED, gpointer data UNUSED)
 		    pixbuf_new_from_png_data(vim48x48_png, vim48x48_png_len));
 
 	    gtk_window_set_icon_list(GTK_WINDOW(gui.mainwin), icons);
-	    for (item = icons; item != NULL; iem = item->next)
+	    for (item = icons; item != NULL; item = item->next)
 		g_object_unref(item->data);
 	    g_list_free(icons);
 	}
@@ -5347,8 +5348,9 @@ ascii_glyph_table_init(void)
 	}
     }
 
-    // TODO: is this type cast OK?
-    g_list_foreach(item_list, (GFunc)(void *)&pango_item_free, NULL);
+    GList *item;
+    for (item = item_list; item != NULL; item = item->next)
+	pango_item_free(item->data);
     g_list_free(item_list);
     pango_attr_list_unref(attr_list);
 }

--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -3008,6 +3008,7 @@ drawarea_configure_event_cb(GtkWidget	      *widget,
     static int cur_height = 0;
 
     g_return_val_if_fail(event
+	    && event->width >= 1 && event->height >= 1, TRUE);
 
     if (event->width == cur_width && event->height == cur_height)
 	return TRUE;

--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -778,6 +778,7 @@ draw_event(GtkWidget *widget UNUSED,
 				// for GTK+ 3, may induce other draw events.
 
     cairo_set_source_surface(cr, gui.surface, 0, 0);
+    cairo_paint(cr);
 
     {
 	cairo_rectangle_list_t *list = NULL;

--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -6959,7 +6959,6 @@ gui_mch_flush(void)
 		dirty_rect.top, (dirty_rect.right - dirty_rect.left),
 		(dirty_rect.bottom - dirty_rect.top));
     }
-    gdk_display_sync(gtk_widget_get_display(gui.mainwin));
 #endif
 }
 


### PR DESCRIPTION
Pegging my CPU at 400MHz freq I saw an improvement in performance on x11 using same strategy as wayland. 

Changes
* [coalesce x11 redraws](https://github.com/vim/vim/pull/20747/commits/962cc4d769143bcb068746b3ada8e08114f877bb)
Same deferred optimization. Renamed wayland specific functions to generic and removed condition - enabling the deferred dirty rect flushing on X11.
* [avoid unnecessary gdk_display_sync](https://github.com/vim/vim/pull/20747/commits/90b7864c50ee09e1d1a0c0f1c341b360d52034a0)
Not needed as it happens automatically.
* [simplify draw_event](https://github.com/vim/vim/pull/20747/commits/fcff2516036bcc1818f7688a36bacc9c7ccf5b39)
Older was manual, explicit and unnecessarily complicated.

Lint
* Wrapped @ 80ch and joined some unnecessarily split lines.

Follows: https://github.com/vim/vim/pull/20528
Closes: #1199