### PR TITLE
Visual block reselection wrong with 'virtualedit'

### DIFF
--- a/src/normal.c
+++ b/src/normal.c
@@ -5579,13 +5579,12 @@ nv_visual(cmdarg_T *cap)
 	    }
 	    else if (VIsual_mode == Ctrl_V)
 	    {
-		// Update curswant on the original line, that is where "col" is
-		// valid.
-		linenr_T lnum = curwin->w_cursor.lnum;
-		curwin->w_cursor.lnum = VIsual.lnum;
+		// Update curswant at the original cursor position.
+		pos_T tmp_cursor = curwin->w_cursor;
+		curwin->w_cursor = VIsual;
 		update_curswant_force();
 		curwin->w_curswant += resel_VIsual_vcol * cap->count0 - 1;
-		curwin->w_cursor.lnum = lnum;
+		curwin->w_cursor = tmp_cursor;
 		if (*p_sel == 'e')
 		    ++curwin->w_curswant;
 		coladvance(curwin->w_curswant);

--- a/src/testdir/test_visual.vim
+++ b/src/testdir/test_visual.vim
@@ -1004,6 +1004,28 @@ func Test_virtualedit_visual_block()
   bwipe!
 endfunc
 
+func Test_virtualedit_visual_block_reselect()
+  set ve=all
+  new
+  call append(0, ['###', '###', '###', '#####'])
+  call cursor(1, 1)
+  exe "norm! \<C-V>lljj"
+  call assert_equal([0, 3, 3, 0], getpos('.'))
+  call assert_equal([0, 1, 1, 0], getpos('v'))
+  norm! y
+  call assert_equal(['###', '###', '###'], getreg('"', v:true, v:true))
+  call cursor(2, 6)
+  call assert_equal([0, 2, 4, 2], getpos('.'))
+  norm! 1v
+  call assert_equal([0, 4, 6, 2], getpos('.'))
+  call assert_equal([0, 2, 4, 2], getpos('v'))
+  norm! r!
+  call assert_equal(['###  !!!', '###  !!!', '#####!!!'], getline(2, 4))
+
+  bwipe!
+  set ve&
+endfunc
+
 " Test for changing case
 func Test_visual_change_case()
   new


### PR DESCRIPTION
Problem:  Visual block reselection wrong with 'virtualedit' when line
          lengths are different (after 8.2.3494).
Solution: Set the entire cursor position to old position when computing
          target curswant, since the check_cursor() added in 8.2.3494
          may change cursor column as well.

fixes: #20746
