### PR TITLE
filetype: msmtp system-wide rc file not detected

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -3338,6 +3338,7 @@ const ft_from_name = {
   "meson.options": "meson",
   "meson_options.txt": "meson",
   # msmtp
+  "msmtprc": "msmtp",
   ".msmtprc": "msmtp",
   # Mrxvtrc
   "mrxvtrc": "mrxvtrc",

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -559,7 +559,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     mplayerconf: ['mplayer.conf', '/.mplayer/config', 'any/.mplayer/config'],
     mrxvtrc: ['mrxvtrc', '.mrxvtrc'],
     msidl: ['file.odl', 'file.mof'],
-    msmtp: ['.msmtprc'],
+    msmtp: ['msmtprc', '.msmtprc'],
     msql: ['file.msql'],
     mss: ['file.mss'],
     mupad: ['file.mu'],


### PR DESCRIPTION
Problem:  filetype: msmtp system-wide rc file not detected.
Solution: Detect 'msmtprc' as filetype msmtp, like '.msmtprc'.

Fixes #20751.
