### PR TITLE
test_spell: personal spell files leak into later tests

### DIFF
--- a/src/testdir/test_spell.vim
+++ b/src/testdir/test_spell.vim
@@ -1591,6 +1591,7 @@ endfunc
 " tree_count_words() fix (9.2.0653).
 func Test_spelldump_prefixtree_overflow()
   CheckUnix
+  let save_rtp = &runtimepath
   call mkdir('Xrtp/spell', 'pR')
   " VIMspell + v50, SN_PREFCOND(prefixcnt=1), SN_END,
   " LWORDTREE word "a" with affixID=1 (so dump_prefixes runs),
@@ -1606,7 +1607,8 @@ func Test_spelldump_prefixtree_overflow()
   spelldump
   call assert_true(line('$') > 1)
 
-  set spell& spelllang& runtimepath&
+  set spell& spelllang&
+  let &runtimepath = save_rtp
   bwipe!
   bwipe!
 endfunc


### PR DESCRIPTION
## Problem

`Test_spelldump_prefixtree_overflow()` resets `'runtimepath'` to its default value during cleanup. That reintroduces the user's Vim directory, so later spell tests can load a personal `.spl` file and fail. With a personal `en.utf-8.add.spl`, the unmodified test suite reproduced the `Test_spellinfo()` failure reported in #20765.

## Solution

Save the test runner's existing `'runtimepath'` before adding `Xrtp`, then restore that exact value during cleanup instead of resetting the option to its user default.

## Verification

- `make -j4` passed.
- Before the change, `HOME` containing `~/.vim/spell/en.utf-8.add.spl` reproduced the reported `Test_spellinfo()` failure.
- After the change, the same HOME passed all 46 relevant spell tests when excluding `Test_compl_with_CTRL_X_s`, a local screen-message assertion that fails identically with an empty HOME.
- The codestyle suite passed all 5 tests.
- `git diff --check` passed.

This contribution was prepared with OpenAI Codex assistance. I reviewed and validated the final change, and the commit includes an AI co-author trailer and my DCO sign-off.

Closes #20765
