### PR TITLE
docs(cmdline): better fuzzy file picker

### DIFF
--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -1430,14 +1430,13 @@ file picker: >
 	set findfunc=Find
 	func Find(arg, _)
 	  if empty(s:filescache)
-	    let s:filescache = globpath('.', '**', 1, 1)
+	    autocmd CmdlineLeave : ++once let s:filescache = []
+	    let s:filescache = expand('**', 1, 1)
 	    call filter(s:filescache, '!isdirectory(v:val)')
-	    call map(s:filescache, "fnamemodify(v:val, ':.')")
 	  endif
-	  return a:arg == '' ? s:filescache : matchfuzzy(s:filescache, a:arg)
+	  return empty(a:arg) ? s:filescache : matchfuzzy(s:filescache, a:arg)
 	endfunc
 	let s:filescache = []
-	autocmd CmdlineEnter : let s:filescache = []
 
 The `:Grep` command searches for lines matching a pattern and updates the
 results dynamically as you type (triggered after two characters; note: needs


### PR DESCRIPTION
1. Only reset cache after used.
2. Use `expand('**', 1, 1)` than `globpath('.', '**', 1, 1)`.

| Environment     | expand (s) | globpath (s) | expand faster |
| --------------- | ---------- | ------------ | ------------- |
| WSL (small)     | 0.0491     | 0.0537       | 9.4%          |
| Windows (large) | 1.6606     | 2.3565       | 41.9%         |

3. fnamemodify() is useless here.
