### PR TITLE
showcmd may show internal command keys

### DIFF
--- a/src/drawscreen.c
+++ b/src/drawscreen.c
@@ -620,7 +620,7 @@ win_redr_status(win_T *wp, int ignore_pum UNUSED)
 	    if (width > 0)
 		screen_puts_len(showcmd_buf, width, row,
 				wp->w_wincol + this_ru_col - width - 1, attr);
-	    showcmd_is_clear = (showcmd_buf[0] == NUL);
+	    showcmd_set_clear_state();
 	}
     }
 

--- a/src/drawscreen.c
+++ b/src/drawscreen.c
@@ -620,6 +620,7 @@ win_redr_status(win_T *wp, int ignore_pum UNUSED)
 	    if (width > 0)
 		screen_puts_len(showcmd_buf, width, row,
 				wp->w_wincol + this_ru_col - width - 1, attr);
+	    showcmd_is_clear = (showcmd_buf[0] == NUL);
 	}
     }
 

--- a/src/globals.h
+++ b/src/globals.h
@@ -2103,6 +2103,7 @@ EXTERN int skip_update_topline INIT(= FALSE);
 // 'showcmd' buffer shared between normal.c and statusline code
 #define SHOWCMD_BUFLEN (SHOWCMD_COLS + 1 + 30)
 EXTERN char_u showcmd_buf[SHOWCMD_BUFLEN];
+EXTERN int showcmd_is_clear INIT(= TRUE);
 
 #ifdef FEAT_TERMGUICOLORS
 EXTERN int	p_tgc_set INIT(= FALSE);

--- a/src/globals.h
+++ b/src/globals.h
@@ -2103,7 +2103,6 @@ EXTERN int skip_update_topline INIT(= FALSE);
 // 'showcmd' buffer shared between normal.c and statusline code
 #define SHOWCMD_BUFLEN (SHOWCMD_COLS + 1 + 30)
 EXTERN char_u showcmd_buf[SHOWCMD_BUFLEN];
-EXTERN int showcmd_is_clear INIT(= TRUE);
 
 #ifdef FEAT_TERMGUICOLORS
 EXTERN int	p_tgc_set INIT(= FALSE);

--- a/src/normal.c
+++ b/src/normal.c
@@ -1605,7 +1605,6 @@ may_clear_cmdline(void)
  */
 
 static char_u	old_showcmd_buf[SHOWCMD_BUFLEN];  // For push_showcmd()
-static int	showcmd_is_clear = TRUE;
 static int	showcmd_visual = FALSE;
 
 static void display_showcmd(void);
@@ -1739,7 +1738,7 @@ add_to_showcmd(int c)
 	K_RIGHTMOUSE, K_RIGHTDRAG, K_RIGHTRELEASE,
 	K_MOUSEDOWN, K_MOUSEUP, K_MOUSELEFT, K_MOUSERIGHT,
 	K_X1MOUSE, K_X1DRAG, K_X1RELEASE, K_X2MOUSE, K_X2DRAG, K_X2RELEASE,
-	K_CURSORHOLD,
+	K_CURSORHOLD, K_COMMAND, K_SCRIPT_COMMAND,
 	0
     };
 

--- a/src/normal.c
+++ b/src/normal.c
@@ -1605,6 +1605,7 @@ may_clear_cmdline(void)
  */
 
 static char_u	old_showcmd_buf[SHOWCMD_BUFLEN];  // For push_showcmd()
+static int	showcmd_is_clear = TRUE;
 static int	showcmd_visual = FALSE;
 
 static void display_showcmd(void);
@@ -1833,12 +1834,18 @@ pop_showcmd(void)
     display_showcmd();
 }
 
+    void
+showcmd_set_clear_state(void)
+{
+    showcmd_is_clear = (showcmd_buf[0] == NUL);
+}
+
     static void
 display_showcmd(void)
 {
     int	    len = vim_strsize(showcmd_buf);
 
-    showcmd_is_clear = (len == 0);
+    showcmd_set_clear_state();
     cursor_off();
 
     if (*p_sloc == 's')

--- a/src/proto/normal.pro
+++ b/src/proto/normal.pro
@@ -19,6 +19,7 @@ int add_to_showcmd(int c);
 void add_to_showcmd_c(int c);
 void push_showcmd(void);
 void pop_showcmd(void);
+void showcmd_set_clear_state(void);
 void do_check_scrollbind(int check);
 void check_scrollbind(linenr_T topline_diff, long leftcol_diff);
 int find_decl(char_u *ptr, int len, int locally, int thisblock, int flags_arg);

--- a/src/screen.c
+++ b/src/screen.c
@@ -1676,6 +1676,9 @@ win_redr_custom(
     }
     ewp->w_p_crb = p_crb_save;
 
+    if (p_sc && STRCMP(opt_name, p_sloc) == 0)
+	showcmd_is_clear = (showcmd_buf[0] == NUL);
+
     // Note: In the loop, build_stl_str_hl_mline() may replace stl_tmp with
     // a newly allocated buffer (when "%!" evaluation occurs), freeing the
     // original "stl" internally.  After the loop, stl_tmp must be freed
@@ -5303,6 +5306,7 @@ draw_tabline(void)
 	    if (width > 0)
 		screen_puts_len(showcmd_buf, width, 0, (int)Columns
 			    - width - (tabcount > 1) * 2, attr_nosel);
+	    showcmd_is_clear = (showcmd_buf[0] == NUL);
 	}
 
 	// Put an "X" for closing the current tab if there are several.

--- a/src/screen.c
+++ b/src/screen.c
@@ -1677,7 +1677,7 @@ win_redr_custom(
     ewp->w_p_crb = p_crb_save;
 
     if (p_sc && STRCMP(opt_name, p_sloc) == 0)
-	showcmd_is_clear = (showcmd_buf[0] == NUL);
+	showcmd_set_clear_state();
 
     // Note: In the loop, build_stl_str_hl_mline() may replace stl_tmp with
     // a newly allocated buffer (when "%!" evaluation occurs), freeing the
@@ -5306,7 +5306,7 @@ draw_tabline(void)
 	    if (width > 0)
 		screen_puts_len(showcmd_buf, width, 0, (int)Columns
 			    - width - (tabcount > 1) * 2, attr_nosel);
-	    showcmd_is_clear = (showcmd_buf[0] == NUL);
+	    showcmd_set_clear_state();
 	}
 
 	// Put an "X" for closing the current tab if there are several.

--- a/src/testdir/test_statusline.vim
+++ b/src/testdir/test_statusline.vim
@@ -657,6 +657,47 @@ func Test_statusline_showcmd()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_statusline_showcmd_redraw_tabline()
+  CheckRunVimInTerminal
+
+  let lines =<< trim END
+    set showcmd showcmdloc=tabline showtabline=2 tabline=%S timeoutlen=0
+    nnoremap g :redraw<CR>
+    nnoremap gc <Nop>
+  END
+  call writefile(lines, 'XTest_statusline_showcmd_redraw', 'D')
+
+  let buf = RunVimInTerminal('-S XTest_statusline_showcmd_redraw', #{rows: 6, cols: 40})
+  call term_sendkeys(buf, 'g')
+  call WaitForAssert({-> assert_match(':redraw', term_getline(buf, 6))})
+  call WaitForAssert({-> assert_notmatch('^:', term_getline(buf, 1))})
+  call StopVimInTerminal(buf)
+endfunc
+
+func Test_statusline_showcmd_cmd_mapping()
+  set showcmd
+  set statusline=AAA%SBBB
+  set showcmdloc=statusline
+  try
+    let g:showcmd_statusline = ''
+    nnoremap <F3> <Cmd>let g:showcmd_statusline = <SID>get_statusline()<CR>
+    call feedkeys("\<F3>", 'xt')
+    call assert_equal('AAABBB', trim(g:showcmd_statusline))
+    let g:showcmd_statusline = ''
+    nunmap <F3>
+
+    nnoremap <F3> <ScriptCmd>let g:showcmd_statusline = <SID>get_statusline()<CR>
+    call feedkeys("\<F3>", 'xt')
+    call assert_equal('AAABBB', trim(g:showcmd_statusline))
+  finally
+    silent! nunmap <F3>
+    unlet! g:showcmd_statusline
+    set showcmd&
+    set statusline&
+    set showcmdloc&
+  endtry
+endfunc
+
 func Test_statusline_highlight_group_cleared()
   CheckScreendump
 


### PR DESCRIPTION
related: neovim/neovim#40735

## Problem

if `'showcmdloc'` set to `"statusline"` `%S` show internal mapping dispatch keys when a `<cmd>`/`<ScriptCmd>` mapping redraws the statusline before returning ~~lol this is such a convoluted issue~~

## Solution

1. ignore `<Cmd>`/`<ScriptCmd>` dispatch keys similar to the other non-user-input keys ignored by showcmd (i.e. just prevent `%S` from displaying internal keys)
2. update the `showcmd` clear state when `%S` is rendered through the statusline or tabline path -> later clears still know to redraw away stale text