### PR TITLE
'completeslash' breaks :find completion with 'findfunc'

### DIFF
--- a/src/cmdexpand.c
+++ b/src/cmdexpand.c
@@ -3346,7 +3346,9 @@ expand_files_and_dirs(
     if (free_pat)
 	vim_free(pat);
 #ifdef BACKSLASH_IN_FILENAME
-    if (p_csl[0] != NUL && (options & WILD_IGNORE_COMPLETESLASH) == 0)
+    if (p_csl[0] != NUL
+	    && (options & WILD_IGNORE_COMPLETESLASH) == 0
+	    && xp->xp_context != EXPAND_FINDFUNC)
     {
 	int j;
 

--- a/src/testdir/test_findfile.vim
+++ b/src/testdir/test_findfile.vim
@@ -898,4 +898,29 @@ func Test_path_env_variable_with_whitespaces()
     enew
 endfunc
 
+func Test_findfunc_completeslash()
+  CheckMSWindows
+
+  func FindBsl(pat, cmdarg)
+    return ['Xdir\foo.c']->matchfuzzy(a:pat)
+  endfunc
+  func FindFwd(pat, cmdarg)
+    return ['Xdir/foo.c']->matchfuzzy(a:pat)
+  endfunc
+
+  set findfunc=FindBsl
+  set completeslash=slash
+  call feedkeys(":find Xdir\<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"find Xdir\foo.c', @:)
+
+  set findfunc=FindFwd
+  set completeslash=backslash
+  call feedkeys(":find Xdir\<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"find Xdir/foo.c', @:)
+
+  set completeslash& findfunc&
+  delfunc FindBsl
+  delfunc FindFwd
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  On MS-Windows with 'completeslash' set, an item completed by
          'findfunc' cannot be opened with :find, E345 is given.
Solution: Do not apply 'completeslash' to matches returned by 'findfunc',
          they are opaque strings that are passed back to the function
          unchanged.

fixes: #20770