### PR TITLE
runtime(hip): add filetype detection, ftplugin, indent and syntax menu

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -1964,6 +1964,8 @@ const ft_from_ext = {
   # CUDA Compute Unified Device Architecture
   "cu": "cuda",
   "cuh": "cuda",
+  # HIP Heterogeneous-compute Interface for Portability
+  "hip": "hip",
   # Cue
   "cue": "cue",
   # DAX

--- a/runtime/ftplugin/hip.vim
+++ b/runtime/ftplugin/hip.vim
@@ -1,0 +1,11 @@
+" Vim filetype plugin
+" Language:	HIP (Heterogeneous-compute Interface for Portability)
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2026 Jul 15
+
+if exists('b:did_ftplugin')
+  finish
+endif
+
+" Behaves mostly just like C++
+runtime! ftplugin/cpp.vim

--- a/runtime/indent/hip.vim
+++ b/runtime/indent/hip.vim
@@ -1,0 +1,15 @@
+" Vim indent file
+" Language:	HIP (Heterogeneous-compute Interface for Portability)
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2026 Jul 15
+
+" Only load this indent file when no other was loaded.
+if exists("b:did_indent")
+   finish
+endif
+let b:did_indent = 1
+
+" It's just like C indenting
+setlocal cindent
+
+let b:undo_indent = "setl cin<"

--- a/runtime/makemenu.vim
+++ b/runtime/makemenu.vim
@@ -276,6 +276,7 @@ SynMenu HIJK.Hercules:hercules
 SynMenu HIJK.Hex\ dump.XXD:xxd
 SynMenu HIJK.Hex\ dump.Intel\ MCS51:hex
 SynMenu HIJK.Hg\ commit:hgcommit
+SynMenu HIJK.HIP:hip
 SynMenu HIJK.Hollywood:hollywood
 SynMenu HIJK.HTML.HTML:html
 SynMenu HIJK.HTML.HTML\ with\ M4:htmlm4

--- a/runtime/synmenu.vim
+++ b/runtime/synmenu.vim
@@ -257,6 +257,7 @@ an 50.50.170 &Syntax.HIJK.Hercules :cal SetSyn("hercules")<CR>
 an 50.50.180 &Syntax.HIJK.Hex\ dump.XXD :cal SetSyn("xxd")<CR>
 an 50.50.190 &Syntax.HIJK.Hex\ dump.Intel\ MCS51 :cal SetSyn("hex")<CR>
 an 50.50.200 &Syntax.HIJK.Hg\ commit :cal SetSyn("hgcommit")<CR>
+an 50.50.205 &Syntax.HIJK.HIP :cal SetSyn("hip")<CR>
 an 50.50.210 &Syntax.HIJK.Hollywood :cal SetSyn("hollywood")<CR>
 an 50.50.220 &Syntax.HIJK.HTML.HTML :cal SetSyn("html")<CR>
 an 50.50.230 &Syntax.HIJK.HTML.HTML\ with\ M4 :cal SetSyn("htmlm4")<CR>

--- a/runtime/syntax/hip.vim
+++ b/runtime/syntax/hip.vim
@@ -1,0 +1,53 @@
+" Vim syntax file
+" Language:	HIP (Heterogeneous-compute Interface for Portability)
+" Maintainer:	Young <young20050727@gmail.com>
+" Last Change:	2026 Jul 15
+" Based On:	syntax/cuda.vim by Timothy B. Terriberry
+
+" quit when a syntax file was already loaded
+if exists("b:current_syntax")
+  finish
+endif
+
+" Read the C++ syntax to start with
+runtime! syntax/cpp.vim
+
+" HIP extensions.
+" Reference: https://docs.amd.com/en/latest/develop-perf-tips/hip-programming-guide/
+syn keyword hipStorageClass	__device__ __global__ __host__ __managed__
+syn keyword hipStorageClass	__constant__ __grid_constant__ __shared__
+syn keyword hipStorageClass	__inline__ __noinline__ __forceinline__ __inline_hint__
+syn keyword hipStorageClass	__align__ __thread__ __restrict__
+"syn keyword hipStorageClass	__import__ __export__ __location__
+syn keyword hipType		char1 char2 char3 char4
+syn keyword hipType		uchar1 uchar2 uchar3 uchar4
+syn keyword hipType		short1 short2 short3 short4
+syn keyword hipType		ushort1 ushort2 ushort3 ushort4
+syn keyword hipType		int1 int2 int3 int4
+syn keyword hipType		uint1 uint2 uint3 uint4
+syn keyword hipType		long1 long2 long3 long4
+syn keyword hipType		ulong1 ulong2 ulong3 ulong4
+syn keyword hipType		longlong1 longlong2 longlong3 longlong4
+syn keyword hipType		ulonglong1 ulonglong2 ulonglong3 ulonglong4
+syn keyword hipType		float1 float2 float3 float4
+syn keyword hipType		double1 double2 double3 double4
+syn keyword hipType		dim3 texture textureReference
+syn keyword hipType		hipError_t hipDeviceProp hipMemcpyKind
+syn keyword hipType		hipArray hipChannelFormatKind
+syn keyword hipType		hipChannelFormatDesc hipTextureAddressMode
+syn keyword hipType		hipTextureFilterMode hipTextureReadMode
+syn keyword hipVariable		gridDim blockIdx blockDim threadIdx warpSize
+syn keyword hipConstant		__HIP_ARCH__
+syn keyword hipConstant		__DEVICE_EMULATION__
+" There are too many HIP enumeration constants. We only define a subset of commonly used constants.
+" Reference: https://docs.amd.com/en/latest/develop-perf-tips/hip-programming-guide/
+syn keyword hipConstant		hipSuccess
+
+hi def link hipStorageClass	StorageClass
+hi def link hipType		Type
+hi def link hipVariable	Identifier
+hi def link hipConstant	Constant
+
+let b:current_syntax = "hip"
+
+" vim: ts=8


### PR DESCRIPTION
This rounds out HIP (Heterogeneous-compute Interface for Portability) support so
it mirrors the existing CUDA runtime files.

Changes, each mirroring its CUDA counterpart:

- **`syntax/hip.vim`**: sources `syntax/cpp.vim` and adds the HIP-specific
  keywords, mirroring `syntax/cuda.vim`.
- **`autoload/dist/ft.vim`**: detect the `.hip` extension as filetype `hip`
  (next to the existing `.cu`/`.cuh` → `cuda` entries).
- **`ftplugin/hip.vim`**: behaves like C++ by sourcing `ftplugin/cpp.vim`,
  mirroring `ftplugin/cuda.vim`.
- **`indent/hip.vim`**: uses `cindent`, mirroring `indent/cuda.vim`.
- **`makemenu.vim` / `synmenu.vim`**: add a `Syntax` menu entry under `HIJK.HIP`.

The `synmenu.vim` change is a minimal single-line insert rather than a full
regeneration, to keep the diff limited to HIP. (A `make menu` regeneration also
renumbers an unrelated pre-existing duplicate priority in the C section.)

Verified with a locally built Vim on a real `.hip` file: filetype resolves to
`hip`, `cindent` is set, the C++ ftplugin chain applies (e.g. `commentstring`),
and HIP keywords highlight correctly (`__global__` → StorageClass,
`hipError_t`/`dim3` → Type, `hipSuccess` → Constant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)