### PR TITLE
WinResized not triggered when the whole Vim is resized

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -3531,6 +3531,9 @@ give_up:
     if (starting == 0 && ++retry_count <= 3)
     {
 	apply_autocmds(EVENT_VIMRESIZED, NULL, NULL, FALSE, curbuf);
+	// A shell resize also changes window sizes; trigger WinResized (and
+	// WinScrolled) now instead of waiting for the next command.
+	may_trigger_win_scrolled_resized();
 	// In rare cases, autocommands may have altered Rows or Columns,
 	// jump back to check if we need to allocate the screen again.
 	goto retry;

--- a/src/testdir/test_autocmd.vim
+++ b/src/testdir/test_autocmd.vim
@@ -5872,6 +5872,27 @@ func Test_VimResized_and_window_width_not_equalized()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_WinResized_on_shell_resize()
+  CheckRunVimInTerminal
+
+  " A shell (terminal/GUI) resize changes window sizes, so WinResized must
+  " trigger from the resize alone, not only on the next typed command.
+  let lines =<< trim END
+    autocmd WinResized * call writefile(['x'], 'XwinResized', 'a')
+  END
+  call writefile(lines, 'XTest_WinResized_shell', 'D')
+  let buf = RunVimInTerminal('-S XTest_WinResized_shell', {'rows': 10, 'cols': 30})
+  call TermWait(buf)
+  call delete('XwinResized')
+
+  " Resize the terminal (SIGWINCH); do not send any key to the inner Vim.
+  call term_setsize(buf, 15, 40)
+  call WaitForAssert({-> assert_true(filereadable('XwinResized'))})
+
+  call StopVimInTerminal(buf)
+  call delete('XwinResized')
+endfunc
+
 func Test_win_tabclose_autocmd()
 
   defer CleanUpTestAuGroup()


### PR DESCRIPTION
```
Problem:  When the whole Vim (terminal or GUI) is resized, VimResized fires
          right away but WinResized does not: it only triggers on the next
          typed command, even though the windows already changed size.
Solution: Trigger the WinResized (and WinScrolled) check right after firing
          VimResized on a shell resize, so window size changes are reported
          immediately instead of waiting for the next command.
```

fixes: #20774