### PR TITLE
runtime(netrw): Fix `reset_ssl` reference error on file rename

### DIFF
--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -8683,6 +8683,8 @@ function s:NetrwLocalRename(path) range
             if exists('+shellslash') && !&ssl
                 let reset_ssl = 1
                 set ssl
+            else
+                let reset_ssl = 0
             endif
             " Consistently use / as directory separator
             let oldname= netrw#fs#ComposePath(a:path,curword)


### PR DESCRIPTION
On file rename in netrw window (`Shift + r`), it raises `reset_ssl` reference error.
