### PR TITLE
fix(gtk3-dialog): normalize FocusGained

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -484,6 +484,10 @@ gui_init_check(void)
 #else
 # ifdef FEAT_GUI_GTK
     gui.is_x11 = false;
+#  ifdef FEAT_GUI_DIALOG
+    gui.dialogs_active = 0;
+    gui.dialog_focus_pending = 0;
+#  endif
 #  ifdef GDK_WINDOWING_WAYLAND
     gui.is_wayland = false;
 #  endif
@@ -4883,7 +4887,11 @@ gui_focus_change(int in_focus)
     // Put events in the input queue only when allowed.
     // ui_focus_change() isn't called directly, because it invokes
     // autocommands and that must not happen asynchronously.
-    if (!hold_gui_events)
+    if (!hold_gui_events
+# if defined(FEAT_GUI_GTK) && defined(FEAT_GUI_DIALOG)
+	    && gui.dialogs_active == 0
+# endif
+       )
     {
 	char_u  bytes[3];
 

--- a/src/gui.c
+++ b/src/gui.c
@@ -483,6 +483,7 @@ gui_init_check(void)
     result = OK;
 #else
 # ifdef FEAT_GUI_GTK
+    gui.is_x11 = false;
 #  ifdef GDK_WINDOWING_WAYLAND
     gui.is_wayland = false;
 #  endif

--- a/src/gui.h
+++ b/src/gui.h
@@ -412,6 +412,7 @@ typedef struct Gui
     char_u	*browse_fname;	    // file name from filedlg
 
     guint32	event_time;
+    bool	is_x11;	            // active gdk backend in gtk is x11
 # ifdef GDK_WINDOWING_WAYLAND
     bool	is_wayland;	    // active gdk backend in gtk is wayland
 # endif

--- a/src/gui.h
+++ b/src/gui.h
@@ -412,6 +412,13 @@ typedef struct Gui
     char_u	*browse_fname;	    // file name from filedlg
 
     guint32	event_time;
+# ifdef FEAT_GUI_DIALOG
+    // Multiple dialogs not allowed, just tracked for future use.
+    int		dialogs_active;     // number of active GUI dialogs
+
+    // X11 focus_in_event() by dialogs, ignored to match wayland.
+    int		dialog_focus_pending;
+# endif
     bool	is_x11;	            // active gdk backend in gtk is x11
 # ifdef GDK_WINDOWING_WAYLAND
     bool	is_wayland;	    // active gdk backend in gtk is wayland

--- a/src/gui_gtk.c
+++ b/src/gui_gtk.c
@@ -1709,6 +1709,10 @@ gui_mch_dialog(int	type,	    // type of dialog
     int		response;
     DialogInfo  dialoginfo;
 
+    ++gui.dialogs_active;
+    if (gui.is_x11)
+	++gui.dialog_focus_pending;
+
     dialog = create_message_dialog(type, title, message);
     dialoginfo.dialog = GTK_DIALOG(dialog);
     dialog_add_buttons(GTK_DIALOG(dialog), buttons);
@@ -1796,6 +1800,7 @@ gui_mch_dialog(int	type,	    // type of dialog
 	gtk_widget_destroy(dialog);
     }
 
+    --gui.dialogs_active;
     return response > 0 ? response : 0;
 }
 

--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -4136,6 +4136,7 @@ gui_mch_init(void)
 #if GTK_CHECK_VERSION(3,4,0)
     if (GDK_IS_X11_DISPLAY(gdk_display_get_default()))
     {
+	gui.is_x11 = true;
 	// for X11, if we were using smooth scroll events, we
 	// would get an scroll without deltas on the very first user scroll* and
 	// get both "unsmooth" scroll and smooth scroll events after

--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -1080,7 +1080,12 @@ focus_in_event(GtkWidget *widget,
 	       GdkEventFocus *event UNUSED,
 	       gpointer data UNUSED)
 {
-    gui_focus_change(TRUE);
+#ifdef FEAT_GUI_DIALOG
+    if (gui.is_x11 && gui.dialog_focus_pending > 0)
+	--gui.dialog_focus_pending;
+    else
+#endif
+	gui_focus_change(TRUE);
 
     if (blink_state == BLINK_NONE)
 	gui_mch_start_blink();


### PR DESCRIPTION
gtk3 dialogs can trigger `FocusGained` while a dialog is active or-
immediately after it closes in a loop.

**Problem**:

Previously:

* Wayland: queued `FocusGained` events gives multiple dialogs.
* X11: Close triggers `focus_in_event()` and `FocusGained` loop.

The benefit of the previous behaviour being highly inconsistent between
Wayland or X11 and potentially different compositors is questionable.

It is mentioned in
https://github.com/vim/vim/blob/5680e3b2946666e237f433756c1a54bcc7814475/runtime/doc/autocmd.txt#L959-L962
that `FocusLost` may also trigger when dialogs happen,
_however this was not reproduced_ on neither x11 or wayland.

**Solution**:

Prerequisite: 8ded7f0a `fix(gtk): add gui.is_x11` for reliable detection of `x11` backend.

Track active GUI dialogs for future use
https://github.com/dezza/vim/blob/807f6984d8e18eb02f51c68bf3994e8ccb2797a3/src/gui.h#L415-L421
and suppress dialog-generated focus events while a dialog is active.

On X11, also ignore the restoring `focus_in_event()` caused by closing
a dialog.

This normalizes the behaviour between Wayland and X11 while matching
terminal Vim, where only a single dialog can be active.
