### PR TITLE
filetype: *.Containerfile not recognized as dockerfile

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -281,7 +281,7 @@ au BufNewFile,BufRead *.cpy
 
 " Dockerfile; Podman uses the same syntax with name Containerfile
 " Also see Dockerfile.* below.
-au BufNewFile,BufRead Containerfile,Dockerfile,dockerfile,*.[dD]ockerfile	setf dockerfile
+au BufNewFile,BufRead Containerfile,Dockerfile,dockerfile,*.[dD]ockerfile,*.[cC]ontainerfile	setf dockerfile
 
 " Enlightenment configuration files
 au BufNewFile,BufRead *enlightenment/*.cfg	setf c

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -246,7 +246,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     dircolors: ['.dir_colors', '.dircolors', '/etc/DIR_COLORS', 'any/etc/DIR_COLORS'],
     djot: ['file.dj', 'file.djot'],
     dnsmasq: ['/etc/dnsmasq.conf', '/etc/dnsmasq.d/file', 'any/etc/dnsmasq.conf', 'any/etc/dnsmasq.d/file'],
-    dockerfile: ['Containerfile', 'Dockerfile', 'dockerfile', 'file.Dockerfile', 'file.dockerfile', 'Dockerfile.debian', 'Containerfile.something'],
+    dockerfile: ['Containerfile', 'Dockerfile', 'dockerfile', 'file.Dockerfile', 'file.dockerfile', 'file.Containerfile', 'file.containerfile', 'Dockerfile.debian', 'Containerfile.something'],
     dosbatch: ['file.bat'],
     dosini: ['/etc/yum.conf', '/etc/nfs.conf', '/etc/nfsmount.conf', 'file.ini',
              'npmrc', '.npmrc', 'php.ini', 'php.ini-5', 'php.ini-file', 'php-fpm.conf', 'php-fpm.conf.default', 'www.conf', 'www.conf.default',


### PR DESCRIPTION
Problem:  *.Containerfile files are not recognized as dockerfile (only *.Dockerfile is).
Solution: Also detect *.[cC]ontainerfile as dockerfile.

Disclosure: prepared with AI assistance (Claude); reviewed and tested by me.

Signed-off-by: Omer Tuchfeld <omer@tuchfeld.dev>
