### PR TITLE
screenpos() "curscol" is wrong with 'rightleft'

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -9416,6 +9416,10 @@ screenpos({winid}, {lnum}, {col})			*screenpos()*
 		The "curscol" value is where the cursor would be placed.  For
 		a Tab it would be the same as "endcol", while for a double
 		width character it would be the same as "col".
+		With 'rightleft' set, "col" and "endcol" are still counted
+		from the start of the line, while "curscol" is the actual
+		screen column, thus counted from the left side of the
+		window.
 		The |conceal| feature is ignored here, the column numbers are
 		as if 'conceallevel' is zero.  You can set the cursor to the
 		right position and use |screencol()| to get the value with

--- a/src/move.c
+++ b/src/move.c
@@ -1560,6 +1560,16 @@ textpos2screenpos(
     *scolp = scol + coloff;
     *ccolp = ccol + coloff;
     *ecolp = ecol + coloff;
+# ifdef FEAT_RIGHTLEFT
+    if (wp->w_p_rl && row > 0)
+    {
+	// With 'rightleft' the cursor is on the leftmost cell of the
+	// character, which comes last in reading order.
+	int endoff = *ecolp - wp->w_wincol - 1;
+
+	*ccolp = wp->w_wincol + wp->w_width - endoff;
+    }
+# endif
 }
 #endif
 

--- a/src/testdir/test_cursor_func.vim
+++ b/src/testdir/test_cursor_func.vim
@@ -216,6 +216,44 @@ func Test_screenpos()
   call assert_equal(#{col: 1, row: 1, endcol: 1, curscol: 1}, screenpos(0, 1, -v:maxcol))
 endfunc
 
+func Test_screenpos_rightleft()
+  CheckFeature rightleft
+
+  rightbelow new
+  call setline(1, ["aあb", "\tx"])
+  setlocal rightleft
+  redraw
+  let winid = win_getid()
+  let [winrow, wincol] = win_screenpos(winid)
+  let width = winwidth(winid)
+
+  " "col" and "endcol" stay reading-order columns, while "curscol" is the
+  " screen column where the cursor lands, counted from the left.
+  call assert_equal({'row': winrow,
+	\ 'col': wincol + 0,
+	\ 'curscol': wincol + width - 1,
+	\ 'endcol': wincol + 0}, screenpos(winid, 1, 1))
+
+  " A double-wide character: the cursor is on its leftmost cell.
+  call assert_equal({'row': winrow,
+	\ 'col': wincol + 1,
+	\ 'curscol': wincol + width - 3,
+	\ 'endcol': wincol + 2}, screenpos(winid, 1, 2))
+
+  call assert_equal({'row': winrow,
+	\ 'col': wincol + 3,
+	\ 'curscol': wincol + width - 4,
+	\ 'endcol': wincol + 3}, screenpos(winid, 1, 5))
+
+  " A Tab: the cursor is on its last cell in reading order.
+  call assert_equal({'row': winrow + 1,
+	\ 'col': wincol + 0,
+	\ 'curscol': wincol + width - 8,
+	\ 'endcol': wincol + 7}, screenpos(winid, 2, 1))
+
+  bwipe!
+endfunc
+
 func Test_screenpos_fold()
   CheckFeature folding
 


### PR DESCRIPTION
```
Problem:  With 'rightleft' set, the "curscol" value of screenpos() does not
          point to the screen column where the cursor is placed.
Solution: Count "curscol" from the left side of the window, leaving "col"
          and "endcol" as reading-order columns.
```

related: #20763