### PR TITLE
copy_tv() and clear_tv() can be improved for scalar values

### DIFF
--- a/Filelist
+++ b/Filelist
@@ -96,6 +96,7 @@ SRC_ALL =	\
 		src/help.c \
 		src/highlight.c \
 		src/indent.c \
+		src/inline_funcs.h \
 		src/insexpand.c \
 		src/job.c \
 		src/json.c \

--- a/src/Make_cyg_ming.mak
+++ b/src/Make_cyg_ming.mak
@@ -1266,7 +1266,7 @@ nvcmdidxs: nv_cmds.h
 ###########################################################################
 INCL =	vim.h alloc.h ascii.h ex_cmds.h feature.h errors.h globals.h \
 	keymap.h macros.h option.h optiondefs.h os_dos.h os_win32.h \
-	proto.h regexp.h spell.h structs.h termdefs.h beval.h \
+	proto.h inline_funcs.h regexp.h spell.h structs.h termdefs.h beval.h \
 	$(NBDEBUG_INCL)
 GUI_INCL = gui.h
 ifeq ($(DIRECTX),yes)

--- a/src/Make_mvc.mak
+++ b/src/Make_mvc.mak
@@ -680,7 +680,7 @@ CFLAGS = $(CFLAGS) $(CFLAGS_DEPR)
 !INCLUDE .\testdir\Make_all.mak
 
 INCL = vim.h alloc.h ascii.h ex_cmds.h feature.h errors.h globals.h \
-	keymap.h macros.h option.h os_dos.h os_win32.h proto.h regexp.h \
+	keymap.h macros.h option.h os_dos.h os_win32.h proto.h inline_funcs.h regexp.h \
 	spell.h structs.h termdefs.h beval.h $(NBDEBUG_INCL)
 
 OBJ = \

--- a/src/Make_vms.mms
+++ b/src/Make_vms.mms
@@ -1016,7 +1016,7 @@ lua_env :
 
 [.$(DEST)]alloc.obj : alloc.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h gui.h beval.h \
- option.h ex_cmds.h proto.h errors.h globals.h
+ option.h ex_cmds.h proto.h inline_funcs.h errors.h globals.h
 [.$(DEST)]arabic.obj : arabic.c vim.h
 [.$(DEST)]arglist.obj : arglist.c vim.h [.$(DEST)]config.h feature.h os_unix.h
 [.$(DEST)]autocmd.obj : autocmd.c vim.h [.$(DEST)]config.h feature.h os_unix.h
@@ -1024,475 +1024,475 @@ lua_env :
 [.$(DEST)]blob.obj : blob.c vim.h [.$(DEST)]config.h feature.h os_unix.h
 [.$(DEST)]buffer.obj : buffer.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h version.h
 [.$(DEST)]bufwrite.obj : bufwrite.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]change.obj : change.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]charset.obj : charset.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]channel.obj : channel.c vim.h [.$(DEST)]config.h feature.h
 [.$(DEST)]cindent.obj : cindent.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]clientserver.obj : clientserver.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]clipboard.obj : clipboard.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]cmdexpand.obj : cmdexpand.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]cmdhist.obj : cmdhist.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]crypt.obj : crypt.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h structs.h regexp.h gui.h \
- beval.h alloc.h ex_cmds.h spell.h proto.h \
+ beval.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]crypt_zip.obj : crypt_zip.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h structs.h \
  regexp.h gui.h beval.h alloc.h ex_cmds.h spell.h \
- proto.h errors.h globals.h
+ proto.h inline_funcs.h errors.h globals.h
 [.$(DEST)]debugger.obj : debugger.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]dict.obj : dict.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h structs.h regexp.h gui.h \
- beval.h alloc.h ex_cmds.h spell.h proto.h \
+ beval.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]diff.obj : diff.c vim.h [.$(DEST)]config.h feature.h os_unix.h   \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h gui.h beval.h \
- option.h ex_cmds.h proto.h errors.h globals.h
+ option.h ex_cmds.h proto.h inline_funcs.h errors.h globals.h
 [.$(DEST)]digraph.obj : digraph.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]drawline.obj : drawline.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]drawscreen.obj : drawscreen.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]edit.obj : edit.c vim.h [.$(DEST)]config.h feature.h os_unix.h   \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h gui.h beval.h \
- option.h ex_cmds.h proto.h errors.h globals.h
+ option.h ex_cmds.h proto.h inline_funcs.h errors.h globals.h
 [.$(DEST)]eval.obj : eval.c vim.h [.$(DEST)]config.h feature.h os_unix.h   \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h gui.h beval.h \
- option.h ex_cmds.h proto.h errors.h globals.h
+ option.h ex_cmds.h proto.h inline_funcs.h errors.h globals.h
 [.$(DEST)]evalbuffer.obj : evalbuffer.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h structs.h \
  regexp.h gui.h beval.h alloc.h ex_cmds.h spell.h \
- proto.h errors.h globals.h
+ proto.h inline_funcs.h errors.h globals.h
 [.$(DEST)]evalfunc.obj : evalfunc.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h structs.h \
  regexp.h gui.h beval.h alloc.h ex_cmds.h spell.h \
- proto.h errors.h globals.h version.h
+ proto.h inline_funcs.h errors.h globals.h version.h
 [.$(DEST)]evalvars.obj : evalvars.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h structs.h \
  regexp.h gui.h beval.h alloc.h ex_cmds.h spell.h \
- proto.h errors.h globals.h version.h
+ proto.h inline_funcs.h errors.h globals.h version.h
 [.$(DEST)]evalwindow.obj : evalwindow.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h structs.h \
  regexp.h gui.h beval.h alloc.h ex_cmds.h spell.h \
- proto.h errors.h globals.h
+ proto.h inline_funcs.h errors.h globals.h
 [.$(DEST)]ex_cmds.obj : ex_cmds.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h version.h
 [.$(DEST)]ex_cmds2.obj : ex_cmds2.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h version.h
 [.$(DEST)]ex_docmd.obj : ex_docmd.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h ex_cmdidxs.h
 [.$(DEST)]ex_eval.obj : ex_eval.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]ex_getln.obj : ex_getln.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]fileio.obj : fileio.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]filepath.obj : filepath.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]findfile.obj : findfile.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]float.obj : float.c vim.h [.$(DEST)]config.h feature.h os_unix.h   \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h gui.h beval.h \
- option.h ex_cmds.h proto.h errors.h globals.h
+ option.h ex_cmds.h proto.h inline_funcs.h errors.h globals.h
 [.$(DEST)]fold.obj : fold.c vim.h [.$(DEST)]config.h feature.h os_unix.h   \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h gui.h beval.h \
- option.h ex_cmds.h proto.h errors.h globals.h
+ option.h ex_cmds.h proto.h inline_funcs.h errors.h globals.h
 [.$(DEST)]fuzzy.obj : fuzzy.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]getchar.obj : getchar.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]gc.obj : gc.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]gui_xim.obj : gui_xim.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]hardcopy.obj : hardcopy.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h version.h
 [.$(DEST)]hashtab.obj : hashtab.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]help.obj : help.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]highlight.obj : highlight.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]if_cscope.obj : if_cscope.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]if_xcmdsrv.obj : if_xcmdsrv.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h version.h
 [.$(DEST)]if_mzsch.obj : if_mzsch.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h structs.h \
- regexp.h gui.h beval.h ex_cmds.h proto.h \
+ regexp.h gui.h beval.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h if_mzsch.h
 [.$(DEST)]indent.obj : indent.c vim.h [.$(DEST)]config.h feature.h os_unix.h
 [.$(DEST)]insexpand.obj : insexpand.c vim.h [.$(DEST)]config.h feature.h os_unix.h
 [.$(DEST)]job.obj : job.c vim.h [.$(DEST)]config.h feature.h os_unix.h
 [.$(DEST)]json.obj : json.c vim.h [.$(DEST)]config.h feature.h os_unix.h   \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h gui.h beval.h \
- option.h ex_cmds.h proto.h errors.h globals.h
+ option.h ex_cmds.h proto.h inline_funcs.h errors.h globals.h
 [.$(DEST)]linematch.obj : linematch.c vim.h [.$(DEST)]config.h feature.h os_unix.h   \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h gui.h beval.h \
- option.h ex_cmds.h proto.h errors.h globals.h
+ option.h ex_cmds.h proto.h inline_funcs.h errors.h globals.h
 [.$(DEST)]list.obj : list.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h structs.h regexp.h gui.h \
- beval.h alloc.h ex_cmds.h spell.h proto.h \
+ beval.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]locale.obj : locale.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h structs.h regexp.h gui.h \
- beval.h alloc.h ex_cmds.h spell.h proto.h \
+ beval.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]logfile.obj : logfile.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h structs.h regexp.h gui.h \
- beval.h alloc.h ex_cmds.h spell.h proto.h \
+ beval.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]main.obj : main.c vim.h [.$(DEST)]config.h feature.h os_unix.h   \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h gui.h beval.h \
- option.h ex_cmds.h proto.h errors.h globals.h \
+ option.h ex_cmds.h proto.h inline_funcs.h errors.h globals.h \
  arabic.c
 [.$(DEST)]map.obj : map.c vim.h [.$(DEST)]config.h feature.h os_unix.h   \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h gui.h beval.h \
- option.h ex_cmds.h proto.h errors.h globals.h
+ option.h ex_cmds.h proto.h inline_funcs.h errors.h globals.h
 [.$(DEST)]mark.obj : mark.c vim.h [.$(DEST)]config.h feature.h os_unix.h   \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h gui.h beval.h \
- option.h ex_cmds.h proto.h errors.h globals.h
+ option.h ex_cmds.h proto.h inline_funcs.h errors.h globals.h
 [.$(DEST)]match.obj : match.c vim.h [.$(DEST)]config.h feature.h os_unix.h   \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h gui.h beval.h \
- option.h ex_cmds.h proto.h errors.h globals.h
+ option.h ex_cmds.h proto.h inline_funcs.h errors.h globals.h
 [.$(DEST)]memfile.obj : memfile.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]memline.obj : memline.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]menu.obj : menu.c vim.h [.$(DEST)]config.h feature.h os_unix.h   \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h gui.h beval.h \
- option.h ex_cmds.h proto.h errors.h globals.h
+ option.h ex_cmds.h proto.h inline_funcs.h errors.h globals.h
 [.$(DEST)]message.obj : message.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]misc1.obj : misc1.c vim.h [.$(DEST)]config.h feature.h os_unix.h   \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h gui.h beval.h \
- option.h ex_cmds.h proto.h errors.h globals.h \
+ option.h ex_cmds.h proto.h inline_funcs.h errors.h globals.h \
  version.h
 [.$(DEST)]misc2.obj : misc2.c vim.h [.$(DEST)]config.h feature.h os_unix.h   \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h gui.h beval.h \
- option.h ex_cmds.h proto.h errors.h globals.h
+ option.h ex_cmds.h proto.h inline_funcs.h errors.h globals.h
 [.$(DEST)]mouse.obj : mouse.c vim.h [.$(DEST)]config.h feature.h os_unix.h   \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h gui.h beval.h \
- option.h ex_cmds.h proto.h errors.h globals.h
+ option.h ex_cmds.h proto.h inline_funcs.h errors.h globals.h
 [.$(DEST)]move.obj : move.c vim.h [.$(DEST)]config.h feature.h os_unix.h   \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h gui.h beval.h \
- option.h ex_cmds.h proto.h errors.h globals.h
+ option.h ex_cmds.h proto.h inline_funcs.h errors.h globals.h
 [.$(DEST)]mbyte.obj : mbyte.c vim.h [.$(DEST)]config.h feature.h os_unix.h   \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h gui.h beval.h \
- option.h ex_cmds.h proto.h errors.h globals.h
+ option.h ex_cmds.h proto.h inline_funcs.h errors.h globals.h
 [.$(DEST)]normal.obj : normal.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h nv_cmdidxs.h nv_cmds.h
 [.$(DEST)]ops.obj : ops.c vim.h [.$(DEST)]config.h feature.h os_unix.h   \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h gui.h beval.h \
- option.h ex_cmds.h proto.h errors.h globals.h
+ option.h ex_cmds.h proto.h inline_funcs.h errors.h globals.h
 [.$(DEST)]option.obj : option.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h optiondefs.h
 [.$(DEST)]optionstr.obj : optionstr.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]os_unix.obj : os_unix.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h os_unixx.h
 [.$(DEST)]os_vms.obj : os_vms.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h os_unixx.h
 [.$(DEST)]pathdef.obj : [.$(DEST)]pathdef.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]popupmenu.obj : popupmenu.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]popupwin.obj : popupwin.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]pty.obj : pty.c vim.h [.$(DEST)]config.h feature.h os_unix.h
 [.$(DEST)]profiler.obj : profiler.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]quickfix.obj : quickfix.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]regexp.obj : regexp.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]register.obj : register.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]scriptfile.obj : scriptfile.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]screen.obj : screen.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]search.obj : search.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]session.obj : session.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]sha256.obj : sha256.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h structs.h regexp.h gui.h \
- beval.h alloc.h ex_cmds.h spell.h proto.h \
+ beval.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]sign.obj : sign.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h structs.h regexp.h gui.h \
- beval.h alloc.h ex_cmds.h spell.h proto.h \
+ beval.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]sixel.obj : sixel.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h structs.h regexp.h gui.h \
- beval.h alloc.h ex_cmds.h spell.h proto.h \
+ beval.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]kitty.obj : kitty.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h structs.h regexp.h gui.h \
- beval.h alloc.h ex_cmds.h spell.h proto.h \
+ beval.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]cairo.obj : cairo.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h structs.h regexp.h gui.h \
- beval.h alloc.h ex_cmds.h spell.h proto.h \
+ beval.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]sound.obj : sound.c vim.h [.$(DEST)]config.h feature.h
 [.$(DEST)]spell.obj : spell.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]spellfile.obj : spellfile.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h structs.h \
  regexp.h gui.h beval.h alloc.h ex_cmds.h spell.h \
- proto.h errors.h globals.h
+ proto.h inline_funcs.h errors.h globals.h
 [.$(DEST)]spellsuggest.obj : spellsuggest.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h structs.h \
  regexp.h gui.h beval.h alloc.h ex_cmds.h spell.h \
- proto.h errors.h globals.h
+ proto.h inline_funcs.h errors.h globals.h
 [.$(DEST)]strings.obj : strings.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h structs.h \
  regexp.h gui.h beval.h alloc.h ex_cmds.h spell.h \
- proto.h errors.h globals.h
+ proto.h inline_funcs.h errors.h globals.h
 [.$(DEST)]syntax.obj : syntax.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]tabpanel.obj : tabpanel.c vim.h [.$(DEST)]config.h feature.h os_unix.h   \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]tag.obj : tag.c vim.h [.$(DEST)]config.h feature.h os_unix.h   \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h gui.h beval.h \
- option.h ex_cmds.h proto.h errors.h globals.h
+ option.h ex_cmds.h proto.h inline_funcs.h errors.h globals.h
 [.$(DEST)]term.obj : term.c vim.h [.$(DEST)]config.h feature.h os_unix.h   \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h gui.h beval.h \
- option.h ex_cmds.h proto.h errors.h globals.h
+ option.h ex_cmds.h proto.h inline_funcs.h errors.h globals.h
 [.$(DEST)]terminal.obj : terminal.c vim.h [.$(DEST)]config.h feature.h os_unix.h
 [.$(DEST)]termlib.obj : termlib.c vim.h [.$(DEST)]config.h feature.h os_unix.h   \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h gui.h beval.h \
- option.h ex_cmds.h proto.h errors.h globals.h
+ option.h ex_cmds.h proto.h inline_funcs.h errors.h globals.h
 [.$(DEST)]testing.obj : testing.c vim.h [.$(DEST)]config.h feature.h os_unix.h   \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h gui.h beval.h \
- option.h ex_cmds.h proto.h errors.h globals.h
+ option.h ex_cmds.h proto.h inline_funcs.h errors.h globals.h
 [.$(DEST)]textformat.obj : textformat.c vim.h [.$(DEST)]config.h feature.h os_unix.h   \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h gui.h beval.h \
- option.h ex_cmds.h proto.h errors.h globals.h
+ option.h ex_cmds.h proto.h inline_funcs.h errors.h globals.h
 [.$(DEST)]textobject.obj : textobject.c vim.h [.$(DEST)]config.h feature.h os_unix.h   \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h gui.h beval.h \
- option.h ex_cmds.h proto.h errors.h globals.h
+ option.h ex_cmds.h proto.h inline_funcs.h errors.h globals.h
 [.$(DEST)]textprop.obj : textprop.c vim.h [.$(DEST)]config.h feature.h os_unix.h   \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h gui.h beval.h \
- option.h ex_cmds.h proto.h errors.h globals.h
+ option.h ex_cmds.h proto.h inline_funcs.h errors.h globals.h
 [.$(DEST)]time.obj : time.c vim.h [.$(DEST)]config.h feature.h os_unix.h   \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h gui.h beval.h \
- option.h ex_cmds.h proto.h errors.h globals.h
+ option.h ex_cmds.h proto.h inline_funcs.h errors.h globals.h
 [.$(DEST)]tuple.obj : tuple.c vim.h [.$(DEST)]config.h feature.h os_unix.h   \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h gui.h beval.h \
- option.h ex_cmds.h proto.h errors.h globals.h
+ option.h ex_cmds.h proto.h inline_funcs.h errors.h globals.h
 [.$(DEST)]typval.obj : typval.c vim.h [.$(DEST)]config.h feature.h os_unix.h   \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h gui.h beval.h \
- option.h ex_cmds.h proto.h errors.h globals.h
+ option.h ex_cmds.h proto.h inline_funcs.h errors.h globals.h
 [.$(DEST)]ui.obj : ui.c vim.h [.$(DEST)]config.h feature.h os_unix.h   \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h gui.h beval.h \
- option.h ex_cmds.h proto.h errors.h globals.h
+ option.h ex_cmds.h proto.h inline_funcs.h errors.h globals.h
 [.$(DEST)]undo.obj : undo.c vim.h [.$(DEST)]config.h feature.h os_unix.h   \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h gui.h beval.h \
- option.h ex_cmds.h proto.h errors.h globals.h
+ option.h ex_cmds.h proto.h inline_funcs.h errors.h globals.h
 [.$(DEST)]usercmd.obj : usercmd.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h structs.h \
  regexp.h gui.h beval.h alloc.h ex_cmds.h spell.h \
- proto.h errors.h globals.h
+ proto.h inline_funcs.h errors.h globals.h
 [.$(DEST)]userfunc.obj : userfunc.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h structs.h \
  regexp.h gui.h beval.h alloc.h ex_cmds.h spell.h \
- proto.h errors.h globals.h
+ proto.h inline_funcs.h errors.h globals.h
 [.$(DEST)]version.obj : version.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h version.h
 [.$(DEST)]viminfo.obj : viminfo.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h version.h
 [.$(DEST)]vim9class.obj : vim9class.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h version.h
 [.$(DEST)]vim9cmds.obj : vim9cmds.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h version.h
 [.$(DEST)]vim9compile.obj : vim9compile.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h version.h
 [.$(DEST)]vim9execute.obj : vim9execute.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h version.h
 [.$(DEST)]vim9expr.obj : vim9expr.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h version.h
 [.$(DEST)]vim9instr.obj : vim9instr.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h version.h
 [.$(DEST)]vim9generics.obj : vim9generics.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h version.h
 [.$(DEST)]vim9script.obj : vim9script.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h version.h
 [.$(DEST)]vim9type.obj : vim9type.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h version.h
 [.$(DEST)]window.obj : window.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]gui.obj : gui.c vim.h [.$(DEST)]config.h feature.h os_unix.h   \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h gui.h beval.h \
- option.h ex_cmds.h proto.h errors.h globals.h
+ option.h ex_cmds.h proto.h inline_funcs.h errors.h globals.h
 [.$(DEST)]gui_gtk.obj : gui_gtk.c gui_gtk_f.h vim.h [.$(DEST)]config.h feature.h \
  os_unix.h   ascii.h keymap.h termdefs.h macros.h structs.h \
  regexp.h gui.h beval.h option.h ex_cmds.h \
- proto.h errors.h globals.h [-.pixmaps]stock_icons.h
+ proto.h inline_funcs.h errors.h globals.h [-.pixmaps]stock_icons.h
 [.$(DEST)]gui_gtk_f.obj : gui_gtk_f.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h gui_gtk_f.h
 [.$(DEST)]gui_motif.obj : gui_motif.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h [-.pixmaps]alert.xpm [-.pixmaps]error.xpm \
  [-.pixmaps]generic.xpm [-.pixmaps]info.xpm [-.pixmaps]quest.xpm
 [.$(DEST)]gui_athena.obj : gui_athena.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h gui_at_sb.h
 [.$(DEST)]gui_gtk_x11.obj : gui_gtk_x11.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h gui_gtk_f.h [-.runtime]vim32x32.xpm \
  [-.runtime]vim16x16.xpm [-.runtime]vim48x48.xpm version.h
 [.$(DEST)]gui_x11.obj : gui_x11.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h [-.runtime]vim32x32.xpm \
  [-.runtime]vim16x16.xpm [-.runtime]vim48x48.xpm [-.pixmaps]tb_new.xpm \
  [-.pixmaps]tb_open.xpm [-.pixmaps]tb_close.xpm [-.pixmaps]tb_save.xpm \
@@ -1512,44 +1512,44 @@ lua_env :
  [-.pixmaps]tb_minwidth.xpm
 [.$(DEST)]gui_at_sb.obj : gui_at_sb.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h gui_at_sb.h
 [.$(DEST)]gui_at_fs.obj : gui_at_fs.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h gui_at_sb.h
 [.$(DEST)]pty.obj : pty.c vim.h [.$(DEST)]config.h feature.h os_unix.h   \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h gui.h beval.h \
- option.h ex_cmds.h proto.h errors.h globals.h
+ option.h ex_cmds.h proto.h inline_funcs.h errors.h globals.h
 [.$(DEST)]if_perl.obj : [.auto]if_perl.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]if_python.obj : if_python.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]if_tcl.obj : if_tcl.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]if_ruby.obj : if_ruby.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h version.h
 [.$(DEST)]if_lua.obj : if_lua.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  errors.h globals.h version.h
 [.$(DEST)]beval.obj : beval.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]gui_beval.obj : gui_beval.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h
 [.$(DEST)]netbeans.obj : netbeans.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
- gui.h beval.h option.h ex_cmds.h proto.h \
+ gui.h beval.h option.h ex_cmds.h proto.h inline_funcs.h \
  errors.h globals.h version.h
 [.$(DEST)]gui_xmdlg.obj : gui_xmdlg.c [.$(DEST)]config.h vim.h feature.h os_unix.h
 [.$(DEST)]gui_xmebw.obj : gui_xmebw.c [.$(DEST)]config.h vim.h feature.h os_unix.h

--- a/src/Makefile
+++ b/src/Makefile
@@ -3235,7 +3235,7 @@ VIM_H_DEPENDENCIES = \
 	vim.h protodef.h auto/config.h feature.h os_unix.h \
 	auto/osdef.h ascii.h keymap.h termdefs.h macros.h option.h beval.h \
 	structs.h regexp.h gui.h alloc.h ex_cmds.h spell.h \
-	proto.h globals.h errors.h
+	proto.h inline_funcs.h globals.h errors.h
 
 # All the object files are put in the "objects" directory.  Since not all make
 # commands understand putting object files in another directory, it must be
@@ -3881,684 +3881,684 @@ installglinks_haiku: $(HAIKU_GLINKS) install_haiku_extra
 objects/alloc.o: auto/osdef.h alloc.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/arabic.o: auto/osdef.h arabic.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/arglist.o: auto/osdef.h arglist.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/autocmd.o: auto/osdef.h autocmd.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/beval.o: auto/osdef.h beval.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/blob.o: auto/osdef.h blob.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/blowfish.o: auto/osdef.h blowfish.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/buffer.o: auto/osdef.h buffer.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h version.h
 objects/change.o: auto/osdef.h change.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/charset.o: auto/osdef.h charset.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/cindent.o: auto/osdef.h cindent.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/clientserver.o: auto/osdef.h clientserver.c vim.h protodef.h auto/config.h feature.h \
  os_unix.h ascii.h keymap.h termdefs.h macros.h option.h \
  beval.h structs.h regexp.h gui.h \
  libvterm/include/vterm.h libvterm/include/vterm_keycodes.h alloc.h \
- ex_cmds.h spell.h proto.h globals.h errors.h
+ ex_cmds.h spell.h proto.h inline_funcs.h globals.h errors.h
 objects/clipboard.o: auto/osdef.h clipboard.c vim.h protodef.h auto/config.h feature.h \
  os_unix.h ascii.h keymap.h termdefs.h macros.h option.h \
  beval.h structs.h regexp.h gui.h libvterm/include/vterm.h \
  libvterm/include/vterm_keycodes.h alloc.h \
- ex_cmds.h spell.h proto.h globals.h errors.h wayland.h
+ ex_cmds.h spell.h proto.h inline_funcs.h globals.h errors.h wayland.h
 objects/cmdexpand.o: auto/osdef.h cmdexpand.c vim.h protodef.h auto/config.h feature.h \
  os_unix.h ascii.h keymap.h termdefs.h macros.h option.h \
  beval.h structs.h regexp.h gui.h \
  libvterm/include/vterm.h libvterm/include/vterm_keycodes.h alloc.h \
- ex_cmds.h spell.h proto.h globals.h errors.h
+ ex_cmds.h spell.h proto.h inline_funcs.h globals.h errors.h
 objects/cmdhist.o: auto/osdef.h cmdhist.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/crypt.o: auto/osdef.h crypt.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/crypt_zip.o: auto/osdef.h crypt_zip.c vim.h protodef.h auto/config.h feature.h \
  os_unix.h ascii.h keymap.h termdefs.h macros.h option.h \
  beval.h structs.h regexp.h gui.h \
  libvterm/include/vterm.h libvterm/include/vterm_keycodes.h alloc.h \
- ex_cmds.h spell.h proto.h globals.h errors.h
+ ex_cmds.h spell.h proto.h inline_funcs.h globals.h errors.h
 objects/debugger.o: auto/osdef.h debugger.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/dict.o: auto/osdef.h dict.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/diff.o: auto/osdef.h diff.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h xdiff/xdiff.h
 objects/digraph.o: auto/osdef.h digraph.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/drawline.o: auto/osdef.h drawline.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/drawscreen.o: auto/osdef.h drawscreen.c vim.h protodef.h auto/config.h feature.h \
  os_unix.h ascii.h keymap.h termdefs.h macros.h option.h \
  beval.h structs.h regexp.h gui.h \
  libvterm/include/vterm.h libvterm/include/vterm_keycodes.h alloc.h \
- ex_cmds.h spell.h proto.h globals.h errors.h
+ ex_cmds.h spell.h proto.h inline_funcs.h globals.h errors.h
 objects/edit.o: auto/osdef.h edit.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/eval.o: auto/osdef.h eval.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/evalbuffer.o: auto/osdef.h evalbuffer.c vim.h protodef.h auto/config.h feature.h \
  os_unix.h ascii.h keymap.h termdefs.h macros.h option.h \
  beval.h structs.h regexp.h gui.h \
  libvterm/include/vterm.h libvterm/include/vterm_keycodes.h alloc.h \
- ex_cmds.h spell.h proto.h globals.h errors.h
+ ex_cmds.h spell.h proto.h inline_funcs.h globals.h errors.h
 objects/evalfunc.o: auto/osdef.h evalfunc.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h version.h
 objects/evalvars.o: auto/osdef.h evalvars.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h version.h
 objects/evalwindow.o: auto/osdef.h evalwindow.c vim.h protodef.h auto/config.h feature.h \
  os_unix.h ascii.h keymap.h termdefs.h macros.h option.h \
  beval.h structs.h regexp.h gui.h \
  libvterm/include/vterm.h libvterm/include/vterm_keycodes.h alloc.h \
- ex_cmds.h spell.h proto.h globals.h errors.h
+ ex_cmds.h spell.h proto.h inline_funcs.h globals.h errors.h
 objects/ex_cmds.o: auto/osdef.h ex_cmds.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h version.h
 objects/ex_cmds2.o: auto/osdef.h ex_cmds2.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h version.h
 objects/ex_docmd.o: auto/osdef.h ex_docmd.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h ex_cmdidxs.h
 objects/ex_eval.o: auto/osdef.h ex_eval.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/ex_getln.o: auto/osdef.h ex_getln.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/fileio.o: auto/osdef.h fileio.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/filepath.o: auto/osdef.h filepath.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/findfile.o: auto/osdef.h findfile.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/float.o: auto/osdef.h float.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/fold.o: auto/osdef.h fold.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/fuzzy.o: auto/osdef.h fuzzy.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/getchar.o: auto/osdef.h getchar.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/gc.o: auto/osdef.h gc.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/gui_xim.o: auto/osdef.h gui_xim.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/hardcopy.o: auto/osdef.h hardcopy.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h version.h
 objects/hashtab.o: auto/osdef.h hashtab.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/help.o: auto/osdef.h help.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/highlight.o: auto/osdef.h highlight.c vim.h protodef.h auto/config.h feature.h \
  os_unix.h ascii.h keymap.h termdefs.h macros.h option.h \
  beval.h structs.h regexp.h gui.h \
  libvterm/include/vterm.h libvterm/include/vterm_keycodes.h alloc.h \
- ex_cmds.h spell.h proto.h globals.h errors.h
+ ex_cmds.h spell.h proto.h inline_funcs.h globals.h errors.h
 objects/if_cscope.o: auto/osdef.h if_cscope.c vim.h protodef.h auto/config.h feature.h \
  os_unix.h ascii.h keymap.h termdefs.h macros.h option.h \
  beval.h structs.h regexp.h gui.h \
  libvterm/include/vterm.h libvterm/include/vterm_keycodes.h alloc.h \
- ex_cmds.h spell.h proto.h globals.h errors.h
+ ex_cmds.h spell.h proto.h inline_funcs.h globals.h errors.h
 objects/if_xcmdsrv.o: auto/osdef.h if_xcmdsrv.c vim.h protodef.h auto/config.h feature.h \
  os_unix.h ascii.h keymap.h termdefs.h macros.h option.h \
  beval.h structs.h regexp.h gui.h \
  libvterm/include/vterm.h libvterm/include/vterm_keycodes.h alloc.h \
- ex_cmds.h spell.h proto.h globals.h errors.h version.h
+ ex_cmds.h spell.h proto.h inline_funcs.h globals.h errors.h version.h
 objects/indent.o: auto/osdef.h indent.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/insexpand.o: auto/osdef.h insexpand.c vim.h protodef.h auto/config.h feature.h \
  os_unix.h ascii.h keymap.h termdefs.h macros.h option.h \
  beval.h structs.h regexp.h gui.h \
  libvterm/include/vterm.h libvterm/include/vterm_keycodes.h alloc.h \
- ex_cmds.h spell.h proto.h globals.h errors.h
+ ex_cmds.h spell.h proto.h inline_funcs.h globals.h errors.h
 objects/json.o: auto/osdef.h json.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/linematch.o: auto/osdef.h linematch.c vim.h protodef.h auto/config.h feature.h \
  os_unix.h ascii.h keymap.h termdefs.h macros.h option.h \
  beval.h structs.h regexp.h gui.h \
  libvterm/include/vterm.h libvterm/include/vterm_keycodes.h xdiff/xdiff.h \
- alloc.h ex_cmds.h spell.h proto.h globals.h errors.h
+ alloc.h ex_cmds.h spell.h proto.h inline_funcs.h globals.h errors.h
 objects/list.o: auto/osdef.h list.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/locale.o: auto/osdef.h locale.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/logfile.o: auto/osdef.h logfile.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/main.o: auto/osdef.h main.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/map.o: auto/osdef.h map.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/mark.o: auto/osdef.h mark.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/match.o: auto/osdef.h match.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/mbyte.o: auto/osdef.h mbyte.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/memfile.o: auto/osdef.h memfile.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/memline.o: auto/osdef.h memline.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/menu.o: auto/osdef.h menu.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/message.o: auto/osdef.h message.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/misc1.o: auto/osdef.h misc1.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h version.h
 objects/misc2.o: auto/osdef.h misc2.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/mouse.o: auto/osdef.h mouse.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/move.o: auto/osdef.h move.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/normal.o: auto/osdef.h normal.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h nv_cmds.h nv_cmdidxs.h
 objects/ops.o: auto/osdef.h ops.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/option.o: auto/osdef.h option.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h optiondefs.h
 objects/optionstr.o: auto/osdef.h optionstr.c vim.h protodef.h auto/config.h feature.h \
  os_unix.h ascii.h keymap.h termdefs.h macros.h option.h \
  beval.h structs.h regexp.h gui.h \
  libvterm/include/vterm.h libvterm/include/vterm_keycodes.h alloc.h \
- ex_cmds.h spell.h proto.h globals.h errors.h
+ ex_cmds.h spell.h proto.h inline_funcs.h globals.h errors.h
 objects/os_unix.o: auto/osdef.h os_unix.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h os_unixx.h
 objects/pathdef.o: auto/osdef.h auto/pathdef.c vim.h protodef.h auto/config.h feature.h \
  os_unix.h ascii.h keymap.h termdefs.h macros.h option.h \
  beval.h structs.h regexp.h gui.h \
  libvterm/include/vterm.h libvterm/include/vterm_keycodes.h alloc.h \
- ex_cmds.h spell.h proto.h globals.h errors.h
+ ex_cmds.h spell.h proto.h inline_funcs.h globals.h errors.h
 objects/popupmenu.o: auto/osdef.h popupmenu.c vim.h protodef.h auto/config.h feature.h \
  os_unix.h ascii.h keymap.h termdefs.h macros.h option.h \
  beval.h structs.h regexp.h gui.h \
  libvterm/include/vterm.h libvterm/include/vterm_keycodes.h alloc.h \
- ex_cmds.h spell.h proto.h globals.h errors.h
+ ex_cmds.h spell.h proto.h inline_funcs.h globals.h errors.h
 objects/popupwin.o: auto/osdef.h popupwin.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/profiler.o: auto/osdef.h profiler.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/pty.o: auto/osdef.h pty.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/quickfix.o: auto/osdef.h quickfix.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/regexp.o: auto/osdef.h regexp.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h regexp_bt.c regexp_nfa.c
 objects/register.o: auto/osdef.h register.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/screen.o: auto/osdef.h screen.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/scriptfile.o: auto/osdef.h scriptfile.c vim.h protodef.h auto/config.h feature.h \
  os_unix.h ascii.h keymap.h termdefs.h macros.h option.h \
  beval.h structs.h regexp.h gui.h \
  libvterm/include/vterm.h libvterm/include/vterm_keycodes.h alloc.h \
- ex_cmds.h spell.h proto.h globals.h errors.h
+ ex_cmds.h spell.h proto.h inline_funcs.h globals.h errors.h
 objects/search.o: auto/osdef.h search.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/session.o: auto/osdef.h session.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/sha256.o: auto/osdef.h sha256.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/sign.o: auto/osdef.h sign.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/sixel.o: auto/osdef.h sixel.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/kitty.o: auto/osdef.h kitty.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/cairo.o: auto/osdef.h cairo.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/socketserver.o: socketserver.c vim.h protodef.h auto/config.h feature.h \
  os_unix.h auto/osdef.h ascii.h keymap.h termdefs.h macros.h option.h \
  beval.h structs.h regexp.h gui.h libvterm/include/vterm.h \
  libvterm/include/vterm_keycodes.h xdiff/xdiff.h xdiff/../vim.h alloc.h \
- ex_cmds.h spell.h proto.h globals.h errors.h
+ ex_cmds.h spell.h proto.h inline_funcs.h globals.h errors.h
 objects/sound.o: auto/osdef.h sound.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/spell.o: auto/osdef.h spell.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/spellfile.o: auto/osdef.h spellfile.c vim.h protodef.h auto/config.h feature.h \
  os_unix.h ascii.h keymap.h termdefs.h macros.h option.h \
  beval.h structs.h regexp.h gui.h \
  libvterm/include/vterm.h libvterm/include/vterm_keycodes.h alloc.h \
- ex_cmds.h spell.h proto.h globals.h errors.h
+ ex_cmds.h spell.h proto.h inline_funcs.h globals.h errors.h
 objects/spellsuggest.o: auto/osdef.h spellsuggest.c vim.h protodef.h auto/config.h feature.h \
  os_unix.h ascii.h keymap.h termdefs.h macros.h option.h \
  beval.h structs.h regexp.h gui.h \
  libvterm/include/vterm.h libvterm/include/vterm_keycodes.h alloc.h \
- ex_cmds.h spell.h proto.h globals.h errors.h
+ ex_cmds.h spell.h proto.h inline_funcs.h globals.h errors.h
 objects/strings.o: auto/osdef.h strings.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/syntax.o: auto/osdef.h syntax.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/tabpanel.o: auto/osdef.h tabpanel.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/tag.o: auto/osdef.h tag.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/term.o: auto/osdef.h term.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/terminal.o: auto/osdef.h terminal.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/testing.o: auto/osdef.h testing.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/textformat.o: auto/osdef.h textformat.c vim.h protodef.h auto/config.h feature.h \
  os_unix.h ascii.h keymap.h termdefs.h macros.h option.h \
  beval.h structs.h regexp.h gui.h \
  libvterm/include/vterm.h libvterm/include/vterm_keycodes.h alloc.h \
- ex_cmds.h spell.h proto.h globals.h errors.h
+ ex_cmds.h spell.h proto.h inline_funcs.h globals.h errors.h
 objects/textobject.o: auto/osdef.h textobject.c vim.h protodef.h auto/config.h feature.h \
  os_unix.h ascii.h keymap.h termdefs.h macros.h option.h \
  beval.h structs.h regexp.h gui.h \
  libvterm/include/vterm.h libvterm/include/vterm_keycodes.h alloc.h \
- ex_cmds.h spell.h proto.h globals.h errors.h
+ ex_cmds.h spell.h proto.h inline_funcs.h globals.h errors.h
 objects/textprop.o: auto/osdef.h textprop.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/time.o: auto/osdef.h time.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/tuple.o: auto/osdef.h tuple.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/typval.o: auto/osdef.h typval.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/ui.o: auto/osdef.h ui.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/undo.o: auto/osdef.h undo.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/usercmd.o: auto/osdef.h usercmd.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/userfunc.o: auto/osdef.h userfunc.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/version.o: auto/osdef.h version.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h version.h
 objects/vim9class.o: auto/osdef.h vim9class.c vim.h protodef.h auto/config.h feature.h \
  os_unix.h ascii.h keymap.h termdefs.h macros.h option.h \
  beval.h structs.h regexp.h gui.h \
  libvterm/include/vterm.h libvterm/include/vterm_keycodes.h alloc.h \
- ex_cmds.h spell.h proto.h globals.h errors.h vim9.h
+ ex_cmds.h spell.h proto.h inline_funcs.h globals.h errors.h vim9.h
 objects/vim9cmds.o: auto/osdef.h vim9cmds.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h vim9.h
 objects/vim9compile.o: auto/osdef.h vim9compile.c vim.h protodef.h auto/config.h feature.h \
  os_unix.h ascii.h keymap.h termdefs.h macros.h option.h \
  beval.h structs.h regexp.h gui.h \
  libvterm/include/vterm.h libvterm/include/vterm_keycodes.h alloc.h \
- ex_cmds.h spell.h proto.h globals.h errors.h vim9.h
+ ex_cmds.h spell.h proto.h inline_funcs.h globals.h errors.h vim9.h
 objects/vim9execute.o: auto/osdef.h vim9execute.c vim.h protodef.h auto/config.h feature.h \
  os_unix.h ascii.h keymap.h termdefs.h macros.h option.h \
  beval.h structs.h regexp.h gui.h \
  libvterm/include/vterm.h libvterm/include/vterm_keycodes.h alloc.h \
- ex_cmds.h spell.h proto.h globals.h errors.h vim9.h
+ ex_cmds.h spell.h proto.h inline_funcs.h globals.h errors.h vim9.h
 objects/vim9expr.o: auto/osdef.h vim9expr.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h vim9.h
 objects/vim9generics.o: auto/osdef.h vim9generics.c vim.h protodef.h auto/config.h feature.h \
  os_unix.h ascii.h keymap.h termdefs.h macros.h option.h \
  beval.h structs.h regexp.h gui.h \
  libvterm/include/vterm.h libvterm/include/vterm_keycodes.h alloc.h \
- ex_cmds.h spell.h proto.h globals.h errors.h vim9.h
+ ex_cmds.h spell.h proto.h inline_funcs.h globals.h errors.h vim9.h
 objects/vim9instr.o: auto/osdef.h vim9instr.c vim.h protodef.h auto/config.h feature.h \
  os_unix.h ascii.h keymap.h termdefs.h macros.h option.h \
  beval.h structs.h regexp.h gui.h \
  libvterm/include/vterm.h libvterm/include/vterm_keycodes.h alloc.h \
- ex_cmds.h spell.h proto.h globals.h errors.h vim9.h
+ ex_cmds.h spell.h proto.h inline_funcs.h globals.h errors.h vim9.h
 objects/vim9script.o: auto/osdef.h vim9script.c vim.h protodef.h auto/config.h feature.h \
  os_unix.h ascii.h keymap.h termdefs.h macros.h option.h \
  beval.h structs.h regexp.h gui.h \
  libvterm/include/vterm.h libvterm/include/vterm_keycodes.h alloc.h \
- ex_cmds.h spell.h proto.h globals.h errors.h vim9.h
+ ex_cmds.h spell.h proto.h inline_funcs.h globals.h errors.h vim9.h
 objects/vim9type.o: auto/osdef.h vim9type.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h vim9.h
 objects/viminfo.o: auto/osdef.h viminfo.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h version.h
 objects/window.o: auto/osdef.h window.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/bufwrite.o: auto/osdef.h bufwrite.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/gui.o: auto/osdef.h gui.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/gui_gtk.o: auto/osdef.h gui_gtk.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h gui_gtk_f.h
 objects/gui_gtk4.o: auto/osdef.h gui_gtk4.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h gui_gtk4_f.h auto/gui_gtk_gresources.h \
  gui_gtk4_cb.h gui_gtk4_da.h gui_gtk4_tb.h gui_gtk4_menu.h
 objects/gui_gtk4_f.o: auto/osdef.h gui_gtk4_f.c vim.h protodef.h auto/config.h feature.h \
  os_unix.h ascii.h keymap.h termdefs.h macros.h option.h \
  beval.h structs.h regexp.h gui.h \
  libvterm/include/vterm.h libvterm/include/vterm_keycodes.h alloc.h \
- ex_cmds.h spell.h proto.h globals.h errors.h gui_gtk4_f.h
+ ex_cmds.h spell.h proto.h inline_funcs.h globals.h errors.h gui_gtk4_f.h
 objects/gui_gtk4_cb.o: auto/osdef.h gui_gtk4_cb.c vim.h protodef.h auto/config.h feature.h \
  os_unix.h ascii.h keymap.h termdefs.h macros.h option.h \
  beval.h structs.h regexp.h gui.h \
  libvterm/include/vterm.h libvterm/include/vterm_keycodes.h alloc.h \
- ex_cmds.h spell.h proto.h globals.h errors.h gui_gtk4_cb.h
+ ex_cmds.h spell.h proto.h inline_funcs.h globals.h errors.h gui_gtk4_cb.h
 objects/gui_gtk4_da.o: auto/osdef.h gui_gtk4_da.c vim.h protodef.h auto/config.h feature.h \
  os_unix.h ascii.h keymap.h termdefs.h macros.h option.h \
  beval.h structs.h regexp.h gui.h \
  libvterm/include/vterm.h libvterm/include/vterm_keycodes.h alloc.h \
- ex_cmds.h spell.h proto.h globals.h errors.h gui_gtk4_da.h
+ ex_cmds.h spell.h proto.h inline_funcs.h globals.h errors.h gui_gtk4_da.h
 objects/gui_gtk4_tb.o: auto/osdef.h gui_gtk4_tb.c vim.h protodef.h auto/config.h feature.h \
  os_unix.h ascii.h keymap.h termdefs.h macros.h option.h \
  beval.h structs.h regexp.h gui.h \
  libvterm/include/vterm.h libvterm/include/vterm_keycodes.h alloc.h \
- ex_cmds.h spell.h proto.h globals.h errors.h gui_gtk4_tb.h
+ ex_cmds.h spell.h proto.h inline_funcs.h globals.h errors.h gui_gtk4_tb.h
 objects/gui_gtk4_menu.o: auto/osdef.h gui_gtk4_menu.c vim.h protodef.h auto/config.h feature.h \
  os_unix.h ascii.h keymap.h termdefs.h macros.h option.h \
  beval.h structs.h regexp.h gui.h \
  libvterm/include/vterm.h libvterm/include/vterm_keycodes.h alloc.h \
- ex_cmds.h spell.h proto.h globals.h errors.h gui_gtk4_menu.h
+ ex_cmds.h spell.h proto.h inline_funcs.h globals.h errors.h gui_gtk4_menu.h
 objects/gui_gtk_f.o: auto/osdef.h gui_gtk_f.c vim.h protodef.h auto/config.h feature.h \
  os_unix.h ascii.h keymap.h termdefs.h macros.h option.h \
  beval.h structs.h regexp.h gui.h \
  libvterm/include/vterm.h libvterm/include/vterm_keycodes.h alloc.h \
- ex_cmds.h spell.h proto.h globals.h errors.h gui_gtk_f.h
+ ex_cmds.h spell.h proto.h inline_funcs.h globals.h errors.h gui_gtk_f.h
 objects/gui_motif.o: auto/osdef.h gui_motif.c vim.h protodef.h auto/config.h feature.h \
  os_unix.h ascii.h keymap.h termdefs.h macros.h option.h \
  beval.h structs.h regexp.h gui.h \
  libvterm/include/vterm.h libvterm/include/vterm_keycodes.h alloc.h \
- ex_cmds.h spell.h proto.h globals.h errors.h gui_xmebw.h \
+ ex_cmds.h spell.h proto.h inline_funcs.h globals.h errors.h gui_xmebw.h \
  ../pixmaps/alert.xpm ../pixmaps/error.xpm ../pixmaps/generic.xpm \
  ../pixmaps/info.xpm ../pixmaps/quest.xpm gui_x11_pm.h \
  ../pixmaps/tb_new.xpm ../pixmaps/tb_open.xpm ../pixmaps/tb_close.xpm \
@@ -4580,104 +4580,104 @@ objects/gui_xmdlg.o: auto/osdef.h gui_xmdlg.c vim.h protodef.h auto/config.h fea
  os_unix.h ascii.h keymap.h termdefs.h macros.h option.h \
  beval.h structs.h regexp.h gui.h \
  libvterm/include/vterm.h libvterm/include/vterm_keycodes.h alloc.h \
- ex_cmds.h spell.h proto.h globals.h errors.h
+ ex_cmds.h spell.h proto.h inline_funcs.h globals.h errors.h
 objects/gui_xmebw.o: auto/osdef.h gui_xmebw.c vim.h protodef.h auto/config.h feature.h \
  os_unix.h ascii.h keymap.h termdefs.h macros.h option.h \
  beval.h structs.h regexp.h gui.h \
  libvterm/include/vterm.h libvterm/include/vterm_keycodes.h alloc.h \
- ex_cmds.h spell.h proto.h globals.h errors.h gui_xmebwp.h gui_xmebw.h
+ ex_cmds.h spell.h proto.h inline_funcs.h globals.h errors.h gui_xmebwp.h gui_xmebw.h
 objects/gui_gtk_x11.o: auto/osdef.h gui_gtk_x11.c vim.h protodef.h auto/config.h feature.h \
  os_unix.h ascii.h keymap.h termdefs.h macros.h option.h \
  beval.h structs.h regexp.h gui.h \
  libvterm/include/vterm.h libvterm/include/vterm_keycodes.h alloc.h \
- ex_cmds.h spell.h proto.h globals.h errors.h auto/gui_gtk_gresources.h \
+ ex_cmds.h spell.h proto.h inline_funcs.h globals.h errors.h auto/gui_gtk_gresources.h \
  gui_gtk_f.h ../runtime/vim16x16_png.h ../runtime/vim32x32_png.h \
  ../runtime/vim48x48_png.h
 objects/gui_x11.o: auto/osdef.h gui_x11.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h ../runtime/vim32x32.xpm ../runtime/vim16x16.xpm \
  ../runtime/vim48x48.xpm errors.h vim_icon.xbm vim_mask.xbm
 objects/gui_haiku.o: auto/osdef.h gui_haiku.cc vim.h protodef.h auto/config.h feature.h \
  os_unix.h ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h version.h
 objects/json_test.o: auto/osdef.h json_test.c main.c vim.h protodef.h auto/config.h feature.h \
  os_unix.h ascii.h keymap.h termdefs.h macros.h option.h \
  beval.h structs.h regexp.h gui.h \
  libvterm/include/vterm.h libvterm/include/vterm_keycodes.h alloc.h \
- ex_cmds.h spell.h proto.h globals.h errors.h json.c
+ ex_cmds.h spell.h proto.h inline_funcs.h globals.h errors.h json.c
 objects/kword_test.o: auto/osdef.h kword_test.c main.c vim.h protodef.h auto/config.h \
  feature.h os_unix.h ascii.h keymap.h termdefs.h macros.h \
  option.h beval.h structs.h regexp.h gui.h \
  libvterm/include/vterm.h libvterm/include/vterm_keycodes.h alloc.h \
- ex_cmds.h spell.h proto.h globals.h errors.h charset.c
+ ex_cmds.h spell.h proto.h inline_funcs.h globals.h errors.h charset.c
 objects/memfile_test.o: auto/osdef.h memfile_test.c main.c vim.h protodef.h auto/config.h \
  feature.h os_unix.h ascii.h keymap.h termdefs.h macros.h \
  option.h beval.h structs.h regexp.h gui.h \
  libvterm/include/vterm.h libvterm/include/vterm_keycodes.h alloc.h \
- ex_cmds.h spell.h proto.h globals.h errors.h memfile.c
+ ex_cmds.h spell.h proto.h inline_funcs.h globals.h errors.h memfile.c
 objects/message_test.o: auto/osdef.h message_test.c main.c vim.h protodef.h auto/config.h \
  feature.h os_unix.h ascii.h keymap.h termdefs.h macros.h \
  option.h beval.h structs.h regexp.h gui.h \
  libvterm/include/vterm.h libvterm/include/vterm_keycodes.h alloc.h \
- ex_cmds.h spell.h proto.h globals.h errors.h message.c
+ ex_cmds.h spell.h proto.h inline_funcs.h globals.h errors.h message.c
 objects/if_lua.o: auto/osdef.h if_lua.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h version.h
 objects/if_mzsch.o: auto/osdef.h if_mzsch.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h if_mzsch.h
 objects/if_perl.o: auto/osdef.h auto/if_perl.c vim.h protodef.h auto/config.h feature.h \
  os_unix.h ascii.h keymap.h termdefs.h macros.h option.h \
  beval.h structs.h regexp.h gui.h \
  libvterm/include/vterm.h libvterm/include/vterm_keycodes.h alloc.h \
- ex_cmds.h spell.h proto.h globals.h errors.h
+ ex_cmds.h spell.h proto.h inline_funcs.h globals.h errors.h
 objects/if_python.o: auto/osdef.h if_python.c vim.h protodef.h auto/config.h feature.h \
  os_unix.h ascii.h keymap.h termdefs.h macros.h option.h \
  beval.h structs.h regexp.h gui.h \
  libvterm/include/vterm.h libvterm/include/vterm_keycodes.h alloc.h \
- ex_cmds.h spell.h proto.h globals.h errors.h if_py_both.h
+ ex_cmds.h spell.h proto.h inline_funcs.h globals.h errors.h if_py_both.h
 objects/if_python3.o: auto/osdef.h if_python3.c vim.h protodef.h auto/config.h feature.h \
  os_unix.h ascii.h keymap.h termdefs.h macros.h option.h \
  beval.h structs.h regexp.h gui.h \
  libvterm/include/vterm.h libvterm/include/vterm_keycodes.h alloc.h \
- ex_cmds.h spell.h proto.h globals.h errors.h if_py_both.h
+ ex_cmds.h spell.h proto.h inline_funcs.h globals.h errors.h if_py_both.h
 objects/if_tcl.o: auto/osdef.h if_tcl.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/if_ruby.o: auto/osdef.h if_ruby.c protodef.h auto/config.h vim.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h version.h
 objects/gui_beval.o: auto/osdef.h gui_beval.c vim.h protodef.h auto/config.h feature.h \
  os_unix.h ascii.h keymap.h termdefs.h macros.h option.h \
  beval.h structs.h regexp.h gui.h \
  libvterm/include/vterm.h libvterm/include/vterm_keycodes.h alloc.h \
- ex_cmds.h spell.h proto.h globals.h errors.h
+ ex_cmds.h spell.h proto.h inline_funcs.h globals.h errors.h
 objects/netbeans.o: auto/osdef.h netbeans.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h version.h
 objects/job.o: auto/osdef.h job.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/channel.o: auto/osdef.h channel.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
- libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
+ libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h inline_funcs.h \
  globals.h errors.h
 objects/gui_gtk_gresources.o: auto/gui_gtk_gresources.c
 objects/wlr-data-control-unstable-v1.o: \
@@ -4687,7 +4687,7 @@ objects/wayland.o: auto/osdef.h wayland.c vim.h protodef.h auto/config.h feature
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
  libvterm/include/vterm_keycodes.h alloc.h \
- ex_cmds.h spell.h proto.h globals.h errors.h wayland.h \
+ ex_cmds.h spell.h proto.h inline_funcs.h globals.h errors.h wayland.h \
  auto/wayland/wlr-data-control-unstable-v1.h \
  auto/wayland/ext-data-control-v1.h
 objects/vterm_encoding.o: auto/osdef.h libvterm/src/encoding.c libvterm/src/vterm_internal.h \
@@ -4722,7 +4722,7 @@ objects/xdiffi.o: auto/osdef.h xdiff/xdiffi.c xdiff/xinclude.h auto/config.h \
  structs.h regexp.h gui.h \
  libvterm/include/vterm.h \
  libvterm/include/vterm_keycodes.h alloc.h \
- ex_cmds.h spell.h proto.h globals.h \
+ ex_cmds.h spell.h proto.h inline_funcs.h globals.h \
  errors.h xdiff/xtypes.h xdiff/xutils.h xdiff/xprepare.h \
  xdiff/xdiffi.h xdiff/xemit.h
 objects/xemit.o: auto/osdef.h xdiff/xemit.c xdiff/xinclude.h auto/config.h \
@@ -4733,7 +4733,7 @@ objects/xemit.o: auto/osdef.h xdiff/xemit.c xdiff/xinclude.h auto/config.h \
  structs.h regexp.h gui.h \
  libvterm/include/vterm.h \
  libvterm/include/vterm_keycodes.h alloc.h \
- ex_cmds.h spell.h proto.h globals.h \
+ ex_cmds.h spell.h proto.h inline_funcs.h globals.h \
  errors.h xdiff/xtypes.h xdiff/xutils.h xdiff/xprepare.h \
  xdiff/xdiffi.h xdiff/xemit.h
 objects/xprepare.o: auto/osdef.h xdiff/xprepare.c xdiff/xinclude.h auto/config.h \
@@ -4744,7 +4744,7 @@ objects/xprepare.o: auto/osdef.h xdiff/xprepare.c xdiff/xinclude.h auto/config.h
  structs.h regexp.h gui.h \
  libvterm/include/vterm.h \
  libvterm/include/vterm_keycodes.h alloc.h \
- ex_cmds.h spell.h proto.h globals.h \
+ ex_cmds.h spell.h proto.h inline_funcs.h globals.h \
  errors.h xdiff/xtypes.h xdiff/xutils.h xdiff/xprepare.h \
  xdiff/xdiffi.h xdiff/xemit.h
 objects/xutils.o: auto/osdef.h xdiff/xutils.c xdiff/xinclude.h auto/config.h \
@@ -4755,7 +4755,7 @@ objects/xutils.o: auto/osdef.h xdiff/xutils.c xdiff/xinclude.h auto/config.h \
  structs.h regexp.h gui.h \
  libvterm/include/vterm.h \
  libvterm/include/vterm_keycodes.h alloc.h \
- ex_cmds.h spell.h proto.h globals.h \
+ ex_cmds.h spell.h proto.h inline_funcs.h globals.h \
  errors.h xdiff/xtypes.h xdiff/xutils.h xdiff/xprepare.h \
  xdiff/xdiffi.h xdiff/xemit.h
 objects/xhistogram.o: auto/osdef.h xdiff/xhistogram.c xdiff/xinclude.h auto/config.h \
@@ -4766,7 +4766,7 @@ objects/xhistogram.o: auto/osdef.h xdiff/xhistogram.c xdiff/xinclude.h auto/conf
  structs.h regexp.h gui.h \
  libvterm/include/vterm.h \
  libvterm/include/vterm_keycodes.h alloc.h \
- ex_cmds.h spell.h proto.h globals.h \
+ ex_cmds.h spell.h proto.h inline_funcs.h globals.h \
  errors.h xdiff/xtypes.h xdiff/xutils.h xdiff/xprepare.h \
  xdiff/xdiffi.h xdiff/xemit.h
 objects/xpatience.o: auto/osdef.h xdiff/xpatience.c xdiff/xinclude.h auto/config.h \
@@ -4777,7 +4777,7 @@ objects/xpatience.o: auto/osdef.h xdiff/xpatience.c xdiff/xinclude.h auto/config
  structs.h regexp.h gui.h \
  libvterm/include/vterm.h \
  libvterm/include/vterm_keycodes.h alloc.h \
- ex_cmds.h spell.h proto.h globals.h \
+ ex_cmds.h spell.h proto.h inline_funcs.h globals.h \
  errors.h xdiff/xtypes.h xdiff/xutils.h xdiff/xprepare.h \
  xdiff/xdiffi.h xdiff/xemit.h
 proto/alloc.pro: alloc.c

--- a/src/inline_funcs.h
+++ b/src/inline_funcs.h
@@ -1,0 +1,60 @@
+/* vi:set ts=8 sts=4 sw=4 noet:
+ *
+ * VIM - Vi IMproved	by Bram Moolenaar
+ *
+ * Do ":help uganda"  in Vim to read copying and usage conditions.
+ * Do ":help credits" in Vim to see a list of people who contributed.
+ */
+
+/*
+ * inline_funcs.h: shared inline function definitions.
+ *
+ * Included from vim.h after proto.h, so they may use its prototypes.
+ */
+
+/*
+ * Copy the value of typval "from" to typval "to".  See copy_tv_inner().
+ */
+    static inline int
+copy_tv(typval_T *from, typval_T *to)
+{
+    switch (from->v_type)
+    {
+	case VAR_NUMBER:
+	case VAR_BOOL:
+	case VAR_SPECIAL:
+	case VAR_FLOAT:
+	    to->v_type = from->v_type;
+	    to->v_lock = 0;
+	    to->vval = from->vval;	// union copy covers number and float
+	    return OK;
+	default:
+	    return copy_tv_inner(from, to);
+    }
+}
+
+/*
+ * Free the memory for the value of typval "varp" and set it to NULL or 0.
+ * See clear_tv_inner().
+ */
+    static inline void
+clear_tv(typval_T *varp)
+{
+    if (varp == NULL)
+	return;
+    switch (varp->v_type)
+    {
+	case VAR_NUMBER:
+	case VAR_BOOL:
+	case VAR_SPECIAL:
+	    varp->vval.v_number = 0;
+	    varp->v_lock = 0;
+	    break;
+	case VAR_FLOAT:
+	    varp->vval.v_float = 0.0;
+	    varp->v_lock = 0;
+	    break;
+	default:
+	    clear_tv_inner(varp);
+    }
+}

--- a/src/proto/typval.pro
+++ b/src/proto/typval.pro
@@ -2,7 +2,7 @@
 typval_T *alloc_tv(void);
 typval_T *alloc_string_tv(char_u *s);
 void free_tv(typval_T *varp);
-void clear_tv(typval_T *varp);
+void clear_tv_inner(typval_T *varp);
 void init_tv(typval_T *varp);
 varnumber_T tv_get_number(typval_T *varp);
 varnumber_T tv_to_number(typval_T *varp);
@@ -66,7 +66,7 @@ char_u *tv_get_string_buf_chk(typval_T *varp, char_u *buf);
 char_u *tv_get_string_buf_chk_strict(typval_T *varp, char_u *buf, int strict);
 char_u *tv_stringify(typval_T *varp, char_u *buf);
 int tv_check_lock(typval_T *tv, char_u *name, int use_gettext);
-int copy_tv(typval_T *from, typval_T *to);
+int copy_tv_inner(typval_T *from, typval_T *to);
 int typval_compare2(typval_T *tv1, typval_T *tv2, exprtype_T type, int ic, int *res);
 int typval_compare(typval_T *tv1, typval_T *tv2, exprtype_T type, int ic);
 int typval_compare_list(typval_T *tv1, typval_T *tv2, exprtype_T type, int ic, int *res);

--- a/src/typval.c
+++ b/src/typval.c
@@ -114,9 +114,11 @@ free_tv(typval_T *varp)
 
 /*
  * Free the memory for a variable value and set the value to NULL or 0.
+ * Full implementation for all types; the inline clear_tv() in inline_funcs.h
+ * fast-paths scalars and must stay in sync with this for them.
  */
     void
-clear_tv(typval_T *varp)
+clear_tv_inner(typval_T *varp)
 {
     if (varp == NULL)
 	return;
@@ -1354,9 +1356,11 @@ tv_check_lock(typval_T *tv, char_u *name, int use_gettext)
  * Does not make a copy of a list, blob or dict but copies the reference!
  * It is OK for "from" and "to" to point to the same item.  This is used to
  * make a copy later.
+ * Full implementation for all types; the inline copy_tv() in inline_funcs.h
+ * fast-paths scalars and must stay in sync with this for them.
  */
     int
-copy_tv(typval_T *from, typval_T *to)
+copy_tv_inner(typval_T *from, typval_T *to)
 {
     int		ret = OK;
 

--- a/src/vim.h
+++ b/src/vim.h
@@ -2543,6 +2543,9 @@ typedef int (*opt_expand_cb_T)(optexpand_T *args, int *numMatches, char_u ***mat
 
 #include "proto.h"	    // function prototypes
 
+// Shared inline functions; must come after proto.h (declares the *_inner fallbacks).
+#include "inline_funcs.h"
+
 // This has to go after the include of proto.h, as proto/gui.pro declares
 // functions of these names. The declarations would break if the defines had
 // been seen at that stage.  But it must be before globals.h, where error_ga


### PR DESCRIPTION
## Summary

Every value in Vim is a tagged `typval_T`, and moving values around — onto and off the Vim9 execution stack, into and out of lists/dicts, through `for` loops, on function return — goes through `copy_tv()`/`clear_tv()`, each running a type `switch`. For the common scalar types (number/bool/special/float) the real work is a trivial value copy or a no-op, so the function call plus the switch dominate the cost.

This makes `copy_tv()`/`clear_tv()` thin `static inline` wrappers (new `src/inline_funcs.h`) that handle the scalar types at the call site and fall back to the out-of-line `copy_tv_inner()`/`clear_tv_inner()` for every refcounted or allocating type. The public names are unchanged, so every caller benefits with no call-site churn; observable behaviour is identical.

Two design notes:

- **Why a new header.** The wrappers reference `typval_T` (from `structs.h`) and the `*_inner()` prototypes (from `proto.h`), so they must be included after `proto.h`; `macros.h` is included too early. A small dedicated header keeps `vim.h` short, but these two definitions could just as well sit inline in `vim.h` after `proto.h` — happy to inline them instead if you prefer.
- **Why inline rather than an early return.** An in-place early return in `copy_tv()`/`clear_tv()` would drop the switch but keep the call; inlining at the call site drops both — which is why the wall-clock gain below exceeds the instruction-count gain.

The build-dependency bookkeeping for the new header is split into a second commit, since it is mechanical and is normally regenerated by `make depend`.

## Benchmark

**scalar (best case): −10% instructions, −23% wall-clock. container (worst case): unchanged (+1% `Ir`). Binary: +0.6%.**

Base — `master` at commit `6f02e5cd7c27fc098d0b8dfec99542c7663a807e` — vs patched, measured on GitHub Actions. callgrind instruction-reads (`Ir`) are deterministic and runner-independent; wall-clock is the minimum of 3 native runs (informational — noisy on shared runners).

| workload | `Ir` base → patched | `Ir` Δ | time base → patched | time Δ |
|---|---|---:|---|---:|
| scalar — Sieve of Eratosthenes (best case) | 30,549,307,131 → 27,468,457,830 | **−10.08%** | 5.181s → 3.987s | **−23.05%** |
| container — deepcopy/slice/remove (worst case) | 2,004,554,303 → 2,023,750,673 | +0.96% | 1.884s → 1.903s | +1.01% |

Both workloads produce bit-identical results on the base and patched builds, confirming the change is semantics-preserving. `copy_tv()`/`clear_tv()` are exercised throughout the existing test suite, so no new test is added.

For the scalar workload the wall-clock gain (−23%) is larger than the `Ir` gain (−10%): removing the call and the type switch also helps branch prediction and the instruction cache, which `Ir` alone does not capture. The container workload is effectively unchanged — its sub-1% `Ir` increase is the expected cost of the extra scalar-type check before the non-scalar fallback.  Its wall-clock delta is within run-to-run noise on the shared runner, where the deterministic `Ir` is the reliable signal.

This is a general, low-risk constant-factor win: scalars are a common case whose copy or clear is trivial, so paying a call plus a type switch for them is avoidable overhead. It does not touch the interpreter dispatch loop, so it helps all value-churn-heavy Vim9 code rather than being a redesign.

<details>
<summary>Binary size</summary>

Inlining the scalar fast-path at every call site grows the binary a little (Ubuntu 24.04 CI runner, x86-64, gcc `-O2` without `-g`, base → patched):

| `vim` binary | base | patched | Δ |
|---|---:|---:|---:|
| as built | 4,530,304 | 4,555,040 | +0.55% (+24,736 B) |
| stripped | 4,062,816 | 4,087,392 | +0.60% (+24,576 B) |

</details>

<details>
<summary>Benchmark workloads (vim9script)</summary>

`Ir` is measured with `valgrind --tool=callgrind --dump-instr=no --branch-sim=no` on an `-O2 -g` build; binary size and wall-clock use an `-O2` (no `-g`) build. Driven by `ci/bench/run_typval_bench.sh <base-sha> <patched-sha>`.

**`scalarbench.vim`** — scalar / best case:

```vim
vim9script
# Scalar-heavy workload (the fast-path's best case): a Sieve of Eratosthenes
# over a reused list<bool>.  Each pass resets, sieves and counts purely through
# list-index reads and writes of scalar typvals plus arithmetic and
# comparisons; the list is allocated once (outside the loop) and no builtin or
# string work is in the hot path, so the inline copy_tv()/clear_tv() win is
# what moves the number.
const OUT = exists('g:BENCH_OUT') ? g:BENCH_OUT : '/tmp/scalarbench.txt'
def CountPrimes(sieve: list<bool>): number
  var n = len(sieve)
  var k = 0
  while k < n
    sieve[k] = true			# reset: scalar store (clear_tv + copy_tv)
    k += 1
  endwhile
  var i = 2
  while i * i < n
    if sieve[i]
      var j = i * i
      while j < n
        sieve[j] = false		# mark composite: scalar store
        j += i
      endwhile
    endif
    i += 1
  endwhile
  var count = 0
  i = 2
  while i < n
    if sieve[i]				# read scalar onto the stack
      count += 1
    endif
    i += 1
  endwhile
  return count
enddef
def Main()
  var iter = 200000
  if exists('g:ITER')
    iter = g:ITER
  endif
  var sieve: list<bool> = []
  for _ in range(2000)
    sieve->add(true)			# allocate once, outside the timed loop
  endfor
  var t = reltime()
  var acc = 0
  for _ in range(iter)
    acc += CountPrimes(sieve)		# pi(2000) = 303, so check = iter * 303
  endfor
  writefile([printf('ITER=%d elapsed=%.3fs check=%d',
    iter, reltimefloat(reltime(t)), acc)], OUT)
enddef
try
  Main()
catch
  writefile(['EXC: ' .. v:exception .. ' @ ' .. v:throwpoint], OUT)
endtry
qall!
```

**`containerbench.vim`** — container / worst case:

```vim
vim9script
# Non-scalar-heavy counterpart to scalarbench.vim: hammers copy_tv()/clear_tv()
# on strings, lists and dicts (deepcopy / slice / extend / remove / scope exit),
# so any regression from the scalar fast-path's extra branch on non-scalar
# values would show here.
const OUT = exists('g:BENCH_OUT') ? g:BENCH_OUT : '/tmp/containerbench.txt'
def Build(n: number): list<dict<any>>
  var out: list<dict<any>> = []
  for i in range(n)
    out->add({
      name: 'item_' .. i,
      tag: 'tag_' .. (i % 7),
      vals: [string(i), string(i * 2), string(i * 3)],
      meta: {a: 'x' .. i, b: 'y' .. i},
    })
  endfor
  return out
enddef
def Churn(base: list<dict<any>>): number
  var total = 0
  var c = deepcopy(base)		# copy_tv over every nested string/list/dict
  var s = c[0 : len(c) / 2]		# list slice: copy_tv of dict refs
  c->extend(s)
  for d in c
    total += len(d.name) + len(d.vals)
    for v in d.vals
      total += str2nr(v)		# fold the copied value content, not just its length
    endfor
    if has_key(d, 'meta')
      total += len(d.meta) + len(d.meta.a) + len(d.meta.b)
    endif
  endfor
  while len(c) > 0
    remove(c, 0)			# clear_tv of non-scalar items
  endwhile
  return total
enddef
def Main()
  var iter = 20000
  if exists('g:ITER')
    iter = g:ITER
  endif
  var base = Build(32)
  var t = reltime()
  var acc = 0
  for _ in range(iter)
    acc += Churn(base)
  endfor
  writefile([printf('ITER=%d elapsed=%.3fs check=%d',
    iter, reltimefloat(reltime(t)), acc)], OUT)
enddef
try
  Main()
catch
  writefile(['EXC: ' .. v:exception .. ' @ ' .. v:throwpoint], OUT)
endtry
qall!
```

</details>

AI-assisted; the change is disclosed via the `Co-Authored-By` trailer on the commit, per CONTRIBUTING "Using AI".