### PR TITLE
regression after 9.2.0732: mksession output terminal shell command is not a string.

### DIFF
--- a/src/terminal.c
+++ b/src/terminal.c
@@ -1126,8 +1126,18 @@ term_write_session(FILE *fd, win_T *wp, hashtab_T *terminal_bufs)
     if (fprintf(fd, ".. ' ++type=%s' ", term->tl_job->jv_tty_type) < 0)
 	return FAIL;
 # endif
-    if (term->tl_command != NULL && fputs((char *)term->tl_command, fd) < 0)
-	return FAIL;
+    if (term->tl_command != NULL)
+    {
+	char_u *quoted_command = string_quote(term->tl_command, FALSE);
+	if (quoted_command == NULL)
+	    return FAIL;
+
+	int ret = fputs(".. ' ' .. ", fd) < 0
+		    || fputs((char *)quoted_command, fd) < 0;
+	vim_free(quoted_command);
+	if (ret)
+	    return FAIL;
+    }
     if (put_eol(fd) != OK)
 	return FAIL;
 

--- a/src/testdir/test_mksession.vim
+++ b/src/testdir/test_mksession.vim
@@ -639,6 +639,28 @@ func Test_mksession_terminal_shell_command()
   call delete('Xtest_mks.out')
 endfunc
 
+" Plain :terminal stores no command (tl_command == NULL), so nothing is
+" written after the ':terminal ++curwin ...' line.  Restoring must still
+" produce a running shell terminal.  
+func Test_mksession_terminal_default_restore()
+  CheckFeature terminal
+
+  terminal
+  let term_buf = bufnr()
+  mksession! Xtest_mks.out
+  call StopShellInTerminal(term_buf)
+  %bwipe!
+
+  source Xtest_mks.out
+  let restored = bufnr()
+  call assert_equal('terminal', getbufvar(restored, '&buftype'))
+  call WaitForAssert({-> assert_match('running', term_getstatus(restored))})
+  call StopShellInTerminal(restored)
+
+  %bwipe!
+  call delete('Xtest_mks.out')
+endfunc
+
 func Test_mkview_terminal_windows()
   CheckFeature terminal
 

--- a/src/testdir/test_mksession.vim
+++ b/src/testdir/test_mksession.vim
@@ -641,7 +641,7 @@ endfunc
 
 " Plain :terminal stores no command (tl_command == NULL), so nothing is
 " written after the ':terminal ++curwin ...' line.  Restoring must still
-" produce a running shell terminal.  
+" produce a running shell terminal.
 func Test_mksession_terminal_default_restore()
   CheckFeature terminal
 

--- a/src/testdir/test_mksession.vim
+++ b/src/testdir/test_mksession.vim
@@ -613,6 +613,32 @@ func Test_mksession_terminal_shared_windows()
   call delete('Xtest_mks.out')
 endfunc
 
+func Test_mksession_terminal_shell_command()
+  CheckFeature terminal
+
+  set sessionoptions+=terminal
+  terminal
+  let term_buf = bufnr()
+  eval term_buf->term_setrestore('echo HELLO_WORLD')
+  mksession! Xtest_mks.out
+
+  call StopShellInTerminal(term_buf)
+
+  source Xtest_mks.out
+
+  let restored_buf = bufnr()
+  call assert_equal('terminal', getbufvar(restored_buf, '&buftype'))
+  call WaitForAssert({-> assert_match(
+        \ 'HELLO_WORLD',
+        \ term_getline(restored_buf, 1))})
+  call WaitForAssert({-> assert_match(
+        \ 'finished',
+        \ term_getstatus(restored_buf))})
+
+  bwipe!
+  call delete('Xtest_mks.out')
+endfunc
+
 func Test_mkview_terminal_windows()
   CheckFeature terminal
 


### PR DESCRIPTION
fix: #20788 .