### PR TITLE
fix(tag): tagfunc commands with special chars are truncated

### DIFF
--- a/src/tag.c
+++ b/src/tag.c
@@ -1547,6 +1547,7 @@ find_tagfunc_tags(
 	    }
 	    if (STRCMP(dict_key, "cmd") == 0)
 	    {
+		len += 2; // for ':' and '|'
 		res_cmd = tv->vval.v_string;
 		continue;
 	    }
@@ -1596,8 +1597,11 @@ find_tagfunc_tags(
 	    p += STRLEN(p);
 
 	    *p++ = TAB;
+	    *p++ = ':';
 	    STRCPY(p, res_cmd);
 	    p += STRLEN(p);
+	    *p++ = '|';
+	    *p = NUL;
 
 	    if (has_extra)
 	    {
@@ -3612,6 +3616,8 @@ parse_match(
     p = tagp->command;
     if (find_extra(&p) == OK)
     {
+	if (*tagp->command == ':') // from tagfunc's cmd
+	    ++tagp->command;
 	if (p > tagp->command && p[-1] == '|')
 	    tagp->command_end = p - 1;  // drop trailing bar
 	else
@@ -3781,7 +3787,10 @@ jumpto_tag(
 	    str++;
 	if (find_extra(&str) == OK)
 	{
-	    pbuf_end = str;
+	    if (str[-1] == '|')
+		pbuf_end = str - 1;  // drop trailing bar
+	    else
+		pbuf_end = str;
 	    *pbuf_end = NUL;
 	}
     }

--- a/src/testdir/test_tagfunc.vim
+++ b/src/testdir/test_tagfunc.vim
@@ -456,4 +456,42 @@ func Test_tagfunc_deletes_lines()
   set tagfunc=
 endfunc
 
+" Test for tagfunc with special characters in cmd
+func Test_tagfunc_cmd_special()
+  let s:mytags = [
+          \ {'name': 'a', 'filename': 'Xtest', 'cmd': 'call cursor(3, 5)', 'kind': 'f', 'static': 0},
+          \ {'name': 'a', 'filename': 'Xtest', 'cmd': '3', 'kind': 'f', 'static': 0},
+          \ {'name': 'a', 'filename': 'Xtest', 'cmd': 'normal 3G4|', 'kind': 'f', 'static': 0},
+          \ {'name': 'a', 'filename': 'Xtest', 'cmd': '/pattern/', 'kind': 'f', 'static': 0},
+          \ {'name': 'a', 'filename': 'Xtest', 'cmd': '/pattern', 'kind': 'f', 'static': 0},
+          \ ]
+  func MyTagFunc(pat, flags, info)
+    return s:mytags
+  endfunc
+  set tagfunc=MyTagFunc
+  call assert_equal(s:mytags, taglist('a'))
+  set tagfunc&
+  unlet s:mytags
+  delfunc MyTagFunc
+endfunc
+
+" A tagfunc 'cmd' ending in '|' must execute verbatim on a tag jump.  The
+" ':'/'|' wrapping adds an extra bar that :normal consumes, so the cursor
+" ends at column 1 instead of the intended column 4.
+func Test_tagfunc_cmd_jump_trailing_bar()
+  call writefile(['line one', 'line two', 'abcdefghij'], 'Xtagcmd', 'D')
+  func MyTagFunc(pat, flags, info)
+    return [{'name': 'a', 'filename': 'Xtagcmd', 'cmd': 'normal 3G4|', 'kind': 'f'}]
+  endfunc
+  set tagfunc=MyTagFunc
+
+  enew
+  tag a
+  call assert_equal([3, 4], [line('.'), col('.')])
+
+  bw!
+  set tagfunc=
+  delfunc MyTagFunc
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
```
Problem:  When tagfunc returns a tag with cmd containing special
          characters like ';' or '|', they are incorrectly parsed as
          command separators. This causes the actual command to be
          truncated, breaking tag jumps that use such commands.
Solution: Wrap Ex commands from tagfunc with ':' and '|' prefix/suffix
          in the internal tag format. Skip the leading ':' in
          parse_match() so taglist() returns the original command.
```

fixes: #20781

This is my first patch to Vim core; please let me know if anything needs improvement.