### PR TITLE
Prevent the m4Disabled region from nesting within itself.

### DIFF
--- a/runtime/syntax/m4.vim
+++ b/runtime/syntax/m4.vim
@@ -46,7 +46,7 @@ syn cluster m4Top add=m4Quoted
 "   they simply prevent any macros from being expanded, while the text remains
 "   in the output. This region therefore disables any other matches.
 " – Comments themselves are disabled when quoted.
-syn region m4Disabled start=+#+ end=+$+ containedin=ALLBUT,m4Quoted,m4ParamCount
+syn region m4Disabled start=+#+ end=+$+ containedin=ALLBUT,m4Quoted,m4ParamCount,m4Disabled
 
 " Macros in M4:
 " – Name tokens consist of the longest possible sequence of letters, digits,


### PR DESCRIPTION
Problem: using the `#` character in multiple times creates a nested `m4Disabled` context. This PR prevents nesting the m4Disabled within itself.

See also: [https://www.gnu.org/software/m4/manual/m4.html#Comments](https://www.gnu.org/software/m4/manual/m4.html#Comments)
