### PR TITLE
socketserver: remote commands can be processed in reverse order

### DIFF
--- a/src/socketserver.c
+++ b/src/socketserver.c
@@ -551,11 +551,23 @@ socketserver_accept(channel_T *channel)
     channel->ch_socketserver = true;
     channel->ch_ss_close_cb = socketserver_client_close;
 
-    channel->ch_ss_next = client_channels;
-    channel->ch_ss_prev = NULL;
-    if (client_channels != NULL)
-	client_channels->ch_ss_prev = channel;
-    client_channels = channel;
+    // Append the client, so that commands are processed in the order the
+    // clients were accepted, not reversed.
+    channel->ch_ss_next = NULL;
+    if (client_channels == NULL)
+    {
+	channel->ch_ss_prev = NULL;
+	client_channels = channel;
+    }
+    else
+    {
+	channel_T *last = client_channels;
+
+	while (last->ch_ss_next != NULL)
+	    last = last->ch_ss_next;
+	last->ch_ss_next = channel;
+	channel->ch_ss_prev = last;
+    }
 
     // We will read the command from the client later in the input loop.
     ch_log(NULL, "socketserver: accepted new client");


### PR DESCRIPTION
```
Problem:  When several clients send a command in quick succession, e.g.
          ":drop" from repeated "--remote-tab", the commands can be
          processed in reverse order, so the files open in the wrong
          order.
Solution: The server inserts a newly accepted client at the head of the
          client list, so pending clients are handled newest-first.
          Append the client to the end of the list instead, so they are
          handled in the order they were accepted.
```

related: #20810 (only the tab-ordering part)

---

Reproduces only with a GUI server, where the event loop reads several ready
client sockets in one pass; a terminal server drains them one per select
iteration, so the terminal test harness cannot trigger it -- no automated
test is added.  Verified by hand with gVim.

The separate report of lost tabs with the MS-Windows WM_COPYDATA backend is
not addressed here.