### PR TITLE
fix mismatch between showcmd and count

### DIFF
--- a/src/normal.c
+++ b/src/normal.c
@@ -319,8 +319,8 @@ getcount:
 	// multiplied.
 	if (cap->count0)
 	{
-	    if (cap->opcount >= 999999999L / cap->count0)
-		cap->count0 = 999999999L;
+	    if (cap->opcount >= 2147483647L / cap->count0)
+		cap->count0 = 2147483647L;
 	    else
 		cap->count0 *= cap->opcount;
 	}

--- a/src/normal.c
+++ b/src/normal.c
@@ -214,6 +214,9 @@ check_text_or_curbuf_locked(oparg_T *oap)
     return TRUE;
 }
 
+// declare this function early for use in normal_cmd_get_count
+static void display_showcmd(void);
+
 /*
  * Handle the count before a normal command and set cap->count0.
  */
@@ -241,9 +244,17 @@ getcount:
 		cap->count0 /= 10;
 		del_from_showcmd(4);	// delete the digit and ~@%
 	    }
-	    else if (cap->count0 > 99999999L)
+	    else if (cap->count0 >= 214748364L)
 	    {
-		cap->count0 = 999999999L;
+		if (cap->count0 > 214748364L
+			|| (cap->count0 == 214748364L && c >= '7'))
+		{
+		    cap->count0 = 2147483647L;
+		    mch_memmove(showcmd_buf, "2147483647", 10);
+		    display_showcmd();
+		}
+		else
+		    cap->count0 = cap->count0 * 10 + (c - '0');
 	    }
 	    else
 	    {
@@ -1607,8 +1618,6 @@ may_clear_cmdline(void)
 static char_u	old_showcmd_buf[SHOWCMD_BUFLEN];  // For push_showcmd()
 static int	showcmd_is_clear = TRUE;
 static int	showcmd_visual = FALSE;
-
-static void display_showcmd(void);
 
     void
 clear_showcmd(void)

--- a/src/testdir/test_normal.vim
+++ b/src/testdir/test_normal.vim
@@ -4065,20 +4065,20 @@ func Test_normal_count_out_of_range()
   new
   call setline(1, 'text')
   normal 44444444444|
-  call assert_equal(999999999, v:count)
+  call assert_equal(2147483647, v:count)
   normal 444444444444|
-  call assert_equal(999999999, v:count)
+  call assert_equal(2147483647, v:count)
   normal 4444444444444|
-  call assert_equal(999999999, v:count)
+  call assert_equal(2147483647, v:count)
   normal 4444444444444444444|
-  call assert_equal(999999999, v:count)
+  call assert_equal(2147483647, v:count)
 
   normal 9y99999999|
   call assert_equal(899999991, v:count)
   normal 10y99999999|
-  call assert_equal(999999999, v:count)
+  call assert_equal(2147483647, v:count)
   normal 44444444444y44444444444|
-  call assert_equal(999999999, v:count)
+  call assert_equal(2147483647, v:count)
   bwipe!
 endfunc
 

--- a/src/testdir/test_normal.vim
+++ b/src/testdir/test_normal.vim
@@ -4076,7 +4076,7 @@ func Test_normal_count_out_of_range()
   normal 9y99999999|
   call assert_equal(899999991, v:count)
   normal 10y99999999|
-  call assert_equal(2147483647, v:count)
+  call assert_equal(999999990, v:count)
   normal 44444444444y44444444444|
   call assert_equal(2147483647, v:count)
   bwipe!


### PR DESCRIPTION
this resets the number shown by `:set showcmd` when count has to be capped to prevent overflowing. since `showcmd` only shows exactly 10 characters, and 10 digit numbers fit into count, this gives a count a more exact limit, so old `showcmd` letters don't have to be considered when overwriting `showcmd`.

closes: #20728