### PR TITLE
runtime(doc): document &t_8u as &t_8f and &t_8b are documented

### DIFF
--- a/runtime/doc/term.txt
+++ b/runtime/doc/term.txt
@@ -690,18 +690,20 @@ work the 'termguicolors' option needs to be set.
 See https://github.com/termstandard/colors for a list of terminals that
 support true colors.
 
-For telling the terminal what RGB color to use the |t_8f| and |t_8b| termcap
-entries are used.  These are set by default to values that work for most
-terminals.  If that does not work for your terminal you can set them manually.
-The default values are set like this: >
+For telling the terminal what RGB color to use the |t_8|, |t_8b|, and |t_8u|
+termcap entries are used.  These are set by default to values that work for
+most terminals.  If that does not work for your terminal you can set them
+manually. The default values are set like this: >
 	 let &t_8f = "\<Esc>[38;2;%lu;%lu;%lum"
 	 let &t_8b = "\<Esc>[48;2;%lu;%lu;%lum"
+	 let &t_8u = "\<Esc>[58;2;%lu;%lu;%lum"
 
 Some terminals accept similar sequences, with semicolons replaced by colons
 and an extra colon after the number 2 (this is conformant to the ISO 8613-6
 standard, but less widely supported): >
 	 let &t_8f = "\<Esc>[38:2::%lu:%lu:%lum"
 	 let &t_8b = "\<Esc>[48:2::%lu:%lu:%lum"
+	 let &t_8u = "\<Esc>[58:2::%lu:%lu:%lum"
 
 These options contain printf strings, with |printf()| (actually, its C
 equivalent hence `l` modifier) invoked with the t_ option value and three


### PR DESCRIPTION
Closes #20413

`terminal-output-codes` are out of my depth, but I understand at least this much.

There are 40-odd `terminal-output-codes` defined by Vim, but only the three starting with `t_8` have a default value (for me).

    &t_8f = "\<Esc>[38;2;%lu;%lu;%lum"  # foreground
    &t_8b = "\<Esc>[48;2;%lu;%lu;%lum"  # background
    &t_8u = "\<Esc>[58;2;%lu;%lu;%lum"  # underline

The first two (foreground and background) are mentioned at `:h xterm-true-color`. I found the rest under a table in `:h termcap-options`.

I've updated all three values to the colon form in my vimrc.

    &t_8f = "\<Esc>[38:2::%lu:%lu:%lum"  # foreground
    &t_8b = "\<Esc>[48:2::%lu:%lu:%lum"  # background
    &t_8u = "\<Esc>[58:2::%lu:%lu:%lum"  # underline

After several years using Vim in Windows Terminal, I can't see a difference from setting the two (foreground and background) mentioned specifically at `:h xterm-true-color`.

However, the `&t_8u` underline value (only present in the termcap-options table) causes problems with `set spell` and the `yegappan/lsp` plugin in Windows Terminal. I've added the underline form to the documentation under `:h xterm-true-color`.
