### PR TITLE
'showcmd' not redrawn with empty mapping triggered on timeout

### DIFF
--- a/src/normal.c
+++ b/src/normal.c
@@ -1850,14 +1850,14 @@ display_showcmd(void)
 
     if (*p_sloc == 's')
     {
-	if (showcmd_is_clear)
+	if (showcmd_is_clear && !vgetc_busy)
 	    curwin->w_redr_status = true;
 	else
 	    win_redr_status(curwin, FALSE);
     }
     else if (*p_sloc == 't')
     {
-	if (showcmd_is_clear)
+	if (showcmd_is_clear && !vgetc_busy)
 	    redraw_tabline = TRUE;
 	else
 	    draw_tabline();

--- a/src/testdir/test_statusline.vim
+++ b/src/testdir/test_statusline.vim
@@ -657,23 +657,6 @@ func Test_statusline_showcmd()
   call StopVimInTerminal(buf)
 endfunc
 
-func Test_statusline_showcmd_redraw_tabline()
-  CheckRunVimInTerminal
-
-  let lines =<< trim END
-    set showcmd showcmdloc=tabline showtabline=2 tabline=%S timeoutlen=0
-    nnoremap g :redraw<CR>
-    nnoremap gc <Nop>
-  END
-  call writefile(lines, 'XTest_statusline_showcmd_redraw', 'D')
-
-  let buf = RunVimInTerminal('-S XTest_statusline_showcmd_redraw', #{rows: 6, cols: 40})
-  call term_sendkeys(buf, 'g')
-  call WaitForAssert({-> assert_match(':redraw', term_getline(buf, 6))})
-  call WaitForAssert({-> assert_notmatch('^:', term_getline(buf, 1))})
-  call StopVimInTerminal(buf)
-endfunc
-
 func Test_statusline_showcmd_cmd_mapping()
   set showcmd
   set statusline=AAA%SBBB
@@ -696,6 +679,25 @@ func Test_statusline_showcmd_cmd_mapping()
     set statusline&
     set showcmdloc&
   endtry
+endfunc
+
+func Test_statusline_showcmd_nop_map()
+  CheckRunVimInTerminal
+
+  let lines =<< trim END
+    set timeoutlen=500 showcmdloc=statusline laststatus=2
+    nnoremap <space> <nop>
+    nnoremap <space><space> <nop>
+  END
+  call writefile(lines, 'XTest_statusline_showcmd_nop', 'D')
+
+  let buf = RunVimInTerminal('-S XTest_statusline_showcmd_nop', {'rows': 6})
+  call term_sendkeys(buf, ' ')
+  call WaitForAssert({-> assert_match('<20>', term_getline(buf, 5))}, 400)
+  sleep 500m
+  call WaitForAssert({-> assert_notmatch('<20>', term_getline(buf, 5))}, 400)
+
+  call StopVimInTerminal(buf)
 endfunc
 
 func Test_statusline_highlight_group_cleared()

--- a/src/testdir/test_tabline.vim
+++ b/src/testdir/test_tabline.vim
@@ -213,6 +213,24 @@ func Test_tabline_showcmd()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_tabline_showcmd_redraw_tabline()
+  CheckRunVimInTerminal
+
+  let lines =<< trim END
+    set showcmd showcmdloc=tabline showtabline=2 tabline=%S timeoutlen=0
+    nnoremap g :redraw<CR>
+    nnoremap gc <Nop>
+  END
+  call writefile(lines, 'XTest_tabline_showcmd_redraw', 'D')
+
+  let buf = RunVimInTerminal('-S XTest_tabline_showcmd_redraw', #{rows: 6, cols: 40})
+  call term_sendkeys(buf, 'g')
+  call WaitForAssert({-> assert_match(':redraw', term_getline(buf, 6))})
+  call WaitForAssert({-> assert_notmatch('^:', term_getline(buf, 1))})
+
+  call StopVimInTerminal(buf)
+endfunc
+
 func TruncTabLine()
   return '%1T口口%2Ta' .. repeat('b', &columns - 4) .. '%999X%#TabLine#c'
 endfunc


### PR DESCRIPTION
Problem:  'showcmd' not redrawn with empty mapping triggered on timeout.
Solution: Don't postpone redraw when inside vgetorpeek(). Also move test
          for tabline 'showcmd' to test_tabline.vim.

fixes: #20839
