### PR TITLE
Fix osc52 plugin being used after :gui command

### DIFF
--- a/runtime/pack/dist/opt/osc52/autoload/osc52.vim
+++ b/runtime/pack/dist/opt/osc52/autoload/osc52.vim
@@ -3,6 +3,9 @@ vim9script
 export var allowed: bool = false
 
 export def Available(): bool
+  if has('gui_running')
+    return false
+  endif
   if get(g:, 'osc52_force_avail', 0)
     return true
   endif


### PR DESCRIPTION
`:gui` will query available clipboard methods again, but if the DA1 response is received, the osc52 plugin will always return true for the "available" callback.