### PR TITLE
test: Missing change in test code of patch 9.2.0857

### DIFF
--- a/src/testdir/test_popupwin.vim
+++ b/src/testdir/test_popupwin.vim
@@ -5390,13 +5390,13 @@ func s:do_test_popup_opacity_terminal_close_no_leftover(tabpage)
 
   " A semi-transparent popup over a terminal used to leave the old popup
   " cells behind when it closed.
-  let lines =<< trim END
+  let lines =<< eval trim END
     set shell=/bin/sh noruler
     unlet $PROMPT_COMMAND
     let $PS1 = 'vim> '
     terminal ++curwin
     call popup_create('ABC',
-        \ #{line: 5, col: 10, highlight: 'None', opacity: 30})
+        \ #{{line: 5, col: 10, highlight: 'None', opacity: 30, tabpage: {a:tabpage}}})
     func CloseIt()
       let id = popup_list()[0]
       call popup_close(id)


### PR DESCRIPTION
https://github.com/vim/vim/pull/20848 fixed the problem that closed popup window may remain on window, and introduced a new test suites to check opaque popup windows over terminal windows are properly closed:
- `Test_popup_opacity_global_terminal_close_no_leftover`: Check for popup windows that are shown in every tabpages.
- `Test_popup_opacity_tablocal_terminal_close_no_leftover`: Check for popup windows that are only visible in current tabpage.

And these two test suites are driven by a new test helper function called `s:do_test_popup_opacity_terminal_close_no_leftover()`.
However, due to wrong implementation of the test helper function, the new two test suites actually tests exactly the same thing.  This patch fixes this.