### PR TITLE
GTK4: Queue redraw when draw area bleed changes

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -1727,7 +1727,7 @@ again:
     gui_update_scrollbars(TRUE);
     gui_update_cursor(FALSE, TRUE);
 #if defined(FEAT_GUI_GTK) && defined(USE_GTK4_SNAPSHOT)
-    gui_gtk_calculate_bleed(pixel_width, pixel_height);
+    gui_gtk4_calculate_bleed(pixel_width, pixel_height);
 #endif
 #if defined(FEAT_XIM) && !defined(FEAT_GUI_GTK)
     xim_set_status_area();
@@ -1900,7 +1900,7 @@ gui_set_shellsize(
     gui_reset_scroll_region();
 
 #if defined(FEAT_GUI_GTK) && defined(USE_GTK4_SNAPSHOT)
-    gui_gtk_calculate_bleed(width, height);
+    gui_gtk4_calculate_bleed(width, height);
 #endif
 }
 

--- a/src/gui_gtk4.c
+++ b/src/gui_gtk4.c
@@ -5018,8 +5018,11 @@ gui_mch_set_text_area_pos(int x, int y, int w, int h)
  * after all UI elements are positioned and resized.
  */
     void
-gui_gtk_calculate_bleed(int width, int height)
+gui_gtk4_calculate_bleed(int width, int height)
 {
+    int old_right = gui.bleed_right;
+    int old_bot = gui.bleed_bot;
+
     gui.bleed_right = width - last_text_area_w;
     gui.bleed_bot = height - last_text_area_h;
 
@@ -5035,6 +5038,10 @@ gui_gtk_calculate_bleed(int width, int height)
 	gui.bleed_right = 0;
     if (gui.bleed_bot < 0)
 	gui.bleed_bot = 0;
+
+    // Make sure to update draw area if changed
+    if (old_right != gui.bleed_right || old_bot != gui.bleed_bot)
+	gtk_widget_queue_draw(GTK_WIDGET(gui.drawarea));
 }
 #endif
 

--- a/src/proto/gui_gtk4.pro
+++ b/src/proto/gui_gtk4.pro
@@ -106,7 +106,7 @@ int gui_mch_get_scrollbar_ypadding(void);
 void gui_mch_create_scrollbar(scrollbar_T *sb, int orient);
 void gui_mch_destroy_scrollbar(scrollbar_T *sb);
 void gui_mch_set_text_area_pos(int x, int y, int w, int h);
-void gui_gtk_calculate_bleed(int width, int height);
+void gui_gtk4_calculate_bleed(int width, int height);
 char_u *gui_mch_browse(int saving, char_u *title, char_u *dflt, char_u *ext, char_u *initdir, char_u *filter);
 char_u *gui_mch_browsedir(char_u *title, char_u *initdir);
 int gui_mch_dialog(int type, char_u *title, char_u *message, char_u *buttons, int def_but, char_u *textfield, int ex_cmd);


### PR DESCRIPTION
This makes the bleed smoothly update as the window is resized

Before (see that the updated draw area bleed is finally shown when input is received):
https://github.com/user-attachments/assets/4b865b4c-7190-4e19-a746-dca5289e44c5

After:
https://github.com/user-attachments/assets/b1f532f9-e478-4ebc-beb3-6cb8542e95a0