### PR TITLE
Always resize when in hit enter prompt

### DIFF
--- a/src/term.c
+++ b/src/term.c
@@ -3859,12 +3859,8 @@ set_shellsize(int width, int height, int mustset)
     if (width < 0 || height < 0)    // just checking...
 	return;
 
-    if (State == MODE_HITRETURN || State == MODE_SETWSIZE)
-    {
-	// postpone the resizing
-	State = MODE_SETWSIZE;
+    if (State == MODE_SETWSIZE)
 	return;
-    }
 
     // Avoid recursiveness.  This can happen when setting the window size
     // causes another window-changed signal or when two SIGWINCH signals come


### PR DESCRIPTION
If in a hit enter prompt and the shell size changes, it is supposedly postponed with MODE_SETWSIZE. However that does nothing because its called under the do while loop `wait_return()`, so the loop does not stop, resulting in Vim screen contents being messed up until some input is received (which causes the loop to stop).