### PR TITLE
runtime(tcl): treat xilinx design constraint files as TCL

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -752,7 +752,8 @@ au BufNewFile,BufRead *.mysql,.mysql_history	setf mysql
 " Tcl Shell RC file
 " Vivado journal file records REPL input in tcl syntax
 " Vivado log file records REPL input in tcl syntax and output
-au BufNewFile,BufRead tclsh.rc,vivado*.{jou,log}	setf tcl
+" Xilinx Design Constraints file is a Tcl script
+au BufNewFile,BufRead tclsh.rc,vivado*.{jou,log},*.xdc	setf tcl
 
 " M$ Resource files
 " /etc/Muttrc.d/file.rc is muttrc

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -891,7 +891,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     taskdata: ['pending.data', 'completed.data', 'undo.data'],
     taskedit: ['file.task'],
     tcl: ['file.tcl', 'file.tm', 'file.tk', 'file.itcl', 'file.itk', 'file.jacl', '.tclshrc', 'tclsh.rc', '.wishrc', '.tclsh-history',
-          '.xsctcmdhistory', '.xsdbcmdhistory', 'vivado.jou', 'vivado.log'],
+          '.xsctcmdhistory', '.xsdbcmdhistory', 'vivado.jou', 'vivado.log', 'file.xdc'],
     teal: ['file.tl'],
     templ: ['file.templ'],
     template: ['file.tmpl'],


### PR DESCRIPTION
Refer https://docs.amd.com/r/en-US/ug903-vivado-using-constraints/About-XDC-Constraints