### PR TITLE
Fix link error with gtk2.

### DIFF
--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -4299,7 +4299,7 @@ gui_mch_init(void)
 			   G_CALLBACK(gtk_settings_xft_dpi_changed_cb), NULL);
     }
 
-#ifdef FEAT_IMAGE
+#if defined(FEAT_IMAGE) && GTK_CHECK_VERSION(3,10,0)
     gui.scale = gtk_widget_get_scale_factor(gui.formwin);
 #endif
 


### PR DESCRIPTION
The function `gtk_widget_get_scale_factor()` doesn't exist for gtk2.

```
ld: objects/gui_gtk_x11.o: in function `gui_mch_init': gui_gtk_x11.c:(.text+0x33f1): undefined reference to `gtk_widget_get_scale_factor' 
link.sh: Linking failed
*** Error code 1

Stop.
```

Earlier in the same source file, the use of the function is protected by a `# if GTK_CHECK_VERSION(3,10,0)` so I used the same condition in this case.