### PR TITLE
Cleanup code

### DIFF
--- a/src/auto/configure
+++ b/src/auto/configure
@@ -9177,37 +9177,6 @@ fi
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $enable_fontset" >&5
 printf "%s\n" "$enable_fontset" >&6; }
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if shm_open is available" >&5
-printf %s "checking if shm_open is available... " >&6; }
-cppflags_save=$CPPFLAGS
-CPPFLAGS="$CPPFLAGS $X_CFLAGS"
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-#include <sys/mman.h>
-		    #include <sys/stat.h>
-		    #include <fcntl.h>
-int
-main (void)
-{
-shm_open("/test", O_CREAT, 0600);
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_link "$LINENO"
-then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }; printf "%s\n" "#define HAVE_SHM_OPEN 1" >>confdefs.h
-
-else case e in #(
-  e) { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; } ;;
-esac
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
-    conftest$ac_exeext conftest.$ac_ext
-CPPFLAGS=$cppflags_save
-
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking --with-wayland argument" >&5
 printf %s "checking --with-wayland argument... " >&6; }
 
@@ -9269,6 +9238,9 @@ printf "%s\n" "no" >&6; }
   fi
 CPPFLAGS=$cppflags_save
 CFLAGS=$cflags_save
+else
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
 fi
 
 if test "x$enable_gui" = "xgtk4"; then
@@ -14702,18 +14674,18 @@ then :
 fi
 if test "$enable_largefile,$enable_year2038" != no,no
 then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CPPFLAGS option for large files" >&5
-printf %s "checking for $CPPFLAGS option for large files... " >&6; }
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CC option to enable large file support" >&5
+printf %s "checking for $CC option to enable large file support... " >&6; }
 if test ${ac_cv_sys_largefile_opts+y}
 then :
   printf %s "(cached) " >&6
 else case e in #(
-  e) ac_save_CPPFLAGS=$CPPFLAGS
+  e) ac_save_CC="$CC"
   ac_opt_found=no
-  for ac_opt in "none needed" "-D_FILE_OFFSET_BITS=64" "-D_LARGE_FILES=1"; do
+  for ac_opt in "none needed" "-D_FILE_OFFSET_BITS=64" "-D_LARGE_FILES=1" "-n32"; do
     if test x"$ac_opt" != x"none needed"
 then :
-  CPPFLAGS="$ac_save_CPPFLAGS $ac_opt"
+  CC="$ac_save_CC $ac_opt"
 fi
     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -14742,12 +14714,12 @@ then :
   if test x"$ac_opt" = x"none needed"
 then :
   # GNU/Linux s390x and alpha need _FILE_OFFSET_BITS=64 for wide ino_t.
-	 CPPFLAGS="$CPPFLAGS -DFTYPE=ino_t"
+	 CC="$CC -DFTYPE=ino_t"
 	 if ac_fn_c_try_compile "$LINENO"
 then :
 
 else case e in #(
-  e) CPPFLAGS="$CPPFLAGS -D_FILE_OFFSET_BITS=64"
+  e) CC="$CC -D_FILE_OFFSET_BITS=64"
 	    if ac_fn_c_try_compile "$LINENO"
 then :
   ac_opt='-D_FILE_OFFSET_BITS=64'
@@ -14763,7 +14735,7 @@ fi
 rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
     test $ac_opt_found = no || break
   done
-  CPPFLAGS=$ac_save_CPPFLAGS
+  CC="$ac_save_CC"
 
   test $ac_opt_found = yes || ac_cv_sys_largefile_opts="support not detected" ;;
 esac
@@ -14787,14 +14759,16 @@ printf "%s\n" "#define _FILE_OFFSET_BITS 64" >>confdefs.h
 
 printf "%s\n" "#define _LARGE_FILES 1" >>confdefs.h
  ;; #(
+  "-n32") :
+    CC="$CC -n32" ;; #(
   *) :
     as_fn_error $? "internal error: bad value for \$ac_cv_sys_largefile_opts" "$LINENO" 5 ;;
 esac
 
 if test "$enable_year2038" != no
 then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CPPFLAGS option for timestamps after 2038" >&5
-printf %s "checking for $CPPFLAGS option for timestamps after 2038... " >&6; }
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CC option for timestamps after 2038" >&5
+printf %s "checking for $CC option for timestamps after 2038... " >&6; }
 if test ${ac_cv_sys_year2038_opts+y}
 then :
   printf %s "(cached) " >&6

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -514,9 +514,6 @@
 /* Define if we have flock() */
 #undef HAVE_FLOCK
 
-/* Define if we have shm_open() */
-#undef HAVE_SHM_OPEN
-
 /* Define to inline symbol or empty */
 #undef inline
 

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -2425,17 +2425,6 @@ AC_ARG_ENABLE(fontset,
 AC_MSG_RESULT($enable_fontset)
 dnl defining FEAT_XFONTSET is delayed, so that it can be disabled for no GUI
 
-AC_MSG_CHECKING(if shm_open is available)
-cppflags_save=$CPPFLAGS
-CPPFLAGS="$CPPFLAGS $X_CFLAGS"
-AC_LINK_IFELSE([AC_LANG_PROGRAM(
-		   [#include <sys/mman.h>
-		    #include <sys/stat.h>
-		    #include <fcntl.h>], [shm_open("/test", O_CREAT, 0600);])],
-		   AC_MSG_RESULT(yes); AC_DEFINE(HAVE_SHM_OPEN),
-		   AC_MSG_RESULT(no))
-CPPFLAGS=$cppflags_save
-
 AC_MSG_CHECKING(--with-wayland argument)
 AC_ARG_WITH(wayland,
 	[  --with-wayland	  Include support for the Wayland protocol.],
@@ -2480,6 +2469,8 @@ if test "$with_wayland" = yes; then
   fi
 CPPFLAGS=$cppflags_save
 CFLAGS=$cflags_save
+else
+  AC_MSG_RESULT(no)
 fi
 
 dnl GTK4 does not use X11 APIs directly, so skip X11 detection entirely.

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -26,12 +26,6 @@
 
 #include "os_unixx.h"	    // unix includes for os_unix.c only
 
-#ifdef HAVE_SHM_OPEN
-# include <sys/mman.h>
-# include <sys/stat.h>
-# include <fcntl.h>
-#endif
-
 #ifdef USE_XSMP
 # include <X11/SM/SMlib.h>
 #endif
@@ -9168,44 +9162,3 @@ start_timeout(long msec)
 }
 # endif // PROF_NSEC
 #endif  // FEAT_RELTIME
-
-/*
- * Create an anonymous/temporary file/object and return its file descriptor.
- * Returns -1 on error.
- */
-    int
-mch_create_anon_file(void)
-{
-    int fd = -1;
-#ifdef HAVE_SHM_OPEN
-    const char template[] = "/vimXXXXXX";
-
-    for (int i = 0; i < 100; i++)
-    {
-	mch_get_random((char_u*)template + 4, 6);
-
-	errno = 0;
-	fd = shm_open(template, O_CREAT | O_RDWR | O_EXCL, 0600);
-
-	if (fd >= 0 || errno != EEXIST)
-	    break;
-    }
-    // Remove object name from namespace
-    shm_unlink(template);
-#endif
-    // Last resort
-    if (fd == -1)
-    {
-	char_u	*tempname;
-	// get a name for the temp file
-	if ((tempname = vim_tempname('w', FALSE)) == NULL)
-	{
-	    emsg(_(e_cant_get_temp_file_name));
-	    return -1;
-	}
-	fd = mch_open((char *)tempname, O_CREAT | O_RDWR | O_EXCL, 0600);
-	mch_remove(tempname);
-	vim_free(tempname);
-    }
-    return fd;
-}

--- a/src/proto/os_unix.pro
+++ b/src/proto/os_unix.pro
@@ -95,5 +95,4 @@ void xsmp_close(void);
 void stop_timeout(void);
 volatile sig_atomic_t *start_timeout(long msec);
 void delete_timer(void);
-int mch_create_anon_file(void);
 /* vim: set ft=c : */


### PR DESCRIPTION
- Show "no" result when passing `--without-wayland` configure flag
- Remove mch_open_anon_file() and shm_open checking code, because its not needed anymore (was used for the now defunct focusing stealing feature).