### PR TITLE
MS-Windows: ":language messages" only works once

### DIFF
--- a/src/locale.c
+++ b/src/locale.c
@@ -348,6 +348,10 @@ ex_language(exarg_T *eap)
 	    extern int _nl_msg_cat_cntr;
 
 	    ++_nl_msg_cat_cntr;
+# elif defined(DYNAMIC_GETTEXT)
+	    // Same thing when gettext is loaded at runtime.
+	    if (dyn_libintl_nl_msg_cat_cntr != NULL)
+		++*dyn_libintl_nl_msg_cat_cntr;
 # endif
 	    // Reset $LC_ALL, otherwise it would overrule everything.
 	    vim_setenv((char_u *)"LC_ALL", (char_u *)"");

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -696,6 +696,7 @@ char *(*dyn_libintl_bindtextdomain)(const char *, const char *)
 char *(*dyn_libintl_bind_textdomain_codeset)(const char *, const char *)
 				       = null_libintl_bind_textdomain_codeset;
 int (*dyn_libintl_wputenv)(const wchar_t *) = null_libintl_wputenv;
+int *dyn_libintl_nl_msg_cat_cntr = NULL;
 
     int
 dyn_libintl_init(void)
@@ -770,6 +771,11 @@ dyn_libintl_init(void)
     if (dyn_libintl_wputenv == NULL || dyn_libintl_wputenv == _wputenv)
 	dyn_libintl_wputenv = null_libintl_wputenv;
 
+    // The _nl_msg_cat_cntr variable is optional.  It is used to make gettext
+    // drop the translations it cached.
+    dyn_libintl_nl_msg_cat_cntr = (int *)GetProcAddress(hLibintlDLL,
+							 "_nl_msg_cat_cntr");
+
     return 1;
 }
 
@@ -785,6 +791,7 @@ dyn_libintl_end(void)
     dyn_libintl_bindtextdomain	= null_libintl_bindtextdomain;
     dyn_libintl_bind_textdomain_codeset = null_libintl_bind_textdomain_codeset;
     dyn_libintl_wputenv		= null_libintl_wputenv;
+    dyn_libintl_nl_msg_cat_cntr	= NULL;
 }
 
     static char *

--- a/src/vim.h
+++ b/src/vim.h
@@ -577,6 +577,7 @@ extern char *(*dyn_libintl_bindtextdomain)(const char *domainname, const char *d
 extern char *(*dyn_libintl_bind_textdomain_codeset)(const char *domainname, const char *codeset);
 extern char *(*dyn_libintl_textdomain)(const char *domainname);
 extern int (*dyn_libintl_wputenv)(const wchar_t *envstring);
+extern int *dyn_libintl_nl_msg_cat_cntr;
 #endif
 
 


### PR DESCRIPTION
```
Problem:  On MS-Windows ":language messages" has no effect once messages
          have been translated, the previous language keeps being used.
Solution: Make gettext drop the translations it cached.
```

related: #18622

That report is mainly about the 32-bit build, which is a different problem.
What this fixes is the observation there that ":lan mes" does not change all
messages, with some of them staying in the previous language until Vim is
restarted.

No test is added: gettext() with a domain argument calls textdomain(), which
increments _nl_msg_cat_cntr by itself, so test_gettext_utf8.vim passes even
without this fix although it does switch the message language twice.  Testing
this without a domain argument would need a catalog for the VIMPACKAGE domain,
which bindtextdomain() refuses.