### PR TITLE
"font" in a highlight group has no effect in the GTK GUI

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -5870,6 +5870,8 @@ font={font-name}					*highlight-font*
 	When setting the font for the "Normal" group, this becomes the default
 	font (until the 'guifont' option is changed; the last one set is
 	used).
+	In the GTK GUI, a font can only be set for the "Normal" group; for
+	other groups it is accepted but has no effect.
 	The following only works with Motif, not with other GUIs:
 	When setting the font for the "Menu" group, the menus will be changed.
 	When setting the font for the "Tooltip" group, the tooltips will be
@@ -5880,7 +5882,7 @@ font={font-name}					*highlight-font*
 	To use a font name with an embedded space or other special character,
 	put it in single quotes.  The single quote cannot be used then.
 	Example: >
-	    :hi comment font='Monospace 10'
+	    :hi Normal font='Monospace 10'
 
 guifg={color-name}					*highlight-guifg*
 guibg={color-name}					*highlight-guibg*


### PR DESCRIPTION
```
Problem:  It is not documented that in the GTK GUI the "font" item of a
          highlight group only works for the "Normal" group.  The example
          even uses another group, so it does not work there.
Solution: Mention the restriction and use the "Normal" group in the
          example.
```