### PR TITLE
popup width rule is documented incorrectly

### DIFF
--- a/runtime/doc/popup.txt
+++ b/runtime/doc/popup.txt
@@ -79,9 +79,11 @@ wrapping, lines in the buffer.  It can be limited with the "maxheight"
 property.  You can use empty lines to increase the height or the "minheight"
 property.
 
-The width of the window is normally equal to the longest visible line in the
-buffer.  It can be limited with the "maxwidth" property.  You can use spaces
-to increase the width or use the "minwidth" property.
+The width of the window is normally equal to the longest line in the buffer,
+also when that line is not displayed.  This keeps the width the same while
+scrolling through the popup.  It can be limited with the "maxwidth" property,
+which is a good idea when the buffer may contain long lines.  You can use
+spaces to increase the width or use the "minwidth" property.
 
 By default the 'wrap' option is set, so that no text disappears.  Otherwise,
 if there is not enough space then the window is shifted left in order to

--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -2700,7 +2700,8 @@ popup_adjust_position(win_T *wp)
 	else
 	    ++lnum;
 
-	// do not use the width of lines we're not going to show
+	// stop at the last line that is going to be shown; the width was
+	// already computed above from every buffer line
 	if (maxheight > 0
 		   && (wp->w_firstline >= 0
 			       ? lnum - wp->w_topline


### PR DESCRIPTION
```
Problem:  The documentation says the width of a popup window is equal to
          the longest visible line, while since 9.2.0419 it is the
          longest line in the buffer, also when that line is not
          displayed.
Solution: Update the documentation and correct a comment that says
          otherwise.
```

---

### Notes

Reported on vim_use:
https://groups.google.com/g/vim_use/c/_rOLxGz5kNM

related: #20042 (9.2.0419)  (cc: @mattn )
No. 2 of #20042 changed the width to be computed from every buffer line so that
it does not change while scrolling through the popup, which matters when
scrolling with the mouse: a popup that changes width under the pointer
moves out from under it.  This also matches the popup menu, which sizes
itself to the longest of all its items.  The documentation was not
updated at the time, so the behaviour looked like "maxwidth is ignored".

No test is added: Test_popup_firstline_dump() already covers the rule,
its screen dump was updated by 9.2.0419 for exactly this reason.

