### PR TITLE
screen line is lost when splitting a 'winfixheight' window

### DIFF
--- a/src/testdir/test_window_cmd.vim
+++ b/src/testdir/test_window_cmd.vim
@@ -2481,6 +2481,23 @@ func Test_winfixheight_resize_wmh_zero()
   set winminheight& laststatus&
 endfunc
 
+" Splitting the only window while it has 'winfixheight' set and 'laststatus' is
+" one must not leave a screen line unused.
+func Test_winfixheight_split_only_window()
+  set laststatus=1
+  new
+  only!
+  setlocal winfixheight
+  split
+  " Two windows, both with a status line, and the command line.
+  call assert_equal(&lines - &cmdheight - 2, winheight(1) + winheight(2))
+
+  only!
+  setlocal winfixheight&
+  set laststatus&
+  bwipe!
+endfunc
+
 " Test that setting 'laststatus' from 0 to 2 gives all windows in a vertical
 " split (FR_ROW) the same height and correct status line position.
 func Test_laststatus_vsplit_row_height()

--- a/src/window.c
+++ b/src/window.c
@@ -1232,9 +1232,8 @@ win_split_ins(
 
 	    win_setheight_win(oldwin->w_height + new_size
 		    + statusline_height(oldwin), oldwin);
+	    // w_height now excludes the status line
 	    oldwin_height = oldwin->w_height;
-	    if (need_status)
-		oldwin_height -= statusline_height(oldwin);
 	}
 
 	// Only make all windows the same height if one of them (except oldwin)


### PR DESCRIPTION
```
Problem:  When the only window has 'winfixheight' set and 'laststatus'
          is one, splitting it leaves one screen line unused.  This
          happens for example when jumping to an item from a maximized
          quickfix window.
Solution: Do not subtract the height of the status line twice.
```

fixes: #20495

---

The report asks for the same handling as 9.2.0581 in qf_jump*, but this
is not specific to quickfix.  Any window reproduces it: >
      :setlocal winfixheight
      :split
The quickfix window only stands out because ":copen" sets
'winfixheight' for you.

The height requested from win_setheight_win() already includes room for
the status line, and win_setheight_win() fits the result into the frame,
so subtracting the status line height again loses one line.  This only
shows when the window has no status line yet, which is the case when it
is the only window and 'laststatus' is one, and then the window can
never grow, so the line is always lost.

make test_window_cmd and make test_quickfix pass.