### PR TITLE
Vim9: cannot use a script variable of an enclosing block in a lambda

### DIFF
--- a/src/testdir/test_vim9_script.vim
+++ b/src/testdir/test_vim9_script.vim
@@ -449,6 +449,24 @@ def Test_block_local_vars_with_func()
       assert_equal(['foo', 'bar'], Func())
   END
   v9.CheckScriptSuccess(lines)
+
+  # also when the variables are used in a lambda inside the function
+  lines =<< trim END
+      vim9script
+      if true
+        var foo = 'foo'
+        if true
+          var bar = 'bar'
+          def Func(): list<string>
+            var Lambda = () => [foo, bar]
+            return Lambda()
+          enddef
+          defcompile
+        endif
+      endif
+      assert_equal(['foo', 'bar'], Func())
+  END
+  v9.CheckScriptSuccess(lines)
 enddef
 
 " legacy func for command that's defined later

--- a/src/vim9expr.c
+++ b/src/vim9expr.c
@@ -1795,9 +1795,26 @@ compile_lambda(char_u **arg, cctx_T *cctx)
     clear_tv(&rettv);
 
     if (cctx->ctx_ufunc != NULL)
+    {
 	// This lambda might be defined in a class method.  Inherit the class
 	// from the current function.
 	ufunc->uf_defclass = cctx->ctx_ufunc->uf_defclass;
+
+	// Copy over the block scope IDs, so that a script variable declared in
+	// an enclosing block can be found.
+	int block_depth = cctx->ctx_ufunc->uf_block_depth;
+
+	if (block_depth > 0)
+	{
+	    ufunc->uf_block_ids = ALLOC_MULT(int, block_depth);
+	    if (ufunc->uf_block_ids != NULL)
+	    {
+		mch_memmove(ufunc->uf_block_ids, cctx->ctx_ufunc->uf_block_ids,
+						    sizeof(int) * block_depth);
+		ufunc->uf_block_depth = block_depth;
+	    }
+	}
+    }
 
     // Compile it here to get the return type.  The return type is optional,
     // when it's missing use t_unknown.  This is recognized in


### PR DESCRIPTION
```
Problem:  Vim9: E1001 when a lambda inside a :def function uses a script
          variable that was declared in an enclosing block, while the :def
          function itself can use it (neoharju)
Solution: Copy the block scope IDs to the lambda, like it is done for a
          nested function.
```

fixes #20876

---

### Notes

A script variable declared inside a block gets that block's ID, and
find_script_var() only finds it when the function being compiled records the
same ID.  A :def function gets those IDs from the condition stack when it is
defined, and a nested :def gets them from the enclosing function, but
compile_lambda() only inherited the class, not the block IDs.

compile_lambda() does not set "eval_cstack", so function_using_block_scopes()
does nothing for a lambda and the block IDs have to come from the enclosing
function.