### PR TITLE
popup: "maxwidth" is not respected when 'wrap' is off

### DIFF
--- a/src/popupwin.c
+++ b/src/popupwin.c
@@ -2665,10 +2665,9 @@ popup_adjust_position(win_T *wp)
 		shift_by -= truncate_shift;
 	    }
 
-	    // When wrapping is enabled and maxwidth is explicitly set,
-	    // don't shift beyond maxwidth - let the text wrap instead.
-	    if (wp->w_p_wrap && wp->w_maxwidth > 0
-				    && maxwidth + shift_by > wp->w_maxwidth)
+	    // When maxwidth is explicitly set, don't shift beyond it, the text
+	    // is wrapped or truncated instead.
+	    if (wp->w_maxwidth > 0 && maxwidth + shift_by > wp->w_maxwidth)
 		shift_by = wp->w_maxwidth - maxwidth;
 
 	    if (shift_by > 0)

--- a/src/testdir/test_popupwin.vim
+++ b/src/testdir/test_popupwin.vim
@@ -2203,6 +2203,44 @@ func Test_popup_wrap_with_maxwidth()
   %bwipe!
 endfunc
 
+func Test_popup_nowrap_with_maxwidth()
+  " When wrap is off and maxwidth is explicitly set, a popup near the right
+  " edge of the screen must not get wider than maxwidth by shifting left.
+  let maxw = 20
+  let col = &columns - maxw + 1
+
+  " Text longer than maxwidth is truncated, no shift is needed.
+  let p = popup_create(repeat('x', 40), #{
+	\ line: 5, col: col, maxwidth: maxw, wrap: 0})
+  call s:VerifyPosition(p, 'nowrap with maxwidth at right edge',
+	\ 5, col, maxw, 1)
+  call popup_close(p)
+
+  " Not enough space at the right: shift left, but only up to maxwidth.
+  let p = popup_create(repeat('y', 40), #{
+	\ line: 5, col: &columns - 5, maxwidth: maxw, wrap: 0})
+  call s:VerifyPosition(p, 'nowrap with maxwidth shifts up to maxwidth',
+	\ 5, col, maxw, 1)
+  call popup_close(p)
+
+  " Same with a border and padding.
+  let p = popup_create(repeat('z', 40), #{
+	\ line: 5, col: &columns - 5, maxwidth: maxw, wrap: 0,
+	\ border: [], padding: [0, 1, 0, 1]})
+  call assert_equal(maxw, popup_getpos(p).core_width)
+  call popup_close(p)
+
+  " When maxwidth is not set, shift-left uses the whole text width.
+  let p = popup_create(repeat('w', 40), #{
+	\ line: 5, col: col, wrap: 0})
+  call s:VerifyPosition(p, 'nowrap without maxwidth shifts left',
+	\ 5, col - maxw, 40, 1)
+  call popup_close(p)
+
+  call popup_clear()
+  %bwipe!
+endfunc
+
 func Test_adjust_left_past_screen_width()
   " width of screen
   let X = join(map(range(&columns), {->'X'}), '')


### PR DESCRIPTION
```
Problem:  A popup window can become wider than "maxwidth" when 'wrap' is
          off and the popup is near the right edge of the screen.
Solution: Do not shift the popup leftwards beyond "maxwidth", truncate the
          text instead, like it is done when 'wrap' is on.
```

Reported on vim_use:
https://groups.google.com/g/vim_use/c/_rOLxGz5kNM/m/JFt7d81QCQAJ

---

When 'wrap' is off and the popup is near the right edge of the screen, the
popup is made as wide as the longest text line and "maxwidth" has no effect.
With a 120 column screen:

    call popup_create([repeat('x', 93)],
                \ #{line: 3, col: 80, maxwidth: 50, wrap: 0, border: []})

Before this change the popup is drawn 93 cells wide and popup_getpos()
reports core_width 93 instead of 50.  The same happens with popup_atcursor()
when the cursor is near the right edge, with a popup anchored to a text
property, and after moving a popup to the right with popup_move().

The popup is shifted leftwards to make the text fit on the screen.  This
shift is skipped only when "maxwidth" is smaller than the space left of the
right edge, so close to the right edge the shift raises the width limit
itself.  Patch 9.2.0247 added a check against this, but only for 'wrap'
being on.

The overflow is not new, but since patch 9.2.0419 reserves room for the
right border and padding in the available space, the range of positions
where it shows up got wider by that amount.

No documentation change is needed, popup.txt already describes "maxwidth"
as the maximum width of the contents.