### PR TITLE
scroll: 'smoothscroll' position is lost when the window height changes

### DIFF
--- a/src/testdir/test_scroll_opt.vim
+++ b/src/testdir/test_scroll_opt.vim
@@ -1306,6 +1306,30 @@ func Test_smoothscroll_next_topline()
   bwipe!
 endfunc
 
+func Test_smoothscroll_keep_skipcol()
+  call NewWindow(10, 40)
+  setlocal smoothscroll
+  call setline(1, ['abcde '->repeat(150)]->repeat(2))
+
+  exe "norm! 10\<C-E>"
+  redraw
+  let skipcol = winsaveview().skipcol
+  call assert_notequal(0, skipcol)
+
+  " Changing the height of the window must not reset the scroll position.
+  resize -3
+  resize +3
+  redraw
+  call assert_equal(skipcol, winsaveview().skipcol)
+
+  " Using the autocommand window changes the height as well.
+  call bufload(bufadd(''))
+  redraw
+  call assert_equal(skipcol, winsaveview().skipcol)
+
+  bwipe!
+endfunc
+
 func Test_smoothscroll_long_line_zb()
   call NewWindow(10, 40)
   call setline(1, 'abcde '->repeat(150))

--- a/src/window.c
+++ b/src/window.c
@@ -7413,7 +7413,10 @@ win_new_height(win_T *wp, int height)
     // values might be invalid.
     if (!exiting && *p_spk == 'c')
     {
-	wp->w_skipcol = 0;
+	// With 'smoothscroll' w_skipcol is the scroll position, keep it.
+	// Otherwise it only keeps the cursor visible and is computed again.
+	if (!wp->w_p_sms)
+	    wp->w_skipcol = 0;
 	scroll_to_fraction(wp, prev_height);
     }
 }
@@ -7469,14 +7472,16 @@ scroll_to_fraction(win_T *wp, int prev_height)
 	    if (wp->w_wrow >= wp->w_height
 				       && (wp->w_width - win_col_off(wp)) > 0)
 	    {
-		wp->w_skipcol += wp->w_width - win_col_off(wp);
+		// The cursor must be visible, override the scroll position.
+		colnr_T	skipcol = wp->w_width - win_col_off(wp);
+
 		--wp->w_wrow;
 		while (wp->w_wrow >= wp->w_height)
 		{
-		    wp->w_skipcol += wp->w_width - win_col_off(wp)
-							   + win_col_off2(wp);
+		    skipcol += wp->w_width - win_col_off(wp) + win_col_off2(wp);
 		    --wp->w_wrow;
 		}
+		wp->w_skipcol = skipcol;
 	    }
 	}
 	else if (sline > 0)


### PR DESCRIPTION
```
Problem:  With 'smoothscroll' the scroll position of a window is lost when
          its height changes.
Solution: Only reset the skipped columns when 'smoothscroll' is off, where
          they just serve to keep the cursor visible.
```

---

The height changes for ":split" and ":close", a 'cmdheight' change,
":resize" and every use of the autocommand window.

win_new_height() has reset w_skipcol since the Vim 7 import, when it only
existed to keep the cursor visible in a line too long for the window.  With
'smoothscroll', added in patch 9.0.0640, it is the scroll position itself.

Found while investigating #12085, but a different problem: any height change
loses the position, not just the autocommand window.  The todo.txt entry is
left untouched here to avoid a conflict with #20884.

Not fixed by this: ":help" followed by ":close", where the window is
squeezed to one line in between and the position cannot be kept, and
'splitkeep' "screen", which does not use this code path.