### PR TITLE
runtime(doc): update todo for the remaining 'smoothscroll' scroll position

### DIFF
--- a/runtime/doc/todo.txt
+++ b/runtime/doc/todo.txt
@@ -40,10 +40,13 @@ Mapping with modifier is not recognized after a partial mapping.  Probably
 because the typeahead was simplified when looking for a matching mapping.
 Need to somehow undo the simplification.  #12002
 
-Using the autocmd window resets w_skipcol when the cursor is in a long
-wrapped line.  In restore_snapshot_rec() restore more values from the
-snapshot, instead of calling frame_new_height() and frame_new_width(),
-especially w_skipcol.
+With 'smoothscroll' the scroll position is lost when a window is temporarily
+squeezed to a couple of lines, for example ":help" followed by ":close".  In
+restore_snapshot_rec() restore more values from the snapshot, instead of
+calling frame_new_height() and frame_new_width(), especially w_skipcol.
+
+With 'splitkeep' "screen" the scroll position is lost when splitting and
+closing a window, win_fix_cursor() moves the cursor to another line.
 
 Check places that source "path/*.vim" to not match other extensions, e.g.
 .vim9, on MS-Windows (short file name match, gets expanded to long file name).


### PR DESCRIPTION
The autocommand window no longer resets the scroll position since patch 9.2.0881.  What is left is a window that is temporarily squeezed to a couple of lines, and 'splitkeep' "screen".