### PR TITLE
:bwipe crashes if WinLeave wipes all other buffers

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -1653,7 +1653,8 @@ do_buffer_ext(
 		buf = curbuf->b_next;
 	    else
 		buf = curbuf->b_prev;
-	    if (bt_quickfix(buf) || (buf != curbuf && buf->b_locked_split))
+	    if (bt_quickfix(buf)
+		    || (buf != NULL && buf != curbuf && buf->b_locked_split))
 		buf = NULL;
 	}
     }

--- a/src/testdir/test_buffer.vim
+++ b/src/testdir/test_buffer.vim
@@ -935,6 +935,13 @@ func Test_split_window_in_BufLeave_from_switching_buffer()
   bwipe! Xb
 endfunc
 
+func Test_wipe_other_buffers_in_WinLeave_from_bwipe()
+  tabnew
+  autocmd WinLeave * ++once 1,$-1bwipe!
+  " This should not crash
+  $bwipe!
+endfunc
+
 " Switch to a buffer whose name contains '%' via completion (#20529).
 func Test_buffer_switch_to_name_with_percent()
   CheckMSWindows


### PR DESCRIPTION
Problem:  :bwipe crashes if WinLeave wipes all other buffers (after
          9.1.2068).
Solution: Check for NULL pointer.

related: neovim/neovim#41066
