### PR TITLE
scroll: unreachable 'smoothscroll' code in cursor_correct()

### DIFF
--- a/src/move.c
+++ b/src/move.c
@@ -3114,19 +3114,6 @@ cursor_correct(void)
 	    )
 	return;
 
-    if (curwin->w_p_sms && !curwin->w_p_wrap)
-    {
-	// 'smoothscroll' is active
-	if (curwin->w_cline_height == curwin->w_height)
-	{
-	    // The cursor line just fits in the window, don't scroll.
-	    reset_skipcol();
-	    return;
-	}
-	// TODO: If the cursor line doesn't fit in the window then only adjust
-	// w_skipcol.
-    }
-
     /*
      * Narrow down the area where the cursor can be put by taking lines from
      * the top and the bottom until:


### PR DESCRIPTION
```
Problem:  cursor_correct() checks for 'smoothscroll' with 'wrap' off, a
          combination where 'smoothscroll' has no effect.
Solution: Remove the check, adjust_skipcol() already handles the case where
          the cursor line just fits in the window.
```

---

Found while auditing the places that reset w_skipcol.  The check requires
'wrap' to be off, where 'smoothscroll' has no effect, so it never runs.
Removing it does not change behaviour: 20 cases of 'smoothscroll' with
'nowrap' in a one line window give identical results before and after.