### PR TITLE
scroll: 'smoothscroll' position is lost when the window is squeezed

### DIFF
--- a/src/move.c
+++ b/src/move.c
@@ -2537,9 +2537,23 @@ scroll_cursor_top(int min_scroll, int always)
 	{
 	    validate_virtcol();
 	    if (curwin->w_skipcol >= curwin->w_virtcol)
-		// TODO: if the line doesn't fit may optimize w_skipcol instead
-		// of making it zero
-		reset_skipcol();
+	    {
+		// Skip up to the screen line the cursor is in, so that the
+		// position in the line is kept.
+		int	width1 = curwin->w_width - curwin_col_off();
+		int	width2 = width1 + curwin_col_off2();
+		int	plines_off = 0;
+		int	skipcol;
+
+		if (width2 > 0 && curwin->w_virtcol >= (colnr_T)width1)
+		    plines_off = (curwin->w_virtcol - width1) / width2 + 1;
+		skipcol = skipcol_from_plines(curwin, plines_off);
+		if (skipcol != curwin->w_skipcol)
+		{
+		    curwin->w_skipcol = skipcol;
+		    redraw_later(UPD_SOME_VALID);
+		}
+	    }
 	}
 	if (curwin->w_topline != old_topline
 		|| curwin->w_skipcol != old_skipcol

--- a/src/testdir/test_scroll_opt.vim
+++ b/src/testdir/test_scroll_opt.vim
@@ -1330,6 +1330,27 @@ func Test_smoothscroll_keep_skipcol()
   bwipe!
 endfunc
 
+func Test_smoothscroll_squeezed_window()
+  setlocal smoothscroll
+  call setline(1, [repeat('x', 3000)] + repeat(['line'], 10))
+  exe "norm! gg10\<C-E>"
+  redraw
+  let skipcol = winsaveview().skipcol
+  call assert_notequal(0, skipcol)
+  let virtcol = virtcol('.')
+
+  " Squeezing the window to one line and restoring it must not scroll back to
+  " the start of the line.
+  new
+  wincmd _
+  close
+  redraw
+  call assert_notequal(0, winsaveview().skipcol)
+  call assert_equal(virtcol, virtcol('.'))
+
+  bwipe!
+endfunc
+
 func Test_smoothscroll_long_line_zb()
   call NewWindow(10, 40)
   call setline(1, 'abcde '->repeat(150))


### PR DESCRIPTION
```
Problem:  With 'smoothscroll' the scroll position in a long line is lost when
          a window is temporarily squeezed to a couple of lines, for example
          when opening and closing a help window.
Solution: When the cursor ends up in the skipped columns, skip up to the
          screen line the cursor is in instead of showing the start of the
          line.
```

---

To reproduce, with 'smoothscroll' and a line longer than the window:

    exe "norm! gg10\<C-E>"
    new
    wincmd _
    close

The window was scrolled back to the start of the line.  ":help" followed by
":close" does the same when the help window leaves little room.

Not fixed by this: while the window is squeezed the skipped columns are
adjusted to keep the cursor visible, which is correct, so the position can
end up one screen line off.  Restoring it exactly needs the saved values
that the todo.txt entry asks for, that entry stays as it is.