### PR TITLE
gtk3(dialog): avoid FocusGained on close

### DIFF
--- a/src/gui.h
+++ b/src/gui.h
@@ -422,6 +422,7 @@ typedef struct Gui
 # ifdef FEAT_GUI_DIALOG
     // Multiple dialogs not allowed, just tracked for future use.
     int		dialogs_active;     // number of active GUI dialogs
+    // Suppress focus-in event when focus returns.
     int		dialog_focus_pending;
 # endif
     bool	is_x11;	            // active gdk backend in gtk is x11

--- a/src/gui.h
+++ b/src/gui.h
@@ -422,8 +422,6 @@ typedef struct Gui
 # ifdef FEAT_GUI_DIALOG
     // Multiple dialogs not allowed, just tracked for future use.
     int		dialogs_active;     // number of active GUI dialogs
-
-    // X11 focus_in_event() by dialogs, ignored to match wayland.
     int		dialog_focus_pending;
 # endif
     bool	is_x11;	            // active gdk backend in gtk is x11

--- a/src/gui_gtk.c
+++ b/src/gui_gtk.c
@@ -1710,8 +1710,6 @@ gui_mch_dialog(int	type,	    // type of dialog
     DialogInfo  dialoginfo;
 
     ++gui.dialogs_active;
-    if (gui.is_x11)
-	++gui.dialog_focus_pending;
 
     dialog = create_message_dialog(type, title, message);
     dialoginfo.dialog = GTK_DIALOG(dialog);
@@ -1798,7 +1796,8 @@ gui_mch_dialog(int	type,	    // type of dialog
 	gtk_widget_destroy(dialog);
     }
 
-    --gui.dialogs_active;
+    if (gui.dialogs_active > 0)
+	--gui.dialogs_active;
     return response > 0 ? response : 0;
 }
 

--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -1089,8 +1089,13 @@ focus_in_event(GtkWidget *widget,
 	       gpointer data UNUSED)
 {
 #ifdef FEAT_GUI_DIALOG
-    if (gui.is_x11 && gui.dialog_focus_pending > 0)
+    if (gui.dialog_focus_pending)
+    {
 	--gui.dialog_focus_pending;
+	++hold_gui_events;
+	gui_focus_change(TRUE);
+	--hold_gui_events;
+    }
     else
 #endif
 	gui_focus_change(TRUE);
@@ -1111,6 +1116,11 @@ focus_out_event(GtkWidget *widget UNUSED,
 		GdkEventFocus *event UNUSED,
 		gpointer data UNUSED)
 {
+    if (gui.dialogs_active > 0)
+    {
+      ++gui.dialog_focus_pending;
+    }
+
     gui_focus_change(FALSE);
 
     if (blink_state != BLINK_NONE)

--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -1089,7 +1089,7 @@ focus_in_event(GtkWidget *widget,
 	       gpointer data UNUSED)
 {
 #ifdef FEAT_GUI_DIALOG
-    if (gui.dialog_focus_pending)
+    if (gui.dialog_focus_pending > 0)
     {
 	--gui.dialog_focus_pending;
 	++hold_gui_events;
@@ -1116,10 +1116,10 @@ focus_out_event(GtkWidget *widget UNUSED,
 		GdkEventFocus *event UNUSED,
 		gpointer data UNUSED)
 {
+#ifdef FEAT_GUI_DIALOG
     if (gui.dialogs_active > 0)
-    {
-      ++gui.dialog_focus_pending;
-    }
+	++gui.dialog_focus_pending;
+#endif
 
     gui_focus_change(FALSE);
 


### PR DESCRIPTION
**Problem:**

Still not consistent.

**Solution:**

Hold gui events while dialog active.

also simplify handling and correct wrong comment.

*Possibly related: https://github.com/vim/vim/pull/20727 (could have changed behaviour since my initial PR causing the disconnect - not verified as `POPUP_HINT` generally was a bad fix with many side-effects directly affecting `events`-layering in gtk, particularly worsened with vim's idioms of manual pushing `g_main_context_iteration`)

*Related issue* #20907 
postponed for later: Visual selection can happen when focusing the main window.

Sorry to whom it might have affected!