### PR TITLE
scroll: jump-scrolling when moving the cursor onto a wrapping line

### DIFF
--- a/runtime/doc/todo.txt
+++ b/runtime/doc/todo.txt
@@ -64,9 +64,6 @@ Virtual text problems:
 When 'virtualedit' is "all" and 'cursorcolumn' is set, the wrong column may be
 highlighted. (van-de-bugger, 2018 Jan 23, #2576)
 
-With 'smoothscroll' set and "lastline" in 'display', moving the cursor to a
-wrapping line that makes the display scroll up may scroll much more than
-needed, thus jump-scrolling. (part of issue 12411)
 Errors when running tests with valgrind:
 - test_codestyle.vim:  e.g.:
     command line..script /home/mool/vim/vim91/src/testdir/runtest.vim[569]..function RunTheTest[52]..Test_test_files line 6: keycode_check.vim: space before tab: Expected 0 but got 7

--- a/src/move.c
+++ b/src/move.c
@@ -2687,6 +2687,15 @@ scroll_cursor_bot(int min_scroll, int set_topbot)
     used = curwin->w_cline_height;
 #endif
 
+    if (do_sms && (dy_flags & DY_LASTLINE))
+    {
+	// The rest of the cursor line may be cut off at the bottom.
+	int upto_cursor = plines_win_col(curwin, cln, curwin->w_cursor.col);
+
+	if (upto_cursor < used)
+	    used = upto_cursor;
+    }
+
     // If the cursor is on or below botline, we will at least scroll by the
     // height of the cursor line, which is "used".  Correct for empty lines,
     // which are really part of botline.

--- a/src/testdir/test_scroll_opt.vim
+++ b/src/testdir/test_scroll_opt.vim
@@ -1330,6 +1330,26 @@ func Test_smoothscroll_keep_skipcol()
   bwipe!
 endfunc
 
+func Test_smoothscroll_lastline_no_jump()
+  call NewWindow(10, 40)
+  setlocal smoothscroll
+  set display=lastline
+  call setline(1, map(range(1, 9), {i, v -> 'short ' .. v})
+        \ + [repeat('long ', 60)] + repeat(['tail'], 5))
+  normal! gg
+  redraw
+  call assert_equal(1, line('w0'))
+
+  " The first screen line of the wrapping line is already visible.
+  normal! 9j
+  redraw
+  call assert_equal(10, line('.'))
+  call assert_equal(1, line('w0'))
+
+  set display&
+  bwipe!
+endfunc
+
 func Test_smoothscroll_long_line_zb()
   call NewWindow(10, 40)
   call setline(1, 'abcde '->repeat(150))


### PR DESCRIPTION
```
Problem:  With 'smoothscroll' and "lastline" in 'display', moving the cursor
          to a wrapping line scrolls much more than needed.
Solution: Only require the screen lines up to the cursor to be visible, the
          rest of the line can be cut off at the bottom.
```

related: #12411

---

With 'smoothscroll' and "lastline" in 'display', moving the cursor to a
wrapping line below the window scrolled far enough to show the whole line.
The first screen line of that line was already visible, so no scrolling was
needed.

Without "lastline" the line cannot be shown partially, so the behaviour there
is unchanged.