### PR TITLE
feat(osc52) clipboard

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -13252,6 +13252,7 @@ cindent			Compiled with 'cindent' support. (always true)
 clientserver		Compiled with remote invocation support |clientserver|.
 clipboard		Compiled with 'clipboard' support.
 clipboard_working	Compiled with 'clipboard' support and it can be used.
+osc52	                Compiled with 'osc52' clipboard support.
 cmdline_compl		Compiled with |cmdline-completion| support.
 cmdline_hist		Compiled with |cmdline-history| support.
 cmdline_info		Compiled with 'showcmd' and 'ruler' support.

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -490,6 +490,9 @@
 /* Define to include OSC 52 tiny clipboard support. */
 #undef FEAT_CLIPBOARD_OSC52_TINY
 
+/* Define to use OSC 52 as the only clipboard backend. */
+#undef FEAT_CLIPBOARD_OSC52_ONLY
+
 /* Define if we have AvailabilityMacros.h on Mac OS X */
 #undef HAVE_AVAILABILITYMACROS_H
 

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -484,6 +484,12 @@
 /* Define if you want Cygwin to use the WIN32 clipboard, not compatible with X11*/
 #undef FEAT_CYGWIN_WIN32_CLIPBOARD
 
+/* Define to include OSC 52 clipboard support. */
+#undef FEAT_CLIPBOARD_OSC52
+
+/* Define to include OSC 52 tiny clipboard support. */
+#undef FEAT_CLIPBOARD_OSC52_TINY
+
 /* Define if we have AvailabilityMacros.h on Mac OS X */
 #undef HAVE_AVAILABILITYMACROS_H
 

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -2425,7 +2425,6 @@ AC_LINK_IFELSE([AC_LANG_PROGRAM(
 		   AC_MSG_RESULT(yes); AC_DEFINE(HAVE_SHM_OPEN),
 		   AC_MSG_RESULT(no))
 CPPFLAGS=$cppflags_save
-
 AC_MSG_CHECKING(--with-wayland argument)
 AC_ARG_WITH(wayland,
 	[  --with-wayland	  Include support for the Wayland protocol.],
@@ -2435,6 +2434,22 @@ AC_ARG_WITH(wayland,
 			 AC_MSG_RESULT([cannot use wayland with tiny features])],
 			[with_wayland=yes
 			 AC_MSG_RESULT([yes])]))
+
+dnl OSC 52 clipboard support.
+AC_MSG_CHECKING(--enable-osc52 argument)
+AC_ARG_ENABLE(osc52,
+ [  --enable-osc52[=OPTS]     OSC 52 Clipboard [default=yes] [OPTS=no/yes/only]], , enable_osc52="no")
+case "$enable_osc52" in
+  no|yes|only) ;;
+  *) AC_MSG_ERROR([--enable-osc52 accepts: no, yes or only]);;
+esac
+AC_MSG_RESULT($enable_osc52)
+
+if test "$enable_osc52" = only; then
+  with_wayland=no
+  with_x=no
+  with_x_arg=no
+fi
 
 if test "$with_wayland" = yes; then
   cppflags_save=$CPPFLAGS
@@ -3388,6 +3403,24 @@ if test "$enable_fontset" = "yes"; then
   AC_DEFINE(FEAT_XFONTSET)
 fi
 
+dnl Finish OSC 52 setup after GUI selection is known.
+if test "$enable_osc52" = yes; then
+  case "$enable_gui_canon:$GUITYPE" in
+    no:NONE|auto:NONE);; # OK
+    *)
+      AC_MSG_ERROR(
+      [--enable-osc52=$enable_osc52 not supported without --enable-gui=no]);;
+  esac
+fi
+
+if test "$enable_osc52" != no; then
+  AC_DEFINE(FEAT_CLIPBOARD_OSC52)
+  if test "$features" = tiny; then
+    AC_DEFINE(FEAT_CLIPBOARD_OSC52_TINY)
+  elif test "$enable_osc52" = only; then
+    AC_DEFINE(FEAT_CLIPBOARD_OSC52_ONLY)
+  fi
+fi
 
 dnl ---------------------------------------------------------------------------
 dnl end of GUI-checking

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -3716,148 +3716,6 @@ f_balloon_split(typval_T *argvars, typval_T *rettv UNUSED)
 # endif
 #endif
 
-// Base64 character set
-static const char_u base64_table[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-
-// Base64 decoding table (initialized in init_base64_dec_table() below)
-static char_u base64_dec_table[256];
-
-/*
- * Initialize the base64 decoding table
- */
-    static void
-init_base64_dec_table(void)
-{
-    static int base64_dec_tbl_initialized = FALSE;
-
-    if (base64_dec_tbl_initialized)
-	return;
-
-    // Unsupported characters are set to 0xFF
-    vim_memset(base64_dec_table, 0xFF, sizeof(base64_dec_table));
-
-    // Initialize the index for the base64 alphabets
-    for (size_t i = 0; i < sizeof(base64_table) - 1; i++)
-	base64_dec_table[(char_u)base64_table[i]] = (char_u)i;
-
-    // base64 padding character
-    base64_dec_table['='] = 0;
-
-    base64_dec_tbl_initialized = TRUE;
-}
-
-/*
- * Encode the bytes in "blob" using base-64 encoding.
- */
-    static char_u *
-base64_encode(blob_T *blob)
-{
-    size_t input_len = blob->bv_ga.ga_len;
-    size_t encoded_len = ((input_len + 2) / 3) * 4;
-    char_u *data = blob->bv_ga.ga_data;
-
-    char_u *encoded = alloc(encoded_len + 1);
-    if (encoded == NULL)
-	return NULL;
-
-    size_t i, j;
-    for (i = 0, j = 0; i < input_len;)
-    {
-	int_u octet_a = i < input_len ? data[i++] : 0;
-	int_u octet_b = i < input_len ? data[i++] : 0;
-	int_u octet_c = i < input_len ? data[i++] : 0;
-
-	int_u triple = (octet_a << 16) | (octet_b << 8) | octet_c;
-
-	encoded[j++] = base64_table[(triple >> 18) & 0x3F];
-	encoded[j++] = base64_table[(triple >> 12) & 0x3F];
-	encoded[j++] = (!octet_b && i >= input_len) ? '='
-					: base64_table[(triple >> 6) & 0x3F];
-	encoded[j++] = (!octet_c && i >= input_len) ? '='
-					: base64_table[triple & 0x3F];
-    }
-    encoded[j] = NUL;
-
-    return encoded;
-}
-
-/*
- * Decode the string "data" using base-64 encoding.
- */
-    static void
-base64_decode(const char_u *data, blob_T *blob)
-{
-    size_t input_len = STRLEN(data);
-
-    if (input_len == 0)
-	return;
-
-    if (input_len % 4 != 0)
-    {
-	// Invalid input length
-	semsg(_(e_invalid_argument_str), data);
-	return;
-    }
-
-    init_base64_dec_table();
-
-    size_t decoded_len = (input_len / 4) * 3;
-    if (data[input_len - 1] == '=')
-	decoded_len--;
-    if (data[input_len - 2] == '=')
-	decoded_len--;
-
-    size_t i, j;
-    for (i = 0, j = 0; i < input_len;)
-    {
-	int_u sextet_a = base64_dec_table[(char_u)data[i++]];
-	int_u sextet_b = base64_dec_table[(char_u)data[i++]];
-	int_u sextet_c = base64_dec_table[(char_u)data[i++]];
-	int_u sextet_d = base64_dec_table[(char_u)data[i++]];
-
-	if (sextet_a == 0xFF || sextet_b == 0xFF || sextet_c == 0xFF
-							|| sextet_d == 0xFF)
-	{
-	    // Invalid character
-	    semsg(_(e_invalid_argument_str), data);
-	    ga_clear(&blob->bv_ga);
-	    return;
-	}
-
-	int_u triple = (sextet_a << 18) | (sextet_b << 12)
-						| (sextet_c << 6) | sextet_d;
-
-	if (j < decoded_len)
-	{
-	    ga_append(&blob->bv_ga, (triple >> 16) & 0xFF);
-	    j++;
-	}
-	if (j < decoded_len)
-	{
-	    ga_append(&blob->bv_ga, (triple >> 8) & 0xFF);
-	    j++;
-	}
-	if (j < decoded_len)
-	{
-	    ga_append(&blob->bv_ga, triple & 0xFF);
-	    j++;
-	}
-
-	if (j == decoded_len)
-	{
-	    // Check for invalid padding bytes (based on the
-	    // "Base64 Malleability in Practice" ACM paper).
-	    if ((data[input_len - 2] == '=' && ((sextet_b & 0xF) != 0))
-		|| ((data[input_len - 1] == '=') && ((sextet_c & 0x3) != 0)))
-	    {
-		semsg(_(e_invalid_argument_str), data);
-		ga_clear(&blob->bv_ga);
-		return;
-	    }
-	}
-    }
-}
-
 /*
  * "base64_decode(string)" function
  */
@@ -3872,7 +3730,8 @@ f_base64_decode(typval_T *argvars, typval_T *rettv)
 
     char_u *str = tv_get_string_chk(&argvars[0]);
     if (str != NULL)
-	base64_decode(str, rettv->vval.v_blob);
+	base64_decode_bytes(str, STRLEN(str), &rettv->vval.v_blob->bv_ga,
+								    TRUE);
 }
 
 /*
@@ -3889,7 +3748,8 @@ f_base64_encode(typval_T *argvars, typval_T *rettv)
 
     blob_T *blob = argvars->vval.v_blob;
     if (blob != NULL)
-	rettv->vval.v_string = base64_encode(blob);
+	rettv->vval.v_string = base64_encode_bytes(
+				blob->bv_ga.ga_data, blob->bv_ga.ga_len);
 }
 
 /*

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -6856,7 +6856,7 @@ f_has(typval_T *argvars, typval_T *rettv)
 #endif
 		},
 	{"clipboard",
-#ifdef FEAT_CLIPBOARD
+#if defined(FEAT_CLIPBOARD) || defined(FEAT_CLIPBOARD_OSC52)
 		1
 #else
 		0
@@ -7333,6 +7333,13 @@ f_has(typval_T *argvars, typval_T *rettv)
 		0
 #endif
 		},
+	{"osc52",
+#ifdef FEAT_CLIPBOARD_OSC52
+		1
+#else
+		0
+#endif
+	},
 	{"packages",
 #ifdef FEAT_EVAL
 		1

--- a/src/feature.h
+++ b/src/feature.h
@@ -925,7 +925,8 @@
 #if defined(FEAT_NORMAL) \
 	&& (defined(UNIX) || defined(VMS)) \
 	&& defined(WANT_X11) && defined(HAVE_X11) \
-	&& !defined(USE_GTK4)
+	&& !defined(USE_GTK4) \
+	&& !defined(FEAT_CLIPBOARD_OSC52_ONLY)
 # define FEAT_XCLIPBOARD
 # ifndef FEAT_CLIPBOARD
 #  define FEAT_CLIPBOARD
@@ -933,7 +934,8 @@
 #endif
 
 #if defined(FEAT_NORMAL) && defined(UNIX) \
-    && defined(HAVE_WAYLAND) && defined(WANT_WAYLAND)
+    && defined(HAVE_WAYLAND) && defined(WANT_WAYLAND) \
+    && !defined(FEAT_CLIPBOARD_OSC52_ONLY)
 # define FEAT_WAYLAND_CLIPBOARD
 # ifndef FEAT_CLIPBOARD
 #  define FEAT_CLIPBOARD

--- a/src/feature.h
+++ b/src/feature.h
@@ -907,6 +907,7 @@
 
 /*
  * +clipboard		Clipboard support.  Always used for the GUI.
+ * +osc52		OSC 52 terminal clipboard support.
  * +xterm_clipboard	Unix only: Include code for handling the clipboard
  *			in an xterm like in the GUI.
  */

--- a/src/misc1.c
+++ b/src/misc1.c
@@ -2955,3 +2955,155 @@ trim_to_int(vimlong_T x)
     return x > INT_MAX ? INT_MAX : x < INT_MIN ? INT_MIN : x;
 }
 
+#if defined(FEAT_EVAL) || defined(FEAT_CLIPBOARD_OSC52)
+// Base64 character set
+static const char_u base64_table[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+// Base64 decoding table (initialized in init_base64_dec_table() below)
+static char_u base64_dec_table[256];
+
+/*
+ * Initialize the base64 decoding table
+ */
+    static void
+init_base64_dec_table(void)
+{
+    static int base64_dec_tbl_initialized = FALSE;
+
+    if (base64_dec_tbl_initialized)
+	return;
+
+    // Unsupported characters are set to 0xFF
+    vim_memset(base64_dec_table, 0xFF, sizeof(base64_dec_table));
+
+    // Initialize the index for the base64 alphabets
+    for (size_t i = 0; i < sizeof(base64_table) - 1; i++)
+	base64_dec_table[(char_u)base64_table[i]] = (char_u)i;
+
+    // base64 padding character
+    base64_dec_table['='] = 0;
+
+    base64_dec_tbl_initialized = TRUE;
+}
+
+/*
+ * Encode "input_len" bytes from "data".
+ */
+    char_u *
+base64_encode_bytes(const char_u *data, size_t input_len)
+{
+    size_t encoded_len = ((input_len + 2) / 3) * 4;
+    char_u *encoded = alloc(encoded_len + 1);
+    if (encoded == NULL)
+	return NULL;
+
+    size_t i, j;
+    for (i = 0, j = 0; i < input_len;)
+    {
+	int_u octet_a = i < input_len ? data[i++] : 0;
+	int_u octet_b = i < input_len ? data[i++] : 0;
+	int_u octet_c = i < input_len ? data[i++] : 0;
+
+	int_u triple = (octet_a << 16) | (octet_b << 8) | octet_c;
+
+	encoded[j++] = base64_table[(triple >> 18) & 0x3F];
+	encoded[j++] = base64_table[(triple >> 12) & 0x3F];
+	encoded[j++] = (!octet_b && i >= input_len) ? '='
+					: base64_table[(triple >> 6) & 0x3F];
+	encoded[j++] = (!octet_c && i >= input_len) ? '='
+					: base64_table[triple & 0x3F];
+    }
+    encoded[j] = NUL;
+
+    return encoded;
+}
+
+/*
+ * Decode "input_len" bytes of base-64 data.
+ *
+ * Appends decoded bytes to "gap".  Returns FAIL for invalid input.  When
+ * "message" is true an invalid-input error is reported.
+ */
+    int
+base64_decode_bytes(
+    const char_u	*data,
+    size_t		input_len,
+    garray_T		*gap,
+    int			message)
+{
+    size_t decoded_len;
+
+    if (input_len == 0)
+	return OK;
+
+    if (input_len % 4 != 0)
+    {
+	// Invalid input length
+	if (message)
+	    semsg(_(e_invalid_argument_str), data);
+	return FAIL;
+    }
+
+    init_base64_dec_table();
+
+    decoded_len = (input_len / 4) * 3;
+    if (data[input_len - 1] == '=')
+	decoded_len--;
+    if (data[input_len - 2] == '=')
+	decoded_len--;
+
+    size_t i, j;
+    for (i = 0, j = 0; i < input_len;)
+    {
+	int_u sextet_a = base64_dec_table[(char_u)data[i++]];
+	int_u sextet_b = base64_dec_table[(char_u)data[i++]];
+	int_u sextet_c = base64_dec_table[(char_u)data[i++]];
+	int_u sextet_d = base64_dec_table[(char_u)data[i++]];
+
+	if (sextet_a == 0xFF || sextet_b == 0xFF || sextet_c == 0xFF
+							|| sextet_d == 0xFF)
+	{
+	    // Invalid character
+	    if (message)
+		semsg(_(e_invalid_argument_str), data);
+	    ga_clear(gap);
+	    return FAIL;
+	}
+
+	int_u triple = (sextet_a << 18) | (sextet_b << 12)
+						| (sextet_c << 6) | sextet_d;
+
+	if (j < decoded_len)
+	{
+	    ga_append(gap, (triple >> 16) & 0xFF);
+	    j++;
+	}
+	if (j < decoded_len)
+	{
+	    ga_append(gap, (triple >> 8) & 0xFF);
+	    j++;
+	}
+	if (j < decoded_len)
+	{
+	    ga_append(gap, triple & 0xFF);
+	    j++;
+	}
+
+	if (j == decoded_len)
+	{
+	    // Check for invalid padding bytes (based on the
+	    // "Base64 Malleability in Practice" ACM paper).
+	    if ((data[input_len - 2] == '=' && ((sextet_b & 0xF) != 0))
+		|| ((data[input_len - 1] == '=') && ((sextet_c & 0x3) != 0)))
+	    {
+		if (message)
+		    semsg(_(e_invalid_argument_str), data);
+		ga_clear(gap);
+		return FAIL;
+	    }
+	}
+    }
+    return OK;
+}
+
+#endif // FEAT_EVAL FEAT_CLIPBOARD_OSC52

--- a/src/optiondefs.h
+++ b/src/optiondefs.h
@@ -641,7 +641,11 @@ static struct vimoption options[] =
 #ifdef HAVE_CLIPMETHOD
 			    (char_u *)&p_cpm, PV_NONE, did_set_clipmethod, expand_set_clipmethod,
 # ifdef UNIX
+#  ifdef FEAT_CLIPBOARD_OSC52_ONLY
+			    {(char_u *)"osc52", (char_u *)0L}
+#  else
 			    {(char_u *)"wayland,x11", (char_u *)0L}
+#  endif
 # elif defined(VMS)
 			    {(char_u *)"x11", (char_u *)0L}
 # else

--- a/src/proto/misc1.pro
+++ b/src/proto/misc1.pro
@@ -56,4 +56,6 @@ void restore_v_event(dict_T *v_event, save_v_event_T *sve);
 void may_trigger_modechanged(void);
 int vim_append_digit_long(long *value, int digit);
 int trim_to_int(vimlong_T x);
+char_u *base64_encode_bytes(const char_u *data, size_t input_len);
+int base64_decode_bytes(const char_u *data, size_t input_len, garray_T *gap, int message);
 /* vim: set ft=c : */

--- a/src/proto/term.pro
+++ b/src/proto/term.pro
@@ -100,4 +100,7 @@ void term_disable_dec(void);
 void term_set_win_resize(bool state);
 int sync_output_active(void);
 void term_set_sync_output(int flags);
+bool term_osc52_is_enabled(void);
+void term_osc52_request(int regname);
+void term_osc52_send(const char *selection, const char_u *payload, size_t len);
 /* vim: set ft=c : */

--- a/src/register.c
+++ b/src/register.c
@@ -46,7 +46,57 @@ get_y_regs(void)
 }
 #endif
 
-#if defined(FEAT_CLIPBOARD) || defined(FEAT_CLIPBOARD_PROVIDER)
+#ifdef FEAT_CLIPBOARD_OSC52_TINY
+    static void
+may_get_osc52_register(int regname)
+{
+    if (regname == '+' || regname == '*')
+	term_osc52_request(regname);
+    else if ((regname == 0 || regname == '"')
+	    && term_osc52_is_enabled())
+	term_osc52_request('+');
+}
+
+/*
+ * Send "reg" to the terminal clipboard.
+ */
+    static void
+osc52_send_yankreg(int regname, yankreg_T *reg)
+{
+    char_u	*text;
+    char_u	*p;
+    size_t	len = 0;
+    long	i;
+
+    if (reg->y_array == NULL)
+	return;
+
+    for (i = 0; i < reg->y_size; ++i)
+    {
+	len += reg->y_array[i].length;
+	if (i + 1 < reg->y_size || reg->y_type == MLINE)
+	    ++len;
+    }
+    text = alloc(len + 1);
+    if (text == NULL)
+	return;
+
+    p = text;
+    for (i = 0; i < reg->y_size; ++i)
+    {
+	mch_memmove(p, reg->y_array[i].string, reg->y_array[i].length);
+	p += reg->y_array[i].length;
+	if (i + 1 < reg->y_size || reg->y_type == MLINE)
+	    *p++ = '\n';
+    }
+    *p = NUL;
+    term_osc52_send(regname == '+' ? "c" : "p", text, len);
+    vim_free(text);
+}
+#endif
+
+#if defined(FEAT_CLIPBOARD) || defined(FEAT_CLIPBOARD_PROVIDER) \
+    || defined(FEAT_CLIPBOARD_OSC52)
     yankreg_T *
 get_y_register(int reg)
 {
@@ -190,8 +240,9 @@ valid_yank_reg(
 	    || regname == '"'
 	    || regname == '-'
 	    || regname == '_'
-#if defined(FEAT_CLIPBOARD) // If +clipboard is enabled, then these registers
-			    // always exist.
+#if defined(FEAT_CLIPBOARD) || defined(FEAT_CLIPBOARD_OSC52)
+	    // If +clipboard or +osc52 is enabled, then these registers
+	    // always exist.
 	    || regname == '*'
 	    || regname == '+'
 #elif defined(FEAT_CLIPBOARD_PROVIDER)
@@ -207,7 +258,7 @@ valid_yank_reg(
 #endif
 							)
 	return TRUE;
-#ifndef FEAT_CLIPBOARD
+#if !defined(FEAT_CLIPBOARD) && !defined(FEAT_CLIPBOARD_OSC52)
     // clipboard support not enabled in this build
     else if (regname == '*' || regname == '+')
     {
@@ -237,6 +288,15 @@ get_yank_register(int regname, int writing)
     int	    ret = FALSE;
 
     y_append = FALSE;
+#ifdef FEAT_CLIPBOARD_OSC52_TINY
+    if ((regname == 0 || regname == '"') && term_osc52_is_enabled())
+    {
+	y_current = &y_regs[PLUS_REGISTER];
+	if (writing)
+	    y_previous = y_current;
+	return TRUE;
+    }
+#endif
     if ((regname == 0 || regname == '"') && !writing && y_previous != NULL)
     {
 	y_current = y_previous;
@@ -285,6 +345,17 @@ get_yank_register(int regname, int writing)
 	i = REAL_PLUS_REGISTER;
 	ret = TRUE;
     }
+#elif defined(FEAT_CLIPBOARD_OSC52_TINY)
+    else if (regname == '*')
+    {
+	i = STAR_REGISTER;
+	ret = TRUE;
+    }
+    else if (regname == '+')
+    {
+	i = PLUS_REGISTER;
+	ret = TRUE;
+    }
 #endif
 #ifdef FEAT_DND
     else if (!writing && regname == '~')
@@ -313,7 +384,7 @@ get_register(
 #ifdef FEAT_CLIPBOARD_PROVIDER
     call_clip_provider_request(name);
 #endif
-#ifdef FEAT_CLIPBOARD
+#if defined(FEAT_CLIPBOARD)
     if (clipmethod != CLIPMETHOD_PROVIDER)
     {
 	// When Visual area changed, may have to update selection.  Obtain the
@@ -331,6 +402,8 @@ get_register(
 	    may_get_selection(name);
 	}
     }
+#elif defined(FEAT_CLIPBOARD_OSC52_TINY)
+    may_get_osc52_register(name);
 #endif
 
     get_yank_register(name, 0);
@@ -381,14 +454,16 @@ put_register(int name, void *reg)
     free_yank_all();
     *y_current = *(yankreg_T *)reg;
     vim_free(reg);
-
-#ifdef FEAT_CLIPBOARD
+#if defined(FEAT_CLIPBOARD) && defined(HAVE_CLIPMETHOD)
     // Send text written to clipboard register to the clipboard.
     may_set_selection();
+#elif defined(FEAT_CLIPBOARD_OSC52_TINY)
+    if (name == '+' || name == '*')
+	osc52_send_yankreg(name, y_current);
 #endif
 }
 
-#if defined(FEAT_CLIPBOARD)
+#if defined(FEAT_CLIPBOARD) || defined(FEAT_CLIPBOARD_OSC52)
     void
 free_register(void *reg)
 {
@@ -662,10 +737,13 @@ do_execreg(
     }
     execreg_lastc = regname;
 
+#ifdef FEAT_CLIPBOARD_OSC52_TINY
+    may_get_osc52_register(regname);
+#endif
 #ifdef FEAT_CLIPBOARD_PROVIDER
     call_clip_provider_request(regname);
 #endif
-#ifdef FEAT_CLIPBOARD
+#if defined(FEAT_CLIPBOARD) && defined(HAVE_CLIPMETHOD)
     if (clipmethod != CLIPMETHOD_PROVIDER)
 	regname = may_get_selection(regname);
 #endif
@@ -869,11 +947,13 @@ insert_reg(
     // check for valid regname
     if (regname != NUL && !valid_yank_reg(regname, FALSE))
 	return FAIL;
-
+#ifdef FEAT_CLIPBOARD_OSC52_TINY
+    may_get_osc52_register(regname);
+#endif
 #ifdef FEAT_CLIPBOARD_PROVIDER
     call_clip_provider_request(regname);
 #endif
-#ifdef FEAT_CLIPBOARD
+#if defined(FEAT_CLIPBOARD) && defined(HAVE_CLIPMETHOD)
     if (clipmethod != CLIPMETHOD_PROVIDER)
 	regname = may_get_selection(regname);
 #endif
@@ -1039,6 +1119,9 @@ cmdline_paste_reg(
     long	i;
     int		literally = literally_arg;
 
+#ifdef FEAT_CLIPBOARD_OSC52_TINY
+    may_get_osc52_register(regname);
+#endif
     if (get_yank_register(regname, FALSE))
 	literally = TRUE;
     if (y_current->y_array == NULL)
@@ -1206,7 +1289,7 @@ put_do_autocmd(
     inc_clip_provider();
     call_clip_provider_request(regname);
 # endif
-# ifdef FEAT_CLIPBOARD
+# if defined(FEAT_CLIPBOARD) && defined(HAVE_CLIPMETHOD)
     if (clipmethod != CLIPMETHOD_PROVIDER)
 	regname = may_get_selection(regname);
 # endif
@@ -1348,7 +1431,7 @@ op_yank(oparg_T *oap, int deleting, int mess)
     if (oap->regname == '_')	    // black hole: nothing to do
 	return OK;
 
-#ifdef FEAT_CLIPBOARD
+#if defined(FEAT_CLIPBOARD)
     if ((!clip_star.available && oap->regname == '*') ||
 	(!clip_plus.available && oap->regname == '+'))
     {
@@ -1564,7 +1647,7 @@ op_yank(oparg_T *oap, int deleting, int mess)
     }
 #endif
 
-#ifdef FEAT_CLIPBOARD
+#if defined(FEAT_CLIPBOARD)
     if (clipmethod != CLIPMETHOD_PROVIDER)
     {
 	// If we were yanking to the '*' register, send result to clipboard. If
@@ -1599,6 +1682,16 @@ op_yank(oparg_T *oap, int deleting, int mess)
 	    clip_gen_set_selection(&clip_plus);
 	}
 # endif
+    }
+#endif
+
+#ifdef FEAT_CLIPBOARD_OSC52_TINY
+    if (term_osc52_is_enabled())
+    {
+	if (curr == &y_regs[PLUS_REGISTER])
+	    osc52_send_yankreg('+', curr);
+	else if (curr == &y_regs[STAR_REGISTER])
+	    osc52_send_yankreg('*', curr);
     }
 #endif
 
@@ -1725,7 +1818,9 @@ do_put(
     pos_T	orig_start = curbuf->b_op_start;
     pos_T	orig_end = curbuf->b_op_end;
     unsigned int cur_ve_flags = get_ve_flags();
-
+#ifdef FEAT_CLIPBOARD_OSC52_TINY
+    may_get_osc52_register(regname);
+#endif
 #ifdef HAVE_CLIPMETHOD
     adjust_clip_reg(&regname);
 #endif
@@ -1733,7 +1828,7 @@ do_put(
     inc_clip_provider();
     call_clip_provider_request(regname);
 #endif
-#ifdef FEAT_CLIPBOARD
+#if defined(FEAT_CLIPBOARD) && defined(HAVE_CLIPMETHOD)
     if (clipmethod != CLIPMETHOD_PROVIDER)
 	// Adjust register name for "unnamed" in 'clipboard'.
 	(void)may_get_selection(regname);
@@ -2586,7 +2681,12 @@ get_register_name(int num)
 	return num + '0';
     else if (num == DELETION_REGISTER)
 	return '-';
-#if defined(FEAT_CLIPBOARD) || defined(FEAT_CLIPBOARD_PROVIDER)
+#ifdef FEAT_CLIPBOARD_OSC52_TINY
+    else if (num == PLUS_REGISTER)
+	return '+';
+    else if (num == STAR_REGISTER)
+	return '*';
+#elif defined(FEAT_CLIPBOARD) || defined(FEAT_CLIPBOARD_PROVIDER)
     else if (num == STAR_REGISTER)
 	return '*';
     // If there is only one clipboard, we only want the plus register to point
@@ -2644,12 +2744,6 @@ ex_display(exarg_T *eap)
     for (i = -1; i < NUM_REGISTERS && !got_int; ++i)
     {
 	name = get_register_name(i);
-	switch (get_reg_type(name, NULL))
-	{
-	    case MLINE: type = 'l'; break;
-	    case MCHAR: type = 'c'; break;
-	    default:	type = 'b'; break;
-	}
 	if (arg != NULL && vim_strchr(arg, name) == NULL
 #ifdef ONE_CLIPBOARD
 		// Star register and plus register contain the same thing.
@@ -2657,6 +2751,12 @@ ex_display(exarg_T *eap)
 #endif
 		)
 	    continue;	    // did not ask for this register
+	switch (get_reg_type(name, NULL))
+	{
+	    case MLINE: type = 'l'; break;
+	    case MCHAR: type = 'c'; break;
+	    default:	type = 'b'; break;
+	}
 
 #ifdef HAVE_CLIPMETHOD
 	adjust_clip_reg(&name);
@@ -2664,7 +2764,7 @@ ex_display(exarg_T *eap)
 #ifdef FEAT_CLIPBOARD_PROVIDER
 	call_clip_provider_request(name);
 #endif
-#ifdef FEAT_CLIPBOARD
+#if defined(FEAT_CLIPBOARD) && defined(HAVE_CLIPMETHOD)
 	if (clipmethod != CLIPMETHOD_PROVIDER)
 	    // Adjust register name for "unnamed" in 'clipboard'.
 	    // When it's a clipboard register, fill it with the current contents
@@ -2867,10 +2967,13 @@ get_reg_type(int regname, long *reglen)
 	    return MCHAR;
     }
 
+#ifdef FEAT_CLIPBOARD_OSC52_TINY
+    may_get_osc52_register(regname);
+#endif
 #ifdef FEAT_CLIPBOARD_PROVIDER
     call_clip_provider_request(regname);
 #endif
-#ifdef FEAT_CLIPBOARD
+#if defined(FEAT_CLIPBOARD)
     if (clipmethod != CLIPMETHOD_PROVIDER)
 	regname = may_get_selection(regname);
 #endif
@@ -2949,11 +3052,13 @@ get_reg_contents(int regname, int flags)
     // check for valid regname
     if (regname != NUL && !valid_yank_reg(regname, FALSE))
 	return NULL;
-
+#ifdef FEAT_CLIPBOARD_OSC52_TINY
+    may_get_osc52_register(regname);
+#endif
 # ifdef FEAT_CLIPBOARD_PROVIDER
     call_clip_provider_request(regname);
 # endif
-# ifdef FEAT_CLIPBOARD
+# if defined(FEAT_CLIPBOARD) && defined(HAVE_CLIPMETHOD)
     if (clipmethod != CLIPMETHOD_PROVIDER)
 	regname = may_get_selection(regname);
 # endif
@@ -3052,9 +3157,14 @@ finish_write_reg(
     yankreg_T	*old_y_previous,
     yankreg_T	*old_y_current)
 {
-# ifdef FEAT_CLIPBOARD
+# if defined(FEAT_CLIPBOARD)
     // Send text of clipboard register to the clipboard.
     may_set_selection();
+# elif defined(FEAT_CLIPBOARD_OSC52_TINY)
+    if (y_current == &y_regs[PLUS_REGISTER])
+	osc52_send_yankreg('+', y_current);
+    else if (y_current == &y_regs[STAR_REGISTER])
+	osc52_send_yankreg('*', y_current);
 # endif
 
     // ':let @" = "val"' should change the meaning of the "" register
@@ -3211,7 +3321,8 @@ write_reg_contents_ex(
 }
 #endif	// FEAT_EVAL
 
-#if defined(FEAT_CLIPBOARD) || defined(FEAT_EVAL)
+#if defined(FEAT_CLIPBOARD) || defined(FEAT_CLIPBOARD_OSC52) \
+    || defined(FEAT_EVAL)
 /*
  * Put a string into a register.  When the register is not empty, the string
  * is appended.
@@ -3367,4 +3478,4 @@ str_to_reg(
     y_ptr->y_time_set = vim_time();
 # endif
 }
-#endif // FEAT_CLIPBOARD || FEAT_EVAL
+#endif // FEAT_CLIPBOARD || FEAT_CLIPBOARD_OSC52 || FEAT_EVAL

--- a/src/structs.h
+++ b/src/structs.h
@@ -5106,9 +5106,11 @@ typedef enum {
 
 // Symbolic names for some registers.
 #define DELETION_REGISTER	36
-#if defined(FEAT_CLIPBOARD) || defined(HAVE_CLIPMETHOD)
+#if defined(FEAT_CLIPBOARD) || defined(HAVE_CLIPMETHOD) \
+	|| defined(FEAT_CLIPBOARD_OSC52)
 # define STAR_REGISTER		37
-# if defined(FEAT_X11) || defined(FEAT_WAYLAND)
+# if defined(FEAT_X11) || defined(FEAT_WAYLAND) \
+	|| defined(FEAT_CLIPBOARD_OSC52)
 #  define PLUS_REGISTER	38
 #  define REAL_PLUS_REGISTER	PLUS_REGISTER
 # else
@@ -5126,7 +5128,7 @@ typedef enum {
 # define TILDE_REGISTER		(PLUS_REGISTER + 1)
 #endif
 
-#ifdef FEAT_CLIPBOARD
+#if defined(FEAT_CLIPBOARD) || defined(FEAT_CLIPBOARD_OSC52)
 # ifdef FEAT_DND
 #  define NUM_REGISTERS		(TILDE_REGISTER + 1)
 # else

--- a/src/term.c
+++ b/src/term.c
@@ -56,6 +56,7 @@
 static void parse_builtin_tcap(char_u *s);
 static void gather_termleader(void);
 #ifdef FEAT_TERMRESPONSE
+static int can_get_termresponse(void);
 static void req_codes_from_term(void);
 static void req_more_codes_from_term(void);
 static void got_code_from_term(char_u *code, int len);
@@ -1581,6 +1582,149 @@ init_term_props(int all)
 	if (all || term_props[i].tpr_set_by_termresponse)
 	    term_props[i].tpr_status = TPR_UNKNOWN;
 }
+#ifdef FEAT_CLIPBOARD_OSC52
+static unsigned osc52_response_count[2] = {0, 0};
+
+    bool
+term_osc52_is_enabled(void)
+{
+    static int enabled = -1;
+
+    if (enabled < 0)
+    {
+	char_u *value = mch_getenv((char_u *)"VIMOSC52");
+
+	enabled = value != NULL && STRCMP(value, "1") == 0;
+    }
+    return enabled;
+}
+
+    static char
+*osc52_msg(const char *target, const char *payload)
+{
+    size_t len = 8 + strlen(target) + strlen(payload);
+
+    char *buf = (char *)alloc(len);
+    if (buf == NULL)
+	return NULL;
+
+    snprintf(buf, len,
+	    "\033]52;%s;%s\007",
+	    target, payload);
+    return buf;
+}
+
+    void
+term_osc52_send(const char *selection, const char_u *payload, size_t len)
+{
+    char_u	*b64;
+    char	*msg;
+
+    if (!term_osc52_is_enabled())
+	return;
+
+    b64 = base64_encode_bytes(payload, len);
+    if (b64 == NULL)
+	return;
+
+    msg = osc52_msg(selection, (char *)b64);
+    vim_free(b64);
+
+    if (msg != NULL)
+    {
+        out_str((char_u *)msg);
+        out_flush();
+        vim_free(msg);
+    }
+}
+
+    void
+term_osc52_request(int regname)
+{
+    int		idx = regname == '*' ? 0 : 1;
+    unsigned	count;
+    long	elapsed = 0;
+    long	timeout = 100L;
+    char	*msg;
+
+    if (!term_osc52_is_enabled() || !can_get_termresponse())
+	return;
+
+    count = osc52_response_count[idx];
+    msg = osc52_msg(regname == '*' ? "p" : "c", "?");
+    if (msg == NULL)
+	return;
+
+    out_str((char_u *)msg);
+    out_flush();
+    vim_free(msg);
+
+    if (p_ost < timeout)
+	timeout = p_ost;
+
+    while (!got_int && elapsed < timeout
+	    && count == osc52_response_count[idx])
+    {
+	(void)vpeekc_nomap();
+	if (count != osc52_response_count[idx])
+	    break;
+
+	ui_delay(10L, FALSE);
+	elapsed += 10;
+    }
+}
+
+    static void
+handle_osc52_read(int regname, char_u *b64)
+{
+    char_u		*end;
+    char_u		*str;
+    garray_T	decoded;
+    long		len;
+    yankreg_T	*old_y_current;
+    yankreg_T	*old_y_previous;
+
+    // b64 points to "<base64> BEL" or "<base64> ESC \\".
+    end = vim_strchr(b64, '\007');
+    if (end == NULL)
+	end = (char_u *)strstr((char *)b64, "\033\\");
+    if (end == NULL)
+	return;
+    if (end == b64)
+    {
+	str = (char_u *)"";
+	len = 0;
+    }
+    else
+    {
+	ga_init2(&decoded, 1, 100);
+	if (base64_decode_bytes(b64, (size_t)(end - b64),
+		    &decoded, FALSE) == FAIL)
+	{
+	    ga_clear(&decoded);
+	    return;
+	}
+
+	str = decoded.ga_data;
+	len = decoded.ga_len;
+    }
+
+    old_y_current = get_y_current();
+    old_y_previous = get_y_previous();
+
+    get_yank_register(regname, TRUE);
+    free_yank_all();
+    str_to_reg(get_y_current(), MAUTO, str, len, 0L, FALSE);
+
+    set_y_previous(old_y_previous);
+    set_y_current(old_y_current);
+
+    if (end != b64)
+	ga_clear(&decoded);
+
+    ++osc52_response_count[regname == '*' ? 0 : 1];
+}
+#endif
 
 #if defined(FEAT_EVAL)
     void
@@ -6127,6 +6271,19 @@ handle_osc(char_u *tp, int len, char_u *key_name, int *slen)
 	    check_for_color_response(osc_state.buf.ga_data, osc_state.buf.ga_len - 1);
 
 	    char_u savebg = *p_bg;
+#ifdef FEAT_CLIPBOARD_OSC52
+	    if (term_osc52_is_enabled()
+		    && STRNCMP(osc_state.buf.ga_data, "\033]52;", 5) == 0)
+	    {
+		char_u *target = osc_state.buf.ga_data + 5;
+		char_u *payload = vim_strchr(target, ';');
+
+		if (payload != NULL && payload == target + 1
+			&& (*target == 'c' || *target == 'p'))
+		    handle_osc52_read(*target == 'p' ? '*' : '+',
+			    payload + 1);
+	    }
+#endif
 	    apply_autocmds(EVENT_TERMRESPONSEALL, (char_u *)"osc",
 		    NULL, FALSE, curbuf);
 	    if (*p_bg != savebg)

--- a/src/version.c
+++ b/src/version.c
@@ -151,7 +151,7 @@ static char *(features[]) =
 #else
 	"-clientserver",
 #endif
-#ifdef FEAT_CLIPBOARD
+#if defined(FEAT_CLIPBOARD) || defined(FEAT_CLIPBOARD_OSC52)
 	"+clipboard",
 #else
 	"-clipboard",
@@ -421,6 +421,11 @@ static char *(features[]) =
 	"-netbeans_intg",
 #endif
 	"+num64",
+#if defined(FEAT_CLIPBOARD_OSC52)
+	"+osc52",
+#else
+	"-osc52",
+#endif
 #ifdef FEAT_GUI_MSWIN
 # ifdef FEAT_OLE
 	"+ole",

--- a/src/vim.h
+++ b/src/vim.h
@@ -2051,7 +2051,8 @@ typedef int sock_T;
 # define HAVE_CLIPMETHOD
 #endif
 
-#if defined(HAVE_CLIPMETHOD) && defined(FEAT_EVAL)
+#if defined(HAVE_CLIPMETHOD) && defined(FEAT_EVAL) \
+	&& !defined(FEAT_CLIPBOARD_OSC52_ONLY)
 # define FEAT_CLIPBOARD_PROVIDER
 #endif
 


### PR DESCRIPTION
Just letting you know I am still working on this, thus leaving this for input.

I have spend time polishing and minimizing the tiny version, but have everything else implemented for `normal,huge`, but I need to merge it into my new base and its getting late.

Issue: #19441

Plan:

### Configure, Feature

` [  --enable-osc52[=OPTS]` (*not supported with --enable-gui*)
```
OSC 52 Clipboard [default=yes] [OPTS=no/yes/only]], , enable_osc52="no")
```
(*`default=yes` means `--enable-osc52` without explicit `=yes|only` choice)

`yes`
* enables `FEAT_CLIPBOARD_OSC52` (and `FEAT_CLIPBOARD_OSC52_TINY` if built on tiny.)

`only`
* disables `x11,wayland` in configure making a super minimal `clipboard` terminal setup.

What lacks in tiny: 

* Detection
* * osc52 via `DA1` and `XTGETTCAP`
* * ssh
* * tmux
* * screen
(*also useful for clipboard syncronization*)


When enabled `:version`:
```
+osc52
+clipboard
```
Because the features are similar to regular `clipboard` but it does not have `clipboard_provider` etc. All other code is bypassed, it does not enable `FEAT_CLIPBOARD` it just shows the feature as it is otherwise fully compatible with the provided features.

### Environment variable
(*most relevant to tiny version, but also works on regular build*)

`VIMOSC52=1`, enables `"+`, and `"*` registers loading content at startup from `OSC52 p,c` `primary/clipboard`

#### Why env var?
Functions as an entrypoint for your regular sysadmin/devops who have no readwrite access/forbidden to customize config and just want clipboard working remotely on servers he trusts.

### Integration with `clipboard.c` on regular build

Current suggestion is that it defaults to `wayland,x11,osc52` if built with `--enable-osc52=yes`.

If `VIMOSC52=1` is used on regular build it reorders `clipmethod` to
```
clipmethod=osc52,wayland,x11
```
Meaning it prioritizes it first. Same argument as described above for tiny;  make the feature extremely accessible to anyone; even system admins who never really configures vim.

vimrc configuration is an explicit, non-default - ordered to your liking.
```
set clipmethod=osc52,wayland,x11
```

**Configuration is explicit, non-default, always** for this feature.


### Doc

*options.txt* (`--enable=only` not listed here as all other backends disabled)
```
                                                *'clipmethod'* *'cpm'*
 'clipmethod' 'cpm'     string  (default for Unix: "wayland,x11",
                                with OSC 52: "wayland,x11,osc52",
                                 for VMS: "x11",
                                 otherwise: "")
                        global
                        {only when the |+xterm_clipboard|, |+wayland_clipboard|,
                       or |+eval| features are included}
                       |+osc52| or |+eval| features are included}
        Specifies which method of accessing the system clipboard (or clipboard
        provider) is used.  Methods are tried in the order given; the first
        working method is used.  Supported methods are:
                wayland         Wayland selections
                x11             X11 selections
                osc52           OSC 52 terminal clipboard.
                               {only non-gui when compiled with |+osc52|}
                               See |clipboard-osc52|.
                <name>          Use a clipboard provider with the given name

        Note: This option is ignored when either the GUI is running or if Vim
       is run on a system without Wayland or X11 support, such as Windows or
       macOS.  The GUI or system way of accessing the clipboard is used
       instead, meaning |v:clipmethod| will be set to "none".  The
       is run on a system without Wayland, X11, or OSC 52 support, such as
       Windows or macOS.  The GUI or system way of accessing the clipboard
       is used instead, meaning |v:clipmethod| will be set to "none".  The
        exception to this is the |clipboard-providers| feature, in which if
        a clipboard provider is being used, then it will override the existing
        clipboard functionality.
```
*term.txt*
```

                                                       *osc52-clipboard*
OSC 52 provides terminal-mediated access to the clipboard, including over
SSH.  See |clipboard-osc52|.

                                                        *xterm-command-server*
 When the X-server clipboard is available, the command server described in
 |x11-clientserver| can be enabled with the --servername command line argument.
    *+clipboard*                |clipboard| support compiled-in
    *+clipboard_working*        |clipboard| support compiled-in and working
    *+clipboard_provider*  |clipboard-providers| support compiled-in
    *+osc52*            OSC 52 terminal clipboard support compiled-in
```

#### Detection

`DA1` and `XTGETTCAP Ms` is supported in regular builds.

#### Additional notes

##### Timeouts, performance
In my draft for regular builds it is thus with timeout on reading:
```
long       timeout = term_osc52_is_ssh() ? 250L : 100L;
```

250ms over ssh, 100ms on regular PC.
(*non-blocking btw*)

In my testing 10MB clipboard on a Ryzen 7900 finishes as fast as `31ms`, quite impressive.
```
head -c 10M /dev/zero | tr '\0' x
```

Thus it is also extremely unlikely to fail unless OOM, all-core workload, or over ssh.

It is more likely that a wayland or x11 connection will trip requiring `:wlrestore`, `:xrestore` in my experience.

I don't think there are reliable probes into system loadavg that can scale with loadavg, nor do I think network provides a similar probe of performance, however one could scale with the highest recorded timeout over a flaky ssh connection - always expecting output on the other side.

As soon as it receives first byte, it knows that there is actually coming data and can increase timeout sensibly.

I am biased to sensible defaults, basically no configuration and scaling timeout if done correctly.

For errors/warning I am considering if these are sufficient for regular build.
```
								*W23*
When you are yanking into the "* or "+ register and Vim cannot establish a
connection to the X11 selection (or clipboard), it will use register 0 and
output a warning:

  Warning: Clipboard register not available, using register 0 ~

Note: This also applies to the Wayland clipboard feature as well.

								*W24*
Vim comes in different flavors, from a tiny build, that just tries to be
compatible to original Vi, to enhanced builds which include many improvements
(like a GUI).  However, on servers and embedded systems, Vim is typically
compiled without clipboard support, since this feature requires X11 libraries
to be present.  Check the ":version" output for the flag |+clipboard| or
-clipboard.  The former means clipboard support is present while the latter
means your Vim does not contain clipboard support.

In the case when you are trying to access the "* or "+ register and Vim has
no clipboard support, you will see this warning:

  Warning: Clipboard register not available. See :h W24~

If you have a vim with no clipboard support but would like to use the
clipboard, try to install a more enhanced Vim package like vim-enhanced or
vim-gtk3 (the gui packages usually also come with a terminal Vim that has
clipboard support included).
```

# Security

Its not enabled by default for neither `configure` nor `vimrc` and if you have reading enabled in your terminal emulator there are plenty of attack vectors already, vim is not the only one - you could have one waiting for you in .bashrc 🤥

Imho, if anyone should filter `osc52` it should be `.ssh/config` similar to how `X11Forwarding=` is as toggle, but they will probably point at terminal emulators; even if they chose to support the now fading x11 support.