### PR TITLE
MS-Windows: "*.vim" also matches files with a longer extension

### DIFF
--- a/runtime/doc/todo.txt
+++ b/runtime/doc/todo.txt
@@ -48,10 +48,6 @@ calling frame_new_height() and frame_new_width(), especially w_skipcol.
 With 'splitkeep' "screen" the scroll position is lost when splitting and
 closing a window, win_fix_cursor() moves the cursor to another line.
 
-Check places that source "path/*.vim" to not match other extensions, e.g.
-.vim9, on MS-Windows (short file name match, gets expanded to long file name).
-E.g. for startup files, plugins, packs, etc.
-
 When a help item can't be found, then open 'helpfile'.  Search for the tag in
 that file and gtive E149 only when not found.  Helps for a tiny Vim installed
 without all the help files.

--- a/src/filepath.c
+++ b/src/filepath.c
@@ -3574,6 +3574,7 @@ dos_expandpath(
     char_u		*matchname;
     int			ok;
     char_u		*p_alt;
+    int			use_short_name;
 
     // Expanding "**" may take a long time, check for CTRL-C.
     if (stardepth > 0)
@@ -3668,6 +3669,10 @@ dos_expandpath(
     // remember the pattern or file name being looked for
     matchname = vim_strsave(s);
 
+    // Only match against the alternate (8.3) file name when the pattern looks
+    // like a short name, it contains a '~'.
+    use_short_name = vim_strchr(s, '~') != NULL;
+
     len = (size_t)(s - buf);
     // If "**" is by itself, this is the first time we encounter it and more
     // is following then find matches without any directory.
@@ -3697,7 +3702,8 @@ dos_expandpath(
 	// Do not use the alternate filename when the file name ends in '~',
 	// because it picks up backup files: short name for "foo.vim~" is
 	// "foo~1.vim", which matches "*.vim".
-	if (*wfb.cAlternateFileName == NUL || p[STRLEN(p) - 1] == '~')
+	if (!use_short_name || *wfb.cAlternateFileName == NUL
+						  || p[STRLEN(p) - 1] == '~')
 	    p_alt = NULL;
 	else
 	    p_alt = utf16_to_enc(wfb.cAlternateFileName, NULL);

--- a/src/testdir/test_shortpathname.vim
+++ b/src/testdir/test_shortpathname.vim
@@ -119,7 +119,7 @@ func Test_glob_short_name_extension()
   call assert_equal(['bar.vim'], matches)
 
   " A pattern that is a short name still matches.
-  let short = fnamemodify(file, ':p:8:t')
+  let short = fnamemodify(fnamemodify(file, ':p:8'), ':t')
   call assert_equal([file], split(glob(dir . '/' . short), "\n"))
 endfunc
 

--- a/src/testdir/test_shortpathname.vim
+++ b/src/testdir/test_shortpathname.vim
@@ -101,4 +101,26 @@ func Test_ColonEight_notexists()
   call assert_equal(non_exists, fnamemodify(non_exists, ':p:8'))
 endfunc
 
+" A pattern must not match the short name of a file with a longer extension:
+" the short name of "foo.vim9" is "FOO~1.VIM", which matches "*.vim".
+func Test_glob_short_name_extension()
+  let dir = 'c:/Xtest_glob8'
+  call s:SetupDir(dir)
+  call mkdir(dir, 'D')
+
+  let file = dir . '/foo.vim9'
+  call writefile([], file, 'D')
+  if fnamemodify(file, ':p:8') ==? fnamemodify(file, ':p')
+    throw 'Skipped: 8.3 short names are not created on this volume'
+  endif
+  call writefile([], dir . '/bar.vim', 'D')
+
+  let matches = map(split(glob(dir . '/*.vim'), "\n"), {_, v -> fnamemodify(v, ':t')})
+  call assert_equal(['bar.vim'], matches)
+
+  " A pattern that is a short name still matches.
+  let short = fnamemodify(file, ':p:8:t')
+  call assert_equal([file], split(glob(dir . '/' . short), "\n"))
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
```
Problem:  On MS-Windows a pattern like "path/*.vim" also matches files such
          as "foo.vim9", because the 8.3 short name "FOO~1.VIM" is used for
          matching as well.  These files are then sourced.
Solution: Only match against the short name when the pattern contains a '~'.
```

---

This was in todo.txt, the entry is removed.

On MS-Windows, with a directory containing "bar.vim", "foo.vim9" and
"foo.vimx" on a volume where 8.3 short names are created:

    glob('plugin/*.vim')        -> bar.vim, foo.vim9, foo.vimx
    :runtime! plugin/*.vim      -> all three are sourced

The short name of "foo.vim9" is "FOO~1.VIM", which matches "*.vim", and
dos_expandpath() matches the pattern against both the long and the short
name.  The only guard was for names ending in `'~'`.

With this change the short name is only used when the pattern contains a
'~', which is how the function already recognizes a short name, see the
comment about "a wildcard or a ~1" at the top.  Both now find only
"bar.vim", while a pattern that is a short name still matches:

    glob('FOO~1.VIM')           -> foo.vim9

The test skips when the volume does not create short names, checked with
":p:8".

The `'~'` test is a heuristic; a pattern with a `'~'` keeps the previous
behaviour, so nothing that matched before stops matching.