### PR TITLE
runtime(doc): remove todo entry for test_codestyle errors

### DIFF
--- a/runtime/doc/todo.txt
+++ b/runtime/doc/todo.txt
@@ -61,9 +61,6 @@ When 'virtualedit' is "all" and 'cursorcolumn' is set, the wrong column may be
 highlighted. (van-de-bugger, 2018 Jan 23, #2576)
 
 Errors when running tests with valgrind:
-- test_codestyle.vim:  e.g.:
-    command line..script /home/mool/vim/vim91/src/testdir/runtest.vim[569]..function RunTheTest[52]..Test_test_files line 6: keycode_check.vim: space before tab: Expected 0 but got 7
-    command line..script /home/mool/vim/vim91/src/testdir/runtest.vim[569]..function RunTheTest[52]..Test_test_files line 10: setup.vim: trailing white space: Expected 0 but got 23
 - test_gui.vim:
     Found errors in Test_gui_mouse_event():
 


### PR DESCRIPTION
The two reported problems are gone: keycode_check.vim has no space before a tab and setup.vim, now util/setup.vim, has no trailing white space.  Since patch 9.2.0195 the check is not part of the test suite but a separate "make codestyle" target.

---

Checked on the current master:

- "cd src/testdir && make codestyle" runs its five tests without errors.
- keycode_check.vim has no space before a tab.
- setup.vim was moved to util/setup.vim in patch 9.1.1525 and has no
  trailing white space.

Since patch 9.2.0195 test_codestyle is no longer in the test list, it has
its own "codestyle" target, so it is also not one of the tests that are run
with valgrind.

The entry for test_gui.vim is left, that one is not checked.