### PR TITLE
fnamemodify: ":8" followed by ":t" uses the wrong name

### DIFF
--- a/src/filepath.c
+++ b/src/filepath.c
@@ -586,6 +586,10 @@ repeat:
 	    }
 	    *fnamelen = l;
 	}
+
+	// The name was replaced by the short name, "tail" points into the
+	// previous name.
+	tail = gettail(*fnamep);
     }
 #endif // MSWIN
 

--- a/src/testdir/test_shortpathname.vim
+++ b/src/testdir/test_shortpathname.vim
@@ -101,4 +101,24 @@ func Test_ColonEight_notexists()
   call assert_equal(non_exists, fnamemodify(non_exists, ':p:8'))
 endfunc
 
+" ":8" replaces the name, the modifiers after it must use the new name.
+func Test_ColonEight_then_tail()
+  let dir = 'c:/Xtest_C8tail'
+  call s:SetupDir(dir)
+
+  let file = dir . '/longfilename.txt'
+
+  call mkdir(dir, 'D')
+  call writefile([], file, 'D')
+
+  let sfile = fnamemodify(file, ':p:8')
+  if sfile ==? fnamemodify(file, ':p')
+    throw 'Skipped: 8.3 short names are not created on this volume'
+  endif
+
+  call assert_equal(fnamemodify(sfile, ':t'), fnamemodify(file, ':p:8:t'))
+  call assert_equal(fnamemodify(sfile, ':e'), fnamemodify(file, ':p:8:e'))
+  call assert_equal(fnamemodify(sfile, ':r'), fnamemodify(file, ':p:8:r'))
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
```
Problem:  On MS-Windows using ":8" with ":t", ":e" or ":r" in one
          fnamemodify() gives a wrong result or an out of memory error.
Solution: Recompute the tail after ":8" replaced the name.
```

---

fnamemodify('c:/temp/longfilename.txt', ':p:8:t') gives

    E342: Out of memory!  (allocating 4294966969 bytes)

on a volume where 8.3 short names are created.

modify_fname() computes "tail" before handling ":8".  That code replaces
the name with the short name in another buffer, so ":t" then subtracts a
pointer into the old buffer:

    *fnamelen -= tail - *fnamep;
    *fnamep = tail;

The length underflows and the name points into the freed buffer.  ":e" and
":r" use "tail" as well.

Found by the CI of #20899, where a test used ":p:8:t".