### PR TITLE
VMS: spurious "INVALID DECC FEATURE VALUE" message at every startup

### DIFF
--- a/src/os_vms.c
+++ b/src/os_vms.c
@@ -1005,9 +1005,11 @@ vms_init(void)
 	    feat_value_max = decc$feature_get_value(feat_index, 3);
 
 	    if ((decc_feat_array[i].value >= feat_value_min) && (decc_feat_array[i].value <= feat_value_max))
+	    {
 		// Valid value.  Set it if necessary
 		if (feat_value != decc_feat_array[i].value)
 		    sts = decc$feature_set_value(feat_index, 1, decc_feat_array[i].value);
+	    }
 	    else
 		// Invalid DECC feature value
 		printf("INVALID DECC FEATURE VALUE, %d: %d <= %s <= %d.\n",


### PR DESCRIPTION
### Problem

On OpenVMS, Vim prints a spurious error at **every** startup — one line per DECC feature:

```
INVALID DECC FEATURE VALUE, 1: 0 <= DECC$ARGV_PARSE_STYLE <= 1.
INVALID DECC FEATURE VALUE, 1: 0 <= DECC$EFS_CASE_PRESERVE <= 2.
INVALID DECC FEATURE VALUE, 1: 0 <= DECC$EFS_CHARSET <= 1.
```

Note the message is self-contradicting: it reports value `1` as invalid for the range `0 <= x <= 1`.

### Cause

In `vms_init_files()` (`src/os_vms.c`) the `if` has no braces, so `else` binds to the **inner** `if`, not the range check the indentation implies:

```c
if ((decc_feat_array[i].value >= feat_value_min) && (decc_feat_array[i].value <= feat_value_max))
    // Valid value.  Set it if necessary
    if (feat_value != decc_feat_array[i].value)
        sts = decc$feature_set_value(feat_index, 1, decc_feat_array[i].value);
else
    // Invalid DECC feature value
    printf("INVALID DECC FEATURE VALUE, %d: %d <= %s <= %d.\n", ...);
```

Effectively:

```c
if (in_range) {
    if (feat_value != wanted) set_it();
    else printf("INVALID DECC FEATURE VALUE ...");   // fires when ALREADY correct
}
```

So there are two defects:

* the message is printed precisely when the feature is **already** set to the value Vim wants — which is what happens whenever the corresponding DECC logical name is defined;
* a genuinely **out-of-range** value now falls into the empty `else` of the outer `if` and is **silently ignored**, so the real error condition is never reported.

### Reproduce

On OpenVMS, define any of the three features as a logical name and start Vim:

```dcl
$ DEFINE DECC$EFS_CHARSET ENABLE
$ vim
```

### Fix

Add braces so `else` binds to the range check.

### Testing

Verified on **OpenVMS x86-64 V9.2-3**, Vim 9.2 (patches 1-888) built with MMS V4.0-5 and VSI C x86-64 V7.7-003:

* before: 3 spurious messages at every startup;
* after: 0 messages, **with the logicals still defined** (`DECC$EFS_CHARSET` = `ENABLE`) — confirming the fix rather than removal of the logicals, which Vim needs for ODS-5 filename handling.

No test is added: this path is OpenVMS-only, runs from `LIB$INITIALIZE` before Vim starts, and its observable effect is text on stdout at image activation, so it is not reachable from the `src/testdir` harness. Happy to add one if you see a way.

Not tested on Alpha or IA-64 — only x86-64. The change is platform-independent C, but I can only claim what I ran.

### AI disclosure

Per `CONTRIBUTING.md`: this patch was found and written by **Claude Opus 5** (Anthropic), driven by me. It surfaced while building Vim from source on a hobbyist OpenVMS x86-64 system. The diagnosis, the before/after runs, and the reproduction above were all performed on real hardware, not inferred.
