### PR TITLE
test: use <NL> instead of CTRL-J for a NL (after 9.2.0888)

### DIFF
--- a/src/testdir/test_termcodes.vim
+++ b/src/testdir/test_termcodes.vim
@@ -2313,7 +2313,7 @@ func Test_modifyOtherKeys_after_partial_mapping()
   " A NL that was not simplified from the key protocol does not use the
   " mapping for CTRL-J.
   %d _
-  call feedkeys("aa\<C-J>\<Esc>", 'Lx!')
+  call feedkeys("aa\<NL>\<Esc>", 'Lx!')
   call assert_equal(['a', ''], getline(1, '$'))
 
   iunmap <C-J>


### PR DESCRIPTION
The comment says "A NL", using <NL> makes the intent clearer.

related: #20898
https://github.com/vim/vim/pull/20898#discussion_r3693717989