### PR TITLE
runtime(vim): make 'gf' find imported python files

### DIFF
--- a/runtime/autoload/vimgoto.vim
+++ b/runtime/autoload/vimgoto.vim
@@ -37,7 +37,12 @@ export def Find(editcmd: string) #{{{2
         return
     endif
 
-    var curfunc = FindCurfunc()
+    if curline =~ '^\s*py\%(thon\)\=3\s\+\%(from\|import\)\s'
+      HandlePythonImportLine(editcmd, curline)
+      return
+    endif
+
+    var curfunc = ExpandCurWord('#')
 
     if stridx(curfunc, '#') >= 0
         var parts = split(curfunc, '#')
@@ -171,6 +176,48 @@ def HandleImportLine(editcmd: string, curline: string) #{{{2
     execute how_to_split .. ' ' .. fnameescape(filepath)
 enddef
 
+def HandlePythonImportLine(editcmd: string, curline: string) #{{{2
+  # from ftplugin/python.vim
+  var grandparent_match: string = '^\(.\.\)\(\.*\)'
+  var grandparent_sub: string = '\=submatch(1)."/".repeat("../",strlen(submatch(2)))'
+
+  var parent_match: string = '^\.\(\.\)\@!'
+  var parent_sub: string = './'
+
+  var child_match: string = '\(\w\)\.\(\w\)'
+  var child_sub: string = '\1/\2'
+
+  var fname: string
+
+  if curline =~ '\<from\>' || curline =~ '\<as\>'
+    fname = curline->matchstr('^\s*py\%(thon\)\=3\s\+\%(from\|import\)\s\+\zs\S\+')
+  else
+    fname = ExpandCurWord('.')
+  endif
+
+  fname = fname
+    ->substitute(grandparent_match, grandparent_sub, '')
+    ->substitute(parent_match, parent_sub, '')
+    ->substitute(child_match, child_sub, 'g')
+    .. '.py'
+
+  var filepath: string = globpath(&runtimepath, 'python/' .. fname, true, true)
+    ->get(0, '')
+
+  if !filepath->filereadable()
+    printf('E447: Can''t find file "%s" in path', fname)
+      ->Error()
+    return
+  endif
+
+  var how_to_split: string = {
+    gF: 'edit',
+    "\<C-W>F": 'split',
+    "\<C-W>gF": 'tab split',
+  }[editcmd]
+  execute how_to_split .. ' ' .. fnameescape(filepath)
+enddef
+
 def Open(target: any, editcmd: string, search_pattern: string = '') #{{{2
     var split: string = editcmd[0] == 'g' ? 'edit' : editcmd[1] == 'g' ? 'tabedit' : 'split'
     var fname: string
@@ -220,12 +267,12 @@ def Fallback(editcmd: string) #{{{2
     endtry
 enddef
 
-def FindCurfunc(): string #{{{2
+def ExpandCurWord(char: string): string #{{{2
     var curfunc = ''
     var saved_iskeyword = &iskeyword
 
     try
-        set iskeyword+=#
+        execute 'set iskeyword+=' .. char
         curfunc = expand('<cword>')
     finally
         &iskeyword = saved_iskeyword

--- a/runtime/ftplugin/vim.vim
+++ b/runtime/ftplugin/vim.vim
@@ -135,7 +135,7 @@ endif
 
 " set 'path' to common Vim directories
 setlocal path-=/usr/include
-setlocal path+=pack/**,runtime/**,autoload/**,colors/**,compiler/**,ftplugin/**,indent/**,keymap/**,macros/**,plugin/**,syntax/**,after/**
+setlocal path+=pack/**,runtime/**,autoload/**,colors/**,compiler/**,ftplugin/**,indent/**,keymap/**,macros/**,plugin/**,syntax/**,after/**,python/**
 
 if !exists("no_plugin_maps") && !exists("no_vim_maps")
   let b:did_add_maps = 1


### PR DESCRIPTION
I think it's useful for plugin developers who use python that when pressing `gf` on a line like this
```vim
py3 import something
```
vim knows to search the file `something.py` in `&rtp`.

Probably the logic that handles corner cases could be exported to the python runtime file. 

ping @dkearns