### PR TITLE
Fix :set pumopt and :set pumborder command-line completion

### DIFF
--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -1131,10 +1131,8 @@ did_set_ambiwidth(optset_T *args UNUSED)
     return check_chars_options();
 }
 
-#if defined(FEAT_TABPANEL) || defined(FEAT_DIFF) || defined(FEAT_PROP_POPUP)
-
 // "name" must be a string literal, the length is computed at compile time.
-# define completing_value_for_subopt(args, name) \
+#define completing_value_for_subopt(args, name) \
 	  completing_value_for_subopt_len(args, name, (int)STRLEN_LITERAL(name))
 
 /*
@@ -1155,7 +1153,6 @@ completing_value_for_subopt_len(optexpand_T *args, char *name, int len)
 
     return STRNCMP(colon - len, name, len) == 0;
 }
-#endif
 
     int
 expand_set_ambiwidth(optexpand_T *args, int *numMatches, char_u ***matches)
@@ -3921,9 +3918,29 @@ error:
     return e_invalid_argument;
 }
 
+    static char_u *
+get_pum_border_style(expand_T *xp UNUSED, int idx)
+{
+    static char *styles[] = {"ascii", "custom:", "single", "double", "round"};
+    return idx < ((enc_utf8 && *p_ambw == 's') ? (int)ARRAY_LENGTH(styles) : 2)
+	    ? (char_u *)styles[idx] : NULL;
+}
+
     int
 expand_set_pumopt(optexpand_T *args, int *numMatches, char_u ***matches)
 {
+    expand_T *xp = args->oe_xp;
+
+    if (xp->xp_pattern > args->oe_set_arg && *(xp->xp_pattern-1) == ':')
+    {
+	if (completing_value_for_subopt(args, "border"))
+	{
+	    return expand_set_opt_generic(
+		    args, get_pum_border_style, numMatches, matches);
+	}
+	return FAIL;
+    }
+
     static char *(p_pumopt_values[]) = {"border:", "height:", "width:",
 	"maxwidth:", "opacity:", "shadow", "margin", NULL};
     return expand_set_opt_string(
@@ -3996,17 +4013,19 @@ error:
     return e_invalid_argument;
 }
 
+    static char_u *
+get_pumborder_token(expand_T *xp, int idx)
+{
+    return idx == 0 ? (char_u *)"margin"
+	 : idx == 1 ? (char_u *)"shadow"
+	 : get_pum_border_style(xp, idx - 2);
+}
+
     int
 expand_set_pumborder(optexpand_T *args, int *numMatches, char_u ***matches)
 {
-    static char *(p_pb_values[]) = {"single", "double", "round", "ascii",
-	"custom", "shadow", "margin", NULL};
-    return expand_set_opt_string(
-	    args,
-	    p_pb_values,
-	    ARRAY_LENGTH(p_pb_values) - 1,
-	    numMatches,
-	    matches);
+    return expand_set_opt_generic(
+	    args, get_pumborder_token, numMatches, matches);
 }
 
 #if defined(FEAT_STL_OPT)

--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -1131,8 +1131,6 @@ did_set_ambiwidth(optset_T *args UNUSED)
     return check_chars_options();
 }
 
-#if defined(FEAT_TABPANEL) || defined(FEAT_DIFF) || defined(FEAT_PROP_POPUP)
-
 // "name" must be a string literal, the length is computed at compile time.
 # define completing_value_for_subopt(args, name) \
 	  completing_value_for_subopt_len(args, name, (int)STRLEN_LITERAL(name))
@@ -1155,7 +1153,6 @@ completing_value_for_subopt_len(optexpand_T *args, char *name, int len)
 
     return STRNCMP(colon - len, name, len) == 0;
 }
-#endif
 
     int
 expand_set_ambiwidth(optexpand_T *args, int *numMatches, char_u ***matches)
@@ -3924,6 +3921,23 @@ error:
     int
 expand_set_pumopt(optexpand_T *args, int *numMatches, char_u ***matches)
 {
+    if (args->oe_xp->xp_pattern > args->oe_set_arg
+	    && *(args->oe_xp->xp_pattern-1) == ':')
+    {
+	if (completing_value_for_subopt(args, "border"))
+	{
+	    static char *(p_pumopt_border_values[]) = {"ascii", "custom:",
+		"double", "round", "single", NULL};
+	    return expand_set_opt_string(
+		    args,
+		    p_pumopt_border_values,
+		    ARRAY_LENGTH(p_pumopt_border_values) - 1,
+		    numMatches,
+		    matches);
+	}
+	return FAIL;
+    }
+
     static char *(p_pumopt_values[]) = {"border:", "height:", "width:",
 	"maxwidth:", "opacity:", "shadow", "margin", NULL};
     return expand_set_opt_string(

--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -820,6 +820,32 @@ func Test_set_completion_string_values()
   set ww&
 endfunc
 
+func Test_set_pumopt_and_pumborder_completion()
+  let Chk = {cmd, completions ->
+            \ assert_equal(sort(completions),
+            \              sort(getcompletion(cmd, 'cmdline')))}
+
+  " opacity can be any integer from 0 to 100; no completions are offered.
+  call Chk('set pumopt=opacity:', [])
+
+  set encoding=utf-8 | set ambiwidth=single
+  call Chk('set pumborder=',
+        \ ['ascii', 'custom:', 'double', 'margin', 'round', 'shadow', 'single'])
+  call Chk('set pumborder=s', ['shadow', 'single'])
+  call Chk('set pumopt=shadow,border:',
+        \ ['ascii', 'custom:', 'double', 'round', 'single'])
+
+  for [&encoding, &ambiwidth] in
+        \ [['utf-8', 'double'], ['latin1', 'single'], ['latin1', 'double']]
+    call Chk('set pumborder=', ['ascii', 'custom:', 'margin', 'shadow'])
+    call Chk('set pumborder=s', ['shadow'])
+    call Chk('set pumopt=shadow,border:', ['ascii', 'custom:'])
+  endfor
+
+  set encoding&
+  set ambiwidth&
+endfunc
+
 func Test_set_option_errors()
   call assert_fails('set scroll=-1', 'E49:')
   call assert_fails('set backupcopy=', 'E474:')

--- a/src/testdir/test_options.vim
+++ b/src/testdir/test_options.vim
@@ -698,6 +698,13 @@ func Test_set_completion_string_values()
   call assert_equal('patience', getcompletion('set diffopt+=iblank,algorithm:pat*', 'cmdline')[0])
   call assert_equal('char', getcompletion('set diffopt+=iwhite,inline:ch*', 'cmdline')[0])
 
+  " pumopt
+  call assert_equal(['custom:'], getcompletion('set pumopt=border:c', 'cmdline'))
+  " opacity can be any integer from 0 to 100; no completions are offered.
+  call assert_equal([], getcompletion('set pumopt=opacity:', 'cmdline'))
+  call assert_equal(['ascii', 'custom:', 'double', 'round', 'single'],
+        \ getcompletion('set pumopt=shadow,border:', 'cmdline'))
+
   " highlight: special parsing, including auto-completing highlight groups
   " after ':'
   call assert_equal([escape(&hl, '|'), '8'], getcompletion('set hl=', 'cmdline')[0:1])


### PR DESCRIPTION
**Problem:** Incorrect completions are offered for the 'pumopt' and 'pumborder' options.
**Solution:** Fix expand_set_pumborder() and expand_set_pumopt() to only offer valid completions.

The "single", "double" and "round" border styles aren't offered when they cannot be used: 'encoding' must be "utf-8" and 'ambiwidth' must be "single" to use them.

"custom:" is now offered instead of "custom".

For 'pumopt', previously sub-option names were incorrectly offered as the only possible completions for a sub-option value.

No completions are offered for the values of 'pumopt' sub-options that take a number. Offering all of the integers from 0 to 100 for "opacity:" wouldn't be useful.