### PR TITLE
scroll: 'smoothscroll' position is lost when splitting a window

### DIFF
--- a/runtime/doc/todo.txt
+++ b/runtime/doc/todo.txt
@@ -41,9 +41,6 @@ squeezed to a couple of lines, for example ":help" followed by ":close".  In
 restore_snapshot_rec() restore more values from the snapshot, instead of
 calling frame_new_height() and frame_new_width(), especially w_skipcol.
 
-With 'splitkeep' "screen" the scroll position is lost when splitting and
-closing a window, win_fix_cursor() moves the cursor to another line.
-
 When a help item can't be found, then open 'helpfile'.  Search for the tag in
 that file and gtive E149 only when not found.  Helps for a tiny Vim installed
 without all the help files.

--- a/src/testdir/test_window_cmd.vim
+++ b/src/testdir/test_window_cmd.vim
@@ -2034,6 +2034,25 @@ func Test_splitkeep_cmdheight()
   set splitkeep& cmdheight&
 endfunc
 
+func Test_splitkeep_screen_smoothscroll()
+  set splitkeep=screen
+  setlocal smoothscroll
+  call setline(1, [repeat('x', 3000)] + repeat(['line'], 10))
+  exe "normal! gg10\<C-E>"
+  redraw
+  let skipcol = winsaveview().skipcol
+  call assert_notequal(0, skipcol)
+
+  " Keeping the same screen lines also keeps the position in a long line.
+  split
+  close
+  redraw
+  call assert_equal(skipcol, winsaveview().skipcol)
+
+  %bwipeout!
+  set splitkeep&
+endfunc
+
 func Test_aucmd_win_scroll_multibyte()
   " Using the autocommand window must not scroll the current window when the
   " cursor is behind multi-byte characters.

--- a/src/window.c
+++ b/src/window.c
@@ -7287,6 +7287,9 @@ win_fix_scroll(int resize)
 		int diff = (wp->w_winrow - wp->w_prev_winrow)
 					  + (wp->w_height - wp->w_prev_height);
 		pos_T cursor = wp->w_cursor;
+		linenr_T topline = wp->w_topline;
+		colnr_T skipcol = wp->w_skipcol;
+
 		wp->w_cursor.lnum = wp->w_botline - 1;
 
 		//  Add difference in height and row to botline.
@@ -7301,6 +7304,9 @@ win_fix_scroll(int resize)
 		scroll_to_fraction(wp, wp->w_prev_height);
 
 		wp->w_cursor = cursor;
+		// Keeping the same screen lines includes the skipped columns.
+		if (wp->w_topline == topline)
+		    wp->w_skipcol = skipcol;
 		wp->w_valid &= ~VALID_WCOL;
 	    }
 	    else if (wp == curwin)
@@ -7468,15 +7474,17 @@ scroll_to_fraction(win_T *wp, int prev_height)
 	     * Make cursor line the first line in the window.  If not enough
 	     * room use w_skipcol;
 	     */
+	    int		want_row = wp->w_wrow;	// where the cursor should be
+
 	    wp->w_wrow = line_size;
 	    if (wp->w_wrow >= wp->w_height
 				       && (wp->w_width - win_col_off(wp)) > 0)
 	    {
-		// The cursor must be visible, override the scroll position.
+		// Skip columns to get the cursor in the wanted row.
 		colnr_T	skipcol = wp->w_width - win_col_off(wp);
 
 		--wp->w_wrow;
-		while (wp->w_wrow >= wp->w_height)
+		while (wp->w_wrow > want_row)
 		{
 		    skipcol += wp->w_width - win_col_off(wp) + win_col_off2(wp);
 		    --wp->w_wrow;


### PR DESCRIPTION
```
Problem:  With 'smoothscroll' the position in a long line is lost when a
          window is split and closed again.
Solution: With 'splitkeep' "screen" keep the skipped columns, they are part
          of keeping the same screen lines.  Otherwise put the cursor in the
          row that keeps its relative position, instead of the last row.
```

---

This was in todo.txt, the entry is removed.

With 'smoothscroll' and a line longer than the window, ":split" followed by
":close" moved the view back by several screen lines.  With a window of 23
lines and 'columns' 80, the skipped columns went from 800 to 160.

For 'splitkeep' "screen" win_fix_scroll() keeps the same screen lines by
moving the cursor to the last line and scrolling to it; that recomputes the
skipped columns for a position which is not where the cursor is.  The cursor
is put back afterwards, now the skipped columns are as well, when the topline
did not change.  The position is now kept exactly.

For 'splitkeep' "cursor" scroll_to_fraction() put the cursor in the last row
of the window when the cursor line does not fit, instead of the row that
keeps its relative position.  With the example above the skipped columns are
now 880 instead of 160; the remaining difference of one screen line is the
resolution of the fraction.

The second change also applies without 'smoothscroll', where the skipped
columns are used to keep the cursor visible in a line that is longer than
the window.