### PR TITLE
test: Test_aucmd_win_scroll_multibyte() is flaky in the GUI

### DIFF
--- a/src/testdir/test_window_cmd.vim
+++ b/src/testdir/test_window_cmd.vim
@@ -2038,8 +2038,11 @@ func Test_aucmd_win_scroll_multibyte()
   " Using the autocommand window must not scroll the current window when the
   " cursor is behind multi-byte characters.
   set splitkeep=cursor
-  call setline(1, repeat([repeat(nr2char(0x3042), 200)], 20))
-  normal! G0100l
+  " Use a window with a fixed size, the size of the screen may change while
+  " the test is running.
+  call NewWindow(11, 40)
+  call setline(1, repeat([repeat(nr2char(0x3042), 100)], 20))
+  normal! G050l
   redraw
   let topline = line('w0')
 
@@ -2049,6 +2052,7 @@ func Test_aucmd_win_scroll_multibyte()
   call assert_equal(topline, line('w0'))
 
   %bwipeout!
+  only!
   set splitkeep&
 endfunc
 


### PR DESCRIPTION
```
Problem:  The test comparing the top line before and after using the
          autocommand window is flaky in the GUI.
Solution: Run the test in a window with a fixed size.  In the GUI a
          pending resize of the shell is applied at the end of a screen
          update, thus the size may change between the two measurements.
```

https://github.com/vim/vim/pull/20901#issuecomment-5152419075