### PR TITLE
fix: ":for" over a tuple leaks memory on every iteration

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -3005,9 +3005,12 @@ next_for_item(void *fi_void, char_u *arg)
 	++fi->fi_tuple_idx;
 	++fi->fi_bi;
 	if (skip_assign)
-	    return TRUE;
-	return ex_let_vars(arg, &tv, TRUE, fi->fi_semicolon,
+	    result = TRUE;
+	else
+	    result = ex_let_vars(arg, &tv, TRUE, fi->fi_semicolon,
 					    fi->fi_varcount, flag, NULL) == OK;
+	clear_tv(&tv);
+	return result;
     }
 
     item = fi->fi_lw.lw_item;

--- a/src/testdir/test_tuple.vim
+++ b/src/testdir/test_tuple.vim
@@ -778,6 +778,20 @@ func Test_tuple_for()
       LET sum += v2
     endfor
     call assert_equal(0, sum)
+
+    #" iterating over string items; the copied item must not be leaked
+    VAR res = ''
+    for v3 in ('a', 'bb', 'ccc')
+      LET res ..= v3
+    endfor
+    call assert_equal('abbccc', res)
+
+    #" iterating over container items must not leak a reference
+    VAR flat = []
+    for v4 in (['a'], ['b', 'c'])
+      LET flat += v4
+    endfor
+    call assert_equal(['a', 'b', 'c'], flat)
   END
   call v9.CheckSourceLegacyAndVim9Success(lines)
 
@@ -786,6 +800,18 @@ func Test_tuple_for()
     vim9script
     var count = 0
     for _ in (1, 2, 3)
+      count += 1
+    endfor
+    assert_equal(3, count)
+  END
+  call v9.CheckSourceSuccess(lines)
+
+  " ignoring the for loop assignment using '_'; string items must not be
+  " leaked
+  let lines =<< trim END
+    vim9script
+    var count = 0
+    for _ in ('a', 'bb', 'ccc')
       count += 1
     endfor
     assert_equal(3, count)


### PR DESCRIPTION
Problem:  Looping over a tuple with ":for" copies each item with copy_tv() but never clears the copy, leaking the value on every iteration (26MB over 100k iterations of a two-string tuple).  Container items keep an extra reference forever, also defeating garbage collection.

Solution: Clear the copied typval on both return paths, like the string branch of next_for_item() already does.

Disclosure: Claude Fable 5 was used to assist with finding this bug. I reviewed this, but I am new to this codebase so forgive me if I am wrong about this problem. This fix was also verified with tests locally, but I didn't think it made sense to add this kind of test to the build. Let me know if we'd like a regression test here.