### PR TITLE
fix: Test_aucmd_win_scroll_multibyte flakiness

### DIFF
--- a/src/testdir/test_window_cmd.vim
+++ b/src/testdir/test_window_cmd.vim
@@ -2035,6 +2035,14 @@ func Test_splitkeep_cmdheight()
 endfunc
 
 func Test_aucmd_win_scroll_multibyte()
+  " The assertion below compares the window topline before and after using
+  " the autocommand window, which assumes the window geometry stays the
+  " same.  In the GUI a resize event from the window manager may be
+  " processed in between and legitimately change the topline, making the
+  " test flaky.  The plines_win_col() logic being tested is not
+  " GUI-specific.
+  CheckNotGui
+
   " Using the autocommand window must not scroll the current window when the
   " cursor is behind multi-byte characters.
   set splitkeep=cursor


### PR DESCRIPTION
Test_aucmd_win_scroll_multibyte compares the window topline before and after using the autocommand window, which assumes the window geometry doesn't change in between. In the GUI a resize can be processed while the test runs, legitimately changing the topline, which makes the test flaky. It appears to have failed on master, for instance, and it failed on my other recent PR as well #20914.

The solution is to skip this test in the GUI. The logic in plines_win_col being tested isn't GUI specific, so it stays covered by the non-GUI test configurations.