### PR TITLE
runtime(doc): remove todo entries that are fixed

### DIFF
--- a/runtime/doc/todo.txt
+++ b/runtime/doc/todo.txt
@@ -36,18 +36,9 @@ browser use: https://github.com/vim/vim/issues/1234
 							*known-bugs*
 -------------------- Known bugs and current work -----------------------
 
-With 'smoothscroll' the scroll position is lost when a window is temporarily
-squeezed to a couple of lines, for example ":help" followed by ":close".  In
-restore_snapshot_rec() restore more values from the snapshot, instead of
-calling frame_new_height() and frame_new_width(), especially w_skipcol.
-
 When a help item can't be found, then open 'helpfile'.  Search for the tag in
 that file and gtive E149 only when not found.  Helps for a tiny Vim installed
 without all the help files.
-
-Virtual text problems:
--  Virtual text aligned "above": Wrong indentation when using tabs  (Issue
-   #12232)
 
 Errors when running tests with valgrind:
 - test_gui.vim:


### PR DESCRIPTION
The 'smoothscroll' scroll position is kept when a window is squeezed since patch 9.2.0885, and the Tab size in a line with virtual text above it is correct since patch 9.2.0896.