### PR TITLE
Vim9: cannot use an exported function of an autoload import as a value

### DIFF
--- a/src/testdir/test_vim9_import.vim
+++ b/src/testdir/test_vim9_import.vim
@@ -2843,6 +2843,41 @@ def Test_import_autoload_postponed()
   &rtp = save_rtp
 enddef
 
+def Test_import_autoload_func_as_value()
+  var lines =<< trim END
+      vim9script
+      export def Exported(): string
+        return 'exported'
+      enddef
+  END
+  writefile(lines, 'XimportRelFunc.vim', 'D')
+  writefile(lines, 'XimportRelFunc2.vim', 'D')
+
+  # Using the exported function as a value, not calling it.
+  lines =<< trim END
+      vim9script
+      import autoload './XimportRelFunc.vim'
+      def Func()
+        var Fn: func = XimportRelFunc.Exported
+        assert_equal('exported', Fn())
+      enddef
+      Func()
+  END
+  v9.CheckScriptSuccess(lines)
+
+  # The script is not loaded yet when compiling, thus the name is only
+  # checked when the function runs.
+  lines =<< trim END
+      vim9script
+      import autoload './XimportRelFunc2.vim'
+      def Func()
+        var Fn: func = XimportRelFunc2.NoSuchFunc
+      enddef
+      Func()
+  END
+  v9.CheckScriptFailure(lines, 'E121: Undefined variable: NoSuchFunc', 1)
+enddef
+
 def Test_import_autoload_override()
   mkdir('Xoverdir/autoload', 'pR')
   var save_rtp = &rtp

--- a/src/vim9execute.c
+++ b/src/vim9execute.c
@@ -4180,9 +4180,30 @@ exec_instructions(ectx_T *ectx)
 
 		    if (di == NULL)
 		    {
-			SOURCING_LNUM = iptr->isn_lnum;
-			semsg(_(e_undefined_variable_str), name);
-			goto on_error;
+			ufunc_T	*ufunc = NULL;
+
+			if (iptr->isn_type == ISN_LOADEXPORT)
+			{
+			    type_T	*type;
+
+			    // Not a variable, it can be an exported function
+			    // used as a value.
+			    (void)find_exported(sid, name, &ufunc, &type,
+							 NULL, NULL, FALSE);
+			}
+			if (ufunc == NULL)
+			{
+			    SOURCING_LNUM = iptr->isn_lnum;
+			    semsg(_(e_undefined_variable_str), name);
+			    goto on_error;
+			}
+			if (GA_GROW_FAILS(&ectx->ec_stack, 1))
+			    goto theend;
+			tv = STACK_TV_BOT(0);
+			tv->v_lock = 0;
+			++ectx->ec_stack.ga_len;
+			tv->v_type = VAR_FUNC;
+			tv->vval.v_string = vim_strsave(ufunc->uf_name);
 		    }
 		    else
 		    {


### PR DESCRIPTION
```
Problem:  Using an exported function of a script imported with "import
          autoload" as a value gives E121, unless the script is under an
          "autoload" directory.
Solution: When the name is not a script variable also look for an exported
          function and push a funcref for it.
```

fixes: #20911