### PR TITLE
"zb" scrolls incorrectly with cursor just above fold

### DIFF
--- a/src/move.c
+++ b/src/move.c
@@ -2790,6 +2790,7 @@ scroll_cursor_bot(int min_scroll, int set_topbot)
 		)
 	    break;
 
+	linenr_T loff_lnum_before = loff.lnum;
 	// Add one line above
 	topline_back(&loff);
 	if (loff.height == MAXCOL)
@@ -2808,15 +2809,13 @@ scroll_cursor_bot(int min_scroll, int set_topbot)
 	    // Count screen lines that are below the window.
 	    scrolled += loff.height;
 	    if (loff.lnum == curwin->w_botline
-#ifdef FEAT_DIFF
-			    && loff.fill == 0
-#endif
-		    )
+		    && loff_lnum_before > curwin->w_botline)
 		scrolled -= curwin->w_empty_rows;
 	}
 
 	if (boff.lnum < curbuf->b_ml.ml_line_count)
 	{
+	    linenr_T boff_lnum_before = boff.lnum;
 	    // Add one line below
 	    botline_forw(&boff);
 	    used += boff.height;
@@ -2835,11 +2834,8 @@ scroll_cursor_bot(int min_scroll, int set_topbot)
 		{
 		    // Count screen lines that are below the window.
 		    scrolled += boff.height;
-		    if (boff.lnum == curwin->w_botline
-#ifdef FEAT_DIFF
-			    && boff.fill == 0
-#endif
-			    )
+		    if (boff.lnum >= curwin->w_botline
+			    && boff_lnum_before < curwin->w_botline)
 			scrolled -= curwin->w_empty_rows;
 		}
 	    }

--- a/src/testdir/test_normal.vim
+++ b/src/testdir/test_normal.vim
@@ -4397,13 +4397,18 @@ func Test_single_line_filler_zb()
 endfunc
 
 " Test for zb with fewer buffer lines than window height, non-zero 'scrolloff'
-" and cursor on fold.
-func Test_zb_with_cursor_on_fold()
+" and cursor on or just above a fold.
+func Test_zb_with_cursor_on_or_just_above_fold()
   15new
   call setline(1, range(1, 5) + ['', 'foo{{{', 'bar}}}', '', 'baz'])
   setlocal foldmethod=marker scrolloff=1
   call assert_equal(8, foldclosedend(7))
+
   call cursor(7, 1)
+  normal! zb
+  call assert_equal(1, line('w0'))
+
+  call cursor(6, 1)
   normal! zb
   call assert_equal(1, line('w0'))
 


### PR DESCRIPTION
Problem:  "zb" scrolls incorrectly with cursor just above fold.
Solution: Handle boff.lnum being set to the last line of a fold.

With the cursor just above fold, botline_forw() moves boff.lnum to the
last line of the fold, but curwin->w_botline is at the first line of the
fold, so the boff.lnum == curwin->w_botline condition never holds.

Instead, check that boff.lnum has just moved to or past w_botline by
comparing its previous value with w_botline.

Also make a similar change to the loff.lnum check above for symmetry.
That one doesn't change behavior, as topline_back() sets loff.lnum to
the first line of a fold.

related: neovim/neovim#41122
