### PR TITLE
ci-linux: ubuntu-26.04 & GCC-15

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -15,11 +15,11 @@ permissions:
 
 jobs:
   linux:
-    runs-on: ${{ matrix.architecture == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+    runs-on: ${{ matrix.architecture == 'arm64' && 'ubuntu-26.04-arm' || 'ubuntu-26.04' }}
 
     env:
       CC: ${{ matrix.compiler }}
-      GCC_VER: 14
+      GCC_VER: 15
       CLANG_VER: 22
       TEST: test
       SRCDIR: ./src

--- a/.github/workflows/ci-linux_asan.yml
+++ b/.github/workflows/ci-linux_asan.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   linux-asan:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
 
     env:
       CC: clang

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   scan:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
 
     env:
       CC: gcc

--- a/src/testdir/test_terminal2.vim
+++ b/src/testdir/test_terminal2.vim
@@ -711,8 +711,8 @@ func Test_term_gettty()
     " Find tty using the tty shell command.
     call WaitForAssert({-> assert_notequal('', term_getline(buf, 1))})
     call term_sendkeys(buf, "tty\r")
-    call WaitForAssert({-> assert_notequal('', term_getline(buf, 3))})
-    let tty = term_getline(buf, 2)
+    call WaitForAssert({-> assert_equal(gettty, term_getline(buf, 2)[: len(gettty) - 1])})
+    let tty = term_getline(buf, 2)[: len(gettty) - 1]
     call assert_equal(tty, gettty)
   endif
 


### PR DESCRIPTION
24.04: Expanded Security Maintenance ends in 9 years (31 May 2036)