### PR TITLE
Include `hardcopy_postscript.c` in makefiles

### DIFF
--- a/src/Make_ami.mak
+++ b/src/Make_ami.mak
@@ -128,6 +128,7 @@ SRC += \
 	getchar.c \
 	gc.c \
 	hardcopy.c \
+	hardcopy_postscript.c \
 	hashtab.c \
 	help.c \
 	highlight.c \

--- a/src/Make_cyg_ming.mak
+++ b/src/Make_cyg_ming.mak
@@ -834,6 +834,7 @@ OBJ = \
 	$(OUTDIR)/gc.o \
 	$(OUTDIR)/gui_xim.o \
 	$(OUTDIR)/hardcopy.o \
+	$(OUTDIR)/hardcopy_postscript.o \
 	$(OUTDIR)/hashtab.o \
 	$(OUTDIR)/help.o \
 	$(OUTDIR)/highlight.o \
@@ -1323,6 +1324,8 @@ $(OUTDIR)/ex_cmds2.o: ex_cmds2.c $(INCL) version.h
 $(OUTDIR)/ex_docmd.o: ex_docmd.c $(INCL) ex_cmdidxs.h
 
 $(OUTDIR)/hardcopy.o: hardcopy.c $(INCL) version.h
+
+$(OUTDIR)/hardcopy_postscript.o: hardcopy_postscript.c $(INCL) version.h
 
 $(OUTDIR)/misc1.o: misc1.c $(INCL) version.h
 

--- a/src/Make_mvc.mak
+++ b/src/Make_mvc.mak
@@ -729,6 +729,7 @@ OBJ = \
 	$(OUTDIR)\gc.obj \
 	$(OUTDIR)\gui_xim.obj \
 	$(OUTDIR)\hardcopy.obj \
+	$(OUTDIR)\hardcopy_postscript.obj \
 	$(OUTDIR)\hashtab.obj \
 	$(OUTDIR)\help.obj \
 	$(OUTDIR)\highlight.obj \
@@ -1621,6 +1622,8 @@ $(OUTDIR)/gc.obj: $(OUTDIR) gc.c $(INCL)
 $(OUTDIR)/gui_xim.obj: $(OUTDIR) gui_xim.c $(INCL)
 
 $(OUTDIR)/hardcopy.obj: $(OUTDIR) hardcopy.c $(INCL) version.h
+
+$(OUTDIR)/hardcopy_postscript.obj: $(OUTDIR) hardcopy_postscript.c $(INCL) version.h
 
 $(OUTDIR)/hashtab.obj: $(OUTDIR) hashtab.c $(INCL)
 

--- a/src/Make_vms.mms
+++ b/src/Make_vms.mms
@@ -536,6 +536,7 @@ SRC = \
  gc.c \
  gui_xim.c \
  hardcopy.c \
+ hardcopy_postscript.c \
  hashtab.c \
  help.c \
  highlight.c \
@@ -676,6 +677,7 @@ OBJ = \
  [.$(DEST)]gc.obj \
  [.$(DEST)]gui_xim.obj \
  [.$(DEST)]hardcopy.obj \
+ [.$(DEST)]hardcopy_postscript.obj \
  [.$(DEST)]hashtab.obj \
  [.$(DEST)]help.obj \
  [.$(DEST)]highlight.obj \
@@ -1167,6 +1169,10 @@ lua_env :
  gui.h beval.h option.h ex_cmds.h proto.h \
  errors.h globals.h
 [.$(DEST)]hardcopy.obj : hardcopy.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
+ ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
+ gui.h beval.h option.h ex_cmds.h proto.h \
+ errors.h globals.h version.h
+[.$(DEST)]hardcopy_postscript.obj : hardcopy_postscript.c vim.h [.$(DEST)]config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h structs.h regexp.h \
  gui.h beval.h option.h ex_cmds.h proto.h \
  errors.h globals.h version.h


### PR DESCRIPTION
Problem:  A recent commit moved the original content of `hardcopy.c`
          into `hardcopy_postscript.c`, but the makefiles were not
          updated to compile and link the new source file. This
          caused build failures on Windows and other systems
          (after v9.2.0898).
Solution: Update makefiles to include `hardcopy_postscript.c`.