### PR TITLE
configure: honor `--disable-hardcopy-pango` with GTK

### DIFF
--- a/src/auto/configure
+++ b/src/auto/configure
@@ -11545,25 +11545,36 @@ printf %s "checking --enable-hardcopy-pango argument... " >&6; }
 if test ${enable_hardcopy_pango+y}
 then :
   enableval=$enable_hardcopy_pango;
+else case e in #(
+  e) enable_hardcopy_pango="auto" ;;
+esac
 fi
 
 
 if test "x$have_pango" = "xno" || test "x$have_cairo" = "xno"; then
+  if test "$fail_if_missing" = "yes" -a "$enable_hardcopy_pango" = "yes"; then
+    as_fn_error $? "could not configure hardcopy-pango" "$LINENO" 5
+  fi
+  enable_hardcopy_pango="no"
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no, Pango or Cairo not found" >&5
 printf "%s\n" "no, Pango or Cairo not found" >&6; }
 else
-  if test "x$GUITYPE" = "xGTK" || test "x$GUITYPE" = "xGTK4"; then
-    enable_hardcopy_pango="yes"
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes, GTK GUI enabled" >&5
+  if test "x$enable_hardcopy_pango" = "xauto"; then
+    if test "x$GUITYPE" = "xGTK" || test "x$GUITYPE" = "xGTK4"; then
+      enable_hardcopy_pango="yes"
+      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes, GTK GUI enabled" >&5
 printf "%s\n" "yes, GTK GUI enabled" >&6; }
-  else
-    if test "$enable_hardcopy_pango" = "yes"; then
-      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
     else
+      enable_hardcopy_pango="no"
       { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
 printf "%s\n" "no" >&6; }
     fi
+  elif test "$enable_hardcopy_pango" = "yes"; then
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; }
+  else
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
   fi
 fi
 

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -3154,20 +3154,28 @@ AC_SUBST(UPDATE_DESKTOP_DATABASE)
 AC_MSG_CHECKING(--enable-hardcopy-pango argument)
 AC_ARG_ENABLE(hardcopy-pango,
 	[  --enable-hardcopy-pango     Use Pango and Cairo for improved hardcopy printing. [default=yes when GTK GUI enabled]],
-	,, enable_hardcopy_pango="no")
+	[],
+	[enable_hardcopy_pango="auto"])
 
 if test "x$have_pango" = "xno" || test "x$have_cairo" = "xno"; then
+  if test "$fail_if_missing" = "yes" -a "$enable_hardcopy_pango" = "yes"; then
+    AC_MSG_ERROR([could not configure hardcopy-pango])
+  fi
+  enable_hardcopy_pango="no"
   AC_MSG_RESULT([no, Pango or Cairo not found])
 else
-  if test "x$GUITYPE" = "xGTK" || test "x$GUITYPE" = "xGTK4"; then
-    enable_hardcopy_pango="yes"
-    AC_MSG_RESULT([yes, GTK GUI enabled])
-  else
-    if test "$enable_hardcopy_pango" = "yes"; then
-      AC_MSG_RESULT([yes])
+  if test "x$enable_hardcopy_pango" = "xauto"; then
+    if test "x$GUITYPE" = "xGTK" || test "x$GUITYPE" = "xGTK4"; then
+      enable_hardcopy_pango="yes"
+      AC_MSG_RESULT([yes, GTK GUI enabled])
     else
+      enable_hardcopy_pango="no"
       AC_MSG_RESULT([no])
     fi
+  elif test "$enable_hardcopy_pango" = "yes"; then
+    AC_MSG_RESULT([yes])
+  else
+    AC_MSG_RESULT([no])
   fi
 fi
 


### PR DESCRIPTION
Problem:  The configure script enables Pango hardcopy automatically
          when the GTK GUI is selected, even when the user explicitly
          specified `--disable-hardcopy-pango` (after v9.2.0898).

Solution: Only enable Pango hardcopy by default when the option was not
          explicitly specified. Preserve the user's choice.