### PR TITLE
hardcopy: prototypes are hand-written instead of generated (after 9.2.0898)

### DIFF
--- a/Filelist
+++ b/Filelist
@@ -95,7 +95,6 @@ SRC_ALL =	\
 		src/hardcopy.c \
 		src/hardcopy.h \
 		src/hardcopy_pango.c \
-		src/hardcopy_pango.h \
 		src/hardcopy_postscript.c \
 		src/hardcopy_postscript.h \
 		src/hashtab.c \
@@ -316,6 +315,8 @@ SRC_ALL =	\
 		src/proto/gui.pro \
 		src/proto/gui_beval.pro \
 		src/proto/hardcopy.pro \
+		src/proto/hardcopy_pango.pro \
+		src/proto/hardcopy_postscript.pro \
 		src/proto/hashtab.pro \
 		src/proto/help.pro \
 		src/proto/highlight.pro \

--- a/src/Make_mvc.mak
+++ b/src/Make_mvc.mak
@@ -1987,6 +1987,8 @@ proto.h: \
 	proto/gc.pro \
 	proto/gui_xim.pro \
 	proto/hardcopy.pro \
+	proto/hardcopy_pango.pro \
+	proto/hardcopy_postscript.pro \
 	proto/hashtab.pro \
 	proto/help.pro \
 	proto/highlight.pro \

--- a/src/Makefile
+++ b/src/Makefile
@@ -1927,6 +1927,8 @@ PROTO_FILES = \
 	proto/gui_gtk_gresources.pro \
 	proto/gui_xim.pro \
 	proto/hardcopy.pro \
+	proto/hardcopy_pango.pro \
+	proto/hardcopy_postscript.pro \
 	proto/hashtab.pro \
 	proto/help.pro \
 	proto/highlight.pro \
@@ -4109,12 +4111,12 @@ objects/hardcopy.o: auto/osdef.h hardcopy.c vim.h protodef.h auto/config.h featu
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
  libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
- globals.h errors.h version.h hardcopy.h hardcopy_pango.h hardcopy_postscript.h
+ globals.h errors.h version.h hardcopy.h hardcopy_postscript.h
 objects/hardcopy_pango.o: auto/osdef.h hardcopy_pango.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
  libvterm/include/vterm_keycodes.h alloc.h ex_cmds.h spell.h proto.h \
- globals.h errors.h hardcopy.h hardcopy_pango.h
+ globals.h errors.h hardcopy.h
 objects/hardcopy_postscript.o: auto/osdef.h hardcopy_postscript.c vim.h protodef.h auto/config.h feature.h os_unix.h \
  ascii.h keymap.h termdefs.h macros.h option.h beval.h \
  structs.h regexp.h gui.h libvterm/include/vterm.h \
@@ -4850,6 +4852,8 @@ proto/gui_beval.pro: gui_beval.c
 proto/gui_gtk_gresources.pro: auto/gui_gtk_gresources.c
 proto/gui_xim.pro: gui_xim.c
 proto/hardcopy.pro: hardcopy.c
+proto/hardcopy_pango.pro: hardcopy_pango.c
+proto/hardcopy_postscript.pro: hardcopy_postscript.c
 proto/hashtab.pro: hashtab.c
 proto/help.pro: help.c
 proto/highlight.pro: highlight.c

--- a/src/hardcopy.c
+++ b/src/hardcopy.c
@@ -20,9 +20,6 @@
 #ifdef FEAT_POSTSCRIPT
 # include "hardcopy_postscript.h"
 #endif
-#ifdef FEAT_PRINT_PANGO
-# include "hardcopy_pango.h"
-#endif
 
 /*
  * To implement printing on a platform, the following functions must be

--- a/src/hardcopy_pango.c
+++ b/src/hardcopy_pango.c
@@ -21,7 +21,6 @@
 #ifdef FEAT_PRINT_PANGO
 
 #include "hardcopy.h"
-#include "hardcopy_pango.h"
 
 #include <cairo/cairo-ps.h>
 #include <cairo/cairo-pdf.h>

--- a/src/hardcopy_postscript.h
+++ b/src/hardcopy_postscript.h
@@ -24,19 +24,6 @@
 
 extern option_table_T mbfont_opts[OPT_MBFONT_NUM_OPTIONS];
 
-void mch_print_cleanup(void);
-int mch_print_init(prt_settings_T *psettings, char_u *jobname, int forceit);
-int mch_print_begin(prt_settings_T *psettings);
-void mch_print_end(prt_settings_T *psettings);
-int mch_print_end_page(void);
-int mch_print_begin_page(char_u *str);
-int mch_print_blank_page(void);
-void mch_print_start_line(int margin, int page_line);
-int mch_print_text_out(char_u *textp, int len);
-void mch_print_set_font(int iBold, int iItalic, int iUnderline);
-void mch_print_set_bg(long_u bgcol);
-void mch_print_set_fg(long_u fgcol);
-
 #endif
 
 #endif

--- a/src/proto.h
+++ b/src/proto.h
@@ -98,6 +98,12 @@ extern int _stricoll(char *a, char *b);
 # include "gc.pro"
 # include "gui_xim.pro"
 # include "hardcopy.pro"
+# ifdef FEAT_PRINT_PANGO
+#  include "hardcopy_pango.pro"
+# endif
+# ifdef FEAT_POSTSCRIPT
+#  include "hardcopy_postscript.pro"
+# endif
 # include "hashtab.pro"
 # include "help.pro"
 # include "highlight.pro"

--- a/src/proto/hardcopy_pango.pro
+++ b/src/proto/hardcopy_pango.pro
@@ -1,19 +1,4 @@
-/* vi:set ts=8 sts=4 sw=4 noet:
- *
- * VIM - Vi IMproved	by Bram Moolenaar
- *
- * Do ":help uganda"  in Vim to read copying and usage conditions.
- * Do ":help credits" in Vim to see a list of people who contributed.
- * See README.txt for an overview of the Vim source code.
- */
-
-#ifndef HARDCOPY_PANGO_H
-#define HARDCOPY_PANGO_H
-
-#include "vim.h"
-
-#if defined(FEAT_PRINT_PANGO)
-
+/* hardcopy_pango.c */
 int mch_print_init(prt_settings_T *psettings, char_u *jobname, int forceit);
 int mch_print_begin(prt_settings_T *psettings);
 void mch_print_end(prt_settings_T *psettings);
@@ -26,7 +11,4 @@ void mch_print_set_font(int bold, int italic, int underline);
 void mch_print_set_bg(long_u bgcol);
 void mch_print_set_fg(long_u fgcol);
 void mch_print_cleanup(void);
-
-#endif
-
-#endif
+/* vim: set ft=c : */

--- a/src/proto/hardcopy_postscript.pro
+++ b/src/proto/hardcopy_postscript.pro
@@ -1,0 +1,14 @@
+/* hardcopy_postscript.c */
+void mch_print_cleanup(void);
+int mch_print_init(prt_settings_T *psettings, char_u *jobname, int forceit);
+int mch_print_begin(prt_settings_T *psettings);
+void mch_print_end(prt_settings_T *psettings);
+int mch_print_end_page(void);
+int mch_print_begin_page(char_u *str);
+int mch_print_blank_page(void);
+void mch_print_start_line(int margin, int page_line);
+int mch_print_text_out(char_u *textp, int len);
+void mch_print_set_font(int iBold, int iItalic, int iUnderline);
+void mch_print_set_bg(long_u bgcol);
+void mch_print_set_fg(long_u fgcol);
+/* vim: set ft=c : */


### PR DESCRIPTION
```
Problem:  The prototypes for the pango and PostScript hardcopy functions
          are written by hand in hardcopy_pango.h and
          hardcopy_postscript.h, instead of being generated into proto/
          like for every other source file.
Solution: Generate proto/hardcopy_pango.pro and
          proto/hardcopy_postscript.pro, include them from proto.h and
          drop the hand-written declarations.  hardcopy_pango.h only held
          prototypes and is removed; hardcopy_postscript.h keeps its
          defines and the mbfont_opts declaration.
```

(Cc: @64-bitman )