### PR TITLE
screen: fill char with a zero low byte is stored as a NUL cell

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -1233,6 +1233,7 @@ skip_opacity:
 			{
 			    ScreenLinesUC[off_to] = c;
 			    ScreenLinesC[0][off_to] = 0;
+			    ScreenLines[off_to] = 0x80; // avoid storing zero
 			}
 			else
 			    ScreenLinesUC[off_to] = 0;
@@ -3081,6 +3082,7 @@ skip_opacity_fill:
 		    {
 			ScreenLinesUC[off] = c;
 			ScreenLinesC[0][off] = 0;
+			ScreenLines[off] = 0x80; // avoid storing zero
 		    }
 		    else
 			ScreenLinesUC[off] = 0;


### PR DESCRIPTION
```
Problem:  Using a multibyte fill character whose lower byte is zero, such
          as U+2500 for a popup border or 'fillchars', stores a NUL in
          ScreenLines[].  That marks the cell as the right half of a
          double-width character, and the GUI reports E340 when the window
          is resized (iranoan).
Solution: Store 0x80 instead of the truncated character code, like
          fold_line() already does.
```

fixes: https://github.com/vim-jp/issues/issues/1460 (Japanese)

---

No test: the NUL in `ScreenLines[]` is invisible from Vim script, since
`screenchar()` returns `ScreenLinesUC[]`. A test would pass on a broken build.