### PR TITLE
screen: the wrong array is copied into ScreenCols on a resize

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -3446,7 +3446,7 @@ give_up:
 			    ScreenAttrs + LineOffset[old_row],
 			    (size_t)len * sizeof(sattr_T));
 		    mch_memmove(new_ScreenCols + new_LineOffset[new_row],
-			    ScreenAttrs + LineOffset[old_row],
+			    ScreenCols + LineOffset[old_row],
 			    (size_t)len * sizeof(colnr_T));
 		}
 	    }


### PR DESCRIPTION
```
Problem:  When the screen is resized without clearing, screenalloc() copies
          ScreenAttrs[] into the new ScreenCols[] instead of ScreenCols[],
          so the virtual columns are replaced by attribute values.  Since
          colnr_T is twice the size of sattr_T it also reads twice the
          intended number of bytes.
Solution: Copy from ScreenCols[].
```

---

No visible symptom, so no test.

The only reader of `ScreenCols[]` is `mouse.c`, guarded by
`curwin->w_redr_type <= UPD_VALID_NO_UPDATE`. The stale values exist only
between the resize and the next redraw, when that guard is false, and
`drawline.c` has rewritten them by the time the array is read. The over-long
read stays inside `ScreenAttrs[]`, ending at exactly
`(screen_Rows + 1) * screen_Columns`.