### PR TITLE
build failure with Pango older than 1.44

### DIFF
--- a/src/hardcopy_pango.c
+++ b/src/hardcopy_pango.c
@@ -378,9 +378,15 @@ mch_print_init(
 	pctx.char_height = (double)(ascent + descent
 		+ (PANGO_SCALE * 15.0) / 16.0) / PANGO_SCALE;
 
+	// Line spacing (line gap) - only available in Pango 1.44+
+#if PANGO_VERSION_CHECK(1,44,0)
 	pctx.line_spacing = (double)
 	    (pango_font_metrics_get_height(metrics) - (ascent + descent))
 	    / PANGO_SCALE;
+#else
+	// Pango < 1.44 doesn't have height metric, default to no line gap
+	pctx.line_spacing = 0.0;
+#endif
 
 	pctx.ul_pos =
 	    (double)pango_font_metrics_get_underline_position(metrics)


### PR DESCRIPTION
Problem:  Build failure with Pango older than 1.44, because
          hardcopy_pango.c calls pango_font_metrics_get_height(), which
          was only added in Pango 1.44 (e.g. RHEL 8 ships 1.42.1).
Solution: Guard the call with PANGO_VERSION_CHECK(1,44,0) and fall back
          to a zero line gap on older Pango (Chris Hamilton).

The line height metric and its accessor pango_font_metrics_get_height() were both introduced in Pango 1.44. Before that release the height field did not exist in PangoFontMetrics at all, so there is no way to recover the font's line gap through either the public API or the private struct. On such systems the line spacing is set to zero, which matches the behaviour Vim had before printing support started using this metric.

fixes: #20952
related: #20648