### PR TITLE
tests: Test_termwinscroll fails on FreeBSD

### DIFF
--- a/src/testdir/test_terminal2.vim
+++ b/src/testdir/test_terminal2.vim
@@ -224,6 +224,11 @@ func Test_termwinscroll()
   exe 'set termwinscroll=' . &lines
   let buf = term_start('/bin/sh')
   call TermWait(buf)
+  " Some shells enable a line editor when interactive on a terminal,
+  " which echoes the typed line a second time; "+o" is a no-op on
+  " shells that have none.
+  call feedkeys("set +o emacs\<CR>", 'xt')
+  call TermWait(buf)
   for i in range(1, &lines)
     call feedkeys("echo " . i . "\<CR>", 'xt')
     call WaitForAssert({-> assert_match(string(i), term_getline(buf, term_getcursor(buf)[0] - 1))})


### PR DESCRIPTION
Test_termwinscroll fails on FreeBSD, 14.4 and 15.1 alike. It is marked
g:test_is_flaky, so the retry hides it often enough that it reads as
flakiness, but the failure is deterministic.

The test requires each "echo N" to appear exactly once in the terminal
buffer. On FreeBSD it appears twice, and when the two copies collide they
land on one line:

   1 |$ echo 12|
   2 |echo 12|
   3 |12|
   4 |echo 13|
   5 |$ echo 13|
   6 |13|
  16 |$ echo echo 17|
  26 |$ echo 2echo 21|

FreeBSD's /bin/sh is linked against libedit, and sh(1) says of -E emacs:
"set automatically when interactive on terminals". term_start('/bin/sh')
gives it a terminal, so it is on. Read from inside the terminal vim
creates:

  vi              off
  emacs           on

The line discipline echoes the keystrokes and libedit redraws the same
line, so the command reaches the scrollback twice. Linux /bin/sh is dash,
which links only libc and has no line editor, which is why this never
shows up there.

Sending "set +o emacs" before the loop removes it. dash accepts "+o" for
an option it does not have, so the line is a no-op there.

Measured with TEST_NO_RETRY=yes, so every run is one independent attempt.
Same VM, patched and pristine, --with-features=huge:

  FreeBSD 14.4-RELEASE       patched 0/10 failed   pristine 10/10 failed
  FreeBSD 15.1-RELEASE-p1    patched 0/10 failed   pristine 10/10 failed

Whole test_terminal2.vim patched, retries on: 23 executed, 0 errors, 0
give-ups on both.

It is not the terminal size. The pristine test fails the same way under
script(1) with a 0x0 pty, with stty 24x80, with stty 40x100, and with no
tty at all; with a 40-row terminal the failures just move up to "echo 40",
following &lines.

CI on my fork. This change alone, 31 of 33 green:
https://github.com/neilpang/vim/actions/runs/31140739256
This change plus a FreeBSD job, 33 of 35, with FreeBSD 14 and 15 both
passing and Test_termwinscroll executed 14 times with no errors:
https://github.com/neilpang/vim/actions/runs/31142503570
The two red jobs in both are the Windows mingw ones that are red on
master as well -- https://github.com/vim/vim/actions/runs/31127598550 is
31/33 with the same two.

Disclosure per CONTRIBUTING.md: written with the help of Claude.
