### PR TITLE
GTK3(wl): fix mouse selection redraw in cmdline

### DIFF
--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -6909,7 +6909,13 @@ gui_mch_wait_for_chars(long wtime)
 	 * situations, sort of race condition).
 	 */
 	if (!input_available())
+	{
 	    g_main_context_iteration(NULL, TRUE);
+#ifdef GDK_WINDOWING_WAYLAND
+    if (gui.is_wayland && clip_star.state == SELECT_IN_PROGRESS)
+	gui_may_flush();
+#endif
+	}
 
 	// Got char, return immediately
 	if (input_available())


### PR DESCRIPTION
Modeless mouse selection on Wayland may not redraw while Vim is
waiting for input, causing the selection highlight to lag behind
mouse movement.

Flush pending GUI updates while a modeless selection is in progress.

* X11 was not affected.
* Tested `FEAT_TINY`, `set clipboard=`, `set mouse=` settings.

```
Notes: `(State & MODE_CMDLINE)`  was not true at the time.

Alternatives:

Considered targeting `process_motion_notify`

However, this is more properly scoped to redraw
main loop, ensures no double scheduling and
equally surgically targeted.
```

Closes: #20969
