### PR TITLE
tests: terminal tests fail on FreeBSD when the shell has a line editor

### DIFF
--- a/src/testdir/util/term_util.vim
+++ b/src/testdir/util/term_util.vim
@@ -181,11 +181,29 @@ endfunc
 
 " Open a terminal with a shell, assign the job to g:job and return the buffer
 " number.
+" Some shells turn on a line editor when they are interactive on a
+" terminal; FreeBSD /bin/sh does.  The editor redraws the line the
+" terminal has already echoed, so a command can land in the buffer
+" twice and shift everything below it.  POSIX shells read $ENV at
+" startup and it produces no output of its own; shells that do not
+" use $ENV ignore the variable.
+let s:shell_env_file = ''
+
+func s:ShellStartupFile()
+  if s:shell_env_file == '' || !filereadable(s:shell_env_file)
+    let s:shell_env_file = tempname()
+    call writefile(['set +o emacs 2>/dev/null', 'set +o vi 2>/dev/null'], s:shell_env_file)
+  endif
+  return s:shell_env_file
+endfunc
+
 func Run_shell_in_terminal(options)
   if has('win32')
     let buf = term_start([&shell, '/D', '/k'], a:options)
   else
-    let buf = term_start(&shell, a:options)
+    let l:options = copy(a:options)
+    let l:options.env = extend({'ENV': s:ShellStartupFile()}, get(a:options, 'env', {}))
+    let buf = term_start(&shell, l:options)
   endif
   let g:test_is_flaky = 1
 


### PR DESCRIPTION
Three more tests in the terminal suite fail on FreeBSD for the same reason
as #20966, but through the shared helper rather than in one test:

  Test_terminal_version       Expected '902'     but got 'exit'
  Test_terminal_env           Expected 'correct' but got 'exit'
  Test_terminal_servername    Expected ''        but got 'exit'

All three go through s:test_environment, which reads getline(2) -- line 1
the prompt and command, line 2 the output. FreeBSD's /bin/sh turns on its
libedit line editor when interactive on a terminal, so the typed command
is echoed twice, everything below shifts by a line, and getline(2) returns
the "exit" that StopShellInTerminal sent instead of the value.

Run_shell_in_terminal now points $ENV at a file that turns the editor off.
POSIX shells read it at startup and it produces no output of its own, so
no buffer line moves; shells that do not use $ENV ignore the variable.
"set +o emacs" and "set +o vi" both exit 0 on dash and bash for options
they do not have.

Measured with TEST_NO_RETRY=yes, so each run is one independent attempt.
Patched and pristine in the same session, on the same VM:

                            patched      pristine
  FreeBSD 14.4-RELEASE
    Test_terminal_version     0/10          3/10
    Test_terminal_env         0/10          3/10
    Test_terminal_servername  0/10          2/10
  FreeBSD 15.1-RELEASE-p1
    Test_terminal_version     0/10          3/10
    Test_terminal_env         0/10          7/10
    Test_terminal_servername  0/10          3/10

Whole files, retries on, both releases:

                        patched                   pristine
  test_terminal.vim     103 run, 0 errors         104 run, 1-2 errors
  test_terminal2.vim    25 run, 4 errors          26 run, 5 errors
  test_terminal3.vim    67 run, 0 errors          67 run, 0-1 errors

test_terminal2's remaining failure is Test_termwinscroll, which is #20966
and not in this tree.

CI on my fork, 31 of 33 green:
https://github.com/neilpang/vim/actions/runs/31169689889
With #20966 and a FreeBSD job on top, 33 of 35, both FreeBSD releases
passing:
https://github.com/neilpang/vim/actions/runs/31169717779
Across both runs the four tests ran 26 times each with no errors. The two
red jobs in both are the Windows mingw ones that are red on master as well.

Disclosure per CONTRIBUTING.md: written with the help of Claude.
