### PR TITLE
tabpage: closing a tab page loses the alternate tab page

### DIFF
--- a/src/testdir/test_tabpage.vim
+++ b/src/testdir/test_tabpage.vim
@@ -942,6 +942,23 @@ func Test_lastused_tabpage()
   tabonly!
 endfunc
 
+" Closing a tab page must keep the last used tab page when it is another one.
+func Test_lastused_tabpage_close()
+  tabonly!
+  tabnew
+  tabnew
+  tabfirst
+  tablast
+  call assert_equal(1, tabpagenr('#'))
+
+  tabclose
+  call assert_equal(1, tabpagenr('#'))
+  call feedkeys("g\<Tab>", "xt")
+  call assert_equal(1, tabpagenr())
+
+  tabonly!
+endfunc
+
 " Test for tabpage allocation failure
 func Test_tabpage_alloc_failure()
   call test_alloc_fail(GetAllocId('newtabpage_tvars'), 0, 0)

--- a/src/window.c
+++ b/src/window.c
@@ -2665,6 +2665,7 @@ close_last_window_tabpage(
 	return FALSE;
 
     buf_T	*old_curbuf = curbuf;
+    tabpage_T	*save_lastused = lastused_tabpage;
 
     /*
      * Closing the last window in a tab page.  First go to another tab
@@ -2682,6 +2683,11 @@ close_last_window_tabpage(
     // to the other tab page.
     if (valid_tabpage(prev_curtab) && prev_curtab->tp_firstwin == win)
 	win_close_othertab(win, free_buf, prev_curtab);
+
+    // Entering the other tab page made the closed one the last used tab page.
+    // Restore the previous one when it is still there.
+    if (valid_tabpage(save_lastused) && save_lastused != curtab)
+	lastused_tabpage = save_lastused;
 #ifdef FEAT_JOB_CHANNEL
     entering_window(curwin);
 #endif


### PR DESCRIPTION
```
Problem:  Closing the current tab page resets the alternate tab page, even
          when that is another tab page which still exists, so that
          CTRL-Tab stops working (igorlfs).
Solution: Restore the last used tab page after entering another one to
          close the current one.
```

related: #20965

---

Closing the current tab page clears the alternate tab page even when the
alternate is a different tab page that still exists:

    :tabnew
    :tabnew
    :tabfirst
    :tablast
    :echo tabpagenr('#')    " 1
    :tabclose
    :echo tabpagenr('#')    " 0, while tab page 1 is still there

`close_last_window_tabpage()` enters another tab page before closing the
current one, which makes the tab page about to be closed the last used one,
and `free_tabpage()` then resets it.

This does not fix the steps in #20965. There the alternate tab page becomes
the current one after the close, so there is nothing left to go back to
without keeping a history of visited tab pages. That would be out of line
with the rest of Vim, where the alternate file (`#`) and the previous window
(`CTRL-W p`) are single entries as well, and it would make the destination of
CTRL-Tab hard to predict.