### PR TITLE
filetype: AL (Business Central) files are detected as perl

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -3,7 +3,7 @@ vim9script
 # Vim functions for file type detection
 #
 # Maintainer:		The Vim Project <https://github.com/vim/vim>
-# Last Change:		2026 Aug 06
+# Last Change:		2026 Aug 08
 # Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 # These functions are moved here from runtime/filetype.vim to make startup
@@ -39,6 +39,32 @@ export def Check_inp()
       n += 1
     endwhile
   endif
+enddef
+
+# AL (Microsoft Dynamics 365 Business Central) or Perl AutoLoader
+export def FTal()
+  if exists("g:filetype_al")
+    exe "setf " .. g:filetype_al
+    return
+  endif
+
+  # AL sources declare an object as "<kind> <id> <name>" at the start of a
+  # line, optionally preceded by namespace and using declarations.  Perl
+  # AutoLoader chunks match neither.  Matching a bare keyword anywhere would
+  # be wrong: table, page and report are ordinary English words, so the object
+  # name must follow.  The match is case sensitive because AL tooling emits
+  # lowercase keywords, while prose in Perl comments is usually capitalised.
+  for lnum in range(1, min([line("$"), 200]))
+    var line = getline(lnum)
+    if line =~# '^\s*\%(codeunit\|page\|pageextension\|pagecustomization\|table\|tableextension\|report\|reportextension\|xmlport\|query\|enum\|enumextension\|profile\|profileextension\|controladdin\|interface\|permissionset\|permissionsetextension\|entitlement\)\>\s\+\%(\d\|"\|\u\)'
+	|| line =~# '^\s*dotnet\s*$'
+	|| line =~# '^\s*\%(namespace\|using\)\s\+[[:alnum:]._]\+\s*;'
+      setf al
+      return
+    endif
+  endfor
+
+  setf perl
 enddef
 
 # Erlang Application Resource Files (*.app.src is matched by extension)

--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -1,4 +1,4 @@
-*filetype.txt*	For Vim version 9.2.  Last change: 2026 Jul 01
+*filetype.txt*	For Vim version 9.2.  Last change: 2026 Aug 08
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -138,6 +138,7 @@ what kind of file it is.  This doesn't always work.  A number of global
 variables can be used to overrule the filetype used for certain extensions:
 
 	file name	variable ~
+	*.al		g:filetype_al
 	*.app		g:filetype_app
 	*.as		g:filetype_as
 	*.asa		g:filetype_asa		|ft-aspperl-syntax|

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1,7 +1,7 @@
 " Vim support file to detect file types
 "
 " Maintainer:		The Vim Project <https://github.com/vim/vim>
-" Last Change:		2026 Jul 18
+" Last Change:		2026 Aug 08
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " If the filetype can be detected from extension or file name(the final path component),
@@ -862,7 +862,10 @@ if has("fname_case")
 else
   au BufNewFile,BufRead *.pl				call dist#ft#FTpl()
 endif
-au BufNewFile,BufRead *.plx,*.al,*.psgi			setf perl
+au BufNewFile,BufRead *.plx,*.psgi			setf perl
+
+" Perl AutoLoader or AL (Dynamics 365 Business Central)
+au BufNewFile,BufRead *.al				call dist#ft#FTal()
 
 " Perl, XPM or XPM2
 au BufNewFile,BufRead *.pm

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -635,7 +635,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     pcmk: ['file.pcmk'],
     pdf: ['file.pdf'],
     pem: ['file.pem', 'file.cer', 'file.crt', 'file.csr'],
-    perl: ['file.plx', 'file.al', 'file.psgi', 'gitolite.rc', '.gitolite.rc', 'example.gitolite.rc', '.latexmkrc', 'latexmkrc'],
+    perl: ['file.plx', 'file.psgi', 'gitolite.rc', '.gitolite.rc', 'example.gitolite.rc', '.latexmkrc', 'latexmkrc'],
     pf: ['pf.conf'],
     pfmain: ['main.cf', 'main.cf.proto'],
     php: ['file.php', 'file.php9', 'file.phtml', 'file.ctp', 'file.phpt', 'file.theme'],
@@ -1267,6 +1267,57 @@ endfunc
 " Tests for specific extensions and filetypes.
 " Keep sorted.
 """""""""""""""""""""""""""""""""""""""""""""""""
+
+func Test_al_file()
+  filetype on
+
+  " AL object declaration
+  call writefile(['codeunit 50100 "My Codeunit"', '{', '}'], 'Xfile.al', 'D')
+  split Xfile.al
+  call assert_equal('al', &filetype)
+  bwipe!
+
+  " AL namespace and using declarations before the object
+  call writefile(['namespace Microsoft.Sales;', '', 'using Microsoft.Foundation;'], 'Xfile.al')
+  split Xfile.al
+  call assert_equal('al', &filetype)
+  bwipe!
+
+  " Perl AutoLoader chunk
+  call writefile(['# NOTE: Derived from blib/lib/Net/SSLeay.pm.', 'package Net::SSLeay;', 'sub do_https {'], 'Xfile.al')
+  split Xfile.al
+  call assert_equal('perl', &filetype)
+  bwipe!
+
+  " AL DotNet alias object, which is a bare keyword on its own line
+  call writefile(['dotnet', '{', '    assembly("mscorlib")', '}'], 'Xfile.al')
+  split Xfile.al
+  call assert_equal('al', &filetype)
+  bwipe!
+
+  " Perl code containing AL object kinds as ordinary words
+  call writefile(['sub value {', '  my $table = shift;', '  # report page interface', '}'], 'Xfile.al')
+  split Xfile.al
+  call assert_equal('perl', &filetype)
+  bwipe!
+
+  " Perl documentation containing AL object kinds at the start of a line
+  call writefile(['package Foo;', '=pod', 'Table of contents', 'using the -x option', 'table of contents follows'], 'Xfile.al')
+  split Xfile.al
+  call assert_equal('perl', &filetype)
+  bwipe!
+
+  " Test dist#ft#FTal()
+
+  let g:filetype_al = 'perl'
+  call writefile(['codeunit 50100 "My Codeunit"'], 'Xfile.al')
+  split Xfile.al
+  call assert_equal('perl', &filetype)
+  bwipe!
+  unlet g:filetype_al
+
+  filetype off
+endfunc
 
 " Since dist#ft#FTm4() looks around for configure.ac
 " the test needs to isolate itself in a fresh temporary project tree,


### PR DESCRIPTION
```
Problem:  *.al is mapped unconditionally to perl.  The extension is shared:
          it is Perl's AutoLoader extension, and also the extension for AL,
          the language of Microsoft Dynamics 365 Business Central, which is
          by now the far more common source of *.al files.
Solution: Detect the two by content in dist#ft#FTal().  An AL object
          declaration at the start of a line, or a namespace or using
          declaration, selects al; anything else keeps returning perl, so
          existing AutoLoader users are unaffected.  g:filetype_al overrules
          the guess (Torben Leth).
```

## Background

`runtime/filetype.vim` currently has:

```vim
au BufNewFile,BufRead *.plx,*.al,*.psgi			setf perl
```

AL is a recognised language in GitHub Linguist, has a maintained tree-sitter grammar, and
is what most `.al` files in the wild contain today. Perl AutoLoader files still exist, so
the extension cannot simply be reassigned, which is why this is content detection in the
style already used for `*.cls` and `*.bas`.

## On the keyword list

The detection deliberately requires declaration syntax rather than a bare keyword match.
Several AL object kinds (`table`, `page`, `report`, `query`) are ordinary English words
that appear freely in Perl comments, POD and here-docs. For comparison, GitHub Linguist
matches those keywords anywhere in the file, which is tolerable when the cost of a false
positive is a wrong colour in a language bar, but not when the cost is a Perl user losing
their filetype.

Three things narrow it:

* the keyword must start the line and be followed by the object name, so
  `table of contents` does not match while `table 50100 "Customer"` does
* the match is case sensitive, because AL tooling emits lowercase keywords while English
  prose is usually capitalised
* `namespace` and `using` must be terminated with `;`, as they always are in AL

Both of these files are correctly detected as `perl`:

```perl
sub value {
  my $table = shift;
  # report page interface
}
```

```perl
package Foo;
=pod
Table of contents
using the -x option
table of contents follows
=cut
```

## Measurements

Run against two corpora:

| Corpus | Files | Correctly detected |
| --- | --- | --- |
| Business Central application sources | 15358 | 99.609% |
| Perl AutoLoader files shipped with Git for Windows | 75 | 100% |

The 60 AL files not detected have no object declaration in their first 200 lines. Most are
files whose entire contents are commented out behind `#if not CLEAN26`, leaving nothing to
match; the rest are header or stub files. They fall back to `perl`.

Treating AL preprocessor directives (`#if`, `#pragma`, `#region`) as an additional signal
was tried and rejected: it recovered 13 of those files but introduced 3 false positives on
Perl sources, where lines such as `#if what we've read so far is greater or equal` are
ordinary comments.

## Testing

`Test_al_file()` is added to `src/testdir/test_filetype.vim` in the sorted section. It
covers an AL object declaration, a namespace and using preamble, a DotNet alias object, a
Perl AutoLoader chunk, both adversarial Perl files above, and the `g:filetype_al`
override. `file.al` is removed from the `perl` entry in `s:filename_checks`, since
detection is now content based.

Run locally with Vim 9.2 and `$VIMRUNTIME` pointed at the modified runtime:

| Test | Result |
| --- | --- |
| `Test_al_file()` | pass |
| `Test_filetype_detection()` | pass |
| `Test_bas_file()`, `Test_cls_file()`, `Test_perl_file()` | pass |
| `test_codestyle.vim` (all 5 tests) | pass |

## Note on scope

This adds detection only. There is no `syntax/al.vim` or `ftplugin/al.vim` in the Vim
runtime, so `al` files get the filetype and the `FileType` autocommand, and syntax
highlighting continues to come from plugins. Happy to split a syntax plugin into a
separate PR if that is wanted, but detection is useful on its own and is currently wrong.

## AI disclosure

Per CONTRIBUTING.md: this change was prepared with AI assistance (Claude). The detection
logic, the measurements above, and the tests were reviewed and run locally by the author.
`test_codestyle.vim` reports no failures.

## Note on Neovim

This was first proposed at neovim/neovim#41230 and closed with the guidance that filetype
detection is inherited from Vim, so the change belongs here first and Neovim will port it.
