### PR TITLE
curswant not set by 8g8

### DIFF
--- a/src/mbyte.c
+++ b/src/mbyte.c
@@ -4461,6 +4461,7 @@ utf_find_illegal(void)
 			curwin->w_cursor.col += l;
 		    }
 		}
+		curwin->w_set_curswant = TRUE;
 		goto theend;
 	    }
 	    p += len;

--- a/src/testdir/test_normal.vim
+++ b/src/testdir/test_normal.vim
@@ -2900,7 +2900,7 @@ func Test_normal_8g8()
   " With invalid byte.
   call setline(1, "___\xff___")
   norm! 1G08g8g
-  call assert_equal([0, 1, 4, 0, 1], getcurpos())
+  call assert_equal([0, 1, 4, 0, 4], getcurpos())
 
   " With invalid byte before the cursor.
   call setline(1, "___\xff___")
@@ -2910,12 +2910,12 @@ func Test_normal_8g8()
   " With truncated sequence.
   call setline(1, "___\xE2\x82___")
   norm! 1G08g8g
-  call assert_equal([0, 1, 4, 0, 1], getcurpos())
+  call assert_equal([0, 1, 4, 0, 4], getcurpos())
 
   " With overlong sequence.
   call setline(1, "___\xF0\x82\x82\xAC___")
   norm! 1G08g8g
-  call assert_equal([0, 1, 4, 0, 1], getcurpos())
+  call assert_equal([0, 1, 4, 0, 4], getcurpos())
 
   " With valid utf8.
   call setline(1, "café")


### PR DESCRIPTION
When 8g8 finds an illegal UTF-8 byte sequence, it moves the cursor but doesn't update the curswant. Make sure to update it.