### PR TITLE
NFA engine fallback can double free the compiled program

### DIFF
--- a/src/regexp.c
+++ b/src/regexp.c
@@ -3114,15 +3114,23 @@ vim_regexec_string(
 	char_u *pat = vim_strsave(((nfa_regprog_T *)rmp->regprog)->pattern);
 
 	p_re = BACKTRACKING_ENGINE;
-	vim_regfree(rmp->regprog);
 	if (pat != NULL)
 	{
+	    regprog_T *prev_prog = rmp->regprog;
+
 #ifdef FEAT_EVAL
 	    report_re_switch(pat);
 #endif
 	    rmp->regprog = vim_regcomp(pat, re_flags);
-	    if (rmp->regprog != NULL)
+	    if (rmp->regprog == NULL)
 	    {
+		// Somehow compiling the pattern failed now, put back the
+		// previous one to avoid "regprog" becoming NULL.
+		rmp->regprog = prev_prog;
+	    }
+	    else
+	    {
+		vim_regfree(prev_prog);
 		rmp->regprog->re_in_use = TRUE;
 		result = rmp->regprog->engine->regexec_nl(rmp, line, col, nl);
 		rmp->regprog->re_in_use = FALSE;


### PR DESCRIPTION
## Problem

When the automatic regexp engine falls back to the backtracking engine in
vim_regexec_string(), the compiled program is freed before the replacement
is compiled.  When vim_strsave() of the pattern fails (out of memory), the
caller's regprog is left pointing at freed memory and is freed again later.
vim_regexec_multi() already has the guarded version of the same code.

## Solution

Free the previous program only after compiling the replacement succeeded,
mirroring vim_regexec_multi().

Found while auditing the ownership hand-off in #20941; the problem exists
on master independently of that PR.  OOM-only path, so no test; the change
is the same shape as the multi-line variant just below it.

AI assistance is acknowledged with Co-Authored-By trailers on the commit,
per AGENTS.md.