### PR TITLE
u_read_undo() leaks the file name when the undo file owner differs

### DIFF
--- a/src/undo.c
+++ b/src/undo.c
@@ -1881,6 +1881,7 @@ u_read_undo(char_u *name, char_u *hash, char_u *orig_name UNUSED)
 								   file_name);
 		verbose_leave();
 	    }
+	    vim_free(file_name);
 	    return;
 	}
 # endif


### PR DESCRIPTION
## Problem

When the owner of an undo file differs from the owner of the text file and
the current user, u_read_undo() returns without freeing the file name it
allocated with u_get_undo_file_name().  Every other exit frees it under
the "theend" label; this early return sits before the file pointer is
initialized, so it cannot use that label.

## Solution

Free the file name before returning.

Noticed while reworking #20942; independent of that change, so sent
separately.

AI assistance is acknowledged with Co-Authored-By trailers on the commit,
per AGENTS.md.
