### PR TITLE
MinGW: tests hang when Vim is built with coverage enabled

### DIFF
--- a/src/Make_cyg_ming.mak
+++ b/src/Make_cyg_ming.mak
@@ -1163,8 +1163,10 @@ endif
 
 all: $(MAIN_TARGET) vimrun.exe xxd/xxd.exe tee/tee.exe install.exe uninstall.exe GvimExt/gvimext.dll
 
+# Coverage instrumentation makes _wsystem() in vimrun hang, and vimrun is not
+# part of Vim itself, so never instrument it.
 vimrun.exe: vimrun.c
-	$(CC) $(CFLAGS) -o vimrun.exe vimrun.c $(LIB)
+	$(CC) $(filter-out --coverage,$(CFLAGS)) -o vimrun.exe vimrun.c $(LIB)
 
 install.exe: dosinst.c dosinst.h version.h
 	$(CC) $(CFLAGS) -o install.exe dosinst.c $(LIB) -lole32 -luuid


### PR DESCRIPTION
```
Problem:  When building with MinGW and COVERAGE=yes the tests hang: a
          command started from Vim never returns, although the child
          process has already exited.
Solution: Do not build vimrun.exe with coverage instrumentation.
```

fixes: #20976

---

## (UPDATE: 2026-08-10 10:50 UTC)

`vimrun.exe` is built with `--coverage`, and a gcov-instrumented `vimrun` hangs
on exit while gcov writes its `.gcda` file. Reproduced locally.

## Why only those two jobs

`Make_cyg_ming.mak` builds vimrun with the same `CFLAGS` as Vim itself:

```make
vimrun.exe: vimrun.c
	$(CC) $(CFLAGS) -o vimrun.exe vimrun.c $(LIB)
```

With `COVERAGE=yes` that pulls in `--coverage`. The two failing jobs are the
only ones in the matrix carrying `coverage: yes`. Everything else lines up with
that: MSVC jobs pass, mingw jobs without coverage pass, and NORMAL/TINY pass.

## What is actually happening

When the run is hung, the process tree is:

    gvim (runtest.vim test_assert.vim)
      +- vimrun -s cmd.exe /c (..\gvim ... -S Xafter.vim )
           +- conhost.exe

No child gvim, no cmd.exe - both have already exited. `Xerrors` is on disk and
contains exactly `Expected 0 but got 1`, with no script location prefixed, so
`Test_assert_equal_typed()` did its job correctly and the child quit normally.

Attaching to the stuck vimrun shows where it sits:

    #0  gcov_do_dump.constprop ()
    #1  __gcov_exit ()
    #2  __do_global_dtors ()
    #3  msvcrt!_initterm_e ()
    #4  msvcrt!exit ()
    #5  __tmainCRTStartup () at mingw-w64-crt/crt/crtexe.c:270

`_wsystem()` has already returned and `main()` is done; vimrun is in its exit
path, writing the gcov `.gcda` file, and never finishes.

So the test, `feedkeys(..., 't')`, the typed-ahead `:qa!` and the child gvim are
all fine. Only the instrumented vimrun is stuck.

## Fix

vimrun is a helper program, not part of Vim, so there is no reason to
instrument it. Rebuilding vimrun without `--coverage` and changing nothing else
makes the test return immediately.

## Reproducing

MSVC will never show this. You need mingw and, above all, `COVERAGE=yes`:

    # MSYS2 MINGW32
    mingw32-make -f Make_ming.mak -j2 FEATURES=HUGE GUI=yes IME=yes ICONV=yes \
      VIMDLL=yes STATIC_STDCPLUS=yes COVERAGE=yes

    # cmd, with C:\msys64\mingw32\bin on PATH
    cd src\testdir
    set TEST_FILTER=Test_assert_equal_typed
    nmake -f Make_mvc.mak VIMPROG=..\gvim

## On the timing

The trigger was still the msys2 side. Between the last passing master run
(30983059032, 08-05 06:55Z) and the first failing one (31036852585, 08-05
18:53Z) the runner image and the workflows were unchanged, while `setup-msys2`
runs with `update: true`:

| package | pass | fail |
| --- | --- | --- |
| `mingw-w64-i686-crt` | 14.0.0.r220.gd999af622-1 | 14.0.0.r248.g7735a1a63-1 |
| `mingw-w64-i686-binutils` | 2.47-1 | 2.47-3 |
| `mingw-w64-i686-gcc` | 16.1.0-6 | 16.1.0-6 |

The CRT range is 28 commits reworking TLS, atexit and the global destructor
handling (`crt/crtexe.c`, `crt/tlssup.c`, `crt/tls_atexit.c`,
`crt/gcc_ctors_dtors.c`, ...) - the very path the backtrace above goes through.
I have not confirmed the causal link, and the fix does not depend on it, but if
someone wants to take this upstream, that is where to look.