### PR TITLE
GTK4(preproc): NORMAL- lacks popup-image guards

### DIFF
--- a/src/gui_gtk4.c
+++ b/src/gui_gtk4.c
@@ -2133,10 +2133,11 @@ drawarea_realize_cb(GtkWidget *widget UNUSED, gpointer data UNUSED)
     // Use GdkSurface, as that handles fractional scale values.
     GdkSurface *surface = gtk_native_get_surface(
 	    gtk_widget_get_native(gui.drawarea));
+#ifdef FEAT_IMAGE
     double old = gui.scale;
-
     gui.scale = gdk_surface_get_scale(surface);
     popup_update_scale(old);
+#endif
     g_signal_connect(G_OBJECT(surface), "notify::scale",
 	    G_CALLBACK(scale_factor_cb), NULL);
 

--- a/src/gui_gtk4_da.c
+++ b/src/gui_gtk4_da.c
@@ -162,7 +162,9 @@ struct _VimDrawArea
 #endif
 };
 
+#ifdef FEAT_IMAGE
 static void draw_image_free(DrawImage *dimg);
+#endif
 static void draw_row_init(DrawRow *drow, int row, int cols);
 static void draw_row_clear(DrawRow *drow);
 static void draw_row_dirty_layer(DrawRow *drow, DrawLayerType dlayer_t);


### PR DESCRIPTION
`--with-features=normal` results in:

```
gui_gtk4_da.c:165:29: error: unknown type name 'DrawImage'
  165 | static void draw_image_free(DrawImage *dimg);
      |                             ^~~~~~~~~
gui_gtk4.c: In function 'drawarea_realize_cb':
gui_gtk4.c:2136:21: error: 'gui_T' {aka 'struct Gui'} has no member named 'scale'
 2136 |     double old = gui.scale;
      |                     ^
gui_gtk4.c:2138:8: error: 'gui_T' {aka 'struct Gui'} has no member named 'scale'
 2138 |     gui.scale = gdk_surface_get_scale(surface);
      |        ^
```

(*FEAT_TINY also not building btw, seems to be larger issue atm*)