### PR TITLE
patch 9.0.XXXX: floating point exception when displaying pum

### DIFF
--- a/src/popupmenu.c
+++ b/src/popupmenu.c
@@ -363,7 +363,10 @@ pum_display(
 	{
 	    int wcol = pum_wcol >= 0 ? pum_wcol : curwin->w_wcol;
 	    // w_wcol includes virtual text "above".
-	    wcol %= curwin->w_width;
+	    if (curwin->w_width > 0)
+		wcol %= curwin->w_width;
+	    else
+		wcol = 0;
 #ifdef FEAT_CONCEAL
 	    // w_wcol does not account for text concealed before the cursor;
 	    // shift by the offset win_line() recorded for the cursor line so the

--- a/src/testdir/test_popup.vim
+++ b/src/testdir/test_popup.vim
@@ -2734,4 +2734,24 @@ func Test_popup_sandbox()
   call assert_fails('sandbox call popup_setoptions(1, {})', 'E48:')
 endfunc
 
+func Test_pum_display_with_zero_width_window()
+  " Force curwin to width 0 (like Test_window_minimal_size does for
+  " win_ensure_size itself), then start completion via a non-typed,
+  " stuffed key sequence so KeyTyped stays FALSE and the repair is
+  " skipped.  pum_display() must not divide by curwin->w_width in that
+  " state (would SIGFPE).
+  set winminwidth=0
+  vert new
+  call win_execute(win_getid(2), 'wincmd |')
+  call assert_equal(0, winwidth(0))
+
+  call setline(1, ['foo', 'foobar', 'foo'])
+  call feedkeys("A\<C-N>\<Esc>", 'x')
+  call assert_equal(0, winwidth(0))
+
+  bwipe!
+  bwipe!
+  set winminwidth&
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  floating point exception when displaying pum
          (dvaave2025)
Solution: Verify that curwin->w_width > 0

fixes:  #20985
closes: #PR

Supported by AI.