### PR TITLE
runtime(strace): highlight stack trace as comment

### DIFF
--- a/runtime/syntax/strace.vim
+++ b/runtime/syntax/strace.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language: strace output
 " Maintainer: David Necas (Yeti) <yeti@physics.muni.cz>
-" Last Change: 2022 Jan 29
+" Last Change: 2026 Aug 10
 
 " Setup
 " quit when a syntax file was already loaded
@@ -29,11 +29,13 @@ syn match straceSysCallEmbed "\w\+" contained
 syn keyword stracePID pid contained
 syn match straceOperator "[-+=*/!%&|:,]"
 syn region straceComment start="/\*" end="\*/" oneline
+syn match straceStackTrace "^ *> .*$"
 
 " Define the default highlighting
 
 hi def link straceComment Comment
 hi def link straceVerbosed Comment
+hi def link straceStackTrace Comment
 hi def link stracePID PreProc
 hi def link straceNumber Number
 hi def link straceNumberRHS Type


### PR DESCRIPTION
strace supports printing a complete stack trace for each syscall using the `-k` (`--stack-trace`) flag. Highlight the trace as a comment.