### PR TITLE
cursorbind: cursor in the other window is not updated after undo

### DIFF
--- a/src/move.c
+++ b/src/move.c
@@ -3408,11 +3408,19 @@ pagescroll(int dir, long count, int half)
 do_check_cursorbind(void)
 {
     static win_T	*prev_curwin = NULL;
+    static buf_T	*prev_curbuf = NULL;
+    static varnumber_T	prev_changedtick = 0;
     static pos_T	prev_cursor = {0, 0, 0};
 
-    if (curwin == prev_curwin && EQUAL_POS(curwin->w_cursor, prev_cursor))
+    // Nothing to do when the cursor didn't move and the text didn't change.
+    // After a change the corresponding line in a diff may be different.
+    if (curwin == prev_curwin && curbuf == prev_curbuf
+	    && CHANGEDTICK(curbuf) == prev_changedtick
+	    && EQUAL_POS(curwin->w_cursor, prev_cursor))
 	return;
     prev_curwin = curwin;
+    prev_curbuf = curbuf;
+    prev_changedtick = CHANGEDTICK(curbuf);
     prev_cursor = curwin->w_cursor;
 
     linenr_T	line = curwin->w_cursor.lnum;

--- a/src/testdir/test_diffmode.vim
+++ b/src/testdir/test_diffmode.vim
@@ -3646,4 +3646,29 @@ func Test_diffput_to_empty_buf()
   call StopVimInTerminal(buf)
 endfunc
 
+" Undo can change which lines correspond in a diff. 'cursorbind' must update
+" the other window even when the cursor here did not move.
+func Test_diff_cursorbind_after_undo()
+  call setline(1, ['x', 'y', 'c', 'd'])
+  let w1 = win_getid()
+  new
+  call setline(1, ['p', 'q', 'c', 'd'])
+  let w2 = win_getid()
+  windo diffthis
+  call win_gotoid(w1)
+
+  normal! 2dd
+  call assert_equal(1, line('.', w1))
+  call assert_equal(1, line('.', w2))
+  normal! jk
+  call assert_equal(1, line('.', w1))
+  call assert_equal(3, line('.', w2))
+
+  normal! u
+  call assert_equal(1, line('.', w1))
+  call assert_equal(1, line('.', w2))
+
+  %bw!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
```
Problem:  In diff mode with 'cursorbind' the cursor in the other window is
          not updated after an undo that changes which lines correspond.
Solution: Also check whether the text changed before skipping the update.
```

fixes: #20982
related: #13219
related: #13210
