### PR TITLE
GTK4: columns are lost when a scrollbar appears

### DIFF
--- a/src/gui.h
+++ b/src/gui.h
@@ -505,6 +505,13 @@ typedef struct Gui
 #if defined(FEAT_GUI_GTK) && defined(USE_GTK4)
     int decor_height;
 
+    // Size of the form widget last asked for with gui_mch_set_shellsize().
+    // "pending_form_skip" counts how many allocations that do not answer it
+    // may still be ignored.
+    int pending_form_w;
+    int pending_form_h;
+    int pending_form_skip;
+
     // Used for clipboard functionality in GTK4 GUI
     GdkContentProvider *regular_provider;
     GdkContentProvider *primary_provider;

--- a/src/gui_gtk4.c
+++ b/src/gui_gtk4.c
@@ -959,6 +959,13 @@ gui_mch_set_shellsize(int width, int height,
 	int base_width UNUSED, int base_height UNUSED,
 	int direction UNUSED)
 {
+    // Remember the size the form widget is supposed to get. An allocation
+    // that arrives before the compositor has answered this request still has
+    // the previous size and must not be used.
+    gui.pending_form_w = width;
+    gui.pending_form_h = height;
+    gui.pending_form_skip = 1;
+
     width += get_menu_tool_width();
     height += get_menu_tool_height();
 

--- a/src/gui_gtk4_f.c
+++ b/src/gui_gtk4_f.c
@@ -216,7 +216,21 @@ vim_form_resize_idle_cb(VimForm *self)
 	goto exit;
 
     if (self->last_width > 1 && self->last_height > 1)
+    {
+	// Ignore an allocation that does not answer the size that was last
+	// asked for: it was computed before the request and using it would
+	// compute Rows and Columns from the old size together with the new
+	// base size, losing columns. Give up after one allocation in case
+	// the request is never answered exactly.
+	if (gui.pending_form_w > 0
+		&& (self->last_width != gui.pending_form_w
+		    || self->last_height != gui.pending_form_h)
+		&& --gui.pending_form_skip >= 0)
+	    goto exit;
+
+	gui.pending_form_w = 0;
 	gui_resize_shell(self->last_width, self->last_height);
+    }
 
 exit:
     g_object_unref(self);


### PR DESCRIPTION
```
Problem:  With the GTK4 GUI the shell loses columns every time a window is
          split, so that the text area keeps getting narrower.
Solution: Ignore a size allocation that was computed before the size that
          was last asked for, instead of computing Rows and Columns from
          the old size together with the new base size.
```

related: #20920

---

This shows up in the GTK4 CI job added in 9.2.0931, where the screen dumps of
several tests are a few columns too narrow. The window that RunVimInTerminal()
opens gets narrower on every call, e.g. Test_popupwin_cursorline_1 through _8
came out 75, 74, 72, 72, 70, 70, 68 and 66 columns wide where 75 is expected.

Logging the sizes in the CI job shows what happens. When a window is split a
scrollbar appears, the base width grows and gui_set_shellsize() asks for a
window that is wider by that amount:

    set_shell_pre  req 668  formwin 654  base_w 28  Columns 80
    set_shell_post req 668  formwin 654  base_w 28  Columns 80
    form_alloc         654 x 448         base_w 28  Columns 80
    idle_apply         654 x 448         base_w 28  Columns 80
    set_shell_pre  req 638  formwin 654  base_w 14  Columns 78

The allocation that arrives is still the old 654, it was computed before the
request. vim_form_resize_idle_cb() passes it to gui_resize_shell(), which
combines that old width with the new base width and gets
(654 - 28) / 8 = 78 columns. The next request is then based on 78 columns, so
the window keeps shrinking.

I could not reproduce this on my own compositor, where the same transition
happens but the size recovers. Measured in the CI job, before and after:

    Columns   before   after
    80           583     793
    78           151       8
    76            83       0
    74            48       0
    72            25       0
    70            27       0
    68            15       0
    66             2       0

With this, test_popupwin under the GTK4 GUI goes from eleven failing tests to
one. The remaining one is Test_popup_select, which fails for an unrelated
reason: it needs 'clipboard' with autoselect, and the Visual selection is lost
when a Wayland compositor is running.