### PR TITLE
CI: Keep the GTK4 job from affecting the other jobs

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -69,7 +69,6 @@ jobs:
             extra: [uchar, testgui]
           - features: huge
             compiler: gcc
-            coverage: true
             interface: dynamic
             extra: [uchar, testgui, use_gtk4]
           - features: huge
@@ -107,7 +106,11 @@ jobs:
           coverage: ${{ matrix.coverage }}
 
       - name: Test
-        timeout-minutes: 30
+        timeout-minutes: 20
+        # The GTK4 GUI is not stable enough yet to block the other jobs: it
+        # is the only job that runs a Wayland compositor, which makes
+        # 'clipboard' behave differently.
+        continue-on-error: ${{ contains(matrix.extra, 'use_gtk4') }}
         run: make ${SHADOWOPT} ${TEST}
 
       # Enable to debug failing tests live and ssh into the CI runners


### PR DESCRIPTION
The GTK4 job added in 9.2.0931 timed out after 30 minutes on every run. The
tests did not hang, they were retried: 82 test functions failed under GTK4
against two in the otherwise identical GTK3 job, and runtest.vim runs a flaky
test up to five times with a sleep in between.

Raising the Test step timeout from 20 to 30 minutes for this made it apply to
every other job as well. Once the columns are no longer lost when a window is
split the job needs about sixteen minutes, so put the limit back to 20.

Twelve tests still fail, among them Test_hlsearch_clipboard and
Test_popup_select, which need a working clipboard; this is the only job that
runs a Wayland compositor. Let the job fail without failing the workflow
until that is sorted out. The Build step stays blocking, so a broken GTK4
build is still reported.

Also drop coverage from the job. The GTK3 job runs the same "make testgui"
with coverage enabled, so the instrumentation only makes this job slower.


related: #20920

---

depends on: #21006

The 20 minute limit only fits with #21006, which stops the GTK4 job from
losing columns and brings its test run down from a 30 minute timeout to
15m40s. If this goes in first the job times out earlier than before, which
continue-on-error absorbs, so the order does not matter much.

Numbers from the GTK4 job with #21006 applied, compared with master:

                          master   with #21006
    test run time         30 min       15m40s
                       (timed out)   (completed)
    retried tests             82            5
    failing tests       not known           12

The twelve that still fail:

    Test_hlsearch_clipboard                  <-- Fixed in #21008
    Test_popup_select                        <-- Fixed in #21008
    Test_empty_buffer                        <-- Fixed in #21009
    Test_printexpr                           <-- Fixed in #21009
    Test_autocomplete_completeopt_preinsert
    Test_autocomplete_longest
    Test_mksession_winpos
    Test_scrolloffpad_basic
    Test_win_gotoid_in_mapping
    Test_window_split_no_room
    Test_winfixsize_vsep_statusline
    Test_write_in_vimrc

The clipboard ones look like a separate problem: only this job starts a
Wayland compositor, so it is the only place where the Wayland clipboard code
is exercised in CI. I am looking into that separately.