### PR TITLE
tests: clipboard tests fail in the GUI when the terminal has no clipboard

### DIFF
--- a/src/testdir/test_hlsearch.vim
+++ b/src/testdir/test_hlsearch.vim
@@ -95,6 +95,7 @@ func Test_hlsearch_clipboard()
   CheckScreendump
   CheckRunVimInTerminal
   CheckFeature clipboard_working
+  CheckClipboardInTerminal
 
   let lines =<< trim END
       set incsearch hlsearch

--- a/src/testdir/test_popupwin.vim
+++ b/src/testdir/test_popupwin.vim
@@ -921,6 +921,7 @@ endfunc
 func Test_popup_select()
   CheckScreendump
   CheckFeature clipboard_working
+  CheckClipboardInTerminal
 
   " create a popup with some text to be selected
   let lines =<< trim END

--- a/src/testdir/util/check.vim
+++ b/src/testdir/util/check.vim
@@ -193,6 +193,25 @@ func CheckRunVimInTerminal()
   endif
 endfunc
 
+" Command to check that the Vim started by RunVimInTerminal() can use the
+" clipboard.  Checking 'clipboard_working' of the Vim that runs the tests is
+" not enough: in the GUI that Vim always has a clipboard, while the Vim
+" started in a terminal window may not have one.
+command CheckClipboardInTerminal call CheckClipboardInTerminal()
+func CheckClipboardInTerminal()
+  if !exists('s:clipboard_in_terminal')
+    call delete('Xclipcheck')
+    " "-v" is needed because in a GUI test run the command from "vimcmd"
+    " starts the GUI, which always has a clipboard.
+    call RunVim([], ['call writefile([has("clipboard_working")], "Xclipcheck")', 'qall!'], '-v')
+    let s:clipboard_in_terminal = filereadable('Xclipcheck') && readfile('Xclipcheck')->get(0, '0') == '1'
+    call delete('Xclipcheck')
+  endif
+  if !s:clipboard_in_terminal
+    throw 'Skipped: Vim in a terminal window cannot use the clipboard'
+  endif
+endfunc
+
 " Command to check that we can run the GUI
 command CheckCanRunGui call CheckCanRunGui()
 func CheckCanRunGui()


### PR DESCRIPTION
```
Problem:  Tests that need the clipboard in a Vim started with
          RunVimInTerminal() are not skipped when only the Vim running the
          tests has a clipboard, which is always the case in the GUI.
Solution: Add CheckClipboardInTerminal to ask a Vim started the same way
          whether it can use the clipboard.
```

related: #20920
related: #21007

Test_popup_select and Test_hlsearch_clipboard start with
"CheckFeature clipboard_working", but that asks the wrong process. A screen
dump test involves two Vims:

    the Vim running the tests        <- CheckFeature and has() answer here
      terminal buffer
        the Vim started by term_start()  <- the one under test

In a GUI test run the first one is gvim, which always has a clipboard through
GTK, so the check never skips. The second one may well have none. A temporary
log of the clipboard state during "make test_popupwin GUI_FLAG=-g" shows the
difference:

    gvim         clipmethod NONE  clip_star.available 1
    terminal Vim clipmethod NONE  clip_star.available 0

The terminal Vim found neither wayland nor x11 usable, so 'clipboard' does
nothing there, "*" stays empty and Test_popup_select fails on the screen dump.
Test_hlsearch_clipboard does not even get that far: the "let @*" in its script
produces "W23: Clipboard register not available", the hit-enter prompt keeps
the ruler from showing and RunVimInTerminal() times out.

For Test_popup_select there is no way to avoid the clipboard. Selecting text
with the mouse in a popup is a modeless selection, and mouse.c only enters
that code when clip_star.available or clip_plus.available is set, so without a
clipboard the selection never happens. The register is where a modeless
selection lives, not just how the test looks at it.

The new check runs one Vim the same way RunVimInTerminal() does and asks it.
"-v" is needed because in a GUI test run the command in "vimcmd" has "-g" in
it. The result is cached, so it costs one Vim start per test file.

What changes where:

    non-GUI CI jobs (Xvfb)        unchanged, the tests keep running
    GUI CI job with GTK3 (Xvfb)   unchanged, the tests keep running
    GUI CI job with GTK4 (weston) skipped instead of failing
    GUI run on a Wayland desktop  skipped instead of failing

The ordinary Linux jobs are where these tests get their coverage: ci-linux.yml
sets DISPLAY for every job and ci/setup-xvfb.sh runs unconditionally, so the
Vim running the tests is a terminal Vim with an X11 clipboard and nothing is
skipped there.

This takes two off the list of tests failing in the GTK4 CI job.