### PR TITLE
Fix hardcopy tests for GTK4 GUI

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -29,6 +29,7 @@ jobs:
       DISPLAY: ":99"
       WAYLAND_DISPLAY: "/tmp/weston_sock"
       GTK_A11Y: "none"
+      GDK_DEBUG: "no-portals"
       DEBIAN_FRONTEND: noninteractive
 
     strategy:

--- a/.github/workflows/ci-linux_asan.yml
+++ b/.github/workflows/ci-linux_asan.yml
@@ -27,6 +27,7 @@ jobs:
       DISPLAY: ":99"
       WAYLAND_DISPLAY: "/tmp/weston_sock"
       GTK_A11Y: "none"
+      GDK_DEBUG: "no-portals"
       DEBIAN_FRONTEND: noninteractive
 
     strategy:

--- a/src/testdir/test_hardcopy.vim
+++ b/src/testdir/test_hardcopy.vim
@@ -118,7 +118,7 @@ func Test_printexpr()
   set printexpr=PrintFile(v:fname_in)
 
   help help
-  hardcopy dummy args
+  hardcopy! dummy args
   call assert_equal(['Test printexpr: dummy args'],
   \                 readfile('Xhardcopy_printexpr'))
   call delete('Xhardcopy_printexpr')
@@ -129,7 +129,7 @@ func Test_printexpr()
     return 1
   endfunc
   set printexpr=PrintFails(v:fname_in)
-  call assert_fails('hardcopy', 'E365:')
+  call assert_fails('hardcopy!', 'E365:')
 
   " Using a script-local function
   func s:NewPrintExpr()
@@ -175,7 +175,7 @@ func Test_empty_buffer()
   HasPostscript
 
   new
-  call assert_equal("\nNo text to be printed", execute('hardcopy'))
+  call assert_equal("\nNo text to be printed", execute('hardcopy!'))
   bwipe
 endfunc
 


### PR DESCRIPTION
The main problem is that `hardcopy` is used instead of `hardcopy!`, so GTK4 print dialog attempts to show, which tries to use xdg-desktop-portal that is not available.

Related: #21007