### PR TITLE
GTK3: the cursor does not blink (after 9.2.0897)

### DIFF
--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -986,9 +986,7 @@ gui_mch_stop_blink(int may_call_gui_update_cursor)
     if (blink_state == BLINK_OFF && may_call_gui_update_cursor)
     {
 	gui_update_cursor(TRUE, FALSE);
-#if !GTK_CHECK_VERSION(3,0,0)
 	gui_mch_flush();
-#endif
     }
     blink_state = BLINK_NONE;
 }
@@ -1008,9 +1006,7 @@ blink_cb(gpointer data UNUSED)
 	blink_state = BLINK_ON;
 	blink_timer = timeout_add(blink_ontime, blink_cb, NULL);
     }
-#if !GTK_CHECK_VERSION(3,0,0)
     gui_mch_flush();
-#endif
 
     return FALSE;		// don't happen again
 }
@@ -1033,9 +1029,7 @@ gui_mch_start_blink(void)
 	blink_timer = timeout_add(blink_waittime, blink_cb, NULL);
 	blink_state = BLINK_ON;
 	gui_update_cursor(TRUE, FALSE);
-#if !GTK_CHECK_VERSION(3,0,0)
 	gui_mch_flush();
-#endif
     }
 }
 
@@ -6961,8 +6955,7 @@ gui_mch_flush(void)
 	dirty_region = NULL;
     }
 #else
-       gdk_display_flush(gtk_widget_get_display(gui.mainwin));
-       return;
+    gdk_display_flush(gtk_widget_get_display(gui.mainwin));
 #endif
 }
 


### PR DESCRIPTION
```
Problem:  In the GTK3 GUI the cursor stops blinking: after the blinkwait
          time the cursor stays visible and never toggles.
Solution: Flush the pending drawing from the blink callbacks for GTK3 as
          well, so that the redraw is queued right away.  Also fix the
          indent of the GTK2 branch of gui_mch_flush() and drop the
          redundant return.
```

fixes: #20983