### PR TITLE
GTK4(font): fix letterspacing, signcol seams

### DIFF
--- a/src/gui_gtk4.c
+++ b/src/gui_gtk4.c
@@ -1278,7 +1278,7 @@ gui_mch_init_font(char_u *font_name, int fontset UNUSED)
     pango_layout_get_size(layout, &width, NULL);
     g_object_unref(layout);
 
-    gui.char_width = (width / 2 + PANGO_SCALE - 1) / PANGO_SCALE;
+    gui.char_width = (width / 2 + PANGO_SCALE / 2) / PANGO_SCALE;
     if (gui.char_width <= 0)
 	gui.char_width = 8;
 

--- a/src/gui_gtk4_da.c
+++ b/src/gui_gtk4_da.c
@@ -691,9 +691,9 @@ draw_layer_get_texture(
 
     // Scale texture to actual size
     node = gsk_texture_scale_node_new(texture,
-	    &GRAPHENE_RECT_INIT(FILL_X(0), FILL_Y(row),
-		(da->n_cols + bleed) * gui.char_width, gui.char_height),
-	    GSK_SCALING_FILTER_NEAREST);
+		&GRAPHENE_RECT_INIT(FILL_X(0), FILL_Y(row),
+		(da->n_cols + bleed) * gui.char_width, gui.char_height + bleed),
+	    GSK_SCALING_FILTER_TRILINEAR);
     if (bleed)
     {
 	GskRenderNode *new;
@@ -701,7 +701,7 @@ draw_layer_get_texture(
 	new = gsk_clip_node_new(node,
 		&GRAPHENE_RECT_INIT(FILL_X(0), FILL_Y(row),
 		    da->n_cols * gui.char_width + da->bleed_right,
-		    gui.char_height));
+		    gui.char_height + 1));
 	gsk_render_node_unref(node);
 	node = new;
     }

--- a/src/gui_gtk4_da.c
+++ b/src/gui_gtk4_da.c
@@ -693,7 +693,7 @@ draw_layer_get_texture(
     node = gsk_texture_scale_node_new(texture,
 		&GRAPHENE_RECT_INIT(FILL_X(0), FILL_Y(row),
 		(da->n_cols + bleed) * gui.char_width, gui.char_height + bleed),
-	    GSK_SCALING_FILTER_TRILINEAR);
+	    GSK_SCALING_FILTER_NEAREST);
     if (bleed)
     {
 	GskRenderNode *new;


### PR DESCRIPTION
**Problem**:

* Fonts do not account for letter spacing (`:help 'linespace'` is what vim calls it).
* Sign column has seams between lines.

**Solution**:
* Font: Round char with nearest pixel
* Signs: Overlap adjacent row nodes by one pixel.

----

c158acfce39d8afa61f74ffb857dea93a3df3105 round char w nearest px

c158acf Overlap adjacent row nodes by one pixel.

GSK renderer rounding seems to add 1px (not sure).

Possibly related: https://blogs.gnome.org/gtk/2026/05/28/snapping/
author responded in irc with:
```
<Company> dza: but if you draw backgrounds with tiles of adjacent color/texture/whatever nodes, then you need snapping to avoid seams
```
(trying [gtk_snapshot_set_snap](https://gitlab.gnome.org/GNOME/gtk/-/blob/main/gtk/gtksnapshot.c?ref_type=heads#L2654) after gtk 4.24)

Fixes: #21002