### PR TITLE
GTK2/3: mouse move starts Visual selection after a dialog

### DIFF
--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -2222,6 +2222,20 @@ button_release_event(GtkWidget *widget UNUSED,
     return TRUE;
 }
 
+/*
+ * Another widget, e.g. a modal dialog, was shadowing us with a GTK grab. The
+ * button release went to that widget, thus forget about the pressed button to
+ * avoid that the next mouse move is taken for a drag.
+ */
+    static void
+grab_notify_event(GtkWidget *widget UNUSED,
+		  gboolean  was_grabbed,
+		  gpointer  data UNUSED)
+{
+    if (!was_grabbed)
+	dragging_button_state = 0;
+}
+
 
 #ifdef FEAT_DND
 /////////////////////////////////////////////////////////////////////////////
@@ -4228,6 +4242,8 @@ gui_mch_init(void)
 		     G_CALLBACK(button_press_event), NULL);
     g_signal_connect(G_OBJECT(gui.drawarea), "button-release-event",
 		     G_CALLBACK(button_release_event), NULL);
+    g_signal_connect(G_OBJECT(gui.drawarea), "grab-notify",
+		     G_CALLBACK(grab_notify_event), NULL);
     g_signal_connect(G_OBJECT(gui.drawarea), "scroll-event",
 		     G_CALLBACK(scroll_event), NULL);
 


### PR DESCRIPTION
```
Problem:  In GTK2/GTK3, when a dialog pops up while a mouse button is
          pressed, moving the mouse afterwards starts a Visual selection
          without any button being held down.
Solution: Forget about the pressed mouse button when another widget
          shadows the text area with a grab, since the button release
          event goes to that widget.
```

fixes: #20907