### PR TITLE
Fix tests when running in GTK4 GUI

### DIFF
--- a/src/socketserver.c
+++ b/src/socketserver.c
@@ -486,7 +486,9 @@ socketserver_get_path(
 	if (new)
 	{
 	    emsg_silent++;
+	    emsg_off++;
 	    channel = channel_open_unix((char *)buf, NULL);
+	    emsg_off--;
 	    emsg_silent--;
 
 	    if (channel != NULL)

--- a/src/testdir/test_gui.vim
+++ b/src/testdir/test_gui.vim
@@ -1929,6 +1929,11 @@ func Test_geometry_exact_size()
   CheckCanRunGui
   CheckFeature gui_gtk
 
+  if has('gui_gtk4')
+    " Wayland is kinda finicky
+    let g:test_is_flaky = 1
+  endif
+
   let after =<< trim [CODE]
     call writefile([string(&columns), string(&lines)], 'Xtest_geomsize')
     qall
@@ -1954,6 +1959,11 @@ endfunc
 func Test_tabnew_tabclose_size_stable()
   CheckCanRunGui
   CheckFeature gui_gtk
+
+  if has('gui_gtk4')
+    " Wayland is kinda finicky
+    let g:test_is_flaky = 1
+  endif
 
   let after =<< trim [CODE]
     let cols0 = &columns

--- a/src/testdir/test_mksession.vim
+++ b/src/testdir/test_mksession.vim
@@ -1106,7 +1106,8 @@ endfunc
 func Test_mksession_winpos()
   " Only applicable in GUI Vim
   CheckGui
-  CheckNotFeature gui_gtk4 " window position does not work in gtk4 gui
+  " Window position does not work in gtk4 gui
+  CheckNotFeature gui_gtk4
 
   set sessionoptions+=winpos
   mksession! Xtest_mks.out

--- a/src/testdir/test_vim9_builtin.vim
+++ b/src/testdir/test_vim9_builtin.vim
@@ -5150,6 +5150,7 @@ enddef
 
 func Test_win_gotoid_in_mapping()
   CheckScreendump
+  CheckClipboardInTerminal
 
   " requires a working clipboard and this doesn't work on MacOS
   if has('clipboard_working') && !has('mac')


### PR DESCRIPTION
FYI, master is red: `Test_mksession_winpos()` throws on every GUI build,
because `CheckNotFeature` takes the trailing comment 9.2.0942 added as part of
the feature name. The fix is the `test_mksession.vim` hunk in this PR.