### PR TITLE
Make popup image feature optional for now

### DIFF
--- a/src/auto/configure
+++ b/src/auto/configure
@@ -878,6 +878,7 @@ with_gnome
 enable_icon_cache_update
 enable_desktop_database_update
 enable_hardcopy_pango
+enable_popup_image
 with_motif_lib
 with_tlib
 enable_largefile
@@ -1555,6 +1556,7 @@ Optional Features:
   --disable-icon-cache-update        update disabled
   --disable-desktop-database-update  update disabled
   --enable-hardcopy-pango     Use Pango 1.44 or later and Cairo for improved hardcopy printing. default=yes when GTK GUI enabled
+  --enable-popup-iamge     Render images using popup windows default=no
   --disable-largefile     omit support for large files
   --disable-canberra      Do not use libcanberra.
   --disable-libsodium      Do not use libsodium.
@@ -11615,6 +11617,25 @@ if test "$enable_hardcopy_pango" = "yes"; then
   CFLAGS=$cflags_save
 fi
 
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking --enable-popup-image argument" >&5
+printf %s "checking --enable-popup-image argument... " >&6; }
+# Check whether --enable-popup-image was given.
+if test ${enable_popup_image+y}
+then :
+  enableval=$enable_popup_image;
+fi
+
+
+if test "$enable_popup_image" = "yes"; then
+  printf "%s\n" "#define FEAT_IMAGE 1" >>confdefs.h
+
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; }
+else
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+fi
+
 
 
 if test -z "$SKIP_MOTIF"; then
@@ -14772,18 +14793,18 @@ then :
 fi
 if test "$enable_largefile,$enable_year2038" != no,no
 then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CPPFLAGS option for large files" >&5
-printf %s "checking for $CPPFLAGS option for large files... " >&6; }
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CC option to enable large file support" >&5
+printf %s "checking for $CC option to enable large file support... " >&6; }
 if test ${ac_cv_sys_largefile_opts+y}
 then :
   printf %s "(cached) " >&6
 else case e in #(
-  e) ac_save_CPPFLAGS=$CPPFLAGS
+  e) ac_save_CC="$CC"
   ac_opt_found=no
-  for ac_opt in "none needed" "-D_FILE_OFFSET_BITS=64" "-D_LARGE_FILES=1"; do
+  for ac_opt in "none needed" "-D_FILE_OFFSET_BITS=64" "-D_LARGE_FILES=1" "-n32"; do
     if test x"$ac_opt" != x"none needed"
 then :
-  CPPFLAGS="$ac_save_CPPFLAGS $ac_opt"
+  CC="$ac_save_CC $ac_opt"
 fi
     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -14812,12 +14833,12 @@ then :
   if test x"$ac_opt" = x"none needed"
 then :
   # GNU/Linux s390x and alpha need _FILE_OFFSET_BITS=64 for wide ino_t.
-	 CPPFLAGS="$CPPFLAGS -DFTYPE=ino_t"
+	 CC="$CC -DFTYPE=ino_t"
 	 if ac_fn_c_try_compile "$LINENO"
 then :
 
 else case e in #(
-  e) CPPFLAGS="$CPPFLAGS -D_FILE_OFFSET_BITS=64"
+  e) CC="$CC -D_FILE_OFFSET_BITS=64"
 	    if ac_fn_c_try_compile "$LINENO"
 then :
   ac_opt='-D_FILE_OFFSET_BITS=64'
@@ -14833,7 +14854,7 @@ fi
 rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
     test $ac_opt_found = no || break
   done
-  CPPFLAGS=$ac_save_CPPFLAGS
+  CC="$ac_save_CC"
 
   test $ac_opt_found = yes || ac_cv_sys_largefile_opts="support not detected" ;;
 esac
@@ -14857,14 +14878,16 @@ printf "%s\n" "#define _FILE_OFFSET_BITS 64" >>confdefs.h
 
 printf "%s\n" "#define _LARGE_FILES 1" >>confdefs.h
  ;; #(
+  "-n32") :
+    CC="$CC -n32" ;; #(
   *) :
     as_fn_error $? "internal error: bad value for \$ac_cv_sys_largefile_opts" "$LINENO" 5 ;;
 esac
 
 if test "$enable_year2038" != no
 then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CPPFLAGS option for timestamps after 2038" >&5
-printf %s "checking for $CPPFLAGS option for timestamps after 2038... " >&6; }
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CC option for timestamps after 2038" >&5
+printf %s "checking for $CC option for timestamps after 2038... " >&6; }
 if test ${ac_cv_sys_year2038_opts+y}
 then :
   printf %s "(cached) " >&6

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -502,6 +502,9 @@
 /* Define to use Pango and Cairo for hardcopy printing */
 #undef FEAT_PRINT_PANGO
 
+/* Define to render images using popup windows */
+#undef FEAT_IMAGE
+
 /* Define if we have isinf() */
 #undef HAVE_ISINF
 

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -3213,6 +3213,18 @@ if test "$enable_hardcopy_pango" = "yes"; then
   CFLAGS=$cflags_save
 fi
 
+AC_MSG_CHECKING(--enable-popup-image argument)
+AC_ARG_ENABLE(popup-image,
+	[  --enable-popup-iamge     Render images using popup windows [default=no]],
+	,, enable_popup_image="no")
+
+if test "$enable_popup_image" = "yes"; then
+  AC_DEFINE(FEAT_IMAGE)
+  AC_MSG_RESULT([yes])
+else
+  AC_MSG_RESULT([no])
+fi
+
 
 dnl Check for Motif include files location.
 dnl The LAST one found is used, this makes the highest version to be used,

--- a/src/feature.h
+++ b/src/feature.h
@@ -1114,10 +1114,6 @@
  * shared RGB plumbing; at least one backend has to be enabled to actually
  * paint anything.
  */
-#if defined(FEAT_HUGE) && defined(FEAT_PROP_POPUP)
-# define FEAT_IMAGE
-#endif
-
 #if defined(FEAT_IMAGE) && !defined(ALWAYS_USE_GUI)
 # define FEAT_IMAGE_SIXEL
 # define FEAT_IMAGE_KITTY


### PR DESCRIPTION
I don't think the popup image feature is ready for mainstream use as of now.
- Kitty graphics protocol backend is designed wrong
- `clipwindow` property of popup images does not work well with images
- Clipping of images does not behave as expected
- Possibly other bugs

I plan on adding tests later:
- GTK4 GUI we can use the existing GTK4 infastructure for comparing render nodes. This should be feasible.
- For Kitty graphics protocol and sixel, we could possibly run a graphical terminal in a headless kiosk Wayland compositor (e.g. `cage`), take a screenshot of the output, and compare to an existing image with ImageMagick. Same with GTK3 GUI. Not sure if this will actually work however
- Not sure about MS-Windows (GDI), but it should be very similar to the GTK3 GUI in how its implemented. So not having tests shouldn't be too big of a deal.