### PR TITLE
GTK3(redraw): flush cursor

### DIFF
--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -986,9 +986,7 @@ gui_mch_stop_blink(int may_call_gui_update_cursor)
     if (blink_state == BLINK_OFF && may_call_gui_update_cursor)
     {
 	gui_update_cursor(TRUE, FALSE);
-#if !GTK_CHECK_VERSION(3,0,0)
-	gui_mch_flush();
-#endif
+	gui_may_flush();
     }
     blink_state = BLINK_NONE;
 }
@@ -1008,9 +1006,7 @@ blink_cb(gpointer data UNUSED)
 	blink_state = BLINK_ON;
 	blink_timer = timeout_add(blink_ontime, blink_cb, NULL);
     }
-#if !GTK_CHECK_VERSION(3,0,0)
-    gui_mch_flush();
-#endif
+    gui_may_flush();
 
     return FALSE;		// don't happen again
 }

--- a/src/gui_gtk_x11.c
+++ b/src/gui_gtk_x11.c
@@ -1029,9 +1029,7 @@ gui_mch_start_blink(void)
 	blink_timer = timeout_add(blink_waittime, blink_cb, NULL);
 	blink_state = BLINK_ON;
 	gui_update_cursor(TRUE, FALSE);
-#if !GTK_CHECK_VERSION(3,0,0)
-	gui_mch_flush();
-#endif
+	gui_may_flush();
     }
 }
 


### PR DESCRIPTION
Fixes: #20983

I'm making the assumption that

7.4 commit -- introduces flush in `gui_mch_start_blink`
https://github.com/vim/vim/commit/da3a77d9ec28407b8fa2aa014e76944d0a525662
8.0 commit -- introduces `disable_flush` mechanism (`gui_may_flush`)
https://github.com/vim/vim/commit/a338adcf222b6a24e26ea5ae6a2ad27f914acb38

From that, it seems this was never incorporated into these and I think its better late than never - also you should not use `disable_flush` if you expect cursor to update anyways!

Besides that, I also think it highlights how much better gtk2 was written - *because* .. Now you see the patterns showing with the new redraw in gtk3 - there is actually so little difference between how they work when fixed and normalized.. Before gtk3 rang the redraw bell ALL THE TIME 🔔🔔🔔