### PR TITLE
GTK4: screen is cleared when moving the mouse after startup

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -1864,6 +1864,10 @@ gui_set_shellsize(
     limit_screen_size();
     gui.num_cols = Columns;
     gui.num_rows = Rows;
+#ifdef USE_GTK4
+    // Keep the drawing area in sync with the size Vim is going to draw.
+    gui_gtk4_update_size();
+#endif
 
     min_width = base_width + MIN_COLUMNS * gui.char_width;
     min_height = base_height + MIN_LINES * gui.char_height;


### PR DESCRIPTION
```
Problem:  In GTK4, moving the mouse over the window right after startup
          clears the screen, including the intro message.
Solution: Keep the cached contents of the drawing area in sync with the
          size Vim is going to draw.
```

fixes: #21016

---

`gui.num_rows` and `gui.num_cols` are set in two places at runtime, but only
`gui_resize_shell()` passes the new size on to the drawing area,
`gui_set_shellsize()` does not.

At startup the window is first allocated without the client side decorations,
so the row cache of the drawing area is created for 22 rows.
`gui_set_shellsize()` then raises `gui.num_rows` to 24 without resizing that
cache. When the window later gets its full size, `gui_resize_shell()` recreates
the cache for 24 rows and throws away everything in it. `shell_resized()` is
skipped there, because `gui.num_rows`, `Rows`, `Columns` and `screen_Rows` /
`screen_Columns` already agree, so nothing is redrawn and the next frame shows
an empty screen. Moving the mouse is only what makes GTK render that frame.

Syncing the drawing area in `gui_set_shellsize()` as well makes the cache 24
rows before anything is drawn, so nothing is lost and it is not recreated later.

Verified with `vim --clean -g +h` and `vim --clean -g +"se ls=2"`, and with
`:set lines=40` / `:set columns=100` at runtime.

Not fixed here: the window still opens two rows short and grows when it first
receives a pointer event. That is the two step sizing added in 9.2.0931 and
needs a separate change.