### PR TITLE
setpos() updates the wrong logical Visual mark

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -1,4 +1,4 @@
-*builtin.txt*	For Vim version 9.2.  Last change: 2026 Aug 11
+*builtin.txt*	For Vim version 9.2.  Last change: 2026 Aug 12
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -4933,9 +4933,7 @@ getpos({expr})						*getpos()*
 		use |getcharpos()|.
 
 		The visual marks |'<| and |'>| refer to the beginning and end
-		of the visual selection relative to the buffer.  Note that
-		this differs from |setpos()|, where they are relative to the
-		cursor position.
+		of the visual selection relative to the buffer.
 
 		Note that for '< and '> Visual mode matters: when it is "V"
 		(visual line mode) the column of '< is zero and the column of
@@ -10233,14 +10231,12 @@ setpos({expr}, {list})					*setpos()*
 		preferred column is not set.  When it is present and setting a
 		mark position it is not used.
 
-		Note that for |'<| and |'>| changing the line number may
-		result in the marks to be effectively swapped, so that |'<| is
-		always before |'>|.
+		For |'<| and |'>|, setting one mark past the other may
+		effectively swap them, so that |'<| is always before |'>| when
+		getting the marks.
 
 		The visual marks |'<| and |'>| refer to the beginning and end
-		of the visual selection relative to the cursor position.
-		Note that this differs from |getpos()|, where they are
-		relative to the buffer.
+		of the visual selection relative to the buffer.
 
 		Returns 0 when the position could be set, -1 otherwise.
 		An error message is given if {expr} is invalid.

--- a/src/mark.c
+++ b/src/mark.c
@@ -96,10 +96,39 @@ setmark_pos(int c, pos_T *pos, int fnum)
 
     if (c == '<' || c == '>')
     {
-	if (c == '<')
-	    buf->b_visual.vi_start = *pos;
+	pos_T	*startp = &buf->b_visual.vi_start;
+	pos_T	*endp = &buf->b_visual.vi_end;
+	pos_T	*markp;
+	pos_T	*otherp;
+
+	// Keep the fixed association until both endpoints can be ordered.
+	if (startp->lnum == 0 || endp->lnum == 0)
+	    markp = c == '<' ? startp : endp;
+	else if ((c == '<') == LT_POS(*startp, *endp))
+	    markp = startp;
 	else
-	    buf->b_visual.vi_end = *pos;
+	    markp = endp;
+	otherp = markp == startp ? endp : startp;
+
+	if (pos->lnum == 0)
+	{
+	    pos_T other = *otherp;
+
+	    // Store a missing endpoint in its fixed slot, so that it can be
+	    // recreated after the Visual direction has been lost.
+	    if (c == '<')
+	    {
+		*startp = *pos;
+		*endp = other;
+	    }
+	    else
+	    {
+		*startp = other;
+		*endp = *pos;
+	    }
+	}
+	else
+	    *markp = *pos;
 	if (buf->b_visual.vi_mode == NUL)
 	    // Visual_mode has not yet been set, use a sane default.
 	    buf->b_visual.vi_mode = 'v';

--- a/src/testdir/test_marks.vim
+++ b/src/testdir/test_marks.vim
@@ -46,6 +46,110 @@ func Test_setpos()
   let twowin = win_getid()
   call setline(1, ['aaa', 'bbb', 'ccc'])
 
+  " setpos() uses the same buffer-relative visual marks as getpos()
+  new Xvisual
+  call setline(1, 'hello world')
+  for normal_cmd in ["normal! gg0vw\<Esc>", "normal! gg0vwo\<Esc>"]
+    execute normal_cmd
+    call setpos("'<", [0, 1, 2, 0])
+    call assert_equal([[0, 1, 2, 0], [0, 1, 7, 0]],
+          \ [getpos("'<"), getpos("'>")], normal_cmd)
+    call setpos("'>", [0, 1, 6, 0])
+    call assert_equal([[0, 1, 2, 0], [0, 1, 6, 0]],
+          \ [getpos("'<"), getpos("'>")], normal_cmd)
+
+    execute normal_cmd
+    call setpos("'>", [0, 1, 6, 0])
+    call assert_equal([[0, 1, 1, 0], [0, 1, 6, 0]],
+          \ [getpos("'<"), getpos("'>")], normal_cmd)
+
+    " Crossing either end changes the ordering of the logical marks.
+    call setpos("'<", [0, 1, 8, 0])
+    call assert_equal([[0, 1, 6, 0], [0, 1, 8, 0]],
+          \ [getpos("'<"), getpos("'>")], normal_cmd)
+    call setpos("'>", [0, 1, 10, 0])
+    call assert_equal([[0, 1, 6, 0], [0, 1, 10, 0]],
+          \ [getpos("'<"), getpos("'>")], normal_cmd)
+    call setpos("'>", [0, 1, 4, 0])
+    call assert_equal([[0, 1, 4, 0], [0, 1, 6, 0]],
+          \ [getpos("'<"), getpos("'>")], normal_cmd)
+    call setpos("'<", [0, 1, 2, 0])
+    call assert_equal([[0, 1, 2, 0], [0, 1, 6, 0]],
+          \ [getpos("'<"), getpos("'>")], normal_cmd)
+
+    " Deleting and recreating either end preserves the other end.
+    execute normal_cmd
+    call setpos("'<", [0, 0, 0, 0])
+    call assert_equal([[0, 1, 7, 0], [0, 1, 7, 0]],
+          \ [getpos("'<"), getpos("'>")], normal_cmd)
+    call setpos("'<", [0, 1, 2, 0])
+    call assert_equal([[0, 1, 2, 0], [0, 1, 7, 0]],
+          \ [getpos("'<"), getpos("'>")], normal_cmd)
+    normal! gvy
+    call assert_equal('ello w', getreg('"'), normal_cmd)
+
+    execute normal_cmd
+    call setpos("'>", [0, 0, 0, 0])
+    call assert_equal([[0, 1, 1, 0], [0, 1, 1, 0]],
+          \ [getpos("'<"), getpos("'>")], normal_cmd)
+    call setpos("'>", [0, 1, 6, 0])
+    call assert_equal([[0, 1, 1, 0], [0, 1, 6, 0]],
+          \ [getpos("'<"), getpos("'>")], normal_cmd)
+    normal! gvy
+    call assert_equal('hello ', getreg('"'), normal_cmd)
+  endfor
+
+  " While Visual mode is active the marks still refer to the last completed
+  " selection.  Leaving Visual mode replaces them with the current selection.
+  execute "normal! gg0vwo\<Esc>"
+  call feedkeys("gg02lv2l", 'xt')
+  call assert_equal('v', mode())
+  call setpos("'<", [0, 1, 2, 0])
+  call assert_equal([[0, 1, 2, 0], [0, 1, 7, 0]],
+        \ [getpos("'<"), getpos("'>")])
+  call feedkeys("\<Esc>", 'xt')
+  call assert_equal([[0, 1, 3, 0], [0, 1, 5, 0]],
+        \ [getpos("'<"), getpos("'>")])
+
+  " Moving one logical mark past the other must not discard the old range.
+  %delete _
+  call setline(1, ['one', 'two', 'three'])
+  normal! 2GVjy
+  call setpos("'>", [0, 1, 1, 0])
+  call assert_equal([[0, 1, 1, 0], [0, 2, v:maxcol, 0]],
+        \ [getpos("'<"), getpos("'>")])
+  '<,'>d
+  call assert_equal(['three'], getline(1, '$'))
+
+  " Check crossing the line boundary in the other direction as well.
+  call setline(1, ['one', 'two', 'three'])
+  normal! ggVjy
+  call setpos("'<", [0, 3, 1, 0])
+  call assert_equal([[0, 2, 1, 0], [0, 3, v:maxcol, 0]],
+        \ [getpos("'<"), getpos("'>")])
+  '<,'>d
+  call assert_equal(['one'], getline(1, '$'))
+  bwipe!
+
+  " visual marks can still be initialized independently
+  new Xvisual
+  call setline(1, 'hello world')
+  call setpos("'<", [0, 1, 2, 0])
+  call setpos("'>", [0, 1, 4, 0])
+  call assert_equal([[0, 1, 2, 0], [0, 1, 4, 0]],
+        \ [getpos("'<"), getpos("'>")])
+  bwipe!
+
+  " setcharpos() uses the same visual mark path
+  new Xvisual
+  call setline(1, 'aβcδεz')
+  execute "normal! gg0v$\<Esc>"
+  call setcharpos("'<", [0, 1, 2, 0])
+  call setcharpos("'>", [0, 1, 5, 0])
+  call assert_equal([[0, 1, 2, 0], [0, 1, 5, 0]],
+        \ [getcharpos("'<"), getcharpos("'>")])
+  bwipe!
+
   " for the cursor the buffer number is ignored
   call setpos(".", [0, 2, 1, 0])
   call assert_equal([0, 2, 1, 0], getpos("."))


### PR DESCRIPTION
## Problem

For a reversed Visual selection, `getpos("'<")` reports the buffer-relative start while `setpos("'<", ...)` updates the endpoint associated with the selection direction. `setcharpos()` follows the same path, so the get/set APIs are inconsistent. Fixes #19049.

## Solution

Resolve `'<` and `'>` to their logical buffer-relative endpoints before updating them. Crossing the other endpoint now changes the stored order without changing that other endpoint; `getmark()` continues to return the marks in logical order. Deleting either endpoint preserves the remaining endpoint so the deleted mark can be recreated.

Update `builtin.txt` and add regression coverage for forward and reversed selections, column and line crossings in both directions, deletion and recreation, active Visual mode, independent initialization, and `setcharpos()`.

## Tests

- `make -C src -j2`
- `make -C src/testdir -W test_marks.vim TEST_FILTER=Test_setpos test_marks.res`
- `make -C src/testdir -j3 -W test_marks.vim -W test_visual.vim -W test_codestyle.vim test_marks.res test_visual.res test_codestyle.res`
- `git diff --check origin/master..HEAD`

Full test counts: `test_marks` 14/14, `test_visual` 81/81, `test_codestyle` 5/5.

AI-assisted: Codex
