### PR TITLE
patch 9.2.XXXX: GDK_KEY_VoidSymbol might be undefined

### DIFF
--- a/src/gui_xim.c
+++ b/src/gui_xim.c
@@ -190,6 +190,9 @@ static int im_preedit_trailing = 0;	// number of characters after cursor
 
 static unsigned long im_commit_handler_id  = 0;
 #  ifndef USE_GTK4
+#   ifndef GDK_KEY_VoidSymbol
+#    define GDK_KEY_VoidSymbol GDK_VoidSymbol
+#   endif
 static unsigned int  im_activatekey_keyval = GDK_KEY_VoidSymbol;
 static unsigned int  im_activatekey_state  = 0;
 #  endif


### PR DESCRIPTION
Problem:    Build fails because GDK_KEY_VoidSymbol is undefined
            (Hisashi T Fujinaka, after v9.2.0931)
Solution:   Define GDK_KEY_VoidSymbol as GDK_VoidSymbol when not
            already defined, before using it for the non-GTK4 case.

closes: #PR