### PR TITLE
transstr() can be improved (after 9.2.0906)

### DIFF
--- a/src/charset.c
+++ b/src/charset.c
@@ -383,8 +383,6 @@ transstr(char_u *s)
     if (res == NULL)
 	return NULL;
 
-    // Keep a tail pointer to append to, appending with STRCAT would make
-    // this loop quadratic.
     char_u *d = res;
 
     p = s;
@@ -395,7 +393,6 @@ transstr(char_u *s)
 	    c = (*mb_ptr2char)(p);
 	    if (vim_isprintc(c))
 	    {
-		// append printable multi-byte char
 		mch_memmove(d, p, (size_t)l);
 		d += l;
 	    }
@@ -409,9 +406,9 @@ transstr(char_u *s)
 	else
 	{
 	    char_u	*trs = transchar_byte(*p++);
-	    int		trs_len = (int)STRLEN(trs);
+	    size_t	trs_len = STRLEN(trs);
 
-	    mch_memmove(d, trs, (size_t)trs_len);
+	    mch_memmove(d, trs, trs_len);
 	    d += trs_len;
 	}
     }

--- a/src/testdir/test_functions.vim
+++ b/src/testdir/test_functions.vim
@@ -253,7 +253,6 @@ func Test_strtrans()
   call assert_equal('^A^_^?', strtrans("\x01\x1f\x7f"))
   " an unprintable byte above 0x7f uses the meta notation
   call assert_equal('| ', strtrans("\xa0"))
-  " a printable high byte is unchanged
   call assert_equal("\xe9", strtrans("\xe9"))
   call assert_equal("x^B\xe9| y", strtrans("x\x02\xe9\xa0y"))
   set encoding=utf-8


### PR DESCRIPTION
```
Problem:  transstr() has comments that do not add anything to what the
          code says, and it casts a length to int only to cast it back to
          size_t.
Solution: Drop the comments and keep the length in a size_t.
```

related: #20925