### PR TITLE
insert completion code can be improved (after 9.2.0909)

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -137,11 +137,9 @@ static compl_T    *compl_shown_match = NULL;
 static compl_T    *compl_old_match = NULL;
 
 // Hashtab with the strings of the matches in the list above, except the
-// original-text entries.  Used to make the duplicate check O(1) instead of
-// a scan of the whole list.  Each entry owns a copy of the string and
-// counts the matches with that string, so that when matches were added
-// with "adup" the entry remains until the last match with the string is
-// removed.
+// original-text entries.  Each entry owns a copy of the string and counts
+// the matches with that string, so that when matches were added with "adup"
+// the entry remains until the last match with the string is removed.
 typedef struct
 {
     int	    cse_count;	// number of matches with this string
@@ -155,8 +153,7 @@ static hashtab_T  compl_strings_ht;
 
 /*
  * Count the string of a new match in the duplicate-check hashtab.
- * "hash" is the hash of "str" when it is not zero, saving hashing the
- * string again.
+ * "hash" is the hash of "str" when it is not zero.
  */
     static void
 compl_strings_add(char_u *str, size_t len, hash_T hash)
@@ -967,8 +964,7 @@ ins_compl_add(
     // If the same match is already present, don't add it.
     if (compl_first_match != NULL && !adup && compl_strings_ht.ht_used > 0)
     {
-	// Use a stack buffer for the NUL-terminated key when it fits, so
-	// that rejecting a duplicate does not allocate memory.
+	// The key must be NUL terminated.
 	char_u	    keybuf[128];
 	char_u	    *key;
 	hashitem_T  *hi;


### PR DESCRIPTION
```
Problem:  The duplicate-check hashtab in insexpand.c has comments that do
          not add anything to what the code says.
Solution: Drop the redundant comments.
```

related: #20926