### PR TITLE
u_read_undo() can be improved (after 9.2.0935)

### DIFF
--- a/src/undo.c
+++ b/src/undo.c
@@ -1817,8 +1817,7 @@ theend:
 }
 
 /*
- * Compare undo headers on the sequence number, for sorting uhp_table in
- * u_read_undo().
+ * Compare undo headers on the sequence number, for sorting uhp_table.
  */
     static int
 uhp_seq_cmp(const void *v1, const void *v2)
@@ -2107,9 +2106,7 @@ u_read_undo(char_u *name, char_u *hash, char_u *orig_name UNUSED)
 
     // We have put all of the headers into a table.  Each header stores the
     // sequence numbers of the headers it links to; resolve those into
-    // pointers.  Sort the table on uh_seq once, so that every lookup is a
-    // binary search instead of a linear scan, which would be quadratic
-    // overall.  Every entry is non-NULL: a header that failed to
+    // pointers.  Every entry is non-NULL: a header that failed to
     // unserialize or a count mismatch was an error above.
     if (num_head > 0)
 	qsort(uhp_table, (size_t)num_head, sizeof(u_header_T *), uhp_seq_cmp);


### PR DESCRIPTION
```
Problem:  u_read_undo() has comments that do not add anything to what the
          code says.
Solution: Drop the redundant comments.
```

related: #20942