### PR TITLE
sort() with a numeric option can be improved (after 9.2.0937)

### DIFF
--- a/src/list.c
+++ b/src/list.c
@@ -2077,13 +2077,12 @@ typedef struct
 {
     listitem_T	*item;
     int		idx;
-    // Sort key precomputed once per item for the numeric compare modes, so
-    // item_compare() does not convert the value on every comparison.  Only
-    // valid when sortinfo->item_compare_keys_ready is set (the sort() path);
-    // uniq() passes a bare listitem_T pointer and must not read this.
+    // Sort key precomputed once per item for the numeric compare modes.
+    // Only valid when sortinfo->item_compare_keys_ready is set (the sort()
+    // path); uniq() passes a bare listitem_T pointer and must not read this.
     union {
-	varnumber_T	inum;	// for item_compare_numbers ("N")
-	double		fnum;	// for item_compare_numeric ("n") and _float ("f")
+	varnumber_T	inum;	// for "N"
+	double		fnum;	// for "n" and "f"
     } key;
 } sortItem_T;
 
@@ -2265,10 +2264,8 @@ item_compare2(const void *s1, const void *s2)
 }
 
 /*
- * Precompute the numeric sort key of each item, so that item_compare() can
- * compare the stored value instead of converting the item on every one of the
- * O(n log n) comparisons.  Only for the builtin numeric compare modes; each
- * key is computed exactly as item_compare() would have, once per item.
+ * Precompute the numeric sort key of each item.  Only for the builtin numeric
+ * compare modes; each key is computed exactly as item_compare() would have.
  */
     static void
 sort_compute_keys(sortItem_T *ptrs, long len, sortinfo_T *info)
@@ -2292,7 +2289,7 @@ sort_compute_keys(sortItem_T *ptrs, long len, sortinfo_T *info)
 	    typval_T	*tv = &ptrs[i].item->li_tv;
 
 	    // A string is compared as a single quote in numeric mode, which
-	    // strtod() reads as 0; only numbers contribute a value.
+	    // strtod() reads as 0.
 	    if (tv->v_type == VAR_STRING)
 		ptrs[i].key.fnum = 0.0;
 	    else
@@ -2338,8 +2335,7 @@ do_sort(list_T *l, sortinfo_T *info)
     info->item_compare_func_err = FALSE;
     info->item_compare_keep_zero = FALSE;
     info->item_compare_keys_ready = FALSE;
-    // For the builtin numeric compares, precompute each item's key once
-    // instead of converting it on every comparison.
+
     if (info->item_compare_func == NULL && info->item_compare_partial == NULL
 	    && (info->item_compare_numbers || info->item_compare_float
 						|| info->item_compare_numeric))


### PR DESCRIPTION
```
Problem:  The comments on the precomputed sort keys explain the code by
          contrasting it with the previous implementation, and one of
          them exceeds 80 columns.
Solution: Drop the redundant comments and shorten the union member ones.
```

related: #21003