### PR TITLE
GTK4: crash when the window is resized

### DIFF
--- a/src/gui_gtk4_da.c
+++ b/src/gui_gtk4_da.c
@@ -133,6 +133,7 @@ typedef struct
     gboolean draw; // If cursor should be drawn
     int width;
     int height;
+    int n_cells; // Cells covered, 2 for a double width character
     GdkRGBA bg_color;
     GdkRGBA fg_color;
 } DrawCursor;
@@ -1598,6 +1599,9 @@ vim_draw_area_set_cursor(VimDrawArea *self, int w, int h)
     self->cursor.draw = TRUE;
     self->cursor.width = w;
     self->cursor.height = h;
+    // Remember this now: the snapshot runs later, when the drawing position
+    // has moved on.
+    self->cursor.n_cells = 1 + mb_lefthalve(gui.cursor_row, gui.cursor_col);
     self->cursor.bg_color = *gui.bgcolor;
     self->cursor.fg_color = *gui.fgcolor;
 }
@@ -1873,8 +1877,7 @@ vim_draw_area_snapshot_cursor(
 
     if (cursor->width <= 0 && cursor->height <= 0)
     {
-	// Double width if double width character
-	w += gui.char_width * (1 + mb_lefthalve(gui.row, gui.col));
+	w += gui.char_width * cursor->n_cells;
 	h = gui.char_height;
     }
 


### PR DESCRIPTION
```
Problem:  In GTK4, Vim may crash when the window is resized while the
          cursor is displayed.
Solution: Remember the number of cells the cursor covers when the cursor
          is set, instead of deriving it from the drawing position when
          the snapshot is taken.
```

fixes: #21037

