### PR TITLE
tests: terminal tests are flaky

### DIFF
--- a/src/testdir/test_terminal.vim
+++ b/src/testdir/test_terminal.vim
@@ -692,24 +692,21 @@ endfunc
 func s:get_sleep_cmd()
   if s:python != ''
     let cmd = s:python . " test_short_sleep.py"
-    " 500 was not enough for Travis
-    let waittime = 900
   else
     echo 'This will take five seconds...'
-    let waittime = 2000
     if has('win32')
       let cmd = $windir . '\system32\timeout.exe 1'
     else
       let cmd = 'sleep 1'
     endif
   endif
-  return [cmd, waittime]
+  return cmd
 endfunc
 
 func Test_terminal_finish_open_close()
   call assert_equal(1, winnr('$'))
 
-  let [cmd, waittime] = s:get_sleep_cmd()
+  let cmd = s:get_sleep_cmd()
 
   " shell terminal closes automatically
   terminal
@@ -718,7 +715,7 @@ func Test_terminal_finish_open_close()
   " Wait for the shell to display a prompt
   call WaitForAssert({-> assert_notequal('', term_getline(buf, 1))})
   call StopShellInTerminal(buf)
-  call WaitForAssert({-> assert_equal(1, winnr('$'))}, waittime)
+  call WaitForAssert({-> assert_equal(1, winnr('$'))})
 
   " shell terminal that does not close automatically
   terminal ++noclose
@@ -734,32 +731,32 @@ func Test_terminal_finish_open_close()
   exe 'terminal ++close ' . cmd
   call assert_equal(2, winnr('$'))
   wincmd p
-  call WaitForAssert({-> assert_equal(1, winnr('$'))}, waittime)
+  call WaitForAssert({-> assert_equal(1, winnr('$'))})
 
   call term_start(cmd, {'term_finish': 'close'})
   call assert_equal(2, winnr('$'))
   wincmd p
-  call WaitForAssert({-> assert_equal(1, winnr('$'))}, waittime)
+  call WaitForAssert({-> assert_equal(1, winnr('$'))})
   call assert_equal(1, winnr('$'))
 
   exe 'terminal ++open ' . cmd
   close!
-  call WaitForAssert({-> assert_equal(2, winnr('$'))}, waittime)
+  call WaitForAssert({-> assert_equal(2, winnr('$'))})
   bwipe
 
   call term_start(cmd, {'term_finish': 'open'})
   close!
-  call WaitForAssert({-> assert_equal(2, winnr('$'))}, waittime)
+  call WaitForAssert({-> assert_equal(2, winnr('$'))})
   bwipe
 
   exe 'terminal ++hidden ++open ' . cmd
   call assert_equal(1, winnr('$'))
-  call WaitForAssert({-> assert_equal(2, winnr('$'))}, waittime)
+  call WaitForAssert({-> assert_equal(2, winnr('$'))})
   bwipe
 
   call term_start(cmd, {'term_finish': 'open', 'hidden': 1})
   call assert_equal(1, winnr('$'))
-  call WaitForAssert({-> assert_equal(2, winnr('$'))}, waittime)
+  call WaitForAssert({-> assert_equal(2, winnr('$'))})
   bwipe
 
   call assert_fails("call term_start(cmd, {'term_opencmd': 'open'})", 'E475:')
@@ -769,7 +766,7 @@ func Test_terminal_finish_open_close()
 
   call term_start(cmd, {'term_finish': 'open', 'term_opencmd': '4split | buffer %d | let g:result = "opened the buffer in a window"'})
   close!
-  call WaitForAssert({-> assert_equal(2, winnr('$'))}, waittime)
+  call WaitForAssert({-> assert_equal(2, winnr('$'))})
   call assert_equal(4, winheight(0))
   call assert_equal('opened the buffer in a window', g:result)
   unlet g:result
@@ -1233,6 +1230,7 @@ func Test_terminal_composing_unicode()
 endfunc
 
 func Test_terminal_aucmd_on_close()
+  let s:called = 0
   fun Nop()
     let s:called = 1
   endfun
@@ -1242,14 +1240,14 @@ func Test_terminal_aucmd_on_close()
       au BufWinLeave * call Nop()
   aug END
 
-  let [cmd, waittime] = s:get_sleep_cmd()
+  let cmd = s:get_sleep_cmd()
 
   call assert_equal(1, winnr('$'))
   new
   call setline(1, ['one', 'two'])
   exe 'term ++close ' . cmd
   wincmd p
-  call WaitForAssert({-> assert_equal(2, winnr('$'))}, waittime)
+  call WaitForAssert({-> assert_equal(2, winnr('$'))})
   call assert_equal(1, s:called)
   bwipe!
 
@@ -2498,9 +2496,10 @@ func Test_terminal_unwraps()
   call assert_equal('14+15', l)
 
   call TermWait(buf)
-  " It should appear as a single buffer line in vim
-  let lastline = getline('$')
-  call assert_equal('1+2+3+4+5+6+7+8+9+10+11+12+13+14+15', lastline)
+  " It should appear as a single buffer line in vim, once the job finished and
+  " the contents were moved to the buffer.
+  call WaitForAssert({-> assert_equal(
+	\ '1+2+3+4+5+6+7+8+9+10+11+12+13+14+15', getline('$'))})
 
   bwipe!
 endfunc


### PR DESCRIPTION
```
Problem:  Test_terminal_aucmd_on_close() is flaky on MS-Windows: the
          tests that wait for a terminal window to close use a timeout
          shorter than the default, which is not enough when starting a
          process is slow.  When the wait fails the test aborts with
          E121 and leaves an autocommand behind for the following tests.
          Test_terminal_unwraps() checks the buffer contents without
          waiting for the job to finish.
Solution: Use the default timeout of WaitForAssert(), initialize the
          variable checked after the wait, and wait for the buffer to
          hold the unwrapped line.
```

---

Note:
Dropping "waittime" does not make a passing test slower: WaitForAssert() returns
as soon as the assert succeeds, so the argument is only an upper bound. It only
changes how long a broken test waits before reporting the failure.

900 msec was already raised once, from 500, in 8.1.0031 with the comment "500
was not enough for Travis". Travis is gone and 900 is being outgrown by py.exe
starting the interpreter on a busy Windows runner.