### PR TITLE
GTK4: use >=4.24 snapping

### DIFF
--- a/src/gui_gtk4.c
+++ b/src/gui_gtk4.c
@@ -1278,7 +1278,7 @@ gui_mch_init_font(char_u *font_name, int fontset UNUSED)
     pango_layout_get_size(layout, &width, NULL);
     g_object_unref(layout);
 
-    gui.char_width = (width / 2 + PANGO_SCALE - 1) / PANGO_SCALE;
+    gui.char_width = (width / 2 + PANGO_SCALE / 2) / PANGO_SCALE;
     if (gui.char_width <= 0)
 	gui.char_width = 8;
 

--- a/src/gui_gtk4_da.c
+++ b/src/gui_gtk4_da.c
@@ -691,8 +691,8 @@ draw_layer_get_texture(
 
     // Scale texture to actual size
     node = gsk_texture_scale_node_new(texture,
-	    &GRAPHENE_RECT_INIT(FILL_X(0), FILL_Y(row),
-		(da->n_cols + bleed) * gui.char_width, gui.char_height),
+		&GRAPHENE_RECT_INIT(FILL_X(0), FILL_Y(row),
+		(da->n_cols + bleed) * gui.char_width, gui.char_height + bleed),
 	    GSK_SCALING_FILTER_NEAREST);
     if (bleed)
     {
@@ -701,7 +701,7 @@ draw_layer_get_texture(
 	new = gsk_clip_node_new(node,
 		&GRAPHENE_RECT_INIT(FILL_X(0), FILL_Y(row),
 		    da->n_cols * gui.char_width + da->bleed_right,
-		    gui.char_height));
+		    gui.char_height + (!GTK_CHECK_VERSION(4,24,0))));
 	gsk_render_node_unref(node);
 	node = new;
     }
@@ -1952,6 +1952,9 @@ vim_draw_area_snapshot(GtkWidget *widget, GtkSnapshot *snapshot)
     // First append everything that should be inverted to another snapshot, then
     // free that snapshot into a node so it can be blended (if needed).
     body_snapshot = gtk_snapshot_new();
+#if GTK_CHECK_VERSION(4,24,0)
+	gtk_snapshot_set_snap(body_snapshot, GSK_RECT_SNAP_ROUND);
+#endif
 
     for (int r = 0; r < self->n_rows; r++)
     {
@@ -1971,7 +1974,13 @@ vim_draw_area_snapshot(GtkWidget *widget, GtkSnapshot *snapshot)
 		if (l == DRAW_LAYER_OVERLAY)
 		{
 		    if (invert_snapshot == NULL)
+		    {
 			invert_snapshot = gtk_snapshot_new();
+#if GTK_CHECK_VERSION(4,24,0)
+			    gtk_snapshot_set_snap(invert_snapshot,
+				    GSK_RECT_SNAP_ROUND);
+#endif
+		    }
 		    gtk_snapshot_append_node(invert_snapshot, dlayer->node);
 		}
 		else

--- a/src/gui_gtk4_da.c
+++ b/src/gui_gtk4_da.c
@@ -1960,7 +1960,7 @@ vim_draw_area_snapshot(GtkWidget *widget, GtkSnapshot *snapshot)
     // free that snapshot into a node so it can be blended (if needed).
     body_snapshot = gtk_snapshot_new();
 #if GTK_CHECK_VERSION(4,24,0)
-	gtk_snapshot_set_snap(body_snapshot, GSK_RECT_SNAP_ROUND);
+    gtk_snapshot_set_snap(body_snapshot, GSK_RECT_SNAP_ROUND);
 #endif
 
     for (int r = 0; r < self->n_rows; r++)
@@ -1984,8 +1984,8 @@ vim_draw_area_snapshot(GtkWidget *widget, GtkSnapshot *snapshot)
 		    {
 			invert_snapshot = gtk_snapshot_new();
 #if GTK_CHECK_VERSION(4,24,0)
-			    gtk_snapshot_set_snap(invert_snapshot,
-				    GSK_RECT_SNAP_ROUND);
+			gtk_snapshot_set_snap(invert_snapshot,
+				GSK_RECT_SNAP_ROUND);
 #endif
 		    }
 		    gtk_snapshot_append_node(invert_snapshot, dlayer->node);

--- a/src/gui_gtk4_da.c
+++ b/src/gui_gtk4_da.c
@@ -704,7 +704,7 @@ draw_layer_get_texture(
 	new = gsk_clip_node_new(node,
 		&GRAPHENE_RECT_INIT(FILL_X(0), FILL_Y(row),
 		    da->n_cols * gui.char_width + da->bleed_right,
-		    gui.char_height + 1));
+		    gui.char_height + (!GTK_CHECK_VERSION(4,24,0))));
 	gsk_render_node_unref(node);
 	node = new;
     }
@@ -1959,6 +1959,9 @@ vim_draw_area_snapshot(GtkWidget *widget, GtkSnapshot *snapshot)
     // First append everything that should be inverted to another snapshot, then
     // free that snapshot into a node so it can be blended (if needed).
     body_snapshot = gtk_snapshot_new();
+#if GTK_CHECK_VERSION(4,24,0)
+	gtk_snapshot_set_snap(body_snapshot, GSK_RECT_SNAP_ROUND);
+#endif
 
     for (int r = 0; r < self->n_rows; r++)
     {
@@ -1978,7 +1981,13 @@ vim_draw_area_snapshot(GtkWidget *widget, GtkSnapshot *snapshot)
 		if (l == DRAW_LAYER_OVERLAY)
 		{
 		    if (invert_snapshot == NULL)
+		    {
 			invert_snapshot = gtk_snapshot_new();
+#if GTK_CHECK_VERSION(4,24,0)
+			    gtk_snapshot_set_snap(invert_snapshot,
+				    GSK_RECT_SNAP_ROUND);
+#endif
+		    }
 		    gtk_snapshot_append_node(invert_snapshot, dlayer->node);
 		}
 		else


### PR DESCRIPTION
Scheduled when GTK4.24 lands, which introduces snapping - a recommended solution to our sign col seam spacing problem in linked PR.

See: https://github.com/vim/vim/pull/21013, https://blogs.gnome.org/gtk/2026/05/28/snapping/