### PR TITLE
term: avoid leak kitty term resp to buffer,prompt,:!shell

### DIFF
--- a/src/term.c
+++ b/src/term.c
@@ -3981,32 +3981,28 @@ may_send_t_RK(void)
 }
 
 #ifdef FEAT_TERMRESPONSE
-static int barrier_pending = false;
-
 /*
- * Flush terminal mode changes and wait for DA1 response.
-   Term responses are ordered so receiving also consumes earlier replies.
+ * Flush terminal mode changes and wait for the response to T_CRK.  Since
+ * terminal responses are ordered, receiving it also consumes earlier replies.
  */
-static void
+    static void
 termresponse_barrier(void)
 {
     int count = 0;
 
-    send_t_RK = false;
-    if (can_get_termresponse())
+    send_t_RK = FALSE;
+    if (can_get_termresponse() && *T_CRK != NUL)
     {
-	barrier_pending = false;
-	out_str((char_u *)"\033[c");
+	out_str(T_CRK);
+	termrequest_sent(&rk_status);
 	out_flush();
-
-	while (barrier_pending && count++ < 10)
+	while (termrequest_any_pending() && count++ < 10)
 	{
 	    (void)vpeekc_nomap();
-	    if (barrier_pending)
-		ui_delay(10L, false);
+	    if (termrequest_any_pending())
+		ui_delay(10L, FALSE);
 	}
 	check_for_codes_from_term();
-	barrier_pending = false;
     }
     else
 	out_flush();
@@ -5811,9 +5807,7 @@ handle_csi(
     else if (first == '?' && trail == 'c')
     {
 	LOG_TRN("Received DA1 response: %s", tp);
-#ifdef FEAT_TERMRESPONSE
-	barrier_pending = false;
-#endif
+
 	*slen = csi_len;
 #ifdef FEAT_EVAL
 	set_vim_var_string(VV_TERMDA1, tp, *slen);

--- a/src/term.c
+++ b/src/term.c
@@ -163,22 +163,6 @@ static unsigned int decrqm_pending = 0;
 // Request keyboard protocol state:
 static termrequest_T rk_status = TERMREQUEST_INIT;
 
-static termrequest_T *all_termrequests[] = {
-    &crv_status,
-    &u7_status,
-    &xcc_status,
-# ifdef FEAT_TERMINAL
-    &rfg_status,
-# endif
-    &rbg_status,
-    &rbm_status,
-    &rcs_status,
-    &winpos_status,
-    &decrqm_status,
-    &rk_status,
-    NULL
-};
-
 // The t_8u code may default to a value but get reset when the term response is
 // received.  To avoid redrawing too often, only redraw when t_8u is not reset
 // and it was supposed to be written.  Unless t_8u was set explicitly.
@@ -3146,31 +3130,6 @@ termrequest_sent(termrequest_T *status)
 {
     status->tr_progress = STATUS_SENT;
     status->tr_start = time(NULL);
-}
-
-/*
- * Return TRUE if any of the requests are in STATUS_SENT.
- */
-    static int
-termrequest_any_pending(void)
-{
-    int	    i;
-    time_t  now = time(NULL);
-
-    for (i = 0; all_termrequests[i] != NULL; ++i)
-    {
-	if (all_termrequests[i]->tr_progress == STATUS_SENT)
-	{
-	    if (all_termrequests[i]->tr_start > 0 && now > 0
-				    && all_termrequests[i]->tr_start + 2 < now)
-		// Sent the request more than 2 seconds ago and didn't get a
-		// response, assume it failed.
-		all_termrequests[i]->tr_progress = STATUS_FAIL;
-	    else
-		return TRUE;
-	}
-    }
-    return FALSE;
 }
 
 static int winpos_x = -1;

--- a/src/term.c
+++ b/src/term.c
@@ -3980,35 +3980,6 @@ may_send_t_RK(void)
     }
 }
 
-#ifdef FEAT_TERMRESPONSE
-/*
- * Flush terminal mode changes and wait for the response to T_CRK.  Since
- * terminal responses are ordered, receiving it also consumes earlier replies.
- */
-    static void
-termresponse_barrier(void)
-{
-    int count = 0;
-
-    send_t_RK = FALSE;
-    if (can_get_termresponse() && *T_CRK != NUL)
-    {
-	out_str(T_CRK);
-	termrequest_sent(&rk_status);
-	out_flush();
-	while (termrequest_any_pending() && count++ < 10)
-	{
-	    (void)vpeekc_nomap();
-	    if (termrequest_any_pending())
-		ui_delay(10L, FALSE);
-	}
-	check_for_codes_from_term();
-    }
-    else
-	out_flush();
-}
-#endif
-
 /*
  * Set the terminal to TMODE_RAW (for Normal mode) or TMODE_COOK (for external
  * commands and Ex mode).
@@ -4035,10 +4006,21 @@ settmode(tmode_T tmode)
      */
     if (tmode != cur_tmode)
     {
-	if (tmode != TMODE_RAW)
+#ifdef FEAT_TERMRESPONSE
+# ifdef FEAT_GUI
+	if (!gui.in_use && !gui.starting)
+# endif
 	{
-	    mch_setmouse(FALSE);	// switch mouse off
+	    // May need to check for T_CRV response and termcodes, it
+	    // doesn't work in Cooked mode, an external program may get
+	    // them.
+	    if (tmode != TMODE_RAW && termrequest_any_pending())
+		(void)vpeekc_nomap();
+	    check_for_codes_from_term();
 	}
+#endif
+	if (tmode != TMODE_RAW)
+	    mch_setmouse(FALSE);	// switch mouse off
 
 	// Disable bracketed paste and modifyOtherKeys in cooked mode.
 	// Avoid doing this too often, on some terminals the codes are not
@@ -4060,18 +4042,11 @@ settmode(tmode_T tmode)
 		out_str_t_TI();	// possibly enables modifyOtherKeys
 	    }
 	}
-#ifdef FEAT_TERMRESPONSE
-	if (tmode != TMODE_RAW)
-	    termresponse_barrier();
-	else
-#endif
-	    out_flush();
-
+	out_flush();
 	mch_settmode(tmode);	// machine specific function
 	cur_tmode = tmode;
 	if (tmode == TMODE_RAW)
 	    setmouse();		// may switch mouse on
-
 	out_flush();
     }
 #ifdef FEAT_TERMRESPONSE
@@ -4124,6 +4099,29 @@ stoptermcap(void)
     if (!termcap_active)
 	return;
 
+#ifdef FEAT_TERMRESPONSE
+# ifdef FEAT_GUI
+    if (!gui.in_use && !gui.starting)
+# endif
+    {
+	// May need to discard T_CRV, T_U7 or T_RBG response.
+	if (termrequest_any_pending())
+	{
+# ifdef UNIX
+	    // Give the terminal a chance to respond.
+	    mch_delay(100L, 0);
+# endif
+# ifdef TCIFLUSH
+	    // Discard data received but not read.
+	    if (exiting)
+		tcflush(fileno(stdin), TCIFLUSH);
+# endif
+	}
+	// Check for termcodes first, otherwise an external program may
+	// get them.
+	check_for_codes_from_term();
+    }
+#endif
     MAY_WANT_TO_LOG_THIS;
 
 #if defined(UNIX) || defined(VMS)
@@ -4134,6 +4132,8 @@ stoptermcap(void)
 
     out_str(T_BD);			// disable bracketed paste mode
     out_str(T_KE);			// stop "keypad transmit" mode
+    out_flush();
+    termcap_active = FALSE;
 
     // Output t_te before t_TE, t_te may switch between main and alternate
     // screen and following codes may work on the active screen only.
@@ -4151,14 +4151,8 @@ stoptermcap(void)
     cursor_on();			// just in case it is still off
     out_str_t_TE();			// stop "raw" mode, modifyOtherKeys and
 					// Kitty keyboard protocol
-#ifdef FEAT_TERMRESPONSE
-    termresponse_barrier();
-#else
-    out_flush();
-#endif
-
-    termcap_active = FALSE;
     screen_start();			// don't know where cursor is now
+    out_flush();
 }
 
 #if defined(FEAT_TERMRESPONSE)

--- a/src/term.c
+++ b/src/term.c
@@ -163,6 +163,22 @@ static unsigned int decrqm_pending = 0;
 // Request keyboard protocol state:
 static termrequest_T rk_status = TERMREQUEST_INIT;
 
+static termrequest_T *all_termrequests[] = {
+    &crv_status,
+    &u7_status,
+    &xcc_status,
+# ifdef FEAT_TERMINAL
+    &rfg_status,
+# endif
+    &rbg_status,
+    &rbm_status,
+    &rcs_status,
+    &winpos_status,
+    &decrqm_status,
+    &rk_status,
+    NULL
+};
+
 // The t_8u code may default to a value but get reset when the term response is
 // received.  To avoid redrawing too often, only redraw when t_8u is not reset
 // and it was supposed to be written.  Unless t_8u was set explicitly.
@@ -3130,6 +3146,31 @@ termrequest_sent(termrequest_T *status)
 {
     status->tr_progress = STATUS_SENT;
     status->tr_start = time(NULL);
+}
+
+/*
+ * Return TRUE if any of the requests are in STATUS_SENT.
+ */
+    static int
+termrequest_any_pending(void)
+{
+    int	    i;
+    time_t  now = time(NULL);
+
+    for (i = 0; all_termrequests[i] != NULL; ++i)
+    {
+	if (all_termrequests[i]->tr_progress == STATUS_SENT)
+	{
+	    if (all_termrequests[i]->tr_start > 0 && now > 0
+				    && all_termrequests[i]->tr_start + 2 < now)
+		// Sent the request more than 2 seconds ago and didn't get a
+		// response, assume it failed.
+		all_termrequests[i]->tr_progress = STATUS_FAIL;
+	    else
+		return TRUE;
+	}
+    }
+    return FALSE;
 }
 
 static int winpos_x = -1;

--- a/src/term.c
+++ b/src/term.c
@@ -159,6 +159,9 @@ static termrequest_T winpos_status = TERMREQUEST_INIT;
 // Request DECRQM (DEC mode) report:
 static termrequest_T decrqm_status = TERMREQUEST_INIT;
 
+// Request keyboard protocol state:
+static termrequest_T rk_status = TERMREQUEST_INIT;
+
 static termrequest_T *all_termrequests[] = {
     &crv_status,
     &u7_status,
@@ -171,6 +174,7 @@ static termrequest_T *all_termrequests[] = {
     &rcs_status,
     &winpos_status,
     &decrqm_status,
+    &rk_status,
     NULL
 };
 
@@ -3967,6 +3971,10 @@ may_send_t_RK(void)
     {
 	send_t_RK = FALSE;
 	out_str(T_CRK);
+#ifdef FEAT_TERMRESPONSE
+	if (*T_CRK != NUL)
+	    termrequest_sent(&rk_status);
+#endif
 	out_flush();
     }
 }
@@ -5749,8 +5757,13 @@ handle_csi(
     if (first == '>' && (argc == 1 || argc == 2) && trail == 'm')
     {
 	if (arg[0] == 4 && argc == 2)
+	{
 	    modify_otherkeys_state = arg[1] == 2 ? MOKS_ENABLED : MOKS_OFF;
-
+#ifdef FEAT_TERMRESPONSE
+	    if (rk_status.tr_progress == STATUS_SENT)
+		rk_status.tr_progress = STATUS_GOT;
+#endif
+	}
 	key_name[0] = (int)KS_EXTRA;
 	key_name[1] = (int)KE_IGNORE;
 	*slen = csi_len;
@@ -5903,6 +5916,10 @@ handle_csi(
     // Kitty keyboard protocol status response: CSI ? flags u
     else if (first == '?' && argc == 1 && trail == 'u')
     {
+#ifdef FEAT_TERMRESPONSE
+	if (rk_status.tr_progress == STATUS_SENT)
+	    rk_status.tr_progress = STATUS_GOT;
+#endif
 	// The protocol has various "progressive enhancement flags" values, but
 	// we only check for zero and non-zero here.
 	if (arg[0] == '0')

--- a/src/term.c
+++ b/src/term.c
@@ -3980,6 +3980,35 @@ may_send_t_RK(void)
     }
 }
 
+#ifdef FEAT_TERMRESPONSE
+/*
+ * Flush terminal mode changes and wait for the response to T_CRK.  Since
+ * terminal responses are ordered, receiving it also consumes earlier replies.
+ */
+    static void
+termresponse_barrier(void)
+{
+    int count = 0;
+
+    send_t_RK = FALSE;
+    if (can_get_termresponse() && *T_CRK != NUL)
+    {
+	out_str(T_CRK);
+	termrequest_sent(&rk_status);
+	out_flush();
+	while (termrequest_any_pending() && count++ < 10)
+	{
+	    (void)vpeekc_nomap();
+	    if (termrequest_any_pending())
+		ui_delay(10L, FALSE);
+	}
+	check_for_codes_from_term();
+    }
+    else
+	out_flush();
+}
+#endif
+
 /*
  * Set the terminal to TMODE_RAW (for Normal mode) or TMODE_COOK (for external
  * commands and Ex mode).
@@ -4006,21 +4035,10 @@ settmode(tmode_T tmode)
      */
     if (tmode != cur_tmode)
     {
-#ifdef FEAT_TERMRESPONSE
-# ifdef FEAT_GUI
-	if (!gui.in_use && !gui.starting)
-# endif
-	{
-	    // May need to check for T_CRV response and termcodes, it
-	    // doesn't work in Cooked mode, an external program may get
-	    // them.
-	    if (tmode != TMODE_RAW && termrequest_any_pending())
-		(void)vpeekc_nomap();
-	    check_for_codes_from_term();
-	}
-#endif
 	if (tmode != TMODE_RAW)
+	{
 	    mch_setmouse(FALSE);	// switch mouse off
+	}
 
 	// Disable bracketed paste and modifyOtherKeys in cooked mode.
 	// Avoid doing this too often, on some terminals the codes are not
@@ -4042,11 +4060,18 @@ settmode(tmode_T tmode)
 		out_str_t_TI();	// possibly enables modifyOtherKeys
 	    }
 	}
-	out_flush();
+#ifdef FEAT_TERMRESPONSE
+	if (tmode != TMODE_RAW)
+	    termresponse_barrier();
+	else
+#endif
+	    out_flush();
+
 	mch_settmode(tmode);	// machine specific function
 	cur_tmode = tmode;
 	if (tmode == TMODE_RAW)
 	    setmouse();		// may switch mouse on
+
 	out_flush();
     }
 #ifdef FEAT_TERMRESPONSE
@@ -4099,29 +4124,6 @@ stoptermcap(void)
     if (!termcap_active)
 	return;
 
-#ifdef FEAT_TERMRESPONSE
-# ifdef FEAT_GUI
-    if (!gui.in_use && !gui.starting)
-# endif
-    {
-	// May need to discard T_CRV, T_U7 or T_RBG response.
-	if (termrequest_any_pending())
-	{
-# ifdef UNIX
-	    // Give the terminal a chance to respond.
-	    mch_delay(100L, 0);
-# endif
-# ifdef TCIFLUSH
-	    // Discard data received but not read.
-	    if (exiting)
-		tcflush(fileno(stdin), TCIFLUSH);
-# endif
-	}
-	// Check for termcodes first, otherwise an external program may
-	// get them.
-	check_for_codes_from_term();
-    }
-#endif
     MAY_WANT_TO_LOG_THIS;
 
 #if defined(UNIX) || defined(VMS)
@@ -4132,8 +4134,6 @@ stoptermcap(void)
 
     out_str(T_BD);			// disable bracketed paste mode
     out_str(T_KE);			// stop "keypad transmit" mode
-    out_flush();
-    termcap_active = FALSE;
 
     // Output t_te before t_TE, t_te may switch between main and alternate
     // screen and following codes may work on the active screen only.
@@ -4151,8 +4151,14 @@ stoptermcap(void)
     cursor_on();			// just in case it is still off
     out_str_t_TE();			// stop "raw" mode, modifyOtherKeys and
 					// Kitty keyboard protocol
-    screen_start();			// don't know where cursor is now
+#ifdef FEAT_TERMRESPONSE
+    termresponse_barrier();
+#else
     out_flush();
+#endif
+
+    termcap_active = FALSE;
+    screen_start();			// don't know where cursor is now
 }
 
 #if defined(FEAT_TERMRESPONSE)

--- a/src/term.c
+++ b/src/term.c
@@ -3981,28 +3981,32 @@ may_send_t_RK(void)
 }
 
 #ifdef FEAT_TERMRESPONSE
+static int barrier_pending = false;
+
 /*
- * Flush terminal mode changes and wait for the response to T_CRK.  Since
- * terminal responses are ordered, receiving it also consumes earlier replies.
+ * Flush terminal mode changes and wait for DA1 response.
+   Term responses are ordered so receiving also consumes earlier replies.
  */
-    static void
+static void
 termresponse_barrier(void)
 {
     int count = 0;
 
-    send_t_RK = FALSE;
-    if (can_get_termresponse() && *T_CRK != NUL)
+    send_t_RK = false;
+    if (can_get_termresponse())
     {
-	out_str(T_CRK);
-	termrequest_sent(&rk_status);
+	barrier_pending = false;
+	out_str((char_u *)"\033[c");
 	out_flush();
-	while (termrequest_any_pending() && count++ < 10)
+
+	while (barrier_pending && count++ < 10)
 	{
 	    (void)vpeekc_nomap();
-	    if (termrequest_any_pending())
-		ui_delay(10L, FALSE);
+	    if (barrier_pending)
+		ui_delay(10L, false);
 	}
 	check_for_codes_from_term();
+	barrier_pending = false;
     }
     else
 	out_flush();
@@ -5807,7 +5811,9 @@ handle_csi(
     else if (first == '?' && trail == 'c')
     {
 	LOG_TRN("Received DA1 response: %s", tp);
-
+#ifdef FEAT_TERMRESPONSE
+	barrier_pending = false;
+#endif
 	*slen = csi_len;
 #ifdef FEAT_EVAL
 	set_vim_var_string(VV_TERMDA1, tp, *slen);

--- a/src/term.c
+++ b/src/term.c
@@ -158,6 +158,7 @@ static termrequest_T winpos_status = TERMREQUEST_INIT;
 
 // Request DECRQM (DEC mode) report:
 static termrequest_T decrqm_status = TERMREQUEST_INIT;
+static unsigned int decrqm_pending = 0;
 
 // Request keyboard protocol state:
 static termrequest_T rk_status = TERMREQUEST_INIT;
@@ -5391,10 +5392,12 @@ handle_version_response(int first, int *arg, int argc, char_u *tp)
 	{
 	    MAY_WANT_TO_LOG_THIS;
 	    LOG_TR1("Sending DECRQM requests");
+	    decrqm_pending = 0;
 	    for (int i = 0; i < (int)ARRAY_LENGTH(dec_modes); i++)
 	    {
 		vim_snprintf((char *)IObuff, IOSIZE, "\033[?%d$p", dec_modes[i]);
 		out_str(IObuff);
+		decrqm_pending |= 1U << i;
 	    }
 	    termrequest_sent(&decrqm_status);
 	    need_flush = TRUE;
@@ -5821,10 +5824,15 @@ handle_csi(
 	key_name[1] = (int)KE_IGNORE;
 
 #ifdef FEAT_TERMRESPONSE
-	// Mark the DECRQM request as answered so it is not sent again and
-	// stoptermcap() does not wait for it.
+	// Mark this DECRQM reply received; complete when all replies arrived.
 	if (decrqm_status.tr_progress == STATUS_SENT)
-	    decrqm_status.tr_progress = STATUS_GOT;
+	{
+	    for (int i = 0; i < (int)ARRAY_LENGTH(dec_modes); i++)
+		if (arg[0] == dec_modes[i])
+		    decrqm_pending &= ~(1U << i);
+	    if (decrqm_pending == 0)
+		decrqm_status.tr_progress = STATUS_GOT;
+	}
 #endif
 
 	if (setting >= 0 && setting <= 4)

--- a/src/term.c
+++ b/src/term.c
@@ -3173,6 +3173,20 @@ termrequest_any_pending(void)
     return FALSE;
 }
 
+    static void
+termrequest_wait_pending(void)
+{
+    int count = 0;
+
+    while (termrequest_any_pending() && count++ < 10 && !got_int)
+    {
+	(void)vpeekc_nomap();
+	if (termrequest_any_pending())
+	    ui_delay(10L, FALSE);
+    }
+    check_for_codes_from_term();
+}
+
 static int winpos_x = -1;
 static int winpos_y = -1;
 static int did_request_winpos = 0;
@@ -4006,6 +4020,9 @@ settmode(tmode_T tmode)
      */
     if (tmode != cur_tmode)
     {
+	if (tmode != TMODE_RAW)
+	    send_t_RK = FALSE;
+
 #ifdef FEAT_TERMRESPONSE
 # ifdef FEAT_GUI
 	if (!gui.in_use && !gui.starting)
@@ -4014,9 +4031,10 @@ settmode(tmode_T tmode)
 	    // May need to check for T_CRV response and termcodes, it
 	    // doesn't work in Cooked mode, an external program may get
 	    // them.
-	    if (tmode != TMODE_RAW && termrequest_any_pending())
-		(void)vpeekc_nomap();
-	    check_for_codes_from_term();
+	    if (tmode != TMODE_RAW)
+		termrequest_wait_pending();
+	    else
+		check_for_codes_from_term();
 	}
 #endif
 	if (tmode != TMODE_RAW)
@@ -4099,27 +4117,18 @@ stoptermcap(void)
     if (!termcap_active)
 	return;
 
+    send_t_RK = false;
 #ifdef FEAT_TERMRESPONSE
 # ifdef FEAT_GUI
     if (!gui.in_use && !gui.starting)
 # endif
     {
-	// May need to discard T_CRV, T_U7 or T_RBG response.
-	if (termrequest_any_pending())
-	{
-# ifdef UNIX
-	    // Give the terminal a chance to respond.
-	    mch_delay(100L, 0);
-# endif
+	termrequest_wait_pending();
 # ifdef TCIFLUSH
-	    // Discard data received but not read.
-	    if (exiting)
-		tcflush(fileno(stdin), TCIFLUSH);
+	// Discard data received but not read.
+	if (exiting)
+	    tcflush(fileno(stdin), TCIFLUSH);
 # endif
-	}
-	// Check for termcodes first, otherwise an external program may
-	// get them.
-	check_for_codes_from_term();
     }
 #endif
     MAY_WANT_TO_LOG_THIS;


### PR DESCRIPTION
Since I changed to ghostty term resp have been leaking everywhere in multiple modes.

Some of the stray ansi ESC observed both in buffer and elsewhere;
```
^[[?1u
^[[?0u
^[[?12;2$y
^[[105;5u
O]
^[0B^[0B
```

Sometimes any character seems possible; its unclear whether it copies these from buffer text, sometimes I see `,` next to another, but the `u` is definetily consistent and aligns with `CSI u` esc for key decoding - that is the most common single-char I see.
```
u
j
k
,
```

More frequent reproduction when invoking shell commands `:!` or `:make!` and other shell mode mappings. It seems once it happens it stays in that mode until restarted and continously produce stray characters.

Over a few weeks I've tried these one by one everytime it happened and none of them have consistently avoided the issue;
```
set keyprotocol=
let &term = &term
let &t_RK=''
let &t_fe=''
let &t_fd=''
let &t_ks=''
let &t_ke=''
endif
```

Related:
#16318
733a69b

I am still daily driving to verify. Leaving for other ghostty users to try if they encounter the issue.