### PR TITLE
GTK4: window opens two lines too small

### DIFF
--- a/src/gui_gtk4.c
+++ b/src/gui_gtk4.c
@@ -256,6 +256,7 @@ static void mainwin_destroy_cb(GObject *object, gpointer data);
 static gboolean delete_event_cb(GtkWindow *window, gpointer data);
 static int query_pointer_pos(int *x, int *y, GdkModifierType *state);
 static void mainwin_fullscreened_cb(GObject *obj, GParamSpec *pspec, gpointer user_data);
+static void set_form_size(int width, int height);
 static void drawarea_realize_cb(GtkWidget *widget, gpointer data);
 static void drawarea_unrealize_cb(GtkWidget *widget, gpointer data);
 #if defined(FEAT_IMAGE)
@@ -770,11 +771,6 @@ gui_mch_open(void)
     pixel_width  += get_menu_tool_width();
     pixel_height += get_menu_tool_height();
 
-    // Dimensions may be smaller because of client side decorations, we handle
-    // that after we present the window.
-    gtk_window_set_default_size(GTK_WINDOW(gui.mainwin),
-	    pixel_width, pixel_height);
-
     if (foreground_argument != NULL)
 	fg_pixel = gui_get_color((char_u *)foreground_argument);
     if (fg_pixel == INVALCOLOR)
@@ -804,15 +800,14 @@ gui_mch_open(void)
 		     G_CALLBACK(mainwin_destroy_cb), NULL);
     // Resize is handled by GtkForm's size_allocate callback.
 
+    set_form_size((int)pixel_width - get_menu_tool_width(),
+	    (int)pixel_height - get_menu_tool_height());
+
     gtk_window_present(GTK_WINDOW(gui.mainwin));
 
-    // Update so that we get the "gui.decor_height", which we can then use to
-    // set the exact dimensions of the window.
     gui_mch_update();
     Columns = columns;
     Rows = rows;
-    gtk_window_set_default_size(GTK_WINDOW(gui.mainwin),
-	    pixel_width, pixel_height + gui.decor_height);
 
     // Make sure the drawing area gets keyboard focus.
     gtk_widget_grab_focus(gui.drawarea);
@@ -953,12 +948,19 @@ gui_gtk_init_decor_height(void)
     gui.decor_height = h;
 }
 
-    void
-gui_mch_set_shellsize(int width, int height,
-	int min_width UNUSED, int min_height UNUSED,
-	int base_width UNUSED, int base_height UNUSED,
-	int direction UNUSED)
+/*
+ * Ask for the form widget, and thus the shell, to become "width" by "height"
+ * pixels.
+ */
+    static void
+set_form_size(int width, int height)
 {
+    // Nothing to do when the form widget already has this size: no allocation
+    // would follow and the size request below would never be dropped.
+    if (gtk_widget_get_width(gui.formwin) == width
+	    && gtk_widget_get_height(gui.formwin) == height)
+	return;
+
     // Remember the size the form widget is supposed to get. An allocation
     // that arrives before the compositor has answered this request still has
     // the previous size and must not be used.
@@ -966,14 +968,26 @@ gui_mch_set_shellsize(int width, int height,
     gui.pending_form_h = height;
     gui.pending_form_skip = 1;
 
-    width += get_menu_tool_width();
-    height += get_menu_tool_height();
-
     // GtkWindow default size also includes client side decorations, so must
-    // include it also.
-    height += gui.decor_height;
+    // include it also.  It also keeps the natural width of the toolbar from
+    // deciding the width.
+    gtk_window_set_default_size(GTK_WINDOW(gui.mainwin),
+	    width + get_menu_tool_width(),
+	    height + get_menu_tool_height() + gui.decor_height);
 
-    gtk_window_set_default_size(GTK_WINDOW(gui.mainwin), width, height);
+    // The window drops a request made while it is being presented, and
+    // "gui.decor_height" is not known before that.  A size request on the form
+    // widget is honoured then; it is dropped again once the size was given.
+    gtk_widget_set_size_request(gui.formwin, width, height);
+}
+
+    void
+gui_mch_set_shellsize(int width, int height,
+	int min_width UNUSED, int min_height UNUSED,
+	int base_width UNUSED, int base_height UNUSED,
+	int direction UNUSED)
+{
+    set_form_size(width, height);
 
     gui_mch_update();
 }

--- a/src/gui_gtk4.c
+++ b/src/gui_gtk4.c
@@ -805,6 +805,8 @@ gui_mch_open(void)
 
     gtk_window_present(GTK_WINDOW(gui.mainwin));
 
+    // Undo the 80x24 clamp above, gui_init() asks for this size next.  Drain
+    // the pending allocation before that, or gui_resize_shell() overwrites it.
     gui_mch_update();
     Columns = columns;
     Rows = rows;

--- a/src/gui_gtk4_f.c
+++ b/src/gui_gtk4_f.c
@@ -228,7 +228,21 @@ vim_form_resize_idle_cb(VimForm *self)
 		&& --gui.pending_form_skip >= 0)
 	    goto exit;
 
+	int	req_w, req_h;
+
 	gui.pending_form_w = 0;
+
+	// The size request that Vim made has been answered.  Keep the size and
+	// drop the request, otherwise the window could not be made smaller.
+	gtk_widget_get_size_request(GTK_WIDGET(self), &req_w, &req_h);
+	if (req_w != -1 || req_h != -1)
+	{
+	    gtk_window_set_default_size(GTK_WINDOW(gui.mainwin),
+		    gtk_widget_get_width(gui.mainwin),
+		    gtk_widget_get_height(gui.mainwin));
+	    gtk_widget_set_size_request(GTK_WIDGET(self), -1, -1);
+	}
+
 	gui_resize_shell(self->last_width, self->last_height);
     }
 


### PR DESCRIPTION
```
Problem:  On startup the GUI window is the height of the window decorations
          too small, so it shows two lines less than 'lines'.  It only gets
          the right size after the first pointer event.
Solution: Also request the shell size on the form widget, so that GTK derives
          the window height from it with the decorations included.  Drop the
          request again once the size was given, so that the window can still
          be made smaller.
```

related: #21021

---

What was confirmed while working on this:

- The second `gtk_window_set_default_size()` in `gui_mch_open()` cannot do
  anything. `gui.decor_height` is still 0 at that point, so it asks for the
  same size as the call made before `gtk_window_present()`. The property does
  not change, so no resize is queued.
- A `gtk_window_set_default_size()` made right after `gtk_window_present()` is
  dropped for about 600 to 740 msec here. Retrying every 20 msec and retrying
  every 100 msec end at the same time, so it does not depend on how often it
  is asked. `gtk_widget_queue_resize()` on the window does not help either.
- Once startup has settled, `:set lines` and `:set columns` resize the window
  through `gtk_window_set_default_size()` as expected. The problem is limited
  to the window right after it was presented.
- Blocking in the main loop until the window has the size does work, but it
  costs about half a second of startup time, so it is not an option.
- A size request on the form widget is honoured in that window, and GTK
  derives the window height from it with the decorations included. So
  `gui.decor_height` is not needed to get the first size right.
- The width cannot be left to the content. The natural width of the toolbar is
  wider than what Vim asks for (762 px against 654 px here, about 13 columns),
  so the window would open too wide. That is why the size is still set on the
  window as well.
- The size request has to be dropped again, otherwise the window cannot be
  made smaller than the size Vim asked for. Dropping it when the form widget
  has been given the size works, but `set_form_size()` must do nothing when
  the form already has that size: no allocation would follow and the request
  would stay. `gui_init()` calls `gui_set_shellsize()` with the same size right
  after `gui_mch_open()`, so this happens on every startup.

Tested: starts with 80x24, `+"set columns=120"` opens with 120 columns,
`:set lines` and `:set columns` work in both directions, the window can be
resized with the mouse in every direction right after startup.