### PR TITLE
patch 9.2.XXXX: logrotate files are not recognized

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -3,7 +3,7 @@ vim9script
 # Vim functions for file type detection
 #
 # Maintainer:		The Vim Project <https://github.com/vim/vim>
-# Last Change:		2026 Aug 10
+# Last Change:		2026 Aug 13
 # Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 # These functions are moved here from runtime/filetype.vim to make startup
@@ -1738,6 +1738,14 @@ export def Detect_UCI_statements(): bool
   \         )
 enddef
 
+# Detect direct children of a logrotate.d directory.  The autocmd pattern also
+# matches nested paths, so the immediate parent must be checked here.
+export def FTlogrotate()
+  if fnamemodify(expand('<amatch>'), ':h:t') ==# 'logrotate.d'
+    setf logrotate
+  endif
+enddef
+
 export def DetectFromName()
   const amatch = expand("<amatch>")
   const name = fnamemodify(amatch, ':t')
@@ -2430,6 +2438,8 @@ const ft_from_ext = {
   "lt": "lite",
   # Livebook
   "livemd": "livebook",
+  # Logrotate configuration
+  "logrotate": "logrotate",
   # Logtalk
   "lgt": "logtalk",
   # LOTOS
@@ -3372,6 +3382,8 @@ const ft_from_name = {
   "lfrc": "lf",
   # Lilo: Linux loader
   "lilo.conf": "lilo",
+  # Logrotate configuration
+  "logrotate.conf": "logrotate",
   # SBCL implementation of Common Lisp
   "sbclrc": "lisp",
   ".sbclrc": "lisp",

--- a/runtime/autoload/dist/script.vim
+++ b/runtime/autoload/dist/script.vim
@@ -4,7 +4,7 @@ vim9script
 # Invoked from "scripts.vim" in 'runtimepath'
 #
 # Maintainer:	The Vim Project <https://github.com/vim/vim>
-# Last Change:	2026 Apr 09
+# Last Change:	2026 Aug 13
 # Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 export def DetectFiletype()
@@ -260,8 +260,16 @@ def DetectFromText(line1: string)
   var line4 = getline(4)
   var line5 = getline(5)
 
+  # Logrotate configuration.  Keep content detection bounded because this is
+  # tried for every otherwise unclassified text file.
+  const logrotate_path = '\%("\%([^"\\]\|\\.\)\+"\|''\%([^''\\]\|\\.\)\+''\|\%(/\|[~]/\)\%([^[:space:]{}#\\]\|\\.\)\+\)'
+  const logrotate_stanza = '^\s*' .. logrotate_path .. '\%(\s\+' .. logrotate_path .. '\)*\s*{\s*\%(#.*\)\?$'
+
+  if strchars(line1) <= 8192 && line1 =~# logrotate_stanza
+    setl ft=logrotate
+
   # Bourne-like shell scripts: sh ksh bash bash2
-  if line1 =~ '^:$'
+  elseif line1 =~ '^:$'
     call dist#ft#SetFileTypeSH(line1)
 
   # Z shell scripts

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -64,6 +64,10 @@ au BufNewFile,BufRead */doc/*.txt
 " Detect by name
 au BufNewFile,BufRead *				call dist#ft#DetectFromName()
 
+" Logrotate configuration
+au BufNewFile,BufRead *.logrotate.conf		setf logrotate
+au BufNewFile,BufRead */logrotate.d/*		call dist#ft#FTlogrotate()
+
 " Abaqus or Trasys
 au BufNewFile,BufRead *.inp			call dist#ft#Check_inp()
 

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -84,7 +84,8 @@ enddef
 " First one is checking that these files have no filetype.
 def s:GetFilenameChecks(): dict<list<string>>
   return {
-    none: ['bsd', 'some-bsd'],
+    none: ['bsd', 'some-bsd', '/etc/logrotate.d/nested/application',
+      'C:/ProgramData/logrotate/logrotate.d/nested/application', '/var/lib/logrotate/status'],
     8th: ['file.8th'],
     a2ps: ['/etc/a2ps.cfg', '/etc/a2ps/file.cfg', 'a2psrc', '.a2psrc', 'any/etc/a2ps.cfg', 'any/etc/a2ps/file.cfg'],
     a65: ['file.a65'],
@@ -195,7 +196,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     codeowners: ['CODEOWNERS'],
     conaryrecipe: ['file.recipe'],
     concerto: ['file.cto'],
-    conf: ['auto.master', 'file.conf', 'texdoc.cnf', '.x11vncrc', '.chktexrc', '.ripgreprc', 'ripgreprc', 'file.ctags'],
+    conf: ['auto.master', 'file.conf', 'application.conf', 'texdoc.cnf', '.x11vncrc', '.chktexrc', '.ripgreprc', 'ripgreprc', 'file.ctags'],
     config: ['/etc/hostname.file', 'any/etc/hostname.file', 'configure.in', 'configure.ac', 'file.at', 'aclocal.m4'],
     confini: ['pacman.conf', 'paru.conf', 'mpv.conf', 'any/.aws/config', 'any/.aws/credentials', 'any/.aws/cli/alias', 'file.nmconnection',
               'any/.gnuradio/grc.conf', 'any/gnuradio/config.conf', 'any/gnuradio/conf.d/modtool.conf'],
@@ -483,6 +484,9 @@ def s:GetFilenameChecks(): dict<list<string>>
     logcheck: ['/etc/logcheck/file.d-some/file', '/etc/logcheck/file.d/file', 'any/etc/logcheck/file.d-some/file', 'any/etc/logcheck/file.d/file'],
     loginaccess: ['/etc/login.access', 'any/etc/login.access'],
     logindefs: ['/etc/login.defs', 'any/etc/login.defs'],
+    logrotate: ['/etc/logrotate.conf', 'C:/ProgramData/logrotate/logrotate.conf',
+      '/etc/logrotate.d/application', 'C:/ProgramData/logrotate/logrotate.d/application',
+      '/tmp/application.logrotate', '/tmp/application.logrotate.conf'],
     logtalk: ['file.lgt'],
     lotos: ['file.lot', 'file.lotos'],
     lout: ['file.lou', 'file.lout'],
@@ -1078,7 +1082,13 @@ enddef
 " Content lines that should not result in filetype detection
 def s:GetFalsePositiveChecks(): dict<list<list<string>>>
   return {
-      '': [['test execve("/usr/bin/pstree", ["pstree"], 0x7ff0 /* 63 vars */) = 0']],
+      '': [['test execve("/usr/bin/pstree", ["pstree"], 0x7ff0 /* 63 vars */) = 0'],
+           ['application.conf'],
+           ['/var/log/application.log'],
+           ['function deploy() {'],
+           ['logrotate state -- version 1'],
+           ['logrotate state -- version 2'],
+           ['/' .. repeat('\!', 4094) .. 'xx {']],
       }
 enddef
 
@@ -1165,6 +1175,11 @@ def s:GetScriptChecks(): dict<list<list<string>>>
     bpftrace:  [['#!/path/bpftrace']],
     vim:    [['#!/path/vim']],
     ed:     [['#!/usr/bin/ed -f']],
+    logrotate: [['/var/log/application.log {'],
+            ['  ~/logs/application.log { # project policy'],
+            ['"/var/log/application output.log" /var/log/second.log {'],
+            ['/var/log/application\ output.log {'],
+            ['/' .. repeat('\!', 4094) .. 'x {']],
   }
 enddef
 


### PR DESCRIPTION
Vim currently detects logrotate configuration files as the generic conf file type. This detects logrotate.conf, direct children of logrotate.d, the .logrotate and .logrotate.conf suffixes, and otherwise unclassified files whose first line is a complete path stanza.

The filetype regression test failed for each accepted case before the runtime change. make test_filetype.res and make test_codestyle.res pass with the change.

Codex was used to help implement and test this change.