### PR TITLE
patch 9.2.XXXX: double-free in string_reduce() 

### DIFF
--- a/src/list.c
+++ b/src/list.c
@@ -3477,7 +3477,7 @@ f_reduce(typval_T *argvars, typval_T *rettv)
     else if (argvars[1].v_type == VAR_PARTIAL)
 	func_name = partial_name(argvars[1].vval.v_partial);
     else
-	func_name = tv_get_string(&argvars[1]);
+	func_name = tv_get_string_strict(&argvars[1]);
     if (func_name == NULL || *func_name == NUL)
     {
 	emsg(_(e_missing_function_argument));

--- a/src/strings.c
+++ b/src/strings.c
@@ -1043,9 +1043,14 @@ string_reduce(
     for ( ; *p != NUL; p += len)
     {
 	argv[0] = *rettv;
+	rettv->v_type = VAR_UNKNOWN;
+
 	len = copy_first_char_to_tv(p, &argv[1]);
 	if (len < 0)
+	{
+	    *rettv = argv[0];
 	    break;
+	}
 
 	r = eval_expr_typval(expr, TRUE, argv, 2, fc, rettv);
 

--- a/src/testdir/test_listdict.vim
+++ b/src/testdir/test_listdict.vim
@@ -1115,6 +1115,14 @@ func Test_reduce()
   " should not crash
   call assert_fails('echo reduce([1], test_null_function())', 'E1132:')
   call assert_fails('echo reduce([1], test_null_partial())', 'E1132:')
+
+  " did cause double free
+  function! OuterReduce()
+    vim9 echo reduce('ab', 42)
+  endfunction
+  call assert_fails('call OuterReduce()', 'E1024:')
+  call assert_fails("echo reduce('ab', 'NoSuchFunc')", 'E117:')
+  delfunc OuterReduce
 endfunc
 
 " splitting a string to a List using split()


### PR DESCRIPTION
Problem:  string_reduce() copies *rettv into argv[0] before calling
          eval_expr_typval().  When the evaluator fails early, rettv is never
          reset and still aliases argv[0]'s v_string.  clear_tv(&argv[0]) frees
          it, leaving rettv dangling. In vim9script get_func_tv() then frees it
          again.
Solution: Null out argv[0].vval.v_string before clearing it when it
          aliases rettv->vval.v_string.

Supported by AI