### PR TITLE
'isprint' is applied to the leading byte of a character

### DIFF
--- a/src/drawline.c
+++ b/src/drawline.c
@@ -3325,8 +3325,9 @@ win_line(
 		}
 	    }
 
-	    // Handling of non-printable characters.
-	    if (!vim_isprintc(c))
+	    // Handling of non-printable characters. 'isprint' does not apply
+	    // to a UTF-8 leading byte, the character was checked above.
+	    if (!vim_isprintc(c) && !(enc_utf8 && c >= 0x80))
 	    {
 		// when getting a character from the file, we may have to
 		// turn it into something else on the way to putting it

--- a/src/testdir/test_utf8.vim
+++ b/src/testdir/test_utf8.vim
@@ -388,4 +388,22 @@ func Test_overlong_utf8_cells()
   bwipe!
 endfunc
 
+func Test_isprint_leading_byte()
+  new
+  let save_isprint = &isprint
+  " 226 is the leading byte of U+222B, which must not be affected.
+  set isprint+=^226
+  call setline(1, "∫")
+  redraw
+  call assert_equal("∫", ScreenLines(1, 1)[0])
+
+  " U+00E2 has the character value 226 and is still excluded.
+  call setline(1, "â")
+  redraw
+  call assert_equal('<e2>', ScreenLines(1, 4)[0])
+
+  let &isprint = save_isprint
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
```
Problem:  Excluding a value with 'isprint' also breaks the display of
          unrelated characters whose leading byte has that value.  After
          ":set isprint+=^226" the character U+222B is displayed as "<".
Solution: Apply 'isprint' to the character value only, not to the leading
          byte of its UTF-8 encoding.
```

fixes: #21053