### PR TITLE
runtime(shaderslang): fix b:match_words breaking % on braces

### DIFF
--- a/runtime/ftplugin/shaderslang.vim
+++ b/runtime/ftplugin/shaderslang.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin file
 " Language:	Slang
 " Maintainer:	Austin Shijo <epestr@proton.me>
-" Last Change:	2025 Jan 05
+" Last Change:	2026 Aug 16
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin")
@@ -28,12 +28,9 @@ setlocal commentstring=//\ %s
 setlocal comments=sO:*\ -,mO:*\ \ ,exO:*/,s1:/*,mb:*,ex:*/,:///,://
 
 " When the matchit plugin is loaded, this makes the % command skip parens and
-" braces in comments properly, and adds support for shader-specific keywords
+" braces in comments properly
 if exists("loaded_matchit")
-  " Add common shader control structures
-  let b:match_words = '{\|^\s*\<\(if\|for\|while\|switch\|struct\|class\)\>:}\|^\s*\<break\>,' ..
-        \ '^\s*#\s*if\(\|def\|ndef\)\>:^\s*#\s*elif\>:^\s*#\s*else\>:^\s*#\s*endif\>,' ..
-        \ '\[:\]'
+  let b:match_words = '^\s*#\s*if\(\|def\|ndef\)\>:^\s*#\s*elif\>:^\s*#\s*else\>:^\s*#\s*endif\>'
   let b:match_skip = 's:comment\|string\|character\|special'
   let b:match_ignorecase = 0
   let b:undo_ftplugin ..= " | unlet! b:match_skip b:match_words b:match_ignorecase"

--- a/src/testdir/test_plugin_matchit.vim
+++ b/src/testdir/test_plugin_matchit.vim
@@ -55,4 +55,22 @@ func Test_html_matchit_tag_multiline_attributes()
   bwipe!
 endfunc
 
+func Test_shaderslang_matchit_switch_break()
+  call s:Setup(['void main() {', '  switch (x) {', '    case 1:',
+        \ '      break;', '  }', '}'], 'shaderslang')
+  call assert_equal(5, s:PercentTo([2, 14]))
+  call assert_equal(2, s:PercentTo([5, 3]))
+  bwipe!
+endfunc
+
+func Test_shaderslang_matchit_loop_break()
+  call s:Setup(['void f() {', '  for (int i = 0; i < 4; ++i) {',
+        \ '    if (i == 2)', '      break;', '    total += i;', '  }',
+        \ '  int after = 1;', '}'], 'shaderslang')
+  call assert_equal(8, s:PercentTo([1, 10]))
+  call assert_equal(6, s:PercentTo([2, 31]))
+  call assert_equal(2, s:PercentTo([6, 3]))
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
In `ftplugin/shaderslang.vim`, `b:match_words` puts `{` in the same *open* half as `if`/`for`/`while`/`switch`/`struct`/`class`, and `}` in the same *close* half as `break`.
matchit counts every alternative in a group instead of pairing them with each other, so `for (...) {` counts as two openers and a brace can pair with a `break`.

With `vim --clean -c 'packadd matchit' -c 'edit x.slang'` (in Nvim `nvim --clean x.slang` is enough, it enables matchit by default):

```slang
void f() {                       // % -> line 7   (should be 13)
  switch (mode) {                // % -> line 4   (should be 7)
    case 1:
      break;
    default:
      break;
  }                              // % -> line 1   (should be 2)
  for (int i = 0; i < 4; ++i) {  // % -> line 12  (correct)
    if (i == 2)
      break;
    total += i;
  }
}                                // % -> line 8   (should be 1)
```

With one more keyword line in the mix (e.g. an `if` above the `break` in `case 1`) the surplus stops balancing altogether and `%` on the function's opening brace finds no match at all, leaving the cursor where it is.

### Fix

Drop the brace/keyword group and `\[:\]` — matchit appends `'matchpairs'` by itself.
The preprocessor group is left unchanged: Slang has no `#elifdef`/`#elifndef` (`kDirectives` in `slang-preprocessor.cpp`), so it should not follow `ftplugin/c.vim` there. `b:match_skip` is untouched.

Trade-offs: braces match correctly again, brackets and parens are unaffected, and `%` on `if`/`for`/`while` now goes to the header's closing paren as in C files - but `%` on a `break;` no longer jumps back to the enclosing opener.
Keeping that would need a group of its own (e.g. `^\s*\<\(do\|for\|switch\|while\)\>:^\s*\<break\>`), which in turn leaves `%` dead on any `for`/`while` without a `break` in it.

### Tests

`Test_shaderslang_matchit_switch_break` and `Test_shaderslang_matchit_loop_break` in `src/testdir/test_plugin_matchit.vim` fail before this change and pass after it.

cc @mTvare6 as the file's maintainer.

Prepared with AI assistance (Claude Opus 5) per CONTRIBUTING.md, recorded in the commit's `Co-Authored-By` trailer.

Mainly, I wanted to report this - the patch is a suggestion, written with AI assistance and reviewed as far as my understanding goes. So, please change or replace it as you see fit. If I can help with anything, let me know :)
