### PR TITLE
tests: Test_xrestore() is flaky and cannot recover

### DIFF
--- a/src/testdir/test_paste.vim
+++ b/src/testdir/test_paste.vim
@@ -176,6 +176,9 @@ endfunc
 func CheckCopyPaste()
   call setline(1, ['copy this', ''])
   normal 1G0"*y$
+  " The selection may not be available right away after connecting to the X
+  " server, the put below would then throw E353.
+  call WaitForAssert({-> assert_equal('copy this', getreg('*'))})
   normal j"*p
   call assert_equal('copy this', getline(2))
 endfunc
@@ -186,15 +189,20 @@ func Test_xrestore()
 
   let display = $DISPLAY
   new
-  call CheckCopyPaste()
+  " Restore the display even when a check fails, otherwise the retry runs
+  " without a connection to the X server.
+  try
+    call CheckCopyPaste()
 
-  xrestore
-  call CheckCopyPaste()
+    xrestore
+    call CheckCopyPaste()
 
-  exe "xrestore " .. display
-  call CheckCopyPaste()
-
-  bwipe!
+    exe "xrestore " .. display
+    call CheckCopyPaste()
+  finally
+    exe "xrestore " .. display
+    bwipe!
+  endtry
 endfunc
 
 " Test for 'pastetoggle'


### PR DESCRIPTION
```
Problem:  Test_xrestore() fails on CI and the retry fails as well, because
          the retry runs in the same Vim and the connection to the X server
          was not restored.
Solution: Restore the display in a "finally" block.  Wait for the selection
          to become available instead of failing with E353.
```

The failure: https://github.com/vim/vim/actions/runs/31956315725/job/95187385784