### PR TITLE
patch 9.2.XXXX: line continuation for command arguments is undocumented

### DIFF
--- a/runtime/doc/vim9.txt
+++ b/runtime/doc/vim9.txt
@@ -914,8 +914,16 @@ Notes:
 	echo [1, 2]
 		[3, 4]
 - In some cases it is difficult for Vim to parse a command, especially when
-  commands are used as an argument to another command, such as `:windo`.  In
-  those cases the line continuation with a backslash has to be used.
+  commands are used as an argument to another command, such as `:windo`,
+  `:command` or `:autocmd`.  In those cases the line continuation with a
+  backslash has to be used.  For example: >
+	command! Foo call Bar('x', {
+	      \ 'key': 'value',
+	      \ })
+	autocmd BufWritePre * call Bar('x', {
+	      \ 'key': 'value',
+	      \ })
+<
 
 
 White space ~

--- a/src/testdir/test_autocmd.vim
+++ b/src/testdir/test_autocmd.vim
@@ -4070,6 +4070,24 @@ func Test_autocmd_with_block()
   augroup END
 endfunc
 
+" Test for a backslash line continuation in an :autocmd command
+func Test_autocmd_line_continuation()
+  let lines =<< trim END
+      vim9script
+      def Bar(label: string, value: any): void
+        g:result = [label, value]
+      enddef
+      autocmd BufWritePre * call Bar('x', {
+            \ 'key': 'value',
+            \ })
+      doautocmd BufWritePre
+      assert_equal(['x', {'key': 'value'}], g:result)
+  END
+  call v9.CheckScriptSuccess(lines)
+  unlet g:result
+  au! BufWritePre
+endfunc
+
 " Test for a {} block at script level in an :autocmd nested in another one
 func Test_autocmd_nested_block()
   let lines =<< trim END

--- a/src/testdir/test_usercommands.vim
+++ b/src/testdir/test_usercommands.vim
@@ -927,6 +927,24 @@ func Test_usercmd_custom()
   delfunc T2
 endfunc
 
+" Test for a backslash line continuation in a :command replacement
+func Test_usercmd_line_continuation()
+  let lines =<< trim END
+      vim9script
+      def Bar(label: string, value: any): void
+        g:result = [label, value]
+      enddef
+      command! Foo call Bar('x', {
+            \ 'key': 'value',
+            \ })
+      Foo
+      assert_equal(['x', {'key': 'value'}], g:result)
+  END
+  call v9.CheckScriptSuccess(lines)
+  unlet g:result
+  delcommand Foo
+endfunc
+
 " Test for a {} block in a command nested in :command or :autocmd
 func Test_usercmd_nested_block()
   command DefineIt command DoNested {


### PR DESCRIPTION
Problem:  Line continuation for command arguments such as :command and :autocmd is not documented.

Location: The issue concerns Vim9 command parsing when a command is used as the argument of another command. A multiline dictionary inside :command or :autocmd cannot be reliably distinguished from a command block, lambda body, string, pattern, or other expression that ends with a curly brace.

Solution: Document the required backslash continuation form for :command and :autocmd in *vim9-line-continuation*. Add regression tests that define and execute the called function, trigger the autocommand, and verify the resulting dictionary contents.

The parser workaround was withdrawn rather than extending a delimiter heuristic. This avoids restoring the ambiguous behavior removed by patch 9.2.0908 and provides a clear, documented syntax that does not require changing the general Ex or Vim9 expression parser.

Tests:
- make -C src -j2
- make -C src/testdir test_usercommands.res
- make -C src/testdir test_autocmd.res
- make -C src/testdir test_vim9_script.res
- make -C src/testdir codestyle
- git diff --check

Fixes: #21070