### PR TITLE
minor spelling correction of initiali[s]ation to initali[z]ation

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2743,7 +2743,7 @@ v:profiling	Normally zero.  Set to one after using ":profile start".
 
 					*v:progname* *progname-variable*
 v:progname	Contains the name (with path removed) with which Vim was
-		invoked.  Allows you to do special initialisations for |view|,
+		invoked.  Allows you to do special initializations for |view|,
 		|evim| etc., or any other name you might symlink to Vim.
 		Read-only.
 

--- a/runtime/doc/help.txt
+++ b/runtime/doc/help.txt
@@ -116,7 +116,7 @@ General subjects ~
 |uganda.txt|	Vim distribution conditions and what to do with your money
 
 Basic editing ~
-|starting.txt|	starting Vim, Vim command arguments, initialisation
+|starting.txt|	starting Vim, Vim command arguments, initialization
 |editing.txt|	editing and writing files
 |motion.txt|	commands for moving around
 |scroll.txt|	scrolling the text in the window

--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -1143,7 +1143,7 @@ To enter debugging mode use one of these methods:
 	vim -D file.txt
 <  Debugging will start as soon as the first vimrc file is sourced.  This is
    useful to find out what is happening when Vim is starting up.  A side
-   effect is that Vim will switch the terminal mode before initialisations
+   effect is that Vim will switch the terminal mode before initializations
    have finished, with unpredictable results.
    For a GUI-only version (Windows, Macintosh) the debugging will start as
    soon as the GUI window has been opened.  To make this happen early, add a

--- a/runtime/doc/version5.txt
+++ b/runtime/doc/version5.txt
@@ -4380,7 +4380,7 @@ VisVim could still crash on exit. (Erhardt)
 "case a: case b:" (two case statements in one line) aligned with the second
 case.  Now it uses one 'sw' for indent. (Webb)
 
-Font initialisation wasn't right for Athena/Motif GUI.  Moved the call to
+Font initialization wasn't right for Athena/Motif GUI.  Moved the call to
 highlight_gui_started() gui_mch_init() to gui_mch_open(). (Nam)
 
 In Replace mode, backspacing over a TAB before where the replace mode started

--- a/runtime/doc/version7.txt
+++ b/runtime/doc/version7.txt
@@ -12913,7 +12913,7 @@ Files:	    src/ui.c
 
 Patch 7.3.441
 Problem:    Newer versions of MzScheme (Racket) require earlier (trampolined)
-	    initialisation.
+	    initialization.
 Solution:   Call mzscheme_main() early in main(). (Sergey Khorev)
 Files:	    src/Make_mvc.mak, src/if_mzsch.c, src/main.c,
 	    src/proto/if_mzsch.pro

--- a/runtime/doc/version8.txt
+++ b/runtime/doc/version8.txt
@@ -16807,7 +16807,7 @@ Files:      runtime/doc/if_mzsch.txt, runtime/doc/if_pyth.txt,
             src/testdir/test_viml.vim
 
 Patch 8.0.0361
-Problem:    GUI initialisation is not sufficiently tested.
+Problem:    GUI initialization is not sufficiently tested.
 Solution:   Add the gui_init test. (Kazunobu Kuriyama)
 Files:      src/Makefile, src/testdir/Make_all.mak, src/testdir/Make_dos.mak,
             src/testdir/Make_ming.mak, src/testdir/Makefile,
@@ -19016,7 +19016,7 @@ Files:      src/option.c, src/option.h, src/structs.h
 
 Patch 8.0.0713 (after 8.0.0712)
 Problem:    'termkey' option not fully implemented.
-Solution:   Add initialisation.
+Solution:   Add initialization.
 Files:      src/option.c
 
 Patch 8.0.0714
@@ -20201,7 +20201,7 @@ Solution:   Add the 'nocombine' value to replace attributes instead of
 Files:      runtime/doc/syntax.txt, src/syntax.c, src/vim.h
 
 Patch 8.0.0915
-Problem:    Wrong initialisation of global.
+Problem:    Wrong initialization of global.
 Solution:   Use INIT().
 Files:      src/globals.h
 
@@ -37785,7 +37785,7 @@ Files:	    src/cmdexpand.c, src/misc1.c
 
 Patch 8.1.1898
 Problem:    Crash when out of memory during startup.
-Solution:   When out of memory message given during initialisation bail out.
+Solution:   When out of memory message given during initialization bail out.
             (closes #4842)
 Files:	    src/misc2.c
 

--- a/runtime/doc/version9.txt
+++ b/runtime/doc/version9.txt
@@ -26468,7 +26468,7 @@ Solution:   Update #ifdefs. (Ken Takata, closes #9709)
 Files:      src/main.c, src/os_unix.c, src/pty.c, src/vim.h
 
 Patch 8.2.4317
-Problem:    MS-Windows: Vim exits when Python 3 initialisation fails.
+Problem:    MS-Windows: Vim exits when Python 3 initialization fails.
 Solution:   Hook into the exit() function to recover from the failure.
             (Ken Takata, closes #9710)
 Files:      runtime/doc/if_pyth.txt, src/if_python3.c, src/os_win32.c,

--- a/runtime/macros/hanoi/hanoi.vim
+++ b/runtime/macros/hanoi/hanoi.vim
@@ -19,7 +19,7 @@ map e "fy2l
 map E "hp
 map F "hy2l
 
-" initialisations:
+" initializations:
 " KM	cleanup buffer
 " Y	create tower of desired height
 " NOQ	copy it and insert a T

--- a/runtime/macros/life/life.vim
+++ b/runtime/macros/life/life.vim
@@ -101,7 +101,7 @@ map z ,^,&,*,&<1,*<2
 "
 "  ----- END of macros that can be used by the human -----
 "
-"  ----- Initialisation -----
+"  ----- Initialization -----
 "
 map ,- :s/./-/g
 map ,o oPut 'X's in the left box, then hit 'C' or 'R'
@@ -114,7 +114,7 @@ map )1 o-    JOHN CONWAY     --....................--....................-
 map )2 o-       LIVES        --....................--....................-
 "
 "
-" Initialisation of the pattern/command to execute for working out a square.
+" Initialization of the pattern/command to execute for working out a square.
 " Pattern is: "#<germ><count>"
 " where <germ>   is " " if the current germ is dead, "X" when living.
 "       <count>  is the number of living neighbours (including current germ)
@@ -146,7 +146,7 @@ map ,Iab o=RS =ST =TU =UV =VW =WX =XY =YZ =Z 
 " Insert the searched patterns above the board
 map ,IIN G?^top,Il8,Id8,Il7,Id7,Il6,Id6,Il5,Id5,Il4,Id4,Il3,Id3,Il2,Id2,Il1,Id1,Il0,Id0,Iaa,Iab
 "
-"  ----- END of Initialisation -----
+"  ----- END of Initialization -----
 "
 "  ----- Work out one line -----
 "

--- a/runtime/syntax/testdir/input/c.c
+++ b/runtime/syntax/testdir/input/c.c
@@ -103,7 +103,7 @@ main
 #endif
 
     /*
-     * Do any system-specific initialisations.  These can NOT use IObuff or
+     * Do any system-specific initializations.  These can NOT use IObuff or
      * NameBuff.  Thus emsg2() cannot be called!
      */
     mch_early_init();
@@ -114,7 +114,7 @@ main
 #if 0
     /*
      * Newer version of MzScheme (Racket) require earlier (trampolined)
-     * initialisation via scheme_main_setup.
+     * initialization via scheme_main_setup.
      */
     return mzscheme_main();
 #else

--- a/runtime/tools/shtags.pl
+++ b/runtime/tools/shtags.pl
@@ -43,7 +43,7 @@ _EOVERS
 }
 
 #
-# initialisations
+# initializations
 #
 ($program = $0) =~ s,.*/,,;
 

--- a/src/cindent.c
+++ b/src/cindent.c
@@ -3288,7 +3288,7 @@ get_c_indent(void)
 		//   sizeof
 		//	  here
 		// Otherwise check whether it is an enumeration or structure
-		// initialisation (not indented) or a variable declaration
+		// initialization (not indented) or a variable declaration
 		// (indented).
 		terminated = cin_isterminated(l, FALSE, TRUE);
 

--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -5792,7 +5792,7 @@ ole_error(char *arg)
     gui.in_use = mch_is_gui_executable();
 # endif
 
-    // Can't use emsg() here, we have not finished initialisation yet.
+    // Can't use emsg() here, we have not finished initialization yet.
     vim_snprintf(buf, IOSIZE,
 			 _(e_argument_not_supported_str_use_ole_version), arg);
     mch_errmsg(buf);

--- a/src/if_ole.cpp
+++ b/src/if_ole.cpp
@@ -133,7 +133,7 @@ CVim *CVim::Create(int *pbDoRestart)
     me = new CVim();
     if (me == NULL)
     {
-	MessageBox(0, "Cannot create application object", "Vim Initialisation", 0);
+	MessageBox(0, "Cannot create application object", "Vim Initialization", 0);
 	return NULL;
     }
 
@@ -155,7 +155,7 @@ CVim *CVim::Create(int *pbDoRestart)
 	RegCloseKey(hKey);
 
 	if (MessageBox(0, "Cannot load registered type library.\nDo you want to register Vim now?",
-		    "Vim Initialisation", MB_YESNO | MB_ICONQUESTION) != IDYES)
+		    "Vim Initialization", MB_YESNO | MB_ICONQUESTION) != IDYES)
 	{
 	    delete me;
 	    return NULL;
@@ -168,7 +168,7 @@ CVim *CVim::Create(int *pbDoRestart)
 	if (FAILED(hr))
 	{
 	    MessageBox(0, "You must restart Vim in order for the registration to take effect.",
-						     "Vim Initialisation", 0);
+						     "Vim Initialization", 0);
 	    *pbDoRestart = TRUE;
 	    delete me;
 	    return NULL;
@@ -182,7 +182,7 @@ CVim *CVim::Create(int *pbDoRestart)
     if (FAILED(hr))
     {
 	MessageBox(0, "Cannot get interface type information",
-						     "Vim Initialisation", 0);
+						     "Vim Initialization", 0);
 	delete me;
 	return NULL;
     }
@@ -446,7 +446,7 @@ CVimCF *CVimCF::Create()
     CVimCF *me = new CVimCF();
 
     if (me == NULL)
-	MessageBox(0, "Cannot create class factory", "Vim Initialisation", 0);
+	MessageBox(0, "Cannot create class factory", "Vim Initialization", 0);
 
     return me;
 }
@@ -698,7 +698,7 @@ static void SetKeyAndValue(const char *key, const char *subkey, const char *valu
 }
 
 /*****************************************************************************
- 5. OLE Initialisation and shutdown processing
+ 5. OLE Initialization and shutdown processing
 *****************************************************************************/
 extern "C" void InitOLE(int *pbDoRestart)
 {
@@ -710,7 +710,7 @@ extern "C" void InitOLE(int *pbDoRestart)
     hr = OleInitialize(NULL);
     if (FAILED(hr))
     {
-	MessageBox(0, "Cannot initialise OLE", "Vim Initialisation", 0);
+	MessageBox(0, "Cannot initialize OLE", "Vim Initialization", 0);
 	goto error0;
     }
 
@@ -734,7 +734,7 @@ extern "C" void InitOLE(int *pbDoRestart)
 
     if (FAILED(hr))
     {
-	MessageBox(0, "Cannot register class factory", "Vim Initialisation", 0);
+	MessageBox(0, "Cannot register class factory", "Vim Initialization", 0);
 	goto error1;
     }
 
@@ -747,7 +747,7 @@ extern "C" void InitOLE(int *pbDoRestart)
 
     if (FAILED(hr))
     {
-	MessageBox(0, "Cannot register application object", "Vim Initialisation", 0);
+	MessageBox(0, "Cannot register application object", "Vim Initialization", 0);
 	goto error1;
     }
 

--- a/src/if_perl.xs
+++ b/src/if_perl.xs
@@ -924,7 +924,7 @@ struct ufuncs cw_funcs = { cur_val, 0, 0 };
 struct ufuncs cb_funcs = { cur_val, 0, 1 };
 
 /*
- * VIM_init(): Vim-specific initialisation.
+ * VIM_init(): Vim-specific initialization.
  * Make the magical main::curwin and main::curbuf variables
  */
     static void

--- a/src/main.c
+++ b/src/main.c
@@ -102,7 +102,7 @@ main
 #  endif
 
     /*
-     * Do any system-specific initialisations.  These can NOT use IObuff or
+     * Do any system-specific initializations.  These can NOT use IObuff or
      * NameBuff.  Thus emsg2() cannot be called!
      */
     mch_early_init();
@@ -145,7 +145,7 @@ main
 #  endif
 
     /*
-     * Various initialisations #1 shared with tests.
+     * Various initializations #1 shared with tests.
      */
     common_init_1();
 
@@ -190,7 +190,7 @@ main
 #  endif
 
     /*
-     * Various initialisations #2 shared with tests.
+     * Various initializations #2 shared with tests.
      */
     common_init_2(&params);
 
@@ -443,7 +443,7 @@ main
 #  ifdef FEAT_MZSCHEME
     /*
      * Newer version of MzScheme (Racket) require earlier (trampolined)
-     * initialisation via scheme_main_setup.
+     * initialization via scheme_main_setup.
      * Implement this by initialising it as early as possible
      * and splitting off remaining Vim main into vim_main2().
      * Do source startup scripts, so that 'mzschemedll' can be set.
@@ -982,7 +982,7 @@ vim_main2(void)
 }
 
 /*
- * Initialisation #1 shared by main() and some tests.
+ * Initialization #1 shared by main() and some tests.
  */
     void
 common_init_1(void)
@@ -1011,7 +1011,7 @@ common_init_1(void)
 
 
 /*
- * Initialisation #2 shared by main() and some tests.
+ * Initialization #2 shared by main() and some tests.
  */
     void
 common_init_2(mparm_T *paramp)

--- a/src/message.c
+++ b/src/message.c
@@ -387,7 +387,7 @@ smsg(const char *s, ...)
 {
     if (IObuff == NULL)
     {
-	// Very early in initialisation and already something wrong, just
+	// Very early in initialization and already something wrong, just
 	// give the raw message so the user at least gets a hint.
 	return msg((char *)s);
     }
@@ -405,7 +405,7 @@ smsg_attr(int attr, const char *s, ...)
 {
     if (IObuff == NULL)
     {
-	// Very early in initialisation and already something wrong, just
+	// Very early in initialization and already something wrong, just
 	// give the raw message so the user at least gets a hint.
 	return msg_attr((char *)s, attr);
     }
@@ -423,7 +423,7 @@ smsg_attr_keep(int attr, const char *s, ...)
 {
     if (IObuff == NULL)
     {
-	// Very early in initialisation and already something wrong, just
+	// Very early in initialization and already something wrong, just
 	// give the raw message so the user at least gets a hint.
 	return msg_attr_keep((char *)s, attr, TRUE);
     }
@@ -822,7 +822,7 @@ semsg(const char *s, ...)
 	return TRUE;
 
     if (IObuff == NULL)
-	// Very early in initialisation and already something wrong, just
+	// Very early in initialization and already something wrong, just
 	// give the raw message so the user at least gets a hint.
 	return emsg_core(s);
 
@@ -878,7 +878,7 @@ siemsg(const char *s, ...)
 
     if (IObuff == NULL)
     {
-	// Very early in initialisation and already something wrong, just
+	// Very early in initialization and already something wrong, just
 	// give the raw message so the user at least gets a hint.
 	emsg_core(s);
     }
@@ -4192,7 +4192,7 @@ give_warning2(char_u *message, char_u *a1, int hl)
 {
     if (IObuff == NULL)
     {
-	// Very early in initialisation and already something wrong, just give
+	// Very early in initialization and already something wrong, just give
 	// the raw message so the user at least gets a hint.
 	give_warning(message, hl);
     }

--- a/src/po/en_GB.po
+++ b/src/po/en_GB.po
@@ -353,7 +353,7 @@ msgid "E1010: Type not recognized: %s"
 msgstr "E1010: Type not recognised: %s"
 
 msgid "E1022: Type or initialization required"
-msgstr "E1022: Type or initialisation required"
+msgstr "E1022: Type or initialization required"
 
 #, c-format
 msgid "E1146: Command not recognized: %s"

--- a/src/vim9class.c
+++ b/src/vim9class.c
@@ -57,7 +57,7 @@ class_cleared(class_T *cl)
  * Parse a member declaration, both object and class member.
  * Returns OK or FAIL.  When OK then "varname_end" is set to just after the
  * variable name and "type_ret" is set to the declared or detected type.
- * "init_expr" is set to the initialisation expression (allocated), if there is
+ * "init_expr" is set to the initialization expression (allocated), if there is
  * one.  For an interface "init_expr" is NULL.
  */
     static int


### PR DESCRIPTION
Changed all occurrences of the spelling mistake I could find. Note that this does NOT include the french use-cases, as initiali[s]ation is the correct french spelling. Additionally the syntax highlighting for the B programming language was NOT changed as the documentation I found showed that the B statement is INITIALSATION instead of INITIALIZATION.