### PR TITLE
the ja.euc-jp.po file is generated wrong on macOS

### DIFF
--- a/src/po/Makefile
+++ b/src/po/Makefile
@@ -108,8 +108,11 @@ ja.sjis.po: ja.po
 sjiscorr: sjiscorr.c
 	$(CC) -o sjiscorr sjiscorr.c
 
+# Use EUC-JP-MS instead of EUC-JP: the iconv of macOS turns a backslash that
+# follows a multibyte character into a fullwidth one for EUC-JP, which breaks
+# the escaping in the po file. The result is the same for both names.
 ja.euc-jp.po: ja.po
-	iconv -f UTF-8 -t EUC-JP $? | \
+	iconv -f UTF-8 -t EUC-JP-MS $? | \
 		$(SED) -e 's/charset=[uU][tT][fF]-8/charset=EUC-JP/' \
 			-e 's/# Original translations/# Generated from $?, DO NOT EDIT/' \
 			> $@


### PR DESCRIPTION
```
Problem:  The macOS CI job fails now and then on the check of ja.euc-jp.po.
          The iconv of macOS turns a backslash that follows a multibyte
          character into a fullwidth one, which breaks the escaping. The
          file in the repository is correct, it is only regenerated when a
          checkout leaves ja.po newer, which is why the failure comes and
          goes.
Solution: Convert to EUC-JP-MS, which keeps the backslash and gives the same
          result otherwise.
```

Measured on a macOS runner, converting ja.po and dumping the msgstr of E1078:

```
-t EUC-JP        a1 a3  a1 c0  22    。 ＼ "
-t EUC-JP-MS     a1 a3  5c 22        。 \ "
-t eucJP-open    a1 a3  5c 22        。 \ "
```

On Linux, converting the whole file with EUC-JP and with EUC-JP-MS gives byte
identical output, and it matches the ja.euc-jp.po in the repository, so
regenerating produces no diff.

Verified by removing ja.euc-jp.po on a branch to force the conversion: all
six macOS jobs pass with the change and fail without it.

The four `。\n` in the file are corrupted the same way, but the check only
counts `%` and does not notice them.

<img width="75%" height="75%" alt="image" src="https://github.com/user-attachments/assets/a863e7f4-d42b-4398-af6c-e661335e1927" />