### PR TITLE
'laststatus' is ignored when creating a full-height vertical split

### DIFF
--- a/src/testdir/test_statusline.vim
+++ b/src/testdir/test_statusline.vim
@@ -1250,4 +1250,61 @@ func Test_statusline_vsep_borrow_hl_mode_change()
   call StopVimInTerminal(buf)
 endfunc
 
+" Creating a full-height vertical split must not add a status line when
+" 'laststatus' is zero.
+func Test_window_cmd_ls0_splitmove()
+  set laststatus=0
+  let avail = &lines - &cmdheight
+
+  " CTRL-W H and CTRL-W L move a window into a full-height vertical split.
+  for cmd in ['H', 'L']
+    split
+    exe 'wincmd ' .. cmd
+    call assert_equal([0, 0],
+          \ map(range(1, winnr('$')), 'avail - winheight(v:val)'),
+          \ 'wincmd ' .. cmd)
+    only!
+  endfor
+
+  " The same when the full-height vertical split is created directly, which
+  " does not go through win_splitmove().
+  for cmd in ['vert topleft new', 'vert botright new',
+        \ 'topleft vsplit', 'botright vsplit']
+    exe cmd
+    call assert_equal([0, 0],
+          \ map(range(1, winnr('$')), 'avail - winheight(v:val)'), cmd)
+    only!
+  endfor
+
+  " With a horizontal split next to it the new window still spans the full
+  " height; the status line between the stacked windows remains.
+  for cmd in ['split | split | wincmd H', 'split | vert topleft new']
+    exe cmd
+    call assert_equal(0, avail - winheight(1), cmd .. ', left window')
+    call assert_equal(1, avail - winheight(2) - winheight(3),
+          \ cmd .. ', right column')
+    only!
+  endfor
+
+  " The reverse still adds a status line to the upper window.
+  vsplit
+  wincmd K
+  call assert_equal(1, avail - winheight(1) - winheight(2))
+  only!
+
+  " With 'laststatus' set every window does get a status line.
+  for ls in [1, 2]
+    exe 'set laststatus=' .. ls
+    split
+    wincmd H
+    call assert_equal([1, 1],
+          \ map(range(1, winnr('$')), 'avail - winheight(v:val)'),
+          \ 'laststatus=' .. ls)
+    only!
+  endfor
+
+  set laststatus&vim
+  %bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/window.c
+++ b/src/window.c
@@ -1378,10 +1378,13 @@ win_split_ins(
 	if (flags & (WSP_TOP | WSP_BOT))
 	{
 	    // set height and row of new window to full height
+	    // no status line when 'laststatus' is zero
+	    int stl_height = p_ls > 0 ? statusline_height(curfrp->fr_win) : 0;
+
 	    wp->w_winrow = tabline_height();
-	    win_new_height(wp, curfrp->fr_height
-		    - statusline_height(curfrp->fr_win) - WINBAR_HEIGHT(wp));
-	    wp->w_status_height = statusline_height(curfrp->fr_win);
+	    win_new_height(wp, curfrp->fr_height - stl_height
+							  - WINBAR_HEIGHT(wp));
+	    wp->w_status_height = stl_height;
 	}
 	else
 	{


### PR DESCRIPTION
Problem:  'laststatus' is ignored when creating a full-height vertical
          split.  With 'laststatus' zero, CTRL-W H, CTRL-W L and
          :vertical topleft/botright split all give the new window a
          status line, e.g. with
          "vim --clean -c 'set laststatus=0' -c 'sp|wincmd H'".  Setting
          'laststatus' to zero again makes it disappear.
Solution: In win_split_ins(), only reserve a status line for the new
          full-height window when 'laststatus' is non-zero.