### PR TITLE
fix(cli): parsing bug - require exact match for longopt name

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1921,7 +1921,7 @@ early_arg_scan(mparm_T *parmp UNUSED)
 #  endif
 	}
 #  ifdef FEAT_CLIENTSERVER_BACKENDS
-	else if (STRNICMP(argv[i], "--clientserver", 14) == 0)
+	else if (STRICMP(argv[i], "--clientserver") == 0)
 	{
 	    char_u *arg;
 	    if (i == argc - 1)

--- a/src/main.c
+++ b/src/main.c
@@ -2265,11 +2265,11 @@ command_line_scan(mparm_T *parmp)
 # ifdef FEAT_CLIENTSERVER
 		else if (STRNICMP(argv[0] + argv_idx, "serverlist", 10) == 0)
 		    ; // already processed -- no arg
-		else if (STRNICMP(argv[0] + argv_idx, "servername", 10) == 0
-		       || STRNICMP(argv[0] + argv_idx, "serversend", 10) == 0
+		else if (STRICMP(argv[0] + argv_idx, "servername") == 0
+		       || STRICMP(argv[0] + argv_idx, "serversend") == 0
 		       // Don't put this under FEAT_CLIENTSERVER_BACKENDS, just
 		       // let it be ignored. Makes tests less complicated
-		       || STRNICMP(argv[0] + argv_idx, "clientserver", 12) == 0
+		       || STRICMP(argv[0] + argv_idx, "clientserver") == 0
 		       )
 		{
 		    // already processed -- snatch the following arg

--- a/src/main.c
+++ b/src/main.c
@@ -2263,7 +2263,7 @@ command_line_scan(mparm_T *parmp)
 		    argv_idx += 3;
 		}
 # ifdef FEAT_CLIENTSERVER
-		else if (STRNICMP(argv[0] + argv_idx, "serverlist", 10) == 0)
+		else if (STRICMP(argv[0] + argv_idx, "serverlist") == 0)
 		    ; // already processed -- no arg
 		else if (STRICMP(argv[0] + argv_idx, "servername") == 0
 		       || STRICMP(argv[0] + argv_idx, "serversend") == 0

--- a/src/testdir/test_startup.vim
+++ b/src/testdir/test_startup.vim
@@ -985,6 +985,18 @@ func Test_v_argv()
   call assert_equal(['arg1', '--cmd', 'echo v:argv', '--cmd', 'q'']'], list[idx:])
 endfunc
 
+func Test_longopt_prefix_not_accepted()
+  CheckNotGui
+  CheckFeature clientserver
+
+  let command = printf('%s -es -X -Nu NONE -i NONE -n',
+    \ GetVimCommand())
+  let output = system($'{command} --servername=test --clientserver socket 2>&1')
+
+  call assert_notequal(0, v:shell_error)
+  call assert_match('Unknown option', output)
+endfunc
+
 " Test for the "-r" recovery mode option
 func Test_r_arg()
   " Can't catch the output of gvim.

--- a/src/testdir/test_startup.vim
+++ b/src/testdir/test_startup.vim
@@ -989,12 +989,13 @@ func Test_longopt_prefix_not_accepted()
   CheckNotGui
   CheckFeature clientserver
 
-  let command = printf('%s -es -X -Nu NONE -i NONE -n',
-    \ GetVimCommand())
-  let output = system($'{command} --servername=test --clientserver socket 2>&1')
-
-  call assert_notequal(0, v:shell_error)
-  call assert_match('Unknown option', output)
+  let command = printf('%s -es -X -i NONE -n', GetVimCommand())
+  for args in ['--servername=test --clientserver socket',
+        \ '--clientserver=socket',
+        \ '--serverlistx']
+    call system($'{command} {args}')
+    call assert_notequal(0, v:shell_error, args)
+  endfor
 endfunc
 
 " Test for the "-r" recovery mode option


### PR DESCRIPTION
**Problem**

```sh
 # socket arg is parsed wrongly as positional argument buffer(file) arg: 1
gvim --servername=gvim --clientserver socket
```

```sh
/usr/bin/vim -Es --servername=test --clientserver socket \
+'redir! > /dev/stdout' \
+'echo "servername:" .. v:servername' \
+'echo "initialbufname:" .. bufname()' +'qall!'

servername:
initialbufname:socket
```

**Solution**
Use exact string comparison for `servername`, `serversend`, and
`clientserver` instead of prefix comparison, so trailing characters are not
accepted as part of those option names.