### PR TITLE
runtime(netrw): prioritize g:netrw_home for bookmarks and history directory setting

### DIFF
--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -4459,10 +4459,10 @@ endfunction
 
 "  s:NetrwHome: this function determines a "home" for saving bookmarks and history {{{2
 function s:NetrwHome()
-    if has('nvim')
-        let home = netrw#fs#PathJoin(stdpath('state'), 'netrw')
-    elseif exists('g:netrw_home')
+    if exists('g:netrw_home')
         let home = expand(g:netrw_home)
+    elseif has('nvim')
+        let home = netrw#fs#PathJoin(stdpath('state'), 'netrw')
     elseif exists('$MYVIMDIR')
         let home = expand('$MYVIMDIR')->substitute('/$', '', '')
     else


### PR DESCRIPTION
The documentation for `*netrw-browser-settings*` says that `g:netrw_home` defines the "home directory for where bookmarks and history are saved ...". However, in Neovim this variable is ignored because the `has('nvim')` check evaluates first, so users can't override the default path.

Since this is a Neovim-specific fix, maybe @zeertzjq can confirm if this bypass was intentional?