### PR TITLE
substitute: wrong text after undo of a confirmed replacement with "\r"

### DIFF
--- a/src/ex_cmds.c
+++ b/src/ex_cmds.c
@@ -4417,6 +4417,7 @@ ex_substitute(exarg_T *eap)
 	    int		do_again;	// do it again after joining lines
 	    int		skip_match = FALSE;
 	    linenr_T	sub_firstlnum;	// nr of first sub line
+	    bool	did_split = false;	// "\r" split the line
 #ifdef FEAT_PROP_POPUP
 	    int		apc_flags = APC_SAVE_FOR_UNDO | APC_SUBSTITUTE;
 	    colnr_T	total_added =  0;
@@ -5124,6 +5125,7 @@ ex_substitute(exarg_T *eap)
 			    ++sub_firstlnum;
 			    ++lnum;
 			    ++line2;
+			    did_split = true;
 			    // move the cursor to the new line, like Vi
 			    ++curwin->w_cursor.lnum;
 			    // copy the rest
@@ -5166,9 +5168,12 @@ skip:
 		 * match, otherwise "\@<=" won't work.
 		 * When the match starts below where we start searching also
 		 * need to replace the line first (using \zs after \n).
+		 * When asking, undo is synced at every match, so a line split
+		 * by "\r" must be replaced in the same undo block.
 		 */
 		if (lastone
 			|| nmatch_tl > 0
+			|| (subflags.do_ask && did_split)
 			|| (nmatch = vim_regexec_multi(&regmatch, curwin,
 							curbuf, sub_firstlnum,
 						    matchcol, NULL)) == 0
@@ -5247,6 +5252,7 @@ skip:
 			prev_matchcol = (colnr_T)(sub_firstline.length
 							      - prev_matchcol);
 			copycol = 0;
+			did_split = false;
 		    }
 		    if (nmatch == -1 && !lastone)
 			nmatch = vim_regexec_multi(&regmatch, curwin, curbuf,

--- a/src/testdir/test_substitute.vim
+++ b/src/testdir/test_substitute.vim
@@ -1526,4 +1526,27 @@ func Test_substitute_expr_cpo()
   delfunc XSubExpr
 endfunc
 
+" Test that undo after a confirmed substitution restores the state right
+" before the confirmed match, also when "\r" splits the line (issue #4798)
+func Test_sub_undo_after_confirm()
+  new
+  call setline(1, 'foofoo')
+  call feedkeys(":s/foo/bar\\r/gc\<CR>yy", 'xt')
+  call assert_equal(['bar', 'bar', ''], getline(1, '$'))
+  call feedkeys('u', 'xt')
+  call assert_equal(['bar', 'foo'], getline(1, '$'))
+  call feedkeys('u', 'xt')
+  call assert_equal(['foofoo'], getline(1, '$'))
+  bwipe!
+
+  " Without "\r" all the matches in one line are still undone at once.
+  new
+  call setline(1, 'aXbXcXd')
+  call feedkeys(":s/X/-/gc\<CR>yyy", 'xt')
+  call assert_equal(['a-b-c-d'], getline(1, '$'))
+  call feedkeys('u', 'xt')
+  call assert_equal(['aXbXcXd'], getline(1, '$'))
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
```
Problem:  When a substitution is confirmed with the "c" flag and the
          replacement contains "\r", undo restores the whole original line
          while the lines already produced by earlier replacements stay,
          duplicating text.
Solution: Replace the line before the next confirmation prompt, so that the
          line split and the replacement it belongs to end up in the same
          undo block.
```

fixes: #4798