### PR TITLE
terminal: mouse stays enabled after Vim is killed with SIGTERM

### DIFF
--- a/src/misc1.c
+++ b/src/misc1.c
@@ -2295,6 +2295,11 @@ prepare_to_exit(void)
     {
 	windgoto((int)Rows - 1, cmdline_col_off);
 
+	// When "full_screen" was reset, e.g. by deathtrap(), settmode() below
+	// returns without switching the mouse off, so do it here.
+	if (!full_screen)
+	    mch_setmouse(FALSE);
+
 	/*
 	 * Switch terminal mode back now, so messages end up on the "normal"
 	 * screen (if there are two screens).


### PR DESCRIPTION
```
Problem:  After Vim is killed with a deadly signal such as SIGTERM the mouse
          stays enabled in the terminal, so moving the mouse afterwards
          produces escape sequences in the shell.
Solution: Switch the mouse off when exiting after a deadly signal.  The
          terminal mode is restored with "full_screen" already reset, which
          makes settmode() return before it can do this.
```

fixes: #21090

`deathtrap()` resets `full_screen` before calling `preserve_exit()`
(os_unix.c:1193), and `settmode()` returns early when it is not set
(term.c:3987).  The `mch_setmouse(FALSE)` that lives inside `settmode()` is
therefore never reached.  `stoptermcap()` does not look at `full_screen`,
which is why the alternate screen, bracketed paste and focus reporting are
restored and only the mouse is left enabled.

The added call is guarded by `!full_screen`.  The other callers of
`preserve_exit()`, `read_error_exit()` and the MS-Windows console control
handler, leave `full_screen` set, and there `settmode()` still switches the
mouse off after reading pending terminal responses, as before.

Recorded with `script` while sending SIGTERM from another process.  Before:

    ^[[?1002h        <- no matching l
    ^[[?1006;1000h   <- no matching l
    ^[[?1049h / ^[[?1049l
    ^[[?1004h / ^[[?1004l

After the change every mode is paired again.

No test: reproducing this needs a pty plus a signal, which is hard to keep
reliable in the test suite.