### PR TITLE
patch 9.2.XXXX: heap-buffer-overflow in spell_suggest()

### DIFF
--- a/src/spellsuggest.c
+++ b/src/spellsuggest.c
@@ -484,6 +484,9 @@ spell_suggest(int count)
 	parse_spelllang(curwin);
 	curwin->w_p_spell = TRUE;
     }
+    // Autocommands, may have changed the buffer and made the cursor invalid
+    check_cursor();
+    prev_cursor = curwin->w_cursor;
 
     if (*curwin->w_s->b_p_spl == NUL)
     {

--- a/src/testdir/test_spell.vim
+++ b/src/testdir/test_spell.vim
@@ -1613,4 +1613,23 @@ func Test_spelldump_prefixtree_overflow()
   bwipe!
 endfunc
 
+" This was using the cursor position from before a SpellFileMissing
+" autocommand made the line shorter.
+func Test_spell_file_missing_z_equal()
+  new
+  call setline(1, repeat('a', 40))
+  call cursor(1, 30)
+  set spelllang=xy
+  au SpellFileMissing * call setline(1, 'ab')
+
+  " The language cannot be loaded, so z= reports E756; the invalid cursor
+  " position was used before that error reached the script level.
+  silent! norm! z=
+  call assert_equal('ab', getline(1))
+
+  au! SpellFileMissing
+  set nospell spelllang=en
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  Heap-buffer-overflow in spell_suggest() when the cursor is
          beyond the end of the line, because a SpellFileMissing
          autocommand changed the buffer (dvaave2025).
Solution: parse_spelllang() may run autocommands, so validate the cursor
          position and re-take the saved position afterwards.

fixes: #21097

Supported by AI.