### PR TITLE
Multiline messages not visible when mapping starts cmdline

### DIFF
--- a/src/message.c
+++ b/src/message.c
@@ -1287,12 +1287,10 @@ wait_return(int redraw)
 	c = CAR;		// no need for a return in ex mode
 	got_int = FALSE;
     }
-    else if (!stuff_empty() || !typebuf_typed())
-	// When there are stuffed characters or pending mapped characters, the
-	// next character will dismiss the hit-enter prompt immediately.  A
-	// stuffed character then has to be put back, while a mapped character
-	// may even be swallowed (e.g. "g" treated as a message-scrollback key),
-	// so instead just don't show the hit-enter prompt at all.
+    else if (!stuff_empty())
+	// When there are stuffed characters, the next stuffed character will
+	// dismiss the hit-enter prompt immediately and have to be put back, so
+	// instead just don't show the hit-enter prompt at all.
 	c = CAR;
     else
     {
@@ -1348,7 +1346,7 @@ wait_return(int redraw)
 		// at the hit-enter prompt.  Use CTRL-Y, because the same is
 		// used in Cmdline-mode and it's harmless when there is no
 		// selection.
-		if (c == Ctrl_Y && clip_star.state == SELECT_DONE)
+		if (KeyTyped && c == Ctrl_Y && clip_star.state == SELECT_DONE)
 		{
 		    clip_copy_modeless_selection(TRUE);
 		    c = K_IGNORE;
@@ -1361,7 +1359,7 @@ wait_return(int redraw)
 		* screen, to avoid that typing one 'j' too many makes the
 		* messages disappear.
 		*/
-		if (p_more && !p_cp)
+		if (KeyTyped && p_more && !p_cp)
 		{
 		    if (c == 'b' || c == Ctrl_B || c == 'k' || c == 'u' || c == 'g'
 						|| c == K_UP || c == K_PAGEUP)
@@ -1421,8 +1419,8 @@ wait_return(int redraw)
 	    if (c == K_LEFTMOUSE || c == K_MIDDLEMOUSE || c == K_RIGHTMOUSE
 					|| c == K_X1MOUSE || c == K_X2MOUSE)
 		(void)jump_to_mouse(MOUSE_SETPOS, NULL, 0);
-	    else if (vim_strchr((char_u *)"\r\n ", c) == NULL && c != Ctrl_C
-		    && c != 'q')
+	    else if (!KeyTyped || (vim_strchr((char_u *)"\r\n ", c) == NULL
+						   && c != Ctrl_C && c != 'q'))
 	    {
 		// Put the character back in the typeahead buffer.  Don't use
 		// the stuff buffer, because lmaps wouldn't work.

--- a/src/testdir/test_messages.vim
+++ b/src/testdir/test_messages.vim
@@ -813,28 +813,41 @@ func Test_long_formatprg_no_hit_enter()
   call StopVimInTerminal(buf)
 endfunc
 
-" A message shown while a mapping is still being processed must not raise a
-" hit-enter prompt that eats the mapping's remaining keys.
-func Test_hit_enter_no_eat_mapped_keys()
+" A message shown while a mapping is still being processed must not eat the
+" mapping's remaining keys.
+" If a mapping starts cmdline after multiline messages exceeding 'cmdheight',
+" the messages should still be visible.
+func Test_hit_enter_during_mapping()
   CheckRunVimInTerminal
 
   let lines =<< trim END
     set ruler
     call setline(1, range(1, 20))
-    " The 8-line :echo scrolls the screen and would raise a hit-enter prompt;
-    " the mapping then runs "gg" to move the cursor to line 1.
+    " The 8-line :echo leads to a hit-enter prompt.
     nnoremap X :echo "a\nb\nc\nd\ne\nf\ng\nh"<CR>gg
+    nnoremap \b :echo "a\nb\nc\nd\ne\nf\ng\nh"<CR>:b<Space>
     normal! 10G
   END
   call writefile(lines, 'XtestHitEnterMap', 'D')
   let buf = RunVimInTerminal('-S XtestHitEnterMap', #{rows: 10})
-  call WaitForAssert({-> assert_match('10,1', term_getline(buf, 10))})
+  call WaitForAssert({-> assert_match(' 10,1 ', term_getline(buf, 10))})
 
   call term_sendkeys(buf, "X")
   " Without the fix the hit-enter prompt eats the mapping's "g" keys and the
   " cursor stays put.  With the fix "gg" runs and moves the cursor to line 1.
-  call WaitForAssert({-> assert_match('1,1', term_getline(buf, 10))})
+  call WaitForAssert({-> assert_match(' 1,1 ', term_getline(buf, 10))})
   call assert_notmatch('Press ENTER', term_getline(buf, 10))
+
+  call term_sendkeys(buf, '\b')
+  call WaitForAssert({-> assert_match('^:b ', term_getline(buf, 10))})
+  call assert_match('^a *$', term_getline(buf, 2))
+  call assert_match('^b *$', term_getline(buf, 3))
+  call assert_match('^c *$', term_getline(buf, 4))
+  call assert_match('^d *$', term_getline(buf, 5))
+  call assert_match('^e *$', term_getline(buf, 6))
+  call assert_match('^f *$', term_getline(buf, 7))
+  call assert_match('^g *$', term_getline(buf, 8))
+  call assert_match('^h *$', term_getline(buf, 9))
 
   " clean up
   call StopVimInTerminal(buf)


### PR DESCRIPTION
Problem:  Multiline messages exceeding 'cmdheight' not visible when a
          mapping starts cmdline immediately after it (after 9.2.0967).
Solution: Revert patch 9.2.0967 and use a different solution.

fixes: #21098
