### PR TITLE
completion list is miss sorted after complete()

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -620,6 +620,23 @@ is_first_match(compl_T *match)
 }
 
 /*
+ * Return the entry holding the original text, NULL if not found.
+ * It is the first item, or the last one for backward completion.
+ */
+    static compl_T *
+find_original_text_match(void)
+{
+    if (compl_first_match == NULL)
+	return NULL;
+    if (match_at_original_text(compl_first_match))
+	return compl_first_match;
+    if (compl_first_match->cp_prev != NULL
+	    && match_at_original_text(compl_first_match->cp_prev))
+	return compl_first_match->cp_prev;
+    return NULL;
+}
+
+/*
  * Return TRUE when character "c" is part of the item currently being
  * completed.  Used to decide whether to abandon complete mode when the menu
  * is visible.
@@ -1709,19 +1726,22 @@ set_fuzzy_score(void)
 }
 
 /*
- * Sort completion matches, excluding the node that contains the leader.
+ * Sort completion matches, leaving the entry with the original text in place.
  */
     static void
 sort_compl_match_list(int (*compare)(const void *, const void *))
 {
-    compl_T     *compl;
+    compl_T	*orig_text;
 
     if (!compl_first_match || is_first_match(compl_first_match->cp_next))
 	return;
 
-    compl = compl_first_match->cp_prev;
+    orig_text = find_original_text_match();
+    if (orig_text == NULL)
+	return;
+
     ins_compl_make_linear();
-    if (compl_shows_dir_forward())
+    if (orig_text == compl_first_match)
     {
 	compl_first_match->cp_next->cp_prev = NULL;
 	compl_first_match->cp_next = mergesort_list(compl_first_match->cp_next,
@@ -1730,14 +1750,16 @@ sort_compl_match_list(int (*compare)(const void *, const void *))
     }
     else
     {
-	compl->cp_prev->cp_next = NULL;
+	compl_T	*tail;
+
+	orig_text->cp_prev->cp_next = NULL;
 	compl_first_match = mergesort_list(compl_first_match, cp_get_next,
 		cp_set_next, cp_get_prev, cp_set_prev, compare);
-	compl_T	*tail = compl_first_match;
+	tail = compl_first_match;
 	while (tail->cp_next != NULL)
 	    tail = tail->cp_next;
-	tail->cp_next = compl;
-	compl->cp_prev = tail;
+	tail->cp_next = orig_text;
+	orig_text->cp_prev = tail;
     }
     (void)ins_compl_make_cyclic();
 }
@@ -2828,30 +2850,20 @@ ins_compl_restart(void)
     static void
 ins_compl_set_original_text(char_u *str, size_t len)
 {
+    compl_T	*match = find_original_text_match();
+    char_u	*p;
+
     // Replace the original text entry.
-    // The CP_ORIGINAL_TEXT flag is either at the first item or might possibly
-    // be at the last item for backward completion
-    if (match_at_original_text(compl_first_match))	// safety check
-    {
-	char_u	*p = vim_strnsave(str, len);
-	if (p != NULL)
-	{
-	    VIM_CLEAR_STRING(compl_first_match->cp_str);
-	    compl_first_match->cp_str.string = p;
-	    compl_first_match->cp_str.length = len;
-	}
-    }
-    else if (compl_first_match->cp_prev != NULL
-	    && match_at_original_text(compl_first_match->cp_prev))
-    {
-	char_u *p = vim_strnsave(str, len);
-	if (p != NULL)
-	{
-	    VIM_CLEAR_STRING(compl_first_match->cp_prev->cp_str);
-	    compl_first_match->cp_prev->cp_str.string = p;
-	    compl_first_match->cp_prev->cp_str.length = len;
-	}
-    }
+    if (match == NULL)
+	return;
+
+    p = vim_strnsave(str, len);
+    if (p == NULL)
+	return;
+
+    VIM_CLEAR_STRING(match->cp_str);
+    match->cp_str.string = p;
+    match->cp_str.length = len;
 }
 
 /*

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -6756,4 +6756,21 @@ func Test_complete_info_hlgroup()
   bwipe!
 endfunc
 
+func Test_complete_fuzzy_resort()
+  new
+  set completeopt=menu,menuone,noselect,fuzzy
+
+  inoremap <buffer> <F5> <Cmd>call complete(1, ['xxxb', 'xb', 'b'])<CR>
+  call feedkeys("i\<F5>b\<C-R>=string(map(complete_info(['items']).items, 'v:val.word'))\<CR>\<Esc>", 'tx')
+  call assert_equal("b['b', 'xb', 'xxxb']", getline(1))
+
+  %d _
+  call setline(1, ['xxxbar', 'xbar', 'bar'])
+  call feedkeys("Go\<C-P>b\<C-R>=string(map(complete_info(['items']).items, 'v:val.word'))\<CR>\<Esc>", 'tx')
+  call assert_equal("b['bar', 'xbar', 'xxxbar']", getline('$'))
+
+  bwipe!
+  set completeopt&
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab nofoldenable


### PR DESCRIPTION
Problem:  With 'completeopt' "fuzzy", a resort after complete() leaves the
          last match unsorted at the end of the list.
Solution: Find the original text by its flag instead of assuming
          compl_shows_dir points at it.