### PR TITLE
runtime(odin): improve float number syntax

### DIFF
--- a/runtime/syntax/odin.vim
+++ b/runtime/syntax/odin.vim
@@ -4,7 +4,7 @@ vim9script
 # Language: Odin
 # Maintainer: Maxim Kim <habamax@gmail.com>
 # Website: https://github.com/habamax/vim-odin
-# Last Change: 2026 Aug 16
+# Last Change: 2026 Aug 21
 
 if exists("b:current_syntax")
   finish
@@ -63,10 +63,11 @@ syntax region odinAttributeBraces
       \ transparent oneline
       \ contained
 
-syntax match odinInteger "\v-?<[0-9]+%(_[0-9]+)*>" display
-syntax match odinFloat "\v-?<[0-9]+%(_[0-9]+)*%(\.[0-9]+%(_[0-9]+)*)%([eE][+-]=[0-9]+%(_[0-9]+)*)=" display
+syntax match odinInteger "\v<[0-9]+%(_[0-9]+)*>" display
+syntax match odinFloat "\v<[0-9]+%(_[0-9]+)*%(\.[0-9]+%(_[0-9]+)*)%([eE][+-]=[0-9]+%(_[0-9]+)*)=" display
+syntax match odinFloat "\v<[0-9]+%(_[0-9]+)*[eE][+-]?[0-9]+%(_[0-9]+)*" display
 syntax match odinHex "\v<0[xX][0-9A-Fa-f]+%(_[0-9A-Fa-f]+)*>" display
-syntax match odinDoz "\v<0[zZ][0-9A-Ba-b]+%(_[0-9A-Ba-b]+)*>" display
+syntax match odinHexFloat "\v<0[hH][0-9A-Fa-f]+%(_[0-9A-Fa-f]+)*>" display
 syntax match odinOct "\v<0[oO][0-7]+%(_[0-7]+)*>" display
 syntax match odinBin "\v<0[bB][01]+%(_[01]+)*>" display
 
@@ -107,10 +108,10 @@ highlight def link odinBool Boolean
 highlight def link odinNull Constant
 highlight def link odinUninitialized Constant
 highlight def link odinFloat Float
+highlight def link odinHexFloat odinFloat
 highlight def link odinInteger Number
 highlight def link odinHex Number
 highlight def link odinOct Number
 highlight def link odinBin Number
-highlight def link odinDoz Number
 
 b:current_syntax = "odin"


### PR DESCRIPTION
- highlight exp numbers without decimal point, e.g. 12e-5
- highlight hex floats, e.g. 0hff3a001f
- remove non-existent 0z number literals
- do not highlight unary minus as a part of a number
