### PR TITLE
runtime(syntax): nested pov comments break highlighting

### DIFF
--- a/runtime/syntax/pov.vim
+++ b/runtime/syntax/pov.vim
@@ -70,10 +70,10 @@ syn match povConsts "\<[tuvxyz]\>"
 syn match povDotItem "\.\@<=\(blue\|green\|gray\|filter\|red\|transmit\|hf\|t\|u\|v\|x\|y\|z\)\>" display
 
 " Comments
-syn region povComment start="/\*" end="\*/" contains=povTodo,povComment
-syn match povComment "//.*" contains=povTodo
+syn region povBlockComment start="/\*" end="\*/" contains=povTodo,povBlockComment
+syn match povLineComment "//.*" contains=povTodo
 syn match povCommentError "\*/"
-syn sync ccomment povComment
+syn sync ccomment povBlockComment
 syn sync minlines=50
 syn keyword povTodo TODO FIXME XXX NOT contained
 syn cluster povPRIVATE add=povTodo
@@ -105,7 +105,8 @@ syn match povBraceError "}"
 syn match povNumber "\(^\|\W\)\@<=[+-]\=\(\d\+\)\=\.\=\d\+\([eE][+-]\=\d\+\)\="
 
 " Define the default highlighting
-hi def link povComment Comment
+hi def link povBlockComment Comment
+hi def link povLineComment Comment
 hi def link povTodo Todo
 hi def link povNumber Number
 hi def link povString String


### PR DESCRIPTION
A line comment nested in a block comment (the comment plugin uses a block comment on every line) breaks syntax highlighting and shades the rest of the file as a comment.

POV-Ray Scene Description Language (in Vim, ft=pov) allows two comment styles:

- `\\ line comment`
- `\* block comment *\`

The Vim internal comment plugin uses a block comment on every line. The syntax file previously interpreted ...

`\* block comment \\ nested line comment *\`

... as a comment without an ending, leaving the rest of the file highlighted as one long comment string.

before patch:
<img width="430" height="64" alt="pov_snytax_before" src="https://github.com/user-attachments/assets/2c6a5884-ff17-40fc-a695-f4fdfa39572f" />

after patch:
<img width="433" height="65" alt="pov_snytax_after" src="https://github.com/user-attachments/assets/c3674568-23af-4ce1-8ff4-9aef6425eed6" />
