### PR TITLE
Fix CursorLineFold/CursorLineSign docs for 'cursorlineopt'

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3024,7 +3024,10 @@ A jump table for the options with a short description can be found at |Q_op|.
 	"screenline"	Highlight only the screen line of the cursor with
 			CursorLine |hl-CursorLine|.
 	"number"	Highlight the line number of the cursor with
-			CursorLineNr |hl-CursorLineNr|.
+			CursorLineNr |hl-CursorLineNr|. Also highlight
+			the fold and sign columns with CursorLineFold
+			|hl-CursorLineFold| and CursorLineSign
+			|hl-CursorLineSign|.
 
 	Special value:
 	"both"		Alias for the values "line,number".

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1,4 +1,4 @@
-*options.txt*	For Vim version 9.2.  Last change: 2026 Aug 20
+*options.txt*	For Vim version 9.2.  Last change: 2026 Sep 07
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -3024,10 +3024,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	"screenline"	Highlight only the screen line of the cursor with
 			CursorLine |hl-CursorLine|.
 	"number"	Highlight the line number of the cursor with
-			CursorLineNr |hl-CursorLineNr|. Also highlight
-			the fold and sign columns with CursorLineFold
-			|hl-CursorLineFold| and CursorLineSign
-			|hl-CursorLineSign|.
+			CursorLineNr |hl-CursorLineNr|.
 
 	Special value:
 	"both"		Alias for the values "line,number".

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -6030,9 +6030,11 @@ LineNrBelow	Line number for when the 'relativenumber'
 CursorLineNr	Like LineNr when 'cursorline' is set and 'cursorlineopt'
 		contains "number" or is "both", for the cursor line.
 							*hl-CursorLineFold*
-CursorLineFold	Like FoldColumn when 'cursorline' is set for the cursor line.
+CursorLineFold	Like FoldColumn when 'cursorline' is set and 'cursorlineopt'
+		contains "number" or is "both", for the cursor line.
 							*hl-CursorLineSign*
-CursorLineSign	Like SignColumn when 'cursorline' is set for the cursor line.
+CursorLineSign	Like SignColumn when 'cursorline' is set and 'cursorlineopt'
+		contains "number" or is "both", for the cursor line.
 							*hl-MatchParen*
 MatchParen	Character under the cursor or just before it, if it
 		is a paired bracket, and its match. |pi_paren.txt|

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1,4 +1,4 @@
-*syntax.txt*	For Vim version 9.2.  Last change: 2026 Aug 13
+*syntax.txt*	For Vim version 9.2.  Last change: 2026 Sep 07
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -6030,11 +6030,9 @@ LineNrBelow	Line number for when the 'relativenumber'
 CursorLineNr	Like LineNr when 'cursorline' is set and 'cursorlineopt'
 		contains "number" or is "both", for the cursor line.
 							*hl-CursorLineFold*
-CursorLineFold	Like FoldColumn when 'cursorline' is set and 'cursorlineopt'
-		contains "number" or is "both", for the cursor line.
+CursorLineFold	Like FoldColumn when 'cursorline' is set for the cursor line.
 							*hl-CursorLineSign*
-CursorLineSign	Like SignColumn when 'cursorline' is set and 'cursorlineopt'
-		contains "number" or is "both", for the cursor line.
+CursorLineSign	Like SignColumn when 'cursorline' is set for the cursor line.
 							*hl-MatchParen*
 MatchParen	Character under the cursor or just before it, if it
 		is a paired bracket, and its match. |pi_paren.txt|

--- a/src/drawline.c
+++ b/src/drawline.c
@@ -223,14 +223,14 @@ typedef struct {
 
 #if defined(FEAT_SIGNS) || defined(FEAT_FOLDING)
 /*
- * Return TRUE if CursorLineSign highlight is to be used.
+ * Return TRUE if CursorLineSign / CursorLineFold highlight is to be used.
+ * This depends only on 'cursorline', not on 'cursorlineopt'.
  */
     static int
 use_cursor_line_highlight(win_T *wp, linenr_T lnum)
 {
     return wp->w_p_cul
-	    && lnum == wp->w_cursor.lnum
-	    && (wp->w_p_culopt_flags & CULOPT_NBR);
+	    && lnum == wp->w_cursor.lnum;
 }
 #endif
 

--- a/src/testdir/test_cursorline.vim
+++ b/src/testdir/test_cursorline.vim
@@ -106,6 +106,56 @@ func Test_cursorline_highlight2()
   endtry
 endfunc
 
+func Test_cursorline_fold_sign_independent_of_culopt()
+  " CursorLineFold/CursorLineSign follow 'cursorline', not 'cursorlineopt'.
+  CheckOption cursorlineopt
+  CheckFeature signs
+  CheckFeature folding
+
+  call s:test_windows(10, 20)
+  try
+    call setline(1, repeat(['aaaa'], 5))
+    setl number numberwidth=4 signcolumn=yes foldcolumn=1
+    hi FoldColumn ctermbg=1 guibg=Red
+    hi CursorLineFold ctermbg=2 guibg=Green
+    hi SignColumn ctermbg=3 guibg=Yellow
+    hi CursorLineSign ctermbg=4 guibg=Blue
+
+    setl nocursorline
+    redraw
+    let fold_off = screenattr(1, 1)
+    let sign_off = screenattr(1, 2)
+
+    " 'cursorlineopt' is "line" only: fold/sign on the cursor line still
+    " use CursorLineFold / CursorLineSign.
+    setl cursorline cursorlineopt=line
+    redraw
+    call assert_notequal(fold_off, screenattr(1, 1))
+    call assert_notequal(sign_off, screenattr(1, 2))
+    call assert_equal(fold_off, screenattr(2, 1))
+    call assert_equal(sign_off, screenattr(2, 2))
+
+    setl cursorlineopt=number
+    redraw
+    call assert_notequal(fold_off, screenattr(1, 1))
+    call assert_notequal(sign_off, screenattr(1, 2))
+
+    setl cursorlineopt=both
+    redraw
+    call assert_notequal(fold_off, screenattr(1, 1))
+    call assert_notequal(sign_off, screenattr(1, 2))
+  finally
+    setl number& numberwidth& signcolumn& foldcolumn& cursorline& cursorlineopt&
+    hi clear FoldColumn
+    hi clear CursorLineFold
+    hi clear SignColumn
+    hi clear CursorLineSign
+    hi default link CursorLineFold FoldColumn
+    hi default link CursorLineSign SignColumn
+    call s:close_windows()
+  endtry
+endfunc
+
 func Test_cursorline_screenline()
   CheckScreendump
   CheckOption cursorlineopt


### PR DESCRIPTION
- Document that CursorLineFold and CursorLineSign only apply when 'cursorlineopt' contains "number" or is "both", matching existing behavior and CursorLineNr.
- Mention fold/sign in the 'cursorlineopt' "number" description.
Fixes #20480
