### PR TITLE
runtime(netrw): fix error when parent dir of g:netrw_home doesn't exist

### DIFF
--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -1,7 +1,7 @@
 " Creator:    Charles E Campbell
 " Previous Maintainer: Luca Saccarola <github.e41mv@aleeas.com>
 " Maintainer: This runtime file is looking for a new maintainer.
-" Last Change: 2026 Aug 19
+" Last Change: 2026 Aug 21
 " Copyright:  Copyright (C) 2016 Charles E. Campbell {{{1
 "             Permission is hereby granted to use and distribute this code,
 "             with or without modifications, provided that this copyright
@@ -4485,7 +4485,7 @@ function s:NetrwHome()
         if exists("g:netrw_mkdir")
             call system(g:netrw_mkdir." ".s:ShellEscape(s:NetrwFile(home)))
         else
-            call mkdir(home)
+            call mkdir(home, 'p')
         endif
     endif
 

--- a/src/testdir/test_plugin_netrw.vim
+++ b/src/testdir/test_plugin_netrw.vim
@@ -919,9 +919,11 @@ endfunc
 
 func Test_netrw_home_setting()
   let save_home = get(g:, 'netrw_home', '')
-  let dir = fnamemodify('XnetrwHome', ':p:h')
+  let dir = fnamemodify('XnetrwHome', ':p')
+  let subdir = fnamemodify('XnetrwHomeParent/XnetrwHome', ':p')
   if has('win32')
     let dir = substitute(dir, '/', '\\', 'g')
+    let subdir = substitute(subdir, '/', '\\', 'g')
   endif
  
   if has('nvim')
@@ -932,6 +934,10 @@ func Test_netrw_home_setting()
   let g:netrw_home = dir
   call assert_equal(dir, Test_NetrwHome())
   call assert_true(isdirectory(dir))
+
+  let g:netrw_home = subdir
+  call assert_equal(subdir, Test_NetrwHome())
+  call assert_true(isdirectory(subdir))
 
   " the value is expanded
   let $NETRW_TEST_HOME = dir
@@ -944,6 +950,8 @@ func Test_netrw_home_setting()
   call assert_equal(dir, Test_NetrwHome())
 
   call delete(dir, 'd')
+  call delete(subdir, 'd')
+  call delete(fnamemodify(subdir, ':h'), 'd')
   let $NETRW_TEST_HOME = ''
   if empty(save_home)
     unlet! g:netrw_home


### PR DESCRIPTION
Problem:  netrw: error when parent dir of g:netrw_home doesn't exist.
Solution: Use 'p' flag of mkdir().
