### PR TITLE
runtime(doc): a server request with a String id cannot be answered

### DIFF
--- a/runtime/doc/channel.txt
+++ b/runtime/doc/channel.txt
@@ -1639,6 +1639,10 @@ from the server request message.  Example: >
     let resp.result = 1
     call ch_sendexpr(ch, resp)
 
+A request whose "id" is a String cannot be answered this way.  The request is
+delivered with the "id" the server sent, but |ch_sendexpr()| takes only a
+Number there, so copying it fails.
+
 The JSON-RPC notification messages from the server are delivered through the
 |channel-callback| function.
 


### PR DESCRIPTION
The LSP section tells the reader to copy the "id" from a server request into the response, but ch_sendexpr() takes only a Number there while the request itself arrives with whatever the server sent.  Say so where the response is described; the note further up that only a Number is supported does not cover the case, as it reads as being about requests Vim sends.