### PR TITLE
GUI(fix): preserve blink cycle on CursorHold

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -3186,7 +3186,7 @@ gui_wait_for_chars_buf(
     retval = inchar_loop(buf, maxlen, wtime, tb_change_cnt,
 			 gui_wait_for_chars_or_timer, NULL);
 
-    // Keep blinking when CursorHold wakes the input loop.
+    // Keep blinking when CursorHold wakes the input loop. (See PR #21115)
     keep_blinking = retval == 3 && buf != NULL
 	&& buf[0] == K_SPECIAL && buf[1] == KS_EXTRA
 	&& buf[2] == (int)KE_CURSORHOLD;

--- a/src/gui.c
+++ b/src/gui.c
@@ -3153,6 +3153,7 @@ gui_wait_for_chars_buf(
     int		tb_change_cnt)
 {
     int	    retval;
+    int	    keep_blinking; // Guard against restarting blink cycle on CursorHold
 
 #ifdef FEAT_MENU
     // If we're going to wait a bit, update the menus and mouse shape for the
@@ -3164,6 +3165,8 @@ gui_wait_for_chars_buf(
     gui_mch_update();
     if (input_available())	// Got char, return immediately
     {
+	if (gui_mch_is_blinking())
+	    gui_mch_stop_blink(TRUE);
 	if (buf != NULL && !typebuf_changed(tb_change_cnt))
 	    return read_from_input_buf(buf, (long)maxlen);
 	return 0;
@@ -3175,14 +3178,21 @@ gui_wait_for_chars_buf(
     gui_mch_flush();
 
     // Blink while waiting for a character.
-    gui_mch_start_blink();
+    if (!gui_mch_is_blinking())
+	gui_mch_start_blink();
 
     // Common function to loop until "wtime" is met, while handling timers and
     // other callbacks.
     retval = inchar_loop(buf, maxlen, wtime, tb_change_cnt,
 			 gui_wait_for_chars_or_timer, NULL);
 
-    gui_mch_stop_blink(TRUE);
+    // Keep blinking when CursorHold wakes the input loop.
+    keep_blinking = retval == 3 && buf != NULL
+	&& buf[0] == K_SPECIAL && buf[1] == KS_EXTRA
+	&& buf[2] == (int)KE_CURSORHOLD;
+
+    if (!keep_blinking)
+	gui_mch_stop_blink(TRUE);
 
     return retval;
 }


### PR DESCRIPTION
```vim
:set guicursor=a:blinkwait100-blinkon300-blinkoff300
:autocmd CursorHold * echo ''
:set updatetime=1000
```
press any key like "pgup" or "pgdn" after setting you will see the blinking stops, then resumes - right after it resumes the hiccup happens; exactly 1s (updatetime=1000) later.

The underlying problem seems that gui.c /^gui_wait_for_chars( stops and restarts blinking whenever the input loop returns, assuming that means actual user input occurred.

CursorHold is thus cause of the hiccup as it wakes the input loop. So the existing guards were not proper, the blink timer was still cancelled and restarted even though the user remained idle.

I looked briefly into if there was accidental "workarounds" in other gui's, these are my findings:

**Verified affected:**
✅ GTK3,4

**Verified unaffected:**
❌ Motif/X11
❌ Win32: uses native win32 API (SetTimer(), KillTimer())

**Unverified:**
* Photon(QNX)
* Haiku (*gui blink seems not fully implemented*)

Mailing-list: https://groups.google.com/g/vim_dev/c/lmGzT9gftvs/m/kzeEG77fDgAJ

Credit https://github.com/tonymec for reporting the issue.
