### PR TITLE
Reject non-string-literal arguments to STRLEN_LITERAL

### DIFF
--- a/src/ascii.h
+++ b/src/ascii.h
@@ -87,6 +87,6 @@
 # define PATHSEP	psepc
 # define PATHSEPSTR	pseps
 #else
-# define PATHSEP	'/'
+# define PATHSEP	((char_u)'/')
 # define PATHSEPSTR	"/"
 #endif

--- a/src/cmdexpand.c
+++ b/src/cmdexpand.c
@@ -4135,7 +4135,7 @@ expand_shellcmd(
 		// Do not match directories inside a $PATH item.
 		flags &= ~EW_DIR;
 
-	    seplen = !after_pathsep(s, e) ? STRLEN_LITERAL(PATHSEPSTR) : 0;
+	    seplen = !after_pathsep(s, e) ? sizeof(PATHSEP) : 0;
 	}
 
 	// Make sure that the pathed pattern (ie the path and pattern concatenated

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -5424,7 +5424,7 @@ vim_settempdir(char_u *tempdir)
     if (!after_pathsep(buf, buf + buflen))
     {
 	STRCPY(buf + buflen, PATHSEPSTR);
-	buflen += STRLEN_LITERAL(PATHSEPSTR);
+	buflen += sizeof(PATHSEP);
     }
     vim_tempdir = vim_strnsave(buf, buflen);
 # if defined(UNIX) && defined(HAVE_FLOCK) && defined(HAVE_DIRFD)
@@ -5501,7 +5501,7 @@ vim_tempname(
 		if (!after_pathsep(itmp, itmp + itmplen))
 		{
 		    STRCPY(itmp + itmplen, PATHSEPSTR);
-		    itmplen += STRLEN_LITERAL(PATHSEPSTR);
+		    itmplen += sizeof(PATHSEP);
 		}
 
 # ifdef HAVE_MKDTEMP

--- a/src/filepath.c
+++ b/src/filepath.c
@@ -3200,7 +3200,7 @@ vim_fnamencmp(char_u *x, char_u *y, size_t len)
     char_u  *
 concat_fnames(char_u *fname1, size_t fname1len, char_u *fname2, size_t fname2len, int sep, string_T *ret)
 {
-    ret->string = alloc(fname1len + (sep ? STRLEN_LITERAL(PATHSEPSTR) : 0) + fname2len + 1);
+    ret->string = alloc(fname1len + (sep ? sizeof(PATHSEP) : 0) + fname2len + 1);
     if (ret->string == NULL)
 	ret->length = 0;
     else
@@ -3210,7 +3210,7 @@ concat_fnames(char_u *fname1, size_t fname1len, char_u *fname2, size_t fname2len
 	if (sep && *ret->string != NUL && !after_pathsep(ret->string, ret->string + ret->length))
 	{
 	    STRCPY(ret->string + ret->length, PATHSEPSTR);
-	    ret->length += STRLEN_LITERAL(PATHSEPSTR);
+	    ret->length += sizeof(PATHSEP);
 	}
 	STRCPY(ret->string + ret->length, fname2);
 	ret->length += fname2len;

--- a/src/findfile.c
+++ b/src/findfile.c
@@ -2678,7 +2678,7 @@ uniquefy_paths(
 	    continue;
 	}
 
-	rel_pathsize = 1 + STRLEN_LITERAL(PATHSEPSTR) + STRLEN(short_name) + 1;
+	rel_pathsize = 1 + sizeof(PATHSEP) + STRLEN(short_name) + 1;
 	rel_path = alloc(rel_pathsize);
 	if (rel_path == NULL)
 	    goto theend;

--- a/src/help.c
+++ b/src/help.c
@@ -795,7 +795,7 @@ fix_help_buffer(void)
 		    if (*NameBuff != NUL && !after_pathsep(NameBuff, NameBuff + NameBufflen))
 		    {
 			STRCPY(NameBuff + NameBufflen, PATHSEPSTR);
-			NameBufflen += STRLEN_LITERAL(PATHSEPSTR);
+			NameBufflen += sizeof(PATHSEP);
 		    }
 #ifdef FEAT_MULTI_LANG
 		    STRCPY(NameBuff + NameBufflen, "doc/*.??[tx]");

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -2824,7 +2824,7 @@ mch_FullName(
 						   && STRCMP(fname, ".") != 0)
 	{
 	    STRCPY(buf + buflen, PATHSEPSTR);
-	    buflen += STRLEN_LITERAL(PATHSEPSTR);
+	    buflen += sizeof(PATHSEP);
 	}
 #endif
     }

--- a/src/scriptfile.c
+++ b/src/scriptfile.c
@@ -667,7 +667,7 @@ do_in_path(
 		    && !after_pathsep(buf.string, buf.string + buf.length))
 		{
 		    STRCPY(buf.string + buf.length, PATHSEPSTR);
-		    buf.length += STRLEN_LITERAL(PATHSEPSTR);
+		    buf.length += sizeof(PATHSEP);
 		}
 		STRCPY(buf.string + buf.length, prefix);
 		buf.length += prefixlen;

--- a/src/structs.h
+++ b/src/structs.h
@@ -5475,8 +5475,7 @@ typedef struct {
 // Return the length of a string literal.
 // This macro only computes a string's length for a string-literal token; for
 // anything else, including a char*, compilation will fail (note "" following
-// s) instead of the macro expanding to an expression that doesn't determine a
-// string's length.
+// s).
 #define STRLEN_LITERAL(s) (sizeof(s "") - 1)
 
 // Store a key/value (string) pair

--- a/src/structs.h
+++ b/src/structs.h
@@ -5472,8 +5472,12 @@ typedef struct {
 #endif
 } spellvars_T;
 
-// Return the length of a string literal
-#define STRLEN_LITERAL(s) (sizeof(s) - 1)
+// Return the length of a string literal.
+// This macro only computes a string's length for a string-literal token; for
+// anything else, including a char*, compilation will fail (note "" following
+// s) instead of the macro expanding to an expression that doesn't determine a
+// string's length.
+#define STRLEN_LITERAL(s) (sizeof(s "") - 1)
 
 // Store a key/value (string) pair
 typedef struct


### PR DESCRIPTION
**Problem:**  STRLEN_LITERAL silently expands to an expression that doesn't
	  determine a string's length if it's given a non-string-literal
	  token.
**Solution:** Modify STRLEN_LITERAL so that a non-string-literal argument
	  produces a compile error.

_Regarding character arrays:_

A compilation error will now be generated for the following:
	`char s[64] = "12345";`
	`int l = STRLEN_LITERAL(s);  // previously l was assigned 63 (not 5).`
Had `s` been defined as:
	`char s[] = "12345";`
the original definition of STRLEN_LITERAL would have correctly
determined the string length to be 5; however, the macro cannot
distinguish a padded array like the first from an exactly-sized one like
the second, so both are rejected.

_Regarding PATHSEPSTR:_

On MS-Windows, PATHSEPSTR does not expand to a string-literal token, so
STRLEN_LITERAL(PATHSEPSTR) fails to compile. Each
STRLEN_LITERAL(PATHSEPSTR) is replaced with sizeof(PATHSEP).
sizeof(PATHSEP) is now always 1; previously it was 1 (sizeof(char_u)) on
MS-Windows but sizeof(int) elsewhere. (PATHSEP is a single character;
PATHSEPSTR is a null-terminated string with a single content byte
followed by NUL.)

Supported by AI (Claude Sonnet 5).
