### PR TITLE
Documentation updates

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -8798,7 +8798,7 @@ readdir({directory} [, {expr} [, {dict}]])		*readdir()*
 		Each time {expr} is evaluated |v:val| is set to the entry name.
 		When {expr} is a function the name is passed as the argument.
 		For example, to get a list of files ending in ".txt": >
-		  readdir(dirname, {n -> n =~ '.txt$'})
+		  readdir(dirname, {n -> n =~ '\.txt$'})
 <		To skip hidden and backup files: >
 		  readdir(dirname, {n -> n !~ '^\.\|\~$'})
 <								*E857*

--- a/runtime/doc/usr_51.txt
+++ b/runtime/doc/usr_51.txt
@@ -346,8 +346,8 @@ Here is the resulting complete example: >
  26	noremap <SID>Add  :call <SID>Add(expand("<cword>"), true)<CR>
  27
  28	def Add(from: string, correct: bool)
- 29	  var to = input("type the correction for " .. from .. ": ")
- 30	  exe ":iabbrev " .. from .. " " .. to
+ 29	  var to = input($"type the correction for {from}: ")
+ 30	  exe $":iabbrev {from} {to}"
  31	  if correct | exe "normal viws\<C-R>\" \b\e" | endif
  32	  count += 1
  33	  echo "you now have " .. count .. " corrections"


### PR DESCRIPTION
While reading the documentation, I found a couple of small errors fixed here:
The first commit takes care of a missing escape sequence in an example of `readdir()`.
The second commit makes the final example plugin in `:help write-plugin` match the snippets provided during the tutorial.