### PR TITLE
serverlist() fails when there is no connection to the X server

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -9929,7 +9929,8 @@ server2client({clientid}, {string})			*server2client()*
 serverlist([{dict}])					*serverlist()*
 		Return a list of available server names, one per line.
 		When there are no servers or the information is not available
-		an empty string is returned.
+		an empty string is returned, or an empty |List| when the
+		"list" option below is used.
 		{only available when compiled with the |+clientserver| feature}
 
 		If {dict} is given, then it is a |Dictionary| supporting the

--- a/src/clientserver.c
+++ b/src/clientserver.c
@@ -1284,18 +1284,19 @@ f_serverlist(typval_T *argvars UNUSED, typval_T *rettv)
 #  ifdef FEAT_X11
     if (clientserver_method == CLIENTSERVER_METHOD_X11)
     {
-	// This function fails if there is no X11 connection.
-	if (check_connection() == FAIL)
-	    return;
-	// If the check_connection() function returns OK, it has already been
-	// confirmed within that function that make_connection() was called and
-	// that X_DISPLAY is not NULL.
-	list = serverGetVimNames(X_DISPLAY);
+	make_connection();
+	if (X_DISPLAY != NULL)
+	    list = serverGetVimNames(X_DISPLAY);
     }
 #  endif
 # endif
-    if (use_list && list != NULL)
+    if (use_list)
     {
+	if (list == NULL)
+	{
+	    rettv_list_alloc(rettv);
+	    return;
+	}
 	list->lv_refcount++;
 	rettv->v_type = VAR_LIST;
 	rettv->vval.v_list = list;

--- a/src/testdir/test_clientserver.vim
+++ b/src/testdir/test_clientserver.vim
@@ -708,20 +708,24 @@ func Test_clientserver_serverlist_without_x11()
     throw 'GetVimCommand() failed'
   endif
 
-  " This test verifies that serverlist() fails with error E240 when a
+  " This test verifies that serverlist() returns an empty result when a
   " connection to X11 cannot be established. It must be executed with the
   " CLIENTSERVER backend set to x11 and in a state where the X11 server is
   " unreachable.
   "
   " To achieve this, the `VIM_CLIENTSERVER` and `DISPLAY` environment
-  " variables must be unset before running Vim as a child process. Within the
-  " child process, `assert_fails()` and `v:errors` are used to confirm that
-  " E240 occurred; if E240 is raised as expected, `v:errors` remains empty,
-  " whereas if the call succeeds or a different error occurs, `v:errors` will
-  " contain one or more errors.
+  " variables must be unset before running Vim as a child process. The child
+  " process reports the number of `v:errors` as its exit code. The calls are
+  " wrapped in a try/catch, because an error would otherwise skip the
+  " assertion without adding anything to `v:errors`.
 
   call writefile([
-        \ "call assert_fails('let x = serverlist()', 'E240:')",
+        \ "try",
+        \ "  call assert_equal('', serverlist())",
+        \ "  call assert_equal([], serverlist(#{list: v:true}))",
+        \ "catch",
+        \ "  call add(v:errors, 'unexpected exception: ' .. v:exception)",
+        \ "endtry",
         \ "execute 'cq! ' .. len(v:errors)"
         \ ], 'Xtest', 'D')
 

--- a/src/testdir/test_vim9_builtin.vim
+++ b/src/testdir/test_vim9_builtin.vim
@@ -3631,14 +3631,10 @@ def Test_remote_serverlist()
 
   v9.CheckSourceDefAndScriptFailure(['serverlist("")'], ['E1013: Argument 1: type mismatch, expected dict<any> but got string', 'E1206: Dictionary required for argument 1'])
   v9.CheckSourceScriptFailure(['vim9script', 'serverlist({list: ""})'], 'E1135: Using a String as a Bool: ""')
-  try
-    var l: any = serverlist()
-    assert_equal(v:t_string, type(l))
-    l = serverlist({'list': true})
-    assert_equal(v:t_list, type(l))
-  catch /E240:/
-    # ignore no connection to the X server
-  endtry
+  var l: any = serverlist()
+  assert_equal(v:t_string, type(l))
+  l = serverlist({'list': true})
+  assert_equal(v:t_list, type(l))
 enddef
 
 def Test_remove_literal_list()


### PR DESCRIPTION
## Problem

Since patch 9.2.0818 (#20716), `serverlist()` gives `E240: No connection to the X server` when the X11 clientserver backend cannot connect to the X server — for example on a Wayland-only system or with `$DISPLAY` unset. Before that patch it returned an empty result.

## Why this is a regression

- **It contradicts the documentation.** `:help serverlist()` says *"When there are no servers or the information is not available an empty string is returned"*, and 9.2.0818 did not update it.
- **The error was deliberately removed before.** Patch 6.0.191: *"When no servers are available serverlist() gives an error instead of returning an empty string"* → *"Don't give an error message"*. Patch 6.1.349 did the same for `--serverlist` when the display cannot be opened.
- **Entry points and backends now disagree.** In exactly the situation where the function fails, the `--serverlist` command line argument still prints an empty list, and the socket backend still returns an empty list.
- **The return type is broken on the failing path.** `rettv` is never set, so the result is a Number rather than a String or a List:
  ```vim
  silent! let r = serverlist()
  echo type(r)   " 0 (Number), r == 0
  ```

## Solution

Do not give an error when the X server cannot be reached; return an empty string, or an empty `List` when the `"list"` option is used.

The `"list"` option now always results in a `List` when no server names are available. That is the type inconsistency 9.2.0818 set out to fix — `serverlist({'list': 1})` returning a String — and it is fixed for every backend, including a build without `+clientserver`.

## Tests

`Test_clientserver_serverlist_without_x11()` now checks that a child Vim without `$DISPLAY` returns `''` from `serverlist()` and `[]` from `serverlist(#{list: v:true})`. It fails before the fix and passes after it:

```
# before
Found errors in Test_clientserver_serverlist_without_x11():
... line 36: Expected 0 but got 1
# after
Executed 1 test
```

The child process wraps the calls in a try/catch because an error in a sourced script only aborts the failing command: without it the assertion is never reached, `v:errors` stays empty and the test passes even when `serverlist()` fails (verified: exit code 0).

The `catch /E240:/` workaround that 9.2.0818 added to `Test_remote_serverlist()` in `test_vim9_builtin.vim` is no longer needed and is removed, so that test checks the return types again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
