### PR TITLE
runtime(css): Update ftplugin, disable auto-commenting

### DIFF
--- a/runtime/ftplugin/css.vim
+++ b/runtime/ftplugin/css.vim
@@ -2,25 +2,22 @@
 " Language:		CSS
 " Maintainer:		Doug Kearns <dougkearns@gmail.com>
 " Previous Maintainer:	Nikolai Weibull <now@bitwi.se>
-" Last Change:		2020 Dec 21
-"			2024 Jun 02 by Riley Bruins <ribru17@gmail.com> ('commentstring')
+" Contributors:		Riley Bruins <ribru17@gmail.com> ('commentstring')
+" Last Change:		2026 Aug 22
 
 if exists("b:did_ftplugin")
   finish
 endif
 let b:did_ftplugin = 1
 
-let s:cpo_save = &cpo
-set cpo&vim
-
 let b:undo_ftplugin = "setl com< cms< inc< fo< ofu< isk<"
 
 setlocal comments=s1:/*,mb:*,ex:*/ commentstring=/*\ %s\ */
-setlocal formatoptions-=t formatoptions+=croql
+" exclude "ro" - CSS universal selector "*" cannot be distinguished from
+" 'comments' middle "*" pattern
+setlocal formatoptions-=rot formatoptions+=cql
 setlocal omnifunc=csscomplete#CompleteCSS
 setlocal iskeyword+=-
 
 let &l:include = '^\s*@import\s\+\%(url(\)\='
 
-let &cpo = s:cpo_save
-unlet s:cpo_save


### PR DESCRIPTION
Remove "ro" from 'formatoptions'.

The universal selector "\*" cannot be disambiguated from the 'comments'
middle "\*" pattern, causing spurious "\*" characters to be inserted after
selector lines.

Fixes #15140.

