### PR TITLE
Problem: backupcopy=auto writes in place with a restrictive umask

### DIFF
--- a/src/bufwrite.c
+++ b/src/bufwrite.c
@@ -1241,7 +1241,7 @@ buf_write(
 		    vim_ignored = fchown(fd, st_old.st_uid, st_old.st_gid);
 #  endif
 #  ifdef HAVE_FCHMOD
-		    vim_ignored = fchmod(fd, perm);
+		    (void)mch_fsetperm(fd, perm);
 #  else
 		    (void)mch_setperm(tmp_fname, perm);
 #  endif

--- a/src/bufwrite.c
+++ b/src/bufwrite.c
@@ -1209,7 +1209,7 @@ buf_write(
 		char_u	tmp_fname[MAXPATHL];
 		int	i;
 
-		// Check if we can create a file and set the owner/group to
+		// Check if we can create a file and set the owner/group/mode to
 		// the ones from the original file.
 		// First find a file name that doesn't exist yet (use some
 		// arbitrary numbers).
@@ -1239,6 +1239,11 @@ buf_write(
 # ifdef UNIX
 #  ifdef HAVE_FCHOWN
 		    vim_ignored = fchown(fd, st_old.st_uid, st_old.st_gid);
+#  endif
+#  ifdef HAVE_FCHMOD
+		    vim_ignored = fchmod(fd, perm);
+#  else
+		    (void)mch_setperm(tmp_fname, perm);
 #  endif
 		    if (mch_stat((char *)tmp_fname, &st) < 0
 			    || st.st_uid != st_old.st_uid

--- a/src/testdir/test_writefile.vim
+++ b/src/testdir/test_writefile.vim
@@ -997,7 +997,6 @@ func Test_write_with_xattr_support()
   bw!
 endfunc
 
-
 func Test_backupcopy_auto_restrictive_umask()
   CheckUnix
   set backupskip=
@@ -1019,4 +1018,5 @@ func Test_backupcopy_auto_restrictive_umask()
   call assert_notequal(inode_before, split(system('ls -i Xumaskfile'))[0])
   set backupskip&
 endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_writefile.vim
+++ b/src/testdir/test_writefile.vim
@@ -999,24 +999,22 @@ endfunc
 
 func Test_backupcopy_auto_restrictive_umask()
   CheckUnix
-  set backupskip=
   call writefile(['FOO'], 'Xumaskfile', 'D')
   call setfperm('Xumaskfile', 'rw-r--r--')
-  let inode_before = split(system('ls -i Xumaskfile'))[0]
+  let inode_before = systemlist('ls -i Xumaskfile')[0]->matchstr('^\s*\zs\d\+')
   call writefile([
 	\ 'set backupcopy=auto writebackup nobackup backupskip=',
 	\ 'edit Xumaskfile',
 	\ 'call setline(1, ["BAR"])',
 	\ 'write',
-	\ 'quit',
+	\ 'qall!'
 	\ ], 'Xumaskscript', 'D')
-  call system('umask 0077; ' .. GetVimCommand()
-	\ .. ' -u NONE -U NONE -i NONE -n -S Xumaskscript')
+  call system('umask 0077; ' .. GetVimCommand() .. ' -i NONE -n -S Xumaskscript')
   call assert_equal(0, v:shell_error)
   call assert_equal(['BAR'], readfile('Xumaskfile'))
   call assert_equal('rw-r--r--', getfperm('Xumaskfile'))
-  call assert_notequal(inode_before, split(system('ls -i Xumaskfile'))[0])
-  set backupskip&
+  call assert_notequal(inode_before,
+	\ systemlist('ls -i Xumaskfile')[0]->matchstr('^\s*\zs\d\+'))
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_writefile.vim
+++ b/src/testdir/test_writefile.vim
@@ -997,4 +997,26 @@ func Test_write_with_xattr_support()
   bw!
 endfunc
 
+
+func Test_backupcopy_auto_restrictive_umask()
+  CheckUnix
+  set backupskip=
+  call writefile(['FOO'], 'Xumaskfile', 'D')
+  call setfperm('Xumaskfile', 'rw-r--r--')
+  let inode_before = split(system('ls -i Xumaskfile'))[0]
+  call writefile([
+	\ 'set backupcopy=auto writebackup nobackup backupskip=',
+	\ 'edit Xumaskfile',
+	\ 'call setline(1, ["BAR"])',
+	\ 'write',
+	\ 'quit',
+	\ ], 'Xumaskscript', 'D')
+  call system('umask 0077; ' .. GetVimCommand()
+	\ .. ' -u NONE -U NONE -i NONE -n -S Xumaskscript')
+  call assert_equal(0, v:shell_error)
+  call assert_equal(['BAR'], readfile('Xumaskfile'))
+  call assert_equal('rw-r--r--', getfperm('Xumaskfile'))
+  call assert_notequal(inode_before, split(system('ls -i Xumaskfile'))[0])
+  set backupskip&
+endfunc
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
The `'backupcopy'` auto probe compares the probe file mode to the original
without trying to set the mode. With umask `0077`, `open(..., 0644)` creates
`0600`, the check fails, and Vim overwrites the original inode.
This tries `fchmod()` (or `mch_setperm()`) after `fchown()`.
A test in `test_writefile.vim` asserts the inode changes and mode stays 0644.
Related: https://redhat.atlassian.net/browse/RHEL-122841