### PR TITLE
runtime(syntax): Add Regexp default highlight group

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1,4 +1,4 @@
-*syntax.txt*	For Vim version 9.2.  Last change: 2026 Aug 13
+*syntax.txt*	For Vim version 9.2.  Last change: 2026 Aug 24
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -230,6 +230,7 @@ you can see the actual color, except for "Ignore"):
 	 Character	a character constant: 'c', '\n'
 	 Number		a number constant: 234, 0xff
 	 Boolean	a boolean constant: TRUE, false
+	 Regexp		a regular expression constant: /ab*c/
 	 Float		a floating point constant: 2.3e10
 
 	*Identifier	any variable name

--- a/runtime/syntax/help.vim
+++ b/runtime/syntax/help.vim
@@ -2,7 +2,7 @@
 " Language:		Vim help file
 " Maintainer:		Doug Kearns <dougkearns@gmail.com>
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:		2026 Aug 02
+" Last Change:		2026 Aug 24
 
 " Quit when a (custom) syntax file was already loaded
 if exists("b:current_syntax")
@@ -177,6 +177,7 @@ syn match helpString		"\t[* ]String\t\+[a-z].*"
 syn match helpCharacter		"\t[* ]Character\t\+[a-z].*"
 syn match helpNumber		"\t[* ]Number\t\+[a-z].*"
 syn match helpBoolean		"\t[* ]Boolean\t\+[a-z].*"
+syn match helpRegexp		"\t[* ]Regexp\t\+[a-z].*"
 syn match helpFloat		"\t[* ]Float\t\+[a-z].*"
 syn match helpIdentifier	"\t[* ]Identifier\t\+[a-z].*"
 syn match helpFunction		"\t[* ]Function\t\+[a-z].*"
@@ -271,6 +272,7 @@ hi def link helpString		String
 hi def link helpCharacter	Character
 hi def link helpNumber		Number
 hi def link helpBoolean		Boolean
+hi def link helpRegexp		Regexp
 hi def link helpFloat		Float
 hi def link helpIdentifier	Identifier
 hi def link helpFunction	Function

--- a/runtime/syntax/syncolor.vim
+++ b/runtime/syntax/syncolor.vim
@@ -1,6 +1,6 @@
 " Vim syntax support file
 " Maintainer:	The Vim Project <https://github.com/vim/vim>
-" Last Change:	2026 Jul 22
+" Last Change:	2026 Aug 24
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " This file sets up the default methods for highlighting.
@@ -72,6 +72,7 @@ SynLink String		Constant
 SynLink Character	Constant
 SynLink Number		Constant
 SynLink Boolean		Constant
+SynLink Regexp		Constant
 SynLink Float		Number
 SynLink Function	Identifier
 SynLink Conditional	Statement

--- a/runtime/syntax/vim.vim
+++ b/runtime/syntax/vim.vim
@@ -2,7 +2,7 @@
 " Language:	   Vim script
 " Maintainer:	   Hirohito Higashi <h.east.727 ATMARK gmail.com>
 "	   Doug Kearns <dougkearns@gmail.com>
-" Last Change:	   2026 Aug 22
+" Last Change:	   2026 Aug 24
 " Former Maintainer: Charles E. Campbell
 
 " DO NOT CHANGE DIRECTLY.
@@ -180,7 +180,7 @@ syn match	vimUserAutoEvent	contained	"\<\h\w*\>"	skipwhite skipnl nextgroup=vimU
 
 " Highlight commonly used Groupnames {{{2
 " GEN_SYN_VIM: vimGroup, START_STR='syn keyword vimGroup contained', END_STR=''
-syn keyword vimGroup contained Added Bold BoldItalic Boolean Changed Character Comment Conditional Constant Debug Define Delimiter Error Exception Float Function Identifier Ignore Include Italic Keyword Label Macro Number Operator PreCondit PreProc Removed Repeat Special SpecialChar SpecialComment Statement StorageClass String Structure Tag Todo Type Typedef Underlined
+syn keyword vimGroup contained Added Bold BoldItalic Boolean Changed Character Comment Conditional Constant Debug Define Delimiter Error Exception Float Function Identifier Ignore Include Italic Keyword Label Macro Number Operator PreCondit PreProc Regexp Removed Repeat Special SpecialChar SpecialComment Statement StorageClass String Structure Tag Todo Type Typedef Underlined
 
 " Default highlighting groups {{{2
 " GEN_SYN_VIM: vimHLGroup, START_STR='syn keyword vimHLGroup contained', END_STR=''


### PR DESCRIPTION
Most syntax files currently use String or Normal for highlighting
regular expression literals; these should have a dedicated group.

