### PR TITLE
Vim9: hang when a line break is used before "->("

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -7592,6 +7592,21 @@ eval_isdictc(int c)
 }
 
 /*
+ * Return true when "p" points to "->" followed by a method name or a lambda.
+ * Only called for Vim9 script.
+ */
+    static bool
+method_call_follows(char_u *p)
+{
+    if (p[0] != '-' || p[1] != '>')
+	return false;
+
+    char_u	*after = skipwhite(p + 2);
+
+    return ASCII_ISALPHA(*after) || *after == '(';
+}
+
+/*
  * Handle:
  * - expr[expr], expr[expr:expr] subscript
  * - ".name" lookup
@@ -7619,7 +7634,7 @@ handle_subscript(
 
     while (ret == OK)
     {
-	// When at the end of the line and ".name" or "->{" or "->X" follows in
+	// When at the end of the line and ".name" or a method call follows in
 	// the next line then consume the line break.
 	p = eval_next_non_blank(*arg, evalarg, &getnext);
 	if (getnext
@@ -7627,9 +7642,7 @@ handle_subscript(
 		    && ((rettv->v_type == VAR_DICT && eval_isdictc(p[1]))
 			|| rettv->v_type == VAR_CLASS
 			|| rettv->v_type == VAR_OBJECT))
-		|| (p[0] == '-' && p[1] == '>' && (p[2] == '{'
-			|| ASCII_ISALPHA(in_vim9script() ? *skipwhite(p + 2)
-								    : p[2])))))
+		|| method_call_follows(p)))
 	{
 	    *arg = eval_next_line(*arg, evalarg);
 	    p = *arg;

--- a/src/testdir/test_vim9_expr.vim
+++ b/src/testdir/test_vim9_expr.vim
@@ -3964,6 +3964,14 @@ def Test_expr9_method_call()
       var sorted = [3, 1, 2]
                     -> sort()
       assert_equal([1, 2, 3], sorted)
+
+      var nrs = [1, 2]
+                    ->((x) => x)()
+      assert_equal([1, 2], nrs)
+
+      nrs = [3, 4]
+                    -> ((x) => x)()
+      assert_equal([3, 4], nrs)
   END
   v9.CheckDefAndScriptSuccess(lines)
 

--- a/src/vim9expr.c
+++ b/src/vim9expr.c
@@ -2550,7 +2550,7 @@ compile_subscript(
 	    if (next != NULL &&
 		    ((next[0] == '-' && next[1] == '>'
 				 && (next[2] == '{'
-				       || next[2] == '('
+				       || *skipwhite(next + 2) == '('
 				       || ASCII_ISALPHA(*skipwhite(next + 2))))
 		    || (next[0] == '.' && eval_isdictc(next[1]))))
 	    {


### PR DESCRIPTION
```
Problem:  In Vim9 script a line break before "->(" makes Vim hang and
          use up memory.
Solution: Consume the line break for "->(" as well, and skip white
          space after "->" in a compiled function too.
```

fixes: #21144