### PR TITLE
completion asked for during 'autocompletedelay' looks automatic

### DIFF
--- a/src/edit.c
+++ b/src/edit.c
@@ -684,6 +684,9 @@ edit(
 	    // Don't want delayed autocompletion from the previous key either.
 	    ins_compl_clear_autocomplete_delay();
 	    ins_compl_disarm_autostart();
+	    // A completion already on screen goes on being what it was.
+	    if (!ins_compl_active())
+		ins_compl_disable_autocomplete();
 	}
 
 #ifdef FEAT_RIGHTLEFT

--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -4232,8 +4232,8 @@ get_complete_info(list_T *what_list, dict_T *retdict)
 # define CI_WHAT_ITEMS		    0x04
 # define CI_WHAT_SELECTED	    0x08
 # define CI_WHAT_COMPLETED	    0x10
-# define CI_WHAT_MATCHES		    0x20
-# define CI_WHAT_PREINSERTED_TEXT    0x40
+# define CI_WHAT_MATCHES	    0x20
+# define CI_WHAT_PREINSERTED_TEXT   0x40
 # define CI_WHAT_AUTO		    0x80
 # define CI_WHAT_ALL		    0xff
     int		what_flag;
@@ -7518,6 +7518,15 @@ ins_compl_enable_autocomplete(void)
     compl_autocomplete = TRUE;
     compl_get_longest = FALSE;
 #endif
+}
+
+/*
+ * Disable autocompletion
+ */
+    void
+ins_compl_disable_autocomplete(void)
+{
+    compl_autocomplete = FALSE;
 }
 
 /*

--- a/src/proto/insexpand.pro
+++ b/src/proto/insexpand.pro
@@ -76,6 +76,7 @@ void ins_compl_insert(int move_cursor, int insert_prefix);
 void ins_compl_check_keys(int frequency, int in_compl_func);
 int ins_complete(int c, int enable_pum);
 void ins_compl_enable_autocomplete(void);
+void ins_compl_disable_autocomplete(void);
 void ins_compl_arm_autostart(void);
 void ins_compl_disarm_autostart(void);
 bool ins_compl_arm_autocomplete_delay(void);

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -6802,6 +6802,49 @@ func Test_complete_info_auto()
   bwipe!
 endfunc
 
+" A completion asked for while 'autocompletedelay' runs is not given the
+" implicit "noselect" of autocompletion.
+func Test_complete_asked_for_during_delay()
+  call test_override("char_avail", 1)
+  new
+  func! AutoOmni(findstart, base)
+    if a:findstart
+      return 4
+    endif
+    return ['alpha', 'alphabet']
+  endfunc
+  func! Selected()
+    let g:selected = complete_info(['selected']).selected
+    return ''
+  endfunc
+  setlocal omnifunc=AutoOmni
+  setlocal complete=o
+  setlocal completeopt=menuone
+  setlocal autocomplete
+  call setline(1, '    al')
+
+  " CTRL-X CTRL-O before the delay expires: the first match is selected,
+  " and taken.
+  set autocompletedelay=100
+  call feedkeys("A\<C-X>\<C-O>\<C-R>=Selected()\<CR>\<Esc>", 'tx')
+  call assert_equal(0, g:selected)
+  call assert_equal('    alpha', getline(1))
+
+  " What autocompletion puts up on its own selects nothing, so the word is
+  " left as it was.
+  set autocompletedelay&
+  call setline(1, '    al')
+  call feedkeys("A\<C-R>=Selected()\<CR>\<Esc>", 'tx')
+  call assert_equal(-1, g:selected)
+  call assert_equal('    al', getline(1))
+
+  call test_override("ALL", 0)
+  unlet g:selected
+  delfunc AutoOmni
+  delfunc Selected
+  bwipe!
+endfunc
+
 func Test_complete_fuzzy_resort()
   new
   set completeopt=menu,menuone,noselect,fuzzy


### PR DESCRIPTION
```
Problem:  A completion asked for with CTRL-X CTRL-O while
          'autocompletedelay' is running is given the look of an
          automatic one, the implicit "noselect" among it.
Solution: Turn autocompletion off where a typed key takes the completion
          over.  A completion already on screen goes on being what it
          was.
```

related: #21152
related: #21143

---

Also lines up the CI_WHAT_* values, which were off by a tab on two lines.