### PR TITLE
Session restoration fails on options using lambdas

### DIFF
--- a/src/option.c
+++ b/src/option.c
@@ -6595,6 +6595,12 @@ makeset(FILE *fd, int opt_flags, int local_only)
 		    int		do_endif = FALSE;
 		    bool	legacy;
 
+		    // Ignore those options associated to lambda expressions because
+		    // persistence makes no sense for them.
+		    if ((p->flags & P_FUNC) && *(char_u **)varp != NULL
+			    && strstr(*(char **)varp, "<lambda>") != NULL)
+			continue;
+
 #ifdef FEAT_EVAL
 		    legacy = !is_option_value_vim9(p - &options[0],
 			    round == 1 ? opt_flags | OPT_GLOBAL : OPT_LOCAL);

--- a/src/testdir/test_mksession.vim
+++ b/src/testdir/test_mksession.vim
@@ -1961,4 +1961,35 @@ func Test_mksession_winminwidth()
   only
 endfunc
 
+" Test for avoiding options relying on lambdas in the session file.
+func Test_mksession_avoid_lambda_options()
+  set sessionoptions+=options
+  set sessionoptions+=localoptions
+
+  " Set global and local options that rely on a lambda function.
+  let Lambda = {-> 'dummy function'}
+  let &opfunc = Lambda
+  let &completefunc = Lambda
+
+  mksession! Xtest_mks.out
+
+  " Test restoring session
+  const msg = 'Option relying on lambda function should not be restored'
+  try
+    set opfunc&
+    set completefunc&
+    source Xtest_mks.out
+    call assert_true(empty(&opfunc), msg)
+    call assert_true(empty(&completefunc), msg)
+  catch /^Vim\%((\S\+)\)\=:E700:/
+    call assert_report(msg)
+  endtry
+
+  " clean up
+  set opfunc&
+  set completefunc&
+  call delete('Xtest_mks.out')
+  set sessionoptions&
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Some plugins (like the builtin `comment` one) set options to *lambdas* for convenience (`comment.vim` does that with `'operatorfunc'`).

In that case `:mksession` will include a `set operatorfunc=function('<lambda>xxxx')` . Trying to source the session file will throw a `E700: Unknown function: <lambda>xxxx` because the lambda is either not there or has a different number associated.
In the case of `comment` plugin the *lambda* is defined from the mappings and is not available on plugin load.

This pull request prevents those operators associated with *lambdas* from being recorded in the session.
