### PR TITLE
runtime(evcxr): Recognize evcxr history files

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -308,6 +308,9 @@ if has("fname_case")
    au BufNewFile,BufRead *.EU,*.EW,*.EX,*.EXU,*.EXW  call dist#ft#EuphoriaCheck()
 endif
 
+" Evcxr history
+au BufNewFile,BufRead */evcxr/history.txt		setf rust
+
 " Execline (s6) scripts
 au BufNewFile,BufRead *s6*/\(up\|down\|run\|finish\)    setf execline
 

--- a/src/testdir/test_filetype.vim
+++ b/src/testdir/test_filetype.vim
@@ -728,7 +728,7 @@ def s:GetFilenameChecks(): dict<list<string>>
     ruby: ['.irbrc', 'irbrc', '.irb_history', 'irb_history', 'file.rb', 'file.rbi', 'file.rbw', 'file.gemspec', 'file.ru', 'Gemfile', 'file.builder',
            'file.rxml', 'file.rjs', 'file.rant', 'file.rake', 'rakefile', 'Rakefile', 'rantfile', 'Rantfile', 'rakefile-file', 'Rakefile-file',
            'Puppetfile', 'Vagrantfile', 'Brewfile'],
-    rust: ['file.rs'],
+    rust: ['file.rs', 'any/.config/evcxr/history.txt'],
     sage: ['file.sage'],
     salt: ['file.sls'],
     samba: ['smb.conf'],


### PR DESCRIPTION
[evcxr_repl](https://github.com/evcxr/evcxr/blob/main/evcxr_repl/README.md) is a Rust REPL.

Refer https://github.com/evcxr/evcxr/blob/main/evcxr_repl/README.md .