### PR TITLE
Vim9: v:errmsg is set while looking ahead at a command

### DIFF
--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -3847,8 +3847,10 @@ find_ex_command(
 		//	name[idx] = val
 		//	name[idx].member = val
 		//	etc.
+		// Not emsg_silent: that would still let what skip_expr()
+		// makes of an expression it cannot follow reach "v:errmsg".
 		eap->cmdidx = CMD_eval;
-		++emsg_silent;
+		++emsg_off;
 		if (skip_expr(&after, NULL) == OK)
 		{
 		    after = skipwhite(after);
@@ -3857,7 +3859,7 @@ find_ex_command(
 							   && after[2] == '='))
 			eap->cmdidx = CMD_var;
 		}
-		--emsg_silent;
+		--emsg_off;
 		return eap->cmd;
 	    }
 

--- a/src/testdir/test_vim9_cmd.vim
+++ b/src/testdir/test_vim9_cmd.vim
@@ -2251,4 +2251,21 @@ def Test_delfunction_dict_funcref()
   v9.CheckScriptSuccess(lines)
 enddef
 
+" Looking ahead at a line that starts with a dict member, to tell an
+" assignment from an expression, must not leave an error behind.
+def Test_no_error_from_looking_ahead()
+  var lines =<< trim END
+      vim9script
+      var d = {Fn: (m: string) => 0}
+      def F(b: bool)
+        d.Fn(b ? 'one'
+               : 'two')
+      enddef
+      v:errmsg = ''
+      defcompile
+      assert_equal('', v:errmsg)
+  END
+  v9.CheckScriptSuccess(lines)
+enddef
+
 " vim: ts=8 sw=2 sts=2 expandtab tw=80 fdm=marker

--- a/src/testdir/test_vim9_generics.vim
+++ b/src/testdir/test_vim9_generics.vim
@@ -1211,7 +1211,7 @@ def Test_generic_obj_method()
     var a = A.new()
     a.Fn<>()
   END
-  v9.CheckSourceFailureList(lines, ["E1555: Empty type list specified for generic function '<>()'"])
+  v9.CheckSourceFailureList(lines, ["E1555: Empty type list specified for generic function 'Fn'"])
 
   lines =<< trim END
     vim9script
@@ -1295,7 +1295,7 @@ def Test_generic_obj_method_call_from_another_method()
     enddef
     defcompile
   END
-  v9.CheckSourceFailureList(lines, ["E1555: Empty type list specified for generic function '<>()'"])
+  v9.CheckSourceFailureList(lines, ["E1555: Empty type list specified for generic function 'Fn'"])
 
   lines =<< trim END
     vim9script
@@ -1476,7 +1476,7 @@ def Test_generic_class_method()
     endclass
     A.Fn<>()
   END
-  v9.CheckSourceFailureList(lines, ["E1555: Empty type list specified for generic function '<>()'"])
+  v9.CheckSourceFailureList(lines, ["E1555: Empty type list specified for generic function 'Fn'"])
 
   lines =<< trim END
     vim9script
@@ -1554,7 +1554,7 @@ def Test_generic_class_method_call_from_another_method()
     enddef
     defcompile
   END
-  v9.CheckSourceFailureList(lines, ["E1555: Empty type list specified for generic function '<>()'"])
+  v9.CheckSourceFailureList(lines, ["E1555: Empty type list specified for generic function 'Fn'"])
 
   lines =<< trim END
     vim9script


### PR DESCRIPTION
```
Problem:  In Vim9 script a line starting with a dict member is looked
    ahead at, to tell an assignment from an expression.  Where the
    expression runs on into the next line the lookahead cannot follow
    it, and what it makes of that reaches "v:errmsg" and whatever is
    being redirected, though nothing is wrong and the function compiles.
Solution: Turn error messages off around the lookahead instead of
    silencing them.
```