### PR TITLE
patch 9.2.XXXX: tests: viminfo bar line length overflow test fails un…

### DIFF
--- a/src/testdir/test_viminfo.vim
+++ b/src/testdir/test_viminfo.vim
@@ -1385,6 +1385,7 @@ func Test_viminfo_len_one()
 endfunc
 
 func Test_viminfo_len_overflow()
+  CheckNotAsan
   let _viminfofile = &viminfofile
   let &viminfofile=''
   let viminfo_file = tempname()


### PR DESCRIPTION
…der ASAN

Problem:  Test_viminfo_len_overflow() triggers an ASAN abort when
          attempting a ~4GB allocation, before alloc() can return NULL
Solution: Skip the test when running under ASAN.