### PR TITLE
patch 9.2.XXXX: heap-use-after-free in ml_open_file()

### DIFF
--- a/src/memline.c
+++ b/src/memline.c
@@ -810,6 +810,12 @@ ml_open_file(buf_T *buf)
 	// and creating it, another Vim creates the file.  In that case the
 	// creation will fail and we will use another directory.
 	fname = findswapname(buf, &dirp, NULL); // allocates fname
+	// autocmd may have freed mfp, grr!
+	if (buf->b_ml.ml_mfp != mfp)
+	{
+	    vim_free(fname);
+	    return;
+	}
 	if (dirp == NULL)
 	    break;  // out of memory
 	if (fname == NULL)


### PR DESCRIPTION
Problem:  A SwapExists autocmd can re-open the buffer being edited,
          causing ml_close() to free the memfile that
          ml_open_file() still holds a local pointer to, causing
          use-after-free.
Solution: After findswapname() returns, verify that buf->b_ml.ml_mfp
          is still the same as the copy mfp we hold.

No tests, because I couldn't figure it out :(