### PR TITLE
autocmd: crash when 'eventignore' is changed while it is being set (after 9.2.0991)

### DIFF
--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -2412,7 +2412,6 @@ did_set_eventignore(optset_T *args)
 {
     char_u	**varp = (char_u **)args->os_varp;
     char_u	*oldval = args->os_oldval.string;
-    char_u	*newval;
 
     if (check_ei(*varp) == FAIL)
 	return e_invalid_argument;
@@ -2424,10 +2423,24 @@ did_set_eventignore(optset_T *args)
     // state, with the old value in effect: what happened while an event was
     // ignored must not be reported once it is not ignored anymore, and what
     // happened before must still be reported.
-    newval = *varp;
-    *varp = oldval;
-    may_trigger_deferred_events();
-    *varp = newval;
+    // Use a copy, the caller owns "oldval" and autocommands may free it.
+    char_u	*save_ei = vim_strsave(oldval);
+    if (save_ei != NULL)
+    {
+	char_u	*newval = *varp;
+	win_T	*wp = is_window_local_option(args->os_idx) ? curwin : NULL;
+
+	*varp = save_ei;
+	// "varp" points into "wp" for 'eventignorewin'.
+	if (wp != NULL)
+	    ++wp->w_locked;
+	may_trigger_deferred_events();
+	if (wp != NULL)
+	    --wp->w_locked;
+
+	free_string_option(*varp);
+	*varp = newval;
+    }
 
     return NULL;
 }

--- a/src/testdir/test_autocmd.vim
+++ b/src/testdir/test_autocmd.vim
@@ -6114,6 +6114,61 @@ func Test_eventignore_deferred_events()
   call StopVimInTerminal(buf)
 endfunc
 
+" Changing 'eventignore' from an autocommand that is triggered by setting
+" 'eventignore' must not crash.
+func Test_eventignore_changed_while_triggering()
+  new
+  call setline(1, range(1, 10))
+  augroup testing
+    autocmd!
+    autocmd CursorMoved * set eventignore=WinLeave
+  augroup END
+
+  " The pending cursor move is reported when the option changes.
+  set eventignore=WinNew
+  normal! j
+  set eventignore=all
+  call assert_equal('all', &eventignore)
+
+  augroup testing
+    autocmd!
+    autocmd CursorMoved * noautocmd echo ''
+  augroup END
+  set eventignore=WinNew
+  normal! j
+  set eventignore=all
+  call assert_equal('all', &eventignore)
+
+  set eventignore=
+  call CleanUpTestAuGroup()
+  %bw!
+endfunc
+
+" An autocommand that is triggered by setting 'eventignorewin' cannot close
+" the window that holds the option.
+func Test_eventignorewin_window_not_closed_while_triggering()
+  new
+  call setline(1, range(1, 10))
+  split
+  let nwin = winnr('$')
+  let s:tried = 0
+  augroup testing
+    autocmd!
+    autocmd CursorMoved * if !s:tried | let s:tried = 1 | close | endif
+  augroup END
+
+  normal! j
+  set eventignorewin=WinLeave
+  call assert_equal(1, s:tried)
+  call assert_equal(nwin, winnr('$'))
+  call assert_equal('WinLeave', &eventignorewin)
+
+  set eventignorewin=
+  unlet s:tried
+  call CleanUpTestAuGroup()
+  %bw!
+endfunc
+
 func Test_VimResized_and_window_width_not_equalized()
   CheckRunVimInTerminal
 


### PR DESCRIPTION
```
Problem:  Vim crashes when an autocommand that is triggered by setting
          'eventignore' or 'eventignorewin' changes that option again.
          This happens with plugins that use ":noautocmd" in an
          autocommand for an event that is checked in the main loop.
Solution: Trigger the events with a copy of the old value in effect, so
          that the value the caller is still using is not freed.  Keep
          the window that holds 'eventignorewin' from being closed while
          the events are triggered.
```

fixes: #21169
related: #21074