### PR TITLE
runtime(c): syntax depends on the 'iskeyword' option

### DIFF
--- a/runtime/syntax/c.vim
+++ b/runtime/syntax/c.vim
@@ -25,6 +25,13 @@ if exists("c_autodoc")
   unlet b:current_syntax
 endif
 
+" In VMS C keywords contain '$' characters.
+if has("vms")
+  syn iskeyword @,48-57,_,192-255,$
+else
+  syn iskeyword @,48-57,_,192-255
+endif
+
 " A bunch of useful C keywords
 syn keyword	cStatement	goto break return continue asm
 syn keyword	cLabel		case default


### PR DESCRIPTION
```
Problem:  C keywords are matched using the characters from 'iskeyword',
          so changing that option highlights part of an identifier as a
          keyword and leaves keywords containing an underscore
          unhighlighted.
Solution: Set the keyword characters with ":syn iskeyword".
```

fixes: #21173

The patch in the issue also removed `setlocal iskeyword+=$` from
runtime/ftplugin/c.vim. That line is kept here. It sets the option, which is
what `w`, `*`, `ciw`, `K` and `CTRL-]` use, so removing it would stop VMS C
identifiers such as `sys$open` from being treated as one word. Making the
highlighting independent of 'iskeyword' needs the syntax file only.