### PR TITLE
patch 9.2.XXXX: heap-use-after-free via DiffUpdated autocommand

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -1,4 +1,4 @@
-*autocmd.txt*	For Vim version 9.2.  Last change: 2026 Aug 04
+*autocmd.txt*	For Vim version 9.2.  Last change: 2026 Aug 28
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -812,6 +812,7 @@ DiffUpdated			After diffs have been updated.  Depending on
 				what kind of diff is being used (internal or
 				external) this can be triggered on every
 				change or when doing |:diffupdate|.
+				It is not allowed to change the window layout.
 							*DirChangedPre*
 DirChangedPre			The working directory is going to be changed,
 				as with |DirChanged|.  The pattern is like

--- a/src/diff.c
+++ b/src/diff.c
@@ -1191,7 +1191,9 @@ theend:
     if (had_diffs || curtab->tp_first_diff != NULL)
     {
 	diff_redraw(TRUE);
+	window_layout_lock();
 	apply_autocmds(EVENT_DIFFUPDATED, NULL, NULL, FALSE, curbuf);
+	window_layout_unlock();
     }
 }
 
@@ -4444,7 +4446,9 @@ theend:
     {
 	// Also need to redraw the other buffers.
 	diff_redraw(FALSE);
+	window_layout_lock();
 	apply_autocmds(EVENT_DIFFUPDATED, NULL, NULL, FALSE, curbuf);
+	window_layout_unlock();
     }
 }
 

--- a/src/testdir/test_diffmode.vim
+++ b/src/testdir/test_diffmode.vim
@@ -3671,4 +3671,35 @@ func Test_diff_cursorbind_after_undo()
   %bw!
 endfunc
 
+func Test_diffupdated_close_window_fails()
+  new
+  only
+  call setline(1, ['one', 'two', 'three'])
+  let w1 = win_getid()
+  vnew
+  call setline(1, ['one', 'Two', 'three'])
+  windo diffthis
+  call win_gotoid(w1)
+
+  augroup TestDiffUpdated
+    autocmd!
+    autocmd DiffUpdated * bw!
+  augroup END
+
+  try
+  diffupdate
+  catch
+  endtry
+
+  augroup TestDiffUpdated
+    autocmd!
+  augroup END
+  augroup! TestDiffUpdated
+
+  call assert_equal(2, winnr('$'))
+
+  diffoff!
+  %bw!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:    A DiffUpdated autococmd wiping the current buffer
            can cause a use-after-free (Evaopo).
Solution:   Disallow changing the window layout while DiffUpdated
            autocommand runs.