### PR TITLE
NFA regexp matching is slower than necessary

### DIFF
--- a/src/regexp_nfa.c
+++ b/src/regexp_nfa.c
@@ -5960,8 +5960,14 @@ nfa_regmatch(
 	for (listidx = 0; listidx < thislist->n; ++listidx)
 	{
 	    // If the list gets very long there probably is something wrong.
-	    // At least allow interrupting with CTRL-C.
-	    fast_breakcheck();
+	    // At least allow interrupting with CTRL-C.  Only check once in a
+	    // while, calling ui_breakcheck() for every state is too slow.
+	    static int	breakcheck_count = 0;  // using "static" makes it faster
+	    if (unlikely(++breakcheck_count >= 100000))
+	    {
+		ui_breakcheck();
+		breakcheck_count = 0;
+	    }
 	    if (got_int)
 		break;
 #ifdef FEAT_RELTIME


### PR DESCRIPTION
Problem:  NFA regexp matching is slower than necessary because
          fast_breakcheck() is called for every state in the list.
Solution: Only call fast_breakcheck() once every 100 states, using a
          static counter, like exec_instructions().

The inner loop of nfa_regmatch() that computes the next state list called fast_breakcheck() on every iteration. fast_breakcheck() lives in a separate translation unit and thus cannot be inlined, so each state paid the cost of a function call merely to increment a counter that only reaches ui_breakcheck() once in ten thousand calls. During syntax highlighting, where the state lists can grow long, this has a measurable overhead. Guarding the call behind a static counter, like done with the breakcheck_count variable in src/vim9execute.c make things less worse.

A "perf stat -e instructions" on a full scroll of a 60000 line C file with syntax highlighting enabled shows a 2% reduction.