### PR TITLE
NFA regexp matching is slow for ASCII text

### DIFF
--- a/src/regexp_nfa.c
+++ b/src/regexp_nfa.c
@@ -5898,8 +5898,19 @@ nfa_regmatch(
 
 	if (has_mbyte)
 	{
-	    curc = (*mb_ptr2char)(rex.input);
-	    clen = (*mb_ptr2len)(rex.input);
+	    // Fast path for an ASCII byte not followed by a composing
+	    // character, matching the check in utfc_ptr2len().  Avoids two
+	    // indirect calls for the common case.
+	    if (rex.input[0] != NUL && rex.input[0] < 0x80 && rex.input[1] < 0x80)
+	    {
+		curc = rex.input[0];
+		clen = 1;
+	    }
+	    else
+	    {
+		curc = (*mb_ptr2char)(rex.input);
+		clen = (*mb_ptr2len)(rex.input);
+	    }
 	}
 	else
 	{


### PR DESCRIPTION
Problem:  NFA regexp matching is slower than necessary for ASCII text
          because two indirect function calls are made for every
          character.
Solution: Add an inline fast path for an ASCII byte that is not followed
          by a composing character.

The main loop of nfa_regmatch() fetched the current character and its byte length with two calls through the mb_ptr2char and mb_ptr2len function pointers on every character.  These pointers cannot be inlined, yet for ASCII text, which is the common case, both merely return the byte and a length of one.

Handle that case inline.  NUL is checked first so that reading the next byte cannot go past the end of the line, and the "next byte is ASCII" condition matches the check in utfc_ptr2len(), so a base character followed by a composing character still falls through to the original calls.

A "perf stat -e instructions" on a full scroll of a 60000 line C file with syntax highlighting enabled shows an instructions count reduction of 4%.