### PR TITLE
runtime(gitignore): take care when undo_ftplugin is already set

### DIFF
--- a/runtime/ftplugin/gitignore.vim
+++ b/runtime/ftplugin/gitignore.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin
 " Language:	git ignore
 " Maintainer:	ObserverOfTime <chronobserver@disroot.org>
-" Last Change:	2022 Sep 10
+" Last Change:	2026 Aug 28
 
 if exists('b:did_ftplugin')
   finish
@@ -10,4 +10,8 @@ let b:did_ftplugin = 1
 
 setl comments=:# commentstring=#\ %s
 
-let b:undo_ftplugin = 'setl com< cms<'
+let b:undo_ftplugin = get(b:, 'undo_ftplugin', '')
+if !empty(b:undo_ftplugin)
+  let b:undo_ftplugin .= ' | '
+endif
+let b:undo_ftplugin .= 'setlocal comments< commentstring<'


### PR DESCRIPTION
This duplicates some of what I have in https://github.com/benknoble/gitignore-vim, which it looks like I created before Vim gained this ftplugin of its own :)