### PR TITLE
patch 9.2.XXXX: wildmode list:full does not complete first match

### DIFF
--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -1006,7 +1006,7 @@ cmdline_wildchar_complete(
 	    res = nextwild(xp, WILD_LONGEST, options, escape);
 	else
 	{
-	    if (wim_noselect || wim_list)
+	    if (wim_noselect || (wim_list && !wim_full))
 		options |= WILD_NOSELECT;
 	    if (wim_noinsert)
 		options |= WILD_NOINSERT;

--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -2348,6 +2348,27 @@ func Wildmode_tests()
   call assert_equal('oneA  oneB  oneC', g:Sline)
   call assert_equal('"MyCmd one', @:)
 
+  " Colon-separated modes apply during the same completion phase.
+  call writefile([], 'XwildmodeA', 'D')
+  call writefile([], 'XwildmodeB', 'D')
+  call writefile([], 'XwildmodeC', 'D')
+  set wildmode=list:full
+  let g:Sline = ''
+  call feedkeys(":e Xwildmode\t\<F4>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('XwildmodeA  XwildmodeB  XwildmodeC', g:Sline)
+  call assert_equal('"e XwildmodeA', @:)
+  call feedkeys(":e Xwildmode\t\t\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"e XwildmodeB', @:)
+
+  " Comma-separated modes apply on consecutive Tab presses.
+  set wildmode=list,full
+  let g:Sline = ''
+  call feedkeys(":MyCmd o\t\<F4>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('oneA  oneB  oneC', g:Sline)
+  call assert_equal('"MyCmd o', @:)
+  call feedkeys(":MyCmd o\t\t\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"MyCmd oneA', @:)
+
   set wildmode=""
   call feedkeys(":MyCmd \t\t\<C-B>\"\<CR>", 'xt')
   call assert_equal('"MyCmd oneA', @:)
@@ -2381,6 +2402,13 @@ func Wildmode_tests()
   call assert_equal('"MyCmd o', @:)
   call feedkeys(":MyCmd o\t\t\<C-Y>\<C-B>\"\<CR>", 'xt')
   call assert_equal('"MyCmd o', @:)
+
+  " 'noselect' takes precedence over 'full' on the first Tab.
+  set wildmode=noselect:full
+  call feedkeys(":MyCmd o\t\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"MyCmd o', @:)
+  call feedkeys(":MyCmd o\t\t\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"MyCmd oneA', @:)
 
   " When 'full' is present, complete after first <tab>.
   set wildmode=noselect,full


### PR DESCRIPTION
Problem: With 'wildmode' set to `list:full`, matches are listed but the first match is not completed on the first Tab press.

Solution: Do not set `WILD_NOSELECT` when `list` and `full` are active in the same completion phase. Preserve the existing behavior of `list`, comma-separated `list,full`, `noselect`, and `noinsert`.

Regression coverage includes the original `:edit` file-completion path, first and second Tab behavior, comma-separated completion phases, and `noselect` precedence.

Tests:
- Focused `Test_wildmode()`
- All 179 `test_cmdline` tests
- All 5 codestyle tests
- Full source test suite: 7,596 executed, 951 skipped, 0 failed
- `git diff --check`

AI disclosure: OpenAI Codex was used to analyze the issue, implement the change, add tests, and prepare this pull request. The contributor reviewed the resulting code and validation results.

fixes: #19532
related: #18088