### PR TITLE
destructors of polymorphic classes must be virtual

### DIFF
--- a/src/GvimExt/gvimext.h
+++ b/src/GvimExt/gvimext.h
@@ -85,7 +85,7 @@ protected:
 
 public:
     CShellExtClassFactory();
-    ~CShellExtClassFactory();
+    virtual ~CShellExtClassFactory();
 
     //IUnknown members
     STDMETHODIMP		QueryInterface(REFIID, LPVOID FAR *);
@@ -133,7 +133,7 @@ public:
     int		 m_cntOfHWnd;
     HWND	 m_hWnd[MAX_HWND];
     CShellExt();
-    ~CShellExt();
+    virtual ~CShellExt();
 
     //IUnknown members
     STDMETHODIMP QueryInterface(REFIID, LPVOID FAR *);


### PR DESCRIPTION
Problem:  The classes CShellExtClassFactory and CShellExt contain virtual
          member functions (declared with STDMETHODIMP), but the
	  destructors are non-virtual which might cause undefined
	  behavior.
Solution: Mark destructors as virtual.