### PR TITLE
patch 9.2.XXXX: CTRL-D moves cursor up with 'scrolloffpad'

### DIFF
--- a/src/move.c
+++ b/src/move.c
@@ -3383,7 +3383,13 @@ pagescroll(int dir, long count, int half)
 	}
     }
 
-    if (get_scrolloff_value() > 0)
+    // With 'scrolloffpad', correcting the cursor when scrolling did not change
+    // anything could move it in the opposite direction.
+    if (get_scrolloff_value() > 0
+	    && (!use_scrolloffpad()
+		|| did_move
+		|| prev_col != curwin->w_cursor.col
+		|| prev_lnum != curwin->w_cursor.lnum))
 	cursor_correct();
 #ifdef FEAT_FOLDING
     // Move cursor to first line of closed fold.

--- a/src/move.c
+++ b/src/move.c
@@ -3113,8 +3113,9 @@ cursor_correct(void)
     if (curwin->w_botline == curbuf->b_ml.ml_line_count + 1
 	    && mouse_dragging == 0)
     {
-	if (!use_scrolloffpad())
-		below_wanted = 0;
+	// Missing context below EOF must not move the cursor up.  Automatic
+	// scrolling handles the centering for 'scrolloffpad'.
+	below_wanted = 0;
 	max_off = (curwin->w_height - 1) / 2;
 	if (above_wanted > max_off)
 	    above_wanted = max_off;
@@ -3383,13 +3384,7 @@ pagescroll(int dir, long count, int half)
 	}
     }
 
-    // With 'scrolloffpad', correcting the cursor when scrolling did not change
-    // anything could move it in the opposite direction.
-    if (get_scrolloff_value() > 0
-	    && (!use_scrolloffpad()
-		|| did_move
-		|| prev_col != curwin->w_cursor.col
-		|| prev_lnum != curwin->w_cursor.lnum))
+    if (get_scrolloff_value() > 0)
 	cursor_correct();
 #ifdef FEAT_FOLDING
     // Move cursor to first line of closed fold.

--- a/src/testdir/test_scroll_opt.vim
+++ b/src/testdir/test_scroll_opt.vim
@@ -1760,6 +1760,24 @@ func Test_scrolloffpad_paging_to_eof()
   bwipe!
 endfunc
 
+func Test_scrolloffpad_ctrl_d_at_eof()
+  new
+  resize 12
+  setlocal scroll=6 scrolloff=999
+  call setline(1, map(range(1, 80), 'printf("line %d", v:val)'))
+
+  for sop in [0, 1]
+    let &l:scrolloffpad = sop
+    normal! ggG
+    let view_before = winsaveview()
+
+    call assert_beeps('execute "normal! \<C-D>"')
+    call assert_equal(view_before, winsaveview())
+  endfor
+
+  bwipe!
+endfunc
+
 func Test_scrolloffpad_autocmd_append_at_eof()
   let states = {}
   for sop in [0, 1]

--- a/src/testdir/test_scroll_opt.vim
+++ b/src/testdir/test_scroll_opt.vim
@@ -1762,17 +1762,53 @@ endfunc
 
 func Test_scrolloffpad_ctrl_d_at_eof()
   new
-  resize 12
-  setlocal scroll=6 scrolloff=999
+  setlocal scroll=6
   call setline(1, map(range(1, 80), 'printf("line %d", v:val)'))
 
-  for sop in [0, 1]
-    let &l:scrolloffpad = sop
-    normal! ggG
-    let view_before = winsaveview()
+  for height in [11, 12]
+    execute 'resize ' .. height
+    for so in [1, 999]
+      let &l:scrolloff = so
+      for sop in [0, 1]
+        let &l:scrolloffpad = sop
+        for endcmd in ['ggG', 'ggGzb']
+          let context = printf('height=%d so=%d sop=%d %s',
+                \ height, so, sop, endcmd)
+          execute 'normal! ' .. endcmd
+          let view_before = winsaveview()
 
-    call assert_beeps('execute "normal! \<C-D>"')
-    call assert_equal(view_before, winsaveview())
+          call assert_beeps('execute "normal! \<C-D>"')
+          call assert_equal(view_before, winsaveview(), context)
+        endfor
+      endfor
+    endfor
+  endfor
+
+  bwipe!
+endfunc
+
+func Test_scrolloffpad_ctrl_e_at_eof()
+  new
+  call setline(1, map(range(1, 80), 'printf("line %d", v:val)'))
+
+  for height in [11, 12]
+    execute 'resize ' .. height
+    for so in [1, 999]
+      let &l:scrolloff = so
+      for sop in [0, 1]
+        let &l:scrolloffpad = sop
+        for endcmd in ['ggG', 'ggGzb']
+          let context = printf('height=%d so=%d sop=%d %s',
+                \ height, so, sop, endcmd)
+          execute 'normal! ' .. endcmd
+          let expected_view = winsaveview()
+          let expected_view.topline += 1
+
+          execute "normal! \<C-E>"
+          call assert_equal(expected_view, winsaveview(), context)
+        endfor
+      endfor
+    endfor
   endfor
 
   bwipe!


### PR DESCRIPTION
Problem:

With 'scrolloff=999' and 'scrolloffpad=1', pressing CTRL-D on the last line invokes cursor correction after a no-op page scroll and moves the cursor upward.  This contradicts the documented behavior that nothing happens and a beep is produced.

Solution:

Skip cursor correction only when 'scrolloffpad' is active and neither the viewport nor the cursor moved.  Existing correction is preserved when 'scrolloffpad' is disabled or when the page command makes progress.  Add a regression test covering both 'scrolloffpad=0' and 'scrolloffpad=1', the unchanged view, and the beep.

Tests:

- Focused Test_scrolloffpad_ctrl_d_at_eof test
- test_scroll_opt: 69 tests passed
- test_normal: 121 tests passed
- codestyle: passed
- Full test suite: 7600 executed, 951 skipped, 0 failed

Fixes #21096