### PR TITLE
runtime(doc): terminal: the ruler in Terminal-Job mode

### DIFF
--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -381,6 +381,10 @@ job.  That includes the cursor position.  Typed keys are sent to the job.
 The terminal contents can change at any time.  This is called Terminal-Job
 mode.
 
+The 'ruler' and the position shown by 'statusline' do not follow it: what the
+terminal shows reaches the buffer only when Vim takes over, so there is no
+position in the buffer to report until then.
+
 Use CTRL-W N (or 'termwinkey' N) to switch to Terminal-Normal mode.  Now the
 contents of the terminal window is under control of Vim, the job output is
 suspended.  CTRL-\ CTRL-N does the same.


### PR DESCRIPTION
```
Problem:  Nothing says why the cursor position shown by the 'ruler' does
    not follow the cursor in a terminal window while the job runs.
Solution: Say that what the terminal shows reaches the buffer only when
    Vim takes over, so there is no position to report until then.
```

related: #21174