### PR TITLE
Add terminalprops().rgb and TermResponseAll 'rgb'

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -1324,12 +1324,12 @@ TermResponse			After the response to |t_RV| is received from
 				takes time is involved.
 							*TermResponseAll*
 TermResponseAll			After the response to |t_RV|, |t_RC|, |t_RS|,
-				|t_u7| or any OSC command are received from
-				the terminal.  The value of |v:termresponse|,
-				|v:termblinkresp|, |v:termstyleresp|,
-				|v:termu7resp|, and |v:termosc|
-				correspondingly, can be used.  <amatch> will
-				be set to any of:
+				|t_u7|, to any OSC command or to true color
+				support are received from the terminal.  The
+				value of |v:termresponse|, |v:termblinkresp|,
+				|v:termstyleresp|, |v:termu7resp|, |v:termosc|
+				and |terminalprops()|.rgb correspondingly, can
+				be used.  <amatch> will be set to any of:
 				    "ambiguouswidth" (|t_u7|),
 				    "background" (|t_RB|),
 				    "cursorblink" (|t_RC|),
@@ -1338,6 +1338,7 @@ TermResponseAll			After the response to |t_RV|, |t_RC|, |t_RS|,
 				    "da1",
 				    "osc",
 				    "version" (|t_RV|)
+				    "rgb" (|xterm-true-color|)
 				Note that this event may be triggered halfway
 				executing another event, especially if file
 				I/O, a shell command or anything else that

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -12182,6 +12182,7 @@ terminalprops()						*terminalprops()*
 		   mouse		mouse type supported
 		   kitty		whether Kitty terminal was detected
 		   decrqm		whether sending DECRQM sequences work
+		   rgb			whether true color is supported  **
 
 		** value 'u' for unknown, 'y' for yes, 'n' for no
 
@@ -12203,6 +12204,9 @@ terminalprops()						*terminalprops()*
 
 		If "decrqm" is 'y', then Vim will query support for the
 		'termsync' and 'termresize' ("inband") options.
+
+		If "rgb" is 'y', then the terminal supports true color.  See
+		|xterm-true-color|.
 
 		Also see:
 		- 'ambiwidth' - detected by using |t_u7|.

--- a/runtime/doc/term.txt
+++ b/runtime/doc/term.txt
@@ -710,6 +710,23 @@ equivalent hence `l` modifier) invoked with the t_ option value and three
 unsigned long integers that may have any value between 0 and 255 (inclusive)
 representing red, green and blue colors respectively.
 
+Some terminal descriptions set 't_Co' to 16777216 to indicate that the
+terminal supports true color.  The terminal itself may report support for true
+color by sending a valid |xterm-codes| RGB response, and in that case the
+|TermResponseAll| autocommand event is fired, with <amatch> set to "rgb" and
+|terminalprops()|.rgb set to 'y'.
+
+Vim does not automatically enable 'termguicolors' when it detects that the
+terminal supports true color.  You can use 't_Co' and |TermResponseAll|, as
+described above, to set the option yourself: >
+    if &t_Co == '16777216'
+	set termguicolors
+    endif
+    autocmd TermResponseAll *
+	\   if expand('<amatch>') == 'rgb'
+	\ |	set termguicolors
+	\ | endif
+<
 							*xterm-resize*
 Window resizing with xterm only works if the allowWindowOps resource is
 enabled.  On some systems and versions of xterm it's disabled by default

--- a/src/autocmd.c
+++ b/src/autocmd.c
@@ -2612,6 +2612,7 @@ static char_u	*old_termrfgresp = NULL;
 static char_u	*old_termstyleresp = NULL;
 static char_u	*old_termda1 = NULL;
 static char_u	*old_termosc = NULL;
+static int	 old_term_is_rgb = 0;
 #endif
 
 /*
@@ -2633,6 +2634,7 @@ block_autocmds(void)
 	old_termstyleresp = get_vim_var_str(VV_TERMSTYLERESP);
 	old_termda1 = get_vim_var_str(VV_TERMDA1);
 	old_termosc = get_vim_var_str(VV_TERMOSC);
+	old_term_is_rgb = term_is_rgb();
     }
 #endif
     ++autocmd_blocked;
@@ -2681,6 +2683,13 @@ unblock_autocmds(void)
 	if (get_vim_var_str(VV_TERMOSC) != old_termosc)
 	{
 	    apply_autocmds(EVENT_TERMRESPONSEALL, (char_u *)"osc", NULL, FALSE, curbuf);
+	}
+	// The "rgb" event should only fire when the terminal responds
+	// positively to RGB request, which turns term_is_rgb() from FALSE to
+	// TRUE.
+	if (!old_term_is_rgb && term_is_rgb())
+	{
+	    apply_autocmds(EVENT_TERMRESPONSEALL, (char_u *)"rgb", NULL, FALSE, curbuf);
 	}
     }
 #endif

--- a/src/autocmd.c
+++ b/src/autocmd.c
@@ -2610,6 +2610,8 @@ static char_u	*old_termblinkresp = NULL;
 static char_u	*old_termrbgresp = NULL;
 static char_u	*old_termrfgresp = NULL;
 static char_u	*old_termstyleresp = NULL;
+static char_u	*old_termda1 = NULL;
+static char_u	*old_termosc = NULL;
 #endif
 
 /*
@@ -2629,6 +2631,8 @@ block_autocmds(void)
 	old_termrbgresp = get_vim_var_str(VV_TERMRBGRESP);
 	old_termrfgresp = get_vim_var_str(VV_TERMRFGRESP);
 	old_termstyleresp = get_vim_var_str(VV_TERMSTYLERESP);
+	old_termda1 = get_vim_var_str(VV_TERMDA1);
+	old_termosc = get_vim_var_str(VV_TERMOSC);
     }
 #endif
     ++autocmd_blocked;
@@ -2669,6 +2673,14 @@ unblock_autocmds(void)
 	if (get_vim_var_str(VV_TERMSTYLERESP) != old_termstyleresp)
 	{
 	    apply_autocmds(EVENT_TERMRESPONSEALL, (char_u *)"cursorshape", NULL, FALSE, curbuf);
+	}
+	if (get_vim_var_str(VV_TERMDA1) != old_termda1)
+	{
+	    apply_autocmds(EVENT_TERMRESPONSEALL, (char_u *)"da1", NULL, FALSE, curbuf);
+	}
+	if (get_vim_var_str(VV_TERMOSC) != old_termosc)
+	{
+	    apply_autocmds(EVENT_TERMRESPONSEALL, (char_u *)"osc", NULL, FALSE, curbuf);
 	}
     }
 #endif

--- a/src/globals.h
+++ b/src/globals.h
@@ -2106,10 +2106,6 @@ EXTERN int skip_update_topline INIT(= FALSE);
 #define SHOWCMD_BUFLEN (SHOWCMD_COLS + 1 + 30)
 EXTERN char_u showcmd_buf[SHOWCMD_BUFLEN];
 
-#ifdef FEAT_TERMGUICOLORS
-EXTERN int	p_tgc_set INIT(= FALSE);
-#endif
-
 // If we've already warned about missing/unavailable clipboard
 EXTERN bool did_warn_clipboard INIT(= FALSE);
 

--- a/src/option.c
+++ b/src/option.c
@@ -4793,7 +4793,6 @@ did_set_termguicolors(optset_T *args UNUSED)
 #  endif
 	    !has_vtp_working())
     {
-	p_tgc_set = TRUE;
 	p_tgc = 0;
 	return e_24_bit_colors_are_not_supported_on_this_environment;
     }
@@ -4818,7 +4817,6 @@ did_set_termguicolors(optset_T *args UNUSED)
     term_update_palette_all();
     term_update_hlfwin_all();
 # endif
-    p_tgc_set = TRUE;
 
     return NULL;
 }

--- a/src/proto/term.pro
+++ b/src/proto/term.pro
@@ -3,6 +3,7 @@ guicolor_T termgui_get_color(char_u *name);
 guicolor_T termgui_mch_get_rgb(guicolor_T color);
 void init_term_props(int all);
 void f_terminalprops(typval_T *argvars, typval_T *rettv);
+int term_is_rgb(void);
 void apply_keyprotocol(char_u *term, keyprot_T prot);
 void set_color_count(int nr);
 keyprot_T match_keyprotocol(char_u *term);

--- a/src/term.c
+++ b/src/term.c
@@ -1549,8 +1549,10 @@ typedef struct {
 #define TPR_KITTY		    4
 // can send DECRQM requests to terminal
 #define TPR_DECRQM		    5
+// supports true color
+#define TPR_RGB			    6
 // table size
-#define TPR_COUNT		    6
+#define TPR_COUNT		    7
 
 static termprop_T term_props[TPR_COUNT];
 
@@ -1576,6 +1578,8 @@ init_term_props(int all)
     term_props[TPR_KITTY].tpr_set_by_termresponse = FALSE;
     term_props[TPR_DECRQM].tpr_name = "decrqm";
     term_props[TPR_DECRQM].tpr_set_by_termresponse = TRUE;
+    term_props[TPR_RGB].tpr_name = "rgb";
+    term_props[TPR_RGB].tpr_set_by_termresponse = TRUE;
 
     for (i = 0; i < TPR_COUNT; ++i)
 	if (all || term_props[i].tpr_set_by_termresponse)
@@ -1605,6 +1609,12 @@ f_terminalprops(typval_T *argvars UNUSED, typval_T *rettv)
 # endif
 }
 #endif
+
+    int
+term_is_rgb(void)
+{
+    return term_props[TPR_RGB].tpr_status == TPR_YES;
+}
 
 /*
  * Find the builtin termcap entries for "term".
@@ -1747,13 +1757,6 @@ set_color_count(int nr)
 	sprintf((char *)nr_colors, "%d", t_colors);
     else
 	*nr_colors = NUL;
-#if 0
-# ifdef FEAT_TERMGUICOLORS
-    // xterm-direct, enable termguicolors, when it wasn't set yet
-    if (t_colors == 0x1000000 && !p_tgc_set)
-	set_option_value((char_u *)"termguicolors", 1L, NULL, 0);
-# endif
-#endif
     set_string_option_direct((char_u *)"t_Co", -1, nr_colors, OPT_FREE, 0);
 }
 
@@ -1787,11 +1790,9 @@ may_adjust_color_count(int val)
 static char *(key_names[]) =
 {
 # ifdef FEAT_TERMRESPONSE
-    // Do those ones first, both may cause a screen redraw.
-    "Co",
-    // disabled, because it switches termguicolors, but that
-    // is noticeable and confuses users
-    // "RGB",
+    // Do those ones first.  "Co" may cause a redraw, "RGB" may
+    // trigger an autocommand that causes a redraw.
+    "Co", "RGB",
 # endif
     "ku", "kd", "kr", "kl",
     "#2", "#4", "%i", "*7",
@@ -1901,7 +1902,10 @@ get_term_entries(int *height, int *width)
      * get key codes
      */
     for (i = 0; key_names[i] != NULL; ++i)
-	if (find_termcode((char_u *)key_names[i]) == NULL)
+	// "RGB" is obtained from the terminal.
+	// Termcap doesn't support 3-character names.
+	if (key_names[i][2] == NUL &&
+		find_termcode((char_u *)key_names[i]) == NULL)
 	{
 	    char_u *p = TGETSTR(key_names[i], &tp);
 
@@ -7636,25 +7640,25 @@ got_code_from_term(char_u *code, int len)
 # endif
 		may_adjust_color_count(val);
 	    }
-# if 0
-#  ifdef FEAT_TERMGUICOLORS
-	    // when RGB result comes back, it is supported when the result contains an '='
+	    // When RGB result comes back, it is supported when the result contains an '='.
+	    // Direct color uses the same sequence no matter what the RGB value here is,
+	    // so don't check the value.
 	    else if (name[0] == 'R' && name[1] == 'G' && name[2] == 'B' && code[9] == '=')
 	    {
-		int val = atoi((char *)str);
-		// only enable it, if termguicolors hasn't been set yet and
-		// there are 8 bits per color channel
-		if (val == 8 && !p_tgc_set)
-		{
-#   ifdef FEAT_EVAL
-		    ch_log(NULL, "got_code_from_term(RGB): xterm-direct colors detected");
-#   endif
-		    // RGB capability set, enable termguicolors
-		    set_option_value((char_u *)"termguicolors", 1L, NULL, 0);
-		}
-	    }
-#  endif
+# ifdef FEAT_EVAL
+		ch_log(NULL, "got_code_from_term(RGB): xterm-direct colors detected");
 # endif
+		term_props[TPR_RGB].tpr_status = TPR_YES;
+# ifdef FEAT_TERMGUICOLORS
+		int savetgc = p_tgc;
+# endif
+		apply_autocmds(EVENT_TERMRESPONSEALL,
+					(char_u *)"rgb", NULL, FALSE, curbuf);
+# ifdef FEAT_TERMGUICOLORS
+		if (p_tgc != savetgc)
+		    redraw_asap(UPD_CLEAR);
+# endif
+	    }
 	    else
 	    {
 		i = find_term_bykeys(str, NULL);

--- a/src/testdir/test_termcodes.vim
+++ b/src/testdir/test_termcodes.vim
@@ -1720,6 +1720,7 @@ func Test_xx01_term_style_response()
         \ underline_rgb: 'u',
         \ mouse: 's',
         \ kitty: 'u',
+        \ rgb: 'u',
         \ decrqm: 'u'
         \ }, terminalprops())
 
@@ -1756,6 +1757,7 @@ func Test_xx02_iTerm2_response()
         \ underline_rgb: 'u',
         \ mouse: 's',
         \ kitty: 'u',
+        \ rgb: 'u',
         \ decrqm: 'y'
         \ }, terminalprops())
 
@@ -1777,6 +1779,7 @@ func Run_libvterm_konsole_response(code)
         \ underline_rgb: 'u',
         \ mouse: 's',
         \ kitty: 'u',
+        \ rgb: 'u',
         \ decrqm: 'u'
         \ }, terminalprops())
 endfunc
@@ -1821,6 +1824,7 @@ func Test_xx04_Mac_Terminal_response()
         \ underline_rgb: 'y',
         \ mouse: 's',
         \ kitty: 'u',
+        \ rgb: 'u',
         \ decrqm: 'n'
         \ }, terminalprops())
   call assert_equal("\<Esc>[58;2;%lu;%lu;%lum", &t_8u)
@@ -1853,6 +1857,7 @@ func Test_xx05_mintty_response()
         \ underline_rgb: 'y',
         \ mouse: 's',
         \ kitty: 'u',
+        \ rgb: 'u',
         \ decrqm: 'u'
         \ }, terminalprops())
 
@@ -1890,6 +1895,7 @@ func Test_xx06_screen_response()
         \ underline_rgb: 'y',
         \ mouse: 's',
         \ kitty: 'u',
+        \ rgb: 'u',
         \ decrqm: 'n'
         \ }, terminalprops())
 
@@ -1916,6 +1922,7 @@ func Do_check_t_8u_set_reset(set_by_user)
         \ underline_rgb: 'u',
         \ mouse: 's',
         \ kitty: 'u',
+        \ rgb: 'u',
         \ decrqm: 'u'
         \ }, terminalprops())
   call assert_equal(a:set_by_user ? default_value : '', &t_8u)
@@ -1956,6 +1963,7 @@ func Test_xx07_xterm_response()
         \ underline_rgb: 'y',
         \ mouse: 'u',
         \ kitty: 'u',
+        \ rgb: 'u',
         \ decrqm: 'u'
         \ }, terminalprops())
 
@@ -1973,6 +1981,7 @@ func Test_xx07_xterm_response()
         \ underline_rgb: 'u',
         \ mouse: '2',
         \ kitty: 'u',
+        \ rgb: 'u',
         \ decrqm: 'u'
         \ }, terminalprops())
 
@@ -1990,6 +1999,7 @@ func Test_xx07_xterm_response()
         \ underline_rgb: 'u',
         \ mouse: 's',
         \ kitty: 'u',
+        \ rgb: 'u',
         \ decrqm: 'u'
         \ }, terminalprops())
 
@@ -2020,6 +2030,7 @@ func Test_xx08_kitty_response()
         \ underline_rgb: 'y',
         \ mouse: 's',
         \ kitty: 'y',
+        \ rgb: 'u',
         \ decrqm: 'y'
         \ }, terminalprops())
 
@@ -2981,6 +2992,41 @@ func Test_term_response_osc()
   " Test small OSC responses
   call feedkeys("\<Esc>]15;hello world!\x07", 'Lx!')
   call assert_equal("\<Esc>]15;hello world!\x07", v:termosc)
+endfunc
+
+" Test if XTGETTCAP RGB response enables rgb termprop
+func Test_term_response_true_color()
+  " Termresponse is only parsed when t_RV is not empty.
+  set t_RV=x
+  call test_override('term_props', 1)
+
+  " ensure terminalprop rgb is unknown
+  call feedkeys("\<Esc>[>0;0;0c", 'Lx!')
+  call assert_equal('u', terminalprops().rgb)
+
+  let g:got_rgb_resp = 'no'
+  augroup testRespRGB
+    autocmd!
+    autocmd TermResponseAll * if expand('<amatch>') == 'rgb' | let g:got_rgb_resp = 'yes' | endif
+  augroup END
+
+  " Test negative response
+  " also try some out-of-spec formats to make sure 0 or 1 status is checked
+  call feedkeys("\<Esc>P0+r\<Esc>\\", 'Lx!')
+  call feedkeys("\<Esc>P0+r524742\<Esc>\\", 'Lx!')
+  call feedkeys("\<Esc>P0+r524742=38\<Esc>\\", 'Lx!')
+  call assert_equal('u', terminalprops().rgb)
+  call assert_equal('no', g:got_rgb_resp)
+
+  " Test positive response
+  call feedkeys("\<Esc>P1+r524742=38\<Esc>\\", 'Lx!')
+  call assert_equal('y', terminalprops().rgb)
+  call assert_equal('yes', g:got_rgb_resp)
+
+  autocmd! testRespRGB
+
+  set t_RV=
+  call test_override('term_props', 0)
 endfunc
 
 " Test if xOSC key is emitted.


### PR DESCRIPTION
Suggested fix for #16327.

This patch tries to implement a compromise both for users who want automatic termguicolors and users who don't. For users who don't want termguicolors, nothing needs to change. For users who want termguicolors and already added `set termguicolors` to their vimrc, nothing needs to change. For users who want their vimrc to adapt to different kinds of terminals which can and can't handle termguicolors, it's now possible to add this to their vimrc:

```
if str2nr(&t_Co) == 16777216
	set termguicolors
endif

autocmd TermResponseAll * {
	if expand('<amatch>') == 'RGB' && v:termrgbresp == '8'
		set termguicolors
		redraw!
	endif
}
```

(this is vim9script, I didn't check whether the syntax is valid for old vim script)

This script exactly matches the behaviour of #16490 (the original fix for #16327), and additionally runs `redraw!` to fix the bug that the colours only change after the first user action. (I added the same fix to the #if-0-ed out code, for consistency)

It is possible to add this to defaults.vim if this behaviour becomes desirable in the future.