### PR TITLE
redraw: cursor is left in the wrong place with an operator pending

### DIFF
--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -9043,6 +9043,8 @@ redraw_cmd(int clear)
     validate_cursor();
     update_topline();
     update_screen(clear ? UPD_CLEAR : VIsual_active ? UPD_INVERTED : 0);
+    if ((State & MODE_CMDLINE) == 0)
+	setcursor(); // put cursor back where it belongs
     if (need_maketitle)
 	maketitle();
 #if defined(MSWIN) && (!defined(FEAT_GUI_MSWIN) || defined(VIMDLL))

--- a/src/testdir/test_popupwin.vim
+++ b/src/testdir/test_popupwin.vim
@@ -6376,4 +6376,30 @@ func Test_popup_no_filter_at_hit_enter()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_popupwin_close_and_redraw_keeps_cursor()
+  CheckRunVimInTerminal
+
+  let lines =<< trim END
+      call setline(1, repeat(['some text'], 8))
+      call cursor(3, 2)
+      let g:id = popup_atcursor(['a popup'], #{moved: 'any'})
+      func CloseIt()
+        call popup_close(g:id)
+        redraw
+      endfunc
+      autocmd ModeChanged * ++once call CloseIt()
+  END
+  call writefile(lines, 'XtestPopupCursor', 'D')
+  let buf = RunVimInTerminal('-S XtestPopupCursor', #{rows: 10})
+  call WaitForAssert({-> assert_equal([3, 2], term_getcursor(buf)[0:1])})
+
+  " With the operator waiting, nothing after the redraw puts the cursor back.
+  call term_sendkeys(buf, "c")
+  call TermWait(buf, 100)
+  call assert_equal([3, 2], term_getcursor(buf)[0:1])
+
+  call term_sendkeys(buf, "\<Esc>")
+  call StopVimInTerminal(buf)
+endfunc
+
 " vim: shiftwidth=2 sts=2


### PR DESCRIPTION
```
Problem:  With an operator pending, a :redraw from an autocommand or a
          callback leaves the cursor where the drawing ended, so it is
          seen in the wrong place until the operator is finished.  A
          popup closed from such an autocommand shows this.
Solution: Put the cursor back after the screen is updated.  This has to
          happen before RedrawingDisabled is restored, which an
          autocommand may have set, since setcursor() does nothing then.
```