### PR TITLE
fix(ftplugin): jsonc fix commentstring

### DIFF
--- a/runtime/ftplugin/jsonc.vim
+++ b/runtime/ftplugin/jsonc.vim
@@ -6,6 +6,7 @@
 " License:          MIT
 " Last Change:      2021 Nov 22
 "                   2024 May 23 by Riley Bruins <ribru17@gmail.com> ('commentstring')
+"                   2026 Aug 31 by GX <nomail@example.com> ('commentstring')
 
 runtime! ftplugin/json.vim
 
@@ -15,8 +16,9 @@ else
   let b:did_ftplugin_jsonc = 1
 endif
 
-" Set comment (formatting) related options. {{{1
-setlocal commentstring=//\ %s comments=sO:*\ -,mO:*\ \ ,exO:*/,s1:/*,mb:*,ex:*/,://
+" Set comment (formatting) related options.
+setlocal comments=sO:*\ -,mO:*\ \ ,exO:*/,s1:/*,mb:*,ex:*/,://
+setlocal commentstring=//\ %s
 
 " Let Vim know how to disable the plug-in.
 let b:undo_ftplugin = 'setlocal commentstring< comments<'


### PR DESCRIPTION
Commentstring with func `gcc` didn't work for jsconc files.