### PR TITLE
'wildmode' list:full does not show 'wildmenu'

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -10463,6 +10463,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 			doesn't extend the input, the next 'wildmode' part is
 			used.
 	"list"		If multiple matches are found, list all of them.
+			When the same press shows 'wildmenu', the menu takes
+			the place of the list.
 	"lastused"	When completing buffer names, sort them by most
 			recently used (excluding the current buffer).  Only
 			applies to buffer name completion.

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -10463,8 +10463,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 			doesn't extend the input, the next 'wildmode' part is
 			used.
 	"list"		If multiple matches are found, list all of them.
-			When the same press shows 'wildmenu', the menu takes
-			the place of the list.
 	"lastused"	When completing buffer names, sort them by most
 			recently used (excluding the current buffer).  Only
 			applies to buffer name completion.

--- a/src/cmdexpand.c
+++ b/src/cmdexpand.c
@@ -1479,6 +1479,30 @@ showmatches_oneline(
 }
 
 /*
+ * Show the matches in a popup menu, with the first one selected unless
+ * "noselect" is set.
+ */
+    static int
+show_pum_matches(
+	cmdline_info_T	*ccline,
+	expand_T	*xp,
+	char_u		**matches,
+	int		numMatches,
+	int		showtail,
+	int		noselect)
+{
+    int	retval = cmdline_pum_create(ccline, xp, matches, numMatches, showtail);
+
+    if (retval == EXPAND_OK)
+    {
+	compl_selected = noselect ? -1 : 0;
+	pum_clear();
+	cmdline_pum_display();
+    }
+    return retval;
+}
+
+/*
  * Display completion matches.
  * Returns EXPAND_NOTHING when the character that triggered expansion should be
  *   inserted as a normal character.
@@ -1522,17 +1546,8 @@ showmatches(
 
     if (display_wildmenu && !display_list
 	    && vim_strchr(p_wop, WOP_PUM) != NULL)
-    {
-	int retval = cmdline_pum_create(ccline, xp, matches, numMatches,
-		showtail && !cmdline_unchanged);
-	if (retval == EXPAND_OK)
-	{
-	    compl_selected = noselect ? -1 : 0;
-	    pum_clear();
-	    cmdline_pum_display();
-	}
-	return retval;
-    }
+	return show_pum_matches(ccline, xp, matches, numMatches,
+		showtail && !cmdline_unchanged, noselect);
 
     if (display_list)
     {
@@ -1607,6 +1622,18 @@ showmatches(
 	// we redraw the command below the lines that we have just listed
 	// This is a bit tricky, but it saves a lot of screen updating.
 	cmdline_row = msg_row;	// will put it back later
+    }
+
+    // "list" and "full" in the same 'wildmode' phase: the matches are listed
+    // above and shown in the menu as well.
+    if (display_wildmenu && display_list)
+    {
+	if (vim_strchr(p_wop, WOP_PUM) != NULL)
+	    (void)show_pum_matches(ccline, xp, matches, numMatches,
+		    showtail && !cmdline_unchanged, noselect);
+	else
+	    win_redr_status_matches(xp, numMatches, matches,
+		    noselect ? -1 : 0, showtail);
     }
 
     if (xp->xp_numfiles == -1)

--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -1063,7 +1063,9 @@ cmdline_wildchar_complete(
 	    {
 		if (wim_list || (p_wmnu && (wim_full || wim_noselect
 				|| wim_noinsert)))
-		    (void)showmatches(xp, p_wmnu, wim_list,
+		    // The menu stands where the matches would be listed.
+		    (void)showmatches(xp, p_wmnu,
+			    wim_list && !(p_wmnu && wim_full),
 			    p_wmnu ? wim_flags[0] : 0);
 		else
 		    vim_beep(BO_WILD);

--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -1037,8 +1037,10 @@ cmdline_wildchar_complete(
 	    if (wim_longest)
 	    {
 		int found_longest_prefix = (ccline.cmdpos != cmdpos_before);
-		if (wim_list || (p_wmnu && wim_full))
-		    (void)showmatches(xp, p_wmnu, wim_list, WIM_NOSELECT);
+		int show_menu = p_wmnu && wim_full;
+
+		if (wim_list || show_menu)
+		    (void)showmatches(xp, show_menu, wim_list, WIM_NOSELECT);
 		else if (!found_longest_prefix)
 		{
 		    int wim_list_next = (wim_flags[1] & WIM_LIST);
@@ -1051,7 +1053,8 @@ cmdline_wildchar_complete(
 			if (wim_full_next && !wim_noselect_next && !wim_noinsert_next)
 			    nextwild(xp, WILD_NEXT, options, escape);
 			else
-			    (void)showmatches(xp, p_wmnu, wim_list_next,
+			    (void)showmatches(xp, p_wmnu && (wim_noselect_next
+					|| wim_noinsert_next), wim_list_next,
 				    p_wmnu ? wim_flags[1] : 0);
 
 			if (wim_list_next)
@@ -1061,11 +1064,11 @@ cmdline_wildchar_complete(
 	    }
 	    else
 	    {
-		if (wim_list || (p_wmnu && (wim_full || wim_noselect
-				|| wim_noinsert)))
-		    // The menu stands where the matches would be listed.
-		    (void)showmatches(xp, p_wmnu,
-			    wim_list && !(p_wmnu && wim_full),
+		int show_menu = p_wmnu && (wim_full || wim_noselect
+							    || wim_noinsert);
+
+		if (wim_list || show_menu)
+		    (void)showmatches(xp, show_menu, wim_list,
 			    p_wmnu ? wim_flags[0] : 0);
 		else
 		    vim_beep(BO_WILD);
@@ -2196,7 +2199,9 @@ getcmdline_int(
 			    || p_wmnu))
 		{
 		    // Trigger the popup menu when wildoptions=pum
-		    showmatches(&xpc, p_wmnu, wim_flags[wim_index] & WIM_LIST,
+		    int list = wim_flags[wim_index] & WIM_LIST;
+
+		    showmatches(&xpc, p_wmnu && !list, list,
 			    p_wmnu ? wim_flags[0] : 0);
 		}
 		if (nextwild(&xpc, WILD_PREV, 0, firstc != '@') == OK

--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -3346,6 +3346,30 @@ func Test_wildmenu_pum_info_async_update()
   call StopVimInTerminal(buf)
 endfunc
 
+" Test that "list" and "full" in the same 'wildmode' phase show the wildmenu
+func Test_wildmenu_with_list_full()
+  call writefile([], 'XwildA', 'D')
+  call writefile([], 'XwildB', 'D')
+  cnoremap <expr> <F2> wildmenumode()
+  set wildmenu wildmode=list:full
+
+  for wop in ['pum', '']
+    execute 'set wildoptions=' .. wop
+    call feedkeys(":e Xwild\<Tab>\<F2>\<C-B>\"\<CR>", 'xt')
+    call assert_equal('"e XwildA1', @:, 'wildoptions=' .. wop)
+  endfor
+
+  " Without 'wildmenu' the matches are listed as before.
+  set nowildmenu wildoptions=
+  let g:Sline = ''
+  call feedkeys(":e Xwild\<Tab>\<F4>\<F2>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('XwildA  XwildB', g:Sline)
+  call assert_equal('"e XwildA0', @:)
+
+  cunmap <F2>
+  set nowildmenu wildoptions& wildmode&
+endfunc
+
 " Test for wildmenumode() with the cmdline popup menu
 func Test_wildmenumode_with_pum()
   set wildmenu

--- a/src/testdir/test_cmdline.vim
+++ b/src/testdir/test_cmdline.vim
@@ -3346,18 +3346,30 @@ func Test_wildmenu_pum_info_async_update()
   call StopVimInTerminal(buf)
 endfunc
 
-" Test that "list" and "full" in the same 'wildmode' phase show the wildmenu
+" Test that "list" and "full" in the same 'wildmode' phase list the matches
+" and show the wildmenu as well
 func Test_wildmenu_with_list_full()
   call writefile([], 'XwildA', 'D')
   call writefile([], 'XwildB', 'D')
+  func! SaveScreenLineAbove()
+    let g:Sabove = Screenline(&lines - 2)
+    return ''
+  endfunc
   cnoremap <expr> <F2> wildmenumode()
+  cnoremap <expr> <F3> SaveScreenLineAbove()
   set wildmenu wildmode=list:full
 
-  for wop in ['pum', '']
-    execute 'set wildoptions=' .. wop
-    call feedkeys(":e Xwild\<Tab>\<F2>\<C-B>\"\<CR>", 'xt')
-    call assert_equal('"e XwildA1', @:, 'wildoptions=' .. wop)
-  endfor
+  " The matches are listed above the menu.
+  let [g:Sabove, g:Sline] = ['', '']
+  call feedkeys(":e Xwild\<Tab>\<F3>\<F4>\<F2>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"e XwildA1', @:)
+  call assert_equal('XwildA  XwildB', g:Sabove)
+  call assert_equal('XwildA  XwildB', g:Sline)
+
+  " The popup menu is shown over the listed matches.
+  set wildoptions=pum
+  call feedkeys(":e Xwild\<Tab>\<F2>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"e XwildA1', @:)
 
   " Without 'wildmenu' the matches are listed as before.
   set nowildmenu wildoptions=
@@ -3367,6 +3379,9 @@ func Test_wildmenu_with_list_full()
   call assert_equal('"e XwildA0', @:)
 
   cunmap <F2>
+  cunmap <F3>
+  delfunc SaveScreenLineAbove
+  unlet g:Sabove
   set nowildmenu wildoptions& wildmode&
 endfunc
 


### PR DESCRIPTION
```
Problem:  With 'wildmode' set to list:full the matches are listed but the
          wildmenu is not shown, although it is "full" that starts
          wildmenu mode (zeertzjq).
Solution: List the matches and show the menu, as the two behaviors in
          the same phase ask for.  The menu is left to the phases that
          ask for it, so that "list" on its own still only lists.
```

fixes: #21196