### PR TITLE
Change print font to Courier instead of Courier New for Pango hardcopy

### DIFF
--- a/runtime/doc/print.txt
+++ b/runtime/doc/print.txt
@@ -200,7 +200,7 @@ font may be named, and the special "guifont=*" syntax is not available.
 
 In the Win32 GUI version this specifies a font name with its extra attributes,
 as with the 'guifont' option.  When |+pango| is enabled, the format is the
-same as 'guifont' for the GTK GUI (e.g. "Courier New 10").
+same as 'guifont' for the GTK GUI (e.g. "Courier 10").
 
 For other systems, only ":h11" is recognized, where "11" is the point size of
 the font.  When omitted, the point size is 10.

--- a/src/hardcopy_pango.c
+++ b/src/hardcopy_pango.c
@@ -375,8 +375,7 @@ mch_print_init(
 	descent = pango_font_metrics_get_descent(metrics);
 
 	pctx.char_ascent = (double)ascent / PANGO_SCALE;
-	pctx.char_height = (double)(ascent + descent
-		+ (PANGO_SCALE * 15.0) / 16.0) / PANGO_SCALE;
+	pctx.char_height = (double)(ascent + descent) / PANGO_SCALE;
 
 	pctx.line_spacing = (double)
 	    (pango_font_metrics_get_height(metrics) - (ascent + descent))

--- a/src/optiondefs.h
+++ b/src/optiondefs.h
@@ -2037,7 +2037,7 @@ static struct vimoption options[] =
 # ifdef MSWIN
 				(char_u *)"Courier_New:h10",
 # elif defined(FEAT_PRINT_PANGO)
-				(char_u *)"Courier New 10",
+				(char_u *)"Courier 10",
 # else
 				(char_u *)"courier",
 # endif


### PR DESCRIPTION
Fixes #21203

Also removes a spurious increment to the char height, I'm guessing that was taken from the GTK GUI (which does not apply here). This caused a slight spacing between lines even with the Courier font.