### PR TITLE
Scrolling recomputes the height of every visible line

### DIFF
--- a/src/move.c
+++ b/src/move.c
@@ -85,6 +85,8 @@ comp_botline(win_T *wp)
     int		n;
     linenr_T	lnum;
     int		done;
+    int		i = 0;
+    int		use_cache;
 #ifdef FEAT_FOLDING
     linenr_T    last;
     int		folded;
@@ -95,6 +97,26 @@ comp_botline(win_T *wp)
      * Otherwise have to start at w_topline.
      */
     check_cursor_moved(wp);
+
+    // The wl_size values computed for the previous redraw give the height of
+    // each displayed line.  When the display is up-to-date they are equal to
+    // what plines_correct_topline() would compute, so reuse them to avoid
+    // walking every line to measure its width on each scroll (like curs_rows()
+    // does).  Only trust them when actually redrawing, the buffer was not
+    // changed, no "$" is displayed for a change and w_lines[] starts at or
+    // above w_topline.  With 'smoothscroll' or in diff mode wl_size includes
+    // the skipped rows of the top line and the filler lines, so it does not
+    // match plines_correct_topline(); do not use the cache then.
+    use_cache = redrawing()
+		    && !wp->w_buffer->b_mod_set
+		    && dollar_vcol == -1
+		    && wp->w_skipcol == 0
+#ifdef FEAT_DIFF
+		    && !wp->w_p_diff
+#endif
+		    && wp->w_lines_valid > 0
+		    && wp->w_lines[0].wl_lnum <= wp->w_topline;
+
     if (wp->w_valid & VALID_CROW)
     {
 	lnum = wp->w_cursor.lnum;
@@ -106,20 +128,51 @@ comp_botline(win_T *wp)
 	done = 0;
     }
 
-    for ( ; lnum <= wp->w_buffer->b_ml.ml_line_count; ++lnum)
+    // Find the w_lines[] entry for the starting line.
+    if (use_cache)
+	while (i < wp->w_lines_valid && wp->w_lines[i].wl_lnum < lnum)
+	    ++i;
+
+    for ( ; lnum <= wp->w_buffer->b_ml.ml_line_count; ++i)
     {
+	int	valid = FALSE;
+
 #ifdef FEAT_FOLDING
 	last = lnum;
 	folded = FALSE;
-	if (hasFoldingWin(wp, lnum, NULL, &last, TRUE, NULL))
+#endif
+	// Try to use the size from the previous redraw.
+	if (use_cache && i < wp->w_lines_valid)
 	{
-	    n = 1;
-	    folded = TRUE;
+	    if (wp->w_lines[i].wl_lnum < lnum || !wp->w_lines[i].wl_valid)
+		continue;		// skip changed or deleted lines
+	    if (wp->w_lines[i].wl_lnum == lnum)
+		valid = TRUE;
+	    else // wl_lnum > lnum
+		--i;			// hold at inserted lines
+	}
+
+	// The cache is not used with 'smoothscroll' or in diff mode, so here
+	// wl_size holds the same height as plines_correct_topline().
+	if (valid)
+	{
+	    n = wp->w_lines[i].wl_size;
+#ifdef FEAT_FOLDING
+	    folded = wp->w_lines[i].wl_folded;
+	    last = wp->w_lines[i].wl_lastlnum;
+#endif
 	}
 	else
-#endif
 	{
-	    n = plines_correct_topline(wp, lnum, TRUE);
+#ifdef FEAT_FOLDING
+	    if (hasFoldingWin(wp, lnum, NULL, &last, TRUE, NULL))
+	    {
+		n = 1;
+		folded = TRUE;
+	    }
+	    else
+#endif
+		n = plines_correct_topline(wp, lnum, TRUE);
 	}
 	if (
 #ifdef FEAT_FOLDING
@@ -141,7 +194,9 @@ comp_botline(win_T *wp)
 	    break;
 	done += n;
 #ifdef FEAT_FOLDING
-	lnum = last;
+	lnum = last + 1;
+#else
+	++lnum;
 #endif
     }
 

--- a/src/testdir/test_scroll_opt.vim
+++ b/src/testdir/test_scroll_opt.vim
@@ -2289,4 +2289,41 @@ func Test_smoothscroll_textoff_showbreak()
   call StopVimInTerminal(buf)
 endfunc
 
+" comp_botline() reuses the line heights computed for the previous redraw.
+" Changing an option that affects the displayed height of a line must
+" invalidate that cache.  Check that scrolling after such a change gives the
+" same result as setting the option before scrolling.
+func Test_botline_cache_invalidated_on_option_change()
+  " Resizing the height of a vertically split window pushes the reclaimed
+  " lines into 'cmdheight'; save and restore it so the following tests run
+  " with a full-height screen.
+  let save_cmdheight = &cmdheight
+  vnew
+  vertical resize 40
+  resize 10
+  setlocal scrolloff=0
+  let lines = map(range(1, 400), {_, v -> printf('%4d ', v) .. repeat('word ', 30)})
+
+  for opt in ['number', 'breakindent', 'foldcolumn=4', 'list', 'nowrap']
+    " Reference: option set before scrolling, so no stale cache is possible.
+    call setline(1, lines)
+    setlocal wrap nonumber nobreakindent nolist foldcolumn=0
+    exe 'setlocal ' .. opt
+    normal! 120Gzt
+    redraw
+    let expected = getwininfo(win_getid())[0].botline
+
+    " Same option applied after scrolling, when the cache is populated.
+    setlocal wrap nonumber nobreakindent nolist foldcolumn=0
+    normal! 120Gzt
+    redraw
+    exe 'setlocal ' .. opt
+    redraw
+    call assert_equal(expected, getwininfo(win_getid())[0].botline, 'setlocal ' .. opt)
+  endfor
+
+  bwipe!
+  let &cmdheight = save_cmdheight
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  When scrolling, comp_botline() recomputes the display height of
          every line in the window on each cursor movement, which is
          slower than necessary.
Solution: Reuse the line heights computed for the previous redraw, stored
          in w_lines[], the same way curs_rows() already does.

comp_botline() computes w_botline by calling plines_correct_topline() for every line from the top (or cursor) to the bottom of the window. This walks every character of every line to measure its display width, and it runs on every scroll. When the display is up to date the heights are already known in w_lines[].wl_size and are equal to what plines() would return, so they can be reused, avoiding the per-line width computation. The cache is only trusted when redrawing, the buffer was not changed, no "$" is displayed and w_lines[] starts at or above w_topline; otherwise the previous computation is used.

Benchmark: 1500 real keystrokes sent to a terminal Vim scrolling a 60000-line syntax-highlighted C file in a 120x40 window. Instructions retired were measured with "perf stat", with the constant startup cost subtracted; run-to-run variation was under 0.01%.

                             instructions per key
    command                 baseline    patched   change
    j       (line down)       252883     117800    -53%
    CTRL-E  (view down)       210580     114017    -46%
    V then j  (visual)        320142     184959    -42%
    CTRL-D  (half page)       634489     585040     -8%
    CTRL-F  (full page)      1179034    1173068     -1%
    k       (line up)           4289       4289      0%

The same test without syntax highlighting drops "j" from 217149 to 116598 instructions per key (-46%), and on a file of long wrapped lines from 374952 to 175579 (-53%).

The win scales with how much of the window is reused: a line- or view-scroll keeps all but one line, a half page keeps half, and a full page or an upward scroll reuse nothing, so those are unchanged.