### PR TITLE
runtime(misc): Use correct terminal feature test in ftplugins

### DIFF
--- a/runtime/ftplugin/c.vim
+++ b/runtime/ftplugin/c.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin file
 " Language:	C
 " Maintainer:	The Vim Project <https://github.com/vim/vim>
-" Last Change:	2026 Feb 3
+" Last Change:	2026 Sep 1
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Only do this when not done yet for this buffer
@@ -41,7 +41,7 @@ if has("vms")
 endif
 
 " Use terminal window for gui
-if has('gui_running') && exists(':terminal') == 2 && executable("man")
+if has('gui_running') && has('terminal') && executable("man")
   setlocal keywordprg=:CKeywordPrg
 
   command! -buffer -nargs=1 -count CKeywordPrg call s:CKeywordPrg(<q-args>, <count>)

--- a/runtime/ftplugin/gpg.vim
+++ b/runtime/ftplugin/gpg.vim
@@ -2,7 +2,7 @@
 " Language:             gpg(1) configuration file
 " Maintainer:           This runtime file is looking for a new maintainer.
 " Previous Maintainer:  Nikolai Weibull <now@bitwi.se>
-" Latest Revision:      2025-07-22 (use :hor term #17822)
+" Latest Revision:      2026 Sep 01
 
 if exists("b:did_ftplugin")
   finish
@@ -16,7 +16,7 @@ let b:undo_ftplugin = "setl com< cms< fo<"
 
 setlocal comments=:# commentstring=#\ %s formatoptions-=t formatoptions+=croql
 
-if has('unix') && executable('less') && exists(':terminal') == 2
+if has('unix') && executable('less') && has('terminal')
   command -buffer -nargs=1 GpgKeywordPrg
         \ silent exe ':hor term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s+--' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . 'gpg'
   setlocal iskeyword+=-

--- a/runtime/ftplugin/modconf.vim
+++ b/runtime/ftplugin/modconf.vim
@@ -2,7 +2,7 @@
 " Language:             modules.conf(5) configuration file
 " Maintainer:           This runtime file is looking for a new maintainer.
 " Previous Maintainer:  Nikolai Weibull <now@bitwi.se>
-" Latest Revision:      2025-07-22 (use :hor term #17822)
+" Latest Revision:      2026 Sep 01
 
 if exists("b:did_ftplugin")
   finish
@@ -17,7 +17,7 @@ let b:undo_ftplugin = "setl com< cms< inc< fo<"
 setlocal comments=:# commentstring=#\ %s include=^\\s*include
 setlocal formatoptions-=t formatoptions+=croql
 
-if has('unix') && executable('less') && exists(':terminal') == 2
+if has('unix') && executable('less') && has('terminal')
   command -buffer -nargs=1 ModconfKeywordPrg
         \ silent exe ':hor term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s{,8}' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . 'modprobe.d'
   setlocal iskeyword+=-

--- a/runtime/ftplugin/muttrc.vim
+++ b/runtime/ftplugin/muttrc.vim
@@ -2,7 +2,7 @@
 " Language:             mutt RC File
 " Maintainer:           This runtime file is looking for a new maintainer.
 " Previous Maintainer:  Nikolai Weibull <now@bitwi.se>
-" Latest Revision:      2025-07-22 (use :hor term #17822)
+" Latest Revision:      2026 Sep 01
 
 if exists("b:did_ftplugin")
   finish
@@ -19,7 +19,7 @@ setlocal formatoptions-=t formatoptions+=croql
 
 let &l:include = '^\s*source\>'
 
-if has('unix') && executable('less') && exists(':terminal') == 2
+if has('unix') && executable('less') && has('terminal')
   command -buffer -nargs=1 MuttrcKeywordPrg
         \ silent exe 'hor term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s+' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . 'muttrc'
   setlocal iskeyword+=-

--- a/runtime/ftplugin/ps1.vim
+++ b/runtime/ftplugin/ps1.vim
@@ -7,6 +7,7 @@
 "              2024 Sep 19 by Konfekt (simplify keywordprg #15696)
 "              2025 Jul 22 by phanium (use :hor term #17822)
 "              2026 Jul 10 by Vim Project (quote K argument, prevent command injection)
+"              2026 Sep 01 by Vim Project (use correct terminal feature test)
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin") | finish | endif
@@ -52,7 +53,7 @@ elseif executable('powershell.exe') | let s:pwsh_cmd = 'powershell.exe'
 endif
 
 if exists('s:pwsh_cmd')
-  if exists(':terminal') == 2
+  if exists('*term_start')
     command! -buffer -nargs=1 GetHelp call term_start([s:pwsh_cmd, '-NoLogo', '-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'RemoteSigned', '-Command', "Get-Help -Full '" . substitute(<q-args>, "'", "''", 'g') . "'" . (executable('less') ? ' | less' : '')])
   else
     command! -buffer -nargs=1 GetHelp echo system([s:pwsh_cmd, '-NoLogo', '-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'RemoteSigned', '-Command', "Get-Help -Full '" . substitute(<q-args>, "'", "''", 'g') . "'"])

--- a/runtime/ftplugin/readline.vim
+++ b/runtime/ftplugin/readline.vim
@@ -5,6 +5,7 @@
 " Last Change:		2024 Sep 19 (simplify keywordprg #15696)
 " 2024 Jul 22 by Vim project (use :hor term #17822)
 " 2026 May 04 by Vim Project: fix typo
+" 2026 Sep 01 by Vim Project: use correct terminal feature test
 
 if exists("b:did_ftplugin")
   finish
@@ -36,7 +37,7 @@ if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
   let b:undo_ftplugin ..= " | unlet! b:browsefilter"
 endif
 
-if has('unix') && executable('less') && exists(':terminal') == 2
+if has('unix') && executable('less') && has('terminal')
   command -buffer -nargs=1 ReadlineKeywordPrg
         \ silent exe 'hor term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s+' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . '3 readline'
   setlocal iskeyword+=-

--- a/runtime/ftplugin/sh.vim
+++ b/runtime/ftplugin/sh.vim
@@ -9,6 +9,7 @@
 "			2025 Mar 09 by Vim Project (set b:match_skip)
 "			2025 Jul 22 by phanium (use :hor term #17822)
 "			2026 Jul 10 by Vim Project (pass K argument as a list, prevent shell injection)
+"			2026 Sep 01 by Vim Project (use correct terminal feature test)
 
 if exists("b:did_ftplugin")
   finish
@@ -54,7 +55,7 @@ let s:is_bash = get(b:, "is_bash", get(g:, "is_bash", 0))
 let s:is_kornshell = get(b:, "is_kornshell", get(g:, "is_kornshell", 0))
 
 if s:is_bash
-  if exists(':terminal') == 2
+  if exists('*term_start')
     command! -buffer -nargs=1 ShKeywordPrg call term_start(['bash', '-c', 'help "$1" 2>/dev/null || man "$1"', '--', <q-args>])
   else
     command! -buffer -nargs=1 ShKeywordPrg echo system(['bash', '-c', 'help "$1" 2>/dev/null || MANPAGER= man "$1"', '--', <q-args>])

--- a/runtime/ftplugin/sshconfig.vim
+++ b/runtime/ftplugin/sshconfig.vim
@@ -2,7 +2,7 @@
 " Language:	OpenSSH client configuration file
 " Maintainer:	This runtime file is looking for a new maintainer.
 " Previous Maintainer:	Nikolai Weibull <now@bitwi.se>
-" Latest Revision:	2026-03-11 (`less -I`)
+" Latest Revision:	2026 Sep 01
 
 if exists("b:did_ftplugin")
   finish
@@ -15,7 +15,7 @@ set cpo&vim
 setlocal comments=:# commentstring=#\ %s formatoptions-=t formatoptions+=croql
 let b:undo_ftplugin = 'setlocal com< cms< fo<'
 
-if has('unix') && executable('less') && exists(':terminal') == 2
+if has('unix') && executable('less') && has('terminal')
   command -buffer -nargs=1 SshconfigKeywordPrg
         \ silent exe 'hor term ' . 'env LESS= MANPAGER="less -I --pattern=''' . escape('^\s+' . <q-args> . '$', '\') . ''' --hilite-search" man ' . 'ssh_config'
   setlocal iskeyword+=-

--- a/runtime/ftplugin/sudoers.vim
+++ b/runtime/ftplugin/sudoers.vim
@@ -2,7 +2,7 @@
 " Language:	sudoers(5) configuration files
 " Maintainer:	This runtime file is looking for a new maintainer.
 " Previous Maintainer:	Nikolai Weibull <now@bitwi.se>
-" Latest Revision:	2025-07-22 (use :hor term #17822)
+" Latest Revision:	2026 Sep 01
 
 if exists("b:did_ftplugin")
   finish
@@ -16,7 +16,7 @@ let b:undo_ftplugin = "setl com< cms< fo<"
 
 setlocal comments=:# commentstring=#\ %s formatoptions-=t formatoptions+=croql
 
-if has('unix') && executable('less') && exists(':terminal') == 2
+if has('unix') && executable('less') && has('terminal')
   command -buffer -nargs=1 SudoersKeywordPrg
         \ silent exe ':hor term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('\b' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . 'sudoers'
   setlocal keywordprg=:SudoersKeywordPrg

--- a/runtime/ftplugin/systemd.vim
+++ b/runtime/ftplugin/systemd.vim
@@ -2,6 +2,7 @@
 " Language:			systemd.unit(5)
 " Keyword Lookup Support:	Enno Nagel <enno.nagel+vim@gmail.com>
 " Latest Revision:		2024-10-02 (small fixes to &keywordprg)
+" 2026 Sep 01 by Vim Project: use correct terminal feature test
 
 if exists("b:did_ftplugin")
   finish
@@ -9,7 +10,7 @@ endif
 " Looks a lot like dosini files.
 runtime! ftplugin/dosini.vim
 
-if has('unix') && executable('less') && exists(':terminal') == 2
+if has('unix') && executable('less') && has('terminal')
   command! -buffer -nargs=1 SystemdKeywordPrg silent exe 'term ++close ' KeywordLookup_systemd(<q-args>)
   silent! function KeywordLookup_systemd(keyword) abort
     let matches = matchlist(getline(search('\v^\s*\[\s*.+\s*\]\s*$', 'nbWz')), '\v^\s*\[\s*(\k+).*\]\s*$')

--- a/runtime/ftplugin/udevrules.vim
+++ b/runtime/ftplugin/udevrules.vim
@@ -2,7 +2,7 @@
 " Language:	udev(8) rules file
 " Maintainer:	This runtime file is looking for a new maintainer.
 " Previous Maintainer:	Nikolai Weibull <now@bitwi.se>
-" Latest Revision:	2025-07-22 (use :hor term #17822)
+" Latest Revision:	2026 Sep 01
 
 if exists("b:did_ftplugin")
   finish
@@ -16,7 +16,7 @@ let b:undo_ftplugin = "setl com< cms< fo<"
 
 setlocal comments=:# commentstring=#\ %s formatoptions-=t formatoptions+=croql
 
-if has('unix') && executable('less') && exists(':terminal') == 2
+if has('unix') && executable('less') && has('terminal')
   command -buffer -nargs=1 UdevrulesKeywordPrg
         \ silent exe ':hor term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s{,8}' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . 'udev'
   setlocal iskeyword+=-

--- a/runtime/ftplugin/zsh.vim
+++ b/runtime/ftplugin/zsh.vim
@@ -2,7 +2,7 @@
 " Language:             Zsh shell script
 " Maintainer:           Christian Brabandt <cb@256bit.org>
 " Previous Maintainer:  Nikolai Weibull <now@bitwi.se>
-" Latest Revision:      2026 Jul 23
+" Latest Revision:      2026 Sep 01
 " License:              Vim (see :h license)
 " Repository:           https://github.com/chrisbra/vim-zsh
 
@@ -24,7 +24,7 @@ if get(g:, 'zsh_fold_enable', 0)
 endif
 
 if executable('zsh') && &shell !~# '/\%(nologin\|false\)$'
-  if exists(':terminal') == 2
+  if exists('*term_start')
     command! -buffer -nargs=1 ZshKeywordPrg call term_start(['zsh', '-c', 'autoload -Uz run-help; run-help "$1"', '--', <q-args>])
   elseif has("patch-9.2.0250")
     command! -buffer -nargs=1 ZshKeywordPrg echo system(['zsh', '-c', 'autoload -Uz run-help; MANPAGER= run-help "$1" 2>/dev/null', '--', <q-args>])


### PR DESCRIPTION
Problem:  The current test 'exists(':terminal') == 2' is valid even in
          Vim builds that have the terminal not included (e.g. normal
          feature builds) and thus the K key would cause an error:
          "E319: Sorry, the command is not available in this version" or
          "E117: Unknown function: term_start()"
Solution: Change the terminal feature test to "has('terminal')" to
          properly detect Vims without the terminal feature, while at
          it, change the Last Change date to the preferred style for Vim
          runtime files.

fyi @dkearns @Konfekt 