### PR TITLE
getregionpos() is slow when only the region bounds are needed

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -1,4 +1,4 @@
-*builtin.txt*	For Vim version 9.2.  Last change: 2026 Sep 01
+*builtin.txt*	For Vim version 9.2.  Last change: 2026 Sep 02
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -5250,6 +5250,31 @@ getregionpos({pos1}, {pos2} [, {opts}])			*getregionpos()*
 					beyond the end of a line, a "col"
 					value of 0 is used for both positions.
 					(default: |FALSE|)
+
+			bounds		If |TRUE|, return only the outer
+					bounds of the region as a single
+					pair: >
+						[[{start_pos}, {end_pos}]]
+<					{start_pos} is the start position on
+					the first line of the region and
+					{end_pos} the end position on its
+					last line.  The lines in between are
+					not visited, which is much faster for
+					a large region.
+					(default: |FALSE|)
+
+		Using "bounds" with the same {opts} is equivalent to taking
+		the outer positions of the full result: >
+			let full = getregionpos(pos1, pos2, opts)
+			let bounds = [[full[0][0], full[-1][1]]]
+<		When the full result is empty, e.g. because {pos1} and {pos2}
+		are in different buffers, the result is empty as well.
+		Note that the two positions then come from different lines, so
+		they describe a diagonal of the region and not its shape.  For
+		a blockwise region they are the start of the first line and
+		the end of the last line, not the corners of the block.
+		Likewise, when the first line is empty and "eol" is |FALSE|,
+		{start_pos} has a "col" of 0 while {end_pos} may not.
 
 		Can also be used as a |method|: >
 			getpos('.')->getregionpos(getpos("'a"))

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -6293,6 +6293,111 @@ add_regionpos_range(typval_T *rettv, pos_T p1, pos_T p2)
 }
 
 /*
+ * Compute the positions of the region segment on line "lnum".
+ * "ret_p1" is set to the start position of the segment and "ret_p2" to its
+ * end position.
+ */
+    static void
+getregionpos_line(
+    linenr_T	lnum,
+    pos_T	p1,
+    pos_T	p2,
+    int		inclusive,
+    int		region_type,
+    oparg_T	*oap,
+    int		allow_eol,
+    pos_T	*ret_p1,
+    pos_T	*ret_p2)
+{
+    char_u	*line = ml_get(lnum);
+    colnr_T	line_len = ml_get_len(lnum);
+
+    if (region_type == MLINE)
+    {
+	ret_p1->col = 1;
+	ret_p1->coladd = 0;
+	ret_p2->col = MAXCOL;
+	ret_p2->coladd = 0;
+    }
+    else
+    {
+	struct block_def	bd;
+
+	if (region_type == MBLOCK)
+	    block_prep(oap, &bd, lnum, FALSE);
+	else
+	    charwise_block_prep(p1, p2, &bd, lnum, inclusive);
+
+	if (bd.is_oneChar)  // selection entirely inside one char
+	{
+	    if (region_type == MBLOCK)
+	    {
+		ret_p1->col = mb_prevptr(line, bd.textstart) - line + 1;
+		ret_p1->coladd = bd.start_char_vcols
+					   - (bd.start_vcol - oap->start_vcol);
+	    }
+	    else
+	    {
+		ret_p1->col = p1.col + 1;
+		ret_p1->coladd = p1.coladd;
+	    }
+	}
+	else if (region_type == MBLOCK && oap->start_vcol > bd.start_vcol)
+	{
+	    // blockwise selection entirely beyond end of line
+	    ret_p1->col = MAXCOL;
+	    ret_p1->coladd = oap->start_vcol - bd.start_vcol;
+	    bd.is_oneChar = TRUE;
+	}
+	else if (bd.startspaces > 0)
+	{
+	    ret_p1->col = mb_prevptr(line, bd.textstart) - line + 1;
+	    ret_p1->coladd = bd.start_char_vcols - bd.startspaces;
+	}
+	else
+	{
+	    ret_p1->col = bd.textcol + 1;
+	    ret_p1->coladd = 0;
+	}
+
+	if (bd.is_oneChar)  // selection entirely inside one char
+	{
+	    ret_p2->col = ret_p1->col;
+	    ret_p2->coladd = ret_p1->coladd + bd.startspaces + bd.endspaces;
+	}
+	else if (bd.endspaces > 0)
+	{
+	    ret_p2->col = bd.textcol + bd.textlen + 1;
+	    ret_p2->coladd = bd.endspaces;
+	}
+	else
+	{
+	    ret_p2->col = bd.textcol + bd.textlen;
+	    ret_p2->coladd = 0;
+	}
+    }
+
+    if (!allow_eol && ret_p1->col > line_len)
+    {
+	ret_p1->col = 0;
+	ret_p1->coladd = 0;
+    }
+    else if (ret_p1->col > line_len + 1)
+	ret_p1->col = line_len + 1;
+
+    if (!allow_eol && ret_p2->col > line_len)
+    {
+	ret_p2->col = ret_p1->col == 0 ? 0 : line_len;
+	ret_p2->coladd = 0;
+    }
+    else if (ret_p2->col > line_len + 1)
+	ret_p2->col = line_len + 1;
+
+    ret_p1->lnum = lnum;
+    ret_p2->lnum = lnum;
+}
+
+/*
  * "getregionpos()" function
  */
     static void
@@ -6320,93 +6425,10 @@ f_getregionpos(typval_T *argvars, typval_T *rettv)
 
     for (lnum = p1.lnum; lnum <= p2.lnum; lnum++)
     {
-	pos_T		ret_p1, ret_p2;
-	char_u		*line = ml_get(lnum);
-	colnr_T		line_len = ml_get_len(lnum);
+	pos_T	ret_p1, ret_p2;
 
-	if (region_type == MLINE)
-	{
-	    ret_p1.col = 1;
-	    ret_p1.coladd = 0;
-	    ret_p2.col = MAXCOL;
-	    ret_p2.coladd = 0;
-	}
-	else
-	{
-	    struct block_def	bd;
-
-	    if (region_type == MBLOCK)
-		block_prep(&oa, &bd, lnum, FALSE);
-	    else
-		charwise_block_prep(p1, p2, &bd, lnum, inclusive);
-
-	    if (bd.is_oneChar)  // selection entirely inside one char
-	    {
-		if (region_type == MBLOCK)
-		{
-		    ret_p1.col = mb_prevptr(line, bd.textstart) - line + 1;
-		    ret_p1.coladd = bd.start_char_vcols
-					     - (bd.start_vcol - oa.start_vcol);
-		}
-		else
-		{
-		    ret_p1.col = p1.col + 1;
-		    ret_p1.coladd = p1.coladd;
-		}
-	    }
-	    else if (region_type == MBLOCK && oa.start_vcol > bd.start_vcol)
-	    {
-		// blockwise selection entirely beyond end of line
-		ret_p1.col = MAXCOL;
-		ret_p1.coladd = oa.start_vcol - bd.start_vcol;
-		bd.is_oneChar = TRUE;
-	    }
-	    else if (bd.startspaces > 0)
-	    {
-		ret_p1.col = mb_prevptr(line, bd.textstart) - line + 1;
-		ret_p1.coladd = bd.start_char_vcols - bd.startspaces;
-	    }
-	    else
-	    {
-		ret_p1.col = bd.textcol + 1;
-		ret_p1.coladd = 0;
-	    }
-
-	    if (bd.is_oneChar)  // selection entirely inside one char
-	    {
-		ret_p2.col = ret_p1.col;
-		ret_p2.coladd = ret_p1.coladd + bd.startspaces + bd.endspaces;
-	    }
-	    else if (bd.endspaces > 0)
-	    {
-		ret_p2.col = bd.textcol + bd.textlen + 1;
-		ret_p2.coladd = bd.endspaces;
-	    }
-	    else
-	    {
-		ret_p2.col = bd.textcol + bd.textlen;
-		ret_p2.coladd = 0;
-	    }
-	}
-
-	if (!allow_eol && ret_p1.col > line_len)
-	{
-	    ret_p1.col = 0;
-	    ret_p1.coladd = 0;
-	}
-	else if (ret_p1.col > line_len + 1)
-	    ret_p1.col = line_len + 1;
-
-	if (!allow_eol && ret_p2.col > line_len)
-	{
-	    ret_p2.col = ret_p1.col == 0 ? 0 : line_len;
-	    ret_p2.coladd = 0;
-	}
-	else if (ret_p2.col > line_len + 1)
-	    ret_p2.col = line_len + 1;
-
-	ret_p1.lnum = lnum;
-	ret_p2.lnum = lnum;
+	getregionpos_line(lnum, p1, p2, inclusive, region_type, &oa,
+					      allow_eol, &ret_p1, &ret_p2);
 	add_regionpos_range(rettv, ret_p1, ret_p2);
     }
 

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -6407,6 +6407,7 @@ f_getregionpos(typval_T *argvars, typval_T *rettv)
     int		inclusive = TRUE;
     int		region_type = -1;
     int		allow_eol = FALSE;
+    int		bounds_only = FALSE;
     oparg_T	oa;
     int		lnum;
 
@@ -6421,15 +6422,38 @@ f_getregionpos(typval_T *argvars, typval_T *rettv)
 	return;
 
     if (argvars[2].v_type == VAR_DICT)
-	allow_eol = dict_get_bool(argvars[2].vval.v_dict, "eol", FALSE);
-
-    for (lnum = p1.lnum; lnum <= p2.lnum; lnum++)
     {
-	pos_T	ret_p1, ret_p2;
+	allow_eol = dict_get_bool(argvars[2].vval.v_dict, "eol", FALSE);
+	bounds_only = dict_get_bool(argvars[2].vval.v_dict, "bounds", FALSE);
+    }
 
-	getregionpos_line(lnum, p1, p2, inclusive, region_type, &oa,
+    if (bounds_only)
+    {
+	// Only the outer bounds of the region are wanted, so the lines in
+	// between do not have to be visited.
+	pos_T	start_pos, end_pos;
+
+	getregionpos_line(p1.lnum, p1, p2, inclusive, region_type, &oa,
+					   allow_eol, &start_pos, &end_pos);
+	if (p2.lnum != p1.lnum)
+	{
+	    pos_T	unused;
+
+	    getregionpos_line(p2.lnum, p1, p2, inclusive, region_type, &oa,
+					      allow_eol, &unused, &end_pos);
+	}
+	add_regionpos_range(rettv, start_pos, end_pos);
+    }
+    else
+    {
+	for (lnum = p1.lnum; lnum <= p2.lnum; lnum++)
+	{
+	    pos_T	ret_p1, ret_p2;
+
+	    getregionpos_line(lnum, p1, p2, inclusive, region_type, &oa,
 					      allow_eol, &ret_p1, &ret_p2);
-	add_regionpos_range(rettv, ret_p1, ret_p2);
+	    add_regionpos_range(rettv, ret_p1, ret_p2);
+	}
     }
 
     // getregionpos() may change curbuf and virtual_op

--- a/src/testdir/test_visual.vim
+++ b/src/testdir/test_visual.vim
@@ -2692,6 +2692,107 @@ func Test_visual_getregion()
   call v9.CheckLegacyAndVim9Success(lines)
 endfunc
 
+" Test the "bounds" option of getregionpos(), which returns only the outer
+" endpoints of the region as a single pair.
+func Test_visual_getregionpos_bounds()
+  new
+  call setline(1, [
+        \ 'one two',
+        \ '',
+        \ "a\tb\tc",
+        \ 'ábĉdé',
+        \ "e\u0301x\u0301",
+        \ "\U0001f1e6\u00ab\U0001f1e7\u00ab\U0001f1e8",
+        \ 'last line',
+        \ ])
+  let b = bufnr('%')
+
+  " The pair is the start on the first line and the end on the last line.
+  call assert_equal([[[b, 1, 5, 0], [b, 3, 3, 0]]],
+        \ getregionpos([0, 1, 5, 0], [0, 3, 3, 0], #{bounds: v:true}))
+  call assert_equal([[[b, 1, 1, 0], [b, 3, 5, 0]]],
+        \ getregionpos([0, 1, 5, 0], [0, 3, 3, 0],
+        \              #{type: 'V', bounds: v:true}))
+
+  " For a blockwise region that is a diagonal of the block, not its corners.
+  call assert_equal([[[b, 1, 3, 0], [b, 3, 5, 0]]],
+        \ getregionpos([0, 1, 3, 0], [0, 3, 5, 0],
+        \              #{type: "\<C-v>", bounds: v:true}))
+  call assert_equal([[[b, 1, 3, 0], [b, 3, 2, 5]]],
+        \ getregionpos([0, 1, 3, 0], [0, 3, 5, 0],
+        \              #{type: "\<C-v>4", bounds: v:true}))
+
+  " When the first line is empty and "eol" is false its "col" is 0, while the
+  " "col" of the end position is not.
+  call assert_equal([[[b, 2, 0, 0], [b, 4, 5, 0]]],
+        \ getregionpos([0, 2, 1, 0], [0, 4, 5, 0], #{bounds: v:true}))
+  call assert_equal([[[b, 2, 1, 0], [b, 4, 5, 0]]],
+        \ getregionpos([0, 2, 1, 0], [0, 4, 5, 0],
+        \              #{eol: v:true, bounds: v:true}))
+
+  " Region within one line, also with the positions reversed.
+  call assert_equal([[[b, 4, 3, 0], [b, 4, 8, 0]]],
+        \ getregionpos([0, 4, 3, 0], [0, 4, 7, 0], #{bounds: v:true}))
+  call assert_equal([[[b, 4, 3, 0], [b, 4, 8, 0]]],
+        \ getregionpos([0, 4, 7, 0], [0, 4, 3, 0], #{bounds: v:true}))
+
+  " Combining characters and v:maxcol.
+  call assert_equal([[[b, 5, 1, 0], [b, 6, 16, 0]]],
+        \ getregionpos([0, 5, 1, 0], [0, 6, v:maxcol, 0], #{bounds: v:true}))
+
+  " The pair is always what indexing the full result gives.
+  for ve in ['', 'all', 'block', 'onemore']
+    let &virtualedit = ve
+    for sel in ['inclusive', 'exclusive']
+      let &selection = sel
+      for type in ['v', 'V', "\<C-v>", "\<C-v>3"]
+        for excl in [#{}, #{exclusive: v:false}, #{exclusive: v:true}]
+          for eol in [v:false, v:true]
+            let opts = extend(#{type: type, eol: eol}, excl)
+            for p1 in [[0, 1, 3, 0], [0, 2, 1, 0], [0, 3, 4, 0], [0, 5, 1, 0]]
+              for p2 in [[0, 3, 2, 0], [0, 4, 6, 0],
+                    \    [0, 6, v:maxcol, 0], [0, 7, 10, 0]]
+                for args in [[p1, p2], [p2, p1]]
+                  let full = getregionpos(args[0], args[1], opts)
+                  call assert_equal([[full[0][0], full[-1][1]]],
+                        \ getregionpos(args[0], args[1],
+                        \              extend(copy(opts), #{bounds: v:true})),
+                        \ printf('%s ve=%s sel=%s %s',
+                        \        string(args), ve, sel, string(opts)))
+                endfor
+              endfor
+            endfor
+          endfor
+        endfor
+      endfor
+    endfor
+  endfor
+  set virtualedit& selection&
+
+  " "bounds" does not change the errors for invalid arguments.
+  call assert_fails('call getregionpos(1, 2, #{bounds: v:true})', 'E1211:')
+  call assert_fails('call getregionpos([0, 1, 1, 0], [0, 1, 1, 0],
+        \ #{type: "", bounds: v:true})', 'E475:')
+  call assert_fails('call getregionpos([0, 0, 1, 0], [0, 1, 1, 0],
+        \ #{bounds: v:true})', 'E966:')
+  call assert_fails('call getregionpos([0, 1, 0, 0], [0, 1, 1, 0],
+        \ #{bounds: v:true})', 'E964:')
+
+  " Positions in two different buffers still give an empty list, not a pair.
+  new
+  call setline(1, ['other buffer'])
+  let other = bufnr('%')
+  normal! mA
+  wincmd p
+  call assert_equal([],
+        \ getregionpos(getpos('.'), getpos("'A"), #{bounds: v:true}))
+  call assert_equal([],
+        \ getregionpos(getpos("'A"), getpos('.'), #{bounds: v:true}))
+
+  exe other .. 'bwipe!'
+  bwipe!
+endfunc
+
 func Test_getregion_invalid_buf()
   new
   help


### PR DESCRIPTION
## Problem

`getregionpos()` returns a pair of positions for every line of the region, so
obtaining just the outer endpoints costs O(lines).

## Solution

Add a `bounds` item to `{opts}` defaulting to false. When it is set, only the
first and the last line of the region are visited and the result is a single
pair:

    [[{start_pos}, {end_pos}]]

`{start_pos}` is the start position on the first line and `{end_pos}` the end
position on the last line, so with the same `{opts}` this is equivalent to
taking the outer positions of the full result:

    let full = getregionpos(pos1, pos2, opts)
    let bounds = [[full[0][0], full[-1][1]]]

That equivalence is the whole specification, so the existing corners are
reproduced:

- The two positions come from different lines, so they describe a diagonal of
  the region and not its shape. For a blockwise region they are the start of
  the first line and the end of the last line, not the corners of the block.
- If the first line is empty and `eol` is false, `{start_pos}` has a `col` of
  0 while `{end_pos}` may not.
- Error behaviour is untouched, and positions in two different buffers still
  return an empty list rather than a pair.

## Numbers

Measured on a 100000 line buffer, macOS arm64, `-O2`:

| region type | full result | `bounds` |
|-------------|-------------|----------|
| charwise    | 45.6 ms     | 0.003 ms |
| linewise    | 41.0 ms     | 0.003 ms |
| blockwise   | 42.9 ms     | 0.003 ms |

The normal per-line path is unaffected by the refactor.

## Tests

`Test_visual_getregionpos_bounds()` in `src/testdir/test_visual.vim` asserts
explicit expected pairs for the interesting shapes — the blockwise diagonal,
an empty first line with and without `eol`, multibyte and combining
characters, tabs, `v:maxcol`, a region within one line, and reversed
arguments — and then checks over 6144 generated cases that `bounds` equals
`[[full[0][0], full[-1][1]]]` for every combination of region type, `eol`,
`exclusive`, `'selection'` and `'virtualedit'`. It also covers the unchanged
error cases and the different-buffer empty list.

During development the same equivalence was checked over 3888000 cases with no
mismatches; the committed matrix is the small readable subset of that.

## AI Disclosure

This change was prepared with AI assistance.

## Context

Neovim intends to port this afterwards, see
https://github.com/neovim/neovim/issues/41448.