### PR TITLE
libvterm: characters can get a different width in a terminal window

### DIFF
--- a/src/libvterm/src/unicode.c
+++ b/src/libvterm/src/unicode.c
@@ -417,6 +417,7 @@ static int bisearch(uint32_t ucs, const struct interval *table, int max) {
 #ifdef WCWIDTH_FUNCTION
 // use a provided wcwidth() function
 int WCWIDTH_FUNCTION(uint32_t ucs);
+# define HAVE_PROVIDED_WCWIDTH
 #else
 # define WCWIDTH_FUNCTION mk_wcwidth
 
@@ -564,14 +565,20 @@ vterm_get_special_pty_type_placeholder(void)
 // ################################
 // ### The rest added by Paul Evans
 
+#ifndef HAVE_PROVIDED_WCWIDTH
 static const struct interval fullwidth[] = {
 #include "fullwidth.inc"
 };
+#endif
 
 INTERNAL int vterm_unicode_width(uint32_t codepoint)
 {
+  // The fullwidth table is outdated.  When a wcwidth() function is provided
+  // it is the only authority on the width of a character.
+#ifndef HAVE_PROVIDED_WCWIDTH
   if(bisearch(codepoint, fullwidth, sizeof(fullwidth) / sizeof(fullwidth[0]) - 1))
     return 2;
+#endif
 
   return WCWIDTH_FUNCTION(codepoint);
 }

--- a/src/testdir/test_terminal.vim
+++ b/src/testdir/test_terminal.vim
@@ -436,6 +436,32 @@ func Test_terminal_scrape_multibyte()
   exe buf . 'bwipe'
 endfunc
 
+func Test_terminal_scrape_char_width()
+  " These characters do not come through a Windows console.
+  CheckUnix
+
+  " U+1F93B and U+1F946 have East Asian Width "Neutral", the surrounding
+  " emoji are "Wide".  A terminal cell must get the same width as the
+  " character gets in an ordinary buffer.
+  let chars = ["\U0001F93A", "\U0001F93B", "\U0001F945", "\U0001F946"]
+  call writefile([join(chars, '')], 'Xwidth', 'D')
+  let buf = term_start("cat Xwidth")
+
+  call WaitFor({-> len(term_scrape(buf, 1)) >= len(chars)
+        \ && term_scrape(buf, 1)[0].chars == chars[0]})
+  let l = term_scrape(buf, 1)
+  for i in range(len(chars))
+    call assert_equal(chars[i], l[i].chars)
+    call assert_equal(strdisplaywidth(chars[i]), l[i].width, chars[i])
+  endfor
+
+  let job = term_getjob(buf)
+  call WaitForAssert({-> assert_equal("dead", job_status(job))})
+  call TermWait(buf)
+
+  exe buf . 'bwipe'
+endfunc
+
 func Test_terminal_one_column()
   " This creates a terminal, displays a double-wide character and makes the
   " window one column wide.  This used to cause a crash.


### PR DESCRIPTION
```
Problem:  Some characters get a different width in a terminal window
          than in an ordinary window.
Solution: When the application provides a width function, use it as the
          only source for the width of a character.
```

libvterm looks up its own "fullwidth" table before calling the wcwidth()
function that Vim provides.  That table holds Unicode 12 data, while Vim
follows a newer version, so U+1F93B and U+1F946 are two cells wide in a
terminal window and one cell wide everywhere else.  U+302A-302D and
U+3099-309A are affected as well: both tables list them as wide, but the
function Vim provides reports zero for a composing character.

Skipping the table when a wcwidth() function is provided makes that
function the only authority, so a terminal cell gets the same width as
the character gets in a buffer.  A build of libvterm without such a
function keeps using the table.