### PR TITLE
Fix formatlistpat for Org-mode

### DIFF
--- a/runtime/ftplugin/org.vim
+++ b/runtime/ftplugin/org.vim
@@ -20,7 +20,7 @@ setl commentstring=#\ %s
 setl comments=fb:*,fb:-,fb:+,b:#,b:\:
 
 setl formatoptions+=nql
-setl formatlistpat=^\\s*\\(\\(\\d\\|\\a\\)\\+[.)]\\|[+-]\\)\\s\\+
+setl formatlistpat=^\\s*\\(\\(\\d\\\|\\a\\)\\+[.)]\\\|[+-]\\)\\s\\+
 
 function OrgFoldExpr()
     let l:depth = match(getline(v:lnum), '\(^\*\+\)\@<=\( .*$\)\@=')


### PR DESCRIPTION
Unlike for any other file in the `ftplugin` folder, this one uses `\\|` instead of `\\\|` in the `formatlistpat` option. This sets the incorrect value for `formatlistpat`, preventing vim from correctly identifying lists in Org-mode files.