### PR TITLE
Vim script execution is slower than necessary

### DIFF
--- a/src/proto/vim9script.pro
+++ b/src/proto/vim9script.pro
@@ -1,5 +1,4 @@
 /* vim9script.c */
-int in_vim9script(void);
 int in_old_script(int max_version);
 int current_script_is_vim9(void);
 void clear_vim9_scriptlocal_vars(int sid);

--- a/src/vim.h
+++ b/src/vim.h
@@ -2586,6 +2586,25 @@ typedef int (*opt_expand_cb_T)(optexpand_T *args, int *numMatches, char_u ***mat
 #include "globals.h"	    // global variables and messages
 #include "errors.h"	    // error messages
 
+#ifndef PROTO
+/*
+ * Return TRUE when currently using Vim9 script syntax.
+ * Does not go up the stack, a ":function" inside vim9script uses legacy
+ * syntax.
+ * Defined here as "static inline" because it is called very frequently from
+ * the eval hot path; inlining avoids the cross-file call overhead.
+ */
+    static inline int
+in_vim9script(void)
+{
+    // "sc_version" is also set when compiling a ":def" function in legacy
+    // script.
+    return (current_sctx.sc_version == SCRIPT_VERSION_VIM9
+					 || (cmdmod.cmod_flags & CMOD_VIM9CMD))
+		&& !(cmdmod.cmod_flags & CMOD_LEGACY);
+}
+#endif
+
 /*
  * If console dialog not supported, but GUI dialog is, use the GUI one.
  */

--- a/src/vim9script.c
+++ b/src/vim9script.c
@@ -13,21 +13,6 @@
 
 #include "vim.h"
 
-/*
- * Return TRUE when currently using Vim9 script syntax.
- * Does not go up the stack, a ":function" inside vim9script uses legacy
- * syntax.
- */
-    int
-in_vim9script(void)
-{
-    // "sc_version" is also set when compiling a ":def" function in legacy
-    // script.
-    return (current_sctx.sc_version == SCRIPT_VERSION_VIM9
-					 || (cmdmod.cmod_flags & CMOD_VIM9CMD))
-		&& !(cmdmod.cmod_flags & CMOD_LEGACY);
-}
-
 #if defined(FEAT_EVAL)
 /*
  * Return TRUE when currently in a script with script version smaller than


### PR DESCRIPTION
Problem:  in_vim9script() is called very frequently on the script
          evaluation hot path, but is a cross-file function call whose
          overhead dominates its trivial body.
Solution: Make in_vim9script() a "static inline" function in vim.h so it
          is inlined at its call sites.

in_vim9script() only reads two globals, yet it accounted for about 9% of self time in a legacy script evaluation profile because it is invoked in a lot of call sites in the eval path and could not be inlined across translation units. Moving the body to a `static inline` function in vim.h guarded with `#ifndef PROTO` and removing the out-of-line definition eliminates the call overhead. Measured with retired instructions, this reduces legacy Vim script execution by roughly 3 to 4% in tight loops, function calls, builtin-heavy and string processing workloads; expression-bound editing such as `:s//\=expr/g` improves by about 2%. Vim9 script is unaffected. All in all, nothing groundbreaking, but a couple of percents improvements for a simple `static inline` sounds worthwhile to me.