### PR TITLE
runtime(robot): Add comment string

### DIFF
--- a/runtime/ftplugin/robot.vim
+++ b/runtime/ftplugin/robot.vim
@@ -1,0 +1,17 @@
+" Vim filetype plugin
+" Language:	Robot Framework
+" Maintainer:	Dawid Dziurla (github.com/dawidd6)
+" Last Change:	2026 Sep 04
+
+if exists('b:did_ftplugin')
+  finish
+endif
+let b:did_ftplugin = 1
+
+setl comments=:# commentstring=#\ %s
+
+let b:undo_ftplugin = get(b:, 'undo_ftplugin', '')
+if !empty(b:undo_ftplugin)
+  let b:undo_ftplugin .= ' | '
+endif
+let b:undo_ftplugin .= 'setlocal comments< commentstring<'


### PR DESCRIPTION
## Problem

Robot Framework files have no ftplugin, so Vim does not configure their comment settings.

## Solution

Add a Robot Framework ftplugin that sets `comments` and `commentstring`.


AI-assisted

Adapted from https://github.com/neovim/neovim/pull/41704