### PR TITLE
Copying a List is slower than necessary

### DIFF
--- a/src/list.c
+++ b/src/list.c
@@ -1297,18 +1297,35 @@ list_concat(list_T *l1, list_T *l2, typval_T *tv)
 list_slice(list_T *ol, long n1, long n2)
 {
     listitem_T	*item;
-    list_T	*l = list_alloc();
+    list_T	*l;
+    long	count;
+    long	idx;
 
+    if (n2 < n1)
+	return list_alloc();
+    if (n1 > INT_MAX - (n2 - n1) - 1)
+	return NULL;
+    count = n2 - n1 + 1;
+
+    // The length is known, so allocate the list and all items at once.
+    l = list_alloc_with_items((int)count);
     if (l == NULL)
 	return NULL;
-    for (item = list_find(ol, n1); n1 <= n2; ++n1)
+
+    item = list_find(ol, n1);
+    for (idx = 0; idx < count; ++idx)
     {
+	typval_T	new_tv;
+
 	// "item" is NULL when materializing "ol" stopped early.
-	if (item == NULL || list_append_tv(l, &item->li_tv) == FAIL)
+	if (item == NULL)
 	{
 	    list_free(l);
 	    return NULL;
 	}
+
+	copy_tv(&item->li_tv, &new_tv);
+	list_set_item(l, (int)idx, &new_tv);
 	item = item->li_next;
     }
     return l;
@@ -1402,12 +1419,14 @@ list_copy(list_T *orig, int deep, int top, int copyID)
 {
     list_T	*copy;
     listitem_T	*item;
-    listitem_T	*ni;
+    int		idx = 0;
 
     if (orig == NULL)
 	return NULL;
 
-    copy = list_alloc();
+    // The length is known, so allocate the list and all items at once.
+    CHECK_LIST_MATERIALIZE(orig);
+    copy = list_alloc_with_items(orig->lv_len);
     if (copy == NULL)
 	return NULL;
 
@@ -1422,25 +1441,19 @@ list_copy(list_T *orig, int deep, int top, int copyID)
 	orig->lv_copyID = copyID;
 	orig->lv_copylist = copy;
     }
-    CHECK_LIST_MATERIALIZE(orig);
     for (item = orig->lv_first; item != NULL && !got_int;
 	    item = item->li_next)
     {
-	ni = listitem_alloc();
-	if (ni == NULL)
-	    break;
+	typval_T	new_tv;
+
 	if (deep)
 	{
-	    if (item_copy(&item->li_tv, &ni->li_tv,
-			deep, FALSE, copyID) == FAIL)
-	    {
-		vim_free(ni);
+	    if (item_copy(&item->li_tv, &new_tv, deep, FALSE, copyID) == FAIL)
 		break;
-	    }
 	}
 	else
-	    copy_tv(&item->li_tv, &ni->li_tv);
-	list_append(copy, ni);
+	    copy_tv(&item->li_tv, &new_tv);
+	list_set_item(copy, idx++, &new_tv);
     }
     ++copy->lv_refcount;
     if (item != NULL)


### PR DESCRIPTION
Problem:  Copying or slicing a List allocates every item individually,
          even though the number of items is known in advance.
Solution: Allocate the List and all of its items in a single block with
          list_alloc_with_items(), as list_concat() already does.

Measured with `perf stat -e instructions` on workloads that model list-heavy plugin usage:
  - windowed slicing over a 120k-item list (pager/fuzzy-finder): -10.7%
  - copy() of an 800-item list, repeated (state snapshotting):   -39.2%
  - deepcopy() of a nested list structure (config cloning):      -42.6%

As a nice side-effect, I think it makes the code a tad more clear/clean.