### PR TITLE
Fix mksession with same terminal in shared windows

### DIFF
--- a/src/terminal.c
+++ b/src/terminal.c
@@ -1107,7 +1107,7 @@ term_write_session(FILE *fd, win_T *wp, hashtab_T *terminal_bufs)
 	if (!HASHITEM_EMPTY(entry))
 	{
 	    // we've already opened this terminal buffer
-	    if (fprintf(fd, "execute 'buffer ' . term_buf_%d", bufnr) < 0)
+	    if (fprintf(fd, "execute 'buffer ' .. term_buf_%d", bufnr) < 0)
 		return FAIL;
 	    return put_eol(fd);
 	}

--- a/src/testdir/test_mksession.vim
+++ b/src/testdir/test_mksession.vim
@@ -602,7 +602,7 @@ func Test_mksession_terminal_shared_windows()
       call assert_match('exe '':terminal ++curwin ++cols='' \.\. ((&columns \* \d\+ + \d\+) \/ \d\+) \.\. '' ++rows='' \.\. ((&lines \* \d\+ + \d\+) \/ \d\+)', line)
     elseif line =~ $"^var term_buf_{term_buf}: number = bufnr()$"
       let found_var = 1
-    elseif line =~ "^execute 'buffer ' . term_buf_" . term_buf . "$"
+    elseif line =~ "^execute 'buffer ' \\.\\. term_buf_" . term_buf . "$"
       let found_use = 1
     endif
   endfor
@@ -610,6 +610,9 @@ func Test_mksession_terminal_shared_windows()
   call assert_true(found_creation && found_use && found_var)
 
   call StopShellInTerminal(term_buf)
+
+  source Xtest_mks.out
+
   call delete('Xtest_mks.out')
 endfunc
 

--- a/src/testdir/test_mksession.vim
+++ b/src/testdir/test_mksession.vim
@@ -613,6 +613,12 @@ func Test_mksession_terminal_shared_windows()
 
   source Xtest_mks.out
 
+  let restored = bufnr()
+  call assert_equal('terminal', getbufvar(restored, '&buftype'))
+  call WaitForAssert({-> assert_match('running', term_getstatus(restored))})
+  call StopShellInTerminal(restored)
+
+  %bwipe!
   call delete('Xtest_mks.out')
 endfunc
 


### PR DESCRIPTION
## Problem
Vim session files use `vim9script`, which requires the `..` string concatenation syntax, but the legacy `.` form is currently used when making a session file from a state where one Vim terminal is shared in multiple windows.

## Steps to reproduce
Go to a test directory , launch vim, open a vim terminal, split its window, make a session file, then quit.  Sourcing the created session file will fail during execution with error `E15: Invalid expression: ". term_buf_2"`. Like this:
```sh
$ cd "$(mktemp -d)"
$ vim --clean -c 'exec "term"|sp|mksession!|qa!'
$ vim --clean -S Session.vim
```

## Solution
* Change to the `..` form in the specific part of the `term_write_session` function where the legacy form was still used.
* Amend the existing test to check for this form, and add sourcing of the resulting session file to ensure it is valid.