### PR TITLE
runtime(netrw): E46 when changing to an inaccessible directory

### DIFF
--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -1,7 +1,8 @@
 " Creator:    Charles E Campbell
 " Previous Maintainer: Luca Saccarola <github.e41mv@aleeas.com>
 " Maintainer: This runtime file is looking for a new maintainer.
-" Last Change: 2026 Aug 21
+" Last Change: 2026 Sep 05
+"              Fix error handling when changing directories fails.
 " Copyright:  Copyright (C) 2016 Charles E. Campbell {{{1
 "             Permission is hereby granted to use and distribute this code,
 "             with or without modifications, provided that this copyright
@@ -9300,12 +9301,9 @@ function s:NetrwLcd(newdir)
 
     if err472
         call netrw#msg#Notify('ERROR', printf('unable to change directory to <%s> (permissions?)', a:newdir))
-        if exists("w:netrw_prvdir")
-            let a:newdir= w:netrw_prvdir
-        else
+        if !exists("w:netrw_prvdir")
             call s:NetrwOptionsRestore("w:")
             exe "setl ".g:netrw_bufsettings
-            let a:newdir= dirname
         endif
         return -1
     endif

--- a/src/testdir/test_plugin_netrw.vim
+++ b/src/testdir/test_plugin_netrw.vim
@@ -133,6 +133,10 @@ function Test_NetrwFile(fname) abort
     return s:NetrwFile(a:fname)
 endfunction
 
+function Test_NetrwLcd(newdir) abort
+    return s:NetrwLcd(a:newdir)
+endfunction
+
 " Test hostname validation
 function Test_NetrwValidateHostname(hostname) abort
     return s:NetrwValidateHostname(a:hostname)
@@ -312,6 +316,44 @@ func s:combine
   endfor
 endfunction
 
+
+func Test_netrw_lcd_failure()
+  CheckUnix
+  CheckNotRoot
+  let dirname = getcwd() .. '/Xnetrw_noaccess'
+  call mkdir(dirname)
+  call assert_true(setfperm(dirname, 'r--------'))
+  try
+    for prevdir in [1, 0]
+      new
+      try
+        let cwd = getcwd()
+        if prevdir
+          let w:netrw_prvdir = cwd
+        else
+          unlet! w:netrw_prvdir
+        endif
+        setlocal modifiable noreadonly number
+        let msg = execute('call assert_equal(-1, Test_NetrwLcd(dirname))')
+        call assert_match('unable to change directory to <' .. dirname .. '>', msg)
+        call assert_equal(cwd, getcwd())
+        if prevdir
+          call assert_equal(cwd, w:netrw_prvdir)
+          call assert_true(&l:modifiable)
+        else
+          call assert_false(&l:modifiable)
+          call assert_true(&l:readonly)
+          call assert_false(&l:number)
+        endif
+      finally
+        bwipe!
+      endtry
+    endfor
+  finally
+    call setfperm(dirname, 'rwx------')
+    call delete(dirname, 'd')
+  endtry
+endfunc
 
 func Test_netrw_parse_remote_simple()
   let result = TestNetrwCaptureRemotePath('scp://user@localhost:2222/test.txt')


### PR DESCRIPTION
Problem: When changing to an inaccessible directory fails with E472,
          s:NetrwLcd() attempts to assign to the read-only a:newdir
          argument and raises E46 instead of returning -1. The fallback
          branch also refers to dirname, which is not defined on this path.
Solution: Remove both unused assignments and retain the existing option
          restoration and failure return (Qiming zhao).

The failed :lcd leaves the current directory unchanged. Callers use the
function's return value; assigning to its argument cannot update the
caller's directory variable.

The regression test uses a directory without execute permission and covers
both the presence and absence of w:netrw_prvdir. It checks the failure
return, error notification, unchanged working directory, and buffer options.
The test reproduced E46 before the fix and passes after it. It is skipped
on non-Unix systems and when running as root.

Validation: make -j4 completed successfully, with linker warnings about
duplicate -lcairo and -lintl libraries. The full test_plugin_netrw suite
completed with 29 tests passing and 11 skipped for platform or missing
PowerShell dependencies. The new regression test also passed with the
freshly built Vim. All five make codestyle tests passed.

This contribution was developed with assistance from OpenAI Codex.
