### PR TITLE
runtime(spup): E492 for an out-of-range comment mode

### DIFF
--- a/runtime/syntax/spup.vim
+++ b/runtime/syntax/spup.vim
@@ -2,7 +2,7 @@
 " Language:     Speedup, plant simulator from AspenTech
 " Maintainer:   Stefan.Schwarzer <s.schwarzer@ndh.net>
 " URL:		http://www.ndh.net/home/sschwarzer/download/spup.vim
-" Last Change:  2012 Feb 03 by Thilo Six
+" Last Change:  2026 Sep 05
 " Filename:     spup.vim
 
 " Bugs
@@ -157,7 +157,7 @@ syn region spupHelp  start="^HELP"hs=e+1  end="^\$ENDHELP"he=s-1 contained
 syn region spupCode  start="^CODE"hs=e+1  end="^\$ENDCODE"he=s-1 contained
 " oneline comments
 if oneline_comments > 3
-    oneline_comments = 2   " default
+    let oneline_comments = 2   " default
 endif
 if oneline_comments == 1
     syn match spupComment  "#[^#]*#\="


### PR DESCRIPTION
Loading the Speedup syntax script with `g:oneline_comments > 3` raises
`E492: Not an editor command` because the fallback assignment is missing
`let`. Add `let` so the script correctly resets the mode to its default
value of 2 and finishes loading.

Reproduce in a clean Vim session:

```vim
let g:oneline_comments = 4
runtime syntax/spup.vim
```

The original script raises E492 at the fallback assignment. With this
change, `g:oneline_comments` becomes 2 and `b:current_syntax` becomes
`spup`.

Validated by sourcing the original and corrected scripts with the local
Vim build. The corrected script was checked with modes 1, 2, 3, 4 and 99,
and with the variable unset; all checks passed. Option restoration was
also checked. The repository's five code-style tests passed with the
assignment fix present.

The header still lists Stefan Schwarzer as maintainer and links to an old
ndh.net download URL. I could not open that URL or locate an upstream Git
repository for this syntax file, so this small correction is submitted
here for review.

The assignment correction was supplied by the contributor. Validation
and PR preparation were assisted by OpenAI Codex.
