### PR TITLE
always equalize windows when 'equalalways' is set

### DIFF
--- a/src/testdir/test_window_cmd.vim
+++ b/src/testdir/test_window_cmd.vim
@@ -609,6 +609,23 @@ func Test_equalalways_on_close()
   set equalalways&
 endfunc
 
+func Test_equalalways_on_open()
+  set equalalways
+  vsplit
+  split
+  wincmd l
+  windo vsplit
+
+  let basewidth = winwidth(1)
+
+  for win in range(2, winnr("$"))
+    call assert_true(abs(winwidth(win) - basewidth) <= 1)
+  endfor
+
+  only
+  set equalalways&
+endfunc
+
 func Test_win_screenpos()
   CheckFeature quickfix
 

--- a/src/window.c
+++ b/src/window.c
@@ -1134,25 +1134,11 @@ win_split_ins(
 	if (oldwin->w_p_wfw)
 	    win_setwidth_win(oldwin->w_width + new_size + 1, oldwin);
 
-	// Only make all windows the same width if one of them (except oldwin)
-	// is wider than one of the split windows.
+	// Make all windows the same width if 'equalalways' is set, 'ead'
+	// not set to 'v', a size was not provided and there is a parent frame.
 	if (!do_equal && p_ea && size == 0 && *p_ead != 'v'
-					 && oldwin->w_frame->fr_parent != NULL)
-	{
-	    frp = oldwin->w_frame->fr_parent->fr_child;
-	    while (frp != NULL)
-	    {
-		if (frp->fr_win != oldwin && frp->fr_win != NULL
-			&& (frp->fr_win->w_width > new_size
-			    || frp->fr_win->w_width > oldwin->w_width
-							      - new_size - 1))
-		{
-		    do_equal = TRUE;
-		    break;
-		}
-		frp = frp->fr_next;
-	    }
-	}
+	    && oldwin->w_frame->fr_parent != NULL)
+	    do_equal = TRUE;
     }
     else
     {
@@ -1236,25 +1222,11 @@ win_split_ins(
 	    oldwin_height = oldwin->w_height;
 	}
 
-	// Only make all windows the same height if one of them (except oldwin)
-	// is higher than one of the split windows.
+	// Make all windows the same height if 'equalalways' is set, 'ead' is
+	// not set to 'h', a size was not provided and there is a parent frame.
 	if (!do_equal && p_ea && size == 0 && *p_ead != 'h'
-	   && oldwin->w_frame->fr_parent != NULL)
-	{
-	    frp = oldwin->w_frame->fr_parent->fr_child;
-	    while (frp != NULL)
-	    {
-		if (frp->fr_win != oldwin && frp->fr_win != NULL
-			&& (frp->fr_win->w_height > new_size
-			    || frp->fr_win->w_height > oldwin_height - new_size
-						- statusline_height(oldwin)))
-		{
-		    do_equal = TRUE;
-		    break;
-		}
-		frp = frp->fr_next;
-	    }
-	}
+	    && oldwin->w_frame->fr_parent != NULL)
+	    do_equal = TRUE;
     }
 
     /*


### PR DESCRIPTION
Problem:  Windows are not always rebalanced when opening a new window
          with 'equalalways' set due to incorrect logic which fails to
          detect when a resize is necessary.
Solution: Always rebalance window sizes when opening a new window with
          'equalalways' set.

The detection logic tries to detect when a resize is necessary by comparing the size of the children of the parent frame of the split window. This fails in certain layouts because the check doesn't recurse into frame trees so cannot get the size of a layout frame.

Fixes https://github.com/vim/vim/issues/3416, https://github.com/vim/vim/issues/13076