### PR TITLE
Update quickfix help text with missing information

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -1,4 +1,4 @@
-*builtin.txt*	For Vim version 9.2.  Last change: 2026 Sep 01
+*builtin.txt*	For Vim version 9.2.  Last change: 2026 Sep 05
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -5009,7 +5009,8 @@ getqflist([{what}])					*getqflist()*
 			valid	|TRUE|: recognized error message
 			user_data
 				custom data associated with the item, can be
-				any type.
+				any type.  This entry is present only when
+				user data was set for this item.
 
 		When there is no error list or it's empty, an empty list is
 		returned.  Quickfix list entries with a non-existing buffer
@@ -5051,6 +5052,11 @@ getqflist([{what}])					*getqflist()*
 			qfbufnr number of the buffer displayed in the quickfix
 				window.  Returns 0 if the quickfix buffer is
 				not present.  See |quickfix-buffer|.
+			quickfixtextfunc
+				function to get the text to display in the
+				quickfix window.  Returns an empty string if
+				this function is not set for the list.  See
+				|quickfix-window-function|.
 			size	number of entries in the quickfix list
 			title	get the list title |quickfix-title|
 			winid	get the quickfix |window-ID|
@@ -5082,6 +5088,9 @@ getqflist([{what}])					*getqflist()*
 				0
 			qfbufnr	number of the buffer displayed in the quickfix
 				window.  If not present, set to 0.
+			quickfixtextfunc
+				'quickfixtextfunc' setting of the list.  If
+				not present, set to "".
 			size	number of entries in the quickfix list.  If
 				not present, set to 0.
 			title	quickfix list title text.  If not present, set
@@ -10403,7 +10412,10 @@ setqflist({list} [, {action} [, {what}]])		*setqflist()*
 				:call setqflist([], 'r')
 <
 		'u'	Like 'r', but tries to preserve the current selection
-			in the quickfix list.
+			in the quickfix list.  The entry nearest to the
+			previously selected one becomes the current entry.
+			Proximity is determined by comparing the file, then
+			the line number and then the column number.
 		'f'	All the quickfix lists in the quickfix stack are
 			freed.
 

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -1,4 +1,4 @@
-*quickfix.txt*  For Vim version 9.2.  Last change: 2026 May 28
+*quickfix.txt*  For Vim version 9.2.  Last change: 2026 Sep 05
 
 
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
@@ -686,6 +686,15 @@ to find a window to edit the file:
    is used.
 6. If the above step fails, then a new horizontally split window above the
    quickfix window is used.
+
+						*quickfix-winfixbuf*
+When 'winfixbuf' is set for the window that would be used to display the
+error, jumping to an error in another buffer is not possible in that window.
+For a quickfix list Vim then looks for another suitable window, using the
+previously accessed window if it does not have 'winfixbuf' set, and otherwise
+splits a new window.  For a location list this fails with |E1513|, because a
+location list is tied to its window and cannot move to or split off another
+one.  Using [!] skips these checks.
 
 					*CTRL-W_<Enter>* *CTRL-W_<CR>*
 You can use CTRL-W <Enter> to open a new window and jump to the error there.
@@ -1833,6 +1842,8 @@ Basic items
 			    w - warning message
 			    i - info message
 			    n - note message
+			The uppercase letters E, W, I and N are also
+			recognized and have the same meaning.
 	%n		error number (finds a number)
 	%m		error message (finds a string)
 	%r		matches the "rest" of a single-line file message %O/P/Q

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -10046,6 +10046,7 @@ quickfix-valid	quickfix.txt	/*quickfix-valid*
 quickfix-window	quickfix.txt	/*quickfix-window*
 quickfix-window-ID	quickfix.txt	/*quickfix-window-ID*
 quickfix-window-function	quickfix.txt	/*quickfix-window-function*
+quickfix-winfixbuf	quickfix.txt	/*quickfix-winfixbuf*
 quickfix.txt	quickfix.txt	/*quickfix.txt*
 quickref	quickref.txt	/*quickref*
 quickref.txt	quickref.txt	/*quickref.txt*


### PR DESCRIPTION

Update the quickfix help text with additional details.  Used Github Copilot to compare the code and the help text to find the missing details.