### PR TITLE
keys(), values() and items() are slower than necessary

### DIFF
--- a/src/dict.c
+++ b/src/dict.c
@@ -1567,6 +1567,7 @@ typedef enum {
     static void
 dict2list(typval_T *argvars, typval_T *rettv, dict2list_T what)
 {
+    list_T	*l;
     list_T	*l2;
     dictitem_T	*di;
     hashitem_T	*hi;
@@ -1574,29 +1575,37 @@ dict2list(typval_T *argvars, typval_T *rettv, dict2list_T what)
     dict_T	*d;
     int		todo;
 
-    if (rettv_list_alloc(rettv) == FAIL)
-	return;
-
     if (check_for_dict_arg(argvars, 0) == FAIL)
+    {
+	// invalid argument, return an empty list
+	(void)rettv_list_alloc(rettv);
 	return;
+    }
 
+    // NULL dict behaves like an empty dict
     d = argvars[0].vval.v_dict;
-    if (d == NULL)
-	// NULL dict behaves like an empty dict
+    todo = d == NULL ? 0 : (int)d->dv_hashtab.ht_used;
+
+    // The number of items is known, allocate the list and all its items in
+    // one go for efficiency.
+    l = list_alloc_with_items(todo);
+    if (l == NULL)
+    {
+	(void)rettv_list_alloc(rettv);
+	return;
+    }
+    rettv_list_set(rettv, l);
+    if (todo == 0)
+	// NULL or empty dict, return the empty list
 	return;
 
-    todo = (int)d->dv_hashtab.ht_used;
+    li = l->lv_first;
     FOR_ALL_HASHTAB_ITEMS(&d->dv_hashtab, hi, todo)
     {
 	if (!HASHITEM_EMPTY(hi))
 	{
 	    --todo;
 	    di = HI2DI(hi);
-
-	    li = listitem_alloc();
-	    if (li == NULL)
-		break;
-	    list_append(rettv->vval.v_list, li);
 
 	    if (what == DICT2LIST_KEYS)
 	    {
@@ -1618,15 +1627,23 @@ dict2list(typval_T *argvars, typval_T *rettv, dict2list_T what)
 		li->li_tv.v_lock = 0;
 		li->li_tv.vval.v_list = l2;
 		if (l2 == NULL)
-		    break;
+		    goto alloc_failed;
 		++l2->lv_refcount;
 
 		if (list_append_string(l2, di->di_key, -1) == FAIL
 			|| list_append_tv(l2, &di->di_tv) == FAIL)
-		    break;
+		    goto alloc_failed;
 	    }
+	    li = li->li_next;
 	}
     }
+    return;
+
+alloc_failed:
+    // On a memory allocation failure some of the pre-allocated items may be
+    // left unset; free the whole list and return an empty one instead.
+    list_unref(l);
+    (void)rettv_list_alloc(rettv);
 }
 
 /*


### PR DESCRIPTION
Problem:  Turning a Dictionary into a List with keys(), values() or
          items() allocates each list item separately, although the
          number of items is known in advance.
Solution: Allocate the list and all its items in a single block with
          list_alloc_with_items().

dict2list() knew the item count up front (the hashtab's ht_used) but still called listitem_alloc() plus list_append() once per element. Pre-allocate the whole list in one go, as list_copy() and get_buffer_lines() already do.

Measured with "perf stat -e instructions", an isolated keys()+values()+items() loop over a 2000-entry dict is 33% faster, and a keys()-only loop scales from 27% faster on a 50-entry dict to 43% on a 500-entry one. Running matchfuzzy() over keys() of a 2000-path dict improves ~6%.