### PR TITLE
vimcomplete: do not autocomplete after ( or [

### DIFF
--- a/runtime/autoload/vimcomplete.vim
+++ b/runtime/autoload/vimcomplete.vim
@@ -3,7 +3,7 @@ vim9script
 # Vim completion script
 # Language:    Vim script
 # Maintainer:  Maxim Kim <habamax@gmail.com>
-# Last Change: 2025-10-15
+# Last Change: 2026 Sep 07
 #
 # Usage:
 # setlocal omnifunc=vimcomplete#Complete
@@ -25,7 +25,7 @@ def GetTrigger(line: string): list<any>
     elseif line =~ '\vse%[t]\s+(\k+\s+)*no\k*$'
         result = 'nooption'
         result_len = -2
-    elseif line =~ '[\[(]\s*$'
+    elseif line =~ '[\[(]\s*$' && !complete_info(["auto"]).auto
         result = 'expression'
     elseif line =~ '[lvgsb]:\k*$'
         result = 'var'


### PR DESCRIPTION
With autocomplete following should not trigger completion:

    strpart(<cursor>

However, pressing i_CTRL-X_CTRL-O should.