### PR TITLE
Speed up byte searches with strchr

### DIFF
--- a/src/strings.c
+++ b/src/strings.c
@@ -681,15 +681,11 @@ vim_strchr(char_u *string, int c)
     char_u  *
 vim_strbyte(char_u *string, int c)
 {
-    char_u	*p = string;
-
-    while (*p != NUL)
-    {
-	if (*p == c)
-	    return p;
-	++p;
-    }
-    return NULL;
+    // strchr() converts c to char and also matches the terminating NUL.
+    // Keep the byte range and NUL behavior of this function.
+    if (c <= 0 || c > 255)
+	return NULL;
+    return (char_u *)strchr((char *)string, c);
 }
 
 /*

--- a/src/testdir/test_regexp_utf8.vim
+++ b/src/testdir/test_regexp_utf8.vim
@@ -1,5 +1,33 @@
 " Tests for regexp in utf8 encoding
 
+func Test_regexp_literal_byte_search()
+  let save_encoding = &encoding
+  let save_re = &regexpengine
+  try
+    for enc in ['latin1', 'utf-8']
+      let &encoding = enc
+      for engine in [1, 2]
+        let &regexpengine = engine
+        let chars = ['z', nr2char(0x7f), nr2char(0xff)]
+        if enc == 'utf-8'
+          call add(chars, nr2char(0x100))
+        endif
+        for c in chars
+          let prefix = repeat('x', 4096)
+          call assert_equal(-1, match('', c))
+          call assert_equal(-1, match(prefix, c))
+          call assert_equal(0, match(c .. prefix, c))
+          call assert_equal(4096, match(prefix .. c, c))
+        endfor
+        call assert_equal(-1, match('xxx', '\%d0'))
+      endfor
+    endfor
+  finally
+    let &encoding = save_encoding
+    let &regexpengine = save_re
+  endtry
+endfunc
+
 func s:equivalence_test()
   let str = "AÀÁÂÃÄÅĀĂĄǍǞǠǺȂȦȺḀẠẢẤẦẨẪẬẮẰẲẴẶ BƁɃḂḄḆ CÇĆĈĊČƇȻḈꞒ DĎĐƊḊḌḎḐḒ EÈÉÊËĒĔĖĘĚȄȆȨɆḔḖḘḚḜẸẺẼẾỀỂỄỆ FƑḞꞘ GĜĞĠĢƓǤǦǴḠꞠ HĤĦȞḢḤḦḨḪⱧ IÌÍÎÏĨĪĬĮİƗǏȈȊḬḮỈỊ JĴɈ KĶƘǨḰḲḴⱩꝀ LĹĻĽĿŁȽḶḸḺḼⱠ MḾṀṂ NÑŃŅŇǸṄṆṈṊꞤ OÒÓÔÕÖØŌŎŐƟƠǑǪǬǾȌȎȪȬȮȰṌṎṐṒỌỎỐỒỔỖỘỚỜỞỠỢ PƤṔṖⱣ QɊ RŔŖŘȐȒɌṘṚṜṞⱤꞦ SŚŜŞŠȘṠṢṤṦṨⱾꞨ TŢŤŦƬƮȚȾṪṬṮṰ UÙÚÛÜŨŪŬŮŰƯǕǙǛǓǗȔȖɄṲṴṶṸṺỤỦỨỪỬỮỰ  VƲṼṾ WŴẀẂẄẆẈ XẊẌ YÝŶŸƳȲɎẎỲỴỶỸ ZŹŻŽƵẐẒẔⱫ aàáâãäåāăąǎǟǡǻȃȧᶏḁẚạảấầẩẫậắằẳẵặⱥ bƀɓᵬᶀḃḅḇ cçćĉċčƈȼḉꞓꞔ dďđɗᵭᶁᶑḋḍḏḑḓ eèéêëēĕėęěȅȇȩɇᶒḕḗḙḛḝẹẻẽếềểễệ fƒᵮᶂḟꞙ gĝğġģǥǧǵɠᶃḡꞡ hĥħȟḣḥḧḩḫẖⱨꞕ iìíîïĩīĭįǐȉȋɨᶖḭḯỉị jĵǰɉ kķƙǩᶄḱḳḵⱪꝁ lĺļľŀłƚḷḹḻḽⱡ mᵯḿṁṃ nñńņňŉǹᵰᶇṅṇṉṋꞥ oòóôõöøōŏőơǒǫǭǿȍȏȫȭȯȱɵṍṏṑṓọỏốồổỗộớờởỡợ pƥᵱᵽᶈṕṗ qɋʠ rŕŗřȑȓɍɽᵲᵳᶉṛṝṟꞧ sśŝşšșȿᵴᶊṡṣṥṧṩꞩ tţťŧƫƭțʈᵵṫṭṯṱẗⱦ uùúûüũūŭůűųǚǖưǔǘǜȕȗʉᵾᶙṳṵṷṹṻụủứừửữự vʋᶌṽṿ wŵẁẃẅẇẉẘ xẋẍ yýÿŷƴȳɏẏẙỳỵỷỹ zźżžƶᵶᶎẑẓẕⱬ"
   let groups = split(str)


### PR DESCRIPTION
Replace the byte-by-byte scan in `vim_strbyte()` with `strchr()`, preserving its byte-range and NUL behavior. Add regression coverage for both regexp engines in Latin-1 and UTF-8.

Benchmark: 100 calls to `match(input, 'z')` on 3,000,000 `x` bytes, with either no match or one `z` appended. Times are medians of five runs on the same Linux machine with GCC `-O2`; before is `a96c3bc1f7`, after is `6c4e26fbaf`.

| Regexp engine | Match position | Before (ms) | After (ms) | Speedup |
| --- | --- | ---: | ---: | ---: |
| 1 | Absent | 260.865 | 29.894 | 8.73x |
| 1 | End | 224.975 | 28.697 | 7.84x |
| 2 | Absent | 210.428 | 29.356 | 7.17x |
| 2 | End | 165.721 | 28.718 | 5.77x |

Validation: build passed without new warnings; `test_regexp_latin` (34 tests), `test_regexp_utf8` (25 tests), and the Vim9 `escape`, `fnameescape`, and `shellescape` tests passed. Speedups are specific to this benchmark and libc implementation.

Additional UTF-8 performance comparison (same before/after revisions): 20 `match()` calls per sample, median of seven paired runs, pinned to CPU 0 with before/after execution order alternating. Tested on AMD Ryzen 7 7735HS, Linux/WSL, GCC 13.3.0 `-O2`, glibc 2.39. Every case also checks the expected match offset.

Inputs are approximately 3 MB: Japanese is `repeat('日本語', 333333)`, mixed is `repeat('abc日本語🙂', 187500)`, and combining is `repeat("a\u0301", 1000000)`. Search strings are `z` (ASCII), `界` (Japanese), or `🚀` (emoji). End-match cases append the search string. Negative time changes mean faster execution.

| Input / search string | Engine | Match position | Before (ms) | After (ms) | Time change |
| --- | --- | --- | ---: | ---: | ---: |
| Japanese / ASCII | 1 | Absent | 45.072 | 8.463 | -81.2% |
| Japanese / ASCII | 1 | End | 34.972 | 5.767 | -83.5% |
| Japanese / ASCII | 2 | Absent | 39.153 | 6.235 | -84.1% |
| Japanese / ASCII | 2 | End | 35.901 | 6.092 | -83.0% |
| Mixed / ASCII | 1 | Absent | 33.068 | 6.016 | -81.8% |
| Mixed / ASCII | 1 | End | 33.115 | 6.192 | -81.3% |
| Mixed / ASCII | 2 | Absent | 33.197 | 6.084 | -81.7% |
| Mixed / ASCII | 2 | End | 37.378 | 6.491 | -82.6% |
| Combining / ASCII | 1 | Absent | 38.202 | 5.857 | -84.7% |
| Combining / ASCII | 1 | End | 36.146 | 5.736 | -84.1% |
| Combining / ASCII | 2 | Absent | 35.942 | 6.074 | -83.1% |
| Combining / ASCII | 2 | End | 34.919 | 6.219 | -82.2% |
| Japanese / Japanese | 1 | Absent | 608.503 | 616.490 | +1.3% |
| Japanese / Japanese | 1 | End | 608.025 | 600.805 | -1.2% |
| Japanese / Japanese | 2 | Absent | 612.427 | 602.823 | -1.6% |
| Japanese / Japanese | 2 | End | 599.909 | 616.616 | +2.8% |
| Mixed / emoji | 1 | Absent | 548.959 | 541.048 | -1.4% |
| Mixed / emoji | 1 | End | 531.523 | 560.504 | +5.5% |
| Mixed / emoji | 2 | Absent | 537.845 | 558.084 | +3.8% |
| Mixed / emoji | 2 | End | 556.023 | 531.983 | -4.3% |

ASCII searches in these UTF-8 inputs were 81–85% faster. Searching for a multibyte character uses the unchanged multibyte path in `vim_strchr()`; its measured median changes ranged from -4.3% to +5.5%. Some cases measured slower, so these results do not justify an unconditional claim of no multibyte performance regression.
