### PR TITLE
Avoid repeated case conversion in fuzzy matching

### DIFF
--- a/src/fuzzy.c
+++ b/src/fuzzy.c
@@ -992,12 +992,13 @@ has_match(char_u *needle, char_u *haystack)
     while (*n_ptr)
     {
 	int n_char = mb_ptr2char(n_ptr);
+	int n_upper = MB_TOUPPER(n_char);
 	int found = FALSE;
 
 	while (*h_ptr)
 	{
 	    int h_char = mb_ptr2char(h_ptr);
-	    if (h_char == n_char || h_char == MB_TOUPPER(n_char))
+	    if (h_char == n_char || h_char == n_upper)
 	    {
 		found = TRUE;
 		h_ptr += mb_ptr2len(h_ptr);


### PR DESCRIPTION
Compute the uppercase search character once per character in `has_match()`, instead of repeating the conversion while scanning each candidate. This reduces work in fuzzy completion without changing matching or scoring.

Benchmark: five `matchfuzzypos()` calls per sample, median of seven paired trials with alternating before/after order, pinned to CPU 0. UTF-8, GCC `-O2`; before `a96c3bc1f7`, after `06ebf3020d`. Path cases use 8,430 tracked files under `src/` and `runtime/`; mixed cases prefix each path with `日本語/`, and Unicode-case candidates append `/École`. Short cases use 5,000 copies of `abc`. Negative time changes mean faster execution.

| Candidates | Pattern | Before (ms) | After (ms) | Time change |
| --- | --- | ---: | ---: | ---: |
| Paths | `zzzz` | 21.037 | 15.369 | -26.9% |
| Paths | `cmd` | 47.668 | 38.968 | -18.3% |
| Paths | `test vim` | 110.191 | 90.553 | -17.8% |
| Japanese + paths | `界` | 46.061 | 18.662 | -59.5% |
| Japanese + paths | `日cmd` | 60.188 | 50.384 | -16.3% |
| Paths + `/École` | `éco` | 130.553 | 101.616 | -22.2% |
| Short, exact match | `abc` | 22.159 | 22.359 | +0.9% |
| Short, no match | `z` | 3.467 | 3.110 | -10.3% |

All result lists, match positions, and scores were identical before and after in every trial. Multibyte cases improved in this benchmark; the short exact-match case measured 0.9% slower.

Validation: build passed without warnings; all nine `test_matchfuzzy` tests and four `Test_getcompletion*` tests in `test_cmdline` passed.
