### PR TITLE
Cannot use the stdin and stdout of Vim as a channel

### DIFF
--- a/runtime/doc/channel.txt
+++ b/runtime/doc/channel.txt
@@ -139,6 +139,24 @@ From another Vim instance (or any program) you can connect to it: >
 
 When done, close the server channel: >
 	call ch_close(server)
+<
+							*channel-stdio*
+Vim can also be the other end of a channel on its own stdin and stdout, like a
+language server that is started by an editor.  Start Vim with
+|--stdio-channel| and a script that opens the channel: >
+	vim --stdio-channel -S server.vim
+And in server.vim: >
+	func OnMessage(ch, msg)
+	  ...
+	endfunc
+	let ch = ch_open('stdio', #{mode: 'lsp', callback: 'OnMessage'})
+<
+							*E1582* *E1583*
+The address "stdio" can only be used when Vim was started with
+|--stdio-channel|, and only once.  The stdin and stdout of Vim are then
+redirected to the null device, so that messages from Vim and from the commands
+it starts do not get into the channel.  Stderr is left alone and can be used
+for error messages.
 
 ==============================================================================
 3. Opening a channel					*channel-open*
@@ -152,11 +170,12 @@ Use |ch_status()| to see if the channel could be opened.
 
 					*channel-address*
 {address} can be a domain name or an IP address, followed by a port number, or
-a Unix-domain socket path prefixed by "unix:".  E.g. >
+a Unix-domain socket path prefixed by "unix:", or "stdio".  E.g. >
     www.example.com:80   " domain + port
     127.0.0.1:1234       " IPv4 + port
     [2001:db8::1]:8765   " IPv6 + port
     unix:/tmp/my-socket  " Unix-domain socket path
+    stdio                " stdin and stdout of Vim, see |channel-stdio|
 
 When a domain name resolves to multiple addresses (e.g., both IPv6 and IPv4),
 Vim tries each address in order.  If a connection is slow or unreachable, it

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -443,6 +443,16 @@ a slash.  Thus "-R" means recovery and "-/R" readonly.
 --ttyfail	When the stdin or stdout is not a terminal (tty) then exit
 		right away.
 
+							*--stdio-channel*
+--stdio-channel	Use the stdin and stdout of Vim for a channel instead of for a
+		terminal.  Implies "-es": nothing is displayed, no Ex commands
+		are read and the GUI is not started.  A script opens the
+		channel with |ch_open()| and the address "stdio".
+		See |channel-stdio|.
+		After the startup commands and scripts have been executed Vim
+		waits for messages on the channel and exits when it is closed.
+		{only available when compiled with the |+channel| feature}
+
 							*-d*
 -d		Start in diff mode, like |vimdiff|.
 		{not available when compiled without the |+diff| feature}

--- a/runtime/doc/vim.1
+++ b/runtime/doc/vim.1
@@ -531,6 +531,14 @@ GTK GUI only: Use the GtkPlug mechanism to run gVim in another window.
 \-\-startuptime {file}
 During startup write timing messages to the file {fname}.
 .TP
+\-\-stdio\-channel
+Use the stdin and stdout of
+.B Vim
+for a channel instead of for a terminal.  Implies "\-es": nothing is
+displayed, no Ex commands are read and the GUI is not started.  A script
+opens the channel with ch_open() and the address "stdio", see ":help
+\-\-stdio\-channel".  Only available when compiled with the channel feature.
+.TP
 \-\-ttyfail
 When stdin or stdout is not a terminal (tty) then exit right away.
 .TP

--- a/src/channel.c
+++ b/src/channel.c
@@ -64,6 +64,7 @@ typedef struct sockaddr_un {
 static void channel_read(channel_T *channel, ch_part_T part, char *func);
 static ch_mode_T channel_get_mode(channel_T *channel, ch_part_T part);
 static int channel_get_timeout(channel_T *channel, ch_part_T part);
+static channel_T *channel_open_stdio(void);
 static ch_part_T channel_part_send(channel_T *channel);
 static ch_part_T channel_part_read(channel_T *channel);
 
@@ -1346,6 +1347,7 @@ channel_open_func(typval_T *argvars)
     int		port = 0;
     int		is_ipv6 = FALSE;
     int		is_unix = FALSE;
+    int		is_stdio = FALSE;
     jobopt_T    opt;
     channel_T	*channel = NULL;
 
@@ -1365,7 +1367,9 @@ channel_open_func(typval_T *argvars)
 	return NULL;
     }
 
-    if (STRNCMP(address, "unix:", 5) == 0)
+    if (STRCMP(address, "stdio") == 0)
+	is_stdio = TRUE;
+    else if (STRNCMP(address, "unix:", 5) == 0)
     {
 	is_unix = TRUE;
 	address += 5;
@@ -1392,7 +1396,7 @@ channel_open_func(typval_T *argvars)
 	}
     }
 
-    if (!is_unix)
+    if (!is_unix && !is_stdio)
     {
 	port = strtol((char *)(p + 1), &rest, 10);
 	if (port <= 0 || port >= 65536 || *rest != NUL)
@@ -1416,7 +1420,7 @@ channel_open_func(typval_T *argvars)
     opt.jo_timeout = 2000;
     if (get_job_options(&argvars[1], &opt,
 	    JO_MODE_ALL + JO_CB_ALL + JO_TIMEOUT_ALL
-		+ (is_unix? 0 : JO_WAITTIME), 0) == FAIL)
+		+ (is_unix || is_stdio ? 0 : JO_WAITTIME), 0) == FAIL)
 	goto theend;
     if (opt.jo_timeout < 0)
     {
@@ -1424,17 +1428,138 @@ channel_open_func(typval_T *argvars)
 	goto theend;
     }
 
-    if (is_unix)
+    if (is_stdio)
+	channel = channel_open_stdio();
+    else if (is_unix)
 	channel = channel_open_unix((char *)address, NULL);
     else
 	channel = channel_open((char *)address, port, opt.jo_waittime, NULL);
     if (channel != NULL)
     {
+	int	user_set = opt.jo_set;
+
 	opt.jo_set = JO_ALL;
+	if (is_stdio)
+	    // "mode" and "timeout" apply to both reading and writing, unless
+	    // given for a part specifically.
+	    opt.jo_set &= ~((JO_IN_MODE | JO_OUT_MODE | JO_ERR_MODE
+				| JO_OUT_TIMEOUT | JO_ERR_TIMEOUT) & ~user_set);
 	channel_set_options(channel, &opt);
     }
 theend:
     free_job_options(&opt);
+    return channel;
+}
+
+// The channel on the stdin and stdout of Vim, see --stdio-channel.
+static channel_T *stdio_channel = NULL;
+
+/*
+ * Open a channel that reads from the stdin of Vim and writes to its stdout.
+ * Only when started with --stdio-channel, and only once.
+ * Returns the channel for success.
+ * Returns NULL for failure.
+ */
+    static channel_T *
+channel_open_stdio(void)
+{
+    channel_T	*channel;
+    sock_T	in_fd;		// our stdin, the channel reads from it
+    sock_T	out_fd;		// our stdout, the channel writes to it
+
+    if (!use_stdio_channel)
+    {
+	emsg(_(e_not_started_with_stdio_channel));
+	return NULL;
+    }
+    if (stdio_channel != NULL)
+    {
+	emsg(_(e_cannot_open_stdio_channel));
+	return NULL;
+    }
+
+    // Point the original stdin and stdout at the null device, so that neither
+    // Vim nor the commands it starts can use the channel.
+#ifdef MSWIN
+    {
+	HANDLE	proc = GetCurrentProcess();
+	HANDLE	hin;
+	HANDLE	hout;
+	HANDLE	hnul;
+	int	nul_fd;
+
+	if (!DuplicateHandle(proc, GetStdHandle(STD_INPUT_HANDLE), proc, &hin,
+					      0, FALSE, DUPLICATE_SAME_ACCESS))
+	{
+	    emsg(_(e_cannot_open_stdio_channel));
+	    return NULL;
+	}
+	if (!DuplicateHandle(proc, GetStdHandle(STD_OUTPUT_HANDLE), proc,
+				       &hout, 0, FALSE, DUPLICATE_SAME_ACCESS))
+	{
+	    CloseHandle(hin);
+	    emsg(_(e_cannot_open_stdio_channel));
+	    return NULL;
+	}
+	hnul = CreateFile("NUL", GENERIC_READ | GENERIC_WRITE,
+		FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING, 0,
+		NULL);
+	if (hnul != INVALID_HANDLE_VALUE)
+	{
+	    SetStdHandle(STD_INPUT_HANDLE, hnul);
+	    SetStdHandle(STD_OUTPUT_HANDLE, hnul);
+	}
+	// The C runtime keeps its own stdout, used for messages.
+	nul_fd = _open("NUL", _O_RDWR);
+	if (nul_fd >= 0)
+	{
+	    _dup2(nul_fd, 1);
+	    _close(nul_fd);
+	}
+	in_fd = (sock_T)hin;
+	out_fd = (sock_T)hout;
+    }
+#else
+    {
+	int	nul_fd;
+
+	in_fd = dup(0);
+	out_fd = dup(1);
+	if (in_fd < 0 || out_fd < 0)
+	{
+	    if (in_fd >= 0)
+		close(in_fd);
+	    if (out_fd >= 0)
+		close(out_fd);
+	    emsg(_(e_cannot_open_stdio_channel));
+	    return NULL;
+	}
+	(void)fcntl(in_fd, F_SETFD, FD_CLOEXEC);
+	(void)fcntl(out_fd, F_SETFD, FD_CLOEXEC);
+	nul_fd = open("/dev/null", O_RDWR);
+	if (nul_fd >= 0)
+	{
+	    dup2(nul_fd, 0);
+	    dup2(nul_fd, 1);
+	    close(nul_fd);
+	}
+    }
+#endif
+
+    channel = add_channel();
+    if (channel == NULL)
+    {
+	ch_error(NULL, "Cannot allocate channel.");
+	fd_close(in_fd);
+	fd_close(out_fd);
+	return NULL;
+    }
+    channel_set_pipes(channel, out_fd, in_fd, INVALID_FD);
+    ch_log(channel, "Using stdin and stdout as a channel");
+
+    // Keep a reference for channel_stdio_loop().
+    ++channel->ch_refcount;
+    stdio_channel = channel;
     return channel;
 }
 
@@ -5511,6 +5636,69 @@ channel_select_check(int ret_in, void *rfds_in, void *wfds_in)
     return ret;
 }
 #endif // !MSWIN && HAVE_SELECT
+
+/*
+ * Wait up to "msec" for something to read on any channel and read it.
+ * For channel_stdio_loop(), which has no terminal to wait for.
+ */
+    static void
+channel_wait_any(long msec)
+{
+#ifdef MSWIN
+    // A pipe cannot be waited for, channel_wait() polls it.
+    if (stdio_channel->CH_OUT_FD != INVALID_FD)
+	(void)channel_wait(stdio_channel, stdio_channel->CH_OUT_FD,
+						(int)(msec > 20 ? 20 : msec));
+    channel_handle_events(FALSE);
+#elif defined(HAVE_SELECT)
+    fd_set		rfds;
+    fd_set		wfds;
+    struct timeval	tv;
+    struct timeval	*tvp = &tv;
+    int			maxfd;
+    int			ret;
+
+    FD_ZERO(&rfds);
+    FD_ZERO(&wfds);
+    tv.tv_sec = msec / 1000;
+    tv.tv_usec = (msec % 1000) * 1000;
+    maxfd = channel_select_setup(-1, &rfds, &wfds, &tv, &tvp);
+    ret = select(maxfd + 1, &rfds, &wfds, NULL, tvp);
+    if (ret >= 0)
+	(void)channel_select_check(ret, &rfds, &wfds);
+#else
+    struct pollfd	fds[4 * MAX_OPEN_CHANNELS + MAX_CLIENT_CHANNELS];
+    int			nfd;
+    int			towait = (int)msec;
+    int			ret;
+
+    nfd = channel_poll_setup(0, fds, &towait);
+    ret = poll(fds, nfd, towait);
+    if (ret >= 0)
+	(void)channel_poll_check(ret, fds);
+#endif
+}
+
+/*
+ * Wait for messages on the stdio channel and handle them, until the channel
+ * is closed.  Takes the place of the main loop with --stdio-channel.
+ */
+    void
+channel_stdio_loop(void)
+{
+    while (stdio_channel != NULL && channel_is_open(stdio_channel))
+    {
+	long	msec = 1000;
+#ifdef FEAT_TIMERS
+	long	due_time = check_due_timer();
+
+	if (due_time > 0 && due_time < msec)
+	    msec = due_time;
+#endif
+	channel_wait_any(msec);
+	parse_queued_messages();
+    }
+}
 
 /*
  * Execute queued up commands.

--- a/src/errors.h
+++ b/src/errors.h
@@ -3826,3 +3826,9 @@ EXTERN char e_too_many_text_properties_on_a_single_line[]
 EXTERN char e_cannot_extend_null_blob[]
 	INIT(= N_("E1581: Cannot extend a null blob"));
 #endif
+#ifdef FEAT_JOB_CHANNEL
+EXTERN char e_not_started_with_stdio_channel[]
+	INIT(= N_("E1582: Not started with --stdio-channel"));
+EXTERN char e_cannot_open_stdio_channel[]
+	INIT(= N_("E1583: Cannot open stdio channel"));
+#endif

--- a/src/globals.h
+++ b/src/globals.h
@@ -1198,6 +1198,11 @@ EXTERN int	sandbox INIT(= 0);
 EXTERN int	silent_mode INIT(= FALSE);
 				// set to TRUE when "-s" commandline argument
 				// used for ex
+#ifdef FEAT_JOB_CHANNEL
+EXTERN int	use_stdio_channel INIT(= FALSE);
+				// set to TRUE for the "--stdio-channel"
+				// commandline argument
+#endif
 
 EXTERN pos_T	VIsual;		// start position of active Visual selection
 EXTERN int	VIsual_active INIT(= FALSE);

--- a/src/main.c
+++ b/src/main.c
@@ -971,6 +971,16 @@ vim_main2(void)
 
     TIME_MSG("before starting main loop");
 
+# ifdef FEAT_JOB_CHANNEL
+    if (use_stdio_channel)
+    {
+	// Serve the stdio channel instead of reading Ex commands, exit when
+	// it is closed.
+	channel_stdio_loop();
+	getout(0);
+    }
+# endif
+
     /*
      * Call the main command loop.  This never returns.
      */
@@ -2217,6 +2227,7 @@ command_line_scan(mparm_T *parmp)
 				// "--not-a-term" don't warn for not a term
 				// "--gui-dialog-file fname" write dialog text
 				// "--ttyfail" exit if not a term
+				// "--stdio-channel" use stdin/stdout as channel
 				// "--noplugin[s]" skip plugins
 				// "--cmd <cmd>" execute cmd before vimrc
 		if (STRICMP(argv[0] + argv_idx, "help") == 0)
@@ -2267,6 +2278,19 @@ command_line_scan(mparm_T *parmp)
 		}
 		else if (STRNICMP(argv[0] + argv_idx, "ttyfail", 7) == 0)
 		    parmp->tty_fail = TRUE;
+# ifdef FEAT_JOB_CHANNEL
+		else if (STRNICMP(argv[0] + argv_idx, "stdio-channel", 13) == 0)
+		{
+		    // Like "-es": no terminal, but the channel is served
+		    // instead of reading Ex commands.
+		    use_stdio_channel = TRUE;
+		    exmode_active = EXMODE_NORMAL;
+		    silent_mode = TRUE;
+#  if defined(FEAT_GUI) && !defined(VIMDLL)
+		    gui.starting = false;	// don't start GUI
+#  endif
+		}
+# endif
 		else if (STRNICMP(argv[0] + argv_idx, "cmd", 3) == 0)
 		{
 		    want_argument = TRUE;
@@ -3758,6 +3782,9 @@ usage(void)
     main_msg(_("--gui-dialog-file {fname}  For testing: write dialog text"));
 # endif
     main_msg(_("--ttyfail\t\tExit if input or output is not a terminal"));
+# ifdef FEAT_JOB_CHANNEL
+    main_msg(_("--stdio-channel\tUse stdin and stdout as a channel"));
+# endif
     main_msg(_("-u <vimrc>\t\tUse <vimrc> instead of any .vimrc"));
 # ifdef FEAT_GUI
     main_msg(_("-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"));

--- a/src/proto/channel.pro
+++ b/src/proto/channel.pro
@@ -45,6 +45,7 @@ int channel_poll_setup(int nfd_in, void *fds_in, int *towait);
 int channel_poll_check(int ret_in, void *fds_in);
 int channel_select_setup(int maxfd_in, void *rfds_in, void *wfds_in, struct timeval *tv, struct timeval **tvp);
 int channel_select_check(int ret_in, void *rfds_in, void *wfds_in);
+void channel_stdio_loop(void);
 int channel_parse_messages(void);
 int channel_any_readahead(void);
 int set_ref_in_channel(int copyID);

--- a/src/testdir/test_channel.vim
+++ b/src/testdir/test_channel.vim
@@ -2933,6 +2933,50 @@ func Test_listen_unix_first_socket()
   call delete('Xlistensock')
 endfunc
 
+" A Vim started with --stdio-channel answers on its stdin and stdout.
+func Test_stdio_channel()
+  if has('win32') && has('gui_running')
+    throw 'Skipped: gvim.exe cannot run without the GUI'
+  endif
+  let lines =<< trim END
+    func OnMessage(ch, msg)
+      if a:msg.method == 'ping'
+        call ch_sendexpr(a:ch, #{id: a:msg.id, result: 'pong ' .. a:msg.params})
+      elseif a:msg.method == 'again'
+        try
+          call ch_open('stdio')
+          let err = 'none'
+        catch
+          let err = v:exception
+        endtry
+        call ch_sendexpr(a:ch, #{id: a:msg.id, result: err})
+      endif
+    endfunc
+    let ch = ch_open('stdio', #{mode: 'lsp', callback: 'OnMessage'})
+    " Output of Vim itself must not get into the channel.
+    set verbose=1
+    echo 'noise'
+  END
+  call writefile(lines, 'Xstdio_server.vim', 'D')
+
+  let job = job_start([GetVimProg(), '--clean', '--stdio-channel',
+        \ '-S', 'Xstdio_server.vim'], #{in_mode: 'lsp', out_mode: 'lsp'})
+  call assert_equal('run', job_status(job))
+
+  let resp = ch_evalexpr(job, #{method: 'ping', params: 'x'}, #{timeout: 5000})
+  call assert_equal('pong x', resp->get('result', resp))
+  let resp = ch_evalexpr(job, #{method: 'again'}, #{timeout: 5000})
+  call assert_match('E1583:', resp->get('result', ''))
+
+  " Without --stdio-channel the address cannot be used.
+  call assert_fails("call ch_open('stdio')", 'E1582:')
+
+  " The child exits when its stdin is closed.
+  call ch_close(job)
+  call WaitForAssert({-> assert_equal('dead', job_status(job))})
+  call job_stop(job)
+endfunc
+
 func Test_channel_lsp_mode()
   " The channel lsp mode test is flaky and gives the same error.
   let g:giveup_same_error = 0


### PR DESCRIPTION
```
Problem:  A Vim started by another program cannot talk to it over its
          stdin and stdout the way a language server does; a script has
          to make it connect to a socket instead.
Solution: Add the --stdio-channel argument and the "stdio" address for
          ch_open().  Vim then serves the channel instead of reading Ex
          commands and exits when it is closed.  Stdin and stdout are
          redirected to the null device so that other output cannot get
          into the channel.
```

---

With `--stdio-channel` Vim can be the process at the other end of a channel:
it is started by another program and talks to it over its own stdin and
stdout, the way language servers and other tools do.  Until now a Vim that
had to serve another process needed a socket, and a script to set up the
connection on both sides.

### What this makes possible:

- A language server for Vim script, written in Vim script.  The server runs
  in a Vim, so it can use getcompletion(), the help files and the user's
  'runtimepath' to answer requests.  Any editor whose LSP client speaks stdio
  can start it with `vim --stdio-channel -S server.vim`; no client-side
  support for sockets is needed.

- Vim as a worker for Vim.  A child Vim can be started with job_start() like
  any other job and used in JSON mode, to run slow Vim script or a large
  search and replace without blocking the editor, or to run code that may
  crash without taking the editor down.

- Embedding Vim in other programs.  A Python or Node program can start a Vim
  and drive it through the existing channel commands ("ex", "normal", "call",
  "expr") in one session, instead of a temporary file and a new `vim -es` for
  every step.

- Testing.  The state of a child Vim can be queried directly over the
  channel, without a terminal or a Python test server in between.

The change reuses the existing channel code: the two file descriptors are
handed to channel_set_pipes() and the "lsp" and "json" modes work unchanged.
After the channel is opened the stdin and stdout of Vim point at the null
device, so messages from Vim and from commands it starts cannot corrupt the
protocol; stderr is left for error messages.  Works on Unix and MS-Windows.