### PR TITLE
MS-Windows: no terminal warnings when the parent passes pipes

### DIFF
--- a/src/os_mswin.c
+++ b/src/os_mswin.c
@@ -165,7 +165,7 @@ mch_input_isatty(void)
 	return TRUE;	    // GUI always has a tty
 #endif
 #if !defined(FEAT_GUI_MSWIN) || defined(VIMDLL)
-    if (isatty(read_cmd_fd))
+    if (isatty(read_cmd_fd) || mch_input_from_console())
 	return TRUE;
     return FALSE;
 #endif

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -34,6 +34,10 @@
 #include <winternl.h>
 #include <direct.h>
 
+#if !defined(FEAT_GUI_MSWIN) || defined(VIMDLL)
+# include "iscygpty.h"
+#endif
+
 #if !defined(FEAT_GUI_MSWIN)
 # include <shellapi.h>
 #endif
@@ -2331,12 +2335,14 @@ conio_replaceable(HANDLE h)
 
 /*
  * Return TRUE when Vim uses the console for the screen.  Not in Ex or silent
- * mode, which use streams, and not with "--not-a-term".
+ * mode, which use streams, not with "--not-a-term", and not in a Cygwin or
+ * MSYS pty, which check_tty() refuses to run in.
  */
     static int
 want_console_io(void)
 {
-    return !is_not_a_term() && !silent_mode && !exmode_active;
+    return !is_not_a_term() && !silent_mode && !exmode_active
+						    && !is_cygpty_used();
 }
 
 /*

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -2306,6 +2306,52 @@ create_conin(void)
 }
 
 /*
+ * Create the console output.  Used when writing to stdout doesn't work.
+ * GENERIC_READ is also needed, the console screen buffer is read back for the
+ * text attributes and, on an older console, to save the screen contents.
+ */
+    static void
+create_conout(void)
+{
+    g_hConOut =	CreateFile("CONOUT$", GENERIC_READ|GENERIC_WRITE,
+			FILE_SHARE_READ|FILE_SHARE_WRITE,
+			(LPSECURITY_ATTRIBUTES) NULL,
+			OPEN_EXISTING, 0, (HANDLE)NULL);
+}
+
+/*
+ * Return TRUE when "h" is a pipe, and thus does not lead to the console.
+ * A console handle or a redirection to a file is left alone.
+ */
+    static int
+conio_replaceable(HANDLE h)
+{
+    return GetFileType(h) == FILE_TYPE_PIPE;
+}
+
+/*
+ * Return TRUE when Vim uses the console for the screen.  Not in Ex or silent
+ * mode, which use streams, and not with "--not-a-term".
+ */
+    static int
+want_console_io(void)
+{
+    return !is_not_a_term() && !silent_mode && !exmode_active;
+}
+
+/*
+ * Return TRUE if Vim reads its keys from the console device.  That device has
+ * no file descriptor, so isatty() cannot see it.
+ */
+    int
+mch_input_from_console(void)
+{
+    DWORD	mode;
+
+    return GetConsoleMode(g_hConIn, &mode) != 0;
+}
+
+/*
  * Get a keystroke or a mouse event, use a blocking wait.
  */
     static WCHAR
@@ -3469,12 +3515,31 @@ mch_init_c(void)
     _fmode = O_BINARY;		// we do our own CR-LF translation
     out_flush();
 
-    // Obtain handles for the standard Console I/O devices
-    if (read_cmd_fd == 0)
-	g_hConIn =  GetStdHandle(STD_INPUT_HANDLE);
-    else
+    /*
+     * Obtain handles for the standard Console I/O devices.  A parent process
+     * may pass a pipe instead of the console; the console API fails on that,
+     * so use the console device.  Without a console the open fails.
+     */
+    if (read_cmd_fd != 0		// "vim -": stdin is the text to edit
+	    || (want_console_io()
+		    && conio_replaceable(GetStdHandle(STD_INPUT_HANDLE))))
 	create_conin();
-    g_hConOut = GetStdHandle(STD_OUTPUT_HANDLE);
+    else
+	g_hConIn = GetStdHandle(STD_INPUT_HANDLE);
+
+    if (want_console_io()
+		    && conio_replaceable(GetStdHandle(STD_OUTPUT_HANDLE)))
+    {
+	create_conout();
+	if (g_hConOut == INVALID_HANDLE_VALUE)
+	    g_hConOut = GetStdHandle(STD_OUTPUT_HANDLE);
+	else
+	    // "stdout_isatty" was set in common_init_2(), which runs before
+	    // mch_init(), from a handle that is still a pipe.
+	    stdout_isatty = TRUE;
+    }
+    else
+	g_hConOut = GetStdHandle(STD_OUTPUT_HANDLE);
 
     wt_init();
     vtp_flag_init();
@@ -9148,7 +9213,9 @@ vtp_flag_init(void)
     if (!gui.in_use)
 # endif
     {
-	out = GetStdHandle(STD_OUTPUT_HANDLE);
+	// Use the console Vim draws on, a pipe has no console mode.
+	out = (g_hConOut != INVALID_HANDLE_VALUE)
+			  ? g_hConOut : GetStdHandle(STD_OUTPUT_HANDLE);
 
 	vtp_working = (win_version >= VTP_FIRST_SUPPORT_BUILD) ? 1 : 0;
 	GetConsoleMode(out, &mode);

--- a/src/proto/os_win32.pro
+++ b/src/proto/os_win32.pro
@@ -15,6 +15,7 @@ int test_mswin_event(char_u *event, dict_T *args);
 void mch_update_cursor(void);
 int mch_char_avail(void);
 int mch_check_messages(void);
+int mch_input_from_console(void);
 int mch_inchar(char_u *buf, int maxlen, long time, int tb_change_cnt);
 void mch_init(void);
 void mch_exit(int r);

--- a/src/testdir/test_mswin_console.py
+++ b/src/testdir/test_mswin_console.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+#
+# Start Vim with no console attached at all and pipes on every standard
+# handle.  Used by test_startup.vim.
+#
+# Vim script cannot start a process this way: DETACHED_PROCESS is a
+# CreateProcess() flag that job_start() does not offer.  Without a console
+# there is no console device to fall back to, so mch_init_c() has to leave
+# the pipes alone and Vim has to report that it has no terminal.
+#
+# Vim is given "--ttyfail", so it exits(1) from check_tty() before sourcing
+# anything.  The script it is handed writes a file, which must therefore not
+# appear.
+#
+# One line of "name=value" pairs is printed for the Vim test to check.
+#
+# This requires Python 3.
+
+import os
+import subprocess
+import sys
+
+DETACHED_PROCESS = 0x00000008
+PROBE = 'Xnoconsole.vim'
+RESULT = 'Xnoconsole_result'
+
+
+def main():
+    if len(sys.argv) < 2:
+        sys.stderr.write('usage: test_mswin_console.py <vim-executable>\n')
+        return 2
+
+    with open(PROBE, 'w') as f:
+        f.write('call writefile(["reached"], "' + RESULT + '")\n')
+        f.write('qall!\n')
+    if os.path.exists(RESULT):
+        os.remove(RESULT)
+
+    proc = subprocess.Popen(
+        [sys.argv[1], '-u', 'NONE', '-i', 'NONE', '--ttyfail', '-S', PROBE],
+        stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        creationflags=DETACHED_PROCESS)
+    try:
+        err = proc.communicate(timeout=30)[1]
+        code = proc.returncode
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        err = proc.communicate()[1]
+        code = -1
+    err = err.decode('utf-8', 'replace')
+
+    print('exit=%d out_warn=%d in_warn=%d reached=%d' % (
+        code,
+        'Output is not to a terminal' in err,
+        'Input is not from a terminal' in err,
+        os.path.exists(RESULT)))
+
+    for name in (PROBE, RESULT):
+        if os.path.exists(name):
+            os.remove(name)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/src/testdir/test_startup.vim
+++ b/src/testdir/test_startup.vim
@@ -1224,6 +1224,147 @@ func Test_io_not_a_terminal()
         \ 'Vim: Warning: Input is not from a terminal'], l)
 endfunc
 
+" Tests for MS-Windows using the console device when a standard handle is a
+" pipe rather than the console.  A parent process is free to hand a child
+" pipes, and some shells do so for the programs they start.  See mch_init_c()
+" in os_win32.c.
+"
+" system() with a List bypasses the shell, so the child gets pipes for its
+" standard handles while this Vim's console stays attached, which is the state
+" under test.  "--ttyfail" makes Vim exit(1) from check_tty() before sourcing
+" anything, so a build that does not reach the console device leaves no result
+" file rather than hanging on a screen it cannot draw.
+"
+" A console must be attached, so these are skipped in the GUI.  Running them
+" with no console attached at all would fail rather than skip.
+func s:WriteTtyProbe()
+  call writefile([
+        \ 'call writefile([has("ttyout") .. " " .. has("ttyin")'
+        \    .. ' .. " " .. has("vcon")], "Xttyresult")',
+        \ 'qall!',
+        \ ], 'Xttyprobe.vim')
+endfunc
+
+" A pipe on the standard handles is replaced by the console device.
+func Test_mswin_console_for_piped_stdio()
+  CheckMSWindows
+  CheckNotGui
+
+  call s:WriteTtyProbe()
+  call delete('Xttyresult')
+  call system([v:progpath, '-u', 'NONE', '-i', 'NONE', '--ttyfail',
+        \ '-S', 'Xttyprobe.vim'])
+
+  call assert_true(filereadable('Xttyresult'),
+        \ 'Vim exited early: the console device was not used for a pipe')
+  let res = split(readfile('Xttyresult')[0])
+  call assert_equal('1', res[0], 'has("ttyout")')
+  if has('vtp')
+    " vtp_flag_init() must probe the console, not the standard handle.
+    call assert_equal('1', res[2], 'has("vcon")')
+  endif
+
+  call delete('Xttyresult')
+  call delete('Xttyprobe.vim')
+endfunc
+
+" A pipe on standard input is replaced by the console device.  This goes
+" through a shell pipeline: system() with a List leaves the child's standard
+" input as something isatty() already accepts, so it would not exercise this.
+" The trailing pipe is needed too, so that standard output is a pipe rather
+" than the file system() would otherwise redirect it to.
+func Test_mswin_console_for_piped_stdin()
+  CheckMSWindows
+  CheckNotGui
+
+  call s:WriteTtyProbe()
+  call delete('Xttyresult')
+  call system('echo hi | ' .. v:progpath
+        \ .. ' -u NONE -i NONE --ttyfail -S Xttyprobe.vim | sort')
+
+  call assert_true(filereadable('Xttyresult'),
+        \ 'Vim exited early: the console device was not used for piped stdin')
+  let res = split(readfile('Xttyresult')[0])
+  call assert_equal('1', res[1], 'has("ttyin")')
+
+  call delete('Xttyresult')
+  call delete('Xttyprobe.vim')
+endfunc
+
+" With no console attached there is no console device to fall back to, so the
+" pipes are left alone and Vim reports that it has no terminal.  This needs a
+" helper: Vim script cannot start a process with DETACHED_PROCESS.
+func Test_mswin_console_absent()
+  CheckMSWindows
+  CheckNotGui
+  CheckEnglish
+
+  let python = PythonProg()
+  if python == ''
+    throw 'Skipped: python program missing'
+  endif
+
+  let out = system(python .. ' test_mswin_console.py "' .. v:progpath .. '"')
+  call assert_equal('exit=1 out_warn=1 in_warn=1 reached=0', trim(out))
+endfunc
+
+" A handle redirected to a file is what the caller asked for: not replaced.
+func Test_mswin_console_not_used_for_file()
+  CheckMSWindows
+  CheckNotGui
+
+  call s:WriteTtyProbe()
+  call delete('Xttyresult')
+  " Through the shell, so that stdout is a file rather than a pipe.
+  call system(v:progpath
+        \ .. ' -u NONE -i NONE --ttyfail -S Xttyprobe.vim > Xttyout')
+
+  call assert_equal(1, v:shell_error)
+  call assert_false(filereadable('Xttyresult'),
+        \ 'a handle redirected to a file must not be replaced')
+
+  call delete('Xttyout')
+  call delete('Xttyprobe.vim')
+endfunc
+
+" Ex and silent mode read and write streams instead of drawing a screen, so
+" the console device is not used even when the handles are pipes.
+func Test_mswin_console_not_used_for_ex_mode()
+  CheckMSWindows
+  CheckNotGui
+
+  call s:WriteTtyProbe()
+  call delete('Xttyresult')
+  call system([v:progpath, '-u', 'NONE', '-i', 'NONE', '-es',
+        \ '-S', 'Xttyprobe.vim'])
+
+  call assert_true(filereadable('Xttyresult'))
+  let res = split(readfile('Xttyresult')[0])
+  call assert_equal('0', res[0], 'has("ttyout") must stay 0 in Ex mode')
+
+  call delete('Xttyresult')
+  call delete('Xttyprobe.vim')
+endfunc
+
+" "vim -" still reads the text to edit from the pipe on stdin.
+func Test_mswin_dash_still_reads_stdin()
+  CheckMSWindows
+  CheckNotGui
+
+  call writefile([
+        \ 'call writefile(getline(1, "$"), "Xttybuf")',
+        \ 'qall!',
+        \ ], 'Xstdinprobe.vim')
+  call delete('Xttybuf')
+  call system([v:progpath, '-u', 'NONE', '-i', 'NONE',
+        \ '-S', 'Xstdinprobe.vim', '-'], "hello from stdin\n")
+
+  call assert_equal(['hello from stdin'], readfile('Xttybuf'))
+
+  call delete('Xttybuf')
+  call delete('Xstdinprobe.vim')
+endfunc
+
 " Test for --not-a-term avoiding escape codes.
 func Test_not_a_term()
   CheckUnix


### PR DESCRIPTION
## Problem

On MS-Windows Vim prints

```
Vim: Warning: Output is not to a terminal
Vim: Warning: Input is not from a terminal
```

when the parent process passes pipes on all three standard handles while a
console is still attached.  `has('vcon')` is then 0 and `:set termguicolors`
fails with E954, because the console API cannot work on a pipe.

Reproducible from an interactive PowerShell -- both 7.x and Windows PowerShell
5.1, with `-NoProfile` -- on Windows 11.  A non-interactive `pwsh -File` run
does not do it.  Why the parent hands over pipes was not established; the fix
does not depend on the reason.

## Solution

`mch_init_c()` opens the console device when a standard handle is a pipe --
input via `create_conin()`, output via a new `create_conout()`.
`stdout_isatty` is set, because `common_init_2()` computed it earlier from the
pipe.  `mch_input_isatty()` also reports the console, since that device has no
file descriptor for `isatty()` to see.  `vtp_flag_init()` probes the console
Vim draws on instead of the standard handle.

A handle that is a file or a character device is used as it is, so redirection
keeps working.  Ex mode, silent mode and `--not-a-term` never take the console,
and `vim -` still reads its text from stdin.

## Tests

Six tests in `src/testdir/test_startup.vim`, plus `src/testdir/test_mswin_console.py`
for the no-console case, since Vim script cannot start a process with
`DETACHED_PROCESS`.

Fail before, pass after -- measured against an unpatched build of the same
tree: `Test_mswin_console_for_piped_stdin()` and
`Test_mswin_console_for_piped_stdio()` fail without the patch and pass with it.
The other four assert that existing behaviour is preserved and pass either way.

Full suite: 38 failures unpatched, 36 patched, none unique to the patch -- the
remainder are Unix tools missing from my Windows test environment.  Console,
GUI and VIMDLL all build clean, and `codestyle` passes.