### PR TITLE
backtracking engine stack push is slower than necessary

### DIFF
--- a/src/regexp_bt.c
+++ b/src/regexp_bt.c
@@ -3188,7 +3188,7 @@ regstack_push(regstate_T state, char_u *scan)
 	emsg(_(e_pattern_uses_more_memory_than_maxmempattern));
 	return NULL;
     }
-    if (ga_grow(&regstack, sizeof(regitem_T)) == FAIL)
+    if (GA_GROW_FAILS(&regstack, (int)sizeof(regitem_T)))
 	return NULL;
 
     rp = (regitem_T *)((char *)regstack.ga_data + regstack.ga_len);
@@ -3924,7 +3924,7 @@ regmatch(
 		if (i == backpos.ga_len)
 		{
 		    // First time at this BACK, make room to store the pos.
-		    if (ga_grow(&backpos, 1) == FAIL)
+		    if (GA_GROW_FAILS(&backpos, 1))
 			status = RA_FAIL;
 		    else
 		    {
@@ -4324,7 +4324,7 @@ regmatch(
 			emsg(_(e_pattern_uses_more_memory_than_maxmempattern));
 			status = RA_FAIL;
 		    }
-		    else if (ga_grow(&regstack, sizeof(regstar_T)) == FAIL)
+		    else if (GA_GROW_FAILS(&regstack, (int)sizeof(regstar_T)))
 			status = RA_FAIL;
 		    else
 		    {
@@ -4369,7 +4369,7 @@ regmatch(
 		emsg(_(e_pattern_uses_more_memory_than_maxmempattern));
 		status = RA_FAIL;
 	    }
-	    else if (ga_grow(&regstack, sizeof(regbehind_T)) == FAIL)
+	    else if (GA_GROW_FAILS(&regstack, (int)sizeof(regbehind_T)))
 		status = RA_FAIL;
 	    else
 	    {


### PR DESCRIPTION
Problem:  The backtracking regexp engine calls ga_grow() as an
          out-of-line function on every regstack/backpos push, even in
          the common case where the growable array already has room.
Solution: Use the inlined GA_GROW_FAILS() macro, which checks the
          capacity inline and only calls ga_grow_inner() when the array
          actually needs to grow, matching the pattern already used in
          vim9execute.c.

The backtracking engine is used for patterns with backreferences, look-behind and an explicit \%#=1, most visibly by syntax files that force it (yaml, python, ruby). Converting the four hot ga_grow() call sites in regmatch()/regstack_push() to GA_GROW_FAILS() removes the per-push call overhead. On a \%#=1-forced substitute/match benchmark this is about -3.6%; on real-world YAML syntax highlighting, whose number/float/timestamp rules use \%#=1 heavily, about -1.9%.