### PR TITLE
NFA word-boundary checks are slower than necessary

### DIFF
--- a/src/regexp_bt.c
+++ b/src/regexp_bt.c
@@ -3517,7 +3517,11 @@ regmatch(
 	  case BOW:	// \<word; rex.input points to w
 	    if (c == NUL)	// Can't match at end of line
 		status = RA_NOMATCH;
-	    else if (has_mbyte)
+	    // An ASCII byte under UTF-8 gets the same result from the cheaper
+	    // non-mbyte branch below.
+	    else if (has_mbyte
+		    && !(enc_utf8 && c < 0x80
+			&& (rex.input == rex.line || rex.input[-1] < 0x80)))
 	    {
 		int this_class;
 
@@ -3539,7 +3543,9 @@ regmatch(
 	  case EOW:	// word\>; rex.input points after d
 	    if (rex.input == rex.line)    // Can't match at start of line
 		status = RA_NOMATCH;
-	    else if (has_mbyte)
+	    // ASCII fast path, see BOW above.
+	    else if (has_mbyte
+		    && !(enc_utf8 && c < 0x80 && rex.input[-1] < 0x80))
 	    {
 		int this_class, prev_class;
 

--- a/src/regexp_nfa.c
+++ b/src/regexp_nfa.c
@@ -6333,7 +6333,11 @@ nfa_regmatch(
 
 		if (curc == NUL)
 		    result = FALSE;
-		else if (has_mbyte)
+		// An ASCII byte under UTF-8 gets the same result from the cheaper
+		// non-mbyte branch below.
+		else if (has_mbyte
+			&& !(enc_utf8 && curc < 0x80
+			    && (rex.input == rex.line || rex.input[-1] < 0x80)))
 		{
 		    int this_class;
 
@@ -6359,7 +6363,9 @@ nfa_regmatch(
 		result = TRUE;
 		if (rex.input == rex.line)
 		    result = FALSE;
-		else if (has_mbyte)
+		// ASCII fast path, see NFA_BOW above.
+		else if (has_mbyte
+			&& !(enc_utf8 && curc < 0x80 && rex.input[-1] < 0x80))
 		{
 		    int this_class, prev_class;
 

--- a/src/testdir/test_regexp_utf8.vim
+++ b/src/testdir/test_regexp_utf8.vim
@@ -710,4 +710,39 @@ func Test_lookbehind_submatch_on_second_line()
   bwipe!
 endfunc
 
+" Test \< and \> where an ASCII byte meets a multi-byte character.  This is
+" what the ASCII fast path in the BOW/EOW handling must get right: the byte
+" before the current one may be a multi-byte tail, so the class of the
+" neighbour still has to be considered.
+func Test_word_boundary_ascii_multibyte()
+  new
+  let save_re = &regexpengine
+  for engine in [0, 1, 2]
+    let &regexpengine = engine
+    let msg = 're' .. engine
+
+    " Latin-1 and Cyrillic letters have the same word class as ASCII letters,
+    " so an ASCII byte next to them is inside the same word: no boundary.
+    call setline(1, 'abcé déf')
+    call assert_equal('|abcé |déf', substitute(getline(1), '\<', '|', 'g'), msg)
+    call assert_equal('abcé| déf|', substitute(getline(1), '\>', '|', 'g'), msg)
+    call setline(1, 'aФ Фb ab')
+    call assert_equal('|aФ |Фb |ab', substitute(getline(1), '\<', '|', 'g'), msg)
+    call assert_equal('aФ| Фb| ab|', substitute(getline(1), '\>', '|', 'g'), msg)
+
+    " CJK characters have a different word class, so the ASCII/CJK border is a
+    " word boundary.
+    call setline(1, 'test日本word 文字')
+    call assert_equal('|test|日本|word |文字', substitute(getline(1), '\<', '|', 'g'), msg)
+    call assert_equal('test|日本|word| 文字|', substitute(getline(1), '\>', '|', 'g'), msg)
+
+    " A composing character attaches to its ASCII base, no boundary there.
+    call setline(1, "cafe\u0301 nai\u0308ve xy")
+    call assert_equal("|cafe\u0301 |nai\u0308ve |xy", substitute(getline(1), '\<', '|', 'g'), msg)
+    call assert_equal("cafe\u0301| nai\u0308ve| xy|", substitute(getline(1), '\>', '|', 'g'), msg)
+  endfor
+  let &regexpengine = save_re
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  The NFA regexp engine tests the \< and \> word boundaries
          with mb_get_class_buf() and reg_prev_class() for every
          character, even for plain ASCII text where the cheaper
          vim_iswordc_buf() based test gives the same result.
Solution: For an ASCII byte with a UTF-8 encoding, skip the multi-byte
          branch and use the non-multi-byte branch instead, which avoids
          the mb_get_class_buf() and reg_prev_class() calls.

The NFA_BOW and NFA_EOW cases pick between a multi-byte, character-class based test and a plain vim_iswordc_buf() based test. For a byte < 0x80 under UTF-8 the two are equivalent, so route ASCII characters through the cheaper branch. The guard requires both the current and the neighbouring byte to be ASCII so a word character next to a multi-byte one is still handled by the multi-byte branch; it is limited to UTF-8 because a DBCS trailing byte can be below 0x80.

Word boundaries (\<, \>, \w) are pervasive in syntax highlighting and text editing. Measured with retired instructions: word-boundary matching -3.2%, a general substitute -3.3%, Python syntax highlighting -1.1%, Ruby -0.8%.