### PR TITLE
terminalprops() does not report a direct color terminal

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -12196,6 +12196,7 @@ terminalprops()						*terminalprops()*
 		   mouse		mouse type supported
 		   kitty		whether Kitty terminal was detected
 		   decrqm		whether sending DECRQM sequences work
+		   rgb			whether the terminal has true color  **
 
 		** value 'u' for unknown, 'y' for yes, 'n' for no
 
@@ -12217,6 +12218,9 @@ terminalprops()						*terminalprops()*
 
 		If "decrqm" is 'y', then Vim will query support for the
 		'termsync' and 'termresize' ("inband") options.
+
+		"rgb" is 'y' when 't_Co' is 16777216, as it is for the
+		"xterm-direct" terminal entry.  See |xterm-true-color|.
 
 		Also see:
 		- 'ambiwidth' - detected by using |t_u7|.

--- a/runtime/doc/term.txt
+++ b/runtime/doc/term.txt
@@ -690,6 +690,15 @@ work the 'termguicolors' option needs to be set.
 See https://github.com/termstandard/colors for a list of terminals that
 support true colors.
 
+The entry of a direct color terminal, such as "xterm-direct", has 16777216
+colors.  Then 't_Co' is 16777216 and |terminalprops()| reports "rgb" as 'y'.
+Vim does not set 'termguicolors' by itself.  To have it set for such a
+terminal, put this in the vimrc: >
+	if terminalprops().rgb == 'y'
+	  set termguicolors
+	endif
+<
+
 For telling the terminal what RGB color to use the |t_8f|, |t_8b|, and |t_8u|
 termcap entries are used.  These are set by default to values that work for
 most terminals.  If that does not work for your terminal you can set them

--- a/src/term.c
+++ b/src/term.c
@@ -1549,10 +1549,23 @@ typedef struct {
 #define TPR_KITTY		    4
 // can send DECRQM requests to terminal
 #define TPR_DECRQM		    5
+// true color, from the color count of the terminal entry
+#define TPR_RGB			    6
 // table size
-#define TPR_COUNT		    6
+#define TPR_COUNT		    7
 
 static termprop_T term_props[TPR_COUNT];
+
+/*
+ * Set the "rgb" terminal property from the color count.  The entry of a
+ * direct color terminal, such as xterm-direct, has 16777216 colors.
+ */
+    static void
+set_rgb_term_prop(void)
+{
+    term_props[TPR_RGB].tpr_status = t_colors == 0x1000000
+						       ? TPR_YES : TPR_UNKNOWN;
+}
 
 /*
  * Initialize the term_props table.
@@ -1576,10 +1589,15 @@ init_term_props(int all)
     term_props[TPR_KITTY].tpr_set_by_termresponse = FALSE;
     term_props[TPR_DECRQM].tpr_name = "decrqm";
     term_props[TPR_DECRQM].tpr_set_by_termresponse = TRUE;
+    term_props[TPR_RGB].tpr_name = "rgb";
+    term_props[TPR_RGB].tpr_set_by_termresponse = FALSE;
 
     for (i = 0; i < TPR_COUNT; ++i)
 	if (all || term_props[i].tpr_set_by_termresponse)
 	    term_props[i].tpr_status = TPR_UNKNOWN;
+
+    // Derived from the color count, not reset.
+    set_rgb_term_prop();
 }
 
 #if defined(FEAT_EVAL)
@@ -3567,6 +3585,7 @@ ttest(int pairs)
 		set_color_count(colors);
 	}
     }
+    set_rgb_term_prop();
 }
 
 #if defined(FEAT_GUI) && (defined(FEAT_MENU) || !defined(USE_ON_FLY_SCROLL))

--- a/src/testdir/test_termcodes.vim
+++ b/src/testdir/test_termcodes.vim
@@ -1720,6 +1720,7 @@ func Test_xx01_term_style_response()
         \ underline_rgb: 'u',
         \ mouse: 's',
         \ kitty: 'u',
+        \ rgb: 'u',
         \ decrqm: 'u'
         \ }, terminalprops())
 
@@ -1756,6 +1757,7 @@ func Test_xx02_iTerm2_response()
         \ underline_rgb: 'u',
         \ mouse: 's',
         \ kitty: 'u',
+        \ rgb: 'u',
         \ decrqm: 'y'
         \ }, terminalprops())
 
@@ -1777,6 +1779,7 @@ func Run_libvterm_konsole_response(code)
         \ underline_rgb: 'u',
         \ mouse: 's',
         \ kitty: 'u',
+        \ rgb: 'u',
         \ decrqm: 'u'
         \ }, terminalprops())
 endfunc
@@ -1821,6 +1824,7 @@ func Test_xx04_Mac_Terminal_response()
         \ underline_rgb: 'y',
         \ mouse: 's',
         \ kitty: 'u',
+        \ rgb: 'u',
         \ decrqm: 'n'
         \ }, terminalprops())
   call assert_equal("\<Esc>[58;2;%lu;%lu;%lum", &t_8u)
@@ -1853,6 +1857,7 @@ func Test_xx05_mintty_response()
         \ underline_rgb: 'y',
         \ mouse: 's',
         \ kitty: 'u',
+        \ rgb: 'u',
         \ decrqm: 'u'
         \ }, terminalprops())
 
@@ -1890,6 +1895,7 @@ func Test_xx06_screen_response()
         \ underline_rgb: 'y',
         \ mouse: 's',
         \ kitty: 'u',
+        \ rgb: 'u',
         \ decrqm: 'n'
         \ }, terminalprops())
 
@@ -1916,6 +1922,7 @@ func Do_check_t_8u_set_reset(set_by_user)
         \ underline_rgb: 'u',
         \ mouse: 's',
         \ kitty: 'u',
+        \ rgb: 'u',
         \ decrqm: 'u'
         \ }, terminalprops())
   call assert_equal(a:set_by_user ? default_value : '', &t_8u)
@@ -1956,6 +1963,7 @@ func Test_xx07_xterm_response()
         \ underline_rgb: 'y',
         \ mouse: 'u',
         \ kitty: 'u',
+        \ rgb: 'u',
         \ decrqm: 'u'
         \ }, terminalprops())
 
@@ -1973,6 +1981,7 @@ func Test_xx07_xterm_response()
         \ underline_rgb: 'u',
         \ mouse: '2',
         \ kitty: 'u',
+        \ rgb: 'u',
         \ decrqm: 'u'
         \ }, terminalprops())
 
@@ -1990,6 +1999,7 @@ func Test_xx07_xterm_response()
         \ underline_rgb: 'u',
         \ mouse: 's',
         \ kitty: 'u',
+        \ rgb: 'u',
         \ decrqm: 'u'
         \ }, terminalprops())
 
@@ -2020,6 +2030,7 @@ func Test_xx08_kitty_response()
         \ underline_rgb: 'y',
         \ mouse: 's',
         \ kitty: 'y',
+        \ rgb: 'u',
         \ decrqm: 'y'
         \ }, terminalprops())
 
@@ -2968,6 +2979,16 @@ endfunc
 func Test_da1_handling()
   call feedkeys("\<Esc>[?62,52;c", 'Lx!')
   call assert_equal("\<Esc>[?62,52;c", v:termda1)
+endfunc
+
+" Test that terminalprops().rgb follows the color count.
+func Test_terminalprops_rgb()
+  let save_t_Co = &t_Co
+  set t_Co=16777216
+  call assert_equal('y', terminalprops().rgb)
+  set t_Co=256
+  call assert_equal('u', terminalprops().rgb)
+  let &t_Co = save_t_Co
 endfunc
 
 " Test if OSC terminal responses are captured correctly


### PR DESCRIPTION
```
Problem:  A terminal entry with 16777216 colors, such as xterm-direct,
          needs 'termguicolors' to show its colors, and a vimrc has no
          way to tell that it is such a terminal.
Solution: Add "rgb" to terminalprops(), 'y' when 't_Co' is 16777216,
          and document setting 'termguicolors' from it.
```

related: #21191