### PR TITLE
Vim9: a lambda with a block body fails to compile after another error

### DIFF
--- a/src/testdir/test_vim9_expr.vim
+++ b/src/testdir/test_vim9_expr.vim
@@ -2862,6 +2862,30 @@ def Test_expr9_lambda_block()
   END
   v9.CheckDefFailure(lines, 'E1145: Missing heredoc end marker: ENDIT', 0)
   v9.CheckScriptFailure(['vim9script'] + lines, 'E1145: Missing heredoc end marker: ENDIT', 2)
+
+  # An error in one function must not make the block lambda in the next
+  # function fail to compile in the same :defcompile.  Class methods are
+  # compiled in the order they are defined.
+  lines =<< trim END
+      vim9script
+      class C
+        static def Broken(): number
+          return 'x'
+        enddef
+        static def Healthy(): list<number>
+          return [1, 2]->map((_, v) => {
+            return v * 2
+          })
+        enddef
+      endclass
+      try
+        defcompile C
+      catch
+        assert_match('E1012:', v:exception)
+      endtry
+      assert_equal([2, 4], C.Healthy())
+  END
+  v9.CheckScriptSuccess(lines)
 enddef
 
 def NewLambdaWithComments(): func

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -994,6 +994,7 @@ get_function_body(
     garray_T	heredoc_ga;
     char_u	*heredoc_trimmed = NULL;
     size_t	heredoc_trimmedlen = 0;
+    int		did_emsg_start = did_emsg;
 
     ga_init2(&heredoc_ga, 1, 500);
 
@@ -1422,8 +1423,9 @@ get_function_body(
 	    line_arg = NULL;
     }
 
-    // Return OK when no error was detected.
-    if (!did_emsg)
+    // Return OK when no error was detected here; "did_emsg" may already be
+    // set by an earlier error in the same command.
+    if (did_emsg == did_emsg_start)
 	ret = OK;
 
 theend:
@@ -5412,12 +5414,12 @@ define_function(
     // Save the starting line number.
     sourcing_lnum_top = SOURCING_LNUM;
 
-    // Do not define the function when getting the body fails and when
-    // skipping.
+    // Do not define the function when getting the body fails, when the header
+    // had an error (the body is still read to find the end) and when skipping.
     if (((class_flags & CF_INTERFACE) == 0
 		&& (class_flags & CF_ABSTRACT_METHOD) == 0
-		&& get_function_body(eap, &newlines, line_arg, lines_to_free)
-								       == FAIL)
+		&& (get_function_body(eap, &newlines, line_arg, lines_to_free)
+							== FAIL || did_emsg))
 	    || eap->skip)
 	goto erret;
 


### PR DESCRIPTION
```
Problem:  When ":defcompile" compiles several functions and one of them
          fails, a function after it that contains a lambda with a
          block body fails as well, with E1028 and nothing else.
Solution: In get_function_body() only consider errors that were given
          while reading the body.  Keep define_function() from defining
          a function whose header had an error.
```