### PR TITLE
Fix stale funccall left by `string_reduce()` in `src/strings.c`

### DIFF
--- a/src/strings.c
+++ b/src/strings.c
@@ -1053,7 +1053,7 @@ string_reduce(
 	clear_tv(&argv[0]);
 	clear_tv(&argv[1]);
 	if (r == FAIL || called_emsg != called_emsg_start)
-	    return;
+	    break;
     }
 
     if (fc != NULL)

--- a/src/testdir/test_vim9_builtin.vim
+++ b/src/testdir/test_vim9_builtin.vim
@@ -3514,6 +3514,14 @@ def Test_reduce()
   v9.CheckSourceDefAndScriptFailure(['reduce({a: 10}, "1")'], ['E1013: Argument 1: type mismatch, expected list<any> but got dict<number>', 'E1253: String, List, Tuple or Blob required for argument 1'])
   assert_equal(6, [1, 2, 3]->reduce((r, c) => r + c, 0))
   assert_equal(11, 0z0506->reduce((r, c) => r + c, 0))
+
+  # A closure that fails part way through a String must not leave the
+  # funccall_T behind on the current_funccal chain.
+  var lines =<< trim END
+      vim9script
+      echo reduce('abc', (acc, c) => [][0])
+  END
+  v9.CheckScriptFailure(lines, 'E684:')
 enddef
 
 def Test_reltime()


### PR DESCRIPTION
### Problem

In `string_reduce()` in `src/strings.c`, one `funccall_T` is created for all the
per-character calls (line **1037**):

```c
    // Create one funccall_T for all eval_expr_typval() calls.
    fc = eval_expr_get_funccal(expr, rettv);
```

and removed after the loop (lines **1059–1060**):

```c
    if (fc != NULL)
	remove_funccal();
```

The error path inside the loop returns directly, skipping it (lines **1055–1056**):

```c
	if (r == FAIL || called_emsg != called_emsg_start)
	    return;
```

The `funccall_T` is leaked and left on the `current_funccal` chain, with an `fc_ectx`
pointing at a `call_def_function()` frame that has already returned. `list_reduce()` in
`src/list.c` has the same loop and the same condition, but uses `break`.

Sourcing this under AddressSanitizer gives a stack-use-after-return in
`unwind_def_callstack()`, from `invoke_all_defer()` at exit:

```vim
vim9script
silent! echo reduce("abc", (acc, c) => [][0])
qall!
```

### Solution

Use `break` instead of `return`, so the error path reaches the existing `remove_funccal()`.
The fix is included in this commit.
