### PR TITLE
diff mode redraws slowly with many changes

### DIFF
--- a/src/diff.c
+++ b/src/diff.c
@@ -126,11 +126,52 @@ static int parse_diffanchors(int check_only, buf_T *buf, linenr_T *anchors, int 
 # define FOR_ALL_DIFFBLOCKS_IN_TAB(tp, dp) \
     for ((dp) = (tp)->tp_first_diff; (dp) != NULL; (dp) = (dp)->df_next)
 
+// Cursor into the diff block list for diff_infold() and
+// diff_check_with_linestatus(): both scan blocks in ascending df_lnum order,
+// usually with an increasing "lnum" during redraw.  Remembering the last block
+// at or before "lnum" lets the next call resume there instead of from the head.
+// Cleared when a block is freed, allocated or line-shifted (see below).
+static diff_T	    *diff_finger_dp = NULL;
+static tabpage_T    *diff_finger_tp = NULL;
+static int	    diff_finger_idx = -1;
+static linenr_T	    diff_finger_lnum = 0;
+
     static void
 clear_diffblock(diff_T *dp)
 {
+    if (dp == diff_finger_dp)
+	diff_finger_dp = NULL;		// don't leave a dangling finger
     ga_clear(&dp->df_changes);
     vim_free(dp);
+}
+
+/*
+ * Return the diff block to start a forward scan for line "lnum" in tab "tp",
+ * buffer index "idx".  Resumes from the finger when it is still valid and
+ * "lnum" did not move backwards, else starts at the first block.
+ */
+    static diff_T *
+diff_scan_start(tabpage_T *tp, int idx, linenr_T lnum)
+{
+    if (diff_finger_dp != NULL
+	    && diff_finger_tp == tp
+	    && diff_finger_idx == idx
+	    && lnum >= diff_finger_lnum)
+	return diff_finger_dp;
+    return tp->tp_first_diff;
+}
+
+/*
+ * Remember "dp" as the finger for the next scan: the last block with
+ * df_lnum[idx] <= "lnum" seen by the scan, or NULL when there is none.
+ */
+    static void
+diff_scan_remember(tabpage_T *tp, int idx, linenr_T lnum, diff_T *dp)
+{
+    diff_finger_tp = tp;
+    diff_finger_idx = idx;
+    diff_finger_lnum = lnum;
+    diff_finger_dp = dp != NULL ? dp : tp->tp_first_diff;
 }
 
 /*
@@ -336,6 +377,8 @@ diff_mark_adjust_tp(
     linenr_T	last;
     linenr_T	lnum_deleted = line1;	// lnum of remaining deletion
     int		check_unchanged;
+
+    diff_finger_dp = NULL;		// may shift df_lnum, invalidate the finger
 
     if (diff_internal())
     {
@@ -606,6 +649,7 @@ diff_alloc_new(tabpage_T *tp, diff_T *dprev, diff_T *dp)
     dnew = ALLOC_CLEAR_ONE(diff_T);
     if (dnew == NULL)
 	return NULL;
+    diff_finger_dp = NULL;		// list changed, invalidate the finger
 
     dnew->is_linematched = FALSE;
     dnew->df_next = dp;
@@ -1075,6 +1119,8 @@ diff_try_update(
 
 	if (anchor_i != 0)
 	{
+	    diff_finger_dp = NULL;	// df_lnum shifted, invalidate the finger
+
 	    // Combine the new diff blocks with the existing ones
 	    for (diff_T *dp = curtab->tp_first_diff; dp != NULL; dp = dp->df_next)
 	    {
@@ -2475,10 +2521,17 @@ diff_check_with_linestatus(win_T *wp, linenr_T lnum, int *linestatus)
 	return 0;
 # endif
 
-    // search for a change that includes "lnum" in the list of diffblocks.
-    FOR_ALL_DIFFBLOCKS_IN_TAB(curtab, dp)
+    // Search for a change that includes "lnum" in the list of diffblocks.
+    // Resume from the scan finger to avoid restarting at the first block.
+    diff_T	*le = NULL;		// last block with df_lnum[idx] <= lnum
+    for (dp = diff_scan_start(curtab, idx, lnum); dp != NULL; dp = dp->df_next)
+    {
+	if (dp->df_lnum[idx] <= lnum)
+	    le = dp;
 	if (lnum <= dp->df_lnum[idx] + dp->df_count[idx])
 	    break;
+    }
+    diff_scan_remember(curtab, idx, lnum, le);
     if (dp == NULL || lnum < dp->df_lnum[idx])
 	return 0;
 
@@ -4009,16 +4062,25 @@ diff_infold(win_T *wp, linenr_T lnum)
     if (curtab->tp_first_diff == NULL)
 	return TRUE;
 
-    FOR_ALL_DIFFBLOCKS_IN_TAB(curtab, dp)
+    // Resume from the scan finger to avoid restarting at the first block.
+    diff_T	*le = NULL;		// last block with df_lnum[idx] <= lnum
+    int		result = TRUE;
+    for (dp = diff_scan_start(curtab, idx, lnum); dp != NULL; dp = dp->df_next)
     {
+	if (dp->df_lnum[idx] <= lnum)
+	    le = dp;
 	// If this change is below the line there can't be any further match.
 	if (dp->df_lnum[idx] - diff_context > lnum)
 	    break;
 	// If this change ends before the line we have a match.
 	if (dp->df_lnum[idx] + dp->df_count[idx] + diff_context > lnum)
-	    return FALSE;
+	{
+	    result = FALSE;
+	    break;
+	}
     }
-    return TRUE;
+    diff_scan_remember(curtab, idx, lnum, le);
+    return result;
 }
 # endif
 

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -5606,7 +5606,7 @@ vim_tempname(
     // randomize the name to avoid collisions
     i = mch_get_pid() + extra_char;
     buf4[1] = chartab[i % 36];
-    buf4[2] = chartab[101 * i % 36];
+    buf4[2] = chartab[(i / 36) % 36];
     if (GetTempFileNameW(wszTempFile, buf4, 0, itmp) == 0)
 	return NULL;
     if (!keep)

--- a/src/testdir/test_diffmode.vim
+++ b/src/testdir/test_diffmode.vim
@@ -3702,4 +3702,94 @@ func Test_diffupdated_close_window_fails()
   %bw!
 endfunc
 
+" Redrawing folds scans the diff block list.  The scan is resumed from a
+" remembered position (the "finger") when the line number does not move
+" backwards, so make sure it yields exactly the same folds as a full scan
+" with many changes, when walking up and down, in both windows, and after an
+" edit invalidates the finger.
+func Test_diff_fold_scan_finger()
+  enew!
+  let lines = []
+  for i in range(1, 600)
+    call add(lines, string(i))
+  endfor
+  call setline(1, lines)
+  diffthis
+  let winone = win_getid()
+  new
+  let other = copy(lines)
+  " Change one line in every 30-line block, far enough apart to stay separate.
+  let changes = range(30, 570, 30)
+  for c in changes
+    let other[c - 1] = 'x' . other[c - 1]
+  endfor
+  call setline(1, other)
+  diffthis
+  let wintwo = win_getid()
+
+  set diffopt=internal,filler,context:4
+  diffupdate
+  " Park the cursor on a changed (never folded) line so the fold under the
+  " cursor is not opened, which would perturb the checks below.
+  call cursor(300, 1)
+  normal! zx
+
+  " Fold boundaries derived independently from the change positions: each
+  " change at line c keeps [c - 4, c + 4] visible, the gaps are closed folds.
+  let expected = []
+  let prev_end = 0
+  for c in changes
+    if c - 4 - 1 >= prev_end + 1
+      call add(expected, [prev_end + 1, c - 4 - 1])
+    endif
+    let prev_end = c + 4
+  endfor
+  if prev_end + 1 <= 600
+    call add(expected, [prev_end + 1, 600])
+  endif
+
+  " Walk the folds forward (lnum increasing: exercises the resume path).
+  for [s, e] in expected
+    call assert_equal(s, foldclosed(s), 'foldclosed at ' . s)
+    call assert_equal(e, foldclosedend(s), 'foldclosedend at ' . s)
+  endfor
+
+  " Walk the folds backward (lnum decreasing: forces the finger to restart).
+  for [s, e] in reverse(copy(expected))
+    call assert_equal(s, foldclosed(e), 'reverse foldclosed at ' . e)
+    call assert_equal(e, foldclosedend(e), 'reverse foldclosedend at ' . e)
+  endfor
+
+  " The context lines around every change must not be in a closed fold.
+  for c in changes
+    call assert_equal(-1, foldclosed(c), 'change line ' . c . ' visible')
+  endfor
+
+  " The other window (different buffer index) must produce the same folds.
+  call win_gotoid(winone)
+  call cursor(300, 1)
+  normal! zx
+  for [s, e] in expected
+    call assert_equal(s, foldclosed(s), 'winone foldclosed at ' . s)
+    call assert_equal(e, foldclosedend(s), 'winone foldclosedend at ' . s)
+  endfor
+
+  " Editing invalidates the finger; a new change deep inside a fold must split
+  " it and become visible.
+  call win_gotoid(wintwo)
+  call cursor(300, 1)
+  call setline(315, 'x' . getline(315))
+  diffupdate
+  normal! zx
+  call assert_equal(305, foldclosed(305))
+  call assert_equal(310, foldclosedend(305))
+  call assert_equal(-1, foldclosed(315))
+  call assert_equal(320, foldclosed(320))
+  call assert_equal(325, foldclosedend(320))
+
+  diffoff!
+  %bwipe!
+  set diffopt&
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  Redrawing or folding a diff with many changes is slow because for
          every screen line the list of diff blocks is scanned from the
          start.
Solution: Remember the last examined diff block and resume the scan from
          there while the line number does not move backwards.

This change is similar to 5feaa6c6c201d4d05b833a7230d07da44bf2504b and f1b454912996d6417acd0d738de0eb7b60902c56: quadratic behaviour replaced with a linear one by keeping track of previous ordered insertions.

diff_check_with_linestatus() and diff_infold() are called for every line during redraw and fold updates, with a line number that usually increases monotonically, yet each restarted its scan at tp_first_diff. A cursor into the block list is now kept and cleared whenever a block is freed, allocated or has its line numbers shifted, so the next call continues where the previous one stopped.

Scanning the diff blocks during a scroll of a 20000-line diff drops from 4.12G to 1.27G instructions with ~3300 changes, and scales with the number of changes.

Tests were added as the change is non-trivial.