### PR TITLE
Add ":source ++dryrun" to check a script without running it

### DIFF
--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -262,6 +262,9 @@ For writing a Vim script, see chapter 41 of the user manual |usr_41.txt|.
 			A script that is imported is read the same way, but an
 			autoload script is not loaded.  No |SourceCmd|,
 			|SourcePre| or |SourcePost| autocommand is triggered.
+			A class or enum in an autoload script is defined again
+			by a dry run, and after one by a normal load, since no
+			object was made from it; see |vim9-reload|.
 			Note: An error in a definition does not stop the
 			reading, the rest of the script is read as well.  And
 			an error in a line of a function does not stop

--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -239,6 +239,32 @@ For writing a Vim script, see chapter 41 of the user manual |usr_41.txt|.
 			will be adjusted to the start and end of the fold,
 			but only if a two line specifiers range was used.
 
+						*:source-dryrun*
+:so[urce] ++dryrun {file}
+:[range]so[urce] ++dryrun
+			Read the script without running it: only what
+			defines something is executed, then every |:def|
+			function in it is compiled and the errors are reported
+			as usual.
+			What is executed: `vim9script`, `import`, `def`,
+			`function`, `class`, `interface`, `enum`, `type` and a
+			declaration with `var`, `const` or `final`.  The
+			declared variable gets the type from the declaration,
+			or "any" when there is none, and a zero value; the
+			expression is not evaluated.  A static class variable
+			is treated the same way and an enum value is not
+			created.
+			Everything else is skipped, also `finish` and the
+			condition of an `if`, `while` or `for`; a definition
+			inside such a block is executed whether the condition
+			holds or not.  A function may therefore be defined
+			twice, the last definition counts.
+			A script that is imported is read the same way, but an
+			autoload script is not loaded.  No |SourceCmd|,
+			|SourcePre| or |SourcePost| autocommand is triggered.
+			Note: An error in a definition does not stop the
+			reading, the rest of the script is read as well.
+
 							*:source!*
 :so[urce]! {file}	Read Vim commands from {file}.  These are commands
 			that are executed from Normal mode, like you type

--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -263,7 +263,9 @@ For writing a Vim script, see chapter 41 of the user manual |usr_41.txt|.
 			autoload script is not loaded.  No |SourceCmd|,
 			|SourcePre| or |SourcePost| autocommand is triggered.
 			Note: An error in a definition does not stop the
-			reading, the rest of the script is read as well.
+			reading, the rest of the script is read as well.  And
+			an error in a line of a function does not stop
+			compiling it, every line with an error is reported.
 
 							*:source!*
 :so[urce]! {file}	Read Vim commands from {file}.  These are commands

--- a/runtime/doc/tags
+++ b/runtime/doc/tags
@@ -3426,6 +3426,7 @@ $quote	eval.txt	/*$quote*
 :sort-uniq	change.txt	/*:sort-uniq*
 :source	repeat.txt	/*:source*
 :source!	repeat.txt	/*:source!*
+:source-dryrun	repeat.txt	/*:source-dryrun*
 :source-range	repeat.txt	/*:source-range*
 :source_crnl	repeat.txt	/*:source_crnl*
 :sp	windows.txt	/*:sp*

--- a/src/evalvars.c
+++ b/src/evalvars.c
@@ -3961,8 +3961,12 @@ delete_autoload_export_vars(char_u *prefix)
 	    dictitem_T	*di = HI2DI(hi);
 
 	    --todo;
-	    // Keep a class or enum: existing objects still refer to it.
-	    if (di->di_tv.v_type != VAR_CLASS
+	    // Keep a class or enum: existing objects still refer to it.  Not
+	    // in a dry run, nor one a dry run defined: no object was made.
+	    if ((di->di_tv.v_type != VAR_CLASS || source_dryrun
+			|| (di->di_tv.vval.v_class != NULL
+			    && (di->di_tv.vval.v_class->class_flags
+							     & CLASS_DRYRUN)))
 		    && STRNCMP(di->di_key, prefix, prefixlen) == 0)
 		delete_var(&globvarht, hi);
 	}

--- a/src/evalvars.c
+++ b/src/evalvars.c
@@ -1128,6 +1128,36 @@ ex_let(exarg_T *eap)
 	return;
     }
 
+    if (source_dryrun && vim9script && (flags & ASSIGN_NO_DECL) == 0)
+    {
+	// ":source ++dryrun": skip the expression, it may span lines, and only
+	// declare the variables.
+	int	save_skip = eap->skip;
+
+	eap->skip = TRUE;
+	if (expr[0] == '=' && expr[1] == '<' && expr[2] == '<')
+	{
+	    list_T *l = heredoc_get(eap, expr + 3, FALSE, FALSE);
+
+	    if (l != NULL)
+		list_free(l);
+	}
+	else
+	{
+	    evalarg_T	evalarg;
+
+	    ++emsg_skip;
+	    fill_evalarg_from_eap(&evalarg, eap, TRUE);
+	    expr = skipwhite_and_linebreak(expr + 1, &evalarg);
+	    (void)eval0(expr, &rettv, eap, &evalarg);
+	    --emsg_skip;
+	    clear_evalarg(&evalarg, eap);
+	}
+	eap->skip = save_skip;
+	vim9_declare_dryrun(arg, flags & (ASSIGN_CONST | ASSIGN_FINAL));
+	return;
+    }
+
     if (expr[0] == '=' && expr[1] == '<' && expr[2] == '<')
     {
 	list_T	*l = NULL;

--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -824,7 +824,7 @@ do_cmdline(
 	if (next_cmdline == NULL
 #ifdef FEAT_EVAL
 		&& !force_abort
-		&& cstack.cs_idx < 0
+		&& (cstack.cs_idx < 0 || source_dryrun)
 		&& !(getline_is_func && func_has_abort(real_cookie))
 #endif
 							)
@@ -1215,7 +1215,10 @@ do_cmdline(
      */
     while (!((got_int
 #ifdef FEAT_EVAL
-		    || (did_emsg && (force_abort || in_vim9script()))
+		    // With ":source ++dryrun" an error does not stop the
+		    // script, nothing is executed anyway.
+		    || (did_emsg && (force_abort
+				       || (in_vim9script() && !source_dryrun)))
 		    || did_throw
 #endif
 	     )
@@ -1751,6 +1754,39 @@ comment_start(char_u *p, int starts_with_colon UNUSED)
 #define CURRENT_TAB_NR current_tab_nr(curtab)
 #define LAST_TAB_NR current_tab_nr(NULL)
 
+#ifdef FEAT_EVAL
+/*
+ * Return TRUE if the command "cmdidx" is executed with ":source ++dryrun":
+ * one that defines something.  "no_keyword" is TRUE for a Vim9 assignment,
+ * which is CMD_var without the ":var" keyword.
+ */
+    static int
+dryrun_executes(cmdidx_T cmdidx, int no_keyword)
+{
+    switch (cmdidx)
+    {
+	case CMD_vim9script:
+	case CMD_scriptencoding:
+	case CMD_scriptversion:
+	case CMD_import:
+	case CMD_def:
+	case CMD_function:
+	case CMD_class:
+	case CMD_abstract:
+	case CMD_interface:
+	case CMD_enum:
+	case CMD_type:
+	    return TRUE;
+	case CMD_var:
+	case CMD_const:
+	case CMD_final:
+	    return !no_keyword;
+	default:
+	    return FALSE;
+    }
+}
+#endif
+
 /*
  * Execute one Ex command.
  *
@@ -1912,6 +1948,12 @@ do_one_cmd(
 	p = find_ex_command(&ea, NULL, NULL, NULL);
 
 #ifdef FEAT_EVAL
+    // With ":source ++dryrun" only a command that defines something is
+    // executed, also inside a block that is not active.
+    if (source_dryrun)
+	ea.skip = did_emsg || got_int || did_throw
+				    || !dryrun_executes(ea.cmdidx, p == ea.cmd);
+
 # ifdef FEAT_PROFILE
     // Count this line for profiling if skip is TRUE.
     if (do_profiling == PROF_YES

--- a/src/ex_eval.c
+++ b/src/ex_eval.c
@@ -1098,8 +1098,9 @@ ex_if(exarg_T *eap)
 	 * Don't do something after an error, interrupt, or throw, or when
 	 * there is a surrounding conditional and it was not active.
 	 */
-	skip = did_emsg || got_int || did_throw || (cstack->cs_idx > 0
-		&& !(cstack->cs_flags[cstack->cs_idx - 1] & CSF_ACTIVE));
+	skip = did_emsg || got_int || did_throw || source_dryrun
+		|| (cstack->cs_idx > 0
+		    && !(cstack->cs_flags[cstack->cs_idx - 1] & CSF_ACTIVE));
 
 	result = eval_to_bool(eap->arg, &error, eap, skip, FALSE);
 
@@ -1163,7 +1164,8 @@ ex_else(exarg_T *eap)
      * Don't do something after an error, interrupt, or throw, or when there is
      * a surrounding conditional and it was not active.
      */
-    skip = did_emsg || got_int || did_throw || (cstack->cs_idx > 0
+    skip = did_emsg || got_int || did_throw || source_dryrun
+	|| (cstack->cs_idx > 0
 	    && !(cstack->cs_flags[cstack->cs_idx - 1] & CSF_ACTIVE));
 
     if (cstack->cs_idx < 0
@@ -1331,8 +1333,9 @@ ex_while(exarg_T *eap)
 	 * Don't do something after an error, interrupt, or throw, or when
 	 * there is a surrounding conditional and it was not active.
 	 */
-	skip = did_emsg || got_int || did_throw || (cstack->cs_idx > 0
-		&& !(cstack->cs_flags[cstack->cs_idx - 1] & CSF_ACTIVE));
+	skip = did_emsg || got_int || did_throw || source_dryrun
+		|| (cstack->cs_idx > 0
+		    && !(cstack->cs_flags[cstack->cs_idx - 1] & CSF_ACTIVE));
 	if (eap->cmdidx == CMD_while)
 	{
 	    /*
@@ -1769,8 +1772,9 @@ ex_try(exarg_T *eap)
 	 * Don't do something after an error, interrupt, or throw, or when there
 	 * is a surrounding conditional and it was not active.
 	 */
-	skip = did_emsg || got_int || did_throw || (cstack->cs_idx > 0
-		&& !(cstack->cs_flags[cstack->cs_idx - 1] & CSF_ACTIVE));
+	skip = did_emsg || got_int || did_throw || source_dryrun
+		|| (cstack->cs_idx > 0
+		    && !(cstack->cs_flags[cstack->cs_idx - 1] & CSF_ACTIVE));
 
 	if (!skip)
 	{

--- a/src/globals.h
+++ b/src/globals.h
@@ -327,6 +327,9 @@ EXTERN sctx_T	current_sctx
 // whether inside compile_def_function()
 EXTERN int	estack_compiling INIT(= FALSE);
 
+// whether sourcing with ":source ++dryrun": only definitions are executed
+EXTERN int	source_dryrun INIT(= FALSE);
+
 EXTERN int	ex_nesting_level INIT(= 0);	// nesting level
 EXTERN int	debug_break_level INIT(= -1);	// break below this level
 EXTERN int	debug_did_msg INIT(= FALSE);	// did "debug mode" message

--- a/src/proto/vim9expr.pro
+++ b/src/proto/vim9expr.pro
@@ -13,6 +13,7 @@ int get_lambda_tv_and_compile(char_u **arg, typval_T *rettv, int types_optional,
 exprtype_T get_compare_type(char_u *p, int *len, int *type_is);
 void skip_expr_cctx(char_u **arg, cctx_T *cctx);
 int bool_on_stack(cctx_T *cctx);
+int recover_expr(char_u **arg, type_T *type, cctx_T *cctx);
 void error_white_both(char_u *op, int len);
 int compile_expr1(char_u **arg, cctx_T *cctx, ppconst_T *ppconst);
 int compile_expr0_ext(char_u **arg, cctx_T *cctx, int *is_const);

--- a/src/proto/vim9script.pro
+++ b/src/proto/vim9script.pro
@@ -14,6 +14,7 @@ void ex_import(exarg_T *eap);
 void import_check_sourced_sid(int *sid);
 int find_exported(int sid, char_u *name, ufunc_T **ufunc, type_T **type, cctx_T *cctx, cstack_T *cstack, int verbose);
 char_u *vim9_declare_scriptvar(exarg_T *eap, char_u *arg);
+void vim9_declare_dryrun(char_u *arg, int flags);
 void update_vim9_script_var(int create, dictitem_T *di, char_u *name, int flags, typval_T *tv, type_T **type, int do_member);
 void hide_script_var(scriptitem_T *si, int idx, int func_defined);
 svar_T *find_typval_in_script(typval_T *dest, scid_T sid, int must_find);

--- a/src/scriptfile.c
+++ b/src/scriptfile.c
@@ -23,7 +23,7 @@ static garray_T		ga_loaded = {0, 0, sizeof(char_u *), 4, NULL};
 static int		last_current_SID_seq = 0;
 #endif
 
-static int do_source_ext(char_u *fname, int check_other, int is_vimrc, int *ret_sid, exarg_T *eap, int clearvars);
+static int do_source_ext(char_u *fname, int check_other, int is_vimrc, int *ret_sid, exarg_T *eap, int clearvars, int dryrun);
 
 /*
  * Initialize the execution stack.
@@ -1398,6 +1398,7 @@ ExpandPackAddDir(
 cmd_source(char_u *fname, exarg_T *eap)
 {
     int clearvars = FALSE;
+    int dryrun = FALSE;
 
     if (*fname != NUL && STRNCMP(fname, "++clear", 7) == 0)
     {
@@ -1409,6 +1410,12 @@ cmd_source(char_u *fname, exarg_T *eap)
 	    semsg(_(e_invalid_argument_str), eap->arg);
 	    return;
 	}
+    }
+    else if (STRNCMP(fname, "++dryrun", 8) == 0
+				    && (fname[8] == NUL || fname[8] == ' '))
+    {
+	dryrun = TRUE;
+	fname = skipwhite(fname + 8);
     }
 
     if (*fname != NUL && eap != NULL && eap->addr_count > 0)
@@ -1425,7 +1432,7 @@ cmd_source(char_u *fname, exarg_T *eap)
 	    emsg(_(e_argument_required));
 	else
 	    // source ex commands from the current buffer
-	    do_source_ext(NULL, FALSE, DOSO_NONE, NULL, eap, clearvars);
+	    do_source_ext(NULL, FALSE, DOSO_NONE, NULL, eap, clearvars, dryrun);
     }
     else if (eap != NULL && eap->forceit)
 	// ":source!": read Normal mode commands
@@ -1442,7 +1449,8 @@ cmd_source(char_u *fname, exarg_T *eap)
 						 );
 
     // ":source" read ex commands
-    else if (do_source(fname, FALSE, DOSO_NONE, NULL) == FAIL)
+    else if (do_source_ext(fname, FALSE, DOSO_NONE, NULL, NULL, FALSE, dryrun)
+								       == FAIL)
 	semsg(_(e_cant_open_file_str), fname);
 }
 
@@ -1639,7 +1647,8 @@ do_source_ext(
     int		is_vimrc,	    // DOSO_ value
     int		*ret_sid UNUSED,
     exarg_T	*eap,
-    int		clearvars UNUSED)
+    int		clearvars UNUSED,
+    int		dryrun UNUSED)
 {
     source_cookie_T	    cookie;
     char_u		    *p;
@@ -1647,7 +1656,11 @@ do_source_ext(
     char_u		    *fname_exp = NULL;
     char_u		    *firstline = NULL;
     int			    retval = FAIL;
+    int			    source_autocmds = TRUE;
     sctx_T		    save_current_sctx;
+#ifdef FEAT_EVAL
+    int			    save_source_dryrun = source_dryrun;
+#endif
 #ifdef STARTUPTIME
     struct timeval	    tv_rel;
     struct timeval	    tv_start;
@@ -1703,8 +1716,16 @@ do_source_ext(
     }
 #endif
 
+#ifdef FEAT_EVAL
+    // Also applies to the scripts this one imports.
+    if (dryrun)
+	source_dryrun = TRUE;
+    // Nothing is sourced in a dry run, no Source* autocommand either.
+    source_autocmds = !source_dryrun;
+#endif
+
     // Apply SourceCmd autocommands, they should get the file and source it.
-    if (has_autocmd(EVENT_SOURCECMD, fname_exp, NULL)
+    if (source_autocmds && has_autocmd(EVENT_SOURCECMD, fname_exp, NULL)
 	    && apply_autocmds(EVENT_SOURCECMD, fname_exp, fname_exp,
 							       FALSE, curbuf))
     {
@@ -1721,7 +1742,8 @@ do_source_ext(
     }
 
     // Apply SourcePre autocommands, they may get the file.
-    apply_autocmds(EVENT_SOURCEPRE, fname_exp, fname_exp, FALSE, curbuf);
+    if (source_autocmds)
+	apply_autocmds(EVENT_SOURCEPRE, fname_exp, fname_exp, FALSE, curbuf);
 
     if (!cookie.source_from_buf)
     {
@@ -1954,6 +1976,18 @@ do_source_ext(
 				     DOCMD_VERBOSE|DOCMD_NOWAIT|DOCMD_REPEAT);
     retval = OK;
 
+#ifdef FEAT_EVAL
+    if (dryrun)
+    {
+	exarg_T	ea;
+
+	// Compile what was defined.
+	CLEAR_FIELD(ea);
+	ea.arg = (char_u *)"";
+	ex_defcompile(&ea);
+    }
+#endif
+
 #ifdef FEAT_PROFILE
     if (do_profiling == PROF_YES)
     {
@@ -1993,7 +2027,7 @@ do_source_ext(
     }
 #endif
 
-    if (!got_int)
+    if (!got_int && source_autocmds)
 	trigger_source_post = TRUE;
 
 #ifdef FEAT_EVAL
@@ -2085,6 +2119,7 @@ theend:
     sticky_cmdmod_flags = save_sticky_cmdmod_flags;
 #ifdef FEAT_EVAL
     estack_compiling = save_estack_compiling;
+    source_dryrun = save_source_dryrun;
 #endif
     return retval;
 }
@@ -2096,7 +2131,8 @@ do_source(
     int		is_vimrc,	    // DOSO_ value
     int		*ret_sid)
 {
-    return do_source_ext(fname, check_other, is_vimrc, ret_sid, NULL, FALSE);
+    return do_source_ext(fname, check_other, is_vimrc, ret_sid, NULL, FALSE,
+									FALSE);
 }
 
 

--- a/src/structs.h
+++ b/src/structs.h
@@ -1692,6 +1692,7 @@ struct itf2class_S {
 #define CLASS_EXTENDED	    0x2	    // another class extends this one
 #define CLASS_ABSTRACT	    0x4	    // abstract class
 #define CLASS_ENUM	    0x8	    // enum
+#define CLASS_DRYRUN	    0x10    // defined by ":source ++dryrun"
 
 // "class_T": used for v_class of typval of VAR_CLASS
 // Also used for an interface (class_flags has CLASS_INTERFACE).

--- a/src/testdir/test_source.vim
+++ b/src/testdir/test_source.vim
@@ -635,6 +635,12 @@ func Test_source_buffer_vim9()
   %bw!
 endfunc
 
+" What the class and the enum of Xdryrun/autoload/xshape.vim give; a legacy
+" function cannot reach them by their autoload name.
+def s:DryrunShapeInfo(): list<any>
+  return [xshape#Shape.new().Area(), xshape#Color.Blue.name]
+enddef
+
 " Test for ":source ++dryrun": only definitions are executed, then the
 " functions are compiled.
 func Test_source_dryrun()
@@ -874,6 +880,29 @@ func Test_source_dryrun()
   unlet g:dryrun_events
   autocmd! DryrunAutocmds
   augroup! DryrunAutocmds
+
+  " a class in an autoload script can be defined again by a dry run, and
+  " after one by a normal source: no object was made from it
+  call mkdir('Xdryrun/autoload', 'pR')
+  let lines =<< trim END
+    vim9script
+    export class Shape
+      var width: number = 1
+      def Area(): number
+        return this.width
+      enddef
+    endclass
+    export enum Color
+      Red,
+      Blue
+    endenum
+  END
+  call writefile(lines, 'Xdryrun/autoload/xshape.vim')
+  source ++dryrun Xdryrun/autoload/xshape.vim
+  source ++dryrun Xdryrun/autoload/xshape.vim
+  source Xdryrun/autoload/xshape.vim
+  call assert_equal([1, 'Blue'], s:DryrunShapeInfo())
+  call assert_fails('source Xdryrun/autoload/xshape.vim', 'E1041:')
 
   " a normal source afterwards runs the script level
   let lines =<< trim END

--- a/src/testdir/test_source.vim
+++ b/src/testdir/test_source.vim
@@ -635,6 +635,214 @@ func Test_source_buffer_vim9()
   %bw!
 endfunc
 
+" Test for ":source ++dryrun": only definitions are executed, then the
+" functions are compiled.
+func Test_source_dryrun()
+  let lines =<< trim END
+    vim9script
+    writefile(['ran'], 'Xdryrun_import_ran')
+    export def Helper(n: number): string
+      return string(n)
+    enddef
+  END
+  call writefile(lines, 'Xdryrun_import.vim', 'D')
+
+  let lines =<< trim END
+    vim9script
+    # nothing at the script level runs
+    writefile(['ran'], 'Xdryrun_ran')
+    g:dryrun_touched = 1
+    command! DryrunCmd echo 1
+    augroup DryrunGroup
+      autocmd BufEnter * echo 1
+    augroup END
+    nnoremap <F13> :echo 1<CR>
+
+    import './Xdryrun_import.vim' as imp
+    # an import with a function in its name does not call it
+    def ImportName(): string
+      writefile(['ran'], 'Xdryrun_ran')
+      return './Xdryrun_import.vim'
+    enddef
+    import ImportName() as unnamed
+
+    # declared with the type or "any", the expression is not evaluated
+    var typed: string = DoesNotExist()
+    var untyped = DoesNotExist()
+    const LIMIT = 10
+    var [first, second] = [1, 2]
+    var text =<< trim EOT
+      heredoc line
+    EOT
+    var multi = {
+      a: 1,
+      b: 2,
+    }
+
+    # both branches define the function
+    if has('win32')
+      def Platform(): string
+        return 'win'
+      enddef
+    else
+      def Platform(): string
+        return 'unix'
+      enddef
+    endif
+
+    class Config
+      var name: string = 'x'
+      static var registry: dict<any> = DoesNotExist()
+      def Describe(): string
+        return this.name .. Platform()
+      enddef
+    endclass
+
+    enum Color
+      Red('ff'),
+      Blue('00')
+      var code: string
+      def new(code: string)
+        this.code = code
+      enddef
+    endenum
+
+    def Broken(): number
+      return 'x'
+    enddef
+    def UsesAll(): string
+      return imp.Helper(1) .. typed .. untyped .. LIMIT .. text[0] .. first
+    enddef
+    def WrongConst()
+      LIMIT = 11
+    enddef
+
+    finish
+    def AfterFinish(): number
+      return 'x'
+    enddef
+  END
+  call writefile(lines, 'Xdryrun.vim', 'D')
+
+  redir => msgs
+  silent! source ++dryrun Xdryrun.vim
+  redir END
+  call assert_match('function <SNR>\d\+_Broken:\_.*E1012:', msgs)
+  call assert_match('function <SNR>\d\+_WrongConst:\_.*E46:', msgs)
+  call assert_match('function <SNR>\d\+_AfterFinish:\_.*E1012:', msgs)
+  call assert_notmatch('E1073:', msgs)
+  call assert_false(filereadable('Xdryrun_ran'))
+  call assert_false(filereadable('Xdryrun_import_ran'))
+  call assert_false(exists('g:dryrun_touched'))
+  call assert_false(exists(':DryrunCmd'))
+  call assert_false(exists('#DryrunGroup'))
+  call assert_equal('', maparg('<F13>'))
+  let sid = getscriptinfo({'name': 'Xdryrun\.vim$'})[0].sid
+  let info = getscriptinfo({'sid': sid})[0]
+  call assert_equal(['AfterFinish', 'Broken', 'ImportName', 'Platform',
+        \ 'UsesAll', 'WrongConst'],
+        \ sort(map(copy(info.functions), 'substitute(v:val, ".*_", "", "")')))
+  call assert_equal(['Color', 'Config', 'LIMIT', 'first', 'multi', 'second',
+        \ 'text', 'typed', 'untyped'], sort(keys(info.variables)))
+  call assert_equal(v:t_string, type(info.variables.typed))
+
+  " a range of buffer lines
+  new
+  let lines =<< trim END
+    vim9script
+    g:dryrun_touched = 1
+    def Broken(): number
+      return 'x'
+    enddef
+  END
+  call setline(1, lines)
+  call assert_fails('%source ++dryrun', 'E1012:')
+  call assert_false(exists('g:dryrun_touched'))
+
+  " an error in a definition does not stop the script
+  %d _
+  let lines =<< trim END
+    vim9script
+    var bad: nosuchtype = 1
+    if 1
+      def Bad(): number
+        return 'x'
+      enddef
+    endif
+    def Later(): number
+      return 'x'
+    enddef
+  END
+  call setline(1, lines)
+  redir => msgs
+  silent! %source ++dryrun
+  redir END
+  call assert_match('E1010:', msgs)
+  call assert_match('function <SNR>\d\+_Bad:\_.*E1012:', msgs)
+  call assert_match('function <SNR>\d\+_Later:\_.*E1012:', msgs)
+  bwipe!
+
+  " a legacy script defines its functions, they are not compiled; the
+  " condition of an :if, :elseif, :while or :for is not evaluated
+  let lines =<< trim END
+    let g:dryrun_touched = 1
+    if g:dryrun_undefined
+      let g:dryrun_touched = 2
+    elseif g:dryrun_undefined
+    endif
+    while g:dryrun_undefined
+    endwhile
+    for i in g:dryrun_undefined
+    endfor
+    try
+      let g:dryrun_touched = 3
+    catch
+    endtry
+    function DryrunLegacy()
+      return undefined_name
+    endfunction
+  END
+  call writefile(lines, 'Xdryrun_legacy.vim', 'D')
+  source ++dryrun Xdryrun_legacy.vim
+  call assert_false(exists('g:dryrun_touched'))
+  call assert_true(exists('*DryrunLegacy'))
+  delfunc DryrunLegacy
+
+  " no SourceCmd, SourcePre or SourcePost autocommand, also not for the
+  " imported script
+  let g:dryrun_events = ''
+  augroup DryrunAutocmds
+    autocmd SourceCmd * let g:dryrun_events ..= 'cmd '
+    autocmd SourcePre * let g:dryrun_events ..= 'pre '
+    autocmd SourcePost * let g:dryrun_events ..= 'post '
+  augroup END
+  call writefile(['vim9script'], 'Xdryrun_import2.vim', 'D')
+  let lines =<< trim END
+    vim9script
+    import './Xdryrun_import2.vim' as imp2
+  END
+  call writefile(lines, 'Xdryrun_events.vim', 'D')
+  source ++dryrun Xdryrun_events.vim
+  call assert_equal('', g:dryrun_events)
+  source Xdryrun_legacy.vim
+  call assert_equal('cmd post ', g:dryrun_events)
+  unlet g:dryrun_events
+  autocmd! DryrunAutocmds
+  augroup! DryrunAutocmds
+
+  " a normal source afterwards runs the script level
+  let lines =<< trim END
+    vim9script
+    g:dryrun_touched = 1
+  END
+  call writefile(lines, 'Xdryrun_normal.vim', 'D')
+  source Xdryrun_normal.vim
+  call assert_true(exists('g:dryrun_touched'))
+  unlet g:dryrun_touched
+
+  call assert_fails('source ++dryrunx Xdryrun.vim', 'E484:')
+endfunc
+
 " Test that the modifier does not override the script type when sourcing files
 " with :vim9cmd and :legacy
 func Test_source_file_ignores_modifiers()

--- a/src/testdir/test_source.vim
+++ b/src/testdir/test_source.vim
@@ -780,6 +780,51 @@ func Test_source_dryrun()
   call assert_match('E1010:', msgs)
   call assert_match('function <SNR>\d\+_Bad:\_.*E1012:', msgs)
   call assert_match('function <SNR>\d\+_Later:\_.*E1012:', msgs)
+
+  " every line with an error in a function is reported, the error does not
+  " lead to more errors and the function is not compiled
+  %d _
+  let lines =<< trim END
+    vim9script
+    def Many(): number
+      var a: number = 'one'
+      var b: nosuchtype = 1
+      echo b
+      var c = NoSuchFunc()
+      echo c
+      if UndefinedVar
+        var d: string = 2
+      else
+        echo undefined_e
+      endif
+      for i in NoSuchList()
+        echo i
+      endfor
+      while UndefinedCond
+      endwhile
+      nosuchcommand
+      def Nested(): string
+        return 7
+      enddef
+      return 'nine'
+    enddef
+  END
+  call setline(1, lines)
+  redir => msgs
+  silent! %source ++dryrun
+  redir END
+  " with ":silent!" E1028 is given as well, the errors did not count
+  let found = []
+  for line in split(msgs, "\n")
+    if line =~ '^line'
+      let lnum = str2nr(matchstr(line, '\d\+'))
+    elseif line =~ '^E\d\+:' && line !~ '^E1028:'
+      call add(found, [lnum, matchstr(line, '^E\d\+:')])
+    endif
+  endfor
+  call assert_equal([[1, 'E1012:'], [2, 'E1010:'], [4, 'E117:'], [6, 'E1001:'],
+        \ [7, 'E1012:'], [9, 'E1001:'], [11, 'E117:'], [14, 'E1001:'],
+        \ [16, 'E476:'], [1, 'E1012:'], [20, 'E1012:']], found)
   bwipe!
 
   " a legacy script defines its functions, they are not compiled; the

--- a/src/userfunc.c
+++ b/src/userfunc.c
@@ -5514,10 +5514,11 @@ define_function(
 	    int dead = fp != NULL && (fp->uf_flags & FC_DEAD);
 
 	    // Function can be replaced with "function!" and when sourcing the
-	    // same script again, but only once.
+	    // same script again, but only once.  With ":source ++dryrun" both
+	    // branches of an ":if" define their function.
 	    // A name that is used by an import can not be overruled.
 	    if (import != NULL
-		    || (!dead && !eap->forceit
+		    || (!dead && !eap->forceit && !source_dryrun
 			&& (fp->uf_script_ctx.sc_sid != current_sctx.sc_sid
 			  || fp->uf_script_ctx.sc_seq == current_sctx.sc_seq)))
 	    {

--- a/src/vim9class.c
+++ b/src/vim9class.c
@@ -2136,6 +2136,8 @@ early_ret:
 	cl->class_flags = CLASS_INTERFACE;
     else if (is_abstract)
 	cl->class_flags = CLASS_ABSTRACT;
+    if (source_dryrun)
+	cl->class_flags |= CLASS_DRYRUN;
 
     cl->class_refcount = 1;
     cl->class_name.length = (size_t)(name_end - name_start);

--- a/src/vim9class.c
+++ b/src/vim9class.c
@@ -1428,7 +1428,8 @@ add_class_members(class_T *cl, exarg_T *eap, garray_T *type_list_gap)
     {
 	ocmember_T	*m = &cl->class_class_members[i];
 	typval_T	*tv = &cl->class_members_tv[i];
-	if (m->ocm_init != NULL)
+	// With ":source ++dryrun" the value is not needed, only the type.
+	if (m->ocm_init != NULL && !source_dryrun)
 	{
 	    sctx_T	save_current_sctx = current_sctx;
 
@@ -3841,6 +3842,11 @@ can_free_enum(class_T *cl)
 	    // If all of those members are no longer referenced, then the enum
 	    // may be freed.
 	    return TRUE;
+
+	// With ":source ++dryrun" the enum values were not created.
+	if (tv->v_type == VAR_OBJECT ? tv->vval.v_object == NULL
+						   : tv->vval.v_list == NULL)
+	    continue;
 
 	if (tv->v_type == VAR_LIST
 		&& tv->vval.v_list->lv_type->tt_member->tt_type == VAR_OBJECT

--- a/src/vim9cmds.c
+++ b/src/vim9cmds.c
@@ -515,7 +515,8 @@ compile_if(char_u *arg, cctx_T *cctx)
     if (compile_expr1(&p, cctx, &ppconst) == FAIL)
     {
 	clear_ppconst(&ppconst);
-	return NULL;
+	if (recover_expr(&p, &t_bool, cctx) == FAIL)
+	    return NULL;
     }
     if (!ends_excmd2(arg, skipwhite(p)))
     {
@@ -697,7 +698,8 @@ compile_elseif(char_u *arg, cctx_T *cctx)
     if (compile_expr1(&p, cctx, &ppconst) == FAIL)
     {
 	clear_ppconst(&ppconst);
-	return NULL;
+	if (recover_expr(&p, &t_bool, cctx) == FAIL)
+	    return NULL;
     }
     cctx->ctx_skip = save_skip;
     if (!ends_excmd2(arg, skipwhite(p)))
@@ -1033,7 +1035,8 @@ compile_for(char_u *arg_start, cctx_T *cctx)
 
     // compile "expr", it remains on the stack until "endfor"
     arg = p;
-    if (compile_expr0(&arg, cctx) == FAIL)
+    if (compile_expr0(&arg, cctx) == FAIL
+			       && recover_expr(&arg, &t_list_any, cctx) == FAIL)
     {
 	drop_scope(cctx);
 	return NULL;
@@ -1339,7 +1342,8 @@ compile_while(char_u *arg, cctx_T *cctx)
     whilescope->ws_loop_info.li_depth = scope->se_loop_depth - 1;
 
     // compile "expr"
-    if (compile_expr0(&p, cctx) == FAIL)
+    if (compile_expr0(&p, cctx) == FAIL
+				    && recover_expr(&p, &t_bool, cctx) == FAIL)
 	return NULL;
 
     if (!ends_excmd2(arg, skipwhite(p)))

--- a/src/vim9compile.c
+++ b/src/vim9compile.c
@@ -2330,7 +2330,16 @@ compile_lhs(
     {
 	// set the LHS variable type
 	if (compile_lhs_set_type(cctx, lhs, var_end, is_decl) == FAIL)
+	{
+	    // In a dry run declare the variable anyway, so that using it does
+	    // not add an error.
+	    if (source_dryrun && lhs->lhs_lvar == NULL
+		    && lhs->lhs_dest == dest_local
+		    && cctx->ctx_skip != SKIP_YES)
+		reserve_local(cctx, var_start, lhs->lhs_varlen, ASSIGN_VAR,
+								       &t_any);
 	    return FAIL;
+	}
     }
 
     if (oplen == 3 && !heredoc && !lhs_concatenable(lhs))
@@ -4292,6 +4301,8 @@ compile_def_function_body(
     char_u	*line = NULL;
     char_u	*p;
     int		did_emsg_before = did_emsg;
+    int		failed = FALSE;
+    int		stack_len = 0;
 #ifdef FEAT_PROFILE
     int		prof_lnum = -1;
 #endif
@@ -4304,10 +4315,12 @@ compile_def_function_body(
 	char_u	    *cmd;
 	cmdmod_T    local_cmdmod;
 
+	stack_len = cctx->ctx_type_stack.ga_len;
+
 	// Bail out on the first error to avoid a flood of errors and report
 	// the right line number when inside try/catch.
 	if (did_emsg_before != did_emsg)
-	    return FAIL;
+	    goto linefail;
 
 	if (line != NULL && *line == '|')
 	    // the line continues after a '|'
@@ -4317,10 +4330,10 @@ compile_def_function_body(
 						    || VIM_ISWHITE(line[-1]))))
 	{
 	    semsg(_(e_trailing_characters_str), line);
-	    return FAIL;
+	    goto linefail;
 	}
 	else if (line != NULL && vim9_bad_comment(skipwhite(line)))
-	    return FAIL;
+	    goto linefail;
 	else
 	{
 	    line = next_line_from_context(cctx, FALSE);
@@ -4355,7 +4368,7 @@ compile_def_function_body(
 	{
 	    // "#" starts a comment, but "#{" is an error
 	    if (vim9_bad_comment(ea.cmd))
-		return FAIL;
+		goto linefail;
 	    line = (char_u *)"";
 	    continue;
 	}
@@ -4395,7 +4408,7 @@ compile_def_function_body(
 		    else
 		    {
 			emsg(_(e_using_rcurly_outside_if_block_scope));
-			return FAIL;
+			goto linefail;
 		    }
 		    if (line != NULL)
 			line = skipwhite(ea.cmd + 1);
@@ -4419,7 +4432,7 @@ compile_def_function_body(
 	cctx->ctx_has_cmdmod = FALSE;
 	if (parse_command_modifiers(&ea, errormsg, &local_cmdmod, FALSE)
 								       == FAIL)
-	    return FAIL;
+	    goto linefail;
 	generate_cmdmods(cctx, &local_cmdmod);
 	undo_cmdmod(&local_cmdmod);
 
@@ -4455,7 +4468,7 @@ compile_def_function_body(
 		if (assign == OK)
 		    goto nextline;
 		if (assign == FAIL)
-		    return FAIL;
+		    goto linefail;
 	    }
 	}
 
@@ -4483,7 +4496,7 @@ compile_def_function_body(
 				   && !(local_cmdmod.cmod_flags & CMOD_LEGACY))
 		{
 		    semsg(_(e_colon_required_before_range_str), cmd);
-		    return FAIL;
+		    goto linefail;
 		}
 		ea.addr_count = 1;
 		if (ends_excmd2(line, ea.cmd))
@@ -4504,7 +4517,7 @@ compile_def_function_body(
 	{
 	    if (cctx->ctx_skip != SKIP_YES)
 		semsg(_(e_ambiguous_use_of_user_defined_command_str), ea.cmd);
-	    return FAIL;
+	    goto linefail;
 	}
 
 	// When using ":legacy cmd" always use compile_exec().
@@ -4529,7 +4542,7 @@ compile_def_function_body(
 		case CMD_finally:
 		case CMD_endtry:
 			semsg(_(e_cannot_use_legacy_with_command_str), ea.cmd);
-			return FAIL;
+			goto linefail;
 		default: break;
 	    }
 
@@ -4554,7 +4567,7 @@ compile_def_function_body(
 	    else
 	    {
 		semsg(_(e_command_not_recognized_str), ea.cmd);
-		return FAIL;
+		goto linefail;
 	    }
 	}
 
@@ -4571,7 +4584,7 @@ compile_def_function_body(
 	{
 	    semsg(_(e_unreachable_code_after_str),
 				     cctx->ctx_had_return ? "return" : "throw");
-	    return FAIL;
+	    goto linefail;
 	}
 
 	// When processing the end of an if-else block, don't clear the
@@ -4598,7 +4611,7 @@ compile_def_function_body(
 	    if ((ea.argt & EX_RANGE) == 0 && ea.addr_count > 0)
 	    {
 		emsg(_(e_no_range_allowed));
-		return FAIL;
+		goto linefail;
 	    }
 	}
 
@@ -4743,7 +4756,7 @@ compile_def_function_body(
 
 	    case CMD_substitute:
 		    if (check_global_and_subst(ea.cmd, p) == FAIL)
-			return FAIL;
+			goto linefail;
 		    if (cctx->ctx_skip == SKIP_YES)
 			line = (char_u *)"";
 		    else
@@ -4781,13 +4794,13 @@ compile_def_function_body(
 	    case CMD_t:
 	    case CMD_xit:
 		    not_in_vim9(&ea);
-		    return FAIL;
+		    goto linefail;
 
 	    case CMD_SIZE:
 		    if (cctx->ctx_skip != SKIP_YES)
 		    {
 			semsg(_(e_invalid_command_str), ea.cmd);
-			return FAIL;
+			goto linefail;
 		    }
 		    // We don't check for a next command here.
 		    line = (char_u *)"";
@@ -4815,30 +4828,30 @@ compile_def_function_body(
 		    if (cctx->ctx_skip != SKIP_YES)
 		    {
 			emsg(_(e_vim9script_can_only_be_used_in_script));
-			return FAIL;
+			goto linefail;
 		    }
 		    line = (char_u *)"";
 		    break;
 
 	    case CMD_class:
 		    emsg(_(e_class_can_only_be_used_in_script));
-		    return FAIL;
+		    goto linefail;
 
 	    case CMD_enum:
 		    emsg(_(e_enum_can_only_be_used_in_script));
-		    return FAIL;
+		    goto linefail;
 
 	    case CMD_interface:
 		    emsg(_(e_interface_can_only_be_used_in_script));
-		    return FAIL;
+		    goto linefail;
 
 	    case CMD_type:
 		    emsg(_(e_type_can_only_be_used_in_script));
-		    return FAIL;
+		    goto linefail;
 
 	    case CMD_global:
 		    if (check_global_and_subst(ea.cmd, p) == FAIL)
-			return FAIL;
+			goto linefail;
 		    // FALLTHROUGH
 	    default:
 		    // Not recognized, execute with do_cmdline_cmd().
@@ -4848,7 +4861,7 @@ compile_def_function_body(
 	}
 nextline:
 	if (line == NULL)
-	    return FAIL;
+	    goto linefail;
 	line = skipwhite(line);
 
 	// Undo any command modifiers.
@@ -4859,9 +4872,25 @@ nextline:
 	    iemsg("Type stack underflow");
 	    return FAIL;
 	}
+	continue;
+
+linefail:
+	// With ":source ++dryrun" go on with the next line, to report the
+	// errors in the rest of the function as well.
+	if (!source_dryrun)
+	    return FAIL;
+	if (*errormsg != NULL)
+	{
+	    emsg(*errormsg);
+	    *errormsg = NULL;
+	}
+	failed = TRUE;
+	did_emsg_before = did_emsg;
+	cctx->ctx_type_stack.ga_len = stack_len;
+	line = (char_u *)"";
     } // END of the loop over all the function body lines.
 
-    return OK;
+    return failed ? FAIL : OK;
 }
 
 /*

--- a/src/vim9expr.c
+++ b/src/vim9expr.c
@@ -2407,6 +2407,20 @@ bool_on_stack(cctx_T *cctx)
 }
 
 /*
+ * With ":source ++dryrun", after an error in an expression: put a value of
+ * "type" in its place and skip the rest of the line, so that compiling can
+ * go on.  Returns FAIL when not in a dry run.
+ */
+    int
+recover_expr(char_u **arg, type_T *type, cctx_T *cctx)
+{
+    if (!source_dryrun)
+	return FAIL;
+    *arg += STRLEN(*arg);
+    return push_type_stack(cctx, type);
+}
+
+/*
  * Give the "white on both sides" error, taking the operator from "p[len]".
  */
     void

--- a/src/vim9script.c
+++ b/src/vim9script.c
@@ -14,6 +14,8 @@
 #include "vim.h"
 
 #if defined(FEAT_EVAL)
+static void declare_scriptvar_zero(char_u *name, type_T *type, int flags);
+
 /*
  * Return TRUE when currently in a script with script version smaller than
  * "max_version" or command modifiers forced it.
@@ -416,7 +418,9 @@ handle_import(
     }
 
     // The name of the file can be an expression, which must evaluate to a
-    // string.
+    // string.  With ":source ++dryrun" no function is called for it.
+    if (source_dryrun && vim_strchr(arg, '(') != NULL)
+	return NULL;
     ret = eval0_retarg(arg, &tv, NULL, evalarg, &expr_end);
     if (ret == FAIL)
 	goto erret;
@@ -787,7 +791,6 @@ vim9_declare_scriptvar(exarg_T *eap, char_u *arg)
     char_u	    *name;
     scriptitem_T    *si = SCRIPT_ITEM(current_sctx.sc_sid);
     type_T	    *type;
-    typval_T	    init_tv;
 
     if (eap->cmdidx == CMD_final || eap->cmdidx == CMD_const)
     {
@@ -832,17 +835,75 @@ vim9_declare_scriptvar(exarg_T *eap, char_u *arg)
 	return p;
     }
 
-    // Create the variable with 0/NULL value.
+    declare_scriptvar_zero(name, type, 0);
+
+    vim_free(name);
+    return p;
+}
+
+/*
+ * Create the variable "name" with "type" and a 0/NULL value.  "flags" can
+ * have ASSIGN_CONST or ASSIGN_FINAL.
+ */
+    static void
+declare_scriptvar_zero(char_u *name, type_T *type, int flags)
+{
+    typval_T	init_tv;
+
     CLEAR_FIELD(init_tv);
     if (type->tt_type == VAR_ANY)
 	// A variable of type "any" is not possible, just use zero instead
 	init_tv.v_type = VAR_NUMBER;
     else
 	init_tv.v_type = type->tt_type;
-    set_var_const(name, 0, type, &init_tv, FALSE, ASSIGN_INIT, 0);
+    set_var_const(name, 0, type, &init_tv, FALSE, ASSIGN_INIT | flags, 0);
+}
 
-    vim_free(name);
-    return p;
+/*
+ * ":source ++dryrun": declare the variables of a ":var", ":const" or ":final"
+ * command with "arg" pointing at the first name, without evaluating the
+ * expression.  Each gets the declared type or "any", and a 0/NULL value.
+ */
+    void
+vim9_declare_dryrun(char_u *arg, int flags)
+{
+    scriptitem_T    *si = SCRIPT_ITEM(current_sctx.sc_sid);
+    char_u	    *p = arg;
+    int		    in_list = *p == '[';
+
+    if (in_list)
+	++p;
+    for (;;)
+    {
+	char_u	*name_start;
+	char_u	*name;
+	type_T	*type = &t_any;
+
+	p = skipwhite(p);
+	if (!eval_isnamec1(*p))
+	    break;
+	name_start = p;
+	for (p = p + 1; *p != NUL && eval_isnamec(*p); MB_PTR_ADV(p))
+	    if (*p == ':' && (VIM_ISWHITE(p[1]) || p != name_start + 1))
+		break;
+	name = vim_strnsave(name_start, p - name_start);
+	if (name == NULL)
+	    break;
+	if (*p == ':')
+	{
+	    p = skipwhite(p + 1);
+	    type = parse_type(&p, &si->sn_type_list, NULL, NULL, TRUE);
+	}
+	if (type != NULL && check_reserved_name(name, FALSE) == OK)
+	    declare_scriptvar_zero(name, type, flags);
+	vim_free(name);
+	if (type == NULL || !in_list)
+	    break;
+	p = skipwhite(p);
+	if (*p != ',' && *p != ';')
+	    break;
+	++p;
+    }
 }
 
 /*


### PR DESCRIPTION
```
Problem:  There is no way to have Vim read a script and compile its
          :def functions without running it, so that a script can be
          checked for errors without its side effects.
Solution: Add "++dryrun" to ":source": only the definitions in the
          script are executed, a declared variable gets its type but
          not its value, everything else is skipped, then the functions
          are compiled and the errors reported.  An error in a
          definition does not stop the reading.
```