### PR TITLE
runtime(netrw): netrw#fs#Glob() cannot list a remote directory

### DIFF
--- a/runtime/pack/dist/opt/netrw/autoload/netrw/fs.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw/fs.vim
@@ -115,8 +115,8 @@ function! netrw#fs#Glob(direntry, expr, pare)
         keepalt 1sp
         keepalt enew
         let keep_liststyle = w:netrw_liststyle
-        let w:netrw_liststyle = s:THINLIST
-        if s:NetrwRemoteListing() == 0
+        let w:netrw_liststyle = netrw#Expose('THINLIST')
+        if netrw#Call('NetrwRemoteListing') == 0
             keepj keepalt %s@/@@
             let filelist = getline(1,$)
             q!


### PR DESCRIPTION
```
Problem:  netrw#fs#Glob() calls s:NetrwRemoteListing() and uses
          s:THINLIST, which are script-local to autoload/netrw.vim and
          not visible in autoload/netrw/fs.vim.  Listing a remote
          directory in the tree view fails with E117 and E121.
Solution: Use netrw#Call() and netrw#Expose(), which exist to reach
          the script-local functions and variables of netrw.vim.
```

---

I haven't used netrw in over 10 years.
I just happened to stumble upon this while building on a language server for Vim script.