### PR TITLE
Other channels are not read while waiting for a response on one

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -62,6 +62,7 @@ typedef struct sockaddr_un {
 #endif
 
 static void channel_read(channel_T *channel, ch_part_T part, char *func);
+static void channel_wait_any(long msec);
 static ch_mode_T channel_get_mode(channel_T *channel, ch_part_T part);
 static int channel_get_timeout(channel_T *channel, ch_part_T part);
 static channel_T *channel_open_stdio(void);
@@ -4642,6 +4643,23 @@ channel_in_blocking_wait(void)
 }
 
 /*
+ * Wait up to "timeout" msec for something to read on "fd" of "channel", and
+ * read what arrives on any channel meanwhile.
+ */
+    static void
+channel_wait_reading(channel_T *channel UNUSED, sock_T fd UNUSED, int timeout)
+{
+#ifdef MSWIN
+    // A pipe cannot be waited for, channel_wait() polls it; the other
+    // channels are looked at every 10 msec.
+    (void)channel_wait(channel, fd, timeout > 10 ? 10 : timeout);
+    channel_handle_events(FALSE);
+#else
+    channel_wait_any(timeout);
+#endif
+}
+
+/*
  * Read one JSON message with ID "id" from "channel"/"part" and store the
  * result in "rettv".
  * When "id" is -1 accept any message;
@@ -4663,6 +4681,11 @@ channel_read_json_block(
     chanpart_T	*chanpart = &channel->ch_part[part];
     ch_mode_T	mode = channel->ch_part[part].ch_mode;
     int		retval = FAIL;
+#ifdef ELAPSED_FUNC
+    elapsed_T	start_tv;
+
+    ELAPSED_INIT(start_tv);
+#endif
 
     ch_log(channel, "Blocking read JSON for id %d", id);
     ++channel_blocking_wait;
@@ -4705,48 +4728,46 @@ channel_read_json_block(
 	    if (readahead_ptr != NULL && readahead_ptr != prev_readahead_ptr)
 		continue;
 
-	    // Wait for up to the timeout.  If there was an incomplete message
-	    // use the deadline for that.
+	    // Wait for up to what is left of the timeout.
 	    timeout = timeout_arg;
+#ifdef ELAPSED_FUNC
+	    timeout -= (int)ELAPSED_FUNC(start_tv);
+#endif
+	    fd = chanpart->ch_fd;
+	    if (timeout <= 0 || fd == INVALID_FD)
+	    {
+		if (fd != INVALID_FD)
+		    ch_log(channel, "Timed out on id %d", id);
+		break;
+	    }
+	    // If there was an incomplete message use the deadline for that.
 	    if (chanpart->ch_wait_len > 0)
 	    {
+		int	left;
 #ifdef MSWIN
-		timeout = chanpart->ch_deadline - GetTickCount() + 1;
+		left = chanpart->ch_deadline - GetTickCount() + 1;
 #else
 		{
 		    struct timeval now_tv;
 
 		    gettimeofday(&now_tv, NULL);
-		    timeout = (chanpart->ch_deadline.tv_sec
-						       - now_tv.tv_sec) * 1000
-			+ (chanpart->ch_deadline.tv_usec
-						     - now_tv.tv_usec) / 1000
-			+ 1;
+		    left = (chanpart->ch_deadline.tv_sec - now_tv.tv_sec) * 1000
+			+ (chanpart->ch_deadline.tv_usec - now_tv.tv_usec)
+								    / 1000 + 1;
 		}
 #endif
-		if (timeout < 0)
-		{
+		if (left < 0)
 		    // Something went wrong, channel_parse_json() didn't
 		    // discard message.  Cancel waiting.
 		    chanpart->ch_wait_len = 0;
-		    timeout = timeout_arg;
-		}
-		else if (timeout > timeout_arg)
-		    timeout = timeout_arg;
+		else if (left < timeout)
+		    timeout = left;
 	    }
-	    fd = chanpart->ch_fd;
-	    if (fd == INVALID_FD
-			    || channel_wait(channel, fd, timeout) != CW_READY)
-	    {
-		if (timeout == timeout_arg)
-		{
-		    if (fd != INVALID_FD)
-			ch_log(channel, "Timed out on id %d", id);
-		    break;
-		}
-	    }
-	    else
-		channel_read(channel, part, "channel_read_json_block");
+	    channel_wait_reading(channel, fd, timeout);
+#ifndef ELAPSED_FUNC
+	    // Without a clock the wait counts as the whole timeout.
+	    timeout_arg = 0;
+#endif
 	}
     }
     if (id >= 0)

--- a/src/testdir/test_channel.vim
+++ b/src/testdir/test_channel.vim
@@ -2977,6 +2977,66 @@ func Test_stdio_channel()
   call job_stop(job)
 endfunc
 
+" A message that is only partly read when Vim gets busy with blocking reads
+" on another channel is not dropped: the rest of it was there to be read.
+func Test_lsp_incomplete_message_while_blocked()
+  if has('win32') && has('gui_running')
+    throw 'Skipped: gvim.exe cannot run without the GUI'
+  endif
+  let lines =<< trim END
+    func OnMessage(ch, msg)
+      if a:msg.method == 'quick'
+        call timer_start(10, {-> ch_sendexpr(a:ch, #{id: a:msg.id, result: 1})})
+      endif
+    endfunc
+    call ch_open('stdio', #{mode: 'lsp', callback: 'OnMessage'})
+  END
+  call writefile(lines, 'Xstdio_child.vim', 'D')
+  let lines =<< trim END
+    let notes = 0
+    let child = job_start([v:progpath, '--clean', '--stdio-channel',
+          \ '-S', 'Xstdio_child.vim'], #{in_mode: 'lsp', out_mode: 'lsp'})
+    func Block(timer)
+      for i in range(30)
+        call ch_evalexpr(g:child, #{method: 'quick'}, #{timeout: 5000})
+      endfor
+    endfunc
+    func OnMessage(ch, msg)
+      if a:msg.method == 'note'
+        let g:notes += 1
+      elseif a:msg.method == 'count'
+        call ch_sendexpr(a:ch, #{id: a:msg.id, result: g:notes})
+      elseif a:msg.method == 'block'
+        call ch_sendexpr(a:ch, #{id: a:msg.id, result: 'ok'})
+        call timer_start(10, 'Block')
+      endif
+    endfunc
+    call ch_open('stdio', #{mode: 'lsp', callback: 'OnMessage'})
+  END
+  call writefile(lines, 'Xstdio_busy.vim', 'D')
+  let job = job_start([GetVimProg(), '--clean', '--stdio-channel',
+        \ '-S', 'Xstdio_busy.vim'], #{in_mode: 'lsp', out_mode: 'lsp'})
+  call assert_equal('run', job_status(job))
+
+  " The first half of a notification is read before the blocking reads
+  " start, the second half arrives while they go on.
+  call ch_evalexpr(job, #{method: 'block'}, #{timeout: 5000})
+  let body = json_encode(#{method: 'note', jsonrpc: '2.0',
+        \ params: #{text: repeat('x', 1000)}})
+  let framed = 'Content-Length: ' .. strlen(body) .. "\r\n\r\n" .. body
+  let half = strlen(framed) / 2
+  call ch_sendraw(job, framed[: half - 1])
+  sleep 50m
+  call ch_sendraw(job, framed[half :])
+  sleep 500m
+  let resp = ch_evalexpr(job, #{method: 'count'}, #{timeout: 5000})
+  call assert_equal(1, resp->get('result', resp))
+
+  call ch_close(job)
+  call WaitForAssert({-> assert_equal('dead', job_status(job))})
+  call job_stop(job)
+endfunc
+
 func Test_channel_lsp_mode()
   " The channel lsp mode test is flaky and gives the same error.
   let g:giveup_same_error = 0


### PR DESCRIPTION
```
Problem:  While ch_evalexpr() waits for a response, nothing is read
          from the other channels: what they receive stays in the pipe,
          and a message of theirs that was only partly read is dropped
          as garbage after 100 msec, along with what follows it.
Solution: Wait for the response and for the other channels together,
          reading what arrives on any of them; count the timeout over
          the whole wait.
```

While `ch_evalexpr()` waits for a response, nothing is read from the other
channels.  What they receive stays in the pipe, and a message of theirs that
was only partly read when the wait started hits the 100 msec limit for an
incomplete message and is dropped as garbage, together with whatever follows
it in the buffer.  A JSON, LSP or DAP message larger than one read, arriving
on one channel while a plugin does a series of `ch_evalexpr()` calls on
another, is enough.  The peer has no way of knowing: a notification is simply
lost.

That a single-threaded Vim talking to two or more peers should use
`ch_sendexpr()` with a callback rather than `ch_evalexpr()` is obvious.
Still, what arrives while `ch_evalexpr()` waits must not be lost.

This PR waits for the response and for the other channels together, reading
what arrives on any of them, which is what `:help ch_evalexpr()` already
describes: "while waiting for the response, Vim handles other messages".
The timeout is counted over the whole wait, so a wait no longer exceeds the
timeout by up to 100 msec after a short wait for an incomplete message.

What changes for a plugin that calls `ch_evalexpr()` while other channels are
open:

- The callbacks of the other channels can be invoked during the wait more
  often than before, since their data is read during the wait; the kind of
  callback is the same as before.
- During the wait, data of the other channels is buffered in Vim instead of
  staying in the pipe, so a peer that keeps sending is not held back by the
  pipe filling up.
- On MS-Windows the other channels are polled every 10 msec during the wait;
  the latency for the channel being waited for is unchanged.

The test starts a Vim that serves one channel while it calls `ch_evalexpr()`
on a second one; it fails without the change.