### PR TITLE
Tests: GUI shell resize can land in the middle of a test

### DIFF
--- a/src/testdir/runtest.vim
+++ b/src/testdir/runtest.vim
@@ -63,6 +63,9 @@ if has('gui_running')
 
   func s:SetDefaultOptionsForGUIBuilds()
     set columns=80 lines=25
+    " The GUI may postpone resizing the shell until after a redraw; a test
+    " that measures windows must not see the resize land halfway.
+    redraw
   endfunc
 else
   func s:SetDefaultOptionsForGUIBuilds()


### PR DESCRIPTION
```
Problem:  In a GUI build the shell may be resized only after a redraw,
          so a test that measures windows can see the resize land
          halfway, Test_window_width for one.
Solution: Redraw after setting the size for a test, so that the resize
          is done before the test starts.
```