### PR TITLE
Completion shows an included file by a long name

### DIFF
--- a/src/findfile.c
+++ b/src/findfile.c
@@ -1861,7 +1861,6 @@ find_file_in_path_option(
 	if (first == TRUE)
 	{
 	    int		l;
-	    int		NameBufflen;
 	    int		run;
 	    size_t	rel_fnamelen = 0;
 	    char_u	*suffix;
@@ -1902,7 +1901,6 @@ find_file_in_path_option(
 
 		// When the file doesn't exist, try adding parts of
 		// 'suffixesadd'.
-		NameBufflen = l;
 		suffix = suffixes;
 		for (;;)
 		{
@@ -1911,13 +1909,13 @@ find_file_in_path_option(
 				 || ((find_what == FINDFILE_DIR)
 						    == mch_isdir(NameBuff))))
 		    {
-			file_name = vim_strnsave(NameBuff, NameBufflen);
+			file_name = vim_strnsave(NameBuff,
+						  simplify_filename(NameBuff));
 			goto theend;
 		    }
 		    if (*suffix == NUL)
 			break;
-		    NameBufflen = l + copy_option_part(&suffix, NameBuff + l,
-							    MAXPATHL - l, ",");
+		    copy_option_part(&suffix, NameBuff + l, MAXPATHL - l, ",");
 		}
 	    }
 	}

--- a/src/search.c
+++ b/src/search.c
@@ -3890,7 +3890,8 @@ search_line:
 		}
 
 		add_r = ins_compl_add_infercase(aux, i, p_ic,
-			curr_fname == curbuf->b_fname ? NULL : curr_fname,
+			curr_fname == curbuf->b_fname ? NULL
+						  : shorten_fname1(curr_fname),
 			dir, cont_s_ipos, 0);
 		if (add_r == OK)
 		    // if dir was BACKWARD then honor it just once

--- a/src/testdir/test_ins_complete.vim
+++ b/src/testdir/test_ins_complete.vim
@@ -3440,6 +3440,26 @@ func s:Tagfunc(t,f,o)
   return []
 endfunc
 
+" A match from an included file shows the file by its name under the current
+" directory, without the "./" of the include line.
+func Test_complete_included_file_name()
+  CheckRunVimInTerminal
+  call mkdir('Xincl/sub', 'pR')
+  call writefile(['let included_word = 1'], 'Xincl/sub/inc.vim')
+  call writefile(['source ./sub/inc.vim', ''], 'Xincl/main.vim')
+  let lines =<< trim END
+    setlocal include=^\\s*source\\s\\+ complete=i completeopt=menuone,noselect
+  END
+  call writefile(lines, 'Xincl/setup.vim')
+  let buf = RunVimInTerminal('-S Xincl/setup.vim Xincl/main.vim',
+        \ {'rows': 8, 'cols': 120})
+  call term_sendkeys(buf, "Goincluded_\<C-N>")
+  call WaitForAssert({-> assert_match('included_word\s\+Xincl/sub/inc.vim\s',
+        \ term_getline(buf, 4))})
+  call term_sendkeys(buf, "\<Esc>")
+  call StopVimInTerminal(buf)
+endfunc
+
 " This was using freed memory, since 'complete' was in a wiped out buffer.
 " Also using a window that was closed.
 func Test_tagfunc_wipes_out_buffer()


### PR DESCRIPTION
```
Problem:  A match found in an included file is shown with the full path
          of the file, while a match from a buffer is shown with the
          name under the current directory.  A file included as
          "./file" even has the "./" left in: "dir/./file".
Solution: Show the file by its name under the current directory, and
          simplify the name of a file found relative to the current
          one.
```