### PR TITLE
Remove a TODO

### DIFF
--- a/src/regexp.h
+++ b/src/regexp.h
@@ -22,12 +22,6 @@
 #define NSUBEXP  10
 
 /*
- * In the NFA engine: how many braces are allowed.
- * TODO(RE): Use dynamic memory allocation instead of static, like here
- */
-#define NFA_MAX_BRACES 20
-
-/*
  * In the NFA engine: how many states are allowed
  */
 #define NFA_MAX_STATES 100000


### PR DESCRIPTION
Problem: NFA_MAX_BRACES has an associated TODO to get rid of it.
Solution: NFA_MAX_BRACES isn't used anywhere, so get rid of it and the TODO