### PR TITLE
runtime(syntax): avoid SynSet recursion with "syntax" as filetype

### DIFF
--- a/runtime/syntax/synload.vim
+++ b/runtime/syntax/synload.vim
@@ -55,7 +55,7 @@ fun! s:SynSet()
     " Load the syntax file(s).  When there are several, separated by dots,
     " load each in sequence.  Skip empty entries.
     for name in split(s, '\.')
-      if !empty(name)
+      if !empty(name) && name !=# 'syntax'
 	exe "runtime! syntax/" . name . ".vim syntax/" . name . "/*.vim"
       endif
     endfor

--- a/src/testdir/test_syntax.vim
+++ b/src/testdir/test_syntax.vim
@@ -1077,5 +1077,4 @@ func Test_syn_sync_grouphere_shorter_next_line()
   bw!
 endfunc
 
-
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/testdir/test_syntax.vim
+++ b/src/testdir/test_syntax.vim
@@ -101,6 +101,13 @@ func Test_syntax_after_reload()
   call delete('Xsomefile')
 endfunc
 
+func Test_syntax_filetype_syntax()
+  set filetype=syntax
+  syntax on
+  syntax off
+  set filetype= syntax=
+endfunc
+
 func Test_syntime()
   CheckFeature profile
 
@@ -1069,5 +1076,6 @@ func Test_syn_sync_grouphere_shorter_next_line()
 
   bw!
 endfunc
+
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
**Problem**
```sh
vim -Nu NONE \
  +'set filetype=syntax' \
  +'syntax on'
```
yields
```text
Error detected while processing command line..script /usr/share/vim/vim92/syntax/syntax.vim[42]..
FileType Autocommands for "*"..Syntax Autocomm ands for "*"..function <SNR>2_SynSet[25]..
script /usr/share/vim/vim92/syntax/syntax.vim[20]../usr/share/vim/vim92/syntax/synload.vim: 
line 63: E127: Cannot redefine function <SNR>2_SynSet: It is in use
```

Handles a cornercase; if filetype is accidentally set as `syntax`.

That reloads `synload.vim` while `SynSet()` is still executing, causing Vim to try to redefine the active function:

```text
E127: Cannot redefine function <SNR>2_SynSet: It is in use
```

**Solution**
Skip the special `syntax` filetype.