### PR TITLE
MS-Windows: testing.obj and sound.obj are not rebuilt on header changes

### DIFF
--- a/src/Make_mvc.mak
+++ b/src/Make_mvc.mak
@@ -1782,6 +1782,8 @@ $(OUTDIR)/cairo.obj: $(OUTDIR) cairo.c $(INCL)
 
 $(OUTDIR)/socketserver.obj: $(OUTDIR) socketserver.c $(INCL)
 
+$(OUTDIR)/sound.obj: $(OUTDIR) sound.c $(INCL)
+
 $(OUTDIR)/spell.obj: $(OUTDIR) spell.c $(INCL)
 
 $(OUTDIR)/spellfile.obj: $(OUTDIR) spellfile.c $(INCL)
@@ -1798,7 +1800,7 @@ $(OUTDIR)/tag.obj: $(OUTDIR) tag.c $(INCL)
 
 $(OUTDIR)/term.obj: $(OUTDIR) term.c $(INCL)
 
-$(OUTDIR)/term.obj: $(OUTDIR) testing.c $(INCL)
+$(OUTDIR)/testing.obj: $(OUTDIR) testing.c $(INCL)
 
 $(OUTDIR)/textformat.obj: $(OUTDIR) textformat.c $(INCL)
 


### PR DESCRIPTION
```
Problem:  With Make_mvc.mak, testing.obj and sound.obj are only rebuilt
          when their own source file changes.  The rule for testing.obj
          names term.obj as its target, sound.obj has no rule at all, so
          both are built by the inference rule, which does not depend on
          the header files.  Linking fails with an unresolved
          in_vim9script() after patch 9.2.1044 unless the old object is
          deleted by hand.
Solution: Name testing.obj in its rule and add a rule for sound.obj.
```