### PR TITLE
:write fails when a BufWritePre autocmd changes to another directory

### DIFF
--- a/src/bufwrite.c
+++ b/src/bufwrite.c
@@ -965,15 +965,16 @@ buf_write(
 	}
 
 	// The autocommands may have changed the name of the buffer, which may
-	// be kept in fname, ffname and sfname.
+	// be kept in fname, ffname and sfname.  A ":cd" may also have dropped
+	// the short name, then b_fname is the full name.
 	if (buf_ffname)
 	    ffname = buf->b_ffname;
 	if (buf_sfname)
-	    sfname = buf->b_sfname;
+	    sfname = buf->b_fname;
 	if (buf_fname_f)
 	    fname = buf->b_ffname;
 	if (buf_fname_s)
-	    fname = buf->b_sfname;
+	    fname = buf->b_fname;
     }
 
     if (cmdmod.cmod_flags & CMOD_LOCKMARKS)

--- a/src/testdir/test_writefile.vim
+++ b/src/testdir/test_writefile.vim
@@ -1017,4 +1017,20 @@ func Test_backupcopy_auto_restrictive_umask()
 	\ systemlist('ls -i Xumaskfile')[0]->matchstr('^\s*\zs\d\+'))
 endfunc
 
+" Test for :write when a BufWritePre autocmd changes to a directory that does
+" not contain the file: the short file name is dropped and the full name must
+" be used.
+func Test_write_BufWritePre_cd_away()
+  call mkdir('Xcdaway/other', 'pR')
+  let save_cwd = getcwd()
+  defer chdir(save_cwd)
+  cd Xcdaway
+  new file.txt
+  call setline(1, 'hello')
+  autocmd BufWritePre <buffer> cd other
+  write
+  call assert_equal(['hello'], readfile('../file.txt'))
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
## Problem:

  :write fails with E212 when a BufWritePre autocmd changes to a
  directory that does not contain the file.  The directory change
  drops the buffer's short name, and buf_write() uses that NULL
  short name when it re-reads the buffer's names after the
  autocommands.

## Solution:

  Use b_fname, which is the short name when there is one and the
  full name otherwise.

fixes: #21275