### PR TITLE
Write the prototype files with "//" comments

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1988,6 +1988,7 @@ PROTO_FILES = \
 	proto/sixel.pro \
 	proto/kitty.pro \
 	proto/cairo.pro \
+	proto/socketserver.pro \
 	proto/sound.pro \
 	proto/spell.pro \
 	proto/spellfile.pro \

--- a/src/proto/alloc.pro
+++ b/src/proto/alloc.pro
@@ -1,4 +1,4 @@
-/* alloc.c */
+// alloc.c
 void vim_mem_profile_dump(void);
 int alloc_does_fail(size_t size);
 void *alloc(size_t size);
@@ -28,4 +28,4 @@ void ga_concat(garray_T *gap, char_u *s);
 void ga_concat_len(garray_T *gap, char_u *s, size_t len);
 int ga_append(garray_T *gap, int c);
 void append_ga_line(garray_T *gap);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/arabic.pro
+++ b/src/proto/arabic.pro
@@ -1,5 +1,5 @@
-/* arabic.c */
+// arabic.c
 int arabic_maycombine(int two);
 int arabic_combine(int one, int two);
 int arabic_shape(int c, int *ccp, int *c1p, int prev_c, int prev_c1, int next_c);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/arglist.pro
+++ b/src/proto/arglist.pro
@@ -1,4 +1,4 @@
-/* arglist.c */
+// arglist.c
 void alist_clear(alist_T *al);
 void alist_init(alist_T *al);
 void alist_unlink(alist_T *al);
@@ -30,4 +30,4 @@ void f_argc(typval_T *argvars, typval_T *rettv);
 void f_argidx(typval_T *argvars, typval_T *rettv);
 void f_arglistid(typval_T *argvars, typval_T *rettv);
 void f_argv(typval_T *argvars, typval_T *rettv);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/autocmd.pro
+++ b/src/proto/autocmd.pro
@@ -1,4 +1,4 @@
-/* autocmd.c */
+// autocmd.c
 void aubuflocal_remove(buf_T *buf);
 int au_has_group(char_u *name);
 void do_augroup(char_u *arg, int del_group);
@@ -51,4 +51,4 @@ int au_exists(char_u *arg);
 void f_autocmd_add(typval_T *argvars, typval_T *rettv);
 void f_autocmd_delete(typval_T *argvars, typval_T *rettv);
 void f_autocmd_get(typval_T *argvars, typval_T *rettv);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/beval.pro
+++ b/src/proto/beval.pro
@@ -1,7 +1,7 @@
-/* beval.c */
+// beval.c
 int find_word_under_cursor(int mouserow, int mousecol, int getword, int flags, win_T **winp, linenr_T *lnump, char_u **textp, int *colp, int *startcolp);
 int get_beval_info(BalloonEval *beval, int getword, win_T **winp, linenr_T *lnump, char_u **textp, int *colp);
 void post_balloon(BalloonEval *beval, char_u *mesg, list_T *list);
 int can_use_beval(void);
 void general_beval_cb(BalloonEval *beval, int state);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/blob.pro
+++ b/src/proto/blob.pro
@@ -1,4 +1,4 @@
-/* blob.c */
+// blob.c
 blob_T *blob_alloc(void);
 int rettv_blob_alloc(typval_T *rettv);
 void rettv_blob_set(typval_T *rettv, blob_T *b);
@@ -28,4 +28,4 @@ void blob_reduce(typval_T *argvars, typval_T *expr, typval_T *rettv);
 void blob_reverse(blob_T *b, typval_T *rettv);
 void f_blob2list(typval_T *argvars, typval_T *rettv);
 void f_list2blob(typval_T *argvars, typval_T *rettv);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/blowfish.pro
+++ b/src/proto/blowfish.pro
@@ -1,6 +1,6 @@
-/* blowfish.c */
+// blowfish.c
 void crypt_blowfish_encode(cryptstate_T *state, char_u *from, size_t len, char_u *to, int last);
 void crypt_blowfish_decode(cryptstate_T *state, char_u *from, size_t len, char_u *to, int last);
 int crypt_blowfish_init(cryptstate_T *state, char_u *key, crypt_arg_T *arg);
 int blowfish_self_test(void);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/buffer.pro
+++ b/src/proto/buffer.pro
@@ -1,4 +1,4 @@
-/* buffer.c */
+// buffer.c
 int get_highest_fnum(void);
 void buffer_ensure_loaded(buf_T *buf);
 int open_buffer(int read_stdin, exarg_T *eap, int flags_arg);
@@ -74,4 +74,4 @@ char_u *buf_get_fname(buf_T *buf);
 void set_buflisted(int on);
 int buf_contents_changed(buf_T *buf);
 void wipe_buffer(buf_T *buf, int aucmd);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/bufwrite.pro
+++ b/src/proto/bufwrite.pro
@@ -1,4 +1,4 @@
-/* bufwrite.c */
+// bufwrite.c
 char *new_file_message(void);
 int buf_write(buf_T *buf, char_u *fname, char_u *sfname, linenr_T start, linenr_T end, exarg_T *eap, int append, int forceit, int reset_changed, int filtering);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/cairo.pro
+++ b/src/proto/cairo.pro
@@ -1,6 +1,6 @@
-/* cairo.c */
+// cairo.c
 bool cairo_popup_image_ensure(win_T *wp);
 bool cairo_popup_image_update(win_T *wp);
 void cairo_popup_image_free(win_T *wp);
 void cairo_popup_image_paint(win_T *wp, void *target, int x, int y, double src_x, double src_y, double draw_w, double draw_h);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/change.pro
+++ b/src/proto/change.pro
@@ -1,4 +1,4 @@
-/* change.c */
+// change.c
 void change_warning(int col);
 void changed(void);
 void changed_internal(void);
@@ -30,4 +30,4 @@ int del_bytes(long count, int fixpos_arg, int use_delcombine);
 int open_line(int dir, int flags, int second_line_indent, int *did_do_comment);
 int truncate_line(int fixpos);
 void del_lines(long nlines, int undo);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/channel.pro
+++ b/src/proto/channel.pro
@@ -1,4 +1,4 @@
-/* channel.c */
+// channel.c
 channel_T *add_channel(void);
 int has_any_channel(void);
 int channel_still_useful(channel_T *channel);
@@ -68,4 +68,4 @@ void f_ch_setoptions(typval_T *argvars, typval_T *rettv);
 void f_ch_status(typval_T *argvars, typval_T *rettv);
 char_u *channel_to_string_buf(typval_T *varp, char_u *buf);
 channel_T *channel_find(int ch_id);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/charset.pro
+++ b/src/proto/charset.pro
@@ -1,4 +1,4 @@
-/* charset.c */
+// charset.c
 int init_chartab(void);
 int buf_init_chartab(buf_T *buf, int global);
 int check_isopt(char_u *var);
@@ -74,4 +74,4 @@ int hexhex2nr(char_u *p);
 int rem_backslash(char_u *str);
 void backslash_halve(char_u *p);
 char_u *backslash_halve_save(char_u *p);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/cindent.pro
+++ b/src/proto/cindent.pro
@@ -1,4 +1,4 @@
-/* cindent.c */
+// cindent.c
 int cin_is_cinword(char_u *line);
 int is_pos_in_string(char_u *line, colnr_T col);
 int check_linecomment(char_u *line);
@@ -9,4 +9,4 @@ int get_c_indent(void);
 int in_cinkeys(int keytyped, int when, int line_is_empty);
 void do_c_expr_indent(void);
 void f_cindent(typval_T *argvars, typval_T *rettv);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/clientserver.pro
+++ b/src/proto/clientserver.pro
@@ -1,4 +1,4 @@
-/* clientserver.c */
+// clientserver.c
 void server_to_input_buf(char_u *str);
 char_u *eval_client_expr_to_string(char_u *expr);
 int sendToLocalVim(char_u *cmd, int asExpr, char_u **result);
@@ -14,4 +14,4 @@ void f_remote_startserver(typval_T *argvars, typval_T *rettv);
 void f_server2client(typval_T *argvars, typval_T *rettv);
 void f_serverlist(typval_T *argvars, typval_T *rettv);
 void check_clientserver_method_env(void);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/clipboard.pro
+++ b/src/proto/clipboard.pro
@@ -1,4 +1,4 @@
-/* clipboard.c */
+// clipboard.c
 void clip_init(int can_use);
 void clip_update_selection(Clipboard_T *clip);
 void clip_own_selection(Clipboard_T *cbd);
@@ -46,4 +46,4 @@ void call_clip_provider_set(int reg);
 void inc_clip_provider(void);
 void dec_clip_provider(void);
 int clip_convert_data(char_u **buf, long *len_store, int *motion, bool vim, bool vimenc, char_u **tofree);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/cmdexpand.pro
+++ b/src/proto/cmdexpand.pro
@@ -1,4 +1,4 @@
-/* cmdexpand.c */
+// cmdexpand.c
 int cmdline_fuzzy_complete(char_u *fuzzystr);
 int nextwild(expand_T *xp, int type, int options, int escape);
 void cmdline_pum_display(void);
@@ -28,4 +28,4 @@ void wildmenu_cleanup(cmdline_info_T *cclp);
 void f_getcompletion(typval_T *argvars, typval_T *rettv);
 void f_getcompletiontype(typval_T *argvars, typval_T *rettv);
 void f_cmdcomplete_info(typval_T *argvars, typval_T *rettv);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/cmdhist.pro
+++ b/src/proto/cmdhist.pro
@@ -1,4 +1,4 @@
-/* cmdhist.c */
+// cmdhist.c
 int get_hislen(void);
 histentry_T *get_histentry(int hist_type);
 void set_histentry(int hist_type, histentry_T *entry);
@@ -16,4 +16,4 @@ void f_histget(typval_T *argvars, typval_T *rettv);
 void f_histnr(typval_T *argvars, typval_T *rettv);
 void remove_key_from_history(void);
 void ex_history(exarg_T *eap);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/crypt.pro
+++ b/src/proto/crypt.pro
@@ -1,4 +1,4 @@
-/* crypt.c */
+// crypt.c
 int sodium_enabled(int verbose);
 int crypt_method_nr_from_name(char_u *name);
 int crypt_method_nr_from_magic(char *ptr, int len);
@@ -31,4 +31,4 @@ int crypt_sodium_munlock(void *const addr, const size_t len);
 void crypt_sodium_randombytes_buf(void *const buf, const size_t size);
 int crypt_sodium_init(void);
 UINT32_T crypt_sodium_randombytes_random(void);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/crypt_zip.pro
+++ b/src/proto/crypt_zip.pro
@@ -1,5 +1,5 @@
-/* crypt_zip.c */
+// crypt_zip.c
 int crypt_zip_init(cryptstate_T *state, char_u *key, crypt_arg_T *arg);
 void crypt_zip_encode(cryptstate_T *state, char_u *from, size_t len, char_u *to, int last);
 void crypt_zip_decode(cryptstate_T *state, char_u *from, size_t len, char_u *to, int last);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/debugger.pro
+++ b/src/proto/debugger.pro
@@ -1,4 +1,4 @@
-/* debugger.c */
+// debugger.c
 int has_watchexpr(void);
 void do_debug(char_u *cmd);
 void ex_debug(exarg_T *eap);
@@ -12,4 +12,4 @@ void ex_breaklist(exarg_T *eap);
 linenr_T dbg_find_breakpoint(int file, char_u *fname, linenr_T after);
 int has_profiling(int file, char_u *fname, int *fp, hash_T *hashp);
 void dbg_breakpoint(char_u *name, linenr_T lnum);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/dict.pro
+++ b/src/proto/dict.pro
@@ -1,4 +1,4 @@
-/* dict.c */
+// dict.c
 dict_T *dict_alloc(void);
 dict_T *dict_alloc_id(alloc_id_T id);
 dict_T *dict_alloc_lock(int lock);
@@ -51,4 +51,4 @@ void f_keys(typval_T *argvars, typval_T *rettv);
 void f_values(typval_T *argvars, typval_T *rettv);
 void dict_set_items_ro(dict_T *di);
 void f_has_key(typval_T *argvars, typval_T *rettv);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/diff.pro
+++ b/src/proto/diff.pro
@@ -1,4 +1,4 @@
-/* diff.c */
+// diff.c
 void diff_buf_delete(buf_T *buf);
 void diff_buf_adjust(win_T *win);
 void diff_buf_add(buf_T *buf);
@@ -34,4 +34,4 @@ linenr_T diff_lnum_win(linenr_T lnum, win_T *wp);
 void f_diff_filler(typval_T *argvars, typval_T *rettv);
 void f_diff_hlID(typval_T *argvars, typval_T *rettv);
 void f_diff(typval_T *argvars, typval_T *rettv);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/digraph.pro
+++ b/src/proto/digraph.pro
@@ -1,4 +1,4 @@
-/* digraph.c */
+// digraph.c
 int do_digraph(int c);
 char_u *get_digraph_for_char(int val_arg);
 int get_digraph(int cmdline);
@@ -12,4 +12,4 @@ void f_digraph_setlist(typval_T *argvars, typval_T *rettv);
 char *keymap_init(void);
 void ex_loadkeymap(exarg_T *eap);
 void keymap_clear(garray_T *kmap);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/drawline.pro
+++ b/src/proto/drawline.pro
@@ -1,5 +1,5 @@
-/* drawline.c */
+// drawline.c
 int text_prop_position(win_T *wp, textprop_T *tp, int vcol, int scr_col, int *n_extra, char_u **p_extra, int *n_attr, int *n_attr_skip, int do_skip);
 int text_prop_no_showbreak(textprop_T *tp);
 int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int number_only, spellvars_T *spv);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/drawscreen.pro
+++ b/src/proto/drawscreen.pro
@@ -1,4 +1,4 @@
-/* drawscreen.c */
+// drawscreen.c
 int update_screen(int type_arg);
 int statusline_row(win_T *wp);
 void win_redr_status(win_T *wp, int ignore_pum);
@@ -28,4 +28,4 @@ void redraw_win_range_later(win_T *wp, linenr_T first, linenr_T last);
 void redraw_win_range_now(win_T *wp, linenr_T first, linenr_T last);
 void f_redraw_listener_add(typval_T *argvars, typval_T *rettv);
 void f_redraw_listener_remove(typval_T *argvars, typval_T *rettv);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/edit.pro
+++ b/src/proto/edit.pro
@@ -1,4 +1,4 @@
-/* edit.c */
+// edit.c
 int edit(int cmdchar, int startln, long count);
 int ins_need_undo_get(void);
 void ins_redraw(int ready);
@@ -39,4 +39,4 @@ colnr_T get_nolist_virtcol(void);
 int get_can_cindent(void);
 void set_can_cindent(int val);
 int ins_apply_autocmds(event_T event);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/eval.pro
+++ b/src/proto/eval.pro
@@ -1,4 +1,4 @@
-/* eval.c */
+// eval.c
 varnumber_T num_divide(varnumber_T n1, varnumber_T n2, int *failed);
 varnumber_T num_modulus(varnumber_T n1, varnumber_T n2, int *failed);
 void eval_init(void);
@@ -77,4 +77,4 @@ void ex_execute(exarg_T *eap);
 char_u *find_option_end(char_u **arg, int *scope);
 void last_set_msg(sctx_T script_ctx);
 char_u *do_string_sub(char_u *str, size_t len, char_u *pat, char_u *sub, typval_T *expr, char_u *flags, size_t *ret_len);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/evalbuffer.pro
+++ b/src/proto/evalbuffer.pro
@@ -1,4 +1,4 @@
-/* evalbuffer.c */
+// evalbuffer.c
 int set_ref_in_buffers(int copyID);
 buf_T *buflist_find_by_name(char_u *name, int curtab_only);
 buf_T *find_buffer(typval_T *avar);
@@ -24,4 +24,4 @@ void switch_buffer(bufref_T *save_curbuf, buf_T *buf);
 void restore_buffer(bufref_T *save_curbuf);
 void switch_to_win_for_buf(buf_T *buf, switchwin_T *switchwin, bufref_T *save_curbuf);
 void restore_win_for_buf(switchwin_T *switchwin, bufref_T *save_curbuf);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/evalfunc.pro
+++ b/src/proto/evalfunc.pro
@@ -1,4 +1,4 @@
-/* evalfunc.c */
+// evalfunc.c
 int arg_type_modifiable(type_T *type, int arg_idx);
 char_u *get_function_name(expand_T *xp, int idx);
 char_u *get_expr_name(expand_T *xp, int idx);
@@ -29,4 +29,4 @@ void mzscheme_call_vim(char_u *name, typval_T *args, typval_T *rettv);
 void range_list_materialize(list_T *list);
 long do_searchpair(char_u *spat, char_u *mpat, char_u *epat, int dir, typval_T *skip, int flags, pos_T *match_pos, linenr_T lnum_stop, long time_limit);
 int get_yank_type(char_u **pp, char_u *yank_type, long *block_len);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/evalvars.pro
+++ b/src/proto/evalvars.pro
@@ -1,4 +1,4 @@
-/* evalvars.c */
+// evalvars.c
 void evalvars_init(void);
 void evalvars_clear(void);
 int garbage_collect_globvars(int copyID);
@@ -112,4 +112,4 @@ void set_callback(callback_T *dest, callback_T *src);
 void copy_callback(callback_T *dest, callback_T *src);
 void expand_autload_callback(callback_T *cb);
 void free_callback(callback_T *callback);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/evalwindow.pro
+++ b/src/proto/evalwindow.pro
@@ -1,4 +1,4 @@
-/* evalwindow.c */
+// evalwindow.c
 win_T *win_id2wp(int id);
 win_T *win_id2wp_tp(int id, tabpage_T **tpp);
 void win_findbuf(typval_T *argvars, list_T *list);
@@ -38,4 +38,4 @@ int switch_win(switchwin_T *switchwin, win_T *win, tabpage_T *tp, int no_display
 int switch_win_noblock(switchwin_T *switchwin, win_T *win, tabpage_T *tp, int no_display);
 void restore_win(switchwin_T *switchwin, int no_display);
 void restore_win_noblock(switchwin_T *switchwin, int no_display);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/ex_cmds.pro
+++ b/src/proto/ex_cmds.pro
@@ -1,4 +1,4 @@
-/* ex_cmds.c */
+// ex_cmds.c
 void do_ascii(exarg_T *eap);
 void ex_align(exarg_T *eap);
 void ex_sort(exarg_T *eap);
@@ -42,4 +42,4 @@ void ex_drop(exarg_T *eap);
 char_u *skip_vimgrep_pat(char_u *p, char_u **s, int *flags);
 char_u *skip_vimgrep_pat_ext(char_u *p, char_u **s, int *flags, char_u **nulp, int *cp);
 void ex_oldfiles(exarg_T *eap);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/ex_cmds2.pro
+++ b/src/proto/ex_cmds2.pro
@@ -1,4 +1,4 @@
-/* ex_cmds2.c */
+// ex_cmds2.c
 int autowrite(buf_T *buf, int forceit);
 void autowrite_all(void);
 int check_changed(buf_T *buf, int flags);
@@ -15,4 +15,4 @@ void ex_pyxfile(exarg_T *eap);
 void ex_pyx(exarg_T *eap);
 void ex_pyxdo(exarg_T *eap);
 void ex_checktime(exarg_T *eap);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/ex_docmd.pro
+++ b/src/proto/ex_docmd.pro
@@ -1,4 +1,4 @@
-/* ex_docmd.c */
+// ex_docmd.c
 void do_exmode(int improved);
 int do_cmdline_cmd(char_u *cmd);
 int do_cmdline(char_u *cmdline, char_u *(*fgetline)(int, void *, int, getline_opt_T), void *cookie, int flags);
@@ -80,4 +80,4 @@ void set_no_hlsearch(int flag);
 int is_loclist_cmd(int cmdidx);
 int get_pressedreturn(void);
 void set_pressedreturn(int val);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/ex_eval.pro
+++ b/src/proto/ex_eval.pro
@@ -1,4 +1,4 @@
-/* ex_eval.c */
+// ex_eval.c
 int aborting(void);
 void update_force_abort(void);
 int should_abort(int retcode);
@@ -40,4 +40,4 @@ int cleanup_conditionals(cstack_T *cstack, int searched_cond, int inclusive);
 void rewind_conditionals(cstack_T *cstack, int idx, int cond_type, int *cond_level);
 void ex_endfunction(exarg_T *eap);
 int has_loop_cmd(char_u *p);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/ex_getln.pro
+++ b/src/proto/ex_getln.pro
@@ -1,4 +1,4 @@
-/* ex_getln.c */
+// ex_getln.c
 int parse_pattern_and_range(pos_T *incsearch_start, int *search_delim, int *skiplen, int *patlen);
 void cmdline_init(void);
 char_u *getcmdline(int firstc, long count, int indent, getline_opt_T do_concat);
@@ -47,4 +47,4 @@ int is_in_cmdwin(void);
 char_u *script_get(exarg_T *eap, char_u *cmd);
 void get_user_input(typval_T *argvars, typval_T *rettv, int inputdialog, int secret);
 void f_wildtrigger(typval_T *argvars, typval_T *rettv);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/fileio.pro
+++ b/src/proto/fileio.pro
@@ -1,4 +1,4 @@
-/* fileio.c */
+// fileio.c
 void filemess(buf_T *buf, char_u *name, char_u *s, int attr);
 int readfile(char_u *fname, char_u *sfname, linenr_T from, linenr_T lines_to_skip, linenr_T lines_to_read, exarg_T *eap, int flags);
 int is_dev_fd_file(char_u *fname);
@@ -42,4 +42,4 @@ int match_file_list(char_u *list, char_u *sfname, char_u *ffname);
 char_u *file_pat_to_reg_pat(char_u *pat, char_u *pat_end, char *allow_dirs, int no_bslash);
 long read_eintr(int fd, void *buf, size_t bufsize);
 long write_eintr(int fd, void *buf, size_t bufsize);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/filepath.pro
+++ b/src/proto/filepath.pro
@@ -1,4 +1,4 @@
-/* filepath.c */
+// filepath.c
 int modify_fname(char_u *src, int tilde_file, size_t *usedlen, char_u **fnamep, char_u **bufp, size_t *fnamelen);
 void shorten_dir(char_u *str);
 int file_is_readable(char_u *fname);
@@ -63,4 +63,4 @@ void FreeWild(int count, char_u **files);
 int pathcmp(const char *p, const char *q, int maxlen);
 int vim_isAbsName(char_u *name);
 int vim_FullName(char_u *fname, char_u *buf, int len, int force);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/findfile.pro
+++ b/src/proto/findfile.pro
@@ -1,4 +1,4 @@
-/* findfile.c */
+// findfile.c
 void *vim_findfile_init(char_u *path, char_u *filename, size_t filenamelen, char_u *stopdirs, int level, int free_visited, int find_what, void *search_ctx_arg, int tagfile, char_u *rel_fname);
 char_u *vim_findfile_stopdir(char_u *buf);
 void vim_findfile_cleanup(void *ctx);
@@ -16,4 +16,4 @@ void uniquefy_paths(garray_T *gap, char_u *pattern, char_u *path_option);
 int expand_in_path(garray_T *gap, char_u *pattern, int flags);
 size_t simplify_filename(char_u *filename);
 void f_simplify(typval_T *argvars, typval_T *rettv);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/float.pro
+++ b/src/proto/float.pro
@@ -1,4 +1,4 @@
-/* float.c */
+// float.c
 int string2float(char_u *text, float_T *value, int skip_quotes);
 void f_abs(typval_T *argvars, typval_T *rettv);
 void f_acos(typval_T *argvars, typval_T *rettv);
@@ -26,4 +26,4 @@ void f_str2float(typval_T *argvars, typval_T *rettv);
 void f_tan(typval_T *argvars, typval_T *rettv);
 void f_tanh(typval_T *argvars, typval_T *rettv);
 void f_trunc(typval_T *argvars, typval_T *rettv);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/fold.pro
+++ b/src/proto/fold.pro
@@ -1,4 +1,4 @@
-/* fold.c */
+// fold.c
 void copyFoldingState(win_T *wp_from, win_T *wp_to);
 int hasAnyFolding(win_T *win);
 int hasFolding(linenr_T lnum, linenr_T *firstp, linenr_T *lastp);
@@ -42,4 +42,4 @@ void f_foldclosedend(typval_T *argvars, typval_T *rettv);
 void f_foldlevel(typval_T *argvars, typval_T *rettv);
 void f_foldtext(typval_T *argvars, typval_T *rettv);
 void f_foldtextresult(typval_T *argvars, typval_T *rettv);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/fuzzy.pro
+++ b/src/proto/fuzzy.pro
@@ -1,4 +1,4 @@
-/* fuzzy.c */
+// fuzzy.c
 int fuzzy_match(char_u *str, char_u *pat_arg, int matchseq, int *outScore, int_u *matches, int maxMatches);
 void f_matchfuzzy(typval_T *argvars, typval_T *rettv);
 void f_matchfuzzypos(typval_T *argvars, typval_T *rettv);
@@ -8,4 +8,4 @@ int fuzzy_match_str_in_line(char_u **ptr, char_u *pat, int *len, pos_T *current_
 int search_for_fuzzy_match(buf_T *buf, pos_T *pos, char_u *pattern, int dir, pos_T *start_pos, int *len, char_u **ptr, int *score);
 void fuzmatch_str_free(fuzmatch_str_T *fuzmatch, int count);
 int fuzzymatches_to_strmatches(fuzmatch_str_T *fuzmatch, char_u ***matches, int count, int funcsort);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/gc.pro
+++ b/src/proto/gc.pro
@@ -1,4 +1,4 @@
-/* gc.c */
+// gc.c
 int get_copyID(void);
 int garbage_collect(int testing);
 int set_ref_in_ht(hashtab_T *ht, int copyID, list_stack_T **list_stack, tuple_stack_T **tuple_stack);
@@ -10,4 +10,4 @@ int set_ref_in_tuple_items(tuple_T *tuple, int copyID, ht_stack_T **ht_stack, li
 int set_ref_in_callback(callback_T *cb, int copyID);
 int set_ref_in_item_class(class_T *cl, int copyID, ht_stack_T **ht_stack, list_stack_T **list_stack, tuple_stack_T **tuple_stack);
 int set_ref_in_item(typval_T *tv, int copyID, ht_stack_T **ht_stack, list_stack_T **list_stack, tuple_stack_T **tuple_stack);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/gen_prototypes.py
+++ b/src/proto/gen_prototypes.py
@@ -459,10 +459,10 @@ def write_prototypes(out_path: Path, headers: List[str], src_name: str) -> None:
     out_path.parent.mkdir(parents=True, exist_ok=True)
     try:
         with out_path.open("w", encoding="utf-8", newline="\n") as f:
-            f.write(f"/* {src_name} */\n")
+            f.write(f"// {src_name}\n")
             for h in headers:
                 f.write(h + "\n")
-            f.write("/* vim: set ft=c : */\n")
+            f.write("// vim: ft=c\n")
     except Exception as e:
         print(f"write failed: {e}", file=sys.stderr)
         sys.exit(4)

--- a/src/proto/getchar.pro
+++ b/src/proto/getchar.pro
@@ -1,4 +1,4 @@
-/* getchar.c */
+// getchar.c
 char_u *get_recorded(void);
 string_T get_inserted(void);
 int stuff_empty(void);
@@ -59,4 +59,4 @@ int input_available(void);
 void may_add_last_used_map_to_redobuff(void);
 int do_cmdkey_command(int key, int flags);
 void reset_last_used_map(mapblock_T *mp);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/gui.pro
+++ b/src/proto/gui.pro
@@ -1,4 +1,4 @@
-/* gui.c */
+// gui.c
 void gui_start(char_u *arg);
 void gui_prepare(int *argc, char **argv);
 int gui_init_check(void);
@@ -65,4 +65,4 @@ int gui_do_findrepl(int flags, char_u *find_text, char_u *repl_text, int down);
 void gui_handle_drop(int x, int y, int_u modifiers, char_u **fnames, int count);
 int check_for_interrupt(int key, int modifiers_arg);
 int gui_dialog_log(char_u *title, char_u *message);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/gui_beval.pro
+++ b/src/proto/gui_beval.pro
@@ -1,4 +1,4 @@
-/* gui_beval.c */
+// gui_beval.c
 BalloonEval *gui_mch_create_beval_area(void *target, char_u *mesg, void (*mesgCB)(BalloonEval *, int), void *clientData);
 void gui_mch_destroy_beval_area(BalloonEval *beval);
 void gui_mch_enable_beval_area(BalloonEval *beval);
@@ -6,4 +6,4 @@ void gui_mch_disable_beval_area(BalloonEval *beval);
 BalloonEval *gui_mch_currently_showing_beval(void);
 void gui_mch_post_balloon(BalloonEval *beval, char_u *mesg);
 void gui_mch_unpost_balloon(BalloonEval *beval);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/gui_gtk.pro
+++ b/src/proto/gui_gtk.pro
@@ -1,4 +1,4 @@
-/* gui_gtk.c */
+// gui_gtk.c
 void gui_gtk_register_stock_icons(void);
 void gui_mch_add_menu(vimmenu_T *menu, int idx);
 void gui_mch_add_menu_item(vimmenu_T *menu, int idx);
@@ -22,4 +22,4 @@ void gui_mch_find_dialog(exarg_T *eap);
 void gui_mch_replace_dialog(exarg_T *eap);
 void ex_helpfind(exarg_T *eap);
 void gui_mch_set_fullscreen(int flag);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/gui_gtk4.pro
+++ b/src/proto/gui_gtk4.pro
@@ -1,4 +1,4 @@
-/* gui_gtk4.c */
+// gui_gtk4.c
 void gui_mch_prepare(int *argc, char **argv);
 void gui_mch_free_all(void);
 int gui_mch_is_blinking(void);
@@ -111,4 +111,4 @@ void gui_mch_replace_dialog(exarg_T *eap);
 void ex_helpfind(exarg_T *eap);
 char_u *gui_gtk4_print_dialog(prt_settings_T *psettings, char_u *jobname, double *page_width, double *page_height);
 void gui_gtk4_print_finish(void);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/gui_gtk_gresources.pro
+++ b/src/proto/gui_gtk_gresources.pro
@@ -1,5 +1,5 @@
-/* gui_gtk_gresources.c */
+// gui_gtk_gresources.c
 GResource *gui_gtk_get_resource(void);
 void gui_gtk_unregister_resource(void);
 void gui_gtk_register_resource(void);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/gui_gtk_x11.pro
+++ b/src/proto/gui_gtk_x11.pro
@@ -1,4 +1,4 @@
-/* gui_gtk_x11.c */
+// gui_gtk_x11.c
 void gui_mch_prepare(int *argc, char **argv);
 void gui_mch_free_all(void);
 int gui_mch_is_blinking(void);
@@ -82,4 +82,4 @@ void mch_set_mouse_shape(int shape);
 void gui_mch_drawsign(int row, int col, int typenr);
 void *gui_mch_register_sign(char_u *signfile);
 void gui_mch_destroy_sign(void *sign);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/gui_haiku.pro
+++ b/src/proto/gui_haiku.pro
@@ -1,4 +1,4 @@
-/* gui_haiku.cc - hand crafted */
+// manually generated from gui_haiku.cc
 
 void gui_mch_prepare(int *argc, char **argv);
 int gui_mch_init(void);
@@ -95,3 +95,4 @@ void gui_mch_set_tabline_pos(int x, int y, int w, int h);
 int gui_mch_showing_tabline(void);
 void gui_mch_update_tabline(void);
 void gui_mch_set_curtab(int nr);
+// vim: ft=c

--- a/src/proto/gui_motif.pro
+++ b/src/proto/gui_motif.pro
@@ -1,4 +1,4 @@
-/* gui_motif.c */
+// gui_motif.c
 void gui_x11_create_widgets(void);
 void gui_x11_destroy_widgets(void);
 void gui_mch_set_text_area_pos(int x, int y, int w, int h);
@@ -43,4 +43,4 @@ void gui_motif_menu_fontlist(Widget id);
 void gui_mch_find_dialog(exarg_T *eap);
 void gui_mch_replace_dialog(exarg_T *eap);
 void gui_motif_synch_fonts(void);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/gui_photon.pro
+++ b/src/proto/gui_photon.pro
@@ -1,4 +1,4 @@
-/* gui_photon.c */
+// gui_photon.c
 void gui_ph_encoding_changed(int new_encoding);
 void gui_mch_prepare(int *argc, char **argv);
 int gui_mch_init(void);
@@ -69,4 +69,4 @@ GuiFont gui_mch_get_font(char_u *vim_font_name, int report_error);
 char_u *gui_mch_get_fontname(GuiFont font, char_u *name);
 void gui_mch_set_font(GuiFont font);
 void gui_mch_free_font(GuiFont font);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/gui_w32.pro
+++ b/src/proto/gui_w32.pro
@@ -1,4 +1,4 @@
-/* gui_w32.c */
+// gui_w32.c
 int gui_mch_set_rendering_options(char_u *s);
 int gui_mch_is_blinking(void);
 int gui_mch_is_blink_off(void);
@@ -104,4 +104,4 @@ BalloonEval *gui_mch_create_beval_area(void *target, char_u *mesg, void (*mesgCB
 void gui_mch_destroy_beval_area(BalloonEval *beval);
 void netbeans_draw_multisign_indicator(int row);
 int test_gui_w32_sendevent(char_u *event, dict_T *args);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/gui_x11.pro
+++ b/src/proto/gui_x11.pro
@@ -1,4 +1,4 @@
-/* gui_x11.c */
+// gui_x11.c
 void gui_x11_key_hit_cb(Widget w, XtPointer dud, XEvent *event, Boolean *dum);
 void gui_mch_prepare(int *argc, char **argv);
 int gui_mch_init_check(void);
@@ -69,4 +69,4 @@ void gui_mch_destroy_sign(void *sign);
 void gui_mch_mousehide(int hide);
 void mch_set_mouse_shape(int shape);
 void gui_mch_menu_set_tip(vimmenu_T *menu);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/gui_xim.pro
+++ b/src/proto/gui_xim.pro
@@ -1,4 +1,4 @@
-/* gui_xim.c */
+// gui_xim.c
 char *did_set_imactivatefunc(optset_T *args);
 char *did_set_imstatusfunc(optset_T *args);
 void free_xim_stuff(void);
@@ -18,4 +18,4 @@ int preedit_get_status(void);
 int im_is_preediting(void);
 void xim_set_status_area(void);
 int xim_get_status_area_height(void);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/gui_xmdlg.pro
+++ b/src/proto/gui_xmdlg.pro
@@ -1,3 +1,3 @@
-/* gui_xmdlg.c */
+// gui_xmdlg.c
 char_u *gui_xm_select_font(char_u *current);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/hardcopy.pro
+++ b/src/proto/hardcopy.pro
@@ -1,4 +1,4 @@
-/* hardcopy.c */
+// hardcopy.c
 char *parse_printoptions(optset_T *args);
 char *parse_printmbfont(optset_T *args);
 int prt_header_height(void);
@@ -6,4 +6,4 @@ int prt_use_number(void);
 int prt_get_unit(int idx);
 void prt_message(char_u *s);
 void ex_hardcopy(exarg_T *eap);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/hardcopy_pango.pro
+++ b/src/proto/hardcopy_pango.pro
@@ -1,4 +1,4 @@
-/* hardcopy_pango.c */
+// hardcopy_pango.c
 int mch_print_init(prt_settings_T *psettings, char_u *jobname, int forceit);
 int mch_print_begin(prt_settings_T *psettings);
 void mch_print_end(prt_settings_T *psettings);
@@ -11,4 +11,4 @@ void mch_print_set_font(int bold, int italic, int underline);
 void mch_print_set_bg(long_u bgcol);
 void mch_print_set_fg(long_u fgcol);
 void mch_print_cleanup(void);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/hardcopy_postscript.pro
+++ b/src/proto/hardcopy_postscript.pro
@@ -1,4 +1,4 @@
-/* hardcopy_postscript.c */
+// hardcopy_postscript.c
 void mch_print_cleanup(void);
 int mch_print_init(prt_settings_T *psettings, char_u *jobname, int forceit);
 int mch_print_begin(prt_settings_T *psettings);
@@ -11,4 +11,4 @@ int mch_print_text_out(char_u *textp, int len);
 void mch_print_set_font(int iBold, int iItalic, int iUnderline);
 void mch_print_set_bg(long_u bgcol);
 void mch_print_set_fg(long_u fgcol);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/hashtab.pro
+++ b/src/proto/hashtab.pro
@@ -1,4 +1,4 @@
-/* hashtab.c */
+// hashtab.c
 void hash_init(hashtab_T *ht);
 int check_hashtab_frozen(hashtab_T *ht, char *command);
 void hash_clear(hashtab_T *ht);
@@ -13,4 +13,4 @@ void hash_lock(hashtab_T *ht);
 void hash_lock_size(hashtab_T *ht, int size);
 void hash_unlock(hashtab_T *ht);
 hash_T hash_hash(char_u *key);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/help.pro
+++ b/src/proto/help.pro
@@ -1,4 +1,4 @@
-/* help.c */
+// help.c
 void ex_help(exarg_T *eap);
 void ex_helpclose(exarg_T *eap);
 char_u *check_help_lang(char_u *arg);
@@ -10,4 +10,4 @@ void fix_help_buffer(void);
 void ex_exusage(exarg_T *eap);
 void ex_viusage(exarg_T *eap);
 void ex_helptags(exarg_T *eap);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/highlight.pro
+++ b/src/proto/highlight.pro
@@ -1,4 +1,4 @@
-/* highlight.c */
+// highlight.c
 int highlight_num_groups(void);
 char_u *highlight_group_name(int id);
 int highlight_link_id(int id);
@@ -56,4 +56,4 @@ void pop_highlight_overrides(void);
 char *update_winhighlight(win_T *wp, char_u *opt);
 int hlf_get_id(win_T *wp, int hlf);
 char *update_wincolor(win_T *wp, char_u *opt);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/if_cscope.pro
+++ b/src/proto/if_cscope.pro
@@ -1,4 +1,4 @@
-/* if_cscope.c */
+// if_cscope.c
 char_u *get_cscope_name(expand_T *xp, int idx);
 void set_context_in_cscope_cmd(expand_T *xp, char_u *arg, cmdidx_T cmdidx);
 void ex_cscope(exarg_T *eap);
@@ -9,4 +9,4 @@ void cs_free_tags(void);
 void cs_print_tags(void);
 void cs_end(void);
 void f_cscope_connection(typval_T *argvars, typval_T *rettv);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/if_lua.pro
+++ b/src/proto/if_lua.pro
@@ -1,4 +1,4 @@
-/* if_lua.c */
+// if_lua.c
 int lua_enabled(int verbose);
 void lua_end(void);
 void ex_lua(exarg_T *eap);
@@ -9,4 +9,4 @@ void lua_window_free(win_T *o);
 void do_luaeval(char_u *str, typval_T *arg, typval_T *rettv);
 int set_ref_in_lua(int copyID);
 void update_package_paths_in_lua(void);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/if_mzsch.pro
+++ b/src/proto/if_mzsch.pro
@@ -1,4 +1,4 @@
-/* if_mzsch.c */
+// if_mzsch.c
 int mzscheme_enabled(int verbose);
 void mzvim_check_threads(void);
 char *did_set_mzquantum(optset_T *args);
@@ -14,4 +14,4 @@ void raise_if_error(void);
 buf_T *get_valid_buffer(void *obj);
 win_T *get_valid_window(void *obj);
 int mzthreads_allowed(void);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/if_ole.pro
+++ b/src/proto/if_ole.pro
@@ -1,5 +1,6 @@
-/* manually generated from if_ole.cpp */
+// manually generated from if_ole.cpp
 void InitOLE(int* pbDoRestart);
 void UninitOLE(void);
 void RegisterMe(int silent);
 void UnregisterMe(int bNotifyUser);
+// vim: ft=c

--- a/src/proto/if_perl.pro
+++ b/src/proto/if_perl.pro
@@ -1,4 +1,4 @@
-/* manually generated if_perl.c from if_perl.xs */
+// manually generated if_perl.c from if_perl.xs
 int perl_enabled(int verbose);
 void perl_end(void);
 void msg_split(char_u *s, int attr);
@@ -7,3 +7,4 @@ void perl_buf_free(buf_T *bp);
 void ex_perl(exarg_T *eap);
 void do_perleval(char_u *str, typval_T *rettv);
 void ex_perldo(exarg_T *eap);
+// vim: ft=c

--- a/src/proto/if_python.pro
+++ b/src/proto/if_python.pro
@@ -1,4 +1,4 @@
-/* if_python.c */
+// if_python.c
 int python_enabled(int verbose);
 void python_end(void);
 int python_loaded(void);
@@ -10,4 +10,4 @@ void python_window_free(win_T *win);
 void python_tabpage_free(tabpage_T *tab);
 void do_pyeval(char_u *str, dict_T *locals, typval_T *rettv);
 int set_ref_in_python(int copyID);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/if_python3.pro
+++ b/src/proto/if_python3.pro
@@ -1,4 +1,4 @@
-/* if_python3.c */
+// if_python3.c
 int python3_enabled(int verbose);
 void python3_end(void);
 int python3_loaded(void);
@@ -11,4 +11,4 @@ void python3_tabpage_free(tabpage_T *tab);
 void do_py3eval(char_u *str, dict_T *locals, typval_T *rettv);
 int set_ref_in_python3(int copyID);
 int python3_version(void);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/if_ruby.pro
+++ b/src/proto/if_ruby.pro
@@ -1,4 +1,4 @@
-/* if_ruby.c */
+// if_ruby.c
 int ruby_enabled(int verbose);
 void ruby_end(void);
 void ex_ruby(exarg_T *eap);
@@ -8,4 +8,4 @@ void ruby_buffer_free(buf_T *buf);
 void ruby_window_free(win_T *win);
 void vim_ruby_init(void *stack_start);
 void do_rubyeval(char_u *str, typval_T *rettv);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/if_tcl.pro
+++ b/src/proto/if_tcl.pro
@@ -1,4 +1,4 @@
-/* if_tcl.c */
+// if_tcl.c
 void vim_tcl_init(char *arg);
 int tcl_enabled(int verbose);
 void vim_tcl_finalize(void);
@@ -8,4 +8,4 @@ void ex_tclfile(exarg_T *eap);
 void ex_tcldo(exarg_T *eap);
 void tcl_buffer_free(buf_T *buf);
 void tcl_window_free(win_T *win);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/if_xcmdsrv.pro
+++ b/src/proto/if_xcmdsrv.pro
@@ -1,4 +1,4 @@
-/* if_xcmdsrv.c */
+// if_xcmdsrv.c
 int serverRegisterName(Display *dpy, char_u *name);
 void serverChangeRegisteredWindow(Display *dpy, Window newwin);
 int serverSendToVim(Display *dpy, char_u *name, char_u *cmd, char_u **result, Window *server, Bool asExpr, int timeout, Bool localLoop, int silent);
@@ -10,4 +10,4 @@ int serverPeekReply(Display *dpy, Window win, char_u **str);
 void serverEventProc(Display *dpy, XEvent *eventPtr, int immediate);
 void server_parse_messages(void);
 int server_waiting(void);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/indent.pro
+++ b/src/proto/indent.pro
@@ -1,4 +1,4 @@
-/* indent.c */
+// indent.c
 int tabstop_set(char_u *var, int **array);
 int tabstop_padding(colnr_T col, int ts_arg, int *vts);
 int tabstop_at(colnr_T col, int ts, int *vts, int left);
@@ -35,4 +35,4 @@ int use_indentexpr_for_lisp(void);
 void fix_indent(void);
 void f_indent(typval_T *argvars, typval_T *rettv);
 void f_lispindent(typval_T *argvars, typval_T *rettv);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/insexpand.pro
+++ b/src/proto/insexpand.pro
@@ -1,4 +1,4 @@
-/* insexpand.c */
+// insexpand.c
 void ins_ctrl_x(void);
 int ctrl_x_mode_none(void);
 int ctrl_x_mode_normal(void);
@@ -85,4 +85,4 @@ bool ins_compl_autocomplete_pending(void);
 long ins_compl_autocomplete_elapsed(void);
 void free_insexpand_stuff(void);
 void f_preinserted(typval_T *argvars, typval_T *rettv);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/job.pro
+++ b/src/proto/job.pro
@@ -1,4 +1,4 @@
-/* job.c */
+// job.c
 void clear_job_options(jobopt_T *opt);
 void free_job_options(jobopt_T *opt);
 int get_job_options(typval_T *tv, jobopt_T *opt, int supported, int supported2);
@@ -34,4 +34,4 @@ void f_job_start(typval_T *argvars, typval_T *rettv);
 void f_job_status(typval_T *argvars, typval_T *rettv);
 void f_job_stop(typval_T *argvars, typval_T *rettv);
 char_u *job_to_string_buf(typval_T *varp, char_u *buf);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/json.pro
+++ b/src/proto/json.pro
@@ -1,4 +1,4 @@
-/* json.c */
+// json.c
 char_u *json_encode(typval_T *val, int options);
 char_u *json_encode_nr_expr(int nr, typval_T *val, int options);
 char_u *json_encode_lsp_msg(typval_T *val);
@@ -8,4 +8,4 @@ void f_js_decode(typval_T *argvars, typval_T *rettv);
 void f_js_encode(typval_T *argvars, typval_T *rettv);
 void f_json_decode(typval_T *argvars, typval_T *rettv);
 void f_json_encode(typval_T *argvars, typval_T *rettv);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/kitty.pro
+++ b/src/proto/kitty.pro
@@ -1,6 +1,6 @@
-/* kitty.c */
+// kitty.c
 int kitty_transmit(image_rgb_T *img, int id);
 void kitty_place(int id, int row, int col, int src_x, int src_y, int w, int h, int z);
 void kitty_delete(int id, bool del_data);
 int kitty_probe_parse(char *buf, int n);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/linematch.pro
+++ b/src/proto/linematch.pro
@@ -1,3 +1,3 @@
-/* linematch.c */
+// linematch.c
 size_t linematch_nbuffers(const mmfile_t **diff_blk, const int *diff_len, const size_t ndiffs, int **decisions, int iwhite);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/list.pro
+++ b/src/proto/list.pro
@@ -1,4 +1,4 @@
-/* list.c */
+// list.c
 void list_add_watch(list_T *l, listwatch_T *lw);
 void list_rem_watch(list_T *l, listwatch_T *lwrem);
 list_T *list_alloc(void);
@@ -68,4 +68,4 @@ void f_remove(typval_T *argvars, typval_T *rettv);
 void f_reverse(typval_T *argvars, typval_T *rettv);
 void f_reduce(typval_T *argvars, typval_T *rettv);
 void f_slice(typval_T *argvars, typval_T *rettv);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/locale.pro
+++ b/src/proto/locale.pro
@@ -1,4 +1,4 @@
-/* locale.c */
+// locale.c
 char_u *get_mess_lang(void);
 void set_lang_var(void);
 void init_locale(void);
@@ -6,4 +6,4 @@ void ex_language(exarg_T *eap);
 void free_locales(void);
 char_u *get_lang_arg(expand_T *xp, int idx);
 char_u *get_locales(expand_T *xp, int idx);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/logfile.pro
+++ b/src/proto/logfile.pro
@@ -1,7 +1,7 @@
-/* logfile.c */
+// logfile.c
 void ch_logfile(char_u *fname, char_u *opt);
 int ch_log_active(void);
 void ch_log_literal(char *lead, channel_T *ch, ch_part_T part, char_u *buf, int len);
 void f_ch_log(typval_T *argvars, typval_T *rettv);
 void f_ch_logfile(typval_T *argvars, typval_T *rettv);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/main.pro
+++ b/src/proto/main.pro
@@ -1,4 +1,4 @@
-/* main.c */
+// main.c
 int vim_main2(void);
 void common_init_1(void);
 void common_init_2(mparm_T *paramp);
@@ -18,4 +18,4 @@ void getout_preserve_modified(int exitval);
 void getout(int exitval);
 int process_env(char_u *env, int is_viminit);
 void mainerr_arg_missing(char_u *str);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/map.pro
+++ b/src/proto/map.pro
@@ -1,4 +1,4 @@
-/* map.c */
+// map.c
 mapblock_T *get_maphash_list(int state, int c);
 mapblock_T *get_buf_maphash_list(int state, int c);
 int is_maphash_valid(void);
@@ -32,4 +32,4 @@ void ex_map(exarg_T *eap);
 void ex_unmap(exarg_T *eap);
 void ex_mapclear(exarg_T *eap);
 void ex_abclear(exarg_T *eap);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/mark.pro
+++ b/src/proto/mark.pro
@@ -1,4 +1,4 @@
-/* mark.c */
+// mark.c
 int setmark(int c);
 int setmark_pos(int c, pos_T *pos, int fnum);
 void mark_forget_file(win_T *wp, int fnum);
@@ -29,4 +29,4 @@ void set_last_cursor(win_T *win);
 void free_all_marks(void);
 xfmark_T *get_namedfm(void);
 void f_getmarklist(typval_T *argvars, typval_T *rettv);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/match.pro
+++ b/src/proto/match.pro
@@ -1,4 +1,4 @@
-/* match.c */
+// match.c
 void clear_matches(win_T *wp);
 void init_search_hl(win_T *wp, match_T *search_hl);
 void prepare_search_hl(win_T *wp, match_T *search_hl, linenr_T lnum);
@@ -14,4 +14,4 @@ void f_matchaddpos(typval_T *argvars, typval_T *rettv);
 void f_matcharg(typval_T *argvars, typval_T *rettv);
 void f_matchdelete(typval_T *argvars, typval_T *rettv);
 void ex_match(exarg_T *eap);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/mbyte.pro
+++ b/src/proto/mbyte.pro
@@ -1,4 +1,4 @@
-/* mbyte.c */
+// mbyte.c
 int enc_canon_props(char_u *name);
 char *mb_init(void);
 int bomb_size(void);
@@ -92,4 +92,4 @@ void f_setcellwidths(typval_T *argvars, typval_T *rettv);
 void f_getcellwidths(typval_T *argvars, typval_T *rettv);
 void f_charclass(typval_T *argvars, typval_T *rettv);
 char_u *get_encoding_name(expand_T *xp, int idx);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/memfile.pro
+++ b/src/proto/memfile.pro
@@ -1,4 +1,4 @@
-/* memfile.c */
+// memfile.c
 memfile_T *mf_open(char_u *fname, int flags);
 int mf_open_file(memfile_T *mfp, char_u *fname);
 void mf_close(memfile_T *mfp, int del_file);
@@ -15,4 +15,4 @@ blocknr_T mf_trans_del(memfile_T *mfp, blocknr_T old_nr);
 void mf_set_ffname(memfile_T *mfp);
 void mf_fullname(memfile_T *mfp);
 int mf_need_trans(memfile_T *mfp);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/memline.pro
+++ b/src/proto/memline.pro
@@ -1,4 +1,4 @@
-/* memline.c */
+// memline.c
 int ml_open(buf_T *buf);
 void ml_set_crypt_key(buf_T *buf, char_u *old_key, char_u *old_cm);
 void ml_setname(buf_T *buf);
@@ -44,4 +44,4 @@ char_u *ml_encrypt_data(memfile_T *mfp, char_u *data, off_T offset, unsigned siz
 void ml_decrypt_data(memfile_T *mfp, char_u *data, off_T offset, unsigned size);
 long ml_find_line_or_offset(buf_T *buf, linenr_T lnum, long *offp);
 void goto_byte(long cnt);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/menu.pro
+++ b/src/proto/menu.pro
@@ -1,4 +1,4 @@
-/* menu.c */
+// menu.c
 int winbar_height(win_T *wp);
 void ex_menu(exarg_T *eap);
 void remove_winbar(win_T *wp);
@@ -24,4 +24,4 @@ void winbar_click(win_T *wp, int col);
 vimmenu_T *gui_find_menu(char_u *path_name);
 void ex_menutranslate(exarg_T *eap);
 void f_menu_info(typval_T *argvars, typval_T *rettv);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/message.pro
+++ b/src/proto/message.pro
@@ -1,4 +1,4 @@
-/* message.c */
+// message.c
 int msg(char *s);
 int verb_msg(char *s);
 int msg_attr(char *s, int attr);
@@ -79,4 +79,4 @@ int do_dialog(int type, char_u *title, char_u *message, char_u *buttons, int dfl
 int vim_dialog_yesno(int type, char_u *title, char_u *message, int dflt);
 int vim_dialog_yesnocancel(int type, char_u *title, char_u *message, int dflt);
 int vim_dialog_yesnoallcancel(int type, char_u *title, char_u *message, int dflt);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/misc1.pro
+++ b/src/proto/misc1.pro
@@ -1,4 +1,4 @@
-/* misc1.c */
+// misc1.c
 int get_leader_len(char_u *line, char_u **flags, int backward, int include_space);
 int get_last_leader_offset(char_u *line, char_u **flags);
 int plines(linenr_T lnum);
@@ -56,4 +56,4 @@ void restore_v_event(dict_T *v_event, save_v_event_T *sve);
 void may_trigger_modechanged(void);
 int vim_append_digit_long(long *value, int digit);
 int trim_to_int(vimlong_T x);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/misc2.pro
+++ b/src/proto/misc2.pro
@@ -1,4 +1,4 @@
-/* misc2.c */
+// misc2.c
 int virtual_active(void);
 int getviscol(void);
 int coladvance_force(colnr_T wcol);
@@ -69,4 +69,4 @@ void *mergesort_list(void *head, void *(*get_next)(void *), void (*set_next)(voi
 long base64_encode_buf(char_u *dst, const char_u *src, size_t len);
 char_u *base64_encode(const char_u *data, size_t len);
 int base64_decode(const char_u *data, size_t len, garray_T *out);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/mouse.pro
+++ b/src/proto/mouse.pro
@@ -1,4 +1,4 @@
-/* mouse.c */
+// mouse.c
 void mouse_set_vert_scroll_step(long step);
 void mouse_set_hor_scroll_step(long step);
 int do_mouse(oparg_T *oap, int c, int dir, long count, int fixindent);
@@ -24,4 +24,4 @@ int mouse_comp_pos(win_T *win, int *rowp, int *colp, linenr_T *lnump, int *pline
 win_T *mouse_find_win(int *rowp, int *colp, mouse_find_T popup);
 int vcol2col(win_T *wp, linenr_T lnum, int vcol, colnr_T *coladdp);
 void f_getmousepos(typval_T *argvars, typval_T *rettv);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/move.pro
+++ b/src/proto/move.pro
@@ -1,4 +1,4 @@
-/* move.c */
+// move.c
 int plines_correct_topline(win_T *wp, linenr_T lnum, int limit_winheight);
 void set_valid_virtcol(win_T *wp, colnr_T vcol);
 int sms_marker_overlap(win_T *wp, int extra2);
@@ -51,4 +51,4 @@ void scroll_cursor_halfway(int atend, int prefer_above);
 void cursor_correct(void);
 int pagescroll(int dir, long count, int half);
 void do_check_cursorbind(void);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/netbeans.pro
+++ b/src/proto/netbeans.pro
@@ -1,4 +1,4 @@
-/* netbeans.c */
+// netbeans.c
 void netbeans_parse_messages(void);
 int isNetbeansBuffer(buf_T *bufp);
 int isNetbeansModified(buf_T *bufp);
@@ -25,4 +25,4 @@ void netbeans_deleted_all_lines(buf_T *bufp);
 int netbeans_is_guarded(linenr_T top, linenr_T bot);
 void netbeans_draw_multisign_indicator(int row);
 void netbeans_gutter_click(linenr_T lnum);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/normal.pro
+++ b/src/proto/normal.pro
@@ -1,4 +1,4 @@
-/* normal.c */
+// normal.c
 int check_text_or_curbuf_locked(oparg_T *oap);
 void normal_cmd(oparg_T *oap, int toplevel);
 void check_visual_highlight(void);
@@ -34,4 +34,4 @@ void nv_g_home_m_cmd(cmdarg_T *cap);
 int unadjust_for_sel(void);
 int unadjust_for_sel_inner(pos_T *pp);
 void set_cursor_for_append_to_line(void);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/ops.pro
+++ b/src/proto/ops.pro
@@ -1,4 +1,4 @@
-/* ops.c */
+// ops.c
 int get_op_type(int char1, int char2);
 int op_is_change(int op);
 int get_op_char(int optype);
@@ -24,4 +24,4 @@ char *did_set_operatorfunc(optset_T *args);
 void free_operatorfunc_option(void);
 int set_ref_in_opfunc(int copyID);
 void do_pending_operator(cmdarg_T *cap, int old_col, int gui_yank);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/option.pro
+++ b/src/proto/option.pro
@@ -1,4 +1,4 @@
-/* option.c */
+// option.c
 void set_init_1(int clean_arg);
 void set_fencs_unicode(void);
 void set_string_default(char *name, char_u *val);
@@ -157,4 +157,4 @@ int fill_culopt_flags(char_u *val, win_T *wp);
 int magic_isset(void);
 int option_set_callback_func(char_u *optval, callback_T *optcb);
 char *did_set_showtabpanel(optset_T *args);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/optionstr.pro
+++ b/src/proto/optionstr.pro
@@ -1,4 +1,4 @@
-/* optionstr.c */
+// optionstr.c
 void didset_string_options(void);
 void trigger_optionset_string(int opt_idx, int opt_flags, char_u *oldval, char_u *oldval_l, char_u *oldval_g, char_u *newval);
 void check_buf_options(buf_T *buf);
@@ -220,4 +220,4 @@ int check_ff_value(char_u *p);
 void save_clear_shm_value(void);
 void restore_shm_value(void);
 void export_myvimdir(void);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/os_amiga.pro
+++ b/src/proto/os_amiga.pro
@@ -1,4 +1,4 @@
-/* os_amiga.c */
+// os_amiga.c
 void win_resize_on(void);
 void win_resize_off(void);
 void mch_write(char_u *p, int len);
@@ -43,4 +43,4 @@ int mch_has_wildcard(char_u *p);
 char_u *mch_getenv(char_u *var);
 int mch_setenv(char *var, char *value, int x);
 int mch_get_random(char_u *buf, int len);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/os_mac_conv.pro
+++ b/src/proto/os_mac_conv.pro
@@ -1,4 +1,4 @@
-/* os_mac_conv.c */
+// os_mac_conv.c
 char_u *mac_string_convert(char_u *ptr, int len, int *lenp, int fail_on_error, int from_enc, int to_enc, int *unconvlenp);
 int macroman2enc(char_u *ptr, long *sizep, long real_size);
 int enc2macroman(char_u *from, size_t fromlen, char_u *to, int *tolenp, int maxtolen, char_u *rest, int *restlenp);
@@ -9,4 +9,4 @@ unsigned short *mac_enc_to_utf16(char_u *from, size_t fromLen, size_t *actualLen
 void *mac_enc_to_cfstring(char_u *from, size_t fromLen);
 char_u *mac_precompose_path(char_u *decompPath, size_t decompLen, size_t *precompLen);
 void mac_lang_init(void);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/os_macosx.pro
+++ b/src/proto/os_macosx.pro
@@ -1,7 +1,7 @@
-/* manually generated from os_macosx.m */
+// manually generated from os_macosx.m
 void process_cfrunloop(void);
 bool sound_mch_play(const char_u* event, long sound_id, soundcb_T *callback, bool playfile);
 void sound_mch_stop(long sound_id);
 void sound_mch_clear(void);
 void sound_mch_free(void);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/os_mswin.pro
+++ b/src/proto/os_mswin.pro
@@ -1,4 +1,4 @@
-/* os_mswin.c */
+// os_mswin.c
 void SaveInst(HINSTANCE hInst);
 void mch_exit_g(int r);
 void mch_early_init(void);
@@ -60,4 +60,4 @@ void gui_mch_expand_font(optexpand_T *args, void *param, int (*add_match)(char_u
 UINT WINAPI vimGetDpiForSystem(void);
 int get_logfont(LOGFONTW *lf, char_u *name, HDC printer_dc, int verbose);
 void channel_init_winsock(void);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/os_qnx.pro
+++ b/src/proto/os_qnx.pro
@@ -1,8 +1,8 @@
-/* os_qnx.c */
+// os_qnx.c
 void qnx_init(void);
 void qnx_clip_init(void);
 int clip_mch_own_selection(Clipboard_T *cbd);
 void clip_mch_lose_selection(Clipboard_T *cbd);
 void clip_mch_request_selection(Clipboard_T *cbd);
 void clip_mch_set_selection(Clipboard_T *cbd);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/os_unix.pro
+++ b/src/proto/os_unix.pro
@@ -1,4 +1,4 @@
-/* os_unix.c */
+// os_unix.c
 sighandler_T mch_signal(int sig, sighandler_T func);
 int mch_chdir(char *path);
 void mch_write(char_u *s, int len);
@@ -95,4 +95,4 @@ void xsmp_close(void);
 void stop_timeout(void);
 volatile sig_atomic_t *start_timeout(long msec);
 void delete_timer(void);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/os_vms.pro
+++ b/src/proto/os_vms.pro
@@ -1,4 +1,4 @@
-/* os_vms.c */
+// os_vms.c
 void mch_settmode(tmode_T tmode);
 int mch_get_shellsize(void);
 void mch_set_shellsize(void);
@@ -13,4 +13,4 @@ int mch_expandpath(garray_T *gap, char_u *path, int flags);
 void *vms_fixfilename(void *instring);
 void vms_remove_version(void *fname);
 int RealWaitForChar(int fd, long msec, int *check_for_gpm, int *interrupted);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/os_win32.pro
+++ b/src/proto/os_win32.pro
@@ -1,4 +1,4 @@
-/* os_win32.c */
+// os_win32.c
 void mch_get_exe_name(void);
 HINSTANCE vimLoadLib(const char *name);
 int mch_is_gui_executable(void);
@@ -92,4 +92,4 @@ void resize_console_buf(void);
 char *GetWin32Error(void);
 void stop_timeout(void);
 volatile sig_atomic_t *start_timeout(long msec);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/popupmenu.pro
+++ b/src/proto/popupmenu.pro
@@ -1,4 +1,4 @@
-/* popupmenu.c */
+// popupmenu.c
 void pum_set_border(int enable);
 void pum_set_shadow(int enable);
 void pum_set_margin(int enable);
@@ -23,4 +23,4 @@ void pum_show_popupmenu(vimmenu_T *menu);
 void pum_make_popup(char_u *path_name, int use_mouse_pos);
 void pum_set_border_chars(int top, int right, int bottom, int left, int top_left, int top_right, int bottom_right, int bottom_left);
 void put_shadow_char(int row, int col);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/popupwin.pro
+++ b/src/proto/popupwin.pro
@@ -1,4 +1,4 @@
-/* popupwin.c */
+// popupwin.c
 int popup_on_border(win_T *wp, int row, int col);
 int popup_close_if_on_X(win_T *wp, int row, int col);
 void popup_start_drag(win_T *wp, int row, int col);
@@ -85,4 +85,4 @@ void end_echowindow(void);
 int popup_win_closed(win_T *win);
 void popup_set_title(win_T *wp);
 void popup_update_preview_title(void);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/profiler.pro
+++ b/src/proto/profiler.pro
@@ -1,4 +1,4 @@
-/* profiler.c */
+// profiler.c
 void profile_start(proftime_T *tm);
 void profile_end(proftime_T *tm);
 void profile_sub(proftime_T *tm, proftime_T *tm2);
@@ -32,4 +32,4 @@ void profile_dump(void);
 void script_line_start(void);
 void script_line_exec(void);
 void script_line_end(void);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/pty.pro
+++ b/src/proto/pty.pro
@@ -1,5 +1,5 @@
-/* pty.c */
+// pty.c
 int setup_slavepty(int fd);
 int mch_openpty(char **ttyn);
 int mch_isatty(int fd);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/quickfix.pro
+++ b/src/proto/quickfix.pro
@@ -1,4 +1,4 @@
-/* quickfix.c */
+// quickfix.c
 int qf_init(win_T *wp, char_u *efile, char_u *errorformat, int newlist, char_u *qf_title, char_u *enc);
 int qf_stack_get_bufnr(void);
 void qf_free_all(win_T *wp);
@@ -43,4 +43,4 @@ void f_getloclist(typval_T *argvars, typval_T *rettv);
 void f_getqflist(typval_T *argvars, typval_T *rettv);
 void f_setloclist(typval_T *argvars, typval_T *rettv);
 void f_setqflist(typval_T *argvars, typval_T *rettv);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/regexp.pro
+++ b/src/proto/regexp.pro
@@ -1,4 +1,4 @@
-/* regexp.c */
+// regexp.c
 void init_regexp_timeout(long msec);
 void disable_regexp_timeout(void);
 void save_timeout_for_debugging(void);
@@ -24,4 +24,4 @@ int vim_regexec_prog(regprog_T **prog, int ignore_case, char_u *line, colnr_T co
 int vim_regexec(regmatch_T *rmp, char_u *line, colnr_T col);
 int vim_regexec_nl(regmatch_T *rmp, char_u *line, colnr_T col);
 long vim_regexec_multi(regmmatch_T *rmp, win_T *win, buf_T *buf, linenr_T lnum, colnr_T col, int *timed_out);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/register.pro
+++ b/src/proto/register.pro
@@ -1,4 +1,4 @@
-/* register.c */
+// register.c
 yankreg_T *get_y_regs(void);
 yankreg_T *get_y_register(int reg);
 yankreg_T *get_y_current(void);
@@ -39,4 +39,4 @@ void write_reg_contents(int name, char_u *str, int maxlen, int must_append);
 void write_reg_contents_lst(int name, char_u **strings, int maxlen, int must_append, int yank_type, long block_len);
 void write_reg_contents_ex(int name, char_u *str, int maxlen, int must_append, int yank_type, long block_len);
 void str_to_reg(yankreg_T *y_ptr, int yank_type, char_u *str, long len, long blocklen, int str_list);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/screen.pro
+++ b/src/proto/screen.pro
@@ -1,4 +1,4 @@
-/* screen.c */
+// screen.c
 int conceal_cursor_line(win_T *wp);
 void conceal_check_cursor_line(int was_concealed);
 int get_win_attr(win_T *wp);
@@ -61,4 +61,4 @@ char *set_listchars_option(win_T *wp, char_u *val, int apply, char *errbuf, size
 char_u *get_fillchars_name(expand_T *xp, int idx);
 char_u *get_listchars_name(expand_T *xp, int idx);
 char *check_chars_options(void);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/scriptfile.pro
+++ b/src/proto/scriptfile.pro
@@ -1,4 +1,4 @@
-/* scriptfile.c */
+// scriptfile.c
 void estack_init(void);
 estack_T *estack_push(etype_T type, char_u *name, long lnum);
 estack_T *estack_push_ufunc(ufunc_T *ufunc, long lnum);
@@ -50,4 +50,4 @@ char_u *get_autoload_prefix(scriptitem_T *si);
 char_u *may_prefix_autoload(char_u *name);
 char_u *autoload_name(char_u *name);
 int script_autoload(char_u *name, int reload);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/search.pro
+++ b/src/proto/search.pro
@@ -1,4 +1,4 @@
-/* search.c */
+// search.c
 int search_regcomp(char_u *pat, size_t patlen, char_u **used_pat, int pat_save, int pat_use, int options, regmmatch_T *regmatch);
 char_u *get_search_pat(void);
 void save_re_pat(int idx, char_u *pat, size_t patlen, int magic);
@@ -37,4 +37,4 @@ void find_pattern_in_path(char_u *ptr, int dir, int len, int whole, int skip_com
 spat_T *get_spat(int idx);
 int get_spat_last_idx(void);
 void f_searchcount(typval_T *argvars, typval_T *rettv);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/session.pro
+++ b/src/proto/session.pro
@@ -1,8 +1,8 @@
-/* session.c */
+// session.c
 void ex_loadview(exarg_T *eap);
 int write_session_file(char_u *filename);
 void ex_mkrc(exarg_T *eap);
 var_flavour_T var_flavour(char_u *varname);
 int put_eol(FILE *fd);
 int put_line(FILE *fd, char *s);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/sha256.pro
+++ b/src/proto/sha256.pro
@@ -1,4 +1,4 @@
-/* sha256.c */
+// sha256.c
 void sha256_start(context_sha256_T *ctx);
 void sha256_update(context_sha256_T *ctx, char_u *input, UINT32_T length);
 void sha256_finish(context_sha256_T *ctx, char_u digest[32]);
@@ -6,4 +6,4 @@ char_u *sha256_bytes(char_u *buf, int buf_len, char_u *salt, int salt_len);
 char_u *sha256_key(char_u *buf, char_u *salt, int salt_len);
 int sha256_self_test(void);
 void sha2_seed(char_u *header, int header_len, char_u *salt, int salt_len);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/sign.pro
+++ b/src/proto/sign.pro
@@ -1,4 +1,4 @@
-/* sign.c */
+// sign.c
 void init_signs(void);
 int buf_get_signattrs(win_T *wp, linenr_T lnum, sign_attrs_T *sattr);
 linenr_T buf_delsign(buf_T *buf, linenr_T atlnum, int id, char_u *group);
@@ -30,4 +30,4 @@ sign_entry_T *get_first_valid_sign(win_T *wp);
 int signcolumn_on(win_T *wp);
 void f_sign_unplace(typval_T *argvars, typval_T *rettv);
 void f_sign_unplacelist(typval_T *argvars, typval_T *rettv);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/sixel.pro
+++ b/src/proto/sixel.pro
@@ -1,5 +1,5 @@
-/* sixel.c */
+// sixel.c
 char_u *sixel_resize_rgb(char_u *src, int sw, int sh, int dw, int dh);
 char_u *sixel_encode(image_rgb_T *img);
 void sixel_free_all(void);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/socketserver.pro
+++ b/src/proto/socketserver.pro
@@ -1,4 +1,4 @@
-/* socketserver.c */
+// socketserver.c
 int socketserver_start(char_u *name, bool quiet);
 void socketserver_stop(void);
 list_T *socketserver_list(void);
@@ -8,4 +8,4 @@ int socketserver_send(char_u *name, char_u *str, char_u **result, bool is_expr, 
 int socketserver_send_reply(char_u *client, char_u *str);
 int socketserver_read_reply(char_u *client, char_u **str, int timeout, bool remotewait);
 int socketserver_peek_reply(char_u *sender, char_u **str);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/sound.pro
+++ b/src/proto/sound.pro
@@ -1,4 +1,4 @@
-/* sound.c */
+// sound.c
 int has_any_sound_callback(void);
 void call_sound_callback(soundcb_T *soundcb, long snd_id, int result);
 void delete_sound_callback(soundcb_T *soundcb);
@@ -9,4 +9,4 @@ void f_sound_playfile(typval_T *argvars, typval_T *rettv);
 void f_sound_stop(typval_T *argvars, typval_T *rettv);
 void f_sound_clear(typval_T *argvars, typval_T *rettv);
 void sound_free(void);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/spell.pro
+++ b/src/proto/spell.pro
@@ -1,4 +1,4 @@
-/* spell.c */
+// spell.c
 int spell_check(win_T *wp, char_u *ptr, hlf_T *attrp, int *capcol, int docount);
 int match_checkcompoundpattern(char_u *ptr, int wlen, garray_T *gap);
 int can_compound(slang_T *slang, char_u *word, char_u *flags);
@@ -48,4 +48,4 @@ int valid_spelllang(char_u *val);
 int valid_spellfile(char_u *val);
 char *did_set_spell_option(void);
 char *compile_cap_prog(synblock_T *synblock);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/spellfile.pro
+++ b/src/proto/spellfile.pro
@@ -1,4 +1,4 @@
-/* spellfile.c */
+// spellfile.c
 slang_T *spell_load_file(char_u *fname, char_u *lang, slang_T *old_lp, int silent);
 void suggest_load_files(void);
 int spell_check_msm(void);
@@ -6,4 +6,4 @@ void ex_mkspell(exarg_T *eap);
 void mkspell(int fcount, char_u **fnames, int ascii, int over_write, int added_word);
 void ex_spell(exarg_T *eap);
 void spell_add_word(char_u *word, int len, int what, int idx, int undo);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/spellsuggest.pro
+++ b/src/proto/spellsuggest.pro
@@ -1,5 +1,5 @@
-/* spellsuggest.c */
+// spellsuggest.c
 int spell_check_sps(void);
 void spell_suggest(int count);
 void spell_suggest_list(garray_T *gap, char_u *word, int maxcount, int need_cap, int interactive);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/strings.pro
+++ b/src/proto/strings.pro
@@ -1,4 +1,4 @@
-/* strings.c */
+// strings.c
 char_u *vim_strsave(char_u *string);
 char_u *vim_strnsave(char_u *string, size_t len);
 char_u *vim_strsave_escaped(char_u *string, char_u *esc_chars);
@@ -54,4 +54,4 @@ void f_tr(typval_T *argvars, typval_T *rettv);
 void f_trim(typval_T *argvars, typval_T *rettv);
 void f_uridecode(typval_T *argvars, typval_T *rettv);
 void f_uriencode(typval_T *argvars, typval_T *rettv);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/syntax.pro
+++ b/src/proto/syntax.pro
@@ -1,4 +1,4 @@
-/* syntax.c */
+// syntax.c
 void syntax_start(win_T *wp, linenr_T lnum);
 void syn_stack_free_all(synblock_T *block);
 void syn_stack_apply_changes(buf_T *buf);
@@ -21,4 +21,4 @@ int syn_get_stack_item(int i);
 int syn_get_foldlevel(win_T *wp, long lnum);
 void ex_syntime(exarg_T *eap);
 char_u *get_syntime_arg(expand_T *xp, int idx);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/tabpanel.pro
+++ b/src/proto/tabpanel.pro
@@ -1,4 +1,4 @@
-/* tabpanel.c */
+// tabpanel.c
 int tabpanelopt_changed(void);
 void tabpanel_forget_tabpage(const tabpage_T *tp);
 int tabpanel_width(void);
@@ -12,4 +12,4 @@ bool tabpanel_scroll(int dir, int count);
 bool tabpanel_set_offset(int offset);
 void f_tabpanel_getinfo(typval_T *argvars, typval_T *rettv);
 void f_tabpanel_scroll(typval_T *argvars, typval_T *rettv);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/tag.pro
+++ b/src/proto/tag.pro
@@ -1,4 +1,4 @@
-/* tag.c */
+// tag.c
 char *did_set_tagfunc(optset_T *args);
 void free_tagfunc_option(void);
 int set_ref_in_tagfunc(int copyID);
@@ -15,4 +15,4 @@ int expand_tags(int tagnames, char_u *pat, int *num_file, char_u ***file);
 int get_tags(list_T *list, char_u *pat, char_u *buf_fname);
 void get_tagstack(win_T *wp, dict_T *retdict);
 int set_tagstack(win_T *wp, dict_T *d, int action);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/term.pro
+++ b/src/proto/term.pro
@@ -1,4 +1,4 @@
-/* term.c */
+// term.c
 guicolor_T termgui_get_color(char_u *name);
 guicolor_T termgui_mch_get_rgb(guicolor_T color);
 void init_term_props(int all);
@@ -100,4 +100,4 @@ void term_disable_dec(void);
 void term_set_win_resize(bool state);
 int sync_output_active(void);
 void term_set_sync_output(int flags);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/terminal.pro
+++ b/src/proto/terminal.pro
@@ -1,4 +1,4 @@
-/* terminal.c */
+// terminal.c
 void init_job_options(jobopt_T *opt);
 buf_T *term_start(typval_T *argvar, char **argv, jobopt_T *opt, int flags);
 void ex_terminal(exarg_T *eap);
@@ -74,4 +74,4 @@ void term_send_eof(channel_T *ch);
 job_T *term_getjob(term_T *term);
 int use_conpty(void);
 int terminal_enabled(void);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/termlib.pro
+++ b/src/proto/termlib.pro
@@ -1,8 +1,8 @@
-/* termlib.c */
+// termlib.c
 int tgetent(char *tbuf, char *term);
 int tgetflag(char *id);
 int tgetnum(char *id);
 char *tgetstr(char *id, char **buf);
 char *tgoto(char *cm, int col, int line);
 int tputs(char *cp, int affcnt, void (*outc)(unsigned int));
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/testing.pro
+++ b/src/proto/testing.pro
@@ -1,4 +1,4 @@
-/* testing.c */
+// testing.c
 void f_assert_beeps(typval_T *argvars, typval_T *rettv);
 void f_assert_nobeep(typval_T *argvars, typval_T *rettv);
 void f_assert_equal(typval_T *argvars, typval_T *rettv);
@@ -37,4 +37,4 @@ void f_test_setmouse(typval_T *argvars, typval_T *rettv);
 void f_test_mswin_event(typval_T *argvars, typval_T *rettv);
 void f_test_gui_event(typval_T *argvars, typval_T *rettv);
 void f_test_settime(typval_T *argvars, typval_T *rettv);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/textformat.pro
+++ b/src/proto/textformat.pro
@@ -1,4 +1,4 @@
-/* textformat.c */
+// textformat.c
 int has_format_option(int x);
 void internal_format(int textwidth, int second_indent, int flags, int format_only, int c);
 void auto_format(int trailblank, int prev_line);
@@ -8,4 +8,4 @@ void op_format(oparg_T *oap, int keep_cursor);
 void op_formatexpr(oparg_T *oap);
 int fex_format(linenr_T lnum, long count, int c);
 void format_lines(linenr_T line_count, int avoid_fex);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/textobject.pro
+++ b/src/proto/textobject.pro
@@ -1,4 +1,4 @@
-/* textobject.c */
+// textobject.c
 int findsent(int dir, long count);
 int findpar(int *pincl, int dir, long count, int what, int both);
 int startPS(linenr_T lnum, int para, int both);
@@ -12,4 +12,4 @@ int current_block(oparg_T *oap, long count, int include, int what, int other);
 int current_tagblock(oparg_T *oap, long count_arg, int include);
 int current_par(oparg_T *oap, long count, int include, int type);
 int current_quote(oparg_T *oap, long count, int include, int quotechar);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/textprop.pro
+++ b/src/proto/textprop.pro
@@ -1,4 +1,4 @@
-/* textprop.c */
+// textprop.c
 unpacked_memline_T um_open(buf_T *buf);
 bool um_goto_line(unpacked_memline_T *um, linenr_T lnum, int extra_props);
 unpacked_memline_T um_open_at(buf_T *buf, linenr_T lnum, int extra_props);
@@ -38,4 +38,4 @@ void adjust_props_for_split(linenr_T lnum_props, linenr_T lnum_top, int kept, in
 void prepend_joined_props(unpacked_memline_T *um, linenr_T lnum, int last_line, long col, int removed);
 bool text_prop_count_valid(int prop_count, size_t propdata_len);
 bool text_prop_vtext_valid(char_u *props, int prop_count, size_t propdata_len);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/time.pro
+++ b/src/proto/time.pro
@@ -1,4 +1,4 @@
-/* time.c */
+// time.c
 time_T vim_time(void);
 char *get_ctime(time_t thetime, int add_newline);
 void f_localtime(typval_T *argvars, typval_T *rettv);
@@ -27,4 +27,4 @@ time_T get8ctime(FILE *fd);
 int put_time(FILE *fd, time_T the_time);
 void time_to_bytes(time_T the_time, char_u *buf);
 void add_time(char_u *buf, size_t buflen, time_t tt);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/tuple.pro
+++ b/src/proto/tuple.pro
@@ -1,4 +1,4 @@
-/* tuple.c */
+// tuple.c
 tuple_T *tuple_alloc(void);
 tuple_T *tuple_alloc_with_items(int count);
 void tuple_set_item(tuple_T *tuple, int idx, typval_T *tv);
@@ -31,4 +31,4 @@ void tuple_repeat(tuple_T *tuple, int n, typval_T *rettv);
 void tuple_reverse(tuple_T *tuple, typval_T *rettv);
 void tuple_reduce(typval_T *argvars, typval_T *expr, typval_T *rettv);
 int check_tuples_addable(type_T *type1, type_T *type2);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/typval.pro
+++ b/src/proto/typval.pro
@@ -1,4 +1,4 @@
-/* typval.c */
+// typval.c
 typval_T *alloc_tv(void);
 typval_T *alloc_string_tv(char_u *s);
 void free_tv(typval_T *varp);
@@ -92,4 +92,4 @@ linenr_T tv_get_lnum(typval_T *argvars);
 linenr_T tv_get_lnum_buf(typval_T *argvars, buf_T *buf);
 buf_T *tv_get_buf(typval_T *tv, int curtab_only);
 buf_T *tv_get_buf_from_arg(typval_T *tv);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/ui.pro
+++ b/src/proto/ui.pro
@@ -1,4 +1,4 @@
-/* ui.c */
+// ui.c
 void ui_write(char_u *s, int len, int console);
 void ui_inchar_undo(char_u *s, int len);
 int ui_inchar(char_u *buf, int maxlen, long wtime, int tb_change_cnt);
@@ -34,4 +34,4 @@ long scroll_line_len(linenr_T lnum);
 linenr_T ui_find_longest_lnum(void);
 void ui_focus_change(int in_focus);
 void im_save_status(long *psave);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/undo.pro
+++ b/src/proto/undo.pro
@@ -1,4 +1,4 @@
-/* undo.c */
+// undo.c
 int u_save_cursor(void);
 int u_save(linenr_T top, linenr_T bot);
 int u_savesub(linenr_T lnum);
@@ -28,4 +28,4 @@ int curbufIsChanged(void);
 void f_undofile(typval_T *argvars, typval_T *rettv);
 void u_undofile_reset_and_delete(buf_T *buf);
 void f_undotree(typval_T *argvars, typval_T *rettv);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/usercmd.pro
+++ b/src/proto/usercmd.pro
@@ -1,4 +1,4 @@
-/* usercmd.c */
+// usercmd.c
 char_u *find_ucmd(exarg_T *eap, char_u *p, int *full, expand_T *xp, int *complp);
 char_u *set_context_in_user_cmd(expand_T *xp, char_u *arg_in);
 char_u *set_context_in_user_cmdarg(char_u *cmd, char_u *arg, long argt, int context, expand_T *xp, int forceit);
@@ -22,4 +22,4 @@ void ex_delcommand(exarg_T *eap);
 size_t add_win_cmd_modifiers(char_u *buf, cmdmod_T *cmod, int *multi_mods);
 size_t produce_cmdmods(char_u *buf, cmdmod_T *cmod, int quote);
 void do_ucmd(exarg_T *eap);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/userfunc.pro
+++ b/src/proto/userfunc.pro
@@ -1,4 +1,4 @@
-/* userfunc.c */
+// userfunc.c
 void func_init(void);
 hashtab_T *func_tbl_get(void);
 char_u *make_ufunc_name_readable(char_u *name, char_u *buf, size_t bufsize);
@@ -95,4 +95,4 @@ int set_ref_in_call_stack(int copyID);
 int set_ref_in_functions(int copyID);
 int set_ref_in_func_args(int copyID);
 int set_ref_in_func(char_u *name, ufunc_T *fp_in, int copyID);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/version.pro
+++ b/src/proto/version.pro
@@ -1,4 +1,4 @@
-/* version.c */
+// version.c
 void init_longVersion(void);
 int highest_patch(void);
 int has_patch(int n);
@@ -7,4 +7,4 @@ void list_in_columns(char_u **items, int size, int current);
 void list_version(void);
 void maybe_intro_message(void);
 void ex_intro(exarg_T *eap);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/vim9class.pro
+++ b/src/proto/vim9class.pro
@@ -1,4 +1,4 @@
-/* vim9class.c */
+// vim9class.c
 int object_index_from_itf_index(class_T *itf, int is_method, int idx, class_T *cl);
 int is_valid_builtin_obj_methodname(char_u *funcname);
 ufunc_T *class_get_builtin_method(class_T *cl, class_builtin_T builtin_method, int *method_idx);
@@ -44,4 +44,4 @@ int object_equal(object_T *o1, object_T *o2, int ic);
 char_u *object2string(object_T *obj, char_u *numbuf, int copyID, int echo_style, int restore_copyID, int composite_val);
 int class_instance_of(class_T *cl, class_T *other_cl);
 void f_instanceof(typval_T *argvars, typval_T *rettv);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/vim9cmds.pro
+++ b/src/proto/vim9cmds.pro
@@ -1,4 +1,4 @@
-/* vim9cmds.c */
+// vim9cmds.c
 void free_locals(cctx_T *cctx);
 int check_vim9_unlet(char_u *name);
 char_u *compile_unletlock(char_u *arg, exarg_T *eap, cctx_T *cctx);
@@ -34,4 +34,4 @@ char_u *compile_redir(char_u *line, exarg_T *eap, cctx_T *cctx);
 char_u *compile_cexpr(char_u *line, exarg_T *eap, cctx_T *cctx);
 char_u *compile_return(char_u *arg, int check_return_type, int legacy, cctx_T *cctx);
 int check_global_and_subst(char_u *cmd, char_u *arg);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/vim9compile.pro
+++ b/src/proto/vim9compile.pro
@@ -1,4 +1,4 @@
-/* vim9compile.c */
+// vim9compile.c
 int lookup_local(char_u *name, size_t len, lvar_T *lvar, cctx_T *cctx);
 int arg_exists(char_u *name, size_t len, int *idxp, type_T **type, int *gen_load_outer, cctx_T *cctx);
 void update_script_var_block_id(char_u *name, int block_id);
@@ -33,4 +33,4 @@ void set_function_type(ufunc_T *ufunc);
 void unlink_def_function(ufunc_T *ufunc);
 void link_def_function(ufunc_T *ufunc);
 void free_def_functions(void);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/vim9execute.pro
+++ b/src/proto/vim9execute.pro
@@ -1,4 +1,4 @@
-/* vim9execute.c */
+// vim9execute.c
 void to_string_error(vartype_T vartype);
 void update_has_breakpoint(ufunc_T *ufunc);
 int funcstack_check_refcount(funcstack_T *funcstack);
@@ -27,4 +27,4 @@ void ex_disassemble(exarg_T *eap);
 int tv2bool(typval_T *tv);
 void emsg_using_string_as(typval_T *tv, int as_number);
 int check_not_string(typval_T *tv);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/vim9expr.pro
+++ b/src/proto/vim9expr.pro
@@ -1,4 +1,4 @@
-/* vim9expr.c */
+// vim9expr.c
 int generate_ppconst(cctx_T *cctx, ppconst_T *ppconst);
 void clear_ppconst(ppconst_T *ppconst);
 int compile_member(int is_slice, int *keeping_dict, cctx_T *cctx);
@@ -17,4 +17,4 @@ void error_white_both(char_u *op, int len);
 int compile_expr1(char_u **arg, cctx_T *cctx, ppconst_T *ppconst);
 int compile_expr0_ext(char_u **arg, cctx_T *cctx, int *is_const);
 int compile_expr0(char_u **arg, cctx_T *cctx);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/vim9generics.pro
+++ b/src/proto/vim9generics.pro
@@ -1,4 +1,4 @@
-/* vim9generics.c */
+// vim9generics.c
 char_u *generic_func_find_open_bracket(char_u *name);
 int skip_generic_func_type_args(char_u **argp);
 char_u *append_generic_func_type_args(char_u *funcname, size_t namelen, char_u **argp);
@@ -16,4 +16,4 @@ ufunc_T *generic_func_get(ufunc_T *fp, gfargs_tab_T *gfatab);
 ufunc_T *find_generic_func(ufunc_T *ufunc, char_u *name, char_u **argp);
 type_T *find_generic_type(char_u *gt_name, size_t name_len, ufunc_T *ufunc, cctx_T *cctx);
 void generic_func_clear_items(ufunc_T *fp);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/vim9instr.pro
+++ b/src/proto/vim9instr.pro
@@ -1,4 +1,4 @@
-/* vim9instr.c */
+// vim9instr.c
 isn_T *generate_instr(cctx_T *cctx, isntype_T isn_type);
 isn_T *generate_instr_drop(cctx_T *cctx, isntype_T isn_type, int drop);
 isn_T *generate_instr_type(cctx_T *cctx, isntype_T isn_type, type_T *type);
@@ -86,4 +86,4 @@ int generate_SCRIPTCTX_SET(cctx_T *cctx, sctx_T new_sctx);
 void may_generate_prof_end(cctx_T *cctx, int prof_lnum);
 void delete_instr(isn_T *isn);
 void clear_instr_ga(garray_T *gap);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/vim9script.pro
+++ b/src/proto/vim9script.pro
@@ -1,4 +1,4 @@
-/* vim9script.c */
+// vim9script.c
 int in_old_script(int max_version);
 int current_script_is_vim9(void);
 void clear_vim9_scriptlocal_vars(int sid);
@@ -19,4 +19,4 @@ void hide_script_var(scriptitem_T *si, int idx, int func_defined);
 svar_T *find_typval_in_script(typval_T *dest, scid_T sid, int must_find);
 int check_script_var_type(svar_T *sv, typval_T *value, char_u *name, where_T where);
 int check_reserved_name(char_u *name, int is_objm_access);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/vim9type.pro
+++ b/src/proto/vim9type.pro
@@ -1,4 +1,4 @@
-/* vim9type.c */
+// vim9type.c
 type_T *get_type_ptr(garray_T *type_gap);
 type_T *copy_type(type_T *type, garray_T *type_gap);
 type_T *copy_type_deep(type_T *type, garray_T *type_gap);
@@ -42,4 +42,4 @@ char *type_name(type_T *type, char **tofree);
 void f_typename(typval_T *argvars, typval_T *rettv);
 int check_typval_is_value(typval_T *tv);
 int check_type_is_value(type_T *type);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/viminfo.pro
+++ b/src/proto/viminfo.pro
@@ -1,8 +1,8 @@
-/* viminfo.c */
+// viminfo.c
 int get_viminfo_parameter(int type);
 int buf_compare(const void *s1, const void *s2);
 void check_marks_read(void);
 int read_viminfo(char_u *file, int flags);
 void write_viminfo(char_u *file, int forceit);
 void ex_viminfo(exarg_T *eap);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/wayland.pro
+++ b/src/proto/wayland.pro
@@ -1,4 +1,4 @@
-/* wayland.c */
+// wayland.c
 int vwl_connection_flush(vwl_connection_T *self);
 int vwl_connection_dispatch(vwl_connection_T *self);
 int vwl_connection_roundtrip(vwl_connection_T *self);
@@ -23,4 +23,4 @@ void vwl_data_offer_add_listener(vwl_data_offer_T *self, const vwl_data_offer_li
 void vwl_data_device_set_selection(vwl_data_device_T *self, vwl_data_source_T *source, uint32_t serial, wayland_selection_T selection);
 void vwl_data_source_offer(vwl_data_source_T *self, const char *mime_type);
 void vwl_data_offer_receive(vwl_data_offer_T *self, const char *mime_type, int32_t fd);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/winclip.pro
+++ b/src/proto/winclip.pro
@@ -1,4 +1,4 @@
-/* winclip.c */
+// winclip.c
 int utf8_to_utf16(char_u *instr, int inlen, short_u *outstr, int *unconvlenp);
 int utf16_to_utf8(short_u *instr, int inlen, char_u *outstr);
 void MultiByteToWideChar_alloc(UINT cp, DWORD flags, LPCSTR in, int inlen, LPWSTR *out, int *outlen);
@@ -12,4 +12,4 @@ short_u *enc_to_utf16(char_u *str, int *lenp);
 char_u *utf16_to_enc(short_u *str, int *lenp);
 void acp_to_enc(char_u *str, int str_size, char_u **out, int *outlen);
 void enc_to_acp(char_u *str, int str_size, char_u **out, int *outlen);
-/* vim: set ft=c : */
+// vim: ft=c

--- a/src/proto/window.pro
+++ b/src/proto/window.pro
@@ -1,4 +1,4 @@
-/* window.c */
+// window.c
 void window_layout_lock(void);
 void window_layout_unlock(void);
 int frames_locked(void);
@@ -111,4 +111,4 @@ int get_tab_number(tabpage_T *tp);
 char *check_colorcolumn(char_u *cc, win_T *wp);
 int get_last_winid(void);
 int win_locked(win_T *wp);
-/* vim: set ft=c : */
+// vim: ft=c


### PR DESCRIPTION
```
Problem:  gen_prototypes.py writes the source file name and the modeline
          of a .pro file as "/* */" comments, while the sources use "//"
          comments.  The modeline needs a ":" at the end to keep the
          "*/" out of the options.  proto/socketserver.pro is not in
          PROTO_FILES, "make proto" does not regenerate it.
Solution: Write both lines as "//" comments, with the form of the
          modeline that has no ":set" and needs no ":".  Add
          socketserver.pro to PROTO_FILES.
```