### PR TITLE
GUI: gui_mch_wait_for_chars() takes an int on some systems

### DIFF
--- a/src/gui_haiku.cc
+++ b/src/gui_haiku.cc
@@ -4329,7 +4329,7 @@ gui_mch_update()
  */
 int
 gui_mch_wait_for_chars(
-	int	wtime)
+	long	wtime)
 {
     int		focus;
     bigtime_t	until, timeout;

--- a/src/gui_photon.c
+++ b/src/gui_photon.c
@@ -1353,7 +1353,7 @@ gui_mch_update(void)
 }
 
     int
-gui_mch_wait_for_chars(int wtime)
+gui_mch_wait_for_chars(long wtime)
 {
     is_timeout = FALSE;
 

--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -2666,7 +2666,7 @@ server_flush_input(void)
  * or FAIL otherwise.
  */
     int
-gui_mch_wait_for_chars(int wtime)
+gui_mch_wait_for_chars(long wtime)
 {
     int		focus;
 

--- a/src/proto/gui_haiku.pro
+++ b/src/proto/gui_haiku.pro
@@ -54,7 +54,7 @@ void gui_mch_settitle(char_u *title, char_u *icon);
 void gui_mch_draw_hollow_cursor(guicolor_T color);
 void gui_mch_draw_part_cursor(int w, int h, guicolor_T color);
 void gui_mch_update(void);
-int gui_mch_wait_for_chars(int wtime);
+int gui_mch_wait_for_chars(long wtime);
 void gui_mch_clear_block(int row1, int col1, int row2, int col2);
 void gui_mch_clear_all(void);
 void gui_mch_delete_lines(int row, int num_lines);

--- a/src/proto/gui_photon.pro
+++ b/src/proto/gui_photon.pro
@@ -6,7 +6,7 @@ int gui_mch_init_check(void);
 int gui_mch_open(void);
 void gui_mch_exit(int rc);
 void gui_mch_update(void);
-int gui_mch_wait_for_chars(int wtime);
+int gui_mch_wait_for_chars(long wtime);
 char_u *gui_mch_browse(int saving, char_u *title, char_u *default_name, char_u *ext, char_u *initdir, char_u *filter);
 int gui_mch_dialog(int type, char_u *title, char_u *message, char_u *buttons, int default_button, char_u *textfield, int ex_cmd);
 int gui_mch_get_winpos(int *x, int *y);

--- a/src/proto/gui_w32.pro
+++ b/src/proto/gui_w32.pro
@@ -31,7 +31,7 @@ void gui_mch_draw_hollow_cursor(guicolor_T color);
 void gui_mch_draw_part_cursor(int w, int h, guicolor_T color);
 void gui_mch_update(void);
 void server_add_input(char_u *str);
-int gui_mch_wait_for_chars(int wtime);
+int gui_mch_wait_for_chars(long wtime);
 void gui_mch_clear_block(int row1, int col1, int row2, int col2);
 void gui_mch_free_popup_image(win_T *wp);
 bool gui_mch_update_popup_image_pixels(win_T *wp);


### PR DESCRIPTION
```
Problem:  gui_wait_for_chars() passes a long to gui_mch_wait_for_chars(),
          the GTK and X11 implementations take a long, the MS-Windows,
          Photon and Haiku ones take an int.
Solution: Take a long everywhere.
```