### PR TITLE
MS-Windows: warning for a size_t to int conversion in insexpand.c

### DIFF
--- a/src/insexpand.c
+++ b/src/insexpand.c
@@ -3877,7 +3877,7 @@ theend:
 get_user_highlight_id(char_u *hlname)
 {
     if (hlname != NULL && *hlname != NUL)
-	return syn_check_group(hlname, STRLEN(hlname));
+	return syn_check_group(hlname, (int)STRLEN(hlname));
     return 0;
 }
 /*


### PR DESCRIPTION
```
Problem:  get_user_highlight_id() passes the size_t of STRLEN() to
          syn_check_group(), which takes an int.  MSVC warns with C4267.
Solution: Cast to int, like the other callers do.
```

related: #21105