### PR TITLE
Fix use-after-free when appending a new list fails

### DIFF
--- a/src/blob.c
+++ b/src/blob.c
@@ -331,7 +331,7 @@ blob2items(typval_T *argvars, typval_T *rettv)
 
 	if (list_append_list(rettv->vval.v_list, l2) == FAIL)
 	{
-	    vim_free(l2);
+	    list_free(l2);
 	    return;
 	}
 

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -5670,7 +5670,7 @@ f_getchangelist(typval_T *argvars, typval_T *rettv)
 	return;
     if (list_append_list(rettv->vval.v_list, l) == FAIL)
     {
-	vim_free(l);
+	list_free(l);
 	return;
     }
 
@@ -5910,7 +5910,7 @@ f_getjumplist(typval_T *argvars, typval_T *rettv)
 	return;
     if (list_append_list(rettv->vval.v_list, l) == FAIL)
     {
-	vim_free(l);
+	list_free(l);
 	return;
     }
 

--- a/src/list.c
+++ b/src/list.c
@@ -1147,7 +1147,7 @@ list2items(typval_T *argvars, typval_T *rettv)
 	    break;
 	if (list_append_list(rettv->vval.v_list, l2) == FAIL)
 	{
-	    vim_free(l2);
+	    list_free(l2);
 	    break;
 	}
 	if (list_append_number(l2, idx) == FAIL
@@ -1183,7 +1183,7 @@ string2items(typval_T *argvars, typval_T *rettv)
 	    break;
 	if (list_append_list(rettv->vval.v_list, l2) == FAIL)
 	{
-	    vim_free(l2);
+	    list_free(l2);
 	    break;
 	}
 	if (list_append_number(l2, idx) == FAIL

--- a/src/tuple.c
+++ b/src/tuple.c
@@ -874,7 +874,7 @@ tuple2items(typval_T *argvars, typval_T *rettv)
 
 	if (list_append_list(rettv->vval.v_list, l) == FAIL)
 	{
-	    vim_free(l);
+	    list_free(l);
 	    break;
 	}
 	if (list_append_number(l, idx) == FAIL

--- a/src/vim9execute.c
+++ b/src/vim9execute.c
@@ -1104,7 +1104,7 @@ add_defer_item(int var_idx, int argcount, ectx_T *ectx)
     listval.v_lock = 0;
     if (list_insert_tv(defer_l, &listval, defer_l->lv_first) == FAIL)
     {
-	vim_free(l);
+	list_free(l);
 	return NULL;
     }
 


### PR DESCRIPTION
### Problem

`list_alloc()` links every new list header into the global chain used for garbage collection,
in `list_init()` (`src/list.c`, lines **74–79**):

```c
    // Prepend the list to the list of lists for garbage collection.
    if (first_list != NULL)
	first_list->lv_used_prev = l;
    l->lv_used_prev = NULL;
    l->lv_used_next = first_list;
    first_list = l;
```

The only code that unlinks it again is `list_free_list()` (lines **269–275**), reached through
`list_free()`:

```c
    // Remove the list from the list of lists for garbage collection.
    if (l->lv_used_prev == NULL)
	first_list = l->lv_used_next;
    else
	l->lv_used_prev->lv_used_next = l->lv_used_next;
    if (l->lv_used_next != NULL)
	l->lv_used_next->lv_used_prev = l->lv_used_prev;
```

Seven functions release such a header with a plain `vim_free()` when appending it fails, for
example `tuple2items()` in `src/tuple.c` (line **877**):

```c
	if (list_append_list(rettv->vval.v_list, l) == FAIL)
	{
	    vim_free(l);
	    break;
	}
```

`first_list` is then left pointing at freed memory. The next `list_alloc()` writes through it
immediately, and a later `garbage_collect()` walks the chain into the freed block.

Forcing `listitem_alloc()` to fail once with a debugger, under AddressSanitizer, then
allocating another list:

```
ERROR: AddressSanitizer: heap-use-after-free
WRITE of size 8
    #0 list_init  list.c:76
    #1 list_alloc list.c:93
freed by:
    vim_free   alloc.c:623   <- blob2items blob.c:334
previously allocated by:
    list_alloc list.c:91     <- blob2items blob.c:328
```

The other six are `list2items()` and `string2items()` in `src/list.c`, `blob2items()` in
`src/blob.c`, `f_getchangelist()` and `f_getjumplist()` in `src/evalfunc.c`, and
`add_defer_item()` in `src/vim9execute.c`.

Patch 9.2.0808 fixed the same mistake in `add_regionpos_range()`.

### Solution

Use `list_free()` at those seven sites. The append failed, so no reference was taken:
`list_append_list()` increments `lv_refcount` only after a successful `list_append()`, and
`list_insert_tv()` fails before `copy_tv()`. In `add_defer_item()` the list comes from
`list_alloc_with_items()`, whose `listitem_T`s are embedded in the same allocation;
`list_free_item()` checks `lv_with_items` and does not free them separately.

`listitem_alloc()` uses `ALLOC_ONE` without an id, so `test_alloc_fail()` cannot reach this path.
I can add an alloc id to it if you would like a regression test.
