### PR TITLE
Fix memory leak in f_setmatches() in src/match.c

### DIFF
--- a/src/match.c
+++ b/src/match.c
@@ -1135,6 +1135,7 @@ f_setmatches(typval_T *argvars UNUSED, typval_T *rettv UNUSED)
 		    s = list_alloc();
 		    if (s == NULL)
 			return;
+		    ++s->lv_refcount;
 		}
 
 		// match from matchaddpos()
@@ -1144,10 +1145,12 @@ f_setmatches(typval_T *argvars UNUSED, typval_T *rettv UNUSED)
 		    if ((di = dict_find(d, (char_u *)buf, -1)) != NULL)
 		    {
 			if (di->di_tv.v_type != VAR_LIST)
+			{
+			    list_unref(s);
 			    return;
+			}
 
 			list_append_tv(s, &di->di_tv);
-			s->lv_refcount++;
 		    }
 		    else
 			break;

--- a/src/testdir/test_match.vim
+++ b/src/testdir/test_match.vim
@@ -314,6 +314,27 @@ func Test_matchaddpos_error()
   call assert_fails("call matchaddpos('Search', [[3, 4, {}]])", 'E728:')
 endfunc
 
+" setmatches() with more than one "posN" entry used to keep a reference to
+" every position list, so they were not released until the next garbage
+" collection.  A "posN" value that is not a List made it bail out early
+" without releasing the list at all.
+func Test_setmatches_pos_refcount()
+  let p1 = [1, 1, 1]
+  let p2 = [2, 1, 1]
+  call assert_equal(1, test_refcount(p1))
+  call assert_equal(1, test_refcount(p2))
+
+  call setmatches([#{group: 'Search', priority: 10, id: 4, pos1: p1, pos2: p2}])
+  call clearmatches()
+  call assert_equal(1, test_refcount(p1))
+  call assert_equal(1, test_refcount(p2))
+
+  let p3 = [3, 1, 1]
+  call assert_equal(-1, setmatches([#{group: 'Search', priority: 10, id: 4, pos1: p3, pos2: {}}]))
+  call clearmatches()
+  call assert_equal(1, test_refcount(p3))
+endfunc
+
 func OtherWindowCommon()
   let lines =<< trim END
     call setline(1, 'Hello Vim world')


### PR DESCRIPTION
### Problem

In `f_setmatches()` in `src/match.c`, a list is allocated to collect the positions of a match
created by `matchaddpos()` (line **1135**):

```c
		    s = list_alloc();
		    if (s == NULL)
			return;
```

and its reference count is then incremented once for every `posN` entry appended to it
(line **1150**):

```c
			list_append_tv(s, &di->di_tv);
			s->lv_refcount++;
```

`match_add()` does not keep a reference, and `list_unref(s)` is called only once after the loop.
With two or more positions the count never reaches zero, so the list and the position lists it
references are not released until the next garbage collection:

```vim
call setmatches([{'group': 'Search', 'id': 4, 'priority': 10, 'pos1': [1,1,1], 'pos2': [2,1,1]}])
```

The reference count of a position list can be read directly:

```vim
let p = [1, 1, 1]
call setmatches([#{group: 'Search', id: 4, priority: 10, pos1: p, pos2: [2, 1, 1]}])
call clearmatches()
echo test_refcount(p)   " 2, expected 1
```

When a `posN` value is not a List the function returns without releasing `s` at all
(lines **1146–1147**):

```c
			if (di->di_tv.v_type != VAR_LIST)
			    return;
```

```vim
let p = [1, 1, 1]
call setmatches([#{group: 'Search', id: 4, priority: 10, pos1: p, pos2: {}}])
call clearmatches()
echo test_refcount(p)   " 2, expected 1
```

`test_match.vim` already reaches this path, in `Test_match()`, without noticing the leak:

```vim
call assert_equal(-1, setmatches([{'group' : 'Search', 'priority' : 10, 'id' : 5, 'pos1' : {}}]))
```

### Solution

Take one reference right after `list_alloc()`, drop the per-item increment, and `list_unref()`
the list on the early return.
