### PR TITLE
Timers stop after nonconsecutive callback errors

### DIFF
--- a/src/testdir/test_timers.vim
+++ b/src/testdir/test_timers.vim
@@ -293,6 +293,39 @@ func Test_timer_errors()
   call assert_fails('call timer_stop("abc")', 'E1210:')
 endfunc
 
+func FuncWithErrorPattern(state, timer)
+  let a:state.calls += 1
+  if a:state.errors[a:state.calls - 1]
+    doesnotexist
+  endif
+endfunc
+
+func Test_timer_nonconsecutive_errors()
+  for [errors, expected] in [[[1, 0, 1, 0, 1, 0], 6],
+        \ [[1, 1, 0, 1, 1, 1, 0], 6]]
+    let state = {'calls': 0, 'errors': errors}
+    let timer = timer_start(10, function('FuncWithErrorPattern', [state]),
+          \ {'repeat': len(errors)})
+    call WaitForAssert({-> assert_equal([], timer_info(timer))})
+    call assert_equal(expected, state.calls)
+  endfor
+endfunc
+
+func Test_timer_errors_are_independent()
+  let failing = {'calls': 0, 'errors': [1, 1, 1, 1]}
+  let passing = {'calls': 0, 'errors': [0, 0, 0, 0]}
+  let timers = []
+  for state in [failing, passing]
+    call add(timers, timer_start(10,
+          \ function('FuncWithErrorPattern', [state]), {'repeat': 4}))
+  endfor
+  for timer in timers
+    call WaitForAssert({-> assert_equal([], timer_info(timer))})
+  endfor
+  call assert_equal(3, failing.calls)
+  call assert_equal(4, passing.calls)
+endfunc
+
 func FuncWithCaughtError(timer)
   let g:call_count += 1
   try

--- a/src/time.c
+++ b/src/time.c
@@ -595,6 +595,8 @@ check_due_timer(void)
 	    vgetc_busy = save_vgetc_busy;
 	    if (uncaught_emsg > prev_uncaught_emsg)
 		++timer->tr_emsg_count;
+	    else
+		timer->tr_emsg_count = 0;
 	    did_emsg = save_did_emsg;
 	    called_emsg = save_called_emsg;
 	    exception_state_restore(&estate);


### PR DESCRIPTION
Problem: A repeating timer stops after its third uncaught callback error, even when successful callbacks separate the errors. This contradicts `:help timer_start()`, which specifies three errors in a row.

Solution: Reset the timer's error count after a callback finishes without an uncaught error. Add regression tests for separated errors, a new run of three consecutive errors after a successful callback, and independent error counts for concurrent timers.

The timer error-count discrepancy was reported in [this comment on #21121](https://github.com/vim/vim/issues/21121#issuecomment-5394283295). This patch addresses that discrepancy; it does not implement the separate redraw-listener proposal.

Validation on macOS arm64, Vim 9.2.1080, huge build without GUI: configure and `make -j4` succeeded; the full timer test file passed (26 passed, 2 existing Mac M1 skips); all 5 code-style checks passed. The new regression fails on the unmodified base: the two callback sequences stop after 5 and 4 calls, respectively, instead of 6. The build has the same pre-existing duplicate `-lcairo` linker warning before and after the change.

related: #21121

Prepared with OpenAI Codex assistance, including implementation, tests, and an independent Codex review.
