### PR TITLE
fix splitkeep winrow tracking, when splitkeep is set after splitting

### DIFF
--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -4467,7 +4467,10 @@ did_set_splitkeep(optset_T *args UNUSED)
     win_T	*wp;
     tabpage_T	*tp;
     FOR_ALL_TAB_WINDOWS(tp, wp)
+    {
 	wp->w_prev_height = wp->w_height;
+	wp->w_prev_winrow = wp->w_winrow;
+    }
     return did_set_opt_strings(p_spk, p_spk_values, FALSE);
 }
 

--- a/src/testdir/test_window_cmd.vim
+++ b/src/testdir/test_window_cmd.vim
@@ -2041,6 +2041,38 @@ func Test_splitkeep_screen_cursor_pos()
   set splitkeep&
 endfunc
 
+func Test_splitkeep_phantom_jump()
+  set splitbelow
+  call setline(1, range(1, 100))
+  split
+
+  " Move cursor to last visible line so it is at risk of being pushed off
+  normal! L
+  let [buf, line, col, off, curswant] = getcurpos()
+
+  " No jumps, just 3 header lines
+  call assert_equal(execute('jumps')->split('\n')->len(), 3)
+
+  " Switching to "screen" was causing vim to not update relevant variables
+  set splitkeep=screen
+
+  " Reduce window 2's space, and so bump up the cursor
+  set cmdheight=2
+
+  " Cursor has moved up a single line in the buffer, respecting splitkeep
+  call assert_equal(execute('jumps')->split('\n')->len(), 4)
+
+  let [buf2, line2, col2, off2, curswant2] = getcurpos()
+  call assert_equal(buf, buf2)
+  call assert_equal(line, line2 + 1)
+  call assert_equal(col, col2)
+  call assert_equal(off, off2)
+  call assert_equal(curswant, curswant2)
+
+  %bwipeout!
+  set splitbelow& splitkeep& cmdheight&
+endfunc
+
 func Test_splitkeep_cmdheight()
   set splitkeep=screen
   call setline(1, range(&lines))


### PR DESCRIPTION
`w_prev_winrow` is only set (on `:split`) if `splitkeep=screen`:

https://github.com/vim/vim/blob/c6333215b22c5a71e849bc1c98450a5f60d2b377/src/window.c#L1581-L1588

Otherwise, it remains at 0, in particular, if we change `'splitkeep'` after splitting a window, it's still 0.

Because of this, when we apply `splitkeep=screen` logic, the offset of the cursor from this default (0) is incorrect. It can in fact be huge if the cursor's a long way through the file, for example:

```vim
set splitbelow
help state()
set splitkeep=screen
set cmdheight=2 " bump the help window, shifting the cursor unexpectedly
```

(^ the repro only works if ran all at once, for example as part of a `:source`)