### PR TITLE
Fix memory leak of 'completeslash' in src/buffer.c

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -2509,6 +2509,9 @@ free_buf_options(
     clear_string_option(&buf->b_p_cinw);
     clear_string_option(&buf->b_p_cot);
     clear_string_option(&buf->b_p_cpt);
+#ifdef BACKSLASH_IN_FILENAME
+    clear_string_option(&buf->b_p_csl);
+#endif
 #ifdef FEAT_COMPL_FUNC
     clear_string_option(&buf->b_p_cfu);
     free_callback(&buf->b_cfu_cb);


### PR DESCRIPTION
### Problem

`buf_copy_options()` in `src/option.c` allocates the buffer-local value of `'completeslash'`
(line **7946**):

```c
#ifdef BACKSLASH_IN_FILENAME
	    buf->b_p_csl = vim_strsave(p_csl);
	    COPY_OPT_SCTX(buf, BV_CSL);
#endif
```

`free_buf_options()` in `src/buffer.c` clears every other buffer-local string option, but not
this one — `grep b_p_csl src/buffer.c` returns nothing.

Both paths that reach the assignment run through `free_buf_options()` first: the
not-yet-initialized case calls `free_buf_options(buf, TRUE)` (`src/option.c`, line **7881**) and
the re-entry case, taken when `'cpo'` contains `S` and the buffer is entered again, calls
`free_buf_options(buf, FALSE)` (line **7902**). Neither releases the old `b_p_csl`, so the
previous string is lost on every such re-entry, and once more when the buffer itself is freed.

`'completeslash'` was added in patch 8.1.1769, whose file list does not include `src/buffer.c`.

Only built when `BACKSLASH_IN_FILENAME` is defined, so this is an MS-Windows-only leak.

### Solution

Clear `b_p_csl` in `free_buf_options()`, next to `b_p_cpt`, where `buf_copy_options()` also
puts it. Placed outside the `free_p_ff` block so that both call sites above release it.

Cross-compiled at this revision with mingw-w64 and exercised under Wine: `:set completeslash=`,
50 buffer create/wipe cycles, and 400 `buf_copy_options()` re-entries with `'cpo'` containing
`S` — no crash.
