### PR TITLE
tests: Test_sign_jump_name_with_bar fails on MS-Windows (after 9.2.1090)

### DIFF
--- a/src/testdir/test_signs.vim
+++ b/src/testdir/test_signs.vim
@@ -2169,6 +2169,8 @@ func Test_sign_jump_name_with_bar()
   CheckFeature signs
 
   let bufnr = bufadd('Xsign|call setline(1, "PWNED")')
+  " The name is not valid for a file on MS-Windows, do not create a swap file.
+  call setbufvar(bufnr, '&swapfile', 0)
   call bufload(bufnr)
   call setbufline(bufnr, 1, ['one', 'two', 'three'])
 


### PR DESCRIPTION
```
Problem:  Test_sign_jump_name_with_bar fails on MS-Windows with E303,
    the buffer name contains a bar which is not valid in a file name
    there and the swap file cannot be created.
Solution: Do not create a swap file for the buffer, the name itself is
    what the test is about.
```