### PR TITLE
Remove the "|| defined(PROTO)" that the prototype generator does not need

### DIFF
--- a/src/cairo.c
+++ b/src/cairo.c
@@ -23,7 +23,7 @@
 
 #include "vim.h"
 
-#if defined(FEAT_IMAGE_CAIRO) || defined(PROTO)
+#if defined(FEAT_IMAGE_CAIRO)
 # include <cairo.h>
 
 /*
@@ -208,4 +208,4 @@ cairo_popup_image_paint(
     cairo_destroy(cr);
 }
 
-#endif // FEAT_IMAGE_CAIRO || PROTO
+#endif // FEAT_IMAGE_CAIRO

--- a/src/drawline.c
+++ b/src/drawline.c
@@ -841,7 +841,7 @@ text_prop_position(
     return (below && col_with_padding > win_col_off(wp) && !wp->w_p_wrap);
 }
 
-# if defined(FEAT_LINEBREAK) || defined(PROTO)
+# if defined(FEAT_LINEBREAK)
 /*
  * no 'showbreak' before "below" text property
  * or after "above" or "right" text property

--- a/src/eval.c
+++ b/src/eval.c
@@ -3344,7 +3344,7 @@ eval_regfree(char_u *pat, regprog_T *prog)
     eval_prog_re = eval_compile_re;
 }
 
-#if defined(EXITFREE) || defined(PROTO)
+#if defined(EXITFREE)
     void
 free_eval_regcomp_cache(void)
 {

--- a/src/kitty.c
+++ b/src/kitty.c
@@ -18,7 +18,7 @@
 
 #include "vim.h"
 
-#if defined(FEAT_IMAGE_KITTY) || defined(PROTO)
+#if defined(FEAT_IMAGE_KITTY)
 
 // Max base64 chars per envelope, per the kitty graphics protocol.
 #define KITTY_CHUNK_B64		4096
@@ -213,4 +213,4 @@ kitty_probe_parse(char *buf, int n)
     return strstr(buf, "_Gi=31;OK") != NULL;
 }
 
-#endif // FEAT_IMAGE_KITTY || PROTO
+#endif // FEAT_IMAGE_KITTY

--- a/src/mouse.c
+++ b/src/mouse.c
@@ -1396,7 +1396,7 @@ ins_mousescroll(int dir)
     }
 }
 
-#if defined(FEAT_PROP_POPUP) || defined(PROTO)
+#if defined(FEAT_PROP_POPUP)
 /*
  * Command-line mode implementation for scrolling in direction "dir", which is
  * one of the MSCR_ values.  Scrolls the completion info popup when the mouse

--- a/src/os_win32.c
+++ b/src/os_win32.c
@@ -4874,7 +4874,7 @@ mch_calc_cell_size(struct cellsize *cs_out)
     }
 }
 
-# if defined(FEAT_IMAGE_KITTY) || defined(PROTO)
+# if defined(FEAT_IMAGE_KITTY)
 /*
  * Synchronously probe the host terminal for kitty graphics protocol
  * support.  Windows console counterpart of popup_kitty_probe() in

--- a/src/sixel.c
+++ b/src/sixel.c
@@ -20,7 +20,7 @@
 
 #include "vim.h"
 
-#if defined(FEAT_IMAGE_SIXEL) || defined(PROTO)
+#if defined(FEAT_IMAGE_SIXEL)
 
 // Palette size cap (sixel allows up to 256 color registers; index 0 is
 // reserved as a transparent key, so usable colors are 1..MAX_COLORS).
@@ -662,7 +662,7 @@ fail:
     return NULL;
 }
 
-#if defined(EXITFREE) || defined(PROTO)
+#if defined(EXITFREE)
 /*
  * Release all module-level allocations cached by the sixel encoder.  Called
  * from free_all_mem() on shutdown when EXITFREE is defined; the encoder

--- a/src/structs.h
+++ b/src/structs.h
@@ -5502,7 +5502,7 @@ struct cellsize {
 };
 #endif
 
-#if defined(FEAT_IMAGE) || defined(PROTO)
+#if defined(FEAT_IMAGE)
 // RGB(A) image input shared by all popup image backends.
 // "data" points to width*height*3 bytes of tightly packed R,G,B triples
 // when has_alpha is FALSE, or width*height*4 R,G,B,A quadruples otherwise.


### PR DESCRIPTION
```
Problem:  A few "#if" guards still have "|| defined(PROTO)", which made
    cproto see the functions inside a feature guard.  Since 9.1.1840 the
    prototypes are generated by gen_prototypes.py, which takes a
    feature guard as true, so the functions inside "#if
    defined(FEAT_*)" get their prototype anyway.
Solution: Drop the check from the guards that still have it.
```

related: #18045