### PR TITLE
Vim9: a name with an underscore is taken for a command with an argument

### DIFF
--- a/src/ex_docmd.c
+++ b/src/ex_docmd.c
@@ -4149,11 +4149,18 @@ find_ex_command(
 	    && (eap->cmdidx < 0 ||
 		(cmdnames[eap->cmdidx].cmd_argt & EX_NONWHITE_OK) == 0))
     {
-	char_u *cmd = vim_strnsave(eap->cmd, p - eap->cmd);
+	// A name that goes on with an underscore is not this command with an
+	// argument: "ch_log" is not ":change".  Leave it to be reported as an
+	// invalid command.
+	if (*p != '_')
+	{
+	    char_u *cmd = vim_strnsave(eap->cmd, p - eap->cmd);
 
-	semsg(_(e_command_str_not_followed_by_white_space_str), cmd, eap->cmd);
+	    semsg(_(e_command_str_not_followed_by_white_space_str), cmd,
+								    eap->cmd);
+	    vim_free(cmd);
+	}
 	eap->cmdidx = CMD_SIZE;
-	vim_free(cmd);
     }
 #endif
 

--- a/src/testdir/test_vim9_cmd.vim
+++ b/src/testdir/test_vim9_cmd.vim
@@ -1510,6 +1510,25 @@ def Test_user_command_comment()
   delcommand Foo
 enddef
 
+" A name with an underscore is not a command with an argument: "ch_log" is
+" not ":change".
+def Test_command_name_with_underscore()
+  var lines =<< trim END
+      vim9script
+      ch_log
+  END
+  v9.CheckScriptFailure(lines, 'E492: Not an editor command: ch_log')
+  lines =<< trim END
+      vim9script
+      command Foo echo 'Foo'
+      Foo_bar
+  END
+  v9.CheckScriptFailure(lines, 'E492: Not an editor command: Foo_bar')
+  delcommand Foo
+  v9.CheckDefFailure(['ch_log'], 'E476: Invalid command: ch_log')
+  v9.CheckDefFailure(['echo_x'], 'E476: Invalid command: echo_x')
+enddef
+
 def Test_star_command()
   var lines =<< trim END
     vim9script

--- a/src/testdir/test_vim9_script.vim
+++ b/src/testdir/test_vim9_script.vim
@@ -4789,10 +4789,12 @@ def Test_invoke_normal_in_visual_mode()
 enddef
 
 def Test_white_space_after_command()
+  # "exit_cb" is not ":exit"; nothing must be executed.
   var lines =<< trim END
     exit_cb: Func})
   END
-  v9.CheckDefAndScriptFailure(lines, 'E1144:', 1)
+  v9.CheckDefAndScriptFailure(lines, ['E476: Invalid command: exit_cb: Func})',
+    'E492: Not an editor command: exit_cb: Func})'], 1)
 
   lines =<< trim END
     e#


### PR DESCRIPTION
```
Problem:  In Vim9 script "ch_log" on a line of its own gives E1144
    "Command ch is not followed by white space", as if it were ":change"
    with "_log" behind it, while "strlen" gives E476 "Invalid command".
    The message sends the reader looking for a missing space.
Solution: When the character after the command name is an underscore,
    treat the word as an invalid command.  Nothing is executed either
    way; the "exit_cb" line that once ran ":exit" now gets E476.
```